### PR TITLE
vmm: openapi: Add the 'iommu' and 'id' option to 'VmAddDevice'

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -811,6 +811,11 @@ components:
       properties:
         path:
           type: string
+        iommu:
+          type: boolean
+          default: false
+        id:
+          type: string
 
     VmRemoveDevice:
       type: object


### PR DESCRIPTION
This patch adds the missing the `iommu` and `id` option for
`VmAddDevice` in the openApi yaml to respect the internal data structure
in the code base. Also, setting the `id` explicitly for VFIO device
hotplug is required for VFIO device unplug through openAPI calls.

Signed-off-by: Bo Chen <chen.bo@intel.com>