### PR TITLE
Remove vhost-user-net dependency on virtio-devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,12 +633,15 @@ version = "0.1.0"
 dependencies = [
  "lazy_static",
  "libc",
+ "log 0.4.8",
  "net_gen",
  "pnet",
  "rand 0.7.3",
  "serde",
  "serde_json",
  "virtio-bindings",
+ "vm-memory",
+ "vm-virtio",
  "vmm-sys-util",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
 name = "net_util"
 version = "0.1.0"
 dependencies = [
+ "epoll",
  "lazy_static",
  "libc",
  "log 0.4.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,7 +1486,6 @@ dependencies = [
  "vhost",
  "vhost_user_backend",
  "virtio-bindings",
- "virtio-devices",
  "vm-memory",
  "vmm-sys-util",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
+ "virtio-bindings",
  "vmm-sys-util",
 ]
 

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -5,10 +5,13 @@ authors = ["The Chromium OS Authors"]
 
 [dependencies]
 libc = "0.2.72"
+log = "0.4.8"
 net_gen = { path = "../net_gen" }
 rand = "0.7.3"
 serde = "1.0.114"
 virtio-bindings = "0.1.0"
+vm-memory = { version = "0.2.1", features = ["backend-mmap", "backend-atomic"] }
+vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 
 [dev-dependencies]

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
+epoll = ">=4.0.1"
 libc = "0.2.72"
 log = "0.4.8"
 net_gen = { path = "../net_gen" }

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["The Chromium OS Authors"]
 
 [dependencies]
 libc = "0.2.72"
+net_gen = { path = "../net_gen" }
 rand = "0.7.3"
 serde = "1.0.114"
+virtio-bindings = "0.1.0"
 vmm-sys-util = ">=0.3.1"
-
-net_gen = { path = "../net_gen" }
 
 [dev-dependencies]
 lazy_static = "1.3.0"

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -70,6 +70,11 @@ fn create_socket() -> Result<net::UdpSocket> {
     Ok(unsafe { net::UdpSocket::from_raw_fd(sock) })
 }
 
+fn vnet_hdr_len() -> usize {
+    use virtio_bindings::bindings::virtio_net::virtio_net_hdr_v1;
+    std::mem::size_of::<virtio_net_hdr_v1>()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -11,13 +11,14 @@
 #[macro_use]
 extern crate lazy_static;
 extern crate libc;
+extern crate net_gen;
 extern crate rand;
 extern crate serde;
-
-extern crate net_gen;
+extern crate virtio_bindings;
 extern crate vmm_sys_util;
 
 mod mac;
+mod open_tap;
 mod tap;
 
 use std::io::Error as IoError;
@@ -26,6 +27,7 @@ use std::net;
 use std::os::unix::io::FromRawFd;
 
 pub use mac::{MacAddr, MAC_ADDR_LEN};
+pub use open_tap::{open_tap, Error as OpenTapError};
 pub use tap::{Error as TapError, Tap};
 
 #[derive(Debug)]

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -11,14 +11,19 @@
 #[macro_use]
 extern crate lazy_static;
 extern crate libc;
+#[macro_use]
+extern crate log;
 extern crate net_gen;
 extern crate rand;
 extern crate serde;
 extern crate virtio_bindings;
+extern crate vm_memory;
+extern crate vm_virtio;
 extern crate vmm_sys_util;
 
 mod mac;
 mod open_tap;
+mod queue_pair;
 mod tap;
 
 use std::io::Error as IoError;
@@ -28,6 +33,7 @@ use std::os::unix::io::FromRawFd;
 
 pub use mac::{MacAddr, MAC_ADDR_LEN};
 pub use open_tap::{open_tap, Error as OpenTapError};
+pub use queue_pair::{RxVirtio, TxVirtio};
 pub use tap::{Error as TapError, Tap};
 
 #[derive(Debug)]

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -32,7 +32,10 @@ use std::{io, mem, net};
 
 pub use mac::{MacAddr, MAC_ADDR_LEN};
 pub use open_tap::{open_tap, Error as OpenTapError};
-pub use queue_pair::{RxVirtio, TxVirtio};
+pub use queue_pair::{
+    NetCounters, NetQueuePair, NetQueuePairError, RxVirtio, TxVirtio, RX_QUEUE_EVENT, RX_TAP_EVENT,
+    TX_QUEUE_EVENT,
+};
 pub use tap::{Error as TapError, Tap};
 
 #[derive(Debug)]

--- a/net_util/src/open_tap.rs
+++ b/net_util/src/open_tap.rs
@@ -1,0 +1,124 @@
+// Copyright (c) 2020 Intel Corporation. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+use super::TapError;
+use super::{MacAddr, Tap};
+use std::net::Ipv4Addr;
+use std::path::Path;
+use std::{fs, io};
+use virtio_bindings::bindings::virtio_net::virtio_net_hdr_v1;
+
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to convert an hexadecimal string into an integer.
+    ConvertHexStringToInt(std::num::ParseIntError),
+    /// Error related to the multiqueue support.
+    MultiQueueSupport(String),
+    /// Failed to read the TAP flags from sysfs.
+    ReadSysfsTunFlags(io::Error),
+    /// Open tap device failed.
+    TapOpen(TapError),
+    /// Setting tap IP failed.
+    TapSetIp(TapError),
+    /// Setting tap netmask failed.
+    TapSetNetmask(TapError),
+    /// Setting MAC address failed
+    TapSetMac(TapError),
+    /// Getting MAC address failed
+    TapGetMac(TapError),
+    /// Setting tap interface offload flags failed.
+    TapSetOffload(TapError),
+    /// Setting vnet header size failed.
+    TapSetVnetHdrSize(TapError),
+    /// Enabling tap interface failed.
+    TapEnable(TapError),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+fn vnet_hdr_len() -> usize {
+    std::mem::size_of::<virtio_net_hdr_v1>()
+}
+
+fn check_mq_support(if_name: &Option<&str>, queue_pairs: usize) -> Result<()> {
+    if let Some(tap_name) = if_name {
+        let mq = queue_pairs > 1;
+        let path = format!("/sys/class/net/{}/tun_flags", tap_name);
+        // interface does not exist, check is not required
+        if !Path::new(&path).exists() {
+            return Ok(());
+        }
+        let tun_flags_str = fs::read_to_string(path).map_err(Error::ReadSysfsTunFlags)?;
+        let tun_flags = u32::from_str_radix(tun_flags_str.trim().trim_start_matches("0x"), 16)
+            .map_err(Error::ConvertHexStringToInt)?;
+        if (tun_flags & net_gen::IFF_MULTI_QUEUE != 0) && !mq {
+            return Err(Error::MultiQueueSupport(String::from(
+                "TAP interface supports MQ while device does not",
+            )));
+        } else if (tun_flags & net_gen::IFF_MULTI_QUEUE == 0) && mq {
+            return Err(Error::MultiQueueSupport(String::from(
+                "Device supports MQ while TAP interface does not",
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Create a new virtio network device with the given IP address and
+/// netmask.
+pub fn open_tap(
+    if_name: Option<&str>,
+    ip_addr: Option<Ipv4Addr>,
+    netmask: Option<Ipv4Addr>,
+    host_mac: &mut Option<MacAddr>,
+    num_rx_q: usize,
+) -> Result<Vec<Tap>> {
+    let mut taps: Vec<Tap> = Vec::new();
+    let mut ifname: String = String::new();
+    let vnet_hdr_size = vnet_hdr_len() as i32;
+    let flag = net_gen::TUN_F_CSUM | net_gen::TUN_F_UFO | net_gen::TUN_F_TSO4 | net_gen::TUN_F_TSO6;
+
+    // In case the tap interface already exists, check if the number of
+    // queues is appropriate. The tap might not support multiqueue while
+    // the number of queues indicates the user expects multiple queues, or
+    // on the contrary, the tap might support multiqueue while the number
+    // of queues indicates the user doesn't expect multiple queues.
+    check_mq_support(&if_name, num_rx_q)?;
+
+    for i in 0..num_rx_q {
+        let tap: Tap;
+        if i == 0 {
+            tap = match if_name {
+                Some(name) => Tap::open_named(name, num_rx_q).map_err(Error::TapOpen)?,
+                None => Tap::new(num_rx_q).map_err(Error::TapOpen)?,
+            };
+            if let Some(ip) = ip_addr {
+                tap.set_ip_addr(ip).map_err(Error::TapSetIp)?;
+            }
+            if let Some(mask) = netmask {
+                tap.set_netmask(mask).map_err(Error::TapSetNetmask)?;
+            }
+            if let Some(mac) = host_mac {
+                tap.set_mac_addr(*mac).map_err(Error::TapSetMac)?
+            } else {
+                *host_mac = Some(tap.get_mac_addr().map_err(Error::TapGetMac)?)
+            }
+            tap.enable().map_err(Error::TapEnable)?;
+            tap.set_offload(flag).map_err(Error::TapSetOffload)?;
+
+            tap.set_vnet_hdr_size(vnet_hdr_size)
+                .map_err(Error::TapSetVnetHdrSize)?;
+
+            ifname = String::from_utf8(tap.get_if_name()).unwrap();
+        } else {
+            tap = Tap::open_named(ifname.as_str(), num_rx_q).map_err(Error::TapOpen)?;
+            tap.set_offload(flag).map_err(Error::TapSetOffload)?;
+
+            tap.set_vnet_hdr_size(vnet_hdr_size)
+                .map_err(Error::TapSetVnetHdrSize)?;
+        }
+        taps.push(tap);
+    }
+    Ok(taps)
+}

--- a/net_util/src/open_tap.rs
+++ b/net_util/src/open_tap.rs
@@ -2,12 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use super::TapError;
-use super::{MacAddr, Tap};
+use super::{vnet_hdr_len, MacAddr, Tap, TapError};
 use std::net::Ipv4Addr;
 use std::path::Path;
 use std::{fs, io};
-use virtio_bindings::bindings::virtio_net::virtio_net_hdr_v1;
 
 #[derive(Debug)]
 pub enum Error {
@@ -38,10 +36,6 @@ pub enum Error {
 }
 
 type Result<T> = std::result::Result<T, Error>;
-
-fn vnet_hdr_len() -> usize {
-    std::mem::size_of::<virtio_net_hdr_v1>()
-}
 
 fn check_mq_support(if_name: &Option<&str>, queue_pairs: usize) -> Result<()> {
     if let Some(tap_name) = if_name {

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -1,0 +1,189 @@
+// Copyright (c) 2020 Intel Corporation. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+use super::Tap;
+use std::cmp;
+use std::io::Write;
+use std::num::Wrapping;
+use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
+use vm_virtio::{DescriptorChain, Queue};
+use virtio_bindings::bindings::virtio_net::virtio_net_hdr_v1
+
+/// The maximum buffer size when segmentation offload is enabled. This
+/// includes the 12-byte virtio net header.
+/// http://docs.oasis-open.org/virtio/virtio/v1.0/virtio-v1.0.html#x1-1740003
+const MAX_BUFFER_SIZE: usize = 65562;
+
+#[derive(Clone)]
+pub struct TxVirtio {
+    pub iovec: Vec<(GuestAddress, usize)>,
+    pub frame_buf: [u8; MAX_BUFFER_SIZE],
+    pub counter_bytes: Wrapping<u64>,
+    pub counter_frames: Wrapping<u64>,
+}
+
+impl Default for TxVirtio {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TxVirtio {
+    pub fn new() -> Self {
+        TxVirtio {
+            iovec: Vec::new(),
+            frame_buf: [0u8; MAX_BUFFER_SIZE],
+            counter_bytes: Wrapping(0),
+            counter_frames: Wrapping(0),
+        }
+    }
+
+    pub fn process_desc_chain(&mut self, mem: &GuestMemoryMmap, tap: &mut Tap, queue: &mut Queue) {
+        while let Some(avail_desc) = queue.iter(&mem).next() {
+            let head_index = avail_desc.index;
+            let mut read_count = 0;
+            let mut next_desc = Some(avail_desc);
+
+            self.iovec.clear();
+            while let Some(desc) = next_desc {
+                if desc.is_write_only() {
+                    break;
+                }
+                self.iovec.push((desc.addr, desc.len as usize));
+                read_count += desc.len as usize;
+                next_desc = desc.next_descriptor();
+            }
+
+            read_count = 0;
+            // Copy buffer from across multiple descriptors.
+            // TODO(performance - Issue #420): change this to use `writev()` instead of `write()`
+            // and get rid of the intermediate buffer.
+            for (desc_addr, desc_len) in self.iovec.drain(..) {
+                let limit = cmp::min((read_count + desc_len) as usize, self.frame_buf.len());
+
+                let read_result =
+                    mem.read_slice(&mut self.frame_buf[read_count..limit as usize], desc_addr);
+                match read_result {
+                    Ok(_) => {
+                        // Increment by number of bytes actually read
+                        read_count += limit - read_count;
+                    }
+                    Err(e) => {
+                        println!("Failed to read slice: {:?}", e);
+                        break;
+                    }
+                }
+            }
+
+            let write_result = tap.write(&self.frame_buf[..read_count]);
+            match write_result {
+                Ok(_) => {}
+                Err(e) => {
+                    println!("net: tx: error failed to write to tap: {}", e);
+                }
+            };
+
+            self.counter_bytes += Wrapping((read_count - vnet_hdr_len()) as u64);
+            self.counter_frames += Wrapping(1);
+
+            queue.add_used(&mem, head_index, 0);
+            queue.update_avail_event(&mem);
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RxVirtio {
+    pub deferred_frame: bool,
+    pub deferred_irqs: bool,
+    pub bytes_read: usize,
+    pub frame_buf: [u8; MAX_BUFFER_SIZE],
+    pub counter_bytes: Wrapping<u64>,
+    pub counter_frames: Wrapping<u64>,
+}
+
+impl Default for RxVirtio {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RxVirtio {
+    pub fn new() -> Self {
+        RxVirtio {
+            deferred_frame: false,
+            deferred_irqs: false,
+            bytes_read: 0,
+            frame_buf: [0u8; MAX_BUFFER_SIZE],
+            counter_bytes: Wrapping(0),
+            counter_frames: Wrapping(0),
+        }
+    }
+
+    pub fn process_desc_chain(
+        &mut self,
+        mem: &GuestMemoryMmap,
+        mut next_desc: Option<DescriptorChain>,
+        queue: &mut Queue,
+    ) -> bool {
+        let head_index = next_desc.as_ref().unwrap().index;
+        let mut write_count = 0;
+
+        // Copy from frame into buffer, which may span multiple descriptors.
+        loop {
+            match next_desc {
+                Some(desc) => {
+                    if !desc.is_write_only() {
+                        break;
+                    }
+                    let limit = cmp::min(write_count + desc.len as usize, self.bytes_read);
+                    let source_slice = &self.frame_buf[write_count..limit];
+                    let write_result = mem.write_slice(source_slice, desc.addr);
+
+                    match write_result {
+                        Ok(_) => {
+                            write_count = limit;
+                        }
+                        Err(e) => {
+                            error!("Failed to write slice: {:?}", e);
+                            break;
+                        }
+                    };
+
+                    if write_count >= self.bytes_read {
+                        break;
+                    }
+                    next_desc = desc.next_descriptor();
+                }
+                None => {
+                    warn!("Receiving buffer is too small to hold frame of current size");
+                    break;
+                }
+            }
+        }
+
+        self.counter_bytes += Wrapping((write_count - vnet_hdr_len()) as u64);
+        self.counter_frames += Wrapping(1);
+
+        queue.add_used(&mem, head_index, write_count as u32);
+        queue.update_avail_event(&mem);
+
+        // Mark that we have at least one pending packet and we need to interrupt the guest.
+        self.deferred_irqs = true;
+
+        // Update the frame_buf buffer.
+        if write_count < self.bytes_read {
+            self.frame_buf.copy_within(write_count..self.bytes_read, 0);
+            self.bytes_read -= write_count;
+            false
+        } else {
+            self.bytes_read = 0;
+            true
+        }
+    }
+}
+
+fn vnet_hdr_len() -> usize {
+    std::mem::size_of::<virtio_net_hdr_v1>()
+}

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -2,13 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use super::Tap;
+use super::{vnet_hdr_len, Tap};
 use std::cmp;
 use std::io::Write;
 use std::num::Wrapping;
 use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
 use vm_virtio::{DescriptorChain, Queue};
-use virtio_bindings::bindings::virtio_net::virtio_net_hdr_v1
 
 /// The maximum buffer size when segmentation offload is enabled. This
 /// includes the 12-byte virtio net header.
@@ -182,8 +181,4 @@ impl RxVirtio {
             true
         }
     }
-}
-
-fn vnet_hdr_len() -> usize {
-    std::mem::size_of::<virtio_net_hdr_v1>()
 }

--- a/scripts/run_cargo_tests.sh
+++ b/scripts/run_cargo_tests.sh
@@ -17,12 +17,9 @@ time cargo test
 time cargo audit
 time cargo clippy --all-targets --no-default-features --features "pci,acpi,kvm" -- -D warnings
 time cargo rustc --bin cloud-hypervisor --no-default-features --features "pci,acpi,kvm"  -- -D warnings
-time cargo rustc -p vhost_user_net --bin vhost_user_net --no-default-features --features "pci,acpi,kvm"  -- -D warnings
 time cargo clippy --all-targets --no-default-features --features "pci,kvm" -- -D warnings
 time cargo rustc --bin cloud-hypervisor --no-default-features --features "pci,kvm"  -- -D warnings
-time cargo rustc -p vhost_user_net --bin vhost_user_net --no-default-features --features "pci,kvm"  -- -D warnings
 time cargo clippy --all-targets --no-default-features --features "mmio,kvm" -- -D warnings
 time cargo rustc --bin cloud-hypervisor --no-default-features --features "mmio,kvm"  -- -D warnings
-time cargo rustc -p vhost_user_net --bin vhost_user_net --no-default-features --features "mmio,kvm"  -- -D warnings
 time cargo fmt -- --check
 time cargo build --all --release

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -14,6 +14,5 @@ option_parser = { path = "../option_parser" }
 vhost_user_backend = { path = "../vhost_user_backend" }
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "dragonball", package = "vhost", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
-virtio-devices = { path = "../virtio-devices" }
 vm-memory = "0.2.1"
 vmm-sys-util = ">=0.3.1"

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -14,7 +14,7 @@ extern crate virtio_devices;
 
 use libc::{self, EFD_NONBLOCK};
 use log::*;
-use net_util::{MacAddr, Tap};
+use net_util::{open_tap, MacAddr, OpenTapError, Tap};
 use option_parser::{OptionParser, OptionParserError};
 use std::fmt;
 use std::io::{self};
@@ -28,7 +28,7 @@ use vhost_rs::vhost_user::{Error as VhostUserError, Listener};
 use vhost_user_backend::{VhostUserBackend, VhostUserDaemon, Vring, VringWorker};
 use virtio_bindings::bindings::virtio_net::*;
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use virtio_devices::net_util::{open_tap, RxVirtio, TxVirtio};
+use virtio_devices::net_util::{RxVirtio, TxVirtio};
 use virtio_devices::{NetCounters, NetQueuePair};
 use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 use vmm_sys_util::eventfd::EventFd;
@@ -66,7 +66,7 @@ pub enum Error {
     /// No memory configured.
     NoMemoryConfigured,
     /// Open tap device failed.
-    OpenTap(virtio_devices::net_util::Error),
+    OpenTap(OpenTapError),
     /// No socket provided
     SocketParameterMissing,
     /// Underlying QueuePair error

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -14,7 +14,7 @@ extern crate virtio_devices;
 
 use libc::{self, EFD_NONBLOCK};
 use log::*;
-use net_util::{open_tap, MacAddr, OpenTapError, Tap};
+use net_util::{open_tap, MacAddr, OpenTapError, RxVirtio, Tap, TxVirtio};
 use option_parser::{OptionParser, OptionParserError};
 use std::fmt;
 use std::io::{self};
@@ -28,7 +28,6 @@ use vhost_rs::vhost_user::{Error as VhostUserError, Listener};
 use vhost_user_backend::{VhostUserBackend, VhostUserDaemon, Vring, VringWorker};
 use virtio_bindings::bindings::virtio_net::*;
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use virtio_devices::net_util::{RxVirtio, TxVirtio};
 use virtio_devices::{NetCounters, NetQueuePair};
 use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 use vmm_sys_util::eventfd::EventFd;

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -10,11 +10,12 @@ extern crate log;
 extern crate net_util;
 extern crate vhost_rs;
 extern crate vhost_user_backend;
-extern crate virtio_devices;
 
 use libc::{self, EFD_NONBLOCK};
 use log::*;
-use net_util::{open_tap, MacAddr, OpenTapError, RxVirtio, Tap, TxVirtio};
+use net_util::{
+    open_tap, MacAddr, NetCounters, NetQueuePair, OpenTapError, RxVirtio, Tap, TxVirtio,
+};
 use option_parser::{OptionParser, OptionParserError};
 use std::fmt;
 use std::io::{self};
@@ -28,7 +29,6 @@ use vhost_rs::vhost_user::{Error as VhostUserError, Listener};
 use vhost_user_backend::{VhostUserBackend, VhostUserDaemon, Vring, VringWorker};
 use virtio_bindings::bindings::virtio_net::*;
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use virtio_devices::{NetCounters, NetQueuePair};
 use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -69,7 +69,7 @@ pub enum Error {
     /// No socket provided
     SocketParameterMissing,
     /// Underlying QueuePair error
-    NetQueuePair(virtio_devices::Error),
+    NetQueuePair(net_util::NetQueuePairError),
 }
 
 pub const SYNTAX: &str = "vhost-user-net backend parameters \

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -103,7 +103,6 @@ pub enum Error {
         event_type: &'static str,
         underlying: io::Error,
     },
-    FailedReadTap,
     FailedSignalingUsedQueue(io::Error),
     PayloadExpected,
     UnknownEvent {
@@ -111,8 +110,6 @@ pub enum Error {
         event: DeviceEventT,
     },
     IoError(io::Error),
-    RegisterListener(io::Error),
-    UnregisterListener(io::Error),
     EpollCreateFd(io::Error),
     EpollCtl(io::Error),
     EpollWait(io::Error),
@@ -122,4 +119,5 @@ pub enum Error {
     SetShmRegionsNotSupported,
     EpollHander(String),
     NoMemoryConfigured,
+    NetQueuePair(::net_util::NetQueuePairError),
 }

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -6,9 +6,9 @@
 // found in the THIRD-PARTY file.
 
 use super::net_util::{
-    build_net_config_space, build_net_config_space_with_mq, register_listener, unregister_listener,
-    CtrlVirtio, NetCtrlEpollHandler, VirtioNetConfig, KILL_EVENT, NET_EVENTS_COUNT, PAUSE_EVENT,
-    RX_QUEUE_EVENT, RX_TAP_EVENT, TX_QUEUE_EVENT,
+    build_net_config_space, build_net_config_space_with_mq, CtrlVirtio, NetCtrlEpollHandler,
+    VirtioNetConfig, KILL_EVENT, NET_EVENTS_COUNT, PAUSE_EVENT, RX_QUEUE_EVENT, RX_TAP_EVENT,
+    TX_QUEUE_EVENT,
 };
 use super::Error as DeviceError;
 use super::{
@@ -18,7 +18,10 @@ use crate::VirtioInterrupt;
 use anyhow::anyhow;
 use libc::EAGAIN;
 use libc::EFD_NONBLOCK;
-use net_util::{open_tap, MacAddr, OpenTapError, RxVirtio, Tap, TxVirtio};
+use net_util::{
+    open_tap, register_listener, unregister_listener, MacAddr, OpenTapError, RxVirtio, Tap,
+    TxVirtio,
+};
 use std::cmp;
 use std::collections::HashMap;
 use std::fs::File;

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -6,9 +6,9 @@
 // found in the THIRD-PARTY file.
 
 use super::net_util::{
-    build_net_config_space, build_net_config_space_with_mq, open_tap, register_listener,
-    unregister_listener, CtrlVirtio, NetCtrlEpollHandler, RxVirtio, TxVirtio, VirtioNetConfig,
-    KILL_EVENT, NET_EVENTS_COUNT, PAUSE_EVENT, RX_QUEUE_EVENT, RX_TAP_EVENT, TX_QUEUE_EVENT,
+    build_net_config_space, build_net_config_space_with_mq, register_listener, unregister_listener,
+    CtrlVirtio, NetCtrlEpollHandler, RxVirtio, TxVirtio, VirtioNetConfig, KILL_EVENT,
+    NET_EVENTS_COUNT, PAUSE_EVENT, RX_QUEUE_EVENT, RX_TAP_EVENT, TX_QUEUE_EVENT,
 };
 use super::Error as DeviceError;
 use super::{
@@ -18,6 +18,7 @@ use crate::VirtioInterrupt;
 use anyhow::anyhow;
 use libc::EAGAIN;
 use libc::EFD_NONBLOCK;
+use net_util::{open_tap, OpenTapError};
 use net_util::{MacAddr, Tap};
 use std::cmp;
 use std::collections::HashMap;
@@ -44,7 +45,7 @@ use vmm_sys_util::eventfd::EventFd;
 #[derive(Debug)]
 pub enum Error {
     /// Failed to open taps.
-    OpenTap(super::net_util::Error),
+    OpenTap(OpenTapError),
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -7,8 +7,8 @@
 
 use super::net_util::{
     build_net_config_space, build_net_config_space_with_mq, register_listener, unregister_listener,
-    CtrlVirtio, NetCtrlEpollHandler, RxVirtio, TxVirtio, VirtioNetConfig, KILL_EVENT,
-    NET_EVENTS_COUNT, PAUSE_EVENT, RX_QUEUE_EVENT, RX_TAP_EVENT, TX_QUEUE_EVENT,
+    CtrlVirtio, NetCtrlEpollHandler, VirtioNetConfig, KILL_EVENT, NET_EVENTS_COUNT, PAUSE_EVENT,
+    RX_QUEUE_EVENT, RX_TAP_EVENT, TX_QUEUE_EVENT,
 };
 use super::Error as DeviceError;
 use super::{
@@ -18,8 +18,7 @@ use crate::VirtioInterrupt;
 use anyhow::anyhow;
 use libc::EAGAIN;
 use libc::EFD_NONBLOCK;
-use net_util::{open_tap, OpenTapError};
-use net_util::{MacAddr, Tap};
+use net_util::{open_tap, MacAddr, OpenTapError, RxVirtio, Tap, TxVirtio};
 use std::cmp;
 use std::collections::HashMap;
 use std::fs::File;

--- a/virtio-devices/src/net_util.rs
+++ b/virtio-devices/src/net_util.rs
@@ -4,10 +4,9 @@
 
 use super::Error as DeviceError;
 use super::{DescriptorChain, DeviceEventT, Queue};
-use net_util::MacAddr;
+use net_util::{register_listener, MacAddr};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use std::fs::File;
-use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -178,34 +177,6 @@ impl CtrlVirtio {
 
         Ok(())
     }
-}
-
-pub fn register_listener(
-    epoll_fd: RawFd,
-    fd: RawFd,
-    ev_type: epoll::Events,
-    data: u64,
-) -> std::result::Result<(), io::Error> {
-    epoll::ctl(
-        epoll_fd,
-        epoll::ControlOptions::EPOLL_CTL_ADD,
-        fd,
-        epoll::Event::new(ev_type, data),
-    )
-}
-
-pub fn unregister_listener(
-    epoll_fd: RawFd,
-    fd: RawFd,
-    ev_type: epoll::Events,
-    data: u64,
-) -> std::result::Result<(), io::Error> {
-    epoll::ctl(
-        epoll_fd,
-        epoll::ControlOptions::EPOLL_CTL_DEL,
-        fd,
-        epoll::Event::new(ev_type, data),
-    )
 }
 
 pub struct NetCtrlEpollHandler {

--- a/virtio-devices/src/net_util.rs
+++ b/virtio-devices/src/net_util.rs
@@ -4,30 +4,22 @@
 
 use super::Error as DeviceError;
 use super::{DescriptorChain, DeviceEventT, Queue};
-use net_util::{MacAddr, Tap};
+use net_util::MacAddr;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
-use std::cmp;
 use std::fs::File;
-use std::io::{self, Write};
-use std::mem;
-use std::num::Wrapping;
+use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
 use virtio_bindings::bindings::virtio_net::*;
 use vm_memory::{
-    ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryError,
-    GuestMemoryMmap,
+    ByteValued, Bytes, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryError, GuestMemoryMmap,
 };
 use vmm_sys_util::eventfd::EventFd;
 
 type Result<T> = std::result::Result<T, Error>;
 
-/// The maximum buffer size when segmentation offload is enabled. This
-/// includes the 12-byte virtio net header.
-/// http://docs.oasis-open.org/virtio/virtio/v1.0/virtio-v1.0.html#x1-1740003
-const MAX_BUFFER_SIZE: usize = 65562;
 const QUEUE_SIZE: usize = 256;
 
 // The guest has made a buffer available to receive a frame into.
@@ -315,175 +307,6 @@ impl NetCtrlEpollHandler {
     }
 }
 
-#[derive(Clone)]
-pub struct TxVirtio {
-    pub iovec: Vec<(GuestAddress, usize)>,
-    pub frame_buf: [u8; MAX_BUFFER_SIZE],
-    pub counter_bytes: Wrapping<u64>,
-    pub counter_frames: Wrapping<u64>,
-}
-
-impl Default for TxVirtio {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl TxVirtio {
-    pub fn new() -> Self {
-        TxVirtio {
-            iovec: Vec::new(),
-            frame_buf: [0u8; MAX_BUFFER_SIZE],
-            counter_bytes: Wrapping(0),
-            counter_frames: Wrapping(0),
-        }
-    }
-
-    pub fn process_desc_chain(&mut self, mem: &GuestMemoryMmap, tap: &mut Tap, queue: &mut Queue) {
-        while let Some(avail_desc) = queue.iter(&mem).next() {
-            let head_index = avail_desc.index;
-            let mut read_count = 0;
-            let mut next_desc = Some(avail_desc);
-
-            self.iovec.clear();
-            while let Some(desc) = next_desc {
-                if desc.is_write_only() {
-                    break;
-                }
-                self.iovec.push((desc.addr, desc.len as usize));
-                read_count += desc.len as usize;
-                next_desc = desc.next_descriptor();
-            }
-
-            read_count = 0;
-            // Copy buffer from across multiple descriptors.
-            // TODO(performance - Issue #420): change this to use `writev()` instead of `write()`
-            // and get rid of the intermediate buffer.
-            for (desc_addr, desc_len) in self.iovec.drain(..) {
-                let limit = cmp::min((read_count + desc_len) as usize, self.frame_buf.len());
-
-                let read_result =
-                    mem.read_slice(&mut self.frame_buf[read_count..limit as usize], desc_addr);
-                match read_result {
-                    Ok(_) => {
-                        // Increment by number of bytes actually read
-                        read_count += limit - read_count;
-                    }
-                    Err(e) => {
-                        println!("Failed to read slice: {:?}", e);
-                        break;
-                    }
-                }
-            }
-
-            let write_result = tap.write(&self.frame_buf[..read_count]);
-            match write_result {
-                Ok(_) => {}
-                Err(e) => {
-                    println!("net: tx: error failed to write to tap: {}", e);
-                }
-            };
-
-            self.counter_bytes += Wrapping((read_count - vnet_hdr_len()) as u64);
-            self.counter_frames += Wrapping(1);
-
-            queue.add_used(&mem, head_index, 0);
-            queue.update_avail_event(&mem);
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct RxVirtio {
-    pub deferred_frame: bool,
-    pub deferred_irqs: bool,
-    pub bytes_read: usize,
-    pub frame_buf: [u8; MAX_BUFFER_SIZE],
-    pub counter_bytes: Wrapping<u64>,
-    pub counter_frames: Wrapping<u64>,
-}
-
-impl Default for RxVirtio {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl RxVirtio {
-    pub fn new() -> Self {
-        RxVirtio {
-            deferred_frame: false,
-            deferred_irqs: false,
-            bytes_read: 0,
-            frame_buf: [0u8; MAX_BUFFER_SIZE],
-            counter_bytes: Wrapping(0),
-            counter_frames: Wrapping(0),
-        }
-    }
-
-    pub fn process_desc_chain(
-        &mut self,
-        mem: &GuestMemoryMmap,
-        mut next_desc: Option<DescriptorChain>,
-        queue: &mut Queue,
-    ) -> bool {
-        let head_index = next_desc.as_ref().unwrap().index;
-        let mut write_count = 0;
-
-        // Copy from frame into buffer, which may span multiple descriptors.
-        loop {
-            match next_desc {
-                Some(desc) => {
-                    if !desc.is_write_only() {
-                        break;
-                    }
-                    let limit = cmp::min(write_count + desc.len as usize, self.bytes_read);
-                    let source_slice = &self.frame_buf[write_count..limit];
-                    let write_result = mem.write_slice(source_slice, desc.addr);
-
-                    match write_result {
-                        Ok(_) => {
-                            write_count = limit;
-                        }
-                        Err(e) => {
-                            error!("Failed to write slice: {:?}", e);
-                            break;
-                        }
-                    };
-
-                    if write_count >= self.bytes_read {
-                        break;
-                    }
-                    next_desc = desc.next_descriptor();
-                }
-                None => {
-                    warn!("Receiving buffer is too small to hold frame of current size");
-                    break;
-                }
-            }
-        }
-
-        self.counter_bytes += Wrapping((write_count - vnet_hdr_len()) as u64);
-        self.counter_frames += Wrapping(1);
-
-        queue.add_used(&mem, head_index, write_count as u32);
-        queue.update_avail_event(&mem);
-
-        // Mark that we have at least one pending packet and we need to interrupt the guest.
-        self.deferred_irqs = true;
-
-        // Update the frame_buf buffer.
-        if write_count < self.bytes_read {
-            self.frame_buf.copy_within(write_count..self.bytes_read, 0);
-            self.bytes_read -= write_count;
-            false
-        } else {
-            self.bytes_read = 0;
-            true
-        }
-    }
-}
-
 pub fn build_net_config_space(
     mut config: &mut VirtioNetConfig,
     mac: MacAddr,
@@ -508,8 +331,4 @@ pub fn build_net_config_space_with_mq(
         config.max_virtqueue_pairs = num_queue_pairs;
         *avail_features |= 1 << VIRTIO_NET_F_MQ;
     }
-}
-
-fn vnet_hdr_len() -> usize {
-    mem::size_of::<virtio_net_hdr_v1>()
 }

--- a/virtio-devices/src/net_util.rs
+++ b/virtio-devices/src/net_util.rs
@@ -21,12 +21,6 @@ type Result<T> = std::result::Result<T, Error>;
 
 const QUEUE_SIZE: usize = 256;
 
-// The guest has made a buffer available to receive a frame into.
-pub const RX_QUEUE_EVENT: DeviceEventT = 0;
-// The transmit queue has a frame that is ready to send from the guest.
-pub const TX_QUEUE_EVENT: DeviceEventT = 1;
-// A frame is available for reading from the tap device to receive in the guest.
-pub const RX_TAP_EVENT: DeviceEventT = 2;
 // The device has been dropped.
 pub const KILL_EVENT: DeviceEventT = 3;
 // The device should be paused.

--- a/virtio-devices/src/net_util.rs
+++ b/virtio-devices/src/net_util.rs
@@ -4,17 +4,14 @@
 
 use super::Error as DeviceError;
 use super::{DescriptorChain, DeviceEventT, Queue};
-use net_util::{MacAddr, Tap, TapError};
+use net_util::{MacAddr, Tap};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use std::cmp;
-use std::fs;
 use std::fs::File;
 use std::io::{self, Write};
 use std::mem;
-use std::net::Ipv4Addr;
 use std::num::Wrapping;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
-use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
@@ -94,8 +91,6 @@ unsafe impl ByteValued for VirtioNetConfig {}
 
 #[derive(Debug)]
 pub enum Error {
-    /// Failed to convert an hexadecimal string into an integer.
-    ConvertHexStringToInt(std::num::ParseIntError),
     /// Read process MQ.
     FailedProcessMQ,
     /// Read queue failed.
@@ -108,30 +103,10 @@ pub enum Error {
     InvalidDesc,
     /// Invalid queue pairs number
     InvalidQueuePairsNum,
-    /// Error related to the multiqueue support.
-    MultiQueueSupport(String),
     /// No memory passed in.
     NoMemory,
     /// No ueue pairs nummber.
     NoQueuePairsNum,
-    /// Failed to read the TAP flags from sysfs.
-    ReadSysfsTunFlags(io::Error),
-    /// Open tap device failed.
-    TapOpen(TapError),
-    /// Setting tap IP failed.
-    TapSetIp(TapError),
-    /// Setting tap netmask failed.
-    TapSetNetmask(TapError),
-    /// Setting MAC address failed
-    TapSetMac(TapError),
-    /// Getting MAC address failed
-    TapGetMac(TapError),
-    /// Setting tap interface offload flags failed.
-    TapSetOffload(TapError),
-    /// Setting vnet header size failed.
-    TapSetVnetHdrSize(TapError),
-    /// Enabling tap interface failed.
-    TapEnable(TapError),
 }
 
 pub struct CtrlVirtio {
@@ -537,86 +512,4 @@ pub fn build_net_config_space_with_mq(
 
 fn vnet_hdr_len() -> usize {
     mem::size_of::<virtio_net_hdr_v1>()
-}
-
-fn check_mq_support(if_name: &Option<&str>, queue_pairs: usize) -> Result<()> {
-    if let Some(tap_name) = if_name {
-        let mq = queue_pairs > 1;
-        let path = format!("/sys/class/net/{}/tun_flags", tap_name);
-        // interface does not exist, check is not required
-        if !Path::new(&path).exists() {
-            return Ok(());
-        }
-        let tun_flags_str = fs::read_to_string(path).map_err(Error::ReadSysfsTunFlags)?;
-        let tun_flags = u32::from_str_radix(tun_flags_str.trim().trim_start_matches("0x"), 16)
-            .map_err(Error::ConvertHexStringToInt)?;
-        if (tun_flags & net_gen::IFF_MULTI_QUEUE != 0) && !mq {
-            return Err(Error::MultiQueueSupport(String::from(
-                "TAP interface supports MQ while device does not",
-            )));
-        } else if (tun_flags & net_gen::IFF_MULTI_QUEUE == 0) && mq {
-            return Err(Error::MultiQueueSupport(String::from(
-                "Device supports MQ while TAP interface does not",
-            )));
-        }
-    }
-    Ok(())
-}
-
-/// Create a new virtio network device with the given IP address and
-/// netmask.
-pub fn open_tap(
-    if_name: Option<&str>,
-    ip_addr: Option<Ipv4Addr>,
-    netmask: Option<Ipv4Addr>,
-    host_mac: &mut Option<MacAddr>,
-    num_rx_q: usize,
-) -> Result<Vec<Tap>> {
-    let mut taps: Vec<Tap> = Vec::new();
-    let mut ifname: String = String::new();
-    let vnet_hdr_size = vnet_hdr_len() as i32;
-    let flag = net_gen::TUN_F_CSUM | net_gen::TUN_F_UFO | net_gen::TUN_F_TSO4 | net_gen::TUN_F_TSO6;
-
-    // In case the tap interface already exists, check if the number of
-    // queues is appropriate. The tap might not support multiqueue while
-    // the number of queues indicates the user expects multiple queues, or
-    // on the contrary, the tap might support multiqueue while the number
-    // of queues indicates the user doesn't expect multiple queues.
-    check_mq_support(&if_name, num_rx_q)?;
-
-    for i in 0..num_rx_q {
-        let tap: Tap;
-        if i == 0 {
-            tap = match if_name {
-                Some(name) => Tap::open_named(name, num_rx_q).map_err(Error::TapOpen)?,
-                None => Tap::new(num_rx_q).map_err(Error::TapOpen)?,
-            };
-            if let Some(ip) = ip_addr {
-                tap.set_ip_addr(ip).map_err(Error::TapSetIp)?;
-            }
-            if let Some(mask) = netmask {
-                tap.set_netmask(mask).map_err(Error::TapSetNetmask)?;
-            }
-            if let Some(mac) = host_mac {
-                tap.set_mac_addr(*mac).map_err(Error::TapSetMac)?
-            } else {
-                *host_mac = Some(tap.get_mac_addr().map_err(Error::TapGetMac)?)
-            }
-            tap.enable().map_err(Error::TapEnable)?;
-            tap.set_offload(flag).map_err(Error::TapSetOffload)?;
-
-            tap.set_vnet_hdr_size(vnet_hdr_size)
-                .map_err(Error::TapSetVnetHdrSize)?;
-
-            ifname = String::from_utf8(tap.get_if_name()).unwrap();
-        } else {
-            tap = Tap::open_named(ifname.as_str(), num_rx_q).map_err(Error::TapOpen)?;
-            tap.set_offload(flag).map_err(Error::TapSetOffload)?;
-
-            tap.set_vnet_hdr_size(vnet_hdr_size)
-                .map_err(Error::TapSetVnetHdrSize)?;
-        }
-        taps.push(tap);
-    }
-    Ok(taps)
 }


### PR DESCRIPTION
Move code into the common, shared, pre-existing `net_util` crate to remove the dependency from the vhost-user-net crate on virtio-devices. This simplifies the dependency chain and means that the backend doe not depend on e.g. pci or qcow crates.