### PR TITLE
vmm: openapi: fix integers format

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -352,7 +352,7 @@ components:
         type: object
         additionalProperties:
           type: integer
-          format: uint64
+          format: int64
 
     PciDeviceInfo:
       required:
@@ -681,7 +681,7 @@ components:
       properties:
         size:
           type: integer
-          format: uint64
+          format: int64
         prefault:
           type: boolean
           default: false


### PR DESCRIPTION
According to openAPI specification[1], the format for `integer` types
can be only `int32` or `int64`, unsigned integers are not supported.
This patch replaces `uint64` with `int64`.

[1]: https://swagger.io/specification/#data-types

Signed-off-by: Julio Montes <julio.montes@intel.com>