### PR TITLE
arch: x86: Always set the bootloader type

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -307,13 +307,15 @@ fn configure_64bit_boot(
         // We should use the header if the loader provides one (e.g. from a bzImage).
         params.0.hdr = hdr;
     } else {
-        params.0.hdr.type_of_loader = KERNEL_LOADER_OTHER;
         params.0.hdr.boot_flag = KERNEL_BOOT_FLAG_MAGIC;
         params.0.hdr.header = KERNEL_HDR_MAGIC;
         params.0.hdr.kernel_alignment = KERNEL_MIN_ALIGNMENT_BYTES;
     };
 
     // Common bootparams settings
+    if params.0.hdr.type_of_loader == 0 {
+        params.0.hdr.type_of_loader = KERNEL_LOADER_OTHER;
+    }
     params.0.hdr.cmd_line_ptr = cmdline_addr.raw_value() as u32;
     params.0.hdr.cmdline_size = cmdline_size as u32;
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -304,17 +304,18 @@ fn configure_64bit_boot(
     let mut params: BootParamsWrapper = BootParamsWrapper(boot_params::default());
 
     if let Some(hdr) = setup_hdr {
+        // We should use the header if the loader provides one (e.g. from a bzImage).
         params.0.hdr = hdr;
-        params.0.hdr.cmd_line_ptr = cmdline_addr.raw_value() as u32;
-        params.0.hdr.cmdline_size = cmdline_size as u32;
     } else {
         params.0.hdr.type_of_loader = KERNEL_LOADER_OTHER;
         params.0.hdr.boot_flag = KERNEL_BOOT_FLAG_MAGIC;
         params.0.hdr.header = KERNEL_HDR_MAGIC;
-        params.0.hdr.cmd_line_ptr = cmdline_addr.raw_value() as u32;
-        params.0.hdr.cmdline_size = cmdline_size as u32;
         params.0.hdr.kernel_alignment = KERNEL_MIN_ALIGNMENT_BYTES;
     };
+
+    // Common bootparams settings
+    params.0.hdr.cmd_line_ptr = cmdline_addr.raw_value() as u32;
+    params.0.hdr.cmdline_size = cmdline_size as u32;
 
     add_e820_entry(&mut params.0, 0, layout::EBDA_START.raw_value(), E820_RAM)?;
 


### PR DESCRIPTION

We set it to 0xff, which is for unregistered loaders.
The kernel checks that the bootloader ID is set when e.g. loading
ramdisks, so not setting it when we get a bootparams header from the
loader will prevent the kernel from loading ramdisks.

Fixes: #918

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>