### PR TITLE
arch: x86_64: Add 5th level of paging when needed

### DIFF
--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -47,9 +47,10 @@ pub const BOOT_STACK_START: GuestAddress = GuestAddress(0x8000);
 pub const BOOT_STACK_POINTER: GuestAddress = GuestAddress(0x8ff0);
 
 // Initial pagetables.
-pub const PML4_START: GuestAddress = GuestAddress(0x9000);
-pub const PDPTE_START: GuestAddress = GuestAddress(0xa000);
-pub const PDE_START: GuestAddress = GuestAddress(0xb000);
+pub const PML5_START: GuestAddress = GuestAddress(0x9000);
+pub const PML4_START: GuestAddress = GuestAddress(0xa000);
+pub const PDPTE_START: GuestAddress = GuestAddress(0xb000);
+pub const PDE_START: GuestAddress = GuestAddress(0xc000);
 
 /// Kernel command line start address.
 pub const CMDLINE_START: GuestAddress = GuestAddress(0x20000);


### PR DESCRIPTION
For correctness, when the CPUID supports the LA57 feature, the VMM sets
the CR4.LA57 register, which means a fifth level of page table might be
needed. Even if it's not needed because the kernel should not use
addresses over 1GiB, it's better to define this new level anyway.

This patch only applies to the Linux boot codepath, which means it
affects both vmlinux without PVH and bzImage binaries. The bzImage
does not need this since the page tables and CR4 registers are set in
the decompression code from the kernel.

And for vmlinux with PVH, if we follow the PVH specification, the kernel
must be responsible for setting things up, but the implementation is
missing. This means for now that PVH does not support LA57 with 5 levels
of paging.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>