### PR TITLE
vmm: Add support for fixed VHD disk files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "tempfile",
  "thiserror",
  "virtio-bindings",
  "vm-memory",

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -21,3 +21,6 @@ virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"]}
 vm-memory = { version = "0.4.0", features = ["backend-mmap", "backend-atomic"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
+
+[dev-dependencies]
+tempfile = "3.2.0"

--- a/block_util/src/fixed_vhd_async.rs
+++ b/block_util/src/fixed_vhd_async.rs
@@ -1,0 +1,110 @@
+// Copyright © 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::async_io::{
+    AsyncIo, AsyncIoError, AsyncIoResult, DiskFile, DiskFileError, DiskFileResult,
+};
+use crate::raw_async::RawFileAsync;
+use crate::vhd::VhdFooter;
+use std::fs::File;
+use std::os::unix::io::{AsRawFd, RawFd};
+use vmm_sys_util::eventfd::EventFd;
+
+pub struct FixedVhdDiskAsync {
+    file: File,
+    size: u64,
+}
+
+impl FixedVhdDiskAsync {
+    pub fn new(mut file: File) -> std::io::Result<Self> {
+        let footer = VhdFooter::new(&mut file)?;
+
+        Ok(FixedVhdDiskAsync {
+            file,
+            size: footer.current_size(),
+        })
+    }
+}
+
+impl DiskFile for FixedVhdDiskAsync {
+    fn size(&mut self) -> DiskFileResult<u64> {
+        Ok(self.size)
+    }
+
+    fn new_async_io(&self, ring_depth: u32) -> DiskFileResult<Box<dyn AsyncIo>> {
+        Ok(Box::new(
+            FixedVhdAsync::new(self.file.as_raw_fd(), ring_depth, self.size)
+                .map_err(DiskFileError::NewAsyncIo)?,
+        ) as Box<dyn AsyncIo>)
+    }
+}
+
+pub struct FixedVhdAsync {
+    raw_file_async: RawFileAsync,
+    size: u64,
+}
+
+impl FixedVhdAsync {
+    pub fn new(fd: RawFd, ring_depth: u32, size: u64) -> std::io::Result<Self> {
+        let raw_file_async = RawFileAsync::new(fd, ring_depth)?;
+
+        Ok(FixedVhdAsync {
+            raw_file_async,
+            size,
+        })
+    }
+}
+
+impl AsyncIo for FixedVhdAsync {
+    fn notifier(&self) -> &EventFd {
+        self.raw_file_async.notifier()
+    }
+
+    fn read_vectored(
+        &mut self,
+        offset: libc::off_t,
+        iovecs: Vec<libc::iovec>,
+        user_data: u64,
+    ) -> AsyncIoResult<()> {
+        if offset as u64 >= self.size {
+            return Err(AsyncIoError::ReadVectored(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "Invalid offset {}, can't be larger than file size {}",
+                    offset, self.size
+                ),
+            )));
+        }
+
+        self.raw_file_async.read_vectored(offset, iovecs, user_data)
+    }
+
+    fn write_vectored(
+        &mut self,
+        offset: libc::off_t,
+        iovecs: Vec<libc::iovec>,
+        user_data: u64,
+    ) -> AsyncIoResult<()> {
+        if offset as u64 >= self.size {
+            return Err(AsyncIoError::WriteVectored(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "Invalid offset {}, can't be larger than file size {}",
+                    offset, self.size
+                ),
+            )));
+        }
+
+        self.raw_file_async
+            .write_vectored(offset, iovecs, user_data)
+    }
+
+    fn fsync(&mut self, user_data: Option<u64>) -> AsyncIoResult<()> {
+        self.raw_file_async.fsync(user_data)
+    }
+
+    fn complete(&mut self) -> Vec<(u64, i32)> {
+        self.raw_file_async.complete()
+    }
+}

