### PR TITLE
Reorganize interrupt management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,14 +473,11 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
- "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
  "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-ioctls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
  "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-ioctls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "net_gen 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,8 +1108,6 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
  "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "net_gen 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,8 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
+ "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-ioctls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-allocator 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,7 @@ dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-allocator 0.1.0",
+ "vm-device 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,6 +1089,7 @@ dependencies = [
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -8,10 +8,7 @@ edition = "2018"
 vm-allocator = { path = "../vm-allocator" }
 byteorder = "1.3.2"
 devices = { path = "../devices" }
-kvm-bindings = "0.2.0"
-kvm-ioctls = "0.4.0"
 libc = "0.2.60"
 log = "0.4.8"
 vm-device = { path = "../vm-device" }
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
-vmm-sys-util = ">=0.3.1"

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -12,5 +12,6 @@ kvm-bindings = "0.2.0"
 kvm-ioctls = "0.4.0"
 libc = "0.2.60"
 log = "0.4.8"
+vm-device = { path = "../vm-device" }
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
 vmm-sys-util = ">=0.3.1"

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2018"
 vm-allocator = { path = "../vm-allocator" }
 byteorder = "1.3.2"
 devices = { path = "../devices" }
+kvm-bindings = "0.2.0"
+kvm-ioctls = "0.4.0"
 libc = "0.2.60"
 log = "0.4.8"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -67,7 +67,7 @@ pub trait PciDevice: BusDevice {
     }
 
     /// Assign MSI-X to this device.
-    fn assign_msix(&mut self, _msi_cb: Arc<InterruptDelivery>) {}
+    fn assign_msix(&mut self) {}
 
     /// Allocates the needed PCI BARs space using the `allocate` function which takes a size and
     /// returns an address. Returns a Vec of (GuestAddress, GuestUsize) tuples.

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -27,6 +27,14 @@ pub use self::device::{
 };
 pub use self::msi::MsiCap;
 pub use self::msix::{MsixCap, MsixConfig, MsixTableEntry, MSIX_TABLE_ENTRY_SIZE};
+use kvm_bindings::{kvm_irq_routing, kvm_irq_routing_entry};
+use kvm_ioctls::*;
+use std::collections::HashMap;
+use std::io;
+use std::mem::size_of;
+use std::sync::{Arc, Mutex};
+use vm_allocator::SystemAllocator;
+use vmm_sys_util::eventfd::EventFd;
 
 /// PCI has four interrupt pins A->D.
 #[derive(Copy, Clone)]
@@ -40,5 +48,91 @@ pub enum PciInterruptPin {
 impl PciInterruptPin {
     pub fn to_mask(self) -> u32 {
         self as u32
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    AllocateGsi,
+    EventFd(io::Error),
+    IrqFd(kvm_ioctls::Error),
+    SetGsiRouting(kvm_ioctls::Error),
+}
+
+// Returns a `Vec<T>` with a size in bytes at least as large as `size_in_bytes`.
+fn vec_with_size_in_bytes<T: Default>(size_in_bytes: usize) -> Vec<T> {
+    let rounded_size = (size_in_bytes + size_of::<T>() - 1) / size_of::<T>();
+    let mut v = Vec::with_capacity(rounded_size);
+    v.resize_with(rounded_size, T::default);
+    v
+}
+
+// The kvm API has many structs that resemble the following `Foo` structure:
+//
+// ```
+// #[repr(C)]
+// struct Foo {
+//    some_data: u32
+//    entries: __IncompleteArrayField<__u32>,
+// }
+// ```
+//
+// In order to allocate such a structure, `size_of::<Foo>()` would be too small because it would not
+// include any space for `entries`. To make the allocation large enough while still being aligned
+// for `Foo`, a `Vec<Foo>` is created. Only the first element of `Vec<Foo>` would actually be used
+// as a `Foo`. The remaining memory in the `Vec<Foo>` is for `entries`, which must be contiguous
+// with `Foo`. This function is used to make the `Vec<Foo>` with enough space for `count` entries.
+pub fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
+    let element_space = count * size_of::<F>();
+    let vec_size_bytes = size_of::<T>() + element_space;
+    vec_with_size_in_bytes(vec_size_bytes)
+}
+
+pub fn set_kvm_routes<S: ::std::hash::BuildHasher>(
+    vm_fd: VmFd,
+    gsi_msi_routes: Arc<Mutex<HashMap<u32, kvm_irq_routing_entry, S>>>,
+) -> Result<(), Error> {
+    let mut entry_vec: Vec<kvm_irq_routing_entry> = Vec::new();
+    for (_, entry) in gsi_msi_routes.lock().unwrap().iter() {
+        entry_vec.push(*entry);
+    }
+
+    let mut irq_routing =
+        vec_with_array_field::<kvm_irq_routing, kvm_irq_routing_entry>(entry_vec.len());
+    irq_routing[0].nr = entry_vec.len() as u32;
+    irq_routing[0].flags = 0;
+
+    unsafe {
+        let entries: &mut [kvm_irq_routing_entry] =
+            irq_routing[0].entries.as_mut_slice(entry_vec.len());
+        entries.copy_from_slice(&entry_vec);
+    }
+
+    vm_fd
+        .set_gsi_routing(&irq_routing[0])
+        .map_err(Error::SetGsiRouting)
+}
+
+pub struct InterruptRoute {
+    gsi: u32,
+    irq_fd: EventFd,
+}
+
+impl InterruptRoute {
+    pub fn new(allocator: &mut SystemAllocator) -> Result<Self, Error> {
+        let irq_fd = EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFd)?;
+        let gsi = allocator.allocate_gsi().ok_or(Error::AllocateGsi)?;
+
+        Ok(InterruptRoute { gsi, irq_fd })
+    }
+
+    pub fn enable(&self, vm: &Arc<VmFd>) -> Result<(), Error> {
+        vm.register_irqfd(&self.irq_fd, self.gsi)
+            .map_err(Error::IrqFd)
+    }
+
+    pub fn disable(&self, vm: &Arc<VmFd>) -> Result<(), Error> {
+        vm.unregister_irqfd(&self.irq_fd, self.gsi)
+            .map_err(Error::IrqFd)
     }
 }

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -7,7 +7,6 @@
 extern crate log;
 extern crate devices;
 extern crate vm_memory;
-extern crate vmm_sys_util;
 
 mod bus;
 mod configuration;
@@ -27,14 +26,6 @@ pub use self::device::{
 };
 pub use self::msi::{msi_num_enabled_vectors, MsiCap, MsiConfig};
 pub use self::msix::{MsixCap, MsixConfig, MsixTableEntry, MSIX_TABLE_ENTRY_SIZE};
-use kvm_bindings::{kvm_irq_routing, kvm_irq_routing_entry};
-use kvm_ioctls::*;
-use std::collections::HashMap;
-use std::io;
-use std::mem::size_of;
-use std::sync::Arc;
-use vm_allocator::SystemAllocator;
-use vmm_sys_util::eventfd::EventFd;
 
 /// PCI has four interrupt pins A->D.
 #[derive(Copy, Clone)]
