### PR TITLE
virtio-mem: Remove unwrap for tx.send

### DIFF
--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -187,4 +187,5 @@ pub enum Error {
     VhostUserUpdateMemory(vhost_user::Error),
     EventfdError(io::Error),
     SetShmRegionsNotSupported,
+    EpollHander(String),
 }


### PR DESCRIPTION
Remove unwrap for tx.send.
Change this part to should output error and break epoll.

Fixes: #1081

Signed-off-by: Hui Zhu <teawater@antfin.com>