### PR TITLE
vhost_user_fs: Fix seccomp filter for musl

### DIFF
--- a/vhost_user_fs/src/seccomp.rs
+++ b/vhost_user_fs/src/seccomp.rs
@@ -42,6 +42,7 @@ fn vuf_filter(action: SeccompAction) -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_epoll_create),
             allow_syscall(libc::SYS_epoll_create1),
             allow_syscall(libc::SYS_epoll_ctl),
+            allow_syscall(libc::SYS_epoll_pwait),
             allow_syscall(libc::SYS_epoll_wait),
             allow_syscall(libc::SYS_eventfd2),
             allow_syscall(libc::SYS_exit),


### PR DESCRIPTION
Add missing syscall used by the musl build.

TEST=scripts/dev_cli.sh tests --libc musl --integration -- vhost_user_fs_daemon

Signed-off-by: Rob Bradford <robert.bradford@intel.com>