### PR TITLE
README: Fix copy command when using config from Cloud-hypervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ $ git clone --depth 1 https://github.com/cloud-hypervisor/linux.git -b virtio-fs
 $ pushd linux-cloud-hypervisor
 
 # Use the cloud-hypervisor kernel config to build your kernel
-$ cp $CLOUDH/cloud-hypervisor/resources/linux-config .config
+$ cp $CLOUDH/cloud-hypervisor/resources/linux-config-x86_64 .config
 $ make bzImage -j `nproc`
 $ popd
 ```


### PR DESCRIPTION
The command which is mentioned in the README is wrong. We have two
cofigs one for x86_64 and another for aarh64. Previously it was a single
config. After adding the configs the read me was not modified. This
patch fixes the issue.

Signed-off-by: Muminul Islam <muislam@microsoft.com>