### PR TITLE
ci: Simplify test scripts

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -133,7 +133,6 @@ update_workloads() {
         cp build/tools/virtiofsd/virtiofsd $VIRTIOFSD || exit 1
         popd
         rm -rf $QEMU_DIR
-        sudo setcap cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_setgid,cap_setuid,cap_mknod,cap_setfcap,cap_sys_admin+epi "virtiofsd" || exit 1
         popd
     fi
 
@@ -191,23 +190,14 @@ strip target/$BUILD_TARGET/release/cloud-hypervisor
 strip target/$BUILD_TARGET/release/vhost_user_net
 strip target/$BUILD_TARGET/release/ch-remote
 
-# Copy for non-privileged net test
-cp target/$BUILD_TARGET/release/cloud-hypervisor target/$BUILD_TARGET/release/cloud-hypervisor-unprivileged
-
-sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/cloud-hypervisor
-sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/vhost_user_net
-
 # Enable KSM with some reasonable parameters so that it won't take too long
 # for the memory to be merged between two processes.
 sudo bash -c "echo 1000000 > /sys/kernel/mm/ksm/pages_to_scan"
 sudo bash -c "echo 10 > /sys/kernel/mm/ksm/sleep_millisecs"
 sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 
-sudo adduser $USER kvm
-newgrp kvm << EOF
 export RUST_BACKTRACE=1
 time cargo test --no-default-features --features "integration_tests,pci,kvm" "tests::parallel::$@" -- --skip test_snapshot_restore
-EOF
 RES=$?
 
 if [ $RES -eq 0 ]; then
@@ -217,18 +207,8 @@ if [ $RES -eq 0 ]; then
     strip target/$BUILD_TARGET/release/vhost_user_net
     strip target/$BUILD_TARGET/release/ch-remote
 
-    sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/cloud-hypervisor
-    sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/vhost_user_net
-
-    # Ensure test binary has the same caps as the cloud-hypervisor one
-    time cargo test --no-run --no-default-features --features "integration_tests,mmio,kvm" || exit 1
-    ls target/debug/deps/cloud_hypervisor-* | xargs -n 1 sudo setcap cap_net_admin+ep
-
-    newgrp kvm << EOF
-export RUST_BACKTRACE=1
-time cargo test --no-default-features --features "integration_tests,mmio,kvm" "tests::parallel::$@"
-EOF
-
+    export RUST_BACKTRACE=1
+    time cargo test --no-default-features --features "integration_tests,mmio,kvm" "tests::parallel::$@"
     RES=$?
 fi
 

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -134,7 +134,6 @@ if [ ! -f "$VIRTIOFSD" ]; then
     cp build/tools/virtiofsd/virtiofsd $VIRTIOFSD || exit 1
     popd
     rm -rf $QEMU_DIR
-    sudo setcap cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_setgid,cap_setuid,cap_mknod,cap_setfcap,cap_sys_admin+epi "virtiofsd" || exit 1
     popd
 fi
 
@@ -207,12 +206,6 @@ strip target/$BUILD_TARGET/release/cloud-hypervisor
 strip target/$BUILD_TARGET/release/vhost_user_net
 strip target/$BUILD_TARGET/release/ch-remote
 
-# Copy for non-privileged net test
-cp target/$BUILD_TARGET/release/cloud-hypervisor target/$BUILD_TARGET/release/cloud-hypervisor-unprivileged
-
-sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/cloud-hypervisor
-sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/vhost_user_net
-
 # We always copy a fresh version of our binary for our L2 guest.
 cp target/$BUILD_TARGET/release/cloud-hypervisor $VFIO_DIR
 cp target/$BUILD_TARGET/release/ch-remote $VFIO_DIR
@@ -227,24 +220,15 @@ sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 echo 4096 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
-# Ensure test binary has the same caps as the cloud-hypervisor one
-time cargo test --no-run --features "integration_tests" || exit 1
-ls target/debug/deps/cloud_hypervisor-* | xargs -n 1 sudo setcap cap_net_admin+ep
-
-sudo adduser $USER kvm
-newgrp kvm << EOF
 export RUST_BACKTRACE=1
 time cargo test --features "integration_tests" "tests::parallel::$@"
-EOF
 RES=$?
 
 # Run some tests in sequence since the result could be affected by other tests
 # running in parallel.
 if [ $RES -eq 0 ]; then
-    newgrp kvm << EOF
-export RUST_BACKTRACE=1
-time cargo test --features "integration_tests" "tests::sequential::$@" -- --test-threads=1
-EOF
+    export RUST_BACKTRACE=1
+    time cargo test --features "integration_tests" "tests::sequential::$@" -- --test-threads=1
     RES=$?
 fi
 
@@ -255,26 +239,15 @@ if [ $RES -eq 0 ]; then
     strip target/$BUILD_TARGET/release/vhost_user_net
     strip target/$BUILD_TARGET/release/ch-remote
 
-    sudo setcap cap_net_admin+ep target/$BUILD_TARGET/release/cloud-hypervisor
-
-    # Ensure test binary has the same caps as the cloud-hypervisor one
-    time cargo test --no-run --features "integration_tests,mmio" || exit 1
-    ls target/debug/deps/cloud_hypervisor-* | xargs -n 1 sudo setcap cap_net_admin+ep
-
-    newgrp kvm << EOF
-export RUST_BACKTRACE=1
-time cargo test --features "integration_tests,mmio" "tests::parallel::$@" 
-EOF
-
+    export RUST_BACKTRACE=1
+    time cargo test --features "integration_tests,mmio" "tests::parallel::$@" 
     RES=$?
 
     # Run some tests in sequence since the result could be affected by other tests
     # running in parallel.
     if [ $RES -eq 0 ]; then
-        newgrp kvm << EOF
-export RUST_BACKTRACE=1
-time cargo test --features "integration_tests,mmio" "tests::sequential::$@" -- --test-threads=1
-EOF
+        export RUST_BACKTRACE=1
+        time cargo test --features "integration_tests,mmio" "tests::sequential::$@" -- --test-threads=1
         RES=$?
     fi
 fi

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -7,13 +7,5 @@ cargo_args=("$@")
 [ $(uname -m) = "aarch64" ] && cargo_args+=("--no-default-features")
 [ $(uname -m) = "aarch64" ] && cargo_args+=("--features mmio,kvm")
 
-cargo test --target $BUILD_TARGET --workspace --no-run ${cargo_args[@]}
-pushd target/$BUILD_TARGET/debug
-ls  | grep net_util | grep -v "\.d" | xargs -n 1 sudo setcap cap_net_admin,cap_net_raw+ep
-popd
-
-sudo adduser $USER kvm
-newgrp kvm << EOF || exit 1
-  export RUST_BACKTRACE=1
-  cargo test --target $BUILD_TARGET --workspace ${cargo_args[@]} || exit 1;
-EOF
+export RUST_BACKTRACE=1
+cargo test --target $BUILD_TARGET --workspace ${cargo_args[@]} || exit 1;


### PR DESCRIPTION
Since all unit and integration tests are run inside containers because
they are called from dev_cli.sh, they always run as root. That's why
both unit and integration scripts can be simplified as they don't need
to apply specific capabilities and run cargo tests in a dedicated 'kvm'
group.

Fixes #1683

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>