### PR TITLE
vmm: Add vm.add-fs route

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -93,8 +93,9 @@ Dump the VM information            | `/vm.info`          | N/A                  
 Add VFIO PCI device to the VM      | `/vm.add-device`    | `/schemas/VmAddDevice`    | N/A               | The VM is booted
 Remove VFIO PCI device from the VM | `/vm.remove-device` | `/schemas/VmRemoveDevice` | N/A               | The VM is booted
 Add disk device to the VM          | `/vm.add-disk`      | `/schemas/DiskConfig`     | N/A               | The VM is booted
+Add fs device to the VM            | `/vm.add-fs`        | `/schemas/FsConfig`       | N/A               | The VM is booted
 Add pmem device to the VM          | `/vm.add-pmem`      | `/schemas/PmemConfig`     | N/A               | The VM is booted
-Add network device to the VM       | `/vm.add-net`       | `/schemas/NetConfig`     | N/A               | The VM is booted
+Add network device to the VM       | `/vm.add-net`       | `/schemas/NetConfig`      | N/A               | The VM is booted
 
 ### REST API Examples
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,12 +155,7 @@ fn create_app<'a, 'b>(
         .arg(
             Arg::with_name("fs")
                 .long("fs")
-                .help(
-                    "virtio-fs parameters \
-                     \"tag=<tag_name>,sock=<socket_path>,num_queues=<number_of_queues>,\
-                     queue_size=<size_of_each_queue>,dax=on|off,cache_size=<DAX cache size: \
-                     default 8Gib>\"",
-                )
+                .help(config::FsConfig::SYNTAX)
                 .takes_value(true)
                 .min_values(1)
                 .group("vm-config"),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1912,6 +1912,122 @@ mod tests {
         });
     }
 
