### PR TITLE
vmm: Remove 'mergeable' from memory zones

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,7 @@ fn create_app<'a, 'b>(
                 .help(
                     "User defined memory zone parameters \
                      \"size=<guest_memory_region_size>,file=<backing_file>,\
-                     mergeable=on|off,shared=on|off,hugepages=on|off\"",
+                     shared=on|off,hugepages=on|off\"",
                 )
                 .takes_value(true)
                 .min_values(1)

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -349,8 +349,6 @@ pub struct MemoryZoneConfig {
     #[serde(default)]
     pub file: Option<PathBuf>,
     #[serde(default)]
-    pub mergeable: bool,
-    #[serde(default)]
     pub shared: bool,
     #[serde(default)]
     pub hugepages: bool,
@@ -432,7 +430,6 @@ impl MemoryConfig {
                 parser
                     .add("size")
                     .add("file")
-                    .add("mergeable")
                     .add("shared")
                     .add("hugepages");
                 parser.parse(memory_zone).map_err(Error::ParseMemoryZone)?;
@@ -443,11 +440,6 @@ impl MemoryConfig {
                     .unwrap_or(ByteSized(DEFAULT_MEMORY_MB << 20))
                     .0;
                 let file = parser.get("file").map(PathBuf::from);
-                let mergeable = parser
-                    .convert::<Toggle>("mergeable")
-                    .map_err(Error::ParseMemoryZone)?
-                    .unwrap_or(Toggle(false))
-                    .0;
                 let shared = parser
                     .convert::<Toggle>("shared")
                     .map_err(Error::ParseMemoryZone)?
@@ -462,7 +454,6 @@ impl MemoryConfig {
                 zones.push(MemoryZoneConfig {
                     size,
                     file,
-                    mergeable,
                     shared,
                     hugepages,
                 });

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -362,7 +362,6 @@ impl MemoryManager {
             let zones = vec![MemoryZoneConfig {
                 size: config.size,
                 file: None,
-                mergeable: config.mergeable,
                 shared: config.shared,
                 hugepages: config.hugepages,
             }];


### PR DESCRIPTION
The flag 'mergeable' should only apply to the entire guest RAM, which is
why it is removed from the MemoryZoneConfig as it is defined as a global
parameter at the MemoryConfig level.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>