### PR TITLE
virtio-devices: Update seccomp filters for virtio-net thread

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -223,6 +223,7 @@ fn virtio_net_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_futex),
         allow_syscall(libc::SYS_madvise),
         allow_syscall(libc::SYS_munmap),
+        allow_syscall(libc::SYS_openat),
         allow_syscall(libc::SYS_read),
         allow_syscall(libc::SYS_rt_sigprocmask),
         allow_syscall(libc::SYS_sigaltstack),


### PR DESCRIPTION
On aarch64, the openat() syscall was missing from the seccomp filters
list, preventing the test_watchdog from running properly.

Fixes #2103

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>