### PR TITLE
vmm: drop unnecessary semicolon

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -393,7 +393,7 @@ pub fn get_win_size() -> (u16, u16) {
         cols: u16,
         xpixel: u16,
         ypixel: u16,
-    };
+    }
     let ws: WS = WS::default();
 
     unsafe {


### PR DESCRIPTION
Building with 1.51 nightly produces the following warning:

warning: unnecessary trailing semicolon
   --> vmm/src/device_manager.rs:396:6
    |
396 |     };
    |      ^ help: remove this semicolon
    |
    = note: `#[warn(redundant_semicolons)]` on by default

warning: 1 warning emitted

Signed-off-by: Wei Liu <liuwe@microsoft.com>