### PR TITLE
vm-virtio: Fix update_avail_event() memory ordering

### DIFF
--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -607,8 +607,8 @@ impl Queue {
             None => warn!("Can't update avail_event"),
         }
 
-        // This fence ensures the guest sees the value we've just written.
-        fence(Ordering::Release);
+        // This fence ensures both guest and us see the correct value (avail idx and avail event)
+        fence(Ordering::SeqCst);
     }
 
     /// Return the value present in the used_event field of the avail ring.


### PR DESCRIPTION
We should use full memory barrier to ensure both guest and us
can see the correct avail_idx and avail_event_idx. Something
like this pattern:
```
VM:                           CLH:
update vring.avail->idx       update avail_event_idx
mb()                          mb()
read avail_event_idx          read vring.avail->idx
```

Signed-off-by: Xie Yongji <xieyongji@bytedance.com>