### PR TITLE
Use device mapper for faster integration tests

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -209,16 +209,19 @@ TARGET_CC="musl-gcc"
 CFLAGS="-I /usr/include/aarch64-linux-musl/ -idirafter /usr/include/"
 fi
 
+mkdir /tmp/images
 # Use device mapper to create a snapshot of the Ubuntu Bionic image
-bionic_img_blk_size=$(du -b -B 512 /root/workloads/bionic-server-cloudimg-arm64.raw | awk '{print $1;}')
-bionic_loop_device=$(losetup --find --show --read-only /root/workloads/bionic-server-cloudimg-arm64.raw)
+cp /root/workloads/bionic-server-cloudimg-arm64.raw /tmp/images/
+bionic_img_blk_size=$(du -b -B 512 /tmp/images/bionic-server-cloudimg-arm64.raw | awk '{print $1;}')
+bionic_loop_device=$(losetup --find --show --read-only /tmp/images/bionic-server-cloudimg-arm64.raw)
 dmsetup create bionic-base --table "0 $bionic_img_blk_size linear $bionic_loop_device 0"
 dmsetup mknodes
 dmsetup create bionic-snapshot-base --table "0 $bionic_img_blk_size snapshot-origin /dev/mapper/bionic-base"
 dmsetup mknodes
 # Use device mapper to create a snapshot of the Ubuntu Focal image
-focal_img_blk_size=$(du -b -B 512 /root/workloads/focal-server-cloudimg-arm64-custom.raw | awk '{print $1;}')
-focal_loop_device=$(losetup --find --show --read-only /root/workloads/focal-server-cloudimg-arm64-custom.raw)
+cp /root/workloads/focal-server-cloudimg-arm64-custom.raw /tmp/images/
+focal_img_blk_size=$(du -b -B 512 /tmp/images/focal-server-cloudimg-arm64-custom.raw | awk '{print $1;}')
+focal_loop_device=$(losetup --find --show --read-only /tmp/images/focal-server-cloudimg-arm64-custom.raw)
 dmsetup create focal-base --table "0 $focal_img_blk_size linear $focal_loop_device 0"
 dmsetup mknodes
 dmsetup create focal-snapshot-base --table "0 $focal_img_blk_size snapshot-origin /dev/mapper/focal-base"

--- a/scripts/run_integration_tests_sgx.sh
+++ b/scripts/run_integration_tests_sgx.sh
@@ -17,9 +17,11 @@ TARGET_CC="musl-gcc"
 CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
 fi
 
+mkdir /tmp/images
 # Use device mapper to create a snapshot of the Ubuntu Focal image
-img_blk_size=$(du -b -B 512 /root/workloads/focal-server-cloudimg-amd64-sgx.raw | awk '{print $1;}')
-loop_device=$(losetup --find --show --read-only /root/workloads/focal-server-cloudimg-amd64-sgx.raw)
+cp /root/workloads/focal-server-cloudimg-amd64-sgx.raw /tmp/images/
+img_blk_size=$(du -b -B 512 /tmp/images/focal-server-cloudimg-amd64-sgx.raw | awk '{print $1;}')
+loop_device=$(losetup --find --show --read-only /tmp/images/focal-server-cloudimg-amd64-sgx.raw)
 dmsetup create focal-sgx-base --table "0 $img_blk_size linear $loop_device 0"
 dmsetup mknodes
 dmsetup create focal-sgx-snapshot-base --table "0 $img_blk_size snapshot-origin /dev/mapper/focal-sgx-base"

--- a/scripts/run_integration_tests_sgx.sh
+++ b/scripts/run_integration_tests_sgx.sh
@@ -17,6 +17,14 @@ TARGET_CC="musl-gcc"
 CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
 fi
 
+# Use device mapper to create a snapshot of the Ubuntu Focal image
+img_blk_size=$(du -b -B 512 /root/workloads/focal-server-cloudimg-amd64-sgx.raw | awk '{print $1;}')
+loop_device=$(losetup --find --show --read-only /root/workloads/focal-server-cloudimg-amd64-sgx.raw)
+dmsetup create focal-sgx-base --table "0 $img_blk_size linear $loop_device 0"
+dmsetup mknodes
+dmsetup create focal-sgx-snapshot-base --table "0 $img_blk_size snapshot-origin /dev/mapper/focal-sgx-base"
+dmsetup mknodes
+
 cargo build --all --release $features_build --target $BUILD_TARGET
 strip target/$BUILD_TARGET/release/cloud-hypervisor
 
@@ -24,5 +32,10 @@ export RUST_BACKTRACE=1
 
 time cargo test $features_test "tests::sgx::"
 RES=$?
+
+dmsetup remove -f focal-sgx-snapshot-base
+dmsetup mknodes
+dmsetup remove -f focal-sgx-base
+losetup -d $loop_device
 
 exit $RES

--- a/scripts/run_integration_tests_windows.sh
+++ b/scripts/run_integration_tests_windows.sh
@@ -5,7 +5,7 @@ source $HOME/.cargo/env
 source $(dirname "$0")/test-util.sh
 
 process_common_args "$@"
-# For now these values are deafult for kvm
+# For now these values are default for kvm
 features_build=""
 features_test="--features integration_tests"
 

