### PR TITLE
vmm: seccomp: Add open() to vCPU permitted syscalls

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -447,6 +447,8 @@ fn vcpu_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_mprotect),
         allow_syscall(libc::SYS_munmap),
         allow_syscall(libc::SYS_nanosleep),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_open),
         allow_syscall(libc::SYS_openat),
         #[cfg(target_arch = "aarch64")]
         allow_syscall(libc::SYS_newfstatat),


### PR DESCRIPTION
Older libc (like RHEL7) uses open() rather than openat(). This was
demonstrated through a failure to open /etc/localtime as used by
gmtime() libc call trigged from the vCPU thread (CMOS device.)

Fixes: #2111

Signed-off-by: Rob Bradford <robert.bradford@intel.com>