### PR TITLE
ci: Enable baremetal VFIO integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,6 +136,39 @@ pipeline{
 						}
 					}
 				}
+				stage ('Worker build VFIO') {
+					agent { node { label 'bionic-vfio' } }
+					when { branch 'master' }
+					stages {
+						stage ('Checkout') {
+							steps {
+								checkout scm
+							}
+						}
+						stage ('Run VFIO integration tests') {
+							options {
+								timeout(time: 1, unit: 'HOURS')
+							}
+							steps {
+								sh "scripts/dev_cli.sh tests --integration-vfio"
+							}
+						}
+						stage ('Run VFIO integration tests for musl') {
+							options {
+								timeout(time: 1, unit: 'HOURS')
+							}
+							steps {
+								sh "scripts/dev_cli.sh tests --integration-vfio --libc musl"
+							}
+						}
+					}
+					post {
+						always {
+							sh "sudo chown -R jenkins.jenkins ${WORKSPACE}"
+							deleteDir()
+						}
+					}
+				}
 				stage ('Worker build - Windows guest') {
 					agent { node { label 'groovy-win' } }
 					stages {

--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -x
+
+source $HOME/.cargo/env
+source $(dirname "$0")/test-util.sh
+
+process_common_args "$@"
+# For now these values are deafult for kvm
+features_build=""
+features_test="--features integration_tests"
+
+BUILD_TARGET="$(uname -m)-unknown-linux-${CH_LIBC}"
+CFLAGS=""
+TARGET_CC=""
+if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
+TARGET_CC="musl-gcc"
+CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
+fi
+
+cargo build --all --release $features_build --target $BUILD_TARGET
+strip target/$BUILD_TARGET/release/cloud-hypervisor
+
+export RUST_BACKTRACE=1
+
+time cargo test $features_test "tests::vfio::$test_filter"
+RES=$?
+
+exit $RES


### PR DESCRIPTION
Relying on a NVIDIA Tesla T4 card present in the SGX machine, this patch
enables baremetal VFIO testing, validated by running several NVIDIA
tools in the guest. The guest image has been prepared to include all the
software needed to run these tests.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>