### PR TITLE
Port virtio-net to EpollHelper

### DIFF
--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -32,10 +32,7 @@ use std::{io, mem, net};
 
 pub use mac::{MacAddr, MAC_ADDR_LEN};
 pub use open_tap::{open_tap, Error as OpenTapError};
-pub use queue_pair::{
-    NetCounters, NetQueuePair, NetQueuePairError, RxVirtio, TxVirtio, RX_QUEUE_EVENT, RX_TAP_EVENT,
-    TX_QUEUE_EVENT,
-};
+pub use queue_pair::{NetCounters, NetQueuePair, NetQueuePairError, RxVirtio, TxVirtio};
 pub use tap::{Error as TapError, Tap};
 
 #[derive(Debug)]

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -216,15 +216,8 @@ pub struct NetQueuePair {
     pub epoll_fd: Option<RawFd>,
     pub rx_tap_listening: bool,
     pub counters: NetCounters,
+    pub tap_event_id: u16,
 }
-
-pub type DeviceEventT = u16;
-// The guest has made a buffer available to receive a frame into.
-pub const RX_QUEUE_EVENT: DeviceEventT = 0;
-// The transmit queue has a frame that is ready to send from the guest.
-pub const TX_QUEUE_EVENT: DeviceEventT = 1;
-// A frame is available for reading from the tap device to receive in the guest.
-pub const RX_TAP_EVENT: DeviceEventT = 2;
 
 impl NetQueuePair {
     // Copies a single frame from `self.rx.frame_buf` into the guest. Returns true
@@ -245,7 +238,7 @@ impl NetQueuePair {
                     self.epoll_fd.unwrap(),
                     self.tap.as_raw_fd(),
                     epoll::Events::EPOLLIN,
-                    u64::from(RX_TAP_EVENT),
+                    u64::from(self.tap_event_id),
                 )
                 .map_err(NetQueuePairError::UnregisterListener)?;
                 self.rx_tap_listening = false;
@@ -314,7 +307,7 @@ impl NetQueuePair {
                 self.epoll_fd.unwrap(),
                 self.tap.as_raw_fd(),
                 epoll::Events::EPOLLIN,
-                u64::from(RX_TAP_EVENT),
+                u64::from(self.tap_event_id),
             )
             .map_err(NetQueuePairError::RegisterListener)?;
             self.rx_tap_listening = true;

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -110,6 +110,7 @@ impl VhostUserNetThread {
                 rx_tap_listening: false,
                 epoll_fd: None,
                 counters: NetCounters::default(),
+                tap_event_id: 2,
             },
         })
     }

--- a/virtio-devices/src/epoll_helper.rs
+++ b/virtio-devices/src/epoll_helper.rs
@@ -132,3 +132,9 @@ impl EpollHelper {
         }
     }
 }
+
+impl AsRawFd for EpollHelper {
+    fn as_raw_fd(&self) -> RawFd {
+        self.epoll_file.as_raw_fd()
+    }
+}

--- a/virtio-devices/src/epoll_helper.rs
+++ b/virtio-devices/src/epoll_helper.rs
@@ -29,7 +29,7 @@ pub enum EpollHelperError {
 
 pub const EPOLL_HELPER_EVENT_PAUSE: u16 = 0;
 pub const EPOLL_HELPER_EVENT_KILL: u16 = 1;
-pub const EPOLL_HELPER_EVENT_LAST: u16 = EPOLL_HELPER_EVENT_KILL;
+pub const EPOLL_HELPER_EVENT_LAST: u16 = 15;
 
 pub trait EpollHelperHandler {
     // Return true if execution of the loop should be stopped


### PR DESCRIPTION
This allows the removal of duplicate epoll loop handling code. As a side effect the error reporting is slightly improved and if an error occurs during the network queue processing it will be logged.