### PR TITLE
vmm: Allow distances to be specified between NUMA nodes

### DIFF
--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -214,3 +214,37 @@ impl FromStr for IntegerList {
         Ok(IntegerList(integer_list))
     }
 }
+
+pub struct TupleTwoIntegers(pub Vec<(u64, u64)>);
+
+pub enum TupleTwoIntegersParseError {
+    InvalidValue(String),
+}
+
+impl FromStr for TupleTwoIntegers {
+    type Err = TupleTwoIntegersParseError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let mut list = Vec::new();
+        let tuples_list: Vec<&str> = s.trim().split(':').collect();
+
+        for tuple in tuples_list.iter() {
+            let items: Vec<&str> = tuple.split('@').collect();
+
+            if items.len() != 2 {
+                return Err(TupleTwoIntegersParseError::InvalidValue(tuple.to_string()));
+            }
+
+            let item1 = items[0]
+                .parse::<u64>()
+                .map_err(|_| TupleTwoIntegersParseError::InvalidValue(items[0].to_owned()))?;
+            let item2 = items[1]
+                .parse::<u64>()
+                .map_err(|_| TupleTwoIntegersParseError::InvalidValue(items[1].to_owned()))?;
+
+            list.push((item1, item2));
+        }
+
+        Ok(TupleTwoIntegers(list))
+    }
+}

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -721,6 +721,19 @@ components:
           type: boolean
           default: false
 
+    NumaDistance:
+      required:
+      - destination
+      - distance
+      type: object
+      properties:
+        destination:
+          type: integer
+          format: uint32
+        distance:
+          type: integer
+          format: uint8
+
     NumaConfig:
       required:
       - id
@@ -734,6 +747,10 @@ components:
           items:
             type: integer
             format: uint8
+        distances:
+          type: array
+          items:
+            $ref: '#/components/schemas/NumaDistance'
 
     VmResize:
       type: object

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -67,6 +67,7 @@ struct HotPlugState {
 pub struct NumaNode {
     memory_regions: Vec<Arc<GuestRegionMmap>>,
     cpus: Vec<u8>,
+    distances: BTreeMap<u32, u8>,
 }
 
 impl NumaNode {
@@ -80,6 +81,14 @@ impl NumaNode {
 
     pub fn cpus_mut(&mut self) -> &mut Vec<u8> {
         &mut self.cpus
+    }
+
+    pub fn distances(&self) -> &BTreeMap<u32, u8> {
+        &self.distances
+    }
+
+    pub fn distances_mut(&mut self) -> &mut BTreeMap<u32, u8> {
+        &mut self.distances
     }
 }
 
@@ -366,6 +375,7 @@ impl MemoryManager {
                             NumaNode {
                                 memory_regions: vec![region.clone()],
                                 cpus: Vec::new(),
+                                distances: BTreeMap::new(),
                             },
                         );
                     }


### PR DESCRIPTION
In order to let the user choose the distance between the NUMA nodes exposed to the guest, two complementary options `destination` and `distance` have been added to the existing `--numa` parameter. This let the user specify a list of destination nodes for a given node represented by `id`, which must come with the associated list of distances. It's mandatory that both options contain the same amount of elements. Any existing node that is not referenced through the list will be replaced with the distance 20 by default, unless it's the identity (which is always located at a distance of 10).
If any non-existing node is referenced from the list of destinations, an error will be thrown.

Here is an example of a VM exposing 3 NUMA nodes with each node being located at a different distance from the others:
```
./cloud-hypervisor
    --memory size=0
    --memory-zone size=1G,guest_numa_node=0 size=1G,guest_numa_node=1 size=1G,guest_numa_node=2
    --numa id=0,distances=1@20:2@30 id=1,distances=0@20:2@15 id=2,distances=0@30:1@15
```