### PR TITLE
vhost_user_backend: Make sure multiqueue/multithread can be supported without contention

### DIFF
--- a/src/bin/vhost_user_fs.rs
+++ b/src/bin/vhost_user_fs.rs
@@ -266,7 +266,7 @@ impl<F: FileSystem + Send + Sync + 'static> VhostUserBackend for VhostUserFsBack
         Ok(false)
     }
 
-    fn exit_event(&self) -> Option<(EventFd, Option<u16>)> {
+    fn exit_event(&self, _thread_index: usize) -> Option<(EventFd, Option<u16>)> {
         Some((
             self.thread.lock().unwrap().kill_evt.try_clone().unwrap(),
             Some(KILL_EVENT),

--- a/src/bin/vhost_user_fs.rs
+++ b/src/bin/vhost_user_fs.rs
@@ -217,7 +217,7 @@ impl<F: FileSystem + Send + Sync + 'static> VhostUserBackend for VhostUserFsBack
     }
 
     fn handle_event(
-        &mut self,
+        &self,
         device_event: u16,
         evset: epoll::Events,
         vrings: &[Arc<RwLock<Vring>>],

--- a/src/bin/vhost_user_fs.rs
+++ b/src/bin/vhost_user_fs.rs
@@ -221,6 +221,7 @@ impl<F: FileSystem + Send + Sync + 'static> VhostUserBackend for VhostUserFsBack
         device_event: u16,
         evset: epoll::Events,
         vrings: &[Arc<RwLock<Vring>>],
+        _thread_id: usize,
     ) -> VhostUserBackendResult<bool> {
         if evset != epoll::Events::EPOLLIN {
             return Err(Error::HandleEventNotEpollIn.into());

--- a/vhost_user_backend/src/lib.rs
+++ b/vhost_user_backend/src/lib.rs
@@ -81,7 +81,7 @@ pub trait VhostUserBackend: Send + Sync + 'static {
     /// virtqueues on its own, but does not know what to do with events
     /// happening on custom listeners.
     fn handle_event(
-        &mut self,
+        &self,
         device_event: u16,
         evset: epoll::Events,
         vrings: &[Arc<RwLock<Vring>>],
@@ -310,7 +310,7 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
         }
 
         self.backend
-            .write()
+            .read()
             .unwrap()
             .handle_event(device_event, evset, &self.vrings)
             .map_err(VringEpollHandlerError::HandleEventBackendHandling)

--- a/vhost_user_backend/src/lib.rs
+++ b/vhost_user_backend/src/lib.rs
@@ -191,8 +191,8 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
     /// Retrieve the vring worker. This is necessary to perform further
     /// actions like registering and unregistering some extra event file
     /// descriptors.
-    pub fn get_vring_worker(&self) -> Arc<VringWorker> {
-        self.handler.lock().unwrap().get_vring_worker()
+    pub fn get_vring_workers(&self) -> Vec<Arc<VringWorker>> {
+        self.handler.lock().unwrap().get_vring_workers()
     }
 }
 
@@ -545,8 +545,8 @@ impl<S: VhostUserBackend> VhostUserHandler<S> {
         })
     }
 
-    fn get_vring_worker(&self) -> Arc<VringWorker> {
-        self.workers[0].clone()
+    fn get_vring_workers(&self) -> Vec<Arc<VringWorker>> {
+        self.workers.clone()
     }
 
     fn vmm_va_to_gpa(&self, vmm_va: u64) -> VhostUserHandlerResult<u64> {

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -277,7 +277,7 @@ impl VhostUserBackend for VhostUserBlkBackend {
     }
 
     fn handle_event(
-        &mut self,
+        &self,
         device_event: u16,
         evset: epoll::Events,
         vrings: &[Arc<RwLock<Vring>>],

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -281,6 +281,7 @@ impl VhostUserBackend for VhostUserBlkBackend {
         device_event: u16,
         evset: epoll::Events,
         vrings: &[Arc<RwLock<Vring>>],
+        _thread_id: usize,
     ) -> VhostUserBackendResult<bool> {
         if evset != epoll::Events::EPOLLIN {
             return Err(Error::HandleEventNotEpollIn.into());

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -449,14 +449,14 @@ pub fn start_block_backend(backend_command: &str) {
     .unwrap();
     debug!("blk_daemon is created!\n");
 
-    let vring_worker = blk_daemon.get_vring_worker();
+    let vring_worker = blk_daemon.get_vring_workers();
     blk_backend
         .write()
         .unwrap()
         .thread
         .lock()
         .unwrap()
-        .set_vring_worker(Some(vring_worker));
+        .set_vring_worker(Some(vring_worker[0].clone()));
 
     if let Err(e) = blk_daemon.start() {
         error!(

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -342,7 +342,7 @@ impl VhostUserBackend for VhostUserBlkBackend {
         buf.to_vec()
     }
 
-    fn exit_event(&self) -> Option<(EventFd, Option<u16>)> {
+    fn exit_event(&self, _thread_index: usize) -> Option<(EventFd, Option<u16>)> {
         Some((
             self.thread.lock().unwrap().kill_evt.try_clone().unwrap(),
             None,

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -307,7 +307,7 @@ impl VhostUserBackend for VhostUserNetBackend {
     }
 
     fn handle_event(
-        &mut self,
+        &self,
         device_event: u16,
         evset: epoll::Events,
         vrings: &[Arc<RwLock<Vring>>],

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -473,7 +473,7 @@ pub fn start_net_backend(backend_command: &str) {
     )
     .unwrap();
 
-    let vring_worker = net_daemon.get_vring_worker();
+    let vring_worker = net_daemon.get_vring_workers();
 
     net_backend
         .write()
@@ -481,7 +481,7 @@ pub fn start_net_backend(backend_command: &str) {
         .thread
         .lock()
         .unwrap()
-        .set_vring_worker(Some(vring_worker));
+        .set_vring_worker(Some(vring_worker[0].clone()));
 
     if let Err(e) = net_daemon.start() {
         println!(

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -337,17 +337,17 @@ impl VhostUserBackend for VhostUserNetBackend {
         Ok(false)
     }
 
-    fn exit_event(&self) -> Option<(EventFd, Option<u16>)> {
-        let tap_end_index = (self.num_queues + self.num_queues / 2 - 1) as u16;
-        let kill_index = tap_end_index + 1;
+    fn exit_event(&self, thread_index: usize) -> Option<(EventFd, Option<u16>)> {
+        // The exit event is placed after the queues and the tap event, which
+        // is event index 3.
         Some((
-            self.threads[0]
+            self.threads[thread_index]
                 .lock()
                 .unwrap()
                 .kill_evt
                 .try_clone()
                 .unwrap(),
-            Some(kill_index),
+            Some(3),
         ))
     }
 }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -224,6 +224,7 @@ pub fn vmm_thread_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_madvise),
             allow_syscall(libc::SYS_mmap),
             allow_syscall(libc::SYS_mprotect),
+            allow_syscall(libc::SYS_mremap),
             allow_syscall(libc::SYS_munmap),
             allow_syscall(libc::SYS_nanosleep),
             allow_syscall(libc::SYS_open),


### PR DESCRIPTION
This pull request updates the vhost_user_backend crate (and each backend implementation accordingly) so that multiqueues on multiple threads can be supported without hitting a contention point that causes no performance benefit.

It also includes the modification of the vhost-user-net backend so that multithreaded multiqueue can be supported.