### PR TITLE
vmm: device_manager: Remove ActivatedBackend struct

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -656,17 +656,6 @@ impl DeviceRelocation for AddressManager {
     }
 }
 
-struct ActivatedBackend {
-    _socket_file: tempfile::NamedTempFile,
-    child: std::process::Child,
-}
-
-impl Drop for ActivatedBackend {
-    fn drop(&mut self) {
-        self.child.wait().ok();
-    }
-}
-
 #[derive(Serialize, Deserialize)]
 struct DeviceManagerState {
     device_tree: DeviceTree,


### PR DESCRIPTION
This was used for vhost-user self spawning but no longer has any users.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>