### PR TITLE
Check KVM API version

### DIFF
--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -79,10 +79,6 @@ pub trait Hypervisor: Send + Sync {
     ///
     fn create_vm(&self) -> Result<Arc<dyn Vm>>;
     ///
-    /// Get the API version of the hypervisor
-    ///
-    fn get_api_version(&self) -> i32;
-    ///
     /// Returns the size of the memory mapping required to use the vcpu's structures
     ///
     fn get_vcpu_mmap_size(&self) -> Result<usize>;

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -55,6 +55,11 @@ pub enum HypervisorError {
     ///
     #[error("Failed to get the list of supported MSRs: {0}")]
     GetMsrList(#[source] anyhow::Error),
+    ///
+    /// API version is not compatible
+    ///
+    #[error("Incompatible API version")]
+    IncompatibleApiVersion,
 }
 
 ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -345,6 +345,12 @@ impl KvmHypervisor {
     /// Create a hypervisor based on Kvm
     pub fn new() -> hypervisor::Result<KvmHypervisor> {
         let kvm_obj = Kvm::new().map_err(|e| hypervisor::HypervisorError::VmCreate(e.into()))?;
+        let api_version = kvm_obj.get_api_version();
+
+        if api_version != kvm_bindings::KVM_API_VERSION as i32 {
+            return Err(hypervisor::HypervisorError::IncompatibleApiVersion);
+        }
+
         Ok(KvmHypervisor { kvm: kvm_obj })
     }
 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -425,12 +425,6 @@ impl hypervisor::Hypervisor for KvmHypervisor {
     }
 
     ///
-    /// Returns the KVM API version.
-    ///
-    fn get_api_version(&self) -> i32 {
-        self.kvm.get_api_version()
-    }
-    ///
     ///  Returns the size of the memory mapping required to use the vcpu's `kvm_run` structure.
     ///
     fn get_vcpu_mmap_size(&self) -> hypervisor::Result<usize> {


### PR DESCRIPTION
Check KVM API version and make sure the version is what CH expects before returning a KVM object to `vmm`.

Furthermore this allows us to remove one public API from the `Hypervisor` trait.

See https://github.com/cloud-hypervisor/cloud-hypervisor/issues/1677 .