### PR TITLE
mm: Apply memory policy for virtio-mem region

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -606,7 +606,7 @@ impl MemoryManager {
                             false,
                             config.shared,
                             config.hugepages,
-                            None,
+                            zone.host_numa_node,
                             &None,
                         )?;
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -604,8 +604,8 @@ impl MemoryManager {
                             start_addr,
                             hotplug_size as usize,
                             false,
-                            config.shared,
-                            config.hugepages,
+                            zone.shared,
+                            zone.hugepages,
                             zone.host_numa_node,
                             &None,
                         )?;


### PR DESCRIPTION
Use zone.host_numa_node to create memory zone, so that memory zone
can apply memory policy in according with host numa node ID

Fixes: #1733

Signed-off-by: Jiangbo Wu <jiangbo.wu@intel.com>