### PR TITLE
Introduce InterruptManager for legacy interrupts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-device 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -11,6 +11,7 @@ kvm-bindings = "0.2.0"
 kvm-ioctls = "0.4.0"
 libc = "0.2.60"
 log = "0.4.8"
+vm-device = { path = "../vm-device" }
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
 vmm-sys-util = ">=0.3.1"
 

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -15,6 +15,7 @@ extern crate kvm_ioctls;
 extern crate libc;
 #[macro_use]
 extern crate log;
+extern crate vm_device;
 extern crate vm_memory;
 extern crate vmm_sys_util;
 

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -20,7 +20,7 @@ extern crate vm_memory;
 extern crate vmm_sys_util;
 
 use std::fs::File;
-use std::{io, result};
+use std::io;
 
 #[cfg(feature = "acpi")]
 mod acpi;
@@ -68,10 +68,6 @@ pub enum Error {
         event: DeviceEventT,
     },
     IoError(io::Error),
-}
-
-pub trait Interrupt: Send + Sync {
-    fn deliver(&self) -> result::Result<(), std::io::Error>;
 }
 
 bitflags! {

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -4,11 +4,9 @@
 
 use crate::configuration::{self, PciBarRegionType};
 use crate::msix::MsixTableEntry;
-use crate::PciInterruptPin;
 use devices::BusDevice;
 use std::any::Any;
 use std::fmt::{self, Display};
-use std::sync::Arc;
 use std::{self, io, result};
 use vm_allocator::SystemAllocator;
 use vm_memory::{GuestAddress, GuestUsize};
@@ -56,19 +54,6 @@ pub struct BarReprogrammingParams {
 }
 
 pub trait PciDevice: BusDevice {
-    /// Assign a legacy PCI IRQ to this device.
-    /// The device may write to `irq_evt` to trigger an interrupt.
-    fn assign_pin_irq(
-        &mut self,
-        _irq_cb: Arc<InterruptDelivery>,
-        _irq_num: u32,
-        _irq_pin: PciInterruptPin,
-    ) {
-    }
-
-    /// Assign MSI-X to this device.
-    fn assign_msix(&mut self) {}
-
     /// Allocates the needed PCI BARs space using the `allocate` function which takes a size and
     /// returns an address. Returns a Vec of (GuestAddress, GuestUsize) tuples.
     fn allocate_bars(

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -3,20 +3,12 @@
 // found in the LICENSE-BSD-3-Clause file.
 
 use crate::configuration::{self, PciBarRegionType};
-use crate::msix::MsixTableEntry;
 use devices::BusDevice;
 use std::any::Any;
 use std::fmt::{self, Display};
 use std::{self, io, result};
 use vm_allocator::SystemAllocator;
 use vm_memory::{GuestAddress, GuestUsize};
-
-pub struct InterruptParameters<'a> {
-    pub msix: Option<&'a MsixTableEntry>,
-}
-
-pub type InterruptDelivery =
-    Box<dyn Fn(InterruptParameters) -> result::Result<(), io::Error> + Send + Sync>;
 
 #[derive(Debug)]
 pub enum Error {

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -21,8 +21,7 @@ pub use self::configuration::{
     PciNetworkControllerSubclass, PciProgrammingInterface, PciSerialBusSubClass, PciSubclass,
 };
 pub use self::device::{
-    BarReprogrammingParams, DeviceRelocation, Error as PciDeviceError, InterruptDelivery,
-    InterruptParameters, PciDevice,
+    BarReprogrammingParams, DeviceRelocation, Error as PciDeviceError, PciDevice,
 };
 pub use self::msi::{msi_num_enabled_vectors, MsiCap, MsiConfig};
 pub use self::msix::{MsixCap, MsixConfig, MsixTableEntry, MSIX_TABLE_ENTRY_SIZE};

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -472,7 +472,7 @@ impl DeviceManager {
                 &memory_manager,
                 &mut virt_iommu,
                 virtio_devices,
-                interrupt_manager.clone(),
+                &interrupt_manager,
                 &mut migratable_devices,
             )?;
         } else if cfg!(feature = "mmio_support") {
@@ -522,7 +522,7 @@ impl DeviceManager {
         memory_manager: &Arc<Mutex<MemoryManager>>,
         virt_iommu: &mut Option<(u32, Vec<u32>)>,
         virtio_devices: Vec<(Arc<Mutex<dyn vm_virtio::VirtioDevice>>, bool)>,
-        interrupt_manager: Arc<dyn InterruptManager>,
+        interrupt_manager: &Arc<dyn InterruptManager>,
         migratable_devices: &mut Vec<Arc<Mutex<dyn Migratable>>>,
     ) -> DeviceManagerResult<()> {
         #[cfg(feature = "pci_support")]
@@ -558,7 +558,7 @@ impl DeviceManager {
                     &mut pci_bus,
                     mapping,
                     migratable_devices,
-                    &interrupt_manager,
+                    interrupt_manager,
                 )?;
 
                 if let Some(dev_id) = virtio_iommu_attach_dev {
@@ -572,7 +572,7 @@ impl DeviceManager {
                 &mut pci_bus,
                 memory_manager,
                 &mut iommu_device,
-                &interrupt_manager,
+                interrupt_manager,
             )?;
 
             iommu_attached_devices.append(&mut vfio_iommu_device_ids);
@@ -596,7 +596,7 @@ impl DeviceManager {
                     &mut pci_bus,
                     &None,
                     migratable_devices,
-                    &interrupt_manager,
+                    interrupt_manager,
                 )?;
 
                 *virt_iommu = Some((iommu_id, iommu_attached_devices));
@@ -1379,7 +1379,7 @@ impl DeviceManager {
                 }
 
                 let mut vfio_pci_device =
-                    VfioPciDevice::new(vm_info.vm_fd, vfio_device, &interrupt_manager)
+                    VfioPciDevice::new(vm_info.vm_fd, vfio_device, interrupt_manager)
                         .map_err(DeviceManagerError::VfioPciCreate)?;
 
                 let bars = vfio_pci_device

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1473,8 +1473,6 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RegisterIoevent)?;
         }
 
-        virtio_pci_device.assign_msix();
-
         let virtio_pci_device = Arc::new(Mutex::new(virtio_pci_device));
 
         pci.add_device(virtio_pci_device.clone())

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -458,6 +458,7 @@ impl DeviceManager {
             address_manager.allocator.clone(),
             vm_info.vm_fd.clone(),
             kvm_gsi_msi_routes,
+            ioapic.clone(),
         ));
 
         let console = DeviceManager::add_console_device(

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex};
 use vm_allocator::SystemAllocator;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceConfig, InterruptSourceGroup, InterruptType,
-    PCI_MSI_IRQ,
+    PCI_MSI_IRQ, PIN_IRQ,
 };
 use vmm_sys_util::eventfd::EventFd;
 
@@ -241,6 +241,24 @@ impl InterruptSourceGroup for MsiInterruptGroup {
     }
 }
 
