### PR TITLE
Add host NUMA nodes support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,7 @@ fn create_app<'a, 'b>(
                 .help(
                     "User defined memory zone parameters \
                      \"size=<guest_memory_region_size>,file=<backing_file>,\
-                     shared=on|off,hugepages=on|off\"",
+                     shared=on|off,hugepages=on|off,host_numa_node=<node_id>\"",
                 )
                 .takes_value(true)
                 .min_values(1)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2217,7 +2217,12 @@ mod tests {
                 let mut cmd = GuestCommand::new(&guest);
                 cmd.args(&["--cpus", "boot=1"])
                     .args(&["--memory", "size=0"])
-                    .args(&["--memory-zone", "size=1G", "size=3G,file=/dev/shm"])
+                    .args(&[
+                        "--memory-zone",
+                        "size=1G",
+                        "size=3G,file=/dev/shm",
+                        "size=1G,host_numa_node=0",
+                    ])
                     .args(&["--kernel", guest.fw_path.as_str()])
                     .default_disks()
                     .default_net();

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -467,6 +467,8 @@ components:
         hugepages:
           type: boolean
           default: false
+        host_numa_node:
+          type: uint64
 
     MemoryConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -352,6 +352,8 @@ pub struct MemoryZoneConfig {
     pub shared: bool,
     #[serde(default)]
     pub hugepages: bool,
+    #[serde(default)]
+    pub host_numa_node: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -431,7 +433,8 @@ impl MemoryConfig {
                     .add("size")
                     .add("file")
                     .add("shared")
-                    .add("hugepages");
+                    .add("hugepages")
+                    .add("host_numa_node");
                 parser.parse(memory_zone).map_err(Error::ParseMemoryZone)?;
 
                 let size = parser
@@ -450,12 +453,16 @@ impl MemoryConfig {
                     .map_err(Error::ParseMemoryZone)?
                     .unwrap_or(Toggle(false))
                     .0;
+                let host_numa_node = parser
+                    .convert::<u64>("host_numa_node")
+                    .map_err(Error::ParseMemoryZone)?;
 
                 zones.push(MemoryZoneConfig {
                     size,
                     file,
                     shared,
                     hugepages,
+                    host_numa_node,
                 });
             }
             Some(zones)

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -364,6 +364,7 @@ impl MemoryManager {
                 file: None,
                 shared: config.shared,
                 hugepages: config.hugepages,
+                host_numa_node: None,
             }];
 
             (config.size, zones)

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -402,10 +402,10 @@ impl MemoryManager {
             for zone in zones.iter() {
                 total_ram_size += zone.size;
 
-                if zone.shared && zone.host_numa_node.is_some() {
+                if zone.shared && zone.file.is_some() && zone.host_numa_node.is_some() {
                     error!(
                         "Invalid to set host NUMA policy for a memory zone \
-                        mapped as 'shared'"
+                        backed by a regular file and mapped as 'shared'"
                     );
                     return Err(Error::InvalidSharedMemoryZoneWithHostNuma);
                 }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -289,6 +289,7 @@ fn vmm_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_listen),
         allow_syscall(libc::SYS_lseek),
         allow_syscall(libc::SYS_madvise),
+        allow_syscall(libc::SYS_mbind),
         allow_syscall(libc::SYS_memfd_create),
         allow_syscall(libc::SYS_mmap),
         allow_syscall(libc::SYS_mprotect),


### PR DESCRIPTION
Now that it is possible to specify with a fine granularity how to back the guest RAM through `--memory-zone`, this pull request extends the capability of this parameter by adding the new option `host_numa_nodes`. When specifying this new option, the user can specify which NUMA node from the host should be used to allocate the memory of each memory zone.

With this new feature, any user having access to a system with 2 NUMA nodes might choose to back a 4G guest memory with half of it from the first node and the second half from the second node. Here is how this can be described from the CLI:
```
./cloud-hypervisor ... --memory size=0 --memory-zone size=2G,host_numa_nodes=0 size=2G,host_numa_nodes=1
```

Fixes #1603 