### PR TITLE
Add poll_queue and fix some openapi properties

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -276,7 +276,7 @@ components:
           type: string
         readonly:
           type: boolean
-          default: true
+          default: false
         iommu:
           type: boolean
           default: false
@@ -293,7 +293,7 @@ components:
           type: string
         wce:
           type: boolean
-          default: false
+          default: true
 
     NetConfig:
       type: object

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -277,6 +277,9 @@ components:
         readonly:
           type: boolean
           default: false
+        direct:
+          type: boolean
+          default: false
         iommu:
           type: boolean
           default: false

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -297,6 +297,9 @@ components:
         wce:
           type: boolean
           default: true
+        poll_queue:
+          type: boolean
+          default: true
 
     NetConfig:
       type: object


### PR DESCRIPTION
This patch series adds the `poll_queue` property to `DiskConfig` and, while there, it also fixes a couple of issues with the `DiskConfig` representation in `cloud-hypervisor.yaml`.