### PR TITLE
ci: use `cargo check` to validate building commits

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,9 +28,9 @@ jobs:
             target: ${{ matrix.target }}
             override: true
 
-      - name: Debug Build (default features)
+      - name: Debug Check (default features)
         run: |
-          git rev-list origin/master..$GITHUB_SHA | xargs -t -I % sh -c 'git checkout %; cargo build --all --target=${{ matrix.target }}'
+          git rev-list origin/master..$GITHUB_SHA | xargs -t -I % sh -c 'git checkout %; cargo check --all --target=${{ matrix.target }}'
           git checkout $GITHUB_SHA
 
       - name: Build (pci,acpi,kvm)


### PR DESCRIPTION
The purpose of that step is to make sure each commit builds. The `check`
command is much faster for that purpose.

On my 32-core machine `cargo check --all` takes around 25 seconds while
`cargo build --all` takes around 35 seconds, so that's quite a bit of
time saving there.

Signed-off-by: Wei Liu <liuwe@microsoft.com>