### PR TITLE
vmm: tdx: Correctly populate the 64-bit MMIO region

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1652,8 +1652,12 @@ impl Vm {
             .unwrap()
             .end_of_device_area()
             .raw_value();
-        hob.add_mmio_resource(&mem, start_of_device_area, end_of_device_area)
-            .map_err(Error::PopulateHob)?;
+        hob.add_mmio_resource(
+            &mem,
+            start_of_device_area,
+            end_of_device_area - start_of_device_area,
+        )
+        .map_err(Error::PopulateHob)?;
 
         hob.finish(&mem).map_err(Error::PopulateHob)?;
 


### PR DESCRIPTION
The MMIO structure contains the length rather than the maximum address
so it is necessary to subtract the starting address from the end address
to calculate the length.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>