### PR TITLE
vmm: openapi: Update DiskConfig

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -274,6 +274,9 @@ components:
       properties:
         path:
           type: string
+        readonly:
+          type: boolean
+          default: true
         iommu:
           type: boolean
           default: false
@@ -283,6 +286,14 @@ components:
         queue_size:
           type: integer
           default: 128
+        vhost_user:
+          type: boolean
+          default: false
+        vhost_socket:
+          type: string
+        wce:
+          type: boolean
+          default: false
 
     NetConfig:
       type: object


### PR DESCRIPTION
It's missing a few knobs (readonly, vhost, wce) that should be exposed
through the rest API.

Fixes: #790

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>