### PR TITLE
resources: Update Dockerfile to Ubuntu Focal Fossa

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as dev
+FROM ubuntu:20.04 as dev
 
 ARG TARGETARCH
 ARG RUST_TOOLCHAIN="1.51.0"
@@ -37,7 +37,6 @@ RUN apt-get update \
 	socat \
 	dosfstools \
 	cpio \
-	bsdtar \
 	libfdt-dev \
 	python3-setuptools \
     && apt-get clean \


### PR DESCRIPTION
In order to avoid possible issues with Bionic Beaver (18.04) as it's
getting old, we move the CI container to Focal Fossa (20.04).

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>