### PR TITLE
Support rebooting with virtio-vsock

### DIFF
--- a/vm-virtio/src/vsock/mod.rs
+++ b/vm-virtio/src/vsock/mod.rs
@@ -166,6 +166,7 @@ mod tests {
     use crate::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
     use libc::EFD_NONBLOCK;
     use std::os::unix::io::AsRawFd;
+    use std::path::PathBuf;
     use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, RwLock};
     use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
@@ -265,7 +266,14 @@ mod tests {
                 cid: CID,
                 mem: GuestMemoryMmap::from_ranges(&[(GuestAddress(0), MEM_SIZE)]).unwrap(),
                 mem_size: MEM_SIZE,
-                device: Vsock::new(String::from("vsock"), CID, TestBackend::new(), false).unwrap(),
+                device: Vsock::new(
+                    String::from("vsock"),
+                    CID,
+                    PathBuf::from("/test/sock"),
+                    TestBackend::new(),
+                    false,
+                )
+                .unwrap(),
             }
         }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1714,8 +1714,14 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::CreateVsockBackend)?;
 
         let vsock_device = Arc::new(Mutex::new(
-            vm_virtio::Vsock::new(id.clone(), vsock_cfg.cid, backend, vsock_cfg.iommu)
-                .map_err(DeviceManagerError::CreateVirtioVsock)?,
+            vm_virtio::Vsock::new(
+                id.clone(),
+                vsock_cfg.cid,
+                vsock_cfg.sock.clone(),
+                backend,
+                vsock_cfg.iommu,
+            )
+            .map_err(DeviceManagerError::CreateVirtioVsock)?,
         ));
 
         self.add_migratable_device(Arc::clone(&vsock_device) as Arc<Mutex<dyn Migratable>>);


### PR DESCRIPTION
Delete the unix socket on shutdown (we can't relisten on existing files) and add integration test to check the reboot functionality.

Fixes: #1083 