### PR TITLE
vmm: seccomp: Add missing SYS_newfstatat

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -344,6 +344,7 @@ fn vmm_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_mremap),
         allow_syscall(libc::SYS_munmap),
         allow_syscall(libc::SYS_nanosleep),
+        allow_syscall(libc::SYS_newfstatat),
         #[cfg(target_arch = "x86_64")]
         allow_syscall(libc::SYS_open),
         allow_syscall(libc::SYS_openat),
@@ -432,6 +433,7 @@ fn vcpu_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall(libc::SYS_mprotect),
         allow_syscall(libc::SYS_munmap),
         allow_syscall(libc::SYS_nanosleep),
+        allow_syscall(libc::SYS_newfstatat),
         #[cfg(target_arch = "x86_64")]
         allow_syscall(libc::SYS_open),
         allow_syscall(libc::SYS_openat),


### PR DESCRIPTION
This is used when running on a new libc like Fedora34.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>