### PR TITLE
Implement virtio-fs DAX in cloud-hypervisor backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,7 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost_rs 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3388,6 +3388,21 @@ mod tests {
     }
 
     #[cfg_attr(not(feature = "mmio"), test)]
+    fn test_virtio_fs_dax_on_default_cache_size_w_vhost_user_fs_daemon() {
+        test_virtio_fs(true, None, "none", &prepare_vhost_user_fs_daemon)
+    }
+
+    #[cfg_attr(not(feature = "mmio"), test)]
+    fn test_virtio_fs_dax_on_cache_size_1_gib_w_vhost_user_fs_daemon() {
+        test_virtio_fs(
+            true,
+            Some(0x4000_0000),
+            "none",
+            &prepare_vhost_user_fs_daemon,
+        )
+    }
+
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_fs_dax_off_w_vhost_user_fs_daemon() {
         test_virtio_fs(false, None, "none", &prepare_vhost_user_fs_daemon)
     }

--- a/vhost_rs/src/vhost_user/slave_fs_cache.rs
+++ b/vhost_rs/src/vhost_user/slave_fs_cache.rs
@@ -1,0 +1,94 @@
+// Copyright (C) 2020 Alibaba Cloud Computing. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::connection::Endpoint;
+use super::message::*;
+use super::{Error, HandlerResult, Result, VhostUserMasterReqHandler};
+use std::io;
+use std::mem;
+use std::os::unix::io::RawFd;
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex};
+
+struct SlaveFsCacheReqInternal {
+    sock: Endpoint<SlaveReq>,
+}
+
+/// A vhost-user slave endpoint which sends fs cache requests to the master
+#[derive(Clone)]
+pub struct SlaveFsCacheReq {
+    // underlying Unix domain socket for communication
+    node: Arc<Mutex<SlaveFsCacheReqInternal>>,
+
+    // whether the endpoint has encountered any failure
+    error: Option<i32>,
+}
+
+impl SlaveFsCacheReq {
+    fn new(ep: Endpoint<SlaveReq>) -> Self {
+        SlaveFsCacheReq {
+            node: Arc::new(Mutex::new(SlaveFsCacheReqInternal { sock: ep })),
+            error: None,
+        }
+    }
+
+    /// Create a new instance.
+    pub fn from_stream(sock: UnixStream) -> Self {
+        Self::new(Endpoint::<SlaveReq>::from_stream(sock))
+    }
+
+    fn send_message(
+        &mut self,
+        flags: SlaveReq,
+        fs: &VhostUserFSSlaveMsg,
+        fds: Option<&[RawFd]>,
+    ) -> Result<()> {
+        self.check_state()?;
+
+        let len = mem::size_of::<VhostUserFSSlaveMsg>();
+        let mut hdr = VhostUserMsgHeader::new(flags, 0, len as u32);
+        hdr.set_need_reply(true);
+        self.node.lock().unwrap().sock.send_message(&hdr, fs, fds)?;
+
+        self.wait_for_ack(&hdr)
+    }
+
+    fn wait_for_ack(&mut self, hdr: &VhostUserMsgHeader<SlaveReq>) -> Result<()> {
+        self.check_state()?;
+        let (reply, body, rfds) = self.node.lock().unwrap().sock.recv_body::<VhostUserU64>()?;
+        if !reply.is_reply_for(&hdr) || rfds.is_some() || !body.is_valid() {
+            Endpoint::<SlaveReq>::close_rfds(rfds);
+            return Err(Error::InvalidMessage);
+        }
+        if body.value != 0 {
+            return Err(Error::MasterInternalError);
+        }
+        Ok(())
+    }
+
+    fn check_state(&self) -> Result<()> {
+        match self.error {
+            Some(e) => Err(Error::SocketBroken(std::io::Error::from_raw_os_error(e))),
+            None => Ok(()),
+        }
+    }
+
+    /// Mark endpoint as failed with specified error code.
+    pub fn set_failed(&mut self, error: i32) {
+        self.error = Some(error);
+    }
+}
+
+impl VhostUserMasterReqHandler for SlaveFsCacheReq {
+    /// Handle virtio-fs map file requests from the slave.
+    fn fs_slave_map(&mut self, fs: &VhostUserFSSlaveMsg, fd: RawFd) -> HandlerResult<()> {
+        self.send_message(SlaveReq::FS_MAP, fs, Some(&[fd]))
+            .or_else(|e| Err(io::Error::new(io::ErrorKind::Other, format!("{}", e))))
+    }
+
+    /// Handle virtio-fs unmap file requests from the slave.
+    fn fs_slave_unmap(&mut self, fs: &VhostUserFSSlaveMsg) -> HandlerResult<()> {
+        self.send_message(SlaveReq::FS_UNMAP, fs, None)
+            .or_else(|e| Err(io::Error::new(io::ErrorKind::Other, format!("{}", e))))
+    }
+}

