### PR TITLE
main: Give a friendly message when we get a seccomp violation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "option_parser",
  "seccomp",
  "serde_json",
+ "signal-hook",
  "ssh2",
  "tempdir",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,12 @@ log = { version = "0.4.13", features = ["std"] }
 option_parser = { path = "option_parser" }
 seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.22.0" }
 serde_json = "1.0.61"
+signal-hook = "0.3.3"
 thiserror = "1.0"
 vmm = { path = "vmm" }
 vmm-sys-util = "0.7.0"
-wait-timeout = "0.2.0"
 vm-memory = "0.4.0"
+wait-timeout = "0.2.0"
 
 [build-dependencies]
 clap = { version = "2.33.3", features = ["wrap_help"] }


### PR DESCRIPTION
If we receive SIGSYS and identify it as a seccomp violation then give
friendly instructions on how to debug further. We are unable to decode
the siginfo_t struct ourselves due to https://github.com/rust-lang/libc/issues/716

Fixes: #2139

Signed-off-by: Rob Bradford <robert.bradford@intel.com>