### PR TITLE
Backport FC vsock patches to address stalling problems

### DIFF
--- a/vm-virtio/src/vsock/csm/connection.rs
+++ b/vm-virtio/src/vsock/csm/connection.rs
@@ -764,6 +764,16 @@ mod tests {
         }
     }
 
+    impl<S> VsockConnection<S>
+    where
+        S: Read + Write + AsRawFd,
+    {
+        /// Get the fwd_cnt value from the connection.
+        pub(crate) fn fwd_cnt(&self) -> Wrapping<u32> {
+            self.fwd_cnt
+        }
+    }
+
     fn init_pkt(pkt: &mut VsockPacket, op: u16, len: u32) -> &mut VsockPacket {
         for b in pkt.hdr_mut() {
             *b = 0;

--- a/vm-virtio/src/vsock/csm/connection.rs
+++ b/vm-virtio/src/vsock/csm/connection.rs
@@ -600,7 +600,9 @@ where
     /// Check if the credit information the peer has last received from us is outdated.
     ///
     fn peer_needs_credit_update(&self) -> bool {
-        (self.fwd_cnt - self.last_fwd_cnt_to_peer).0 as usize >= defs::CONN_CREDIT_UPDATE_THRESHOLD
+        let peer_seen_free_buf =
+            Wrapping(defs::CONN_TX_BUF_SIZE) - (self.fwd_cnt - self.last_fwd_cnt_to_peer);
+        peer_seen_free_buf < Wrapping(defs::CONN_CREDIT_UPDATE_THRESHOLD)
     }
 
     /// Check if we need to ask the peer for a credit update before sending any more data its
@@ -632,7 +634,7 @@ where
             .set_src_port(self.local_port)
             .set_dst_port(self.peer_port)
             .set_type(uapi::VSOCK_TYPE_STREAM)
-            .set_buf_alloc(defs::CONN_TX_BUF_SIZE as u32)
+            .set_buf_alloc(defs::CONN_TX_BUF_SIZE)
             .set_fwd_cnt(self.fwd_cnt.0)
     }
 }
@@ -1052,7 +1054,7 @@ mod tests {
         assert!(ctx.conn.has_pending_rx());
         ctx.recv();
         assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_CREDIT_UPDATE);
-        assert_eq!(ctx.pkt.buf_alloc(), csm_defs::CONN_TX_BUF_SIZE as u32);
+        assert_eq!(ctx.pkt.buf_alloc(), csm_defs::CONN_TX_BUF_SIZE);
         assert_eq!(ctx.pkt.fwd_cnt(), ctx.conn.fwd_cnt.0);
     }
 
@@ -1062,10 +1064,23 @@ mod tests {
 
         // Force a stale state, where the peer hasn't been updated on our credit situation.
         ctx.conn.last_fwd_cnt_to_peer = Wrapping(0);
-        ctx.conn.fwd_cnt = Wrapping(csm_defs::CONN_CREDIT_UPDATE_THRESHOLD as u32);
 
-        // Fake a data send from the peer, to bring us over the credit update threshold.
+        // Since a credit update token is sent when the fwd_cnt value exceeds
+        // CONN_TX_BUF_SIZE - CONN_CREDIT_UPDATE_THRESHOLD, we initialize
+        // fwd_cnt at 6 bytes below the threshold.
+        let initial_fwd_cnt =
+            csm_defs::CONN_TX_BUF_SIZE as u32 - csm_defs::CONN_CREDIT_UPDATE_THRESHOLD as u32 - 6;
+        ctx.conn.fwd_cnt = Wrapping(initial_fwd_cnt);
+
+        // Use a 4-byte packet for triggering the credit update threshold.
         let data = &[1, 2, 3, 4];
+
+        // Check that there is no pending RX.
+        ctx.init_data_pkt(data);
+        ctx.send();
+        assert!(!ctx.conn.has_pending_rx());
+
+        // Send a packet again.
         ctx.init_data_pkt(data);
         ctx.send();
 
@@ -1073,10 +1088,7 @@ mod tests {
         assert!(ctx.conn.has_pending_rx());
         ctx.recv();
         assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_CREDIT_UPDATE);
-        assert_eq!(
-            ctx.pkt.fwd_cnt() as usize,
-            csm_defs::CONN_CREDIT_UPDATE_THRESHOLD + data.len()
-        );
+        assert_eq!(ctx.pkt.fwd_cnt(), initial_fwd_cnt + data.len() as u32 * 2);
         assert_eq!(ctx.conn.fwd_cnt, ctx.conn.last_fwd_cnt_to_peer);
     }
 
