### PR TITLE
Store and restore resources related to virtio-pci devices

### DIFF
--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -34,6 +34,8 @@ pub enum PciRootError {
     NoPciDeviceSlotAvailable,
     /// Invalid PCI device identifier provided.
     InvalidPciDeviceSlot(usize),
+    /// Valid PCI device identifier but already used.
+    AlreadyInUsePciDeviceSlot(usize),
 }
 pub type Result<T> = std::result::Result<T, PciRootError>;
 
@@ -153,6 +155,19 @@ impl PciBus {
         }
 
         Err(PciRootError::NoPciDeviceSlotAvailable)
+    }
+
+    pub fn get_device_id(&mut self, id: usize) -> Result<()> {
+        if id < NUM_DEVICE_IDS {
+            if !self.device_ids[id] {
+                self.device_ids[id] = true;
+                Ok(())
+            } else {
+                Err(PciRootError::AlreadyInUsePciDeviceSlot(id))
+            }
+        } else {
+            Err(PciRootError::InvalidPciDeviceSlot(id))
+        }
     }
 
     pub fn put_device_id(&mut self, id: usize) -> Result<()> {

--- a/vmm/src/device_tree.rs
+++ b/vmm/src/device_tree.rs
@@ -15,6 +15,8 @@ pub struct DeviceNode {
     pub children: Vec<String>,
     #[serde(skip)]
     pub migratable: Option<Arc<Mutex<dyn Migratable>>>,
+    #[cfg(feature = "pci_support")]
+    pub pci_bdf: Option<u32>,
 }
 
 impl DeviceNode {
@@ -25,6 +27,8 @@ impl DeviceNode {
             parent: None,
             children: Vec::new(),
             migratable,
+            #[cfg(feature = "pci_support")]
+            pci_bdf: None,
         }
     }
 }


### PR DESCRIPTION
This pull request takes care of storing and restoring important resource information such as the PCI `b/d/f` or the addresses of the PCI BARs in order to restore every `virtio-pci` device at the right place on the PCI bus, and at the right location in the guest address space.
It also takes care of updating the device tree upon PCI BAR reprogramming related to a virtio-pci device.
This means with this pull request, Cloud-Hypervisor can now fully support being snapshot and restored, no matter how complex the situation will be (different location in guest address space will be handled).