### PR TITLE
release: v0.6.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,8 +48,8 @@ jobs:
           release_name: ${{ github.ref }}
           draft: true
           prerelease: true
-      - name: Upload Release Asset
-        id: upload-release-asset
+      - name: Upload cloud-hypervisor
+        id: upload-release-cloud-hypervisor
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,4 +57,14 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: target/release/cloud-hypervisor
           asset_name: cloud-hypervisor
+          asset_content_type: application/octet-stream
+      - name: Upload ch-remote
+        id: upload-release-ch-remote
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: target/release/ch-remote
+          asset_name: ch-remote
           asset_content_type: application/octet-stream

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "cloud-hypervisor"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arc-swap 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloud-hypervisor"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 default-run = "cloud-hypervisor"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,10 @@
+- [v0.6.0](#v060)
+    - [Directly Assigned Devices Hotplug](#directly-assigned-devices-hotplug)
+    - [Shared Filesystem Improvements](#shared-filesystem-improvements)
+    - [Block and Networking IO Self Offloading](#block-and-networking-io-self-offloading)
+    - [Command Line Interface](#command-line-interface)
+    - [PVH Boot](#pvh-boot)
+    - [Contributors](#contributors)
 - [v0.5.1](#v051)
 - [v0.5.0](#v050)
     - [Virtual Machine Dynamic Resizing](#virtual-machine-dynamic-resizing)
@@ -40,6 +47,74 @@
     - [Console over virtio](#console-over-virtio)
     - [Unit testing](#unit-testing)
     - [Integration tests parallelization](#integration-tests-parallelization)
+
+# v0.6.0
+
+This release has been tracked through the [0.6.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/7).
+
+Highlights for `cloud-hypervisor` version 0.6.0 include:
+
+### Directly Assigned Devices Hotplug
+
+We continued our efforts around supporting dynamically changing the guest
+resources. After adding support for CPU and memory hotplug, Cloud Hypervisor
+now supports hot plugging and hot unplugging directly assigned (a.k.a. `VFIO`)
+devices into an already running guest. This closes the features gap for
+providing a complete Kata Containers workloads support with Cloud Hypervisor.
+
+### Shared Filesystem Improvements
+
+We enhanced our shared filesystem support through many `virtio-fs` improvements.
+By adding support for DAX, parallel processing of multiple requests, `FS_IO`,
+`LSEEK` and the `MMIO` virtio transport layer to our `vhost_user_fs` daemon, we
+improved our filesystem sharing performance, but also made it more stable and
+compatible with other `virtio-fs` implementations.
+
+### Block and Networking IO Self Offloading
+
+When choosing to offload the paravirtualized block and networking I/O to an
+external process (through the `vhost-user` protocol), Cloud Hypervisor now
+automatically spawns its default `vhost-user-blk` and `vhost-user-net` backends
+into their own, separate processes.
+This provides a seamless parvirtualized I/O user experience for those who want
+to run their guest I/O into separate executions contexts.
+
+### Command Line Interface
+
+More and more Cloud Hypervisor services are exposed through the
+[Rest API](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/vmm/src/api/openapi/cloud-hypervisor.yaml)
+and thus only accessible via relatively cumbersome HTTP calls. In order
+to abstract those calls into a more user friendly tool, we created a Cloud
+Hypervisor Command Line Interface (CLI) called `ch-remote`.
+The `ch-remote` binary is created with each build and available e.g. at
+`cloud-hypervisor/target/debug/ch-remote` when doing a debug build.
+
+Please check `ch-remote --help` for a complete description of all available
+commands.
+
+### PVH Boot
+
+In addition to the traditional Linux boot protocol, Cloud Hypervisor now
+supports direct kernel booting through the [PVH ABI](https://xenbits.xen.org/docs/unstable/misc/pvh.html).
+
+### Contributors
+
+With the 0.6.0 release, we are welcoming a few new contributors. Many thanks
+to them and to everyone that contributed to this release:
+
+* Alejandro Jimenez <alejandro.j.jimenez@oracle.com>
+* Arron Wang <arron.wang@intel.com>
+* Bin Liu <liubin0329@gmail.com>
+* Bo Chen <chen.bo@intel.com>
+* Cathy Zhang <cathy.zhang@intel.com>
+* Eryu Guan <eguan@linux.alibaba.com>
+* Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>
+* Liu Bo <bo.liu@linux.alibaba.com>
+* Qiu Wenbo <qiuwenbo@phytium.com.cn>
+* Rob Bradford <robert.bradford@intel.com>
+* Samuel Ortiz <sameo@linux.intel.com>
+* Sebastien Boeuf <sebastien.boeuf@intel.com>
+* Sergio Lopez <slp@redhat.com>
 
 # v0.5.1
 


### PR DESCRIPTION
Expand the release notes and bump Cargo.toml.

We also amend the github action to upload `ch-remote` to the release assets.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>