### PR TITLE
ci: Validate each commit can be built

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
         with:
@@ -26,7 +29,9 @@ jobs:
             override: true
 
       - name: Debug Build (default features)
-        run: cargo build --all --target=${{ matrix.target }}
+        run: |
+          git rev-list origin/master..$GITHUB_SHA | xargs -t -I % sh -c 'git checkout %; cargo build --all --target=${{ matrix.target }}'
+          git checkout $GITHUB_SHA
 
       - name: Build (pci,acpi,kvm)
         run: cargo rustc --bin cloud-hypervisor --no-default-features --features "pci,acpi,kvm"  -- -D warnings


### PR DESCRIPTION
It's important to ensure Cloud-Hypervisor's Git tree is bisectable, and
that's why this commit extends the existing build.yaml Github action.
This will validate that each commit from an incoming pull request can be
built.

Fixes #1808

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>