### PR TITLE
seccomp: AArch64: add SYS_unlinkat to seccomp whitelist

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -330,6 +330,8 @@ pub fn vmm_thread_filter() -> Result<SeccompFilter, Error> {
             ),
             #[cfg(target_arch = "x86_64")]
             allow_syscall(libc::SYS_unlink),
+            #[cfg(target_arch = "aarch64")]
+            allow_syscall(libc::SYS_unlinkat),
             allow_syscall(libc::SYS_wait4),
             allow_syscall(libc::SYS_write),
         ]


### PR DESCRIPTION
This commit fixes an "Bad syscall" error when shutting down the VM
on AArch64 by adding the SYS_unlinkat syscall to the seccomp
whitelist.

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@michael2012z  @rbradford @MrXinWang @sboeuf 