### PR TITLE
vm-virtio: Consume pause events to prevent infinite epoll_wait calls

### DIFF
--- a/vm-virtio/src/block.rs
+++ b/vm-virtio/src/block.rs
@@ -745,6 +745,8 @@ impl<T: DiskFile> BlockEpollHandler<T> {
                         break 'epoll;
                     }
                     PAUSE_EVENT => {
+                        // Drain pause event
+                        let _ = self.pause_evt.read();
                         debug!("PAUSE_EVENT received, pausing virtio-block epoll loop");
                         // We loop here to handle spurious park() returns.
                         // Until we have not resumed, the paused boolean will

--- a/vm-virtio/src/console.rs
+++ b/vm-virtio/src/console.rs
@@ -275,6 +275,8 @@ impl ConsoleEpollHandler {
                         break 'epoll;
                     }
                     PAUSE_EVENT => {
+                        // Drain pause event
+                        let _ = self.pause_evt.read();
                         debug!("PAUSE_EVENT received, pausing virtio-console epoll loop");
                         // We loop here to handle spurious park() returns.
                         // Until we have not resumed, the paused boolean will

--- a/vm-virtio/src/iommu.rs
+++ b/vm-virtio/src/iommu.rs
@@ -729,6 +729,8 @@ impl IommuEpollHandler {
                         break 'epoll;
                     }
                     PAUSE_EVENT => {
+                        // Drain pause event
+                        let _ = self.pause_evt.read();
                         debug!("PAUSE_EVENT received, pausing virtio-iommu epoll loop");
                         // We loop here to handle spurious park() returns.
                         // Until we have not resumed, the paused boolean will

--- a/vm-virtio/src/net.rs
+++ b/vm-virtio/src/net.rs
@@ -272,6 +272,8 @@ impl NetEpollHandler {
                         break 'epoll;
                     }
                     PAUSE_EVENT => {
+                        // Drain pause event
+                        let _ = self.pause_evt.read();
                         debug!("PAUSE_EVENT received, pausing virtio-net epoll loop");
                         // We loop here to handle spurious park() returns.
                         // Until we have not resumed, the paused boolean will

--- a/vm-virtio/src/net_util.rs
+++ b/vm-virtio/src/net_util.rs
@@ -269,6 +269,8 @@ impl NetCtrlEpollHandler {
                         break 'epoll;
                     }
                     PAUSE_EVENT => {
+                        // Drain pause event
+                        let _ = self.pause_evt.read();
                         debug!("PAUSE_EVENT received, pausing vhost-user epoll loop");
                         // We loop here to handle spurious park() returns.
                         // Until we have not resumed, the paused boolean will

--- a/vm-virtio/src/pmem.rs
+++ b/vm-virtio/src/pmem.rs
@@ -290,6 +290,8 @@ impl PmemEpollHandler {
                         break 'epoll;
                     }
                     PAUSE_EVENT => {
+                        // Drain pause event
+                        let _ = self.pause_evt.read();
                         debug!("PAUSE_EVENT received, pausing virtio-pmem epoll loop");
                         // We loop here to handle spurious park() returns.
                         // Until we have not resumed, the paused boolean will

--- a/vm-virtio/src/rng.rs
+++ b/vm-virtio/src/rng.rs
@@ -155,6 +155,8 @@ impl RngEpollHandler {
                         break 'epoll;
                     }
                     PAUSE_EVENT => {
+                        // Drain pause event
+                        let _ = self.pause_evt.read();
                         debug!("PAUSE_EVENT received, pausing virtio-rng epoll loop");
                         // We loop here to handle spurious park() returns.
                         // Until we have not resumed, the paused boolean will

--- a/vm-virtio/src/vhost_user/handler.rs
+++ b/vm-virtio/src/vhost_user/handler.rs
@@ -153,6 +153,8 @@ impl<S: VhostUserMasterReqHandler> VhostUserEpollHandler<S> {
                         break 'poll;
                     }
                     x if pause_evt_index == x => {
+                        // Drain pause event
+                        let _ = self.vu_epoll_cfg.pause_evt.read();
                         debug!("PAUSE_EVENT received, pausing vhost-user epoll loop");
                         // We loop here to handle spurious park() returns.
                         // Until we have not resumed, the paused boolean will

--- a/vm-virtio/src/vsock/device.rs
+++ b/vm-virtio/src/vsock/device.rs
@@ -351,6 +351,8 @@ where
                 return Ok(true);
             }
             PAUSE_EVENT => {
+                // Drain pause event
+                let _ = self.pause_evt.read();
                 debug!("PAUSE_EVENT received, pausing virtio-vsock epoll loop");
                 // We loop here to handle spurious park() returns.
                 // Until we have not resumed, the paused boolean will


### PR DESCRIPTION
When a virtio device is paused an event is written to the appropriate
"pause" EventFd for the device. This will be noticed by the the device's
epoll_wait(), an atomic bool checked an if true then the thread is
parked(). When resuming the bool is reset and the thread is unpark()ed.
However the event triggering the pause is still in the EventFd so the
epoll_wait() will continue to return but because the boolean is not set
the thread will not be park()ed but instead we will busy loop around an
event that is not being consumed.

The solution is to drain the "pause" EventFd when the event is first
received and thus the epoll_wait() will only return for the pause event
once. This resolves the infinite epoll_wait() wake-ups.

Fixes: #869

Signed-off-by: Rob Bradford <robert.bradford@intel.com>