### PR TITLE
vmm: openapi: Fix "readonly" and "wce" defaults in DiskConfig

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -276,7 +276,7 @@ components:
           type: string
         readonly:
           type: boolean
-          default: true
+          default: false
         iommu:
           type: boolean
           default: false
@@ -293,7 +293,7 @@ components:
           type: string
         wce:
           type: boolean
-          default: false
+          default: true
 
     NetConfig:
       type: object


### PR DESCRIPTION
Fix "readonly" and "wce" defaults in cloud-hypervisor.yaml to match
their respective defaults in config.rs:DiskConfig.

Signed-off-by: Sergio Lopez <slp@redhat.com>