### PR TITLE
vmm: Manually override CPU physical bits

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -63,6 +63,7 @@ pub fn configure_vcpu(
     id: u8,
     kernel_entry_point: Option<EntryPoint>,
     vm_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
+    _phys_bits: u8,
 ) -> super::Result<u64> {
     if let Some(kernel_entry_point) = kernel_entry_point {
         regs::setup_regs(

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,8 @@ fn create_app<'a, 'b>(
                 .long("cpus")
                 .help(
                     "boot=<boot_vcpus>,max=<max_vcpus>,\
-                    topology=<threads_per_core>:<cores_per_die>:<dies_per_package>:<packages>,kvm_hyperv=on|off",
+                    topology=<threads_per_core>:<cores_per_die>:<dies_per_package>:<packages>,\
+                    kvm_hyperv=on|off,max_phys_bits=<maximum_number_of_physical_bits>",
                 )
                 .default_value(&default_vcpus)
                 .group("vm-config"),
@@ -133,8 +134,10 @@ fn create_app<'a, 'b>(
         .arg(
             Arg::with_name("kernel")
                 .long("kernel")
-                .help("Path to loaded kernel. This may be a kernel or firmware that supports a PVH \
-                entry point, a vmlinux ELF file or a Linux bzImage or achitecture equivalent")
+                .help(
+                    "Path to loaded kernel. This may be a kernel or firmware that supports a PVH \
+                entry point, a vmlinux ELF file or a Linux bzImage or achitecture equivalent",
+                )
                 .takes_value(true)
                 .group("vm-config"),
         )
@@ -545,6 +548,7 @@ mod unit_tests {
                     max_vcpus: 1,
                     topology: None,
                     kvm_hyperv: false,
+                    max_phys_bits: None,
                 },
                 memory: MemoryConfig {
                     size: 536_870_912,

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -469,6 +469,8 @@ components:
           type: integer
         topology:
             $ref: '#/components/schemas/CpuTopology'
+        max_phys_bits:
+          type: integer
 
     MemoryZoneConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -320,6 +320,8 @@ pub struct CpusConfig {
     pub topology: Option<CpuTopology>,
     #[serde(default)]
     pub kvm_hyperv: bool,
+    #[serde(default)]
+    pub max_phys_bits: Option<u8>,
 }
 
 impl CpusConfig {
@@ -329,7 +331,8 @@ impl CpusConfig {
             .add("boot")
             .add("max")
             .add("topology")
-            .add("kvm_hyperv");
+            .add("kvm_hyperv")
+            .add("max_phys_bits");
         parser.parse(cpus).map_err(Error::ParseCpus)?;
 
         let boot_vcpus: u8 = parser
@@ -346,12 +349,16 @@ impl CpusConfig {
             .map_err(Error::ParseCpus)?
             .unwrap_or(Toggle(false))
             .0;
+        let max_phys_bits = parser
+            .convert::<u8>("max_phys_bits")
+            .map_err(Error::ParseCpus)?;
 
         Ok(CpusConfig {
             boot_vcpus,
             max_vcpus,
             topology,
             kvm_hyperv,
+            max_phys_bits,
         })
     }
 }
@@ -363,6 +370,7 @@ impl Default for CpusConfig {
             max_vcpus: DEFAULT_VCPUS,
             topology: None,
             kvm_hyperv: false,
+            max_phys_bits: None,
         }
     }
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -433,7 +433,7 @@ impl VmmOps for VmOps {
     }
 }
 
-fn physical_bits(max_phys_bits: Option<u8>) -> u8 {
+pub fn physical_bits(max_phys_bits: Option<u8>) -> u8 {
     let host_phys_bits = get_host_cpu_phys_bits();
     cmp::min(host_phys_bits, max_phys_bits.unwrap_or(host_phys_bits))
 }


### PR DESCRIPTION
The goal for this pull request is to provide the user with the ability to limit the guest address space to a specific value.
By introducing new option `phys_bits` to the `--cpus` parameter, one can specify the amount of physical bits exposed to the guest, which will have the effect of limiting the CPU addressable space as well as the available address space for devices.