### PR TITLE
Enable VM rebooting on AArch64

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -194,6 +194,7 @@ pub enum VmExit<'a> {
     MmioWrite(u64 /* address */, &'a [u8]),
     Ignore,
     Reset,
+    Shutdown,
     Hyperv,
 }
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -738,10 +738,10 @@ impl cpu::Vcpu for KvmVcpu {
                     use kvm_bindings::{KVM_SYSTEM_EVENT_RESET, KVM_SYSTEM_EVENT_SHUTDOWN};
                     // On Aarch64, when the VM is shutdown, run() returns
                     // VcpuExit::SystemEvent with reason KVM_SYSTEM_EVENT_SHUTDOWN
-                    if event_type == KVM_SYSTEM_EVENT_SHUTDOWN
-                        || event_type == KVM_SYSTEM_EVENT_RESET
-                    {
+                    if event_type == KVM_SYSTEM_EVENT_RESET {
                         Ok(cpu::VmExit::Reset)
+                    } else if event_type == KVM_SYSTEM_EVENT_SHUTDOWN {
+                        Ok(cpu::VmExit::Shutdown)
                     } else {
                         Err(cpu::HypervisorCpuError::RunVcpu(anyhow!(
                             "Unexpected system event with type 0x{:x}, flags 0x{:x}",

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -34,7 +34,7 @@ use devices::interrupt_controller::InterruptController;
 use hypervisor::kvm::kvm_bindings;
 #[cfg(target_arch = "x86_64")]
 use hypervisor::CpuId;
-use hypervisor::{CpuState, VmExit};
+use hypervisor::{CpuState, HypervisorCpuError, VmExit};
 use seccomp::{SeccompAction, SeccompFilter};
 
 use libc::{c_void, siginfo_t};
@@ -213,8 +213,6 @@ pub struct Vcpu {
     // The hypervisor abstracted CPU.
     vcpu: Arc<dyn hypervisor::Vcpu>,
     id: u8,
-    #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
-    interrupt_controller: Option<Arc<Mutex<dyn InterruptController>>>,
     #[cfg(target_arch = "aarch64")]
     mpidr: u64,
     saved_state: Option<CpuState>,
@@ -227,11 +225,7 @@ impl Vcpu {
     ///
     /// * `id` - Represents the CPU number between [0, max vcpus).
     /// * `vm` - The virtual machine this vcpu will get attached to.
-    pub fn new(
-        id: u8,
-        vm: &Arc<dyn hypervisor::Vm>,
-        interrupt_controller: Option<Arc<Mutex<dyn InterruptController>>>,
-    ) -> Result<Arc<Mutex<Self>>> {
+    pub fn new(id: u8, vm: &Arc<dyn hypervisor::Vm>) -> Result<Arc<Mutex<Self>>> {
         let vcpu = vm
             .create_vcpu(id)
             .map_err(|e| Error::VcpuCreate(e.into()))?;
@@ -239,7 +233,6 @@ impl Vcpu {
         Ok(Arc::new(Mutex::new(Vcpu {
             vcpu,
             id,
-            interrupt_controller,
             #[cfg(target_arch = "aarch64")]
             mpidr: 0,
             saved_state: None,
@@ -323,28 +316,8 @@ impl Vcpu {
     ///
     /// Note that the state of the VCPU and associated VM must be setup first for this to do
     /// anything useful.
-    pub fn run(&self) -> Result<bool> {
-        match self.vcpu.run() {
-            Ok(run) => match run {
-                #[cfg(target_arch = "x86_64")]
-                VmExit::IoapicEoi(vector) => {
-                    if let Some(interrupt_controller) = &self.interrupt_controller {
-                        interrupt_controller
-                            .lock()
-                            .unwrap()
-                            .end_of_interrupt(vector);
-                    }
-                    Ok(true)
-                }
-                VmExit::Ignore => Ok(true),
-                VmExit::Reset => Ok(false),
-                // No need to handle anything from a KVM HyperV exit
-                VmExit::Hyperv => Ok(true),
-                _ => Err(Error::UnexpectedVmExit),
-            },
-
-            Err(e) => Err(Error::VcpuRun(e.into())),
-        }
+    pub fn run(&self) -> std::result::Result<VmExit, HypervisorCpuError> {
+        self.vcpu.run()
     }
 }
 
@@ -425,6 +398,7 @@ pub struct CpuManager {
     vm: Arc<dyn hypervisor::Vm>,
     vcpus_kill_signalled: Arc<AtomicBool>,
     vcpus_pause_signalled: Arc<AtomicBool>,
+    exit_evt: EventFd,
     #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     reset_evt: EventFd,
     vcpu_states: Vec<VcpuState>,
@@ -555,6 +529,7 @@ impl CpuManager {
         device_manager: &Arc<Mutex<DeviceManager>>,
         memory_manager: &Arc<Mutex<MemoryManager>>,
         vm: Arc<dyn hypervisor::Vm>,
+        exit_evt: EventFd,
         reset_evt: EventFd,
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
         seccomp_action: SeccompAction,
@@ -584,6 +559,7 @@ impl CpuManager {
             vcpus_kill_signalled: Arc::new(AtomicBool::new(false)),
             vcpus_pause_signalled: Arc::new(AtomicBool::new(false)),
             vcpu_states,
+            exit_evt,
             reset_evt,
             selected_cpu: 0,
             vcpus: Vec::with_capacity(usize::from(config.max_vcpus)),
@@ -679,13 +655,7 @@ impl CpuManager {
     ) -> Result<Arc<Mutex<Vcpu>>> {
         info!("Creating vCPU: cpu_id = {}", cpu_id);
 
-        let interrupt_controller = if let Some(interrupt_controller) = &self.interrupt_controller {
-            Some(interrupt_controller.clone())
-        } else {
-            None
-        };
-
-        let vcpu = Vcpu::new(cpu_id, &self.vm, interrupt_controller)?;
+        let vcpu = Vcpu::new(cpu_id, &self.vm)?;
 
         if let Some(snapshot) = snapshot {
             // AArch64 vCPUs should be initialized after created.
@@ -756,6 +726,7 @@ impl CpuManager {
     ) -> Result<()> {
         let cpu_id = vcpu.lock().unwrap().id;
         let reset_evt = self.reset_evt.try_clone().unwrap();
+        let exit_evt = self.exit_evt.try_clone().unwrap();
         let vcpu_kill_signalled = self.vcpus_kill_signalled.clone();
         let vcpu_pause_signalled = self.vcpus_pause_signalled.clone();
 
@@ -769,6 +740,14 @@ impl CpuManager {
         // Retrieve seccomp filter for vcpu thread
         let vcpu_seccomp_filter = get_seccomp_filter(&self.seccomp_action, Thread::Vcpu)
             .map_err(Error::CreateSeccompFilter)?;
+
+        #[cfg(target_arch = "x86_64")]
+        let interrupt_controller_clone =
+            if let Some(interrupt_controller) = &self.interrupt_controller {
+                Some(interrupt_controller.clone())
+            } else {
+                None
+            };
 
         let handle = Some(
             thread::Builder::new()
@@ -816,14 +795,39 @@ impl CpuManager {
 
                         // vcpu.run() returns false on a triple-fault so trigger a reset
                         match vcpu.lock().unwrap().run() {
+                            Ok(run) => match run {
+                                #[cfg(target_arch = "x86_64")]
+                                VmExit::IoapicEoi(vector) => {
+                                    if let Some(interrupt_controller) = &interrupt_controller_clone
+                                    {
+                                        interrupt_controller
+                                            .lock()
+                                            .unwrap()
+                                            .end_of_interrupt(vector);
+                                    }
+                                }
+                                VmExit::Ignore => {}
+                                VmExit::Hyperv => {}
+                                VmExit::Reset => {
+                                    debug!("VmExit::Reset");
+                                    vcpu_run_interrupted.store(true, Ordering::SeqCst);
+                                    reset_evt.write(1).unwrap();
+                                    break;
+                                }
+                                VmExit::Shutdown => {
+                                    debug!("VmExit::Shutdown");
+                                    vcpu_run_interrupted.store(true, Ordering::SeqCst);
+                                    exit_evt.write(1).unwrap();
+                                    break;
+                                }
+                                _ => {
+                                    error!("VCPU generated error: {:?}", Error::UnexpectedVmExit);
+                                    break;
+                                }
+                            },
+
                             Err(e) => {
-                                error!("VCPU generated error: {:?}", e);
-                                break;
-                            }
-                            Ok(true) => {}
-                            Ok(false) => {
-                                vcpu_run_interrupted.store(true, Ordering::SeqCst);
-                                reset_evt.write(1).unwrap();
+                                error!("VCPU generated error: {:?}", Error::VcpuRun(e.into()));
                                 break;
                             }
                         }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -432,6 +432,7 @@ impl Vmm {
 
     fn vm_reboot(&mut self) -> result::Result<(), VmError> {
         // Without ACPI, a reset is equivalent to a shutdown
+        #[cfg(target_arch = "x86_64")]
         #[cfg(not(feature = "acpi"))]
         {
             if self.vm.is_some() {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -512,11 +512,13 @@ impl Vm {
         });
         vm.set_vmmops(vm_ops).map_err(Error::SetVmmOpsInterface)?;
 
+        let exit_evt_clone = exit_evt.try_clone().map_err(Error::EventFdClone)?;
         let cpu_manager = cpu::CpuManager::new(
             &config.lock().unwrap().cpus.clone(),
             &device_manager,
             &memory_manager,
             vm.clone(),
+            exit_evt_clone,
             reset_evt,
             hypervisor,
             seccomp_action.clone(),


### PR DESCRIPTION
In `Vmm::vm_reboot()`, we checked whether ACPI feature is enabled or not. If not, rebooting was handled as shutting down.

Now ACPI is still not implemented on AArch64. We can remove the check on AArch64 to let the VM be able to reboot.