### PR TITLE
ci: Extend VFIO integration test

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -145,6 +145,10 @@ sudo ip tuntap add vfio-tap1 mode tap
 sudo ip link set vfio-tap1 master vfio-br0
 sudo ip link set vfio-tap1 up
 
+sudo ip tuntap add vfio-tap2 mode tap
+sudo ip link set vfio-tap2 master vfio-br0
+sudo ip link set vfio-tap2 up
+
 cargo build --release
 sudo setcap cap_net_admin+ep target/release/cloud-hypervisor
 sudo setcap cap_net_admin+ep target/release/vhost_user_net
@@ -187,5 +191,6 @@ fi
 sudo ip link del vfio-br0
 sudo ip link del vfio-tap0
 sudo ip link del vfio-tap1
+sudo ip link del vfio-tap2
 
 exit $RES

--- a/test_data/cloud-init/clear/openstack/latest/user_data
+++ b/test_data/cloud-init/clear/openstack/latest/user_data
@@ -17,7 +17,7 @@ write_files:
         Gateway=192.168.2.1
 
   -
-    path: /etc/systemd/network/00-static-l2.network
+    path: /etc/systemd/network/00-static-l2-1.network
     permissions: 0644
     content: |
         [Match]
@@ -25,6 +25,17 @@ write_files:
 
         [Network]
         Address=192.168.2.3/24
+        Gateway=192.168.2.1
+
+  -
+    path: /etc/systemd/network/00-static-l2-2.network
+    permissions: 0644
+    content: |
+        [Match]
+        MACAddress=de:ad:be:ef:34:56
+
+        [Network]
+        Address=192.168.2.4/24
         Gateway=192.168.2.1
 
   -
@@ -50,5 +61,7 @@ write_files:
         mount -t virtio_fs virtiofs /mnt -o rootmode=040000,user_id=0,group_id=0,dax
         bash -c "echo 0000:00:05.0 > /sys/bus/pci/devices/0000\:00\:05.0/driver/unbind"
         bash -c "echo 1af4 1041 > /sys/bus/pci/drivers/vfio-pci/new_id"
+        bash -c "echo 0000:00:06.0 > /sys/bus/pci/devices/0000\:00\:06.0/driver/unbind"
+        bash -c "echo 1af4 1041 > /sys/bus/pci/drivers/vfio-pci/new_id"
 
-        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda2 VFIOTAG" --disk path=/mnt/clear-31310-cloudguest.img path=/mnt/cloudinit.img --cpus 1 --memory size=512M --rng --device path=/sys/bus/pci/devices/0000:00:05.0/
+        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda2 VFIOTAG" --disk path=/mnt/clear-31310-cloudguest.img path=/mnt/cloudinit.img --cpus 1 --memory size=512M --rng --device path=/sys/bus/pci/devices/0000:00:05.0/ path=/sys/bus/pci/devices/0000:00:06.0/


### PR DESCRIPTION
In order to validate that multiple devices can be passed through and
they are still fully functional, this patch extends the existing VFIO
test to pass a second virtio-net device, and verifies that both
interfaces are functional by ssh'ing into each network interface.

Fixes #503

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>