### PR TITLE
Fix Queue EVENT_IDX check to avoid missing notifications

### DIFF
--- a/src/bin/vhost_user_fs.rs
+++ b/src/bin/vhost_user_fs.rs
@@ -126,8 +126,7 @@ impl<F: FileSystem + Send + Sync + 'static> VhostUserFsBackend<F> {
                 .map_err(Error::ProcessQueue)?;
             if self.event_idx {
                 if let Some(used_idx) = vring.mut_queue().add_used(mem, head_index, 0) {
-                    let used_event = vring.mut_queue().get_used_event(mem);
-                    if vring.needs_notification(Wrapping(used_idx), used_event) {
+                    if vring.needs_notification(&mem, Wrapping(used_idx)) {
                         vring.signal_used_queue().map_err(Error::SignalQueue)?;
                     }
                     used_any = true;

--- a/vhost_user_backend/src/lib.rs
+++ b/vhost_user_backend/src/lib.rs
@@ -235,11 +235,7 @@ impl Vring {
         self.event_idx = enabled;
     }
 
-    pub fn needs_notification(
-        &mut self,
-        used_idx: Wrapping<u16>,
-        used_event: Option<Wrapping<u16>>,
-    ) -> bool {
+    pub fn needs_notification(&mut self, mem: &GuestMemoryMmap, used_idx: Wrapping<u16>) -> bool {
         if !self.event_idx {
             return true;
         }
@@ -247,7 +243,7 @@ impl Vring {
         let mut notify = true;
 
         if let Some(old_idx) = self.signalled_used {
-            if let Some(used_event) = used_event {
+            if let Some(used_event) = self.mut_queue().get_used_event(&mem) {
                 if (used_idx - used_event - Wrapping(1u16)) >= (used_idx - old_idx) {
                     notify = false;
                 }

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -197,8 +197,7 @@ impl VhostUserBlkBackend {
 
             if self.event_idx {
                 if let Some(used_idx) = vring.mut_queue().add_used(mem, head.index, len) {
-                    let used_event = vring.mut_queue().get_used_event(mem);
-                    if vring.needs_notification(Wrapping(used_idx), used_event) {
+                    if vring.needs_notification(&mem, Wrapping(used_idx)) {
                         debug!("signalling queue");
                         vring.signal_used_queue().unwrap();
                     } else {

--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -559,6 +559,8 @@ impl Queue {
                 }
             };
 
+        // This fence ensures we're seeing the latest update from the guest.
+        fence(Ordering::Acquire);
         match mem.read_obj::<u16>(used_event_addr) {
             Ok(ret) => Some(Wrapping(ret)),
             Err(_) => None,

--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -543,7 +543,7 @@ impl Queue {
             None => warn!("Can't update avail_event"),
         }
 
-        // This fence ensures all descriptor writes are visible before the index update is.
+        // This fence ensures the guest sees the value we've just written.
         fence(Ordering::Release);
     }
 

--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -548,6 +548,7 @@ impl Queue {
     }
 
     /// Return the value present in the used_event field of the avail ring.
+    #[inline(always)]
     pub fn get_used_event(&self, mem: &GuestMemoryMmap) -> Option<Wrapping<u16>> {
         let avail_ring = self.avail_ring;
         let used_event_addr =


### PR DESCRIPTION
When EVENT_IDX is enabled, users may rely on `Queue::get_used_event` to check if a notification should be delivered to the guest. But, if the window before the call to that function and the actual check is too wide, it's possible to miss an update and wrongly omit a notification. This issue only manifest when putting a lot of pressure on a vring by continuously issuing a significant number of parallel requests that complete very fast.

This patch series fixes the issue by hinting the compiler that `Queue::get_used_event` needs to be inlined, and by calling to this function directly from `Vring::needs_notification`.