### PR TITLE
vmm: drop two unused error

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -348,14 +348,8 @@ pub enum DeviceManagerError {
     /// Could not find the node in the device tree.
     MissingNode,
 
-    /// Could not find a MMIO range.
-    MmioRangeAllocation,
-
     /// Resource was already found.
     ResourceAlreadyExists,
-
-    /// Expected resources for virtio-mmio could not be found.
-    MissingVirtioMmioResources,
 
     /// Expected resources for virtio-pci could not be found.
     MissingVirtioPciResources,


### PR DESCRIPTION
Their last users were gone in af3c6c34c3d.

Signed-off-by: Wei Liu <liuwe@microsoft.com>