### PR TITLE
vhost_rs: Fix unit test race condition

### DIFF
--- a/vhost_rs/src/vhost_user/connection.rs
+++ b/vhost_rs/src/vhost_user/connection.rs
@@ -489,7 +489,6 @@ mod tests {
 
     use self::tempfile::tempfile;
     use super::*;
-    use libc;
     use std::fs::File;
     use std::io::{Read, Seek, SeekFrom, Write};
     use std::os::unix::io::FromRawFd;
@@ -513,15 +512,6 @@ mod tests {
         // accept on a fd without incoming connection
         let conn = listener.accept().unwrap();
         assert!(conn.is_none());
-
-        listener.set_nonblocking(true).unwrap();
-
-        // accept on a closed fd
-        unsafe {
-            libc::close(listener.as_raw_fd());
-        }
-        let conn2 = listener.accept();
-        assert!(conn2.is_err());
     }
 
     #[test]


### PR DESCRIPTION
The unit tests are run from cargo test through multiple threads of the
same process. For this reason, all these threads share their file
descriptors (because that's how this works on Linux), which means that
any of them can close a file descriptor opened from another thread.

In the context of create_listener() and accept_connection() tests, they
can run concurrently and this generates some failure when the file
descriptor create_listener() is binding to is being closed from the
accept_connection() test.

In order to avoid such race condition, this patch simply removes the
part of the unit test performing an explicit and unsafe file descriptor
closure.

Fixes #759

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>