### PR TITLE
ci: Make the integration tests fail if images are not valid

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -66,6 +66,13 @@ if [ ! -f "$EOAN_OS_RAW_IMAGE" ]; then
     popd
 fi
 
+pushd $WORKLOADS_DIR
+curl --silent "https://cloudhypervisorstorage.blob.core.windows.net/images/sha1sums" | sha1sum --check
+if [ $? -ne 0 ]; then
+    echo "sha1sum validation of images failed, remove invalid images to fix the issue."
+    exit 1
+fi
+popd
 
 # Build custom kernel based on virtio-pmem and virtio-fs upstream patches
 VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"


### PR DESCRIPTION
When the CI runs in a brand new VM, there's no problem with the validity
of the images as they just got downloaded from the Azure bucket.

In case of a user who runs the CI locally, while doing some debug, he
might provision the images with cloudinit at some point, and later try
to run the CI based on these same images. What happens is that the CI
might randomly fail because the provisioning will not happen again as
it already happened.

This patch ensures the CI to fail early and show an error message to
notify the user about the validity of the images, based on their
sha1sum.

Fixes #112

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>