### PR TITLE
vmm: Improve NUMA nodes parameters and options

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -308,7 +308,7 @@ struct NumaConfig {
 --numa <numa>	Settings related to a given NUMA node "id=<node_id>,cpus=<cpus_id>,distances=<list_of_distances_to_destination_nodes>,memory_zones=<list_of_memory_zones>"
 ```
 
-### `id`
+### `guest_numa_id`
 
 Node identifier of a guest NUMA node. This identifier must be unique, otherwise
 an error will be returned.
@@ -320,14 +320,14 @@ Value is an unsigned integer of 32 bits.
 _Example_
 
 ```
---numa id=0
+--numa guest_numa_id=0
 ```
 
 ### `cpus`
 
-List of virtual CPUs attached to the guest NUMA node identified by the `id`
-option. This allows for describing a list of CPUs which must be seen by the
-guest as belonging to the NUMA node `id`.
+List of virtual CPUs attached to the guest NUMA node identified by the
+`guest_numa_id` option. This allows for describing a list of CPUs which
+must be seen by the guest as belonging to the NUMA node `guest_numa_id`.
 
 One can use this option for a fine grained description of the NUMA topology
 regarding the CPUs associated with it, which might help the guest run more
@@ -348,17 +348,17 @@ _Example_
 
 ```
 --cpus boot=8
---numa id=0,cpus=1-3:7
---numa id=1,cpus=0:4-6
+--numa guest_numa_id=0,cpus=1-3:7
+--numa guest_numa_id=1,cpus=0:4-6
 ```
 
 ### `distances`
 
-List of distances between the current NUMA node referred by `id` and the
-destination NUMA nodes listed along with distances. This option let the user
-choose the distances between guest NUMA nodes. This is important to provide an
-accurate description of the way non uniform memory accesses will perform in the
-guest.
+List of distances between the current NUMA node referred by `guest_numa_id`
+and the destination NUMA nodes listed along with distances. This option let
+the user choose the distances between guest NUMA nodes. This is important to
+provide an accurate description of the way non uniform memory accesses will
+perform in the guest.
 
 One or more tuple of two values must be provided through this option. The first
 value is an unsigned integer of 32 bits as it represents the destination NUMA
@@ -374,16 +374,16 @@ different distances, it can be described with the following example.
 _Example_
 
 ```
---numa id=0,distances=1@15:2@25
---numa id=1,distances=0@15:2@20
---numa id=2,distances=0@25:1@20
+--numa guest_numa_id=0,distances=1@15:2@25
+--numa guest_numa_id=1,distances=0@15:2@20
+--numa guest_numa_id=2,distances=0@25:1@20
 ```
 
 ### `memory_zones`
 
-List of memory zones attached to the guest NUMA node identified by the `id`
-option. This allows for describing a list of memory ranges which must be seen
-by the guest as belonging to the NUMA node `id`.
+List of memory zones attached to the guest NUMA node identified by the
+`guest_numa_id` option. This allows for describing a list of memory ranges
+which must be seen by the guest as belonging to the NUMA node `guest_numa_id`.
 
 This option can be very useful and powerful when combined with `host_numa_node`
 option from `--memory-zone` parameter as it allows for creating a VM with non
@@ -402,6 +402,6 @@ _Example_
 --memory-zone id=mem0,size=1G
 --memory-zone id=mem1,size=1G
 --memory-zone id=mem2,size=1G
---numa id=0,memory_zones=mem0:mem2
---numa id=1,memory_zones=mem1
+--numa guest_numa_id=0,memory_zones=mem0:mem2
+--numa guest_numa_id=1,memory_zones=mem1
 ```

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -248,3 +248,19 @@ impl FromStr for TupleTwoIntegers {
         Ok(TupleTwoIntegers(list))
     }
 }
