### PR TITLE
Fix lints added in clippy nightly.

### DIFF
--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -732,9 +732,9 @@ impl Field {
     ) -> Self {
         Field {
             path,
+            fields,
             access_type,
             update_rule,
-            fields,
         }
     }
 }
@@ -851,8 +851,8 @@ impl<'a> Aml for If<'a> {
 }
 
 pub struct Equal<'a> {
-    right: &'a dyn Aml,
     left: &'a dyn Aml,
+    right: &'a dyn Aml,
 }
 
 impl<'a> Equal<'a> {
@@ -871,8 +871,8 @@ impl<'a> Aml for Equal<'a> {
 }
 
 pub struct LessThan<'a> {
-    right: &'a dyn Aml,
     left: &'a dyn Aml,
+    right: &'a dyn Aml,
 }
 
 impl<'a> LessThan<'a> {
@@ -1056,7 +1056,7 @@ macro_rules! binary_op {
 
         impl<'a> $name<'a> {
             pub fn new(target: &'a dyn Aml, a: &'a dyn Aml, b: &'a dyn Aml) -> Self {
-                $name { target, a, b }
+                $name { a, b, target }
             }
         }
 

--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -76,11 +76,8 @@ impl StatusCode {
 
 fn get_header<'a>(res: &'a str, header: &'a str) -> Option<&'a str> {
     let header_str = format!("{}: ", header);
-    if let Some(o) = res.find(&header_str) {
-        Some(&res[o + header_str.len()..o + res[o..].find('\r').unwrap()])
-    } else {
-        None
-    }
+    res.find(&header_str)
+        .map(|o| &res[o + header_str.len()..o + res[o..].find('\r').unwrap()])
 }
 
 fn get_status_code(res: &str) -> Result<StatusCode, Error> {

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -190,7 +190,7 @@ impl Tap {
             return Err(Error::ConfigureTap(IoError::last_os_error()));
         }
 
-        let tap = Tap { if_name, tap_file };
+        let tap = Tap { tap_file, if_name };
         let offload_flags =
             net_gen::TUN_F_CSUM | net_gen::TUN_F_UFO | net_gen::TUN_F_TSO4 | net_gen::TUN_F_TSO6;
         let vnet_hdr_size = vnet_hdr_len() as i32;

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -538,11 +538,7 @@ impl VirtioDevice for Fs {
     }
 
     fn get_shm_regions(&self) -> Option<VirtioSharedMemoryList> {
-        if let Some(cache) = self.cache.as_ref() {
-            Some(cache.0.clone())
-        } else {
-            None
-        }
+        self.cache.as_ref().map(|cache| cache.0.clone())
     }
 
     fn set_shm_regions(

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -852,12 +852,12 @@ impl DiskConfig {
             iommu,
             num_queues,
             queue_size,
-            vhost_socket,
             vhost_user,
+            vhost_socket,
             poll_queue,
+            rate_limiter_config,
             id,
             disable_io_uring,
-            rate_limiter_config,
         })
     }
 }
@@ -1319,7 +1319,7 @@ impl ConsoleConfig {
             .unwrap_or(Toggle(false))
             .0;
 
-        Ok(Self { mode, file, iommu })
+        Ok(Self { file, mode, iommu })
     }
 
     pub fn default_serial() -> Self {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -560,12 +560,12 @@ impl CpuManager {
         vcpu_states.resize_with(usize::from(config.max_vcpus), VcpuState::default);
 
         #[cfg(target_arch = "x86_64")]
-        let sgx_epc_sections =
-            if let Some(sgx_epc_region) = memory_manager.lock().unwrap().sgx_epc_region() {
-                Some(sgx_epc_region.epc_sections().clone())
-            } else {
-                None
-            };
+        let sgx_epc_sections = memory_manager
+            .lock()
+            .unwrap()
+            .sgx_epc_region()
+            .as_ref()
+            .map(|sgx_epc_region| sgx_epc_region.epc_sections().clone());
         #[cfg(target_arch = "x86_64")]
         let cpuid = {
             let phys_bits = physical_bits(config.max_phys_bits);
@@ -858,12 +858,7 @@ impl CpuManager {
             .map_err(Error::CreateSeccompFilter)?;
 
         #[cfg(target_arch = "x86_64")]
-        let interrupt_controller_clone =
-            if let Some(interrupt_controller) = &self.interrupt_controller {
-                Some(interrupt_controller.clone())
-            } else {
-                None
-            };
+        let interrupt_controller_clone = self.interrupt_controller.as_ref().cloned();
 
         let handle = Some(
             thread::Builder::new()

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3136,11 +3136,9 @@ impl DeviceManager {
     }
 
     pub fn interrupt_controller(&self) -> Option<Arc<Mutex<dyn InterruptController>>> {
-        if let Some(interrupt_controller) = &self.interrupt_controller {
-            Some(interrupt_controller.clone() as Arc<Mutex<dyn InterruptController>>)
-        } else {
-            None
-        }
+        self.interrupt_controller
+            .as_ref()
+            .map(|ic| ic.clone() as Arc<Mutex<dyn InterruptController>>)
     }
 
     pub fn console(&self) -> &Arc<Console> {


### PR DESCRIPTION
Specifically, this PR:
- Changes usage of struct constructors to match the order of fields in the struct declaration (or vice versa)
- Introduces usages of Option::map (or Option::cloned) where appropriate

With this PR, `cargo +nightly clippy` runs without warnings.