### PR TITLE
Simplify hypervisor crate exception types

### DIFF
--- a/hypervisor/src/arch/emulator/mod.rs
+++ b/hypervisor/src/arch/emulator/mod.rs
@@ -6,19 +6,20 @@
 
 extern crate thiserror;
 
+use crate::arch::x86::ExceptionVector;
 use core::fmt::Debug;
 use std::fmt::{self, Display};
 use thiserror::Error;
 
 #[derive(Clone, Copy, Error, Debug)]
-pub struct Exception<T: Debug> {
-    vector: T,
+pub struct Exception {
+    vector: ExceptionVector,
     ip: u64,
     error: Option<u32>,
     payload: Option<u64>,
 }
 
-impl<T: Debug> Display for Exception<T> {
+impl Display for Exception {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Exception {:?} at IP {:#x}", self.vector, self.ip)
     }
@@ -58,7 +59,7 @@ pub enum PlatformError {
 }
 
 #[derive(Error, Debug)]
-pub enum EmulationError<T: Debug> {
+pub enum EmulationError {
     #[error("Unsupported instruction: {0}")]
     UnsupportedInstruction(#[source] anyhow::Error),
 
@@ -72,7 +73,7 @@ pub enum EmulationError<T: Debug> {
     WrongNumberOperands(#[source] anyhow::Error),
 
     #[error("Instruction Exception: {0}")]
-    InstructionException(Exception<T>),
+    InstructionException(Exception),
 
     #[error("Instruction fetching error: {0}")]
     InstructionFetchingError(#[source] anyhow::Error),
@@ -145,4 +146,4 @@ pub trait PlatformEmulator: Send + Sync {
     fn fetch(&self, ip: u64, instruction_bytes: &mut [u8]) -> Result<(), PlatformError>;
 }
 
-pub type EmulationResult<S, E> = std::result::Result<S, EmulationError<E>>;
+pub type EmulationResult<S> = std::result::Result<S, EmulationError>;

--- a/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
@@ -15,7 +15,6 @@ extern crate iced_x86;
 use crate::arch::emulator::{EmulationError, PlatformEmulator};
 use crate::arch::x86::emulator::instructions::*;
 use crate::arch::x86::regs::*;
-use crate::arch::x86::ExceptionVector;
 
 // CMP affects OF, SF, ZF, AF, PF and CF
 const FLAGS_MASK: u64 = CF | PF | AF | ZF | SF | OF;
@@ -61,7 +60,7 @@ macro_rules! cmp_rm_r {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<ExceptionVector>> {
+        ) -> Result<(), EmulationError> {
             let op0_value = get_op(&insn, 0, std::mem::size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
             let op1_value = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
@@ -83,7 +82,7 @@ macro_rules! cmp_r_rm {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<ExceptionVector>> {
+        ) -> Result<(), EmulationError> {
             let op0_value = get_op(&insn, 0, std::mem::size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
             let op1_value = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
@@ -105,7 +104,7 @@ macro_rules! cmp_rm_imm {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<ExceptionVector>> {
+        ) -> Result<(), EmulationError> {
             let op0_value = get_op(&insn, 0, std::mem::size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
             let op1_value = get_op(&insn, 1, std::mem::size_of::<$imm>(), state, platform)

--- a/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
@@ -15,7 +15,7 @@ extern crate iced_x86;
 use crate::arch::emulator::{EmulationError, PlatformEmulator};
 use crate::arch::x86::emulator::instructions::*;
 use crate::arch::x86::regs::*;
-use crate::arch::x86::Exception;
+use crate::arch::x86::ExceptionVector;
 
 // CMP affects OF, SF, ZF, AF, PF and CF
 const FLAGS_MASK: u64 = CF | PF | AF | ZF | SF | OF;
@@ -61,7 +61,7 @@ macro_rules! cmp_rm_r {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<Exception>> {
+        ) -> Result<(), EmulationError<ExceptionVector>> {
             let op0_value = get_op(&insn, 0, std::mem::size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
             let op1_value = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
@@ -83,7 +83,7 @@ macro_rules! cmp_r_rm {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<Exception>> {
+        ) -> Result<(), EmulationError<ExceptionVector>> {
             let op0_value = get_op(&insn, 0, std::mem::size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
             let op1_value = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
@@ -105,7 +105,7 @@ macro_rules! cmp_rm_imm {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<Exception>> {
+        ) -> Result<(), EmulationError<ExceptionVector>> {
             let op0_value = get_op(&insn, 0, std::mem::size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
             let op1_value = get_op(&insn, 1, std::mem::size_of::<$imm>(), state, platform)

--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -8,7 +8,7 @@ extern crate iced_x86;
 
 use crate::arch::emulator::{EmulationError, PlatformEmulator, PlatformError};
 use crate::arch::x86::emulator::CpuStateManager;
-use crate::arch::x86::Exception;
+use crate::arch::x86::ExceptionVector;
 use iced_x86::*;
 
 pub mod cmp;
@@ -143,7 +143,7 @@ pub trait InstructionHandler<T: CpuStateManager> {
         insn: &Instruction,
         state: &mut T,
         platform: &mut dyn PlatformEmulator<CpuState = T>,
-    ) -> Result<(), EmulationError<Exception>>;
+    ) -> Result<(), EmulationError<ExceptionVector>>;
 }
 
 macro_rules! insn_format {

--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -8,7 +8,6 @@ extern crate iced_x86;
 
 use crate::arch::emulator::{EmulationError, PlatformEmulator, PlatformError};
 use crate::arch::x86::emulator::CpuStateManager;
-use crate::arch::x86::ExceptionVector;
 use iced_x86::*;
 
 pub mod cmp;
@@ -143,7 +142,7 @@ pub trait InstructionHandler<T: CpuStateManager> {
         insn: &Instruction,
         state: &mut T,
         platform: &mut dyn PlatformEmulator<CpuState = T>,
-    ) -> Result<(), EmulationError<ExceptionVector>>;
+    ) -> Result<(), EmulationError>;
 }
 
 macro_rules! insn_format {

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -16,7 +16,7 @@ extern crate iced_x86;
 
 use crate::arch::emulator::{EmulationError, PlatformEmulator};
 use crate::arch::x86::emulator::instructions::*;
-use crate::arch::x86::Exception;
+use crate::arch::x86::ExceptionVector;
 
 macro_rules! mov_rm_r {
     ($bound:ty) => {
@@ -25,7 +25,7 @@ macro_rules! mov_rm_r {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<Exception>> {
+        ) -> Result<(), EmulationError<ExceptionVector>> {
             let src_reg_value = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 
@@ -51,7 +51,7 @@ macro_rules! mov_rm_imm {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<Exception>> {
+        ) -> Result<(), EmulationError<ExceptionVector>> {
             let imm = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 
@@ -77,7 +77,7 @@ macro_rules! movzx {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<Exception>> {
+        ) -> Result<(), EmulationError<ExceptionVector>> {
             let src_value = get_op(
                 &insn,
                 1,
@@ -116,7 +116,7 @@ macro_rules! mov_r_imm {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<Exception>> {
+        ) -> Result<(), EmulationError<ExceptionVector>> {
             let imm = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -16,7 +16,6 @@ extern crate iced_x86;
 
 use crate::arch::emulator::{EmulationError, PlatformEmulator};
 use crate::arch::x86::emulator::instructions::*;
-use crate::arch::x86::ExceptionVector;
 
 macro_rules! mov_rm_r {
     ($bound:ty) => {
@@ -25,7 +24,7 @@ macro_rules! mov_rm_r {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<ExceptionVector>> {
+        ) -> Result<(), EmulationError> {
             let src_reg_value = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 
@@ -51,7 +50,7 @@ macro_rules! mov_rm_imm {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<ExceptionVector>> {
+        ) -> Result<(), EmulationError> {
             let imm = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 
@@ -77,7 +76,7 @@ macro_rules! movzx {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<ExceptionVector>> {
+        ) -> Result<(), EmulationError> {
             let src_value = get_op(
                 &insn,
                 1,
@@ -116,7 +115,7 @@ macro_rules! mov_r_imm {
             insn: &Instruction,
             state: &mut T,
             platform: &mut dyn PlatformEmulator<CpuState = T>,
-        ) -> Result<(), EmulationError<ExceptionVector>> {
+        ) -> Result<(), EmulationError> {
             let imm = get_op(&insn, 1, std::mem::size_of::<$bound>(), state, platform)
                 .map_err(EmulationError::PlatformEmulationError)?;
 

--- a/hypervisor/src/arch/x86/emulator/instructions/movs.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/movs.rs
@@ -15,7 +15,6 @@ extern crate iced_x86;
 use crate::arch::emulator::{EmulationError, PlatformEmulator};
 use crate::arch::x86::emulator::instructions::*;
 use crate::arch::x86::regs::DF;
-use crate::arch::x86::ExceptionVector;
 
 pub struct Movsd_m32_m32;
 impl<T: CpuStateManager> InstructionHandler<T> for Movsd_m32_m32 {
@@ -24,7 +23,7 @@ impl<T: CpuStateManager> InstructionHandler<T> for Movsd_m32_m32 {
         insn: &Instruction,
         state: &mut T,
         platform: &mut dyn PlatformEmulator<CpuState = T>,
-    ) -> Result<(), EmulationError<ExceptionVector>> {
+    ) -> Result<(), EmulationError> {
         let mut count: u64 = if insn.has_rep_prefix() {
             state
                 .read_reg(Register::ECX)

--- a/hypervisor/src/arch/x86/emulator/instructions/movs.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/movs.rs
@@ -15,7 +15,7 @@ extern crate iced_x86;
 use crate::arch::emulator::{EmulationError, PlatformEmulator};
 use crate::arch::x86::emulator::instructions::*;
 use crate::arch::x86::regs::DF;
-use crate::arch::x86::Exception;
+use crate::arch::x86::ExceptionVector;
 
 pub struct Movsd_m32_m32;
 impl<T: CpuStateManager> InstructionHandler<T> for Movsd_m32_m32 {
@@ -24,7 +24,7 @@ impl<T: CpuStateManager> InstructionHandler<T> for Movsd_m32_m32 {
         insn: &Instruction,
         state: &mut T,
         platform: &mut dyn PlatformEmulator<CpuState = T>,
-    ) -> Result<(), EmulationError<Exception>> {
+    ) -> Result<(), EmulationError<ExceptionVector>> {
         let mut count: u64 = if insn.has_rep_prefix() {
             state
                 .read_reg(Register::ECX)

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -9,8 +9,8 @@ extern crate iced_x86;
 use crate::arch::emulator::{EmulationError, EmulationResult, PlatformEmulator, PlatformError};
 use crate::arch::x86::emulator::instructions::*;
 use crate::arch::x86::regs::*;
+use crate::arch::x86::SegmentRegisterOps;
 use crate::arch::x86::*;
-use crate::arch::x86::{ExceptionVector, SegmentRegisterOps};
 use crate::x86_64::{SegmentRegister, SpecialRegisters, StandardRegisters};
 use anyhow::Context;
 use iced_x86::*;
@@ -537,7 +537,7 @@ impl<'a, T: CpuStateManager> Emulator<'a, T> {
         cpu_id: usize,
         insn_stream: &[u8],
         num_insn: Option<usize>,
-    ) -> EmulationResult<T, ExceptionVector> {
+    ) -> EmulationResult<T> {
         let mut state = self
             .platform
             .cpu_state(cpu_id)
@@ -618,11 +618,7 @@ impl<'a, T: CpuStateManager> Emulator<'a, T> {
     }
 
     /// Emulate all instructions from the instructions stream.
-    pub fn emulate(
-        &mut self,
-        cpu_id: usize,
-        insn_stream: &[u8],
-    ) -> EmulationResult<T, ExceptionVector> {
+    pub fn emulate(&mut self, cpu_id: usize, insn_stream: &[u8]) -> EmulationResult<T> {
         self.emulate_insn_stream(cpu_id, insn_stream, None)
     }
 
@@ -631,11 +627,7 @@ impl<'a, T: CpuStateManager> Emulator<'a, T> {
     /// This is useful for cases where we get readahead instruction stream
     /// but implicitly must only emulate the first instruction, and then return
     /// to the guest.
-    pub fn emulate_first_insn(
-        &mut self,
-        cpu_id: usize,
-        insn_stream: &[u8],
-    ) -> EmulationResult<T, ExceptionVector> {
+    pub fn emulate_first_insn(&mut self, cpu_id: usize, insn_stream: &[u8]) -> EmulationResult<T> {
         self.emulate_insn_stream(cpu_id, insn_stream, Some(1))
     }
 }

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -10,7 +10,7 @@ use crate::arch::emulator::{EmulationError, EmulationResult, PlatformEmulator, P
 use crate::arch::x86::emulator::instructions::*;
 use crate::arch::x86::regs::*;
 use crate::arch::x86::*;
-use crate::arch::x86::{Exception, SegmentRegisterOps};
+use crate::arch::x86::{ExceptionVector, SegmentRegisterOps};
 use crate::x86_64::{SegmentRegister, SpecialRegisters, StandardRegisters};
 use anyhow::Context;
 use iced_x86::*;
@@ -537,7 +537,7 @@ impl<'a, T: CpuStateManager> Emulator<'a, T> {
         cpu_id: usize,
         insn_stream: &[u8],
         num_insn: Option<usize>,
-    ) -> EmulationResult<T, Exception> {
+    ) -> EmulationResult<T, ExceptionVector> {
         let mut state = self
             .platform
             .cpu_state(cpu_id)
@@ -618,7 +618,11 @@ impl<'a, T: CpuStateManager> Emulator<'a, T> {
     }
 
     /// Emulate all instructions from the instructions stream.
-    pub fn emulate(&mut self, cpu_id: usize, insn_stream: &[u8]) -> EmulationResult<T, Exception> {
+    pub fn emulate(
+        &mut self,
+        cpu_id: usize,
+        insn_stream: &[u8],
+    ) -> EmulationResult<T, ExceptionVector> {
         self.emulate_insn_stream(cpu_id, insn_stream, None)
     }
 
@@ -631,7 +635,7 @@ impl<'a, T: CpuStateManager> Emulator<'a, T> {
         &mut self,
         cpu_id: usize,
         insn_stream: &[u8],
-    ) -> EmulationResult<T, Exception> {
+    ) -> EmulationResult<T, ExceptionVector> {
         self.emulate_insn_stream(cpu_id, insn_stream, Some(1))
     }
 }

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -28,7 +28,7 @@ pub const NUM_IOAPIC_PINS: usize = 24;
 
 // X86 Exceptions
 #[allow(dead_code)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 pub enum ExceptionVector {
     DE = 0,  // Divide Error
     DB = 1,  // Debug Exception

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -29,7 +29,7 @@ pub const NUM_IOAPIC_PINS: usize = 24;
 // X86 Exceptions
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
-pub enum Exception {
+pub enum ExceptionVector {
     DE = 0,  // Divide Error
     DB = 1,  // Debug Exception
     BP = 3,  // Breakpoint


### PR DESCRIPTION
There is no need to use generic.