### PR TITLE
scripts: Don't update submodules when building virtiofsd

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -135,7 +135,8 @@ update_workloads() {
         pushd $WORKLOADS_DIR
         git clone --depth 1 "https://gitlab.com/virtio-fs/qemu.git" -b "qemu5.0-virtiofs-dax" $QEMU_DIR
         pushd $QEMU_DIR
-        time ./configure --prefix=$PWD --target-list=aarch64-softmmu
+        time ./configure --prefix=$PWD --target-list=aarch64-softmmu --disable-git-update
+
         time make virtiofsd -j `nproc`
         cp virtiofsd $VIRTIOFSD || exit 1
         popd

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -124,7 +124,7 @@ if [ ! -f "$VIRTIOFSD" ]; then
     pushd $WORKLOADS_DIR
     git clone --depth 1 "https://gitlab.com/virtio-fs/qemu.git" -b "qemu5.0-virtiofs-dax" $QEMU_DIR
     pushd $QEMU_DIR
-    time ./configure --prefix=$PWD --target-list=x86_64-softmmu
+    time ./configure --prefix=$PWD --target-list=x86_64-softmmu --disable-git-update
     time make virtiofsd -j `nproc`
     cp virtiofsd $VIRTIOFSD || exit 1
     popd


### PR DESCRIPTION
These submodules are not necessary for building virtiofsd and are hosted
on a flaky server.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>