### PR TITLE
vmm: Get and set KVM clock during pause/resume operations

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -57,8 +57,8 @@ pub use kvm_ioctls::{Cap, Kvm};
 /// Export generically-named wrappers of kvm-bindings for Unix-based platforms
 ///
 pub use {
-    kvm_bindings::kvm_create_device as CreateDevice, kvm_bindings::kvm_irq_routing as IrqRouting,
-    kvm_bindings::kvm_mp_state as MpState,
+    kvm_bindings::kvm_clock_data as ClockData, kvm_bindings::kvm_create_device as CreateDevice,
+    kvm_bindings::kvm_irq_routing as IrqRouting, kvm_bindings::kvm_mp_state as MpState,
     kvm_bindings::kvm_userspace_memory_region as MemoryRegion,
     kvm_bindings::kvm_vcpu_events as VcpuEvents, kvm_ioctls::DeviceFd, kvm_ioctls::IoEventAddress,
     kvm_ioctls::VcpuExit,
@@ -210,6 +210,20 @@ impl vm::Vm for KvmVm {
             .enable_cap(&cap)
             .map_err(|e| vm::HypervisorVmError::EnableSplitIrq(e.into()))?;
         Ok(())
+    }
+    /// Retrieve guest clock.
+    #[cfg(target_arch = "x86_64")]
+    fn get_clock(&self) -> vm::Result<ClockData> {
+        self.fd
+            .get_clock()
+            .map_err(|e| vm::HypervisorVmError::GetClock(e.into()))
+    }
+    /// Set guest clock.
+    #[cfg(target_arch = "x86_64")]
+    fn set_clock(&self, data: &ClockData) -> vm::Result<()> {
+        self.fd
+            .set_clock(data)
+            .map_err(|e| vm::HypervisorVmError::SetClock(e.into()))
     }
 }
 /// Wrapper over KVM system ioctls.

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -11,6 +11,8 @@
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::VcpuInit;
 use crate::cpu::Vcpu;
+#[cfg(target_arch = "x86_64")]
+use crate::ClockData;
 use crate::{CreateDevice, DeviceFd, IoEventAddress, IrqRouting, MemoryRegion};
 use std::sync::Arc;
 use thiserror::Error;
@@ -97,6 +99,16 @@ pub enum HypervisorVmError {
     ///
     #[error("Failed to enable split Irq: {0}")]
     EnableSplitIrq(#[source] anyhow::Error),
+    ///
+    /// Get clock error
+    ///
+    #[error("Failed to get clock: {0}")]
+    GetClock(#[source] anyhow::Error),
+    ///
+    /// Set clock error
+    ///
+    #[error("Failed to set clock: {0}")]
+    SetClock(#[source] anyhow::Error),
 }
 ///
 /// Result type for returning from a function
@@ -141,4 +153,10 @@ pub trait Vm: Send + Sync {
     /// Enable split Irq capability
     #[cfg(target_arch = "x86_64")]
     fn enable_split_irq(&self) -> Result<()>;
+    /// Retrieve guest clock.
+    #[cfg(target_arch = "x86_64")]
+    fn get_clock(&self) -> Result<ClockData>;
+    /// Set guest clock.
+    #[cfg(target_arch = "x86_64")]
+    fn set_clock(&self, data: &ClockData) -> Result<()>;
 }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -59,6 +59,7 @@ const KVM_SET_CPUID2: u64 = 0x4008_ae90;
 const KVM_SET_DEVICE_ATTR: u64 = 0x4018_aee1;
 const KVM_SET_USER_MEMORY_REGION: u64 = 0x4020_ae46;
 const KVM_IRQFD: u64 = 0x4020_ae76;
+const KVM_SET_CLOCK: u64 = 0x4030_ae7b;
 const KVM_CREATE_PIT2: u64 = 0x4040_ae77;
 const KVM_IOEVENTFD: u64 = 0x4040_ae79;
 const KVM_ENABLE_CAP: u64 = 0x4068_aea3;
@@ -69,6 +70,7 @@ const KVM_SET_FPU: u64 = 0x41a0_ae8d;
 const KVM_SET_LAPIC: u64 = 0x4400_ae8f;
 const KVM_SET_XSAVE: u64 = 0x5000_aea5;
 const KVM_GET_MP_STATE: u64 = 0x8004_ae98;
+const KVM_GET_CLOCK: u64 = 0x8030_ae7c;
 const KVM_GET_VCPU_EVENTS: u64 = 0x8040_ae9f;
 const KVM_GET_REGS: u64 = 0x8090_ae81;
 const KVM_GET_SREGS: u64 = 0x8138_ae83;
@@ -123,6 +125,7 @@ fn create_vmm_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_VM)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_ENABLE_CAP)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_API_VERSION,)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_CLOCK,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_FPU)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_LAPIC)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MP_STATE)?],
@@ -137,6 +140,7 @@ fn create_vmm_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_IOEVENTFD)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_IRQFD)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_RUN)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_CLOCK)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_CPUID2)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_DEVICE_ATTR,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_FPU)?],


### PR DESCRIPTION
The KVM clock can be used as a clock source from the guest, that's why it's important to store it when the VM is being paused and restore it when the VM is being resumed.
Because the snapshot/restore operations expect the VM to go through pause/resume states, this use case is covered by this PR.