+pub struct LegacyUserspaceInterruptGroup {}
+
+impl LegacyUserspaceInterruptGroup {
+    fn new() -> Self {
+        LegacyUserspaceInterruptGroup {}
+    }
+}
+
+impl InterruptSourceGroup for LegacyUserspaceInterruptGroup {
+    fn trigger(&self, _index: InterruptIndex) -> Result<()> {
+        Ok(())
+    }
+
+    fn update(&self, _index: InterruptIndex, _config: InterruptSourceConfig) -> Result<()> {
+        Ok(())
+    }
+}
+
 pub struct KvmInterruptManager {
     allocator: Arc<Mutex<SystemAllocator>>,
     vm_fd: Arc<VmFd>,
@@ -269,6 +287,7 @@ impl InterruptManager for KvmInterruptManager {
         count: InterruptIndex,
     ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
         let interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>> = match interrupt_type {
+            PIN_IRQ => Arc::new(Box::new(LegacyUserspaceInterruptGroup::new())),
             PCI_MSI_IRQ => {
                 let mut allocator = self.allocator.lock().unwrap();
                 let mut irq_routes: HashMap<InterruptIndex, InterruptRoute> =

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -272,7 +272,7 @@ impl InterruptManager for KvmInterruptManager {
 
         let mut irq_routes: HashMap<InterruptIndex, InterruptRoute> =
             HashMap::with_capacity(count as usize);
-        for i in base..count {
+        for i in base..base + count {
             irq_routes.insert(i, InterruptRoute::new(&mut allocator)?);
         }
 

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 //
 
+use devices::ioapic;
 use kvm_bindings::{kvm_irq_routing, kvm_irq_routing_entry, KVM_IRQ_ROUTING_MSI};
 use kvm_ioctls::VmFd;
 use std::collections::HashMap;
@@ -263,6 +264,7 @@ pub struct KvmInterruptManager {
     allocator: Arc<Mutex<SystemAllocator>>,
     vm_fd: Arc<VmFd>,
     gsi_msi_routes: Arc<Mutex<HashMap<u32, KvmRoutingEntry>>>,
+    _ioapic: Arc<Mutex<ioapic::Ioapic>>,
 }
 
 impl KvmInterruptManager {
@@ -270,11 +272,13 @@ impl KvmInterruptManager {
         allocator: Arc<Mutex<SystemAllocator>>,
         vm_fd: Arc<VmFd>,
         gsi_msi_routes: Arc<Mutex<HashMap<u32, KvmRoutingEntry>>>,
+        ioapic: Arc<Mutex<ioapic::Ioapic>>,
     ) -> Self {
         KvmInterruptManager {
             allocator,
             vm_fd,
             gsi_msi_routes,
+            _ioapic: ioapic,
         }
     }
 }


### PR DESCRIPTION
In order to follow up the pull request introducing the `InterruptManager` for PCI devices (`virtio-pci` and `vfio-pci`), this new pull request replaces the old way of dealing with legacy interrupts with the `InterruptManager` and more particularly with `InterruptSourceGroup` implementation for legacy interrupts.

Additionally, this pull request fixes and cleans up some code that can be simplified after the Interrupt Manager is being used everywhere in the codebase.