### PR TITLE
build: Bump vm-memory and linux-loader dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@
 name = "acpi_tables"
 version = "0.1.0"
 dependencies = [
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -45,7 +45,7 @@ dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "linux-loader 0.1.0 (git+https://github.com/rust-vmm/linux-loader)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -176,7 +176,7 @@ dependencies = [
  "vhost_user_net 0.1.0",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-device 0.1.0",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-virtio 0.1.0",
  "vmm 0.1.0",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -226,7 +226,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-device 0.1.0",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -467,9 +467,9 @@ dependencies = [
 [[package]]
 name = "linux-loader"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/linux-loader#0ce5bfa70d1073a9743fadfea233edef09c81e49"
+source = "git+https://github.com/rust-vmm/linux-loader#bf2e6ea1500e1f92c4d7721b234824a2db8e9a40"
 dependencies = [
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -583,7 +583,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1128,7 +1128,7 @@ dependencies = [
  "vfio-bindings 0.1.0 (git+https://github.com/rust-vmm/vfio-bindings)",
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1159,7 +1159,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-virtio 0.1.0",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1176,7 +1176,7 @@ dependencies = [
  "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
  "vhost_user_backend 0.1.0",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-virtio 0.1.0",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1189,7 +1189,7 @@ dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-virtio 0.1.0",
 ]
 
@@ -1205,7 +1205,7 @@ dependencies = [
  "vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)",
  "vhost_user_backend 0.1.0",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-virtio 0.1.0",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1225,7 +1225,7 @@ name = "vm-allocator"
 version = "0.1.0"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1237,13 +1237,13 @@ dependencies = [
  "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "vm-memory"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arc-swap 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1269,7 +1269,7 @@ dependencies = [
  "virtio-bindings 0.1.0 (git+https://github.com/rust-vmm/virtio-bindings)",
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1302,7 +1302,7 @@ dependencies = [
  "vfio 0.0.1",
  "vm-allocator 0.1.0",
  "vm-device 0.1.0",
- "vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-virtio 0.1.0",
  "vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1485,7 +1485,7 @@ dependencies = [
 "checksum vhost 0.1.0 (git+https://github.com/cloud-hypervisor/vhost?branch=dragonball)" = "<none>"
 "checksum virtio-bindings 0.1.0 (git+https://github.com/rust-vmm/virtio-bindings)" = "<none>"
 "checksum virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
-"checksum vm-memory 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d5563ea4d856645b13bc9623e6a0617457a77555a22301d896597cbc5131c2b"
+"checksum vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98d50eb34b2ec250e098fbad7486e81f592a1bdeff2b10f0433638f3ce6a0828"
 "checksum vmm-sys-util 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "048b10a74f061d87dacca196a1964052a7135651641ab8d100aef21e58f33571"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ vhost_user_net = { path = "vhost_user_net"}
 virtio-bindings = "0.1.0"
 vmm = { path = "vmm" }
 vm-device = { path = "vm-device" }
-vm-memory = "0.1.0"
+vm-memory = "0.2.0"
 vmm-sys-util = "0.4.0"
 vm-virtio = { path = "vm-virtio" }
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }

--- a/acpi_tables/Cargo.toml
+++ b/acpi_tables/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 
 [dependencies]
-vm-memory = "0.1.0"
+vm-memory = "0.2.0"
 

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -11,7 +11,7 @@ byteorder = "1.3.4"
 kvm-bindings = "0.2.0"
 kvm-ioctls = "0.5.0"
 libc = "0.2.68"
-vm-memory = { version = "0.1.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.2.0", features = ["backend-mmap"] }
 
 acpi_tables = { path = "../acpi_tables", optional = true }
 arch_gen = { path = "../arch_gen" }

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -11,7 +11,7 @@ libc = "0.2.68"
 log = "0.4.8"
 vm-device = { path = "../vm-device" }
 acpi_tables = { path = "../acpi_tables", optional = true }
-vm-memory = "0.1.0"
+vm-memory = "0.2.0"
 vmm-sys-util = ">=0.3.1"
 
 [dev-dependencies]

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -11,4 +11,4 @@ devices = { path = "../devices" }
 libc = "0.2.68"
 log = "0.4.8"
 vm-device = { path = "../vm-device" }
-vm-memory = "0.1.0"
+vm-memory = "0.2.0"

--- a/vfio/Cargo.toml
+++ b/vfio/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4.8"
 pci = { path = "../pci" }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.1.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.2.0", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.3.1"
 
 [dependencies.vfio-bindings]

--- a/vhost_user_backend/Cargo.toml
+++ b/vhost_user_backend/Cargo.toml
@@ -14,7 +14,7 @@ epoll = ">=4.0.1"
 libc = "0.2.68"
 log = "0.4.8"
 virtio-bindings = "0.1.0"
-vm-memory = "0.1.0"
+vm-memory = "0.2.0"
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -13,6 +13,6 @@ qcow = { path = "../qcow" }
 vhost_user_backend = { path = "../vhost_user_backend" }
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
-vm-memory = "0.1.0"
+vm-memory = "0.2.0"
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"

--- a/vhost_user_fs/Cargo.toml
+++ b/vhost_user_fs/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 bitflags = "1.1.0"
 libc = "0.2.68"
 log = "0.4.8"
-vm-memory = "0.1.0"
+vm-memory = "0.2.0"
 vm-virtio = { path = "../vm-virtio" }
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -13,6 +13,6 @@ net_util = { path = "../net_util" }
 vhost_user_backend = { path = "../vhost_user_backend" }
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
-vm-memory = "0.1.0"
+vm-memory = "0.2.0"
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.68"
-vm-memory = "0.1.0"
+vm-memory = "0.2.0"

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -10,6 +10,6 @@ thiserror = "1.0"
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
-vm-memory = { version = "0.1.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.2.0", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.3.1"
 

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -23,6 +23,6 @@ tempfile = "3.1.0"
 virtio-bindings = { git = "https://github.com/rust-vmm/virtio-bindings", version = "0.1", features = ["virtio-v5_0_0"]}
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.1.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.2.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = ">=0.3.1"
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-master", "vhost-user-slave"] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = ">=1.0.9"
 vfio = { path = "../vfio", optional = true }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.1.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.2.0", features = ["backend-mmap", "backend-atomic"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 signal-hook = "0.1.13"


### PR DESCRIPTION
linux-loader depends on vm-memory so must be updated at the same time.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>