### PR TITLE
build: Use same virtio-bindings version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
  "vhost_user_block",
  "vhost_user_fs",
  "vhost_user_net",
- "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-bindings",
  "vm-device",
  "vm-memory",
  "vm-virtio",
@@ -1384,7 +1384,7 @@ dependencies = [
  "libc",
  "log 0.4.8",
  "vhost",
- "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-bindings",
  "vm-memory",
  "vm-virtio",
  "vmm-sys-util",
@@ -1401,7 +1401,7 @@ dependencies = [
  "qcow",
  "vhost",
  "vhost_user_backend",
- "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-bindings",
  "vm-memory",
  "vm-virtio",
  "vmm",
@@ -1433,17 +1433,12 @@ dependencies = [
  "net_util",
  "vhost",
  "vhost_user_backend",
- "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-bindings",
  "vm-memory",
  "vm-virtio",
  "vmm",
  "vmm-sys-util",
 ]
-
-[[package]]
-name = "virtio-bindings"
-version = "0.1.0"
-source = "git+https://github.com/rust-vmm/virtio-bindings#921b722856335b799261b736cbb90e767e739dfc"
 
 [[package]]
 name = "virtio-bindings"
@@ -1513,7 +1508,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "vhost",
- "virtio-bindings 0.1.0 (git+https://github.com/rust-vmm/virtio-bindings)",
+ "virtio-bindings",
  "vm-allocator",
  "vm-device",
  "vm-memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ vhost_user_backend = { path = "vhost_user_backend"}
 vhost_user_block = { path = "vhost_user_block"}
 vhost_user_fs = { path = "vhost_user_fs"}
 vhost_user_net = { path = "vhost_user_net"}
-virtio-bindings = "0.1.0"
+virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"]}
 vmm = { path = "vmm" }
 vm-device = { path = "vm-device" }
 vm-memory = "0.2.0"

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -24,7 +24,7 @@ serde = ">=1.0.27"
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 tempfile = "3.1.0"
-virtio-bindings = { git = "https://github.com/rust-vmm/virtio-bindings", version = "0.1", features = ["virtio-v5_0_0"]}
+virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"]}
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.2.0", features = ["backend-mmap", "backend-atomic"] }


### PR DESCRIPTION
Consistently use the crates.io 0.1.0 version based on Linux 5.0.0

Fixes: #1192

Signed-off-by: Rob Bradford <robert.bradford@intel.com>