### PR TITLE
vmm: Move to the latest linux-loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "linux-loader"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/linux-loader#bf2e6ea1500e1f92c4d7721b234824a2db8e9a40"
+source = "git+https://github.com/rust-vmm/linux-loader#2adddce25b37f68c99ae8e7db1cb7f5853626fdd"
 dependencies = [
  "vm-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -16,7 +16,7 @@ pub mod regs;
 use crate::InitramfsConfig;
 use crate::RegionType;
 use linux_loader::loader::bootparam::{boot_params, setup_header};
-use linux_loader::loader::start_info::{hvm_memmap_table_entry, hvm_start_info};
+use linux_loader::loader::elf::start_info::{hvm_memmap_table_entry, hvm_start_info};
 use std::mem;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion,


### PR DESCRIPTION
Commit 2adddce2 reorganized the crate for a cleaner multi architecture
(x86_64 and aarch64) support.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>