### PR TITLE
vmm: config: Use Default::default() value for initramfs field

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1160,6 +1160,7 @@ pub struct VmConfig {
     #[serde(default)]
     pub memory: MemoryConfig,
     pub kernel: Option<KernelConfig>,
+    #[serde(default)]
     pub initramfs: Option<InitramfsConfig>,
     #[serde(default)]
     pub cmdline: CmdlineConfig,


### PR DESCRIPTION
This ensures that the field is filled with None when it is not specified
as part of the deserialisation step.

Fixes: #1015

Signed-off-by: Rob Bradford <robert.bradford@intel.com>