### PR TITLE
Add support for CPU hotplug

### DIFF
--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -5,6 +5,8 @@
 
 use vmm_sys_util::eventfd::EventFd;
 use BusDevice;
+use HotPlugNotificationType;
+use Interrupt;
 
 /// A device for handling ACPI shutdown and reboot
 pub struct AcpiShutdownDevice {
@@ -49,4 +51,38 @@ impl BusDevice for AcpiShutdownDevice {
             }
         }
     }
+}
+
+/// A device for handling ACPI GED event generation
+pub struct AcpiGEDDevice {
+    interrupt: Box<dyn Interrupt>,
+    notification_type: HotPlugNotificationType,
+}
+
+impl AcpiGEDDevice {
+    pub fn new(interrupt: Box<dyn Interrupt>) -> AcpiGEDDevice {
+        AcpiGEDDevice {
+            interrupt,
+            notification_type: HotPlugNotificationType::NoDevicesChanged,
+        }
+    }
+
+    pub fn notify(
+        &mut self,
+        notification_type: HotPlugNotificationType,
+    ) -> Result<(), std::io::Error> {
+        self.notification_type = notification_type;
+        self.interrupt.deliver()
+    }
+}
+
+// I/O port reports what type of notification was made
+impl BusDevice for AcpiGEDDevice {
+    // Spec has all fields as zero
+    fn read(&mut self, _base: u64, _offset: u64, data: &mut [u8]) {
+        data[0] = self.notification_type as u8;
+        self.notification_type = HotPlugNotificationType::NoDevicesChanged;
+    }
+
+    fn write(&mut self, _base: u64, _offset: u64, _data: &[u8]) {}
 }

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -26,7 +26,7 @@ pub mod ioapic;
 pub mod legacy;
 
 #[cfg(feature = "acpi")]
-pub use self::acpi::AcpiShutdownDevice;
+pub use self::acpi::{AcpiGEDDevice, AcpiShutdownDevice};
 pub use self::bus::{Bus, BusDevice, Error as BusError};
 
 pub type DeviceEventT = u16;
