### PR TITLE
Improve command line parsing

### DIFF
--- a/net_util/src/mac.rs
+++ b/net_util/src/mac.rs
@@ -9,6 +9,7 @@ use rand::Rng;
 use std::fmt;
 use std::io;
 use std::result::Result;
+use std::str::FromStr;
 
 use serde::de::{Deserialize, Deserializer, Error};
 use serde::ser::{Serialize, Serializer};
@@ -117,6 +118,18 @@ impl<'de> Deserialize<'de> for MacAddr {
         let s = String::deserialize(deserializer)?;
         MacAddr::parse_str(&s)
             .map_err(|e| D::Error::custom(format!("The provided MAC address is invalid: {}", e)))
+    }
+}
+
+pub enum MacAddrParseError {
+    InvalidValue(String),
+}
+
+impl FromStr for MacAddr {
+    type Err = MacAddrParseError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        MacAddr::parse_str(s).map_err(|_| MacAddrParseError::InvalidValue(s.to_owned()))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,7 +280,7 @@ fn start_vmm(cmd_arguments: ArgMatches) {
     let vm_config = match config::VmConfig::parse(vm_params) {
         Ok(config) => config,
         Err(e) => {
-            println!("Failed parsing parameters {:?}", e);
+            println!("{}", e);
             process::exit(1);
         }
     };

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1296,4 +1296,26 @@ mod tests {
         assert!(parser.is_set("size"));
         Ok(())
     }
+
+    #[test]
+    fn test_cpu_parsing() -> Result<()> {
+        assert_eq!(CpusConfig::parse("")?, CpusConfig::default());
+
+        assert_eq!(
+            CpusConfig::parse("boot=1")?,
+            CpusConfig {
+                boot_vcpus: 1,
+                max_vcpus: 1
+            }
+        );
+        assert_eq!(
+            CpusConfig::parse("boot=1,max=2")?,
+            CpusConfig {
+                boot_vcpus: 1,
+                max_vcpus: 2,
+            }
+        );
+        assert!(CpusConfig::parse("boot=2,max=1").is_err());
+        Ok(())
+    }
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -507,6 +507,23 @@ fn default_diskconfig_poll_queue() -> bool {
     true
 }
 
+impl Default for DiskConfig {
+    fn default() -> Self {
+        Self {
+            path: None,
+            readonly: false,
+            direct: false,
+            iommu: false,
+            num_queues: default_diskconfig_num_queues(),
+            queue_size: default_diskconfig_queue_size(),
+            vhost_user: false,
+            vhost_socket: None,
+            wce: default_diskconfig_wce(),
+            poll_queue: default_diskconfig_poll_queue(),
+        }
+    }
+}
+
 impl DiskConfig {
     pub const SYNTAX: &'static str = "Disk parameters \
          \"path=<disk_image_path>,readonly=on|off,iommu=on|off,num_queues=<number_of_queues>,\
@@ -1394,6 +1411,95 @@ mod tests {
                 ..Default::default()
             }
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_disk_parsing() -> Result<()> {
+        assert_eq!(
+            DiskConfig::parse("path=/path/to_file")?,
+            DiskConfig {
+                path: Some(PathBuf::from("/path/to_file")),
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            DiskConfig::parse("path=/path/to_file,vhost_user=true")?,
+            DiskConfig {
+                path: Some(PathBuf::from("/path/to_file")),
+                vhost_user: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            DiskConfig::parse("path=/path/to_file,iommu=on")?,
+            DiskConfig {
+                path: Some(PathBuf::from("/path/to_file")),
+                iommu: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            DiskConfig::parse("path=/path/to_file,iommu=on,queue_size=256")?,
+            DiskConfig {
+                path: Some(PathBuf::from("/path/to_file")),
+                iommu: true,
+                queue_size: 256,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            DiskConfig::parse("path=/path/to_file,iommu=on,queue_size=256,num_queues=4")?,
+            DiskConfig {
+                path: Some(PathBuf::from("/path/to_file")),
+                iommu: true,
+                queue_size: 256,
+                num_queues: 4,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            DiskConfig::parse("path=/path/to_file,direct=on")?,
+            DiskConfig {
+                path: Some(PathBuf::from("/path/to_file")),
+                direct: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            DiskConfig::parse("path=/path/to_file,wce=true")?,
+            DiskConfig {
+                path: Some(PathBuf::from("/path/to_file")),
+                wce: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            DiskConfig::parse("path=/path/to_file,wce=false")?,
+            DiskConfig {
+                path: Some(PathBuf::from("/path/to_file")),
+                wce: false,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            DiskConfig::parse("path=/path/to_file,poll_queue=false")?,
+            DiskConfig {
+                path: Some(PathBuf::from("/path/to_file")),
+                poll_queue: false,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            DiskConfig::parse("path=/path/to_file,poll_queue=true")?,
+            DiskConfig {
+                path: Some(PathBuf::from("/path/to_file")),
+                poll_queue: true,
+                ..Default::default()
+            }
+        );
+        assert!(DiskConfig::parse("path=/path/to_file,socket=/path/to_socket").is_err());
+
         Ok(())
     }
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -250,10 +250,12 @@ impl FromStr for Toggle {
     type Err = ToggleParseError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        match s {
+        match s.to_lowercase().as_str() {
             "" => Ok(Toggle(false)),
             "on" => Ok(Toggle(true)),
             "off" => Ok(Toggle(false)),
+            "true" => Ok(Toggle(true)),
+            "false" => Ok(Toggle(false)),
             _ => Err(ToggleParseError::InvalidValue(s.to_owned())),
         }
     }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1682,4 +1682,27 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_vsock_parsing() -> Result<()> {
+        // sock and cid is required
+        assert!(VsockConfig::parse("").is_err());
+        assert_eq!(
+            VsockConfig::parse("sock=/tmp/sock,cid=1")?,
+            VsockConfig {
+                cid: 1,
+                sock: PathBuf::from("/tmp/sock"),
+                iommu: false
+            }
+        );
+        assert_eq!(
+            VsockConfig::parse("sock=/tmp/sock,cid=1,iommu=on")?,
+            VsockConfig {
+                cid: 1,
+                sock: PathBuf::from("/tmp/sock"),
+                iommu: true
+            }
+        );
+        Ok(())
+    }
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -349,7 +349,7 @@ impl MemoryConfig {
         // Split the parameters based on the comma delimiter
         let params_list: Vec<&str> = memory.split(',').collect();
 
-        let mut size_str: &str = "";
+        let mut size_str: &str = "512M";
         let mut file_str: &str = "";
         let mut mergeable_str: &str = "";
         let mut backed = false;
@@ -1304,6 +1304,66 @@ mod tests {
             }
         );
         assert!(CpusConfig::parse("boot=2,max=1").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_mem_parsing() -> Result<()> {
+        assert_eq!(MemoryConfig::parse("")?, MemoryConfig::default());
+        // Default string
+        assert_eq!(MemoryConfig::parse("size=512M")?, MemoryConfig::default());
+        assert_eq!(
+            MemoryConfig::parse("size=512M,file=/some/file")?,
+            MemoryConfig {
+                size: 512 << 20,
+                file: Some(PathBuf::from("/some/file")),
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            MemoryConfig::parse("size=512M,mergeable=on")?,
+            MemoryConfig {
+                size: 512 << 20,
+                mergeable: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            MemoryConfig::parse("mergeable=on")?,
+            MemoryConfig {
+                mergeable: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            MemoryConfig::parse("size=1G,mergeable=off")?,
+            MemoryConfig {
+                size: 1 << 30,
+                mergeable: false,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            MemoryConfig::parse("hotplug_method=acpi")?,
+            MemoryConfig {
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            MemoryConfig::parse("hotplug_method=acpi,hotplug_size=512M")?,
+            MemoryConfig {
+                hotplug_size: Some(512 << 20),
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            MemoryConfig::parse("hotplug_method=virtio-mem,hotplug_size=512M")?,
+            MemoryConfig {
+                hotplug_size: Some(512 << 20),
+                hotplug_method: HotplugMethod::VirtioMem,
+                ..Default::default()
+            }
+        );
         Ok(())
     }
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1657,4 +1657,36 @@ mod tests {
         );
         Ok(())
     }
+
+    #[test]
+    fn test_device_parsing() -> Result<()> {
+        assert_eq!(
+            DeviceConfig::parse("path=/path/to/device")?,
+            DeviceConfig {
+                path: PathBuf::from("/path/to/device"),
+                id: None,
+                iommu: false
+            }
+        );
+
+        assert_eq!(
+            DeviceConfig::parse("path=/path/to/device,iommu=on")?,
+            DeviceConfig {
+                path: PathBuf::from("/path/to/device"),
+                id: None,
+                iommu: true
+            }
+        );
+
+        assert_eq!(
+            DeviceConfig::parse("path=/path/to/device,iommu=on,id=mydevice0")?,
+            DeviceConfig {
+                path: PathBuf::from("/path/to/device"),
+                id: Some("mydevice0".to_owned()),
+                iommu: true
+            }
+        );
+
+        Ok(())
+    }
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1585,4 +1585,59 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_console_parsing() -> Result<()> {
+        assert!(ConsoleConfig::parse("").is_err());
+        assert!(ConsoleConfig::parse("badmode").is_err());
+        assert_eq!(
+            ConsoleConfig::parse("off")?,
+            ConsoleConfig {
+                mode: ConsoleOutputMode::Off,
+                iommu: false,
+                file: None,
+            }
+        );
+        assert_eq!(
+            ConsoleConfig::parse("tty")?,
+            ConsoleConfig {
+                mode: ConsoleOutputMode::Tty,
+                iommu: false,
+                file: None,
+            }
+        );
+        assert_eq!(
+            ConsoleConfig::parse("null")?,
+            ConsoleConfig {
+                mode: ConsoleOutputMode::Null,
+                iommu: false,
+                file: None,
+            }
+        );
+        assert_eq!(
+            ConsoleConfig::parse("file=/tmp/console")?,
+            ConsoleConfig {
+                mode: ConsoleOutputMode::File,
+                iommu: false,
+                file: Some(PathBuf::from("/tmp/console"))
+            }
+        );
+        assert_eq!(
+            ConsoleConfig::parse("null,iommu=on")?,
+            ConsoleConfig {
+                mode: ConsoleOutputMode::Null,
+                iommu: true,
+                file: None,
+            }
+        );
+        assert_eq!(
+            ConsoleConfig::parse("file=/tmp/console,iommu=on")?,
+            ConsoleConfig {
+                mode: ConsoleOutputMode::File,
+                iommu: true,
+                file: Some(PathBuf::from("/tmp/console"))
+            }
+        );
+        Ok(())
+    }
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -246,6 +246,22 @@ impl<'a> VmParams<'a> {
     }
 }
 
+struct Toggle(bool);
+
+enum ToggleParseError {
+    InvalidValue(String),
+}
+
+impl FromStr for Toggle {
+    type Err = ToggleParseError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(Toggle(parse_on_off(s).map_err(|_| {
+            ToggleParseError::InvalidValue(s.to_owned())
+        })?))
+    }
+}
+
 fn parse_size(size: &str) -> Result<u64> {
     let s = size.trim();
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -9,6 +9,7 @@ use clap::ArgMatches;
 use net_util::MacAddr;
 use std::collections::HashMap;
 use std::convert::From;
+use std::fmt;
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::result;
@@ -72,6 +73,52 @@ pub enum Error {
     /// Failed to parse vsock parameters
     ParseVsock(OptionParserError),
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::Error::*;
+        match self {
+            ParseConsole(o) => write!(f, "Error parsing --console: {}", o),
+            ParseConsoleFileMissing => {
+                write!(f, "Error parsing --console: path missing when using file")
+            }
+            ParseConsoleInvalidModeGiven => {
+                write!(f, "Error parsing --console: invalid console mode given")
+            }
+            ParseCpus(o) => write!(f, "Error parsing --cpus: {}", o),
+            ParseCpusMaxLowerThanBoot => {
+                write!(f, "Error parsing --cpus: max CPUs greater than boot CPUs")
+            }
+            ParseDevice(o) => write!(f, "Error parsing --device: {}", o),
+            ParseDevicePathMissing => write!(f, "Error parsing --device: path missing"),
+            ParseDiskSocketAndPath => write!(
+                f,
+                "Error parsing --disk: vhost socket and disk path both provided"
+            ),
+            ParseFileSystem(o) => write!(f, "Error parsing --fs: {}", o),
+            ParseFsSockMissing => write!(f, "Error parsing --fs: sock missing"),
+            ParseFsTagMissing => write!(f, "Error parsing --fs: tag missing"),
+            InvalidCacheSizeWithDaxOff => {
+                write!(f, "Error parsing --fs: cache_size used with dax=on")
+            }
+            ParsePersistentMemory(o) => write!(f, "Error parsing --pmem: {}", o),
+            ParsePmemFileMissing => write!(f, "Error parsing --pmem: file missing"),
+            ParsePmemSizeMissing => write!(f, "Error parsing --pmem: size missing"),
+            ParseTTYParam => write!(
+                f,
+                "Console mode tty specified for both --serial and --console"
+            ),
+            ParseVsock(o) => write!(f, "Error parsing --vsock: {}", o),
+            ParseVsockCidMissing => write!(f, "Error parsing --vsock: cid missing"),
+            ParseVsockSockMissing => write!(f, "Error parsing --vsock: sock missing"),
+            ParseMemory(o) => write!(f, "Error parsing --memory: {}", o),
+            ParseNetwork(o) => write!(f, "Error parsing --net: {}", o),
+            ParseDisk(o) => write!(f, "Error parsing --disk: {}", o),
+            ParseRNG(o) => write!(f, "Error parsing --rng: {}", o),
+        }
+    }
+}
+
 pub type Result<T> = result::Result<T, Error>;
 
 #[derive(Default)]
@@ -91,6 +138,17 @@ pub enum OptionParserError {
     Conversion(String, String),
 }
 
+impl fmt::Display for OptionParserError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            OptionParserError::UnknownOption(s) => write!(f, "unknown option: {}", s),
+            OptionParserError::InvalidSyntax(s) => write!(f, "invalid syntax:{}", s),
+            OptionParserError::Conversion(field, value) => {
+                write!(f, "unable to parse {} for {}", value, field)
+            }
+        }
+    }
+}
 type OptionParserResult<T> = std::result::Result<T, OptionParserError>;
 
 impl OptionParser {

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -717,7 +717,7 @@ impl RngConfig {
         // Split the parameters based on the comma delimiter
         let params_list: Vec<&str> = rng.split(',').collect();
 
-        let mut src_str: &str = "";
+        let mut src_str: &str = DEFAULT_RNG_SOURCE;
         let mut iommu_str: &str = "";
 
         for param in params_list.iter() {
@@ -1483,6 +1483,33 @@ mod tests {
             }
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_rng() -> Result<()> {
+        assert_eq!(RngConfig::parse("")?, RngConfig::default());
+        assert_eq!(
+            RngConfig::parse("src=/dev/random")?,
+            RngConfig {
+                src: PathBuf::from("/dev/random"),
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            RngConfig::parse("src=/dev/random,iommu=on")?,
+            RngConfig {
+                src: PathBuf::from("/dev/random"),
+                iommu: true,
+            }
+        );
+        assert_eq!(
+            RngConfig::parse("iommu=on")?,
+            RngConfig {
+                iommu: true,
+                ..Default::default()
+            }
+        );
         Ok(())
     }
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -291,6 +291,22 @@ impl FromStr for HotplugMethod {
     }
 }
 
+struct ByteSized(u64);
+
+enum ByteSizedParseError {
+    InvalidValue(String),
+}
+
+impl FromStr for ByteSized {
+    type Err = ByteSizedParseError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(ByteSized(parse_size(s).map_err(|_| {
+            ByteSizedParseError::InvalidValue(s.to_owned())
+        })?))
+    }
+}
+
 fn parse_size(size: &str) -> Result<u64> {
     let s = size.trim();
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -27,10 +27,6 @@ pub const DEFAULT_QUEUE_SIZE_VUBLK: u16 = 128;
 pub enum Error {
     /// Max is less than boot
     ParseCpusMaxLowerThanBoot,
-    /// Failed parsing kernel parameters.
-    ParseKernelParams,
-    /// Failed parsing kernel command line parameters.
-    ParseCmdlineParams,
     /// Both socket and path specified
     ParseDiskSocketAndPath,
     /// Filesystem tag is missing
@@ -49,8 +45,6 @@ pub enum Error {
     ParseVsockSockMissing,
     /// Missing vsock cid parameter.
     ParseVsockCidMissing,
-    /// Missing kernel configuration
-    ValidateMissingKernelConfig,
     /// Error parsing CPU options
     ParseCpus(OptionParserError),
     /// Error parsing memory options

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -132,7 +132,10 @@ impl OptionParser {
     }
 
     pub fn get(&self, option: &str) -> Option<String> {
-        self.options.get(option).and_then(|v| v.value.clone())
+        self.options
+            .get(option)
+            .and_then(|v| v.value.clone())
+            .and_then(|s| if s.is_empty() { None } else { Some(s) })
     }
 
     pub fn is_set(&self, option: &str) -> bool {
@@ -143,7 +146,7 @@ impl OptionParser {
     }
 
     pub fn convert<T: FromStr>(&self, option: &str) -> OptionParserResult<Option<T>> {
-        match self.options.get(option).and_then(|v| v.value.as_ref()) {
+        match self.get(option) {
             None => Ok(None),
             Some(v) => Ok(Some(v.parse().map_err(|_| {
                 OptionParserError::Conversion(option.to_owned(), v.to_owned())


### PR DESCRIPTION
Introduce a new helper infrastructure for parsing the command line arguments: `OptionParser` which handles the comma separated `key=value` syntax and use that for our command line options.

I added unit testing for the command line arguments and fix any issues that arise prior to the porting and then ported so that the behaviour was consistent.

This change also improves the error messages we get from command line parsing errors making then human readable!

Fixes: #367  