### PR TITLE
virtio-devices: Allow SYS_write syscall for virtio-net-ctl thread

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -181,6 +181,7 @@ fn virtio_net_ctl_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_read),
         allow_syscall(libc::SYS_rt_sigprocmask),
         allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_write),
     ])
 }
 


### PR DESCRIPTION
"debug!" macro is used in `virtio-devices/src/epoll_helper.rs` for logging. When `-vvv` and `--log-file` options were specified, the missing `SYS_write` rule caused a "bad system call" crash.
