### PR TITLE
virtio-fs: Update virtiofs daemon parameters

### DIFF
--- a/docs/fs.md
+++ b/docs/fs.md
@@ -26,7 +26,7 @@ _Run virtiofsd_
 ```bash
 ./virtiofsd \
     -d \
-    -o vhost_user_socket=/tmp/virtiofs \
+    --socket-path=/tmp/virtiofs \
     -o source=/tmp/shared_dir \
     -o cache=none
 ```

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -91,7 +91,7 @@ VIRTIOFSD="$WORKLOADS_DIR/virtiofsd"
 QEMU_DIR="qemu_build"
 if [ ! -f "$VIRTIOFSD" ]; then
     pushd $WORKLOADS_DIR
-    git clone --depth 1 "https://gitlab.com/virtio-fs/qemu.git" -b "virtio-fs-dev" $QEMU_DIR
+    git clone --depth 1 "https://github.com/sboeuf/qemu.git" -b "virtio-fs" $QEMU_DIR
     pushd $QEMU_DIR
     time ./configure --prefix=$PWD --target-list=x86_64-softmmu
     time make virtiofsd -j `nproc`

--- a/src/main.rs
+++ b/src/main.rs
@@ -1718,10 +1718,7 @@ mod tests {
 
         // Start the daemon
         let child = Command::new(virtiofsd_path.as_str())
-            .args(&[
-                "-o",
-                format!("vhost_user_socket={}", virtiofsd_socket_path).as_str(),
-            ])
+            .args(&[format!("--socket-path={}", virtiofsd_socket_path).as_str()])
             .args(&["-o", format!("source={}", shared_dir).as_str()])
             .args(&["-o", format!("cache={}", cache).as_str()])
             .spawn()


### PR DESCRIPTION
With the latest version of virtiofsd, some changes have been made
to the socket path parameter. This needs to be updated in the cloud
hypervisor codebase, so that our CI keeps running correctly.

Fixes #611

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>