### PR TITLE
Make CLI and HTTP API behave identically

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
         }
     }
 
-    let default_vcpus = format! {"{}", config::DEFAULT_VCPUS};
+    let default_vcpus = format! {"boot={}", config::DEFAULT_VCPUS};
     let default_memory = format! {"size={}M", config::DEFAULT_MEMORY_MB};
     let default_rng = format! {"src={}", config::DEFAULT_RNG_SOURCE};
 

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -391,19 +391,19 @@ components:
     VhostUserBlkConfig:
       required:
       - sock
-      - num_queues
-      - queue_size
-      - wce
       type: object
       properties:
         sock:
           type: string
         num_queues:
           type: integer
+          default: 1
         queue_size:
           type: integer
+          default: 128
         wce:
           type: boolean
+          default: true
 
     VsockConfig:
       required:

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -171,7 +171,7 @@ components:
       type: object
       properties:
         cpus:
-          $ref: '#/components/schemas/CpuConfig'
+          $ref: '#/components/schemas/CpusConfig'
         memory:
           $ref: '#/components/schemas/MemoryConfig'
         kernel:
@@ -221,7 +221,7 @@ components:
           default: false
       description: Virtual machine configuration
 
-    CpuConfig:
+    CpusConfig:
       required:
       - boot_vcpus
       - max_vcpus

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -324,6 +324,9 @@ components:
         queue_size:
           type: integer
           default: 1024
+        dax:
+          type: boolean
+          default: true
         cache_size:
           type: integer
           format: int64

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -375,17 +375,16 @@ components:
     VhostUserNetConfig:
       required:
       - sock
-      - num_queues
-      - queue_size
-      - mac
       type: object
       properties:
         sock:
           type: string
         num_queues:
           type: integer
+          default: 2
         queue_size:
           type: integer
+          default: 256
         mac:
           type: string
 

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -372,41 +372,39 @@ components:
           type: boolean
           default: false
 
-    VhostUserConfig:
+    VhostUserNetConfig:
       required:
       - sock
       - num_queues
       - queue_size
+      - mac
       type: object
       properties:
         sock:
           type: string
         num_queues:
           type: integer
-        queue:size:
+        queue_size:
           type: integer
-
-    VhostUserNetConfig:
-      required:
-      - mac
-      - vu_cfg
-      type: object
-      properties:
         mac:
           type: string
-        vu_cfg:
-          $ref: '#/components/schemas/VhostUserConfig'
 
     VhostUserBlkConfig:
       required:
+      - sock
+      - num_queues
+      - queue_size
       - wce
-      - vu_cfg
       type: object
       properties:
+        sock:
+          type: string
+        num_queues:
+          type: integer
+        queue_size:
+          type: integer
         wce:
           type: boolean
