### PR TITLE
vmm: Allow unlink syscall for vCPU threads

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -460,6 +460,10 @@ fn vcpu_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_statx),
         allow_syscall(libc::SYS_tgkill),
         allow_syscall(libc::SYS_tkill),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_unlink),
+        #[cfg(target_arch = "aarch64")]
+        allow_syscall(libc::SYS_unlinkat),
         allow_syscall(libc::SYS_write),
     ])
 }


### PR DESCRIPTION
Without the unlink(2) syscall being allowed, Cloud-Hypervisor crashes
when we remove a virtio-vsock device that has been previously added.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>