### PR TITLE
docs/virtio-fs: Update --memory option parameters

### DIFF
--- a/docs/fs.md
+++ b/docs/fs.md
@@ -56,7 +56,7 @@ Assuming you have `focal-server-cloudimg-amd64.raw` and `custom-vmlinux.bin` on 
 ```bash
 ./cloud-hypervisor \
     --cpus 4 \
-    --memory "size=512,file=/dev/shm" \
+    --memory "size=512M,shared=on" \
     --disk path=focal-server-cloudimg-amd64.raw \
     --kernel custom-vmlinux.bin \
     --cmdline "console=ttyS0 console=hvc0 root=/dev/vda1 rw" \


### PR DESCRIPTION
Use updated --memory option parameters. The field `size` needs
M/G suffix. Without the suffix cloud-hypervisor panics at
src/main.rs:353
Also the use of backing file is deprecated so use `shared` field

Signed-off-by: Amey Narkhede <ameynarkhede02@gmail.com>