### PR TITLE
virtio-mem: Show actual size of virtio-mem in memory_actual_size and zones_actual_size of vm.info 

### DIFF
--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -142,10 +142,17 @@ pub enum ApiError {
 pub type ApiResult<T> = std::result::Result<T, ApiError>;
 
 #[derive(Clone, Deserialize, Serialize)]
+pub struct VmZoneActualSize {
+    pub id: String,
+    pub size: u64,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
 pub struct VmInfo {
     pub config: Arc<Mutex<VmConfig>>,
     pub state: VmState,
     pub memory_actual_size: u64,
+    pub zones_actual_size: Option<Vec<VmZoneActualSize>>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -349,6 +349,18 @@ components:
           type: string
       description: Virtual Machine Monitor information
 
+    VmZoneActualSize:
+      required:
+      - id
+      - size
+      type: object
+      properties:
+        id:
+          type: string
+        size:
+          type: integer
+          format: int64
+
     VmInfo:
       required:
       - config
@@ -363,6 +375,10 @@ components:
         memory_actual_size:
           type: integer
           format: int64
+        zones_actual_size:
+          type: array
+          items:
+            $ref: '#/components/schemas/VmZoneActualSize'
       description: Virtual Machine information
 
     VmCounters:

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -467,15 +467,23 @@ impl Vmm {
 
                 let config = Arc::clone(config);
 
-                let mut memory_actual_size = config.lock().unwrap().memory.total_size();
+                let mut memory_actual_size;
+                let zones_actual_size;
                 if let Some(vm) = &self.vm {
+                    let (size, zones) = vm.total_ram_actual()?;
+                    memory_actual_size = size;
+                    zones_actual_size = zones;
                     memory_actual_size -= vm.balloon_size();
+                } else {
+                    memory_actual_size = 0;
+                    zones_actual_size = None;
                 }
 
                 Ok(VmInfo {
                     config,
                     state,
                     memory_actual_size,
+                    zones_actual_size,
                 })
             }
             None => Err(VmError::VmNotCreated),

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -43,7 +43,7 @@ use vm_migration::{
     Transportable,
 };
 
-const DEFAULT_MEMORY_ZONE: &str = "mem0";
+pub const DEFAULT_MEMORY_ZONE: &str = "mem0";
 
 #[cfg(target_arch = "x86_64")]
 const X86_64_IRQ_BASE: u32 = 5;
@@ -1221,6 +1221,20 @@ impl MemoryManager {
         }
 
         error!("Failed resizing virtio-mem region: Unknown memory zone");
+        Err(Error::UnknownMemoryZone)
+    }
+
+    pub fn zone_actual_size(&self, id: &str) -> Result<u64, Error> {
+        if let Some(memory_zone) = self.memory_zones.get(id) {
+            if let Some(virtio_mem_zone) = memory_zone.virtio_mem_zone() {
+                return Ok(virtio_mem_zone.resize_handler().get_actual());
+            } else {
+                // If hotplug_size is 0, virtio_mem_zone will not set.
+                return Ok(0);
+            }
+        }
+
+        error!("Failed get zone actual: Unknown memory zone");
         Err(Error::UnknownMemoryZone)
     }
 


### PR DESCRIPTION
The virtio-mem change the memory size is asynchronous.
This PR add code to show actual size of virtio-mem in memory_actual_size and zones_actual_size of vm.info.