### PR TITLE
tests: Remove network interface from test_memory_overhead

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3798,7 +3798,6 @@ mod tests {
                 ])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .default_disks()
-                .default_net()
                 .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .spawn()
                 .unwrap();


### PR DESCRIPTION
Continue to try and track down the instability in the numbers generated
by this test by removing the (unused) network interface. It's possible
we are getting broadcast packets into the tap device and generating a
variable size of allocations.

See: #760

Signed-off-by: Rob Bradford <robert.bradford@intel.com>