### PR TITLE
vmm: memory_manager: Move the restoration of guest memory later

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -639,7 +639,6 @@ impl Vm {
         let memory_manager = MemoryManager::new(
             vm.clone(),
             &config.lock().unwrap().memory.clone(),
-            None,
             false,
             phys_bits,
         )


### PR DESCRIPTION
Rather than filling the guest memory from a file at the point of the the
guest memory region being created instead fill from the file later. This
simplifies the region creation code but also adds flexibility for
sourcing the guest memory from a source other than an on disk file.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>