### PR TITLE
Jenkinsfile: Remove "Build" steps from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,16 +63,6 @@ pipeline{
 								checkout scm
 							}
 						}
-						stage ('Build') {
-							steps {
-								sh "scripts/dev_cli.sh build --release"
-							}
-						}
-						stage ('Build for musl') {
-							steps {
-								sh "scripts/dev_cli.sh build --release --libc musl"
-							}
-						}
 						stage ('Run unit tests') {
 							steps {
 								sh "scripts/dev_cli.sh tests --unit"


### PR DESCRIPTION
Build testing of changes happens on GitHub actions and the integration
tests will build the binary (with different feature flags) again. So
these earlier build operations are just wasted time on the critical
path.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>