### PR TITLE
bin: ch-remote: Ensure ch-remote supports syntax it advertises

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -402,7 +402,7 @@ fn main() {
                 .long("api-socket")
                 .help("HTTP API socket path (UNIX domain socket).")
                 .takes_value(true)
-                .min_values(1)
+                .number_of_values(1)
                 .required(true),
         )
         .subcommand(


### PR DESCRIPTION
The ch-remote usage says:

OPTIONS:
        --api-socket <api-socket>    HTTP API socket path (UNIX domain socket).

However it doesn't seem to actually accept that syntax, instead
requiring "--api-socket=". This may be a clap bug however it is resolved
by setting the number of arguments requires to exactly one. Which is
also the actual correct number.

Fixes: #1117
Fixes: #1116

Signed-off-by: Rob Bradford <robert.bradford@intel.com>