### PR TITLE
virtio-devices: Derive thread names from device ids

### DIFF
--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -446,7 +446,7 @@ impl VirtioDevice for Balloon {
             get_seccomp_filter(&self.seccomp_action, Thread::VirtioBalloon)
                 .map_err(ActivateError::CreateSeccompFilter)?;
         thread::Builder::new()
-            .name("virtio_balloon".to_string())
+            .name(self.id.clone())
             .spawn(move || {
                 if let Err(e) = SeccompFilter::apply(virtio_balloon_seccomp_filter) {
                     error!("Error applying seccomp filter: {:?}", e);

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -444,7 +444,7 @@ impl<T: 'static + DiskFile + Send> VirtioDevice for Block<T> {
         self.update_writeback();
 
         let mut epoll_threads = Vec::new();
-        for _ in 0..self.common.queue_sizes.len() {
+        for i in 0..self.common.queue_sizes.len() {
             let queue_evt = queue_evts.remove(0);
             let kill_evt = self
                 .common
@@ -492,7 +492,7 @@ impl<T: 'static + DiskFile + Send> VirtioDevice for Block<T> {
                     .map_err(ActivateError::CreateSeccompFilter)?;
 
             thread::Builder::new()
-                .name("virtio_blk".to_string())
+                .name(format!("{}_q{}", self.id.clone(), i))
                 .spawn(move || {
                     if let Err(e) = SeccompFilter::apply(virtio_blk_seccomp_filter) {
                         error!("Error applying seccomp filter: {:?}", e);

--- a/virtio-devices/src/block_io_uring.rs
+++ b/virtio-devices/src/block_io_uring.rs
@@ -561,7 +561,7 @@ impl VirtioDevice for BlockIoUring {
                     .map_err(ActivateError::CreateSeccompFilter)?;
 
             thread::Builder::new()
-                .name("virtio_blk_io_uring".to_string())
+                .name(format!("{}_q{}", self.id.clone(), i))
                 .spawn(move || {
                     if let Err(e) = SeccompFilter::apply(virtio_blk_io_uring_seccomp_filter) {
                         error!("Error applying seccomp filter: {:?}", e);

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -470,7 +470,7 @@ impl VirtioDevice for Console {
             get_seccomp_filter(&self.seccomp_action, Thread::VirtioConsole)
                 .map_err(ActivateError::CreateSeccompFilter)?;
         thread::Builder::new()
-            .name("virtio_console".to_string())
+            .name(self.id.clone())
             .spawn(move || {
                 if let Err(e) = SeccompFilter::apply(virtio_console_seccomp_filter) {
                     error!("Error applying seccomp filter: {:?}", e);

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -934,7 +934,7 @@ impl VirtioDevice for Iommu {
             get_seccomp_filter(&self.seccomp_action, Thread::VirtioIommu)
                 .map_err(ActivateError::CreateSeccompFilter)?;
         thread::Builder::new()
-            .name("virtio_iommu".to_string())
+            .name(self.id.clone())
             .spawn(move || {
                 if let Err(e) = SeccompFilter::apply(virtio_iommu_seccomp_filter) {
                     error!("Error applying seccomp filter: {:?}", e);

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -860,7 +860,7 @@ impl VirtioDevice for Mem {
         let virtio_mem_seccomp_filter = get_seccomp_filter(&self.seccomp_action, Thread::VirtioMem)
             .map_err(ActivateError::CreateSeccompFilter)?;
         thread::Builder::new()
-            .name("virtio_mem".to_string())
+            .name(self.id.clone())
             .spawn(move || {
                 if let Err(e) = SeccompFilter::apply(virtio_mem_seccomp_filter) {
                     error!("Error applying seccomp filter: {:?}", e);

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -421,7 +421,7 @@ impl VirtioDevice for Net {
                     get_seccomp_filter(&self.seccomp_action, Thread::VirtioNetCtl)
                         .map_err(ActivateError::CreateSeccompFilter)?;
                 thread::Builder::new()
-                    .name("virtio_net_ctl".to_string())
+                    .name(format!("{}_ctrl", self.id))
                     .spawn(move || {
                         if let Err(e) = SeccompFilter::apply(virtio_net_ctl_seccomp_filter) {
                             error!("Error applying seccomp filter: {:?}", e);
@@ -439,7 +439,7 @@ impl VirtioDevice for Net {
             let event_idx = self.common.feature_acked(VIRTIO_RING_F_EVENT_IDX.into());
 
             let mut epoll_threads = Vec::new();
-            for _ in 0..taps.len() {
+            for i in 0..taps.len() {
                 let rx = RxVirtio::new();
                 let tx = TxVirtio::new();
                 let rx_tap_listening = false;
@@ -501,7 +501,7 @@ impl VirtioDevice for Net {
                     get_seccomp_filter(&self.seccomp_action, Thread::VirtioNet)
                         .map_err(ActivateError::CreateSeccompFilter)?;
                 thread::Builder::new()
-                    .name("virtio_net".to_string())
+                    .name(format!("{}_qp{}", self.id.clone(), i))
                     .spawn(move || {
                         if let Err(e) = SeccompFilter::apply(virtio_net_seccomp_filter) {
                             error!("Error applying seccomp filter: {:?}", e);

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -413,7 +413,7 @@ impl VirtioDevice for Pmem {
                 get_seccomp_filter(&self.seccomp_action, Thread::VirtioPmem)
                     .map_err(ActivateError::CreateSeccompFilter)?;
             thread::Builder::new()
-                .name("virtio_pmem".to_string())
+                .name(self.id.clone())
                 .spawn(move || {
                     if let Err(e) = SeccompFilter::apply(virtio_pmem_seccomp_filter) {
                         error!("Error applying seccomp filter: {:?}", e);

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -258,7 +258,7 @@ impl VirtioDevice for Rng {
                 get_seccomp_filter(&self.seccomp_action, Thread::VirtioRng)
                     .map_err(ActivateError::CreateSeccompFilter)?;
             thread::Builder::new()
-                .name("virtio_rng".to_string())
+                .name(self.id.clone())
                 .spawn(move || {
                     if let Err(e) = SeccompFilter::apply(virtio_rng_seccomp_filter) {
                         error!("Error applying seccomp filter: {:?}", e);

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -216,7 +216,7 @@ impl VirtioDevice for Blk {
         .map_err(ActivateError::VhostUserBlkSetup)?;
 
         let mut epoll_threads = Vec::new();
-        for _ in 0..vu_interrupt_list.len() {
+        for i in 0..vu_interrupt_list.len() {
             let mut interrupt_list_sub: Vec<(Option<EventFd>, Queue)> = Vec::with_capacity(1);
             interrupt_list_sub.push(vu_interrupt_list.remove(0));
 
@@ -255,7 +255,7 @@ impl VirtioDevice for Blk {
                 get_seccomp_filter(&self.seccomp_action, Thread::VirtioVhostBlk)
                     .map_err(ActivateError::CreateSeccompFilter)?;
             thread::Builder::new()
-                .name("vhost_blk".to_string())
+                .name(format!("{}_q{}", self.id.clone(), i))
                 .spawn(move || {
                     if let Err(e) = SeccompFilter::apply(virtio_vhost_blk_seccomp_filter) {
                         error!("Error applying seccomp filter: {:?}", e);

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -475,7 +475,7 @@ impl VirtioDevice for Fs {
             get_seccomp_filter(&self.seccomp_action, Thread::VirtioVhostFs)
                 .map_err(ActivateError::CreateSeccompFilter)?;
         thread::Builder::new()
-            .name("vhost_fs".to_string())
+            .name(self.id.clone())
             .spawn(move || {
                 if let Err(e) = SeccompFilter::apply(virtio_vhost_fs_seccomp_filter) {
                     error!("Error applying seccomp filter: {:?}", e);

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -244,7 +244,7 @@ impl VirtioDevice for Net {
                 get_seccomp_filter(&self.seccomp_action, Thread::VirtioVhostNetCtl)
                     .map_err(ActivateError::CreateSeccompFilter)?;
             thread::Builder::new()
-                .name("vhost_net_ctl".to_string())
+                .name(format!("{}_ctrl", self.id))
                 .spawn(move || {
                     if let Err(e) = SeccompFilter::apply(virtio_vhost_net_ctl_seccomp_filter) {
                         error!("Error applying seccomp filter: {:?}", e);
@@ -270,7 +270,7 @@ impl VirtioDevice for Net {
         .map_err(ActivateError::VhostUserNetSetup)?;
 
         let mut epoll_threads = Vec::new();
-        for _ in 0..vu_interrupt_list.len() / 2 {
+        for i in 0..vu_interrupt_list.len() / 2 {
             let mut interrupt_list_sub: Vec<(Option<EventFd>, Queue)> = Vec::with_capacity(2);
             interrupt_list_sub.push(vu_interrupt_list.remove(0));
             interrupt_list_sub.push(vu_interrupt_list.remove(0));
@@ -310,7 +310,7 @@ impl VirtioDevice for Net {
                 get_seccomp_filter(&self.seccomp_action, Thread::VirtioVhostNet)
                     .map_err(ActivateError::CreateSeccompFilter)?;
             thread::Builder::new()
-                .name("vhost_net".to_string())
+                .name(format!("{}_qp{}", self.id.clone(), i))
                 .spawn(move || {
                     if let Err(e) = SeccompFilter::apply(virtio_vhost_net_seccomp_filter) {
                         error!("Error applying seccomp filter: {:?}", e);

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -456,7 +456,7 @@ where
             get_seccomp_filter(&self.seccomp_action, Thread::VirtioVsock)
                 .map_err(ActivateError::CreateSeccompFilter)?;
         thread::Builder::new()
-            .name("virtio_vsock".to_string())
+            .name(self.id.clone())
             .spawn(move || {
                 if let Err(e) = SeccompFilter::apply(virtio_vsock_seccomp_filter) {
                     error!("Error applying seccomp filter: {:?}", e);

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -339,7 +339,7 @@ impl VirtioDevice for Watchdog {
             get_seccomp_filter(&self.seccomp_action, Thread::VirtioWatchdog)
                 .map_err(ActivateError::CreateSeccompFilter)?;
         thread::Builder::new()
-            .name("virtio_watchdog".to_string())
+            .name(self.id.clone())
             .spawn(move || {
                 if let Err(e) = SeccompFilter::apply(virtio_watchdog_seccomp_filter) {
                     error!("Error applying seccomp filter: {:?}", e);


### PR DESCRIPTION
In order to make the thread naming more useful derive their name from
the device id (which can be supplied by the user) and a device specific
suffix that has details of the individual queue (or queue pair.)

e.g.

rob@artemis:~$ pstree -p -c -l -t `pidof cloud-hypervisor`
cloud-hyperviso(27501)─┬─{_console}(27525)
                       ├─{_disk0_q0}(27529)
                       ├─{_disk0_q1}(27532)
                       ├─{_net1_ctrl}(27533)
                       ├─{_net1_qp0}(27534)
                       ├─{_net1_qp1}(27535)
                       ├─{_rng}(27526)
                       ├─{http-server}(27504)
                       ├─{seccomp_signal_}(27502)
                       ├─{signal_handler}(27523)
                       ├─{vcpu0}(27520)
                       ├─{vcpu1}(27522)
                       └─{vmm}(27503)

Fixes: #2077

Signed-off-by: Rob Bradford <robert.bradford@intel.com>