### PR TITLE
Initial live migration support

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -70,7 +70,8 @@ use std::mem;
 pub use kvm_bindings;
 pub use kvm_bindings::{
     kvm_create_device, kvm_device_type_KVM_DEV_TYPE_VFIO, kvm_irq_routing, kvm_irq_routing_entry,
-    kvm_userspace_memory_region, KVM_IRQ_ROUTING_MSI, KVM_MEM_READONLY, KVM_MSI_VALID_DEVID,
+    kvm_userspace_memory_region, KVM_IRQ_ROUTING_MSI, KVM_MEM_LOG_DIRTY_PAGES, KVM_MEM_READONLY,
+    KVM_MSI_VALID_DEVID,
 };
 pub use kvm_ioctls;
 pub use kvm_ioctls::{Cap, Kvm};
@@ -255,13 +256,19 @@ impl vm::Vm for KvmVm {
         memory_size: u64,
         userspace_addr: u64,
         readonly: bool,
+        log_dirty_pages: bool,
     ) -> MemoryRegion {
         MemoryRegion {
             slot,
             guest_phys_addr,
             memory_size,
             userspace_addr,
-            flags: if readonly { KVM_MEM_READONLY } else { 0 },
+            flags: if readonly { KVM_MEM_READONLY } else { 0 }
+                | if log_dirty_pages {
+                    KVM_MEM_LOG_DIRTY_PAGES
+                } else {
+                    0
+                },
         }
     }
     ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -369,6 +369,14 @@ impl vm::Vm for KvmVm {
         self.vmmops.store(Some(Arc::new(vmmops)));
         Ok(())
     }
