### PR TITLE
hypervisor, arch: Fix warnings introduced in hypervisor crate

### DIFF
--- a/arch/src/aarch64/gic.rs
+++ b/arch/src/aarch64/gic.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use kvm_ioctls::{DeviceFd, VmFd};
+use kvm_ioctls::DeviceFd;
 use std::sync::Arc;
 use std::{boxed::Box, result};
 

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -16,7 +16,6 @@ pub mod regs;
 pub use self::fdt::DeviceInfoForFDT;
 use crate::DeviceType;
 use crate::RegionType;
-use kvm_ioctls::*;
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fmt::Debug;

--- a/arch/src/aarch64/regs.rs
+++ b/arch/src/aarch64/regs.rs
@@ -13,7 +13,6 @@ use kvm_bindings::{
     KVM_REG_ARM64_SYSREG_OP1_SHIFT, KVM_REG_ARM64_SYSREG_OP2_MASK, KVM_REG_ARM64_SYSREG_OP2_SHIFT,
     KVM_REG_ARM_CORE, KVM_REG_SIZE_U64,
 };
-use kvm_ioctls::VcpuFd;
 use std::sync::Arc;
 use std::{mem, result};
 use vm_memory::GuestMemoryMmap;

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -10,7 +10,7 @@
 use crate::vm::Vm;
 #[cfg(target_arch = "x86_64")]
 use crate::x86_64::CpuId;
-
+#[cfg(target_arch = "x86_64")]
 use kvm_ioctls::Cap;
 use std::sync::Arc;
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -11,6 +11,7 @@
 use kvm_ioctls::{NoDatamatch, VcpuFd, VmFd};
 use std::result;
 use std::sync::Arc;
+#[cfg(target_arch = "x86_64")]
 use vm_memory::Address;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -617,6 +618,7 @@ impl cpu::Vcpu for KvmVcpu {
 
         Ok(())
     }
+    #[allow(unused_variables)]
     #[cfg(target_arch = "aarch64")]
     fn set_cpu_state(&self, state: &CpuState) -> cpu::Result<()> {
         Ok(())

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -586,6 +586,7 @@ impl VcpuState {
 }
 
 impl CpuManager {
+    #[allow(unused_variables)]
     pub fn new(
         config: &CpusConfig,
         device_manager: &Arc<Mutex<DeviceManager>>,


### PR DESCRIPTION
This commit fixes some warning introduced in the previous
hyperviosr crate PR.Removed some unused variables from arch/aarch64
module.

Signed-off-by: Muminul Islam <muislam@microsoft.com>