### PR TITLE
vmm: openapi: remove `omitempty` json tag

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -654,8 +654,12 @@ components:
 
     FsConfig:
       required:
-      - tag
+      - cache_size
+      - dax
+      - num_queues
+      - queue_size
       - socket
+      - tag
       type: object
       properties:
         tag:


### PR DESCRIPTION
Due to a known limitation in OpenAPITools/openapi-generator tool,
it's impossible to send go zero types, like false and 0 to
cloud-hypervisor because `omitempty` is added if a field is not
required.
Set cache_size, dax, num_queues and queue_size as required to remove
`omitempty` from the json tag.

fixes #1961

Signed-off-by: Julio Montes <julio.montes@intel.com>