### PR TITLE
Add a vhost-user-fs daemon in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-virtio 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost_rs 0.1.0",
  "vhost_user_backend 0.1.0",
+ "vhost_user_fs 0.1.0",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-device 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
@@ -1007,6 +1008,10 @@ dependencies = [
  "vm-virtio 0.1.0",
  "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "vhost_user_fs"
+version = "0.1.0"
 
 [[package]]
 name = "virtio-bindings"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,11 @@ dependencies = [
 [[package]]
 name = "vhost_user_fs"
 version = "0.1.0"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+]
 
 [[package]]
 name = "virtio-bindings"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ net_gen = { path = "net_gen" }
 net_util = { path = "net_util" }
 qcow = { path = "qcow" }
 vhost_user_backend = { path = "vhost_user_backend"}
+vhost_user_fs = { path = "vhost_user_fs"}
 virtio-bindings = "0.1.0"
 vmm = { path = "vmm" }
 vm-device = { path = "vm-device" }

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -148,6 +148,7 @@ sudo ip link set vfio-tap1 up
 cargo build --release
 sudo setcap cap_net_admin+ep target/release/cloud-hypervisor
 sudo setcap cap_net_admin+ep target/release/vhost_user_net
+sudo setcap cap_dac_override,cap_sys_admin+epi target/release/vhost_user_fs
 
 # We always copy a fresh version of our binary for our L2 guest.
 cp target/release/cloud-hypervisor $VFIO_DIR

--- a/src/bin/vhost_user_fs.rs
+++ b/src/bin/vhost_user_fs.rs
@@ -199,7 +199,7 @@ fn main() {
         .get_matches();
 
     // Retrieve arguments
-    let _shared_dir = cmd_arguments
+    let shared_dir = cmd_arguments
         .value_of("shared-dir")
         .expect("Failed to retrieve shared directory path");
     let sock = cmd_arguments
@@ -209,7 +209,11 @@ fn main() {
     // Convert into appropriate types
     let sock = String::from(sock);
 
-    let fs = PassthroughFs::new(passthrough::Config::default()).unwrap();
+    let fs_cfg = passthrough::Config {
+        root_dir: shared_dir.to_string(),
+        ..Default::default()
+    };
+    let fs = PassthroughFs::new(fs_cfg).unwrap();
     let fs_backend = Arc::new(RwLock::new(VhostUserFsBackend::new(fs).unwrap()));
 
     let mut daemon = VhostUserDaemon::new(

--- a/src/bin/vhost_user_fs.rs
+++ b/src/bin/vhost_user_fs.rs
@@ -1,0 +1,242 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+
+#[macro_use(crate_version, crate_authors)]
+extern crate clap;
+extern crate log;
+extern crate vhost_rs;
+extern crate vhost_user_backend;
+extern crate vm_virtio;
+
+use clap::{App, Arg};
+use epoll;
+use libc::EFD_NONBLOCK;
+use log::*;
+use std::os::unix::io::AsRawFd;
+use std::sync::{Arc, RwLock};
+use std::{convert, error, fmt, io, process};
+
+use vhost_rs::vhost_user::message::*;
+use vhost_user_backend::{VhostUserBackend, VhostUserDaemon, Vring};
+use vhost_user_fs::descriptor_utils::{Reader, Writer};
+use vhost_user_fs::filesystem::FileSystem;
+use vhost_user_fs::passthrough::{self, PassthroughFs};
+use vhost_user_fs::server::Server;
+use vhost_user_fs::Error as VhostUserFsError;
+use virtio_bindings::bindings::virtio_net::*;
+use vm_memory::GuestMemoryMmap;
+use vmm_sys_util::eventfd::EventFd;
+
+const QUEUE_SIZE: usize = 1024;
+const NUM_QUEUES: usize = 2;
+
+// The guest queued an available buffer for the high priority queue.
+const HIPRIO_QUEUE_EVENT: u16 = 0;
+// The guest queued an available buffer for the request queue.
+const REQ_QUEUE_EVENT: u16 = 1;
+// The device has been dropped.
+const KILL_EVENT: u16 = 2;
+
+type Result<T> = std::result::Result<T, Error>;
+type VhostUserBackendResult<T> = std::result::Result<T, std::io::Error>;
+
+#[derive(Debug)]
+enum Error {
+    /// Failed to create kill eventfd.
+    CreateKillEventFd,
+    /// Failed to handle event other than input event.
+    HandleEventNotEpollIn,
+    /// Failed to handle unknown event.
+    HandleEventUnknownEvent,
+    /// No memory configured.
+    NoMemoryConfigured,
+    /// Processing queue failed.
+    ProcessQueue(VhostUserFsError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "vhost_user_fs_error: {:?}", self)
+    }
+}
+
+impl error::Error for Error {}
+
+impl convert::From<Error> for io::Error {
+    fn from(e: Error) -> Self {
+        io::Error::new(io::ErrorKind::Other, e)
+    }
+}
+
+struct VhostUserFsBackend<F: FileSystem + Send + Sync + 'static> {
+    mem: Option<GuestMemoryMmap>,
+    kill_evt: EventFd,
+    server: Arc<Server<F>>,
+}
+
+impl<F: FileSystem + Send + Sync + 'static> Clone for VhostUserFsBackend<F> {
+    fn clone(&self) -> Self {
+        VhostUserFsBackend {
+            mem: self.mem.clone(),
+            kill_evt: self.kill_evt.try_clone().unwrap(),
+            server: self.server.clone(),
+        }
+    }
+}
+
+impl<F: FileSystem + Send + Sync + 'static> VhostUserFsBackend<F> {
+    fn new(fs: F) -> Result<Self> {
+        Ok(VhostUserFsBackend {
+            mem: None,
+            kill_evt: EventFd::new(EFD_NONBLOCK).map_err(|_| Error::CreateKillEventFd)?,
+            server: Arc::new(Server::new(fs)),
+        })
+    }
+
+    fn process_queue(&mut self, vring: &mut Vring) -> Result<()> {
+        let mem = self.mem.as_ref().ok_or(Error::NoMemoryConfigured)?;
+
+        let mut used_desc_heads = [(0, 0); QUEUE_SIZE];
+        let mut used_count = 0;
+        while let Some(avail_desc) = vring.mut_queue().iter(&mem).next() {
+            let head_index = avail_desc.index;
+            let reader = Reader::new(mem, avail_desc.clone()).unwrap();
+            let writer = Writer::new(mem, avail_desc.clone()).unwrap();
+
+            let total = self
+                .server
+                .handle_message(reader, writer)
+                .map_err(Error::ProcessQueue)?;
+
+            used_desc_heads[used_count] = (head_index, total);
+            used_count += 1;
+        }
+
+        if used_count > 0 {
+            for &(desc_index, _) in &used_desc_heads[..used_count] {
+                vring.mut_queue().add_used(&mem, desc_index, 0);
+            }
+            vring.signal_used_queue().unwrap();
+        }
+
+        Ok(())
+    }
+}
+
+impl<F: FileSystem + Send + Sync + 'static> VhostUserBackend for VhostUserFsBackend<F> {
+    fn num_queues(&self) -> usize {
+        NUM_QUEUES
+    }
+
+    fn max_queue_size(&self) -> usize {
+        QUEUE_SIZE
+    }
+
+    fn features(&self) -> u64 {
+        1 << VIRTIO_F_VERSION_1 | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
+    }
+
+    fn protocol_features(&self) -> VhostUserProtocolFeatures {
+        VhostUserProtocolFeatures::all()
+    }
+
+    fn update_memory(&mut self, mem: GuestMemoryMmap) -> VhostUserBackendResult<()> {
+        self.mem = Some(mem);
+        Ok(())
+    }
+
+    fn handle_event(
+        &mut self,
+        device_event: u16,
+        evset: epoll::Events,
+        vrings: &[Arc<RwLock<Vring>>],
+    ) -> VhostUserBackendResult<bool> {
+        if evset != epoll::Events::EPOLLIN {
+            return Err(Error::HandleEventNotEpollIn.into());
+        }
+
+        match device_event {
+            HIPRIO_QUEUE_EVENT => {
+                debug!("HIPRIO_QUEUE_EVENT");
+            }
+            REQ_QUEUE_EVENT => {
+                debug!("REQ_QUEUE_EVENT");
+                let mut vring = vrings[1].write().unwrap();
+                self.process_queue(&mut vring)?;
+            }
+            KILL_EVENT => {
+                debug!("KILL_EVENT");
+                self.kill_evt.read().unwrap();
+                return Ok(true);
+            }
+            _ => return Err(Error::HandleEventUnknownEvent.into()),
+        }
+
+        Ok(false)
+    }
+}
+
+fn main() {
+    let cmd_arguments = App::new("vhost-user-fs backend")
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about("Launch a vhost-user-fs backend.")
+        .arg(
+            Arg::with_name("shared-dir")
+                .long("shared-dir")
+                .help("Shared directory path")
+                .takes_value(true)
+                .min_values(1),
+        )
+        .arg(
+            Arg::with_name("sock")
+                .long("sock")
+                .help("vhost-user socket path")
+                .takes_value(true)
+                .min_values(1),
+        )
+        .get_matches();
+
+    // Retrieve arguments
+    let _shared_dir = cmd_arguments
+        .value_of("shared-dir")
+        .expect("Failed to retrieve shared directory path");
+    let sock = cmd_arguments
+        .value_of("sock")
+        .expect("Failed to retrieve vhost-user socket path");
+
+    // Convert into appropriate types
+    let sock = String::from(sock);
+
+    let fs = PassthroughFs::new(passthrough::Config::default()).unwrap();
+    let fs_backend = Arc::new(RwLock::new(VhostUserFsBackend::new(fs).unwrap()));
+
+    let mut daemon = VhostUserDaemon::new(
+        String::from("vhost-user-fs-backend"),
+        sock,
+        fs_backend.clone(),
+    )
+    .unwrap();
+
+    let vring_worker = daemon.get_vring_worker();
+
+    if let Err(e) = vring_worker.register_listener(
+        fs_backend.read().unwrap().kill_evt.as_raw_fd(),
+        epoll::Events::EPOLLIN,
+        u64::from(KILL_EVENT),
+    ) {
+        println!("Failed to register listener for kill event: {:?}", e);
+        process::exit(1);
+    }
+
+    if let Err(e) = daemon.start() {
+        println!("Failed to start daemon: {:?}", e);
+        process::exit(1);
+    }
+
+    if let Err(e) = daemon.wait() {
+        println!("Waiting for daemon failed: {:?}", e);
+        process::exit(1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -705,6 +705,26 @@ mod tests {
         (child, virtiofsd_socket_path)
     }
 
+    fn prepare_vhost_user_fs_daemon(
+        tmp_dir: &TempDir,
+        shared_dir: &str,
+        _cache: &str,
+    ) -> (std::process::Child, String) {
+        let virtiofsd_socket_path =
+            String::from(tmp_dir.path().join("virtiofs.sock").to_str().unwrap());
+
+        // Start the daemon
+        let child = Command::new("target/release/vhost_user_fs")
+            .args(&["--shared-dir", shared_dir])
+            .args(&["--sock", virtiofsd_socket_path.as_str()])
+            .spawn()
+            .unwrap();
+
+        thread::sleep(std::time::Duration::new(10, 0));
+
+        (child, virtiofsd_socket_path)
+    }
+
     fn prepare_vubd(tmp_dir: &TempDir, blk_img: &str) -> (std::process::Child, String) {
         let mut workload_path = dirs::home_dir().unwrap();
         workload_path.push("workloads");
@@ -1646,7 +1666,12 @@ mod tests {
         });
     }
 
-    fn test_virtio_fs(dax: bool, cache_size: Option<u64>, virtiofsd_cache: &str) {
+    fn test_virtio_fs(
+        dax: bool,
+        cache_size: Option<u64>,
+        virtiofsd_cache: &str,
+        prepare_daemon: &dyn Fn(&TempDir, &str, &str) -> (std::process::Child, String),
+    ) {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
@@ -1667,7 +1692,7 @@ mod tests {
                 "".to_string()
             };
 
-            let (mut daemon_child, virtiofsd_socket_path) = prepare_virtiofsd(
+            let (mut daemon_child, virtiofsd_socket_path) = prepare_daemon(
                 &guest.tmp_dir,
                 shared_dir.to_str().unwrap(),
                 virtiofsd_cache,
@@ -1773,17 +1798,22 @@ mod tests {
 
     #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_fs_dax_on_default_cache_size() {
-        test_virtio_fs(true, None, "always")
+        test_virtio_fs(true, None, "always", &prepare_virtiofsd)
     }
 
     #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_fs_dax_on_cache_size_1_gib() {
-        test_virtio_fs(true, Some(0x4000_0000), "always")
+        test_virtio_fs(true, Some(0x4000_0000), "always", &prepare_virtiofsd)
     }
 
     #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_fs_dax_off() {
-        test_virtio_fs(false, None, "none")
+        test_virtio_fs(false, None, "none", &prepare_virtiofsd)
+    }
+
+    #[cfg_attr(not(feature = "mmio"), test)]
+    fn test_virtio_fs_dax_off_w_vhost_user_fs_daemon() {
+        test_virtio_fs(false, None, "none", &prepare_vhost_user_fs_daemon)
     }
 
     #[test]

--- a/vhost_user_fs/Cargo.toml
+++ b/vhost_user_fs/Cargo.toml
@@ -9,3 +9,4 @@ bitflags = "1.1.0"
 libc = "0.2.65"
 log = "0.4.8"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
+vm-virtio = { path = "../vm-virtio" }

--- a/vhost_user_fs/Cargo.toml
+++ b/vhost_user_fs/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 [dependencies]
 bitflags = "1.1.0"
 libc = "0.2.65"
+log = "0.4.8"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }

--- a/vhost_user_fs/Cargo.toml
+++ b/vhost_user_fs/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "vhost_user_fs"
+version = "0.1.0"
+authors = ["The Cloud Hypervisor Authors"]
+edition = "2018"
+
+[dependencies]

--- a/vhost_user_fs/Cargo.toml
+++ b/vhost_user_fs/Cargo.toml
@@ -5,3 +5,6 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 
 [dependencies]
+bitflags = "1.1.0"
+libc = "0.2.65"
+vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }

--- a/vhost_user_fs/src/descriptor_utils.rs
+++ b/vhost_user_fs/src/descriptor_utils.rs
@@ -1,0 +1,985 @@
+// Copyright 2019 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+use std::cmp;
+use std::collections::VecDeque;
+use std::fmt::{self, Display};
+use std::io::{self, Read, Write};
+use std::mem::{size_of, MaybeUninit};
+use std::ops::Deref;
+use std::ptr::copy_nonoverlapping;
+use std::result;
+
+use vm_memory::{
+    Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap,
+    GuestMemoryRegion, Le16, Le32, Le64, VolatileMemory, VolatileMemoryError, VolatileSlice,
+};
+use vm_virtio::DescriptorChain;
+
+use crate::file_traits::{FileReadWriteAtVolatile, FileReadWriteVolatile};
+
+#[derive(Debug)]
+pub enum Error {
+    DescriptorChainOverflow,
+    FindMemoryRegion,
+    GuestMemoryError(GuestMemoryError),
+    InvalidChain,
+    IoError(io::Error),
+    SplitOutOfBounds(usize),
+    VolatileMemoryError(VolatileMemoryError),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::Error::*;
+
+        match self {
+            DescriptorChainOverflow => write!(
+                f,
+                "the combined length of all the buffers in a `DescriptorChain` would overflow"
+            ),
+            FindMemoryRegion => write!(f, "no memory region for this address range"),
+            GuestMemoryError(e) => write!(f, "descriptor guest memory error: {}", e),
+            InvalidChain => write!(f, "invalid descriptor chain"),
+            IoError(e) => write!(f, "descriptor I/O error: {}", e),
+            SplitOutOfBounds(off) => write!(f, "`DescriptorChain` split is out of bounds: {}", off),
+            VolatileMemoryError(e) => write!(f, "volatile memory error: {}", e),
+        }
+    }
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+impl std::error::Error for Error {}
+
+#[derive(Clone)]
+struct DescriptorChainConsumer<'a> {
+    buffers: VecDeque<VolatileSlice<'a>>,
+    bytes_consumed: usize,
+}
+
+impl<'a> DescriptorChainConsumer<'a> {
+    fn available_bytes(&self) -> usize {
+        // This is guaranteed not to overflow because the total length of the chain
+        // is checked during all creations of `DescriptorChainConsumer` (see
+        // `Reader::new()` and `Writer::new()`).
+        self.buffers
+            .iter()
+            .fold(0usize, |count, vs| count + vs.len() as usize)
+    }
+
+    fn bytes_consumed(&self) -> usize {
+        self.bytes_consumed
+    }
+
+    /// Consumes at most `count` bytes from the `DescriptorChain`. Callers must provide a function
+    /// that takes a `&[VolatileSlice]` and returns the total number of bytes consumed. This
+    /// function guarantees that the combined length of all the slices in the `&[VolatileSlice]` is
+    /// less than or equal to `count`.
+    ///
+    /// # Errors
+    ///
+    /// If the provided function returns any error then no bytes are consumed from the buffer and
+    /// the error is returned to the caller.
+    fn consume<F>(&mut self, count: usize, f: F) -> io::Result<usize>
+    where
+        F: FnOnce(&[VolatileSlice]) -> io::Result<usize>,
+    {
+        let mut buflen = 0;
+        let mut bufs = Vec::with_capacity(self.buffers.len());
+        for &vs in &self.buffers {
+            if buflen >= count {
+                break;
+            }
+
+            bufs.push(vs);
+
+            let rem = count - buflen;
+            if rem < vs.len() {
+                buflen += rem;
+            } else {
+                buflen += vs.len() as usize;
+            }
+        }
+
+        if bufs.is_empty() {
+            return Ok(0);
+        }
+
+        let bytes_consumed = f(&*bufs)?;
+
+        // This can happen if a driver tricks a device into reading/writing more data than
+        // fits in a `usize`.
+        let total_bytes_consumed =
+            self.bytes_consumed
+                .checked_add(bytes_consumed)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, Error::DescriptorChainOverflow)
+                })?;
+
+        let mut rem = bytes_consumed;
+        while let Some(vs) = self.buffers.pop_front() {
+            if rem < vs.len() {
+                // Split the slice and push the remainder back into the buffer list. Safe because we
+                // know that `rem` is not out of bounds due to the check and we checked the bounds
+                // on `vs` when we added it to the buffer list.
+                self.buffers.push_front(vs.offset(rem).unwrap());
+                break;
+            }
+
+            // No need for checked math because we know that `vs.size() <= rem`.
+            rem -= vs.len();
+        }
+
+        self.bytes_consumed = total_bytes_consumed;
+
+        Ok(bytes_consumed)
+    }
+
+    fn split_at(&mut self, offset: usize) -> Result<DescriptorChainConsumer<'a>> {
+        let mut rem = offset;
+        let pos = self.buffers.iter().position(|vs| {
+            if rem < vs.len() {
+                true
+            } else {
+                rem -= vs.len();
+                false
+            }
+        });
+
+        if let Some(at) = pos {
+            let mut other = self.buffers.split_off(at);
+
+            if rem > 0 {
+                // There must be at least one element in `other` because we checked
+                // its `size` value in the call to `position` above.
+                let front = other.pop_front().expect("empty VecDeque after split");
+                self.buffers
+                    .push_back(front.offset(rem).map_err(Error::VolatileMemoryError)?);
+                other.push_front(front.offset(rem).map_err(Error::VolatileMemoryError)?);
+            }
+
+            Ok(DescriptorChainConsumer {
+                buffers: other,
+                bytes_consumed: 0,
+            })
+        } else if rem == 0 {
+            Ok(DescriptorChainConsumer {
+                buffers: VecDeque::new(),
+                bytes_consumed: 0,
+            })
+        } else {
+            Err(Error::SplitOutOfBounds(offset))
+        }
+    }
+}
+
+/// Provides high-level interface over the sequence of memory regions
+/// defined by readable descriptors in the descriptor chain.
+///
+/// Note that virtio spec requires driver to place any device-writable
+/// descriptors after any device-readable descriptors (2.6.4.2 in Virtio Spec v1.1).
+/// Reader will skip iterating over descriptor chain when first writable
+/// descriptor is encountered.
+#[derive(Clone)]
+pub struct Reader<'a> {
+    buffer: DescriptorChainConsumer<'a>,
+}
+
+impl<'a> Reader<'a> {
+    /// Construct a new Reader wrapper over `desc_chain`.
+    pub fn new(mem: &'a GuestMemoryMmap, desc_chain: DescriptorChain<'a>) -> Result<Reader<'a>> {
+        let mut total_len: usize = 0;
+        let buffers = desc_chain
+            .into_iter()
+            .readable()
+            .map(|desc| {
+                // Verify that summing the descriptor sizes does not overflow.
+                // This can happen if a driver tricks a device into reading more data than
+                // fits in a `usize`.
+                total_len = total_len
+                    .checked_add(desc.len as usize)
+                    .ok_or(Error::DescriptorChainOverflow)?;
+
+                let region = mem.find_region(desc.addr).ok_or(Error::FindMemoryRegion)?;
+                let offset = desc
+                    .addr
+                    .checked_sub(region.start_addr().raw_value())
+                    .unwrap();
+                region
+                    .deref()
+                    .get_slice(offset.raw_value() as usize, desc.len as usize)
+                    .map_err(Error::VolatileMemoryError)
+            })
+            .collect::<Result<VecDeque<VolatileSlice<'a>>>>()?;
+        Ok(Reader {
+            buffer: DescriptorChainConsumer {
+                buffers,
+                bytes_consumed: 0,
+            },
+        })
+    }
+
+    /// Reads an object from the descriptor chain buffer.
+    pub fn read_obj<T: ByteValued>(&mut self) -> io::Result<T> {
+        let mut obj = MaybeUninit::<T>::uninit();
+
+        // Safe because `MaybeUninit` guarantees that the pointer is valid for
+        // `size_of::<T>()` bytes.
+        let buf = unsafe {
+            ::std::slice::from_raw_parts_mut(obj.as_mut_ptr() as *mut u8, size_of::<T>())
+        };
+
+        self.read_exact(buf)?;
+
+        // Safe because any type that implements `ByteValued` can be considered initialized
+        // even if it is filled with random data.
+        Ok(unsafe { obj.assume_init() })
+    }
+
+    /// Reads data from the descriptor chain buffer into a file descriptor.
+    /// Returns the number of bytes read from the descriptor chain buffer.
+    /// The number of bytes read can be less than `count` if there isn't
+    /// enough data in the descriptor chain buffer.
+    pub fn read_to<F: FileReadWriteVolatile>(
+        &mut self,
+        mut dst: F,
+        count: usize,
+    ) -> io::Result<usize> {
+        self.buffer
+            .consume(count, |bufs| dst.write_vectored_volatile(bufs))
+    }
+
+    /// Reads data from the descriptor chain buffer into a File at offset `off`.
+    /// Returns the number of bytes read from the descriptor chain buffer.
+    /// The number of bytes read can be less than `count` if there isn't
+    /// enough data in the descriptor chain buffer.
+    pub fn read_to_at<F: FileReadWriteAtVolatile>(
+        &mut self,
+        mut dst: F,
+        count: usize,
+        off: u64,
+    ) -> io::Result<usize> {
+        self.buffer
+            .consume(count, |bufs| dst.write_vectored_at_volatile(bufs, off))
+    }
+
+    pub fn read_exact_to<F: FileReadWriteVolatile>(
+        &mut self,
+        mut dst: F,
+        mut count: usize,
+    ) -> io::Result<()> {
+        while count > 0 {
+            match self.read_to(&mut dst, count) {
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "failed to fill whole buffer",
+                    ))
+                }
+                Ok(n) => count -= n,
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns number of bytes available for reading.  May return an error if the combined
+    /// lengths of all the buffers in the DescriptorChain would cause an integer overflow.
+    pub fn available_bytes(&self) -> usize {
+        self.buffer.available_bytes()
+    }
+
+    /// Returns number of bytes already read from the descriptor chain buffer.
+    pub fn bytes_read(&self) -> usize {
+        self.buffer.bytes_consumed()
+    }
+
+    /// Splits this `Reader` into two at the given offset in the `DescriptorChain` buffer.
+    /// After the split, `self` will be able to read up to `offset` bytes while the returned
+    /// `Reader` can read up to `available_bytes() - offset` bytes.  Returns an error if
+    /// `offset > self.available_bytes()`.
+    pub fn split_at(&mut self, offset: usize) -> Result<Reader<'a>> {
+        self.buffer.split_at(offset).map(|buffer| Reader { buffer })
+    }
+}
+
+impl<'a> io::Read for Reader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.buffer.consume(buf.len(), |bufs| {
+            let mut rem = buf;
+            let mut total = 0;
+            for vs in bufs {
+                let copy_len = cmp::min(rem.len(), vs.len());
+
+                // Safe because we have already verified that `vs` points to valid memory.
+                unsafe {
+                    copy_nonoverlapping(vs.as_ptr() as *const u8, rem.as_mut_ptr(), copy_len);
+                }
+                rem = &mut rem[copy_len..];
+                total += copy_len;
+            }
+            Ok(total)
+        })
+    }
+}
+
+/// Provides high-level interface over the sequence of memory regions
+/// defined by writable descriptors in the descriptor chain.
+///
+/// Note that virtio spec requires driver to place any device-writable
+/// descriptors after any device-readable descriptors (2.6.4.2 in Virtio Spec v1.1).
+/// Writer will start iterating the descriptors from the first writable one and will
+/// assume that all following descriptors are writable.
+#[derive(Clone)]
+pub struct Writer<'a> {
+    buffer: DescriptorChainConsumer<'a>,
+}
+
+impl<'a> Writer<'a> {
+    /// Construct a new Writer wrapper over `desc_chain`.
+    pub fn new(mem: &'a GuestMemoryMmap, desc_chain: DescriptorChain<'a>) -> Result<Writer<'a>> {
+        let mut total_len: usize = 0;
+        let buffers = desc_chain
+            .into_iter()
+            .writable()
+            .map(|desc| {
+                // Verify that summing the descriptor sizes does not overflow.
+                // This can happen if a driver tricks a device into writing more data than
+                // fits in a `usize`.
+                total_len = total_len
+                    .checked_add(desc.len as usize)
+                    .ok_or(Error::DescriptorChainOverflow)?;
+
+                let region = mem.find_region(desc.addr).ok_or(Error::FindMemoryRegion)?;
+                let offset = desc
+                    .addr
+                    .checked_sub(region.start_addr().raw_value())
+                    .unwrap();
+                region
+                    .deref()
+                    .get_slice(offset.raw_value() as usize, desc.len as usize)
+                    .map_err(Error::VolatileMemoryError)
+            })
+            .collect::<Result<VecDeque<VolatileSlice<'a>>>>()?;
+
+        Ok(Writer {
+            buffer: DescriptorChainConsumer {
+                buffers,
+                bytes_consumed: 0,
+            },
+        })
+    }
+
+    /// Writes an object to the descriptor chain buffer.
+    pub fn write_obj<T: ByteValued>(&mut self, val: T) -> io::Result<()> {
+        self.write_all(val.as_slice())
+    }
+
+    /// Returns number of bytes available for writing.  May return an error if the combined
+    /// lengths of all the buffers in the DescriptorChain would cause an overflow.
+    pub fn available_bytes(&self) -> usize {
+        self.buffer.available_bytes()
+    }
+
+    /// Writes data to the descriptor chain buffer from a file descriptor.
+    /// Returns the number of bytes written to the descriptor chain buffer.
+    /// The number of bytes written can be less than `count` if
+    /// there isn't enough data in the descriptor chain buffer.
+    pub fn write_from<F: FileReadWriteVolatile>(
+        &mut self,
+        mut src: F,
+        count: usize,
+    ) -> io::Result<usize> {
+        self.buffer
+            .consume(count, |bufs| src.read_vectored_volatile(bufs))
+    }
+
+    /// Writes data to the descriptor chain buffer from a File at offset `off`.
+    /// Returns the number of bytes written to the descriptor chain buffer.
+    /// The number of bytes written can be less than `count` if
+    /// there isn't enough data in the descriptor chain buffer.
+    pub fn write_from_at<F: FileReadWriteAtVolatile>(
+        &mut self,
+        mut src: F,
+        count: usize,
+        off: u64,
+    ) -> io::Result<usize> {
+        self.buffer
+            .consume(count, |bufs| src.read_vectored_at_volatile(bufs, off))
+    }
+
+    pub fn write_all_from<F: FileReadWriteVolatile>(
+        &mut self,
+        mut src: F,
+        mut count: usize,
+    ) -> io::Result<()> {
+        while count > 0 {
+            match self.write_from(&mut src, count) {
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    ))
+                }
+                Ok(n) => count -= n,
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns number of bytes already written to the descriptor chain buffer.
+    pub fn bytes_written(&self) -> usize {
+        self.buffer.bytes_consumed()
+    }
+
+    /// Splits this `Writer` into two at the given offset in the `DescriptorChain` buffer.
+    /// After the split, `self` will be able to write up to `offset` bytes while the returned
+    /// `Writer` can write up to `available_bytes() - offset` bytes.  Returns an error if
+    /// `offset > self.available_bytes()`.
+    pub fn split_at(&mut self, offset: usize) -> Result<Writer<'a>> {
+        self.buffer.split_at(offset).map(|buffer| Writer { buffer })
+    }
+}
+
+impl<'a> io::Write for Writer<'a> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buffer.consume(buf.len(), |bufs| {
+            let mut rem = buf;
+            let mut total = 0;
+            for vs in bufs {
+                let copy_len = cmp::min(rem.len(), vs.len());
+
+                // Safe because we have already verified that `vs` points to valid memory.
+                unsafe {
+                    copy_nonoverlapping(rem.as_ptr(), vs.as_ptr(), copy_len);
+                }
+                rem = &rem[copy_len..];
+                total += copy_len;
+            }
+            Ok(total)
+        })
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // Nothing to flush since the writes go straight into the buffer.
+        Ok(())
+    }
+}
+
+const VIRTQ_DESC_F_NEXT: u16 = 0x1;
+const VIRTQ_DESC_F_WRITE: u16 = 0x2;
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum DescriptorType {
+    Readable,
+    Writable,
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+#[repr(C)]
+struct virtq_desc {
+    addr: Le64,
+    len: Le32,
+    flags: Le16,
+    next: Le16,
+}
+
+// Safe because it only has data and has no implicit padding.
+unsafe impl ByteValued for virtq_desc {}
+
+/// Test utility function to create a descriptor chain in guest memory.
+pub fn create_descriptor_chain(
+    memory: &GuestMemoryMmap,
+    descriptor_array_addr: GuestAddress,
+    mut buffers_start_addr: GuestAddress,
+    descriptors: Vec<(DescriptorType, u32)>,
+    spaces_between_regions: u32,
+) -> Result<DescriptorChain> {
+    let descriptors_len = descriptors.len();
+    for (index, (type_, size)) in descriptors.into_iter().enumerate() {
+        let mut flags = 0;
+        if let DescriptorType::Writable = type_ {
+            flags |= VIRTQ_DESC_F_WRITE;
+        }
+        if index + 1 < descriptors_len {
+            flags |= VIRTQ_DESC_F_NEXT;
+        }
+
+        let index = index as u16;
+        let desc = virtq_desc {
+            addr: buffers_start_addr.raw_value().into(),
+            len: size.into(),
+            flags: flags.into(),
+            next: (index + 1).into(),
+        };
+
+        let offset = size + spaces_between_regions;
+        buffers_start_addr = buffers_start_addr
+            .checked_add(u64::from(offset))
+            .ok_or(Error::InvalidChain)?;
+
+        let _ = memory.write_obj(
+            desc,
+            descriptor_array_addr
+                .checked_add(u64::from(index) * std::mem::size_of::<virtq_desc>() as u64)
+                .ok_or(Error::InvalidChain)?,
+        );
+    }
+
+    DescriptorChain::checked_new(memory, descriptor_array_addr, 0x100, 0, None)
+        .ok_or(Error::InvalidChain)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reader_test_simple_chain() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let chain = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![
+                (Readable, 8),
+                (Readable, 16),
+                (Readable, 18),
+                (Readable, 64),
+            ],
+            0,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut reader = Reader::new(&memory, chain).expect("failed to create Reader");
+        assert_eq!(reader.available_bytes(), 106);
+        assert_eq!(reader.bytes_read(), 0);
+
+        let mut buffer = [0 as u8; 64];
+        if let Err(_) = reader.read_exact(&mut buffer) {
+            panic!("read_exact should not fail here");
+        }
+
+        assert_eq!(reader.available_bytes(), 42);
+        assert_eq!(reader.bytes_read(), 64);
+
+        match reader.read(&mut buffer) {
+            Err(_) => panic!("read should not fail here"),
+            Ok(length) => assert_eq!(length, 42),
+        }
+
+        assert_eq!(reader.available_bytes(), 0);
+        assert_eq!(reader.bytes_read(), 106);
+    }
+
+    #[test]
+    fn writer_test_simple_chain() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let chain = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![
+                (Writable, 8),
+                (Writable, 16),
+                (Writable, 18),
+                (Writable, 64),
+            ],
+            0,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut writer = Writer::new(&memory, chain).expect("failed to create Writer");
+        assert_eq!(writer.available_bytes(), 106);
+        assert_eq!(writer.bytes_written(), 0);
+
+        let mut buffer = [0 as u8; 64];
+        if let Err(_) = writer.write_all(&mut buffer) {
+            panic!("write_all should not fail here");
+        }
+
+        assert_eq!(writer.available_bytes(), 42);
+        assert_eq!(writer.bytes_written(), 64);
+
+        match writer.write(&mut buffer) {
+            Err(_) => panic!("write should not fail here"),
+            Ok(length) => assert_eq!(length, 42),
+        }
+
+        assert_eq!(writer.available_bytes(), 0);
+        assert_eq!(writer.bytes_written(), 106);
+    }
+
+    #[test]
+    fn reader_test_incompatible_chain() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let chain = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![(Writable, 8)],
+            0,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut reader = Reader::new(&memory, chain).expect("failed to create Reader");
+        assert_eq!(reader.available_bytes(), 0);
+        assert_eq!(reader.bytes_read(), 0);
+
+        assert!(reader.read_obj::<u8>().is_err());
+
+        assert_eq!(reader.available_bytes(), 0);
+        assert_eq!(reader.bytes_read(), 0);
+    }
+
+    #[test]
+    fn writer_test_incompatible_chain() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let chain = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![(Readable, 8)],
+            0,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut writer = Writer::new(&memory, chain).expect("failed to create Writer");
+        assert_eq!(writer.available_bytes(), 0);
+        assert_eq!(writer.bytes_written(), 0);
+
+        assert!(writer.write_obj(0u8).is_err());
+
+        assert_eq!(writer.available_bytes(), 0);
+        assert_eq!(writer.bytes_written(), 0);
+    }
+
+    #[test]
+    fn reader_writer_shared_chain() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let chain = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![
+                (Readable, 16),
+                (Readable, 16),
+                (Readable, 96),
+                (Writable, 64),
+                (Writable, 1),
+                (Writable, 3),
+            ],
+            0,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut reader = Reader::new(&memory, chain.clone()).expect("failed to create Reader");
+        let mut writer = Writer::new(&memory, chain).expect("failed to create Writer");
+
+        assert_eq!(reader.bytes_read(), 0);
+        assert_eq!(writer.bytes_written(), 0);
+
+        let mut buffer = Vec::with_capacity(200);
+
+        assert_eq!(
+            reader
+                .read_to_end(&mut buffer)
+                .expect("read should not fail here"),
+            128
+        );
+
+        // The writable descriptors are only 68 bytes long.
+        writer
+            .write_all(&buffer[..68])
+            .expect("write should not fail here");
+
+        assert_eq!(reader.available_bytes(), 0);
+        assert_eq!(reader.bytes_read(), 128);
+        assert_eq!(writer.available_bytes(), 0);
+        assert_eq!(writer.bytes_written(), 68);
+    }
+
+    #[test]
+    fn reader_writer_shattered_object() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let secret: Le32 = 0x12345678.into();
+
+        // Create a descriptor chain with memory regions that are properly separated.
+        let chain_writer = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![(Writable, 1), (Writable, 1), (Writable, 1), (Writable, 1)],
+            123,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut writer = Writer::new(&memory, chain_writer).expect("failed to create Writer");
+        if let Err(_) = writer.write_obj(secret) {
+            panic!("write_obj should not fail here");
+        }
+
+        // Now create new descriptor chain pointing to the same memory and try to read it.
+        let chain_reader = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![(Readable, 1), (Readable, 1), (Readable, 1), (Readable, 1)],
+            123,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut reader = Reader::new(&memory, chain_reader).expect("failed to create Reader");
+        match reader.read_obj::<Le32>() {
+            Err(_) => panic!("read_obj should not fail here"),
+            Ok(read_secret) => assert_eq!(read_secret, secret),
+        }
+    }
+
+    #[test]
+    fn reader_unexpected_eof() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let chain = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![(Readable, 256), (Readable, 256)],
+            0,
+        )
+        .expect("create_descriptor_chain failed");
+
+        let mut reader = Reader::new(&memory, chain).expect("failed to create Reader");
+
+        let mut buf = Vec::with_capacity(1024);
+        buf.resize(1024, 0);
+
+        assert_eq!(
+            reader
+                .read_exact(&mut buf[..])
+                .expect_err("read more bytes than available")
+                .kind(),
+            io::ErrorKind::UnexpectedEof
+        );
+    }
+
+    #[test]
+    fn split_border() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let chain = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![
+                (Readable, 16),
+                (Readable, 16),
+                (Readable, 96),
+                (Writable, 64),
+                (Writable, 1),
+                (Writable, 3),
+            ],
+            0,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut reader = Reader::new(&memory, chain).expect("failed to create Reader");
+
+        let other = reader.split_at(32).expect("failed to split Reader");
+        assert_eq!(reader.available_bytes(), 32);
+        assert_eq!(other.available_bytes(), 96);
+    }
+
+    #[test]
+    fn split_middle() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let chain = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![
+                (Readable, 16),
+                (Readable, 16),
+                (Readable, 96),
+                (Writable, 64),
+                (Writable, 1),
+                (Writable, 3),
+            ],
+            0,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut reader = Reader::new(&memory, chain).expect("failed to create Reader");
+
+        let other = reader.split_at(24).expect("failed to split Reader");
+        assert_eq!(reader.available_bytes(), 24);
+        assert_eq!(other.available_bytes(), 104);
+    }
+
+    #[test]
+    fn split_end() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let chain = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![
+                (Readable, 16),
+                (Readable, 16),
+                (Readable, 96),
+                (Writable, 64),
+                (Writable, 1),
+                (Writable, 3),
+            ],
+            0,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut reader = Reader::new(&memory, chain).expect("failed to create Reader");
+
+        let other = reader.split_at(128).expect("failed to split Reader");
+        assert_eq!(reader.available_bytes(), 128);
+        assert_eq!(other.available_bytes(), 0);
+    }
+
+    #[test]
+    fn split_beginning() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let chain = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![
+                (Readable, 16),
+                (Readable, 16),
+                (Readable, 96),
+                (Writable, 64),
+                (Writable, 1),
+                (Writable, 3),
+            ],
+            0,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut reader = Reader::new(&memory, chain).expect("failed to create Reader");
+
+        let other = reader.split_at(0).expect("failed to split Reader");
+        assert_eq!(reader.available_bytes(), 0);
+        assert_eq!(other.available_bytes(), 128);
+    }
+
+    #[test]
+    fn split_outofbounds() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let chain = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![
+                (Readable, 16),
+                (Readable, 16),
+                (Readable, 96),
+                (Writable, 64),
+                (Writable, 1),
+                (Writable, 3),
+            ],
+            0,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut reader = Reader::new(&memory, chain).expect("failed to create Reader");
+
+        if let Ok(_) = reader.split_at(256) {
+            panic!("successfully split Reader with out of bounds offset");
+        }
+    }
+
+    #[test]
+    fn read_full() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let chain = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![(Readable, 16), (Readable, 16), (Readable, 16)],
+            0,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut reader = Reader::new(&memory, chain).expect("failed to create Reader");
+
+        let mut buf = vec![0u8; 64];
+        assert_eq!(
+            reader.read(&mut buf[..]).expect("failed to read to buffer"),
+            48
+        );
+    }
+
+    #[test]
+    fn write_full() {
+        use DescriptorType::*;
+
+        let memory_start_addr = GuestAddress(0x0);
+        let memory = GuestMemoryMmap::new(&vec![(memory_start_addr, 0x10000)]).unwrap();
+
+        let chain = create_descriptor_chain(
+            &memory,
+            GuestAddress(0x0),
+            GuestAddress(0x100),
+            vec![(Writable, 16), (Writable, 16), (Writable, 16)],
+            0,
+        )
+        .expect("create_descriptor_chain failed");
+        let mut writer = Writer::new(&memory, chain).expect("failed to create Writer");
+
+        let buf = vec![0xdeu8; 64];
+        assert_eq!(
+            writer.write(&buf[..]).expect("failed to write from buffer"),
+            48
+        );
+    }
+}

