### PR TITLE
RFC (still needs micro-http crate changes) main: Enable the api-socket to be passed as an fd

### DIFF
--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -31,7 +31,8 @@
 extern crate vm_device;
 extern crate vmm_sys_util;
 
-pub use self::http::start_http_thread;
+pub use self::http::start_http_fd_thread;
+pub use self::http::start_http_path_thread;
 
 pub mod http;
 pub mod http_endpoint;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -250,6 +250,7 @@ impl Serialize for PciDeviceInfo {
 pub fn start_vmm_thread(
     vmm_version: String,
     http_path: &Option<String>,
+    http_fd: Option<RawFd>,
     api_event: EventFd,
     api_sender: Sender<ApiRequest>,
     api_receiver: Receiver<ApiRequest>,
@@ -280,9 +281,11 @@ pub fn start_vmm_thread(
         })
         .map_err(Error::VmmThreadSpawn)?;
 
+    // The VMM thread is started, we can start serving HTTP requests
     if let Some(http_path) = http_path {
-        // The VMM thread is started, we can start serving HTTP requests
-        api::start_http_thread(http_path, http_api_event, api_sender, seccomp_action)?;
+        api::start_http_path_thread(http_path, http_api_event, api_sender, seccomp_action)?;
+    } else if let Some(http_fd) = http_fd {
+        api::start_http_fd_thread(http_fd, http_api_event, api_sender, seccomp_action)?;
     }
     Ok(thread)
 }


### PR DESCRIPTION
To avoid race issues where the api-socket may not be created by the
time a cloud-hypervisor caller is ready to look for it, enable the
caller to pass the api-socket fd directly. To avoid breaking existing
callers, add a new command-line option to handle this directly. Also
if both a path and a api-socket fd are given ignore the api-socket
fd.

Signed-off-by: William Douglas <william.r.douglas@gmail.com>