### PR TITLE
ioapic: Rely on the InterruptManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,6 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "qcow 0.1.0",
  "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "ssh2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1041,7 +1040,7 @@ dependencies = [
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
- "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1069,7 +1068,7 @@ dependencies = [
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
- "vmm-sys-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,8 +226,6 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -7,8 +7,6 @@ authors = ["The Chromium OS Authors"]
 bitflags = ">=1.2.1"
 byteorder = "1.3.2"
 epoll = ">=4.0.1"
-kvm-bindings = "0.2.0"
-kvm-ioctls = "0.4.0"
 libc = "0.2.60"
 log = "0.4.8"
 vm-device = { path = "../vm-device" }

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -10,8 +10,6 @@
 extern crate bitflags;
 extern crate byteorder;
 extern crate epoll;
-extern crate kvm_bindings;
-extern crate kvm_ioctls;
 extern crate libc;
 #[macro_use]
 extern crate log;

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -451,8 +451,7 @@ impl DeviceManager {
                 None,
             ));
 
-        let ioapic =
-            DeviceManager::add_ioapic(vm_info, &address_manager, ioapic_interrupt_manager)?;
+        let ioapic = DeviceManager::add_ioapic(&address_manager, ioapic_interrupt_manager)?;
 
         // Creation of the global interrupt manager, which can take a hold onto
         // the brand new Ioapic.
@@ -698,13 +697,12 @@ impl DeviceManager {
     }
 
     fn add_ioapic(
-        vm_info: &VmInfo,
         address_manager: &Arc<AddressManager>,
         interrupt_manager: Arc<dyn InterruptManager>,
     ) -> DeviceManagerResult<Arc<Mutex<ioapic::Ioapic>>> {
         // Create IOAPIC
         let ioapic = Arc::new(Mutex::new(
-            ioapic::Ioapic::new(vm_info.vm_fd.clone(), APIC_START, interrupt_manager)
+            ioapic::Ioapic::new(APIC_START, interrupt_manager)
                 .map_err(DeviceManagerError::CreateIoapic)?,
         ));
 


### PR DESCRIPTION
Through this PR, the IOAPIC and the `devices` crate are freed from `kvm_ioctls` and `kvm_bindings` dependencies.
By relying on the `InterruptManager`, the IOAPIC does not need to know about the type of hypervisor, and how the update and delivery of an interrupt should be managed.
This simplifies the IOAPIC code and the chain of dependencies.