### PR TITLE
Move most CPUID changes to common CPUID patching code

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -63,7 +63,6 @@ pub fn configure_vcpu(
     id: u8,
     kernel_entry_point: Option<EntryPoint>,
     vm_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
-    _phys_bits: u8,
 ) -> super::Result<u64> {
     if let Some(kernel_entry_point) = kernel_entry_point {
         regs::setup_regs(

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -341,58 +341,6 @@ pub fn configure_vcpu(
     CpuidPatch::set_cpuid_reg(&mut cpuid, 0xb, None, CpuidReg::EDX, u32::from(id));
     CpuidPatch::set_cpuid_reg(&mut cpuid, 0x1f, None, CpuidReg::EDX, u32::from(id));
 
-    if kvm_hyperv {
-        // Remove conflicting entries
-        cpuid.retain(|c| c.function != 0x4000_0000);
-        cpuid.retain(|c| c.function != 0x4000_0001);
-
-        // See "Hypervisor Top Level Functional Specification" for details
-        // Compliance with "Hv#1" requires leaves up to 0x4000_000a
-        cpuid
-            .push(CpuIdEntry {
-                function: 0x40000000,
-                eax: 0x4000000a, // Maximum cpuid leaf
-                ebx: 0x756e694c, // "Linu"
-                ecx: 0x564b2078, // "x KV"
-                edx: 0x7648204d, // "M Hv"
-                ..Default::default()
-            })
-            .map_err(|_| Error::PopulatingCpuid)?;
-        cpuid
-            .push(CpuIdEntry {
-                function: 0x40000001,
-                eax: 0x31237648, // "Hv#1"
-                ..Default::default()
-            })
-            .map_err(|_| Error::PopulatingCpuid)?;
-        cpuid
-            .push(CpuIdEntry {
-                function: 0x40000002,
-                eax: 0x3839,  // "Build number"
-                ebx: 0xa0000, // "Version"
-                ..Default::default()
-            })
-            .map_err(|_| Error::PopulatingCpuid)?;
-        cpuid
-            .push(CpuIdEntry {
-                function: 0x4000_0003,
-                eax: 1 << 1 // AccessPartitionReferenceCounter
-                   | 1 << 2 // AccessSynicRegs
-                   | 1 << 3 // AccessSyntheticTimerRegs
-                   | 1 << 9, // AccessPartitionReferenceTsc
-                ..Default::default()
-            })
-            .map_err(|_| Error::PopulatingCpuid)?;
-        for i in 0x4000_0004..=0x4000_000a {
-            cpuid
-                .push(CpuIdEntry {
-                    function: i,
-                    ..Default::default()
-                })
-                .map_err(|_| Error::PopulatingCpuid)?;
-        }
-    }
-
     fd.set_cpuid2(&cpuid)
         .map_err(|e| Error::SetSupportedCpusFailed(e.into()))?;
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -393,22 +393,6 @@ pub fn configure_vcpu(
         }
     }
 
-    // Copy CPU identification string
-    for i in 0x8000_0002..=0x8000_0004 {
-        cpuid.retain(|c| c.function != i);
-        let leaf = unsafe { x86_64::__cpuid(i) };
-        cpuid
-            .push(CpuIdEntry {
-                function: i,
-                eax: leaf.eax,
-                ebx: leaf.ebx,
-                ecx: leaf.ecx,
-                edx: leaf.edx,
-                ..Default::default()
-            })
-            .map_err(|_| Error::PopulatingCpuid)?;
-    }
-
     fd.set_cpuid2(&cpuid)
         .map_err(|e| Error::SetSupportedCpusFailed(e.into()))?;
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -336,7 +336,6 @@ pub fn configure_vcpu(
     vm_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
     cpuid: CpuId,
     kvm_hyperv: bool,
-    phys_bits: u8,
 ) -> super::Result<()> {
     let mut cpuid = cpuid;
     CpuidPatch::set_cpuid_reg(&mut cpuid, 0xb, None, CpuidReg::EDX, u32::from(id));
@@ -408,13 +407,6 @@ pub fn configure_vcpu(
                 ..Default::default()
             })
             .map_err(|_| Error::PopulatingCpuid)?;
-    }
-
-    // Set CPU physical bits
-    for entry in cpuid.as_mut_slice().iter_mut() {
-        if entry.function == 0x8000_0008 {
-            entry.eax = (entry.eax & 0xffff_ff00) | (phys_bits as u32 & 0xff);
-        }
     }
 
     fd.set_cpuid2(&cpuid)

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -173,9 +173,6 @@ pub enum Error {
 
     /// Missing SGX_LC CPU feature
     MissingSgxLaunchControlFeature,
-
-    // Error populating Cpuid
-    PopulatingCpuid,
 }
 
 impl From<Error> for super::Error {
@@ -337,6 +334,7 @@ pub fn configure_vcpu(
     cpuid: CpuId,
     kvm_hyperv: bool,
 ) -> super::Result<()> {
+    // Per vCPU CPUID changes; common are handled via CpuManager::generate_common_cpuid()
     let mut cpuid = cpuid;
     CpuidPatch::set_cpuid_reg(&mut cpuid, 0xb, None, CpuidReg::EDX, u32::from(id));
     CpuidPatch::set_cpuid_reg(&mut cpuid, 0x1f, None, CpuidReg::EDX, u32::from(id));

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -554,7 +554,13 @@ impl CpuManager {
         #[cfg(target_arch = "x86_64")]
         let cpuid = {
             let phys_bits = physical_bits(config.max_phys_bits);
-            CpuManager::patch_cpuid(hypervisor, &config.topology, sgx_epc_sections, phys_bits)?
+            CpuManager::patch_cpuid(
+                hypervisor,
+                &config.topology,
+                sgx_epc_sections,
+                phys_bits,
+                config.kvm_hyperv,
+            )?
         };
 
         let device_manager = device_manager.lock().unwrap();
@@ -604,6 +610,7 @@ impl CpuManager {
         topology: &Option<CpuTopology>,
         sgx_epc_sections: Option<Vec<SgxEpcSection>>,
         phys_bits: u8,
+        kvm_hyperv: bool,
     ) -> Result<CpuId> {
         let mut cpuid_patches = Vec::new();
 
@@ -681,6 +688,57 @@ impl CpuManager {
                     ..Default::default()
                 })
                 .unwrap();
+        }
+
+        if kvm_hyperv {
+            // Remove conflicting entries
+            cpuid.retain(|c| c.function != 0x4000_0000);
+            cpuid.retain(|c| c.function != 0x4000_0001);
+            // See "Hypervisor Top Level Functional Specification" for details
+            // Compliance with "Hv#1" requires leaves up to 0x4000_000a
+            cpuid
+                .push(CpuIdEntry {
+                    function: 0x40000000,
+                    eax: 0x4000000a, // Maximum cpuid leaf
+                    ebx: 0x756e694c, // "Linu"
+                    ecx: 0x564b2078, // "x KV"
+                    edx: 0x7648204d, // "M Hv"
+                    ..Default::default()
+                })
+                .unwrap();
+            cpuid
+                .push(CpuIdEntry {
+                    function: 0x40000001,
+                    eax: 0x31237648, // "Hv#1"
+                    ..Default::default()
+                })
+                .unwrap();
+            cpuid
+                .push(CpuIdEntry {
+                    function: 0x40000002,
+                    eax: 0x3839,  // "Build number"
+                    ebx: 0xa0000, // "Version"
+                    ..Default::default()
+                })
+                .unwrap();
+            cpuid
+                .push(CpuIdEntry {
+                    function: 0x4000_0003,
+                    eax: 1 << 1 // AccessPartitionReferenceCounter
+                       | 1 << 2 // AccessSynicRegs
+                       | 1 << 3 // AccessSyntheticTimerRegs
+                       | 1 << 9, // AccessPartitionReferenceTsc
+                    ..Default::default()
+                })
+                .unwrap();
+            for i in 0x4000_0004..=0x4000_000a {
+                cpuid
+                    .push(CpuIdEntry {
+                        function: i,
+                        ..Default::default()
+                    })
+                    .unwrap();
+            }
         }
 
         Ok(cpuid)


### PR DESCRIPTION
For TDX enabling I need a set of common CPUID bits; rather than generate them afresh it would be nice to reuse the code. To facilitate this I move all the CPUID adjustments that are common for all vCPUs into one function.