### PR TITLE
Shutdown all threads if VM is paused

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -873,6 +873,13 @@ impl CpuManager {
                         while vcpu_pause_signalled.load(Ordering::SeqCst) {
                             thread::park();
                         }
+
+                        // We've been told to terminate
+                        if vcpu_kill_signalled.load(Ordering::SeqCst)
+                            || vcpu_kill.load(Ordering::SeqCst)
+                        {
+                            break;
+                        }
                     }
                 })
                 .map_err(Error::VcpuSpawn)?,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -608,6 +608,13 @@ impl Vm {
             signals.close();
         }
 
+        // Wake up the DeviceManager threads so they will get terminated cleanly
+        self.device_manager
+            .lock()
+            .unwrap()
+            .resume()
+            .map_err(Error::Resume)?;
+
         self.cpu_manager
             .lock()
             .unwrap()


### PR DESCRIPTION
The initial solution to this problem had the right idea by resuming the vCPU and device threads upon a shutdown from a paused state. However this unfortunately has the effect of making the vCPU threads start running again which is not desirable.

Instead this version modifies the vCPU shutdown to process so that the kill state is set, pause state cleared and then the thread is unparked if necessarily with the kill state being checked immediately after the thread is resumed.

For the device threads we call `resume()` on the DeviceManager and allow those threads to cleanly terminate as part of the `drop()` driven approach.

Fixes: #816