### PR TITLE
Jenkinsfile: Add a cleanup stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,12 +84,6 @@ pipeline{
 							}
 						}
 					}
-					post {
-						always {
-							sh "sudo chown -R jenkins.jenkins ${WORKSPACE}"
-							deleteDir()
-						}
-					}
 				}
 				stage ('Worker build (musl)') {
 					agent { node { label 'bionic' } }
@@ -114,6 +108,13 @@ pipeline{
 						}
 					}
 				}
+			}
+		}
+		stage ('Cleanup') {
+			agent { node { label 'bionic-arm64' } }
+			steps {
+				sh "sudo chown -R jenkins.jenkins ${WORKSPACE}"
+				deleteDir()
 			}
 		}
 	}


### PR DESCRIPTION
Cleanup of the Aarch64 machine can't be done as part of the parallel
stage as this is often skipped. When the build is aborted because
another parallel stage failed, the post actions are simply not
performed. That's why we need a dedicated stage, out of the parallel
ones, to cleanup the Aarch64 machine.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>