### PR TITLE
pci: device_manager: Remove hardcoded I/O port assignment

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3513,8 +3513,6 @@ impl Aml for DeviceManager {
             &aml::ResourceTemplate::new(vec![
                 &aml::AddressSpace::new_bus_number(0x0u16, 0xffu16),
                 &aml::IO::new(0xcf8, 0xcf8, 1, 0x8),
-                &aml::AddressSpace::new_io(0x0u16, 0xcf7u16),
-                &aml::AddressSpace::new_io(0xd00u16, 0xffffu16),
                 &aml::AddressSpace::new_memory(
                     aml::AddressSpaceCachable::NotCacheable,
                     true,


### PR DESCRIPTION
It is otherwise seems to be able to cause resource conflicts with
Windows APCI_HAL. The OS might do a better job on assigning resources to this
device, withouth them to be requested explicitly. 0xcf8 and 0xcfc are
only what is certainly needed for the PCI device enumeration.

Signed-off-by: Anatol Belski <anatol.belski@microsoft.com>