### PR TITLE
ci: Use device mapper to avoid copying Windows image

### DIFF
--- a/scripts/run_integration_tests_windows.sh
+++ b/scripts/run_integration_tests_windows.sh
@@ -17,6 +17,14 @@ TARGET_CC="musl-gcc"
 CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
 fi
 
+# Use device mapper to create a snapshot of the Windows image
+img_blk_size=$(du -b -B 512 /root/workloads/windows-server-2019.raw | awk '{print $1;}')
+loop_device=$(losetup --find --show --read-only /root/workloads/windows-server-2019.raw)
+dmsetup create windows-base --table "0 $img_blk_size linear $loop_device 0"
+dmsetup mknodes
+dmsetup create windows-snapshot-base --table "0 $img_blk_size snapshot-origin /dev/mapper/windows-base"
+dmsetup mknodes
+
 cargo build --all --release $features_build --target $BUILD_TARGET
 strip target/$BUILD_TARGET/release/cloud-hypervisor
 
@@ -26,5 +34,8 @@ export RUST_BACKTRACE=1
 # Windows has a static IP configured
 time cargo test $features_test "tests::windows::" -- --test-threads=1
 RES=$?
+
+dmsetup remove_all -f
+losetup -D
 
 exit $RES


### PR DESCRIPTION
The Windows image is quite large (about 20GiB), hence it takes some time
to copy it for every test in order to avoid potential corruption.

One way to mitigate that without compromising on safety between each
test is by using device mapper. By creating a read-only base, we ensure
the image won't be modified by any of the tests, and by creating one
snapshot for each test, we avoid copying the entire image each time.
A dedicated Copy On Write disk image is created to handle any change
that might be performed on the base image, letting the tests behave as
expected.

Fixes #2155

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>