### PR TITLE
main: Enable the api-socket to be passed as an fd

### DIFF
--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -31,7 +31,8 @@
 extern crate vm_device;
 extern crate vmm_sys_util;
 
-pub use self::http::start_http_thread;
+pub use self::http::start_http_fd_thread;
+pub use self::http::start_http_path_thread;
 
 pub mod http;
 pub mod http_endpoint;


### PR DESCRIPTION
To avoid race issues where the api-socket may not be created by the
time a cloud-hypervisor caller is ready to look for it, enable the
caller to pass the api-socket fd directly.

Avoid breaking current callers by allowing the --api-socket path to be
passed as it is now in addition to through the path argument.

Signed-off-by: William Douglas <william.r.douglas@gmail.com>