@@ -1175,7 +1187,7 @@ mod tests {
         // Fill up the TX buffer.
         let data = vec![0u8; ctx.pkt.buf().unwrap().len()];
         ctx.init_data_pkt(data.as_slice());
-        for _i in 0..(csm_defs::CONN_TX_BUF_SIZE / data.len()) {
+        for _i in 0..(csm_defs::CONN_TX_BUF_SIZE / data.len() as u32) {
             ctx.send();
         }
 

--- a/vm-virtio/src/vsock/csm/connection.rs
+++ b/vm-virtio/src/vsock/csm/connection.rs
@@ -772,6 +772,11 @@ mod tests {
         pub(crate) fn fwd_cnt(&self) -> Wrapping<u32> {
             self.fwd_cnt
         }
+
+        /// Forcefully insert a credit update flag.
+        pub(crate) fn insert_credit_update(&mut self) {
+            self.pending_rx.insert(PendingRx::CreditUpdate);
+        }
     }
 
     fn init_pkt(pkt: &mut VsockPacket, op: u16, len: u32) -> &mut VsockPacket {

--- a/vm-virtio/src/vsock/csm/connection.rs
+++ b/vm-virtio/src/vsock/csm/connection.rs
@@ -454,7 +454,13 @@ where
                         "vsock: error flushing TX buf for (lp={}, pp={}): {:?}",
                         self.local_port, self.peer_port, err
                     );
-                    self.kill();
+                    match err {
+                        Error::TxBufFlush(inner) if inner.kind() == ErrorKind::WouldBlock => {
+                            // This should never happen (EWOULDBLOCK after EPOLLOUT), but
+                            // it does, so let's absorb it.
+                        }
+                        _ => self.kill(),
+                    };
                     0
                 });
             self.fwd_cnt += Wrapping(flushed as u32);

--- a/vm-virtio/src/vsock/csm/connection.rs
+++ b/vm-virtio/src/vsock/csm/connection.rs
@@ -571,12 +571,29 @@ where
         self.pending_rx.insert(PendingRx::Rst);
     }
 
+    /// Return the connections state.
+    ///
+    pub fn state(&self) -> ConnState {
+        self.state
+    }
+
+    /// Send some raw, untracked, data straight to the underlying connected stream.
+    /// Returns: number of bytes written, or the error describing the write failure.
+    ///
+    /// Warning: this will bypass the connection state machine and write directly to the
+    /// underlying stream. No account of this write is kept, which includes bypassing
+    /// vsock flow control.
+    ///
+    pub fn send_bytes_raw(&mut self, buf: &[u8]) -> Result<usize> {
+        self.stream.write(buf).map_err(Error::StreamWrite)
+    }
+
     /// Send some raw data (a byte-slice) to the host stream.
     ///
     /// Raw data can either be sent straight to the host stream, or to our TX buffer, if the
     /// former fails.
     ///
-    pub fn send_bytes(&mut self, buf: &[u8]) -> Result<()> {
+    fn send_bytes(&mut self, buf: &[u8]) -> Result<()> {
         // If there is data in the TX buffer, that means we're already registered for EPOLLOUT
         // events on the underlying stream. Therefore, there's no point in attempting a write
         // at this point. `self.notify()` will get called when EPOLLOUT arrives, and it will
@@ -609,11 +626,6 @@ where
         }
 
         Ok(())
-    }
-
-    /// Return the connections state.
-    pub fn state(&self) -> ConnState {
-        self.state
     }
 
     /// Check if the credit information the peer has last received from us is outdated.

