### PR TITLE
cargo: Bump the kvm and vmm-sys-util crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,8 +35,8 @@ dependencies = [
  "acpi_tables 0.1.0",
  "arch_gen 0.1.0",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.3.0 (git+https://github.com/rust-vmm/kvm-ioctls)",
+ "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-ioctls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "linux-loader 0.1.0 (git+https://github.com/rust-vmm/linux-loader)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -188,7 +188,7 @@ dependencies = [
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
  "vmm 0.1.0",
- "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -228,13 +228,13 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.3.0 (git+https://github.com/rust-vmm/kvm-ioctls)",
+ "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-ioctls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -330,17 +330,20 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.3.0"
-source = "git+https://github.com/rust-vmm/kvm-ioctls#681745a7776d60e390bcf62eefd48531a5f8ec47"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -418,7 +421,7 @@ dependencies = [
 name = "net_gen"
 version = "0.1.0"
 dependencies = [
- "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -432,7 +435,7 @@ dependencies = [
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -457,7 +460,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-allocator 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -568,7 +571,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "remain 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -966,8 +969,8 @@ version = "0.0.1"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
- "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.3.0 (git+https://github.com/rust-vmm/kvm-ioctls)",
+ "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-ioctls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pci 0.1.0",
@@ -975,7 +978,7 @@ dependencies = [
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -994,7 +997,7 @@ dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1006,7 +1009,7 @@ dependencies = [
  "vhost_rs 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
- "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1070,7 +1073,7 @@ dependencies = [
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1081,8 +1084,8 @@ dependencies = [
  "arch 0.1.0",
  "devices 0.1.0",
  "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.3.0 (git+https://github.com/rust-vmm/kvm-ioctls)",
+ "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-ioctls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "linux-loader 0.1.0 (git+https://github.com/rust-vmm/linux-loader)",
@@ -1099,7 +1102,7 @@ dependencies = [
  "vm-allocator 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
- "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1112,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1196,8 +1199,8 @@ dependencies = [
 "checksum ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3d862c86f7867f19b693ec86765e0252d82e53d4240b9b629815675a0714ad1"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c223e8703d2eb76d990c5f58e29c85b0f6f50e24b823babde927948e7c71fc03"
-"checksum kvm-ioctls 0.3.0 (git+https://github.com/rust-vmm/kvm-ioctls)" = "<none>"
+"checksum kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d381156ad52005b4655a9421401f02b80f9f049e653496e3ea6639a83fc12453"
+"checksum kvm-ioctls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8a59db3c7098cc87f140eb7a4317decda01dd42e7979b1d4d789bd6f6c599a"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum libssh2-sys 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "5fcd5a428a31cbbfe059812d74f4b6cd3b9b7426c2bdaec56993c5365da1c328"
@@ -1271,7 +1274,7 @@ dependencies = [
 "checksum virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
 "checksum vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)" = "<none>"
 "checksum vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "46996f56aeae31fbc0532ae57a944e00089302f03b18c10c76eebfd9249f4a6c"
-"checksum vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b75440f66b299f66acf005431d5f13be6e6a8d02b4dcaa83be5144e88762d010"
+"checksum vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6ebb6ba7ba5653b69bfd3fab8c8c363945c0d3f616a6a1592e12122c3be4724e"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ virtio-bindings = "0.1.0"
 vmm = { path = "vmm" }
 vm-device = { path = "vm-device" }
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
-vmm-sys-util = ">=0.1.1"
+vmm-sys-util = ">=0.2.1"
 vm-virtio = { path = "vm-virtio" }
 
 [dev-dependencies]

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -8,8 +8,8 @@ default = []
 
 [dependencies]
 byteorder = "1.3.2"
-kvm-bindings = "0.1.1"
-kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master" }
+kvm-bindings = "0.2.0"
+kvm-ioctls = "0.4.0"
 libc = "0.2.60"
 
 acpi_tables = { path = "../acpi_tables", optional = true }

--- a/arch/src/x86_64/interrupts.rs
+++ b/arch/src/x86_64/interrupts.rs
@@ -5,7 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
-use std::io::{self, Cursor};
+use std::io::Cursor;
 use std::mem;
 use std::result;
 
@@ -16,8 +16,8 @@ use kvm_ioctls;
 
 #[derive(Debug)]
 pub enum Error {
-    GetLapic(io::Error),
-    SetLapic(io::Error),
+    GetLapic(kvm_ioctls::Error),
+    SetLapic(kvm_ioctls::Error),
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -6,12 +6,12 @@ authors = ["The Chromium OS Authors"]
 [dependencies]
 byteorder = "1.3.2"
 epoll = ">=4.0.1"
-kvm-bindings = "0.1.1"
-kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master" }
+kvm-bindings = "0.2.0"
+kvm-ioctls = "0.4.0"
 libc = "0.2.60"
 log = "0.4.8"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
-vmm-sys-util = ">=0.1.1"
+vmm-sys-util = ">=0.2.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -13,14 +13,14 @@ use crate::BusDevice;
 use byteorder::{ByteOrder, LittleEndian};
 use kvm_bindings::kvm_msi;
 use kvm_ioctls::VmFd;
+use std::result;
 use std::sync::Arc;
-use std::{io, result};
 use vm_memory::GuestAddress;
 
 #[derive(Debug)]
 pub enum Error {
     /// Failed to send an interrupt.
-    InterruptFailed(io::Error),
+    InterruptFailed(kvm_ioctls::Error),
     /// Invalid destination mode.
     InvalidDestinationMode,
     /// Invalid trigger mode.

--- a/net_gen/Cargo.toml
+++ b/net_gen/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
-vmm-sys-util = ">=0.1.1"
+vmm-sys-util = ">=0.2.1"

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["The Chromium OS Authors"]
 libc = "0.2.60"
 rand = "0.7.0"
 serde = "1.0.98"
-vmm-sys-util = ">=0.1.1"
+vmm-sys-util = ">=0.2.1"
 
 net_gen = { path = "../net_gen" }
 

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -11,4 +11,4 @@ devices = { path = "../devices" }
 libc = "0.2.60"
 log = "0.4.8"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
-vmm-sys-util = ">=0.1.1"
+vmm-sys-util = ">=0.2.1"

--- a/qcow/Cargo.toml
+++ b/qcow/Cargo.toml
@@ -13,7 +13,7 @@ byteorder = "1.3.2"
 libc = "0.2.60"
 log = "0.4.8"
 remain = "0.1.3"
-vmm-sys-util = ">=0.1.1"
+vmm-sys-util = ">=0.2.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/vfio/Cargo.toml
+++ b/vfio/Cargo.toml
@@ -6,15 +6,15 @@ authors = ["The Cloud Hypervisor Authors"]
 [dependencies]
 byteorder = "1.3.2"
 devices = { path = "../devices" }
-kvm-bindings = "0.1.1"
-kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master" }
+kvm-bindings = "0.2.0"
+kvm-ioctls = "0.4.0"
 libc = "0.2.60"
 log = "0.4.8"
 pci = { path = "../pci" }
 vfio-bindings = "0.1.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vmm-sys-util = ">=0.1.1"
+vmm-sys-util = ">=0.2.1"
 
 [dependencies.vm-memory]
 git = "https://github.com/rust-vmm/vm-memory"

--- a/vfio/src/vfio_device.rs
+++ b/vfio/src/vfio_device.rs
@@ -38,7 +38,7 @@ pub enum VfioError {
     UnsetContainer,
     ContainerSetIOMMU,
     GroupGetDeviceFD,
-    KvmSetDeviceAttr(io::Error),
+    KvmSetDeviceAttr(kvm_ioctls::Error),
     VfioDeviceGetInfo,
     VfioDeviceGetRegionInfo,
     InvalidPath,
@@ -268,7 +268,7 @@ impl VfioGroup {
             .map_err(VfioError::KvmSetDeviceAttr)
     }
 
-    fn kvm_device_del_group(&self) -> std::result::Result<(), io::Error> {
+    fn kvm_device_del_group(&self) -> std::result::Result<(), kvm_ioctls::Error> {
         let group_fd = self.as_raw_fd();
         let group_fd_ptr = &group_fd as *const i32;
         let dev_attr = kvm_bindings::kvm_device_attr {

--- a/vhost_rs/Cargo.toml
+++ b/vhost_rs/Cargo.toml
@@ -15,7 +15,7 @@ vhost-user-slave = []
 [dependencies]
 bitflags = "1.1.0"
 libc = "0.2.60"
-vmm-sys-util = ">=0.1.1"
+vmm-sys-util = ">=0.2.1"
 
 [dependencies.vm-memory]
 git = "https://github.com/rust-vmm/vm-memory"

--- a/vhost_user_backend/Cargo.toml
+++ b/vhost_user_backend/Cargo.toml
@@ -12,9 +12,9 @@ mmio_support = ["vm-virtio/mmio_support"]
 [dependencies]
 epoll = ">=4.0.1"
 libc = "0.2.66"
-vm-memory = { git = "https://github.com/rust-vmm/vm-memory" } 
+vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
 vm-virtio = { path = "../vm-virtio" }
-vmm-sys-util = ">=0.1.1"
+vmm-sys-util = ">=0.2.1"
 
 [dependencies.vhost_rs]
 path = "../vhost_rs"

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -22,7 +22,7 @@ tempfile = "3.1.0"
 virtio-bindings = { git = "https://github.com/rust-vmm/virtio-bindings", version = "0.1", features = ["virtio-v5_0_0"]}
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vmm-sys-util = ">=0.1.1"
+vmm-sys-util = ">=0.2.1"
 
 [dependencies.vhost_rs]
 path = "../vhost_rs"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -16,8 +16,8 @@ acpi_tables = { path = "../acpi_tables", optional = true }
 arch = { path = "../arch" }
 devices = { path = "../devices" }
 epoll = ">=4.0.1"
-kvm-bindings = "0.1.1"
-kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master" }
+kvm-bindings = "0.2.0"
+kvm-ioctls = "0.4.0"
 lazy_static = "1.4.0"
 libc = "0.2.62"
 log = "0.4.8"
@@ -31,7 +31,7 @@ serde_json = ">=1.0.9"
 vfio = { path = "../vfio", optional = true }
 vm-allocator = { path = "../vm-allocator" }
 vm-virtio = { path = "../vm-virtio" }
-vmm-sys-util = ">=0.1.1"
+vmm-sys-util = ">=0.2.1"
 signal-hook = "0.1.10"
 
 [dependencies.linux-loader]


### PR DESCRIPTION
Since the kvm crates now depend on vmm-sys-util, the bump must be
atomic.
The kvm-bindings and ioctls 0.2.0 and 0.4.0 crates come with a few API
changes, one of them being the use of a kvm_ioctls specific error type.
Porting our code to that type makes for a fairly large diff stat.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>