### PR TITLE
tests: Stabilise overhead value by requesting multiple times

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3736,8 +3736,11 @@ mod tests {
             let mut workload_path = dirs::home_dir().unwrap();
             workload_path.push("workloads");
 
-            let mut kernel_path = workload_path;
+            let mut kernel_path = workload_path.clone();
             kernel_path.push("vmlinux");
+
+            let mut initramfs_path = workload_path;
+            initramfs_path.push("alpine_initramfs.img");
 
             let guest_memory_size_kb = 512 * 1024;
 
@@ -3748,9 +3751,8 @@ mod tests {
                     format!("size={}K", guest_memory_size_kb).as_str(),
                 ])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .default_disks()
-                .default_net()
-                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
+                .args(&["--initramfs", initramfs_path.to_str().unwrap()])
+                .args(&["--cmdline", "console=hvc0"])
                 .spawn()
                 .unwrap();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3756,11 +3756,21 @@ mod tests {
 
             thread::sleep(std::time::Duration::new(20, 0));
 
-            let overhead = get_vmm_overhead(child.id(), guest_memory_size_kb);
-            eprintln!(
-                "Guest memory overhead: {} vs {}",
-                overhead, MAXIMUM_VMM_OVERHEAD_KB
-            );
+            let mut last_overhead = None;
+            let mut overhead = get_vmm_overhead(child.id(), guest_memory_size_kb);
+            let mut counter = 10;
+            while last_overhead != Some(overhead) {
+                eprintln!(
+                    "Guest memory overhead: {} vs {}",
+                    overhead, MAXIMUM_VMM_OVERHEAD_KB
+                );
+                thread::sleep(std::time::Duration::new(20, 0));
+                last_overhead = Some(overhead);
+                overhead = get_vmm_overhead(child.id(), guest_memory_size_kb);
+                counter -= 1;
+
+                aver!(tb, counter > 0);
+            }
             aver!(tb, overhead <= MAXIMUM_VMM_OVERHEAD_KB);
 
             let _ = child.kill();


### PR DESCRIPTION
Try and stabilise the the overhead value that we get by sampling
multiple times.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>