### PR TITLE
ch-remote: Add usage to app

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -397,6 +397,7 @@ fn main() {
         .author(crate_authors!())
         .setting(AppSettings::SubcommandRequired)
         .about("Remotely control a cloud-hypervisor VMM.")
+        .usage("ch-remote --api-socket=<api-socket> <SUBCOMMAND>")
         .arg(
             Arg::with_name("api-socket")
                 .long("api-socket")


### PR DESCRIPTION
Current usage of ch-remote is
"ch-remote --api-socket <api-socket> <SUBCOMMAND>".
It is not right.
It should be
"ch-remote --api-socket=<api-socket> <SUBCOMMAND>".

The wrong usage is generated by clap::App.

Add right usage to app.

Fixes: #1117

Signed-off-by: Hui Zhu <teawater@antfin.com>