### PR TITLE
hypervisor, arch: rename "OneRegister" and relevant code

### DIFF
--- a/arch/src/aarch64/regs.rs
+++ b/arch/src/aarch64/regs.rs
@@ -53,7 +53,7 @@ pub fn setup_regs(
 
     // Get the register index of the PSTATE (Processor State) register.
     let pstate = offset__of!(user_pt_regs, pstate) + kreg_off;
-    vcpu.set_one_reg(
+    vcpu.set_reg(
         arm64_core_reg_id!(KVM_REG_SIZE_U64, pstate),
         PSTATE_FAULT_BITS_64,
     )
@@ -63,7 +63,7 @@ pub fn setup_regs(
     if cpu_id == 0 {
         // Setting the PC (Processor Counter) to the current program address (kernel address).
         let pc = offset__of!(user_pt_regs, pc) + kreg_off;
-        vcpu.set_one_reg(arm64_core_reg_id!(KVM_REG_SIZE_U64, pc), boot_ip as u64)
+        vcpu.set_reg(arm64_core_reg_id!(KVM_REG_SIZE_U64, pc), boot_ip as u64)
             .map_err(Error::SetCoreRegister)?;
 
         // Last mandatory thing to set -> the address pointing to the FDT (also called DTB).
@@ -71,7 +71,7 @@ pub fn setup_regs(
         // not exceed 2 megabytes in size." -> https://www.kernel.org/doc/Documentation/arm64/booting.txt.
         // We are choosing to place it the end of DRAM. See `get_fdt_addr`.
         let regs0 = offset__of!(user_pt_regs, regs) + kreg_off;
-        vcpu.set_one_reg(
+        vcpu.set_reg(
             arm64_core_reg_id!(KVM_REG_SIZE_U64, regs0),
             get_fdt_addr(mem) as u64,
         )

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -11,7 +11,7 @@
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::VcpuInit;
 #[cfg(target_arch = "aarch64")]
-use crate::aarch64::{OneRegister, RegList, StandardRegisters};
+use crate::aarch64::{RegList, Register, StandardRegisters};
 use crate::{CpuState, MpState};
 
 #[cfg(target_arch = "x86_64")]
@@ -139,12 +139,12 @@ pub enum HypervisorCpuError {
     /// Setting one reg error
     ///
     #[error("Failed to init vcpu: {0}")]
-    SetOneReg(#[source] anyhow::Error),
+    SetRegister(#[source] anyhow::Error),
     ///
     /// Getting one reg error
     ///
     #[error("Failed to init vcpu: {0}")]
-    GetOneReg(#[source] anyhow::Error),
+    GetRegister(#[source] anyhow::Error),
     ///
     /// Getting guest clock paused error
     ///
@@ -326,12 +326,12 @@ pub trait Vcpu: Send + Sync {
     /// Sets the value of one register for this vCPU.
     ///
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    fn set_one_reg(&self, reg_id: u64, data: u64) -> Result<()>;
+    fn set_reg(&self, reg_id: u64, data: u64) -> Result<()>;
     ///
     /// Sets the value of one register for this vCPU.
     ///
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    fn get_one_reg(&self, reg_id: u64) -> Result<u64>;
+    fn get_reg(&self, reg_id: u64) -> Result<u64>;
     ///
     /// Gets a list of the guest registers that are supported for the
     /// KVM_GET_ONE_REG/KVM_SET_ONE_REG calls.
@@ -352,12 +352,12 @@ pub trait Vcpu: Send + Sync {
     /// Save the state of the system registers.
     ///
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    fn system_registers(&self, state: &mut Vec<OneRegister>) -> Result<()>;
+    fn system_registers(&self, state: &mut Vec<Register>) -> Result<()>;
     ///
     /// Restore the state of the system registers.
     ///
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    fn set_system_registers(&self, state: &[OneRegister]) -> Result<()>;
+    fn set_system_registers(&self, state: &[Register]) -> Result<()>;
     ///
     /// Read the MPIDR - Multiprocessor Affinity Register.
     ///

--- a/hypervisor/src/kvm/aarch64/mod.rs
+++ b/hypervisor/src/kvm/aarch64/mod.rs
@@ -21,7 +21,7 @@ use kvm_bindings::{
     KVM_REG_SIZE_U32, KVM_REG_SIZE_U64,
 };
 pub use kvm_bindings::{
-    kvm_one_reg as OneRegister, kvm_regs as StandardRegisters, kvm_vcpu_init as VcpuInit, RegList,
+    kvm_one_reg as Register, kvm_regs as StandardRegisters, kvm_vcpu_init as VcpuInit, RegList,
 };
 use serde_derive::{Deserialize, Serialize};
 pub use {kvm_ioctls::Cap, kvm_ioctls::Kvm};

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -38,7 +38,7 @@ use x86_64::{
 };
 
 #[cfg(target_arch = "aarch64")]
-use aarch64::{OneRegister, RegList, StandardRegisters};
+use aarch64::{RegList, Register, StandardRegisters};
 
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
@@ -814,19 +814,19 @@ impl cpu::Vcpu for KvmVcpu {
     /// Sets the value of one register for this vCPU.
     ///
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    fn set_one_reg(&self, reg_id: u64, data: u64) -> cpu::Result<()> {
+    fn set_reg(&self, reg_id: u64, data: u64) -> cpu::Result<()> {
         self.fd
             .set_one_reg(reg_id, data)
-            .map_err(|e| cpu::HypervisorCpuError::SetOneReg(e.into()))
+            .map_err(|e| cpu::HypervisorCpuError::SetRegister(e.into()))
     }
     ///
     /// Gets the value of one register for this vCPU.
     ///
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    fn get_one_reg(&self, reg_id: u64) -> cpu::Result<u64> {
+    fn get_reg(&self, reg_id: u64) -> cpu::Result<u64> {
         self.fd
             .get_one_reg(reg_id)
-            .map_err(|e| cpu::HypervisorCpuError::GetOneReg(e.into()))
+            .map_err(|e| cpu::HypervisorCpuError::GetRegister(e.into()))
     }
     ///
     /// Gets a list of the guest registers that are supported for the
@@ -1014,7 +1014,7 @@ impl cpu::Vcpu for KvmVcpu {
     /// Save the state of the system registers.
     ///
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    fn system_registers(&self, state: &mut Vec<OneRegister>) -> cpu::Result<()> {
+    fn system_registers(&self, state: &mut Vec<Register>) -> cpu::Result<()> {
         // Call KVM_GET_REG_LIST to get all registers available to the guest. For ArmV8 there are
         // around 500 registers.
         let mut reg_list = RegList::new(512);
@@ -1055,7 +1055,7 @@ impl cpu::Vcpu for KvmVcpu {
     /// Restore the state of the system registers.
     ///
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    fn set_system_registers(&self, state: &[OneRegister]) -> cpu::Result<()> {
+    fn set_system_registers(&self, state: &[Register]) -> cpu::Result<()> {
         for reg in state {
             self.fd
                 .set_one_reg(reg.id, reg.addr)

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1627,7 +1627,7 @@ mod tests {
         assert!(vcpu.set_core_registers(&state).is_ok());
         let off = offset__of!(user_pt_regs, pstate);
         let pstate = vcpu
-            .get_one_reg(arm64_core_reg_id!(KVM_REG_SIZE_U64, off))
+            .get_reg(arm64_core_reg_id!(KVM_REG_SIZE_U64, off))
             .expect("Failed to call kvm get one reg");
         assert_eq!(state.regs.pstate, pstate);
     }


### PR DESCRIPTION
The OneRegister literally means "one (arbitrary) register". Just call it
"Register" instead. There is no need to inherit KVM's naming scheme in
the hypervisor agnostic code.

Signed-off-by: Wei Liu <liuwe@microsoft.com>