### PR TITLE
Introduce VirtioCommon and start using it for features

### DIFF
--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -14,7 +14,7 @@
 
 use super::{
     ActivateError, ActivateResult, EpollHelper, EpollHelperError, EpollHelperHandler, Queue,
-    VirtioDevice, VirtioDeviceType, EPOLL_HELPER_EVENT_LAST, VIRTIO_F_VERSION_1,
+    VirtioCommon, VirtioDevice, VirtioDeviceType, EPOLL_HELPER_EVENT_LAST, VIRTIO_F_VERSION_1,
 };
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
 use crate::vm_memory::GuestMemory;
@@ -308,12 +308,11 @@ impl EpollHelperHandler for BalloonEpollHandler {
 
 // Virtio device for exposing entropy to the guest OS through virtio.
 pub struct Balloon {
+    common: VirtioCommon,
     id: String,
     resize: VirtioBalloonResize,
     kill_evt: Option<EventFd>,
     pause_evt: Option<EventFd>,
-    avail_features: u64,
-    pub acked_features: u64,
     config: Arc<Mutex<VirtioBalloonConfig>>,
     queue_evts: Option<Vec<EventFd>>,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
@@ -332,12 +331,14 @@ impl Balloon {
         config.num_pages = (size >> PAGE_SHIFT) as u32;
 
         Ok(Balloon {
+            common: VirtioCommon {
+                avail_features,
+                acked_features: 0u64,
+            },
             id,
             resize: VirtioBalloonResize::new()?,
             kill_evt: None,
             pause_evt: None,
-            avail_features,
-            acked_features: 0u64,
             config: Arc::new(Mutex::new(config)),
             queue_evts: None,
             interrupt_cb: None,
@@ -372,20 +373,11 @@ impl VirtioDevice for Balloon {
     }
 
     fn features(&self) -> u64 {
-        self.avail_features
+        self.common.avail_features
     }
 
     fn ack_features(&mut self, value: u64) {
-        let mut v = value;
-        // Check if the guest is ACK'ing a feature that we didn't claim to have.
-        let unrequested_features = v & !self.avail_features;
-        if unrequested_features != 0 {
-            warn!("Received acknowledge request for unknown feature.");
-
-            // Don't count these features as acked.
-            v &= !unrequested_features;
-        }
-        self.acked_features |= v;
+        self.common.ack_features(value)
     }
 
     fn read_config(&self, offset: u64, data: &mut [u8]) {


### PR DESCRIPTION
There is lots of duplicated code in our virtio devices. The goal is to consolidate this into a common location. This PR starts with doing that for the feature handling. In a subsequent PR I will follow-up with device reset and (probably) pause.