### PR TITLE
vhost-user-net: Allow reuse of existing tap interface

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -161,6 +161,11 @@ sudo ip tuntap add vfio-tap3 mode tap
 sudo ip link set vfio-tap3 master vfio-br0
 sudo ip link set vfio-tap3 up
 
+# Create tap interface without multipe queues support for vhost_user_net test.
+sudo ip tuntap add name vunet-tap0 mode tap
+# Create tap interface with multipe queues support for vhost_user_net test.
+sudo ip tuntap add name vunet-tap1 mode tap multi_queue
+
 cargo build --release
 sudo setcap cap_net_admin+ep target/release/cloud-hypervisor
 sudo setcap cap_net_admin+ep target/release/vhost_user_net
@@ -208,5 +213,9 @@ sudo ip link del vfio-tap0
 sudo ip link del vfio-tap1
 sudo ip link del vfio-tap2
 sudo ip link del vfio-tap3
+
+# Tear vhost_user_net test network down
+sudo ip link del vunet-tap0
+sudo ip link del vunet-tap1
 
 exit $RES

--- a/src/bin/vhost_user_net.rs
+++ b/src/bin/vhost_user_net.rs
@@ -25,7 +25,8 @@ fn main() {
                     "vhost-user-net backend parameters \"ip=<ip_addr>,\
                      mask=<net_mask>,sock=<socket_path>,\
                      num_queues=<number_of_queues>,\
-                     queue_size=<size_of_each_queue>\"",
+                     queue_size=<size_of_each_queue>,\
+                     tap=<if_name>\"",
                 )
                 .takes_value(true)
                 .min_values(1),

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,7 +264,8 @@ fn create_app<'a, 'b>(
                     "vhost-user-net backend parameters \"ip=<ip_addr>,\
                      mask=<net_mask>,sock=<socket_path>,\
                      num_queues=<number_of_queues>,\
-                     queue_size=<size_of_each_queue>\"",
+                     queue_size=<size_of_each_queue>,\
+                     tap=<if_name>\"",
                 )
                 .takes_value(true)
                 .conflicts_with_all(&["block-backend", "kernel"])


### PR DESCRIPTION
Add tap option for vhost-user-net backend, it will allow to use the existing Tap interface.

Fix #742 