### PR TITLE
scripts: dev_cli: Use a tmpfs mount for /tmp

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -248,6 +248,7 @@ cmd_tests() {
 	       --workdir "$CTR_CLH_ROOT_DIR" \
 	       --rm \
 	       --privileged \
+	       --mount type=tmpfs,destination=/tmp \
 	       --volume /dev:/dev \
 	       --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
 	       --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \


### PR DESCRIPTION
To mitigate Azure slow disk IO, we mount /tmp on tmpfs.
This is a reproduction of our CI environment, as setup by the
Jenkinsfile.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>