### PR TITLE
vmm: acpi_tables: Fix PM timer I/O port width

### DIFF
--- a/acpi_tables/src/sdt.rs
+++ b/acpi_tables/src/sdt.rs
@@ -13,12 +13,12 @@ pub struct GenericAddress {
 }
 
 impl GenericAddress {
-    pub fn io_port_address(address: u16) -> Self {
+    pub fn io_port_address<T>(address: u16) -> Self {
         GenericAddress {
             address_space_id: 1,
-            register_bit_width: 8,
+            register_bit_width: 8 * std::mem::size_of::<T>() as u8,
             register_bit_offset: 0,
-            access_size: 1,
+            access_size: std::mem::size_of::<T>() as u8,
             address: u64::from(address),
         }
     }

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -65,14 +65,14 @@ pub fn create_acpi_tables(
     let mut facp = SDT::new(*b"FACP", 276, 6, *b"CLOUDH", *b"CHFACP  ", 1);
 
     // PM_TMR_BLK I/O port
-    facp.write(76, 0xb008);
+    facp.write(76, 0xb008u32);
 
     // HW_REDUCED_ACPI, RESET_REG_SUP, TMR_VAL_EXT
     let fadt_flags: u32 = 1 << 20 | 1 << 10 | 1 << 8;
     facp.write(112, fadt_flags);
 
     // RESET_REG
-    facp.write(116, GenericAddress::io_port_address(0x3c0));
+    facp.write(116, GenericAddress::io_port_address::<u8>(0x3c0));
     // RESET_VALUE
     facp.write(128, 1u8);
 
@@ -80,12 +80,12 @@ pub fn create_acpi_tables(
     facp.write(140, dsdt_offset.0); // X_DSDT
 
     // X_PM_TMR_BLK
-    facp.write(208, GenericAddress::io_port_address(0xb008));
+    facp.write(208, GenericAddress::io_port_address::<u32>(0xb008));
 
     // SLEEP_CONTROL_REG
-    facp.write(244, GenericAddress::io_port_address(0x3c0));
+    facp.write(244, GenericAddress::io_port_address::<u8>(0x3c0));
     // SLEEP_STATUS_REG
-    facp.write(256, GenericAddress::io_port_address(0x3c0));
+    facp.write(256, GenericAddress::io_port_address::<u8>(0x3c0));
 
     facp.write(268, b"CLOUDHYP"); // Hypervisor Vendor Identity
 


### PR DESCRIPTION
Ensure that the width of the I/O port is correctly set to 32-bits in the
generic address used for the X_PM_TMR_BLK. Do this by type
parameterising GenericAddress::io_port_address() fuction.

TEST=Boot with clocksource=acpi_pm and observe no errors in the dmesg.

Fixes: #1496

Signed-off-by: Rob Bradford <robert.bradford@intel.com>