### PR TITLE
Support tap from fd (e.g. macvtap) usage over reboot

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5393,6 +5393,17 @@ mod tests {
                         .unwrap_or_default(),
                     2
                 );
+                guest.ssh_command("sudo reboot").unwrap();
+                guest.wait_vm_boot(None).unwrap();
+                assert_eq!(
+                    guest
+                        .ssh_command("ip -o link | wc -l")
+                        .unwrap()
+                        .trim()
+                        .parse::<u32>()
+                        .unwrap_or_default(),
+                    2
+                );
             });
 
             let _ = child.kill();


### PR DESCRIPTION
Currently the VMM fails to reboot as the tap interface  fd has been closed. Duplicate it so that the original version is not closed and so can be reused in the new boot.