### PR TITLE
virtio-devices: seccomp: Add seccomp filters for balloon/mem/vhost worker threads

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -20,6 +20,7 @@ pub enum Thread {
     VirtioPmem,
     VirtioRng,
     VirtioVhostFs,
+    VirtioVhostNetCtl,
 }
 
 fn virtio_balloon_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
@@ -253,6 +254,20 @@ fn virtio_vhost_fs_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     ])
 }
 
+fn virtio_vhost_net_ctl_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
+    Ok(vec![
+        allow_syscall(libc::SYS_brk),
+        allow_syscall(libc::SYS_dup),
+        allow_syscall(libc::SYS_epoll_create1),
+        allow_syscall(libc::SYS_epoll_ctl),
+        allow_syscall(libc::SYS_epoll_pwait),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_epoll_wait),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_read),
+    ])
+}
+
 fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> {
     let rules = match thread_type {
         Thread::VirtioBalloon => virtio_balloon_thread_rules()?,
@@ -265,6 +280,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
         Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules()?,
+        Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules()?,
     };
 
     Ok(SeccompFilter::new(
@@ -285,6 +301,7 @@ fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
         Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules()?,
+        Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules()?,
     };
 
     Ok(SeccompFilter::new(

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -20,6 +20,7 @@ pub enum Thread {
     VirtioPmem,
     VirtioRng,
     VirtioVhostFs,
+    VirtioVhostNet,
     VirtioVhostNetCtl,
 }
 
@@ -254,6 +255,21 @@ fn virtio_vhost_fs_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     ])
 }
 
+fn virtio_vhost_net_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
+    Ok(vec![
+        allow_syscall(libc::SYS_brk),
+        allow_syscall(libc::SYS_dup),
+        allow_syscall(libc::SYS_epoll_create1),
+        allow_syscall(libc::SYS_epoll_ctl),
+        allow_syscall(libc::SYS_epoll_pwait),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_epoll_wait),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_read),
+        allow_syscall(libc::SYS_write),
+    ])
+}
+
 fn virtio_vhost_net_ctl_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
         allow_syscall(libc::SYS_brk),
@@ -280,6 +296,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
         Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules()?,
+        Thread::VirtioVhostNet => virtio_vhost_net_thread_rules()?,
         Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules()?,
     };
 
@@ -301,6 +318,7 @@ fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
         Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules()?,
+        Thread::VirtioVhostNet => virtio_vhost_net_thread_rules()?,
         Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules()?,
     };
 

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -19,6 +19,7 @@ pub enum Thread {
     VirtioNetCtl,
     VirtioPmem,
     VirtioRng,
+    VirtioVhostFs,
 }
 
 fn virtio_balloon_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
@@ -228,6 +229,30 @@ fn virtio_rng_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     ])
 }
 
+fn virtio_vhost_fs_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
+    Ok(vec![
+        allow_syscall(libc::SYS_brk),
+        allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_dup),
+        allow_syscall(libc::SYS_epoll_create1),
+        allow_syscall(libc::SYS_epoll_ctl),
+        allow_syscall(libc::SYS_epoll_pwait),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_epoll_wait),
+        allow_syscall(libc::SYS_exit),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_madvise),
+        allow_syscall(libc::SYS_mmap),
+        allow_syscall(libc::SYS_munmap),
+        allow_syscall(libc::SYS_read),
+        allow_syscall(libc::SYS_recvmsg),
+        allow_syscall(libc::SYS_rt_sigprocmask),
+        allow_syscall(libc::SYS_sendmsg),
+        allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_write),
+    ])
+}
+
 fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> {
     let rules = match thread_type {
         Thread::VirtioBalloon => virtio_balloon_thread_rules()?,
@@ -239,6 +264,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
         Thread::VirtioNetCtl => virtio_net_ctl_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
+        Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules()?,
     };
 
     Ok(SeccompFilter::new(
@@ -258,6 +284,7 @@ fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
         Thread::VirtioNetCtl => virtio_net_ctl_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
+        Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules()?,
     };
 
     Ok(SeccompFilter::new(

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -19,6 +19,7 @@ pub enum Thread {
     VirtioNetCtl,
     VirtioPmem,
     VirtioRng,
+    VirtioVhostBlk,
     VirtioVhostFs,
     VirtioVhostNet,
     VirtioVhostNetCtl,
@@ -231,6 +232,27 @@ fn virtio_rng_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     ])
 }
 
+fn virtio_vhost_blk_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
+    Ok(vec![
+        allow_syscall(libc::SYS_brk),
+        allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_dup),
+        allow_syscall(libc::SYS_epoll_create1),
+        allow_syscall(libc::SYS_epoll_ctl),
+        allow_syscall(libc::SYS_epoll_pwait),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_epoll_wait),
+        allow_syscall(libc::SYS_exit),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_madvise),
+        allow_syscall(libc::SYS_munmap),
+        allow_syscall(libc::SYS_read),
+        allow_syscall(libc::SYS_rt_sigprocmask),
+        allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_write),
+    ])
+}
+
 fn virtio_vhost_fs_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
         allow_syscall(libc::SYS_brk),
@@ -295,6 +317,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
         Thread::VirtioNetCtl => virtio_net_ctl_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
+        Thread::VirtioVhostBlk => virtio_vhost_blk_thread_rules()?,
         Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules()?,
         Thread::VirtioVhostNet => virtio_vhost_net_thread_rules()?,
         Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules()?,
@@ -317,6 +340,7 @@ fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
         Thread::VirtioNetCtl => virtio_net_ctl_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
         Thread::VirtioRng => virtio_rng_thread_rules()?,
