### PR TITLE
virtio-devices: seccomp: Add seccomp_filter module

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -260,7 +260,7 @@ fn create_app<'a, 'b>(
             Arg::with_name("seccomp")
                 .long("seccomp")
                 .takes_value(true)
-                .possible_values(&["true", "false"])
+                .possible_values(&["true", "false", "log"])
                 .default_value("true"),
         );
 
@@ -292,6 +292,7 @@ fn start_vmm(cmd_arguments: ArgMatches) {
         match seccomp_value {
             "true" => SeccompAction::Trap,
             "false" => SeccompAction::Allow,
+            "log" => SeccompAction::Log,
             _ => {
                 eprintln!("Invalid parameter {} for \"--seccomp\" flag", seccomp_value);
                 process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ extern crate clap;
 use clap::{App, Arg, ArgGroup, ArgMatches};
 use libc::EFD_NONBLOCK;
 use log::LevelFilter;
-use seccomp::SeccompLevel;
+use seccomp::SeccompAction;
 use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
 use std::{env, process};
@@ -288,18 +288,17 @@ fn start_vmm(cmd_arguments: ArgMatches) {
     let api_evt = EventFd::new(EFD_NONBLOCK).expect("Cannot create API EventFd");
 
     let http_sender = api_request_sender.clone();
-
-    let seccomp_level = if let Some(seccomp_value) = cmd_arguments.value_of("seccomp") {
+    let seccomp_action = if let Some(seccomp_value) = cmd_arguments.value_of("seccomp") {
         match seccomp_value {
-            "true" => SeccompLevel::Advanced,
-            "false" => SeccompLevel::None,
+            "true" => SeccompAction::Trap,
+            "false" => SeccompAction::Allow,
             _ => {
                 eprintln!("Invalid parameter {} for \"--seccomp\" flag", seccomp_value);
                 process::exit(1);
             }
         }
     } else {
-        SeccompLevel::Advanced
+        SeccompAction::Trap
     };
     let hypervisor = hypervisor::new().unwrap();
     let vmm_thread = match vmm::start_vmm_thread(
@@ -308,7 +307,7 @@ fn start_vmm(cmd_arguments: ArgMatches) {
         api_evt.try_clone().unwrap(),
         http_sender,
         api_request_receiver,
-        &seccomp_level,
+        &seccomp_action,
         hypervisor,
     ) {
         Ok(t) => t,

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -13,7 +13,7 @@ io_uring = ["block_util/io_uring"]
 [dependencies]
 anyhow = "1.0"
 arc-swap = ">=0.4.4"
-block_util = { path = "../block_util" } 
+block_util = { path = "../block_util" }
 byteorder = "1.3.4"
 devices = { path = "../devices" }
 epoll = ">=4.0.1"
@@ -23,6 +23,7 @@ log = "0.4.11"
 net_gen = { path = "../net_gen" }
 net_util = { path = "../net_util" }
 pci = { path = "../pci", optional = true }
+seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.21.1" }
 serde = ">=1.0.27"
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
@@ -36,4 +37,3 @@ vm-memory = { version = "0.2.1", features = ["backend-mmap", "backend-atomic"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
-

--- a/virtio-devices/src/epoll_helper.rs
+++ b/virtio-devices/src/epoll_helper.rs
@@ -25,6 +25,7 @@ pub enum EpollHelperError {
     CreateFd(std::io::Error),
     Ctl(std::io::Error),
     Wait(std::io::Error),
+    ApplySeccompFilter(seccomp::Error),
 }
 
 pub const EPOLL_HELPER_EVENT_PAUSE: u16 = 0;

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -41,6 +41,7 @@ pub mod net;
 pub mod net_util;
 mod pmem;
 mod rng;
+pub mod seccomp_filters;
 pub mod transport;
 pub mod vhost_user;
 pub mod vsock;
@@ -97,6 +98,8 @@ pub enum ActivateError {
     VhostUserBlkSetup(vhost_user::Error),
     /// Failed to reset vhost-user daemon.
     VhostUserReset(vhost_user::Error),
+    /// Cannot create seccomp filter
+    CreateSeccompFilter(seccomp::SeccompError),
 }
 
 pub type ActivateResult = std::result::Result<(), ActivateError>;

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -1,0 +1,91 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use seccomp::{
+    allow_syscall, BpfProgram, Error, SeccompAction, SeccompError, SeccompFilter, SyscallRuleSet,
+};
+use std::convert::TryInto;
+
+pub enum Thread {
+    VirtioBlk,
+}
+
+// The filter containing the allowed syscall rules required by the
+// virtio_blk thread to function.
+fn virtio_blk_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
+    Ok(vec![
+        allow_syscall(libc::SYS_brk),
+        allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_dup),
+        allow_syscall(libc::SYS_epoll_create1),
+        allow_syscall(libc::SYS_epoll_ctl),
+        allow_syscall(libc::SYS_epoll_pwait),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_epoll_wait),
+        allow_syscall(libc::SYS_exit),
+        allow_syscall(libc::SYS_fallocate),
+        allow_syscall(libc::SYS_fdatasync),
+        allow_syscall(libc::SYS_fsync),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_ftruncate),
+        #[cfg(target_arch = "aarch64")]
+        // The definition of libc::SYS_ftruncate is missing on AArch64.
+        // Use a hard-code number instead.
+        allow_syscall(46),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_lseek),
+        allow_syscall(libc::SYS_madvise),
+        allow_syscall(libc::SYS_mmap),
+        allow_syscall(libc::SYS_mprotect),
+        allow_syscall(libc::SYS_munmap),
+        allow_syscall(libc::SYS_openat),
+        allow_syscall(libc::SYS_prctl),
+        allow_syscall(libc::SYS_read),
+        allow_syscall(libc::SYS_rt_sigprocmask),
+        allow_syscall(libc::SYS_sched_getaffinity),
+        allow_syscall(libc::SYS_set_robust_list),
+        allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_write),
+    ])
+}
+
+fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> {
+    let rules = match thread_type {
+        Thread::VirtioBlk => virtio_blk_thread_rules()?,
+    };
+
+    Ok(SeccompFilter::new(
+        rules.into_iter().collect(),
+        SeccompAction::Trap,
+    )?)
+}
+
+fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
+    let rules = match thread_type {
+        Thread::VirtioBlk => virtio_blk_thread_rules()?,
+    };
+
+    Ok(SeccompFilter::new(
+        rules.into_iter().collect(),
+        SeccompAction::Log,
+    )?)
+}
+
+/// Generate a BPF program based on the seccomp_action value
+pub fn get_seccomp_filter(
+    seccomp_action: &SeccompAction,
+    thread_type: Thread,
+) -> Result<BpfProgram, SeccompError> {
+    match seccomp_action {
+        SeccompAction::Allow => Ok(vec![]),
+        SeccompAction::Log => get_seccomp_filter_log(thread_type)
+            .and_then(|filter| filter.try_into())
+            .map_err(SeccompError::SeccompFilter),
+        _ => get_seccomp_filter_trap(thread_type)
+            .and_then(|filter| filter.try_into())
+            .map_err(SeccompError::SeccompFilter),
+    }
+}

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -8,7 +8,7 @@ use crate::api::{ApiError, ApiRequest, VmAction};
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
 use crate::{Error, Result};
 use micro_http::{Body, HttpServer, MediaType, Method, Request, Response, StatusCode, Version};
-use seccomp::{SeccompFilter, SeccompLevel};
+use seccomp::{SeccompAction, SeccompFilter};
 use serde_json::Error as SerdeError;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -241,14 +241,14 @@ pub fn start_http_thread(
     path: &str,
     api_notifier: EventFd,
     api_sender: Sender<ApiRequest>,
-    seccomp_level: &SeccompLevel,
+    seccomp_action: &SeccompAction,
 ) -> Result<thread::JoinHandle<Result<()>>> {
     std::fs::remove_file(path).unwrap_or_default();
     let socket_path = PathBuf::from(path);
 
     // Retrieve seccomp filter for API thread
     let api_seccomp_filter =
-        get_seccomp_filter(seccomp_level, Thread::Api).map_err(Error::CreateSeccompFilter)?;
+        get_seccomp_filter(seccomp_action, Thread::Api).map_err(Error::CreateSeccompFilter)?;
 
     thread::Builder::new()
         .name("http-server".to_string())

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -6,8 +6,7 @@
 
 use seccomp::{
     allow_syscall, allow_syscall_if, BpfProgram, Error, SeccompAction, SeccompCmpArgLen as ArgLen,
-    SeccompCmpOp::Eq, SeccompCondition as Cond, SeccompError, SeccompFilter, SeccompLevel,
-    SeccompRule,
+    SeccompCmpOp::Eq, SeccompCondition as Cond, SeccompError, SeccompFilter, SeccompRule,
 };
 use std::convert::TryInto;
 
@@ -381,17 +380,17 @@ pub fn api_thread_filter() -> Result<SeccompFilter, Error> {
     )?)
 }
 
-/// Generate a BPF program based on a seccomp level value.
+/// Generate a BPF program based on the seccomp_action value
 pub fn get_seccomp_filter(
-    seccomp_level: &SeccompLevel,
+    seccomp_action: &SeccompAction,
     thread_type: Thread,
 ) -> Result<BpfProgram, SeccompError> {
     let filter = match thread_type {
         Thread::Vmm => vmm_thread_filter(),
         Thread::Api => api_thread_filter(),
     };
-    match *seccomp_level {
-        SeccompLevel::None => Ok(vec![]),
+    match seccomp_action {
+        SeccompAction::Allow => Ok(vec![]),
         _ => filter
             .and_then(|filter| filter.try_into())
             .map_err(SeccompError::SeccompFilter),

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -45,6 +45,7 @@ use linux_loader::loader::elf::Error::InvalidElfMagicNumber;
 #[cfg(target_arch = "x86_64")]
 use linux_loader::loader::elf::PvhBootCapability::PvhEntryPresent;
 use linux_loader::loader::KernelLoader;
+use seccomp::SeccompAction;
 use signal_hook::{iterator::Signals, SIGINT, SIGTERM, SIGWINCH};
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -267,6 +268,7 @@ impl Vm {
         exit_evt: EventFd,
         reset_evt: EventFd,
         vmm_path: PathBuf,
+        _seccomp_action: &SeccompAction,
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
         _saved_clock: Option<hypervisor::ClockData>,
     ) -> Result<Self> {
@@ -332,6 +334,7 @@ impl Vm {
         exit_evt: EventFd,
         reset_evt: EventFd,
         vmm_path: PathBuf,
+        seccomp_action: &SeccompAction,
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
     ) -> Result<Self> {
         #[cfg(target_arch = "x86_64")]
@@ -365,6 +368,7 @@ impl Vm {
             exit_evt,
             reset_evt,
             vmm_path,
+            seccomp_action,
             hypervisor,
             None,
         )?;
@@ -381,6 +385,7 @@ impl Vm {
         Ok(new_vm)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new_from_snapshot(
         snapshot: &Snapshot,
         exit_evt: EventFd,
@@ -388,6 +393,7 @@ impl Vm {
         vmm_path: PathBuf,
         source_url: &str,
         prefault: bool,
+        seccomp_action: &SeccompAction,
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
     ) -> Result<Self> {
         #[cfg(target_arch = "x86_64")]
@@ -422,6 +428,7 @@ impl Vm {
             exit_evt,
             reset_evt,
             vmm_path,
+            seccomp_action,
             hypervisor,
             #[cfg(target_arch = "x86_64")]
             vm_snapshot.clock,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -268,7 +268,7 @@ impl Vm {
         exit_evt: EventFd,
         reset_evt: EventFd,
         vmm_path: PathBuf,
-        _seccomp_action: &SeccompAction,
+        seccomp_action: &SeccompAction,
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
         _saved_clock: Option<hypervisor::ClockData>,
     ) -> Result<Self> {
@@ -285,6 +285,7 @@ impl Vm {
             &exit_evt,
             &reset_evt,
             vmm_path,
+            seccomp_action.clone(),
         )
         .map_err(Error::DeviceManager)?;
 


### PR DESCRIPTION
This patch added the seccomp_filter module to the virtio-devices crate
by taking reference code from the vmm crate. This patch also adds
allowed-list for the virtio-block worker thread.

Partially fixes: #925

This patch also extends the CLI option '--seccomp' to accept the 'log'
parameter in addition 'true/false'. It also refactors the
vmm::seccomp_filters module to support both "SeccompAction::Trap" and
"SeccompAction::Log".

Fixes: #1180

Signed-off-by: Bo Chen <chen.bo@intel.com>