### PR TITLE
vmm: seccomp: Add missing open() syscall

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -206,6 +206,7 @@ pub fn vmm_thread_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_mprotect),
             allow_syscall(libc::SYS_munmap),
             allow_syscall(libc::SYS_nanosleep),
+            allow_syscall(libc::SYS_open),
             allow_syscall(libc::SYS_openat),
             allow_syscall(libc::SYS_prctl),
             allow_syscall(libc::SYS_pread64),


### PR DESCRIPTION
On some systems, the open() system call is used by Cloud-Hypervisor,
that's why it should be part of the seccomp filters whitelist.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>