### PR TITLE
build: Move to Groovy Gorilla for builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline{
 					}
 				}	
 				stage ('Worker build') {
-					agent { node { label 'bionic' } }
+					agent { node { label 'groovy' } }
 					options {
 						timeout(time: 1, unit: 'HOURS')
 					}
@@ -109,7 +109,7 @@ pipeline{
 					}
 				}
 				stage ('Worker build (musl)') {
-					agent { node { label 'bionic' } }
+					agent { node { label 'groovy' } }
 					options {
 						timeout(time: 1, unit: 'HOURS')
 					}


### PR DESCRIPTION
In anticipation for having host VMs running a 5.6 Linux kernel, this
patch moves our CI to daily builds of Ubuntu 20.10. For now, they run
a 5.4 kernel, but soon they should include a linux-azure kernel relying
on 5.6 or more recent, which will give us the opportunity to test
asynchronous operations relying on io_uring.