### PR TITLE
ci: Increase time to stabilize memory measurement

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1854,7 +1854,7 @@ mod tests {
 
             // Let enough time for the first VM to be spawned, and to make
             // sure the PSS measurement is accurate.
-            thread::sleep(std::time::Duration::new(60, 0));
+            thread::sleep(std::time::Duration::new(120, 0));
 
             // Get initial PSS
             let old_pss = get_pss(child1.id());


### PR DESCRIPTION
Check if increasing the time after the VM is spawned help with getting
more stable numbers for the base PSS.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>