### PR TITLE
AArch64 ci improvements

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -197,7 +197,7 @@ sudo bash -c "echo 10 > /sys/kernel/mm/ksm/sleep_millisecs"
 sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 
 export RUST_BACKTRACE=1
-time cargo test --no-default-features --features "integration_tests,kvm" "tests::parallel::$@" -- --skip test_snapshot_restore
+time cargo test --no-default-features --features "integration_tests,kvm" "tests::parallel::$@"
 RES=$?
 
 # Tear vhost_user_net test network down

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5247,6 +5247,7 @@ mod tests {
         // through each ssh command. There's no need to perform a dedicated test to
         // verify the migration went well for virtio-net.
         #[test]
+        #[cfg(target_arch = "x86_64")]
         fn test_snapshot_restore() {
             let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
             let guest = Guest::new(&mut focal);
@@ -5254,10 +5255,7 @@ mod tests {
             workload_path.push("workloads");
 
             let mut kernel_path = workload_path;
-            #[cfg(target_arch = "x86_64")]
             kernel_path.push("bzImage");
-            #[cfg(target_arch = "aarch64")]
-            kernel_path.push("Image");
 
             let api_socket = temp_api_path(&guest.tmp_dir);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -31,6 +31,7 @@ mod tests {
     use std::thread;
     use tempdir::TempDir;
     use tempfile::NamedTempFile;
+    #[cfg_attr(target_arch = "aarch64", allow(unused_imports))]
     use wait_timeout::ChildExt;
 
     lazy_static! {
@@ -5579,10 +5580,10 @@ mod tests {
         }
     }
 
+    #[cfg(target_arch = "x86_64")]
     mod windows {
         use crate::tests::*;
 
-        #[cfg(target_arch = "x86_64")]
         fn windows_auth() -> PasswordAuth {
             PasswordAuth {
                 username: String::from("administrator"),
@@ -5591,7 +5592,6 @@ mod tests {
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_windows_guest() {
             let mut workload_path = dirs::home_dir().unwrap();
             workload_path.push("workloads");
@@ -5643,7 +5643,6 @@ mod tests {
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_windows_guest_snapshot_restore() {
             let tmp_dir = TempDir::new("ch").unwrap();
             let mut workload_path = dirs::home_dir().unwrap();
@@ -5738,11 +5737,11 @@ mod tests {
         }
     }
 
+    #[cfg(target_arch = "x86_64")]
     mod sgx {
         use crate::tests::*;
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_sgx() {
             let mut focal = UbuntuDiskConfig::new(FOCAL_SGX_IMAGE_NAME.to_string());
             let guest = Guest::new(&mut focal);


### PR DESCRIPTION
Set test_snapshot_restore X86 specific, because now migration is no longer available on AArch64 after removing virtio-mmio.

Fixed some build warnings on AArch64.