### PR TITLE
ch-remote: Support using unit suffices for "resize"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "libc",
  "log 0.4.11",
  "net_util",
+ "option_parser",
  "seccomp",
  "serde_json",
  "ssh2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ clap = { version = "2.33.3", features = ["wrap_help"] }
 hypervisor = { path = "hypervisor" }
 libc = "0.2.76"
 log = { version = "0.4.11", features = ["std"] }
+option_parser = { path = "option_parser" }
 seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.22.0" }
 serde_json = "1.0.57"
 vhost_user_block = { path = "vhost_user_block"}

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -143,6 +143,7 @@ impl FromStr for Toggle {
 
 pub struct ByteSized(pub u64);
 
+#[derive(Debug)]
 pub enum ByteSizedParseError {
     InvalidValue(String),
 }


### PR DESCRIPTION
Remove the requirement for the user to calculate the size they want in
bytes.

Fixes: #1596

Signed-off-by: Rob Bradford <robert.bradford@intel.com>