### PR TITLE
Implement VIRTIO_PCI_CAP_PCI_CFG

### DIFF
--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -67,7 +67,7 @@ impl PciDevice for PciRoot {
         self.config.write_config_register(reg_idx, offset, data);
     }
 
-    fn read_config_register(&self, reg_idx: usize) -> u32 {
+    fn read_config_register(&mut self, reg_idx: usize) -> u32 {
         self.config.read_reg(reg_idx)
     }
 

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -61,7 +61,7 @@ pub trait PciDevice: BusDevice {
     fn write_config_register(&mut self, reg_idx: usize, offset: u64, data: &[u8]);
     /// Gets a register from the configuration space.
     /// * `reg_idx` - The index of the config register to read.
-    fn read_config_register(&self, reg_idx: usize) -> u32;
+    fn read_config_register(&mut self, reg_idx: usize) -> u32;
     /// Detects if a BAR is being reprogrammed.
     fn detect_bar_reprogramming(
         &mut self,

--- a/vfio/src/vfio_pci.rs
+++ b/vfio/src/vfio_pci.rs
@@ -852,7 +852,7 @@ impl PciDevice for VfioPciDevice {
             .region_write(VFIO_PCI_CONFIG_REGION_INDEX, data, reg + offset);
     }
 
-    fn read_config_register(&self, reg_idx: usize) -> u32 {
+    fn read_config_register(&mut self, reg_idx: usize) -> u32 {
         // When reading the BARs, we trap it and return what comes
         // from our local configuration space. We want the guest to
         // use that and not the VFIO device BARs as it does not map

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -556,7 +556,7 @@ impl PciDevice for VirtioPciDevice {
             .write_config_register(reg_idx, offset, data);
     }
 
-    fn read_config_register(&self, reg_idx: usize) -> u32 {
+    fn read_config_register(&mut self, reg_idx: usize) -> u32 {
         self.configuration.read_reg(reg_idx)
     }
 


### PR DESCRIPTION
The virtio capability VIRTIO_PCI_CAP_PCI_CFG is exposed through the device's PCI config space the same way other virtio-pci capabilities are exposed.

The main and important difference is that this specific capability is designed as a way for the guest to access virtio capabilities without mapping the PCI BAR. This is very rarely used, but it can be useful when it is too early for the guest to be able to map the BARs.

One thing to note, this special feature MUST be implemented, based on the virtio specification.