### PR TITLE
virtio-devices: vhost-user: Port to EpollHelper

### DIFF
--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -1,10 +1,11 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::super::{ActivateError, ActivateResult, Queue, VirtioDevice, VirtioDeviceType};
+use super::super::{
+    ActivateError, ActivateResult, EpollHelperError, Queue, VirtioDevice, VirtioDeviceType,
+};
 use super::handler::*;
 use super::vu_common_ctrl::*;
-use super::Error as DeviceError;
 use super::{Error, Result};
 use crate::VirtioInterrupt;
 use block_util::VirtioBlockConfig;
@@ -41,7 +42,7 @@ pub struct Blk {
     queue_sizes: Vec<u16>,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), EpollHelperError>>>>,
     paused: Arc<AtomicBool>,
 }
 

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::vu_common_ctrl::{reset_vhost_user, setup_vhost_user, update_mem_table};
-use super::Error as DeviceError;
 use super::{Error, Result};
 use crate::vhost_user::handler::{VhostUserEpollConfig, VhostUserEpollHandler};
 use crate::{
-    ActivateError, ActivateResult, Queue, UserspaceMapping, VirtioDevice, VirtioDeviceType,
-    VirtioInterrupt, VirtioSharedMemoryList, VIRTIO_F_VERSION_1,
+    ActivateError, ActivateResult, EpollHelperError, Queue, UserspaceMapping, VirtioDevice,
+    VirtioDeviceType, VirtioInterrupt, VirtioSharedMemoryList, VIRTIO_F_VERSION_1,
 };
 use libc::{self, c_void, off64_t, pread64, pwrite64, EFD_NONBLOCK};
 use std::io;
@@ -279,7 +278,7 @@ pub struct Fs {
     slave_req_support: bool,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), EpollHelperError>>>>,
     paused: Arc<AtomicBool>,
 }
 

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -34,14 +34,6 @@ pub enum Error {
     CloneKillEventFd(io::Error),
     /// Invalid descriptor table address.
     DescriptorTableAddress,
-    /// Create Epoll eventfd failed
-    EpollCreateFd(io::Error),
-    /// Epoll ctl error
-    EpollCtl(io::Error),
-    /// Epoll wait error
-    EpollWait(io::Error),
-    /// Read queue failed.
-    FailedReadingQueue(io::Error),
     /// Signal used queue failed.
     FailedSignalingUsedQueue(io::Error),
     /// Failed to read vhost eventfd.
@@ -88,8 +80,6 @@ pub enum Error {
     VhostIrqRead(io::Error),
     /// Failed to read vhost eventfd.
     VhostUserMemoryRegion(MmapError),
-    /// Failed to handle vhost-user slave request.
-    VhostUserSlaveRequest(vhost_rs::vhost_user::Error),
     /// Failed to create the master request handler from slave.
     MasterReqHandlerCreation(vhost_rs::vhost_user::Error),
     /// Set slave request fd failed.

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -5,10 +5,11 @@ use super::super::net_util::{
     build_net_config_space, CtrlVirtio, NetCtrlEpollHandler, VirtioNetConfig,
 };
 use super::super::Error as CtrlError;
-use super::super::{ActivateError, ActivateResult, Queue, VirtioDevice, VirtioDeviceType};
+use super::super::{
+    ActivateError, ActivateResult, EpollHelperError, Queue, VirtioDevice, VirtioDeviceType,
+};
 use super::handler::*;
 use super::vu_common_ctrl::*;
-use super::Error as DeviceError;
 use super::{Error, Result};
 use crate::VirtioInterrupt;
 use libc::EFD_NONBLOCK;
@@ -45,7 +46,7 @@ pub struct Net {
     queue_sizes: Vec<u16>,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), DeviceError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), EpollHelperError>>>>,
     ctrl_queue_epoll_thread: Option<thread::JoinHandle<result::Result<(), CtrlError>>>,
     paused: Arc<AtomicBool>,
 }


### PR DESCRIPTION
Migrate all vhost-user devices to EpollHelper so as to remove code that
is duplicated between multiple virtio devices.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>