### PR TITLE
bin: Share VFIO device syntax between cloud-hypervisor and ch-remote

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -267,10 +267,11 @@ fn main() {
         .subcommand(
             SubCommand::with_name("add-device")
                 .about("Add VFIO device")
-                .arg(Arg::with_name("device_config").index(1).help(
-                    "Direct device assignment parameters \
-                     \"path=<device_path>,iommu=on|off,id=<device_id>\"",
-                )),
+                .arg(
+                    Arg::with_name("device_config")
+                        .index(1)
+                        .help(vmm::config::DeviceConfig::SYNTAX),
+                ),
         )
         .subcommand(
             SubCommand::with_name("remove-device")

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,10 +198,7 @@ fn create_app<'a, 'b>(
         .arg(
             Arg::with_name("device")
                 .long("device")
-                .help(
-                    "Direct device assignment parameters \
-                     \"path=<device_path>,iommu=on|off,id=<device_id>\"",
-                )
+                .help(config::DeviceConfig::SYNTAX)
                 .takes_value(true)
                 .min_values(1)
                 .group("vm-config"),

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -904,6 +904,8 @@ pub struct DeviceConfig {
 }
 
 impl DeviceConfig {
+    pub const SYNTAX: &'static str =
+        "Direct device assignment parameters \"path=<device_path>,iommu=on|off,id=<device_id>\"";
     pub fn parse(device: &str) -> Result<Self> {
         // Split the parameters based on the comma delimiter
         let params_list: Vec<&str> = device.split(',').collect();


### PR DESCRIPTION
Signed-off-by: Rob Bradford <robert.bradford@intel.com>