### PR TITLE
Move to rust-vmm vfio-ioctls crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,6 +1449,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "thiserror",
+ "vfio-ioctls",
  "vm-memory",
  "vmm-sys-util",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "vfio-ioctls",
  "vhost",
  "virtio-bindings",
  "vm-allocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.1.0"
-source = "git+https://github.com/cloud-hypervisor/vfio-ioctls?branch=ch#6ea1b934bbff9102bbdc80c23a357a48645cd722"
+source = "git+https://github.com/rust-vmm/vfio-ioctls?branch=master#95e70655e34ad942f5ca8d3bc450d7dec4964514"
 dependencies = [
  "byteorder",
  "kvm-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ clap = { version = "2.33.3", features = ["wrap_help"] }
 [patch.'https://github.com/rust-vmm/vhost']
 vhost_rs = { git = "https://github.com/cloud-hypervisor/vhost", branch = "ch", package = "vhost", features = ["vhost-user-master", "vhost-user-slave"] }
 
+[patch.crates-io]
+kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch", features = ["with-serde", "fam-wrappers"] }
+kvm-ioctls = { git = "https://github.com/cloud-hypervisor/kvm-ioctls", branch = "ch" }
+
 [dev-dependencies]
 credibility = "0.1.3"
 dirs = "3.0.1"

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 anyhow = "1.0"
 byteorder = "1.3.4"
 hypervisor = { path = "../hypervisor" }
-vfio-ioctls = { git = "https://github.com/cloud-hypervisor/vfio-ioctls", branch = "ch" }
+vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "master" }
 vmm-sys-util = ">=0.3.1"
 libc = "0.2.86"
 log = "0.4.14"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -25,7 +25,6 @@ seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v
 serde = ">=1.0.27"
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
-vfio-ioctls = { git = "https://github.com/cloud-hypervisor/vfio-ioctls", branch = "ch" }
 vhost_rs = { git = "https://github.com/rust-vmm/vhost", branch = "master", package = "vhost", features = ["vhost-user-master", "vhost-user-slave"] }
 virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"]}
 vm-allocator = { path = "../vm-allocator" }

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -22,7 +22,7 @@ use std::result;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier, RwLock};
 use std::thread;
-use vfio_ioctls::ExternalDmaMapping;
+use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
     GuestMemoryError, GuestMemoryMmap,

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -3,13 +3,12 @@
 
 use super::super::{Descriptor, Queue};
 use super::{Error, Result};
-use crate::{VirtioInterrupt, VirtioInterruptType};
+use crate::{get_host_address_range, VirtioInterrupt, VirtioInterruptType};
 use libc::EFD_NONBLOCK;
 use std::convert::TryInto;
 use std::os::unix::io::AsRawFd;
 use std::sync::Arc;
 use std::vec::Vec;
-use vfio_ioctls::get_host_address_range;
 use vhost_rs::vhost_user::{Master, VhostUserMaster};
 use vhost_rs::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
 use vm_memory::{Address, Error as MmapError, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -17,10 +17,9 @@
 ///
 use byteorder::{ByteOrder, LittleEndian};
 
-use super::super::DescriptorChain;
 use super::defs;
 use super::{Result, VsockError};
-use vfio_ioctls::get_host_address_range;
+use crate::{get_host_address_range, DescriptorChain};
 
 // The vsock packet header is defined by the C struct:
 //

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -10,6 +10,7 @@ thiserror = "1.0"
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
+vfio-ioctls = { git = "https://github.com/cloud-hypervisor/vfio-ioctls", branch = "ch" }
 vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.3.1"
 

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -10,7 +10,7 @@ thiserror = "1.0"
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
-vfio-ioctls = { git = "https://github.com/cloud-hypervisor/vfio-ioctls", branch = "ch" }
+vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "master" }
 vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.3.1"
 

--- a/vm-device/src/dma_mapping/mod.rs
+++ b/vm-device/src/dma_mapping/mod.rs
@@ -1,0 +1,17 @@
+// Copyright © 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+pub mod vfio;
+
+/// Trait meant for triggering the DMA mapping update related to an external
+/// device not managed fully through virtio. It is dedicated to virtio-iommu
+/// in order to trigger the map update anytime the mapping is updated from the
+/// guest.
+pub trait ExternalDmaMapping: Send + Sync {
+    /// Map a memory range
+    fn map(&self, iova: u64, gpa: u64, size: u64) -> std::result::Result<(), std::io::Error>;
+
+    /// Unmap a memory range
+    fn unmap(&self, iova: u64, size: u64) -> std::result::Result<(), std::io::Error>;
+}

