### PR TITLE
scripts: Add container based development script

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,34 @@ $ popd
 
 This will build a `cloud-hypervisor` binary under `$CLOUDH/cloud-hypervisor/target/release/cloud-hypervisor`.
 
+### Containerized builds and tests
+
+If you want to build and test Cloud Hypervisor without having to install all the
+required dependencies (The rust toolchain, cargo tools, etc), you can also use
+Cloud Hypervisor's development script: `dev_cli.sh`. Please note that upon its
+first invocation, this script will pull a fairly large container image.
+
+For example, to build the Cloud Hypervisor release binary:
+
+```shell
+$ pushd $CLOUDH
+$ cd cloud-hypervisor
+$ ./scripts/dev_cli.sh build --release
+```
+
+With `dev_cli.sh`, one can also run the Cloud Hypervisor CI locally. This can be
+very convenient for debugging CI errors without having to fully rely on the
+Cloud Hypervisor CI infrastructure.
+
+For example, to run the Cloud Hypervisor unit tests:
+
+```shell
+$ ./scripts/dev_cli.sh tests --release
+```
+
+Run the `./scripts/dev_cli.sh --help` command to view all the supported
+development script commands and their related options.
+
 ## Run
 
 You can run a guest VM by either using an existing cloud image or booting into your own kernel and disk image.

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:18.04 as dev
+
+ARG RUST_TOOLCHAIN="1.40.0"
+ARG CLH_SRC_DIR="/cloud-hypervisor"
+ARG CLH_BUILD_DIR="$CLH_SRC_DIR/build"
+ARG CARGO_REGISTRY_DIR="$CLH_BUILD_DIR/cargo_registry"
+ARG CARGO_GIT_REGISTRY_DIR="$CLH_BUILD_DIR/cargo_git_registry"
+
+ENV CARGO_HOME=/usr/local/rust
+ENV RUSTUP_HOME=$CARGO_HOME
+ENV PATH="$PATH:$CARGO_HOME/bin"
+
+# Install all CI dependencies
+RUN apt-get update
+RUN apt-get -yq upgrade
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+	build-essential \
+	bc \
+	docker.io \
+	curl \
+	wget \
+	sudo \
+	mtools \
+	libssl-dev \
+	pkg-config \
+	flex \
+	bison \
+	libelf-dev \
+	qemu-utils \
+	qemu-system \
+	libglib2.0-dev \
+	libpixman-1-dev \
+	libseccomp-dev \
+	libcap-ng-dev \
+	socat \
+	dosfstools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the rust toolchain
+RUN nohup curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN" \
+    && rustup component add rustfmt \
+    && rustup component add clippy \
+    && cargo install cargo-audit \
+    && rm -rf "$CARGO_HOME/registry" \
+    && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \
+    && rm -rf "$CARGO_HOME/git" \
+    && ln -s "$CARGO_GIT_REGISTRY_DIR" "$CARGO_HOME/git"
+
+# Set the rust environment
+RUN echo 'source $CARGO_HOME/env' >> $HOME/.bashrc \
+    && mkdir $HOME/.cargo \
+    && ln -s $CARGO_HOME/env $HOME/.cargo/env

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -1,0 +1,296 @@
+#!/bin/bash
+
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright © 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CLI_NAME="Cloud Hypervisor"
+
+CTR_IMAGE_TAG="cloudhypervisor/dev"
+CTR_IMAGE_VERSION="v1"
+CTR_IMAGE="${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}"
+
+DOCKER_RUNTIME="docker"
+
+# Host paths
+CLH_SCRIPTS_DIR=$(cd "$(dirname "$0")" && pwd)
+CLH_ROOT_DIR=$(cd "${CLH_SCRIPTS_DIR}/.." && pwd)
+CLH_BUILD_DIR="${CLH_ROOT_DIR}/build"
+CLH_CARGO_TARGET="${CLH_BUILD_DIR}/cargo_target"
+CLH_DOCKERFILE="${CLH_SCRIPTS_DIR}/../resources/Dockerfile"
+CLH_CTR_BUILD_DIR="/tmp/cloud-hypervisor/ctr-build"
+CLH_INTEGRATION_WORKLOADS="${HOME}/workloads"
+
+# Container paths
+CTR_CLH_ROOT_DIR="/cloud-hypervisor"
+CTR_CLH_CARGO_TARGET="${CTR_CLH_ROOT_DIR}/build/cargo_target"
+CTR_CLH_INTEGRATION_WORKLOADS="/root/workloads"
+
+# Cargo paths
+# Full path to the cargo registry dir on the host. This appears on the host
+# because we want to persist the cargo registry across container invocations.
+# Otherwise, any rust crates from crates.io would be downloaded again each time
+# we build or test.
+CARGO_REGISTRY_DIR="${CLH_BUILD_DIR}/cargo_registry"
+
+# Full path to the cargo git registry on the host. This serves the same purpose
+# as CARGO_REGISTRY_DIR, for crates downloaded from GitHub repos instead of
+# crates.io.
+CARGO_GIT_REGISTRY_DIR="${CLH_BUILD_DIR}/cargo_git_registry"
+
+# Full path to the cargo target dir on the host.
+CARGO_TARGET_DIR="${CLH_BUILD_DIR}/cargo_target"
+
+# Send a decorated message to stdout, followed by a new line
+#
+say() {
+    [ -t 1 ] && [ -n "$TERM" ] \
+        && echo "$(tput setaf 2)[$CLI_NAME]$(tput sgr0) $*" \
+        || echo "[$CLI_NAME] $*"
+}
+
+# Send a decorated message to stdout, without a trailing new line
+#
+say_noln() {
+    [ -t 1 ] && [ -n "$TERM" ] \
+        && echo -n "$(tput setaf 2)[$CLI_NAME]$(tput sgr0) $*" \
+        || echo "[$CLI_NAME] $*"
+}
+
+# Send a text message to stderr
+#
+say_err() {
+    [ -t 2 ] && [ -n "$TERM" ] \
+        && echo "$(tput setaf 1)[$CLI_NAME] $*$(tput sgr0)" 1>&2 \
+        || echo "[$CLI_NAME] $*" 1>&2
+}
+
+# Send a warning-highlighted text to stdout
+say_warn() {
+    [ -t 1 ] && [ -n "$TERM" ] \
+        && echo "$(tput setaf 3)[$CLI_NAME] $*$(tput sgr0)" \
+        || echo "[$CLI_NAME] $*"
+}
+
+# Exit with an error message and (optional) code
+# Usage: die [-c <error code>] <error message>
+#
+die() {
+    code=1
+    [[ "$1" = "-c" ]] && {
+        code="$2"
+        shift 2
+    }
+    say_err "$@"
+    exit $code
+}
+
+# Exit with an error message if the last exit code is not 0
+#
+ok_or_die() {
+    code=$?
+    [[ $code -eq 0 ]] || die -c $code "$@"
+}
+
+# Make sure the build/ dirs are available. Exit if we can't create them.
+# Upon returning from this call, the caller can be certain the build/ dirs exist.
+#
+ensure_build_dir() {
+    for dir in "$CLH_BUILD_DIR" \
+		   "$CLH_INTEGRATION_WORKLOADS" \
+		   "$CLH_CTR_BUILD_DIR" \
+		   "$CARGO_TARGET_DIR" \
+		   "$CARGO_REGISTRY_DIR" \
+		   "$CARGO_GIT_REGISTRY_DIR"; do
+        mkdir -p "$dir" || die "Error: cannot create dir $dir"
+        [ -x "$dir" ] && [ -w "$dir" ] || \
+            {
+                say "Wrong permissions for $dir. Attempting to fix them ..."
+                chmod +x+w "$dir"
+            } || \
+            die "Error: wrong permissions for $dir. Should be +x+w"
+    done
+}
+
+cmd_help() {
+    echo ""
+    echo "Cloud Hypervisor $(basename $0)"
+    echo "Usage: $(basename $0) <command> [<command args>]"
+    echo ""
+    echo "Available commands:"
+    echo ""
+    echo "    build [--debug|--release] [-- [<cargo args>]]"
+    echo "        Build the Cloud Hypervisor binaries."
+    echo "        --debug               Build the debug binaries. This is the default."
+    echo "        --release             Build the release binaries."
+    echo ""
+    echo "    tests [--unit|--cargo|--all]"
+    echo "        Run the Cloud Hypervisor tests."
+    echo "        --unit               Run the unit tests."
+    echo "        --cargo              Run the cargo tests."
+    echo "        --integration        Run the integration tests."
+    echo "        --all                Run all tests."
+    echo ""
+    echo "    build-container [--type]"
+    echo "        Build the Cloud Hypervisor container."
+    echo "        --dev                Build dev container. This is the default."
+    echo ""
+    echo "    help"
+    echo "        Display this help message."
+    echo ""
+}
+
+cmd_build() {
+    build="debug"
+
+    while [ $# -gt 0 ]; do
+	case "$1" in
+            "-h"|"--help")  { cmd_help; exit 1;     } ;;
+            "--debug")      { build="debug";      } ;;
+            "--release")    { build="release";    } ;;
+            "--")           { shift; break;         } ;;
+            *)
+		die "Unknown build argument: $1. Please use --help for help."
+		;;
+	esac
+	shift
+    done
+
+    cargo_args=("$@")
+    [ $build = "release" ] && cargo_args+=("--release")
+
+    $DOCKER_RUNTIME run \
+	   -ti \
+	   --workdir "$CTR_CLH_ROOT_DIR" \
+	   --rm \
+	   --volume /dev:/dev \
+	   --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+	   "$CTR_IMAGE" \
+	   cargo build \
+	         --target-dir "$CTR_CLH_CARGO_TARGET" \
+	         "${cargo_args[@]}"
+
+    ret=$?
+
+    # If `cargo build` was successful, let's copy the binaries to a more
+    # accessible location.
+    [ $ret -eq 0 ] && {
+        cargo_bin_dir="$CLH_CARGO_TARGET/$build"
+        say "Binaries placed under $cargo_bin_dir"
+    }
+}
+
+cmd_tests() {
+    unit=false
+    cargo=false
+    integration=false
+
+    while [ $# -gt 0 ]; do
+	case "$1" in
+            "-h"|"--help")    { cmd_help; exit 1;     } ;;
+            "--unit")         { unit=true;      } ;;
+            "--cargo")        { cargo=true;    } ;;
+	    "--integration")  { integration=true;    } ;;
+	    "--all")          { cargo=true; unit=true; integration=true;  } ;;
+            "--")             { shift; break;         } ;;
+            *)
+		die "Unknown tests argument: $1. Please use --help for help."
+		;;
+	esac
+	shift
+    done
+
+    if [ "$unit" = true ] ;  then
+	say "Running unit tests..."
+	$DOCKER_RUNTIME run \
+	       -ti \
+	       --workdir "$CTR_CLH_ROOT_DIR" \
+	       --rm \
+	       --privileged \
+	       --volume /dev:/dev \
+	       --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+	       "$CTR_IMAGE" \
+	       ./scripts/run_unit_tests.sh
+    fi
+
+    if [ "$cargo" = true ] ;  then
+	say "Running cargo tests..."
+	$DOCKER_RUNTIME run \
+	       -ti \
+	       --workdir "$CTR_CLH_ROOT_DIR" \
+	       --rm \
+	       --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+	       "$CTR_IMAGE" \
+	       ./scripts/run_cargo_tests.sh
+    fi
+
+    if [ "$integration" = true ] ;  then
+	say "Running integration tests..."
+	$DOCKER_RUNTIME run \
+	       -ti \
+	       --workdir "$CTR_CLH_ROOT_DIR" \
+	       --rm \
+	       --privileged \
+	       --volume /dev:/dev \
+	       --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+	       --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+	       "$CTR_IMAGE" \
+	       ./scripts/run_integration_tests.sh
+    fi
+}
+
+cmd_build-container() {
+    container_type="dev"
+
+    while [ $# -gt 0 ]; do
+	case "$1" in
+            "-h"|"--help")  { cmd_help; exit 1;     } ;;
+            "--dev")        { container_type="dev"; } ;;
+            "--")           { shift; break;         } ;;
+            *)
+		die "Unknown build-container argument: $1. Please use --help for help."
+		;;
+	esac
+	shift
+    done
+
+    BUILD_DIR=/tmp/cloud-hypervisor/container/
+
+    mkdir -p $BUILD_DIR
+    cp $CLH_DOCKERFILE $BUILD_DIR
+
+    $DOCKER_RUNTIME build \
+	   --target $container_type \
+	   -t $CTR_IMAGE \
+	   -f $BUILD_DIR/Dockerfile \
+	   $BUILD_DIR
+}
+
+# Parse main command line args.
+#
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help)              { cmd_help; exit 1;     } ;;
+        -y|--unattended)        { OPT_UNATTENDED=true;  } ;;
+        -*)
+            die "Unknown arg: $1. Please use \`$0 help\` for help."
+            ;;
+        *)
+            break
+            ;;
+    esac
+    shift
+done
+
+# $1 is now a command name. Check if it is a valid command and, if so,
+# run it.
+#
+declare -f "cmd_$1" > /dev/null
+ok_or_die "Unknown command: $1. Please use \`$0 help\` for help."
+
+cmd=cmd_$1
+shift
+
+ensure_build_dir
+
+$cmd "$@"

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -135,6 +135,9 @@ cmd_help() {
     echo "        Build the Cloud Hypervisor container."
     echo "        --dev                Build dev container. This is the default."
     echo ""
+    echo "    clean [<cargo args>]]"
+    echo "        Remove the Cloud Hypervisor artifacts."
+    echo ""
     echo "    help"
     echo "        Display this help message."
     echo ""
@@ -179,6 +182,20 @@ cmd_build() {
         say "Binaries placed under $cargo_bin_dir"
     }
 }
