### PR TITLE
ci: Ignore test_snapshot_restore

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4046,6 +4046,7 @@ mod tests {
     // One thing to note about this test. The virtio-net device is heavily used
     // through each ssh command. There's no need to perform a dedicated test to
     // verify the migration went well for virtio-net.
+    #[ignore]
     #[cfg_attr(feature = "mmio", test)]
     fn test_snapshot_restore() {
         test_block!(tb, "", {


### PR DESCRIPTION
The newly added integration test "test_snapshot_restore" is very
unstable, which causes our CI to fail on most pull requests, which is
not acceptable. That's why we ignore this test until we can fix the
stability issue.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>