### PR TITLE
ci: No need to build Docker image locally for arm64

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -427,9 +427,4 @@ if [ $(uname -m) = "x86_64" ]; then
     ensure_latest_ctr
 fi
 
-# Before a public image for AArch64 ready, we build the container if needed.
-if [ $(uname -m) = "aarch64" ]; then
-    cmd_build-container
-fi
-
 $cmd "$@"


### PR DESCRIPTION
Now that Docker images are automatically generated for both amd64 and
arm64 architectures, there's no need to generate the arm64 image locally
on the ARM CI during a CI run. The image should be available from
DockerHub instead.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>