### PR TITLE
virtio-devices: seccomp: Add virtio filters for the rng/console/net/pmem worker thread

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -535,13 +535,14 @@ impl<T: 'static + DiskFile + Send> VirtioDevice for Block<T> {
             let paused = self.paused.clone();
 
             // Retrieve seccomp filter for virtio_blk thread
-            let api_seccomp_filter = get_seccomp_filter(&self.seccomp_action, Thread::VirtioBlk)
-                .map_err(ActivateError::CreateSeccompFilter)?;
+            let virtio_blk_seccomp_filter =
+                get_seccomp_filter(&self.seccomp_action, Thread::VirtioBlk)
+                    .map_err(ActivateError::CreateSeccompFilter)?;
 
             thread::Builder::new()
                 .name("virtio_blk".to_string())
                 .spawn(move || {
-                    SeccompFilter::apply(api_seccomp_filter)
+                    SeccompFilter::apply(virtio_blk_seccomp_filter)
                         .map_err(EpollHelperError::ApplySeccompFilter)?;
 
                     handler.run(paused)

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -129,4 +129,5 @@ pub enum Error {
     EpollHander(String),
     NoMemoryConfigured,
     NetQueuePair(::net_util::NetQueuePairError),
+    ApplySeccompFilter(seccomp::Error),
 }

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -11,6 +11,7 @@ use std::convert::TryInto;
 
 pub enum Thread {
     VirtioBlk,
+    VirtioConsole,
     VirtioRng,
 }
 
@@ -53,6 +54,30 @@ fn virtio_blk_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     ])
 }
 
+fn virtio_console_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
+    Ok(vec![
+        allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_epoll_create1),
+        allow_syscall(libc::SYS_epoll_ctl),
+        allow_syscall(libc::SYS_epoll_pwait),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_epoll_wait),
+        allow_syscall(libc::SYS_exit),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_madvise),
+        allow_syscall(libc::SYS_mmap),
+        allow_syscall(libc::SYS_mprotect),
+        allow_syscall(libc::SYS_munmap),
+        allow_syscall(libc::SYS_prctl),
+        allow_syscall(libc::SYS_read),
+        allow_syscall(libc::SYS_rt_sigprocmask),
+        allow_syscall(libc::SYS_sched_getaffinity),
+        allow_syscall(libc::SYS_set_robust_list),
+        allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_write),
+    ])
+}
+
 fn virtio_rng_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
         allow_syscall(libc::SYS_close),
@@ -80,6 +105,7 @@ fn virtio_rng_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
 fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> {
     let rules = match thread_type {
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
+        Thread::VirtioConsole => virtio_console_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
     };
 
@@ -92,6 +118,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
 fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
     let rules = match thread_type {
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
+        Thread::VirtioConsole => virtio_console_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
     };
 

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -13,6 +13,7 @@ pub enum Thread {
     VirtioBlk,
     VirtioConsole,
     VirtioNet,
+    VirtioPmem,
     VirtioRng,
 }
 
@@ -97,6 +98,26 @@ fn virtio_net_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     ])
 }
 
+fn virtio_pmem_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
+    Ok(vec![
+        allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_epoll_create1),
+        allow_syscall(libc::SYS_epoll_ctl),
+        allow_syscall(libc::SYS_epoll_pwait),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_epoll_wait),
+        allow_syscall(libc::SYS_exit),
+        allow_syscall(libc::SYS_fsync),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_madvise),
+        allow_syscall(libc::SYS_munmap),
+        allow_syscall(libc::SYS_read),
+        allow_syscall(libc::SYS_rt_sigprocmask),
+        allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_write),
+    ])
+}
+
 fn virtio_rng_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
         allow_syscall(libc::SYS_close),
@@ -126,6 +147,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
         Thread::VirtioConsole => virtio_console_thread_rules()?,
         Thread::VirtioNet => virtio_net_thread_rules()?,
+        Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
     };
 
@@ -140,6 +162,7 @@ fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
         Thread::VirtioConsole => virtio_console_thread_rules()?,
         Thread::VirtioNet => virtio_net_thread_rules()?,
