### PR TITLE
Use `match` to dispatch instruction emulation

### DIFF
--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -10,7 +10,6 @@ use crate::arch::emulator::{EmulationError, PlatformEmulator, PlatformError};
 use crate::arch::x86::emulator::CpuStateManager;
 use crate::arch::x86::Exception;
 use iced_x86::*;
-use std::collections::HashMap;
 
 macro_rules! imm_op {
     (u8, $insn:ident) => {
@@ -81,38 +80,6 @@ pub trait InstructionHandler<T: CpuStateManager> {
         state: &mut T,
         platform: &mut dyn PlatformEmulator<CpuState = T>,
     ) -> Result<(), EmulationError<Exception>>;
-}
-
-pub struct InstructionMap<T: CpuStateManager> {
-    pub instructions: HashMap<Code, Box<dyn InstructionHandler<T> + Sync + Send>>,
-}
-
-impl<T: CpuStateManager> InstructionMap<T> {
-    pub fn new() -> InstructionMap<T> {
-        InstructionMap {
-            instructions: HashMap::new(),
-        }
-    }
-
-    pub fn add_insn(
-        &mut self,
-        insn: Code,
-        insn_handler: Box<dyn InstructionHandler<T> + Sync + Send>,
-    ) {
-        self.instructions.insert(insn, insn_handler);
-    }
-}
-
-impl<T: CpuStateManager> Default for InstructionMap<T> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-macro_rules! insn_add {
-    ($insn_map:ident, $mnemonic:ident, $code:ident) => {
-        $insn_map.add_insn(Code::$code, Box::new($mnemonic::$code {}));
-    };
 }
 
 macro_rules! insn_format {

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -475,32 +475,47 @@ impl CpuStateManager for EmulatorCpuState {
 
 pub struct Emulator<'a, T: CpuStateManager> {
     platform: &'a mut dyn PlatformEmulator<CpuState = T>,
-    insn_map: InstructionMap<T>,
+}
+
+// Reduce repetition, see its invocation in get_handler().
+macro_rules! gen_handler_match {
+    ($value: ident, $( ($module:ident, $code:ident) ),* ) => {
+        match $value {
+            $(
+                Code::$code => Some(Box::new($module::$code {})),
+            )*
+            _ => None,
+        }
+    };
 }
 
 impl<'a, T: CpuStateManager> Emulator<'a, T> {
     pub fn new(platform: &mut dyn PlatformEmulator<CpuState = T>) -> Emulator<T> {
-        let mut insn_map = InstructionMap::<T>::new();
+        Emulator { platform }
+    }
 
-        // MOV
-        insn_add!(insn_map, mov, Mov_r8_imm8);
-        insn_add!(insn_map, mov, Mov_r8_rm8);
-        insn_add!(insn_map, mov, Mov_r16_imm16);
-        insn_add!(insn_map, mov, Mov_r16_rm16);
-        insn_add!(insn_map, mov, Mov_r32_imm32);
-        insn_add!(insn_map, mov, Mov_r32_rm32);
-        insn_add!(insn_map, mov, Mov_r64_imm64);
-        insn_add!(insn_map, mov, Mov_r64_rm64);
-        insn_add!(insn_map, mov, Mov_rm8_imm8);
-        insn_add!(insn_map, mov, Mov_rm8_r8);
-        insn_add!(insn_map, mov, Mov_rm16_imm16);
-        insn_add!(insn_map, mov, Mov_rm16_r16);
-        insn_add!(insn_map, mov, Mov_rm32_imm32);
-        insn_add!(insn_map, mov, Mov_rm32_r32);
-        insn_add!(insn_map, mov, Mov_rm64_imm32);
-        insn_add!(insn_map, mov, Mov_rm64_r64);
+    fn get_handler(code: Code) -> Option<Box<dyn InstructionHandler<T>>> {
+        let handler: Option<Box<dyn InstructionHandler<T>>> = gen_handler_match!(
+            code,
+            (mov, Mov_r8_rm8),
+            (mov, Mov_r8_imm8),
+            (mov, Mov_r16_imm16),
+            (mov, Mov_r16_rm16),
+            (mov, Mov_r32_imm32),
+            (mov, Mov_r32_rm32),
+            (mov, Mov_r64_imm64),
+            (mov, Mov_r64_rm64),
+            (mov, Mov_rm8_imm8),
+            (mov, Mov_rm8_r8),
+            (mov, Mov_rm16_imm16),
+            (mov, Mov_rm16_r16),
+            (mov, Mov_rm32_imm32),
+            (mov, Mov_rm32_r32),
+            (mov, Mov_rm64_imm32),
+            (mov, Mov_rm64_r64)
+        );
 
-        Emulator { platform, insn_map }
+        handler
     }
 
     fn emulate_insn_stream(
@@ -561,9 +576,7 @@ impl<'a, T: CpuStateManager> Emulator<'a, T> {
             }
 
             // Emulate the decoded instruction
-            self.insn_map
-                .instructions
-                .get(&insn.code())
+            Emulator::get_handler(insn.code())
                 .ok_or_else(|| {
                     EmulationError::UnsupportedInstruction(anyhow!(
                         "{:#x?} {:?} {:?}",


### PR DESCRIPTION
This allows the compiler to optimize it better. It also avoids the overhead of allocation and deallocation of the HashMap.