### PR TITLE
vfio: fix bug cloud-hypervisor: 763.978581807s: ERROR:pci/src/vfio.rs:651 -- failed to remove all guest memory regions from iommu table

### DIFF
--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -645,7 +645,7 @@ impl Drop for VfioPciDevice {
 
         if self
             .device
-            .setup_dma_map(self.mem.memory().deref())
+            .unset_dma_map(self.mem.memory().deref())
             .is_err()
         {
             error!("failed to remove all guest memory regions from iommu table");


### PR DESCRIPTION
cloud-hypervisor: 763.978581807s: ERROR:pci/src/vfio.rs:651 -- failed to remove all guest memory regions from iommu table

when poweroff a vm with vfio device, clh will finally remove all guest memory region from iommu table
with the method unset_dma_map, not method setup_dma_map.

Signed-off-by: LiYa'nan <oliverliyn@gmail.com>