### PR TITLE
vmm: Update seccomp filters with clock_nanosleep

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -196,6 +196,7 @@ pub fn vmm_thread_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_bind),
             allow_syscall(libc::SYS_brk),
             allow_syscall(libc::SYS_clock_gettime),
+            allow_syscall(libc::SYS_clock_nanosleep),
             allow_syscall(libc::SYS_clone),
             allow_syscall(libc::SYS_close),
             allow_syscall(libc::SYS_connect),


### PR DESCRIPTION
The clock_nanosleep system call needs to be whitelisted since the commit
12e00c0f4539879be4622da93f941035c14561ae introduced the use of a sleep()
function. Without this patch, we can see an error when the VM is paused
or killed.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>