### PR TITLE
vmm: Expose NUMA nodes to the guest

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,8 @@ fn create_app<'a, 'b>(
                 .help(
                     "User defined memory zone parameters \
                      \"size=<guest_memory_region_size>,file=<backing_file>,\
-                     shared=on|off,hugepages=on|off,host_numa_node=<node_id>\"",
+                     shared=on|off,hugepages=on|off,host_numa_node=<node_id>,\
+                     guest_numa_node=<node_id>\"",
                 )
                 .takes_value(true)
                 .min_values(1)

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -470,6 +470,9 @@ components:
         host_numa_node:
           type: integer
           format: uint32
+        guest_numa_node:
+          type: integer
+          format: uint32
 
     MemoryConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -354,6 +354,8 @@ pub struct MemoryZoneConfig {
     pub hugepages: bool,
     #[serde(default)]
     pub host_numa_node: Option<u32>,
+    #[serde(default)]
+    pub guest_numa_node: Option<u32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -434,7 +436,8 @@ impl MemoryConfig {
                     .add("file")
                     .add("shared")
                     .add("hugepages")
-                    .add("host_numa_node");
+                    .add("host_numa_node")
+                    .add("guest_numa_node");
                 parser.parse(memory_zone).map_err(Error::ParseMemoryZone)?;
 
                 let size = parser
@@ -456,6 +459,9 @@ impl MemoryConfig {
                 let host_numa_node = parser
                     .convert::<u32>("host_numa_node")
                     .map_err(Error::ParseMemoryZone)?;
+                let guest_numa_node = parser
+                    .convert::<u32>("guest_numa_node")
+                    .map_err(Error::ParseMemoryZone)?;
 
                 zones.push(MemoryZoneConfig {
                     size,
@@ -463,6 +469,7 @@ impl MemoryConfig {
                     shared,
                     hugepages,
                     host_numa_node,
+                    guest_numa_node,
                 });
             }
             Some(zones)

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -379,6 +379,7 @@ impl MemoryManager {
                 shared: config.shared,
                 hugepages: config.hugepages,
                 host_numa_node: None,
+                guest_numa_node: None,
             }];
 
             (config.size, zones)


### PR DESCRIPTION
This pull request adds a new option `guest_numa_node` to the parameter `--memory-zone`, allowing a user to specify which NUMA node a memory zone should belong to.
With the following command line example:
```
./cloud-hypervisor ... --memory size=0 --memory-zone size=1G,guest_numa_node=0 size=2G,guest_numa_node=1
```
we can find 2 NUMA nodes detected in the guest, with the first node attached to a memory range of 1G, while the second node is attached to a memory range of 2G.