### PR TITLE
vmm: Support snapshot/restore with user defined regions

### DIFF
--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -70,7 +70,7 @@ impl Snapshottable for Gic {
         GIC_SNAPSHOT_ID.to_string()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         unimplemented!();
     }
 

--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -405,7 +405,7 @@ impl Snapshottable for Ioapic {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -289,7 +289,7 @@ impl Snapshottable for Serial {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -889,7 +889,7 @@ impl Snapshottable for PciConfiguration {
         String::from("pci_configuration")
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -437,7 +437,7 @@ impl Snapshottable for MsixConfig {
         String::from("msix_config")
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,18 @@ fn create_app<'a, 'b>(
                 .group("vm-config"),
         )
         .arg(
+            Arg::with_name("memory-region")
+                .long("memory-region")
+                .help(
+                    "Custom memory region parameters \
+                     \"size=<guest_memory_region_size>,file=<backing_file>,\
+                     mergeable=on|off,shared=on|off,hugepages=on|off\"",
+                )
+                .takes_value(true)
+                .min_values(1)
+                .group("vm-config"),
+        )
+        .arg(
             Arg::with_name("kernel")
                 .long("kernel")
                 .help("Path to kernel image (vmlinux)")
@@ -522,6 +534,7 @@ mod unit_tests {
                     hugepages: false,
                     balloon: false,
                     balloon_size: 0,
+                    regions: None,
                 },
                 kernel: Some(KernelConfig {
                     path: PathBuf::from("/path/to/kernel"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -526,7 +526,6 @@ mod unit_tests {
                 },
                 memory: MemoryConfig {
                     size: 536_870_912,
-                    file: None,
                     mergeable: false,
                     hotplug_method: HotplugMethod::Acpi,
                     hotplug_size: None,

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -620,7 +620,7 @@ impl<T: 'static + DiskFile + Send> Snapshottable for Block<T> {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/block_io_uring.rs
+++ b/virtio-devices/src/block_io_uring.rs
@@ -670,7 +670,7 @@ impl Snapshottable for BlockIoUring {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -552,7 +552,7 @@ impl Snapshottable for Console {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -1016,7 +1016,7 @@ impl Snapshottable for Iommu {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -565,7 +565,7 @@ impl Snapshottable for Net {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -524,7 +524,7 @@ impl Snapshottable for Pmem {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -348,7 +348,7 @@ impl Snapshottable for Rng {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/transport/mmio.rs
+++ b/virtio-devices/src/transport/mmio.rs
@@ -462,7 +462,7 @@ impl Snapshottable for MmioDevice {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -290,7 +290,7 @@ impl Snapshottable for VirtioPciCommonConfig {
         String::from("virtio_pci_common_config")
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1040,7 +1040,7 @@ impl Snapshottable for VirtioPciDevice {
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -535,7 +535,7 @@ where
         self.id.clone()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot =
             serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
 

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -111,7 +111,7 @@ pub trait Snapshottable: Pausable {
     }
 
     /// Take a component snapshot.
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         Ok(Snapshot::new(""))
     }
 

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -448,6 +448,27 @@ components:
         topology:
             $ref: '#/components/schemas/CpuTopology'
 
+    MemoryRegionConfig:
+      required:
+      - size
+      type: object
+      properties:
+        size:
+          type: integer
+          format: int64
+          default: 512 MB
+        file:
+          type: string
+        mergeable:
+          type: boolean
+          default: false
+        shared:
+          type: boolean
+          default: false
+        hugepages:
+          type: boolean
+          default: false
+
     MemoryConfig:
       required:
       - size
@@ -477,6 +498,10 @@ components:
         balloon:
           type: boolean
           default: false
+        regions:
+          type: array
+          items:
+            $ref: '#/components/schemas/MemoryRegionConfig'
 
     KernelConfig:
       required:

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -481,8 +481,6 @@ components:
         hotplug_size:
           type: integer
           format: int64
-        file:
-          type: string
         mergeable:
           type: boolean
           default: false

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -361,8 +361,6 @@ pub struct MemoryRegionConfig {
 pub struct MemoryConfig {
     pub size: u64,
     #[serde(default)]
-    pub file: Option<PathBuf>,
-    #[serde(default)]
     pub mergeable: bool,
     #[serde(default)]
     pub hotplug_method: HotplugMethod,
@@ -399,7 +397,6 @@ impl MemoryConfig {
             .map_err(Error::ParseMemory)?
             .unwrap_or(ByteSized(DEFAULT_MEMORY_MB << 20))
             .0;
-        let file = parser.get("file").map(PathBuf::from);
         let mergeable = parser
             .convert::<Toggle>("mergeable")
             .map_err(Error::ParseMemory)?
@@ -481,7 +478,6 @@ impl MemoryConfig {
 
         Ok(MemoryConfig {
             size,
-            file,
             mergeable,
             hotplug_method,
             hotplug_size,
@@ -498,7 +494,6 @@ impl Default for MemoryConfig {
     fn default() -> Self {
         MemoryConfig {
             size: DEFAULT_MEMORY_MB << 20,
-            file: None,
             mergeable: false,
             hotplug_method: HotplugMethod::Acpi,
             hotplug_size: None,
@@ -1292,10 +1287,6 @@ impl VmConfig {
             return Err(ValidationError::CpusMaxLowerThanBoot);
         }
 
-        if self.memory.file.is_some() {
-            error!("Use of backing file ('--memory file=') is deprecated. Use the 'shared' and 'hugepages' controls.");
-        }
-
         if let Some(disks) = &self.disks {
             for disk in disks {
                 if disk.vhost_socket.as_ref().and(disk.path.as_ref()).is_some() {
@@ -1565,7 +1556,6 @@ mod tests {
             MemoryConfig::parse("size=512M,file=/some/file", None)?,
             MemoryConfig {
                 size: 512 << 20,
-                file: Some(PathBuf::from("/some/file")),
                 ..Default::default()
             }
         );
@@ -2020,7 +2010,6 @@ mod tests {
             },
             memory: MemoryConfig {
                 size: 536_870_912,
-                file: None,
                 mergeable: false,
                 hotplug_method: HotplugMethod::Acpi,
                 hotplug_size: None,

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -400,7 +400,7 @@ impl Snapshottable for Vcpu {
         VCPU_SNAPSHOT_ID.to_string()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let snapshot = serde_json::to_vec(&self.saved_state)
             .map_err(|e| MigratableError::Snapshot(e.into()))?;
 
@@ -1368,7 +1368,7 @@ impl Snapshottable for CpuManager {
         CPU_MANAGER_SNAPSHOT_ID.to_string()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let mut cpu_manager_snapshot = Snapshot::new(CPU_MANAGER_SNAPSHOT_ID);
 
         // The CpuManager snapshot is a collection of all vCPUs snapshots.

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3628,7 +3628,7 @@ impl Snapshottable for DeviceManager {
         DEVICE_MANAGER_SNAPSHOT_ID.to_string()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let mut snapshot = Snapshot::new(DEVICE_MANAGER_SNAPSHOT_ID);
 
         // We aggregate all devices snapshots.

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -168,10 +168,6 @@ pub enum Error {
     /// Forbidden operation. Impossible to resize guest memory if it is
     /// backed by user defined memory regions.
     InvalidResizeWithCustomMemoryRegions,
-
-    /// Forbidden operation. Impossible to restore guest memory if it is
-    /// backed by user defined memory regions.
-    InvalidRestoreWithCustomMemoryRegions,
 }
 
 const ENABLE_FLAG: usize = 0;
@@ -560,14 +556,6 @@ impl MemoryManager {
         source_url: &str,
         prefault: bool,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
-        if config.size == 0 {
-            error!(
-                "Not allowed to restore guest memory when backed with user \
-                defined memory regions."
-            );
-            return Err(Error::InvalidRestoreWithCustomMemoryRegions);
-        }
-
         let url = Url::parse(source_url).unwrap();
         /* url must be valid dir which is verified in recv_vm_snapshot() */
         let vm_snapshot_path = url.to_file_path().unwrap();
@@ -1536,13 +1524,6 @@ impl Snapshottable for MemoryManager {
     }
 
     fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
-        if self.use_custom_regions {
-            return Err(MigratableError::Snapshot(anyhow!(
-                "Not allowed to snapshot guest memory when backed with user \
-                defined memory regions."
-            )));
-        }
-
         let mut memory_manager_snapshot = Snapshot::new(MEMORY_MANAGER_SNAPSHOT_ID);
         let guest_memory = self.guest_memory.memory();
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -66,7 +66,6 @@ pub struct MemoryManager {
     pub vm: Arc<dyn hypervisor::Vm>,
     hotplug_slots: Vec<HotPlugState>,
     selected_slot: usize,
-    backing_file: Option<PathBuf>,
     mergeable: bool,
     allocator: Arc<Mutex<SystemAllocator>>,
     hotplug_method: HotplugMethod,
@@ -373,7 +372,7 @@ impl MemoryManager {
 
             for region in ram_regions.iter() {
                 mem_regions.push(MemoryManager::create_ram_region(
-                    &config.file,
+                    &None,
                     0,
                     region.0,
                     region.1,
@@ -440,7 +439,7 @@ impl MemoryManager {
 
                 if !use_custom_regions {
                     virtiomem_region = Some(MemoryManager::create_ram_region(
-                        &config.file,
+                        &None,
                         0,
                         start_addr,
                         size as usize,
@@ -492,7 +491,6 @@ impl MemoryManager {
             vm,
             hotplug_slots,
             selected_slot: 0,
-            backing_file: config.file.clone(),
             mergeable: config.mergeable,
             allocator: allocator.clone(),
             hotplug_method: config.hotplug_method.clone(),
@@ -793,7 +791,7 @@ impl MemoryManager {
 
         // Allocate memory for the region
         let region = MemoryManager::create_ram_region(
-            &self.backing_file,
+            &None,
             0,
             start_addr,
             size,

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -82,6 +82,7 @@ pub struct MemoryManager {
     #[cfg(target_arch = "x86_64")]
     sgx_epc_region: Option<SgxEpcRegion>,
     use_custom_regions: bool,
+    snapshot_memory_regions: Vec<MemoryRegion>,
 }
 
 #[derive(Debug)]
@@ -528,6 +529,7 @@ impl MemoryManager {
             #[cfg(target_arch = "x86_64")]
             sgx_epc_region: None,
             use_custom_regions,
+            snapshot_memory_regions: Vec::new(),
         }));
 
         guest_memory.memory().with_regions(|_, region| {
@@ -1141,6 +1143,17 @@ impl MemoryManager {
     pub fn sgx_epc_region(&self) -> &Option<SgxEpcRegion> {
         &self.sgx_epc_region
     }
+
+    pub fn file_backed_with_hardlink(f: &File) -> bool {
+        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+        let ret = unsafe { libc::fstat(f.as_raw_fd(), stat.as_mut_ptr()) };
+        if ret != 0 {
+            error!("Couldn't fstat the backing file");
+            return false;
+        }
+
+        unsafe { (*stat.as_ptr()).st_nlink as usize > 0 }
+    }
 }
 
 #[cfg(feature = "acpi")]
@@ -1518,7 +1531,7 @@ impl Pausable for MemoryManager {}
 #[serde(remote = "GuestAddress")]
 pub struct GuestAddressDef(pub u64);
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct MemoryRegion {
     backing_file: Option<PathBuf>,
     #[serde(with = "GuestAddressDef")]
@@ -1547,21 +1560,43 @@ impl Snapshottable for MemoryManager {
         let mut memory_manager_snapshot = Snapshot::new(MEMORY_MANAGER_SNAPSHOT_ID);
         let guest_memory = self.guest_memory.memory();
 
-        let mut memory_regions: Vec<MemoryRegion> = Vec::with_capacity(10);
+        let mut memory_regions: Vec<MemoryRegion> = Vec::new();
 
         guest_memory.with_regions_mut(|index, region| {
             if region.len() == 0 {
                 return Err(MigratableError::Snapshot(anyhow!("Zero length region")));
             }
 
+            let mut backing_file = Some(PathBuf::from(format!("memory-region-{}", index)));
+            if let Some(file_offset) = region.file_offset() {
+                if (region.flags() & libc::MAP_SHARED == libc::MAP_SHARED)
+                    && Self::file_backed_with_hardlink(file_offset.file())
+                {
+                    // In this very specific case, we know the memory region
+                    // is backed by a file on the host filesystem that can be
+                    // accessed by the user, and additionally the mapping is
+                    // shared, which means that modifications to the content
+                    // are written to the actual file.
+                    // When meeting these conditions, we can skip the copy of
+                    // the memory content for this specific region, as we can
+                    // assume the user will have it saved through the backing
+                    // file already.
+                    backing_file = None;
+                }
+            }
+
             memory_regions.push(MemoryRegion {
-                backing_file: Some(PathBuf::from(format!("memory-region-{}", index))),
+                backing_file,
                 start_addr: region.start_addr(),
                 size: region.len(),
             });
 
             Ok(())
         })?;
+
+        // Store locally this list of regions as it will be used through the
+        // Transportable::send() implementation.
+        self.snapshot_memory_regions = memory_regions.clone();
 
         let snapshot_data_section =
             serde_json::to_vec(&MemoryManagerSnapshotData { memory_regions })
@@ -1608,28 +1643,28 @@ impl Transportable for MemoryManager {
                     })?;
 
                 if let Some(guest_memory) = &*self.snapshot.lock().unwrap() {
-                    guest_memory.with_regions_mut(|index, region| {
-                        let mut memory_region_path = vm_memory_snapshot_path.clone();
-                        memory_region_path.push(format!("memory-region-{}", index));
+                    for region in self.snapshot_memory_regions.iter() {
+                        if let Some(backing_file) = &region.backing_file {
+                            let mut memory_region_path = vm_memory_snapshot_path.clone();
+                            memory_region_path.push(backing_file);
 
-                        // Create the snapshot file for the region
-                        let mut memory_region_file = OpenOptions::new()
-                            .read(true)
-                            .write(true)
-                            .create_new(true)
-                            .open(memory_region_path)
-                            .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+                            // Create the snapshot file for the region
+                            let mut memory_region_file = OpenOptions::new()
+                                .read(true)
+                                .write(true)
+                                .create_new(true)
+                                .open(memory_region_path)
+                                .map_err(|e| MigratableError::MigrateSend(e.into()))?;
 
-                        guest_memory
-                            .write_to(
-                                region.start_addr(),
-                                &mut memory_region_file,
-                                region.len().try_into().unwrap(),
-                            )
-                            .map_err(|e| MigratableError::MigrateSend(e.into()))?;
-
-                        Ok(())
-                    })?;
+                            guest_memory
+                                .write_to(
+                                    region.start_addr,
+                                    &mut memory_region_file,
+                                    region.size as usize,
+                                )
+                                .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+                        }
+                    }
                 }
             }
             _ => {

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -5,7 +5,7 @@
 extern crate hypervisor;
 #[cfg(target_arch = "x86_64")]
 use crate::config::SgxEpcConfig;
-use crate::config::{HotplugMethod, MemoryConfig};
+use crate::config::{HotplugMethod, MemoryConfig, MemoryRegionConfig};
 use crate::MEMORY_MANAGER_SNAPSHOT_ID;
 #[cfg(feature = "acpi")]
 use acpi_tables::{aml, aml::Aml};
@@ -81,6 +81,7 @@ pub struct MemoryManager {
     balloon: Option<Arc<Mutex<virtio_devices::Balloon>>>,
     #[cfg(target_arch = "x86_64")]
     sgx_epc_region: Option<SgxEpcRegion>,
+    use_custom_regions: bool,
 }
 
 #[derive(Debug)]
@@ -156,6 +157,20 @@ pub enum Error {
     /// Failed creating a new MmapRegion instance.
     #[cfg(target_arch = "x86_64")]
     NewMmapRegion(vm_memory::mmap::MmapRegionError),
+
+    /// No custom memory regions found.
+    MissingMemoryRegions,
+
+    /// Memory configuration is not valid.
+    InvalidMemoryParameters,
+
+    /// Forbidden operation. Impossible to resize guest memory if it is
+    /// backed by user defined memory regions.
+    InvalidResizeWithCustomMemoryRegions,
+
+    /// Forbidden operation. Impossible to restore guest memory if it is
+    /// backed by user defined memory regions.
+    InvalidRestoreWithCustomMemoryRegions,
 }
 
 const ENABLE_FLAG: usize = 0;
@@ -246,52 +261,183 @@ impl BusDevice for MemoryManager {
 }
 
 impl MemoryManager {
+    /// Creates all memory regions based on the available RAM ranges defined
+    /// by `ram_regions`, and based on the description of the custom regions.
+    /// In practice, this function can perform multiple memory mappings of the
+    /// same backing file if there's a hole in the address space between two
+    /// RAM ranges.
+    /// One example might be ram_regions containing 2 regions (0-3G and 4G-6G)
+    /// and custom_regions containing two regions (size 1G and size 4G).
+    /// This function will create 3 resulting regions:
+    /// - First one mapping entirely the first custom region on 0-1G range
+    /// - Second one mapping partially the second custom region on 1G-3G range
+    /// - Third one mapping partially the second custom region on 4G-6G range
+    fn create_memory_regions_from_custom_regions(
+        ram_regions: &[(GuestAddress, usize)],
+        custom_regions: &[MemoryRegionConfig],
+        prefault: bool,
+    ) -> Result<Vec<Arc<GuestRegionMmap>>, Error> {
+        let mut custom_regions = custom_regions.to_owned();
+        let mut mem_regions = Vec::new();
+        let mut custom_region = custom_regions.remove(0);
+        let mut custom_region_offset = 0;
+
+        for ram_region in ram_regions.iter() {
+            let mut ram_region_offset = 0;
+            let mut exit = false;
+
+            loop {
+                let mut ram_region_consumed = false;
+                let mut pull_next_custom_region = false;
+
+                let ram_region_sub_size = ram_region.1 - ram_region_offset;
+                let custom_region_sub_size = custom_region.size as usize - custom_region_offset;
+
+                let file_offset = custom_region_offset as u64;
+                let region_start = ram_region.0.unchecked_add(ram_region_offset as u64);
+                let region_size = if custom_region_sub_size <= ram_region_sub_size {
+                    if custom_region_sub_size == ram_region_sub_size {
+                        ram_region_consumed = true;
+                    }
+
+                    ram_region_offset += custom_region_sub_size;
+                    pull_next_custom_region = true;
+
+                    custom_region_sub_size
+                } else {
+                    custom_region_offset += ram_region_sub_size;
+                    ram_region_consumed = true;
+
+                    ram_region_sub_size
+                };
+
+                mem_regions.push(MemoryManager::create_ram_region(
+                    &custom_region.file,
+                    file_offset,
+                    region_start,
+                    region_size,
+                    false,
+                    prefault,
+                    custom_region.shared,
+                    custom_region.hugepages,
+                )?);
+
+                if pull_next_custom_region {
+                    // Get the next custom region and reset the offset.
+                    custom_region_offset = 0;
+                    if custom_regions.is_empty() {
+                        exit = true;
+                        break;
+                    }
+                    custom_region = custom_regions.remove(0);
+                }
+
+                if ram_region_consumed {
+                    break;
+                }
+            }
+
+            if exit {
+                break;
+            }
+        }
+
+        Ok(mem_regions)
+    }
+
     pub fn new(
         vm: Arc<dyn hypervisor::Vm>,
         config: &MemoryConfig,
         ext_regions: Option<Vec<MemoryRegion>>,
         prefault: bool,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
-        // Init guest memory
-        let arch_mem_regions = arch::arch_memory_regions(config.size);
-
-        let ram_regions: Vec<(GuestAddress, usize)> = arch_mem_regions
-            .iter()
-            .filter(|r| r.2 == RegionType::Ram)
-            .map(|r| (r.0, r.1))
-            .collect();
-
         let mut mem_regions = Vec::new();
-        if let Some(ext_regions) = &ext_regions {
-            if ram_regions.len() > ext_regions.len() {
-                return Err(Error::InvalidAmountExternalBackingFiles);
+        let arch_mem_regions: Vec<(GuestAddress, usize, RegionType)>;
+        let use_custom_regions = config.size == 0;
+
+        if !use_custom_regions {
+            if config.regions.is_some() {
+                error!(
+                    "User defined memory regions can't be provided if the \
+                    memory size is not 0"
+                );
+                return Err(Error::InvalidMemoryParameters);
             }
 
-            for region in ext_regions.iter() {
-                mem_regions.push(MemoryManager::create_ram_region(
-                    &Some(region.backing_file.clone()),
-                    0,
-                    region.start_addr,
-                    region.size as usize,
-                    true,
-                    prefault,
-                    false,
-                    false,
-                )?);
+            // Init guest memory
+            arch_mem_regions = arch::arch_memory_regions(config.size);
+
+            let ram_regions: Vec<(GuestAddress, usize)> = arch_mem_regions
+                .iter()
+                .filter(|r| r.2 == RegionType::Ram)
+                .map(|r| (r.0, r.1))
+                .collect();
+
+            if let Some(ext_regions) = &ext_regions {
+                if ram_regions.len() > ext_regions.len() {
+                    return Err(Error::InvalidAmountExternalBackingFiles);
+                }
+
+                for region in ext_regions.iter() {
+                    mem_regions.push(MemoryManager::create_ram_region(
+                        &Some(region.backing_file.clone()),
+                        0,
+                        region.start_addr,
+                        region.size as usize,
+                        true,
+                        prefault,
+                        false,
+                        false,
+                    )?);
+                }
+            } else {
+                for region in ram_regions.iter() {
+                    mem_regions.push(MemoryManager::create_ram_region(
+                        &config.file,
+                        0,
+                        region.0,
+                        region.1,
+                        false,
+                        prefault,
+                        config.shared,
+                        config.hugepages,
+                    )?);
+                }
             }
         } else {
-            for region in ram_regions.iter() {
-                mem_regions.push(MemoryManager::create_ram_region(
-                    &config.file,
-                    0,
-                    region.0,
-                    region.1,
-                    false,
-                    prefault,
-                    config.shared,
-                    config.hugepages,
-                )?);
+            if config.regions.is_none() {
+                error!(
+                    "User defined memory regions must be provided if the \
+                    memory size is 0"
+                );
+                return Err(Error::MissingMemoryRegions);
             }
+
+            // Safe to unwrap as we checked right above there were some
+            // regions.
+            let custom_regions = config.regions.clone().unwrap();
+            if custom_regions.is_empty() {
+                return Err(Error::MissingMemoryRegions);
+            }
+
+            let mut total_ram_size: u64 = 0;
+            for custom_region in custom_regions.iter() {
+                total_ram_size += custom_region.size;
+            }
+
+            arch_mem_regions = arch::arch_memory_regions(total_ram_size as GuestUsize);
+
+            let ram_regions: Vec<(GuestAddress, usize)> = arch_mem_regions
+                .iter()
+                .filter(|r| r.2 == RegionType::Ram)
+                .map(|r| (r.0, r.1))
+                .collect();
+
+            mem_regions = Self::create_memory_regions_from_custom_regions(
+                &ram_regions,
+                &custom_regions,
+                prefault,
+            )?;
         }
 
         let guest_memory =
@@ -311,16 +457,19 @@ impl MemoryManager {
                         / virtio_devices::VIRTIO_MEM_DEFAULT_BLOCK_SIZE
                         * virtio_devices::VIRTIO_MEM_DEFAULT_BLOCK_SIZE,
                 );
-                virtiomem_region = Some(MemoryManager::create_ram_region(
-                    &config.file,
-                    0,
-                    start_addr,
-                    size as usize,
-                    false,
-                    false,
-                    config.shared,
-                    config.hugepages,
-                )?);
+
+                if !use_custom_regions {
+                    virtiomem_region = Some(MemoryManager::create_ram_region(
+                        &config.file,
+                        0,
+                        start_addr,
+                        size as usize,
+                        false,
+                        false,
+                        config.shared,
+                        config.hugepages,
+                    )?);
+                }
 
                 virtiomem_resize = Some(virtio_devices::Resize::new().map_err(Error::EventFdFail)?);
 
@@ -378,6 +527,7 @@ impl MemoryManager {
             balloon: None,
             #[cfg(target_arch = "x86_64")]
             sgx_epc_region: None,
+            use_custom_regions,
         }));
 
         guest_memory.memory().with_regions(|_, region| {
@@ -425,6 +575,14 @@ impl MemoryManager {
         source_url: &str,
         prefault: bool,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
+        if config.size == 0 {
+            error!(
+                "Not allowed to restore guest memory when backed with user \
+                defined memory regions."
+            );
+            return Err(Error::InvalidRestoreWithCustomMemoryRegions);
+        }
+
         let url = Url::parse(source_url).unwrap();
         /* url must be valid dir which is verified in recv_vm_snapshot() */
         let vm_snapshot_path = url.to_file_path().unwrap();
@@ -863,6 +1021,15 @@ impl MemoryManager {
     /// use case never adds a new region as the whole hotpluggable memory has
     /// already been allocated at boot time.
     pub fn resize(&mut self, desired_ram: u64) -> Result<Option<Arc<GuestRegionMmap>>, Error> {
+        if self.use_custom_regions {
+            error!(
+                "Not allowed to resize guest memory when backed with user \
+                defined memory regions.\n Try adding new memory regions \
+                instead."
+            );
+            return Err(Error::InvalidResizeWithCustomMemoryRegions);
+        }
+
         let mut region: Option<Arc<GuestRegionMmap>> = None;
         match self.hotplug_method {
             HotplugMethod::VirtioMem => {
@@ -1364,6 +1531,13 @@ impl Snapshottable for MemoryManager {
     }
 
     fn snapshot(&self) -> result::Result<Snapshot, MigratableError> {
+        if self.use_custom_regions {
+            return Err(MigratableError::Snapshot(anyhow!(
+                "Not allowed to snapshot guest memory when backed with user \
+                defined memory regions."
+            )));
+        }
+
         let mut memory_manager_snapshot = Snapshot::new(MEMORY_MANAGER_SNAPSHOT_ID);
         let guest_memory = self.guest_memory.memory();
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1530,7 +1530,7 @@ impl Snapshottable for MemoryManager {
         MEMORY_MANAGER_SNAPSHOT_ID.to_string()
     }
 
-    fn snapshot(&self) -> result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
         if self.use_custom_regions {
             return Err(MigratableError::Snapshot(anyhow!(
                 "Not allowed to snapshot guest memory when backed with user \

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -613,11 +613,9 @@ impl MemoryManager {
         };
 
         #[cfg(target_arch = "x86_64")]
-        let start_addr = if mem_end < arch::layout::MEM_32BIT_RESERVED_START {
-            arch::layout::RAM_64BIT_START
-        } else {
-            start_addr
-        };
+        if mem_end < arch::layout::MEM_32BIT_RESERVED_START {
+            return arch::layout::RAM_64BIT_START;
+        }
 
         start_addr
     }

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -277,6 +277,7 @@ impl MemoryManager {
         ram_regions: &[(GuestAddress, usize)],
         custom_regions: &[MemoryRegionConfig],
         prefault: bool,
+        ext_regions: Option<Vec<MemoryRegion>>,
     ) -> Result<Vec<Arc<GuestRegionMmap>>, Error> {
         let mut custom_regions = custom_regions.to_owned();
         let mut mem_regions = Vec::new();
@@ -317,10 +318,10 @@ impl MemoryManager {
                     file_offset,
                     region_start,
                     region_size,
-                    false,
                     prefault,
                     custom_region.shared,
                     custom_region.hugepages,
+                    &ext_regions,
                 )?);
 
                 if pull_next_custom_region {
@@ -374,36 +375,17 @@ impl MemoryManager {
                 .map(|r| (r.0, r.1))
                 .collect();
 
-            if let Some(ext_regions) = &ext_regions {
-                if ram_regions.len() > ext_regions.len() {
-                    return Err(Error::InvalidAmountExternalBackingFiles);
-                }
-
-                for region in ext_regions.iter() {
-                    mem_regions.push(MemoryManager::create_ram_region(
-                        &region.backing_file,
-                        0,
-                        region.start_addr,
-                        region.size as usize,
-                        true,
-                        prefault,
-                        false,
-                        false,
-                    )?);
-                }
-            } else {
-                for region in ram_regions.iter() {
-                    mem_regions.push(MemoryManager::create_ram_region(
-                        &config.file,
-                        0,
-                        region.0,
-                        region.1,
-                        false,
-                        prefault,
-                        config.shared,
-                        config.hugepages,
-                    )?);
-                }
+            for region in ram_regions.iter() {
+                mem_regions.push(MemoryManager::create_ram_region(
+                    &config.file,
+                    0,
+                    region.0,
+                    region.1,
+                    prefault,
+                    config.shared,
+                    config.hugepages,
+                    &ext_regions,
+                )?);
             }
         } else {
             if config.regions.is_none() {
@@ -438,6 +420,7 @@ impl MemoryManager {
                 &ram_regions,
                 &custom_regions,
                 prefault,
+                ext_regions,
             )?;
         }
 
@@ -466,9 +449,9 @@ impl MemoryManager {
                         start_addr,
                         size as usize,
                         false,
-                        false,
                         config.shared,
                         config.hugepages,
+                        &None,
                     )?);
                 }
 
@@ -604,6 +587,14 @@ impl MemoryManager {
                     }
                 };
 
+            // Here we turn the backing file name into a backing file path as
+            // this will be needed when the memory region will be created with
+            // mmap().
+            // We simply ignore the backing files that are None, as they
+            // represent files that have been directly saved by the user, with
+            // no need for saving into a dedicated external file. For these
+            // files, the VmConfig already contains the information on where to
+            // find them.
             let mut ext_regions = mem_snapshot.memory_regions;
             for region in ext_regions.iter_mut() {
                 if let Some(backing_file) = &mut region.backing_file {
@@ -613,45 +604,7 @@ impl MemoryManager {
                 }
             }
 
-            // In case there was no backing file, we can safely use CoW by
-            // mapping the source files provided for restoring. This case
-            // allows for a faster VM restoration and does not require us to
-            // fill the memory content, hence we can return right away.
-            if config.file.is_none() {
-                return MemoryManager::new(vm, config, Some(ext_regions), prefault);
-            };
-
-            let memory_manager = MemoryManager::new(vm, config, None, false)?;
-            let guest_memory = memory_manager.lock().unwrap().guest_memory();
-
-            // In case the previous config was using a backing file, this means
-            // it was MAP_SHARED, therefore we must copy the content into the
-            // new regions so that we can still use MAP_SHARED when restoring
-            // the VM.
-            guest_memory.memory().with_regions(|index, region| {
-                if let Some(backing_file) = &ext_regions[index].backing_file {
-                    // Open (read only) the snapshot file for the given region.
-                    let mut memory_region_file = OpenOptions::new()
-                        .read(true)
-                        .open(backing_file)
-                        .map_err(|e| {
-                        Error::Restore(MigratableError::MigrateReceive(e.into()))
-                    })?;
-
-                    // Fill the region with the file content.
-                    region
-                        .read_from(
-                            MemoryRegionAddress(0),
-                            &mut memory_region_file,
-                            region.len().try_into().unwrap(),
-                        )
-                        .map_err(|e| Error::Restore(MigratableError::MigrateReceive(e.into())))?;
-                }
-
-                Ok(())
-            })?;
-
-            Ok(memory_manager)
+            MemoryManager::new(vm, config, Some(ext_regions), prefault)
         } else {
             Err(Error::Restore(MigratableError::Restore(anyhow!(
                 "Could not find {}-section from snapshot",
@@ -672,24 +625,52 @@ impl MemoryManager {
 
     #[allow(clippy::too_many_arguments)]
     fn create_ram_region(
-        backing_file: &Option<PathBuf>,
+        file: &Option<PathBuf>,
         mut file_offset: u64,
         start_addr: GuestAddress,
         size: usize,
-        copy_on_write: bool,
         prefault: bool,
         shared: bool,
         hugepages: bool,
+        ext_regions: &Option<Vec<MemoryRegion>>,
     ) -> Result<Arc<GuestRegionMmap>, Error> {
-        Ok(Arc::new(match backing_file {
+        let mut backing_file: Option<PathBuf> = file.clone();
+        let mut copy_ext_region_content: Option<PathBuf> = None;
+
+        if let Some(ext_regions) = ext_regions {
+            for ext_region in ext_regions.iter() {
+                if ext_region.start_addr == start_addr && ext_region.size as usize == size {
+                    if ext_region.backing_file.is_some() {
+                        // If the region is memory mapped as "shared", then we
+                        // don't replace the backing file, but expect to copy
+                        // the content from the external backing file after the
+                        // region has been created.
+                        if shared {
+                            copy_ext_region_content = ext_region.backing_file.clone();
+                        } else {
+                            backing_file = ext_region.backing_file.clone();
+                            // We must override the file offset as in this case
+                            // we're restoring an existing region, which means
+                            // it will fit perfectly the calculated region.
+                            file_offset = 0;
+                        }
+                    }
+
+                    // No need to iterate further as we found the external
+                    // region matching the current region.
+                    break;
+                }
+            }
+        }
+
+        let (f, f_off) = match backing_file {
             Some(ref file) => {
-                let f = if file.is_dir() {
+                if file.is_dir() {
                     // Override file offset as it does not apply in this case.
                     info!(
                         "Ignoring file offset since the backing file is a \
                         temporary file created from the specified directory."
                     );
-                    file_offset = 0;
                     let fs_str = format!("{}{}", file.display(), "/tmpfile_XXXXXX");
                     let fs = ffi::CString::new(fs_str).unwrap();
                     let mut path = fs.as_bytes_with_nul().to_owned();
@@ -698,34 +679,17 @@ impl MemoryManager {
                     unsafe { libc::unlink(path_ptr) };
                     let f = unsafe { File::from_raw_fd(fd) };
                     f.set_len(size as u64).map_err(Error::SharedFileSetLen)?;
-                    f
+
+                    (f, 0)
                 } else {
-                    OpenOptions::new()
+                    let f = OpenOptions::new()
                         .read(true)
                         .write(true)
                         .open(file)
-                        .map_err(Error::SharedFileCreate)?
-                };
+                        .map_err(Error::SharedFileCreate)?;
 
-                let mut mmap_flags = if copy_on_write {
-                    libc::MAP_NORESERVE | libc::MAP_PRIVATE
-                } else {
-                    libc::MAP_NORESERVE | libc::MAP_SHARED
-                };
-                if prefault {
-                    mmap_flags |= libc::MAP_POPULATE;
+                    (f, file_offset)
                 }
-                GuestRegionMmap::new(
-                    MmapRegion::build(
-                        Some(FileOffset::new(f, file_offset)),
-                        size,
-                        libc::PROT_READ | libc::PROT_WRITE,
-                        mmap_flags,
-                    )
-                    .map_err(Error::GuestMemoryRegion)?,
-                    start_addr,
-                )
-                .map_err(Error::GuestMemory)?
             }
             None => {
                 let fd = Self::memfd_create(
@@ -741,25 +705,47 @@ impl MemoryManager {
                 let f = unsafe { File::from_raw_fd(fd) };
                 f.set_len(size as u64).map_err(Error::SharedFileSetLen)?;
 
-                let mmap_flags = libc::MAP_NORESERVE
-                    | if shared {
-                        libc::MAP_SHARED
-                    } else {
-                        libc::MAP_PRIVATE
-                    };
-                GuestRegionMmap::new(
-                    MmapRegion::build(
-                        Some(FileOffset::new(f, 0)),
-                        size,
-                        libc::PROT_READ | libc::PROT_WRITE,
-                        mmap_flags,
-                    )
-                    .map_err(Error::GuestMemoryRegion)?,
-                    start_addr,
-                )
-                .map_err(Error::GuestMemory)?
+                (f, 0)
             }
-        }))
+        };
+
+        let mut mmap_flags = libc::MAP_NORESERVE
+            | if shared {
+                libc::MAP_SHARED
+            } else {
+                libc::MAP_PRIVATE
+            };
+        if prefault {
+            mmap_flags |= libc::MAP_POPULATE;
+        }
+
+        let region = GuestRegionMmap::new(
+            MmapRegion::build(
+                Some(FileOffset::new(f, f_off)),
+                size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                mmap_flags,
+            )
+            .map_err(Error::GuestMemoryRegion)?,
+            start_addr,
+        )
+        .map_err(Error::GuestMemory)?;
+
+        // Copy data to the region if needed
+        if let Some(ext_backing_file) = &copy_ext_region_content {
+            // Open (read only) the snapshot file for the given region.
+            let mut memory_region_file = OpenOptions::new()
+                .read(true)
+                .open(ext_backing_file)
+                .unwrap();
+
+            // Fill the region with the file content.
+            region
+                .read_from(MemoryRegionAddress(0), &mut memory_region_file, size)
+                .unwrap();
+        }
+
+        Ok(Arc::new(region))
     }
 
     // Update the GuestMemoryMmap with the new range
@@ -824,9 +810,9 @@ impl MemoryManager {
             start_addr,
             size,
             false,
-            false,
             self.shared,
             self.hugepages,
+            &None,
         )?;
 
         // Map it into the guest

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -380,7 +380,7 @@ impl MemoryManager {
 
                 for region in ext_regions.iter() {
                     mem_regions.push(MemoryManager::create_ram_region(
-                        &Some(region.backing_file.clone()),
+                        &region.backing_file,
                         0,
                         region.start_addr,
                         region.size as usize,
@@ -604,9 +604,11 @@ impl MemoryManager {
 
             let mut ext_regions = mem_snapshot.memory_regions;
             for region in ext_regions.iter_mut() {
-                let mut memory_region_path = vm_snapshot_path.clone();
-                memory_region_path.push(region.backing_file.clone());
-                region.backing_file = memory_region_path;
+                if let Some(backing_file) = &mut region.backing_file {
+                    let mut memory_region_path = vm_snapshot_path.clone();
+                    memory_region_path.push(backing_file.clone());
+                    *backing_file = memory_region_path;
+                }
             }
 
             // In case there was no backing file, we can safely use CoW by
@@ -625,20 +627,24 @@ impl MemoryManager {
             // new regions so that we can still use MAP_SHARED when restoring
             // the VM.
             guest_memory.memory().with_regions(|index, region| {
-                // Open (read only) the snapshot file for the given region.
-                let mut memory_region_file = OpenOptions::new()
-                    .read(true)
-                    .open(&ext_regions[index].backing_file)
-                    .map_err(|e| Error::Restore(MigratableError::MigrateReceive(e.into())))?;
+                if let Some(backing_file) = &ext_regions[index].backing_file {
+                    // Open (read only) the snapshot file for the given region.
+                    let mut memory_region_file = OpenOptions::new()
+                        .read(true)
+                        .open(backing_file)
+                        .map_err(|e| {
+                        Error::Restore(MigratableError::MigrateReceive(e.into()))
+                    })?;
 
-                // Fill the region with the file content.
-                region
-                    .read_from(
-                        MemoryRegionAddress(0),
-                        &mut memory_region_file,
-                        region.len().try_into().unwrap(),
-                    )
-                    .map_err(|e| Error::Restore(MigratableError::MigrateReceive(e.into())))?;
+                    // Fill the region with the file content.
+                    region
+                        .read_from(
+                            MemoryRegionAddress(0),
+                            &mut memory_region_file,
+                            region.len().try_into().unwrap(),
+                        )
+                        .map_err(|e| Error::Restore(MigratableError::MigrateReceive(e.into())))?;
+                }
 
                 Ok(())
             })?;
@@ -1514,7 +1520,7 @@ pub struct GuestAddressDef(pub u64);
 
 #[derive(Serialize, Deserialize)]
 pub struct MemoryRegion {
-    backing_file: PathBuf,
+    backing_file: Option<PathBuf>,
     #[serde(with = "GuestAddressDef")]
     start_addr: GuestAddress,
     size: GuestUsize,
@@ -1549,7 +1555,7 @@ impl Snapshottable for MemoryManager {
             }
 
             memory_regions.push(MemoryRegion {
-                backing_file: PathBuf::from(format!("memory-region-{}", index)),
+                backing_file: Some(PathBuf::from(format!("memory-region-{}", index))),
                 start_addr: region.start_addr(),
                 size: region.len(),
             });

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1267,7 +1267,7 @@ impl Snapshottable for Vm {
         VM_SNAPSHOT_ID.to_string()
     }
 
-    fn snapshot(&self) -> std::result::Result<Snapshot, MigratableError> {
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let current_state = self.get_state().unwrap();
         if current_state != VmState::Paused {
             return Err(MigratableError::Snapshot(anyhow!(


### PR DESCRIPTION
This pull request simplifies and factorizes some pieces of the MemoryManager, allowing for proper support of snapshot/restore with the new feature letting users define their own memory regions.