### PR TITLE
Activate virtio devices via VMM thread

### DIFF
--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -93,8 +93,6 @@ impl BusDevice for AcpiGEDDevice {
         data[0] = self.notification_type.bits();
         self.notification_type = HotPlugNotificationFlags::NO_DEVICES_CHANGED;
     }
-
-    fn write(&mut self, _base: u64, _offset: u64, _data: &[u8]) {}
 }
 
 #[cfg(feature = "acpi")]
@@ -183,6 +181,4 @@ impl BusDevice for AcpiPMTimerDevice {
 
         data.copy_from_slice(&counter.to_le_bytes());
     }
-
-    fn write(&mut self, _base: u64, _offset: u64, _data: &[u8]) {}
 }

--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -4,7 +4,7 @@
 //
 
 use acpi_tables::{aml, aml::Aml};
-use std::sync::Arc;
+use std::sync::{Arc, Barrier};
 use std::time::Instant;
 use vm_device::interrupt::InterruptSourceGroup;
 use vm_device::BusDevice;
@@ -36,7 +36,7 @@ impl BusDevice for AcpiShutdownDevice {
         }
     }
 
-    fn write(&mut self, _base: u64, _offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, _offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         if data[0] == 1 {
             debug!("ACPI Reboot signalled");
             if let Err(e) = self.reset_evt.write(1) {
@@ -54,6 +54,7 @@ impl BusDevice for AcpiShutdownDevice {
                 error!("Error triggering ACPI shutdown event: {}", e);
             }
         }
+        None
     }
 }
 

--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -13,7 +13,7 @@ use super::interrupt_controller::{Error, InterruptController};
 use anyhow::anyhow;
 use byteorder::{ByteOrder, LittleEndian};
 use std::result;
-use std::sync::Arc;
+use std::sync::{Arc, Barrier};
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceConfig, InterruptSourceGroup,
     MsiIrqGroupConfig, MsiIrqSourceConfig,
@@ -167,7 +167,7 @@ impl BusDevice for Ioapic {
         LittleEndian::write_u32(data, value);
     }
 
-    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         assert!(data.len() == 4);
 
         debug!("IOAPIC_W @ offset 0x{:x}", offset);
@@ -181,6 +181,7 @@ impl BusDevice for Ioapic {
                 error!("IOAPIC: failed writing at offset {}", offset);
             }
         }
+        None
     }
 }
 

--- a/devices/src/legacy/fwdebug.rs
+++ b/devices/src/legacy/fwdebug.rs
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 //
 
+use std::sync::{Arc, Barrier};
 use vm_device::BusDevice;
 
 /// Provides firmware debug output via I/O port controls
@@ -30,11 +31,13 @@ impl BusDevice for FwDebugDevice {
         }
     }
 
-    fn write(&mut self, _base: u64, _offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, _offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         if data.len() == 1 {
             print!("{}", data[0] as char);
         } else {
             error!("Invalid write size on debug port: {}", data.len())
         }
+
+        None
     }
 }

--- a/devices/src/legacy/i8042.rs
+++ b/devices/src/legacy/i8042.rs
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
-use vmm_sys_util::eventfd::EventFd;
-
+use std::sync::{Arc, Barrier};
 use vm_device::BusDevice;
+use vmm_sys_util::eventfd::EventFd;
 
 /// A i8042 PS/2 controller that emulates just enough to shutdown the machine.
 pub struct I8042Device {
@@ -32,12 +32,14 @@ impl BusDevice for I8042Device {
         }
     }
 
-    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         if data.len() == 1 && data[0] == 0xfe && offset == 3 {
             debug!("i8042 reset signalled");
             if let Err(e) = self.reset_evt.write(1) {
                 error!("Error triggering i8042 reset event: {}", e);
             }
         }
+
+        None
     }
 }

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -9,7 +9,7 @@
 //! a real-time clock input.
 //!
 use std::fmt;
-use std::sync::Arc;
+use std::sync::{Arc, Barrier};
 use std::time::Instant;
 use std::{io, result};
 use vm_device::interrupt::InterruptSourceGroup;
@@ -371,7 +371,7 @@ impl BusDevice for RTC {
         }
     }
 