--- a/vm-virtio/src/vsock/csm/connection.rs
+++ b/vm-virtio/src/vsock/csm/connection.rs
@@ -180,81 +180,94 @@ where
             return Ok(());
         }
 
+        if self.pending_rx.remove(PendingRx::Rw) {
+            // We're due to produce a data packet, by reading the data from the host-side
+            // Unix socket.
+
+            match self.state {
+                // A data packet is only valid for established connections, and connections for
+                // which our peer has initiated a graceful shutdown, but can still receive data.
+                ConnState::Established | ConnState::PeerClosed(false, _) => (),
+                _ => {
+                    // Any other connection state is invalid at this point, and we need to kill it
+                    // with fire.
+                    pkt.set_op(uapi::VSOCK_OP_RST);
+                    return Ok(());
+                }
+            }
+
+            // Oh wait, before we start bringing in the big data, can our peer handle receiving so
+            // much bytey goodness?
+            if self.need_credit_update_from_peer() {
+                self.last_fwd_cnt_to_peer = self.fwd_cnt;
+                pkt.set_op(uapi::VSOCK_OP_CREDIT_REQUEST);
+                return Ok(());
+            }
+
+            let buf = pkt.buf_mut().ok_or(VsockError::PktBufMissing)?;
+
+            // The maximum amount of data we can read in is limited by both the RX buffer size and
+            // the peer available buffer space.
+            let max_len = std::cmp::min(buf.len(), self.peer_avail_credit());
+
+            // Read data from the stream straight to the RX buffer, for maximum throughput.
+            match self.stream.read(&mut buf[..max_len]) {
+                Ok(read_cnt) => {
+                    if read_cnt == 0 {
+                        // A 0-length read means the host stream was closed down. In that case,
+                        // we'll ask our peer to shut down the connection. We can neither send nor
+                        // receive any more data.
+                        self.state = ConnState::LocalClosed;
+                        self.expiry = Some(
+                            Instant::now() + Duration::from_millis(defs::CONN_SHUTDOWN_TIMEOUT_MS),
+                        );
+                        pkt.set_op(uapi::VSOCK_OP_SHUTDOWN)
+                            .set_flag(uapi::VSOCK_FLAGS_SHUTDOWN_RCV)
+                            .set_flag(uapi::VSOCK_FLAGS_SHUTDOWN_SEND);
+                    } else {
+                        // On a successful data read, we fill in the packet with the RW op, and
+                        // length of the read data.
+                        pkt.set_op(uapi::VSOCK_OP_RW).set_len(read_cnt as u32);
+                    }
+                    self.rx_cnt += Wrapping(pkt.len());
+                    self.last_fwd_cnt_to_peer = self.fwd_cnt;
+                    return Ok(());
+                }
+                Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                    // This shouldn't actually happen (receiving EWOULDBLOCK after EPOLLIN), but
+                    // apparently it does, so we need to handle it greacefully.
+                    warn!(
+                        "vsock: unexpected EWOULDBLOCK while reading from backing stream: \
+                         lp={}, pp={}, err={:?}",
+                        self.local_port, self.peer_port, err
+                    );
+                }
+                Err(err) => {
+                    // We are not expecting any other errors when reading from the underlying
+                    // stream. If any show up, we'll immediately kill this connection.
+                    error!(
+                        "vsock: error reading from backing stream: lp={}, pp={}, err={:?}",
+                        self.local_port, self.peer_port, err
+                    );
+                    pkt.set_op(uapi::VSOCK_OP_RST);
+                    self.last_fwd_cnt_to_peer = self.fwd_cnt;
+                    return Ok(());
+                }
+            };
+        }
+
         // A credit update is basically a no-op, so we should only waste a perfectly fine RX
-        // buffer on it if we really have nothing else to say.
+        // buffer on it if we really have nothing else to say, hence we check for this RX
+        // indication last.
         if self.pending_rx.remove(PendingRx::CreditUpdate) && !self.has_pending_rx() {
             pkt.set_op(uapi::VSOCK_OP_CREDIT_UPDATE);
             self.last_fwd_cnt_to_peer = self.fwd_cnt;
             return Ok(());
         }
 
