### PR TITLE
vmm: Support resizing memory >= hotplug size

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1015,8 +1015,7 @@ impl MemoryManager {
 
         let start_addr = MemoryManager::start_addr(self.guest_memory.memory().last_addr(), true);
 
-        if start_addr.checked_add(size.try_into().unwrap()).unwrap() >= self.start_of_device_area()
-        {
+        if start_addr.checked_add(size.try_into().unwrap()).unwrap() > self.start_of_device_area() {
             return Err(Error::InsufficientHotplugRAM);
         }
 


### PR DESCRIPTION
The start address after the hottplugged memory can be the start address of
device area.

Fixes: #1803