### PR TITLE
virtio-devices: seccomp: Add seccomp filters for iommu/net thread

### DIFF
--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -745,7 +745,7 @@ pub struct Iommu {
     ext_mapping: BTreeMap<u32, Arc<dyn ExternalDmaMapping>>,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), EpollHelperError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<()>>>,
     paused: Arc<AtomicBool>,
     paused_sync: Arc<Barrier>,
 }
@@ -965,7 +965,11 @@ impl VirtioDevice for Iommu {
         let mut epoll_threads = Vec::new();
         thread::Builder::new()
             .name("virtio_iommu".to_string())
-            .spawn(move || handler.run(paused, paused_sync))
+            .spawn(move || {
+                if let Err(e) = handler.run(paused, paused_sync) {
+                    error!("Error running worker: {:?}", e);
+                }
+            })
             .map(|thread| epoll_threads.push(thread))
             .map_err(|e| {
                 error!("failed to clone the virtio-iommu epoll thread: {}", e);

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -431,14 +431,14 @@ impl VirtioDevice for Net {
                 self.paused_sync = Arc::new(Barrier::new(taps.len() + 2));
                 let paused_sync = self.paused_sync.clone();
 
-                // Retrieve seccomp filter for virtio_net thread
-                let virtio_net_seccomp_filter =
-                    get_seccomp_filter(&self.seccomp_action, Thread::VirtioNet)
+                // Retrieve seccomp filter for virtio_net_ctl thread
+                let virtio_net_ctl_seccomp_filter =
+                    get_seccomp_filter(&self.seccomp_action, Thread::VirtioNetCtl)
                         .map_err(ActivateError::CreateSeccompFilter)?;
                 thread::Builder::new()
-                    .name("virtio_net".to_string())
+                    .name("virtio_net_ctl".to_string())
                     .spawn(move || {
-                        if let Err(e) = SeccompFilter::apply(virtio_net_seccomp_filter) {
+                        if let Err(e) = SeccompFilter::apply(virtio_net_ctl_seccomp_filter) {
                             error!("Error applying seccomp filter: {:?}", e);
                         } else if let Err(e) = ctrl_handler.run_ctrl(paused, paused_sync) {
                             error!("Error running worker: {:?}", e);

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -13,6 +13,7 @@ pub enum Thread {
     VirtioBlk,
     VirtioConsole,
     VirtioIommu,
+    VirtioNet,
     VirtioNetCtl,
     VirtioPmem,
     VirtioRng,
@@ -96,6 +97,26 @@ fn virtio_iommu_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     ])
 }
 
+fn virtio_net_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
+    Ok(vec![
+        allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_epoll_create1),
+        allow_syscall(libc::SYS_epoll_ctl),
+        allow_syscall(libc::SYS_dup),
+        allow_syscall(libc::SYS_epoll_pwait),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_epoll_wait),
+        allow_syscall(libc::SYS_exit),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_madvise),
+        allow_syscall(libc::SYS_munmap),
+        allow_syscall(libc::SYS_read),
+        allow_syscall(libc::SYS_rt_sigprocmask),
+        allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_write),
+    ])
+}
+
 fn virtio_net_ctl_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
         allow_syscall(libc::SYS_close),
@@ -166,6 +187,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
         Thread::VirtioConsole => virtio_console_thread_rules()?,
         Thread::VirtioIommu => virtio_iommu_thread_rules()?,
+        Thread::VirtioNet => virtio_net_thread_rules()?,
         Thread::VirtioNetCtl => virtio_net_ctl_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
@@ -182,6 +204,7 @@ fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
         Thread::VirtioConsole => virtio_console_thread_rules()?,
         Thread::VirtioIommu => virtio_iommu_thread_rules()?,
+        Thread::VirtioNet => virtio_net_thread_rules()?,
         Thread::VirtioNetCtl => virtio_net_ctl_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -60,6 +60,7 @@ fn virtio_blk_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
 
 fn virtio_console_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
+        allow_syscall(libc::SYS_brk),
         allow_syscall(libc::SYS_close),
         allow_syscall(libc::SYS_dup),
         allow_syscall(libc::SYS_epoll_create1),
@@ -85,6 +86,7 @@ fn virtio_console_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
 
 fn virtio_iommu_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
+        allow_syscall(libc::SYS_brk),
         allow_syscall(libc::SYS_epoll_create1),
         allow_syscall(libc::SYS_epoll_ctl),
         allow_syscall(libc::SYS_dup),
@@ -99,6 +101,7 @@ fn virtio_iommu_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
 
 fn virtio_net_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
+        allow_syscall(libc::SYS_brk),
         allow_syscall(libc::SYS_close),
         allow_syscall(libc::SYS_epoll_create1),
         allow_syscall(libc::SYS_epoll_ctl),
@@ -119,6 +122,7 @@ fn virtio_net_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
 
 fn virtio_net_ctl_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
+        allow_syscall(libc::SYS_brk),
         allow_syscall(libc::SYS_close),
         allow_syscall(libc::SYS_dup),
         allow_syscall(libc::SYS_epoll_create1),
@@ -138,6 +142,7 @@ fn virtio_net_ctl_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
 
 fn virtio_pmem_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
+        allow_syscall(libc::SYS_brk),
         allow_syscall(libc::SYS_close),
         allow_syscall(libc::SYS_dup),
         allow_syscall(libc::SYS_epoll_create1),

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -159,6 +159,7 @@ fn virtio_pmem_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
 
 fn virtio_rng_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
+        allow_syscall(libc::SYS_brk),
         allow_syscall(libc::SYS_close),
         allow_syscall(libc::SYS_dup),
         allow_syscall(libc::SYS_epoll_create1),

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -13,7 +13,7 @@ pub enum Thread {
     VirtioBlk,
     VirtioConsole,
     VirtioIommu,
-    VirtioNet,
+    VirtioNetCtl,
     VirtioPmem,
     VirtioRng,
 }
@@ -96,7 +96,7 @@ fn virtio_iommu_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     ])
 }
 
