### PR TITLE
vhost_user_net, vm-virtio: Interrupt guest when TX queue is updated

### DIFF
--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -312,7 +312,9 @@ impl VhostUserBackend for VhostUserNetBackend {
                 }
             }
             1 => {
-                thread.process_tx(&mut vrings[1].write().unwrap().mut_queue())?;
+                let mut vring = vrings[1].write().unwrap();
+                thread.process_tx(vring.mut_queue())?;
+                vring.signal_used_queue()?;
             }
             2 => {
                 let mut vring = vrings[0].write().unwrap();

--- a/vm-virtio/src/net.rs
+++ b/vm-virtio/src/net.rs
@@ -148,8 +148,7 @@ impl NetEpollHandler {
         let mem = self.mem.memory();
 
         self.tx.process_desc_chain(&mem, &mut self.tap, &mut queue);
-
-        Ok(())
+        self.signal_used_queue(queue)
     }
 
     fn read_tap(&mut self) -> io::Result<usize> {


### PR DESCRIPTION
According to the virtio spec the guest should always be interrupted when
"used" descriptors are returned from the device to the driver. However
this was not the case for the TX queue in either the virtio-net
implementation or the vhost-user-net implementation.

This would have meant that the guest could end up with a reduced TX
throughput as it would not know that the packets had been dispatched via
the VMM.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>