### PR TITLE
ci: Offload more tests to the Azure worker node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,7 @@ language: rust
 rust:
   - stable
 
-before_script:
-  - rustup component add clippy
-  - rustup component add rustfmt
-  - cargo install --force cargo-audit
-
 script:
-  - cargo rustc --bin cloud-hypervisor -- -D warnings
-  - cargo rustc --bin vhost_user_net -- -D warnings
-  - cargo test
-  - cargo audit
-  - cargo rustc --bin cloud-hypervisor --no-default-features --features "pci,acpi"  -- -D warnings
-  - cargo rustc --bin vhost_user_net --no-default-features --features "pci,acpi"  -- -D warnings
-  - cargo clippy --all-targets --all-features -- -D warnings
-  - cargo rustc --bin cloud-hypervisor --no-default-features --features "pci"  -- -D warnings
-  - cargo rustc --bin vhost_user_net --no-default-features --features "pci"  -- -D warnings
-  - cargo rustc --bin cloud-hypervisor --no-default-features --features "mmio"  -- -D warnings
-  - cargo rustc --bin vhost_user_net --no-default-features --features "mmio"  -- -D warnings
-  - find . -name "*.rs" | xargs rustfmt --check
   - cargo build --release
   
 deploy:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ pipeline{
 			steps {
 				sh "sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq build-essential mtools libssl-dev pkg-config"
 				sh "sudo apt-get install -yq flex bison libelf-dev qemu-utils qemu-system libglib2.0-dev libpixman-1-dev libseccomp-dev socat"
+				sh "sudo snap install docker"
 			}
 		}
 		stage ('Install Rust') {
@@ -23,6 +24,11 @@ pipeline{
 		stage ('Run Cargo tests') {
 			steps {
 				sh "scripts/run_cargo_tests.sh"
+			}
+		}
+		stage ('Run OpenAPI tests') {
+			steps {
+				sh "scripts/run_openapi_tests.sh"
 			}
 		}
 		stage ('Run unit tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,11 @@ pipeline{
 				sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"
 			}
 		}
+		stage ('Run Cargo tests') {
+			steps {
+				sh "scripts/run_cargo_tests.sh"
+			}
+		}
 		stage ('Run unit tests') {
 			steps {
 				sh "scripts/run_unit_tests.sh"

--- a/scripts/run_cargo_tests.sh
+++ b/scripts/run_cargo_tests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+set -x
+
+source $HOME/.cargo/env
+
+# Install cargo components
+rustup component add clippy
+rustup component add rustfmt
+cargo install --force cargo-audit
+
+# Run cargo builds and checks
+cargo rustc --bin cloud-hypervisor -- -D warnings
+cargo rustc --bin vhost_user_net -- -D warnings
+cargo test
+cargo audit
+cargo rustc --bin cloud-hypervisor --no-default-features --features "pci,acpi"  -- -D warnings
+cargo rustc --bin vhost_user_net --no-default-features --features "pci,acpi"  -- -D warnings
+cargo clippy --all-targets --all-features -- -D warnings
+cargo rustc --bin cloud-hypervisor --no-default-features --features "pci"  -- -D warnings
+cargo rustc --bin vhost_user_net --no-default-features --features "pci"  -- -D warnings
+cargo rustc --bin cloud-hypervisor --no-default-features --features "mmio"  -- -D warnings
+cargo rustc --bin vhost_user_net --no-default-features --features "mmio"  -- -D warnings
+find . -name "*.rs" | xargs rustfmt --check
+cargo build --release

--- a/scripts/run_openapi_tests.sh
+++ b/scripts/run_openapi_tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+set -x
+
+sudo docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli validate -i /local/vmm/src/api/openapi/cloud-hypervisor.yaml


### PR DESCRIPTION
In order to run our CI more efficiently, we decided to offload some tests running on Travis to the Azure worker node. Additionally, we introduced some testing for the OpenAPI scheme definition.

Fixes #527 