-        vu_cfg:
-          $ref: '#/components/schemas/VhostUserConfig'
 
     VsockConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -436,8 +436,10 @@ pub struct FsConfig {
     pub num_queues: usize,
     #[serde(default = "default_fsconfig_queue_size")]
     pub queue_size: u16,
+    #[serde(default = "default_fsconfig_dax")]
+    pub dax: bool,
     #[serde(default = "default_fsconfig_cache_size")]
-    pub cache_size: Option<u64>,
+    pub cache_size: u64,
 }
 
 fn default_fsconfig_num_queues() -> usize {
@@ -448,8 +450,12 @@ fn default_fsconfig_queue_size() -> u16 {
     1024
 }
 
-fn default_fsconfig_cache_size() -> Option<u64> {
-    Some(0x0002_0000_0000)
+fn default_fsconfig_dax() -> bool {
+    true
+}
+
+fn default_fsconfig_cache_size() -> u64 {
+    0x0002_0000_0000
 }
 
 impl FsConfig {
@@ -482,9 +488,9 @@ impl FsConfig {
 
         let mut num_queues: usize = default_fsconfig_num_queues();
         let mut queue_size: u16 = default_fsconfig_queue_size();
-        let mut dax: bool = true;
+        let mut dax: bool = default_fsconfig_dax();
         // Default cache size set to 8Gib.
-        let mut cache_size: Option<u64> = default_fsconfig_cache_size();
+        let mut cache_size: u64 = default_fsconfig_cache_size();
 
         if tag.is_empty() {
             return Err(Error::ParseFsTagParam);
@@ -516,9 +522,9 @@ impl FsConfig {
             if !cache_size_str.is_empty() {
                 return Err(Error::InvalidCacheSizeWithDaxOff);
             }
-            cache_size = None;
+            cache_size = 0;
         } else if !cache_size_str.is_empty() {
-            cache_size = Some(parse_size(cache_size_str)?);
+            cache_size = parse_size(cache_size_str)?;
         }
 
         Ok(FsConfig {
@@ -526,6 +532,7 @@ impl FsConfig {
             sock: PathBuf::from(sock),
             num_queues,
             queue_size,
+            dax,
             cache_size,
         })
     }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -694,16 +694,11 @@ impl DeviceConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct VuConfig {
+pub struct VhostUserNetConfig {
     pub sock: String,
     pub num_queues: usize,
     pub queue_size: u16,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct VhostUserNetConfig {
     pub mac: MacAddr,
-    pub vu_cfg: VuConfig,
 }
 
 impl VhostUserNetConfig {
@@ -749,13 +744,12 @@ impl VhostUserNetConfig {
                 .map_err(Error::ParseVuQueueSizeParam)?;
         }
 
-        let vu_cfg = VuConfig {
+        Ok(VhostUserNetConfig {
             sock: sock.to_string(),
             num_queues,
             queue_size,
-        };
-
-        Ok(VhostUserNetConfig { mac, vu_cfg })
+            mac,
+        })
     }
 }
 
@@ -800,8 +794,10 @@ impl VsockConfig {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VhostUserBlkConfig {
+    pub sock: String,
+    pub num_queues: usize,
+    pub queue_size: u16,
     pub wce: bool,
-    pub vu_cfg: VuConfig,
 }
 
 impl VhostUserBlkConfig {
@@ -844,13 +840,12 @@ impl VhostUserBlkConfig {
             wce = wce_str.parse().map_err(Error::ParseVuBlkWceParam)?;
         }
 
-        let vu_cfg = VuConfig {
+        Ok(VhostUserBlkConfig {
             sock: sock.to_string(),
             num_queues,
             queue_size,
-        };
-
-        Ok(VhostUserBlkConfig { wce, vu_cfg })
+            wce,
+        })
     }
 }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -15,6 +15,8 @@ use std::result;
 pub const DEFAULT_VCPUS: u8 = 1;
 pub const DEFAULT_MEMORY_MB: u64 = 512;
 pub const DEFAULT_RNG_SOURCE: &str = "/dev/urandom";
+pub const DEFAULT_NUM_QUEUES_VUNET: usize = 2;
+pub const DEFAULT_QUEUE_SIZE_VUNET: u16 = 256;
 
 /// Errors associated with VM configuration parameters.
 #[derive(Debug)]
@@ -696,9 +698,24 @@ impl DeviceConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VhostUserNetConfig {
     pub sock: String,
+    #[serde(default = "default_vunetconfig_num_queues")]
     pub num_queues: usize,
+    #[serde(default = "default_vunetconfig_queue_size")]
     pub queue_size: u16,
+    #[serde(default = "default_vunetconfig_mac")]
     pub mac: MacAddr,
+}
+
+fn default_vunetconfig_num_queues() -> usize {
+    DEFAULT_NUM_QUEUES_VUNET
+}
+
+fn default_vunetconfig_queue_size() -> u16 {
+    DEFAULT_QUEUE_SIZE_VUNET
+}
+
+fn default_vunetconfig_mac() -> MacAddr {
+    MacAddr::local_random()
 }
 
 impl VhostUserNetConfig {
@@ -723,9 +740,9 @@ impl VhostUserNetConfig {
             }
         }
 
-        let mut mac: MacAddr = MacAddr::local_random();
-        let mut num_queues: usize = 2;
-        let mut queue_size: u16 = 256;
+        let mut mac: MacAddr = default_vunetconfig_mac();
+        let mut num_queues: usize = default_vunetconfig_num_queues();
+        let mut queue_size: u16 = default_vunetconfig_queue_size();
 
         if !mac_str.is_empty() {
             mac = MacAddr::parse_str(mac_str).map_err(Error::ParseVuNetMacParam)?;

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -17,6 +17,8 @@ pub const DEFAULT_MEMORY_MB: u64 = 512;
 pub const DEFAULT_RNG_SOURCE: &str = "/dev/urandom";
 pub const DEFAULT_NUM_QUEUES_VUNET: usize = 2;
 pub const DEFAULT_QUEUE_SIZE_VUNET: u16 = 256;
+pub const DEFAULT_NUM_QUEUES_VUBLK: usize = 1;
+pub const DEFAULT_QUEUE_SIZE_VUBLK: u16 = 128;
 
 /// Errors associated with VM configuration parameters.
 #[derive(Debug)]
@@ -812,9 +814,24 @@ impl VsockConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VhostUserBlkConfig {
     pub sock: String,
+    #[serde(default = "default_vublkconfig_num_queues")]
     pub num_queues: usize,
+    #[serde(default = "default_vublkconfig_queue_size")]
     pub queue_size: u16,
+    #[serde(default = "default_vublkconfig_wce")]
     pub wce: bool,
+}
+
+fn default_vublkconfig_num_queues() -> usize {
+    DEFAULT_NUM_QUEUES_VUBLK
+}
+
+fn default_vublkconfig_queue_size() -> u16 {
+    DEFAULT_QUEUE_SIZE_VUBLK
+}
+
+fn default_vublkconfig_wce() -> bool {
+    true
 }
 
 impl VhostUserBlkConfig {
@@ -839,9 +856,9 @@ impl VhostUserBlkConfig {
             }
         }
 
-        let mut num_queues: usize = 1;
-        let mut queue_size: u16 = 128;
-        let mut wce: bool = true;
+        let mut num_queues: usize = default_vublkconfig_num_queues();
+        let mut queue_size: u16 = default_vublkconfig_queue_size();
+        let mut wce: bool = default_vublkconfig_wce();
 
         if !num_queues_str.is_empty() {
             num_queues = num_queues_str

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -196,6 +196,7 @@ impl Default for CpusConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MemoryConfig {
     pub size: u64,
+    #[serde(default)]
     pub file: Option<PathBuf>,
     #[serde(default)]
     pub mergeable: bool,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -591,10 +591,15 @@ impl ConsoleOutputMode {
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct ConsoleConfig {
+    #[serde(default = "default_consoleconfig_file")]
     pub file: Option<PathBuf>,
     pub mode: ConsoleOutputMode,
     #[serde(default)]
     pub iommu: bool,
+}
+
+fn default_consoleconfig_file() -> Option<PathBuf> {
+    None
 }
 
 impl ConsoleConfig {
@@ -603,7 +608,7 @@ impl ConsoleConfig {
         let params_list: Vec<&str> = console.split(',').collect();
 
         let mut valid = false;
-        let mut file: Option<PathBuf> = None;
+        let mut file: Option<PathBuf> = default_consoleconfig_file();
         let mut mode: ConsoleOutputMode = ConsoleOutputMode::Off;
         let mut iommu_str: &str = "";
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -977,8 +977,8 @@ impl DeviceManager {
         if let Some(fs_list_cfg) = &vm_info.vm_cfg.lock().unwrap().fs {
             for fs_cfg in fs_list_cfg.iter() {
                 if let Some(fs_sock) = fs_cfg.sock.to_str() {
-                    let mut cache: Option<(VirtioSharedMemoryList, u64)> = None;
-                    if let Some(fs_cache) = fs_cfg.cache_size {
+                    let cache: Option<(VirtioSharedMemoryList, u64)> = if fs_cfg.dax {
+                        let fs_cache = fs_cfg.cache_size;
                         // The memory needs to be 2MiB aligned in order to support
                         // hugepages.
                         let fs_guest_addr = allocator
@@ -1023,15 +1023,18 @@ impl DeviceManager {
                             offset: 0,
                             len: fs_cache,
                         });
-                        cache = Some((
+
+                        Some((
                             VirtioSharedMemoryList {
                                 addr: fs_guest_addr,
                                 len: fs_cache as GuestUsize,
                                 region_list,
                             },
                             addr as u64,
-                        ));
-                    }
+                        ))
+                    } else {
+                        None
+                    };
 
                     let virtio_fs_device = vm_virtio::vhost_user::Fs::new(
                         fs_sock,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1162,9 +1162,9 @@ impl DeviceManager {
         if let Some(vhost_user_net_list_cfg) = &vm_info.vm_cfg.lock().unwrap().vhost_user_net {
             for vhost_user_net_cfg in vhost_user_net_list_cfg.iter() {
                 let vu_cfg = VhostUserConfig {
-                    sock: vhost_user_net_cfg.vu_cfg.sock.clone(),
-                    num_queues: vhost_user_net_cfg.vu_cfg.num_queues,
-                    queue_size: vhost_user_net_cfg.vu_cfg.queue_size,
+                    sock: vhost_user_net_cfg.sock.clone(),
+                    num_queues: vhost_user_net_cfg.num_queues,
+                    queue_size: vhost_user_net_cfg.queue_size,
                 };
                 let vhost_user_net_device =
                     vm_virtio::vhost_user::Net::new(vhost_user_net_cfg.mac, vu_cfg)
@@ -1188,9 +1188,9 @@ impl DeviceManager {
         if let Some(vhost_user_blk_list_cfg) = &vm_info.vm_cfg.lock().unwrap().vhost_user_blk {
             for vhost_user_blk_cfg in vhost_user_blk_list_cfg.iter() {
                 let vu_cfg = VhostUserConfig {
-                    sock: vhost_user_blk_cfg.vu_cfg.sock.clone(),
-                    num_queues: vhost_user_blk_cfg.vu_cfg.num_queues,
-                    queue_size: vhost_user_blk_cfg.vu_cfg.queue_size,
+                    sock: vhost_user_blk_cfg.sock.clone(),
+                    num_queues: vhost_user_blk_cfg.num_queues,
+                    queue_size: vhost_user_blk_cfg.queue_size,
                 };
                 let vhost_user_blk_device =
                     vm_virtio::vhost_user::Blk::new(vhost_user_blk_cfg.wce, vu_cfg)


### PR DESCRIPTION
The point of this pull request is to improve a bit the code and the OpenAPI definition to ensure CLI and HTTP behave the same regarding the provided parameters, and especially regarding the default values being picked.