### PR TITLE
doc: AArch64: align rootfs name in arm64.md

### DIFF
--- a/docs/arm64.md
+++ b/docs/arm64.md
@@ -43,7 +43,7 @@ cargo build --no-default-features --features pci,kvm
 Download kernel binary and rootfs image from AWS.
 
 ```bash
-wget https://s3.amazonaws.com/spec.ccfc.min/img/aarch64/ubuntu_with_ssh/fsfiles/xenial.rootfs.ext4 -O rootfs.img
+wget https://s3.amazonaws.com/spec.ccfc.min/img/aarch64/ubuntu_with_ssh/fsfiles/xenial.rootfs.ext4 -O rootfs.ext4
 wget https://s3.amazonaws.com/spec.ccfc.min/img/aarch64/ubuntu_with_ssh/kernel/vmlinux.bin -O kernel.bin
 ```
 


### PR DESCRIPTION
The rootfs name in "Image" section and "Run"  section.