### PR TITLE
build: Add the 'v' prefix when using the crate version

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ extern crate clap;
 use std::process::Command;
 
 fn main() {
-    let mut version = crate_version!().to_string();
+    let mut version = "v".to_owned() + crate_version!();
 
     if let Ok(git_out) = Command::new("git").args(&["describe", "--dirty"]).output() {
         if git_out.status.success() {


### PR DESCRIPTION
This patch makes the `--version` information consistent when 
using `git describe` and 'cloud-hypervisor' crate version.

Signed-off-by: Bo Chen <chen.bo@intel.com>