### PR TITLE
Enable initramfs support when using PVH boot protocol

### DIFF
--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -43,6 +43,8 @@ pub enum Error {
     StartInfoSetup,
     /// Failed to compute initramfs address.
     InitramfsAddress,
+    /// Error writing module entry to guest memory.
+    ModlistSetup(vm_memory::GuestMemoryError),
 }
 pub type Result<T> = result::Result<T, Error>;
 

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -31,6 +31,10 @@ pub const BOOT_IDT_START: GuestAddress = GuestAddress(0x520);
 /// Address for the hvm_start_info struct used in PVH boot
 pub const PVH_INFO_START: GuestAddress = GuestAddress(0x6000);
 
+/// Starting address of array of modules of hvm_modlist_entry type.
+/// Used to enable initrd support using the PVH boot ABI.
+pub const MODLIST_START: GuestAddress = GuestAddress(0x6040);
+
 /// Address of memory map table used in PVH boot. Can overlap
 /// with the zero page address since they are mutually exclusive.
 pub const MEMMAP_START: GuestAddress = GuestAddress(0x7000);


### PR DESCRIPTION
Setup the required data structures in guest memory so an initrafms can be loaded by the PVH boot protocol. Remove the restriction added by https://github.com/cloud-hypervisor/cloud-hypervisor/commit/785812d976ef08d9d3ab83d7ac439ace595963b2, and modify the code as per @sboeuf suggestion in a previous discussion. 

Closes #963