### PR TITLE
virtio-devices: vsock: Port to EpollHelper

### DIFF
--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -241,8 +241,9 @@ impl BalloonEpollHandler {
 }
 
 impl EpollHelperHandler for BalloonEpollHandler {
-    fn handle_event(&mut self, _helper: &mut EpollHelper, event: u16) -> bool {
-        match event {
+    fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
+        let ev_type = event.data as u16;
+        match ev_type {
             RESIZE_EVENT => {
                 if let Err(e) = self.resize_receiver.evt.read() {
                     error!("Failed to get resize event: {:?}", e);
@@ -275,7 +276,7 @@ impl EpollHelperHandler for BalloonEpollHandler {
                 if let Err(e) = self.inflate_queue_evt.read() {
                     error!("Failed to get inflate queue event: {:?}", e);
                     return true;
-                } else if let Err(e) = self.process_queue(event) {
+                } else if let Err(e) = self.process_queue(ev_type) {
                     error!("Failed to signal used inflate queue: {:?}", e);
                     return true;
                 }
@@ -284,7 +285,7 @@ impl EpollHelperHandler for BalloonEpollHandler {
                 if let Err(e) = self.deflate_queue_evt.read() {
                     error!("Failed to get deflate queue event: {:?}", e);
                     return true;
-                } else if let Err(e) = self.process_queue(event) {
+                } else if let Err(e) = self.process_queue(ev_type) {
                     error!("Failed to signal used deflate queue: {:?}", e);
                     return true;
                 }

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -208,8 +208,9 @@ impl<T: DiskFile> BlockEpollHandler<T> {
 }
 
 impl<T: DiskFile> EpollHelperHandler for BlockEpollHandler<T> {
-    fn handle_event(&mut self, _helper: &mut EpollHelper, event: u16) -> bool {
-        match event {
+    fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
+        let ev_type = event.data as u16;
+        match ev_type {
             QUEUE_AVAIL_EVENT => {
                 if let Err(e) = self.queue_evt.read() {
                     error!("Failed to get queue event: {:?}", e);
@@ -244,7 +245,7 @@ impl<T: DiskFile> EpollHelperHandler for BlockEpollHandler<T> {
                 }
             }
             _ => {
-                error!("Unexpected event: {}", event);
+                error!("Unexpected event: {}", ev_type);
                 return true;
             }
         }

--- a/virtio-devices/src/block_io_uring.rs
+++ b/virtio-devices/src/block_io_uring.rs
@@ -240,8 +240,9 @@ impl BlockIoUringEpollHandler {
 }
 
 impl EpollHelperHandler for BlockIoUringEpollHandler {
-    fn handle_event(&mut self, _helper: &mut EpollHelper, event: u16) -> bool {
-        match event {
+    fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
+        let ev_type = event.data as u16;
+        match ev_type {
             QUEUE_AVAIL_EVENT => {
                 if let Err(e) = self.queue_evt.read() {
                     error!("Failed to get queue event: {:?}", e);
@@ -285,7 +286,7 @@ impl EpollHelperHandler for BlockIoUringEpollHandler {
                 }
             }
             _ => {
-                error!("Unexpected event: {}", event);
+                error!("Unexpected event: {}", ev_type);
                 return true;
             }
         }

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -193,8 +193,9 @@ impl ConsoleEpollHandler {
 }
 
 impl EpollHelperHandler for ConsoleEpollHandler {
-    fn handle_event(&mut self, _helper: &mut EpollHelper, event: u16) -> bool {
-        match event {
+    fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
+        let ev_type = event.data as u16;
+        match ev_type {
             INPUT_QUEUE_EVENT => {
                 if let Err(e) = self.input_queue_evt.read() {
                     error!("Failed to get queue event: {:?}", e);

--- a/virtio-devices/src/epoll_helper.rs
+++ b/virtio-devices/src/epoll_helper.rs
@@ -33,7 +33,7 @@ pub const EPOLL_HELPER_EVENT_LAST: u16 = 15;
 
 pub trait EpollHelperHandler {
     // Return true if execution of the loop should be stopped
-    fn handle_event(&mut self, helper: &mut EpollHelper, event: u16) -> bool;
+    fn handle_event(&mut self, helper: &mut EpollHelper, event: &epoll::Event) -> bool;
 }
 
 impl EpollHelper {
@@ -122,8 +122,8 @@ impl EpollHelper {
                         // and every thread related to this virtio device.
                         let _ = self.pause_evt.read();
                     }
-                    id => {
-                        if handler.handle_event(self, id) {
+                    _ => {
+                        if handler.handle_event(self, event) {
                             return Ok(());
                         }
                     }

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -657,8 +657,9 @@ impl IommuEpollHandler {
 }
 
 impl EpollHelperHandler for IommuEpollHandler {
-    fn handle_event(&mut self, _helper: &mut EpollHelper, event: u16) -> bool {
-        match event {
+    fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
+        let ev_type = event.data as u16;
+        match ev_type {
             REQUEST_Q_EVENT => {
                 if let Err(e) = self.queue_evts[0].read() {
                     error!("Failed to get queue event: {:?}", e);
@@ -682,7 +683,7 @@ impl EpollHelperHandler for IommuEpollHandler {
                 }
             }
             _ => {
-                error!("Unexpected event: {}", event);
+                error!("Unexpected event: {}", ev_type);
                 return true;
             }
         }

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -600,8 +600,9 @@ impl MemEpollHandler {
 }
 
 impl EpollHelperHandler for MemEpollHandler {
-    fn handle_event(&mut self, _helper: &mut EpollHelper, event: u16) -> bool {
-        match event {
+    fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
+        let ev_type = event.data as u16;
+        match ev_type {
             RESIZE_EVENT => {
                 if let Err(e) = self.resize.evt.read() {
                     error!("Failed to get resize event: {:?}", e);
@@ -663,7 +664,7 @@ impl EpollHelperHandler for MemEpollHandler {
                 }
             }
             _ => {
-                error!("Unexpected event: {}", event);
+                error!("Unexpected event: {}", ev_type);
                 return true;
             }
         }

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -160,8 +160,9 @@ impl NetEpollHandler {
 }
 
 impl EpollHelperHandler for NetEpollHandler {
-    fn handle_event(&mut self, _helper: &mut EpollHelper, event: u16) -> bool {
-        match event {
+    fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
+        let ev_type = event.data as u16;
+        match ev_type {
             RX_QUEUE_EVENT => {
                 self.driver_awake = true;
                 if let Err(e) = self.handle_rx_event() {
@@ -183,7 +184,7 @@ impl EpollHelperHandler for NetEpollHandler {
                 }
             }
             _ => {
-                error!("Unknown event: {}", event);
+                error!("Unknown event: {}", ev_type);
                 return true;
             }
         }

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -253,8 +253,9 @@ impl PmemEpollHandler {
 }
 
 impl EpollHelperHandler for PmemEpollHandler {
-    fn handle_event(&mut self, _helper: &mut EpollHelper, event: u16) -> bool {
-        match event {
+    fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
+        let ev_type = event.data as u16;
+        match ev_type {
             QUEUE_AVAIL_EVENT => {
                 if let Err(e) = self.queue_evt.read() {
                     error!("Failed to get queue event: {:?}", e);
@@ -267,7 +268,7 @@ impl EpollHelperHandler for PmemEpollHandler {
                 }
             }
             _ => {
-                error!("Unexpected event: {}", event);
+                error!("Unexpected event: {}", ev_type);
                 return true;
             }
         }

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -98,8 +98,9 @@ impl RngEpollHandler {
 }
 
 impl EpollHelperHandler for RngEpollHandler {
-    fn handle_event(&mut self, _helper: &mut EpollHelper, event: u16) -> bool {
-        match event {
+    fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
+        let ev_type = event.data as u16;
+        match ev_type {
             QUEUE_AVAIL_EVENT => {
                 if let Err(e) = self.queue_evt.read() {
                     error!("Failed to get queue event: {:?}", e);
@@ -112,7 +113,7 @@ impl EpollHelperHandler for RngEpollHandler {
                 }
             }
             _ => {
-                error!("Unexpected event: {}", event);
+                error!("Unexpected event: {}", ev_type);
                 return true;
             }
         }


### PR DESCRIPTION
Migrate to EpollHelper so as to remove code that is duplicated between
multiple virtio devices.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>