### PR TITLE
Update for LinuxBoot deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Multiple arguments can be given to the `--disk` parameter.
 
 #### Building your kernel
 
-Cloud Hypervisor also supports direct kernel boot into a `vmlinux` ELF kernel or `bzImage`. In order to support virtio-fs and virtio-iommu we have our own development branch. You are of course able to use your own kernel but these instructions will continue with the version that we develop and test against.
+Cloud Hypervisor also supports direct kernel boot into a `vmlinux` ELF kernel. In order to support virtio-iommu we have our own development branch. You are of course able to use your own kernel but these instructions will continue with the version that we develop and test against.
 
 To build the kernel:
 

--- a/docs/intel_sgx.md
+++ b/docs/intel_sgx.md
@@ -32,7 +32,7 @@ memory, the second one being 32MiB with no pre-allocated memory.
     --cpus boot=1 \
     --memory size=1G \
     --disk path=focal-server-cloudimg-amd64.raw \
-    --kernel bzImage \
+    --kernel vmlinux \
     --cmdline "console=ttyS0 console=hvc0 root=/dev/vda1 rw" \
     --sgx-epc size=64M,prefault=on size=32M,prefault=off
 ```

--- a/docs/iommu.md
+++ b/docs/iommu.md
@@ -89,7 +89,7 @@ virtual IOMMU:
     --cpus boot=1 \
     --memory size=512M \
     --disk path=focal-server-cloudimg-amd64.raw,iommu=on \
-    --kernel custom-bzImage \
+    --kernel custom-vmlinux \
     --cmdline "console=ttyS0 console=hvc0 root=/dev/vda1 rw" \
 ```
 
@@ -166,7 +166,7 @@ be consumed.
     --cpus boot=1 \
     --memory size=8G,hugepages=on \
     --disk path=focal-server-cloudimg-amd64.raw \
-    --kernel custom-bzImage \
+    --kernel custom-vmlinux \
     --cmdline "console=ttyS0 console=hvc0 root=/dev/vda1 rw hugepagesz=2M hugepages=2048" \
     --net tap=,mac=,iommu=on
 ```
@@ -183,7 +183,7 @@ passing through is `0000:00:01.0`.
     --cpus boot=1 \
     --memory size=8G,hugepages=on \
     --disk path=focal-server-cloudimg-amd64.raw \
-    --kernel custom-bzImage \
+    --kernel custom-vmlinux \
     --cmdline "console=ttyS0 console=hvc0 root=/dev/vda1 rw kvm-intel.nested=1 vfio_iommu_type1.allow_unsafe_interrupts rw hugepagesz=2M hugepages=2048" \
     --device path=/sys/bus/pci/devices/0000:00:01.0,iommu=on
 ```
@@ -203,7 +203,7 @@ Last thing is to start the L2 guest with the huge pages memory backend.
     --cpus boot=1 \
     --memory size=4G,hugepages=on \
     --disk path=focal-server-cloudimg-amd64.raw \
-    --kernel custom-bzImage \
+    --kernel custom-vmlinux \
     --cmdline "console=ttyS0 console=hvc0 root=/dev/vda1 rw" \
     --device path=/sys/bus/pci/devices/0000:00:04.0
 ```

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -20,7 +20,7 @@ First thing, we must run a Cloud-Hypervisor VM:
     --api-socket /tmp/cloud-hypervisor.sock \
     --cpus boot=4 \
     --memory size=4G \
-    --kernel bzImage \
+    --kernel vmlinux \
     --cmdline "root=/dev/vda1 console=hvc0 rw" \
     --disk path=focal-server-cloudimg-amd64.raw
 ```

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2206,8 +2206,7 @@ mod tests {
             let mut workload_path = dirs::home_dir().unwrap();
             workload_path.push("workloads");
 
-            let mut kernel_path = workload_path;
-            kernel_path.push("bzImage");
+            let kernel_path = direct_kernel_boot_path();
 
             let mut child = GuestCommand::new(&guest)
                 .args(&["--cpus", "boot=1"])
@@ -2290,8 +2289,7 @@ mod tests {
             let mut workload_path = dirs::home_dir().unwrap();
             workload_path.push("workloads");
 
-            let mut kernel_path = workload_path;
-            kernel_path.push("bzImage");
+            let kernel_path = direct_kernel_boot_path();
 
             let mut child = GuestCommand::new(&guest)
                 .args(&["--cpus", "boot=6"])
@@ -3430,8 +3428,7 @@ mod tests {
             let mut workload_path = dirs::home_dir().unwrap();
             workload_path.push("workloads");
 
-            let mut kernel_path = workload_path.clone();
-            kernel_path.push("bzImage");
+            let kernel_path = direct_kernel_boot_path();
 
             let mut vfio_path = workload_path.clone();
             vfio_path.push("vfio");
@@ -3982,8 +3979,7 @@ mod tests {
             let mut workload_path = dirs::home_dir().unwrap();
             workload_path.push("workloads");
 
-            let mut kernel_path = workload_path;
-            kernel_path.push("bzImage");
+            let kernel_path = direct_kernel_boot_path();
 
             let mut child = GuestCommand::new(&guest)
                 .args(&["--cpus", "boot=1"])
@@ -5036,8 +5032,7 @@ mod tests {
             let mut workload_path = dirs::home_dir().unwrap();
             workload_path.push("workloads");
 
-            let mut kernel_path = workload_path;
-            kernel_path.push("bzImage");
+            let kernel_path = direct_kernel_boot_path();
 
             let api_socket = temp_api_path(&guest.tmp_dir);
 


### PR DESCRIPTION
Non CONFIG_PVH ELF binaries were deprecated in 0.14.0. Update documentation to not encourage new use of bzImage files and move non-bzImage specific tests to the generic direct boot code path.