### PR TITLE
Remove userspace mapping when unplugging VirtioDevice

### DIFF
--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -35,6 +35,15 @@ pub type VirtioIommuRemapping =
     Box<dyn Fn(u64) -> std::result::Result<u64, std::io::Error> + Send + Sync>;
 
 #[derive(Clone)]
+pub struct UserspaceMapping {
+    pub host_addr: u64,
+    pub mem_slot: u32,
+    pub addr: GuestAddress,
+    pub len: GuestUsize,
+    pub mergeable: bool,
+}
+
+#[derive(Clone)]
 pub struct VirtioSharedMemory {
     pub offset: u64,
     pub len: u64,
@@ -119,6 +128,11 @@ pub trait VirtioDevice: Send {
 
     fn update_memory(&mut self, _mem: &GuestMemoryMmap) -> std::result::Result<(), Error> {
         Ok(())
+    }
+
+    /// Returns the list of userspace mappings associated with this device.
+    fn userspace_mappings(&self) -> Vec<UserspaceMapping> {
+        Vec::new()
     }
 }
 

--- a/vm-virtio/src/vhost_user/fs.rs
+++ b/vm-virtio/src/vhost_user/fs.rs
@@ -13,7 +13,7 @@ use libc::{self, c_void, off64_t, pread64, pwrite64, EFD_NONBLOCK};
 use std::cmp;
 use std::io;
 use std::io::Write;
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -542,6 +542,10 @@ impl VirtioDevice for Fs {
             self.interrupt_cb.take().unwrap(),
             self.queue_evts.take().unwrap(),
         ))
+    }
+
+    fn shutdown(&mut self) {
+        let _ = unsafe { libc::close(self.vu.as_raw_fd()) };
     }
 
     fn get_shm_regions(&self) -> Option<VirtioSharedMemoryList> {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2209,7 +2209,22 @@ impl DeviceManager {
 
             // Shutdown and remove the underlying virtio-device if present
             if let Some(virtio_device) = virtio_device {
+                for mapping in virtio_device.lock().unwrap().userspace_mappings() {
+                    self.memory_manager
+                        .lock()
+                        .unwrap()
+                        .remove_userspace_mapping(
+                            mapping.addr.raw_value(),
+                            mapping.len,
+                            mapping.host_addr,
+                            mapping.mergeable,
+                            mapping.mem_slot,
+                        )
+                        .map_err(DeviceManagerError::MemoryManager)?;
+                }
+
                 virtio_device.lock().unwrap().shutdown();
+
                 self.virtio_devices
                     .retain(|(d, _, _)| !Arc::ptr_eq(d, &virtio_device));
             }


### PR DESCRIPTION
This pull request fixes the previous implementation of hot-unplugging virtio device. One piece was missing, as we were not removing the userspace mappings from virtio-pmem devices.
This is a generic fix so that further work adding the support of hot-unplug to virtio-fs will be transparently benefiting from this patch.