### PR TITLE
hypervisor: Bump iced-x86 to 1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "iced-x86"
-version = "1.9.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248ce8ff0784d2b15f3c3d8b01f529be0e18aa693a2ba7415df76857967c8fc3"
+checksum = "b0be3ac4fec5cdbfd39a653e9145789e7a989359874da3cf2f18611468937767"
 dependencies = [
  "lazy_static",
  "rustc_version",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -32,7 +32,7 @@ git = "https://github.com/rust-vmm/linux-loader"
 features = ["elf", "bzimage"]
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]
-version = "1.9.1"
+version = "1.10"
 default-features = false
 features = ["std", "decoder", "op_code_info", "instr_info", "fast_fmt"]
 

--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -38,8 +38,14 @@ fn get_op<T: CpuStateManager>(
         }
     }
 
-    let value = match insn.op_kind(op_index) {
-        OpKind::Register => state.read_reg(insn.op_register(op_index))?,
+    let value = match insn
+        .try_op_kind(op_index)
+        .map_err(|e| PlatformError::InvalidOperand(e.into()))?
+    {
+        OpKind::Register => state.read_reg(
+            insn.try_op_register(op_index)
+                .map_err(|e| PlatformError::InvalidOperand(e.into()))?,
+        )?,
         OpKind::Memory => {
             let addr = memory_operand_address(insn, state, false)?;
             let mut memory: [u8; 8] = [0; 8];
@@ -85,8 +91,15 @@ fn set_op<T: CpuStateManager>(
         }
     }
 
-    match insn.op_kind(op_index) {
-        OpKind::Register => state.write_reg(insn.op_register(op_index), value)?,
+    match insn
+        .try_op_kind(op_index)
+        .map_err(|e| PlatformError::InvalidOperand(e.into()))?
+    {
+        OpKind::Register => state.write_reg(
+            insn.try_op_register(op_index)
+                .map_err(|e| PlatformError::InvalidOperand(e.into()))?,
+            value,
+        )?,
         OpKind::Memory => {
             let addr = memory_operand_address(insn, state, true)?;
             platform.write_memory(addr, &value.to_le_bytes()[..op_size])?;


### PR DESCRIPTION
And fix related warnings: op_kind and op_register are being deprecated
as they might panic.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>
Signed-off-by: Rob Bradford <robert.bradford@intel.com>