### PR TITLE
vmm: Remove unneeded `return` statement

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3161,14 +3161,13 @@ impl DeviceManager {
 
     #[cfg(feature = "acpi")]
     pub fn notify_power_button(&self) -> DeviceManagerResult<()> {
-        return self
-            .ged_notification_device
+        self.ged_notification_device
             .as_ref()
             .unwrap()
             .lock()
             .unwrap()
             .notify(AcpiNotificationFlags::POWER_BUTTON_CHANGED)
-            .map_err(DeviceManagerError::PowerButtonNotification);
+            .map_err(DeviceManagerError::PowerButtonNotification)
     }
 }
 


### PR DESCRIPTION
This unneeded return statement giving clippy warnings

Signed-off-by: Muminul Islam <muislam@microsoft.com>