### PR TITLE
Remove hardcoded GED IRQ

### DIFF
--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -57,13 +57,15 @@ impl BusDevice for AcpiShutdownDevice {
 pub struct AcpiGEDDevice {
     interrupt: Box<dyn Interrupt>,
     notification_type: HotPlugNotificationType,
+    ged_irq: u32,
 }
 
 impl AcpiGEDDevice {
-    pub fn new(interrupt: Box<dyn Interrupt>) -> AcpiGEDDevice {
+    pub fn new(interrupt: Box<dyn Interrupt>, ged_irq: u32) -> AcpiGEDDevice {
         AcpiGEDDevice {
             interrupt,
             notification_type: HotPlugNotificationType::NoDevicesChanged,
+            ged_irq,
         }
     }
 
@@ -73,6 +75,10 @@ impl AcpiGEDDevice {
     ) -> Result<(), std::io::Error> {
         self.notification_type = notification_type;
         self.interrupt.deliver()
+    }
+
+    pub fn irq(&self) -> u32 {
+        self.ged_irq
     }
 }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -51,7 +51,7 @@ use vm_memory::{
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::terminal::Terminal;
 
-const X86_64_IRQ_BASE: u32 = 6;
+const X86_64_IRQ_BASE: u32 = 5;
 
 // CPUID feature bits
 const TSC_DEADLINE_TIMER_ECX_BIT: u8 = 24; // tsc deadline timer ecx bit.


### PR DESCRIPTION
Now that creation of the ACPI tables is delegated to the device manager the hardcoded GED IRQ can be removed.