### PR TITLE
vhost_user_fs: Update FUSE API to 7.31

### DIFF
--- a/vhost_user_fs/src/filesystem.rs
+++ b/vhost_user_fs/src/filesystem.rs
@@ -1096,6 +1096,22 @@ pub trait FileSystem {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn copyfilerange(
+        &self,
+        ctx: Context,
+        inode_in: Self::Inode,
+        handle_in: Self::Handle,
+        offset_in: u64,
+        inode_out: Self::Inode,
+        handle_out: Self::Handle,
+        offset_out: u64,
+        len: u64,
+        flags: u64,
+    ) -> io::Result<usize> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
     /// TODO: support this
     fn getlk(&self) -> io::Result<()> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))

--- a/vhost_user_fs/src/filesystem.rs
+++ b/vhost_user_fs/src/filesystem.rs
@@ -682,10 +682,10 @@ pub trait FileSystem {
     /// implementation did not return a `Handle` from `open` then the contents of `handle` are
     /// undefined.
     ///
-    /// If the `FsOptions::HANDLE_KILLPRIV` feature is not enabled then then the file system is
-    /// expected to clear the setuid and setgid bits.
-    ///
     /// If `delayed_write` is true then it indicates that this is a write for buffered data.
+    ///
+    /// If `kill_priv` is true then it indicates that the file system is expected to clear the
+    /// setuid and setgid bits.
     ///
     /// This method should return exactly the number of bytes requested by the kernel, except in the
     /// case of error. An exception to this rule is if the file was opened with the "direct I/O"
@@ -702,6 +702,7 @@ pub trait FileSystem {
         offset: u64,
         lock_owner: Option<u64>,
         delayed_write: bool,
+        kill_priv: bool,
         flags: u32,
     ) -> io::Result<usize> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))

--- a/vhost_user_fs/src/fuse.rs
+++ b/vhost_user_fs/src/fuse.rs
@@ -143,6 +143,9 @@ const MAX_PAGES: u32 = 4_194_304;
 /// Cache READLINK responses
 const CACHE_SYMLINKS: u32 = 8_388_608;
 
+/// Kernel supports zero-message opendir
+const NO_OPENDIR_SUPPORT: u32 = 16_777_216;
+
 bitflags! {
     /// A bitfield passed in as a parameter to and returned from the `init` method of the
     /// `FileSystem` trait.
@@ -328,6 +331,16 @@ bitflags! {
         ///
         /// This feature is not currently supported.
         const CACHE_SYMLINKS = CACHE_SYMLINKS;
+
+        /// Indicates support for zero-message opens. If this flag is set in the `capable` parameter
+        /// of the `init` trait method, then the file system may return `ENOSYS` from the opendir() handler
+        /// to indicate success. Further attempts to open directories will be handled in the kernel. (If
+        /// this flag is not set, returning ENOSYS will be treated as an error and signaled to the
+        /// caller).
+        ///
+        /// Setting (or not setting) the field in the `FsOptions` returned from the `init` method
+        /// has no effect.
+        const ZERO_MESSAGE_OPENDIR = NO_OPENDIR_SUPPORT;
     }
 }
 

--- a/vhost_user_fs/src/fuse.rs
+++ b/vhost_user_fs/src/fuse.rs
@@ -134,6 +134,9 @@ const HANDLE_KILLPRIV: u32 = 524_288;
 /// FileSystem supports posix acls.
 const POSIX_ACL: u32 = 1_048_576;
 
+/// Reading the device after abort returns ECONNABORTED.
+const ABORT_ERROR: u32 = 2_097_152;
+
 bitflags! {
     /// A bitfield passed in as a parameter to and returned from the `init` method of the
     /// `FileSystem` trait.
@@ -300,6 +303,12 @@ bitflags! {
         ///
         /// This feature is disabled by default.
         const POSIX_ACL = POSIX_ACL;
+
+        /// Indicates that if the connection is gone because of sysfs abort, reading from the device
+        /// will return -ECONNABORTED.
+        ///
+        /// This feature is not currently supported.
+        const ABORT_ERROR = ABORT_ERROR;
     }
 }
 

--- a/vhost_user_fs/src/fuse.rs
+++ b/vhost_user_fs/src/fuse.rs
@@ -373,6 +373,9 @@ pub const WRITE_CACHE: u32 = 1;
 /// `lock_owner` field is valid.
 pub const WRITE_LOCKOWNER: u32 = 2;
 
