### PR TITLE
Temporarily disable flaky tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,14 +168,6 @@ pipeline{
 								sh "scripts/dev_cli.sh tests --integration-windows"
 							}
 						}
-						stage ('Run Windows guest integration tests for musl') {
-							options {
-								timeout(time: 1, unit: 'HOURS')
-							}
-							steps {
-								sh "scripts/dev_cli.sh tests --integration-windows --libc musl"
-							}
-						}
 					}
 				}
 			}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5443,7 +5443,9 @@ mod tests {
             handle_child_output(r, &output);
         }
 
+        // Temporarily limited to x86_64 - see #2103
         #[test]
+        #[cfg(target_arch = "x86_64")]
         fn test_watchdog() {
             let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
             let guest = Guest::new(&mut focal);

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -94,9 +94,9 @@ impl NetEpollHandler {
             || !self.driver_awake
         {
             self.signal_used_queue(&self.queue_pair[0])?;
-            info!("Signalling RX queue");
+            debug!("Signalling RX queue");
         } else {
-            info!("Not signalling RX queue");
+            debug!("Not signalling RX queue");
         }
 
         Ok(())
@@ -114,9 +114,9 @@ impl NetEpollHandler {
             || !self.driver_awake
         {
             self.signal_used_queue(&self.queue_pair[1])?;
-            info!("Signalling TX queue");
+            debug!("Signalling TX queue");
         } else {
-            info!("Not signalling TX queue");
+            debug!("Not signalling TX queue");
         }
         Ok(())
     }
@@ -129,9 +129,9 @@ impl NetEpollHandler {
             || !self.driver_awake
         {
             self.signal_used_queue(&self.queue_pair[0])?;
-            info!("Signalling RX queue");
+            debug!("Signalling RX queue");
         } else {
-            info!("Not signalling RX queue");
+            debug!("Not signalling RX queue");
         }
         Ok(())
     }

--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -707,7 +707,7 @@ impl Queue {
 
         if let Some(old_idx) = self.signalled_used {
             if let Some(used_event) = self.get_used_event(&mem) {
-                info!(
+                debug!(
                     "used_event = {:?} used_idx = {:?} old_idx = {:?}",
                     used_event, used_idx, old_idx
                 );
@@ -718,7 +718,7 @@ impl Queue {
         }
 
         self.signalled_used = Some(used_idx);
-        info!("Needs notification: {:?}", notify);
+        debug!("Needs notification: {:?}", notify);
         notify
     }
 }


### PR DESCRIPTION
Temporarily disable very flaky tests to help get our CI running with more stability.