### PR TITLE
vmm: don't call notify_guest_clock_paused when Hyper-V emulation is on

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1357,9 +1357,14 @@ impl Pausable for CpuManager {
             let mut vcpu = vcpu.lock().unwrap();
             vcpu.pause()?;
             #[cfg(target_arch = "x86_64")]
-            vcpu.vcpu.notify_guest_clock_paused().map_err(|e| {
-                MigratableError::Pause(anyhow!("Could not notify guest it has been paused {:?}", e))
-            })?;
+            if !self.config.kvm_hyperv {
+                vcpu.vcpu.notify_guest_clock_paused().map_err(|e| {
+                    MigratableError::Pause(anyhow!(
+                        "Could not notify guest it has been paused {:?}",
+                        e
+                    ))
+                })?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
We turn on that emulation for Windows. Windows does not have KVM's PV
clock, so calling notify_guest_clock_paused results in an error.

Signed-off-by: Wei Liu <liuwe@microsoft.com>