### PR TITLE
Accept multiple TAP fds for creating virtio-net devices

### DIFF
--- a/net_util/src/open_tap.rs
+++ b/net_util/src/open_tap.rs
@@ -65,6 +65,7 @@ pub fn open_tap(
     netmask: Option<Ipv4Addr>,
     host_mac: &mut Option<MacAddr>,
     num_rx_q: usize,
+    flags: Option<i32>,
 ) -> Result<Vec<Tap>> {
     let mut taps: Vec<Tap> = Vec::new();
     let mut ifname: String = String::new();
@@ -82,7 +83,7 @@ pub fn open_tap(
         let tap: Tap;
         if i == 0 {
             tap = match if_name {
-                Some(name) => Tap::open_named(name, num_rx_q, None).map_err(Error::TapOpen)?,
+                Some(name) => Tap::open_named(name, num_rx_q, flags).map_err(Error::TapOpen)?,
                 None => Tap::new(num_rx_q).map_err(Error::TapOpen)?,
             };
             if let Some(ip) = ip_addr {
@@ -104,7 +105,7 @@ pub fn open_tap(
 
             ifname = String::from_utf8(tap.get_if_name()).unwrap();
         } else {
-            tap = Tap::open_named(ifname.as_str(), num_rx_q, None).map_err(Error::TapOpen)?;
+            tap = Tap::open_named(ifname.as_str(), num_rx_q, flags).map_err(Error::TapOpen)?;
             tap.set_offload(flag).map_err(Error::TapSetOffload)?;
 
             tap.set_vnet_hdr_size(vnet_hdr_size)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5724,11 +5724,6 @@ mod tests {
             let _ = child.kill();
             let output = child.wait_with_output().unwrap();
 
-            std::process::Command::new("bash")
-                .args(&["-c", "sudo ip tuntap del mode tap name chtap0"])
-                .status()
-                .expect("Expected upping interface to work");
-
             handle_child_output(r, &output);
         }
     }

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -143,6 +143,7 @@ impl VhostUserNetBackend {
             Some(netmask),
             &mut Some(host_mac),
             num_queues / 2,
+            None,
         )
         .map_err(Error::OpenTap)?;
 

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -283,7 +283,7 @@ impl Net {
         queue_size: u16,
         seccomp_action: SeccompAction,
     ) -> Result<Self> {
-        let taps = open_tap(if_name, ip_addr, netmask, host_mac, num_queues / 2)
+        let taps = open_tap(if_name, ip_addr, netmask, host_mac, num_queues / 2, None)
             .map_err(Error::OpenTap)?;
 
         Self::new_with_tap(

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -398,7 +398,7 @@ components:
         pci_bdf:
           type: integer
           format: int32
-        
+
     VmCounters:
       type: object
       additionalProperties:
@@ -665,8 +665,10 @@ components:
         id:
           type: string
         fd:
-          type: integer
-          format: int32
+          type: array
+          items:
+            type: integer
+            format: int32
 
     RngConfig:
       required:

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1790,11 +1790,11 @@ impl DeviceManager {
                     )
                     .map_err(DeviceManagerError::CreateVirtioNet)?,
                 ))
-            } else if let Some(fd) = net_cfg.fd {
+            } else if let Some(fds) = &net_cfg.fds {
                 Arc::new(Mutex::new(
-                    virtio_devices::Net::from_tap_fd(
+                    virtio_devices::Net::from_tap_fds(
                         id.clone(),
-                        fd,
+                        fds,
                         Some(net_cfg.mac),
                         net_cfg.iommu,
                         net_cfg.queue_size,


### PR DESCRIPTION
This patch enables multi-queue support for creating virtio-net devices by
accepting multiple TAP fds, e.g. '--net fds=3:7'. It also extends the existing
integration test `test_tap_from_fd()`.

Fixes: #2164

Signed-off-by: Bo Chen <chen.bo@intel.com>