### PR TITLE
Live migration fixes

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -38,7 +38,7 @@ impl fmt::Display for Error {
         use Error::*;
         match self {
             ApiClient(e) => e.fmt(f),
-            Connect(e) => write!(f, "Error openning HTTP socket: {}", e),
+            Connect(e) => write!(f, "Error opening HTTP socket: {}", e),
             InvalidCPUCount(e) => write!(f, "Error parsing CPU count: {}", e),
             InvalidMemorySize(e) => write!(f, "Error parsing memory size: {:?}", e),
             InvalidBalloonSize(e) => write!(f, "Error parsing balloon size: {:?}", e),

--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -112,7 +112,7 @@ impl Bus {
             .range(..=BusRange { base: addr, len: 1 })
             .rev()
             .next()?;
-        Some((*range, dev.upgrade().unwrap().clone()))
+        dev.upgrade().map(|d| (*range, d.clone()))
     }
 
     #[allow(clippy::type_complexity)]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -673,8 +673,9 @@ impl Vmm {
         let reset_evt = self.reset_evt.try_clone().map_err(|e| {
             MigratableError::MigrateReceive(anyhow!("Error cloning reset EventFd: {}", e))
         })?;
+        self.vm_config = Some(Arc::new(Mutex::new(config)));
         let vm = Vm::new_from_migration(
-            Arc::new(Mutex::new(config)),
+            self.vm_config.clone().unwrap(),
             exit_evt,
             reset_evt,
             &self.seccomp_action,
@@ -848,6 +849,7 @@ impl Vmm {
                 Command::Abandon => {
                     info!("Abandon Command Received");
                     self.vm = None;
+                    self.vm_config = None;
                     Response::ok().write_to(&mut socket).ok();
                     break;
                 }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -101,6 +101,7 @@ const KVM_ENABLE_CAP: u64 = 0x4068_aea3;
 const KVM_SET_REGS: u64 = 0x4090_ae82;
 const KVM_GET_MP_STATE: u64 = 0x8004_ae98;
 const KVM_GET_DEVICE_ATTR: u64 = 0x4018_aee2;
+const KVM_GET_DIRTY_LOG: u64 = 0x4010_ae42;
 const KVM_GET_VCPU_EVENTS: u64 = 0x8040_ae9f;
 const KVM_GET_ONE_REG: u64 = 0x4010_aeab;
 const KVM_GET_REGS: u64 = 0x8090_ae81;
@@ -126,6 +127,7 @@ fn create_vmm_ioctl_seccomp_rule_common() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_ENABLE_CAP)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_API_VERSION,)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_DEVICE_ATTR,)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_DIRTY_LOG)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_MP_STATE)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_ONE_REG)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, KVM_GET_REGS)?],


### PR DESCRIPTION
This PR fixes two issues in the live migration code (plus a typo I spotted):

* Add the new ioctl to the permitted list for the VMM process (`KVM_GET_DIRTY_LOG`)
* Fix the panic from the vcpu thread due to the VM not being shutdown correctly because the configuration wasn't saved into the VMM.