### PR TITLE
io-uring: Move to the crates.io 0.4.0 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,8 +491,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.3.5"
-source = "git+https://github.com/tokio-rs/io-uring.git?branch=0.4#445fbc4ae4d144b7418d721bf92e657a6c65bfe6"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f7589adca0ddd74f56ed83a5098b45e3abf264dc27e150a8bec3397fcc34338"
 dependencies = [
  "bitflags 1.2.1",
  "libc",

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 io_uring = []
 
 [dependencies]
-io-uring = { git = "https://github.com/tokio-rs/io-uring.git", branch = "0.4" }
+io-uring = ">=0.4.0"
 libc = "0.2.74"
 log = "0.4.11"
 serde = ">=1.0.27"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -17,7 +17,7 @@ block_util = { path = "../block_util" }
 byteorder = "1.3.4"
 devices = { path = "../devices" }
 epoll = ">=4.0.1"
-io-uring = { git = "https://github.com/tokio-rs/io-uring.git", branch = "0.4" }
+io-uring = ">=0.4.0"
 libc = "0.2.74"
 log = "0.4.11"
 net_gen = { path = "../net_gen" }


### PR DESCRIPTION
Now that io-uring crate has been stabilized, let's move to the latest
release 0.4.0 from crates.io.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>