### PR TITLE
.gitignore: Add build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/build
 /target
 **/*.rs.bk
 **/Cargo.lock


### PR DESCRIPTION
This directory contains the source code for crates that we pull in and
should be excluded.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>