### PR TITLE
tests: Use hugepages for test_vfio

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -131,12 +131,11 @@ if [ ! -d "$SHARED_DIR" ]; then
 fi
 
 VFIO_DIR="$WORKLOADS_DIR/vfio"
-if [ ! -d "$VFIO_DIR" ]; then
-    mkdir -p $VFIO_DIR
-    cp $CLEAR_OS_IMAGE $VFIO_DIR
-    cp $FW $VFIO_DIR
-    cp $VMLINUX_IMAGE $VFIO_DIR
-fi
+rm -rf $VFIO_DIR
+mkdir -p $VFIO_DIR
+cp $CLEAR_OS_IMAGE $VFIO_DIR
+cp $FW $VFIO_DIR
+cp $VMLINUX_IMAGE $VFIO_DIR
 
 # VFIO test network setup.
 # We reserve a different IP class for it: 172.17.0.0/24.

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -174,6 +174,10 @@ sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 time cargo test --no-run --features "integration_tests" -- --nocapture
 ls target/debug/deps/cloud_hypervisor-* | xargs -n 1 sudo setcap cap_net_admin+ep
 
+# test_vfio relies on hugepages
+echo 4096 | sudo tee /proc/sys/vm/nr_hugepages
+sudo chmod a+rwX /dev/hugepages
+
 sudo adduser $USER kvm
 newgrp kvm << EOF
 export RUST_BACKTRACE=1

--- a/src/main.rs
+++ b/src/main.rs
@@ -3831,7 +3831,7 @@ mod tests {
 
             let mut child = Command::new("target/release/cloud-hypervisor")
                 .args(&["--cpus", "boot=4"])
-                .args(&["--memory", "size=1G,file=/dev/shm"])
+                .args(&["--memory", "size=1G,file=/dev/hugepages"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&[
                     "--disk",

--- a/test_data/cloud-init/clear/openstack/latest/user_data
+++ b/test_data/cloud-init/clear/openstack/latest/user_data
@@ -63,5 +63,7 @@ write_files:
         bash -c "echo 1af4 1041 > /sys/bus/pci/drivers/vfio-pci/new_id"
         bash -c "echo 0000:00:06.0 > /sys/bus/pci/devices/0000\:00\:06.0/driver/unbind"
         bash -c "echo 1af4 1041 > /sys/bus/pci/drivers/vfio-pci/new_id"
-
-        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda2 VFIOTAG" --disk path=/mnt/clear-31310-cloudguest.img path=/mnt/cloudinit.img --cpus boot=1 --memory size=512M --device path=/sys/bus/pci/devices/0000:00:05.0/ path=/sys/bus/pci/devices/0000:00:06.0/
+        # 512M ram requires 256 pages
+        echo 256 | sudo tee /proc/sys/vm/nr_hugepages
+        sudo chmod a+rwX /dev/hugepages
+        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda2 VFIOTAG" --disk path=/mnt/clear-31310-cloudguest.img path=/mnt/cloudinit.img --cpus boot=1 --memory size=512M,file=/dev/hugepages --device path=/sys/bus/pci/devices/0000:00:05.0/ path=/sys/bus/pci/devices/0000:00:06.0/


### PR DESCRIPTION
Using hugepages with VFIO and virtiofs can improve the performance of
the test_vfio test.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>