### PR TITLE
arch: x86_64: Create MP table after SMBIOS table if space

### DIFF
--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -161,7 +161,7 @@ fn write_string(
     Ok(curptr)
 }
 
-pub fn setup_smbios(mem: &GuestMemoryMmap) -> Result<()> {
+pub fn setup_smbios(mem: &GuestMemoryMmap) -> Result<u64> {
     let physptr = GuestAddress(SMBIOS_START)
         .checked_add(mem::size_of::<Smbios30Entrypoint>() as u64)
         .ok_or(Error::NotEnoughMemory)?;
@@ -224,7 +224,7 @@ pub fn setup_smbios(mem: &GuestMemoryMmap) -> Result<()> {
             .map_err(|_| Error::WriteSmbiosEp)?;
     }
 
-    Ok(())
+    Ok(curptr.unchecked_offset_from(physptr))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In order to speed up the Linux boot (so as to avoid it having to scan a
large number of pages) place the MP table directly after the SMBIOS
table if there is sufficient room. The start address of the SMBIOS table
is one of the three (and the largest) location that the MP table can
also be located at.

Before:
[    0.000399] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WP  UC- WT
[    0.014945] check: Scanning 1 areas for low memory corruption

After:
[    0.000284] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WP  UC- WT
[    0.000421] found SMP MP-table at [mem 0x000f0090-0x000f009f]

Signed-off-by: Rob Bradford <robert.bradford@intel.com>