### PR TITLE
Remove `--net-backend` and `--block-backend` from cloud-hypervisor binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,8 +230,6 @@ dependencies = [
  "tempdir",
  "tempfile",
  "thiserror",
- "vhost_user_block",
- "vhost_user_net",
  "vmm",
  "vmm-sys-util",
  "wait-timeout",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,6 @@ option_parser = { path = "option_parser" }
 seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.22.0" }
 serde_json = "1.0.59"
 thiserror = "1.0"
-vhost_user_block = { path = "vhost_user_block"}
-vhost_user_net = { path = "vhost_user_net"}
 vmm = { path = "vmm" }
 vmm-sys-util = "0.7.0"
 wait-timeout = "0.2.0"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -386,7 +386,7 @@ mod tests {
         let vubd_socket_path = String::from(tmp_dir.path().join("vub.sock").to_str().unwrap());
 
         // Start the daemon
-        let child = Command::new(clh_command("cloud-hypervisor"))
+        let child = Command::new(clh_command("vhost_user_block"))
             .args(&[
                 "--block-backend",
                 format!(
@@ -461,7 +461,7 @@ mod tests {
             )
         };
 
-        let child = Command::new(clh_command("cloud-hypervisor"))
+        let child = Command::new(clh_command("vhost_user_net"))
             .args(&["--net-backend", net_params.as_str()])
             .spawn()
             .unwrap();


### PR DESCRIPTION
As we no longer support self spawning we can remove this code and this gives us a 4.1% reduction in the size of our cloud-hypervisor binary (stripped).