### PR TITLE
Allow controlling huge page size

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -15,6 +15,7 @@ struct MemoryConfig {
     mergeable: bool,
     shared: bool,
     hugepages: bool,
+    hugepage_size: Option<u64>,
     hotplug_method: HotplugMethod,
     hotplug_size: Option<u64>,
     hotplugged_size: Option<u64>,
@@ -76,23 +77,24 @@ _Example_
 --memory size=1G,shared=on
 ```
 
-### `hugepages`
+### `hugepages` and `hugepage_size`
 
-Specifies if the memory must be `mmap(2)` with `MAP_HUGETLB` and `MAP_HUGE_2MB`
-flags. This performs a memory mapping relying on 2MiB pages instead of the
-default 4kiB pages.
+Specifies if the memory must be created and `mmap(2)` with `MAP_HUGETLB` and size
+flags. This performs a memory mapping relying on the specified huge page size. If no huge page size is supplied the system's default huge page size is used.
 
 By using hugepages, one can improve the overall performance of the VM, assuming
 the guest will allocate hugepages as well. Another interesting use case is VFIO
 as it speeds up the VM's boot time since the amount of IOMMU mappings are
 reduced.
 
+The user is responsible for ensuring there are sufficient huge pages of the specified size for the VMM to use. Failure to do so may result in strange VMM behaviour.
+
 By default this option is turned off.
 
 _Example_
 
 ```
---memory size=1G,hugepages=on
+--memory size=1G,hugepages=on,hugepage_size=2M
 ```
 
 ### `hotplug_method`

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,8 @@ fn create_app<'a, 'b>(
                 .long("memory")
                 .help(
                     "Memory parameters \
-                     \"size=<guest_memory_size>,mergeable=on|off,shared=on|off,hugepages=on|off,\
+                     \"size=<guest_memory_size>,mergeable=on|off,shared=on|off,\
+                     hugepages=on|off,hugepage_size=<hugepage_size>\
                      hotplug_method=acpi|virtio-mem,\
                      hotplug_size=<hotpluggable_memory_size>,\
                      hotplugged_size=<hotplugged_memory_size>\"",
@@ -161,7 +162,9 @@ fn create_app<'a, 'b>(
                 .help(
                     "User defined memory zone parameters \
                      \"size=<guest_memory_region_size>,file=<backing_file>,\
-                     shared=on|off,hugepages=on|off,host_numa_node=<node_id>,\
+                     shared=on|off,\
+                     hugepages=on|off,hugepage_size=<hugepage_size>\
+                     host_numa_node=<node_id>,\
                      id=<zone_identifier>,hotplug_size=<hotpluggable_memory_size>,\
                      hotplugged_size=<hotplugged_memory_size>\"",
                 )
@@ -585,6 +588,7 @@ mod unit_tests {
                     shared: false,
                     hugepages: false,
                     zones: None,
+                    hugepage_size: None,
                 },
                 kernel: Some(KernelConfig {
                     path: PathBuf::from("/path/to/kernel"),

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -534,6 +534,9 @@ components:
         hugepages:
           type: boolean
           default: false
+        hugepage_size:
+          type: integer
+          format: int64
         host_numa_node:
           type: integer
           format: int32
@@ -571,6 +574,9 @@ components:
         hugepages:
           type: boolean
           default: false
+        hugepage_size:
+          type: integer
+          format: int64
         zones:
           type: array
           items:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2352,9 +2352,6 @@ mod tests {
         assert!(invalid_config.validate().is_err());
 
         let mut still_valid_config = valid_config;
-        invalid_config.fs = Some(vec![FsConfig {
-            ..Default::default()
-        }]);
         still_valid_config.memory.shared = true;
         assert!(still_valid_config.validate().is_ok());
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -548,6 +548,7 @@ impl MemoryManager {
                 file: None,
                 shared: config.shared,
                 hugepages: config.hugepages,
+                hugepage_size: config.hugepage_size,
                 host_numa_node: None,
                 hotplug_size: config.hotplug_size,
                 hotplugged_size: config.hotplugged_size,

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -127,6 +127,7 @@ pub struct MemoryManager {
     snapshot: Mutex<Option<GuestMemoryLoadGuard<GuestMemoryMmap>>>,
     shared: bool,
     hugepages: bool,
+    hugepage_size: Option<u64>,
     #[cfg(target_arch = "x86_64")]
     sgx_epc_region: Option<SgxEpcRegion>,
     user_provided_zones: bool,
@@ -422,6 +423,7 @@ impl MemoryManager {
                     prefault,
                     zone.shared,
                     zone.hugepages,
+                    zone.hugepage_size,
                     zone.host_numa_node,
                 )?;
 
@@ -675,6 +677,7 @@ impl MemoryManager {
                             false,
                             zone.shared,
                             zone.hugepages,
+                            zone.hugepage_size,
                             zone.host_numa_node,
                         )?;
 
@@ -751,6 +754,7 @@ impl MemoryManager {
             snapshot: Mutex::new(None),
             shared: config.shared,
             hugepages: config.hugepages,
+            hugepage_size: config.hugepage_size,
             #[cfg(target_arch = "x86_64")]
             sgx_epc_region: None,
             user_provided_zones,
@@ -923,6 +927,7 @@ impl MemoryManager {
         prefault: bool,
         shared: bool,
         hugepages: bool,
+        hugepage_size: Option<u64>,
         host_numa_node: Option<u32>,
     ) -> Result<Arc<GuestRegionMmap>, Error> {
         let (f, f_off) = match backing_file {
@@ -957,7 +962,23 @@ impl MemoryManager {
                 let fd = Self::memfd_create(
                     &ffi::CString::new("ch_ram").unwrap(),
                     if hugepages {
-                        libc::MFD_HUGETLB | libc::MAP_HUGE_2MB as u32
+                        libc::MFD_HUGETLB
+                            | if let Some(hugepage_size) = hugepage_size {
+                                /*
+                                 * From the Linux kernel:
+                                 * Several system calls take a flag to request "hugetlb" huge pages.
+                                 * Without further specification, these system calls will use the
+                                 * system's default huge page size.  If a system supports multiple
+                                 * huge page sizes, the desired huge page size can be specified in
+                                 * bits [26:31] of the flag arguments.  The value in these 6 bits
+                                 * will encode the log2 of the huge page size.
+                                 */
+
+                                hugepage_size.trailing_zeros() << 26
+                            } else {
+                                // Use the system default huge page size
+                                0
+                            }
                     } else {
                         0
                     },
@@ -1095,6 +1116,7 @@ impl MemoryManager {
             false,
             self.shared,
             self.hugepages,
+            self.hugepage_size,
             None,
         )?;
 


### PR DESCRIPTION
Allow the user to control the huge page size; it is the responsibility of the user to ensure they have enough pages of the required size available to use.

No integration test changes as we cannot add new page sizes at runtime.