### PR TITLE
vm-virtio, vmm, vfio: Store GuestMemoryMmap in an Arc<ArcSwap<T>>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
 name = "cloud-hypervisor"
 version = "0.4.0"
 dependencies = [
+ "arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "credibility 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -991,6 +992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "vfio"
 version = "0.0.1"
 dependencies = [
+ "arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
  "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1091,6 +1093,7 @@ dependencies = [
 name = "vm-virtio"
 version = "0.1.0"
 dependencies = [
+ "arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
  "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1114,6 +1117,7 @@ version = "0.1.0"
 dependencies = [
  "acpi_tables 0.1.0",
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "arch 0.1.0",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 default-run = "cloud-hypervisor"
 
 [dependencies]
+arc-swap = ">=0.4.4"
 clap = "2.33.0"
 epoll = ">=4.0.1"
 lazy_static = "1.4.0"

--- a/vfio/Cargo.toml
+++ b/vfio/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 authors = ["The Cloud Hypervisor Authors"]
 
 [dependencies]
+arc-swap = ">=0.4.4"
 byteorder = "1.3.2"
 devices = { path = "../devices" }
 kvm-bindings = "0.2.0"

--- a/vfio/src/lib.rs
+++ b/vfio/src/lib.rs
@@ -5,6 +5,7 @@
 
 //#![deny(missing_docs)]
 //! Virtual Function I/O (VFIO) API
+extern crate arc_swap;
 extern crate byteorder;
 extern crate devices;
 extern crate kvm_bindings;

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -10,6 +10,7 @@ pci_support = ["pci"]
 mmio_support = []
 
 [dependencies]
+arc-swap = ">=0.4.4"
 byteorder = "1.3.2"
 devices = { path = "../devices" }
 epoll = ">=4.0.1"

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -7,7 +7,8 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use super::*;
-use std::sync::{Arc, RwLock};
+use arc_swap::ArcSwap;
+use std::sync::Arc;
 use vm_memory::{GuestAddress, GuestMemoryMmap, GuestUsize};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -70,7 +71,7 @@ pub trait VirtioDevice: Send {
     /// Activates this device for real usage.
     fn activate(
         &mut self,
-        mem: Arc<RwLock<GuestMemoryMmap>>,
+        mem: Arc<ArcSwap<GuestMemoryMmap>>,
         interrupt_evt: Arc<VirtioInterrupt>,
         queues: Vec<Queue>,
         queue_evts: Vec<EventFd>,

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -9,6 +9,8 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 //! Implements virtio devices, queues, and transport mechanisms.
+
+extern crate arc_swap;
 extern crate epoll;
 #[macro_use]
 extern crate log;

--- a/vm-virtio/src/transport/pci_common_config.rs
+++ b/vm-virtio/src/transport/pci_common_config.rs
@@ -7,12 +7,11 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 extern crate byteorder;
 
+use crate::{Queue, VirtioDevice};
 use byteorder::{ByteOrder, LittleEndian};
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Arc, Mutex};
 use vm_memory::GuestAddress;
-
-use crate::{Queue, VirtioDevice};
 
 /// Contains the data for reading and writing the common configuration structure of a virtio PCI
 /// device.
@@ -255,8 +254,8 @@ impl VirtioPciCommonConfig {
 mod tests {
     use super::*;
     use crate::{ActivateResult, VirtioInterrupt};
-
-    use std::sync::{Arc, RwLock};
+    use arc_swap::ArcSwap;
+    use std::sync::Arc;
     use vm_memory::GuestMemoryMmap;
     use vmm_sys_util::eventfd::EventFd;
 
@@ -273,7 +272,7 @@ mod tests {
         }
         fn activate(
             &mut self,
-            _mem: Arc<RwLock<GuestMemoryMmap>>,
+            _mem: Arc<ArcSwap<GuestMemoryMmap>>,
             _interrupt_evt: Arc<VirtioInterrupt>,
             _queues: Vec<Queue>,
             _queue_evts: Vec<EventFd>,

--- a/vm-virtio/src/vhost_user/blk.rs
+++ b/vm-virtio/src/vhost_user/blk.rs
@@ -1,35 +1,32 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::super::{ActivateError, ActivateResult, Queue, VirtioDevice, VirtioDeviceType};
+use super::handler::*;
+use super::vu_common_ctrl::*;
+use super::Error as DeviceError;
+use super::{Error, Result};
+use crate::VirtioInterrupt;
+use arc_swap::ArcSwap;
 use libc;
 use libc::EFD_NONBLOCK;
 use std::cmp;
 use std::io::Write;
+use std::mem;
 use std::ptr::null;
 use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::thread;
 use std::vec::Vec;
-
-use crate::VirtioInterrupt;
-
-use super::Error as DeviceError;
-
-use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
-use vm_memory::GuestMemoryMmap;
-use vmm_sys_util::eventfd::EventFd;
-
-use super::super::{ActivateError, ActivateResult, Queue, VirtioDevice, VirtioDeviceType};
-use super::handler::*;
-use super::vu_common_ctrl::*;
-use super::{Error, Result};
-use std::mem;
 use vhost_rs::vhost_user::message::VhostUserConfigFlags;
 use vhost_rs::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
 use vhost_rs::vhost_user::{Master, VhostUserMaster, VhostUserMasterReqHandler};
 use vhost_rs::VhostBackend;
 use virtio_bindings::bindings::virtio_blk::*;
+use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
+use vm_memory::GuestMemoryMmap;
+use vmm_sys_util::eventfd::EventFd;
 
 macro_rules! offset_of {
     ($ty:ty, $field:ident) => {
@@ -222,7 +219,7 @@ impl VirtioDevice for Blk {
 
     fn activate(
         &mut self,
-        mem: Arc<RwLock<GuestMemoryMmap>>,
+        mem: Arc<ArcSwap<GuestMemoryMmap>>,
         interrupt_cb: Arc<VirtioInterrupt>,
         queues: Vec<Queue>,
         queue_evts: Vec<EventFd>,
@@ -260,7 +257,7 @@ impl VirtioDevice for Blk {
 
         let vu_interrupt_list = setup_vhost_user(
             &mut self.vhost_user_blk,
-            &mem.read().unwrap(),
+            mem.load().as_ref(),
             queues,
             queue_evts,
             self.acked_features,

--- a/vm-virtio/src/vsock/mod.rs
+++ b/vm-virtio/src/vsock/mod.rs
@@ -17,9 +17,8 @@ pub use self::device::Vsock;
 pub use self::unix::VsockUnixBackend;
 pub use self::unix::VsockUnixError;
 
-use std::os::unix::io::RawFd;
-
 use packet::VsockPacket;
+use std::os::unix::io::RawFd;
 
 mod defs {
 
@@ -158,22 +157,20 @@ pub trait VsockBackend: VsockChannel + VsockEpollListener + Send {}
 
 #[cfg(test)]
 mod tests {
-    use libc::EFD_NONBLOCK;
-
     use super::device::{VsockEpollHandler, RX_QUEUE_EVENT, TX_QUEUE_EVENT};
     use super::packet::VSOCK_PKT_HDR_SIZE;
     use super::*;
-
-    use std::os::unix::io::AsRawFd;
-    use std::sync::atomic::AtomicBool;
-    use std::sync::{Arc, RwLock};
-    use vmm_sys_util::eventfd::EventFd;
-
     use crate::device::{VirtioInterrupt, VirtioInterruptType};
     use crate::queue::tests::VirtQueue as GuestQ;
     use crate::queue::Queue;
     use crate::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
+    use arc_swap::ArcSwap;
+    use libc::EFD_NONBLOCK;
+    use std::os::unix::io::AsRawFd;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::{Arc, RwLock};
     use vm_memory::{GuestAddress, GuestMemoryMmap};
+    use vmm_sys_util::eventfd::EventFd;
 
     pub struct TestBackend {
         pub evfd: EventFd,
@@ -303,7 +300,7 @@ mod tests {
                 guest_txvq,
                 guest_evvq,
                 handler: VsockEpollHandler {
-                    mem: Arc::new(RwLock::new(self.mem.clone())),
+                    mem: Arc::new(ArcSwap::new(Arc::new(self.mem.clone()))),
                     queues,
                     queue_evts,
                     kill_evt: EventFd::new(EFD_NONBLOCK).unwrap(),

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -12,6 +12,7 @@ mmio_support = ["vm-virtio/mmio_support"]
 cmos = ["devices/cmos"]
 
 [dependencies]
+arc-swap = ">=0.4.4"
 clap = "2.33.0"
 acpi_tables = { path = "../acpi_tables", optional = true }
 anyhow = "1.0"

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+extern crate arc_swap;
 #[macro_use]
 extern crate lazy_static;
-
 #[macro_use]
 extern crate log;
 extern crate serde;


### PR DESCRIPTION
This allows us to change the memory map that is being used by the
devices via an atomic swap (by replacing the map with another one). The
ArcSwap provides the mechanism for atomically swapping from to another
whilst still giving good read performace. It is inside an Arc so that we
can use a single ArcSwap for all users.

Not covered by this change is replacing the GuestMemoryMmap itself.

This change also removes some vertical whitespace from use blocks in the
files that this commit also changed. Vertical whitespace was being used
inconsistently and broke rustfmt's behaviour of ordering the imports as
it would only do it within the block.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>