### PR TITLE
vmm: seccomp: Allow clock_gettime() on the vCPU thread

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -409,6 +409,7 @@ fn vcpu_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
     Ok(vec![
         allow_syscall(libc::SYS_accept4),
         allow_syscall(libc::SYS_brk),
+        allow_syscall(libc::SYS_clock_gettime),
         allow_syscall(libc::SYS_clock_nanosleep),
         allow_syscall(libc::SYS_clone),
         allow_syscall(libc::SYS_close),


### PR DESCRIPTION
If the vCPU thread calls log!() the time difference between the call
time and the boot up time is reported. On most environments and
architectures this covered by a vDSO call rather than a syscall. However
on some platforms this turns into a syscall.

Fixes: #2080

Signed-off-by: Rob Bradford <robert.bradford@intel.com>