### PR TITLE
hypervisor, vmm: Remove shared ownership of VmmOps

### DIFF
--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -174,7 +174,7 @@ pub trait Vm: Send + Sync {
     /// Unregister an event that will, when signaled, trigger the `gsi` IRQ.
     fn unregister_irqfd(&self, fd: &EventFd, gsi: u32) -> Result<()>;
     /// Creates a new KVM vCPU file descriptor and maps the memory corresponding
-    fn create_vcpu(&self, id: u8) -> Result<Arc<dyn Vcpu>>;
+    fn create_vcpu(&self, id: u8, vmmops: Option<Arc<Box<dyn VmmOps>>>) -> Result<Arc<dyn Vcpu>>;
     /// Registers an event to be signaled whenever a certain address is written to.
     fn register_ioevent(
         &self,
@@ -220,8 +220,6 @@ pub trait Vm: Send + Sync {
     fn state(&self) -> Result<VmState>;
     /// Set the VM state
     fn set_state(&self, state: VmState) -> Result<()>;
-    /// Set VmmOps interface
-    fn set_vmmops(&self, vmmops: Box<dyn VmmOps>) -> Result<()>;
     /// Get dirty pages bitmap
     fn get_dirty_log(&self, slot: u32, memory_size: u64) -> Result<Vec<u64>>;
 }

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -415,7 +415,7 @@ mod tests {
     fn test_get_set_dist_regs() {
         let hv = hypervisor::new().unwrap();
         let vm = hv.create_vm().unwrap();
-        let _ = vm.create_vcpu(0).unwrap();
+        let _ = vm.create_vcpu(0, None).unwrap();
         let gic = create_gic(&vm, 1).expect("Cannot create gic");
 
         let res = get_dist_regs(gic.device());
@@ -431,7 +431,7 @@ mod tests {
     fn test_get_set_redist_regs() {
         let hv = hypervisor::new().unwrap();
         let vm = hv.create_vm().unwrap();
-        let _ = vm.create_vcpu(0).unwrap();
+        let _ = vm.create_vcpu(0, None).unwrap();
         let gic = create_gic(&vm, 1).expect("Cannot create gic");
 
         let mut gicr_typer = Vec::new();
@@ -449,7 +449,7 @@ mod tests {
     fn test_get_set_icc_regs() {
         let hv = hypervisor::new().unwrap();
         let vm = hv.create_vm().unwrap();
-        let _ = vm.create_vcpu(0).unwrap();
+        let _ = vm.create_vcpu(0, None).unwrap();
         let gic = create_gic(&vm, 1).expect("Cannot create gic");
 
         let mut gicr_typer = Vec::new();
@@ -467,7 +467,7 @@ mod tests {
     fn test_save_pending_tables() {
         let hv = hypervisor::new().unwrap();
         let vm = hv.create_vm().unwrap();
-        let _ = vm.create_vcpu(0).unwrap();
+        let _ = vm.create_vcpu(0, None).unwrap();
         let gic = create_gic(&vm, 1).expect("Cannot create gic");
 
         assert!(save_pending_tables(gic.device()).is_ok());


### PR DESCRIPTION
This interface is used by the vCPU thread to delegate responsibility for
handling MMIO/PIO operations and to support different approaches than a
VM exit.

During profiling I found that we were spending 13.75% of the boot CPU
uage acquiring access to the object holding the VmmOps via
ArcSwap::load_full()

    13.75%     6.02%  vcpu0            cloud-hypervisor    [.] arc_swap::ArcSwapAny<T,S>::load_full
            |
            ---arc_swap::ArcSwapAny<T,S>::load_full
               |
                --13.43%--<hypervisor::kvm::KvmVcpu as hypervisor::cpu::Vcpu>::run
                          std::sys_common::backtrace::__rust_begin_short_backtrace
                          core::ops::function::FnOnce::call_once{{vtable-shim}}
                          std::sys::unix::thread::Thread::new::thread_start

However since the object implementing VmmOps does not need to be mutable
and it is only used from the vCPU side we can change the ownership to
being a simple Arc<> that is passed in when calling create_vcpu().

This completely removes the above CPU usage from subsequent profiles.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>