### PR TITLE
vmm: Add support for VFIO unplug

### DIFF
--- a/devices/src/bus.rs
+++ b/devices/src/bus.rs
@@ -171,6 +171,24 @@ impl Bus {
         Ok(())
     }
 
+    /// Removes all entries referencing the given device.
+    pub fn remove_by_device(&self, device: &Arc<Mutex<dyn BusDevice>>) -> Result<()> {
+        let mut device_list = self.devices.write().unwrap();
+        let mut remove_key_list = Vec::new();
+
+        for (key, value) in device_list.iter() {
+            if Arc::ptr_eq(&value.upgrade().unwrap(), device) {
+                remove_key_list.push(*key);
+            }
+        }
+
+        for key in remove_key_list.iter() {
+            device_list.remove(key);
+        }
+
+        Ok(())
+    }
+
     /// Updates the address range for an existing device.
     pub fn update_range(
         &self,

--- a/docs/api.md
+++ b/docs/api.md
@@ -78,19 +78,20 @@ Shut the VMM down                   | `/vmm.shutdown` | N/A          | N/A      
 
 #### Virtual Machine (VM) Actions
 
-Action                           | Endpoint         | Request Body           | Response Body     | Prerequisites
----------------------------------|------------------|------------------------|-------------------|---------------------------
-Create the VM                    | `/vm.create`     | `/schemas/VmConfig`    | N/A               | The VM is not created yet
-Delete the VM                    | `/vm.delete`     | N/A                    | N/A               | The VM is created but not booted
-Boot the VM                      | `/vm.boot`       | N/A                    | N/A               | The VM is created
-Shut the VM down                 | `/vm.shutdown`   | N/A                    | N/A               | The VM is booted
-Reboot the VM                    | `/vm.reboot`     | N/A                    | N/A               | The VM is booted
-Pause the VM                     | `/vm.pause`      | N/A                    | N/A               | The VM is booted
-Resume the VM                    | `/vm.resume`     | N/A                    | N/A               | The VM is paused
-Add/remove CPUs to/from the VM   | `/vm.resize`     | `/schemas/VmResize`    | N/A               | The VM is booted
-Remove memory from the VM        | `/vm.resize`     | `/schemas/VmResize`    | N/A               | The VM is booted
-Dump the VM information          | `/vm.info`       | N/A                    | `/schemas/VmInfo` | The VM is created
-Add VFIO PCI device to the VM    | `/vm.add-device` | `/schemas/VmAddDevice` | N/A               | The VM is booted
+Action                             | Endpoint            | Request Body              | Response Body     | Prerequisites
+-----------------------------------|---------------------|---------------------------|-------------------|---------------------------
+Create the VM                      | `/vm.create`        | `/schemas/VmConfig`       | N/A               | The VM is not created yet
+Delete the VM                      | `/vm.delete`        | N/A                       | N/A               | The VM is created but not booted
+Boot the VM                        | `/vm.boot`          | N/A                       | N/A               | The VM is created
+Shut the VM down                   | `/vm.shutdown`      | N/A                       | N/A               | The VM is booted
+Reboot the VM                      | `/vm.reboot`        | N/A                       | N/A               | The VM is booted
+Pause the VM                       | `/vm.pause`         | N/A                       | N/A               | The VM is booted
+Resume the VM                      | `/vm.resume`        | N/A                       | N/A               | The VM is paused
+Add/remove CPUs to/from the VM     | `/vm.resize`        | `/schemas/VmResize`       | N/A               | The VM is booted
+Remove memory from the VM          | `/vm.resize`        | `/schemas/VmResize`       | N/A               | The VM is booted
+Dump the VM information            | `/vm.info`          | N/A                       | `/schemas/VmInfo` | The VM is created
+Add VFIO PCI device to the VM      | `/vm.add-device`    | `/schemas/VmAddDevice`    | N/A               | The VM is booted
+Remove VFIO PCI device from the VM | `/vm.remove-device` | `/schemas/VmRemoveDevice` | N/A               | The VM is booted
 
 ### REST API Examples
 

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -124,6 +124,11 @@ impl PciBus {
         Ok(())
     }
 
+    pub fn remove_by_device(&mut self, device: &Arc<Mutex<dyn PciDevice>>) -> Result<()> {
+        self.devices.retain(|dev| !Arc::ptr_eq(dev, device));
+        Ok(())
+    }
+
     pub fn next_device_id(&self) -> u32 {
         self.devices.len() as u32
     }

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -31,6 +31,8 @@ pub enum PciRootError {
     MmioInsert(devices::BusError),
     /// Could not find an available device slot on the PCI bus.
     NoPciDeviceSlotAvailable,
+    /// Invalid PCI device identifier provided.
+    InvalidPciDeviceSlot(usize),
 }
 pub type Result<T> = std::result::Result<T, PciRootError>;
 
@@ -145,6 +147,15 @@ impl PciBus {
         }
 
         Err(PciRootError::NoPciDeviceSlotAvailable)
+    }
+
+    pub fn put_device_id(&mut self, id: usize) -> Result<()> {
+        if id < NUM_DEVICE_IDS {
+            self.device_ids[id] = false;
+            Ok(())
+        } else {
+            Err(PciRootError::InvalidPciDeviceSlot(id))
+        }
     }
 }
 

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -4,7 +4,7 @@
 //
 
 use crate::api::http_endpoint::{
-    VmActionHandler, VmAddDevice, VmCreate, VmInfo, VmResize, VmmPing, VmmShutdown,
+    VmActionHandler, VmAddDevice, VmCreate, VmInfo, VmRemoveDevice, VmResize, VmmPing, VmmShutdown,
 };
 use crate::api::{ApiRequest, VmAction};
 use crate::{Error, Result};
