### PR TITLE
Revert "build: Fix AArch64 musl cross build failure"

### DIFF
--- a/.github/workflows/cross-build.yaml
+++ b/.github/workflows/cross-build.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.46.0
+          - stable
         target:
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl


### PR DESCRIPTION
This reverts commit 2a7b1d78ff4e3f457a8388377db8e779677035e0.

Restore the cross toolchain to the "stable" one

Fixes: #1839

Signed-off-by: Rob Bradford <robert.bradford@intel.com>