### PR TITLE
vm-virtio macro simplifications

### DIFF
--- a/vm-virtio/src/block.rs
+++ b/vm-virtio/src/block.rs
@@ -1011,9 +1011,6 @@ impl<T: 'static + DiskFile + Send> VirtioDevice for Block<T> {
     }
 }
 
-impl<T: 'static + DiskFile + Send> Pausable for Block<T> {
-    virtio_pausable_inner!();
-}
-
+virtio_pausable!(Block, T: 'static + DiskFile + Send);
 impl<T: 'static + DiskFile + Send> Snapshotable for Block<T> {}
 impl<T: 'static + DiskFile + Send> Migratable for Block<T> {}

--- a/vm-virtio/src/block.rs
+++ b/vm-virtio/src/block.rs
@@ -775,7 +775,7 @@ pub struct Block<T: DiskFile> {
     config_space: Vec<u8>,
     queue_evt: Option<EventFd>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_thread: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
     pause_evt: Option<EventFd>,
     paused: Arc<AtomicBool>,
 }
@@ -831,7 +831,7 @@ impl<T: DiskFile> Block<T> {
             config_space: build_config_space(disk_size),
             queue_evt: None,
             interrupt_cb: None,
-            epoll_thread: None,
+            epoll_threads: None,
             pause_evt: None,
             paused: Arc::new(AtomicBool::new(false)),
         })
@@ -985,7 +985,7 @@ impl<T: 'static + DiskFile + Send> VirtioDevice for Block<T> {
                     ActivateError::BadActivate
                 })?;
 
-            self.epoll_thread = Some(epoll_threads);
+            self.epoll_threads = Some(epoll_threads);
 
             return Ok(());
         }

--- a/vm-virtio/src/console.rs
+++ b/vm-virtio/src/console.rs
@@ -351,7 +351,7 @@ pub struct Console {
     out: Arc<Mutex<Box<dyn io::Write + Send + Sync + 'static>>>,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_thread: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
     paused: Arc<AtomicBool>,
 }
 
@@ -391,7 +391,7 @@ impl Console {
                 out: Arc::new(Mutex::new(out)),
                 queue_evts: None,
                 interrupt_cb: None,
-                epoll_thread: None,
+                epoll_threads: None,
                 paused: Arc::new(AtomicBool::new(false)),
             },
             console_input,
@@ -554,7 +554,7 @@ impl VirtioDevice for Console {
                 ActivateError::BadActivate
             })?;
 
-        self.epoll_thread = Some(epoll_threads);
+        self.epoll_threads = Some(epoll_threads);
 
         Ok(())
     }

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -136,9 +136,9 @@ macro_rules! virtio_pausable_inner {
                 VirtioDeviceType::from(self.device_type())
             );
             self.paused.store(false, Ordering::SeqCst);
