### PR TITLE
Allow "--disk" to be used for controlling vhost-user-block

### DIFF
--- a/docs/device_model.md
+++ b/docs/device_model.md
@@ -166,8 +166,8 @@ processes, we added support for vhost-user-blk backends. This enables
 `cloud-hypervisor` users to plug a `vhost-user` based block device (e.g. SPDK)
 into the VMM as their virtio block backend.
 
-This device is always built-in, and it is enabled based on the presence of the
-flag `--vhost-user-blk`.
+This device is always built-in, and it is enabled when `vhost_user=true` and
+`socket` are provided to the `--disk` parameter.
 
 ### vhost-user-fs
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2771,16 +2771,13 @@ mod tests {
                         guest.disk_config.disk(DiskType::CloudInit).unwrap()
                     )
                     .as_str(),
-                ])
-                .args(&["--net", guest.default_net_string().as_str()])
-                .args(&[
-                    "--vhost-user-blk",
                     format!(
-                        "sock={},num_queues=1,queue_size=128,wce=true",
+                        "vhost_user=true,socket={},num_queues=1,queue_size=128,wce=true",
                         vubd_socket_path
                     )
                     .as_str(),
                 ])
+                .args(&["--net", guest.default_net_string().as_str()])
                 .spawn()
                 .unwrap();
 
@@ -2855,16 +2852,13 @@ mod tests {
                         guest.disk_config.disk(DiskType::CloudInit).unwrap()
                     )
                     .as_str(),
-                ])
-                .args(&["--net", guest.default_net_string().as_str()])
-                .args(&[
-                    "--vhost-user-blk",
                     format!(
-                        "sock={},num_queues=1,queue_size=128,wce=true",
+                        "vhost_user=true,socket={},num_queues=1,queue_size=128,wce=true",
                         vubd_socket_path
                     )
                     .as_str(),
                 ])
+                .args(&["--net", guest.default_net_string().as_str()])
                 .spawn()
                 .unwrap();
 
@@ -2932,16 +2926,13 @@ mod tests {
                         guest.disk_config.disk(DiskType::CloudInit).unwrap()
                     )
                     .as_str(),
-                ])
-                .args(&["--net", guest.default_net_string().as_str()])
-                .args(&[
-                    "--vhost-user-blk",
                     format!(
-                        "sock={},num_queues=1,queue_size=128,wce=true",
+                        "vhost_user=true,socket={},num_queues=1,queue_size=128,wce=true",
                         vubd_socket_path
                     )
                     .as_str(),
                 ])
+                .args(&["--net", guest.default_net_string().as_str()])
                 .spawn()
                 .unwrap();
 
@@ -3000,16 +2991,13 @@ mod tests {
                         guest.disk_config.disk(DiskType::CloudInit).unwrap()
                     )
                     .as_str(),
-                ])
-                .args(&["--net", guest.default_net_string().as_str()])
-                .args(&[
-                    "--vhost-user-blk",
                     format!(
-                        "sock={},num_queues=1,queue_size=128,wce=true",
+                        "vhost_user=true,socket={},num_queues=1,queue_size=128,wce=true",
                         vubd_socket_path
                     )
                     .as_str(),
                 ])
+                .args(&["--net", guest.default_net_string().as_str()])
                 .spawn()
                 .unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -681,6 +681,36 @@ mod unit_tests {
                 }"#,
                 false,
             ),
+            (
+                vec![
+                    "cloud-hypervisor",
+                    "--disk",
+                    "path=/path/to/disk/1,vhost_user=true,socket=/tmp/socket1",
+                    "path=/path/to/disk/2",
+                ],
+                r#"{
+                    "disks": [
+                        {"path": "/path/to/disk/1", "vhost_user":true, "vhost_socket":"/tmp/socket1"},
+                        {"path": "/path/to/disk/2"}
+                    ]
+                }"#,
+                true,
+            ),
+            (
+                vec![
+                    "cloud-hypervisor",
+                    "--disk",
+                    "path=/path/to/disk/1,vhost_user=true,socket=/tmp/socket1,wce=true",
+                    "path=/path/to/disk/2",
+                ],
+                r#"{
+                    "disks": [
+                        {"path": "/path/to/disk/1", "vhost_user":true, "vhost_socket":"/tmp/socket1", "wce":true},
+                        {"path": "/path/to/disk/2"}
+                    ]
+                }"#,
+                true,
+            ),
         ]
         .iter()
         .for_each(|(cli, openapi, equal)| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,9 @@ fn create_app<'a, 'b>(
                     "Disk parameters \"path=<disk_image_path>,\
                      readonly=on|off,iommu=on|off,\
                      num_queues=<number_of_queues>,\
-                     queue_size=<size_of_each_queue>\"",
+                     queue_size=<size_of_each_queue>,
+                     vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>,
+                     wce=<true|false, default true>\"",
                 )
                 .takes_value(true)
                 .min_values(1)

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1061,6 +1061,7 @@ fn default_vublkconfig_wce() -> bool {
 
 impl VhostUserBlkConfig {
     pub fn parse(vhost_user_blk: &str) -> Result<Self> {
+        error!("Using deprecated --vhost-user-blk syntax. Use --disk with vhost_user=true,socket=<socket path>");
         // Split the parameters based on the comma delimiter
         let params_list: Vec<&str> = vhost_user_blk.split(',').collect();
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -441,6 +441,9 @@ impl DiskConfig {
             vhost_socket = Some(vhost_socket_str.to_owned());
         }
         if !wce_str.is_empty() {
+            if !vhost_user {
+                warn!("wce parameter currently only has effect when used vhost_user=true");
+            }
             wce = wce_str.parse().map_err(Error::ParseDiskWceParam)?;
         }
 


### PR DESCRIPTION
Deprecate the "--vhost-user-blk" command by providing the necessary parameters to "--disk"

See #630 for context.