### PR TITLE
Minor fixes for the VM resize path

### DIFF
--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -44,6 +44,9 @@ pub enum HttpError {
     /// Could not act on a VM
     VmAction(ApiError),
 
+    /// Could not resize a VM
+    VmResize(ApiError),
+
     /// Could not shut the VMM down
     VmmShutdown(ApiError),
 
@@ -244,7 +247,7 @@ impl EndpointHandler for VmResize {
 
                         // Call vm_resize()
                         match vm_resize(api_notifier, api_sender, Arc::new(vm_resize_data))
-                            .map_err(HttpError::VmCreate)
+                            .map_err(HttpError::VmResize)
                         {
                             Ok(_) => Response::new(Version::Http11, StatusCode::NoContent),
                             Err(e) => error_response(e, StatusCode::InternalServerError),

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -179,7 +179,7 @@ pub enum ApiRequest {
     /// VMM process.
     VmmShutdown(Sender<ApiResponse>),
 
-    //// Resuze the VMM
+    /// Resize the VMM
     VmResize(Arc<VmResizeData>, Sender<ApiResponse>),
 }
 
@@ -323,7 +323,7 @@ pub fn vm_resize(
 ) -> ApiResult<()> {
     let (response_sender, response_receiver) = channel();
 
-    // Send the VM creation request.
+    // Send the VM resizing request.
     api_sender
         .send(ApiRequest::VmResize(data, response_sender))
         .map_err(ApiError::RequestSend)?;


### PR DESCRIPTION
This fixes a couple of typos and the `VmResize` returned error.