### PR TITLE
hypervisor: emulator: fix MOVZX

### DIFF
--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -71,7 +71,7 @@ macro_rules! mov_rm_imm {
 }
 
 macro_rules! movzx {
-    ($src_op_size:ty, $dest_op_size:ty) => {
+    ($dest_op_size:ty, $src_op_size:ty) => {
         fn emulate(
             &self,
             insn: &Instruction,


### PR DESCRIPTION
According to Intel's mnemonic (which is used by iced-x86) the first
argument is destination while the second is source.

Signed-off-by: Wei Liu <liuwe@microsoft.com>