### PR TITLE
Expand clippy coverage

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -27,10 +27,10 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Clippy (all features)
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all --all-targets --all-features --tests -- -D warnings
       
       - name: Clippy (acpi,kvm)
-        run: cargo clippy --all-targets --no-default-features --features "acpi,kvm" -- -D warnings
+        run: cargo clippy --all --all-targets --no-default-features --tests --features "acpi,kvm" -- -D warnings
       
       - name: Clippy (kvm)
-        run: cargo clippy --all-targets --no-default-features --features "kvm" -- -D warnings
+        run: cargo clippy --all --all-targets --no-default-features --tests --features "kvm" -- -D warnings

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -991,7 +991,7 @@ mod tests {
     #[test]
     fn test_system_configuration() {
         let no_vcpus = 4;
-        let gm = GuestMemoryMmap::from_ranges(&vec![(GuestAddress(0), 0x10000)]).unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let config_err = configure_system(
             &gm,
             GuestAddress(0),

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -264,7 +264,7 @@ mod tests {
     use vm_memory::{GuestAddress, GuestMemoryMmap};
 
     fn create_guest_mem() -> GuestMemoryMmap {
-        GuestMemoryMmap::from_ranges(&vec![(GuestAddress(0), 0x10000)]).unwrap()
+        GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap()
     }
 
     fn read_u64(gm: &GuestMemoryMmap, offset: GuestAddress) -> u64 {

--- a/arch_gen/src/x86/mpspec.rs
+++ b/arch_gen/src/x86/mpspec.rs
@@ -67,7 +67,7 @@ fn bindgen_test_layout_mpf_intel() {
         concat!("Alignment of ", stringify!(mpf_intel))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpf_intel)).signature as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpf_intel>()).signature as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -77,7 +77,7 @@ fn bindgen_test_layout_mpf_intel() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpf_intel)).physptr as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpf_intel>()).physptr as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -87,7 +87,7 @@ fn bindgen_test_layout_mpf_intel() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpf_intel)).length as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpf_intel>()).length as *const _ as usize },
         8usize,
         concat!(
             "Alignment of field: ",
@@ -97,7 +97,7 @@ fn bindgen_test_layout_mpf_intel() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpf_intel)).specification as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpf_intel>()).specification as *const _ as usize },
         9usize,
         concat!(
             "Alignment of field: ",
@@ -107,7 +107,7 @@ fn bindgen_test_layout_mpf_intel() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpf_intel)).checksum as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpf_intel>()).checksum as *const _ as usize },
         10usize,
         concat!(
             "Alignment of field: ",
@@ -117,7 +117,7 @@ fn bindgen_test_layout_mpf_intel() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpf_intel)).feature1 as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpf_intel>()).feature1 as *const _ as usize },
         11usize,
         concat!(
             "Alignment of field: ",
@@ -127,7 +127,7 @@ fn bindgen_test_layout_mpf_intel() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpf_intel)).feature2 as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpf_intel>()).feature2 as *const _ as usize },
         12usize,
         concat!(
             "Alignment of field: ",
@@ -137,7 +137,7 @@ fn bindgen_test_layout_mpf_intel() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpf_intel)).feature3 as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpf_intel>()).feature3 as *const _ as usize },
         13usize,
         concat!(
             "Alignment of field: ",
@@ -147,7 +147,7 @@ fn bindgen_test_layout_mpf_intel() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpf_intel)).feature4 as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpf_intel>()).feature4 as *const _ as usize },
         14usize,
         concat!(
             "Alignment of field: ",
@@ -157,7 +157,7 @@ fn bindgen_test_layout_mpf_intel() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpf_intel)).feature5 as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpf_intel>()).feature5 as *const _ as usize },
         15usize,
         concat!(
             "Alignment of field: ",
@@ -200,7 +200,7 @@ fn bindgen_test_layout_mpc_table() {
         concat!("Alignment of ", stringify!(mpc_table))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_table)).signature as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_table>()).signature as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -210,7 +210,7 @@ fn bindgen_test_layout_mpc_table() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_table)).length as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_table>()).length as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -220,7 +220,7 @@ fn bindgen_test_layout_mpc_table() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_table)).spec as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_table>()).spec as *const _ as usize },
         6usize,
         concat!(
             "Alignment of field: ",
@@ -230,7 +230,7 @@ fn bindgen_test_layout_mpc_table() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_table)).checksum as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_table>()).checksum as *const _ as usize },
         7usize,
         concat!(
             "Alignment of field: ",
@@ -240,7 +240,7 @@ fn bindgen_test_layout_mpc_table() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_table)).oem as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_table>()).oem as *const _ as usize },
         8usize,
         concat!(
             "Alignment of field: ",
@@ -250,7 +250,7 @@ fn bindgen_test_layout_mpc_table() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_table)).productid as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_table>()).productid as *const _ as usize },
         16usize,
         concat!(
             "Alignment of field: ",
@@ -260,7 +260,7 @@ fn bindgen_test_layout_mpc_table() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_table)).oemptr as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_table>()).oemptr as *const _ as usize },
         28usize,
         concat!(
             "Alignment of field: ",
@@ -270,7 +270,7 @@ fn bindgen_test_layout_mpc_table() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_table)).oemsize as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_table>()).oemsize as *const _ as usize },
         32usize,
         concat!(
             "Alignment of field: ",
@@ -280,7 +280,7 @@ fn bindgen_test_layout_mpc_table() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_table)).oemcount as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_table>()).oemcount as *const _ as usize },
         34usize,
         concat!(
             "Alignment of field: ",
@@ -290,7 +290,7 @@ fn bindgen_test_layout_mpc_table() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_table)).lapic as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_table>()).lapic as *const _ as usize },
         36usize,
         concat!(
             "Alignment of field: ",
@@ -300,7 +300,7 @@ fn bindgen_test_layout_mpc_table() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_table)).reserved as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_table>()).reserved as *const _ as usize },
         40usize,
         concat!(
             "Alignment of field: ",
@@ -339,7 +339,7 @@ fn bindgen_test_layout_mpc_cpu() {
         concat!("Alignment of ", stringify!(mpc_cpu))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_cpu)).type_ as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_cpu>()).type_ as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -349,7 +349,7 @@ fn bindgen_test_layout_mpc_cpu() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_cpu)).apicid as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_cpu>()).apicid as *const _ as usize },
         1usize,
         concat!(
             "Alignment of field: ",
@@ -359,7 +359,7 @@ fn bindgen_test_layout_mpc_cpu() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_cpu)).apicver as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_cpu>()).apicver as *const _ as usize },
         2usize,
         concat!(
             "Alignment of field: ",
@@ -369,7 +369,7 @@ fn bindgen_test_layout_mpc_cpu() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_cpu)).cpuflag as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_cpu>()).cpuflag as *const _ as usize },
         3usize,
         concat!(
             "Alignment of field: ",
@@ -379,7 +379,7 @@ fn bindgen_test_layout_mpc_cpu() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_cpu)).cpufeature as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_cpu>()).cpufeature as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -389,7 +389,7 @@ fn bindgen_test_layout_mpc_cpu() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_cpu)).featureflag as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_cpu>()).featureflag as *const _ as usize },
         8usize,
         concat!(
             "Alignment of field: ",
@@ -399,7 +399,7 @@ fn bindgen_test_layout_mpc_cpu() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_cpu)).reserved as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_cpu>()).reserved as *const _ as usize },
         12usize,
         concat!(
             "Alignment of field: ",
@@ -434,7 +434,7 @@ fn bindgen_test_layout_mpc_bus() {
         concat!("Alignment of ", stringify!(mpc_bus))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_bus)).type_ as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_bus>()).type_ as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -444,7 +444,7 @@ fn bindgen_test_layout_mpc_bus() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_bus)).busid as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_bus>()).busid as *const _ as usize },
         1usize,
         concat!(
             "Alignment of field: ",
@@ -454,7 +454,7 @@ fn bindgen_test_layout_mpc_bus() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_bus)).bustype as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_bus>()).bustype as *const _ as usize },
         2usize,
         concat!(
             "Alignment of field: ",
@@ -491,7 +491,7 @@ fn bindgen_test_layout_mpc_ioapic() {
         concat!("Alignment of ", stringify!(mpc_ioapic))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_ioapic)).type_ as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_ioapic>()).type_ as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -501,7 +501,7 @@ fn bindgen_test_layout_mpc_ioapic() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_ioapic)).apicid as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_ioapic>()).apicid as *const _ as usize },
         1usize,
         concat!(
             "Alignment of field: ",
@@ -511,7 +511,7 @@ fn bindgen_test_layout_mpc_ioapic() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_ioapic)).apicver as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_ioapic>()).apicver as *const _ as usize },
         2usize,
         concat!(
             "Alignment of field: ",
@@ -521,7 +521,7 @@ fn bindgen_test_layout_mpc_ioapic() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_ioapic)).flags as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_ioapic>()).flags as *const _ as usize },
         3usize,
         concat!(
             "Alignment of field: ",
@@ -531,7 +531,7 @@ fn bindgen_test_layout_mpc_ioapic() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_ioapic)).apicaddr as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_ioapic>()).apicaddr as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -570,7 +570,7 @@ fn bindgen_test_layout_mpc_intsrc() {
         concat!("Alignment of ", stringify!(mpc_intsrc))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_intsrc)).type_ as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_intsrc>()).type_ as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -580,7 +580,7 @@ fn bindgen_test_layout_mpc_intsrc() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_intsrc)).irqtype as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_intsrc>()).irqtype as *const _ as usize },
         1usize,
         concat!(
             "Alignment of field: ",
@@ -590,7 +590,7 @@ fn bindgen_test_layout_mpc_intsrc() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_intsrc)).irqflag as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_intsrc>()).irqflag as *const _ as usize },
         2usize,
         concat!(
             "Alignment of field: ",
@@ -600,7 +600,7 @@ fn bindgen_test_layout_mpc_intsrc() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_intsrc)).srcbus as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_intsrc>()).srcbus as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -610,7 +610,7 @@ fn bindgen_test_layout_mpc_intsrc() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_intsrc)).srcbusirq as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_intsrc>()).srcbusirq as *const _ as usize },
         5usize,
         concat!(
             "Alignment of field: ",
@@ -620,7 +620,7 @@ fn bindgen_test_layout_mpc_intsrc() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_intsrc)).dstapic as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_intsrc>()).dstapic as *const _ as usize },
         6usize,
         concat!(
             "Alignment of field: ",
@@ -630,7 +630,7 @@ fn bindgen_test_layout_mpc_intsrc() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_intsrc)).dstirq as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_intsrc>()).dstirq as *const _ as usize },
         7usize,
         concat!(
             "Alignment of field: ",
@@ -674,7 +674,7 @@ fn bindgen_test_layout_mpc_lintsrc() {
         concat!("Alignment of ", stringify!(mpc_lintsrc))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_lintsrc)).type_ as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_lintsrc>()).type_ as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -684,7 +684,7 @@ fn bindgen_test_layout_mpc_lintsrc() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_lintsrc)).irqtype as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_lintsrc>()).irqtype as *const _ as usize },
         1usize,
         concat!(
             "Alignment of field: ",
@@ -694,7 +694,7 @@ fn bindgen_test_layout_mpc_lintsrc() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_lintsrc)).irqflag as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_lintsrc>()).irqflag as *const _ as usize },
         2usize,
         concat!(
             "Alignment of field: ",
@@ -704,7 +704,7 @@ fn bindgen_test_layout_mpc_lintsrc() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_lintsrc)).srcbusid as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_lintsrc>()).srcbusid as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -714,7 +714,7 @@ fn bindgen_test_layout_mpc_lintsrc() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_lintsrc)).srcbusirq as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_lintsrc>()).srcbusirq as *const _ as usize },
         5usize,
         concat!(
             "Alignment of field: ",
@@ -724,7 +724,7 @@ fn bindgen_test_layout_mpc_lintsrc() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_lintsrc)).destapic as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_lintsrc>()).destapic as *const _ as usize },
         6usize,
         concat!(
             "Alignment of field: ",
@@ -734,7 +734,7 @@ fn bindgen_test_layout_mpc_lintsrc() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_lintsrc)).destapiclint as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_lintsrc>()).destapiclint as *const _ as usize },
         7usize,
         concat!(
             "Alignment of field: ",
@@ -771,7 +771,7 @@ fn bindgen_test_layout_mpc_oemtable() {
         concat!("Alignment of ", stringify!(mpc_oemtable))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_oemtable)).signature as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_oemtable>()).signature as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -781,7 +781,7 @@ fn bindgen_test_layout_mpc_oemtable() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_oemtable)).length as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_oemtable>()).length as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -791,7 +791,7 @@ fn bindgen_test_layout_mpc_oemtable() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_oemtable)).rev as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_oemtable>()).rev as *const _ as usize },
         6usize,
         concat!(
             "Alignment of field: ",
@@ -801,7 +801,7 @@ fn bindgen_test_layout_mpc_oemtable() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_oemtable)).checksum as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_oemtable>()).checksum as *const _ as usize },
         7usize,
         concat!(
             "Alignment of field: ",
@@ -811,7 +811,7 @@ fn bindgen_test_layout_mpc_oemtable() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const mpc_oemtable)).mpc as *const _ as usize },
+        unsafe { &(*std::ptr::null::<mpc_oemtable>()).mpc as *const _ as usize },
         8usize,
         concat!(
             "Alignment of field: ",

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -394,13 +394,13 @@ mod tests {
             Box::new(serial_out.clone()),
         );
 
-        serial.write(0, DATA as u64, &['x' as u8, 'y' as u8]);
-        serial.write(0, DATA as u64, &['a' as u8]);
-        serial.write(0, DATA as u64, &['b' as u8]);
-        serial.write(0, DATA as u64, &['c' as u8]);
+        serial.write(0, DATA as u64, &[b'x', b'y']);
+        serial.write(0, DATA as u64, &[b'a']);
+        serial.write(0, DATA as u64, &[b'b']);
+        serial.write(0, DATA as u64, &[b'c']);
         assert_eq!(
             serial_out.buf.lock().unwrap().as_slice(),
-            &['a' as u8, 'b' as u8, 'c' as u8]
+            &[b'a', b'b', b'c']
         );
     }
 