@@ -63,6 +63,7 @@ lazy_static! {
         r.routes.insert(endpoint!("/vmm.ping"), Box::new(VmmPing {}));
         r.routes.insert(endpoint!("/vm.resize"), Box::new(VmResize {}));
         r.routes.insert(endpoint!("/vm.add-device"), Box::new(VmAddDevice {}));
+        r.routes.insert(endpoint!("/vm.remove-device"), Box::new(VmRemoveDevice {}));
 
         r
     };

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -155,6 +155,22 @@ paths:
         404:
           description: The new device could not be added to the VM instance.
 
+  /vm.remove-device:
+    put:
+      summary: Remove a device from the VM
+      requestBody:
+        description: The identifier of the device
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VmRemoveDevice'
+        required: true
+      responses:
+        204:
+          description: The device was successfully removed from the VM instance.
+        404:
+          description: The device could not be removed from the VM instance.
+
 components:
   schemas:
 
@@ -448,4 +464,10 @@ components:
       type: object
       properties:
         path:
+          type: string
+
+    VmRemoveDevice:
+      type: object
+      properties:
+        id:
           type: string

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -889,6 +889,8 @@ pub struct DeviceConfig {
     pub path: PathBuf,
     #[serde(default)]
     pub iommu: bool,
+    #[serde(default)]
+    pub id: Option<String>,
 }
 
 impl DeviceConfig {
@@ -910,6 +912,7 @@ impl DeviceConfig {
         Ok(DeviceConfig {
             path: PathBuf::from(path_str),
             iommu: parse_on_off(iommu_str)?,
+            id: None,
         })
     }
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -577,6 +577,28 @@ impl Vm {
         }
     }
 
+    pub fn remove_device(&mut self, _id: String) -> Result<()> {
+        if cfg!(feature = "pci_support") {
+            #[cfg(feature = "pci_support")]
+            {
+                self.device_manager
+                    .lock()
+                    .unwrap()
+                    .remove_device(_id)
+                    .map_err(Error::DeviceManager)?;
+
+                self.device_manager
+                    .lock()
+                    .unwrap()
+                    .notify_hotplug(HotPlugNotificationFlags::PCI_DEVICES_CHANGED)
+                    .map_err(Error::DeviceManager)?;
+            }
+            Ok(())
+        } else {
+            Err(Error::NoPciSupport)
+        }
+    }
+
     fn os_signal_handler(signals: Signals, console_input_clone: Arc<Console>, on_tty: bool) {
         for signal in signals.forever() {
             match signal {


### PR DESCRIPTION
This pull request adds support for the removal of VFIO PCI devices while the VM is running. It does not matter if the VFIO device has been hotplugged or not, as any VFIO device can now be removed.