### PR TITLE
vhost_user_fs: Implement support for FUSE_LSEEK

### DIFF
--- a/vhost_user_fs/src/filesystem.rs
+++ b/vhost_user_fs/src/filesystem.rs
@@ -1084,6 +1084,18 @@ pub trait FileSystem {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }
 
+    /// Reposition read/write file offset.
+    fn lseek(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        offset: u64,
+        whence: u32,
+    ) -> io::Result<u64> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
     /// TODO: support this
     fn getlk(&self) -> io::Result<()> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
@@ -1116,11 +1128,6 @@ pub trait FileSystem {
 
     /// TODO: support this
     fn notify_reply(&self) -> io::Result<()> {
-        Err(io::Error::from_raw_os_error(libc::ENOSYS))
-    }
-
-    /// TODO: support this
-    fn lseek(&self) -> io::Result<()> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }
 }


### PR DESCRIPTION
Implement missing support for FUSE_LSEEK, which basically implies
calling to libc::lseek on the file handle. As this operation alters
the file offset, we take a write lock on the File's RwLock.

Signed-off-by: Sergio Lopez <slp@redhat.com>