### PR TITLE
build, vmm: Update to latest kvm-ioctls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
 [[package]]
 name = "kvm-ioctls"
 version = "0.5.0"
-source = "git+https://github.com/cloud-hypervisor/kvm-ioctls?branch=ch#4999c0f4366b5cf017cf757c0d84b054881d3206"
+source = "git+https://github.com/cloud-hypervisor/kvm-ioctls?branch=ch#5b7f1cc5de6d9664ee30e7d6a2f183499de0f685"
 dependencies = [
  "kvm-bindings",
  "libc",

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1426,7 +1426,7 @@ pub fn test_vm() {
             VcpuExit::Watchdog => {}
             VcpuExit::S390Tsch => {}
             VcpuExit::Epr => {}
-            VcpuExit::SystemEvent => {}
+            VcpuExit::SystemEvent(_, _) => {}
             VcpuExit::S390Stsi => {}
             VcpuExit::IoapicEoi(_vector) => {}
             VcpuExit::Hyperv => {}


### PR DESCRIPTION
The ch branch has been rebased to incorporate the latest upstream code
requiring a small change to the unit tests.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>