### PR TITLE
tests: Capture more logs for better debugging

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -91,7 +91,7 @@ mod tests {
 
     const DIRECT_KERNEL_BOOT_CMDLINE: &str = "root=/dev/vda1 console=ttyS0 console=hvc0 quiet rw";
 
-    const PIPE_SIZE: i32 = 256 << 10;
+    const PIPE_SIZE: i32 = 32 << 20;
 
     impl UbuntuDiskConfig {
         fn new(image_name: String) -> Self {
@@ -1025,6 +1025,7 @@ mod tests {
             if self.capture_output {
                 let child = self
                     .command
+                    .arg("-v")
                     .stderr(Stdio::piped())
                     .stdout(Stdio::piped())
                     .spawn()
@@ -1044,7 +1045,7 @@ mod tests {
                     ))
                 }
             } else {
-                self.command.spawn()
+                self.command.arg("-v").spawn()
             }
         }
 
@@ -5362,11 +5363,11 @@ mod tests {
                 .unwrap();
 
             let fd = child.stdout.as_ref().unwrap().as_raw_fd();
-            let pipesize = unsafe { libc::fcntl(fd, libc::F_SETPIPE_SZ, PIPE_SIZE * 100) };
+            let pipesize = unsafe { libc::fcntl(fd, libc::F_SETPIPE_SZ, PIPE_SIZE) };
             let fd = child.stderr.as_ref().unwrap().as_raw_fd();
-            let pipesize1 = unsafe { libc::fcntl(fd, libc::F_SETPIPE_SZ, PIPE_SIZE * 100) };
+            let pipesize1 = unsafe { libc::fcntl(fd, libc::F_SETPIPE_SZ, PIPE_SIZE) };
 
-            assert!(pipesize >= PIPE_SIZE * 100 && pipesize1 >= PIPE_SIZE * 100);
+            assert!(pipesize >= PIPE_SIZE && pipesize1 >= PIPE_SIZE);
 
             thread::sleep(std::time::Duration::new(40, 0));
             let auth = PasswordAuth {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -532,6 +532,7 @@ mod tests {
         cmd.status().expect("Failed to launch ch-remote").success()
     }
 
+    #[derive(Debug)]
     struct PasswordAuth {
         username: String,
         password: String,
@@ -574,6 +575,16 @@ mod tests {
                 Err(e) => {
                     counter += 1;
                     if counter >= retries {
+                        eprintln!(
+                            "\n\n==== Start ssh command output (FAILED) ====\n\n\
+                             command=\"{}\"\n\
+                             auth=\"{:#?}\"\n\
+                             ip=\"{}\"\n\
+                             output=\"{}\"\n\
+                             \n==== End ssh command outout ====\n\n",
+                            command, auth, ip, s
+                        );
+
                         return Err(e);
                     }
                 }
@@ -1004,6 +1015,13 @@ mod tests {
         }
 
         fn spawn(&mut self) -> io::Result<Child> {
+            println!(
+                "\n\n==== Start cloud-hypervisor command-line ====\n\n\
+                 {:?}\n\
+                 \n==== End cloud-hypervisor command-line ====\n\n",
+                self.command
+            );
+
             if self.capture_output {
                 let child = self
                     .command


### PR DESCRIPTION
This patch prints the complete commandline when launching
cloud-hypervisor. It also prints the details of the `ssh` command if
the command is failing.

This patch enable the `INFO` (`-v`) level logging. Given the increased 
amount of output from cloud-hypervisor, it also increased the 
PIPE_SIZE to 32MB (from 256KB).

Signed-off-by: Bo Chen <chen.bo@intel.com>