### PR TITLE
virtio-devices: vsock: Add 'brk' to the seccomp list

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -382,6 +382,7 @@ fn create_vsock_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
 fn virtio_vsock_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
         allow_syscall(libc::SYS_accept4),
+        allow_syscall(libc::SYS_brk),
         allow_syscall(libc::SYS_close),
         allow_syscall(libc::SYS_dup),
         allow_syscall(libc::SYS_epoll_create1),


### PR DESCRIPTION
We observed CI instability for the past couple of days. This
instability is confirmed to be a result of incomplete seccomp
filters. Given the filter on 'virtio_vsock' is recently added and
is missing 'brk', it is likely to be the root cause of the
instability.

Signed-off-by: Bo Chen <chen.bo@intel.com>