+
+pub struct StringList(pub Vec<String>);
+
+pub enum StringListParseError {
+    InvalidValue(String),
+}
+
+impl FromStr for StringList {
+    type Err = StringListParseError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let string_list: Vec<String> = s.trim().split(':').map(|e| e.to_owned()).collect();
+
+        Ok(StringList(string_list))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ fn create_app<'a, 'b>(
                     "User defined memory zone parameters \
                      \"size=<guest_memory_region_size>,file=<backing_file>,\
                      shared=on|off,hugepages=on|off,host_numa_node=<node_id>,\
-                     guest_numa_node=<node_id>,id=<zone_identifier>\"",
+                     id=<zone_identifier>\"",
                 )
                 .takes_value(true)
                 .min_values(1)

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ fn create_app<'a, 'b>(
                     "User defined memory zone parameters \
                      \"size=<guest_memory_region_size>,file=<backing_file>,\
                      shared=on|off,hugepages=on|off,host_numa_node=<node_id>,\
-                     guest_numa_node=<node_id>\"",
+                     guest_numa_node=<node_id>,id=<zone_identifier>\"",
                 )
                 .takes_value(true)
                 .min_values(1)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2282,9 +2282,9 @@ mod tests {
                 .args(&["--memory", "size=0"])
                 .args(&[
                     "--memory-zone",
-                    "size=1G",
-                    "size=3G,file=/dev/shm",
-                    "size=1G,host_numa_node=0",
+                    "id=mem0,size=1G",
+                    "id=mem1,size=3G,file=/dev/shm",
+                    "id=mem2,size=1G,host_numa_node=0",
                 ])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .capture_output()
@@ -2319,15 +2319,15 @@ mod tests {
                 .args(&["--memory", "size=0"])
                 .args(&[
                     "--memory-zone",
-                    "size=1G,guest_numa_node=0",
-                    "size=2G,guest_numa_node=1",
-                    "size=3G,guest_numa_node=2",
+                    "id=mem0,size=1G",
+                    "id=mem1,size=2G",
+                    "id=mem2,size=3G",
                 ])
                 .args(&[
                     "--numa",
-                    "id=0,cpus=0-2,distances=1@15:2@20",
-                    "id=1,cpus=3-4,distances=0@20:2@25",
-                    "id=2,cpus=5,distances=0@25:1@30",
+                    "id=0,cpus=0-2,distances=1@15:2@20,memory_zones=mem0",
+                    "id=1,cpus=3-4,distances=0@20:2@25,memory_zones=mem1",
+                    "id=2,cpus=5,distances=0@25:1@30,memory_zones=mem2",
                 ])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .capture_output()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2325,9 +2325,9 @@ mod tests {
                 ])
                 .args(&[
                     "--numa",
-                    "id=0,cpus=0-2,distances=1@15:2@20,memory_zones=mem0",
-                    "id=1,cpus=3-4,distances=0@20:2@25,memory_zones=mem1",
-                    "id=2,cpus=5,distances=0@25:1@30,memory_zones=mem2",
+                    "guest_numa_id=0,cpus=0-2,distances=1@15:2@20,memory_zones=mem0",
+                    "guest_numa_id=1,cpus=3-4,distances=0@20:2@25,memory_zones=mem1",
+                    "guest_numa_id=2,cpus=5,distances=0@25:1@30,memory_zones=mem2",
                 ])
                 .args(&["--kernel", guest.fw_path.as_str()])
                 .capture_output()

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -5,6 +5,7 @@
 use crate::cpu::CpuManager;
 use crate::device_manager::DeviceManager;
 use crate::memory_manager::MemoryManager;
+use crate::vm::NumaNodes;
 use acpi_tables::{
     aml::Aml,
     rsdp::RSDP,
@@ -73,6 +74,7 @@ pub fn create_acpi_tables(
     device_manager: &Arc<Mutex<DeviceManager>>,
     cpu_manager: &Arc<Mutex<CpuManager>>,
     memory_manager: &Arc<Mutex<MemoryManager>>,
+    numa_nodes: &NumaNodes,
 ) -> GuestAddress {
     // RSDP is at the EBDA
     let rsdp_offset = layout::RSDP_POINTER;
@@ -152,7 +154,6 @@ pub fn create_acpi_tables(
 
     // SRAT and SLIT
     // Only created if the NUMA nodes list is not empty.
-    let numa_nodes = memory_manager.lock().unwrap().numa_nodes().clone();
     let (prev_tbl_len, prev_tbl_off) = if numa_nodes.is_empty() {
         (mcfg.len(), mcfg_offset)
     } else {

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -477,9 +477,6 @@ components:
         host_numa_node:
           type: integer
           format: uint32
-        guest_numa_node:
-          type: integer
-          format: uint32
 
     MemoryConfig:
       required:

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -736,10 +736,10 @@ components:
 
     NumaConfig:
       required:
-      - id
+      - guest_numa_id
       type: object
       properties:
-        id:
+        guest_numa_id:
           type: integer
           format: uint32
         cpus:

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -754,6 +754,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/NumaDistance'
+        memory_zones:
+          type: array
+          items:
+            type: string
 
     VmResize:
       type: object

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -453,9 +453,12 @@ components:
 
     MemoryZoneConfig:
       required:
+      - id
       - size
       type: object
       properties:
+        id:
+          type: string
         size:
           type: integer
           format: int64

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -366,8 +366,6 @@ pub struct MemoryZoneConfig {
     pub hugepages: bool,
     #[serde(default)]
     pub host_numa_node: Option<u32>,
-    #[serde(default)]
-    pub guest_numa_node: Option<u32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -449,8 +447,7 @@ impl MemoryConfig {
                     .add("file")
                     .add("shared")
                     .add("hugepages")
-                    .add("host_numa_node")
-                    .add("guest_numa_node");
+                    .add("host_numa_node");
                 parser.parse(memory_zone).map_err(Error::ParseMemoryZone)?;
 
                 let id = parser.get("id").ok_or(Error::ParseMemoryZoneIdMissing)?;
@@ -473,9 +470,6 @@ impl MemoryConfig {
                 let host_numa_node = parser
                     .convert::<u32>("host_numa_node")
                     .map_err(Error::ParseMemoryZone)?;
-                let guest_numa_node = parser
-                    .convert::<u32>("guest_numa_node")
-                    .map_err(Error::ParseMemoryZone)?;
 
                 zones.push(MemoryZoneConfig {
                     id,
@@ -484,7 +478,6 @@ impl MemoryConfig {
                     shared,
                     hugepages,
                     host_numa_node,
-                    guest_numa_node,
                 });
             }
             Some(zones)

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -6,7 +6,7 @@
 use clap::ArgMatches;
 use net_util::MacAddr;
 use option_parser::{
-    ByteSized, IntegerList, OptionParser, OptionParserError, Toggle, TupleTwoIntegers,
+    ByteSized, IntegerList, OptionParser, OptionParserError, StringList, Toggle, TupleTwoIntegers,
 };
 use std::convert::From;
 use std::fmt;
@@ -1235,14 +1235,21 @@ pub struct NumaConfig {
     pub cpus: Option<Vec<u8>>,
     #[serde(default)]
     pub distances: Option<Vec<NumaDistance>>,
+    #[serde(default)]
+    pub memory_zones: Option<Vec<String>>,
 }
 
 impl NumaConfig {
     pub const SYNTAX: &'static str = "Settings related to a given NUMA node \
-        \"id=<node_id>,cpus=<cpus_id>,distances=<list_of_distances_to_destination_nodes>\"";
+        \"id=<node_id>,cpus=<cpus_id>,distances=<list_of_distances_to_destination_nodes>,\
+        memory_zones=<list_of_memory_zones>\"";
     pub fn parse(numa: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
-        parser.add("id").add("cpus").add("distances");
+        parser
+            .add("id")
+            .add("cpus")
+            .add("distances")
+            .add("memory_zones");
         parser.parse(numa).map_err(Error::ParseNuma)?;
 
         let id = parser
@@ -1264,11 +1271,16 @@ impl NumaConfig {
                     })
                     .collect()
             });
+        let memory_zones = parser
+            .convert::<StringList>("memory_zones")
+            .map_err(Error::ParseNuma)?
+            .map(|v| v.0);
 
         Ok(NumaConfig {
             id,
             cpus,
             distances,
+            memory_zones,
         })
     }
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1223,7 +1223,7 @@ pub struct NumaDistance {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Default)]
 pub struct NumaConfig {
     #[serde(default)]
-    pub id: u32,
+    pub guest_numa_id: u32,
     #[serde(default)]
     pub cpus: Option<Vec<u8>>,
     #[serde(default)]
@@ -1234,19 +1234,19 @@ pub struct NumaConfig {
 
 impl NumaConfig {
     pub const SYNTAX: &'static str = "Settings related to a given NUMA node \
-        \"id=<node_id>,cpus=<cpus_id>,distances=<list_of_distances_to_destination_nodes>,\
+        \"guest_numa_id=<node_id>,cpus=<cpus_id>,distances=<list_of_distances_to_destination_nodes>,\
         memory_zones=<list_of_memory_zones>\"";
     pub fn parse(numa: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser
-            .add("id")
+            .add("guest_numa_id")
             .add("cpus")
             .add("distances")
             .add("memory_zones");
         parser.parse(numa).map_err(Error::ParseNuma)?;
 
-        let id = parser
-            .convert::<u32>("id")
+        let guest_numa_id = parser
+            .convert::<u32>("guest_numa_id")
             .map_err(Error::ParseNuma)?
             .unwrap_or(0);
         let cpus = parser
@@ -1270,7 +1270,7 @@ impl NumaConfig {
             .map(|v| v.0);
 
         Ok(NumaConfig {
-            id,
+            guest_numa_id,
             cpus,
             distances,
             memory_zones,

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -44,6 +44,8 @@ use vm_migration::{
     Transportable,
 };
 
+const DEFAULT_MEMORY_ZONE: &str = "mem0";
+
 #[cfg(target_arch = "x86_64")]
 const X86_64_IRQ_BASE: u32 = 5;
 
@@ -426,6 +428,7 @@ impl MemoryManager {
             // Create a single zone from the global memory config. This lets
             // us reuse the codepath for user defined memory zones.
             let zones = vec![MemoryZoneConfig {
+                id: String::from(DEFAULT_MEMORY_ZONE),
                 size: config.size,
                 file: None,
                 shared: config.shared,

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -414,7 +414,6 @@ impl MemoryManager {
                 shared: config.shared,
                 hugepages: config.hugepages,
                 host_numa_node: None,
-                guest_numa_node: None,
             }];
 
             (config.size, zones)

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -377,10 +377,10 @@ impl Vm {
         let mut numa_nodes = BTreeMap::new();
 
         if let Some(configs) = &configs {
-            let node_id_list: Vec<u32> = configs.iter().map(|cfg| cfg.id).collect();
+            let node_id_list: Vec<u32> = configs.iter().map(|cfg| cfg.guest_numa_id).collect();
 
             for config in configs.iter() {
-                if numa_nodes.contains_key(&config.id) {
+                if numa_nodes.contains_key(&config.guest_numa_id) {
                     error!("Can't define twice the same NUMA node");
                     return Err(Error::InvalidNumaConfig);
                 }
@@ -425,7 +425,7 @@ impl Vm {
                     }
                 }
 
-                numa_nodes.insert(config.id, node);
+                numa_nodes.insert(config.guest_numa_id, node);
             }
         }
 


### PR DESCRIPTION
In order to give more flexibility to the user, and in order to follow what's possible to describe through ACPI, this pull request introduces new options to both `--memory-zone` and `--numa` to modify the way NUMA nodes are described to the guest.
One can more freely describe the expected NUMA topology, while before a memory range had to be attached to a NUMA node.

Fixes #1665