### PR TITLE
http: api: implement vmm.ping

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2722,6 +2722,9 @@ mod tests {
 
             thread::sleep(std::time::Duration::new(1, 0));
 
+            // Verify API server is running
+            curl_command(&api_socket, "GET", "http://localhost/api/v1/vmm.ping", None);
+
             // Create the VM first
             let cpu_count: u8 = 4;
             let http_body = guest.api_create_body(cpu_count);
@@ -2777,6 +2780,9 @@ mod tests {
                 .unwrap();
 
             thread::sleep(std::time::Duration::new(1, 0));
+
+            // Verify API server is running
+            curl_command(&api_socket, "GET", "http://localhost/api/v1/vmm.ping", None);
 
             // Create the VM first
             let cpu_count: u8 = 4;

--- a/src/main.rs
+++ b/src/main.rs
@@ -358,6 +358,7 @@ fn main() {
 
     let http_sender = api_request_sender.clone();
     let vmm_thread = match vmm::start_vmm_thread(
+        env!("CARGO_PKG_VERSION").to_string(),
         api_socket_path,
         api_evt.try_clone().unwrap(),
         http_sender,

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::api::http_endpoint::{VmActionHandler, VmCreate, VmInfo, VmmShutdown};
+use crate::api::http_endpoint::{VmActionHandler, VmCreate, VmInfo, VmmPing, VmmShutdown};
 use crate::api::{ApiRequest, VmAction};
 use crate::{Error, Result};
 use micro_http::{HttpServer, MediaType, Request, Response, StatusCode, Version};
@@ -58,6 +58,7 @@ lazy_static! {
         r.routes.insert(endpoint!("/vm.shutdown"), Box::new(VmActionHandler::new(VmAction::Shutdown)));
         r.routes.insert(endpoint!("/vm.reboot"), Box::new(VmActionHandler::new(VmAction::Reboot)));
         r.routes.insert(endpoint!("/vmm.shutdown"), Box::new(VmmShutdown {}));
+        r.routes.insert(endpoint!("/vmm.ping"), Box::new(VmmPing {}));
 
         r
     };

--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -5,7 +5,7 @@
 
 use crate::api::http::EndpointHandler;
 use crate::api::{
-    vm_boot, vm_create, vm_delete, vm_info, vm_pause, vm_reboot, vm_resume, vm_shutdown,
+    vm_boot, vm_create, vm_delete, vm_info, vm_pause, vm_reboot, vm_resume, vm_shutdown, vmm_ping,
     vmm_shutdown, ApiError, ApiRequest, ApiResult, VmAction, VmConfig,
 };
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
@@ -46,6 +46,9 @@ pub enum HttpError {
 
     /// Could not shut the VMM down
     VmmShutdown(ApiError),
+
+    /// Could not handle VMM ping
+    VmmPing(ApiError),
 }
 
 fn error_response(error: HttpError, status: StatusCode) -> Response {
@@ -158,6 +161,32 @@ impl EndpointHandler for VmInfo {
                 Ok(info) => {
                     let mut response = Response::new(Version::Http11, StatusCode::OK);
                     let info_serialized = serde_json::to_string(&info).unwrap();
+
+                    response.set_body(Body::new(info_serialized));
+                    response
+                }
+                Err(e) => error_response(e, StatusCode::InternalServerError),
+            },
+            _ => Response::new(Version::Http11, StatusCode::BadRequest),
+        }
+    }
+}
+
+// /api/v1/vmm.info handler
+pub struct VmmPing {}
+
+impl EndpointHandler for VmmPing {
+    fn handle_request(
+        &self,
+        req: &Request,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+    ) -> Response {
+        match req.method() {
+            Method::Get => match vmm_ping(api_notifier, api_sender).map_err(HttpError::VmmPing) {
+                Ok(pong) => {
+                    let mut response = Response::new(Version::Http11, StatusCode::OK);
+                    let info_serialized = serde_json::to_string(&pong).unwrap();
 
                     response.set_body(Body::new(info_serialized));
                     response

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -105,12 +105,20 @@ pub struct VmInfo {
     pub state: VmState,
 }
 
+#[derive(Clone, Deserialize, Serialize)]
+pub struct VmmPingResponse {
+    pub version: String,
+}
+
 pub enum ApiResponsePayload {
     /// No data is sent on the channel.
     Empty,
 
     /// Virtual machine information
     VmInfo(VmInfo),
+
+    /// Vmm ping response
+    VmmPing(VmmPingResponse),
 }
 
 /// This is the response sent by the VMM API server through the mpsc channel.
@@ -137,6 +145,9 @@ pub enum ApiRequest {
 
     /// Request the VM information.
     VmInfo(Sender<ApiResponse>),
+
+    /// Request the VMM API server status
+    VmmPing(Sender<ApiResponse>),
 
     /// Pause a VM.
     VmPause(Sender<ApiResponse>),
@@ -259,6 +270,22 @@ pub fn vm_info(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> ApiResult<Vm
 
     match vm_info {
         ApiResponsePayload::VmInfo(info) => Ok(info),
+        _ => Err(ApiError::ResponsePayloadType),
+    }
+}
+
+pub fn vmm_ping(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> ApiResult<VmmPingResponse> {
+    let (response_sender, response_receiver) = channel();
+
+    api_sender
+        .send(ApiRequest::VmmPing(response_sender))
+        .map_err(ApiError::RequestSend)?;
+    api_evt.write(1).map_err(ApiError::EventFdWrite)?;
+
+    let vmm_pong = response_receiver.recv().map_err(ApiError::ResponseRecv)??;
+
+    match vmm_pong {
+        ApiResponsePayload::VmmPing(pong) => Ok(pong),
         _ => Err(ApiError::ResponsePayloadType),
     }
 }

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -12,16 +12,16 @@ servers:
 
 paths:
 
-  /vmm.info:
+  /vmm.ping:
     get:
-      summary: Returns general information about the cloud-hypervisor Virtual Machine Monitor (VMM).
+      summary: Ping the VMM to check for API server availability
       responses:
         200:
           description: The VMM information
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VmmInfo'
+                $ref: '#/components/schemas/VmmPingResponse'
 
   /vmm.shutdown:
     put:
@@ -126,7 +126,7 @@ paths:
 components:
   schemas:
 
-    VmmInfo:
+    VmmPingResponse:
       required:
       - version
       type: object


### PR DESCRIPTION

vmm.ping will help to check if http API server is up and
running.


Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>