### PR TITLE
dev_cli: Remove the use of undefined '$libc' for the 'shell' command

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -369,7 +369,6 @@ cmd_shell() {
 	   --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
 	   --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
 	   --env USER="root" \
-	   --env CH_LIBC="${libc}" \
 	   --entrypoint bash \
 	   "$CTR_IMAGE"
 


### PR DESCRIPTION
The '$libc' value is missing but is used to start the container
shell. This patch removes it from the `shell` command.

Signed-off-by: Bo Chen <chen.bo@intel.com>