### PR TITLE
build: Move on-demand workers from bionic to groovy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline{
 			failFast true
             parallel {
 				stage ('Worker build') {
-					agent { node { label 'bionic' } }
+					agent { node { label 'groovy' } }
 					options {
 						timeout(time: 1, unit: 'HOURS')
 					}
@@ -82,7 +82,7 @@ pipeline{
 					}
 				}
 				stage ('Worker build (musl)') {
-					agent { node { label 'bionic' } }
+					agent { node { label 'groovy' } }
 					options {
 						timeout(time: 1, unit: 'HOURS')
 					}
@@ -135,7 +135,7 @@ pipeline{
 					}
 				}
 				stage ('Worker build - Windows guest') {
-					agent { node { label 'bionic-win' } }
+					agent { node { label 'groovy-win' } }
 					options {
 						timeout(time: 1, unit: 'HOURS')
 					}


### PR DESCRIPTION
This is an interim step to be able to test io_uring on our CI system.

See: #1561

Signed-off-by: Rob Bradford <robert.bradford@intel.com>