### PR TITLE
Add structured event monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,6 +1614,7 @@ dependencies = [
  "credibility",
  "devices",
  "epoll",
+ "event_monitor",
  "hypervisor",
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,7 @@ dependencies = [
  "block_util",
  "byteorder",
  "epoll",
+ "event_monitor",
  "io-uring",
  "libc",
  "log 0.4.14",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event_monitor"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "credibility",
  "dirs",
  "epoll",
+ "event_monitor",
  "hypervisor",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ members = [
     "arch_gen",
     "block_util",
     "devices",
+    "event_monitor",
     "hypervisor",
     "net_gen",
     "net_util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1.0"
 api_client = { path = "api_client" }
 clap = { version = "2.33.3", features = ["wrap_help"] }
 epoll = ">=4.0.1"
+event_monitor = { path = "event_monitor" }
 hypervisor = { path = "hypervisor" }
 libc = "0.2.86"
 log = { version = "0.4.14", features = ["std"] }

--- a/event_monitor/Cargo.toml
+++ b/event_monitor/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "event_monitor"
+version = "0.1.0"
+authors = ["The Cloud Hypervisor Authors"]
+edition = "2018"
+
+[dependencies]
+libc = "0.2.86"
+serde = {version = ">=1.0.27", features = ["rc"] }
+serde_derive = ">=1.0.27"
+serde_json = ">=1.0.9"

--- a/event_monitor/src/lib.rs
+++ b/event_monitor/src/lib.rs
@@ -1,0 +1,77 @@
+// Copyright © 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#[macro_use]
+extern crate serde_derive;
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fs::File;
+use std::os::unix::io::AsRawFd;
+use std::time::{Duration, Instant};
+
+static mut MONITOR: Option<(File, Instant)> = None;
+
+/// This function must only be called once from the main process before any threads
+/// are created to avoid race conditions
+pub fn set_monitor(file: File) -> Result<(), std::io::Error> {
+    assert!(unsafe { MONITOR.is_none() });
+    let fd = file.as_raw_fd();
+    let ret = unsafe {
+        let mut flags = libc::fcntl(fd, libc::F_GETFL);
+        flags |= libc::O_NONBLOCK;
+        libc::fcntl(fd, libc::F_SETFL, flags)
+    };
+    if ret < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    unsafe {
+        MONITOR = Some((file, Instant::now()));
+    };
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct Event<'a> {
+    timestamp: Duration,
+    source: &'a str,
+    event: &'a str,
+    properties: Option<&'a HashMap<Cow<'a, str>, Cow<'a, str>>>,
+}
+
+pub fn event_log(source: &str, event: &str, properties: Option<&HashMap<Cow<str>, Cow<str>>>) {
+    if let Some((file, start)) = unsafe { MONITOR.as_ref() } {
+        let e = Event {
+            timestamp: start.elapsed(),
+            source,
+            event,
+            properties,
+        };
+        serde_json::to_writer_pretty(file, &e).ok();
+    }
+}
+
+/*
+    Through the use of Cow<'a, str> it is possible to use String as well as
+    &str as the parameters:
+    e.g.
+    event!("cpu_manager", "create_vcpu", "id", cpu_id.to_string());
+*/
+#[macro_export]
+macro_rules! event {
+    ($source:expr, $event:expr) => {
+        $crate::event_log($source, $event, None)
+    };
+    ($source:expr, $event:expr, $($key:expr, $value:expr),*) => {
+        {
+            let mut properties = ::std::collections::HashMap::new();
+            $(
+                properties.insert($key.into(), $value.into());
+            )+
+            $crate::event_log($source, $event, Some(&properties))
+        }
+     };
+
+}

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -14,6 +14,7 @@ arc-swap = ">=1.0.0"
 block_util = { path = "../block_util" }
 byteorder = "1.3.4"
 epoll = ">=4.0.1"
+event_monitor = { path = "../event_monitor" }
 io-uring = ">=0.4.0"
 libc = "0.2.86"
 log = "0.4.14"

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -462,11 +462,14 @@ impl VirtioDevice for Balloon {
             })?;
         self.common.epoll_threads = Some(epoll_threads);
 
+        event!("virtio-device", "activated", "id", &self.id);
         Ok(())
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.common.reset()
+        let result = self.common.reset();
+        event!("virtio-device", "reset", "id", &self.id);
+        result
     }
 }
 

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -567,12 +567,15 @@ impl VirtioDevice for Block {
         }
 
         self.common.epoll_threads = Some(epoll_threads);
+        event!("virtio-device", "activated", "id", &self.id);
 
         Ok(())
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.common.reset()
+        let result = self.common.reset();
+        event!("virtio-device", "reset", "id", &self.id);
+        result
     }
 
     fn counters(&self) -> Option<HashMap<&'static str, Wrapping<u64>>> {

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -485,11 +485,14 @@ impl VirtioDevice for Console {
 
         self.common.epoll_threads = Some(epoll_threads);
 
+        event!("virtio-device", "activated", "id", &self.id);
         Ok(())
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.common.reset()
+        let result = self.common.reset();
+        event!("virtio-device", "reset", "id", &self.id);
+        result
     }
 }
 

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -948,11 +948,14 @@ impl VirtioDevice for Iommu {
 
         self.common.epoll_threads = Some(epoll_threads);
 
+        event!("virtio-device", "activated", "id", &self.id);
         Ok(())
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.common.reset()
+        let result = self.common.reset();
+        event!("virtio-device", "reset", "id", &self.id);
+        result
     }
 }
 

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -13,6 +13,8 @@
 extern crate arc_swap;
 extern crate epoll;
 #[macro_use]
