### PR TITLE
main: Ignore error on log writing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ impl log::Log for Logger {
         let now = std::time::Instant::now();
         let duration = now.duration_since(self.start);
 
-        if let Err(e) = if record.file().is_some() && record.line().is_some() {
+        if record.file().is_some() && record.line().is_some() {
             writeln!(
                 *(*(self.output.lock().unwrap())),
                 "cloud-hypervisor: {:?}: {}:{}:{} -- {}",
@@ -57,9 +57,7 @@ impl log::Log for Logger {
                 record.target(),
                 record.args()
             )
-        } {
-            eprintln!("Error writing log output: {:?}", e);
-        }
+        }.ok();
     }
     fn flush(&self) {}
 }


### PR DESCRIPTION
A previous version of this change attempted to avoid panicking by not
using .expect() when handling an error when attempting to write to the
log file. Unfortunately the macro eprintln!() that was used to replace
the .expect() also has the behaviour of panicking if stderr cannot be
used. Instead swallow the error completely as if writing to the log has
failed at logging time it is almost certainly the case that any message
about the log would also not be seen.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>