### PR TITLE
vhost_user_net: don't claim to impl all features

### DIFF
--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -185,7 +185,7 @@ impl VhostUserBackend for VhostUserNetBackend {
     }
 
     fn protocol_features(&self) -> VhostUserProtocolFeatures {
-        VhostUserProtocolFeatures::all()
+        VhostUserProtocolFeatures::MQ | VhostUserProtocolFeatures::REPLY_ACK
     }
 
     fn set_event_idx(&mut self, _enabled: bool) {}


### PR DESCRIPTION
Even if the vhost-user-net device did implement all currently-defined
features, it would be very short-sighted to use ::all(), because if a
new feature was defined later, the device would start claiming to
implement it even though it didn't.

More practically, claiming to implement all features breaks using QEMU
with the cloud-hypervisor vhost-user-net backend, because QEMU will
negotiate VHOST_USER_PROTOCOL_F_SLAVE_REQ, and then break when the
communication channel isn't actually set up.

I wasn't sure exactly which features the backend should claim to
implement, though.  Definitely MQ, and I'm fairly certain none of the
features I've ommitted are implemented.  But I'm not sure about
REPLY_ACK and INBAND_NOTIFICATIONS.  As far as I can tell they should
be implemented entirely by the vhost crate, with no cooperation
required from the vhost-user-net backend itself, so there should be no
reason to let a frontend use them if it wants to.  But despite this,
neither vhost-user-fs nor vhost-user-blk claim to implement them.

With this fix, as well as https://github.com/cloud-hypervisor/vhost/pull/22, the cloud-hypervisor vhost-user-net backend works with QEMU as well as cloud-hypervisor.

Signed-off-by: Alyssa Ross <hi@alyssa.is>