### PR TITLE
virtio-mem: Cleanup the code based on specification

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -330,8 +330,8 @@ pub enum DeviceManagerError {
     /// Cannot create virtio-mem device
     CreateVirtioMem(io::Error),
 
-    /// Cannot try Clone virtio-mem resize
-    TryCloneVirtioMemResize(virtio_devices::mem::Error),
+    /// Cannot generate a ResizeSender from the Resize object.
+    CreateResizeSender(virtio_devices::mem::Error),
 
     /// Cannot find a memory range for virtio-mem memory
     VirtioMemRangeAllocation,
@@ -2342,8 +2342,8 @@ impl DeviceManager {
                         virtio_mem_zone.region(),
                         virtio_mem_zone
                             .resize_handler()
-                            .try_clone()
-                            .map_err(DeviceManagerError::TryCloneVirtioMemResize)?,
+                            .new_resize_sender()
+                            .map_err(DeviceManagerError::CreateResizeSender)?,
                         self.seccomp_action.clone(),
                         node_id,
                         virtio_mem_zone.hotplugged_size(),

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2347,6 +2347,7 @@ impl DeviceManager {
                         self.seccomp_action.clone(),
                         node_id,
                         virtio_mem_zone.hotplugged_size(),
+                        virtio_mem_zone.hugepages(),
                     )
                     .map_err(DeviceManagerError::CreateVirtioMem)?,
                 ));

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -72,6 +72,7 @@ pub struct VirtioMemZone {
     region: Arc<GuestRegionMmap>,
     resize_handler: virtio_devices::Resize,
     hotplugged_size: u64,
+    hugepages: bool,
 }
 
 impl VirtioMemZone {
@@ -83,6 +84,9 @@ impl VirtioMemZone {
     }
     pub fn hotplugged_size(&self) -> u64 {
         self.hotplugged_size
+    }
+    pub fn hugepages(&self) -> bool {
+        self.hugepages
     }
 }
 
@@ -684,6 +688,7 @@ impl MemoryManager {
                             resize_handler: virtio_devices::Resize::new()
                                 .map_err(Error::EventFdFail)?,
                             hotplugged_size: zone.hotplugged_size.unwrap_or(0),
+                            hugepages: zone.hugepages,
                         });
 
                         start_of_device_area = start_addr


### PR DESCRIPTION
Relying on the virtio-mem specification, this PR performs a few simplifications. At the same time, it cleans up the code to make it more readable.

Fixes #1883