### PR TITLE
virtio-devices: Add rate limiter for the virtio-net device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,7 @@ dependencies = [
  "log 0.4.14",
  "net_gen",
  "pnet",
+ "rate_limiter",
  "serde",
  "serde_json",
  "virtio-bindings",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rate_limiter"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "log 0.4.14",
+ "vmm-sys-util",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1283,7 @@ dependencies = [
  "net_gen",
  "net_util",
  "pci",
+ "rate_limiter",
  "seccomp",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ members = [
     "option_parser",
     "pci",
     "qcow",
+    "rate_limiter",
     "vhost_user_backend",
     "vhost_user_block",
     "vhost_user_net",

--- a/docs/io_throttling.md
+++ b/docs/io_throttling.md
@@ -1,13 +1,16 @@
 # I/O Throttling
 
-Cloud Hypervisor now supports I/O throttling on virtio-block
+Cloud Hypervisor now supports I/O throttling on virtio-block and virtio-net
 devices. This support is based on the [`rate-limiter` module](https://github.com/firecracker-microvm/firecracker/tree/master/src/rate_limiter)
 from Firecracker. This document explains the user interface of this
 feature, and highlights some internal implementations that can help users
 better understand the expected behavior of I/O throttling in practice.
 
 Cloud Hypervisor allows to limit both the I/O bandwidth (e.g. bytes/s)
-and I/O operations (ops/s) independently. To limit the I/O bandwidth, it
+and I/O operations (ops/s) independently. For virtio-net devices, while
+sharing the same "rate limit" from user inputs (on both bandwidth and
+operations), the RX and TX queues are throttled independently.
+To limit the I/O bandwidth, Cloud Hypervisor
 provides three user options, i.e., `bw_size` (bytes), `bw_one_time_burst`
 (bytes), and `bw_refill_time` (ms). Both `bw_size` and `bw_refill_time`
 are required, while `bw_one_time_burst` is optional.
@@ -29,8 +32,8 @@ empty, it will stop I/O operations for a fixed amount of time
 (`cool_down_time`). The `cool_down_time` now is fixed at `100 ms`, it
 can have big implications to the actual rate limit (which can be a lot
 different the expected "refill-rate" derived from user inputs). For
-example, to have a 1000 IOPS limit, users should be able to provide
-either of the following two options:
+example, to have a 1000 IOPS limit on a virtio-blk device, users should
+be able to provide either of the following two options:
 `ops_size=1000,ops_refill_time=1000` or
 `ops_size=10,ops_refill_time=10`. However, the actual IOPS limits are
 likely to be ~1000 IOPS and ~100 IOPS respectively. The reason is the

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -8,6 +8,7 @@ epoll = ">=4.0.1"
 libc = "0.2.92"
 log = "0.4.14"
 net_gen = { path = "../net_gen" }
+rate_limiter = { path = "../rate_limiter" }
 serde = "1.0.125"
 virtio-bindings = "0.1.0"
 vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-atomic"] }

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -14,6 +14,7 @@ extern crate libc;
 #[macro_use]
 extern crate log;
 extern crate net_gen;
+extern crate rate_limiter;
 extern crate serde;
 extern crate virtio_bindings;
 extern crate vm_memory;

--- a/rate_limiter/Cargo.toml
+++ b/rate_limiter/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rate_limiter"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+libc = "0.2.91"
+log = "0.4.14"
+vmm-sys-util = "0.8.0"

--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -43,6 +43,9 @@
 //! It is meant to be used in an external event loop and thus implements the `AsRawFd`
 //! trait and provides an *event-handler* as part of its API. This *event-handler*
 //! needs to be called by the user on every event on the rate limiter's `AsRawFd` FD.
+#[macro_use]
+extern crate log;
+
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 use std::{fmt, io};

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -111,6 +111,8 @@ impl VhostUserNetThread {
                 epoll_fd: None,
                 counters: NetCounters::default(),
                 tap_event_id: 2,
+                rx_desc_avail: false,
+                rx_rate_limiter: None,
                 tx_rate_limiter: None,
             },
         })

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -111,6 +111,7 @@ impl VhostUserNetThread {
                 epoll_fd: None,
                 counters: NetCounters::default(),
                 tap_event_id: 2,
+                tx_rate_limiter: None,
             },
         })
     }

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4.14"
 net_gen = { path = "../net_gen" }
 net_util = { path = "../net_util" }
 pci = { path = "../pci" }
