### PR TITLE
Revert "build: Temporarily disable ARM64 builds"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,39 @@ pipeline{
 						}
 					}
 				}
+				stage ('AArch64 worker build') {
+					agent { node { label 'bionic-arm64' } }
+					options {
+						timeout(time: 1, unit: 'HOURS')
+					}
+					stages {
+						stage ('Checkout') {
+							steps {
+								checkout scm
+							}
+						}
+						stage ('Build') {
+							steps {
+								sh "scripts/dev_cli.sh build --release"
+							}
+						}
+						stage ('Build for musl') {
+							steps {
+								sh "scripts/dev_cli.sh build --release --libc musl"
+							}
+						}
+						stage ('Run unit tests') {
+							steps {
+								sh "scripts/dev_cli.sh tests --unit"
+							}
+						}
+						stage ('Run integration tests') {
+							steps {
+								sh "scripts/dev_cli.sh tests --integration"
+							}
+						}
+					}
+				}
 				stage ('Worker build (musl)') {
 					agent { node { label 'bionic' } }
 					options {


### PR DESCRIPTION
This reverts commit 743ebe2fa64f09bd83924b45a59296fec4e46835.

ARM64 builder is now back online.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>