### PR TITLE
Jenkinsfile: chown the workspace before cleaning up

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,6 +104,7 @@ pipeline{
 					}
 					post {
 						always {
+							sh "sudo chown -R jenkins.jenkins ${WORKSPACE}"
 							deleteDir()
 						}
 					}


### PR DESCRIPTION
If the build was aborted then the dev_cli.sh code that is responsible
for changing the file ownership will not get run. This results in the
failure to delete some of the files in the workspace.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>