### PR TITLE
build: Fix cargo fuzz build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,6 @@ clap = { version = "2.33.3", features = ["wrap_help"] }
 # List of patched crates
 [patch.'https://github.com/rust-vmm/vhost']
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "ch", package = "vhost", features = ["vhost-user-master", "vhost-user-slave"] }
-[patch.'https://github.com/rust-vmm/kvm-ioctls']
-kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "ch" }
-[patch.'https://github.com/rust-vmm/kvm-bindings']
-kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch", features = ["with-serde", "fam-wrappers"] }
 
 [dev-dependencies]
 ssh2 = "0.9.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,4 +1,3 @@
-
 [package]
 name = "cloud-hypervisor-fuzz"
 version = "0.0.0"
@@ -10,7 +9,6 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master" }
 libc = "0.2.72"
 libfuzzer-sys = "0.3"
 qcow = { path = "../qcow" }
@@ -22,11 +20,6 @@ vm-memory = "0.4.0"
 
 [dependencies.cloud-hypervisor]
 path = ".."
-
-[patch.'https://github.com/rust-vmm/kvm-ioctls']
-kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "ch" }
-[patch.'https://github.com/rust-vmm/kvm-bindings']
-kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch", features = ["with-serde", "fam-wrappers"] }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -13,8 +13,8 @@ anyhow = "1.0"
 thiserror = "1.0"
 libc = "0.2.80"
 log = "0.4.11"
-kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master" }
-kvm-bindings = { git = "https://github.com/rust-vmm/kvm-bindings", branch = "master", features = ["with-serde", "fam-wrappers"] }
+kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "ch" }
+kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch", features = ["with-serde", "fam-wrappers"] }
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"


### PR DESCRIPTION
Unfortunately it seems patch entries are ignored when obtaining
dependencies from another workspace.

Remove the problematic kvm-ioctls and kvm-bindings patch entries and use
the forked repository directly.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>