@@ -48,91 +39,5 @@ pub enum PciInterruptPin {
 impl PciInterruptPin {
     pub fn to_mask(self) -> u32 {
         self as u32
-    }
-}
-
-#[derive(Debug)]
-pub enum Error {
-    AllocateGsi,
-    EventFd(io::Error),
-    IrqFd(kvm_ioctls::Error),
-    SetGsiRouting(kvm_ioctls::Error),
-}
-
-// Returns a `Vec<T>` with a size in bytes at least as large as `size_in_bytes`.
-fn vec_with_size_in_bytes<T: Default>(size_in_bytes: usize) -> Vec<T> {
-    let rounded_size = (size_in_bytes + size_of::<T>() - 1) / size_of::<T>();
-    let mut v = Vec::with_capacity(rounded_size);
-    v.resize_with(rounded_size, T::default);
-    v
-}
-
-// The kvm API has many structs that resemble the following `Foo` structure:
-//
-// ```
-// #[repr(C)]
-// struct Foo {
-//    some_data: u32
-//    entries: __IncompleteArrayField<__u32>,
-// }
-// ```
-//
-// In order to allocate such a structure, `size_of::<Foo>()` would be too small because it would not
-// include any space for `entries`. To make the allocation large enough while still being aligned
-// for `Foo`, a `Vec<Foo>` is created. Only the first element of `Vec<Foo>` would actually be used
-// as a `Foo`. The remaining memory in the `Vec<Foo>` is for `entries`, which must be contiguous
-// with `Foo`. This function is used to make the `Vec<Foo>` with enough space for `count` entries.
-pub fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
-    let element_space = count * size_of::<F>();
-    let vec_size_bytes = size_of::<T>() + element_space;
-    vec_with_size_in_bytes(vec_size_bytes)
-}
-
-pub fn set_kvm_routes<S: ::std::hash::BuildHasher>(
-    vm_fd: &Arc<VmFd>,
-    gsi_msi_routes: &HashMap<u32, kvm_irq_routing_entry, S>,
-) -> Result<(), Error> {
-    let mut entry_vec: Vec<kvm_irq_routing_entry> = Vec::new();
-    for (_, entry) in gsi_msi_routes.iter() {
-        entry_vec.push(*entry);
-    }
-
-    let mut irq_routing =
-        vec_with_array_field::<kvm_irq_routing, kvm_irq_routing_entry>(entry_vec.len());
-    irq_routing[0].nr = entry_vec.len() as u32;
-    irq_routing[0].flags = 0;
-
-    unsafe {
-        let entries: &mut [kvm_irq_routing_entry] =
-            irq_routing[0].entries.as_mut_slice(entry_vec.len());
-        entries.copy_from_slice(&entry_vec);
-    }
-
-    vm_fd
-        .set_gsi_routing(&irq_routing[0])
-        .map_err(Error::SetGsiRouting)
-}
-
-pub struct InterruptRoute {
-    pub gsi: u32,
-    pub irq_fd: EventFd,
-}
-
-impl InterruptRoute {
-    pub fn new(allocator: &mut SystemAllocator) -> Result<Self, Error> {
-        let irq_fd = EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFd)?;
-        let gsi = allocator.allocate_gsi().ok_or(Error::AllocateGsi)?;
-
-        Ok(InterruptRoute { gsi, irq_fd })
-    }
-
-    pub fn enable(&self, vm: &Arc<VmFd>) -> Result<(), Error> {
-        vm.register_irqfd(&self.irq_fd, self.gsi)
-            .map_err(Error::IrqFd)
-    }
-
-    pub fn disable(&self, vm: &Arc<VmFd>) -> Result<(), Error> {
-        vm.unregister_irqfd(&self.irq_fd, self.gsi)
-            .map_err(Error::IrqFd)
     }
 }

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -25,7 +25,7 @@ pub use self::device::{
     BarReprogrammingParams, DeviceRelocation, Error as PciDeviceError, InterruptDelivery,
     InterruptParameters, PciDevice,
 };
