### PR TITLE
build: Temporarily disable nightly builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,6 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl


### PR DESCRIPTION
Rust nightly builds are currently failing due to a crate outside of
our control not meeting the latest cargo requirements.

See XAMPPRocky/remove_dir_all#19

Signed-off-by: Rob Bradford <robert.bradford@intel.com>