### PR TITLE
virtio-devices, vmm: Enhance debugging around virtio device activation

### DIFF
--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -673,6 +673,8 @@ impl VirtioPciDevice {
                     info!("{}: Barrier released", self.id);
                 }
             }
+        } else {
+            info!("{}: Device does not need activation", self.id)
         }
     }
 
@@ -1018,8 +1020,12 @@ impl PciDevice for VirtioPciDevice {
 
         // Try and activate the device if the driver status has changed
         if self.needs_activation() {
-            info!("{}: Needs activation; returning barrier", self.id);
+            info!(
+                "{}: Needs activation; writing to activate event fd",
+                self.id
+            );
             self.activate_evt.write(1).ok();
+            info!("{}: Needs activation; returning barrier", self.id);
             return Some(self.activate_barrier.clone());
         }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1099,10 +1099,14 @@ impl Vmm {
                         }
                         EpollDispatch::ActivateVirtioDevices => {
                             if let Some(ref vm) = self.vm {
+                                let count = self.activate_evt.read().map_err(Error::EventFdRead)?;
+                                info!(
+                                    "Trying to activate pending virtio devices: count = {}",
+                                    count
+                                );
                                 vm.activate_virtio_devices()
                                     .map_err(Error::ActivateVirtioDevices)?;
                             }
-                            self.activate_evt.read().map_err(Error::EventFdRead)?;
                         }
                         EpollDispatch::Api => {
                             // Consume the event.


### PR DESCRIPTION
Sometimes when running under the CI tests fail due to a barrier not
being released and the guest blocks on an MMIO write. Add further
debugging to try and identify the issue.

See: #2118

Signed-off-by: Rob Bradford <robert.bradford@intel.com>