### PR TITLE
 vmm: seccomp: add mprotect to API thread filter

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -363,6 +363,7 @@ fn api_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall_if(libc::SYS_ioctl, create_api_ioctl_seccomp_rule()?),
         allow_syscall(libc::SYS_listen),
         allow_syscall(libc::SYS_madvise),
+        allow_syscall(libc::SYS_mprotect),
         allow_syscall(libc::SYS_munmap),
         allow_syscall(libc::SYS_recvfrom),
         allow_syscall(libc::SYS_sigaltstack),


### PR DESCRIPTION
Add `mprotect` to API thread rules. Prevent the VMM is killed when it is used.
