### PR TITLE
Enable AArch64

### DIFF
--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -56,8 +56,8 @@ pub const LEGACY_RTC_MAPPED_IO_START: u64 = 0x0901_0000;
 pub const LEGACY_DEVICES_MAPPED_IO_SIZE: u64 = 0x0700_0000;
 
 /// Starting from 0x1000_0000 (256MiB), the 768MiB (ends at 1 GiB) is used for PCIE MMIO
-pub const PCI_DEVICES_MAPPED_IO_START: u64 = 0x1000_0000;
-pub const PCI_DEVICES_MAPPED_IO_SIZE: u64 = 0x3000_0000;
+pub const MEM_32BIT_DEVICES_START: GuestAddress = GuestAddress(0x1000_0000);
+pub const MEM_32BIT_DEVICES_SIZE: u64 = 0x3000_0000;
 
 /// PCI MMCONFIG space (start: after the device space at 1 GiB, length: 256MiB)
 pub const PCI_MMCONFIG_START: GuestAddress = GuestAddress(0x4000_0000);

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -63,14 +63,14 @@ pub fn arch_memory_regions(size: GuestUsize) -> Vec<(GuestAddress, usize, Region
     // 0 ~ 256 MiB: Reserved
     regions.push((
         GuestAddress(0),
-        layout::PCI_DEVICES_MAPPED_IO_START as usize,
+        layout::MEM_32BIT_DEVICES_START.0 as usize,
         RegionType::Reserved,
     ));
 
     // 256 MiB ~ 1 G: MMIO space
     regions.push((
-        GuestAddress(layout::PCI_DEVICES_MAPPED_IO_START),
-        layout::PCI_DEVICES_MAPPED_IO_SIZE as usize,
+        layout::MEM_32BIT_DEVICES_START,
+        layout::MEM_32BIT_DEVICES_SIZE as usize,
         RegionType::SubRegion,
     ));
 

--- a/docs/arm64.md
+++ b/docs/arm64.md
@@ -1,0 +1,64 @@
+# How to build and run Cloud-hypervisor on Arm64
+
+Cloud-hypervisor is partially enabled on AArch64 architecture.
+Although all features are not ready yet, you can begin to test Cloud-hypervisor on a Arm64 host by following this guide.
+
+## Prerequisites
+
+On Arm64 machines, Cloud-hypervisor depends on an external library `libfdt-dev` for generating Flatted Device Tree (FDT).
+
+The long-term plan is to replace `libfdt-dev` with some pure-Rust component to get rid of such dependency.
+
+```bash
+sudo apt-get update
+sudo apt-get install libfdt-dev
+```
+
+## Build
+
+Before building, a hack trick need to be performed to get rid of some build error in vmm component. See [this](https://github.com/cloud-hypervisor/kvm-bindings/pull/1) for more info about this temporary workaround.
+
+```bash
+sed -i 's/"with-serde",\ //g' vmm/Cargo.toml
+```
+
+The support of AArch64 is in very early stage, only Virtio devices with MMIO tranport is available.
+
+```bash
+cargo build --no-default-features --features "mmio"
+```
+
+## Image
+
+Download kernel binary and rootfs image from AWS.
+
+```bash
+wget https://s3.amazonaws.com/spec.ccfc.min/img/aarch64/ubuntu_with_ssh/fsfiles/xenial.rootfs.ext4 -O rootfs.img
+wget https://s3.amazonaws.com/spec.ccfc.min/img/aarch64/ubuntu_with_ssh/kernel/vmlinux.bin -O kernel.bin
+```
+
+## Containerized build
+
+If you want to build and test Cloud Hypervisor without having to install all the required dependencies, you can also turn to the development script: dev_cli.sh.
+
+To build the development container:
+
+```bash
+./scripts/dev_cli.sh build-container
+```
+
+To build Cloud-hypervisor in the container:
+
+```bash
+./scripts/dev_cli.sh build
+```
+
+## Run
+
+Assuming you have built Cloud-hypervisor with the development container, a VM can be started with command:
+
+```bash
+sudo target/debug/cloud-hypervisor --kernel kernel.bin --disk path=rootfs.ext4 --cmdline "keep_bootcon console=hvc0 reboot=k panic=1 pci=off root=/dev/vda rw" --cpus boot=4 --memory size=512M --seccomp false --serial file=serial.log --log-file log.log -vvv
+```
+
+If the build was done out of the container, replace the binary path with `build/cargo_target/aarch64-unknown-linux-gnu/debug/cloud-hypervisor`.

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -208,6 +208,11 @@ cmd_build() {
         rustflags="-C link-arg=-lgcc"
     fi
 
+    # A workaround on Arm64 to avoid build errors in kvm-bindings
+    if [ $(uname -m) = "aarch64" ]; then
+        sed -i 's/"with-serde",\ //g' "$CLH_ROOT_DIR"/vmm/Cargo.toml
+    fi
+
     $DOCKER_RUNTIME run \
 	   --user "$(id -u):$(id -g)" \
 	   --workdir "$CTR_CLH_ROOT_DIR" \

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 libc = "0.2.71"
 vm-memory = "0.2.1"
+arch = { path = "../arch" }

--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+#[cfg(target_arch = "aarch64")]
+use arch;
+#[cfg(target_arch = "x86_64")]
 use std::collections::btree_map::BTreeMap;
 use std::result;
 
@@ -13,12 +16,14 @@ pub enum Error {
 pub type Result<T> = result::Result<T, Error>;
 
 /// GsiApic
+#[cfg(target_arch = "x86_64")]
 #[derive(Copy, Clone)]
 pub struct GsiApic {
     base: u32,
     irqs: u32,
 }
 
+#[cfg(target_arch = "x86_64")]
 impl GsiApic {
     /// New GSI APIC
     pub fn new(base: u32, irqs: u32) -> Self {
@@ -28,12 +33,14 @@ impl GsiApic {
 
 /// GsiAllocator
 pub struct GsiAllocator {
+    #[cfg(target_arch = "x86_64")]
     apics: BTreeMap<u32, u32>,
     next_irq: u32,
     next_gsi: u32,
 }
 
 impl GsiAllocator {
+    #[cfg(target_arch = "x86_64")]
     /// New GSI allocator
     pub fn new(apics: Vec<GsiApic>) -> Self {
         let mut allocator = GsiAllocator {
@@ -57,13 +64,23 @@ impl GsiAllocator {
         allocator
     }
 
-    /// Allocate a GSI
-    pub fn allocate_gsi(&mut self) -> Result<u32> {
-        self.next_gsi = self.next_gsi.checked_add(1).ok_or(Error::Overflow)?;
-
-        Ok(self.next_gsi - 1)
+    #[cfg(target_arch = "aarch64")]
+    /// New GSI allocator
+    pub fn new() -> Self {
+        GsiAllocator {
+            next_irq: arch::IRQ_BASE,
+            next_gsi: arch::IRQ_BASE,
+        }
     }
 
+    /// Allocate a GSI
+    pub fn allocate_gsi(&mut self) -> Result<u32> {
+        let gsi = self.next_gsi;
+        self.next_gsi = self.next_gsi.checked_add(1).ok_or(Error::Overflow)?;
+        Ok(gsi)
+    }
+
+    #[cfg(target_arch = "x86_64")]
     /// Allocate an IRQ
     pub fn allocate_irq(&mut self) -> Result<u32> {
         let mut irq: u32 = 0;
@@ -79,6 +96,14 @@ impl GsiAllocator {
             return Err(Error::Overflow);
         }
 
+        Ok(irq)
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    /// Allocate an IRQ
+    pub fn allocate_irq(&mut self) -> Result<u32> {
+        let irq = self.next_irq;
+        self.next_irq = self.next_irq.checked_add(1).ok_or(Error::Overflow)?;
         Ok(irq)
     }
 }

--- a/vm-allocator/src/lib.rs
+++ b/vm-allocator/src/lib.rs
@@ -18,5 +18,7 @@ mod gsi;
 mod system;
 
 pub use crate::address::AddressAllocator;
-pub use crate::gsi::{GsiAllocator, GsiApic};
+pub use crate::gsi::GsiAllocator;
+#[cfg(target_arch = "x86_64")]
+pub use crate::gsi::GsiApic;
 pub use crate::system::SystemAllocator;

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -41,6 +41,7 @@ fn pagesize() -> usize {
 ///
 /// ```
 pub struct SystemAllocator {
+    #[cfg(target_arch = "x86_64")]
     io_address_space: AddressAllocator,
     mmio_address_space: AddressAllocator,
     mmio_hole_address_space: AddressAllocator,
@@ -51,8 +52,8 @@ impl SystemAllocator {
     /// Creates a new `SystemAllocator` for managing addresses and irq numvers.
     /// Can return `None` if `base` + `size` overflows a u64
     ///
-    /// * `io_base` - The starting address of IO memory.
-    /// * `io_size` - The size of IO memory.
+    /// * `io_base` - (X86) The starting address of IO memory.
+    /// * `io_size` - (X86) The size of IO memory.
     /// * `mmio_base` - The starting address of MMIO memory.
     /// * `mmio_size` - The size of MMIO memory.
     /// * `mmio_hole_base` - The starting address of MMIO memory in 32-bit address space.
@@ -60,8 +61,8 @@ impl SystemAllocator {
     /// * `apics` - (X86) Vector of APIC's.
     ///
     pub fn new(
-        io_base: GuestAddress,
-        io_size: GuestUsize,
+        #[cfg(target_arch = "x86_64")] io_base: GuestAddress,
+        #[cfg(target_arch = "x86_64")] io_size: GuestUsize,
         mmio_base: GuestAddress,
         mmio_size: GuestUsize,
         mmio_hole_base: GuestAddress,
@@ -69,6 +70,7 @@ impl SystemAllocator {
         #[cfg(target_arch = "x86_64")] apics: Vec<GsiApic>,
     ) -> Option<Self> {
         Some(SystemAllocator {
+            #[cfg(target_arch = "x86_64")]
             io_address_space: AddressAllocator::new(io_base, io_size)?,
             mmio_address_space: AddressAllocator::new(mmio_base, mmio_size)?,
             mmio_hole_address_space: AddressAllocator::new(mmio_hole_base, mmio_hole_size)?,
@@ -89,6 +91,7 @@ impl SystemAllocator {
         self.gsi_allocator.allocate_gsi().ok()
     }
 
+    #[cfg(target_arch = "x86_64")]
     /// Reserves a section of `size` bytes of IO address space.
     pub fn allocate_io_addresses(
         &mut self,
@@ -128,6 +131,7 @@ impl SystemAllocator {
         )
     }
 
+    #[cfg(target_arch = "x86_64")]
     /// Free an IO address range.
     /// We can only free a range if it matches exactly an already allocated range.
     pub fn free_io_addresses(&mut self, address: GuestAddress, size: GuestUsize) {

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -46,7 +46,7 @@ tempfile = "3.1.0"
 
 [dependencies.linux-loader]
 git = "https://github.com/rust-vmm/linux-loader"
-features = ["elf", "bzimage"]
+features = ["elf", "bzimage", "pe"]
 
 [dev-dependencies]
 credibility = "0.1.3"

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1000,13 +1000,13 @@ impl CpuManager {
     }
 
     #[cfg(target_arch = "aarch64")]
-    pub fn get_mpidr(&self) -> Vec<u64> {
-        let vcpu_mpidr = self
+    pub fn get_mpidrs(&self) -> Vec<u64> {
+        let vcpu_mpidrs = self
             .vcpus
             .iter()
             .map(|cpu| cpu.lock().unwrap().get_mpidr())
             .collect();
-        vcpu_mpidr
+        vcpu_mpidrs
     }
 
     #[cfg(feature = "acpi")]

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -37,7 +37,9 @@ use std::os::unix::thread::JoinHandleExt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use std::{cmp, io, result, thread};
-use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
+#[cfg(target_arch = "x86_64")]
+use vm_memory::GuestAddress;
+use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, SnapshotDataSection, Snapshottable,
     Transportable,
@@ -675,6 +677,7 @@ impl CpuManager {
             vcpus: Vec::with_capacity(usize::from(config.max_vcpus)),
         }));
 
+        #[cfg(target_arch = "x86_64")]
         device_manager
             .allocator()
             .lock()

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -230,7 +230,7 @@ struct InterruptSourceOverride {
 pub struct Vcpu {
     fd: VcpuFd,
     id: u8,
-    #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
+    #[cfg(target_arch = "x86_64")]
     io_bus: Arc<devices::Bus>,
     mmio_bus: Arc<devices::Bus>,
     #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
@@ -267,7 +267,7 @@ impl Vcpu {
     pub fn new(
         id: u8,
         fd: &Arc<VmFd>,
-        io_bus: Arc<devices::Bus>,
+        #[cfg(target_arch = "x86_64")] io_bus: Arc<devices::Bus>,
         mmio_bus: Arc<devices::Bus>,
         interrupt_controller: Option<Arc<Mutex<dyn InterruptController>>>,
         creation_ts: std::time::Instant,
@@ -277,6 +277,7 @@ impl Vcpu {
         Ok(Arc::new(Mutex::new(Vcpu {
             fd: kvm_vcpu,
             id,
+            #[cfg(target_arch = "x86_64")]
             io_bus,
             mmio_bus,
             interrupt_controller,
@@ -504,6 +505,7 @@ impl Snapshottable for Vcpu {
 pub struct CpuManager {
     boot_vcpus: u8,
     max_vcpus: u8,
+    #[cfg(target_arch = "x86_64")]
     io_bus: Arc<devices::Bus>,
     #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     mmio_bus: Arc<devices::Bus>,
@@ -657,6 +659,7 @@ impl CpuManager {
         let cpu_manager = Arc::new(Mutex::new(CpuManager {
             boot_vcpus: config.boot_vcpus,
             max_vcpus: config.max_vcpus,
+            #[cfg(target_arch = "x86_64")]
             io_bus: device_manager.io_bus().clone(),
             mmio_bus: device_manager.mmio_bus().clone(),
             interrupt_controller: device_manager.interrupt_controller().clone(),
@@ -679,6 +682,7 @@ impl CpuManager {
             .allocate_io_addresses(Some(GuestAddress(0x0cd8)), 0x8, None)
             .ok_or(Error::AllocateIOPort)?;
 
+        #[cfg(target_arch = "x86_64")]
         cpu_manager
             .lock()
             .unwrap()
@@ -742,6 +746,7 @@ impl CpuManager {
         let vcpu = Vcpu::new(
             cpu_id,
             &self.fd,
+            #[cfg(target_arch = "x86_64")]
             self.io_bus.clone(),
             self.mmio_bus.clone(),
             interrupt_controller,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1092,6 +1092,14 @@ impl DeviceManager {
         Ok(interrupt_controller)
     }
 
+    #[cfg(target_arch = "aarch64")]
+    pub fn enable_interrupt_controller(&self) -> DeviceManagerResult<()> {
+        if let Some(interrupt_controller) = &self.interrupt_controller {
+            interrupt_controller.lock().unwrap().enable().unwrap();
+        }
+        Ok(())
+    }
+
     #[cfg(target_arch = "x86_64")]
     fn add_interrupt_controller(
         &mut self,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -365,7 +365,8 @@ impl Vmm {
         #[cfg(not(feature = "acpi"))]
         {
             if self.vm.is_some() {
-                return self.vm_shutdown();
+                self.exit_evt.write(1).unwrap();
+                return Ok(());
             }
         }
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -56,7 +56,7 @@ pub struct MemoryManager {
     next_kvm_memory_slot: u32,
     start_of_device_area: GuestAddress,
     end_of_device_area: GuestAddress,
-    fd: Arc<VmFd>,
+    pub fd: Arc<VmFd>,
     hotplug_slots: Vec<HotPlugState>,
     selected_slot: usize,
     backing_file: Option<PathBuf>,

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -302,8 +302,10 @@ impl MemoryManager {
         // Both MMIO and PIO address spaces start at address 0.
         let allocator = Arc::new(Mutex::new(
             SystemAllocator::new(
+                #[cfg(target_arch = "x86_64")]
                 GuestAddress(0),
-                1 << 16 as GuestUsize,
+                #[cfg(target_arch = "x86_64")]
+                (1 << 16 as GuestUsize),
                 GuestAddress(0),
                 mmio_address_space_size(),
                 layout::MEM_32BIT_DEVICES_START,


### PR DESCRIPTION
This pull request contains the code to enable the basic functionalities of Cloud-hypervisor on AArch64.

Summary of the major changes:
- Enabled vm-allocator, device manager, memory manager and vcpu manager for AArch64.
- Enabled Virtio devices with MMIO transport option.
- Configured VM: load kernel, setup GIC setup and generate FDT.
- Exit VMM when guest shutdown on AArch64.
- Added a guide for testing on Arm64.

What was tested:
- Booting a VM (Ubuntu 18.04) with up to 4 VCPUs.
- Booting a VM with up to 256 GiB memory.
- Serial I/O.
- Virtio devices with MMIO transport option: virtio-blk and virtio-console devices were tested.
