### PR TITLE
Rust 1.48.0 clippy warnings fixes

### DIFF
--- a/arch/src/aarch64/gic/mod.rs
+++ b/arch/src/aarch64/gic/mod.rs
@@ -174,6 +174,7 @@ pub mod kvm {
         }
 
         /// Method to initialize the GIC device
+        #[allow(clippy::new_ret_no_self)]
         fn new(vm: &Arc<dyn hypervisor::Vm>, vcpu_count: u64) -> Result<Box<dyn GICDevice>> {
             let vgic_fd = Self::init_device(vm)?;
 

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -43,7 +43,7 @@
 //
 //
 
-use vm_memory::{GuestAddress, GuestUsize};
+use vm_memory::GuestAddress;
 
 /// Below this address will reside the GIC, above this address will reside the MMIO devices.
 pub const MAPPED_IO_START: u64 = 0x0900_0000;
@@ -61,7 +61,7 @@ pub const MEM_32BIT_DEVICES_SIZE: u64 = 0x3000_0000;
 
 /// PCI MMCONFIG space (start: after the device space at 1 GiB, length: 256MiB)
 pub const PCI_MMCONFIG_START: GuestAddress = GuestAddress(0x4000_0000);
-pub const PCI_MMCONFIG_SIZE: GuestUsize = 256 << 20;
+pub const PCI_MMCONFIG_SIZE: u64 = 256 << 20;
 
 /// Start of RAM on 64 bit ARM.
 pub const RAM_64BIT_START: u64 = 0x8000_0000;

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -7,7 +7,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
-use vm_memory::{GuestAddress, GuestUsize};
+use vm_memory::GuestAddress;
 
 /*
 
@@ -81,22 +81,22 @@ pub const HIGH_RAM_START: GuestAddress = GuestAddress(0x100000);
 
 // ** 32-bit reserved area (start: 3GiB, length: 1GiB) **
 pub const MEM_32BIT_RESERVED_START: GuestAddress = GuestAddress(0xc000_0000);
-pub const MEM_32BIT_RESERVED_SIZE: GuestUsize = 1024 << 20;
+pub const MEM_32BIT_RESERVED_SIZE: u64 = 1024 << 20;
 
 // == Fixed constants within the "32-bit reserved" range ==
 
 // Sub range: 32-bit PCI devices (start: 3GiB, length: 640Mib)
 pub const MEM_32BIT_DEVICES_START: GuestAddress = MEM_32BIT_RESERVED_START;
-pub const MEM_32BIT_DEVICES_SIZE: GuestUsize = 640 << 20;
+pub const MEM_32BIT_DEVICES_SIZE: u64 = 640 << 20;
 
 // PCI MMCONFIG space (start: after the device space, length: 256MiB)
 pub const PCI_MMCONFIG_START: GuestAddress =
     GuestAddress(MEM_32BIT_DEVICES_START.0 + MEM_32BIT_DEVICES_SIZE);
-pub const PCI_MMCONFIG_SIZE: GuestUsize = 256 << 20;
+pub const PCI_MMCONFIG_SIZE: u64 = 256 << 20;
 
 // IOAPIC
 pub const IOAPIC_START: GuestAddress = GuestAddress(0xfec0_0000);
-pub const IOAPIC_SIZE: GuestUsize = 0x20;
+pub const IOAPIC_SIZE: u64 = 0x20;
 
 // APIC
 pub const APIC_START: GuestAddress = GuestAddress(0xfee0_0000);

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -570,7 +570,7 @@ impl PciConfiguration {
         let end_addr = config
             .addr
             .checked_add(config.size - 1)
-            .ok_or_else(|| Error::BarAddressInvalid(config.addr, config.size))?;
+            .ok_or(Error::BarAddressInvalid(config.addr, config.size))?;
         match config.region_type {
             PciBarRegionType::Memory32BitRegion | PciBarRegionType::IORegion => {
                 if end_addr > u64::from(u32::max_value()) {
@@ -642,7 +642,7 @@ impl PciConfiguration {
         let end_addr = config
             .addr
             .checked_add(config.size - 1)
-            .ok_or_else(|| Error::RomBarAddressInvalid(config.addr, config.size))?;
+            .ok_or(Error::RomBarAddressInvalid(config.addr, config.size))?;
 
         if end_addr > u64::from(u32::max_value()) {
             return Err(Error::RomBarAddressInvalid(config.addr, config.size));
@@ -698,7 +698,7 @@ impl PciConfiguration {
         };
         let end_offset = cap_offset
             .checked_add(total_len)
-            .ok_or_else(|| Error::CapabilitySpaceFull(total_len))?;
+            .ok_or(Error::CapabilitySpaceFull(total_len))?;
         if end_offset > CAPABILITY_MAX_OFFSET {
             return Err(Error::CapabilitySpaceFull(total_len));
         }

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -750,7 +750,7 @@ impl PciDevice for VfioPciDevice {
                     // The address needs to be 4 bytes aligned.
                     bar_addr = allocator
                         .allocate_io_addresses(None, region_size, Some(0x4))
-                        .ok_or_else(|| PciDeviceError::IoAllocationFailed(region_size))?;
+                        .ok_or(PciDeviceError::IoAllocationFailed(region_size))?;
                 }
                 #[cfg(target_arch = "aarch64")]
                 unimplemented!()
@@ -797,11 +797,11 @@ impl PciDevice for VfioPciDevice {
                 if is_64bit_bar {
                     bar_addr = allocator
                         .allocate_mmio_addresses(None, region_size, Some(bar_alignment))
-                        .ok_or_else(|| PciDeviceError::IoAllocationFailed(region_size))?;
+                        .ok_or(PciDeviceError::IoAllocationFailed(region_size))?;
                 } else {
                     bar_addr = allocator
                         .allocate_mmio_hole_addresses(None, region_size, Some(bar_alignment))
-                        .ok_or_else(|| PciDeviceError::IoAllocationFailed(region_size))?;
+                        .ok_or(PciDeviceError::IoAllocationFailed(region_size))?;
                 }
             }
 

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -77,15 +77,15 @@ pub fn setup_vhost_user_vring(
                 queue.desc_table,
                 actual_size * std::mem::size_of::<Descriptor>(),
             )
-            .ok_or_else(|| Error::DescriptorTableAddress)? as u64,
+            .ok_or(Error::DescriptorTableAddress)? as u64,
             // The used ring is {flags: u16; idx: u16; virtq_used_elem [{id: u16, len: u16}; actual_size]},
             // i.e. 4 + (4 + 4) * actual_size.
             used_ring_addr: get_host_address_range(mem, queue.used_ring, 4 + actual_size * 8)
-                .ok_or_else(|| Error::UsedAddress)? as u64,
+                .ok_or(Error::UsedAddress)? as u64,
             // The used ring is {flags: u16; idx: u16; elem [u16; actual_size]},
             // i.e. 4 + (2) * actual_size.
             avail_ring_addr: get_host_address_range(mem, queue.avail_ring, 4 + actual_size * 2)
-                .ok_or_else(|| Error::AvailAddress)? as u64,
+                .ok_or(Error::AvailAddress)? as u64,
             log_addr: None,
         };
 

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -118,7 +118,7 @@ impl VsockPacket {
 
         let mut pkt = Self {
             hdr: get_host_address_range(head.mem, head.addr, VSOCK_PKT_HDR_SIZE)
-                .ok_or_else(|| VsockError::GuestMemory)? as *mut u8,
+                .ok_or(VsockError::GuestMemory)? as *mut u8,
             buf: None,
             buf_size: 0,
         };
@@ -151,7 +151,7 @@ impl VsockPacket {
         pkt.buf_size = buf_desc.len as usize;
         pkt.buf = Some(
             get_host_address_range(buf_desc.mem, buf_desc.addr, pkt.buf_size)
-                .ok_or_else(|| VsockError::GuestMemory)? as *mut u8,
+                .ok_or(VsockError::GuestMemory)? as *mut u8,
         );
 
         Ok(pkt)
@@ -183,10 +183,10 @@ impl VsockPacket {
 
         Ok(Self {
             hdr: get_host_address_range(head.mem, head.addr, VSOCK_PKT_HDR_SIZE)
-                .ok_or_else(|| VsockError::GuestMemory)? as *mut u8,
+                .ok_or(VsockError::GuestMemory)? as *mut u8,
             buf: Some(
                 get_host_address_range(buf_desc.mem, buf_desc.addr, buf_size)
-                    .ok_or_else(|| VsockError::GuestMemory)? as *mut u8,
+                    .ok_or(VsockError::GuestMemory)? as *mut u8,
             ),
             buf_size,
         })


### PR DESCRIPTION
The stable toolchain moved to 1.48.0, which triggered 2 new clippy warnings.