### PR TITLE
vsock: Fix potential host memory overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ dependencies = [
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
 ]
 
 [[package]]

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -10,3 +10,7 @@ thiserror = "1.0"
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
+
+[dependencies.vm-memory]
+git = "https://github.com/rust-vmm/vm-memory"
+features = ["backend-mmap"]

--- a/vm-device/src/lib.rs
+++ b/vm-device/src/lib.rs
@@ -1,5 +1,11 @@
 extern crate serde;
 extern crate thiserror;
+extern crate vm_memory;
+
+use vm_memory::{
+    Address, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap,
+    MemoryRegionAddress,
+};
 
 use thiserror::Error;
 
@@ -42,3 +48,67 @@ pub trait Snapshotable {}
 /// eventually resumed. Thus any Migratable component must be both Pausable
 /// and Snapshotable.
 pub trait Migratable: Pausable + Snapshotable {}
+
+fn get_region_host_address_range(
+    region: &GuestRegionMmap,
+    addr: MemoryRegionAddress,
+    size: usize,
+) -> Option<*mut u8> {
+    region.check_address(addr).and_then(|addr| {
+        region
+            .checked_offset(addr, size)
+            .map(|_| region.as_ptr().wrapping_offset(addr.raw_value() as isize))
+    })
+}
+
+/// Convert an absolute address into an address space (GuestMemory)
+/// to a host pointer and verify that the provided size define a valid
+/// range within a single memory region.
+/// Return None if it is out of bounds or if addr+size overlaps a single region.
+///
+/// This is a temporary vm-memory wrapper.
+pub fn get_host_address_range(
+    mem: &GuestMemoryMmap,
+    addr: GuestAddress,
+    size: usize,
+) -> Option<*mut u8> {
+    mem.to_region_addr(addr)
+        .and_then(|(r, addr)| get_region_host_address_range(r, addr, size))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use vm_memory::{GuestAddress, GuestMemoryMmap};
+
+    #[test]
+    fn test_get_host_address_range() {
+        let start_addr1 = GuestAddress(0x0);
+        let start_addr2 = GuestAddress(0x1000);
+        let guest_mem =
+            GuestMemoryMmap::new(&[(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
+
+        assert!(get_host_address_range(&guest_mem, GuestAddress(0x600), 0x100).is_none());
+
+        // Overlapping range
+        assert!(get_host_address_range(&guest_mem, GuestAddress(0x1000), 0x500).is_none());
+
+        // Overlapping range
+        assert!(get_host_address_range(&guest_mem, GuestAddress(0x1200), 0x500).is_none());
+
+        let ptr = get_host_address_range(&guest_mem, GuestAddress(0x1000), 0x100).unwrap();
+
+        let ptr0 = get_host_address_range(&guest_mem, GuestAddress(0x1100), 0x100).unwrap();
+
+        let ptr1 = guest_mem.get_host_address(GuestAddress(0x1200)).unwrap();
+        assert_eq!(
+            ptr,
+            guest_mem
+                .find_region(GuestAddress(0x1100))
+                .unwrap()
+                .as_ptr()
+        );
+        assert_eq!(unsafe { ptr0.offset(0x100) }, ptr1);
+    }
+}

--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -63,7 +63,7 @@ impl<'a> Iterator for DescIter<'a> {
 /// A virtio descriptor constraints with C representive.
 #[repr(C)]
 #[derive(Default, Clone, Copy)]
-struct Descriptor {
+pub struct Descriptor {
     addr: u64,
     len: u32,
     flags: u16,


### PR DESCRIPTION
The vsock packets that we're building are resolving guest addresses to
host ones and use the latter as raw pointers.
If the corresponding guest mapped buffer spans across several regions in
the guest, they will do so in the host as well. Since we have no
guarantees that host regions are contiguous, it may lead the VMM into
trying to access memory outside of its memory space.

For now we fix that by ensuring that the guest buffers do not span
across several regions. If they do, we error out.
Ideally, we should enhance the rust-vmm memory model to support safe
acces across host regions.

Fixes CVE-2019-18960

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>