### PR TITLE
DO NOT MERGE: Disable io_uring to identify test flakiness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde_json = "1.0.61"
 net_util = { path = "net_util" }
 
 [features]
-default = ["acpi", "cmos", "io_uring", "kvm"]
+default = ["acpi", "cmos", "kvm"]
 # Common features for all hypervisors
 common = ["acpi", "cmos", "fwdebug", "io_uring"]
 acpi = ["vmm/acpi"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,14 +168,6 @@ pipeline{
 								sh "scripts/dev_cli.sh tests --integration-windows"
 							}
 						}
-						stage ('Run Windows guest integration tests for musl') {
-							options {
-								timeout(time: 1, unit: 'HOURS')
-							}
-							steps {
-								sh "scripts/dev_cli.sh tests --integration-windows --libc musl"
-							}
-						}
 					}
 				}
 			}

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -44,7 +44,7 @@ if [ ! -f "$BIONIC_OS_RAW_IMAGE" ]; then
 fi
 
 
-FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom.qcow2"
+FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210106-1.qcow2"
 FOCAL_OS_IMAGE_URL="https://cloudhypervisorstorage.blob.core.windows.net/images/$FOCAL_OS_IMAGE_NAME"
 FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_IMAGE" ]; then
@@ -53,7 +53,7 @@ if [ ! -f "$FOCAL_OS_IMAGE" ]; then
     popd
 fi
 
-FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-amd64-custom.raw"
+FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210106-1.raw"
 FOCAL_OS_RAW_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_RAW_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_RAW_IMAGE" ]; then
     pushd $WORKLOADS_DIR

--- a/scripts/sha1sums-x86_64
+++ b/scripts/sha1sums-x86_64
@@ -1,5 +1,5 @@
 27f3b17962ace69b51f0ddc2012095e3109e6ed8 bionic-server-cloudimg-amd64.qcow2
 8db9cc58b01452ce2d06c313177e6e74d8582d93 bionic-server-cloudimg-amd64.raw
 d4a44acc6014d5f83dea1c625c43d677a95fa75f alpine-minirootfs-x86_64.tar.gz
-f131563d3aa466cb5d2c25ffe7007c9cb8d15818 focal-server-cloudimg-amd64-custom.qcow2
-d5a08d2b35d48042d2c08fdc0c31ae656073f43e focal-server-cloudimg-amd64-custom.raw
+4ee774e9e10f3cd985203c3ea20b487c285dfa1d focal-server-cloudimg-amd64-custom-20210106-1.qcow2
+7cd439f9dfe63b5f354011ea0e893256a8111174 focal-server-cloudimg-amd64-custom-20210106-1.raw

--- a/test_data/cloud-init/ubuntu/user-data
+++ b/test_data/cloud-init/ubuntu/user-data
@@ -43,7 +43,7 @@ write_files:
         # 1G ram requires 512 pages
         echo 512 | sudo tee /proc/sys/vm/nr_hugepages
         sudo chmod a+rwX /dev/hugepages
-        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda1 VFIOTAG" --disk path=/mnt/focal-server-cloudimg-amd64-custom.qcow2 path=/mnt/cloudinit.img --cpus boot=1 --memory size=512M,hotplug_size=1G,hugepages=on --device path=/sys/bus/pci/devices/0000:00:06.0/ path=/sys/bus/pci/devices/0000:00:07.0/ --api-socket /tmp/ch_api.sock
+        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda1 VFIOTAG" --disk path=/mnt/focal-server-cloudimg-amd64-custom-20210106-1.qcow2 path=/mnt/cloudinit.img --cpus boot=1 --memory size=512M,hotplug_size=1G,hugepages=on --device path=/sys/bus/pci/devices/0000:00:06.0/ path=/sys/bus/pci/devices/0000:00:07.0/ --api-socket /tmp/ch_api.sock
 
   -
     path: /etc/systemd/system/notify-booted.service

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -95,7 +95,8 @@ mod tests {
     #[cfg(target_arch = "aarch64")]
     const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-arm64-custom";
 
-    const DIRECT_KERNEL_BOOT_CMDLINE: &str = "root=/dev/vda1 console=hvc0 rw";
+    const DIRECT_KERNEL_BOOT_CMDLINE: &str =
+        "root=/dev/vda1 console=hvc0 rw systemd.journald.forward_to_console=1";
 
     const PIPE_SIZE: i32 = 32 << 20;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5411,7 +5411,9 @@ mod tests {
             handle_child_output(r, &output);
         }
 
+        // Temporarily limited to x86_64 - see #2103
         #[test]
+        #[cfg(target_arch = "x86_64")]
         fn test_watchdog() {
             let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
             let guest = Guest::new(&mut focal);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -87,7 +87,7 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     const BIONIC_IMAGE_NAME: &str = "bionic-server-cloudimg-amd64";
     #[cfg(target_arch = "x86_64")]
-    const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-custom";
+    const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-custom-20210106-1";
     #[cfg(target_arch = "x86_64")]
     const FOCAL_SGX_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-sgx";
     #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
We've observed that sometimes the journal inside the VM does not appear
to reflect that the VM was rebooted. This might be due to the use of
io_uring by default.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>