### PR TITLE
Jenkinsfile: Force the cleanup after stages are aborted

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,12 @@ pipeline{
 							}
 						}
 					}
+					post {
+						always {
+							sh "sudo chown -R jenkins.jenkins ${WORKSPACE}"
+							deleteDir()
+						}
+					}
 				}
 				stage ('Worker build (musl)') {
 					agent { node { label 'bionic' } }
@@ -108,13 +114,6 @@ pipeline{
 						}
 					}
 				}
-			}
-		}
-		stage ('Cleanup') {
-			agent { node { label 'bionic-arm64' } }
-			steps {
-				sh "sudo chown -R jenkins.jenkins ${WORKSPACE}"
-				deleteDir()
 			}
 		}
 	}


### PR DESCRIPTION
Problem with the previous solution was that Cleanup stage was not
executed when previous stages failed. We fix this by adding a post
section that executes always after the Aarch64 build completed, no
matter if it has failed, succeeded or been aborted.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>