### PR TITLE
arch: Report use of deprecated LinuxBoot protocol

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -459,6 +459,7 @@ pub fn configure_system(
             )?;
         }
         BootProtocol::LinuxBoot => {
+            error!("Using deprecated LinuxBoot protocol: Please configure your kernel with CONFIG_PVH=y and supply the `vmlinux` file to `--kernel`");
             configure_64bit_boot(
                 guest_mem,
                 cmdline_addr,


### PR DESCRIPTION
With CONFIG_PVH in stable kernels for some time we should deprecate the
use of alternative boot methods since this will lead to a much simpler
boot flow and CI process.

See: #2231

Signed-off-by: Rob Bradford <robert.bradford@intel.com>