### PR TITLE
hypervisor: Update license to Apache-2.0 AND BSD-3-Clause

### DIFF
--- a/hypervisor/src/arch/mod.rs
+++ b/hypervisor/src/arch/mod.rs
@@ -6,7 +6,10 @@
 //
 // Copyright © 2019 Intel Corporation
 //
-// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+//
+// Copyright © 2020, Microsoft  Corporation
+//
 
 #[cfg(target_arch = "x86_64")]
 pub mod x86;

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -6,7 +6,10 @@
 //
 // Copyright © 2019 Intel Corporation
 //
-// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+//
+// Copyright © 2020, Microsoft  Corporation
+//
 
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -1,12 +1,12 @@
 // Copyright © 2019 Intel Corporation
 //
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 //
 // Copyright © 2020, Microsoft  Corporation
 //
 // Copyright 2018-2019 CrowdStrike, Inc.
 //
-// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
 
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::VcpuInit;

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -1,6 +1,6 @@
 // Copyright © 2019 Intel Corporation
 //
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 //
 // Copyright © 2020, Microsoft  Corporation
 //

--- a/hypervisor/src/kvm/aarch64/mod.rs
+++ b/hypervisor/src/kvm/aarch64/mod.rs
@@ -1,8 +1,11 @@
 // Copyright © 2019 Intel Corporation
 //
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 //
 // Copyright © 2020, Microsoft  Corporation
+//
+// Copyright 2018-2019 CrowdStrike, Inc.
+//
 //
 
 ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1,6 +1,6 @@
 // Copyright © 2019 Intel Corporation
 //
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 //
 // Copyright © 2020, Microsoft  Corporation
 //

--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -1,6 +1,6 @@
 // Copyright © 2019 Intel Corporation
 //
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 //
 // Copyright © 2020, Microsoft  Corporation
 //

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright © 2019 Intel Corporation
 //
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 //
 // Copyright © 2020, Microsoft  Corporation
 //

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -1,6 +1,6 @@
 // Copyright © 2019 Intel Corporation
 //
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 //
 // Copyright © 2020, Microsoft  Corporation
 //


### PR DESCRIPTION
Initially the licensing was just Apache-2.0. This patch changes
the licensing to dual license Apache-2.0 AND BSD-3-Clause

Signed-off-by: Muminul Islam <muislam@microsoft.com>