@@ -411,16 +411,14 @@ mod tests {
         let mut serial = Serial::new_out(
             String::from(SERIAL_NAME),
             Arc::new(Box::new(TestInterrupt::new(intr_evt.try_clone().unwrap()))),
-            Box::new(serial_out.clone()),
+            Box::new(serial_out),
         );
 
         // write 1 to the interrupt event fd, so that read doesn't block in case the event fd
         // counter doesn't change (for 0 it blocks)
         assert!(intr_evt.write(1).is_ok());
         serial.write(0, IER as u64, &[IER_RECV_BIT]);
-        serial
-            .queue_input_bytes(&['a' as u8, 'b' as u8, 'c' as u8])
-            .unwrap();
+        serial.queue_input_bytes(&[b'a', b'b', b'c']).unwrap();
 
         assert_eq!(intr_evt.read().unwrap(), 2);
 
@@ -433,11 +431,11 @@ mod tests {
         serial.read(0, LSR as u64, &mut data[..]);
         assert_ne!(data[0] & LSR_DATA_BIT, 0);
         serial.read(0, DATA as u64, &mut data[..]);
-        assert_eq!(data[0], 'a' as u8);
+        assert_eq!(data[0], b'a');
         serial.read(0, DATA as u64, &mut data[..]);
-        assert_eq!(data[0], 'b' as u8);
+        assert_eq!(data[0], b'b');
         serial.read(0, DATA as u64, &mut data[..]);
-        assert_eq!(data[0], 'c' as u8);
+        assert_eq!(data[0], b'c');
 
         // check if reading from the largest u8 offset returns 0
         serial.read(0, 0xff, &mut data[..]);
@@ -456,7 +454,7 @@ mod tests {
         // counter doesn't change (for 0 it blocks)
         assert!(intr_evt.write(1).is_ok());
         serial.write(0, IER as u64, &[IER_THR_BIT]);
-        serial.write(0, DATA as u64, &['a' as u8]);
+        serial.write(0, DATA as u64, &[b'a']);
 
         assert_eq!(intr_evt.read().unwrap(), 2);
         let mut data = [0u8];
@@ -496,9 +494,9 @@ mod tests {
         );
 
         serial.write(0, MCR as u64, &[MCR_LOOP_BIT as u8]);
-        serial.write(0, DATA as u64, &['a' as u8]);
-        serial.write(0, DATA as u64, &['b' as u8]);
-        serial.write(0, DATA as u64, &['c' as u8]);
+        serial.write(0, DATA as u64, &[b'a']);
+        serial.write(0, DATA as u64, &[b'b']);
+        serial.write(0, DATA as u64, &[b'c']);
 
         let mut data = [0u8];
         serial.read(0, MSR as u64, &mut data[..]);
@@ -506,11 +504,11 @@ mod tests {
         serial.read(0, MCR as u64, &mut data[..]);
         assert_eq!(data[0], MCR_LOOP_BIT as u8);
         serial.read(0, DATA as u64, &mut data[..]);
-        assert_eq!(data[0], 'a' as u8);
+        assert_eq!(data[0], b'a');
         serial.read(0, DATA as u64, &mut data[..]);
-        assert_eq!(data[0], 'b' as u8);
+        assert_eq!(data[0], b'b');
         serial.read(0, DATA as u64, &mut data[..]);
-        assert_eq!(data[0], 'c' as u8);
+        assert_eq!(data[0], b'c');
     }
 
     #[test]

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -455,7 +455,7 @@ impl VhostUserBlkBackendConfig {
         let poll_queue = parser
             .convert::<Toggle>("poll_queue")
             .map_err(Error::FailedConfigParse)?
-            .unwrap_or_else(|| Toggle(true))
+            .unwrap_or(Toggle(true))
             .0;
         let queue_size = parser
             .convert("queue_size")

--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -282,10 +282,11 @@ mod tests {
         assert!(bus.insert(dummy.clone(), 0x0, 0x20).is_err());
         assert!(bus.insert(dummy.clone(), 0x20, 0x05).is_ok());
         assert!(bus.insert(dummy.clone(), 0x25, 0x05).is_ok());
-        assert!(bus.insert(dummy.clone(), 0x0, 0x10).is_ok());
+        assert!(bus.insert(dummy, 0x0, 0x10).is_ok());
     }
 
     #[test]
+    #[allow(clippy::redundant_clone)]
     fn bus_read_write() {
         let bus = Bus::new();
         let dummy = Arc::new(Mutex::new(DummyDevice));
@@ -297,12 +298,13 @@ mod tests {
         assert!(bus.read(0x16, &mut [0, 0, 0, 0]).is_ok());
         assert!(bus.write(0x16, &[0, 0, 0, 0]).is_ok());
         assert!(bus.read(0x20, &mut [0, 0, 0, 0]).is_err());
-        assert!(bus.write(0x20, &mut [0, 0, 0, 0]).is_err());
+        assert!(bus.write(0x20, &[0, 0, 0, 0]).is_err());
         assert!(bus.read(0x06, &mut [0, 0, 0, 0]).is_err());
-        assert!(bus.write(0x06, &mut [0, 0, 0, 0]).is_err());
+        assert!(bus.write(0x06, &[0, 0, 0, 0]).is_err());
     }
 
     #[test]
+    #[allow(clippy::redundant_clone)]
     fn bus_read_write_values() {
         let bus = Bus::new();
         let dummy = Arc::new(Mutex::new(ConstantDevice));
@@ -318,6 +320,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::redundant_clone)]
     fn busrange_cmp() {
         let range = BusRange { base: 0x10, len: 2 };
         assert_eq!(range, BusRange { base: 0x10, len: 3 });
@@ -332,7 +335,7 @@ mod tests {
         let mut data = [1, 2, 3, 4];
         let device = Arc::new(Mutex::new(DummyDevice));
         assert!(bus.insert(device.clone(), 0x10, 0x10).is_ok());
-        assert!(bus.write(0x10, &mut data).is_ok());
+        assert!(bus.write(0x10, &data).is_ok());
         assert!(bus.read(0x10, &mut data).is_ok());
         assert_eq!(data, [1, 2, 3, 4]);
     }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1541,7 +1541,7 @@ mod tests {
         let vcpu = vm.create_vcpu(0, None).unwrap();
 
         let mut expected_sregs: SpecialRegisters = vcpu.get_sregs().unwrap();
-        let gm = GuestMemoryMmap::from_ranges(&vec![(GuestAddress(0), 0x10000)]).unwrap();
+        let gm = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         configure_segments_and_sregs(&gm, &mut expected_sregs, BootProtocol::LinuxBoot).unwrap();
         setup_page_tables(&gm, &mut expected_sregs).unwrap();
 


### PR DESCRIPTION
Extend to include tests (`--tests`) and also all crate in the workspace (`--all`)