### PR TITLE
tests: Enable AArch64 Jenkins CI with unit tests

### DIFF
--- a/.github/workflows/cross-build.yaml
+++ b/.github/workflows/cross-build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install arm64 libfdt
         run: wget http://ftp.us.debian.org/debian/pool/main/d/device-tree-compiler/libfdt-dev_1.6.0-1_arm64.deb && dpkg-deb -xv libfdt-dev_1.6.0-1_arm64.deb ./tlibfdtdev && sudo mkdir /tmmmp && mkdir target && mkdir target/debug && mkdir target/debug/deps && sudo cp ./tlibfdtdev/usr/lib/aarch64-linux-gnu/libfdt.a target/debug/deps/libfdt.a && echo "libfdt installed"
       - name: Disable "with-serde" in kvm-bindings
-        run: sed -i 's/"with-serde",\ //g' vmm/Cargo.toml && sed -i 's/"with-serde",\ //g' hypervisor/Cargo.toml
+        run: sed -i 's/"with-serde",\ //g' hypervisor/Cargo.toml
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,29 @@ pipeline{
 						}
 					}
 				}
+				stage ('AArch64 worker build') {
+					agent { node { label 'bionic-arm64' } }
+					options {
+						timeout(time: 1, unit: 'HOURS')
+					}
+					stages {
+						stage ('Checkout') {
+							steps {
+								checkout scm
+							}
+						}
+						stage ('Build') {
+							steps {
+								sh "scripts/dev_cli.sh build --release"
+							}
+						}
+						stage ('Run unit tests') {
+							steps {
+								sh "scripts/dev_cli.sh tests --unit"
+							}
+						}
+					}
+				}
 				stage ('Worker build (musl)') {
 					agent { node { label 'bionic' } }
 					options {

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -531,7 +531,7 @@ mod tests {
     use super::*;
     use crate::aarch64::gic::create_gic;
     use crate::aarch64::layout;
-    use kvm_ioctls::Kvm;
+    use std::sync::Arc;
 
     const LEN: u64 = 4096;
 
@@ -585,8 +585,10 @@ mod tests {
         .iter()
         .cloned()
         .collect();
-        let kvm = Kvm::new().unwrap();
-        let vm = kvm.create_vm().unwrap();
+
+        let kvm = hypervisor::kvm::KvmHypervisor::new().unwrap();
+        let hv: Arc<dyn hypervisor::Hypervisor> = Arc::new(kvm);
+        let vm = hv.create_vm().unwrap();
         let gic = create_gic(&vm, 1).unwrap();
         assert!(create_fdt(
             &mem,

--- a/arch/src/aarch64/gic.rs
+++ b/arch/src/aarch64/gic.rs
@@ -146,14 +146,14 @@ pub fn create_gic(vm: &Arc<dyn hypervisor::Vm>, vcpu_count: u64) -> Result<Box<d
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
-    use kvm_ioctls::Kvm;
 
     #[test]
     fn test_create_gic() {
-        let kvm = Kvm::new().unwrap();
-        let vm = kvm.create_vm().unwrap();
+        let kvm = hypervisor::kvm::KvmHypervisor::new().unwrap();
+        let hv: Arc<dyn hypervisor::Hypervisor> = Arc::new(kvm);
+        let vm = hv.create_vm().unwrap();
+
         assert!(create_gic(&vm, 1).is_ok());
     }
 }

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -210,7 +210,7 @@ cmd_build() {
 
     # A workaround on Arm64 to avoid build errors in kvm-bindings
     if [ $(uname -m) = "aarch64" ]; then
-        sed -i 's/"with-serde",\ //g' "$CLH_ROOT_DIR"/vmm/Cargo.toml
+        sed -i 's/"with-serde",\ //g' "$CLH_ROOT_DIR"/hypervisor/Cargo.toml
     fi
 
     $DOCKER_RUNTIME run \

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -6,6 +6,7 @@ BUILD_TARGET=${BUILD_TARGET-x86_64-unknown-linux-gnu}
 cargo_args=("$@")
 [ $(uname -m) = "aarch64" ] && cargo_args+=("--no-default-features")
 [ $(uname -m) = "aarch64" ] && cargo_args+=("--features mmio")
+[ $(uname -m) = "aarch64" ] && sed -i 's/"with-serde",\ //g' hypervisor/Cargo.toml
 
 cargo test --target $BUILD_TARGET --workspace --no-run ${cargo_args[@]}
 pushd target/$BUILD_TARGET/debug


### PR DESCRIPTION
This commit enables the AArch64 Jenkins CI with build and running unit tests for the GNU toolchain.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>