### PR TITLE
hypervisor: emulator: emulate CMP

### DIFF
--- a/hypervisor/src/arch/emulator/mod.rs
+++ b/hypervisor/src/arch/emulator/mod.rs
@@ -52,6 +52,9 @@ pub enum PlatformError {
 
     #[error("Unsupported CPU Mode: {0}")]
     UnsupportedCpuMode(#[source] anyhow::Error),
+
+    #[error("Invalid instruction operand: {0}")]
+    InvalidOperand(#[source] anyhow::Error),
 }
 
 #[derive(Error, Debug)]

--- a/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
@@ -14,23 +14,10 @@ extern crate iced_x86;
 
 use crate::arch::emulator::{EmulationError, PlatformEmulator};
 use crate::arch::x86::emulator::instructions::*;
+use crate::arch::x86::regs::*;
 use crate::arch::x86::Exception;
 
 // CMP affects OF, SF, ZF, AF, PF and CF
-const CF_SHIFT: usize = 0;
-const PF_SHIFT: usize = 2;
-const AF_SHIFT: usize = 4;
-const ZF_SHIFT: usize = 6;
-const SF_SHIFT: usize = 7;
-const OF_SHIFT: usize = 11;
-
-const CF: u64 = 1 << CF_SHIFT;
-const PF: u64 = 1 << PF_SHIFT;
-const AF: u64 = 1 << AF_SHIFT;
-const ZF: u64 = 1 << ZF_SHIFT;
-const SF: u64 = 1 << SF_SHIFT;
-const OF: u64 = 1 << OF_SHIFT;
-
 const FLAGS_MASK: u64 = CF | PF | AF | ZF | SF | OF;
 
 // TODO: Switch to inline asm when that's stable. Executing CMP (or any arthimetic instructions)

--- a/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
@@ -1,0 +1,380 @@
+//
+// Copyright © 2020 Microsoft
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#![allow(non_camel_case_types)]
+
+//
+// CMP-Compare Two Operands
+//
+
+extern crate iced_x86;
+
+use crate::arch::emulator::{EmulationError, PlatformEmulator};
+use crate::arch::x86::emulator::instructions::*;
+use crate::arch::x86::Exception;
+
+// CMP affects OF, SF, ZF, AF, PF and CF
+const CF_SHIFT: usize = 0;
+const PF_SHIFT: usize = 2;
+const AF_SHIFT: usize = 4;
+const ZF_SHIFT: usize = 6;
+const SF_SHIFT: usize = 7;
+const OF_SHIFT: usize = 11;
+
+const CF: u64 = 1 << CF_SHIFT;
+const PF: u64 = 1 << PF_SHIFT;
+const AF: u64 = 1 << AF_SHIFT;
+const ZF: u64 = 1 << ZF_SHIFT;
+const SF: u64 = 1 << SF_SHIFT;
+const OF: u64 = 1 << OF_SHIFT;
+
+const FLAGS_MASK: u64 = CF | PF | AF | ZF | SF | OF;
+
+// TODO: Switch to inline asm when that's stable. Executing CMP (or any arthimetic instructions)
+// natively and extracting RFLAGS will be much faster and make the code simpler.
+fn calc_rflags_cpazso(op0: u64, op1: u64, op_size: usize) -> u64 {
+    let op_bits = op_size * 8;
+    let msb_shift = op_bits - 1;
+    // CMP is the same as SUB.
+    let result = op0.wrapping_sub(op1);
+
+    // Carry-out vector for SUB.
+    let cout = (!op0 & op1) | ((!op0 ^ op1) & result);
+
+    let cf = ((cout >> msb_shift) & 0x1) << CF_SHIFT;
+
+    // PF only needs the least significant byte. XOR its higher 4 bits with its lower 4 bits then
+    // use the value directly.
+    let pf = ((0x9669 >> ((result ^ (result >> 4)) & 0xf)) & 0x1) << PF_SHIFT;
+
+    // AF cares about the lowest 4 bits (nibble). msb_shift is 3 in this case.
+    let af = ((cout >> 3) & 0x1) << AF_SHIFT;
+
+    let zf = if result & (!0u64 >> (63 - msb_shift)) == 0 {
+        1
+    } else {
+        0
+    } << ZF_SHIFT;
+
+    let sf = ((result >> msb_shift) & 0x1) << SF_SHIFT;
+
+    // Overflow happens when two operands have the same sign but the result has a different sign.
+    let of = ((((op0 ^ op1) & (op0 ^ result)) >> msb_shift) & 0x1) << OF_SHIFT;
+
+    cf | pf | af | zf | sf | of
+}
+
+macro_rules! cmp_rm_r {
+    ($bound:ty) => {
+        fn emulate(
+            &self,
+            insn: &Instruction,
+            state: &mut T,
+            platform: &mut dyn PlatformEmulator<CpuState = T>,
+        ) -> Result<(), EmulationError<Exception>> {
+            let op0_value = get_op(&insn, 0, std::mem::size_of::<$bound>(), state, platform)
+                .map_err(EmulationError::PlatformEmulationError)?;
+            let op1_value = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
+                .map_err(EmulationError::PlatformEmulationError)?;
+
+            let cpazso = calc_rflags_cpazso(op0_value, op1_value, std::mem::size_of::<$bound>());
+
+            state.set_flags((state.flags() & !FLAGS_MASK) | cpazso);
+
+            state.set_ip(insn.ip());
+
+            Ok(())
+        }
+    };
+}
+
+macro_rules! cmp_r_rm {
+    ($bound:ty) => {
+        fn emulate(
+            &self,
+            insn: &Instruction,
+            state: &mut T,
+            platform: &mut dyn PlatformEmulator<CpuState = T>,
+        ) -> Result<(), EmulationError<Exception>> {
+            let op0_value = get_op(&insn, 0, std::mem::size_of::<$bound>(), state, platform)
+                .map_err(EmulationError::PlatformEmulationError)?;
+            let op1_value = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
+                .map_err(EmulationError::PlatformEmulationError)?;
+
+            let cpazso = calc_rflags_cpazso(op0_value, op1_value, std::mem::size_of::<$bound>());
+
+            state.set_flags((state.flags() & !FLAGS_MASK) | cpazso);
+
+            state.set_ip(insn.ip());
+
+            Ok(())
+        }
+    };
+}
+
+macro_rules! cmp_rm_imm {
+    ($imm:ty, $bound:ty) => {
+        fn emulate(
+            &self,
+            insn: &Instruction,
+            state: &mut T,
+            platform: &mut dyn PlatformEmulator<CpuState = T>,
+        ) -> Result<(), EmulationError<Exception>> {
+            let op0_value = get_op(&insn, 0, std::mem::size_of::<$bound>(), state, platform)
+                .map_err(EmulationError::PlatformEmulationError)?;
+            let op1_value = get_op(&insn, 1, std::mem::size_of::<$imm>(), state, platform)
+                .map_err(EmulationError::PlatformEmulationError)?;
+
+            let cpazso = calc_rflags_cpazso(op0_value, op1_value, std::mem::size_of::<$bound>());
+
+            state.set_flags((state.flags() & !FLAGS_MASK) | cpazso);
+
+            state.set_ip(insn.ip());
+
+            Ok(())
+        }
+    };
+}
+
+pub struct Cmp_rm64_r64;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm64_r64 {
+    cmp_rm_r!(u64);
+}
+
+pub struct Cmp_rm32_r32;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm32_r32 {
+    cmp_rm_r!(u32);
+}
+
+pub struct Cmp_rm16_r16;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm16_r16 {
+    cmp_rm_r!(u16);
+}
+
+pub struct Cmp_rm8_r8;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm8_r8 {
+    cmp_rm_r!(u8);
+}
+
+pub struct Cmp_r64_rm64;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_r64_rm64 {
+    cmp_r_rm!(u64);
+}
+
+pub struct Cmp_r32_rm32;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_r32_rm32 {
+    cmp_r_rm!(u32);
+}
+
+pub struct Cmp_r16_rm16;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_r16_rm16 {
+    cmp_r_rm!(u16);
+}
+
+pub struct Cmp_r8_rm8;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_r8_rm8 {
+    cmp_r_rm!(u8);
+}
+
+pub struct Cmp_AL_imm8;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_AL_imm8 {
+    cmp_rm_imm!(u8, u8);
+}
+
+pub struct Cmp_AX_imm16;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_AX_imm16 {
+    cmp_rm_imm!(u16, u16);
+}
+
+pub struct Cmp_EAX_imm32;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_EAX_imm32 {
+    cmp_rm_imm!(u32, u32);
+}
+
+pub struct Cmp_RAX_imm32;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_RAX_imm32 {
+    cmp_rm_imm!(u32, u64);
+}
+
+pub struct Cmp_rm8_imm8;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm8_imm8 {
+    cmp_rm_imm!(u8, u8);
+}
+
+pub struct Cmp_rm16_imm16;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm16_imm16 {
+    cmp_rm_imm!(u16, u16);
+}
+
+pub struct Cmp_rm32_imm32;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm32_imm32 {
+    cmp_rm_imm!(u32, u32);
+}
+
+pub struct Cmp_rm64_imm32;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm64_imm32 {
+    cmp_rm_imm!(u32, u64);
+}
+
+pub struct Cmp_rm16_imm8;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm16_imm8 {
+    cmp_rm_imm!(u8, u16);
+}
+
+pub struct Cmp_rm32_imm8;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm32_imm8 {
+    cmp_rm_imm!(u8, u32);
+}
+
+pub struct Cmp_rm64_imm8;
+impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm64_imm8 {
+    cmp_rm_imm!(u8, u64);
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unused_mut)]
+
+    use super::*;
+    use crate::arch::x86::emulator::mock_vmm::*;
+
+    macro_rules! hashmap {
+        ($( $key: expr => $val: expr ),*) => {{
+            let mut map = ::std::collections::HashMap::new();
+            $( map.insert($key, $val); )*
+                map
+        }}
+    }
+
+    #[test]
+    // cmp ah,al
+    fn test_cmp_rm8_r8_1() -> MockResult {
+        let rax: u64 = 0x0;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0x38, 0xc4]; // cmp ah,al
+        let mut vmm = MockVMM::new(ip, hashmap![Register::RAX => rax], None);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+
+        let rflags: u64 = vmm.cpu_state(cpu_id).unwrap().flags() & FLAGS_MASK;
+        assert_eq!(0b1000100, rflags);
+
+        Ok(())
+    }
+
+    #[test]
+    // cmp eax,100
+    fn test_cmp_rm32_imm8_1() -> MockResult {
+        let rax: u64 = 0xabcdef;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0x83, 0xf8, 0x64]; // cmp eax,100
+        let mut vmm = MockVMM::new(ip, hashmap![Register::RAX => rax], None);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+
+        let rflags: u64 = vmm.cpu_state(cpu_id).unwrap().flags() & FLAGS_MASK;
+        assert_eq!(0b100, rflags);
+
+        Ok(())
+    }
+
+    #[test]
+    // cmp eax,-1
+    fn test_cmp_rm32_imm8_2() -> MockResult {
+        let rax: u64 = 0xabcdef;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0x83, 0xf8, 0xff]; // cmp eax,-1
+        let mut vmm = MockVMM::new(ip, hashmap![Register::RAX => rax], None);
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+
+        let rflags: u64 = vmm.cpu_state(cpu_id).unwrap().flags() & FLAGS_MASK;
+        assert_eq!(0b101, rflags);
+
+        Ok(())
+    }
+
+    #[test]
+    // cmp rax,rbx
+    fn test_cmp_rm64_r64() -> MockResult {
+        let rax: u64 = 0xabcdef;
+        let rbx: u64 = 0x1234;
+        let ip: u64 = 0x1000;
+        let cpu_id = 0;
+        let insn = [0x48, 0x39, 0xd8, 0x00, 0xc3]; // cmp rax,rbx + two bytes garbage
+        let mut vmm = MockVMM::new(
+            ip,
+            hashmap![Register::RAX => rax, Register::RBX => rbx],
+            None,
+        );
+        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+
+        let rflags: u64 = vmm.cpu_state(cpu_id).unwrap().flags() & FLAGS_MASK;
+        assert_eq!(0b100, rflags);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cmp_64() -> MockResult {
+        let data = [
+            (0xabcdef, 0x1234, 0b100),
+            (0x0, 0x101, 0b1001_0101),
+            (0x0, 0x8000_0000_0000_0000, 0b1000_1000_0101),
+            (0x1234abcd, 0x1234abcd, 0b100_0100),
+            (0x1234abcd, 0xdeadbeef, 0b1001_0101),
+            (0xffff_ffff_ffff_ffff, 0xdeadbeef, 0b1000_0000),
+            (0xffff_ffff_ffff_ffff, 0x0, 0b1000_0100),
+        ];
+
+        for d in data.iter() {
+            let rax = d.0;
+            let rbx = d.1;
+            let insn = [0x48, 0x39, 0xd8]; // cmp rax,rbx
+            let mut vmm = MockVMM::new(
+                0x1000,
+                hashmap![Register::RAX => rax, Register::RBX => rbx],
+                None,
+            );
+            assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+
+            let rflags: u64 = vmm.cpu_state(0).unwrap().flags() & FLAGS_MASK;
+            assert_eq!(d.2, rflags);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cmp_32() -> MockResult {
+        let data = [
+            (0xabcdef, 0x1234, 0b100),
+            (0x0, 0x101, 0b1001_0101),
+            (0x0, 0x8000_0000_0000_0000, 0b100_0100), // Same as cmp 0,0 due to truncation
+            (0x1234abcd, 0x1234abcd, 0b100_0100),
+            (0x1234abcd, 0xdeadbeef, 0b1_0101),
+            (0xffff_ffff_ffff_ffff, 0xdeadbeef, 0b0), // Same as cmp 0xffffffff,0xdeadbeef
+            (0xffff_ffff, 0x0, 0b1000_0100),
+        ];
+
+        for d in data.iter() {
+            let rax = d.0;
+            let rbx = d.1;
+            let insn = [0x39, 0xd8]; // cmp eax,ebx
+            let mut vmm = MockVMM::new(
+                0x1000,
+                hashmap![Register::RAX => rax, Register::RBX => rbx],
+                None,
+            );
+            assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+
+            let rflags: u64 = vmm.cpu_state(0).unwrap().flags() & FLAGS_MASK;
+            assert_eq!(d.2, rflags);
+        }
+
+        Ok(())
+    }
+}

--- a/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
@@ -241,14 +241,6 @@ mod tests {
     use super::*;
     use crate::arch::x86::emulator::mock_vmm::*;
 
-    macro_rules! hashmap {
-        ($( $key: expr => $val: expr ),*) => {{
-            let mut map = ::std::collections::HashMap::new();
-            $( map.insert($key, $val); )*
-                map
-        }}
-    }
-
     #[test]
     // cmp ah,al
     fn test_cmp_rm8_r8_1() -> MockResult {
@@ -256,7 +248,7 @@ mod tests {
         let ip: u64 = 0x1000;
         let cpu_id = 0;
         let insn = [0x38, 0xc4]; // cmp ah,al
-        let mut vmm = MockVMM::new(ip, hashmap![Register::RAX => rax], None);
+        let mut vmm = MockVMM::new(ip, vec![(Register::RAX, rax)], None);
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let rflags: u64 = vmm.cpu_state(cpu_id).unwrap().flags() & FLAGS_MASK;
@@ -272,7 +264,7 @@ mod tests {
         let ip: u64 = 0x1000;
         let cpu_id = 0;
         let insn = [0x83, 0xf8, 0x64]; // cmp eax,100
-        let mut vmm = MockVMM::new(ip, hashmap![Register::RAX => rax], None);
+        let mut vmm = MockVMM::new(ip, vec![(Register::RAX, rax)], None);
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let rflags: u64 = vmm.cpu_state(cpu_id).unwrap().flags() & FLAGS_MASK;
@@ -288,7 +280,7 @@ mod tests {
         let ip: u64 = 0x1000;
         let cpu_id = 0;
         let insn = [0x83, 0xf8, 0xff]; // cmp eax,-1
-        let mut vmm = MockVMM::new(ip, hashmap![Register::RAX => rax], None);
+        let mut vmm = MockVMM::new(ip, vec![(Register::RAX, rax)], None);
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let rflags: u64 = vmm.cpu_state(cpu_id).unwrap().flags() & FLAGS_MASK;
@@ -305,11 +297,7 @@ mod tests {
         let ip: u64 = 0x1000;
         let cpu_id = 0;
         let insn = [0x48, 0x39, 0xd8, 0x00, 0xc3]; // cmp rax,rbx + two bytes garbage
-        let mut vmm = MockVMM::new(
-            ip,
-            hashmap![Register::RAX => rax, Register::RBX => rbx],
-            None,
-        );
+        let mut vmm = MockVMM::new(ip, vec![(Register::RAX, rax), (Register::RBX, rbx)], None);
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let rflags: u64 = vmm.cpu_state(cpu_id).unwrap().flags() & FLAGS_MASK;
@@ -336,7 +324,7 @@ mod tests {
             let insn = [0x48, 0x39, 0xd8]; // cmp rax,rbx
             let mut vmm = MockVMM::new(
                 0x1000,
-                hashmap![Register::RAX => rax, Register::RBX => rbx],
+                vec![(Register::RAX, rax), (Register::RBX, rbx)],
                 None,
             );
             assert!(vmm.emulate_first_insn(0, &insn).is_ok());
@@ -366,7 +354,7 @@ mod tests {
             let insn = [0x39, 0xd8]; // cmp eax,ebx
             let mut vmm = MockVMM::new(
                 0x1000,
-                hashmap![Register::RAX => rax, Register::RBX => rbx],
+                vec![(Register::RAX, rax), (Register::RBX, rbx)],
                 None,
             );
             assert!(vmm.emulate_first_insn(0, &insn).is_ok());

--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -11,40 +11,6 @@ use crate::arch::x86::emulator::CpuStateManager;
 use crate::arch::x86::Exception;
 use iced_x86::*;
 
-macro_rules! imm_op {
-    (u8, $insn:ident) => {
-        $insn.immediate8()
-    };
-
-    (u16, $insn:ident) => {
-        $insn.immediate16()
-    };
-
-    (u32, $insn:ident) => {
-        $insn.immediate32()
-    };
-
-    (u64, $insn:ident) => {
-        $insn.immediate64()
-    };
-
-    (u32tou64, $insn:ident) => {
-        $insn.immediate32to64()
-    };
-
-    (u8tou16, $insn:ident) => {
-        $insn.immediate8to16()
-    };
-
-    (u8tou32, $insn:ident) => {
-        $insn.immediate8to32()
-    };
-
-    (u8tou64, $insn:ident) => {
-        $insn.immediate8to64()
-    };
-}
-
 pub mod mov;
 
 fn get_op<T: CpuStateManager>(

--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -11,6 +11,7 @@ use crate::arch::x86::emulator::CpuStateManager;
 use crate::arch::x86::Exception;
 use iced_x86::*;
 
+pub mod cmp;
 pub mod mov;
 
 fn get_op<T: CpuStateManager>(

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -216,14 +216,6 @@ mod tests {
     use super::*;
     use crate::arch::x86::emulator::mock_vmm::*;
 
-    macro_rules! hashmap {
-        ($( $key: expr => $val: expr ),*) => {{
-            let mut map = ::std::collections::HashMap::new();
-            $( map.insert($key, $val); )*
-                map
-        }}
-    }
-
     #[test]
     // mov rax,rbx
     fn test_mov_r64_r64() -> MockResult {
@@ -231,7 +223,7 @@ mod tests {
         let ip: u64 = 0x1000;
         let cpu_id = 0;
         let insn = [0x48, 0x89, 0xd8];
-        let mut vmm = MockVMM::new(ip, hashmap![Register::RBX => rbx], None);
+        let mut vmm = MockVMM::new(ip, vec![(Register::RBX, rbx)], None);
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let rax: u64 = vmm
@@ -251,7 +243,7 @@ mod tests {
         let ip: u64 = 0x1000;
         let cpu_id = 0;
         let insn = [0x48, 0xb8, 0x44, 0x33, 0x22, 0x11, 0x44, 0x33, 0x22, 0x11];
-        let mut vmm = MockVMM::new(ip, hashmap![], None);
+        let mut vmm = MockVMM::new(ip, vec![], None);
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let rax: u64 = vmm
@@ -273,11 +265,7 @@ mod tests {
         let cpu_id = 0;
         let memory: [u8; 8] = target_rax.to_le_bytes();
         let insn = [0x48, 0x8b, 0x04, 0x00];
-        let mut vmm = MockVMM::new(
-            ip,
-            hashmap![Register::RAX => rax],
-            Some((rax + rax, &memory)),
-        );
+        let mut vmm = MockVMM::new(ip, vec![(Register::RAX, rax)], Some((rax + rax, &memory)));
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         rax = vmm
@@ -297,7 +285,7 @@ mod tests {
         let ip: u64 = 0x1000;
         let cpu_id = 0;
         let insn = [0xb0, 0x11];
-        let mut vmm = MockVMM::new(ip, hashmap![], None);
+        let mut vmm = MockVMM::new(ip, vec![], None);
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let al = vmm
@@ -317,7 +305,7 @@ mod tests {
         let ip: u64 = 0x1000;
         let cpu_id = 0;
         let insn = [0xb8, 0x11, 0x00, 0x00, 0x00];
-        let mut vmm = MockVMM::new(ip, hashmap![], None);
+        let mut vmm = MockVMM::new(ip, vec![], None);
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let eax = vmm
@@ -337,7 +325,7 @@ mod tests {
         let ip: u64 = 0x1000;
         let cpu_id = 0;
         let insn = [0x48, 0xc7, 0xc0, 0x44, 0x33, 0x22, 0x11];
-        let mut vmm = MockVMM::new(ip, hashmap![], None);
+        let mut vmm = MockVMM::new(ip, vec![], None);
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
         let rax: u64 = vmm
@@ -360,7 +348,7 @@ mod tests {
         let insn = [0x88, 0x30];
         let mut vmm = MockVMM::new(
             ip,
-            hashmap![Register::RAX => rax, Register::DH => dh.into()],
+            vec![(Register::RAX, rax), (Register::DH, dh.into())],
             None,
         );
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
@@ -383,7 +371,7 @@ mod tests {
         let insn = [0x89, 0x30];
         let mut vmm = MockVMM::new(
             ip,
-            hashmap![Register::RAX => rax, Register::ESI => esi.into()],
+            vec![(Register::RAX, rax), (Register::ESI, esi.into())],
             None,
         );
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
@@ -407,7 +395,7 @@ mod tests {
         let insn = [0x89, 0x3c, 0x05, 0x01, 0x00, 0x00, 0x00];
         let mut vmm = MockVMM::new(
             ip,
-            hashmap![Register::RAX => rax, Register::EDI => edi.into()],
+            vec![(Register::RAX, rax), (Register::EDI, edi.into())],
             None,
         );
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
@@ -432,7 +420,7 @@ mod tests {
         let insn = [0x8b, 0x40, 0x10];
         let mut vmm = MockVMM::new(
             ip,
-            hashmap![Register::RAX => rax],
+            vec![(Register::RAX, rax)],
             Some((rax + displacement, &memory)),
         );
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
@@ -459,7 +447,7 @@ mod tests {
         let memory: [u8; 1] = al.to_le_bytes();
         let mut vmm = MockVMM::new(
             ip,
-            hashmap![Register::RAX => rax],
+            vec![(Register::RAX, rax)],
             Some((rax + displacement, &memory)),
         );
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
@@ -488,7 +476,7 @@ mod tests {
             0x48, 0xc7, 0xc0, 0x00, 0x01, 0x00, 0x00, // mov rax, 0x100
             0x48, 0x8b, 0x58, 0x10, // mov rbx, qword ptr [rax+10h]
         ];
-        let mut vmm = MockVMM::new(ip, hashmap![], Some((rax + displacement, &memory)));
+        let mut vmm = MockVMM::new(ip, vec![], Some((rax + displacement, &memory)));
         assert!(vmm.emulate_insn(cpu_id, &insn, Some(2)).is_ok());
 
         let rbx: u64 = vmm
@@ -516,7 +504,7 @@ mod tests {
             0x48, 0x8b, 0x58, 0x10, // mov rbx, qword ptr [rax+10h]
         ];
 
-        let mut vmm = MockVMM::new(ip, hashmap![], Some((rax + displacement, &memory)));
+        let mut vmm = MockVMM::new(ip, vec![], Some((rax + displacement, &memory)));
         // Only run the first instruction.
         assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
 
@@ -549,7 +537,7 @@ mod tests {
             0x48, 0xc7, 0xc0, 0x00, 0x02, 0x00, 0x00, // mov rax, 0x200
         ];
 
-        let mut vmm = MockVMM::new(ip, hashmap![], Some((rax + displacement, &memory)));
+        let mut vmm = MockVMM::new(ip, vec![], Some((rax + displacement, &memory)));
         // Run the 2 first instructions.
         assert!(vmm.emulate_insn(cpu_id, &insn, Some(2)).is_ok());
 

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -497,6 +497,12 @@ impl<'a, T: CpuStateManager> Emulator<'a, T> {
     fn get_handler(code: Code) -> Option<Box<dyn InstructionHandler<T>>> {
         let handler: Option<Box<dyn InstructionHandler<T>>> = gen_handler_match!(
             code,
+            // CMP
+            (cmp, Cmp_rm32_r32),
+            (cmp, Cmp_rm8_r8),
+            (cmp, Cmp_rm32_imm8),
+            (cmp, Cmp_rm64_r64),
+            // MOV
             (mov, Mov_r8_rm8),
             (mov, Mov_r8_imm8),
             (mov, Mov_r16_imm16),

--- a/hypervisor/src/arch/x86/regs.rs
+++ b/hypervisor/src/arch/x86/regs.rs
@@ -15,3 +15,18 @@ pub const CR0_PG: u64 = 0x80000000;
 // CR4 bits
 pub const CR4_PAE: u64 = 0x20;
 pub const CR4_LA57: u64 = 0x1000;
+
+// RFlags bits
+pub const CF_SHIFT: usize = 0;
+pub const PF_SHIFT: usize = 2;
+pub const AF_SHIFT: usize = 4;
+pub const ZF_SHIFT: usize = 6;
+pub const SF_SHIFT: usize = 7;
+pub const OF_SHIFT: usize = 11;
+
+pub const CF: u64 = 1 << CF_SHIFT;
+pub const PF: u64 = 1 << PF_SHIFT;
+pub const AF: u64 = 1 << AF_SHIFT;
+pub const ZF: u64 = 1 << ZF_SHIFT;
+pub const SF: u64 = 1 << SF_SHIFT;
+pub const OF: u64 = 1 << OF_SHIFT;


### PR DESCRIPTION
Unfortunately Rust stable does not yet have inline ASM support the flag
calculation will have to be implemented in software.

Signed-off-by: Wei Liu <liuwe@microsoft.com>