### PR TITLE
vhost_rs: control SlaveFsCacheReq with vhost-user-slave feature

### DIFF
--- a/vhost_rs/src/vhost_user/mod.rs
+++ b/vhost_rs/src/vhost_user/mod.rs
@@ -43,6 +43,7 @@ mod slave_req_handler;
 pub use self::slave_req_handler::{SlaveReqHandler, VhostUserSlaveReqHandler};
 #[cfg(feature = "vhost-user-slave")]
 mod slave_fs_cache;
+#[cfg(feature = "vhost-user-slave")]
 pub use self::slave_fs_cache::SlaveFsCacheReq;
 
 pub mod sock_ctrl_msg;


### PR DESCRIPTION
We import slave_fs_cache mod under vhost-user-slave feature control,
but not the self::slave_fs_cache::SlaveFsCacheReq import.

Fixes: #814
Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>