### PR TITLE
vmm, hypervisor: adjust set_gsi_routing / set_gsi_routes

### DIFF
--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -13,7 +13,7 @@ use crate::aarch64::VcpuInit;
 use crate::cpu::Vcpu;
 #[cfg(target_arch = "x86_64")]
 use crate::ClockData;
-use crate::{CreateDevice, DeviceFd, IoEventAddress, IrqRouting, MemoryRegion};
+use crate::{CreateDevice, DeviceFd, IoEventAddress, IrqRoutingEntry, MemoryRegion};
 use kvm_ioctls::Cap;
 use std::sync::Arc;
 use thiserror::Error;
@@ -148,7 +148,7 @@ pub trait Vm: Send + Sync {
     /// Unregister an event from a certain address it has been previously registered to.
     fn unregister_ioevent(&self, fd: &EventFd, addr: &IoEventAddress) -> Result<()>;
     /// Sets the GSI routing table entries, overwriting any previously set
-    fn set_gsi_routing(&self, irq_routing: &IrqRouting) -> Result<()>;
+    fn set_gsi_routing(&self, entries: &[IrqRoutingEntry]) -> Result<()>;
     /// Creates a memory region structure that can be used with set_user_memory_region
     fn make_user_memory_region(
         &self,


### PR DESCRIPTION
Make set_gsi_routing take a vector of IrqRoutingEntry. The construction
of hypervisor specific structure is left to set_gsi_routing.

Now set_gsi_routes, which is part of the interrupt module, is only
responsible for constructing a list of routing entries.

This further splits hypervisor specific code from hypervisor agnostic
code.

Signed-off-by: Wei Liu <liuwe@microsoft.com>