### PR TITLE
vm-virtio: queue: Use a SeqCst fence on get_used_event

### DIFF
--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -597,7 +597,7 @@ impl Queue {
             };
 
         // This fence ensures we're seeing the latest update from the guest.
-        fence(Ordering::Acquire);
+        fence(Ordering::SeqCst);
         match mem.read_obj::<u16>(used_event_addr) {
             Ok(ret) => Some(Wrapping(ret)),
             Err(_) => None,


### PR DESCRIPTION
On x86_64, a hint to the compiler is not enough, we need to issue a
MFENCE instruction. Replace the Acquire fence with a SeqCst one.

Without this, it's still possible to miss an used_event update,
leading to the omission of a notification, possibly stalling the
vring.

Signed-off-by: Sergio Lopez <slp@redhat.com>