### PR TITLE
vmm: openapi: fix integers format

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -492,7 +492,7 @@ components:
           default: false
         host_numa_node:
           type: integer
-          format: uint32
+          format: int32
         hotplug_size:
           type: integer
           format: int64
@@ -532,7 +532,7 @@ components:
           default: false
         balloon_size:
           type: integer
-          format: uint64
+          format: int64
         zones:
           type: array
           items:
@@ -754,10 +754,10 @@ components:
       properties:
         destination:
           type: integer
-          format: uint32
+          format: int32
         distance:
           type: integer
-          format: uint8
+          format: int32
 
     NumaConfig:
       required:
@@ -766,12 +766,12 @@ components:
       properties:
         guest_numa_id:
           type: integer
-          format: uint32
+          format: int32
         cpus:
           type: array
           items:
             type: integer
-            format: uint8
+            format: int32
         distances:
           type: array
           items:


### PR DESCRIPTION
According to openAPI specification [1], the format for `integer` types
can be only `int32` or `int64`, unsigned and 8-bits integers are not
supported.
This patch replaces `uint64` with `int64`, `uint32` with `int32` and
`uint8` with `int32`.

[1]: https://swagger.io/specification/#data-types

Signed-off-by: Julio Montes <julio.montes@intel.com>