### PR TITLE
resources: Fix Dockerfile to support multi-architecture

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -6,7 +6,7 @@ on:
     paths: resources/Dockerfile
 
 jobs:
-  multi:
+  main:
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04 as dev
 
-ARG TARGETARCH="x86_64"
+ARG TARGETARCH
 ARG RUST_TOOLCHAIN="1.43.0"
 ARG CLH_SRC_DIR="/cloud-hypervisor"
 ARG CLH_BUILD_DIR="$CLH_SRC_DIR/build"
@@ -43,14 +43,14 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN if [ "$TARGETARCH" = "x86_64" ]; then \
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
 	apt-get update \
 	&& apt-get -yq upgrade \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc-multilib \
 	&& apt-get clean \
     && rm -rf /var/lib/apt/lists/*;	fi
 
-RUN if [ "$TARGETARCH" = "aarch64" ]; then \
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
         # On AArch64, `setcap` binary should be installed via `libcap2-bin`.
         # The `setcap` binary is used in integration tests.
         apt-get update \
@@ -67,17 +67,17 @@ RUN if [ "$TARGETARCH" = "aarch64" ]; then \
         && rm -rf /dtc;	fi
 
 # Fix the libssl-dev install
-RUN cp /usr/include/"$TARGETARCH"-linux-gnu/openssl/opensslconf.h /usr/include/openssl/
-ENV OPENSSL_DIR=/usr/lib/"$TARGETARCH"-linux-gnu/
-ENV OPENSSL_LIB_DIR=/usr/lib/"$TARGETARCH"-linux-gnu/
+RUN cp /usr/include/"$(uname -m)"-linux-gnu/openssl/opensslconf.h /usr/include/openssl/
+RUN echo 'export OPENSSL_DIR=/usr/lib/"$(uname -m)"-linux-gnu/' >> $HOME/.bashrc
+RUN echo 'export OPENSSL_LIB_DIR=/usr/lib/"$(uname -m)"-linux-gnu/' >> $HOME/.bashrc
 ENV OPENSSL_INCLUDE_DIR=/usr/include/
 
 # Install the rust toolchain
 RUN nohup curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN" \
-    && rustup target add $TARGETARCH-unknown-linux-musl --toolchain "$RUST_TOOLCHAIN" \
-    && if [ "$TARGETARCH" = "x86_64" ]; then rustup toolchain add $RUST_TOOLCHAIN-x86_64-unknown-linux-musl; fi \
-    && if [ "$TARGETARCH" = "x86_64" ]; then rustup component add rustfmt; fi \
-    && if [ "$TARGETARCH" = "x86_64" ]; then rustup component add clippy; fi \
+    && rustup target add "$(uname -m)"-unknown-linux-musl --toolchain "$RUST_TOOLCHAIN" \
+    && if [ "$TARGETARCH" = "amd64" ]; then rustup toolchain add $RUST_TOOLCHAIN-x86_64-unknown-linux-musl; fi \
+    && if [ "$TARGETARCH" = "amd64" ]; then rustup component add rustfmt; fi \
+    && if [ "$TARGETARCH" = "amd64" ]; then rustup component add clippy; fi \
     && cargo install cargo-audit \
     && rm -rf "$CARGO_HOME/registry" \
     && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \


### PR DESCRIPTION
In order to support both amd64 and arm64, we rely on the TARGETARCH
variable that is passed from the docker buildx command, based on the
platform used to build the container image.

There is no way to rely directly on $(uname -m) to assign a variable
with the correct x86_64 or aarch64 values we're looking for. Both ENV
and ARG don't evaluate the command, which means they see it as a simple
string. Using RUN is the only way to evaluate a command.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>