### PR TITLE
vmm: acpi: Support compiling ACPI code on aarch64

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1201,17 +1201,20 @@ impl DeviceManager {
         self.bus_devices
             .push(Arc::clone(&shutdown_device) as Arc<Mutex<dyn BusDevice>>);
 
-        self.address_manager
-            .allocator
-            .lock()
-            .unwrap()
-            .allocate_io_addresses(Some(GuestAddress(0x3c0)), 0x8, None)
-            .ok_or(DeviceManagerError::AllocateIOPort)?;
+        #[cfg(target_arch = "x86_64")]
+        {
+            self.address_manager
+                .allocator
+                .lock()
+                .unwrap()
+                .allocate_io_addresses(Some(GuestAddress(0x3c0)), 0x8, None)
+                .ok_or(DeviceManagerError::AllocateIOPort)?;
 
-        self.address_manager
-            .io_bus
-            .insert(shutdown_device, 0x3c0, 0x4)
-            .map_err(DeviceManagerError::BusError)?;
+            self.address_manager
+                .io_bus
+                .insert(shutdown_device, 0x3c0, 0x4)
+                .map_err(DeviceManagerError::BusError)?;
+        }
 
         let ged_irq = self
             .address_manager
@@ -1253,17 +1256,20 @@ impl DeviceManager {
         self.bus_devices
             .push(Arc::clone(&pm_timer_device) as Arc<Mutex<dyn BusDevice>>);
 
-        self.address_manager
-            .allocator
-            .lock()
-            .unwrap()
-            .allocate_io_addresses(Some(GuestAddress(0xb008)), 0x4, None)
-            .ok_or(DeviceManagerError::AllocateIOPort)?;
+        #[cfg(target_arch = "x86_64")]
+        {
+            self.address_manager
+                .allocator
+                .lock()
+                .unwrap()
+                .allocate_io_addresses(Some(GuestAddress(0xb008)), 0x4, None)
+                .ok_or(DeviceManagerError::AllocateIOPort)?;
 
-        self.address_manager
-            .io_bus
-            .insert(pm_timer_device, 0xb008, 0x4)
-            .map_err(DeviceManagerError::BusError)?;
+            self.address_manager
+                .io_bus
+                .insert(pm_timer_device, 0xb008, 0x4)
+                .map_err(DeviceManagerError::BusError)?;
+        }
 
         Ok(Some(ged_device))
     }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1033,6 +1033,17 @@ impl Vm {
 
         let pci_space = (pci_space_start.0, pci_space_size);
 
+        #[cfg(feature = "acpi")]
+        {
+            let _ = crate::acpi::create_acpi_tables(
+                &mem,
+                &self.device_manager,
+                &self.cpu_manager,
+                &self.memory_manager,
+                &self.numa_nodes,
+            );
+        }
+
         // Call `configure_system` and pass the GIC devices out, so that
         // we can register the GIC device to the device manager.
         let gic_device = arch::configure_system(


### PR DESCRIPTION
This skeleton commit brings in the support for compiling aarch64 with
the "acpi" feature ready to the ACPI enabling. It builds on the work to
move the ACPI hotplug devices from I/O ports to MMIO and conditionalises
any code that is x86_64 only (i.e. because it uses an I/O port.)

Filling in the aarch64 specific details in tables such as the MADT it
out of the scope.

See: #2178

Signed-off-by: Rob Bradford <robert.bradford@intel.com>