### PR TITLE
hypervisor: drop arc-swap dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,6 @@ name = "hypervisor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arc-swap",
  "env_logger",
  "iced-x86",
  "kvm-bindings",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -10,7 +10,6 @@ kvm = []
 
 [dependencies]
 anyhow = "1.0"
-arc-swap = ">=1.0.0"
 thiserror = "1.0"
 libc = "0.2.80"
 log = "0.4.11"


### PR DESCRIPTION
It is no longer needed after 0fec32658.

Signed-off-by: Wei Liu <liuwe@microsoft.com>