### PR TITLE
build: Enable io_uring feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde_json = "1.0.59"
 net_util = { path = "net_util" }
 
 [features]
-default = ["acpi", "cmos", "kvm"]
+default = ["acpi", "cmos", "io_uring", "kvm"]
 acpi = ["vmm/acpi"]
 cmos = ["vmm/cmos"]
 fwdebug = ["vmm/fwdebug"]

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -127,6 +127,7 @@ fn virtio_blk_io_uring_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         #[cfg(target_arch = "x86_64")]
         allow_syscall(libc::SYS_epoll_wait),
         allow_syscall(libc::SYS_exit),
+        allow_syscall(libc::SYS_fsync),
         allow_syscall(libc::SYS_futex),
         allow_syscall(SYS_IO_URING_ENTER),
         allow_syscall(libc::SYS_madvise),


### PR DESCRIPTION
Now that we that our CI is running with a kernel that is new enough to
support io_uring we can turn this feature on by default.

See: #1561

Signed-off-by: Rob Bradford <robert.bradford@intel.com>