### PR TITLE
main: Display git commit hash with the '--version' option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.5.0"
 authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 default-run = "cloud-hypervisor"
+build = "build.rs"
 
 [dependencies]
 arc-swap = ">=0.4.4"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::process::Command;
+
+fn main() {
+    let git_out = Command::new("git")
+        .args(&["describe", "--dirty"])
+        .output()
+        .expect("Expect to get git describe output");
+
+    // This println!() has a special behavior, as it will set the environment
+    // variable BUILT_VERSION, so that it can be reused from the binary.
+    // Particularly, this is used from src/main.rs to display the exact
+    // version.
+    println!(
+        "cargo:rustc-env=BUILT_VERSION={}",
+        String::from_utf8(git_out.stdout).unwrap()
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@
 extern crate vmm;
 extern crate vmm_sys_util;
 
-#[macro_use(crate_version, crate_authors)]
+#[macro_use(crate_authors)]
 extern crate clap;
 
 use clap::{App, Arg, ArgGroup, ArgMatches};
@@ -78,7 +78,9 @@ fn create_app<'a, 'b>(
     api_server_path: &'a str,
 ) -> App<'a, 'b> {
     App::new("cloud-hypervisor")
-        .version(crate_version!())
+        // 'BUILT_VERSION' is set by the build script 'build.rs' at
+        // compile time
+        .version(env!("BUILT_VERSION"))
         .author(crate_authors!())
         .about("Launch a cloud-hypervisor VMM.")
         .group(ArgGroup::with_name("vm-config").multiple(true))


### PR DESCRIPTION
Add a build-script to propagate the git commit hash to other crates at
compile time through environment variables, and display the hash along
with the '--version' option.

Fixes #729

Signed-off-by: Bo Chen <chen.bo@intel.com>