### PR TITLE
tests: Wait explicitly for the guest vm to boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "clap",
  "credibility",
  "dirs",
+ "epoll",
  "hypervisor",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ lto = true
 anyhow = "1.0"
 api_client = { path = "api_client" }
 clap = { version = "2.33.3", features = ["wrap_help"] }
+epoll = ">=4.0.1"
 hypervisor = { path = "hypervisor" }
 libc = "0.2.80"
 log = { version = "0.4.11", features = ["std"] }

--- a/test_data/cloud-init/ubuntu/user-data
+++ b/test_data/cloud-init/ubuntu/user-data
@@ -9,6 +9,11 @@ users:
 
 ssh_pwauth: True
 
+runcmd:
+  - [ systemctl, daemon-reload]
+  - [ systemctl, enable, notify-booted.service]
+  - [ systemctl, start, --no-block, notify-booted.service ]
+
 write_files:
   -
     path: /etc/systemd/system/vfio.service
@@ -39,3 +44,26 @@ write_files:
         echo 512 | sudo tee /proc/sys/vm/nr_hugepages
         sudo chmod a+rwX /dev/hugepages
         /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda1 VFIOTAG" --disk path=/mnt/focal-server-cloudimg-amd64-custom.qcow2 path=/mnt/cloudinit.img --cpus boot=1 --memory size=512M,hotplug_size=1G,hugepages=on --device path=/sys/bus/pci/devices/0000:00:06.0/ path=/sys/bus/pci/devices/0000:00:07.0/ --api-socket /tmp/ch_api.sock
+
+  -
+    path: /etc/systemd/system/notify-booted.service
+    permissions: 0644
+    content: |
+        [Unit]
+        Description=Notify the tcp listener on the host that the guest is booted
+        After=sshd.service
+
+        [Service]
+        Type=simple
+        ExecStart=/usr/bin/cloud-hypervisor-notify-booted.sh
+
+        [Install]
+        WantedBy=multi-user.target
+
+  -
+    path: /usr/bin/cloud-hypervisor-notify-booted.sh
+    permissions: 0755
+    content: |
+        #!/bin/bash
+
+        echo -n "@DEFAULT_TCP_LISTENER_MESSAGE" | nc -w0 @HOST_IP @TCP_LISTENER_PORT


### PR DESCRIPTION
Instead of blindly waiting for 20-40s for the guest VM to boot, this
patch waits the notification from the guest VM explicitly by using a
simple TcpListener on the host and a custom systemd service in the
guest.

This patch also ported few tests to use this new machanism, while more
tests are to be ported.

Signed-off-by: Bo Chen <chen.bo@intel.com>