### PR TITLE
build: Strip the binaries before using/releasing them

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,8 @@ jobs:
         run: cargo build --release --target=x86_64-unknown-linux-gnu
       - name: Static Build
         run: cargo build --release --target=x86_64-unknown-linux-musl
+      - name: Strip cloud-hypervisor binaries
+        run: strip target/*/release/cloud-hypervisor
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -211,6 +211,10 @@ sudo ip tuntap add name vunet-tap0 mode tap
 sudo ip tuntap add name vunet-tap1 mode tap multi_queue
 
 cargo build --release --target $BUILD_TARGET
+strip target/$BUILD_TARGET/release/cloud-hypervisor
+strip target/$BUILD_TARGET/release/vhost_user_net
+strip target/$BUILD_TARGET/release/ch-remote
+
 sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/cloud-hypervisor
 sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/vhost_user_net
 
@@ -242,6 +246,10 @@ RES=$?
 if [ $RES -eq 0 ]; then
     # virtio-mmio based testing
     cargo build --release --target $BUILD_TARGET --no-default-features --features "mmio"
+    strip target/$BUILD_TARGET/release/cloud-hypervisor
+    strip target/$BUILD_TARGET/release/vhost_user_net
+    strip target/$BUILD_TARGET/release/ch-remote
+
     sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/cloud-hypervisor
 
     # Ensure test binary has the same caps as the cloud-hypervisor one


### PR DESCRIPTION
Stripping the release build for glibc shrinks the size considerably:

$ du -h target/release/cloud-hypervisor
8.5M    target/release/cloud-hypervisor
$ strip target/release/cloud-hypervisor
$ du -h target/release/cloud-hypervisor
5.2M    target/release/cloud-hypervisor

Signed-off-by: Rob Bradford <robert.bradford@intel.com>