### PR TITLE
hyperv: Fix CPU hotadd

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -742,10 +742,18 @@ impl CpuManager {
                        | 1 << 2 // AccessSynicRegs
                        | 1 << 3 // AccessSyntheticTimerRegs
                        | 1 << 9, // AccessPartitionReferenceTsc
+                    edx: 1 << 3, // CPU dynamic partitioning
                     ..Default::default()
                 })
                 .map_err(Error::CpuidKvmHyperV)?;
-            for i in 0x4000_0004..=0x4000_000a {
+            cpuid
+                .push(CpuIdEntry {
+                    function: 0x4000_0004,
+                    eax: 1 << 5, // Recommend relaxed timing
+                    ..Default::default()
+                })
+                .map_err(Error::CpuidKvmHyperV)?;
+            for i in 0x4000_0005..=0x4000_000a {
                 cpuid
                     .push(CpuIdEntry {
                         function: i,


### PR DESCRIPTION
The actual issue is the missing cpuid bits for the CPU dynamic partitioning support. There are two points to follow up, however:

- Adding a test involving the reproduce way as per #1799, best way is to be figured out to avoid UI usage.
- CpuManager functionality seems currently to have a bug introduced in 55a3a38e140c32748ed49acdacf6d54e59933048 at least for Windows guest. The number of CPUs as passed in `boot=` doesn't currently match the factual number in the VM. This needs more investigation and perhaps a separate fix.

Closes #1799.

Signed-off-by: Anatol Belski <anbelski@linux.microsoft.com>