### PR TITLE
tests,vm-virtio,vmm: Use 'socket' for all CLI/API parameters

### DIFF
--- a/docs/fs.md
+++ b/docs/fs.md
@@ -59,21 +59,21 @@ Assuming you have `clear-kvm.img` and `custom-vmlinux.bin` on your system, here 
     --memory "size=512,file=/dev/shm" \
     --disk path=clear-kvm.img \
     --kernel custom-vmlinux.bin \
-    --cmdline "console=ttyS0 reboot=k panic=1 nomodules root=/dev/vda3" \ 
-    --fs tag=myfs,sock=/tmp/virtiofs,num_queues=1,queue_size=512
+    --cmdline "console=ttyS0 reboot=k panic=1 nomodules root=/dev/vda3" \
+    --fs tag=myfs,socket=/tmp/virtiofs,num_queues=1,queue_size=512
 ```
 
 By default, DAX is enabled with a cache window of 8GiB. You can specify a custom size (let's say 4GiB for this example) for the cache by explicitly setting DAX and the cache size:
 
 ```bash
---fs tag=virtiofs,sock=/tmp/virtiofs,num_queues=1,queue_size=512,dax=on,cache_size=4G
+--fs tag=virtiofs,socket=/tmp/virtiofs,num_queues=1,queue_size=512,dax=on,cache_size=4G
 
 ```
 
 In case you don't want to use a shared window of cache to pass the shared files content, this means you will have to explicitly disable DAX with `dax=off`. Note that in this case, the `cache_size` parameter will be ignored.
 
 ```bash
