### PR TITLE
ci: Improve test_memory_mergeable_on stability

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4722,7 +4722,9 @@ mod tests {
                 .spawn()
                 .unwrap();
 
-            thread::sleep(std::time::Duration::new(20, 0));
+            // Let enough time for the first VM to be spawned, and to make
+            // sure the PSS measurement is accurate.
+            thread::sleep(std::time::Duration::new(60, 0));
 
             // Get initial PSS
             let old_pss = get_pss(child1.id());
@@ -4752,9 +4754,9 @@ mod tests {
                 .unwrap();
 
             // Let enough time for the second VM to be spawned, and to make
-            // sure KVM has enough time to merge identical pages between the
+            // sure KSM has enough time to merge identical pages between the
             // 2 VMs.
-            thread::sleep(std::time::Duration::new(30, 0));
+            thread::sleep(std::time::Duration::new(60, 0));
 
             // Get new PSS
             let new_pss = get_pss(child1.id());


### PR DESCRIPTION
The integration test test_memory_mergeable_on has been fairly unstable
for quite some time now. Because it can take some time for the VM to be
spawned and to be able to perform a correct measure of the PSS, this
commit simply increases the time before such measure is done.
This should return more accurate PSS results, which should help
stabilize the test.

Fixes #781

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>