### PR TITLE
vmm: Fix LENGTH_OFFSET_HIGH of MemoryManager

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -116,7 +116,7 @@ const EJECT_FLAG: usize = 3;
 const BASE_OFFSET_LOW: u64 = 0;
 const BASE_OFFSET_HIGH: u64 = 0x4;
 const LENGTH_OFFSET_LOW: u64 = 0x8;
-const LENGTH_OFFSET_HIGH: u64 = 0xA;
+const LENGTH_OFFSET_HIGH: u64 = 0xC;
 const STATUS_OFFSET: u64 = 0x14;
 const SELECTION_OFFSET: u64 = 0;
 


### PR DESCRIPTION
There are many warnings of unexpected IO port access on boot. In my case, 

```
cloud-hypervisor: 115.750067ms: WARN:vmm/src/memory_manager.rs:152 -- Unexpected offset for accessing memory manager device: 12
```
and 
```
cloud-hypervisor: 116.776781ms: WARN:vmm/src/memory_manager.rs:152 -- Unexpected offset for accessing memory manager device: 15
```

The former is caused by a wrong offset of IO port and should be fixed by the pull request. The latter should be a conflict IO port range with a driver named telco_clock.

```
root@cloud-hypervisor ~ # cat /proc/ioports 
0000-0cf7 : PCI Bus 0000:00
  0000-001f : dma1
  0020-0021 : pic1
  0040-0043 : timer0
  0050-0053 : timer1
  0060-0060 : keyboard
  0064-0064 : keyboard
  0070-0071 : rtc_cmos
  0080-008f : dma page reg
  00a0-00a1 : pic2
  00c0-00df : dma2
  00f0-00ff : fpu
  03f8-03ff : serial
  0a08-0a0f : telco_clock
0cf8-0cff : PCI conf1
0d00-ffff : PCI Bus 0000:00
```
