### PR TITLE
ci: Always download the Windows image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,6 +144,21 @@ pipeline{
 								checkout scm
 							}
 						}
+						stage ('Download assets') {
+							steps {
+								sh "mkdir ${env.HOME}/workloads"
+								azureDownload(storageCredentialId: 'ch-image-store',
+											  containerName: 'private-images',
+											  includeFilesPattern: 'OVMF.fd',
+											  downloadType: 'container',
+											  downloadDirLoc: "${env.HOME}/workloads")
+								azureDownload(storageCredentialId: 'ch-image-store',
+											  containerName: 'private-images',
+											  includeFilesPattern: 'windows-server-2019.raw',
+											  downloadType: 'container',
+											  downloadDirLoc: "${env.HOME}/workloads")
+							}
+						}
 						stage ('Run Windows guest integration tests') {
 							options {
 								timeout(time: 1, unit: 'HOURS')


### PR DESCRIPTION
Because we're back on transient builder, let's download the image
everytime.

This reverts commit b5653d52787a0be5f58d557fb06ff798ac280c45.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>