-fn virtio_net_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
+fn virtio_net_ctl_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
         allow_syscall(libc::SYS_close),
         allow_syscall(libc::SYS_dup),
@@ -166,7 +166,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
         Thread::VirtioConsole => virtio_console_thread_rules()?,
         Thread::VirtioIommu => virtio_iommu_thread_rules()?,
-        Thread::VirtioNet => virtio_net_thread_rules()?,
+        Thread::VirtioNetCtl => virtio_net_ctl_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
     };
@@ -182,7 +182,7 @@ fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
         Thread::VirtioConsole => virtio_console_thread_rules()?,
         Thread::VirtioIommu => virtio_iommu_thread_rules()?,
-        Thread::VirtioNet => virtio_net_thread_rules()?,
+        Thread::VirtioNetCtl => virtio_net_ctl_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
     };

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -12,6 +12,7 @@ use std::convert::TryInto;
 pub enum Thread {
     VirtioBlk,
     VirtioConsole,
+    VirtioIommu,
     VirtioNet,
     VirtioPmem,
     VirtioRng,
@@ -77,6 +78,20 @@ fn virtio_console_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_sched_getaffinity),
         allow_syscall(libc::SYS_set_robust_list),
         allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_write),
+    ])
+}
+
+fn virtio_iommu_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
+    Ok(vec![
+        allow_syscall(libc::SYS_epoll_create1),
+        allow_syscall(libc::SYS_epoll_ctl),
+        allow_syscall(libc::SYS_dup),
+        allow_syscall(libc::SYS_epoll_pwait),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_epoll_wait),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_read),
         allow_syscall(libc::SYS_write),
     ])
 }
@@ -150,6 +165,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
     let rules = match thread_type {
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
         Thread::VirtioConsole => virtio_console_thread_rules()?,
+        Thread::VirtioIommu => virtio_iommu_thread_rules()?,
         Thread::VirtioNet => virtio_net_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
@@ -165,6 +181,7 @@ fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
     let rules = match thread_type {
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
         Thread::VirtioConsole => virtio_console_thread_rules()?,
+        Thread::VirtioIommu => virtio_iommu_thread_rules()?,
         Thread::VirtioNet => virtio_net_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1009,8 +1009,9 @@ impl DeviceManager {
             let iommu_id = String::from(IOMMU_DEVICE_NAME);
 
             let (iommu_device, iommu_mapping) = if self.config.lock().unwrap().iommu {
-                let (device, mapping) = virtio_devices::Iommu::new(iommu_id.clone())
-                    .map_err(DeviceManagerError::CreateVirtioIommu)?;
+                let (device, mapping) =
+                    virtio_devices::Iommu::new(iommu_id.clone(), self.seccomp_action.clone())
+                        .map_err(DeviceManagerError::CreateVirtioIommu)?;
                 let device = Arc::new(Mutex::new(device));
                 self.iommu_device = Some(Arc::clone(&device));
 


### PR DESCRIPTION
This patch enables the seccomp filters for the iommu/net worker thread.

Partially fixes: #925

This patch also prints out error message from the iommu/net worker thread.

Partially fixes: #1551