### PR TITLE
vmm: memory_manager: fix the issue virtio-mem start_addr is not align…

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -249,7 +249,8 @@ impl MemoryManager {
             if hotplug_method == HotplugMethod::VirtioMem {
                 let start_addr = GuestAddress(
                     (start_of_device_area.0 + vm_virtio::VIRTIO_MEM_DEFAULT_BLOCK_SIZE - 1)
-                        & (!(vm_virtio::VIRTIO_MEM_DEFAULT_BLOCK_SIZE - 1)),
+                        / vm_virtio::VIRTIO_MEM_DEFAULT_BLOCK_SIZE
+                        * vm_virtio::VIRTIO_MEM_DEFAULT_BLOCK_SIZE,
                 );
                 virtiomem_region = Some(MemoryManager::create_ram_region(
                     backing_file,


### PR DESCRIPTION
…ed with block

We can't assume virtio-mem block size is always the power of 2.
And the bitwise operation fixed by this commit can't align the start_addr
with block size if VIRTIO_MEM_DEFAULT_BLOCK_SIZE is not the power of 2.

Signed-off-by: MartinXu <martin.xu@intel.com>