### PR TITLE
vmm: Add id field to --device through CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ fn create_app<'a, 'b>(
                 .help("Direct device assignment parameter")
                 .help(
                     "Direct device assignment parameters \
-                     \"path=<device_path>,iommu=on|off\"",
+                     \"path=<device_path>,iommu=on|off,id=<device_id>\"",
                 )
                 .takes_value(true)
                 .min_values(1)

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -432,6 +432,8 @@ components:
         iommu:
           type: boolean
           default: false
+        id:
+          type: string
 
     VsockConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -900,19 +900,28 @@ impl DeviceConfig {
 
         let mut path_str: &str = "";
         let mut iommu_str: &str = "";
+        let mut id_str: &str = "";
 
         for param in params_list.iter() {
             if param.starts_with("path=") {
                 path_str = &param[5..];
             } else if param.starts_with("iommu=") {
                 iommu_str = &param[6..];
+            } else if param.starts_with("id=") {
+                id_str = &param[3..];
             }
         }
+
+        let id = if !id_str.is_empty() {
+            Some(String::from(id_str))
+        } else {
+            None
+        };
 
         Ok(DeviceConfig {
             path: PathBuf::from(path_str),
             iommu: parse_on_off(iommu_str)?,
-            id: None,
+            id,
         })
     }
 }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -248,6 +248,9 @@ pub enum DeviceManagerError {
     /// Could not give the PCI device ID back.
     #[cfg(feature = "pci_support")]
     PutPciDeviceId(pci::PciRootError),
+
+    /// Incorrect device ID as it is already used by another device.
+    DeviceIdAlreadyInUse,
 }
 pub type DeviceManagerResult<T> = result::Result<T, DeviceManagerError>;
 
@@ -1545,8 +1548,17 @@ impl DeviceManager {
         )
         .map_err(DeviceManagerError::AddPciDevice)?;
 
-        let vfio_name = self.next_device_name(VFIO_DEVICE_NAME_PREFIX)?;
-        device_cfg.id = Some(vfio_name.clone());
+        let vfio_name = if let Some(id) = &device_cfg.id {
+            if self.pci_id_list.contains_key(id) {
+                return Err(DeviceManagerError::DeviceIdAlreadyInUse);
+            }
+
+            id.clone()
+        } else {
+            let id = self.next_device_name(VFIO_DEVICE_NAME_PREFIX)?;
+            device_cfg.id = Some(id.clone());
+            id
+        };
         self.pci_id_list.insert(vfio_name, pci_device_bdf);
 
         Ok(pci_device_bdf)


### PR DESCRIPTION
Add the ability to specify the "id" associated with a device, by adding
an extra option to the parameter --device.

This new option is not mandatory, and by default, the VMM will take care
of finding a unique identifier.

If the identifier provided by the user through this new option is not
unique, an error will be thrown and the VM won't be started.

Fixes #881

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>