### PR TITLE
Minimal snapshot/resume support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,8 +464,7 @@ dependencies = [
 [[package]]
 name = "kvm-bindings"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d381156ad52005b4655a9421401f02b80f9f049e653496e3ea6639a83fc12453"
+source = "git+https://github.com/cloud-hypervisor/kvm-bindings?branch=topic/serde#3a6780089e0e2d69aaf77666524e81801c814bdd"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -473,8 +472,7 @@ dependencies = [
 [[package]]
 name = "kvm-ioctls"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99720f5df3814a7188f095ad6774775b7635dfdd62b7c091ce7e00a51c3c109"
+source = "git+https://github.com/cloud-hypervisor/kvm-ioctls?branch=topic/vmm-sys-util-dep#15969e192a02f5e41b4946683ed40d9d16296e67"
 dependencies = [
  "kvm-bindings",
  "libc",
@@ -1465,6 +1463,8 @@ checksum = "3a6cc7e1659e545d250261676c9193732da57357cc610b12a0e7c776ed047fc9"
 dependencies = [
  "bitflags 1.2.1",
  "libc",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,48 +4,52 @@
 name = "acpi_tables"
 version = "0.1.0"
 dependencies = [
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory",
 ]
 
 [[package]]
 name = "aho-corasick"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 dependencies = [
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr",
 ]
 
 [[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "anyhow"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
 
 [[package]]
 name = "arc-swap"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
 
 [[package]]
 name = "arch"
 version = "0.1.0"
 dependencies = [
- "acpi_tables 0.1.0",
- "arch_gen 0.1.0",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "linux-loader 0.1.0 (git+https://github.com/rust-vmm/linux-loader)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "acpi_tables",
+ "arch_gen",
+ "byteorder",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "linux-loader",
+ "rand 0.7.3",
+ "vm-memory",
 ]
 
 [[package]]
@@ -56,1089 +60,1205 @@ version = "0.1.0"
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi",
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
 version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
 dependencies = [
- "backtrace-sys 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys",
+ "cfg-if",
+ "libc",
+ "rustc-demangle",
 ]
 
 [[package]]
 name = "backtrace-sys"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
 dependencies = [
- "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
+ "libc",
 ]
 
 [[package]]
 name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "bitflags"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
 
 [[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2b_simd"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
- "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cc"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term",
+ "atty",
+ "bitflags 1.2.1",
+ "strsim",
+ "term_size",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
 name = "cloud-hypervisor"
 version = "0.6.0"
 dependencies = [
- "arc-swap 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "credibility 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "seccomp 0.1.0 (git+https://github.com/firecracker-microvm/firecracker?tag=v0.21.1)",
- "serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "ssh2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
- "vhost_user_backend 0.1.0",
- "vhost_user_block 0.1.0",
- "vhost_user_fs 0.1.0",
- "vhost_user_net 0.1.0",
+ "arc-swap",
+ "clap",
+ "credibility",
+ "dirs",
+ "epoll",
+ "futures",
+ "lazy_static",
+ "libc",
+ "log 0.4.8",
+ "seccomp",
+ "serde_json",
+ "ssh2",
+ "tempdir",
+ "tempfile",
+ "vhost",
+ "vhost_user_backend",
+ "vhost_user_block",
+ "vhost_user_fs",
+ "vhost_user_net",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-device 0.1.0",
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-virtio 0.1.0",
- "vmm 0.1.0",
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-device",
+ "vm-memory",
+ "vm-virtio",
+ "vmm",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1",
 ]
 
 [[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "credibility"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fae7a162fd5b462bc49704873a89950a655d44161add4be07e00e64c4c83a5bf"
 dependencies = [
- "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure",
+ "failure_derive",
 ]
 
 [[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
 ]
 
 [[package]]
 name = "devices"
 version = "0.1.0"
 dependencies = [
- "acpi_tables 0.1.0",
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-device 0.1.0",
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "acpi_tables",
+ "bitflags 1.2.1",
+ "byteorder",
+ "epoll",
+ "libc",
+ "log 0.4.8",
+ "tempfile",
+ "vm-device",
+ "vm-memory",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "dirs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "redox_users",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "epoll"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990bcfe26bea89669ede68c3f970f61d02568dbc8660317c98d805ea4e710685"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1",
+ "libc",
 ]
 
 [[package]]
 name = "failure"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
 dependencies = [
- "backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace",
+ "failure_derive",
 ]
 
 [[package]]
 name = "failure_derive"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
 dependencies = [
- "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-executor 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
 name = "futures-channel"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
 dependencies = [
- "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
 
 [[package]]
 name = "futures-executor"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
 dependencies = [
- "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core",
+ "futures-task",
+ "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
 name = "futures-io"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
 
 [[package]]
 name = "futures-macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
- "proc-macro-hack 0.5.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "futures-sink"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
 
 [[package]]
 name = "futures-task"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
 
 [[package]]
 name = "futures-util"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
 dependencies = [
- "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-hack 0.5.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-nested 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 
 [[package]]
 name = "hermit-abi"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
 dependencies = [
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "ipnetwork"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dd5e3613374e74da81c251750153abe3bd0ad17641ea63d43d1e21d0dbd4d"
 dependencies = [
- "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
 ]
 
 [[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
 name = "kvm-bindings"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d381156ad52005b4655a9421401f02b80f9f049e653496e3ea6639a83fc12453"
 dependencies = [
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "kvm-ioctls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d99720f5df3814a7188f095ad6774775b7635dfdd62b7c091ce7e00a51c3c109"
 dependencies = [
- "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-bindings",
+ "libc",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 
 [[package]]
 name = "libssh2-sys"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb70f29dc7c31d32c97577f13f41221af981b31248083e347b7f2c39225a6bc"
 dependencies = [
- "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
 name = "libz-sys"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 dependencies = [
- "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
 name = "linux-loader"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/linux-loader#2adddce25b37f68c99ae8e7db1cb7f5853626fdd"
+source = "git+https://github.com/rust-vmm/linux-loader#61d95eb67b5d78f75357f4e3ed039bf5d6549065"
 dependencies = [
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory",
 ]
 
 [[package]]
 name = "lock_api"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 dependencies = [
- "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard",
 ]
 
 [[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8",
 ]
 
 [[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
 ]
 
 [[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "micro_http"
 version = "0.1.0"
 source = "git+https://github.com/firecracker-microvm/micro-http#0d87a94c8e5a76499fbd1e4acb20a5f4406e6ad1"
 dependencies = [
- "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "epoll",
 ]
 
 [[package]]
 name = "net_gen"
 version = "0.1.0"
 dependencies = [
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "net_util"
 version = "0.1.0"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "net_gen 0.1.0",
- "pnet 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "libc",
+ "net_gen",
+ "pnet",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "num_cpus"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 dependencies = [
- "hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
 name = "openssl-sys"
 version = "0.9.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
 name = "parking_lot"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 dependencies = [
- "lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "cloudabi",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "pci"
 version = "0.1.0"
 dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "devices 0.1.0",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-allocator 0.1.0",
- "vm-device 0.1.0",
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "devices",
+ "libc",
+ "log 0.4.8",
+ "vm-allocator",
+ "vm-device",
+ "vm-memory",
 ]
 
 [[package]]
 name = "pin-utils"
 version = "0.1.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 
 [[package]]
 name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "pnet"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c08c2c6c26481fcbe49dc4405baedf47151f859c5a45d3f254c2ff74ce51cf0"
 dependencies = [
- "ipnetwork 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_datalink 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_packet 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_sys 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_transport 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipnetwork",
+ "pnet_base",
+ "pnet_datalink",
+ "pnet_packet",
+ "pnet_sys",
+ "pnet_transport",
 ]
 
 [[package]]
 name = "pnet_base"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df28acf2fcc77436dd2b91a9a0c2bb617f9ca5f2acefee1a4135058b9f9801f"
 
 [[package]]
 name = "pnet_datalink"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545f8df67cbc53438f37f56e68ae5ca49beb3990e9fd7e9e214c8ffd36c0e0ea"
 dependencies = [
- "ipnetwork 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_sys 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipnetwork",
+ "libc",
+ "pnet_base",
+ "pnet_sys",
+ "winapi 0.2.8",
 ]
 
 [[package]]
 name = "pnet_macros"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf402424ca7281aa234b726c32bce5a8e2278c72f5863305e291ac3de08e16f8"
 dependencies = [
- "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_syntax 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex",
+ "syntex",
+ "syntex_syntax",
 ]
 
 [[package]]
 name = "pnet_macros_support"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e586854ba703c15f74c486e1a46624566b47f1f61cc8a6b02c6bbe5e34a383b"
 dependencies = [
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_base",
 ]
 
 [[package]]
 name = "pnet_packet"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c44c075c6d4f2e814dba621a999838e4a4f749f6117024f52b05b3c559a4fd17"
 dependencies = [
- "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_macros 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_macros_support 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob",
+ "pnet_base",
+ "pnet_macros",
+ "pnet_macros_support",
+ "syntex",
 ]
 
 [[package]]
 name = "pnet_sys"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f881a6d75ac98c5541db6144682d1773bb14c6fc50c6ebac7086c8f7f23c29"
 dependencies = [
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
 name = "pnet_transport"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b75ccaee7b5daba9f9a7d47bceeb73cc32edde9952dc5409460d6621ec667b6"
 dependencies = [
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_packet 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_sys 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "pnet_base",
+ "pnet_packet",
+ "pnet_sys",
 ]
 
 [[package]]
 name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "proc-macro-hack"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
 
 [[package]]
 name = "proc-macro-nested"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
 name = "qcow"
 version = "0.1.0"
 dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "remain 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-virtio 0.1.0",
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "libc",
+ "log 0.4.8",
+ "remain",
+ "tempfile",
+ "vm-virtio",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "quote"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core 0.5.1",
+ "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
- "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 dependencies = [
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2",
 ]
 
 [[package]]
 name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "redox_users"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
 dependencies = [
- "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
 ]
 
 [[package]]
 name = "regex"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
 dependencies = [
- "aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
+ "utf8-ranges",
 ]
 
 [[package]]
 name = "regex-syntax"
 version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
 name = "remain"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c861227fc40c8da6fdaa3d58144ac84c0537080a43eb1d7d45c28f88dcb888"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "remove_dir_all"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "rust-argon2"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 dependencies = [
- "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "ryu"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
 
 [[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "seccomp"
 version = "0.1.0"
 source = "git+https://github.com/firecracker-microvm/firecracker?tag=v0.21.1#047a379eb041f9ceae35df5fa072d88cac55340e"
 dependencies = [
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "serde"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
 
 [[package]]
 name = "serde_derive"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a7a12c167809363ec3bd7329fc0a3369056996de43c4b37ef3cd54a6ce4867"
 dependencies = [
- "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
 name = "signal-hook"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b9f3a1686a29f53cfd91ee5e3db3c12313ec02d33765f02c1a9645a1811e2c"
 dependencies = [
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "signal-hook-registry",
 ]
 
 [[package]]
 name = "signal-hook-registry"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 dependencies = [
- "arc-swap 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arc-swap",
+ "libc",
 ]
 
 [[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
 name = "ssh2"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1a0bdfb47e1fa1eb80f67c7909cfddab49d4262025aa9e4f6e9c39ad77b482"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssh2-sys 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1",
+ "libc",
+ "libssh2-sys",
+ "parking_lot",
 ]
 
 [[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
 name = "synstructure"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
 name = "syntex"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a30b08a6b383a22e5f6edc127d169670d48f905bb00ca79a00ea3e442ebe317"
 dependencies = [
- "syntex_errors 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_syntax 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_errors",
+ "syntex_syntax",
 ]
 
 [[package]]
 name = "syntex_errors"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c48f32867b6114449155b2a82114b86d4b09e1bddb21c47ff104ab9172b646"
 dependencies = [
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_pos 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "log 0.3.9",
+ "rustc-serialize",
+ "syntex_pos",
+ "term",
+ "unicode-xid 0.0.3",
 ]
 
 [[package]]
 name = "syntex_pos"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd49988e52451813c61fecbe9abb5cfd4e1b7bb6cdbb980a6fbcbab859171a6"
 dependencies = [
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize",
 ]
 
 [[package]]
 name = "syntex_syntax"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7628a0506e8f9666fdabb5f265d0059b059edac9a3f810bda077abb5d826bd8d"
 dependencies = [
- "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_errors 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_pos 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.5.0",
+ "libc",
+ "log 0.3.9",
+ "rustc-serialize",
+ "syntex_errors",
+ "syntex_pos",
+ "term",
+ "unicode-xid 0.0.3",
 ]
 
 [[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "rand 0.7.3",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "term"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys",
+ "winapi 0.2.8",
 ]
 
 [[package]]
 name = "term_size"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys",
+ "libc",
+ "winapi 0.2.8",
 ]
 
 [[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size",
+ "unicode-width",
 ]
 
 [[package]]
 name = "thiserror"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
 dependencies = [
- "thiserror-impl 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
 ]
 
 [[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 
 [[package]]
 name = "unicode-xid"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "utf8-ranges"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
 name = "vcpkg"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "vfio"
 version = "0.0.1"
 dependencies = [
- "arc-swap 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "devices 0.1.0",
- "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pci 0.1.0",
- "vfio-bindings 0.1.0 (git+https://github.com/rust-vmm/vfio-bindings)",
- "vm-allocator 0.1.0",
- "vm-device 0.1.0",
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arc-swap",
+ "byteorder",
+ "devices",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "log 0.4.8",
+ "pci",
+ "vfio-bindings",
+ "vm-allocator",
+ "vm-device",
+ "vm-memory",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1146,77 +1266,77 @@ name = "vfio-bindings"
 version = "0.1.0"
 source = "git+https://github.com/rust-vmm/vfio-bindings#46ef9d418e8d75b6a4b96f3bbc04e6eb47fef54b"
 dependencies = [
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "vhost"
 version = "0.1.0"
-source = "git+https://github.com/cloud-hypervisor/vhost?branch=dragonball#92778e12aa9c9bd024ee81cd32a0a7f5ece03272"
+source = "git+https://github.com/cloud-hypervisor/vhost?branch=dragonball#d756e08224973cae7d9191e80adaa59b1101b35a"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1",
+ "libc",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "vhost_user_backend"
 version = "0.1.0"
 dependencies = [
- "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
+ "epoll",
+ "libc",
+ "log 0.4.8",
+ "vhost",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-virtio 0.1.0",
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory",
+ "vm-virtio",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "vhost_user_block"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "qcow 0.1.0",
- "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
- "vhost_user_backend 0.1.0",
+ "bitflags 1.2.1",
+ "epoll",
+ "libc",
+ "log 0.4.8",
+ "qcow",
+ "vhost",
+ "vhost_user_backend",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-virtio 0.1.0",
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory",
+ "vm-virtio",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "vhost_user_fs"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-virtio 0.1.0",
+ "bitflags 1.2.1",
+ "libc",
+ "log 0.4.8",
+ "vhost",
+ "vm-memory",
+ "vm-virtio",
 ]
 
 [[package]]
 name = "vhost_user_net"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "net_util 0.1.0",
- "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
- "vhost_user_backend 0.1.0",
+ "bitflags 1.2.1",
+ "epoll",
+ "libc",
+ "log 0.4.8",
+ "net_util",
+ "vhost",
+ "vhost_user_backend",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-virtio 0.1.0",
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory",
+ "vm-virtio",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1228,281 +1348,166 @@ source = "git+https://github.com/rust-vmm/virtio-bindings#921b722856335b799261b7
 name = "virtio-bindings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
 
 [[package]]
 name = "vm-allocator"
 version = "0.1.0"
 dependencies = [
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "vm-memory",
 ]
 
 [[package]]
 name = "vm-device"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "vm-memory",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "vm-memory"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d50eb34b2ec250e098fbad7486e81f592a1bdeff2b10f0433638f3ce6a0828"
 dependencies = [
- "arc-swap 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arc-swap",
+ "libc",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "vm-migration"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
 name = "vm-virtio"
 version = "0.1.0"
 dependencies = [
- "arc-swap 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "devices 0.1.0",
- "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "net_gen 0.1.0",
- "net_util 0.1.0",
- "pci 0.1.0",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
+ "arc-swap",
+ "byteorder",
+ "devices",
+ "epoll",
+ "libc",
+ "log 0.4.8",
+ "net_gen",
+ "net_util",
+ "pci",
+ "tempfile",
+ "vhost",
  "virtio-bindings 0.1.0 (git+https://github.com/rust-vmm/virtio-bindings)",
- "vm-allocator 0.1.0",
- "vm-device 0.1.0",
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-allocator",
+ "vm-device",
+ "vm-memory",
+ "vm-migration",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "vmm"
 version = "0.1.0"
 dependencies = [
- "acpi_tables 0.1.0",
- "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "arc-swap 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "arch 0.1.0",
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "devices 0.1.0",
- "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "linux-loader 0.1.0 (git+https://github.com/rust-vmm/linux-loader)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "micro_http 0.1.0 (git+https://github.com/firecracker-microvm/micro-http)",
- "net_util 0.1.0",
- "pci 0.1.0",
- "qcow 0.1.0",
- "seccomp 0.1.0 (git+https://github.com/firecracker-microvm/firecracker?tag=v0.21.1)",
- "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vfio 0.0.1",
- "vm-allocator 0.1.0",
- "vm-device 0.1.0",
- "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-virtio 0.1.0",
- "vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "acpi_tables",
+ "anyhow",
+ "arc-swap",
+ "arch",
+ "clap",
+ "devices",
+ "epoll",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "lazy_static",
+ "libc",
+ "linux-loader",
+ "log 0.4.8",
+ "micro_http",
+ "net_util",
+ "pci",
+ "qcow",
+ "seccomp",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "signal-hook",
+ "tempfile",
+ "vfio",
+ "vm-allocator",
+ "vm-device",
+ "vm-memory",
+ "vm-migration",
+ "vm-virtio",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "vmm-sys-util"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6cc7e1659e545d250261676c9193732da57357cc610b12a0e7c776ed047fc9"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1",
+ "libc",
 ]
 
 [[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
 name = "winapi-build"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8",
+ "winapi-build",
 ]
-
-[metadata]
-"checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
-"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
-"checksum arc-swap 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
-"checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
-"checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-"checksum backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)" = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
-"checksum backtrace-sys 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
-"checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-"checksum bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
-"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
-"checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-"checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
-"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
-"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-"checksum credibility 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fae7a162fd5b462bc49704873a89950a655d44161add4be07e00e64c4c83a5bf"
-"checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-"checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
-"checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
-"checksum epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "990bcfe26bea89669ede68c3f970f61d02568dbc8660317c98d805ea4e710685"
-"checksum failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
-"checksum failure_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
-"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-"checksum futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
-"checksum futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
-"checksum futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
-"checksum futures-executor 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
-"checksum futures-io 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
-"checksum futures-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
-"checksum futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
-"checksum futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
-"checksum futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
-"checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
-"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
-"checksum ipnetwork 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a69dd5e3613374e74da81c251750153abe3bd0ad17641ea63d43d1e21d0dbd4d"
-"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d381156ad52005b4655a9421401f02b80f9f049e653496e3ea6639a83fc12453"
-"checksum kvm-ioctls 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d99720f5df3814a7188f095ad6774775b7635dfdd62b7c091ce7e00a51c3c109"
-"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
-"checksum libssh2-sys 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "7bb70f29dc7c31d32c97577f13f41221af981b31248083e347b7f2c39225a6bc"
-"checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
-"checksum linux-loader 0.1.0 (git+https://github.com/rust-vmm/linux-loader)" = "<none>"
-"checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
-"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-"checksum micro_http 0.1.0 (git+https://github.com/firecracker-microvm/micro-http)" = "<none>"
-"checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
-"checksum openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)" = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
-"checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
-"checksum parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
-"checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
-"checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
-"checksum pnet 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c08c2c6c26481fcbe49dc4405baedf47151f859c5a45d3f254c2ff74ce51cf0"
-"checksum pnet_base 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4df28acf2fcc77436dd2b91a9a0c2bb617f9ca5f2acefee1a4135058b9f9801f"
-"checksum pnet_datalink 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "545f8df67cbc53438f37f56e68ae5ca49beb3990e9fd7e9e214c8ffd36c0e0ea"
-"checksum pnet_macros 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf402424ca7281aa234b726c32bce5a8e2278c72f5863305e291ac3de08e16f8"
-"checksum pnet_macros_support 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e586854ba703c15f74c486e1a46624566b47f1f61cc8a6b02c6bbe5e34a383b"
-"checksum pnet_packet 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c44c075c6d4f2e814dba621a999838e4a4f749f6117024f52b05b3c559a4fd17"
-"checksum pnet_sys 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "82f881a6d75ac98c5541db6144682d1773bb14c6fc50c6ebac7086c8f7f23c29"
-"checksum pnet_transport 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b75ccaee7b5daba9f9a7d47bceeb73cc32edde9952dc5409460d6621ec667b6"
-"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
-"checksum proc-macro-hack 0.5.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
-"checksum proc-macro-nested 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
-"checksum proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
-"checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
-"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-"checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-"checksum rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-"checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
-"checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
-"checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
-"checksum remain 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "99c861227fc40c8da6fdaa3d58144ac84c0537080a43eb1d7d45c28f88dcb888"
-"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
-"checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-"checksum ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
-"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-"checksum seccomp 0.1.0 (git+https://github.com/firecracker-microvm/firecracker?tag=v0.21.1)" = "<none>"
-"checksum serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
-"checksum serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
-"checksum serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "78a7a12c167809363ec3bd7329fc0a3369056996de43c4b37ef3cd54a6ce4867"
-"checksum signal-hook 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "10b9f3a1686a29f53cfd91ee5e3db3c12313ec02d33765f02c1a9645a1811e2c"
-"checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
-"checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
-"checksum ssh2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb1a0bdfb47e1fa1eb80f67c7909cfddab49d4262025aa9e4f6e9c39ad77b482"
-"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
-"checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-"checksum syntex 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0a30b08a6b383a22e5f6edc127d169670d48f905bb00ca79a00ea3e442ebe317"
-"checksum syntex_errors 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04c48f32867b6114449155b2a82114b86d4b09e1bddb21c47ff104ab9172b646"
-"checksum syntex_pos 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd49988e52451813c61fecbe9abb5cfd4e1b7bb6cdbb980a6fbcbab859171a6"
-"checksum syntex_syntax 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7628a0506e8f9666fdabb5f265d0059b059edac9a3f810bda077abb5d826bd8d"
-"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-"checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
-"checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
-"checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
-"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-"checksum thiserror 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
-"checksum thiserror-impl 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
-"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-"checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum utf8-ranges 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
-"checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
-"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum vfio-bindings 0.1.0 (git+https://github.com/rust-vmm/vfio-bindings)" = "<none>"
-"checksum vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)" = "<none>"
-"checksum virtio-bindings 0.1.0 (git+https://github.com/rust-vmm/virtio-bindings)" = "<none>"
-"checksum virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
-"checksum vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98d50eb34b2ec250e098fbad7486e81f592a1bdeff2b10f0433638f3ce6a0828"
-"checksum vmm-sys-util 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a6cc7e1659e545d250261676c9193732da57357cc610b12a0e7c776ed047fc9"
-"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "ipnetwork"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +566,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +665,12 @@ dependencies = [
  "vm-device",
  "vm-memory",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-utils"
@@ -1212,6 +1235,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1269,17 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
+name = "url"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+dependencies = [
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utf8-ranges"
@@ -1448,6 +1500,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "tempfile",
+ "url",
  "vfio",
  "vm-allocator",
  "vm-device",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,8 @@ name = "kvm-bindings"
 version = "0.2.0"
 source = "git+https://github.com/cloud-hypervisor/kvm-bindings?branch=topic/serde#3a6780089e0e2d69aaf77666524e81801c814bdd"
 dependencies = [
+ "serde",
+ "serde_derive",
  "vmm-sys-util",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,14 +242,19 @@ name = "devices"
 version = "0.1.0"
 dependencies = [
  "acpi_tables",
+ "anyhow",
  "bitflags 1.2.1",
  "byteorder",
  "epoll",
  "libc",
  "log 0.4.8",
+ "serde",
+ "serde_derive",
+ "serde_json",
  "tempfile",
  "vm-device",
  "vm-memory",
+ "vm-migration",
  "vmm-sys-util",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
     "vmm",
     "vm-virtio",
     "vm-device",
+    "vm-migration",
     "vhost_user_block",
     "vhost_user_backend",
     "vhost_user_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ credibility = "0.1.3"
 tempdir= "0.3.7"
 lazy_static= "1.4.0"
 tempfile = "3.1.0"
+serde_json = ">=1.0.9"
 
 [features]
 default = ["acpi", "pci", "cmos"]

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -8,8 +8,8 @@ default = []
 
 [dependencies]
 byteorder = "1.3.4"
-kvm-bindings = "0.2.0"
-kvm-ioctls = "0.5.0"
+kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "topic/serde" }
+kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "topic/vmm-sys-util-dep" }
 libc = "0.2.68"
 vm-memory = { version = "0.2.0", features = ["backend-mmap"] }
 

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -79,7 +79,7 @@ pub mod x86_64;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
     arch_memory_regions, configure_system, initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE,
-    layout::CMDLINE_START, BootProtocol, EntryPoint,
+    layout::CMDLINE_START, regs, BootProtocol, EntryPoint,
 };
 
 /// Safe wrapper for `sysconf(_SC_PAGESIZE)`.

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -70,7 +70,7 @@ pub fn setup_fpu(vcpu: &VcpuFd) -> Result<()> {
 ///
 /// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
 pub fn setup_msrs(vcpu: &VcpuFd) -> Result<()> {
-    vcpu.set_msrs(&create_msr_entries())
+    vcpu.set_msrs(&boot_msr_entries())
         .map_err(Error::SetModelSpecificRegisters)?;
 
     Ok(())
@@ -262,7 +262,7 @@ macro_rules! KVM_MSR_DATA {
     };
 }
 
-fn create_msr_entries() -> Msrs {
+pub fn boot_msr_entries() -> Msrs {
     Msrs::from_entries(&[
         KVM_MSR!(msr_index::MSR_IA32_SYSENTER_CS),
         KVM_MSR!(msr_index::MSR_IA32_SYSENTER_ESP),
@@ -426,7 +426,7 @@ mod tests {
         // Official entries that were setup when we did setup_msrs. We need to assert that the
         // tenth one (i.e the one with index msr_index::MSR_IA32_MISC_ENABLE has the data we
         // expect.
-        let entry_vec = create_msr_entries();
+        let entry_vec = boot_msr_entries();
         assert_eq!(entry_vec.as_slice()[9], msrs.as_slice()[0]);
     }
 

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -242,68 +242,43 @@ fn setup_page_tables(mem: &GuestMemoryMmap, sregs: &mut kvm_sregs) -> Result<()>
     Ok(())
 }
 
+macro_rules! KVM_MSR {
+    ($msr:expr) => {
+        kvm_msr_entry {
+            index: $msr,
+            data: 0x0,
+            ..Default::default()
+        }
+    };
+}
+
+macro_rules! KVM_MSR_DATA {
+    ($msr:expr, $data:expr) => {
+        kvm_msr_entry {
+            index: $msr,
+            data: $data,
+            ..Default::default()
+        }
+    };
+}
+
 fn create_msr_entries() -> Msrs {
-    let mut entries = Vec::<kvm_msr_entry>::new();
-
-    entries.push(kvm_msr_entry {
-        index: msr_index::MSR_IA32_SYSENTER_CS,
-        data: 0x0,
-        ..Default::default()
-    });
-    entries.push(kvm_msr_entry {
-        index: msr_index::MSR_IA32_SYSENTER_ESP,
-        data: 0x0,
-        ..Default::default()
-    });
-    entries.push(kvm_msr_entry {
-        index: msr_index::MSR_IA32_SYSENTER_EIP,
-        data: 0x0,
-        ..Default::default()
-    });
-    // x86_64 specific msrs, we only run on x86_64 not x86.
-    entries.push(kvm_msr_entry {
-        index: msr_index::MSR_STAR,
-        data: 0x0,
-        ..Default::default()
-    });
-    entries.push(kvm_msr_entry {
-        index: msr_index::MSR_CSTAR,
-        data: 0x0,
-        ..Default::default()
-    });
-    entries.push(kvm_msr_entry {
-        index: msr_index::MSR_KERNEL_GS_BASE,
-        data: 0x0,
-        ..Default::default()
-    });
-    entries.push(kvm_msr_entry {
-        index: msr_index::MSR_SYSCALL_MASK,
-        data: 0x0,
-        ..Default::default()
-    });
-    entries.push(kvm_msr_entry {
-        index: msr_index::MSR_LSTAR,
-        data: 0x0,
-        ..Default::default()
-    });
-    // end of x86_64 specific code
-    entries.push(kvm_msr_entry {
-        index: msr_index::MSR_IA32_TSC,
-        data: 0x0,
-        ..Default::default()
-    });
-    entries.push(kvm_msr_entry {
-        index: msr_index::MSR_IA32_MISC_ENABLE,
-        data: msr_index::MSR_IA32_MISC_ENABLE_FAST_STRING as u64,
-        ..Default::default()
-    });
-    entries.push(kvm_msr_entry {
-        index: msr_index::MSR_MTRRdefType,
-        data: MTRR_ENABLE | MTRR_MEM_TYPE_WB,
-        ..Default::default()
-    });
-
-    Msrs::from_entries(&entries)
+    Msrs::from_entries(&[
+        KVM_MSR!(msr_index::MSR_IA32_SYSENTER_CS),
+        KVM_MSR!(msr_index::MSR_IA32_SYSENTER_ESP),
+        KVM_MSR!(msr_index::MSR_IA32_SYSENTER_EIP),
+        KVM_MSR!(msr_index::MSR_STAR),
+        KVM_MSR!(msr_index::MSR_CSTAR),
+        KVM_MSR!(msr_index::MSR_LSTAR),
+        KVM_MSR!(msr_index::MSR_KERNEL_GS_BASE),
+        KVM_MSR!(msr_index::MSR_SYSCALL_MASK),
+        KVM_MSR!(msr_index::MSR_IA32_TSC),
+        KVM_MSR_DATA!(
+            msr_index::MSR_IA32_MISC_ENABLE,
+            msr_index::MSR_IA32_MISC_ENABLE_FAST_STRING as u64
+        ),
+        KVM_MSR_DATA!(msr_index::MSR_MTRRdefType, MTRR_ENABLE | MTRR_MEM_TYPE_WB),
+    ])
 }
 
 #[cfg(test)]

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -4,14 +4,19 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
+anyhow = "1.0"
 bitflags = ">=1.2.1"
 byteorder = "1.3.4"
 epoll = ">=4.0.1"
 libc = "0.2.68"
 log = "0.4.8"
+serde = {version = ">=1.0.27", features = ["rc"] }
+serde_derive = ">=1.0.27"
+serde_json = ">=1.0.9"
 vm-device = { path = "../vm-device" }
 acpi_tables = { path = "../acpi_tables", optional = true }
 vm-memory = "0.2.0"
+vm-migration = { path = "../vm-migration" }
 vmm-sys-util = ">=0.3.1"
 
 [dev-dependencies]

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -6,10 +6,15 @@
 // found in the LICENSE-BSD-3-Clause file.
 
 use crate::BusDevice;
+use anyhow::anyhow;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::{io, result};
 use vm_device::interrupt::InterruptSourceGroup;
+use vm_migration::{
+    Migratable, MigratableError, Pausable, Snapshot, SnapshotDataSection, Snapshotable,
+    Transportable,
+};
 use vmm_sys_util::errno::Result;
 
 const LOOP_SIZE: usize = 0x40;
@@ -66,6 +71,19 @@ pub struct Serial {
     baud_divisor: u16,
     in_buffer: VecDeque<u8>,
     out: Option<Box<dyn io::Write + Send>>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SerialState {
+    interrupt_enable: u8,
+    interrupt_identification: u8,
+    line_control: u8,
+    line_status: u8,
+    modem_control: u8,
+    modem_status: u8,
+    scratch: u8,
+    baud_divisor: u16,
+    in_buffer: VecDeque<u8>,
 }
 
 impl Serial {
@@ -194,6 +212,33 @@ impl Serial {
         }
         Ok(())
     }
+
+    fn state(&self) -> SerialState {
+        SerialState {
+            interrupt_enable: self.interrupt_enable,
+            interrupt_identification: self.interrupt_identification,
+            line_control: self.line_control,
+            line_status: self.line_status,
+            modem_control: self.modem_control,
+            modem_status: self.modem_status,
+            scratch: self.scratch,
+            baud_divisor: self.baud_divisor,
+            in_buffer: self.in_buffer.clone(),
+        }
+    }
+
+    #[allow(unused)]
+    fn set_state(&mut self, state: &SerialState) {
+        self.interrupt_enable = state.interrupt_enable;
+        self.interrupt_identification = state.interrupt_identification;
+        self.line_control = state.line_control;
+        self.line_status = state.line_status;
+        self.modem_control = state.modem_control;
+        self.modem_status = state.modem_status;
+        self.scratch = state.scratch;
+        self.baud_divisor = state.baud_divisor;
+        self.in_buffer = state.in_buffer.clone();
+    }
 }
 
 impl BusDevice for Serial {
@@ -235,6 +280,55 @@ impl BusDevice for Serial {
         if let Err(_e) = self.handle_write(offset as u8, data[0]) {}
     }
 }
+
+const SERIAL_SNAPSHOT_ID: &str = "serial";
+impl Snapshotable for Serial {
+    fn id(&self) -> String {
+        SERIAL_SNAPSHOT_ID.to_string()
+    }
+
+    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+        let snapshot =
+            serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
+
+        let mut serial_snapshot = Snapshot::new(SERIAL_SNAPSHOT_ID);
+        serial_snapshot.add_data_section(SnapshotDataSection {
+            id: format!("{}-section", SERIAL_SNAPSHOT_ID),
+            snapshot,
+        });
+
+        Ok(serial_snapshot)
+    }
+
+    fn restore(&mut self, snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
+        if let Some(serial_section) = snapshot
+            .snapshot_data
+            .get(&format!("{}-section", SERIAL_SNAPSHOT_ID))
+        {
+            let serial_state = match serde_json::from_slice(&serial_section.snapshot) {
+                Ok(state) => state,
+                Err(error) => {
+                    return Err(MigratableError::Restore(anyhow!(
+                        "Could not deserialize SERIAL {}",
+                        error
+                    )))
+                }
+            };
+
+            self.set_state(&serial_state);
+
+            return Ok(());
+        }
+
+        Err(MigratableError::Restore(anyhow!(
+            "Could not find the serial snapshot section"
+        )))
+    }
+}
+
+impl Pausable for Serial {}
+impl Transportable for Serial {}
+impl Migratable for Serial {}
 
 #[cfg(test)]
 mod tests {

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -6,6 +6,7 @@
 // found in the LICENSE-BSD-3-Clause file.
 
 //! Emulates virtual and hardware devices.
+extern crate anyhow;
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;
@@ -15,9 +16,14 @@ extern crate libc;
 extern crate log;
 #[cfg(feature = "acpi")]
 extern crate acpi_tables;
+extern crate serde;
 extern crate vm_device;
 extern crate vm_memory;
+extern crate vm_migration;
 extern crate vmm_sys_util;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
 
 use std::fs::File;
 use std::io;

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,6 +232,14 @@ fn create_app<'a, 'b>(
                 .group("vmm-config"),
         )
         .arg(
+            Arg::with_name("restore-from")
+                .long("restore-from")
+                .help("Restore from a VM snapshot.")
+                .takes_value(true)
+                .min_values(1)
+                .group("vmm-config"),
+        )
+        .arg(
             Arg::with_name("net-backend")
                 .long("net-backend")
                 .help(
@@ -333,6 +341,15 @@ fn start_vmm(cmd_arguments: ArgMatches) {
         )
         .expect("Could not create the VM");
         vmm::api::vm_boot(api_evt.try_clone().unwrap(), sender).expect("Could not boot the VM");
+    } else if let Some(restore_url) = cmd_arguments.value_of("restore-from") {
+        vmm::api::vm_restore(
+            api_evt.try_clone().unwrap(),
+            api_request_sender,
+            Arc::new(vmm::api::VmRestoreConfig {
+                source_url: restore_url.to_string(),
+            }),
+        )
+        .expect("Could not restore the VM");
     }
 
     match vmm_thread.join() {

--- a/vfio/Cargo.toml
+++ b/vfio/Cargo.toml
@@ -7,8 +7,8 @@ authors = ["The Cloud Hypervisor Authors"]
 arc-swap = ">=0.4.4"
 byteorder = "1.3.4"
 devices = { path = "../devices" }
-kvm-bindings = "0.2.0"
-kvm-ioctls = "0.5.0"
+kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "topic/serde" }
+kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "topic/vmm-sys-util-dep" }
 libc = "0.2.68"
 log = "0.4.8"
 pci = { path = "../pci" }

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -12,4 +12,3 @@ serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 vm-memory = { version = "0.2.0", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.3.1"
-

--- a/vm-device/src/lib.rs
+++ b/vm-device/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate serde;
-extern crate thiserror;
 extern crate vm_memory;
 
 pub mod interrupt;
@@ -8,8 +6,6 @@ use vm_memory::{
     Address, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap,
     MemoryRegionAddress,
 };
-
-use thiserror::Error;
 
 /// Trait meant for triggering the DMA mapping update related to an external
 /// device not managed fully through virtio. It is dedicated to virtio-iommu
@@ -22,34 +18,6 @@ pub trait ExternalDmaMapping: Send + Sync {
     /// Unmap a memory range
     fn unmap(&self, iova: u64, size: u64) -> std::result::Result<(), std::io::Error>;
 }
-
-#[derive(Error, Debug)]
-pub enum MigratableError {
-    #[error("Failed to pause migratable component: {0}")]
-    Pause(#[source] anyhow::Error),
-
-    #[error("Failed to resume migratable component: {0}")]
-    Resume(#[source] anyhow::Error),
-}
-
-/// A Pausable component can be paused and resumed.
-pub trait Pausable {
-    /// Pause the component.
-    fn pause(&mut self) -> std::result::Result<(), MigratableError>;
-
-    /// Resume the component.
-    fn resume(&mut self) -> std::result::Result<(), MigratableError>;
-}
-
-/// A snapshotable component can be snapshoted.
-pub trait Snapshotable {}
-
-/// Trait to be implemented by any component (device, CPU, RAM, etc) that
-/// can be migrated.
-/// All migratable components are paused before being snapshotted, and then
-/// eventually resumed. Thus any Migratable component must be both Pausable
-/// and Snapshotable.
-pub trait Migratable: Send + Pausable + Snapshotable {}
 
 fn get_region_host_address_range(
     region: &GuestRegionMmap,

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vm-migration"
+version = "0.1.0"
+authors = ["The Cloud Hypervisor Authors"]
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+thiserror = "1.0"
+serde = {version = ">=1.0.27", features = ["rc"] }
+serde_derive = ">=1.0.27"
+serde_json = ">=1.0.9"

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -1,0 +1,162 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+//
+
+extern crate serde;
+extern crate thiserror;
+#[macro_use]
+extern crate serde_derive;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum MigratableError {
+    #[error("Failed to pause migratable component: {0}")]
+    Pause(#[source] anyhow::Error),
+
+    #[error("Failed to resume migratable component: {0}")]
+    Resume(#[source] anyhow::Error),
+
+    #[error("Failed to snapshot migratable component: {0}")]
+    Snapshot(#[source] anyhow::Error),
+
+    #[error("Failed to restore migratable component: {0}")]
+    Restore(#[source] anyhow::Error),
+
+    #[error("Failed to send migratable component snapshot: {0}")]
+    MigrateSend(#[source] anyhow::Error),
+
+    #[error("Failed to receive migratable component snapshot: {0}")]
+    MigrateReceive(#[source] anyhow::Error),
+}
+
+/// A Pausable component can be paused and resumed.
+pub trait Pausable {
+    /// Pause the component.
+    fn pause(&mut self) -> std::result::Result<(), MigratableError> {
+        Ok(())
+    }
+
+    /// Resume the component.
+    fn resume(&mut self) -> std::result::Result<(), MigratableError> {
+        Ok(())
+    }
+}
+
+/// A Snapshotable component snapshot section.
+/// Migratable component can split their migration snapshot into
+/// separate sections.
+/// Splitting a component migration data into different sections
+/// allows for easier and forward compatible extensions.
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub struct SnapshotDataSection {
+    /// The section id.
+    pub id: String,
+
+    /// The section serialized snapshot.
+    pub snapshot: Vec<u8>,
+}
+
+/// A Snapshotable component's snapshot is a tree of snapshots, where leafs
+/// contain the snapshot data. Nodes of this tree track all their children
+/// through the snapshots field, which is basically their sub-components.
+/// Leaves will typically have an empty snapshots map, while nodes usually
+/// carry an empty snapshot_data.
+///
+/// For example, a device manager snapshot is the composition of all its
+/// devices snapshots. The device manager Snapshot would have no snapshot_data
+/// but one Snapshot child per tracked device. Then each device's Snapshot
+/// would carry an empty snapshots map but a map of SnapshotDataSection, i.e.
+/// the actual device snapshot data.
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub struct Snapshot {
+    /// The Snapshotable component id.
+    pub id: String,
+
+    /// The Snapshotable component snapshots.
+    pub snapshots: std::collections::HashMap<String, Box<Snapshot>>,
+
+    /// The Snapshotable component's snapshot data.
+    /// A map of snapshot sections, indexed by the section ids.
+    pub snapshot_data: std::collections::HashMap<String, SnapshotDataSection>,
+}
+
+impl Snapshot {
+    /// Create an empty Snapshot.
+    pub fn new(id: &str) -> Self {
+        Snapshot {
+            id: id.to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// Add a sub-component's Snapshot to the Snapshot.
+    pub fn add_snapshot(&mut self, snapshot: Snapshot) {
+        self.snapshots
+            .insert(snapshot.id.clone(), Box::new(snapshot));
+    }
+
+    /// Add a SnapshotDatasection to the component snapshot data.
+    pub fn add_data_section(&mut self, section: SnapshotDataSection) {
+        self.snapshot_data.insert(section.id.clone(), section);
+    }
+}
+
+/// A snapshotable component can be snapshoted.
+pub trait Snapshotable: Pausable {
+    /// The snapshotable component id.
+    fn id(&self) -> String {
+        String::new()
+    }
+
+    /// Take a component snapshot.
+    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+        Ok(Snapshot::new(""))
+    }
+
+    /// Restore a component from its snapshot.
+    fn restore(&mut self, _snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
+        Ok(())
+    }
+}
+
+/// A transportable component can be sent or receive to a specific URL.
+///
+/// This trait is meant to be used for component that have custom
+/// transport handlers.
+pub trait Transportable: Pausable + Snapshotable {
+    /// Send a component snapshot.
+    ///
+    /// # Arguments
+    ///
+    /// * `snapshot` - The migratable component snapshot to send.
+    /// * `destination_url` - The destination URL to send the snapshot to. This
+    ///                       could be an HTTP endpoint, a TCP address or a local file.
+    fn send(
+        &self,
+        _snapshot: &Snapshot,
+        _destination_url: &str,
+    ) -> std::result::Result<(), MigratableError> {
+        Ok(())
+    }
+
+    /// Receive a component snapshot.
+    ///
+    /// # Arguments
+    ///
+    /// * `source_url` - The source URL to fetch the snapshot from. This could be an HTTP
+    ///                  endpoint, a TCP address or a local file.
+    fn recv(&self, _source_url: &str) -> std::result::Result<Snapshot, MigratableError> {
+        Ok(Snapshot::new(""))
+    }
+}
+
+/// Trait to be implemented by any component (device, CPU, RAM, etc) that
+/// can be migrated.
+/// All migratable components are paused before being snapshotted, and then
+/// eventually resumed. Thus any Migratable component must be both Pausable
+/// and Snapshotable.
+/// Moreover a migratable component can be transported to a remote or local
+/// destination and thus must be Transportable.
+pub trait Migratable: Send + Pausable + Snapshotable + Transportable {}

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -24,5 +24,6 @@ virtio-bindings = { git = "https://github.com/rust-vmm/virtio-bindings", version
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.2.0", features = ["backend-mmap", "backend-atomic"] }
+vm-migration = { path = "../vm-migration" }
 vmm-sys-util = ">=0.3.1"
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-master", "vhost-user-slave"] }

--- a/vm-virtio/src/block.rs
+++ b/vm-virtio/src/block.rs
@@ -31,11 +31,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use virtio_bindings::bindings::virtio_blk::*;
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{
     ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
     GuestMemoryError, GuestMemoryMmap,
 };
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::{eventfd::EventFd, seek_hole::SeekHole, write_zeroes::PunchHole};
 
 const SECTOR_SHIFT: u8 = 9;
@@ -1052,4 +1052,5 @@ impl<T: 'static + DiskFile + Send> VirtioDevice for Block<T> {
 
 virtio_pausable!(Block, T: 'static + DiskFile + Send);
 impl<T: 'static + DiskFile + Send> Snapshotable for Block<T> {}
+impl<T: 'static + DiskFile + Send> Transportable for Block<T> {}
 impl<T: 'static + DiskFile + Send> Migratable for Block<T> {}

--- a/vm-virtio/src/console.rs
+++ b/vm-virtio/src/console.rs
@@ -20,8 +20,8 @@ use std::result;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{ByteValued, Bytes, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 
 const QUEUE_SIZE: u16 = 256;
@@ -564,4 +564,5 @@ impl VirtioDevice for Console {
 
 virtio_pausable!(Console);
 impl Snapshotable for Console {}
+impl Transportable for Console {}
 impl Migratable for Console {}

--- a/vm-virtio/src/iommu.rs
+++ b/vm-virtio/src/iommu.rs
@@ -21,11 +21,12 @@ use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread;
-use vm_device::{ExternalDmaMapping, Migratable, MigratableError, Pausable, Snapshotable};
+use vm_device::ExternalDmaMapping;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
     GuestMemoryError, GuestMemoryMmap,
 };
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 
 /// Queues sizes
@@ -1039,4 +1040,5 @@ impl VirtioDevice for Iommu {
 
 virtio_pausable!(Iommu);
 impl Snapshotable for Iommu {}
+impl Transportable for Iommu {}
 impl Migratable for Iommu {}

--- a/vm-virtio/src/mem.rs
+++ b/vm-virtio/src/mem.rs
@@ -30,11 +30,11 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
     GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap,
 };
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 
 const QUEUE_SIZE: u16 = 128;
@@ -956,4 +956,5 @@ impl VirtioDevice for Mem {
 
 virtio_pausable!(Mem);
 impl Snapshotable for Mem {}
+impl Transportable for Mem {}
 impl Migratable for Mem {}

--- a/vm-virtio/src/net.rs
+++ b/vm-virtio/src/net.rs
@@ -30,8 +30,8 @@ use std::sync::Arc;
 use std::thread;
 use std::vec::Vec;
 use virtio_bindings::bindings::virtio_net::*;
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{ByteValued, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 
 #[derive(Debug)]
@@ -568,4 +568,5 @@ impl VirtioDevice for Net {
 
 virtio_ctrl_q_pausable!(Net);
 impl Snapshotable for Net {}
+impl Transportable for Net {}
 impl Migratable for Net {}

--- a/vm-virtio/src/pmem.rs
+++ b/vm-virtio/src/pmem.rs
@@ -24,11 +24,11 @@ use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
     GuestMemoryError, GuestMemoryMmap, GuestUsize,
 };
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 
 const QUEUE_SIZE: u16 = 256;
@@ -507,4 +507,5 @@ impl VirtioDevice for Pmem {
 
 virtio_pausable!(Pmem);
 impl Snapshotable for Pmem {}
+impl Transportable for Pmem {}
 impl Migratable for Pmem {}

--- a/vm-virtio/src/rng.rs
+++ b/vm-virtio/src/rng.rs
@@ -18,8 +18,8 @@ use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 
 const QUEUE_SIZE: u16 = 256;
@@ -358,4 +358,5 @@ impl VirtioDevice for Rng {
 
 virtio_pausable!(Rng);
 impl Snapshotable for Rng {}
+impl Transportable for Rng {}
 impl Migratable for Rng {}

--- a/vm-virtio/src/transport/mmio.rs
+++ b/vm-virtio/src/transport/mmio.rs
@@ -15,8 +15,8 @@ use std::result;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use vm_device::interrupt::InterruptSourceGroup;
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::{errno::Result, eventfd::EventFd};
 
 const VENDOR_ID: u32 = 0;
@@ -355,4 +355,5 @@ impl Pausable for MmioDevice {
 }
 
 impl Snapshotable for MmioDevice {}
+impl Transportable for MmioDevice {}
 impl Migratable for MmioDevice {}

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -37,11 +37,11 @@ use vm_allocator::SystemAllocator;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceGroup, MsiIrqGroupConfig,
 };
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{
     Address, ByteValued, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap,
     GuestUsize, Le32,
 };
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::{errno::Result, eventfd::EventFd};
 
 #[allow(clippy::enum_variant_names)]
@@ -917,4 +917,5 @@ impl Pausable for VirtioPciDevice {
 }
 
 impl Snapshotable for VirtioPciDevice {}
+impl Transportable for VirtioPciDevice {}
 impl Migratable for VirtioPciDevice {}

--- a/vm-virtio/src/vhost_user/blk.rs
+++ b/vm-virtio/src/vhost_user/blk.rs
@@ -26,8 +26,8 @@ use vhost_rs::vhost_user::{Master, VhostUserMaster, VhostUserMasterReqHandler};
 use vhost_rs::VhostBackend;
 use virtio_bindings::bindings::virtio_blk::*;
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{ByteValued, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 
 struct SlaveReqHandler {}
@@ -329,4 +329,5 @@ impl VirtioDevice for Blk {
 
 virtio_pausable!(Blk);
 impl Snapshotable for Blk {}
+impl Transportable for Blk {}
 impl Migratable for Blk {}

--- a/vm-virtio/src/vhost_user/fs.rs
+++ b/vm-virtio/src/vhost_user/fs.rs
@@ -26,10 +26,10 @@ use vhost_rs::vhost_user::{
     HandlerResult, Master, MasterReqHandler, VhostUserMaster, VhostUserMasterReqHandler,
 };
 use vhost_rs::VhostBackend;
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{
     Address, ByteValued, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap,
 };
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 
 const NUM_QUEUE_OFFSET: usize = 1;
@@ -556,4 +556,5 @@ impl VirtioDevice for Fs {
 
 virtio_pausable!(Fs);
 impl Snapshotable for Fs {}
+impl Transportable for Fs {}
 impl Migratable for Fs {}

--- a/vm-virtio/src/vhost_user/net.rs
+++ b/vm-virtio/src/vhost_user/net.rs
@@ -27,8 +27,8 @@ use vhost_rs::vhost_user::{Master, VhostUserMaster, VhostUserMasterReqHandler};
 use vhost_rs::VhostBackend;
 use virtio_bindings::bindings::virtio_net;
 use virtio_bindings::bindings::virtio_ring;
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{ByteValued, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 
 const DEFAULT_QUEUE_NUMBER: usize = 2;
@@ -366,4 +366,5 @@ impl VirtioDevice for Net {
 
 virtio_ctrl_q_pausable!(Net);
 impl Snapshotable for Net {}
+impl Transportable for Net {}
 impl Migratable for Net {}

--- a/vm-virtio/src/vsock/device.rs
+++ b/vm-virtio/src/vsock/device.rs
@@ -44,8 +44,8 @@ use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread;
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 
 const QUEUE_SIZE: u16 = 256;
@@ -575,6 +575,7 @@ where
 virtio_pausable!(Vsock, T: 'static + VsockBackend + Sync);
 
 impl<B> Snapshotable for Vsock<B> where B: VsockBackend + Sync + 'static {}
+impl<B> Transportable for Vsock<B> where B: VsockBackend + Sync + 'static {}
 impl<B> Migratable for Vsock<B> where B: VsockBackend + Sync + 'static {}
 
 #[cfg(test)]

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -32,6 +32,7 @@ seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
+url = "2.1.1"
 vfio = { path = "../vfio", optional = true }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0"
 arch = { path = "../arch" }
 devices = { path = "../devices" }
 epoll = ">=4.0.1"
-kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "topic/serde" }
+kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "topic/serde", features = ["with-serde", "fam-wrappers"] }
 kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "topic/vmm-sys-util-dep" }
 lazy_static = "1.4.0"
 libc = "0.2.68"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -19,8 +19,8 @@ anyhow = "1.0"
 arch = { path = "../arch" }
 devices = { path = "../devices" }
 epoll = ">=4.0.1"
-kvm-bindings = "0.2.0"
-kvm-ioctls = "0.5.0"
+kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "topic/serde" }
+kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "topic/vmm-sys-util-dep" }
 lazy_static = "1.4.0"
 libc = "0.2.68"
 log = "0.4.8"
@@ -38,7 +38,7 @@ vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.2.0", features = ["backend-mmap", "backend-atomic"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
-vmm-sys-util = ">=0.3.1"
+vmm-sys-util = { version = ">=0.5.0", features = ["with-serde"] }
 signal-hook = "0.1.13"
 tempfile = "3.1.0"
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -36,6 +36,7 @@ vfio = { path = "../vfio", optional = true }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.2.0", features = ["backend-mmap", "backend-atomic"] }
+vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 signal-hook = "0.1.13"

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -5,7 +5,7 @@
 
 use crate::api::http_endpoint::{
     VmActionHandler, VmAddDevice, VmAddDisk, VmAddNet, VmAddPmem, VmCreate, VmInfo, VmRemoveDevice,
-    VmResize, VmmPing, VmmShutdown,
+    VmResize, VmSnapshot, VmmPing, VmmShutdown,
 };
 use crate::api::{ApiRequest, VmAction};
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
@@ -62,6 +62,7 @@ lazy_static! {
         r.routes.insert(endpoint!("/vm.resume"), Box::new(VmActionHandler::new(VmAction::Resume)));
         r.routes.insert(endpoint!("/vm.shutdown"), Box::new(VmActionHandler::new(VmAction::Shutdown)));
         r.routes.insert(endpoint!("/vm.reboot"), Box::new(VmActionHandler::new(VmAction::Reboot)));
+        r.routes.insert(endpoint!("/vm.snapshot"), Box::new(VmSnapshot {}));
         r.routes.insert(endpoint!("/vmm.shutdown"), Box::new(VmmShutdown {}));
         r.routes.insert(endpoint!("/vmm.ping"), Box::new(VmmPing {}));
         r.routes.insert(endpoint!("/vm.resize"), Box::new(VmResize {}));

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -5,7 +5,7 @@
 
 use crate::api::http_endpoint::{
     VmActionHandler, VmAddDevice, VmAddDisk, VmAddNet, VmAddPmem, VmCreate, VmInfo, VmRemoveDevice,
-    VmResize, VmSnapshot, VmmPing, VmmShutdown,
+    VmResize, VmRestore, VmSnapshot, VmmPing, VmmShutdown,
 };
 use crate::api::{ApiRequest, VmAction};
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
@@ -63,6 +63,7 @@ lazy_static! {
         r.routes.insert(endpoint!("/vm.shutdown"), Box::new(VmActionHandler::new(VmAction::Shutdown)));
         r.routes.insert(endpoint!("/vm.reboot"), Box::new(VmActionHandler::new(VmAction::Reboot)));
         r.routes.insert(endpoint!("/vm.snapshot"), Box::new(VmSnapshot {}));
+        r.routes.insert(endpoint!("/vm.restore"), Box::new(VmRestore {}));
         r.routes.insert(endpoint!("/vmm.shutdown"), Box::new(VmmShutdown {}));
         r.routes.insert(endpoint!("/vmm.ping"), Box::new(VmmPing {}));
         r.routes.insert(endpoint!("/vm.resize"), Box::new(VmResize {}));

--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -6,9 +6,10 @@
 use crate::api::http::EndpointHandler;
 use crate::api::{
     vm_add_device, vm_add_disk, vm_add_net, vm_add_pmem, vm_boot, vm_create, vm_delete, vm_info,
-    vm_pause, vm_reboot, vm_remove_device, vm_resize, vm_resume, vm_shutdown, vm_snapshot,
-    vmm_ping, vmm_shutdown, ApiError, ApiRequest, ApiResult, DeviceConfig, DiskConfig, NetConfig,
-    PmemConfig, VmAction, VmConfig, VmRemoveDeviceData, VmResizeData, VmSnapshotConfig,
+    vm_pause, vm_reboot, vm_remove_device, vm_resize, vm_restore, vm_resume, vm_shutdown,
+    vm_snapshot, vmm_ping, vmm_shutdown, ApiError, ApiRequest, ApiResult, DeviceConfig, DiskConfig,
+    NetConfig, PmemConfig, VmAction, VmConfig, VmRemoveDeviceData, VmResizeData, VmRestoreConfig,
+    VmSnapshotConfig,
 };
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 use serde_json::Error as SerdeError;
@@ -45,6 +46,9 @@ pub enum HttpError {
 
     /// Could not snapshot a VM
     VmSnapshot(ApiError),
+
+    /// Could not restore a VM
+    VmRestore(ApiError),
 
     /// Could not act on a VM
     VmAction(ApiError),
@@ -221,6 +225,45 @@ impl EndpointHandler for VmSnapshot {
                         // Call vm_snapshot()
                         match vm_snapshot(api_notifier, api_sender, Arc::new(vm_snapshot_data))
                             .map_err(HttpError::VmSnapshot)
+                        {
+                            Ok(_) => Response::new(Version::Http11, StatusCode::NoContent),
+                            Err(e) => error_response(e, StatusCode::InternalServerError),
+                        }
+                    }
+                    None => Response::new(Version::Http11, StatusCode::BadRequest),
+                }
+            }
+            _ => Response::new(Version::Http11, StatusCode::BadRequest),
+        }
+    }
+}
+
+// /api/v1/vm.restore handler
+pub struct VmRestore {}
+
+impl EndpointHandler for VmRestore {
+    fn handle_request(
+        &self,
+        req: &Request,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+    ) -> Response {
+        match req.method() {
+            Method::Put => {
+                match &req.body {
+                    Some(body) => {
+                        // Deserialize into a VmRestoreConfig
+                        let vm_restore_data: VmRestoreConfig =
+                            match serde_json::from_slice(body.raw())
+                                .map_err(HttpError::SerdeJsonDeserialize)
+                            {
+                                Ok(data) => data,
+                                Err(e) => return error_response(e, StatusCode::BadRequest),
+                            };
+
+                        // Call vm_restore()
+                        match vm_restore(api_notifier, api_sender, Arc::new(vm_restore_data))
+                            .map_err(HttpError::VmRestore)
                         {
                             Ok(_) => Response::new(Version::Http11, StatusCode::NoContent),
                             Err(e) => error_response(e, StatusCode::InternalServerError),

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -171,24 +171,6 @@ paths:
         404:
           description: The device could not be removed from the VM instance.
 
-  /vm.snapshot:
-    put:
-      summary: Returns a VM snapshot.
-      requestBody:
-        description: The snapshot configuration
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VmSnapshotConfig'
-        required: true
-      responses:
-        204:
-          description: The VM instance was successfully snapshotted.
-        404:
-          description: The VM instance could not be snapshotted because it is not created.
-        405:
-          description: The VM instance could not be snapshotted because it is not booted.
-
   /vm.add-disk:
     put:
       summary: Add a new disk to the VM
@@ -236,6 +218,40 @@ paths:
           description: The new device was successfully added to the VM instance.
         500:
           description: The new device could not be added to the VM instance.
+
+  /vm.snapshot:
+    put:
+      summary: Returns a VM snapshot.
+      requestBody:
+        description: The snapshot configuration
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VmSnapshotConfig'
+        required: true
+      responses:
+        204:
+          description: The VM instance was successfully snapshotted.
+        404:
+          description: The VM instance could not be snapshotted because it is not created.
+        405:
+          description: The VM instance could not be snapshotted because it is not booted.
+
+  /vm.restore:
+    put:
+      summary: Restore a VM from a snapshot.
+      requestBody:
+        description: The restore configuration
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VmRestoreConfig'
+        required: true
+      responses:
+        204:
+          description: The VM instance was successfully restored.
+        404:
+          description: The VM instance could not be restored because it is already created.
 
 components:
   schemas:
@@ -565,4 +581,10 @@ components:
       type: object
       properties:
         destination_url:
+          type: string
+
+    VmRestoreConfig:
+      type: object
+      properties:
+        source_url:
           type: string

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -171,6 +171,24 @@ paths:
         404:
           description: The device could not be removed from the VM instance.
 
+  /vm.snapshot:
+    put:
+      summary: Returns a VM snapshot.
+      requestBody:
+        description: The snapshot configuration
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VmSnapshotConfig'
+        required: true
+      responses:
+        204:
+          description: The VM instance was successfully snapshotted.
+        404:
+          description: The VM instance could not be snapshotted because it is not created.
+        405:
+          description: The VM instance could not be snapshotted because it is not booted.
+
   /vm.add-disk:
     put:
       summary: Add a new disk to the VM
@@ -541,4 +559,10 @@ components:
       type: object
       properties:
         id:
+          type: string
+
+    VmSnapshotConfig:
+      type: object
+      properties:
+        destination_url:
           type: string

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -22,8 +22,8 @@ use arch::layout;
 use arch::EntryPoint;
 use devices::{ioapic, BusDevice};
 use kvm_bindings::{
-    kvm_clock_data, kvm_fpu, kvm_lapic_state, kvm_mp_state, kvm_regs, kvm_sregs, kvm_vcpu_events,
-    kvm_xcrs, kvm_xsave, CpuId, Msrs,
+    kvm_clock_data, kvm_fpu, kvm_lapic_state, kvm_regs, kvm_sregs, kvm_vcpu_events, kvm_xcrs,
+    kvm_xsave, CpuId, Msrs,
 };
 use kvm_ioctls::*;
 use libc::{c_void, siginfo_t};
@@ -324,7 +324,6 @@ pub struct Vcpu {
 pub struct VcpuKvmState {
     msrs: Msrs,
     vcpu_events: kvm_vcpu_events,
-    mp_state: kvm_mp_state,
     regs: kvm_regs,
     sregs: kvm_sregs,
     fpu: kvm_fpu,
@@ -476,7 +475,6 @@ impl Vcpu {
             .fd
             .get_vcpu_events()
             .map_err(Error::VcpuGetVcpuEvents)?;
-        let mp_state = self.fd.get_mp_state().map_err(Error::VcpuGetMpState)?;
         let regs = self.fd.get_regs().map_err(Error::VcpuGetRegs)?;
         let sregs = self.fd.get_sregs().map_err(Error::VcpuGetSregs)?;
         let lapic_state = self.fd.get_lapic().map_err(Error::VcpuGetLapic)?;
@@ -487,7 +485,6 @@ impl Vcpu {
         Ok(VcpuKvmState {
             msrs,
             vcpu_events,
-            mp_state,
             regs,
             sregs,
             fpu,
@@ -512,11 +509,6 @@ impl Vcpu {
             .map_err(Error::VcpuSetSregs)?;
 
         self.fd.set_xcrs(&state.xcrs).map_err(Error::VcpuSetXcrs)?;
-
-        println!("MP STATE {:#?}", state.mp_state);
-        self.fd
-            .set_mp_state(state.mp_state)
-            .map_err(Error::VcpuSetMpState)?;
 
         self.fd.set_msrs(&state.msrs).map_err(Error::VcpuSetMsrs)?;
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -26,8 +26,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 use std::{fmt, io, result};
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{Address, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::{register_signal_handler, SIGRTMIN};
 
@@ -1069,4 +1069,5 @@ impl Pausable for CpuManager {
 }
 
 impl Snapshotable for CpuManager {}
+impl Transportable for CpuManager {}
 impl Migratable for CpuManager {}

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1315,12 +1315,6 @@ impl Snapshotable for CpuManager {
     }
 
     fn restore(&mut self, snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
-        if snapshot.snapshots.len() != self.vcpus.len() {
-            return Err(MigratableError::Restore(anyhow!(
-                "Snapshot length mismatch"
-            )));
-        }
-
         let vcpu_iter = snapshot.snapshots.iter().zip(self.vcpus.iter());
         for ((_id, snapshot), vcpu) in vcpu_iter {
             vcpu.lock().unwrap().restore(*snapshot.clone())?;

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -17,9 +17,13 @@ use acpi_tables::{aml, aml::Aml, sdt::SDT};
 use arch::layout;
 use arch::EntryPoint;
 use devices::{ioapic, BusDevice};
-use kvm_bindings::CpuId;
+use kvm_bindings::{
+    kvm_clock_data, kvm_fpu, kvm_lapic_state, kvm_mp_state, kvm_regs, kvm_sregs, kvm_vcpu_events,
+    CpuId, Msrs,
+};
 use kvm_ioctls::*;
 use libc::{c_void, siginfo_t};
+use serde_derive::{Deserialize, Serialize};
 use std::cmp;
 use std::os::unix::thread::JoinHandleExt;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -121,6 +125,54 @@ pub enum Error {
 
     /// Asking for more vCPUs that we can have
     DesiredVCPUCountExceedsMax,
+
+    /// Failed to get KVM vcpu lapic.
+    VcpuGetLapic(kvm_ioctls::Error),
+
+    /// Failed to set KVM vcpu lapic.
+    VcpuSetLapic(kvm_ioctls::Error),
+
+    /// Failed to get KVM vcpu MP state.
+    VcpuGetMpState(kvm_ioctls::Error),
+
+    /// Failed to set KVM vcpu MP state.
+    VcpuSetMpState(kvm_ioctls::Error),
+
+    /// Failed to get KVM vcpu msrs.
+    VcpuGetMsrs(kvm_ioctls::Error),
+
+    /// Failed to set KVM vcpu msrs.
+    VcpuSetMsrs(kvm_ioctls::Error),
+
+    /// Failed to get KVM vcpu regs.
+    VcpuGetRegs(kvm_ioctls::Error),
+
+    /// Failed to set KVM vcpu regs.
+    VcpuSetRegs(kvm_ioctls::Error),
+
+    /// Failed to get KVM vcpu sregs.
+    VcpuGetSregs(kvm_ioctls::Error),
+
+    /// Failed to set KVM vcpu sregs.
+    VcpuSetSregs(kvm_ioctls::Error),
+
+    /// Failed to get KVM vcpu events.
+    VcpuGetVcpuEvents(kvm_ioctls::Error),
+
+    /// Failed to set KVM vcpu events.
+    VcpuSetVcpuEvents(kvm_ioctls::Error),
+
+    /// Failed to get KVM vcpu FPU.
+    VcpuGetFpu(kvm_ioctls::Error),
+
+    /// Failed to set KVM vcpu FPU.
+    VcpuSetFpu(kvm_ioctls::Error),
+
+    /// Failed to get KVM clock data.
+    VcpuGetClockData(kvm_ioctls::Error),
+
+    /// Failed to set KVM clock data.
+    VcpuSetClockData(kvm_ioctls::Error),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -240,6 +292,18 @@ pub struct Vcpu {
     mmio_bus: Arc<devices::Bus>,
     ioapic: Option<Arc<Mutex<ioapic::Ioapic>>>,
     vm_ts: std::time::Instant,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct VcpuKvmState {
+    msrs: Msrs,
+    vcpu_events: kvm_vcpu_events,
+    mp_state: kvm_mp_state,
+    regs: kvm_regs,
+    sregs: kvm_sregs,
+    fpu: kvm_fpu,
+    lapic_state: kvm_lapic_state,
+    //    clock_data: kvm_clock_data,
 }
 
 impl Vcpu {
@@ -375,6 +439,49 @@ impl Vcpu {
             ts.as_micros()
         );
     }
+
+    #[allow(unused)]
+    fn kvm_state(&self) -> Result<VcpuKvmState> {
+        let mut msrs = arch::x86_64::regs::boot_msr_entries();
+        self.fd.get_msrs(&mut msrs).map_err(Error::VcpuGetMsrs)?;
+
+        let vcpu_events = self
+            .fd
+            .get_vcpu_events()
+            .map_err(Error::VcpuGetVcpuEvents)?;
+        let mp_state = self.fd.get_mp_state().map_err(Error::VcpuGetMpState)?;
+        let regs = self.fd.get_regs().map_err(Error::VcpuGetRegs)?;
+        let sregs = self.fd.get_sregs().map_err(Error::VcpuGetSregs)?;
+        let lapic_state = self.fd.get_lapic().map_err(Error::VcpuGetLapic)?;
+        let fpu = self.fd.get_fpu().map_err(Error::VcpuGetFpu)?;
+
+        Ok(VcpuKvmState {
+            msrs,
+            vcpu_events,
+            mp_state,
+            regs,
+            sregs,
+            fpu,
+            lapic_state,
+        })
+    }
+
+    #[allow(unused)]
+    fn set_kvm_state(&mut self, state: &VcpuKvmState) -> Result<()> {
+        self.fd.set_fpu(&state.fpu).map_err(Error::VcpuSetFpu)?;
+        self.fd
+            .set_lapic(&state.lapic_state)
+            .map_err(Error::VcpuSetLapic)?;
+        self.fd
+            .set_sregs(&state.sregs)
+            .map_err(Error::VcpuSetSregs)?;
+        self.fd.set_regs(&state.regs).map_err(Error::VcpuSetRegs)?;
+        self.fd
+            .set_mp_state(state.mp_state)
+            .map_err(Error::VcpuSetMpState)?;
+        self.fd.set_msrs(&state.msrs).map_err(Error::VcpuSetMsrs)?;
+        Ok(())
+    }
 }
 
 pub struct CpuManager {
@@ -496,6 +603,11 @@ impl VcpuState {
             handle.thread().unpark()
         }
     }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CpuManagerKvmState {
+    clock_data: kvm_clock_data,
 }
 
 impl CpuManager {
@@ -748,6 +860,21 @@ impl CpuManager {
         });
 
         madt
+    }
+
+    #[allow(unused)]
+    fn kvm_state(&self) -> Result<CpuManagerKvmState> {
+        let clock_data = self.fd.get_clock().map_err(Error::VcpuGetClockData)?;
+
+        Ok(CpuManagerKvmState { clock_data })
+    }
+
+    #[allow(unused)]
+    fn set_kvm_state(&mut self, state: &CpuManagerKvmState) -> Result<()> {
+        self.fd
+            .set_clock(&state.clock_data)
+            .map_err(Error::VcpuSetMsrs)?;
+        Ok(())
     }
 }
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -12,6 +12,7 @@
 //
 
 use crate::device_manager::DeviceManager;
+use crate::CPU_MANAGER_SNAPSHOT_ID;
 #[cfg(feature = "acpi")]
 use acpi_tables::{aml, aml::Aml, sdt::SDT};
 use anyhow::anyhow;
@@ -1253,7 +1254,6 @@ impl Pausable for CpuManager {
     }
 }
 
-const CPU_MANAGER_SNAPSHOT_ID: &str = "cpu-manager";
 impl Snapshotable for CpuManager {
     fn id(&self) -> String {
         CPU_MANAGER_SNAPSHOT_ID.to_string()

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -41,6 +41,10 @@ use vm_migration::{
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::{register_signal_handler, SIGRTMIN};
 
+// CPUID feature bits
+const TSC_DEADLINE_TIMER_ECX_BIT: u8 = 24; // tsc deadline timer ecx bit.
+const HYPERVISOR_ECX_BIT: u8 = 31; // Hypervisor ecx bit.
+
 // Debug I/O port
 #[cfg(target_arch = "x86_64")]
 const DEBUG_IOPORT: u16 = 0x80;
@@ -93,6 +97,9 @@ pub enum Error {
 
     /// Cannot spawn a new vCPU thread.
     VcpuSpawn(io::Error),
+
+    /// Cannot patch the CPU ID
+    PatchCpuId(kvm_ioctls::Error),
 
     #[cfg(target_arch = "x86_64")]
     /// Error configuring the general purpose registers
@@ -670,14 +677,15 @@ impl CpuManager {
         max_vcpus: u8,
         device_manager: &Arc<Mutex<DeviceManager>>,
         guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
+        kvm: &Kvm,
         fd: Arc<VmFd>,
-        cpuid: CpuId,
         reset_evt: EventFd,
     ) -> Result<Arc<Mutex<CpuManager>>> {
         let mut vcpu_states = Vec::with_capacity(usize::from(max_vcpus));
         vcpu_states.resize_with(usize::from(max_vcpus), VcpuState::default);
 
         let device_manager = device_manager.lock().unwrap();
+        let cpuid = CpuManager::patch_cpuid(kvm)?;
         let cpu_manager = Arc::new(Mutex::new(CpuManager {
             boot_vcpus,
             max_vcpus,
@@ -710,6 +718,41 @@ impl CpuManager {
             .map_err(Error::BusError)?;
 
         Ok(cpu_manager)
+    }
+
+    fn patch_cpuid(kvm: &Kvm) -> Result<CpuId> {
+        let mut cpuid_patches = Vec::new();
+
+        // Patch tsc deadline timer bit
+        cpuid_patches.push(CpuidPatch {
+            function: 1,
+            index: 0,
+            flags_bit: None,
+            eax_bit: None,
+            ebx_bit: None,
+            ecx_bit: Some(TSC_DEADLINE_TIMER_ECX_BIT),
+            edx_bit: None,
+        });
+
+        // Patch hypervisor bit
+        cpuid_patches.push(CpuidPatch {
+            function: 1,
+            index: 0,
+            flags_bit: None,
+            eax_bit: None,
+            ebx_bit: None,
+            ecx_bit: Some(HYPERVISOR_ECX_BIT),
+            edx_bit: None,
+        });
+
+        // Supported CPUID
+        let mut cpuid = kvm
+            .get_supported_cpuid(kvm_bindings::KVM_MAX_CPUID_ENTRIES)
+            .map_err(Error::PatchCpuId)?;
+
+        CpuidPatch::patch_cpuid(&mut cpuid, cpuid_patches);
+
+        Ok(cpuid)
     }
 
     fn activate_vcpus(&mut self, desired_vcpus: u8, entry_point: Option<EntryPoint>) -> Result<()> {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -19,6 +19,7 @@ use crate::interrupt::{
     KvmLegacyUserspaceInterruptManager, KvmMsiInterruptManager, KvmRoutingEntry,
 };
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
+use crate::DEVICE_MANAGER_SNAPSHOT_ID;
 #[cfg(feature = "acpi")]
 use acpi_tables::{aml, aml::Aml};
 use anyhow::anyhow;
@@ -2390,7 +2391,6 @@ impl Pausable for DeviceManager {
     }
 }
 
-const DEVICE_MANAGER_SNAPSHOT_ID: &str = "device-manager";
 impl Snapshotable for DeviceManager {
     fn id(&self) -> String {
         DEVICE_MANAGER_SNAPSHOT_ID.to_string()

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -551,7 +551,6 @@ impl DeviceManager {
     pub fn new(
         vm_fd: Arc<VmFd>,
         config: Arc<Mutex<VmConfig>>,
-        allocator: Arc<Mutex<SystemAllocator>>,
         memory_manager: Arc<Mutex<MemoryManager>>,
         _exit_evt: &EventFd,
         reset_evt: &EventFd,
@@ -566,7 +565,7 @@ impl DeviceManager {
         let mut cmdline_additions = Vec::new();
 
         let address_manager = Arc::new(AddressManager {
-            allocator,
+            allocator: memory_manager.lock().unwrap().allocator(),
             io_bus: Arc::new(devices::Bus::new()),
             mmio_bus: Arc::new(devices::Bus::new()),
             vm_fd: vm_fd.clone(),

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -592,6 +592,7 @@ impl DeviceManager {
 
         let ioapic =
             DeviceManager::add_ioapic(&address_manager, Arc::clone(&msi_interrupt_manager))?;
+        let ioapic_migratable = Arc::clone(&ioapic) as Arc<Mutex<dyn Migratable>>;
         bus_devices.push(Arc::clone(&ioapic) as Arc<Mutex<dyn BusDevice>>);
 
         // Now we can create the legacy interrupt manager, which needs the freshly
@@ -651,6 +652,8 @@ impl DeviceManager {
 
         device_manager
             .add_legacy_devices(reset_evt.try_clone().map_err(DeviceManagerError::EventFd)?)?;
+
+        device_manager.add_migratable_device(ioapic_migratable);
 
         #[cfg(feature = "acpi")]
         {
@@ -981,6 +984,8 @@ impl DeviceManager {
                 .io_bus
                 .insert(serial.clone(), 0x3f8, 0x8)
                 .map_err(DeviceManagerError::BusError)?;
+
+            self.add_migratable_device(Arc::clone(&serial) as Arc<Mutex<dyn Migratable>>);
 
             Some(serial)
         } else {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -51,11 +51,11 @@ use vm_allocator::SystemAllocator;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, LegacyIrqGroupConfig, MsiIrqGroupConfig,
 };
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::guest_memory::FileOffset;
 use vm_memory::{
     Address, GuestAddress, GuestAddressSpace, GuestRegionMmap, GuestUsize, MmapRegion,
 };
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 #[cfg(feature = "pci_support")]
 use vm_virtio::transport::VirtioPciDevice;
 use vm_virtio::transport::VirtioTransport;
@@ -2374,6 +2374,7 @@ impl Pausable for DeviceManager {
 }
 
 impl Snapshotable for DeviceManager {}
+impl Transportable for DeviceManager {}
 impl Migratable for DeviceManager {}
 
 #[cfg(feature = "pci_support")]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -21,6 +21,7 @@ use crate::interrupt::{
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 #[cfg(feature = "acpi")]
 use acpi_tables::{aml, aml::Aml};
+use anyhow::anyhow;
 #[cfg(feature = "acpi")]
 use arch::layout;
 use arch::layout::{APIC_START, IOAPIC_SIZE, IOAPIC_START};
@@ -55,7 +56,7 @@ use vm_memory::guest_memory::FileOffset;
 use vm_memory::{
     Address, GuestAddress, GuestAddressSpace, GuestRegionMmap, GuestUsize, MmapRegion,
 };
-use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshotable, Transportable};
 #[cfg(feature = "pci_support")]
 use vm_virtio::transport::VirtioPciDevice;
 use vm_virtio::transport::VirtioTransport;
@@ -2389,7 +2390,37 @@ impl Pausable for DeviceManager {
     }
 }
 
-impl Snapshotable for DeviceManager {}
+const DEVICE_MANAGER_SNAPSHOT_ID: &str = "device-manager";
+impl Snapshotable for DeviceManager {
+    fn id(&self) -> String {
+        DEVICE_MANAGER_SNAPSHOT_ID.to_string()
+    }
+
+    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+        let mut snapshot = Snapshot::new(DEVICE_MANAGER_SNAPSHOT_ID);
+
+        // We aggregate all devices snapshot.
+        for dev in self.migratable_devices.values() {
+            let device_snapshot = dev.lock().unwrap().snapshot()?;
+            snapshot.add_snapshot(device_snapshot);
+        }
+
+        Ok(snapshot)
+    }
+
+    fn restore(&mut self, snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
+        for (id, snapshot) in snapshot.snapshots {
+            if let Some(device) = self.migratable_devices.get(&id) {
+                device.lock().unwrap().restore(*snapshot)?;
+            } else {
+                return Err(MigratableError::Restore(anyhow!("Missing device {}", id)));
+            }
+        }
+
+        Ok(())
+    }
+}
+
 impl Transportable for DeviceManager {}
 impl Migratable for DeviceManager {}
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -318,7 +318,13 @@ impl Vmm {
         let exit_evt = self.exit_evt.try_clone().map_err(VmError::EventFdClone)?;
         let reset_evt = self.reset_evt.try_clone().map_err(VmError::EventFdClone)?;
 
-        let vm = Vm::new_from_snapshot(&vm_snapshot, exit_evt, reset_evt, self.vmm_path.clone())?;
+        let vm = Vm::new_from_snapshot(
+            &vm_snapshot,
+            exit_evt,
+            reset_evt,
+            self.vmm_path.clone(),
+            source_url,
+        )?;
         self.vm = Some(vm);
 
         // Now we can restore the rest of the VM.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -14,6 +14,7 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 extern crate tempfile;
+extern crate url;
 extern crate vmm_sys_util;
 
 use crate::api::{ApiError, ApiRequest, ApiResponse, ApiResponsePayload, VmInfo, VmmPingResponse};
@@ -37,6 +38,7 @@ pub mod cpu;
 pub mod device_manager;
 pub mod interrupt;
 pub mod memory_manager;
+pub mod migration;
 pub mod seccomp_filters;
 pub mod vm;
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -318,16 +318,10 @@ impl Vmm {
         let exit_evt = self.exit_evt.try_clone().map_err(VmError::EventFdClone)?;
         let reset_evt = self.reset_evt.try_clone().map_err(VmError::EventFdClone)?;
 
-        let vm = Vm::new(
-            Arc::clone(&vm_config),
-            exit_evt,
-            reset_evt,
-            self.vmm_path.clone(),
-        )?;
-
+        let vm = Vm::new_from_snapshot(&vm_snapshot, exit_evt, reset_evt, self.vmm_path.clone())?;
         self.vm = Some(vm);
 
-        // Now we can restore the VM.
+        // Now we can restore the rest of the VM.
         if let Some(ref mut vm) = self.vm {
             vm.restore(vm_snapshot).map_err(VmError::Restore)
         } else {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -676,3 +676,7 @@ impl Vmm {
         Ok(())
     }
 }
+
+const CPU_MANAGER_SNAPSHOT_ID: &str = "cpu-manager";
+const MEMORY_MANAGER_SNAPSHOT_ID: &str = "memory-manager";
+const DEVICE_MANAGER_SNAPSHOT_ID: &str = "device-manager";

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+extern crate anyhow;
 extern crate arc_swap;
 #[macro_use]
 extern crate lazy_static;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -27,7 +27,7 @@ use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, RecvError, SendError, Sender};
 use std::sync::{Arc, Mutex};
 use std::{result, thread};
-use vm_device::Pausable;
+use vm_migration::Pausable;
 use vmm_sys_util::eventfd::EventFd;
 
 pub mod api;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -23,6 +23,7 @@ use vm_memory::{
     GuestMemory, GuestMemoryAtomic, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap,
     GuestUsize, MmapRegion,
 };
+use vm_migration::{Migratable, Pausable, Snapshotable, Transportable};
 
 const HOTPLUG_COUNT: usize = 8;
 
@@ -884,3 +885,8 @@ impl Aml for MemoryManager {
         bytes
     }
 }
+
+impl Pausable for MemoryManager {}
+impl Snapshotable for MemoryManager {}
+impl Transportable for MemoryManager {}
+impl Migratable for MemoryManager {}

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -4,6 +4,7 @@
 //
 
 use crate::config::HotplugMethod;
+use crate::MEMORY_MANAGER_SNAPSHOT_ID;
 #[cfg(feature = "acpi")]
 use acpi_tables::{aml, aml::Aml};
 use anyhow::anyhow;
@@ -911,7 +912,6 @@ pub struct MemoryManagerSnapshotData {
     memory_regions: Vec<MemoryRegion>,
 }
 
-const MEMORY_MANAGER_SNAPSHOT_ID: &str = "memory-manager";
 impl Snapshotable for MemoryManager {
     fn id(&self) -> String {
         MEMORY_MANAGER_SNAPSHOT_ID.to_string()

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -18,10 +18,11 @@ use std::io;
 use std::os::unix::io::FromRawFd;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use url::Url;
 use vm_allocator::SystemAllocator;
 use vm_memory::guest_memory::FileOffset;
 use vm_memory::{
-    mmap::MmapRegionError, Address, Error as MmapError, GuestAddress, GuestAddressSpace,
+    mmap::MmapRegionError, Address, Bytes, Error as MmapError, GuestAddress, GuestAddressSpace,
     GuestMemory, GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemoryMmap, GuestMemoryRegion,
     GuestRegionMmap, GuestUsize, MmapRegion,
 };
@@ -953,5 +954,67 @@ impl Snapshotable for MemoryManager {
     }
 }
 
-impl Transportable for MemoryManager {}
+impl Transportable for MemoryManager {
+    fn send(
+        &self,
+        _snapshot: &Snapshot,
+        destination_url: &str,
+    ) -> std::result::Result<(), MigratableError> {
+        let url = Url::parse(destination_url).map_err(|e| {
+            MigratableError::MigrateSend(anyhow!("Could not parse destination URL: {}", e))
+        })?;
+
+        match url.scheme() {
+            "file" => {
+                let vm_memory_snapshot_path = url
+                    .to_file_path()
+                    .map_err(|_| {
+                        MigratableError::MigrateSend(anyhow!(
+                            "Could not convert file URL to a file path"
+                        ))
+                    })
+                    .and_then(|path| {
+                        if !path.is_dir() {
+                            return Err(MigratableError::MigrateSend(anyhow!(
+                                "Destination is not a directory"
+                            )));
+                        }
+                        Ok(path)
+                    })?;
+
+                if let Some(guest_memory) = &*self.snapshot.lock().unwrap() {
+                    guest_memory.with_regions_mut(|index, region| {
+                        let mut memory_region_path = vm_memory_snapshot_path.clone();
+                        memory_region_path.push(format!("memory-region-{}", index));
+
+                        // Create the snapshot file for the region
+                        let mut memory_region_file = OpenOptions::new()
+                            .read(true)
+                            .write(true)
+                            .create_new(true)
+                            .open(memory_region_path)
+                            .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+
+                        guest_memory
+                            .write_to(
+                                region.start_addr(),
+                                &mut memory_region_file,
+                                region.len().try_into().unwrap(),
+                            )
+                            .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+
+                        Ok(())
+                    })?;
+                }
+            }
+            _ => {
+                return Err(MigratableError::MigrateSend(anyhow!(
+                    "Unsupported VM transport URL scheme: {}",
+                    url.scheme()
+                )))
+            }
+        }
+        Ok(())
+    }
+}
 impl Migratable for MemoryManager {}

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -6,6 +6,7 @@
 use crate::config::HotplugMethod;
 #[cfg(feature = "acpi")]
 use acpi_tables::{aml, aml::Aml};
+use anyhow::anyhow;
 use arch::RegionType;
 use devices::BusDevice;
 use kvm_bindings::{kvm_userspace_memory_region, KVM_MEM_READONLY};
@@ -20,10 +21,13 @@ use vm_allocator::SystemAllocator;
 use vm_memory::guest_memory::FileOffset;
 use vm_memory::{
     mmap::MmapRegionError, Address, Error as MmapError, GuestAddress, GuestAddressSpace,
-    GuestMemory, GuestMemoryAtomic, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap,
-    GuestUsize, MmapRegion,
+    GuestMemory, GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemoryMmap, GuestMemoryRegion,
+    GuestRegionMmap, GuestUsize, MmapRegion,
 };
-use vm_migration::{Migratable, Pausable, Snapshotable, Transportable};
+use vm_migration::{
+    Migratable, MigratableError, Pausable, Snapshot, SnapshotDataSection, Snapshotable,
+    Transportable,
+};
 
 const HOTPLUG_COUNT: usize = 8;
 
@@ -53,6 +57,7 @@ pub struct MemoryManager {
     next_hotplug_slot: usize,
     pub virtiomem_region: Option<Arc<GuestRegionMmap>>,
     pub virtiomem_resize: Option<vm_virtio::Resize>,
+    snapshot: Mutex<Option<GuestMemoryLoadGuard<GuestMemoryMmap>>>,
 }
 
 #[derive(Debug)]
@@ -288,6 +293,7 @@ impl MemoryManager {
             next_hotplug_slot: 0,
             virtiomem_region: virtiomem_region.clone(),
             virtiomem_resize,
+            snapshot: Mutex::new(None),
         }));
 
         guest_memory.memory().with_regions(|_, region| {
@@ -887,6 +893,65 @@ impl Aml for MemoryManager {
 }
 
 impl Pausable for MemoryManager {}
-impl Snapshotable for MemoryManager {}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "GuestAddress")]
+pub struct GuestAddressDef(pub u64);
+
+#[derive(Serialize, Deserialize)]
+pub struct MemoryRegion {
+    backing_file: PathBuf,
+    #[serde(with = "GuestAddressDef")]
+    start_addr: GuestAddress,
+    size: GuestUsize,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct MemoryManagerSnapshotData {
+    memory_regions: Vec<MemoryRegion>,
+}
+
+const MEMORY_MANAGER_SNAPSHOT_ID: &str = "memory-manager";
+impl Snapshotable for MemoryManager {
+    fn id(&self) -> String {
+        MEMORY_MANAGER_SNAPSHOT_ID.to_string()
+    }
+
+    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+        let mut memory_manager_snapshot = Snapshot::new(MEMORY_MANAGER_SNAPSHOT_ID);
+        let guest_memory = self.guest_memory.memory();
+
+        let mut memory_regions: Vec<MemoryRegion> = Vec::with_capacity(10);
+
+        guest_memory.with_regions_mut(|index, region| {
+            if region.len() == 0 {
+                return Err(MigratableError::Snapshot(anyhow!("Zero length region")));
+            }
+
+            memory_regions.push(MemoryRegion {
+                backing_file: PathBuf::from(format!("memory-region-{}", index)),
+                start_addr: region.start_addr(),
+                size: region.len(),
+            });
+
+            Ok(())
+        })?;
+
+        let snapshot_data_section =
+            serde_json::to_vec(&MemoryManagerSnapshotData { memory_regions })
+                .map_err(|e| MigratableError::Snapshot(e.into()))?;
+
+        memory_manager_snapshot.add_data_section(SnapshotDataSection {
+            id: format!("{}-section", MEMORY_MANAGER_SNAPSHOT_ID),
+            snapshot: snapshot_data_section,
+        });
+
+        let mut memory_snapshot = self.snapshot.lock().unwrap();
+        *memory_snapshot = Some(guest_memory);
+
+        Ok(memory_manager_snapshot)
+    }
+}
+
 impl Transportable for MemoryManager {}
 impl Migratable for MemoryManager {}

--- a/vmm/src/migration.rs
+++ b/vmm/src/migration.rs
@@ -1,0 +1,61 @@
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::anyhow;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::PathBuf;
+use url::Url;
+use vm_migration::{MigratableError, Snapshot};
+
+pub const VM_SNAPSHOT_FILE: &str = "vm.json";
+
+pub fn url_to_path(url: &Url) -> std::result::Result<PathBuf, MigratableError> {
+    match url.scheme() {
+        "file" => url
+            .to_file_path()
+            .map_err(|_| {
+                MigratableError::MigrateSend(anyhow!("Could not convert file URL to a file path"))
+            })
+            .and_then(|path| {
+                if !path.is_dir() {
+                    return Err(MigratableError::MigrateSend(anyhow!(
+                        "Destination is not a directory"
+                    )));
+                }
+                Ok(path)
+            }),
+
+        _ => Err(MigratableError::MigrateSend(anyhow!(
+            "URL scheme is not file: {}",
+            url.scheme()
+        ))),
+    }
+}
+
+pub fn recv_vm_snapshot(source_url: &str) -> std::result::Result<Snapshot, MigratableError> {
+    let url = Url::parse(source_url).map_err(|e| {
+        MigratableError::MigrateSend(anyhow!("Could not parse destination URL: {}", e))
+    })?;
+
+    match url.scheme() {
+        "file" => {
+            let mut vm_snapshot_path = url_to_path(&url)?;
+            vm_snapshot_path.push(VM_SNAPSHOT_FILE);
+
+            // Try opening the snapshot file
+            let vm_snapshot_file =
+                File::open(vm_snapshot_path).map_err(|e| MigratableError::MigrateSend(e.into()))?;
+            let vm_snapshot_reader = BufReader::new(vm_snapshot_file);
+            let vm_snapshot = serde_json::from_reader(vm_snapshot_reader)
+                .map_err(|e| MigratableError::MigrateReceive(e.into()))?;
+
+            Ok(vm_snapshot)
+        }
+        _ => Err(MigratableError::MigrateSend(anyhow!(
+            "Unsupported VM transport URL scheme: {}",
+            url.scheme()
+        ))),
+    }
+}

--- a/vmm/src/migration.rs
+++ b/vmm/src/migration.rs
@@ -2,10 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::config::VmConfig;
+use crate::vm::{VmSnapshot, VM_SNAPSHOT_ID};
 use anyhow::anyhow;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use url::Url;
 use vm_migration::{MigratableError, Snapshot};
 
@@ -58,4 +61,26 @@ pub fn recv_vm_snapshot(source_url: &str) -> std::result::Result<Snapshot, Migra
             url.scheme()
         ))),
     }
+}
+
+pub fn vm_config_from_snapshot(
+    snapshot: &Snapshot,
+) -> std::result::Result<Arc<Mutex<VmConfig>>, MigratableError> {
+    if let Some(vm_section) = snapshot
+        .snapshot_data
+        .get(&format!("{}-section", VM_SNAPSHOT_ID))
+    {
+        let vm_snapshot: VmSnapshot =
+            serde_json::from_slice(&vm_section.snapshot).map_err(|e| {
+                MigratableError::Restore(anyhow!("Could not deserialize VM snapshot {}", e))
+            })?;
+
+        //        self.set_state(&ioapic_state);
+
+        return Ok(vm_snapshot.config);
+    }
+
+    Err(MigratableError::Restore(anyhow!(
+        "Could not find VM config snapshot section"
+    )))
 }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -53,6 +53,7 @@ const KVM_CREATE_VCPU: u64 = 0xae41;
 const KVM_SET_TSS_ADDR: u64 = 0xae47;
 const KVM_CREATE_IRQCHIP: u64 = 0xae60;
 const KVM_RUN: u64 = 0xae80;
+const KVM_SET_MP_STATE: u64 = 0x4004_ae99;
 const KVM_SET_GSI_ROUTING: u64 = 0x4008_ae6a;
 const KVM_SET_MSRS: u64 = 0x4008_ae89;
 const KVM_SET_CPUID2: u64 = 0x4008_ae90;
@@ -64,11 +65,20 @@ const KVM_IOEVENTFD: u64 = 0x4040_ae79;
 const KVM_ENABLE_CAP: u64 = 0x4068_aea3;
 const KVM_SET_REGS: u64 = 0x4090_ae82;
 const KVM_SET_SREGS: u64 = 0x4138_ae84;
+const KVM_SET_XCRS: u64 = 0x4188_aea7;
 const KVM_SET_FPU: u64 = 0x41a0_ae8d;
 const KVM_SET_LAPIC: u64 = 0x4400_ae8f;
+const KVM_SET_XSAVE: u64 = 0x5000_aea5;
+const KVM_GET_MP_STATE: u64 = 0x8004_ae98;
+const KVM_GET_VCPU_EVENTS: u64 = 0x8040_ae9f;
+const KVM_GET_REGS: u64 = 0x8090_ae81;
 const KVM_GET_SREGS: u64 = 0x8138_ae83;
+const KVM_GET_XCRS: u64 = 0x8188_aea6;
+const KVM_GET_FPU: u64 = 0x81a0_ae8c;
 const KVM_GET_LAPIC: u64 = 0x8400_ae8e;
+const KVM_GET_XSAVE: u64 = 0x9000_aea4;
 const KVM_GET_SUPPORTED_CPUID: u64 = 0xc008_ae05;
+const KVM_GET_MSRS: u64 = 0xc008_ae88;
 const KVM_CREATE_DEVICE: u64 = 0xc00c_aee0;
 
 // See include/uapi/linux/if_tun.h in the kernel code.
@@ -111,10 +121,17 @@ fn create_vmm_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_VM)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_ENABLE_CAP)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_API_VERSION,)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_FPU)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_LAPIC)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MP_STATE)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MSRS)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_REGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_SREGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_SUPPORTED_CPUID,)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_VCPU_EVENTS,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_VCPU_MMAP_SIZE,)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_XSAVE,)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_XCRS,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_IOEVENTFD)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_IRQFD)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_RUN)?],
@@ -123,11 +140,14 @@ fn create_vmm_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_FPU)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_GSI_ROUTING)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_LAPIC)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_MP_STATE)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_MSRS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_REGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_SREGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_TSS_ADDR,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_USER_MEMORY_REGION,)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XSAVE,)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XCRS,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, SIOCSIFADDR)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, SIOCSIFFLAGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, SIOCSIFNETMASK)?],

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -319,11 +319,6 @@ impl Vm {
             None => None,
         };
 
-        let ioapic = GsiApic::new(
-            X86_64_IRQ_BASE,
-            ioapic::NUM_IOAPIC_PINS as u32 - X86_64_IRQ_BASE,
-        );
-
         // Let's allocate 64 GiB of addressable MMIO space, starting at 0.
         let allocator = Arc::new(Mutex::new(
             SystemAllocator::new(
@@ -333,7 +328,10 @@ impl Vm {
                 1 << get_host_cpu_phys_bits(),
                 layout::MEM_32BIT_RESERVED_START,
                 layout::MEM_32BIT_DEVICES_SIZE,
-                vec![ioapic],
+                vec![GsiApic::new(
+                    X86_64_IRQ_BASE,
+                    ioapic::NUM_IOAPIC_PINS as u32 - X86_64_IRQ_BASE,
+                )],
             )
             .ok_or(Error::CreateSystemAllocator)?,
         ));

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -28,11 +28,11 @@ extern crate vm_virtio;
 use crate::config::{DeviceConfig, DiskConfig, HotplugMethod, NetConfig, PmemConfig, VmConfig};
 use crate::cpu;
 use crate::device_manager::{get_win_size, Console, DeviceManager, DeviceManagerError};
-use crate::memory_manager::{get_host_cpu_phys_bits, Error as MemoryManagerError, MemoryManager};
+use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 use crate::migration::{url_to_path, VM_SNAPSHOT_FILE};
 use crate::{CPU_MANAGER_SNAPSHOT_ID, DEVICE_MANAGER_SNAPSHOT_ID, MEMORY_MANAGER_SNAPSHOT_ID};
 use anyhow::anyhow;
-use arch::{layout, BootProtocol, EntryPoint};
+use arch::{BootProtocol, EntryPoint};
 use devices::{ioapic, HotPlugNotificationFlags};
 use kvm_bindings::{kvm_enable_cap, kvm_userspace_memory_region, KVM_CAP_SPLIT_IRQCHIP};
 use kvm_ioctls::*;
@@ -50,10 +50,9 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
 use std::{result, str, thread};
 use url::Url;
-use vm_allocator::{GsiApic, SystemAllocator};
 use vm_memory::{
     Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryMmap,
-    GuestMemoryRegion, GuestUsize,
+    GuestMemoryRegion,
 };
 use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, SnapshotDataSection, Snapshotable,
@@ -61,8 +60,6 @@ use vm_migration::{
 };
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::terminal::Terminal;
-
-const X86_64_IRQ_BASE: u32 = 5;
 
 // 64 bit direct boot entry offset for bzImage
 const KERNEL_64BIT_ENTRY_OFFSET: u64 = 0x200;
@@ -116,9 +113,6 @@ pub enum Error {
 
     /// Cannot setup terminal in canonical mode.
     SetTerminalCanon(vmm_sys_util::errno::Error),
-
-    /// Cannot create the system allocator
-    CreateSystemAllocator,
 
     /// Failed parsing network parameters
     ParseNetworkParameters,
@@ -319,35 +313,13 @@ impl Vm {
             None => None,
         };
 
-        // Let's allocate 64 GiB of addressable MMIO space, starting at 0.
-        let allocator = Arc::new(Mutex::new(
-            SystemAllocator::new(
-                GuestAddress(0),
-                1 << 16 as GuestUsize,
-                GuestAddress(0),
-                1 << get_host_cpu_phys_bits(),
-                layout::MEM_32BIT_RESERVED_START,
-                layout::MEM_32BIT_DEVICES_SIZE,
-                vec![GsiApic::new(
-                    X86_64_IRQ_BASE,
-                    ioapic::NUM_IOAPIC_PINS as u32 - X86_64_IRQ_BASE,
-                )],
-            )
-            .ok_or(Error::CreateSystemAllocator)?,
-        ));
-
-        let memory_manager = MemoryManager::new(
-            allocator.clone(),
-            fd.clone(),
-            &config.lock().unwrap().memory.clone(),
-        )
-        .map_err(Error::MemoryManager)?;
+        let memory_manager = MemoryManager::new(fd.clone(), &config.lock().unwrap().memory.clone())
+            .map_err(Error::MemoryManager)?;
 
         let guest_memory = memory_manager.lock().unwrap().guest_memory();
         let device_manager = DeviceManager::new(
             fd.clone(),
             config.clone(),
-            allocator,
             memory_manager.clone(),
             &exit_evt,
             &reset_evt,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -180,6 +180,12 @@ pub enum Error {
 
     /// Eventfd write error
     EventfdError(std::io::Error),
+
+    /// Cannot snapshot VM
+    Snapshot(MigratableError),
+
+    /// Cannot send VM snapshot
+    SnapshotSend(MigratableError),
 }
 pub type Result<T> = result::Result<T, Error>;
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -336,21 +336,14 @@ impl Vm {
             .ok_or(Error::CreateSystemAllocator)?,
         ));
 
-        let memory_config = config.lock().unwrap().memory.clone();
-
         let memory_manager = MemoryManager::new(
             allocator.clone(),
             fd.clone(),
-            memory_config.size,
-            memory_config.hotplug_method,
-            memory_config.hotplug_size,
-            &memory_config.file,
-            memory_config.mergeable,
+            &config.lock().unwrap().memory.clone(),
         )
         .map_err(Error::MemoryManager)?;
 
         let guest_memory = memory_manager.lock().unwrap().guest_memory();
-
         let device_manager = DeviceManager::new(
             fd.clone(),
             config.clone(),

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -305,14 +305,6 @@ impl Vm {
     ) -> Result<Self> {
         let (kvm, fd) = Vm::kvm_new()?;
 
-        let kernel = File::open(&config.lock().unwrap().kernel.as_ref().unwrap().path)
-            .map_err(Error::KernelFile)?;
-
-        let initramfs = match &config.lock().unwrap().initramfs {
-            Some(initramfs) => Some(File::open(&initramfs.path).map_err(Error::InitramfsFile)?),
-            None => None,
-        };
-
         let memory_manager = MemoryManager::new(fd.clone(), &config.lock().unwrap().memory.clone())
             .map_err(Error::MemoryManager)?;
 
@@ -337,6 +329,14 @@ impl Vm {
         .map_err(Error::CpuManager)?;
 
         let on_tty = unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0;
+        let kernel = File::open(&config.lock().unwrap().kernel.as_ref().unwrap().path)
+            .map_err(Error::KernelFile)?;
+
+        let initramfs = match &config.lock().unwrap().initramfs {
+            Some(initramfs) => Some(File::open(&initramfs.path).map_err(Error::InitramfsFile)?),
+            None => None,
+        };
+
         Ok(Vm {
             kernel,
             initramfs,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -29,6 +29,7 @@ use crate::config::{DeviceConfig, DiskConfig, HotplugMethod, NetConfig, PmemConf
 use crate::cpu;
 use crate::device_manager::{get_win_size, Console, DeviceManager, DeviceManagerError};
 use crate::memory_manager::{get_host_cpu_phys_bits, Error as MemoryManagerError, MemoryManager};
+use crate::migration::{url_to_path, VM_SNAPSHOT_FILE};
 use crate::{CPU_MANAGER_SNAPSHOT_ID, DEVICE_MANAGER_SNAPSHOT_ID, MEMORY_MANAGER_SNAPSHOT_ID};
 use anyhow::anyhow;
 use arch::{layout, BootProtocol, EntryPoint};
@@ -41,12 +42,14 @@ use linux_loader::loader::KernelLoader;
 use signal_hook::{iterator::Signals, SIGINT, SIGTERM, SIGWINCH};
 use std::convert::TryInto;
 use std::ffi::CString;
-use std::fs::File;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
 use std::io::{self, Seek, SeekFrom};
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
 use std::{result, str, thread};
+use url::Url;
 use vm_allocator::{GsiApic, SystemAllocator};
 use vm_memory::{
     Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryMmap,
@@ -1002,7 +1005,7 @@ impl Snapshotable for Vm {
 
         vm_snapshot.add_snapshot(self.cpu_manager.lock().unwrap().snapshot()?);
         vm_snapshot.add_snapshot(self.memory_manager.lock().unwrap().snapshot()?);
-        vm_snapshot.add_snapshot(self.device_manager.snapshot()?);
+        vm_snapshot.add_snapshot(self.device_manager.lock().unwrap().snapshot()?);
         vm_snapshot.add_data_section(SnapshotDataSection {
             id: format!("{}-section", VM_SNAPSHOT_ID),
             snapshot: vm_snapshot_data,
@@ -1025,6 +1028,8 @@ impl Snapshotable for Vm {
 
         if let Some(device_manager_snapshot) = snapshot.snapshots.get(DEVICE_MANAGER_SNAPSHOT_ID) {
             self.device_manager
+                .lock()
+                .unwrap()
                 .restore(*device_manager_snapshot.clone())?;
         } else {
             return Err(MigratableError::Restore(anyhow!(
@@ -1047,7 +1052,61 @@ impl Snapshotable for Vm {
     }
 }
 
-impl Transportable for Vm {}
+impl Transportable for Vm {
+    fn send(
+        &self,
+        snapshot: &Snapshot,
+        destination_url: &str,
+    ) -> std::result::Result<(), MigratableError> {
+        let url = Url::parse(destination_url).map_err(|e| {
+            MigratableError::MigrateSend(anyhow!("Could not parse destination URL: {}", e))
+        })?;
+
+        match url.scheme() {
+            "file" => {
+                let mut vm_snapshot_path = url_to_path(&url)?;
+                vm_snapshot_path.push(VM_SNAPSHOT_FILE);
+
+                // Create the snapshot file
+                let mut vm_snapshot_file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create_new(true)
+                    .open(vm_snapshot_path)
+                    .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+
+                // Serialize and write the snapshot
+                let vm_snapshot = serde_json::to_vec(snapshot)
+                    .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+
+                vm_snapshot_file
+                    .write(&vm_snapshot)
+                    .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+
+                // Tell the memory manager to also send/write its own snapshot.
+                if let Some(memory_manager_snapshot) =
+                    snapshot.snapshots.get(MEMORY_MANAGER_SNAPSHOT_ID)
+                {
+                    self.memory_manager
+                        .lock()
+                        .unwrap()
+                        .send(&*memory_manager_snapshot.clone(), destination_url)?;
+                } else {
+                    return Err(MigratableError::Restore(anyhow!(
+                        "Missing memory manager snapshot"
+                    )));
+                }
+            }
+            _ => {
+                return Err(MigratableError::MigrateSend(anyhow!(
+                    "Unsupported VM transport URL scheme: {}",
+                    url.scheme()
+                )))
+            }
+        }
+        Ok(())
+    }
+}
 impl Migratable for Vm {}
 
 #[cfg(test)]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -11,7 +11,6 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 //
 
-extern crate anyhow;
 extern crate arch;
 extern crate devices;
 extern crate epoll;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -316,7 +316,6 @@ impl Vm {
         let memory_manager = MemoryManager::new(fd.clone(), &config.lock().unwrap().memory.clone())
             .map_err(Error::MemoryManager)?;
 
-        let guest_memory = memory_manager.lock().unwrap().guest_memory();
         let device_manager = DeviceManager::new(
             fd.clone(),
             config.clone(),
@@ -327,21 +326,17 @@ impl Vm {
         )
         .map_err(Error::DeviceManager)?;
 
-        let on_tty = unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0;
-
-        let boot_vcpus = config.lock().unwrap().cpus.boot_vcpus;
-        let max_vcpus = config.lock().unwrap().cpus.max_vcpus;
         let cpu_manager = cpu::CpuManager::new(
-            boot_vcpus,
-            max_vcpus,
+            &config.lock().unwrap().cpus.clone(),
             &device_manager,
-            guest_memory,
+            memory_manager.lock().unwrap().guest_memory(),
             &kvm,
             fd,
             reset_evt,
         )
         .map_err(Error::CpuManager)?;
 
+        let on_tty = unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0;
         Ok(Vm {
             kernel,
             initramfs,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -145,6 +145,9 @@ pub enum Error {
     /// VM is not created
     VmNotCreated,
 
+    /// VM is already created
+    VmAlreadyCreated,
+
     /// VM is not running
     VmNotRunning,
 
@@ -189,6 +192,9 @@ pub enum Error {
 
     /// Cannot snapshot VM
     Snapshot(MigratableError),
+
+    /// Cannot restore VM
+    Restore(MigratableError),
 
     /// Cannot send VM snapshot
     SnapshotSend(MigratableError),
@@ -980,10 +986,10 @@ impl Pausable for Vm {
 
 #[derive(Serialize, Deserialize)]
 pub struct VmSnapshot {
-    config: Arc<Mutex<VmConfig>>,
+    pub config: Arc<Mutex<VmConfig>>,
 }
 
-const VM_SNAPSHOT_ID: &str = "vm";
+pub const VM_SNAPSHOT_ID: &str = "vm";
 impl Snapshotable for Vm {
     fn id(&self) -> String {
         VM_SNAPSHOT_ID.to_string()

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -375,6 +375,7 @@ impl Vm {
         exit_evt: EventFd,
         reset_evt: EventFd,
         vmm_path: PathBuf,
+        source_url: &str,
     ) -> Result<Self> {
         let (kvm, fd) = Vm::kvm_new()?;
         let config = vm_config_from_snapshot(snapshot).map_err(Error::Restore)?;
@@ -382,8 +383,13 @@ impl Vm {
         let memory_manager = if let Some(memory_manager_snapshot) =
             snapshot.snapshots.get(MEMORY_MANAGER_SNAPSHOT_ID)
         {
-            MemoryManager::new_from_snapshot(memory_manager_snapshot, fd.clone())
-                .map_err(Error::MemoryManager)?
+            MemoryManager::new_from_snapshot(
+                memory_manager_snapshot,
+                fd.clone(),
+                &config.lock().unwrap().memory.clone(),
+                source_url,
+            )
+            .map_err(Error::MemoryManager)?
         } else {
             return Err(Error::Restore(MigratableError::Restore(anyhow!(
                 "Missing memory manager snapshot"

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -297,17 +297,15 @@ impl Vm {
         Ok((kvm, fd))
     }
 
-    pub fn new(
+    fn new_from_memory_manager(
         config: Arc<Mutex<VmConfig>>,
+        memory_manager: Arc<Mutex<MemoryManager>>,
+        fd: Arc<VmFd>,
+        kvm: Kvm,
         exit_evt: EventFd,
         reset_evt: EventFd,
         vmm_path: PathBuf,
     ) -> Result<Self> {
-        let (kvm, fd) = Vm::kvm_new()?;
-
-        let memory_manager = MemoryManager::new(fd.clone(), &config.lock().unwrap().memory.clone())
-            .map_err(Error::MemoryManager)?;
-
         let device_manager = DeviceManager::new(
             fd.clone(),
             config.clone(),
@@ -349,6 +347,27 @@ impl Vm {
             cpu_manager,
             memory_manager,
         })
+    }
+
+    pub fn new(
+        config: Arc<Mutex<VmConfig>>,
+        exit_evt: EventFd,
+        reset_evt: EventFd,
+        vmm_path: PathBuf,
+    ) -> Result<Self> {
+        let (kvm, fd) = Vm::kvm_new()?;
+        let memory_manager = MemoryManager::new(fd.clone(), &config.lock().unwrap().memory.clone())
+            .map_err(Error::MemoryManager)?;
+
+        Vm::new_from_memory_manager(
+            config,
+            memory_manager,
+            fd,
+            kvm,
+            exit_evt,
+            reset_evt,
+            vmm_path,
+        )
     }
 
     fn load_initramfs(&mut self, guest_mem: &GuestMemoryMmap) -> Result<arch::InitramfsConfig> {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -48,11 +48,11 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
 use std::{result, str, thread};
 use vm_allocator::{GsiApic, SystemAllocator};
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{
     Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryMmap,
     GuestMemoryRegion, GuestUsize,
 };
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshotable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::terminal::Terminal;
 
@@ -967,6 +967,7 @@ impl Pausable for Vm {
 }
 
 impl Snapshotable for Vm {}
+impl Transportable for Vm {}
 impl Migratable for Vm {}
 
 #[cfg(test)]


### PR DESCRIPTION
As an initial step, we want to be able to support snapshot and resume on a minimal guest (RAM based block device, no virtio, serial+ioapic only).

Fixes #338

TODO:

* [x] Define the `Snapshotable` trait
* [x] Implement the `Snapshotable` trait for legacy devices (at least serial and ioapic)
* [x] Implement the `Snapshotable` trait for the CPU, device and memory managers
* [x] Define and implement a migration API (internal and HTTP) for snapshot and restore

