### PR TITLE
tests: Don't build separate pvh/non-pvh vmlinux binary

### DIFF
--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -96,12 +96,11 @@ popd
 
 # Build custom kernel based on virtio-pmem and virtio-fs upstream patches
 VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
-VMLINUX_PVH_IMAGE="$WORKLOADS_DIR/vmlinux.pvh"
 BZIMAGE_IMAGE="$WORKLOADS_DIR/bzImage"
 
 LINUX_CUSTOM_DIR="$WORKLOADS_DIR/linux-custom"
 
-if [ ! -f "$VMLINUX_IMAGE" ] || [ ! -f "$VMLINUX_PVH_IMAGE" ]; then
+if [ ! -f "$VMLINUX_IMAGE" ]; then
     SRCDIR=$PWD
     pushd $WORKLOADS_DIR
     time git clone --depth 1 "https://github.com/cloud-hypervisor/linux.git" -b "ch-5.10.6" $LINUX_CUSTOM_DIR
@@ -111,18 +110,9 @@ fi
 
 if [ ! -f "$VMLINUX_IMAGE" ]; then
     pushd $LINUX_CUSTOM_DIR
-    scripts/config --disable "CONFIG_PVH"
     time make bzImage -j `nproc`
     cp vmlinux $VMLINUX_IMAGE || exit 1
     cp arch/x86/boot/bzImage $BZIMAGE_IMAGE || exit 1
-    popd
-fi
-
-if [ ! -f "$VMLINUX_PVH_IMAGE" ]; then
-    pushd $LINUX_CUSTOM_DIR
-    scripts/config --enable "CONFIG_PVH"
-    time make bzImage -j `nproc`
-    cp vmlinux $VMLINUX_PVH_IMAGE || exit 1
     popd
 fi
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2487,52 +2487,6 @@ mod tests {
 
         #[test]
         #[cfg(target_arch = "x86_64")]
-        fn test_pvh_boot() {
-            let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-            let guest = Guest::new(&mut focal);
-            let mut workload_path = dirs::home_dir().unwrap();
-            workload_path.push("workloads");
-
-            let mut kernel_path = workload_path;
-            kernel_path.push("vmlinux.pvh");
-
-            let mut child = GuestCommand::new(&guest)
-                .args(&["--cpus", "boot=1"])
-                .args(&["--memory", "size=512M"])
-                .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
-                .default_disks()
-                .default_net()
-                .capture_output()
-                .spawn()
-                .unwrap();
-
-            let r = std::panic::catch_unwind(|| {
-                guest.wait_vm_boot(None).unwrap();
-
-                assert_eq!(guest.get_cpu_count().unwrap_or_default(), 1);
-                assert!(guest.get_total_memory().unwrap_or_default() > 480_000);
-                assert!(guest.get_entropy().unwrap_or_default() >= 900);
-
-                assert_eq!(
-                    guest
-                        .ssh_command("grep -c PCI-MSI /proc/interrupts")
-                        .unwrap()
-                        .trim()
-                        .parse::<u32>()
-                        .unwrap_or_default(),
-                    12
-                );
-            });
-
-            let _ = child.kill();
-            let output = child.wait_with_output().unwrap();
-
-            handle_child_output(r, &output);
-        }
-
-        #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_bzimage_boot() {
             let mut focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
             let guest = Guest::new(&mut focal);
@@ -4982,7 +4936,7 @@ mod tests {
             #[cfg(target_arch = "x86_64")]
             {
                 let mut pvh_kernel_path = workload_path.clone();
-                pvh_kernel_path.push("vmlinux.pvh");
+                pvh_kernel_path.push("vmlinux");
                 kernels.push(pvh_kernel_path);
             }
 


### PR DESCRIPTION
Use the PVH vmlinux for all tests (with the exception of the specific
bzImage test.)

See: #2231

Signed-off-by: Rob Bradford <robert.bradford@intel.com>