### PR TITLE
vm-virtio: vhost_user: Fix blk device configuration space offset value

### DIFF
--- a/vm-virtio/src/vhost_user/blk.rs
+++ b/vm-virtio/src/vhost_user/blk.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::thread;
 use std::vec::Vec;
 use vhost_rs::vhost_user::message::VhostUserConfigFlags;
+use vhost_rs::vhost_user::message::VHOST_USER_CONFIG_OFFSET;
 use vhost_rs::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
 use vhost_rs::vhost_user::{Master, VhostUserMaster, VhostUserMasterReqHandler};
 use vhost_rs::VhostBackend;
@@ -116,7 +117,7 @@ impl Blk {
         let config_space: Vec<u8> = vec![0u8; config_len as usize];
         let (_, config_space) = vhost_user_blk
             .get_config(
-                0,
+                VHOST_USER_CONFIG_OFFSET,
                 config_len as u32,
                 VhostUserConfigFlags::WRITABLE,
                 config_space.as_slice(),


### PR DESCRIPTION
Current device configuration space offset value is 0, we need to
update that value to VHOST_USER_CONFIG_OFFSET(0x100) to follow the spec

Fixes #844

Signed-off-by: Arron Wang <arron.wang@intel.com>