### PR TITLE
vmm: Do not create virtio devices when missing a transport

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -453,6 +453,7 @@ impl DeviceManager {
             &mut virtio_devices,
         )?;
 
+        #[cfg(any(feature = "pci_support", feature = "mmio_support"))]
         virtio_devices.append(&mut DeviceManager::make_virtio_devices(
             vm_info,
             &address_manager,


### PR DESCRIPTION
If neither PCI or MMIO are built in, we should not bother creating any
virtio devices at all.
When building a minimal VMM made of a kernel with an initramfs and a
serial console, the RNG virtio device is still created even though there
is no way it can ever get probed.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>