### PR TITLE
github: Add a new action to update the Docker image

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,0 +1,37 @@
+name: Cloud-Hypervisor's Docker image update
+
+on:
+  push:
+    branches: master
+    paths: resources/Dockerfile
+
+jobs:
+  multi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          file: ./resources/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: cloudhypervisor/dev:latest
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
The idea is to rely on this new Github Action to detect when the
Dockerfile is updated after a push to the master branch on the
repository.

Once triggered, this action builds the Docker image for both
linux/amd64 and linux/arm64 platforms, and updates it directly
on Docker Hub.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>