### PR TITLE
arch, arch_gen, hypervisor: Remove some unnecessary clippy attributes

### DIFF
--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -6,13 +6,7 @@
 
 //! Implements platform specific functionality.
 //! Supported platforms: x86_64, aarch64.
-#![allow(
-    clippy::unreadable_literal,
-    clippy::redundant_static_lifetimes,
-    clippy::cast_lossless,
-    clippy::transmute_ptr_to_ptr,
-    clippy::cast_ptr_alignment
-)]
+#![allow(clippy::transmute_ptr_to_ptr, clippy::redundant_static_lifetimes)]
 
 extern crate anyhow;
 extern crate byteorder;

--- a/arch_gen/src/x86/mod.rs
+++ b/arch_gen/src/x86/mod.rs
@@ -8,14 +8,6 @@
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
-#[allow(
-    clippy::unreadable_literal,
-    clippy::redundant_static_lifetimes,
-    clippy::trivially_copy_pass_by_ref,
-    clippy::useless_transmute,
-    clippy::should_implement_trait,
-    clippy::transmute_ptr_to_ptr
-)]
 #[allow(non_camel_case_types)]
 #[allow(non_upper_case_globals)]
 #[allow(clippy::unreadable_literal, clippy::redundant_static_lifetimes)]

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -11,26 +11,13 @@
 // Copyright © 2020, Microsoft Corporation
 //
 
+pub mod emulator;
 pub mod gdt;
-
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
 #[allow(non_upper_case_globals)]
-#[allow(unused)]
-#[allow(
-    clippy::unreadable_literal,
-    clippy::redundant_static_lifetimes,
-    clippy::trivially_copy_pass_by_ref,
-    clippy::useless_transmute,
-    clippy::should_implement_trait,
-    clippy::transmute_ptr_to_ptr,
-    clippy::unreadable_literal,
-    clippy::redundant_static_lifetimes
-)]
 pub mod msr_index;
-
-pub mod emulator;
 
 // MTRR constants
 pub const MTRR_ENABLE: u64 = 0x800; // IA32_MTRR_DEF_TYPE MSR: E (MTRRs enabled) flag, bit 11


### PR DESCRIPTION
Signed-off-by: Rob Bradford <robert.bradford@intel.com>