### PR TITLE
Support setting host MAC address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log 0.4.8",
+ "net_util",
  "seccomp",
  "serde_json",
  "ssh2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tempdir= "0.3.7"
 lazy_static= "1.4.0"
 tempfile = "3.1.0"
 serde_json = ">=1.0.9"
+net_util = { path = "net_util" }
 
 [features]
 default = ["acpi", "pci", "cmos"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -798,11 +798,11 @@ mod unit_tests {
                 false,
             ),
             (
-                vec!["cloud-hypervisor", "--kernel", "/path/to/kernel", "--net", "mac=12:34:56:78:90:ab"],
+                vec!["cloud-hypervisor", "--kernel", "/path/to/kernel", "--net", "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd"],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "net": [
-                        {"mac": "12:34:56:78:90:ab"}
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd"}
                     ]
                 }"#,
                 true,
@@ -811,12 +811,12 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--net",
-                    "mac=12:34:56:78:90:ab,tap=tap0",
+                    "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,tap=tap0",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "net": [
-                        {"mac": "12:34:56:78:90:ab", "tap": "tap0"}
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "tap": "tap0"}
                     ]
                 }"#,
                 true,
@@ -825,12 +825,12 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--net",
-                    "mac=12:34:56:78:90:ab,tap=tap0,ip=1.2.3.4",
+                    "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,tap=tap0,ip=1.2.3.4",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "net": [
-                        {"mac": "12:34:56:78:90:ab", "tap": "tap0", "ip": "1.2.3.4"}
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "tap": "tap0", "ip": "1.2.3.4"}
                     ]
                 }"#,
                 true,
@@ -839,12 +839,12 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--net",
-                    "mac=12:34:56:78:90:ab,tap=tap0,ip=1.2.3.4,mask=5.6.7.8",
+                    "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,tap=tap0,ip=1.2.3.4,mask=5.6.7.8",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "net": [
-                        {"mac": "12:34:56:78:90:ab", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8"}
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8"}
                     ]
                 }"#,
                 true,
@@ -853,12 +853,12 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--net",
-                    "mac=12:34:56:78:90:ab,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=4",
+                    "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=4",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "net": [
-                        {"mac": "12:34:56:78:90:ab", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 4}
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 4}
                     ]
                 }"#,
                 true,
@@ -867,12 +867,12 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--net",
-                    "mac=12:34:56:78:90:ab,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=4,queue_size=128",
+                    "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=4,queue_size=128",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "net": [
-                        {"mac": "12:34:56:78:90:ab", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 4, "queue_size": 128}
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 4, "queue_size": 128}
                     ]
                 }"#,
                 true,
@@ -881,12 +881,12 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--net",
-                    "mac=12:34:56:78:90:ab,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=2,queue_size=256",
+                    "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=2,queue_size=256",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "net": [
-                        {"mac": "12:34:56:78:90:ab", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8"}
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8"}
                     ]
                 }"#,
                 true,
@@ -895,12 +895,12 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--net",
-                    "mac=12:34:56:78:90:ab,tap=tap0,ip=1.2.3.4,mask=5.6.7.8",
+                    "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,tap=tap0,ip=1.2.3.4,mask=5.6.7.8",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "net": [
-                        {"mac": "12:34:56:78:90:ab", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 2, "queue_size": 256}
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 2, "queue_size": 256}
                     ]
                 }"#,
                 true,
@@ -909,12 +909,12 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--net",
-                    "mac=12:34:56:78:90:ab,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=2,queue_size=256,iommu=on",
+                    "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=2,queue_size=256,iommu=on",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "net": [
-                        {"mac": "12:34:56:78:90:ab", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 2, "queue_size": 256, "iommu": true}
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 2, "queue_size": 256, "iommu": true}
                     ]
                 }"#,
                 false,
@@ -923,12 +923,12 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--net",
-                    "mac=12:34:56:78:90:ab,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=2,queue_size=256,iommu=on",
+                    "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=2,queue_size=256,iommu=on",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "net": [
-                        {"mac": "12:34:56:78:90:ab", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 2, "queue_size": 256, "iommu": true}
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 2, "queue_size": 256, "iommu": true}
                     ],
                     "iommu": true
                 }"#,
@@ -938,23 +938,23 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--net",
-                    "mac=12:34:56:78:90:ab,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=2,queue_size=256,iommu=off",
+                    "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,num_queues=2,queue_size=256,iommu=off",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "net": [
-                        {"mac": "12:34:56:78:90:ab", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 2, "queue_size": 256, "iommu": false}
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 2, "queue_size": 256, "iommu": false}
                     ]
                 }"#,
                 true,
             ),
             (
-                vec!["cloud-hypervisor", "--kernel", "/path/to/kernel", "--memory", "shared=true", "--net", "mac=12:34:56:78:90:ab,vhost_user=true,socket=/tmp/socket"],
+                vec!["cloud-hypervisor", "--kernel", "/path/to/kernel", "--memory", "shared=true", "--net", "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,vhost_user=true,socket=/tmp/socket"],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "net": [
-                        {"mac": "12:34:56:78:90:ab", "vhost_user": true, "vhost_socket": "/tmp/socket"}
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "vhost_user": true, "vhost_socket": "/tmp/socket"}
                     ]
                 }"#,
                 true,

