### PR TITLE
build: Don't cancel older master builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline{
 					}
 				}
 				stage ('Cancel older builds') {
+					when { not { branch 'master' } }
 					steps {
 						cancelPreviousBuilds()
 					}


### PR DESCRIPTION
If a new build request for master comes in don't cancel the older
builds. Cancelling older builds is very useful for PRs that are being
updated but less so for a build of the master branch that has been
triggered via a merge or a periodic build.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>