### PR TITLE
virtio-devices: Allow driver to program fewer queues

### DIFF
--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -332,6 +332,7 @@ impl Balloon {
                 avail_features,
                 paused_sync: Some(Arc::new(Barrier::new(2))),
                 queue_sizes: QUEUE_SIZES.to_vec(),
+                min_queues: NUM_QUEUES as u16,
                 ..Default::default()
             },
             id,

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -337,6 +337,7 @@ impl<T: DiskFile> Block<T> {
                 avail_features,
                 paused_sync: Some(Arc::new(Barrier::new(num_queues + 1))),
                 queue_sizes: vec![queue_size; num_queues],
+                min_queues: 1,
                 ..Default::default()
             },
             id,

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -444,8 +444,9 @@ impl<T: 'static + DiskFile + Send> VirtioDevice for Block<T> {
         self.update_writeback();
 
         let mut epoll_threads = Vec::new();
-        for i in 0..self.common.queue_sizes.len() {
+        for i in 0..queues.len() {
             let queue_evt = queue_evts.remove(0);
+            let queue = queues.remove(0);
             let kill_evt = self
                 .common
                 .kill_evt
@@ -467,7 +468,7 @@ impl<T: 'static + DiskFile + Send> VirtioDevice for Block<T> {
                     ActivateError::BadActivate
                 })?;
             let mut handler = BlockEpollHandler {
-                queue: queues.remove(0),
+                queue,
                 mem: mem.clone(),
                 disk_image: self.disk_image.clone(),
                 disk_nsectors: self.disk_nsectors,

--- a/virtio-devices/src/block_io_uring.rs
+++ b/virtio-devices/src/block_io_uring.rs
@@ -378,6 +378,7 @@ impl BlockIoUring {
                 avail_features,
                 paused_sync: Some(Arc::new(Barrier::new(num_queues + 1))),
                 queue_sizes: vec![queue_size; num_queues],
+                min_queues: 1,
                 ..Default::default()
             },
             id,

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -348,6 +348,7 @@ impl Console {
                     queue_sizes: QUEUE_SIZES.to_vec(),
                     avail_features,
                     paused_sync: Some(Arc::new(Barrier::new(2))),
+                    min_queues: NUM_QUEUES as u16,
                     ..Default::default()
                 },
                 id,

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -250,10 +250,10 @@ impl VirtioCommon {
         queue_evts: &[EventFd],
         interrupt_cb: &Arc<dyn VirtioInterrupt>,
     ) -> ActivateResult {
-        if queues.len() != self.queue_sizes.len() || queue_evts.len() != self.queue_sizes.len() {
+        if queues.len() != queue_evts.len() {
             error!(
-                "Cannot perform activate. Expected {} queue(s), got {}",
-                self.queue_sizes.len(),
+                "Cannot activate: length mismatch: queue_evts={} queues={}",
+                queue_evts.len(),
                 queues.len()
             );
             return Err(ActivateError::BadActivate);

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -224,6 +224,7 @@ pub struct VirtioCommon {
     pub epoll_threads: Option<Vec<thread::JoinHandle<()>>>,
     pub queue_sizes: Vec<u16>,
     pub device_type: u32,
+    pub min_queues: u16,
 }
 
 impl VirtioCommon {
@@ -255,6 +256,15 @@ impl VirtioCommon {
                 "Cannot activate: length mismatch: queue_evts={} queues={}",
                 queue_evts.len(),
                 queues.len()
+            );
+            return Err(ActivateError::BadActivate);
+        }
+
+        if queues.len() < self.min_queues.into() {
+            error!(
+                "Number of enabled queues lower tham min: {} vs {}",
+                queues.len(),
+                self.min_queues
             );
             return Err(ActivateError::BadActivate);
         }

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -764,6 +764,7 @@ impl Mem {
                 avail_features,
                 paused_sync: Some(Arc::new(Barrier::new(2))),
                 queue_sizes: QUEUE_SIZES.to_vec(),
+                min_queues: 1,
                 ..Default::default()
             },
             id,

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -256,6 +256,7 @@ impl Net {
                 avail_features,
                 queue_sizes: vec![queue_size; queue_num],
                 paused_sync: Some(Arc::new(Barrier::new((num_queues / 2) + 1))),
+                min_queues: 2,
                 ..Default::default()
             },
             id,

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -304,6 +304,7 @@ impl Pmem {
                 queue_sizes: QUEUE_SIZES.to_vec(),
                 paused_sync: Some(Arc::new(Barrier::new(2))),
                 avail_features,
+                min_queues: 1,
                 ..Default::default()
             },
             id,

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -158,6 +158,7 @@ impl Rng {
                 queue_sizes: QUEUE_SIZES.to_vec(),
                 paused_sync: Some(Arc::new(Barrier::new(2))),
                 avail_features,
+                min_queues: 1,
                 ..Default::default()
             },
             id,

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -135,6 +135,7 @@ impl Blk {
                 avail_features,
                 acked_features,
                 paused_sync: Some(Arc::new(Barrier::new(vu_cfg.num_queues + 1))),
+                min_queues: 1,
                 ..Default::default()
             },
             id,

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -352,6 +352,7 @@ impl Fs {
                 acked_features,
                 queue_sizes: vec![queue_size; num_queues],
                 paused_sync: Some(Arc::new(Barrier::new(2))),
+                min_queues: NUM_QUEUE_OFFSET as u16,
                 ..Default::default()
             },
             id,

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -144,6 +144,7 @@ impl Net {
                 avail_features,
                 acked_features,
                 paused_sync: Some(Arc::new(Barrier::new((vu_cfg.num_queues / 2) + 1))),
+                min_queues: 2,
                 ..Default::default()
             },
             vhost_user_net,

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -337,6 +337,7 @@ where
                 avail_features,
                 paused_sync: Some(Arc::new(Barrier::new(2))),
                 queue_sizes: QUEUE_SIZES.to_vec(),
+                min_queues: NUM_QUEUES as u16,
                 ..Default::default()
             },
             id,

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -193,6 +193,7 @@ impl Watchdog {
                 queue_sizes: QUEUE_SIZES.to_vec(),
                 paused_sync: Some(Arc::new(Barrier::new(2))),
                 avail_features,
+                min_queues: 1,
                 ..Default::default()
             },
             id,


### PR DESCRIPTION
From the virtio 1.1 spec

> num_queues
    is the total number of request virtqueues exposed by the device. The driver MAY use only one request queue, or it can use more to achieve better performance. 

Support this use case by allowing the driver to program fewer queues by only providing the device implementation with a list of queues that is filtered to only include those that are enabled.

Fixes: #2136