### PR TITLE
vmm: Output config used for booting VM at info!() level

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -528,6 +528,8 @@ impl Vm {
             .validate()
             .map_err(Error::ConfigValidation)?;
 
+        info!("Booting VM from config: {:?}", &config);
+
         // Create NUMA nodes based on NumaConfig.
         #[cfg(feature = "acpi")]
         let numa_nodes =


### PR DESCRIPTION
This helps with debugging VM behaviour when the VM is created via an
API.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>