### PR TITLE
vmm: Associate vCPUs with specific guest NUMA node

### DIFF
--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -170,3 +170,47 @@ impl FromStr for ByteSized {
         }))
     }
 }
+
+pub struct IntegerList(pub Vec<u64>);
+
+pub enum IntegerListParseError {
+    InvalidValue(String),
+}
+
+impl FromStr for IntegerList {
+    type Err = IntegerListParseError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let mut integer_list = Vec::new();
+        let ranges_list: Vec<&str> = s.trim().split(':').collect();
+
+        for range in ranges_list.iter() {
+            let items: Vec<&str> = range.split('-').collect();
+
+            if items.len() > 2 {
+                return Err(IntegerListParseError::InvalidValue(range.to_string()));
+            }
+
+            let start_range = items[0]
+                .parse::<u64>()
+                .map_err(|_| IntegerListParseError::InvalidValue(items[0].to_owned()))?;
+
+            integer_list.push(start_range);
+
+            if items.len() == 2 {
+                let end_range = items[1]
+                    .parse::<u64>()
+                    .map_err(|_| IntegerListParseError::InvalidValue(items[1].to_owned()))?;
+                if start_range >= end_range {
+                    return Err(IntegerListParseError::InvalidValue(range.to_string()));
+                }
+
+                for i in start_range..end_range {
+                    integer_list.push(i + 1);
+                }
+            }
+        }
+
+        Ok(IntegerList(integer_list))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,6 +222,14 @@ fn create_app<'a, 'b>(
                 .group("vm-config"),
         )
         .arg(
+            Arg::with_name("numa")
+                .long("numa")
+                .help(config::NumaConfig::SYNTAX)
+                .takes_value(true)
+                .min_values(1)
+                .group("vm-config"),
+        )
+        .arg(
             Arg::with_name("v")
                 .short("v")
                 .multiple(true)
@@ -566,6 +574,7 @@ mod unit_tests {
                 iommu: false,
                 #[cfg(target_arch = "x86_64")]
                 sgx_epc: None,
+                numa: None,
             };
 
             aver_eq!(tb, expected_vm_config, result_vm_config);

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -413,6 +413,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SgxEpcConfig'
+        numa:
+          type: array
+          items:
+            $ref: '#/components/schemas/NumaConfig'
         iommu:
           type: boolean
           default: false
@@ -716,6 +720,20 @@ components:
         prefault:
           type: boolean
           default: false
+
+    NumaConfig:
+      required:
+      - id
+      type: object
+      properties:
+        id:
+          type: integer
+          format: uint32
+        cpus:
+          type: array
+          items:
+            type: integer
+            format: uint8
 
     VmResize:
       type: object

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -66,11 +66,20 @@ struct HotPlugState {
 #[derive(Clone)]
 pub struct NumaNode {
     memory_regions: Vec<Arc<GuestRegionMmap>>,
+    cpus: Vec<u8>,
 }
 
 impl NumaNode {
     pub fn memory_regions(&self) -> &Vec<Arc<GuestRegionMmap>> {
         &self.memory_regions
+    }
+
+    pub fn cpus(&self) -> &Vec<u8> {
+        &self.cpus
+    }
+
+    pub fn cpus_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.cpus
     }
 }
 
@@ -356,6 +365,7 @@ impl MemoryManager {
                             node_id,
                             NumaNode {
                                 memory_regions: vec![region.clone()],
+                                cpus: Vec::new(),
                             },
                         );
                     }
@@ -1232,6 +1242,10 @@ impl MemoryManager {
 
     pub fn numa_nodes(&self) -> &NumaNodes {
         &self.numa_nodes
+    }
+
+    pub fn numa_nodes_mut(&mut self) -> &mut NumaNodes {
+        &mut self.numa_nodes
     }
 }
 


### PR DESCRIPTION
By introducing a new `--numa` parameter, this pull request allows users to specify some settings associated with the NUMA nodes created through `--memory-zone`.
The first setting supported through this pull request is `cpus=`, which let the user choose which vCPU should be associated with which NUMA node from the guest.

For instance, if one wants to create a VM with 4vCPUs, 2 NUMA nodes, with the first NUMA node being assigned with the vCPU 0 and the second node with the rest of the vCPUs, here is what the command line would look like:

```
./cloud-hypervisor
    --cpus boot=4
    --memory size=0
    --memory-zone size=1G,guest_numa_node=0 size=1G,guest_numa_node=1
    --numa id=0,cpus=0 id=1,cpus=1-3
```

The plan is to extend this `--numa` parameter through follow up pull requests, so that we can describe the distance between each NUMA node.