### PR TITLE
vmm: openapi: Mark "initramfs" field nullable

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -374,6 +374,7 @@ components:
           type: string
 
     InitramfsConfig:
+      nullable: true
       required:
       - path
       type: object


### PR DESCRIPTION
This should make it a pointer in the Go generated code so that it will
be ommitted and thus not populated with an unhelpful default value.

Fixes: #1015

Signed-off-by: Rob Bradford <robert.bradford@intel.com>