### PR TITLE
Add snapshot/restore support for virtio-mmio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,6 +1454,7 @@ dependencies = [
 name = "vm-virtio"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arc-swap",
  "byteorder",
  "devices",
@@ -1463,6 +1464,9 @@ dependencies = [
  "net_gen",
  "net_util",
  "pci",
+ "serde",
+ "serde_derive",
+ "serde_json",
  "tempfile",
  "vhost",
  "virtio-bindings 0.1.0 (git+https://github.com/rust-vmm/virtio-bindings)",

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -10,6 +10,7 @@ pci_support = ["pci"]
 mmio_support = []
 
 [dependencies]
+anyhow = "1.0"
 arc-swap = ">=0.4.4"
 byteorder = "1.3.4"
 devices = { path = "../devices" }
@@ -19,6 +20,9 @@ log = "0.4.8"
 net_gen = { path = "../net_gen" }
 net_util = { path = "../net_util" }
 pci = { path = "../pci", optional = true }
+serde = ">=1.0.27"
+serde_derive = ">=1.0.27"
+serde_json = ">=1.0.9"
 tempfile = "3.1.0"
 virtio-bindings = { git = "https://github.com/rust-vmm/virtio-bindings", version = "0.1", features = ["virtio-v5_0_0"]}
 vm-allocator = { path = "../vm-allocator" }

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -16,6 +16,10 @@ extern crate epoll;
 extern crate log;
 #[cfg(feature = "pci_support")]
 extern crate pci;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
 extern crate vhost_rs;
 extern crate virtio_bindings;
 extern crate vm_device;

--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -383,11 +383,15 @@ impl<'a, 'b> Iterator for AvailIter<'a, 'b> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "GuestAddress")]
+struct GuestAddressDef(pub u64);
+
+#[derive(Clone, Serialize, Deserialize)]
 /// A virtio queue's parameters.
 pub struct Queue {
     /// The maximal size in elements offered by the device
-    max_size: u16,
+    pub max_size: u16,
 
     /// The queue size in elements the driver selected
     pub size: u16,
@@ -398,18 +402,22 @@ pub struct Queue {
     /// Interrupt vector index of the queue
     pub vector: u16,
 
+    #[serde(with = "GuestAddressDef")]
     /// Guest physical address of the descriptor table
     pub desc_table: GuestAddress,
 
+    #[serde(with = "GuestAddressDef")]
     /// Guest physical address of the available ring
     pub avail_ring: GuestAddress,
 
+    #[serde(with = "GuestAddressDef")]
     /// Guest physical address of the used ring
     pub used_ring: GuestAddress,
 
     pub next_avail: Wrapping<u16>,
     pub next_used: Wrapping<u16>,
 
+    #[serde(skip)]
     pub iommu_mapping_cb: Option<Arc<VirtioIommuRemapping>>,
 }
 


### PR DESCRIPTION
This pull request introduces snapshot/restore support to all virtio devices using the virtio-mmio transport layer. It only contains support for virtio-rng and virtio-blk for now, but more devices will be added through follow up pull requests.