### PR TITLE
vhost_user_block: Implement VIRTIO_BLK_F_FLUSH

### DIFF
--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -259,6 +259,7 @@ impl VhostUserBackend for VhostUserBlkBackend {
             | 1 << VIRTIO_BLK_F_CONFIG_WCE
             | 1 << VIRTIO_RING_F_EVENT_IDX
             | 1 << VIRTIO_F_VERSION_1
+            | 1 << VIRTIO_BLK_F_FLUSH
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
 
         if self.rdonly {


### PR DESCRIPTION
As the parsing code is reused the flush feature is already implemented
and ready to be used.

Fixes: #1197

Signed-off-by: Rob Bradford <robert.bradford@intel.com>