--- a/scripts/run_integration_tests_windows.sh
+++ b/scripts/run_integration_tests_windows.sh
@@ -35,7 +35,9 @@ export RUST_BACKTRACE=1
 time cargo test $features_test "tests::windows::" -- --test-threads=1
 RES=$?
 
-dmsetup remove_all -f
-losetup -D
+dmsetup remove -f windows-snapshot-base
+dmsetup mknodes
+dmsetup remove -f windows-base
+losetup -d $loop_device
 
 exit $RES

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -223,16 +223,19 @@ TARGET_CC="musl-gcc"
 CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
 fi
 
+mkdir /tmp/images
 # Use device mapper to create a snapshot of the Ubuntu Bionic image
-bionic_img_blk_size=$(du -b -B 512 /root/workloads/bionic-server-cloudimg-amd64.raw | awk '{print $1;}')
-bionic_loop_device=$(losetup --find --show --read-only /root/workloads/bionic-server-cloudimg-amd64.raw)
+cp /root/workloads/bionic-server-cloudimg-amd64.raw /tmp/images/
+bionic_img_blk_size=$(du -b -B 512 /tmp/images/bionic-server-cloudimg-amd64.raw | awk '{print $1;}')
+bionic_loop_device=$(losetup --find --show --read-only /tmp/images/bionic-server-cloudimg-amd64.raw)
 dmsetup create bionic-base --table "0 $bionic_img_blk_size linear $bionic_loop_device 0"
 dmsetup mknodes
 dmsetup create bionic-snapshot-base --table "0 $bionic_img_blk_size snapshot-origin /dev/mapper/bionic-base"
 dmsetup mknodes
 # Use device mapper to create a snapshot of the Ubuntu Focal image
-focal_img_blk_size=$(du -b -B 512 /root/workloads/focal-server-cloudimg-amd64-custom-20210106-1.raw | awk '{print $1;}')
-focal_loop_device=$(losetup --find --show --read-only /root/workloads/focal-server-cloudimg-amd64-custom-20210106-1.raw)
+cp /root/workloads/focal-server-cloudimg-amd64-custom-20210106-1.raw /tmp/images/
+focal_img_blk_size=$(du -b -B 512 /tmp/images/focal-server-cloudimg-amd64-custom-20210106-1.raw | awk '{print $1;}')
+focal_loop_device=$(losetup --find --show --read-only /tmp/images/focal-server-cloudimg-amd64-custom-20210106-1.raw)
 dmsetup create focal-base --table "0 $focal_img_blk_size linear $focal_loop_device 0"
 dmsetup mknodes
 dmsetup create focal-snapshot-base --table "0 $focal_img_blk_size snapshot-origin /dev/mapper/focal-base"

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -223,6 +223,21 @@ TARGET_CC="musl-gcc"
 CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
 fi
 
+# Use device mapper to create a snapshot of the Ubuntu Bionic image
+bionic_img_blk_size=$(du -b -B 512 /root/workloads/bionic-server-cloudimg-amd64.raw | awk '{print $1;}')
+bionic_loop_device=$(losetup --find --show --read-only /root/workloads/bionic-server-cloudimg-amd64.raw)
+dmsetup create bionic-base --table "0 $bionic_img_blk_size linear $bionic_loop_device 0"
+dmsetup mknodes
+dmsetup create bionic-snapshot-base --table "0 $bionic_img_blk_size snapshot-origin /dev/mapper/bionic-base"
+dmsetup mknodes
+# Use device mapper to create a snapshot of the Ubuntu Focal image
+focal_img_blk_size=$(du -b -B 512 /root/workloads/focal-server-cloudimg-amd64-custom-20210106-1.raw | awk '{print $1;}')
+focal_loop_device=$(losetup --find --show --read-only /root/workloads/focal-server-cloudimg-amd64-custom-20210106-1.raw)
+dmsetup create focal-base --table "0 $focal_img_blk_size linear $focal_loop_device 0"
+dmsetup mknodes
+dmsetup create focal-snapshot-base --table "0 $focal_img_blk_size snapshot-origin /dev/mapper/focal-base"
+dmsetup mknodes
+
 cargo build --all  --release $features_build --target $BUILD_TARGET
 strip target/$BUILD_TARGET/release/cloud-hypervisor
 strip target/$BUILD_TARGET/release/vhost_user_net
@@ -243,7 +258,7 @@ echo 4096 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 export RUST_BACKTRACE=1
-time cargo test $features_test "tests::parallel::"
+time cargo test $features_test "tests::parallel::" -- --test-threads=$(($(nproc)/2))
 RES=$?
 
 # Run some tests in sequence since the result could be affected by other tests
@@ -253,6 +268,16 @@ if [ $RES -eq 0 ]; then
     time cargo test $features_test "tests::sequential::" -- --test-threads=1
     RES=$?
 fi
+
+# Cleanup device mapper images
+dmsetup remove -f focal-snapshot-base
+dmsetup mknodes
+dmsetup remove -f focal-base
+losetup -d $focal_loop_device
+dmsetup remove -f bionic-snapshot-base
+dmsetup mknodes
+dmsetup remove -f bionic-base
+losetup -d $bionic_loop_device
 
 # Tear VFIO test network down
 sudo ip link del vfio-br0


### PR DESCRIPTION
In order to speed up the integration testing, we use device mapper to avoid copying the OS disk image for each and every test. Instead we create a snapshot for each test.

Fixes #2132 