### PR TITLE
tests: Increase sleep time in Windows integration tests

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5614,7 +5614,7 @@ mod tests {
 
             assert!(pipesize >= PIPE_SIZE && pipesize1 >= PIPE_SIZE);
 
-            thread::sleep(std::time::Duration::new(40, 0));
+            thread::sleep(std::time::Duration::new(60, 0));
             let auth = windows_auth();
             let r = std::panic::catch_unwind(|| {
                 ssh_command_ip_with_auth(
@@ -5627,7 +5627,7 @@ mod tests {
                 .unwrap();
             });
 
-            let _ = child.wait_timeout(std::time::Duration::from_secs(40));
+            let _ = child.wait_timeout(std::time::Duration::from_secs(60));
             let _ = child.kill();
             let output = child.wait_with_output().unwrap();
 
@@ -5670,7 +5670,7 @@ mod tests {
             assert!(pipesize >= PIPE_SIZE && pipesize1 >= PIPE_SIZE);
 
             // Wait to make sure Windows boots up
-            thread::sleep(std::time::Duration::new(20, 0));
+            thread::sleep(std::time::Duration::new(60, 0));
 
             let snapshot_dir = temp_snapshot_dir_path(&tmp_dir);
 
@@ -5685,7 +5685,7 @@ mod tests {
             ));
 
             // Wait to make sure the snapshot is completed
-            thread::sleep(std::time::Duration::new(20, 0));
+            thread::sleep(std::time::Duration::new(30, 0));
 
             let _ = child.kill();
             child.wait().unwrap();
@@ -5703,7 +5703,7 @@ mod tests {
                 .unwrap();
 
             // Wait for the VM to be restored
-            thread::sleep(std::time::Duration::new(10, 0));
+            thread::sleep(std::time::Duration::new(20, 0));
 
             let r = std::panic::catch_unwind(|| {
                 // Resume the VM
@@ -5721,7 +5721,7 @@ mod tests {
                 .unwrap();
             });
 
-            let _ = child.wait_timeout(std::time::Duration::from_secs(20));
+            let _ = child.wait_timeout(std::time::Duration::from_secs(60));
             let _ = child.kill();
             let output = child.wait_with_output().unwrap();
 


### PR DESCRIPTION
Some sporadic failures were due to an early connection to the VM while
it was not fully ready. Increasing sleep times fixes these issues.

Fixes #2104

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>