### PR TITLE
vhost-user-fs: return correct result of fs_slave_io()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.1.0"
-source = "git+https://github.com/cloud-hypervisor/vhost?branch=dragonball#af264bb39201b175607d7cc517ee2d90b8820dcc"
+source = "git+https://github.com/cloud-hypervisor/vhost?branch=dragonball#92778e12aa9c9bd024ee81cd32a0a7f5ece03272"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/vhost_user_fs/src/fs_cache_req_handler.rs
+++ b/vhost_user_fs/src/fs_cache_req_handler.rs
@@ -42,7 +42,8 @@ impl FsCacheReqHandler for SlaveFsCacheReq {
             VhostUserFSSlaveMsgFlags::MAP_R
         };
 
-        self.fs_slave_map(&msg, fd)
+        self.fs_slave_map(&msg, fd)?;
+        Ok(())
     }
 
     fn unmap(&mut self, requests: Vec<fuse::RemovemappingOne>) -> io::Result<()> {

--- a/vm-virtio/src/vhost_user/fs.rs
+++ b/vm-virtio/src/vhost_user/fs.rs
@@ -41,12 +41,12 @@ struct SlaveReqHandler {
 }
 
 impl VhostUserMasterReqHandler for SlaveReqHandler {
-    fn handle_config_change(&mut self) -> HandlerResult<()> {
+    fn handle_config_change(&mut self) -> HandlerResult<u64> {
         debug!("handle_config_change");
-        Ok(())
+        Ok(0)
     }
 
-    fn fs_slave_map(&mut self, fs: &VhostUserFSSlaveMsg, fd: RawFd) -> HandlerResult<()> {
+    fn fs_slave_map(&mut self, fs: &VhostUserFSSlaveMsg, fd: RawFd) -> HandlerResult<u64> {
         debug!("fs_slave_map");
 
         for i in 0..VHOST_USER_FS_SLAVE_ENTRIES {
@@ -80,10 +80,10 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
             }
         }
 
-        Ok(())
+        Ok(0)
     }
 
-    fn fs_slave_unmap(&mut self, fs: &VhostUserFSSlaveMsg) -> HandlerResult<()> {
+    fn fs_slave_unmap(&mut self, fs: &VhostUserFSSlaveMsg) -> HandlerResult<u64> {
         debug!("fs_slave_unmap");
 
         for i in 0..VHOST_USER_FS_SLAVE_ENTRIES {
@@ -120,10 +120,10 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
             }
         }
 
-        Ok(())
+        Ok(0)
     }
 
-    fn fs_slave_sync(&mut self, fs: &VhostUserFSSlaveMsg) -> HandlerResult<()> {
+    fn fs_slave_sync(&mut self, fs: &VhostUserFSSlaveMsg) -> HandlerResult<u64> {
         debug!("fs_slave_sync");
 
         for i in 0..VHOST_USER_FS_SLAVE_ENTRIES {
@@ -145,12 +145,13 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
             }
         }
 
-        Ok(())
+        Ok(0)
     }
 
-    fn fs_slave_io(&mut self, fs: &VhostUserFSSlaveMsg, fd: RawFd) -> HandlerResult<()> {
+    fn fs_slave_io(&mut self, fs: &VhostUserFSSlaveMsg, fd: RawFd) -> HandlerResult<u64> {
         debug!("fs_slave_io");
 
+        let mut done: u64 = 0;
         for i in 0..VHOST_USER_FS_SLAVE_ENTRIES {
             // Ignore if the length is 0.
             if fs.len[i] == 0 {
@@ -199,6 +200,7 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
                 len -= ret as usize;
                 foffset += ret as u64;
                 ptr += ret as u64;
+                done += ret as u64;
             }
         }
 
@@ -207,7 +209,7 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
             return Err(io::Error::last_os_error());
         }
 
-        Ok(())
+        Ok(done)
     }
 }
 


### PR DESCRIPTION
Virtio-fs daemon expects fs_slave_io() returns the number of bytes
read/written on success, but we always return 0 and make userspace think
nothing has been read/written.

Fix it by returning the actual bytes read/written. Note that This
depends on the corresponding fix in vhost crate.

[The vm-virtio/Cargo.toml and Cargo.lock updates are only for testing,
will update when vhost changes get merged]

Fixes: #949
Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>