### PR TITLE
scripts: Run test container with the default bridge network

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -28,8 +28,7 @@ CTR_CLH_CARGO_TARGET="${CTR_CLH_CARGO_BUILT_DIR}/cargo_target"
 CTR_CLH_INTEGRATION_WORKLOADS="/root/workloads"
 
 # Container networking option
-CTR_CLH_NET="host"
-[ $(uname -m) = "aarch64" ] && CTR_CLH_NET="bridge"
+CTR_CLH_NET="bridge"
 
 # Cargo paths
 # Full path to the cargo registry dir on the host. This appears on the host

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -189,10 +189,10 @@ cp $FW $VFIO_DIR
 cp $VMLINUX_IMAGE $VFIO_DIR || exit 1
 
 # VFIO test network setup.
-# We reserve a different IP class for it: 172.17.0.0/24.
+# We reserve a different IP class for it: 172.18.0.0/24.
 sudo ip link add name vfio-br0 type bridge
 sudo ip link set vfio-br0 up
-sudo ip addr add 172.17.0.1/24 dev vfio-br0
+sudo ip addr add 172.18.0.1/24 dev vfio-br0
 
 sudo ip tuntap add vfio-tap0 mode tap
 sudo ip link set vfio-tap0 master vfio-br0

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3538,7 +3538,7 @@ mod tests {
         // it is being added to the L2 VM through hotplugging mechanism.
         fn test_vfio() {
             let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-            let guest = Guest::new_from_ip_range(&mut focal, "172.17", 0);
+            let guest = Guest::new_from_ip_range(&mut focal, "172.18", 0);
 
             let mut workload_path = dirs::home_dir().unwrap();
             workload_path.push("workloads");


### PR DESCRIPTION
Using --net=host is not necessary for any of the integration tests, so
let's use the default network option called "bridge".

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>