### PR TITLE
Make vhost-user devices compatible with memory hotplug

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -216,6 +216,10 @@ if [ $RES -eq 0 ]; then
     cargo build --release --no-default-features --features "mmio"
     sudo setcap cap_net_admin+ep target/release/cloud-hypervisor
 
+    # Ensure test binary has the same caps as the cloud-hypervisor one
+    time cargo test --no-run --features "integration_tests,mmio" -- --nocapture || exit 1
+    ls target/debug/deps/cloud_hypervisor-* | xargs -n 1 sudo setcap cap_net_admin+ep
+
     newgrp kvm << EOF
 export RUST_BACKTRACE=1
 time cargo test --features "integration_tests,mmio" "$@" -- --nocapture

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1294,6 +1294,8 @@ mod tests {
             // Since virtio-net has 2 queue pairs, its vectors is as follows:
             // 1 virtio-net     with 5 vectors: config, Rx (2), Tx (2)
             // Based on the above, the total vectors should 14.
+            // This is a PCI only feature.
+            #[cfg(not(feature = "mmio"))]
             aver_eq!(
                 tb,
                 guest
@@ -1318,12 +1320,12 @@ mod tests {
         });
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
+    #[test]
     fn test_vhost_user_net_default() {
         test_vhost_user_net(None, 2, Some(&prepare_vhost_user_net_daemon), false)
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
+    #[test]
     fn test_vhost_user_net_tap() {
         test_vhost_user_net(
             Some("vunet-tap0"),
@@ -1333,12 +1335,12 @@ mod tests {
         )
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
+    #[test]
     fn test_vhost_user_net_multiple_queues() {
         test_vhost_user_net(None, 4, Some(&prepare_vhost_user_net_daemon), false)
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
+    #[test]
     fn test_vhost_user_net_tap_multiple_queues() {
         test_vhost_user_net(
             Some("vunet-tap1"),
@@ -1348,7 +1350,7 @@ mod tests {
         )
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
+    #[test]
     fn test_vhost_user_net_self_spawning() {
         test_vhost_user_net(None, 4, None, true)
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -96,6 +96,12 @@ mod tests {
     const BIONIC_IMAGE_NAME: &str = "bionic-server-cloudimg-amd64-raw.img";
     const EOAN_IMAGE_NAME: &str = "eoan-server-cloudimg-amd64-raw.img";
 
+    const CLEAR_KERNEL_CMDLINE: &str = "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c \
+                     console=tty0 console=ttyS0,115200n8 console=hvc0 quiet \
+                     init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable \
+                     no_timer_check noreplace-smp cryptomgr.notests \
+                     rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw";
+
     impl UbuntuDiskConfig {
         fn new(image_name: String) -> Self {
             UbuntuDiskConfig {
@@ -1020,12 +1026,12 @@ mod tests {
             kernel_path.push("vmlinux");
 
             let mut child = GuestCommand::new(&guest)
-                .args(&["--cpus","boot=1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .default_disks()
                 .default_net()
-                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw"])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .spawn()
                 .unwrap();
 
@@ -1065,12 +1071,12 @@ mod tests {
             kernel_path.push("vmlinux.pvh");
 
             let mut child = GuestCommand::new(&guest)
-                .args(&["--cpus","boot=1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .default_disks()
                 .default_net()
-                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw"])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .spawn()
                 .unwrap();
 
@@ -1110,12 +1116,12 @@ mod tests {
             kernel_path.push("bzImage");
 
             let mut child = GuestCommand::new(&guest)
-                .args(&["--cpus","boot=1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .default_disks()
                 .default_net()
-                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw"])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .spawn()
                 .unwrap();
 
@@ -1268,14 +1274,7 @@ mod tests {
                 .args(&["--cpus", format!("boot={}", num_queues / 2).as_str()])
                 .args(&["--memory", "size=512M,file=/dev/shm"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .args(&[
-                    "--cmdline",
-                    "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c \
-                     console=tty0 console=ttyS0,115200n8 console=hvc0 quiet \
-                     init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable \
-                     no_timer_check noreplace-smp cryptomgr.notests \
-                     rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw",
-                ])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .default_disks()
                 .args(&["--net", net_params.as_str()])
                 .spawn()
@@ -1420,14 +1419,7 @@ mod tests {
                 .args(&["--cpus", format!("boot={}", num_queues).as_str()])
                 .args(&["--memory", "size=512M,file=/dev/shm"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .args(&[
-                    "--cmdline",
-                    "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c \
-                     console=tty0 console=ttyS0,115200n8 console=hvc0 quiet \
-                     init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable \
-                     no_timer_check noreplace-smp cryptomgr.notests \
-                     rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw",
-                ])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .args(&[
                     "--disk",
                     format!(
@@ -1598,14 +1590,7 @@ mod tests {
                 .args(&["--cpus", format!("boot={}", num_queues).as_str()])
                 .args(&["--memory", "size=512M,file=/dev/shm"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .args(&[
-                    "--cmdline",
-                    "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c \
-                     console=tty0 console=ttyS0,115200n8 console=hvc0 quiet \
-                     init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable \
-                     no_timer_check noreplace-smp cryptomgr.notests \
-                     rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw",
-                ])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .args(&[
                     "--disk",
                     blk_boot_params.as_str(),
@@ -1767,14 +1752,7 @@ mod tests {
                     )
                     .as_str(),
                 ])
-                .args(&[
-                    "--cmdline",
-                    "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c \
-                     console=tty0 console=ttyS0,115200n8 console=hvc0 quiet \
-                     init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable \
-                     no_timer_check noreplace-smp cryptomgr.notests \
-                     rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw",
-                ])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .spawn()
                 .unwrap();
 
@@ -1990,26 +1968,38 @@ mod tests {
             kernel_path.push("vmlinux");
 
             let mut child = GuestCommand::new(&guest)
-                .args(&["--cpus","boot=1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .args(&["--disk",
+                .args(&[
+                    "--disk",
                     format!(
                         "path={}",
                         guest.disk_config.disk(DiskType::CloudInit).unwrap()
                     )
-                    .as_str()])
+                    .as_str(),
+                ])
                 .default_net()
                 .args(&[
                     "--pmem",
                     format!(
                         "file={},size={}",
-                        guest.disk_config.disk(DiskType::RawOperatingSystem).unwrap(),
-                        fs::metadata(&guest.disk_config.disk(DiskType::RawOperatingSystem).unwrap()).unwrap().len()
+                        guest
+                            .disk_config
+                            .disk(DiskType::RawOperatingSystem)
+                            .unwrap(),
+                        fs::metadata(
+                            &guest
+                                .disk_config
+                                .disk(DiskType::RawOperatingSystem)
+                                .unwrap()
+                        )
+                        .unwrap()
+                        .len()
                     )
                     .as_str(),
                 ])
-                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw"])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .spawn()
                 .unwrap();
 
@@ -2371,23 +2361,30 @@ mod tests {
                 .args(&["--memory", "size=1G,file=/dev/hugepages"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .default_disks()
-                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 vfio_iommu_type1.allow_unsafe_interrupts rw"])
+                .args(&[
+                    "--cmdline",
+                    format!(
+                        "{} vfio_iommu_type1.allow_unsafe_interrupts",
+                        CLEAR_KERNEL_CMDLINE
+                    )
+                    .as_str(),
+                ])
                 .args(&[
                     "--net",
+                    format!("tap={},mac={}", vfio_tap0, guest.network.guest_mac).as_str(),
                     format!(
-                        "tap={},mac={}", vfio_tap0, guest.network.guest_mac
+                        "tap={},mac={},iommu=on",
+                        vfio_tap1, guest.network.l2_guest_mac1
                     )
                     .as_str(),
                     format!(
-                        "tap={},mac={},iommu=on", vfio_tap1, guest.network.l2_guest_mac1
+                        "tap={},mac={},iommu=on",
+                        vfio_tap2, guest.network.l2_guest_mac2
                     )
                     .as_str(),
                     format!(
-                        "tap={},mac={},iommu=on", vfio_tap2, guest.network.l2_guest_mac2
-                    )
-                    .as_str(),
-                    format!(
-                        "tap={},mac={},iommu=on", vfio_tap3, guest.network.l2_guest_mac3
+                        "tap={},mac={},iommu=on",
+                        vfio_tap3, guest.network.l2_guest_mac3
                     )
                     .as_str(),
                 ])
@@ -2534,12 +2531,15 @@ mod tests {
             kernel_path.push("vmlinux");
 
             let mut child = GuestCommand::new(&guest)
-                .args(&["--cpus","boot=1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .default_disks()
                 .default_net()
-                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw acpi=off"])
+                .args(&[
+                    "--cmdline",
+                    format!("{} acpi=off", CLEAR_KERNEL_CMDLINE).as_str(),
+                ])
                 .spawn()
                 .unwrap();
 
@@ -2638,12 +2638,12 @@ mod tests {
             kernel_path.push("bzImage");
 
             let mut child = GuestCommand::new(&guest)
-                .args(&["--cpus","boot=1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .default_disks()
                 .default_net()
-                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw"])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .spawn()
                 .unwrap();
 
@@ -2899,7 +2899,7 @@ mod tests {
             kernel_path.push("bzImage");
 
             let mut child = GuestCommand::new(&guest)
-                .args(&["--cpus","boot=1"])
+                .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&[
@@ -2916,7 +2916,7 @@ mod tests {
                     .as_str(),
                 ])
                 .args(&["--net", guest.default_net_string_w_iommu().as_str()])
-                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw"])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .spawn()
                 .unwrap();
 
@@ -3168,7 +3168,7 @@ mod tests {
                 .args(&["--cpus", "boot=2,max=4"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw"])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .default_disks()
                 .default_net()
                 .args(&["--api-socket", &api_socket])
@@ -3249,7 +3249,7 @@ mod tests {
                 .args(&["--cpus", "boot=2,max=4"])
                 .args(&["--memory", "size=512M,hotplug_size=8192M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw"])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .default_disks()
                 .default_net()
                 .args(&["--api-socket", &api_socket])
@@ -3343,7 +3343,7 @@ mod tests {
                 .args(&["--cpus", "boot=2,max=4"])
                 .args(&["--memory", "size=512M,hotplug_size=8192M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw"])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .default_disks()
                 .default_net()
                 .args(&["--api-socket", &api_socket])
@@ -3429,12 +3429,15 @@ mod tests {
             let guest_memory_size_kb = 512 * 1024;
 
             let mut child = GuestCommand::new(&guest)
-                .args(&["--cpus","boot=1"])
-                .args(&["--memory", format!("size={}K", guest_memory_size_kb).as_str()])
+                .args(&["--cpus", "boot=1"])
+                .args(&[
+                    "--memory",
+                    format!("size={}K", guest_memory_size_kb).as_str(),
+                ])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .default_disks()
                 .default_net()
-                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw"])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .spawn()
                 .unwrap();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1355,7 +1355,7 @@ mod tests {
         test_vhost_user_net(None, 4, None, true)
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
+    #[test]
     fn test_vhost_user_blk() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1447,7 +1447,7 @@ mod tests {
         });
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
+    #[test]
     fn test_vhost_user_blk_self_spawning() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1535,7 +1535,7 @@ mod tests {
         });
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
+    #[test]
     fn test_vhost_user_blk_readonly() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1627,7 +1627,7 @@ mod tests {
         });
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
+    #[test]
     fn test_vhost_user_blk_direct() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1719,7 +1719,7 @@ mod tests {
         });
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
+    #[test]
     fn test_boot_from_vhost_user_blk() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1775,7 +1775,7 @@ mod tests {
         });
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
+    #[test]
     fn test_boot_from_vhost_user_blk_self_spawning() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1808,24 +1808,28 @@ mod tests {
             aver_eq!(tb, guest.get_cpu_count().unwrap_or_default(), 1);
             aver!(tb, guest.get_total_memory().unwrap_or_default() > 491_000);
 
-            let reboot_count = guest
-                .ssh_command("sudo journalctl | grep -c -- \"-- Reboot --\"")
-                .unwrap_or_default()
-                .trim()
-                .parse::<u32>()
-                .unwrap_or(1);
+            // The reboot is not supported with mmio, so no reason to test it.
+            #[cfg(not(feature = "mmio"))]
+            {
+                let reboot_count = guest
+                    .ssh_command("sudo journalctl | grep -c -- \"-- Reboot --\"")
+                    .unwrap_or_default()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or(1);
 
-            aver_eq!(tb, reboot_count, 0);
-            guest.ssh_command("sudo reboot").unwrap_or_default();
+                aver_eq!(tb, reboot_count, 0);
+                guest.ssh_command("sudo reboot").unwrap_or_default();
 
-            thread::sleep(std::time::Duration::new(20, 0));
-            let reboot_count = guest
-                .ssh_command("sudo journalctl | grep -c -- \"-- Reboot --\"")
-                .unwrap_or_default()
-                .trim()
-                .parse::<u32>()
-                .unwrap_or_default();
-            aver_eq!(tb, reboot_count, 1);
+                thread::sleep(std::time::Duration::new(20, 0));
+                let reboot_count = guest
+                    .ssh_command("sudo journalctl | grep -c -- \"-- Reboot --\"")
+                    .unwrap_or_default()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default();
+                aver_eq!(tb, reboot_count, 1);
+            }
 
             let _ = cloud_child.kill();
             let _ = cloud_child.wait();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1235,6 +1235,12 @@ mod tests {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
 
+            let mut workload_path = dirs::home_dir().unwrap();
+            workload_path.push("workloads");
+
+            let mut kernel_path = workload_path;
+            kernel_path.push("vmlinux");
+
             let (net_params, daemon_child) = if self_spawned {
                 (
                     format!(
@@ -1261,7 +1267,15 @@ mod tests {
             let mut cloud_child = GuestCommand::new(&guest)
                 .args(&["--cpus", format!("boot={}", num_queues / 2).as_str()])
                 .args(&["--memory", "size=512M,file=/dev/shm"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .args(&[
+                    "--cmdline",
+                    "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c \
+                     console=tty0 console=ttyS0,115200n8 console=hvc0 quiet \
+                     init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable \
+                     no_timer_check noreplace-smp cryptomgr.notests \
+                     rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw",
+                ])
                 .default_disks()
                 .args(&["--net", net_params.as_str()])
                 .spawn()
@@ -1369,10 +1383,13 @@ mod tests {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
 
-            let (blk_params, daemon_child) = if self_spawned {
-                let mut workload_path = dirs::home_dir().unwrap();
-                workload_path.push("workloads");
+            let mut workload_path = dirs::home_dir().unwrap();
+            workload_path.push("workloads");
 
+            let mut kernel_path = workload_path.clone();
+            kernel_path.push("vmlinux");
+
+            let (blk_params, daemon_child) = if self_spawned {
                 let mut blk_file_path = workload_path;
                 blk_file_path.push("blk.img");
                 let blk_file_path = String::from(blk_file_path.to_str().unwrap());
@@ -1402,7 +1419,15 @@ mod tests {
             let mut cloud_child = GuestCommand::new(&guest)
                 .args(&["--cpus", format!("boot={}", num_queues).as_str()])
                 .args(&["--memory", "size=512M,file=/dev/shm"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .args(&[
+                    "--cmdline",
+                    "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c \
+                     console=tty0 console=ttyS0,115200n8 console=hvc0 quiet \
+                     init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable \
+                     no_timer_check noreplace-smp cryptomgr.notests \
+                     rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw",
+                ])
                 .args(&[
                     "--disk",
                     format!(
@@ -1529,6 +1554,13 @@ mod tests {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
+
+            let mut workload_path = dirs::home_dir().unwrap();
+            workload_path.push("workloads");
+
+            let mut kernel_path = workload_path;
+            kernel_path.push("vmlinux");
+
             let disk_path = guest
                 .disk_config
                 .disk(DiskType::RawOperatingSystem)
@@ -1565,7 +1597,15 @@ mod tests {
             let mut cloud_child = GuestCommand::new(&guest)
                 .args(&["--cpus", format!("boot={}", num_queues).as_str()])
                 .args(&["--memory", "size=512M,file=/dev/shm"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .args(&[
+                    "--cmdline",
+                    "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c \
+                     console=tty0 console=ttyS0,115200n8 console=hvc0 quiet \
+                     init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable \
+                     no_timer_check noreplace-smp cryptomgr.notests \
+                     rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw",
+                ])
                 .args(&[
                     "--disk",
                     blk_boot_params.as_str(),

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use super::*;
+use crate::{ActivateResult, Error, Queue};
 use std::sync::Arc;
 use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryMmap, GuestUsize};
 use vmm_sys_util::eventfd::EventFd;
@@ -106,6 +106,10 @@ pub trait VirtioDevice: Send {
     /// every device as part of shutting down the VM. Acting on the device
     /// after a shutdown() can lead to unpredictable results.
     fn shutdown(&mut self) {}
+
+    fn update_memory(&mut self, _mem: &GuestMemoryMmap) -> std::result::Result<(), Error> {
+        Ok(())
+    }
 }
 
 /// Trait providing address translation the same way a physical DMA remapping

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -175,4 +175,5 @@ pub enum Error {
     EpollCtl(io::Error),
     EpollWait(io::Error),
     FailedSignalingDriver(io::Error),
+    VhostUserUpdateMemory(vhost_user::Error),
 }

--- a/vm-virtio/src/vhost_user/blk.rs
+++ b/vm-virtio/src/vhost_user/blk.rs
@@ -321,6 +321,10 @@ impl VirtioDevice for Blk {
     fn shutdown(&mut self) {
         let _ = unsafe { libc::close(self.vhost_user_blk.as_raw_fd()) };
     }
+
+    fn update_memory(&mut self, mem: &GuestMemoryMmap) -> std::result::Result<(), crate::Error> {
+        update_mem_table(&mut self.vhost_user_blk, mem).map_err(crate::Error::VhostUserUpdateMemory)
+    }
 }
 
 virtio_pausable!(Blk);

--- a/vm-virtio/src/vhost_user/fs.rs
+++ b/vm-virtio/src/vhost_user/fs.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::vu_common_ctrl::{reset_vhost_user, setup_vhost_user};
+use super::vu_common_ctrl::{reset_vhost_user, setup_vhost_user, update_mem_table};
 use super::Error as DeviceError;
 use super::{Error, Result};
 use crate::vhost_user::handler::{VhostUserEpollConfig, VhostUserEpollHandler};
@@ -528,6 +528,10 @@ impl VirtioDevice for Fs {
         } else {
             None
         }
+    }
+
+    fn update_memory(&mut self, mem: &GuestMemoryMmap) -> std::result::Result<(), crate::Error> {
+        update_mem_table(&mut self.vu, mem).map_err(crate::Error::VhostUserUpdateMemory)
     }
 }
 

--- a/vm-virtio/src/vhost_user/net.rs
+++ b/vm-virtio/src/vhost_user/net.rs
@@ -358,6 +358,10 @@ impl VirtioDevice for Net {
     fn shutdown(&mut self) {
         let _ = unsafe { libc::close(self.vhost_user_net.as_raw_fd()) };
     }
+
+    fn update_memory(&mut self, mem: &GuestMemoryMmap) -> std::result::Result<(), crate::Error> {
+        update_mem_table(&mut self.vhost_user_net, mem).map_err(crate::Error::VhostUserUpdateMemory)
+    }
 }
 
 virtio_ctrl_q_pausable!(Net);

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -556,6 +556,12 @@ impl Vm {
                 self.device_manager
                     .lock()
                     .unwrap()
+                    .update_memory()
+                    .map_err(Error::DeviceManager)?;
+
+                self.device_manager
+                    .lock()
+                    .unwrap()
                     .notify_hotplug(HotPlugNotificationFlags::MEMORY_DEVICES_CHANGED)
                     .map_err(Error::DeviceManager)?;
             }


### PR DESCRIPTION
This PR fills the lack of support regarding memory hotplug and vhost-user backends. The vhost-user device must explicitly notify the backend with the new regions whenever the guest memory changes.
This is important as it will let virtio-fs work with memory hotplug, which is a use case for Kata Containers.