### PR TITLE
resources: Dockerfile: Update Dockerfile for AArch64

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -49,6 +49,22 @@ RUN if [ "$TARGETARCH" = "x86_64" ]; then \
 	&& apt-get clean \
     && rm -rf /var/lib/apt/lists/*;	fi
 
+RUN if [ "$TARGETARCH" = "aarch64" ]; then \
+        # On AArch64, `setcap` binary should be installed via `libcap2-bin`.
+        # The `setcap` binary is used in integration tests.
+        apt-get update \
+        && apt-get -yq upgrade \
+        && DEBIAN_FRONTEND=noninteractive apt-get install -yq libcap2-bin \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/* \
+        # Build and install the musl-gcc version of libfdt. This is to ensure
+        # the cloud-hypervisor binary can be built and linked using musl toolchain.
+        && git clone https://github.com/dgibson/dtc.git && cd dtc \
+        && sed -i 's/$(LIBFDT_archive) $(LIBFDT_lib)/$(LIBFDT_archive)/g' Makefile \
+        && export CC=musl-gcc && make libfdt \
+        && cp libfdt/libfdt.a /usr/lib/aarch64-linux-musl \
+        && rm -rf /dtc;	fi
+
 # Fix the libssl-dev install
 RUN cp /usr/include/"$TARGETARCH"-linux-gnu/openssl/opensslconf.h /usr/include/openssl/
 ENV OPENSSL_DIR=/usr/lib/"$TARGETARCH"-linux-gnu/


### PR DESCRIPTION
As requested in https://github.com/cloud-hypervisor/cloud-hypervisor/pull/1395#issuecomment-651728247. This update of Dockerfile will add support to the AArch64 integration tests and musl building, including:

1. Installation of the missing `setcap` binary on AArch64. On AArch64, `setcap` binary should be installed via `libcap2-bin`.
This binary is needed in the integration test.

2. Related support for the cloud-hypervisor binary building by musl toolchain. Details can be found in https://github.com/rust-lang/rust/issues/73493#issuecomment-651916925

Test building with musl using the updated container:
```
~/cloud-hypervisor-dev/cloud-hypervisor-build# ./scripts/dev_cli.sh build --release --libc musl
...
Successfully tagged cloudhypervisor/dev:v4
...
   Compiling cloud-hypervisor v0.8.0 (/cloud-hypervisor)
    Finished release [optimized] target(s) in 2m 28s
[Cloud Hypervisor] Binaries placed under /root/cloud-hypervisor-dev/cloud-hypervisor-build/build/cargo_target/aarch64-unknown-linux-musl/release

~/cloud-hypervisor-dev/cloud-hypervisor-build/build/cargo_target/aarch64-unknown-linux-musl/release# file cloud-hypervisor

cloud-hypervisor: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), statically linked, with debug_info, not stripped
```

Signed-off-by: Henry Wang <Henry.Wang@arm.com>