### PR TITLE
Enable quality checks for AArch64

### DIFF
--- a/.github/workflows/quality-aarch64.yaml
+++ b/.github/workflows/quality-aarch64.yaml
@@ -1,0 +1,40 @@
+name: Cloud Hypervisor Quality Checks
+on: [pull_request, create]
+
+jobs:
+  build:
+    if: github.event_name == 'pull_request'
+    name: Quality (clippy, rustfmt)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+        target:
+          - aarch64-unknown-linux-gnu
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v2
+      - name: Install Rust toolchain (${{ matrix.rust }})
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ matrix.rust }}
+            target: ${{ matrix.target }}
+            override: true
+            components: rustfmt, clippy
+      - name: Install arm64 libfdt
+        run: wget http://ftp.us.debian.org/debian/pool/main/d/device-tree-compiler/libfdt-dev_1.6.0-1_arm64.deb && dpkg-deb -xv libfdt-dev_1.6.0-1_arm64.deb ./tlibfdtdev && sudo mkdir /tmmmp && mkdir target && mkdir target/debug && mkdir target/debug/deps && sudo cp ./tlibfdtdev/usr/lib/aarch64-linux-gnu/libfdt.a target/debug/deps/libfdt.a && echo "libfdt installed"
+      - name: Formatting (rustfmt)
+        run: cargo fmt -- --check
+      - name: Clippy (mmio,kvm)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: clippy
+          args: --target=${{ matrix.target }} --no-default-features --features "mmio,kvm" -- -D warnings
+      - name: Clippy (pci,kvm)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: clippy
+          args: --target=${{ matrix.target }} --no-default-features --features "pci,kvm" -- -D warnings

