### PR TITLE
Jenkinsfile: Temporarily disable SGX CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,39 +103,6 @@ pipeline{
 						}
 					}
 				}
-				stage ('Worker build SGX') {
-					agent { node { label 'bionic-sgx' } }
-					when { branch 'master' }
-					stages {
-						stage ('Checkout') {
-							steps {
-								checkout scm
-							}
-						}
-						stage ('Run SGX integration tests') {
-							options {
-								timeout(time: 1, unit: 'HOURS')
-							}
-							steps {
-								sh "scripts/dev_cli.sh tests --integration-sgx"
-							}
-						}
-						stage ('Run SGX integration tests for musl') {
-							options {
-								timeout(time: 1, unit: 'HOURS')
-							}
-							steps {
-								sh "scripts/dev_cli.sh tests --integration-sgx --libc musl"
-							}
-						}
-					}
-					post {
-						always {
-							sh "sudo chown -R jenkins.jenkins ${WORKSPACE}"
-							deleteDir()
-						}
-					}
-				}
 				stage ('Worker build - Windows guest') {
 					agent { node { label 'groovy-win' } }
 					stages {


### PR DESCRIPTION
Since the SGX server is down for maintenance, all builds are waiting on
the node agent to answer, causing all PRs to be blocked.

Let's disable temporarily the SGX CI until the server is back up.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>