### PR TITLE
Enable vhost-user-net self-spawn test cases on Aarch64

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2587,13 +2587,11 @@ mod tests {
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_vhost_user_net_self_spawning() {
             test_vhost_user_net(None, 4, None, true, false)
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_vhost_user_net_self_spawning_host_mac() {
             test_vhost_user_net(None, 2, None, true, true)
         }

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -290,6 +290,13 @@ fn virtio_vhost_net_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_futex),
         allow_syscall(libc::SYS_read),
         allow_syscall(libc::SYS_write),
+        allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_munmap),
+        #[cfg(target_arch = "aarch64")]
+        allow_syscall(libc::SYS_madvise),
+        #[cfg(target_arch = "aarch64")]
+        allow_syscall(libc::SYS_exit),
     ])
 }
 
@@ -304,6 +311,15 @@ fn virtio_vhost_net_ctl_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_epoll_wait),
         allow_syscall(libc::SYS_futex),
         allow_syscall(libc::SYS_read),
+        allow_syscall(libc::SYS_close),
+        #[cfg(target_arch = "aarch64")]
+        allow_syscall(libc::SYS_sigaltstack),
+        #[cfg(target_arch = "aarch64")]
+        allow_syscall(libc::SYS_munmap),
+        #[cfg(target_arch = "aarch64")]
+        allow_syscall(libc::SYS_madvise),
+        #[cfg(target_arch = "aarch64")]
+        allow_syscall(libc::SYS_exit),
     ])
 }
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -276,6 +276,10 @@ fn vmm_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         // The definition of libc::SYS_ftruncate is missing on AArch64.
         // Use a hard-code number instead.
         allow_syscall(46),
+        #[cfg(target_arch = "aarch64")]
+        allow_syscall(libc::SYS_faccessat),
+        #[cfg(target_arch = "aarch64")]
+        allow_syscall(libc::SYS_newfstatat),
         allow_syscall(libc::SYS_futex),
         allow_syscall(libc::SYS_getpid),
         allow_syscall(libc::SYS_getrandom),


### PR DESCRIPTION
Fixes https://github.com/cloud-hypervisor/cloud-hypervisor/issues/1650.

The PR includes:
- Adding the missing seccomp rules needed for starting self-spawned vhost-user-net back-end
- Adding the missing seccomp rules needed in back-end shutdown
- Enabling integration test cases