### PR TITLE
ci: Add unit tests to compare CLI and OpenAPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "net_gen 0.1.0",
  "net_util 0.1.0",
  "qcow 0.1.0",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "ssh2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost_rs 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,7 @@ dependencies = [
  "acpi_tables 0.1.0",
  "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "arch 0.1.0",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
  "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ dirs = "2.0.2"
 credibility = "0.1.3"
 tempdir= "0.3.7"
 lazy_static= "1.4.0"
+serde_json = ">=1.0.9"
 
 [dependencies.vhost_rs]
 path = "vhost_rs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,14 @@ impl log::Log for Logger {
     fn flush(&self) {}
 }
 
+fn prepare_default_values() -> (String, String, String) {
+    let default_vcpus = format! {"boot={}", config::DEFAULT_VCPUS};
+    let default_memory = format! {"size={}M", config::DEFAULT_MEMORY_MB};
+    let default_rng = format! {"src={}", config::DEFAULT_RNG_SOURCE};
+
+    (default_vcpus, default_memory, default_rng)
+}
+
 fn create_app<'a, 'b>(
     default_vcpus: &'a str,
     default_memory: &'a str,
@@ -269,9 +277,7 @@ fn main() {
         }
     }
 
-    let default_vcpus = format! {"boot={}", config::DEFAULT_VCPUS};
-    let default_memory = format! {"size={}M", config::DEFAULT_MEMORY_MB};
-    let default_rng = format! {"src={}", config::DEFAULT_RNG_SOURCE};
+    let (default_vcpus, default_memory, default_rng) = prepare_default_values();
 
     let cmd_arguments = create_app(
         &default_vcpus,

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,28 +287,7 @@ fn main() {
     )
     .get_matches();
 
-    // These .unwrap()s cannot fail as there is a default value defined
-    let cpus = cmd_arguments.value_of("cpus").unwrap();
-    let memory = cmd_arguments.value_of("memory").unwrap();
-    let rng = cmd_arguments.value_of("rng").unwrap();
-    let serial = cmd_arguments.value_of("serial").unwrap();
-
-    let kernel = cmd_arguments.value_of("kernel");
-    let cmdline = cmd_arguments.value_of("cmdline");
-
-    let disks: Option<Vec<&str>> = cmd_arguments.values_of("disk").map(|x| x.collect());
-    let net: Option<Vec<&str>> = cmd_arguments.values_of("net").map(|x| x.collect());
-    let console = cmd_arguments.value_of("console").unwrap();
-    let fs: Option<Vec<&str>> = cmd_arguments.values_of("fs").map(|x| x.collect());
-    let pmem: Option<Vec<&str>> = cmd_arguments.values_of("pmem").map(|x| x.collect());
-    let devices: Option<Vec<&str>> = cmd_arguments.values_of("device").map(|x| x.collect());
-    let vhost_user_net: Option<Vec<&str>> = cmd_arguments
-        .values_of("vhost-user-net")
-        .map(|x| x.collect());
-    let vhost_user_blk: Option<Vec<&str>> = cmd_arguments
-        .values_of("vhost-user-blk")
-        .map(|x| x.collect());
-    let vsock: Option<Vec<&str>> = cmd_arguments.values_of("vsock").map(|x| x.collect());
+    let vm_params = config::VmParams::from_arg_matches(&cmd_arguments);
 
     let log_level = match cmd_arguments.occurrences_of("v") {
         0 => LevelFilter::Error,
@@ -334,23 +313,7 @@ fn main() {
     .map(|()| log::set_max_level(log_level))
     .expect("Expected to be able to setup logger");
 
-    let vm_config = match config::VmConfig::parse(config::VmParams {
-        cpus,
-        memory,
-        kernel,
-        cmdline,
-        disks,
-        net,
-        rng,
-        fs,
-        pmem,
-        serial,
-        console,
-        devices,
-        vhost_user_net,
-        vhost_user_blk,
-        vsock,
-    }) {
+    let vm_config = match config::VmConfig::parse(vm_params) {
         Ok(config) => config,
         Err(e) => {
             println!("Failed parsing parameters {:?}", e);

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -12,6 +12,7 @@ mmio_support = ["vm-virtio/mmio_support"]
 cmos = ["devices/cmos"]
 
 [dependencies]
+clap = "2.33.0"
 acpi_tables = { path = "../acpi_tables", optional = true }
 anyhow = "1.0"
 arch = { path = "../arch" }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -304,7 +304,7 @@ pub struct KernelConfig {
     pub path: PathBuf,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Default, Deserialize, Serialize)]
 pub struct CmdlineConfig {
     pub args: String,
 }
@@ -941,6 +941,7 @@ pub struct VmConfig {
     #[serde(default)]
     pub memory: MemoryConfig,
     pub kernel: Option<KernelConfig>,
+    #[serde(default)]
     pub cmdline: CmdlineConfig,
     pub disks: Option<Vec<DiskConfig>>,
     pub net: Option<Vec<NetConfig>>,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -5,6 +5,7 @@
 
 extern crate vm_virtio;
 
+use clap::ArgMatches;
 use net_util::MacAddr;
 use std::convert::From;
 use std::net::AddrParseError;
@@ -104,6 +105,49 @@ pub struct VmParams<'a> {
     pub vhost_user_net: Option<Vec<&'a str>>,
     pub vhost_user_blk: Option<Vec<&'a str>>,
     pub vsock: Option<Vec<&'a str>>,
+}
+
+impl<'a> VmParams<'a> {
+    pub fn from_arg_matches(args: &'a ArgMatches) -> Self {
+        // These .unwrap()s cannot fail as there is a default value defined
+        let cpus = args.value_of("cpus").unwrap();
+        let memory = args.value_of("memory").unwrap();
+        let rng = args.value_of("rng").unwrap();
+        let serial = args.value_of("serial").unwrap();
+
+        let kernel = args.value_of("kernel");
+        let cmdline = args.value_of("cmdline");
+
+        let disks: Option<Vec<&str>> = args.values_of("disk").map(|x| x.collect());
+        let net: Option<Vec<&str>> = args.values_of("net").map(|x| x.collect());
+        let console = args.value_of("console").unwrap();
+        let fs: Option<Vec<&str>> = args.values_of("fs").map(|x| x.collect());
+        let pmem: Option<Vec<&str>> = args.values_of("pmem").map(|x| x.collect());
+        let devices: Option<Vec<&str>> = args.values_of("device").map(|x| x.collect());
+        let vhost_user_net: Option<Vec<&str>> =
+            args.values_of("vhost-user-net").map(|x| x.collect());
+        let vhost_user_blk: Option<Vec<&str>> =
+            args.values_of("vhost-user-blk").map(|x| x.collect());
+        let vsock: Option<Vec<&str>> = args.values_of("vsock").map(|x| x.collect());
+
+        VmParams {
+            cpus,
+            memory,
+            kernel,
+            cmdline,
+            disks,
+            net,
+            rng,
+            fs,
+            pmem,
+            serial,
+            console,
+            devices,
+            vhost_user_net,
+            vhost_user_blk,
+            vsock,
+        }
+    }
 }
 
 fn parse_size(size: &str) -> Result<u64> {

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -182,7 +182,7 @@ fn parse_on_off(param: &str) -> Result<bool> {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct CpusConfig {
     pub boot_vcpus: u8,
     pub max_vcpus: u8,
@@ -241,7 +241,7 @@ impl Default for CpusConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct MemoryConfig {
     pub size: u64,
     #[serde(default)]
@@ -299,12 +299,12 @@ impl Default for MemoryConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct KernelConfig {
     pub path: PathBuf,
 }
 
-#[derive(Clone, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct CmdlineConfig {
     pub args: String,
 }
@@ -319,7 +319,7 @@ impl CmdlineConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct DiskConfig {
     pub path: PathBuf,
     #[serde(default)]
@@ -349,7 +349,7 @@ impl DiskConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct NetConfig {
     #[serde(default = "default_netconfig_tap")]
     pub tap: Option<String>,
@@ -433,7 +433,7 @@ impl NetConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct RngConfig {
     pub src: PathBuf,
     #[serde(default)]
@@ -472,7 +472,7 @@ impl Default for RngConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct FsConfig {
     pub tag: String,
     pub sock: PathBuf,
@@ -582,7 +582,7 @@ impl FsConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct PmemConfig {
     pub file: PathBuf,
     pub size: u64,
@@ -627,7 +627,7 @@ impl PmemConfig {
     }
 }
 
-#[derive(Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum ConsoleOutputMode {
     Off,
     Tty,
@@ -644,7 +644,7 @@ impl ConsoleOutputMode {
     }
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct ConsoleConfig {
     #[serde(default = "default_consoleconfig_file")]
     pub file: Option<PathBuf>,
@@ -718,7 +718,7 @@ impl ConsoleConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct DeviceConfig {
     pub path: PathBuf,
     #[serde(default)]
@@ -748,7 +748,7 @@ impl DeviceConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct VhostUserNetConfig {
     pub sock: String,
     #[serde(default = "default_vunetconfig_num_queues")]
@@ -823,7 +823,7 @@ impl VhostUserNetConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct VsockConfig {
     pub cid: u64,
     pub sock: PathBuf,
@@ -862,7 +862,7 @@ impl VsockConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct VhostUserBlkConfig {
     pub sock: String,
     #[serde(default = "default_vublkconfig_num_queues")]
@@ -934,7 +934,7 @@ impl VhostUserBlkConfig {
     }
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct VmConfig {
     #[serde(default)]
     pub cpus: CpusConfig,


### PR DESCRIPTION
The goal here is to ensure that CLI and OpenAPI both behave as closely
as possible, and also that they behave as expected.

Leveraging the reorganization of the code, we can now compare two
VmConfig structures generated from one CLI entry on one side, and from
an OpenAPI entry (JSON payload) on the other side.

Fixes #535 

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>