### PR TITLE
ci: Introduce SGX integration testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,6 +114,36 @@ pipeline{
 						}
 					}
 				}
+				stage ('Worker build SGX') {
+					agent { node { label 'bionic-sgx' } }
+					options {
+						timeout(time: 1, unit: 'HOURS')
+					}
+					when { branch 'master' }
+					stages {
+						stage ('Checkout') {
+							steps {
+								checkout scm
+							}
+						}
+						stage ('Run SGX integration tests') {
+							steps {
+								sh "scripts/dev_cli.sh tests --integration-sgx"
+							}
+						}
+						stage ('Run SGX integration tests for musl') {
+							steps {
+								sh "scripts/dev_cli.sh tests --integration-sgx --libc musl"
+							}
+						}
+					}
+					post {
+						always {
+							sh "sudo chown -R jenkins.jenkins ${WORKSPACE}"
+							deleteDir()
+						}
+					}
+				}
 			}
 		}
 	}

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -161,6 +161,7 @@ cmd_help() {
     echo "        --unit               Run the unit tests."
     echo "        --cargo              Run the cargo tests."
     echo "        --integration        Run the integration tests."
+    echo "        --integration-sgx    Run the SGX integration tests."
     echo "        --libc               Select the C library Cloud Hypervisor will be built against. Default is gnu"
     echo "        --all                Run all tests."
     echo ""
@@ -246,6 +247,7 @@ cmd_tests() {
     unit=false
     cargo=false
     integration=false
+    integration_sgx=false
     libc="gnu"
 
     while [ $# -gt 0 ]; do
@@ -254,6 +256,7 @@ cmd_tests() {
             "--unit")                { unit=true;      } ;;
             "--cargo")               { cargo=true;    } ;;
             "--integration")         { integration=true;    } ;;
+            "--integration-sgx")     { integration_sgx=true;    } ;;
             "--libc")
                 shift
                 [[ "$1" =~ ^(musl|gnu)$ ]] || \
@@ -320,6 +323,25 @@ cmd_tests() {
 	       --env CH_LIBC="${libc}" \
 	       "$CTR_IMAGE" \
 	       ./scripts/run_integration_tests_$(uname -m).sh "$@" || fix_dir_perms $? || exit $?
+    fi
+
+    if [ "$integration_sgx" = true ] ;  then
+	say "Running integration tests for $target..."
+	$DOCKER_RUNTIME run \
+	       --workdir "$CTR_CLH_ROOT_DIR" \
+	       --rm \
+	       --privileged \
+	       --security-opt seccomp=unconfined \
+	       --ipc=host \
+	       --net="$CTR_CLH_NET" \
+	       --mount type=tmpfs,destination=/tmp \
+	       --volume /dev:/dev \
+	       --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+	       --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+	       --env USER="root" \
+	       --env CH_LIBC="${libc}" \
+	       "$CTR_IMAGE" \
+	       ./scripts/run_integration_tests_sgx.sh "$@" || fix_dir_perms $? || exit $?
     fi
 
     fix_dir_perms $?

--- a/scripts/run_integration_tests_sgx.sh
+++ b/scripts/run_integration_tests_sgx.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -x
+
+source $HOME/.cargo/env
+
+BUILD_TARGET="$(uname -m)-unknown-linux-${CH_LIBC}"
+CFLAGS=""
+TARGET_CC=""
+if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
+TARGET_CC="musl-gcc"
+CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
+fi
+
+cargo build --all --release --target $BUILD_TARGET
+strip target/$BUILD_TARGET/release/cloud-hypervisor
+
+export RUST_BACKTRACE=1
+
+time cargo test --features "integration_tests" "tests::sgx::$@"
+RES=$?
+
+if [ $RES -eq 0 ]; then
+    # virtio-mmio based testing
+    cargo build --all --release --target $BUILD_TARGET --no-default-features --features "mmio,kvm"
+    strip target/$BUILD_TARGET/release/cloud-hypervisor
+
+    time cargo test --features "integration_tests,mmio" "tests::sgx::$@"
+    RES=$?
+fi
+
+exit $RES


### PR DESCRIPTION
Extending the Cloud-Hypervisor CI to allow for testing SGX on a
dedicated machine where special image and kernels are ready.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>