### PR TITLE
misc: Use a more relaxed memory model when possible

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -602,7 +602,7 @@ impl cpu::Vcpu for KvmVcpu {
     fn enable_hyperv_synic(&self) -> cpu::Result<()> {
         // Update the information about Hyper-V SynIC being enabled and
         // emulated as it will influence later which MSRs should be saved.
-        self.hyperv_synic.store(true, Ordering::SeqCst);
+        self.hyperv_synic.store(true, Ordering::Release);
 
         let mut cap: kvm_enable_cap = Default::default();
         cap.cap = KVM_CAP_HYPERV_SYNIC;
@@ -1151,7 +1151,7 @@ impl cpu::Vcpu for KvmVcpu {
 
         // Save extra MSRs if the Hyper-V synthetic interrupt controller is
         // emulated.
-        if self.hyperv_synic.load(Ordering::SeqCst) {
+        if self.hyperv_synic.load(Ordering::Acquire) {
             let hyperv_synic_msrs = vec![
                 0x40000020, 0x40000021, 0x40000080, 0x40000081, 0x40000082, 0x40000083, 0x40000084,
                 0x40000090, 0x40000091, 0x40000092, 0x40000093, 0x40000094, 0x40000095, 0x40000096,

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -132,7 +132,7 @@ impl VhostUserBlkThread {
             match Request::parse(&head, mem) {
                 Ok(mut request) => {
                     debug!("element is a valid request");
-                    request.set_writeback(self.writeback.load(Ordering::SeqCst));
+                    request.set_writeback(self.writeback.load(Ordering::Acquire));
                     let status = match request.execute(
                         &mut self.disk_image.lock().unwrap().deref_mut(),
                         self.disk_nsectors,
@@ -273,7 +273,7 @@ impl VhostUserBlkBackend {
                 "writethrough"
             }
         );
-        self.writeback.store(writeback, Ordering::SeqCst);
+        self.writeback.store(writeback, Ordering::Release);
     }
 }
 

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -98,7 +98,7 @@ struct VirtioBalloonResizeReceiver {
 
 impl VirtioBalloonResizeReceiver {
     fn get_size(&self) -> u64 {
-        self.size.load(Ordering::SeqCst)
+        self.size.load(Ordering::Acquire)
     }
 
     fn send(&self, r: Result<(), Error>) -> Result<(), mpsc::SendError<Result<(), Error>>> {
@@ -134,7 +134,7 @@ impl VirtioBalloonResize {
     }
 
     pub fn work(&self, size: u64) -> Result<(), Error> {
-        self.size.store(size, Ordering::SeqCst);
+        self.size.store(size, Ordering::Release);
         self.evt.write(1).map_err(Error::EventFdWriteFail)?;
         self.rx.recv().map_err(Error::MpscRecvFail)?
     }

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -108,7 +108,7 @@ impl<T: DiskFile> BlockEpollHandler<T> {
             let len;
             match Request::parse(&avail_desc, &mem) {
                 Ok(mut request) => {
-                    request.set_writeback(self.writeback.load(Ordering::SeqCst));
+                    request.set_writeback(self.writeback.load(Ordering::Acquire));
 
                     let mut disk_image_locked = self.disk_image.lock().unwrap();
                     let mut disk_image = disk_image_locked.deref_mut();
@@ -387,7 +387,7 @@ impl<T: DiskFile> Block<T> {
                 "writethrough"
             }
         );
-        self.writeback.store(writeback, Ordering::SeqCst);
+        self.writeback.store(writeback, Ordering::Release);
     }
 }
 

--- a/virtio-devices/src/block_io_uring.rs
+++ b/virtio-devices/src/block_io_uring.rs
@@ -116,7 +116,7 @@ impl BlockIoUringEpollHandler {
 
         for avail_desc in queue.iter(&mem) {
             let mut request = Request::parse(&avail_desc, &mem).map_err(Error::RequestParsing)?;
-            request.set_writeback(self.writeback.load(Ordering::SeqCst));
+            request.set_writeback(self.writeback.load(Ordering::Acquire));
             if request
                 .execute_io_uring(
                     &mem,
@@ -428,7 +428,7 @@ impl BlockIoUring {
                 "writethrough"
             }
         );
-        self.writeback.store(writeback, Ordering::SeqCst);
+        self.writeback.store(writeback, Ordering::Release);
     }
 }
 

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -270,7 +270,7 @@ impl ConsoleInput {
     pub fn update_console_size(&self, cols: u16, rows: u16) {
         if self
             .acked_features
-            .fetch_and(1u64 << VIRTIO_CONSOLE_F_SIZE, Ordering::SeqCst)
+            .fetch_and(1u64 << VIRTIO_CONSOLE_F_SIZE, Ordering::AcqRel)
             != 0
         {
             self.config.lock().unwrap().update_console_size(cols, rows);

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -284,7 +284,7 @@ impl Resize {
 
     pub fn work(&self, size: u64) -> Result<(), Error> {
         if let Some(rx) = &self.rx {
-            self.size.store(size, Ordering::SeqCst);
+            self.size.store(size, Ordering::Release);
             self.evt.write(1).map_err(Error::EventFdWriteFail)?;
             rx.recv().map_err(Error::MpscRecvFail)?
         } else {
@@ -293,7 +293,7 @@ impl Resize {
     }
 
     fn get_size(&self) -> u64 {
-        self.size.load(Ordering::SeqCst)
+        self.size.load(Ordering::Acquire)
     }
 
     fn send(&self, r: Result<(), Error>) -> Result<(), mpsc::SendError<Result<(), Error>>> {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -785,6 +785,11 @@ impl CpuManager {
                         // We enter a loop because park() could spuriously
                         // return. We will then park() again unless the
                         // pause boolean has been toggled.
+
+                        // Need to use Ordering::SeqCst as we have multiple
+                        // loads and stores to different atomics and we need
+                        // to see them in a consistent order in all threads
+
                         if vcpu_pause_signalled.load(Ordering::SeqCst) {
                             vcpu_run_interrupted.store(true, Ordering::SeqCst);
                             while vcpu_pause_signalled.load(Ordering::SeqCst) {


### PR DESCRIPTION
When a total ordering between multiple atomic variables is not required
then use Ordering::Acquire with atomic loads and Ordering::Release with
atomic stores.

This will improve performance as this does not require a memory fence
on x86_64 which Ordering::SeqCst will use.

Add a comment to the code in the vCPU handling code where it operates on
multiple atomics to explain why Ordering::SeqCst is required.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>