### PR TITLE
vmm: cpu: Import CpuTopology conditionally on x86_64 only

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -11,7 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 //
 
-use crate::config::{CpuTopology, CpusConfig};
+#[cfg(target_arch = "x86_64")]
+use crate::config::CpuTopology;
+use crate::config::CpusConfig;
 use crate::device_manager::DeviceManager;
 use crate::CPU_MANAGER_SNAPSHOT_ID;
 #[cfg(feature = "acpi")]


### PR DESCRIPTION
The aarch64 build has no use for this structure at the moment.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>