### PR TITLE
dev_cli: Fix TARGETARCH inconsistancy

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -367,11 +367,14 @@ cmd_build-container() {
     mkdir -p $BUILD_DIR
     cp $CLH_DOCKERFILE $BUILD_DIR
 
+    [ $(uname -m) = "aarch64" ] && TARGETARCH="arm64"
+    [ $(uname -m) = "x86_64" ] && TARGETARCH="amd64"
+
     $DOCKER_RUNTIME build \
 	   --target $container_type \
 	   -t $CTR_IMAGE \
 	   -f $BUILD_DIR/Dockerfile \
-	   --build-arg TARGETARCH="$(uname -m)" \
+	   --build-arg TARGETARCH=$TARGETARCH \
 	   $BUILD_DIR
 }
 


### PR DESCRIPTION
In previous dev_cli.sh, the `uname -m` command will generate either `x86_64` or `aarch64`, which is inconsistent with the architectures in the Dockerfile, namely `amd64` and `arm64`.

This will cause some dependancy missing in the docker container when the docker image is built locally.

This commit fixes this inconsistancy.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>