### PR TITLE
Only notify on newly inserted CPUs

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1685,7 +1685,7 @@ fn create_ged_device(ged_irq: u32) -> Vec<u8> {
                 true,
                 vec![&aml::If::new(
                     &aml::Equal::new(&aml::Path::new("GDAT"), &aml::ONE),
-                    vec![&aml::MethodCall::new("\\_SB_.CPUS.CTFY".into(), vec![])],
+                    vec![&aml::MethodCall::new("\\_SB_.CPUS.CSCN".into(), vec![])],
                 )],
             ),
         ],


### PR DESCRIPTION
Rather than notifying for all ACPI CPU objects when we received a notification of hotplug instead only notify on the changed devices.

This fixes: #555 and works towards CPU unplug.