### PR TITLE
msi/msi-x: Prevent from losing masked interrupts

### DIFF
--- a/pci/src/msi.rs
+++ b/pci/src/msi.rs
@@ -214,6 +214,8 @@ impl MsiConfig {
                     if let Err(e) = self.interrupt_source_group.mask(idx as InterruptIndex) {
                         error!("Failed masking vector: {:?}", e);
                     }
+                } else if let Err(e) = self.interrupt_source_group.unmask(idx as InterruptIndex) {
+                    error!("Failed unmasking vector: {:?}", e);
                 }
             }
 

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -116,6 +116,9 @@ impl MsixConfig {
                         if let Err(e) = self.interrupt_source_group.mask(idx as InterruptIndex) {
                             error!("Failed masking vector: {:?}", e);
                         }
+                    } else if let Err(e) = self.interrupt_source_group.unmask(idx as InterruptIndex)
+                    {
+                        error!("Failed unmasking vector: {:?}", e);
                     }
                 }
 


### PR DESCRIPTION
We want to prevent from losing interrupts while they are masked. The
way they can be lost is due to the internals of how they are connected
through KVM. An eventfd is registered to a specific GSI, and then a
route is associated with this same GSI.

The current code adds/removes a route whenever a mask/unmask action
happens. Problem with this approach, KVM will consume the eventfd but
it won't be able to find an associated route and eventually it won't
be able to deliver the interrupt.

That's why this patch introduces a different way of masking/unmasking
the interrupts, simply by registering/unregistering the eventfd with the
GSI. This way, when the vector is masked, the eventfd is going to be
written but nothing will happen because KVM won't consume the event.
Whenever the unmask happens, the eventfd will be registered with a
specific GSI, and if there's some pending events, KVM will trigger them,
based on the route associated with the GSI.

Suggested-by: Liu Jiang <gerry@linux.alibaba.com>
Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>