### PR TITLE
virtio-devices: Print out worker error messages

### DIFF
--- a/virtio-devices/src/epoll_helper.rs
+++ b/virtio-devices/src/epoll_helper.rs
@@ -25,7 +25,6 @@ pub enum EpollHelperError {
     CreateFd(std::io::Error),
     Ctl(std::io::Error),
     Wait(std::io::Error),
-    ApplySeccompFilter(seccomp::Error),
 }
 
 pub const EPOLL_HELPER_EVENT_PAUSE: u16 = 0;

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -285,7 +285,7 @@ pub struct Pmem {
     config: VirtioPmemConfig,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), EpollHelperError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<()>>>,
     paused: Arc<AtomicBool>,
     mapping: UserspaceMapping,
     seccomp_action: SeccompAction,
@@ -468,10 +468,11 @@ impl VirtioDevice for Pmem {
             thread::Builder::new()
                 .name("virtio_pmem".to_string())
                 .spawn(move || {
-                    SeccompFilter::apply(virtio_pmem_seccomp_filter)
-                        .map_err(DeviceError::ApplySeccompFilter)?;
-
-                    handler.run(paused)
+                    if let Err(e) = SeccompFilter::apply(virtio_pmem_seccomp_filter) {
+                        error!("Error applying seccomp filter: {:?}", e);
+                    } else if let Err(e) = handler.run(paused) {
+                        error!("Error running worker: {:?}", e);
+                    }
                 })
                 .map(|thread| epoll_threads.push(thread))
                 .map_err(|e| {

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -101,6 +101,7 @@ fn virtio_net_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
 fn virtio_pmem_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
         allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_dup),
         allow_syscall(libc::SYS_epoll_create1),
         allow_syscall(libc::SYS_epoll_ctl),
         allow_syscall(libc::SYS_epoll_pwait),
@@ -121,6 +122,7 @@ fn virtio_pmem_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
 fn virtio_rng_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
         allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_dup),
         allow_syscall(libc::SYS_epoll_create1),
         allow_syscall(libc::SYS_epoll_ctl),
         allow_syscall(libc::SYS_epoll_pwait),


### PR DESCRIPTION
Currently any messages generated during the worker thread are not
shown anywhere as the thread is never join()ed on. Instead output the
error immediately.

For now only cover the subset where the work to port to EpollHandler
clashed with the seccomp filtering for virtio devices.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>