### PR TITLE
resources: Dockerfile: Update Rust toolchain

### DIFF
--- a/arch/src/x86_64/gdt.rs
+++ b/arch/src/x86_64/gdt.rs
@@ -11,17 +11,17 @@ use kvm_bindings::kvm_segment;
 
 /// Constructor for a conventional segment GDT (or LDT) entry. Derived from the kernel's segment.h.
 pub fn gdt_entry(flags: u16, base: u32, limit: u32) -> u64 {
-    ((((base as u64) & 0xff000000u64) << (56 - 24))
+    (((base as u64) & 0xff000000u64) << (56 - 24))
         | (((flags as u64) & 0x0000f0ffu64) << 40)
         | (((limit as u64) & 0x000f0000u64) << (48 - 16))
         | (((base as u64) & 0x00ffffffu64) << 16)
-        | ((limit as u64) & 0x0000ffffu64))
+        | ((limit as u64) & 0x0000ffffu64)
 }
 
 fn get_base(entry: u64) -> u64 {
-    ((((entry) & 0xFF00000000000000) >> 32)
+    (((entry) & 0xFF00000000000000) >> 32)
         | (((entry) & 0x000000FF00000000) >> 16)
-        | (((entry) & 0x00000000FFFF0000) >> 16))
+        | (((entry) & 0x00000000FFFF0000) >> 16)
 }
 
 fn get_limit(entry: u64) -> u32 {

--- a/arch/src/x86_64/interrupts.rs
+++ b/arch/src/x86_64/interrupts.rs
@@ -55,7 +55,7 @@ fn set_klapic_reg(klapic: &mut kvm_lapic_state, reg_offset: usize, value: u32) {
 }
 
 fn set_apic_delivery_mode(reg: u32, mode: u32) -> u32 {
-    (((reg) & !0x700) | ((mode) << 8))
+    ((reg) & !0x700) | ((mode) << 8)
 }
 
 /// Configures LAPICs.  LAPIC0 is set for external interrupts, LAPIC1 is set for NMI.

--- a/qcow/src/vec_cache.rs
+++ b/qcow/src/vec_cache.rs
@@ -120,7 +120,7 @@ impl<T: Cacheable> CacheMap<T> {
     {
         if self.map.len() == self.capacity {
             // TODO(dgreid) - smarter eviction strategy.
-            let to_evict = *self.map.iter().nth(0).unwrap().0;
+            let to_evict = *self.map.iter().next().unwrap().0;
             if let Some(evicted) = self.map.remove(&to_evict) {
                 if evicted.dirty() {
                     write_callback(to_evict, evicted)?;

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04 as dev
 
-ARG RUST_TOOLCHAIN="1.40.0"
+ARG RUST_TOOLCHAIN="1.42.0"
 ARG CLH_SRC_DIR="/cloud-hypervisor"
 ARG CLH_BUILD_DIR="$CLH_SRC_DIR/build"
 ARG CARGO_REGISTRY_DIR="$CLH_BUILD_DIR/cargo_registry"


### PR DESCRIPTION
To the latest stable version: 1.42.0

This PR also includes 1.42 clippy warning fixes.

Fixes: #909

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>