### PR TITLE
virtio-mem: Add support for backing file

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2412,6 +2412,7 @@ impl DeviceManager {
                         self.seccomp_action.clone(),
                         node_id,
                         virtio_mem_zone.hotplugged_size(),
+                        virtio_mem_zone.has_backing_file(),
                     )
                     .map_err(DeviceManagerError::CreateVirtioMem)?,
                 ));


### PR DESCRIPTION
Current virtio-mem is not set backing file when call create_ram_region
and call fallocate64 incorrently.

This commit setup backing file when call create_ram_region.
And corrent the code that call fallocate64.

Signed-off-by: Hui Zhu <teawater@antfin.com>