--- a/vm-virtio/src/net.rs
+++ b/vm-virtio/src/net.rs
@@ -392,11 +392,13 @@ impl Net {
         ip_addr: Option<Ipv4Addr>,
         netmask: Option<Ipv4Addr>,
         guest_mac: Option<MacAddr>,
+        host_mac: Option<MacAddr>,
         iommu: bool,
         num_queues: usize,
         queue_size: u16,
     ) -> Result<Self> {
-        let taps = open_tap(if_name, ip_addr, netmask, num_queues / 2).map_err(Error::OpenTap)?;
+        let taps = open_tap(if_name, ip_addr, netmask, host_mac, num_queues / 2)
+            .map_err(Error::OpenTap)?;
 
         Self::new_with_tap(id, taps, guest_mac, iommu, num_queues, queue_size)
     }

--- a/vm-virtio/src/net_util.rs
+++ b/vm-virtio/src/net_util.rs
@@ -119,6 +119,8 @@ pub enum Error {
     TapSetIp(TapError),
     /// Setting tap netmask failed.
     TapSetNetmask(TapError),
+    /// Setting MAC address failed
+    TapSetMac(TapError),
     /// Setting tap interface offload flags failed.
     TapSetOffload(TapError),
     /// Setting vnet header size failed.
@@ -531,6 +533,7 @@ pub fn open_tap(
     if_name: Option<&str>,
     ip_addr: Option<Ipv4Addr>,
     netmask: Option<Ipv4Addr>,
+    host_mac: Option<MacAddr>,
     num_rx_q: usize,
 ) -> Result<Vec<Tap>> {
     let mut taps: Vec<Tap> = Vec::new();
@@ -557,6 +560,9 @@ pub fn open_tap(
             }
             if let Some(mask) = netmask {
                 tap.set_netmask(mask).map_err(Error::TapSetNetmask)?;
+            }
+            if let Some(mac) = host_mac {
+                tap.set_mac_addr(mac).map_err(Error::TapSetMac)?
             }
             tap.enable().map_err(Error::TapEnable)?;
             tap.set_offload(flag).map_err(Error::TapSetOffload)?;

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1463,8 +1463,13 @@ impl DeviceManager {
             .args(&[
                 "--net-backend",
                 &format!(
-                    "ip={},mask={},socket={},num_queues={},queue_size={}",
-                    net_cfg.ip, net_cfg.mask, &sock, net_cfg.num_queues, net_cfg.queue_size
+                    "ip={},mask={},socket={},num_queues={},queue_size={},host_mac={}",
+                    net_cfg.ip,
+                    net_cfg.mask,
+                    &sock,
+                    net_cfg.num_queues,
+                    net_cfg.queue_size,
+                    net_cfg.host_mac
                 ),
             ])
             .spawn()
@@ -1529,6 +1534,7 @@ impl DeviceManager {
                         None,
                         None,
                         Some(net_cfg.mac),
+                        Some(net_cfg.host_mac),
                         net_cfg.iommu,
                         net_cfg.num_queues,
                         net_cfg.queue_size,
@@ -1543,6 +1549,7 @@ impl DeviceManager {
                         Some(net_cfg.ip),
                         Some(net_cfg.mask),
                         Some(net_cfg.mac),
+                        Some(net_cfg.host_mac),
                         net_cfg.iommu,
                         net_cfg.num_queues,
                         net_cfg.queue_size,

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -88,8 +88,10 @@ const TUNSETVNETHDRSZ: u64 = 0x4004_54d8;
 const TUNGETFEATURES: u64 = 0x8004_54cf;
 
 // See include/uapi/linux/sockios.h in the kernel code.
+const SIOCGIFHWADDR: u64 = 0x8927;
 const SIOCSIFFLAGS: u64 = 0x8914;
 const SIOCSIFADDR: u64 = 0x8916;
+const SIOCSIFHWADDR: u64 = 0x8924;
 const SIOCSIFNETMASK: u64 = 0x891c;
 
 // See include/uapi/linux/vfio.h in the kernel code.
@@ -148,8 +150,10 @@ fn create_vmm_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_USER_MEMORY_REGION,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XSAVE,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XCRS,)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, SIOCGIFHWADDR)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, SIOCSIFADDR)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, SIOCSIFFLAGS)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, SIOCSIFHWADDR)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, SIOCSIFNETMASK)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TCSETS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TCGETS)?],


### PR DESCRIPTION
Provide options to let the user choose their host MAC address. If the user does not provide one we generate one and store it in the config.

Fixes: #1177