### PR TITLE
vmm: Move virtio-balloon out of the MemoryManager

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -18,14 +18,12 @@ struct MemoryConfig {
     hotplug_method: HotplugMethod,
     hotplug_size: Option<u64>,
     hotplugged_size: Option<u64>,
-    balloon: bool,
-    balloon_size: u64,
     zones: Option<Vec<MemoryZoneConfig>>,
 }
 ```
 
 ```
---memory <memory>	Memory parameters "size=<guest_memory_size>,mergeable=on|off,shared=on|off,hugepages=on|off,hotplug_method=acpi|virtio-mem,hotplug_size=<hotpluggable_memory_size>,hotplugged_size=<hotplugged_memory_size>,balloon=on|off"
+--memory <memory>	Memory parameters "size=<guest_memory_size>,mergeable=on|off,shared=on|off,hugepages=on|off,hotplug_method=acpi|virtio-mem,hotplug_size=<hotpluggable_memory_size>,hotplugged_size=<hotplugged_memory_size>"
 ```
 
 ### `size`
@@ -140,20 +138,6 @@ _Example_
 
 ```
 --memory size=1G,hotplug_method=virtio-mem,hotplug_size=1G,hotplugged_size=512M
-```
-
-### `balloon`
-
-Specifies if the `virtio-balloon` device must be activated. This creates a
-dedicated virtio device for managing the balloon in the guest, which allows
-guest to access more or less memory depending on the balloon size.
-
-By default this option is turned off.
-
-_Example_
-
-```
---memory size=1G,balloon=on
 ```
 
 ## Advanced Parameters

--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -226,7 +226,7 @@ fn resize_api_command(
         None
     };
 
-    let desired_ram_w_balloon: Option<u64> = if let Some(balloon) = balloon {
+    let desired_balloon: Option<u64> = if let Some(balloon) = balloon {
         Some(
             balloon
                 .parse::<ByteSized>()
@@ -240,7 +240,7 @@ fn resize_api_command(
     let resize = vmm::api::VmResizeData {
         desired_vcpus,
         desired_ram,
-        desired_ram_w_balloon,
+        desired_balloon,
     };
 
     simple_api_command(
@@ -577,7 +577,7 @@ fn main() {
                 .arg(
                     Arg::with_name("balloon")
                         .long("balloon")
-                        .help("New memory with balloon size in bytes (supports K/M/G suffix)")
+                        .help("New balloon size in bytes (supports K/M/G suffix)")
                         .takes_value(true)
                         .number_of_values(1),
                 ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,8 +111,7 @@ fn create_app<'a, 'b>(
                      \"size=<guest_memory_size>,mergeable=on|off,shared=on|off,hugepages=on|off,\
                      hotplug_method=acpi|virtio-mem,\
                      hotplug_size=<hotpluggable_memory_size>,\
-                     hotplugged_size=<hotplugged_memory_size>,\
-                     balloon=on|off\"",
+                     hotplugged_size=<hotplugged_memory_size>\"",
                 )
                 .default_value(&default_memory)
                 .group("vm-config"),
@@ -572,8 +571,6 @@ mod unit_tests {
                     hotplugged_size: None,
                     shared: false,
                     hugepages: false,
-                    balloon: false,
-                    balloon_size: 0,
                     zones: None,
                 },
                 kernel: Some(KernelConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,13 @@ fn create_app<'a, 'b>(
                 .group("vm-config"),
         )
         .arg(
+            Arg::with_name("balloon")
+                .long("balloon")
+                .help(config::BalloonConfig::SYNTAX)
+                .takes_value(true)
+                .group("vm-config"),
+        )
+        .arg(
             Arg::with_name("fs")
                 .long("fs")
                 .help(config::FsConfig::SYNTAX)
@@ -582,6 +589,7 @@ mod unit_tests {
                     src: PathBuf::from("/dev/urandom"),
                     iommu: false,
                 },
+                balloon: None,
                 fs: None,
                 pmem: None,
                 serial: ConsoleConfig {

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -157,7 +157,7 @@ pub struct VmmPingResponse {
 pub struct VmResizeData {
     pub desired_vcpus: Option<u8>,
     pub desired_ram: Option<u64>,
-    pub desired_ram_w_balloon: Option<u64>,
+    pub desired_balloon: Option<u64>,
 }
 
 #[derive(Clone, Deserialize, Serialize, Default)]

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -537,12 +537,6 @@ components:
         hugepages:
           type: boolean
           default: false
-        balloon:
-          type: boolean
-          default: false
-        balloon_size:
-          type: integer
-          format: int64
         zones:
           type: array
           items:
@@ -810,8 +804,8 @@ components:
           description: desired memory ram in bytes
           type: integer
           format: int64
-        desired_ram_w_balloon:
-          description: desired ballon size in bytes
+        desired_balloon:
+          description: desired balloon size in bytes
           type: integer
           format: int64
 

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -410,6 +410,8 @@ components:
             $ref: '#/components/schemas/NetConfig'
         rng:
           $ref: '#/components/schemas/RngConfig'
+        balloon:
+          $ref: '#/components/schemas/BalloonConfig'
         fs:
           type: array
           items:
@@ -646,6 +648,15 @@ components:
         iommu:
           type: boolean
           default: false
+
+    BalloonConfig:
+      required:
+      - size
+      type: object
+      properties:
+        size:
+          type: integer
+          format: int64
 
     FsConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -418,10 +418,6 @@ pub struct MemoryConfig {
     #[serde(default)]
     pub hugepages: bool,
     #[serde(default)]
-    pub balloon: bool,
-    #[serde(default)]
-    pub balloon_size: u64,
-    #[serde(default)]
     pub zones: Option<Vec<MemoryZoneConfig>>,
 }
 
@@ -436,8 +432,7 @@ impl MemoryConfig {
             .add("hotplug_size")
             .add("hotplugged_size")
             .add("shared")
-            .add("hugepages")
-            .add("balloon");
+            .add("hugepages");
         parser.parse(memory).map_err(Error::ParseMemory)?;
 
         let size = parser
@@ -469,11 +464,6 @@ impl MemoryConfig {
             .0;
         let hugepages = parser
             .convert::<Toggle>("hugepages")
-            .map_err(Error::ParseMemory)?
-            .unwrap_or(Toggle(false))
-            .0;
-        let balloon = parser
-            .convert::<Toggle>("balloon")
             .map_err(Error::ParseMemory)?
             .unwrap_or(Toggle(false))
             .0;
@@ -546,8 +536,6 @@ impl MemoryConfig {
             hotplugged_size,
             shared,
             hugepages,
-            balloon,
-            balloon_size: 0,
             zones,
         })
     }
@@ -581,8 +569,6 @@ impl Default for MemoryConfig {
             hotplugged_size: None,
             shared: false,
             hugepages: false,
-            balloon: false,
-            balloon_size: 0,
             zones: None,
         }
     }
@@ -2194,8 +2180,6 @@ mod tests {
                 hotplugged_size: None,
                 shared: false,
                 hugepages: false,
-                balloon: false,
-                balloon_size: 0,
                 zones: None,
             },
             kernel: Some(KernelConfig {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -469,7 +469,7 @@ impl Vmm {
 
                 let mut memory_actual_size = config.lock().unwrap().memory.total_size();
                 if let Some(vm) = &self.vm {
-                    memory_actual_size -= vm.get_balloon_actual();
+                    memory_actual_size -= vm.balloon_size();
                 }
 
                 Ok(VmInfo {
@@ -511,10 +511,10 @@ impl Vmm {
         &mut self,
         desired_vcpus: Option<u8>,
         desired_ram: Option<u64>,
-        desired_ram_w_balloon: Option<u64>,
+        desired_balloon: Option<u64>,
     ) -> result::Result<(), VmError> {
         if let Some(ref mut vm) = self.vm {
-            if let Err(e) = vm.resize(desired_vcpus, desired_ram, desired_ram_w_balloon) {
+            if let Err(e) = vm.resize(desired_vcpus, desired_ram, desired_balloon) {
                 error!("Error when resizing VM: {:?}", e);
                 Err(e)
             } else {
@@ -801,7 +801,7 @@ impl Vmm {
                                         .vm_resize(
                                             resize_data.desired_vcpus,
                                             resize_data.desired_ram,
-                                            resize_data.desired_ram_w_balloon,
+                                            resize_data.desired_balloon,
                                         )
                                         .map_err(ApiError::VmResize)
                                         .map(|_| ApiResponsePayload::Empty);


### PR DESCRIPTION
This pull request fully moves the `virtio-balloon` code from the `MemoryManager` to the `DeviceManager`. Before that, the code was split across managers' code, implying extra complexity. In order to make the `virtio-balloon` a fully standalone virtio device, the CLI and OpenAPI have been extended with a new `--balloon` parameter, while the options `balloon=on|off` and `balloon_size=` have been removed from `--memory` parameter.
The behavior for resizing the balloon has been simplified and decoupled from the `MemoryManager` by accepting the expected balloon size as value (instead of the expected RAM size as before).

Fixes #1844