### PR TITLE
ci: Run clippy for each specific feature

### DIFF
--- a/scripts/run_cargo_tests.sh
+++ b/scripts/run_cargo_tests.sh
@@ -10,15 +10,18 @@ time rustup component add rustfmt
 time cargo install --force cargo-audit
 
 # Run cargo builds and checks
+time cargo clippy --all-targets --all-features -- -D warnings
 time cargo rustc --bin cloud-hypervisor -- -D warnings
 time cargo rustc --bin vhost_user_net -- -D warnings
 time cargo test
 time cargo audit
+time cargo clippy --all-targets --no-default-features --features "pci,acpi" -- -D warnings
 time cargo rustc --bin cloud-hypervisor --no-default-features --features "pci,acpi"  -- -D warnings
 time cargo rustc --bin vhost_user_net --no-default-features --features "pci,acpi"  -- -D warnings
-time cargo clippy --all-targets --all-features -- -D warnings
+time cargo clippy --all-targets --no-default-features --features "pci" -- -D warnings
 time cargo rustc --bin cloud-hypervisor --no-default-features --features "pci"  -- -D warnings
 time cargo rustc --bin vhost_user_net --no-default-features --features "pci"  -- -D warnings
+time cargo clippy --all-targets --no-default-features --features "mmio" -- -D warnings
 time cargo rustc --bin cloud-hypervisor --no-default-features --features "mmio"  -- -D warnings
 time cargo rustc --bin vhost_user_net --no-default-features --features "mmio"  -- -D warnings
 time sh -c 'find . \( -name "*.rs" ! -wholename "*/out/*.rs" \) | xargs rustfmt --check'

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -130,6 +130,7 @@ impl fmt::Display for VirtioDeviceType {
 const INTERRUPT_STATUS_USED_RING: u32 = 0x1;
 #[allow(dead_code)]
 const INTERRUPT_STATUS_CONFIG_CHANGED: u32 = 0x2;
+#[cfg(feature = "pci_support")]
 const VIRTIO_MSI_NO_VECTOR: u16 = 0xffff;
 
 #[derive(Debug)]

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -12,6 +12,7 @@ use crate::device_manager::DeviceManager;
 #[cfg(feature = "acpi")]
 use acpi_tables::{aml, aml::Aml, sdt::SDT};
 use arc_swap::ArcSwap;
+#[cfg(feature = "acpi")]
 use arch::layout;
 use devices::{ioapic, BusDevice};
 use kvm_bindings::CpuId;
@@ -197,6 +198,7 @@ impl CpuidPatch {
     }
 }
 
+#[cfg(feature = "acpi")]
 #[repr(packed)]
 struct LocalAPIC {
     pub r#type: u8,
@@ -747,10 +749,12 @@ impl CpuManager {
     }
 }
 
+#[cfg(feature = "acpi")]
 struct CPU {
     cpu_id: u8,
 }
 
+#[cfg(feature = "acpi")]
 const MADT_CPU_ENABLE_FLAG: usize = 0;
 
 #[cfg(feature = "acpi")]
@@ -813,6 +817,7 @@ impl Aml for CPU {
     }
 }
 
+#[cfg(feature = "acpi")]
 struct CPUNotify {
     cpu_id: u8,
 }
@@ -829,6 +834,7 @@ impl Aml for CPUNotify {
     }
 }
 
+#[cfg(feature = "acpi")]
 struct CPUMethods {
     max_vcpus: u8,
 }

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -462,6 +462,7 @@ impl MemoryManager {
     }
 }
 
+#[cfg(feature = "acpi")]
 struct MemoryNotify {
     slot_id: usize,
 }
@@ -478,6 +479,7 @@ impl Aml for MemoryNotify {
     }
 }
 
+#[cfg(feature = "acpi")]
 struct MemorySlot {
     slot_id: usize,
 }
@@ -534,6 +536,7 @@ impl Aml for MemorySlot {
     }
 }
 
+#[cfg(feature = "acpi")]
 struct MemorySlots {
     slots: usize,
 }
@@ -551,6 +554,7 @@ impl Aml for MemorySlots {
     }
 }
 
+#[cfg(feature = "acpi")]
 struct MemoryMethods {
     slots: usize,
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -695,7 +695,6 @@ mod tests {
                 assert!(state.valid_transition(VmState::Shutdown).is_ok());
                 assert!(state.valid_transition(VmState::Paused).is_err());
             }
-            _ => {}
         }
     }
 


### PR DESCRIPTION
The build is run against "--all-features", "pci,acpi", "pci" and "mmio"
separately. The clippy validation must be run against the same set of
features in order to validate the code is correct.

Because of these new checks, this commit includes multiple fixes
related to the errors generated when manually running the checks.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>