### PR TITLE
README: Fix a typo for using cli_dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Cloud Hypervisor CI infrastructure.
 For example, to run the Cloud Hypervisor unit tests:
 
 ```shell
-$ ./scripts/dev_cli.sh tests --release
+$ ./scripts/dev_cli.sh tests --unit
 ```
 
 Run the `./scripts/dev_cli.sh --help` command to view all the supported


### PR DESCRIPTION
Fix the typo for the instructions of using cli_dev to run unit tests.

Signed-off-by: Bo Chen <chen.bo@intel.com>