### PR TITLE
deps: bump iced-x86 from 1.10.3 to 1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,12 +431,11 @@ dependencies = [
 
 [[package]]
 name = "iced-x86"
-version = "1.10.3"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644fd8d7e49d1ccae568a8fbb873a7ee7fcb3bc9214a474a5e55c03b6d1fa5ac"
+checksum = "4261b15a556aa9b83b976b7aa4613f5a3b80351683af14c5d8d7e62c00869d5a"
 dependencies = [
  "lazy_static",
- "rustc_version",
  "static_assertions",
 ]
 
@@ -902,15 +901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,21 +919,6 @@ source = "git+https://github.com/firecracker-microvm/firecracker?tag=v0.22.0#cc5
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -1012,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "static_assertions"
-version = "0.3.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -27,7 +27,7 @@ vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = ">=0.5.0", features = ["with-serde"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]
-version = "1.10"
+version = "1.11"
 default-features = false
 features = ["std", "decoder", "op_code_info", "instr_info", "fast_fmt"]
 

--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -131,7 +131,7 @@ fn memory_operand_address<T: CpuStateManager>(
         address += index;
     }
 
-    address += insn.memory_displacement() as u64;
+    address += insn.memory_displacement64();
 
     // Translate to a linear address.
     state.linearize(insn.memory_segment(), address, write)


### PR DESCRIPTION
Bumps iced-x86 from 1.10.3 to 1.11.0.

Manual update of the code was needed since memory_displacement() was
deprecated and replaced with either memory_displacement32() or
memory_displacement64().

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>