### PR TITLE
ci: Update ClearLinux image with fio

### DIFF
--- a/docs/custom-image.md
+++ b/docs/custom-image.md
@@ -45,7 +45,7 @@ sudo swupd bundle-add os-installer
 wget https://download.clearlinux.org/current/config/image/cloudguest.yaml
 sed -i '/size: \"864M\"/d' cloudguest.yaml
 sed -i 's/\"800M\"/\"2G\"/g' cloudguest.yaml
-sed -i 's/bootloader,/bootloader,\n    curl,\n    iperf,/g' cloudguest.yaml
+sed -i 's/bootloader,/bootloader,\n    curl,\n    fio,\n    iperf,/g' cloudguest.yaml
 sed -i 's/systemd-networkd-autostart/sysadmin-basic,\n    systemd-networkd-autostart/g' cloudguest.yaml
 # Create the custom cloudguest image
 clr-installer -c cloudguest.yaml

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -18,7 +18,7 @@ if [ ! -f "$FW" ]; then
     popd
 fi
 
-CLEAR_OS_IMAGE_NAME="clear-31311-cloudguest.img"
+CLEAR_OS_IMAGE_NAME="clear-32480-cloudguest.img"
 CLEAR_OS_IMAGE_URL="https://cloudhypervisorstorage.blob.core.windows.net/images/$CLEAR_OS_IMAGE_NAME"
 CLEAR_OS_IMAGE="$WORKLOADS_DIR/$CLEAR_OS_IMAGE_NAME"
 if [ ! -f "$CLEAR_OS_IMAGE" ]; then
@@ -27,7 +27,7 @@ if [ ! -f "$CLEAR_OS_IMAGE" ]; then
     popd
 fi
 
-CLEAR_OS_RAW_IMAGE_NAME="clear-31311-cloudguest-raw.img"
+CLEAR_OS_RAW_IMAGE_NAME="clear-32480-cloudguest-raw.img"
 CLEAR_OS_RAW_IMAGE="$WORKLOADS_DIR/$CLEAR_OS_RAW_IMAGE_NAME"
 if [ ! -f "$CLEAR_OS_RAW_IMAGE" ]; then
     pushd $WORKLOADS_DIR

--- a/scripts/sha1sums
+++ b/scripts/sha1sums
@@ -1,5 +1,5 @@
-cf7cfa783082fc4d6b4d1c0a53e4402648c14b82 clear-31311-cloudguest.img
-142a410546b592ff9536b46bb410faf8ac11edee clear-31311-cloudguest-raw.img
+a73a9a2afd3f71144d6665cded025f8ec9c3e43a clear-32480-cloudguest.img
+deabfc1ad27f1f97bafb71bd77275a6894ebeb15 clear-32480-cloudguest-raw.img
 27f3b17962ace69b51f0ddc2012095e3109e6ed8 bionic-server-cloudimg-amd64.img
 8db9cc58b01452ce2d06c313177e6e74d8582d93 bionic-server-cloudimg-amd64-raw.img
 d4a44acc6014d5f83dea1c625c43d677a95fa75f alpine-minirootfs-x86_64.tar.gz

--- a/test_data/cloud-init/clear/openstack/latest/user_data
+++ b/test_data/cloud-init/clear/openstack/latest/user_data
@@ -77,4 +77,4 @@ write_files:
         # 1G ram requires 512 pages
         echo 512 | sudo tee /proc/sys/vm/nr_hugepages
         sudo chmod a+rwX /dev/hugepages
-        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c VFIOTAG" --disk path=/mnt/clear-31311-cloudguest.img path=/mnt/cloudinit.img --cpus boot=1 --memory size=512M,hotplug_size=1G,file=/dev/hugepages --device path=/sys/bus/pci/devices/0000:00:05.0/ path=/sys/bus/pci/devices/0000:00:06.0/ --api-socket /tmp/ch_api.sock
+        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=PARTUUID=1485769e-8c72-4a3a-a5f5-2bf2bc822816 VFIOTAG" --disk path=/mnt/clear-31311-cloudguest.img path=/mnt/cloudinit.img --cpus boot=1 --memory size=512M,hotplug_size=1G,file=/dev/hugepages --device path=/sys/bus/pci/devices/0000:00:05.0/ path=/sys/bus/pci/devices/0000:00:06.0/ --api-socket /tmp/ch_api.sock

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -99,11 +99,11 @@ mod tests {
     const BIONIC_IMAGE_NAME: &str = "bionic-server-cloudimg-amd64-raw.img";
     const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-raw.img";
 
-    const CLEAR_KERNEL_CMDLINE: &str = "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c \
+    const CLEAR_KERNEL_CMDLINE: &str = "root=PARTUUID=1485769e-8c72-4a3a-a5f5-2bf2bc822816 \
                      console=tty0 console=ttyS0,115200n8 console=hvc0 quiet \
                      init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable \
-                     no_timer_check noreplace-smp cryptomgr.notests \
-                     rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw";
+                     no_timer_check noreplace-smp cryptomgr.notests page_alloc.shuffle=1 \
+                     rootfstype=ext4,btrfs,xfs rw";
 
     impl UbuntuDiskConfig {
         fn new(image_name: String) -> Self {
@@ -215,10 +215,10 @@ mod tests {
             workload_path.push("workloads");
 
             let mut osdisk_base_path = workload_path.clone();
-            osdisk_base_path.push("clear-31311-cloudguest.img");
+            osdisk_base_path.push("clear-32480-cloudguest.img");
 
             let mut osdisk_raw_base_path = workload_path;
-            osdisk_raw_base_path.push("clear-31311-cloudguest-raw.img");
+            osdisk_raw_base_path.push("clear-32480-cloudguest-raw.img");
 
             let osdisk_path = String::from(tmp_dir.path().join("osdisk.img").to_str().unwrap());
             let osdisk_raw_path =
@@ -2851,7 +2851,7 @@ mod tests {
                 .args(&[
                     "--cmdline",
                     format!(
-                        "{} vfio_iommu_type1.allow_unsafe_interrupts",
+                        "{} kvm-intel.nested=1 vfio_iommu_type1.allow_unsafe_interrupts",
                         CLEAR_KERNEL_CMDLINE
                     )
                     .as_str(),
@@ -3900,9 +3900,12 @@ mod tests {
 
             let mut child = GuestCommand::new(&guest)
                 .args(&["--cpus", "boot=2,max=4"])
-                .args(&["--memory", "size=512M,hotplug_method=virtio-mem,hotplug_size=8192M"])
+                .args(&[
+                    "--memory",
+                    "size=512M,hotplug_method=virtio-mem,hotplug_size=8192M",
+                ])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .args(&["--cmdline", "root=PARTUUID=6fb4d1a8-6c8c-4dd7-9f7c-1fe0b9f2574c console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw"])
+                .args(&["--cmdline", CLEAR_KERNEL_CMDLINE])
                 .default_disks()
                 .default_net()
                 .args(&["--api-socket", &api_socket])


### PR DESCRIPTION
A new ClearLinux image has been uploaded to the Azure storage account.
It is based off of the ClearLinux cloudguest image 32480 version, with
four extra bundles added to it.

First bundle is curl, adding the curl binary to the image, second
bundle is fio, adding the fio binary to the image, third bundle is
iperf, adding the iperf binary to the image, and fourth bundle is
sysadmin-basic to include utility like netcat.

The image is 2G in size.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>