### PR TITLE
cargo: Move to crates.io vm-memory 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "tempdir",
  "tempfile",
  "thiserror",
+ "vm-memory",
  "vmm",
  "vmm-sys-util",
  "wait-timeout",
@@ -1609,8 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "vm-memory"
-version = "0.3.0"
-source = "git+https://github.com/cloud-hypervisor/vm-memory?branch=ch#66f0c8422ae2f2994676becfe3e0d95ef90bf104"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45b5b0a6f371f8147143b1adb95edddafc9cb9e40adaf94edb6f93a1d04b0330"
 dependencies = [
  "arc-swap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,12 @@ thiserror = "1.0"
 vmm = { path = "vmm" }
 vmm-sys-util = "0.7.0"
 wait-timeout = "0.2.0"
+vm-memory = "0.4.0"
 
 [build-dependencies]
 clap = { version = "2.33.3", features = ["wrap_help"] }
 
 # List of patched crates
-[patch.crates-io]
-vm-memory = { git = "https://github.com/cloud-hypervisor/vm-memory", branch = "ch" }
 [patch.'https://github.com/rust-vmm/vhost']
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "ch", package = "vhost", features = ["vhost-user-master", "vhost-user-slave"] }
 [patch.'https://github.com/rust-vmm/kvm-ioctls']

--- a/acpi_tables/Cargo.toml
+++ b/acpi_tables/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 
 [dependencies]
-vm-memory = "0.3.0"
+vm-memory = "0.4.0"
 

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.11"
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
-vm-memory = { version = "0.3.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.4.0", features = ["backend-mmap"] }
 vm-migration = { path = "../vm-migration" }
 acpi_tables = { path = "../acpi_tables", optional = true }
 arch_gen = { path = "../arch_gen" }

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -16,6 +16,6 @@ serde = ">=1.0.27"
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"]}
-vm-memory = { version = "0.3.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.4.0", features = ["backend-mmap", "backend-atomic"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -15,7 +15,7 @@ serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 vm-device = { path = "../vm-device" }
 acpi_tables = { path = "../acpi_tables", optional = true }
-vm-memory = "0.3.0"
+vm-memory = "0.4.0"
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = ">=0.3.1"
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,13 +18,11 @@ seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v
 virtio-devices = { path = "../virtio-devices" }
 vmm-sys-util = ">=0.3.1"
 vm-virtio = { path = "../vm-virtio" }
-vm-memory = "0.3.0"
+vm-memory = "0.4.0"
 
 [dependencies.cloud-hypervisor]
 path = ".."
 
-[patch.crates-io]
-vm-memory = { git = "https://github.com/cloud-hypervisor/vm-memory", branch = "ch" }
 [patch.'https://github.com/rust-vmm/kvm-ioctls']
 kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "ch" }
 [patch.'https://github.com/rust-vmm/kvm-bindings']

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -19,7 +19,7 @@ kvm-bindings = { git = "https://github.com/rust-vmm/kvm-bindings", branch = "mas
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
-vm-memory = { version = "0.3.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.4.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = ">=0.5.0", features = ["with-serde"] }
 
 [dependencies.linux-loader]

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -11,7 +11,7 @@ net_gen = { path = "../net_gen" }
 rand = "0.7.3"
 serde = "1.0.117"
 virtio-bindings = "0.1.0"
-vm-memory = { version = "0.3.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.4.0", features = ["backend-mmap", "backend-atomic"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -17,7 +17,7 @@ serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = "0.3.0"
+vm-memory = "0.4.0"
 vm-migration = { path = "../vm-migration" }
 
 [dependencies.vfio-bindings]

--- a/vhost_user_backend/Cargo.toml
+++ b/vhost_user_backend/Cargo.toml
@@ -12,7 +12,7 @@ epoll = ">=4.0.1"
 libc = "0.2.80"
 log = "0.4.11"
 virtio-bindings = "0.1.0"
-vm-memory = "0.3.0"
+vm-memory = "0.4.0"
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 vhost_rs = { git = "https://github.com/rust-vmm/vhost", branch = "master", package = "vhost", features = ["vhost-user-slave"] }

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -15,5 +15,5 @@ qcow = { path = "../qcow" }
 vhost_user_backend = { path = "../vhost_user_backend" }
 vhost_rs = { git = "https://github.com/rust-vmm/vhost", branch = "master", package = "vhost", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
-vm-memory = "0.3.0"
+vm-memory = "0.4.0"
 vmm-sys-util = ">=0.3.1"

--- a/vhost_user_fs/Cargo.toml
+++ b/vhost_user_fs/Cargo.toml
@@ -18,6 +18,6 @@ virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"]}
 virtio-devices = { path = "../virtio-devices" }
 vhost_rs = { git = "https://github.com/rust-vmm/vhost", branch = "master", package = "vhost", features = ["vhost-user-slave"] }
 vhost_user_backend = { path = "../vhost_user_backend"}
-vm-memory = "0.3.0"
+vm-memory = "0.4.0"
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.7.0"

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -14,5 +14,5 @@ option_parser = { path = "../option_parser" }
 vhost_user_backend = { path = "../vhost_user_backend" }
 vhost_rs = { git = "https://github.com/rust-vmm/vhost", branch = "master", package = "vhost", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
-vm-memory = "0.3.0"
+vm-memory = "0.4.0"
 vmm-sys-util = ">=0.3.1"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -30,7 +30,7 @@ vhost_rs = { git = "https://github.com/rust-vmm/vhost", branch = "master", packa
 virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"]}
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.3.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.4.0", features = ["backend-mmap", "backend-atomic"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.80"
-vm-memory = "0.3.0"
+vm-memory = "0.4.0"
 arch = { path = "../arch" }

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -10,6 +10,6 @@ thiserror = "1.0"
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
-vm-memory = { version = "0.3.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.4.0", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.3.1"
 

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -13,4 +13,4 @@ serde = ">=1.0.27"
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"]}
-vm-memory = { version = "0.3.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.4.0", features = ["backend-mmap", "backend-atomic"] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -43,7 +43,7 @@ vfio-ioctls = { git = "https://github.com/cloud-hypervisor/vfio-ioctls", branch 
 virtio-devices = { path = "../virtio-devices" }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.3.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.4.0", features = ["backend-mmap", "backend-atomic"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { version = ">=0.5.0", features = ["with-serde"] }


### PR DESCRIPTION
vm-memory 0.4.0 now contains all our fixes.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>