### PR TITLE
vm-virtio: Change default queue size to 1024

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -736,7 +736,7 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor",
                     "--net",
-                    "mac=12:34:56:78:90:ab,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=2,queue_size=256",
+                    "mac=12:34:56:78:90:ab,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=2,queue_size=1024",
                 ],
                 r#"{
                     "net": [
@@ -753,7 +753,7 @@ mod unit_tests {
                 ],
                 r#"{
                     "net": [
-                        {"mac": "12:34:56:78:90:ab", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 2, "queue_size": 256}
+                        {"mac": "12:34:56:78:90:ab", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 2, "queue_size": 1024}
                     ]
                 }"#,
                 true,
@@ -1230,7 +1230,7 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor",
                     "--vhost-user-net",
-                    "sock=/path/to/sock,mac=12:34:56:78:90:ab,num_queues=2,queue_size=256",
+                    "sock=/path/to/sock,mac=12:34:56:78:90:ab,num_queues=2,queue_size=1024",
                 ],
                 r#"{
                     "vhost_user_net": [
@@ -1247,7 +1247,7 @@ mod unit_tests {
                 ],
                 r#"{
                     "vhost_user_net": [
-                        {"sock": "/path/to/sock", "mac": "12:34:56:78:90:ab", "num_queues": 2, "queue_size": 256}
+                        {"sock": "/path/to/sock", "mac": "12:34:56:78:90:ab", "num_queues": 2, "queue_size": 1024}
                     ]
                 }"#,
                 true,
@@ -1308,11 +1308,11 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor",
                     "--vhost-user-blk",
-                    "sock=/path/to/sock/1,num_queues=4,queue_size=1024",
+                    "sock=/path/to/sock/1,num_queues=4,queue_size=128",
                 ],
                 r#"{
                     "vhost_user_blk": [
-                        {"sock": "/path/to/sock/1", "num_queues": 4, "queue_size": 1024}
+                        {"sock": "/path/to/sock/1", "num_queues": 4, "queue_size": 128}
                     ]
                 }"#,
                 true,
@@ -1321,11 +1321,11 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor",
                     "--vhost-user-blk",
-                    "sock=/path/to/sock/1,num_queues=4,queue_size=1024,wce=true",
+                    "sock=/path/to/sock/1,num_queues=4,queue_size=128,wce=true",
                 ],
                 r#"{
                     "vhost_user_blk": [
-                        {"sock": "/path/to/sock/1", "num_queues": 4, "queue_size": 1024, "wce": true}
+                        {"sock": "/path/to/sock/1", "num_queues": 4, "queue_size": 128, "wce": true}
                     ]
                 }"#,
                 true,
@@ -1334,7 +1334,7 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor",
                     "--vhost-user-blk",
-                    "sock=/path/to/sock/1,num_queues=1,queue_size=128,wce=true",
+                    "sock=/path/to/sock/1,num_queues=1,queue_size=1024,wce=true",
                 ],
                 r#"{
                     "vhost_user_blk": [
@@ -1351,7 +1351,7 @@ mod unit_tests {
                 ],
                 r#"{
                     "vhost_user_blk": [
-                        {"sock": "/path/to/sock/1", "num_queues": 1, "queue_size": 128, "wce": true}
+                        {"sock": "/path/to/sock/1", "num_queues": 1, "queue_size": 1024, "wce": true}
                     ]
                 }"#,
                 true,

--- a/vm-virtio/src/block.rs
+++ b/vm-virtio/src/block.rs
@@ -11,7 +11,7 @@
 use super::Error as DeviceError;
 use super::{
     ActivateError, ActivateResult, DescriptorChain, DeviceEventT, Queue, VirtioDevice,
-    VirtioDeviceType, VirtioInterruptType,
+    VirtioDeviceType, VirtioInterruptType, VIRTIO_DEFAULT_QUEUE_SIZE,
 };
 use crate::VirtioInterrupt;
 use arc_swap::ArcSwap;
