### PR TITLE
build: Reorder travis build commands to reuse build assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,19 @@ before_script:
 
 script:
   - cargo rustc --bin cloud-hypervisor -- -D warnings
-  - cargo rustc --bin cloud-hypervisor --no-default-features --features "pci"  -- -D warnings
-  - cargo rustc --bin cloud-hypervisor --no-default-features --features "pci,acpi"  -- -D warnings
-  - cargo rustc --bin cloud-hypervisor --no-default-features --features "mmio"  -- -D warnings
   - cargo rustc --bin vhost_user_net -- -D warnings
-  - cargo rustc --bin vhost_user_net --no-default-features --features "pci"  -- -D warnings
-  - cargo rustc --bin vhost_user_net --no-default-features --features "pci,acpi"  -- -D warnings
-  - cargo rustc --bin vhost_user_net --no-default-features --features "mmio"  -- -D warnings
   - cargo test
-  - cargo clippy --all-targets --all-features -- -D warnings
-  - find . -name "*.rs" | xargs rustfmt --check
   - cargo audit
+  - cargo rustc --bin cloud-hypervisor --no-default-features --features "pci,acpi"  -- -D warnings
+  - cargo rustc --bin vhost_user_net --no-default-features --features "pci,acpi"  -- -D warnings
+  - cargo clippy --all-targets --all-features -- -D warnings
+  - cargo rustc --bin cloud-hypervisor --no-default-features --features "pci"  -- -D warnings
+  - cargo rustc --bin vhost_user_net --no-default-features --features "pci"  -- -D warnings
+  - cargo rustc --bin cloud-hypervisor --no-default-features --features "mmio"  -- -D warnings
+  - cargo rustc --bin vhost_user_net --no-default-features --features "mmio"  -- -D warnings
+  - find . -name "*.rs" | xargs rustfmt --check
   - cargo build --release
-
+  
 deploy:
   provider: releases
   api_key: $GITHUB_OAUTH_TOKEN


### PR DESCRIPTION
Reorder the build commands so that more build assets in the target/
build directory can be reused. This will reduce the build time.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>