### PR TITLE
Revert "tests: Temporarily disable test_watchdog on aarch64"

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5357,9 +5357,7 @@ mod tests {
             handle_child_output(r, &output);
         }
 
-        // Temporarily limited to x86_64 - see #2103
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_watchdog() {
             let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
             let guest = Guest::new(&mut focal);


### PR DESCRIPTION
This reverts commit 49b49421d05329532ba066febe58a20cece853ba.

Probable solution was applied in f70852c04b65e7ae9f9a6edfa471bd00b9fead07

Fixes: #2103

Signed-off-by: Rob Bradford <robert.bradford@intel.com>