### PR TITLE
vmm: Add support for notifying guest is being paused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "kvm-ioctls"
 version = "0.5.0"
-source = "git+https://github.com/cloud-hypervisor/kvm-ioctls?branch=ch#5b7f1cc5de6d9664ee30e7d6a2f183499de0f685"
+source = "git+https://github.com/cloud-hypervisor/kvm-ioctls?branch=ch#c5cbd2eef7337b2767173bf9ba0e6ccb1674f09a"
 dependencies = [
  "kvm-bindings",
  "libc",

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -139,6 +139,11 @@ pub enum HypervisorCpuError {
     ///
     #[error("Failed to init vcpu: {0}")]
     GetOneReg(#[source] anyhow::Error),
+    ///
+    /// Getting guest clock paused error
+    ///
+    #[error("Failed to notify guest its clock was paused: {0}")]
+    NotifyGuestClockPaused(#[source] anyhow::Error),
 }
 
 ///
@@ -248,6 +253,12 @@ pub trait Vcpu: Send + Sync {
     /// states of the vcpu.
     ///
     fn get_vcpu_events(&self) -> Result<VcpuEvents>;
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// Let the guest know that it has been paused, which prevents from
+    /// potential soft lockups when being resumed.
+    ///
+    fn notify_guest_clock_paused(&self) -> Result<()>;
     ///
     /// Sets the type of CPU to be exposed to the guest and optional features.
     ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -525,6 +525,16 @@ impl cpu::Vcpu for KvmVcpu {
             .get_vcpu_events()
             .map_err(|e| cpu::HypervisorCpuError::GetVcpuEvents(e.into()))
     }
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// Let the guest know that it has been paused, which prevents from
+    /// potential soft lockups when being resumed.
+    ///
+    fn notify_guest_clock_paused(&self) -> cpu::Result<()> {
+        self.fd
+            .kvmclock_ctrl()
+            .map_err(|e| cpu::HypervisorCpuError::NotifyGuestClockPaused(e.into()))
+    }
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     fn vcpu_init(&self, kvi: &VcpuInit) -> cpu::Result<()> {
         self.fd

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -745,9 +745,10 @@ impl CpuManager {
                 .expect("Failed to configure vCPU");
         }
 
-        let vcpu_clone = Arc::clone(&vcpu);
+        // Adding vCPU to the CpuManager's vCPU list.
+        self.vcpus.push(Arc::clone(&vcpu));
 
-        Ok(vcpu_clone)
+        Ok(vcpu)
     }
 
     /// Only create new vCPUs if there aren't any inactive ones to reuse
@@ -766,8 +767,7 @@ impl CpuManager {
 
         // Only create vCPUs in excess of all the allocated vCPUs.
         for cpu_id in self.vcpus.len() as u8..desired_vcpus {
-            let vcpu = self.create_vcpu(cpu_id, entry_point, None)?;
-            self.vcpus.push(vcpu);
+            self.create_vcpu(cpu_id, entry_point, None)?;
         }
 
         Ok(())

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1322,6 +1322,20 @@ impl Pausable for CpuManager {
             state.signal_thread();
         }
 
+        #[cfg(target_arch = "x86_64")]
+        for vcpu in self.vcpus.iter() {
+            vcpu.lock()
+                .unwrap()
+                .fd
+                .notify_guest_clock_paused()
+                .map_err(|e| {
+                    MigratableError::Pause(anyhow!(
+                        "Could not notify guest it has been paused {:?}",
+                        e
+                    ))
+                })?;
+        }
+
         Ok(())
     }
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -52,6 +52,7 @@ const KVM_CREATE_VCPU: u64 = 0xae41;
 const KVM_SET_TSS_ADDR: u64 = 0xae47;
 const KVM_CREATE_IRQCHIP: u64 = 0xae60;
 const KVM_RUN: u64 = 0xae80;
+const KVM_KVMCLOCK_CTRL: u64 = 0xaead;
 const KVM_SET_MP_STATE: u64 = 0x4004_ae99;
 const KVM_SET_GSI_ROUTING: u64 = 0x4008_ae6a;
 const KVM_SET_MSRS: u64 = 0x4008_ae89;
@@ -139,6 +140,7 @@ fn create_vmm_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_XCRS,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_IOEVENTFD)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_IRQFD)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_KVMCLOCK_CTRL)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_RUN)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_CLOCK)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_CPUID2)?],


### PR DESCRIPTION
Extend the Vcpu trait to be able to notify a guest that it is being paused. This is useful to avoid watchdogs running in the guest to complain when the guest is resumed after a certain period of time.