### PR TITLE
vm-virtio: Correctly reset the virtqueues

### DIFF
--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -477,6 +477,8 @@ impl Queue {
     pub fn reset(&mut self) {
         self.ready = false;
         self.size = self.max_size;
+        self.next_avail = Wrapping(0);
+        self.next_used = Wrapping(0);
     }
 
     pub fn is_valid(&self, mem: &GuestMemoryMmap) -> bool {


### PR DESCRIPTION
Upon a virtio reset, the driver expects that available and used indexes
will be reset to 0. That's why we need to reset these values from the
VMM for any virtio device that might get reset.

This issue was not detected before because the Vec<Queue> maintained
through VirtioPciDevice or MmioDevice was never updated from the virtio
device thread after the device had been actived. For this reason, upon
reset, both available and used indexes were already at the value 0.

The issue arose when trying to reset a device after the VM was restored.
That's because during the restore, each queue is assigned with the right
available and used indexes before it is passed to the device through the
activate function. And that's why upon reset, each queue was still
assigned with these indexes while it should have been reset to 0.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>