### PR TITLE
.github: Simplify cross-build action

### DIFF
--- a/.github/workflows/cross-build.yaml
+++ b/.github/workflows/cross-build.yaml
@@ -23,7 +23,7 @@ jobs:
             target: ${{ matrix.target }}
             override: true
       - name: Install arm64 libfdt
-        run: wget http://ftp.us.debian.org/debian/pool/main/d/device-tree-compiler/libfdt-dev_1.6.0-1_arm64.deb && dpkg-deb -xv libfdt-dev_1.6.0-1_arm64.deb ./tlibfdtdev && sudo mkdir /tmmmp && mkdir target && mkdir target/debug && mkdir target/debug/deps && sudo cp ./tlibfdtdev/usr/lib/aarch64-linux-gnu/libfdt.a target/debug/deps/libfdt.a && echo "libfdt installed"
+        run: wget http://ftp.us.debian.org/debian/pool/main/d/device-tree-compiler/libfdt-dev_1.6.0-1_arm64.deb && dpkg-deb -xv libfdt-dev_1.6.0-1_arm64.deb ./tlibfdtdev && mkdir -p target/debug/deps &&  cp ./tlibfdtdev/usr/lib/aarch64-linux-gnu/libfdt.a target/debug/deps/ && echo "libfdt copied into build tree"
       - name: Build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Remove unnecessary commands to simplify the cross-build action.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>