### PR TITLE
vmm: vm: fix test_vm test case

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1493,6 +1493,7 @@ pub fn test_vm() {
             VcpuExit::Debug => {}
             VcpuExit::Hlt => {
                 println!("HLT");
+                break;
             }
             VcpuExit::IrqWindowOpen => {}
             VcpuExit::Shutdown => {}


### PR DESCRIPTION
We should break out from the loop after getting the HLT exit, otherwise
the VM hangs forever.

Signed-off-by: Wei Liu <liuwe@microsoft.com>