### PR TITLE
Minor integration test improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,8 +73,9 @@ impl log::Log for Logger {
         if record.file().is_some() && record.line().is_some() {
             writeln!(
                 *(*(self.output.lock().unwrap())),
-                "cloud-hypervisor: {:?}: {}:{}:{} -- {}",
+                "cloud-hypervisor: {:?}: <{}> {}:{}:{} -- {}",
                 duration,
+                std::thread::current().name().unwrap_or("anonymous"),
                 record.level(),
                 record.file().unwrap(),
                 record.line().unwrap(),
@@ -83,8 +84,9 @@ impl log::Log for Logger {
         } else {
             writeln!(
                 *(*(self.output.lock().unwrap())),
-                "cloud-hypervisor: {:?}: {}:{} -- {}",
+                "cloud-hypervisor: {:?}: <{}> {}:{} -- {}",
                 duration,
+                std::thread::current().name().unwrap_or("anonymous"),
                 record.level(),
                 record.target(),
                 record.args()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -95,7 +95,7 @@ mod tests {
     #[cfg(target_arch = "aarch64")]
     const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-arm64-custom";
 
-    const DIRECT_KERNEL_BOOT_CMDLINE: &str = "root=/dev/vda1 console=hvc0 quiet rw";
+    const DIRECT_KERNEL_BOOT_CMDLINE: &str = "root=/dev/vda1 console=hvc0 rw";
 
     const PIPE_SIZE: i32 = 32 << 20;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1250,7 +1250,11 @@ mod tests {
                 ),
             ])
             .args(&["--memory", "size=512M"])
-            .args(&["--kernel", guest.fw_path.as_str()])
+            .args(&[
+                "--kernel",
+                direct_kernel_boot_path().unwrap().to_str().unwrap(),
+            ])
+            .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .default_disks()
             .default_net()
             .capture_output()
@@ -1729,9 +1733,9 @@ mod tests {
             .args(&["--cpus", "boot=1"])
             .args(&["--memory", "size=512M,hotplug_size=2048M,shared=on"])
             .args(&["--kernel", kernel_path.to_str().unwrap()])
+            .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .default_disks()
             .default_net()
-            .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .args(&["--api-socket", &api_socket]);
 
         let fs_params = format!(
@@ -2324,13 +2328,14 @@ mod tests {
             let mut cmd = GuestCommand::new(&guest);
             cmd.args(&["--cpus", "boot=2,max=4"])
                 .args(&["--memory", "size=512M"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&[
+                    "--kernel",
+                    direct_kernel_boot_path().unwrap().to_str().unwrap(),
+                ])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .capture_output()
                 .default_raw_disks()
                 .default_net();
-
-            #[cfg(target_arch = "aarch64")]
-            cmd.args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE]);
 
             let mut child = cmd.spawn().unwrap();
 
@@ -2394,7 +2399,11 @@ mod tests {
             let mut child = GuestCommand::new(&guest)
                 .args(&["--cpus", &format!("max_phys_bits={}", max_phys_bits)])
                 .args(&["--memory", "size=512M"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&[
+                    "--kernel",
+                    direct_kernel_boot_path().unwrap().to_str().unwrap(),
+                ])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
                 .default_net()
                 .capture_output()
@@ -2427,16 +2436,16 @@ mod tests {
             let mut cmd = GuestCommand::new(&guest);
             cmd.args(&["--cpus", "boot=48"])
                 .args(&["--memory", "size=5120M"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&[
+                    "--kernel",
+                    direct_kernel_boot_path().unwrap().to_str().unwrap(),
+                ])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .args(&["--serial", "tty"])
                 .args(&["--console", "off"])
                 .capture_output()
                 .default_disks()
                 .default_net();
-
-            // Now AArch64 can only boot from direct kernel, command-line is needed.
-            #[cfg(target_arch = "aarch64")]
-            cmd.args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE]);
 
             let mut child = cmd.spawn().unwrap();
 
@@ -2459,14 +2468,14 @@ mod tests {
             let mut cmd = GuestCommand::new(&guest);
             cmd.args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=128G"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&[
+                    "--kernel",
+                    direct_kernel_boot_path().unwrap().to_str().unwrap(),
+                ])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .capture_output()
                 .default_disks()
                 .default_net();
-
-            // Now AArch64 can only boot from direct kernel, command-line is needed.
-            #[cfg(target_arch = "aarch64")]
-            cmd.args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE]);
 
             let mut child = cmd.spawn().unwrap();
 
@@ -2654,13 +2663,14 @@ mod tests {
             let mut cmd = GuestCommand::new(&guest);
             cmd.args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&[
+                    "--kernel",
+                    direct_kernel_boot_path().unwrap().to_str().unwrap(),
+                ])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .capture_output()
                 .default_disks()
                 .default_net();
-
-            #[cfg(target_arch = "aarch64")]
-            cmd.args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE]);
 
             let mut child = cmd.spawn().unwrap();
 
@@ -2703,9 +2713,9 @@ mod tests {
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
                 .default_net()
-                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .capture_output()
                 .spawn()
                 .unwrap();
@@ -2757,9 +2767,9 @@ mod tests {
                     .args(&["--cpus", "boot=1"])
                     .args(&["--memory", "size=512M"])
                     .args(&["--kernel", kernel_path.to_str().unwrap()])
+                    .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                     .default_disks()
                     .default_net()
-                    .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                     .args(&["--seccomp", "false"])
                     .capture_output()
                     .spawn()
@@ -2795,9 +2805,9 @@ mod tests {
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
                 .default_net()
-                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .capture_output()
                 .spawn()
                 .unwrap();
@@ -2841,9 +2851,9 @@ mod tests {
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
                 .default_net()
-                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .capture_output()
                 .spawn()
                 .unwrap();
@@ -3045,7 +3055,11 @@ mod tests {
             let mut child = GuestCommand::new(&guest)
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&[
+                    "--kernel",
+                    direct_kernel_boot_path().unwrap().to_str().unwrap(),
+                ])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
                 .default_net()
                 .capture_output()
@@ -3293,9 +3307,9 @@ mod tests {
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
                 .default_net()
-                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .args(&["--serial", "off"])
                 .capture_output()
                 .spawn()
@@ -3329,16 +3343,21 @@ mod tests {
             let mut cmd = GuestCommand::new(&guest);
             cmd.args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&[
+                    "--kernel",
+                    direct_kernel_boot_path().unwrap().to_str().unwrap(),
+                ])
+                .args(&[
+                    "--cmdline",
+                    DIRECT_KERNEL_BOOT_CMDLINE
+                        .replace("console=hvc0 ", "console=ttyS0")
+                        .as_str(),
+                ])
                 .default_disks()
                 .default_net()
                 .args(&["--serial", "null"])
                 .args(&["--console", "off"])
                 .capture_output();
-
-            // Now AArch64 can only boot from direct kernel, command-line is needed.
-            #[cfg(target_arch = "aarch64")]
-            cmd.args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE]);
 
             let mut child = cmd.spawn().unwrap();
 
@@ -3437,7 +3456,16 @@ mod tests {
             let mut child = GuestCommand::new(&guest)
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&[
+                    "--kernel",
+                    direct_kernel_boot_path().unwrap().to_str().unwrap(),
+                ])
+                .args(&[
+                    "--cmdline",
+                    DIRECT_KERNEL_BOOT_CMDLINE
+                        .replace("console=hvc0 ", "console=ttyS0")
+                        .as_str(),
+                ])
                 .default_disks()
                 .default_net()
                 .args(&[
@@ -3543,7 +3571,11 @@ mod tests {
             let mut child = GuestCommand::new(&guest)
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&[
+                    "--kernel",
+                    direct_kernel_boot_path().unwrap().to_str().unwrap(),
+                ])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
                 .default_net()
                 .args(&[
@@ -3835,12 +3867,12 @@ mod tests {
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .default_disks()
-                .default_net()
                 .args(&[
                     "--cmdline",
                     format!("{} acpi=off", DIRECT_KERNEL_BOOT_CMDLINE).as_str(),
                 ])
+                .default_disks()
+                .default_net()
                 .capture_output()
                 .spawn()
                 .unwrap();
@@ -3875,13 +3907,14 @@ mod tests {
                 let mut cmd = GuestCommand::new(&guest);
                 cmd.args(&["--cpus", "boot=1"])
                     .args(&["--memory", "size=512M"])
-                    .args(&["--kernel", guest.fw_path.as_str()])
+                    .args(&[
+                        "--kernel",
+                        direct_kernel_boot_path().unwrap().to_str().unwrap(),
+                    ])
+                    .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                     .default_raw_disks()
                     .default_net()
                     .capture_output();
-
-                #[cfg(target_arch = "aarch64")]
-                cmd.args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE]);
 
                 let mut child = cmd.spawn().unwrap();
 
@@ -3945,9 +3978,9 @@ mod tests {
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
                 .default_net()
-                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .capture_output()
                 .spawn()
                 .unwrap();
@@ -4155,6 +4188,7 @@ mod tests {
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .args(&[
                     "--disk",
                     format!(
@@ -4169,7 +4203,6 @@ mod tests {
                     .as_str(),
                 ])
                 .args(&["--net", guest.default_net_string_w_iommu().as_str()])
-                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .capture_output()
                 .spawn()
                 .unwrap();
@@ -4233,7 +4266,11 @@ mod tests {
             let mut child = GuestCommand::new(&guest)
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&[
+                    "--kernel",
+                    direct_kernel_boot_path().unwrap().to_str().unwrap(),
+                ])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
                 .args(&[
                     "--net",
@@ -4701,8 +4738,8 @@ mod tests {
                     format!("size={}K", guest_memory_size_kb).as_str(),
                 ])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .default_disks()
                 .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+                .default_disks()
                 .capture_output()
                 .spawn()
                 .unwrap();
@@ -5373,14 +5410,15 @@ mod tests {
             let mut cmd = GuestCommand::new(&guest);
             cmd.args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
-                .args(&["--kernel", guest.fw_path.as_str()])
+                .args(&[
+                    "--kernel",
+                    direct_kernel_boot_path().unwrap().to_str().unwrap(),
+                ])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
                 .args(&["--net", guest.default_net_string().as_str()])
                 .args(&["--api-socket", &api_socket])
                 .capture_output();
-
-            #[cfg(target_arch = "aarch64")]
-            cmd.args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE]);
 
             let mut child = cmd.spawn().unwrap();
 
@@ -5775,9 +5813,9 @@ mod tests {
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
                 .default_net()
-                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .args(&["--sgx-epc", "size=64M"])
                 .capture_output()
                 .spawn()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -95,7 +95,7 @@ mod tests {
     #[cfg(target_arch = "aarch64")]
     const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-arm64-custom";
 
-    const DIRECT_KERNEL_BOOT_CMDLINE: &str = "root=/dev/vda1 console=ttyS0 console=hvc0 quiet rw";
+    const DIRECT_KERNEL_BOOT_CMDLINE: &str = "root=/dev/vda1 console=hvc0 quiet rw";
 
     const PIPE_SIZE: i32 = 32 << 20;
 
@@ -3295,12 +3295,7 @@ mod tests {
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .default_disks()
                 .default_net()
-                .args(&[
-                    "--cmdline",
-                    DIRECT_KERNEL_BOOT_CMDLINE
-                        .replace("console=ttyS0 ", "")
-                        .as_str(),
-                ])
+                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .args(&["--serial", "off"])
                 .capture_output()
                 .spawn()
@@ -3389,7 +3384,12 @@ mod tests {
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+                .args(&[
+                    "--cmdline",
+                    DIRECT_KERNEL_BOOT_CMDLINE
+                        .replace("console=hvc0 ", "console=ttyS0")
+                        .as_str(),
+                ])
                 .default_disks()
                 .default_net()
                 .args(&["--serial", "tty"])

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -30,8 +30,8 @@ use std::cmp;
 use std::io::Write;
 use std::num::Wrapping;
 use std::result;
-use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
-use std::sync::{atomic::AtomicBool, Arc, Barrier, Mutex};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier, Mutex};
 use vm_allocator::SystemAllocator;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceGroup, MsiIrqGroupConfig,
@@ -668,9 +668,9 @@ impl VirtioPciDevice {
                         )
                         .expect("Failed to activate device");
                     self.device_activated.store(true, Ordering::SeqCst);
-                    info!("Waiting for barrier");
+                    info!("{}: Waiting for barrier", self.id);
                     self.activate_barrier.wait();
-                    info!("Barrier released");
+                    info!("{}: Barrier released", self.id);
                 }
             }
         }
@@ -1018,6 +1018,7 @@ impl PciDevice for VirtioPciDevice {
 
         // Try and activate the device if the driver status has changed
         if self.needs_activation() {
+            info!("{}: Needs activation; returning barrier", self.id);
             self.activate_evt.write(1).ok();
             return Some(self.activate_barrier.clone());
         }


### PR DESCRIPTION
Opt for using the faster (fewer KVM exits) virtio-console over serial and use direct boot for the majority of tests.