### PR TITLE
build: Use the crate version when the 'git describe' command failed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ vhost_user_net = { path = "vhost_user_net"}
 vmm = { path = "vmm" }
 vmm-sys-util = "0.6.1"
 
+[build-dependencies]
+clap = { version = "2.33.3", features = ["wrap_help"] }
+
 [patch.crates-io]
 vm-memory = { git = "https://github.com/cloud-hypervisor/vm-memory", branch = "ch" }
 

--- a/build.rs
+++ b/build.rs
@@ -3,20 +3,25 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#[macro_use(crate_version)]
+extern crate clap;
+
 use std::process::Command;
 
 fn main() {
-    let git_out = Command::new("git")
-        .args(&["describe", "--dirty"])
-        .output()
-        .expect("Expect to get git describe output");
+    let mut version = crate_version!().to_string();
+
+    if let Ok(git_out) = Command::new("git").args(&["describe", "--dirty"]).output() {
+        if git_out.status.success() {
+            if let Ok(git_out_str) = String::from_utf8(git_out.stdout) {
+                version = git_out_str;
+            }
+        }
+    }
 
     // This println!() has a special behavior, as it will set the environment
     // variable BUILT_VERSION, so that it can be reused from the binary.
     // Particularly, this is used from src/main.rs to display the exact
     // version.
-    println!(
-        "cargo:rustc-env=BUILT_VERSION={}",
-        String::from_utf8(git_out.stdout).unwrap()
-    );
+    println!("cargo:rustc-env=BUILT_VERSION={}", version);
 }


### PR DESCRIPTION
In our build-script (build.rs), we won't set the environment variable
'BUILD_VERSION' when the 'git describe' command failed (e.g. when the
current source tree does not contain git information). This patch added
a fall back path where the default value of 'BUILD_VERSION' is based on
the 'cloud-hypervisor' crate version.

Fixes: #1669

Signed-off-by: Bo Chen <chen.bo@intel.com>