### PR TITLE
vmm: Change booting process to cover AArch64 requirements

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -5,7 +5,16 @@ pub mod layout;
 
 use crate::RegionType;
 use kvm_ioctls::*;
-use vm_memory::{GuestAddress, GuestMemoryMmap, GuestUsize};
+use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryMmap, GuestUsize};
+
+#[derive(Debug)]
+pub enum Error {}
+
+impl From<Error> for super::Error {
+    fn from(e: Error) -> super::Error {
+        super::Error::AArch64Setup(e)
+    }
+}
 
 /// Stub function that needs to be implemented when aarch64 functionality is added.
 pub fn arch_memory_regions(size: GuestUsize) -> Vec<(GuestAddress, usize, RegionType)> {
@@ -18,6 +27,15 @@ pub fn arch_memory_regions(size: GuestUsize) -> Vec<(GuestAddress, usize, Region
 pub struct EntryPoint {
     /// Address in guest memory where the guest must start execution
     pub entry_addr: GuestAddress,
+}
+
+pub fn configure_vcpu(
+    _fd: &VcpuFd,
+    _id: u8,
+    _kernel_entry_point: Option<EntryPoint>,
+    _vm_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
+) -> super::Result<()> {
+    unimplemented!();
 }
 
 /// Stub function that needs to be implemented when aarch64 functionality is added.

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -30,6 +30,9 @@ pub enum Error {
     #[cfg(target_arch = "x86_64")]
     /// X86_64 specific error triggered during system configuration.
     X86_64Setup(x86_64::Error),
+    #[cfg(target_arch = "aarch64")]
+    /// AArch64 specific error triggered during system configuration.
+    AArch64Setup(aarch64::Error),
     /// The zero page extends past the end of guest_mem.
     ZeroPagePastRamEnd,
     /// Error writing the zero page of guest memory.
@@ -76,8 +79,9 @@ pub mod aarch64;
 
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
-    arch_memory_regions, check_required_kvm_extensions, configure_system, get_host_cpu_phys_bits,
-    get_reserved_mem_addr, layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START, EntryPoint,
+    arch_memory_regions, check_required_kvm_extensions, configure_system, configure_vcpu,
+    get_host_cpu_phys_bits, get_reserved_mem_addr, layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START,
+    EntryPoint,
 };
 
 #[cfg(target_arch = "x86_64")]
@@ -85,9 +89,9 @@ pub mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
-    arch_memory_regions, check_required_kvm_extensions, configure_system, get_host_cpu_phys_bits,
-    initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START, regs,
-    BootProtocol, EntryPoint,
+    arch_memory_regions, check_required_kvm_extensions, configure_system, configure_vcpu,
+    get_host_cpu_phys_bits, initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE,
+    layout::CMDLINE_START, regs, BootProtocol, CpuidPatch, CpuidReg, EntryPoint,
 };
 
 /// Safe wrapper for `sysconf(_SC_PAGESIZE)`.

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -50,6 +50,8 @@ pub struct EntryPoint {
     pub entry_addr: GuestAddress,
     /// Specifies which boot protocol to use
     pub protocol: BootProtocol,
+    /// This field is used for bzImage to fill zero page
+    pub setup_header: Option<setup_header>,
 }
 
 const E820_RAM: u32 = 1;


### PR DESCRIPTION
Splits from https://github.com/cloud-hypervisor/cloud-hypervisor/pull/1126.

To enable CH on AArch64, we need to change the process of creating and activating VCPU's. 
To make it easy to review, this PR contains the modifications for X86 only, ARM code will be added later.

Between X86 and AArch64, there is some differences in booting a VM:
- X86_64 can setup IOAPIC before creating any VCPU.
- AArch64 have to create VCPU's before creating GIC.

The old booting process is:
1. load_kernel()
    load kernel binary
    configure system
2. activate_vcpus()
    create & start VCPU's

So we need to separate "activate_vcpus()" into "create_vcpus()" and "activate_vcpus()" (to start VCPUS's only). We also separate load_kernel() into "load_kernel()" and "configure system()" (GIC setup and FDT generating is included in it) to align the steps among architectures.

The new procedure is:
1. load kernel
2. create VCPU's
3. configure system
4. start VCPU's

Signed-off-by: Michael Zhao <michael.zhao@arm.com>