### PR TITLE
vmm: api: Make NetConfig structure more OpenAPI friendly

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -281,6 +281,7 @@ components:
       properties:
         tap:
           type: string
+          default: ""
         ip:
           type: string
           default: "192.168.249.1"

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -276,8 +276,6 @@ components:
 
     NetConfig:
       required:
-      - ip
-      - mask
       - mac
       type: object
       properties:
@@ -285,8 +283,10 @@ components:
           type: string
         ip:
           type: string
+          default: "192.168.249.1"
         mask:
           type: string
+          default: "255.255.255.0"
         mac:
           type: string
         iommu:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -302,7 +302,7 @@ impl DiskConfig {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NetConfig {
-    pub tap: Option<String>,
+    pub tap: String,
     pub ip: Ipv4Addr,
     pub mask: Ipv4Addr,
     pub mac: MacAddr,
@@ -335,15 +335,11 @@ impl NetConfig {
             }
         }
 
-        let mut tap: Option<String> = None;
         let mut ip: Ipv4Addr = Ipv4Addr::new(192, 168, 249, 1);
         let mut mask: Ipv4Addr = Ipv4Addr::new(255, 255, 255, 0);
         let mut mac: MacAddr = MacAddr::local_random();
         let iommu = parse_on_off(iommu_str)?;
 
-        if !tap_str.is_empty() {
-            tap = Some(tap_str.to_string());
-        }
         if !ip_str.is_empty() {
             ip = ip_str.parse().map_err(Error::ParseNetIpParam)?;
         }
@@ -355,7 +351,7 @@ impl NetConfig {
         }
 
         Ok(NetConfig {
-            tap,
+            tap: tap_str.to_string(),
             ip,
             mask,
             mac,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -909,12 +909,13 @@ impl DeviceManager {
         // Add virtio-net if required
         if let Some(net_list_cfg) = &vm_info.vm_cfg.lock().unwrap().net {
             for net_cfg in net_list_cfg.iter() {
-                let virtio_net_device = if let Some(ref tap_if_name) = net_cfg.tap {
-                    let tap = Tap::open_named(tap_if_name).map_err(DeviceManagerError::OpenTap)?;
-                    vm_virtio::Net::new_with_tap(tap, Some(&net_cfg.mac), net_cfg.iommu)
+                let virtio_net_device = if net_cfg.tap.is_empty() {
+                    vm_virtio::Net::new(net_cfg.ip, net_cfg.mask, Some(&net_cfg.mac), net_cfg.iommu)
                         .map_err(DeviceManagerError::CreateVirtioNet)?
                 } else {
-                    vm_virtio::Net::new(net_cfg.ip, net_cfg.mask, Some(&net_cfg.mac), net_cfg.iommu)
+                    let tap = Tap::open_named(net_cfg.tap.as_str())
+                        .map_err(DeviceManagerError::OpenTap)?;
+                    vm_virtio::Net::new_with_tap(tap, Some(&net_cfg.mac), net_cfg.iommu)
                         .map_err(DeviceManagerError::CreateVirtioNet)?
                 };
 


### PR DESCRIPTION
In order to keep things consistent between the CLI and the HTTP API, this pull request submit some changes to the NetConfig structure. It will be possible for a consumer of the API to have the same level of functionality as if it was using the CLI.