### PR TITLE
Allow VMM to mark memory pages as mergeable

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -158,6 +158,10 @@ sudo bash -c "echo 10000 > /sys/kernel/mm/ksm/pages_to_scan"
 sudo bash -c "echo 10 > /sys/kernel/mm/ksm/sleep_millisecs"
 sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 
+# Ensure test binary has the same caps as the cloud-hypervisor one
+cargo test --no-run --features "integration_tests" -- --nocapture
+sudo setcap cap_net_admin+ep target/debug/deps/cloud_hypervisor-*
+
 sudo adduser $USER kvm
 newgrp kvm << EOF
 export RUST_BACKTRACE=1

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -152,6 +152,12 @@ sudo setcap cap_net_admin+ep target/release/vhost_user_net
 # We always copy a fresh version of our binary for our L2 guest.
 cp target/release/cloud-hypervisor $VFIO_DIR
 
+# Enable KSM with some reasonable parameters so that it won't take too long
+# for the memory to be merged between two processes.
+sudo bash -c "echo 10000 > /sys/kernel/mm/ksm/pages_to_scan"
+sudo bash -c "echo 10 > /sys/kernel/mm/ksm/sleep_millisecs"
+sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
+
 sudo adduser $USER kvm
 newgrp kvm << EOF
 export RUST_BACKTRACE=1

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn main() {
                 .long("memory")
                 .help(
                     "Memory parameters \"size=<guest_memory_size>,\
-                     file=<backing_file_path>\"",
+                     file=<backing_file_path>,mergeable=on|off\"",
                 )
                 .default_value(&default_memory)
                 .group("vm-config"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ fn main() {
                 .long("pmem")
                 .help(
                     "Persistent memory parameters \"file=<backing_file_path>,\
-                     size=<persistent_memory_size>,iommu=on|off\"",
+                     size=<persistent_memory_size>,iommu=on|off,mergeable=on|off\"",
                 )
                 .takes_value(true)
                 .min_values(1)

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -226,6 +226,9 @@ components:
           default: 512 MB
         file:
           type: string
+        mergeable:
+          type: boolean
+          default: false
 
     KernelConfig:
       required:

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -322,6 +322,9 @@ components:
         iommu:
           type: boolean
           default: false
+        mergeable:
+          type: boolean
+          default: false
 
     ConsoleConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -455,6 +455,8 @@ pub struct PmemConfig {
     pub size: u64,
     #[serde(default)]
     pub iommu: bool,
+    #[serde(default)]
+    pub mergeable: bool,
 }
 
 impl PmemConfig {
@@ -465,6 +467,7 @@ impl PmemConfig {
         let mut file_str: &str = "";
         let mut size_str: &str = "";
         let mut iommu_str: &str = "";
+        let mut mergeable_str: &str = "";
 
         for param in params_list.iter() {
             if param.starts_with("file=") {
@@ -473,6 +476,8 @@ impl PmemConfig {
                 size_str = &param[5..];
             } else if param.starts_with("iommu=") {
                 iommu_str = &param[6..];
+            } else if param.starts_with("mergeable=") {
+                mergeable_str = &param[10..];
             }
         }
 
@@ -484,6 +489,7 @@ impl PmemConfig {
             file: PathBuf::from(file_str),
             size: parse_size(size_str)?,
             iommu: parse_on_off(iommu_str)?,
+            mergeable: parse_on_off(mergeable_str)?,
         })
     }
 }


### PR DESCRIPTION
In order to let users decide whether or not they want to use KSM on the host, this pull request makes the marking of the memory pages as "mergeable" optional. By default, the pages are not marked as "mergeable", which means the default behavior of the VMM is not modified.
If the user is looking for better memory footprint when running multiple VMs side by side on the same host, KSM can help. By adding the option `mergeable=on` to `--memory` or `--pmem`, one can decide to mark the memory pages as mergeable, hence making them detectable by KSM.

Fixes #436