### PR TITLE
docs: Update VFIO binding instructions

### DIFF
--- a/docs/iommu.md
+++ b/docs/iommu.md
@@ -194,6 +194,7 @@ guest, and bind it to VFIO (it should appear as `0000:00:04.0`).
 ```bash
 echo 0000:00:04.0 > /sys/bus/pci/devices/0000\:00\:04.0/driver/unbind
 echo 8086 1502 > /sys/bus/pci/drivers/vfio-pci/new_id
+echo 0000:00:04.0 > /sys/bus/pci/drivers/vfio-pci/bind
 ```
 
 Last thing is to start the L2 guest with the huge pages memory backend.

--- a/docs/vfio.md
+++ b/docs/vfio.md
@@ -54,6 +54,7 @@ $ lspci -n -s 01:00.0
 01:00.0 ff00: 10ec:525a (rev 01)
 
 $ echo 10ec 525a > /sys/bus/pci/drivers/vfio-pci/new_id
+$ echo 0000:01:00.0 > /sys/bus/pci/drivers/vfio-pci/bind
 ```
 
 Now the device is managed by the VFIO framework.


### PR DESCRIPTION
With recent kernels, it is now expected to use "bind" control from the
sysfs in order to bind a specific device to the vfio-pci driver.

The use of "new_id" is still required but it is only needed once per
device type. Let's say you want to bind two virtio-net devices, you will
need to add the device_id:vendor_id pair through "new_id", while you
will be required to use "bind" for each device.

Fixes #2545

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>