### PR TITLE
build: Fix Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,15 +128,20 @@ pipeline{
 	}
 	post {
 		regression {
-			when { branch 'master' }
-			slackSend (color: '#ff0000', message: '"master" branch build is now failing')
+			script {
+				if (env.BRANCH_NAME == 'master') {
+					slackSend (color: '#ff0000', message: '"master" branch build is now failing')
+				}
+			}
 		}
 		fixed {
-			when { branch 'master' }
-			slackSend (color: '#00ff00', message: '"master" branch build is now fixed')
+			script {
+				if (env.BRANCH_NAME == 'master') {
+					slackSend (color: '#00ff00', message: '"master" branch build is now fixed')
+				}
+			}
 		}
 	}
-	
 }
 
 def cancelPreviousBuilds() {


### PR DESCRIPTION
Turns out that "when" blocks are permitted but not effectual in "post"
sections so instead use a script behaviour to make the message
conditional on build change.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>