### PR TITLE
build: Use stable virtio-fs QEMU branch

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -126,11 +126,11 @@ update_workloads() {
 
     if [ ! -f "$VIRTIOFSD" ]; then
         pushd $WORKLOADS_DIR
-        git clone --depth 1 "https://gitlab.com/virtio-fs/qemu.git" -b "virtio-fs-dev" $QEMU_DIR
+        git clone --depth 1 "https://gitlab.com/virtio-fs/qemu.git" -b "qemu5.0-virtiofs-dax" $QEMU_DIR
         pushd $QEMU_DIR
         time ./configure --prefix=$PWD --target-list=aarch64-softmmu
-        time make -j `nproc`
-        cp build/tools/virtiofsd/virtiofsd $VIRTIOFSD || exit 1
+        time make virtiofsd -j `nproc`
+        cp virtiofsd $VIRTIOFSD || exit 1
         popd
         rm -rf $QEMU_DIR
         popd

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -127,11 +127,11 @@ VIRTIOFSD="$WORKLOADS_DIR/virtiofsd"
 QEMU_DIR="qemu_build"
 if [ ! -f "$VIRTIOFSD" ]; then
     pushd $WORKLOADS_DIR
-    git clone --depth 1 "https://gitlab.com/virtio-fs/qemu.git" -b "virtio-fs-dev" $QEMU_DIR
+    git clone --depth 1 "https://gitlab.com/virtio-fs/qemu.git" -b "qemu5.0-virtiofs-dax" $QEMU_DIR
     pushd $QEMU_DIR
     time ./configure --prefix=$PWD --target-list=x86_64-softmmu
-    time make -j `nproc`
-    cp build/tools/virtiofsd/virtiofsd $VIRTIOFSD || exit 1
+    time make virtiofsd -j `nproc`
+    cp virtiofsd $VIRTIOFSD || exit 1
     popd
     rm -rf $QEMU_DIR
     popd


### PR DESCRIPTION
Address build failure from activity in the development virtio-fs branch
by using the stable fork.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>