### PR TITLE
build: Bump linux-loader and vm-memory dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@
 name = "acpi_tables"
 version = "0.1.0"
 dependencies = [
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -20,7 +20,7 @@ name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -45,7 +45,7 @@ dependencies = [
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "linux-loader 0.1.0 (git+https://github.com/rust-vmm/linux-loader)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -69,7 +69,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -181,7 +181,7 @@ dependencies = [
  "vhost_user_net 0.1.0",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-device 0.1.0",
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-virtio 0.1.0",
  "vmm 0.1.0",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -231,7 +231,7 @@ dependencies = [
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-device 0.1.0",
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -252,7 +252,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -389,9 +389,9 @@ dependencies = [
 [[package]]
 name = "linux-loader"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/linux-loader#e5c6d66d3121421672c9b25b02e8954f0ed5f58d"
+source = "git+https://github.com/rust-vmm/linux-loader#8cb7c6621bec18afdb193447b5aaf671cc630ec3"
 dependencies = [
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ dependencies = [
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -496,7 +496,7 @@ dependencies = [
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -628,7 +628,7 @@ dependencies = [
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -736,7 +736,7 @@ name = "remove_dir_all"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -919,7 +919,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1010,7 +1010,7 @@ dependencies = [
  "vfio-bindings 0.1.0 (git+https://github.com/rust-vmm/vfio-bindings)",
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1041,7 +1041,7 @@ dependencies = [
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-virtio 0.1.0",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1058,7 +1058,7 @@ dependencies = [
  "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
  "vhost_user_backend 0.1.0",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-virtio 0.1.0",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1071,7 +1071,7 @@ dependencies = [
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-virtio 0.1.0",
 ]
 
@@ -1087,7 +1087,7 @@ dependencies = [
  "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
  "vhost_user_backend 0.1.0",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-virtio 0.1.0",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1107,7 +1107,7 @@ name = "vm-allocator"
 version = "0.1.0"
 dependencies = [
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1119,18 +1119,18 @@ dependencies = [
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "vm-memory"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vm-memory#a84a7b8f531e9102f884bfbe7c97147fbe91a317"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1151,7 +1151,7 @@ dependencies = [
  "virtio-bindings 0.1.0 (git+https://github.com/rust-vmm/virtio-bindings)",
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1184,7 +1184,7 @@ dependencies = [
  "vfio 0.0.1",
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",
- "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
+ "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-virtio 0.1.0",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1209,7 +1209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1353,11 +1353,11 @@ dependencies = [
 "checksum vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)" = "<none>"
 "checksum virtio-bindings 0.1.0 (git+https://github.com/rust-vmm/virtio-bindings)" = "<none>"
 "checksum virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
-"checksum vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)" = "<none>"
+"checksum vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d5563ea4d856645b13bc9623e6a0617457a77555a22301d896597cbc5131c2b"
 "checksum vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "048b10a74f061d87dacca196a1964052a7135651641ab8d100aef21e58f33571"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
+"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ vhost_user_net = { path = "vhost_user_net"}
 virtio-bindings = "0.1.0"
 vmm = { path = "vmm" }
 vm-device = { path = "vm-device" }
-vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
-vmm-sys-util = ">=0.3.1"
+vm-memory = "0.1.0"
+vmm-sys-util = "0.4.0"
 vm-virtio = { path = "vm-virtio" }
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }
 

--- a/acpi_tables/Cargo.toml
+++ b/acpi_tables/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 
 [dependencies]
-vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
+vm-memory = "0.1.0"
 

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -11,13 +11,10 @@ byteorder = "1.3.4"
 kvm-bindings = "0.2.0"
 kvm-ioctls = "0.5.0"
 libc = "0.2.67"
+vm-memory = { version = "0.1.0", features = ["backend-mmap"] }
 
 acpi_tables = { path = "../acpi_tables", optional = true }
 arch_gen = { path = "../arch_gen" }
-
-[dependencies.vm-memory]
-git = "https://github.com/rust-vmm/vm-memory"
-features = ["backend-mmap"]
 
 [dependencies.linux-loader]
 git = "https://github.com/rust-vmm/linux-loader"

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -11,7 +11,7 @@ libc = "0.2.67"
 log = "0.4.8"
 vm-device = { path = "../vm-device" }
 acpi_tables = { path = "../acpi_tables", optional = true }
-vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
+vm-memory = "0.1.0"
 vmm-sys-util = ">=0.3.1"
 
 [dev-dependencies]

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -11,4 +11,4 @@ devices = { path = "../devices" }
 libc = "0.2.67"
 log = "0.4.8"
 vm-device = { path = "../vm-device" }
-vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
+vm-memory = "0.1.0"

--- a/vfio/Cargo.toml
+++ b/vfio/Cargo.toml
@@ -14,11 +14,8 @@ log = "0.4.8"
 pci = { path = "../pci" }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
+vm-memory = { version = "0.1.0", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.3.1"
-
-[dependencies.vm-memory]
-git = "https://github.com/rust-vmm/vm-memory"
-features = ["backend-mmap"]
 
 [dependencies.vfio-bindings]
 git = "https://github.com/rust-vmm/vfio-bindings"

--- a/vhost_user_backend/Cargo.toml
+++ b/vhost_user_backend/Cargo.toml
@@ -14,7 +14,7 @@ epoll = ">=4.0.1"
 libc = "0.2.67"
 log = "0.4.8"
 virtio-bindings = "0.1.0"
-vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
+vm-memory = "0.1.0"
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -13,6 +13,6 @@ qcow = { path = "../qcow" }
 vhost_user_backend = { path = "../vhost_user_backend" }
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
-vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
+vm-memory = "0.1.0"
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"

--- a/vhost_user_fs/Cargo.toml
+++ b/vhost_user_fs/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 bitflags = "1.1.0"
 libc = "0.2.67"
 log = "0.4.8"
-vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
+vm-memory = "0.1.0"
 vm-virtio = { path = "../vm-virtio" }
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -13,6 +13,6 @@ net_util = { path = "../net_util" }
 vhost_user_backend = { path = "../vhost_user_backend" }
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
-vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
+vm-memory = "0.1.0"
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.67"
-vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
+vm-memory = "0.1.0"

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -10,8 +10,6 @@ thiserror = "1.0"
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
+vm-memory = { version = "0.1.0", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.3.1"
 
-[dependencies.vm-memory]
-git = "https://github.com/rust-vmm/vm-memory"
-features = ["backend-mmap"]

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -23,9 +23,6 @@ tempfile = "3.1.0"
 virtio-bindings = { git = "https://github.com/rust-vmm/virtio-bindings", version = "0.1", features = ["virtio-v5_0_0"]}
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
+vm-memory = { version = "0.1.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = ">=0.3.1"
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-master", "vhost-user-slave"] }
-
-[dependencies.vm-memory]
-git = "https://github.com/rust-vmm/vm-memory"
-features = ["backend-mmap", "backend-atomic"]

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = ">=1.0.9"
 vfio = { path = "../vfio", optional = true }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
+vm-memory = { version = "0.1.0", features = ["backend-mmap", "backend-atomic"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 signal-hook = "0.1.13"
@@ -42,7 +43,3 @@ tempfile = "3.1.0"
 [dependencies.linux-loader]
 git = "https://github.com/rust-vmm/linux-loader"
 features = ["elf", "bzimage"]
-
-[dependencies.vm-memory]
-git = "https://github.com/rust-vmm/vm-memory"
-features = ["backend-mmap", "backend-atomic"]


### PR DESCRIPTION
linux-loader now uses the released vm-memory so we must move to that
version at the same time.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>