### PR TITLE
Add basic CPU topology support

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -208,6 +208,7 @@ pub fn configure_vcpu(
 ) -> super::Result<()> {
     let mut cpuid = cpuid;
     CpuidPatch::set_cpuid_reg(&mut cpuid, 0xb, None, CpuidReg::EDX, u32::from(id));
+    CpuidPatch::set_cpuid_reg(&mut cpuid, 0x1f, None, CpuidReg::EDX, u32::from(id));
     fd.set_cpuid2(&cpuid)
         .map_err(Error::SetSupportedCpusFailed)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -487,6 +487,7 @@ mod unit_tests {
                 cpus: CpusConfig {
                     boot_vcpus: 1,
                     max_vcpus: 1,
+                    topology: None,
                 },
                 memory: MemoryConfig {
                     size: 536_870_912,

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,10 @@ fn create_app<'a, 'b>(
         .arg(
             Arg::with_name("cpus")
                 .long("cpus")
-                .help("Number of virtual CPUs")
+                .help(
+                    "boot=<boot_vcpus>,max=<max_vcpus>,\
+                    topology=<threads_per_core>:<cores_per_die>:<dies_per_package>:<packages>",
+                )
                 .default_value(&default_vcpus)
                 .group("vm-config"),
         )

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -396,6 +396,18 @@ components:
           default: false
       description: Virtual machine configuration
 
+    CpuTopology:
+      type: object
+      properties:
+        threads_per_core:
+          type: integer
+        cores_per_die:
+          type: integer
+        dies_per_package:
+          type: integer
+        packages:
+          type: integer
+
     CpusConfig:
       required:
       - boot_vcpus
@@ -410,6 +422,8 @@ components:
           minimum: 1
           default: 1
           type: integer
+        topology:
+            $ref: '#/components/schemas/CpuTopology'
 
     MemoryConfig:
       required:

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -789,6 +789,7 @@ impl CpuManager {
             {
                 let mut cpuid = self.cpuid.clone();
                 CpuidPatch::set_cpuid_reg(&mut cpuid, 0xb, None, CpuidReg::EDX, u32::from(cpu_id));
+                CpuidPatch::set_cpuid_reg(&mut cpuid, 0x1f, None, CpuidReg::EDX, u32::from(cpu_id));
 
                 vcpu.lock()
                     .unwrap()


### PR DESCRIPTION
Add support for specifying the CPU topology in terms of threads per core, cores per die, dies per package and total packages/sockets. This is exposed through CPUID leaves.

Although the Linux kernel does read the dies per package field it doesn't expose it to the user in `/proc/cpuinfo`. In practice the user will almost always want to set this to 1.

Fixes: #1284 