### PR TITLE
Add network device hotplug

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -94,6 +94,7 @@ Add VFIO PCI device to the VM      | `/vm.add-device`    | `/schemas/VmAddDevice
 Remove VFIO PCI device from the VM | `/vm.remove-device` | `/schemas/VmRemoveDevice` | N/A               | The VM is booted
 Add disk device to the VM          | `/vm.add-disk`      | `/schemas/DiskConfig`     | N/A               | The VM is booted
 Add pmem device to the VM          | `/vm.add-pmem`      | `/schemas/PmemConfig`     | N/A               | The VM is booted
+Add network device to the VM       | `/vm.add-net`       | `/schemas/NetConfig`     | N/A               | The VM is booted
 
 ### REST API Examples
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,12 +131,7 @@ fn create_app<'a, 'b>(
         .arg(
             Arg::with_name("net")
                 .long("net")
-                .help(
-                    "Network parameters \
-                     \"tap=<if_name>,ip=<ip_addr>,mask=<net_mask>,mac=<mac_addr>,iommu=on|off,\
-                     num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,\
-                     vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>\"",
-                )
+                .help(config::NetConfig::SYNTAX)
                 .takes_value(true)
                 .min_values(1)
                 .group("vm-config"),

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -4,8 +4,8 @@
 //
 
 use crate::api::http_endpoint::{
-    VmActionHandler, VmAddDevice, VmAddDisk, VmAddPmem, VmCreate, VmInfo, VmRemoveDevice, VmResize,
-    VmmPing, VmmShutdown,
+    VmActionHandler, VmAddDevice, VmAddDisk, VmAddNet, VmAddPmem, VmCreate, VmInfo, VmRemoveDevice,
+    VmResize, VmmPing, VmmShutdown,
 };
 use crate::api::{ApiRequest, VmAction};
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
@@ -69,6 +69,7 @@ lazy_static! {
         r.routes.insert(endpoint!("/vm.remove-device"), Box::new(VmRemoveDevice {}));
         r.routes.insert(endpoint!("/vm.add-disk"), Box::new(VmAddDisk {}));
         r.routes.insert(endpoint!("/vm.add-pmem"), Box::new(VmAddPmem {}));
+        r.routes.insert(endpoint!("/vm.add-net"), Box::new(VmAddNet {}));
 
         r
     };

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -203,6 +203,22 @@ paths:
         500:
           description: The new device could not be added to the VM instance.
 
+  /vm.add-net:
+    put:
+      summary: Add a new network device to the VM
+      requestBody:
+        description: The details of the new network device
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NetConfig'
+        required: true
+      responses:
+        204:
+          description: The new device was successfully added to the VM instance.
+        500:
+          description: The new device could not be added to the VM instance.
+
 components:
   schemas:
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -553,6 +553,11 @@ fn default_netconfig_queue_size() -> u16 {
 }
 
 impl NetConfig {
+    pub const SYNTAX: &'static str = "Network parameters \
+    \"tap=<if_name>,ip=<ip_addr>,mask=<net_mask>,mac=<mac_addr>,iommu=on|off,\
+    num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,\
+    vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>\"";
+
     pub fn parse(net: &str) -> Result<Self> {
         // Split the parameters based on the comma delimiter
         let params_list: Vec<&str> = net.split(',').collect();

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2072,6 +2072,12 @@ impl DeviceManager {
         let (device, iommu_attached) = self.make_virtio_pmem_device(pmem_cfg)?;
         self.hotplug_virtio_pci_device(device, iommu_attached)
     }
+
+    #[cfg(feature = "pci_support")]
+    pub fn add_net(&mut self, net_cfg: &mut NetConfig) -> DeviceManagerResult<()> {
+        let (device, iommu_attached) = self.make_virtio_net_device(net_cfg)?;
+        self.hotplug_virtio_pci_device(device, iommu_attached)
+    }
 }
 
 #[cfg(feature = "acpi")]


### PR DESCRIPTION
The integration test is kinda novel. It boots without a network and then adds one with the details it would have used for the boot one. This means the existing cloud init infrastructure is reused and it isn't necessary to add another special purpose network device to our tests.