### PR TITLE
scripts: dev_cli: Pass unit and integration test args to cargo test

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -124,7 +124,7 @@ cmd_help() {
     echo "        --debug               Build the debug binaries. This is the default."
     echo "        --release             Build the release binaries."
     echo ""
-    echo "    tests [--unit|--cargo|--all]"
+    echo "    tests [--unit|--cargo|--all] [-- [<cargo test args>]]"
     echo "        Run the Cloud Hypervisor tests."
     echo "        --unit               Run the unit tests."
     echo "        --cargo              Run the cargo tests."
@@ -227,7 +227,7 @@ cmd_tests() {
 	       --volume /dev:/dev \
 	       --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
 	       "$CTR_IMAGE" \
-	       ./scripts/run_unit_tests.sh
+	       ./scripts/run_unit_tests.sh "$@"
     fi
 
     if [ "$cargo" = true ] ;  then
@@ -252,7 +252,7 @@ cmd_tests() {
 	       --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
 	       --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
 	       "$CTR_IMAGE" \
-	       ./scripts/run_integration_tests.sh
+	       ./scripts/run_integration_tests.sh "$@"
     fi
 }
 

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -177,7 +177,7 @@ ls target/debug/deps/cloud_hypervisor-* | xargs -n 1 sudo setcap cap_net_admin+e
 sudo adduser $USER kvm
 newgrp kvm << EOF
 export RUST_BACKTRACE=1
-time cargo test --features "integration_tests" -- --nocapture
+time cargo test --features "integration_tests" "$@" -- --nocapture
 EOF
 RES=$?
 
@@ -188,7 +188,7 @@ if [ $RES -eq 0 ]; then
 
     newgrp kvm << EOF
 export RUST_BACKTRACE=1
-time cargo test --features "integration_tests,mmio" -- --nocapture
+time cargo test --features "integration_tests,mmio" "$@" -- --nocapture
 EOF
 
     RES=$?

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -10,5 +10,5 @@ popd
 sudo adduser $USER kvm
 newgrp kvm << EOF || exit 1
   export RUST_BACKTRACE=1
-  cargo test --workspace || exit 1;
+  cargo test --workspace "$@" || exit 1;
 EOF


### PR DESCRIPTION
In order, among other things, to use the development CLI to run specific
integration tests. For example, to run only the memory_overhead
integration test:

./scripts/dev_cli.sh tests --integration -- memory_overhead

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>