### PR TITLE
AArch64 initial build

### DIFF
--- a/.github/workflows/cross-build.yaml
+++ b/.github/workflows/cross-build.yaml
@@ -1,0 +1,32 @@
+name: Cloud Hypervisor Cross Build
+on: [pull_request, create]
+
+jobs:
+  build:
+    if: github.event_name == 'pull_request'
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+        target:
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v2
+      - name: Install Rust toolchain (${{ matrix.rust }})
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ matrix.rust }}
+            target: ${{ matrix.target }}
+            override: true
+      - name: Disable "with-serde" in kvm-bindings
+        run: sed -i 's/"with-serde",\ //g' vmm/Cargo.toml
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target=${{ matrix.target }} --no-default-features --features "mmio"

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -3,16 +3,26 @@
 
 pub mod layout;
 
-use memory_model::{GuestAddress, GuestMemory};
+use crate::RegionType;
+use kvm_ioctls::*;
+use vm_memory::{GuestAddress, GuestMemoryMmap, GuestUsize};
 
 /// Stub function that needs to be implemented when aarch64 functionality is added.
-pub fn arch_memory_regions(size: usize) -> Vec<(GuestAddress, usize, RegionType)> {
-    vec![(GuestAddress(0), size, RegionType::Ram)]
+pub fn arch_memory_regions(size: GuestUsize) -> Vec<(GuestAddress, usize, RegionType)> {
+    vec![(GuestAddress(0), size as usize, RegionType::Ram)]
+}
+
+#[derive(Debug, Copy, Clone)]
+/// Specifies the entry point address where the guest must start
+/// executing code.
+pub struct EntryPoint {
+    /// Address in guest memory where the guest must start execution
+    pub entry_addr: GuestAddress,
 }
 
 /// Stub function that needs to be implemented when aarch64 functionality is added.
 pub fn configure_system(
-    _guest_mem: &GuestMemory,
+    _guest_mem: &GuestMemoryMmap,
     _cmdline_addr: GuestAddress,
     _cmdline_size: usize,
     _num_cpus: u8,
@@ -24,4 +34,30 @@ pub fn configure_system(
 /// Stub function that needs to be implemented when aarch64 functionality is added.
 pub fn get_reserved_mem_addr() -> usize {
     0
+}
+
+pub fn get_host_cpu_phys_bits() -> u8 {
+    // The value returned here is used to determine the physical address space size
+    // for a VM (IPA size).
+    // In recent kernel versions, the maxium IPA size supported by the host can be
+    // known by querying cap KVM_CAP_ARM_VM_IPA_SIZE. And the IPA size for a
+    // guest can be configured smaller.
+    // But in Cloud-Hypervisor we simply use the maxium value for the VM.
+    // Reference https://lwn.net/Articles/766767/.
+    //
+    // The correct way to query KVM_CAP_ARM_VM_IPA_SIZE is via rust-vmm/kvm-ioctls,
+    // which wraps all IOCTL's and provides easy interface to user hypervisors.
+    // For now the cap hasn't been supported. A separate patch will be submitted to
+    // rust-vmm to add it.
+    // So a hardcoded value is used here as a temporary solution.
+    // It will be replace once rust-vmm/kvm-ioctls is ready.
+    //
+    40
+}
+
+pub fn check_required_kvm_extensions(kvm: &Kvm) -> super::Result<()> {
+    if !kvm.check_extension(Cap::SignalMsi) {
+        return Err(super::Error::CapabilityMissing(Cap::SignalMsi));
+    }
+    Ok(())
 }

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -22,6 +22,7 @@ extern crate kvm_ioctls;
 extern crate linux_loader;
 extern crate vm_memory;
 
+use kvm_ioctls::*;
 use std::result;
 
 #[derive(Debug)]
@@ -47,6 +48,8 @@ pub enum Error {
     ModlistSetup(vm_memory::GuestMemoryError),
     /// RSDP Beyond Guest Memory
     RSDPPastRamEnd,
+    /// Capability missing
+    CapabilityMissing(Cap),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -73,8 +76,8 @@ pub mod aarch64;
 
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
-    arch_memory_regions, configure_system, get_reserved_mem_addr, layout::CMDLINE_MAX_SIZE,
-    layout::CMDLINE_START,
+    arch_memory_regions, check_required_kvm_extensions, configure_system, get_host_cpu_phys_bits,
+    get_reserved_mem_addr, layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START, EntryPoint,
 };
 
 #[cfg(target_arch = "x86_64")]
@@ -82,11 +85,13 @@ pub mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
-    arch_memory_regions, configure_system, initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE,
-    layout::CMDLINE_START, regs, BootProtocol, EntryPoint,
+    arch_memory_regions, check_required_kvm_extensions, configure_system, get_host_cpu_phys_bits,
+    initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START, regs,
+    BootProtocol, EntryPoint,
 };
 
 /// Safe wrapper for `sysconf(_SC_PAGESIZE)`.
+#[cfg(target_arch = "x86_64")]
 #[inline(always)]
 fn pagesize() -> usize {
     // Trivially safe

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -192,7 +192,7 @@ impl Tap {
         unsafe {
             let ifru_hwaddr = ifreq.ifr_ifru.ifru_hwaddr.as_mut();
             for (i, v) in addr.get_bytes().iter().enumerate() {
-                ifru_hwaddr.sa_data[i] = *v as i8;
+                ifru_hwaddr.sa_data[i] = *v as c_char;
             }
         }
 

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:18.04 as dev
 
+ARG TARGETARCH="x86_64"
 ARG RUST_TOOLCHAIN="1.42.0"
 ARG CLH_SRC_DIR="/cloud-hypervisor"
 ARG CLH_BUILD_DIR="$CLH_SRC_DIR/build"
@@ -11,9 +12,9 @@ ENV RUSTUP_HOME=$CARGO_HOME
 ENV PATH="$PATH:$CARGO_HOME/bin"
 
 # Install all CI dependencies
-RUN apt-get update
-RUN apt-get -yq upgrade
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+RUN apt-get update \
+	&& apt-get -yq upgrade \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -yq \
 	build-essential \
 	bc \
 	docker.io \
@@ -37,22 +38,29 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq \
 	dosfstools \
 	cpio \
 	bsdtar \
-	gcc-multilib \
+	libfdt-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+RUN if [ "$TARGETARCH" = "x86_64" ]; then \
+	apt-get update \
+	&& apt-get -yq upgrade \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc-multilib \
+	&& apt-get clean \
+    && rm -rf /var/lib/apt/lists/*;	fi
+
 # Fix the libssl-dev install
-RUN cp /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl/
-ENV OPENSSL_DIR=/usr/lib/x86_64-linux-gnu/
-ENV OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu/
+RUN cp /usr/include/"$TARGETARCH"-linux-gnu/openssl/opensslconf.h /usr/include/openssl/
+ENV OPENSSL_DIR=/usr/lib/"$TARGETARCH"-linux-gnu/
+ENV OPENSSL_LIB_DIR=/usr/lib/"$TARGETARCH"-linux-gnu/
 ENV OPENSSL_INCLUDE_DIR=/usr/include/
 
 # Install the rust toolchain
 RUN nohup curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN" \
-    && rustup target add x86_64-unknown-linux-musl --toolchain "$RUST_TOOLCHAIN" \
-    && rustup toolchain add $RUST_TOOLCHAIN-x86_64-unknown-linux-musl \
-    && rustup component add rustfmt \
-    && rustup component add clippy \
+    && rustup target add $TARGETARCH-unknown-linux-musl --toolchain "$RUST_TOOLCHAIN" \
+    && if [ "$TARGETARCH" = "x86_64" ]; then rustup toolchain add $RUST_TOOLCHAIN-x86_64-unknown-linux-musl; fi \
+    && if [ "$TARGETARCH" = "x86_64" ]; then rustup component add rustfmt; fi \
+    && if [ "$TARGETARCH" = "x86_64" ]; then rustup component add clippy; fi \
     && cargo install cargo-audit \
     && rm -rf "$CARGO_HOME/registry" \
     && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \

--- a/vhost_user_fs/src/seccomp.rs
+++ b/vhost_user_fs/src/seccomp.rs
@@ -39,10 +39,12 @@ fn vuf_filter(action: SeccompAction) -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_close),
             allow_syscall(libc::SYS_copy_file_range),
             allow_syscall(libc::SYS_dup),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_epoll_create),
             allow_syscall(libc::SYS_epoll_create1),
             allow_syscall(libc::SYS_epoll_ctl),
             allow_syscall(libc::SYS_epoll_pwait),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_epoll_wait),
             allow_syscall(libc::SYS_eventfd2),
             allow_syscall(libc::SYS_exit),
@@ -59,10 +61,13 @@ fn vuf_filter(action: SeccompAction) -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_fremovexattr),
             allow_syscall(libc::SYS_fsetxattr),
             allow_syscall(libc::SYS_fstat),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_fstatfs),
             allow_syscall(libc::SYS_fsync),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_ftruncate),
             allow_syscall(libc::SYS_futex),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_getdents),
             allow_syscall(libc::SYS_getdents64),
             allow_syscall(libc::SYS_getegid),
@@ -82,6 +87,7 @@ fn vuf_filter(action: SeccompAction) -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_mremap),
             allow_syscall(libc::SYS_munmap),
             allow_syscall(libc::SYS_newfstatat),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_open),
             allow_syscall(libc::SYS_openat),
             allow_syscall(libc::SYS_prctl), // TODO restrict to just PR_SET_NAME?
@@ -109,9 +115,11 @@ fn vuf_filter(action: SeccompAction) -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_sigaltstack),
             allow_syscall(libc::SYS_statx),
             allow_syscall(libc::SYS_symlinkat),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_time), // Rarely needed, except on static builds
             allow_syscall(libc::SYS_tgkill),
             allow_syscall(libc::SYS_umask),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_unlink),
             allow_syscall(libc::SYS_unlinkat),
             allow_syscall(libc::SYS_unshare),

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -24,6 +24,7 @@ use acpi_tables::{aml, aml::Aml};
 use anyhow::anyhow;
 #[cfg(feature = "acpi")]
 use arch::layout;
+#[cfg(target_arch = "x86_64")]
 use arch::layout::{APIC_START, IOAPIC_SIZE, IOAPIC_START};
 use devices::{ioapic, BusDevice, HotPlugNotificationFlags};
 use kvm_ioctls::*;
@@ -75,6 +76,7 @@ const MMIO_LEN: u64 = 0x1000;
 #[cfg(feature = "pci_support")]
 const VFIO_DEVICE_NAME_PREFIX: &str = "_vfio";
 
+#[cfg(target_arch = "x86_64")]
 const IOAPIC_DEVICE_NAME: &str = "_ioapic";
 const SERIAL_DEVICE_NAME_PREFIX: &str = "_serial";
 
@@ -662,6 +664,7 @@ pub struct DeviceManager {
     #[cfg(feature = "pci_support")]
     pci_bus: Option<Arc<Mutex<PciBus>>>,
 
+    #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     // MSI Interrupt Manager
     msi_interrupt_manager: Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>>,
 
@@ -999,6 +1002,12 @@ impl DeviceManager {
         Ok(())
     }
 
+    #[cfg(target_arch = "aarch64")]
+    fn add_ioapic(&mut self) -> DeviceManagerResult<Arc<Mutex<ioapic::Ioapic>>> {
+        unimplemented!();
+    }
+
+    #[cfg(target_arch = "x86_64")]
     fn add_ioapic(&mut self) -> DeviceManagerResult<Arc<Mutex<ioapic::Ioapic>>> {
         let id = String::from(IOAPIC_DEVICE_NAME);
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -195,7 +195,9 @@ pub fn vmm_thread_filter() -> Result<SeccompFilter, Error> {
     Ok(SeccompFilter::new(
         vec![
             allow_syscall(libc::SYS_accept4),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_access),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_arch_prctl),
             allow_syscall(libc::SYS_bind),
             allow_syscall(libc::SYS_brk),
@@ -208,6 +210,7 @@ pub fn vmm_thread_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_epoll_create1),
             allow_syscall(libc::SYS_epoll_ctl),
             allow_syscall(libc::SYS_epoll_pwait),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_epoll_wait),
             allow_syscall(libc::SYS_eventfd2),
             allow_syscall(libc::SYS_execve),
@@ -216,9 +219,11 @@ pub fn vmm_thread_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_fallocate),
             allow_syscall(libc::SYS_fcntl),
             allow_syscall(libc::SYS_fdatasync),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_fork),
             allow_syscall(libc::SYS_fstat),
             allow_syscall(libc::SYS_fsync),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_ftruncate),
             allow_syscall(libc::SYS_futex),
             allow_syscall(libc::SYS_getpid),
@@ -236,6 +241,7 @@ pub fn vmm_thread_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_mremap),
             allow_syscall(libc::SYS_munmap),
             allow_syscall(libc::SYS_nanosleep),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_open),
             allow_syscall(libc::SYS_openat),
             allow_syscall(libc::SYS_pipe2),
@@ -244,6 +250,7 @@ pub fn vmm_thread_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_prlimit64),
             allow_syscall(libc::SYS_pwrite64),
             allow_syscall(libc::SYS_read),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_readlink),
             allow_syscall(libc::SYS_recvfrom),
             allow_syscall(libc::SYS_recvmsg),
@@ -264,10 +271,12 @@ pub fn vmm_thread_filter() -> Result<SeccompFilter, Error> {
                 ],
             ),
             allow_syscall(libc::SYS_socketpair),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_stat),
             allow_syscall(libc::SYS_statx),
             allow_syscall(libc::SYS_tgkill),
             allow_syscall(libc::SYS_tkill),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_unlink),
             allow_syscall(libc::SYS_wait4),
             allow_syscall(libc::SYS_write),
@@ -290,6 +299,7 @@ pub fn api_thread_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_epoll_create1),
             allow_syscall(libc::SYS_epoll_ctl),
             allow_syscall(libc::SYS_epoll_pwait),
+            #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_epoll_wait),
             allow_syscall(libc::SYS_exit),
             allow_syscall(libc::SYS_futex),

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -35,24 +35,37 @@ use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 use crate::migration::{url_to_path, vm_config_from_snapshot, VM_SNAPSHOT_FILE};
 use crate::{CPU_MANAGER_SNAPSHOT_ID, DEVICE_MANAGER_SNAPSHOT_ID, MEMORY_MANAGER_SNAPSHOT_ID};
 use anyhow::anyhow;
-use arch::{BootProtocol, EntryPoint};
-use devices::{ioapic, HotPlugNotificationFlags};
+#[cfg(target_arch = "x86_64")]
+use arch::BootProtocol;
+use arch::{check_required_kvm_extensions, EntryPoint};
+#[cfg(target_arch = "x86_64")]
+use devices::ioapic;
+use devices::HotPlugNotificationFlags;
+#[cfg(target_arch = "x86_64")]
 use kvm_bindings::{kvm_enable_cap, kvm_userspace_memory_region, KVM_CAP_SPLIT_IRQCHIP};
 use kvm_ioctls::*;
+#[cfg(target_arch = "x86_64")]
 use linux_loader::cmdline::Cmdline;
+#[cfg(target_arch = "x86_64")]
 use linux_loader::loader::elf::Error::InvalidElfMagicNumber;
+#[cfg(target_arch = "x86_64")]
 use linux_loader::loader::KernelLoader;
 use signal_hook::{iterator::Signals, SIGINT, SIGTERM, SIGWINCH};
+#[cfg(target_arch = "x86_64")]
 use std::convert::TryInto;
+#[cfg(target_arch = "x86_64")]
 use std::ffi::CString;
 use std::fs::{File, OpenOptions};
-use std::io::Write;
-use std::io::{self, Seek, SeekFrom};
+use std::io::{self, Write};
+#[cfg(target_arch = "x86_64")]
+use std::io::{Seek, SeekFrom};
+#[cfg(target_arch = "x86_64")]
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
 use std::{result, str, thread};
 use url::Url;
+#[cfg(target_arch = "x86_64")]
 use vm_memory::{
     Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryMmap,
     GuestMemoryRegion,
@@ -65,6 +78,7 @@ use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::terminal::Terminal;
 
 // 64 bit direct boot entry offset for bzImage
+#[cfg(target_arch = "x86_64")]
 const KERNEL_64BIT_ENTRY_OFFSET: u64 = 0x200;
 
 /// Errors associated with VM management
@@ -152,9 +166,6 @@ pub enum Error {
 
     /// Error from CPU handling
     CpuManager(cpu::Error),
-
-    /// Capability missing
-    CapabilityMissing(Cap),
 
     /// Cannot pause devices
     PauseDevices(MigratableError),
@@ -246,7 +257,9 @@ impl VmState {
 }
 
 pub struct Vm {
+    #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     kernel: File,
+    #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     initramfs: Option<File>,
     threads: Vec<thread::JoinHandle<()>>,
     device_manager: Arc<Mutex<DeviceManager>>,
@@ -262,18 +275,7 @@ impl Vm {
     fn kvm_new() -> Result<(Kvm, Arc<VmFd>)> {
         let kvm = Kvm::new().map_err(Error::KvmNew)?;
 
-        // Check required capabilities:
-        if !kvm.check_extension(Cap::SignalMsi) {
-            return Err(Error::CapabilityMissing(Cap::SignalMsi));
-        }
-
-        if !kvm.check_extension(Cap::TscDeadlineTimer) {
-            return Err(Error::CapabilityMissing(Cap::TscDeadlineTimer));
-        }
-
-        if !kvm.check_extension(Cap::SplitIrqchip) {
-            return Err(Error::CapabilityMissing(Cap::SplitIrqchip));
-        }
+        check_required_kvm_extensions(&kvm).expect("Missing KVM capabilities");
 
         let fd: VmFd;
         loop {
@@ -295,16 +297,20 @@ impl Vm {
         let fd = Arc::new(fd);
 
         // Set TSS
+        #[cfg(target_arch = "x86_64")]
         fd.set_tss_address(arch::x86_64::layout::KVM_TSS_ADDRESS.raw_value() as usize)
             .map_err(Error::VmSetup)?;
 
-        // Create split irqchip
-        // Only the local APIC is emulated in kernel, both PICs and IOAPIC
-        // are not.
-        let mut cap: kvm_enable_cap = Default::default();
-        cap.cap = KVM_CAP_SPLIT_IRQCHIP;
-        cap.args[0] = ioapic::NUM_IOAPIC_PINS as u64;
-        fd.enable_cap(&cap).map_err(Error::VmSetup)?;
+        #[cfg(target_arch = "x86_64")]
+        {
+            // Create split irqchip
+            // Only the local APIC is emulated in kernel, both PICs and IOAPIC
+            // are not.
+            let mut cap: kvm_enable_cap = Default::default();
+            cap.cap = KVM_CAP_SPLIT_IRQCHIP;
+            cap.args[0] = ioapic::NUM_IOAPIC_PINS as u64;
+            fd.enable_cap(&cap).map_err(Error::VmSetup)?;
+        }
 
         Ok((kvm, fd))
     }
@@ -446,6 +452,7 @@ impl Vm {
         )
     }
 
+    #[cfg(target_arch = "x86_64")]
     fn load_initramfs(&mut self, guest_mem: &GuestMemoryMmap) -> Result<arch::InitramfsConfig> {
         let mut initramfs = self.initramfs.as_ref().unwrap();
         let size: usize = initramfs
@@ -468,6 +475,12 @@ impl Vm {
         Ok(arch::InitramfsConfig { address, size })
     }
 
+    #[cfg(target_arch = "aarch64")]
+    fn load_kernel(&mut self) -> Result<EntryPoint> {
+        unimplemented!();
+    }
+
+    #[cfg(target_arch = "x86_64")]
     fn load_kernel(&mut self) -> Result<EntryPoint> {
         let mut cmdline = Cmdline::new(arch::CMDLINE_MAX_SIZE);
         cmdline
@@ -1276,6 +1289,7 @@ impl Transportable for Vm {
 }
 impl Migratable for Vm {}
 
+#[cfg(target_arch = "x86_64")]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1334,6 +1348,7 @@ mod tests {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 #[allow(unused)]
 pub fn test_vm() {
     // This example based on https://lwn.net/Articles/658511/


### PR DESCRIPTION
This PR is splitted from https://github.com/cloud-hypervisor/cloud-hypervisor/pull/1126. 
It prepares for upcoming PR's to enable AArch64. All building issues were fixed, but no functionality was introduced. A lot of `#[cfg(target_arch = "xxx")]` were used in source files to separate architecture specific code. Some utility files were updated as well.

For X86, the logic of code was not changed at all. Nothing should be broken.

For ARM, the architecture specific part is still empty. Some new added ARM-specific code may looks weird, because they were added temporarily to workaround lint warnings. But they will be replaced later by other commits with real functionality.

A workflow for "Checks" was setup to cross-build for AArch64. But now the cross-build fails, which is related to Serde in kvm-bindings. The reason is that CH forked `kvm-bindings` to add the support of Serde, the modification was mainly for X86 and a little was modified for ARM, but it is not ready for ARM. A workaround is to revert the modification for ARM totally. A PR for this has been issued to `cloud-hypervisor/kvm-bindings`
