### PR TITLE
tests: Add tests that use (non-existing) named tap

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1306,6 +1306,15 @@ mod tests {
                 .unwrap();
 
             thread::sleep(std::time::Duration::new(20, 0));
+
+            if let Some(tap_name) = tap {
+                let tap_count = std::process::Command::new("bash")
+                    .arg("-c")
+                    .arg(format!("ip link | grep -c {}", tap_name))
+                    .output()
+                    .expect("Expected checking of tap count to succeed");
+                aver_eq!(tb, String::from_utf8_lossy(&tap_count.stdout).trim(), "1");
+            }
             // 1 network interface + default localhost ==> 2 interfaces
             // It's important to note that this test is fully exercising the
             // vhost-user-net implementation and the associated backend since

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1386,7 +1386,17 @@ mod tests {
     }
 
     #[test]
-    fn test_vhost_user_net_tap() {
+    fn test_vhost_user_net_named_tap() {
+        test_vhost_user_net(
+            Some("mytap0"),
+            2,
+            Some(&prepare_vhost_user_net_daemon),
+            false,
+        )
+    }
+
+    #[test]
+    fn test_vhost_user_net_existing_tap() {
         test_vhost_user_net(
             Some("vunet-tap0"),
             2,
@@ -2176,7 +2186,7 @@ mod tests {
                     "--net",
                     guest.default_net_string().as_str(),
                     "tap=,mac=8a:6b:6f:5a:de:ac,ip=192.168.3.1,mask=255.255.255.0",
-                    "tap=,mac=fe:1f:9e:e1:60:f2,ip=192.168.4.1,mask=255.255.255.0",
+                    "tap=mytap1,mac=fe:1f:9e:e1:60:f2,ip=192.168.4.1,mask=255.255.255.0",
                 ])
                 .spawn()
                 .unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2202,6 +2202,13 @@ mod tests {
 
             thread::sleep(std::time::Duration::new(20, 0));
 
+            let tap_count = std::process::Command::new("bash")
+                .arg("-c")
+                .arg("ip link | grep -c mytap1")
+                .output()
+                .expect("Expected checking of tap count to succeed");
+            aver_eq!(tb, String::from_utf8_lossy(&tap_count.stdout).trim(), "1");
+
             // 3 network interfaces + default localhost ==> 4 interfaces
             aver_eq!(
                 tb,


### PR DESCRIPTION
The current tests support giving a tap name but they only test with tap
interfaces that already exist.

Fixes: #871

Signed-off-by: Rob Bradford <robert.bradford@intel.com>