### PR TITLE
openapi: Add hotplug_size for memory hotplug

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -269,6 +269,9 @@ components:
           type: integer
           format: int64
           default: 512 MB
+        hotplug_size:
+          type: integer
+          format: int64
         file:
           type: string
         mergeable:


### PR DESCRIPTION
Add hotplug_size, needed to be defined when hotplug is used.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>