### PR TITLE
acpi: Add hotplug numa node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,6 +1611,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "arch",
+ "bitflags 1.2.1",
  "block_util",
  "clap",
  "credibility",

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -16,6 +16,7 @@ io_uring = ["virtio-devices/io_uring"]
 
 [dependencies]
 arc-swap = ">=0.4.4"
+bitflags = ">=1.2.1"
 clap = "2.33.3"
 acpi_tables = { path = "../acpi_tables", optional = true }
 anyhow = "1.0"

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -218,6 +218,7 @@ pub type Result<T> = result::Result<T, Error>;
 #[derive(Clone, Default)]
 pub struct NumaNode {
     memory_regions: Vec<Arc<GuestRegionMmap>>,
+    hotplug_regions: Vec<Arc<GuestRegionMmap>>,
     cpus: Vec<u8>,
     distances: BTreeMap<u32, u8>,
     memory_zones: Vec<String>,
@@ -226,6 +227,10 @@ pub struct NumaNode {
 impl NumaNode {
     pub fn memory_regions(&self) -> &Vec<Arc<GuestRegionMmap>> {
         &self.memory_regions
+    }
+
+    pub fn hotplug_regions(&self) -> &Vec<Arc<GuestRegionMmap>> {
+        &self.hotplug_regions
     }
 
     pub fn cpus(&self) -> &Vec<u8> {
@@ -411,6 +416,9 @@ impl Vm {
                     for memory_zone in memory_zones.iter() {
                         if let Some(mm_zone) = mm_zones.get(memory_zone) {
                             node.memory_regions.extend(mm_zone.regions().clone());
+                            if let Some(virtiomem_zone) = mm_zone.virtio_mem_zone() {
+                                node.hotplug_regions.push(virtiomem_zone.region().clone());
+                            }
                             node.memory_zones.push(memory_zone.clone());
                         } else {
                             error!("Unknown memory zone '{}'", memory_zone);


### PR DESCRIPTION
virtio-mem device would use 'VIRTIO_MEM_F_ACPI_PXM' to add memory to NUMA
node, which MUST be existed, otherwise it will be assigned to node id 0,
even if user specify different node id.

According ACPI spec about Memory Affinity Structure, system hardware
supports hot-add memory region using 'Hot Pluggable | Enabled' flags.

Fixes: #1736

Signed-off-by: Jiangbo Wu <jiangbo.wu@intel.com>