### PR TITLE
hypervisor: emulator: Small improvements

### DIFF
--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -28,7 +28,7 @@ features = ["elf", "bzimage"]
 [dependencies.iced-x86]
 version = "1.9.1"
 default-features = false
-features = ["std", "decoder", "op_code_info", "instr_info"]
+features = ["std", "decoder", "op_code_info", "instr_info", "fast_fmt"]
 
 [dev-dependencies]
 env_logger = "0.8.2"

--- a/hypervisor/src/arch/emulator/mod.rs
+++ b/hypervisor/src/arch/emulator/mod.rs
@@ -76,6 +76,9 @@ pub enum EmulationError<T: Debug> {
 
     #[error("Platform emulation error: {0}")]
     PlatformEmulationError(PlatformError),
+
+    #[error(transparent)]
+    EmulationError(#[from] anyhow::Error),
 }
 
 /// The PlatformEmulator trait emulates a guest platform.

--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -12,6 +12,40 @@ use crate::arch::x86::Exception;
 use iced_x86::*;
 use std::collections::HashMap;
 
+macro_rules! imm_op {
+    (u8, $insn:ident) => {
+        $insn.immediate8()
+    };
+
+    (u16, $insn:ident) => {
+        $insn.immediate16()
+    };
+
+    (u32, $insn:ident) => {
+        $insn.immediate32()
+    };
+
+    (u64, $insn:ident) => {
+        $insn.immediate64()
+    };
+
+    (u32tou64, $insn:ident) => {
+        $insn.immediate32to64()
+    };
+
+    (u8tou16, $insn:ident) => {
+        $insn.immediate8to16()
+    };
+
+    (u8tou32, $insn:ident) => {
+        $insn.immediate8to32()
+    };
+
+    (u8tou64, $insn:ident) => {
+        $insn.immediate8to64()
+    };
+}
+
 pub mod mov;
 
 // Returns the linear a.k.a. virtual address for a memory operand.

--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -114,3 +114,16 @@ macro_rules! insn_add {
         $insn_map.add_insn(Code::$code, Box::new($mnemonic::$code {}));
     };
 }
+
+macro_rules! insn_format {
+    ($insn:ident) => {{
+        let mut output = String::new();
+        let mut formatter = FastFormatter::new();
+        formatter
+            .options_mut()
+            .set_space_after_operand_separator(true);
+        formatter.format(&$insn, &mut output);
+
+        output
+    }};
+}

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -164,6 +164,18 @@ macro_rules! imm_op {
     (u32tou64, $insn:ident) => {
         $insn.immediate32to64()
     };
+
+    (u8tou16, $insn:ident) => {
+        $insn.immediate8to16()
+    };
+
+    (u8tou32, $insn:ident) => {
+        $insn.immediate8to32()
+    };
+
+    (u8tou64, $insn:ident) => {
+        $insn.immediate8to64()
+    };
 }
 
 pub struct Mov_r8_rm8 {}

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -144,40 +144,6 @@ macro_rules! mov_r_imm {
     };
 }
 
-macro_rules! imm_op {
-    (u8, $insn:ident) => {
-        $insn.immediate8()
-    };
-
-    (u16, $insn:ident) => {
-        $insn.immediate16()
-    };
-
-    (u32, $insn:ident) => {
-        $insn.immediate32()
-    };
-
-    (u64, $insn:ident) => {
-        $insn.immediate64()
-    };
-
-    (u32tou64, $insn:ident) => {
-        $insn.immediate32to64()
-    };
-
-    (u8tou16, $insn:ident) => {
-        $insn.immediate8to16()
-    };
-
-    (u8tou32, $insn:ident) => {
-        $insn.immediate8to32()
-    };
-
-    (u8tou64, $insn:ident) => {
-        $insn.immediate8to64()
-    };
-}
-
 pub struct Mov_r8_rm8 {}
 impl<T: CpuStateManager> InstructionHandler<T> for Mov_r8_rm8 {
     mov_r_rm!(u8);


### PR DESCRIPTION
* Extend the `imm_op` macro and make it available to all instruction emulation implementations
* Format instructions on error paths, and display human readable assembly