### PR TITLE
fuzz: Fix the building errors with recent changes

### DIFF
--- a/.github/workflows/fuzz-build.yaml
+++ b/.github/workflows/fuzz-build.yaml
@@ -1,0 +1,27 @@
+name: Cloud Hypervisor Cargo Fuzz Build
+on: [pull_request, create]
+
+jobs:
+  build:
+    if: github.event_name == 'pull_request'
+    name: Cargo Fuzz Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - nightly
+        target:
+          - x86_64-unknown-linux-gnu
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v2
+      - name: Install Rust toolchain (${{ matrix.rust }})
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ matrix.rust }}
+            target: ${{ matrix.target }}
+            override: true
+      - name: Install Cargo fuzz
+        run: cargo install -f cargo-fuzz
+      - name: Cargo Fuzz Build
+        run: cargo fuzz build

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,9 +10,11 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
+kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "ch" }
 libc = "0.2.72"
 libfuzzer-sys = "0.3"
 qcow = { path = "../qcow" }
+seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.22.0" }
 virtio-devices = { path = "../virtio-devices" }
 vmm-sys-util = ">=0.3.1"
 vm-virtio = { path = "../vm-virtio" }

--- a/fuzz/fuzz_targets/block.rs
+++ b/fuzz/fuzz_targets/block.rs
@@ -16,6 +16,7 @@ use virtio_devices::{Block, VirtioDevice, VirtioInterrupt, VirtioInterruptType};
 use vm_memory::{Bytes, GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
 use vm_virtio::Queue;
 use vmm_sys_util::eventfd::EventFd;
+use seccomp::SeccompAction;
 
 const MEM_SIZE: u64 = 256 * 1024 * 1024;
 const DESC_SIZE: u64 = 16; // Bytes in one virtio descriptor.
@@ -92,6 +93,7 @@ fuzz_target!(|bytes| {
         false,
         2,
         256,
+        SeccompAction::Allow,
     )
     .unwrap();
 


### PR DESCRIPTION
This patch adds two required dependencies to fuzz/Cargo.toml, and fixes
the building error on the 'block' fuzzer.

Signed-off-by: Bo Chen <chen.bo@intel.com>