### PR TITLE
vmm: Use u32 instead of u64 for host_numa_node option

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -468,7 +468,8 @@ components:
           type: boolean
           default: false
         host_numa_node:
-          type: uint64
+          type: integer
+          format: uint32
 
     MemoryConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -353,7 +353,7 @@ pub struct MemoryZoneConfig {
     #[serde(default)]
     pub hugepages: bool,
     #[serde(default)]
-    pub host_numa_node: Option<u64>,
+    pub host_numa_node: Option<u32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -454,7 +454,7 @@ impl MemoryConfig {
                     .unwrap_or(Toggle(false))
                     .0;
                 let host_numa_node = parser
-                    .convert::<u64>("host_numa_node")
+                    .convert::<u32>("host_numa_node")
                     .map_err(Error::ParseMemoryZone)?;
 
                 zones.push(MemoryZoneConfig {

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -653,7 +653,7 @@ impl MemoryManager {
         prefault: bool,
         shared: bool,
         hugepages: bool,
-        host_numa_node: Option<u64>,
+        host_numa_node: Option<u32>,
         ext_regions: &Option<Vec<MemoryRegion>>,
     ) -> Result<Arc<GuestRegionMmap>, Error> {
         let mut backing_file: Option<PathBuf> = file.clone();
@@ -778,7 +778,7 @@ impl MemoryManager {
             // Linux is kind of buggy in the way it interprets maxnode as it
             // will cut off the last node. That's why we have to add 1 to what
             // we would consider as the proper maxnode value.
-            let maxnode = node + 1 + 1;
+            let maxnode = node as u64 + 1 + 1;
 
             // Allocate the right size for the vector.
             nodemask.resize((node as usize / 64) + 1, 0);


### PR DESCRIPTION
Given that ACPI uses u32 as the type for the Proximity Domain, we can
use u32 instead of u64 as the type for 'host_numa_node' option.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>