### PR TITLE
tests: Enable AArch64 CI with musl toolchain

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,6 +83,11 @@ pipeline{
 								sh "scripts/dev_cli.sh build --release"
 							}
 						}
+						stage ('Build for musl') {
+							steps {
+								sh "scripts/dev_cli.sh build --release --libc musl"
+							}
+						}
 						stage ('Run unit tests') {
 							steps {
 								sh "scripts/dev_cli.sh tests --unit"

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -208,7 +208,7 @@ cmd_build() {
 
     rustflags=""
     if [ $(uname -m) = "aarch64" ] && [ $libc = "musl" ] ; then
-        rustflags="-C link-arg=-lgcc"
+        rustflags="-C link-arg=-lgcc -C link_arg=-specs -C link_arg=/usr/lib/aarch64-linux-musl/musl-gcc.specs"
     fi
 
     # A workaround on Arm64 to avoid build errors in kvm-bindings


### PR DESCRIPTION
This commit adds a Jenkins stage to enable AArch64 CI with musl toolchain.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>