### PR TITLE
vhost-user: Make ActivateError messages more consistent

### DIFF
--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -85,11 +85,11 @@ pub enum ActivateError {
     CloneKillEventFd,
     /// Failed to create Vhost-user interrupt eventfd
     VhostIrqCreate,
-    /// Failed to setup vhost-user daemon.
-    VhostUserSetup(vhost_user::Error),
-    /// Failed to setup vhost-user daemon.
+    /// Failed to setup vhost-user-fs daemon.
+    VhostUserFsSetup(vhost_user::Error),
+    /// Failed to setup vhost-user-net daemon.
     VhostUserNetSetup(vhost_user::Error),
-    /// Failed to setup vhost-user daemon.
+    /// Failed to setup vhost-user-blk daemon.
     VhostUserBlkSetup(vhost_user::Error),
     /// Failed to reset vhost-user daemon.
     VhostUserReset(vhost_user::Error),

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -433,7 +433,7 @@ impl VirtioDevice for Fs {
             &interrupt_cb,
             self.common.acked_features,
         )
-        .map_err(ActivateError::VhostUserSetup)?;
+        .map_err(ActivateError::VhostUserFsSetup)?;
 
         // Initialize slave communication.
         let slave_req_handler = if self.slave_req_support {
@@ -447,13 +447,13 @@ impl VirtioDevice for Fs {
 
                 let mut req_handler =
                     MasterReqHandler::new(vu_master_req_handler).map_err(|e| {
-                        ActivateError::VhostUserSetup(Error::MasterReqHandlerCreation(e))
+                        ActivateError::VhostUserFsSetup(Error::MasterReqHandlerCreation(e))
                     })?;
                 req_handler.set_reply_ack_flag(true);
                 self.vu
                     .set_slave_request_fd(req_handler.get_tx_raw_fd())
                     .map_err(|e| {
-                        ActivateError::VhostUserSetup(Error::VhostUserSetSlaveRequestFd(e))
+                        ActivateError::VhostUserFsSetup(Error::VhostUserSetSlaveRequestFd(e))
                     })?;
                 Some(req_handler)
             } else {


### PR DESCRIPTION
Originally, VhostUserSetup is only used by vhost-user-fs. While
vhost-user-blk and vhost-user-net have their own error messages,
we rename VhostUserSetup to VhostUserFsSetup.

Signed-off-by: Jiachen Zhang <zhangjiachen.jaycee@bytedance.com>