### PR TITLE
vmm: Cleanup warning from build

### DIFF
--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -74,18 +74,18 @@ pub const HIGH_RAM_START: GuestAddress = GuestAddress(0x100000);
 
 // ** 32-bit reserved area (start: 3GiB, length: 1GiB) **
 pub const MEM_32BIT_RESERVED_START: GuestAddress = GuestAddress(0xc000_0000);
-pub const MEM_32BIT_RESERVED_SIZE: GuestUsize = (1024 << 20);
+pub const MEM_32BIT_RESERVED_SIZE: GuestUsize = 1024 << 20;
 
 // == Fixed constants within the "32-bit reserved" range ==
 
 // Sub range: 32-bit PCI devices (start: 3GiB, length: 640Mib)
 pub const MEM_32BIT_DEVICES_START: GuestAddress = MEM_32BIT_RESERVED_START;
-pub const MEM_32BIT_DEVICES_SIZE: GuestUsize = (640 << 20);
+pub const MEM_32BIT_DEVICES_SIZE: GuestUsize = 640 << 20;
 
 // PCI MMCONFIG space (start: after the device space, length: 256MiB)
 pub const PCI_MMCONFIG_START: GuestAddress =
     GuestAddress(MEM_32BIT_DEVICES_START.0 + MEM_32BIT_DEVICES_SIZE);
-pub const PCI_MMCONFIG_SIZE: GuestUsize = (256 << 20);
+pub const PCI_MMCONFIG_SIZE: GuestUsize = 256 << 20;
 
 // IOAPIC
 pub const IOAPIC_START: GuestAddress = GuestAddress(0xfec0_0000);

--- a/vhost_user_fs/src/server.rs
+++ b/vhost_user_fs/src/server.rs
@@ -19,7 +19,7 @@ use crate::filesystem::{
 use crate::fuse::*;
 use crate::{Error, Result};
 
-const MAX_BUFFER_SIZE: u32 = (1 << 20);
+const MAX_BUFFER_SIZE: u32 = 1 << 20;
 const DIRENT_PADDING: [u8; 8] = [0; 8];
 
 struct ZCReader<'a>(Reader<'a>);

--- a/vm-virtio/src/mem.rs
+++ b/vm-virtio/src/mem.rs
@@ -42,7 +42,7 @@ const NUM_QUEUES: usize = 1;
 const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE];
 
 // Use 2 MiB alignment so transparent hugepages can be used by KVM.
-pub const VIRTIO_MEM_DEFAULT_BLOCK_SIZE: u64 = (512 * 4096);
+pub const VIRTIO_MEM_DEFAULT_BLOCK_SIZE: u64 = 512 * 4096;
 const VIRTIO_MEM_USABLE_EXTENT: u64 = 256 * 1024 * 1024;
 
 // Request processed successfully, applicable for


### PR DESCRIPTION
Remove unnecessary parentheses from code and this will cleanup
the warning from cargo build.
