### PR TITLE
Extend live migration support with tracking dirty-pages written by the VMM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,8 +1228,7 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=master#956b5a5ea1d7b9202
 [[package]]
 name = "vm-memory"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625f401b1b8b3ac3d43f53903cd138cfe840bd985f8581e553027b31d2bb8ae8"
+source = "git+https://github.com/rust-vmm/vm-memory?rev=5bd7138758183a73ac0da27ce40c004d95f1a7e9#5bd7138758183a73ac0da27ce40c004d95f1a7e9"
 dependencies = [
  "arc-swap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ clap = { version = "2.33.3", features = ["wrap_help"] }
 [patch.crates-io]
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.4.0", features = ["with-serde", "fam-wrappers"] }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
+vm-memory = { git = "https://github.com/rust-vmm/vm-memory", rev = "5bd7138758183a73ac0da27ce40c004d95f1a7e9"}
 
 [dev-dependencies]
 credibility = "0.1.3"

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -22,6 +22,6 @@ thiserror = "1.0"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-fdt = { git = "https://github.com/rust-vmm/vm-fdt", branch = "master" }
-vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -12,6 +12,7 @@ use std::fmt::Debug;
 use std::result;
 
 use super::super::DeviceType;
+use super::super::GuestMemoryMmap;
 use super::super::InitramfsConfig;
 use super::get_fdt_addr;
 use super::gic::GicDevice;
@@ -20,7 +21,7 @@ use super::layout::{
     PCI_MMCONFIG_START,
 };
 use vm_fdt::{FdtWriter, FdtWriterResult};
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap};
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryError};
 
 // This is a value for uniquely identifying the FDT node declaring the interrupt controller.
 const GIC_PHANDLE: u32 = 1;

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -13,6 +13,7 @@ pub mod regs;
 
 pub use self::fdt::DeviceInfoForFdt;
 use crate::DeviceType;
+use crate::GuestMemoryMmap;
 use crate::RegionType;
 use gic::GicDevice;
 use std::collections::HashMap;
@@ -20,8 +21,7 @@ use std::ffi::CStr;
 use std::fmt::Debug;
 use std::sync::Arc;
 use vm_memory::{
-    Address, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, GuestMemoryMmap,
-    GuestUsize,
+    Address, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, GuestUsize,
 };
 
 /// Errors thrown while configuring aarch64 system.

--- a/arch/src/aarch64/regs.rs
+++ b/arch/src/aarch64/regs.rs
@@ -6,13 +6,13 @@
 // found in the THIRD-PARTY file.
 
 use super::get_fdt_addr;
+use crate::GuestMemoryMmap;
 use hypervisor::kvm::kvm_bindings::{
     kvm_regs, user_pt_regs, KVM_REG_ARM64, KVM_REG_ARM_CORE, KVM_REG_SIZE_U64,
 };
 use hypervisor::{arm64_core_reg_id, offset__of};
 use std::sync::Arc;
 use std::{mem, result};
-use vm_memory::GuestMemoryMmap;
 
 /// Errors thrown while setting aarch64 registers.
 #[derive(Debug)]

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -14,6 +14,8 @@ extern crate log;
 use std::fmt;
 use std::result;
 
+type GuestMemoryMmap = vm_memory::GuestMemoryMmap<vm_memory::bitmap::AtomicBitmap>;
+
 /// Type for returning error code.
 #[derive(Debug)]
 pub enum Error {

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -12,6 +12,7 @@ pub mod layout;
 mod mpspec;
 mod mptable;
 pub mod regs;
+use crate::GuestMemoryMmap;
 use crate::InitramfsConfig;
 use crate::RegionType;
 use hypervisor::{CpuId, CpuIdEntry, CPUID_FLAG_VALID_INDEX};
@@ -22,7 +23,7 @@ use linux_loader::loader::elf::start_info::{
 use std::mem;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
-    GuestMemoryMmap, GuestMemoryRegion, GuestUsize,
+    GuestMemoryRegion, GuestUsize,
 };
 mod smbios;
 use std::arch::x86_64;

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -7,14 +7,13 @@
 
 use crate::layout::{APIC_START, HIGH_RAM_START, IOAPIC_START};
 use crate::x86_64::mpspec;
+use crate::GuestMemoryMmap;
 use libc::c_char;
 use std::io;
 use std::mem;
 use std::result;
 use std::slice;
-use vm_memory::{
-    Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap,
-};
+use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError};
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
 // trait (in this case `ByteValued`) where:

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -7,12 +7,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 use crate::layout::{BOOT_GDT_START, BOOT_IDT_START, PVH_INFO_START};
+use crate::GuestMemoryMmap;
 use hypervisor::arch::x86::gdt::{gdt_entry, segment_from_gdt};
 use hypervisor::arch::x86::regs::*;
 use hypervisor::x86_64::{FpuState, SpecialRegisters, StandardRegisters};
 use std::sync::Arc;
 use std::{mem, result};
