### PR TITLE
virtio-devices: Acknowledge a device being paused

### DIFF
--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -25,7 +25,7 @@ use std::os::unix::io::AsRawFd;
 use std::result;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
@@ -229,12 +229,16 @@ impl BalloonEpollHandler {
         Ok(())
     }
 
-    fn run(&mut self, paused: Arc<AtomicBool>) -> result::Result<(), EpollHelperError> {
+    fn run(
+        &mut self,
+        paused: Arc<AtomicBool>,
+        paused_sync: Arc<Barrier>,
+    ) -> result::Result<(), EpollHelperError> {
         let mut helper = EpollHelper::new(&self.kill_evt, &self.pause_evt)?;
         helper.add_event(self.resize_receiver.evt.as_raw_fd(), RESIZE_EVENT)?;
         helper.add_event(self.inflate_queue_evt.as_raw_fd(), INFLATE_QUEUE_EVENT)?;
         helper.add_event(self.deflate_queue_evt.as_raw_fd(), DEFLATE_QUEUE_EVENT)?;
-        helper.run(paused, self)?;
+        helper.run(paused, paused_sync, self)?;
 
         Ok(())
     }
@@ -313,6 +317,7 @@ pub struct Balloon {
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
     epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), EpollHelperError>>>>,
     paused: Arc<AtomicBool>,
+    paused_sync: Arc<Barrier>,
 }
 
 impl Balloon {
@@ -335,6 +340,7 @@ impl Balloon {
             interrupt_cb: None,
             epoll_threads: None,
             paused: Arc::new(AtomicBool::new(false)),
+            paused_sync: Arc::new(Barrier::new(2)),
         })
     }
 
@@ -443,10 +449,11 @@ impl VirtioDevice for Balloon {
         };
 
         let paused = self.paused.clone();
+        let paused_sync = self.paused_sync.clone();
         let mut epoll_threads = Vec::new();
         thread::Builder::new()
             .name("virtio_balloon".to_string())
-            .spawn(move || handler.run(paused))
+            .spawn(move || handler.run(paused, paused_sync))
             .map(|thread| epoll_threads.push(thread))
             .map_err(|e| {
                 error!("failed to clone virtio-balloon epoll thread: {}", e);

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -205,6 +205,13 @@ macro_rules! virtio_pausable_trait_inner {
                 pause_evt
                     .write(1)
                     .map_err(|e| MigratableError::Pause(e.into()))?;
+
+                // Wait for all threads to acknowledge the pause before going
+                // any further. This is exclusively performed when pause_evt
+                // eventfd is Some(), as this means the virtio device has been
+                // activated. One specific case where the device can be paused
+                // while it hasn't been yet activated is snapshot/restore.
+                self.paused_sync.wait();
             }
 
             Ok(())

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -19,7 +19,7 @@ use std::ops::Bound::Included;
 use std::os::unix::io::AsRawFd;
 use std::result;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Barrier, RwLock};
 use std::thread;
 use vfio_ioctls::ExternalDmaMapping;
 use vm_memory::{
@@ -646,11 +646,15 @@ impl IommuEpollHandler {
             })
     }
 
-    fn run(&mut self, paused: Arc<AtomicBool>) -> result::Result<(), EpollHelperError> {
+    fn run(
+        &mut self,
+        paused: Arc<AtomicBool>,
+        paused_sync: Arc<Barrier>,
+    ) -> result::Result<(), EpollHelperError> {
         let mut helper = EpollHelper::new(&self.kill_evt, &self.pause_evt)?;
         helper.add_event(self.queue_evts[0].as_raw_fd(), REQUEST_Q_EVENT)?;
         helper.add_event(self.queue_evts[1].as_raw_fd(), EVENT_Q_EVENT)?;
-        helper.run(paused, self)?;
+        helper.run(paused, paused_sync, self)?;
 
         Ok(())
     }
@@ -743,6 +747,7 @@ pub struct Iommu {
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
     epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), EpollHelperError>>>>,
     paused: Arc<AtomicBool>,
+    paused_sync: Arc<Barrier>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -783,6 +788,7 @@ impl Iommu {
                 interrupt_cb: None,
                 epoll_threads: None,
                 paused: Arc::new(AtomicBool::new(false)),
+                paused_sync: Arc::new(Barrier::new(2)),
             },
             mapping,
         ))
@@ -955,10 +961,11 @@ impl VirtioDevice for Iommu {
         };
 
         let paused = self.paused.clone();
+        let paused_sync = self.paused_sync.clone();
         let mut epoll_threads = Vec::new();
         thread::Builder::new()
             .name("virtio_iommu".to_string())
-            .spawn(move || handler.run(paused))
+            .spawn(move || handler.run(paused, paused_sync))
             .map(|thread| epoll_threads.push(thread))
             .map_err(|e| {
                 error!("failed to clone the virtio-iommu epoll thread: {}", e);

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -28,7 +28,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::result;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
@@ -589,11 +589,15 @@ impl MemEpollHandler {
         used_count > 0
     }
 
-    fn run(&mut self, paused: Arc<AtomicBool>) -> result::Result<(), EpollHelperError> {
+    fn run(
+        &mut self,
+        paused: Arc<AtomicBool>,
+        paused_sync: Arc<Barrier>,
+    ) -> result::Result<(), EpollHelperError> {
         let mut helper = EpollHelper::new(&self.kill_evt, &self.pause_evt)?;
         helper.add_event(self.resize.evt.as_raw_fd(), RESIZE_EVENT)?;
         helper.add_event(self.queue_evt.as_raw_fd(), QUEUE_AVAIL_EVENT)?;
-        helper.run(paused, self)?;
+        helper.run(paused, paused_sync, self)?;
 
         Ok(())
     }
@@ -687,6 +691,7 @@ pub struct Mem {
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
     epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), EpollHelperError>>>>,
     paused: Arc<AtomicBool>,
+    paused_sync: Arc<Barrier>,
 }
 
 impl Mem {
@@ -737,6 +742,7 @@ impl Mem {
             interrupt_cb: None,
             epoll_threads: None,
             paused: Arc::new(AtomicBool::new(false)),
+            paused_sync: Arc::new(Barrier::new(2)),
         })
     }
 }
@@ -844,10 +850,11 @@ impl VirtioDevice for Mem {
         };
 
         let paused = self.paused.clone();
+        let paused_sync = self.paused_sync.clone();
         let mut epoll_threads = Vec::new();
         thread::Builder::new()
             .name("virtio_mem".to_string())
-            .spawn(move || handler.run(paused))
+            .spawn(move || handler.run(paused, paused_sync))
             .map(|thread| epoll_threads.push(thread))
             .map_err(|e| {
                 error!("failed to clone virtio-mem epoll thread: {}", e);


### PR DESCRIPTION
Using the Rust Barrier mechanism, this patch forces each virtio device
to acknowledge they've been correctly paused before going further.

Fixes #1556 

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>