### PR TITLE
virtio: Replace some repr(C, packed) with repr(C)

### DIFF
--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -159,7 +159,7 @@ struct VirtioMemResp {
 unsafe impl ByteValued for VirtioMemResp {}
 
 // Got from qemu/include/standard-headers/linux/virtio_mem.h
-#[repr(C, packed)]
+#[repr(C)]
 #[derive(Copy, Clone, Debug, Default)]
 struct VirtioMemConfig {
     // Block size and alignment. Cannot change.


### PR DESCRIPTION
The goal here is to replace anywhere possible a virtio structure
with a "C, packed" representation by a "C" representation. Some
virtio structures are not expected to be packed, therefore there's
no reason for using the more restrictive "C, packed" representation.

This is important since "packed" representation can still cause
undefined behaviors with Rust 2018.

By removing the need for "packed" representation, we can simplify a
bit of code by deriving the Serialize trait without writing the
implementation ourselves.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>