### PR TITLE
vfio: Fix 64bits BAR size reading

### DIFF
--- a/vfio/src/vfio_pci.rs
+++ b/vfio/src/vfio_pci.rs
@@ -714,7 +714,7 @@ impl PciDevice for VfioPciDevice {
                     let msb_bar_offset: u32 = PCI_CONFIG_BAR_OFFSET + (bar_id + 1) * 4;
 
                     self.vfio_pci_configuration
-                        .write_config_dword(msb_bar_offset, msb_size);
+                        .write_config_dword(msb_size, msb_bar_offset);
 
                     msb_size = self
                         .vfio_pci_configuration


### PR DESCRIPTION
The way to get the BAR size is by writing all 1's to the BAR register in
the PCI config space. The mechanism was in place but the parameters were
swapped. The data buffer was provided with the actual offset, while the
offset was provided with the actual all 1's dword. We were effectively
trying to write the real offset at the offset 0xffffffff, which was
failing and resulting in the size being wrong.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>