### PR TITLE
build: Remove "pvh_boot" feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ acpi = ["vmm/acpi"]
 pci = ["vmm/pci_support"]
 mmio = ["vmm/mmio_support"]
 cmos = ["vmm/cmos"]
-pvh_boot = ["vmm/pvh_boot"]
 
 # Integration tests require a special environment to run in
 integration_tests = []

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -224,19 +224,6 @@ EOF
     RES=$?
 fi
 
-# Test the pvh_boot feature
-if [ $RES -eq 0 ]; then
-    cargo build --release --features "pvh_boot"
-    sudo setcap cap_net_admin+ep target/release/cloud-hypervisor
-
-    newgrp kvm << EOF
-export RUST_BACKTRACE=1
-time cargo test --features "integration_tests,pvh_boot" "$@" -- --nocapture
-EOF
-
-    RES=$?
-fi
-
 # Tear VFIO test network down
 sudo ip link del vfio-br0
 sudo ip link del vfio-tap0

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1052,7 +1052,7 @@ mod tests {
         });
     }
 
-    #[cfg_attr(feature = "pvh_boot", test)]
+    #[test]
     fn test_pvh_boot() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -10,7 +10,6 @@ acpi = ["acpi_tables","devices/acpi"]
 pci_support = ["pci", "vfio", "vm-virtio/pci_support"]
 mmio_support = ["vm-virtio/mmio_support"]
 cmos = ["devices/cmos"]
-pvh_boot = []
 
 [dependencies]
 arc-swap = ">=0.4.4"

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -465,8 +465,7 @@ impl Vm {
                 // Assume by default Linux boot protocol is used and not PVH
                 let mut entry_point_addr: GuestAddress = entry_addr.kernel_load;
 
-                let boot_prot = if cfg!(feature = "pvh_boot") && entry_addr.pvh_entry_addr.is_some()
-                {
+                let boot_prot = if entry_addr.pvh_entry_addr.is_some() {
                     // entry_addr.pvh_entry_addr field is safe to unwrap here
                     entry_point_addr = entry_addr.pvh_entry_addr.unwrap();
                     BootProtocol::PvhBoot


### PR DESCRIPTION
This feature is stable and there is no need for this to be behind a
flag. This will also reduce the time needed to run the integration test
as we will not be running them all again under the flag.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>