### PR TITLE
vmm: Prevent memory overcommitment through virtio-fs shared regions

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1092,8 +1092,13 @@ impl DeviceManager {
                             )
                             .ok_or(DeviceManagerError::FsRangeAllocation)?;
 
-                        let mmap_region = MmapRegion::new(fs_cache as usize)
-                            .map_err(DeviceManagerError::NewMmapRegion)?;
+                        let mmap_region = MmapRegion::build(
+                            None,
+                            fs_cache as usize,
+                            libc::PROT_NONE,
+                            libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
+                        )
+                        .map_err(DeviceManagerError::NewMmapRegion)?;
                         let addr: u64 = mmap_region.as_ptr() as u64;
 
                         self._mmap_regions.push(mmap_region);


### PR DESCRIPTION
When a virtio-fs device is created with a dedicated shared region, by
default the region should be mapped as PROT_NONE so that no pages can be
faulted in.

It's only when the guest performs the mount of the virtiofs filesystem
that we can expect the VMM, on behalf of the backend, to perform some
new mappings in the reserved shared window, using PROT_READ and/or
PROT_WRITE.

Fixes #763

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>