### PR TITLE
virtio-devices: vhost-user-net: unpark control queue thread in resume

### DIFF
--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -366,7 +366,12 @@ impl Pausable for Net {
     }
 
     fn resume(&mut self) -> result::Result<(), MigratableError> {
-        self.common.resume()
+        self.common.resume()?;
+
+        if let Some(ctrl_queue_epoll_thread) = &self.ctrl_queue_epoll_thread {
+            ctrl_queue_epoll_thread.thread().unpark();
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This thread is virtio-net specific, so it is not handled in the common
virtio device code.

The non-vhost implementation resumes the thread itself. Do the same
thing for vhost-user-net.

Signed-off-by: Wei Liu <liuwe@microsoft.com>