### PR TITLE
vmm: Add Intel SGX support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "linux-loader",
+ "log 0.4.8",
  "rand 0.7.3",
  "vm-memory",
 ]

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -14,6 +14,7 @@ hypervisor = { path = "../hypervisor" }
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch" }
 kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "ch" }
 libc = "0.2.72"
+log = "0.4.8"
 vm-memory = { version = "0.2.1", features = ["backend-mmap"] }
 acpi_tables = { path = "../acpi_tables", optional = true }
 arch_gen = { path = "../arch_gen" }

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -19,13 +19,13 @@ extern crate hypervisor;
 extern crate kvm_bindings;
 extern crate kvm_ioctls;
 extern crate libc;
-
-extern crate vm_memory;
-
+#[macro_use]
+extern crate log;
 #[cfg(feature = "acpi")]
 extern crate acpi_tables;
 extern crate arch_gen;
 extern crate linux_loader;
+extern crate vm_memory;
 
 use std::fmt;
 use std::result;

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -58,6 +58,52 @@ pub struct EntryPoint {
 const E820_RAM: u32 = 1;
 const E820_RESERVED: u32 = 2;
 
+#[derive(Clone)]
+pub struct SgxEpcSection {
+    start: GuestAddress,
+    size: GuestUsize,
+}
+
+impl SgxEpcSection {
+    pub fn new(start: GuestAddress, size: GuestUsize) -> Self {
+        SgxEpcSection { start, size }
+    }
+    pub fn start(&self) -> GuestAddress {
+        self.start
+    }
+    pub fn size(&self) -> GuestUsize {
+        self.size
+    }
+}
+
+pub struct SgxEpcRegion {
+    start: GuestAddress,
+    size: GuestUsize,
+    epc_sections: Vec<SgxEpcSection>,
+}
+
+impl SgxEpcRegion {
+    pub fn new(start: GuestAddress, size: GuestUsize) -> Self {
+        SgxEpcRegion {
+            start,
+            size,
+            epc_sections: Vec::new(),
+        }
+    }
+    pub fn start(&self) -> GuestAddress {
+        self.start
+    }
+    pub fn size(&self) -> GuestUsize {
+        self.size
+    }
+    pub fn epc_sections(&self) -> &Vec<SgxEpcSection> {
+        &self.epc_sections
+    }
+    pub fn push(&mut self, epc_section: SgxEpcSection) {
+        self.epc_sections.push(epc_section);
+    }
+}
+
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
 // trait (in this case `DataInit`) where:
 // *    the type that is implementing the trait is foreign or

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -31,7 +31,8 @@ use x86_64::{
 
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
-    CpuId, ExtendedControlRegisters, LapicState, MsrEntries, VcpuKvmState as CpuState, Xsave,
+    CpuId, CpuIdEntry, ExtendedControlRegisters, LapicState, MsrEntries, VcpuKvmState as CpuState,
+    Xsave, CPUID_FLAG_VALID_INDEX,
 };
 
 #[cfg(target_arch = "x86_64")]

--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -18,13 +18,14 @@ use serde_derive::{Deserialize, Serialize};
 /// Export generically-named wrappers of kvm-bindings for Unix-based platforms
 ///
 pub use {
-    kvm_bindings::kvm_dtable as DescriptorTable, kvm_bindings::kvm_fpu as FpuState,
-    kvm_bindings::kvm_lapic_state as LapicState, kvm_bindings::kvm_mp_state as MpState,
-    kvm_bindings::kvm_msr_entry as MsrEntry, kvm_bindings::kvm_regs as StandardRegisters,
-    kvm_bindings::kvm_segment as SegmentRegister, kvm_bindings::kvm_sregs as SpecialRegisters,
-    kvm_bindings::kvm_vcpu_events as VcpuEvents,
+    kvm_bindings::kvm_cpuid_entry2 as CpuIdEntry, kvm_bindings::kvm_dtable as DescriptorTable,
+    kvm_bindings::kvm_fpu as FpuState, kvm_bindings::kvm_lapic_state as LapicState,
+    kvm_bindings::kvm_mp_state as MpState, kvm_bindings::kvm_msr_entry as MsrEntry,
+    kvm_bindings::kvm_regs as StandardRegisters, kvm_bindings::kvm_segment as SegmentRegister,
+    kvm_bindings::kvm_sregs as SpecialRegisters, kvm_bindings::kvm_vcpu_events as VcpuEvents,
     kvm_bindings::kvm_xcrs as ExtendedControlRegisters, kvm_bindings::kvm_xsave as Xsave,
     kvm_bindings::CpuId, kvm_bindings::MsrList, kvm_bindings::Msrs as MsrEntries,
+    kvm_bindings::KVM_CPUID_FLAG_SIGNIFCANT_INDEX as CPUID_FLAG_VALID_INDEX,
 };
 
 pub const KVM_TSS_ADDRESS: GuestAddress = GuestAddress(0xfffb_d000);

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -410,6 +410,10 @@ components:
             $ref: '#/components/schemas/DeviceConfig'
         vsock:
             $ref: '#/components/schemas/VsockConfig'
+        sgx_epc:
+          type: array
+          items:
+            $ref: '#/components/schemas/SgxEpcConfig'
         iommu:
           type: boolean
           default: false
@@ -669,6 +673,18 @@ components:
           default: false
         id:
           type: string
+
+    SgxEpcConfig:
+      required:
+      - size
+      type: object
+      properties:
+        size:
+          type: integer
+          format: uint64
+        prefault:
+          type: boolean
+          default: false
 
     VmResize:
       type: object

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -15,6 +15,7 @@
 use crate::config::CpuTopology;
 use crate::config::CpusConfig;
 use crate::device_manager::DeviceManager;
+use crate::memory_manager::MemoryManager;
 use crate::CPU_MANAGER_SNAPSHOT_ID;
 #[cfg(feature = "acpi")]
 use acpi_tables::{aml, aml::Aml, sdt::SDT};
@@ -579,11 +580,12 @@ impl CpuManager {
     pub fn new(
         config: &CpusConfig,
         device_manager: &Arc<Mutex<DeviceManager>>,
-        guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
+        memory_manager: &Arc<Mutex<MemoryManager>>,
         vm: Arc<dyn hypervisor::Vm>,
         reset_evt: EventFd,
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
     ) -> Result<Arc<Mutex<CpuManager>>> {
+        let guest_memory = memory_manager.lock().unwrap().guest_memory();
         let mut vcpu_states = Vec::with_capacity(usize::from(config.max_vcpus));
         vcpu_states.resize_with(usize::from(config.max_vcpus), VcpuState::default);
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -584,6 +584,14 @@ impl Vm {
             ));
         }
 
+        let sgx_epc_region = self
+            .memory_manager
+            .lock()
+            .unwrap()
+            .sgx_epc_region()
+            .as_ref()
+            .cloned();
+
         match entry_addr.setup_header {
             Some(hdr) => {
                 arch::configure_system(
@@ -595,6 +603,7 @@ impl Vm {
                     Some(hdr),
                     rsdp_addr,
                     BootProtocol::LinuxBoot,
+                    sgx_epc_region,
                 )
                 .map_err(Error::ConfigureSystem)?;
             }
@@ -608,6 +617,7 @@ impl Vm {
                     None,
                     rsdp_addr,
                     entry_addr.protocol,
+                    sgx_epc_region,
                 )
                 .map_err(Error::ConfigureSystem)?;
             }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -293,7 +293,7 @@ impl Vm {
         let cpu_manager = cpu::CpuManager::new(
             &config.lock().unwrap().cpus.clone(),
             &device_manager,
-            memory_manager.lock().unwrap().guest_memory(),
+            &memory_manager,
             vm.clone(),
             reset_evt,
             hypervisor,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -351,6 +351,17 @@ impl Vm {
         )
         .map_err(Error::MemoryManager)?;
 
+        #[cfg(target_arch = "x86_64")]
+        {
+            if let Some(sgx_epc_config) = config.lock().unwrap().sgx_epc.clone() {
+                memory_manager
+                    .lock()
+                    .unwrap()
+                    .setup_sgx(sgx_epc_config)
+                    .map_err(Error::MemoryManager)?;
+            }
+        }
+
         let new_vm = Vm::new_from_memory_manager(
             config,
             memory_manager,


### PR DESCRIPTION
This pull request brings the support for SGX capable hosts to Cloud-Hypervisor. An SGX application can be run in a Cloud-Hypervisor VM, leveraging the hardware support of SGX.

Fixes #1311 