### PR TITLE
net_util: Fix deprecated `mac_address()` call in test

### DIFF
--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -527,7 +527,7 @@ mod tests {
         let interface = interfaces.into_iter().find(interface_name_matches).unwrap();
 
         if let Ok(Ethernet(tx, rx)) = datalink::channel(&interface, Default::default()) {
-            (interface.mac_address(), tx, rx)
+            (interface.mac.unwrap(), tx, rx)
         } else {
             panic!("datalink channel error or unhandled channel type");
         }


### PR DESCRIPTION
This cleans out the test compilation warning

```
warning: use of deprecated item 'tap::tests::pnet::datalink::NetworkInterface::mac_address': Please use NetworkInterface's field 'mac' instead.
   --> net_util/src/tap.rs:530:24
    |
530 |             (interface.mac_address(), tx, rx)
    |                        ^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default
```

Signed-off-by: Anatol Belski <ab@php.net>