--- a/vm-device/src/dma_mapping/vfio.rs
+++ b/vm-device/src/dma_mapping/vfio.rs
@@ -1,0 +1,73 @@
+// Copyright © 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use crate::dma_mapping::ExternalDmaMapping;
+use std::io;
+use std::sync::Arc;
+use vfio_ioctls::VfioContainer;
+use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemory};
+
+/// This structure implements the ExternalDmaMapping trait. It is meant to
+/// be used when the caller tries to provide a way to update the mappings
+/// associated with a specific VFIO container.
+pub struct VfioDmaMapping<M: GuestAddressSpace> {
+    container: Arc<VfioContainer>,
+    memory: Arc<M>,
+}
+
+impl<M: GuestAddressSpace> VfioDmaMapping<M> {
+    /// Create a DmaMapping object.
+    ///
+    /// # Parameters
+    /// * `container`: VFIO container object.
+    /// * `memory·: guest memory to mmap.
+    pub fn new(container: Arc<VfioContainer>, memory: Arc<M>) -> Self {
+        VfioDmaMapping { container, memory }
+    }
+}
+
+impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioDmaMapping<M> {
+    fn map(&self, iova: u64, gpa: u64, size: u64) -> std::result::Result<(), io::Error> {
+        let mem = self.memory.memory();
+        let guest_addr = GuestAddress(gpa);
+        let user_addr = if mem.check_range(guest_addr, size as usize) {
+            mem.get_host_address(guest_addr).unwrap() as u64
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "failed to convert guest address 0x{:x} into \
+                     host user virtual address",
+                    gpa
+                ),
+            ));
+        };
+
+        self.container
+            .vfio_dma_map(iova, size, user_addr)
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!(
+                        "failed to map memory for VFIO container, \
+                         iova 0x{:x}, gpa 0x{:x}, size 0x{:x}: {:?}",
+                        iova, gpa, size, e
+                    ),
+                )
+            })
+    }
+
+    fn unmap(&self, iova: u64, size: u64) -> std::result::Result<(), io::Error> {
+        self.container.vfio_dma_unmap(iova, size).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "failed to unmap memory for VFIO container, \
+                     iova 0x{:x}, size 0x{:x}: {:?}",
+                    iova, size, e
+                ),
+            )
+        })
+    }
+}

--- a/vm-device/src/lib.rs
+++ b/vm-device/src/lib.rs
@@ -10,6 +10,7 @@ extern crate vm_memory;
 use std::io;
 
 mod bus;
+pub mod dma_mapping;
 pub mod interrupt;
 
 pub use self::bus::{Bus, BusDevice, Error as BusError};

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -40,7 +40,7 @@ serde_json = ">=1.0.9"
 signal-hook = "0.3.6"
 thiserror = "1.0"
 url = "2.2.1"
-vfio-ioctls = { git = "https://github.com/cloud-hypervisor/vfio-ioctls", branch = "ch" }
+vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "master" }
 virtio-devices = { path = "../virtio-devices" }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2691,12 +2691,8 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::VfioCreate)?,
         );
 
-        let vfio_device = VfioDevice::new(
-            &device_cfg.path,
-            Arc::clone(&vfio_container),
-            device_cfg.iommu,
-        )
-        .map_err(DeviceManagerError::VfioCreate)?;
+        let vfio_device = VfioDevice::new(&device_cfg.path, Arc::clone(&vfio_container))
+            .map_err(DeviceManagerError::VfioCreate)?;
 
         if device_cfg.iommu {
             if let Some(iommu) = &self.iommu_device {
@@ -2731,9 +2727,11 @@ impl DeviceManager {
         let mut vfio_pci_device = VfioPciDevice::new(
             &self.address_manager.vm,
             vfio_device,
+            vfio_container,
             &self.msi_interrupt_manager,
             legacy_interrupt_group,
             memory,
+            device_cfg.iommu,
         )
         .map_err(DeviceManagerError::VfioPciCreate)?;
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -79,13 +79,15 @@ use std::path::PathBuf;
 use std::result;
 use std::sync::{Arc, Barrier, Mutex};
 #[cfg(feature = "kvm")]
-use vfio_ioctls::{VfioContainer, VfioDevice, VfioDmaMapping};
+use vfio_ioctls::{VfioContainer, VfioDevice};
 use virtio_devices::transport::VirtioPciDevice;
 use virtio_devices::transport::VirtioTransport;
 use virtio_devices::vhost_user::VhostUserConfig;
 use virtio_devices::{DmaRemapping, IommuMapping};
 use virtio_devices::{VirtioSharedMemory, VirtioSharedMemoryList};
 use vm_allocator::SystemAllocator;
+#[cfg(feature = "kvm")]
+use vm_device::dma_mapping::vfio::VfioDmaMapping;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, LegacyIrqGroupConfig, MsiIrqGroupConfig,
 };


### PR DESCRIPTION
With this PR, we move Cloud Hypervisor away from its internal `vfio-ioctls` crate to the upstream one from the Rust-VMM project.