### PR TITLE
tests: Add clippy check for integration test building

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Clippy (mshv)
         run: cargo clippy --all --all-targets --no-default-features --tests --features "mshv" -- -D warnings
+
+      - name: Clippy (integration tests)
+        run: cargo clippy --all --all-targets --tests --features "integration_tests" -- -D warnings

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -447,8 +447,8 @@ mod tests {
                 .expect("Expect device mapper nodes to be ready");
 
             self.osdisk_path = format!("/dev/mapper/{}", windows_snapshot);
-            self.windows_snapshot_cow = windows_snapshot_cow.clone();
-            self.windows_snapshot = windows_snapshot.clone();
+            self.windows_snapshot_cow = windows_snapshot_cow;
+            self.windows_snapshot = windows_snapshot;
         }
 
         fn disk(&self, disk_type: DiskType) -> Option<String> {


### PR DESCRIPTION
Ensure that we try and keep the integration tests clippy clean.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>