--- a/vhost_user_backend/src/lib.rs
+++ b/vhost_user_backend/src/lib.rs
@@ -20,7 +20,8 @@ use vhost_rs::vhost_user::message::{
     VhostUserVirtioFeatures, VhostUserVringAddrFlags, VhostUserVringState,
 };
 use vhost_rs::vhost_user::{
-    Error as VhostUserError, Result as VhostUserResult, SlaveListener, VhostUserSlaveReqHandler,
+    Error as VhostUserError, Result as VhostUserResult, SlaveFsCacheReq, SlaveListener,
+    VhostUserSlaveReqHandler,
 };
 use vm_memory::guest_memory::FileOffset;
 use vm_memory::{GuestAddress, GuestMemoryMmap};
@@ -103,6 +104,11 @@ pub trait VhostUserBackend: Send + Sync + 'static {
     fn exit_event(&self) -> Option<(EventFd, Option<u16>)> {
         None
     }
+
+    /// Set slave fd.
+    /// A default implementation is provided as we cannot expect all backends
+    /// to implement this function.
+    fn set_slave_req_fd(&mut self, _vu_req: SlaveFsCacheReq) {}
 }
 
 /// This structure is the public API the backend is allowed to interact with
@@ -778,6 +784,10 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
             .unwrap()
             .set_config(offset, buf)
             .map_err(VhostUserError::ReqHandlerError)
+    }
+
+    fn set_slave_req_fd(&mut self, vu_req: SlaveFsCacheReq) {
+        self.backend.write().unwrap().set_slave_req_fd(vu_req);
     }
 }
 

--- a/vhost_user_fs/Cargo.toml
+++ b/vhost_user_fs/Cargo.toml
@@ -10,3 +10,7 @@ libc = "0.2.65"
 log = "0.4.8"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
 vm-virtio = { path = "../vm-virtio" }
+
+[dependencies.vhost_rs]
+path = "../vhost_rs"
+features = ["vhost-user-slave"]

--- a/vhost_user_fs/src/filesystem.rs
+++ b/vhost_user_fs/src/filesystem.rs
@@ -13,8 +13,10 @@ use libc;
 
 use crate::fuse;
 
+use super::fs_cache_req_handler::FsCacheReqHandler;
 pub use fuse::FsOptions;
 pub use fuse::OpenOptions;
+pub use fuse::RemovemappingOne;
 pub use fuse::SetattrValid;
 pub use fuse::ROOT_ID;
 
@@ -1039,6 +1041,31 @@ pub trait FileSystem {
         inode: Self::Inode,
         flags: u32,
         handle: Self::Handle,
+    ) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Setup a mapping so that guest can access files in DAX style.
+    #[allow(clippy::too_many_arguments)]
+    fn setupmapping<T: FsCacheReqHandler>(
+        &self,
+        _ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        foffset: u64,
+        len: u64,
+        flags: u64,
+        moffset: u64,
+        vu_req: &mut T,
+    ) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    fn removemapping<T: FsCacheReqHandler>(
+        &self,
+        _ctx: Context,
+        requests: Vec<RemovemappingOne>,
+        vu_req: &mut T,
     ) -> io::Result<()> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }

