### PR TITLE
Refactor IOAPIC

### DIFF
--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -1,0 +1,85 @@
+// Copyright 2020, ARM Limited.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+use super::interrupt_controller::{Error, InterruptController};
+use std::result;
+use std::sync::Arc;
+use vm_device::interrupt::{
+    InterruptIndex, InterruptManager, InterruptSourceGroup, MsiIrqGroupConfig,
+};
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
+
+type Result<T> = result::Result<T, Error>;
+
+// Reserve 32 IRQs (GSI 32 ~ 64) for legacy device.
+// GsiAllocator should allocate beyond this: from 64 on
+pub const IRQ_LEGACY_COUNT: usize = 32;
+pub const IRQ_SPI_OFFSET: usize = 32;
+
+// This Gic struct implements InterruptController to provide interrupt delivery service.
+// The Gic source files in arch/ folder maintain the Aarch64 specific Gic device.
+// The 2 Gic instances could be merged together.
+// Leave this refactoring to future. Two options may be considered:
+//   1. Move Gic*.rs from arch/ folder here.
+//   2. Move this file and ioapic.rs to arch/, as they are architecture specific.
+pub struct Gic {
+    interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+}
+
+impl Gic {
+    pub fn new(
+        _vcpu_count: u8,
+        interrupt_manager: Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>>,
+    ) -> Result<Gic> {
+        let interrupt_source_group = interrupt_manager
+            .create_group(MsiIrqGroupConfig {
+                base: IRQ_SPI_OFFSET as InterruptIndex,
+                count: IRQ_LEGACY_COUNT as InterruptIndex,
+            })
+            .map_err(Error::CreateInterruptSourceGroup)?;
+
+        Ok(Gic {
+            interrupt_source_group,
+        })
+    }
+}
+
+impl InterruptController for Gic {
+    fn enable(&self) -> Result<()> {
+        &self
+            .interrupt_source_group
+            .enable()
+            .map_err(Error::EnableInterrupt)?;
+        Ok(())
+    }
+
+    // This should be called anytime an interrupt needs to be injected into the
+    // running guest.
+    fn service_irq(&mut self, irq: usize) -> Result<()> {
+        self.interrupt_source_group
+            .trigger(irq as InterruptIndex)
+            .map_err(Error::TriggerInterrupt)?;
+
+        Ok(())
+    }
+}
+
+const GIC_SNAPSHOT_ID: &str = "gic";
+impl Snapshottable for Gic {
+    fn id(&self) -> String {
+        GIC_SNAPSHOT_ID.to_string()
+    }
+
+    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+        unimplemented!();
+    }
+
+    fn restore(&mut self, _snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
+        unimplemented!();
+    }
+}
+
+impl Pausable for Gic {}
+impl Transportable for Gic {}
+impl Migratable for Gic {}

