### PR TITLE
virtio-devices: pci: Improve debugging for activation barriers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,8 +73,9 @@ impl log::Log for Logger {
         if record.file().is_some() && record.line().is_some() {
             writeln!(
                 *(*(self.output.lock().unwrap())),
-                "cloud-hypervisor: {:?}: {}:{}:{} -- {}",
+                "cloud-hypervisor: {:?}: <{}> {}:{}:{} -- {}",
                 duration,
+                std::thread::current().name().unwrap_or("anonymous"),
                 record.level(),
                 record.file().unwrap(),
                 record.line().unwrap(),
@@ -83,8 +84,9 @@ impl log::Log for Logger {
         } else {
             writeln!(
                 *(*(self.output.lock().unwrap())),
-                "cloud-hypervisor: {:?}: {}:{} -- {}",
+                "cloud-hypervisor: {:?}: <{}> {}:{} -- {}",
                 duration,
+                std::thread::current().name().unwrap_or("anonymous"),
                 record.level(),
                 record.target(),
                 record.args()

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -30,8 +30,8 @@ use std::cmp;
 use std::io::Write;
 use std::num::Wrapping;
 use std::result;
-use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
-use std::sync::{atomic::AtomicBool, Arc, Barrier, Mutex};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier, Mutex};
 use vm_allocator::SystemAllocator;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceGroup, MsiIrqGroupConfig,
@@ -668,9 +668,9 @@ impl VirtioPciDevice {
                         )
                         .expect("Failed to activate device");
                     self.device_activated.store(true, Ordering::SeqCst);
-                    info!("Waiting for barrier");
+                    info!("{}: Waiting for barrier", self.id);
                     self.activate_barrier.wait();
-                    info!("Barrier released");
+                    info!("{}: Barrier released", self.id);
                 }
             }
         }
@@ -1018,6 +1018,7 @@ impl PciDevice for VirtioPciDevice {
 
         // Try and activate the device if the driver status has changed
         if self.needs_activation() {
+            info!("{}: Needs activation; returning barrier", self.id);
             self.activate_evt.write(1).ok();
             return Some(self.activate_barrier.clone());
         }


### PR DESCRIPTION
On the CI we are seeing issues with the activation barriers not being released:

cloud-hypervisor: 12.452434193s: INFO:vmm/src/vm.rs:413 -- Waiting for barrier
cloud-hypervisor: 12.452499794s: INFO:virtio-devices/src/block.rs:382 -- Changing cache mode to writeback
cloud-hypervisor: 12.452605195s: INFO:vmm/src/vm.rs:413 -- Waiting for barrier
cloud-hypervisor: 12.452684596s: INFO:virtio-devices/src/transport/pci_device.rs:671 -- Waiting for barrier
cloud-hypervisor: 12.452708196s: INFO:virtio-devices/src/transport/pci_device.rs:673 -- Barrier released
cloud-hypervisor: 12.452717596s: INFO:vmm/src/vm.rs:415 -- Barrier released

Add some debugging to try and identify the vause of this issue.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>