### PR TITLE
vm-virtio: make VsockPacket public

### DIFF
--- a/vm-virtio/src/vsock/mod.rs
+++ b/vm-virtio/src/vsock/mod.rs
@@ -17,7 +17,7 @@ pub use self::device::Vsock;
 pub use self::unix::VsockUnixBackend;
 pub use self::unix::VsockUnixError;
 
-use packet::VsockPacket;
+pub use packet::VsockPacket;
 use std::os::unix::io::RawFd;
 
 mod defs {


### PR DESCRIPTION
This patch makes VsockPacket public to allow other crates (e.g. [vhost-user-vsock](https://github.com/stefano-garzarella/vhost-user-vsock)) to use it.