### PR TITLE
vmm: Move DeviceManager into an Arc<Mutex<>>

### DIFF
--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -80,14 +80,14 @@ struct IortIdMapping {
 }
 
 pub fn create_dsdt_table(
-    device_manager: &DeviceManager,
+    device_manager: &Arc<Mutex<DeviceManager>>,
     cpu_manager: &Arc<Mutex<CpuManager>>,
     memory_manager: &Arc<Mutex<MemoryManager>>,
 ) -> SDT {
     // DSDT
     let mut dsdt = SDT::new(*b"DSDT", 36, 6, *b"CLOUDH", *b"CHDSDT  ", 1);
 
-    dsdt.append_slice(device_manager.to_aml_bytes().as_slice());
+    dsdt.append_slice(device_manager.lock().unwrap().to_aml_bytes().as_slice());
     dsdt.append_slice(cpu_manager.lock().unwrap().to_aml_bytes().as_slice());
     dsdt.append_slice(memory_manager.lock().unwrap().to_aml_bytes().as_slice());
 
@@ -96,7 +96,7 @@ pub fn create_dsdt_table(
 
 pub fn create_acpi_tables(
     guest_mem: &GuestMemoryMmap,
-    device_manager: &DeviceManager,
+    device_manager: &Arc<Mutex<DeviceManager>>,
     cpu_manager: &Arc<Mutex<CpuManager>>,
     memory_manager: &Arc<Mutex<MemoryManager>>,
 ) -> GuestAddress {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -494,7 +494,7 @@ impl CpuManager {
     pub fn new(
         boot_vcpus: u8,
         max_vcpus: u8,
-        device_manager: &DeviceManager,
+        device_manager: &Arc<Mutex<DeviceManager>>,
         guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
         fd: Arc<VmFd>,
         cpuid: CpuId,
@@ -503,6 +503,7 @@ impl CpuManager {
         let mut vcpu_states = Vec::with_capacity(usize::from(max_vcpus));
         vcpu_states.resize_with(usize::from(max_vcpus), VcpuState::default);
 
+        let device_manager = device_manager.lock().unwrap();
         let cpu_manager = Arc::new(Mutex::new(CpuManager {
             boot_vcpus,
             max_vcpus,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -440,7 +440,7 @@ impl DeviceManager {
         _exit_evt: &EventFd,
         reset_evt: &EventFd,
         vmm_path: PathBuf,
-    ) -> DeviceManagerResult<Self> {
+    ) -> DeviceManagerResult<Arc<Mutex<Self>>> {
         let io_bus = devices::Bus::new();
         let mmio_bus = devices::Bus::new();
 
@@ -543,7 +543,7 @@ impl DeviceManager {
 
         device_manager.virtio_devices = virtio_devices;
 
-        Ok(device_manager)
+        Ok(Arc::new(Mutex::new(device_manager)))
     }
 
     #[allow(unused_variables)]


### PR DESCRIPTION
In anticipation of the support for device hotplug, this commit moves the
DeviceManager object into an Arc<Mutex<>> when the DeviceManager is
being created. The reason is, we need the DeviceManager to implement the
BusDevice trait and then provide it to the IO bus, so that IO accesses
related to device hotplug can be handled correctly.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>