### PR TITLE
vmm: Move Weak BusDevice references to Bus structure

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -507,7 +507,7 @@ impl CpuManager {
         let cpu_manager = Arc::new(Mutex::new(CpuManager {
             boot_vcpus,
             max_vcpus,
-            io_bus: device_manager.io_bus(),
+            io_bus: device_manager.io_bus().clone(),
             mmio_bus: device_manager.mmio_bus().clone(),
             ioapic: device_manager.ioapic().clone(),
             vm_memory: guest_memory,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -630,7 +630,7 @@ impl DeviceManager {
             let pci_root = PciRoot::new(None);
             let mut pci_bus = PciBus::new(
                 pci_root,
-                Arc::downgrade(&self.address_manager) as Weak<dyn DeviceRelocation>,
+                Arc::clone(&self.address_manager) as Arc<dyn DeviceRelocation>,
             );
 
             let (iommu_device, iommu_mapping) = if self.config.lock().unwrap().iommu {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -474,7 +474,6 @@ impl DeviceManager {
         _exit_evt: &EventFd,
         reset_evt: &EventFd,
         vmm_path: PathBuf,
-        io_bus: &Arc<devices::Bus>,
     ) -> DeviceManagerResult<Arc<Mutex<Self>>> {
         let mut virtio_devices: Vec<(Arc<Mutex<dyn vm_virtio::VirtioDevice>>, bool)> = Vec::new();
         let migratable_devices: Vec<Arc<Mutex<dyn Migratable>>> = Vec::new();
@@ -486,7 +485,7 @@ impl DeviceManager {
 
         let address_manager = Arc::new(AddressManager {
             allocator,
-            io_bus: Arc::clone(io_bus),
+            io_bus: Arc::new(devices::Bus::new()),
             mmio_bus: Arc::new(devices::Bus::new()),
             vm_fd: vm_fd.clone(),
         });

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -222,8 +222,6 @@ pub struct Vm {
     state: RwLock<VmState>,
     cpu_manager: Arc<Mutex<cpu::CpuManager>>,
     memory_manager: Arc<Mutex<MemoryManager>>,
-    // Hold the strong reference onto the IO bus.
-    _io_bus: Arc<devices::Bus>,
 }
 
 impl Vm {
@@ -331,8 +329,6 @@ impl Vm {
             .ok_or(Error::CreateSystemAllocator)?,
         ));
 
-        let io_bus = Arc::new(devices::Bus::new());
-
         let memory_config = config.lock().unwrap().memory.clone();
 
         let memory_manager = MemoryManager::new(
@@ -355,7 +351,6 @@ impl Vm {
             &exit_evt,
             &reset_evt,
             vmm_path,
-            &io_bus,
         )
         .map_err(Error::DeviceManager)?;
 
@@ -384,7 +379,6 @@ impl Vm {
             state: RwLock::new(VmState::Created),
             cpu_manager,
             memory_manager,
-            _io_bus: io_bus,
         })
     }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -621,7 +621,13 @@ impl Vm {
             .start_boot_vcpus(entry_addr)
             .map_err(Error::CpuManager)?;
 
-        if self.device_manager.lock().unwrap().console().input_enabled() {
+        if self
+            .device_manager
+            .lock()
+            .unwrap()
+            .console()
+            .input_enabled()
+        {
             let console = self.device_manager.lock().unwrap().console().clone();
             let signals = Signals::new(&[SIGWINCH, SIGINT, SIGTERM]);
             match signals {
@@ -660,7 +666,13 @@ impl Vm {
             .read_raw(&mut out)
             .map_err(Error::Console)?;
 
-        if self.device_manager.lock().unwrap().console().input_enabled() {
+        if self
+            .device_manager
+            .lock()
+            .unwrap()
+            .console()
+            .input_enabled()
+        {
             self.device_manager
                 .lock()
                 .unwrap()


### PR DESCRIPTION
By moving the weak references to the Bus structure, the whole codebase gets simplified and cleaned up through this pull request.