### PR TITLE
vmm: Don't continue to lookup debug I/O port

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -422,6 +422,7 @@ impl VmmOps for VmOps {
     fn pio_write(&self, addr: u64, data: &[u8]) -> hypervisor::vm::Result<()> {
         if addr == DEBUG_IOPORT as u64 && data.len() == 1 {
             self.log_debug_ioport(data[0]);
+            return Ok(());
         }
 
         if let Err(e) = self.io_bus.write(addr, data) {


### PR DESCRIPTION
When using an PIO write to 0x80 which is a special case handle that and
then return without going through the resolve.

This removes an extra warning that is reported.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>