### PR TITLE
vmm: Stabilize vCPU snapshot/restore

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -125,6 +125,11 @@ pub enum HypervisorCpuError {
     #[error("Failed to get Vcpu events: {0}")]
     GetVcpuEvents(#[source] anyhow::Error),
     ///
+    /// Setting Vcpu events error
+    ///
+    #[error("Failed to set Vcpu events: {0}")]
+    SetVcpuEvents(#[source] anyhow::Error),
+    ///
     /// Vcpu Init error
     ///
     #[error("Failed to init vcpu: {0}")]
@@ -253,6 +258,12 @@ pub trait Vcpu: Send + Sync {
     /// states of the vcpu.
     ///
     fn get_vcpu_events(&self) -> Result<VcpuEvents>;
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// Sets pending exceptions, interrupts, and NMIs as well as related states
+    /// of the vcpu.
+    ///
+    fn set_vcpu_events(&self, events: &VcpuEvents) -> Result<()>;
     #[cfg(target_arch = "x86_64")]
     ///
     /// Let the guest know that it has been paused, which prevents from

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -9,7 +9,7 @@
 //
 use crate::vm::Vm;
 #[cfg(target_arch = "x86_64")]
-use crate::x86_64::CpuId;
+use crate::x86_64::{CpuId, MsrList};
 #[cfg(target_arch = "x86_64")]
 use kvm_ioctls::Cap;
 use std::sync::Arc;
@@ -55,6 +55,11 @@ pub enum HypervisorError {
     ///
     #[error("Failed to get number of max vcpus: {0}")]
     GetCpuId(#[source] anyhow::Error),
+    ///
+    /// Failed to retrieve list of MSRs.
+    ///
+    #[error("Failed to get the list of supported MSRs: {0}")]
+    GetMsrList(#[source] anyhow::Error),
 }
 
 ///
@@ -103,4 +108,9 @@ pub trait Hypervisor: Send + Sync {
     /// Check particular extensions if any
     ///
     fn check_required_extensions(&self) -> Result<()>;
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// Retrieve the list of MSRs supported by the hypervisor.
+    ///
+    fn get_msr_list(&self) -> Result<MsrList>;
 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -36,7 +36,7 @@ pub use x86_64::{
 };
 
 #[cfg(target_arch = "x86_64")]
-use kvm_bindings::{kvm_enable_cap, KVM_CAP_SPLIT_IRQCHIP};
+use kvm_bindings::{kvm_enable_cap, MsrList, KVM_CAP_SPLIT_IRQCHIP};
 
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::NUM_IOAPIC_PINS;
@@ -332,6 +332,15 @@ impl hypervisor::Hypervisor for KvmHypervisor {
         self.kvm
             .get_supported_cpuid(kvm_bindings::KVM_MAX_CPUID_ENTRIES)
             .map_err(|e| hypervisor::HypervisorError::GetCpuId(e.into()))
+    }
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// Retrieve the list of MSRs supported by KVM.
+    ///
+    fn get_msr_list(&self) -> hypervisor::Result<MsrList> {
+        self.kvm
+            .get_msr_index_list()
+            .map_err(|e| hypervisor::HypervisorError::GetMsrList(e.into()))
     }
 }
 /// Vcpu struct for KVM

--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -24,7 +24,7 @@ pub use {
     kvm_bindings::kvm_segment as SegmentRegister, kvm_bindings::kvm_sregs as SpecialRegisters,
     kvm_bindings::kvm_vcpu_events as VcpuEvents,
     kvm_bindings::kvm_xcrs as ExtendedControlRegisters, kvm_bindings::kvm_xsave as Xsave,
-    kvm_bindings::CpuId, kvm_bindings::Msrs as MsrEntries,
+    kvm_bindings::CpuId, kvm_bindings::MsrList, kvm_bindings::Msrs as MsrEntries,
 };
 
 pub const KVM_TSS_ADDRESS: GuestAddress = GuestAddress(0xfffb_d000);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4516,7 +4516,7 @@ mod tests {
 
             let mut child = GuestCommand::new(&guest)
                 .args(&["--api-socket", &api_socket])
-                .args(&["--cpus", "boot=1"])
+                .args(&["--cpus", "boot=4"])
                 .args(&["--memory", "size=4G"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&[
@@ -4538,7 +4538,7 @@ mod tests {
             thread::sleep(std::time::Duration::new(20, 0));
 
             // Check the number of vCPUs
-            aver_eq!(tb, guest.get_cpu_count().unwrap_or_default(), 1);
+            aver_eq!(tb, guest.get_cpu_count().unwrap_or_default(), 4);
             // Check the guest RAM
             aver!(tb, guest.get_total_memory().unwrap_or_default() > 3_968_000);
             // Check block devices are readable
@@ -4646,7 +4646,7 @@ mod tests {
             aver!(tb, remote_command(&api_socket, "resume", None));
 
             // Perform same checks to validate VM has been properly restored
-            aver_eq!(tb, guest.get_cpu_count().unwrap_or_default(), 1);
+            aver_eq!(tb, guest.get_cpu_count().unwrap_or_default(), 4);
             aver!(tb, guest.get_total_memory().unwrap_or_default() > 3_968_000);
             aver!(
                 tb,

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -80,6 +80,7 @@ const KVM_GET_XCRS: u64 = 0x8188_aea6;
 const KVM_GET_FPU: u64 = 0x81a0_ae8c;
 const KVM_GET_LAPIC: u64 = 0x8400_ae8e;
 const KVM_GET_XSAVE: u64 = 0x9000_aea4;
+const KVM_GET_MSR_INDEX_LIST: u64 = 0xc004_ae02;
 const KVM_GET_SUPPORTED_CPUID: u64 = 0xc008_ae05;
 const KVM_GET_MSRS: u64 = 0xc008_ae88;
 const KVM_CREATE_DEVICE: u64 = 0xc00c_aee0;
@@ -131,6 +132,7 @@ fn create_vmm_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_FPU)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_LAPIC)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MP_STATE)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MSR_INDEX_LIST)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MSRS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_REGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_SREGS)?],

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -63,6 +63,7 @@ const KVM_IRQFD: u64 = 0x4020_ae76;
 const KVM_SET_CLOCK: u64 = 0x4030_ae7b;
 const KVM_CREATE_PIT2: u64 = 0x4040_ae77;
 const KVM_IOEVENTFD: u64 = 0x4040_ae79;
+const KVM_SET_VCPU_EVENTS: u64 = 0x4040_aea0;
 const KVM_ENABLE_CAP: u64 = 0x4068_aea3;
 const KVM_SET_REGS: u64 = 0x4090_ae82;
 const KVM_SET_SREGS: u64 = 0x4138_ae84;
@@ -154,6 +155,7 @@ fn create_vmm_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_SREGS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_TSS_ADDR,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_USER_MEMORY_REGION,)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_VCPU_EVENTS,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XSAVE,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_SET_XCRS,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, SIOCGIFFLAGS)?],


### PR DESCRIPTION
This pull request, mainly by saving all supported MSRs, fixes all the remaining issues related to vCPU snapshot/restore. Thanks to this pull request, we can now correctly snapshot and restore a VM with one or more vCPUs.

Fixes #1176 