### PR TITLE
openapi: make context ID vsock int64

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -395,6 +395,7 @@ components:
       properties:
         cid:
           type: integer
+          format: int64
           minimum: 3
           description: Guest Vsock CID
         sock:


### PR DESCRIPTION
context ID on vsock man defines a 32-bits value, openapi default integer
is a signed 32-bits value.

This could lead to miss one bit during castings for typed client
implmentations. Lets increase the range of valid values by requesting an
int64.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>