### PR TITLE
Add a virtio-watchdog

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -676,10 +676,12 @@ impl cpu::Vcpu for KvmVcpu {
 
                 #[cfg(target_arch = "aarch64")]
                 VcpuExit::SystemEvent(event_type, flags) => {
-                    use kvm_bindings::KVM_SYSTEM_EVENT_SHUTDOWN;
+                    use kvm_bindings::{KVM_SYSTEM_EVENT_RESET, KVM_SYSTEM_EVENT_SHUTDOWN};
                     // On Aarch64, when the VM is shutdown, run() returns
                     // VcpuExit::SystemEvent with reason KVM_SYSTEM_EVENT_SHUTDOWN
-                    if event_type == KVM_SYSTEM_EVENT_SHUTDOWN {
+                    if event_type == KVM_SYSTEM_EVENT_SHUTDOWN
+                        || event_type == KVM_SYSTEM_EVENT_RESET
+                    {
                         Ok(cpu::VmExit::Reset)
                     } else {
                         Err(cpu::HypervisorCpuError::RunVcpu(anyhow!(

--- a/resources/linux-config-x86_64
+++ b/resources/linux-config-x86_64
@@ -1525,7 +1525,68 @@ CONFIG_THERMAL_GOV_USER_SPACE=y
 # CONFIG_INTEL_PCH_THERMAL is not set
 # end of Intel thermal drivers
 
-# CONFIG_WATCHDOG is not set
+CONFIG_WATCHDOG=y
+CONFIG_WATCHDOG_CORE=y
+# CONFIG_WATCHDOG_NOWAYOUT is not set
+CONFIG_WATCHDOG_HANDLE_BOOT_ENABLED=y
+CONFIG_WATCHDOG_OPEN_TIMEOUT=0
+# CONFIG_WATCHDOG_SYSFS is not set
+
+#
+# Watchdog Pretimeout Governors
+#
+# CONFIG_WATCHDOG_PRETIMEOUT_GOV is not set
+
+#
+# Watchdog Device Drivers
+#
+# CONFIG_SOFT_WATCHDOG is not set
+# CONFIG_WDAT_WDT is not set
+# CONFIG_XILINX_WATCHDOG is not set
+# CONFIG_CADENCE_WATCHDOG is not set
+# CONFIG_DW_WATCHDOG is not set
+# CONFIG_MAX63XX_WATCHDOG is not set
+# CONFIG_ACQUIRE_WDT is not set
+# CONFIG_ADVANTECH_WDT is not set
+# CONFIG_ALIM1535_WDT is not set
+# CONFIG_ALIM7101_WDT is not set
+# CONFIG_EBC_C384_WDT is not set
+# CONFIG_F71808E_WDT is not set
+# CONFIG_SP5100_TCO is not set
+# CONFIG_SBC_FITPC2_WATCHDOG is not set
+# CONFIG_EUROTECH_WDT is not set
+# CONFIG_IB700_WDT is not set
+# CONFIG_IBMASR is not set
+# CONFIG_WAFER_WDT is not set
+# CONFIG_I6300ESB_WDT is not set
+# CONFIG_IE6XX_WDT is not set
+# CONFIG_ITCO_WDT is not set
+# CONFIG_IT8712F_WDT is not set
+# CONFIG_IT87_WDT is not set
+# CONFIG_HP_WATCHDOG is not set
+# CONFIG_SC1200_WDT is not set
+# CONFIG_PC87413_WDT is not set
+# CONFIG_NV_TCO is not set
+# CONFIG_60XX_WDT is not set
+# CONFIG_CPU5_WDT is not set
+# CONFIG_SMSC_SCH311X_WDT is not set
+# CONFIG_SMSC37B787_WDT is not set
+# CONFIG_TQMX86_WDT is not set
+# CONFIG_VIA_WDT is not set
+# CONFIG_W83627HF_WDT is not set
+# CONFIG_W83877F_WDT is not set
+# CONFIG_W83977F_WDT is not set
+# CONFIG_MACHZ_WDT is not set
+# CONFIG_SBC_EPX_C3_WATCHDOG is not set
+# CONFIG_NI903X_WDT is not set
+# CONFIG_NIC7018_WDT is not set
+CONFIG_VIRTIO_WDT=y
+
+#
+# PCI-based Watchdog Cards
+#
+# CONFIG_PCIPCWATCHDOG is not set
+# CONFIG_WDTPCI is not set
 CONFIG_SSB_POSSIBLE=y
 # CONFIG_SSB is not set
 CONFIG_BCMA_POSSIBLE=y

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -97,7 +97,7 @@ LINUX_CUSTOM_DIR="$WORKLOADS_DIR/linux-custom"
 if [ ! -f "$VMLINUX_IMAGE" ] || [ ! -f "$VMLINUX_PVH_IMAGE" ]; then
     SRCDIR=$PWD
     pushd $WORKLOADS_DIR
-    time git clone --depth 1 "https://github.com/cloud-hypervisor/linux.git" -b "virtio-fs-virtio-iommu-5.8-rc4" $LINUX_CUSTOM_DIR
+    time git clone --depth 1 "https://github.com/rbradford/linux.git" -b "2020-09-22-virtio-watchdog" $LINUX_CUSTOM_DIR
     cp $SRCDIR/resources/linux-config-x86_64 $LINUX_CUSTOM_DIR/.config
     popd
 fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,6 +232,13 @@ fn create_app<'a, 'b>(
                 .group("vm-config"),
         )
         .arg(
+            Arg::with_name("watchdog")
+            .long("watchdog")
+            .help("Enable virtio-watchdog")
+            .takes_value(false)
+            .group("vm-config")
+        )
+        .arg(
             Arg::with_name("v")
                 .short("v")
                 .multiple(true)
@@ -579,6 +586,7 @@ mod unit_tests {
                 #[cfg(target_arch = "x86_64")]
                 sgx_epc: None,
                 numa: None,
+                watchdog: false,
             };
 
             aver_eq!(tb, expected_vm_config, result_vm_config);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5236,6 +5236,116 @@ mod tests {
 
             handle_child_output(r, &output);
         }
+
+        #[cfg_attr(not(feature = "mmio"), test)]
+        fn test_watchdog() {
+            let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+            let guest = Guest::new(&mut focal);
+            let api_socket = temp_api_path(&guest.tmp_dir);
+
+            let kernel_path = direct_kernel_boot_path().unwrap();
+
+            let mut cmd = GuestCommand::new(&guest);
+            cmd.args(&["--cpus", "boot=1"])
+                .args(&["--memory", "size=512M"])
+                .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+                .default_disks()
+                .args(&["--net", guest.default_net_string().as_str()])
+                .args(&["--watchdog"])
+                .args(&["--api-socket", &api_socket])
+                .capture_output();
+
+            let mut child = cmd.spawn().unwrap();
+
+            thread::sleep(std::time::Duration::new(20, 0));
+            let r = std::panic::catch_unwind(|| {
+                // Check for PCI device
+                assert!(guest
+                    .does_device_vendor_pair_match("0x1063", "0x1af4")
+                    .unwrap_or_default());
+
+                // Enable systemd watchdog
+                guest
+                    .ssh_command(
+                        "echo RuntimeWatchdogSec=15s | sudo tee -a /etc/systemd/system.conf",
+                    )
+                    .unwrap();
+
+                guest.ssh_command("sudo reboot").unwrap();
+                thread::sleep(std::time::Duration::new(20, 0));
+
+                // Check that systemd has activated the watchdog
+                assert_eq!(
+                    guest
+                        .ssh_command("sudo journalctl | grep -c -- \"Watchdog started\"")
+                        .unwrap_or_default()
+                        .trim()
+                        .parse::<u32>()
+                        .unwrap_or_default(),
+                    2
+                );
+
+                // Ensure that the current boot journal is written so reboot counts are valid
+                guest.ssh_command("sudo journalctl --sync").unwrap();
+
+                let boot_count = guest
+                    .ssh_command("sudo journalctl --list-boots | wc -l")
+                    .unwrap_or_default()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default();
+                assert_eq!(boot_count, 2);
+                // Allow some normal time to elapse to check we don't get spurious reboots
+                thread::sleep(std::time::Duration::new(40, 0));
+
+                // Check no reboot
+                let boot_count = guest
+                    .ssh_command("sudo journalctl --list-boots | wc -l")
+                    .unwrap_or_default()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default();
+                assert_eq!(boot_count, 2);
+
+                // Ensure that the current boot journal is written so reboot counts are valid
+                guest.ssh_command("sudo journalctl --sync").unwrap();
+
+                // Trigger a panic (sync first). We need to do this inside a screen with a delay so the SSH command returns.
+                guest.ssh_command("screen -dmS reboot sh -c \"sleep 5; echo s | tee /proc/sysrq-trigger; echo c | sudo tee /proc/sysrq-trigger\"").unwrap();
+
+                // Allow some time for the watchdog to trigger (max 30s) and reboot to happen
+                thread::sleep(std::time::Duration::new(50, 0));
+
+                // Check that watchdog triggered reboot
+                let boot_count = guest
+                    .ssh_command("sudo journalctl --list-boots | wc -l")
+                    .unwrap_or_default()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default();
+                assert_eq!(boot_count, 3);
+
+                // Now pause the VM and remain offline for 30s
+                assert!(remote_command(&api_socket, "pause", None));
+                thread::sleep(std::time::Duration::new(30, 0));
+                assert!(remote_command(&api_socket, "resume", None));
+
+                // Check no reboot
+                let boot_count = guest
+                    .ssh_command("sudo journalctl --list-boots | wc -l")
+                    .unwrap_or_default()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default();
+                assert_eq!(boot_count, 3);
+            });
+
+            let _ = child.kill();
+            let output = child.wait_with_output().unwrap();
+
+            handle_child_output(r, &output);
+        }
     }
 
     mod sequential {

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -45,6 +45,7 @@ pub mod seccomp_filters;
 pub mod transport;
 pub mod vhost_user;
 pub mod vsock;
+pub mod watchdog;
 
 pub use self::balloon::*;
 pub use self::block::*;
@@ -60,6 +61,7 @@ pub use self::net_util::*;
 pub use self::pmem::*;
 pub use self::rng::*;
 pub use self::vsock::*;
+pub use self::watchdog::*;
 use vm_virtio::{queue::*, VirtioDeviceType};
 
 const DEVICE_INIT: u32 = 0x00;

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -27,6 +27,7 @@ pub enum Thread {
     VirtioVhostNet,
     VirtioVhostNetCtl,
     VirtioVsock,
+    VirtioWatchdog,
 }
 
 /// Shorthand for chaining `SeccompCondition`s with the `and` operator  in a `SeccompRule`.
@@ -408,6 +409,33 @@ fn virtio_vsock_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     ])
 }
 
+fn virtio_watchdog_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
+    Ok(vec![
+        allow_syscall(libc::SYS_brk),
+        allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_dup),
+        allow_syscall(libc::SYS_epoll_create1),
+        allow_syscall(libc::SYS_epoll_ctl),
+        allow_syscall(libc::SYS_epoll_pwait),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_epoll_wait),
+        allow_syscall(libc::SYS_exit),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_madvise),
+        allow_syscall(libc::SYS_mmap),
+        allow_syscall(libc::SYS_mprotect),
+        allow_syscall(libc::SYS_munmap),
+        allow_syscall(libc::SYS_prctl),
+        allow_syscall(libc::SYS_read),
+        allow_syscall(libc::SYS_rt_sigprocmask),
+        allow_syscall(libc::SYS_sched_getaffinity),
+        allow_syscall(libc::SYS_set_robust_list),
+        allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_timerfd_settime),
+        allow_syscall(libc::SYS_write),
+    ])
+}
+
 fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> {
     let rules = match thread_type {
         Thread::VirtioBalloon => virtio_balloon_thread_rules()?,
@@ -425,6 +453,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
         Thread::VirtioVhostNet => virtio_vhost_net_thread_rules()?,
         Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules()?,
         Thread::VirtioVsock => virtio_vsock_thread_rules()?,
+        Thread::VirtioWatchdog => virtio_watchdog_thread_rules()?,
     };
 
     Ok(SeccompFilter::new(
@@ -450,6 +479,7 @@ fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
         Thread::VirtioVhostNet => virtio_vhost_net_thread_rules()?,
         Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules()?,
         Thread::VirtioVsock => virtio_vsock_thread_rules()?,
+        Thread::VirtioWatchdog => virtio_watchdog_thread_rules()?,
     };
 
     Ok(SeccompFilter::new(

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -1,0 +1,439 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+use super::Error as DeviceError;
+use super::{
+    ActivateError, ActivateResult, EpollHelper, EpollHelperError, EpollHelperHandler, Queue,
+    VirtioCommon, VirtioDevice, VirtioDeviceType, EPOLL_HELPER_EVENT_LAST, VIRTIO_F_VERSION_1,
+};
+use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::{VirtioInterrupt, VirtioInterruptType};
+use anyhow::anyhow;
+use seccomp::{SeccompAction, SeccompFilter};
+use std::fs::File;
+use std::io::{self, Read};
+use std::num::Wrapping;
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::result;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Barrier, Mutex};
+use std::thread;
+use std::time::Instant;
+use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_migration::{
+    Migratable, MigratableError, Pausable, Snapshot, SnapshotDataSection, Snapshottable,
+    Transportable,
+};
+use vmm_sys_util::eventfd::EventFd;
+
+const QUEUE_SIZE: u16 = 256;
+const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE];
+
+// New descriptors are pending on the virtio queue.
+const QUEUE_AVAIL_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 1;
+// Timer expired
+const TIMER_EXPIRED_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 2;
+
+// Number of seconds to check to see if there has been a ping
+// This needs to match what the driver is using.
+const WATCHDOG_TIMER_INTERVAL: i64 = 15;
+
+// Number of seconds since last ping to trigger reboot
+const WATCHDOG_TIMEOUT: u64 = WATCHDOG_TIMER_INTERVAL as u64 + 5;
+
+struct WatchdogEpollHandler {
+    queues: Vec<Queue>,
+    mem: GuestMemoryAtomic<GuestMemoryMmap>,
+    interrupt_cb: Arc<dyn VirtioInterrupt>,
+    queue_evt: EventFd,
+    kill_evt: EventFd,
+    pause_evt: EventFd,
+    counter: Wrapping<u64>,
+    timer: File,
+    last_ping_time: Arc<Mutex<Option<Instant>>>,
+    reset_evt: EventFd,
+}
+
+impl WatchdogEpollHandler {
+    // The main queue is very simple - the driver "pings" the device by passing it a (write-only)
+    // descriptor. In response the device returns an incrementing counter. The driver doesn't
+    // currently do anything with that value. So therefore we don't preserve it over snapshot/restore.
+    fn process_queue(&mut self) -> bool {
+        let queue = &mut self.queues[0];
+        let mut used_desc_heads = [(0, 0); QUEUE_SIZE as usize];
+        let mut used_count = 0;
+        let mem = self.mem.memory();
+        for avail_desc in queue.iter(&mem) {
+            let mut len = 0;
+
+            if avail_desc.is_write_only() {
+                if mem
+                    .write_slice(&self.counter.0.to_le_bytes(), avail_desc.addr)
+                    .is_ok()
+                {
+                    len = avail_desc.len;
+                    // If this is the first "ping" then setup the timer
+                    if self.last_ping_time.lock().unwrap().is_none() {
+                        info!(
+                            "First ping received. Starting timer (every {} seconds)",
+                            WATCHDOG_TIMER_INTERVAL
+                        );
+                        if let Err(e) = timerfd_setup(&self.timer, WATCHDOG_TIMER_INTERVAL) {
+                            error!("Error programming timer fd: {:?}", e);
+                        }
+                    }
+                    self.last_ping_time.lock().unwrap().replace(Instant::now());
+                }
+                self.counter += Wrapping(1);
+            }
+
+            used_desc_heads[used_count] = (avail_desc.index, len);
+            used_count += 1;
+        }
+
+        for &(desc_index, len) in &used_desc_heads[..used_count] {
+            queue.add_used(&mem, desc_index, len);
+        }
+        used_count > 0
+    }
+
+    fn signal_used_queue(&self) -> result::Result<(), DeviceError> {
+        self.interrupt_cb
+            .trigger(&VirtioInterruptType::Queue, Some(&self.queues[0]))
+            .map_err(|e| {
+                error!("Failed to signal used queue: {:?}", e);
+                DeviceError::FailedSignalingUsedQueue(e)
+            })
+    }
+
+    fn run(
+        &mut self,
+        paused: Arc<AtomicBool>,
+        paused_sync: Arc<Barrier>,
+    ) -> result::Result<(), EpollHelperError> {
+        let mut helper = EpollHelper::new(&self.kill_evt, &self.pause_evt)?;
+        helper.add_event(self.queue_evt.as_raw_fd(), QUEUE_AVAIL_EVENT)?;
+        helper.add_event(self.timer.as_raw_fd(), TIMER_EXPIRED_EVENT)?;
+        helper.run(paused, paused_sync, self)?;
+
+        Ok(())
+    }
+}
+
+impl EpollHelperHandler for WatchdogEpollHandler {
+    fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
+        let ev_type = event.data as u16;
+        match ev_type {
+            QUEUE_AVAIL_EVENT => {
+                if let Err(e) = self.queue_evt.read() {
+                    error!("Failed to get queue event: {:?}", e);
+                    return true;
+                } else if self.process_queue() {
+                    if let Err(e) = self.signal_used_queue() {
+                        error!("Failed to signal used queue: {:?}", e);
+                        return true;
+                    }
+                }
+            }
+            TIMER_EXPIRED_EVENT => {
+                // When reading from the timerfd you get 8 bytes indicating
+                // the number of times this event has elapsed since the last read.
+                let mut buf = vec![0; 8];
+                if let Err(e) = self.timer.read_exact(&mut buf) {
+                    error!("Error reading from timer fd: {:}", e);
+                    return true;
+                }
+                if let Some(last_ping_time) = self.last_ping_time.lock().unwrap().as_ref() {
+                    let now = Instant::now();
+                    let gap = now.duration_since(*last_ping_time).as_secs();
+                    if gap > WATCHDOG_TIMEOUT {
+                        error!("Watchdog triggered: {} seconds since last ping", gap);
+                        self.reset_evt.write(1).ok();
+                    }
+                }
+                return false;
+            }
+            _ => {
+                error!("Unexpected event: {}", ev_type);
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Virtio device for exposing entropy to the guest OS through virtio.
+pub struct Watchdog {
+    common: VirtioCommon,
+    id: String,
+    seccomp_action: SeccompAction,
+    reset_evt: EventFd,
+    last_ping_time: Arc<Mutex<Option<Instant>>>,
+    timer: File,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct WatchdogState {
+    pub avail_features: u64,
+    pub acked_features: u64,
+    pub enabled: bool,
+}
+
+impl Watchdog {
+    /// Create a new virtio watchdog device that will reboot VM if the guest hangs
+    pub fn new(
+        id: String,
+        reset_evt: EventFd,
+        seccomp_action: SeccompAction,
+    ) -> io::Result<Watchdog> {
+        let avail_features = 1u64 << VIRTIO_F_VERSION_1;
+        let timer_fd = timerfd_create().map_err(|e| {
+            error!("Failed to create timer fd {}", e);
+            e
+        })?;
+        let timer = unsafe { File::from_raw_fd(timer_fd) };
+        Ok(Watchdog {
+            common: VirtioCommon {
+                device_type: VirtioDeviceType::TYPE_WATCHDOG as u32,
+                queue_sizes: QUEUE_SIZES.to_vec(),
+                paused_sync: Some(Arc::new(Barrier::new(2))),
+                avail_features,
+                ..Default::default()
+            },
+            id,
+            seccomp_action,
+            reset_evt,
+            last_ping_time: Arc::new(Mutex::new(None)),
+            timer,
+        })
+    }
+
+    fn state(&self) -> WatchdogState {
+        WatchdogState {
+            avail_features: self.common.avail_features,
+            acked_features: self.common.acked_features,
+            enabled: self.last_ping_time.lock().unwrap().is_some(),
+        }
+    }
+
+    fn set_state(&mut self, state: &WatchdogState) -> io::Result<()> {
+        self.common.avail_features = state.avail_features;
+        self.common.acked_features = state.acked_features;
+        // When restoring enable the watchdog if it was previously enabled. We reset the timer
+        // to ensure that we don't unnecesarily reboot due to the offline time.
+        if state.enabled {
+            self.last_ping_time.lock().unwrap().replace(Instant::now());
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Watchdog {
+    fn drop(&mut self) {
+        if let Some(kill_evt) = self.common.kill_evt.take() {
+            // Ignore the result because there is nothing we can do about it.
+            let _ = kill_evt.write(1);
+        }
+    }
+}
+
+fn timerfd_create() -> Result<RawFd, io::Error> {
+    let res = unsafe { libc::timerfd_create(libc::CLOCK_MONOTONIC, 0) };
+    if res < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(res as RawFd)
+    }
+}
+
+fn timerfd_setup(timer: &File, secs: i64) -> Result<(), io::Error> {
+    let periodic = libc::itimerspec {
+        it_interval: libc::timespec {
+            tv_sec: secs,
+            tv_nsec: 0,
+        },
+        it_value: libc::timespec {
+            tv_sec: secs,
+            tv_nsec: 0,
+        },
+    };
+
+    let res =
+        unsafe { libc::timerfd_settime(timer.as_raw_fd(), 0, &periodic, std::ptr::null_mut()) };
+
+    if res < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+impl VirtioDevice for Watchdog {
+    fn device_type(&self) -> u32 {
+        self.common.device_type
+    }
+
+    fn queue_max_sizes(&self) -> &[u16] {
+        &self.common.queue_sizes
+    }
+
+    fn features(&self) -> u64 {
+        self.common.avail_features
+    }
+
+    fn ack_features(&mut self, value: u64) {
+        self.common.ack_features(value)
+    }
+
+    fn activate(
+        &mut self,
+        mem: GuestMemoryAtomic<GuestMemoryMmap>,
+        interrupt_cb: Arc<dyn VirtioInterrupt>,
+        queues: Vec<Queue>,
+        mut queue_evts: Vec<EventFd>,
+    ) -> ActivateResult {
+        self.common.activate(&queues, &queue_evts, &interrupt_cb)?;
+        let kill_evt = self
+            .common
+            .kill_evt
+            .as_ref()
+            .unwrap()
+            .try_clone()
+            .map_err(|e| {
+                error!("Failed to clone kill_evt eventfd: {}", e);
+                ActivateError::BadActivate
+            })?;
+        let pause_evt = self
+            .common
+            .pause_evt
+            .as_ref()
+            .unwrap()
+            .try_clone()
+            .map_err(|e| {
+                error!("Failed to clone pause_evt eventfd: {}", e);
+                ActivateError::BadActivate
+            })?;
+
+        let reset_evt = self.reset_evt.try_clone().map_err(|e| {
+            error!("Failed to clone reset_evt eventfd: {}", e);
+            ActivateError::BadActivate
+        })?;
+
+        let timer = self.timer.try_clone().map_err(|e| {
+            error!("Failed to clone timer fd: {}", e);
+            ActivateError::BadActivate
+        })?;
+
+        let mut handler = WatchdogEpollHandler {
+            queues,
+            mem,
+            counter: Wrapping(0),
+            interrupt_cb,
+            queue_evt: queue_evts.remove(0),
+            kill_evt,
+            pause_evt,
+            timer,
+            last_ping_time: self.last_ping_time.clone(),
+            reset_evt,
+        };
+
+        let paused = self.common.paused.clone();
+        let paused_sync = self.common.paused_sync.clone();
+        let mut epoll_threads = Vec::new();
+        // Retrieve seccomp filter for virtio_watchdog thread
+        let virtio_watchdog_seccomp_filter =
+            get_seccomp_filter(&self.seccomp_action, Thread::VirtioWatchdog)
+                .map_err(ActivateError::CreateSeccompFilter)?;
+        thread::Builder::new()
+            .name("virtio_watchdog".to_string())
+            .spawn(move || {
+                if let Err(e) = SeccompFilter::apply(virtio_watchdog_seccomp_filter) {
+                    error!("Error applying seccomp filter: {:?}", e);
+                } else if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
+                    error!("Error running worker: {:?}", e);
+                }
+            })
+            .map(|thread| epoll_threads.push(thread))
+            .map_err(|e| {
+                error!("failed to clone the virtio-watchdog epoll thread: {}", e);
+                ActivateError::BadActivate
+            })?;
+
+        self.common.epoll_threads = Some(epoll_threads);
+
+        Ok(())
+    }
+
+    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+        self.common.reset()
+    }
+}
+
+impl Pausable for Watchdog {
+    fn pause(&mut self) -> result::Result<(), MigratableError> {
+        info!("Watchdog paused - disabling timer");
+        timerfd_setup(&self.timer, 0)
+            .map_err(|e| MigratableError::Pause(anyhow!("Error clearing timer: {:?}", e)))?;
+        self.common.pause()
+    }
+
+    fn resume(&mut self) -> result::Result<(), MigratableError> {
+        // Reset the timer on pause if it was previously used
+        if self.last_ping_time.lock().unwrap().is_some() {
+            info!(
+                "Watchdog resumed - enabling timer (every {} seconds)",
+                WATCHDOG_TIMER_INTERVAL
+            );
+            self.last_ping_time.lock().unwrap().replace(Instant::now());
+            timerfd_setup(&self.timer, WATCHDOG_TIMER_INTERVAL)
+                .map_err(|e| MigratableError::Resume(anyhow!("Error setting timer: {:?}", e)))?;
+        }
+        self.common.resume()
+    }
+}
+
+impl Snapshottable for Watchdog {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+        let snapshot =
+            serde_json::to_vec(&self.state()).map_err(|e| MigratableError::Snapshot(e.into()))?;
+
+        let mut watchdog_snapshot = Snapshot::new(self.id.as_str());
+        watchdog_snapshot.add_data_section(SnapshotDataSection {
+            id: format!("{}-section", self.id),
+            snapshot,
+        });
+
+        Ok(watchdog_snapshot)
+    }
+
+    fn restore(&mut self, snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
+        if let Some(watchdog_section) = snapshot.snapshot_data.get(&format!("{}-section", self.id))
+        {
+            let watchdog_state = match serde_json::from_slice(&watchdog_section.snapshot) {
+                Ok(state) => state,
+                Err(error) => {
+                    return Err(MigratableError::Restore(anyhow!(
+                        "Could not deserialize watchdog {}",
+                        error
+                    )))
+                }
+            };
+
+            return self.set_state(&watchdog_state).map_err(|e| {
+                MigratableError::Restore(anyhow!("Could not restore watchdog state {:?}", e))
+            });
+        }
+
+        Err(MigratableError::Restore(anyhow!(
+            "Could not find watchdog snapshot section"
+        )))
+    }
+}
+
+impl Transportable for Watchdog {}
+impl Migratable for Watchdog {}

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -42,6 +42,7 @@ pub enum VirtioDeviceType {
     TYPE_MEM = 24,
     TYPE_FS = 26,
     TYPE_PMEM = 27,
+    TYPE_WATCHDOG = 35, // Temporary until official number allocated
     TYPE_UNKNOWN = 0xFF,
 }
 
@@ -61,6 +62,7 @@ impl From<u32> for VirtioDeviceType {
             24 => VirtioDeviceType::TYPE_MEM,
             26 => VirtioDeviceType::TYPE_FS,
             27 => VirtioDeviceType::TYPE_PMEM,
+            28 => VirtioDeviceType::TYPE_WATCHDOG,
             _ => VirtioDeviceType::TYPE_UNKNOWN,
         }
     }
@@ -85,6 +87,7 @@ impl fmt::Display for VirtioDeviceType {
             VirtioDeviceType::TYPE_MEM => "mem",
             VirtioDeviceType::TYPE_FS => "fs",
             VirtioDeviceType::TYPE_PMEM => "pmem",
+            VirtioDeviceType::TYPE_WATCHDOG => "watchdog",
             VirtioDeviceType::TYPE_UNKNOWN => "UNKNOWN",
         };
         write!(f, "{}", output)

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -436,6 +436,9 @@ components:
         iommu:
           type: boolean
           default: false
+        watchdog:
+          type: boolean
+          default: false
       description: Virtual machine configuration
 
     CpuTopology:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -193,6 +193,7 @@ pub struct VmParams<'a> {
     #[cfg(target_arch = "x86_64")]
     pub sgx_epc: Option<Vec<&'a str>>,
     pub numa: Option<Vec<&'a str>>,
+    pub watchdog: bool,
 }
 
 impl<'a> VmParams<'a> {
@@ -218,6 +219,7 @@ impl<'a> VmParams<'a> {
         #[cfg(target_arch = "x86_64")]
         let sgx_epc: Option<Vec<&str>> = args.values_of("sgx-epc").map(|x| x.collect());
         let numa: Option<Vec<&str>> = args.values_of("numa").map(|x| x.collect());
+        let watchdog = args.is_present("watchdog");
 
         VmParams {
             cpus,
@@ -238,6 +240,7 @@ impl<'a> VmParams<'a> {
             #[cfg(target_arch = "x86_64")]
             sgx_epc,
             numa,
+            watchdog,
         }
     }
 }
@@ -1378,6 +1381,8 @@ pub struct VmConfig {
     #[cfg(target_arch = "x86_64")]
     pub sgx_epc: Option<Vec<SgxEpcConfig>>,
     pub numa: Option<Vec<NumaConfig>>,
+    #[serde(default)]
+    pub watchdog: bool,
 }
 
 impl VmConfig {
@@ -1594,6 +1599,7 @@ impl VmConfig {
             #[cfg(target_arch = "x86_64")]
             sgx_epc,
             numa,
+            watchdog: vm_params.watchdog,
         };
         config.validate().map_err(Error::Validation)?;
         Ok(config)
@@ -2173,6 +2179,7 @@ mod tests {
             #[cfg(target_arch = "x86_64")]
             sgx_epc: None,
             numa: None,
+            watchdog: false,
         };
 
         assert!(valid_config.validate().is_ok());

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -118,6 +118,7 @@ const NET_DEVICE_NAME_PREFIX: &str = "_net";
 const PMEM_DEVICE_NAME_PREFIX: &str = "_pmem";
 const RNG_DEVICE_NAME: &str = "_rng";
 const VSOCK_DEVICE_NAME_PREFIX: &str = "_vsock";
+const WATCHDOG_DEVICE_NAME: &str = "_watchdog";
 
 #[cfg(feature = "pci_support")]
 const IOMMU_DEVICE_NAME: &str = "_iommu";
@@ -177,6 +178,9 @@ pub enum DeviceManagerError {
 
     /// Cannot create virtio-balloon device
     CreateVirtioBalloon(io::Error),
+
+    /// Cannot create virtio-watchdog device
+    CreateVirtioWatchdog(io::Error),
 
     /// Failed parsing disk image format
     DetectImageType(qcow::Error),
@@ -798,8 +802,6 @@ pub struct DeviceManager {
     #[cfg(feature = "acpi")]
     exit_evt: EventFd,
 
-    // Reset event
-    #[cfg(target_arch = "x86_64")]
     reset_evt: EventFd,
 
     #[cfg(target_arch = "aarch64")]
@@ -820,7 +822,7 @@ impl DeviceManager {
         config: Arc<Mutex<VmConfig>>,
         memory_manager: Arc<Mutex<MemoryManager>>,
         _exit_evt: &EventFd,
-        #[cfg_attr(target_arch = "aarch64", allow(unused_variables))] reset_evt: &EventFd,
+        reset_evt: &EventFd,
         vmm_path: PathBuf,
         seccomp_action: SeccompAction,
         #[cfg(feature = "acpi")] numa_nodes: NumaNodes,
@@ -881,7 +883,6 @@ impl DeviceManager {
             device_tree,
             #[cfg(feature = "acpi")]
             exit_evt: _exit_evt.try_clone().map_err(DeviceManagerError::EventFd)?,
-            #[cfg(target_arch = "x86_64")]
             reset_evt: reset_evt.try_clone().map_err(DeviceManagerError::EventFd)?,
             #[cfg(target_arch = "aarch64")]
             id_to_dev_info: HashMap::new(),
@@ -1591,6 +1592,9 @@ impl DeviceManager {
 
         // Add virtio-balloon if required
         devices.append(&mut self.make_virtio_balloon_devices()?);
+
+        // Add virtio-watchdog device
+        devices.append(&mut self.make_virtio_watchdog_devices()?);
 
         Ok(devices)
     }
@@ -2524,6 +2528,39 @@ impl DeviceManager {
                 .unwrap()
                 .insert(id.clone(), device_node!(id, virtio_balloon_device));
         }
+
+        Ok(devices)
+    }
+
+    fn make_virtio_watchdog_devices(
+        &mut self,
+    ) -> DeviceManagerResult<Vec<(VirtioDeviceArc, bool, String)>> {
+        let mut devices = Vec::new();
+
+        if !self.config.lock().unwrap().watchdog {
+            return Ok(devices);
+        }
+
+        let id = String::from(WATCHDOG_DEVICE_NAME);
+
+        let virtio_watchdog_device = Arc::new(Mutex::new(
+            virtio_devices::Watchdog::new(
+                id.clone(),
+                self.reset_evt.try_clone().unwrap(),
+                self.seccomp_action.clone(),
+            )
+            .map_err(DeviceManagerError::CreateVirtioWatchdog)?,
+        ));
+        devices.push((
+            Arc::clone(&virtio_watchdog_device) as VirtioDeviceArc,
+            false,
+            id.clone(),
+        ));
+
+        self.device_tree
+            .lock()
+            .unwrap()
+            .insert(id.clone(), device_node!(id, virtio_watchdog_device));
 
         Ok(devices)
     }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -364,6 +364,8 @@ fn vmm_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_stat),
         allow_syscall(libc::SYS_statx),
         allow_syscall(libc::SYS_tgkill),
+        allow_syscall(libc::SYS_timerfd_create),
+        allow_syscall(libc::SYS_timerfd_settime),
         allow_syscall(libc::SYS_tkill),
         allow_syscall_if(
             libc::SYS_umask,
@@ -456,6 +458,8 @@ fn vcpu_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_stat),
         allow_syscall(libc::SYS_statx),
         allow_syscall(libc::SYS_tgkill),
+        allow_syscall(libc::SYS_timerfd_create),
+        allow_syscall(libc::SYS_timerfd_settime),
         allow_syscall(libc::SYS_tkill),
         allow_syscall(libc::SYS_write),
     ])


### PR DESCRIPTION
Early review

- [ ] Need to request device id allocation (looks like it takes some time ~ last request has been open since early September)
- [ ] Need to decide if we want to have the watchdog driver set the timeout times - e.g. via virtio config range - currently time is fixed at 15s on both sides
- [ ] Currently the protocol is just writing a u64 counter into the descriptor - used by neither side so could just be a u8 status bit. Or maybe be more advanced in having a handshake with guest writing a value to a driver write-only descriptor then the device writing the same value to a device write-only acknowledge that is has seen it.
- [ ] Need to consider whether we want to be able to explicitly start/stop e.g. via an enabled flag in some virtio config range vs current "no way out" and started by first ping

Should flesh this out before we submit the design for review.