### PR TITLE
scripts: dev_cli: Fix build directory permissions

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -163,6 +163,7 @@ cmd_build() {
     [ $build = "release" ] && cargo_args+=("--release")
 
     $DOCKER_RUNTIME run \
+	   --user "$(id -u):$(id -g)" \
 	   --workdir "$CTR_CLH_ROOT_DIR" \
 	   --rm \
 	   --volume /dev:/dev \
@@ -186,6 +187,7 @@ cmd_clean() {
     cargo_args=("$@")
 
     $DOCKER_RUNTIME run \
+	   --user "$(id -u):$(id -g)" \
 	   --workdir "$CTR_CLH_ROOT_DIR" \
 	   --rm \
 	   --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
@@ -230,6 +232,7 @@ cmd_tests() {
     if [ "$cargo" = true ] ;  then
 	say "Running cargo tests..."
 	$DOCKER_RUNTIME run \
+	       --user "$(id -u):$(id -g)" \
 	       --workdir "$CTR_CLH_ROOT_DIR" \
 	       --rm \
 	       --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -191,16 +191,7 @@ cmd_build() {
 	   "$CTR_IMAGE" \
 	   cargo build \
 	         --target-dir "$CTR_CLH_CARGO_TARGET" \
-	         "${cargo_args[@]}"
-
-    ret=$?
-
-    # If `cargo build` was successful, let's copy the binaries to a more
-    # accessible location.
-    [ $ret -eq 0 ] && {
-        cargo_bin_dir="$CLH_CARGO_TARGET/$build"
-        say "Binaries placed under $cargo_bin_dir"
-    }
+	         "${cargo_args[@]}" && say "Binaries placed under $CLH_CARGO_TARGET/$build"
 }
 
 cmd_clean() {


### PR DESCRIPTION
By default our dev container commands run as root inside the container, which means any build artifact will be owned by root on the *host*. This prevents Jenkins from being able to properly clean the build directory up.

This PR does 2 things, in order to fix that:

1. For commands that do not need to be run as root, run the container as the host user. The build directory will then not be owned by root.
2. For commands that do need to be run as root, fix the build directory permissions after the container is done.