### PR TITLE
Support virtio-mmio with virtio-fs 

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1754,27 +1754,22 @@ mod tests {
         });
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_fs_dax_on_default_cache_size() {
         test_virtio_fs(true, None, "none", &prepare_virtiofsd)
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_fs_dax_on_cache_size_1_gib() {
         test_virtio_fs(true, Some(0x4000_0000), "none", &prepare_virtiofsd)
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_fs_dax_off() {
         test_virtio_fs(false, None, "none", &prepare_virtiofsd)
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_fs_dax_on_default_cache_size_w_vhost_user_fs_daemon() {
         test_virtio_fs(true, None, "none", &prepare_vhost_user_fs_daemon)
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_fs_dax_on_cache_size_1_gib_w_vhost_user_fs_daemon() {
         test_virtio_fs(
             true,
@@ -1784,7 +1779,6 @@ mod tests {
         )
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_fs_dax_off_w_vhost_user_fs_daemon() {
         test_virtio_fs(false, None, "none", &prepare_vhost_user_fs_daemon)
     }


### PR DESCRIPTION
Add the missing virtio-mmio configuration fields to support shm regions which is necessary for virtio-fs. Enable the virtio-fs tests to run with virtio-mmio.

Fixes: #750