### PR TITLE
AArch64: Adding AArch64 arch-related files

### DIFF
--- a/.github/workflows/cross-build.yaml
+++ b/.github/workflows/cross-build.yaml
@@ -22,6 +22,8 @@ jobs:
             toolchain: ${{ matrix.rust }}
             target: ${{ matrix.target }}
             override: true
+      - name: Install arm64 libfdt
+        run: wget http://ftp.us.debian.org/debian/pool/main/d/device-tree-compiler/libfdt-dev_1.6.0-1_arm64.deb && dpkg-deb -xv libfdt-dev_1.6.0-1_arm64.deb ./tlibfdtdev && sudo mkdir /tmmmp && mkdir target && mkdir target/debug && mkdir target/debug/deps && sudo cp ./tlibfdtdev/usr/lib/aarch64-linux-gnu/libfdt.a target/debug/deps/libfdt.a && echo "libfdt installed"
       - name: Disable "with-serde" in kvm-bindings
         run: sed -i 's/"with-serde",\ //g' vmm/Cargo.toml
       - name: Build

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -1,0 +1,610 @@
+// Copyright 2020 Arm Limited (or its affiliates). All rights reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+use libc::{c_char, c_int, c_void};
+use std::collections::HashMap;
+use std::ffi::{CStr, CString, NulError};
+use std::fmt::Debug;
+use std::ptr::null;
+use std::{io, result};
+
+use super::super::DeviceType;
+use super::super::InitrdConfig;
+use super::get_fdt_addr;
+use super::gic::GICDevice;
+use super::layout::FDT_MAX_SIZE;
+use crate::aarch64::fdt::Error::CstringFDTTransform;
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap};
+
+// This is a value for uniquely identifying the FDT node declaring the interrupt controller.
+const GIC_PHANDLE: u32 = 1;
+// This is a value for uniquely identifying the FDT node containing the clock definition.
+const CLOCK_PHANDLE: u32 = 2;
+// Read the documentation specified when appending the root node to the FDT.
+const ADDRESS_CELLS: u32 = 0x2;
+const SIZE_CELLS: u32 = 0x2;
+
+// As per kvm tool and
+// https://www.kernel.org/doc/Documentation/devicetree/bindings/interrupt-controller/arm%2Cgic.txt
+// Look for "The 1st cell..."
+const GIC_FDT_IRQ_TYPE_SPI: u32 = 0;
+const GIC_FDT_IRQ_TYPE_PPI: u32 = 1;
+
+// From https://elixir.bootlin.com/linux/v4.9.62/source/include/dt-bindings/interrupt-controller/irq.h#L17
+const IRQ_TYPE_EDGE_RISING: u32 = 1;
+const IRQ_TYPE_LEVEL_HI: u32 = 4;
+
+// This links to libfdt which handles the creation of the binary blob
+// flattened device tree (fdt) that is passed to the kernel and indicates
+// the hardware configuration of the machine.
+#[link(name = "fdt")]
+extern "C" {
+    fn fdt_create(buf: *mut c_void, bufsize: c_int) -> c_int;
+    fn fdt_finish_reservemap(fdt: *mut c_void) -> c_int;
+    fn fdt_begin_node(fdt: *mut c_void, name: *const c_char) -> c_int;
+    fn fdt_property(fdt: *mut c_void, name: *const c_char, val: *const c_void, len: c_int)
+        -> c_int;
+    fn fdt_end_node(fdt: *mut c_void) -> c_int;
+    fn fdt_open_into(fdt: *const c_void, buf: *mut c_void, bufsize: c_int) -> c_int;
+    fn fdt_finish(fdt: *const c_void) -> c_int;
+    fn fdt_pack(fdt: *mut c_void) -> c_int;
+}
+
+/// Trait for devices to be added to the Flattened Device Tree.
+pub trait DeviceInfoForFDT {
+    /// Returns the address where this device will be loaded.
+    fn addr(&self) -> u64;
+    /// Returns the associated interrupt for this device.
+    fn irq(&self) -> u32;
+    /// Returns the amount of memory that needs to be reserved for this device.
+    fn length(&self) -> u64;
+}
+
+/// Errors thrown while configuring the Flattened Device Tree for aarch64.
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to append node to the FDT.
+    AppendFDTNode(io::Error),
+    /// Failed to append a property to the FDT.
+    AppendFDTProperty(io::Error),
+    /// Syscall for creating FDT failed.
+    CreateFDT(io::Error),
+    /// Failed to obtain a C style string.
+    CstringFDTTransform(NulError),
+    /// Failure in calling syscall for terminating this FDT.
+    FinishFDTReserveMap(io::Error),
+    /// Failure in writing FDT in memory.
+    WriteFDTToMemory(GuestMemoryError),
+}
+type Result<T> = result::Result<T, Error>;
+
+/// Creates the flattened device tree for this aarch64 VM.
+pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug>(
+    guest_mem: &GuestMemoryMmap,
+    cmdline: &CStr,
+    vcpu_mpidr: Vec<u64>,
+    device_info: &HashMap<(DeviceType, String), T>,
+    gic_device: &Box<dyn GICDevice>,
+    initrd: &Option<InitrdConfig>,
+) -> Result<Vec<u8>> {
+    // Alocate stuff necessary for the holding the blob.
+    let mut fdt = vec![0; FDT_MAX_SIZE];
+
+    allocate_fdt(&mut fdt)?;
+
+    // For an explanation why these nodes were introduced in the blob take a look at
+    // https://github.com/torvalds/linux/blob/master/Documentation/devicetree/booting-without-of.txt#L845
+    // Look for "Required nodes and properties".
+
+    // Header or the root node as per above mentioned documentation.
+    append_begin_node(&mut fdt, "")?;
+    append_property_string(&mut fdt, "compatible", "linux,dummy-virt")?;
+    // For info on #address-cells and size-cells read "Note about cells and address representation"
+    // from the above mentioned txt file.
+    append_property_u32(&mut fdt, "#address-cells", ADDRESS_CELLS)?;
+    append_property_u32(&mut fdt, "#size-cells", SIZE_CELLS)?;
+    // This is not mandatory but we use it to point the root node to the node
+    // containing description of the interrupt controller for this VM.
+    append_property_u32(&mut fdt, "interrupt-parent", GIC_PHANDLE)?;
+    create_cpu_nodes(&mut fdt, &vcpu_mpidr)?;
+    create_memory_node(&mut fdt, guest_mem)?;
+    create_chosen_node(&mut fdt, cmdline, initrd)?;
+    create_gic_node(&mut fdt, gic_device)?;
+    create_timer_node(&mut fdt)?;
+    create_clock_node(&mut fdt)?;
+    create_psci_node(&mut fdt)?;
+    create_devices_node(&mut fdt, device_info)?;
+
+    // End Header node.
+    append_end_node(&mut fdt)?;
+
+    // Allocate another buffer so we can format and then write fdt to guest.
+    let mut fdt_final = vec![0; FDT_MAX_SIZE];
+    finish_fdt(&mut fdt, &mut fdt_final)?;
+
+    // Write FDT to memory.
+    let fdt_address = GuestAddress(get_fdt_addr(&guest_mem));
+    guest_mem
+        .write_slice(fdt_final.as_slice(), fdt_address)
+        .map_err(Error::WriteFDTToMemory)?;
+    Ok(fdt_final)
+}
+
+// Following are auxiliary functions for allocating and finishing the FDT.
+fn allocate_fdt(fdt: &mut Vec<u8>) -> Result<()> {
+    // Safe since we allocated this array with FDT_MAX_SIZE.
+    let mut fdt_ret = unsafe { fdt_create(fdt.as_mut_ptr() as *mut c_void, FDT_MAX_SIZE as c_int) };
+
+    if fdt_ret != 0 {
+        return Err(Error::CreateFDT(io::Error::last_os_error()));
+    }
+
+    // The flattened device trees created with fdt_create() contains a list of
+    // reserved memory areas. We need to call `fdt_finish_reservemap` so as to make sure that there is a
+    // terminator in the reservemap list and whatever happened to be at the
+    // start of the FDT data section would end up being interpreted as
+    // reservemap entries.
+    // Safe since we previously allocated this array.
+    fdt_ret = unsafe { fdt_finish_reservemap(fdt.as_mut_ptr() as *mut c_void) };
+    if fdt_ret != 0 {
+        return Err(Error::FinishFDTReserveMap(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+fn finish_fdt(from_fdt: &mut Vec<u8>, to_fdt: &mut Vec<u8>) -> Result<()> {
+    // Safe since we allocated `fdt_final` and previously passed in its size.
+    let mut fdt_ret = unsafe { fdt_finish(from_fdt.as_mut_ptr() as *mut c_void) };
+    if fdt_ret != 0 {
+        return Err(Error::FinishFDTReserveMap(io::Error::last_os_error()));
+    }
+
+    // Safe because we allocated both arrays with the correct size.
+    fdt_ret = unsafe {
+        fdt_open_into(
+            from_fdt.as_mut_ptr() as *mut c_void,
+            to_fdt.as_mut_ptr() as *mut c_void,
+            FDT_MAX_SIZE as i32,
+        )
+    };
+    if fdt_ret != 0 {
+        return Err(Error::FinishFDTReserveMap(io::Error::last_os_error()));
+    }
+
+    // Safe since we allocated `to_fdt`.
+    fdt_ret = unsafe { fdt_pack(to_fdt.as_mut_ptr() as *mut c_void) };
+    if fdt_ret != 0 {
+        return Err(Error::FinishFDTReserveMap(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+// Following are auxiliary functions for appending nodes to FDT.
+fn append_begin_node(fdt: &mut Vec<u8>, name: &str) -> Result<()> {
+    let cstr_name = CString::new(name).map_err(CstringFDTTransform)?;
+
+    // Safe because we allocated fdt and converted name to a CString
+    let fdt_ret = unsafe { fdt_begin_node(fdt.as_mut_ptr() as *mut c_void, cstr_name.as_ptr()) };
+    if fdt_ret != 0 {
+        return Err(Error::AppendFDTNode(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+fn append_end_node(fdt: &mut Vec<u8>) -> Result<()> {
+    // Safe because we allocated fdt.
+    let fdt_ret = unsafe { fdt_end_node(fdt.as_mut_ptr() as *mut c_void) };
+    if fdt_ret != 0 {
+        return Err(Error::AppendFDTNode(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+// Following are auxiliary functions for appending property nodes to the nodes of the FDT.
+fn append_property_u32(fdt: &mut Vec<u8>, name: &str, val: u32) -> Result<()> {
+    append_property(fdt, name, &to_be32(val))
+}
+
+fn append_property_u64(fdt: &mut Vec<u8>, name: &str, val: u64) -> Result<()> {
+    append_property(fdt, name, &to_be64(val))
+}
+
+fn append_property_string(fdt: &mut Vec<u8>, name: &str, value: &str) -> Result<()> {
+    let cstr_value = CString::new(value).map_err(CstringFDTTransform)?;
+    append_property_cstring(fdt, name, &cstr_value)
+}
+
+fn append_property_cstring(fdt: &mut Vec<u8>, name: &str, cstr_value: &CStr) -> Result<()> {
+    let value_bytes = cstr_value.to_bytes_with_nul();
+    let cstr_name = CString::new(name).map_err(CstringFDTTransform)?;
+    // Safe because we allocated fdt, converted name and value to CStrings
+    let fdt_ret = unsafe {
+        fdt_property(
+            fdt.as_mut_ptr() as *mut c_void,
+            cstr_name.as_ptr(),
+            value_bytes.as_ptr() as *mut c_void,
+            value_bytes.len() as i32,
+        )
+    };
+    if fdt_ret != 0 {
+        return Err(Error::AppendFDTProperty(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+fn append_property_null(fdt: &mut Vec<u8>, name: &str) -> Result<()> {
+    let cstr_name = CString::new(name).map_err(CstringFDTTransform)?;
+
+    // Safe because we allocated fdt, converted name to a CString
+    let fdt_ret = unsafe {
+        fdt_property(
+            fdt.as_mut_ptr() as *mut c_void,
+            cstr_name.as_ptr(),
+            null(),
+            0,
+        )
+    };
+    if fdt_ret != 0 {
+        return Err(Error::AppendFDTProperty(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+fn append_property(fdt: &mut Vec<u8>, name: &str, val: &[u8]) -> Result<()> {
+    let cstr_name = CString::new(name).map_err(CstringFDTTransform)?;
+    let val_ptr = val.as_ptr() as *const c_void;
+
+    // Safe because we allocated fdt and converted name to a CString
+    let fdt_ret = unsafe {
+        fdt_property(
+            fdt.as_mut_ptr() as *mut c_void,
+            cstr_name.as_ptr(),
+            val_ptr,
+            val.len() as i32,
+        )
+    };
+    if fdt_ret != 0 {
+        return Err(Error::AppendFDTProperty(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+// Auxiliary functions for writing u32/u64 numbers in big endian order.
+fn to_be32(input: u32) -> [u8; 4] {
+    u32::to_be_bytes(input)
+}
+
+fn to_be64(input: u64) -> [u8; 8] {
+    u64::to_be_bytes(input)
+}
+
+// Helper functions for generating a properly formatted byte vector using 32-bit/64-bit cells.
+fn generate_prop32(cells: &[u32]) -> Vec<u8> {
+    let mut ret: Vec<u8> = Vec::new();
+    for &e in cells {
+        ret.extend(to_be32(e).iter());
+    }
+    ret
+}
+
+fn generate_prop64(cells: &[u64]) -> Vec<u8> {
+    let mut ret: Vec<u8> = Vec::new();
+    for &e in cells {
+        ret.extend(to_be64(e).iter());
+    }
+    ret
+}
+
+// Following are the auxiliary function for creating the different nodes that we append to our FDT.
+fn create_cpu_nodes(fdt: &mut Vec<u8>, vcpu_mpidr: &Vec<u64>) -> Result<()> {
+    // See https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/arm/cpus.yaml.
+    append_begin_node(fdt, "cpus")?;
+    // As per documentation, on ARM v8 64-bit systems value should be set to 2.
+    append_property_u32(fdt, "#address-cells", 0x02)?;
+    append_property_u32(fdt, "#size-cells", 0x0)?;
+    let num_cpus = vcpu_mpidr.len();
+
+    for cpu_index in 0..num_cpus {
+        let cpu_name = format!("cpu@{:x}", cpu_index);
+        append_begin_node(fdt, &cpu_name)?;
+        append_property_string(fdt, "device_type", "cpu")?;
+        append_property_string(fdt, "compatible", "arm,arm-v8")?;
+        if num_cpus > 1 {
+            // This is required on armv8 64-bit. See aforementioned documentation.
+            append_property_string(fdt, "enable-method", "psci")?;
+        }
+        // Set the field to first 24 bits of the MPIDR - Multiprocessor Affinity Register.
+        // See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0488c/BABHBJCI.html.
+        append_property_u64(fdt, "reg", vcpu_mpidr[cpu_index] & 0x7FFFFF)?;
+        append_end_node(fdt)?;
+    }
+    append_end_node(fdt)?;
+    Ok(())
+}
+
+fn create_memory_node(fdt: &mut Vec<u8>, guest_mem: &GuestMemoryMmap) -> Result<()> {
+    let mem_size = guest_mem.last_addr().raw_value() - super::layout::RAM_64BIT_START + 1;
+    // See https://github.com/torvalds/linux/blob/master/Documentation/devicetree/booting-without-of.txt#L960
+    // for an explanation of this.
+    let mem_reg_prop = generate_prop64(&[super::layout::RAM_64BIT_START as u64, mem_size as u64]);
+
+    append_begin_node(fdt, "memory")?;
+    append_property_string(fdt, "device_type", "memory")?;
+    append_property(fdt, "reg", &mem_reg_prop)?;
+    append_end_node(fdt)?;
+    Ok(())
+}
+
+fn create_chosen_node(
+    fdt: &mut Vec<u8>,
+    cmdline: &CStr,
+    initrd: &Option<InitrdConfig>,
+) -> Result<()> {
+    append_begin_node(fdt, "chosen")?;
+    append_property_cstring(fdt, "bootargs", cmdline)?;
+
+    if let Some(initrd_config) = initrd {
+        append_property_u64(
+            fdt,
+            "linux,initrd-start",
+            initrd_config.address.raw_value() as u64,
+        )?;
+        append_property_u64(
+            fdt,
+            "linux,initrd-end",
+            initrd_config.address.raw_value() + initrd_config.size as u64,
+        )?;
+    }
+
+    append_end_node(fdt)?;
+
+    Ok(())
+}
+
+fn create_gic_node(fdt: &mut Vec<u8>, gic_device: &Box<dyn GICDevice>) -> Result<()> {
+    let gic_reg_prop = generate_prop64(gic_device.device_properties());
+
+    append_begin_node(fdt, "intc")?;
+    append_property_string(fdt, "compatible", gic_device.fdt_compatibility())?;
+    append_property_null(fdt, "interrupt-controller")?;
+    // "interrupt-cells" field specifies the number of cells needed to encode an
+    // interrupt source. The type shall be a <u32> and the value shall be 3 if no PPI affinity description
+    // is required.
+    append_property_u32(fdt, "#interrupt-cells", 3)?;
+    append_property(fdt, "reg", &gic_reg_prop)?;
+    append_property_u32(fdt, "phandle", GIC_PHANDLE)?;
+    append_property_u32(fdt, "#address-cells", 2)?;
+    append_property_u32(fdt, "#size-cells", 2)?;
+    append_property_null(fdt, "ranges")?;
+    let gic_intr = [
+        GIC_FDT_IRQ_TYPE_PPI,
+        gic_device.fdt_maint_irq(),
+        IRQ_TYPE_LEVEL_HI,
+    ];
+    let gic_intr_prop = generate_prop32(&gic_intr);
+
+    append_property(fdt, "interrupts", &gic_intr_prop)?;
+    append_end_node(fdt)?;
+
+    Ok(())
+}
+
+fn create_clock_node(fdt: &mut Vec<u8>) -> Result<()> {
+    // The Advanced Peripheral Bus (APB) is part of the Advanced Microcontroller Bus Architecture
+    // (AMBA) protocol family. It defines a low-cost interface that is optimized for minimal power
+    // consumption and reduced interface complexity.
+    // PCLK is the clock source and this node defines exactly the clock for the APB.
+    append_begin_node(fdt, "apb-pclk")?;
+    append_property_string(fdt, "compatible", "fixed-clock")?;
+    append_property_u32(fdt, "#clock-cells", 0x0)?;
+    append_property_u32(fdt, "clock-frequency", 24000000)?;
+    append_property_string(fdt, "clock-output-names", "clk24mhz")?;
+    append_property_u32(fdt, "phandle", CLOCK_PHANDLE)?;
+    append_end_node(fdt)?;
+
+    Ok(())
+}
+
+fn create_timer_node(fdt: &mut Vec<u8>) -> Result<()> {
+    // See
+    // https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/interrupt-controller/arch_timer.txt
+    // These are fixed interrupt numbers for the timer device.
+    let irqs = [13, 14, 11, 10];
+    let compatible = "arm,armv8-timer";
+
+    let mut timer_reg_cells: Vec<u32> = Vec::new();
+    for &irq in irqs.iter() {
+        timer_reg_cells.push(GIC_FDT_IRQ_TYPE_PPI);
+        timer_reg_cells.push(irq);
+        timer_reg_cells.push(IRQ_TYPE_LEVEL_HI);
+    }
+    let timer_reg_prop = generate_prop32(timer_reg_cells.as_slice());
+
+    append_begin_node(fdt, "timer")?;
+    append_property_string(fdt, "compatible", compatible)?;
+    append_property_null(fdt, "always-on")?;
+    append_property(fdt, "interrupts", &timer_reg_prop)?;
+    append_end_node(fdt)?;
+
+    Ok(())
+}
+
+fn create_psci_node(fdt: &mut Vec<u8>) -> Result<()> {
+    let compatible = "arm,psci-0.2";
+    append_begin_node(fdt, "psci")?;
+    append_property_string(fdt, "compatible", compatible)?;
+    // Two methods available: hvc and smc.
+    // As per documentation, PSCI calls between a guest and hypervisor may use the HVC conduit instead of SMC.
+    // So, since we are using kvm, we need to use hvc.
+    append_property_string(fdt, "method", "hvc")?;
+    append_end_node(fdt)?;
+
+    Ok(())
+}
+
+fn create_virtio_node<T: DeviceInfoForFDT + Clone + Debug>(
+    fdt: &mut Vec<u8>,
+    dev_info: &T,
+) -> Result<()> {
+    let device_reg_prop = generate_prop64(&[dev_info.addr(), dev_info.length()]);
+    let irq = generate_prop32(&[GIC_FDT_IRQ_TYPE_SPI, dev_info.irq(), IRQ_TYPE_EDGE_RISING]);
+
+    append_begin_node(fdt, &format!("virtio_mmio@{:x}", dev_info.addr()))?;
+    append_property_string(fdt, "compatible", "virtio,mmio")?;
+    append_property(fdt, "reg", &device_reg_prop)?;
+    append_property(fdt, "interrupts", &irq)?;
+    append_property_u32(fdt, "interrupt-parent", GIC_PHANDLE)?;
+    append_end_node(fdt)?;
+
+    Ok(())
+}
+
+fn create_serial_node<T: DeviceInfoForFDT + Clone + Debug>(
+    fdt: &mut Vec<u8>,
+    dev_info: &T,
+) -> Result<()> {
+    let serial_reg_prop = generate_prop64(&[dev_info.addr(), dev_info.length()]);
+    let irq = generate_prop32(&[GIC_FDT_IRQ_TYPE_SPI, dev_info.irq(), IRQ_TYPE_EDGE_RISING]);
+
+    append_begin_node(fdt, &format!("uart@{:x}", dev_info.addr()))?;
+    append_property_string(fdt, "compatible", "ns16550a")?;
+    append_property(fdt, "reg", &serial_reg_prop)?;
+    append_property_u32(fdt, "clocks", CLOCK_PHANDLE)?;
+    append_property_string(fdt, "clock-names", "apb_pclk")?;
+    append_property(fdt, "interrupts", &irq)?;
+    append_end_node(fdt)?;
+
+    Ok(())
+}
+
+fn create_rtc_node<T: DeviceInfoForFDT + Clone + Debug>(
+    fdt: &mut Vec<u8>,
+    dev_info: &T,
+) -> Result<()> {
+    let compatible = b"arm,pl031\0arm,primecell\0";
+    let rtc_reg_prop = generate_prop64(&[dev_info.addr(), dev_info.length()]);
+    let irq = generate_prop32(&[GIC_FDT_IRQ_TYPE_SPI, dev_info.irq(), IRQ_TYPE_LEVEL_HI]);
+    append_begin_node(fdt, &format!("rtc@{:x}", dev_info.addr()))?;
+    append_property(fdt, "compatible", compatible)?;
+    append_property(fdt, "reg", &rtc_reg_prop)?;
+    append_property(fdt, "interrupts", &irq)?;
+    append_property_u32(fdt, "clocks", CLOCK_PHANDLE)?;
+    append_property_string(fdt, "clock-names", "apb_pclk")?;
+    append_end_node(fdt)?;
+
+    Ok(())
+}
+
+fn create_devices_node<T: DeviceInfoForFDT + Clone + Debug>(
+    fdt: &mut Vec<u8>,
+    dev_info: &HashMap<(DeviceType, String), T>,
+) -> Result<()> {
+    // Create one temp Vec to store all virtio devices
+    let mut ordered_virtio_device: Vec<&T> = Vec::new();
+
+    for ((device_type, _device_id), info) in dev_info {
+        match device_type {
+            DeviceType::RTC => create_rtc_node(fdt, info)?,
+            DeviceType::Serial => create_serial_node(fdt, info)?,
+            DeviceType::Virtio(_) => {
+                ordered_virtio_device.push(info);
+            }
+        }
+    }
+
+    // Sort out virtio devices by address from low to high and insert them into fdt table.
+    ordered_virtio_device.sort_by(|a, b| a.addr().cmp(&b.addr()));
+    for ordered_device_info in ordered_virtio_device.drain(..) {
+        create_virtio_node(fdt, ordered_device_info)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aarch64::gic::create_gic;
+    use crate::aarch64::layout;
+    use kvm_ioctls::Kvm;
+
+    const LEN: u64 = 4096;
+
+    #[derive(Clone, Debug)]
+    pub struct MMIODeviceInfo {
+        addr: u64,
+        irq: u32,
+    }
+
+    impl DeviceInfoForFDT for MMIODeviceInfo {
+        fn addr(&self) -> u64 {
+            self.addr
+        }
+        fn irq(&self) -> u32 {
+            self.irq
+        }
+        fn length(&self) -> u64 {
+            LEN
+        }
+    }
+
+    // The `load` function from the `device_tree` will mistakenly check the actual size
+    // of the buffer with the allocated size. This works around that.
+    fn set_size(buf: &mut [u8], pos: usize, val: usize) {
+        buf[pos] = ((val >> 24) & 0xff) as u8;
+        buf[pos + 1] = ((val >> 16) & 0xff) as u8;
+        buf[pos + 2] = ((val >> 8) & 0xff) as u8;
+        buf[pos + 3] = (val & 0xff) as u8;
+    }
+
+    #[test]
+    fn test_create_fdt_with_devices() {
+        let mut regions = Vec::new();
+        regions.push((
+            GuestAddress(layout::RAM_64BIT_START),
+            (layout::FDT_MAX_SIZE + 0x1000) as usize,
+        ));
+        let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
+
+        let dev_info: HashMap<(DeviceType, std::string::String), MMIODeviceInfo> = [
+            (
+                (DeviceType::Serial, DeviceType::Serial.to_string()),
+                MMIODeviceInfo { addr: 0x00, irq: 1 },
+            ),
+            (
+                (DeviceType::Virtio(1), "virtio".to_string()),
+                MMIODeviceInfo {
+                    addr: 0x00 + LEN,
+                    irq: 2,
+                },
+            ),
+            (
+                (DeviceType::RTC, "rtc".to_string()),
+                MMIODeviceInfo {
+                    addr: 0x00 + 2 * LEN,
+                    irq: 3,
+                },
+            ),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        let gic = create_gic(&vm, 1).unwrap();
+        assert!(create_fdt(
+            &mem,
+            &CString::new("console=tty0").unwrap(),
+            vec![0],
+            &dev_info,
+            &gic,
+            &None,
+        )
+        .is_ok())
+    }
+}

--- a/arch/src/aarch64/gic.rs
+++ b/arch/src/aarch64/gic.rs
@@ -1,0 +1,159 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{boxed::Box, result};
+
+use kvm_ioctls::{DeviceFd, VmFd};
+
+use super::gicv2::GICv2;
+use super::gicv3::GICv3;
+
+/// Errors thrown while setting up the GIC.
+#[derive(Debug)]
+pub enum Error {
+    /// Error while calling KVM ioctl for setting up the global interrupt controller.
+    CreateGIC(kvm_ioctls::Error),
+    /// Error while setting device attributes for the GIC.
+    SetDeviceAttribute(kvm_ioctls::Error),
+}
+type Result<T> = result::Result<T, Error>;
+
+/// Trait for GIC devices.
+pub trait GICDevice: Send + Sync {
+    /// Returns the file descriptor of the GIC device
+    fn device_fd(&self) -> &DeviceFd;
+
+    /// Returns an array with GIC device properties
+    fn device_properties(&self) -> &[u64];
+
+    /// Returns the number of vCPUs this GIC handles
+    fn vcpu_count(&self) -> u64;
+
+    /// Returns the fdt compatibility property of the device
+    fn fdt_compatibility(&self) -> &str;
+
+    /// Returns the maint_irq fdt property of the device
+    fn fdt_maint_irq(&self) -> u32;
+
+    /// Returns the GIC version of the device
+    fn version() -> u32
+    where
+        Self: Sized;
+
+    /// Create the GIC device object
+    fn create_device(fd: DeviceFd, vcpu_count: u64) -> Box<dyn GICDevice>
+    where
+        Self: Sized;
+
+    /// Setup the device-specific attributes
+    fn init_device_attributes(gic_device: &Box<dyn GICDevice>) -> Result<()>
+    where
+        Self: Sized;
+
+    /// Initialize a GIC device
+    fn init_device(vm: &VmFd) -> Result<DeviceFd>
+    where
+        Self: Sized,
+    {
+        let mut gic_device = kvm_bindings::kvm_create_device {
+            type_: Self::version(),
+            fd: 0,
+            flags: 0,
+        };
+
+        vm.create_device(&mut gic_device).map_err(Error::CreateGIC)
+    }
+
+    /// Set a GIC device attribute
+    fn set_device_attribute(
+        fd: &DeviceFd,
+        group: u32,
+        attr: u64,
+        addr: u64,
+        flags: u32,
+    ) -> Result<()>
+    where
+        Self: Sized,
+    {
+        let attr = kvm_bindings::kvm_device_attr {
+            group: group,
+            attr: attr,
+            addr: addr,
+            flags: flags,
+        };
+        fd.set_device_attr(&attr)
+            .map_err(Error::SetDeviceAttribute)?;
+
+        Ok(())
+    }
+
+    /// Finalize the setup of a GIC device
+    fn finalize_device(gic_device: &Box<dyn GICDevice>) -> Result<()>
+    where
+        Self: Sized,
+    {
+        /* We need to tell the kernel how many irqs to support with this vgic.
+         * See the `layout` module for details.
+         */
+        let nr_irqs: u32 = super::layout::IRQ_MAX - super::layout::IRQ_BASE + 1;
+        let nr_irqs_ptr = &nr_irqs as *const u32;
+        Self::set_device_attribute(
+            gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_NR_IRQS,
+            0,
+            nr_irqs_ptr as u64,
+            0,
+        )?;
+
+        /* Finalize the GIC.
+         * See https://code.woboq.org/linux/linux/virt/kvm/arm/vgic/vgic-kvm-device.c.html#211.
+         */
+        Self::set_device_attribute(
+            gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_CTRL,
+            u64::from(kvm_bindings::KVM_DEV_ARM_VGIC_CTRL_INIT),
+            0,
+            0,
+        )?;
+
+        Ok(())
+    }
+
+    /// Method to initialize the GIC device
+    fn new(vm: &VmFd, vcpu_count: u64) -> Result<Box<dyn GICDevice>>
+    where
+        Self: Sized,
+    {
+        let vgic_fd = Self::init_device(vm)?;
+
+        let device = Self::create_device(vgic_fd, vcpu_count);
+
+        Self::init_device_attributes(&device)?;
+
+        Self::finalize_device(&device)?;
+
+        Ok(device)
+    }
+}
+
+/// Create a GIC device.
+///
+/// It will try to create by default a GICv3 device. If that fails it will try
+/// to fall-back to a GICv2 device.
+pub fn create_gic(vm: &VmFd, vcpu_count: u64) -> Result<Box<dyn GICDevice>> {
+    GICv3::new(vm, vcpu_count).or_else(|_| GICv2::new(vm, vcpu_count))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use kvm_ioctls::Kvm;
+
+    #[test]
+    fn test_create_gic() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        assert!(create_gic(&vm, 1).is_ok());
+    }
+}

--- a/arch/src/aarch64/gicv2.rs
+++ b/arch/src/aarch64/gicv2.rs
@@ -1,0 +1,114 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{boxed::Box, result};
+
+use kvm_ioctls::DeviceFd;
+
+use super::gic::{Error, GICDevice};
+
+type Result<T> = result::Result<T, Error>;
+
+/// Represent a GIC v2 device
+pub struct GICv2 {
+    /// The file descriptor for the KVM device
+    fd: DeviceFd,
+
+    /// GIC device properties, to be used for setting up the fdt entry
+    properties: [u64; 4],
+
+    /// Number of CPUs handled by the device
+    vcpu_count: u64,
+}
+
+impl GICv2 {
+    // Unfortunately bindgen omits defines that are based on other defines.
+    // See arch/arm64/include/uapi/asm/kvm.h file from the linux kernel.
+    const KVM_VGIC_V2_DIST_SIZE: u64 = 0x1000;
+    const KVM_VGIC_V2_CPU_SIZE: u64 = 0x2000;
+
+    // Device trees specific constants
+    const ARCH_GIC_V2_MAINT_IRQ: u32 = 8;
+
+    /// Get the address of the GICv2 distributor.
+    const fn get_dist_addr() -> u64 {
+        super::layout::MAPPED_IO_START - GICv2::KVM_VGIC_V2_DIST_SIZE
+    }
+
+    /// Get the size of the GIC_v2 distributor.
+    const fn get_dist_size() -> u64 {
+        GICv2::KVM_VGIC_V2_DIST_SIZE
+    }
+
+    /// Get the address of the GIC_v2 CPU.
+    const fn get_cpu_addr() -> u64 {
+        GICv2::get_dist_addr() - GICv2::KVM_VGIC_V2_CPU_SIZE
+    }
+
+    /// Get the size of the GIC_v2 CPU.
+    const fn get_cpu_size() -> u64 {
+        GICv2::KVM_VGIC_V2_CPU_SIZE
+    }
+}
+
+impl GICDevice for GICv2 {
+    fn version() -> u32 {
+        kvm_bindings::kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V2
+    }
+
+    fn device_fd(&self) -> &DeviceFd {
+        &self.fd
+    }
+
+    fn device_properties(&self) -> &[u64] {
+        &self.properties
+    }
+
+    fn vcpu_count(&self) -> u64 {
+        self.vcpu_count
+    }
+
+    fn fdt_compatibility(&self) -> &str {
+        "arm,gic-400"
+    }
+
+    fn fdt_maint_irq(&self) -> u32 {
+        GICv2::ARCH_GIC_V2_MAINT_IRQ
+    }
+
+    fn create_device(fd: DeviceFd, vcpu_count: u64) -> Box<dyn GICDevice> {
+        Box::new(GICv2 {
+            fd: fd,
+            properties: [
+                GICv2::get_dist_addr(),
+                GICv2::get_dist_size(),
+                GICv2::get_cpu_addr(),
+                GICv2::get_cpu_size(),
+            ],
+            vcpu_count: vcpu_count,
+        })
+    }
+
+    fn init_device_attributes(gic_device: &Box<dyn GICDevice>) -> Result<()> {
+        /* Setting up the distributor attribute.
+        We are placing the GIC below 1GB so we need to substract the size of the distributor. */
+        Self::set_device_attribute(
+            &gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_VGIC_V2_ADDR_TYPE_DIST),
+            &GICv2::get_dist_addr() as *const u64 as u64,
+            0,
+        )?;
+
+        /* Setting up the CPU attribute. */
+        Self::set_device_attribute(
+            &gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_VGIC_V2_ADDR_TYPE_CPU),
+            &GICv2::get_cpu_addr() as *const u64 as u64,
+            0,
+        )?;
+
+        Ok(())
+    }
+}

--- a/arch/src/aarch64/gicv3.rs
+++ b/arch/src/aarch64/gicv3.rs
@@ -1,0 +1,117 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{boxed::Box, result};
+
+use kvm_ioctls::DeviceFd;
+
+use super::gic::{Error, GICDevice};
+
+type Result<T> = result::Result<T, Error>;
+
+pub struct GICv3 {
+    /// The file descriptor for the KVM device
+    fd: DeviceFd,
+
+    /// GIC device properties, to be used for setting up the fdt entry
+    properties: [u64; 4],
+
+    /// Number of CPUs handled by the device
+    vcpu_count: u64,
+}
+
+impl GICv3 {
+    // Unfortunately bindgen omits defines that are based on other defines.
+    // See arch/arm64/include/uapi/asm/kvm.h file from the linux kernel.
+    const SZ_64K: u64 = 0x0001_0000;
+    const KVM_VGIC_V3_DIST_SIZE: u64 = GICv3::SZ_64K;
+    const KVM_VGIC_V3_REDIST_SIZE: u64 = (2 * GICv3::SZ_64K);
+
+    // Device trees specific constants
+    const ARCH_GIC_V3_MAINT_IRQ: u32 = 9;
+
+    /// Get the address of the GIC distributor.
+    fn get_dist_addr() -> u64 {
+        super::layout::MAPPED_IO_START - GICv3::KVM_VGIC_V3_DIST_SIZE
+    }
+
+    /// Get the size of the GIC distributor.
+    fn get_dist_size() -> u64 {
+        GICv3::KVM_VGIC_V3_DIST_SIZE
+    }
+
+    /// Get the address of the GIC redistributors.
+    fn get_redists_addr(vcpu_count: u64) -> u64 {
+        GICv3::get_dist_addr() - GICv3::get_redists_size(vcpu_count)
+    }
+
+    /// Get the size of the GIC redistributors.
+    fn get_redists_size(vcpu_count: u64) -> u64 {
+        vcpu_count * GICv3::KVM_VGIC_V3_REDIST_SIZE
+    }
+}
+
+impl GICDevice for GICv3 {
+    fn version() -> u32 {
+        kvm_bindings::kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3
+    }
+
+    fn device_fd(&self) -> &DeviceFd {
+        &self.fd
+    }
+
+    fn device_properties(&self) -> &[u64] {
+        &self.properties
+    }
+
+    fn vcpu_count(&self) -> u64 {
+        self.vcpu_count
+    }
+
+    fn fdt_compatibility(&self) -> &str {
+        "arm,gic-v3"
+    }
+
+    fn fdt_maint_irq(&self) -> u32 {
+        GICv3::ARCH_GIC_V3_MAINT_IRQ
+    }
+
+    fn create_device(fd: DeviceFd, vcpu_count: u64) -> Box<dyn GICDevice> {
+        Box::new(GICv3 {
+            fd: fd,
+            properties: [
+                GICv3::get_dist_addr(),
+                GICv3::get_dist_size(),
+                GICv3::get_redists_addr(vcpu_count),
+                GICv3::get_redists_size(vcpu_count),
+            ],
+            vcpu_count: vcpu_count,
+        })
+    }
+
+    fn init_device_attributes(gic_device: &Box<dyn GICDevice>) -> Result<()> {
+        /* Setting up the distributor attribute.
+         We are placing the GIC below 1GB so we need to substract the size of the distributor.
+        */
+        Self::set_device_attribute(
+            &gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_VGIC_V3_ADDR_TYPE_DIST),
+            &GICv3::get_dist_addr() as *const u64 as u64,
+            0,
+        )?;
+
+        /* Setting up the redistributors' attribute.
+        We are calculating here the start of the redistributors address. We have one per CPU.
+        */
+        Self::set_device_attribute(
+            &gic_device.device_fd(),
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_VGIC_V3_ADDR_TYPE_REDIST),
+            &GICv3::get_redists_addr(u64::from(gic_device.vcpu_count())) as *const u64 as u64,
+            0,
+        )?;
+
+        Ok(())
+    }
+}

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -1,7 +1,86 @@
+// Copyright 2020 Arm Limited (or its affiliates). All rights reserved.
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Kernel command line start address.
-pub const CMDLINE_START: usize = 0x0;
-/// Kernel command line start address maximum size.
-pub const CMDLINE_MAX_SIZE: usize = 0x0;
+//
+// Memory layout of Aarch64 guest:
+//
+// Physical  +---------------------------------------------------------------+
+// address   |                                                               |
+// end       |                                                               |
+//           ~                   ~                       ~                   ~
+//           |                                                               |
+//           |                      Highmem PCI MMIO space                   |
+//           |                                                               |
+// RAM end   +---------------------------------------------------------------+
+// (dynamic, |                                                               |
+// including |                                                               |
+// hotplug   ~                   ~                       ~                   ~
+// memory)   |                                                               |
+//           |                            DRAM                               |
+//           |                                                               |
+// 2GB       +---------------------------------------------------------------+
+//           |                                                               |
+//           |                           Reserved                            |
+//           |                                                               |
+// 1G+256M   +---------------------------------------------------------------+
+//           |                                                               |
+//           |                        PCI MMCONFIG space                     |
+//           |                                                               |
+// 1GB       +---------------------------------------------------------------+
+//           |                                                               |
+//           |                           PCI MMIO space                      |
+//           |                                                               |
+// 256 M     +---------------------------------------------------------------|
+//           |                                                               |
+//           |                        Legacy devices space                   |
+//           |                                                               |
+// 144 M     +---------------------------------------------------------------|
+//           |                                                               |
+//           |                    Reserverd (now GIC is here)                |
+//           |                                                               |
+// 0GB       +---------------------------------------------------------------+
+//
+//
+
+use vm_memory::{GuestAddress, GuestUsize};
+
+/// Below this address will reside the GIC, above this address will reside the MMIO devices.
+pub const MAPPED_IO_START: u64 = 0x0900_0000;
+
+/// Space 0x0900_0000 ~ 0x1000_0000 is reserved for legacy devices.
+pub const LEGACY_SERIAL_MAPPED_IO_START: u64 = 0x0900_0000;
+pub const LEGACY_RTC_MAPPED_IO_START: u64 = 0x0901_0000;
+
+/// Legacy space will be allocated at once whiling setting up legacy devices.
+pub const LEGACY_DEVICES_MAPPED_IO_SIZE: u64 = 0x0700_0000;
+
+/// Starting from 0x1000_0000 (256MiB), the 768MiB (ends at 1 GiB) is used for PCIE MMIO
+pub const PCI_DEVICES_MAPPED_IO_START: u64 = 0x1000_0000;
+pub const PCI_DEVICES_MAPPED_IO_SIZE: u64 = 0x3000_0000;
+
+/// PCI MMCONFIG space (start: after the device space at 1 GiB, length: 256MiB)
+pub const PCI_MMCONFIG_START: GuestAddress = GuestAddress(0x4000_0000);
+pub const PCI_MMCONFIG_SIZE: GuestUsize = 256 << 20;
+
+/// Start of RAM on 64 bit ARM.
+pub const RAM_64BIT_START: u64 = 0x8000_0000;
+
+/// Kernel command line maximum size.
+/// As per `arch/arm64/include/uapi/asm/setup.h`.
+pub const CMDLINE_MAX_SIZE: usize = 2048;
+
+/// Maximum size of the device tree blob as specified in https://www.kernel.org/doc/Documentation/arm64/booting.txt.
+pub const FDT_MAX_SIZE: usize = 0x20_0000;
+
+// As per virt/kvm/arm/vgic/vgic-kvm-device.c we need
+// the number of interrupts our GIC will support to be:
+// * bigger than 32
+// * less than 1023 and
+// * a multiple of 32.
+// We are setting up our interrupt controller to support a maximum of 128 interrupts.
+/// First usable interrupt on aarch64.
+pub const IRQ_BASE: u32 = 32;
+
+/// Last usable interrupt on aarch64.
+pub const IRQ_MAX: u32 = 159;

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -1,6 +1,9 @@
+// Copyright 2020 Arm Limited (or its affiliates). All rights reserved.
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Module for the flattened device tree.
+pub mod fdt;
 /// Module for the global interrupt controller configuration.
 pub mod gic;
 mod gicv2;
@@ -11,25 +14,14 @@ pub mod layout;
 pub mod regs;
 
 use crate::RegionType;
+use aarch64::gic::GICDevice;
 use kvm_ioctls::*;
+use std::collections::HashMap;
+use std::ffi::CStr;
 use std::fmt::Debug;
 use vm_memory::{
     Address, GuestAddress, GuestMemory, GuestMemoryAtomic, GuestMemoryMmap, GuestUsize,
 };
-
-#[derive(Debug)]
-pub enum Error {}
-
-impl From<Error> for super::Error {
-    fn from(e: Error) -> super::Error {
-        super::Error::AArch64Setup(e)
-    }
-}
-
-/// Stub function that needs to be implemented when aarch64 functionality is added.
-pub fn arch_memory_regions(size: GuestUsize) -> Vec<(GuestAddress, usize, RegionType)> {
-    vec![(GuestAddress(0), size as usize, RegionType::Ram)]
-}
 
 #[derive(Debug, Copy, Clone)]
 /// Specifies the entry point address where the guest must start
@@ -48,20 +40,88 @@ pub fn configure_vcpu(
     unimplemented!();
 }
 
-/// Stub function that needs to be implemented when aarch64 functionality is added.
-pub fn configure_system(
-    _guest_mem: &GuestMemoryMmap,
-    _cmdline_addr: GuestAddress,
-    _cmdline_size: usize,
-    _num_cpus: u8,
-    _rsdp_addr: Option<GuestAddress>,
+/// Errors thrown while configuring aarch64 system.
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to create a Flattened Device Tree for this aarch64 VM.
+    SetupFDT(fdt::Error),
+    /// Failed to compute the initrd address.
+    InitrdAddress,
+}
+
+impl From<Error> for super::Error {
+    fn from(e: Error) -> super::Error {
+        super::Error::AArch64Setup(e)
+    }
+}
+
+pub use self::fdt::DeviceInfoForFDT;
+use crate::DeviceType;
+
+pub fn arch_memory_regions(size: GuestUsize) -> Vec<(GuestAddress, usize, RegionType)> {
+    let mut regions = Vec::new();
+    // 0 ~ 256 MiB: Reserved
+    regions.push((
+        GuestAddress(0),
+        layout::PCI_DEVICES_MAPPED_IO_START as usize,
+        RegionType::Reserved,
+    ));
+
+    // 256 MiB ~ 1 G: MMIO space
+    regions.push((
+        GuestAddress(layout::PCI_DEVICES_MAPPED_IO_START),
+        layout::PCI_DEVICES_MAPPED_IO_SIZE as usize,
+        RegionType::SubRegion,
+    ));
+
+    // 1G  ~ 2G: reserved. The leading 256M for PCIe MMCONFIG space
+    regions.push((
+        layout::PCI_MMCONFIG_START,
+        (layout::RAM_64BIT_START - layout::PCI_MMCONFIG_START.0) as usize,
+        RegionType::Reserved,
+    ));
+
+    regions.push((
+        GuestAddress(layout::RAM_64BIT_START),
+        size as usize,
+        RegionType::Ram,
+    ));
+
+    regions
+}
+
+/// Configures the system and should be called once per vm before starting vcpu threads.
+///
+/// # Arguments
+///
+/// * `guest_mem` - The memory to be used by the guest.
+/// * `num_cpus` - Number of virtual CPUs the guest will have.
+#[allow(clippy::too_many_arguments)]
+#[allow(unused_variables)]
+pub fn configure_system<T: DeviceInfoForFDT + Clone + Debug>(
+    guest_mem: &GuestMemoryMmap,
+    cmdline_cstring: &CStr,
+    vcpu_mpidr: Vec<u64>,
+    device_info: &HashMap<(DeviceType, String), T>,
+    gic_device: &Box<dyn GICDevice>,
+    initrd: &Option<super::InitrdConfig>,
 ) -> super::Result<()> {
+    let dtb = fdt::create_fdt(
+        guest_mem,
+        cmdline_cstring,
+        vcpu_mpidr,
+        device_info,
+        gic_device,
+        initrd,
+    )
+    .map_err(Error::SetupFDT)?;
+
     Ok(())
 }
 
-/// Stub function that needs to be implemented when aarch64 functionality is added.
-pub fn get_reserved_mem_addr() -> usize {
-    0
+/// Returns the memory address where the kernel could be loaded.
+pub fn get_kernel_start() -> u64 {
+    layout::RAM_64BIT_START
 }
 
 // Auxiliary function to get the address where the device tree blob is loaded.
@@ -103,4 +163,47 @@ pub fn check_required_kvm_extensions(kvm: &Kvm) -> super::Result<()> {
         return Err(super::Error::CapabilityMissing(Cap::SignalMsi));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_arch_memory_regions_dram() {
+        let regions = arch_memory_regions((1usize << 32) as u64); //4GB
+        assert_eq!(4, regions.len());
+        assert_eq!(GuestAddress(layout::RAM_64BIT_START), regions[3].0);
+        assert_eq!(1usize << 32, regions[3].1);
+        assert_eq!(RegionType::Ram, regions[3].2);
+    }
+
+    #[test]
+    fn test_get_fdt_addr() {
+        let mut regions = Vec::new();
+
+        regions.push((
+            GuestAddress(layout::RAM_64BIT_START),
+            (layout::FDT_MAX_SIZE - 0x1000) as usize,
+        ));
+        let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
+        assert_eq!(get_fdt_addr(&mem), layout::RAM_64BIT_START);
+        regions.clear();
+
+        regions.push((
+            GuestAddress(layout::RAM_64BIT_START),
+            (layout::FDT_MAX_SIZE) as usize,
+        ));
+        let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
+        assert_eq!(get_fdt_addr(&mem), layout::RAM_64BIT_START);
+        regions.clear();
+
+        regions.push((
+            GuestAddress(layout::RAM_64BIT_START),
+            (layout::FDT_MAX_SIZE + 0x1000) as usize,
+        ));
+        let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
+        assert_eq!(get_fdt_addr(&mem), 0x1000 + layout::RAM_64BIT_START);
+        regions.clear();
+    }
 }

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -1,6 +1,11 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Module for the global interrupt controller configuration.
+pub mod gic;
+mod gicv2;
+mod gicv3;
+/// Layout for this aarch64 system.
 pub mod layout;
 
 use crate::RegionType;

--- a/arch/src/aarch64/regs.rs
+++ b/arch/src/aarch64/regs.rs
@@ -1,0 +1,198 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+use std::{mem, result};
+
+use super::get_fdt_addr;
+use kvm_bindings::{
+    user_pt_regs, KVM_REG_ARM64, KVM_REG_ARM64_SYSREG, KVM_REG_ARM64_SYSREG_CRM_MASK,
+    KVM_REG_ARM64_SYSREG_CRM_SHIFT, KVM_REG_ARM64_SYSREG_CRN_MASK, KVM_REG_ARM64_SYSREG_CRN_SHIFT,
+    KVM_REG_ARM64_SYSREG_OP0_MASK, KVM_REG_ARM64_SYSREG_OP0_SHIFT, KVM_REG_ARM64_SYSREG_OP1_MASK,
+    KVM_REG_ARM64_SYSREG_OP1_SHIFT, KVM_REG_ARM64_SYSREG_OP2_MASK, KVM_REG_ARM64_SYSREG_OP2_SHIFT,
+    KVM_REG_ARM_CORE, KVM_REG_SIZE_U64,
+};
+use kvm_ioctls::VcpuFd;
+
+use vm_memory::GuestMemoryMmap;
+
+/// Errors thrown while setting aarch64 registers.
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to set core register (PC, PSTATE or general purpose ones).
+    SetCoreRegister(kvm_ioctls::Error),
+    /// Failed to get a system register.
+    GetSysRegister(kvm_ioctls::Error),
+}
+type Result<T> = result::Result<T, Error>;
+
+#[allow(non_upper_case_globals)]
+// PSR (Processor State Register) bits.
+// Taken from arch/arm64/include/uapi/asm/ptrace.h.
+const PSR_MODE_EL1h: u64 = 0x0000_0005;
+const PSR_F_BIT: u64 = 0x0000_0040;
+const PSR_I_BIT: u64 = 0x0000_0080;
+const PSR_A_BIT: u64 = 0x0000_0100;
+const PSR_D_BIT: u64 = 0x0000_0200;
+// Taken from arch/arm64/kvm/inject_fault.c.
+const PSTATE_FAULT_BITS_64: u64 = PSR_MODE_EL1h | PSR_A_BIT | PSR_F_BIT | PSR_I_BIT | PSR_D_BIT;
+
+// Following are macros that help with getting the ID of a aarch64 core register.
+// The core register are represented by the user_pt_regs structure. Look for it in
+// arch/arm64/include/uapi/asm/ptrace.h.
+
+// This macro gets the offset of a structure (i.e `str`) member (i.e `field`) without having
+// an instance of that structure.
+// It uses a null pointer to retrieve the offset to the field.
+// Inspired by C solution: `#define offsetof(str, f) ((size_t)(&((str *)0)->f))`.
+// Doing `offset__of!(user_pt_regs, pstate)` in our rust code will trigger the following:
+// unsafe { &(*(0 as *const user_pt_regs)).pstate as *const _ as usize }
+// The dereference expression produces an lvalue, but that lvalue is not actually read from,
+// we're just doing pointer math on it, so in theory, it should safe.
+macro_rules! offset__of {
+    ($str:ty, $field:ident) => {
+        unsafe { &(*(0 as *const $str)).$field as *const _ as usize }
+    };
+}
+
+macro_rules! arm64_core_reg {
+    ($reg: tt) => {
+        // As per `kvm_arm_copy_reg_indices`, the id of a core register can be obtained like this:
+        // `const u64 core_reg = KVM_REG_ARM64 | KVM_REG_SIZE_U64 | KVM_REG_ARM_CORE | i`, where i is obtained with:
+        // `for (i = 0; i < sizeof(struct kvm_regs) / sizeof(__u32); i++) {`
+        // We are using here `user_pt_regs` since this structure contains the core register and it is at
+        // the start of `kvm_regs`.
+        // struct kvm_regs {
+        //	struct user_pt_regs regs;	/* sp = sp_el0 */
+        //
+        //	__u64	sp_el1;
+        //	__u64	elr_el1;
+        //
+        //	__u64	spsr[KVM_NR_SPSR];
+        //
+        //	struct user_fpsimd_state fp_regs;
+        //};
+        // struct user_pt_regs {
+        //	__u64		regs[31];
+        //	__u64		sp;
+        //	__u64		pc;
+        //	__u64		pstate;
+        //};
+        // In our implementation we need: pc, pstate and user_pt_regs->regs[0].
+        KVM_REG_ARM64 as u64
+            | KVM_REG_SIZE_U64 as u64
+            | u64::from(KVM_REG_ARM_CORE)
+            | ((offset__of!(user_pt_regs, $reg) / mem::size_of::<u32>()) as u64)
+    };
+}
+
+// This macro computes the ID of a specific ARM64 system register similar to how
+// the kernel C macro does.
+// https://elixir.bootlin.com/linux/v4.20.17/source/arch/arm64/include/uapi/asm/kvm.h#L203
+macro_rules! arm64_sys_reg {
+    ($name: tt, $op0: tt, $op1: tt, $crn: tt, $crm: tt, $op2: tt) => {
+        const $name: u64 = KVM_REG_ARM64 as u64
+            | KVM_REG_SIZE_U64 as u64
+            | KVM_REG_ARM64_SYSREG as u64
+            | ((($op0 as u64) << KVM_REG_ARM64_SYSREG_OP0_SHIFT)
+                & KVM_REG_ARM64_SYSREG_OP0_MASK as u64)
+            | ((($op1 as u64) << KVM_REG_ARM64_SYSREG_OP1_SHIFT)
+                & KVM_REG_ARM64_SYSREG_OP1_MASK as u64)
+            | ((($crn as u64) << KVM_REG_ARM64_SYSREG_CRN_SHIFT)
+                & KVM_REG_ARM64_SYSREG_CRN_MASK as u64)
+            | ((($crm as u64) << KVM_REG_ARM64_SYSREG_CRM_SHIFT)
+                & KVM_REG_ARM64_SYSREG_CRM_MASK as u64)
+            | ((($op2 as u64) << KVM_REG_ARM64_SYSREG_OP2_SHIFT)
+                & KVM_REG_ARM64_SYSREG_OP2_MASK as u64);
+    };
+}
+
+// Constant imported from the Linux kernel:
+// https://elixir.bootlin.com/linux/v4.20.17/source/arch/arm64/include/asm/sysreg.h#L135
+arm64_sys_reg!(MPIDR_EL1, 3, 0, 0, 0, 5);
+
+/// Configure core registers for a given CPU.
+///
+/// # Arguments
+///
+/// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
+/// * `cpu_id` - Index of current vcpu.
+/// * `boot_ip` - Starting instruction pointer.
+/// * `mem` - Reserved DRAM for current VM.
+pub fn setup_regs(vcpu: &VcpuFd, cpu_id: u8, boot_ip: u64, mem: &GuestMemoryMmap) -> Result<()> {
+    // Get the register index of the PSTATE (Processor State) register.
+    vcpu.set_one_reg(arm64_core_reg!(pstate), PSTATE_FAULT_BITS_64)
+        .map_err(Error::SetCoreRegister)?;
+
+    // Other vCPUs are powered off initially awaiting PSCI wakeup.
+    if cpu_id == 0 {
+        // Setting the PC (Processor Counter) to the current program address (kernel address).
+        vcpu.set_one_reg(arm64_core_reg!(pc), boot_ip)
+            .map_err(Error::SetCoreRegister)?;
+
+        // Last mandatory thing to set -> the address pointing to the FDT (also called DTB).
+        // "The device tree blob (dtb) must be placed on an 8-byte boundary and must
+        // not exceed 2 megabytes in size." -> https://www.kernel.org/doc/Documentation/arm64/booting.txt.
+        // We are choosing to place it the end of DRAM. See `get_fdt_addr`.
+        vcpu.set_one_reg(arm64_core_reg!(regs), get_fdt_addr(mem) as u64)
+            .map_err(Error::SetCoreRegister)?;
+    }
+    Ok(())
+}
+
+/// Read the MPIDR - Multiprocessor Affinity Register.
+///
+/// # Arguments
+///
+/// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
+pub fn read_mpidr(vcpu: &VcpuFd) -> Result<u64> {
+    vcpu.get_one_reg(MPIDR_EL1).map_err(Error::GetSysRegister)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aarch64::layout;
+    use kvm_ioctls::Kvm;
+    use vm_memory::{GuestAddress, GuestMemoryMmap};
+
+    #[test]
+    fn test_setup_regs() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+        let mut regions = Vec::new();
+        regions.push((
+            GuestAddress(layout::RAM_64BIT_START),
+            (layout::FDT_MAX_SIZE + 0x1000) as usize,
+        ));
+        let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
+
+        match setup_regs(&vcpu, 0, 0x0, &mem).unwrap_err() {
+            Error::SetCoreRegister(ref e) => assert_eq!(e.errno(), libc::ENOEXEC),
+            _ => panic!("Expected to receive Error::SetCoreRegister"),
+        }
+        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        vm.get_preferred_target(&mut kvi).unwrap();
+        vcpu.vcpu_init(&kvi).unwrap();
+
+        assert!(setup_regs(&vcpu, 0, 0x0, &mem).is_ok());
+    }
+    #[test]
+    fn test_read_mpidr() {
+        let kvm = Kvm::new().unwrap();
+        let vm = kvm.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        vm.get_preferred_target(&mut kvi).unwrap();
+
+        // Must fail when vcpu is not initialized yet.
+        assert!(read_mpidr(&vcpu).is_err());
+
+        vcpu.vcpu_init(&kvi).unwrap();
+        assert_eq!(read_mpidr(&vcpu).unwrap(), 0x80000000);
+    }
+}

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -1,3 +1,4 @@
+// Copyright 2020 Arm Limited (or its affiliates). All rights reserved.
 // Copyright © 2020, Oracle and/or its affiliates.
 //
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -80,8 +81,8 @@ pub mod aarch64;
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
     arch_memory_regions, check_required_kvm_extensions, configure_system, configure_vcpu,
-    get_host_cpu_phys_bits, get_reserved_mem_addr, layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START,
-    EntryPoint,
+    get_host_cpu_phys_bits, get_reserved_mem_addr, layout, layout::CMDLINE_MAX_SIZE,
+    layout::IRQ_BASE, layout::IRQ_MAX, EntryPoint,
 };
 
 #[cfg(target_arch = "x86_64")]

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -4,6 +4,8 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Implements platform specific functionality.
+//! Supported platforms: x86_64, aarch64.
 #![allow(
     clippy::unreadable_literal,
     clippy::redundant_static_lifetimes,
@@ -14,18 +16,21 @@
 
 extern crate byteorder;
 extern crate kvm_bindings;
+extern crate kvm_ioctls;
 extern crate libc;
+
+extern crate vm_memory;
 
 #[cfg(feature = "acpi")]
 extern crate acpi_tables;
 extern crate arch_gen;
-extern crate kvm_ioctls;
 extern crate linux_loader;
-extern crate vm_memory;
 
 use kvm_ioctls::*;
+use std::fmt;
 use std::result;
 
+/// Type for returning error code.
 #[derive(Debug)]
 pub enum Error {
     #[cfg(target_arch = "x86_64")]
@@ -55,9 +60,12 @@ pub enum Error {
     /// Capability missing
     CapabilityMissing(Cap),
 }
+
+/// Type for returning public functions outcome.
 pub type Result<T> = result::Result<T, Error>;
 
-#[derive(PartialEq)]
+/// Type for memory region types.
+#[derive(PartialEq, Debug)]
 pub enum RegionType {
     /// RAM type
     Ram,
@@ -75,14 +83,15 @@ pub enum RegionType {
     Reserved,
 }
 
+/// Module for aarch64 related functionality.
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64;
 
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
     arch_memory_regions, check_required_kvm_extensions, configure_system, configure_vcpu,
-    get_host_cpu_phys_bits, get_reserved_mem_addr, layout, layout::CMDLINE_MAX_SIZE,
-    layout::IRQ_BASE, layout::IRQ_MAX, EntryPoint,
+    fdt::DeviceInfoForFDT, get_host_cpu_phys_bits, get_kernel_start, layout,
+    layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, layout::IRQ_MAX, EntryPoint,
 };
 
 #[cfg(target_arch = "x86_64")]
@@ -109,4 +118,55 @@ pub struct InitramfsConfig {
     pub address: vm_memory::GuestAddress,
     /// Size of initramfs in guest memory
     pub size: usize,
+}
+
+/// Types of devices that can get attached to this platform.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Copy)]
+pub enum DeviceType {
+    /// Device Type: Virtio.
+    Virtio(u32),
+    /// Device Type: Serial.
+    #[cfg(target_arch = "aarch64")]
+    Serial,
+    /// Device Type: RTC.
+    #[cfg(target_arch = "aarch64")]
+    RTC,
+}
+
+/// Type for passing information about the initrd in the guest memory.
+pub struct InitrdConfig {
+    /// Load address of initrd in guest memory
+    pub address: vm_memory::GuestAddress,
+    /// Size of initrd in guest memory
+    pub size: usize,
+}
+
+/// Default (smallest) memory page size for the supported architectures.
+pub const PAGE_SIZE: usize = 4096;
+
+impl fmt::Display for DeviceType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Structure to describe MMIO device information
+#[derive(Clone, Debug)]
+#[cfg(target_arch = "aarch64")]
+pub struct MMIODeviceInfo {
+    pub addr: u64,
+    pub irq: u32,
+}
+
+#[cfg(target_arch = "aarch64")]
+impl DeviceInfoForFDT for MMIODeviceInfo {
+    fn addr(&self) -> u64 {
+        self.addr
+    }
+    fn irq(&self) -> u32 {
+        self.irq
+    }
+    fn length(&self) -> u64 {
+        4096 as u64
+    }
 }


### PR DESCRIPTION
This PR adds the AArch64 arch-related files for the Cloud-Hypervisor AArch64 enabling, including:

- AArch64 memory layout 
- Ported Firecracker AArch64 files with some modifications
- libfdt dependancy for cross-building in the Github action

The commits in this PR are splited from #1126.

Signed-off-by: Henry Wang <<Henry.Wang@arm.com>>