### PR TITLE
Add virtio device counters

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -337,6 +337,7 @@ fn do_command(matches: &ArgMatches) -> Result<(), Error> {
 
     match matches.subcommand_name() {
         Some("info") => simple_api_command(&mut socket, "GET", "info", None),
+        Some("counters") => simple_api_command(&mut socket, "GET", "counters", None),
         Some("resize") => resize_api_command(
             &mut socket,
             matches
@@ -498,6 +499,7 @@ fn main() {
                 .arg(Arg::with_name("id").index(1).help("<device_id>")),
         )
         .subcommand(SubCommand::with_name("info").about("Info on the VM"))
+        .subcommand(SubCommand::with_name("counters").about("Counters from the VM"))
         .subcommand(SubCommand::with_name("pause").about("Pause the VM"))
         .subcommand(SubCommand::with_name("reboot").about("Reboot the VM"))
         .subcommand(

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -30,7 +30,7 @@ use virtio_bindings::bindings::virtio_net::*;
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 use vm_virtio::net_util::{open_tap, RxVirtio, TxVirtio};
-use vm_virtio::NetQueuePair;
+use vm_virtio::{NetCounters, NetQueuePair};
 use vmm::config::{OptionParser, OptionParserError};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -111,6 +111,7 @@ impl VhostUserNetThread {
                 tx: TxVirtio::new(),
                 rx_tap_listening: false,
                 epoll_fd: None,
+                counters: NetCounters::default(),
             },
         })
     }

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use crate::{ActivateResult, Error, Queue};
+use std::collections::HashMap;
+use std::num::Wrapping;
 use std::sync::Arc;
 use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryMmap, GuestUsize};
 use vmm_sys_util::eventfd::EventFd;
@@ -133,6 +135,11 @@ pub trait VirtioDevice: Send {
     /// Returns the list of userspace mappings associated with this device.
     fn userspace_mappings(&self) -> Vec<UserspaceMapping> {
         Vec::new()
+    }
+
+    /// Return the counters that this device exposes
+    fn counters(&self) -> Option<HashMap<&'static str, Wrapping<u64>>> {
+        None
     }
 }
 

--- a/vm-virtio/src/net.rs
+++ b/vm-virtio/src/net.rs
@@ -20,6 +20,7 @@ use libc::EAGAIN;
 use libc::EFD_NONBLOCK;
 use net_util::{MacAddr, Tap};
 use std::cmp;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::io::{self, Write};
@@ -738,6 +739,29 @@ impl VirtioDevice for Net {
             self.interrupt_cb.take().unwrap(),
             self.queue_evts.take().unwrap(),
         ))
+    }
+
+    fn counters(&self) -> Option<HashMap<&'static str, Wrapping<u64>>> {
+        let mut counters = HashMap::new();
+
+        counters.insert(
+            "rx_bytes",
+            Wrapping(self.counters.rx_bytes.load(Ordering::Acquire)),
+        );
+        counters.insert(
+            "rx_frames",
+            Wrapping(self.counters.rx_frames.load(Ordering::Acquire)),
+        );
+        counters.insert(
+            "tx_bytes",
+            Wrapping(self.counters.tx_bytes.load(Ordering::Acquire)),
+        );
+        counters.insert(
+            "tx_frames",
+            Wrapping(self.counters.tx_frames.load(Ordering::Acquire)),
+        );
+
+        Some(counters)
     }
 }
 

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -174,26 +174,26 @@ lazy_static! {
             routes: HashMap::new(),
         };
 
-        r.routes.insert(endpoint!("/vm.create"), Box::new(VmCreate {}));
+        r.routes.insert(endpoint!("/vm.add-device"), Box::new(VmActionHandler::new(VmAction::AddDevice(Arc::default()))));
+        r.routes.insert(endpoint!("/vm.add-disk"), Box::new(VmActionHandler::new(VmAction::AddDisk(Arc::default()))));
+        r.routes.insert(endpoint!("/vm.add-fs"), Box::new(VmActionHandler::new(VmAction::AddFs(Arc::default()))));
+        r.routes.insert(endpoint!("/vm.add-net"), Box::new(VmActionHandler::new(VmAction::AddNet(Arc::default()))));
+        r.routes.insert(endpoint!("/vm.add-pmem"), Box::new(VmActionHandler::new(VmAction::AddPmem(Arc::default()))));
+        r.routes.insert(endpoint!("/vm.add-vsock"), Box::new(VmActionHandler::new(VmAction::AddVsock(Arc::default()))));
         r.routes.insert(endpoint!("/vm.boot"), Box::new(VmActionHandler::new(VmAction::Boot)));
+        r.routes.insert(endpoint!("/vm.create"), Box::new(VmCreate {}));
         r.routes.insert(endpoint!("/vm.delete"), Box::new(VmActionHandler::new(VmAction::Delete)));
         r.routes.insert(endpoint!("/vm.info"), Box::new(VmInfo {}));
         r.routes.insert(endpoint!("/vm.pause"), Box::new(VmActionHandler::new(VmAction::Pause)));
