### PR TITLE
vmm: Add the 'shared' and 'hugepages' controls to MemoryConfig

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn create_app<'a, 'b>(
                 .long("memory")
                 .help(
                     "Memory parameters \
-                     \"size=<guest_memory_size>,file=<backing_file_path>,mergeable=on|off,\
+                     \"size=<guest_memory_size>,mergeable=on|off,shared=on|off,hugepages=on|off,\
                      hotplug_method=acpi|virtio-mem,\
                      hotplug_size=<hotpluggable_memory_size>\"",
                 )
@@ -501,6 +501,8 @@ mod unit_tests {
                     mergeable: false,
                     hotplug_method: HotplugMethod::Acpi,
                     hotplug_size: None,
+                    shared: false,
+                    hugepages: false,
                 },
                 kernel: Some(KernelConfig {
                     path: PathBuf::from("/path/to/kernel"),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1175,7 +1175,7 @@ mod tests {
 
             let mut cloud_child = GuestCommand::new(&guest)
                 .args(&["--cpus", "boot=4"])
-                .args(&["--memory", "size=512M,file=/dev/shm"])
+                .args(&["--memory", "size=512M,shared=on"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .args(&[
                     "--disk",
@@ -1288,7 +1288,7 @@ mod tests {
 
             let mut cloud_child = GuestCommand::new(&guest)
                 .args(&["--cpus", format!("boot={}", num_queues / 2).as_str()])
-                .args(&["--memory", "size=512M,hotplug_size=2048M,file=/dev/shm"])
+                .args(&["--memory", "size=512M,hotplug_size=2048M,shared=on"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .default_disks()
@@ -1457,7 +1457,7 @@ mod tests {
 
             let mut cloud_child = GuestCommand::new(&guest)
                 .args(&["--cpus", format!("boot={}", num_queues).as_str()])
-                .args(&["--memory", "size=512M,hotplug_size=2048M,file=/dev/shm"])
+                .args(&["--memory", "size=512M,hotplug_size=2048M,shared=on"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .args(&[
@@ -1659,7 +1659,7 @@ mod tests {
 
             let mut cloud_child = GuestCommand::new(&guest)
                 .args(&["--cpus", format!("boot={}", num_queues).as_str()])
-                .args(&["--memory", "size=512M,file=/dev/shm"])
+                .args(&["--memory", "size=512M,shared=on"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .args(&[
@@ -1814,7 +1814,7 @@ mod tests {
             let mut guest_command = GuestCommand::new(&guest);
             guest_command
                 .args(&["--cpus", "boot=1"])
-                .args(&["--memory", "size=512M,hotplug_size=2048M,file=/dev/shm"])
+                .args(&["--memory", "size=512M,hotplug_size=2048M,shared=on"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .default_disks()
                 .default_net()
@@ -2491,7 +2491,7 @@ mod tests {
 
             let mut child = GuestCommand::new(&guest)
                 .args(&["--cpus", "boot=4"])
-                .args(&["--memory", "size=2G,file=/dev/hugepages"])
+                .args(&["--memory", "size=2G,hugepages=on,shared=on"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .default_disks()
                 .args(&[

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -380,6 +380,12 @@ components:
         hotplug_method:
           type: string
           default: "acpi"
+        shared:
+          type: boolean
+          default: false
+        hugepages:
+          type: boolean
+          default: false
 
     KernelConfig:
       required:

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -222,6 +222,7 @@ pub fn vmm_thread_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_listen),
             allow_syscall(libc::SYS_lseek),
             allow_syscall(libc::SYS_madvise),
+            allow_syscall(libc::SYS_memfd_create),
             allow_syscall(libc::SYS_mmap),
             allow_syscall(libc::SYS_mprotect),
             allow_syscall(libc::SYS_mremap),


### PR DESCRIPTION
The new 'shared' and 'hugepages' controls aim to replace the 'file'
option in MemoryConfig. This patch also updated all related integration
tests to use the new controls (instead of providing explicit paths to
"/dev/shm" or "/dev/hugepages").

Fixes: #1011

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
Signed-off-by: Bo Chen <chen.bo@intel.com>