### PR TITLE
Clean up --help wrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -924,10 +925,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1330,6 +1342,7 @@ dependencies = [
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
+"checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ee14bf8e6767ab4c687c9e8bc003879e042a96fd67a3ba5934eadb6536bef4db"
 "checksum thiserror-impl 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 
 [dependencies]
 arc-swap = ">=0.4.4"
-clap = "2.33.0"
+clap = { version = "2.33.0", features=["wrap_help"] }
 epoll = ">=4.0.1"
 lazy_static = "1.4.0"
 libc = "0.2.67"

--- a/src/bin/vhost_user_blk.rs
+++ b/src/bin/vhost_user_blk.rs
@@ -24,8 +24,8 @@ fn main() {
             Arg::with_name("block-backend")
                 .long("block-backend")
                 .help(
-                    "vhost-user-block backend parameters \"image=<image_path>,\
-                     sock=<socket_path>,num_queues=<number_of_queues>,\
+                    "vhost-user-block backend parameters \
+                     \"image=<image_path>,sock=<socket_path>,num_queues=<number_of_queues>,\
                      readonly=true|false,direct=true|false,poll_queue=true|false\"",
                 )
                 .takes_value(true)

--- a/src/bin/vhost_user_net.rs
+++ b/src/bin/vhost_user_net.rs
@@ -22,11 +22,9 @@ fn main() {
             Arg::with_name("net-backend")
                 .long("net-backend")
                 .help(
-                    "vhost-user-net backend parameters \"ip=<ip_addr>,\
-                     mask=<net_mask>,sock=<socket_path>,\
-                     num_queues=<number_of_queues>,\
-                     queue_size=<size_of_each_queue>,\
-                     tap=<if_name>\"",
+                    "vhost-user-net backend parameters \
+                     \"ip=<ip_addr>,mask=<net_mask>,sock=<socket_path>,\
+                     num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,tap=<if_name>\"",
                 )
                 .takes_value(true)
                 .min_values(1),

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,8 +97,8 @@ fn create_app<'a, 'b>(
             Arg::with_name("memory")
                 .long("memory")
                 .help(
-                    "Memory parameters \"size=<guest_memory_size>,\
-                     file=<backing_file_path>,mergeable=on|off,\
+                    "Memory parameters \
+                     \"size=<guest_memory_size>,file=<backing_file_path>,mergeable=on|off,\
                      hotplug_size=<hotpluggable_memory_size>\"",
                 )
                 .default_value(&default_memory)
@@ -122,11 +122,10 @@ fn create_app<'a, 'b>(
             Arg::with_name("disk")
                 .long("disk")
                 .help(
-                    "Disk parameters \"path=<disk_image_path>,\
-                     readonly=on|off,iommu=on|off,\
-                     num_queues=<number_of_queues>,\
-                     queue_size=<size_of_each_queue>,
-                     vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>,
+                    "Disk parameters \
+                     \"path=<disk_image_path>,readonly=on|off,iommu=on|off,\
+                     num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,\
+                     vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>,\
                      wce=<true|false, default true>\"",
                 )
                 .takes_value(true)
@@ -137,10 +136,9 @@ fn create_app<'a, 'b>(
             Arg::with_name("net")
                 .long("net")
                 .help(
-                    "Network parameters \"tap=<if_name>,\
-                     ip=<ip_addr>,mask=<net_mask>,mac=<mac_addr>,\
-                     iommu=on|off,num_queues=<number_of_queues>,\
-                     queue_size=<size_of_each_queue>,\
+                    "Network parameters \
+                     \"tap=<if_name>,ip=<ip_addr>,mask=<net_mask>,mac=<mac_addr>,iommu=on|off,\
+                     num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,\
                      vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>\"",
                 )
                 .takes_value(true)
@@ -151,8 +149,7 @@ fn create_app<'a, 'b>(
             Arg::with_name("rng")
                 .long("rng")
                 .help(
-                    "Random number generator parameters \
-                     \"src=<entropy_source_path>,iommu=on|off\"",
+                    "Random number generator parameters \"src=<entropy_source_path>,iommu=on|off\"",
                 )
                 .default_value(&default_rng)
                 .group("vm-config"),
@@ -161,10 +158,10 @@ fn create_app<'a, 'b>(
             Arg::with_name("fs")
                 .long("fs")
                 .help(
-                    "virtio-fs parameters \"tag=<tag_name>,\
-                     sock=<socket_path>,num_queues=<number_of_queues>,\
-                     queue_size=<size_of_each_queue>,dax=on|off,\
-                     cache_size=<DAX cache size: default 8Gib>\"",
+                    "virtio-fs parameters \
+                     \"tag=<tag_name>,sock=<socket_path>,num_queues=<number_of_queues>,\
+                     queue_size=<size_of_each_queue>,dax=on|off,cache_size=<DAX cache size: \
+                     default 8Gib>\"",
                 )
                 .takes_value(true)
                 .min_values(1)
@@ -174,8 +171,9 @@ fn create_app<'a, 'b>(
             Arg::with_name("pmem")
                 .long("pmem")
                 .help(
-                    "Persistent memory parameters \"file=<backing_file_path>,\
-                     size=<persistent_memory_size>,iommu=on|off,mergeable=on|off\"",
+                    "Persistent memory parameters \
+                     \"file=<backing_file_path>,size=<persistent_memory_size>,iommu=on|off,\
+                     mergeable=on|off\"",
                 )
                 .takes_value(true)
                 .min_values(1)
@@ -192,8 +190,7 @@ fn create_app<'a, 'b>(
             Arg::with_name("console")
                 .long("console")
                 .help(
-                    "Control (virtio) console: \"off|null|tty|file=/path/to/a/file,\
-                     iommu=on|off\"",
+                    "Control (virtio) console: \"off|null|tty|file=/path/to/a/file,iommu=on|off\"",
                 )
                 .default_value("tty")
                 .group("vm-config"),
@@ -213,9 +210,8 @@ fn create_app<'a, 'b>(
             Arg::with_name("vhost-user-net")
                 .long("vhost-user-net")
                 .help(
-                    "Network parameters \"mac=<mac_addr>,\
-                     sock=<socket_path>, num_queues=<number_of_queues>,\
-                     queue_size=<size_of_each_queue>\"",
+                    "Network parameters \"mac=<mac_addr>,sock=<socket_path>, \
+                     num_queues=<number_of_queues>,queue_size=<size_of_each_queue>\"",
                 )
                 .takes_value(true)
                 .min_values(1)
@@ -225,8 +221,7 @@ fn create_app<'a, 'b>(
             Arg::with_name("vsock")
                 .long("vsock")
                 .help(
-                    "Virtio VSOCK parameters \"cid=<context_id>,\
-                     sock=<socket_path>,iommu=on|off\"",
+                    "Virtio VSOCK parameters \"cid=<context_id>,sock=<socket_path>,iommu=on|off\"",
                 )
                 .takes_value(true)
                 .min_values(1)
@@ -260,11 +255,9 @@ fn create_app<'a, 'b>(
             Arg::with_name("net-backend")
                 .long("net-backend")
                 .help(
-                    "vhost-user-net backend parameters \"ip=<ip_addr>,\
-                     mask=<net_mask>,sock=<socket_path>,\
-                     num_queues=<number_of_queues>,\
-                     queue_size=<size_of_each_queue>,\
-                     tap=<if_name>\"",
+                    "vhost-user-net backend parameters \
+                     \"ip=<ip_addr>,mask=<net_mask>,sock=<socket_path>,\
+                     num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,tap=<if_name>\"",
                 )
                 .takes_value(true)
                 .conflicts_with_all(&["block-backend", "kernel"])
@@ -274,8 +267,8 @@ fn create_app<'a, 'b>(
             Arg::with_name("block-backend")
                 .long("block-backend")
                 .help(
-                    "vhost-user-block backend parameters \"image=<image_path>,\
-                     sock=<socket_path>,num_queues=<number_of_queues>,\
+                    "vhost-user-block backend parameters \
+                     \"image=<image_path>,sock=<socket_path>,num_queues=<number_of_queues>,\
                      readonly=true|false,direct=true|false,poll_queue=true|false\"",
                 )
                 .takes_value(true)
@@ -299,8 +292,8 @@ fn start_vmm(cmd_arguments: ArgMatches) {
         .expect("Missing argument: api-socket");
 
     println!(
-        "Cloud Hypervisor Guest\n\tAPI server: {}\n\tvCPUs: {}\n\tMemory: {} MB\
-         \n\tKernel: {:?}\n\tKernel cmdline: {}\n\tDisk(s): {:?}",
+        "Cloud Hypervisor Guest\n\tAPI server: {}\n\tvCPUs: {}\n\tMemory: {} MB\n\tKernel: \
+         {:?}\n\tKernel cmdline: {}\n\tDisk(s): {:?}",
         api_socket_path,
         vm_config.cpus.boot_vcpus,
         vm_config.memory.size >> 20,


### PR DESCRIPTION
New result:

```
rob@artemis:~/src/cloud-hypervisor (2020-03-12-fix-help-wrapping)$ target/debug/cloud-hypervisor --help
cloud-hypervisor v0.5.0-235-g3ec040cd-dirty
The Cloud Hypervisor Authors
Launch a cloud-hypervisor VMM.

USAGE:
    cloud-hypervisor [FLAGS] [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -v               Sets the level of debugging output
    -V, --version    Prints version information

OPTIONS:
        --api-socket <api-socket>            HTTP API socket path (UNIX domain socket). [default: /run/user/1000/cloud-hypervisor.66188]
        --block-backend <block-backend>      vhost-user-block backend parameters "image=<image_path>,sock=<socket_path>,num_queues=<number_of_queues>,readonly=true|false,direct=true|false,poll_queue=true|false"
        --cmdline <cmdline>                  Kernel command line
        --console <console>                  Control (virtio) console: "off|null|tty|file=/path/to/a/file,iommu=on|off" [default: tty]
        --cpus <cpus>                        Number of virtual CPUs [default: boot=1]
        --device <device>                    Direct device assignment parameters "path=<device_path>,iommu=on|off,id=<device_id>"
        --disk <disk>                        Disk parameters "path=<disk_image_path>,readonly=on|off,iommu=on|off,num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>,wce=<true|false, default true>"
        --fs <fs>                            virtio-fs parameters "tag=<tag_name>,sock=<socket_path>,num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,dax=on|off,cache_size=<DAX cache size: default 8Gib>"
        --kernel <kernel>                    Path to kernel image (vmlinux)
        --log-file <log-file>                Log file. Standard error is used if not specified
        --memory <memory>                    Memory parameters "size=<guest_memory_size>,file=<backing_file_path>,mergeable=on|off,hotplug_size=<hotpluggable_memory_size>" [default: size=512M]
        --net <net>                          Network parameters "tap=<if_name>,ip=<ip_addr>,mask=<net_mask>,mac=<mac_addr>,iommu=on|off,num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>"
        --net-backend <net-backend>          vhost-user-net backend parameters "ip=<ip_addr>,mask=<net_mask>,sock=<socket_path>,num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,tap=<if_name>"
        --pmem <pmem>                        Persistent memory parameters "file=<backing_file_path>,size=<persistent_memory_size>,iommu=on|off,mergeable=on|off"
        --rng <rng>                          Random number generator parameters "src=<entropy_source_path>,iommu=on|off" [default: src=/dev/urandom]
        --serial <serial>                    Control serial port: off|null|tty|file=/path/to/a/file [default: null]
        --vhost-user-net <vhost-user-net>    Network parameters "mac=<mac_addr>,sock=<socket_path>, num_queues=<number_of_queues>,queue_size=<size_of_each_queue>"
        --vsock <vsock>                      Virtio VSOCK parameters "cid=<context_id>,sock=<socket_path>,iommu=on|off"

```