### PR TITLE
vhost-user: Support vhost-user socket reconnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,6 +804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +836,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -875,6 +922,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "retry"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15ef4789108d066d7fd85dcec330eab9b8e51244275922a9b7161afc4f46dda"
+dependencies = [
+ "rand",
 ]
 
 [[package]]
@@ -1287,6 +1343,7 @@ dependencies = [
  "net_gen",
  "net_util",
  "pci",
+ "retry",
  "seccomp",
  "serde",
  "serde_derive",

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -33,3 +33,4 @@ vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-atomic"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
+retry = "1.2.0"

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -197,6 +197,13 @@ pub trait VirtioDevice: Send {
             offset_config.write_all(data).unwrap();
         }
     }
+
+    /// Default implementation if the device is not vhost-user or reconnection is
+    /// not supported, disconnected status will always be false for this default
+    /// one.
+    fn get_disconnected_arc(&self) -> Result<Arc<AtomicBool>, std::io::Error> {
+        Ok(Arc::new(AtomicBool::new(false)).clone())
+    }
 }
 
 /// Trait providing address translation the same way a physical DMA remapping

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -202,7 +202,7 @@ pub trait VirtioDevice: Send {
     /// not supported, disconnected status will always be false for this default
     /// one.
     fn get_disconnected_arc(&self) -> Result<Arc<AtomicBool>, std::io::Error> {
-        Ok(Arc::new(AtomicBool::new(false)).clone())
+        Ok(Arc::new(AtomicBool::new(false)))
     }
 }
 

--- a/virtio-devices/src/epoll_helper.rs
+++ b/virtio-devices/src/epoll_helper.rs
@@ -127,10 +127,7 @@ impl EpollHelper {
             };
 
             for event in events.iter().take(num_events) {
-                let ev_events = event.events as i32;
                 let ev_type = event.data as u16;
-
-                error!("event detected! type: {} event:{}", ev_type, ev_events);
 
                 match ev_type {
                     EPOLL_HELPER_EVENT_KILL => {

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -99,6 +99,8 @@ pub enum ActivateError {
     CreateSeccompFilter(seccomp::SeccompError),
     /// Cannot create rate limiter
     CreateRateLimiter(std::io::Error),
+    /// Failed to clone eventfd.
+    CloneEventfd(std::io::Error),
 }
 
 pub type ActivateResult = std::result::Result<(), ActivateError>;

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -656,6 +656,7 @@ impl VirtioPciDevice {
                 let mut device = self.device.lock().unwrap();
                 let mut queue_evts = Vec::new();
                 let mut queues = self.queues.clone();
+                let virtio_interrupt = virtio_interrupt.clone();
                 queues.retain(|q| q.ready);
                 for (i, queue) in queues.iter().enumerate() {
                     queue_evts.push(self.queue_evts[i].try_clone().unwrap());
@@ -663,7 +664,7 @@ impl VirtioPciDevice {
                         error!("Queue {} is not valid", i);
                     }
                 }
-                return device.activate(mem, virtio_interrupt.clone(), queues, queue_evts);
+                return device.activate(mem, virtio_interrupt, queues, queue_evts);
             }
         }
         Ok(())
@@ -686,9 +687,8 @@ impl VirtioPciDevice {
     }
 
     fn needs_activation(&self) -> bool {
-        let ret = self.disconneted.load(Ordering::SeqCst)
-            || !self.device_activated.load(Ordering::SeqCst) && self.is_driver_ready();
-        ret
+        self.disconneted.load(Ordering::SeqCst)
+            || !self.device_activated.load(Ordering::SeqCst) && self.is_driver_ready()
     }
 }
 

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -94,3 +94,4 @@ pub enum Error {
     MissingRegionFd,
 }
 type Result<T> = std::result::Result<T, Error>;
+type ResultOnlyError = std::result::Result<(), Error>;

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -43,7 +43,7 @@ pub enum Error {
     /// Failed to open vhost device.
     VhostUserOpen(VhostError),
     /// Connection to socket failed.
-    VhostUserConnect(vhost::Error),
+    VhostUserConnect(retry::Error<vhost::Error>),
     /// Get features failed.
     VhostUserGetFeatures(VhostError),
     /// Get queue max number failed.

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -319,6 +319,9 @@ impl VirtioDevice for Net {
                 pause_evt,
                 vu_interrupt_list: interrupt_list_sub,
                 slave_req_handler: None,
+                sockfd: None,
+                disconnected: None,
+                activate_evt: None,
             });
 
             let paused = self.common.paused.clone();

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -110,7 +110,8 @@ pub fn setup_vhost_user_vring(
 
         vu.set_vring_addr(queue_index, &config_data)
             .map_err(Error::VhostUserSetVringAddr)?;
-        vu.set_vring_base(queue_index, 0u16)
+        let last_avail_index = queue.avail_index_from_memory(mem).unwrap();
+        vu.set_vring_base(queue_index, last_avail_index as u16)
             .map_err(Error::VhostUserSetVringBase)?;
 
         if let Some(eventfd) = virtio_interrupt.notifier(&VirtioInterruptType::Queue, Some(&queue))

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1847,11 +1847,16 @@ impl DeviceManager {
                 num_queues: disk_cfg.num_queues,
                 queue_size: disk_cfg.queue_size,
             };
+            let activate_evt = self
+                .activate_evt
+                .try_clone()
+                .map_err(DeviceManagerError::EventFd)?;
             let vhost_user_block_device = Arc::new(Mutex::new(
                 match virtio_devices::vhost_user::Blk::new(
                     id.clone(),
                     vu_cfg,
                     self.seccomp_action.clone(),
+                    activate_evt,
                 ) {
                     Ok(vub_device) => vub_device,
                     Err(e) => {
@@ -2270,6 +2275,9 @@ impl DeviceManager {
                     fs_cfg.queue_size,
                     cache,
                     self.seccomp_action.clone(),
+                    self.activate_evt
+                        .try_clone()
+                        .map_err(DeviceManagerError::EventFd)?,
                 )
                 .map_err(DeviceManagerError::CreateVirtioFs)?,
             ));


### PR DESCRIPTION
Hi, all

We implement vhost-user reconnection feature in this patch. The
reconnection here means cloud-hypervisor can reconnect to a new
vhost-user daemon after the old one crashes. 

This patch also support starting a vhost-user daemon after the
start cloud-hypervisor process.

We are also planning to implement vhost-user inflight I/O tracking
based on this feature. Looking forward to any comments. Thanks!

The commit message of this patch is following:

We epoll the EPOLLHUP events for each vhost-user devices in their
epoll thread. When a socket is broken, we notify the vmm thread by
the activate_evt eventfd. Subsequent reconnection will be done in the
activate() procedure of the disconnected vhost-user device.

Vhost-user-blk and vhost-user-fs is already done, while vhost-user-net
is not support yet. Because until this commit inflight virtqueue I/O
tracking is not implemented, this reconnection feature only guarantees
no error if there is no inflight I/O when the socket was broken for
vhost-user-blk. For virtio-fs, remount should be done after
reconnection.

Signed-off-by: Jiachen Zhang <zhangjiachen.jaycee@bytedance.com>