### PR TITLE
virtio-devices: Print out worker thread errors

### DIFF
--- a/virtio-devices/src/block_io_uring.rs
+++ b/virtio-devices/src/block_io_uring.rs
@@ -310,7 +310,7 @@ pub struct BlockIoUring {
     config: VirtioBlockConfig,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
-    epoll_threads: Option<Vec<thread::JoinHandle<result::Result<(), EpollHelperError>>>>,
+    epoll_threads: Option<Vec<thread::JoinHandle<()>>>,
     pause_evt: Option<EventFd>,
     paused: Arc<AtomicBool>,
     paused_sync: Arc<Barrier>,
@@ -601,7 +601,11 @@ impl VirtioDevice for BlockIoUring {
 
             thread::Builder::new()
                 .name("virtio_blk".to_string())
-                .spawn(move || handler.run(paused, paused_sync))
+                .spawn(move || {
+                    if let Err(e) = handler.run(paused, paused_sync) {
+                        error!("Error running worker: {:?}", e);
+                    }
+                })
                 .map(|thread| epoll_threads.push(thread))
                 .map_err(|e| {
                     error!("failed to clone the virtio-blk epoll thread: {}", e);


### PR DESCRIPTION
As we never join the spawned virtio-devices worker threads, the error
returned from each worker thread is lost. For now, we simply print out
the error from each worker thread.

Fixes: #1551

Signed-off-by: Bo Chen <chen.bo@intel.com>