### PR TITLE
vm-device: interrupt: Remove InterruptType dependencies and  definitions

### DIFF
--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -16,7 +16,7 @@ use std::result;
 use std::sync::Arc;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceConfig, InterruptSourceGroup,
-    MsiIrqSourceConfig, PCI_MSI_IRQ,
+    MsiIrqGroupConfig, MsiIrqSourceConfig,
 };
 use vm_memory::GuestAddress;
 
@@ -211,14 +211,13 @@ impl BusDevice for Ioapic {
 impl Ioapic {
     pub fn new(
         apic_address: GuestAddress,
-        interrupt_manager: Arc<dyn InterruptManager>,
+        interrupt_manager: Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>>,
     ) -> Result<Ioapic> {
         let interrupt_source_group = interrupt_manager
-            .create_group(
-                PCI_MSI_IRQ,
-                0 as InterruptIndex,
-                NUM_IOAPIC_PINS as InterruptIndex,
-            )
+            .create_group(MsiIrqGroupConfig {
+                base: 0 as InterruptIndex,
+                count: NUM_IOAPIC_PINS as InterruptIndex,
+            })
             .map_err(Error::CreateInterruptSourceGroup)?;
 
         interrupt_source_group


### PR DESCRIPTION


Having the InterruptManager trait depend on an InterruptType forces
implementations into supporting potentially very different kind of
interrupts from the same code base. What we're defining through the
current, interrupt type based create_group() method is a need for having
different interrupt managers for different kind of interrupts.

By associating the InterruptManager trait to an interrupt group
configuration type, we create a cleaner design to support that need as
we're basically saying that one interrupt manager should have the single
responsibility of supporting one kind of interrupt (defined through its
configuration).

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>