### PR TITLE
 pci: fix pci MMCONFIG address parsing 

### DIFF
--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -9,8 +9,8 @@ use crate::{MsixConfig, PciInterruptPin};
 use byteorder::{ByteOrder, LittleEndian};
 use std::fmt::{self, Display};
 
-// The number of 32bit registers in the config space, 256 bytes.
-const NUM_CONFIGURATION_REGISTERS: usize = 64;
+// The number of 32bit registers in the config space, 4096 bytes.
+const NUM_CONFIGURATION_REGISTERS: usize = 1024;
 
 const STATUS_REG: usize = 1;
 const STATUS_REG_CAPABILITIES_USED_MASK: u32 = 0x0010_0000;


### PR DESCRIPTION
The entire MMCONFIG space is broken since we are regarding it as legacy PCI port io address format. Accessing registers in the extended configuration space results to 0xffffffff in most cases since the bus number is decoded to a number above 0 by mistake. Most devices except VFIO devices with extended configuration space work fine since they are not trying to access the memory mapped MMCONFIG space and accessing PCI config space by port io. 

I can just list the extended capability by `lspci -vvv`. But I'm not sure whether the device is functional properly. 

Fixes #716 