### PR TITLE
virtio-devices: net: Expand VirtioNetConfig to match kernel

### DIFF
--- a/virtio-devices/src/net_util.rs
+++ b/virtio-devices/src/net_util.rs
@@ -33,6 +33,9 @@ pub struct VirtioNetConfig {
     pub mtu: u16,
     pub speed: u32,
     pub duplex: u8,
+    pub rss_max_key_size: u8,
+    pub rss_max_indirection_table_length: u16,
+    pub supported_hash_types: u32,
 }
 
 // We must explicitly implement Serialize since the structure is packed and


### PR DESCRIPTION
Expand the VirtioNetConfig struct to match the the kernel. This
mitigates issues seen from the Windows driver where it tries to access
variables with the wrong data length:

cloud-hypervisor: 101.537823101s: <vcpu1> ERROR:virtio-devices/src/device.rs:164 -- Out-of-bound access to configuration: config_len = 17 offset = 10 length = 4 for 1

See: #1798

Signed-off-by: Rob Bradford <robert.bradford@intel.com>