### PR TITLE
Add identifiers to virtio devices

### DIFF
--- a/vm-virtio/src/iommu.rs
+++ b/vm-virtio/src/iommu.rs
@@ -793,6 +793,7 @@ impl DmaRemapping for IommuMapping {
 }
 
 pub struct Iommu {
+    id: String,
     kill_evt: Option<EventFd>,
     pause_evt: Option<EventFd>,
     avail_features: u64,
@@ -808,7 +809,7 @@ pub struct Iommu {
 }
 
 impl Iommu {
-    pub fn new() -> io::Result<(Self, Arc<IommuMapping>)> {
+    pub fn new(id: String) -> io::Result<(Self, Arc<IommuMapping>)> {
         let config = VirtioIommuConfig {
             page_size_mask: VIRTIO_IOMMU_PAGE_SIZE_MASK,
             probe_size: PROBE_PROP_SIZE,
@@ -822,6 +823,7 @@ impl Iommu {
 
         Ok((
             Iommu {
+                id,
                 kill_evt: None,
                 pause_evt: None,
                 avail_features: 1u64 << VIRTIO_F_VERSION_1
@@ -1039,6 +1041,10 @@ impl VirtioDevice for Iommu {
 }
 
 virtio_pausable!(Iommu);
-impl Snapshottable for Iommu {}
+impl Snapshottable for Iommu {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+}
 impl Transportable for Iommu {}
 impl Migratable for Iommu {}

--- a/vm-virtio/src/mem.rs
+++ b/vm-virtio/src/mem.rs
@@ -738,6 +738,7 @@ impl MemEpollHandler {
 
 // Virtio device for exposing entropy to the guest OS through virtio.
 pub struct Mem {
+    id: String,
     resize: Resize,
     kill_evt: Option<EventFd>,
     pause_evt: Option<EventFd>,
@@ -754,7 +755,7 @@ pub struct Mem {
 
 impl Mem {
     // Create a new virtio-mem device.
-    pub fn new(region: &Arc<GuestRegionMmap>, resize: Resize) -> io::Result<Mem> {
+    pub fn new(id: String, region: &Arc<GuestRegionMmap>, resize: Resize) -> io::Result<Mem> {
         let region_len = region.len();
 
         if region_len != region_len / VIRTIO_MEM_DEFAULT_BLOCK_SIZE * VIRTIO_MEM_DEFAULT_BLOCK_SIZE
@@ -787,6 +788,7 @@ impl Mem {
         };
 
         Ok(Mem {
+            id,
             resize,
             kill_evt: None,
             pause_evt: None,
@@ -955,6 +957,10 @@ impl VirtioDevice for Mem {
 }
 
 virtio_pausable!(Mem);
-impl Snapshottable for Mem {}
+impl Snapshottable for Mem {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+}
 impl Transportable for Mem {}
 impl Migratable for Mem {}

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -259,6 +259,8 @@ const VIRTIO_PCI_VENDOR_ID: u16 = 0x1af4;
 const VIRTIO_PCI_DEVICE_ID_BASE: u16 = 0x1040; // Add to device type to get device ID.
 
 pub struct VirtioPciDevice {
+    id: String,
+
     // PCI configuration registers.
     configuration: PciConfiguration,
 
@@ -308,6 +310,7 @@ pub struct VirtioPciDevice {
 impl VirtioPciDevice {
     /// Constructs a new PCI transport for the given virtio device.
     pub fn new(
+        id: String,
         memory: GuestMemoryAtomic<GuestMemoryMmap>,
         device: Arc<Mutex<dyn VirtioDevice>>,
         msix_num: u16,
@@ -384,6 +387,7 @@ impl VirtioPciDevice {
         );
 
         let mut virtio_pci_device = VirtioPciDevice {
+            id,
             configuration,
             common_config: VirtioPciCommonConfig {
                 driver_status: 0,
@@ -962,6 +966,10 @@ impl Pausable for VirtioPciDevice {
     }
 }
 
-impl Snapshottable for VirtioPciDevice {}
+impl Snapshottable for VirtioPciDevice {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+}
 impl Transportable for VirtioPciDevice {}
 impl Migratable for VirtioPciDevice {}

--- a/vm-virtio/src/vhost_user/blk.rs
+++ b/vm-virtio/src/vhost_user/blk.rs
@@ -34,6 +34,7 @@ struct SlaveReqHandler {}
 impl VhostUserMasterReqHandler for SlaveReqHandler {}
 
 pub struct Blk {
+    id: String,
     vhost_user_blk: Master,
     kill_evt: Option<EventFd>,
     pause_evt: Option<EventFd>,
@@ -49,7 +50,7 @@ pub struct Blk {
 
 impl Blk {
     /// Create a new vhost-user-blk device
-    pub fn new(wce: bool, vu_cfg: VhostUserConfig) -> Result<Blk> {
+    pub fn new(id: String, wce: bool, vu_cfg: VhostUserConfig) -> Result<Blk> {
         let mut vhost_user_blk = Master::connect(&vu_cfg.sock, vu_cfg.num_queues as u64)
             .map_err(Error::VhostUserCreateMaster)?;
 
@@ -140,6 +141,7 @@ impl Blk {
         }
 
         Ok(Blk {
+            id,
             vhost_user_blk,
             kill_evt: None,
             pause_evt: None,
@@ -328,6 +330,10 @@ impl VirtioDevice for Blk {
 }
 
 virtio_pausable!(Blk);
-impl Snapshottable for Blk {}
+impl Snapshottable for Blk {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+}
 impl Transportable for Blk {}
 impl Migratable for Blk {}

--- a/vm-virtio/src/vhost_user/fs.rs
+++ b/vm-virtio/src/vhost_user/fs.rs
@@ -267,6 +267,7 @@ impl Default for VirtioFsConfig {
 unsafe impl ByteValued for VirtioFsConfig {}
 
 pub struct Fs {
+    id: String,
     vu: Master,
     queue_sizes: Vec<u16>,
     avail_features: u64,
@@ -287,6 +288,7 @@ pub struct Fs {
 impl Fs {
     /// Create a new virtio-fs device.
     pub fn new(
+        id: String,
         path: &str,
         tag: &str,
         req_num_queues: usize,
@@ -352,6 +354,7 @@ impl Fs {
         config.num_request_queues = req_num_queues as u32;
 
         Ok(Fs {
+            id,
             vu: master,
             queue_sizes: vec![queue_size; num_queues],
             avail_features,
@@ -605,6 +608,10 @@ impl VirtioDevice for Fs {
 }
 
 virtio_pausable!(Fs);
-impl Snapshottable for Fs {}
+impl Snapshottable for Fs {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+}
 impl Transportable for Fs {}
 impl Migratable for Fs {}

--- a/vm-virtio/src/vhost_user/net.rs
+++ b/vm-virtio/src/vhost_user/net.rs
@@ -37,6 +37,7 @@ struct SlaveReqHandler {}
 impl VhostUserMasterReqHandler for SlaveReqHandler {}
 
 pub struct Net {
+    id: String,
     vhost_user_net: Master,
     kill_evt: Option<EventFd>,
     pause_evt: Option<EventFd>,
@@ -55,7 +56,7 @@ pub struct Net {
 impl Net {
     /// Create a new vhost-user-net device
     /// Create a new vhost-user-net device
-    pub fn new(mac_addr: MacAddr, vu_cfg: VhostUserConfig) -> Result<Net> {
+    pub fn new(id: String, mac_addr: MacAddr, vu_cfg: VhostUserConfig) -> Result<Net> {
         let mut vhost_user_net = Master::connect(&vu_cfg.sock, vu_cfg.num_queues as u64)
             .map_err(Error::VhostUserCreateMaster)?;
 
@@ -141,6 +142,7 @@ impl Net {
         }
 
         Ok(Net {
+            id,
             vhost_user_net,
             kill_evt: None,
             pause_evt: None,
@@ -365,6 +367,10 @@ impl VirtioDevice for Net {
 }
 
 virtio_ctrl_q_pausable!(Net);
-impl Snapshottable for Net {}
+impl Snapshottable for Net {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+}
 impl Transportable for Net {}
 impl Migratable for Net {}

--- a/vm-virtio/src/vsock/device.rs
+++ b/vm-virtio/src/vsock/device.rs
@@ -376,6 +376,7 @@ where
 
 /// Virtio device exposing virtual socket to the guest.
 pub struct Vsock<B: VsockBackend> {
+    id: String,
     cid: u64,
     backend: Arc<RwLock<B>>,
     kill_evt: Option<EventFd>,
@@ -394,7 +395,7 @@ where
 {
     /// Create a new virtio-vsock device with the given VM CID and vsock
     /// backend.
-    pub fn new(cid: u64, backend: B, iommu: bool) -> io::Result<Vsock<B>> {
+    pub fn new(id: String, cid: u64, backend: B, iommu: bool) -> io::Result<Vsock<B>> {
         let mut avail_features = 1u64 << VIRTIO_F_VERSION_1 | 1u64 << VIRTIO_F_IN_ORDER;
 
         if iommu {
@@ -402,6 +403,7 @@ where
         }
 
         Ok(Vsock {
+            id,
             cid,
             backend: Arc::new(RwLock::new(backend)),
             kill_evt: None,
@@ -574,7 +576,14 @@ where
 
 virtio_pausable!(Vsock, T: 'static + VsockBackend + Sync);
 
-impl<B> Snapshottable for Vsock<B> where B: VsockBackend + Sync + 'static {}
+impl<B> Snapshottable for Vsock<B>
+where
+    B: VsockBackend + Sync + 'static,
+{
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+}
 impl<B> Transportable for Vsock<B> where B: VsockBackend + Sync + 'static {}
 impl<B> Migratable for Vsock<B> where B: VsockBackend + Sync + 'static {}
 

--- a/vm-virtio/src/vsock/mod.rs
+++ b/vm-virtio/src/vsock/mod.rs
@@ -265,7 +265,7 @@ mod tests {
                 cid: CID,
                 mem: GuestMemoryMmap::from_ranges(&[(GuestAddress(0), MEM_SIZE)]).unwrap(),
                 mem_size: MEM_SIZE,
-                device: Vsock::new(CID, TestBackend::new(), false).unwrap(),
+                device: Vsock::new(String::from("vsock"), CID, TestBackend::new(), false).unwrap(),
             }
         }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -73,6 +73,8 @@ const MMIO_LEN: u64 = 0x1000;
 #[cfg(feature = "pci_support")]
 const VFIO_DEVICE_NAME_PREFIX: &str = "vfio";
 
+const IOAPIC_DEVICE_NAME: &str = "ioapic";
+
 const CONSOLE_DEVICE_NAME: &str = "console";
 const DISK_DEVICE_NAME_PREFIX: &str = "disk";
 const FS_DEVICE_NAME_PREFIX: &str = "fs";
@@ -902,6 +904,8 @@ impl DeviceManager {
         address_manager: &Arc<AddressManager>,
         interrupt_manager: Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>>,
     ) -> DeviceManagerResult<Arc<Mutex<ioapic::Ioapic>>> {
+        let _id = String::from(IOAPIC_DEVICE_NAME);
+
         // Create IOAPIC
         let ioapic = Arc::new(Mutex::new(
             ioapic::Ioapic::new(APIC_START, interrupt_manager)

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1683,7 +1683,7 @@ impl DeviceManager {
 
         Ok((
             Arc::clone(&vsock_device) as VirtioDeviceArc,
-            false,
+            vsock_cfg.iommu,
             vsock_cfg.id.clone(),
         ))
     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1201,7 +1201,7 @@ impl DeviceManager {
                 queue_size: disk_cfg.queue_size,
             };
             let vhost_user_block_device = Arc::new(Mutex::new(
-                vm_virtio::vhost_user::Blk::new(disk_cfg.wce, vu_cfg)
+                vm_virtio::vhost_user::Blk::new(id, disk_cfg.wce, vu_cfg)
                     .map_err(DeviceManagerError::CreateVhostUserBlk)?,
             ));
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1114,11 +1114,15 @@ impl DeviceManager {
             let (virtio_console_device, console_input) =
                 vm_virtio::Console::new(id.clone(), writer, col, row, console_config.iommu)
                     .map_err(DeviceManagerError::CreateVirtioConsole)?;
+            let virtio_console_device = Arc::new(Mutex::new(virtio_console_device));
             virtio_devices.push((
-                Arc::new(Mutex::new(virtio_console_device)) as VirtioDeviceArc,
+                Arc::clone(&virtio_console_device) as VirtioDeviceArc,
                 console_config.iommu,
                 id,
             ));
+
+            self.add_migratable_device(virtio_console_device as Arc<Mutex<dyn Migratable>>);
+
             Some(console_input)
         } else {
             None

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1458,9 +1458,13 @@ impl DeviceManager {
         &mut self,
         fs_cfg: &mut FsConfig,
     ) -> DeviceManagerResult<(VirtioDeviceArc, bool, Option<String>)> {
-        if fs_cfg.id.is_none() {
-            fs_cfg.id = Some(self.next_device_name(FS_DEVICE_NAME_PREFIX)?);
-        }
+        let id = if let Some(id) = &fs_cfg.id {
+            id.clone()
+        } else {
+            let id = self.next_device_name(FS_DEVICE_NAME_PREFIX)?;
+            fs_cfg.id = Some(id.clone());
+            id
+        };
 
         if let Some(fs_sock) = fs_cfg.sock.to_str() {
             let cache = if fs_cfg.dax {
@@ -1519,6 +1523,7 @@ impl DeviceManager {
 
             let virtio_fs_device = Arc::new(Mutex::new(
                 vm_virtio::vhost_user::Fs::new(
+                    id,
                     fs_sock,
                     &fs_cfg.tag,
                     fs_cfg.num_queues,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -82,6 +82,9 @@ const PMEM_DEVICE_NAME_PREFIX: &str = "pmem";
 const RNG_DEVICE_NAME: &str = "rng";
 const VSOCK_DEVICE_NAME_PREFIX: &str = "vsock";
 
+#[cfg(feature = "pci_support")]
+const IOMMU_DEVICE_NAME: &str = "iommu";
+
 /// Errors associated with device manager
 #[derive(Debug)]
 pub enum DeviceManagerError {
@@ -839,7 +842,7 @@ impl DeviceManager {
                     &mut pci_bus,
                     &None,
                     &interrupt_manager,
-                    None,
+                    Some(String::from(IOMMU_DEVICE_NAME)),
                 )?;
             }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -77,6 +77,7 @@ const DISK_DEVICE_NAME_PREFIX: &str = "disk";
 const FS_DEVICE_NAME_PREFIX: &str = "fs";
 const NET_DEVICE_NAME_PREFIX: &str = "net";
 const PMEM_DEVICE_NAME_PREFIX: &str = "pmem";
+const RNG_DEVICE_NAME: &str = "rng";
 const VSOCK_DEVICE_NAME_PREFIX: &str = "vsock";
 
 /// Errors associated with device manager
@@ -1415,6 +1416,8 @@ impl DeviceManager {
         // Add virtio-rng if required
         let rng_config = self.config.lock().unwrap().rng.clone();
         if let Some(rng_path) = rng_config.src.to_str() {
+            let id = String::from(RNG_DEVICE_NAME);
+
             let virtio_rng_device = Arc::new(Mutex::new(
                 vm_virtio::Rng::new(rng_path, rng_config.iommu)
                     .map_err(DeviceManagerError::CreateVirtioRng)?,
@@ -1422,7 +1425,7 @@ impl DeviceManager {
             devices.push((
                 Arc::clone(&virtio_rng_device) as VirtioDeviceArc,
                 rng_config.iommu,
-                None,
+                Some(id),
             ));
 
             self.add_migratable_device(

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -73,6 +73,7 @@ const MMIO_LEN: u64 = 0x1000;
 #[cfg(feature = "pci_support")]
 const VFIO_DEVICE_NAME_PREFIX: &str = "vfio";
 
+const CONSOLE_DEVICE_NAME: &str = "console";
 const DISK_DEVICE_NAME_PREFIX: &str = "disk";
 const FS_DEVICE_NAME_PREFIX: &str = "fs";
 const MEM_DEVICE_NAME: &str = "mem";
@@ -1100,7 +1101,7 @@ impl DeviceManager {
             virtio_devices.push((
                 Arc::new(Mutex::new(virtio_console_device)) as VirtioDeviceArc,
                 console_config.iommu,
-                None,
+                Some(String::from(CONSOLE_DEVICE_NAME)),
             ));
             Some(console_input)
         } else {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -73,6 +73,7 @@ const MMIO_LEN: u64 = 0x1000;
 const VFIO_DEVICE_NAME_PREFIX: &str = "vfio";
 
 const IOAPIC_DEVICE_NAME: &str = "ioapic";
+const SERIAL_DEVICE_NAME_PREFIX: &str = "serial";
 
 const CONSOLE_DEVICE_NAME: &str = "console";
 const DISK_DEVICE_NAME_PREFIX: &str = "disk";
@@ -1060,6 +1061,8 @@ impl DeviceManager {
             // Serial is tied to IRQ #4
             let serial_irq = 4;
 
+            let id = String::from(SERIAL_DEVICE_NAME_PREFIX);
+
             let interrupt_group = interrupt_manager
                 .create_group(LegacyIrqGroupConfig {
                     irq: serial_irq as InterruptIndex,
@@ -1067,6 +1070,7 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::CreateInterruptGroup)?;
 
             let serial = Arc::new(Mutex::new(devices::legacy::Serial::new(
+                id,
                 interrupt_group,
                 serial_writer,
             )));

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1421,7 +1421,7 @@ impl DeviceManager {
             ));
             devices.push((
                 Arc::clone(&virtio_rng_device) as VirtioDeviceArc,
-                false,
+                rng_config.iommu,
                 None,
             ));
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1099,13 +1099,14 @@ impl DeviceManager {
         };
         let (col, row) = get_win_size();
         let console_input = if let Some(writer) = console_writer {
+            let id = String::from(CONSOLE_DEVICE_NAME);
             let (virtio_console_device, console_input) =
-                vm_virtio::Console::new(writer, col, row, console_config.iommu)
+                vm_virtio::Console::new(id.clone(), writer, col, row, console_config.iommu)
                     .map_err(DeviceManagerError::CreateVirtioConsole)?;
             virtio_devices.push((
                 Arc::new(Mutex::new(virtio_console_device)) as VirtioDeviceArc,
                 console_config.iommu,
-                Some(String::from(CONSOLE_DEVICE_NAME)),
+                Some(id),
             ));
             Some(console_input)
         } else {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -70,27 +70,27 @@ use vmm_sys_util::eventfd::EventFd;
 const MMIO_LEN: u64 = 0x1000;
 
 #[cfg(feature = "pci_support")]
-const VFIO_DEVICE_NAME_PREFIX: &str = "vfio";
+const VFIO_DEVICE_NAME_PREFIX: &str = "_vfio";
 
-const IOAPIC_DEVICE_NAME: &str = "ioapic";
-const SERIAL_DEVICE_NAME_PREFIX: &str = "serial";
+const IOAPIC_DEVICE_NAME: &str = "_ioapic";
+const SERIAL_DEVICE_NAME_PREFIX: &str = "_serial";
 
-const CONSOLE_DEVICE_NAME: &str = "console";
-const DISK_DEVICE_NAME_PREFIX: &str = "disk";
-const FS_DEVICE_NAME_PREFIX: &str = "fs";
-const MEM_DEVICE_NAME: &str = "mem";
-const NET_DEVICE_NAME_PREFIX: &str = "net";
-const PMEM_DEVICE_NAME_PREFIX: &str = "pmem";
-const RNG_DEVICE_NAME: &str = "rng";
-const VSOCK_DEVICE_NAME_PREFIX: &str = "vsock";
+const CONSOLE_DEVICE_NAME: &str = "_console";
+const DISK_DEVICE_NAME_PREFIX: &str = "_disk";
+const FS_DEVICE_NAME_PREFIX: &str = "_fs";
+const MEM_DEVICE_NAME: &str = "_mem";
+const NET_DEVICE_NAME_PREFIX: &str = "_net";
+const PMEM_DEVICE_NAME_PREFIX: &str = "_pmem";
+const RNG_DEVICE_NAME: &str = "_rng";
+const VSOCK_DEVICE_NAME_PREFIX: &str = "_vsock";
 
 #[cfg(feature = "pci_support")]
-const IOMMU_DEVICE_NAME: &str = "iommu";
+const IOMMU_DEVICE_NAME: &str = "_iommu";
 
 #[cfg(feature = "mmio_support")]
-const VIRTIO_MMIO_DEVICE_NAME_PREFIX: &str = "virtio-mmio";
+const VIRTIO_MMIO_DEVICE_NAME_PREFIX: &str = "_virtio-mmio";
 #[cfg(feature = "pci_support")]
-const VIRTIO_PCI_DEVICE_NAME_PREFIX: &str = "virtio-pci";
+const VIRTIO_PCI_DEVICE_NAME_PREFIX: &str = "_virtio-pci";
 
 /// Errors associated with device manager
 #[derive(Debug)]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1097,7 +1097,7 @@ impl DeviceManager {
                     .map_err(DeviceManagerError::CreateVirtioConsole)?;
             virtio_devices.push((
                 Arc::new(Mutex::new(virtio_console_device)) as VirtioDeviceArc,
-                false,
+                console_config.iommu,
                 None,
             ));
             Some(console_input)

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -903,11 +903,11 @@ impl DeviceManager {
         address_manager: &Arc<AddressManager>,
         interrupt_manager: Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>>,
     ) -> DeviceManagerResult<Arc<Mutex<ioapic::Ioapic>>> {
-        let _id = String::from(IOAPIC_DEVICE_NAME);
+        let id = String::from(IOAPIC_DEVICE_NAME);
 
         // Create IOAPIC
         let ioapic = Arc::new(Mutex::new(
-            ioapic::Ioapic::new(APIC_START, interrupt_manager)
+            ioapic::Ioapic::new(id, APIC_START, interrupt_manager)
                 .map_err(DeviceManagerError::CreateIoapic)?,
         ));
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1340,9 +1340,13 @@ impl DeviceManager {
         &mut self,
         net_cfg: &mut NetConfig,
     ) -> DeviceManagerResult<(VirtioDeviceArc, bool, Option<String>)> {
-        if net_cfg.id.is_none() {
-            net_cfg.id = Some(self.next_device_name(NET_DEVICE_NAME_PREFIX)?);
-        }
+        let id = if let Some(id) = &net_cfg.id {
+            id.clone()
+        } else {
+            let id = self.next_device_name(NET_DEVICE_NAME_PREFIX)?;
+            net_cfg.id = Some(id.clone());
+            id
+        };
 
         if net_cfg.vhost_user {
             let sock = if let Some(sock) = net_cfg.vhost_socket.clone() {
@@ -1371,6 +1375,7 @@ impl DeviceManager {
             let virtio_net_device = if let Some(ref tap_if_name) = net_cfg.tap {
                 Arc::new(Mutex::new(
                     vm_virtio::Net::new(
+                        id,
                         Some(tap_if_name),
                         None,
                         None,
@@ -1384,6 +1389,7 @@ impl DeviceManager {
             } else {
                 Arc::new(Mutex::new(
                     vm_virtio::Net::new(
+                        id,
                         None,
                         Some(net_cfg.ip),
                         Some(net_cfg.mask),

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1437,7 +1437,7 @@ impl DeviceManager {
             let id = String::from(RNG_DEVICE_NAME);
 
             let virtio_rng_device = Arc::new(Mutex::new(
-                vm_virtio::Rng::new(rng_path, rng_config.iommu)
+                vm_virtio::Rng::new(id.clone(), rng_path, rng_config.iommu)
                     .map_err(DeviceManagerError::CreateVirtioRng)?,
             ));
             devices.push((

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1360,7 +1360,7 @@ impl DeviceManager {
                 queue_size: net_cfg.queue_size,
             };
             let vhost_user_net_device = Arc::new(Mutex::new(
-                vm_virtio::vhost_user::Net::new(net_cfg.mac, vu_cfg)
+                vm_virtio::vhost_user::Net::new(id, net_cfg.mac, vu_cfg)
                     .map_err(DeviceManagerError::CreateVhostUserNet)?,
             ));
             self.add_migratable_device(

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -75,6 +75,7 @@ const VFIO_DEVICE_NAME_PREFIX: &str = "vfio";
 
 const DISK_DEVICE_NAME_PREFIX: &str = "disk";
 const FS_DEVICE_NAME_PREFIX: &str = "fs";
+const MEM_DEVICE_NAME: &str = "mem";
 const NET_DEVICE_NAME_PREFIX: &str = "net";
 const PMEM_DEVICE_NAME_PREFIX: &str = "pmem";
 const RNG_DEVICE_NAME: &str = "rng";
@@ -1725,7 +1726,7 @@ impl DeviceManager {
             devices.push((
                 Arc::clone(&virtio_mem_device) as VirtioDeviceArc,
                 false,
-                None,
+                Some(String::from(MEM_DEVICE_NAME)),
             ));
 
             let migratable = Arc::clone(&virtio_mem_device) as Arc<Mutex<dyn Migratable>>;

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -788,9 +788,11 @@ impl DeviceManager {
                 Arc::clone(&self.address_manager) as Arc<dyn DeviceRelocation>,
             );
 
+            let iommu_id = String::from(IOMMU_DEVICE_NAME);
+
             let (iommu_device, iommu_mapping) = if self.config.lock().unwrap().iommu {
-                let (device, mapping) =
-                    vm_virtio::Iommu::new().map_err(DeviceManagerError::CreateVirtioIommu)?;
+                let (device, mapping) = vm_virtio::Iommu::new(iommu_id.clone())
+                    .map_err(DeviceManagerError::CreateVirtioIommu)?;
                 let device = Arc::new(Mutex::new(device));
                 self.iommu_device = Some(Arc::clone(&device));
                 (Some(device), Some(mapping))
@@ -841,7 +843,7 @@ impl DeviceManager {
                     &mut pci_bus,
                     &None,
                     &interrupt_manager,
-                    Some(String::from(IOMMU_DEVICE_NAME)),
+                    Some(iommu_id),
                 )?;
             }
 


### PR DESCRIPTION
As a preparatory work to support a full tree containing the resources associated with each device, which is going to be mandatory to perform proper snapshot/restore, we need to identify each virtio device with a unique id.