### PR TITLE
vmm: Improve VFIO unplug

### DIFF
--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -55,6 +55,11 @@ pub trait PciDevice: BusDevice {
         Ok(Vec::new())
     }
 
+    /// Frees the PCI BARs previously allocated with a call to allocate_bars().
+    fn free_bars(&mut self, _allocator: &mut SystemAllocator) -> Result<()> {
+        Ok(())
+    }
+
     /// Sets a register in the configuration space.
     /// * `reg_idx` - The index of the config register to modify.
     /// * `offset` - Offset in to the register.

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -131,4 +131,10 @@ impl SystemAllocator {
     pub fn free_mmio_addresses(&mut self, address: GuestAddress, size: GuestUsize) {
         self.mmio_address_space.free(address, size)
     }
+
+    /// Free an MMIO address range from the 32 bits hole.
+    /// We can only free a range if it matches exactly an already allocated range.
+    pub fn free_mmio_hole_addresses(&mut self, address: GuestAddress, size: GuestUsize) {
+        self.mmio_hole_address_space.free(address, size)
+    }
 }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -354,12 +354,12 @@ impl DeviceRelocation for AddressManager {
             }
             PciBarRegionType::Memory32BitRegion | PciBarRegionType::Memory64BitRegion => {
                 // Update system allocator
-                self.allocator
-                    .lock()
-                    .unwrap()
-                    .free_mmio_addresses(GuestAddress(old_base), len as GuestUsize);
-
                 if region_type == PciBarRegionType::Memory32BitRegion {
+                    self.allocator
+                        .lock()
+                        .unwrap()
+                        .free_mmio_hole_addresses(GuestAddress(old_base), len as GuestUsize);
+
                     self.allocator
                         .lock()
                         .unwrap()
@@ -375,6 +375,11 @@ impl DeviceRelocation for AddressManager {
                             )
                         })?;
                 } else {
+                    self.allocator
+                        .lock()
+                        .unwrap()
+                        .free_mmio_addresses(GuestAddress(old_base), len as GuestUsize);
+
                     self.allocator
                         .lock()
                         .unwrap()


### PR DESCRIPTION
I noticed some bugs when playing with hotplug/hotunplug of VFIO devices. The reasons behind these issues were all related to an incomplete cleanup. This PR fills all the blanks by removing a device from every place left, in particular from the vm-allocator where the range were not removed.