### PR TITLE
Use relative links between cloud-hypervisor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,12 +252,12 @@ Direct kernel boot to userspace should work with a rootfs from most distribution
 
 ## Hot Plug
 
-Cloud Hypervisor supports hotplug of CPUs, passthrough devices (VFIO), `virtio-{net,block,pmem,fs,vsock}` and memory resizing. This [document](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/docs/hotplug.md) details how to add devices to
+Cloud Hypervisor supports hotplug of CPUs, passthrough devices (VFIO), `virtio-{net,block,pmem,fs,vsock}` and memory resizing. This [document](docs/hotplug.md) details how to add devices to
 a running VM.
 
 ## Device Model
 
-Details of the device model can be found in this [documentation](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/docs/device_model.md).
+Details of the device model can be found in this [documentation](docs/device_model.md).
 
 ## TODO
 

--- a/docs/device_model.md
+++ b/docs/device_model.md
@@ -113,9 +113,8 @@ selecting `--serial tty --console off` from the command line.
 ### virtio-iommu
 
 As we want to improve our nested guests support, we added support for exposing
-a [paravirtualized IOMMU](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/docs/iommu.md)
-device through virtio. This allows for a safer nested virtio and directly
-assigned devices support.
+a [paravirtualized IOMMU](iommu.md) device through virtio. This allows for a
+safer nested virtio and directly assigned devices support.
 
 This device is always built-in, and it is enabled based on the presence of the
 parameter `iommu=on` in any of the virtio or VFIO devices. If at least one of
@@ -184,8 +183,8 @@ This device is always built-in, and it is enabled when `vhost_user=true` and
 shared file system, allowing for an efficient and reliable way of sharing
 a filesystem between the host and the cloud-hypervisor guest.
 
-See our [filesystem sharing](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/docs/fs.md)
-documentation for more details on how to use virtio-fs with cloud-hypervisor.
+See our [filesystem sharing](fs.md) documentation for more details on how to
+use virtio-fs with cloud-hypervisor.
 
 This device is always built-in, and it is enabled based on the presence of the
 flag `--fs`.
@@ -206,9 +205,8 @@ VFIO (Virtual Function I/O) is a kernel framework that exposes direct device
 access to userspace. `cloud-hypervisor` uses VFIO to directly assign host
 physical devices into its guest.
 
-See our [VFIO documentation](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/docs/vfio.md)
-for more details on how to directly assign host devices to `cloud-hypervisor`
-guests.
+See our [VFIO documentation](vfio.md) for more details on how to directly
+assign host devices to `cloud-hypervisor` guests.
 
 Because VFIO implies `vfio-pci` in the `cloud-hypervisor` context, the VFIO
 support is built-in when the `pci` feature is selected. And because the `pci`

--- a/release-notes.md
+++ b/release-notes.md
@@ -753,11 +753,11 @@ to run their guest I/O into separate executions contexts.
 ### Command Line Interface
 
 More and more Cloud Hypervisor services are exposed through the
-[Rest API](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/vmm/src/api/openapi/cloud-hypervisor.yaml)
-and thus only accessible via relatively cumbersome HTTP calls. In order
-to abstract those calls into a more user friendly tool, we created a Cloud
-Hypervisor Command Line Interface (CLI) called `ch-remote`.
-The `ch-remote` binary is created with each build and available e.g. at
+[Rest API](vmm/src/api/openapi/cloud-hypervisor.yaml) and thus only
+accessible via relatively cumbersome HTTP calls. In order to abstract
+those calls into a more user friendly tool, we created a Cloud Hypervisor
+Command Line Interface (CLI) called `ch-remote`.  The `ch-remote` binary
+is created with each build and available e.g. at
 `cloud-hypervisor/target/debug/ch-remote` when doing a debug build.
 
 Please check `ch-remote --help` for a complete description of all available
@@ -833,7 +833,7 @@ In order to provide a better developer experience, we worked on improving our
 build, development and testing tools.
 Somehow similar to the excellent
 [Firecracker's devtool](https://github.com/firecracker-microvm/firecracker/blob/master/tools/devtool),
-we now provide a [dev_cli script](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/scripts/dev_cli.sh).
+we now provide a [dev_cli script](scripts/dev_cli.sh).
 
 With this new tool, our users and contributors will be able to build and test
 Cloud Hypervisor through a containerized environment.
@@ -870,7 +870,7 @@ As a way to vertically scale Cloud-Hypervisor guests, we now support dynamically
 adding virtual CPUs to the guests, a mechanism also known as CPU hot plug.
 Through hardware-reduced ACPI notifications, Cloud Hypervisor can now add CPUs
 to an already running guest and the high level operations for that process are
-documented [here](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/docs/hotplug.md)
+documented [here](docs/hotplug.md)
 
 During the next release cycles we are planning to extend Cloud Hypervisor
 hot plug framework to other resources, namely PCI devices and memory.
@@ -986,9 +986,8 @@ configurations that do not require a PCI bus emulation.
 ### Paravirtualized IOMMU
 
 As we want to improve our nested guests support, we added support for exposing
-a [paravirtualized IOMMU](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/docs/iommu.md)
-device through virtio. This allows for a safer nested virtio and directly
-assigned devices support.
+a [paravirtualized IOMMU](docs/iommu.md) device through virtio. This allows
+for a safer nested virtio and directly assigned devices support.
 
 To add the IOMMU support, we had to make some CLI changes for Cloud Hypervisor
 users to be able to specify if devices had to be handled through this virtual
@@ -1037,8 +1036,8 @@ Based on the Firecracker idea of using a dedicated I/O port to measure guest
 boot times, we added support for logging guest events through the
 [0x80](https://www.intel.com/content/www/us/en/support/articles/000005500/boards-and-kits.html)
 PC debug port. This allows, among other things, for granular guest boot time
-measurements. See our [debug port documentation](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/docs/debug-port.md)
-for more details.
+measurements. See our [debug port documentation](docs/debug-port.md) for more
+details.
 
 ### Improved direct device assignment
 
@@ -1073,8 +1072,8 @@ We added support for the [virtio-fs](https://virtio-fs.gitlab.io/) shared file
 system, allowing for an efficient and reliable way of sharing a filesystem
 between the host and the `cloud-hypervisor` guest.
 
-See our [filesystem sharing](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/docs/fs.md)
-documentation for more details on how to use virtio-fs with `cloud-hypervisor`.
+See our [filesystem sharing](docs/fs.md) documentation for more details on how
+to use virtio-fs with `cloud-hypervisor`.
 
 ### Initial direct device assignment support
 
@@ -1082,9 +1081,8 @@ VFIO (Virtual Function I/O) is a kernel framework that exposes direct device
 access to userspace. `cloud-hypervisor` uses VFIO to directly assign host
 physical devices into its guest.
 
-See our [VFIO](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/docs/vfio.md)
-documentation for more detail on how to directly assign host devices to
-`cloud-hypervisor` guests.
+See our [VFIO](docs/vfio.md) documentation for more detail on how to directly
+assign host devices to `cloud-hypervisor` guests.
 
 ### Userspace IOAPIC
 


### PR DESCRIPTION
This way, the links can be navigated locally, not just on GitHub.

Signed-off-by: Alyssa Ross <hi@alyssa.is>
