### PR TITLE
vmm: openapi: Don't expect cmdline to be always there

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -369,7 +369,6 @@ components:
     VmConfig:
       required:
       - kernel
-      - cmdline
       type: object
       properties:
         cpus:


### PR DESCRIPTION
The 'cmdline' parameter should not be required as it is not needed when
the 'kernel' parameter is the rust-hypervisor-fw, which means the kernel
and the associated command line will be found from the EFI partition.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>