--- a/vhost_user_fs/src/file_traits.rs
+++ b/vhost_user_fs/src/file_traits.rs
@@ -1,0 +1,409 @@
+// Copyright 2018 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+use std::fs::File;
+use std::io::{Error, ErrorKind, Result};
+use std::os::unix::io::AsRawFd;
+
+use vm_memory::VolatileSlice;
+
+use libc::{
+    c_int, c_void, off64_t, pread64, preadv64, pwrite64, pwritev64, read, readv, size_t, write,
+    writev,
+};
+
+/// A trait for setting the size of a file.
+/// This is equivalent to File's `set_len` method, but
+/// wrapped in a trait so that it can be implemented for
+/// other types.
+pub trait FileSetLen {
+    // Set the size of this file.
+    // This is the moral equivalent of `ftruncate()`.
+    fn set_len(&self, _len: u64) -> Result<()>;
+}
+
+impl FileSetLen for File {
+    fn set_len(&self, len: u64) -> Result<()> {
+        File::set_len(self, len)
+    }
+}
+
+/// A trait similar to `Read` and `Write`, but uses volatile memory as buffers.
+pub trait FileReadWriteVolatile {
+    /// Read bytes from this file into the given slice, returning the number of bytes read on
+    /// success.
+    fn read_volatile(&mut self, slice: VolatileSlice) -> Result<usize>;
+
+    /// Like `read_volatile`, except it reads to a slice of buffers. Data is copied to fill each
+    /// buffer in order, with the final buffer written to possibly being only partially filled. This
+    /// method must behave as a single call to `read_volatile` with the buffers concatenated would.
+    /// The default implementation calls `read_volatile` with either the first nonempty buffer
+    /// provided, or returns `Ok(0)` if none exists.
+    fn read_vectored_volatile(&mut self, bufs: &[VolatileSlice]) -> Result<usize> {
+        bufs.iter()
+            .find(|b| !b.is_empty())
+            .map(|&b| self.read_volatile(b))
+            .unwrap_or(Ok(0))
+    }
+
+    /// Reads bytes from this into the given slice until all bytes in the slice are written, or an
+    /// error is returned.
+    fn read_exact_volatile(&mut self, mut slice: VolatileSlice) -> Result<()> {
+        while !slice.is_empty() {
+            let bytes_read = self.read_volatile(slice)?;
+            if bytes_read == 0 {
+                return Err(Error::from(ErrorKind::UnexpectedEof));
+            }
+            // Will panic if read_volatile read more bytes than we gave it, which would be worthy of
+            // a panic.
+            slice = slice.offset(bytes_read).unwrap();
+        }
+        Ok(())
+    }
+
+    /// Write bytes from the slice to the given file, returning the number of bytes written on
+    /// success.
+    fn write_volatile(&mut self, slice: VolatileSlice) -> Result<usize>;
+
+    /// Like `write_volatile`, except that it writes from a slice of buffers. Data is copied from
+    /// each buffer in order, with the final buffer read from possibly being only partially
+    /// consumed. This method must behave as a call to `write_volatile` with the buffers
+    /// concatenated would. The default implementation calls `write_volatile` with either the first
+    /// nonempty buffer provided, or returns `Ok(0)` if none exists.
+    fn write_vectored_volatile(&mut self, bufs: &[VolatileSlice]) -> Result<usize> {
+        bufs.iter()
+            .find(|b| !b.is_empty())
+            .map(|&b| self.write_volatile(b))
+            .unwrap_or(Ok(0))
+    }
+
+    /// Write bytes from the slice to the given file until all the bytes from the slice have been
+    /// written, or an error is returned.
+    fn write_all_volatile(&mut self, mut slice: VolatileSlice) -> Result<()> {
+        while !slice.is_empty() {
+            let bytes_written = self.write_volatile(slice)?;
+            if bytes_written == 0 {
+                return Err(Error::from(ErrorKind::WriteZero));
+            }
+            // Will panic if read_volatile read more bytes than we gave it, which would be worthy of
+            // a panic.
+            slice = slice.offset(bytes_written).unwrap();
+        }
+        Ok(())
+    }
+}
+
+impl<'a, T: FileReadWriteVolatile + ?Sized> FileReadWriteVolatile for &'a mut T {
+    fn read_volatile(&mut self, slice: VolatileSlice) -> Result<usize> {
+        (**self).read_volatile(slice)
+    }
+
+    fn read_vectored_volatile(&mut self, bufs: &[VolatileSlice]) -> Result<usize> {
+        (**self).read_vectored_volatile(bufs)
+    }
+
+    fn read_exact_volatile(&mut self, slice: VolatileSlice) -> Result<()> {
+        (**self).read_exact_volatile(slice)
+    }
+
+    fn write_volatile(&mut self, slice: VolatileSlice) -> Result<usize> {
+        (**self).write_volatile(slice)
+    }
+
+    fn write_vectored_volatile(&mut self, bufs: &[VolatileSlice]) -> Result<usize> {
+        (**self).write_vectored_volatile(bufs)
+    }
+
+    fn write_all_volatile(&mut self, slice: VolatileSlice) -> Result<()> {
+        (**self).write_all_volatile(slice)
+    }
+}
+
+/// A trait similar to the unix `ReadExt` and `WriteExt` traits, but for volatile memory.
+pub trait FileReadWriteAtVolatile {
+    /// Reads bytes from this file at `offset` into the given slice, returning the number of bytes
+    /// read on success.
+    fn read_at_volatile(&mut self, slice: VolatileSlice, offset: u64) -> Result<usize>;
+
+    /// Like `read_at_volatile`, except it reads to a slice of buffers. Data is copied to fill each
+    /// buffer in order, with the final buffer written to possibly being only partially filled. This
+    /// method must behave as a single call to `read_at_volatile` with the buffers concatenated
+    /// would. The default implementation calls `read_at_volatile` with either the first nonempty
+    /// buffer provided, or returns `Ok(0)` if none exists.
+    fn read_vectored_at_volatile(&mut self, bufs: &[VolatileSlice], offset: u64) -> Result<usize> {
+        if let Some(&slice) = bufs.first() {
+            self.read_at_volatile(slice, offset)
+        } else {
+            Ok(0)
+        }
+    }
+
+    /// Reads bytes from this file at `offset` into the given slice until all bytes in the slice are
+    /// read, or an error is returned.
+    fn read_exact_at_volatile(&mut self, mut slice: VolatileSlice, mut offset: u64) -> Result<()> {
+        while !slice.is_empty() {
+            match self.read_at_volatile(slice, offset) {
+                Ok(0) => return Err(Error::from(ErrorKind::UnexpectedEof)),
+                Ok(n) => {
+                    slice = slice.offset(n).unwrap();
+                    offset = offset.checked_add(n as u64).unwrap();
+                }
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+
+    /// Writes bytes from this file at `offset` into the given slice, returning the number of bytes
+    /// written on success.
+    fn write_at_volatile(&mut self, slice: VolatileSlice, offset: u64) -> Result<usize>;
+
+    /// Like `write_at_at_volatile`, except that it writes from a slice of buffers. Data is copied
+    /// from each buffer in order, with the final buffer read from possibly being only partially
+    /// consumed. This method must behave as a call to `write_at_volatile` with the buffers
+    /// concatenated would. The default implementation calls `write_at_volatile` with either the
+    /// first nonempty buffer provided, or returns `Ok(0)` if none exists.
+    fn write_vectored_at_volatile(&mut self, bufs: &[VolatileSlice], offset: u64) -> Result<usize> {
+        if let Some(&slice) = bufs.first() {
+            self.write_at_volatile(slice, offset)
+        } else {
+            Ok(0)
+        }
+    }
+
+    /// Writes bytes from this file at `offset` into the given slice until all bytes in the slice
+    /// are written, or an error is returned.
+    fn write_all_at_volatile(&mut self, mut slice: VolatileSlice, mut offset: u64) -> Result<()> {
+        while !slice.is_empty() {
+            match self.write_at_volatile(slice, offset) {
+                Ok(0) => return Err(Error::from(ErrorKind::WriteZero)),
+                Ok(n) => {
+                    slice = slice.offset(n).unwrap();
+                    offset = offset.checked_add(n as u64).unwrap();
+                }
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'a, T: FileReadWriteAtVolatile + ?Sized> FileReadWriteAtVolatile for &'a mut T {
+    fn read_at_volatile(&mut self, slice: VolatileSlice, offset: u64) -> Result<usize> {
+        (**self).read_at_volatile(slice, offset)
+    }
+
+    fn read_vectored_at_volatile(&mut self, bufs: &[VolatileSlice], offset: u64) -> Result<usize> {
+        (**self).read_vectored_at_volatile(bufs, offset)
+    }
+
+    fn read_exact_at_volatile(&mut self, slice: VolatileSlice, offset: u64) -> Result<()> {
+        (**self).read_exact_at_volatile(slice, offset)
+    }
+
+    fn write_at_volatile(&mut self, slice: VolatileSlice, offset: u64) -> Result<usize> {
+        (**self).write_at_volatile(slice, offset)
+    }
+
+    fn write_vectored_at_volatile(&mut self, bufs: &[VolatileSlice], offset: u64) -> Result<usize> {
+        (**self).write_vectored_at_volatile(bufs, offset)
+    }
+
+    fn write_all_at_volatile(&mut self, slice: VolatileSlice, offset: u64) -> Result<()> {
+        (**self).write_all_at_volatile(slice, offset)
+    }
+}
+
+macro_rules! volatile_impl {
+    ($ty:ty) => {
+        impl FileReadWriteVolatile for $ty {
+            fn read_volatile(&mut self, slice: VolatileSlice) -> Result<usize> {
+                // Safe because only bytes inside the slice are accessed and the kernel is expected
+                // to handle arbitrary memory for I/O.
+                let ret =
+                    unsafe { read(self.as_raw_fd(), slice.as_ptr() as *mut c_void, slice.len()) };
+                if ret >= 0 {
+                    Ok(ret as usize)
+                } else {
+                    Err(Error::last_os_error())
+                }
+            }
+
+            fn read_vectored_volatile(&mut self, bufs: &[VolatileSlice]) -> Result<usize> {
+                let iovecs: Vec<libc::iovec> = bufs
+                    .iter()
+                    .map(|s| libc::iovec {
+                        iov_base: s.as_ptr() as *mut c_void,
+                        iov_len: s.len() as size_t,
+                    })
+                    .collect();
+
+                if iovecs.is_empty() {
+                    return Ok(0);
+                }
+
+                // Safe because only bytes inside the buffers are accessed and the kernel is
+                // expected to handle arbitrary memory for I/O.
+                let ret = unsafe { readv(self.as_raw_fd(), &iovecs[0], iovecs.len() as c_int) };
+                if ret >= 0 {
+                    Ok(ret as usize)
+                } else {
+                    Err(Error::last_os_error())
+                }
+            }
+
+            fn write_volatile(&mut self, slice: VolatileSlice) -> Result<usize> {
+                // Safe because only bytes inside the slice are accessed and the kernel is expected
+                // to handle arbitrary memory for I/O.
+                let ret = unsafe {
+                    write(
+                        self.as_raw_fd(),
+                        slice.as_ptr() as *const c_void,
+                        slice.len(),
+                    )
+                };
+                if ret >= 0 {
+                    Ok(ret as usize)
+                } else {
+                    Err(Error::last_os_error())
+                }
+            }
+
+            fn write_vectored_volatile(&mut self, bufs: &[VolatileSlice]) -> Result<usize> {
+                let iovecs: Vec<libc::iovec> = bufs
+                    .iter()
+                    .map(|s| libc::iovec {
+                        iov_base: s.as_ptr() as *mut c_void,
+                        iov_len: s.len() as size_t,
+                    })
+                    .collect();
+
+                if iovecs.is_empty() {
+                    return Ok(0);
+                }
+
+                // Safe because only bytes inside the buffers are accessed and the kernel is
+                // expected to handle arbitrary memory for I/O.
+                let ret = unsafe { writev(self.as_raw_fd(), &iovecs[0], iovecs.len() as c_int) };
+                if ret >= 0 {
+                    Ok(ret as usize)
+                } else {
+                    Err(Error::last_os_error())
+                }
+            }
+        }
+
+        impl FileReadWriteAtVolatile for $ty {
+            fn read_at_volatile(&mut self, slice: VolatileSlice, offset: u64) -> Result<usize> {
+                // Safe because only bytes inside the slice are accessed and the kernel is expected
+                // to handle arbitrary memory for I/O.
+                let ret = unsafe {
+                    pread64(
+                        self.as_raw_fd(),
+                        slice.as_ptr() as *mut c_void,
+                        slice.len(),
+                        offset as off64_t,
+                    )
+                };
+
+                if ret >= 0 {
+                    Ok(ret as usize)
+                } else {
+                    Err(Error::last_os_error())
+                }
+            }
+
+            fn read_vectored_at_volatile(
+                &mut self,
+                bufs: &[VolatileSlice],
+                offset: u64,
+            ) -> Result<usize> {
+                let iovecs: Vec<libc::iovec> = bufs
+                    .iter()
+                    .map(|s| libc::iovec {
+                        iov_base: s.as_ptr() as *mut c_void,
+                        iov_len: s.len() as size_t,
+                    })
+                    .collect();
+
+                if iovecs.is_empty() {
+                    return Ok(0);
+                }
+
+                // Safe because only bytes inside the buffers are accessed and the kernel is
+                // expected to handle arbitrary memory for I/O.
+                let ret = unsafe {
+                    preadv64(
+                        self.as_raw_fd(),
+                        &iovecs[0],
+                        iovecs.len() as c_int,
+                        offset as off64_t,
+                    )
+                };
+                if ret >= 0 {
+                    Ok(ret as usize)
+                } else {
+                    Err(Error::last_os_error())
+                }
+            }
+
+            fn write_at_volatile(&mut self, slice: VolatileSlice, offset: u64) -> Result<usize> {
+                // Safe because only bytes inside the slice are accessed and the kernel is expected
+                // to handle arbitrary memory for I/O.
+                let ret = unsafe {
+                    pwrite64(
+                        self.as_raw_fd(),
+                        slice.as_ptr() as *const c_void,
+                        slice.len(),
+                        offset as off64_t,
+                    )
+                };
+
+                if ret >= 0 {
+                    Ok(ret as usize)
+                } else {
+                    Err(Error::last_os_error())
+                }
+            }
+
+            fn write_vectored_at_volatile(
+                &mut self,
+                bufs: &[VolatileSlice],
+                offset: u64,
+            ) -> Result<usize> {
+                let iovecs: Vec<libc::iovec> = bufs
+                    .iter()
+                    .map(|s| libc::iovec {
+                        iov_base: s.as_ptr() as *mut c_void,
+                        iov_len: s.len() as size_t,
+                    })
+                    .collect();
+
+                if iovecs.is_empty() {
+                    return Ok(0);
+                }
+
+                // Safe because only bytes inside the buffers are accessed and the kernel is
+                // expected to handle arbitrary memory for I/O.
+                let ret = unsafe {
+                    pwritev64(
+                        self.as_raw_fd(),
+                        &iovecs[0],
+                        iovecs.len() as c_int,
+                        offset as off64_t,
+                    )
+                };
+                if ret >= 0 {
+                    Ok(ret as usize)
+                } else {
+                    Err(Error::last_os_error())
+                }
+            }
+        }
+    };
+}
+
+volatile_impl!(File);

--- a/vhost_user_fs/src/filesystem.rs
+++ b/vhost_user_fs/src/filesystem.rs
@@ -1,0 +1,1099 @@
+// Copyright 2019 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+use std::convert::TryInto;
+use std::ffi::CStr;
+use std::fs::File;
+use std::io;
+use std::mem;
+use std::time::Duration;
+
+use libc;
+
+use crate::fuse;
+
+pub use fuse::FsOptions;
+pub use fuse::OpenOptions;
+pub use fuse::SetattrValid;
+pub use fuse::ROOT_ID;
+
+/// Information about a path in the filesystem.
+pub struct Entry {
+    /// An `Inode` that uniquely identifies this path. During `lookup`, setting this to `0` means a
+    /// negative entry. Returning `ENOENT` also means a negative entry but setting this to `0`
+    /// allows the kernel to cache the negative result for `entry_timeout`. The value should be
+    /// produced by converting a `FileSystem::Inode` into a `u64`.
+    pub inode: u64,
+
+    /// The generation number for this `Entry`. Typically used for network file systems. An `inode`
+    /// / `generation` pair must be unique over the lifetime of the file system (rather than just
+    /// the lifetime of the mount). In other words, if a `FileSystem` implementation re-uses an
+    /// `Inode` after it has been deleted then it must assign a new, previously unused generation
+    /// number to the `Inode` at the same time.
+    pub generation: u64,
+
+    /// Inode attributes. Even if `attr_timeout` is zero, `attr` must be correct. For example, for
+    /// `open()`, FUSE uses `attr.st_size` from `lookup()` to determine how many bytes to request.
+    /// If this value is not correct, incorrect data will be returned.
+    pub attr: libc::stat64,
+
+    /// How long the values in `attr` should be considered valid. If the attributes of the `Entry`
+    /// are only modified by the FUSE client, then this should be set to a very large value.
+    pub attr_timeout: Duration,
+
+    /// How long the name associated with this `Entry` should be considered valid. If directory
+    /// entries are only changed or deleted by the FUSE client, then this should be set to a very
+    /// large value.
+    pub entry_timeout: Duration,
+}
+
+impl From<Entry> for fuse::EntryOut {
+    fn from(entry: Entry) -> fuse::EntryOut {
+        fuse::EntryOut {
+            nodeid: entry.inode,
+            generation: entry.generation,
+            entry_valid: entry.entry_timeout.as_secs(),
+            attr_valid: entry.attr_timeout.as_secs(),
+            entry_valid_nsec: entry.entry_timeout.subsec_nanos(),
+            attr_valid_nsec: entry.attr_timeout.subsec_nanos(),
+            attr: entry.attr.into(),
+        }
+    }
+}
+
+/// Represents information about an entry in a directory.
+pub struct DirEntry<'a> {
+    /// The inode number for this entry. This does NOT have to be the same as the `Inode` for this
+    /// directory entry. However, it must be the same as the `attr.st_ino` field of the `Entry` that
+    /// would be returned by a `lookup` request in the parent directory for `name`.
+    pub ino: libc::ino64_t,
+
+    /// Any non-zero value that the kernel can use to identify the current point in the directory
+    /// entry stream. It does not need to be the actual physical position. A value of `0` is
+    /// reserved to mean "from the beginning" and should never be used. The `offset` value of the
+    /// first entry in a stream should point to the beginning of the second entry and so on.
+    pub offset: u64,
+
+    /// The type of this directory entry. Valid values are any of the `libc::DT_*` constants.
+    pub type_: u32,
+
+    /// The name of this directory entry. There are no requirements for the contents of this field
+    /// and any sequence of bytes is considered valid.
+    pub name: &'a [u8],
+}
+
+/// A reply to a `getxattr` method call.
+pub enum GetxattrReply {
+    /// The value of the requested extended attribute. This can be arbitrary textual or binary data
+    /// and does not need to be nul-terminated.
+    Value(Vec<u8>),
+
+    /// The size of the buffer needed to hold the value of the requested extended attribute. Should
+    /// be returned when the `size` parameter is 0. Callers should note that it is still possible
+    /// for the size of the value to change in between `getxattr` calls and should not assume that a
+    /// subsequent call to `getxattr` with the returned count will always succeed.
+    Count(u32),
+}
+
+/// A reply to a `listxattr` method call.
+pub enum ListxattrReply {
+    /// A buffer containing a nul-separated list of the names of all the extended attributes
+    /// associated with this `Inode`. This list of names may be unordered and includes a namespace
+    /// prefix. There may be several disjoint namespaces associated with a single `Inode`.
+    Names(Vec<u8>),
+
+    /// This size of the buffer needed to hold the full list of extended attribute names associated
+    /// with this `Inode`. Should be returned when the `size` parameter is 0. Callers should note
+    /// that it is still possible for the set of extended attributes to change between `listxattr`
+    /// calls and so should not assume that a subsequent call to `listxattr` with the returned count
+    /// will always succeed.
+    Count(u32),
+}
+
+/// A trait for directly copying data from the fuse transport into a `File` without first storing it
+/// in an intermediate buffer.
+pub trait ZeroCopyReader {
+    /// Copies at most `count` bytes from `self` directly into `f` at offset `off` without storing
+    /// it in any intermediate buffers. If the return value is `Ok(n)` then it must be guaranteed
+    /// that `0 <= n <= count`. If `n` is `0`, then it can indicate one of 3 possibilities:
+    ///
+    /// 1. There is no more data left in `self`.
+    /// 2. There is no more space in `f`.
+    /// 3. `count` was `0`.
+    ///
+    /// # Errors
+    ///
+    /// If any error is returned then the implementation must guarantee that no bytes were copied
+    /// from `self`. If the underlying write to `f` returns `0` then the implementation must return
+    /// an error of the kind `io::ErrorKind::WriteZero`.
+    fn read_to(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<usize>;
+
+    /// Copies exactly `count` bytes of data from `self` into `f` at offset `off`. `off + count`
+    /// must be less than `u64::MAX`.
+    ///
+    /// # Errors
+    ///
+    /// If an error is returned then the number of bytes copied from `self` is unspecified but it
+    /// will never be more than `count`.
+    fn read_exact_to(&mut self, f: &mut File, mut count: usize, mut off: u64) -> io::Result<()> {
+        let c = count
+            .try_into()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        if off.checked_add(c).is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "`off` + `count` must be less than u64::MAX",
+            ));
+        }
+
+        while count > 0 {
+            match self.read_to(f, count, off) {
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to fill whole buffer",
+                    ))
+                }
+                Ok(n) => {
+                    count -= n;
+                    off += n as u64;
+                }
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Copies all remaining bytes from `self` into `f` at offset `off`. Equivalent to repeatedly
+    /// calling `read_to` until it returns either `Ok(0)` or a non-`ErrorKind::Interrupted` error.
+    ///
+    /// # Errors
+    ///
+    /// If an error is returned then the number of bytes copied from `self` is unspecified.
+    fn copy_to_end(&mut self, f: &mut File, mut off: u64) -> io::Result<usize> {
+        let mut out = 0;
+        loop {
+            match self.read_to(f, ::std::usize::MAX, off) {
+                Ok(0) => return Ok(out),
+                Ok(n) => {
+                    off = off.saturating_add(n as u64);
+                    out += n;
+                }
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+    }
+}
+
+impl<'a, R: ZeroCopyReader> ZeroCopyReader for &'a mut R {
+    fn read_to(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<usize> {
+        (**self).read_to(f, count, off)
+    }
+    fn read_exact_to(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<()> {
+        (**self).read_exact_to(f, count, off)
+    }
+    fn copy_to_end(&mut self, f: &mut File, off: u64) -> io::Result<usize> {
+        (**self).copy_to_end(f, off)
+    }
+}
+
+/// A trait for directly copying data from a `File` into the fuse transport without first storing
+/// it in an intermediate buffer.
+pub trait ZeroCopyWriter {
+    /// Copies at most `count` bytes from `f` at offset `off` directly into `self` without storing
+    /// it in any intermediate buffers. If the return value is `Ok(n)` then it must be guaranteed
+    /// that `0 <= n <= count`. If `n` is `0`, then it can indicate one of 3 possibilities:
+    ///
+    /// 1. There is no more data left in `f`.
+    /// 2. There is no more space in `self`.
+    /// 3. `count` was `0`.
+    ///
+    /// # Errors
+    ///
+    /// If any error is returned then the implementation must guarantee that no bytes were copied
+    /// from `f`. If the underlying read from `f` returns `0` then the implementation must return an
+    /// error of the kind `io::ErrorKind::UnexpectedEof`.
+    fn write_from(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<usize>;
+
+    /// Copies exactly `count` bytes of data from `f` at offset `off` into `self`. `off + count`
+    /// must be less than `u64::MAX`.
+    ///
+    /// # Errors
+    ///
+    /// If an error is returned then the number of bytes copied from `self` is unspecified but it
+    /// well never be more than `count`.
+    fn write_all_from(&mut self, f: &mut File, mut count: usize, mut off: u64) -> io::Result<()> {
+        let c = count
+            .try_into()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        if off.checked_add(c).is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "`off` + `count` must be less than u64::MAX",
+            ));
+        }
+
+        while count > 0 {
+            match self.write_from(f, count, off) {
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "failed to write whole buffer",
+                    ))
+                }
+                Ok(n) => {
+                    // No need for checked math here because we verified that `off + count` will not
+                    // overflow and `n` must be <= `count`.
+                    count -= n;
+                    off += n as u64;
+                }
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Copies all remaining bytes from `f` at offset `off` into `self`. Equivalent to repeatedly
+    /// calling `write_from` until it returns either `Ok(0)` or a non-`ErrorKind::Interrupted`
+    /// error.
+    ///
+    /// # Errors
+    ///
+    /// If an error is returned then the number of bytes copied from `f` is unspecified.
+    fn copy_to_end(&mut self, f: &mut File, mut off: u64) -> io::Result<usize> {
+        let mut out = 0;
+        loop {
+            match self.write_from(f, ::std::usize::MAX, off) {
+                Ok(0) => return Ok(out),
+                Ok(n) => {
+                    off = off.saturating_add(n as u64);
+                    out += n;
+                }
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+    }
+}
+
+impl<'a, W: ZeroCopyWriter> ZeroCopyWriter for &'a mut W {
+    fn write_from(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<usize> {
+        (**self).write_from(f, count, off)
+    }
+    fn write_all_from(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<()> {
+        (**self).write_all_from(f, count, off)
+    }
+    fn copy_to_end(&mut self, f: &mut File, off: u64) -> io::Result<usize> {
+        (**self).copy_to_end(f, off)
+    }
+}
+
+/// Additional context associated with requests.
+#[derive(Clone, Copy, Debug)]
+pub struct Context {
+    /// The user ID of the calling process.
+    pub uid: libc::uid_t,
+
+    /// The group ID of the calling process.
+    pub gid: libc::gid_t,
+
+    /// The thread group ID of the calling process.
+    pub pid: libc::pid_t,
+}
+
+impl From<fuse::InHeader> for Context {
+    fn from(source: fuse::InHeader) -> Self {
+        Context {
+            uid: source.uid,
+            gid: source.gid,
+            pid: source.pid as i32,
+        }
+    }
+}
+
+/// The main trait that connects a file system with a transport.
+#[allow(unused_variables)]
+pub trait FileSystem {
+    /// Represents a location in the filesystem tree and can be used to perform operations that act
+    /// on the metadata of a file/directory (e.g., `getattr` and `setattr`). Can also be used as the
+    /// starting point for looking up paths in the filesystem tree. An `Inode` may support operating
+    /// directly on the content of the path that to which it points. `FileSystem` implementations
+    /// that support this should set the `FsOptions::ZERO_MESSAGE_OPEN` option in the return value
+    /// of the `init` function. On linux based systems, an `Inode` is equivalent to opening a file
+    /// or directory with the `libc::O_PATH` flag.
+    ///
+    /// # Lookup Count
+    ///
+    /// The `FileSystem` implementation is required to keep a "lookup count" for every `Inode`.
+    /// Every time an `Entry` is returned by a `FileSystem` trait method, this lookup count should
+    /// increase by 1. The lookup count for an `Inode` decreases when the kernel sends a `forget`
+    /// request. `Inode`s with a non-zero lookup count may receive requests from the kernel even
+    /// after calls to `unlink`, `rmdir` or (when overwriting an existing file) `rename`.
+    /// `FileSystem` implementations must handle such requests properly and it is recommended to
+    /// defer removal of the `Inode` until the lookup count reaches zero. Calls to `unlink`, `rmdir`
+    /// or `rename` will be followed closely by `forget` unless the file or directory is open, in
+    /// which case the kernel issues `forget` only after the `release` or `releasedir` calls.
+    ///
+    /// Note that if a file system will be exported over NFS the `Inode`'s lifetime must extend even
+    /// beyond `forget`. See the `generation` field in `Entry`.
+    type Inode: From<u64> + Into<u64>;
+
+    /// Represents a file or directory that is open for reading/writing.
+    type Handle: From<u64> + Into<u64>;
+
+    /// Initialize the file system.
+    ///
+    /// This method is called when a connection to the FUSE kernel module is first established. The
+    /// `capable` parameter indicates the features that are supported by the kernel module. The
+    /// implementation should return the options that it supports. Any options set in the returned
+    /// `FsOptions` that are not also set in `capable` are silently dropped.
+    fn init(&self, capable: FsOptions) -> io::Result<FsOptions> {
+        Ok(FsOptions::empty())
+    }
+
+    /// Clean up the file system.
+    ///
+    /// Called when the filesystem exits. All open `Handle`s should be closed and the lookup count
+    /// for all open `Inode`s implicitly goes to zero. At this point the connection to the FUSE
+    /// kernel module may already be gone so implementations should not rely on being able to
+    /// communicate with the kernel.
+    fn destroy(&self) {}
+
+    /// Look up a directory entry by name and get its attributes.
+    ///
+    /// If this call is successful then the lookup count of the `Inode` associated with the returned
+    /// `Entry` must be increased by 1.
+    fn lookup(&self, ctx: Context, parent: Self::Inode, name: &CStr) -> io::Result<Entry> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Forget about an inode.
+    ///
+    /// Called when the kernel removes an inode from its internal caches. `count` indicates the
+    /// amount by which the lookup count for the inode should be decreased. If reducing the lookup
+    /// count by `count` causes it to go to zero, then the implementation may delete the `Inode`.
+    fn forget(&self, ctx: Context, inode: Self::Inode, count: u64) {}
+
+    /// Forget about multiple inodes.
+    ///
+    /// `requests` is a vector of `(inode, count)` pairs. See the documentation for `forget` for
+    /// more information.
+    fn batch_forget(&self, ctx: Context, requests: Vec<(Self::Inode, u64)>) {
+        for (inode, count) in requests {
+            self.forget(ctx, inode, count)
+        }
+    }
+
+    /// Get attributes for a file / directory.
+    ///
+    /// If `handle` is not `None`, then it contains the handle previously returned by the
+    /// implementation after a call to `open` or `opendir`. However, implementations should still
+    /// take care to verify the handle if they do not trust the client (e.g., virtio-fs).
+    ///
+    /// If writeback caching is enabled (`FsOptions::WRITEBACK_CACHE`), then the kernel module
+    /// likely has a better idea of the length of the file than the file system (for
+    /// example, if there was a write that extended the size of the file but has not yet been
+    /// flushed). In this case, the `st_size` field of the returned struct is ignored.
+    ///
+    /// The returned `Duration` indicates how long the returned attributes should be considered
+    /// valid by the client. If the attributes are only changed via the FUSE kernel module (i.e.,
+    /// the kernel module has exclusive access), then this should be a very large value.
+    fn getattr(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Option<Self::Handle>,
+    ) -> io::Result<(libc::stat64, Duration)> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Set attributes for a file / directory.
+    ///
+    /// If `handle` is not `None`, then it contains the handle previously returned by the
+    /// implementation after a call to `open` or `opendir`. However, implementations should still
+    /// take care to verify the handle if they do not trust the client (e.g., virtio-fs).
+    ///
+    /// The `valid` parameter indicates the fields of `attr` that may be considered valid and should
+    /// be set by the file system. The content of all other fields in `attr` is undefined.
+    ///
+    /// If the `FsOptions::HANDLE_KILLPRIV` was set during `init`, then the implementation is
+    /// expected to reset the setuid and setgid bits if the file size or owner is being changed.
+    ///
+    /// This method returns the new attributes after making the modifications requested by the
+    /// client. The returned `Duration` indicates how long the returned attributes should be
+    /// considered valid by the client. If the attributes are only changed via the FUSE kernel
+    /// module (i.e., the kernel module has exclusive access), then this should be a very large
+    /// value.
+    fn setattr(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        attr: libc::stat64,
+        handle: Option<Self::Handle>,
+        valid: SetattrValid,
+    ) -> io::Result<(libc::stat64, Duration)> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Read a symbolic link.
+    fn readlink(&self, ctx: Context, inode: Self::Inode) -> io::Result<Vec<u8>> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Create a symbolic link.
+    ///
+    /// The file system must create a symbolic link named `name` in the directory represented by
+    /// `parent`, which contains the string `linkname`. Returns an `Entry` for the newly created
+    /// symlink.
+    ///
+    /// If this call is successful then the lookup count of the `Inode` associated with the returned
+    /// `Entry` must be increased by 1.
+    fn symlink(
+        &self,
+        ctx: Context,
+        linkname: &CStr,
+        parent: Self::Inode,
+        name: &CStr,
+    ) -> io::Result<Entry> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Create a file node.
+    ///
+    /// Create a regular file, character device, block device, fifo, or socket node named `name` in
+    /// the directory represented by `inode`. Valid values for `mode` and `rdev` are the same as
+    /// those accepted by the `mknod(2)` system call. Returns an `Entry` for the newly created node.
+    ///
+    /// When the `FsOptions::DONT_MASK` feature is set, the file system is responsible for setting
+    /// the permissions of the created node to `mode & !umask`.
+    ///
+    /// If this call is successful then the lookup count of the `Inode` associated with the returned
+    /// `Entry` must be increased by 1.
+    fn mknod(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        name: &CStr,
+        mode: u32,
+        rdev: u32,
+        umask: u32,
+    ) -> io::Result<Entry> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Create a directory.
+    ///
+    /// When the `FsOptions::DONT_MASK` feature is set, the file system is responsible for setting
+    /// the permissions of the created directory to `mode & !umask`. Returns an `Entry` for the
+    /// newly created directory.
+    ///
+    /// If this call is successful then the lookup count of the `Inode` associated with the returned
+    /// `Entry` must be increased by 1.
+    fn mkdir(
+        &self,
+        ctx: Context,
+        parent: Self::Inode,
+        name: &CStr,
+        mode: u32,
+        umask: u32,
+    ) -> io::Result<Entry> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Remove a file.
+    ///
+    /// If the file's inode lookup count is non-zero, then the file system is expected to delay
+    /// removal of the inode until the lookup count goes to zero. See the documentation of the
+    /// `forget` function for more information.
+    fn unlink(&self, ctx: Context, parent: Self::Inode, name: &CStr) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Remove a directory.
+    ///
+    /// If the directory's inode lookup count is non-zero, then the file system is expected to delay
+    /// removal of the inode until the lookup count goes to zero. See the documentation of the
+    /// `forget` function for more information.
+    fn rmdir(&self, ctx: Context, parent: Self::Inode, name: &CStr) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Rename a file / directory.
+    ///
+    /// If the destination exists, it should be atomically replaced. If the destination's inode
+    /// lookup count is non-zero, then the file system is expected to delay removal of the inode
+    /// until the lookup count goes to zero. See the documentation of the `forget` function for more
+    /// information.
+    ///
+    /// `flags` may be `libc::RENAME_EXCHANGE` or `libc::RENAME_NOREPLACE`. If
+    /// `libc::RENAME_NOREPLACE` is specified, the implementation must not overwrite `newname` if it
+    /// exists and must return an error instead. If `libc::RENAME_EXCHANGE` is specified, the
+    /// implementation must atomically exchange the two files, i.e., both must exist and neither may
+    /// be deleted.
+    fn rename(
+        &self,
+        ctx: Context,
+        olddir: Self::Inode,
+        oldname: &CStr,
+        newdir: Self::Inode,
+        newname: &CStr,
+        flags: u32,
+    ) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Create a hard link.
+    ///
+    /// Create a hard link from `inode` to `newname` in the directory represented by `newparent`.
+    ///
+    /// If this call is successful then the lookup count of the `Inode` associated with the returned
+    /// `Entry` must be increased by 1.
+    fn link(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        newparent: Self::Inode,
+        newname: &CStr,
+    ) -> io::Result<Entry> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Open a file.
+    ///
+    /// Open the file associated with `inode` for reading / writing. All values accepted by the
+    /// `open(2)` system call are valid values for `flags` and must be handled by the file system.
+    /// However, there are some additional rules:
+    ///
+    /// * Creation flags (`libc::O_CREAT`, `libc::O_EXCL`, `libc::O_NOCTTY`) will be filtered out
+    ///   and handled by the kernel.
+    ///
+    /// * The file system should check the access modes (`libc::O_RDONLY`, `libc::O_WRONLY`,
+    ///   `libc::O_RDWR`) to determine if the operation is permitted. If the file system was mounted
+    ///   with the `-o default_permissions` mount option, then this check will also be carried out
+    ///   by the kernel before sending the open request.
+    ///
+    /// * When writeback caching is enabled (`FsOptions::WRITEBACK_CACHE`) the kernel may send read
+    ///   requests even for files opened with `libc::O_WRONLY`. The file system should be prepared
+    ///   to handle this.
+    ///
+    /// * When writeback caching is enabled, the kernel will handle the `libc::O_APPEND` flag.
+    ///   However, this will not work reliably unless the kernel has exclusive access to the file.
+    ///   In this case the file system may either ignore the `libc::O_APPEND` flag or return an
+    ///   error to indicate that reliable `libc::O_APPEND` handling is not available.
+    ///
+    /// * When writeback caching is disabled, the file system is expected to properly handle
+    ///   `libc::O_APPEND` and ensure that each write is appended to the end of the file.
+    ///
+    /// The file system may choose to return a `Handle` to refer to the newly opened file. The
+    /// kernel will then use this `Handle` for all operations on the content of the file (`read`,
+    /// `write`, `flush`, `release`, `fsync`). If the file system does not return a
+    /// `Handle` then the kernel will use the `Inode` for the file to operate on its contents. In
+    /// this case the file system may wish to enable the `FsOptions::ZERO_MESSAGE_OPEN` feature if
+    /// it is supported by the kernel (see below).
+    ///
+    /// The returned `OpenOptions` allow the file system to change the way the opened file is
+    /// handled by the kernel. See the documentation of `OpenOptions` for more information.
+    ///
+    /// If the `FsOptions::ZERO_MESSAGE_OPEN` feature is enabled by both the file system
+    /// implementation and the kernel, then the file system may return an error of `ENOSYS`. This
+    /// will be interpreted by the kernel as success and future calls to `open` and `release` will
+    /// be handled by the kernel without being passed on to the file system.
+    fn open(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        flags: u32,
+    ) -> io::Result<(Option<Self::Handle>, OpenOptions)> {
+        // Matches the behavior of libfuse.
+        Ok((None, OpenOptions::empty()))
+    }
+
+    /// Create and open a file.
+    ///
+    /// If the file does not already exist, the file system should create it with the specified
+    /// `mode`. When the `FsOptions::DONT_MASK` feature is set, the file system is responsible for
+    /// setting the permissions of the created file to `mode & !umask`.
+    ///
+    /// If the file system returns an `ENOSYS` error, then the kernel will treat this method as
+    /// unimplemented and all future calls to `create` will be handled by calling the `mknod` and
+    /// `open` methods instead.
+    ///
+    /// See the documentation for the `open` method for more information about opening the file. In
+    /// addition to the optional `Handle` and the `OpenOptions`, the file system must also return an
+    /// `Entry` for the file. This increases the lookup count for the `Inode` associated with the
+    /// file by 1.
+    fn create(
+        &self,
+        ctx: Context,
+        parent: Self::Inode,
+        name: &CStr,
+        mode: u32,
+        flags: u32,
+        umask: u32,
+    ) -> io::Result<(Entry, Option<Self::Handle>, OpenOptions)> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Read data from a file.
+    ///
+    /// Returns `size` bytes of data starting from offset `off` from the file associated with
+    /// `inode` or `handle`.
+    ///
+    /// `flags` contains the flags used to open the file. Similarly, `handle` is the `Handle`
+    /// returned by the file system from the `open` method, if any. If the file system
+    /// implementation did not return a `Handle` from `open` then the contents of `handle` are
+    /// undefined.
+    ///
+    /// This method should return exactly the number of bytes requested by the kernel, except in the
+    /// case of error or EOF. Otherwise, the kernel will substitute the rest of the data with
+    /// zeroes. An exception to this rule is if the file was opened with the "direct I/O" option
+    /// (`libc::O_DIRECT`), in which case the kernel will forward the return code from this method
+    /// to the userspace application that made the system call.
+    #[allow(clippy::too_many_arguments)]
+    fn read<W: io::Write + ZeroCopyWriter>(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        w: W,
+        size: u32,
+        offset: u64,
+        lock_owner: Option<u64>,
+        flags: u32,
+    ) -> io::Result<usize> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Write data to a file.
+    ///
+    /// Writes `size` bytes of data starting from offset `off` to the file associated with `inode`
+    /// or `handle`.
+    ///
+    /// `flags` contains the flags used to open the file. Similarly, `handle` is the `Handle`
+    /// returned by the file system from the `open` method, if any. If the file system
+    /// implementation did not return a `Handle` from `open` then the contents of `handle` are
+    /// undefined.
+    ///
+    /// If the `FsOptions::HANDLE_KILLPRIV` feature is not enabled then then the file system is
+    /// expected to clear the setuid and setgid bits.
+    ///
+    /// If `delayed_write` is true then it indicates that this is a write for buffered data.
+    ///
+    /// This method should return exactly the number of bytes requested by the kernel, except in the
+    /// case of error. An exception to this rule is if the file was opened with the "direct I/O"
+    /// option (`libc::O_DIRECT`), in which case the kernel will forward the return code from this
+    /// method to the userspace application that made the system call.
+    #[allow(clippy::too_many_arguments)]
+    fn write<R: io::Read + ZeroCopyReader>(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        r: R,
+        size: u32,
+        offset: u64,
+        lock_owner: Option<u64>,
+        delayed_write: bool,
+        flags: u32,
+    ) -> io::Result<usize> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Flush the contents of a file.
+    ///
+    /// This method is called on every `close()` of a file descriptor. Since it is possible to
+    /// duplicate file descriptors there may be many `flush` calls for one call to `open`.
+    ///
+    /// File systems should not make any assumptions about when `flush` will be
+    /// called or even if it will be called at all.
+    ///
+    /// `handle` is the `Handle` returned by the file system from the `open` method, if any. If the
+    /// file system did not return a `Handle` from `open` then the contents of `handle` are
+    /// undefined.
+    ///
+    /// Unlike `fsync`, the file system is not required to flush pending writes. One reason to flush
+    /// data is if the file system wants to return write errors during close. However, this is not
+    /// portable because POSIX does not require `close` to wait for delayed I/O to complete.
+    ///
+    /// If the `FsOptions::POSIX_LOCKS` feature is enabled, then the file system must remove all
+    /// locks belonging to `lock_owner`.
+    ///
+    /// If this method returns an `ENOSYS` error then the kernel will treat it as success and all
+    /// subsequent calls to `flush` will be handled by the kernel without being forwarded to the
+    /// file system.
+    fn flush(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        lock_owner: u64,
+    ) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Synchronize file contents.
+    ///
+    /// File systems must ensure that the file contents have been flushed to disk before returning
+    /// from this method. If `datasync` is true then only the file data (but not the metadata) needs
+    /// to be flushed.
+    ///
+    /// `handle` is the `Handle` returned by the file system from the `open` method, if any. If the
+    /// file system did not return a `Handle` from `open` then the contents of
+    /// `handle` are undefined.
+    ///
+    /// If this method returns an `ENOSYS` error then the kernel will treat it as success and all
+    /// subsequent calls to `fsync` will be handled by the kernel without being forwarded to the
+    /// file system.
+    fn fsync(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        datasync: bool,
+        handle: Self::Handle,
+    ) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Allocate requested space for file data.
+    ///
+    /// If this function returns success, then the file sytem must guarantee that it is possible to
+    /// write up to `length` bytes of data starting at `offset` without failing due to a lack of
+    /// free space on the disk.
+    ///
+    /// `handle` is the `Handle` returned by the file system from the `open` method, if any. If the
+    /// file system did not return a `Handle` from `open` then the contents of `handle` are
+    /// undefined.
+    ///
+    /// If this method returns an `ENOSYS` error then the kernel will treat that as a permanent
+    /// failure: all future calls to `fallocate` will fail with `EOPNOTSUPP` without being forwarded
+    /// to the file system.
+    fn fallocate(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        mode: u32,
+        offset: u64,
+        length: u64,
+    ) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Release an open file.
+    ///
+    /// This method is called when there are no more references to an open file: all file
+    /// descriptors are closed and all memory mappings are unmapped.
+    ///
+    /// For every `open` call there will be exactly one `release` call (unless the file system is
+    /// force-unmounted).
+    ///
+    /// The file system may reply with an error, but error values are not returned to the `close()`
+    /// or `munmap()` which triggered the release.
+    ///
+    /// `handle` is the `Handle` returned by the file system from the `open` method, if any. If the
+    /// file system did not return a `Handle` from `open` then the contents of
+    /// `handle` are undefined.
+    ///
+    /// If `flush` is `true` then the contents of the file should also be flushed to disk.
+    #[allow(clippy::too_many_arguments)]
+    fn release(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        flags: u32,
+        handle: Self::Handle,
+        flush: bool,
+        flock_release: bool,
+        lock_owner: Option<u64>,
+    ) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Get information about the file system.
+    fn statfs(&self, ctx: Context, inode: Self::Inode) -> io::Result<libc::statvfs64> {
+        // Safe because we are zero-initializing a struct with only POD fields.
+        let mut st: libc::statvfs64 = unsafe { mem::zeroed() };
+
+        // This matches the behavior of libfuse as it returns these values if the
+        // filesystem doesn't implement this method.
+        st.f_namemax = 255;
+        st.f_bsize = 512;
+
+        Ok(st)
+    }
+
+    /// Set an extended attribute.
+    ///
+    /// If this method fails with an `ENOSYS` error, then the kernel will treat that as a permanent
+    /// failure. The kernel will return `EOPNOTSUPP` for all future calls to `setxattr` without
+    /// forwarding them to the file system.
+    ///
+    /// Valid values for flags are the same as those accepted by the `setxattr(2)` system call and
+    /// have the same behavior.
+    fn setxattr(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        name: &CStr,
+        value: &[u8],
+        flags: u32,
+    ) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Get an extended attribute.
+    ///
+    /// If `size` is 0, then the file system should respond with `GetxattrReply::Count` and the
+    /// number of bytes needed to hold the value. If `size` is large enough to hold the value, then
+    /// the file system should reply with `GetxattrReply::Value` and the value of the extended
+    /// attribute. If `size` is not 0 but is also not large enough to hold the value, then the file
+    /// system should reply with an `ERANGE` error.
+    ///
+    /// If this method fails with an `ENOSYS` error, then the kernel will treat that as a permanent
+    /// failure. The kernel will return `EOPNOTSUPP` for all future calls to `getxattr` without
+    /// forwarding them to the file system.
+    fn getxattr(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        name: &CStr,
+        size: u32,
+    ) -> io::Result<GetxattrReply> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// List extended attribute names.
+    ///
+    /// If `size` is 0, then the file system should respond with `ListxattrReply::Count` and the
+    /// number of bytes needed to hold a `\0` byte separated list of the names of all the extended
+    /// attributes. If `size` is large enough to hold the `\0` byte separated list of the attribute
+    /// names, then the file system should reply with `ListxattrReply::Names` and the list. If
+    /// `size` is not 0 but is also not large enough to hold the list, then the file system should
+    /// reply with an `ERANGE` error.
+    ///
+    /// If this method fails with an `ENOSYS` error, then the kernel will treat that as a permanent
+    /// failure. The kernel will return `EOPNOTSUPP` for all future calls to `listxattr` without
+    /// forwarding them to the file system.
+    fn listxattr(&self, ctx: Context, inode: Self::Inode, size: u32) -> io::Result<ListxattrReply> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Remove an extended attribute.
+    ///
+    /// If this method fails with an `ENOSYS` error, then the kernel will treat that as a permanent
+    /// failure. The kernel will return `EOPNOTSUPP` for all future calls to `removexattr` without
+    /// forwarding them to the file system.
+    fn removexattr(&self, ctx: Context, inode: Self::Inode, name: &CStr) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Open a directory for reading.
+    ///
+    /// The file system may choose to return a `Handle` to refer to the newly opened directory. The
+    /// kernel will then use this `Handle` for all operations on the content of the directory
+    /// (`readdir`, `readdirplus`, `fsyncdir`, `releasedir`). If the file system does not return a
+    /// `Handle` then the kernel will use the `Inode` for the directory to operate on its contents.
+    /// In this case the file system may wish to enable the `FsOptions::ZERO_MESSAGE_OPENDIR`
+    /// feature if it is supported by the kernel (see below).
+    ///
+    /// The returned `OpenOptions` allow the file system to change the way the opened directory is
+    /// handled by the kernel. See the documentation of `OpenOptions` for more information.
+    ///
+    /// If the `FsOptions::ZERO_MESSAGE_OPENDIR` feature is enabled by both the file system
+    /// implementation and the kernel, then the file system may return an error of `ENOSYS`. This
+    /// will be interpreted by the kernel as success and future calls to `opendir` and `releasedir`
+    /// will be handled by the kernel without being passed on to the file system.
+    fn opendir(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        flags: u32,
+    ) -> io::Result<(Option<Self::Handle>, OpenOptions)> {
+        // Matches the behavior of libfuse.
+        Ok((None, OpenOptions::empty()))
+    }
+
+    /// Read a directory.
+    ///
+    /// `handle` is the `Handle` returned by the file system from the `opendir` method, if any. If
+    /// the file system did not return a `Handle` from `opendir` then the contents of `handle` are
+    /// undefined.
+    ///
+    /// `size` indicates the maximum number of bytes that should be returned by this method.
+    ///
+    /// If `offset` is non-zero then it corresponds to one of the `offset` values from a `DirEntry`
+    /// that was previously returned by a call to `readdir` for the same handle. In this case the
+    /// file system should skip over the entries before the position defined by the `offset` value.
+    /// If entries were added or removed while the `Handle` is open then the file system may still
+    /// include removed entries or skip newly created entries. However, adding or removing entries
+    /// should never cause the file system to skip over unrelated entries or include an entry more
+    /// than once. This means that `offset` cannot be a simple index and must include sufficient
+    /// information to uniquely determine the next entry in the list even when the set of entries is
+    /// being changed.
+    ///
+    /// The file system may return entries for the current directory (".") and parent directory
+    /// ("..") but is not required to do so. If the file system does not return these entries, then
+    /// they are implicitly added by the kernel.
+    ///
+    /// The lookup count for `Inode`s associated with the returned directory entries is **NOT**
+    /// affected by this method.
+    ///
+    // TODO(chirantan): Change method signature to return `Iterator<DirEntry>` rather than using an
+    // `FnMut` for adding entries.
+    fn readdir<F>(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        size: u32,
+        offset: u64,
+        add_entry: F,
+    ) -> io::Result<()>
+    where
+        F: FnMut(DirEntry) -> io::Result<usize>,
+    {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Read a directory with entry attributes.
+    ///
+    /// Like `readdir` but also includes the attributes for each directory entry.
+    ///
+    /// `handle` is the `Handle` returned by the file system from the `opendir` method, if any. If
+    /// the file system did not return a `Handle` from `opendir` then the contents of `handle` are
+    /// undefined.
+    ///
+    /// `size` indicates the maximum number of bytes that should be returned by this method.
+    ///
+    /// Unlike `readdir`, the lookup count for `Inode`s associated with the returned directory
+    /// entries **IS** affected by this method (since it returns an `Entry` for each `DirEntry`).
+    /// The count for each `Inode` should be increased by 1.
+    ///
+    /// File systems that implement this method should enable the `FsOptions::DO_READDIRPLUS`
+    /// feature when supported by the kernel. The kernel will not call this method unless that
+    /// feature is enabled.
+    ///
+    /// Additionally, file systems that implement both `readdir` and `readdirplus` should enable the
+    /// `FsOptions::READDIRPLUS_AUTO` feature to allow the kernel to issue both `readdir` and
+    /// `readdirplus` requests, depending on how much information is expected to be required.
+    ///
+    /// TODO(chirantan): Change method signature to return `Iterator<(DirEntry, Entry)>` rather than
+    /// using an `FnMut` for adding entries.
+    fn readdirplus<F>(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        size: u32,
+        offset: u64,
+        add_entry: F,
+    ) -> io::Result<()>
+    where
+        F: FnMut(DirEntry, Entry) -> io::Result<usize>,
+    {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Synchronize the contents of a directory.
+    ///
+    /// File systems must ensure that the directory contents have been flushed to disk before
+    /// returning from this method. If `datasync` is true then only the directory data (but not the
+    /// metadata) needs to be flushed.
+    ///
+    /// `handle` is the `Handle` returned by the file system from the `opendir` method, if any. If
+    /// the file system did not return a `Handle` from `opendir` then the contents of
+    /// `handle` are undefined.
+    ///
+    /// If this method returns an `ENOSYS` error then the kernel will treat it as success and all
+    /// subsequent calls to `fsyncdir` will be handled by the kernel without being forwarded to the
+    /// file system.
+    fn fsyncdir(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        datasync: bool,
+        handle: Self::Handle,
+    ) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Release an open directory.
+    ///
+    /// For every `opendir` call there will be exactly one `releasedir` call (unless the file system
+    /// is force-unmounted).
+    ///
+    /// `handle` is the `Handle` returned by the file system from the `opendir` method, if any. If
+    /// the file system did not return a `Handle` from `opendir` then the contents of `handle` are
+    /// undefined.
+    ///
+    /// `flags` contains used the flags used to open the directory in `opendir`.
+    fn releasedir(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        flags: u32,
+        handle: Self::Handle,
+    ) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Check file access permissions.
+    ///
+    /// This method is called when a userspace process in the client makes an `access()` or
+    /// `chdir()` system call. If the file system was mounted with the `-o default_permissions`
+    /// mount option, then the kernel will perform these checks itself and this method will not be
+    /// called.
+    ///
+    /// If this method returns an `ENOSYS` error, then the kernel will treat it as a permanent
+    /// success: all future calls to `access` will return success without being forwarded to the
+    /// file system.
+    fn access(&self, ctx: Context, inode: Self::Inode, mask: u32) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// TODO: support this
+    fn getlk(&self) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// TODO: support this
+    fn setlk(&self) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// TODO: support this
+    fn setlkw(&self) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// TODO: support this
+    fn ioctl(&self) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// TODO: support this
+    fn bmap(&self) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// TODO: support this
+    fn poll(&self) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// TODO: support this
+    fn notify_reply(&self) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// TODO: support this
+    fn lseek(&self) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+}

--- a/vhost_user_fs/src/fuse.rs
+++ b/vhost_user_fs/src/fuse.rs
@@ -1,0 +1,1047 @@
+// Copyright 2019 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+use std::mem;
+
+use bitflags::bitflags;
+use libc;
+use vm_memory::ByteValued;
+
+/// Version number of this interface.
+pub const KERNEL_VERSION: u32 = 7;
+
+/// Minor version number of this interface.
+pub const KERNEL_MINOR_VERSION: u32 = 27;
+
+/// The ID of the inode corresponding to the root directory of the file system.
+pub const ROOT_ID: u64 = 1;
+
+// Bitmasks for `fuse_setattr_in.valid`.
+const FATTR_MODE: u32 = 1;
+const FATTR_UID: u32 = 2;
+const FATTR_GID: u32 = 4;
+const FATTR_SIZE: u32 = 8;
+const FATTR_ATIME: u32 = 16;
+const FATTR_MTIME: u32 = 32;
+pub const FATTR_FH: u32 = 64;
+const FATTR_ATIME_NOW: u32 = 128;
+const FATTR_MTIME_NOW: u32 = 256;
+pub const FATTR_LOCKOWNER: u32 = 512;
+const FATTR_CTIME: u32 = 1024;
+
+bitflags! {
+    pub struct SetattrValid: u32 {
+        const MODE = FATTR_MODE;
+        const UID = FATTR_UID;
+        const GID = FATTR_GID;
+        const SIZE = FATTR_SIZE;
+        const ATIME = FATTR_ATIME;
+        const MTIME = FATTR_MTIME;
+        const ATIME_NOW = FATTR_ATIME_NOW;
+        const MTIME_NOW = FATTR_MTIME_NOW;
+        const CTIME = FATTR_CTIME;
+    }
+}
+
+// Flags returned by the OPEN request.
+
+/// Bypass page cache for this open file.
+const FOPEN_DIRECT_IO: u32 = 1;
+
+/// Don't invalidate the data cache on open.
+const FOPEN_KEEP_CACHE: u32 = 2;
+
+/// The file is not seekable.
+const FOPEN_NONSEEKABLE: u32 = 4;
+
+bitflags! {
+    /// Options controlling the behavior of files opened by the server in response
+    /// to an open or create request.
+    pub struct OpenOptions: u32 {
+        const DIRECT_IO = FOPEN_DIRECT_IO;
+        const KEEP_CACHE = FOPEN_KEEP_CACHE;
+        const NONSEEKABLE = FOPEN_NONSEEKABLE;
+    }
+}
+
+// INIT request/reply flags.
+
+/// Asynchronous read requests.
+const ASYNC_READ: u32 = 1;
+
+/// Remote locking for POSIX file locks.
+const POSIX_LOCKS: u32 = 2;
+
+/// Kernel sends file handle for fstat, etc... (not yet supported).
+const FILE_OPS: u32 = 4;
+
+/// Handles the O_TRUNC open flag in the filesystem.
+const ATOMIC_O_TRUNC: u32 = 8;
+
+/// FileSystem handles lookups of "." and "..".
+const EXPORT_SUPPORT: u32 = 16;
+
+/// FileSystem can handle write size larger than 4kB.
+const BIG_WRITES: u32 = 32;
+
+/// Don't apply umask to file mode on create operations.
+const DONT_MASK: u32 = 64;
+
+/// Kernel supports splice write on the device.
+const SPLICE_WRITE: u32 = 128;
+
+/// Kernel supports splice move on the device.
+const SPLICE_MOVE: u32 = 256;
+
+/// Kernel supports splice read on the device.
+const SPLICE_READ: u32 = 512;
+
+/// Remote locking for BSD style file locks.
+const FLOCK_LOCKS: u32 = 1024;
+
+/// Kernel supports ioctl on directories.
+const HAS_IOCTL_DIR: u32 = 2048;
+
+/// Automatically invalidate cached pages.
+const AUTO_INVAL_DATA: u32 = 4096;
+
+/// Do READDIRPLUS (READDIR+LOOKUP in one).
+const DO_READDIRPLUS: u32 = 8192;
+
+/// Adaptive readdirplus.
+const READDIRPLUS_AUTO: u32 = 16384;
+
+/// Asynchronous direct I/O submission.
+const ASYNC_DIO: u32 = 32768;
+
+/// Use writeback cache for buffered writes.
+const WRITEBACK_CACHE: u32 = 65536;
+
+/// Kernel supports zero-message opens.
+const NO_OPEN_SUPPORT: u32 = 131_072;
+
+/// Allow parallel lookups and readdir.
+const PARALLEL_DIROPS: u32 = 262_144;
+
+/// Fs handles killing suid/sgid/cap on write/chown/trunc.
+const HANDLE_KILLPRIV: u32 = 524_288;
+
+/// FileSystem supports posix acls.
+const POSIX_ACL: u32 = 1_048_576;
+
+bitflags! {
+    /// A bitfield passed in as a parameter to and returned from the `init` method of the
+    /// `FileSystem` trait.
+    pub struct FsOptions: u32 {
+        /// Indicates that the filesystem supports asynchronous read requests.
+        ///
+        /// If this capability is not requested/available, the kernel will ensure that there is at
+        /// most one pending read request per file-handle at any time, and will attempt to order
+        /// read requests by increasing offset.
+        ///
+        /// This feature is enabled by default when supported by the kernel.
+        const ASYNC_READ = ASYNC_READ;
+
+        /// Indicates that the filesystem supports "remote" locking.
+        ///
+        /// This feature is not enabled by default and should only be set if the filesystem
+        /// implements the `getlk` and `setlk` methods of the `FileSystem` trait.
+        const POSIX_LOCKS = POSIX_LOCKS;
+
+        /// Kernel sends file handle for fstat, etc... (not yet supported).
+        const FILE_OPS = FILE_OPS;
+
+        /// Indicates that the filesystem supports the `O_TRUNC` open flag. If disabled, and an
+        /// application specifies `O_TRUNC`, fuse first calls `setattr` to truncate the file and
+        /// then calls `open` with `O_TRUNC` filtered out.
+        ///
+        /// This feature is enabled by default when supported by the kernel.
+        const ATOMIC_O_TRUNC = ATOMIC_O_TRUNC;
+
+        /// Indicates that the filesystem supports lookups of "." and "..".
+        ///
+        /// This feature is disabled by default.
+        const EXPORT_SUPPORT = EXPORT_SUPPORT;
+
+        /// FileSystem can handle write size larger than 4kB.
+        const BIG_WRITES = BIG_WRITES;
+
+        /// Indicates that the kernel should not apply the umask to the file mode on create
+        /// operations.
+        ///
+        /// This feature is disabled by default.
+        const DONT_MASK = DONT_MASK;
+
+        /// Indicates that the server should try to use `splice(2)` when writing to the fuse device.
+        /// This may improve performance.
+        ///
+        /// This feature is not currently supported.
+        const SPLICE_WRITE = SPLICE_WRITE;
+
+        /// Indicates that the server should try to move pages instead of copying when writing to /
+        /// reading from the fuse device. This may improve performance.
+        ///
+        /// This feature is not currently supported.
+        const SPLICE_MOVE = SPLICE_MOVE;
+
+        /// Indicates that the server should try to use `splice(2)` when reading from the fuse
+        /// device. This may improve performance.
+        ///
+        /// This feature is not currently supported.
+        const SPLICE_READ = SPLICE_READ;
+
+        /// If set, then calls to `flock` will be emulated using POSIX locks and must
+        /// then be handled by the filesystem's `setlock()` handler.
+        ///
+        /// If not set, `flock` calls will be handled by the FUSE kernel module internally (so any
+        /// access that does not go through the kernel cannot be taken into account).
+        ///
+        /// This feature is disabled by default.
+        const FLOCK_LOCKS = FLOCK_LOCKS;
+
+        /// Indicates that the filesystem supports ioctl's on directories.
+        ///
+        /// This feature is enabled by default when supported by the kernel.
+        const HAS_IOCTL_DIR = HAS_IOCTL_DIR;
+
+        /// Traditionally, while a file is open the FUSE kernel module only asks the filesystem for
+        /// an update of the file's attributes when a client attempts to read beyond EOF. This is
+        /// unsuitable for e.g. network filesystems, where the file contents may change without the
+        /// kernel knowing about it.
+        ///
+        /// If this flag is set, FUSE will check the validity of the attributes on every read. If
+        /// the attributes are no longer valid (i.e., if the *attribute* timeout has expired) then
+        /// FUSE will first send another `getattr` request. If the new mtime differs from the
+        /// previous value, any cached file *contents* will be invalidated as well.
+        ///
+        /// This flag should always be set when available. If all file changes go through the
+        /// kernel, *attribute* validity should be set to a very large number to avoid unnecessary
+        /// `getattr()` calls.
+        ///
+        /// This feature is enabled by default when supported by the kernel.
+        const AUTO_INVAL_DATA = AUTO_INVAL_DATA;
+
+        /// Indicates that the filesystem supports readdirplus.
+        ///
+        /// The feature is not enabled by default and should only be set if the filesystem
+        /// implements the `readdirplus` method of the `FileSystem` trait.
+        const DO_READDIRPLUS = DO_READDIRPLUS;
+
+        /// Indicates that the filesystem supports adaptive readdirplus.
+        ///
+        /// If `DO_READDIRPLUS` is not set, this flag has no effect.
+        ///
+        /// If `DO_READDIRPLUS` is set and this flag is not set, the kernel will always issue
+        /// `readdirplus()` requests to retrieve directory contents.
+        ///
+        /// If `DO_READDIRPLUS` is set and this flag is set, the kernel will issue both `readdir()`
+        /// and `readdirplus()` requests, depending on how much information is expected to be
+        /// required.
+        ///
+        /// This feature is not enabled by default and should only be set if the file system
+        /// implements both the `readdir` and `readdirplus` methods of the `FileSystem` trait.
+        const READDIRPLUS_AUTO = READDIRPLUS_AUTO;
+
+        /// Indicates that the filesystem supports asynchronous direct I/O submission.
+        ///
+        /// If this capability is not requested/available, the kernel will ensure that there is at
+        /// most one pending read and one pending write request per direct I/O file-handle at any
+        /// time.
+        ///
+        /// This feature is enabled by default when supported by the kernel.
+        const ASYNC_DIO = ASYNC_DIO;
+
+        /// Indicates that writeback caching should be enabled. This means that individual write
+        /// request may be buffered and merged in the kernel before they are sent to the file
+        /// system.
+        ///
+        /// This feature is disabled by default.
+        const WRITEBACK_CACHE = WRITEBACK_CACHE;
+
+        /// Indicates support for zero-message opens. If this flag is set in the `capable` parameter
+        /// of the `init` trait method, then the file system may return `ENOSYS` from the open() handler
+        /// to indicate success. Further attempts to open files will be handled in the kernel. (If
+        /// this flag is not set, returning ENOSYS will be treated as an error and signaled to the
+        /// caller).
+        ///
+        /// Setting (or not setting) the field in the `FsOptions` returned from the `init` method
+        /// has no effect.
+        const ZERO_MESSAGE_OPEN = NO_OPEN_SUPPORT;
+
+        /// Indicates support for parallel directory operations. If this flag is unset, the FUSE
+        /// kernel module will ensure that lookup() and readdir() requests are never issued
+        /// concurrently for the same directory.
+        ///
+        /// This feature is enabled by default when supported by the kernel.
+        const PARALLEL_DIROPS = PARALLEL_DIROPS;
+
+        /// Indicates that the file system is responsible for unsetting setuid and setgid bits when a
+        /// file is written, truncated, or its owner is changed.
+        ///
+        /// This feature is enabled by default when supported by the kernel.
+        const HANDLE_KILLPRIV = HANDLE_KILLPRIV;
+
+        /// Indicates support for POSIX ACLs.
+        ///
+        /// If this feature is enabled, the kernel will cache and have responsibility for enforcing
+        /// ACLs. ACL will be stored as xattrs and passed to userspace, which is responsible for
+        /// updating the ACLs in the filesystem, keeping the file mode in sync with the ACL, and
+        /// ensuring inheritance of default ACLs when new filesystem nodes are created. Note that
+        /// this requires that the file system is able to parse and interpret the xattr
+        /// representation of ACLs.
+        ///
+        /// Enabling this feature implicitly turns on the `default_permissions` mount option (even
+        /// if it was not passed to mount(2)).
+        ///
+        /// This feature is disabled by default.
+        const POSIX_ACL = POSIX_ACL;
+    }
+}
+
+// Release flags.
+pub const RELEASE_FLUSH: u32 = 1;
+pub const RELEASE_FLOCK_UNLOCK: u32 = 2;
+
+// Getattr flags.
+pub const GETATTR_FH: u32 = 1;
+
+// Lock flags.
+pub const LK_FLOCK: u32 = 1;
+
+// Write flags.
+
+/// Delayed write from page cache, file handle is guessed.
+pub const WRITE_CACHE: u32 = 1;
+
+/// `lock_owner` field is valid.
+pub const WRITE_LOCKOWNER: u32 = 2;
+
+// Read flags.
+pub const READ_LOCKOWNER: u32 = 2;
+
+// Ioctl flags.
+
+/// 32bit compat ioctl on 64bit machine
+const IOCTL_COMPAT: u32 = 1;
+
+/// Not restricted to well-formed ioctls, retry allowed
+const IOCTL_UNRESTRICTED: u32 = 2;
+
+/// Retry with new iovecs
+const IOCTL_RETRY: u32 = 4;
+
+/// 32bit ioctl
+const IOCTL_32BIT: u32 = 8;
+
+/// Is a directory
+const IOCTL_DIR: u32 = 16;
+
+/// Maximum of in_iovecs + out_iovecs
+const IOCTL_MAX_IOV: u32 = 256;
+
+bitflags! {
+    pub struct IoctlFlags: u32 {
+        /// 32bit compat ioctl on 64bit machine
+        const IOCTL_COMPAT = IOCTL_COMPAT;
+
+        /// Not restricted to well-formed ioctls, retry allowed
+        const IOCTL_UNRESTRICTED = IOCTL_UNRESTRICTED;
+
+        /// Retry with new iovecs
+        const IOCTL_RETRY = IOCTL_RETRY;
+
+        /// 32bit ioctl
+        const IOCTL_32BIT = IOCTL_32BIT;
+
+        /// Is a directory
+        const IOCTL_DIR = IOCTL_DIR;
+
+        /// Maximum of in_iovecs + out_iovecs
+        const IOCTL_MAX_IOV = IOCTL_MAX_IOV;
+    }
+}
+
+/// Request poll notify.
+pub const POLL_SCHEDULE_NOTIFY: u32 = 1;
+
+/// The read buffer is required to be at least 8k, but may be much larger.
+pub const FUSE_MIN_READ_BUFFER: u32 = 8192;
+
+pub const FUSE_COMPAT_ENTRY_OUT_SIZE: u32 = 120;
+pub const FUSE_COMPAT_ATTR_OUT_SIZE: u32 = 96;
+pub const FUSE_COMPAT_MKNOD_IN_SIZE: u32 = 8;
+pub const FUSE_COMPAT_WRITE_IN_SIZE: u32 = 24;
+pub const FUSE_COMPAT_STATFS_SIZE: u32 = 48;
+pub const FUSE_COMPAT_INIT_OUT_SIZE: u32 = 8;
+pub const FUSE_COMPAT_22_INIT_OUT_SIZE: u32 = 24;
+
+// Message definitions follow.  It is safe to implement ByteValued for all of these
+// because they are POD types.
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Attr {
+    pub ino: u64,
+    pub size: u64,
+    pub blocks: u64,
+    pub atime: u64,
+    pub mtime: u64,
+    pub ctime: u64,
+    pub atimensec: u32,
+    pub mtimensec: u32,
+    pub ctimensec: u32,
+    pub mode: u32,
+    pub nlink: u32,
+    pub uid: u32,
+    pub gid: u32,
+    pub rdev: u32,
+    pub blksize: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for Attr {}
+
+impl From<libc::stat64> for Attr {
+    fn from(st: libc::stat64) -> Attr {
+        Attr {
+            ino: st.st_ino,
+            size: st.st_size as u64,
+            blocks: st.st_blocks as u64,
+            atime: st.st_atime as u64,
+            mtime: st.st_mtime as u64,
+            ctime: st.st_ctime as u64,
+            atimensec: st.st_atime_nsec as u32,
+            mtimensec: st.st_mtime_nsec as u32,
+            ctimensec: st.st_ctime_nsec as u32,
+            mode: st.st_mode,
+            nlink: st.st_nlink as u32,
+            uid: st.st_uid,
+            gid: st.st_gid,
+            rdev: st.st_rdev as u32,
+            blksize: st.st_blksize as u32,
+            ..Default::default()
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Kstatfs {
+    pub blocks: u64,
+    pub bfree: u64,
+    pub bavail: u64,
+    pub files: u64,
+    pub ffree: u64,
+    pub bsize: u32,
+    pub namelen: u32,
+    pub frsize: u32,
+    pub padding: u32,
+    pub spare: [u32; 6],
+}
+unsafe impl ByteValued for Kstatfs {}
+
+impl From<libc::statvfs64> for Kstatfs {
+    fn from(st: libc::statvfs64) -> Self {
+        Kstatfs {
+            blocks: st.f_blocks,
+            bfree: st.f_bfree,
+            bavail: st.f_bavail,
+            files: st.f_files,
+            ffree: st.f_ffree,
+            bsize: st.f_bsize as u32,
+            namelen: st.f_namemax as u32,
+            frsize: st.f_frsize as u32,
+            ..Default::default()
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct FileLock {
+    pub start: u64,
+    pub end: u64,
+    pub type_: u32,
+    pub pid: u32, /* tgid */
+}
+unsafe impl ByteValued for FileLock {}
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone)]
+pub enum Opcode {
+    Lookup = 1,
+    Forget = 2, /* No Reply */
+    Getattr = 3,
+    Setattr = 4,
+    Readlink = 5,
+    Symlink = 6,
+    Mknod = 8,
+    Mkdir = 9,
+    Unlink = 10,
+    Rmdir = 11,
+    Rename = 12,
+    Link = 13,
+    Open = 14,
+    Read = 15,
+    Write = 16,
+    Statfs = 17,
+    Release = 18,
+    Fsync = 20,
+    Setxattr = 21,
+    Getxattr = 22,
+    Listxattr = 23,
+    Removexattr = 24,
+    Flush = 25,
+    Init = 26,
+    Opendir = 27,
+    Readdir = 28,
+    Releasedir = 29,
+    Fsyncdir = 30,
+    Getlk = 31,
+    Setlk = 32,
+    Setlkw = 33,
+    Access = 34,
+    Create = 35,
+    Interrupt = 36,
+    Bmap = 37,
+    Destroy = 38,
+    Ioctl = 39,
+    Poll = 40,
+    NotifyReply = 41,
+    BatchForget = 42,
+    Fallocate = 43,
+    Readdirplus = 44,
+    Rename2 = 45,
+    Lseek = 46,
+}
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone)]
+pub enum NotifyOpcode {
+    Poll = 1,
+    InvalInode = 2,
+    InvalEntry = 3,
+    Store = 4,
+    Retrieve = 5,
+    Delete = 6,
+    CodeMax = 7,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct EntryOut {
+    pub nodeid: u64,      /* Inode ID */
+    pub generation: u64,  /* Inode generation: nodeid:gen must be unique for the fs's lifetime */
+    pub entry_valid: u64, /* Cache timeout for the name */
+    pub attr_valid: u64,  /* Cache timeout for the attributes */
+    pub entry_valid_nsec: u32,
+    pub attr_valid_nsec: u32,
+    pub attr: Attr,
+}
+unsafe impl ByteValued for EntryOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ForgetIn {
+    pub nlookup: u64,
+}
+unsafe impl ByteValued for ForgetIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ForgetOne {
+    pub nodeid: u64,
+    pub nlookup: u64,
+}
+unsafe impl ByteValued for ForgetOne {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct BatchForgetIn {
+    pub count: u32,
+    pub dummy: u32,
+}
+unsafe impl ByteValued for BatchForgetIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct GetattrIn {
+    pub flags: u32,
+    pub dummy: u32,
+    pub fh: u64,
+}
+unsafe impl ByteValued for GetattrIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct AttrOut {
+    pub attr_valid: u64, /* Cache timeout for the attributes */
+    pub attr_valid_nsec: u32,
+    pub dummy: u32,
+    pub attr: Attr,
+}
+unsafe impl ByteValued for AttrOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct MknodIn {
+    pub mode: u32,
+    pub rdev: u32,
+    pub umask: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for MknodIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct MkdirIn {
+    pub mode: u32,
+    pub umask: u32,
+}
+unsafe impl ByteValued for MkdirIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct RenameIn {
+    pub newdir: u64,
+}
+unsafe impl ByteValued for RenameIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Rename2In {
+    pub newdir: u64,
+    pub flags: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for Rename2In {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct LinkIn {
+    pub oldnodeid: u64,
+}
+unsafe impl ByteValued for LinkIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SetattrIn {
+    pub valid: u32,
+    pub padding: u32,
+    pub fh: u64,
+    pub size: u64,
+    pub lock_owner: u64,
+    pub atime: u64,
+    pub mtime: u64,
+    pub ctime: u64,
+    pub atimensec: u32,
+    pub mtimensec: u32,
+    pub ctimensec: u32,
+    pub mode: u32,
+    pub unused4: u32,
+    pub uid: u32,
+    pub gid: u32,
+    pub unused5: u32,
+}
+unsafe impl ByteValued for SetattrIn {}
+
+impl Into<libc::stat64> for SetattrIn {
+    fn into(self) -> libc::stat64 {
+        // Safe because we are zero-initializing a struct with only POD fields.
+        let mut out: libc::stat64 = unsafe { mem::zeroed() };
+        out.st_mode = self.mode;
+        out.st_uid = self.uid;
+        out.st_gid = self.gid;
+        out.st_size = self.size as i64;
+        out.st_atime = self.atime as i64;
+        out.st_mtime = self.mtime as i64;
+        out.st_ctime = self.ctime as i64;
+        out.st_atime_nsec = i64::from(self.atimensec);
+        out.st_mtime_nsec = i64::from(self.mtimensec);
+        out.st_ctime_nsec = i64::from(self.ctimensec);
+
+        out
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct OpenIn {
+    pub flags: u32,
+    pub unused: u32,
+}
+unsafe impl ByteValued for OpenIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct CreateIn {
+    pub flags: u32,
+    pub mode: u32,
+    pub umask: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for CreateIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct OpenOut {
+    pub fh: u64,
+    pub open_flags: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for OpenOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ReleaseIn {
+    pub fh: u64,
+    pub flags: u32,
+    pub release_flags: u32,
+    pub lock_owner: u64,
+}
+unsafe impl ByteValued for ReleaseIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct FlushIn {
+    pub fh: u64,
+    pub unused: u32,
+    pub padding: u32,
+    pub lock_owner: u64,
+}
+unsafe impl ByteValued for FlushIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ReadIn {
+    pub fh: u64,
+    pub offset: u64,
+    pub size: u32,
+    pub read_flags: u32,
+    pub lock_owner: u64,
+    pub flags: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for ReadIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct WriteIn {
+    pub fh: u64,
+    pub offset: u64,
+    pub size: u32,
+    pub write_flags: u32,
+    pub lock_owner: u64,
+    pub flags: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for WriteIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct WriteOut {
+    pub size: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for WriteOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct StatfsOut {
+    pub st: Kstatfs,
+}
+unsafe impl ByteValued for StatfsOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct FsyncIn {
+    pub fh: u64,
+    pub fsync_flags: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for FsyncIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SetxattrIn {
+    pub size: u32,
+    pub flags: u32,
+}
+unsafe impl ByteValued for SetxattrIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct GetxattrIn {
+    pub size: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for GetxattrIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct GetxattrOut {
+    pub size: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for GetxattrOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct LkIn {
+    pub fh: u64,
+    pub owner: u64,
+    pub lk: FileLock,
+    pub lk_flags: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for LkIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct LkOut {
+    pub lk: FileLock,
+}
+unsafe impl ByteValued for LkOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct AccessIn {
+    pub mask: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for AccessIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct InitIn {
+    pub major: u32,
+    pub minor: u32,
+    pub max_readahead: u32,
+    pub flags: u32,
+}
+unsafe impl ByteValued for InitIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct InitOut {
+    pub major: u32,
+    pub minor: u32,
+    pub max_readahead: u32,
+    pub flags: u32,
+    pub max_background: u16,
+    pub congestion_threshold: u16,
+    pub max_write: u32,
+    pub time_gran: u32,
+    pub unused: [u32; 9],
+}
+unsafe impl ByteValued for InitOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct InterruptIn {
+    pub unique: u64,
+}
+unsafe impl ByteValued for InterruptIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct BmapIn {
+    pub block: u64,
+    pub blocksize: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for BmapIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct BmapOut {
+    pub block: u64,
+}
+unsafe impl ByteValued for BmapOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct IoctlIn {
+    pub fh: u64,
+    pub flags: u32,
+    pub cmd: u32,
+    pub arg: u64,
+    pub in_size: u32,
+    pub out_size: u32,
+}
+unsafe impl ByteValued for IoctlIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct IoctlIovec {
+    pub base: u64,
+    pub len: u64,
+}
+unsafe impl ByteValued for IoctlIovec {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct IoctlOut {
+    pub result: i32,
+    pub flags: u32,
+    pub in_iovs: u32,
+    pub out_iovs: u32,
+}
+unsafe impl ByteValued for IoctlOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PollIn {
+    pub fh: u64,
+    pub kh: u64,
+    pub flags: u32,
+    pub events: u32,
+}
+unsafe impl ByteValued for PollIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PollOut {
+    pub revents: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for PollOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct NotifyPollWakeupOut {
+    pub kh: u64,
+}
+unsafe impl ByteValued for NotifyPollWakeupOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct FallocateIn {
+    pub fh: u64,
+    pub offset: u64,
+    pub length: u64,
+    pub mode: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for FallocateIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct InHeader {
+    pub len: u32,
+    pub opcode: u32,
+    pub unique: u64,
+    pub nodeid: u64,
+    pub uid: u32,
+    pub gid: u32,
+    pub pid: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for InHeader {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct OutHeader {
+    pub len: u32,
+    pub error: i32,
+    pub unique: u64,
+}
+unsafe impl ByteValued for OutHeader {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Dirent {
+    pub ino: u64,
+    pub off: u64,
+    pub namelen: u32,
+    pub type_: u32,
+    // char name[];
+}
+unsafe impl ByteValued for Dirent {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Direntplus {
+    pub entry_out: EntryOut,
+    pub dirent: Dirent,
+}
+unsafe impl ByteValued for Direntplus {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct NotifyInvalInodeOut {
+    pub ino: u64,
+    pub off: i64,
+    pub len: i64,
+}
+unsafe impl ByteValued for NotifyInvalInodeOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct NotifyInvalEntryOut {
+    pub parent: u64,
+    pub namelen: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for NotifyInvalEntryOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct NotifyDeleteOut {
+    pub parent: u64,
+    pub child: u64,
+    pub namelen: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for NotifyDeleteOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct NotifyStoreOut {
+    pub nodeid: u64,
+    pub offset: u64,
+    pub size: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for NotifyStoreOut {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Notify_Retrieve_Out {
+    pub notify_unique: u64,
+    pub nodeid: u64,
+    pub offset: u64,
+    pub size: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for Notify_Retrieve_Out {}
+
+/* Matches the size of fuse_write_in */
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct NotifyRetrieveIn {
+    pub dummy1: u64,
+    pub offset: u64,
+    pub size: u32,
+    pub dummy2: u32,
+    pub dummy3: u64,
+    pub dummy4: u64,
+}
+unsafe impl ByteValued for NotifyRetrieveIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct LseekIn {
+    pub fh: u64,
+    pub offset: u64,
+    pub whence: u32,
+    pub padding: u32,
+}
+unsafe impl ByteValued for LseekIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct LseekOut {
+    pub offset: u64,
+}
+unsafe impl ByteValued for LseekOut {}

--- a/vhost_user_fs/src/lib.rs
+++ b/vhost_user_fs/src/lib.rs
@@ -1,3 +1,5 @@
 // Copyright © 2019 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+pub mod fuse;

--- a/vhost_user_fs/src/lib.rs
+++ b/vhost_user_fs/src/lib.rs
@@ -11,3 +11,47 @@ pub mod filesystem;
 pub mod fuse;
 pub mod multikey;
 pub mod passthrough;
+pub mod server;
+
+use std::ffi::FromBytesWithNulError;
+use std::{error, fmt, io};
+
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to decode protocol messages.
+    DecodeMessage(io::Error),
+    /// Failed to encode protocol messages.
+    EncodeMessage(io::Error),
+    /// One or more parameters are missing.
+    MissingParameter,
+    /// A C string parameter is invalid.
+    InvalidCString(FromBytesWithNulError),
+    /// The `len` field of the header is too small.
+    InvalidHeaderLength,
+    /// The `size` field of the `SetxattrIn` message does not match the length
+    /// of the decoded value.
+    InvalidXattrSize((u32, usize)),
+}
+
+impl error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+        match self {
+            DecodeMessage(err) => write!(f, "failed to decode fuse message: {}", err),
+            EncodeMessage(err) => write!(f, "failed to encode fuse message: {}", err),
+            MissingParameter => write!(f, "one or more parameters are missing"),
+            InvalidHeaderLength => write!(f, "the `len` field of the header is too small"),
+            InvalidCString(err) => write!(f, "a c string parameter is invalid: {}", err),
+            InvalidXattrSize((size, len)) => write!(
+                f,
+                "The `size` field of the `SetxattrIn` message does not match the length of the\
+                 decoded value: size = {}, value.len() = {}",
+                size, len
+            ),
+        }
+    }
+}
+
+pub type Result<T> = ::std::result::Result<T, Error>;

--- a/vhost_user_fs/src/lib.rs
+++ b/vhost_user_fs/src/lib.rs
@@ -5,6 +5,7 @@
 #[macro_use]
 extern crate log;
 
+pub mod descriptor_utils;
 pub mod file_traits;
 pub mod filesystem;
 pub mod fuse;

--- a/vhost_user_fs/src/lib.rs
+++ b/vhost_user_fs/src/lib.rs
@@ -2,6 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
+#[macro_use]
+extern crate log;
+
 pub mod filesystem;
 pub mod fuse;
 pub mod multikey;
+pub mod passthrough;

--- a/vhost_user_fs/src/lib.rs
+++ b/vhost_user_fs/src/lib.rs
@@ -5,6 +5,7 @@
 #[macro_use]
 extern crate log;
 
+pub mod file_traits;
 pub mod filesystem;
 pub mod fuse;
 pub mod multikey;

--- a/vhost_user_fs/src/lib.rs
+++ b/vhost_user_fs/src/lib.rs
@@ -3,3 +3,4 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 pub mod fuse;
+pub mod multikey;

--- a/vhost_user_fs/src/lib.rs
+++ b/vhost_user_fs/src/lib.rs
@@ -1,0 +1,3 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause

--- a/vhost_user_fs/src/lib.rs
+++ b/vhost_user_fs/src/lib.rs
@@ -2,5 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
+pub mod filesystem;
 pub mod fuse;
 pub mod multikey;

--- a/vhost_user_fs/src/multikey.rs
+++ b/vhost_user_fs/src/multikey.rs
@@ -1,0 +1,274 @@
+// Copyright 2019 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+use std::borrow::Borrow;
+use std::collections::BTreeMap;
+
+/// A BTreeMap that supports 2 types of keys per value. All the usual restrictions and warnings for
+/// `std::collections::BTreeMap` also apply to this struct. Additionally, there is a 1:1
+/// relationship between the 2 key types. In other words, for each `K1` in the map, there is exactly
+/// one `K2` in the map and vice versa.
+#[derive(Default)]
+pub struct MultikeyBTreeMap<K1, K2, V>
+where
+    K1: Ord,
+    K2: Ord,
+{
+    // We need to keep a copy of the second key in the main map so that we can remove entries using
+    // just the main key. Otherwise we would require the caller to provide both keys when calling
+    // `remove`.
+    main: BTreeMap<K1, (K2, V)>,
+    alt: BTreeMap<K2, K1>,
+}
+
+impl<K1, K2, V> MultikeyBTreeMap<K1, K2, V>
+where
+    K1: Clone + Ord,
+    K2: Clone + Ord,
+{
+    /// Create a new empty MultikeyBTreeMap.
+    pub fn new() -> Self {
+        MultikeyBTreeMap {
+            main: BTreeMap::default(),
+            alt: BTreeMap::default(),
+        }
+    }
+
+    /// Returns a reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of `K1``, but the ordering on the borrowed form must match
+    /// the ordering on `K1`.
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K1: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.main.get(key).map(|(_, v)| v)
+    }
+
+    /// Returns a reference to the value corresponding to the alternate key.
+    ///
+    /// The key may be any borrowed form of the `K2``, but the ordering on the borrowed form must
+    /// match the ordering on `K2`.
+    ///
+    /// Note that this method performs 2 lookups: one to get the main key and another to get the
+    /// value associated with that key. For best performance callers should prefer the `get` method
+    /// over this method whenever possible as `get` only needs to perform one lookup.
+    pub fn get_alt<Q2>(&self, key: &Q2) -> Option<&V>
+    where
+        K2: Borrow<Q2>,
+        Q2: Ord + ?Sized,
+    {
+        if let Some(k) = self.alt.get(key) {
+            self.get(k)
+        } else {
+            None
+        }
+    }
+
+    /// Inserts a new entry into the map with the given keys and value.
+    ///
+    /// Returns `None` if the map did not have an entry with `k1` or `k2` present. If exactly one
+    /// key was present, then the value associated with that key is updated, the other key is
+    /// removed, and the old value is returned. If **both** keys were present then the value
+    /// associated with the main key is updated, the value associated with the alternate key is
+    /// removed, and the old value associated with the main key is returned.
+    pub fn insert(&mut self, k1: K1, k2: K2, v: V) -> Option<V> {
+        let oldval = if let Some(oldkey) = self.alt.insert(k2.clone(), k1.clone()) {
+            self.main.remove(&oldkey)
+        } else {
+            None
+        };
+        self.main
+            .insert(k1, (k2.clone(), v))
+            .or(oldval)
+            .map(|(oldk2, v)| {
+                if oldk2 != k2 {
+                    self.alt.remove(&oldk2);
+                }
+                v
+            })
+    }
+
+    /// Remove a key from the map, returning the value associated with that key if it was previously
+    /// in the map.
+    ///
+    /// The key may be any borrowed form of `K1``, but the ordering on the borrowed form must match
+    /// the ordering on `K1`.
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K1: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.main.remove(key).map(|(k2, v)| {
+            self.alt.remove(&k2);
+            v
+        })
+    }
+
+    /// Clears the map, removing all values.
+    pub fn clear(&mut self) {
+        self.alt.clear();
+        self.main.clear()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn get() {
+        let mut m = MultikeyBTreeMap::<u64, i64, u32>::new();
+
+        let k1 = 0xc6c8_f5e0_b13e_ed40;
+        let k2 = 0x1a04_ce4b_8329_14fe;
+        let val = 0xf4e3_c360;
+        assert!(m.insert(k1, k2, val).is_none());
+
+        assert_eq!(*m.get(&k1).expect("failed to look up main key"), val);
+        assert_eq!(*m.get_alt(&k2).expect("failed to look up alt key"), val);
+    }
+
+    #[test]
+    fn update_main_key() {
+        let mut m = MultikeyBTreeMap::<u64, i64, u32>::new();
+
+        let k1 = 0xc6c8_f5e0_b13e_ed40;
+        let k2 = 0x1a04_ce4b_8329_14fe;
+        let val = 0xf4e3_c360;
+        assert!(m.insert(k1, k2, val).is_none());
+
+        let new_k1 = 0x3add_f8f8_c7c5_df5e;
+        let val2 = 0x7389_f8a7;
+        assert_eq!(
+            m.insert(new_k1, k2, val2)
+                .expect("failed to update main key"),
+            val
+        );
+
+        assert!(m.get(&k1).is_none());
+        assert_eq!(*m.get(&new_k1).expect("failed to look up main key"), val2);
+        assert_eq!(*m.get_alt(&k2).expect("failed to look up alt key"), val2);
+    }
+
+    #[test]
+    fn update_alt_key() {
+        let mut m = MultikeyBTreeMap::<u64, i64, u32>::new();
+
+        let k1 = 0xc6c8_f5e0_b13e_ed40;
+        let k2 = 0x1a04_ce4b_8329_14fe;
+        let val = 0xf4e3_c360;
+        assert!(m.insert(k1, k2, val).is_none());
+
+        let new_k2 = 0x6825_a60b_61ac_b333;
+        let val2 = 0xbb14_8f2c;
+        assert_eq!(
+            m.insert(k1, new_k2, val2)
+                .expect("failed to update alt key"),
+            val
+        );
+
+        assert!(m.get_alt(&k2).is_none());
+        assert_eq!(*m.get(&k1).expect("failed to look up main key"), val2);
+        assert_eq!(
+            *m.get_alt(&new_k2).expect("failed to look up alt key"),
+            val2
+        );
+    }
+
+    #[test]
+    fn update_value() {
+        let mut m = MultikeyBTreeMap::<u64, i64, u32>::new();
+
+        let k1 = 0xc6c8_f5e0_b13e_ed40;
+        let k2 = 0x1a04_ce4b_8329_14fe;
+        let val = 0xf4e3_c360;
+        assert!(m.insert(k1, k2, val).is_none());
+
+        let val2 = 0xe42d_79ba;
+        assert_eq!(
+            m.insert(k1, k2, val2).expect("failed to update alt key"),
+            val
+        );
+
+        assert_eq!(*m.get(&k1).expect("failed to look up main key"), val2);
+        assert_eq!(*m.get_alt(&k2).expect("failed to look up alt key"), val2);
+    }
+
+    #[test]
+    fn update_both_keys_main() {
+        let mut m = MultikeyBTreeMap::<u64, i64, u32>::new();
+
+        let k1 = 0xc6c8_f5e0_b13e_ed40;
+        let k2 = 0x1a04_ce4b_8329_14fe;
+        let val = 0xf4e3_c360;
+        assert!(m.insert(k1, k2, val).is_none());
+
+        let new_k1 = 0xc980_587a_24b3_ae30;
+        let new_k2 = 0x2773_c5ee_8239_45a2;
+        let val2 = 0x31f4_33f9;
+        assert!(m.insert(new_k1, new_k2, val2).is_none());
+
+        let val3 = 0x8da1_9cf7;
+        assert_eq!(
+            m.insert(k1, new_k2, val3)
+                .expect("failed to update main key"),
+            val
+        );
+
+        // Both new_k1 and k2 should now be gone from the map.
+        assert!(m.get(&new_k1).is_none());
+        assert!(m.get_alt(&k2).is_none());
+
+        assert_eq!(*m.get(&k1).expect("failed to look up main key"), val3);
+        assert_eq!(
+            *m.get_alt(&new_k2).expect("failed to look up alt key"),
+            val3
+        );
+    }
+
+    #[test]
+    fn update_both_keys_alt() {
+        let mut m = MultikeyBTreeMap::<u64, i64, u32>::new();
+
+        let k1 = 0xc6c8_f5e0_b13e_ed40;
+        let k2 = 0x1a04_ce4b_8329_14fe;
+        let val = 0xf4e3_c360;
+        assert!(m.insert(k1, k2, val).is_none());
+
+        let new_k1 = 0xc980_587a_24b3_ae30;
+        let new_k2 = 0x2773_c5ee_8239_45a2;
+        let val2 = 0x31f4_33f9;
+        assert!(m.insert(new_k1, new_k2, val2).is_none());
+
+        let val3 = 0x8da1_9cf7;
+        assert_eq!(
+            m.insert(new_k1, k2, val3)
+                .expect("failed to update main key"),
+            val2
+        );
+
+        // Both k1 and new_k2 should now be gone from the map.
+        assert!(m.get(&k1).is_none());
+        assert!(m.get_alt(&new_k2).is_none());
+
+        assert_eq!(*m.get(&new_k1).expect("failed to look up main key"), val3);
+        assert_eq!(*m.get_alt(&k2).expect("failed to look up alt key"), val3);
+    }
+
+    #[test]
+    fn remove() {
+        let mut m = MultikeyBTreeMap::<u64, i64, u32>::new();
+
+        let k1 = 0xc6c8_f5e0_b13e_ed40;
+        let k2 = 0x1a04_ce4b_8329_14fe;
+        let val = 0xf4e3_c360;
+        assert!(m.insert(k1, k2, val).is_none());
+
+        assert_eq!(m.remove(&k1).expect("failed to remove entry"), val);
+        assert!(m.get(&k1).is_none());
+        assert!(m.get_alt(&k2).is_none());
+    }
+}

--- a/vhost_user_fs/src/passthrough.rs
+++ b/vhost_user_fs/src/passthrough.rs
@@ -1,0 +1,1551 @@
+// Copyright 2019 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+use std::collections::btree_map;
+use std::collections::BTreeMap;
+use std::ffi::{CStr, CString};
+use std::fs::File;
+use std::io;
+use std::mem::{self, size_of, MaybeUninit};
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::Duration;
+
+use libc;
+use vm_memory::ByteValued;
+
+use crate::filesystem::{
+    Context, DirEntry, Entry, FileSystem, FsOptions, GetxattrReply, ListxattrReply, OpenOptions,
+    SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+};
+use crate::fuse;
+use crate::multikey::MultikeyBTreeMap;
+
+const CURRENT_DIR_CSTR: &[u8] = b".\0";
+const PARENT_DIR_CSTR: &[u8] = b"..\0";
+const EMPTY_CSTR: &[u8] = b"\0";
+const ROOT_CSTR: &[u8] = b"/\0";
+const PROC_CSTR: &[u8] = b"/proc\0";
+
+type Inode = u64;
+type Handle = u64;
+
+#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+struct InodeAltKey {
+    ino: libc::ino64_t,
+    dev: libc::dev_t,
+}
+
+struct InodeData {
+    inode: Inode,
+    // Most of these aren't actually files but ¯\_(ツ)_/¯.
+    file: File,
+    refcount: AtomicU64,
+}
+
+struct HandleData {
+    inode: Inode,
+    file: Mutex<File>,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, Default)]
+struct LinuxDirent64 {
+    d_ino: libc::ino64_t,
+    d_off: libc::off64_t,
+    d_reclen: libc::c_ushort,
+    d_ty: libc::c_uchar,
+}
+unsafe impl ByteValued for LinuxDirent64 {}
+
+macro_rules! scoped_cred {
+    ($name:ident, $ty:ty, $syscall_nr:expr) => {
+        #[derive(Debug)]
+        struct $name;
+
+        impl $name {
+            // Changes the effective uid/gid of the current thread to `val`.  Changes
+            // the thread's credentials back to root when the returned struct is dropped.
+            fn new(val: $ty) -> io::Result<Option<$name>> {
+                if val == 0 {
+                    // Nothing to do since we are already uid 0.
+                    return Ok(None);
+                }
+
+                // We want credential changes to be per-thread because otherwise
+                // we might interfere with operations being carried out on other
+                // threads with different uids/gids.  However, posix requires that
+                // all threads in a process share the same credentials.  To do this
+                // libc uses signals to ensure that when one thread changes its
+                // credentials the other threads do the same thing.
+                //
+                // So instead we invoke the syscall directly in order to get around
+                // this limitation.  Another option is to use the setfsuid and
+                // setfsgid systems calls.   However since those calls have no way to
+                // return an error, it's preferable to do this instead.
+
+                // This call is safe because it doesn't modify any memory and we
+                // check the return value.
+                let res = unsafe { libc::syscall($syscall_nr, -1, val, -1) };
+                if res == 0 {
+                    Ok(Some($name))
+                } else {
+                    Err(io::Error::last_os_error())
+                }
+            }
+        }
+
+        impl Drop for $name {
+            fn drop(&mut self) {
+                let res = unsafe { libc::syscall($syscall_nr, -1, 0, -1) };
+                if res < 0 {
+                    error!(
+                        "failed to change credentials back to root: {}",
+                        io::Error::last_os_error(),
+                    );
+                }
+            }
+        }
+    };
+}
+scoped_cred!(ScopedUid, libc::uid_t, libc::SYS_setresuid);
+scoped_cred!(ScopedGid, libc::gid_t, libc::SYS_setresgid);
+
+fn set_creds(
+    uid: libc::uid_t,
+    gid: libc::gid_t,
+) -> io::Result<(Option<ScopedUid>, Option<ScopedGid>)> {
+    // We have to change the gid before we change the uid because if we change the uid first then we
+    // lose the capability to change the gid.  However changing back can happen in any order.
+    ScopedGid::new(gid).and_then(|gid| Ok((ScopedUid::new(uid)?, gid)))
+}
+
+fn ebadf() -> io::Error {
+    io::Error::from_raw_os_error(libc::EBADF)
+}
+
+fn stat(f: &File) -> io::Result<libc::stat64> {
+    let mut st = MaybeUninit::<libc::stat64>::zeroed();
+
+    // Safe because this is a constant value and a valid C string.
+    let pathname = unsafe { CStr::from_bytes_with_nul_unchecked(EMPTY_CSTR) };
+
+    // Safe because the kernel will only write data in `st` and we check the return
+    // value.
+    let res = unsafe {
+        libc::fstatat64(
+            f.as_raw_fd(),
+            pathname.as_ptr(),
+            st.as_mut_ptr(),
+            libc::AT_EMPTY_PATH | libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if res >= 0 {
+        // Safe because the kernel guarantees that the struct is now fully initialized.
+        Ok(unsafe { st.assume_init() })
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// The caching policy that the file system should report to the FUSE client. By default the FUSE
+/// protocol uses close-to-open consistency. This means that any cached contents of the file are
+/// invalidated the next time that file is opened.
+#[derive(Debug, Clone)]
+pub enum CachePolicy {
+    /// The client should never cache file data and all I/O should be directly forwarded to the
+    /// server. This policy must be selected when file contents may change without the knowledge of
+    /// the FUSE client (i.e., the file system does not have exclusive access to the directory).
+    Never,
+
+    /// The client is free to choose when and how to cache file data. This is the default policy and
+    /// uses close-to-open consistency as described in the enum documentation.
+    Auto,
+
+    /// The client should always cache file data. This means that the FUSE client will not
+    /// invalidate any cached data that was returned by the file system the last time the file was
+    /// opened. This policy should only be selected when the file system has exclusive access to the
+    /// directory.
+    Always,
+}
+
+impl FromStr for CachePolicy {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "never" | "Never" | "NEVER" => Ok(CachePolicy::Never),
+            "auto" | "Auto" | "AUTO" => Ok(CachePolicy::Auto),
+            "always" | "Always" | "ALWAYS" => Ok(CachePolicy::Always),
+            _ => Err("invalid cache policy"),
+        }
+    }
+}
+
+impl Default for CachePolicy {
+    fn default() -> Self {
+        CachePolicy::Auto
+    }
+}
+
+/// Options that configure the behavior of the file system.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// How long the FUSE client should consider directory entries to be valid. If the contents of a
+    /// directory can only be modified by the FUSE client (i.e., the file system has exclusive
+    /// access), then this should be a large value.
+    ///
+    /// The default value for this option is 5 seconds.
+    pub entry_timeout: Duration,
+
+    /// How long the FUSE client should consider file and directory attributes to be valid. If the
+    /// attributes of a file or directory can only be modified by the FUSE client (i.e., the file
+    /// system has exclusive access), then this should be set to a large value.
+    ///
+    /// The default value for this option is 5 seconds.
+    pub attr_timeout: Duration,
+
+    /// The caching policy the file system should use. See the documentation of `CachePolicy` for
+    /// more details.
+    pub cache_policy: CachePolicy,
+
+    /// Whether the file system should enabled writeback caching. This can improve performance as it
+    /// allows the FUSE client to cache and coalesce multiple writes before sending them to the file
+    /// system. However, enabling this option can increase the risk of data corruption if the file
+    /// contents can change without the knowledge of the FUSE client (i.e., the server does **NOT**
+    /// have exclusive access). Additionally, the file system should have read access to all files
+    /// in the directory it is serving as the FUSE client may send read requests even for files
+    /// opened with `O_WRONLY`.
+    ///
+    /// Therefore callers should only enable this option when they can guarantee that: 1) the file
+    /// system has exclusive access to the directory and 2) the file system has read permissions for
+    /// all files in that directory.
+    ///
+    /// The default value for this option is `false`.
+    pub writeback: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            entry_timeout: Duration::from_secs(5),
+            attr_timeout: Duration::from_secs(5),
+            cache_policy: Default::default(),
+            writeback: false,
+        }
+    }
+}
+
+/// A file system that simply "passes through" all requests it receives to the underlying file
+/// system. To keep the implementation simple it servers the contents of its root directory. Users
+/// that wish to serve only a specific directory should set up the environment so that that
+/// directory ends up as the root of the file system process. One way to accomplish this is via a
+/// combination of mount namespaces and the pivot_root system call.
+pub struct PassthroughFs {
+    // File descriptors for various points in the file system tree. These fds are always opened with
+    // the `O_PATH` option so they cannot be used for reading or writing any data. See the
+    // documentation of the `O_PATH` flag in `open(2)` for more details on what one can and cannot
+    // do with an fd opened with this flag.
+    inodes: RwLock<MultikeyBTreeMap<Inode, InodeAltKey, Arc<InodeData>>>,
+    next_inode: AtomicU64,
+
+    // File descriptors for open files and directories. Unlike the fds in `inodes`, these _can_ be
+    // used for reading and writing data.
+    handles: RwLock<BTreeMap<Handle, Arc<HandleData>>>,
+    next_handle: AtomicU64,
+
+    // File descriptor pointing to the `/proc` directory. This is used to convert an fd from
+    // `inodes` into one that can go into `handles`. This is accomplished by reading the
+    // `self/fd/{}` symlink. We keep an open fd here in case the file system tree that we are meant
+    // to be serving doesn't have access to `/proc`.
+    proc: File,
+
+    // Whether writeback caching is enabled for this directory. This will only be true when
+    // `cfg.writeback` is true and `init` was called with `FsOptions::WRITEBACK_CACHE`.
+    writeback: AtomicBool,
+
+    cfg: Config,
+}
+
+impl PassthroughFs {
+    pub fn new(cfg: Config) -> io::Result<PassthroughFs> {
+        // Safe because this is a constant value and a valid C string.
+        let proc_cstr = unsafe { CStr::from_bytes_with_nul_unchecked(PROC_CSTR) };
+
+        // Safe because this doesn't modify any memory and we check the return value.
+        let fd = unsafe {
+            libc::openat(
+                libc::AT_FDCWD,
+                proc_cstr.as_ptr(),
+                libc::O_PATH | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // Safe because we just opened this fd.
+        let proc = unsafe { File::from_raw_fd(fd) };
+
+        Ok(PassthroughFs {
+            inodes: RwLock::new(MultikeyBTreeMap::new()),
+            next_inode: AtomicU64::new(fuse::ROOT_ID + 1),
+
+            handles: RwLock::new(BTreeMap::new()),
+            next_handle: AtomicU64::new(0),
+
+            proc,
+
+            writeback: AtomicBool::new(false),
+            cfg,
+        })
+    }
+
+    pub fn keep_fds(&self) -> Vec<RawFd> {
+        vec![self.proc.as_raw_fd()]
+    }
+
+    fn open_inode(&self, inode: Inode, mut flags: i32) -> io::Result<File> {
+        let data = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&inode)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        let pathname = CString::new(format!("self/fd/{}", data.file.as_raw_fd()))
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        // When writeback caching is enabled, the kernel may send read requests even if the
+        // userspace program opened the file write-only. So we need to ensure that we have opened
+        // the file for reading as well as writing.
+        let writeback = self.writeback.load(Ordering::Relaxed);
+        if writeback && flags & libc::O_ACCMODE == libc::O_WRONLY {
+            flags &= !libc::O_ACCMODE;
+            flags |= libc::O_RDWR;
+        }
+
+        // When writeback caching is enabled the kernel is responsible for handling `O_APPEND`.
+        // However, this breaks atomicity as the file may have changed on disk, invalidating the
+        // cached copy of the data in the kernel and the offset that the kernel thinks is the end of
+        // the file. Just allow this for now as it is the user's responsibility to enable writeback
+        // caching only for directories that are not shared. It also means that we need to clear the
+        // `O_APPEND` flag.
+        if writeback && flags & libc::O_APPEND != 0 {
+            flags &= !libc::O_APPEND;
+        }
+
+        // Safe because this doesn't modify any memory and we check the return value. We don't
+        // really check `flags` because if the kernel can't handle poorly specified flags then we
+        // have much bigger problems. Also, clear the `O_NOFOLLOW` flag if it is set since we need
+        // to follow the `/proc/self/fd` symlink to get the file.
+        let fd = unsafe {
+            libc::openat(
+                self.proc.as_raw_fd(),
+                pathname.as_ptr(),
+                (flags | libc::O_CLOEXEC) & (!libc::O_NOFOLLOW),
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // Safe because we just opened this fd.
+        Ok(unsafe { File::from_raw_fd(fd) })
+    }
+
+    fn do_lookup(&self, parent: Inode, name: &CStr) -> io::Result<Entry> {
+        let p = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&parent)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        // Safe because this doesn't modify any memory and we check the return value.
+        let fd = unsafe {
+            libc::openat(
+                p.file.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_PATH | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // Safe because we just opened this fd.
+        let f = unsafe { File::from_raw_fd(fd) };
+
+        let st = stat(&f)?;
+
+        let altkey = InodeAltKey {
+            ino: st.st_ino,
+            dev: st.st_dev,
+        };
+        let data = self.inodes.read().unwrap().get_alt(&altkey).map(Arc::clone);
+
+        let inode = if let Some(data) = data {
+            // Matches with the release store in `forget`.
+            data.refcount.fetch_add(1, Ordering::Acquire);
+            data.inode
+        } else {
+            // There is a possible race here where 2 threads end up adding the same file
+            // into the inode list.  However, since each of those will get a unique Inode
+            // value and unique file descriptors this shouldn't be that much of a problem.
+            let inode = self.next_inode.fetch_add(1, Ordering::Relaxed);
+            self.inodes.write().unwrap().insert(
+                inode,
+                InodeAltKey {
+                    ino: st.st_ino,
+                    dev: st.st_dev,
+                },
+                Arc::new(InodeData {
+                    inode,
+                    file: f,
+                    refcount: AtomicU64::new(1),
+                }),
+            );
+
+            inode
+        };
+
+        Ok(Entry {
+            inode,
+            generation: 0,
+            attr: st,
+            attr_timeout: self.cfg.attr_timeout,
+            entry_timeout: self.cfg.entry_timeout,
+        })
+    }
+
+    fn do_readdir<F>(
+        &self,
+        inode: Inode,
+        handle: Handle,
+        size: u32,
+        offset: u64,
+        mut add_entry: F,
+    ) -> io::Result<()>
+    where
+        F: FnMut(DirEntry) -> io::Result<usize>,
+    {
+        if size == 0 {
+            return Ok(());
+        }
+
+        let data = self
+            .handles
+            .read()
+            .unwrap()
+            .get(&handle)
+            .filter(|hd| hd.inode == inode)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        let mut buf = vec![0; size as usize];
+
+        {
+            // Since we are going to work with the kernel offset, we have to acquire the file lock
+            // for both the `lseek64` and `getdents64` syscalls to ensure that no other thread
+            // changes the kernel offset while we are using it.
+            let dir = data.file.lock().unwrap();
+
+            // Safe because this doesn't modify any memory and we check the return value.
+            let res =
+                unsafe { libc::lseek64(dir.as_raw_fd(), offset as libc::off64_t, libc::SEEK_SET) };
+            if res < 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            // Safe because the kernel guarantees that it will only write to `buf` and we check the
+            // return value.
+            let res = unsafe {
+                libc::syscall(
+                    libc::SYS_getdents64,
+                    dir.as_raw_fd(),
+                    buf.as_mut_ptr() as *mut LinuxDirent64,
+                    size as libc::c_int,
+                )
+            };
+            if res < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            buf.resize(res as usize, 0);
+
+            // Explicitly drop the lock so that it's not held while we fill in the fuse buffer.
+            mem::drop(dir);
+        }
+
+        let mut rem = &buf[..];
+        while !rem.is_empty() {
+            // We only use debug asserts here because these values are coming from the kernel and we
+            // trust them implicitly.
+            debug_assert!(
+                rem.len() >= size_of::<LinuxDirent64>(),
+                "not enough space left in `rem`"
+            );
+
+            let (front, back) = rem.split_at(size_of::<LinuxDirent64>());
+
+            let dirent64 =
+                LinuxDirent64::from_slice(front).expect("unable to get LinuxDirent64 from slice");
+
+            let namelen = dirent64.d_reclen as usize - size_of::<LinuxDirent64>();
+            debug_assert!(namelen <= back.len(), "back is smaller than `namelen`");
+
+            let name = &back[..namelen];
+            let res = if name.starts_with(CURRENT_DIR_CSTR) || name.starts_with(PARENT_DIR_CSTR) {
+                // We don't want to report the "." and ".." entries. However, returning `Ok(0)` will
+                // break the loop so return `Ok` with a non-zero value instead.
+                Ok(1)
+            } else {
+                add_entry(DirEntry {
+                    ino: dirent64.d_ino,
+                    offset: dirent64.d_off as u64,
+                    type_: u32::from(dirent64.d_ty),
+                    name,
+                })
+            };
+
+            debug_assert!(
+                rem.len() >= dirent64.d_reclen as usize,
+                "rem is smaller than `d_reclen`"
+            );
+
+            match res {
+                Ok(0) => break,
+                Ok(_) => rem = &rem[dirent64.d_reclen as usize..],
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(())
+    }
+
+    fn do_open(&self, inode: Inode, flags: u32) -> io::Result<(Option<Handle>, OpenOptions)> {
+        let file = Mutex::new(self.open_inode(inode, flags as i32)?);
+
+        let handle = self.next_handle.fetch_add(1, Ordering::Relaxed);
+        let data = HandleData { inode, file };
+
+        self.handles.write().unwrap().insert(handle, Arc::new(data));
+
+        let mut opts = OpenOptions::empty();
+        match self.cfg.cache_policy {
+            // We only set the direct I/O option on files.
+            CachePolicy::Never => opts.set(
+                OpenOptions::DIRECT_IO,
+                flags & (libc::O_DIRECTORY as u32) == 0,
+            ),
+            CachePolicy::Always => opts |= OpenOptions::KEEP_CACHE,
+            _ => {}
+        };
+
+        Ok((Some(handle), opts))
+    }
+
+    fn do_release(&self, inode: Inode, handle: Handle) -> io::Result<()> {
+        let mut handles = self.handles.write().unwrap();
+
+        if let btree_map::Entry::Occupied(e) = handles.entry(handle) {
+            if e.get().inode == inode {
+                // We don't need to close the file here because that will happen automatically when
+                // the last `Arc` is dropped.
+                e.remove();
+                return Ok(());
+            }
+        }
+
+        Err(ebadf())
+    }
+
+    fn do_getattr(&self, inode: Inode) -> io::Result<(libc::stat64, Duration)> {
+        let data = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&inode)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        let st = stat(&data.file)?;
+
+        Ok((st, self.cfg.attr_timeout))
+    }
+
+    fn do_unlink(&self, parent: Inode, name: &CStr, flags: libc::c_int) -> io::Result<()> {
+        let data = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&parent)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        // Safe because this doesn't modify any memory and we check the return value.
+        let res = unsafe { libc::unlinkat(data.file.as_raw_fd(), name.as_ptr(), flags) };
+        if res == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+}
+
+fn forget_one(
+    inodes: &mut MultikeyBTreeMap<Inode, InodeAltKey, Arc<InodeData>>,
+    inode: Inode,
+    count: u64,
+) {
+    if let Some(data) = inodes.get(&inode) {
+        // Acquiring the write lock on the inode map prevents new lookups from incrementing the
+        // refcount but there is the possibility that a previous lookup already acquired a
+        // reference to the inode data and is in the process of updating the refcount so we need
+        // to loop here until we can decrement successfully.
+        loop {
+            let refcount = data.refcount.load(Ordering::Relaxed);
+
+            // Saturating sub because it doesn't make sense for a refcount to go below zero and
+            // we don't want misbehaving clients to cause integer overflow.
+            let new_count = refcount.saturating_sub(count);
+
+            // Synchronizes with the acquire load in `do_lookup`.
+            if data
+                .refcount
+                .compare_and_swap(refcount, new_count, Ordering::Release)
+                == refcount
+            {
+                if new_count == 0 {
+                    // We just removed the last refcount for this inode. There's no need for an
+                    // acquire fence here because we hold a write lock on the inode map and any
+                    // thread that is waiting to do a forget on the same inode will have to wait
+                    // until we release the lock. So there's is no other release store for us to
+                    // synchronize with before deleting the entry.
+                    inodes.remove(&inode);
+                }
+                break;
+            }
+        }
+    }
+}
+
+impl FileSystem for PassthroughFs {
+    type Inode = Inode;
+    type Handle = Handle;
+
+    fn init(&self, capable: FsOptions) -> io::Result<FsOptions> {
+        // Safe because this is a constant value and a valid C string.
+        let root = unsafe { CStr::from_bytes_with_nul_unchecked(ROOT_CSTR) };
+
+        // Safe because this doesn't modify any memory and we check the return value.
+        // We use `O_PATH` because we just want this for traversing the directory tree
+        // and not for actually reading the contents.
+        let fd = unsafe {
+            libc::openat(
+                libc::AT_FDCWD,
+                root.as_ptr(),
+                libc::O_PATH | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // Safe because we just opened this fd above.
+        let f = unsafe { File::from_raw_fd(fd) };
+
+        let st = stat(&f)?;
+
+        // Safe because this doesn't modify any memory and there is no need to check the return
+        // value because this system call always succeeds. We need to clear the umask here because
+        // we want the client to be able to set all the bits in the mode.
+        unsafe { libc::umask(0o000) };
+
+        let mut inodes = self.inodes.write().unwrap();
+
+        // Not sure why the root inode gets a refcount of 2 but that's what libfuse does.
+        inodes.insert(
+            fuse::ROOT_ID,
+            InodeAltKey {
+                ino: st.st_ino,
+                dev: st.st_dev,
+            },
+            Arc::new(InodeData {
+                inode: fuse::ROOT_ID,
+                file: f,
+                refcount: AtomicU64::new(2),
+            }),
+        );
+
+        let mut opts = FsOptions::DO_READDIRPLUS | FsOptions::READDIRPLUS_AUTO;
+        if self.cfg.writeback && capable.contains(FsOptions::WRITEBACK_CACHE) {
+            opts |= FsOptions::WRITEBACK_CACHE;
+            self.writeback.store(true, Ordering::Relaxed);
+        }
+        Ok(opts)
+    }
+
+    fn destroy(&self) {
+        self.handles.write().unwrap().clear();
+        self.inodes.write().unwrap().clear();
+    }
+
+    fn statfs(&self, _ctx: Context, inode: Inode) -> io::Result<libc::statvfs64> {
+        let data = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&inode)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        let mut out = MaybeUninit::<libc::statvfs64>::zeroed();
+
+        // Safe because this will only modify `out` and we check the return value.
+        let res = unsafe { libc::fstatvfs64(data.file.as_raw_fd(), out.as_mut_ptr()) };
+        if res == 0 {
+            // Safe because the kernel guarantees that `out` has been initialized.
+            Ok(unsafe { out.assume_init() })
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn lookup(&self, _ctx: Context, parent: Inode, name: &CStr) -> io::Result<Entry> {
+        self.do_lookup(parent, name)
+    }
+
+    fn forget(&self, _ctx: Context, inode: Inode, count: u64) {
+        let mut inodes = self.inodes.write().unwrap();
+
+        forget_one(&mut inodes, inode, count)
+    }
+
+    fn batch_forget(&self, _ctx: Context, requests: Vec<(Inode, u64)>) {
+        let mut inodes = self.inodes.write().unwrap();
+
+        for (inode, count) in requests {
+            forget_one(&mut inodes, inode, count)
+        }
+    }
+
+    fn opendir(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        flags: u32,
+    ) -> io::Result<(Option<Handle>, OpenOptions)> {
+        self.do_open(inode, flags | (libc::O_DIRECTORY as u32))
+    }
+
+    fn releasedir(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        _flags: u32,
+        handle: Handle,
+    ) -> io::Result<()> {
+        self.do_release(inode, handle)
+    }
+
+    fn mkdir(
+        &self,
+        ctx: Context,
+        parent: Inode,
+        name: &CStr,
+        mode: u32,
+        umask: u32,
+    ) -> io::Result<Entry> {
+        let (_uid, _gid) = set_creds(ctx.uid, ctx.gid)?;
+        let data = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&parent)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        // Safe because this doesn't modify any memory and we check the return value.
+        let res = unsafe { libc::mkdirat(data.file.as_raw_fd(), name.as_ptr(), mode & !umask) };
+        if res == 0 {
+            self.do_lookup(parent, name)
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn rmdir(&self, _ctx: Context, parent: Inode, name: &CStr) -> io::Result<()> {
+        self.do_unlink(parent, name, libc::AT_REMOVEDIR)
+    }
+
+    fn readdir<F>(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        handle: Handle,
+        size: u32,
+        offset: u64,
+        add_entry: F,
+    ) -> io::Result<()>
+    where
+        F: FnMut(DirEntry) -> io::Result<usize>,
+    {
+        self.do_readdir(inode, handle, size, offset, add_entry)
+    }
+
+    fn readdirplus<F>(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        handle: Handle,
+        size: u32,
+        offset: u64,
+        mut add_entry: F,
+    ) -> io::Result<()>
+    where
+        F: FnMut(DirEntry, Entry) -> io::Result<usize>,
+    {
+        self.do_readdir(inode, handle, size, offset, |dir_entry| {
+            // Safe because the kernel guarantees that the buffer is nul-terminated. Additionally,
+            // the kernel will pad the name with '\0' bytes up to 8-byte alignment and there's no
+            // way for us to know exactly how many padding bytes there are. This would cause
+            // `CStr::from_bytes_with_nul` to return an error because it would think there are
+            // interior '\0' bytes. We trust the kernel to provide us with properly formatted data
+            // so we'll just skip the checks here.
+            let name = unsafe { CStr::from_bytes_with_nul_unchecked(dir_entry.name) };
+            let entry = self.do_lookup(inode, name)?;
+
+            add_entry(dir_entry, entry)
+        })
+    }
+
+    fn open(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        flags: u32,
+    ) -> io::Result<(Option<Handle>, OpenOptions)> {
+        self.do_open(inode, flags)
+    }
+
+    fn release(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        _flags: u32,
+        handle: Handle,
+        _flush: bool,
+        _flock_release: bool,
+        _lock_owner: Option<u64>,
+    ) -> io::Result<()> {
+        self.do_release(inode, handle)
+    }
+
+    fn create(
+        &self,
+        ctx: Context,
+        parent: Inode,
+        name: &CStr,
+        mode: u32,
+        flags: u32,
+        umask: u32,
+    ) -> io::Result<(Entry, Option<Handle>, OpenOptions)> {
+        let (_uid, _gid) = set_creds(ctx.uid, ctx.gid)?;
+        let data = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&parent)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        // Safe because this doesn't modify any memory and we check the return value. We don't
+        // really check `flags` because if the kernel can't handle poorly specified flags then we
+        // have much bigger problems.
+        let fd = unsafe {
+            libc::openat(
+                data.file.as_raw_fd(),
+                name.as_ptr(),
+                flags as i32 | libc::O_CREAT | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+                mode & !(umask & 0o777),
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // Safe because we just opened this fd.
+        let file = Mutex::new(unsafe { File::from_raw_fd(fd) });
+
+        let entry = self.do_lookup(parent, name)?;
+
+        let handle = self.next_handle.fetch_add(1, Ordering::Relaxed);
+        let data = HandleData {
+            inode: entry.inode,
+            file,
+        };
+
+        self.handles.write().unwrap().insert(handle, Arc::new(data));
+
+        let mut opts = OpenOptions::empty();
+        match self.cfg.cache_policy {
+            CachePolicy::Never => opts |= OpenOptions::DIRECT_IO,
+            CachePolicy::Always => opts |= OpenOptions::KEEP_CACHE,
+            _ => {}
+        };
+
+        Ok((entry, Some(handle), opts))
+    }
+
+    fn unlink(&self, _ctx: Context, parent: Inode, name: &CStr) -> io::Result<()> {
+        self.do_unlink(parent, name, 0)
+    }
+
+    fn read<W: io::Write + ZeroCopyWriter>(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        handle: Handle,
+        mut w: W,
+        size: u32,
+        offset: u64,
+        _lock_owner: Option<u64>,
+        _flags: u32,
+    ) -> io::Result<usize> {
+        let data = self
+            .handles
+            .read()
+            .unwrap()
+            .get(&handle)
+            .filter(|hd| hd.inode == inode)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        let mut f = data.file.lock().unwrap();
+        w.write_from(&mut f, size as usize, offset)
+    }
+
+    fn write<R: io::Read + ZeroCopyReader>(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        handle: Handle,
+        mut r: R,
+        size: u32,
+        offset: u64,
+        _lock_owner: Option<u64>,
+        _delayed_write: bool,
+        _flags: u32,
+    ) -> io::Result<usize> {
+        // We need to change credentials during a write so that the kernel will remove setuid or
+        // setgid bits from the file if it was written to by someone other than the owner.
+        let (_uid, _gid) = set_creds(ctx.uid, ctx.gid)?;
+        let data = self
+            .handles
+            .read()
+            .unwrap()
+            .get(&handle)
+            .filter(|hd| hd.inode == inode)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        let mut f = data.file.lock().unwrap();
+        r.read_to(&mut f, size as usize, offset)
+    }
+
+    fn getattr(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        _handle: Option<Handle>,
+    ) -> io::Result<(libc::stat64, Duration)> {
+        self.do_getattr(inode)
+    }
+
+    fn setattr(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        attr: libc::stat64,
+        handle: Option<Handle>,
+        valid: SetattrValid,
+    ) -> io::Result<(libc::stat64, Duration)> {
+        let inode_data = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&inode)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        enum Data {
+            Handle(Arc<HandleData>, RawFd),
+            ProcPath(CString),
+        }
+
+        // If we have a handle then use it otherwise get a new fd from the inode.
+        let data = if let Some(handle) = handle {
+            let hd = self
+                .handles
+                .read()
+                .unwrap()
+                .get(&handle)
+                .filter(|hd| hd.inode == inode)
+                .map(Arc::clone)
+                .ok_or_else(ebadf)?;
+
+            let fd = hd.file.lock().unwrap().as_raw_fd();
+            Data::Handle(hd, fd)
+        } else {
+            let pathname = CString::new(format!("self/fd/{}", inode_data.file.as_raw_fd()))
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            Data::ProcPath(pathname)
+        };
+
+        if valid.contains(SetattrValid::MODE) {
+            // Safe because this doesn't modify any memory and we check the return value.
+            let res = unsafe {
+                match data {
+                    Data::Handle(_, fd) => libc::fchmod(fd, attr.st_mode),
+                    Data::ProcPath(ref p) => {
+                        libc::fchmodat(self.proc.as_raw_fd(), p.as_ptr(), attr.st_mode, 0)
+                    }
+                }
+            };
+            if res < 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+
+        if valid.intersects(SetattrValid::UID | SetattrValid::GID) {
+            let uid = if valid.contains(SetattrValid::UID) {
+                attr.st_uid
+            } else {
+                // Cannot use -1 here because these are unsigned values.
+                ::std::u32::MAX
+            };
+            let gid = if valid.contains(SetattrValid::GID) {
+                attr.st_gid
+            } else {
+                // Cannot use -1 here because these are unsigned values.
+                ::std::u32::MAX
+            };
+
+            // Safe because this is a constant value and a valid C string.
+            let empty = unsafe { CStr::from_bytes_with_nul_unchecked(EMPTY_CSTR) };
+
+            // Safe because this doesn't modify any memory and we check the return value.
+            let res = unsafe {
+                libc::fchownat(
+                    inode_data.file.as_raw_fd(),
+                    empty.as_ptr(),
+                    uid,
+                    gid,
+                    libc::AT_EMPTY_PATH | libc::AT_SYMLINK_NOFOLLOW,
+                )
+            };
+            if res < 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+
+        if valid.contains(SetattrValid::SIZE) {
+            // Safe because this doesn't modify any memory and we check the return value.
+            let res = match data {
+                Data::Handle(_, fd) => unsafe { libc::ftruncate(fd, attr.st_size) },
+                _ => {
+                    // There is no `ftruncateat` so we need to get a new fd and truncate it.
+                    let f = self.open_inode(inode, libc::O_NONBLOCK | libc::O_RDWR)?;
+                    unsafe { libc::ftruncate(f.as_raw_fd(), attr.st_size) }
+                }
+            };
+            if res < 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+
+        if valid.intersects(SetattrValid::ATIME | SetattrValid::MTIME) {
+            let mut tvs = [
+                libc::timespec {
+                    tv_sec: 0,
+                    tv_nsec: libc::UTIME_OMIT,
+                },
+                libc::timespec {
+                    tv_sec: 0,
+                    tv_nsec: libc::UTIME_OMIT,
+                },
+            ];
+
+            if valid.contains(SetattrValid::ATIME_NOW) {
+                tvs[0].tv_nsec = libc::UTIME_NOW;
+            } else if valid.contains(SetattrValid::ATIME) {
+                tvs[0].tv_sec = attr.st_atime;
+                tvs[0].tv_nsec = attr.st_atime_nsec;
+            }
+
+            if valid.contains(SetattrValid::MTIME_NOW) {
+                tvs[1].tv_nsec = libc::UTIME_NOW;
+            } else if valid.contains(SetattrValid::MTIME) {
+                tvs[1].tv_sec = attr.st_mtime;
+                tvs[1].tv_nsec = attr.st_mtime_nsec;
+            }
+
+            // Safe because this doesn't modify any memory and we check the return value.
+            let res = match data {
+                Data::Handle(_, fd) => unsafe { libc::futimens(fd, tvs.as_ptr()) },
+                Data::ProcPath(ref p) => unsafe {
+                    libc::utimensat(self.proc.as_raw_fd(), p.as_ptr(), tvs.as_ptr(), 0)
+                },
+            };
+            if res < 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+
+        self.do_getattr(inode)
+    }
+
+    fn rename(
+        &self,
+        _ctx: Context,
+        olddir: Inode,
+        oldname: &CStr,
+        newdir: Inode,
+        newname: &CStr,
+        flags: u32,
+    ) -> io::Result<()> {
+        let old_inode = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&olddir)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+        let new_inode = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&newdir)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        // Safe because this doesn't modify any memory and we check the return value.
+        // TODO: Switch to libc::renameat2 once https://github.com/rust-lang/libc/pull/1508 lands
+        // and we have glibc 2.28.
+        let res = unsafe {
+            libc::syscall(
+                libc::SYS_renameat2,
+                old_inode.file.as_raw_fd(),
+                oldname.as_ptr(),
+                new_inode.file.as_raw_fd(),
+                newname.as_ptr(),
+                flags,
+            )
+        };
+        if res == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn mknod(
+        &self,
+        ctx: Context,
+        parent: Inode,
+        name: &CStr,
+        mode: u32,
+        rdev: u32,
+        umask: u32,
+    ) -> io::Result<Entry> {
+        let (_uid, _gid) = set_creds(ctx.uid, ctx.gid)?;
+        let data = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&parent)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        // Safe because this doesn't modify any memory and we check the return value.
+        let res = unsafe {
+            libc::mknodat(
+                data.file.as_raw_fd(),
+                name.as_ptr(),
+                (mode & !umask) as libc::mode_t,
+                u64::from(rdev),
+            )
+        };
+
+        if res < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            self.do_lookup(parent, name)
+        }
+    }
+
+    fn link(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        newparent: Inode,
+        newname: &CStr,
+    ) -> io::Result<Entry> {
+        let data = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&inode)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+        let new_inode = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&newparent)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        // Safe because this is a constant value and a valid C string.
+        let empty = unsafe { CStr::from_bytes_with_nul_unchecked(EMPTY_CSTR) };
+
+        // Safe because this doesn't modify any memory and we check the return value.
+        let res = unsafe {
+            libc::linkat(
+                data.file.as_raw_fd(),
+                empty.as_ptr(),
+                new_inode.file.as_raw_fd(),
+                newname.as_ptr(),
+                libc::AT_EMPTY_PATH,
+            )
+        };
+        if res == 0 {
+            self.do_lookup(newparent, newname)
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn symlink(
+        &self,
+        ctx: Context,
+        linkname: &CStr,
+        parent: Inode,
+        name: &CStr,
+    ) -> io::Result<Entry> {
+        let (_uid, _gid) = set_creds(ctx.uid, ctx.gid)?;
+        let data = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&parent)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        // Safe because this doesn't modify any memory and we check the return value.
+        let res =
+            unsafe { libc::symlinkat(linkname.as_ptr(), data.file.as_raw_fd(), name.as_ptr()) };
+        if res == 0 {
+            self.do_lookup(parent, name)
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn readlink(&self, _ctx: Context, inode: Inode) -> io::Result<Vec<u8>> {
+        let data = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&inode)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        let mut buf = vec![0; libc::PATH_MAX as usize];
+
+        // Safe because this is a constant value and a valid C string.
+        let empty = unsafe { CStr::from_bytes_with_nul_unchecked(EMPTY_CSTR) };
+
+        // Safe because this will only modify the contents of `buf` and we check the return value.
+        let res = unsafe {
+            libc::readlinkat(
+                data.file.as_raw_fd(),
+                empty.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+            )
+        };
+        if res < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        buf.resize(res as usize, 0);
+        Ok(buf)
+    }
+
+    fn flush(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        handle: Handle,
+        _lock_owner: u64,
+    ) -> io::Result<()> {
+        let data = self
+            .handles
+            .read()
+            .unwrap()
+            .get(&handle)
+            .filter(|hd| hd.inode == inode)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        // Since this method is called whenever an fd is closed in the client, we can emulate that
+        // behavior by doing the same thing (dup-ing the fd and then immediately closing it). Safe
+        // because this doesn't modify any memory and we check the return values.
+        unsafe {
+            let newfd = libc::dup(data.file.lock().unwrap().as_raw_fd());
+            if newfd < 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            if libc::close(newfd) < 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn fsync(&self, _ctx: Context, inode: Inode, datasync: bool, handle: Handle) -> io::Result<()> {
+        let data = self
+            .handles
+            .read()
+            .unwrap()
+            .get(&handle)
+            .filter(|hd| hd.inode == inode)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        let fd = data.file.lock().unwrap().as_raw_fd();
+
+        // Safe because this doesn't modify any memory and we check the return value.
+        let res = unsafe {
+            if datasync {
+                libc::fdatasync(fd)
+            } else {
+                libc::fsync(fd)
+            }
+        };
+
+        if res == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn fsyncdir(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        datasync: bool,
+        handle: Handle,
+    ) -> io::Result<()> {
+        self.fsync(ctx, inode, datasync, handle)
+    }
+
+    fn access(&self, ctx: Context, inode: Inode, mask: u32) -> io::Result<()> {
+        let data = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&inode)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        let st = stat(&data.file)?;
+        let mode = mask as i32 & (libc::R_OK | libc::W_OK | libc::X_OK);
+
+        if mode == libc::F_OK {
+            // The file exists since we were able to call `stat(2)` on it.
+            return Ok(());
+        }
+
+        if (mode & libc::R_OK) != 0
+            && ctx.uid != 0
+            && (st.st_uid != ctx.uid || st.st_mode & 0o400 == 0)
+            && (st.st_gid != ctx.gid || st.st_mode & 0o040 == 0)
+            && st.st_mode & 0o004 == 0
+        {
+            return Err(io::Error::from_raw_os_error(libc::EACCES));
+        }
+
+        if (mode & libc::W_OK) != 0
+            && ctx.uid != 0
+            && (st.st_uid != ctx.uid || st.st_mode & 0o200 == 0)
+            && (st.st_gid != ctx.gid || st.st_mode & 0o020 == 0)
+            && st.st_mode & 0o002 == 0
+        {
+            return Err(io::Error::from_raw_os_error(libc::EACCES));
+        }
+
+        // root can only execute something if it is executable by one of the owner, the group, or
+        // everyone.
+        if (mode & libc::X_OK) != 0
+            && (ctx.uid != 0 || st.st_mode & 0o111 == 0)
+            && (st.st_uid != ctx.uid || st.st_mode & 0o100 == 0)
+            && (st.st_gid != ctx.gid || st.st_mode & 0o010 == 0)
+            && st.st_mode & 0o001 == 0
+        {
+            return Err(io::Error::from_raw_os_error(libc::EACCES));
+        }
+
+        Ok(())
+    }
+
+    fn setxattr(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        name: &CStr,
+        value: &[u8],
+        flags: u32,
+    ) -> io::Result<()> {
+        // The f{set,get,remove,list}xattr functions don't work on an fd opened with `O_PATH` so we
+        // need to get a new fd.
+        let file = self.open_inode(inode, libc::O_RDONLY | libc::O_NONBLOCK)?;
+
+        // Safe because this doesn't modify any memory and we check the return value.
+        let res = unsafe {
+            libc::fsetxattr(
+                file.as_raw_fd(),
+                name.as_ptr(),
+                value.as_ptr() as *const libc::c_void,
+                value.len(),
+                flags as libc::c_int,
+            )
+        };
+        if res == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn getxattr(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        name: &CStr,
+        size: u32,
+    ) -> io::Result<GetxattrReply> {
+        // The f{set,get,remove,list}xattr functions don't work on an fd opened with `O_PATH` so we
+        // need to get a new fd.
+        let file = self.open_inode(inode, libc::O_RDONLY | libc::O_NONBLOCK)?;
+
+        let mut buf = vec![0; size as usize];
+
+        // Safe because this will only modify the contents of `buf`.
+        let res = unsafe {
+            libc::fgetxattr(
+                file.as_raw_fd(),
+                name.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_void,
+                size as libc::size_t,
+            )
+        };
+        if res < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        if size == 0 {
+            Ok(GetxattrReply::Count(res as u32))
+        } else {
+            buf.resize(res as usize, 0);
+            Ok(GetxattrReply::Value(buf))
+        }
+    }
+
+    fn listxattr(&self, _ctx: Context, inode: Inode, size: u32) -> io::Result<ListxattrReply> {
+        // The f{set,get,remove,list}xattr functions don't work on an fd opened with `O_PATH` so we
+        // need to get a new fd.
+        let file = self.open_inode(inode, libc::O_RDONLY | libc::O_NONBLOCK)?;
+
+        let mut buf = vec![0; size as usize];
+
+        // Safe because this will only modify the contents of `buf`.
+        let res = unsafe {
+            libc::flistxattr(
+                file.as_raw_fd(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                size as libc::size_t,
+            )
+        };
+        if res < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        if size == 0 {
+            Ok(ListxattrReply::Count(res as u32))
+        } else {
+            buf.resize(res as usize, 0);
+            Ok(ListxattrReply::Names(buf))
+        }
+    }
+
+    fn removexattr(&self, _ctx: Context, inode: Inode, name: &CStr) -> io::Result<()> {
+        // The f{set,get,remove,list}xattr functions don't work on an fd opened with `O_PATH` so we
+        // need to get a new fd.
+        let file = self.open_inode(inode, libc::O_RDONLY | libc::O_NONBLOCK)?;
+
+        // Safe because this doesn't modify any memory and we check the return value.
+        let res = unsafe { libc::fremovexattr(file.as_raw_fd(), name.as_ptr()) };
+
+        if res == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn fallocate(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        handle: Handle,
+        mode: u32,
+        offset: u64,
+        length: u64,
+    ) -> io::Result<()> {
+        let data = self
+            .handles
+            .read()
+            .unwrap()
+            .get(&handle)
+            .filter(|hd| hd.inode == inode)
+            .map(Arc::clone)
+            .ok_or_else(ebadf)?;
+
+        let fd = data.file.lock().unwrap().as_raw_fd();
+        // Safe because this doesn't modify any memory and we check the return value.
+        let res = unsafe {
+            libc::fallocate64(
+                fd,
+                mode as libc::c_int,
+                offset as libc::off64_t,
+                length as libc::off64_t,
+            )
+        };
+        if res == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+}

--- a/vhost_user_fs/src/server.rs
+++ b/vhost_user_fs/src/server.rs
@@ -1,0 +1,1269 @@
+// Copyright 2019 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+use std::ffi::CStr;
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::mem::size_of;
+
+use libc;
+use vm_memory::ByteValued;
+
+use crate::descriptor_utils::{Reader, Writer};
+use crate::filesystem::{
+    Context, DirEntry, Entry, FileSystem, GetxattrReply, ListxattrReply, ZeroCopyReader,
+    ZeroCopyWriter,
+};
+use crate::fuse::*;
+use crate::{Error, Result};
+
+const MAX_BUFFER_SIZE: u32 = (1 << 20);
+const DIRENT_PADDING: [u8; 8] = [0; 8];
+
+struct ZCReader<'a>(Reader<'a>);
+
+impl<'a> ZeroCopyReader for ZCReader<'a> {
+    fn read_to(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<usize> {
+        self.0.read_to_at(f, count, off)
+    }
+}
+
+impl<'a> io::Read for ZCReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+struct ZCWriter<'a>(Writer<'a>);
+
+impl<'a> ZeroCopyWriter for ZCWriter<'a> {
+    fn write_from(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<usize> {
+        self.0.write_from_at(f, count, off)
+    }
+}
+
+impl<'a> io::Write for ZCWriter<'a> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+pub struct Server<F: FileSystem + Sync> {
+    fs: F,
+}
+
+impl<F: FileSystem + Sync> Server<F> {
+    pub fn new(fs: F) -> Server<F> {
+        Server { fs }
+    }
+
+    #[allow(clippy::cognitive_complexity)]
+    pub fn handle_message(&self, mut r: Reader, w: Writer) -> Result<usize> {
+        let in_header: InHeader = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        if in_header.len > MAX_BUFFER_SIZE {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::ENOMEM),
+                in_header.unique,
+                w,
+            );
+        }
+        match in_header.opcode {
+            x if x == Opcode::Lookup as u32 => self.lookup(in_header, r, w),
+            x if x == Opcode::Forget as u32 => self.forget(in_header, r), // No reply.
+            x if x == Opcode::Getattr as u32 => self.getattr(in_header, r, w),
+            x if x == Opcode::Setattr as u32 => self.setattr(in_header, r, w),
+            x if x == Opcode::Readlink as u32 => self.readlink(in_header, w),
+            x if x == Opcode::Symlink as u32 => self.symlink(in_header, r, w),
+            x if x == Opcode::Mknod as u32 => self.mknod(in_header, r, w),
+            x if x == Opcode::Mkdir as u32 => self.mkdir(in_header, r, w),
+            x if x == Opcode::Unlink as u32 => self.unlink(in_header, r, w),
+            x if x == Opcode::Rmdir as u32 => self.rmdir(in_header, r, w),
+            x if x == Opcode::Rename as u32 => self.rename(in_header, r, w),
+            x if x == Opcode::Link as u32 => self.link(in_header, r, w),
+            x if x == Opcode::Open as u32 => self.open(in_header, r, w),
+            x if x == Opcode::Read as u32 => self.read(in_header, r, w),
+            x if x == Opcode::Write as u32 => self.write(in_header, r, w),
+            x if x == Opcode::Statfs as u32 => self.statfs(in_header, w),
+            x if x == Opcode::Release as u32 => self.release(in_header, r, w),
+            x if x == Opcode::Fsync as u32 => self.fsync(in_header, r, w),
+            x if x == Opcode::Setxattr as u32 => self.setxattr(in_header, r, w),
+            x if x == Opcode::Getxattr as u32 => self.getxattr(in_header, r, w),
+            x if x == Opcode::Listxattr as u32 => self.listxattr(in_header, r, w),
+            x if x == Opcode::Removexattr as u32 => self.removexattr(in_header, r, w),
+            x if x == Opcode::Flush as u32 => self.flush(in_header, r, w),
+            x if x == Opcode::Init as u32 => self.init(in_header, r, w),
+            x if x == Opcode::Opendir as u32 => self.opendir(in_header, r, w),
+            x if x == Opcode::Readdir as u32 => self.readdir(in_header, r, w),
+            x if x == Opcode::Releasedir as u32 => self.releasedir(in_header, r, w),
+            x if x == Opcode::Fsyncdir as u32 => self.fsyncdir(in_header, r, w),
+            x if x == Opcode::Getlk as u32 => self.getlk(in_header, r, w),
+            x if x == Opcode::Setlk as u32 => self.setlk(in_header, r, w),
+            x if x == Opcode::Setlkw as u32 => self.setlkw(in_header, r, w),
+            x if x == Opcode::Access as u32 => self.access(in_header, r, w),
+            x if x == Opcode::Create as u32 => self.create(in_header, r, w),
+            x if x == Opcode::Interrupt as u32 => self.interrupt(in_header),
+            x if x == Opcode::Bmap as u32 => self.bmap(in_header, r, w),
+            x if x == Opcode::Destroy as u32 => self.destroy(),
+            x if x == Opcode::Ioctl as u32 => self.ioctl(in_header, r, w),
+            x if x == Opcode::Poll as u32 => self.poll(in_header, r, w),
+            x if x == Opcode::NotifyReply as u32 => self.notify_reply(in_header, r, w),
+            x if x == Opcode::BatchForget as u32 => self.batch_forget(in_header, r, w),
+            x if x == Opcode::Fallocate as u32 => self.fallocate(in_header, r, w),
+            x if x == Opcode::Readdirplus as u32 => self.readdirplus(in_header, r, w),
+            x if x == Opcode::Rename2 as u32 => self.rename2(in_header, r, w),
+            x if x == Opcode::Lseek as u32 => self.lseek(in_header, r, w),
+            _ => reply_error(
+                io::Error::from_raw_os_error(libc::ENOSYS),
+                in_header.unique,
+                w,
+            ),
+        }
+    }
+
+    fn lookup(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let namelen = (in_header.len as usize)
+            .checked_sub(size_of::<InHeader>())
+            .ok_or(Error::InvalidHeaderLength)?;
+
+        let mut buf = vec![0u8; namelen];
+
+        r.read_exact(&mut buf).map_err(Error::DecodeMessage)?;
+
+        let name = bytes_to_cstr(buf.as_ref())?;
+
+        match self
+            .fs
+            .lookup(Context::from(in_header), in_header.nodeid.into(), &name)
+        {
+            Ok(entry) => {
+                let out = EntryOut::from(entry);
+
+                reply_ok(Some(out), None, in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn forget(&self, in_header: InHeader, mut r: Reader) -> Result<usize> {
+        let ForgetIn { nlookup } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        self.fs
+            .forget(Context::from(in_header), in_header.nodeid.into(), nlookup);
+
+        // There is no reply for forget messages.
+        Ok(0)
+    }
+
+    fn getattr(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let GetattrIn { flags, fh, .. } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        let handle = if (flags & GETATTR_FH) != 0 {
+            Some(fh.into())
+        } else {
+            None
+        };
+
+        match self
+            .fs
+            .getattr(Context::from(in_header), in_header.nodeid.into(), handle)
+        {
+            Ok((st, timeout)) => {
+                let out = AttrOut {
+                    attr_valid: timeout.as_secs(),
+                    attr_valid_nsec: timeout.subsec_nanos(),
+                    dummy: 0,
+                    attr: st.into(),
+                };
+                reply_ok(Some(out), None, in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn setattr(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let setattr_in: SetattrIn = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        let handle = if setattr_in.valid & FATTR_FH != 0 {
+            Some(setattr_in.fh.into())
+        } else {
+            None
+        };
+
+        let valid = SetattrValid::from_bits_truncate(setattr_in.valid);
+
+        let st: libc::stat64 = setattr_in.into();
+
+        match self.fs.setattr(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            st,
+            handle,
+            valid,
+        ) {
+            Ok((st, timeout)) => {
+                let out = AttrOut {
+                    attr_valid: timeout.as_secs(),
+                    attr_valid_nsec: timeout.subsec_nanos(),
+                    dummy: 0,
+                    attr: st.into(),
+                };
+                reply_ok(Some(out), None, in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn readlink(&self, in_header: InHeader, w: Writer) -> Result<usize> {
+        match self
+            .fs
+            .readlink(Context::from(in_header), in_header.nodeid.into())
+        {
+            Ok(linkname) => {
+                // We need to disambiguate the option type here even though it is `None`.
+                reply_ok(None::<u8>, Some(&linkname), in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn symlink(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        // Unfortunately the name and linkname are encoded one after another and
+        // separated by a nul character.
+        let len = (in_header.len as usize)
+            .checked_sub(size_of::<InHeader>())
+            .ok_or(Error::InvalidHeaderLength)?;
+        let mut buf = vec![0; len];
+
+        r.read_exact(&mut buf).map_err(Error::DecodeMessage)?;
+
+        // We want to include the '\0' byte in the first slice.
+        let split_pos = buf
+            .iter()
+            .position(|c| *c == b'\0')
+            .map(|p| p + 1)
+            .ok_or(Error::MissingParameter)?;
+
+        let (name, linkname) = buf.split_at(split_pos);
+
+        match self.fs.symlink(
+            Context::from(in_header),
+            bytes_to_cstr(linkname)?,
+            in_header.nodeid.into(),
+            bytes_to_cstr(name)?,
+        ) {
+            Ok(entry) => {
+                let out = EntryOut::from(entry);
+
+                reply_ok(Some(out), None, in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn mknod(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let MknodIn {
+            mode, rdev, umask, ..
+        } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        let namelen = (in_header.len as usize)
+            .checked_sub(size_of::<InHeader>())
+            .and_then(|l| l.checked_sub(size_of::<MknodIn>()))
+            .ok_or(Error::InvalidHeaderLength)?;
+        let mut name = vec![0; namelen];
+
+        r.read_exact(&mut name).map_err(Error::DecodeMessage)?;
+
+        match self.fs.mknod(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            bytes_to_cstr(&name)?,
+            mode,
+            rdev,
+            umask,
+        ) {
+            Ok(entry) => {
+                let out = EntryOut::from(entry);
+
+                reply_ok(Some(out), None, in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn mkdir(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let MkdirIn { mode, umask } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        let namelen = (in_header.len as usize)
+            .checked_sub(size_of::<InHeader>())
+            .and_then(|l| l.checked_sub(size_of::<MkdirIn>()))
+            .ok_or(Error::InvalidHeaderLength)?;
+        let mut name = vec![0; namelen];
+
+        r.read_exact(&mut name).map_err(Error::DecodeMessage)?;
+
+        match self.fs.mkdir(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            bytes_to_cstr(&name)?,
+            mode,
+            umask,
+        ) {
+            Ok(entry) => {
+                let out = EntryOut::from(entry);
+
+                reply_ok(Some(out), None, in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn unlink(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let namelen = (in_header.len as usize)
+            .checked_sub(size_of::<InHeader>())
+            .ok_or(Error::InvalidHeaderLength)?;
+        let mut name = vec![0; namelen];
+
+        r.read_exact(&mut name).map_err(Error::DecodeMessage)?;
+
+        match self.fs.unlink(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            bytes_to_cstr(&name)?,
+        ) {
+            Ok(()) => reply_ok(None::<u8>, None, in_header.unique, w),
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn rmdir(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let namelen = (in_header.len as usize)
+            .checked_sub(size_of::<InHeader>())
+            .ok_or(Error::InvalidHeaderLength)?;
+        let mut name = vec![0; namelen];
+
+        r.read_exact(&mut name).map_err(Error::DecodeMessage)?;
+
+        match self.fs.rmdir(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            bytes_to_cstr(&name)?,
+        ) {
+            Ok(()) => reply_ok(None::<u8>, None, in_header.unique, w),
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn do_rename(
+        &self,
+        in_header: InHeader,
+        msg_size: usize,
+        newdir: u64,
+        flags: u32,
+        mut r: Reader,
+        w: Writer,
+    ) -> Result<usize> {
+        let buflen = (in_header.len as usize)
+            .checked_sub(size_of::<InHeader>())
+            .and_then(|l| l.checked_sub(msg_size))
+            .ok_or(Error::InvalidHeaderLength)?;
+        let mut buf = vec![0; buflen];
+
+        r.read_exact(&mut buf).map_err(Error::DecodeMessage)?;
+
+        // We want to include the '\0' byte in the first slice.
+        let split_pos = buf
+            .iter()
+            .position(|c| *c == b'\0')
+            .map(|p| p + 1)
+            .ok_or(Error::MissingParameter)?;
+
+        let (oldname, newname) = buf.split_at(split_pos);
+
+        match self.fs.rename(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            bytes_to_cstr(oldname)?,
+            newdir.into(),
+            bytes_to_cstr(newname)?,
+            flags,
+        ) {
+            Ok(()) => reply_ok(None::<u8>, None, in_header.unique, w),
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn rename(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let RenameIn { newdir } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        self.do_rename(in_header, size_of::<RenameIn>(), newdir, 0, r, w)
+    }
+
+    fn rename2(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let Rename2In { newdir, flags, .. } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        let flags = flags & (libc::RENAME_EXCHANGE | libc::RENAME_NOREPLACE) as u32;
+
+        self.do_rename(in_header, size_of::<Rename2In>(), newdir, flags, r, w)
+    }
+
+    fn link(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let LinkIn { oldnodeid } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        let namelen = (in_header.len as usize)
+            .checked_sub(size_of::<InHeader>())
+            .and_then(|l| l.checked_sub(size_of::<LinkIn>()))
+            .ok_or(Error::InvalidHeaderLength)?;
+        let mut name = vec![0; namelen];
+
+        r.read_exact(&mut name).map_err(Error::DecodeMessage)?;
+
+        match self.fs.link(
+            Context::from(in_header),
+            oldnodeid.into(),
+            in_header.nodeid.into(),
+            bytes_to_cstr(&name)?,
+        ) {
+            Ok(entry) => {
+                let out = EntryOut::from(entry);
+
+                reply_ok(Some(out), None, in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn open(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let OpenIn { flags, .. } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        match self
+            .fs
+            .open(Context::from(in_header), in_header.nodeid.into(), flags)
+        {
+            Ok((handle, opts)) => {
+                let out = OpenOut {
+                    fh: handle.map(Into::into).unwrap_or(0),
+                    open_flags: opts.bits(),
+                    ..Default::default()
+                };
+
+                reply_ok(Some(out), None, in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn read(&self, in_header: InHeader, mut r: Reader, mut w: Writer) -> Result<usize> {
+        let ReadIn {
+            fh,
+            offset,
+            size,
+            read_flags,
+            lock_owner,
+            flags,
+            ..
+        } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        if size > MAX_BUFFER_SIZE {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::ENOMEM),
+                in_header.unique,
+                w,
+            );
+        }
+
+        let owner = if read_flags & READ_LOCKOWNER != 0 {
+            Some(lock_owner)
+        } else {
+            None
+        };
+
+        // Split the writer into 2 pieces: one for the `OutHeader` and the rest for the data.
+        let data_writer = ZCWriter(w.split_at(size_of::<OutHeader>()).unwrap());
+
+        match self.fs.read(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            fh.into(),
+            data_writer,
+            size,
+            offset,
+            owner,
+            flags,
+        ) {
+            Ok(count) => {
+                // Don't use `reply_ok` because we need to set a custom size length for the
+                // header.
+                let out = OutHeader {
+                    len: (size_of::<OutHeader>() + count) as u32,
+                    error: 0,
+                    unique: in_header.unique,
+                };
+
+                w.write_all(out.as_slice()).map_err(Error::EncodeMessage)?;
+                Ok(out.len as usize)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn write(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let WriteIn {
+            fh,
+            offset,
+            size,
+            write_flags,
+            lock_owner,
+            flags,
+            ..
+        } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        if size > MAX_BUFFER_SIZE {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::ENOMEM),
+                in_header.unique,
+                w,
+            );
+        }
+
+        let owner = if write_flags & WRITE_LOCKOWNER != 0 {
+            Some(lock_owner)
+        } else {
+            None
+        };
+
+        let delayed_write = write_flags & WRITE_CACHE != 0;
+
+        let data_reader = ZCReader(r);
+
+        match self.fs.write(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            fh.into(),
+            data_reader,
+            size,
+            offset,
+            owner,
+            delayed_write,
+            flags,
+        ) {
+            Ok(count) => {
+                let out = WriteOut {
+                    size: count as u32,
+                    ..Default::default()
+                };
+
+                reply_ok(Some(out), None, in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn statfs(&self, in_header: InHeader, w: Writer) -> Result<usize> {
+        match self
+            .fs
+            .statfs(Context::from(in_header), in_header.nodeid.into())
+        {
+            Ok(st) => reply_ok(Some(Kstatfs::from(st)), None, in_header.unique, w),
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn release(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let ReleaseIn {
+            fh,
+            flags,
+            release_flags,
+            lock_owner,
+        } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        let flush = release_flags & RELEASE_FLUSH != 0;
+        let flock_release = release_flags & RELEASE_FLOCK_UNLOCK != 0;
+        let lock_owner = if flush || flock_release {
+            Some(lock_owner)
+        } else {
+            None
+        };
+
+        match self.fs.release(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            flags,
+            fh.into(),
+            flush,
+            flock_release,
+            lock_owner,
+        ) {
+            Ok(()) => reply_ok(None::<u8>, None, in_header.unique, w),
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn fsync(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let FsyncIn {
+            fh, fsync_flags, ..
+        } = r.read_obj().map_err(Error::DecodeMessage)?;
+        let datasync = fsync_flags & 0x1 != 0;
+
+        match self.fs.fsync(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            datasync,
+            fh.into(),
+        ) {
+            Ok(()) => reply_ok(None::<u8>, None, in_header.unique, w),
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn setxattr(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let SetxattrIn { size, flags } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        // The name and value and encoded one after another and separated by a '\0' character.
+        let len = (in_header.len as usize)
+            .checked_sub(size_of::<InHeader>())
+            .and_then(|l| l.checked_sub(size_of::<SetxattrIn>()))
+            .ok_or(Error::InvalidHeaderLength)?;
+        let mut buf = vec![0; len];
+
+        r.read_exact(&mut buf).map_err(Error::DecodeMessage)?;
+
+        // We want to include the '\0' byte in the first slice.
+        let split_pos = buf
+            .iter()
+            .position(|c| *c == b'\0')
+            .map(|p| p + 1)
+            .ok_or(Error::MissingParameter)?;
+
+        let (name, value) = buf.split_at(split_pos);
+
+        if size != value.len() as u32 {
+            return Err(Error::InvalidXattrSize((size, value.len())));
+        }
+
+        match self.fs.setxattr(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            bytes_to_cstr(name)?,
+            value,
+            flags,
+        ) {
+            Ok(()) => reply_ok(None::<u8>, None, in_header.unique, w),
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn getxattr(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let GetxattrIn { size, .. } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        let namelen = (in_header.len as usize)
+            .checked_sub(size_of::<InHeader>())
+            .and_then(|l| l.checked_sub(size_of::<GetxattrIn>()))
+            .ok_or(Error::InvalidHeaderLength)?;
+        let mut name = vec![0; namelen];
+
+        r.read_exact(&mut name).map_err(Error::DecodeMessage)?;
+
+        if size > MAX_BUFFER_SIZE {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::ENOMEM),
+                in_header.unique,
+                w,
+            );
+        }
+
+        match self.fs.getxattr(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            bytes_to_cstr(&name)?,
+            size,
+        ) {
+            Ok(GetxattrReply::Value(val)) => reply_ok(None::<u8>, Some(&val), in_header.unique, w),
+            Ok(GetxattrReply::Count(count)) => {
+                let out = GetxattrOut {
+                    size: count,
+                    ..Default::default()
+                };
+
+                reply_ok(Some(out), None, in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn listxattr(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let GetxattrIn { size, .. } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        if size > MAX_BUFFER_SIZE {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::ENOMEM),
+                in_header.unique,
+                w,
+            );
+        }
+
+        match self
+            .fs
+            .listxattr(Context::from(in_header), in_header.nodeid.into(), size)
+        {
+            Ok(ListxattrReply::Names(val)) => reply_ok(None::<u8>, Some(&val), in_header.unique, w),
+            Ok(ListxattrReply::Count(count)) => {
+                let out = GetxattrOut {
+                    size: count,
+                    ..Default::default()
+                };
+
+                reply_ok(Some(out), None, in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn removexattr(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let namelen = (in_header.len as usize)
+            .checked_sub(size_of::<InHeader>())
+            .ok_or(Error::InvalidHeaderLength)?;
+
+        let mut buf = vec![0; namelen];
+
+        r.read_exact(&mut buf).map_err(Error::DecodeMessage)?;
+
+        let name = bytes_to_cstr(&buf)?;
+
+        match self
+            .fs
+            .removexattr(Context::from(in_header), in_header.nodeid.into(), name)
+        {
+            Ok(()) => reply_ok(None::<u8>, None, in_header.unique, w),
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn flush(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let FlushIn { fh, lock_owner, .. } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        match self.fs.flush(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            fh.into(),
+            lock_owner,
+        ) {
+            Ok(()) => reply_ok(None::<u8>, None, in_header.unique, w),
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn init(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let InitIn {
+            major,
+            minor,
+            max_readahead,
+            flags,
+        } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        if major < KERNEL_VERSION {
+            error!("Unsupported fuse protocol version: {}.{}", major, minor);
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EPROTO),
+                in_header.unique,
+                w,
+            );
+        }
+
+        if major > KERNEL_VERSION {
+            // Wait for the kernel to reply back with a 7.X version.
+            let out = InitOut {
+                major: KERNEL_VERSION,
+                minor: KERNEL_MINOR_VERSION,
+                ..Default::default()
+            };
+
+            return reply_ok(Some(out), None, in_header.unique, w);
+        }
+
+        if minor < KERNEL_MINOR_VERSION {
+            error!(
+                "Unsupported fuse protocol minor version: {}.{}",
+                major, minor
+            );
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EPROTO),
+                in_header.unique,
+                w,
+            );
+        }
+
+        // These fuse features are supported by this server by default.
+        let supported = FsOptions::ASYNC_READ
+            | FsOptions::PARALLEL_DIROPS
+            | FsOptions::BIG_WRITES
+            | FsOptions::AUTO_INVAL_DATA
+            | FsOptions::HANDLE_KILLPRIV
+            | FsOptions::ASYNC_DIO
+            | FsOptions::HAS_IOCTL_DIR
+            | FsOptions::ATOMIC_O_TRUNC;
+
+        let capable = FsOptions::from_bits_truncate(flags);
+
+        match self.fs.init(capable) {
+            Ok(want) => {
+                let enabled = capable & (want | supported);
+
+                let out = InitOut {
+                    major: KERNEL_VERSION,
+                    minor: KERNEL_MINOR_VERSION,
+                    max_readahead,
+                    flags: enabled.bits(),
+                    max_background: ::std::u16::MAX,
+                    congestion_threshold: (::std::u16::MAX / 4) * 3,
+                    max_write: MAX_BUFFER_SIZE,
+                    time_gran: 1, // nanoseconds
+                    ..Default::default()
+                };
+
+                reply_ok(Some(out), None, in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn opendir(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let OpenIn { flags, .. } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        match self
+            .fs
+            .opendir(Context::from(in_header), in_header.nodeid.into(), flags)
+        {
+            Ok((handle, opts)) => {
+                let out = OpenOut {
+                    fh: handle.map(Into::into).unwrap_or(0),
+                    open_flags: opts.bits(),
+                    ..Default::default()
+                };
+
+                reply_ok(Some(out), None, in_header.unique, w)
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn do_readdir(
+        &self,
+        in_header: InHeader,
+        mut r: Reader,
+        mut w: Writer,
+        plus: bool,
+    ) -> Result<usize> {
+        let ReadIn {
+            fh, offset, size, ..
+        } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        if size > MAX_BUFFER_SIZE {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::ENOMEM),
+                in_header.unique,
+                w,
+            );
+        }
+
+        let available_bytes = w.available_bytes();
+        if available_bytes < size as usize {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::ENOMEM),
+                in_header.unique,
+                w,
+            );
+        }
+
+        // Skip over enough bytes for the header.
+        let mut cursor = w.split_at(size_of::<OutHeader>()).unwrap();
+
+        let res = if plus {
+            self.fs.readdirplus(
+                Context::from(in_header),
+                in_header.nodeid.into(),
+                fh.into(),
+                size,
+                offset,
+                |d, e| add_dirent(&mut cursor, size, d, Some(e)),
+            )
+        } else {
+            self.fs.readdir(
+                Context::from(in_header),
+                in_header.nodeid.into(),
+                fh.into(),
+                size,
+                offset,
+                |d| add_dirent(&mut cursor, size, d, None),
+            )
+        };
+
+        if let Err(e) = res {
+            reply_error(e, in_header.unique, w)
+        } else {
+            // Don't use `reply_ok` because we need to set a custom size length for the
+            // header.
+            let out = OutHeader {
+                len: (size_of::<OutHeader>() + cursor.bytes_written()) as u32,
+                error: 0,
+                unique: in_header.unique,
+            };
+
+            w.write_all(out.as_slice()).map_err(Error::EncodeMessage)?;
+            Ok(out.len as usize)
+        }
+    }
+
+    fn readdir(&self, in_header: InHeader, r: Reader, w: Writer) -> Result<usize> {
+        self.do_readdir(in_header, r, w, false)
+    }
+
+    fn readdirplus(&self, in_header: InHeader, r: Reader, w: Writer) -> Result<usize> {
+        self.do_readdir(in_header, r, w, true)
+    }
+
+    fn releasedir(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let ReleaseIn { fh, flags, .. } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        match self.fs.releasedir(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            flags,
+            fh.into(),
+        ) {
+            Ok(()) => reply_ok(None::<u8>, None, in_header.unique, w),
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn fsyncdir(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let FsyncIn {
+            fh, fsync_flags, ..
+        } = r.read_obj().map_err(Error::DecodeMessage)?;
+        let datasync = fsync_flags & 0x1 != 0;
+
+        match self.fs.fsyncdir(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            datasync,
+            fh.into(),
+        ) {
+            Ok(()) => reply_ok(None::<u8>, None, in_header.unique, w),
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn getlk(&self, in_header: InHeader, mut _r: Reader, w: Writer) -> Result<usize> {
+        if let Err(e) = self.fs.getlk() {
+            reply_error(e, in_header.unique, w)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn setlk(&self, in_header: InHeader, mut _r: Reader, w: Writer) -> Result<usize> {
+        if let Err(e) = self.fs.setlk() {
+            reply_error(e, in_header.unique, w)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn setlkw(&self, in_header: InHeader, mut _r: Reader, w: Writer) -> Result<usize> {
+        if let Err(e) = self.fs.setlkw() {
+            reply_error(e, in_header.unique, w)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn access(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let AccessIn { mask, .. } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        match self
+            .fs
+            .access(Context::from(in_header), in_header.nodeid.into(), mask)
+        {
+            Ok(()) => reply_ok(None::<u8>, None, in_header.unique, w),
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn create(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let CreateIn {
+            flags, mode, umask, ..
+        } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        let namelen = (in_header.len as usize)
+            .checked_sub(size_of::<InHeader>())
+            .and_then(|l| l.checked_sub(size_of::<CreateIn>()))
+            .ok_or(Error::InvalidHeaderLength)?;
+
+        let mut buf = vec![0; namelen];
+
+        r.read_exact(&mut buf).map_err(Error::DecodeMessage)?;
+
+        let name = bytes_to_cstr(&buf)?;
+
+        match self.fs.create(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            name,
+            mode,
+            flags,
+            umask,
+        ) {
+            Ok((entry, handle, opts)) => {
+                let entry_out = EntryOut {
+                    nodeid: entry.inode,
+                    generation: entry.generation,
+                    entry_valid: entry.entry_timeout.as_secs(),
+                    attr_valid: entry.attr_timeout.as_secs(),
+                    entry_valid_nsec: entry.entry_timeout.subsec_nanos(),
+                    attr_valid_nsec: entry.attr_timeout.subsec_nanos(),
+                    attr: entry.attr.into(),
+                };
+                let open_out = OpenOut {
+                    fh: handle.map(Into::into).unwrap_or(0),
+                    open_flags: opts.bits(),
+                    ..Default::default()
+                };
+
+                // Kind of a hack to write both structs.
+                reply_ok(
+                    Some(entry_out),
+                    Some(open_out.as_slice()),
+                    in_header.unique,
+                    w,
+                )
+            }
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn interrupt(&self, _in_header: InHeader) -> Result<usize> {
+        Ok(0)
+    }
+
+    fn bmap(&self, in_header: InHeader, mut _r: Reader, w: Writer) -> Result<usize> {
+        if let Err(e) = self.fs.bmap() {
+            reply_error(e, in_header.unique, w)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn destroy(&self) -> Result<usize> {
+        // No reply to this function.
+        self.fs.destroy();
+
+        Ok(0)
+    }
+
+    fn ioctl(&self, in_header: InHeader, _r: Reader, w: Writer) -> Result<usize> {
+        if let Err(e) = self.fs.ioctl() {
+            reply_error(e, in_header.unique, w)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn poll(&self, in_header: InHeader, mut _r: Reader, w: Writer) -> Result<usize> {
+        if let Err(e) = self.fs.poll() {
+            reply_error(e, in_header.unique, w)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn notify_reply(&self, in_header: InHeader, mut _r: Reader, w: Writer) -> Result<usize> {
+        if let Err(e) = self.fs.notify_reply() {
+            reply_error(e, in_header.unique, w)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn batch_forget(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let BatchForgetIn { count, .. } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        if let Some(size) = (count as usize).checked_mul(size_of::<ForgetOne>()) {
+            if size > MAX_BUFFER_SIZE as usize {
+                return reply_error(
+                    io::Error::from_raw_os_error(libc::ENOMEM),
+                    in_header.unique,
+                    w,
+                );
+            }
+        } else {
+            return reply_error(
+                io::Error::from_raw_os_error(libc::EOVERFLOW),
+                in_header.unique,
+                w,
+            );
+        }
+
+        let mut requests = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            requests.push(
+                r.read_obj::<ForgetOne>()
+                    .map(|f| (f.nodeid.into(), f.nlookup))
+                    .map_err(Error::DecodeMessage)?,
+            );
+        }
+
+        self.fs.batch_forget(Context::from(in_header), requests);
+
+        // No reply for forget messages.
+        Ok(0)
+    }
+
+    fn fallocate(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+        let FallocateIn {
+            fh,
+            offset,
+            length,
+            mode,
+            ..
+        } = r.read_obj().map_err(Error::DecodeMessage)?;
+
+        match self.fs.fallocate(
+            Context::from(in_header),
+            in_header.nodeid.into(),
+            fh.into(),
+            mode,
+            offset,
+            length,
+        ) {
+            Ok(()) => reply_ok(None::<u8>, None, in_header.unique, w),
+            Err(e) => reply_error(e, in_header.unique, w),
+        }
+    }
+
+    fn lseek(&self, in_header: InHeader, mut _r: Reader, w: Writer) -> Result<usize> {
+        if let Err(e) = self.fs.lseek() {
+            reply_error(e, in_header.unique, w)
+        } else {
+            Ok(0)
+        }
+    }
+}
+
+fn reply_ok<T: ByteValued>(
+    out: Option<T>,
+    data: Option<&[u8]>,
+    unique: u64,
+    mut w: Writer,
+) -> Result<usize> {
+    let mut len = size_of::<OutHeader>();
+
+    if out.is_some() {
+        len += size_of::<T>();
+    }
+
+    if let Some(ref data) = data {
+        len += data.len();
+    }
+
+    let header = OutHeader {
+        len: len as u32,
+        error: 0,
+        unique,
+    };
+
+    w.write_all(header.as_slice())
+        .map_err(Error::EncodeMessage)?;
+
+    if let Some(out) = out {
+        w.write_all(out.as_slice()).map_err(Error::EncodeMessage)?;
+    }
+
+    if let Some(data) = data {
+        w.write_all(data).map_err(Error::EncodeMessage)?;
+    }
+
+    debug_assert_eq!(len, w.bytes_written());
+    Ok(w.bytes_written())
+}
+
+fn reply_error(e: io::Error, unique: u64, mut w: Writer) -> Result<usize> {
+    let header = OutHeader {
+        len: size_of::<OutHeader>() as u32,
+        error: -e.raw_os_error().unwrap_or(libc::EIO),
+        unique,
+    };
+
+    w.write_all(header.as_slice())
+        .map_err(Error::EncodeMessage)?;
+
+    debug_assert_eq!(header.len as usize, w.bytes_written());
+    Ok(w.bytes_written())
+}
+
+fn bytes_to_cstr(buf: &[u8]) -> Result<&CStr> {
+    // Convert to a `CStr` first so that we can drop the '\0' byte at the end
+    // and make sure there are no interior '\0' bytes.
+    CStr::from_bytes_with_nul(buf).map_err(Error::InvalidCString)
+}
+
+fn add_dirent(
+    cursor: &mut Writer,
+    max: u32,
+    d: DirEntry,
+    entry: Option<Entry>,
+) -> io::Result<usize> {
+    if d.name.len() > ::std::u32::MAX as usize {
+        return Err(io::Error::from_raw_os_error(libc::EOVERFLOW));
+    }
+
+    let dirent_len = size_of::<Dirent>()
+        .checked_add(d.name.len())
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::EOVERFLOW))?;
+
+    // Directory entries must be padded to 8-byte alignment.  If adding 7 causes
+    // an overflow then this dirent cannot be properly padded.
+    let padded_dirent_len = dirent_len
+        .checked_add(7)
+        .map(|l| l & !7)
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::EOVERFLOW))?;
+
+    let total_len = if entry.is_some() {
+        padded_dirent_len
+            .checked_add(size_of::<EntryOut>())
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::EOVERFLOW))?
+    } else {
+        padded_dirent_len
+    };
+
+    if (max as usize).saturating_sub(cursor.bytes_written()) < total_len {
+        Ok(0)
+    } else {
+        if let Some(entry) = entry {
+            cursor.write_all(EntryOut::from(entry).as_slice())?;
+        }
+
+        let dirent = Dirent {
+            ino: d.ino,
+            off: d.offset,
+            namelen: d.name.len() as u32,
+            type_: d.type_,
+        };
+
+        cursor.write_all(dirent.as_slice())?;
+        cursor.write_all(d.name)?;
+
+        // We know that `dirent_len` <= `padded_dirent_len` due to the check above
+        // so there's no need for checked arithmetic.
+        let padding = padded_dirent_len - dirent_len;
+        if padding > 0 {
+            cursor.write_all(&DIRENT_PADDING[..padding])?;
+        }
+
+        Ok(total_len)
+    }
+}


### PR DESCRIPTION
The purpose of this pull request is to introduce the first vhost-user-fs daemon (also known as `virtiofsd`) in Rust, relying on the crates such as `vm-virtio` and `vhost_user_backend` meant to live under the `rust-vmm` organization at some point.

One important thing to notice is that most of this code has been ported from the original implementation that can be found in Crosvm, or from pieces that are still pending.

So far, the current pull request ported the existing code from Crosvm into a dedicated crate `vhost_user_fs` to act as a specific library. This library is being used from the newly introduced binary `vhost-user-fs` which is generated from `/src/bin/vhost_user_fs.rs`.

Important to note that most of the code ported from Crosvm has been added to the `vhost_user_fs` crate in order to prevent from growing `vm-virtio` or `vmm-sys-util` crates for instance. But obviously this needs to be discussed as we might want to push some of this utility code into those crates.

Here is a list of missing things:
- [x] Debug current code to make it work with DAX disabled
- [x] Fix all unit tests for `vhost_user_fs` crate because porting the code broke them.
- [x] Update integration tests to try out this new `virtiofsd` (we cannot switch from the C version to this version directly as there are still some missing features like DAX support for instance)

The rest will be taken care of through follow up PRs:
- Add support for a specific shared directory instead of assuming `/` is being shared. This one needs to be discussed as we could either use a mount namespace or modify the `PassthroughFs` implementation from `passthrough.rs`.
- Implement missing DAX support. This means we need to add support for `VHOST_USER_PROTOCOL_F_SLAVE_REQ` to the `vhost_user_backend` crate, as we need to support some slave driven events.