### PR TITLE
Add 'readonly' and 'direct' support for virtio-blk

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ fn create_app<'a, 'b>(
                 .long("disk")
                 .help(
                     "Disk parameters \"path=<disk_image_path>,\
-                     iommu=on|off\"",
+                     readonly=on|off,iommu=on|off\"",
                 )
                 .takes_value(true)
                 .min_values(1)
@@ -2505,6 +2505,72 @@ mod tests {
             thread::sleep(std::time::Duration::new(10, 0));
             let _ = child.kill();
             let _ = child.wait();
+            Ok(())
+        });
+    }
+
+    #[cfg_attr(not(feature = "mmio"), test)]
+    fn test_virtio_blk_readonly() {
+        test_block!(tb, "", {
+            let mut clear = ClearDiskConfig::new();
+            let guest = Guest::new(&mut clear);
+            let mut blk_file_path = dirs::home_dir().unwrap();
+            blk_file_path.push("workloads");
+            blk_file_path.push("blk.img");
+
+            let mut cloud_child = Command::new("target/release/cloud-hypervisor")
+                .args(&["--cpus", "boot=1"])
+                .args(&["--memory", "size=512M,file=/dev/shm"])
+                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&[
+                    "--disk",
+                    format!(
+                        "path={}",
+                        guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
+                    )
+                    .as_str(),
+                    format!(
+                        "path={}",
+                        guest.disk_config.disk(DiskType::CloudInit).unwrap()
+                    )
+                    .as_str(),
+                    format!("path={},readonly=on", blk_file_path.to_str().unwrap()).as_str(),
+                ])
+                .args(&["--net", guest.default_net_string().as_str()])
+                .spawn()
+                .unwrap();
+
+            thread::sleep(std::time::Duration::new(20, 0));
+
+            // Check both if /dev/vdc exists and if the block size is 16M.
+            aver_eq!(
+                tb,
+                guest
+                    .ssh_command("lsblk | grep vdc | grep -c 16M")
+                    .unwrap_or_default()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default(),
+                1
+            );
+
+            // Check both if /dev/vdc exists and if this block is RO.
+            aver_eq!(
+                tb,
+                guest
+                    .ssh_command("lsblk | grep vdc | awk '{print $5}'")
+                    .unwrap_or_default()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default(),
+                1
+            );
+
+            guest.ssh_command("sudo shutdown -h now")?;
+            thread::sleep(std::time::Duration::new(5, 0));
+            let _ = cloud_child.kill();
+            let _ = cloud_child.wait();
+
             Ok(())
         });
     }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -338,6 +338,8 @@ impl CmdlineConfig {
 pub struct DiskConfig {
     pub path: PathBuf,
     #[serde(default)]
+    pub readonly: bool,
+    #[serde(default)]
     pub iommu: bool,
 }
 
@@ -347,11 +349,14 @@ impl DiskConfig {
         let params_list: Vec<&str> = disk.split(',').collect();
 
         let mut path_str: &str = "";
+        let mut readonly_str: &str = "";
         let mut iommu_str: &str = "";
 
         for param in params_list.iter() {
             if param.starts_with("path=") {
                 path_str = &param[5..];
+            } else if param.starts_with("readonly=") {
+                readonly_str = &param[9..];
             } else if param.starts_with("iommu=") {
                 iommu_str = &param[6..];
             }
@@ -359,6 +364,7 @@ impl DiskConfig {
 
         Ok(DiskConfig {
             path: PathBuf::from(path_str),
+            readonly: parse_on_off(readonly_str)?,
             iommu: parse_on_off(iommu_str)?,
         })
     }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -340,6 +340,8 @@ pub struct DiskConfig {
     #[serde(default)]
     pub readonly: bool,
     #[serde(default)]
+    pub direct: bool,
+    #[serde(default)]
     pub iommu: bool,
 }
 
@@ -350,6 +352,7 @@ impl DiskConfig {
 
         let mut path_str: &str = "";
         let mut readonly_str: &str = "";
+        let mut direct_str: &str = "";
         let mut iommu_str: &str = "";
 
         for param in params_list.iter() {
@@ -357,6 +360,8 @@ impl DiskConfig {
                 path_str = &param[5..];
             } else if param.starts_with("readonly=") {
                 readonly_str = &param[9..];
+            } else if param.starts_with("direct=") {
+                direct_str = &param[7..];
             } else if param.starts_with("iommu=") {
                 iommu_str = &param[6..];
             }
@@ -365,6 +370,7 @@ impl DiskConfig {
         Ok(DiskConfig {
             path: PathBuf::from(path_str),
             readonly: parse_on_off(readonly_str)?,
+            direct: parse_on_off(direct_str)?,
             iommu: parse_on_off(iommu_str)?,
         })
     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -947,7 +947,7 @@ impl DeviceManager {
                 // Open block device path
                 let image: File = OpenOptions::new()
                     .read(true)
-                    .write(true)
+                    .write(!disk_cfg.readonly)
                     .open(&disk_cfg.path)
                     .map_err(DeviceManagerError::Disk)?;
 
@@ -960,7 +960,7 @@ impl DeviceManager {
                         let dev = vm_virtio::Block::new(
                             raw_img,
                             disk_cfg.path.clone(),
-                            false,
+                            disk_cfg.readonly,
                             disk_cfg.iommu,
                         )
                         .map_err(DeviceManagerError::CreateVirtioBlock)?;
@@ -979,7 +979,7 @@ impl DeviceManager {
                         let dev = vm_virtio::Block::new(
                             qcow_img,
                             disk_cfg.path.clone(),
-                            false,
+                            disk_cfg.readonly,
                             disk_cfg.iommu,
                         )
                         .map_err(DeviceManagerError::CreateVirtioBlock)?;


### PR DESCRIPTION
This patch series add 'direct' support for virtio-blk, as requested by #631, and while I was there I also added 'readonly' support, for feature parity with vhost-user-blk.