### PR TITLE
Correctly share VmmOps &  bump arc-swap dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ version = "0.1.0"
 
 [[package]]
 name = "arc-swap"
-version = "0.4.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+checksum = "0688b520bcc7498f6ca8fa006e8031d353e3fd4f51bd4a50fb03cc4230b28bd2"
 
 [[package]]
 name = "arch"
@@ -1612,7 +1612,7 @@ dependencies = [
 [[package]]
 name = "vm-memory"
 version = "0.3.0"
-source = "git+https://github.com/cloud-hypervisor/vm-memory?branch=ch#6f2f7107f29a8f2b66b64a849aeace20783ec8f3"
+source = "git+https://github.com/cloud-hypervisor/vm-memory?branch=ch#66f0c8422ae2f2994676becfe3e0d95ef90bf104"
 dependencies = [
  "arc-swap",
  "libc",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -10,7 +10,7 @@ kvm = []
 
 [dependencies]
 anyhow = "1.0"
-arc-swap = ">=0.4.4"
+arc-swap = ">=1.0.0"
 thiserror = "1.0"
 libc = "0.2.80"
 log = "0.4.11"

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -96,7 +96,7 @@ pub struct KvmVm {
     #[cfg(target_arch = "x86_64")]
     msrs: MsrEntries,
     state: KvmVmState,
-    vmmops: ArcSwapOption<Box<dyn vm::VmmOps>>,
+    vmmops: Arc<ArcSwapOption<Box<dyn vm::VmmOps>>>,
 }
 
 // Returns a `Vec<T>` with a size in bytes at least as large as `size_in_bytes`.
@@ -439,7 +439,7 @@ impl hypervisor::Hypervisor for KvmHypervisor {
                 fd: vm_fd,
                 msrs,
                 state: VmState {},
-                vmmops: ArcSwapOption::from(None),
+                vmmops: Arc::new(ArcSwapOption::from(None)),
             }))
         }
 
@@ -448,7 +448,7 @@ impl hypervisor::Hypervisor for KvmHypervisor {
             Ok(Arc::new(KvmVm {
                 fd: vm_fd,
                 state: VmState {},
-                vmmops: ArcSwapOption::from(None),
+                vmmops: Arc::new(ArcSwapOption::from(None)),
             }))
         }
     }
@@ -509,7 +509,7 @@ pub struct KvmVcpu {
     fd: VcpuFd,
     #[cfg(target_arch = "x86_64")]
     msrs: MsrEntries,
-    vmmops: ArcSwapOption<Box<dyn vm::VmmOps>>,
+    vmmops: Arc<ArcSwapOption<Box<dyn vm::VmmOps>>>,
     #[cfg(target_arch = "x86_64")]
     hyperv_synic: AtomicBool,
 }

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -10,7 +10,7 @@ io_uring = ["block_util/io_uring"]
 
 [dependencies]
 anyhow = "1.0"
-arc-swap = ">=0.4.4"
+arc-swap = ">=1.0.0"
 block_util = { path = "../block_util" }
 byteorder = "1.3.4"
 epoll = ">=4.0.1"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -15,7 +15,7 @@ io_uring = ["virtio-devices/io_uring"]
 [dependencies]
 acpi_tables = { path = "../acpi_tables", optional = true }
 anyhow = "1.0"
-arc-swap = ">=0.4.4"
+arc-swap = ">=1.0.0"
 arch = { path = "../arch" }
 bitflags = ">=1.2.1"
 block_util = { path = "../block_util" }


### PR DESCRIPTION
`ArcSwap::clone()` doesn't do what we or most users expected. arc-swap upstream have removed it.