### PR TITLE
Update docs and fix a build warning for AArch64

### DIFF
--- a/arch/src/aarch64/gic.rs
+++ b/arch/src/aarch64/gic.rs
@@ -166,7 +166,12 @@ pub fn create_gic(
     if its_required {
         GICv3ITS::new(vm, vcpu_count)
     } else {
-        GICv3ITS::new(vm, vcpu_count)
-            .or_else(|_| GICv3::new(vm, vcpu_count).or_else(|_| GICv2::new(vm, vcpu_count)))
+        GICv3ITS::new(vm, vcpu_count).or_else(|_| {
+            debug!("Failed to create GICv3-ITS, will try GICv3 instead.");
+            GICv3::new(vm, vcpu_count).or_else(|_| {
+                debug!("Failed to create GICv3, will try GICv2 instead.");
+                GICv2::new(vm, vcpu_count)
+            })
+        })
     }
 }

--- a/docs/arm64.md
+++ b/docs/arm64.md
@@ -27,7 +27,7 @@ For Virtio devices, you can choose MMIO or PCI as transport option.
 ### MMIO
 
 ```bash
-cargo build --no-default-features --features "mmio"
+cargo build --no-default-features --features mmio,kvm
 ```
 
 ### PCI
@@ -35,7 +35,7 @@ cargo build --no-default-features --features "mmio"
 Using PCI devices requires GICv3-ITS for MSI messaging. GICv3-ITS is very common in modern servers, but your machine happen to be old ones with GICv2(M) (like Raspberry Pi 4) or GICv3 without ITS, MMIO can still work.
 
 ```bash
-cargo build --no-default-features --features "pci"
+cargo build --no-default-features --features pci,kvm
 ```
 
 ## Image


### PR DESCRIPTION
Fixes https://github.com/cloud-hypervisor/cloud-hypervisor/issues/1469

Updated build instructions to use `kvm` feature.
Fixed a build warning for unused `log `crate.