@@ -38,7 +38,7 @@ use vmm_sys_util::{eventfd::EventFd, seek_hole::SeekHole, write_zeroes::PunchHol
 const CONFIG_SPACE_SIZE: usize = 8;
 const SECTOR_SHIFT: u8 = 9;
 pub const SECTOR_SIZE: u64 = (0x01 as u64) << SECTOR_SHIFT;
-const QUEUE_SIZE: u16 = 256;
+const QUEUE_SIZE: u16 = VIRTIO_DEFAULT_QUEUE_SIZE;
 const NUM_QUEUES: usize = 1;
 const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE];
 

--- a/vm-virtio/src/console.rs
+++ b/vm-virtio/src/console.rs
@@ -4,7 +4,7 @@
 use super::Error as DeviceError;
 use super::{
     ActivateError, ActivateResult, DeviceEventT, Queue, VirtioDevice, VirtioDeviceType,
-    VirtioInterruptType, VIRTIO_F_IOMMU_PLATFORM, VIRTIO_F_VERSION_1,
+    VirtioInterruptType, VIRTIO_DEFAULT_QUEUE_SIZE, VIRTIO_F_IOMMU_PLATFORM, VIRTIO_F_VERSION_1,
 };
 use crate::VirtioInterrupt;
 use arc_swap::ArcSwap;
@@ -25,7 +25,7 @@ use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{ByteValued, Bytes, GuestMemoryMmap};
 use vmm_sys_util::eventfd::EventFd;
 
-const QUEUE_SIZE: u16 = 256;
+const QUEUE_SIZE: u16 = VIRTIO_DEFAULT_QUEUE_SIZE;
 const NUM_QUEUES: usize = 2;
 const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE; NUM_QUEUES];
 

--- a/vm-virtio/src/iommu.rs
+++ b/vm-virtio/src/iommu.rs
@@ -5,7 +5,7 @@
 use super::Error as DeviceError;
 use super::{
     ActivateError, ActivateResult, DescriptorChain, DeviceEventT, Queue, VirtioDevice,
-    VirtioDeviceType, VIRTIO_F_VERSION_1,
+    VirtioDeviceType, VIRTIO_DEFAULT_QUEUE_SIZE, VIRTIO_F_VERSION_1,
 };
 use crate::{DmaRemapping, VirtioInterrupt, VirtioInterruptType};
 use arc_swap::ArcSwap;
@@ -27,7 +27,7 @@ use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryError, Gues
 use vmm_sys_util::eventfd::EventFd;
 
 /// Queues sizes
-const QUEUE_SIZE: u16 = 256;
+const QUEUE_SIZE: u16 = VIRTIO_DEFAULT_QUEUE_SIZE;
 const NUM_QUEUES: usize = 2;
 const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE; NUM_QUEUES];
 

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -61,6 +61,8 @@ const VIRTIO_F_VERSION_1: u32 = 32;
 const VIRTIO_F_IOMMU_PLATFORM: u32 = 33;
 const VIRTIO_F_IN_ORDER: u32 = 35;
 
+pub const VIRTIO_DEFAULT_QUEUE_SIZE: u16 = 1024;
+
 // Types taken from linux/virtio_ids.h
 #[derive(Copy, Clone)]
 #[allow(dead_code)]

--- a/vm-virtio/src/pmem.rs
+++ b/vm-virtio/src/pmem.rs
@@ -9,7 +9,7 @@
 use super::Error as DeviceError;
 use super::{
     ActivateError, ActivateResult, DescriptorChain, DeviceEventT, Queue, VirtioDevice,
-    VirtioDeviceType, VIRTIO_F_IOMMU_PLATFORM, VIRTIO_F_VERSION_1,
+    VirtioDeviceType, VIRTIO_DEFAULT_QUEUE_SIZE, VIRTIO_F_IOMMU_PLATFORM, VIRTIO_F_VERSION_1,
 };
 use crate::{VirtioInterrupt, VirtioInterruptType};
 use arc_swap::ArcSwap;
@@ -31,7 +31,7 @@ use vm_memory::{
 };
 use vmm_sys_util::eventfd::EventFd;
 
