### PR TITLE
resources: Update Dockerfile to install missing Python packages

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update \
 	cpio \
 	bsdtar \
 	libfdt-dev \
+	python3-setuptools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
In order to build virtiofsd from the latest build system, the Python
package python3-setuptools is required.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>