### PR TITLE
vmm: device_manager: Make PMEM "discard_writes" mode true CoW

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2347,11 +2347,7 @@ impl DeviceManager {
         let mmap_region = MmapRegion::build(
             Some(FileOffset::new(cloned_file, 0)),
             region_size as usize,
-            if pmem_cfg.discard_writes {
-                PROT_READ
-            } else {
-                PROT_READ | PROT_WRITE
-            },
+            PROT_READ | PROT_WRITE,
             MAP_NORESERVE
                 | if pmem_cfg.discard_writes {
                     MAP_PRIVATE
@@ -2371,7 +2367,7 @@ impl DeviceManager {
                 region_size,
                 host_addr,
                 pmem_cfg.mergeable,
-                pmem_cfg.discard_writes,
+                false,
             )
             .map_err(DeviceManagerError::MemoryManager)?;
 


### PR DESCRIPTION
The PMEM support has an option called "discard_writes" which when true
will prevent changes to the device from hitting the backing file. This
is trying to be the equivalent of "readonly" support of the block
device.

Previously the memory of the device was marked as KVM_READONLY. This
resulted in a trap when the guest attempted to write to it resulting a
VM exit (and recently a warning). This has a very detrimental effect on
the performance so instead make "discard_writes" truly CoW by mapping
the memory as `PROT_READ | PROT_WRITE` and using `MAP_PRIVATE` to
establish the CoW mapping.

Fixes: #1795

Signed-off-by: Rob Bradford <robert.bradford@intel.com>