### PR TITLE
build: Use fork of vm-memory with less performance impact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,8 +1475,7 @@ dependencies = [
 [[package]]
 name = "vm-memory"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fb10d355a0de221e0524cb18491d3dc6e2a0981747f75fd0a3a12109f1712f"
+source = "git+https://github.com/cloud-hypervisor/vm-memory?branch=ch#708e9aa5d4317f7044d9835fe5080287e9c76f21"
 dependencies = [
  "arc-swap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ vmm-sys-util = "0.6.0"
 vm-virtio = { path = "vm-virtio" }
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }
 
+[patch.crates-io]
+vm-memory = { git = "https://github.com/cloud-hypervisor/vm-memory", branch = "ch" }
+
 [dev-dependencies]
 ssh2 = "0.8.1"
 dirs = "2.0.2"


### PR DESCRIPTION
Currently released vm-memory uses aligned and volatile copying for all
data. The version in the fork only uses the assured (and slower) path
for data upto the natural data width.

Fixes: #1258

Signed-off-by: Rob Bradford <robert.bradford@intel.com>