### PR TITLE
vmm: fix a corrupted stack caused by get_win_size

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -265,14 +265,15 @@ type VirtioDeviceArc = Arc<Mutex<dyn vm_virtio::VirtioDevice>>;
 
 pub fn get_win_size() -> (u16, u16) {
     #[repr(C)]
+    #[derive(Default)]
     struct WS {
         rows: u16,
         cols: u16,
+        xpixel: u16,
+        ypixel: u16,
     };
-    let ws: WS = WS {
-        rows: 0u16,
-        cols: 0u16,
-    };
+    let ws: WS = WS::default();
+
     unsafe {
         libc::ioctl(0, TIOCGWINSZ, &ws);
     }


### PR DESCRIPTION
According to `asm-generic/termios.h`, the `struct winsize` should be:

struct winsize {
        unsigned short ws_row;
        unsigned short ws_col;
        unsigned short ws_xpixel;
        unsigned short ws_ypixel;
};

The ioctl of TIOCGWINSZ will trigger a segfault on aarch64.

Signed-off-by: Qiu Wenbo <qiuwenbo@phytium.com.cn>