### PR TITLE
hypervisor: Define a VM-Exit abstraction

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -545,8 +545,51 @@ impl cpu::Vcpu for KvmVcpu {
     ///
     /// Triggers the running of the current virtual CPU returning an exit reason.
     ///
-    fn run(&self) -> std::result::Result<VcpuExit, vmm_sys_util::errno::Error> {
-        self.fd.run()
+    fn run(&self) -> std::result::Result<cpu::VmExit, cpu::HypervisorCpuError> {
+        match self.fd.run() {
+            Ok(run) => match run {
+                #[cfg(target_arch = "x86_64")]
+                VcpuExit::IoIn(addr, data) => Ok(cpu::VmExit::IoIn(addr, data)),
+                #[cfg(target_arch = "x86_64")]
+                VcpuExit::IoOut(addr, data) => Ok(cpu::VmExit::IoOut(addr, data)),
+                #[cfg(target_arch = "x86_64")]
+                VcpuExit::IoapicEoi(vector) => Ok(cpu::VmExit::IoapicEoi(vector)),
+                #[cfg(target_arch = "x86_64")]
+                VcpuExit::Shutdown | VcpuExit::Hlt => Ok(cpu::VmExit::Reset),
+
+                #[cfg(target_arch = "aarch64")]
+                VcpuExit::SystemEvent(event_type, flags) => {
+                    use kvm_bindings::KVM_SYSTEM_EVENT_SHUTDOWN;
+                    // On Aarch64, when the VM is shutdown, run() returns
+                    // VcpuExit::SystemEvent with reason KVM_SYSTEM_EVENT_SHUTDOWN
+                    if event_type == KVM_SYSTEM_EVENT_SHUTDOWN {
+                        Ok(cpu::VmExit::Reset)
+                    } else {
+                        Err(cpu::HypervisorCpuError::RunVcpu(anyhow!(
+                            "Unexpected system event with type 0x{:x}, flags 0x{:x}",
+                            event_type,
+                            flags
+                        )))
+                    }
+                }
+
+                VcpuExit::MmioRead(addr, data) => Ok(cpu::VmExit::MmioRead(addr, data)),
+                VcpuExit::MmioWrite(addr, data) => Ok(cpu::VmExit::MmioWrite(addr, data)),
+
+                r => Err(cpu::HypervisorCpuError::RunVcpu(anyhow!(
+                    "Unexpected exit reason on vcpu run: {:?}",
+                    r
+                ))),
+            },
+
+            Err(ref e) => match e.errno() {
+                libc::EAGAIN | libc::EINTR => Ok(cpu::VmExit::Ignore),
+                _ => Err(cpu::HypervisorCpuError::RunVcpu(anyhow!(
+                    "VCPU error {:?}",
+                    e
+                ))),
+            },
+        }
     }
     #[cfg(target_arch = "x86_64")]
     ///

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -22,6 +22,8 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 extern crate thiserror;
+#[macro_use]
+extern crate anyhow;
 
 /// KVM implementation module
 pub mod kvm;
@@ -39,6 +41,6 @@ pub mod arch;
 mod cpu;
 
 pub use crate::hypervisor::{Hypervisor, HypervisorError};
-pub use cpu::{HypervisorCpuError, Vcpu};
+pub use cpu::{HypervisorCpuError, Vcpu, VmExit};
 pub use kvm::*;
 pub use vm::{DataMatch, HypervisorVmError, Vm};

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1429,7 +1429,7 @@ mod tests {
 #[cfg(target_arch = "x86_64")]
 #[test]
 pub fn test_vm() {
-    use hypervisor::VcpuExit;
+    use hypervisor::VmExit;
     use vm_memory::{GuestMemory, GuestMemoryRegion};
     // This example based on https://lwn.net/Articles/658511/
     let code = [
@@ -1481,52 +1481,18 @@ pub fn test_vm() {
 
     loop {
         match vcpu.run().expect("run failed") {
-            VcpuExit::IoIn(addr, data) => {
-                println!(
-                    "IO in -- addr: {:#x} data [{:?}]",
-                    addr,
-                    str::from_utf8(&data).unwrap()
-                );
-            }
-            VcpuExit::IoOut(addr, data) => {
+            VmExit::IoOut(addr, data) => {
                 println!(
                     "IO out -- addr: {:#x} data [{:?}]",
                     addr,
                     str::from_utf8(&data).unwrap()
                 );
             }
-            VcpuExit::MmioRead(_addr, _data) => {}
-            VcpuExit::MmioWrite(_addr, _data) => {}
-            VcpuExit::Unknown => {}
-            VcpuExit::Exception => {}
-            VcpuExit::Hypercall => {}
-            VcpuExit::Debug => {}
-            VcpuExit::Hlt => {
+            VmExit::Reset => {
                 println!("HLT");
                 break;
             }
-            VcpuExit::IrqWindowOpen => {}
-            VcpuExit::Shutdown => {}
-            VcpuExit::FailEntry => {}
-            VcpuExit::Intr => {}
-            VcpuExit::SetTpr => {}
-            VcpuExit::TprAccess => {}
-            VcpuExit::S390Sieic => {}
-            VcpuExit::S390Reset => {}
-            VcpuExit::Dcr => {}
-            VcpuExit::Nmi => {}
-            VcpuExit::InternalError => {}
-            VcpuExit::Osi => {}
-            VcpuExit::PaprHcall => {}
-            VcpuExit::S390Ucontrol => {}
-            VcpuExit::Watchdog => {}
-            VcpuExit::S390Tsch => {}
-            VcpuExit::Epr => {}
-            VcpuExit::SystemEvent(_, _) => {}
-            VcpuExit::S390Stsi => {}
-            VcpuExit::IoapicEoi(_vector) => {}
-            VcpuExit::Hyperv => {}
+            r => panic!("unexpected exit reason: {:?}", r),
         }
-        //        r => panic!("unexpected exit reason: {:?}", r),
     }
 }


### PR DESCRIPTION
In order to move the hypervisor specific parts of the VM exit handling
path, we're defining a generic, hypervisor agnostic VM exit enum.

This is what the hypervisor's Vcpu run() call should return when the VM
exit can not be completely handled through the hypervisor specific bits.
For KVM based hypervisors, this means directly forwarding the IO related
exits back to the VMM itself. For other hypervisors that e.g. rely on the
VMM to decode and emulate instructions, this means the decoding itself
would happen in the hypervisor crate exclusively, and the rest of the VM
exit handling would be handled through the VMM device model implementation.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>

Fix test_vm unit test by using the new abstraction and dropping some
dead code.

Signed-off-by: Wei Liu <liuwe@microsoft.com>