### PR TITLE
migration: Add support to restore from Copy-on-Write backing file

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -26,6 +26,7 @@ enum Error {
     AddDiskConfig(vmm::config::Error),
     AddPmemConfig(vmm::config::Error),
     AddNetConfig(vmm::config::Error),
+    Restore(vmm::config::Error),
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -262,10 +263,8 @@ fn snapshot_api_command(socket: &mut UnixStream, url: &str) -> Result<(), Error>
     )
 }
 
-fn restore_api_command(socket: &mut UnixStream, url: &str) -> Result<(), Error> {
-    let restore_config = vmm::api::VmRestoreConfig {
-        source_url: String::from(url),
-    };
+fn restore_api_command(socket: &mut UnixStream, config: &str) -> Result<(), Error> {
+    let restore_config = vmm::config::RestoreConfig::parse(config).map_err(Error::Restore)?;
 
     simple_api_command(
         socket,
@@ -445,7 +444,7 @@ fn main() {
                 .arg(
                     Arg::with_name("restore_config")
                         .index(1)
-                        .help("<source_url>"),
+                        .help(vmm::config::RestoreConfig::SYNTAX),
                 ),
         );
 

--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -8,7 +8,7 @@ use crate::api::{
     vm_add_device, vm_add_disk, vm_add_net, vm_add_pmem, vm_boot, vm_create, vm_delete, vm_info,
     vm_pause, vm_reboot, vm_remove_device, vm_resize, vm_restore, vm_resume, vm_shutdown,
     vm_snapshot, vmm_ping, vmm_shutdown, ApiError, ApiRequest, ApiResult, DeviceConfig, DiskConfig,
-    NetConfig, PmemConfig, VmAction, VmConfig, VmRemoveDeviceData, VmResizeData, VmRestoreConfig,
+    NetConfig, PmemConfig, RestoreConfig, VmAction, VmConfig, VmRemoveDeviceData, VmResizeData,
     VmSnapshotConfig,
 };
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
@@ -252,8 +252,8 @@ impl EndpointHandler for VmRestore {
             Method::Put => {
                 match &req.body {
                     Some(body) => {
-                        // Deserialize into a VmRestoreConfig
-                        let vm_restore_data: VmRestoreConfig =
+                        // Deserialize into a RestoreConfig
+                        let vm_restore_data: RestoreConfig =
                             match serde_json::from_slice(body.raw())
                                 .map_err(HttpError::SerdeJsonDeserialize)
                             {

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -37,7 +37,7 @@ pub use self::http::start_http_thread;
 pub mod http;
 pub mod http_endpoint;
 
-use crate::config::{DeviceConfig, DiskConfig, NetConfig, PmemConfig, VmConfig};
+use crate::config::{DeviceConfig, DiskConfig, NetConfig, PmemConfig, RestoreConfig, VmConfig};
 use crate::vm::{Error as VmError, VmState};
 use std::io;
 use std::sync::mpsc::{channel, RecvError, SendError, Sender};
@@ -158,13 +158,6 @@ pub struct VmSnapshotConfig {
     pub destination_url: String,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
-pub struct VmRestoreConfig {
-    /// The snapshot restore source URL.
-    /// This is where the VMM is going to get its snapshot to restore itself from.
-    pub source_url: String,
-}
-
 pub enum ApiResponsePayload {
     /// No data is sent on the channel.
     Empty,
@@ -247,7 +240,7 @@ pub enum ApiRequest {
     VmSnapshot(Arc<VmSnapshotConfig>, Sender<ApiResponse>),
 
     /// Restore from a VM snapshot
-    VmRestore(Arc<VmRestoreConfig>, Sender<ApiResponse>),
+    VmRestore(Arc<RestoreConfig>, Sender<ApiResponse>),
 }
 
 pub fn vm_create(
@@ -357,7 +350,7 @@ pub fn vm_snapshot(
 pub fn vm_restore(
     api_evt: EventFd,
     api_sender: Sender<ApiRequest>,
-    data: Arc<VmRestoreConfig>,
+    data: Arc<RestoreConfig>,
 ) -> ApiResult<()> {
     let (response_sender, response_receiver) = channel();
 

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -245,7 +245,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VmRestoreConfig'
+              $ref: '#/components/schemas/RestoreConfig'
         required: true
       responses:
         204:
@@ -583,8 +583,12 @@ components:
         destination_url:
           type: string
 
-    VmRestoreConfig:
+    RestoreConfig:
+      required:
+      - source_url
       type: object
       properties:
         source_url:
           type: string
+        prefault:
+          type: boolean

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -331,6 +331,7 @@ impl Vmm {
             reset_evt,
             self.vmm_path.clone(),
             source_url,
+            restore_cfg.prefault,
         )?;
         self.vm = Some(vm);
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -387,6 +387,7 @@ impl MemoryManager {
         fd: Arc<VmFd>,
         config: &MemoryConfig,
         source_url: &str,
+        prefault: bool,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
         let url = Url::parse(source_url).unwrap();
         /* url must be valid dir which is verified in recv_vm_snapshot() */
@@ -419,7 +420,7 @@ impl MemoryManager {
             // allows for a faster VM restoration and does not require us to
             // fill the memory content, hence we can return right away.
             if config.file.is_none() {
-                return MemoryManager::new(fd, config, Some(ext_regions), false);
+                return MemoryManager::new(fd, config, Some(ext_regions), prefault);
             };
 
             let memory_manager = MemoryManager::new(fd, config, None, false)?;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -436,9 +436,15 @@ impl MemoryManager {
 
                 f.set_len(size as u64).map_err(Error::SharedFileSetLen)?;
 
+                let mmap_flags = libc::MAP_NORESERVE | libc::MAP_SHARED;
                 GuestRegionMmap::new(
-                    MmapRegion::from_file(FileOffset::new(f, 0), size)
-                        .map_err(Error::GuestMemoryRegion)?,
+                    MmapRegion::build(
+                        Some(FileOffset::new(f, 0)),
+                        size,
+                        libc::PROT_READ | libc::PROT_WRITE,
+                        mmap_flags,
+                    )
+                    .map_err(Error::GuestMemoryRegion)?,
                     start_addr,
                 )
                 .map_err(Error::GuestMemory)?

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -360,9 +360,13 @@ impl Vm {
         vmm_path: PathBuf,
     ) -> Result<Self> {
         let (kvm, fd) = Vm::kvm_new()?;
-        let memory_manager =
-            MemoryManager::new(fd.clone(), &config.lock().unwrap().memory.clone(), None)
-                .map_err(Error::MemoryManager)?;
+        let memory_manager = MemoryManager::new(
+            fd.clone(),
+            &config.lock().unwrap().memory.clone(),
+            None,
+            false,
+        )
+        .map_err(Error::MemoryManager)?;
 
         Vm::new_from_memory_manager(
             config,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -360,8 +360,9 @@ impl Vm {
         vmm_path: PathBuf,
     ) -> Result<Self> {
         let (kvm, fd) = Vm::kvm_new()?;
-        let memory_manager = MemoryManager::new(fd.clone(), &config.lock().unwrap().memory.clone())
-            .map_err(Error::MemoryManager)?;
+        let memory_manager =
+            MemoryManager::new(fd.clone(), &config.lock().unwrap().memory.clone(), None)
+                .map_err(Error::MemoryManager)?;
 
         Vm::new_from_memory_manager(
             config,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -188,6 +188,9 @@ pub enum Error {
 
     /// Cannot send VM snapshot
     SnapshotSend(MigratableError),
+
+    /// Cannot convert source URL from Path into &str
+    RestoreSourceUrlPathToStr,
 }
 pub type Result<T> = result::Result<T, Error>;
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -388,6 +388,7 @@ impl Vm {
         reset_evt: EventFd,
         vmm_path: PathBuf,
         source_url: &str,
+        prefault: bool,
     ) -> Result<Self> {
         let (kvm, fd) = Vm::kvm_new()?;
         let config = vm_config_from_snapshot(snapshot).map_err(Error::Restore)?;
@@ -400,6 +401,7 @@ impl Vm {
                 fd.clone(),
                 &config.lock().unwrap().memory.clone(),
                 source_url,
+                prefault,
             )
             .map_err(Error::MemoryManager)?
         } else {


### PR DESCRIPTION
This pull request prevents the VMM from doing a full copy of the source memory's VM by adding support for CoW. This works by memory mapping the backing files with MAP_PRIVATE instead of MAP_SHARED. And this can only happen if the migrated VM wasn't using a shared backing file before.
In case the source VM was relying on a shared backing file, the code falls back onto the default behavior, which is to copy the memory content to the new VM.