### PR TITLE
vm-virtio: initialize MSI-X vectors with VIRTIO_MSI_NO_VECTOR

### DIFF
--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -75,8 +75,6 @@ const VIRTIO_F_VERSION_1: u32 = 32;
 const VIRTIO_F_IOMMU_PLATFORM: u32 = 33;
 const VIRTIO_F_IN_ORDER: u32 = 35;
 
-const VIRTIO_MSI_NO_VECTOR: u16 = 0xffff;
-
 #[derive(Debug)]
 pub enum ActivateError {
     EpollCtl(std::io::Error),

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -16,7 +16,7 @@ use crate::transport::VirtioTransport;
 use crate::{
     ActivateResult, Queue, VirtioDevice, VirtioDeviceType, VirtioInterrupt, VirtioInterruptType,
     DEVICE_ACKNOWLEDGE, DEVICE_DRIVER, DEVICE_DRIVER_OK, DEVICE_FAILED, DEVICE_FEATURES_OK,
-    DEVICE_INIT, VIRTIO_MSI_NO_VECTOR,
+    DEVICE_INIT,
 };
 use anyhow::anyhow;
 use libc::EFD_NONBLOCK;
@@ -45,7 +45,7 @@ use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, SnapshotDataSection, Snapshottable,
     Transportable,
 };
-use vm_virtio::{queue, VirtioIommuRemapping};
+use vm_virtio::{queue, VirtioIommuRemapping, VIRTIO_MSI_NO_VECTOR};
 use vmm_sys_util::{errno::Result, eventfd::EventFd};
 
 #[derive(Debug)]
@@ -423,7 +423,7 @@ impl VirtioPciDevice {
                 device_feature_select: 0,
                 driver_feature_select: 0,
                 queue_select: 0,
-                msix_config: Arc::new(AtomicU16::new(0)),
+                msix_config: Arc::new(AtomicU16::new(VIRTIO_MSI_NO_VECTOR)),
             },
             msix_config,
             msix_num,

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -23,6 +23,8 @@ pub use queue::*;
 pub type VirtioIommuRemapping =
     Box<dyn Fn(u64) -> std::result::Result<u64, std::io::Error> + Send + Sync>;
 
+pub const VIRTIO_MSI_NO_VECTOR: u16 = 0xffff;
+
 // Types taken from linux/virtio_ids.h
 #[derive(Copy, Clone, Debug)]
 #[allow(dead_code)]

--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -8,7 +8,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use crate::VirtioIommuRemapping;
+use crate::{VirtioIommuRemapping, VIRTIO_MSI_NO_VECTOR};
 use std::cmp::min;
 use std::convert::TryInto;
 use std::fmt::{self, Display};
@@ -438,7 +438,7 @@ impl Queue {
             max_size,
             size: max_size,
             ready: false,
-            vector: 0,
+            vector: VIRTIO_MSI_NO_VECTOR,
             desc_table: GuestAddress(0),
             avail_ring: GuestAddress(0),
             used_ring: GuestAddress(0),
@@ -486,7 +486,7 @@ impl Queue {
         self.size = self.max_size;
         self.next_avail = Wrapping(0);
         self.next_used = Wrapping(0);
-        self.vector = 0;
+        self.vector = VIRTIO_MSI_NO_VECTOR;
         self.desc_table = GuestAddress(0);
         self.avail_ring = GuestAddress(0);
         self.used_ring = GuestAddress(0);


### PR DESCRIPTION
In case of the virtio frontend driver doesn't need interupts for
certain queue event, it may explicitly write VIRTIO_MSI_NO_VECTOR
to the virtio common configuration, or it may doesn't configure
the event type vector at all.

This patch initializes both MSI-X configuration vector and queue vector
with VIRTIO_MSI_NO_VECTOR, so that the backend drivers won't trigger
unexpected interrupts to the guest.

Signed-off-by: Zide Chen <zide.chen@intel.com>