### PR TITLE
devices: Implement snapshot/restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,14 +242,19 @@ name = "devices"
 version = "0.1.0"
 dependencies = [
  "acpi_tables",
+ "anyhow",
  "bitflags 1.2.1",
  "byteorder",
  "epoll",
  "libc",
  "log 0.4.8",
+ "serde",
+ "serde_derive",
+ "serde_json",
  "tempfile",
  "vm-device",
  "vm-memory",
+ "vm-migration",
  "vmm-sys-util",
 ]
 

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -4,14 +4,19 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
+anyhow = "1.0"
 bitflags = ">=1.2.1"
 byteorder = "1.3.4"
 epoll = ">=4.0.1"
 libc = "0.2.68"
 log = "0.4.8"
+serde = {version = ">=1.0.27", features = ["rc"] }
+serde_derive = ">=1.0.27"
+serde_json = ">=1.0.9"
 vm-device = { path = "../vm-device" }
 acpi_tables = { path = "../acpi_tables", optional = true }
 vm-memory = "0.2.0"
+vm-migration = { path = "../vm-migration" }
 vmm-sys-util = ">=0.3.1"
 
 [dev-dependencies]

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -6,6 +6,7 @@
 // found in the LICENSE-BSD-3-Clause file.
 
 //! Emulates virtual and hardware devices.
+extern crate anyhow;
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;
@@ -15,9 +16,14 @@ extern crate libc;
 extern crate log;
 #[cfg(feature = "acpi")]
 extern crate acpi_tables;
+extern crate serde;
 extern crate vm_device;
 extern crate vm_memory;
+extern crate vm_migration;
 extern crate vmm_sys_util;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
 
 use std::fs::File;
 use std::io;


### PR DESCRIPTION
This pull request implements the `Snapshottable` trait for both `Ioapic` and `Serial` devices. This will allow a VM containing these devices to be properly snapshotted and restored.