### PR TITLE
[RFC] vmm, hypervisor: introduce and use VcpuRun trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "linux-loader",
+ "log 0.4.8",
  "serde",
  "serde_derive",
  "serde_json",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -16,6 +16,7 @@ serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 vm-memory = { version = "0.2.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = ">=0.5.0", features = ["with-serde"] }
+log = "0.4.8"
 
 [dependencies.linux-loader]
 git = "https://github.com/rust-vmm/linux-loader"

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -18,10 +18,14 @@
 //! - arm64
 //!
 
+#[macro_use]
+extern crate log;
 extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 extern crate thiserror;
+#[macro_use]
+extern crate anyhow;
 
 /// KVM implementation module
 pub mod kvm;
@@ -36,7 +40,7 @@ pub mod vm;
 pub mod arch;
 
 /// CPU related module
-mod cpu;
+pub mod cpu;
 
 pub use crate::hypervisor::{Hypervisor, HypervisorError};
 pub use cpu::{HypervisorCpuError, Vcpu};


### PR DESCRIPTION
VcpuExit type is going to be hypervisor specific. Push exit handling into hypervisor crate. Expose a VcpuRun trait and require Vcpu inside vmm crate to implement it.

RFC to get an idea if this is acceptable upstream.

I haven't fixed all the test cases yet so CI will fail.
