### PR TITLE
Simplify PCI space address handling in AArch64 FDT

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -97,7 +97,7 @@ pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug, S: ::std::hash::BuildHash
     device_info: &HashMap<(DeviceType, String), T, S>,
     gic_device: &dyn GICDevice,
     initrd: &Option<InitramfsConfig>,
-    pci_space_address: &Option<(u64, u64)>,
+    pci_space_address: &(u64, u64),
 ) -> Result<Vec<u8>> {
     // Allocate stuff necessary for the holding the blob.
     let mut fdt = vec![0; FDT_MAX_SIZE];
@@ -126,9 +126,7 @@ pub fn create_fdt<T: DeviceInfoForFDT + Clone + Debug, S: ::std::hash::BuildHash
     create_clock_node(&mut fdt)?;
     create_psci_node(&mut fdt)?;
     create_devices_node(&mut fdt, device_info)?;
-    if let Some((pci_device_base, pci_device_size)) = pci_space_address {
-        create_pci_nodes(&mut fdt, *pci_device_base, *pci_device_size)?;
-    }
+    create_pci_nodes(&mut fdt, pci_space_address.0, pci_space_address.1)?;
 
     // End Header node.
     append_end_node(&mut fdt)?;

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -126,7 +126,7 @@ pub fn configure_system<T: DeviceInfoForFDT + Clone + Debug, S: ::std::hash::Bui
     vcpu_mpidr: Vec<u64>,
     device_info: &HashMap<(DeviceType, String), T, S>,
     initrd: &Option<super::InitramfsConfig>,
-    pci_space_address: &Option<(u64, u64)>,
+    pci_space_address: &(u64, u64),
 ) -> super::Result<Box<dyn GICDevice>> {
     let gic_device = gic::kvm::create_gic(vm, vcpu_count).map_err(Error::SetupGIC)?;
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -963,7 +963,7 @@ impl Vm {
             .ok_or(Error::MemOverflow)?
             + 1;
 
-        let pci_space = Some((pci_space_start.0, pci_space_size));
+        let pci_space = (pci_space_start.0, pci_space_size);
 
         // Call `configure_system` and pass the GIC devices out, so that
         // we can register the GIC device to the device manager.
@@ -2035,7 +2035,7 @@ mod tests {
             &dev_info,
             &*gic,
             &None,
-            &None,
+            &(0x1_0000_0000, 0x1_0000),
         )
         .is_ok())
     }


### PR DESCRIPTION
Before Virtio-mmio was removed, we passed an optional PCI space address parameter to AArch64 code for generating FDT. The address is none if the transport is MMIO. Now Virtio-PCI is the only option, the parameter is mandatory.
