### PR TITLE
vhost: Bump to latest version from upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vhost?branch=master#8c6919bf60bd641398ddd53864fbc74d75548837"
+source = "git+https://github.com/rust-vmm/vhost?branch=master#576694bcfb09e7c78d812ed07dbc5377d283852a"
 dependencies = [
  "bitflags 1.2.1",
  "libc",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vhost?branch=master#8c6919bf60bd641398ddd53864fbc74d75548837"
+source = "git+https://github.com/rust-vmm/vhost?branch=master#576694bcfb09e7c78d812ed07dbc5377d283852a"
 dependencies = [
  "bitflags",
  "libc",

--- a/vhost_user_backend/src/lib.rs
+++ b/vhost_user_backend/src/lib.rs
@@ -21,7 +21,7 @@ use vhost::vhost_user::message::{
 };
 use vhost::vhost_user::{
     Error as VhostUserError, Listener, Result as VhostUserResult, SlaveFsCacheReq, SlaveListener,
-    VhostUserSlaveReqHandler,
+    VhostUserSlaveReqHandlerMut,
 };
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use vm_memory::guest_memory::FileOffset;
@@ -544,7 +544,7 @@ impl<S: VhostUserBackend> VhostUserHandler<S> {
     }
 }
 
-impl<S: VhostUserBackend> VhostUserSlaveReqHandler for VhostUserHandler<S> {
+impl<S: VhostUserBackend> VhostUserSlaveReqHandlerMut for VhostUserHandler<S> {
     fn set_owner(&mut self) -> VhostUserResult<()> {
         if self.owned {
             return Err(VhostUserError::InvalidOperation);


### PR DESCRIPTION
Moving to the latest version of the rust-vmm/vhost crate, before it gets
published on crates.io.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>