### PR TITLE
vmm: Port to latest vmm-sys-util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
  "vmm 0.1.0",
- "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -234,7 +234,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -333,7 +333,7 @@ name = "kvm-bindings"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -343,7 +343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -421,7 +421,7 @@ dependencies = [
 name = "net_gen"
 version = "0.1.0"
 dependencies = [
- "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -435,7 +435,7 @@ dependencies = [
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -460,7 +460,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-allocator 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -571,7 +571,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "remain 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -978,7 +978,7 @@ dependencies = [
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -997,7 +997,7 @@ dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1009,7 +1009,7 @@ dependencies = [
  "vhost_rs 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
- "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1073,7 +1073,7 @@ dependencies = [
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1102,7 +1102,7 @@ dependencies = [
  "vm-allocator 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
- "vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1274,7 +1274,7 @@ dependencies = [
 "checksum virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
 "checksum vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)" = "<none>"
 "checksum vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "46996f56aeae31fbc0532ae57a944e00089302f03b18c10c76eebfd9249f4a6c"
-"checksum vmm-sys-util 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6ebb6ba7ba5653b69bfd3fab8c8c363945c0d3f616a6a1592e12122c3be4724e"
+"checksum vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4588e216e77682850f4ae35ec855c2517f93d671a2578d2a32d20bf8a73de38"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ virtio-bindings = "0.1.0"
 vmm = { path = "vmm" }
 vm-device = { path = "vm-device" }
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
-vmm-sys-util = ">=0.2.1"
+vmm-sys-util = ">=0.3.1"
 vm-virtio = { path = "vm-virtio" }
 
 [dev-dependencies]

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -11,7 +11,7 @@ kvm-ioctls = "0.4.0"
 libc = "0.2.60"
 log = "0.4.8"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
-vmm-sys-util = ">=0.2.1"
+vmm-sys-util = ">=0.3.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/net_gen/Cargo.toml
+++ b/net_gen/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
-vmm-sys-util = ">=0.2.1"
+vmm-sys-util = ">=0.3.1"

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["The Chromium OS Authors"]
 libc = "0.2.60"
 rand = "0.7.0"
 serde = "1.0.98"
-vmm-sys-util = ">=0.2.1"
+vmm-sys-util = ">=0.3.1"
 
 net_gen = { path = "../net_gen" }
 

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -11,4 +11,4 @@ devices = { path = "../devices" }
 libc = "0.2.60"
 log = "0.4.8"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
-vmm-sys-util = ">=0.2.1"
+vmm-sys-util = ">=0.3.1"

--- a/qcow/Cargo.toml
+++ b/qcow/Cargo.toml
@@ -13,7 +13,7 @@ byteorder = "1.3.2"
 libc = "0.2.60"
 log = "0.4.8"
 remain = "0.1.3"
-vmm-sys-util = ">=0.2.1"
+vmm-sys-util = ">=0.3.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/vfio/Cargo.toml
+++ b/vfio/Cargo.toml
@@ -14,7 +14,7 @@ pci = { path = "../pci" }
 vfio-bindings = "0.1.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vmm-sys-util = ">=0.2.1"
+vmm-sys-util = ">=0.3.1"
 
 [dependencies.vm-memory]
 git = "https://github.com/rust-vmm/vm-memory"

--- a/vhost_rs/Cargo.toml
+++ b/vhost_rs/Cargo.toml
@@ -15,7 +15,7 @@ vhost-user-slave = []
 [dependencies]
 bitflags = "1.1.0"
 libc = "0.2.60"
-vmm-sys-util = ">=0.2.1"
+vmm-sys-util = ">=0.3.1"
 
 [dependencies.vm-memory]
 git = "https://github.com/rust-vmm/vm-memory"

--- a/vhost_user_backend/Cargo.toml
+++ b/vhost_user_backend/Cargo.toml
@@ -14,7 +14,7 @@ epoll = ">=4.0.1"
 libc = "0.2.66"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
 vm-virtio = { path = "../vm-virtio" }
-vmm-sys-util = ">=0.2.1"
+vmm-sys-util = ">=0.3.1"
 
 [dependencies.vhost_rs]
 path = "../vhost_rs"

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -22,7 +22,7 @@ tempfile = "3.1.0"
 virtio-bindings = { git = "https://github.com/rust-vmm/virtio-bindings", version = "0.1", features = ["virtio-v5_0_0"]}
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vmm-sys-util = ">=0.2.1"
+vmm-sys-util = ">=0.3.1"
 
 [dependencies.vhost_rs]
 path = "../vhost_rs"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = ">=1.0.9"
 vfio = { path = "../vfio", optional = true }
 vm-allocator = { path = "../vm-allocator" }
 vm-virtio = { path = "../vm-virtio" }
-vmm-sys-util = ">=0.2.1"
+vmm-sys-util = ">=0.3.1"
 signal-hook = "0.1.10"
 
 [dependencies.linux-loader]


### PR DESCRIPTION
The signal handling for vCPU signals has changed in the latest release
so switch to the new API.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>