### PR TITLE
Revert "tests: Extend test_*_reboot with checks on fd leaking"

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2891,10 +2891,6 @@ mod tests {
         });
     }
 
-    fn get_fd_count(pid: u32) -> usize {
-        fs::read_dir(format!("/proc/{}/fd", pid)).unwrap().count()
-    }
-
     #[cfg_attr(not(feature = "mmio"), test)]
     fn test_reboot() {
         test_block!(tb, "", {
@@ -2922,7 +2918,7 @@ mod tests {
                     .unwrap();
 
                 thread::sleep(std::time::Duration::new(20, 0));
-                let fd_count_1 = get_fd_count(child.id());
+
                 let reboot_count = guest
                     .ssh_command("sudo journalctl | grep -c -- \"-- Reboot --\"")
                     .unwrap_or_default()
@@ -2934,7 +2930,6 @@ mod tests {
                 guest.ssh_command("sudo reboot").unwrap_or_default();
 
                 thread::sleep(std::time::Duration::new(20, 0));
-                let fd_count_2 = get_fd_count(child.id());
                 let reboot_count = guest
                     .ssh_command("sudo journalctl | grep -c -- \"-- Reboot --\"")
                     .unwrap_or_default()
@@ -2942,7 +2937,6 @@ mod tests {
                     .parse::<u32>()
                     .unwrap_or_default();
                 aver_eq!(tb, reboot_count, 1);
-                aver_eq!(tb, fd_count_1, fd_count_2);
 
                 guest
                     .ssh_command("sudo shutdown -h now")
@@ -2980,7 +2974,7 @@ mod tests {
                 .unwrap();
 
             thread::sleep(std::time::Duration::new(20, 0));
-            let fd_count_1 = get_fd_count(child.id());
+
             let reboot_count = guest
                 .ssh_command("journalctl | grep -c -- \"-- Reboot --\"")
                 .unwrap_or_default()
@@ -2992,7 +2986,6 @@ mod tests {
             guest.ssh_command("sudo reboot")?;
 
             thread::sleep(std::time::Duration::new(20, 0));
-            let fd_count_2 = get_fd_count(child.id());
             let reboot_count = guest
                 .ssh_command("sudo journalctl | grep -c -- \"-- Reboot --\"")
                 .unwrap_or_default()
@@ -3000,7 +2993,6 @@ mod tests {
                 .parse::<u32>()
                 .unwrap_or_default();
             aver_eq!(tb, reboot_count, 1);
-            aver_eq!(tb, fd_count_1, fd_count_2);
 
             guest.ssh_command("sudo shutdown -h now")?;
             thread::sleep(std::time::Duration::new(20, 0));


### PR DESCRIPTION
Reverts cloud-hypervisor/cloud-hypervisor#1271

Fixes: #1276