---fs tag=virtiofs,sock=/tmp/virtiofs,num_queues=1,queue_size=512,dax=off
+--fs tag=virtiofs,socket=/tmp/virtiofs,num_queues=1,queue_size=512,dax=off
 
 ```
 

--- a/src/bin/vhost_user_fs.rs
+++ b/src/bin/vhost_user_fs.rs
@@ -297,6 +297,13 @@ fn main() {
         .arg(
             Arg::with_name("sock")
                 .long("sock")
+                .help("vhost-user socket path (deprecated)")
+                .takes_value(true)
+                .min_values(1),
+        )
+        .arg(
+            Arg::with_name("socket")
+                .long("socket")
                 .help("vhost-user socket path")
                 .takes_value(true)
                 .min_values(1),
@@ -331,9 +338,16 @@ fn main() {
     let shared_dir = cmd_arguments
         .value_of("shared-dir")
         .expect("Failed to retrieve shared directory path");
-    let sock = cmd_arguments
-        .value_of("sock")
-        .expect("Failed to retrieve vhost-user socket path");
+    let socket = match cmd_arguments.value_of("socket") {
+        Some(path) => path,
+        None => {
+            println!("warning: use of deprecated parameter '--sock': Please use the '--socket' option instead.");
+            cmd_arguments
+                .value_of("sock")
+                .expect("Failed to retrieve vhost-user socket path")
+        }
+    };
+
     let thread_pool_size: usize = match cmd_arguments.value_of("thread-pool-size") {
         Some(size) => size.parse().expect("Invalid argument for thread-pool-size"),
         None => THREAD_POOL_SIZE,
@@ -348,7 +362,7 @@ fn main() {
         _ => unreachable!(), // We told Arg possible_values
     };
 
-    let listener = Listener::new(sock, true).unwrap();
+    let listener = Listener::new(socket, true).unwrap();
 
     let fs_cfg = if create_sandbox {
         let mut sandbox = Sandbox::new(shared_dir.to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -745,14 +745,14 @@ mod unit_tests {
                     "--memory",
                     "shared=true",
                     "--disk",
-                    "vhost_user=true,socket=/tmp/socket1",
+                    "vhost_user=true,socket=/tmp/sock1",
                     "path=/path/to/disk/2",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "disks": [
-                        {"vhost_user":true, "vhost_socket":"/tmp/socket1"},
+                        {"vhost_user":true, "vhost_socket":"/tmp/sock1"},
                         {"path": "/path/to/disk/2"}
                     ]
                 }"#,
@@ -766,14 +766,14 @@ mod unit_tests {
                     "--memory",
                     "shared=true",
                     "--disk",
-                    "vhost_user=true,socket=/tmp/socket1",
+                    "vhost_user=true,socket=/tmp/sock1",
                     "path=/path/to/disk/2",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "disks": [
-                        {"vhost_user":true, "vhost_socket":"/tmp/socket1"},
+                        {"vhost_user":true, "vhost_socket":"/tmp/sock1"},
                         {"path": "/path/to/disk/2"}
                     ]
                 }"#,
@@ -952,12 +952,12 @@ mod unit_tests {
                 true,
             ),
             (
-                vec!["cloud-hypervisor", "--kernel", "/path/to/kernel", "--memory", "shared=true", "--net", "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,vhost_user=true,socket=/tmp/socket"],
+                vec!["cloud-hypervisor", "--kernel", "/path/to/kernel", "--memory", "shared=true", "--net", "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,vhost_user=true,socket=/tmp/sock"],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "net": [
-                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "vhost_user": true, "vhost_socket": "/tmp/socket"}
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "vhost_user": true, "vhost_socket": "/tmp/sock"}
                     ]
                 }"#,
                 true,
@@ -999,15 +999,15 @@ mod unit_tests {
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--memory", "shared=true",
                     "--fs",
-                    "tag=virtiofs1,sock=/path/to/sock1",
-                    "tag=virtiofs2,sock=/path/to/sock2",
+                    "tag=virtiofs1,socket=/path/to/sock1",
+                    "tag=virtiofs2,socket=/path/to/sock2",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "fs": [
-                        {"tag": "virtiofs1", "sock": "/path/to/sock1"},
-                        {"tag": "virtiofs2", "sock": "/path/to/sock2"}
+                        {"tag": "virtiofs1", "socket": "/path/to/sock1"},
+                        {"tag": "virtiofs2", "socket": "/path/to/sock2"}
                     ]
                 }"#,
                 true,
@@ -1017,14 +1017,14 @@ mod unit_tests {
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--memory", "shared=true",
                     "--fs",
-                    "tag=virtiofs1,sock=/path/to/sock1",
-                    "tag=virtiofs2,sock=/path/to/sock2",
+                    "tag=virtiofs1,socket=/path/to/sock1",
+                    "tag=virtiofs2,socket=/path/to/sock2",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "fs": [
-                        {"tag": "virtiofs1", "sock": "/path/to/sock1"}
+                        {"tag": "virtiofs1", "socket": "/path/to/sock1"}
                     ]
                 }"#,
                 false,
@@ -1034,13 +1034,13 @@ mod unit_tests {
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--memory", "shared=true",
                     "--fs",
-                    "tag=virtiofs1,sock=/path/to/sock1,num_queues=4",
+                    "tag=virtiofs1,socket=/path/to/sock1,num_queues=4",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "fs": [
-                        {"tag": "virtiofs1", "sock": "/path/to/sock1", "num_queues": 4}
+                        {"tag": "virtiofs1", "socket": "/path/to/sock1", "num_queues": 4}
                     ]
                 }"#,
                 true,
@@ -1050,13 +1050,13 @@ mod unit_tests {
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--memory", "shared=true",
                     "--fs",
-                    "tag=virtiofs1,sock=/path/to/sock1,num_queues=4,queue_size=128"
+                    "tag=virtiofs1,socket=/path/to/sock1,num_queues=4,queue_size=128"
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "fs": [
-                        {"tag": "virtiofs1", "sock": "/path/to/sock1", "num_queues": 4, "queue_size": 128}
+                        {"tag": "virtiofs1", "socket": "/path/to/sock1", "num_queues": 4, "queue_size": 128}
                     ]
                 }"#,
                 true,
@@ -1066,13 +1066,13 @@ mod unit_tests {
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--memory", "shared=true",
                     "--fs",
-                    "tag=virtiofs1,sock=/path/to/sock1,num_queues=4,queue_size=128,dax=on"
+                    "tag=virtiofs1,socket=/path/to/sock1,num_queues=4,queue_size=128,dax=on"
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "fs": [
-                        {"tag": "virtiofs1", "sock": "/path/to/sock1", "num_queues": 4, "queue_size": 128}
+                        {"tag": "virtiofs1", "socket": "/path/to/sock1", "num_queues": 4, "queue_size": 128}
                     ]
                 }"#,
                 true,
@@ -1082,13 +1082,13 @@ mod unit_tests {
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--memory", "shared=true",
                     "--fs",
-                    "tag=virtiofs1,sock=/path/to/sock1,num_queues=4,queue_size=128,dax=on"
+                    "tag=virtiofs1,socket=/path/to/sock1,num_queues=4,queue_size=128,dax=on"
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "fs": [
-                        {"tag": "virtiofs1", "sock": "/path/to/sock1", "num_queues": 4, "queue_size": 128, "dax": true}
+                        {"tag": "virtiofs1", "socket": "/path/to/sock1", "num_queues": 4, "queue_size": 128, "dax": true}
                     ]
                 }"#,
                 true,
@@ -1098,13 +1098,13 @@ mod unit_tests {
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--memory", "shared=true",
                     "--fs",
-                    "tag=virtiofs1,sock=/path/to/sock1,num_queues=4,queue_size=128"
+                    "tag=virtiofs1,socket=/path/to/sock1,num_queues=4,queue_size=128"
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "fs": [
-                        {"tag": "virtiofs1", "sock": "/path/to/sock1", "num_queues": 4, "queue_size": 128, "dax": true}
+                        {"tag": "virtiofs1", "socket": "/path/to/sock1", "num_queues": 4, "queue_size": 128, "dax": true}
                     ]
                 }"#,
                 true,
@@ -1114,13 +1114,13 @@ mod unit_tests {
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--memory", "shared=true",
                     "--fs",
-                    "tag=virtiofs1,sock=/path/to/sock1,num_queues=4,queue_size=128,cache_size=8589934592"
+                    "tag=virtiofs1,socket=/path/to/sock1,num_queues=4,queue_size=128,cache_size=8589934592"
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "fs": [
-                        {"tag": "virtiofs1", "sock": "/path/to/sock1", "num_queues": 4, "queue_size": 128}
+                        {"tag": "virtiofs1", "socket": "/path/to/sock1", "num_queues": 4, "queue_size": 128}
                     ]
                 }"#,
                 true,
@@ -1130,13 +1130,13 @@ mod unit_tests {
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--memory", "shared=true",
                     "--fs",
-                    "tag=virtiofs1,sock=/path/to/sock1,num_queues=4,queue_size=128"
+                    "tag=virtiofs1,socket=/path/to/sock1,num_queues=4,queue_size=128"
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "fs": [
-                        {"tag": "virtiofs1", "sock": "/path/to/sock1", "num_queues": 4, "queue_size": 128, "cache_size": 8589934592}
+                        {"tag": "virtiofs1", "socket": "/path/to/sock1", "num_queues": 4, "queue_size": 128, "cache_size": 8589934592}
                     ]
                 }"#,
                 true,
@@ -1146,13 +1146,13 @@ mod unit_tests {
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--memory", "shared=true",
                     "--fs",
-                    "tag=virtiofs1,sock=/path/to/sock1,num_queues=4,queue_size=128,cache_size=4294967296"
+                    "tag=virtiofs1,socket=/path/to/sock1,num_queues=4,queue_size=128,cache_size=4294967296"
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "fs": [
-                        {"tag": "virtiofs1", "sock": "/path/to/sock1", "num_queues": 4, "queue_size": 128, "cache_size": 4294967296}
+                        {"tag": "virtiofs1", "socket": "/path/to/sock1", "num_queues": 4, "queue_size": 128, "cache_size": 4294967296}
                     ]
                 }"#,
                 true,
@@ -1162,13 +1162,13 @@ mod unit_tests {
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--memory", "shared=true",
                     "--fs",
-                    "tag=virtiofs1,sock=/path/to/sock1,num_queues=4,queue_size=128,cache_size=4294967296"
+                    "tag=virtiofs1,socket=/path/to/sock1,num_queues=4,queue_size=128,cache_size=4294967296"
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "fs": [
-                        {"tag": "virtiofs1", "sock": "/path/to/sock1", "num_queues": 4, "queue_size": 128}
+                        {"tag": "virtiofs1", "socket": "/path/to/sock1", "num_queues": 4, "queue_size": 128}
                     ]
                 }"#,
                 false,
@@ -1427,11 +1427,11 @@ mod unit_tests {
                     "--kernel",
                     "/path/to/kernel",
                     "--vsock",
-                    "cid=123,sock=/path/to/sock/1",
+                    "cid=123,socket=/path/to/sock/1",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
-                    "vsock": {"cid": 123, "sock": "/path/to/sock/1"}
+                    "vsock": {"cid": 123, "socket": "/path/to/sock/1"}
                 }"#,
                 true,
             ),
@@ -1441,11 +1441,11 @@ mod unit_tests {
                     "--kernel",
                     "/path/to/kernel",
                     "--vsock",
-                    "cid=124,sock=/path/to/sock/1",
+                    "cid=124,socket=/path/to/sock/1",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
-                    "vsock": {"cid": 123, "sock": "/path/to/sock/1"}
+                    "vsock": {"cid": 123, "socket": "/path/to/sock/1"}
                 }"#,
                 false,
             ),
@@ -1455,11 +1455,11 @@ mod unit_tests {
                     "--kernel",
                     "/path/to/kernel",
                     "--vsock",
-                    "cid=123,sock=/path/to/sock/1,iommu=on",
+                    "cid=123,socket=/path/to/sock/1,iommu=on",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
-                    "vsock": {"cid": 123, "sock": "/path/to/sock/1", "iommu": true},
+                    "vsock": {"cid": 123, "socket": "/path/to/sock/1", "iommu": true},
                     "iommu": true
                 }"#,
                 true,
@@ -1470,11 +1470,11 @@ mod unit_tests {
                     "--kernel",
                     "/path/to/kernel",
                     "--vsock",
-                    "cid=123,sock=/path/to/sock/1,iommu=on",
+                    "cid=123,socket=/path/to/sock/1,iommu=on",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
-                    "vsock": {"cid": 123, "sock": "/path/to/sock/1", "iommu": true}
+                    "vsock": {"cid": 123, "socket": "/path/to/sock/1", "iommu": true}
                 }"#,
                 false,
             ),
@@ -1484,11 +1484,11 @@ mod unit_tests {
                     "--kernel",
                     "/path/to/kernel",
                     "--vsock",
-                    "cid=123,sock=/path/to/sock/1,iommu=off",
+                    "cid=123,socket=/path/to/sock/1,iommu=off",
                 ],
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
-                    "vsock": {"cid": 123, "sock": "/path/to/sock/1", "iommu": false}
+                    "vsock": {"cid": 123, "socket": "/path/to/sock/1", "iommu": false}
                 }"#,
                 true,
             ),

--- a/vm-virtio/src/vhost_user/blk.rs
+++ b/vm-virtio/src/vhost_user/blk.rs
@@ -50,7 +50,7 @@ pub struct Blk {
 impl Blk {
     /// Create a new vhost-user-blk device
     pub fn new(id: String, vu_cfg: VhostUserConfig) -> Result<Blk> {
-        let mut vhost_user_blk = Master::connect(&vu_cfg.sock, vu_cfg.num_queues as u64)
+        let mut vhost_user_blk = Master::connect(&vu_cfg.socket, vu_cfg.num_queues as u64)
             .map_err(Error::VhostUserCreateMaster)?;
 
         // Filling device and vring features VMM supports.

--- a/vm-virtio/src/vhost_user/net.rs
+++ b/vm-virtio/src/vhost_user/net.rs
@@ -56,7 +56,7 @@ impl Net {
     /// Create a new vhost-user-net device
     /// Create a new vhost-user-net device
     pub fn new(id: String, mac_addr: MacAddr, vu_cfg: VhostUserConfig) -> Result<Net> {
-        let mut vhost_user_net = Master::connect(&vu_cfg.sock, vu_cfg.num_queues as u64)
+        let mut vhost_user_net = Master::connect(&vu_cfg.socket, vu_cfg.num_queues as u64)
             .map_err(Error::VhostUserCreateMaster)?;
 
         // Filling device and vring features VMM supports.

--- a/vm-virtio/src/vhost_user/vu_common_ctrl.rs
+++ b/vm-virtio/src/vhost_user/vu_common_ctrl.rs
@@ -18,7 +18,7 @@ use vmm_sys_util::eventfd::EventFd;
 
 #[derive(Debug, Clone)]
 pub struct VhostUserConfig {
-    pub sock: String,
+    pub socket: String,
     pub num_queues: usize,
     pub queue_size: u16,
 }

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -506,12 +506,12 @@ components:
     FsConfig:
       required:
       - tag
-      - sock
+      - socket
       type: object
       properties:
         tag:
           type: string
-        sock:
+        socket:
           type: string
         num_queues:
           type: integer
@@ -581,7 +581,7 @@ components:
     VsockConfig:
       required:
       - cid
-      - sock
+      - socket
       type: object
       properties:
         cid:
@@ -589,7 +589,7 @@ components:
           format: int64
           minimum: 3
           description: Guest Vsock CID
-        sock:
+        socket:
           type: string
           description: Path to UNIX domain socket, used to proxy vsock connections.
         iommu:


### PR DESCRIPTION
This patch unifies the inconsistent uses of 'socket' and 'sock' from our
CLI/API parameters.

Fixes: #1091

Signed-off-by: Bo Chen <chen.bo@intel.com>