### PR TITLE
vmm: api: Modify FsConfig to be OpenAPI friendly

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -321,9 +321,13 @@ components:
           type: integer
         queue_size:
           type: integer
+        dax:
+          type: boolean
+          default: true
         cache_size:
           type: integer
           format: int64
+          default: 8589934592
 
     PmemConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -409,7 +409,8 @@ pub struct FsConfig {
     pub sock: PathBuf,
     pub num_queues: usize,
     pub queue_size: u16,
-    pub cache_size: Option<u64>,
+    pub dax: bool,
+    pub cache_size: u64,
 }
 
 impl FsConfig {
@@ -444,7 +445,7 @@ impl FsConfig {
         let mut queue_size: u16 = 1024;
         let mut dax: bool = true;
         // Default cache size set to 8Gib.
-        let mut cache_size: Option<u64> = Some(0x0002_0000_0000);
+        let mut cache_size: u64 = 0x0002_0000_0000;
 
         if tag.is_empty() {
             return Err(Error::ParseFsTagParam);
@@ -476,9 +477,9 @@ impl FsConfig {
             if !cache_size_str.is_empty() {
                 return Err(Error::InvalidCacheSizeWithDaxOff);
             }
-            cache_size = None;
+            cache_size = 0;
         } else if !cache_size_str.is_empty() {
-            cache_size = Some(parse_size(cache_size_str)?);
+            cache_size = parse_size(cache_size_str)?;
         }
 
         Ok(FsConfig {
@@ -486,6 +487,7 @@ impl FsConfig {
             sock: PathBuf::from(sock),
             num_queues,
             queue_size,
+            dax,
             cache_size,
         })
     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -958,8 +958,8 @@ impl DeviceManager {
         if let Some(fs_list_cfg) = &vm_info.vm_cfg.lock().unwrap().fs {
             for fs_cfg in fs_list_cfg.iter() {
                 if let Some(fs_sock) = fs_cfg.sock.to_str() {
-                    let mut cache: Option<(VirtioSharedMemoryList, u64)> = None;
-                    if let Some(fs_cache) = fs_cfg.cache_size {
+                    let cache: Option<(VirtioSharedMemoryList, u64)> = if fs_cfg.dax {
+                        let fs_cache = fs_cfg.cache_size;
                         // The memory needs to be 2MiB aligned in order to support
                         // hugepages.
                         let fs_guest_addr = allocator
@@ -1004,15 +1004,18 @@ impl DeviceManager {
                             offset: 0,
                             len: fs_cache,
                         });
-                        cache = Some((
+
+                        Some((
                             VirtioSharedMemoryList {
                                 addr: fs_guest_addr,
                                 len: fs_cache as GuestUsize,
                                 region_list,
                             },
                             addr as u64,
-                        ));
-                    }
+                        ))
+                    } else {
+                        None
+                    };
 
                     let virtio_fs_device = vm_virtio::vhost_user::Fs::new(
                         fs_sock,


### PR DESCRIPTION
When consumer of the HTTP API try to interact with cloud-hypervisor,
they have to provide the equivalent of the config structure related to
each component they need. Problem is, the Rust enum type "Option" cannot
be obtained from the OpenAPI YAML definition.

This patch intends to fix this inconsistency between what is possible
through the CLI and what's possible through the HTTP API by using simple
types bool and int64 instead of Option<u64>.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>