### PR TITLE
ci: AArch64: Enable AArch64 mmio-related integration test cases

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -540,6 +540,10 @@ fn create_devices_node<T: DeviceInfoForFDT + Clone + Debug>(
 
     // Sort out virtio devices by address from low to high and insert them into fdt table.
     ordered_virtio_device.sort_by(|a, b| a.addr().cmp(&b.addr()));
+    // Current address allocation strategy in cloud-hypervisor is: the first created device
+    // will be allocated to higher address. Here we reverse the vector to make sure that
+    // the older created device will appear in front of the newer created device in FDT.
+    ordered_virtio_device.reverse();
     for ordered_device_info in ordered_virtio_device.drain(..) {
         create_virtio_node(fdt, ordered_device_info)?;
     }

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -207,6 +207,7 @@ if [ $RES -eq 0 ]; then
     strip target/$BUILD_TARGET/release/ch-remote
 
     sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/cloud-hypervisor
+    sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/vhost_user_net
 
     # Ensure test binary has the same caps as the cloud-hypervisor one
     time cargo test --no-run --no-default-features --features "integration_tests,mmio,kvm" -- --nocapture || exit 1
@@ -214,7 +215,7 @@ if [ $RES -eq 0 ]; then
 
     newgrp kvm << EOF
 export RUST_BACKTRACE=1
-time cargo test --no-default-features --features "integration_tests,mmio,kvm" "tests::parallel::test_aarch64_pe_boot" -- --nocapture
+time cargo test --no-default-features --features "integration_tests,mmio,kvm" "tests::parallel::$@" -- --nocapture
 EOF
 
     RES=$?


### PR DESCRIPTION
This commit enables mmio-related integration test cases on AArch64, including:
* vhost_user test cases
* virtio-blk test cases
* pmem test cases

Also this commit contains a bug fix in creating virtio-blk device. Previously, when creating the FDT, the virtio-blk device was
labeled in the reverse order of address allocation.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>