### PR TITLE
hypervisor: drop linux-loader dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,6 @@ dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
- "linux-loader",
  "log 0.4.11",
  "mshv-bindings",
  "mshv-ioctls",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -27,10 +27,6 @@ serde_json = ">=1.0.9"
 vm-memory = { version = "0.4.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = ">=0.5.0", features = ["with-serde"] }
 
-[dependencies.linux-loader]
-git = "https://github.com/rust-vmm/linux-loader"
-features = ["elf", "bzimage"]
-
 [target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]
 version = "1.10"
 default-features = false


### PR DESCRIPTION
It is not used anywhere inside the hypervisor crate.

Signed-off-by: Wei Liu <liuwe@microsoft.com>