### PR TITLE
openapi: Make desired_ram int64 format

### DIFF
--- a/docs/hotplug.md
+++ b/docs/hotplug.md
@@ -91,7 +91,7 @@ Before issuing the API request it is necessary to run the following command insi
 root@ch-guest ~ # echo online | sudo tee /sys/devices/system/memory/auto_online_blocks
 ```
 
-To ask the VMM to add expand the RAM for the VM:
+To ask the VMM to add expand the RAM for the VM  (request is in bytes):
 
 ```shell
 curl -H "Accept: application/json" -H "Content-Type: application/json" -i -XPUT --unix-socket /tmp/ch-socket -d "{ \"desired_vcpus\": 4, \"desired_ram\" : 3221225472}" http://localhost/api/v1/vm.resize

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -460,7 +460,9 @@ components:
           minimum: 1
           type: integer
         desired_ram:
+          description: desired memory ram in bytes
           type: integer
+          format: int64
 
     VmAddDevice:
       type: object


### PR DESCRIPTION
The option desired_ram is in byte, make larger the amount of memory to
add.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>