### PR TITLE
scripts: Don't download container on help invocations

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -235,6 +235,12 @@ cmd_build() {
 	esac
 	shift
     done
+
+    ensure_build_dir
+    if [ $(uname -m) = "x86_64" ]; then
+	ensure_latest_ctr
+    fi
+
     process_volumes_args
     if [[ "$hypervisor" != "kvm" ]]; then
         die "Hypervisor value must be kvm"
@@ -268,6 +274,11 @@ cmd_build() {
 
 cmd_clean() {
     cargo_args=("$@")
+
+    ensure_build_dir
+    if [ $(uname -m) = "x86_64" ]; then
+	ensure_latest_ctr
+    fi
 
     $DOCKER_RUNTIME run \
 	   --user "$(id -u):$(id -g)" \
@@ -323,6 +334,11 @@ cmd_tests() {
         die "Hypervisor value must be kvm"
     fi
     set -- "$@" '--hypervisor' $hypervisor
+
+    ensure_build_dir
+    if [ $(uname -m) = "x86_64" ]; then
+	ensure_latest_ctr
+    fi
 
     process_volumes_args
     target="$(uname -m)-unknown-linux-${libc}"
@@ -433,6 +449,11 @@ cmd_build-container() {
 	shift
     done
 
+    ensure_build_dir
+    if [ $(uname -m) = "x86_64" ]; then
+	ensure_latest_ctr
+    fi
+
     BUILD_DIR=/tmp/cloud-hypervisor/container/
 
     mkdir -p $BUILD_DIR
@@ -450,6 +471,10 @@ cmd_build-container() {
 }
 
 cmd_shell() {
+    ensure_build_dir
+    if [ $(uname -m) = "x86_64" ]; then
+	ensure_latest_ctr
+    fi
     say_warn "Starting a privileged shell prompt as root ..."
     say_warn "WARNING: Your $CLH_ROOT_DIR folder will be bind-mounted in the container under $CTR_CLH_ROOT_DIR"
     $DOCKER_RUNTIME run \
@@ -496,9 +521,5 @@ ok_or_die "Unknown command: $1. Please use \`$0 help\` for help."
 cmd=cmd_$1
 shift
 
-ensure_build_dir
-if [ $(uname -m) = "x86_64" ]; then
-    ensure_latest_ctr
-fi
 
 $cmd "$@"


### PR DESCRIPTION
Delay downloading the container until it is being used.

Fixes: #2065

Signed-off-by: Rob Bradford <robert.bradford@intel.com>