### PR TITLE
Implement snapshot/restore for virtio-pci

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,13 +667,18 @@ dependencies = [
 name = "pci"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "byteorder",
  "devices",
  "libc",
  "log 0.4.8",
+ "serde",
+ "serde_derive",
+ "serde_json",
  "vm-allocator",
  "vm-device",
  "vm-memory",
+ "vm-migration",
 ]
 
 [[package]]

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -5,10 +5,15 @@ authors = ["Samuel Ortiz <sameo@linux.intel.com>"]
 edition = "2018"
 
 [dependencies]
-vm-allocator = { path = "../vm-allocator" }
+anyhow = "1.0"
 byteorder = "1.3.4"
 devices = { path = "../devices" }
 libc = "0.2.69"
 log = "0.4.8"
+serde = {version = ">=1.0.27", features = ["rc"] }
+serde_derive = ">=1.0.27"
+serde_json = ">=1.0.9"
+vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = "0.2.0"
+vm-migration = { path = "../vm-migration" }

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -6,6 +6,10 @@
 #[macro_use]
 extern crate log;
 extern crate devices;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
 extern crate vm_memory;
 
 mod bus;


### PR DESCRIPTION
This pull request enables snapshot/restore support for virtio-pci transport layer. With this code, Cloud-Hypervisor can now restore a VM with virtio-pci devices attached to it.

This takes care of updating MSI-X vectors so that they are enabled the way they were right before the snapshot has been taken.

One missing part is the `DeviceManager` implementation to make sure these virtio-pci devices are assigned with the same PCI resources compared to the source VM they have been snapshotted from. This will come as a follow up pull request.