+        r.routes.insert(endpoint!("/vm.reboot"), Box::new(VmActionHandler::new(VmAction::Reboot)));
+        r.routes.insert(endpoint!("/vm.remove-device"), Box::new(VmActionHandler::new(VmAction::RemoveDevice(Arc::default()))));
+        r.routes.insert(endpoint!("/vm.resize"), Box::new(VmActionHandler::new(VmAction::Resize(Arc::default()))));
+        r.routes.insert(endpoint!("/vm.restore"), Box::new(VmActionHandler::new(VmAction::Restore(Arc::default()))));
         r.routes.insert(endpoint!("/vm.resume"), Box::new(VmActionHandler::new(VmAction::Resume)));
         r.routes.insert(endpoint!("/vm.shutdown"), Box::new(VmActionHandler::new(VmAction::Shutdown)));
-        r.routes.insert(endpoint!("/vm.reboot"), Box::new(VmActionHandler::new(VmAction::Reboot)));
         r.routes.insert(endpoint!("/vm.snapshot"), Box::new(VmActionHandler::new(VmAction::Snapshot(Arc::default()))));
-        r.routes.insert(endpoint!("/vm.restore"), Box::new(VmActionHandler::new(VmAction::Restore(Arc::default()))));
-        r.routes.insert(endpoint!("/vmm.shutdown"), Box::new(VmmShutdown {}));
         r.routes.insert(endpoint!("/vmm.ping"), Box::new(VmmPing {}));
