### PR TITLE
ci: Fix flaky test_memory_mergeable_on test

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -159,7 +159,7 @@ cp target/release/cloud-hypervisor $VFIO_DIR
 
 # Enable KSM with some reasonable parameters so that it won't take too long
 # for the memory to be merged between two processes.
-sudo bash -c "echo 10000 > /sys/kernel/mm/ksm/pages_to_scan"
+sudo bash -c "echo 1000000 > /sys/kernel/mm/ksm/pages_to_scan"
 sudo bash -c "echo 10 > /sys/kernel/mm/ksm/sleep_millisecs"
 sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4311,7 +4311,7 @@ mod tests {
             let new_pss = new_pss as f32;
 
             if mergeable {
-                aver!(tb, new_pss < (old_pss * 0.9));
+                aver!(tb, new_pss < (old_pss * 0.95));
             } else {
                 aver!(tb, (old_pss * 0.95) < new_pss && new_pss < (old_pss * 1.05));
             }


### PR DESCRIPTION
Because we don't always reach the expected footprint improvements with
KSM, let's review the numbers. By reducing the expectations and
increasing the amount of pages to scan, this should stabilize the CI.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>