### PR TITLE
vmm: Save and restore vCPU states during pause/resume operations

### DIFF
--- a/vm-virtio/src/block.rs
+++ b/vm-virtio/src/block.rs
@@ -832,8 +832,6 @@ impl<T: DiskFile> BlockEpollHandler<T> {
                         break 'epoll;
                     }
                     PAUSE_EVENT => {
-                        // Drain pause event
-                        let _ = self.pause_evt.read();
                         debug!("PAUSE_EVENT received, pausing virtio-block epoll loop");
                         // We loop here to handle spurious park() returns.
                         // Until we have not resumed, the paused boolean will
@@ -841,6 +839,11 @@ impl<T: DiskFile> BlockEpollHandler<T> {
                         while paused.load(Ordering::SeqCst) {
                             thread::park();
                         }
+
+                        // Drain pause event after the device has been resumed.
+                        // This ensures the pause event has been seen by each
+                        // and every thread related to this virtio device.
+                        let _ = self.pause_evt.read();
                     }
                     _ => {
                         error!("Unknown event for virtio-block");

--- a/vm-virtio/src/console.rs
+++ b/vm-virtio/src/console.rs
@@ -313,8 +313,6 @@ impl ConsoleEpollHandler {
                         break 'epoll;
                     }
                     PAUSE_EVENT => {
-                        // Drain pause event
-                        let _ = self.pause_evt.read();
                         debug!("PAUSE_EVENT received, pausing virtio-console epoll loop");
                         // We loop here to handle spurious park() returns.
                         // Until we have not resumed, the paused boolean will
@@ -322,6 +320,11 @@ impl ConsoleEpollHandler {
                         while paused.load(Ordering::SeqCst) {
                             thread::park();
                         }
+
+                        // Drain pause event after the device has been resumed.
+                        // This ensures the pause event has been seen by each
+                        // and every thread related to this virtio device.
+                        let _ = self.pause_evt.read();
                     }
                     _ => {
                         error!("Unknown event for virtio-console");

--- a/vm-virtio/src/mem.rs
+++ b/vm-virtio/src/mem.rs
@@ -747,6 +747,11 @@ impl MemEpollHandler {
                         while paused.load(Ordering::SeqCst) {
                             thread::park();
                         }
+
+                        // Drain pause event after the device has been resumed.
+                        // This ensures the pause event has been seen by each
+                        // and every thread related to this virtio device.
+                        let _ = self.pause_evt.read();
                     }
                     _ => {
                         return Err(DeviceError::EpollHander(String::from(

--- a/vm-virtio/src/net.rs
+++ b/vm-virtio/src/net.rs
@@ -395,8 +395,6 @@ impl NetEpollHandler {
                         break 'epoll;
                     }
                     PAUSE_EVENT => {
-                        // Drain pause event
-                        let _ = self.pause_evt.read();
                         debug!("PAUSE_EVENT received, pausing virtio-net epoll loop");
 
                         // We loop here to handle spurious park() returns.
@@ -405,6 +403,11 @@ impl NetEpollHandler {
                         while paused.load(Ordering::SeqCst) {
                             thread::park();
                         }
+
+                        // Drain pause event after the device has been resumed.
+                        // This ensures the pause event has been seen by each
+                        // and every thread related to this virtio device.
+                        let _ = self.pause_evt.read();
                     }
                     _ => {
                         error!("Unknown event for virtio-net");

--- a/vm-virtio/src/rng.rs
+++ b/vm-virtio/src/rng.rs
@@ -167,8 +167,6 @@ impl RngEpollHandler {
                         break 'epoll;
                     }
                     PAUSE_EVENT => {
-                        // Drain pause event
-                        let _ = self.pause_evt.read();
                         debug!("PAUSE_EVENT received, pausing virtio-rng epoll loop");
                         // We loop here to handle spurious park() returns.
                         // Until we have not resumed, the paused boolean will
@@ -176,6 +174,11 @@ impl RngEpollHandler {
                         while paused.load(Ordering::SeqCst) {
                             thread::park();
                         }
+
+                        // Drain pause event after the device has been resumed.
+                        // This ensures the pause event has been seen by each
+                        // and every thread related to this virtio device.
+                        let _ = self.pause_evt.read();
                     }
                     _ => {
                         error!("Unknown event for virtio-block");

--- a/vm-virtio/src/vsock/device.rs
+++ b/vm-virtio/src/vsock/device.rs
@@ -365,8 +365,6 @@ where
                 return Ok(true);
             }
             PAUSE_EVENT => {
-                // Drain pause event
-                let _ = self.pause_evt.read();
                 debug!("PAUSE_EVENT received, pausing virtio-vsock epoll loop");
                 // We loop here to handle spurious park() returns.
                 // Until we have not resumed, the paused boolean will
@@ -374,6 +372,11 @@ where
                 while paused.load(Ordering::SeqCst) {
                     thread::park();
                 }
+
+                // Drain pause event after the device has been resumed.
+                // This ensures the pause event has been seen by each
+                // and every thread related to this virtio device.
+                let _ = self.pause_evt.read();
             }
             other => {
                 error!("Unknown event for virtio-vsock");

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1162,7 +1162,6 @@ impl Pausable for Vm {
             .valid_transition(new_state)
             .map_err(|e| MigratableError::Resume(anyhow!("Invalid transition: {:?}", e)))?;
 
-        self.device_manager.lock().unwrap().resume()?;
         self.cpu_manager.lock().unwrap().resume()?;
         #[cfg(target_arch = "x86_64")]
         {
@@ -1172,6 +1171,7 @@ impl Pausable for Vm {
                 })?;
             }
         }
+        self.device_manager.lock().unwrap().resume()?;
 
         // And we're back to the Running state.
         *state = new_state;


### PR DESCRIPTION
We need consistency between pause/resume and snapshot/restore operations. The symmetrical behavior of pausing/snapshotting and restoring/resuming has been introduced recently, and we must now ensure that no matter if we're using pause/resume or snapshot/restore features, the resulting VM should be running in the exact same way.

That's why the vCPU state is now stored upon VM pausing. The snapshot operation being a simple serialization of the previously saved state. The same way, the vCPU state is now restored upon VM resuming. The restore operation being a simple deserialization of the state.

It's interesting to note that this patch ensures time consistency from a guest perspective, no matter which clocksource is being used. From a previous patch, the KVM clock was saved/restored upon VM pause/resume. We now have the same behavior for TSC, as the TSC from the vCPUs are saved/restored upon VM pause/resume too.