### PR TITLE
cloud-hypervisor.yaml: MemoryConfig: Add balloon_size

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -497,6 +497,9 @@ components:
         balloon:
           type: boolean
           default: false
+        balloon_size:
+          type: integer
+          format: uint64
         zones:
           type: array
           items:


### PR DESCRIPTION
"struct MemoryConfig" has balloon_size but not in MemoryConfig
of cloud-hypervisor.yaml.
This commit adds it.

Signed-off-by: Hui Zhu <teawater@antfin.com>