### PR TITLE
Move mmap() region ownership to devices

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1467,8 +1467,6 @@ impl DeviceManager {
         .map_err(DeviceManagerError::NewMmapRegion)?;
         let addr: u64 = mmap_region.as_ptr() as u64;
 
-        self._mmap_regions.push(mmap_region);
-
         self.memory_manager
             .lock()
             .unwrap()
@@ -1482,7 +1480,7 @@ impl DeviceManager {
             .map_err(DeviceManagerError::MemoryManager)?;
 
         let virtio_pmem_device = Arc::new(Mutex::new(
-            vm_virtio::Pmem::new(file, pmem_guest_addr, size as GuestUsize, pmem_cfg.iommu)
+            vm_virtio::Pmem::new(file, pmem_guest_addr, mmap_region, pmem_cfg.iommu)
                 .map_err(DeviceManagerError::CreateVirtioPmem)?,
         ));
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -472,12 +472,6 @@ pub struct DeviceManager {
     // IOAPIC
     ioapic: Option<Arc<Mutex<ioapic::Ioapic>>>,
 
-    // List of mmap()ed regions managed through MmapRegion instances.
-    // Using MmapRegion will perform the unmapping automatically when
-    // the instance is dropped, which happens when the DeviceManager
-    // gets dropped.
-    _mmap_regions: Vec<MmapRegion>,
-
     // Things to be added to the commandline (i.e. for virtio-mmio)
     cmdline_additions: Vec<String>,
 
@@ -559,7 +553,6 @@ impl DeviceManager {
         let mut virtio_devices: Vec<(Arc<Mutex<dyn vm_virtio::VirtioDevice>>, bool)> = Vec::new();
         let migratable_devices: HashMap<String, Arc<Mutex<dyn Migratable>>> = HashMap::new();
         let mut bus_devices: Vec<Arc<Mutex<dyn BusDevice>>> = Vec::new();
-        let mut _mmap_regions = Vec::new();
 
         #[allow(unused_mut)]
         let mut cmdline_additions = Vec::new();
@@ -620,7 +613,6 @@ impl DeviceManager {
             address_manager: Arc::clone(&address_manager),
             console: Arc::new(Console::default()),
             ioapic: Some(ioapic),
-            _mmap_regions,
             cmdline_additions,
             #[cfg(feature = "acpi")]
             ged_notification_device: None,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1331,7 +1331,7 @@ impl DeviceManager {
         if let Some(fs_list_cfg) = &self.config.lock().unwrap().fs {
             for fs_cfg in fs_list_cfg.iter() {
                 if let Some(fs_sock) = fs_cfg.sock.to_str() {
-                    let cache: Option<(VirtioSharedMemoryList, u64)> = if fs_cfg.dax {
+                    let cache = if fs_cfg.dax {
                         let fs_cache = fs_cfg.cache_size;
                         // The memory needs to be 2MiB aligned in order to support
                         // hugepages.
@@ -1355,8 +1355,6 @@ impl DeviceManager {
                         )
                         .map_err(DeviceManagerError::NewMmapRegion)?;
                         let addr: u64 = mmap_region.as_ptr() as u64;
-
-                        self._mmap_regions.push(mmap_region);
 
                         self.memory_manager
                             .lock()
@@ -1383,6 +1381,7 @@ impl DeviceManager {
                                 region_list,
                             },
                             addr,
+                            mmap_region,
                         ))
                     } else {
                         None


### PR DESCRIPTION
virtio-pmem and vhost-user-fs both have special memory allocated for their need. This allocation is done by `DeviceManager` but in order to support device unplug the freeing of the memory  should be done inside the device itself.