### PR TITLE
Partial sync with the rust-vmm vm-virtio crate

### DIFF
--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -45,7 +45,7 @@ impl TxVirtio {
 
     pub fn process_desc_chain(&mut self, mem: &GuestMemoryMmap, tap: &mut Tap, queue: &mut Queue) {
         while let Some(avail_desc) = queue.iter(&mem).next() {
-            let head_index = avail_desc.index;
+            let head_index = avail_desc.index();
             let mut read_count = 0;
             let mut next_desc = Some(avail_desc);
 
@@ -54,8 +54,8 @@ impl TxVirtio {
                 if desc.is_write_only() {
                     break;
                 }
-                self.iovec.push((desc.addr, desc.len as usize));
-                read_count += desc.len as usize;
+                self.iovec.push((desc.addr(), desc.len() as usize));
+                read_count += desc.len() as usize;
                 next_desc = desc.next_descriptor();
             }
 
@@ -131,7 +131,7 @@ impl RxVirtio {
         mut next_desc: Option<DescriptorChain>,
         queue: &mut Queue,
     ) -> bool {
-        let head_index = next_desc.as_ref().unwrap().index;
+        let head_index = next_desc.as_ref().unwrap().index();
         let mut write_count = 0;
 
         // Copy from frame into buffer, which may span multiple descriptors.
@@ -141,9 +141,9 @@ impl RxVirtio {
                     if !desc.is_write_only() {
                         break;
                     }
-                    let limit = cmp::min(write_count + desc.len as usize, self.bytes_read);
+                    let limit = cmp::min(write_count + desc.len() as usize, self.bytes_read);
                     let source_slice = &self.frame_buf[write_count..limit];
-                    let write_result = mem.write_slice(source_slice, desc.addr);
+                    let write_result = mem.write_slice(source_slice, desc.addr());
 
                     match write_result {
                         Ok(_) => {

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -127,10 +127,10 @@ impl VhostUserBlkThread {
             None => return false,
         };
 
-        while let Some(head) = vring.mut_queue().iter(mem).next() {
+        while let Some(mut head) = vring.mut_queue().iter(mem).next() {
             debug!("got an element in the queue");
             let len;
-            match Request::parse(&head, mem) {
+            match Request::parse(&mut head, mem) {
                 Ok(mut request) => {
                     debug!("element is a valid request");
                     request.set_writeback(self.writeback.load(Ordering::SeqCst));

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -159,7 +159,7 @@ impl VhostUserBlkThread {
 
             if self.event_idx {
                 let queue = vring.mut_queue();
-                if let Some(used_idx) = queue.add_used(mem, head.index, len) {
+                if let Some(used_idx) = queue.add_used(mem, head.index(), len) {
                     if queue.needs_notification(&mem, Wrapping(used_idx)) {
                         debug!("signalling queue");
                         vring.signal_used_queue().unwrap();
@@ -170,7 +170,7 @@ impl VhostUserBlkThread {
                 }
             } else {
                 debug!("signalling queue");
-                vring.mut_queue().add_used(mem, head.index, len);
+                vring.mut_queue().add_used(mem, head.index(), len);
                 vring.signal_used_queue().unwrap();
                 used_any = true;
             }

--- a/vhost_user_fs/src/descriptor_utils.rs
+++ b/vhost_user_fs/src/descriptor_utils.rs
@@ -209,17 +209,19 @@ impl<'a> Reader<'a> {
                 // This can happen if a driver tricks a device into reading more data than
                 // fits in a `usize`.
                 total_len = total_len
-                    .checked_add(desc.len as usize)
+                    .checked_add(desc.len() as usize)
                     .ok_or(Error::DescriptorChainOverflow)?;
 
-                let region = mem.find_region(desc.addr).ok_or(Error::FindMemoryRegion)?;
+                let region = mem
+                    .find_region(desc.addr())
+                    .ok_or(Error::FindMemoryRegion)?;
                 let offset = desc
-                    .addr
+                    .addr()
                     .checked_sub(region.start_addr().raw_value())
                     .unwrap();
                 region
                     .deref()
-                    .get_slice(offset.raw_value() as usize, desc.len as usize)
+                    .get_slice(offset.raw_value() as usize, desc.len() as usize)
                     .map_err(Error::VolatileMemoryError)
             })
             .collect::<Result<VecDeque<VolatileSlice<'a>>>>()?;
@@ -368,17 +370,19 @@ impl<'a> Writer<'a> {
                 // This can happen if a driver tricks a device into writing more data than
                 // fits in a `usize`.
                 total_len = total_len
-                    .checked_add(desc.len as usize)
+                    .checked_add(desc.len() as usize)
                     .ok_or(Error::DescriptorChainOverflow)?;
 
-                let region = mem.find_region(desc.addr).ok_or(Error::FindMemoryRegion)?;
+                let region = mem
+                    .find_region(desc.addr())
+                    .ok_or(Error::FindMemoryRegion)?;
                 let offset = desc
-                    .addr
+                    .addr()
                     .checked_sub(region.start_addr().raw_value())
                     .unwrap();
                 region
                     .deref()
-                    .get_slice(offset.raw_value() as usize, desc.len as usize)
+                    .get_slice(offset.raw_value() as usize, desc.len() as usize)
                     .map_err(Error::VolatileMemoryError)
             })
             .collect::<Result<VecDeque<VolatileSlice<'a>>>>()?;

--- a/vhost_user_fs/src/main.rs
+++ b/vhost_user_fs/src/main.rs
@@ -145,7 +145,7 @@ impl<F: FileSystem + Send + Sync + 'static> VhostUserFsThread<F> {
             self.pool.spawn_ok(async move {
                 let mem = atomic_mem.memory();
                 let desc = DescriptorChain::new_from_head(&mem, desc_head).unwrap();
-                let head_index = desc.index;
+                let head_index = desc.index();
 
                 let reader = Reader::new(&mem, desc.clone())
                     .map_err(Error::QueueReader)

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -180,7 +180,7 @@ impl BalloonEpollHandler {
         let mut used_count = 0;
         let mem = self.mem.memory();
         for avail_desc in self.queues[queue_index].iter(&mem) {
-            used_desc_heads[used_count] = avail_desc.index;
+            used_desc_heads[used_count] = avail_desc.index();
             used_count += 1;
 
             let data_chunk_size = size_of::<u32>();
@@ -190,14 +190,14 @@ impl BalloonEpollHandler {
                 error!("The head contains the request type is not right");
                 return Err(Error::UnexpectedWriteOnlyDescriptor);
             }
-            if avail_desc.len as usize % data_chunk_size != 0 {
-                error!("the request size {} is not right", avail_desc.len);
+            if avail_desc.len() as usize % data_chunk_size != 0 {
+                error!("the request size {} is not right", avail_desc.len());
                 return Err(Error::InvalidRequest);
             }
 
             let mut offset = 0u64;
-            while offset < avail_desc.len as u64 {
-                let addr = avail_desc.addr.checked_add(offset).unwrap();
+            while offset < avail_desc.len() as u64 {
+                let addr = avail_desc.addr().checked_add(offset).unwrap();
                 let pfn: u32 = mem.read_obj(addr).map_err(Error::GuestMemory)?;
                 offset += data_chunk_size as u64;
 

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -494,8 +494,8 @@ impl Request {
         }
 
         let mut req = Request {
-            request_type: request_type(&mem, avail_desc.addr)?,
-            sector: sector(&mem, avail_desc.addr)?,
+            request_type: request_type(&mem, avail_desc.addr())?,
+            sector: sector(&mem, avail_desc.addr())?,
             data_addr: GuestAddress(0),
             data_len: 0,
             status_addr: GuestAddress(0),
@@ -530,8 +530,8 @@ impl Request {
                 return Err(Error::UnexpectedReadOnlyDescriptor);
             }
 
-            req.data_addr = data_desc.addr;
-            req.data_len = data_desc.len;
+            req.data_addr = data_desc.desc.addr();
+            req.data_len = data_desc.len();
         }
 
         // The status MUST always be writable.
@@ -539,11 +539,11 @@ impl Request {
             return Err(Error::UnexpectedReadOnlyDescriptor);
         }
 
-        if status_desc.len < 1 {
+        if status_desc.is_empty() {
             return Err(Error::DescriptorLengthTooSmall);
         }
 
-        req.status_addr = status_desc.addr;
+        req.status_addr = status_desc.addr();
 
         Ok(req)
     }
@@ -679,7 +679,7 @@ impl<T: DiskFile> BlockEpollHandler<T> {
                     len = 0;
                 }
             }
-            used_desc_heads.push((avail_desc.index, len));
+            used_desc_heads.push((avail_desc.index(), len));
             used_count += 1;
         }
 

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -116,15 +116,15 @@ impl ConsoleEpollHandler {
 
         let mem = self.mem.memory();
         for avail_desc in recv_queue.iter(&mem) {
-            let len = cmp::min(avail_desc.len as u32, in_buffer.len() as u32);
+            let len = cmp::min(avail_desc.len() as u32, in_buffer.len() as u32);
             let source_slice = in_buffer.drain(..len as usize).collect::<Vec<u8>>();
-            if let Err(e) = mem.write_slice(&source_slice[..], avail_desc.addr) {
+            if let Err(e) = mem.write_slice(&source_slice[..], avail_desc.addr()) {
                 error!("Failed to write slice: {:?}", e);
                 recv_queue.go_to_previous_position();
                 break;
             }
 
-            used_desc_heads[used_count] = (avail_desc.index, len);
+            used_desc_heads[used_count] = (avail_desc.index(), len);
             used_count += 1;
 
             if in_buffer.is_empty() {
@@ -156,14 +156,14 @@ impl ConsoleEpollHandler {
             let len;
             let mut out = self.out.lock().unwrap();
             let _ = mem.write_to(
-                avail_desc.addr,
+                avail_desc.addr(),
                 &mut out.deref_mut(),
-                avail_desc.len as usize,
+                avail_desc.len() as usize,
             );
             let _ = out.flush();
 
-            len = avail_desc.len;
-            used_desc_heads[used_count] = (avail_desc.index, len);
+            len = avail_desc.len();
+            used_desc_heads[used_count] = (avail_desc.index(), len);
             used_count += 1;
         }
 

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -397,15 +397,16 @@ impl Request {
             return Err(Error::UnexpectedWriteOnlyDescriptor);
         }
 
-        if (avail_desc.len as usize) < size_of::<VirtioIommuReqHead>() {
+        if (avail_desc.len() as usize) < size_of::<VirtioIommuReqHead>() {
             return Err(Error::InvalidRequest);
         }
 
-        let req_head: VirtioIommuReqHead =
-            mem.read_obj(avail_desc.addr).map_err(Error::GuestMemory)?;
+        let req_head: VirtioIommuReqHead = mem
+            .read_obj(avail_desc.addr())
+            .map_err(Error::GuestMemory)?;
         let req_offset = size_of::<VirtioIommuReqHead>();
-        let desc_size_left = (avail_desc.len as usize) - req_offset;
-        let req_addr = if let Some(addr) = avail_desc.addr.checked_add(req_offset as u64) {
+        let desc_size_left = (avail_desc.len() as usize) - req_offset;
+        let req_addr = if let Some(addr) = avail_desc.addr().checked_add(req_offset as u64) {
             addr
         } else {
             return Err(Error::InvalidRequest);
@@ -576,7 +577,7 @@ impl Request {
             return Err(Error::UnexpectedReadOnlyDescriptor);
         }
 
-        if status_desc.len < hdr_len + size_of::<VirtioIommuReqTail>() as u32 {
+        if status_desc.len() < hdr_len + size_of::<VirtioIommuReqTail>() as u32 {
             return Err(Error::BufferLengthTooSmall);
         }
 
@@ -586,7 +587,7 @@ impl Request {
         };
         reply.extend_from_slice(tail.as_slice());
 
-        mem.write_slice(reply.as_slice(), status_desc.addr)
+        mem.write_slice(reply.as_slice(), status_desc.addr())
             .map_err(Error::GuestMemory)?;
 
         Ok((hdr_len as usize) + size_of::<VirtioIommuReqTail>())
@@ -625,7 +626,7 @@ impl IommuEpollHandler {
                 }
             };
 
-            used_desc_heads[used_count] = (avail_desc.index, len);
+            used_desc_heads[used_count] = (avail_desc.index(), len);
             used_count += 1;
         }
 

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -195,10 +195,12 @@ impl Request {
         if avail_desc.is_write_only() {
             return Err(Error::UnexpectedWriteOnlyDescriptor);
         }
-        if avail_desc.len as usize != size_of::<VirtioMemReq>() {
+        if avail_desc.len() as usize != size_of::<VirtioMemReq>() {
             return Err(Error::InvalidRequest);
         }
-        let req: VirtioMemReq = mem.read_obj(avail_desc.addr).map_err(Error::GuestMemory)?;
+        let req: VirtioMemReq = mem
+            .read_obj(avail_desc.addr())
+            .map_err(Error::GuestMemory)?;
 
         let status_desc = avail_desc
             .next_descriptor()
@@ -209,13 +211,13 @@ impl Request {
             return Err(Error::UnexpectedReadOnlyDescriptor);
         }
 
-        if (status_desc.len as usize) < size_of::<VirtioMemResp>() {
+        if (status_desc.len() as usize) < size_of::<VirtioMemResp>() {
             return Err(Error::BufferLengthTooSmall);
         }
 
         Ok(Request {
             req,
-            status_addr: status_desc.addr,
+            status_addr: status_desc.addr(),
         })
     }
 }
@@ -582,7 +584,7 @@ impl MemEpollHandler {
                     }
                 }
             };
-            used_desc_heads[used_count] = (avail_desc.index, len);
+            used_desc_heads[used_count] = (avail_desc.index(), len);
             used_count += 1;
         }
 

--- a/virtio-devices/src/net_util.rs
+++ b/virtio-devices/src/net_util.rs
@@ -120,7 +120,7 @@ impl CtrlVirtio {
             return Err(Error::NoQueuePairsNum);
         };
         let queue_pairs = mem
-            .read_obj::<u16>(mq_desc.addr)
+            .read_obj::<u16>(mq_desc.addr())
             .map_err(Error::GuestMemory)?;
         if (queue_pairs < VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MIN as u16)
             || (queue_pairs > VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MAX as u16)
@@ -132,7 +132,7 @@ impl CtrlVirtio {
         } else {
             return Err(Error::NoQueuePairsNum);
         };
-        mem.write_obj::<u8>(0, status_desc.addr)
+        mem.write_obj::<u8>(0, status_desc.addr())
             .map_err(Error::GuestMemory)?;
 
         Ok(())
@@ -142,10 +142,10 @@ impl CtrlVirtio {
         let mut used_desc_heads = [(0, 0); QUEUE_SIZE];
         let mut used_count = 0;
         if let Some(avail_desc) = self.queue.iter(&mem).next() {
-            used_desc_heads[used_count] = (avail_desc.index, avail_desc.len);
+            used_desc_heads[used_count] = (avail_desc.index(), avail_desc.len());
             used_count += 1;
             let ctrl_hdr = mem
-                .read_obj::<u16>(avail_desc.addr)
+                .read_obj::<u16>(avail_desc.addr())
                 .map_err(Error::GuestMemory)?;
             let ctrl_hdr_v = ctrl_hdr.as_slice();
             let class = ctrl_hdr_v[0];

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -149,11 +149,13 @@ impl Request {
             return Err(Error::UnexpectedWriteOnlyDescriptor);
         }
 
-        if avail_desc.len as usize != size_of::<VirtioPmemReq>() {
+        if avail_desc.len() as usize != size_of::<VirtioPmemReq>() {
             return Err(Error::InvalidRequest);
         }
 
-        let request: VirtioPmemReq = mem.read_obj(avail_desc.addr).map_err(Error::GuestMemory)?;
+        let request: VirtioPmemReq = mem
+            .read_obj(avail_desc.addr())
+            .map_err(Error::GuestMemory)?;
 
         let request_type = match request.type_ {
             VIRTIO_PMEM_REQ_TYPE_FLUSH => RequestType::Flush,
@@ -169,13 +171,13 @@ impl Request {
             return Err(Error::UnexpectedReadOnlyDescriptor);
         }
 
-        if (status_desc.len as usize) < size_of::<VirtioPmemResp>() {
+        if (status_desc.len() as usize) < size_of::<VirtioPmemResp>() {
             return Err(Error::BufferLengthTooSmall);
         }
 
         Ok(Request {
             type_: request_type,
-            status_addr: status_desc.addr,
+            status_addr: status_desc.addr(),
         })
     }
 }
@@ -226,7 +228,7 @@ impl PmemEpollHandler {
                 }
             };
 
-            used_desc_heads[used_count] = (avail_desc.index, len);
+            used_desc_heads[used_count] = (avail_desc.index(), len);
             used_count += 1;
         }
 

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -60,17 +60,17 @@ impl RngEpollHandler {
                 // Fill the read with data from the random device on the host.
                 if mem
                     .read_from(
-                        avail_desc.addr,
+                        avail_desc.addr(),
                         &mut self.random_file,
-                        avail_desc.len as usize,
+                        avail_desc.len() as usize,
                     )
                     .is_ok()
                 {
-                    len = avail_desc.len;
+                    len = avail_desc.len();
                 }
             }
 
-            used_desc_heads[used_count] = (avail_desc.index, len);
+            used_desc_heads[used_count] = (avail_desc.index(), len);
             used_count += 1;
         }
 

--- a/virtio-devices/src/vsock/csm/connection.rs
+++ b/virtio-devices/src/vsock/csm/connection.rs
@@ -818,7 +818,7 @@ mod tests {
             let mut handler_ctx = vsock_test_ctx.create_epoll_handler_context();
             let stream = TestStream::new();
             let mut pkt = VsockPacket::from_rx_virtq_head(
-                &handler_ctx.handler.queues[0]
+                &mut handler_ctx.handler.queues[0]
                     .iter(&vsock_test_ctx.mem)
                     .next()
                     .unwrap(),

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -787,9 +787,9 @@ mod tests {
             ctx.signal_txq_event();
 
             // The available TX descriptor should have been used.
-            assert_eq!(ctx.guest_txvq.used.idx.get(), 1);
+            assert_eq!(ctx.guest_txvq.used.idx().load(), 1);
             // The available RX descriptor should be untouched.
-            assert_eq!(ctx.guest_rxvq.used.idx.get(), 0);
+            assert_eq!(ctx.guest_rxvq.used.idx().load(), 0);
         }
 
         // Test case:
@@ -803,8 +803,8 @@ mod tests {
             ctx.signal_txq_event();
 
             // Both available RX and TX descriptors should have been used.
-            assert_eq!(ctx.guest_txvq.used.idx.get(), 1);
-            assert_eq!(ctx.guest_rxvq.used.idx.get(), 1);
+            assert_eq!(ctx.guest_txvq.used.idx().load(), 1);
+            assert_eq!(ctx.guest_rxvq.used.idx().load(), 1);
         }
 
         // Test case:
@@ -823,8 +823,8 @@ mod tests {
             ctx.signal_txq_event();
 
             // Both RX and TX queues should be untouched.
-            assert_eq!(ctx.guest_txvq.used.idx.get(), 0);
-            assert_eq!(ctx.guest_rxvq.used.idx.get(), 0);
+            assert_eq!(ctx.guest_txvq.used.idx().load(), 0);
+            assert_eq!(ctx.guest_rxvq.used.idx().load(), 0);
         }
 
         // Test case:
@@ -839,7 +839,7 @@ mod tests {
 
             // The available descriptor should have been consumed, but no packet should have
             // reached the backend.
-            assert_eq!(ctx.guest_txvq.used.idx.get(), 1);
+            assert_eq!(ctx.guest_txvq.used.idx().load(), 1);
             assert_eq!(ctx.handler.backend.read().unwrap().tx_ok_cnt, 0);
         }
 
@@ -878,7 +878,7 @@ mod tests {
             ctx.signal_rxq_event();
 
             // The available RX buffer should've been left untouched.
-            assert_eq!(ctx.guest_rxvq.used.idx.get(), 0);
+            assert_eq!(ctx.guest_rxvq.used.idx().load(), 0);
         }
 
         // Test case:
@@ -893,7 +893,7 @@ mod tests {
             ctx.signal_rxq_event();
 
             // The available RX buffer should have been used.
-            assert_eq!(ctx.guest_rxvq.used.idx.get(), 1);
+            assert_eq!(ctx.guest_rxvq.used.idx().load(), 1);
         }
 
         // Test case: the driver provided a malformed RX descriptor chain.
@@ -906,7 +906,7 @@ mod tests {
 
             // The chain should've been processed, without employing the backend.
             assert!(ctx.handler.process_rx().is_ok());
-            assert_eq!(ctx.guest_rxvq.used.idx.get(), 1);
+            assert_eq!(ctx.guest_rxvq.used.idx().load(), 1);
             assert_eq!(ctx.handler.backend.read().unwrap().rx_ok_cnt, 0);
         }
 
@@ -968,9 +968,9 @@ mod tests {
                 Some(epoll::Events::EPOLLIN)
             );
             // TX queue processing should've been triggered.
-            assert_eq!(ctx.guest_txvq.used.idx.get(), 1);
+            assert_eq!(ctx.guest_txvq.used.idx().load(), 1);
             // RX queue processing should've been triggered.
-            assert_eq!(ctx.guest_rxvq.used.idx.get(), 1);
+            assert_eq!(ctx.guest_rxvq.used.idx().load(), 1);
         }
 
         // Test case:
@@ -995,9 +995,9 @@ mod tests {
                 Some(epoll::Events::EPOLLIN)
             );
             // TX queue processing should've been triggered.
-            assert_eq!(ctx.guest_txvq.used.idx.get(), 1);
+            assert_eq!(ctx.guest_txvq.used.idx().load(), 1);
             // The RX queue should've been left untouched.
-            assert_eq!(ctx.guest_rxvq.used.idx.get(), 0);
+            assert_eq!(ctx.guest_rxvq.used.idx().load(), 0);
         }
     }
 

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -125,8 +125,8 @@ where
         let mut used_desc_heads = [(0, 0); QUEUE_SIZE as usize];
         let mut used_count = 0;
         let mem = self.mem.memory();
-        for avail_desc in self.queues[0].iter(&mem) {
-            let used_len = match VsockPacket::from_rx_virtq_head(&avail_desc) {
+        for mut avail_desc in self.queues[0].iter(&mem) {
+            let used_len = match VsockPacket::from_rx_virtq_head(&mut avail_desc) {
                 Ok(mut pkt) => {
                     if self.backend.write().unwrap().recv_pkt(&mut pkt).is_ok() {
                         pkt.hdr().len() as u32 + pkt.len()
@@ -167,8 +167,8 @@ where
         let mut used_desc_heads = [(0, 0); QUEUE_SIZE as usize];
         let mut used_count = 0;
         let mem = self.mem.memory();
-        for avail_desc in self.queues[1].iter(&mem) {
-            let pkt = match VsockPacket::from_tx_virtq_head(&avail_desc) {
+        for mut avail_desc in self.queues[1].iter(&mem) {
+            let pkt = match VsockPacket::from_tx_virtq_head(&mut avail_desc) {
                 Ok(pkt) => pkt,
                 Err(e) => {
                     error!("vsock: error reading TX packet: {:?}", e);

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -834,7 +834,7 @@ mod tests {
             let mut ctx = test_ctx.create_epoll_handler_context();
 
             // Invalidate the packet header descriptor, by setting its length to 0.
-            ctx.guest_txvq.dtable[0].len.set(0);
+            ctx.guest_txvq.dtable[0].len().store(0);
             ctx.signal_txq_event();
 
             // The available descriptor should have been consumed, but no packet should have
@@ -902,7 +902,7 @@ mod tests {
             let mut ctx = test_ctx.create_epoll_handler_context();
 
             // Invalidate the packet header descriptor, by setting its length to 0.
-            ctx.guest_rxvq.dtable[0].len.set(0);
+            ctx.guest_rxvq.dtable[0].len().store(0);
 
             // The chain should've been processed, without employing the backend.
             assert!(ctx.handler.process_rx().is_ok());

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -787,9 +787,9 @@ mod tests {
             ctx.signal_txq_event();
 
             // The available TX descriptor should have been used.
-            assert_eq!(ctx.guest_txvq.used.idx().load(), 1);
+            assert_eq!(ctx.guest_txvq.used().idx().load(), 1);
             // The available RX descriptor should be untouched.
-            assert_eq!(ctx.guest_rxvq.used.idx().load(), 0);
+            assert_eq!(ctx.guest_rxvq.used().idx().load(), 0);
         }
 
         // Test case:
@@ -803,8 +803,8 @@ mod tests {
             ctx.signal_txq_event();
 
             // Both available RX and TX descriptors should have been used.
-            assert_eq!(ctx.guest_txvq.used.idx().load(), 1);
-            assert_eq!(ctx.guest_rxvq.used.idx().load(), 1);
+            assert_eq!(ctx.guest_txvq.used().idx().load(), 1);
+            assert_eq!(ctx.guest_rxvq.used().idx().load(), 1);
         }
 
         // Test case:
@@ -823,8 +823,8 @@ mod tests {
             ctx.signal_txq_event();
 
             // Both RX and TX queues should be untouched.
-            assert_eq!(ctx.guest_txvq.used.idx().load(), 0);
-            assert_eq!(ctx.guest_rxvq.used.idx().load(), 0);
+            assert_eq!(ctx.guest_txvq.used().idx().load(), 0);
+            assert_eq!(ctx.guest_rxvq.used().idx().load(), 0);
         }
 
         // Test case:
@@ -834,12 +834,12 @@ mod tests {
             let mut ctx = test_ctx.create_epoll_handler_context();
 
             // Invalidate the packet header descriptor, by setting its length to 0.
-            ctx.guest_txvq.dtable[0].len().store(0);
+            ctx.guest_txvq.dtable(0).len().store(0);
             ctx.signal_txq_event();
 
             // The available descriptor should have been consumed, but no packet should have
             // reached the backend.
-            assert_eq!(ctx.guest_txvq.used.idx().load(), 1);
+            assert_eq!(ctx.guest_txvq.used().idx().load(), 1);
             assert_eq!(ctx.handler.backend.read().unwrap().tx_ok_cnt, 0);
         }
 
@@ -878,7 +878,7 @@ mod tests {
             ctx.signal_rxq_event();
 
             // The available RX buffer should've been left untouched.
-            assert_eq!(ctx.guest_rxvq.used.idx().load(), 0);
+            assert_eq!(ctx.guest_rxvq.used().idx().load(), 0);
         }
 
         // Test case:
@@ -893,7 +893,7 @@ mod tests {
             ctx.signal_rxq_event();
 
             // The available RX buffer should have been used.
-            assert_eq!(ctx.guest_rxvq.used.idx().load(), 1);
+            assert_eq!(ctx.guest_rxvq.used().idx().load(), 1);
         }
 
         // Test case: the driver provided a malformed RX descriptor chain.
@@ -902,11 +902,11 @@ mod tests {
             let mut ctx = test_ctx.create_epoll_handler_context();
 
             // Invalidate the packet header descriptor, by setting its length to 0.
-            ctx.guest_rxvq.dtable[0].len().store(0);
+            ctx.guest_rxvq.dtable(0).len().store(0);
 
             // The chain should've been processed, without employing the backend.
             assert!(ctx.handler.process_rx().is_ok());
-            assert_eq!(ctx.guest_rxvq.used.idx().load(), 1);
+            assert_eq!(ctx.guest_rxvq.used().idx().load(), 1);
             assert_eq!(ctx.handler.backend.read().unwrap().rx_ok_cnt, 0);
         }
 
@@ -968,9 +968,9 @@ mod tests {
                 Some(epoll::Events::EPOLLIN)
             );
             // TX queue processing should've been triggered.
-            assert_eq!(ctx.guest_txvq.used.idx().load(), 1);
+            assert_eq!(ctx.guest_txvq.used().idx().load(), 1);
             // RX queue processing should've been triggered.
-            assert_eq!(ctx.guest_rxvq.used.idx().load(), 1);
+            assert_eq!(ctx.guest_rxvq.used().idx().load(), 1);
         }
 
         // Test case:
@@ -995,9 +995,9 @@ mod tests {
                 Some(epoll::Events::EPOLLIN)
             );
             // TX queue processing should've been triggered.
-            assert_eq!(ctx.guest_txvq.used.idx().load(), 1);
+            assert_eq!(ctx.guest_txvq.used().idx().load(), 1);
             // The RX queue should've been left untouched.
-            assert_eq!(ctx.guest_rxvq.used.idx().load(), 0);
+            assert_eq!(ctx.guest_rxvq.used().idx().load(), 0);
         }
     }
 

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -143,7 +143,7 @@ where
                 }
             };
 
-            used_desc_heads[used_count] = (avail_desc.index, used_len);
+            used_desc_heads[used_count] = (avail_desc.index(), used_len);
             used_count += 1;
         }
 
@@ -172,7 +172,7 @@ where
                 Ok(pkt) => pkt,
                 Err(e) => {
                     error!("vsock: error reading TX packet: {:?}", e);
-                    used_desc_heads[used_count] = (avail_desc.index, 0);
+                    used_desc_heads[used_count] = (avail_desc.index(), 0);
                     used_count += 1;
                     continue;
                 }
@@ -183,7 +183,7 @@ where
                 break;
             }
 
-            used_desc_heads[used_count] = (avail_desc.index, 0);
+            used_desc_heads[used_count] = (avail_desc.index(), 0);
             used_count += 1;
         }
 

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -295,14 +295,14 @@ mod tests {
                 1,
             );
             guest_rxvq.dtable[1].set(0x0040_1000, 4096, VIRTQ_DESC_F_WRITE, 0);
-            guest_rxvq.avail.ring[0].set(0);
-            guest_rxvq.avail.idx.set(1);
+            guest_rxvq.avail.ring(0).store(0);
+            guest_rxvq.avail.idx().store(1);
 
             // Set up one available descriptor in the TX queue.
             guest_txvq.dtable[0].set(0x0050_0000, VSOCK_PKT_HDR_SIZE as u32, VIRTQ_DESC_F_NEXT, 1);
             guest_txvq.dtable[1].set(0x0050_1000, 4096, 0, 0);
-            guest_txvq.avail.ring[0].set(0);
-            guest_txvq.avail.idx.set(1);
+            guest_txvq.avail.ring(0).store(0);
+            guest_txvq.avail.idx().store(1);
 
             let queues = vec![rxvq, txvq, evvq];
             let queue_evts = vec![

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -288,21 +288,25 @@ mod tests {
             let evvq = guest_evvq.create_queue();
 
             // Set up one available descriptor in the RX queue.
-            guest_rxvq.dtable[0].set(
+            guest_rxvq.dtable(0).set(
                 0x0040_0000,
                 VSOCK_PKT_HDR_SIZE as u32,
                 VIRTQ_DESC_F_WRITE | VIRTQ_DESC_F_NEXT,
                 1,
             );
-            guest_rxvq.dtable[1].set(0x0040_1000, 4096, VIRTQ_DESC_F_WRITE, 0);
-            guest_rxvq.avail.ring(0).store(0);
-            guest_rxvq.avail.idx().store(1);
+            guest_rxvq
+                .dtable(1)
+                .set(0x0040_1000, 4096, VIRTQ_DESC_F_WRITE, 0);
+            guest_rxvq.avail().ring(0).store(0);
+            guest_rxvq.avail().idx().store(1);
 
             // Set up one available descriptor in the TX queue.
-            guest_txvq.dtable[0].set(0x0050_0000, VSOCK_PKT_HDR_SIZE as u32, VIRTQ_DESC_F_NEXT, 1);
-            guest_txvq.dtable[1].set(0x0050_1000, 4096, 0, 0);
-            guest_txvq.avail.ring(0).store(0);
-            guest_txvq.avail.idx().store(1);
+            guest_txvq
+                .dtable(0)
+                .set(0x0050_0000, VSOCK_PKT_HDR_SIZE as u32, VIRTQ_DESC_F_NEXT, 1);
+            guest_txvq.dtable(1).set(0x0050_1000, 4096, 0, 0);
+            guest_txvq.avail().ring(0).store(0);
+            guest_txvq.avail().idx().store(1);
 
             let queues = vec![rxvq, txvq, evvq];
             let queue_evts = vec![

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -112,12 +112,12 @@ impl VsockPacket {
         }
 
         // The packet header should fit inside the head descriptor.
-        if head.len < VSOCK_PKT_HDR_SIZE as u32 {
-            return Err(VsockError::HdrDescTooSmall(head.len));
+        if head.len() < VSOCK_PKT_HDR_SIZE as u32 {
+            return Err(VsockError::HdrDescTooSmall(head.len()));
         }
 
         let mut pkt = Self {
-            hdr: get_host_address_range(head.mem, head.addr, VSOCK_PKT_HDR_SIZE)
+            hdr: get_host_address_range(head.mem, head.addr(), VSOCK_PKT_HDR_SIZE)
                 .ok_or_else(|| VsockError::GuestMemory)? as *mut u8,
             buf: None,
             buf_size: 0,
@@ -144,13 +144,13 @@ impl VsockPacket {
 
         // The data buffer should be large enough to fit the size of the data, as described by
         // the header descriptor.
-        if buf_desc.len < pkt.len() {
+        if buf_desc.len() < pkt.len() {
             return Err(VsockError::BufDescTooSmall);
         }
 
-        pkt.buf_size = buf_desc.len as usize;
+        pkt.buf_size = buf_desc.len() as usize;
         pkt.buf = Some(
-            get_host_address_range(buf_desc.mem, buf_desc.addr, pkt.buf_size)
+            get_host_address_range(buf_desc.mem, buf_desc.addr(), pkt.buf_size)
                 .ok_or_else(|| VsockError::GuestMemory)? as *mut u8,
         );
 
@@ -170,8 +170,8 @@ impl VsockPacket {
         }
 
         // The packet header should fit inside the head descriptor.
-        if head.len < VSOCK_PKT_HDR_SIZE as u32 {
-            return Err(VsockError::HdrDescTooSmall(head.len));
+        if head.len() < VSOCK_PKT_HDR_SIZE as u32 {
+            return Err(VsockError::HdrDescTooSmall(head.len()));
         }
 
         // All RX descriptor chains should have a header and a data descriptor.
@@ -179,13 +179,13 @@ impl VsockPacket {
             return Err(VsockError::BufDescMissing);
         }
         let buf_desc = head.next_descriptor().ok_or(VsockError::BufDescMissing)?;
-        let buf_size = buf_desc.len as usize;
+        let buf_size = buf_desc.len() as usize;
 
         Ok(Self {
-            hdr: get_host_address_range(head.mem, head.addr, VSOCK_PKT_HDR_SIZE)
+            hdr: get_host_address_range(head.mem, head.addr(), VSOCK_PKT_HDR_SIZE)
                 .ok_or_else(|| VsockError::GuestMemory)? as *mut u8,
             buf: Some(
-                get_host_address_range(buf_desc.mem, buf_desc.addr, buf_size)
+                get_host_address_range(buf_desc.mem, buf_desc.addr(), buf_size)
                     .ok_or_else(|| VsockError::GuestMemory)? as *mut u8,
             ),
             buf_size,

--- a/virtio-devices/src/vsock/unix/muxer.rs
+++ b/virtio-devices/src/vsock/unix/muxer.rs
@@ -842,7 +842,7 @@ mod tests {
             let vsock_test_ctx = VsockTestContext::new();
             let mut handler_ctx = vsock_test_ctx.create_epoll_handler_context();
             let pkt = VsockPacket::from_rx_virtq_head(
-                &handler_ctx.handler.queues[0]
+                &mut handler_ctx.handler.queues[0]
                     .iter(&vsock_test_ctx.mem)
                     .next()
                     .unwrap(),


### PR DESCRIPTION
As a step towards closing #1413, this partially synchronizes the Cloud Hypervisor vm-virtio crate with the [rust-vmm one](https://github.com/rust-vmm/vm-virtio/).

The code is simplified and a bit more idomatic, but there are still a few fundamental differences between the 2 crates that prevent them from quickly converging. In particular, the rust-vmm crate is designed on the assumption that a virtio queue owns the guest address space, while the Cloud Hypervisor one (and the Firecracker approach as well) does not.
Switching to the rust-vmm ownership model would/will be quite intrusive.