### PR TITLE
Enable pty console

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -247,7 +247,7 @@ fn create_app<'a, 'b>(
         .arg(
             Arg::with_name("serial")
                 .long("serial")
-                .help("Control serial port: off|null|tty|file=/path/to/a/file")
+                .help("Control serial port: off|null|pty|tty|file=/path/to/a/file")
                 .default_value("null")
                 .group("vm-config"),
         )
@@ -255,7 +255,7 @@ fn create_app<'a, 'b>(
             Arg::with_name("console")
                 .long("console")
                 .help(
-                    "Control (virtio) console: \"off|null|tty|file=/path/to/a/file,iommu=on|off\"",
+                    "Control (virtio) console: \"off|null|pty|tty|file=/path/to/a/file,iommu=on|off\"",
                 )
                 .default_value("tty")
                 .group("vm-config"),
@@ -1402,6 +1402,57 @@ mod unit_tests {
                     "kernel": {"path": "/path/to/kernel"},
                     "serial": {"mode": "Tty"},
                     "console": {"mode": "Off"}
+                }"#,
+                true,
+            ),
+        ]
+        .iter()
+        .for_each(|(cli, openapi, equal)| {
+            compare_vm_config_cli_vs_json(cli, openapi, *equal);
+        });
+    }
+
+    #[test]
+    fn test_valid_vm_config_serial_pty_console_pty() {
+        vec![
+            (
+                vec!["cloud-hypervisor", "--kernel", "/path/to/kernel"],
+                r#"{
+                    "kernel": {"path": "/path/to/kernel"},
+                    "serial": {"mode": "Null"},
+                    "console": {"mode": "Tty"}
+                }"#,
+                true,
+            ),
+            (
+                vec![
+                    "cloud-hypervisor",
+                    "--kernel",
+                    "/path/to/kernel",
+                    "--serial",
+                    "null",
+                    "--console",
+                    "tty",
+                ],
+                r#"{
+                    "kernel": {"path": "/path/to/kernel"}
+                }"#,
+                true,
+            ),
+            (
+                vec![
+                    "cloud-hypervisor",
+                    "--kernel",
+                    "/path/to/kernel",
+                    "--serial",
+                    "pty",
+                    "--console",
+                    "pty",
+                ],
+                r#"{
+                    "kernel": {"path": "/path/to/kernel"},
+                    "serial": {"mode": "Pty"},
+                    "console": {"mode": "Pty"}
                 }"#,
                 true,
             ),

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -758,7 +758,7 @@ components:
           type: string
         mode:
           type: string
-          enum: [Off, Tty, File, Null]
+          enum: [Off, Pty, Tty, File, Null]
         iommu:
           type: boolean
           default: false

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1170,6 +1170,7 @@ impl PmemConfig {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum ConsoleOutputMode {
     Off,
+    Pty,
     Tty,
     File,
     Null,
@@ -1177,7 +1178,7 @@ pub enum ConsoleOutputMode {
 
 impl ConsoleOutputMode {
     pub fn input_enabled(&self) -> bool {
-        matches!(self, ConsoleOutputMode::Tty)
+        matches!(self, ConsoleOutputMode::Tty | ConsoleOutputMode::Pty)
     }
 }
 
@@ -1199,6 +1200,7 @@ impl ConsoleConfig {
         let mut parser = OptionParser::new();
         parser
             .add_valueless("off")
+            .add_valueless("pty")
             .add_valueless("tty")
             .add_valueless("null")
             .add("file")
@@ -1209,6 +1211,8 @@ impl ConsoleConfig {
         let mut mode: ConsoleOutputMode = ConsoleOutputMode::Off;
 
         if parser.is_set("off") {
+        } else if parser.is_set("pty") {
+            mode = ConsoleOutputMode::Pty
         } else if parser.is_set("tty") {
             mode = ConsoleOutputMode::Tty
         } else if parser.is_set("null") {
@@ -2152,6 +2156,14 @@ mod tests {
             ConsoleConfig::parse("off")?,
             ConsoleConfig {
                 mode: ConsoleOutputMode::Off,
+                iommu: false,
+                file: None,
+            }
+        );
+        assert_eq!(
+            ConsoleConfig::parse("pty")?,
+            ConsoleConfig {
+                mode: ConsoleOutputMode::Pty,
                 iommu: false,
                 file: None,
             }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -47,6 +47,8 @@ const SYS_IO_URING_REGISTER: i64 = 427;
 const TCGETS: u64 = 0x5401;
 const TCSETS: u64 = 0x5402;
 const TIOCGWINSZ: u64 = 0x5413;
+const TIOCSPTLCK: u64 = 0x4004_5431;
+const TIOCGTPEER: u64 = 0x5441;
 const FIOCLEX: u64 = 0x5451;
 const FIONBIO: u64 = 0x5421;
 
@@ -155,6 +157,8 @@ fn create_vmm_ioctl_seccomp_rule_common() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, TCSETS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TCGETS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TIOCGWINSZ)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, TIOCSPTLCK)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, TIOCGTPEER)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNGETFEATURES)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNGETIFF)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, TUNSETIFF)?],


### PR DESCRIPTION
Add the ability for cloud-hypervisor to create, manage and monitor a
pty for serial and/or console I/O from a user. The reasoning for
having cloud-hypervisor create the ptys is so that clients, libvirt
for example, could exit and later re-open the pty without causing I/O
issues. If the clients were responsible for creating the pty, when
they exit the main pty fd would close and cause cloud-hypervisor to
get I/O errors on writes.

Ideally the main and subordinate pty fds would be kept in the main
vmm's Vm structure. However, because the device manager owns parsing
the configuration for the serial and console devices, the information
is instead stored in new fields under the DeviceManager structure
directly.

From there hooking up the main fd is intended to look as close to
handling stdin and stdout on the tty as possible (there is some future
work ahead for perhaps moving support for the pty into the
vmm_sys_utils crate).

The main fd is used for reading user input and writing to output of
the Vm device. The subordinate fd is used to setup raw mode and it is
kept open in order to avoid I/O errors when clients open and close the
pty device.

The ability to handle multiple inputs as part of this change is
intentional. The current code allows serial and console ptys to be
created and both be used as input. There was an implementation gap
though with the queue_input_bytes needing to be modified so the pty
handlers for serial and console could access the methods on the serial
and console structures directly. Without this change only a single
input source could be processed as the console would switch based on
its input type (this is still valid for tty and isn't otherwise
modified).