-use vm_memory::{Address, Bytes, GuestMemory, GuestMemoryError, GuestMemoryMmap};
+use vm_memory::{Address, Bytes, GuestMemory, GuestMemoryError};
 
 #[derive(Debug)]
 pub enum Error {
@@ -163,7 +164,8 @@ pub fn configure_segments_and_sregs(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use vm_memory::{GuestAddress, GuestMemoryMmap};
+    use crate::GuestMemoryMmap;
+    use vm_memory::GuestAddress;
 
     fn create_guest_mem() -> GuestMemoryMmap {
         GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap()

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -7,12 +7,13 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use crate::layout::SMBIOS_START;
+use crate::GuestMemoryMmap;
 use std::fmt::{self, Display};
 use std::mem;
 use std::result;
 use std::slice;
 use vm_memory::ByteValued;
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
+use vm_memory::{Address, Bytes, GuestAddress};
 
 #[allow(unused_variables)]
 #[derive(Debug)]

--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -1,10 +1,11 @@
 // Copyright © 2021 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
+use crate::GuestMemoryMmap;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use thiserror::Error;
-use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemoryError, GuestMemoryMmap};
+use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemoryError};
 
 #[derive(Error, Debug)]
 pub enum TdvfError {

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "1.0"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"]}
-vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 

--- a/block_util/src/lib.rs
+++ b/block_util/src/lib.rs
@@ -35,9 +35,13 @@ use std::sync::{Arc, Mutex};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_bindings::bindings::virtio_blk::*;
-use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap};
+use vm_memory::{
+    bitmap::AtomicBitmap, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError,
+};
 use vm_virtio::DescriptorChain;
 use vmm_sys_util::eventfd::EventFd;
+
+type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 
 const SECTOR_SHIFT: u8 = 9;
 pub const SECTOR_SIZE: u64 = 0x01 << SECTOR_SHIFT;

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -723,8 +723,7 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=master#13ab882e2f8387753
 [[package]]
 name = "vm-memory"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625f401b1b8b3ac3d43f53903cd138cfe840bd985f8581e553027b31d2bb8ae8"
+source = "git+https://github.com/rust-vmm/vm-memory?rev=5bd7138758183a73ac0da27ce40c004d95f1a7e9#5bd7138758183a73ac0da27ce40c004d95f1a7e9"
 dependencies = [
  "arc-swap",
  "libc",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,6 +24,7 @@ path = ".."
 
 [patch.crates-io]
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.4.0", features = ["with-serde", "fam-wrappers"] }
+vm-memory = { git = "https://github.com/rust-vmm/vm-memory", rev = "5bd7138758183a73ac0da27ce40c004d95f1a7e9"}
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -14,7 +14,7 @@ serde = "1.0.126"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 virtio-bindings = "0.1.0"
-vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 

--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
+use crate::GuestMemoryMmap;
 use crate::Tap;
 use libc::c_uint;
 use virtio_bindings::bindings::virtio_net::{
@@ -11,7 +12,7 @@ use virtio_bindings::bindings::virtio_net::{
     VIRTIO_NET_F_GUEST_ECN, VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_TSO6,
     VIRTIO_NET_F_GUEST_UFO, VIRTIO_NET_OK,
 };
-use vm_memory::{ByteValued, Bytes, GuestMemoryError, GuestMemoryMmap};
+use vm_memory::{ByteValued, Bytes, GuestMemoryError};
 use vm_virtio::Queue;
 
 #[derive(Debug)]

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -30,7 +30,9 @@ use virtio_bindings::bindings::virtio_net::{
     VIRTIO_NET_F_GUEST_CSUM, VIRTIO_NET_F_GUEST_ECN, VIRTIO_NET_F_GUEST_TSO4,
     VIRTIO_NET_F_GUEST_TSO6, VIRTIO_NET_F_GUEST_UFO, VIRTIO_NET_F_MAC, VIRTIO_NET_F_MQ,
 };
-use vm_memory::ByteValued;
+use vm_memory::{bitmap::AtomicBitmap, ByteValued};
+
+type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 
 pub use ctrl_queue::{CtrlQueue, Error as CtrlQueueError};
 pub use mac::{MacAddr, MAC_ADDR_LEN};

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -3,13 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use super::{unregister_listener, vnet_hdr_len, Tap};
+use crate::GuestMemoryMmap;
 use rate_limiter::{RateLimiter, TokenType};
 use std::io;
 use std::num::Wrapping;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use vm_memory::{Bytes, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::{Bytes, GuestAddressSpace, GuestMemory, GuestMemoryAtomic};
 use vm_virtio::Queue;
 
 #[derive(Clone)]

--- a/vhost_user_backend/Cargo.toml
+++ b/vhost_user_backend/Cargo.toml
@@ -12,7 +12,7 @@ epoll = ">=4.0.1"
 libc = "0.2.95"
 log = "0.4.14"
 virtio-bindings = "0.1.0"
-vm-memory = "0.5.0"
+vm-memory = { version = "0.5.0", features = ["backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"
 vhost = { git = "https://github.com/rust-vmm/vhost", branch = "master", package = "vhost", features = ["vhost-user-slave"] }

--- a/vhost_user_backend/src/lib.rs
+++ b/vhost_user_backend/src/lib.rs
@@ -27,9 +27,12 @@ use vhost::vhost_user::{
 };
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use vm_memory::guest_memory::FileOffset;
-use vm_memory::{GuestAddress, GuestMemoryMmap, GuestRegionMmap, MmapRegion};
+use vm_memory::{bitmap::AtomicBitmap, GuestAddress, MmapRegion};
 use vm_virtio::Queue;
 use vmm_sys_util::eventfd::EventFd;
+
+pub type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
+pub type GuestRegionMmap = vm_memory::GuestRegionMmap<AtomicBitmap>;
 
 const MAX_MEM_SLOTS: u64 = 32;
 

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -30,11 +30,11 @@ use std::vec::Vec;
 use std::{convert, error, fmt, io};
 use vhost::vhost_user::message::*;
 use vhost::vhost_user::Listener;
-use vhost_user_backend::{VhostUserBackend, VhostUserDaemon, Vring};
+use vhost_user_backend::{GuestMemoryMmap, VhostUserBackend, VhostUserDaemon, Vring};
 use virtio_bindings::bindings::virtio_blk::*;
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use vm_memory::ByteValued;
-use vm_memory::{Bytes, GuestMemoryMmap};
+use vm_memory::Bytes;
 use vmm_sys_util::eventfd::EventFd;
 
 const SECTOR_SHIFT: u8 = 9;

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -22,10 +22,10 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::vec::Vec;
 use vhost::vhost_user::message::*;
 use vhost::vhost_user::Listener;
-use vhost_user_backend::{VhostUserBackend, VhostUserDaemon, Vring, VringWorker};
+use vhost_user_backend::{GuestMemoryMmap, VhostUserBackend, VhostUserDaemon, Vring, VringWorker};
 use virtio_bindings::bindings::virtio_net::*;
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::GuestMemoryAtomic;
 use vmm_sys_util::eventfd::EventFd;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -32,7 +32,7 @@ vhost = { git = "https://github.com/rust-vmm/vhost", branch = "master", package 
 virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"]}
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.3.1"

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -17,6 +17,7 @@ use super::{
     VirtioCommon, VirtioDevice, VirtioDeviceType, EPOLL_HELPER_EVENT_LAST, VIRTIO_F_VERSION_1,
 };
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::GuestMemoryMmap;
 use crate::{VirtioInterrupt, VirtioInterruptType};
 use libc::EFD_NONBLOCK;
 use seccomp::{SeccompAction, SeccompFilter};
@@ -31,7 +32,7 @@ use std::thread;
 use vm_memory::GuestMemory;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
-    GuestMemoryError, GuestMemoryMmap,
+    GuestMemoryError,
 };
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -15,6 +15,7 @@ use super::{
     EPOLL_HELPER_EVENT_LAST,
 };
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::GuestMemoryMmap;
 use crate::VirtioInterrupt;
 use block_util::{
     async_io::AsyncIo, async_io::AsyncIoError, async_io::DiskFile, build_disk_image_id, Request,
@@ -34,7 +35,7 @@ use std::{collections::HashMap, convert::TryInto};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_bindings::bindings::virtio_blk::*;
-use vm_memory::{ByteValued, Bytes, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::{ByteValued, Bytes, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -8,6 +8,7 @@ use super::{
     VIRTIO_F_IOMMU_PLATFORM, VIRTIO_F_VERSION_1,
 };
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::GuestMemoryMmap;
 use crate::VirtioInterrupt;
 use libc::EFD_NONBLOCK;
 use seccomp::{SeccompAction, SeccompFilter};
@@ -23,7 +24,7 @@ use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use vm_memory::{ByteValued, Bytes, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::{ByteValued, Bytes, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use crate::{ActivateError, ActivateResult, Error, Queue};
+use crate::{GuestMemoryMmap, GuestRegionMmap};
 use libc::EFD_NONBLOCK;
 use std::collections::HashMap;
 use std::io::Write;
@@ -16,7 +17,7 @@ use std::sync::{
     Arc, Barrier,
 };
 use std::thread;
-use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryMmap, GuestRegionMmap, GuestUsize};
+use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestUsize};
 use vm_migration::{MigratableError, Pausable};
 use vm_virtio::VirtioDeviceType;
 use vmm_sys_util::eventfd::EventFd;

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -9,6 +9,7 @@ use super::{
     EPOLL_HELPER_EVENT_LAST, VIRTIO_F_VERSION_1,
 };
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::GuestMemoryMmap;
 use crate::{DmaRemapping, VirtioInterrupt, VirtioInterruptType};
 use seccomp::{SeccompAction, SeccompFilter};
 use std::collections::BTreeMap;
@@ -26,7 +27,7 @@ use versionize_derive::Versionize;
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
-    GuestMemoryError, GuestMemoryMmap,
+    GuestMemoryError,
 };
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -49,8 +49,12 @@ pub use self::pmem::*;
 pub use self::rng::*;
 pub use self::vsock::*;
 pub use self::watchdog::*;
-use vm_memory::{GuestAddress, GuestMemory};
+use vm_memory::{bitmap::AtomicBitmap, GuestAddress, GuestMemory};
 use vm_virtio::{queue::*, VirtioDeviceType};
+
+type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
+type GuestRegionMmap = vm_memory::GuestRegionMmap<AtomicBitmap>;
+type MmapRegion = vm_memory::MmapRegion<AtomicBitmap>;
 
 const DEVICE_INIT: u32 = 0x00;
 const DEVICE_ACKNOWLEDGE: u32 = 0x01;

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -19,6 +19,7 @@ use super::{
     EPOLL_HELPER_EVENT_LAST, VIRTIO_F_VERSION_1,
 };
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::{GuestMemoryMmap, GuestRegionMmap};
 use crate::{VirtioInterrupt, VirtioInterruptType};
 use anyhow::anyhow;
 use libc::EFD_NONBLOCK;
@@ -35,7 +36,7 @@ use std::thread;
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
-    GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap,
+    GuestMemoryError, GuestMemoryRegion,
 };
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -12,6 +12,7 @@ use super::{
     EPOLL_HELPER_EVENT_LAST,
 };
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::GuestMemoryMmap;
 use crate::VirtioInterrupt;
 use net_util::CtrlQueue;
 use net_util::{
@@ -33,7 +34,7 @@ use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_bindings::bindings::virtio_net::*;
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use vm_memory::{ByteValued, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::{ByteValued, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -13,6 +13,7 @@ use super::{
     EPOLL_HELPER_EVENT_LAST, VIRTIO_F_IOMMU_PLATFORM, VIRTIO_F_VERSION_1,
 };
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::{GuestMemoryMmap, MmapRegion};
 use crate::{VirtioInterrupt, VirtioInterruptType};
 use seccomp::{SeccompAction, SeccompFilter};
 use std::fmt::{self, Display};
@@ -28,7 +29,7 @@ use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
-    GuestMemoryError, GuestMemoryMmap, MmapRegion,
+    GuestMemoryError,
 };
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -9,6 +9,7 @@ use super::{
     VIRTIO_F_VERSION_1,
 };
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::GuestMemoryMmap;
 use crate::{VirtioInterrupt, VirtioInterruptType};
 use seccomp::{SeccompAction, SeccompFilter};
 use std::fs::File;
@@ -20,7 +21,7 @@ use std::sync::{Arc, Barrier};
 use std::thread;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -305,9 +305,10 @@ impl Snapshottable for VirtioPciCommonConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::GuestMemoryMmap;
     use crate::{ActivateResult, VirtioInterrupt};
     use std::sync::Arc;
-    use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
+    use vm_memory::GuestMemoryAtomic;
     use vmm_sys_util::eventfd::EventFd;
 
     struct DummyDevice(u32);

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -8,6 +8,7 @@
 
 use super::VirtioPciCommonConfig;
 use crate::transport::VirtioTransport;
+use crate::GuestMemoryMmap;
 use crate::{
     ActivateResult, Queue, VirtioDevice, VirtioDeviceType, VirtioInterrupt, VirtioInterruptType,
     DEVICE_ACKNOWLEDGE, DEVICE_DRIVER, DEVICE_DRIVER_OK, DEVICE_FAILED, DEVICE_FEATURES_OK,
@@ -35,8 +36,7 @@ use vm_device::interrupt::{
 };
 use vm_device::BusDevice;
 use vm_memory::{
-    Address, ByteValued, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap,
-    GuestUsize, Le32,
+    Address, ByteValued, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestUsize, Le32,
 };
 use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable, VersionMapped,

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -10,6 +10,7 @@ use super::vu_common_ctrl::{
 };
 use super::{Error, Result, DEFAULT_VIRTIO_FEATURES};
 use crate::VirtioInterrupt;
+use crate::{GuestMemoryMmap, GuestRegionMmap};
 use block_util::VirtioBlockConfig;
 use std::mem;
 use std::ops::Deref;
@@ -27,9 +28,7 @@ use virtio_bindings::bindings::virtio_blk::{
     VIRTIO_BLK_F_GEOMETRY, VIRTIO_BLK_F_MQ, VIRTIO_BLK_F_RO, VIRTIO_BLK_F_SEG_MAX,
     VIRTIO_BLK_F_SIZE_MAX, VIRTIO_BLK_F_TOPOLOGY, VIRTIO_BLK_F_WRITE_ZEROES,
 };
-use vm_memory::{
-    ByteValued, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap, GuestRegionMmap,
-};
+use vm_memory::{ByteValued, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -12,6 +12,7 @@ use crate::{
     ActivateError, ActivateResult, Queue, UserspaceMapping, VirtioCommon, VirtioDevice,
     VirtioDeviceType, VirtioInterrupt, VirtioSharedMemoryList,
 };
+use crate::{GuestMemoryMmap, GuestRegionMmap, MmapRegion};
 use libc::{self, c_void, off64_t, pread64, pwrite64};
 use seccomp::{SeccompAction, SeccompFilter};
 use std::io;
@@ -29,7 +30,6 @@ use vhost::vhost_user::{
 };
 use vm_memory::{
     Address, ByteValued, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
-    GuestMemoryMmap, GuestRegionMmap, MmapRegion,
 };
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    EpollHelper, EpollHelperError, EpollHelperHandler, Queue, VirtioInterrupt,
+    EpollHelper, EpollHelperError, EpollHelperHandler, GuestMemoryMmap, Queue, VirtioInterrupt,
     EPOLL_HELPER_EVENT_LAST, VIRTIO_F_IN_ORDER, VIRTIO_F_NOTIFICATION_DATA,
     VIRTIO_F_ORDER_PLATFORM, VIRTIO_F_RING_EVENT_IDX, VIRTIO_F_RING_INDIRECT_DESC,
     VIRTIO_F_RING_PACKED, VIRTIO_F_VERSION_1,
@@ -14,7 +14,7 @@ use std::sync::{atomic::AtomicBool, Arc, Barrier, Mutex};
 use vhost::vhost_user::message::VhostUserVirtioFeatures;
 use vhost::vhost_user::Master;
 use vhost::Error as VhostError;
-use vm_memory::{Error as MmapError, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::{Error as MmapError, GuestAddressSpace, GuestMemoryAtomic};
 use vmm_sys_util::eventfd::EventFd;
 use vu_common_ctrl::{connect_vhost_user, reinitialize_vhost_user};
 

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -12,6 +12,7 @@ use crate::{
     VirtioCommon, VirtioDevice, VirtioDeviceType, VirtioInterrupt, EPOLL_HELPER_EVENT_LAST,
     VIRTIO_F_RING_EVENT_IDX, VIRTIO_F_VERSION_1,
 };
+use crate::{GuestMemoryMmap, GuestRegionMmap};
 use net_util::{build_net_config_space, CtrlQueue, MacAddr, VirtioNetConfig};
 use seccomp::{SeccompAction, SeccompFilter};
 use std::ops::Deref;
@@ -29,9 +30,7 @@ use virtio_bindings::bindings::virtio_net::{
     VIRTIO_NET_F_HOST_ECN, VIRTIO_NET_F_HOST_TSO4, VIRTIO_NET_F_HOST_TSO6, VIRTIO_NET_F_HOST_UFO,
     VIRTIO_NET_F_MAC, VIRTIO_NET_F_MRG_RXBUF,
 };
-use vm_memory::{
-    ByteValued, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap, GuestRegionMmap,
-};
+use vm_memory::{ByteValued, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -4,6 +4,7 @@
 use super::super::{Descriptor, Queue};
 use super::{Error, Result};
 use crate::{get_host_address_range, VirtioInterrupt, VirtioInterruptType};
+use crate::{GuestMemoryMmap, GuestRegionMmap};
 use std::convert::TryInto;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::UnixListener;
@@ -14,9 +15,7 @@ use std::vec::Vec;
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
 use vhost::vhost_user::{Master, VhostUserMaster};
 use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
-use vm_memory::{
-    Address, Error as MmapError, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap,
-};
+use vm_memory::{Address, Error as MmapError, GuestMemory, GuestMemoryRegion};
 use vmm_sys_util::eventfd::EventFd;
 
 #[derive(Debug, Clone)]

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -30,6 +30,7 @@
 use super::{VsockBackend, VsockPacket};
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
 use crate::Error as DeviceError;
+use crate::GuestMemoryMmap;
 use crate::VirtioInterrupt;
 use crate::{
     ActivateError, ActivateResult, EpollHelper, EpollHelperError, EpollHelperHandler, Queue,
@@ -47,7 +48,7 @@ use std::sync::{Arc, Barrier, RwLock};
 use std::thread;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use vm_memory::{GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::{GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable, VersionMapped,
 };

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -163,11 +163,12 @@ mod tests {
     use crate::device::{VirtioInterrupt, VirtioInterruptType};
     use crate::epoll_helper::EpollHelperHandler;
     use crate::EpollHelper;
+    use crate::GuestMemoryMmap;
     use libc::EFD_NONBLOCK;
     use std::os::unix::io::AsRawFd;
     use std::path::PathBuf;
     use std::sync::{Arc, RwLock};
-    use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
+    use vm_memory::{GuestAddress, GuestMemoryAtomic};
     use vm_virtio::queue::testing::VirtQueue as GuestQ;
     use vm_virtio::queue::Queue;
     use vm_virtio::queue::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -342,7 +342,8 @@ mod tests {
     use super::super::tests::TestContext;
     use super::*;
     use crate::vsock::defs::MAX_PKT_BUF_SIZE;
-    use vm_memory::{GuestAddress, GuestMemoryMmap};
+    use crate::GuestMemoryMmap;
+    use vm_memory::GuestAddress;
     use vm_virtio::queue::testing::VirtqDesc as GuestQDesc;
     use vm_virtio::queue::VIRTQ_DESC_F_WRITE;
 

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -11,6 +11,7 @@ use super::{
     VirtioCommon, VirtioDevice, VirtioDeviceType, EPOLL_HELPER_EVENT_LAST, VIRTIO_F_VERSION_1,
 };
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::GuestMemoryMmap;
 use crate::{VirtioInterrupt, VirtioInterruptType};
 use anyhow::anyhow;
 use seccomp::{SeccompAction, SeccompFilter};
@@ -24,7 +25,7 @@ use std::thread;
 use std::time::Instant;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -10,4 +10,4 @@ default = []
 [dependencies]
 log = "0.4.14"
 virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"]}
-vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -16,13 +16,15 @@ use std::num::Wrapping;
 use std::sync::atomic::{fence, Ordering};
 use std::sync::Arc;
 use vm_memory::{
-    Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap,
+    bitmap::AtomicBitmap, Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError,
     GuestUsize,
 };
 
 pub const VIRTQ_DESC_F_NEXT: u16 = 0x1;
 pub const VIRTQ_DESC_F_WRITE: u16 = 0x2;
 pub const VIRTQ_DESC_F_INDIRECT: u16 = 0x4;
+
+type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 
 #[derive(Debug)]
 pub enum Error {
@@ -717,7 +719,9 @@ pub mod testing {
     use std::marker::PhantomData;
     use std::mem;
     use vm_memory::Bytes;
-    use vm_memory::{Address, GuestAddress, GuestMemoryMmap, GuestUsize};
+    use vm_memory::{bitmap::AtomicBitmap, Address, GuestAddress, GuestUsize};
+
+    type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 
     // Represents a location in GuestMemoryMmap which holds a given type.
     pub struct SomeplaceInMemory<'a, T> {
@@ -960,7 +964,9 @@ pub mod testing {
 pub mod tests {
     use super::testing::*;
     pub use super::*;
-    use vm_memory::{GuestAddress, GuestMemoryMmap};
+    use vm_memory::{bitmap::AtomicBitmap, GuestAddress};
+
+    type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 
     #[test]
     fn test_checked_new_descriptor_chain() {

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -47,7 +47,7 @@ vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "maste
 virtio-devices = { path = "../virtio-devices" }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { version = ">=0.5.0", features = ["with-serde"] }

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -6,6 +6,7 @@ use crate::cpu::CpuManager;
 use crate::device_manager::DeviceManager;
 use crate::memory_manager::MemoryManager;
 use crate::vm::NumaNodes;
+use crate::{GuestMemoryMmap, GuestRegionMmap};
 use acpi_tables::sdt::GenericAddress;
 use acpi_tables::{aml::Aml, rsdp::Rsdp, sdt::Sdt};
 #[cfg(target_arch = "aarch64")]
@@ -15,8 +16,7 @@ use arch::DeviceType;
 
 use bitflags::bitflags;
 use std::sync::{Arc, Mutex};
-use vm_memory::GuestRegionMmap;
-use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap, GuestMemoryRegion};
+use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryRegion};
 
 /* Values for Type in APIC sub-headers */
 #[cfg(target_arch = "x86_64")]

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -19,6 +19,7 @@ use crate::memory_manager::MemoryManager;
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
 #[cfg(target_arch = "x86_64")]
 use crate::vm::physical_bits;
+use crate::GuestMemoryMmap;
 use crate::CPU_MANAGER_SNAPSHOT_ID;
 #[cfg(feature = "acpi")]
 use acpi_tables::{aml, aml::Aml, sdt::Sdt};
@@ -43,7 +44,7 @@ use std::{cmp, io, result, thread};
 use vm_device::BusDevice;
 #[cfg(feature = "acpi")]
 use vm_memory::GuestAddress;
-use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::GuestMemoryAtomic;
 use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, SnapshotDataSection, Snapshottable,
     Transportable,
@@ -1775,6 +1776,7 @@ mod tests {
 #[cfg(target_arch = "aarch64")]
 #[cfg(test)]
 mod tests {
+    use crate::GuestMemoryMmap;
     use arch::aarch64::layout;
     use arch::aarch64::regs::*;
     use hypervisor::kvm::aarch64::{is_system_register, MPIDR_EL1};
@@ -1784,7 +1786,7 @@ mod tests {
     };
     use hypervisor::{arm64_core_reg_id, offset__of};
     use std::mem;
-    use vm_memory::{GuestAddress, GuestMemoryMmap};
+    use vm_memory::GuestAddress;
 
     #[test]
     fn test_setup_regs() {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -24,6 +24,7 @@ use crate::memory_manager::MEMORY_MANAGER_ACPI_SIZE;
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 #[cfg(feature = "acpi")]
 use crate::vm::NumaNodes;
+use crate::GuestRegionMmap;
 use crate::PciDeviceInfo;
 use crate::{device_node, DEVICE_MANAGER_SNAPSHOT_ID};
 #[cfg(feature = "acpi")]
@@ -93,7 +94,7 @@ use vm_device::{Bus, BusDevice, Resource};
 use vm_memory::guest_memory::FileOffset;
 #[cfg(feature = "kvm")]
 use vm_memory::GuestMemoryRegion;
-use vm_memory::{Address, GuestAddress, GuestRegionMmap, GuestUsize, MmapRegion};
+use vm_memory::{Address, GuestAddress, GuestUsize, MmapRegion};
 #[cfg(feature = "cmos")]
 use vm_memory::{GuestAddressSpace, GuestMemory};
 use vm_migration::{

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -40,6 +40,7 @@ use std::sync::mpsc::{Receiver, RecvError, SendError, Sender};
 use std::sync::{Arc, Mutex};
 use std::{result, thread};
 use thiserror::Error;
+use vm_memory::bitmap::AtomicBitmap;
 use vm_migration::protocol::*;
 use vm_migration::{MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
@@ -57,6 +58,9 @@ pub mod vm;
 
 #[cfg(feature = "acpi")]
 mod acpi;
+
+type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
+type GuestRegionMmap = vm_memory::GuestRegionMmap<AtomicBitmap>;
 
 /// Errors associated with VMM management
 #[derive(Debug, Error)]

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -7,6 +7,7 @@ use crate::config::SgxEpcConfig;
 use crate::config::{HotplugMethod, MemoryConfig, MemoryZoneConfig};
 use crate::migration::url_to_path;
 use crate::MEMORY_MANAGER_SNAPSHOT_ID;
+use crate::{GuestMemoryMmap, GuestRegionMmap};
 #[cfg(feature = "acpi")]
 use acpi_tables::{aml, aml::Aml};
 use anyhow::anyhow;
@@ -36,8 +37,8 @@ use vm_device::BusDevice;
 use vm_memory::guest_memory::FileOffset;
 use vm_memory::{
     mmap::MmapRegionError, Address, Bytes, Error as MmapError, GuestAddress, GuestAddressSpace,
-    GuestMemory, GuestMemoryAtomic, GuestMemoryError, GuestMemoryLoadGuard, GuestMemoryMmap,
-    GuestMemoryRegion, GuestRegionMmap, GuestUsize, MmapRegion,
+    GuestMemory, GuestMemoryAtomic, GuestMemoryError, GuestMemoryLoadGuard, GuestMemoryRegion,
+    GuestUsize, MmapRegion,
 };
 use vm_migration::{
     protocol::{MemoryRange, MemoryRangeTable},

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -773,7 +773,7 @@ impl MemoryManager {
             log_dirty,
         }));
 
-        guest_memory.memory().with_regions(|_, region| {
+        for region in guest_memory.memory().iter() {
             let mut mm = memory_manager.lock().unwrap();
             let slot = mm.create_userspace_mapping(
                 region.start_addr().raw_value(),
@@ -788,9 +788,7 @@ impl MemoryManager {
                 size: region.len(),
                 slot,
             });
-
-            Ok(())
-        })?;
+        }
 
         for region in virtio_mem_regions.drain(..) {
             let mut mm = memory_manager.lock().unwrap();
@@ -1942,7 +1940,7 @@ impl Snapshottable for MemoryManager {
 
         let mut memory_regions: Vec<MemoryRegion> = Vec::new();
 
-        guest_memory.with_regions_mut(|index, region| {
+        for (index, region) in guest_memory.iter().enumerate() {
             if region.len() == 0 {
                 return Err(MigratableError::Snapshot(anyhow!("Zero length region")));
             }
@@ -1970,9 +1968,7 @@ impl Snapshottable for MemoryManager {
                 start_addr: region.start_addr().0,
                 size: region.len(),
             });
-
-            Ok(())
-        })?;
+        }
 
         // Store locally this list of regions as it will be used through the
         // Transportable::send() implementation. The point is to avoid the

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2019,13 +2019,12 @@ impl Vm {
         let mut table = MemoryRangeTable::default();
         let guest_memory = self.memory_manager.lock().as_ref().unwrap().guest_memory();
 
-        guest_memory.memory().with_regions_mut(|_, region| {
+        for region in guest_memory.memory().iter() {
             table.push(MemoryRange {
                 gpa: region.start_addr().raw_value(),
                 length: region.len() as u64,
             });
-            Ok(())
-        })?;
+        }
 
         Ok(table)
     }
@@ -2520,7 +2519,7 @@ pub fn test_vm() {
     let hv = hypervisor::new().unwrap();
     let vm = hv.create_vm().expect("new VM creation failed");
 
-    mem.with_regions(|index, region| {
+    for (index, region) in mem.iter().enumerate() {
         let mem_region = vm.make_user_memory_region(
             index as u32,
             region.start_addr().raw_value(),
@@ -2531,8 +2530,8 @@ pub fn test_vm() {
         );
 
         vm.set_user_memory_region(mem_region)
-    })
-    .expect("Cannot configure guest memory");
+            .expect("Cannot configure guest memory");
+    }
     mem.write_slice(&code, load_addr)
         .expect("Writing code to memory failed");
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -25,6 +25,7 @@ use crate::device_tree::DeviceTree;
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 use crate::migration::{get_vm_snapshot, url_to_path, VM_SNAPSHOT_FILE};
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::{GuestMemoryMmap, GuestRegionMmap};
 use crate::{
     PciDeviceInfo, CPU_MANAGER_SNAPSHOT_ID, DEVICE_MANAGER_SNAPSHOT_ID, MEMORY_MANAGER_SNAPSHOT_ID,
 };
@@ -61,7 +62,7 @@ use std::{result, str, thread};
 use vm_device::Bus;
 use vm_memory::{
     Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
-    GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap,
+    GuestMemoryRegion,
 };
 use vm_migration::{
     protocol::{MemoryRange, MemoryRangeTable},
@@ -2435,11 +2436,12 @@ mod tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{GuestMemoryMmap, GuestRegionMmap};
     use arch::aarch64::fdt::create_fdt;
     use arch::aarch64::gic::kvm::create_gic;
     use arch::aarch64::{layout, DeviceInfoForFdt};
     use arch::{DeviceType, MmioDeviceInfo};
-    use vm_memory::{GuestAddress, GuestMemoryMmap};
+    use vm_memory::GuestAddress;
 
     const LEN: u64 = 4096;
 


### PR DESCRIPTION
Complete the live migration with tracking dirty pages written by the VMM. 
Some quick notes:

1. This PR is tested by successfully migrating a guest workload with intensive
    virtio-blk transactions that was interrupted during live migration with
    the upstream Cloud Hypervisor.;
2. We are now relying our the upstream version of the vm-memory crate as 
    the working [1] PR was recently landed;
3. With the current design of dirty-page-tracking in the vm-memory crate 
    (to maximize precision), the vmm (e.g. Cloud Hypervisor) is responsible for 
    manually setting dirty pages when using some special functions [1] [2].

[1] https://github.com/rust-vmm/vm-memory/pull/125
[2] https://github.com/rust-vmm/vm-memory/pull/125#discussion_r634682120

Fixes: #2458

Signed-off-by: Bo Chen <chen.bo@intel.com>