### PR TITLE
Support forcing io_uring off for testing

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2853,8 +2853,7 @@ mod tests {
             handle_child_output(r, &output);
         }
 
-        #[test]
-        fn test_virtio_blk() {
+        fn _test_virtio_block(disable_io_uring: bool) {
             let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
             let guest = Guest::new(&mut focal);
 
@@ -2884,8 +2883,9 @@ mod tests {
                     )
                     .as_str(),
                     format!(
-                        "path={},readonly=on,direct=on,num_queues=4",
-                        blk_file_path.to_str().unwrap()
+                        "path={},readonly=on,direct=on,num_queues=4,_disable_io_uring={}",
+                        blk_file_path.to_str().unwrap(),
+                        disable_io_uring
                     )
                     .as_str(),
                 ])
@@ -2935,6 +2935,16 @@ mod tests {
             let output = cloud_child.wait_with_output().unwrap();
 
             handle_child_output(r, &output);
+        }
+
+        #[test]
+        fn test_virtio_block() {
+            _test_virtio_block(false)
+        }
+
+        #[test]
+        fn test_virtio_block_disable_io_uring() {
+            _test_virtio_block(false)
         }
 
         #[test]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1640,7 +1640,7 @@ impl DeviceManager {
                 ImageType::Raw => {
                     // Use asynchronous backend relying on io_uring if the
                     // syscalls are supported.
-                    if block_io_uring_is_supported() {
+                    if block_io_uring_is_supported() && !disk_cfg.disable_io_uring {
                         let dev = Arc::new(Mutex::new(
                             virtio_devices::BlockIoUring::new(
                                 id.clone(),


### PR DESCRIPTION
This ensures we can continue to test the original virtio-block code even when running on a host that supports io_uring.