### PR TITLE
arch, vmm: Don't build mptable when using ACPI

### DIFF
--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Chromium OS Authors"]
 
 [features]
 default = []
+acpi = ["acpi_tables"]
 
 [dependencies]
 byteorder = "1.3.4"

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -45,6 +45,8 @@ pub enum Error {
     InitramfsAddress,
     /// Error writing module entry to guest memory.
     ModlistSetup(vm_memory::GuestMemoryError),
+    /// RSDP Beyond Guest Memory
+    RSDPPastRamEnd,
 }
 pub type Result<T> = result::Result<T, Error>;
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -10,6 +10,7 @@
 mod gdt;
 pub mod interrupts;
 pub mod layout;
+#[cfg(not(feature = "acpi"))]
 mod mptable;
 pub mod regs;
 
@@ -90,6 +91,7 @@ unsafe impl ByteValued for BootParamsWrapper {}
 pub enum Error {
     /// Invalid e820 setup params.
     E820Configuration,
+    #[cfg(not(feature = "acpi"))]
     /// Error writing MP table to memory.
     MpTableSetup(mptable::Error),
 }
@@ -161,13 +163,14 @@ pub fn configure_system(
     cmdline_addr: GuestAddress,
     cmdline_size: usize,
     initramfs: &Option<InitramfsConfig>,
-    num_cpus: u8,
+    _num_cpus: u8,
     setup_hdr: Option<setup_header>,
     rsdp_addr: Option<GuestAddress>,
     boot_prot: BootProtocol,
 ) -> super::Result<()> {
     // Note that this puts the mptable at the last 1k of Linux's 640k base RAM
-    mptable::setup_mptable(guest_mem, num_cpus).map_err(Error::MpTableSetup)?;
+    #[cfg(not(feature = "acpi"))]
+    mptable::setup_mptable(guest_mem, _num_cpus).map_err(Error::MpTableSetup)?;
 
     // Check that the RAM is not smaller than the RSDP start address
     if let Some(rsdp_addr) = rsdp_addr {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -955,12 +955,12 @@ mod tests {
     }
 
     #[cfg_attr(not(feature = "mmio"), test)]
-    fn test_large_memory() {
+    fn test_large_vm() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
             let guest = Guest::new(&mut clear);
             let mut child = GuestCommand::new(&guest)
-                .args(&["--cpus", "boot=1"])
+                .args(&["--cpus", "boot=48"])
                 .args(&["--memory", "size=5120M"])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .default_disks()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2713,7 +2713,7 @@ mod tests {
         });
     }
 
-    #[cfg_attr(not(feature = "mmio"), test)]
+    #[cfg_attr(feature = "mmio", test)]
     fn test_vmlinux_boot_noacpi() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -2742,16 +2742,6 @@ mod tests {
             aver_eq!(tb, guest.get_cpu_count().unwrap_or_default(), 1);
             aver!(tb, guest.get_total_memory().unwrap_or_default() > 496_000);
             aver!(tb, guest.get_entropy().unwrap_or_default() >= 900);
-            aver_eq!(
-                tb,
-                guest
-                    .ssh_command("grep -c PCI-MSI /proc/interrupts")
-                    .unwrap_or_default()
-                    .trim()
-                    .parse::<u32>()
-                    .unwrap_or_default(),
-                12
-            );
 
             let _ = child.kill();
             let _ = child.wait();

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [features]
 default = []
-acpi = ["acpi_tables","devices/acpi"]
+acpi = ["acpi_tables","devices/acpi", "arch/acpi"]
 pci_support = ["pci", "vfio", "vm-virtio/pci_support"]
 mmio_support = ["vm-virtio/mmio_support"]
 cmos = ["devices/cmos"]


### PR DESCRIPTION
Use the ACPI feature to control whether to build the mptable. This is
necessary as the mptable and ACPI RSDP table can easily overwrite each
other leading to it failing to boot.

TEST=Compile with default features and see that --cpus boot=48 now
works, try with --no-default-features --features "pci" and observe the
--cpus boot=48 also continues to work.

Fixes: #1132

Signed-off-by: Rob Bradford <robert.bradford@intel.com>