### PR TITLE
Generify interrupt module

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -14,7 +14,7 @@ use crate::config::ConsoleOutputMode;
 use crate::config::DeviceConfig;
 use crate::config::{DiskConfig, FsConfig, NetConfig, PmemConfig, VmConfig, VsockConfig};
 use crate::device_tree::{DeviceNode, DeviceTree};
-use crate::interrupt::{KvmMsiInterruptManager, LegacyUserspaceInterruptManager};
+use crate::interrupt::{kvm::KvmMsiInterruptManager, LegacyUserspaceInterruptManager};
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 #[cfg(feature = "pci_support")]
 use crate::PciDeviceInfo;

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -14,7 +14,7 @@ use crate::config::ConsoleOutputMode;
 use crate::config::DeviceConfig;
 use crate::config::{DiskConfig, FsConfig, NetConfig, PmemConfig, VmConfig, VsockConfig};
 use crate::device_tree::{DeviceNode, DeviceTree};
-use crate::interrupt::{KvmLegacyUserspaceInterruptManager, KvmMsiInterruptManager};
+use crate::interrupt::{KvmMsiInterruptManager, LegacyUserspaceInterruptManager};
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 #[cfg(feature = "pci_support")]
 use crate::PciDeviceInfo;
@@ -865,7 +865,7 @@ impl DeviceManager {
         // formed IOAPIC device.
         let legacy_interrupt_manager: Arc<
             dyn InterruptManager<GroupConfig = LegacyIrqGroupConfig>,
-        > = Arc::new(KvmLegacyUserspaceInterruptManager::new(Arc::clone(
+        > = Arc::new(LegacyUserspaceInterruptManager::new(Arc::clone(
             &interrupt_controller,
         )));
 

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -103,7 +103,7 @@ impl InterruptRoute {
     }
 }
 
-pub struct KvmRoutingEntry {
+struct KvmRoutingEntry {
     kvm_route: kvm_irq_routing_entry,
     masked: bool,
 }
@@ -327,11 +327,13 @@ impl KvmLegacyUserspaceInterruptManager {
 }
 
 impl KvmMsiInterruptManager {
-    pub fn new(
-        allocator: Arc<Mutex<SystemAllocator>>,
-        vm_fd: Arc<dyn hypervisor::Vm>,
-        gsi_msi_routes: Arc<Mutex<HashMap<u32, KvmRoutingEntry>>>,
-    ) -> Self {
+    pub fn new(allocator: Arc<Mutex<SystemAllocator>>, vm_fd: Arc<dyn hypervisor::Vm>) -> Self {
+        // Create a shared list of GSI that can be shared through all PCI
+        // devices. This way, we can maintain the full list of used GSI,
+        // preventing one device from overriding interrupts setting from
+        // another one.
+        let gsi_msi_routes = Arc::new(Mutex::new(HashMap::new()));
+
         KvmMsiInterruptManager {
             allocator,
             vm_fd,

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -310,7 +310,7 @@ impl InterruptSourceGroup for LegacyUserspaceInterruptGroup {
     }
 }
 
-pub struct KvmLegacyUserspaceInterruptManager {
+pub struct LegacyUserspaceInterruptManager {
     ioapic: Arc<Mutex<dyn InterruptController>>,
 }
 
@@ -320,9 +320,9 @@ pub struct KvmMsiInterruptManager {
     gsi_msi_routes: Arc<Mutex<HashMap<u32, KvmRoutingEntry>>>,
 }
 
-impl KvmLegacyUserspaceInterruptManager {
+impl LegacyUserspaceInterruptManager {
     pub fn new(ioapic: Arc<Mutex<dyn InterruptController>>) -> Self {
-        KvmLegacyUserspaceInterruptManager { ioapic }
+        LegacyUserspaceInterruptManager { ioapic }
     }
 }
 
@@ -342,7 +342,7 @@ impl KvmMsiInterruptManager {
     }
 }
 
-impl InterruptManager for KvmLegacyUserspaceInterruptManager {
+impl InterruptManager for LegacyUserspaceInterruptManager {
     type GroupConfig = LegacyIrqGroupConfig;
 
     fn create_group(

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -200,7 +200,12 @@ impl MsiInterruptGroupOps for KvmMsiInterruptGroup {
     }
 }
 
-impl InterruptSourceGroup for KvmMsiInterruptGroup {
+impl<E> InterruptSourceGroup for MsiInterruptGroup<E>
+where
+    E: Send + Sync,
+    RoutingEntry<E>: RoutingEntryExt,
+    MsiInterruptGroup<E>: MsiInterruptGroupOps,
+{
     fn enable(&self) -> Result<()> {
         for (_, route) in self.irq_routes.iter() {
             route.enable(&self.vm_fd)?;
@@ -238,7 +243,7 @@ impl InterruptSourceGroup for KvmMsiInterruptGroup {
 
     fn update(&self, index: InterruptIndex, config: InterruptSourceConfig) -> Result<()> {
         if let Some(route) = self.irq_routes.get(&index) {
-            let entry = KvmRoutingEntry::make_entry(route.gsi, &config)?;
+            let entry = RoutingEntry::<_>::make_entry(route.gsi, &config)?;
             self.gsi_msi_routes
                 .lock()
                 .unwrap()

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -133,7 +133,7 @@ impl<E> MsiInterruptGroup<E> {
 type KvmMsiInterruptGroup = MsiInterruptGroup<kvm_irq_routing_entry>;
 
 impl KvmMsiInterruptGroup {
-    fn set_kvm_gsi_routes(&self) -> Result<()> {
+    fn set_gsi_routes(&self) -> Result<()> {
         let gsi_msi_routes = self.gsi_msi_routes.lock().unwrap();
         let mut entry_vec: Vec<kvm_irq_routing_entry> = Vec::new();
         for (_, entry) in gsi_msi_routes.iter() {
@@ -229,7 +229,7 @@ impl InterruptSourceGroup for KvmMsiInterruptGroup {
                 ));
             }
 
-            return self.set_kvm_gsi_routes();
+            return self.set_gsi_routes();
         }
 
         Err(io::Error::new(
@@ -249,9 +249,9 @@ impl InterruptSourceGroup for KvmMsiInterruptGroup {
                     format!("mask: No existing route for interrupt index {}", index),
                 ));
             }
-            // Drop the guard because set_kvm_gsi_routes will try to take the lock again.
+            // Drop the guard because set_gsi_routes will try to take the lock again.
             drop(gsi_msi_routes);
-            self.set_kvm_gsi_routes()?;
+            self.set_gsi_routes()?;
             return route.disable(&self.vm_fd);
         }
 
@@ -272,9 +272,9 @@ impl InterruptSourceGroup for KvmMsiInterruptGroup {
                     format!("mask: No existing route for interrupt index {}", index),
                 ));
             }
-            // Drop the guard because set_kvm_gsi_routes will try to take the lock again.
+            // Drop the guard because set_gsi_routes will try to take the lock again.
             drop(gsi_msi_routes);
-            self.set_kvm_gsi_routes()?;
+            self.set_gsi_routes()?;
             return route.enable(&self.vm_fd);
         }
 

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -116,6 +116,10 @@ struct MsiInterruptGroup<E> {
     irq_routes: HashMap<InterruptIndex, InterruptRoute>,
 }
 
+trait MsiInterruptGroupOps {
+    fn set_gsi_routes(&self) -> Result<()>;
+}
+
 trait RoutingEntryExt {
     fn make_entry(gsi: u32, config: &InterruptSourceConfig) -> Result<Box<Self>>;
 }
@@ -164,7 +168,7 @@ impl<E> MsiInterruptGroup<E> {
 
 type KvmMsiInterruptGroup = MsiInterruptGroup<kvm_irq_routing_entry>;
 
-impl KvmMsiInterruptGroup {
+impl MsiInterruptGroupOps for KvmMsiInterruptGroup {
     fn set_gsi_routes(&self) -> Result<()> {
         let gsi_msi_routes = self.gsi_msi_routes.lock().unwrap();
         let mut entry_vec: Vec<kvm_irq_routing_entry> = Vec::new();


### PR DESCRIPTION
The core logic of the interrupt module is applicable to any hypervisor implementation.

This patch series splits KVM specific logic from the core logic.