### PR TITLE
vhost-user-fs: validate fs_slave_map/unmap/sync request

### DIFF
--- a/vm-virtio/src/vhost_user/fs.rs
+++ b/vm-virtio/src/vhost_user/fs.rs
@@ -71,7 +71,7 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
             }
 
             if !self.is_req_valid(offset, len) {
-                return Err(io::Error::new(io::ErrorKind::Other, "Wrong offset"));
+                return Err(io::Error::from_raw_os_error(libc::EINVAL));
             }
 
             let addr = self.mmap_cache_addr + offset;
@@ -117,7 +117,7 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
             }
 
             if !self.is_req_valid(offset, len) {
-                return Err(io::Error::new(io::ErrorKind::Other, "Wrong offset"));
+                return Err(io::Error::from_raw_os_error(libc::EINVAL));
             }
 
             let addr = self.mmap_cache_addr + offset;
@@ -152,7 +152,7 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
             }
 
             if !self.is_req_valid(offset, len) {
-                return Err(io::Error::new(io::ErrorKind::Other, "Wrong offset"));
+                return Err(io::Error::from_raw_os_error(libc::EINVAL));
             }
 
             let addr = self.mmap_cache_addr + offset;


### PR DESCRIPTION
In fs_slave_map/unmap/sync, we only made sure offset < cache_size, but
didn't validate (offset + len). We should ensure [offset, offset+len]
is within cache range as well.

And while we're at it, return libc::EINVAL instead of custom "Wrong
offset" error, as mmap(2) returns EINVAL when offset/len is invalid.

Fixes: #967 
Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>