-        r.routes.insert(endpoint!("/vm.resize"), Box::new(VmActionHandler::new(VmAction::Resize(Arc::default()))));
-        r.routes.insert(endpoint!("/vm.add-device"), Box::new(VmActionHandler::new(VmAction::AddDevice(Arc::default()))));
-        r.routes.insert(endpoint!("/vm.remove-device"), Box::new(VmActionHandler::new(VmAction::RemoveDevice(Arc::default()))));
-        r.routes.insert(endpoint!("/vm.add-disk"), Box::new(VmActionHandler::new(VmAction::AddDisk(Arc::default()))));
-        r.routes.insert(endpoint!("/vm.add-fs"), Box::new(VmActionHandler::new(VmAction::AddFs(Arc::default()))));
-        r.routes.insert(endpoint!("/vm.add-pmem"), Box::new(VmActionHandler::new(VmAction::AddPmem(Arc::default()))));
-        r.routes.insert(endpoint!("/vm.add-net"), Box::new(VmActionHandler::new(VmAction::AddNet(Arc::default()))));
-        r.routes.insert(endpoint!("/vm.add-vsock"), Box::new(VmActionHandler::new(VmAction::AddVsock(Arc::default()))));
+        r.routes.insert(endpoint!("/vmm.shutdown"), Box::new(VmmShutdown {}));
 
         r
     };

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -94,6 +94,9 @@ pub enum HttpError {
 
     /// Could not add a vsock device to a VM
     VmAddVsock(ApiError),
+
+    /// Could not get counters from VM
+    VmCounters(ApiError),
 }
 
 impl From<serde_json::Error> for HttpError {
@@ -193,6 +196,7 @@ lazy_static! {
         r.routes.insert(endpoint!("/vm.add-pmem"), Box::new(VmActionHandler::new(VmAction::AddPmem(Arc::default()))));
         r.routes.insert(endpoint!("/vm.add-vsock"), Box::new(VmActionHandler::new(VmAction::AddVsock(Arc::default()))));
         r.routes.insert(endpoint!("/vm.boot"), Box::new(VmActionHandler::new(VmAction::Boot)));
+        r.routes.insert(endpoint!("/vm.counters"), Box::new(VmActionHandler::new(VmAction::Counters)));
         r.routes.insert(endpoint!("/vm.create"), Box::new(VmCreate {}));
         r.routes.insert(endpoint!("/vm.delete"), Box::new(VmActionHandler::new(VmAction::Delete)));
         r.routes.insert(endpoint!("/vm.info"), Box::new(VmInfo {}));

--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -6,8 +6,9 @@
 use crate::api::http::{error_response, EndpointHandler, HttpError};
 use crate::api::{
     vm_add_device, vm_add_disk, vm_add_fs, vm_add_net, vm_add_pmem, vm_add_vsock, vm_boot,
-    vm_create, vm_delete, vm_info, vm_pause, vm_reboot, vm_remove_device, vm_resize, vm_restore,
-    vm_resume, vm_shutdown, vm_snapshot, vmm_ping, vmm_shutdown, ApiRequest, VmAction, VmConfig,
+    vm_counters, vm_create, vm_delete, vm_info, vm_pause, vm_reboot, vm_remove_device, vm_resize,
+    vm_restore, vm_resume, vm_shutdown, vm_snapshot, vmm_ping, vmm_shutdown, ApiRequest, VmAction,
+    VmConfig,
 };
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 use std::sync::mpsc::Sender;
@@ -157,6 +158,19 @@ impl EndpointHandler for VmActionHandler {
                 Resume => vm_resume(api_notifier, api_sender).map_err(HttpError::VmResume),
                 _ => Err(HttpError::BadRequest),
             }
+        }
+    }
+
+    fn get_handler(
+        &self,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+        _body: &Option<Body>,
+    ) -> std::result::Result<Option<Body>, HttpError> {
+        use VmAction::*;
+        match self.action {
+            Counters => vm_counters(api_notifier, api_sender).map_err(HttpError::VmCounters),
+            _ => Err(HttpError::BadRequest),
         }
     }
 }

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -214,6 +214,9 @@ pub enum ApiRequest {
     /// Resume a VM.
     VmResume(Sender<ApiResponse>),
 
+    /// Get counters for a VM.
+    VmCounters(Sender<ApiResponse>),
+
     /// Shut the previously booted virtual machine down.
     /// If the VM was not previously booted or created, the VMM API server
     /// will send a VmShutdown error back.
@@ -300,6 +303,9 @@ pub enum VmAction {
     /// Resume a VM
     Resume,
 
+    /// Return VM counters
+    Counters,
+
     /// Add VFIO device
     AddDevice(Arc<DeviceConfig>),
 
@@ -346,6 +352,7 @@ fn vm_action(
         Reboot => ApiRequest::VmReboot(response_sender),
         Pause => ApiRequest::VmPause(response_sender),
         Resume => ApiRequest::VmResume(response_sender),
+        Counters => ApiRequest::VmCounters(response_sender),
         AddDevice(v) => ApiRequest::VmAddDevice(v, response_sender),
         AddDisk(v) => ApiRequest::VmAddDisk(v, response_sender),
         AddFs(v) => ApiRequest::VmAddFs(v, response_sender),
@@ -393,6 +400,10 @@ pub fn vm_pause(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> ApiResult<O
 
 pub fn vm_resume(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> ApiResult<Option<Body>> {
     vm_action(api_evt, api_sender, VmAction::Resume)
+}
+
+pub fn vm_counters(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> ApiResult<Option<Body>> {
+    vm_action(api_evt, api_sender, VmAction::Counters)
 }
 
 pub fn vm_snapshot(

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3134,6 +3134,19 @@ impl DeviceManager {
         let (device, iommu_attached, id) = self.make_virtio_vsock_device(vsock_cfg)?;
         self.hotplug_virtio_pci_device(device, iommu_attached, id)
     }
+
+    pub fn counters(&self) -> HashMap<String, HashMap<&'static str, Wrapping<u64>>> {
+        let mut counters = HashMap::new();
+
+        for (virtio_device, _, id) in &self.virtio_devices {
+            let virtio_device = virtio_device.lock().unwrap();
+            if let Some(device_counters) = virtio_device.counters() {
+                counters.insert(id.clone(), device_counters.clone());
+            }
+        }
+
+        counters
+    }
 }
 
 #[cfg(feature = "acpi")]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -44,8 +44,8 @@ use linux_loader::cmdline::Cmdline;
 #[cfg(target_arch = "x86_64")]
 use linux_loader::loader::elf::Error::InvalidElfMagicNumber;
 use linux_loader::loader::KernelLoader;
-
 use signal_hook::{iterator::Signals, SIGINT, SIGTERM, SIGWINCH};
+use std::collections::HashMap;
 #[cfg(target_arch = "x86_64")]
 use std::convert::TryInto;
 use std::ffi::CString;
@@ -53,6 +53,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 #[cfg(target_arch = "x86_64")]
 use std::io::{Seek, SeekFrom};
+use std::num::Wrapping;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
@@ -990,6 +991,10 @@ impl Vm {
             .map_err(Error::DeviceManager)?;
 
         Ok(pci_device_info)
+    }
+
+    pub fn counters(&self) -> Result<HashMap<String, HashMap<&'static str, Wrapping<u64>>>> {
+        Ok(HashMap::new())
     }
 
     fn os_signal_handler(signals: Signals, console_input_clone: Arc<Console>, on_tty: bool) {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -994,7 +994,7 @@ impl Vm {
     }
 
     pub fn counters(&self) -> Result<HashMap<String, HashMap<&'static str, Wrapping<u64>>>> {
-        Ok(HashMap::new())
+        Ok(self.device_manager.lock().unwrap().counters())
     }
 
     fn os_signal_handler(signals: Signals, console_input_clone: Arc<Console>, on_tty: bool) {


### PR DESCRIPTION
Add counters for key virtio devices (block and net) and expose them through a newly added HTTP API entry point.

See: #1287