### PR TITLE
pci: use vfio-bindings from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "vfio-bindings 0.2.0 (git+https://github.com/rust-vmm/vfio-bindings)",
+ "vfio-bindings",
  "vfio-ioctls",
  "vm-allocator",
  "vm-device",
@@ -1408,16 +1408,11 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 [[package]]
 name = "vfio-bindings"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio-bindings#f08cbcbf4041c981441d9c036c49ebad5098ed1c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a21f546f2bda37f5a8cfb138c87f95b8e34d2d78d6a7a92ba3785f4e08604a7"
 dependencies = [
  "vmm-sys-util",
 ]
-
-[[package]]
-name = "vfio-bindings"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a21f546f2bda37f5a8cfb138c87f95b8e34d2d78d6a7a92ba3785f4e08604a7"
 
 [[package]]
 name = "vfio-ioctls"
@@ -1428,7 +1423,7 @@ dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
  "log 0.4.11",
- "vfio-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vfio-bindings",
  "vm-memory",
  "vmm-sys-util",
 ]

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -22,5 +22,5 @@ vm-memory = "0.2.1"
 vm-migration = { path = "../vm-migration" }
 
 [dependencies.vfio-bindings]
-git = "https://github.com/rust-vmm/vfio-bindings"
+version = "0.2.0"
 features = ["fam-wrappers"]


### PR DESCRIPTION
This fixes `cargo vendor` throwing an error

```
$ cargo vendor
error: failed to sync

Caused by:
  found duplicate version of package `vfio-bindings v0.2.0` vendored from two sources:

	source 1: https://github.com/rust-vmm/vfio-bindings#f08cbcbf
	source 2: registry `https://github.com/rust-lang/crates.io-index`
```

Both sources are indeed same, the conflict is only cause by the
different URLs.

Signed-off-by: Anatol Belski <ab@php.net>