--- a/block_util/src/fixed_vhd_sync.rs
+++ b/block_util/src/fixed_vhd_sync.rs
@@ -1,0 +1,107 @@
+// Copyright © 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::async_io::{
+    AsyncIo, AsyncIoError, AsyncIoResult, DiskFile, DiskFileError, DiskFileResult,
+};
+use crate::raw_sync::RawFileSync;
+use crate::vhd::VhdFooter;
+use std::fs::File;
+use std::os::unix::io::{AsRawFd, RawFd};
+use vmm_sys_util::eventfd::EventFd;
+
+pub struct FixedVhdDiskSync {
+    file: File,
+    size: u64,
+}
+
+impl FixedVhdDiskSync {
+    pub fn new(mut file: File) -> std::io::Result<Self> {
+        let footer = VhdFooter::new(&mut file)?;
+
+        Ok(FixedVhdDiskSync {
+            file,
+            size: footer.current_size(),
+        })
+    }
+}
+
+impl DiskFile for FixedVhdDiskSync {
+    fn size(&mut self) -> DiskFileResult<u64> {
+        Ok(self.size)
+    }
+
+    fn new_async_io(&self, _ring_depth: u32) -> DiskFileResult<Box<dyn AsyncIo>> {
+        Ok(Box::new(
+            FixedVhdSync::new(self.file.as_raw_fd(), self.size)
+                .map_err(DiskFileError::NewAsyncIo)?,
+        ) as Box<dyn AsyncIo>)
+    }
+}
+
+pub struct FixedVhdSync {
+    raw_file_sync: RawFileSync,
+    size: u64,
+}
+
+impl FixedVhdSync {
+    pub fn new(fd: RawFd, size: u64) -> std::io::Result<Self> {
+        Ok(FixedVhdSync {
+            raw_file_sync: RawFileSync::new(fd),
+            size,
+        })
+    }
+}
+
+impl AsyncIo for FixedVhdSync {
+    fn notifier(&self) -> &EventFd {
+        self.raw_file_sync.notifier()
+    }
+
+    fn read_vectored(
+        &mut self,
+        offset: libc::off_t,
+        iovecs: Vec<libc::iovec>,
+        user_data: u64,
+    ) -> AsyncIoResult<()> {
+        if offset as u64 >= self.size {
+            return Err(AsyncIoError::ReadVectored(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "Invalid offset {}, can't be larger than file size {}",
+                    offset, self.size
+                ),
+            )));
+        }
+
+        self.raw_file_sync.read_vectored(offset, iovecs, user_data)
+    }
+
+    fn write_vectored(
+        &mut self,
+        offset: libc::off_t,
+        iovecs: Vec<libc::iovec>,
+        user_data: u64,
+    ) -> AsyncIoResult<()> {
+        if offset as u64 >= self.size {
+            return Err(AsyncIoError::WriteVectored(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "Invalid offset {}, can't be larger than file size {}",
+                    offset, self.size
+                ),
+            )));
+        }
+
+        self.raw_file_sync.write_vectored(offset, iovecs, user_data)
+    }
+
+    fn fsync(&mut self, user_data: Option<u64>) -> AsyncIoResult<()> {
+        self.raw_file_sync.fsync(user_data)
+    }
+
+    fn complete(&mut self) -> Vec<(u64, i32)> {
+        self.raw_file_sync.complete()
+    }
+}

--- a/block_util/src/lib.rs
+++ b/block_util/src/lib.rs
@@ -15,6 +15,7 @@ extern crate serde_derive;
 
 pub mod async_io;
 pub mod fixed_vhd_async;
+pub mod fixed_vhd_sync;
 pub mod qcow_sync;
 pub mod raw_async;
 pub mod raw_sync;

