### PR TITLE
[WIP] migration: state migration infrastructure

### DIFF
--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -12,6 +12,7 @@ libc = "0.2.60"
 log = "0.4.8"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
 vmm-sys-util = ">=0.1.1"
+vmm-serde = { git = "https://github.com/jiangliu/vmm-serde", branch = "v1", features = ["export_as_pub"] }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -9,6 +9,7 @@ use crate::{BusDevice, Interrupt};
 use std::collections::VecDeque;
 use std::{io, result};
 use vmm_sys_util::errno::Result;
+use vmm_serde::*;
 
 const LOOP_SIZE: usize = 0x40;
 
@@ -52,6 +53,7 @@ const DEFAULT_BAUD_DIVISOR: u16 = 12; // 9600 bps
 ///
 /// This can optionally write the guest's output to a Write trait object. To send input to the
 /// guest, use `queue_input_bytes`.
+#[vmm_serde::export_as_pub()]
 pub struct Serial {
     interrupt_enable: u8,
     interrupt_identification: u8,

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -15,6 +15,7 @@ extern crate libc;
 extern crate log;
 extern crate vm_memory;
 extern crate vmm_sys_util;
+extern crate vmm_serde;
 
 use std::fs::File;
 use std::{io, result};
@@ -27,7 +28,7 @@ pub mod legacy;
 
 #[cfg(feature = "acpi")]
 pub use self::acpi::AcpiShutdownDevice;
-pub use self::bus::{Bus, BusDevice, Error as BusError};
+pub use self::bus::{Bus, BusDevice, BusDeviceAny, Error as BusError};
 
 pub type DeviceEventT = u16;
 

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -7,7 +7,7 @@ use crate::configuration::{
 };
 use crate::device::{DeviceRelocation, Error as PciDeviceError, PciDevice};
 use byteorder::{ByteOrder, LittleEndian};
-use devices::BusDevice;
+use devices::{BusDevice, BusDeviceAny};
 use std;
 use std::any::Any;
 use std::ops::DerefMut;
@@ -97,7 +97,7 @@ impl PciBus {
 
     pub fn register_mapping(
         &self,
-        dev: Arc<Mutex<dyn BusDevice>>,
+        dev: Arc<Mutex<dyn BusDeviceAny>>,
         io_bus: &devices::Bus,
         mmio_bus: &devices::Bus,
         bars: Vec<(GuestAddress, GuestUsize, PciBarRegionType)>,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -491,6 +491,26 @@ impl DeviceManager {
         })
     }
 
+    pub fn serde_devices(&self) -> String {
+        let devices = self.address_manager.io_bus.devices.read().unwrap();
+        let mut json = String::new();
+
+        for (_range, device) in devices.iter() {
+            let mut guard = device.lock().unwrap();
+
+            if let Some(dev) = guard.as_any().downcast_ref::<devices::legacy::Serial>() {
+                println!("Serial device.");
+                let serial = crate::migration::device_states::serde_serial(dev);
+                json.push_str(&serial);
+            }
+        }
+
+        println!("Serialize device_state result:");
+        println!("{}", json);
+
+        json
+    }
+
     #[allow(unused_variables)]
     fn add_pci_devices(
         vm_info: &VmInfo,

--- a/vmm/src/migration/device_states.rs
+++ b/vmm/src/migration/device_states.rs
@@ -1,0 +1,70 @@
+use std::result;
+use std::collections::VecDeque;
+use std::io::{self};
+
+use serde::{Serialize, Deserialize};
+use vmm_sys_util::eventfd::EventFd;
+
+use devices::Interrupt;
+
+struct EmpInterrupt {
+    event_fd: EventFd,
+}
+
+impl Interrupt for EmpInterrupt {
+    fn deliver(&self) -> result::Result<(), std::io::Error> {
+        self.event_fd.write(1)
+    }
+}
+
+impl EmpInterrupt {
+    fn new(event_fd: EventFd) -> Self {
+        EmpInterrupt { event_fd }
+    }
+}
+
+pub fn empty_irq() -> Box<dyn Interrupt> {
+    Box::new(EmpInterrupt::new(EventFd::new(0).unwrap()))
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "devices::legacy::Serial")]
+pub struct SerialState {
+    pub interrupt_enable: u8,
+    pub interrupt_identification: u8,
+    #[serde(skip, default="empty_irq")]
+    pub interrupt: Box<dyn Interrupt>,
+    pub line_control: u8,
+    pub line_status: u8,
+    pub modem_control: u8,
+    pub modem_status: u8,
+    pub scratch: u8,
+    pub baud_divisor: u16,
+    pub in_buffer: VecDeque<u8>,
+    #[serde(skip)]
+    pub out: Option<Box<dyn io::Write + Send>>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct WrapSerialStates {
+    #[serde(with = "SerialState")]
+    pub serial: devices::legacy::Serial,
+}
+
+pub fn serde_serial(serial: &devices::legacy::Serial) -> String {
+    let serial_state = devices::legacy::Serial {
+        interrupt_enable: serial.interrupt_enable,
+        interrupt_identification: serial.interrupt_identification,
+        interrupt: empty_irq(),
+        line_control: serial.line_control,
+        line_status: serial.line_status,
+        modem_control: serial.modem_control,
+        modem_status: serial.modem_status,
+        scratch: serial.scratch,
+        baud_divisor: serial.baud_divisor,
+        in_buffer: serial.in_buffer.clone(),
+        out: None,
+    };
+    let serial_wrap = WrapSerialStates { serial: serial_state };
+    serde_json::to_string(&serial_wrap).unwrap()
+}

--- a/vmm/src/migration/mod.rs
+++ b/vmm/src/migration/mod.rs
@@ -1,0 +1,52 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::{io, result};
+use std::sync::{Arc, Mutex};
+use crate::api::ApiResponse;
+use crate::migration::state::{MigrationState, MigrationStateError, Migratable};
+
+pub mod state;
+
+/// Errors associated with VM management
+#[derive(Debug)]
+pub enum Error {
+    /// Cannot spawn a new migration thread.
+    MigrationSpawn(io::Error),
+
+    /// Response send error
+    ResponseSend(MigrationStateError),
+
+    /// Request receive error
+    RequestRecv(MigrationStateError),
+}
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Clone)]
+pub struct Migration {
+    state: MigrationState,
+}
+
+impl Migration {
+    pub fn new() -> Result<Self> {
+        Ok(Migration {
+            state: MigrationState::new(),
+        })
+    }
+
+    pub fn insert(&self, idstr: String, comp: Arc<Mutex<dyn Migratable>>) -> ApiResponse {
+        self.state.insert(idstr, comp)
+    }
+
+    pub fn take_snapshot(&self) -> Result<()> {
+        self.state.get_states().expect("Get states fail");
+        Ok(())
+    }
+
+    pub fn restore_snapshot(&self) -> Result<()> {
+        /* TODO in next phase */
+        Ok(())
+    }
+}

