### PR TITLE
tests: Implement grcov support

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as dev
+FROM ubuntu:18.04 as {NAME}
 
 ARG TARGETARCH="x86_64"
 ARG RUST_TOOLCHAIN="1.43.0"
@@ -39,6 +39,7 @@ RUN apt-get update \
 	cpio \
 	bsdtar \
 	libfdt-dev \
+	lcov \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -78,6 +79,7 @@ RUN nohup curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -
     && if [ "$TARGETARCH" = "x86_64" ]; then rustup component add rustfmt; fi \
     && if [ "$TARGETARCH" = "x86_64" ]; then rustup component add clippy; fi \
     && cargo install cargo-audit \
+    && cargo install grcov \
     && rm -rf "$CARGO_HOME/registry" \
     && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \
     && rm -rf "$CARGO_HOME/git" \

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -7,7 +7,13 @@ cargo_args=("$@")
 [ $(uname -m) = "aarch64" ] && cargo_args+=("--no-default-features")
 [ $(uname -m) = "aarch64" ] && cargo_args+=("--features mmio,kvm")
 
+if [ true = "$COVERAGE" ]; then
+    export CARGO_INCREMENTAL=0
+    export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+    export RUSTDOCFLAGS="-Cpanic=abort"
+fi
 cargo test --target $BUILD_TARGET --workspace --no-run ${cargo_args[@]}
+
 pushd target/$BUILD_TARGET/debug
 ls  | grep net_util | grep -v "\.d" | xargs -n 1 sudo setcap cap_net_admin,cap_net_raw+ep
 popd
@@ -17,3 +23,15 @@ newgrp kvm << EOF || exit 1
   export RUST_BACKTRACE=1
   cargo test --target $BUILD_TARGET --workspace ${cargo_args[@]} || exit 1;
 EOF
+
+if [ true = "$COVERAGE" ]; then
+    BASE_DIR=./target/$BUILD_TARGET/debug
+    LCOV_INFO=$BASE_DIR/$BUILD_TARGET.lcov.info
+    OUT_DIR=$BASE_DIR/coverage
+
+    grcov $BASE_DIR -s . -t lcov --branch --ignore-not-existing -o $LCOV_INFO \
+	    --ignore '*registry/*' --ignore '*git/*' --ignore '*target/*'
+    rm -rf $OUT_DIR
+    genhtml -o $OUT_DIR --show-details --highlight --ignore-errors source --legend $LCOV_INFO --function-coverage --branch-coverage
+fi
+


### PR DESCRIPTION
The goal of the suggested change is to improve QA by visualizing the code coverage. The approach might be not an all rounder to satisfy any  possible cases, but can be certainly seen as a starting point to produce coverage data to prepare a better base for addressing the issue #78.

Required features added in course of research

- 	A container image with the nightly toolset
- 	 Presence of lcov and grcov in the image
- 	Necessary changes in dev scripts

The coverage report will be then available under the target directory. The output format can be made configurable as the desired output is dependent on whether one or another visualisation solution is to be used.

An example report generated by using a container with the nightly toolset, grcov and lcov can be seen under http://51.116.187.114/ch-grcov-2020-06-13/ . Any comment to improve are welcome.

To produce the nightly image, it would be to invoke
`./scripts/dev_cli.sh build-container --dev --nightly`

To produce the test output, it would be to run similar to 
`./scripts/dev_cli.sh tests --unit --coverage`

Similar could be implemented also for integration and other types of tests, if makes sense.

It appears to be really useful to have this kind of information, in first place to see the status on the test coverage. But also, it could help to facilitate the community participation for contributing to a better QA.

Thanks.