### PR TITLE
vmm, devices: Add firmware debug port device

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ acpi = ["vmm/acpi"]
 pci = ["vmm/pci_support"]
 mmio = ["vmm/mmio_support"]
 cmos = ["vmm/cmos"]
+fwdebug = ["vmm/fwdebug"]
 
 # Integration tests require a special environment to run in
 integration_tests = []

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -26,3 +26,4 @@ tempfile = "3.1.0"
 default = []
 acpi = ["acpi_tables"]
 cmos = []
+fwdebug = []

--- a/devices/src/legacy/fwdebug.rs
+++ b/devices/src/legacy/fwdebug.rs
@@ -1,0 +1,40 @@
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+//
+
+use BusDevice;
+
+/// Provides firmware debug output via I/O port controls
+#[derive(Default)]
+pub struct FwDebugDevice {}
+
+impl FwDebugDevice {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// FwDebugDevice sits on the I/O bus as 0x402 and receives ASCII characters
+impl BusDevice for FwDebugDevice {
+    /// Upon read return the magic value to indicate that there is a debug port
+    fn read(&mut self, _base: u64, _offset: u64, data: &mut [u8]) {
+        if data.len() == 1 {
+            data[0] = 0xe9
+        } else {
+            error!("Invalid read size on debug port: {}", data.len())
+        }
+    }
+
+    fn write(&mut self, _base: u64, _offset: u64, data: &[u8]) {
+        if data.len() == 1 {
+            print!("{}", data[0] as char);
+        } else {
+            error!("Invalid write size on debug port: {}", data.len())
+        }
+    }
+}

--- a/devices/src/legacy/mod.rs
+++ b/devices/src/legacy/mod.rs
@@ -7,10 +7,14 @@
 
 #[cfg(feature = "cmos")]
 mod cmos;
+#[cfg(feature = "fwdebug")]
+mod fwdebug;
 mod i8042;
 mod serial;
 
 #[cfg(feature = "cmos")]
 pub use self::cmos::Cmos;
+#[cfg(feature = "fwdebug")]
+pub use self::fwdebug::FwDebugDevice;
 pub use self::i8042::I8042Device;
 pub use self::serial::Serial;

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -10,6 +10,7 @@ acpi = ["acpi_tables","devices/acpi"]
 pci_support = ["pci", "vfio", "vm-virtio/pci_support"]
 mmio_support = ["vm-virtio/mmio_support"]
 cmos = ["devices/cmos"]
+fwdebug = ["devices/fwdebug"]
 
 [dependencies]
 arc-swap = ">=0.4.4"

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -947,6 +947,18 @@ impl DeviceManager {
                 .insert(cmos, 0x70, 0x2)
                 .map_err(DeviceManagerError::BusError)?;
         }
+        #[cfg(feature = "fwdebug")]
+        {
+            let fwdebug = Arc::new(Mutex::new(devices::legacy::FwDebugDevice::new()));
+
+            self.bus_devices
+                .push(Arc::clone(&fwdebug) as Arc<Mutex<dyn BusDevice>>);
+
+            self.address_manager
+                .io_bus
+                .insert(fwdebug, 0x402, 0x1)
+                .map_err(DeviceManagerError::BusError)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
OVMF and other standard firmwares use I/O port 0x402 as a simple debug
port by writing ASCII characters to it. This is gated under a feature
that is not enabled by default.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>