### PR TITLE
tests: Enable virtio-mem testing with virtio-mmio

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4027,7 +4027,7 @@ mod tests {
             });
         }
 
-        #[cfg_attr(not(feature = "mmio"), test)]
+        #[test]
         fn test_virtio_mem() {
             test_block!(tb, "", {
                 let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());


### PR DESCRIPTION
Try and enable virtio-mem testing when using the virtio-mmio transport.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>