+    ///
+    /// Get dirty pages bitmap (one bit per page)
+    ///
+    fn get_dirty_log(&self, slot: u32, memory_size: u64) -> vm::Result<Vec<u64>> {
+        self.fd
+            .get_dirty_log(slot, memory_size as usize)
+            .map_err(|e| vm::HypervisorVmError::GetDirtyLog(e.into()))
+    }
 }
 /// Wrapper over KVM system ioctls.
 pub struct KvmHypervisor {

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -189,6 +189,7 @@ pub trait Vm: Send + Sync {
         memory_size: u64,
         userspace_addr: u64,
         readonly: bool,
+        log_dirty_pages: bool,
     ) -> MemoryRegion;
     /// Creates/modifies a guest physical memory slot.
     fn set_user_memory_region(&self, user_memory_region: MemoryRegion) -> Result<()>;

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -147,6 +147,11 @@ pub enum HypervisorVmError {
     ///
     #[error("Failed to write to IO Bus: {0}")]
     IoBusWrite(#[source] anyhow::Error),
+    ///
+    /// Get dirty log error
+    ///
+    #[error("Failed to get dirty log: {0}")]
+    GetDirtyLog(#[source] anyhow::Error),
 }
 ///
 /// Result type for returning from a function
@@ -217,6 +222,8 @@ pub trait Vm: Send + Sync {
     fn set_state(&self, state: VmState) -> Result<()>;
     /// Set VmmOps interface
     fn set_vmmops(&self, vmmops: Box<dyn VmmOps>) -> Result<()>;
+    /// Get dirty pages bitmap
+    fn get_dirty_log(&self, slot: u32, memory_size: u64) -> Result<Vec<u64>>;
 }
 
 pub trait VmmOps: Send + Sync {

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -561,6 +561,7 @@ impl VfioPciDevice {
                     mmap_size as u64,
                     host_addr as u64,
                     false,
+                    false,
                 );
 
                 vm.set_user_memory_region(mem_region)
@@ -589,6 +590,7 @@ impl VfioPciDevice {
                     region.start.raw_value() + mmap_offset,
                     0,
                     host_addr as u64,
+                    false,
                     false,
                 );
 
@@ -1012,6 +1014,7 @@ impl PciDevice for VfioPciDevice {
                             0,
                             host_addr as u64,
                             false,
+                            false,
                         );
 
                         self.vm
@@ -1024,6 +1027,7 @@ impl PciDevice for VfioPciDevice {
                             new_base + mmap_offset,
                             mmap_size as u64,
                             host_addr as u64,
+                            false,
                             false,
                         );
 

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -10,14 +10,17 @@ use crate::MigratableError;
 // (The establishment is out of scope.)
 // 2: Source -> Dest : send "start command"
 // 3: Dest -> Source : sends "ok response" when read to accept state data
-// 4: Source -> Dest : sends "state command" followed by state data, length
-//                     in command is length of state data
+// 4: Source -> Dest : sends "config command" followed by config data, length
+//                     in command is length of config data
 // 5: Dest -> Source : sends "ok response" when ready to accept memory data
 // 6: Source -> Dest : send "memory command" followed by table of u64 pairs (GPA, size)
 //                     followed by the memory described in those pairs.
 //                     !! length is size of table i.e. 16 * number of ranges !!
 // 7: Dest -> Source : sends "ok response" when ready to accept more memory data
-// 8..(n-2): Repeat steps 6 and 7 until source has no more memory to send
+// 8..(n-4): Repeat steps 6 and 7 until source has no more memory to send
+// (n-3): Source -> Dest : sends "state command" followed by state data, length
+//                     in command is length of config data
+// (n-2): Dest -> Source : sends "ok response"
 // (n-1): Source -> Dest : send "complete command"
 // n: Dest -> Source: sends "ok response"
 
@@ -31,6 +34,7 @@ use std::io::{Read, Write};
 pub enum Command {
     Invalid,
     Start,
+    Config,
     State,
     Memory,
     Complete,
@@ -80,6 +84,10 @@ impl Request {
 
     pub fn state(length: u64) -> Self {
         Self::new(Command::State, length)
+    }
+
+    pub fn config(length: u64) -> Self {
+        Self::new(Command::Config, length)
     }
 
     pub fn memory(length: u64) -> Self {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1990,7 +1990,9 @@ impl DeviceManager {
                     .memory_manager
                     .lock()
                     .unwrap()
-                    .create_userspace_mapping(cache_base, cache_size, host_addr, false, false)
+                    .create_userspace_mapping(
+                        cache_base, cache_size, host_addr, false, false, false,
+                    )
                     .map_err(DeviceManagerError::MemoryManager)?;
 
                 let mut region_list = Vec::new();
@@ -2180,6 +2182,7 @@ impl DeviceManager {
                 region_size,
                 host_addr,
                 pmem_cfg.mergeable,
+                false,
                 false,
             )
             .map_err(DeviceManagerError::MemoryManager)?;

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -612,6 +612,7 @@ impl DeviceRelocation for AddressManager {
                             0,
                             shm_regions.host_addr,
                             false,
+                            false,
                         );
 
                         self.vm.set_user_memory_region(mem_region).map_err(|e| {
@@ -627,6 +628,7 @@ impl DeviceRelocation for AddressManager {
                             new_base,
                             shm_regions.len,
                             shm_regions.host_addr,
+                            false,
                             false,
                         );
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -909,6 +909,7 @@ impl Vmm {
             table.write_to(&mut socket)?;
             // And then the memory itself
             vm.send_memory_regions(&table, &mut socket)?;
+            let res = Response::read_from(&mut socket)?;
             if res.status() != Status::Ok {
                 warn!("Error during memory migration");
                 Request::abandon().write_to(&mut socket)?;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1115,6 +1115,7 @@ impl MemoryManager {
             memory_size,
             userspace_addr,
             readonly,
+            false,
         );
 
         self.vm
@@ -1168,6 +1169,7 @@ impl MemoryManager {
             0, /* memory_size -- using 0 removes this slot */
             userspace_addr,
             false, /* readonly -- don't care */
+            false, /* log dirty */
         );
 
         self.vm

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1704,6 +1704,19 @@ impl Vm {
 
         Ok(table)
     }
+
+    pub fn start_memory_dirty_log(&self) -> std::result::Result<(), MigratableError> {
+        self.memory_manager.lock().unwrap().start_memory_dirty_log()
+    }
+
+    pub fn dirty_memory_range_table(
+        &self,
+    ) -> std::result::Result<MemoryRangeTable, MigratableError> {
+        self.memory_manager
+            .lock()
+            .unwrap()
+            .dirty_memory_range_table()
+    }
 }
 
 impl Pausable for Vm {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2131,6 +2131,7 @@ pub fn test_vm() {
             region.len() as u64,
             region.as_ptr() as u64,
             false,
+            false,
         );
 
         vm.set_user_memory_region(mem_region)


### PR DESCRIPTION
Add initial support for migrating a VM with minimal downtime:

Now the VM is paused/resumed by the migration process itself.
    
0. The guest configuration is sent to the destination
1. Dirty page log tracking is started by start_memory_dirty_log()
2. All guest memory is sent to the destination
3. Up to 5 attempts are made to send the dirty guest memory to the destination...
4. ...before the VM is paused
5. One last set of dirty pages is sent to the destination
6. The guest is snapshotted and sent to the destination
7. When the migration is completed the destination unpauses the received VM.

Things not handled/tested:

- [ ] Networking
- [ ] Only works with devices that already support snapshot/restore
- [ ] Storage is out of scope
- [ ] Actual testing across a network using initramfs / socat for unix scoket to tcp proxying
    
