### PR TITLE
Jenkinsfile: Switch to declarative pipeline format to add a timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,22 +1,32 @@
-stage ("Builds") {
-	node ('bionic') {
+pipeline{
+	agent { node { label 'bionic' } }
+	stages {
 		stage ('Checkout') {
-			checkout scm
+			steps {
+				checkout scm
+			}
 		}
 		stage ('Install system packages') {
-			sh "sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq build-essential mtools libssl-dev pkg-config"
-			sh "sudo apt-get install -yq flex bison libelf-dev qemu-utils qemu-system libglib2.0-dev libpixman-1-dev libseccomp-dev socat"
+			steps {
+				sh "sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq build-essential mtools libssl-dev pkg-config"
+				sh "sudo apt-get install -yq flex bison libelf-dev qemu-utils qemu-system libglib2.0-dev libpixman-1-dev libseccomp-dev socat"
+			}
 		}
 		stage ('Install Rust') {
-			sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"
+			steps {
+				sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"
+			}
 		}
 		stage ('Run unit tests') {
-			sh "scripts/run_unit_tests.sh"
+			steps {
+				sh "scripts/run_unit_tests.sh"
+			}
 		}
 		stage ('Run integration tests') {
-			sh "sudo mount -t tmpfs tmpfs /tmp"
-			sh "scripts/run_integration_tests.sh"
+			steps {
+				sh "sudo mount -t tmpfs tmpfs /tmp"
+				sh "scripts/run_integration_tests.sh"
+			}
 		}
 	}
 }
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline{
 	agent { node { label 'bionic' } }
+	options {
+		timeout(time: 1, unit: 'HOURS')
+	}
 	stages {
 		stage ('Checkout') {
 			steps {


### PR DESCRIPTION
In order to prevent bad builds on the CI consuming excessive resources
set a build timeout of 1 hour. In order to be able to do this it was
necessary to switch to the declarative pipeline syntax.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>