### PR TITLE
memory_manager: Fix address range calculation in MemorySlot

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -188,6 +188,8 @@ This allows for SSH login from a remote machine, for example through the `admini
 
 CPU hotplug is supported. The VM operating system needs to support hotplug and be appropriately licensed. SKU limitations like constraints on the number of cores are to be taken into consideration. Note, that Windows doesn't support CPU hot-remove. When `ch-remote` is invoked to reduce the number of CPUs, the result will be visible after the OS reboot within the same hypervisor instance.
 
+RAM hotplug is supported. Note, that while the `pnpmem.sys` driver in use supports RAM hot-remove, the RAM being unplugged has to be not in use and have no reserved pages. In most cases it means, hot-remove won't work. Same as with the CPU hot-remove, when `ch-remote` is invoked to reduce the RAM size, the result will be visible after the OS reboot.
+
 ## Debugging
 
 The Windows guest debugging process relies heavily on QEMU and [socat](http://www.dest-unreach.org/socat/). The procedure requires two Windows VMs:

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1810,9 +1810,17 @@ impl Aml for MemoryMethods {
                         &aml::Path::new("MINH"),
                         &aml::Path::new("LENH"),
                     ),
+                    &aml::If::new(
+                        &aml::LessThan::new(&aml::Path::new("MAXL"), &aml::Path::new("MINL")),
+                        vec![&aml::Add::new(
+                            &aml::Path::new("MAXH"),
+                            &aml::ONE,
+                            &aml::Path::new("MAXH"),
+                        )],
+                    ),
                     &aml::Subtract::new(
-                        &aml::Path::new("MAXH"),
-                        &aml::Path::new("MAXH"),
+                        &aml::Path::new("MAXL"),
+                        &aml::Path::new("MAXL"),
                         &aml::ONE,
                     ),
                     // Release lock


### PR DESCRIPTION
The patch makes sure care taken of a possible overflow and fixes the subtraction part, while adding a test and a documentation part.

Fixes #1800.

Signed-off-by: Anatol Belski <anbelski@linux.microsoft.com>