### PR TITLE
Jenkinsfile: Don't retry integration tests on failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,9 +46,6 @@ pipeline{
 							}
 						}
 						stage ('Run integration tests') {
-							options {
-								retry(3)
-							}
 							steps {
 								sh "scripts/dev_cli.sh tests --integration"
 							}
@@ -111,9 +108,6 @@ pipeline{
 							}
 						}
 						stage ('Run integration tests for musl') {
-							options {
-								retry(3)
-							}
 							steps {
 								sh "scripts/dev_cli.sh tests --integration --libc musl"
 							}


### PR DESCRIPTION
We recently added the ability for the gnu and musl workers to retry if
integration test were not passing, relying on some simple Jenkins
options. Unfortunately, this is not working as expected as the retries
never pass either. The suspected reason is the machine itself, which
might be scheduled on some specific hardware, which makes our VMs more
error prone.

Bottom line, on a faulty machine, the tests will always fail, therefore
there is no added value in retrying on the same machine.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>