### PR TITLE
vmm: KVM specific variables and fields renaming

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -286,12 +286,13 @@ pub trait Vcpu: Send + Sync {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     fn get_one_reg(&self, reg_id: u64) -> Result<u64>;
     ///
-    /// Retrieve the current cpu states. This function is necessary to snapshot the VM
+    /// Retrieve the vCPU state.
+    /// This function is necessary to snapshot the VM
     ///
-    fn cpu_state(&self) -> Result<CpuState>;
+    fn state(&self) -> Result<CpuState>;
     ///
-    /// Setting the FPU state this.
+    /// Set the vCPU state.
     /// This function is required when restoring the VM
     ///
-    fn set_cpu_state(&self, state: &CpuState) -> Result<()>;
+    fn set_state(&self, state: &CpuState) -> Result<()>;
 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -638,9 +638,9 @@ impl cpu::Vcpu for KvmVcpu {
     /// let vm = hv.create_vm().expect("new VM fd creation failed");
     /// vm.enable_split_irq().unwrap();
     /// let vcpu = vm.create_vcpu(0).unwrap();
-    /// let state = vcpu.cpu_state().unwrap();
+    /// let state = vcpu.state().unwrap();
     /// ```
-    fn cpu_state(&self) -> cpu::Result<CpuState> {
+    fn state(&self) -> cpu::Result<CpuState> {
         let mp_state = self.get_mp_state()?;
         let regs = self.get_regs()?;
         let sregs = self.get_sregs()?;
@@ -665,7 +665,7 @@ impl cpu::Vcpu for KvmVcpu {
         })
     }
     #[cfg(target_arch = "aarch64")]
-    fn cpu_state(&self) -> cpu::Result<CpuState> {
+    fn state(&self) -> cpu::Result<CpuState> {
         unimplemented!();
     }
     #[cfg(target_arch = "x86_64")]
@@ -705,10 +705,10 @@ impl cpu::Vcpu for KvmVcpu {
     /// let vm = hv.create_vm().expect("new VM fd creation failed");
     /// vm.enable_split_irq().unwrap();
     /// let vcpu = vm.create_vcpu(0).unwrap();
-    /// let state = vcpu.cpu_state().unwrap();
-    /// vcpu.set_cpu_state(&state).unwrap();
+    /// let state = vcpu.state().unwrap();
+    /// vcpu.set_state(&state).unwrap();
     /// ```
-    fn set_cpu_state(&self, state: &CpuState) -> cpu::Result<()> {
+    fn set_state(&self, state: &CpuState) -> cpu::Result<()> {
         self.set_mp_state(state.mp_state)?;
         self.set_regs(&state.regs)?;
         self.set_sregs(&state.sregs)?;
@@ -723,7 +723,7 @@ impl cpu::Vcpu for KvmVcpu {
     }
     #[allow(unused_variables)]
     #[cfg(target_arch = "aarch64")]
-    fn set_cpu_state(&self, state: &CpuState) -> cpu::Result<()> {
+    fn set_state(&self, state: &CpuState) -> cpu::Result<()> {
         Ok(())
     }
 }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -403,7 +403,7 @@ const VCPU_SNAPSHOT_ID: &str = "vcpu";
 impl Pausable for Vcpu {
     fn pause(&mut self) -> std::result::Result<(), MigratableError> {
         self.saved_state =
-            Some(self.fd.cpu_state().map_err(|e| {
+            Some(self.fd.state().map_err(|e| {
                 MigratableError::Pause(anyhow!("Could not get vCPU state {:?}", e))
             })?);
 
@@ -412,7 +412,7 @@ impl Pausable for Vcpu {
 
     fn resume(&mut self) -> std::result::Result<(), MigratableError> {
         if let Some(vcpu_state) = &self.saved_state {
-            self.fd.set_cpu_state(vcpu_state).map_err(|e| {
+            self.fd.set_state(vcpu_state).map_err(|e| {
                 MigratableError::Pause(anyhow!("Could not set the vCPU state {:?}", e))
             })?;
         }


### PR DESCRIPTION
Many of our VMM structures fields are now pointing to the abstracted `hypervisor` crate traits, so we should rename them in a more generic, hypervisor agnostic way.

The PR also makes the code slightly more readable by no longer using the KVM specific `fd` name for either vcpu or vm.