-            if let Some(epoll_thread) = &self.epoll_thread {
-                for i in 0..epoll_thread.len() {
-                    epoll_thread[i].thread().unpark();
+            if let Some(epoll_threads) = &self.epoll_threads {
+                for i in 0..epoll_threads.len() {
+                    epoll_threads[i].thread().unpark();
                 }
             }
 
@@ -168,9 +168,9 @@ macro_rules! virtio_pausable_inner {
             );
             self.paused.store(false, Ordering::SeqCst);
 
-            if let Some(epoll_thread) = &self.epoll_thread {
-                for i in 0..epoll_thread.len() {
-                    epoll_thread[i].thread().unpark();
+            if let Some(epoll_threads) = &self.epoll_threads {
+                for i in 0..epoll_threads.len() {
+                    epoll_threads[i].thread().unpark();
                 }
             }
 

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -203,8 +203,11 @@ macro_rules! virtio_pausable {
             }
         }
     };
+}
 
-    ($type:ident, $ctrl_q:expr) => {
+#[macro_export]
+macro_rules! virtio_ctrl_q_pausable {
+    ($type:ident) => {
         virtio_pausable_trait!($type);
 
         impl Pausable for $type {

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -204,7 +204,7 @@ macro_rules! virtio_pausable {
         }
     };
 
-    ($type:ident, $ctrl_q:expr, $mq: expr) => {
+    ($type:ident, $ctrl_q:expr) => {
         virtio_pausable_trait!($type);
 
         impl Pausable for $type {

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -137,7 +137,9 @@ macro_rules! virtio_pausable_inner {
             );
             self.paused.store(false, Ordering::SeqCst);
             if let Some(epoll_thread) = &self.epoll_thread {
-                epoll_thread.thread().unpark();
+                for i in 0..epoll_thread.len() {
+                    epoll_thread[i].thread().unpark();
+                }
             }
 
             Ok(())

--- a/vm-virtio/src/iommu.rs
+++ b/vm-virtio/src/iommu.rs
@@ -765,7 +765,7 @@ pub struct Iommu {
     ext_mapping: BTreeMap<u32, Arc<dyn ExternalDmaMapping>>,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_thread: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
     paused: Arc<AtomicBool>,
 }
 
@@ -795,7 +795,7 @@ impl Iommu {
                 ext_mapping: BTreeMap::new(),
                 queue_evts: None,
                 interrupt_cb: None,
-                epoll_thread: None,
+                epoll_threads: None,
                 paused: Arc::new(AtomicBool::new(false)),
             },
             mapping,
@@ -948,7 +948,7 @@ impl VirtioDevice for Iommu {
                 ActivateError::BadActivate
             })?;
 
-        self.epoll_thread = Some(epoll_threads);
+        self.epoll_threads = Some(epoll_threads);
 
         Ok(())
     }

--- a/vm-virtio/src/iommu.rs
+++ b/vm-virtio/src/iommu.rs
@@ -765,7 +765,7 @@ pub struct Iommu {
     ext_mapping: BTreeMap<u32, Arc<dyn ExternalDmaMapping>>,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_thread: Option<thread::JoinHandle<result::Result<(), DeviceError>>>,
+    epoll_thread: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
     paused: Arc<AtomicBool>,
 }
 
@@ -938,14 +938,17 @@ impl VirtioDevice for Iommu {
         };
 
         let paused = self.paused.clone();
+        let mut epoll_threads = Vec::new();
         thread::Builder::new()
             .name("virtio_iommu".to_string())
             .spawn(move || handler.run(paused))
-            .map(|thread| self.epoll_thread = Some(thread))
+            .map(|thread| epoll_threads.push(thread))
             .map_err(|e| {
                 error!("failed to clone the virtio-iommu epoll thread: {}", e);
                 ActivateError::BadActivate
             })?;
+
+        self.epoll_thread = Some(epoll_threads);
 
         Ok(())
     }

--- a/vm-virtio/src/net.rs
+++ b/vm-virtio/src/net.rs
@@ -583,6 +583,6 @@ impl VirtioDevice for Net {
     }
 }
 
-virtio_pausable!(Net, true);
+virtio_ctrl_q_pausable!(Net);
 impl Snapshotable for Net {}
 impl Migratable for Net {}

--- a/vm-virtio/src/net.rs
+++ b/vm-virtio/src/net.rs
@@ -583,6 +583,6 @@ impl VirtioDevice for Net {
     }
 }
 
-virtio_pausable!(Net, true, true);
+virtio_pausable!(Net, true);
 impl Snapshotable for Net {}
 impl Migratable for Net {}

--- a/vm-virtio/src/pmem.rs
+++ b/vm-virtio/src/pmem.rs
@@ -318,7 +318,7 @@ pub struct Pmem {
     config: VirtioPmemConfig,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_thread: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
     paused: Arc<AtomicBool>,
 }
 
@@ -344,7 +344,7 @@ impl Pmem {
             config,
             queue_evts: None,
             interrupt_cb: None,
-            epoll_thread: None,
+            epoll_threads: None,
             paused: Arc::new(AtomicBool::new(false)),
         })
     }
@@ -494,7 +494,7 @@ impl VirtioDevice for Pmem {
                     ActivateError::BadActivate
                 })?;
 
-            self.epoll_thread = Some(epoll_threads);
+            self.epoll_threads = Some(epoll_threads);
 
             return Ok(());
         }

--- a/vm-virtio/src/rng.rs
+++ b/vm-virtio/src/rng.rs
@@ -184,7 +184,7 @@ pub struct Rng {
     acked_features: u64,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_thread: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
     paused: Arc<AtomicBool>,
 }
 
@@ -206,7 +206,7 @@ impl Rng {
             acked_features: 0u64,
             queue_evts: None,
             interrupt_cb: None,
-            epoll_thread: None,
+            epoll_threads: None,
             paused: Arc::new(AtomicBool::new(false)),
         })
     }
@@ -345,7 +345,7 @@ impl VirtioDevice for Rng {
                     ActivateError::BadActivate
                 })?;
 
-            self.epoll_thread = Some(epoll_threads);
+            self.epoll_threads = Some(epoll_threads);
 
             return Ok(());
         }

--- a/vm-virtio/src/vhost_user/blk.rs
+++ b/vm-virtio/src/vhost_user/blk.rs
@@ -47,7 +47,7 @@ pub struct Blk {
     queue_sizes: Vec<u16>,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_thread: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
     paused: Arc<AtomicBool>,
 }
 
