### PR TITLE
deps: Patch kvm-ioctls and kvm-bindings crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,15 @@ vmm-sys-util = "0.6.1"
 [build-dependencies]
 clap = { version = "2.33.3", features = ["wrap_help"] }
 
+# List of patched crates
 [patch.crates-io]
 vm-memory = { git = "https://github.com/cloud-hypervisor/vm-memory", branch = "ch" }
-
 [patch.'https://github.com/rust-vmm/vhost']
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "ch", package = "vhost", features = ["vhost-user-master", "vhost-user-slave"] }
+[patch.'https://github.com/rust-vmm/kvm-ioctls']
+kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "ch" }
+[patch.'https://github.com/rust-vmm/kvm-bindings']
+kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch", features = ["with-serde", "fam-wrappers"] }
 
 [dev-dependencies]
 ssh2 = "0.8.2"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "ch" }
+kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master" }
 libc = "0.2.72"
 libfuzzer-sys = "0.3"
 qcow = { path = "../qcow" }
@@ -25,6 +25,10 @@ path = ".."
 
 [patch.crates-io]
 vm-memory = { git = "https://github.com/cloud-hypervisor/vm-memory", branch = "ch" }
+[patch.'https://github.com/rust-vmm/kvm-ioctls']
+kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "ch" }
+[patch.'https://github.com/rust-vmm/kvm-bindings']
+kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch", features = ["with-serde", "fam-wrappers"] }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -13,8 +13,8 @@ arc-swap = ">=0.4.4"
 thiserror = "1.0"
 libc = "0.2.79"
 log = "0.4.11"
-kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "ch" }
-kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch", features = ["with-serde", "fam-wrappers"] }
+kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master" }
+kvm-bindings = { git = "https://github.com/rust-vmm/kvm-bindings", branch = "master", features = ["with-serde", "fam-wrappers"] }
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"


### PR DESCRIPTION
Instead of having the hypervisor crate embedding Cloud-Hypervisor forks
from the rust-vmm project, it's more appropriate to leave the rust-vmm
references in the hypervisor crate, and have the root Cargo.toml being
patched.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>