### PR TITLE
Remove the workaround for "with-serde" build error on AArch64

### DIFF
--- a/.github/workflows/cross-build.yaml
+++ b/.github/workflows/cross-build.yaml
@@ -24,8 +24,6 @@ jobs:
             override: true
       - name: Install arm64 libfdt
         run: wget http://ftp.us.debian.org/debian/pool/main/d/device-tree-compiler/libfdt-dev_1.6.0-1_arm64.deb && dpkg-deb -xv libfdt-dev_1.6.0-1_arm64.deb ./tlibfdtdev && sudo mkdir /tmmmp && mkdir target && mkdir target/debug && mkdir target/debug/deps && sudo cp ./tlibfdtdev/usr/lib/aarch64-linux-gnu/libfdt.a target/debug/deps/libfdt.a && echo "libfdt installed"
-      - name: Disable "with-serde" in kvm-bindings
-        run: sed -i 's/"with-serde",\ //g' hypervisor/Cargo.toml
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "kvm-bindings"
 version = "0.2.0"
-source = "git+https://github.com/cloud-hypervisor/kvm-bindings?branch=ch#3a6780089e0e2d69aaf77666524e81801c814bdd"
+source = "git+https://github.com/cloud-hypervisor/kvm-bindings?branch=ch#11af42da85f21ac13d7aaebf5765f3ede6252b25"
 dependencies = [
  "serde",
  "serde_derive",

--- a/docs/arm64.md
+++ b/docs/arm64.md
@@ -16,12 +16,6 @@ sudo apt-get install libfdt-dev
 
 ## Build
 
-Before building, a hack trick need to be performed to get rid of some build error in vmm component. See [this](https://github.com/cloud-hypervisor/kvm-bindings/pull/1) for more info about this temporary workaround.
-
-```bash
-sed -i 's/"with-serde",\ //g' hypervisor/Cargo.toml
-```
-
 For Virtio devices, you can choose MMIO or PCI as transport option.
 
 ### MMIO

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -215,11 +215,6 @@ cmd_build() {
         rustflags="-C link-arg=-lgcc -C link_arg=-specs -C link_arg=/usr/lib/aarch64-linux-musl/musl-gcc.specs"
     fi
 
-    # A workaround on Arm64 to avoid build errors in kvm-bindings
-    if [ $(uname -m) = "aarch64" ]; then
-        sed -i 's/"with-serde",\ //g' "$CLH_ROOT_DIR"/hypervisor/Cargo.toml
-    fi
-
     $DOCKER_RUNTIME run \
 	   --user "$(id -u):$(id -g)" \
 	   --workdir "$CTR_CLH_ROOT_DIR" \

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -184,8 +184,6 @@ TARGET_CC="musl-gcc"
 CFLAGS="-I /usr/include/aarch64-linux-musl/ -idirafter /usr/include/"
 fi
 
-sed -i 's/"with-serde",\ //g' hypervisor/Cargo.toml
-
 cargo build --all --release --no-default-features --features pci,kvm --target $BUILD_TARGET
 strip target/$BUILD_TARGET/release/cloud-hypervisor
 strip target/$BUILD_TARGET/release/vhost_user_net


### PR DESCRIPTION
Having https://github.com/cloud-hypervisor/kvm-bindings/pull/1 merged, now we can remove all the workarounds for fixing build error with `with-serde` feature.