### PR TITLE
README.md: Update URL for hypervisor-fw

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ We need to get the latest `rust-hypervisor-firmware` release and also a working 
 $ pushd $CLOUDH
 $ wget https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
 $ qemu-img convert -p -f qcow2 -O raw focal-server-cloudimg-amd64.img focal-server-cloudimg-amd64.raw
-$ wget https://github.com/cloud-hypervisor/rust-hypervisor-firmware/releases/download/0.2.8/hypervisor-fw
+$ wget https://github.com/cloud-hypervisor/rust-hypervisor-firmware/releases/download/0.3.0/hypervisor-fw
 $ popd
 ```
 


### PR DESCRIPTION
The 0.3.0 release (re)supports booting stock Ubuntu images so users
should be pointed towards that.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>