### PR TITLE
vhost_user_fs: Allow fchmod in seccomp

### DIFF
--- a/vhost_user_fs/src/seccomp.rs
+++ b/vhost_user_fs/src/seccomp.rs
@@ -51,6 +51,7 @@ fn vuf_filter(action: SeccompAction) -> Result<SeccompFilter, Error> {
             allow_syscall(libc::SYS_exit_group),
             allow_syscall(libc::SYS_fallocate),
             allow_syscall(libc::SYS_fchdir),
+            allow_syscall(libc::SYS_fchmod),
             allow_syscall(libc::SYS_fchmodat),
             allow_syscall(libc::SYS_fchownat),
             allow_syscall(libc::SYS_fcntl),


### PR DESCRIPTION
This corresponds to QEMU's 63659fe74e76f5c52854 commit.
the setattr code uses both fchmod and fchmodat in different cases,
however we only had fchmodat in the whitelist.

Signed-off-by: Dr. David Alan Gilbert <dgilbert@redhat.com>