### PR TITLE
virtio-balloon: Show balloon actual in vm.info balloon_size

### DIFF
--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -170,6 +170,28 @@ pub trait VirtioDevice: Send {
                 .unwrap();
         }
     }
+
+    /// Helper to allow common implementation of write_config
+    fn write_config_to_slice(&self, config: &mut [u8], offset: u64, data: &[u8]) {
+        let config_len = config.len() as u64;
+        let data_len = data.len() as u64;
+        if offset + data_len > config_len {
+            error!(
+                    "Out-of-bound access to configuration: config_len = {} offset = {:x} length = {} for {}",
+                    config_len,
+                    offset,
+                    data_len,
+                    self.device_type()
+                );
+            return;
+        }
+
+        if let Some(end) = offset.checked_add(config.len() as u64) {
+            let mut offset_config =
+                &mut config[offset as usize..std::cmp::min(end, config_len) as usize];
+            offset_config.write_all(data).unwrap();
+        }
+    }
 }
 
 /// Trait providing address translation the same way a physical DMA remapping

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -142,6 +142,9 @@ pub enum Error {
     /// Failed to virtio-balloon resize
     VirtioBalloonResizeFail(virtio_devices::balloon::Error),
 
+    /// virtio-balloon device not set
+    VirtioBalloonNotSet,
+
     /// Invalid SGX EPC section size
     #[cfg(target_arch = "x86_64")]
     EpcSectionSizeInvalid,
@@ -1063,6 +1066,13 @@ impl MemoryManager {
         }
 
         Ok(balloon_size)
+    }
+
+    pub fn get_balloon_actual(&mut self) -> Result<u64, Error> {
+        if let Some(balloon) = &self.balloon {
+            return Ok(balloon.lock().unwrap().get_actual());
+        }
+        Err(Error::VirtioBalloonNotSet)
     }
 
     /// In case this function resulted in adding a new memory region to the

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1192,6 +1192,15 @@ impl Vm {
             .map_err(|_| Error::PoisonedState)
             .map(|state| *state)
     }
+
+    /// Gets the actual size of the balloon.
+    pub fn get_balloon_actual(&self) -> Result<u64> {
+        self.memory_manager
+            .lock()
+            .unwrap()
+            .get_balloon_actual()
+            .map_err(Error::MemoryManager)
+    }
 }
 
 impl Pausable for Vm {


### PR DESCRIPTION
The virtio-balloon change the memory size is asynchronous.
VirtioBalloonConfig.actual show current balloon size.

This commit let vm.info balloon_size show balloon actual size.

Signed-off-by: Hui Zhu <teawater@gmail.com>