### PR TITLE
vmm/api: Fix vm.info response definition

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -161,7 +161,7 @@ components:
           $ref: '#/components/schemas/VmConfig'
         state:
           type: string
-          enum: [Created, Booted, Shutdown]
+          enum: [Created, Running, Shutdown, Paused]
       description: Virtual Machine information
 
     VmConfig:
@@ -385,7 +385,7 @@ components:
           type: string
         mode:
           type: string
-          enum: [Off, Tty, File, None]
+          enum: [Off, Tty, File, Null]
         iommu:
           type: boolean
           default: false


### PR DESCRIPTION
Update cloud-hypervisor.yaml with latest code.

Fixes: #841

Signed-off-by: liubin <liubin0329@gmail.com>