### PR TITLE
scripts: AArch64: Fix abnormal integration script behaviour

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -171,6 +171,14 @@ update_workloads() {
     flock -x 12 && update_workloads
 ) 12>$WORKLOADS_LOCK
 
+# Check if there is any error in the execution of `update_workloads`.
+# If there is any error, then kill the shell. Otherwise the script will continue
+# running even if the `update_workloads` function was failed.
+RES=$?
+if [ $RES -ne 0 ]; then
+    exit 1
+fi
+
 # Create tap interface without multipe queues support for vhost_user_net test.
 sudo ip tuntap add name vunet-tap0 mode tap
 # Create tap interface with multipe queues support for vhost_user_net test.


### PR DESCRIPTION
PR #1511 introduced a `flock` command in order to let AArch64 CI can be executed with multiple executors. However the command:
```
(
    echo "try to lock $WORKLOADS_DIR folder and update"
    flock -x 12 && update_workloads
)
```
will introduce an abnormal behavior: If any error happened in function `updated_workloads`, the sub-shell opened by the pair of parentheses will be killed instead of the main shell, which is not right.

This commit fixes this abnormal execution behaviour.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>