### PR TITLE
Port the last two integration tests to the new methodology

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2012,6 +2012,7 @@ mod tests {
             .default_disks()
             .args(&["--net", guest1.default_net_string().as_str()])
             .args(&["--serial", "tty", "--console", "off"])
+            .capture_output()
             .spawn()
             .unwrap();
 


### PR DESCRIPTION
Besides porting the last two tests `test_simple_launch` and `test_reboot`, this patch also sets the pipe size as 256K when we capture/pipe the cloud-hypervisor child process stdout/stderr. This is the work-around for the the `vcpu` thread stall issue when using `--serial tty` (details #1707). 

Note that the pipe size (256K) is chosen based on the output size of our integration tests at this point (`test_reboot` now has the largest stdout size). The pipe size may need to be increased in the future.