### PR TITLE
scripts: Ensure musl-gcc is used by musl build

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -213,7 +213,7 @@ sudo ip tuntap add name vunet-tap1 mode tap multi_queue
 BUILD_TARGET="$(uname -m)-unknown-linux-${CH_LIBC}"
 CFLAGS=""
 TARGET_CC=""
-if [[ "$target" == "x86_64-unknown-linux-musl" ]]; then
+if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
 TARGET_CC="musl-gcc"
 CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
 fi


### PR DESCRIPTION
"cc" is invoked as part of the Cloud Hypervisor Rust build however due
to a copy and paste error the wrong variable was being tested for
overriding the CC and the CFLAGS.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>