### PR TITLE
main: Remove "--vhost-user-net"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -207,17 +207,6 @@ fn create_app<'a, 'b>(
                 .group("vm-config"),
         )
         .arg(
-            Arg::with_name("vhost-user-net")
-                .long("vhost-user-net")
-                .help(
-                    "Network parameters \"mac=<mac_addr>,sock=<socket_path>, \
-                     num_queues=<number_of_queues>,queue_size=<size_of_each_queue>\"",
-                )
-                .takes_value(true)
-                .min_values(1)
-                .group("vm-config"),
-        )
-        .arg(
             Arg::with_name("vsock")
                 .long("vsock")
                 .help(


### PR DESCRIPTION
This option was superseded by using "--net" with "vhost_user=true". This
option wasn't being parsed any more but was left over.

Fixes: #806

Signed-off-by: Rob Bradford <robert.bradford@intel.com>