### PR TITLE
vmm: Kill vhost-user self-spawned process on failure

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -318,6 +318,7 @@ fn vmm_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(SYS_IO_URING_ENTER),
         allow_syscall(SYS_IO_URING_SETUP),
         allow_syscall(SYS_IO_URING_REGISTER),
+        allow_syscall(libc::SYS_kill),
         allow_syscall(libc::SYS_listen),
         allow_syscall(libc::SYS_lseek),
         allow_syscall(libc::SYS_madvise),


### PR DESCRIPTION
If after the creation of the self-spawned backend, the VMM cannot create
the corresponding vhost-user frontend, the VMM must kill the freshly
spawned process in order to ensure the error propagation can happen.

In case the child process would still be around, the VMM cannot return
the error as it waits onto the child to terminate.

This should help us identify when self-spawned failures are caused by a
connection being refused between the VMM and the backend.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>