### PR TITLE
virtio-devices: Rely on vhost crate from Cloud-Hypervisor fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vhost#d257479a40b42895b9adab11befa5385bbee0698"
+source = "git+https://github.com/cloud-hypervisor/vhost?branch=ch#6fc980bf5083d67586ab91d6a965c3a593c33a78"
 dependencies = [
  "bitflags 1.2.1",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ clap = { version = "2.33.3", features = ["wrap_help"] }
 [patch.crates-io]
 vm-memory = { git = "https://github.com/cloud-hypervisor/vm-memory", branch = "ch" }
 
+[patch.'https://github.com/rust-vmm/vhost']
+vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "ch", package = "vhost", features = ["vhost-user-master", "vhost-user-slave"] }
+
 [dev-dependencies]
 ssh2 = "0.8.2"
 dirs = "3.0.1"


### PR DESCRIPTION
The Cloud-Hypervisor fork of the vhost crate contains one small
additional patch compared to the rust-vmm upstream version, meant for
increasing the connection timeout.

This patch is intended to be merged in order to check if it helps our CI
fixing the vhost-user-blk flakes that we've been observing recently.

If it fixes it, we'll submit a similar patch upstream and switch back to
the upstream vhost crate, otherwise we'll simply switch back to the
upstream crate, discarding this patch.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>