+
+cmd_clean() {
+    cargo_args=("$@")
+
+    $DOCKER_RUNTIME run \
+	   -ti \
+	   --workdir "$CTR_CLH_ROOT_DIR" \
+	   --rm \
+	   --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+	   "$CTR_IMAGE" \
+	   cargo clean \
+	         --target-dir "$CTR_CLH_CARGO_TARGET" \
+	         "${cargo_args[@]}"
+    }
 
 cmd_tests() {
     unit=false

--- a/scripts/run_cargo_tests.sh
+++ b/scripts/run_cargo_tests.sh
@@ -7,7 +7,7 @@ source $HOME/.cargo/env
 # Install cargo components
 time rustup component add clippy
 time rustup component add rustfmt
-time cargo install --force cargo-audit
+time which cargo-audit || cargo install cargo-audit
 
 # Run cargo builds and checks
 time cargo clippy --all-targets --all-features -- -D warnings
@@ -24,5 +24,5 @@ time cargo rustc --bin vhost_user_net --no-default-features --features "pci"  --
 time cargo clippy --all-targets --no-default-features --features "mmio" -- -D warnings
 time cargo rustc --bin cloud-hypervisor --no-default-features --features "mmio"  -- -D warnings
 time cargo rustc --bin vhost_user_net --no-default-features --features "mmio"  -- -D warnings
-time sh -c 'find . \( -name "*.rs" ! -wholename "*/out/*.rs" \) | xargs rustfmt --check'
+time cargo fmt
 time cargo build --release


### PR DESCRIPTION
The script is a development tool that runs all commands in a dedicated
    container. This allows for containerized, isolated and reproducible
    builds and CI runs.
    
The script supports the following command:
    
* build: Build Cloud Hypervisor binaries (debug and release)
* build-container: Build the container used by the script
* tests: Run unit, cargo and integration tests
   
```
    $ ./scripts/dev_cli.sh help
    
    Cloud Hypervisor dev_cli.sh
    Usage: dev_cli.sh <command> [<command args>]
    
    Available commands:
    
        build [--debug|--release] [-- [<cargo args>]]
            Build the Cloud Hypervisor binaries.
            --debug               Build the debug binaries. This is the default.
            --release             Build the release binaries.
    
        tests [--unit|--cargo|--all]
            Run the Cloud Hypervisor tests.
            --unit               Run the unit tests.
            --cargo              Run the cargo tests.
            --all                Run all tests.
    
        build-container [--type]
            Build the Cloud Hypervisor container.
            --dev                Build dev container. This is the default.

        clean [<cargo args>]]
            Remove the Cloud Hypervisor artifacts.

        help
            Display this help message.
   ``` 
Fixes: #684
    
Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>