### PR TITLE
ci: AArch64: Enable basic virtio_vsock test case for AArch64

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -40,30 +40,23 @@ update_workloads() {
         popd
     fi
 
-    FOCAL_OS_IMAGE_DOWNLOAD_NAME="focal-server-cloudimg-arm64.img"
-    FOCAL_OS_IMAGE_DOWNLOAD_URL="https://cloudhypervisorstorage.blob.core.windows.net/images/$FOCAL_OS_IMAGE_DOWNLOAD_NAME"
-    FOCAL_OS_DOWNLOAD_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_DOWNLOAD_NAME"
-    if [ ! -f "$FOCAL_OS_DOWNLOAD_IMAGE" ]; then
-        pushd $WORKLOADS_DIR
-        time wget --quiet $FOCAL_OS_IMAGE_DOWNLOAD_URL || exit 1
-        popd
-    fi
-
-    FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-arm64.raw"
+    FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-arm64-custom.raw"
+    FOCAL_OS_RAW_IMAGE_DOWNLOAD_URL="https://cloudhypervisorstorage.blob.core.windows.net/images/$FOCAL_OS_RAW_IMAGE_NAME"
     FOCAL_OS_RAW_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_RAW_IMAGE_NAME"
     if [ ! -f "$FOCAL_OS_RAW_IMAGE" ]; then
         pushd $WORKLOADS_DIR
-        time qemu-img convert -p -f qcow2 -O raw $FOCAL_OS_IMAGE_DOWNLOAD_NAME $FOCAL_OS_RAW_IMAGE_NAME || exit 1
+        time wget --quiet $FOCAL_OS_RAW_IMAGE_DOWNLOAD_URL || exit 1
         popd
     fi
 
     # Convert the raw image to qcow2 image to remove compressed blocks from the disk. Therefore letting the
     # qcow2 format image can be directly used in the integration test.
-    FOCAL_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME="focal-server-cloudimg-arm64.qcow2"
+    FOCAL_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME="focal-server-cloudimg-arm64-custom.qcow2"
+    FOCAL_OS_QCOW2_IMAGE_UNCOMPRESSED_DOWNLOAD_URL="https://cloudhypervisorstorage.blob.core.windows.net/images/$FOCAL_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME"
     FOCAL_OS_QCOW2_UNCOMPRESSED_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME"
     if [ ! -f "$FOCAL_OS_QCOW2_UNCOMPRESSED_IMAGE" ]; then
         pushd $WORKLOADS_DIR
-        time qemu-img convert -p -f raw -O qcow2 $FOCAL_OS_RAW_IMAGE_NAME $FOCAL_OS_QCOW2_UNCOMPRESSED_IMAGE || exit 1
+        time wget --quiet $FOCAL_OS_QCOW2_IMAGE_UNCOMPRESSED_DOWNLOAD_URL || exit 1
         popd
     fi
 

--- a/scripts/sha1sums-aarch64
+++ b/scripts/sha1sums-aarch64
@@ -3,5 +3,5 @@
 34039f2fc4242acff0d42af82fbee91070978da3  bionic-server-cloudimg-arm64.qcow2
 e4addb6e212a298144f9eb0eb6e36019d013f0e7  alpine-minirootfs-aarch64.tar.gz
 b94d74e4af195ee3fbd1e2b8fce46e034b6120e6  focal-server-cloudimg-arm64.img
-b48be83f4d507563cef24f22c70655d287ce3ef9  focal-server-cloudimg-arm64.raw
-af0bba59337bb28079ce40f15c534f1efed6f99b  focal-server-cloudimg-arm64.qcow2
+063d1a9f32db641138e6e0c53f58e6545a3d48e6  focal-server-cloudimg-arm64-custom.raw
+013837926872f1c7d1b3a1a95305e4a31c8600ab  focal-server-cloudimg-arm64-custom.qcow2

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -87,7 +87,7 @@ mod tests {
     #[cfg(target_arch = "aarch64")]
     const BIONIC_IMAGE_NAME: &str = "bionic-server-cloudimg-arm64";
     #[cfg(target_arch = "aarch64")]
-    const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-arm64";
+    const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-arm64-custom";
 
     const DIRECT_KERNEL_BOOT_CMDLINE: &str = "root=/dev/vda1 console=ttyS0 console=hvc0 quiet rw";
 
@@ -1804,6 +1804,9 @@ mod tests {
             guest.check_vsock(socket.as_str());
 
             #[cfg(not(feature = "mmio"))]
+            // AArch64 currently does not support reboot, and therefore we
+            // skip the reboot test here.
+            #[cfg(target_arch = "x86_64")]
             {
                 let reboot_count = guest
                     .ssh_command("sudo journalctl | grep -c -- \"-- Reboot --\"")
@@ -3553,7 +3556,6 @@ mod tests {
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_virtio_vsock() {
             _test_virtio_vsock(false)
         }


### PR DESCRIPTION
This commit enables the test case for testing the basic function of virtio_vsock (i.e. without the hotplug).

Signed-off-by: Henry Wang <Henry.Wang@arm.com>