### PR TITLE
virtio-devices: net_ctrlq: Port to EpollHelper

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -84,6 +84,7 @@ fn virtio_console_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
 fn virtio_net_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
         allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_dup),
         allow_syscall(libc::SYS_epoll_create1),
         allow_syscall(libc::SYS_epoll_ctl),
         allow_syscall(libc::SYS_epoll_pwait),

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -4,7 +4,6 @@
 use super::super::net_util::{
     build_net_config_space, CtrlVirtio, NetCtrlEpollHandler, VirtioNetConfig,
 };
-use super::super::Error as CtrlError;
 use super::super::{
     ActivateError, ActivateResult, EpollHelperError, Queue, VirtioDevice, VirtioDeviceType,
 };
@@ -47,7 +46,7 @@ pub struct Net {
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
     epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), EpollHelperError>>>>,
-    ctrl_queue_epoll_thread: Option<thread::JoinHandle<result::Result<(), CtrlError>>>,
+    ctrl_queue_epoll_thread: Option<thread::JoinHandle<result::Result<(), EpollHelperError>>>,
     paused: Arc<AtomicBool>,
 }
 


### PR DESCRIPTION
Migrate virtio-net and vhost-user-net control queue to EpollHelper so
as to remove code duplication.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>