### PR TITLE
hypervisor: x86: reference PlatformEmulator in Emulator

### DIFF
--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -11,7 +11,6 @@ use crate::arch::x86::emulator::CpuStateManager;
 use crate::arch::x86::Exception;
 use iced_x86::*;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
 pub mod mov;
 
@@ -48,7 +47,7 @@ pub trait InstructionHandler<T: CpuStateManager> {
         &self,
         insn: &Instruction,
         state: &mut T,
-        platform: Arc<Mutex<dyn PlatformEmulator<CpuState = T>>>,
+        platform: &mut dyn PlatformEmulator<CpuState = T>,
     ) -> Result<(), EmulationError<Exception>>;
 }
 


### PR DESCRIPTION
The observation here is PlatformEmulator can be seen as the context for
emulation to take place. It should be rather easy to construct a context
that satisfies the lifetime constraints for instruction emulation.

The thread doing the emulation will have full ownership over the
context, so this removes the need to wrap PlatformEmulator in Arc and
Mutex, as well as the need for the context to be either Clone or Copy.

Signed-off-by: Wei Liu <liuwe@microsoft.com>