### PR TITLE
vmm: api: Make FsConfig defaults match between CLI and HTTP API

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -313,8 +313,6 @@ components:
       required:
       - tag
       - sock
-      - num_queues
-      - queue_size
       type: object
       properties:
         tag:
@@ -323,11 +321,14 @@ components:
           type: string
         num_queues:
           type: integer
+          default: 1
         queue_size:
           type: integer
+          default: 1024
         cache_size:
           type: integer
           format: int64
+          default: 8589934592
 
     PmemConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -407,9 +407,24 @@ impl Default for RngConfig {
 pub struct FsConfig {
     pub tag: String,
     pub sock: PathBuf,
+    #[serde(default = "default_fsconfig_num_queues")]
     pub num_queues: usize,
+    #[serde(default = "default_fsconfig_queue_size")]
     pub queue_size: u16,
+    #[serde(default = "default_fsconfig_cache_size")]
     pub cache_size: Option<u64>,
+}
+
+fn default_fsconfig_num_queues() -> usize {
+    1
+}
+
+fn default_fsconfig_queue_size() -> u16 {
+    1024
+}
+
+fn default_fsconfig_cache_size() -> Option<u64> {
+    Some(0x0002_0000_0000)
 }
 
 impl FsConfig {
@@ -440,11 +455,11 @@ impl FsConfig {
             }
         }
 
-        let mut num_queues: usize = 1;
-        let mut queue_size: u16 = 1024;
+        let mut num_queues: usize = default_fsconfig_num_queues();
+        let mut queue_size: u16 = default_fsconfig_queue_size();
         let mut dax: bool = true;
         // Default cache size set to 8Gib.
-        let mut cache_size: Option<u64> = Some(0x0002_0000_0000);
+        let mut cache_size: Option<u64> = default_fsconfig_cache_size();
 
         if tag.is_empty() {
             return Err(Error::ParseFsTagParam);


### PR DESCRIPTION
In order to let the CLI and the HTTP API behave the same regarding the
FsConfig structure, this patch defines some default values for
num_queues, queue_size and the cache_size.

num_queues is set to 1, queue_size is set to 1024, and cache_size is set
to Some(8G) which means that DAX is enabled by default with a shared
region of 8GiB.

Fixes #508

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>