### PR TITLE
ci: Retry integration tests if failing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,9 @@ pipeline{
 							}
 						}
 						stage ('Run integration tests') {
+							options {
+								retry(3)
+							}
 							steps {
 								sh "scripts/dev_cli.sh tests --integration"
 							}
@@ -84,6 +87,9 @@ pipeline{
 							}
 						}
 						stage ('Run integration tests for musl') {
+							options {
+								retry(3)
+							}
 							steps {
 								sh "scripts/dev_cli.sh tests --integration --libc musl"
 							}


### PR DESCRIPTION
Both gnu and musl workers will retry integration tests up to 3 times if
they fail. This should give us a better pass rate, without having to
restart the entire build every time a single glitch happens.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>