### PR TITLE
hypervisor: Move msr and msr_data macro to arch/x86

### DIFF
--- a/hypervisor/src/arch/mod.rs
+++ b/hypervisor/src/arch/mod.rs
@@ -14,4 +14,5 @@
 pub mod emulator;
 
 #[cfg(target_arch = "x86_64")]
+#[macro_use]
 pub mod x86;

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -122,3 +122,23 @@ pub fn segment_type_ro(t: u8) -> bool {
 pub fn segment_type_expand_down(t: u8) -> bool {
     !segment_type_code(t) && (t & EXPAND_DOWN_SEGMENT_TYPE != 0)
 }
+#[macro_export]
+macro_rules! msr {
+    ($msr:expr) => {
+        MsrEntry {
+            index: $msr,
+            data: 0x0,
+            ..Default::default()
+        }
+    };
+}
+#[macro_export]
+macro_rules! msr_data {
+    ($msr:expr, $data:expr) => {
+        MsrEntry {
+            index: $msr,
+            data: $data,
+            ..Default::default()
+        }
+    };
+}

--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -8,11 +8,10 @@
 //
 //
 
-use vm_memory::GuestAddress;
-
 use crate::arch::x86::{msr_index, SegmentRegisterOps, MTRR_ENABLE, MTRR_MEM_TYPE_WB};
 use crate::kvm::{Cap, Kvm, KvmError, KvmResult};
 use serde_derive::{Deserialize, Serialize};
+use vm_memory::GuestAddress;
 
 ///
 /// Export generically-named wrappers of kvm-bindings for Unix-based platforms
@@ -94,25 +93,6 @@ impl SegmentRegisterOps for SegmentRegister {
 }
 
 pub const KVM_TSS_ADDRESS: GuestAddress = GuestAddress(0xfffb_d000);
-
-macro_rules! msr {
-    ($msr:expr) => {
-        MsrEntry {
-            index: $msr,
-            data: 0x0,
-            ..Default::default()
-        }
-    };
-}
-macro_rules! msr_data {
-    ($msr:expr, $data:expr) => {
-        MsrEntry {
-            index: $msr,
-            data: $data,
-            ..Default::default()
-        }
-    };
-}
 
 pub fn boot_msr_entries() -> MsrEntries {
     MsrEntries::from_entries(&[

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -28,6 +28,10 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate thiserror;
 
+/// Architecture specific definitions
+#[macro_use]
+pub mod arch;
+
 #[cfg(feature = "kvm")]
 /// KVM implementation module
 pub mod kvm;
@@ -41,9 +45,6 @@ pub mod hypervisor;
 
 /// Vm related module
 pub mod vm;
-
-/// Architecture specific definitions
-pub mod arch;
 
 /// CPU related module
 mod cpu;

--- a/hypervisor/src/mshv/x86_64/mod.rs
+++ b/hypervisor/src/mshv/x86_64/mod.rs
@@ -49,15 +49,6 @@ pub enum IoEventAddress {
     /// Representation of an memory mapped I/O address.
     Mmio(u64),
 }
-macro_rules! msr {
-    ($msr:expr) => {
-        MsrEntry {
-            index: $msr,
-            data: 0x0,
-            ..Default::default()
-        }
-    };
-}
 
 impl SegmentRegisterOps for SegmentRegister {
     fn segment_type(&self) -> u8 {


### PR DESCRIPTION
Currently these two macros(msr, msr_data) reside both on kvm and mshv
module. Definition is same for both module. Moving them to arch/x86
module eliminates redundancy and makes more sense.

Signed-off-by: Muminul Islam <muislam@microsoft.com>