### PR TITLE
virtio-devices: seccomp: Add 'timerfd_settime' to block device

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -132,6 +132,7 @@ fn virtio_block_thread_rules() -> Vec<SyscallRuleSet> {
         allow_syscall(libc::SYS_sched_getaffinity),
         allow_syscall(libc::SYS_set_robust_list),
         allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_timerfd_settime),
         allow_syscall(libc::SYS_write),
     ]
 }


### PR DESCRIPTION
The `timerfd_settime` syscall is required when I/O throttling is
enabled.

Signed-off-by: Bo Chen <chen.bo@intel.com>