### PR TITLE
Reject reserved fd from NetworkConfig

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1715,6 +1715,7 @@ impl VmConfig {
                 if net.vhost_user && !self.memory.shared {
                     return Err(ValidationError::VhostUserRequiresSharedMemory);
                 }
+                net.validate()?;
             }
         }
 


### PR DESCRIPTION
Prohibit use of stdin, stdout and stderr.