--- a/arch/src/aarch64/gic.rs
+++ b/arch/src/aarch64/gic.rs
@@ -71,7 +71,7 @@ pub mod kvm {
         /// Setup the device-specific attributes
         fn init_device_attributes(
             vm: &Arc<dyn hypervisor::Vm>,
-            gic_device: &Box<dyn GICDevice>,
+            gic_device: &dyn GICDevice,
         ) -> Result<()>;
 
         /// Initialize a GIC device
@@ -95,10 +95,10 @@ pub mod kvm {
             flags: u32,
         ) -> Result<()> {
             let attr = kvm_bindings::kvm_device_attr {
-                group: group,
-                attr: attr,
-                addr: addr,
-                flags: flags,
+                group,
+                attr,
+                addr,
+                flags,
             };
             device
                 .set_device_attr(&attr)
@@ -108,7 +108,7 @@ pub mod kvm {
         }
 
         /// Finalize the setup of a GIC device
-        fn finalize_device(gic_device: &Box<dyn GICDevice>) -> Result<()> {
+        fn finalize_device(gic_device: &dyn GICDevice) -> Result<()> {
             /* We need to tell the kernel how many irqs to support with this vgic.
              * See the `layout` module for details.
              */
@@ -142,9 +142,9 @@ pub mod kvm {
 
             let device = Self::create_device(vgic_fd, vcpu_count);
 
-            Self::init_device_attributes(vm, &device)?;
+            Self::init_device_attributes(vm, &*device)?;
 
-            Self::finalize_device(&device)?;
+            Self::finalize_device(&*device)?;
 
             Ok(device)
         }

--- a/arch/src/aarch64/gicv2.rs
+++ b/arch/src/aarch64/gicv2.rs
@@ -84,20 +84,20 @@ pub mod kvm {
             vcpu_count: u64,
         ) -> Box<dyn GICDevice> {
             Box::new(KvmGICv2 {
-                device: device,
+                device,
                 properties: [
                     KvmGICv2::get_dist_addr(),
                     KvmGICv2::get_dist_size(),
                     KvmGICv2::get_cpu_addr(),
                     KvmGICv2::get_cpu_size(),
                 ],
-                vcpu_count: vcpu_count,
+                vcpu_count,
             })
         }
 
         fn init_device_attributes(
             _vm: &Arc<dyn hypervisor::Vm>,
-            gic_device: &Box<dyn GICDevice>,
+            gic_device: &dyn GICDevice,
         ) -> Result<()> {
             /* Setting up the distributor attribute.
             We are placing the GIC below 1GB so we need to substract the size of the distributor. */

--- a/arch/src/aarch64/gicv3.rs
+++ b/arch/src/aarch64/gicv3.rs
@@ -84,20 +84,20 @@ pub mod kvm {
             vcpu_count: u64,
         ) -> Box<dyn GICDevice> {
             Box::new(KvmGICv3 {
-                device: device,
+                device,
                 properties: [
                     KvmGICv3::get_dist_addr(),
                     KvmGICv3::get_dist_size(),
                     KvmGICv3::get_redists_addr(vcpu_count),
                     KvmGICv3::get_redists_size(vcpu_count),
                 ],
-                vcpu_count: vcpu_count,
+                vcpu_count,
             })
         }
 
         fn init_device_attributes(
             _vm: &Arc<dyn hypervisor::Vm>,
-            gic_device: &Box<dyn GICDevice>,
+            gic_device: &dyn GICDevice,
         ) -> Result<()> {
             /* Setting up the distributor attribute.
              We are placing the GIC below 1GB so we need to substract the size of the distributor.
@@ -117,8 +117,7 @@ pub mod kvm {
                 gic_device.device(),
                 kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
                 u64::from(kvm_bindings::KVM_VGIC_V3_ADDR_TYPE_REDIST),
-                &KvmGICv3::get_redists_addr(u64::from(gic_device.vcpu_count())) as *const u64
-                    as u64,
+                &KvmGICv3::get_redists_addr(gic_device.vcpu_count()) as *const u64 as u64,
                 0,
             )?;
 

--- a/arch/src/aarch64/gicv3_its.rs
+++ b/arch/src/aarch64/gicv3_its.rs
@@ -80,7 +80,7 @@ pub mod kvm {
             vcpu_count: u64,
         ) -> Box<dyn GICDevice> {
             Box::new(KvmGICv3ITS {
-                device: device,
+                device,
                 gic_properties: [
                     KvmGICv3::get_dist_addr(),
                     KvmGICv3::get_dist_size(),
@@ -91,13 +91,13 @@ pub mod kvm {
                     KvmGICv3ITS::get_msi_addr(vcpu_count),
                     KvmGICv3ITS::get_msi_size(),
                 ],
-                vcpu_count: vcpu_count,
+                vcpu_count,
             })
         }
 
         fn init_device_attributes(
             vm: &Arc<dyn hypervisor::Vm>,
-            gic_device: &Box<dyn GICDevice>,
+            gic_device: &dyn GICDevice,
         ) -> Result<()> {
             KvmGICv3::init_device_attributes(vm, gic_device)?;
 
@@ -115,7 +115,7 @@ pub mod kvm {
                 &its_fd,
                 kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
                 u64::from(kvm_bindings::KVM_VGIC_ITS_ADDR_TYPE),
-                &KvmGICv3ITS::get_msi_addr(u64::from(gic_device.vcpu_count())) as *const u64 as u64,
+                &KvmGICv3ITS::get_msi_addr(gic_device.vcpu_count()) as *const u64 as u64,
                 0,
             )?;
 

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -136,13 +136,14 @@ pub fn arch_memory_regions(size: GuestUsize) -> Vec<(GuestAddress, usize, Region
 ///
 /// * `guest_mem` - The memory to be used by the guest.
 /// * `num_cpus` - Number of virtual CPUs the guest will have.
-pub fn configure_system<T: DeviceInfoForFDT + Clone + Debug>(
+#[allow(clippy::too_many_arguments)]
+pub fn configure_system<T: DeviceInfoForFDT + Clone + Debug, S: ::std::hash::BuildHasher>(
     vm: &Arc<dyn hypervisor::Vm>,
     guest_mem: &GuestMemoryMmap,
     cmdline_cstring: &CStr,
     vcpu_count: u64,
     vcpu_mpidr: Vec<u64>,
-    device_info: &HashMap<(DeviceType, String), T>,
+    device_info: &HashMap<(DeviceType, String), T, S>,
     initrd: &Option<super::InitramfsConfig>,
     pci_space_address: &Option<(u64, u64)>,
 ) -> super::Result<()> {
@@ -157,7 +158,7 @@ pub fn configure_system<T: DeviceInfoForFDT + Clone + Debug>(
         cmdline_cstring,
         vcpu_mpidr,
         device_info,
-        &gic_device,
+        &*gic_device,
         initrd,
         pci_space_address,
     )

--- a/arch/src/aarch64/regs.rs
+++ b/arch/src/aarch64/regs.rs
@@ -52,7 +52,7 @@ const PSTATE_FAULT_BITS_64: u64 = PSR_MODE_EL1h | PSR_A_BIT | PSR_F_BIT | PSR_I_
 // we're just doing pointer math on it, so in theory, it should safe.
 macro_rules! offset__of {
     ($str:ty, $field:ident) => {
-        unsafe { &(*(0 as *const $str)).$field as *const _ as usize }
+        unsafe { &(*std::ptr::null::<user_pt_regs>()).$field as *const _ as usize }
     };
 }
 

--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -47,8 +47,7 @@ impl Gic {
 
 impl InterruptController for Gic {
     fn enable(&self) -> Result<()> {
-        &self
-            .interrupt_source_group
+        self.interrupt_source_group
             .enable()
             .map_err(Error::EnableInterrupt)?;
         Ok(())

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -949,6 +949,7 @@ impl cpu::Vcpu for KvmVcpu {
     #[allow(unused_variables)]
     #[cfg(target_arch = "aarch64")]
     fn set_state(&self, state: &CpuState) -> cpu::Result<()> {
+        warn!("CPU state was not restored");
         Ok(())
     }
 }

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -6,7 +6,6 @@ BUILD_TARGET=${BUILD_TARGET-x86_64-unknown-linux-gnu}
 cargo_args=("$@")
 [ $(uname -m) = "aarch64" ] && cargo_args+=("--no-default-features")
 [ $(uname -m) = "aarch64" ] && cargo_args+=("--features mmio,kvm")
-[ $(uname -m) = "aarch64" ] && sed -i 's/"with-serde",\ //g' hypervisor/Cargo.toml
 
 cargo test --target $BUILD_TARGET --workspace --no-run ${cargo_args[@]}
 pushd target/$BUILD_TARGET/debug

--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
-#[cfg(target_arch = "aarch64")]
-use arch;
 #[cfg(target_arch = "x86_64")]
 use std::collections::btree_map::BTreeMap;
 use std::result;
@@ -65,6 +63,7 @@ impl GsiAllocator {
     }
 
     #[cfg(target_arch = "aarch64")]
+    #[allow(clippy::new_without_default)]
     /// New GSI allocator
     pub fn new() -> Self {
         GsiAllocator {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -981,12 +981,10 @@ impl CpuManager {
 
     #[cfg(target_arch = "aarch64")]
     pub fn get_mpidrs(&self) -> Vec<u64> {
-        let vcpu_mpidrs = self
-            .vcpus
+        self.vcpus
             .iter()
             .map(|cpu| cpu.lock().unwrap().get_mpidr())
-            .collect();
-        vcpu_mpidrs
+            .collect()
     }
 
     #[cfg(feature = "acpi")]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1356,7 +1356,7 @@ impl DeviceManager {
 
         self.address_manager
             .mmio_bus
-            .insert(rtc_device.clone(), addr.0, MMIO_LEN)
+            .insert(rtc_device, addr.0, MMIO_LEN)
             .map_err(DeviceManagerError::BusError)?;
 
         self.id_to_dev_info.insert(

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -604,6 +604,7 @@ impl MemoryManager {
     // If the next area is hotplugged RAM, the start address needs to be aligned
     // to 128MiB boundary, and a gap of 256MiB need to be set before it.
     // On x86_64, it must also start at the 64bit start.
+    #[allow(clippy::let_and_return)]
     fn start_addr(mem_end: GuestAddress, with_gap: bool) -> GuestAddress {
         let start_addr = if with_gap {
             GuestAddress((mem_end.0 + 1 + (256 << 20)) & !((128 << 20) - 1))

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -401,7 +401,7 @@ impl Vm {
         #[cfg(target_arch = "x86_64")]
         vm.enable_split_irq().unwrap();
         let vm_snapshot = get_vm_snapshot(snapshot).map_err(Error::Restore)?;
-        let config = vm_snapshot.config.clone();
+        let config = vm_snapshot.config;
         if let Some(state) = vm_snapshot.state {
             vm.set_state(&state)
                 .map_err(|e| Error::Restore(MigratableError::Restore(e.into())))?;
@@ -1576,7 +1576,7 @@ mod tests {
             &CString::new("console=tty0").unwrap(),
             vec![0],
             &dev_info,
-            &gic,
+            &*gic,
             &None,
             &None,
         )


### PR DESCRIPTION
Added quality check workflow for AArch64;
Fixed all clippy warnings;
Removed the workaround for "with-serde" in unit tests script, by the way.