### PR TITLE
balloon.rs: BalloonEpollHandler: Fix wrong error in handle_event

### DIFF
--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -297,7 +297,7 @@ impl EpollHelperHandler for BalloonEpollHandler {
                 }
             }
             _ => {
-                error!("Unknown event for virtio-mem");
+                error!("Unknown event for virtio-balloon");
                 return true;
             }
         }


### PR DESCRIPTION
error!("Unknown event for virtio-mem");
This error should be
error!("Unknown event for virtio-balloon");

Signed-off-by: Hui Zhu <teawater@antfin.com>