### PR TITLE
virtio-devices: Simplify virtio device reset

### DIFF
--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -464,7 +464,7 @@ impl VirtioDevice for Balloon {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.common.reset()
     }
 }

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -512,7 +512,7 @@ impl<T: 'static + DiskFile + Send> VirtioDevice for Block<T> {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.common.reset()
     }
 

--- a/virtio-devices/src/block_io_uring.rs
+++ b/virtio-devices/src/block_io_uring.rs
@@ -581,7 +581,7 @@ impl VirtioDevice for BlockIoUring {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.common.reset()
     }
 

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -489,7 +489,7 @@ impl VirtioDevice for Console {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.common.reset()
     }
 }

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -116,7 +116,7 @@ pub trait VirtioDevice: Send {
 
     /// Optionally deactivates this device and returns ownership of the guest memory map, interrupt
     /// event, and queue events.
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         None
     }
 
@@ -288,7 +288,7 @@ impl VirtioCommon {
         Ok(())
     }
 
-    pub fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    pub fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         // We first must resume the virtio thread if it was paused.
         if self.pause_evt.take().is_some() {
             self.resume().ok()?;
@@ -307,11 +307,8 @@ impl VirtioCommon {
             }
         }
 
-        // Return the interrupt and queue EventFDs
-        Some((
-            self.interrupt_cb.take().unwrap(),
-            self.queue_evts.take().unwrap(),
-        ))
+        // Return the interrupt
+        Some(self.interrupt_cb.take().unwrap())
     }
 }
 

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -953,7 +953,7 @@ impl VirtioDevice for Iommu {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.common.reset()
     }
 }

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -878,7 +878,7 @@ impl VirtioDevice for Mem {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.common.reset()
     }
 }

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -523,7 +523,7 @@ impl VirtioDevice for Net {
         Err(ActivateError::BadActivate)
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.common.reset()
     }
 

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -434,7 +434,7 @@ impl VirtioDevice for Pmem {
         Err(ActivateError::BadActivate)
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.common.reset()
     }
 

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -279,7 +279,7 @@ impl VirtioDevice for Rng {
         Err(ActivateError::BadActivate)
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.common.reset()
     }
 }

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -274,7 +274,7 @@ impl VirtioDevice for Blk {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         // We first must resume the virtio thread if it was paused.
         if self.common.pause_evt.take().is_some() {
             self.common.resume().ok()?;
@@ -290,11 +290,8 @@ impl VirtioDevice for Blk {
             let _ = kill_evt.write(1);
         }
 
-        // Return the interrupt and queue EventFDs
-        Some((
-            self.common.interrupt_cb.take().unwrap(),
-            self.common.queue_evts.take().unwrap(),
-        ))
+        // Return the interrupt
+        Some(self.common.interrupt_cb.take().unwrap())
     }
 
     fn shutdown(&mut self) {

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -494,7 +494,7 @@ impl VirtioDevice for Fs {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         // We first must resume the virtio thread if it was paused.
         if self.common.pause_evt.take().is_some() {
             self.common.resume().ok()?;
@@ -510,11 +510,8 @@ impl VirtioDevice for Fs {
             let _ = kill_evt.write(1);
         }
 
-        // Return the interrupt and queue EventFDs
-        Some((
-            self.common.interrupt_cb.take().unwrap(),
-            self.common.queue_evts.take().unwrap(),
-        ))
+        // Return the interrupt
+        Some(self.common.interrupt_cb.take().unwrap())
     }
 
     fn shutdown(&mut self) {

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -330,7 +330,7 @@ impl VirtioDevice for Net {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         // We first must resume the virtio thread if it was paused.
         if self.common.pause_evt.take().is_some() {
             self.common.resume().ok()?;
@@ -346,11 +346,8 @@ impl VirtioDevice for Net {
             let _ = kill_evt.write(1);
         }
 
-        // Return the interrupt and queue EventFDs
-        Some((
-            self.common.interrupt_cb.take().unwrap(),
-            self.common.queue_evts.take().unwrap(),
-        ))
+        // Return the interrupt
+        Some(self.common.interrupt_cb.take().unwrap())
     }
 
     fn shutdown(&mut self) {

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -475,7 +475,7 @@ where
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.common.reset()
     }
 

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -358,7 +358,7 @@ impl VirtioDevice for Watchdog {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<(Arc<dyn VirtioInterrupt>, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.common.reset()
     }
 }


### PR DESCRIPTION
Rather than having to give and return the ioeventfd used for a device
clone them each time. This will make it simpler when we start handling
the driver enabling fewer queues than advertised by the device.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>