### PR TITLE
build: Fix AArch64 musl cross build failure

### DIFF
--- a/.github/workflows/cross-build.yaml
+++ b/.github/workflows/cross-build.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
+          - 1.46.0
         target:
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl


### PR DESCRIPTION
Fixes https://github.com/cloud-hypervisor/cloud-hypervisor/issues/1839.

A failure appeared in AArch64 musl cross build, after upgrading rust to v1.47.0. A symbol "strrchr" was missing while linking against static libfdt.a.

The issue could be caused by missing symbol(s) in new rust toolchain.

This fix pins the rust version in this cross build action to a stable-enough version. Further upgrade will be done manually after testing.

Signed-off-by: Michael Zhao <michael.zhao@arm.com>