### PR TITLE
virtio-devices: balloon: Add support for reporting free page  to host

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -915,14 +915,15 @@ impl Default for RngConfig {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct BalloonConfig {
     pub size: u64,
+    pub reporting: bool,
 }
 
 impl BalloonConfig {
-    pub const SYNTAX: &'static str = "Balloon parameters \"size=<balloon_size>\"";
+    pub const SYNTAX: &'static str = "Balloon parameters \"size=<balloon_size>,reporting=on|off\"";
 
     pub fn parse(balloon: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
-        parser.add("size");
+        parser.add("size").add("reporting");
         parser.parse(balloon).map_err(Error::ParseBalloon)?;
 
         let size = parser
@@ -930,8 +931,13 @@ impl BalloonConfig {
             .map_err(Error::ParseBalloon)?
             .map(|v| v.0)
             .unwrap_or(0);
+        let reporting = parser
+            .convert::<Toggle>("reporting")
+            .map_err(Error::ParseBalloon)?
+            .unwrap_or(Toggle(false))
+            .0;
 
-        Ok(BalloonConfig { size })
+        Ok(BalloonConfig { size, reporting })
     }
 }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2457,6 +2457,7 @@ impl DeviceManager {
                 virtio_devices::Balloon::new(
                     id.clone(),
                     balloon_config.size,
+                    balloon_config.reporting,
                     self.seccomp_action.clone(),
                 )
                 .map_err(DeviceManagerError::CreateVirtioBalloon)?,


### PR DESCRIPTION
https://www.kernel.org/doc/Documentation/vm/free_page_reporting.rst
This is the introduction of Linux kernel free page reporting.

Add support for the page reporting feature provided by virtio-balloon.  Reporting differs from the regular balloon functionality in that is is much less durable than a standard memory balloon. Instead of creating a list of pages that cannot be accessed the pages are only inaccessible while they are being indicated to the virtio interface. Once the interface has acknowledged them they are placed back into their respective free lists and are once again accessible by the guest system.

Unlike a standard balloon we don't inflate and deflate the pages.
Instead we perform the reporting, and once the reporting is completed it is assumed that the page has been dropped from the guest and will be faulted back in the next time the page is accessed.