### PR TITLE
main: Change default value of seccomp to false

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -260,7 +260,7 @@ fn create_app<'a, 'b>(
                 .long("seccomp")
                 .takes_value(true)
                 .possible_values(&["true", "false"])
-                .default_value("true"),
+                .default_value("false"),
         )
 }
 


### PR DESCRIPTION
Got "Bad system call" in 2 machines because seccomp is set to true.
Change default value of seccomp to false to handle the issue.

Fixes: #986

Signed-off-by: Hui Zhu <teawater@antfin.com>