### PR TITLE
virtio-devices: Upon reset reap/join the device threads

### DIFF
--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -299,6 +299,14 @@ impl VirtioCommon {
             let _ = kill_evt.write(1);
         }
 
+        if let Some(mut threads) = self.epoll_threads.take() {
+            for t in threads.drain(..) {
+                if let Err(e) = t.join() {
+                    error!("Error joining thread: {:?}", e);
+                }
+            }
+        }
+
         // Return the interrupt and queue EventFDs
         Some((
             self.interrupt_cb.take().unwrap(),


### PR DESCRIPTION
We have killed the device thread by writing to the exit EventFd but we
should wait for them to quit to ensure consistency.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>