-const QUEUE_SIZE: u16 = 256;
+const QUEUE_SIZE: u16 = VIRTIO_DEFAULT_QUEUE_SIZE;
 const NUM_QUEUES: usize = 1;
 const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE];
 

--- a/vm-virtio/src/rng.rs
+++ b/vm-virtio/src/rng.rs
@@ -5,7 +5,7 @@
 use super::Error as DeviceError;
 use super::{
     ActivateError, ActivateResult, DeviceEventT, Queue, VirtioDevice, VirtioDeviceType,
-    VIRTIO_F_IOMMU_PLATFORM, VIRTIO_F_VERSION_1,
+    VIRTIO_DEFAULT_QUEUE_SIZE, VIRTIO_F_IOMMU_PLATFORM, VIRTIO_F_VERSION_1,
 };
 use crate::{VirtioInterrupt, VirtioInterruptType};
 use arc_swap::ArcSwap;
@@ -23,7 +23,7 @@ use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{Bytes, GuestMemoryMmap};
 use vmm_sys_util::eventfd::EventFd;
 
-const QUEUE_SIZE: u16 = 256;
+const QUEUE_SIZE: u16 = VIRTIO_DEFAULT_QUEUE_SIZE;
 const NUM_QUEUES: usize = 1;
 const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE];
 

--- a/vm-virtio/src/vsock/device.rs
+++ b/vm-virtio/src/vsock/device.rs
@@ -13,7 +13,8 @@ use crate::Error as DeviceError;
 use crate::VirtioInterrupt;
 use crate::{
     ActivateError, ActivateResult, DeviceEventT, Queue, VirtioDevice, VirtioDeviceType,
-    VirtioInterruptType, VIRTIO_F_IN_ORDER, VIRTIO_F_IOMMU_PLATFORM, VIRTIO_F_VERSION_1,
+    VirtioInterruptType, VIRTIO_DEFAULT_QUEUE_SIZE, VIRTIO_F_IN_ORDER, VIRTIO_F_IOMMU_PLATFORM,
+    VIRTIO_F_VERSION_1,
 };
 /// This is the `VirtioDevice` implementation for our vsock device. It handles the virtio-level
 /// device logic: feature negociation, device configuration, and device activation.
@@ -49,7 +50,7 @@ use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::GuestMemoryMmap;
 use vmm_sys_util::eventfd::EventFd;
 
-const QUEUE_SIZE: u16 = 256;
+const QUEUE_SIZE: u16 = VIRTIO_DEFAULT_QUEUE_SIZE;
 const NUM_QUEUES: usize = 3;
 const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE; NUM_QUEUES];
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -12,14 +12,15 @@ use std::net::AddrParseError;
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::result;
+use vm_virtio::VIRTIO_DEFAULT_QUEUE_SIZE;
 
 pub const DEFAULT_VCPUS: u8 = 1;
 pub const DEFAULT_MEMORY_MB: u64 = 512;
 pub const DEFAULT_RNG_SOURCE: &str = "/dev/urandom";
 pub const DEFAULT_NUM_QUEUES_VUNET: usize = 2;
-pub const DEFAULT_QUEUE_SIZE_VUNET: u16 = 256;
+pub const DEFAULT_QUEUE_SIZE_VUNET: u16 = VIRTIO_DEFAULT_QUEUE_SIZE;
 pub const DEFAULT_NUM_QUEUES_VUBLK: usize = 1;
-pub const DEFAULT_QUEUE_SIZE_VUBLK: u16 = 128;
+pub const DEFAULT_QUEUE_SIZE_VUBLK: u16 = VIRTIO_DEFAULT_QUEUE_SIZE;
 
 /// Errors associated with VM configuration parameters.
 #[derive(Debug)]


### PR DESCRIPTION
We observed in many places and through many tests that increasing the
queue size to 1024 as the default had a good impact on performances.

What happens is that by having deeper virtio rings, when the host is
notified about a queue, it will go through more descriptors in one run.
By being interrupted a single time, the virtio backend can now process
up to 1024 buffers, which increases the throughput.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>