### PR TITLE
vm-virtio: queue: Fix descriptor chain validation

### DIFF
--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -265,10 +265,7 @@ impl<'a> DescriptorChain<'a> {
     }
 
     fn is_valid(&self) -> bool {
-        !(self
-            .mem
-            .checked_offset(self.addr, self.len as usize)
-            .is_none()
+        !(!self.mem.check_range(self.addr, self.len as usize)
             || (self.has_next() && self.next >= self.table_size))
     }
 


### PR DESCRIPTION
DescriptorChain::is_valid() wrongly used .checked_offset() to attempt to
validate that the descriptor's data is in valid memory. This works in
all cases except where the guest has placed the data at the very end of
the guest memory as the offset + offset will be outside the range (as
the combined offset will be the next byte and as such out of the guest
memory). Instead use the function .check_range() takes an offset and a
length to validate

This fixes issues see with error messages featuring the
DescriptorChainTooShort error.

Fixes: #2424

Signed-off-by: Rob Bradford <robert.bradford@intel.com>