+extern crate event_monitor;
+#[macro_use]
 extern crate log;
 extern crate pci;
 extern crate serde;

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -869,11 +869,14 @@ impl VirtioDevice for Mem {
             })?;
         self.common.epoll_threads = Some(epoll_threads);
 
+        event!("virtio-device", "activated", "id", &self.id);
         Ok(())
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.common.reset()
+        let result = self.common.reset();
+        event!("virtio-device", "reset", "id", &self.id);
+        result
     }
 }
 

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -524,13 +524,16 @@ impl VirtioDevice for Net {
 
             self.common.epoll_threads = Some(epoll_threads);
 
+            event!("virtio-device", "activated", "id", &self.id);
             return Ok(());
         }
         Err(ActivateError::BadActivate)
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.common.reset()
+        let result = self.common.reset();
+        event!("virtio-device", "reset", "id", &self.id);
+        result
     }
 
     fn counters(&self) -> Option<HashMap<&'static str, Wrapping<u64>>> {

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -428,13 +428,16 @@ impl VirtioDevice for Pmem {
 
             self.common.epoll_threads = Some(epoll_threads);
 
+            event!("virtio-device", "activated", "id", &self.id);
             return Ok(());
         }
         Err(ActivateError::BadActivate)
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.common.reset()
+        let result = self.common.reset();
+        event!("virtio-device", "reset", "id", &self.id);
+        result
     }
 
     fn userspace_mappings(&self) -> Vec<UserspaceMapping> {

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -274,13 +274,16 @@ impl VirtioDevice for Rng {
 
             self.common.epoll_threads = Some(epoll_threads);
 
+            event!("virtio-device", "activated", "id", &self.id);
             return Ok(());
         }
         Err(ActivateError::BadActivate)
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.common.reset()
+        let result = self.common.reset();
+        event!("virtio-device", "reset", "id", &self.id);
+        result
     }
 }
 

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -272,6 +272,7 @@ impl VirtioDevice for Blk {
         }
         self.common.epoll_threads = Some(epoll_threads);
 
+        event!("virtio-device", "activated", "id", &self.id);
         Ok(())
     }
 
@@ -290,6 +291,8 @@ impl VirtioDevice for Blk {
             // Ignore the result because there is nothing we can do about it.
             let _ = kill_evt.write(1);
         }
+
+        event!("virtio-device", "reset", "id", &self.id);
 
         // Return the interrupt
         Some(self.common.interrupt_cb.take().unwrap())

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -492,6 +492,7 @@ impl VirtioDevice for Fs {
 
         self.common.epoll_threads = Some(epoll_threads);
 
+        event!("virtio-device", "activated", "id", &self.id);
         Ok(())
     }
 
@@ -510,6 +511,8 @@ impl VirtioDevice for Fs {
             // Ignore the result because there is nothing we can do about it.
             let _ = kill_evt.write(1);
         }
+
+        event!("virtio-device", "reset", "id", &self.id);
 
         // Return the interrupt
         Some(self.common.interrupt_cb.take().unwrap())

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -347,6 +347,8 @@ impl VirtioDevice for Net {
             let _ = kill_evt.write(1);
         }
 
+        event!("virtio-device", "reset", "id", &self.id);
+
         // Return the interrupt
         Some(self.common.interrupt_cb.take().unwrap())
     }

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -471,11 +471,14 @@ where
 
         self.common.epoll_threads = Some(epoll_threads);
 
+        event!("virtio-device", "activated", "id", &self.id);
         Ok(())
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.common.reset()
+        let result = self.common.reset();
+        event!("virtio-device", "reset", "id", &self.id);
+        result
     }
 
     fn shutdown(&mut self) {

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -355,11 +355,14 @@ impl VirtioDevice for Watchdog {
 
         self.common.epoll_threads = Some(epoll_threads);
 
+        event!("virtio-device", "activated", "id", &self.id);
         Ok(())
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.common.reset()
+        let result = self.common.reset();
+        event!("virtio-device", "reset", "id", &self.id);
+        result
     }
 }
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -23,6 +23,7 @@ block_util = { path = "../block_util" }
 clap = "2.33.3"
 devices = { path = "../devices" }
 epoll = ">=4.0.1"
+event_monitor = { path = "../event_monitor" }
 hypervisor = { path = "../hypervisor" }
 lazy_static = "1.4.0"
 libc = "0.2.86"

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -5,6 +5,8 @@
 
 extern crate anyhow;
 extern crate arc_swap;
+#[macro_use]
+extern crate event_monitor;
 extern crate hypervisor;
 extern crate option_parser;
 #[macro_use]
@@ -555,11 +557,15 @@ impl Vmm {
 
         self.vm_config = None;
 
+        event!("vm", "deleted");
+
         Ok(())
     }
 
     fn vmm_shutdown(&mut self) -> result::Result<(), VmError> {
-        self.vm_delete()
+        self.vm_delete()?;
+        event!("vmm", "shutdown");
+        Ok(())
     }
 
     fn vm_resize(

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -419,6 +419,7 @@ fn vcpu_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_exit),
         allow_syscall(libc::SYS_fstat),
         allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_getrandom),
         allow_syscall(libc::SYS_getpid),
         allow_syscall_if(libc::SYS_ioctl, create_vcpu_ioctl_seccomp_rule()?),
         allow_syscall(libc::SYS_lseek),


### PR DESCRIPTION
For systems like libvirt that need to observe what the VMM is doing provide an infrastructure to report structured events by writing to a FD.

This is a simpler solution to #2273 as it does not require CH to maintain a set of locations to write event data to (and the requirement that that be in it's own thread to avoid blocking) and simpler for libvirt does not need to manage a web server for the callbacks.