### PR TITLE
Add basic support for PVH boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "linux-loader"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/linux-loader#0c754f380acaa905e764a6a41175275cbc7d761b"
+source = "git+https://github.com/rust-vmm/linux-loader#0ce5bfa70d1073a9743fadfea233edef09c81e49"
 dependencies = [
  "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ acpi = ["vmm/acpi"]
 pci = ["vmm/pci_support"]
 mmio = ["vmm/mmio_support"]
 cmos = ["vmm/cmos"]
+pvh_boot = ["vmm/pvh_boot"]
 
 # Integration tests require a special environment to run in
 integration_tests = []

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright © 2020, Oracle and/or its affiliates.
+//
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -31,6 +33,14 @@ pub enum Error {
     ZeroPagePastRamEnd,
     /// Error writing the zero page of guest memory.
     ZeroPageSetup(vm_memory::GuestMemoryError),
+    /// The memory map table extends past the end of guest memory.
+    MemmapTablePastRamEnd,
+    /// Error writing memory map table to guest memory.
+    MemmapTableSetup,
+    /// The hvm_start_info structure extends past the end of guest memory.
+    StartInfoPastRamEnd,
+    /// Error writing hvm_start_info to guest memory.
+    StartInfoSetup,
 }
 pub type Result<T> = result::Result<T, Error>;
 

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -77,4 +77,5 @@ pub mod x86_64;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
     arch_memory_regions, configure_system, layout, layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START,
+    BootProtocol, EntryPoint,
 };

--- a/arch/src/x86_64/gdt.rs
+++ b/arch/src/x86_64/gdt.rs
@@ -1,3 +1,5 @@
+// Copyright © 2020, Oracle and/or its affiliates.
+//
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -24,8 +26,34 @@ fn get_base(entry: u64) -> u64 {
         | (((entry) & 0x00000000FFFF0000) >> 16))
 }
 
+// Extract the segment limit from the GDT segment descriptor.
+//
+// In a segment descriptor, the limit field is 20 bits, so it can directly describe
+// a range from 0 to 0xFFFFF (1MByte). When G flag is set (4-KByte page granularity) it
+// scales the value in the limit field by a factor of 2^12 (4Kbytes), making the effective
+// limit range from 0xFFF (4 KBytes) to 0xFFFF_FFFF (4 GBytes).
+//
+// However, the limit field in the VMCS definition is a 32 bit field, and the limit value is not
+// automatically scaled using the G flag. This means that for a desired range of 4GB for a
+// given segment, its limit must be specified as 0xFFFF_FFFF. Therefore the method of obtaining
+// the limit from the GDT entry is not sufficient, since it only provides 20 bits when 32 bits
+// are necessary. Fortunately, we can check if the G flag is set when extracting the limit since
+// the full GDT entry is passed as an argument, and perform the scaling of the limit value to
+// return the full 32 bit value.
+//
+// The scaling mentioned above is required when using PVH boot, since the guest boots in protected
+// (32-bit) mode and must be able to access the entire 32-bit address space. It does not cause issues
+// for the case of direct boot to 64-bit (long) mode, since in 64-bit mode the processor does not
+// perform runtime limit checking on code or data segments.
 fn get_limit(entry: u64) -> u32 {
-    ((((entry) & 0x000F000000000000) >> 32) | ((entry) & 0x000000000000FFFF)) as u32
+    let limit: u32 =
+        ((((entry) & 0x000F000000000000) >> 32) | ((entry) & 0x000000000000FFFF)) as u32;
+
+    // Perform manual limit scaling if G flag is set
+    match get_g(entry) {
+        0 => limit,
+        _ => ((limit << 12) | 0xFFF), // G flag is either 0 or 1
+    }
 }
 
 fn get_g(entry: u64) -> u8 {
@@ -109,7 +137,7 @@ mod tests {
         assert_eq!(0xB, seg.type_);
         // base and limit
         assert_eq!(0x100000, seg.base);
-        assert_eq!(0xfffff, seg.limit);
+        assert_eq!(0xffffffff, seg.limit);
         assert_eq!(0x0, seg.unusable);
     }
 }

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -1,3 +1,5 @@
+// Copyright © 2020, Oracle and/or its affiliates.
+//
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -25,6 +27,13 @@ pub const LOW_RAM_START: GuestAddress = GuestAddress(0x0);
 // Initial GDT/IDT needed to boot kernel
 pub const BOOT_GDT_START: GuestAddress = GuestAddress(0x500);
 pub const BOOT_IDT_START: GuestAddress = GuestAddress(0x520);
