### PR TITLE
Add Pausable trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,6 +1111,7 @@ name = "vmm"
 version = "0.1.0"
 dependencies = [
  "acpi_tables 0.1.0",
+ "anyhow 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "arch 0.1.0",
  "devices 0.1.0",
  "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arc-swap"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +931,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1067,13 @@ dependencies = [
 [[package]]
 name = "vm-device"
 version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "vm-memory"
@@ -1167,6 +1197,7 @@ dependencies = [
 [metadata]
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "6f1072d8f55592084072d2d3cb23a4b680a8543c00f10d446118e85ad3718142"
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
@@ -1262,6 +1293,8 @@ dependencies = [
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cc6b305ec0e323c7b6cfff6098a22516e0063d0bb7c3d88660a890217dca099a"
+"checksum thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45ba8d810d9c48fc456b7ad54574e8bfb7c7918a57ad7a6e6a0985d7959e8597"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,6 +1130,7 @@ dependencies = [
  "signal-hook 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "vfio 0.0.1",
  "vm-allocator 0.1.0",
+ "vm-device 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
  "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/scripts/run_cargo_tests.sh
+++ b/scripts/run_cargo_tests.sh
@@ -21,5 +21,5 @@ cargo rustc --bin cloud-hypervisor --no-default-features --features "pci"  -- -D
 cargo rustc --bin vhost_user_net --no-default-features --features "pci"  -- -D warnings
 cargo rustc --bin cloud-hypervisor --no-default-features --features "mmio"  -- -D warnings
 cargo rustc --bin vhost_user_net --no-default-features --features "mmio"  -- -D warnings
-find . -name "*.rs" | xargs rustfmt --check
+find . \( -name "*.rs" ! -wholename "*/out/*.rs" \) | xargs rustfmt --check
 cargo build --release

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -5,3 +5,8 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0"
+thiserror = "1.0"
+serde = {version = ">=1.0.27", features = ["rc"] }
+serde_derive = ">=1.0.27"
+serde_json = ">=1.0.9"

--- a/vm-device/src/lib.rs
+++ b/vm-device/src/lib.rs
@@ -1,3 +1,8 @@
+extern crate serde;
+extern crate thiserror;
+
+use thiserror::Error;
+
 /// Trait meant for triggering the DMA mapping update related to an external
 /// device not managed fully through virtio. It is dedicated to virtio-iommu
 /// in order to trigger the map update anytime the mapping is updated from the
@@ -9,3 +14,31 @@ pub trait ExternalDmaMapping: Send + Sync {
     /// Unmap a memory range
     fn unmap(&self, iova: u64, size: u64) -> std::result::Result<(), std::io::Error>;
 }
+
+#[derive(Error, Debug)]
+pub enum MigratableError {
+    #[error("Failed to pause migratable component: {0}")]
+    Pause(#[source] anyhow::Error),
+
+    #[error("Failed to resume migratable component: {0}")]
+    Resume(#[source] anyhow::Error),
+}
+
+/// A Pausable component can be paused and resumed.
+pub trait Pausable {
+    /// Pause the component.
+    fn pause(&mut self) -> std::result::Result<(), MigratableError>;
+
+    /// Resume the component.
+    fn resume(&mut self) -> std::result::Result<(), MigratableError>;
+}
+
+/// A snapshotable component can be snapshoted.
+pub trait Snapshotable {}
+
+/// Trait to be implemented by any component (device, CPU, RAM, etc) that
+/// can be migrated.
+/// All migratable components are paused before being snapshotted, and then
+/// eventually resumed. Thus any Migratable component must be both Pausable
+/// and Snapshotable.
+pub trait Migratable: Pausable + Snapshotable {}

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -16,14 +16,16 @@ extern crate log;
 extern crate pci;
 extern crate vhost_rs;
 extern crate virtio_bindings;
+extern crate vm_device;
 extern crate vm_memory;
 
 use std::fmt;
 use std::io;
 
+#[macro_use]
+mod device;
 pub mod block;
 mod console;
-mod device;
 mod iommu;
 pub mod net;
 mod pmem;

--- a/vm-virtio/src/transport/mmio.rs
+++ b/vm-virtio/src/transport/mmio.rs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+use std::result;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -15,6 +16,7 @@ use crate::{
     INTERRUPT_STATUS_CONFIG_CHANGED, INTERRUPT_STATUS_USED_RING,
 };
 use devices::{BusDevice, Interrupt};
+use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{GuestAddress, GuestMemoryMmap};
 use vmm_sys_util::{errno::Result, eventfd::EventFd};
 
@@ -275,3 +277,16 @@ impl BusDevice for MmioDevice {
         }
     }
 }
+
+impl Pausable for MmioDevice {
+    fn pause(&mut self) -> result::Result<(), MigratableError> {
+        Ok(())
+    }
+
+    fn resume(&mut self) -> result::Result<(), MigratableError> {
+        Ok(())
+    }
+}
+
+impl Snapshotable for MmioDevice {}
+impl Migratable for MmioDevice {}

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -15,6 +15,7 @@ extern crate vmm_sys_util;
 
 use libc::EFD_NONBLOCK;
 use std::any::Any;
+use std::result;
 use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -26,6 +27,7 @@ use pci::{
     PciMassStorageSubclass, PciNetworkControllerSubclass, PciSubclass,
 };
 use vm_allocator::SystemAllocator;
+use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{Address, ByteValued, GuestAddress, GuestMemoryMmap, GuestUsize, Le32};
 use vmm_sys_util::{errno::Result, eventfd::EventFd};
 
@@ -762,3 +764,16 @@ impl BusDevice for VirtioPciDevice {
         self.write_bar(base, offset, data)
     }
 }
+
+impl Pausable for VirtioPciDevice {
+    fn pause(&mut self) -> result::Result<(), MigratableError> {
+        Ok(())
+    }
+
+    fn resume(&mut self) -> result::Result<(), MigratableError> {
+        Ok(())
+    }
+}
+
+impl Snapshotable for VirtioPciDevice {}
+impl Migratable for VirtioPciDevice {}

--- a/vm-virtio/src/vhost_user/blk.rs
+++ b/vm-virtio/src/vhost_user/blk.rs
@@ -6,12 +6,17 @@ use libc::EFD_NONBLOCK;
 use std::cmp;
 use std::io::Write;
 use std::ptr::null;
+use std::result;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::vec::Vec;
 
 use crate::VirtioInterrupt;
 
+use super::Error as DeviceError;
+
+use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::GuestMemoryMmap;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -38,12 +43,15 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {}
 pub struct Blk {
     vhost_user_blk: Master,
     kill_evt: Option<EventFd>,
+    pause_evt: Option<EventFd>,
     avail_features: u64,
     acked_features: u64,
     config_space: Vec<u8>,
     queue_sizes: Vec<u16>,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<VirtioInterrupt>>,
+    epoll_thread: Option<thread::JoinHandle<result::Result<(), DeviceError>>>,
+    paused: Arc<AtomicBool>,
 }
 
 impl Blk {
@@ -118,12 +126,15 @@ impl Blk {
         Ok(Blk {
             vhost_user_blk,
             kill_evt: None,
+            pause_evt: None,
             avail_features,
             acked_features,
             config_space,
             queue_sizes: vec![vu_cfg.queue_size; vu_cfg.num_queues],
             queue_evts: None,
             interrupt_cb: None,
+            epoll_thread: None,
+            paused: Arc::new(AtomicBool::new(false)),
         })
     }
 }
@@ -216,15 +227,21 @@ impl VirtioDevice for Blk {
         queues: Vec<Queue>,
         queue_evts: Vec<EventFd>,
     ) -> ActivateResult {
-        let (self_kill_evt, kill_evt) =
-            match EventFd::new(EFD_NONBLOCK).and_then(|e| Ok((e.try_clone()?, e))) {
-                Ok(v) => v,
-                Err(e) => {
-                    error!("failed creating kill EventFd pair: {}", e);
-                    return Err(ActivateError::BadActivate);
-                }
-            };
+        let (self_kill_evt, kill_evt) = EventFd::new(EFD_NONBLOCK)
+            .and_then(|e| Ok((e.try_clone()?, e)))
+            .map_err(|e| {
+                error!("failed creating kill EventFd pair: {}", e);
+                ActivateError::BadActivate
+            })?;
         self.kill_evt = Some(self_kill_evt);
+
+        let (self_pause_evt, pause_evt) = EventFd::new(EFD_NONBLOCK)
+            .and_then(|e| Ok((e.try_clone()?, e)))
+            .map_err(|e| {
+                error!("failed creating pause EventFd pair: {}", e);
+                ActivateError::BadActivate
+            })?;
+        self.pause_evt = Some(self_pause_evt);
 
         // Save the interrupt EventFD as we need to return it on reset
         // but clone it to pass into the thread.
@@ -253,24 +270,30 @@ impl VirtioDevice for Blk {
         let mut handler = VhostUserEpollHandler::<SlaveReqHandler>::new(VhostUserEpollConfig {
             interrupt_cb,
             kill_evt,
+            pause_evt,
             vu_interrupt_list,
             slave_req_handler: None,
         });
 
-        let handler_result = thread::Builder::new()
+        let paused = self.paused.clone();
+        thread::Builder::new()
             .name("vhost_user_blk".to_string())
-            .spawn(move || {
-                if let Err(e) = handler.run() {
-                    error!("net worker thread exited with error {:?}!", e);
-                }
-            });
-        if let Err(e) = handler_result {
-            error!("vhost-user blk thread create failed with error {:?}", e);
-        }
+            .spawn(move || handler.run(paused))
+            .map(|thread| self.epoll_thread = Some(thread))
+            .map_err(|e| {
+                error!("failed to clone virtio epoll thread: {}", e);
+                ActivateError::BadActivate
+            })?;
+
         Ok(())
     }
 
     fn reset(&mut self) -> Option<(Arc<VirtioInterrupt>, Vec<EventFd>)> {
+        // We first must resume the virtio thread if it was paused.
+        if self.pause_evt.take().is_some() {
+            self.resume().ok()?;
+        }
+
         if let Err(e) = reset_vhost_user(&mut self.vhost_user_blk, self.queue_sizes.len()) {
             error!("Failed to reset vhost-user daemon: {:?}", e);
             return None;
@@ -288,3 +311,7 @@ impl VirtioDevice for Blk {
         ))
     }
 }
+
+virtio_pausable!(Blk);
+impl Snapshotable for Blk {}
+impl Migratable for Blk {}

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -13,6 +13,7 @@ cmos = ["devices/cmos"]
 
 [dependencies]
 acpi_tables = { path = "../acpi_tables", optional = true }
+anyhow = "1.0"
 arch = { path = "../arch" }
 devices = { path = "../devices" }
 epoll = ">=4.0.1"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -30,6 +30,7 @@ serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 vfio = { path = "../vfio", optional = true }
 vm-allocator = { path = "../vm-allocator" }
+vm-device = { path = "../vm-device" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 signal-hook = "0.1.10"

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -23,6 +23,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::mpsc::{Receiver, RecvError, SendError, Sender};
 use std::sync::{Arc, Mutex};
 use std::{result, thread};
+use vm_device::Pausable;
 use vmm_sys_util::eventfd::EventFd;
 
 pub mod api;
@@ -236,7 +237,7 @@ impl Vmm {
 
     fn vm_pause(&mut self) -> result::Result<(), VmError> {
         if let Some(ref mut vm) = self.vm {
-            vm.pause()
+            vm.pause().map_err(VmError::Pause)
         } else {
             Err(VmError::VmNotRunning)
         }
@@ -244,7 +245,7 @@ impl Vmm {
 
     fn vm_resume(&mut self) -> result::Result<(), VmError> {
         if let Some(ref mut vm) = self.vm {
-            vm.resume()
+            vm.resume().map_err(VmError::Resume)
         } else {
             Err(VmError::VmNotRunning)
         }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -152,6 +152,12 @@ pub enum Error {
 
     /// Cannot resume devices
     ResumeDevices(MigratableError),
+
+    /// Cannot pause CPUs
+    PauseCpus(MigratableError),
+
+    /// Cannot resume cpus
+    ResumeCpus(MigratableError),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -633,7 +639,7 @@ impl Vm {
             .lock()
             .unwrap()
             .pause()
-            .map_err(Error::CpuManager)?;
+            .map_err(Error::PauseCpus)?;
         self.devices.pause().map_err(Error::PauseDevices)?;
 
         *state = new_state;
@@ -652,7 +658,7 @@ impl Vm {
             .lock()
             .unwrap()
             .resume()
-            .map_err(Error::CpuManager)?;
+            .map_err(Error::ResumeCpus)?;
 
         // And we're back to the Running state.
         *state = new_state;


### PR DESCRIPTION
Define the `Pausable` trait for components that can pause and resume.
Through this trait we can do 2 things:

1. Iteratively go through all devices and pause or resume them when respectively pausing or resuming a VM. This fixes #341  
2. Define the `Migratable` trait as a conjonction of the `Pausable` and `Snapshotable` traits. PR #444 is now based on this PR and on the `Pausable` trait.

To emphasize the relationship between this PR and #444: #444 defines the `Snapshotable` trait on top of the `Pausable` one and this current PR allows to make the initial migration/snapshoting implementation shorter by pushing the `Pausable` part first. 

Fixes #341