### PR TITLE
Add "self spawning" support to --net

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,6 +1212,7 @@ dependencies = [
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vfio 0.0.1",
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -101,6 +101,12 @@ pub trait VirtioDevice: Send {
     fn iommu_translate(&self, addr: u64) -> u64 {
         addr
     }
+
+    /// Some devices may need to do some explicit shutdown work. This method
+    /// may be implemented to do this. The VMM should call shutdown() on
+    /// every device as part of shutting down the VM. Acting on the device
+    /// after a shutdown() can lead to unpredictable results.
+    fn shutdown(&mut self) {}
 }
 
 /// Trait providing address translation the same way a physical DMA remapping

--- a/vm-virtio/src/vhost_user/net.rs
+++ b/vm-virtio/src/vhost_user/net.rs
@@ -17,6 +17,7 @@ use libc::EFD_NONBLOCK;
 use net_util::MacAddr;
 use std::cmp;
 use std::io::Write;
+use std::os::unix::io::AsRawFd;
 use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -353,6 +354,10 @@ impl VirtioDevice for Net {
             self.interrupt_cb.take().unwrap(),
             self.queue_evts.take().unwrap(),
         ))
+    }
+
+    fn shutdown(&mut self) {
+        let _ = unsafe { libc::close(self.vhost_user_net.as_raw_fd()) };
     }
 }
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -37,6 +37,7 @@ vm-device = { path = "../vm-device" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 signal-hook = "0.1.13"
+tempfile = "3.1.0"
 
 [dependencies.linux-loader]
 git = "https://github.com/rust-vmm/linux-loader"

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -587,11 +587,6 @@ impl NetConfig {
             vhost_socket = Some(vhost_socket_str.to_owned());
         }
 
-        // For now we require a socket if vhost-user is turned on
-        if vhost_user && vhost_socket.is_none() {
-            return Err(Error::ParseNetVhostSocketRequired);
-        }
-
         Ok(NetConfig {
             tap,
             ip,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -35,6 +35,7 @@ use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{self, sink, stdout};
 use std::os::unix::fs::OpenOptionsExt;
+use std::path::PathBuf;
 use std::result;
 #[cfg(feature = "pci_support")]
 use std::sync::Weak;
@@ -399,6 +400,9 @@ pub struct DeviceManager {
 
     // The virtio devices on the system
     virtio_devices: Vec<(VirtioDeviceArc, bool)>,
+
+    // The path to the VMM for self spawning
+    _vmm_path: PathBuf,
 }
 
 impl DeviceManager {
@@ -409,6 +413,7 @@ impl DeviceManager {
         memory_manager: Arc<Mutex<MemoryManager>>,
         _exit_evt: &EventFd,
         reset_evt: &EventFd,
+        _vmm_path: PathBuf,
     ) -> DeviceManagerResult<Self> {
         let io_bus = devices::Bus::new();
         let mmio_bus = devices::Bus::new();
@@ -482,6 +487,7 @@ impl DeviceManager {
             migratable_devices,
             memory_manager,
             virtio_devices: Vec::new(),
+            _vmm_path,
         };
 
         device_manager

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -12,6 +12,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+extern crate tempfile;
 extern crate vmm_sys_util;
 
 use crate::api::{ApiError, ApiRequest, ApiResponse, ApiResponsePayload, VmInfo, VmmPingResponse};

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -39,6 +39,7 @@ use signal_hook::{iterator::Signals, SIGINT, SIGTERM, SIGWINCH};
 use std::ffi::CString;
 use std::fs::File;
 use std::io;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
 use std::{result, str, thread};
 use vm_allocator::{GsiApic, SystemAllocator};
@@ -223,6 +224,7 @@ impl Vm {
         config: Arc<Mutex<VmConfig>>,
         exit_evt: EventFd,
         reset_evt: EventFd,
+        vmm_path: PathBuf,
     ) -> Result<Self> {
         let kvm = Kvm::new().map_err(Error::KvmNew)?;
 
@@ -343,6 +345,7 @@ impl Vm {
             memory_manager.clone(),
             &exit_evt,
             &reset_evt,
+            vmm_path,
         )
         .map_err(Error::DeviceManager)?;
 


### PR DESCRIPTION
If "vhost_user=true" is set but no socket is provided respawn the cloud-hypervisor binary as a network backend and use that.

See #630 