--- a/vmm/src/migration/mod.rs
+++ b/vmm/src/migration/mod.rs
@@ -9,6 +9,7 @@ use crate::api::ApiResponse;
 use crate::migration::state::{MigrationState, MigrationStateError, Migratable};
 
 pub mod state;
+pub mod device_states;
 
 /// Errors associated with VM management
 #[derive(Debug)]

--- a/vmm/src/migration/state.rs
+++ b/vmm/src/migration/state.rs
@@ -1,0 +1,80 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::result;
+use std::sync::{Arc, Mutex, RwLock};
+use std::collections::HashMap;
+use crate::api::{ApiResponsePayload, ApiResponse};
+
+/// MigrationState errors are sent back from the receiver through the ApiResponse.
+#[derive(Debug)]
+pub enum MigrationStateError {
+    /// Fail to get migration state.
+    MigrationStateGet,
+
+    /// Fail to load migration state.
+    MigrationStateLoad,
+}
+pub type MigrationStateResult<T> = result::Result<T, MigrationStateError>;
+
+pub struct MigrationComp {
+    comp: Arc<Mutex<dyn Migratable>>,
+    states: Vec<u8>,
+}
+
+#[derive(Clone)]
+pub struct MigrationState {
+    components: Arc<RwLock<HashMap<String, Mutex<MigrationComp>>>>,
+}
+
+impl MigrationState {
+    pub fn new() -> Self {
+        MigrationState {
+            components: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn insert(&self, idstr: String, comp: Arc<Mutex<dyn Migratable>>) -> ApiResponse {
+        println!("Insert migration sender from {}", idstr);
+        let mut map = self.components.write().unwrap();
+        let comp = MigrationComp {
+            comp,
+            states: Vec::new(),
+        };
+
+        map.insert(idstr, Mutex::new(comp));
+
+        /* TODO: check if there is available data in MigrationComp::states. If yes,
+         * it is target VM so return received states as ApiResponsePayload. If
+         * no, it is source VM so return None.
+         */
+        let response = Ok(ApiResponsePayload::Empty);
+
+        response
+    }
+
+    pub fn get_states(&self) -> MigrationStateResult<()> {
+        let map = self.components.read().expect("RwLock poisoned");
+
+        for (idstr, comp) in map.iter() {
+            println!("Get migration states from {}", idstr);
+            let guard = comp.lock().unwrap();
+            let comp = guard.comp.lock().unwrap();
+            let mut states = guard.states.clone();
+
+            if let Some(data) = comp.snapshot() {
+                println!("snapshot result is {}", data);
+                let mut v = data.into_bytes();
+                states.append(&mut v);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub trait Migratable: Send + Sync {
+    fn snapshot(&self) -> Option<String>;
+}

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -715,8 +715,12 @@ impl Vm {
 impl Migratable for Vm {
     fn snapshot(&self) -> Option<String> {
         println!("Vm is taking snapshot.");
-        let config = serde_json::to_string_pretty(&self.config).unwrap();
-        Some(config)
+        let mut vm_states = serde_json::to_string_pretty(&self.config).unwrap();
+        let device_states = self.devices.serde_devices();
+
+        vm_states.push_str(&device_states);
+
+        Some(vm_states)
     }
 }
 


### PR DESCRIPTION
To achieve live migration, live upgrading, snapshot and so on, we need be able to get and restore VM states. This patch set establish "migration" module under "vmm" to handle states.

The first patch creates "migration" module under "vmm" and implements part of the state migration infrastructure. In the future, we may move migration module out as a standalone crate.

The second patch adds new Api request to register component, e.g. Vm. Base on Api, introduce 'MigrationRegister' ApiRequest to be able to make component register itself to a hash map. And, introduce 'MigrationState' ApiResponsePayloads to be able to handle states restore action. Furthermore, implement the functionality to handle the request and response in 'vmm'.

The last patch enables serialization for legacy serial device states. It uses Any/vmm_serde/serde features to avoid modifying external crates (relative to vmm crate) too much.