+    fn test_virtio_fs_hotplug(
+        dax: bool,
+        cache_size: Option<u64>,
+        virtiofsd_cache: &str,
+        prepare_daemon: &dyn Fn(&TempDir, &str, &str) -> (std::process::Child, String),
+    ) {
+        test_block!(tb, "", {
+            let mut clear = ClearDiskConfig::new();
+            let guest = Guest::new(&mut clear);
+            let api_socket = temp_api_path(&guest.tmp_dir);
+
+            let mut workload_path = dirs::home_dir().unwrap();
+            workload_path.push("workloads");
+
+            let mut shared_dir = workload_path.clone();
+            shared_dir.push("shared_dir");
+
+            let mut kernel_path = workload_path;
+            kernel_path.push("vmlinux");
+
+            let (dax_vmm_param, dax_mount_param) = if dax { ("on", "-o dax") } else { ("off", "") };
+            let cache_size_vmm_param = if let Some(cache) = cache_size {
+                format!(",cache_size={}", cache)
+            } else {
+                "".to_string()
+            };
+
+            let (mut daemon_child, virtiofsd_socket_path) = prepare_daemon(
+                &guest.tmp_dir,
+                shared_dir.to_str().unwrap(),
+                virtiofsd_cache,
+            );
+
+            // Spawn without fs, since we'll add it later via API
+            let mut child = GuestCommand::new(&guest)
+                .args(&["--cpus", "boot=1"])
+                .args(&["--memory", "size=512M,file=/dev/shm"])
+                .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .default_disks()
+                .default_net()
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
+                .args(&["--api-socket", &api_socket])
+                .spawn()
+                .unwrap();
+
+            thread::sleep(std::time::Duration::new(20, 0));
+
+            // Add fs to the VM
+            aver!(
+                tb,
+                remote_command(
+                    &api_socket,
+                    "add-fs",
+                    Some(&format!(
+                        "tag=myfs,sock={},num_queues=1,queue_size=1024,dax={}{}",
+                        virtiofsd_socket_path, dax_vmm_param, cache_size_vmm_param
+                    )),
+                )
+            );
+
+            thread::sleep(std::time::Duration::new(10, 0));
+
+            // Mount shared directory through virtio_fs filesystem
+            let mount_cmd = format!(
+                "mkdir -p mount_dir && \
+                 sudo mount -t virtiofs {} myfs mount_dir/ 2>&1 && \
+                 echo ok",
+                dax_mount_param
+            );
+            aver_eq!(
+                tb,
+                guest.ssh_command(&mount_cmd).unwrap_or_default().trim(),
+                "ok"
+            );
+
+            // Check the cache size is the expected one.
+            // With virtio-mmio the cache doesn't appear in /proc/iomem
+            #[cfg(not(feature = "mmio"))]
+            aver_eq!(
+                tb,
+                guest
+                    .valid_virtio_fs_cache_size(dax, cache_size)
+                    .unwrap_or_default(),
+                true
+            );
+            // Check file1 exists and its content is "foo"
+            aver_eq!(
+                tb,
+                guest
+                    .ssh_command("cat mount_dir/file1")
+                    .unwrap_or_default()
+                    .trim(),
+                "foo"
+            );
+
+            // Ensure the VM successfully reboots. The virtio-fs will not be
+            // automatically recreated since virtiofsd exits on disconnect.
+            guest.ssh_command("sudo reboot").unwrap_or_default();
+
+            thread::sleep(std::time::Duration::new(20, 0));
+            let reboot_count = guest
+                .ssh_command("sudo journalctl | grep -c -- \"-- Reboot --\"")
+                .unwrap_or_default()
+                .trim()
+                .parse::<u32>()
+                .unwrap_or_default();
+            aver_eq!(tb, reboot_count, 1);
+
+            let _ = child.kill();
+            let _ = daemon_child.kill();
+            let _ = child.wait();
+            let _ = daemon_child.wait();
+            Ok(())
+        });
+    }
+
     #[test]
     fn test_virtio_fs_dax_on_default_cache_size() {
         test_virtio_fs(true, None, "none", &prepare_virtiofsd)
@@ -1945,6 +2061,26 @@ mod tests {
     #[test]
     fn test_virtio_fs_dax_off_w_vhost_user_fs_daemon() {
         test_virtio_fs(false, None, "none", &prepare_vhost_user_fs_daemon)
+    }
+
+    #[cfg_attr(not(feature = "mmio"), test)]
+    fn test_virtio_fs_hotplug_dax_on() {
+        test_virtio_fs_hotplug(true, None, "none", &prepare_virtiofsd)
+    }
+
+    #[cfg_attr(not(feature = "mmio"), test)]
+    fn test_virtio_fs_hotplug_dax_off() {
+        test_virtio_fs_hotplug(false, None, "none", &prepare_virtiofsd)
+    }
+
+    #[cfg_attr(not(feature = "mmio"), test)]
+    fn test_virtio_fs_hotplug_dax_on_w_vhost_user_fs_daemon() {
+        test_virtio_fs_hotplug(true, None, "none", &prepare_vhost_user_fs_daemon)
+    }
+
+    #[cfg_attr(not(feature = "mmio"), test)]
+    fn test_virtio_fs_hotplug_dax_off_w_vhost_user_fs_daemon() {
+        test_virtio_fs_hotplug(false, None, "none", &prepare_vhost_user_fs_daemon)
     }
 
     #[cfg_attr(not(feature = "mmio"), test)]

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -4,8 +4,8 @@
 //
 
 use crate::api::http_endpoint::{
-    VmActionHandler, VmAddDevice, VmAddDisk, VmAddNet, VmAddPmem, VmCreate, VmInfo, VmRemoveDevice,
-    VmResize, VmRestore, VmSnapshot, VmmPing, VmmShutdown,
+    VmActionHandler, VmAddDevice, VmAddDisk, VmAddFs, VmAddNet, VmAddPmem, VmCreate, VmInfo,
+    VmRemoveDevice, VmResize, VmRestore, VmSnapshot, VmmPing, VmmShutdown,
 };
 use crate::api::{ApiRequest, VmAction};
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
@@ -70,6 +70,7 @@ lazy_static! {
         r.routes.insert(endpoint!("/vm.add-device"), Box::new(VmAddDevice {}));
         r.routes.insert(endpoint!("/vm.remove-device"), Box::new(VmRemoveDevice {}));
         r.routes.insert(endpoint!("/vm.add-disk"), Box::new(VmAddDisk {}));
+        r.routes.insert(endpoint!("/vm.add-fs"), Box::new(VmAddFs {}));
         r.routes.insert(endpoint!("/vm.add-pmem"), Box::new(VmAddPmem {}));
         r.routes.insert(endpoint!("/vm.add-net"), Box::new(VmAddNet {}));
 

--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -487,6 +487,24 @@ impl EndpointHandler for VmAddDisk {
     }
 }
 
+// /api/v1/vm.add-fs handler
+pub struct VmAddFs {}
+
+impl EndpointHandler for VmAddFs {
+    fn handle_request(
+        &self,
+        req: &Request,
+        _api_notifier: EventFd,
+        _api_sender: Sender<ApiRequest>,
+    ) -> Response {
+        match req.method() {
+            // Not implemented.
+            Method::Put => Response::new(Version::Http11, StatusCode::NotImplemented),
+            _ => Response::new(Version::Http11, StatusCode::BadRequest),
+        }
+    }
+}
+
 // /api/v1/vm.add-pmem handler
 pub struct VmAddPmem {}
 

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -37,7 +37,9 @@ pub use self::http::start_http_thread;
 pub mod http;
 pub mod http_endpoint;
 
-use crate::config::{DeviceConfig, DiskConfig, NetConfig, PmemConfig, RestoreConfig, VmConfig};
+use crate::config::{
+    DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, RestoreConfig, VmConfig,
+};
 use crate::vm::{Error as VmError, VmState};
 use std::io;
 use std::sync::mpsc::{channel, RecvError, SendError, Sender};
@@ -121,6 +123,9 @@ pub enum ApiError {
 
     /// The disk could not be added to the VM.
     VmAddDisk(VmError),
+
+    /// The fs could not be added to the VM.
+    VmAddFs(VmError),
 
     /// The pmem device could not be added to the VM.
     VmAddPmem(VmError),
@@ -229,6 +234,9 @@ pub enum ApiRequest {
 
     /// Add a disk to the VM.
     VmAddDisk(Arc<DiskConfig>, Sender<ApiResponse>),
+
+    /// Add a fs to the VM.
+    VmAddFs(Arc<FsConfig>, Sender<ApiResponse>),
 
     /// Add a pmem device to the VM.
     VmAddPmem(Arc<PmemConfig>, Sender<ApiResponse>),
@@ -476,6 +484,24 @@ pub fn vm_add_disk(
     // Send the VM add-disk request.
     api_sender
         .send(ApiRequest::VmAddDisk(data, response_sender))
+        .map_err(ApiError::RequestSend)?;
+    api_evt.write(1).map_err(ApiError::EventFdWrite)?;
+
+    response_receiver.recv().map_err(ApiError::ResponseRecv)??;
+
+    Ok(())
+}
+
+pub fn vm_add_fs(
+    api_evt: EventFd,
+    api_sender: Sender<ApiRequest>,
+    data: Arc<FsConfig>,
+) -> ApiResult<()> {
+    let (response_sender, response_receiver) = channel();
+
+    // Send the VM add-fs request.
+    api_sender
+        .send(ApiRequest::VmAddFs(data, response_sender))
         .map_err(ApiError::RequestSend)?;
     api_evt.write(1).map_err(ApiError::EventFdWrite)?;
 

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -187,6 +187,22 @@ paths:
         500:
           description: The new disk could not be added to the VM instance.
 
+  /vm.add-fs:
+    put:
+      summary: Add a new virtio-fs device to the VM
+      requestBody:
+        description: The details of the new virtio-fs
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FsConfig'
+        required: true
+      responses:
+        204:
+          description: The new device was successfully added to the VM instance.
+        500:
+          description: The new device could not be added to the VM instance.
+
   /vm.add-pmem:
     put:
       summary: Add a new pmem device to the VM

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -876,6 +876,11 @@ impl Default for FsConfig {
 }
 
 impl FsConfig {
+    pub const SYNTAX: &'static str = "virtio-fs parameters \
+    \"tag=<tag_name>,sock=<socket_path>,num_queues=<number_of_queues>,\
+    queue_size=<size_of_each_queue>,dax=on|off,cache_size=<DAX cache size: \
+    default 8Gib>\"";
+
     pub fn parse(fs: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2235,6 +2235,12 @@ impl DeviceManager {
 
         let interrupt_manager = Arc::clone(&self.msi_interrupt_manager);
 
+        // Add the virtio device to the device manager list. This is important
+        // as the list is used to notify virtio devices about memory updates
+        // for instance.
+        self.virtio_devices
+            .push((device.clone(), iommu_attached, id.clone()));
+
         let device_id = self.add_virtio_pci_device(
             device,
             &mut pci.lock().unwrap(),


### PR DESCRIPTION
Adds an API method for creating vhost-user-fs devices after the VM is launched.

This is mostly just copypasta'd from `vm.add-disk`.