### PR TITLE
Patches for interrupt.rs

### DIFF
--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -108,19 +108,19 @@ pub struct KvmRoutingEntry {
     masked: bool,
 }
 
-pub struct MsiInterruptGroup {
+pub struct KvmMsiInterruptGroup {
     vm_fd: Arc<dyn hypervisor::Vm>,
     gsi_msi_routes: Arc<Mutex<HashMap<u32, KvmRoutingEntry>>>,
     irq_routes: HashMap<InterruptIndex, InterruptRoute>,
 }
 
-impl MsiInterruptGroup {
+impl KvmMsiInterruptGroup {
     fn new(
         vm_fd: Arc<dyn hypervisor::Vm>,
         gsi_msi_routes: Arc<Mutex<HashMap<u32, KvmRoutingEntry>>>,
         irq_routes: HashMap<InterruptIndex, InterruptRoute>,
     ) -> Self {
-        MsiInterruptGroup {
+        KvmMsiInterruptGroup {
             vm_fd,
             gsi_msi_routes,
             irq_routes,
@@ -179,7 +179,7 @@ impl MsiInterruptGroup {
     }
 }
 
-impl InterruptSourceGroup for MsiInterruptGroup {
+impl InterruptSourceGroup for KvmMsiInterruptGroup {
     fn enable(&self) -> Result<()> {
         for (_, route) in self.irq_routes.iter() {
             route.enable(&self.vm_fd)?;
@@ -372,7 +372,7 @@ impl InterruptManager for KvmMsiInterruptManager {
             irq_routes.insert(i, InterruptRoute::new(&mut allocator)?);
         }
 
-        Ok(Arc::new(Box::new(MsiInterruptGroup::new(
+        Ok(Arc::new(Box::new(KvmMsiInterruptGroup::new(
             self.vm_fd.clone(),
             self.gsi_msi_routes.clone(),
             irq_routes,

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -44,13 +44,13 @@ fn vec_with_size_in_bytes<T: Default>(size_in_bytes: usize) -> Vec<T> {
 // for `Foo`, a `Vec<Foo>` is created. Only the first element of `Vec<Foo>` would actually be used
 // as a `Foo`. The remaining memory in the `Vec<Foo>` is for `entries`, which must be contiguous
 // with `Foo`. This function is used to make the `Vec<Foo>` with enough space for `count` entries.
-pub fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
+fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
     let element_space = count * size_of::<F>();
     let vec_size_bytes = size_of::<T>() + element_space;
     vec_with_size_in_bytes(vec_size_bytes)
 }
 
-pub struct InterruptRoute {
+struct InterruptRoute {
     pub gsi: u32,
     pub irq_fd: EventFd,
     registered: AtomicBool,
@@ -108,7 +108,7 @@ pub struct KvmRoutingEntry {
     masked: bool,
 }
 
-pub struct KvmMsiInterruptGroup {
+struct KvmMsiInterruptGroup {
     vm_fd: Arc<dyn hypervisor::Vm>,
     gsi_msi_routes: Arc<Mutex<HashMap<u32, KvmRoutingEntry>>>,
     irq_routes: HashMap<InterruptIndex, InterruptRoute>,


### PR DESCRIPTION
Microsoft Hypervisor will use more or less the same architecture like KVM for interrupt handling, yet the data structures and function calls may be different.

The first patch makes clear MsiInterruptGroup is KVM specific. The second patch is a minor clearnup patch I come up with while reading the code.