### PR TITLE
[DNM] vfio: Disable interrupts correctly

### DIFF
--- a/vfio/src/vfio_device.rs
+++ b/vfio/src/vfio_device.rs
@@ -673,7 +673,9 @@ impl VfioDevice {
             return Err(VfioError::VfioDeviceSetIrq);
         }
 
-        Ok(())
+        // Unmask the interrupts after enabling them. This ensures the enabled
+        // interrupts won't be ignored.
+        self.unmask_irq(irq_index)
     }
 
     /// Disables a VFIO device IRQs
@@ -682,6 +684,28 @@ impl VfioDevice {
     ///
     /// * `irq_index` - The type (INTX, MSI or MSI-X) of interrupts to disable.
     pub fn disable_irq(&self, irq_index: u32) -> Result<()> {
+        // Mask the interrupts before disabling them. This is required to
+        // prevent spurious interrupt from being triggered after the eventfds
+        // have been unassigned.
+        self.mask_irq(irq_index)?;
+
+        let mut irq_set = vec_with_array_field::<vfio_irq_set, u32>(0);
+        irq_set[0].argsz = mem::size_of::<vfio_irq_set>() as u32;
+        irq_set[0].flags = VFIO_IRQ_SET_ACTION_TRIGGER | VFIO_IRQ_SET_DATA_NONE;
+        irq_set[0].index = irq_index;
+        irq_set[0].start = 0;
+        irq_set[0].count = 0;
+
+        // Safe as we are the owner of self and irq_set which are valid value
+        let ret = unsafe { ioctl_with_ref(self, VFIO_DEVICE_SET_IRQS(), &irq_set[0]) };
+        if ret < 0 {
+            return Err(VfioError::VfioDeviceSetIrq);
+        }
+
+        Ok(())
+    }
+
+    pub fn mask_irq(&self, irq_index: u32) -> Result<()> {
         let irq = self
             .irqs
             .get(&irq_index)
@@ -692,7 +716,32 @@ impl VfioDevice {
 
         let mut irq_set = vec_with_array_field::<vfio_irq_set, u32>(0);
         irq_set[0].argsz = mem::size_of::<vfio_irq_set>() as u32;
-        irq_set[0].flags = VFIO_IRQ_SET_ACTION_MASK;
+        irq_set[0].flags = VFIO_IRQ_SET_ACTION_MASK | VFIO_IRQ_SET_DATA_NONE;
+        irq_set[0].index = irq_index;
+        irq_set[0].start = 0;
+        irq_set[0].count = irq.count;
+
+        // Safe as we are the owner of self and irq_set which are valid value
+        let ret = unsafe { ioctl_with_ref(self, VFIO_DEVICE_SET_IRQS(), &irq_set[0]) };
+        if ret < 0 {
+            return Err(VfioError::VfioDeviceSetIrq);
+        }
+
+        Ok(())
+    }
+
+    pub fn unmask_irq(&self, irq_index: u32) -> Result<()> {
+        let irq = self
+            .irqs
+            .get(&irq_index)
+            .ok_or(VfioError::VfioDeviceSetIrq)?;
+        if irq.count == 0 {
+            return Err(VfioError::VfioDeviceSetIrq);
+        }
+
+        let mut irq_set = vec_with_array_field::<vfio_irq_set, u32>(0);
+        irq_set[0].argsz = mem::size_of::<vfio_irq_set>() as u32;
+        irq_set[0].flags = VFIO_IRQ_SET_ACTION_UNMASK | VFIO_IRQ_SET_DATA_NONE;
         irq_set[0].index = irq_index;
         irq_set[0].start = 0;
         irq_set[0].count = irq.count;


### PR DESCRIPTION
In order to disable the interrupts related to a specific VFIO device, it
is important to mask the range of subinterrupts so that we avoid
undefined behaviors right after the interrupts are unassigned.

One part of this patch reintroduces the reverted patch
66fde245b39b71dfc2e46803bcaf640f8175bcb5

Fixes #460

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>
Signed-off-by: Wu Zongyong <wuzongyong@linux.alibaba.com>