### PR TITLE
tests: Run test_vfio with PCI binary     

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -181,6 +181,12 @@ time cargo test --features "integration_tests" "$@" -- --nocapture
 EOF
 RES=$?
 
+# Try the VFIO test but ignore the result
+newgrp kvm << EOF
+export RUST_BACKTRACE=1
+time cargo test --features "integration_tests" test_vfio -- --nocapture --ignored
+EOF
+
 if [ $RES -eq 0 ]; then
     # virtio-mmio based testing
     cargo build --release --no-default-features --features "mmio"
@@ -193,12 +199,6 @@ EOF
 
     RES=$?
 fi
-
-# Try the VFIO test but ignore the result
-newgrp kvm << EOF
-export RUST_BACKTRACE=1
-time cargo test --features "integration_tests" test_vfio -- --nocapture --ignored
-EOF
 
 # Tear VFIO test network down
 sudo ip link del vfio-br0


### PR DESCRIPTION
The placement of the explicit run of "test_vfio" meant it was run with
MMIO rather than PCI which meant it always failed.
    
Signed-off-by: Rob Bradford <robert.bradford@intel.com>

