### PR TITLE
arch: drop one level of indirection for boot_msr_entries

### DIFF
--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -68,7 +68,7 @@ pub fn setup_fpu(vcpu: &Arc<dyn hypervisor::Vcpu>) -> Result<()> {
 ///
 /// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
 pub fn setup_msrs(vcpu: &Arc<dyn hypervisor::Vcpu>) -> Result<()> {
-    vcpu.set_msrs(&hypervisor::kvm::x86_64::boot_msr_entries())
+    vcpu.set_msrs(&hypervisor::x86_64::boot_msr_entries())
         .map_err(Error::SetModelSpecificRegisters)?;
 
     Ok(())


### PR DESCRIPTION
This makes setup_msrs hypervisor agnostic.

There is more we could do in this area --  I notice is that the initial state of MSRs isn't really tied to KVM. It would be more appropriate to have `boot_msr_entries` in the `vmm` crate. But then that creates cyclic dependency between `arch` and `vmm`.

Another way to solve this would be to make `configure_vcpu` accept a list of MSRs. The downside is that it makes Aarch64 and x86 have different function signatures for `configure_vcpu`.

Neither of the two solutions looks satisfactory to me. Let me know what you think.