### PR TITLE
hypervisor: x86 code emulator framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "iced-x86",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
@@ -513,6 +514,17 @@ dependencies = [
  "thiserror",
  "vm-memory",
  "vmm-sys-util",
+]
+
+[[package]]
+name = "iced-x86"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248ce8ff0784d2b15f3c3d8b01f529be0e18aa693a2ba7415df76857967c8fc3"
+dependencies = [
+ "lazy_static",
+ "rustc_version",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1127,6 +1139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1166,21 @@ source = "git+https://github.com/firecracker-microvm/firecracker?tag=v0.22.0#cc5
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -1216,6 +1252,12 @@ dependencies = [
  "libssh2-sys",
  "parking_lot",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
+dependencies = [
+ "atty",
+ "humantime",
+ "log 0.4.11",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "epoll"
 version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,11 +510,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+
+[[package]]
 name = "hypervisor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "env_logger",
  "iced-x86",
  "kvm-bindings",
  "kvm-ioctls",
@@ -1382,6 +1402,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1816,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -7,7 +7,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 use std::sync::Arc;
-mod gdt;
 pub mod interrupts;
 pub mod layout;
 mod mptable;

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -9,8 +9,8 @@
 use std::sync::Arc;
 use std::{mem, result};
 
-use super::gdt::{gdt_entry, segment_from_gdt};
 use super::BootProtocol;
+use hypervisor::arch::x86::gdt::{gdt_entry, segment_from_gdt};
 use hypervisor::x86_64::{FpuState, SpecialRegisters, StandardRegisters};
 use layout::{
     BOOT_GDT_START, BOOT_IDT_START, PDE_START, PDPTE_START, PML4_START, PML5_START, PVH_INFO_START,

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -30,3 +30,6 @@ features = ["elf", "bzimage"]
 version = "1.9.1"
 default-features = false
 features = ["std", "decoder", "op_code_info", "instr_info"]
+
+[dev-dependencies]
+env_logger = "0.8.2"

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -25,3 +25,8 @@ vmm-sys-util = { version = ">=0.5.0", features = ["with-serde"] }
 [dependencies.linux-loader]
 git = "https://github.com/rust-vmm/linux-loader"
 features = ["elf", "bzimage"]
+
+[dependencies.iced-x86]
+version = "1.9.1"
+default-features = false
+features = ["std", "decoder", "op_code_info", "instr_info"]

--- a/hypervisor/src/arch/emulator/mod.rs
+++ b/hypervisor/src/arch/emulator/mod.rs
@@ -1,0 +1,122 @@
+//
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+extern crate thiserror;
+
+use core::fmt::Debug;
+use std::fmt::{self, Display};
+use thiserror::Error;
+
+#[derive(Clone, Copy, Error, Debug)]
+pub struct Exception<T: Debug> {
+    vector: T,
+    ip: u64,
+    error: Option<u32>,
+    payload: Option<u64>,
+}
+
+impl<T: Debug> Display for Exception<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Exception {:?} at IP {:#x}", self.vector, self.ip)
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum PlatformError {
+    #[error("Invalid register: {0}")]
+    InvalidRegister(#[source] anyhow::Error),
+
+    #[error("Memory read failure: {0}")]
+    MemoryReadFailure(#[source] anyhow::Error),
+
+    #[error("Memory write failure: {0}")]
+    MemoryWriteFailure(#[source] anyhow::Error),
+
+    #[error("Get CPU state failure: {0}")]
+    GetCpuStateFailure(#[source] anyhow::Error),
+
+    #[error("Set CPU state failure: {0}")]
+    SetCpuStateFailure(#[source] anyhow::Error),
+
+    #[error("Unmapped virtual address: {0}")]
+    UnmappedGVA(#[source] anyhow::Error),
+}
+
+#[derive(Error, Debug)]
+pub enum EmulationError<T: Debug> {
+    #[error("Unsupported instruction: {0}")]
+    UnsupportedInstruction(#[source] anyhow::Error),
+
+    #[error("Unsupported memory size: {0}")]
+    UnsupportedMemorySize(#[source] anyhow::Error),
+
+    #[error("Invalid operand: {0}")]
+    InvalidOperand(#[source] anyhow::Error),
+
+    #[error("Wrong number of operands: {0}")]
+    WrongNumberOperands(#[source] anyhow::Error),
+
+    #[error("Instruction Exception: {0}")]
+    InstructionException(Exception<T>),
+
+    #[error("Platform emulation error: {0}")]
+    PlatformEmulationError(PlatformError),
+}
+
+/// The PlatformEmulator trait emulates a guest platform.
+/// It's mostly a guest resources (memory and CPU state) getter and setter.
+///
+/// A CpuState is an architecture specific type, representing a CPU state.
+/// The emulator and its instruction handlers modify a given CPU state and
+/// eventually ask the platform to commit it back through `set_cpu_state`.
+pub trait PlatformEmulator: Send + Sync {
+    type CpuState: Clone;
+
+    /// Read guest memory into a u8 slice.
+    ///
+    /// # Arguments
+    ///
+    /// * `gva` - Guest virtual address to read from.
+    /// * `data` - Data slice to read into.
+    ///
+    fn read_memory(&self, gva: u64, data: &mut [u8]) -> Result<(), PlatformError>;
+
+    /// Write a u8 slice into guest memory.
+    ///
+    /// # Arguments
+    ///
+    /// * `gva` - Guest virtual address to write into.
+    /// * `data` - Data slice to be written.
+    ///
+    fn write_memory(&mut self, gva: u64, data: &[u8]) -> Result<(), PlatformError>;
+
+    /// Get a CPU state from the guest.
+    ///
+    /// # Arguments
+    ///
+    /// * `cpu_id` - Logical CPU ID.
+    ///
+    fn cpu_state(&self, cpu_id: usize) -> Result<Self::CpuState, PlatformError>;
+
+    /// Set a guest CPU state.
+    ///
+    /// # Arguments
+    ///
+    /// * `cpu_id` - Logical CPU ID.
+    /// * `state` - State to set the CPU into.
+    ///
+    fn set_cpu_state(&self, cpu_id: usize, state: Self::CpuState) -> Result<(), PlatformError>;
+
+    /// Translate a guest virtual address into a physical one
+    ///
+    /// # Arguments
+    ///
+    /// * `gva` - Guest virtual address to translate.
+    ///
+    fn gva_to_gpa(&self, gva: u64) -> Result<u64, PlatformError>;
+}
+
+pub type EmulationResult<S, E> = std::result::Result<S, EmulationError<E>>;

--- a/hypervisor/src/arch/mod.rs
+++ b/hypervisor/src/arch/mod.rs
@@ -11,5 +11,7 @@
 // Copyright © 2020, Microsoft Corporation
 //
 
+pub mod emulator;
+
 #[cfg(target_arch = "x86_64")]
 pub mod x86;

--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -1,0 +1,49 @@
+//
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+extern crate iced_x86;
+
+use crate::arch::emulator::{EmulationError, PlatformEmulator};
+use crate::arch::x86::emulator::CpuStateManager;
+use crate::arch::x86::Exception;
+use iced_x86::*;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+pub trait InstructionHandler<T: CpuStateManager> {
+    fn emulate(
+        &self,
+        insn: &Instruction,
+        state: &mut T,
+        platform: Arc<Mutex<dyn PlatformEmulator<CpuState = T>>>,
+    ) -> Result<(), EmulationError<Exception>>;
+}
+
+pub struct InstructionMap<T: CpuStateManager> {
+    pub instructions: HashMap<Code, Box<Box<dyn InstructionHandler<T> + Sync + Send>>>,
+}
+
+impl<T: CpuStateManager> InstructionMap<T> {
+    pub fn new() -> InstructionMap<T> {
+        InstructionMap {
+            instructions: HashMap::new(),
+        }
+    }
+
+    pub fn add_insn(
+        &mut self,
+        insn: Code,
+        insn_handler: Box<dyn InstructionHandler<T> + Sync + Send>,
+    ) {
+        self.instructions.insert(insn, Box::new(insn_handler));
+    }
+}
+
+impl<T: CpuStateManager> Default for InstructionMap<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -6,12 +6,42 @@
 
 extern crate iced_x86;
 
-use crate::arch::emulator::{EmulationError, PlatformEmulator};
+use crate::arch::emulator::{EmulationError, PlatformEmulator, PlatformError};
 use crate::arch::x86::emulator::CpuStateManager;
 use crate::arch::x86::Exception;
 use iced_x86::*;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+
+pub mod mov;
+
+// Returns the linear a.k.a. virtual address for a memory operand.
+fn memory_operand_address<T: CpuStateManager>(
+    insn: &Instruction,
+    state: &T,
+) -> Result<u64, PlatformError> {
+    let mut address: u64 = 0;
+
+    // Get the DS or override segment base first
+    let segment_base = state.read_segment(insn.memory_segment())?.base;
+    address += segment_base;
+
+    if insn.memory_base() != iced_x86::Register::None {
+        let base: u64 = state.read_reg(insn.memory_base())?;
+        address += base;
+    }
+
+    if insn.memory_index() != iced_x86::Register::None {
+        let mut index: u64 = state.read_reg(insn.memory_index())?;
+        index *= insn.memory_index_scale() as u64;
+
+        address += index;
+    }
+
+    address += insn.memory_displacement() as u64;
+
+    Ok(address)
+}
 
 pub trait InstructionHandler<T: CpuStateManager> {
     fn emulate(

--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -77,3 +77,9 @@ impl<T: CpuStateManager> Default for InstructionMap<T> {
         Self::new()
     }
 }
+
+macro_rules! insn_add {
+    ($insn_map:ident, $mnemonic:ident, $code:ident) => {
+        $insn_map.add_insn(Code::$code, Box::new($mnemonic::$code {}));
+    };
+}

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -1,0 +1,786 @@
+//
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#![allow(non_camel_case_types)]
+
+//
+// MOV-Move
+// SDM Volume 1, Chapter 4.3
+//   Copies the second operand (source operand) to the first operand (destination operand).
+//
+
+extern crate iced_x86;
+
+use crate::arch::emulator::{EmulationError, PlatformEmulator};
+use crate::arch::x86::emulator::instructions::*;
+use crate::arch::x86::Exception;
+use std::mem;
+use std::sync::{Arc, Mutex};
+
+macro_rules! mov_rm_r {
+    ($bound:ty) => {
+        fn emulate(
+            &self,
+            insn: &Instruction,
+            state: &mut T,
+            platform: Arc<Mutex<dyn PlatformEmulator<CpuState = T>>>,
+        ) -> Result<(), EmulationError<Exception>> {
+            let src_reg_value = state
+                .read_reg(insn.op1_register())
+                .map_err(EmulationError::PlatformEmulationError)?;
+            let addr = memory_operand_address(insn, state)
+                .map_err(EmulationError::PlatformEmulationError)?;
+
+            match insn.op0_kind() {
+                OpKind::Register => state
+                    .write_reg(insn.op0_register(), src_reg_value)
+                    .map_err(EmulationError::PlatformEmulationError)?,
+
+                OpKind::Memory => {
+                    let src_reg_value_type: $bound = src_reg_value as $bound;
+                    platform
+                        .lock()
+                        .unwrap()
+                        .write_memory(addr, &src_reg_value_type.to_le_bytes())
+                        .map_err(EmulationError::PlatformEmulationError)?
+                }
+
+                k => return Err(EmulationError::InvalidOperand(anyhow!("{:?}", k))),
+            }
+
+            state.set_ip(insn.ip());
+
+            Ok(())
+        }
+    };
+}
+
+macro_rules! mov_rm_imm {
+    ($type:tt) => {
+        fn emulate(
+            &self,
+            insn: &Instruction,
+            state: &mut T,
+            platform: Arc<Mutex<dyn PlatformEmulator<CpuState = T>>>,
+        ) -> Result<(), EmulationError<Exception>> {
+            let imm = imm_op!($type, insn);
+            let addr = memory_operand_address(insn, state)
+                .map_err(EmulationError::PlatformEmulationError)?;
+
+            match insn.op0_kind() {
+                OpKind::Register => state
+                    .write_reg(insn.op0_register(), imm as u64)
+                    .map_err(EmulationError::PlatformEmulationError)?,
+                OpKind::Memory => platform
+                    .lock()
+                    .unwrap()
+                    .write_memory(addr, &imm.to_le_bytes())
+                    .map_err(EmulationError::PlatformEmulationError)?,
+                k => return Err(EmulationError::InvalidOperand(anyhow!("{:?}", k))),
+            }
+
+            state.set_ip(insn.ip());
+
+            Ok(())
+        }
+    };
+}
+
+macro_rules! mov_r_rm {
+    ($bound:ty) => {
+        fn emulate(
+            &self,
+            insn: &Instruction,
+            state: &mut T,
+            platform: Arc<Mutex<dyn PlatformEmulator<CpuState = T>>>,
+        ) -> Result<(), EmulationError<Exception>> {
+            let src_value: $bound = match insn.op1_kind() {
+                OpKind::Register => state
+                    .read_reg(insn.op1_register())
+                    .map_err(EmulationError::PlatformEmulationError)?
+                    as $bound,
+                OpKind::Memory => {
+                    let target_address = memory_operand_address(insn, state)
+                        .map_err(EmulationError::PlatformEmulationError)?;
+                    let mut memory: [u8; mem::size_of::<$bound>()] = [0; mem::size_of::<$bound>()];
+                    platform
+                        .lock()
+                        .unwrap()
+                        .read_memory(target_address, &mut memory)
+                        .map_err(EmulationError::PlatformEmulationError)?;
+                    <$bound>::from_le_bytes(memory)
+                }
+
+                k => return Err(EmulationError::InvalidOperand(anyhow!("{:?}", k))),
+            };
+
+            state
+                .write_reg(insn.op0_register(), src_value as u64)
+                .map_err(EmulationError::PlatformEmulationError)?;
+
+            state.set_ip(insn.ip());
+
+            Ok(())
+        }
+    };
+}
+
+macro_rules! mov_r_imm {
+    ($type:tt) => {
+        fn emulate(
+            &self,
+            insn: &Instruction,
+            state: &mut T,
+            _platform: Arc<Mutex<dyn PlatformEmulator<CpuState = T>>>,
+        ) -> Result<(), EmulationError<Exception>> {
+            state
+                .write_reg(insn.op0_register(), imm_op!($type, insn) as u64)
+                .map_err(EmulationError::PlatformEmulationError)?;
+
+            state.set_ip(insn.ip());
+
+            Ok(())
+        }
+    };
+}
+
+macro_rules! imm_op {
+    (u8, $insn:ident) => {
+        $insn.immediate8()
+    };
+
+    (u16, $insn:ident) => {
+        $insn.immediate16()
+    };
+
+    (u32, $insn:ident) => {
+        $insn.immediate32()
+    };
+
+    (u64, $insn:ident) => {
+        $insn.immediate64()
+    };
+
+    (u32tou64, $insn:ident) => {
+        $insn.immediate32to64()
+    };
+}
+
+pub struct Mov_r8_rm8 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_r8_rm8 {
+    mov_r_rm!(u8);
+}
+
+pub struct Mov_r8_imm8 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_r8_imm8 {
+    mov_r_imm!(u8);
+}
+
+pub struct Mov_r16_rm16 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_r16_rm16 {
+    mov_r_rm!(u16);
+}
+
+pub struct Mov_r16_imm16 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_r16_imm16 {
+    mov_r_imm!(u16);
+}
+
+pub struct Mov_r32_rm32 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_r32_rm32 {
+    mov_r_rm!(u32);
+}
+
+pub struct Mov_r32_imm32 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_r32_imm32 {
+    mov_r_imm!(u32);
+}
+
+pub struct Mov_r64_rm64 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_r64_rm64 {
+    mov_r_rm!(u64);
+}
+
+pub struct Mov_r64_imm64 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_r64_imm64 {
+    mov_r_imm!(u64);
+}
+
+pub struct Mov_rm8_imm8 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm8_imm8 {
+    mov_rm_imm!(u8);
+}
+
+pub struct Mov_rm8_r8 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm8_r8 {
+    mov_rm_r!(u8);
+}
+
+pub struct Mov_rm16_imm16 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm16_imm16 {
+    mov_rm_imm!(u16);
+}
+
+pub struct Mov_rm16_r16 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm16_r16 {
+    mov_rm_r!(u16);
+}
+
+pub struct Mov_rm32_imm32 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm32_imm32 {
+    mov_rm_imm!(u32);
+}
+
+pub struct Mov_rm32_r32 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm32_r32 {
+    mov_rm_r!(u32);
+}
+
+pub struct Mov_rm64_imm32 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm64_imm32 {
+    mov_rm_imm!(u32tou64);
+}
+
+pub struct Mov_rm64_r64 {}
+impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm64_r64 {
+    mov_rm_r!(u64);
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unused_mut)]
+
+    extern crate env_logger;
+
+    use super::*;
+    use crate::arch::emulator::{EmulationError, PlatformEmulator};
+    use crate::arch::x86::emulator::{Emulator, EmulatorCpuState as CpuState};
+    use crate::arch::x86::gdt::{gdt_entry, segment_from_gdt};
+    use crate::arch::x86::Exception;
+    use std::collections::HashMap;
+
+    #[derive(Debug, Clone)]
+    struct MockVMM {
+        memory: Vec<u8>,
+        state: Arc<Mutex<CpuState>>,
+    }
+
+    unsafe impl Sync for MockVMM {}
+
+    type MockResult = Result<(), EmulationError<Exception>>;
+
+    macro_rules! hashmap {
+        ($( $key: expr => $val: expr ),*) => {{
+            let mut map = ::std::collections::HashMap::new();
+            $( map.insert($key, $val); )*
+                map
+        }}
+    }
+
+    impl MockVMM {
+        pub fn new(state: CpuState) -> MockVMM {
+            MockVMM {
+                memory: vec![0; 4096],
+                state: Arc::new(Mutex::new(state)),
+            }
+        }
+    }
+
+    impl PlatformEmulator for MockVMM {
+        type CpuState = CpuState;
+
+        fn read_memory(&self, gva: u64, data: &mut [u8]) -> Result<(), PlatformError> {
+            debug!(
+                "Memory read {} bytes from [{:#x} -> {:#x}]",
+                data.len(),
+                gva,
+                gva
+            );
+            data.copy_from_slice(&self.memory[gva as usize..gva as usize + data.len()]);
+            Ok(())
+        }
+
+        fn write_memory(&mut self, gva: u64, data: &[u8]) -> Result<(), PlatformError> {
+            debug!(
+                "Memory write {} bytes at [{:#x} -> {:#x}]",
+                data.len(),
+                gva,
+                gva
+            );
+            self.memory[gva as usize..gva as usize + data.len()].copy_from_slice(data);
+
+            Ok(())
+        }
+
+        fn cpu_state(&self, _cpu_id: usize) -> Result<CpuState, PlatformError> {
+            Ok(self.state.lock().unwrap().clone())
+        }
+
+        fn set_cpu_state(
+            &self,
+            _cpu_id: usize,
+            state: Self::CpuState,
+        ) -> Result<(), PlatformError> {
+            *self.state.lock().unwrap() = state;
+            Ok(())
+        }
+
+        fn gva_to_gpa(&self, gva: u64) -> Result<u64, PlatformError> {
+            Ok(gva)
+        }
+    }
+
+    fn _init_and_run(
+        cpu_id: usize,
+        ip: u64,
+        insn: &[u8],
+        regs: HashMap<Register, u64>,
+        memory: Option<(u64, &[u8])>,
+        num_insn: Option<usize>,
+    ) -> Arc<Mutex<MockVMM>> {
+        let _ = env_logger::try_init();
+        let cs_reg = segment_from_gdt(gdt_entry(0xc09b, 0, 0xffffffff), 1);
+        let ds_reg = segment_from_gdt(gdt_entry(0xc093, 0, 0xffffffff), 2);
+        let mut initial_state = CpuState::default();
+        initial_state.set_ip(ip);
+        initial_state.write_segment(Register::CS, cs_reg).unwrap();
+        initial_state.write_segment(Register::DS, ds_reg).unwrap();
+        for (reg, value) in regs {
+            initial_state.write_reg(reg, value).unwrap();
+        }
+
+        let vmm = Arc::new(Mutex::new(MockVMM::new(initial_state)));
+        if let Some(mem) = memory {
+            vmm.lock().unwrap().write_memory(mem.0, &mem.1).unwrap();
+        }
+        let mut emulator = Emulator::new(vmm.clone());
+
+        let new_state = emulator
+            .emulate_insn_stream(cpu_id, &insn, num_insn)
+            .unwrap();
+        if num_insn.is_none() {
+            assert_eq!(ip + insn.len() as u64, new_state.ip());
+        }
+
+        vmm.lock()
+            .unwrap()
+            .set_cpu_state(cpu_id, new_state)
+            .unwrap();
+
+        vmm
+    }
+
+    fn init_and_run(
+        cpu_id: usize,
+        ip: u64,
+        insn: &[u8],
+        regs: HashMap<Register, u64>,
+        memory: Option<(u64, &[u8])>,
+    ) -> Arc<Mutex<MockVMM>> {
+        _init_and_run(cpu_id, ip, insn, regs, memory, None)
+    }
+
+    #[test]
+    // mov rax,rbx
+    fn test_mov_r64_r64() -> MockResult {
+        let rbx: u64 = 0x8899aabbccddeeff;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0x48, 0x89, 0xd8];
+        let vmm = init_and_run(cpu_id, ip, &insn, hashmap![Register::RBX => rbx], None);
+
+        let rax: u64 = vmm
+            .lock()
+            .unwrap()
+            .cpu_state(cpu_id)
+            .unwrap()
+            .read_reg(Register::RAX)
+            .unwrap();
+        assert_eq!(rax, rbx);
+
+        Ok(())
+    }
+
+    #[test]
+    // mov rax,0x1122334411223344
+    fn test_mov_r64_imm64() -> MockResult {
+        let imm64: u64 = 0x1122334411223344;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0x48, 0xb8, 0x44, 0x33, 0x22, 0x11, 0x44, 0x33, 0x22, 0x11];
+        let vmm = init_and_run(cpu_id, ip, &insn, hashmap![], None);
+
+        let rax: u64 = vmm
+            .lock()
+            .unwrap()
+            .cpu_state(cpu_id)
+            .unwrap()
+            .read_reg(Register::RAX)
+            .unwrap();
+        assert_eq!(rax, imm64);
+
+        Ok(())
+    }
+
+    #[test]
+    // mov rax, [rax+rax]
+    fn test_mov_r64_m64() -> MockResult {
+        let target_rax: u64 = 0x1234567812345678;
+        let mut rax: u64 = 0x100;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let memory: [u8; 8] = target_rax.to_le_bytes();
+        let insn = [0x48, 0x8b, 0x04, 0x00];
+        let vmm = init_and_run(
+            cpu_id,
+            ip,
+            &insn,
+            hashmap![Register::RAX => rax],
+            Some((rax + rax, &memory)),
+        );
+
+        rax = vmm
+            .lock()
+            .unwrap()
+            .cpu_state(cpu_id)
+            .unwrap()
+            .read_reg(Register::RAX)
+            .unwrap();
+        assert_eq!(rax, target_rax);
+
+        Ok(())
+    }
+
+    #[test]
+    // mov al,0x11
+    fn test_mov_r8_imm8() -> MockResult {
+        let imm8: u8 = 0x11;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0xb0, 0x11];
+        let vmm = init_and_run(cpu_id, ip, &insn, hashmap![], None);
+
+        let al = vmm
+            .lock()
+            .unwrap()
+            .cpu_state(cpu_id)
+            .unwrap()
+            .read_reg(Register::AL)
+            .unwrap();
+        assert_eq!(al as u8, imm8);
+
+        Ok(())
+    }
+
+    #[test]
+    // mov eax,0x11
+    fn test_mov_r32_imm8() -> MockResult {
+        let imm8: u8 = 0x11;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0xb8, 0x11, 0x00, 0x00, 0x00];
+        let vmm = init_and_run(cpu_id, ip, &insn, hashmap![], None);
+
+        let eax = vmm
+            .lock()
+            .unwrap()
+            .cpu_state(cpu_id)
+            .unwrap()
+            .read_reg(Register::EAX)
+            .unwrap();
+        assert_eq!(eax as u8, imm8);
+
+        Ok(())
+    }
+
+    #[test]
+    // mov rax,0x11223344
+    fn test_mov_r64_imm32() -> MockResult {
+        let imm32: u32 = 0x11223344;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0x48, 0xc7, 0xc0, 0x44, 0x33, 0x22, 0x11];
+        let vmm = init_and_run(cpu_id, ip, &insn, hashmap![], None);
+
+        let rax: u64 = vmm
+            .lock()
+            .unwrap()
+            .cpu_state(cpu_id)
+            .unwrap()
+            .read_reg(Register::RAX)
+            .unwrap();
+        assert_eq!(rax, imm32 as u64);
+
+        Ok(())
+    }
+
+    #[test]
+    // mov byte ptr [rax],dh
+    fn test_mov_m8_r8() -> MockResult {
+        let rax: u64 = 0x100;
+        let dh: u8 = 0x99;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0x88, 0x30];
+        let vmm = init_and_run(
+            cpu_id,
+            ip,
+            &insn,
+            hashmap![Register::RAX => rax, Register::DH => dh.into()],
+            None,
+        );
+
+        let mut memory: [u8; 1] = [0; 1];
+        vmm.lock().unwrap().read_memory(rax, &mut memory).unwrap();
+
+        assert_eq!(u8::from_le_bytes(memory), dh);
+
+        Ok(())
+    }
+
+    #[test]
+    // mov dword ptr [rax],esi
+    fn test_mov_m32_r32() -> MockResult {
+        let rax: u64 = 0x100;
+        let esi: u32 = 0x8899;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0x89, 0x30];
+        let vmm = init_and_run(
+            cpu_id,
+            ip,
+            &insn,
+            hashmap![Register::RAX => rax, Register::ESI => esi.into()],
+            None,
+        );
+
+        let mut memory: [u8; 4] = [0; 4];
+        vmm.lock().unwrap().read_memory(rax, &mut memory).unwrap();
+
+        assert_eq!(u32::from_le_bytes(memory), esi);
+
+        Ok(())
+    }
+
+    #[test]
+    // mov dword ptr [rax+0x00000001],edi
+    fn test_mov_m32imm32_r32() -> MockResult {
+        let rax: u64 = 0x100;
+        let displacement: u64 = 0x1;
+        let edi: u32 = 0x8899;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0x89, 0x3c, 0x05, 0x01, 0x00, 0x00, 0x00];
+        let vmm = init_and_run(
+            cpu_id,
+            ip,
+            &insn,
+            hashmap![Register::RAX => rax, Register::EDI => edi.into()],
+            None,
+        );
+
+        let mut memory: [u8; 4] = [0; 4];
+        vmm.lock()
+            .unwrap()
+            .read_memory(rax + displacement, &mut memory)
+            .unwrap();
+
+        assert_eq!(u32::from_le_bytes(memory), edi);
+
+        Ok(())
+    }
+
+    #[test]
+    // mov eax,dword ptr [rax+10h]
+    fn test_mov_r32_m32imm32() -> MockResult {
+        let rax: u64 = 0x100;
+        let displacement: u64 = 0x10;
+        let eax: u32 = 0xaabbccdd;
+        let memory: [u8; 4] = eax.to_le_bytes();
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0x8b, 0x40, 0x10];
+        let vmm = init_and_run(
+            cpu_id,
+            ip,
+            &insn,
+            hashmap![Register::RAX => rax],
+            Some((rax + displacement, &memory)),
+        );
+
+        let new_eax = vmm
+            .lock()
+            .unwrap()
+            .cpu_state(cpu_id)
+            .unwrap()
+            .read_reg(Register::EAX)
+            .unwrap();
+        assert_eq!(new_eax, eax as u64);
+
+        Ok(())
+    }
+
+    #[test]
+    // mov al,byte ptr [rax+10h]
+    fn test_mov_r8_m32imm32() -> MockResult {
+        let rax: u64 = 0x100;
+        let displacement: u64 = 0x10;
+        let al: u8 = 0xaa;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0x8a, 0x40, 0x10];
+        let memory: [u8; 1] = al.to_le_bytes();
+        let vmm = init_and_run(
+            cpu_id,
+            ip,
+            &insn,
+            hashmap![Register::RAX => rax],
+            Some((rax + displacement, &memory)),
+        );
+
+        let new_al = vmm
+            .lock()
+            .unwrap()
+            .cpu_state(cpu_id)
+            .unwrap()
+            .read_reg(Register::AL)
+            .unwrap();
+        assert_eq!(new_al, al as u64);
+
+        Ok(())
+    }
+
+    #[test]
+    // mov rax, 0x100
+    // mov rbx, qword ptr [rax+10h]
+    fn test_mov_r64_imm64_and_r64_m64() -> MockResult {
+        let target_rax: u64 = 0x1234567812345678;
+        let rax: u64 = 0x100;
+        let displacement: u64 = 0x10;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let memory: [u8; 8] = target_rax.to_le_bytes();
+        let insn = [
+            0x48, 0xc7, 0xc0, 0x00, 0x01, 0x00, 0x00, // mov rax, 0x100
+            0x48, 0x8b, 0x58, 0x10, // mov rbx, qword ptr [rax+10h]
+        ];
+
+        let vmm = init_and_run(
+            cpu_id,
+            ip,
+            &insn,
+            hashmap![],
+            Some((rax + displacement, &memory)),
+        );
+
+        let rbx: u64 = vmm
+            .lock()
+            .unwrap()
+            .cpu_state(cpu_id)
+            .unwrap()
+            .read_reg(Register::RBX)
+            .unwrap();
+        assert_eq!(rbx, target_rax);
+
+        Ok(())
+    }
+
+    #[test]
+    // mov rax, 0x100
+    // mov rbx, qword ptr [rax+10h]
+    fn test_mov_r64_imm64_and_r64_m64_first_insn() -> MockResult {
+        let target_rax: u64 = 0x1234567812345678;
+        let rax: u64 = 0x100;
+        let displacement: u64 = 0x10;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let memory: [u8; 8] = target_rax.to_le_bytes();
+        let insn = [
+            0x48, 0xc7, 0xc0, 0x00, 0x01, 0x00, 0x00, // mov rax, 0x100
+            0x48, 0x8b, 0x58, 0x10, // mov rbx, qword ptr [rax+10h]
+        ];
+
+        // Only run the first instruction.
+        let vmm = _init_and_run(
+            cpu_id,
+            ip,
+            &insn,
+            hashmap![],
+            Some((rax + displacement, &memory)),
+            Some(1),
+        );
+
+        assert_eq!(
+            ip + 7 as u64,
+            vmm.lock().unwrap().cpu_state(cpu_id).unwrap().ip()
+        );
+
+        let new_rax: u64 = vmm
+            .lock()
+            .unwrap()
+            .cpu_state(cpu_id)
+            .unwrap()
+            .read_reg(Register::RAX)
+            .unwrap();
+        assert_eq!(rax, new_rax);
+
+        Ok(())
+    }
+
+    #[test]
+    // mov rax, 0x100
+    // mov rbx, qword ptr [rax+10h]
+    // mov rax, 0x200
+    fn test_mov_r64_imm64_and_r64_m64_two_insns() -> MockResult {
+        let target_rax: u64 = 0x1234567812345678;
+        let rax: u64 = 0x100;
+        let displacement: u64 = 0x10;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let memory: [u8; 8] = target_rax.to_le_bytes();
+        let insn = [
+            0x48, 0xc7, 0xc0, 0x00, 0x01, 0x00, 0x00, // mov rax, 0x100
+            0x48, 0x8b, 0x58, 0x10, // mov rbx, qword ptr [rax+10h]
+            0x48, 0xc7, 0xc0, 0x00, 0x02, 0x00, 0x00, // mov rax, 0x200
+        ];
+
+        // Only run the first instruction.
+        let vmm = _init_and_run(
+            cpu_id,
+            ip,
+            &insn,
+            hashmap![],
+            Some((rax + displacement, &memory)),
+            Some(2),
+        );
+
+        assert_eq!(
+            ip + 7 + 4 as u64,
+            vmm.lock().unwrap().cpu_state(cpu_id).unwrap().ip()
+        );
+
+        let rbx: u64 = vmm
+            .lock()
+            .unwrap()
+            .cpu_state(cpu_id)
+            .unwrap()
+            .read_reg(Register::RBX)
+            .unwrap();
+        assert_eq!(rbx, target_rax);
+
+        // Check that rax is still at 0x100
+        let new_rax: u64 = vmm
+            .lock()
+            .unwrap()
+            .cpu_state(cpu_id)
+            .unwrap()
+            .read_reg(Register::RAX)
+            .unwrap();
+        assert_eq!(rax, new_rax);
+
+        Ok(())
+    }
+}

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -1,0 +1,86 @@
+//
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+extern crate iced_x86;
+
+use crate::arch::emulator::PlatformError;
+use crate::x86_64::SegmentRegister;
+use iced_x86::*;
+
+/// CpuStateManager manages an x86 CPU state.
+///
+/// Instruction emulation handlers get a mutable reference to
+/// a `CpuStateManager` implementation, representing the current state of the
+/// CPU they have to emulate an instruction stream against. Usually those
+/// handlers will modify the CPU state by modifying `CpuState` and it is up to
+/// the handler caller to commit those changes back by invoking a
+/// `PlatformEmulator` implementation `set_state()` method.
+///
+pub trait CpuStateManager: Clone {
+    /// Reads a CPU register.
+    ///
+    /// # Arguments
+    ///
+    /// * `reg` - A general purpose, control or debug register.
+    fn read_reg(&self, reg: Register) -> Result<u64, PlatformError>;
+
+    /// Write to a CPU register.
+    ///
+    /// # Arguments
+    ///
+    /// * `reg` - A general purpose, control or debug register.
+    /// * `val` - The value to load.
+    fn write_reg(&mut self, reg: Register, val: u64) -> Result<(), PlatformError>;
+
+    /// Reads a segment register.
+    ///
+    /// # Arguments
+    ///
+    /// * `reg` - A segment register.
+    fn read_segment(&self, reg: Register) -> Result<SegmentRegister, PlatformError>;
+
+    /// Write to a segment register.
+    ///
+    /// # Arguments
+    ///
+    /// * `reg` - A segment register.
+    /// * `segment_reg` - The segment register value to load.
+    fn write_segment(
+        &mut self,
+        reg: Register,
+        segment_reg: SegmentRegister,
+    ) -> Result<(), PlatformError>;
+
+    /// Get the CPU instruction pointer.
+    fn ip(&self) -> u64;
+
+    /// Set the CPU instruction pointer.
+    ///
+    /// # Arguments
+    ///
+    /// * `ip` - The CPU instruction pointer.
+    fn set_ip(&mut self, ip: u64);
+
+    /// Get the CPU Extended Feature Enable Register.
+    fn efer(&self) -> u64;
+
+    /// Set the CPU Extended Feature Enable Register.
+    ///
+    /// # Arguments
+    ///
+    /// * `efer` - The CPU EFER value.
+    fn set_efer(&mut self, efer: u64);
+
+    /// Get the CPU flags.
+    fn flags(&self) -> u64;
+
+    /// Set the CPU flags.
+    ///
+    /// # Arguments
+    ///
+    /// * `flags` - The CPU flags
+    fn set_flags(&mut self, flags: u64);
+}

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -7,7 +7,7 @@
 extern crate iced_x86;
 
 use crate::arch::emulator::PlatformError;
-use crate::x86_64::SegmentRegister;
+use crate::x86_64::{SegmentRegister, SpecialRegisters, StandardRegisters};
 use iced_x86::*;
 
 /// CpuStateManager manages an x86 CPU state.
@@ -83,4 +83,262 @@ pub trait CpuStateManager: Clone {
     ///
     /// * `flags` - The CPU flags
     fn set_flags(&mut self, flags: u64);
+}
+
+const REGISTER_MASK_64: u64 = 0xffff_ffff_ffff_ffffu64;
+const REGISTER_MASK_32: u64 = 0xffff_ffffu64;
+const REGISTER_MASK_16: u64 = 0xffffu64;
+const REGISTER_MASK_8: u64 = 0xffu64;
+
+macro_rules! set_reg {
+    ($reg:expr, $mask:expr, $value:expr) => {
+        $reg = ($reg & $mask) | $value
+    };
+}
+
+#[derive(Clone, Default, Debug)]
+/// A minimal, emulated CPU state.
+///
+/// Hypervisors needing x86 emulation can choose to either use their own
+/// CPU state structures and implement the CpuStateManager interface for it,
+/// or use `EmulatorCpuState`. The latter implies creating a new state
+/// `EmulatorCpuState` instance for each platform `cpu_state()` call, which
+/// might be less efficient.
+pub struct EmulatorCpuState {
+    pub regs: StandardRegisters,
+    pub sregs: SpecialRegisters,
+}
+
+impl CpuStateManager for EmulatorCpuState {
+    fn read_reg(&self, reg: Register) -> Result<u64, PlatformError> {
+        let mut reg_value: u64 = match reg {
+            Register::RAX | Register::EAX | Register::AX | Register::AL | Register::AH => {
+                self.regs.rax
+            }
+            Register::RBX | Register::EBX | Register::BX | Register::BL | Register::BH => {
+                self.regs.rbx
+            }
+            Register::RCX | Register::ECX | Register::CX | Register::CL | Register::CH => {
+                self.regs.rcx
+            }
+            Register::RDX | Register::EDX | Register::DX | Register::DL | Register::DH => {
+                self.regs.rdx
+            }
+            Register::RSP | Register::ESP => self.regs.rsp,
+            Register::RBP | Register::EBP => self.regs.rbp,
+            Register::RSI | Register::ESI => self.regs.rsi,
+            Register::RDI | Register::EDI | Register::DI | Register::DIL => self.regs.rdi,
+            Register::R8 | Register::R8D => self.regs.r8,
+            Register::R9 | Register::R9D => self.regs.r9,
+            Register::R10 | Register::R10D => self.regs.r10,
+            Register::R11 | Register::R11D => self.regs.r11,
+            Register::R12 | Register::R12D => self.regs.r12,
+            Register::R13 | Register::R13D => self.regs.r13,
+            Register::R14 | Register::R14D => self.regs.r14,
+            Register::R15 | Register::R15D => self.regs.r15,
+            Register::CR0 => self.sregs.cr0,
+            Register::CR2 => self.sregs.cr2,
+            Register::CR3 => self.sregs.cr3,
+            Register::CR4 => self.sregs.cr4,
+            Register::CR8 => self.sregs.cr8,
+
+            r => {
+                return Err(PlatformError::InvalidRegister(anyhow!(
+                    "read_reg invalid GPR {:?}",
+                    r
+                )))
+            }
+        };
+
+        reg_value = if reg.is_gpr64() || reg.is_cr() {
+            reg_value
+        } else if reg.is_gpr32() {
+            reg_value & REGISTER_MASK_32
+        } else if reg.is_gpr16() {
+            reg_value & REGISTER_MASK_16
+        } else if reg.is_gpr8() {
+            if reg == Register::AH
+                || reg == Register::BH
+                || reg == Register::CH
+                || reg == Register::DH
+            {
+                (reg_value >> 8) & REGISTER_MASK_8
+            } else {
+                reg_value & REGISTER_MASK_8
+            }
+        } else {
+            return Err(PlatformError::InvalidRegister(anyhow!(
+                "read_reg invalid GPR {:?}",
+                reg
+            )));
+        };
+
+        debug!("Register read: {:#x} from {:?}", reg_value, reg);
+
+        Ok(reg_value)
+    }
+
+    fn write_reg(&mut self, reg: Register, val: u64) -> Result<(), PlatformError> {
+        debug!("Register write: {:#x} to {:?}", val, reg);
+
+        // SDM Vol 1 - 3.4.1.1
+        //
+        // 8-bit and 16-bit operands generate an 8-bit or 16-bit result.
+        // The upper 56 bits or 48 bits (respectively) of the destination
+        // general-purpose register are not modified by the operation.
+        let (reg_value, mask): (u64, u64) = if reg.is_gpr64() || reg.is_cr() {
+            (val, !REGISTER_MASK_64)
+        } else if reg.is_gpr32() {
+            (val & REGISTER_MASK_32, !REGISTER_MASK_64)
+        } else if reg.is_gpr16() {
+            (val & REGISTER_MASK_16, !REGISTER_MASK_16)
+        } else if reg.is_gpr8() {
+            if reg == Register::AH
+                || reg == Register::BH
+                || reg == Register::CH
+                || reg == Register::DH
+            {
+                ((val & REGISTER_MASK_8) << 8, !(REGISTER_MASK_8 << 8))
+            } else {
+                (val & REGISTER_MASK_8, !REGISTER_MASK_8)
+            }
+        } else {
+            return Err(PlatformError::InvalidRegister(anyhow!(
+                "write_reg invalid register {:?}",
+                reg
+            )));
+        };
+
+        match reg {
+            Register::RAX | Register::EAX | Register::AX | Register::AL | Register::AH => {
+                set_reg!(self.regs.rax, mask, reg_value);
+            }
+            Register::RBX | Register::EBX | Register::BX | Register::BL | Register::BH => {
+                set_reg!(self.regs.rbx, mask, reg_value);
+            }
+            Register::RCX | Register::ECX | Register::CX | Register::CL | Register::CH => {
+                set_reg!(self.regs.rcx, mask, reg_value);
+            }
+            Register::RDX | Register::EDX | Register::DX | Register::DL | Register::DH => {
+                set_reg!(self.regs.rdx, mask, reg_value);
+            }
+            Register::RSP | Register::ESP => {
+                set_reg!(self.regs.rsp, mask, reg_value)
+            }
+            Register::RBP | Register::EBP => {
+                set_reg!(self.regs.rbp, mask, reg_value)
+            }
+            Register::RSI | Register::ESI => {
+                set_reg!(self.regs.rsi, mask, reg_value)
+            }
+            Register::RDI | Register::EDI | Register::DI | Register::DIL => {
+                set_reg!(self.regs.rdi, mask, reg_value)
+            }
+            Register::R8 | Register::R8D => {
+                set_reg!(self.regs.r8, mask, reg_value)
+            }
+            Register::R9 | Register::R9D => {
+                set_reg!(self.regs.r9, mask, reg_value)
+            }
+            Register::R10 | Register::R10D => {
+                set_reg!(self.regs.r10, mask, reg_value)
+            }
+            Register::R11 | Register::R11D => {
+                set_reg!(self.regs.r11, mask, reg_value)
+            }
+            Register::R12 | Register::R12D => {
+                set_reg!(self.regs.r12, mask, reg_value)
+            }
+            Register::R13 | Register::R13D => {
+                set_reg!(self.regs.r13, mask, reg_value)
+            }
+            Register::R14 | Register::R14D => {
+                set_reg!(self.regs.r14, mask, reg_value)
+            }
+            Register::R15 | Register::R15D => {
+                set_reg!(self.regs.r15, mask, reg_value)
+            }
+            Register::CR0 => set_reg!(self.sregs.cr0, mask, reg_value),
+            Register::CR2 => set_reg!(self.sregs.cr2, mask, reg_value),
+            Register::CR3 => set_reg!(self.sregs.cr3, mask, reg_value),
+            Register::CR4 => set_reg!(self.sregs.cr4, mask, reg_value),
+            Register::CR8 => set_reg!(self.sregs.cr8, mask, reg_value),
+            _ => {
+                return Err(PlatformError::InvalidRegister(anyhow!(
+                    "write_reg invalid register {:?}",
+                    reg
+                )))
+            }
+        }
+
+        Ok(())
+    }
+
+    fn read_segment(&self, reg: Register) -> Result<SegmentRegister, PlatformError> {
+        if !reg.is_segment_register() {
+            return Err(PlatformError::InvalidRegister(anyhow!(
+                "read_segment {:?} is not a segment register",
+                reg
+            )));
+        }
+
+        match reg {
+            Register::CS => Ok(self.sregs.cs),
+            Register::DS => Ok(self.sregs.ds),
+            Register::ES => Ok(self.sregs.es),
+            Register::FS => Ok(self.sregs.fs),
+            Register::GS => Ok(self.sregs.gs),
+            Register::SS => Ok(self.sregs.ss),
+            r => Err(PlatformError::InvalidRegister(anyhow!(
+                "read_segment invalid register {:?}",
+                r
+            ))),
+        }
+    }
+
+    fn write_segment(
+        &mut self,
+        reg: Register,
+        segment_register: SegmentRegister,
+    ) -> Result<(), PlatformError> {
+        if !reg.is_segment_register() {
+            return Err(PlatformError::InvalidRegister(anyhow!("{:?}", reg)));
+        }
+
+        match reg {
+            Register::CS => self.sregs.cs = segment_register,
+            Register::DS => self.sregs.ds = segment_register,
+            Register::ES => self.sregs.es = segment_register,
+            Register::FS => self.sregs.fs = segment_register,
+            Register::GS => self.sregs.gs = segment_register,
+            Register::SS => self.sregs.ss = segment_register,
+            r => return Err(PlatformError::InvalidRegister(anyhow!("{:?}", r))),
+        }
+
+        Ok(())
+    }
+
+    fn ip(&self) -> u64 {
+        self.regs.rip
+    }
+
+    fn set_ip(&mut self, ip: u64) {
+        self.regs.rip = ip;
+    }
+
+    fn efer(&self) -> u64 {
+        self.sregs.efer
+    }
+
+    fn set_efer(&mut self, efer: u64) {
+        self.sregs.efer = efer
+    }
+
+    fn flags(&self) -> u64 {
+        self.regs.rflags
+    }
+
+    fn set_flags(&mut self, flags: u64) {
+        self.regs.rflags = flags;
+    }
 }

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -10,6 +10,8 @@ use crate::arch::emulator::PlatformError;
 use crate::x86_64::{SegmentRegister, SpecialRegisters, StandardRegisters};
 use iced_x86::*;
 
+mod instructions;
+
 /// CpuStateManager manages an x86 CPU state.
 ///
 /// Instruction emulation handlers get a mutable reference to

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -13,6 +13,7 @@ use crate::x86_64::{SegmentRegister, SpecialRegisters, StandardRegisters};
 use iced_x86::*;
 use std::sync::{Arc, Mutex};
 
+#[macro_use]
 mod instructions;
 
 /// CpuStateManager manages an x86 CPU state.
@@ -356,6 +357,24 @@ pub struct Emulator<T: CpuStateManager> {
 impl<T: CpuStateManager> Emulator<T> {
     pub fn new(platform: Arc<Mutex<dyn PlatformEmulator<CpuState = T>>>) -> Emulator<T> {
         let mut insn_map = InstructionMap::<T>::new();
+
+        // MOV
+        insn_add!(insn_map, mov, Mov_r8_imm8);
+        insn_add!(insn_map, mov, Mov_r8_rm8);
+        insn_add!(insn_map, mov, Mov_r16_imm16);
+        insn_add!(insn_map, mov, Mov_r16_rm16);
+        insn_add!(insn_map, mov, Mov_r32_imm32);
+        insn_add!(insn_map, mov, Mov_r32_rm32);
+        insn_add!(insn_map, mov, Mov_r64_imm64);
+        insn_add!(insn_map, mov, Mov_r64_rm64);
+        insn_add!(insn_map, mov, Mov_rm8_imm8);
+        insn_add!(insn_map, mov, Mov_rm8_r8);
+        insn_add!(insn_map, mov, Mov_rm16_imm16);
+        insn_add!(insn_map, mov, Mov_rm16_r16);
+        insn_add!(insn_map, mov, Mov_rm32_imm32);
+        insn_add!(insn_map, mov, Mov_rm32_r32);
+        insn_add!(insn_map, mov, Mov_rm64_imm32);
+        insn_add!(insn_map, mov, Mov_rm64_r64);
 
         Emulator {
             platform: Arc::clone(&platform),

--- a/hypervisor/src/arch/x86/gdt.rs
+++ b/hypervisor/src/arch/x86/gdt.rs
@@ -8,7 +8,7 @@
 // found in the LICENSE-BSD-3-Clause file.
 
 // For GDT details see arch/x86/include/asm/segment.h
-use hypervisor::x86_64::SegmentRegister;
+use crate::x86_64::SegmentRegister;
 
 /// Constructor for a conventional segment GDT (or LDT) entry. Derived from the kernel's segment.h.
 pub fn gdt_entry(flags: u16, base: u32, limit: u32) -> u64 {

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -11,6 +11,8 @@
 // Copyright © 2020, Microsoft Corporation
 //
 
+pub mod gdt;
+
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -30,6 +30,8 @@ pub mod gdt;
 )]
 pub mod msr_index;
 
+pub mod emulator;
+
 // MTRR constants
 pub const MTRR_ENABLE: u64 = 0x800; // IA32_MTRR_DEF_TYPE MSR: E (MTRRs enabled) flag, bit 11
 pub const MTRR_MEM_TYPE_WB: u64 = 0x6;

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -38,3 +38,28 @@ pub const MTRR_MEM_TYPE_WB: u64 = 0x6;
 
 // IOAPIC pins
 pub const NUM_IOAPIC_PINS: usize = 24;
+
+// X86 Exceptions
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub enum Exception {
+    DE = 1,  // Divide Error
+    DB = 2,  // Debug Exception
+    BP = 3,  // Breakpoint
+    OF = 4,  // Overflow
+    BR = 5,  // BOUND Range Exceeded
+    UD = 6,  // Invalid/Undefined Opcode
+    NM = 7,  // No Math Coprocessor
+    DF = 8,  // Double Fault
+    TS = 10, // Invalid TSS
+    NP = 11, // Segment Not Present
+    SS = 12, // Stack Segment Fault
+    GP = 13, // General Protection
+    PF = 14, // Page Fault
+    MF = 16, // Math Fault
+    AC = 17, // Alignment Check
+    MC = 18, // Machine Check
+    XM = 19, // SIMD Floating-Point Exception
+    VE = 20, // Virtualization Exception
+    CP = 21, // Control Protection Exception
+}


### PR DESCRIPTION
The framework relies on:

1. The iced_x86 crate for instructions decoding.
1. An `IOEmulator` trait for getting access to the platform's register and memory.
1. An `InstructionHandler` trait that each emulated instruction must implement

Instructions are decoded through `iced_x86`, then the framework tries to resolve an instruction handler for the decoded mnemonic.
The handler then uses the `IOEmulator` implementation to emulate the instruction semantics.

The first and only instruction that is emulated in this PR is the x86 `MOV`.