@@ -69,4 +69,10 @@ pub enum Error {
 
 pub trait Interrupt: Send + Sync {
     fn deliver(&self) -> result::Result<(), std::io::Error>;
+}
+
+#[derive(Clone, Copy)]
+pub enum HotPlugNotificationType {
+    NoDevicesChanged,
+    CPUDevicesChanged,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2041,18 +2041,6 @@ mod tests {
                 0
             );
 
-            // Further test that we're MSI only now
-            aver_eq!(
-                tb,
-                guest
-                    .ssh_command("cat /proc/interrupts | grep -c 'IO-APIC'")
-                    .unwrap_or_default()
-                    .trim()
-                    .parse::<u32>()
-                    .unwrap_or(1),
-                0
-            );
-
             guest.ssh_command("sudo shutdown -h now")?;
             thread::sleep(std::time::Duration::new(10, 0));
             let _ = child.kill();

--- a/src/main.rs
+++ b/src/main.rs
@@ -346,7 +346,7 @@ fn main() {
         "Cloud Hypervisor Guest\n\tAPI server: {}\n\tvCPUs: {}\n\tMemory: {} MB\
          \n\tKernel: {:?}\n\tKernel cmdline: {}\n\tDisk(s): {:?}",
         api_socket_path,
-        vm_config.cpus.cpu_count,
+        vm_config.cpus.boot_vcpus,
         vm_config.memory.size >> 20,
         vm_config.kernel,
         vm_config.cmdline.args.as_str(),
@@ -923,7 +923,8 @@ mod tests {
         }
 
         fn api_create_body(&self, cpu_count: u8) -> String {
-            format! {"{{\"cpus\":{{\"cpu_count\":{}}},\"kernel\":{{\"path\":\"{}\"}},\"cmdline\":{{\"args\": \"\"}},\"net\":[{{\"ip\":\"{}\", \"mask\":\"255.255.255.0\", \"mac\":\"{}\"}}], \"disks\":[{{\"path\":\"{}\"}}, {{\"path\":\"{}\"}}]}}",
+            format! {"{{\"cpus\":{{\"boot_vcpus\":{},\"max_vcpus\":{}}},\"kernel\":{{\"path\":\"{}\"}},\"cmdline\":{{\"args\": \"\"}},\"net\":[{{\"ip\":\"{}\", \"mask\":\"255.255.255.0\", \"mac\":\"{}\"}}], \"disks\":[{{\"path\":\"{}\"}}, {{\"path\":\"{}\"}}]}}",
+                     cpu_count,
                      cpu_count,
                      self.fw_path.as_str(),
                      self.network.host_ip,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1072,7 +1072,7 @@ mod tests {
                 let guest = Guest::new(*disk_config);
 
                 let mut child = Command::new("target/release/cloud-hypervisor")
-                    .args(&["--cpus", "1"])
+                    .args(&["--cpus", "boot=1"])
                     .args(&["--memory", "size=512M"])
                     .args(&["--kernel", guest.fw_path.as_str()])
                     .args(&[
@@ -1122,7 +1122,7 @@ mod tests {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "2"])
+                .args(&["--cpus", "boot=2"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -1160,7 +1160,7 @@ mod tests {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=5120M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -1198,7 +1198,7 @@ mod tests {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=128G"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -1239,7 +1239,7 @@ mod tests {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -1292,7 +1292,7 @@ mod tests {
             kernel_path.push("vmlinux");
 
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus","boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&[
@@ -1351,7 +1351,7 @@ mod tests {
             kernel_path.push("bzImage");
 
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus","boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&[
@@ -1418,7 +1418,7 @@ mod tests {
                 .unwrap();
 
             let mut cloud_child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M,file=/dev/shm"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -1480,7 +1480,7 @@ mod tests {
             let (mut daemon_child, vubd_socket_path) = prepare_vubd(&guest.tmp_dir, "blk.img");
 
             let mut cloud_child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M,file=/dev/shm"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -1570,7 +1570,7 @@ mod tests {
             );
 
             let mut cloud_child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M,file=/dev/shm"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -1620,7 +1620,7 @@ mod tests {
             let guest = Guest::new(&mut clear);
 
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -1704,7 +1704,7 @@ mod tests {
             );
 
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M,file=/dev/shm"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&[
@@ -1834,7 +1834,7 @@ mod tests {
             kernel_path.push("vmlinux");
 
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus","boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&[
@@ -1897,7 +1897,7 @@ mod tests {
             kernel_path.push("vmlinux");
 
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus","boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&["--disk",
@@ -1941,7 +1941,7 @@ mod tests {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -1994,7 +1994,7 @@ mod tests {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -2055,7 +2055,7 @@ mod tests {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -2116,7 +2116,7 @@ mod tests {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -2179,7 +2179,7 @@ mod tests {
 
             let serial_path = guest.tmp_dir.path().join("/tmp/serial-output");
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -2242,7 +2242,7 @@ mod tests {
             let guest = Guest::new(&mut clear);
 
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -2302,7 +2302,7 @@ mod tests {
 
             let console_path = guest.tmp_dir.path().join("/tmp/console-output");
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -2389,7 +2389,7 @@ mod tests {
                 prepare_virtiofsd(&guest.tmp_dir, vfio_path.to_str().unwrap(), "always");
 
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "4"])
+                .args(&["--cpus", "boot=4"])
                 .args(&["--memory", "size=1G,file=/dev/shm"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&[
@@ -2476,7 +2476,7 @@ mod tests {
             kernel_path.push("vmlinux");
 
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus","boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&[
@@ -2538,7 +2538,7 @@ mod tests {
                 let guest = Guest::new(*disk_config);
 
                 let mut child = Command::new("target/release/cloud-hypervisor")
-                    .args(&["--cpus", "1"])
+                    .args(&["--cpus", "boot=1"])
                     .args(&["--memory", "size=512M"])
                     .args(&["--kernel", guest.fw_path.as_str()])
                     .args(&[
@@ -2609,7 +2609,7 @@ mod tests {
             kernel_path.push("bzImage");
 
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus","boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&[
@@ -2675,7 +2675,7 @@ mod tests {
             let sock = temp_vsock_path(&guest.tmp_dir);
 
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -2904,7 +2904,7 @@ mod tests {
             kernel_path.push("bzImage");
 
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus","boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&[
@@ -2990,7 +2990,7 @@ mod tests {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
             let mut child = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
@@ -3109,7 +3109,7 @@ mod tests {
             let guest1 = Guest::new(&mut clear1 as &mut dyn DiskConfig);
 
             let mut child1 = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", format!("size=512M,{}", memory_param).as_str()])
                 .args(&["--kernel", guest1.fw_path.as_str()])
                 .args(&[
@@ -3138,7 +3138,7 @@ mod tests {
             let guest2 = Guest::new(&mut clear2 as &mut dyn DiskConfig);
 
             let mut child2 = Command::new("target/release/cloud-hypervisor")
-                .args(&["--cpus", "1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", format!("size=512M,{}", memory_param).as_str()])
                 .args(&["--kernel", guest2.fw_path.as_str()])
                 .args(&[

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -196,7 +196,7 @@ impl Aml for CPUMethods {
     }
 }
 
-fn create_cpu_data(num_cpus: u8) -> Vec<u8> {
+fn create_cpu_data(max_vcpus: u8) -> Vec<u8> {
     let mut bytes = Vec::new();
     // CPU hotplug controller
     bytes.extend_from_slice(
@@ -250,7 +250,7 @@ fn create_cpu_data(num_cpus: u8) -> Vec<u8> {
     let mut cpu_data_inner: Vec<&dyn aml::Aml> = vec![&hid, &uid, &methods];
 
     let mut cpu_devices = Vec::new();
-    for cpu_id in 0..num_cpus {
+    for cpu_id in 0..max_vcpus {
         let cpu_device = CPU { cpu_id };
 
         cpu_devices.push(cpu_device);
@@ -268,7 +268,7 @@ pub fn create_dsdt_table(
     serial_enabled: bool,
     start_of_device_area: GuestAddress,
     end_of_device_area: GuestAddress,
-    num_cpus: u8,
+    max_vcpus: u8,
 ) -> SDT {
     let pci_dsdt_data = aml::Device::new(
         "_SB_.PCI0".into(),
@@ -341,7 +341,7 @@ pub fn create_dsdt_table(
     let s5_sleep_data =
         aml::Name::new("_S5_".into(), &aml::Package::new(vec![&5u8])).to_aml_bytes();
 
-    let cpu_data = create_cpu_data(num_cpus);
+    let cpu_data = create_cpu_data(max_vcpus);
 
     // DSDT
     let mut dsdt = SDT::new(*b"DSDT", 36, 6, *b"CLOUDH", *b"CHDSDT  ", 1);
@@ -374,7 +374,7 @@ pub fn create_acpi_tables(
         serial_enabled,
         start_of_device_area,
         end_of_device_area,
-        boot_vcpus,
+        max_vcpus,
     );
     let dsdt_offset = rsdp_offset.checked_add(RSDP::len() as u64).unwrap();
     guest_mem

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::api::http_endpoint::{VmActionHandler, VmCreate, VmInfo, VmmPing, VmmShutdown};
+use crate::api::http_endpoint::{
+    VmActionHandler, VmCreate, VmInfo, VmResize, VmmPing, VmmShutdown,
+};
 use crate::api::{ApiRequest, VmAction};
 use crate::{Error, Result};
 use micro_http::{HttpServer, MediaType, Request, Response, StatusCode, Version};
@@ -59,6 +61,7 @@ lazy_static! {
         r.routes.insert(endpoint!("/vm.reboot"), Box::new(VmActionHandler::new(VmAction::Reboot)));
         r.routes.insert(endpoint!("/vmm.shutdown"), Box::new(VmmShutdown {}));
         r.routes.insert(endpoint!("/vmm.ping"), Box::new(VmmPing {}));
+        r.routes.insert(endpoint!("/vm.resize"), Box::new(VmResize {}));
 
         r
     };

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -207,7 +207,14 @@ components:
 
     CpuConfig:
       required:
-      - cpu_count
+      - boot_vcpus
+      type: object
+      properties:
+        cpu_count:
+          minimum: 1
+          default: 1
+          type: integer
+      - max_vcpus
       type: object
       properties:
         cpu_count:

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -123,6 +123,16 @@ paths:
         405:
           description: The VM instance could not reboot because it is not booted.
 
+  /vm.resize:
+    put:
+      summary: Resize the VM
+      requestBody:
+        description: The target size for the VM
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VmResize'
+        required: true
 components:
   schemas:
 
@@ -411,3 +421,13 @@ components:
         iommu:
           type: boolean
           default: false
+
+    VmResize:
+      required:
+      - desired_vcpus
+      type: object
+      properties:
+        cpu_count:
+          minimum: 1
+          default: 1
+          type: integer

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -472,7 +472,11 @@ impl CpuManager {
         Ok(cpu_manager)
     }
 
-    fn activate_vcpus(&mut self, desired_vcpus: u8, entry_addr: GuestAddress) -> Result<()> {
+    fn activate_vcpus(
+        &mut self,
+        desired_vcpus: u8,
+        entry_addr: Option<GuestAddress>,
+    ) -> Result<()> {
         if desired_vcpus > self.max_vcpus {
             return Err(Error::DesiredVCPUCountExceedsMax);
         }
@@ -497,7 +501,7 @@ impl CpuManager {
                 ioapic,
                 creation_ts,
             )?;
-            vcpu.configure(Some(entry_addr), &self.vm_memory, self.cpuid.clone())?;
+            vcpu.configure(entry_addr, &self.vm_memory, self.cpuid.clone())?;
 
             let vcpu_thread_barrier = vcpu_thread_barrier.clone();
 
@@ -569,7 +573,11 @@ impl CpuManager {
 
     // Starts all the vCPUs that the VM is booting with. Blocks until all vCPUs are running.
     pub fn start_boot_vcpus(&mut self, entry_addr: GuestAddress) -> Result<()> {
-        self.activate_vcpus(self.boot_vcpus(), entry_addr)
+        self.activate_vcpus(self.boot_vcpus(), Some(entry_addr))
+    }
+
+    pub fn resize(&mut self, desired_vcpus: u8) -> Result<()> {
+        self.activate_vcpus(desired_vcpus, None)
     }
 
     pub fn shutdown(&mut self) -> Result<()> {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -335,6 +335,7 @@ impl Vcpu {
 
 pub struct CpuManager {
     boot_vcpus: u8,
+    max_vcpus: u8,
     io_bus: Weak<devices::Bus>,
     mmio_bus: Arc<devices::Bus>,
     ioapic: Option<Arc<Mutex<ioapic::Ioapic>>>,
@@ -387,6 +388,7 @@ impl BusDevice for CpuManager {
 impl CpuManager {
     pub fn new(
         boot_vcpus: u8,
+        max_vcpus: u8,
         device_manager: &DeviceManager,
         guest_memory: Arc<RwLock<GuestMemoryMmap>>,
         fd: Arc<VmFd>,
@@ -395,6 +397,7 @@ impl CpuManager {
     ) -> Result<Arc<Mutex<CpuManager>>> {
         let cpu_manager = Arc::new(Mutex::new(CpuManager {
             boot_vcpus,
+            max_vcpus,
             io_bus: Arc::downgrade(&device_manager.io_bus().clone()),
             mmio_bus: device_manager.mmio_bus().clone(),
             ioapic: device_manager.ioapic().clone(),
@@ -566,5 +569,13 @@ impl CpuManager {
             vcpu_thread.thread().unpark();
         }
         Ok(())
+    }
+
+    pub fn boot_vcpus(&self) -> u8 {
+        self.boot_vcpus
+    }
+
+    pub fn max_vcpus(&self) -> u8 {
+        self.max_vcpus
     }
 }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -116,6 +116,9 @@ pub enum Error {
 
     /// Failed to allocate IO port
     AllocateIOPort,
+
+    /// Asking for more vCPUs that we can have
+    DesiredVCPUCountExceedsMax,
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -443,7 +446,7 @@ impl CpuManager {
             fd,
             vcpus_kill_signalled: Arc::new(AtomicBool::new(false)),
             vcpus_pause_signalled: Arc::new(AtomicBool::new(false)),
-            threads: Vec::with_capacity(boot_vcpus as usize),
+            vcpu_states: Vec::with_capacity(max_vcpus as usize),
             reset_evt,
             selected_cpu: 0,
         }));
@@ -467,13 +470,17 @@ impl CpuManager {
         Ok(cpu_manager)
     }
 
-    // Starts all the vCPUs that the VM is booting with. Blocks until all vCPUs are running.
-    pub fn start_boot_vcpus(&mut self, entry_addr: GuestAddress) -> Result<()> {
+    fn activate_vcpus(&mut self, desired_vcpus: u8, entry_addr: GuestAddress) -> Result<()> {
+        if desired_vcpus > self.max_vcpus {
+            return Err(Error::DesiredVCPUCountExceedsMax);
+        }
+
         let creation_ts = std::time::Instant::now();
+        let vcpu_thread_barrier = Arc::new(Barrier::new(
+            (desired_vcpus - self.present_vcpus() + 1) as usize,
+        ));
 
-        let vcpu_thread_barrier = Arc::new(Barrier::new((self.boot_vcpus + 1) as usize));
-
-        for cpu_id in 0..self.boot_vcpus {
+        for cpu_id in self.present_vcpus()..desired_vcpus {
             let ioapic = if let Some(ioapic) = &self.ioapic {
                 Some(ioapic.clone())
             } else {
@@ -556,6 +563,11 @@ impl CpuManager {
         // Unblock all CPU threads.
         vcpu_thread_barrier.wait();
         Ok(())
+    }
+
+    // Starts all the vCPUs that the VM is booting with. Blocks until all vCPUs are running.
+    pub fn start_boot_vcpus(&mut self, entry_addr: GuestAddress) -> Result<()> {
+        self.activate_vcpus(self.boot_vcpus(), entry_addr)
     }
 
     pub fn shutdown(&mut self) -> Result<()> {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -244,7 +244,7 @@ impl Vcpu {
     /// * `vm` - The virtual machine this vcpu will get attached to.
     pub fn configure(
         &mut self,
-        kernel_start_addr: GuestAddress,
+        kernel_start_addr: Option<GuestAddress>,
         vm_memory: &Arc<RwLock<GuestMemoryMmap>>,
         cpuid: CpuId,
     ) -> Result<()> {
@@ -255,17 +255,19 @@ impl Vcpu {
             .map_err(Error::SetSupportedCpusFailed)?;
 
         arch::x86_64::regs::setup_msrs(&self.fd).map_err(Error::MSRSConfiguration)?;
-        // Safe to unwrap because this method is called after the VM is configured
-        arch::x86_64::regs::setup_regs(
-            &self.fd,
-            kernel_start_addr.raw_value(),
-            arch::x86_64::layout::BOOT_STACK_POINTER.raw_value(),
-            arch::x86_64::layout::ZERO_PAGE_START.raw_value(),
-        )
-        .map_err(Error::REGSConfiguration)?;
-        arch::x86_64::regs::setup_fpu(&self.fd).map_err(Error::FPUConfiguration)?;
-        arch::x86_64::regs::setup_sregs(&vm_memory.read().unwrap(), &self.fd)
-            .map_err(Error::SREGSConfiguration)?;
+        if let Some(kernel_start_addr) = kernel_start_addr {
+            // Safe to unwrap because this method is called after the VM is configured
+            arch::x86_64::regs::setup_regs(
+                &self.fd,
+                kernel_start_addr.raw_value(),
+                arch::x86_64::layout::BOOT_STACK_POINTER.raw_value(),
+                arch::x86_64::layout::ZERO_PAGE_START.raw_value(),
+            )
+            .map_err(Error::REGSConfiguration)?;
+            arch::x86_64::regs::setup_fpu(&self.fd).map_err(Error::FPUConfiguration)?;
+            arch::x86_64::regs::setup_sregs(&vm_memory.read().unwrap(), &self.fd)
+                .map_err(Error::SREGSConfiguration)?;
+        }
         arch::x86_64::interrupts::set_lint(&self.fd).map_err(Error::LocalIntConfiguration)?;
         Ok(())
     }
@@ -495,7 +497,7 @@ impl CpuManager {
                 ioapic,
                 creation_ts,
             )?;
-            vcpu.configure(entry_addr, &self.vm_memory, self.cpuid.clone())?;
+            vcpu.configure(Some(entry_addr), &self.vm_memory, self.cpuid.clone())?;
 
             let vcpu_thread_barrier = vcpu_thread_barrier.clone();
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -345,7 +345,7 @@ pub struct CpuManager {
     vcpus_kill_signalled: Arc<AtomicBool>,
     vcpus_pause_signalled: Arc<AtomicBool>,
     reset_evt: EventFd,
-    threads: Vec<thread::JoinHandle<()>>,
+    vcpu_states: Vec<VcpuState>,
     selected_cpu: u8,
 }
 
@@ -358,8 +358,12 @@ impl BusDevice for CpuManager {
     fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         match offset {
             CPU_STATUS_OFFSET => {
-                // All CPUs are currently enabled
-                data[0] |= 1 << CPU_ENABLE_FLAG;
+                if self.selected_cpu < self.present_vcpus() {
+                    let state = &self.vcpu_states[usize::from(self.selected_cpu)];
+                    if state.active() {
+                        data[0] |= 1 << CPU_ENABLE_FLAG;
+                    }
+                }
             }
             _ => {
                 warn!(
@@ -381,6 +385,39 @@ impl BusDevice for CpuManager {
                     offset
                 );
             }
+        }
+    }
+}
+
+struct VcpuState {
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl VcpuState {
+    fn active(&self) -> bool {
+        self.handle.is_some()
+    }
+
+    fn signal_thread(&self) {
+        if let Some(handle) = self.handle.as_ref() {
+            let signum = validate_signal_num(VCPU_RTSIG_OFFSET, true).unwrap();
+            unsafe {
+                libc::pthread_kill(handle.as_pthread_t(), signum);
+            }
+        }
+    }
+
+    fn join_thread(&mut self) -> Result<()> {
+        if let Some(handle) = self.handle.take() {
+            handle.join().map_err(|_| Error::ThreadCleanup)?
+        }
+
+        Ok(())
+    }
+
+    fn unpark_thread(&self) {
+        if let Some(handle) = self.handle.as_ref() {
+            handle.thread().unpark()
         }
     }
 }
@@ -458,7 +495,8 @@ impl CpuManager {
             let reset_evt = self.reset_evt.try_clone().unwrap();
             let vcpu_kill_signalled = self.vcpus_kill_signalled.clone();
             let vcpu_pause_signalled = self.vcpus_pause_signalled.clone();
-            self.threads.push(
+
+            let handle = Some(
                 thread::Builder::new()
                     .name(format!("vcpu{}", vcpu.id))
                     .spawn(move || {
@@ -511,6 +549,8 @@ impl CpuManager {
                     })
                     .map_err(Error::VcpuSpawn)?,
             );
+
+            self.vcpu_states.push(VcpuState { handle });
         }
 
         // Unblock all CPU threads.
@@ -525,16 +565,13 @@ impl CpuManager {
         // Signal to the spawned threads (vCPUs and console signal handler). For the vCPU threads
         // this will interrupt the KVM_RUN ioctl() allowing the loop to check the boolean set
         // above.
-        for thread in self.threads.iter() {
-            let signum = validate_signal_num(VCPU_RTSIG_OFFSET, true).unwrap();
-            unsafe {
-                libc::pthread_kill(thread.as_pthread_t(), signum);
-            }
+        for state in self.vcpu_states.iter() {
+            state.signal_thread();
         }
 
-        // Wait for all the threads to finish
-        for thread in self.threads.drain(..) {
-            thread.join().map_err(|_| Error::ThreadCleanup)?
+        // Wait for all the threads to finish. This removes the state from the vector.
+        for mut state in self.vcpu_states.drain(..) {
+            state.join_thread()?;
         }
 
         Ok(())
@@ -547,11 +584,8 @@ impl CpuManager {
         // Signal to the spawned threads (vCPUs and console signal handler). For the vCPU threads
         // this will interrupt the KVM_RUN ioctl() allowing the loop to check the boolean set
         // above.
-        for thread in self.threads.iter() {
-            let signum = validate_signal_num(VCPU_RTSIG_OFFSET, true).unwrap();
-            unsafe {
-                libc::pthread_kill(thread.as_pthread_t(), signum);
-            }
+        for state in self.vcpu_states.iter() {
+            state.signal_thread();
         }
 
         Ok(())
@@ -565,8 +599,8 @@ impl CpuManager {
         // Once unparked, the next thing they will do is checking for the pause
         // boolean. Since it'll be set to false, they will exit their pause loop
         // and go back to vmx root.
-        for vcpu_thread in self.threads.iter() {
-            vcpu_thread.thread().unpark();
+        for state in self.vcpu_states.iter() {
+            state.unpark_thread();
         }
         Ok(())
     }
@@ -577,5 +611,9 @@ impl CpuManager {
 
     pub fn max_vcpus(&self) -> u8 {
         self.max_vcpus
+    }
+
+    fn present_vcpus(&self) -> u8 {
+        self.vcpu_states.len() as u8
     }
 }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -666,6 +666,13 @@ impl DeviceManager {
             )));
 
             address_manager
+                .allocator
+                .lock()
+                .unwrap()
+                .allocate_io_addresses(Some(GuestAddress(0x3c0)), 0x8, None)
+                .ok_or(DeviceManagerError::AllocateIOPort)?;
+
+            address_manager
                 .io_bus
                 .insert(acpi_device.clone(), 0x3c0, 0x4)
                 .map_err(DeviceManagerError::BusError)?;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -448,8 +448,10 @@ impl Vm {
         let on_tty = unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0;
 
         let boot_vcpus = config.cpus.cpu_count;
+        let max_vcpus = config.cpus.cpu_count;
         let cpu_manager = cpu::CpuManager::new(
             boot_vcpus,
+            max_vcpus,
             &device_manager,
             guest_memory.clone(),
             fd,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -646,6 +646,14 @@ impl Vm {
         Ok(())
     }
 
+    pub fn resize(&mut self, desired_vcpus: u8) -> Result<()> {
+        self.cpu_manager
+            .lock()
+            .unwrap()
+            .resize(desired_vcpus)
+            .map_err(Error::CpuManager)
+    }
+
     fn os_signal_handler(signals: Signals, console_input_clone: Arc<Console>) {
         for signal in signals.forever() {
             if signal == SIGWINCH {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -510,7 +510,7 @@ impl Vm {
         )
         .map_err(|_| Error::CmdLine)?;
         let boot_vcpus = self.cpu_manager.lock().unwrap().boot_vcpus();
-        let max_vcpus = self.cpu_manager.lock().unwrap().max_vcpus();
+        let _max_vcpus = self.cpu_manager.lock().unwrap().max_vcpus();
 
         #[allow(unused_mut, unused_assignments)]
         let mut rsdp_addr: Option<GuestAddress> = None;
@@ -531,7 +531,7 @@ impl Vm {
                 crate::acpi::create_acpi_tables(
                     &mem,
                     boot_vcpus,
-                    max_vcpus,
+                    _max_vcpus,
                     self.config.serial.mode != ConsoleOutputMode::Off,
                     start_of_device_area,
                     end_of_range,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -447,8 +447,8 @@ impl Vm {
 
         let on_tty = unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0;
 
-        let boot_vcpus = config.cpus.cpu_count;
-        let max_vcpus = config.cpus.cpu_count;
+        let boot_vcpus = config.cpus.boot_vcpus;
+        let max_vcpus = config.cpus.max_vcpus;
         let cpu_manager = cpu::CpuManager::new(
             boot_vcpus,
             max_vcpus,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -510,6 +510,7 @@ impl Vm {
         )
         .map_err(|_| Error::CmdLine)?;
         let boot_vcpus = self.cpu_manager.lock().unwrap().boot_vcpus();
+        let max_vcpus = self.cpu_manager.lock().unwrap().max_vcpus();
 
         #[allow(unused_mut, unused_assignments)]
         let mut rsdp_addr: Option<GuestAddress> = None;
@@ -530,6 +531,7 @@ impl Vm {
                 crate::acpi::create_acpi_tables(
                     &mem,
                     boot_vcpus,
+                    max_vcpus,
                     self.config.serial.mode != ConsoleOutputMode::Off,
                     start_of_device_area,
                     end_of_range,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -509,7 +509,7 @@ impl Vm {
             &cmdline_cstring,
         )
         .map_err(|_| Error::CmdLine)?;
-        let vcpu_count = self.config.cpus.cpu_count;
+        let boot_vcpus = self.cpu_manager.lock().unwrap().boot_vcpus();
 
         #[allow(unused_mut, unused_assignments)]
         let mut rsdp_addr: Option<GuestAddress> = None;
@@ -529,7 +529,7 @@ impl Vm {
                 use crate::config::ConsoleOutputMode;
                 crate::acpi::create_acpi_tables(
                     &mem,
-                    vcpu_count,
+                    boot_vcpus,
                     self.config.serial.mode != ConsoleOutputMode::Off,
                     start_of_device_area,
                     end_of_range,
@@ -544,7 +544,7 @@ impl Vm {
                     &mem,
                     arch::layout::CMDLINE_START,
                     cmdline_cstring.to_bytes().len() + 1,
-                    vcpu_count,
+                    boot_vcpus,
                     Some(hdr),
                     rsdp_addr,
                 )
@@ -563,7 +563,7 @@ impl Vm {
                     &mem,
                     arch::layout::CMDLINE_START,
                     cmdline_cstring.to_bytes().len() + 1,
-                    vcpu_count,
+                    boot_vcpus,
                     None,
                     rsdp_addr,
                 )

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -54,7 +54,7 @@ use vm_memory::{
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::terminal::Terminal;
 
-const X86_64_IRQ_BASE: u32 = 5;
+const X86_64_IRQ_BASE: u32 = 6;
 
 // CPUID feature bits
 const TSC_DEADLINE_TIMER_ECX_BIT: u8 = 24; // tsc deadline timer ecx bit.

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -27,7 +27,7 @@ use crate::config::VmConfig;
 use crate::cpu;
 use crate::device_manager::{get_win_size, Console, DeviceManager, DeviceManagerError};
 use arch::RegionType;
-use devices::ioapic;
+use devices::{ioapic, HotPlugNotificationType};
 use kvm_bindings::{
     kvm_enable_cap, kvm_pit_config, kvm_userspace_memory_region, KVM_CAP_SPLIT_IRQCHIP,
     KVM_PIT_SPEAKER_DUMMY,
@@ -651,7 +651,11 @@ impl Vm {
             .lock()
             .unwrap()
             .resize(desired_vcpus)
-            .map_err(Error::CpuManager)
+            .map_err(Error::CpuManager)?;
+        self.devices
+            .notify_hotplug(HotPlugNotificationType::CPUDevicesChanged)
+            .map_err(Error::DeviceManager)?;
+        Ok(())
     }
 
     fn os_signal_handler(signals: Signals, console_input_clone: Arc<Console>) {


### PR DESCRIPTION
Add a "vm.resize()" http method that will ultimately result in more vCPU devices being added to the system.

Integration test included. For manual testing:

`target/debug/cloud-hypervisor  --kernel ~/src/linux/arch/x86/boot/bzImage --cmdline "root=/dev/vda3 console=ttyS0" --serial tty --console off --disk path=~/workloads/clear-31520-kvm.img --memory size=1024M --cpus boot=2,max=4 --api-socket=/tmp/ch-socket`

and 

` curl -H "Accept: application/json" -H "Content-Type: application/json" -i -XPUT --unix-socket /tmp/ch-socket -d "{ \"desired_vcpus\":4}" http://localhost/api/v1/vm.resize`

to resize

Fixes: #407