### PR TITLE
Add support for using TAP fd

### DIFF
--- a/docs/macvtap-bridge.md
+++ b/docs/macvtap-bridge.md
@@ -1,0 +1,32 @@
+# Using MACVTAP to Bridge onto Host Network
+
+Cloud Hypervisor supports using a MACVTAP device which is derived from a MACVLAN. Full details of configuring MACVLAN or MACVTAP is out of scope of this document. However the example below indicates how to bridge the guest directly onto the the network the host is on. Due to the lack of hairpin mode it not usually possible to reach the guest directly from the host.
+
+```bash
+# The MAC address must be attached to the macvtap and be used inside the guest
+mac="c2:67:4f:53:29:cb"
+# Host network adapter to bridge the guest onto
+host_net="eno1"
+
+# Create the macvtap0 as a new virtual MAC associated with the host network
+sudo ip link add link "$host_net" name macvtap0 type macvtap
+sudo ip link set macvtap0 address "$mac" up
+sudo ip link show macvtap0
+
+# A new character device is created for this interface
+tapindex=$(< /sys/class/net/macvtap0/ifindex)
+tapdevice="/dev/tap$tapindex"
+
+# Ensure that we can access this device
+sudo chown "$UID.$UID" "$tapdevice"
+
+# Use --net fd=3 to point to fd 3 which the shell has opened to point to the /dev/tapN device
+target/debug/cloud-hypervisor \
+	--kernel ~/src/linux/vmlinux \
+	--disk path=~/workloads/focal.raw \
+	--cpus boot=1 --memory size=512M \
+	--cmdline "root=/dev/vda1 console=hvc0" \
+    --net fd=3,mac=$mac 3<>$"$tapdevice"
+```
+
+As the guest is now connected to the same L2 network as the host you can obtain an IP address based on your host network (potentially including via DHCP)

