### PR TITLE
ci: Update SGX test to rely on vmlinux

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5835,7 +5835,7 @@ mod tests {
             workload_path.push("workloads");
 
             let mut kernel_path = workload_path;
-            kernel_path.push("bzImage_w_sgx");
+            kernel_path.push("vmlinux_w_sgx");
 
             let mut child = GuestCommand::new(&guest)
                 .args(&["--cpus", "boot=1"])


### PR DESCRIPTION
Since using bzImage is now deprecated, let's update the SGX integration
test to rely on vmlinux instead.

Fixes #2476

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>