+
+/// Address for the hvm_start_info struct used in PVH boot
+pub const PVH_INFO_START: GuestAddress = GuestAddress(0x6000);
+
+/// Address of memory map table used in PVH boot. Can overlap
+/// with the zero page address since they are mutually exclusive.
+pub const MEMMAP_START: GuestAddress = GuestAddress(0x7000);
 
 /// The 'zero page', a.k.a linux kernel bootparams.
 pub const ZERO_PAGE_START: GuestAddress = GuestAddress(0x7000);

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -154,14 +154,152 @@ pub fn configure_system(
     num_cpus: u8,
     setup_hdr: Option<setup_header>,
     rsdp_addr: Option<GuestAddress>,
+    boot_prot: BootProtocol,
+) -> super::Result<()> {
+    // Note that this puts the mptable at the last 1k of Linux's 640k base RAM
+    mptable::setup_mptable(guest_mem, num_cpus).map_err(Error::MpTableSetup)?;
+
+    match boot_prot {
+        BootProtocol::PvhBoot => {
+            configure_pvh(guest_mem, cmdline_addr, rsdp_addr)?;
+        }
+        BootProtocol::LinuxBoot => {
+            configure_64bit_boot(guest_mem, cmdline_addr, cmdline_size, setup_hdr, rsdp_addr)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn configure_pvh(
+    guest_mem: &GuestMemoryMmap,
+    cmdline_addr: GuestAddress,
+    rsdp_addr: Option<GuestAddress>,
+) -> super::Result<()> {
+    const XEN_HVM_START_MAGIC_VALUE: u32 = 0x336ec578;
+
+    let mut start_info: StartInfoWrapper = StartInfoWrapper(hvm_start_info::default());
+
+    start_info.0.magic = XEN_HVM_START_MAGIC_VALUE;
+    start_info.0.version = 1; // pvh has version 1
+    start_info.0.nr_modules = 0;
+    start_info.0.cmdline_paddr = cmdline_addr.raw_value() as u64;
+    start_info.0.memmap_paddr = layout::MEMMAP_START.raw_value();
+
+    if let Some(rsdp_addr) = rsdp_addr {
+        start_info.0.rsdp_paddr = rsdp_addr.0;
+    }
+
+    // Vector to hold the memory maps which needs to be written to guest memory
+    // at MEMMAP_START after all of the mappings are recorded.
+    let mut memmap: Vec<hvm_memmap_table_entry> = Vec::new();
+
+    // Create the memory map entries.
+    add_memmap_entry(&mut memmap, 0, layout::EBDA_START.raw_value(), E820_RAM)?;
+
+    let mem_end = guest_mem.last_addr();
+
+    if mem_end < layout::MEM_32BIT_RESERVED_START {
+        add_memmap_entry(
+            &mut memmap,
+            layout::HIGH_RAM_START.raw_value(),
+            mem_end.unchecked_offset_from(layout::HIGH_RAM_START) + 1,
+            E820_RAM,
+        )?;
+    } else {
+        add_memmap_entry(
+            &mut memmap,
+            layout::HIGH_RAM_START.raw_value(),
+            layout::MEM_32BIT_RESERVED_START.unchecked_offset_from(layout::HIGH_RAM_START),
+            E820_RAM,
+        )?;
+        if mem_end > layout::RAM_64BIT_START {
+            add_memmap_entry(
+                &mut memmap,
+                layout::RAM_64BIT_START.raw_value(),
+                mem_end.unchecked_offset_from(layout::RAM_64BIT_START) + 1,
+                E820_RAM,
+            )?;
+        }
+    }
+
+    add_memmap_entry(
+        &mut memmap,
+        layout::PCI_MMCONFIG_START.0,
+        layout::PCI_MMCONFIG_SIZE,
+        E820_RESERVED,
+    )?;
+
+    start_info.0.memmap_entries = memmap.len() as u32;
+
+    // Copy the vector with the memmap table to the MEMMAP_START address
+    // which is already saved in the memmap_paddr field of hvm_start_info struct.
+    let mut memmap_start_addr = layout::MEMMAP_START;
+
+    guest_mem
+        .checked_offset(
+            memmap_start_addr,
+            mem::size_of::<hvm_memmap_table_entry>() * start_info.0.memmap_entries as usize,
+        )
+        .ok_or(super::Error::MemmapTablePastRamEnd)?;
+
+    // For every entry in the memmap vector, create a MemmapTableEntryWrapper
+    // and write it to guest memory.
+    for memmap_entry in memmap {
+        let map_entry_wrapper: MemmapTableEntryWrapper = MemmapTableEntryWrapper(memmap_entry);
+
+        guest_mem
+            .write_obj(map_entry_wrapper, memmap_start_addr)
+            .map_err(|_| super::Error::MemmapTableSetup)?;
+        memmap_start_addr =
+            memmap_start_addr.unchecked_add(mem::size_of::<hvm_memmap_table_entry>() as u64);
+    }
+
+    // The hvm_start_info struct itself must be stored at PVH_START_INFO
+    // address, and %rbx will be initialized to contain PVH_INFO_START prior to
+    // starting the guest, as required by the PVH ABI.
+    let start_info_addr = layout::PVH_INFO_START;
+
+    guest_mem
+        .checked_offset(start_info_addr, mem::size_of::<hvm_start_info>())
+        .ok_or(super::Error::StartInfoPastRamEnd)?;
+
+    // Write the start_info struct to guest memory.
+    guest_mem
+        .write_obj(start_info, start_info_addr)
+        .map_err(|_| super::Error::StartInfoSetup)?;
+
+    Ok(())
+}
+
+fn add_memmap_entry(
+    memmap: &mut Vec<hvm_memmap_table_entry>,
+    addr: u64,
+    size: u64,
+    mem_type: u32,
+) -> Result<(), Error> {
+    // Add the table entry to the vector
+    memmap.push(hvm_memmap_table_entry {
+        addr,
+        size,
+        type_: mem_type,
+        reserved: 0,
+    });
+
+    Ok(())
+}
+
+fn configure_64bit_boot(
+    guest_mem: &GuestMemoryMmap,
+    cmdline_addr: GuestAddress,
+    cmdline_size: usize,
+    setup_hdr: Option<setup_header>,
+    rsdp_addr: Option<GuestAddress>,
 ) -> super::Result<()> {
     const KERNEL_BOOT_FLAG_MAGIC: u16 = 0xaa55;
     const KERNEL_HDR_MAGIC: u32 = 0x53726448;
     const KERNEL_LOADER_OTHER: u8 = 0xff;
     const KERNEL_MIN_ALIGNMENT_BYTES: u32 = 0x1000000; // Must be non-zero.
-
-    // Note that this puts the mptable at the last 1k of Linux's 640k base RAM
-    mptable::setup_mptable(guest_mem, num_cpus).map_err(Error::MpTableSetup)?;
 
     let mut params: BootParamsWrapper = BootParamsWrapper(boot_params::default());
 
@@ -272,7 +410,15 @@ mod tests {
     fn test_system_configuration() {
         let no_vcpus = 4;
         let gm = GuestMemoryMmap::from_ranges(&vec![(GuestAddress(0), 0x10000)]).unwrap();
-        let config_err = configure_system(&gm, GuestAddress(0), 0, 1, None, None);
+        let config_err = configure_system(
+            &gm,
+            GuestAddress(0),
+            0,
+            1,
+            None,
+            None,
+            BootProtocol::LinuxBoot,
+        );
         assert!(config_err.is_err());
 
         // Now assigning some memory that falls before the 32bit memory hole.
@@ -284,7 +430,16 @@ mod tests {
             .map(|r| (r.0, r.1))
             .collect();
         let gm = GuestMemoryMmap::from_ranges(&ram_regions).unwrap();
-        configure_system(&gm, GuestAddress(0), 0, no_vcpus, None, None).unwrap();
+        configure_system(
+            &gm,
+            GuestAddress(0),
+            0,
+            no_vcpus,
+            None,
+            None,
+            BootProtocol::LinuxBoot,
+        )
+        .unwrap();
 
         // Now assigning some memory that is equal to the start of the 32bit memory hole.
         let mem_size = 3328 << 20;
@@ -295,7 +450,16 @@ mod tests {
             .map(|r| (r.0, r.1))
             .collect();
         let gm = GuestMemoryMmap::from_ranges(&ram_regions).unwrap();
-        configure_system(&gm, GuestAddress(0), 0, no_vcpus, None, None).unwrap();
+        configure_system(
+            &gm,
+            GuestAddress(0),
+            0,
+            no_vcpus,
+            None,
+            None,
+            BootProtocol::LinuxBoot,
+        )
+        .unwrap();
 
         // Now assigning some memory that falls after the 32bit memory hole.
         let mem_size = 3330 << 20;
@@ -306,7 +470,16 @@ mod tests {
             .map(|r| (r.0, r.1))
             .collect();
         let gm = GuestMemoryMmap::from_ranges(&ram_regions).unwrap();
-        configure_system(&gm, GuestAddress(0), 0, no_vcpus, None, None).unwrap();
+        configure_system(
+            &gm,
+            GuestAddress(0),
+            0,
+            no_vcpus,
+            None,
+            None,
+            BootProtocol::LinuxBoot,
+        )
+        .unwrap();
     }
 
     #[test]

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -1,3 +1,5 @@
+// Copyright © 2020, Oracle and/or its affiliates.
+//
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -13,6 +15,7 @@ pub mod regs;
 
 use crate::RegionType;
 use linux_loader::loader::bootparam::{boot_params, setup_header};
+use linux_loader::loader::start_info::{hvm_memmap_table_entry, hvm_start_info};
 use std::mem;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, GuestUsize,
@@ -20,6 +23,22 @@ use vm_memory::{
 
 const E820_RAM: u32 = 1;
 const E820_RESERVED: u32 = 2;
+
+// This is a workaround to the Rust enforcement specifying that any implementation of a foreign
+// trait (in this case `DataInit`) where:
+// *    the type that is implementing the trait is foreign or
+// *    all of the parameters being passed to the trait (if there are any) are also foreign
+// is prohibited.
+#[derive(Copy, Clone, Default)]
+struct StartInfoWrapper(hvm_start_info);
+
+// It is safe to initialize StartInfoWrapper which is a wrapper over `hvm_start_info` (a series of ints).
+unsafe impl ByteValued for StartInfoWrapper {}
+
+#[derive(Copy, Clone, Default)]
+struct MemmapTableEntryWrapper(hvm_memmap_table_entry);
+
+unsafe impl ByteValued for MemmapTableEntryWrapper {}
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
 // trait (in this case `DataInit`) where:

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -21,6 +21,32 @@ use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, GuestUsize,
 };
 
+#[derive(Debug, Copy, Clone)]
+pub enum BootProtocol {
+    LinuxBoot,
+    PvhBoot,
+}
+
+impl ::std::fmt::Display for BootProtocol {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        match self {
+            BootProtocol::LinuxBoot => write!(f, "Linux 64-bit boot protocol"),
+            BootProtocol::PvhBoot => write!(f, "PVH boot protocol"),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+/// Specifies the entry point address where the guest must start
+/// executing code, as well as which of the supported boot protocols
+/// is to be used to configure the guest initial state.
+pub struct EntryPoint {
+    /// Address in guest memory where the guest must start execution
+    pub entry_addr: GuestAddress,
+    /// Specifies which boot protocol to use
+    pub protocol: BootProtocol,
+}
+
 const E820_RAM: u32 = 1;
 const E820_RESERVED: u32 = 2;
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -441,6 +441,17 @@ mod tests {
         )
         .unwrap();
 
+        configure_system(
+            &gm,
+            GuestAddress(0),
+            0,
+            no_vcpus,
+            None,
+            None,
+            BootProtocol::PvhBoot,
+        )
+        .unwrap();
+
         // Now assigning some memory that is equal to the start of the 32bit memory hole.
         let mem_size = 3328 << 20;
         let arch_mem_regions = arch_memory_regions(mem_size);
@@ -461,6 +472,17 @@ mod tests {
         )
         .unwrap();
 
+        configure_system(
+            &gm,
+            GuestAddress(0),
+            0,
+            no_vcpus,
+            None,
+            None,
+            BootProtocol::PvhBoot,
+        )
+        .unwrap();
+
         // Now assigning some memory that falls after the 32bit memory hole.
         let mem_size = 3330 << 20;
         let arch_mem_regions = arch_memory_regions(mem_size);
@@ -478,6 +500,17 @@ mod tests {
             None,
             None,
             BootProtocol::LinuxBoot,
+        )
+        .unwrap();
+
+        configure_system(
+            &gm,
+            GuestAddress(0),
+            0,
+            no_vcpus,
+            None,
+            None,
+            BootProtocol::PvhBoot,
         )
         .unwrap();
     }
@@ -520,5 +553,30 @@ mod tests {
             e820_table[0].type_
         )
         .is_err());
+    }
+
+    #[test]
+    fn test_add_memmap_entry() {
+        let mut memmap: Vec<hvm_memmap_table_entry> = Vec::new();
+
+        let expected_memmap = vec![
+            hvm_memmap_table_entry {
+                addr: 0x0,
+                size: 0x1000,
+                type_: E820_RAM,
+                ..Default::default()
+            },
+            hvm_memmap_table_entry {
+                addr: 0x10000,
+                size: 0xa000,
+                type_: E820_RESERVED,
+                ..Default::default()
+            },
+        ];
+
+        add_memmap_entry(&mut memmap, 0, 0x1000, E820_RAM).unwrap();
+        add_memmap_entry(&mut memmap, 0x10000, 0xa000, E820_RESERVED).unwrap();
+
+        assert_eq!(format!("{:?}", memmap), format!("{:?}", expected_memmap));
     }
 }

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -1,3 +1,5 @@
+// Copyright © 2020, Oracle and/or its affiliates.
+//
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -8,10 +10,11 @@
 use std::{mem, result};
 
 use super::gdt::{gdt_entry, kvm_segment_from_gdt};
+use super::BootProtocol;
 use arch_gen::x86::msr_index;
 use kvm_bindings::{kvm_fpu, kvm_msr_entry, kvm_regs, kvm_sregs, Msrs};
 use kvm_ioctls::VcpuFd;
-use layout::{BOOT_GDT_START, BOOT_IDT_START, PDE_START, PDPTE_START, PML4_START};
+use layout::{BOOT_GDT_START, BOOT_IDT_START, PDE_START, PDPTE_START, PML4_START, PVH_INFO_START};
 use vm_memory::{Address, Bytes, GuestMemory, GuestMemoryError, GuestMemoryMmap};
 
 // MTRR constants
@@ -81,16 +84,31 @@ pub fn setup_msrs(vcpu: &VcpuFd) -> Result<()> {
 /// * `boot_ip` - Starting instruction pointer.
 /// * `boot_sp` - Starting stack pointer.
 /// * `boot_si` - Must point to zero page address per Linux ABI.
-pub fn setup_regs(vcpu: &VcpuFd, boot_ip: u64, boot_sp: u64, boot_si: u64) -> Result<()> {
-    let regs: kvm_regs = kvm_regs {
-        rflags: 0x0000000000000002u64,
-        rip: boot_ip,
-        rsp: boot_sp,
-        rbp: boot_sp,
-        rsi: boot_si,
-        ..Default::default()
+pub fn setup_regs(
+    vcpu: &VcpuFd,
+    boot_ip: u64,
+    boot_sp: u64,
+    boot_si: u64,
+    boot_prot: BootProtocol,
+) -> Result<()> {
+    let regs: kvm_regs = match boot_prot {
+        // Configure regs as required by PVH boot protocol.
+        BootProtocol::PvhBoot => kvm_regs {
+            rflags: 0x0000000000000002u64,
+            rbx: PVH_INFO_START.raw_value(),
+            rip: boot_ip,
+            ..Default::default()
+        },
+        // Configure regs as required by Linux 64-bit boot protocol.
+        BootProtocol::LinuxBoot => kvm_regs {
+            rflags: 0x0000000000000002u64,
+            rip: boot_ip,
+            rsp: boot_sp,
+            rbp: boot_sp,
+            rsi: boot_si,
+            ..Default::default()
+        },
     };
-
     vcpu.set_regs(&regs).map_err(Error::SetBaseRegisters)
 }
 
@@ -100,11 +118,14 @@ pub fn setup_regs(vcpu: &VcpuFd, boot_ip: u64, boot_sp: u64, boot_si: u64) -> Re
 ///
 /// * `mem` - The memory that will be passed to the guest.
 /// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
-pub fn setup_sregs(mem: &GuestMemoryMmap, vcpu: &VcpuFd) -> Result<()> {
+pub fn setup_sregs(mem: &GuestMemoryMmap, vcpu: &VcpuFd, boot_prot: BootProtocol) -> Result<()> {
     let mut sregs: kvm_sregs = vcpu.get_sregs().map_err(Error::GetStatusRegisters)?;
 
-    configure_segments_and_sregs(mem, &mut sregs)?;
-    setup_page_tables(mem, &mut sregs)?; // TODO(dgreid) - Can this be done once per system instead?
+    configure_segments_and_sregs(mem, &mut sregs, boot_prot)?;
+
+    if let BootProtocol::LinuxBoot = boot_prot {
+        setup_page_tables(mem, &mut sregs)?; // TODO(dgreid) - Can this be done once per system instead?
+    }
 
     vcpu.set_sregs(&sregs).map_err(Error::SetStatusRegisters)
 }
@@ -136,13 +157,31 @@ fn write_idt_value(val: u64, guest_mem: &GuestMemoryMmap) -> Result<()> {
         .map_err(Error::WriteIDT)
 }
 
-fn configure_segments_and_sregs(mem: &GuestMemoryMmap, sregs: &mut kvm_sregs) -> Result<()> {
-    let gdt_table: [u64; BOOT_GDT_MAX as usize] = [
-        gdt_entry(0, 0, 0),            // NULL
-        gdt_entry(0xa09b, 0, 0xfffff), // CODE
-        gdt_entry(0xc093, 0, 0xfffff), // DATA
-        gdt_entry(0x808b, 0, 0xfffff), // TSS
-    ];
+fn configure_segments_and_sregs(
+    mem: &GuestMemoryMmap,
+    sregs: &mut kvm_sregs,
+    boot_prot: BootProtocol,
+) -> Result<()> {
+    let gdt_table: [u64; BOOT_GDT_MAX as usize] = match boot_prot {
+        BootProtocol::PvhBoot => {
+            // Configure GDT entries as specified by PVH boot protocol
+            [
+                gdt_entry(0, 0, 0),               // NULL
+                gdt_entry(0xc09b, 0, 0xffffffff), // CODE
+                gdt_entry(0xc093, 0, 0xffffffff), // DATA
+                gdt_entry(0x008b, 0, 0x67),       // TSS
+            ]
+        }
+        BootProtocol::LinuxBoot => {
+            // Configure GDT entries as specified by Linux 64bit boot protocol
+            [
+                gdt_entry(0, 0, 0),            // NULL
+                gdt_entry(0xa09b, 0, 0xfffff), // CODE
+                gdt_entry(0xc093, 0, 0xfffff), // DATA
+                gdt_entry(0x808b, 0, 0xfffff), // TSS
+            ]
+        }
+    };
 
     let code_seg = kvm_segment_from_gdt(gdt_table[1], 1);
     let data_seg = kvm_segment_from_gdt(gdt_table[2], 2);
@@ -165,9 +204,17 @@ fn configure_segments_and_sregs(mem: &GuestMemoryMmap, sregs: &mut kvm_sregs) ->
     sregs.ss = data_seg;
     sregs.tr = tss_seg;
 
-    /* 64-bit protected mode */
-    sregs.cr0 |= X86_CR0_PE;
-    sregs.efer |= EFER_LME | EFER_LMA;
+    match boot_prot {
+        BootProtocol::PvhBoot => {
+            sregs.cr0 = X86_CR0_PE;
+            sregs.cr4 = 0;
+        }
+        BootProtocol::LinuxBoot => {
+            /* 64-bit protected mode */
+            sregs.cr0 |= X86_CR0_PE;
+            sregs.efer |= EFER_LME | EFER_LMA;
+        }
+    }
 
     Ok(())
 }
@@ -280,7 +327,7 @@ mod tests {
     fn segments_and_sregs() {
         let mut sregs: kvm_sregs = Default::default();
         let gm = create_guest_mem();
-        configure_segments_and_sregs(&gm, &mut sregs).unwrap();
+        configure_segments_and_sregs(&gm, &mut sregs, BootProtocol::LinuxBoot).unwrap();
 
         assert_eq!(0x0, read_u64(&gm, BOOT_GDT_START));
         assert_eq!(
@@ -298,13 +345,13 @@ mod tests {
         assert_eq!(0x0, read_u64(&gm, BOOT_IDT_START));
 
         assert_eq!(0, sregs.cs.base);
-        assert_eq!(0xfffff, sregs.ds.limit);
+        assert_eq!(0xffffffff, sregs.ds.limit);
         assert_eq!(0x10, sregs.es.selector);
         assert_eq!(1, sregs.fs.present);
         assert_eq!(1, sregs.gs.g);
         assert_eq!(0, sregs.ss.avl);
         assert_eq!(0, sregs.tr.base);
-        assert_eq!(0xfffff, sregs.tr.limit);
+        assert_eq!(0xffffffff, sregs.tr.limit);
         assert_eq!(0, sregs.tr.avl);
         assert_eq!(X86_CR0_PE, sregs.cr0);
         assert_eq!(EFER_LME | EFER_LMA, sregs.efer);
@@ -398,6 +445,7 @@ mod tests {
             expected_regs.rip,
             expected_regs.rsp,
             expected_regs.rsi,
+            BootProtocol::LinuxBoot,
         )
         .unwrap();
 
@@ -413,10 +461,10 @@ mod tests {
 
         let mut expected_sregs: kvm_sregs = vcpu.get_sregs().unwrap();
         let gm = create_guest_mem();
-        configure_segments_and_sregs(&gm, &mut expected_sregs).unwrap();
+        configure_segments_and_sregs(&gm, &mut expected_sregs, BootProtocol::LinuxBoot).unwrap();
         setup_page_tables(&gm, &mut expected_sregs).unwrap();
 
-        setup_sregs(&gm, &vcpu).unwrap();
+        setup_sregs(&gm, &vcpu, BootProtocol::LinuxBoot).unwrap();
         let actual_sregs: kvm_sregs = vcpu.get_sregs().unwrap();
         assert_eq!(expected_sregs, actual_sregs);
     }

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -355,6 +355,36 @@ mod tests {
         assert_eq!(0, sregs.tr.avl);
         assert_eq!(X86_CR0_PE, sregs.cr0);
         assert_eq!(EFER_LME | EFER_LMA, sregs.efer);
+
+        configure_segments_and_sregs(&gm, &mut sregs, BootProtocol::PvhBoot).unwrap();
+        assert_eq!(0x0, read_u64(&gm, BOOT_GDT_START));
+        assert_eq!(
+            0xcf9b000000ffff,
+            read_u64(&gm, BOOT_GDT_START.unchecked_add(8))
+        );
+        assert_eq!(
+            0xcf93000000ffff,
+            read_u64(&gm, BOOT_GDT_START.unchecked_add(16))
+        );
+        assert_eq!(
+            0x8b0000000067,
+            read_u64(&gm, BOOT_GDT_START.unchecked_add(24))
+        );
+        assert_eq!(0x0, read_u64(&gm, BOOT_IDT_START));
+
+        assert_eq!(0, sregs.cs.base);
+        assert_eq!(0xffffffff, sregs.ds.limit);
+        assert_eq!(0x10, sregs.es.selector);
+        assert_eq!(1, sregs.fs.present);
+        assert_eq!(1, sregs.gs.g);
+        assert_eq!(0, sregs.ss.avl);
+        assert_eq!(0, sregs.tr.base);
+        assert_eq!(0, sregs.tr.g);
+        assert_eq!(0x67, sregs.tr.limit);
+        assert_eq!(0xb, sregs.tr.type_);
+        assert_eq!(0, sregs.tr.avl);
+        assert_eq!(X86_CR0_PE, sregs.cr0);
+        assert_eq!(0, sregs.cr4);
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1052,6 +1052,51 @@ mod tests {
         });
     }
 
+    #[cfg_attr(feature = "pvh_boot", test)]
+    fn test_pvh_boot() {
+        test_block!(tb, "", {
+            let mut clear = ClearDiskConfig::new();
+            let guest = Guest::new(&mut clear);
+            let mut workload_path = dirs::home_dir().unwrap();
+            workload_path.push("workloads");
+
+            let mut kernel_path = workload_path;
+            kernel_path.push("vmlinux.pvh");
+
+            let mut child = GuestCommand::new(&guest)
+                .args(&["--cpus","boot=1"])
+                .args(&["--memory", "size=512M"])
+                .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .default_disks()
+                .default_net()
+                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw"])
+                .spawn()
+                .unwrap();
+
+            thread::sleep(std::time::Duration::new(20, 0));
+
+            aver_eq!(tb, guest.get_cpu_count().unwrap_or_default(), 1);
+            aver!(tb, guest.get_total_memory().unwrap_or_default() > 496_000);
+            aver!(tb, guest.get_entropy().unwrap_or_default() >= 900);
+
+            #[cfg(not(feature = "mmio"))]
+            aver_eq!(
+                tb,
+                guest
+                    .ssh_command("grep -c PCI-MSI /proc/interrupts")
+                    .unwrap_or_default()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default(),
+                12
+            );
+
+            let _ = child.kill();
+            let _ = child.wait();
+            Ok(())
+        });
+    }
+
     #[test]
     fn test_bzimage_boot() {
         test_block!(tb, "", {

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -10,6 +10,7 @@ acpi = ["acpi_tables","devices/acpi"]
 pci_support = ["pci", "vfio", "vm-virtio/pci_support"]
 mmio_support = ["vm-virtio/mmio_support"]
 cmos = ["devices/cmos"]
+pvh_boot = []
 
 [dependencies]
 arc-swap = ">=0.4.4"

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -296,11 +296,16 @@ impl Vcpu {
                 kernel_entry_point.entry_addr.raw_value(),
                 arch::x86_64::layout::BOOT_STACK_POINTER.raw_value(),
                 arch::x86_64::layout::ZERO_PAGE_START.raw_value(),
+                kernel_entry_point.protocol,
             )
             .map_err(Error::REGSConfiguration)?;
             arch::x86_64::regs::setup_fpu(&self.fd).map_err(Error::FPUConfiguration)?;
-            arch::x86_64::regs::setup_sregs(&vm_memory.memory(), &self.fd)
-                .map_err(Error::SREGSConfiguration)?;
+            arch::x86_64::regs::setup_sregs(
+                &vm_memory.memory(),
+                &self.fd,
+                kernel_entry_point.protocol,
+            )
+            .map_err(Error::SREGSConfiguration)?;
         }
         arch::x86_64::interrupts::set_lint(&self.fd).map_err(Error::LocalIntConfiguration)?;
         Ok(())

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -446,6 +446,7 @@ impl Vm {
                     boot_vcpus,
                     Some(hdr),
                     rsdp_addr,
+                    BootProtocol::LinuxBoot,
                 )
                 .map_err(Error::ConfigureSystem)?;
 
@@ -480,6 +481,7 @@ impl Vm {
                     boot_vcpus,
                     None,
                     rsdp_addr,
+                    boot_prot,
                 )
                 .map_err(Error::ConfigureSystem)?;
 


### PR DESCRIPTION
Minimal changes for booting guests using the PVH boot protocol. Relies on proposed patches to RustVMM linux-loader, see issue and linked PR: https://github.com/rust-vmm/linux-loader/issues/3

I have done basic testing of booting a guest successfully using the PVH entry point. Will be focusing next on benchmarking boot times against typical 64 bit boot protocol.

I have similar questions to the ones posted in the linux-loader PR concerning the copyright messages. With regard to design decisions, I would particularly like feedback regarding the addition of the new EntryPoint struct, and the changes made to get_limit() which are documented in the comment.

Closes #131 