--- a/block_util/src/vhd.rs
+++ b/block_util/src/vhd.rs
@@ -1,0 +1,120 @@
+// Copyright © 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryInto;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+
+#[derive(Clone, Copy)]
+pub struct VhdFooter {
+    cookie: u64,
+    features: u32,
+    file_format_version: u32,
+    data_offset: u64,
+    time_stamp: u32,
+    creator_application: u32,
+    creator_version: u32,
+    creator_host_os: u32,
+    original_size: u64,
+    current_size: u64,
+    disk_geometry: u32,
+    disk_type: u32,
+    checksum: u32,
+    unique_id: u128,
+    saved_state: u8,
+}
+
+impl VhdFooter {
+    pub fn new(file: &mut File) -> std::io::Result<VhdFooter> {
+        // We must create a buffer aligned on 512 bytes with a size being a
+        // multiple of 512 bytes as the file might be opened with O_DIRECT flag.
+        #[repr(align(512))]
+        struct Sector {
+            data: [u8; 512],
+        }
+        let mut s = Sector { data: [0; 512] };
+
+        // Place the cursor 512 bytes before the end of the file, as this is
+        // where the footer starts.
+        file.seek(SeekFrom::End(-512))?;
+
+        // Fill in the VhdFooter structure
+        file.read_exact(&mut s.data)?;
+
+        Ok(VhdFooter {
+            cookie: u64::from_be_bytes(s.data[0..8].try_into().unwrap()),
+            features: u32::from_be_bytes(s.data[8..12].try_into().unwrap()),
+            file_format_version: u32::from_be_bytes(s.data[12..16].try_into().unwrap()),
+            data_offset: u64::from_be_bytes(s.data[16..24].try_into().unwrap()),
+            time_stamp: u32::from_be_bytes(s.data[24..28].try_into().unwrap()),
+            creator_application: u32::from_be_bytes(s.data[28..32].try_into().unwrap()),
+            creator_version: u32::from_be_bytes(s.data[32..36].try_into().unwrap()),
+            creator_host_os: u32::from_be_bytes(s.data[36..40].try_into().unwrap()),
+            original_size: u64::from_be_bytes(s.data[40..48].try_into().unwrap()),
+            current_size: u64::from_be_bytes(s.data[48..56].try_into().unwrap()),
+            disk_geometry: u32::from_be_bytes(s.data[56..60].try_into().unwrap()),
+            disk_type: u32::from_be_bytes(s.data[60..64].try_into().unwrap()),
+            checksum: u32::from_be_bytes(s.data[64..68].try_into().unwrap()),
+            unique_id: u128::from_be_bytes(s.data[68..84].try_into().unwrap()),
+            saved_state: u8::from_be_bytes(s.data[84..85].try_into().unwrap()),
+        })
+    }
+
+    pub fn cookie(&self) -> u64 {
+        self.cookie
+    }
+    pub fn features(&self) -> u32 {
+        self.features
+    }
+    pub fn file_format_version(&self) -> u32 {
+        self.file_format_version
+    }
+    pub fn data_offset(&self) -> u64 {
+        self.data_offset
+    }
+    pub fn time_stamp(&self) -> u32 {
+        self.time_stamp
+    }
+    pub fn creator_application(&self) -> u32 {
+        self.creator_application
+    }
+    pub fn creator_version(&self) -> u32 {
+        self.creator_version
+    }
+    pub fn creator_host_os(&self) -> u32 {
+        self.creator_host_os
+    }
+    pub fn original_size(&self) -> u64 {
+        self.original_size
+    }
+    pub fn current_size(&self) -> u64 {
+        self.current_size
+    }
+    pub fn disk_geometry(&self) -> u32 {
+        self.disk_geometry
+    }
+    pub fn disk_type(&self) -> u32 {
+        self.disk_type
+    }
+    pub fn checksum(&self) -> u32 {
+        self.checksum
+    }
+    pub fn unique_id(&self) -> u128 {
+        self.unique_id
+    }
+    pub fn saved_state(&self) -> u8 {
+        self.saved_state
+    }
+}
+
+/// Determine image type through file parsing.
+pub fn is_fixed_vhd(f: &mut File) -> std::io::Result<bool> {
+    let footer = VhdFooter::new(f)?;
+
+    // "conectix" => 0x636f6e6563746978
+    Ok(footer.cookie() == 0x636f6e6563746978
+        && footer.file_format_version() == 0x0001_0000
+        && footer.data_offset() == 0xffff_ffff_ffff_ffff
+        && footer.disk_type() == 0x2)
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -96,6 +96,10 @@ mod tests {
     const FOCAL_IMAGE_NAME_QCOW2: &str = "focal-server-cloudimg-arm64-custom.qcow2";
     #[cfg(target_arch = "x86_64")]
     const FOCAL_IMAGE_NAME_QCOW2: &str = "focal-server-cloudimg-amd64-custom-20210106-1.qcow2";
+    #[cfg(target_arch = "aarch64")]
+    const FOCAL_IMAGE_NAME_VHD: &str = "focal-server-cloudimg-arm64-custom.vhd";
+    #[cfg(target_arch = "x86_64")]
+    const FOCAL_IMAGE_NAME_VHD: &str = "focal-server-cloudimg-amd64-custom-20210106-1.vhd";
     #[cfg(target_arch = "x86_64")]
     const WINDOWS_IMAGE_NAME: &str = "windows-server-2019.raw";
 
@@ -3094,6 +3098,31 @@ mod tests {
         #[test]
         fn test_virtio_block_qcow2() {
             _test_virtio_block(FOCAL_IMAGE_NAME_QCOW2, false)
+        }
+
+        #[test]
+        fn test_virtio_block_vhd() {
+            let mut workload_path = dirs::home_dir().unwrap();
+            workload_path.push("workloads");
+
+            let mut raw_file_path = workload_path.clone();
+            let mut vhd_file_path = workload_path;
+            raw_file_path.push(FOCAL_IMAGE_NAME);
+            vhd_file_path.push(FOCAL_IMAGE_NAME_VHD);
+
+            // Generate VHD file from RAW file
+            std::process::Command::new("qemu-img")
+                .arg("convert")
+                .arg("-p")
+                .args(&["-f", "raw"])
+                .args(&["-O", "vpc"])
+                .args(&["-o", "subformat=fixed"])
+                .arg(raw_file_path.to_str().unwrap())
+                .arg(vhd_file_path.to_str().unwrap())
+                .output()
+                .expect("Expect generating VHD image from RAW image");
+
+            _test_virtio_block(FOCAL_IMAGE_NAME_VHD, false)
         }
 
         #[test]

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -106,6 +106,8 @@ fn virtio_block_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_openat),
         allow_syscall(libc::SYS_prctl),
         allow_syscall(libc::SYS_pread64),
+        allow_syscall(libc::SYS_preadv),
+        allow_syscall(libc::SYS_pwritev),
         allow_syscall(libc::SYS_read),
         allow_syscall(libc::SYS_rt_sigprocmask),
         allow_syscall(libc::SYS_sched_getaffinity),

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -105,6 +105,7 @@ fn virtio_block_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_munmap),
         allow_syscall(libc::SYS_openat),
         allow_syscall(libc::SYS_prctl),
+        allow_syscall(libc::SYS_pread64),
         allow_syscall(libc::SYS_read),
         allow_syscall(libc::SYS_rt_sigprocmask),
         allow_syscall(libc::SYS_sched_getaffinity),

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1686,7 +1686,7 @@ impl DeviceManager {
                         Box::new(RawFileDisk::new(file)) as Box<dyn DiskFile>
                     } else {
                         info!("Using synchronous RAW disk file");
-                        Box::new(RawFileDiskSync::new(file, disk_cfg.direct)) as Box<dyn DiskFile>
+                        Box::new(RawFileDiskSync::new(file)) as Box<dyn DiskFile>
                     }
                 }
                 ImageType::Qcow2 => {

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -344,8 +344,10 @@ fn vmm_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_pipe2),
         allow_syscall(libc::SYS_prctl),
         allow_syscall(libc::SYS_pread64),
+        allow_syscall(libc::SYS_preadv),
         allow_syscall(libc::SYS_prlimit64),
         allow_syscall(libc::SYS_pwrite64),
+        allow_syscall(libc::SYS_pwritev),
         allow_syscall(libc::SYS_read),
         #[cfg(target_arch = "x86_64")]
         allow_syscall(libc::SYS_readlink),


### PR DESCRIPTION
This PR adds both synchronous and asynchronous support for fixed VHD disk files.

Fixes #2185