### PR TITLE
vm-virtio, vhost_user_{fs,block,backend}: Move EVENT_IDX handling

### DIFF
--- a/src/bin/vhost_user_fs.rs
+++ b/src/bin/vhost_user_fs.rs
@@ -163,8 +163,9 @@ impl<F: FileSystem + Send + Sync + 'static> VhostUserFsThread<F> {
                 let mut vring = vring_lock.write().unwrap();
 
                 if event_idx {
-                    if let Some(used_idx) = vring.mut_queue().add_used(&mem, head_index, 0) {
-                        if vring.needs_notification(&mem, Wrapping(used_idx)) {
+                    let queue = vring.mut_queue();
+                    if let Some(used_idx) = queue.add_used(&mem, head_index, 0) {
+                        if queue.needs_notification(&mem, Wrapping(used_idx)) {
                             vring.signal_used_queue().unwrap();
                         }
                     }

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -153,8 +153,9 @@ impl VhostUserBlkThread {
             }
 
             if self.event_idx {
-                if let Some(used_idx) = vring.mut_queue().add_used(mem, head.index, len) {
-                    if vring.needs_notification(&mem, Wrapping(used_idx)) {
+                let queue = vring.mut_queue();
+                if let Some(used_idx) = queue.add_used(mem, head.index, len) {
+                    if queue.needs_notification(&mem, Wrapping(used_idx)) {
                         debug!("signalling queue");
                         vring.signal_used_queue().unwrap();
                     } else {


### PR DESCRIPTION
Move the method that is used to decide whether the guest should be
signalled into the Queue implementation from vm-virtio. This removes
duplicated code between vhost_user_backend and the vm-virtio block
implementation.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>