### PR TITLE
build: Remove job directory on ARM64 build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,6 +102,11 @@ pipeline{
 							}
 						}
 					}
+					post {
+						always {
+							deleteDir()
+						}
+					}
 				}
 				stage ('Worker build (musl)') {
 					agent { node { label 'bionic' } }


### PR DESCRIPTION
This prevents the builder from running out of disk space.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>