### PR TITLE
vm-virtio: queue: Fix comment for DescriptorChain::has_next()

### DIFF
--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -272,7 +272,7 @@ impl<'a> DescriptorChain<'a> {
             || (self.has_next() && self.next >= self.table_size))
     }
 
-    /// Gets if this descriptor chain has another descriptor chain linked after it.
+    /// Gets if this descriptor has another descriptor linked after it.
     pub fn has_next(&self) -> bool {
         self.flags & VIRTQ_DESC_F_NEXT != 0 && self.ttl > 1
     }


### PR DESCRIPTION
This returns trues if this descriptor has another descriptor linked to
it. Not whether this descriptor chain has another one following it.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>