### PR TITLE
main: Set the umask to 0077

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -359,6 +359,9 @@ fn start_vmm(cmd_arguments: ArgMatches) {
 }
 
 fn main() {
+    // Ensure all created files (.e.g sockets) are only accessible by this user
+    let _ = unsafe { libc::umask(0o077) };
+
     let pid = unsafe { libc::getpid() };
     let uid = unsafe { libc::getuid() };
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -276,6 +276,10 @@ pub fn vmm_thread_filter() -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_statx),
             allow_syscall(libc::SYS_tgkill),
             allow_syscall(libc::SYS_tkill),
+            allow_syscall_if(
+                libc::SYS_umask,
+                or![and![Cond::new(0, ArgLen::DWORD, Eq, 0o077)?]],
+            ),
             #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_unlink),
             allow_syscall(libc::SYS_wait4),


### PR DESCRIPTION
This ensures that all created filed are only read/write for the current user.

Fixes: #1240

Signed-off-by: Rob Bradford <robert.bradford@intel.com>