### PR TITLE
build: Enable LTO for release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 default-run = "cloud-hypervisor"
 build = "build.rs"
 
+[profile.release]
+lto = true
+
 [dependencies]
 arc-swap = ">=0.4.4"
 clap = { version = "2.33.1", features=["wrap_help"] }


### PR DESCRIPTION
This results in ~20% reduction of stripped binary size:

Default release build: 8.7M -> stripped: 5.3M
LTO release build: 5.9M -> stripped: 4.3M

Signed-off-by: Rob Bradford <robert.bradford@intel.com>