### PR TITLE
Avoid error spew during "vhost_user=true" reboots/shutdown

### DIFF
--- a/vhost_rs/src/vhost_user/sock_ctrl_msg.rs
+++ b/vhost_rs/src/vhost_user/sock_ctrl_msg.rs
@@ -182,8 +182,9 @@ fn raw_recvmsg(fd: RawFd, iovecs: &mut [iovec], in_fds: &mut [RawFd]) -> Result<
         return Err(Error::last());
     }
 
+    // When the connection is closed recvmsg() doesn't give an explicit error
     if total_read == 0 && msg.msg_controllen < size_of::<cmsghdr>() {
-        return Ok((0, 0));
+        return Err(Error::new(libc::ECONNRESET));
     }
 
     let mut cmsg_ptr = msg.msg_control as *mut cmsghdr;

--- a/vhost_user_backend/src/lib.rs
+++ b/vhost_user_backend/src/lib.rs
@@ -174,7 +174,11 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
     /// terminate.
     pub fn wait(&mut self) -> Result<()> {
         if let Some(handle) = self.main_thread.take() {
-            handle.join().map_err(Error::WaitDaemon)?
+            match handle.join().map_err(Error::WaitDaemon)? {
+                Ok(()) => Ok(()),
+                Err(Error::HandleRequest(VhostUserError::SocketBroken(_))) => Ok(()),
+                Err(e) => Err(e),
+            }
         } else {
             Ok(())
         }


### PR DESCRIPTION
When the backend was terminating and the VMM closed the connection it was printing out an alarming and unhelpful error message.

Identify situations where the connection has been broken and don't report that error.