### PR TITLE
Put KVM specific VFIO code under "kvm" feature guard

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -255,6 +255,17 @@ impl vm::Vm for KvmVm {
     fn check_extension(&self, c: Cap) -> bool {
         self.fd.check_extension(c)
     }
+    /// Create a device that is used for passthrough
+    fn create_passthrough_device(&self) -> vm::Result<DeviceFd> {
+        let mut vfio_dev = kvm_create_device {
+            type_: kvm_device_type_KVM_DEV_TYPE_VFIO,
+            fd: 0,
+            flags: 0,
+        };
+
+        self.create_device(&mut vfio_dev)
+            .map_err(|e| vm::HypervisorVmError::CreatePassthroughDevice(e.into()))
+    }
 }
 /// Wrapper over KVM system ioctls.
 pub struct KvmHypervisor {

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -110,6 +110,11 @@ pub enum HypervisorVmError {
     ///
     #[error("Failed to set clock: {0}")]
     SetClock(#[source] anyhow::Error),
+    ///
+    /// Create passthrough device
+    ///
+    #[error("Failed to create passthrough device: {0}")]
+    CreatePassthroughDevice(#[source] anyhow::Error),
 }
 ///
 /// Result type for returning from a function
@@ -171,4 +176,6 @@ pub trait Vm: Send + Sync {
     fn set_clock(&self, data: &ClockData) -> Result<()>;
     /// Checks if a particular `Cap` is available.
     fn check_extension(&self, c: Cap) -> bool;
+    /// Create a device that is used for passthrough
+    fn create_passthrough_device(&self) -> Result<DeviceFd>;
 }


### PR DESCRIPTION
Hyper-V doesn't have VFIO support yet.

~~I've cobbled together a patch that puts VFIO under kvm feature guard. I'm not sure if it is better to introduce a separate `vfio` feature guard.~~

~~Would love to hear upstream's opinions on this.~~

Patches updated. Only create_kvm_device's internal is put under "kvm" feature.