### PR TITLE
[WIP]The left vhost-user-blk device and backend work

### DIFF
--- a/src/bin/vhost_user_blk.rs
+++ b/src/bin/vhost_user_blk.rs
@@ -172,6 +172,11 @@ impl VhostUserBackend for VhostUserBlkBackend {
     fn features(&self) -> u64 {
         let mut avail_features = 1 << VIRTIO_BLK_F_MQ
             | 1 << VIRTIO_F_VERSION_1
+            | 1 << VIRTIO_BLK_F_SIZE_MAX
+            | 1 << VIRTIO_BLK_F_SEG_MAX
+            | 1 << VIRTIO_BLK_F_TOPOLOGY
+            | 1 << VIRTIO_BLK_F_BLK_SIZE
+            | 1 << VIRTIO_BLK_F_FLUSH
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
 
         if self.iommu {


### PR DESCRIPTION
We still need add some features, like readonly, virtio-iommu and multiple queue into current vhost-user-blk device and backend.

I also added one patch and did performance tuning, and results as below
#all "write back" cache mode
#all num_queue=1 
#read/write test command in guest
  (a). time dd if=/dev/vda of=/dev/null bs=2M iflag=direct
  (b). time dd of=/dev/vda if=/dev/zero bs=2M oflag=direct count=32

#test result
(1). rust vhost user device + rust backend
read: 19.3GB/s
write: 8.67GB/s

(2). qemu vhost user device + rust backend
read: 19.08GB/s
write: 9.24GB/s

(3). qemu vhost user device + spdk
read: 8GB/s
write: 6.3GB/s

(4). qemu vhost user device + qemu backend
read: 6.6GB/s
write: 3.1GB/s

It seems the performance of rust vhost user device + rust backend is better than qemu, even qemu + spdk.   

Need to support in backend

- [x] virtio-iommu
- [x] readonly
- [x] multiple queue
- [x] performance tuning 

Need to support in device
- [ ] multiple queue   