### PR TITLE
Fix issues preventing Cloud Hypervisor running without CAP_NET_ADMIN

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -210,10 +210,14 @@ sudo ip tuntap add name vunet-tap0 mode tap
 # Create tap interface with multipe queues support for vhost_user_net test.
 sudo ip tuntap add name vunet-tap1 mode tap multi_queue
 
+
 cargo build --release --target $BUILD_TARGET
 strip target/$BUILD_TARGET/release/cloud-hypervisor
 strip target/$BUILD_TARGET/release/vhost_user_net
 strip target/$BUILD_TARGET/release/ch-remote
+
+# Copy for non-privileged net test
+cp target/$BUILD_TARGET/release/cloud-hypervisor target/$BUILD_TARGET/release/cloud-hypervisor-unprivileged
 
 sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/cloud-hypervisor
 sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/vhost_user_net

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -141,7 +141,7 @@ impl VhostUserNetBackend {
             ifname,
             Some(ip_addr),
             Some(netmask),
-            Some(host_mac),
+            &mut Some(host_mac),
             num_queues / 2,
         )
         .map_err(Error::OpenTap)?;

--- a/vm-virtio/src/net.rs
+++ b/vm-virtio/src/net.rs
@@ -465,7 +465,7 @@ impl Net {
         ip_addr: Option<Ipv4Addr>,
         netmask: Option<Ipv4Addr>,
         guest_mac: Option<MacAddr>,
-        host_mac: Option<MacAddr>,
+        host_mac: &mut Option<MacAddr>,
         iommu: bool,
         num_queues: usize,
         queue_size: u16,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -683,8 +683,8 @@ pub struct NetConfig {
     pub mask: Ipv4Addr,
     #[serde(default = "default_netconfig_mac")]
     pub mac: MacAddr,
-    #[serde(default = "default_netconfig_mac")]
-    pub host_mac: MacAddr,
+    #[serde(default)]
+    pub host_mac: Option<MacAddr>,
     #[serde(default)]
     pub iommu: bool,
     #[serde(default = "default_netconfig_num_queues")]
@@ -729,7 +729,7 @@ impl Default for NetConfig {
             ip: default_netconfig_ip(),
             mask: default_netconfig_mask(),
             mac: default_netconfig_mac(),
-            host_mac: default_netconfig_mac(),
+            host_mac: None,
             iommu: false,
             num_queues: default_netconfig_num_queues(),
             queue_size: default_netconfig_queue_size(),
@@ -776,10 +776,7 @@ impl NetConfig {
             .convert("mac")
             .map_err(Error::ParseNetwork)?
             .unwrap_or_else(default_netconfig_mac);
-        let host_mac = parser
-            .convert("host_mac")
-            .map_err(Error::ParseNetwork)?
-            .unwrap_or_else(default_netconfig_mac);
+        let host_mac = parser.convert("host_mac").map_err(Error::ParseNetwork)?;
         let iommu = parser
             .convert::<Toggle>("iommu")
             .map_err(Error::ParseNetwork)?
@@ -1633,7 +1630,7 @@ mod tests {
             NetConfig::parse("mac=de:ad:be:ef:12:34,host_mac=12:34:de:ad:be:ef")?,
             NetConfig {
                 mac: MacAddr::parse_str("de:ad:be:ef:12:34").unwrap(),
-                host_mac: MacAddr::parse_str("12:34:de:ad:be:ef").unwrap(),
+                host_mac: Some(MacAddr::parse_str("12:34:de:ad:be:ef").unwrap()),
                 ..Default::default()
             }
         );
@@ -1642,7 +1639,7 @@ mod tests {
             NetConfig::parse("mac=de:ad:be:ef:12:34,host_mac=12:34:de:ad:be:ef,id=mynet0")?,
             NetConfig {
                 mac: MacAddr::parse_str("de:ad:be:ef:12:34").unwrap(),
-                host_mac: MacAddr::parse_str("12:34:de:ad:be:ef").unwrap(),
+                host_mac: Some(MacAddr::parse_str("12:34:de:ad:be:ef").unwrap()),
                 id: Some("mynet0".to_owned()),
                 ..Default::default()
             }
@@ -1654,7 +1651,7 @@ mod tests {
             )?,
             NetConfig {
                 mac: MacAddr::parse_str("de:ad:be:ef:12:34").unwrap(),
-                host_mac: MacAddr::parse_str("12:34:de:ad:be:ef").unwrap(),
+                host_mac: Some(MacAddr::parse_str("12:34:de:ad:be:ef").unwrap()),
                 tap: Some("tap0".to_owned()),
                 ip: "192.168.100.1".parse().unwrap(),
                 mask: "255.255.255.128".parse().unwrap(),
@@ -1666,7 +1663,7 @@ mod tests {
             NetConfig::parse("mac=de:ad:be:ef:12:34,host_mac=12:34:de:ad:be:ef,vhost_user=true,socket=/tmp/socket")?,
             NetConfig {
                 mac: MacAddr::parse_str("de:ad:be:ef:12:34").unwrap(),
-                host_mac: MacAddr::parse_str("12:34:de:ad:be:ef").unwrap(),
+                host_mac: Some(MacAddr::parse_str("12:34:de:ad:be:ef").unwrap()),
                 vhost_user: true,
                 vhost_socket: Some("/tmp/socket".to_owned()),
                 ..Default::default()
@@ -1677,7 +1674,7 @@ mod tests {
             NetConfig::parse("mac=de:ad:be:ef:12:34,host_mac=12:34:de:ad:be:ef,num_queues=4,queue_size=1024,iommu=on")?,
             NetConfig {
                 mac: MacAddr::parse_str("de:ad:be:ef:12:34").unwrap(),
-                host_mac: MacAddr::parse_str("12:34:de:ad:be:ef").unwrap(),
+                host_mac: Some(MacAddr::parse_str("12:34:de:ad:be:ef").unwrap()),
                 num_queues: 4,
                 queue_size: 1024,
                 iommu: true,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1512,13 +1512,17 @@ impl DeviceManager {
             .args(&[
                 "--net-backend",
                 &format!(
-                    "ip={},mask={},socket={},num_queues={},queue_size={},host_mac={}",
+                    "ip={},mask={},socket={},num_queues={},queue_size={}{}",
                     net_cfg.ip,
                     net_cfg.mask,
                     &sock,
                     net_cfg.num_queues,
                     net_cfg.queue_size,
-                    net_cfg.host_mac
+                    if let Some(mac) = net_cfg.host_mac {
+                        format!(",host_mac={:}", mac)
+                    } else {
+                        "".to_owned()
+                    }
                 ),
             ])
             .spawn()
@@ -1583,7 +1587,7 @@ impl DeviceManager {
                         None,
                         None,
                         Some(net_cfg.mac),
-                        Some(net_cfg.host_mac),
+                        &mut net_cfg.host_mac,
                         net_cfg.iommu,
                         net_cfg.num_queues,
                         net_cfg.queue_size,
@@ -1598,7 +1602,7 @@ impl DeviceManager {
                         Some(net_cfg.ip),
                         Some(net_cfg.mask),
                         Some(net_cfg.mac),
-                        Some(net_cfg.host_mac),
+                        &mut net_cfg.host_mac,
                         net_cfg.iommu,
                         net_cfg.num_queues,
                         net_cfg.queue_size,

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -87,6 +87,7 @@ const TUNSETVNETHDRSZ: u64 = 0x4004_54d8;
 const TUNGETFEATURES: u64 = 0x8004_54cf;
 
 // See include/uapi/linux/sockios.h in the kernel code.
+const SIOCGIFFLAGS: u64 = 0x8913;
 const SIOCGIFHWADDR: u64 = 0x8927;
 const SIOCSIFFLAGS: u64 = 0x8914;
 const SIOCSIFADDR: u64 = 0x8916;
@@ -149,6 +150,7 @@ fn create_vmm_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_USER_MEMORY_REGION,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XSAVE,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XCRS,)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, SIOCGIFFLAGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, SIOCGIFHWADDR)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, SIOCSIFADDR)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, SIOCSIFFLAGS)?],


### PR DESCRIPTION
There were two places that prevented CH from running without CAP_NET_ADMIN. Always attempting to enable the interface if it was already up and always setting the host MAC address by autogenerating.

It's worth noting that even if there is an existing tap interface if the user tries to configure the IP/mask/host MAC it will continue to fail as those require privileged ioctl calls. The basis of using an existing tap device has always been on the assumption that the user has already configured it appropriately.

Fixes: #1274 