### PR TITLE
tests: Port integration tests to the new methodology - batch 2

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3324,41 +3324,45 @@ mod tests {
         #[cfg_attr(not(feature = "mmio"), test)]
         #[cfg(target_arch = "x86_64")]
         fn test_console_file() {
-            test_block!(tb, "", {
-                let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-                let guest = Guest::new(&mut focal);
+            let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+            let guest = Guest::new(&mut focal);
 
-                let console_path = guest.tmp_dir.path().join("/tmp/console-output");
-                let mut child = GuestCommand::new(&guest)
-                    .args(&["--cpus", "boot=1"])
-                    .args(&["--memory", "size=512M"])
-                    .args(&["--kernel", guest.fw_path.as_str()])
-                    .default_disks()
-                    .default_net()
-                    .args(&[
-                        "--console",
-                        format!("file={}", console_path.to_str().unwrap()).as_str(),
-                    ])
-                    .spawn()
-                    .unwrap();
+            let console_path = guest.tmp_dir.path().join("/tmp/console-output");
+            let mut child = GuestCommand::new(&guest)
+                .args(&["--cpus", "boot=1"])
+                .args(&["--memory", "size=512M"])
+                .args(&["--kernel", guest.fw_path.as_str()])
+                .default_disks()
+                .default_net()
+                .args(&[
+                    "--console",
+                    format!("file={}", console_path.to_str().unwrap()).as_str(),
+                ])
+                .capture_output()
+                .spawn()
+                .unwrap();
 
-                thread::sleep(std::time::Duration::new(20, 0));
+            thread::sleep(std::time::Duration::new(20, 0));
 
-                guest.ssh_command("sudo shutdown -h now")?;
+            guest.ssh_command("sudo shutdown -h now").unwrap();
+            thread::sleep(std::time::Duration::new(20, 0));
 
+            let _ = child.kill();
+            let output = child.wait_with_output().unwrap();
+
+            let r = std::panic::catch_unwind(|| {
                 // Check that the cloud-hypervisor binary actually terminated
-                if let Ok(status) = child.wait() {
-                    aver_eq!(tb, status.success(), true);
-                }
+                assert_eq!(output.status.success(), true);
+
                 // Do this check after shutdown of the VM as an easy way to ensure
                 // all writes are flushed to disk
-                let mut f = std::fs::File::open(console_path)?;
+                let mut f = std::fs::File::open(console_path).unwrap();
                 let mut buf = String::new();
-                f.read_to_string(&mut buf)?;
-                aver!(tb, buf.contains("cloud login:"));
-
-                Ok(())
+                f.read_to_string(&mut buf).unwrap();
+                assert!(buf.contains("cloud login:"));
             });
+
+            handle_child_output(r, &output);
         }
 
         #[cfg_attr(not(feature = "mmio"), test)]


### PR DESCRIPTION
This PR depends on another PR #1661, and it ports the following tests:

```
test_serial_null 
test_serial_tty
test_serial_file 
test_virtio_console
test_console_file
test_bzimage_reboot
```

There are two more tests to port, e.g. `test_luanch_simple` and `test_reboot`, both of which are failing when the `capture_output()` option is enabled while spawning child process. I will take a closer look into them.

Signed-off-by: Bo Chen <chen.bo@intel.com>
