### PR TITLE
devices: ioapic: Always retrieve destination field on 8 bits

### DIFF
--- a/devices/src/interrupt_controller.rs
+++ b/devices/src/interrupt_controller.rs
@@ -7,8 +7,6 @@ use std::result;
 
 #[derive(Debug)]
 pub enum Error {
-    /// Invalid destination mode.
-    InvalidDestinationMode,
     /// Invalid trigger mode.
     InvalidTriggerMode,
     /// Invalid delivery mode.


### PR DESCRIPTION
When the destination mode is physical, the destination field should
only be defined through bits 56-59, as defined in the IOAPIC spec. But
from the APIC specification, the APIC ID is always defined on 8 bits no
matter which destination mode is selected. That's why we always retrieve
the destination field based on bits 56-63.

Fixes #1767

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>