+/// Kill suid and sgid bits
+pub const WRITE_KILL_PRIV: u32 = 4;
+
 // Read flags.
 pub const READ_LOCKOWNER: u32 = 2;
 

--- a/vhost_user_fs/src/fuse.rs
+++ b/vhost_user_fs/src/fuse.rs
@@ -140,6 +140,9 @@ const ABORT_ERROR: u32 = 2_097_152;
 /// Init_out.max_pages contains the max number of req pages.
 const MAX_PAGES: u32 = 4_194_304;
 
+/// Cache READLINK responses
+const CACHE_SYMLINKS: u32 = 8_388_608;
+
 bitflags! {
     /// A bitfield passed in as a parameter to and returned from the `init` method of the
     /// `FileSystem` trait.
@@ -320,6 +323,11 @@ bitflags! {
         ///
         /// This feature is enabled by default if supported by the kernel.
         const MAX_PAGES = MAX_PAGES;
+
+        /// Indicates that the kernel supports caching READLINK responses.
+        ///
+        /// This feature is not currently supported.
+        const CACHE_SYMLINKS = CACHE_SYMLINKS;
     }
 }
 

--- a/vhost_user_fs/src/fuse.rs
+++ b/vhost_user_fs/src/fuse.rs
@@ -393,6 +393,9 @@ const IOCTL_32BIT: u32 = 8;
 /// Is a directory
 const IOCTL_DIR: u32 = 16;
 
+/// x32 compat ioctl on 64bit machine (64bit time_t)
+const IOCTL_COMPAT_X32: u32 = 32;
+
 /// Maximum of in_iovecs + out_iovecs
 const IOCTL_MAX_IOV: u32 = 256;
 
