### PR TITLE
Allow "--net" to be used for controlling vhost-user-net

### DIFF
--- a/docs/device_model.md
+++ b/docs/device_model.md
@@ -188,8 +188,8 @@ processes, we added support for [vhost-user-net](https://access.redhat.com/solut
 backends. This enables `cloud-hypervisor` users to plug a `vhost-user` based
 networking device (e.g. DPDK) into the VMM as their virtio network backend.
 
-This device is always built-in, and it is enabled based on the presence of the
-flag `--vhost-user-net`.
+This device is always built-in, and it is enabled when `vhost_user=true` and
+`socket` are provided to the `--net` parameter.
 
 ## VFIO
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,8 @@ fn create_app<'a, 'b>(
                     "Network parameters \"tap=<if_name>,\
                      ip=<ip_addr>,mask=<net_mask>,mac=<mac_addr>,\
                      iommu=on|off,num_queues=<number_of_queues>,\
-                     queue_size=<size_of_each_queue>\"",
+                     queue_size=<size_of_each_queue>,\
+                     vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>\"",
                 )
                 .takes_value(true)
                 .min_values(1)

--- a/src/main.rs
+++ b/src/main.rs
@@ -839,6 +839,15 @@ mod unit_tests {
                 }"#,
                 true,
             ),
+            (
+                vec!["cloud-hypervisor", "--net", "mac=12:34:56:78:90:ab,vhost_user=true,socket=/tmp/socket"],
+                r#"{
+                    "net": [
+                        {"mac": "12:34:56:78:90:ab", "vhost_user": true, "vhost_socket": "/tmp/socket"}
+                    ]
+                }"#,
+                true,
+            ),
         ]
         .iter()
         .for_each(|(cli, openapi, equal)| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2671,9 +2671,9 @@ mod tests {
                     .as_str(),
                 ])
                 .args(&[
-                    "--vhost-user-net",
+                    "--net",
                     format!(
-                        "mac={},sock=/tmp/vunet.sock,num_queues=4,queue_size=1024",
+                        "vhost_user=true,mac={},socket=/tmp/vunet.sock,num_queues=4,queue_size=1024",
                         guest.network.guest_mac
                     )
                     .as_str(),

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -307,6 +307,11 @@ components:
         queue_size:
           type: integer
           default: 256
+        vhost_user:
+          type: boolean
+          default: false
+        vhost_socket:
+          type: string
 
     RngConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -899,6 +899,7 @@ fn default_vunetconfig_mac() -> MacAddr {
 
 impl VhostUserNetConfig {
     pub fn parse(vhost_user_net: &str) -> Result<Self> {
+        error!("Using deprecated --vhost-user-net syntax. Use --net with vhost_user=true,socket=<socket path>");
         // Split the parameters based on the comma delimiter
         let params_list: Vec<&str> = vhost_user_net.split(',').collect();
 


### PR DESCRIPTION
Deprecate the "--vhost-user-net" command by providing the necessary parameters to "--net"

See #630 for context.