### PR TITLE
vmm: Simplify snapshot/restore path handling

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -6,6 +6,7 @@ extern crate hypervisor;
 #[cfg(target_arch = "x86_64")]
 use crate::config::SgxEpcConfig;
 use crate::config::{HotplugMethod, MemoryConfig, MemoryZoneConfig};
+use crate::migration::url_to_path;
 use crate::MEMORY_MANAGER_SNAPSHOT_ID;
 #[cfg(feature = "acpi")]
 use acpi_tables::{aml, aml::Aml};
@@ -851,9 +852,7 @@ impl MemoryManager {
         )?;
 
         if let Some(source_url) = source_url {
-            let url = Url::parse(source_url).unwrap();
-            /* url must be valid dir which is verified in recv_vm_snapshot() */
-            let vm_snapshot_path = url.to_file_path().unwrap();
+            let vm_snapshot_path = url_to_path(source_url).map_err(Error::Restore)?;
 
             if let Some(mem_section) = snapshot
                 .snapshot_data

--- a/vmm/src/migration.rs
+++ b/vmm/src/migration.rs
@@ -7,61 +7,40 @@ use anyhow::anyhow;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
-use url::Url;
 use vm_migration::{MigratableError, Snapshot};
 
 pub const VM_SNAPSHOT_FILE: &str = "vm.json";
 
-pub fn url_to_path(url: &Url) -> std::result::Result<PathBuf, MigratableError> {
-    match url.scheme() {
-        "file" => url
-            .to_file_path()
-            .map_err(|_| {
-                MigratableError::MigrateSend(anyhow!(
-                    "Could not convert file URL to a file path: {}",
-                    url.as_str()
-                ))
-            })
-            .and_then(|path| {
-                if !path.is_dir() {
-                    return Err(MigratableError::MigrateSend(anyhow!(
-                        "Destination is not a directory"
-                    )));
-                }
-                Ok(path)
-            }),
+pub fn url_to_path(url: &str) -> std::result::Result<PathBuf, MigratableError> {
+    let path: PathBuf = url
+        .strip_prefix("file://")
+        .ok_or_else(|| {
+            MigratableError::MigrateSend(anyhow!("Could not extract path from URL: {}", url))
+        })
+        .map(|s| s.into())?;
 
-        _ => Err(MigratableError::MigrateSend(anyhow!(
-            "URL scheme is not file: {}",
-            url.scheme()
-        ))),
+    if !path.is_dir() {
+        return Err(MigratableError::MigrateSend(anyhow!(
+            "Destination is not a directory"
+        )));
     }
+
+    Ok(path)
 }
 
 pub fn recv_vm_snapshot(source_url: &str) -> std::result::Result<Snapshot, MigratableError> {
-    let url = Url::parse(source_url).map_err(|e| {
-        MigratableError::MigrateSend(anyhow!("Could not parse destination URL: {}", e))
-    })?;
+    let mut vm_snapshot_path = url_to_path(source_url)?;
 
-    match url.scheme() {
-        "file" => {
-            let mut vm_snapshot_path = url_to_path(&url)?;
-            vm_snapshot_path.push(VM_SNAPSHOT_FILE);
+    vm_snapshot_path.push(VM_SNAPSHOT_FILE);
 
-            // Try opening the snapshot file
-            let vm_snapshot_file =
-                File::open(vm_snapshot_path).map_err(|e| MigratableError::MigrateSend(e.into()))?;
-            let vm_snapshot_reader = BufReader::new(vm_snapshot_file);
-            let vm_snapshot = serde_json::from_reader(vm_snapshot_reader)
-                .map_err(|e| MigratableError::MigrateReceive(e.into()))?;
+    // Try opening the snapshot file
+    let vm_snapshot_file =
+        File::open(vm_snapshot_path).map_err(|e| MigratableError::MigrateSend(e.into()))?;
+    let vm_snapshot_reader = BufReader::new(vm_snapshot_file);
+    let vm_snapshot = serde_json::from_reader(vm_snapshot_reader)
+        .map_err(|e| MigratableError::MigrateReceive(e.into()))?;
 
-            Ok(vm_snapshot)
-        }
-        _ => Err(MigratableError::MigrateSend(anyhow!(
-            "Unsupported VM transport URL scheme: {}",
-            url.scheme()
-        ))),
-    }
+    Ok(vm_snapshot)
 }
 
 pub fn get_vm_snapshot(snapshot: &Snapshot) -> std::result::Result<VmSnapshot, MigratableError> {


### PR DESCRIPTION
Extend the existing url_to_path() to take the URL string and then use
that to simplify the snapshot/restore code paths.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>