### PR TITLE
vmm: cpu: Reuse already allocated vCPUs if available     

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3775,6 +3775,19 @@ mod tests {
                 u32::from(desired_vcpus)
             );
 
+            // Resize the VM back up to 4
+            let desired_vcpus = 4;
+            resize_command(&api_socket, Some(desired_vcpus), None);
+
+            guest.ssh_command("echo 1 | sudo tee /sys/bus/cpu/devices/cpu2/online")?;
+            guest.ssh_command("echo 1 | sudo tee /sys/bus/cpu/devices/cpu3/online")?;
+            thread::sleep(std::time::Duration::new(10, 0));
+            aver_eq!(
+                tb,
+                guest.get_cpu_count().unwrap_or_default(),
+                u32::from(desired_vcpus)
+            );
+
             let _ = child.kill();
             let _ = child.wait();
             Ok(())

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -900,6 +900,10 @@ impl CpuManager {
         state.signal_thread();
         state.join_thread()?;
         state.handle = None;
+
+        // Once the thread has exited, clear the "kill" so that it can reused
+        state.kill.store(false, Ordering::SeqCst);
+
         Ok(())
     }
 


### PR DESCRIPTION
When a request is made to increase the number of vCPUs in the VM attempt
to reuse any previously removed (and hence inactive) vCPUs before
creating new ones.
    
This ensures that the APIC ID is not reused for a different KVM vCPU
(which is not allowed) and that the APIC IDs are also sequential.
    
The two key changes to support this are:
    
* Clearing the "kill" bit on the old vCPU state so that it does not
   immediately exit upon thread recreation.
* Using the length of the vcpus vector (the number of allocated vcpus)
  rather than the number of active vCPUs (.present_vcpus()) to determine
   how many should be created.
    
This change also introduced some new info!() debugging on the vCPU
creation/removal path to aid further development in the future.
    
TEST=Expanded test_cpu_hotplug test.
    
Fixes: #1338
