### PR TITLE
vhost_user_backend: Delegate worker thread management to backends

### DIFF
--- a/src/bin/vhost_user_fs.rs
+++ b/src/bin/vhost_user_fs.rs
@@ -184,36 +184,6 @@ impl<F: FileSystem + Send + Sync + 'static> VhostUserFsBackend<F> {
 
         Ok(used_any)
     }
-}
-
-impl<F: FileSystem + Send + Sync + 'static> VhostUserBackend for VhostUserFsBackend<F> {
-    fn num_queues(&self) -> usize {
-        NUM_QUEUES
-    }
-
-    fn max_queue_size(&self) -> usize {
-        QUEUE_SIZE
-    }
-
-    fn features(&self) -> u64 {
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
-            | 1 << VIRTIO_RING_F_EVENT_IDX
-            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
-    }
-
-    fn protocol_features(&self) -> VhostUserProtocolFeatures {
-        VhostUserProtocolFeatures::MQ | VhostUserProtocolFeatures::SLAVE_REQ
-    }
-
-    fn set_event_idx(&mut self, enabled: bool) {
-        self.event_idx = enabled;
-    }
-
-    fn update_memory(&mut self, mem: GuestMemoryMmap) -> VhostUserBackendResult<()> {
-        self.mem = Some(GuestMemoryAtomic::new(mem));
-        Ok(())
-    }
 
     fn handle_event(
         &mut self,
@@ -263,9 +233,35 @@ impl<F: FileSystem + Send + Sync + 'static> VhostUserBackend for VhostUserFsBack
 
         Ok(false)
     }
+}
 
-    fn exit_event(&self) -> Option<(EventFd, Option<u16>)> {
-        Some((self.kill_evt.try_clone().unwrap(), Some(KILL_EVENT)))
+impl<F: FileSystem + Send + Sync + 'static> VhostUserBackend for VhostUserFsBackend<F> {
+    fn num_queues(&self) -> usize {
+        NUM_QUEUES
+    }
+
+    fn max_queue_size(&self) -> usize {
+        QUEUE_SIZE
+    }
+
+    fn features(&self) -> u64 {
+        1 << VIRTIO_F_VERSION_1
+            | 1 << VIRTIO_RING_F_INDIRECT_DESC
+            | 1 << VIRTIO_RING_F_EVENT_IDX
+            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
+    }
+
+    fn protocol_features(&self) -> VhostUserProtocolFeatures {
+        VhostUserProtocolFeatures::MQ | VhostUserProtocolFeatures::SLAVE_REQ
+    }
+
+    fn set_event_idx(&mut self, enabled: bool) {
+        self.event_idx = enabled;
+    }
+
+    fn update_memory(&mut self, mem: GuestMemoryMmap) -> VhostUserBackendResult<()> {
+        self.mem = Some(GuestMemoryAtomic::new(mem));
+        Ok(())
     }
 
     fn set_slave_req_fd(&mut self, vu_req: SlaveFsCacheReq) {

--- a/vhost_user_backend/src/lib.rs
+++ b/vhost_user_backend/src/lib.rs
@@ -238,6 +238,14 @@ impl Vring {
             Ok(())
         }
     }
+
+    pub fn get_kick(&self) -> Option<&EventFd> {
+        self.kick.as_ref()
+    }
+
+    pub fn get_enabled(&self) -> bool {
+        self.enabled
+    }
 }
 
 #[derive(Debug)]

--- a/vhost_user_backend/src/lib.rs
+++ b/vhost_user_backend/src/lib.rs
@@ -170,6 +170,12 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
             Ok(())
         }
     }
+
+    /// Get vrings for backends to start worker thread which will run
+    /// epoll handler to handle vring events.
+    pub fn get_vrings(&self) -> Vec<Arc<RwLock<Vring>>> {
+        self.handler.lock().unwrap().vrings.clone()
+    }
 }
 
 struct AddrMapping {

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -262,6 +262,7 @@ struct BlockEpollHandler {
     epoll_fd: RawFd,
     num_queues: u16,
     worker_reset: Arc<Mutex<WorkerReset>>,
+    kill_evt: EventFd,
 }
 
 impl BlockEpollHandler {
@@ -332,6 +333,13 @@ impl BlockEpollHandler {
             self.worker_reset.lock().unwrap().get_evt().as_raw_fd(),
             epoll::Events::EPOLLIN,
             u64::try_from(worker_reset_index).unwrap(),
+        )?;
+        let kill_index = worker_reset_index + 1;
+        register_listener(
+            self.epoll_fd,
+            self.kill_evt.as_raw_fd(),
+            epoll::Events::EPOLLIN,
+            u64::try_from(kill_index).unwrap(),
         )?;
 
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); 100];
@@ -409,6 +417,7 @@ impl BlockEpollHandler {
                         self.mem = self.worker_reset.lock().unwrap().get_mem();
                         self.event_idx = self.worker_reset.lock().unwrap().get_event_idx();
                     }
+                    q if q == kill_index => break 'epoll,
                     _ => return Err(Error::HandleEventUnknownEvent.into()),
                 }
             }


### PR DESCRIPTION
While add multiple threads support for vhost_user_net backend, it's found that there is race condition while multiple threads concurrent access and change data structures defined in backend, which lead to performance penalty. To resolve such issue, it's better to let vhost_user_net backend to create and manage the worker threads itself, then those threads will have data structures respectively, we can see throughput improved then. 

Considering that worker threads aim to handle virtqueue data in which each type of backend may have specific requirements, additionally, to keep the design of vhost_user_backend clean, we'd like to move the worker thread management out of the vhost_user_backend lib code, let backends to handle it on their own. 

This PR is opened to implement the new worker thread strategy for vhost_user_backend and the three backend, fs/net/block.