### PR TITLE
vmm: device_tree: make available remove function unconditionally

### DIFF
--- a/vmm/src/device_tree.rs
+++ b/vmm/src/device_tree.rs
@@ -62,7 +62,6 @@ impl DeviceTree {
     pub fn insert(&mut self, k: String, v: DeviceNode) -> Option<DeviceNode> {
         self.0.insert(k, v)
     }
-    #[cfg(feature = "pci_support")]
     pub fn remove(&mut self, k: &str) -> Option<DeviceNode> {
         self.0.remove(k)
     }


### PR DESCRIPTION
Its test case calls remove unconditionally. Instead of making the test
code call remove conditionally, removing the pci_support dependency
simplifies things -- that function is just a wrapper around HashMap's
remove function anyway.

Signed-off-by: Wei Liu <liuwe@microsoft.com>
