### PR TITLE
ACPI initial support on AArch64

### DIFF
--- a/acpi_tables/Cargo.toml
+++ b/acpi_tables/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 vm-memory = "0.5.0"
-
+hex = "0.4.3"

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+extern crate hex;
 use std::marker::PhantomData;
 
 pub trait Aml {
@@ -259,6 +260,38 @@ impl EisaName {
 impl Aml for EisaName {
     fn to_aml_bytes(&self) -> Vec<u8> {
         self.value.to_aml_bytes()
+    }
+}
+
+// UUID (Universally Unique IDentifiers)
+pub struct Uuid {
+    pub data: Vec<u8>,
+}
+
+// Converts an ASCII UUID or GUID string to an encoded 128-bit Buffer object.
+// The UUID string is in the format of aabbccdd-eeff-gghh-iijj-kkllmmnnoopp,
+// where aa – pp are one byte hexadecimal numbers, made up of hexadecimal digits.
+impl Uuid {
+    pub fn new(str: String) -> Self {
+        let mut str = str;
+        let str = &mut str;
+
+        // remove '-' in the string
+        let index = vec![8, 12, 16, 20];
+        for i in index {
+            str.remove(i);
+        }
+
+        let ori = hex::decode(str).unwrap();
+        let mut ret: Vec<u8> = Vec::new();
+
+        // The result sequence of UUID, refer to ACPI specification version 6.3, Table 19-438
+        let index = vec![3, 2, 1, 0, 5, 4, 7, 6, 8, 9, 10, 11, 12, 13, 14, 15];
+        for i in index {
+            ret.push(ori[i]);
+        }
+
+        Uuid { data: ret }
     }
 }
 
@@ -1959,6 +1992,17 @@ mod tests {
                 ]
             )
             .to_aml_bytes(),
+            &data[..]
+        );
+    }
+
+    #[test]
+    fn test_uuid() {
+        let data = [
+            120, 86, 52, 18, 52, 18, 120, 86, 18, 52, 18, 52, 86, 120, 18, 52,
+        ];
+        assert_eq!(
+            Uuid::new("12345678-1234-5678-1234-123456781234".to_string()).data,
             &data[..]
         );
     }

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -16,8 +16,8 @@ use super::super::InitramfsConfig;
 use super::get_fdt_addr;
 use super::gic::GicDevice;
 use super::layout::{
-    FDT_MAX_SIZE, IRQ_BASE, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START, PCI_MMCONFIG_SIZE,
-    PCI_MMCONFIG_START,
+    FDT_MAX_SIZE, IRQ_BASE, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START, MEM_PCI_IO_SIZE,
+    MEM_PCI_IO_START, PCI_HIGH_BASE, PCI_MMCONFIG_SIZE, PCI_MMCONFIG_START,
 };
 use vm_fdt::{FdtWriter, FdtWriterResult};
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap};
@@ -412,7 +412,16 @@ fn create_pci_nodes(
     // Add node for PCIe controller.
     // See Documentation/devicetree/bindings/pci/host-generic-pci.txt in the kernel
     // and https://elinux.org/Device_Tree_Usage.
+    let pci_device_base = pci_device_base + PCI_HIGH_BASE;
     let ranges = [
+        // io addresses
+        0x1000000,
+        0_u32,
+        0_u32,
+        (MEM_PCI_IO_START.0 >> 32) as u32,
+        MEM_PCI_IO_START.0 as u32,
+        (MEM_PCI_IO_SIZE >> 32) as u32,
+        MEM_PCI_IO_SIZE as u32,
         // mmio addresses
         0x2000000,                                // (ss = 10: 32-bit memory space)
         (MEM_32BIT_DEVICES_START.0 >> 32) as u32, // PCI address

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -54,12 +54,12 @@ pub const UEFI_SIZE: u64 = 0x0400_0000;
 /// Below this address will reside the GIC, above this address will reside the MMIO devices.
 pub const MAPPED_IO_START: u64 = 0x0900_0000;
 
-/// Space 0x0900_0000 ~ 0x1000_0000 is reserved for legacy devices.
+/// Space 0x0900_0000 ~ 0x0905_0000 is reserved for legacy devices.
 pub const LEGACY_SERIAL_MAPPED_IO_START: u64 = 0x0900_0000;
 pub const LEGACY_RTC_MAPPED_IO_START: u64 = 0x0901_0000;
 pub const LEGACY_GPIO_MAPPED_IO_START: u64 = 0x0902_0000;
 
-/// Space 0x0905_0000 ~ 0x906_0000 is reserved for pcie io address
+/// Space 0x0905_0000 ~ 0x0906_0000 is reserved for pcie io address
 pub const MEM_PCI_IO_START: GuestAddress = GuestAddress(0x0905_0000);
 pub const MEM_PCI_IO_SIZE: u64 = 0x10000;
 
@@ -90,6 +90,9 @@ pub const RSDP_POINTER: GuestAddress = GuestAddress(ACPI_START);
 
 /// Kernel start after FDT and ACPI
 pub const KERNEL_START: u64 = ACPI_START + ACPI_MAX_SIZE as u64;
+
+/// Pci high memory base
+pub const PCI_HIGH_BASE: u64 = 0x80_0000_0000_u64;
 
 // As per virt/kvm/arm/vgic/vgic-kvm-device.c we need
 // the number of interrupts our GIC will support to be:

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -191,6 +191,11 @@ pub fn get_kernel_start() -> u64 {
     layout::KERNEL_START
 }
 
+///Return guest memory address where the uefi should be loaded.
+pub fn get_uefi_start() -> u64 {
+    layout::UEFI_START
+}
+
 // Auxiliary function to get the address where the device tree blob is loaded.
 fn get_fdt_addr() -> u64 {
     layout::FDT_START

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -72,7 +72,7 @@ pub mod aarch64;
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
     arch_memory_regions, configure_system, configure_vcpu, fdt::DeviceInfoForFdt,
-    get_host_cpu_phys_bits, get_kernel_start, initramfs_load_addr, layout,
+    get_host_cpu_phys_bits, get_kernel_start, get_uefi_start, initramfs_load_addr, layout,
     layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, EntryPoint,
 };
 

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -37,8 +37,12 @@ RUN apt-get update \
 	socat \
 	dosfstools \
 	cpio \
+	python \
+	python3 \
 	python3-setuptools \
 	ntfs-3g \
+	python3-distutils \
+	uuid-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -8,8 +8,72 @@ export BUILD_TARGET=${BUILD_TARGET-aarch64-unknown-linux-gnu}
 
 WORKLOADS_DIR="$HOME/workloads"
 WORKLOADS_LOCK="$WORKLOADS_DIR/integration_test.lock"
+EDK2_BUILD_DIR="$WORKLOADS_DIR/edk2_build"
 
 mkdir -p "$WORKLOADS_DIR"
+
+build_edk2() {
+    EDK2_REPO="https://github.com/jongwu/edk2.git"
+    EDK2_DIR="edk2"
+    EDK2_BRANCH="implement_clh"
+    EDK2_PLAT_REPO="https://github.com/tianocore/edk2-platforms.git"
+    EDK2_PLAT_DIR="edk2-platforms"
+    ACPICA_REPO="https://github.com/acpica/acpica.git"
+    ACPICA_DIR="acpica"
+
+    export WORKSPACE="$EDK2_BUILD_DIR"
+    export PACKAGES_PATH="$WORKSPACE/$EDK2_DIR:$WORKSPACE/$EDK2_PLAT_DIR"
+    export IASL_PREFIX="$WORKSPACE/acpica/generate/unix/bin/"
+
+    cd "$WORKLOADS_DIR"
+    if [ ! -d "$WORKSPACE" ]; then
+        mkdir -p "$WORKSPACE"
+    fi
+
+    pushd "$WORKSPACE"
+
+    # Check whether the local HEAD commit same as the remote HEAD or not. Remove the folder if they are different.
+    if [ -d "$EDK2_DIR" ]; then
+        pushd $EDK2_DIR
+        git fetch
+        EDK2_LOCAL_HEAD=$(git rev-parse HEAD)
+        EDK2_REMOTE_HEAD=$(git rev-parse remotes/origin/$EDK2_BRANCH)
+        popd
+        if [ "$EDK2_LOCAL_HEAD" != "$EDK2_REMOTE_HEAD" ]; then
+            # If EDK2 code is out of date, remove and rebuild all
+            rm -rf "$EDK2_DIR"
+            rm -rf "$EDK2_PLAT_DIR"
+            rm -rf "$ACPICA_DIR"
+        fi
+    fi
+
+    if [ ! -d "$EDK2_DIR" ]; then
+        time git clone --depth 1 "$EDK2_REPO" -b "$EDK2_BRANCH" "$EDK2_DIR"
+        pushd $EDK2_DIR
+        git submodule update --init
+        popd
+    fi
+
+    if [ ! -d "$EDK2_PLAT_DIR" ]; then
+        time git clone --depth 1 "$EDK2_PLAT_REPO" -b master "$EDK2_PLAT_DIR"
+    fi
+
+    if [ ! -d "$ACPICA_DIR" ]; then
+        time git clone --depth 1 "$ACPICA_REPO" -b master "$ACPICA_DIR"
+    fi
+
+    make -C "$ACPICA_DIR"/
+
+    source edk2/edksetup.sh
+    make -C edk2/BaseTools
+
+    build -a AARCH64 -t GCC5 -p ArmVirtPkg/ArmVirtCloudHv.dsc -b RELEASE
+    cp Build/ArmVirtCloudHv-AARCH64/RELEASE_GCC5/FV/CLOUDHV_EFI.fd "$WORKLOADS_DIR"
+
+    echo "Info: build UEFI successfully"
+
+    popd
+}
 
 update_workloads() {
     cp scripts/sha1sums-aarch64 $WORKLOADS_DIR
@@ -176,6 +240,9 @@ update_workloads() {
         echo "foo" > "$SHARED_DIR/file1"
         echo "bar" > "$SHARED_DIR/file3" || exit 1
     fi
+
+    # Check and build EDK2 binary
+    build_edk2
 }
 
 process_common_args "$@"
@@ -234,7 +301,6 @@ echo "Integration test on FDT finished with result $RES."
 if [ $RES -eq 0 ]; then
     # Test with EDK2 + ACPI
     cargo build --all --release $features_build_acpi --target $BUILD_TARGET
-
     RES=$?
     echo "Integration test on UEFI & ACPI finished with result $RES."
 fi

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -28,7 +28,7 @@ event_monitor = { path = "../event_monitor" }
 hypervisor = { path = "../hypervisor" }
 lazy_static = "1.4.0"
 libc = "0.2.95"
-linux-loader = { version = "0.3.0", features = ["elf", "bzimage", "pe"] }
+linux-loader = { git = "https://github.com/jongwu/linux-loader", branch = "uefi", version = "0.3.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.14"
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 net_util = { path = "../net_util" }

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -378,6 +378,8 @@ pub fn create_acpi_tables(
     guest_mem
         .write_slice(dsdt.as_slice(), dsdt_offset)
         .expect("Error writing DSDT table");
+    #[cfg(target_arch = "aarch64")]
+    tables.push(dsdt_offset.0);
 
     // FACP aka FADT
     let facp = create_facp_table(dsdt_offset);

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3736,23 +3736,17 @@ impl Aml for DeviceManager {
               {
                   If ((Arg2 == Zero))
                   {
-                      Return (Buffer (One)
-                      {
-                           0x21                                             // !
-                      })
+                      Return (Buffer (One) { 0x21 })
                   }
                   If ((Arg2 == 0x05))
                   {
                       Return (Zero)
                   }
               }
-
-              Return (Buffer (One)
-              {
-                   0x00                                             // .
-              })
+              Return (Buffer (One) { 0x00 })
         }
-        */
+         */
+        /*
         let uuid = aml::Uuid::new("E5C937D0-3553-4D7A-9117-EA4D19C3434D".to_string());
         let uuid = aml::Buffer::new(uuid.data);
         let buf1 = aml::Buffer::new(vec![0x21]);
@@ -3767,6 +3761,33 @@ impl Aml for DeviceManager {
         let dsm_if1 = aml::If::new(&dsm_eq1, vec![&dsm_if11, &dsm_if12]);
         let dsm_rt2 = aml::Return::new(&buf2);
         let dsm = aml::Method::new("_DSM".into(), 4, false, vec![&dsm_if1, &dsm_rt2]);
+         */
+        #[cfg(target_arch = "aarch64")]
+        let dsm = aml::Method::new(
+            "_DSM".into(),
+            4,
+            false,
+            vec![
+                &aml::If::new(
+                    &aml::Equal::new(
+                        &aml::Arg(0),
+                        &aml::Uuid::new("E5C937D0-3553-4D7A-9117-EA4D19C3434D".to_string()),
+                    ),
+                    vec![
+                        &aml::If::new(
+                            &aml::Equal::new(&aml::Arg(2), &aml::ZERO),
+                            vec![&aml::Return::new(&aml::Buffer::new(vec![0x21]))],
+                        ),
+                        &aml::If::new(
+                            &aml::Equal::new(&aml::Arg(2), &0x05u8),
+                            vec![&aml::Return::new(&aml::ZERO)],
+                        ),
+                    ],
+                ),
+                &aml::Return::new(&aml::Buffer::new(vec![0])),
+            ],
+        );
+        #[cfg(target_arch = "aarch64")]
         pci_dsdt_inner_data.push(&dsm);
 
         let crs = aml::Name::new(


### PR DESCRIPTION
Partially fixes https://github.com/cloud-hypervisor/cloud-hypervisor/issues/2178

This is an early version of ACPI support on AArch64.

By implementing following tables on AArch64, guest VM can boot successfully:
MADT, DSDT, GTDT, SPCR, FADT, MCFG, XSDT,IORT.

Limitations:
- On AArch64, ACPI have to work with EFI. But before EFI ready, we are using a hack setting in VM cmdline `acpi_rsdp=`. This is only a temporary solution for test purpose.
- Other related functionalities (like hot-plug) have not been tested.