### PR TITLE
vmm: Restore a VM in a paused state

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4629,6 +4629,9 @@ mod tests {
             // Wait for the VM to be restored
             thread::sleep(std::time::Duration::new(10, 0));
 
+            // Resume the VM
+            aver!(tb, remote_command(&api_socket, "resume", None));
+
             // Perform same checks to validate VM has been properly restored
             aver_eq!(tb, guest.get_cpu_count().unwrap_or_default(), 1);
             aver!(tb, guest.get_total_memory().unwrap_or_default() > 3_968_000);

--- a/vm-virtio/src/block.rs
+++ b/vm-virtio/src/block.rs
@@ -722,6 +722,14 @@ impl<T: DiskFile> BlockEpollHandler<T> {
         const EPOLL_EVENTS_LEN: usize = 100;
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 
+        // Before jumping into the epoll loop, check if the device is expected
+        // to be in a paused state. This is helpful for the restore code path
+        // as the device thread should not start processing anything before the
+        // device has been resumed.
+        while paused.load(Ordering::SeqCst) {
+            thread::park();
+        }
+
         'epoll: loop {
             let num_events = match epoll::wait(epoll_file.as_raw_fd(), -1, &mut events[..]) {
                 Ok(res) => res,

--- a/vm-virtio/src/console.rs
+++ b/vm-virtio/src/console.rs
@@ -236,6 +236,14 @@ impl ConsoleEpollHandler {
         const EPOLL_EVENTS_LEN: usize = 100;
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 
+        // Before jumping into the epoll loop, check if the device is expected
+        // to be in a paused state. This is helpful for the restore code path
+        // as the device thread should not start processing anything before the
+        // device has been resumed.
+        while paused.load(Ordering::SeqCst) {
+            thread::park();
+        }
+
         'epoll: loop {
             let num_events = match epoll::wait(epoll_file.as_raw_fd(), -1, &mut events[..]) {
                 Ok(res) => res,

--- a/vm-virtio/src/iommu.rs
+++ b/vm-virtio/src/iommu.rs
@@ -687,6 +687,14 @@ impl IommuEpollHandler {
         const EPOLL_EVENTS_LEN: usize = 100;
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 
+        // Before jumping into the epoll loop, check if the device is expected
+        // to be in a paused state. This is helpful for the restore code path
+        // as the device thread should not start processing anything before the
+        // device has been resumed.
+        while paused.load(Ordering::SeqCst) {
+            thread::park();
+        }
+
         'epoll: loop {
             let num_events = match epoll::wait(epoll_file.as_raw_fd(), -1, &mut events[..]) {
                 Ok(res) => res,

--- a/vm-virtio/src/mem.rs
+++ b/vm-virtio/src/mem.rs
@@ -634,6 +634,14 @@ impl MemEpollHandler {
         const EPOLL_EVENTS_LEN: usize = 100;
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 
+        // Before jumping into the epoll loop, check if the device is expected
+        // to be in a paused state. This is helpful for the restore code path
+        // as the device thread should not start processing anything before the
+        // device has been resumed.
+        while paused.load(Ordering::SeqCst) {
+            thread::park();
+        }
+
         'epoll: loop {
             let num_events = match epoll::wait(epoll_file.as_raw_fd(), -1, &mut events[..]) {
                 Ok(res) => res,

--- a/vm-virtio/src/pmem.rs
+++ b/vm-virtio/src/pmem.rs
@@ -278,6 +278,14 @@ impl PmemEpollHandler {
         const EPOLL_EVENTS_LEN: usize = 100;
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 
+        // Before jumping into the epoll loop, check if the device is expected
+        // to be in a paused state. This is helpful for the restore code path
+        // as the device thread should not start processing anything before the
+        // device has been resumed.
+        while paused.load(Ordering::SeqCst) {
+            thread::park();
+        }
+
         'epoll: loop {
             let num_events = match epoll::wait(epoll_file.as_raw_fd(), -1, &mut events[..]) {
                 Ok(res) => res,

--- a/vm-virtio/src/rng.rs
+++ b/vm-virtio/src/rng.rs
@@ -121,6 +121,14 @@ impl RngEpollHandler {
         const EPOLL_EVENTS_LEN: usize = 100;
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 
+        // Before jumping into the epoll loop, check if the device is expected
+        // to be in a paused state. This is helpful for the restore code path
+        // as the device thread should not start processing anything before the
+        // device has been resumed.
+        while paused.load(Ordering::SeqCst) {
+            thread::park();
+        }
+
         'epoll: loop {
             let num_events = match epoll::wait(epoll_file.as_raw_fd(), -1, &mut events[..]) {
                 Ok(res) => res,

--- a/vm-virtio/src/vhost_user/handler.rs
+++ b/vm-virtio/src/vhost_user/handler.rs
@@ -117,6 +117,14 @@ impl<S: VhostUserMasterReqHandler> VhostUserEpollHandler<S> {
 
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); index + 1];
 
+        // Before jumping into the epoll loop, check if the device is expected
+        // to be in a paused state. This is helpful for the restore code path
+        // as the device thread should not start processing anything before the
+        // device has been resumed.
+        while paused.load(Ordering::SeqCst) {
+            thread::park();
+        }
+
         'poll: loop {
             let num_events = match epoll::wait(epoll_file.as_raw_fd(), -1, &mut events[..]) {
                 Ok(res) => res,

--- a/vm-virtio/src/vsock/device.rs
+++ b/vm-virtio/src/vsock/device.rs
@@ -253,6 +253,14 @@ where
 
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EVENTS_LEN];
 
+        // Before jumping into the epoll loop, check if the device is expected
+        // to be in a paused state. This is helpful for the restore code path
+        // as the device thread should not start processing anything before the
+        // device has been resumed.
+        while paused.load(Ordering::SeqCst) {
+            thread::park();
+        }
+
         'epoll: loop {
             let num_events = match epoll::wait(epoll_file.as_raw_fd(), -1, &mut events[..]) {
                 Ok(res) => res,

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -789,28 +789,6 @@ impl CpuManager {
                     vcpu_thread_barrier.wait();
 
                     loop {
-                        // vcpu.run() returns false on a KVM_EXIT_SHUTDOWN (triple-fault) so trigger a reset
-                        match vcpu.lock().unwrap().run() {
-                            Err(e) => {
-                                error!("VCPU generated error: {:?}", e);
-                                break;
-                            }
-                            Ok(true) => {}
-                            Ok(false) => {
-                                vcpu_run_interrupted.store(true, Ordering::SeqCst);
-                                reset_evt.write(1).unwrap();
-                                break;
-                            }
-                        }
-
-                        // We've been told to terminate
-                        if vcpu_kill_signalled.load(Ordering::SeqCst)
-                            || vcpu_kill.load(Ordering::SeqCst)
-                        {
-                            vcpu_run_interrupted.store(true, Ordering::SeqCst);
-                            break;
-                        }
-
                         // If we are being told to pause, we park the thread
                         // until the pause boolean is toggled.
                         // The resume operation is responsible for toggling
@@ -824,6 +802,28 @@ impl CpuManager {
                                 thread::park();
                             }
                             vcpu_run_interrupted.store(false, Ordering::SeqCst);
+                        }
+
+                        // We've been told to terminate
+                        if vcpu_kill_signalled.load(Ordering::SeqCst)
+                            || vcpu_kill.load(Ordering::SeqCst)
+                        {
+                            vcpu_run_interrupted.store(true, Ordering::SeqCst);
+                            break;
+                        }
+
+                        // vcpu.run() returns false on a KVM_EXIT_SHUTDOWN (triple-fault) so trigger a reset
+                        match vcpu.lock().unwrap().run() {
+                            Err(e) => {
+                                error!("VCPU generated error: {:?}", e);
+                                break;
+                            }
+                            Ok(true) => {}
+                            Ok(false) => {
+                                vcpu_run_interrupted.store(true, Ordering::SeqCst);
+                                reset_evt.write(1).unwrap();
+                                break;
+                            }
                         }
 
                         // We've been told to terminate
@@ -1330,6 +1330,9 @@ impl Snapshottable for CpuManager {
 
     fn restore(&mut self, snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
         let vcpu_thread_barrier = Arc::new(Barrier::new((snapshot.snapshots.len() + 1) as usize));
+
+        // Restore the vCPUs in "paused" state.
+        self.vcpus_pause_signalled.store(true, Ordering::SeqCst);
 
         for (cpu_id, snapshot) in snapshot.snapshots.iter() {
             debug!("Restoring VCPU {}", cpu_id);

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3464,6 +3464,7 @@ impl Snapshottable for DeviceManager {
             if let Some(migratable) = &node.migratable {
                 debug!("Restoring {} from DeviceManager", node.id);
                 if let Some(snapshot) = snapshot.snapshots.get(&node.id) {
+                    migratable.lock().unwrap().pause()?;
                     migratable.lock().unwrap().restore(*snapshot.clone())?;
                 } else {
                     return Err(MigratableError::Restore(anyhow!(


### PR DESCRIPTION
In order to stay symmetrical between snapshot and restore, and because the VM must be paused before we can perform a snapshot, the VM is now restored in a paused state. This means after the restore, we must resume it to get it in a running state.