### PR TITLE
virtio-mem: Update VirtioMemConfig according to Linux kernel

### DIFF
--- a/vm-virtio/src/mem.rs
+++ b/vm-virtio/src/mem.rs
@@ -159,10 +159,10 @@ unsafe impl ByteValued for VirtioMemResp {}
 #[derive(Copy, Clone, Debug, Default)]
 struct VirtioMemConfig {
     // Block size and alignment. Cannot change.
-    block_size: u32,
+    block_size: u64,
     // Valid with VIRTIO_MEM_F_ACPI_PXM. Cannot change.
     node_id: u16,
-    padding: u16,
+    padding: [u8; 6],
     // Start address of the memory region. Cannot change.
     addr: u64,
     // Region size (maximum). Cannot change.
@@ -790,7 +790,7 @@ impl Mem {
         let avail_features = 1u64 << VIRTIO_F_VERSION_1;
 
         let mut config = VirtioMemConfig::default();
-        config.block_size = VIRTIO_MEM_DEFAULT_BLOCK_SIZE as u32;
+        config.block_size = VIRTIO_MEM_DEFAULT_BLOCK_SIZE;
         config.addr = region.start_addr().raw_value();
         config.region_size = region.len();
         config.usable_region_size = cmp::min(


### PR DESCRIPTION
Types of block_size and padding is updated in
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=544fc7dbbf920a3e64d109c416ee229e8e1763c5.
Update VirtioMemConfig according to it.

Signed-off-by: Hui Zhu <teawater@antfin.com>