-        // Alright, if we got to here, we need to cough up a data packet. We've already checked
-        // for all other pending RX indications.
-        if !self.pending_rx.remove(PendingRx::Rw) {
-            return Err(VsockError::NoData);
-        }
-
-        match self.state {
-            // A data packet is only valid for established connections, and connections for
-            // which our peer has initiated a graceful shutdown, but can still receive data.
-            ConnState::Established | ConnState::PeerClosed(false, _) => (),
-            _ => {
-                // Any other connection state is invalid at this point, and we need to kill it
-                // with fire.
-                pkt.set_op(uapi::VSOCK_OP_RST);
-                return Ok(());
-            }
-        }
-
-        // Oh wait, before we start bringing in the big data, can our peer handle receiving so
-        // much bytey goodness?
-        if self.need_credit_update_from_peer() {
-            self.last_fwd_cnt_to_peer = self.fwd_cnt;
-            pkt.set_op(uapi::VSOCK_OP_CREDIT_REQUEST);
-            return Ok(());
-        }
-
-        let buf = pkt.buf_mut().ok_or(VsockError::PktBufMissing)?;
-
-        // The maximum amount of data we can read in is limited by both the RX buffer size and
-        // the peer available buffer space.
-        let max_len = std::cmp::min(buf.len(), self.peer_avail_credit());
-
-        // Read data from the stream straight to the RX buffer, for maximum throughput.
-        match self.stream.read(&mut buf[..max_len]) {
-            Ok(read_cnt) => {
-                if read_cnt == 0 {
-                    // A 0-length read means the host stream was closed down. In that case,
-                    // we'll ask our peer to shut down the connection. We can neither send nor
-                    // receive any more data.
-                    self.state = ConnState::LocalClosed;
-                    self.expiry = Some(
-                        Instant::now() + Duration::from_millis(defs::CONN_SHUTDOWN_TIMEOUT_MS),
-                    );
-                    pkt.set_op(uapi::VSOCK_OP_SHUTDOWN)
-                        .set_flag(uapi::VSOCK_FLAGS_SHUTDOWN_RCV)
-                        .set_flag(uapi::VSOCK_FLAGS_SHUTDOWN_SEND);
-                } else {
-                    // On a successful data read, we fill in the packet with the RW op, and
-                    // length of the read data.
-                    pkt.set_op(uapi::VSOCK_OP_RW).set_len(read_cnt as u32);
-                }
-            }
-            Err(err) => {
-                // We are not expecting any errors when reading from the underlying stream. If
-                // any show up, we'll immediately kill this connection.
-                error!(
-                    "vsock: error reading from backing stream: lp={}, pp={}, err={:?}",
-                    self.local_port, self.peer_port, err
-                );
-                pkt.set_op(uapi::VSOCK_OP_RST);
-            }
-        };
-
-        self.rx_cnt += Wrapping(pkt.len());
-        self.last_fwd_cnt_to_peer = self.fwd_cnt;
-
-        Ok(())
+        // We've already checked for all conditions that would have produced a packet, so
+        // if we got to here, we don't know how to yield one.
+        Err(VsockError::NoData)
     }
 
     /// Deliver a guest-generated packet to this connection.