+rate_limiter = { path = "../rate_limiter" }
 seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.22.0" }
 serde = ">=1.0.27"
 serde_derive = ">=1.0.27"

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -14,7 +14,6 @@ use super::{
     RateLimiterConfig, VirtioCommon, VirtioDevice, VirtioDeviceType, VirtioInterruptType,
     EPOLL_HELPER_EVENT_LAST,
 };
-use crate::rate_limiter::{RateLimiter, TokenType};
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
 use crate::VirtioInterrupt;
 use anyhow::anyhow;
@@ -22,6 +21,7 @@ use block_util::{
     async_io::AsyncIo, async_io::AsyncIoError, async_io::DiskFile, build_disk_image_id, Request,
     RequestType, VirtioBlockConfig,
 };
+use rate_limiter::{RateLimiter, TokenType};
 use seccomp::{SeccompAction, SeccompFilter};
 use std::io;
 use std::num::Wrapping;

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -40,7 +40,6 @@ pub mod mem;
 pub mod net;
 pub mod net_util;
 mod pmem;
-mod rate_limiter;
 mod rng;
 pub mod seccomp_filters;
 pub mod transport;

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -101,11 +101,7 @@ impl NetEpollHandler {
         Ok(())
     }
 
-    fn handle_tx_event(&mut self) -> result::Result<(), DeviceError> {
-        let queue_evt = &self.queue_evt_pair[1];
-        if let Err(e) = queue_evt.read() {
-            error!("Failed to get tx queue event: {:?}", e);
-        }
+    fn process_tx(&mut self) -> result::Result<(), DeviceError> {
         if self
             .net
             .process_tx(&mut self.queue_pair[1])
@@ -117,6 +113,17 @@ impl NetEpollHandler {
         } else {
             debug!("Not signalling TX queue");
         }
+        Ok(())
+    }
+
+    fn handle_tx_event(&mut self) -> result::Result<(), DeviceError> {
+        let queue_evt = &self.queue_evt_pair[1];
+        if let Err(e) = queue_evt.read() {
+            error!("Failed to get tx queue event: {:?}", e);
+        }
+
+        self.process_tx()?;
+
         Ok(())
     }
 

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -228,6 +228,7 @@ fn virtio_net_thread_rules() -> Vec<SyscallRuleSet> {
         allow_syscall(libc::SYS_readv),
         allow_syscall(libc::SYS_rt_sigprocmask),
         allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_timerfd_settime),
         allow_syscall(libc::SYS_write),
         allow_syscall(libc::SYS_writev),
     ]

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -719,6 +719,8 @@ components:
           items:
             type: integer
             format: int32
+        rate_limiter_config:
+            $ref: '#/components/schemas/RateLimiterConfig'
 
     RngConfig:
       required:

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2076,6 +2076,7 @@ impl DeviceManager {
                         net_cfg.num_queues,
                         net_cfg.queue_size,
                         self.seccomp_action.clone(),
+                        net_cfg.rate_limiter_config,
                     )
                     .map_err(DeviceManagerError::CreateVirtioNet)?,
                 ))
@@ -2088,6 +2089,7 @@ impl DeviceManager {
                         net_cfg.iommu,
                         net_cfg.queue_size,
                         self.seccomp_action.clone(),
+                        net_cfg.rate_limiter_config,
                     )
                     .map_err(DeviceManagerError::CreateVirtioNet)?,
                 ))
@@ -2104,6 +2106,7 @@ impl DeviceManager {
                         net_cfg.num_queues,
                         net_cfg.queue_size,
                         self.seccomp_action.clone(),
+                        net_cfg.rate_limiter_config,
                     )
                     .map_err(DeviceManagerError::CreateVirtioNet)?,
                 ))


### PR DESCRIPTION
This PR add the rate limiter for virtio-net devices. Also, to resolve a dependency issue, the `rate_limiter` module is now moved into its own crate  (from crate `virtio-devices`). Note: the RX and TX queue share the same `rate limit` from user inputs, but they are throttled independently.

Fixes: #1286

Signed-off-by: Bo Chen <chen.bo@intel.com>