@@ -412,6 +415,9 @@ bitflags! {
 
         /// Is a directory
         const IOCTL_DIR = IOCTL_DIR;
+
+        /// x32 compat ioctl on 64bit machine (64bit time_t)
+        const IOCTL_COMPAT_X32 = IOCTL_COMPAT_X32;
 
         /// Maximum of in_iovecs + out_iovecs
         const IOCTL_MAX_IOV = IOCTL_MAX_IOV;

--- a/vhost_user_fs/src/fuse.rs
+++ b/vhost_user_fs/src/fuse.rs
@@ -146,6 +146,9 @@ const CACHE_SYMLINKS: u32 = 8_388_608;
 /// Kernel supports zero-message opendir
 const NO_OPENDIR_SUPPORT: u32 = 16_777_216;
 
+/// Only invalidate cached pages on explicit request
+const EXPLICIT_INVAL_DATA: u32 = 33_554_432;
+
 bitflags! {
     /// A bitfield passed in as a parameter to and returned from the `init` method of the
     /// `FileSystem` trait.
@@ -341,6 +344,14 @@ bitflags! {
         /// Setting (or not setting) the field in the `FsOptions` returned from the `init` method
         /// has no effect.
         const ZERO_MESSAGE_OPENDIR = NO_OPENDIR_SUPPORT;
+
+        /// Indicates support for explicit data invalidation. If this feature is enabled, the
+        /// server is fully responsible for data cache invalidation, and the kernel won't
+        /// invalidate files data cache on size change and only truncate that cache to new size
+        /// in case the size decreased.
+        ///
+        /// This feature is not currently supported.
+        const EXPLICIT_INVAL_DATA = EXPLICIT_INVAL_DATA;
     }
 }
 

--- a/vhost_user_fs/src/fuse.rs
+++ b/vhost_user_fs/src/fuse.rs
@@ -1049,6 +1049,19 @@ pub struct LseekOut {
 }
 unsafe impl ByteValued for LseekOut {}
 
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct CopyfilerangeIn {
+    pub fh_in: u64,
+    pub off_in: u64,
+    pub nodeid_out: u64,
+    pub fh_out: u64,
+    pub off_out: u64,
+    pub len: u64,
+    pub flags: u64,
+}
+unsafe impl ByteValued for CopyfilerangeIn {}
+
 bitflags! {
     pub struct SetupmappingFlags: u64 {
     const WRITE = 0x1;

--- a/vhost_user_fs/src/fuse.rs
+++ b/vhost_user_fs/src/fuse.rs
@@ -55,6 +55,9 @@ const FOPEN_KEEP_CACHE: u32 = 2;
 /// The file is not seekable.
 const FOPEN_NONSEEKABLE: u32 = 4;
 
+/// Allow caching this directory.
+const FOPEN_CACHE_DIR: u32 = 8;
+
 bitflags! {
     /// Options controlling the behavior of files opened by the server in response
     /// to an open or create request.
@@ -62,6 +65,7 @@ bitflags! {
         const DIRECT_IO = FOPEN_DIRECT_IO;
         const KEEP_CACHE = FOPEN_KEEP_CACHE;
         const NONSEEKABLE = FOPEN_NONSEEKABLE;
+        const CACHE_DIR = FOPEN_CACHE_DIR;
     }
 }
 

--- a/vhost_user_fs/src/fuse.rs
+++ b/vhost_user_fs/src/fuse.rs
@@ -137,6 +137,9 @@ const POSIX_ACL: u32 = 1_048_576;
 /// Reading the device after abort returns ECONNABORTED.
 const ABORT_ERROR: u32 = 2_097_152;
 
+/// Init_out.max_pages contains the max number of req pages.
+const MAX_PAGES: u32 = 4_194_304;
+
 bitflags! {
     /// A bitfield passed in as a parameter to and returned from the `init` method of the
     /// `FileSystem` trait.
@@ -309,6 +312,14 @@ bitflags! {
         ///
         /// This feature is not currently supported.
         const ABORT_ERROR = ABORT_ERROR;
+
+        /// Indicates support for negotiating the maximum number of pages supported.
+        ///
+        /// If this feature is enabled, we can tell the kernel the maximum number of pages that we
+        /// support to transfer in a single request.
+        ///
+        /// This feature is enabled by default if supported by the kernel.
+        const MAX_PAGES = MAX_PAGES;
     }
 }
 
@@ -848,7 +859,9 @@ pub struct InitOut {
     pub congestion_threshold: u16,
     pub max_write: u32,
     pub time_gran: u32,
-    pub unused: [u32; 9],
+    pub max_pages: u16,
+    pub padding: u16,
+    pub unused: [u32; 8],
 }
 unsafe impl ByteValued for InitOut {}
 

--- a/vhost_user_fs/src/passthrough.rs
+++ b/vhost_user_fs/src/passthrough.rs
@@ -558,7 +558,13 @@ impl PassthroughFs {
                 OpenOptions::DIRECT_IO,
                 flags & (libc::O_DIRECTORY as u32) == 0,
             ),
-            CachePolicy::Always => opts |= OpenOptions::KEEP_CACHE,
+            CachePolicy::Always => {
+                if flags & (libc::O_DIRECTORY as u32) == 0 {
+                    opts |= OpenOptions::KEEP_CACHE;
+                } else {
+                    opts |= OpenOptions::CACHE_DIR;
+                }
+            }
             _ => {}
         };
 

--- a/vhost_user_fs/src/passthrough.rs
+++ b/vhost_user_fs/src/passthrough.rs
@@ -998,11 +998,15 @@ impl FileSystem for PassthroughFs {
         offset: u64,
         _lock_owner: Option<u64>,
         _delayed_write: bool,
+        kill_priv: bool,
         _flags: u32,
     ) -> io::Result<usize> {
-        // We need to change credentials during a write so that the kernel will remove setuid or
-        // setgid bits from the file if it was written to by someone other than the owner.
-        let (_uid, _gid) = set_creds(ctx.uid, ctx.gid)?;
+        if kill_priv {
+            // We need to change credentials during a write so that the kernel will remove setuid
+            // or setgid bits from the file if it was written to by someone other than the owner.
+            let (_uid, _gid) = set_creds(ctx.uid, ctx.gid)?;
+        }
+
         let data = self
             .handles
             .read()

--- a/vhost_user_fs/src/server.rs
+++ b/vhost_user_fs/src/server.rs
@@ -636,6 +636,7 @@ impl<F: FileSystem + Sync> Server<F> {
         };
 
         let delayed_write = write_flags & WRITE_CACHE != 0;
+        let kill_priv = write_flags & WRITE_KILL_PRIV != 0;
 
         let data_reader = ZCReader(r);
 
@@ -648,6 +649,7 @@ impl<F: FileSystem + Sync> Server<F> {
             offset,
             owner,
             delayed_write,
+            kill_priv,
             flags,
         ) {
             Ok(count) => {


### PR DESCRIPTION
This patchset updates the vhost_user_fs FUSE personality to add the features required by the last version available at this moment, 7.31.