+        Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
     };
 

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -12,6 +12,7 @@ use std::convert::TryInto;
 pub enum Thread {
     VirtioBlk,
     VirtioConsole,
+    VirtioNet,
     VirtioRng,
 }
 
@@ -78,6 +79,24 @@ fn virtio_console_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     ])
 }
 
+fn virtio_net_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
+    Ok(vec![
+        allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_epoll_create1),
+        allow_syscall(libc::SYS_epoll_ctl),
+        allow_syscall(libc::SYS_epoll_pwait),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_epoll_wait),
+        allow_syscall(libc::SYS_exit),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_madvise),
+        allow_syscall(libc::SYS_munmap),
+        allow_syscall(libc::SYS_read),
+        allow_syscall(libc::SYS_rt_sigprocmask),
+        allow_syscall(libc::SYS_sigaltstack),
+    ])
+}
+
 fn virtio_rng_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
         allow_syscall(libc::SYS_close),
@@ -106,6 +125,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
     let rules = match thread_type {
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
         Thread::VirtioConsole => virtio_console_thread_rules()?,
+        Thread::VirtioNet => virtio_net_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
     };
 
@@ -119,6 +139,7 @@ fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
     let rules = match thread_type {
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
         Thread::VirtioConsole => virtio_console_thread_rules()?,
+        Thread::VirtioNet => virtio_net_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
     };
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1903,6 +1903,7 @@ impl DeviceManager {
                         net_cfg.iommu,
                         net_cfg.num_queues,
                         net_cfg.queue_size,
+                        self.seccomp_action.clone(),
                     )
                     .map_err(DeviceManagerError::CreateVirtioNet)?,
                 ))
@@ -1918,6 +1919,7 @@ impl DeviceManager {
                         net_cfg.iommu,
                         net_cfg.num_queues,
                         net_cfg.queue_size,
+                        self.seccomp_action.clone(),
                     )
                     .map_err(DeviceManagerError::CreateVirtioNet)?,
                 ))

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1960,8 +1960,13 @@ impl DeviceManager {
             let id = String::from(RNG_DEVICE_NAME);
 
             let virtio_rng_device = Arc::new(Mutex::new(
-                virtio_devices::Rng::new(id.clone(), rng_path, rng_config.iommu)
-                    .map_err(DeviceManagerError::CreateVirtioRng)?,
+                virtio_devices::Rng::new(
+                    id.clone(),
+                    rng_path,
+                    rng_config.iommu,
+                    self.seccomp_action.clone(),
+                )
+                .map_err(DeviceManagerError::CreateVirtioRng)?,
             ));
             devices.push((
                 Arc::clone(&virtio_rng_device) as VirtioDeviceArc,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1515,9 +1515,15 @@ impl DeviceManager {
         let virtio_console_input = if let Some(writer) = console_writer {
             let id = String::from(CONSOLE_DEVICE_NAME);
 
-            let (virtio_console_device, virtio_console_input) =
-                virtio_devices::Console::new(id.clone(), writer, col, row, console_config.iommu)
-                    .map_err(DeviceManagerError::CreateVirtioConsole)?;
+            let (virtio_console_device, virtio_console_input) = virtio_devices::Console::new(
+                id.clone(),
+                writer,
+                col,
+                row,
+                console_config.iommu,
+                self.seccomp_action.clone(),
+            )
+            .map_err(DeviceManagerError::CreateVirtioConsole)?;
             let virtio_console_device = Arc::new(Mutex::new(virtio_console_device));
             virtio_devices.push((
                 Arc::clone(&virtio_console_device) as VirtioDeviceArc,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2302,6 +2302,7 @@ impl DeviceManager {
                 mapping,
                 mmap_region,
                 pmem_cfg.iommu,
+                self.seccomp_action.clone(),
             )
             .map_err(DeviceManagerError::CreateVirtioPmem)?,
         ));


### PR DESCRIPTION
This patch enables the seccomp filters for the rng/console/net/pmem worker threads.

Partially fixes: #925

Signed-off-by: Bo Chen <chen.bo@intel.com>