### PR TITLE
build: Update to latest kvm-ioctls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,8 +518,8 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.5.0"
-source = "git+https://github.com/cloud-hypervisor/kvm-ioctls?branch=ch#64427395b60e00403aed3026362a1b19873230e6"
+version = "0.6.0"
+source = "git+https://github.com/cloud-hypervisor/kvm-ioctls?branch=ch#b7f21758bf8e46ac55a28a1b2ed008b5732bbb44"
 dependencies = [
  "kvm-bindings",
  "libc",

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -182,7 +182,7 @@ impl vm::Vm for KvmVm {
     ) -> vm::Result<Arc<dyn cpu::Vcpu>> {
         let vc = self
             .fd
-            .create_vcpu(id)
+            .create_vcpu(id as u64)
             .map_err(|e| vm::HypervisorVmError::CreateVcpu(e.into()))?;
         let vcpu = KvmVcpu {
             fd: vc,


### PR DESCRIPTION
Update the version of the fork pointed to which has been rebased on the
latest upstream.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>