### PR TITLE
pci, vfio, vm-virtio: Specify a PCI revision ID of 1 for virtio-pci

### DIFF
--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -53,6 +53,7 @@ impl PciRoot {
                 config: PciConfiguration::new(
                     VENDOR_ID_INTEL,
                     DEVICE_ID_INTEL_VIRT_PCIE_HOST,
+                    0,
                     PciClassCode::BridgeDevice,
                     &PciBridgeSubclass::HostBridge,
                     None,

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -337,6 +337,7 @@ impl PciConfiguration {
     pub fn new(
         vendor_id: u16,
         device_id: u16,
+        revision_id: u8,
         class_code: PciClassCode,
         subclass: &dyn PciSubclass,
         programming_interface: Option<&dyn PciProgrammingInterface>,
@@ -359,7 +360,8 @@ impl PciConfiguration {
         };
         registers[2] = u32::from(class_code.get_register_value()) << 24
             | u32::from(subclass.get_register_value()) << 16
-            | u32::from(pi) << 8;
+            | u32::from(pi) << 8
+            | u32::from(revision_id);
         writable_bits[3] = 0x0000_00ff; // Cacheline size (r/w)
         match header_type {
             PciHeaderType::Device => {
@@ -862,6 +864,7 @@ mod tests {
         let mut cfg = PciConfiguration::new(
             0x1234,
             0x5678,
+            0x1,
             PciClassCode::MultimediaController,
             &PciMultimediaSubclass::AudioController,
             None,
@@ -917,6 +920,7 @@ mod tests {
         let cfg = PciConfiguration::new(
             0x1234,
             0x5678,
+            0x1,
             PciClassCode::MultimediaController,
             &PciMultimediaSubclass::AudioController,
             Some(&TestPI::Test),

--- a/vfio/src/vfio_pci.rs
+++ b/vfio/src/vfio_pci.rs
@@ -299,6 +299,7 @@ impl VfioPciDevice {
         let configuration = PciConfiguration::new(
             0,
             0,
+            0,
             PciClassCode::Other,
             &PciVfioSubclass::VfioSubclass,
             None,

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -373,6 +373,7 @@ impl VirtioPciDevice {
         let configuration = PciConfiguration::new(
             VIRTIO_PCI_VENDOR_ID,
             pci_device_id,
+            0x1, // For modern virtio-PCI devices
             class,
             subclass,
             None,


### PR DESCRIPTION
Add support for specifying the PCI revision in the PCI configuration and
populate this with the value of 1 for virtio-pci devices.

The virtio-pci specification is slightly ambiguous only saying that
transitional (i.e. devices that support legacy and virtio 1.0) should
set this to 0. In practice it seems that software expects the revision
to be set to 1 for modern only devices.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>