### PR TITLE
vmm: Introduce user-defined memory regions

### DIFF
--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -70,7 +70,7 @@ impl Snapshottable for Gic {
         GIC_SNAPSHOT_ID.to_string()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         unimplemented!();
     }
 

--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -405,7 +405,7 @@ impl Snapshottable for Ioapic {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -289,7 +289,7 @@ impl Snapshottable for Serial {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -889,7 +889,7 @@ impl Snapshottable for PciConfiguration {
         String::from("pci_configuration")
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -437,7 +437,7 @@ impl Snapshottable for MsixConfig {
         String::from("msix_config")
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,18 @@ fn create_app<'a, 'b>(
                 .group("vm-config"),
         )
         .arg(
+            Arg::with_name("memory-zone")
+                .long("memory-zone")
+                .help(
+                    "User defined memory zone parameters \
+                     \"size=<guest_memory_region_size>,file=<backing_file>,\
+                     mergeable=on|off,shared=on|off,hugepages=on|off\"",
+                )
+                .takes_value(true)
+                .min_values(1)
+                .group("vm-config"),
+        )
+        .arg(
             Arg::with_name("kernel")
                 .long("kernel")
                 .help("Path to kernel image (vmlinux)")
@@ -522,6 +534,7 @@ mod unit_tests {
                     hugepages: false,
                     balloon: false,
                     balloon_size: 0,
+                    zones: None,
                 },
                 kernel: Some(KernelConfig {
                     path: PathBuf::from("/path/to/kernel"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -526,7 +526,6 @@ mod unit_tests {
                 },
                 memory: MemoryConfig {
                     size: 536_870_912,
-                    file: None,
                     mergeable: false,
                     hotplug_method: HotplugMethod::Acpi,
                     hotplug_size: None,
@@ -641,18 +640,6 @@ mod unit_tests {
                 r#"{
                     "kernel": {"path": "/path/to/kernel"},
                     "memory": {"size": 1073741824}
-                }"#,
-                true,
-            ),
-            (
-                vec![
-                    "cloud-hypervisor", "--kernel", "/path/to/kernel",
-                    "--memory",
-                    "size=1G,file=/path/to/shared/file",
-                ],
-                r#"{
-                    "kernel": {"path": "/path/to/kernel"},
-                    "memory": {"size": 1073741824, "file": "/path/to/shared/file"}
                 }"#,
                 true,
             ),

--- a/test_data/cloud-init/ubuntu/user-data
+++ b/test_data/cloud-init/ubuntu/user-data
@@ -38,4 +38,4 @@ write_files:
         # 1G ram requires 512 pages
         echo 512 | sudo tee /proc/sys/vm/nr_hugepages
         sudo chmod a+rwX /dev/hugepages
-        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda1 VFIOTAG" --disk path=/mnt/focal-server-cloudimg-amd64-custom.qcow2 path=/mnt/cloudinit.img --cpus boot=1 --memory size=512M,hotplug_size=1G,file=/dev/hugepages --device path=/sys/bus/pci/devices/0000:00:06.0/ path=/sys/bus/pci/devices/0000:00:07.0/ --api-socket /tmp/ch_api.sock
+        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda1 VFIOTAG" --disk path=/mnt/focal-server-cloudimg-amd64-custom.qcow2 path=/mnt/cloudinit.img --cpus boot=1 --memory size=512M,hotplug_size=1G,hugepages=on --device path=/sys/bus/pci/devices/0000:00:06.0/ path=/sys/bus/pci/devices/0000:00:07.0/ --api-socket /tmp/ch_api.sock

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2210,6 +2210,35 @@ mod tests {
         }
 
         #[cfg_attr(not(feature = "mmio"), test)]
+        fn test_user_defined_memory_regions() {
+            test_block!(tb, "", {
+                let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+                let guest = Guest::new(&mut focal);
+                let mut cmd = GuestCommand::new(&guest);
+                cmd.args(&["--cpus", "boot=1"])
+                    .args(&["--memory", "size=0"])
+                    .args(&["--memory-zone", "size=1G", "size=3G,file=/dev/shm"])
+                    .args(&["--kernel", guest.fw_path.as_str()])
+                    .default_disks()
+                    .default_net();
+
+                // Now AArch64 can only boot from direct kernel, command-line is needed.
+                #[cfg(target_arch = "aarch64")]
+                cmd.args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE]);
+
+                let mut child = cmd.spawn().unwrap();
+
+                thread::sleep(std::time::Duration::new(20, 0));
+
+                aver!(tb, guest.get_total_memory().unwrap_or_default() > 3_840_000);
+
+                let _ = child.kill();
+                let _ = child.wait();
+                Ok(())
+            });
+        }
+
+        #[cfg_attr(not(feature = "mmio"), test)]
         #[cfg(target_arch = "x86_64")]
         fn test_pci_msi() {
             test_block!(tb, "", {

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -620,7 +620,7 @@ impl<T: 'static + DiskFile + Send> Snapshottable for Block<T> {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/block_io_uring.rs
+++ b/virtio-devices/src/block_io_uring.rs
@@ -670,7 +670,7 @@ impl Snapshottable for BlockIoUring {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -552,7 +552,7 @@ impl Snapshottable for Console {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -1016,7 +1016,7 @@ impl Snapshottable for Iommu {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -565,7 +565,7 @@ impl Snapshottable for Net {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -524,7 +524,7 @@ impl Snapshottable for Pmem {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -348,7 +348,7 @@ impl Snapshottable for Rng {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/transport/mmio.rs
+++ b/virtio-devices/src/transport/mmio.rs
@@ -462,7 +462,7 @@ impl Snapshottable for MmioDevice {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -290,7 +290,7 @@ impl Snapshottable for VirtioPciCommonConfig {
         String::from("virtio_pci_common_config")
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1040,7 +1040,7 @@ impl Snapshottable for VirtioPciDevice {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -535,7 +535,7 @@ where
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -111,7 +111,7 @@ pub trait Snapshottable: Pausable {
     }
 
     /// Take a component snapshot.
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         Ok(Snapshot::new(""))
     }
 

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -481,8 +481,6 @@ components:
         hotplug_size:
           type: integer
           format: int64
-        file:
-          type: string
         mergeable:
           type: boolean
           default: false

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -448,6 +448,27 @@ components:
         topology:
             $ref: '#/components/schemas/CpuTopology'
 
+    MemoryZoneConfig:
+      required:
+      - size
+      type: object
+      properties:
+        size:
+          type: integer
+          format: int64
+          default: 512 MB
+        file:
+          type: string
+        mergeable:
+          type: boolean
+          default: false
+        shared:
+          type: boolean
+          default: false
+        hugepages:
+          type: boolean
+          default: false
+
     MemoryConfig:
       required:
       - size
@@ -477,6 +498,10 @@ components:
         balloon:
           type: boolean
           default: false
+        zones:
+          type: array
+          items:
+            $ref: '#/components/schemas/MemoryZoneConfig'
 
     KernelConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -42,6 +42,8 @@ pub enum Error {
     ParseCpus(OptionParserError),
     /// Error parsing memory options
     ParseMemory(OptionParserError),
+    /// Error parsing memory zone options
+    ParseMemoryZone(OptionParserError),
     /// Error parsing disk options
     ParseDisk(OptionParserError),
     /// Error parsing network options
@@ -147,6 +149,7 @@ impl fmt::Display for Error {
             ParseVsockCidMissing => write!(f, "Error parsing --vsock: cid missing"),
             ParseVsockSockMissing => write!(f, "Error parsing --vsock: socket missing"),
             ParseMemory(o) => write!(f, "Error parsing --memory: {}", o),
+            ParseMemoryZone(o) => write!(f, "Error parsing --memory-zone: {}", o),
             ParseNetwork(o) => write!(f, "Error parsing --net: {}", o),
             ParseDisk(o) => write!(f, "Error parsing --disk: {}", o),
             ParseRNG(o) => write!(f, "Error parsing --rng: {}", o),
@@ -166,6 +169,7 @@ pub type Result<T> = result::Result<T, Error>;
 pub struct VmParams<'a> {
     pub cpus: &'a str,
     pub memory: &'a str,
+    pub memory_zones: Option<Vec<&'a str>>,
     pub kernel: Option<&'a str>,
     pub initramfs: Option<&'a str>,
     pub cmdline: Option<&'a str>,
@@ -187,6 +191,7 @@ impl<'a> VmParams<'a> {
         // These .unwrap()s cannot fail as there is a default value defined
         let cpus = args.value_of("cpus").unwrap();
         let memory = args.value_of("memory").unwrap();
+        let memory_zones: Option<Vec<&str>> = args.values_of("memory-zone").map(|x| x.collect());
         let rng = args.value_of("rng").unwrap();
         let serial = args.value_of("serial").unwrap();
 
@@ -207,6 +212,7 @@ impl<'a> VmParams<'a> {
         VmParams {
             cpus,
             memory,
+            memory_zones,
             kernel,
             initramfs,
             cmdline,
@@ -338,6 +344,19 @@ impl Default for CpusConfig {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct MemoryZoneConfig {
+    pub size: u64,
+    #[serde(default)]
+    pub file: Option<PathBuf>,
+    #[serde(default)]
+    pub mergeable: bool,
+    #[serde(default)]
+    pub shared: bool,
+    #[serde(default)]
+    pub hugepages: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct MemoryConfig {
     pub size: u64,
     #[serde(default)]
@@ -356,10 +375,12 @@ pub struct MemoryConfig {
     pub balloon: bool,
     #[serde(default)]
     pub balloon_size: u64,
+    #[serde(default)]
+    pub zones: Option<Vec<MemoryZoneConfig>>,
 }
 
 impl MemoryConfig {
-    pub fn parse(memory: &str) -> Result<Self> {
+    pub fn parse(memory: &str, memory_zones: Option<Vec<&str>>) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser
             .add("size")
@@ -407,6 +428,53 @@ impl MemoryConfig {
             .unwrap_or(Toggle(false))
             .0;
 
+        let zones: Option<Vec<MemoryZoneConfig>> = if let Some(memory_zones) = &memory_zones {
+            let mut zones = Vec::new();
+            for memory_zone in memory_zones.iter() {
+                let mut parser = OptionParser::new();
+                parser
+                    .add("size")
+                    .add("file")
+                    .add("mergeable")
+                    .add("shared")
+                    .add("hugepages");
+                parser.parse(memory_zone).map_err(Error::ParseMemoryZone)?;
+
+                let size = parser
+                    .convert::<ByteSized>("size")
+                    .map_err(Error::ParseMemoryZone)?
+                    .unwrap_or(ByteSized(DEFAULT_MEMORY_MB << 20))
+                    .0;
+                let file = parser.get("file").map(PathBuf::from);
+                let mergeable = parser
+                    .convert::<Toggle>("mergeable")
+                    .map_err(Error::ParseMemoryZone)?
+                    .unwrap_or(Toggle(false))
+                    .0;
+                let shared = parser
+                    .convert::<Toggle>("shared")
+                    .map_err(Error::ParseMemoryZone)?
+                    .unwrap_or(Toggle(false))
+                    .0;
+                let hugepages = parser
+                    .convert::<Toggle>("hugepages")
+                    .map_err(Error::ParseMemoryZone)?
+                    .unwrap_or(Toggle(false))
+                    .0;
+
+                zones.push(MemoryZoneConfig {
+                    size,
+                    file,
+                    mergeable,
+                    shared,
+                    hugepages,
+                });
+            }
+            Some(zones)
+        } else {
+            None
+        };
+
         Ok(MemoryConfig {
             size,
             file,
@@ -417,6 +485,7 @@ impl MemoryConfig {
             hugepages,
             balloon,
             balloon_size: 0,
+            zones,
         })
     }
 }
@@ -433,6 +502,7 @@ impl Default for MemoryConfig {
             hugepages: false,
             balloon: false,
             balloon_size: 0,
+            zones: None,
         }
     }
 }
@@ -1388,7 +1458,7 @@ impl VmConfig {
 
         let config = VmConfig {
             cpus: CpusConfig::parse(vm_params.cpus)?,
-            memory: MemoryConfig::parse(vm_params.memory)?,
+            memory: MemoryConfig::parse(vm_params.memory, vm_params.memory_zones)?,
             kernel,
             initramfs,
             cmdline: CmdlineConfig::parse(vm_params.cmdline)?,
@@ -1481,11 +1551,14 @@ mod tests {
 
     #[test]
     fn test_mem_parsing() -> Result<()> {
-        assert_eq!(MemoryConfig::parse("")?, MemoryConfig::default());
+        assert_eq!(MemoryConfig::parse("", None)?, MemoryConfig::default());
         // Default string
-        assert_eq!(MemoryConfig::parse("size=512M")?, MemoryConfig::default());
         assert_eq!(
-            MemoryConfig::parse("size=512M,file=/some/file")?,
+            MemoryConfig::parse("size=512M", None)?,
+            MemoryConfig::default()
+        );
+        assert_eq!(
+            MemoryConfig::parse("size=512M,file=/some/file", None)?,
             MemoryConfig {
                 size: 512 << 20,
                 file: Some(PathBuf::from("/some/file")),
@@ -1493,7 +1566,7 @@ mod tests {
             }
         );
         assert_eq!(
-            MemoryConfig::parse("size=512M,mergeable=on")?,
+            MemoryConfig::parse("size=512M,mergeable=on", None)?,
             MemoryConfig {
                 size: 512 << 20,
                 mergeable: true,
@@ -1501,14 +1574,14 @@ mod tests {
             }
         );
         assert_eq!(
-            MemoryConfig::parse("mergeable=on")?,
+            MemoryConfig::parse("mergeable=on", None)?,
             MemoryConfig {
                 mergeable: true,
                 ..Default::default()
             }
         );
         assert_eq!(
-            MemoryConfig::parse("size=1G,mergeable=off")?,
+            MemoryConfig::parse("size=1G,mergeable=off", None)?,
             MemoryConfig {
                 size: 1 << 30,
                 mergeable: false,
@@ -1516,20 +1589,20 @@ mod tests {
             }
         );
         assert_eq!(
-            MemoryConfig::parse("hotplug_method=acpi")?,
+            MemoryConfig::parse("hotplug_method=acpi", None)?,
             MemoryConfig {
                 ..Default::default()
             }
         );
         assert_eq!(
-            MemoryConfig::parse("hotplug_method=acpi,hotplug_size=512M")?,
+            MemoryConfig::parse("hotplug_method=acpi,hotplug_size=512M", None)?,
             MemoryConfig {
                 hotplug_size: Some(512 << 20),
                 ..Default::default()
             }
         );
         assert_eq!(
-            MemoryConfig::parse("hotplug_method=virtio-mem,hotplug_size=512M")?,
+            MemoryConfig::parse("hotplug_method=virtio-mem,hotplug_size=512M", None)?,
             MemoryConfig {
                 hotplug_size: Some(512 << 20),
                 hotplug_method: HotplugMethod::VirtioMem,
@@ -1951,6 +2024,7 @@ mod tests {
                 hugepages: false,
                 balloon: false,
                 balloon_size: 0,
+                zones: None,
             },
             kernel: Some(KernelConfig {
                 path: PathBuf::from("/path/to/kernel"),

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -400,7 +400,7 @@ impl Snapshottable for Vcpu {
         VCPU_SNAPSHOT_ID.to_string()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot = serde_json::to_vec(&self.saved_state)
             .map_err(|e| MigratableError::Snapshot(e.into()))?;
 
@@ -1368,7 +1368,7 @@ impl Snapshottable for CpuManager {
         CPU_MANAGER_SNAPSHOT_ID.to_string()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let mut cpu_manager_snapshot = Snapshot::new(CPU_MANAGER_SNAPSHOT_ID);
 
         // The CpuManager snapshot is a collection of all vCPUs snapshots.

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3626,7 +3626,7 @@ impl Snapshottable for DeviceManager {
         DEVICE_MANAGER_SNAPSHOT_ID.to_string()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let mut snapshot = Snapshot::new(DEVICE_MANAGER_SNAPSHOT_ID);
 
         // We aggregate all devices snapshots.

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -613,11 +613,9 @@ impl MemoryManager {
         };
 
         #[cfg(target_arch = "x86_64")]
-        let start_addr = if mem_end < arch::layout::MEM_32BIT_RESERVED_START {
-            arch::layout::RAM_64BIT_START
-        } else {
-            start_addr
-        };
+        if mem_end < arch::layout::MEM_32BIT_RESERVED_START {
+            return arch::layout::RAM_64BIT_START;
+        }
 
         start_addr
     }

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -166,10 +166,6 @@ pub enum Error {
     /// Forbidden operation. Impossible to resize guest memory if it is
     /// backed by user defined memory regions.
     InvalidResizeWithMemoryZones,
-
-    /// Forbidden operation. Impossible to restore guest memory if it is
-    /// backed by user defined memory regions.
-    InvalidRestoreWithMemoryZones,
 }
 
 const ENABLE_FLAG: usize = 0;
@@ -558,14 +554,6 @@ impl MemoryManager {
         source_url: &str,
         prefault: bool,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
-        if config.size == 0 {
-            error!(
-                "Not allowed to restore guest memory when backed with user \
-                defined memory regions."
-            );
-            return Err(Error::InvalidRestoreWithMemoryZones);
-        }
-
         let url = Url::parse(source_url).unwrap();
         /* url must be valid dir which is verified in recv_vm_snapshot() */
         let vm_snapshot_path = url.to_file_path().unwrap();
@@ -1534,13 +1522,6 @@ impl Snapshottable for MemoryManager {
     }
 
     fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
-        if self.use_zones {
-            return Err(MigratableError::Snapshot(anyhow!(
-                "Not allowed to snapshot guest memory when backed with user \
-                defined memory regions."
-            )));
-        }
-
         let mut memory_manager_snapshot = Snapshot::new(MEMORY_MANAGER_SNAPSHOT_ID);
         let guest_memory = self.guest_memory.memory();
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -64,7 +64,6 @@ pub struct MemoryManager {
     pub vm: Arc<dyn hypervisor::Vm>,
     hotplug_slots: Vec<HotPlugState>,
     selected_slot: usize,
-    backing_file: Option<PathBuf>,
     mergeable: bool,
     allocator: Arc<Mutex<SystemAllocator>>,
     hotplug_method: HotplugMethod,
@@ -371,7 +370,7 @@ impl MemoryManager {
 
             for region in ram_regions.iter() {
                 mem_regions.push(MemoryManager::create_ram_region(
-                    &config.file,
+                    &None,
                     0,
                     region.0,
                     region.1,
@@ -438,7 +437,7 @@ impl MemoryManager {
 
                 if !use_zones {
                     virtiomem_region = Some(MemoryManager::create_ram_region(
-                        &config.file,
+                        &None,
                         0,
                         start_addr,
                         size as usize,
@@ -490,7 +489,6 @@ impl MemoryManager {
             vm,
             hotplug_slots,
             selected_slot: 0,
-            backing_file: config.file.clone(),
             mergeable: config.mergeable,
             allocator: allocator.clone(),
             hotplug_method: config.hotplug_method.clone(),
@@ -791,7 +789,7 @@ impl MemoryManager {
 
         // Allocate memory for the region
         let region = MemoryManager::create_ram_region(
-            &self.backing_file,
+            &None,
             0,
             start_addr,
             size,

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1526,7 +1526,7 @@ impl Snapshottable for MemoryManager {
         MEMORY_MANAGER_SNAPSHOT_ID.to_string()
     }
 
-    fn snapshot(&self) -> result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         if self.use_zones {
             return Err(MigratableError::Snapshot(anyhow!(
                 "Not allowed to snapshot guest memory when backed with user \

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1267,7 +1267,7 @@ impl Snapshottable for Vm {
         VM_SNAPSHOT_ID.to_string()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let current_state = self.get_state().unwrap();
         if current_state != VmState::Paused {
             return Err(MigratableError::Snapshot(anyhow!(


### PR DESCRIPTION
The goal for this pull request is to introduce a new CLI/API option called `--memory-zone`. This new option works together with the existing `--memory` option, as it gives the user more control over the way the guest memory is backed from a host perspective.
This is an option dedicated for advanced users who want to push the limits of what is possible with Cloud-Hypervisor.

The use of `--memory-zone` will be allowed only when the memory size is 0. Here is a quick example how this option can be used:
```
--memory size=0 --memory-zone size=1G size=4G
```

Fixes #1601 