### PR TITLE
vm-virtio: block: Ensure that VIRTIO_BLK_T_FLUSH requests actually sync

### DIFF
--- a/vm-virtio/src/block.rs
+++ b/vm-virtio/src/block.rs
@@ -351,7 +351,7 @@ impl Write for RawFile {
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        self.file.flush()
+        self.file.sync_all()
     }
 }
 


### PR DESCRIPTION
The implementation of this virtio block (and vhost-user block) command
called a function that was a no-op on Linux. Use the same function as
virtio-pmem to ensure that data is not lost when the guest asks for it
to be flused to disk.

Fixes: #399

Signed-off-by: Rob Bradford <robert.bradford@intel.com>