### PR TITLE
vmm, vhost_user_block: Make parameter names match --disk

### DIFF
--- a/src/bin/vhost_user_blk.rs
+++ b/src/bin/vhost_user_blk.rs
@@ -25,7 +25,7 @@ fn main() {
                 .long("block-backend")
                 .help(
                     "vhost-user-block backend parameters \
-                     \"image=<image_path>,sock=<socket_path>,num_queues=<number_of_queues>,\
+                     \"path=<image_path>,socket=<socket_path>,num_queues=<number_of_queues>,\
                      readonly=true|false,direct=true|false,poll_queue=true|false\"",
                 )
                 .takes_value(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,7 +249,7 @@ fn create_app<'a, 'b>(
                 .long("block-backend")
                 .help(
                     "vhost-user-block backend parameters \
-                     \"image=<image_path>,sock=<socket_path>,num_queues=<number_of_queues>,\
+                     \"path=<image_path>,socket=<socket_path>,num_queues=<number_of_queues>,\
                      readonly=true|false,direct=true|false,poll_queue=true|false\"",
                 )
                 .takes_value(true)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -398,7 +398,7 @@ mod tests {
             .args(&[
                 "--block-backend",
                 format!(
-                    "image={},sock={},num_queues={},readonly={},direct={}",
+                    "path={},socket={},num_queues={},readonly={},direct={}",
                     blk_file_path, vubd_socket_path, num_queues, rdonly, direct
                 )
                 .as_str(),

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -387,10 +387,10 @@ impl<'a> VhostUserBlkBackendConfig<'a> {
         let mut poll_queue: bool = true;
 
         for param in params_list.iter() {
-            if param.starts_with("image=") {
-                image = &param[6..];
-            } else if param.starts_with("sock=") {
-                sock = &param[5..];
+            if param.starts_with("path=") {
+                image = &param[5..];
+            } else if param.starts_with("socket=") {
+                sock = &param[7..];
             } else if param.starts_with("num_queues=") {
                 num_queues_str = &param[11..];
             } else if param.starts_with("readonly=") {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1167,7 +1167,7 @@ impl DeviceManager {
             .args(&[
                 "--block-backend",
                 &format!(
-                    "image={},sock={},num_queues={},queue_size={}",
+                    "path={},socket={},num_queues={},queue_size={}",
                     disk_cfg
                         .path
                         .as_ref()


### PR DESCRIPTION
Make the --block-backend parameters match the --disk parameters.

Fixes: #898

Signed-off-by: Rob Bradford <robert.bradford@intel.com>