-    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         if data.len() <= 4 {
             let v = read_le_u32(&data[..]);
             if let Err(e) = self.handle_write(offset, v) {
@@ -384,6 +384,8 @@ impl BusDevice for RTC {
                 data.len()
             );
         }
+
+        None
     }
 }
 

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -7,7 +7,7 @@
 
 use anyhow::anyhow;
 use std::collections::VecDeque;
-use std::sync::Arc;
+use std::sync::{Arc, Barrier};
 use std::{io, result};
 use vm_device::interrupt::InterruptSourceGroup;
 use vm_device::BusDevice;
@@ -275,12 +275,14 @@ impl BusDevice for Serial {
         };
     }
 
-    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         if data.len() != 1 {
-            return;
+            return None;
         }
 
-        if let Err(_e) = self.handle_write(offset as u8, data[0]) {}
+        self.handle_write(offset as u8, data[0]).ok();
+
+        None
     }
 }
 

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -5,6 +5,7 @@
 use crate::configuration::{self, PciBarRegionType};
 use std::any::Any;
 use std::fmt::{self, Display};
+use std::sync::{Arc, Barrier};
 use std::{self, io, result};
 use vm_allocator::SystemAllocator;
 use vm_device::BusDevice;
@@ -63,7 +64,12 @@ pub trait PciDevice: BusDevice {
     /// Sets a register in the configuration space.
     /// * `reg_idx` - The index of the config register to modify.
     /// * `offset` - Offset in to the register.
-    fn write_config_register(&mut self, reg_idx: usize, offset: u64, data: &[u8]);
+    fn write_config_register(
+        &mut self,
+        reg_idx: usize,
+        offset: u64,
+        data: &[u8],
+    ) -> Option<Arc<Barrier>>;
     /// Gets a register from the configuration space.
     /// * `reg_idx` - The index of the config register to read.
     fn read_config_register(&mut self, reg_idx: usize) -> u32;
@@ -82,7 +88,9 @@ pub trait PciDevice: BusDevice {
     /// Writes to a BAR region mapped in to the device.
     /// * `addr` - The guest address inside the BAR.
     /// * `data` - The data to write.
-    fn write_bar(&mut self, _base: u64, _offset: u64, _data: &[u8]) {}
+    fn write_bar(&mut self, _base: u64, _offset: u64, _data: &[u8]) -> Option<Arc<Barrier>> {
+        None
+    }
     /// Relocates the BAR to a different address in guest address space.
     fn move_bar(&mut self, _old_base: u64, _new_base: u64) -> result::Result<(), io::Error> {
         Ok(())

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -15,7 +15,7 @@ use std::any::Any;
 use std::ops::Deref;
 use std::os::unix::io::AsRawFd;
 use std::ptr::null_mut;
-use std::sync::Arc;
+use std::sync::{Arc, Barrier};
 use std::{fmt, io, result};
 use vfio_bindings::bindings::vfio::*;
 use vfio_ioctls::{VfioDevice, VfioError};
@@ -652,8 +652,10 @@ impl BusDevice for VfioPciDevice {
         self.read_bar(base, offset, data)
     }
 
-    fn write(&mut self, base: u64, offset: u64, data: &[u8]) {
-        self.write_bar(base, offset, data)
+    fn write(&mut self, base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        self.write_bar(base, offset, data);
+
+        None
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -53,7 +53,7 @@ mod tests {
 
     const DEFAULT_TCP_LISTENER_MESSAGE: &str = "booted";
     const DEFAULT_TCP_LISTENER_PORT: u16 = 8000;
-    const DEFAULT_TCP_LISTENER_TIMEOUT: i32 = 40;
+    const DEFAULT_TCP_LISTENER_TIMEOUT: i32 = 80;
 
     struct Guest<'a> {
         tmp_dir: TempDir,

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -31,7 +31,7 @@ use std::io::Write;
 use std::num::Wrapping;
 use std::result;
 use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Barrier, Mutex};
 use vm_allocator::SystemAllocator;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceGroup, MsiIrqGroupConfig,
@@ -1018,8 +1018,9 @@ impl BusDevice for VirtioPciDevice {
         self.read_bar(base, offset, data)
     }
 
-    fn write(&mut self, base: u64, offset: u64, data: &[u8]) {
-        self.write_bar(base, offset, data)
+    fn write(&mut self, base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        self.write_bar(base, offset, data);
+        None
     }
 }
 

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -641,6 +641,30 @@ impl VirtioPciDevice {
     pub fn virtio_device(&self) -> Arc<Mutex<dyn VirtioDevice>> {
         self.device.clone()
     }
+
+    pub fn maybe_activate(&mut self) {
+        if self.needs_activation() {
+            if let Some(virtio_interrupt) = self.virtio_interrupt.take() {
+                if self.memory.is_some() {
+                    let mem = self.memory.as_ref().unwrap().clone();
+                    let mut device = self.device.lock().unwrap();
+                    device
+                        .activate(
+                            mem,
+                            virtio_interrupt,
+                            self.queues.clone(),
+                            self.queue_evts.split_off(0),
+                        )
+                        .expect("Failed to activate device");
+                    self.device_activated = true;
+                }
+            }
+        }
+    }
+
+    fn needs_activation(&self) -> bool {
+        !self.device_activated && self.is_driver_ready() && self.are_queues_valid()
+    }
 }
 
 impl VirtioTransport for VirtioPciDevice {
@@ -976,23 +1000,8 @@ impl PciDevice for VirtioPciDevice {
             _ => (),
         };
 
-        if !self.device_activated && self.is_driver_ready() && self.are_queues_valid() {
-            if let Some(virtio_interrupt) = self.virtio_interrupt.take() {
-                if self.memory.is_some() {
-                    let mem = self.memory.as_ref().unwrap().clone();
-                    let mut device = self.device.lock().unwrap();
-                    device
-                        .activate(
-                            mem,
-                            virtio_interrupt,
-                            self.queues.clone(),
-                            self.queue_evts.split_off(0),
-                        )
-                        .expect("Failed to activate device");
-                    self.device_activated = true;
-                }
-            }
-        }
+        // Try and activate the device if the driver status has changed
+        self.maybe_activate();
 
         // Device has been reset by the driver
         if self.device_activated && self.is_driver_init() {

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -617,18 +617,19 @@ impl VirtioPciDevice {
         }
     }
 
-    fn write_cap_pci_cfg(&mut self, offset: usize, data: &[u8]) {
+    fn write_cap_pci_cfg(&mut self, offset: usize, data: &[u8]) -> Option<Arc<Barrier>> {
         let cap_slice = self.cap_pci_cfg_info.cap.as_mut_slice();
         let data_len = data.len();
         let cap_len = cap_slice.len();
         if offset + data_len > cap_len {
             error!("Failed to write cap_pci_cfg to config space");
-            return;
+            return None;
         }
 
         if offset < std::mem::size_of::<VirtioPciCap>() {
             let (_, right) = cap_slice.split_at_mut(offset);
             right[..data_len].copy_from_slice(&data[..]);
+            None
         } else {
             // Safe since we know self.cap_pci_cfg_info.cap.cap.offset is 32bits long.
             let bar_offset: u32 =
@@ -733,7 +734,12 @@ impl VirtioInterrupt for VirtioInterruptMsix {
 }
 
 impl PciDevice for VirtioPciDevice {
-    fn write_config_register(&mut self, reg_idx: usize, offset: u64, data: &[u8]) {
+    fn write_config_register(
+        &mut self,
+        reg_idx: usize,
+        offset: u64,
+        data: &[u8],
+    ) -> Option<Arc<Barrier>> {
         // Handle the special case where the capability VIRTIO_PCI_CAP_PCI_CFG
         // is accessed. This capability has a special meaning as it allows the
         // guest to access other capabilities without mapping the PCI BAR.
@@ -743,10 +749,11 @@ impl PciDevice for VirtioPciDevice {
                 <= self.cap_pci_cfg_info.offset + self.cap_pci_cfg_info.cap.bytes().len()
         {
             let offset = base + offset as usize - self.cap_pci_cfg_info.offset;
-            self.write_cap_pci_cfg(offset, data);
+            self.write_cap_pci_cfg(offset, data)
         } else {
             self.configuration
                 .write_config_register(reg_idx, offset, data);
+            None
         }
     }
 
@@ -925,7 +932,7 @@ impl PciDevice for VirtioPciDevice {
         }
     }
 
-    fn write_bar(&mut self, _base: u64, offset: u64, data: &[u8]) {
+    fn write_bar(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         match offset {
             o if o < COMMON_CONFIG_BAR_OFFSET + COMMON_CONFIG_SIZE => self.common_config.write(
                 o - COMMON_CONFIG_BAR_OFFSET,
@@ -1006,6 +1013,8 @@ impl PciDevice for VirtioPciDevice {
                 self.common_config.driver_status = crate::DEVICE_FAILED as u8;
             }
         }
+
+        None
     }
 
     fn as_any(&mut self) -> &mut dyn Any {
@@ -1019,8 +1028,7 @@ impl BusDevice for VirtioPciDevice {
     }
 
     fn write(&mut self, base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
-        self.write_bar(base, offset, data);
-        None
+        self.write_bar(base, offset, data)
     }
 }
 

--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -231,13 +231,13 @@ impl Bus {
     /// Writes `data` to the device that owns the range containing `addr`.
     ///
     /// Returns true on success, otherwise `data` is untouched.
-    pub fn write(&self, addr: u64, data: &[u8]) -> Result<()> {
+    pub fn write(&self, addr: u64, data: &[u8]) -> Result<Option<Arc<Barrier>>> {
         if let Some((base, offset, dev)) = self.resolve(addr) {
             // OK to unwrap as lock() failing is a serious error condition and should panic.
-            dev.lock()
+            Ok(dev
+                .lock()
                 .expect("Failed to acquire device lock")
-                .write(base, offset, data);
-            Ok(())
+                .write(base, offset, data))
         } else {
             Err(Error::MissingAddressRange)
         }

--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -9,7 +9,7 @@
 
 use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
 use std::collections::btree_map::BTreeMap;
-use std::sync::{Arc, Mutex, RwLock, Weak};
+use std::sync::{Arc, Barrier, Mutex, RwLock, Weak};
 use std::{convert, error, fmt, io, result};
 
 /// Trait for devices that respond to reads or writes in an arbitrary address space.
@@ -21,7 +21,9 @@ pub trait BusDevice: Send {
     /// Reads at `offset` from this device
     fn read(&mut self, base: u64, offset: u64, data: &mut [u8]) {}
     /// Writes at `offset` into this device
-    fn write(&mut self, base: u64, offset: u64, data: &[u8]) {}
+    fn write(&mut self, base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        None
+    }
     /// Triggers the `irq_mask` interrupt on this device
     fn interrupt(&self, irq_mask: u32) {}
 }
@@ -257,10 +259,12 @@ mod tests {
             }
         }
 
-        fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
+        fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
             for (i, v) in data.iter().enumerate() {
                 assert_eq!(*v, (offset as u8) + (i as u8))
             }
+
+            None
         }
     }
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -446,7 +446,7 @@ impl BusDevice for CpuManager {
         }
     }
 
-    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         match offset {
             CPU_SELECTION_OFFSET => {
                 self.selected_cpu = data[0];
@@ -478,6 +478,7 @@ impl BusDevice for CpuManager {
                 );
             }
         }
+        None
     }
 }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -68,7 +68,7 @@ use std::os::unix::fs::OpenOptionsExt;
 #[cfg(feature = "kvm")]
 use std::os::unix::io::FromRawFd;
 use std::result;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Barrier, Mutex};
 #[cfg(feature = "kvm")]
 use vfio_ioctls::{VfioContainer, VfioDevice, VfioDmaMapping};
 use virtio_devices::transport::VirtioPciDevice;
@@ -3551,7 +3551,7 @@ impl BusDevice for DeviceManager {
         )
     }
 
-    fn write(&mut self, base: u64, offset: u64, data: &[u8]) {
+    fn write(&mut self, base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         match offset {
             B0EJ_FIELD_OFFSET => {
                 assert!(data.len() == B0EJ_FIELD_SIZE);
@@ -3577,7 +3577,9 @@ impl BusDevice for DeviceManager {
         debug!(
             "PCI_HP_REG_W: base 0x{:x}, offset 0x{:x}, data {:?}",
             base, offset, data
-        )
+        );
+
+        None
     }
 }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -131,6 +131,10 @@ pub enum Error {
     /// Cannot apply seccomp filter
     #[error("Error applying seccomp filter: {0}")]
     ApplySeccompFilter(seccomp::Error),
+
+    /// Error activating virtio devices
+    #[error("Error activating virtio devices: {0:?}")]
+    ActivateVirtioDevices(VmError),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -140,6 +144,7 @@ pub enum EpollDispatch {
     Reset,
     Stdin,
     Api,
+    ActivateVirtioDevices,
 }
 
 pub struct EpollContext {
@@ -281,6 +286,7 @@ pub struct Vmm {
     vm_config: Option<Arc<Mutex<VmConfig>>>,
     seccomp_action: SeccompAction,
     hypervisor: Arc<dyn hypervisor::Hypervisor>,
+    activate_evt: EventFd,
 }
 
 impl Vmm {
@@ -293,6 +299,7 @@ impl Vmm {
         let mut epoll = EpollContext::new().map_err(Error::Epoll)?;
         let exit_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?;
         let reset_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?;
+        let activate_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?;
 
         if unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0 {
             epoll.add_stdin().map_err(Error::Epoll)?;
@@ -304,6 +311,10 @@ impl Vmm {
 
         epoll
             .add_event(&reset_evt, EpollDispatch::Reset)
+            .map_err(Error::Epoll)?;
+
+        epoll
+            .add_event(&activate_evt, EpollDispatch::ActivateVirtioDevices)
             .map_err(Error::Epoll)?;
 
         epoll
@@ -320,6 +331,7 @@ impl Vmm {
             vm_config: None,
             seccomp_action,
             hypervisor,
+            activate_evt,
         })
     }
 
@@ -328,6 +340,10 @@ impl Vmm {
         if self.vm.is_none() {
             let exit_evt = self.exit_evt.try_clone().map_err(VmError::EventFdClone)?;
             let reset_evt = self.reset_evt.try_clone().map_err(VmError::EventFdClone)?;
+            let activate_evt = self
+                .activate_evt
+                .try_clone()
+                .map_err(VmError::EventFdClone)?;
 
             if let Some(ref vm_config) = self.vm_config {
                 let vm = Vm::new(
@@ -336,6 +352,7 @@ impl Vmm {
                     reset_evt,
                     &self.seccomp_action,
                     self.hypervisor.clone(),
+                    activate_evt,
                 )?;
                 self.vm = Some(vm);
             }
@@ -397,6 +414,10 @@ impl Vmm {
 
         let exit_evt = self.exit_evt.try_clone().map_err(VmError::EventFdClone)?;
         let reset_evt = self.reset_evt.try_clone().map_err(VmError::EventFdClone)?;
+        let activate_evt = self
+            .activate_evt
+            .try_clone()
+            .map_err(VmError::EventFdClone)?;
 
         let vm = Vm::new_from_snapshot(
             &snapshot,
@@ -406,6 +427,7 @@ impl Vmm {
             restore_cfg.prefault,
             &self.seccomp_action,
             self.hypervisor.clone(),
+            activate_evt,
         )?;
         self.vm = Some(vm);
 
@@ -443,6 +465,10 @@ impl Vmm {
 
             let exit_evt = self.exit_evt.try_clone().map_err(VmError::EventFdClone)?;
             let reset_evt = self.reset_evt.try_clone().map_err(VmError::EventFdClone)?;
+            let activate_evt = self
+                .activate_evt
+                .try_clone()
+                .map_err(VmError::EventFdClone)?;
 
             // The Linux kernel fires off an i8042 reset after doing the ACPI reset so there may be
             // an event sitting in the shared reset_evt. Without doing this we get very early reboots
@@ -456,6 +482,7 @@ impl Vmm {
                 reset_evt,
                 &self.seccomp_action,
                 self.hypervisor.clone(),
+                activate_evt,
             )?);
         }
 
@@ -676,6 +703,10 @@ impl Vmm {
         let reset_evt = self.reset_evt.try_clone().map_err(|e| {
             MigratableError::MigrateReceive(anyhow!("Error cloning reset EventFd: {}", e))
         })?;
+        let activate_evt = self.activate_evt.try_clone().map_err(|e| {
+            MigratableError::MigrateReceive(anyhow!("Error cloning activate EventFd: {}", e))
+        })?;
+
         self.vm_config = Some(Arc::new(Mutex::new(config)));
         let vm = Vm::new_from_migration(
             self.vm_config.clone().unwrap(),
@@ -683,6 +714,7 @@ impl Vmm {
             reset_evt,
             &self.seccomp_action,
             self.hypervisor.clone(),
+            activate_evt,
         )
         .map_err(|e| {
             MigratableError::MigrateReceive(anyhow!("Error creating VM from snapshot: {:?}", e))
@@ -1064,6 +1096,13 @@ impl Vmm {
                             if let Some(ref vm) = self.vm {
                                 vm.handle_stdin().map_err(Error::Stdin)?;
                             }
+                        }
+                        EpollDispatch::ActivateVirtioDevices => {
+                            if let Some(ref vm) = self.vm {
+                                vm.activate_virtio_devices()
+                                    .map_err(Error::ActivateVirtioDevices)?;
+                            }
+                            self.activate_evt.read().map_err(Error::EventFdRead)?;
                         }
                         EpollDispatch::Api => {
                             // Consume the event.

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -26,7 +26,7 @@ use std::ops::Deref;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::PathBuf;
 use std::result;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Barrier, Mutex};
 use url::Url;
 #[cfg(target_arch = "x86_64")]
 use vm_allocator::GsiApic;
@@ -314,7 +314,7 @@ impl BusDevice for MemoryManager {
         }
     }
 
-    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         match offset {
             SELECTION_OFFSET => {
                 self.selected_slot = usize::from(data[0]);
@@ -340,7 +340,8 @@ impl BusDevice for MemoryManager {
                     offset
                 );
             }
-        }
+        };
+        None
     }
 }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -400,11 +400,19 @@ impl VmmOps for VmOps {
     }
 
     fn mmio_write(&self, addr: u64, data: &[u8]) -> hypervisor::vm::Result<()> {
-        if let Err(e) = self.mmio_bus.write(addr, data) {
-            if let vm_device::BusError::MissingAddressRange = e {
-                warn!("Guest MMIO write to unregistered address 0x{:x}", addr);
+        match self.mmio_bus.write(addr, data) {
+            Err(e) => {
+                if let vm_device::BusError::MissingAddressRange = e {
+                    warn!("Guest MMIO write to unregistered address 0x{:x}", addr);
+                }
             }
-        }
+            Ok(Some(barrier)) => {
+                info!("Waiting for barrier");
+                barrier.wait();
+                info!("Barrier released");
+            }
+            _ => {}
+        };
         Ok(())
     }
 
@@ -425,11 +433,19 @@ impl VmmOps for VmOps {
             return Ok(());
         }
 
-        if let Err(e) = self.io_bus.write(addr, data) {
-            if let vm_device::BusError::MissingAddressRange = e {
-                warn!("Guest PIO write to unregistered address 0x{:x}", addr);
+        match self.io_bus.write(addr, data) {
+            Err(e) => {
+                if let vm_device::BusError::MissingAddressRange = e {
+                    warn!("Guest PIO write to unregistered address 0x{:x}", addr);
+                }
             }
-        }
+            Ok(Some(barrier)) => {
+                info!("Waiting for barrier");
+                barrier.wait();
+                info!("Barrier released");
+            }
+            _ => {}
+        };
         Ok(())
     }
 }


### PR DESCRIPTION
If a virtio device needs activation (because the device status field has been updated) signal to the VMM thread that there is a device that can be activated via an EventFd. Since the device must be ready when the write to the configuration register is completed use a barrier so that the CPU thread will wait until the VMM thread activates the device. This ensures that from the guest perspective the device is activated synchronously by the write that it made to the status register.

Fixes: #1863

This is based on an earlier PR: #1953 that didn't correctly handle the required synchronous behaviour.