--- a/devices/src/interrupt_controller.rs
+++ b/devices/src/interrupt_controller.rs
@@ -54,5 +54,8 @@ pub struct MsiMessage {
 // IOAPIC (X86) or GIC (Arm).
 pub trait InterruptController: Send {
     fn service_irq(&mut self, irq: usize) -> Result<()>;
+    #[cfg(target_arch = "aarch64")]
+    fn enable(&self) -> Result<()>;
+    #[cfg(target_arch = "x86_64")]
     fn end_of_interrupt(&mut self, vec: u8);
 }

--- a/devices/src/interrupt_controller.rs
+++ b/devices/src/interrupt_controller.rs
@@ -1,0 +1,58 @@
+// Copyright 2020, ARM Limited.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+use std::io;
+use std::result;
+
+#[derive(Debug)]
+pub enum Error {
+    /// Invalid destination mode.
+    InvalidDestinationMode,
+    /// Invalid trigger mode.
+    InvalidTriggerMode,
+    /// Invalid delivery mode.
+    InvalidDeliveryMode,
+    /// Failed creating the interrupt source group.
+    CreateInterruptSourceGroup(io::Error),
+    /// Failed triggering the interrupt.
+    TriggerInterrupt(io::Error),
+    /// Failed masking the interrupt.
+    MaskInterrupt(io::Error),
+    /// Failed unmasking the interrupt.
+    UnmaskInterrupt(io::Error),
+    /// Failed updating the interrupt.
+    UpdateInterrupt(io::Error),
+    /// Failed enabling the interrupt.
+    EnableInterrupt(io::Error),
+}
+
+type Result<T> = result::Result<T, Error>;
+
+pub struct MsiMessage {
+    // Message Address Register
+    //   31-20: Base address. Fixed value (0x0FEE)
+    //   19-12: Destination ID
+    //   11-4:  Reserved
+    //   3:     Redirection Hint indication
+    //   2:     Destination Mode
+    //   1-0:   Reserved
+    pub addr: u32,
+    // Message Data Register
+    //   32-16: Reserved
+    //   15:    Trigger Mode. 0 = Edge, 1 = Level
+    //   14:    Level. 0 = Deassert, 1 = Assert
+    //   13-11: Reserved
+    //   10-8:  Delivery Mode
+    //   7-0:   Vector
+    pub data: u32,
+}
+
+// Introduce trait InterruptController to uniform the interrupt
+// service provided for devices.
+// Device manager uses this trait without caring whether it is a
+// IOAPIC (X86) or GIC (Arm).
+pub trait InterruptController: Send {
+    fn service_irq(&mut self, irq: usize) -> Result<()>;
+    fn end_of_interrupt(&mut self, vec: u8);
+}

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -31,7 +31,10 @@ use std::io;
 #[cfg(feature = "acpi")]
 mod acpi;
 mod bus;
+#[cfg(target_arch = "aarch64")]
+pub mod gic;
 pub mod interrupt_controller;
+#[cfg(target_arch = "x86_64")]
 pub mod ioapic;
 pub mod legacy;
 

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -31,6 +31,7 @@ use std::io;
 #[cfg(feature = "acpi")]
 mod acpi;
 mod bus;
+pub mod interrupt_controller;
 pub mod ioapic;
 pub mod legacy;
 

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 //
 
-use devices::ioapic;
+use devices::interrupt_controller::InterruptController;
 use kvm_bindings::{kvm_irq_routing, kvm_irq_routing_entry, KVM_IRQ_ROUTING_MSI};
 use kvm_ioctls::VmFd;
 use std::collections::HashMap;
@@ -281,12 +281,12 @@ impl InterruptSourceGroup for MsiInterruptGroup {
 }
 
 pub struct LegacyUserspaceInterruptGroup {
-    ioapic: Arc<Mutex<ioapic::Ioapic>>,
+    ioapic: Arc<Mutex<dyn InterruptController>>,
     irq: u32,
 }
 
 impl LegacyUserspaceInterruptGroup {
-    fn new(ioapic: Arc<Mutex<ioapic::Ioapic>>, irq: u32) -> Self {
+    fn new(ioapic: Arc<Mutex<dyn InterruptController>>, irq: u32) -> Self {
         LegacyUserspaceInterruptGroup { ioapic, irq }
     }
 }
@@ -311,7 +311,7 @@ impl InterruptSourceGroup for LegacyUserspaceInterruptGroup {
 }
 
 pub struct KvmLegacyUserspaceInterruptManager {
-    ioapic: Arc<Mutex<ioapic::Ioapic>>,
+    ioapic: Arc<Mutex<dyn InterruptController>>,
 }
 
 pub struct KvmMsiInterruptManager {
@@ -321,7 +321,7 @@ pub struct KvmMsiInterruptManager {
 }
 
 impl KvmLegacyUserspaceInterruptManager {
-    pub fn new(ioapic: Arc<Mutex<ioapic::Ioapic>>) -> Self {
+    pub fn new(ioapic: Arc<Mutex<dyn InterruptController>>) -> Self {
         KvmLegacyUserspaceInterruptManager { ioapic }
     }
 }


### PR DESCRIPTION
The PR refactors IOAPIC to work with other architectures.

2 commits are included:
1. Introduces trait InterruptController to provide architecture agnostic functions.
2. Implement InterruptController for AArch64.

This PR is split from https://github.com/cloud-hypervisor/cloud-hypervisor/pull/1126.
