### PR TITLE
hypervisor: fix exception vector numbers

### DIFF
--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -43,8 +43,8 @@ pub const NUM_IOAPIC_PINS: usize = 24;
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub enum Exception {
-    DE = 1,  // Divide Error
-    DB = 2,  // Debug Exception
+    DE = 0,  // Divide Error
+    DB = 1,  // Debug Exception
     BP = 3,  // Breakpoint
     OF = 4,  // Overflow
     BR = 5,  // BOUND Range Exceeded


### PR DESCRIPTION
According to Intel SDM, #DE should be 0 and #DB should be 1.

Signed-off-by: Wei Liu <liuwe@microsoft.com>