### PR TITLE
[RFC v2] migration: state migration infrastructure based on Api

### DIFF
--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -38,6 +38,7 @@ pub mod http_endpoint;
 
 use crate::config::VmConfig;
 use crate::vm::{Error as VmError, VmState};
+use crate::migration::state::{MigrationStateData, MigrationStateResponse};
 use std::io;
 use std::sync::mpsc::{channel, RecvError, SendError, Sender};
 use std::sync::Arc;
@@ -111,6 +112,12 @@ pub enum ApiResponsePayload {
 
     /// Virtual machine information
     VmInfo(VmInfo),
+
+    ///Used on source VM to request to get migration states
+    MigrationStateGet(Sender<MigrationStateResponse>),
+
+    /// Used on target VM to returen migration states as response
+    MigrationState(MigrationStateData),
 }
 
 /// This is the response sent by the VMM API server through the mpsc channel.
@@ -158,6 +165,11 @@ pub enum ApiRequest {
     /// This will shutdown and delete the current VM, if any, and then exit the
     /// VMM process.
     VmmShutdown(Sender<ApiResponse>),
+
+    /// Register migration component.
+    /// This will register migration component sender to migrate state array,
+    /// then migration thread can send request to component to get/load states.
+    MigrationRegister(String, Sender<ApiResponse>),
 }
 
 pub fn vm_create(

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -301,7 +301,16 @@ impl Vmm {
         // Now we can boot the VM.
         if let Some(ref mut vm) = self.vm {
             let mut vm = vm.lock().unwrap();
-            vm.boot()
+            vm.boot()?;
+
+            let migration = self.migration.clone();
+            thread::Builder::new()
+                .name(format!("migration_state_get"))
+                .spawn(move || {
+                    migration.take_snapshot();
+                });
+
+            Ok(())
         } else {
             Err(VmError::VmNotCreated)
         }

--- a/vmm/src/migration/mod.rs
+++ b/vmm/src/migration/mod.rs
@@ -1,0 +1,88 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::{io, result, thread};
+use std::sync::mpsc::{channel, Sender, SendError, RecvError};
+use crate::api::ApiResponse;
+use crate::migration::state::MigrationState;
+
+pub mod state;
+
+/// Errors associated with VM management
+#[derive(Debug)]
+pub enum Error {
+    /// Cannot spawn a new migration thread.
+    MigrationSpawn(io::Error),
+
+    /// Request send error
+    RequestSend(SendError<MigrationRequest>),
+
+    /// Request receive error
+    RequestRecv(RecvError),
+}
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum MigrationRequest {
+    /// Start to take snapshot, i.e. save Vm states
+    TakeSnapshot,
+
+    /// Start to restore snapshot, i.e. restore Vm states
+    RestoreSnapshot,
+}
+
+#[derive(Clone)]
+pub struct Migration {
+    state: MigrationState,
+    sender: Sender<MigrationRequest>,
+}
+
+impl Migration {
+    pub fn new() -> Result<Self> {
+        let (sender, receiver) = channel();
+        let state = MigrationState::new();
+        let state1 = state.clone();
+
+        thread::Builder::new()
+            .name(format!("migration"))
+            .spawn(move || {
+                let request = receiver.recv().map_err(Error::RequestRecv);
+
+                match request {
+                    Ok(req) => {
+                        match req {
+                            MigrationRequest::TakeSnapshot => {
+                                state1.get_iter().expect("Fail to get migration states");
+                            }
+                            MigrationRequest::RestoreSnapshot => {
+                                /* TODO: call state's restore interface */
+                            }
+                        }
+                    },
+                    Err(e) => println!("Receive bad MigrationRequest {:?}", e),
+                }
+            })
+            .map_err(Error::MigrationSpawn)?;
+
+        Ok(Migration {
+            state,
+            sender,
+        })
+    }
+
+    pub fn insert(&self, idstr: String, sender: Sender<ApiResponse>) -> ApiResponse {
+        self.state.insert(idstr, sender)
+    }
+
+    pub fn take_snapshot(&self) -> Result<()> {
+        self.sender.send(MigrationRequest::TakeSnapshot).map_err(Error::RequestSend)?;
+        Ok(())
+    }
+
+    pub fn restore_snapshot(&self) -> Result<()> {
+        self.sender.send(MigrationRequest::RestoreSnapshot).map_err(Error::RequestSend)?;
+        Ok(())
+    }
+}

--- a/vmm/src/migration/state.rs
+++ b/vmm/src/migration/state.rs
@@ -1,0 +1,108 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::result;
+use std::sync::{Arc, Mutex, RwLock};
+use std::collections::HashMap;
+use std::sync::mpsc::{channel, Sender, SendError, RecvError};
+use crate::api::{ApiResponsePayload, ApiResponse};
+
+/// MigrationState errors are sent back from the receiver through the ApiResponse.
+#[derive(Debug)]
+pub enum MigrationStateError {
+    /// API request receive error
+    ApiRequestRecv(RecvError),
+
+    /// API response send error
+    ApiResponseSend(SendError<ApiResponse>),
+
+    /// Cannot handle migration state load request.
+    MigrationStateLoad,
+}
+pub type MigrationStateResult<T> = result::Result<T, MigrationStateError>;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MigrationStateData {
+    pub state: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub enum MigrationResponsePayload {
+    /// No data is sent on the channel.
+    Empty,
+
+    /// Migration state content
+    MigrationState(MigrationStateData),
+}
+
+/// This is the response sent by the VMM API server through the mpsc channel.
+pub type MigrationStateResponse = std::result::Result<MigrationResponsePayload, MigrationStateError>;
+
+#[derive(Clone)]
+pub struct MigrationState {
+    state_owners: Arc<RwLock<HashMap<String, Mutex<Sender<ApiResponse>>>>>,
+}
+
+impl MigrationState {
+    pub fn new() -> Self {
+        MigrationState {
+            state_owners: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn insert(&self, idstr: String, sender: Sender<ApiResponse>) -> ApiResponse {
+        println!("Insert migration sender from {}", idstr);
+        let mut map = self.state_owners.write().unwrap();
+        map.insert(idstr, Mutex::new(sender));
+
+        /* TODO: check if there is available data in MigrationDataFile. If yes,
+         * it is target VM so return received states as ApiResponsePayload. If
+         * no, it is source VM so return None.
+         */
+        let response = Ok(ApiResponsePayload::Empty);
+
+        response
+    }
+
+    pub fn get_iter(&self) -> MigrationStateResult<()> {
+        let map = self.state_owners.read().expect("RwLock poisoned");
+        let (response_sender, response_receiver) = channel();
+
+        for (idstr, sender) in map.iter() {
+            println!("Get migration states from {}", idstr);
+            let sender = sender.lock().unwrap();
+            let response = Ok(ApiResponsePayload::MigrationStateGet(response_sender.clone()));
+
+            sender
+                .send(response)
+                .map_err(MigrationStateError::ApiResponseSend)?;
+        }
+
+        let mut iter = response_receiver.iter();
+        loop {
+            let response = match iter.next() {
+                None => {
+                    println!("No more response, break the loop.");
+                    break
+                },
+                Some(data) => data,
+            };
+
+            match response {
+                Ok(resp) => {
+                    match resp {
+                        MigrationResponsePayload::Empty => {},
+                        MigrationResponsePayload::MigrationState(data) => {
+                            /* TODO: Put received state into MigrateDataFile buffer */
+                        }
+                    }
+                },
+                Err(e) => println!("Receive bad migration response {:?}", e),
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/vmm/src/migration/state.rs
+++ b/vmm/src/migration/state.rs
@@ -96,6 +96,8 @@ impl MigrationState {
                         MigrationResponsePayload::Empty => {},
                         MigrationResponsePayload::MigrationState(data) => {
                             /* TODO: Put received state into MigrateDataFile buffer */
+                            let s = String::from_utf8(data.state).expect("Invalid utf8");
+                            println!("Received state is {}", s);
                         }
                     }
                 },

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -499,6 +499,8 @@ pub struct Vm {
     state: RwLock<VmState>,
 }
 
+unsafe impl Send for Vm {}
+
 fn get_host_cpu_phys_bits() -> u8 {
     use core::arch::x86_64;
     unsafe {
@@ -906,6 +908,14 @@ impl Vm {
                 console_input_clone.update_console_size(col, row);
             }
         }
+    }
+
+    pub fn get_states(&self) -> String {
+        /* TODO: use config as example first. Need handle
+         * devices/memory/vcpu/etc in the future
+         */
+        let config = serde_json::to_string_pretty(&self.config).unwrap();
+        config
     }
 
     pub fn boot(&mut self) -> Result<()> {


### PR DESCRIPTION
Per discussion on #386, refined state migration infrastructure which bases on "Cloud Hypervisor internal API".

The first patch creates "migration" module under "vmm" and implements part of the state migration infrastructure. The reason to create module but not the crate is that it depends on api module. In the future, we may move migration module out as a crate if api module is moved out as a crate.

The second patch implements "MigrationRequest" (ApiRequest) and "MigrationStateGet" and "MigrationState" (ApiResponsePayload) in Vmm and the codes to make Vmm be able to register its sender to handle state migration request. The reason to register Vmm but not Vm is below:
1. On source side, we need get Vm's states (e.g. VmConfig) when request comes. It is hard to do this in a child thread in Vm.
2. On target side, we receive the states first and use the states to create Vm instance. It is easy to do this in Vmm (Vm may need provide new interface to create itself according to input states).

The third patch is only for test to verify if getting states route is workable. By applying this patch, you can test the changes on cloud-hypervisor.

---
Changes since v1:
    - Create "migration" module under "vmm" but not a standalone crate.
    - Create "struct Migration" as the interface and start migration thread at very beginning.
    - Register Vmm but not Vm.
    - Send Empty response to MigrationRequest sender on source side.
    - Add "MigrationStateGet" and "MigrationState" (ApiResponsePayload) to request registered component to handle the actions.