### PR TITLE
vmm: Report no error when resizing to current memory size with ACPI

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1266,7 +1266,7 @@ impl MemoryManager {
                 }
             }
             HotplugMethod::Acpi => {
-                if desired_ram >= self.current_ram {
+                if desired_ram > self.current_ram {
                     region =
                         Some(self.hotplug_ram_region((desired_ram - self.current_ram) as usize)?);
                     self.current_ram = desired_ram;


### PR DESCRIPTION
We now try to create a ram region of size 0 when the requested memory
size is the same as current memory size. It results in an error of
`GuestMemoryRegion(Mmap(Os { code: 22, kind: InvalidInput, message:`
`"Invalid argument" }))`. This error is not meaningful to users and we
should not report it.

Signed-off-by: Bo Chen <chen.bo@intel.com>