### PR TITLE
tests: Use ch-remote in test_windows_guest_snapshot_restore

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5569,14 +5569,16 @@ mod tests {
             // Restore the VM from the snapshot
             let mut child = Command::new(clh_command("cloud-hypervisor"))
                 .args(&["--api-socket", &api_socket])
-                .args(&[
-                    "--restore",
-                    format!("source_url=file://{}", snapshot_dir).as_str(),
-                ])
                 .stderr(Stdio::piped())
                 .stdout(Stdio::piped())
                 .spawn()
                 .unwrap();
+
+            assert!(remote_command(
+                &api_socket,
+                "restore",
+                Some(format!("source_url=file://{}", snapshot_dir).as_str()),
+            ));
 
             // Wait for the VM to be restored
             thread::sleep(std::time::Duration::new(10, 0));


### PR DESCRIPTION
Use the API to restore the VM from the file rather than the --restore
command line option as this will block until the restore is completed.
This removes the assumption that the restore completes within 10s.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>