### PR TITLE
aarch64: Add OneReg to the list required extensions for KVM

### DIFF
--- a/hypervisor/src/kvm/aarch64/mod.rs
+++ b/hypervisor/src/kvm/aarch64/mod.rs
@@ -127,6 +127,9 @@ pub fn check_required_kvm_extensions(kvm: &Kvm) -> KvmResult<()> {
     if !kvm.check_extension(Cap::SignalMsi) {
         return Err(KvmError::CapabilityMissing(Cap::SignalMsi));
     }
+    if !kvm.check_extension(Cap::OneReg) {
+        return Err(KvmError::CapabilityMissing(Cap::OneReg));
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Without that capability save / restore for aarch64 won't work.

Signed-off-by: Wei Liu <liuwe@microsoft.com>