--- a/vhost_user_fs/src/fs_cache_req_handler.rs
+++ b/vhost_user_fs/src/fs_cache_req_handler.rs
@@ -1,0 +1,61 @@
+use crate::fuse;
+use std::io;
+use std::os::unix::io::RawFd;
+use vhost_rs::vhost_user::message::{
+    VhostUserFSSlaveMsg, VhostUserFSSlaveMsgFlags, VHOST_USER_FS_SLAVE_ENTRIES,
+};
+use vhost_rs::vhost_user::{SlaveFsCacheReq, VhostUserMasterReqHandler};
+
+/// Trait for virtio-fs cache requests operations.  This is mainly used to hide
+/// vhost-user details from virtio-fs's fuse part.
+pub trait FsCacheReqHandler: Send + Sync + 'static {
+    /// Setup a dedicated mapping so that guest can access file data in DAX style.
+    fn map(
+        &mut self,
+        foffset: u64,
+        moffset: u64,
+        len: u64,
+        flags: u64,
+        fd: RawFd,
+    ) -> io::Result<()>;
+
+    /// Remove those mappings that provide the access to file data.
+    fn unmap(&mut self, requests: Vec<fuse::RemovemappingOne>) -> io::Result<()>;
+}
+
+impl FsCacheReqHandler for SlaveFsCacheReq {
+    fn map(
+        &mut self,
+        foffset: u64,
+        moffset: u64,
+        len: u64,
+        flags: u64,
+        fd: RawFd,
+    ) -> io::Result<()> {
+        let mut msg: VhostUserFSSlaveMsg = Default::default();
+        msg.fd_offset[0] = foffset;
+        msg.cache_offset[0] = moffset;
+        msg.len[0] = len;
+        msg.flags[0] = if (flags & fuse::SetupmappingFlags::WRITE.bits()) != 0 {
+            VhostUserFSSlaveMsgFlags::MAP_W | VhostUserFSSlaveMsgFlags::MAP_R
+        } else {
+            VhostUserFSSlaveMsgFlags::MAP_R
+        };
+
+        self.fs_slave_map(&msg, fd)
+    }
+
+    fn unmap(&mut self, requests: Vec<fuse::RemovemappingOne>) -> io::Result<()> {
+        for chunk in requests.chunks(VHOST_USER_FS_SLAVE_ENTRIES) {
+            let mut msg: VhostUserFSSlaveMsg = Default::default();
+
+            for (ind, req) in chunk.iter().enumerate() {
+                msg.len[ind] = req.len;
+                msg.cache_offset[ind] = req.moffset;
+            }
+
+            self.fs_slave_unmap(&msg)?;
+        }
+        Ok(())
+    }
+}

--- a/vhost_user_fs/src/fuse.rs
+++ b/vhost_user_fs/src/fuse.rs
@@ -513,6 +513,9 @@ pub enum Opcode {
     Readdirplus = 44,
     Rename2 = 45,
     Lseek = 46,
+    CopyFileRange = 47,
+    SetupMapping = 48,
+    RemoveMapping = 49,
 }
 
 #[repr(u32)]
@@ -1045,3 +1048,39 @@ pub struct LseekOut {
     pub offset: u64,
 }
 unsafe impl ByteValued for LseekOut {}
+
+bitflags! {
+    pub struct SetupmappingFlags: u64 {
+    const WRITE = 0x1;
+    const READ = 0x2;
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SetupmappingIn {
+    pub fh: u64,
+    pub foffset: u64,
+    pub len: u64,
+    pub flags: u64,
+    pub moffset: u64,
+}
+
+unsafe impl ByteValued for SetupmappingIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct RemovemappingIn {
+    pub count: u32,
+}
+
+unsafe impl ByteValued for RemovemappingIn {}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct RemovemappingOne {
+    pub moffset: u64,
+    pub len: u64,
+}
+
+unsafe impl ByteValued for RemovemappingOne {}

--- a/vhost_user_fs/src/lib.rs
+++ b/vhost_user_fs/src/lib.rs
@@ -8,6 +8,7 @@ extern crate log;
 pub mod descriptor_utils;
 pub mod file_traits;
 pub mod filesystem;
+pub mod fs_cache_req_handler;
 pub mod fuse;
 pub mod multikey;
 pub mod passthrough;


### PR DESCRIPTION
This attempts to let clh's `vhost_user_fs` binary work with guest's dax mode so that we can get the benefits of using dax mode.

Issue: #481 

Signed-off-by: Liu Bo <bo.liu@linux.alibaba.com>