### PR TITLE
hypervisor: kvm: Make MSRs set/get more flexible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "linux-loader",
+ "log 0.4.11",
  "serde",
  "serde_derive",
  "serde_json",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -11,6 +11,7 @@ kvm = []
 anyhow = "1.0"
 thiserror = "1.0"
 libc = "0.2.74"
+log = "0.4.11"
 kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "ch" }
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch", features = ["with-serde", "fam-wrappers"] }
 serde = {version = ">=1.0.27", features = ["rc"] }

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -18,12 +18,14 @@
 //! - arm64
 //!
 
+#[macro_use]
+extern crate anyhow;
+#[macro_use]
+extern crate log;
 extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 extern crate thiserror;
-#[macro_use]
-extern crate anyhow;
 
 /// KVM implementation module
 pub mod kvm;


### PR DESCRIPTION
Based on the way KVM_GET_MSRS and KVM_SET_MSRS work, both function are
very unlikely to fail, as they simply stop looping through the list of
MSRs as soon as getting or setting one fails. This is causing some
issues with the snapshot/restore feature, as on some platforms, we only
save a subset of the list of MSRs, leading to unproper way of saving the
VM.

The way to address this issue is by checking the number of MSRs get/set
matches the expected amount from the list. In case it does not match, we
simply ignore the failing MSR and continue getting/setting the rest of
the list. By doing this by iterations, we end up getting/setting as many
MSRs as the platform can support.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>