### PR TITLE
pci: Fix BAR reprogramming detection logic

### DIFF
--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -910,26 +910,14 @@ impl PciDevice for VfioPciDevice {
                 let first_bit = region_size.trailing_zeros();
                 region_size = 2u64.pow(first_bit);
 
-                // We need to allocate a guest MMIO address range for that BAR.
-                // In case the BAR is mappable directly, this means it might be
-                // set as user memory region, which expects to deal with 4K
-                // pages. Therefore, the alignment has to be set accordingly.
-                let bar_alignment = if (bar_id == VFIO_PCI_ROM_REGION_INDEX)
-                    || (self.device.get_region_flags(bar_id) & VFIO_REGION_INFO_FLAG_MMAP != 0)
-                {
-                    // 4K alignment
-                    0x1000
-                } else {
-                    // Default 16 bytes alignment
-                    0x10
-                };
+                // BAR allocation needs to be naturally aligned
                 if is_64bit_bar {
                     bar_addr = allocator
-                        .allocate_mmio_addresses(None, region_size, Some(bar_alignment))
+                        .allocate_mmio_addresses(None, region_size, Some(region_size))
                         .ok_or(PciDeviceError::IoAllocationFailed(region_size))?;
                 } else {
                     bar_addr = allocator
-                        .allocate_mmio_hole_addresses(None, region_size, Some(bar_alignment))
+                        .allocate_mmio_hole_addresses(None, region_size, Some(region_size))
                         .ok_or(PciDeviceError::IoAllocationFailed(region_size))?;
                 }
             }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -832,14 +832,22 @@ impl PciDevice for VirtioPciDevice {
         let (virtio_pci_bar_addr, region_type) = if self.use_64bit_bar {
             let region_type = PciBarRegionType::Memory64BitRegion;
             let addr = allocator
-                .allocate_mmio_addresses(self.settings_bar_addr, CAPABILITY_BAR_SIZE, None)
+                .allocate_mmio_addresses(
+                    self.settings_bar_addr,
+                    CAPABILITY_BAR_SIZE,
+                    Some(CAPABILITY_BAR_SIZE),
+                )
                 .ok_or(PciDeviceError::IoAllocationFailed(CAPABILITY_BAR_SIZE))?;
             ranges.push((addr, CAPABILITY_BAR_SIZE, region_type));
             (addr, region_type)
         } else {
             let region_type = PciBarRegionType::Memory32BitRegion;
             let addr = allocator
-                .allocate_mmio_hole_addresses(self.settings_bar_addr, CAPABILITY_BAR_SIZE, None)
+                .allocate_mmio_hole_addresses(
+                    self.settings_bar_addr,
+                    CAPABILITY_BAR_SIZE,
+                    Some(CAPABILITY_BAR_SIZE),
+                )
                 .ok_or(PciDeviceError::IoAllocationFailed(CAPABILITY_BAR_SIZE))?;
             ranges.push((addr, CAPABILITY_BAR_SIZE, region_type));
             (addr, region_type)

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3943,6 +3943,12 @@ impl BusDevice for DeviceManager {
                 // Clear the PCID bitmap
                 self.pci_devices_down = 0;
             }
+            B0EJ_FIELD_OFFSET => {
+                assert!(data.len() == B0EJ_FIELD_SIZE);
+                // Always return an empty bitmap since the eject is always
+                // taken care of right away during a write access.
+                data.copy_from_slice(&[0, 0, 0, 0]);
+            }
             _ => error!(
                 "Accessing unknown location at base 0x{:x}, offset 0x{:x}",
                 base, offset


### PR DESCRIPTION
This PR fixes a bug in the PCI BAR reprogramming detection logic, which fixes proper support for 64 bit BARs in Windows guests.
This fixes both network hotplug along with the weird MSIX issues we were seeing.

Fixes #1797 
Fixes #1798 