### PR TITLE
tests: Support filtering integration tests

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -221,7 +221,7 @@ sudo bash -c "echo 10 > /sys/kernel/mm/ksm/sleep_millisecs"
 sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 
 export RUST_BACKTRACE=1
-time cargo test $features_test "tests::parallel::"
+time cargo test $features_test "tests::parallel::$test_filter"
 RES=$?
 
 # Tear vhost_user_net test network down

--- a/scripts/run_integration_tests_sgx.sh
+++ b/scripts/run_integration_tests_sgx.sh
@@ -22,7 +22,7 @@ strip target/$BUILD_TARGET/release/cloud-hypervisor
 
 export RUST_BACKTRACE=1
 
-time cargo test $features_test "tests::sgx::"
+time cargo test $features_test "tests::sgx::$test_filter"
 RES=$?
 
 exit $RES

--- a/scripts/run_integration_tests_windows.sh
+++ b/scripts/run_integration_tests_windows.sh
@@ -32,7 +32,7 @@ export RUST_BACKTRACE=1
 
 # Only run with 1 thread to avoid tests interfering with one another because
 # Windows has a static IP configured
-time cargo test $features_test "tests::windows::" -- --test-threads=1
+time cargo test $features_test "tests::windows::$test_filter" -- --test-threads=1
 RES=$?
 
 dmsetup remove_all -f

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -9,7 +9,6 @@ export BUILD_TARGET=${BUILD_TARGET-x86_64-unknown-linux-gnu}
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
 
-
 process_common_args "$@"
 
 # For now these values are deafult for kvm
@@ -243,14 +242,14 @@ echo 4096 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 export RUST_BACKTRACE=1
-time cargo test $features_test "tests::parallel::"
+time cargo test $features_test "tests::parallel::$test_filter"
 RES=$?
 
 # Run some tests in sequence since the result could be affected by other tests
 # running in parallel.
 if [ $RES -eq 0 ]; then
     export RUST_BACKTRACE=1
-    time cargo test $features_test "tests::sequential::" -- --test-threads=1
+    time cargo test $features_test "tests::sequential::$test_filter" -- --test-threads=1
     RES=$?
 fi
 

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 hypervisor="kvm"
+test_filter=""
+
 cmd_help() {
     echo ""
     echo "Cloud Hypervisor $(basename $0)"
@@ -8,6 +10,7 @@ cmd_help() {
     echo "Available arguments:"
     echo ""
     echo "    --hypervisor  Underlying hypervisor. Options kvm, mshv"
+    echo "    --test-filter Tests to run"
     echo ""
     echo "    --help        Display this help message."
     echo ""
@@ -21,8 +24,11 @@ process_common_args() {
                 shift
                 hypervisor="$1"
                 ;;
+            "--test-filter")
+                shift
+                test_filter="$1"
+                ;;
             *)
-            # We only care about hypervisor , do nothing for other arguments
 		;;
 	esac
 	shift


### PR DESCRIPTION
e.g.

scripts/dev_cli.sh tests --integration -- --test-filter test_watchdog

This used to be supported by passing "$@" but was broken when multiple
hypervisor support was added.

Fixes: #2182

Signed-off-by: Rob Bradford <robert.bradford@intel.com>