### PR TITLE
Cleanup virtio device configuration

### DIFF
--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -486,10 +486,6 @@ impl VirtioDevice for Balloon {
         }
     }
 
-    fn write_config(&mut self, _offset: u64, _data: &[u8]) {
-        warn!("virtio-balloon device configuration is read-only");
-    }
-
     fn activate(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -20,9 +20,8 @@ use super::{
 use crate::vm_memory::GuestMemory;
 use crate::{VirtioInterrupt, VirtioInterruptType};
 use libc::EFD_NONBLOCK;
-use std::cmp;
 use std::fs::File;
-use std::io::{self, Write};
+use std::io;
 use std::mem::size_of;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::result;
@@ -471,19 +470,8 @@ impl VirtioDevice for Balloon {
         self.acked_features |= v;
     }
 
-    fn read_config(&self, offset: u64, mut data: &mut [u8]) {
-        let config = self.config.lock().unwrap();
-        let config_slice = config.as_slice();
-        let config_len = config_slice.len() as u64;
-        if offset >= config_len {
-            error!("Failed to read config space");
-            return;
-        }
-        if let Some(end) = offset.checked_add(data.len() as u64) {
-            // This write can't fail, offset and end are checked against config_len.
-            data.write_all(&config_slice[offset as usize..cmp::min(end, config_len) as usize])
-                .unwrap();
-        }
+    fn read_config(&self, offset: u64, data: &mut [u8]) {
+        self.read_config_from_slice(self.config.lock().unwrap().as_slice(), offset, data);
     }
 
     fn activate(

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -508,15 +508,20 @@ impl<T: 'static + DiskFile + Send> VirtioDevice for Block<T> {
     }
 
     fn write_config(&mut self, offset: u64, data: &[u8]) {
-        let config_slice = self.config.as_mut_slice();
-        let data_len = data.len() as u64;
-        let config_len = config_slice.len() as u64;
-        if offset + data_len > config_len {
-            error!("Failed to write config space");
+        // The "writeback" field is the only mutable field
+        let writeback_offset =
+            (&self.config.writeback as *const _ as u64) - (&self.config as *const _ as u64);
+        if offset != writeback_offset || data.len() != std::mem::size_of_val(&self.config.writeback)
+        {
+            error!(
+                "Attempt to write to read-only field: offset {:x} length {}",
+                offset,
+                data.len()
+            );
             return;
         }
-        let (_, right) = config_slice.split_at_mut(offset as usize);
-        right.copy_from_slice(&data[..]);
+
+        self.config.writeback = data[0];
         self.update_writeback();
     }
 

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -521,10 +521,6 @@ impl VirtioDevice for Console {
         }
     }
 
-    fn write_config(&mut self, _offset: u64, _data: &[u8]) {
-        warn!("No device specific configration requires write");
-    }
-
     fn activate(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -505,20 +505,8 @@ impl VirtioDevice for Console {
         self.acked_features |= v;
     }
 
-    fn read_config(&self, offset: u64, mut data: &mut [u8]) {
-        let config = self.config.lock().unwrap();
-        let config_slice = config.as_slice();
-        let config_len = config_slice.len() as u64;
-        if offset >= config_len {
-            error!("Failed to read config space");
-            return;
-        }
-
-        if let Some(end) = offset.checked_add(data.len() as u64) {
-            // This write can't fail, offset and end are checked against config_len.
-            data.write_all(&config_slice[offset as usize..cmp::min(end, config_len) as usize])
-                .unwrap();
-        }
+    fn read_config(&self, offset: u64, data: &mut [u8]) {
+        self.read_config_from_slice(self.config.lock().unwrap().as_slice(), offset, data);
     }
 
     fn activate(

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 use std::num::Wrapping;
 use std::sync::Arc;
 use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryMmap, GuestUsize};
+use vm_virtio::VirtioDeviceType;
 use vmm_sys_util::eventfd::EventFd;
 
 pub enum VirtioInterruptType {
@@ -82,10 +83,20 @@ pub trait VirtioDevice: Send {
     }
 
     /// Reads this device configuration space at `offset`.
-    fn read_config(&self, offset: u64, data: &mut [u8]);
+    fn read_config(&self, _offset: u64, _data: &mut [u8]) {
+        warn!(
+            "No readable configuration fields for {}",
+            VirtioDeviceType::from(self.device_type())
+        );
+    }
 
     /// Writes to this device configuration space at `offset`.
-    fn write_config(&mut self, offset: u64, data: &[u8]);
+    fn write_config(&mut self, _offset: u64, _data: &[u8]) {
+        warn!(
+            "No writable configuration fields for {}",
+            VirtioDeviceType::from(self.device_type())
+        );
+    }
 
     /// Activates this device for real usage.
     fn activate(

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -988,11 +988,6 @@ impl VirtioDevice for Iommu {
                 .unwrap();
         }
     }
-
-    fn write_config(&mut self, _offset: u64, _data: &[u8]) {
-        warn!("virtio-iommu device configuration is read-only");
-    }
-
     fn activate(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -21,7 +21,7 @@ use crate::{VirtioInterrupt, VirtioInterruptType};
 use libc::EFD_NONBLOCK;
 use std::cmp;
 use std::fs::File;
-use std::io::{self, Write};
+use std::io;
 use std::mem::size_of;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::result;
@@ -870,19 +870,8 @@ impl VirtioDevice for Mem {
         self.acked_features |= v;
     }
 
-    fn read_config(&self, offset: u64, mut data: &mut [u8]) {
-        let config = self.config.lock().unwrap();
-        let config_slice = config.as_slice();
-        let config_len = config_slice.len() as u64;
-        if offset >= config_len {
-            error!("Failed to read config space");
-            return;
-        }
-        if let Some(end) = offset.checked_add(data.len() as u64) {
-            // This write can't fail, offset and end are checked against config_len.
-            data.write_all(&config_slice[offset as usize..cmp::min(end, config_len) as usize])
-                .unwrap();
-        }
+    fn read_config(&self, offset: u64, data: &mut [u8]) {
+        self.read_config_from_slice(self.config.lock().unwrap().as_slice(), offset, data);
     }
 
     fn activate(

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -885,10 +885,6 @@ impl VirtioDevice for Mem {
         }
     }
 
-    fn write_config(&mut self, _offset: u64, _data: &[u8]) {
-        warn!("virtio-mem device configuration is read-only");
-    }
-
     fn activate(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -427,18 +427,6 @@ impl VirtioDevice for Net {
         }
     }
 
-    fn write_config(&mut self, offset: u64, data: &[u8]) {
-        let config_slice = self.config.as_mut_slice();
-        let data_len = data.len() as u64;
-        let config_len = config_slice.len() as u64;
-        if offset + data_len > config_len {
-            error!("Failed to write config space");
-            return;
-        }
-        let (_, right) = config_slice.split_at_mut(offset as usize);
-        right.copy_from_slice(&data[..]);
-    }
-
     fn activate(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -15,10 +15,9 @@ use crate::{VirtioInterrupt, VirtioInterruptType};
 use anyhow::anyhow;
 use libc::EFD_NONBLOCK;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
-use std::cmp;
 use std::fmt::{self, Display};
 use std::fs::File;
-use std::io::{self, Write};
+use std::io;
 use std::mem::size_of;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::result;
@@ -463,19 +462,8 @@ impl VirtioDevice for Pmem {
         self.acked_features |= v;
     }
 
-    fn read_config(&self, offset: u64, mut data: &mut [u8]) {
-        let config_slice = self.config.as_slice();
-        let config_len = config_slice.len() as u64;
-        if offset >= config_len {
-            error!("Failed to read config space");
-            return;
-        }
-
-        if let Some(end) = offset.checked_add(data.len() as u64) {
-            // This write can't fail, offset and end are checked against config_len.
-            data.write_all(&config_slice[offset as usize..cmp::min(end, config_len) as usize])
-                .unwrap();
-        }
+    fn read_config(&self, offset: u64, data: &mut [u8]) {
+        self.read_config_from_slice(self.config.as_slice(), offset, data);
     }
 
     fn activate(

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -478,10 +478,6 @@ impl VirtioDevice for Pmem {
         }
     }
 
-    fn write_config(&mut self, _offset: u64, _data: &[u8]) {
-        warn!("virtio-pmem device configuration is read-only");
-    }
-
     fn activate(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -288,10 +288,6 @@ impl VirtioDevice for Rng {
         self.acked_features |= v;
     }
 
-    fn read_config(&self, _offset: u64, _data: &mut [u8]) {
-        warn!("No currently device specific configration defined");
-    }
-
     fn activate(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -292,10 +292,6 @@ impl VirtioDevice for Rng {
         warn!("No currently device specific configration defined");
     }
 
-    fn write_config(&mut self, _offset: u64, _data: &[u8]) {
-        warn!("No currently device specific configration defined");
-    }
-
     fn activate(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -9,8 +9,6 @@ use super::{Error, Result};
 use crate::VirtioInterrupt;
 use block_util::VirtioBlockConfig;
 use libc::EFD_NONBLOCK;
-use std::cmp;
-use std::io::Write;
 use std::mem;
 use std::os::unix::io::AsRawFd;
 use std::result;
@@ -188,18 +186,8 @@ impl VirtioDevice for Blk {
         self.acked_features |= v;
     }
 
-    fn read_config(&self, offset: u64, mut data: &mut [u8]) {
-        let config_slice = self.config.as_slice();
-        let config_len = config_slice.len() as u64;
-        if offset >= config_len {
-            error!("Failed to read config space");
-            return;
-        }
-        if let Some(end) = offset.checked_add(data.len() as u64) {
-            // This write can't fail, offset and end are checked against config_len.
-            data.write_all(&config_slice[offset as usize..cmp::min(end, config_len) as usize])
-                .unwrap();
-        }
+    fn read_config(&self, offset: u64, data: &mut [u8]) {
+        self.read_config_from_slice(self.config.as_slice(), offset, data);
     }
 
     fn write_config(&mut self, offset: u64, data: &[u8]) {

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -10,9 +10,7 @@ use crate::{
     VirtioInterrupt, VirtioSharedMemoryList, VIRTIO_F_VERSION_1,
 };
 use libc::{self, c_void, off64_t, pread64, pwrite64, EFD_NONBLOCK};
-use std::cmp;
 use std::io;
-use std::io::Write;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -407,18 +405,8 @@ impl VirtioDevice for Fs {
         self.acked_features |= v;
     }
 
-    fn read_config(&self, offset: u64, mut data: &mut [u8]) {
-        let config_slice = self.config.as_slice();
-        let config_len = config_slice.len() as u64;
-        if offset >= config_len {
-            error!("Failed to read config space");
-            return;
-        }
-        if let Some(end) = offset.checked_add(data.len() as u64) {
-            // This write can't fail, offset and end are checked against config_len.
-            data.write_all(&config_slice[offset as usize..cmp::min(end, config_len) as usize])
-                .unwrap();
-        }
+    fn read_config(&self, offset: u64, data: &mut [u8]) {
+        self.read_config_from_slice(self.config.as_slice(), offset, data);
     }
 
     fn activate(

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -421,18 +421,6 @@ impl VirtioDevice for Fs {
         }
     }
 
-    fn write_config(&mut self, offset: u64, data: &[u8]) {
-        let config_slice = self.config.as_mut_slice();
-        let data_len = data.len() as u64;
-        let config_len = config_slice.len() as u64;
-        if offset + data_len > config_len {
-            error!("Failed to write config space");
-            return;
-        }
-        let (_, right) = config_slice.split_at_mut(offset as usize);
-        right.copy_from_slice(&data[..]);
-    }
-
     fn activate(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -208,18 +208,6 @@ impl VirtioDevice for Net {
         }
     }
 
-    fn write_config(&mut self, offset: u64, data: &[u8]) {
-        let config_slice = self.config.as_mut_slice();
-        let data_len = data.len() as u64;
-        let config_len = config_slice.len() as u64;
-        if offset + data_len > config_len {
-            error!("Failed to write config space");
-            return;
-        }
-        let (_, right) = config_slice.split_at_mut(offset as usize);
-        right.copy_from_slice(&data[..]);
-    }
-
     fn activate(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -13,8 +13,6 @@ use super::{Error, Result};
 use crate::VirtioInterrupt;
 use libc::EFD_NONBLOCK;
 use net_util::MacAddr;
-use std::cmp;
-use std::io::Write;
 use std::os::unix::io::AsRawFd;
 use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -194,18 +192,8 @@ impl VirtioDevice for Net {
         self.acked_features |= v;
     }
 
-    fn read_config(&self, offset: u64, mut data: &mut [u8]) {
-        let config_slice = self.config.as_slice();
-        let config_len = config_slice.len() as u64;
-        if offset >= config_len {
-            error!("Failed to read config space");
-            return;
-        }
-        if let Some(end) = offset.checked_add(data.len() as u64) {
-            // This write can't fail, offset and end are checked against config_len.
-            data.write_all(&config_slice[offset as usize..cmp::min(end, config_len) as usize])
-                .unwrap();
-        }
+    fn read_config(&self, offset: u64, data: &mut [u8]) {
+        self.read_config_from_slice(self.config.as_slice(), offset, data);
     }
 
     fn activate(

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -519,14 +519,6 @@ where
         }
     }
 
-    fn write_config(&mut self, offset: u64, data: &[u8]) {
-        warn!(
-            "vsock: guest driver attempted to write device config (offset={:x}, len={:x})",
-            offset,
-            data.len()
-        );
-    }
-
     fn activate(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,


### PR DESCRIPTION
Clean up the `read_config()` and `write_config()` in our virtio devices:

* Remove `write_config()` for devices that don't support it
* Use helper function for `read_config()`
* For the block devices check the offset matches the only mutable field.

Fixes: #1217