--- a/vm-virtio/src/vsock/csm/mod.rs
+++ b/vm-virtio/src/vsock/csm/mod.rs
@@ -11,11 +11,11 @@ pub use connection::VsockConnection;
 
 pub mod defs {
     /// Vsock connection TX buffer capacity.
-    pub const CONN_TX_BUF_SIZE: usize = 64 * 1024;
+    pub const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
 
-    /// After the guest thinks it has filled our TX buffer up to this limit (in bytes), we'll send
-    /// them a credit update packet, to let them know we can handle more.
-    pub const CONN_CREDIT_UPDATE_THRESHOLD: usize = CONN_TX_BUF_SIZE - 4 * 4 * 1024;
+    /// When the guest thinks we have less than this amount of free buffer space,
+    /// we will send them a credit update packet.
+    pub const CONN_CREDIT_UPDATE_THRESHOLD: u32 = 4 * 1024;
 
     /// Connection request timeout, in millis.
     pub const CONN_REQUEST_TIMEOUT_MS: u64 = 2000;

--- a/vm-virtio/src/vsock/csm/txbuf.rs
+++ b/vm-virtio/src/vsock/csm/txbuf.rs
@@ -138,7 +138,11 @@ impl TxBuf {
         // Attempt our second write. This will return immediately if a second write isn't
         // needed, since checking for an empty buffer is the first thing we do in this
         // function.
-        Ok(written + self.flush_to(sink)?)
+        //
+        // Interesting corner case: if we've already written some data in the first pass,
+        // and then the second write fails, we will consider the flush action a success
+        // and return the number of bytes written in the first pass.
+        Ok(written + self.flush_to(sink).unwrap_or(0))
     }
 
     /// Check if the buffer holds any data that hasn't yet been flushed out.

--- a/vm-virtio/src/vsock/csm/txbuf.rs
+++ b/vm-virtio/src/vsock/csm/txbuf.rs
@@ -25,7 +25,7 @@ pub struct TxBuf {
 impl TxBuf {
     /// Total buffer size, in bytes.
     ///
-    const SIZE: usize = defs::CONN_TX_BUF_SIZE;
+    const SIZE: usize = defs::CONN_TX_BUF_SIZE as usize;
 
     /// Ring-buffer constructor.
     ///

--- a/vm-virtio/src/vsock/unix/muxer.rs
+++ b/vm-virtio/src/vsock/unix/muxer.rs
@@ -60,7 +60,7 @@ pub struct ConnMapKey {
 
 /// A muxer RX queue item.
 ///
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum MuxerRx {
     /// The packet must be fetched from the connection identified by `ConnMapKey`.
     ConnRx(ConnMapKey),
@@ -134,7 +134,7 @@ impl VsockChannel for VsockMuxer {
             self.rxq = MuxerRxQ::from_conn_map(&self.conn_map);
         }
 
-        while let Some(rx) = self.rxq.pop() {
+        while let Some(rx) = self.rxq.peek() {
             let res = match rx {
                 // We need to build an RST packet, going from `local_port` to `peer_port`.
                 MuxerRx::RstPkt {
@@ -151,6 +151,7 @@ impl VsockChannel for VsockMuxer {
                         .set_flags(0)
                         .set_buf_alloc(0)
                         .set_fwd_cnt(0);
+                    self.rxq.pop().unwrap();
                     return Ok(());
                 }
 
@@ -158,9 +159,14 @@ impl VsockChannel for VsockMuxer {
                 // to say.
                 MuxerRx::ConnRx(key) => {
                     let mut conn_res = Err(VsockError::NoData);
+                    let mut do_pop = true;
                     self.apply_conn_mutation(key, |conn| {
                         conn_res = conn.recv_pkt(pkt);
+                        do_pop = !conn.has_pending_rx();
                     });
+                    if do_pop {
+                        self.rxq.pop().unwrap();
+                    }
                     conn_res
                 }
             };

--- a/vm-virtio/src/vsock/unix/muxer.rs
+++ b/vm-virtio/src/vsock/unix/muxer.rs
@@ -1356,4 +1356,26 @@ mod tests {
 
         assert!(!ctx.muxer.has_pending_rx());
     }
+
+    #[test]
+    fn test_regression_handshake() {
+        // Address one of the issues found while fixing the following issue:
+        // https://github.com/firecracker-microvm/firecracker/issues/1751
+        // This test checks that the handshake message is not accounted for
+        let mut ctx = MuxerTestContext::new("regression_handshake");
+        let peer_port = 1025;
+
+        // Create a local connection.
+        let (_, local_port) = ctx.local_connect(peer_port);
+
+        // Get the connection from the connection map.
+        let key = ConnMapKey {
+            local_port,
+            peer_port,
+        };
+        let conn = ctx.muxer.conn_map.get_mut(&key).unwrap();
+
+        // Check that fwd_cnt is 0 - "OK ..." was not accounted for.
+        assert_eq!(conn.fwd_cnt().0, 0);
+    }
 }

--- a/vm-virtio/src/vsock/unix/muxer.rs
+++ b/vm-virtio/src/vsock/unix/muxer.rs
@@ -682,11 +682,20 @@ impl VsockMuxer {
             // If this is a host-initiated connection that has just become established, we'll have
             // to send an ack message to the host end.
             if prev_state == ConnState::LocalInit && conn.state() == ConnState::Established {
-                conn.send_bytes(format!("OK {}\n", key.local_port).as_bytes())
-                    .unwrap_or_else(|err| {
+                let msg = format!("OK {}\n", key.local_port);
+                match conn.send_bytes_raw(msg.as_bytes()) {
+                    Ok(written) if written == msg.len() => (),
+                    Ok(_) => {
+                        // If we can't write a dozen bytes to a pristine connection something
+                        // must be really wrong. Killing it.
+                        conn.kill();
+                        warn!("vsock: unable to fully write connection ack msg.");
+                    }
+                    Err(err) => {
                         conn.kill();
                         warn!("vsock: unable to ack host connection: {:?}", err);
-                    });
+                    }
+                };
             }
 
             // If the connection wasn't previously scheduled for RX, add it to our RX queue.

--- a/vm-virtio/src/vsock/unix/muxer.rs
+++ b/vm-virtio/src/vsock/unix/muxer.rs
@@ -1378,4 +1378,41 @@ mod tests {
         // Check that fwd_cnt is 0 - "OK ..." was not accounted for.
         assert_eq!(conn.fwd_cnt().0, 0);
     }
+
+    #[test]
+    fn test_regression_rxq_pop() {
+        // Address one of the issues found while fixing the following issue:
+        // https://github.com/firecracker-microvm/firecracker/issues/1751
+        // This test checks that a connection is not popped out of the muxer
+        // rxq when multiple flags are set
+        let mut ctx = MuxerTestContext::new("regression_rxq_pop");
+        let peer_port = 1025;
+        let (mut stream, local_port) = ctx.local_connect(peer_port);
+
+        // Send some data.
+        let data = [5u8, 6, 7, 8];
+        stream.write_all(&data).unwrap();
+        ctx.notify_muxer();
+
+        // Get the connection from the connection map.
+        let key = ConnMapKey {
+            local_port,
+            peer_port,
+        };
+        let conn = ctx.muxer.conn_map.get_mut(&key).unwrap();
+
+        // Forcefully insert another flag.
+        conn.insert_credit_update();
+
+        // Call recv twice in order to check that the connection is still
+        // in the rxq.
+        assert!(ctx.muxer.has_pending_rx());
+        ctx.recv();
+        assert!(ctx.muxer.has_pending_rx());
+        ctx.recv();
+
+        // Since initially the connection had two flags set, now there should
+        // not be any pending RX in the muxer.
+        assert!(!ctx.muxer.has_pending_rx());
+    }
 }

--- a/vm-virtio/src/vsock/unix/muxer_rxq.rs
+++ b/vm-virtio/src/vsock/unix/muxer_rxq.rs
@@ -107,6 +107,12 @@ impl MuxerRxQ {
         false
     }
 
+    /// Peek into the front of the queue.
+    ///
+    pub fn peek(&self) -> Option<MuxerRx> {
+        self.q.front().copied()
+    }
+
     /// Pop an RX item from the front of the queue.
     ///
     pub fn pop(&mut self) -> Option<MuxerRx> {


### PR DESCRIPTION
This PR fixes #1001 backporting Firecracker's patches included in https://github.com/firecracker-microvm/firecracker/pull/1910

I tested with iperf-vsock for more than 1000 seconds without stalls. Before this patch, the stall happened in a very few seconds especially with reverse test:
```shell
guest$ ./iperf3 --vsock -s

host$ ./iperf3 --vsock -c /tmp/vm4.vsock -t 10000 -R
```