### PR TITLE
vhost_user_fs: increase RLIMIT_NOFILE

### DIFF
--- a/vhost_user_fs/src/sandbox.rs
+++ b/vhost_user_fs/src/sandbox.rs
@@ -50,7 +50,7 @@ pub enum Error {
     UmountTempDir(io::Error),
     /// Call to libc::unshare returned an error.
     Unshare(io::Error),
-    /// Failed to read procfs.
+    /// Failed to read from procfs.
     ReadProc(io::Error),
     /// Failed to parse `/proc/sys/fs/nr_open`.
     InvalidNrOpen(std::num::ParseIntError),


### PR DESCRIPTION
This change increases the limit of open files for the vhost_user_fs sandboxed process to the maximum allowed in the system. This change is based on this QEMU/virtio-fs commit [1]. One easy way to hit the limit is by creating more than 1024 files (the default is typically 1024) [2] in the vhost_user_fs mount. The last attempts will fail with a "Too many open files" error.

The system maximum is obtained by reading the `/proc/sys/fs/nr_open` sysctl file, and the setting is done using the `setrlimit` syscall. Failure to read or parse the nr_open file, or to set the limit results in a panic.

[1] https://gitlab.com/virtio-fs/qemu/-/commit/ddd21b95215342f5f2d9b94b0960c7292966c075
[2] ```for i in `seq 1 1025`; do touch $i; done```