-pub use self::msi::{MsiCap, MsiConfig};
+pub use self::msi::{msi_num_enabled_vectors, MsiCap, MsiConfig};
 pub use self::msix::{MsixCap, MsixConfig, MsixTableEntry, MSIX_TABLE_ENTRY_SIZE};
 use kvm_bindings::{kvm_irq_routing, kvm_irq_routing_entry};
 use kvm_ioctls::*;

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -32,7 +32,7 @@ use kvm_ioctls::*;
 use std::collections::HashMap;
 use std::io;
 use std::mem::size_of;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use vm_allocator::SystemAllocator;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -89,11 +89,11 @@ pub fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
 }
 
 pub fn set_kvm_routes<S: ::std::hash::BuildHasher>(
-    vm_fd: VmFd,
-    gsi_msi_routes: Arc<Mutex<HashMap<u32, kvm_irq_routing_entry, S>>>,
+    vm_fd: &Arc<VmFd>,
+    gsi_msi_routes: &HashMap<u32, kvm_irq_routing_entry, S>,
 ) -> Result<(), Error> {
     let mut entry_vec: Vec<kvm_irq_routing_entry> = Vec::new();
-    for (_, entry) in gsi_msi_routes.lock().unwrap().iter() {
+    for (_, entry) in gsi_msi_routes.iter() {
         entry_vec.push(*entry);
     }
 
@@ -114,8 +114,8 @@ pub fn set_kvm_routes<S: ::std::hash::BuildHasher>(
 }
 
 pub struct InterruptRoute {
-    gsi: u32,
-    irq_fd: EventFd,
+    pub gsi: u32,
+    pub irq_fd: EventFd,
 }
 
 impl InterruptRoute {

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -25,7 +25,7 @@ pub use self::device::{
     BarReprogrammingParams, DeviceRelocation, Error as PciDeviceError, InterruptDelivery,
     InterruptParameters, PciDevice,
 };
-pub use self::msi::MsiCap;
+pub use self::msi::{MsiCap, MsiConfig};
 pub use self::msix::{MsixCap, MsixConfig, MsixTableEntry, MSIX_TABLE_ENTRY_SIZE};
 use kvm_bindings::{kvm_irq_routing, kvm_irq_routing_entry};
 use kvm_ioctls::*;

--- a/pci/src/msi.rs
+++ b/pci/src/msi.rs
@@ -159,7 +159,7 @@ impl MsiCap {
 }
 
 pub struct MsiConfig {
-    pub cap: MsiCap,
+    cap: MsiCap,
     pub irq_routes: Vec<InterruptRoute>,
     vm_fd: Arc<VmFd>,
     gsi_msi_routes: Arc<Mutex<HashMap<u32, kvm_irq_routing_entry>>>,
@@ -196,14 +196,6 @@ impl MsiConfig {
 
     pub fn size(&self) -> u64 {
         self.cap.size()
-    }
-
-    pub fn num_enabled_vectors(&self) -> usize {
-        self.cap.num_enabled_vectors()
-    }
-
-    pub fn vector_masked(&self, vector: usize) -> bool {
-        self.cap.vector_masked(vector)
     }
 
     pub fn update(&mut self, offset: u64, data: &[u8]) {

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -113,6 +113,12 @@ impl MsixConfig {
             let mut gsi_msi_routes = self.gsi_msi_routes.lock().unwrap();
             if self.enabled && !self.masked {
                 for (idx, table_entry) in self.table_entries.iter().enumerate() {
+                    if !old_enabled || old_masked {
+                        if let Err(e) = self.irq_routes[idx].enable(&self.vm_fd) {
+                            error!("Failed enabling irq_fd: {:?}", e);
+                        }
+                    }
+
                     // Ignore MSI-X vector if masked.
                     if table_entry.masked() {
                         continue;
@@ -134,6 +140,12 @@ impl MsixConfig {
                 }
             } else {
                 for route in self.irq_routes.iter() {
+                    if old_enabled || !old_masked {
+                        if let Err(e) = route.disable(&self.vm_fd) {
+                            error!("Failed disabling irq_fd: {:?}", e);
+                        }
+                    }
+
                     gsi_msi_routes.remove(&route.gsi);
                 }
             }

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use crate::device::InterruptParameters;
 use crate::{InterruptDelivery, InterruptRoute, PciCapability, PciCapabilityID};
 use byteorder::{ByteOrder, LittleEndian};
+use kvm_ioctls::VmFd;
 use vm_allocator::SystemAllocator;
 use vm_memory::ByteValued;
 
@@ -53,13 +54,14 @@ pub struct MsixConfig {
     pub table_entries: Vec<MsixTableEntry>,
     pub pba_entries: Vec<u64>,
     pub irq_routes: Vec<InterruptRoute>,
+    _vm_fd: Arc<VmFd>,
     interrupt_cb: Option<Arc<InterruptDelivery>>,
     masked: bool,
     enabled: bool,
 }
 
 impl MsixConfig {
-    pub fn new(msix_vectors: u16, allocator: &mut SystemAllocator) -> Self {
+    pub fn new(msix_vectors: u16, allocator: &mut SystemAllocator, vm_fd: Arc<VmFd>) -> Self {
         assert!(msix_vectors <= MAX_MSIX_VECTORS_PER_DEVICE);
 
         let mut table_entries: Vec<MsixTableEntry> = Vec::new();
@@ -77,6 +79,7 @@ impl MsixConfig {
             table_entries,
             pba_entries,
             irq_routes,
+            _vm_fd: vm_fd,
             interrupt_cb: None,
             masked: false,
             enabled: false,

--- a/vfio/src/vfio_pci.rs
+++ b/vfio/src/vfio_pci.rs
@@ -412,7 +412,12 @@ impl VfioPciDevice {
             table,
             pba,
         };
-        let msix_config = MsixConfig::new(msix_cap.table_size(), allocator, self.vm_fd.clone());
+        let msix_config = MsixConfig::new(
+            msix_cap.table_size(),
+            allocator,
+            self.vm_fd.clone(),
+            self.gsi_msi_routes.clone(),
+        );
 
         self.interrupt.msix = Some(VfioMsix {
             bar: msix_config,

--- a/vfio/src/vfio_pci.rs
+++ b/vfio/src/vfio_pci.rs
@@ -412,7 +412,7 @@ impl VfioPciDevice {
             table,
             pba,
         };
-        let msix_config = MsixConfig::new(msix_cap.table_size(), allocator);
+        let msix_config = MsixConfig::new(msix_cap.table_size(), allocator, self.vm_fd.clone());
 
         self.interrupt.msix = Some(VfioMsix {
             bar: msix_config,

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -10,6 +10,7 @@ thiserror = "1.0"
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
+vmm-sys-util = ">=0.3.1"
 
 [dependencies.vm-memory]
 git = "https://github.com/rust-vmm/vm-memory"

--- a/vm-device/src/interrupt/mod.rs
+++ b/vm-device/src/interrupt/mod.rs
@@ -1,0 +1,187 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! Traits and Structs to manage interrupt sources for devices.
+//!
+//! In system programming, an interrupt is a signal to the processor emitted by hardware or
+//! software indicating an event that needs immediate attention. An interrupt alerts the processor
+//! to a high-priority condition requiring the interruption of the current code the processor is
+//! executing. The processor responds by suspending its current activities, saving its state, and
+//! executing a function called an interrupt handler (or an interrupt service routine, ISR) to deal
+//! with the event. This interruption is temporary, and, after the interrupt handler finishes,
+//! unless handling the interrupt has emitted a fatal error, the processor resumes normal
+//! activities.
+//!
+//! Hardware interrupts are used by devices to communicate that they require attention from the
+//! operating system, or a bare-metal program running on the CPU if there are no OSes. The act of
+//! initiating a hardware interrupt is referred to as an interrupt request (IRQ). Different devices
+//! are usually associated with different interrupts using a unique value associated with each
+//! interrupt. This makes it possible to know which hardware device caused which interrupts.
+//! These interrupt values are often called IRQ lines, or just interrupt lines.
+//!
+//! Nowadays, IRQ lines is not the only mechanism to deliver device interrupts to processors.
+//! MSI [(Message Signaled Interrupt)](https://en.wikipedia.org/wiki/Message_Signaled_Interrupts)
+//! is another commonly used alternative in-band method of signaling an interrupt, using special
+//! in-band messages to replace traditional out-of-band assertion of dedicated interrupt lines.
+//! While more complex to implement in a device, message signaled interrupts have some significant
+//! advantages over pin-based out-of-band interrupt signaling. Message signaled interrupts are
+//! supported in PCI bus since its version 2.2, and in later available PCI Express bus. Some
+//! non-PCI architectures also use message signaled interrupts.
+//!
+//! While IRQ is a term commonly used by Operating Systems when dealing with hardware
+//! interrupts, the IRQ numbers managed by OSes are independent of the ones managed by VMM.
+//! For simplicity sake, the term `Interrupt Source` is used instead of IRQ to represent both
+//! pin-based interrupts and MSI interrupts.
+//!
+//! A device may support multiple types of interrupts, and each type of interrupt may support one
+//! or multiple interrupt sources. For example, a PCI device may support:
+//! * Legacy Irq: exactly one interrupt source.
+//! * PCI MSI Irq: 1,2,4,8,16,32 interrupt sources.
+//! * PCI MSIx Irq: 2^n(n=0-11) interrupt sources.
+//!
+//! A distinct Interrupt Source Identifier (ISID) will be assigned to each interrupt source.
+//! An ID allocator will be used to allocate and free Interrupt Source Identifiers for devices.
+//! To decouple the vm-device crate from the ID allocator, the vm-device crate doesn't take the
+//! responsibility to allocate/free Interrupt Source IDs but only makes use of assigned IDs.
+//!
+//! The overall flow to deal with interrupts is:
+//! * The VMM creates an interrupt manager
+//! * The VMM creates a device manager, passing on an reference to the interrupt manager
+//! * The device manager passes on an reference to the interrupt manager to all registered devices
+//! * The guest kernel loads drivers for virtual devices
+//! * The guest device driver determines the type and number of interrupts needed, and update the
+//!   device configuration
+//! * The virtual device backend requests the interrupt manager to create an interrupt group
+//!   according to guest configuration information
+
+use std::sync::Arc;
+use vmm_sys_util::eventfd::EventFd;
+
+/// Reuse std::io::Result to simplify interoperability among crates.
+pub type Result<T> = std::io::Result<T>;
+
+/// Data type to store an interrupt source identifier.
+pub type InterruptIndex = u32;
+
+/// Data type to store an interrupt source type.
+///
+/// The interrupt source type is a slim wrapper so that the `InterruptManager`
+/// can be implemented in external, non rust-vmm crates.
+pub type InterruptType = u32;
+
+/// Configuration data for legacy interrupts.
+///
+/// On x86 platforms, legacy interrupts means those interrupts routed through PICs or IOAPICs.
+#[derive(Copy, Clone, Debug)]
+pub struct LegacyIrqSourceConfig {}
+
+/// Configuration data for MSI/MSI-X interrupts.
+///
+/// On x86 platforms, these interrupts are vectors delivered directly to the LAPIC.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct MsiIrqSourceConfig {
+    /// High address to delivery message signaled interrupt.
+    pub high_addr: u32,
+    /// Low address to delivery message signaled interrupt.
+    pub low_addr: u32,
+    /// Data to write to delivery message signaled interrupt.
+    pub data: u32,
+}
+
+/// Configuration data for an interrupt source.
+#[derive(Copy, Clone, Debug)]
+pub enum InterruptSourceConfig {
+    /// Configuration data for Legacy interrupts.
+    LegacyIrq(LegacyIrqSourceConfig),
+    /// Configuration data for PciMsi, PciMsix and generic MSI interrupts.
+    MsiIrq(MsiIrqSourceConfig),
+}
+
+pub const PIN_IRQ: InterruptType = 0;
+pub const PCI_MSI_IRQ: InterruptType = 1;
+
+/// Trait to manage interrupt sources for virtual device backends.
+///
+/// The InterruptManager implementations should protect itself from concurrent accesses internally,
+/// so it could be invoked from multi-threaded context.
+pub trait InterruptManager {
+    /// Create an [InterruptSourceGroup](trait.InterruptSourceGroup.html) object to manage
+    /// interrupt sources for a virtual device
+    ///
+    /// An [InterruptSourceGroup](trait.InterruptSourceGroup.html) object manages all interrupt
+    /// sources of the same type for a virtual device.
+    ///
+    /// # Arguments
+    /// * interrupt_type: type of interrupt source.
+    /// * base: base Interrupt Source ID to be managed by the group object.
+    /// * count: number of Interrupt Sources to be managed by the group object.
+    fn create_group(
+        &self,
+        interrupt_type: InterruptType,
+        base: InterruptIndex,
+        count: InterruptIndex,
+    ) -> Result<Arc<Box<dyn InterruptSourceGroup>>>;
+
+    /// Destroy an [InterruptSourceGroup](trait.InterruptSourceGroup.html) object created by
+    /// [create_group()](trait.InterruptManager.html#tymethod.create_group).
+    ///
+    /// Assume the caller takes the responsibility to disable all interrupt sources of the group
+    /// before calling destroy_group(). This assumption helps to simplify InterruptSourceGroup
+    /// implementations.
+    fn destroy_group(&self, group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()>;
+}
+
+pub trait InterruptSourceGroup: Send + Sync {
+    /// Enable the interrupt sources in the group to generate interrupts.
+    fn enable(&self) -> Result<()> {
+        // Not all interrupt sources can be enabled.
+        // To accommodate this, we can have a no-op here.
+        Ok(())
+    }
+
+    /// Disable the interrupt sources in the group to generate interrupts.
+    fn disable(&self) -> Result<()> {
+        // Not all interrupt sources can be disabled.
+        // To accommodate this, we can have a no-op here.
+        Ok(())
+    }
+
+    /// Inject an interrupt from this interrupt source into the guest.
+    fn trigger(&self, index: InterruptIndex) -> Result<()>;
+
+    /// Returns an interrupt notifier from this interrupt.
+    ///
+    /// An interrupt notifier allows for external components and processes
+    /// to inject interrupts into a guest, by writing to the file returned
+    /// by this method.
+    #[allow(unused_variables)]
+    fn notifier(&self, index: InterruptIndex) -> Option<&EventFd> {
+        // One use case of the notifier is to implement vhost user backends.
+        // For all other implementations we can just return None here.
+        None
+    }
+
+    /// Update the interrupt source group configuration.
+    ///
+    /// # Arguments
+    /// * index: sub-index into the group.
+    /// * config: configuration data for the interrupt source.
+    fn update(&self, index: InterruptIndex, config: InterruptSourceConfig) -> Result<()>;
+
+    /// Mask an interrupt from this interrupt source.
+    fn mask(&self, _index: InterruptIndex) -> Result<()> {
+        // Not all interrupt sources can be disabled.
+        // To accommodate this, we can have a no-op here.
+        Ok(())
+    }
+
+    /// Unmask an interrupt from this interrupt source.
+    fn unmask(&self, _index: InterruptIndex) -> Result<()> {
+        // Not all interrupt sources can be disabled.
+        // To accommodate this, we can have a no-op here.
+        Ok(())
+    }
+}

--- a/vm-device/src/lib.rs
+++ b/vm-device/src/lib.rs
@@ -2,6 +2,8 @@ extern crate serde;
 extern crate thiserror;
 extern crate vm_memory;
 
+pub mod interrupt;
+
 use vm_memory::{
     Address, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap,
     MemoryRegionAddress,

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -14,6 +14,7 @@ arc-swap = ">=0.4.4"
 byteorder = "1.3.2"
 devices = { path = "../devices" }
 epoll = ">=4.0.1"
+kvm-ioctls = "0.4.0"
 libc = "0.2.60"
 log = "0.4.8"
 net_gen = { path = "../net_gen" }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -14,8 +14,6 @@ arc-swap = ">=0.4.4"
 byteorder = "1.3.2"
 devices = { path = "../devices" }
 epoll = ">=4.0.1"
-kvm-bindings = "0.2.0"
-kvm-ioctls = "0.4.0"
 libc = "0.2.60"
 log = "0.4.8"
 net_gen = { path = "../net_gen" }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -14,6 +14,7 @@ arc-swap = ">=0.4.4"
 byteorder = "1.3.2"
 devices = { path = "../devices" }
 epoll = ">=4.0.1"
+kvm-bindings = "0.2.0"
 kvm-ioctls = "0.4.0"
 libc = "0.2.60"
 log = "0.4.8"

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -23,7 +23,11 @@ pub trait VirtioInterrupt: Send + Sync {
         int_type: &VirtioInterruptType,
         queue: Option<&Queue>,
     ) -> std::result::Result<(), std::io::Error>;
-    fn notifier(&self, _int_type: &VirtioInterruptType, _queue: Option<&Queue>) -> Option<EventFd> {
+    fn notifier(
+        &self,
+        _int_type: &VirtioInterruptType,
+        _queue: Option<&Queue>,
+    ) -> Option<&EventFd> {
         None
     }
 }

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -23,6 +23,9 @@ pub trait VirtioInterrupt: Send + Sync {
         int_type: &VirtioInterruptType,
         queue: Option<&Queue>,
     ) -> std::result::Result<(), std::io::Error>;
+    fn notifier(&self, _int_type: &VirtioInterruptType, _queue: Option<&Queue>) -> Option<EventFd> {
+        None
+    }
 }
 
 pub type VirtioIommuRemapping =

--- a/vm-virtio/src/transport/pci_common_config.rs
+++ b/vm-virtio/src/transport/pci_common_config.rs
@@ -273,7 +273,7 @@ mod tests {
         fn activate(
             &mut self,
             _mem: Arc<ArcSwap<GuestMemoryMmap>>,
-            _interrupt_evt: Arc<VirtioInterrupt>,
+            _interrupt_evt: Arc<dyn VirtioInterrupt>,
             _queues: Vec<Queue>,
             _queue_evts: Vec<EventFd>,
         ) -> ActivateResult {

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -498,11 +498,6 @@ impl PciDevice for VirtioPciDevice {
 
     fn assign_msix(&mut self, msi_cb: Arc<InterruptDelivery>) {
         if let Some(msix_config) = &self.msix_config {
-            msix_config
-                .lock()
-                .unwrap()
-                .register_interrupt_cb(msi_cb.clone());
-
             let msix_config_clone = msix_config.clone();
 
             let common_config_msi_vector = self.common_config.msix_config.clone();

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -256,6 +256,7 @@ impl VirtioPciDevice {
         device: Arc<Mutex<dyn VirtioDevice>>,
         msix_num: u16,
         iommu_mapping_cb: Option<Arc<VirtioIommuRemapping>>,
+        allocator: &mut SystemAllocator,
     ) -> Result<Self> {
         let device_clone = device.clone();
         let locked_device = device_clone.lock().unwrap();
@@ -276,7 +277,7 @@ impl VirtioPciDevice {
         let pci_device_id = VIRTIO_PCI_DEVICE_ID_BASE + locked_device.device_type() as u16;
 
         let (msix_config, msix_config_clone) = if msix_num > 0 {
-            let msix_config = Arc::new(Mutex::new(MsixConfig::new(msix_num)));
+            let msix_config = Arc::new(Mutex::new(MsixConfig::new(msix_num, allocator)));
             let msix_config_clone = msix_config.clone();
             (Some(msix_config), Some(msix_config_clone))
         } else {

--- a/vm-virtio/src/vhost_user/blk.rs
+++ b/vm-virtio/src/vhost_user/blk.rs
@@ -46,7 +46,7 @@ pub struct Blk {
     config_space: Vec<u8>,
     queue_sizes: Vec<u16>,
     queue_evts: Option<Vec<EventFd>>,
-    interrupt_cb: Option<Arc<VirtioInterrupt>>,
+    interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
     epoll_thread: Option<thread::JoinHandle<result::Result<(), DeviceError>>>,
     paused: Arc<AtomicBool>,
 }
@@ -220,7 +220,7 @@ impl VirtioDevice for Blk {
     fn activate(
         &mut self,
         mem: Arc<ArcSwap<GuestMemoryMmap>>,
-        interrupt_cb: Arc<VirtioInterrupt>,
+        interrupt_cb: Arc<dyn VirtioInterrupt>,
         queues: Vec<Queue>,
         queue_evts: Vec<EventFd>,
     ) -> ActivateResult {
@@ -285,7 +285,7 @@ impl VirtioDevice for Blk {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
         // We first must resume the virtio thread if it was paused.
         if self.pause_evt.take().is_some() {
             self.resume().ok()?;

--- a/vm-virtio/src/vhost_user/blk.rs
+++ b/vm-virtio/src/vhost_user/blk.rs
@@ -260,6 +260,7 @@ impl VirtioDevice for Blk {
             mem.load().as_ref(),
             queues,
             queue_evts,
+            &interrupt_cb,
             self.acked_features,
         )
         .map_err(ActivateError::VhostUserBlkSetup)?;

--- a/vm-virtio/src/vhost_user/fs.rs
+++ b/vm-virtio/src/vhost_user/fs.rs
@@ -382,6 +382,7 @@ impl VirtioDevice for Fs {
             mem.load().as_ref(),
             queues,
             queue_evts,
+            &interrupt_cb,
             self.acked_features,
         )
         .map_err(ActivateError::VhostUserSetup)?;

--- a/vm-virtio/src/vhost_user/fs.rs
+++ b/vm-virtio/src/vhost_user/fs.rs
@@ -161,7 +161,7 @@ pub struct Fs {
     cache: Option<(VirtioSharedMemoryList, u64)>,
     slave_req_support: bool,
     queue_evts: Option<Vec<EventFd>>,
-    interrupt_cb: Option<Arc<VirtioInterrupt>>,
+    interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
     epoll_thread: Option<thread::JoinHandle<result::Result<(), DeviceError>>>,
     paused: Arc<AtomicBool>,
 }
@@ -333,7 +333,7 @@ impl VirtioDevice for Fs {
     fn activate(
         &mut self,
         mem: Arc<ArcSwap<GuestMemoryMmap>>,
-        interrupt_cb: Arc<VirtioInterrupt>,
+        interrupt_cb: Arc<dyn VirtioInterrupt>,
         queues: Vec<Queue>,
         queue_evts: Vec<EventFd>,
     ) -> ActivateResult {
@@ -431,7 +431,7 @@ impl VirtioDevice for Fs {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
         // We first must resume the virtio thread if it was paused.
         if self.pause_evt.take().is_some() {
             self.resume().ok()?;

--- a/vm-virtio/src/vhost_user/handler.rs
+++ b/vm-virtio/src/vhost_user/handler.rs
@@ -28,7 +28,7 @@ use vhost_rs::vhost_user::{MasterReqHandler, VhostUserMasterReqHandler};
 /// * `kill_evt` - EventFd used to kill the vhost-user device.
 /// * `vu_interrupt_list` - virtqueue and EventFd to signal when buffer used.
 pub struct VhostUserEpollConfig<S: VhostUserMasterReqHandler> {
-    pub interrupt_cb: Arc<VirtioInterrupt>,
+    pub interrupt_cb: Arc<dyn VirtioInterrupt>,
     pub kill_evt: EventFd,
     pub pause_evt: EventFd,
     pub vu_interrupt_list: Vec<(EventFd, Queue)>,
@@ -52,7 +52,9 @@ impl<S: VhostUserMasterReqHandler> VhostUserEpollHandler<S> {
     }
 
     fn signal_used_queue(&self, queue: &Queue) -> Result<()> {
-        (self.vu_epoll_cfg.interrupt_cb)(&VirtioInterruptType::Queue, Some(queue))
+        self.vu_epoll_cfg
+            .interrupt_cb
+            .trigger(&VirtioInterruptType::Queue, Some(queue))
             .map_err(Error::FailedSignalingUsedQueue)
     }
 

--- a/vm-virtio/src/vhost_user/net.rs
+++ b/vm-virtio/src/vhost_user/net.rs
@@ -44,7 +44,7 @@ pub struct Net {
     config_space: Vec<u8>,
     queue_sizes: Vec<u16>,
     queue_evts: Option<Vec<EventFd>>,
-    interrupt_cb: Option<Arc<VirtioInterrupt>>,
+    interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
     epoll_thread: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
     ctrl_queue_epoll_thread: Option<thread::JoinHandle<result::Result<(), CtrlError>>>,
     paused: Arc<AtomicBool>,
@@ -227,7 +227,7 @@ impl VirtioDevice for Net {
     fn activate(
         &mut self,
         mem: Arc<ArcSwap<GuestMemoryMmap>>,
-        interrupt_cb: Arc<VirtioInterrupt>,
+        interrupt_cb: Arc<dyn VirtioInterrupt>,
         mut queues: Vec<Queue>,
         mut queue_evts: Vec<EventFd>,
     ) -> ActivateResult {
@@ -336,7 +336,7 @@ impl VirtioDevice for Net {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
         // We first must resume the virtio thread if it was paused.
         if self.pause_evt.take().is_some() {
             self.resume().ok()?;

--- a/vm-virtio/src/vhost_user/net.rs
+++ b/vm-virtio/src/vhost_user/net.rs
@@ -302,13 +302,14 @@ impl VirtioDevice for Net {
             mem.load().as_ref(),
             queues,
             queue_evts,
+            &interrupt_cb,
             self.acked_features & self.backend_features,
         )
         .map_err(ActivateError::VhostUserNetSetup)?;
 
         let mut epoll_thread = Vec::new();
         for _ in 0..vu_interrupt_list.len() / 2 {
-            let mut interrupt_list_sub: Vec<(EventFd, Queue)> = Vec::with_capacity(2);
+            let mut interrupt_list_sub: Vec<(Option<EventFd>, Queue)> = Vec::with_capacity(2);
             interrupt_list_sub.push(vu_interrupt_list.remove(0));
             interrupt_list_sub.push(vu_interrupt_list.remove(0));
 

--- a/vm-virtio/src/vsock/mod.rs
+++ b/vm-virtio/src/vsock/mod.rs
@@ -172,6 +172,18 @@ mod tests {
     use vm_memory::{GuestAddress, GuestMemoryMmap};
     use vmm_sys_util::eventfd::EventFd;
 
+    pub struct NoopVirtioInterrupt {}
+
+    impl VirtioInterrupt for NoopVirtioInterrupt {
+        fn trigger(
+            &self,
+            _int_type: &VirtioInterruptType,
+            _queue: Option<&Queue>,
+        ) -> std::result::Result<(), std::io::Error> {
+            Ok(())
+        }
+    }
+
     pub struct TestBackend {
         pub evfd: EventFd,
         pub rx_err: Option<VsockError>,
@@ -291,9 +303,7 @@ mod tests {
                 EventFd::new(EFD_NONBLOCK).unwrap(),
                 EventFd::new(EFD_NONBLOCK).unwrap(),
             ];
-            let interrupt_cb = Arc::new(Box::new(
-                move |_: &VirtioInterruptType, _: Option<&Queue>| Ok(()),
-            ) as VirtioInterrupt);
+            let interrupt_cb = Arc::new(NoopVirtioInterrupt {});
 
             EpollHandlerContext {
                 guest_rxvq,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1472,6 +1472,7 @@ impl DeviceManager {
             msix_num,
             iommu_mapping_cb,
             &mut allocator,
+            vm_fd,
         )
         .map_err(DeviceManagerError::VirtioDevice)?;
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1464,11 +1464,16 @@ impl DeviceManager {
                 None
             };
 
-        let mut virtio_pci_device =
-            VirtioPciDevice::new(memory.clone(), virtio_device, msix_num, iommu_mapping_cb)
-                .map_err(DeviceManagerError::VirtioDevice)?;
-
         let mut allocator = address_manager.allocator.lock().unwrap();
+
+        let mut virtio_pci_device = VirtioPciDevice::new(
+            memory.clone(),
+            virtio_device,
+            msix_num,
+            iommu_mapping_cb,
+            &mut allocator,
+        )
+        .map_err(DeviceManagerError::VirtioDevice)?;
 
         let bars = virtio_pci_device
             .allocate_bars(&mut allocator)

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -12,6 +12,8 @@
 extern crate vm_device;
 
 use crate::config::{ConsoleOutputMode, VmConfig};
+#[cfg(feature = "pci_support")]
+use crate::interrupt::{KvmInterruptManager, KvmRoutingEntry};
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 use crate::vm::VmInfo;
 #[cfg(feature = "acpi")]
@@ -20,7 +22,6 @@ use arc_swap::ArcSwap;
 use arch::layout;
 use arch::layout::{APIC_START, IOAPIC_SIZE, IOAPIC_START};
 use devices::{ioapic, HotPlugNotificationFlags};
-use kvm_bindings::kvm_irq_routing_entry;
 use kvm_ioctls::*;
 use libc::O_TMPFILE;
 use libc::TIOCGWINSZ;
@@ -43,6 +44,8 @@ use std::sync::{Arc, Mutex};
 #[cfg(feature = "pci_support")]
 use vfio::{VfioDevice, VfioDmaMapping, VfioPciDevice, VfioPciError};
 use vm_allocator::SystemAllocator;
+#[cfg(feature = "pci_support")]
+use vm_device::interrupt::InterruptManager;
 use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::GuestAddress;
 use vm_memory::{Address, GuestMemoryMmap, GuestUsize};
@@ -547,8 +550,14 @@ impl DeviceManager {
             // devices. This way, we can maintain the full list of used GSI,
             // preventing one device from overriding interrupts setting from
             // another one.
-            let gsi_msi_routes: Arc<Mutex<HashMap<u32, kvm_irq_routing_entry>>> =
+            let kvm_gsi_msi_routes: Arc<Mutex<HashMap<u32, KvmRoutingEntry>>> =
                 Arc::new(Mutex::new(HashMap::new()));
+
+            let interrupt_manager: Arc<dyn InterruptManager> = Arc::new(KvmInterruptManager::new(
+                address_manager.allocator.clone(),
+                vm_info.vm_fd.clone(),
+                kvm_gsi_msi_routes,
+            ));
 
             let (mut iommu_device, iommu_mapping) = if vm_info.vm_cfg.lock().unwrap().iommu {
                 let (device, mapping) =
@@ -575,7 +584,7 @@ impl DeviceManager {
                     &mut pci_bus,
                     mapping,
                     migratable_devices,
-                    &gsi_msi_routes,
+                    &interrupt_manager,
                 )?;
 
                 if let Some(dev_id) = virtio_iommu_attach_dev {
@@ -589,7 +598,7 @@ impl DeviceManager {
                 &mut pci_bus,
                 memory_manager,
                 &mut iommu_device,
-                &gsi_msi_routes,
+                &interrupt_manager,
             )?;
 
             iommu_attached_devices.append(&mut vfio_iommu_device_ids);
@@ -613,7 +622,7 @@ impl DeviceManager {
                     &mut pci_bus,
                     &None,
                     migratable_devices,
-                    &gsi_msi_routes,
+                    &interrupt_manager,
                 )?;
 
                 *virt_iommu = Some((iommu_id, iommu_attached_devices));
@@ -1349,11 +1358,10 @@ impl DeviceManager {
         pci: &mut PciBus,
         memory_manager: &Arc<Mutex<MemoryManager>>,
         iommu_device: &mut Option<vm_virtio::Iommu>,
-        gsi_msi_routes: &Arc<Mutex<HashMap<u32, kvm_irq_routing_entry>>>,
+        interrupt_manager: &Arc<dyn InterruptManager>,
     ) -> DeviceManagerResult<Vec<u32>> {
         let mut mem_slot = memory_manager.lock().unwrap().allocate_kvm_memory_slot();
         let mut iommu_attached_device_ids = Vec::new();
-        let mut allocator = address_manager.allocator.lock().unwrap();
 
         if let Some(device_list_cfg) = &vm_info.vm_cfg.lock().unwrap().devices {
             // Create the KVM VFIO device
@@ -1388,16 +1396,12 @@ impl DeviceManager {
                     }
                 }
 
-                let mut vfio_pci_device = VfioPciDevice::new(
-                    vm_info.vm_fd,
-                    &mut allocator,
-                    vfio_device,
-                    gsi_msi_routes.clone(),
-                )
-                .map_err(DeviceManagerError::VfioPciCreate)?;
+                let mut vfio_pci_device =
+                    VfioPciDevice::new(vm_info.vm_fd, vfio_device, &interrupt_manager)
+                        .map_err(DeviceManagerError::VfioPciCreate)?;
 
                 let bars = vfio_pci_device
-                    .allocate_bars(&mut allocator)
+                    .allocate_bars(&mut address_manager.allocator.lock().unwrap())
                     .map_err(DeviceManagerError::AllocateBars)?;
 
                 mem_slot = vfio_pci_device
@@ -1431,7 +1435,7 @@ impl DeviceManager {
         pci: &mut PciBus,
         iommu_mapping: &Option<Arc<IommuMapping>>,
         migratable_devices: &mut Vec<Arc<Mutex<dyn Migratable>>>,
-        gsi_msi_routes: &Arc<Mutex<HashMap<u32, kvm_irq_routing_entry>>>,
+        interrupt_manager: &Arc<dyn InterruptManager>,
     ) -> DeviceManagerResult<Option<u32>> {
         // Allows support for one MSI-X vector per queue. It also adds 1
         // as we need to take into account the dedicated vector to notify
@@ -1465,19 +1469,16 @@ impl DeviceManager {
                 None
             };
 
-        let mut allocator = address_manager.allocator.lock().unwrap();
-
         let mut virtio_pci_device = VirtioPciDevice::new(
             memory.clone(),
             virtio_device,
             msix_num,
             iommu_mapping_cb,
-            &mut allocator,
-            vm_fd,
-            gsi_msi_routes.clone(),
+            interrupt_manager,
         )
         .map_err(DeviceManagerError::VirtioDevice)?;
 
+        let mut allocator = address_manager.allocator.lock().unwrap();
         let bars = virtio_pci_device
             .allocate_bars(&mut allocator)
             .map_err(DeviceManagerError::AllocateBars)?;

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -1,0 +1,48 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+//
+
+use std::sync::Arc;
+use vm_device::interrupt::{
+    InterruptIndex, InterruptManager, InterruptSourceConfig, InterruptSourceGroup, InterruptType,
+};
+
+/// Reuse std::io::Result to simplify interoperability among crates.
+pub type Result<T> = std::io::Result<T>;
+
+pub struct MsiInterruptGroup {}
+
+impl MsiInterruptGroup {
+    fn new() -> Self {
+        MsiInterruptGroup {}
+    }
+}
+
+impl InterruptSourceGroup for MsiInterruptGroup {
+    fn trigger(&self, _index: InterruptIndex) -> Result<()> {
+        Ok(())
+    }
+
+    fn update(&self, _index: InterruptIndex, _config: InterruptSourceConfig) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub struct KvmInterruptManager {}
+
+impl InterruptManager for KvmInterruptManager {
+    fn create_group(
+        &self,
+        _interrupt_type: InterruptType,
+        _base: InterruptIndex,
+        _count: InterruptIndex,
+    ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
+        let interrupt_source_group = MsiInterruptGroup::new();
+        Ok(Arc::new(Box::new(interrupt_source_group)))
+    }
+
+    fn destroy_group(&self, _group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()> {
+        Ok(())
+    }
+}

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -3,43 +3,294 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 //
 
-use std::sync::Arc;
+use kvm_bindings::{kvm_irq_routing, kvm_irq_routing_entry, KVM_IRQ_ROUTING_MSI};
+use kvm_ioctls::VmFd;
+use std::collections::HashMap;
+use std::io;
+use std::mem::size_of;
+use std::sync::{Arc, Mutex};
+use vm_allocator::SystemAllocator;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceConfig, InterruptSourceGroup, InterruptType,
+    PCI_MSI_IRQ,
 };
+use vmm_sys_util::eventfd::EventFd;
 
 /// Reuse std::io::Result to simplify interoperability among crates.
 pub type Result<T> = std::io::Result<T>;
 
-pub struct MsiInterruptGroup {}
+// Returns a `Vec<T>` with a size in bytes at least as large as `size_in_bytes`.
+fn vec_with_size_in_bytes<T: Default>(size_in_bytes: usize) -> Vec<T> {
+    let rounded_size = (size_in_bytes + size_of::<T>() - 1) / size_of::<T>();
+    let mut v = Vec::with_capacity(rounded_size);
+    v.resize_with(rounded_size, T::default);
+    v
+}
+
+// The kvm API has many structs that resemble the following `Foo` structure:
+//
+// ```
+// #[repr(C)]
+// struct Foo {
+//    some_data: u32
+//    entries: __IncompleteArrayField<__u32>,
+// }
+// ```
+//
+// In order to allocate such a structure, `size_of::<Foo>()` would be too small because it would not
+// include any space for `entries`. To make the allocation large enough while still being aligned
+// for `Foo`, a `Vec<Foo>` is created. Only the first element of `Vec<Foo>` would actually be used
+// as a `Foo`. The remaining memory in the `Vec<Foo>` is for `entries`, which must be contiguous
+// with `Foo`. This function is used to make the `Vec<Foo>` with enough space for `count` entries.
+pub fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
+    let element_space = count * size_of::<F>();
+    let vec_size_bytes = size_of::<T>() + element_space;
+    vec_with_size_in_bytes(vec_size_bytes)
+}
+
+pub struct InterruptRoute {
+    pub gsi: u32,
+    pub irq_fd: EventFd,
+}
+
+impl InterruptRoute {
+    pub fn new(allocator: &mut SystemAllocator) -> Result<Self> {
+        let irq_fd = EventFd::new(libc::EFD_NONBLOCK)?;
+        let gsi = allocator
+            .allocate_gsi()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Failed allocating new GSI"))?;
+
+        Ok(InterruptRoute { gsi, irq_fd })
+    }
+
+    pub fn enable(&self, vm: &Arc<VmFd>) -> Result<()> {
+        vm.register_irqfd(&self.irq_fd, self.gsi).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed registering irq_fd: {}", e),
+            )
+        })
+    }
+
+    pub fn disable(&self, vm: &Arc<VmFd>) -> Result<()> {
+        vm.unregister_irqfd(&self.irq_fd, self.gsi).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed unregistering irq_fd: {}", e),
+            )
+        })
+    }
+}
+
+pub struct KvmRoutingEntry {
+    kvm_route: kvm_irq_routing_entry,
+    masked: bool,
+}
+
+pub struct MsiInterruptGroup {
+    vm_fd: Arc<VmFd>,
+    gsi_msi_routes: Arc<Mutex<HashMap<u32, KvmRoutingEntry>>>,
+    irq_routes: HashMap<InterruptIndex, InterruptRoute>,
+}
 
 impl MsiInterruptGroup {
-    fn new() -> Self {
-        MsiInterruptGroup {}
+    fn new(
+        vm_fd: Arc<VmFd>,
+        gsi_msi_routes: Arc<Mutex<HashMap<u32, KvmRoutingEntry>>>,
+        irq_routes: HashMap<InterruptIndex, InterruptRoute>,
+    ) -> Self {
+        MsiInterruptGroup {
+            vm_fd,
+            gsi_msi_routes,
+            irq_routes,
+        }
+    }
+
+    fn set_kvm_gsi_routes(&self) -> Result<()> {
+        let gsi_msi_routes = self.gsi_msi_routes.lock().unwrap();
+        let mut entry_vec: Vec<kvm_irq_routing_entry> = Vec::new();
+        for (_, entry) in gsi_msi_routes.iter() {
+            if entry.masked {
+                continue;
+            }
+
+            entry_vec.push(entry.kvm_route);
+        }
+
+        let mut irq_routing =
+            vec_with_array_field::<kvm_irq_routing, kvm_irq_routing_entry>(entry_vec.len());
+        irq_routing[0].nr = entry_vec.len() as u32;
+        irq_routing[0].flags = 0;
+
+        unsafe {
+            let entries: &mut [kvm_irq_routing_entry] =
+                irq_routing[0].entries.as_mut_slice(entry_vec.len());
+            entries.copy_from_slice(&entry_vec);
+        }
+
+        self.vm_fd.set_gsi_routing(&irq_routing[0]).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed setting GSI routing: {}", e),
+            )
+        })
+    }
+
+    fn mask_kvm_entry(&self, index: InterruptIndex, mask: bool) -> Result<()> {
+        if let Some(route) = self.irq_routes.get(&index) {
+            let mut gsi_msi_routes = self.gsi_msi_routes.lock().unwrap();
+            if let Some(kvm_entry) = gsi_msi_routes.get_mut(&route.gsi) {
+                kvm_entry.masked = mask;
+            } else {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("mask: No existing route for interrupt index {}", index),
+                ));
+            }
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("mask: Invalid interrupt index {}", index),
+            ));
+        }
+
+        self.set_kvm_gsi_routes()
     }
 }
 
 impl InterruptSourceGroup for MsiInterruptGroup {
-    fn trigger(&self, _index: InterruptIndex) -> Result<()> {
+    fn enable(&self) -> Result<()> {
+        for (_, route) in self.irq_routes.iter() {
+            route.enable(&self.vm_fd)?;
+        }
+
         Ok(())
     }
 
-    fn update(&self, _index: InterruptIndex, _config: InterruptSourceConfig) -> Result<()> {
+    fn disable(&self) -> Result<()> {
+        for (_, route) in self.irq_routes.iter() {
+            route.disable(&self.vm_fd)?;
+        }
+
         Ok(())
+    }
+
+    fn trigger(&self, index: InterruptIndex) -> Result<()> {
+        if let Some(route) = self.irq_routes.get(&index) {
+            return route.irq_fd.write(1);
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("trigger: Invalid interrupt index {}", index),
+        ))
+    }
+
+    fn notifier(&self, index: InterruptIndex) -> Option<&EventFd> {
+        if let Some(route) = self.irq_routes.get(&index) {
+            return Some(&route.irq_fd);
+        }
+
+        None
+    }
+
+    fn update(&self, index: InterruptIndex, config: InterruptSourceConfig) -> Result<()> {
+        if let Some(route) = self.irq_routes.get(&index) {
+            if let InterruptSourceConfig::MsiIrq(cfg) = &config {
+                let mut kvm_route = kvm_irq_routing_entry {
+                    gsi: route.gsi,
+                    type_: KVM_IRQ_ROUTING_MSI,
+                    ..Default::default()
+                };
+
+                kvm_route.u.msi.address_lo = cfg.low_addr;
+                kvm_route.u.msi.address_hi = cfg.high_addr;
+                kvm_route.u.msi.data = cfg.data;
+
+                let kvm_entry = KvmRoutingEntry {
+                    kvm_route,
+                    masked: false,
+                };
+
+                self.gsi_msi_routes
+                    .lock()
+                    .unwrap()
+                    .insert(route.gsi, kvm_entry);
+            } else {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "Interrupt config type not supported",
+                ));
+            }
+
+            return self.set_kvm_gsi_routes();
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("update: Invalid interrupt index {}", index),
+        ))
+    }
+
+    fn mask(&self, index: InterruptIndex) -> Result<()> {
+        self.mask_kvm_entry(index, true)
+    }
+
+    fn unmask(&self, index: InterruptIndex) -> Result<()> {
+        self.mask_kvm_entry(index, false)
     }
 }
 
-pub struct KvmInterruptManager {}
+pub struct KvmInterruptManager {
+    allocator: Arc<Mutex<SystemAllocator>>,
+    vm_fd: Arc<VmFd>,
+    gsi_msi_routes: Arc<Mutex<HashMap<u32, KvmRoutingEntry>>>,
+}
+
+impl KvmInterruptManager {
+    pub fn new(
+        allocator: Arc<Mutex<SystemAllocator>>,
+        vm_fd: Arc<VmFd>,
+        gsi_msi_routes: Arc<Mutex<HashMap<u32, KvmRoutingEntry>>>,
+    ) -> Self {
+        KvmInterruptManager {
+            allocator,
+            vm_fd,
+            gsi_msi_routes,
+        }
+    }
+}
 
 impl InterruptManager for KvmInterruptManager {
     fn create_group(
         &self,
-        _interrupt_type: InterruptType,
-        _base: InterruptIndex,
-        _count: InterruptIndex,
+        interrupt_type: InterruptType,
+        base: InterruptIndex,
+        count: InterruptIndex,
     ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
-        let interrupt_source_group = MsiInterruptGroup::new();
-        Ok(Arc::new(Box::new(interrupt_source_group)))
+        let mut allocator = self.allocator.lock().unwrap();
+
+        let mut irq_routes: HashMap<InterruptIndex, InterruptRoute> =
+            HashMap::with_capacity(count as usize);
+        for i in base..count {
+            irq_routes.insert(i, InterruptRoute::new(&mut allocator)?);
+        }
+
+        let interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>> = match interrupt_type {
+            PCI_MSI_IRQ => Arc::new(Box::new(MsiInterruptGroup::new(
+                self.vm_fd.clone(),
+                self.gsi_msi_routes.clone(),
+                irq_routes,
+            ))),
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "Interrupt type not supported",
+                ))
+            }
+        };
+
+        Ok(interrupt_source_group)
     }
 
     fn destroy_group(&self, _group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()> {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -30,6 +30,7 @@ pub mod api;
 pub mod config;
 pub mod cpu;
 pub mod device_manager;
+pub mod interrupt;
 pub mod memory_manager;
 pub mod vm;
 


### PR DESCRIPTION
The goal for this pull request is to globally reorganize and factorize some code related to interrupt management.

First thing, it changes the way MSI and MSI-X vectors are being triggered through KVM, as the ioctls being used are now `KVM_IRQ` and `KVM_SET_GSI_ROUTING` instead of `KVM_SIGNAL_MSI`. This improve the consistency of the codebase as all MSI vectors can now be managed through the same mechanism.

With this mechanism, the VMM has now access to the event fd responsible for triggering the interrupt and it can be provided directly to vhost-user devices, which optimizes the interrupt delivery path from a vhost-user backend perspective.

In order to prevent from code duplication, the update of the KVM GSI routes has been moved to the lowest level of code, that is `msi.rs` and `msix.rs`. This way, PCI devices (through VFIO or virtio) don't have to re-implement the support for updating the KVM GSI routes themselves.

Last but not the least, once all of this is in place, the pull request introduces two traits coming from rust-vmm/vm-device, so that we can abstract the interrupt management, regardless of the hypervisor and the type of interrupt being used. This allow to keep `pci` and `vm-virtio` crates free from importing `KVM` specific code.

Fixes #590