### PR TITLE
vmm: seccomp: Add seccomp filters for the vcpu and signal_handler threads

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -327,6 +327,7 @@ impl Vm {
             vm.clone(),
             reset_evt,
             hypervisor,
+            seccomp_action.clone(),
         )
         .map_err(Error::CpuManager)?;
 


### PR DESCRIPTION
Those two are the last two worker threads we need to add dedicated seccomp filters.