### PR TITLE
cargo: set cloud-hypervisor as default crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "cloud-hypervisor"
 version = "0.3.0"
 authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
+default-run = "cloud-hypervisor"
 
 [dependencies]
 clap = "2.33.0"


### PR DESCRIPTION
cloud-hypervisor is the main create, useful to do `cargo run`.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>