### PR TITLE
vmm: Improve snapshot/restore reliability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,6 +1478,7 @@ dependencies = [
  "arc-swap",
  "arch",
  "clap",
+ "credibility",
  "devices",
  "epoll",
  "kvm-bindings",

--- a/vm-device/src/lib.rs
+++ b/vm-device/src/lib.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+extern crate serde_derive;
 extern crate vm_memory;
 
 pub mod interrupt;
@@ -8,7 +10,7 @@ use vm_memory::{
 };
 
 /// Type of Message Singaled Interrupt
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub enum MsiIrqType {
     /// PCI MSI IRQ numbers.
     PciMsi,
@@ -20,7 +22,7 @@ pub enum MsiIrqType {
 
 /// Enumeration for device resources.
 #[allow(missing_docs)]
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub enum Resource {
     /// IO Port address range.
     PioAddressRange { base: u16, size: u16 },

--- a/vm-device/src/lib.rs
+++ b/vm-device/src/lib.rs
@@ -7,6 +7,39 @@ use vm_memory::{
     MemoryRegionAddress,
 };
 
+/// Type of Message Singaled Interrupt
+#[derive(Copy, Clone, PartialEq)]
+pub enum MsiIrqType {
+    /// PCI MSI IRQ numbers.
+    PciMsi,
+    /// PCI MSIx IRQ numbers.
+    PciMsix,
+    /// Generic MSI IRQ numbers.
+    GenericMsi,
+}
+
+/// Enumeration for device resources.
+#[allow(missing_docs)]
+#[derive(Clone)]
+pub enum Resource {
+    /// IO Port address range.
+    PioAddressRange { base: u16, size: u16 },
+    /// Memory Mapped IO address range.
+    MmioAddressRange { base: u64, size: u64 },
+    /// Legacy IRQ number.
+    LegacyIrq(u32),
+    /// Message Signaled Interrupt
+    MsiIrq {
+        ty: MsiIrqType,
+        base: u32,
+        size: u32,
+    },
+    /// Network Interface Card MAC address.
+    MacAddress(String),
+    /// KVM memslot index.
+    KvmMemSlot(u32),
+}
+
 /// Trait meant for triggering the DMA mapping update related to an external
 /// device not managed fully through virtio. It is dedicated to virtio-iommu
 /// in order to trigger the map update anytime the mapping is updated from the

--- a/vm-device/src/lib.rs
+++ b/vm-device/src/lib.rs
@@ -10,7 +10,7 @@ use vm_memory::{
 };
 
 /// Type of Message Singaled Interrupt
-#[derive(Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum MsiIrqType {
     /// PCI MSI IRQ numbers.
     PciMsi,
@@ -22,7 +22,7 @@ pub enum MsiIrqType {
 
 /// Enumeration for device resources.
 #[allow(missing_docs)]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Resource {
     /// IO Port address range.
     PioAddressRange { base: u16, size: u16 },

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -47,3 +47,6 @@ tempfile = "3.1.0"
 [dependencies.linux-loader]
 git = "https://github.com/rust-vmm/linux-loader"
 features = ["elf", "bzimage"]
+
+[dev-dependencies]
+credibility = "0.1.3"

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -55,7 +55,10 @@ use vm_memory::guest_memory::FileOffset;
 use vm_memory::{
     Address, GuestAddress, GuestAddressSpace, GuestRegionMmap, GuestUsize, MmapRegion,
 };
-use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
+use vm_migration::{
+    Migratable, MigratableError, Pausable, Snapshot, SnapshotDataSection, Snapshottable,
+    Transportable,
+};
 #[cfg(feature = "pci_support")]
 use vm_virtio::transport::VirtioPciDevice;
 use vm_virtio::transport::VirtioTransport;
@@ -545,11 +548,17 @@ impl Drop for ActivatedBackend {
 }
 
 #[allow(unused)]
-#[derive(Default)]
+#[derive(Clone, Default, Serialize, Deserialize)]
 struct Node {
     resources: Vec<Resource>,
     parent: Option<String>,
     child: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct DeviceManagerState {
+    device_tree: HashMap<String, Node>,
+    device_id_cnt: Wrapping<usize>,
 }
 
 pub struct DeviceManager {
@@ -793,6 +802,20 @@ impl DeviceManager {
             .map_err(DeviceManagerError::BusError)?;
 
         Ok(device_manager)
+    }
+
+    fn state(&self) -> DeviceManagerState {
+        DeviceManagerState {
+            device_tree: self.device_tree.clone(),
+            device_id_cnt: self.device_id_cnt,
+        }
+    }
+
+    fn set_state(&mut self, state: &DeviceManagerState) -> DeviceManagerResult<()> {
+        self.device_tree = state.device_tree.clone();
+        self.device_id_cnt = state.device_id_cnt;
+
+        Ok(())
     }
 
     fn add_migratable_device(&mut self, migratable_device: Arc<Mutex<dyn Migratable>>) {
@@ -2792,16 +2815,43 @@ impl Snapshottable for DeviceManager {
     fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
         let mut snapshot = Snapshot::new(DEVICE_MANAGER_SNAPSHOT_ID);
 
-        // We aggregate all devices snapshot.
+        // We aggregate all devices snapshots.
         for (_, dev) in self.migratable_devices.iter() {
             let device_snapshot = dev.lock().unwrap().snapshot()?;
             snapshot.add_snapshot(device_snapshot);
         }
 
+        // Then we store the DeviceManager state.
+        snapshot.add_data_section(SnapshotDataSection {
+            id: format!("{}-section", DEVICE_MANAGER_SNAPSHOT_ID),
+            snapshot: serde_json::to_vec(&self.state())
+                .map_err(|e| MigratableError::Snapshot(e.into()))?,
+        });
+
         Ok(snapshot)
     }
 
     fn restore(&mut self, snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
+        // Let's first restore the DeviceManager.
+        if let Some(device_manager_section) = snapshot
+            .snapshot_data
+            .get(&format!("{}-section", DEVICE_MANAGER_SNAPSHOT_ID))
+        {
+            let device_manager_state = serde_json::from_slice(&device_manager_section.snapshot)
+                .map_err(|e| {
+                    MigratableError::Restore(anyhow!("Could not deserialize DeviceManager {}", e))
+                })?;
+
+            self.set_state(&device_manager_state).map_err(|e| {
+                MigratableError::Restore(anyhow!("Could not restore DeviceManager state {:?}", e))
+            })?;
+        } else {
+            return Err(MigratableError::Restore(anyhow!(
+                "Could not find DeviceManager snapshot section"
+            )));
+        }
+
+        // Then restore all devices associated with the DeviceManager.
         for (id, dev) in self.migratable_devices.iter() {
             debug!("Restoring {} from DeviceManager", id);
             if let Some(snapshot) = snapshot.snapshots.get(id) {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2855,7 +2855,12 @@ impl Snapshottable for DeviceManager {
             )));
         }
 
-        // Then restore all devices associated with the DeviceManager.
+        // Now that DeviceManager is updated with the right states, it's time
+        // to create the devices based on the configuration.
+        self.create_devices()
+            .map_err(|e| MigratableError::Restore(anyhow!("Could not create devices {:?}", e)))?;
+
+        // Finally, restore all devices associated with the DeviceManager.
         // It's important to restore devices in the right order, that's why
         // the device tree is the right way to ensure we restore a child before
         // its parent node.

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -563,7 +563,7 @@ impl Drop for ActivatedBackend {
 struct DeviceNode {
     resources: Vec<Resource>,
     parent: Option<String>,
-    child: Option<String>,
+    children: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -2138,7 +2138,7 @@ impl DeviceManager {
 
         // Add the new virtio-pci node to the device tree.
         let node = DeviceNode {
-            child: Some(virtio_device_id.clone()),
+            children: vec![virtio_device_id.clone()],
             ..Default::default()
         };
         self.device_tree.insert(id.clone(), node);
@@ -2286,7 +2286,7 @@ impl DeviceManager {
         } else {
             // Add the new virtio-mmio node to the device tree.
             let node = DeviceNode {
-                child: Some(virtio_device_id.clone()),
+                children: vec![virtio_device_id.clone()],
                 ..Default::default()
             };
             self.device_tree.insert(id.clone(), node);
@@ -3052,7 +3052,7 @@ impl Snapshottable for DeviceManager {
         // the device tree is the right way to ensure we restore a child before
         // its parent node.
         for (id, node) in self.device_tree.iter() {
-            if node.child.is_some() {
+            if !node.children.is_empty() {
                 continue;
             }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -581,6 +581,18 @@ impl DeviceNode {
     }
 }
 
+macro_rules! device_node {
+    ($id:ident) => {
+        DeviceNode::new($id.clone(), None)
+    };
+    ($id:ident, $device:ident) => {
+        DeviceNode::new(
+            $id.clone(),
+            Some(Arc::clone(&$device) as Arc<Mutex<dyn Migratable>>),
+        )
+    };
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 struct DeviceTree(HashMap<String, DeviceNode>);
 
@@ -953,13 +965,8 @@ impl DeviceManager {
                 // Fill the device tree with a new node. In case of restore, we
                 // know there is nothing to do, so we can simply override the
                 // existing entry.
-                self.device_tree.insert(
-                    iommu_id.clone(),
-                    DeviceNode::new(
-                        iommu_id.clone(),
-                        Some(Arc::clone(&device) as Arc<Mutex<dyn Migratable>>),
-                    ),
-                );
+                self.device_tree
+                    .insert(iommu_id.clone(), device_node!(iommu_id, device));
 
                 (Some(device), Some(mapping))
             } else {
@@ -1081,10 +1088,8 @@ impl DeviceManager {
         // Fill the device tree with a new node. In case of restore, we
         // know there is nothing to do, so we can simply override the
         // existing entry.
-        self.device_tree.insert(
-            id.clone(),
-            DeviceNode::new(id, Some(Arc::clone(&ioapic) as Arc<Mutex<dyn Migratable>>)),
-        );
+        self.device_tree
+            .insert(id.clone(), device_node!(id, ioapic));
 
         Ok(ioapic)
     }
@@ -1257,10 +1262,8 @@ impl DeviceManager {
             // Fill the device tree with a new node. In case of restore, we
             // know there is nothing to do, so we can simply override the
             // existing entry.
-            self.device_tree.insert(
-                id.clone(),
-                DeviceNode::new(id, Some(Arc::clone(&serial) as Arc<Mutex<dyn Migratable>>)),
-            );
+            self.device_tree
+                .insert(id.clone(), device_node!(id, serial));
 
             Some(serial)
         } else {
@@ -1295,13 +1298,8 @@ impl DeviceManager {
             // Fill the device tree with a new node. In case of restore, we
             // know there is nothing to do, so we can simply override the
             // existing entry.
-            self.device_tree.insert(
-                id.clone(),
-                DeviceNode::new(
-                    id,
-                    Some(Arc::clone(&virtio_console_device) as Arc<Mutex<dyn Migratable>>),
-                ),
-            );
+            self.device_tree
+                .insert(id.clone(), device_node!(id, virtio_console_device));
 
             Some(console_input)
         } else {
@@ -1402,13 +1400,8 @@ impl DeviceManager {
             // Fill the device tree with a new node. In case of restore, we
             // know there is nothing to do, so we can simply override the
             // existing entry.
-            self.device_tree.insert(
-                id.clone(),
-                DeviceNode::new(
-                    id.clone(),
-                    Some(Arc::clone(&vhost_user_block_device) as Arc<Mutex<dyn Migratable>>),
-                ),
-            );
+            self.device_tree
+                .insert(id.clone(), device_node!(id, vhost_user_block_device));
 
             Ok((
                 Arc::clone(&vhost_user_block_device) as VirtioDeviceArc,
@@ -1459,13 +1452,7 @@ impl DeviceManager {
                     // Fill the device tree with a new node. In case of restore, we
                     // know there is nothing to do, so we can simply override the
                     // existing entry.
-                    self.device_tree.insert(
-                        id.clone(),
-                        DeviceNode::new(
-                            id.clone(),
-                            Some(Arc::clone(&block) as Arc<Mutex<dyn Migratable>>),
-                        ),
-                    );
+                    self.device_tree.insert(id.clone(), device_node!(id, block));
 
                     Ok((Arc::clone(&block) as VirtioDeviceArc, disk_cfg.iommu, id))
                 }
@@ -1492,13 +1479,7 @@ impl DeviceManager {
                     // Fill the device tree with a new node. In case of restore, we
                     // know there is nothing to do, so we can simply override the
                     // existing entry.
-                    self.device_tree.insert(
-                        id.clone(),
-                        DeviceNode::new(
-                            id.clone(),
-                            Some(Arc::clone(&block) as Arc<Mutex<dyn Migratable>>),
-                        ),
-                    );
+                    self.device_tree.insert(id.clone(), device_node!(id, block));
 
                     Ok((Arc::clone(&block) as VirtioDeviceArc, disk_cfg.iommu, id))
                 }
@@ -1578,13 +1559,8 @@ impl DeviceManager {
             // Fill the device tree with a new node. In case of restore, we
             // know there is nothing to do, so we can simply override the
             // existing entry.
-            self.device_tree.insert(
-                id.clone(),
-                DeviceNode::new(
-                    id.clone(),
-                    Some(Arc::clone(&vhost_user_net_device) as Arc<Mutex<dyn Migratable>>),
-                ),
-            );
+            self.device_tree
+                .insert(id.clone(), device_node!(id, vhost_user_net_device));
 
             Ok((
                 Arc::clone(&vhost_user_net_device) as VirtioDeviceArc,
@@ -1625,13 +1601,8 @@ impl DeviceManager {
             // Fill the device tree with a new node. In case of restore, we
             // know there is nothing to do, so we can simply override the
             // existing entry.
-            self.device_tree.insert(
-                id.clone(),
-                DeviceNode::new(
-                    id.clone(),
-                    Some(Arc::clone(&virtio_net_device) as Arc<Mutex<dyn Migratable>>),
-                ),
-            );
+            self.device_tree
+                .insert(id.clone(), device_node!(id, virtio_net_device));
 
             Ok((
                 Arc::clone(&virtio_net_device) as VirtioDeviceArc,
@@ -1680,13 +1651,8 @@ impl DeviceManager {
             // Fill the device tree with a new node. In case of restore, we
             // know there is nothing to do, so we can simply override the
             // existing entry.
-            self.device_tree.insert(
-                id.clone(),
-                DeviceNode::new(
-                    id,
-                    Some(Arc::clone(&virtio_rng_device) as Arc<Mutex<dyn Migratable>>),
-                ),
-            );
+            self.device_tree
+                .insert(id.clone(), device_node!(id, virtio_rng_device));
         }
 
         Ok(devices)
@@ -1704,7 +1670,7 @@ impl DeviceManager {
             id
         };
 
-        let mut node = DeviceNode::new(id.clone(), None);
+        let mut node = device_node!(id);
 
         // Look for the id in the device tree. If it can be found, that means
         // the device is being restored, otherwise it's created from scratch.
@@ -1860,7 +1826,7 @@ impl DeviceManager {
             id
         };
 
-        let mut node = DeviceNode::new(id.clone(), None);
+        let mut node = device_node!(id);
 
         // Look for the id in the device tree. If it can be found, that means
         // the device is being restored, otherwise it's created from scratch.
@@ -2070,13 +2036,8 @@ impl DeviceManager {
         // Fill the device tree with a new node. In case of restore, we
         // know there is nothing to do, so we can simply override the
         // existing entry.
-        self.device_tree.insert(
-            id.clone(),
-            DeviceNode::new(
-                id.clone(),
-                Some(Arc::clone(&vsock_device) as Arc<Mutex<dyn Migratable>>),
-            ),
-        );
+        self.device_tree
+            .insert(id.clone(), device_node!(id, vsock_device));
 
         Ok((
             Arc::clone(&vsock_device) as VirtioDeviceArc,
@@ -2129,13 +2090,8 @@ impl DeviceManager {
             // Fill the device tree with a new node. In case of restore, we
             // know there is nothing to do, so we can simply override the
             // existing entry.
-            self.device_tree.insert(
-                id.clone(),
-                DeviceNode::new(
-                    id,
-                    Some(Arc::clone(&virtio_mem_device) as Arc<Mutex<dyn Migratable>>),
-                ),
-            );
+            self.device_tree
+                .insert(id.clone(), device_node!(id, virtio_mem_device));
         }
 
         Ok(devices)
@@ -2319,7 +2275,7 @@ impl DeviceManager {
         let id = format!("{}-{}", VIRTIO_PCI_DEVICE_NAME_PREFIX, virtio_device_id);
 
         // Add the new virtio-pci node to the device tree.
-        let mut node = DeviceNode::new(id.clone(), None);
+        let mut node = device_node!(id);
         node.children = vec![virtio_device_id.clone()];
 
         // Update the existing virtio node by setting the parent.
@@ -2431,7 +2387,7 @@ impl DeviceManager {
 
         // Create the new virtio-mmio node that will be added later to the
         // device tree.
-        let mut node = DeviceNode::new(id.clone(), None);
+        let mut node = device_node!(id);
         node.children = vec![virtio_device_id.clone()];
 
         // Look for the id in the device tree. If it can be found, that means

--- a/vmm/src/device_tree.rs
+++ b/vmm/src/device_tree.rs
@@ -1,0 +1,130 @@
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use vm_device::Resource;
+use vm_migration::Migratable;
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct DeviceNode {
+    pub id: String,
+    pub resources: Vec<Resource>,
+    pub parent: Option<String>,
+    pub children: Vec<String>,
+    #[serde(skip)]
+    pub migratable: Option<Arc<Mutex<dyn Migratable>>>,
+}
+
+impl DeviceNode {
+    pub fn new(id: String, migratable: Option<Arc<Mutex<dyn Migratable>>>) -> Self {
+        DeviceNode {
+            id,
+            resources: Vec::new(),
+            parent: None,
+            children: Vec::new(),
+            migratable,
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! device_node {
+    ($id:ident) => {
+        DeviceNode::new($id.clone(), None)
+    };
+    ($id:ident, $device:ident) => {
+        DeviceNode::new(
+            $id.clone(),
+            Some(Arc::clone(&$device) as Arc<Mutex<dyn Migratable>>),
+        )
+    };
+}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct DeviceTree(HashMap<String, DeviceNode>);
+
+impl DeviceTree {
+    pub fn new() -> Self {
+        DeviceTree(HashMap::new())
+    }
+    pub fn get(&self, k: &str) -> Option<&DeviceNode> {
+        self.0.get(k)
+    }
+    pub fn get_mut(&mut self, k: &str) -> Option<&mut DeviceNode> {
+        self.0.get_mut(k)
+    }
+    pub fn insert(&mut self, k: String, v: DeviceNode) -> Option<DeviceNode> {
+        self.0.insert(k, v)
+    }
+    #[cfg(feature = "pci_support")]
+    pub fn remove(&mut self, k: &str) -> Option<DeviceNode> {
+        self.0.remove(k)
+    }
+    pub fn iter(&self) -> std::collections::hash_map::Iter<String, DeviceNode> {
+        self.0.iter()
+    }
+    pub fn breadth_first_traversal(&self) -> BftIter {
+        BftIter::new(&self.0)
+    }
+}
+
+// Breadth first traversal iterator.
+pub struct BftIter<'a> {
+    nodes: Vec<&'a DeviceNode>,
+}
+
+impl<'a> BftIter<'a> {
+    fn new(hash_map: &'a HashMap<String, DeviceNode>) -> Self {
+        let mut nodes = Vec::new();
+
+        for (_, node) in hash_map.iter() {
+            if node.parent.is_none() {
+                nodes.push(node);
+            }
+        }
+
+        let mut node_layer = nodes.as_slice();
+        loop {
+            let mut next_node_layer = Vec::new();
+
+            for node in node_layer.iter() {
+                for child_node_id in node.children.iter() {
+                    if let Some(child_node) = hash_map.get(child_node_id) {
+                        next_node_layer.push(child_node);
+                    }
+                }
+            }
+
+            if next_node_layer.is_empty() {
+                break;
+            }
+
+            let pos = nodes.len();
+            nodes.extend(next_node_layer);
+
+            node_layer = &nodes[pos..];
+        }
+
+        BftIter { nodes }
+    }
+}
+
+impl<'a> Iterator for BftIter<'a> {
+    type Item = &'a DeviceNode;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.nodes.is_empty() {
+            None
+        } else {
+            Some(self.nodes.remove(0))
+        }
+    }
+}
+
+impl<'a> DoubleEndedIterator for BftIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.nodes.pop()
+    }
+}

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -16,6 +16,9 @@ extern crate serde_json;
 extern crate tempfile;
 extern crate url;
 extern crate vmm_sys_util;
+#[cfg(test)]
+#[macro_use]
+extern crate credibility;
 
 use crate::api::{ApiError, ApiRequest, ApiResponse, ApiResponsePayload, VmInfo, VmmPingResponse};
 use crate::config::{

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -39,6 +39,7 @@ pub mod api;
 pub mod config;
 pub mod cpu;
 pub mod device_manager;
+pub mod device_tree;
 pub mod interrupt;
 pub mod memory_manager;
 pub mod migration;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -334,6 +334,12 @@ impl Vm {
         )
         .map_err(Error::DeviceManager)?;
 
+        device_manager
+            .lock()
+            .unwrap()
+            .create_devices()
+            .map_err(Error::DeviceManager)?;
+
         let cpu_manager = cpu::CpuManager::new(
             &config.lock().unwrap().cpus.clone(),
             &device_manager,


### PR DESCRIPTION
By introducing some refactoring of the `DeviceManager`, and by adding a device tree to the DeviceManager, this pull request managed to improve the snapshot/restore mechanism to make it foolproof.
The device tree contains each device along with its resources. Based on these resources, the DeviceManager can restore each device exactly where it was located before the snapshot.

The pull request only takes care of the virtio devices and the virtio-mmio transport layer, a follow up PR will be needed to handle everything related to PCI.