+        Thread::VirtioVhostBlk => virtio_vhost_blk_thread_rules()?,
         Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules()?,
         Thread::VirtioVhostNet => virtio_vhost_net_thread_rules()?,
         Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules()?,

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -13,6 +13,7 @@ pub enum Thread {
     VirtioBlk,
     VirtioConsole,
     VirtioIommu,
+    VirtioMem,
     VirtioNet,
     VirtioNetCtl,
     VirtioPmem,
@@ -94,6 +95,23 @@ fn virtio_iommu_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         #[cfg(target_arch = "x86_64")]
         allow_syscall(libc::SYS_epoll_wait),
         allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_read),
+        allow_syscall(libc::SYS_write),
+    ])
+}
+
+fn virtio_mem_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
+    Ok(vec![
+        allow_syscall(libc::SYS_brk),
+        allow_syscall(libc::SYS_dup),
+        allow_syscall(libc::SYS_epoll_create1),
+        allow_syscall(libc::SYS_epoll_ctl),
+        allow_syscall(libc::SYS_epoll_pwait),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_epoll_wait),
+        allow_syscall(libc::SYS_fallocate),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_madvise),
         allow_syscall(libc::SYS_read),
         allow_syscall(libc::SYS_write),
     ])
@@ -193,6 +211,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
         Thread::VirtioConsole => virtio_console_thread_rules()?,
         Thread::VirtioIommu => virtio_iommu_thread_rules()?,
+        Thread::VirtioMem => virtio_mem_thread_rules()?,
         Thread::VirtioNet => virtio_net_thread_rules()?,
         Thread::VirtioNetCtl => virtio_net_ctl_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,
@@ -210,6 +229,7 @@ fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
         Thread::VirtioBlk => virtio_blk_thread_rules()?,
         Thread::VirtioConsole => virtio_console_thread_rules()?,
         Thread::VirtioIommu => virtio_iommu_thread_rules()?,
+        Thread::VirtioMem => virtio_mem_thread_rules()?,
         Thread::VirtioNet => virtio_net_thread_rules()?,
         Thread::VirtioNetCtl => virtio_net_ctl_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules()?,

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -318,10 +318,15 @@ impl VirtioDevice for Net {
 
             let paused = self.paused.clone();
             let paused_sync = self.paused_sync.clone();
+            let virtio_vhost_net_seccomp_filter =
+                get_seccomp_filter(&self.seccomp_action, Thread::VirtioVhostNet)
+                    .map_err(ActivateError::CreateSeccompFilter)?;
             thread::Builder::new()
-                .name("vhost_user_net".to_string())
+                .name("vhost_net".to_string())
                 .spawn(move || {
-                    if let Err(e) = handler.run(paused, paused_sync) {
+                    if let Err(e) = SeccompFilter::apply(virtio_vhost_net_seccomp_filter) {
+                        error!("Error applying seccomp filter: {:?}", e);
+                    } else if let Err(e) = handler.run(paused, paused_sync) {
                         error!("Error running worker: {:?}", e);
                     }
                 })

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2452,6 +2452,7 @@ impl DeviceManager {
                 virtio_devices::Balloon::new(
                     id.clone(),
                     self.config.lock().unwrap().memory.balloon_size,
+                    self.seccomp_action.clone(),
                 )
                 .map_err(DeviceManagerError::CreateVirtioBalloon)?,
             ));

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1642,8 +1642,12 @@ impl DeviceManager {
                 queue_size: disk_cfg.queue_size,
             };
             let vhost_user_block_device = Arc::new(Mutex::new(
-                virtio_devices::vhost_user::Blk::new(id.clone(), vu_cfg)
-                    .map_err(DeviceManagerError::CreateVhostUserBlk)?,
+                virtio_devices::vhost_user::Blk::new(
+                    id.clone(),
+                    vu_cfg,
+                    self.seccomp_action.clone(),
+                )
+                .map_err(DeviceManagerError::CreateVhostUserBlk)?,
             ));
 
             // Fill the device tree with a new node. In case of restore, we

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1874,8 +1874,13 @@ impl DeviceManager {
                 queue_size: net_cfg.queue_size,
             };
             let vhost_user_net_device = Arc::new(Mutex::new(
-                virtio_devices::vhost_user::Net::new(id.clone(), net_cfg.mac, vu_cfg)
-                    .map_err(DeviceManagerError::CreateVhostUserNet)?,
+                virtio_devices::vhost_user::Net::new(
+                    id.clone(),
+                    net_cfg.mac,
+                    vu_cfg,
+                    self.seccomp_action.clone(),
+                )
+                .map_err(DeviceManagerError::CreateVhostUserNet)?,
             ));
 
             // Fill the device tree with a new node. In case of restore, we

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2417,6 +2417,7 @@ impl DeviceManager {
                     resize
                         .try_clone()
                         .map_err(DeviceManagerError::TryCloneVirtioMemResize)?,
+                    self.seccomp_action.clone(),
                 )
                 .map_err(DeviceManagerError::CreateVirtioMem)?,
             ));

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2121,6 +2121,7 @@ impl DeviceManager {
                     fs_cfg.num_queues,
                     fs_cfg.queue_size,
                     cache,
+                    self.seccomp_action.clone(),
                 )
                 .map_err(DeviceManagerError::CreateVirtioFs)?,
             ));


### PR DESCRIPTION
This patch enables the seccomp filters for the balloon/mem/vhost worker thread.

Partially fixes: #925

Signed-off-by: Bo Chen <chen.bo@intel.com>