### PR TITLE
vmm: Update 'micro_http' crate branch to 'main'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,7 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 [[package]]
 name = "micro_http"
 version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/micro-http?branch=master#49240ce1d5a81a594aa12895c1ef4091c0fd8e9b"
+source = "git+https://github.com/firecracker-microvm/micro-http?branch=main#49240ce1d5a81a594aa12895c1ef4091c0fd8e9b"
 dependencies = [
  "libc",
  "vmm-sys-util",

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -30,7 +30,7 @@ lazy_static = "1.4.0"
 libc = "0.2.93"
 linux-loader = { version = "0.3.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.14"
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "master" }
+micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
 pci = { path = "../pci" }


### PR DESCRIPTION
The master branch of 'micro_http' crate was renamed to 'main'.
Now the old branch name is making build errors.

Signed-off-by: Michael Zhao <michael.zhao@arm.com>