### PR TITLE
Revert "build: Don't fail build on test_vfio failure"

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -184,12 +184,6 @@ time cargo test --features "integration_tests" "$@" -- --nocapture
 EOF
 RES=$?
 
-# Try the VFIO test but ignore the result
-newgrp kvm << EOF
-export RUST_BACKTRACE=1
-time cargo test --features "integration_tests" test_vfio -- --nocapture --ignored
-EOF
-
 if [ $RES -eq 0 ]; then
     # virtio-mmio based testing
     cargo build --release --no-default-features --features "mmio"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3796,7 +3796,6 @@ mod tests {
     // its cloud-hypervisor host, we should be able to ssh into it, and verify
     // that it's running with the right kernel command line (We tag the command
     // line from cloud-hypervisor for that purpose).
-    #[cfg_attr(not(feature = "mmio"), ignore)]
     fn test_vfio() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();


### PR DESCRIPTION
This reverts commit 014844d0daef115fb9b51ea8bdd9f6f596776653.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>