### PR TITLE
net_util: Check descriptor size

### DIFF
--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -43,7 +43,7 @@ impl TxVirtio {
 
             let mut iovecs = Vec::new();
             while let Some(desc) = next_desc {
-                if !desc.is_write_only() {
+                if !desc.is_write_only() && desc.len > 0 {
                     let buf = mem
                         .get_slice(desc.addr, desc.len as usize)
                         .map_err(NetQueuePairError::GuestMemory)?
@@ -118,7 +118,7 @@ impl RxVirtio {
 
             let mut iovecs = Vec::new();
             while let Some(desc) = next_desc {
-                if desc.is_write_only() {
+                if desc.is_write_only() && desc.len > 0 {
                     let buf = mem
                         .get_slice(desc.addr, desc.len as usize)
                         .map_err(NetQueuePairError::GuestMemory)?


### PR DESCRIPTION
There is no point in queueing an empty descriptor in the list of iovecs.
Let's simply ignore such case and avoid some unnecessary processing.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>