### PR TITLE
Add "discard_writes" option to --pmem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "ssh2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
  "vhost_user_backend 0.1.0",
  "vhost_user_block 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ dirs = "2.0.2"
 credibility = "0.1.3"
 tempdir= "0.3.7"
 lazy_static= "1.4.0"
+tempfile = "3.1.0"
 
 [features]
 default = ["acpi", "pci", "cmos"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,7 @@ fn create_app<'a, 'b>(
                 .help(
                     "Persistent memory parameters \
                      \"file=<backing_file_path>,size=<persistent_memory_size>,iommu=on|off,\
-                     mergeable=on|off\"",
+                     mergeable=on|off,discard_writes=on|off,\"",
                 )
                 .takes_value(true)
                 .min_values(1)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -30,6 +30,7 @@ mod tests {
     use std::sync::Mutex;
     use std::thread;
     use tempdir::TempDir;
+    use tempfile::NamedTempFile;
 
     lazy_static! {
         static ref NEXT_VM_ID: Mutex<u8> = Mutex::new(1);
@@ -1937,6 +1938,9 @@ mod tests {
             let mut kernel_path = workload_path;
             kernel_path.push("vmlinux");
 
+            let mut pmem_temp_file = NamedTempFile::new().unwrap();
+            pmem_temp_file.as_file_mut().set_len(128 << 20).unwrap();
+
             let mut child = GuestCommand::new(&guest)
                 .args(&["--cpus","boot=1"])
                 .args(&["--memory", "size=512M"])
@@ -1947,8 +1951,8 @@ mod tests {
                     "--pmem",
                     format!(
                         "file={},size={}",
-                        guest.disk_config.disk(DiskType::RawOperatingSystem).unwrap(),
-                        fs::metadata(&guest.disk_config.disk(DiskType::RawOperatingSystem).unwrap()).unwrap().len()
+                        pmem_temp_file.path().to_str().unwrap(),
+                        "128M",
                     )
                     .as_str(),
                 ])

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -410,6 +410,9 @@ components:
         mergeable:
           type: boolean
           default: false
+        discard_writes:
+          type: boolean
+          default: false
 
     ConsoleConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -766,6 +766,8 @@ pub struct PmemConfig {
     pub iommu: bool,
     #[serde(default)]
     pub mergeable: bool,
+    #[serde(default)]
+    pub discard_writes: bool,
 }
 
 impl PmemConfig {
@@ -777,6 +779,7 @@ impl PmemConfig {
         let mut size_str: &str = "";
         let mut iommu_str: &str = "";
         let mut mergeable_str: &str = "";
+        let mut discard_writes_str: &str = "";
 
         for param in params_list.iter() {
             if param.starts_with("file=") {
@@ -787,6 +790,8 @@ impl PmemConfig {
                 iommu_str = &param[6..];
             } else if param.starts_with("mergeable=") {
                 mergeable_str = &param[10..];
+            } else if param.starts_with("discard_writes=") {
+                discard_writes_str = &param[15..];
             }
         }
 
@@ -799,6 +804,7 @@ impl PmemConfig {
             size: parse_size(size_str)?,
             iommu: parse_on_off(iommu_str)?,
             mergeable: parse_on_off(mergeable_str)?,
+            discard_writes: parse_on_off(discard_writes_str)?,
         })
     }
 }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1319,6 +1319,7 @@ impl DeviceManager {
                                 fs_cache,
                                 addr,
                                 false,
+                                false,
                             )
                             .map_err(DeviceManagerError::MemoryManager)?;
 
@@ -1416,6 +1417,7 @@ impl DeviceManager {
                         size,
                         addr,
                         pmem_cfg.mergeable,
+                        false,
                     )
                     .map_err(DeviceManagerError::MemoryManager)?;
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -26,8 +26,8 @@ use arch::layout;
 use arch::layout::{APIC_START, IOAPIC_SIZE, IOAPIC_START};
 use devices::{ioapic, BusDevice, HotPlugNotificationFlags};
 use kvm_ioctls::*;
-use libc::O_TMPFILE;
 use libc::TIOCGWINSZ;
+use libc::{MAP_NORESERVE, MAP_SHARED, O_RDONLY, O_TMPFILE, PROT_READ, PROT_WRITE};
 #[cfg(feature = "pci_support")]
 use pci::{
     DeviceRelocation, PciBarRegionType, PciBus, PciConfigIo, PciConfigMmio, PciDevice, PciRoot,
@@ -1402,9 +1402,17 @@ impl DeviceManager {
                 }
 
                 let cloned_file = file.try_clone().map_err(DeviceManagerError::CloneFile)?;
-                let mmap_region =
-                    MmapRegion::from_file(FileOffset::new(cloned_file, 0), size as usize)
-                        .map_err(DeviceManagerError::NewMmapRegion)?;
+                let mmap_region = MmapRegion::build(
+                    Some(FileOffset::new(cloned_file, 0)),
+                    size as usize,
+                    if pmem_cfg.readonly {
+                        PROT_READ
+                    } else {
+                        PROT_READ | PROT_WRITE
+                    },
+                    MAP_NORESERVE | MAP_SHARED,
+                )
+                .map_err(DeviceManagerError::NewMmapRegion)?;
                 let addr: u64 = mmap_region.as_ptr() as u64;
 
                 self._mmap_regions.push(mmap_region);


### PR DESCRIPTION
Unfortunately there lacks the ability to mark a virtio-pmem device readonly however we instead get "discard-on-write" behaviour where changes are not persisted after a reboot.