### PR TITLE
devices: acpi: Add UID to devices with common HID

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1254,6 +1254,7 @@ impl Aml for CpuManager {
                 "_SB_.PRES".into(),
                 vec![
                     &aml::Name::new("_HID".into(), &aml::EISAName::new("PNP0A06")),
+                    &aml::Name::new("_UID".into(), &"CPU Hotplug Controller"),
                     // Mutex to protect concurrent access as we write to choose CPU and then read back status
                     &aml::Mutex::new("CPLK".into(), 0),
                     // I/O port for CPU controller

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3438,6 +3438,7 @@ impl Aml for DeviceManager {
                 vec![
                     &aml::Name::new("_HID".into(), &aml::EISAName::new("PNP0A06")),
                     &aml::Name::new("_STA".into(), &0x0bu8),
+                    &aml::Name::new("_UID".into(), &"PCI Hotplug Controller"),
                     &aml::Mutex::new("BLCK".into(), 0),
                     // I/O port for PCI hotplug controller
                     &aml::Name::new(

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1225,6 +1225,7 @@ impl Aml for MemoryManager {
                 "_SB_.MHPC".into(),
                 vec![
                     &aml::Name::new("_HID".into(), &aml::EISAName::new("PNP0A06")),
+                    &aml::Name::new("_UID".into(), &"Memory Hotplug Controller"),
                     // Mutex to protect concurrent access as we write to choose slot and then read back status
                     &aml::Mutex::new("MLCK".into(), 0),
                     // I/O port for memory controller


### PR DESCRIPTION
Some OS might check for duplicates and bail out, if it can't create a
distinct mapping. According to ACPI 5.0 section 6.1.12, while _UID is
optional, it becomes required when there are multiple devices with the
same _HID.

Signed-off-by: Anatol Belski <ab@php.net>