### PR TITLE
Update virtio-fs definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,7 +1424,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.1.0"
-source = "git+https://github.com/cloud-hypervisor/vhost?branch=dragonball#3e80cf531d278aeb7f947335a4eeca655e0f2c54"
+source = "git+https://github.com/cloud-hypervisor/vhost?branch=dragonball#422964150a69afd4611708076c60cb34c64a9856"
 dependencies = [
  "bitflags 1.2.1",
  "libc",

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -131,14 +131,14 @@ QEMU_DIR="qemu_build"
 
 if [ ! -f "$VIRTIOFSD" ]; then
     pushd $WORKLOADS_DIR
-    git clone --depth 1 "https://github.com/sboeuf/qemu.git" -b "virtio-fs" $QEMU_DIR
+    git clone --depth 1 "https://gitlab.com/virtio-fs/qemu.git" -b "virtio-fs-dev" $QEMU_DIR
     pushd $QEMU_DIR
     time ./configure --prefix=$PWD --target-list=aarch64-softmmu
     time make virtiofsd -j `nproc`
     cp virtiofsd $VIRTIOFSD || exit 1
     popd
     rm -rf $QEMU_DIR
-    sudo setcap cap_dac_override,cap_sys_admin+epi "virtiofsd" || exit 1
+    sudo setcap cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_setgid,cap_setuid,cap_mknod,cap_setfcap,cap_sys_admin+epi "virtiofsd" || exit 1
     popd
 fi
 

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -127,14 +127,14 @@ VIRTIOFSD="$WORKLOADS_DIR/virtiofsd"
 QEMU_DIR="qemu_build"
 if [ ! -f "$VIRTIOFSD" ]; then
     pushd $WORKLOADS_DIR
-    git clone --depth 1 "https://github.com/sboeuf/qemu.git" -b "virtio-fs" $QEMU_DIR
+    git clone --depth 1 "https://gitlab.com/virtio-fs/qemu.git" -b "virtio-fs-dev" $QEMU_DIR
     pushd $QEMU_DIR
     time ./configure --prefix=$PWD --target-list=x86_64-softmmu
     time make virtiofsd -j `nproc`
     cp virtiofsd $VIRTIOFSD || exit 1
     popd
     rm -rf $QEMU_DIR
-    sudo setcap cap_dac_override,cap_sys_admin+epi "virtiofsd" || exit 1
+    sudo setcap cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_setgid,cap_setuid,cap_mknod,cap_setfcap,cap_sys_admin+epi "virtiofsd" || exit 1
     popd
 fi
 


### PR DESCRIPTION
The virtio-fs specific commands which can be issued by the slave to the master have been recently changed as the vhost-user specification evolved. Additionally, the list of vhost-user protocol features has been updated from the specification.
The pull request aims to fix these two recent changes by relying on the latest vhost crate, but also relying on the latest virtiofsd version from the maintainer repository, based on the branch `virtio-fs-dev`.
With these changes, Cloud-Hypervisor will now follow the latest virtiofsd binary.