### PR TITLE
vmm: api: Return complete error responses in handle_http_request()

### DIFF
--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -26,6 +26,12 @@ pub enum HttpError {
     /// Attempt to access unsupported HTTP method
     BadRequest,
 
+    /// Undefined endpoints
+    NotFound,
+
+    /// Internal Server Error
+    InternalServerError,
+
     /// Could not create a VM
     VmCreate(ApiError),
 
@@ -194,9 +200,12 @@ fn handle_http_request(
     let mut response = match HTTP_ROUTES.routes.get(&path) {
         Some(route) => match api_notifier.try_clone() {
             Ok(notifier) => route.handle_request(&request, notifier, api_sender.clone()),
-            Err(_) => Response::new(Version::Http11, StatusCode::InternalServerError),
+            Err(_) => error_response(
+                HttpError::InternalServerError,
+                StatusCode::InternalServerError,
+            ),
         },
-        None => Response::new(Version::Http11, StatusCode::NotFound),
+        None => error_response(HttpError::NotFound, StatusCode::NotFound),
     };
 
     response.set_server("Cloud Hypervisor API");


### PR DESCRIPTION
Instead of responding only headers with error code, we now return
complete error responses to HTTP requests with errors (e.g. undefined
endpoints and InternalSeverError).

Fixes: #472

Signed-off-by: Bo Chen <chen.bo@intel.com>