### PR TITLE
devices: ioapic: Remove unused MsiMessage structure

### DIFF
--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -99,25 +99,6 @@ fn set_remote_irr(entry: &mut RedirectionTableEntry, val: u8) {
     *entry |= u64::from(val & 0x1) << 14;
 }
 
-pub struct MsiMessage {
-    // Message Address Register
-    //   31-20: Base address. Fixed value (0x0FEE)
-    //   19-12: Destination ID
-    //   11-4:  Reserved
-    //   3:     Redirection Hint indication
-    //   2:     Destination Mode
-    //   1-0:   Reserved
-    pub addr: u32,
-    // Message Data Register
-    //   32-16: Reserved
-    //   15:    Trigger Mode. 0 = Edge, 1 = Level
-    //   14:    Level. 0 = Deassert, 1 = Assert
-    //   13-11: Reserved
-    //   10-8:  Delivery Mode
-    //   7-0:   Vector
-    pub data: u32,
-}
-
 pub const NUM_IOAPIC_PINS: usize = 24;
 const IOAPIC_VERSION_ID: u32 = 0x0017_0011;
 


### PR DESCRIPTION
Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>