### PR TITLE
Add support for migrating a paused VM

### DIFF
--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -10,6 +10,8 @@ extern crate serde_derive;
 
 use thiserror::Error;
 
+pub mod protocol;
+
 #[derive(Error, Debug)]
 pub enum MigratableError {
     #[error("Failed to pause migratable component: {0}")]
@@ -29,6 +31,9 @@ pub enum MigratableError {
 
     #[error("Failed to receive migratable component snapshot: {0}")]
     MigrateReceive(#[source] anyhow::Error),
+
+    #[error("Socket error: {0}")]
+    MigrateSocket(#[source] std::io::Error),
 }
 
 /// A Pausable component can be paused and resumed.

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -1,0 +1,231 @@
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::MigratableError;
+
+// Migration protocol
+// 1: Source establishes communication with destination (file socket or TCP connection.)
+// (The establishment is out of scope.)
+// 2: Source -> Dest : send "start command"
+// 3: Dest -> Source : sends "ok response" when read to accept state data
+// 4: Source -> Dest : sends "state command" followed by state data, length
+//                     in command is length of state data
+// 5: Dest -> Source : sends "ok response" when ready to accept memory data
+// 6: Source -> Dest : send "memory command" followed by table of u64 pairs (GPA, size)
+//                     followed by the memory described in those pairs.
+//                     !! length is size of table i.e. 16 * number of ranges !!
+// 7: Dest -> Source : sends "ok response" when ready to accept more memory data
+// 8..(n-2): Repeat steps 6 and 7 until source has no more memory to send
+// (n-1): Source -> Dest : send "complete command"
+// n: Dest -> Source: sends "ok response"
+
+// The destination can at any time send an "error response" to cancel
+// The source can at any time send an "abandon request" to cancel
+
+use std::io::{Read, Write};
+
+#[repr(u16)]
+#[derive(Copy, Clone)]
+pub enum Command {
+    Invalid,
+    Start,
+    State,
+    Memory,
+    Complete,
+    Abandon,
+}
+
+impl Default for Command {
+    fn default() -> Self {
+        Self::Invalid
+    }
+}
+
+trait AsBytes {
+    fn as_bytes<T: Sized>(p: &T) -> &[u8] {
+        unsafe {
+            std::slice::from_raw_parts((p as *const T) as *const u8, std::mem::size_of::<T>())
+        }
+    }
+
+    fn as_mut_bytes<T: Sized>(p: &mut T) -> &mut [u8] {
+        unsafe {
+            std::slice::from_raw_parts_mut((p as *mut T) as *mut u8, std::mem::size_of::<T>())
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Default)]
+pub struct Request {
+    command: Command,
+    padding: [u8; 6],
+    length: u64, // Length of payload for command excluding the Request struct
+}
+
+impl Request {
+    pub fn new(command: Command, length: u64) -> Self {
+        Self {
+            command,
+            length,
+            ..Default::default()
+        }
+    }
+
+    pub fn start() -> Self {
+        Self::new(Command::Start, 0)
+    }
+
+    pub fn state(length: u64) -> Self {
+        Self::new(Command::State, length)
+    }
+
+    pub fn memory(length: u64) -> Self {
+        Self::new(Command::Memory, length)
+    }
+
+    pub fn complete() -> Self {
+        Self::new(Command::Complete, 0)
+    }
+
+    pub fn abandon() -> Self {
+        Self::new(Command::Abandon, 0)
+    }
+
+    pub fn command(&self) -> Command {
+        self.command
+    }
+
+    pub fn length(&self) -> u64 {
+        self.length
+    }
+
+    pub fn read_from(fd: &mut dyn Read) -> Result<Request, MigratableError> {
+        let mut request = Request::default();
+        fd.read_exact(Self::as_mut_bytes(&mut request))
+            .map_err(MigratableError::MigrateSocket)?;
+
+        Ok(request)
+    }
+
+    pub fn write_to(&self, fd: &mut dyn Write) -> Result<(), MigratableError> {
+        fd.write_all(Self::as_bytes(self))
+            .map_err(MigratableError::MigrateSocket)
+    }
+}
+
+impl AsBytes for Request {}
+
+#[repr(u16)]
+#[derive(Copy, Clone, PartialEq)]
+pub enum Status {
+    Invalid,
+    Ok,
+    Error,
+}
+
+impl Default for Status {
+    fn default() -> Self {
+        Self::Invalid
+    }
+}
+
+#[repr(C)]
+#[derive(Default)]
+pub struct Response {
+    status: Status,
+    padding: [u8; 6],
+    length: u64, // Length of payload for command excluding the Response struct
+}
+
+impl Response {
+    pub fn new(status: Status, length: u64) -> Self {
+        Self {
+            status,
+            length,
+            ..Default::default()
+        }
+    }
+
+    pub fn ok() -> Self {
+        Self::new(Status::Ok, 0)
+    }
+
+    pub fn error() -> Self {
+        Self::new(Status::Error, 0)
+    }
+
+    pub fn status(&self) -> Status {
+        self.status
+    }
+
+    pub fn read_from(fd: &mut dyn Read) -> Result<Response, MigratableError> {
+        let mut response = Response::default();
+        fd.read_exact(Self::as_mut_bytes(&mut response))
+            .map_err(MigratableError::MigrateSocket)?;
+
+        Ok(response)
+    }
+
+    pub fn write_to(&self, fd: &mut dyn Write) -> Result<(), MigratableError> {
+        fd.write_all(Self::as_bytes(self))
+            .map_err(MigratableError::MigrateSocket)
+    }
+}
+
+impl AsBytes for Response {}
+
+#[repr(C)]
+pub struct MemoryRange {
+    pub gpa: u64,
+    pub length: u64,
+}
+
+#[derive(Default)]
+pub struct MemoryRangeTable {
+    data: Vec<MemoryRange>,
+}
+
+impl MemoryRangeTable {
+    pub fn regions(&self) -> &[MemoryRange] {
+        &self.data
+    }
+
+    pub fn push(&mut self, range: MemoryRange) {
+        self.data.push(range)
+    }
+
+    pub fn read_from(fd: &mut dyn Read, length: u64) -> Result<MemoryRangeTable, MigratableError> {
+        assert!(length as usize % std::mem::size_of::<MemoryRange>() == 0);
+
+        let mut data = Vec::with_capacity(length as usize / (std::mem::size_of::<MemoryRange>()));
+        unsafe {
+            data.set_len(length as usize / (std::mem::size_of::<MemoryRange>()));
+        }
+        fd.read_exact(unsafe {
+            std::slice::from_raw_parts_mut(
+                data.as_ptr() as *mut MemoryRange as *mut u8,
+                length as usize,
+            )
+        })
+        .map_err(MigratableError::MigrateSocket)?;
+
+        Ok(Self { data })
+    }
+
+    pub fn length(&self) -> u64 {
+        (std::mem::size_of::<MemoryRange>() * self.data.len()) as u64
+    }
+
+    pub fn write_to(&self, fd: &mut dyn Write) -> Result<(), MigratableError> {
+        fd.write_all(unsafe {
+            std::slice::from_raw_parts(
+                self.data.as_ptr() as *const MemoryRange as *const u8,
+                self.length() as usize,
+            )
+        })
+        .map_err(MigratableError::MigrateSocket)
+    }
+}

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -100,6 +100,12 @@ pub enum HttpError {
 
     /// Could not get counters from VM
     VmCounters(ApiError),
+
+    /// Error setting up migration received
+    VmReceiveMigration(ApiError),
+
+    /// Error setting up migration sender
+    VmSendMigration(ApiError),
 }
 
 impl From<serde_json::Error> for HttpError {
@@ -205,11 +211,13 @@ lazy_static! {
         r.routes.insert(endpoint!("/vm.info"), Box::new(VmInfo {}));
         r.routes.insert(endpoint!("/vm.pause"), Box::new(VmActionHandler::new(VmAction::Pause)));
         r.routes.insert(endpoint!("/vm.reboot"), Box::new(VmActionHandler::new(VmAction::Reboot)));
+        r.routes.insert(endpoint!("/vm.receive-migration"), Box::new(VmActionHandler::new(VmAction::ReceiveMigration(Arc::default()))));
         r.routes.insert(endpoint!("/vm.remove-device"), Box::new(VmActionHandler::new(VmAction::RemoveDevice(Arc::default()))));
         r.routes.insert(endpoint!("/vm.resize"), Box::new(VmActionHandler::new(VmAction::Resize(Arc::default()))));
         r.routes.insert(endpoint!("/vm.resize-zone"), Box::new(VmActionHandler::new(VmAction::ResizeZone(Arc::default()))));
         r.routes.insert(endpoint!("/vm.restore"), Box::new(VmActionHandler::new(VmAction::Restore(Arc::default()))));
         r.routes.insert(endpoint!("/vm.resume"), Box::new(VmActionHandler::new(VmAction::Resume)));
+        r.routes.insert(endpoint!("/vm.send-migration"), Box::new(VmActionHandler::new(VmAction::SendMigration(Arc::default()))));
         r.routes.insert(endpoint!("/vm.shutdown"), Box::new(VmActionHandler::new(VmAction::Shutdown)));
         r.routes.insert(endpoint!("/vm.snapshot"), Box::new(VmActionHandler::new(VmAction::Snapshot(Arc::default()))));
         r.routes.insert(endpoint!("/vmm.ping"), Box::new(VmmPing {}));

--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -6,9 +6,9 @@
 use crate::api::http::{error_response, EndpointHandler, HttpError};
 use crate::api::{
     vm_add_device, vm_add_disk, vm_add_fs, vm_add_net, vm_add_pmem, vm_add_vsock, vm_boot,
-    vm_counters, vm_create, vm_delete, vm_info, vm_pause, vm_reboot, vm_remove_device, vm_resize,
-    vm_resize_zone, vm_restore, vm_resume, vm_shutdown, vm_snapshot, vmm_ping, vmm_shutdown,
-    ApiRequest, VmAction, VmConfig,
+    vm_counters, vm_create, vm_delete, vm_info, vm_pause, vm_reboot, vm_receive_migration,
+    vm_remove_device, vm_resize, vm_resize_zone, vm_restore, vm_resume, vm_send_migration,
+    vm_shutdown, vm_snapshot, vmm_ping, vmm_shutdown, ApiRequest, VmAction, VmConfig,
 };
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 use std::sync::mpsc::Sender;
@@ -152,6 +152,20 @@ impl EndpointHandler for VmActionHandler {
                     Arc::new(serde_json::from_slice(body.raw())?),
                 )
                 .map_err(HttpError::VmSnapshot),
+
+                ReceiveMigration(_) => vm_receive_migration(
+                    api_notifier,
+                    api_sender,
+                    Arc::new(serde_json::from_slice(body.raw())?),
+                )
+                .map_err(HttpError::VmReceiveMigration),
+
+                SendMigration(_) => vm_send_migration(
+                    api_notifier,
+                    api_sender,
+                    Arc::new(serde_json::from_slice(body.raw())?),
+                )
+                .map_err(HttpError::VmSendMigration),
 
                 _ => Err(HttpError::BadRequest),
             }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -397,7 +397,7 @@ impl Vmm {
             &snapshot,
             exit_evt,
             reset_evt,
-            source_url,
+            Some(source_url),
             restore_cfg.prefault,
             &self.seccomp_action,
             self.hypervisor.clone(),

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -680,7 +680,7 @@ impl Vm {
         snapshot: &Snapshot,
         exit_evt: EventFd,
         reset_evt: EventFd,
-        source_url: &str,
+        source_url: Option<&str>,
         prefault: bool,
         seccomp_action: &SeccompAction,
         hypervisor: Arc<dyn hypervisor::Hypervisor>,


### PR DESCRIPTION
This is an intermediate step towards live migration. Live migration would build on this by recording the pages touched using a KVM API and sending multiple "Memory" commands to send just those changed pages.

After this PR is merged:

- [ ] Pseudo live migration. If VM is running pause it, send it and resume at destination.
- [ ] TCP socket support
- [ ] Start recording pages with KVM
- [ ] Send those pages to destination
- [ ] Maybe need to send another state snapshot (depends if we disallow changing the VM config during a migration.)