### PR TITLE
Emulator instruction fetch

### DIFF
--- a/hypervisor/src/arch/emulator/mod.rs
+++ b/hypervisor/src/arch/emulator/mod.rs
@@ -71,6 +71,9 @@ pub enum EmulationError<T: Debug> {
     #[error("Instruction Exception: {0}")]
     InstructionException(Exception<T>),
 
+    #[error("Instruction fetching error: {0}")]
+    InstructionFetchingError(#[source] anyhow::Error),
+
     #[error("Platform emulation error: {0}")]
     PlatformEmulationError(PlatformError),
 }
@@ -126,6 +129,14 @@ pub trait PlatformEmulator: Send + Sync {
     /// * `gva` - Guest virtual address to translate.
     ///
     fn gva_to_gpa(&self, gva: u64) -> Result<u64, PlatformError>;
+
+    /// Fetch instruction bytes from memory.
+    ///
+    /// # Arguments
+    ///
+    /// * `ip` - Instruction pointer virtual address to start fetching instructions from.
+    ///
+    fn fetch(&self, ip: u64, instruction_bytes: &mut [u8]) -> Result<(), PlatformError>;
 }
 
 pub type EmulationResult<S, E> = std::result::Result<S, EmulationError<E>>;

--- a/hypervisor/src/arch/emulator/mod.rs
+++ b/hypervisor/src/arch/emulator/mod.rs
@@ -29,6 +29,9 @@ pub enum PlatformError {
     #[error("Invalid register: {0}")]
     InvalidRegister(#[source] anyhow::Error),
 
+    #[error("Invalid state: {0}")]
+    InvalidState(#[source] anyhow::Error),
+
     #[error("Memory read failure: {0}")]
     MemoryReadFailure(#[source] anyhow::Error),
 

--- a/hypervisor/src/arch/emulator/mod.rs
+++ b/hypervisor/src/arch/emulator/mod.rs
@@ -26,6 +26,9 @@ impl<T: Debug> Display for Exception<T> {
 
 #[derive(Error, Debug)]
 pub enum PlatformError {
+    #[error("Invalid address: {0}")]
+    InvalidAddress(#[source] anyhow::Error),
+
     #[error("Invalid register: {0}")]
     InvalidRegister(#[source] anyhow::Error),
 
@@ -46,6 +49,9 @@ pub enum PlatformError {
 
     #[error("Unmapped virtual address: {0}")]
     UnmappedGVA(#[source] anyhow::Error),
+
+    #[error("Unsupported CPU Mode: {0}")]
+    UnsupportedCpuMode(#[source] anyhow::Error),
 }
 
 #[derive(Error, Debug)]

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -37,7 +37,7 @@ macro_rules! mov_rm_r {
                     .map_err(EmulationError::PlatformEmulationError)?,
 
                 OpKind::Memory => {
-                    let addr = memory_operand_address(insn, state)
+                    let addr = memory_operand_address(insn, state, true)
                         .map_err(EmulationError::PlatformEmulationError)?;
                     let src_reg_value_type: $bound = src_reg_value as $bound;
 
@@ -71,7 +71,7 @@ macro_rules! mov_rm_imm {
                     .write_reg(insn.op0_register(), imm as u64)
                     .map_err(EmulationError::PlatformEmulationError)?,
                 OpKind::Memory => {
-                    let addr = memory_operand_address(insn, state)
+                    let addr = memory_operand_address(insn, state, true)
                         .map_err(EmulationError::PlatformEmulationError)?;
 
                     platform
@@ -102,7 +102,7 @@ macro_rules! mov_r_rm {
                     .map_err(EmulationError::PlatformEmulationError)?
                     as $bound,
                 OpKind::Memory => {
-                    let target_address = memory_operand_address(insn, state)
+                    let target_address = memory_operand_address(insn, state, false)
                         .map_err(EmulationError::PlatformEmulationError)?;
                     let mut memory: [u8; mem::size_of::<$bound>()] = [0; mem::size_of::<$bound>()];
                     platform

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -268,7 +268,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0x48, 0x89, 0xd8];
         let mut vmm = MockVMM::new(ip, hashmap![Register::RBX => rbx], None);
-        vmm.emulate_first_insn(cpu_id, &insn);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let rax: u64 = vmm
             .cpu_state(cpu_id)
@@ -288,7 +288,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0x48, 0xb8, 0x44, 0x33, 0x22, 0x11, 0x44, 0x33, 0x22, 0x11];
         let mut vmm = MockVMM::new(ip, hashmap![], None);
-        vmm.emulate_first_insn(cpu_id, &insn);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let rax: u64 = vmm
             .cpu_state(cpu_id)
@@ -314,7 +314,7 @@ mod tests {
             hashmap![Register::RAX => rax],
             Some((rax + rax, &memory)),
         );
-        vmm.emulate_first_insn(cpu_id, &insn);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         rax = vmm
             .cpu_state(cpu_id)
@@ -334,7 +334,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0xb0, 0x11];
         let mut vmm = MockVMM::new(ip, hashmap![], None);
-        vmm.emulate_first_insn(cpu_id, &insn);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let al = vmm
             .cpu_state(cpu_id)
@@ -354,7 +354,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0xb8, 0x11, 0x00, 0x00, 0x00];
         let mut vmm = MockVMM::new(ip, hashmap![], None);
-        vmm.emulate_first_insn(cpu_id, &insn);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let eax = vmm
             .cpu_state(cpu_id)
@@ -374,7 +374,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0x48, 0xc7, 0xc0, 0x44, 0x33, 0x22, 0x11];
         let mut vmm = MockVMM::new(ip, hashmap![], None);
-        vmm.emulate_first_insn(cpu_id, &insn);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let rax: u64 = vmm
             .cpu_state(cpu_id)
@@ -399,7 +399,7 @@ mod tests {
             hashmap![Register::RAX => rax, Register::DH => dh.into()],
             None,
         );
-        vmm.emulate_first_insn(cpu_id, &insn);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let mut memory: [u8; 1] = [0; 1];
         vmm.read_memory(rax, &mut memory).unwrap();
@@ -422,7 +422,7 @@ mod tests {
             hashmap![Register::RAX => rax, Register::ESI => esi.into()],
             None,
         );
-        vmm.emulate_first_insn(cpu_id, &insn);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let mut memory: [u8; 4] = [0; 4];
         vmm.read_memory(rax, &mut memory).unwrap();
@@ -446,7 +446,7 @@ mod tests {
             hashmap![Register::RAX => rax, Register::EDI => edi.into()],
             None,
         );
-        vmm.emulate_first_insn(cpu_id, &insn);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let mut memory: [u8; 4] = [0; 4];
         vmm.read_memory(rax + displacement, &mut memory).unwrap();
@@ -471,7 +471,7 @@ mod tests {
             hashmap![Register::RAX => rax],
             Some((rax + displacement, &memory)),
         );
-        vmm.emulate_first_insn(cpu_id, &insn);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let new_eax = vmm
             .cpu_state(cpu_id)
@@ -498,7 +498,7 @@ mod tests {
             hashmap![Register::RAX => rax],
             Some((rax + displacement, &memory)),
         );
-        vmm.emulate_first_insn(cpu_id, &insn);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let new_al = vmm
             .cpu_state(cpu_id)
@@ -525,7 +525,7 @@ mod tests {
             0x48, 0x8b, 0x58, 0x10, // mov rbx, qword ptr [rax+10h]
         ];
         let mut vmm = MockVMM::new(ip, hashmap![], Some((rax + displacement, &memory)));
-        vmm.emulate_insn(cpu_id, &insn, Some(2));
+        assert!(vmm.emulate_insn(cpu_id, &insn, Some(2)).is_ok());
 
         let rbx: u64 = vmm
             .cpu_state(cpu_id)
@@ -554,7 +554,7 @@ mod tests {
 
         let mut vmm = MockVMM::new(ip, hashmap![], Some((rax + displacement, &memory)));
         // Only run the first instruction.
-        vmm.emulate_first_insn(cpu_id, &insn);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         assert_eq!(ip + 7 as u64, vmm.cpu_state(cpu_id).unwrap().ip());
 
@@ -587,7 +587,7 @@ mod tests {
 
         let mut vmm = MockVMM::new(ip, hashmap![], Some((rax + displacement, &memory)));
         // Run the 2 first instructions.
-        vmm.emulate_insn(cpu_id, &insn, Some(2));
+        assert!(vmm.emulate_insn(cpu_id, &insn, Some(2)).is_ok());
 
         assert_eq!(ip + 7 + 4 as u64, vmm.cpu_state(cpu_id).unwrap().ip());
 

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -525,7 +525,7 @@ mod tests {
             0x48, 0x8b, 0x58, 0x10, // mov rbx, qword ptr [rax+10h]
         ];
         let mut vmm = MockVMM::new(ip, hashmap![], Some((rax + displacement, &memory)));
-        vmm.emulate_first_insn(cpu_id, &insn);
+        vmm.emulate_insn(cpu_id, &insn, Some(2));
 
         let rbx: u64 = vmm
             .cpu_state(cpu_id)
@@ -554,7 +554,7 @@ mod tests {
 
         let mut vmm = MockVMM::new(ip, hashmap![], Some((rax + displacement, &memory)));
         // Only run the first instruction.
-        vmm.emulate_insn(cpu_id, &insn, Some(1));
+        vmm.emulate_first_insn(cpu_id, &insn);
 
         assert_eq!(ip + 7 as u64, vmm.cpu_state(cpu_id).unwrap().ip());
 

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -249,9 +249,6 @@ impl<T: CpuStateManager> InstructionHandler<T> for Mov_rm64_r64 {
 #[cfg(test)]
 mod tests {
     #![allow(unused_mut)]
-
-    extern crate env_logger;
-
     use super::*;
     use crate::arch::x86::emulator::mock_vmm::*;
 

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -665,7 +665,7 @@ mod mock_vmm {
         }
 
         pub fn emulate_first_insn(&mut self, cpu_id: usize, insn: &[u8]) {
-            self.emulate_insn(cpu_id, insn, None)
+            self.emulate_insn(cpu_id, insn, Some(1))
         }
     }
 

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -63,3 +63,5 @@ pub enum Exception {
     VE = 20, // Virtualization Exception
     CP = 21, // Control Protection Exception
 }
+
+pub mod regs;

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -65,3 +65,60 @@ pub enum Exception {
 }
 
 pub mod regs;
+
+// Abstracted segment register ops.
+// Each x86 hypervisor should implement those.
+pub trait SegmentRegisterOps {
+    // Segment type
+    fn segment_type(&self) -> u8;
+    fn set_segment_type(&mut self, val: u8);
+
+    // Descriptor Privilege Level (DPL)
+    fn dpl(&self) -> u8;
+    fn set_dpl(&mut self, val: u8);
+
+    // Granularity
+    fn granularity(&self) -> u8;
+    fn set_granularity(&mut self, val: u8);
+
+    // Memory Presence
+    fn present(&self) -> u8;
+    fn set_present(&mut self, val: u8);
+
+    // Long mode
+    fn long(&self) -> u8;
+    fn set_long(&mut self, val: u8);
+
+    // Available for system use (AVL)
+    fn avl(&self) -> u8;
+    fn set_avl(&mut self, val: u8);
+
+    // Descriptor type (System or code/data)
+    fn desc_type(&self) -> u8;
+    fn set_desc_type(&mut self, val: u8);
+
+    // D/B
+    fn db(&self) -> u8;
+    fn set_db(&mut self, val: u8);
+}
+
+// Code segment
+pub const CODE_SEGMENT_TYPE: u8 = 0x8;
+
+// Read/Write or Read/Exec segment
+pub const RWRX_SEGMENT_TYPE: u8 = 0x2;
+
+// Expand down segment
+pub const EXPAND_DOWN_SEGMENT_TYPE: u8 = 0x4;
+
+pub fn segment_type_code(t: u8) -> bool {
+    t & CODE_SEGMENT_TYPE != 0
+}
+
+pub fn segment_type_ro(t: u8) -> bool {
+    t & !RWRX_SEGMENT_TYPE == 0
+}
+
+pub fn segment_type_expand_down(t: u8) -> bool {
+    !segment_type_code(t) && (t & EXPAND_DOWN_SEGMENT_TYPE != 0)
+}

--- a/hypervisor/src/arch/x86/regs.rs
+++ b/hypervisor/src/arch/x86/regs.rs
@@ -1,0 +1,17 @@
+//
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// EFER (technically not a register) bits
+pub const EFER_LMA: u64 = 0x400;
+pub const EFER_LME: u64 = 0x100;
+
+// CR0 bits
+pub const CR0_PE: u64 = 0x1;
+pub const CR0_PG: u64 = 0x80000000;
+
+// CR4 bits
+pub const CR4_PAE: u64 = 0x20;
+pub const CR4_LA57: u64 = 0x1000;

--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -10,7 +10,7 @@
 
 use vm_memory::GuestAddress;
 
-use crate::arch::x86::{msr_index, MTRR_ENABLE, MTRR_MEM_TYPE_WB};
+use crate::arch::x86::{msr_index, SegmentRegisterOps, MTRR_ENABLE, MTRR_MEM_TYPE_WB};
 use crate::kvm::{Cap, Kvm, KvmError, KvmResult};
 use serde_derive::{Deserialize, Serialize};
 
@@ -27,6 +27,71 @@ pub use {
     kvm_bindings::CpuId, kvm_bindings::MsrList, kvm_bindings::Msrs as MsrEntries,
     kvm_bindings::KVM_CPUID_FLAG_SIGNIFCANT_INDEX as CPUID_FLAG_VALID_INDEX,
 };
+
+impl SegmentRegisterOps for SegmentRegister {
+    fn segment_type(&self) -> u8 {
+        self.type_
+    }
+    fn set_segment_type(&mut self, val: u8) {
+        self.type_ = val;
+    }
+
+    fn dpl(&self) -> u8 {
+        self.dpl
+    }
+
+    fn set_dpl(&mut self, val: u8) {
+        self.dpl = val;
+    }
+
+    fn present(&self) -> u8 {
+        self.present
+    }
+
+    fn set_present(&mut self, val: u8) {
+        self.present = val;
+    }
+
+    fn long(&self) -> u8 {
+        self.l
+    }
+
+    fn set_long(&mut self, val: u8) {
+        self.l = val;
+    }
+
+    fn avl(&self) -> u8 {
+        self.avl
+    }
+
+    fn set_avl(&mut self, val: u8) {
+        self.avl = val;
+    }
+
+    fn desc_type(&self) -> u8 {
+        self.s
+    }
+
+    fn set_desc_type(&mut self, val: u8) {
+        self.s = val;
+    }
+
+    fn granularity(&self) -> u8 {
+        self.g
+    }
+
+    fn set_granularity(&mut self, val: u8) {
+        self.g = val;
+    }
+
+    fn db(&self) -> u8 {
+        self.db
+    }
+
+    fn set_db(&mut self, val: u8) {
+        self.db = val;
+    }
+}
 
 pub const KVM_TSS_ADDRESS: GuestAddress = GuestAddress(0xfffb_d000);
 


### PR DESCRIPTION
On x86 instruction lengths and thus instruction bytes boundaries are not necessarily page aligned. As a consequence, hypervisors may fetch and pass only part of an instruction if said crosses a page boundary. This is why we need to add to the current emulator the ability to fetch instruction bytes from memory.

Adding instruction fetching means we are now allowing for reading memory from different segments, code or data. As a consequence, this PR also adds a generic address linearization (from segmented to virtual) method for the `CpuStateManager` trait, with basic segmentation checks.

With that new method in place, x86 `PlatformEmulator` implementations can linearize their `RIP` and call into `read_memory` with the translated virtual address for fetching instruction bytes.

The x86 instruction fetcher will trigger if the decoder informs us about failing at instruction decoding due truncated/incomplete instruction. The fetcher will then fetch 16 instruction bytes from the last successfully decoded instruction. 16 bytes guarantees that we'll get at least one full instruction, that we will then decode and emulate.