### PR TITLE
Implement EVENT_IDX and polling for vhost_user_block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,6 +1074,7 @@ dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost_rs 0.1.0",
+ "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/bin/vhost_user_blk.rs
+++ b/src/bin/vhost_user_blk.rs
@@ -26,7 +26,7 @@ fn main() {
                 .help(
                     "vhost-user-block backend parameters \"image=<image_path>,\
                      sock=<socket_path>,num_queues=<number_of_queues>,\
-                     readonly=true|false,direct=true|false\"",
+                     readonly=true|false,direct=true|false,poll_queue=true|false\"",
                 )
                 .takes_value(true)
                 .min_values(1),

--- a/src/bin/vhost_user_fs.rs
+++ b/src/bin/vhost_user_fs.rs
@@ -140,6 +140,8 @@ impl<F: FileSystem + Send + Sync + 'static> VhostUserBackend for VhostUserFsBack
         VhostUserProtocolFeatures::all()
     }
 
+    fn set_event_idx(&mut self, _enabled: bool) {}
+
     fn update_memory(&mut self, mem: GuestMemoryMmap) -> VhostUserBackendResult<()> {
         self.mem = Some(mem);
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,7 +289,7 @@ fn create_app<'a, 'b>(
                 .help(
                     "vhost-user-block backend parameters \"image=<image_path>,\
                      sock=<socket_path>,num_queues=<number_of_queues>,\
-                     readonly=true|false,direct=true|false\"",
+                     readonly=true|false,direct=true|false,poll_queue=true|false\"",
                 )
                 .takes_value(true)
                 .conflicts_with_all(&["net-backend", "kernel"])

--- a/vhost_user_backend/Cargo.toml
+++ b/vhost_user_backend/Cargo.toml
@@ -13,6 +13,7 @@ mmio_support = ["vm-virtio/mmio_support"]
 epoll = ">=4.0.1"
 libc = "0.2.66"
 log = "0.4.8"
+virtio-bindings = "0.1.0"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
@@ -20,4 +21,3 @@ vmm-sys-util = ">=0.3.1"
 [dependencies.vhost_rs]
 path = "../vhost_rs"
 features = ["vhost-user-slave"]
-

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -212,6 +212,8 @@ impl VhostUserBackend for VhostUserBlkBackend {
         VhostUserProtocolFeatures::CONFIG
     }
 
+    fn set_event_idx(&mut self, _enabled: bool) {}
+
     fn update_memory(&mut self, mem: GuestMemoryMmap) -> VhostUserBackendResult<()> {
         self.mem = Some(mem);
         Ok(())

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -275,6 +275,8 @@ impl VhostUserBackend for VhostUserNetBackend {
         VhostUserProtocolFeatures::all()
     }
 
+    fn set_event_idx(&mut self, _enabled: bool) {}
+
     fn update_memory(&mut self, mem: GuestMemoryMmap) -> VhostUserBackendResult<()> {
         self.mem = Some(mem);
         Ok(())

--- a/vm-virtio/src/vhost_user/blk.rs
+++ b/vm-virtio/src/vhost_user/blk.rs
@@ -25,6 +25,7 @@ use vhost_rs::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFe
 use vhost_rs::vhost_user::{Master, VhostUserMaster, VhostUserMasterReqHandler};
 use vhost_rs::VhostBackend;
 use virtio_bindings::bindings::virtio_blk::*;
+use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use vm_device::{Migratable, MigratableError, Pausable, Snapshotable};
 use vm_memory::{ByteValued, GuestMemoryMmap};
 use vmm_sys_util::eventfd::EventFd;
@@ -58,6 +59,7 @@ impl Blk {
             | 1 << VIRTIO_BLK_F_BLK_SIZE
             | 1 << VIRTIO_BLK_F_FLUSH
             | 1 << VIRTIO_BLK_F_TOPOLOGY
+            | 1 << VIRTIO_RING_F_EVENT_IDX
             | 1 << VIRTIO_F_VERSION_1
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
 


### PR DESCRIPTION
This patch series implements EVENT_IDX, a virtio feature that allows reducing the number of driver <-> device notifications and thus, reducing the number of vm exits needed while processing requests. This is specially useful when actively polling the virtqueues.