### PR TITLE
scripts: Check the Rust formatting is valid

### DIFF
--- a/scripts/run_cargo_tests.sh
+++ b/scripts/run_cargo_tests.sh
@@ -24,5 +24,5 @@ time cargo rustc --bin vhost_user_net --no-default-features --features "pci"  --
 time cargo clippy --all-targets --no-default-features --features "mmio" -- -D warnings
 time cargo rustc --bin cloud-hypervisor --no-default-features --features "mmio"  -- -D warnings
 time cargo rustc --bin vhost_user_net --no-default-features --features "mmio"  -- -D warnings
-time cargo fmt
+time cargo fmt -- --check
 time cargo build --release

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,8 @@ impl log::Log for Logger {
                 record.target(),
                 record.args()
             )
-        }.ok();
+        }
+        .ok();
     }
     fn flush(&self) {}
 }


### PR DESCRIPTION
Check the rust formatting rather than just reformatting code on the CI
agent.

Also fix a formatting error that slipped in whilst the cargo fmt check
was not working correctly.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>