--- a/net_util/src/open_tap.rs
+++ b/net_util/src/open_tap.rs
@@ -82,7 +82,7 @@ pub fn open_tap(
         let tap: Tap;
         if i == 0 {
             tap = match if_name {
-                Some(name) => Tap::open_named(name, num_rx_q).map_err(Error::TapOpen)?,
+                Some(name) => Tap::open_named(name, num_rx_q, None).map_err(Error::TapOpen)?,
                 None => Tap::new(num_rx_q).map_err(Error::TapOpen)?,
             };
             if let Some(ip) = ip_addr {
@@ -104,7 +104,7 @@ pub fn open_tap(
 
             ifname = String::from_utf8(tap.get_if_name()).unwrap();
         } else {
-            tap = Tap::open_named(ifname.as_str(), num_rx_q).map_err(Error::TapOpen)?;
+            tap = Tap::open_named(ifname.as_str(), num_rx_q, None).map_err(Error::TapOpen)?;
             tap.set_offload(flag).map_err(Error::TapSetOffload)?;
 
             tap.set_vnet_hdr_size(vnet_hdr_size)

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -5,7 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use super::{create_sockaddr, create_socket, Error as NetUtilError, MacAddr};
+use super::{create_sockaddr, create_socket, vnet_hdr_len, Error as NetUtilError, MacAddr};
 use mac::MAC_ADDR_LEN;
 use net_gen;
 use std::fs::File;
@@ -151,6 +151,50 @@ impl Tap {
     /// Create a new tap interface.
     pub fn new(num_queue_pairs: usize) -> Result<Tap> {
         Self::open_named("vmtap%d", num_queue_pairs, None)
+    }
+
+    pub fn from_tap_fd(fd: RawFd) -> Result<Tap> {
+        // Ensure that the file is opened non-blocking, this is particularly
+        // needed when opened via the shell for macvtap.
+        let ret = unsafe {
+            let mut flags = libc::fcntl(fd, libc::F_GETFL);
+            flags |= libc::O_NONBLOCK;
+            libc::fcntl(fd, libc::F_SETFL, flags)
+        };
+        if ret < 0 {
+            return Err(Error::ConfigureTap(IoError::last_os_error()));
+        }
+
+        let tap_file = unsafe { File::from_raw_fd(fd) };
+        let mut ifreq: net_gen::ifreq = Default::default();
+
+        // Get current config including name
+        let ret = unsafe { ioctl_with_mut_ref(&tap_file, net_gen::TUNGETIFF(), &mut ifreq) };
+        if ret < 0 {
+            return Err(Error::IoctlError(IoError::last_os_error()));
+        }
+        let if_name = unsafe { *ifreq.ifr_ifrn.ifrn_name.as_ref() }.to_vec();
+
+        // Try and update flags. Depending on how the tap was created (macvtap
+        // or via open_named()) this might return -EEXIST so we just ignore that.
+        unsafe {
+            let ifru_flags = ifreq.ifr_ifru.ifru_flags.as_mut();
+            *ifru_flags =
+                (net_gen::IFF_TAP | net_gen::IFF_NO_PI | net_gen::IFF_VNET_HDR) as c_short;
+        }
+        let ret = unsafe { ioctl_with_mut_ref(&tap_file, net_gen::TUNSETIFF(), &mut ifreq) };
+        if ret < 0 && IoError::last_os_error().raw_os_error().unwrap() != libc::EEXIST {
+            return Err(Error::ConfigureTap(IoError::last_os_error()));
+        }
+
+        let tap = Tap { if_name, tap_file };
+        let offload_flags =
+            net_gen::TUN_F_CSUM | net_gen::TUN_F_UFO | net_gen::TUN_F_TSO4 | net_gen::TUN_F_TSO6;
+        let vnet_hdr_size = vnet_hdr_len() as i32;
+        tap.set_offload(offload_flags)?;
+        tap.set_vnet_hdr_size(vnet_hdr_size)?;
+
+        Ok(tap)
     }
 
     /// Set the host-side IP address for the tap interface.
@@ -537,6 +581,13 @@ mod tests {
     fn test_tap_create() {
         let t = Tap::new(1).unwrap();
         println!("created tap: {:?}", t);
+    }
+
+    #[test]
+    fn test_tap_from_fd() {
+        let orig_tap = Tap::new(1).unwrap();
+        let fd = orig_tap.as_raw_fd();
+        let _new_tap = Tap::from_tap_fd(fd).unwrap();
     }
 
     #[test]

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -83,7 +83,7 @@ fn build_terminated_if_name(if_name: &str) -> Result<Vec<u8>> {
 }
 
 impl Tap {
-    pub fn open_named(if_name: &str, num_queue_pairs: usize) -> Result<Tap> {
+    pub fn open_named(if_name: &str, num_queue_pairs: usize, flags: Option<i32>) -> Result<Tap> {
         let terminated_if_name = build_terminated_if_name(if_name)?;
 
         let fd = unsafe {
@@ -91,7 +91,7 @@ impl Tap {
             // string and verify the result.
             libc::open(
                 b"/dev/net/tun\0".as_ptr() as *const c_char,
-                libc::O_RDWR | libc::O_NONBLOCK | libc::O_CLOEXEC,
+                flags.unwrap_or(libc::O_RDWR | libc::O_NONBLOCK | libc::O_CLOEXEC),
             )
         };
         if fd < 0 {
@@ -150,7 +150,7 @@ impl Tap {
 
     /// Create a new tap interface.
     pub fn new(num_queue_pairs: usize) -> Result<Tap> {
-        Self::open_named("vmtap%d", num_queue_pairs)
+        Self::open_named("vmtap%d", num_queue_pairs, None)
     }
 
     /// Set the host-side IP address for the tap interface.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5518,6 +5518,77 @@ mod tests {
 
             handle_child_output(r, &output);
         }
+
+        #[test]
+        fn test_tap_from_fd() {
+            let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+            let guest = Guest::new(&mut focal);
+
+            std::process::Command::new("bash")
+                .args(&["-c", "sudo ip tuntap add name chtap0 mode tap"])
+                .status()
+                .expect("Expected creating interface to work");
+
+            std::process::Command::new("bash")
+                .args(&[
+                    "-c",
+                    &format!("sudo ip addr add {}/24 dev chtap0", guest.network.host_ip),
+                ])
+                .status()
+                .expect("Expected programming interface to work");
+
+            std::process::Command::new("bash")
+                .args(&["-c", "sudo ip link set dev chtap0 up"])
+                .status()
+                .expect("Expected upping interface to work");
+
+            let mut workload_path = dirs::home_dir().unwrap();
+            workload_path.push("workloads");
+
+            let kernel_path = direct_kernel_boot_path().unwrap();
+
+            let tap = net_util::Tap::open_named("chtap0", 1, Some(libc::O_RDWR | libc::O_NONBLOCK))
+                .expect("Expect to be able to open tap");
+            let tap_fd = tap.as_raw_fd();
+
+            let mut child = GuestCommand::new(&guest)
+                .args(&["--cpus", "boot=1"])
+                .args(&["--memory", "size=512M"])
+                .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+                .default_disks()
+                .args(&[
+                    "--net",
+                    &format!("fd={},mac={}", tap_fd, guest.network.guest_mac),
+                ])
+                .capture_output()
+                .spawn()
+                .unwrap();
+
+            let r = std::panic::catch_unwind(|| {
+                guest.wait_vm_boot(None).unwrap();
+
+                assert_eq!(
+                    guest
+                        .ssh_command("ip -o link | wc -l")
+                        .unwrap_or_default()
+                        .trim()
+                        .parse::<u32>()
+                        .unwrap_or_default(),
+                    2
+                );
+            });
+
+            let _ = child.kill();
+            let output = child.wait_with_output().unwrap();
+
+            std::process::Command::new("bash")
+                .args(&["-c", "sudo ip tuntap del mode tap name chtap0"])
+                .status()
+                .expect("Expected upping interface to work");
+
+            handle_child_output(r, &output);
+        }
     }
 
     mod sequential {

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -652,6 +652,9 @@ components:
           type: string
         id:
           type: string
+        fd:
+          type: integer
+          format: int32
 
     RngConfig:
       required:

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1801,6 +1801,18 @@ impl DeviceManager {
                     )
                     .map_err(DeviceManagerError::CreateVirtioNet)?,
                 ))
+            } else if let Some(fd) = net_cfg.fd {
+                Arc::new(Mutex::new(
+                    virtio_devices::Net::from_tap_fd(
+                        id.clone(),
+                        fd,
+                        Some(net_cfg.mac),
+                        net_cfg.iommu,
+                        net_cfg.queue_size,
+                        self.seccomp_action.clone(),
+                    )
+                    .map_err(DeviceManagerError::CreateVirtioNet)?,
+                ))
             } else {
                 Arc::new(Mutex::new(
                     virtio_devices::Net::new(

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -51,6 +51,7 @@ const FIOCLEX: u64 = 0x5451;
 const FIONBIO: u64 = 0x5421;
 
 // See include/uapi/linux/if_tun.h in the kernel code.
+const TUNGETIFF: u64 = 0x8004_54d2;
 const TUNSETIFF: u64 = 0x4004_54ca;
 const TUNSETOFFLOAD: u64 = 0x4004_54d0;
 const TUNSETVNETHDRSZ: u64 = 0x4004_54d8;
@@ -155,6 +156,7 @@ fn create_vmm_ioctl_seccomp_rule_common() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, TCGETS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TIOCGWINSZ)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNGETFEATURES)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, TUNGETIFF)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETIFF)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETOFFLOAD)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETVNETHDRSZ)?],


### PR DESCRIPTION
Allow creating a network device using an existing fd for the TAP device. This opens up the possibility of using a MACVTAP with Cloud Hypervisor which is now documented.

Fixes: #872
Fixes: #2052

Ping: kata-containers/runtime#2846