### PR TITLE
Enable PCI on AArch64

### DIFF
--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -15,7 +15,6 @@ kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branc
 kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "ch" }
 libc = "0.2.72"
 vm-memory = { version = "0.2.1", features = ["backend-mmap"] }
-
 acpi_tables = { path = "../acpi_tables", optional = true }
 arch_gen = { path = "../arch_gen" }
 

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -17,7 +17,10 @@ use super::super::DeviceType;
 use super::super::InitramfsConfig;
 use super::get_fdt_addr;
 use super::gic::GICDevice;
-use super::layout::FDT_MAX_SIZE;
+use super::layout::{
+    FDT_MAX_SIZE, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START, PCI_MMCONFIG_SIZE,
+    PCI_MMCONFIG_START,
+};
 use crate::aarch64::fdt::Error::CstringFDTTransform;
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap};
 
@@ -94,6 +97,7 @@ pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug>(
     device_info: &HashMap<(DeviceType, String), T>,
     gic_device: &Box<dyn GICDevice>,
     initrd: &Option<InitramfsConfig>,
+    pci_space_address: &Option<(u64, u64)>,
 ) -> Result<Vec<u8>> {
     // Alocate stuff necessary for the holding the blob.
     let mut fdt = vec![0; FDT_MAX_SIZE];
@@ -122,6 +126,9 @@ pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug>(
     create_clock_node(&mut fdt)?;
     create_psci_node(&mut fdt)?;
     create_devices_node(&mut fdt, device_info)?;
+    if let Some((pci_device_base, pci_device_size)) = pci_space_address {
+        create_pci_nodes(&mut fdt, *pci_device_base, *pci_device_size)?;
+    }
 
     // End Header node.
     append_end_node(&mut fdt)?;
@@ -540,6 +547,49 @@ fn create_devices_node<T: DeviceInfoForFDT + Clone + Debug>(
     Ok(())
 }
 
+fn create_pci_nodes(fdt: &mut Vec<u8>, pci_device_base: u64, pci_device_size: u64) -> Result<()> {
+    // Add node for PCIe controller.
+    // See Documentation/devicetree/bindings/pci/host-generic-pci.txt in the kernel
+    // and https://elinux.org/Device_Tree_Usage.
+    let ranges = generate_prop32(&[
+        // mmio addresses
+        0x2000000,                                // (ss = 10: 32-bit memory space)
+        (MEM_32BIT_DEVICES_START.0 >> 32) as u32, // PCI address
+        MEM_32BIT_DEVICES_START.0 as u32,
+        (MEM_32BIT_DEVICES_START.0 >> 32) as u32, // CPU address
+        MEM_32BIT_DEVICES_START.0 as u32,
+        (MEM_32BIT_DEVICES_SIZE >> 32) as u32, // size
+        MEM_32BIT_DEVICES_SIZE as u32,
+        // device addresses
+        0x3000000,                      // (ss = 11: 64-bit memory space)
+        (pci_device_base >> 32) as u32, // PCI address
+        pci_device_base as u32,
+        (pci_device_base >> 32) as u32, // CPU address
+        pci_device_base as u32,
+        (pci_device_size >> 32) as u32, // size
+        pci_device_size as u32,
+    ]);
+    let bus_range = generate_prop32(&[0, 0]); // Only bus 0
+    let reg = generate_prop64(&[PCI_MMCONFIG_START.0, PCI_MMCONFIG_SIZE]);
+
+    append_begin_node(fdt, "pci")?;
+    append_property_string(fdt, "compatible", "pci-host-ecam-generic")?;
+    append_property_string(fdt, "device_type", "pci")?;
+    append_property(fdt, "ranges", &ranges)?;
+    append_property(fdt, "bus-range", &bus_range)?;
+    append_property_u32(fdt, "#address-cells", 3)?;
+    append_property_u32(fdt, "#size-cells", 2)?;
+    append_property(fdt, "reg", &reg)?;
+    append_property_u32(fdt, "#interrupt-cells", 1)?;
+    append_property_null(fdt, "interrupt-map")?;
+    append_property_null(fdt, "interrupt-map-mask")?;
+    append_property_null(fdt, "dma-coherent")?;
+    append_property_u32(fdt, "msi-parent", MSI_PHANDLE)?;
+    append_end_node(fdt)?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -603,13 +653,14 @@ mod tests {
         let kvm = hypervisor::kvm::KvmHypervisor::new().unwrap();
         let hv: Arc<dyn hypervisor::Hypervisor> = Arc::new(kvm);
         let vm = hv.create_vm().unwrap();
-        let gic = create_gic(&vm, 1).unwrap();
+        let gic = create_gic(&vm, 1, false).unwrap();
         assert!(create_fdt(
             &mem,
             &CString::new("console=tty0").unwrap(),
             vec![0],
             &dev_info,
             &gic,
+            &None,
             &None,
         )
         .is_ok())

--- a/arch/src/aarch64/gicv2.rs
+++ b/arch/src/aarch64/gicv2.rs
@@ -1,11 +1,10 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{boxed::Box, result};
-
-use kvm_ioctls::DeviceFd;
-
 use super::gic::{Error, GICDevice};
+use kvm_ioctls::DeviceFd;
+use std::sync::Arc;
+use std::{boxed::Box, result};
 
 type Result<T> = result::Result<T, Error>;
 
@@ -89,7 +88,10 @@ impl GICDevice for GICv2 {
         })
     }
 
-    fn init_device_attributes(gic_device: &Box<dyn GICDevice>) -> Result<()> {
+    fn init_device_attributes(
+        _vm: &Arc<dyn hypervisor::Vm>,
+        gic_device: &Box<dyn GICDevice>,
+    ) -> Result<()> {
         /* Setting up the distributor attribute.
         We are placing the GIC below 1GB so we need to substract the size of the distributor. */
         Self::set_device_attribute(

--- a/arch/src/aarch64/gicv3.rs
+++ b/arch/src/aarch64/gicv3.rs
@@ -1,11 +1,10 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{boxed::Box, result};
-
-use kvm_ioctls::DeviceFd;
-
 use super::gic::{Error, GICDevice};
+use kvm_ioctls::DeviceFd;
+use std::sync::Arc;
+use std::{boxed::Box, result};
 
 type Result<T> = result::Result<T, Error>;
 
@@ -23,30 +22,30 @@ pub struct GICv3 {
 impl GICv3 {
     // Unfortunately bindgen omits defines that are based on other defines.
     // See arch/arm64/include/uapi/asm/kvm.h file from the linux kernel.
-    const SZ_64K: u64 = 0x0001_0000;
+    pub const SZ_64K: u64 = 0x0001_0000;
     const KVM_VGIC_V3_DIST_SIZE: u64 = GICv3::SZ_64K;
     const KVM_VGIC_V3_REDIST_SIZE: u64 = (2 * GICv3::SZ_64K);
 
     // Device trees specific constants
-    const ARCH_GIC_V3_MAINT_IRQ: u32 = 9;
+    pub const ARCH_GIC_V3_MAINT_IRQ: u32 = 9;
 
     /// Get the address of the GIC distributor.
-    fn get_dist_addr() -> u64 {
+    pub fn get_dist_addr() -> u64 {
         super::layout::MAPPED_IO_START - GICv3::KVM_VGIC_V3_DIST_SIZE
     }
 
     /// Get the size of the GIC distributor.
-    fn get_dist_size() -> u64 {
+    pub fn get_dist_size() -> u64 {
         GICv3::KVM_VGIC_V3_DIST_SIZE
     }
 
     /// Get the address of the GIC redistributors.
-    fn get_redists_addr(vcpu_count: u64) -> u64 {
+    pub fn get_redists_addr(vcpu_count: u64) -> u64 {
         GICv3::get_dist_addr() - GICv3::get_redists_size(vcpu_count)
     }
 
     /// Get the size of the GIC redistributors.
-    fn get_redists_size(vcpu_count: u64) -> u64 {
+    pub fn get_redists_size(vcpu_count: u64) -> u64 {
         vcpu_count * GICv3::KVM_VGIC_V3_REDIST_SIZE
     }
 }
@@ -89,7 +88,10 @@ impl GICDevice for GICv3 {
         })
     }
 
-    fn init_device_attributes(gic_device: &Box<dyn GICDevice>) -> Result<()> {
+    fn init_device_attributes(
+        _vm: &Arc<dyn hypervisor::Vm>,
+        gic_device: &Box<dyn GICDevice>,
+    ) -> Result<()> {
         /* Setting up the distributor attribute.
          We are placing the GIC below 1GB so we need to substract the size of the distributor.
         */

--- a/arch/src/aarch64/gicv3_its.rs
+++ b/arch/src/aarch64/gicv3_its.rs
@@ -1,0 +1,123 @@
+// Copyright 2020 ARM Limited
+// SPDX-License-Identifier: Apache-2.0
+
+use super::gic::{Error, GICDevice};
+use super::gicv3::GICv3;
+use kvm_ioctls::DeviceFd;
+use std::sync::Arc;
+use std::{boxed::Box, result};
+
+type Result<T> = result::Result<T, Error>;
+
+pub struct GICv3ITS {
+    /// The file descriptor for the KVM device
+    fd: DeviceFd,
+
+    /// GIC device properties, to be used for setting up the fdt entry
+    gic_properties: [u64; 4],
+
+    /// MSI device properties, to be used for setting up the fdt entry
+    msi_properties: [u64; 2],
+
+    /// Number of CPUs handled by the device
+    vcpu_count: u64,
+}
+
+impl GICv3ITS {
+    const KVM_VGIC_V3_ITS_SIZE: u64 = (2 * GICv3::SZ_64K);
+
+    fn get_msi_size() -> u64 {
+        GICv3ITS::KVM_VGIC_V3_ITS_SIZE
+    }
+
+    fn get_msi_addr(vcpu_count: u64) -> u64 {
+        GICv3::get_redists_addr(vcpu_count) - GICv3ITS::get_msi_size()
+    }
+}
+
+impl GICDevice for GICv3ITS {
+    fn version() -> u32 {
+        GICv3::version()
+    }
+
+    fn device_fd(&self) -> &DeviceFd {
+        &self.fd
+    }
+
+    fn device_properties(&self) -> &[u64] {
+        &self.gic_properties
+    }
+
+    fn msi_properties(&self) -> &[u64] {
+        &self.msi_properties
+    }
+
+    fn vcpu_count(&self) -> u64 {
+        self.vcpu_count
+    }
+
+    fn fdt_compatibility(&self) -> &str {
+        "arm,gic-v3"
+    }
+
+    fn msi_compatible(&self) -> bool {
+        true
+    }
+
+    fn msi_compatiblility(&self) -> &str {
+        "arm,gic-v3-its"
+    }
+
+    fn fdt_maint_irq(&self) -> u32 {
+        GICv3::ARCH_GIC_V3_MAINT_IRQ
+    }
+
+    fn create_device(fd: DeviceFd, vcpu_count: u64) -> Box<dyn GICDevice> {
+        Box::new(GICv3ITS {
+            fd: fd,
+            gic_properties: [
+                GICv3::get_dist_addr(),
+                GICv3::get_dist_size(),
+                GICv3::get_redists_addr(vcpu_count),
+                GICv3::get_redists_size(vcpu_count),
+            ],
+            msi_properties: [GICv3ITS::get_msi_addr(vcpu_count), GICv3ITS::get_msi_size()],
+            vcpu_count: vcpu_count,
+        })
+    }
+
+    fn init_device_attributes(
+        vm: &Arc<dyn hypervisor::Vm>,
+        gic_device: &Box<dyn GICDevice>,
+    ) -> Result<()> {
+        GICv3::init_device_attributes(vm, gic_device)?;
+
+        let mut its_device = kvm_bindings::kvm_create_device {
+            type_: kvm_bindings::kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_ITS,
+            fd: 0,
+            flags: 0,
+        };
+
+        let its_fd = vm
+            .create_device(&mut its_device)
+            .map_err(Error::CreateGIC)?;
+
+        Self::set_device_attribute(
+            &its_fd,
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_VGIC_ITS_ADDR_TYPE),
+            &GICv3ITS::get_msi_addr(u64::from(gic_device.vcpu_count())) as *const u64 as u64,
+            0,
+        )?;
+
+        Self::set_device_attribute(
+            &its_fd,
+            kvm_bindings::KVM_DEV_ARM_VGIC_GRP_CTRL,
+            u64::from(kvm_bindings::KVM_DEV_ARM_VGIC_CTRL_INIT),
+            0,
+            0,
+        )?;
+
+        Ok(())
+    }
+}

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -8,6 +8,7 @@ pub mod fdt;
 pub mod gic;
 mod gicv2;
 mod gicv3;
+mod gicv3_its;
 /// Layout for this aarch64 system.
 pub mod layout;
 /// Logic for configuring aarch64 registers.

--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -344,6 +344,7 @@ impl Ioapic {
             high_addr: 0x0,
             low_addr,
             data,
+            devid: 0,
         };
 
         self.interrupt_source_group

--- a/docs/arm64.md
+++ b/docs/arm64.md
@@ -19,13 +19,23 @@ sudo apt-get install libfdt-dev
 Before building, a hack trick need to be performed to get rid of some build error in vmm component. See [this](https://github.com/cloud-hypervisor/kvm-bindings/pull/1) for more info about this temporary workaround.
 
 ```bash
-sed -i 's/"with-serde",\ //g' vmm/Cargo.toml
+sed -i 's/"with-serde",\ //g' hypervisor/Cargo.toml
 ```
 
-The support of AArch64 is in very early stage, only Virtio devices with MMIO tranport is available.
+For Virtio devices, you can choose MMIO or PCI as transport option.
+
+### MMIO
 
 ```bash
 cargo build --no-default-features --features "mmio"
+```
+
+### PCI
+
+Using PCI devices requires GICv3-ITS for MSI messaging. GICv3-ITS is very common in modern servers, but your machine happen to be old ones with GICv2(M) (like Raspberry Pi 4) or GICv3 without ITS, MMIO can still work.
+
+```bash
+cargo build --no-default-features --features "pci"
 ```
 
 ## Image
@@ -47,7 +57,7 @@ To build the development container:
 ./scripts/dev_cli.sh build-container
 ```
 
-To build Cloud-hypervisor in the container:
+To build Cloud-hypervisor in the container: (The default option for Virtio transport is MMIO.)
 
 ```bash
 ./scripts/dev_cli.sh build
@@ -58,7 +68,7 @@ To build Cloud-hypervisor in the container:
 Assuming you have built Cloud-hypervisor with the development container, a VM can be started with command:
 
 ```bash
-sudo target/debug/cloud-hypervisor --kernel kernel.bin --disk path=rootfs.ext4 --cmdline "keep_bootcon console=hvc0 reboot=k panic=1 pci=off root=/dev/vda rw" --cpus boot=4 --memory size=512M --serial file=serial.log --log-file log.log -vvv
+sudo build/cargo_target/aarch64-unknown-linux-gnu/debug/cloud-hypervisor --kernel kernel.bin --disk path=rootfs.ext4 --cmdline "keep_bootcon console=hvc0 reboot=k panic=1 pci=off root=/dev/vda rw" --cpus boot=4 --memory size=512M --serial file=serial.log --log-file log.log -vvv
 ```
 
-If the build was done out of the container, replace the binary path with `build/cargo_target/aarch64-unknown-linux-gnu/debug/cloud-hypervisor`.
+If the build was done out of the container, replace the binary path with `target/debug/cloud-hypervisor`.

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -250,6 +250,10 @@ impl vm::Vm for KvmVm {
             .set_clock(data)
             .map_err(|e| vm::HypervisorVmError::SetClock(e.into()))
     }
+    /// Checks if a particular `Cap` is available.
+    fn check_extension(&self, c: Cap) -> bool {
+        self.fd.check_extension(c)
+    }
 }
 /// Wrapper over KVM system ioctls.
 pub struct KvmHypervisor {

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -47,7 +47,7 @@ pub mod aarch64;
 pub use kvm_bindings;
 pub use kvm_bindings::{
     kvm_create_device, kvm_device_type_KVM_DEV_TYPE_VFIO, kvm_irq_routing, kvm_irq_routing_entry,
-    kvm_userspace_memory_region, KVM_IRQ_ROUTING_MSI, KVM_MEM_READONLY,
+    kvm_userspace_memory_region, KVM_IRQ_ROUTING_MSI, KVM_MEM_READONLY, KVM_MSI_VALID_DEVID,
 };
 pub use kvm_ioctls;
 pub use kvm_ioctls::{Cap, Kvm};

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -14,6 +14,7 @@ use crate::cpu::Vcpu;
 #[cfg(target_arch = "x86_64")]
 use crate::ClockData;
 use crate::{CreateDevice, DeviceFd, IoEventAddress, IrqRouting, MemoryRegion};
+use kvm_ioctls::Cap;
 use std::sync::Arc;
 use thiserror::Error;
 use vmm_sys_util::eventfd::EventFd;
@@ -168,4 +169,6 @@ pub trait Vm: Send + Sync {
     /// Set guest clock.
     #[cfg(target_arch = "x86_64")]
     fn set_clock(&self, data: &ClockData) -> Result<()>;
+    /// Checks if a particular `Cap` is available.
+    fn check_extension(&self, c: Cap) -> bool;
 }

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -110,16 +110,19 @@ impl PciBus {
     pub fn register_mapping(
         &self,
         dev: Arc<Mutex<dyn BusDevice>>,
-        io_bus: &devices::Bus,
+        #[cfg(target_arch = "x86_64")] io_bus: &devices::Bus,
         mmio_bus: &devices::Bus,
         bars: Vec<(GuestAddress, GuestUsize, PciBarRegionType)>,
     ) -> Result<()> {
         for (address, size, type_) in bars {
             match type_ {
                 PciBarRegionType::IORegion => {
+                    #[cfg(target_arch = "x86_64")]
                     io_bus
                         .insert(dev.clone(), address.raw_value(), size)
                         .map_err(PciRootError::PioInsert)?;
+                    #[cfg(target_arch = "aarch64")]
+                    error!("I/O region is not supported");
                 }
                 PciBarRegionType::Memory32BitRegion | PciBarRegionType::Memory64BitRegion => {
                     mmio_bus

--- a/pci/src/msi.rs
+++ b/pci/src/msi.rs
@@ -201,6 +201,7 @@ impl MsiConfig {
                     high_addr: self.cap.msg_addr_hi,
                     low_addr: self.cap.msg_addr_lo,
                     data: self.cap.msg_data as u32,
+                    devid: 0,
                 };
 
                 if let Err(e) = self

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -72,6 +72,7 @@ struct MsixConfigState {
 pub struct MsixConfig {
     pub table_entries: Vec<MsixTableEntry>,
     pub pba_entries: Vec<u64>,
+    pub devid: u32,
     interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
     masked: bool,
     enabled: bool,
@@ -81,6 +82,7 @@ impl MsixConfig {
     pub fn new(
         msix_vectors: u16,
         interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+        devid: u32,
     ) -> Self {
         assert!(msix_vectors <= MAX_MSIX_VECTORS_PER_DEVICE);
 
@@ -93,6 +95,7 @@ impl MsixConfig {
         MsixConfig {
             table_entries,
             pba_entries,
+            devid,
             interrupt_source_group,
             masked: false,
             enabled: false,
@@ -124,6 +127,7 @@ impl MsixConfig {
                     high_addr: table_entry.msg_addr_hi,
                     low_addr: table_entry.msg_addr_lo,
                     data: table_entry.msg_data,
+                    devid: self.devid,
                 };
 
                 self.interrupt_source_group
@@ -162,6 +166,7 @@ impl MsixConfig {
                         high_addr: table_entry.msg_addr_hi,
                         low_addr: table_entry.msg_addr_lo,
                         data: table_entry.msg_data,
+                        devid: self.devid,
                     };
 
                     if let Err(e) = self
@@ -306,6 +311,7 @@ impl MsixConfig {
                 high_addr: table_entry.msg_addr_hi,
                 low_addr: table_entry.msg_addr_lo,
                 data: table_entry.msg_data,
+                devid: self.devid,
             };
 
             if let Err(e) = self.interrupt_source_group.update(

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -762,7 +762,7 @@ impl PciDevice for VfioPciDevice {
                         .ok_or_else(|| PciDeviceError::IoAllocationFailed(region_size))?;
                 }
                 #[cfg(target_arch = "aarch64")]
-                unimplemented!();
+                unimplemented!()
             } else {
                 if is_64bit_bar {
                     // 64 bits Memory BAR
@@ -875,7 +875,7 @@ impl PciDevice for VfioPciDevice {
                     #[cfg(target_arch = "x86_64")]
                     allocator.free_io_addresses(region.start, region.length);
                     #[cfg(target_arch = "aarch64")]
-                    unimplemented!();
+                    error!("I/O region is not supported");
                 }
                 PciBarRegionType::Memory32BitRegion => {
                     allocator.free_mmio_hole_addresses(region.start, region.length);

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -363,7 +363,7 @@ impl VfioPciDevice {
             })
             .unwrap();
 
-        let msix_config = MsixConfig::new(msix_cap.table_size(), interrupt_source_group.clone());
+        let msix_config = MsixConfig::new(msix_cap.table_size(), interrupt_source_group.clone(), 0);
 
         self.interrupt.msix = Some(VfioMsix {
             bar: msix_config,

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -336,6 +336,7 @@ impl VirtioPciDevice {
         msix_num: u16,
         iommu_mapping_cb: Option<Arc<VirtioIommuRemapping>>,
         interrupt_manager: &Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>>,
+        pci_device_bdf: u32,
     ) -> Result<Self> {
         let device_clone = device.clone();
         let locked_device = device_clone.lock().unwrap();
@@ -364,6 +365,7 @@ impl VirtioPciDevice {
             let msix_config = Arc::new(Mutex::new(MsixConfig::new(
                 msix_num,
                 interrupt_source_group.clone(),
+                pci_device_bdf,
             )));
             let msix_config_clone = msix_config.clone();
             (Some(msix_config), Some(msix_config_clone))

--- a/vm-device/src/interrupt/mod.rs
+++ b/vm-device/src/interrupt/mod.rs
@@ -83,6 +83,8 @@ pub struct MsiIrqSourceConfig {
     pub low_addr: u32,
     /// Data to write to delivery message signaled interrupt.
     pub data: u32,
+    /// Unique ID of the device to delivery message signaled interrupt.
+    pub devid: u32,
 }
 
 /// Configuration data for an interrupt source.

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2615,6 +2615,7 @@ impl DeviceManager {
             msix_num,
             iommu_mapping_cb,
             interrupt_manager,
+            pci_device_bdf,
         )
         .map_err(DeviceManagerError::VirtioDevice)?;
 


### PR DESCRIPTION
The PR includes:
-  Creating virtual GICv3-ITS
- Updating FDT to include ITS and PCI node
- Setting `devid` in `kvm_irq_routing_msi` on AArch64
- Documentation

In current implementation, PCI requires GICv3-ITS device on host for MSI handling. On AArch64, GICv2M and GICv3-ITS handles MSI. GICv2M is old, its capability is quite limited, and it's not commonly seen nowadays. While GICv3-ITS is dorminant, it is common in modern AArch64 servers. So we implemented GICv3-ITS only.