@@ -130,7 +130,7 @@ impl Blk {
             queue_sizes: vec![vu_cfg.queue_size; vu_cfg.num_queues],
             queue_evts: None,
             interrupt_cb: None,
-            epoll_thread: None,
+            epoll_threads: None,
             paused: Arc::new(AtomicBool::new(false)),
         })
     }
@@ -284,7 +284,7 @@ impl VirtioDevice for Blk {
                 ActivateError::BadActivate
             })?;
 
-        self.epoll_thread = Some(epoll_threads);
+        self.epoll_threads = Some(epoll_threads);
 
         Ok(())
     }

--- a/vm-virtio/src/vhost_user/fs.rs
+++ b/vm-virtio/src/vhost_user/fs.rs
@@ -162,7 +162,7 @@ pub struct Fs {
     slave_req_support: bool,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_thread: Option<thread::JoinHandle<result::Result<(), DeviceError>>>,
+    epoll_thread: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
     paused: Arc<AtomicBool>,
 }
 
@@ -420,14 +420,17 @@ impl VirtioDevice for Fs {
         });
 
         let paused = self.paused.clone();
+        let mut epoll_threads = Vec::new();
         thread::Builder::new()
             .name("virtio_fs".to_string())
             .spawn(move || handler.run(paused))
-            .map(|thread| self.epoll_thread = Some(thread))
+            .map(|thread| epoll_threads.push(thread))
             .map_err(|e| {
                 error!("failed to clone queue EventFd: {}", e);
                 ActivateError::BadActivate
             })?;
+
+        self.epoll_thread = Some(epoll_threads);
 
         Ok(())
     }

--- a/vm-virtio/src/vhost_user/fs.rs
+++ b/vm-virtio/src/vhost_user/fs.rs
@@ -162,7 +162,7 @@ pub struct Fs {
     slave_req_support: bool,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_thread: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
     paused: Arc<AtomicBool>,
 }
 
@@ -248,7 +248,7 @@ impl Fs {
             slave_req_support,
             queue_evts: None,
             interrupt_cb: None,
-            epoll_thread: None,
+            epoll_threads: None,
             paused: Arc::new(AtomicBool::new(false)),
         })
     }
@@ -430,7 +430,7 @@ impl VirtioDevice for Fs {
                 ActivateError::BadActivate
             })?;
 
-        self.epoll_thread = Some(epoll_threads);
+        self.epoll_threads = Some(epoll_threads);
 
         Ok(())
     }

--- a/vm-virtio/src/vhost_user/net.rs
+++ b/vm-virtio/src/vhost_user/net.rs
@@ -361,6 +361,6 @@ impl VirtioDevice for Net {
     }
 }
 
-virtio_pausable!(Net, true, true);
+virtio_pausable!(Net, true);
 impl Snapshotable for Net {}
 impl Migratable for Net {}

--- a/vm-virtio/src/vhost_user/net.rs
+++ b/vm-virtio/src/vhost_user/net.rs
@@ -361,6 +361,6 @@ impl VirtioDevice for Net {
     }
 }
 
-virtio_pausable!(Net, true);
+virtio_ctrl_q_pausable!(Net);
 impl Snapshotable for Net {}
 impl Migratable for Net {}

--- a/vm-virtio/src/vsock/device.rs
+++ b/vm-virtio/src/vsock/device.rs
@@ -383,7 +383,7 @@ pub struct Vsock<B: VsockBackend> {
     acked_features: u64,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_thread: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
     paused: Arc<AtomicBool>,
 }
 
@@ -409,7 +409,7 @@ where
             acked_features: 0u64,
             queue_evts: None,
             interrupt_cb: None,
-            epoll_thread: None,
+            epoll_threads: None,
             paused: Arc::new(AtomicBool::new(false)),
         })
     }
@@ -564,7 +564,7 @@ where
                 ActivateError::BadActivate
             })?;
 
-        self.epoll_thread = Some(epoll_threads);
+        self.epoll_threads = Some(epoll_threads);
 
         Ok(())
     }

--- a/vm-virtio/src/vsock/device.rs
+++ b/vm-virtio/src/vsock/device.rs
@@ -588,12 +588,7 @@ where
     }
 }
 
-impl<B> Pausable for Vsock<B>
-where
-    B: VsockBackend + Sync + 'static,
-{
-    virtio_pausable_inner!();
-}
+virtio_pausable!(Vsock, T: 'static + VsockBackend + Sync);
 
 impl<B> Snapshotable for Vsock<B> where B: VsockBackend + Sync + 'static {}
 impl<B> Migratable for Vsock<B> where B: VsockBackend + Sync + 'static {}


### PR DESCRIPTION
In order to simplify and avoid duplication with the virtio Pausable macros, we need to extend all virtio potentially support multi threading.
Then we can add a hidden abstraction layer and factorize all common Pausable virtio code through the macros.