### PR TITLE
hypervisor, vmm: Introduce VmmOps trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,7 @@ name = "hypervisor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -9,6 +9,7 @@ kvm = []
 
 [dependencies]
 anyhow = "1.0"
+arc-swap = ">=0.4.4"
 thiserror = "1.0"
 libc = "0.2.78"
 log = "0.4.11"

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -117,6 +117,36 @@ pub enum HypervisorVmError {
     ///
     #[error("Failed to create passthrough device: {0}")]
     CreatePassthroughDevice(#[source] anyhow::Error),
+    ///
+    /// Write to Guest memory
+    ///
+    #[error("Failed to write to guest memory: {0}")]
+    GuestMemWrite(#[source] anyhow::Error),
+    ///
+    /// Read Guest memory
+    ///
+    #[error("Failed to read guest memory: {0}")]
+    GuestMemRead(#[source] anyhow::Error),
+    ///
+    /// Read from MMIO Bus
+    ///
+    #[error("Failed to read from MMIO Bus: {0}")]
+    MmioBusRead(#[source] anyhow::Error),
+    ///
+    /// Write to MMIO Bus
+    ///
+    #[error("Failed to write to MMIO Bus: {0}")]
+    MmioBusWrite(#[source] anyhow::Error),
+    ///
+    /// Read from IO Bus
+    ///
+    #[error("Failed to read from IO Bus: {0}")]
+    IoBusRead(#[source] anyhow::Error),
+    ///
+    /// Write to IO Bus
+    ///
+    #[error("Failed to write to IO Bus: {0}")]
+    IoBusWrite(#[source] anyhow::Error),
 }
 ///
 /// Result type for returning from a function
@@ -184,4 +214,17 @@ pub trait Vm: Send + Sync {
     fn state(&self) -> Result<VmState>;
     /// Set the VM state
     fn set_state(&self, state: VmState) -> Result<()>;
+    /// Set VmmOps interface
+    fn set_vmmops(&self, vmmops: Box<dyn VmmOps>) -> Result<()>;
+}
+
+pub trait VmmOps: Send + Sync {
+    fn guest_mem_write(&self, buf: &[u8], gpa: u64) -> Result<usize>;
+    fn guest_mem_read(&self, buf: &mut [u8], gpa: u64) -> Result<usize>;
+    fn mmio_read(&self, addr: u64, data: &mut [u8]) -> Result<()>;
+    fn mmio_write(&self, addr: u64, data: &[u8]) -> Result<()>;
+    #[cfg(target_arch = "x86_64")]
+    fn pio_read(&self, addr: u64, data: &mut [u8]) -> Result<()>;
+    #[cfg(target_arch = "x86_64")]
+    fn pio_write(&self, addr: u64, data: &[u8]) -> Result<()>;
 }


### PR DESCRIPTION
Run loop in hypervisor needs a callback mechanism to access resources
like guest memory, mmio, pio etc.

VmmOps trait is introduced here, which is implemented by vmm module.
While handling vcpuexits in run loop, this trait allows hypervisor
module access to the above mentioned resources via callbacks.

Signed-off-by: Praveen Paladugu <prapal@microsoft.com>
Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>