### PR TITLE
RFC: Implement a handshake for VSock

### DIFF
--- a/vm-virtio/src/vsock/unix/muxer.rs
+++ b/vm-virtio/src/vsock/unix/muxer.rs
@@ -234,19 +234,18 @@ impl VsockChannel for VsockMuxer {
             return Ok(());
         }
 
-        // Right, we know where to send this packet, then (to `conn_key`).
-        // However, if this is an RST, we have to forcefully terminate the connection, so
-        // there's no point in forwarding it the packet.
-        if pkt.op() == uapi::VSOCK_OP_RST {
-            self.remove_connection(conn_key);
-            return Ok(());
-        }
-
         // Alright, everything looks in order - forward this packet to its owning connection.
         let mut res: VsockResult<()> = Ok(());
         self.apply_conn_mutation(conn_key, |conn| {
             res = conn.send_pkt(pkt);
         });
+
+        // Right, we know where to send this packet, then (to `conn_key`).
+        // However, if this is an RST, we have to forcefully terminate the connection, so
+        // there's no point in forwarding it the packet.
+        if pkt.op() == uapi::VSOCK_OP_RST {
+            self.remove_connection(conn_key);
+        }
 
         res
     }
@@ -397,8 +396,10 @@ impl VsockMuxer {
             Some(EpollListener::LocalStream(_)) => {
                 if let Some(EpollListener::LocalStream(mut stream)) = self.remove_listener(fd) {
                     Self::read_local_stream_port(&mut stream)
-                        .and_then(|peer_port| Ok((self.allocate_local_port(), peer_port)))
-                        .and_then(|(local_port, peer_port)| {
+                        .and_then(|(peer_port, need_reply)| {
+                            Ok((self.allocate_local_port(), peer_port, need_reply))
+                        })
+                        .and_then(|(local_port, peer_port, need_reply)| {
                             self.add_connection(
                                 ConnMapKey {
                                     local_port,
@@ -410,6 +411,7 @@ impl VsockMuxer {
                                     self.cid,
                                     local_port,
                                     peer_port,
+                                    need_reply,
                                 ),
                             )
                         })
@@ -425,9 +427,9 @@ impl VsockMuxer {
         }
     }
 
-    /// Parse a host "connect" command, and extract the destination vsock port.
+    /// Parse a host "connect" and "upgrade" command, and extract the destination vsock port.
     ///
-    fn read_local_stream_port(stream: &mut UnixStream) -> Result<u32> {
+    fn read_local_stream_port(stream: &mut UnixStream) -> Result<(u32, bool)> {
         let mut buf = [0u8; 32];
 
         // This is the minimum number of bytes that we should be able to read, when parsing a
@@ -454,11 +456,15 @@ impl VsockMuxer {
             .map_err(|_| Error::InvalidPortRequest)?
             .split_whitespace();
 
-        word_iter
+        let mut need_reply = false;
+        let port = word_iter
             .next()
             .ok_or(Error::InvalidPortRequest)
             .and_then(|word| {
                 if word.to_lowercase() == "connect" {
+                    Ok(())
+                } else if word.to_lowercase() == "upgrade" {
+                    need_reply = true;
                     Ok(())
                 } else {
                     Err(Error::InvalidPortRequest)
@@ -466,7 +472,9 @@ impl VsockMuxer {
             })
             .and_then(|_| word_iter.next().ok_or(Error::InvalidPortRequest))
             .and_then(|word| word.parse::<u32>().map_err(|_| Error::InvalidPortRequest))
-            .map_err(|_| Error::InvalidPortRequest)
+            .map_err(|_| Error::InvalidPortRequest)?;
+
+        Ok((port, need_reply))
     }
 
     /// Add a new connection to the active connection pool.


### PR DESCRIPTION
This RFC implements a *WebSocket-like upgrading* for [host-initiated vsock connection][fc-vsock]

## Background

Currently the *[host-initiated vsock connection][fc-vsock]* is initiated with a straight-fowward `CONNECT <port_num>\n` command:

```
2. Guest: create an AF_VSOCK socket and listen() on <port_num>;
3. Host: connect() to AF_UNIX at uds_path.
4. Host: send() "CONNECT <port_num>\n".
5. Guest: accept() the new connection.
```

This works like a charm if the sequence is correct. However, sometimes we don't know whether the guest listener has been deployed when we send the command in *STEP 4*. As a result, the connection connected in *step 3* will be closed silently.

## The issue we facing

In practice, we don't know the exact time we have set up the VSock connection successfully because there is no message talking about that. We have to write a [dailer][kata-hvsock-dailer] to check the message feedback from guest. 

```go
eot := make([]byte, 1)
if _, _, err = unix.Recvfrom(int(file.Fd()), eot, syscall.MSG_PEEK); err != nil {
	conn.Close()
	return nil, err
}
```

This dailer expects the server in guest send message out once it `accept`s the connection. However, for some servers like [ttRPC][ttrpc], they won't send anything to the client. This makes trouble to the client dailer, which has to

- wait a period and assume it is connected if connection has not been closed; or
- wait a period before the `CONNECT` and assume the server has been deployed.

### Why not use guest-initiated vsock

We prefer host-initiated link because

- For security consideration, we don't allow guest initiate a vsock connection;
- Host-initiated vsock connection are used in other cases (qemu+grpc, qemu+ttrpc, fc+grpc).

## The proposed handshake

What we proposed is a simple handshake interaction like WebSocket:

- A new command called `Upgrade <port_num>\n` on step *4*;
- *4.5a* hybrid vsock response `101\n` (*Switching Protocol*) if connected
- *4.5b* hybrid vsock response `504\n` (*Service Unavailable*) if guest has not listened on the port.

```
+---------------+                    +----------------+
|               |                    |                |
|               |  Upgrade 3         |                |
|               +------------------->+                |    no server available
|               |                    |                +-------------->
|               |  503               |                |
|               +<-------------------+                |
|               |                    |                |
|               |                    |                |                     +-------------+
|               |   (wait and retry) |                |                     |             |
|               |                    |                |                     |             |
|               |                    |                |                     | listen      |
|               |  Upgrade 3         |                |                     | here        |
|               +------------------->+                |    conn accepted    |             |
|               |                    |                +-------------------->+             |
|               |  101               |                |                     |             |
|               +<-------------------+                |                     |             |
|               |                    |                |                     |             |
|               |   (success)        |                |                     |             |
+---------------+                    +----------------+                     +-------------+
   client in                           hybrid vsock                           server in
     host                                                                       guest

```

Then the dailer may retry/fail based on the explicit reponse.

[fc-vsock]: https://github.com/firecracker-microvm/firecracker/blob/master/docs/vsock.md#host-initiated-connections
[kata-hvsock-dailer]: https://github.com/kata-containers/agent/blob/master/protocols/client/client.go#L420
[ttrpc]: https://github.com/containerd/ttrpc