### PR TITLE
vmm, hypervisor: Fix snapshot/restore for Windows guest

### DIFF
--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -85,6 +85,7 @@ pub fn check_required_kvm_extensions(kvm: &Kvm) -> KvmResult<()> {
 }
 #[derive(Clone, Serialize, Deserialize)]
 pub struct VcpuKvmState {
+    pub cpuid: CpuId,
     pub msrs: MsrEntries,
     pub vcpu_events: VcpuEvents,
     pub regs: StandardRegisters,

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -183,6 +183,7 @@ fn create_vmm_ioctl_seccomp_rule_common() -> Result<Vec<SeccompRule>, Error> {
 fn create_vmm_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
     const KVM_CREATE_PIT2: u64 = 0x4040_ae77;
     const KVM_GET_CLOCK: u64 = 0x8030_ae7c;
+    const KVM_GET_CPUID2: u64 = 0xc008_ae91;
     const KVM_GET_FPU: u64 = 0x81a0_ae8c;
     const KVM_GET_LAPIC: u64 = 0x8400_ae8e;
     const KVM_GET_MSR_INDEX_LIST: u64 = 0xc004_ae02;
@@ -205,6 +206,7 @@ fn create_vmm_ioctl_seccomp_rule() -> Result<Vec<SeccompRule>, Error> {
     let mut arch_rules = or![
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_CREATE_PIT2)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_CLOCK,)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_CPUID2,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_FPU)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_LAPIC)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MSR_INDEX_LIST)?],


### PR DESCRIPTION
The snasphot/restore feature is not working because some CPU states are
not properly saved, which means they can't be restored later on.

First thing, we ensure the CPUID is stored so that it can be properly
restored later. The code is simplified and pushed down to the hypervisor
crate.

Second thing, we identify for each vCPU if the Hyper-V SynIC device is
emulated or not. In case it is, that means some specific MSRs will be
set by the guest. These MSRs must be saved in order to properly restore
the VM.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>