### PR TITLE
Support BAR remapping for virtio-fs

### DIFF
--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -42,6 +42,8 @@ pub struct VirtioSharedMemory {
 
 #[derive(Clone)]
 pub struct VirtioSharedMemoryList {
+    pub host_addr: u64,
+    pub mem_slot: u32,
     pub addr: GuestAddress,
     pub len: GuestUsize,
     pub region_list: Vec<VirtioSharedMemory>,
@@ -95,6 +97,14 @@ pub trait VirtioDevice: Send {
     /// Returns the list of shared memory regions required by the device.
     fn get_shm_regions(&self) -> Option<VirtioSharedMemoryList> {
         None
+    }
+
+    /// Updates the list of shared memory regions required by the device.
+    fn set_shm_regions(
+        &mut self,
+        _shm_regions: VirtioSharedMemoryList,
+    ) -> std::result::Result<(), Error> {
+        std::unimplemented!()
     }
 
     fn iommu_translate(&self, addr: u64) -> u64 {

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -186,4 +186,5 @@ pub enum Error {
     FailedSignalingDriver(io::Error),
     VhostUserUpdateMemory(vhost_user::Error),
     EventfdError(io::Error),
+    SetShmRegionsNotSupported,
 }

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -757,6 +757,11 @@ impl PciDevice for VirtioPciDevice {
                     PciDeviceError::IoRegistrationFailed(shm_list.addr.raw_value(), e)
                 })? as u8;
 
+            let region_type = PciBarRegionType::Memory64BitRegion;
+            ranges.push((shm_list.addr, shm_list.len, region_type));
+            self.bar_regions
+                .push((shm_list.addr, shm_list.len, region_type));
+
             for (idx, shm) in shm_list.region_list.iter().enumerate() {
                 let shm_cap = VirtioPciCap64::new(
                     PciCapabilityType::SharedMemoryConfig,


### PR DESCRIPTION
This pull request tackles the problem of PCI BAR remapping associated with the shared memory region as it needs to be updated according to the new BAR location in guest address space.