### PR TITLE
vhost-user-net: Add support for client mode

### DIFF
--- a/vhost_user_backend/src/lib.rs
+++ b/vhost_user_backend/src/lib.rs
@@ -157,7 +157,7 @@ impl<S: VhostUserBackend> VhostUserDaemon<S> {
     /// all requests coming through this socket. This runs in an infinite loop
     /// that should be terminating once the other end of the socket (the VMM)
     /// disconnects.
-    pub fn start(&mut self, listener: Listener) -> Result<()> {
+    pub fn start_server(&mut self, listener: Listener) -> Result<()> {
         let mut slave_listener = SlaveListener::new(listener, self.handler.clone())
             .map_err(Error::CreateSlaveListener)?;
         let mut slave_handler = slave_listener

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -507,7 +507,7 @@ pub fn start_block_backend(backend_command: &str) {
 
     debug!("blk_daemon is created!\n");
 
-    if let Err(e) = blk_daemon.start(listener) {
+    if let Err(e) = blk_daemon.start_server(listener) {
         error!(
             "Failed to start daemon for vhost-user-block with error: {:?}\n",
             e

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -372,7 +372,7 @@ pub fn start_net_backend(backend_command: &str) {
             .set_vring_worker(Some(vring_workers.remove(0)));
     }
 
-    if let Err(e) = net_daemon.start(listener) {
+    if let Err(e) = net_daemon.start_server(listener) {
         error!(
             "failed to start daemon for vhost-user-net with error: {:?}",
             e

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -24,10 +24,14 @@ pub use self::vu_common_ctrl::VhostUserConfig;
 
 #[derive(Debug)]
 pub enum Error {
+    /// Failed accepting connection.
+    AcceptConnection(io::Error),
     /// Invalid available address.
     AvailAddress,
     /// Queue number  is not correct
     BadQueueNum,
+    /// Failed binding vhost-user socket.
+    BindSocket(io::Error),
     /// Creating kill eventfd failed.
     CreateKillEventFd(io::Error),
     /// Cloning kill eventfd failed.

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -712,6 +712,9 @@ components:
           default: false
         vhost_socket:
           type: string
+        vhost_mode:
+          type: string
+          default: "client"
         id:
           type: string
         fd:

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -9,9 +9,10 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 //
 
-use crate::config::ConsoleOutputMode;
-use crate::config::DeviceConfig;
-use crate::config::{DiskConfig, FsConfig, NetConfig, PmemConfig, VmConfig, VsockConfig};
+use crate::config::{
+    ConsoleOutputMode, DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, VhostMode,
+    VmConfig, VsockConfig,
+};
 use crate::device_tree::{DeviceNode, DeviceTree};
 #[cfg(feature = "kvm")]
 use crate::interrupt::kvm::KvmMsiInterruptManager as MsiInterruptManager;
@@ -2035,12 +2036,17 @@ impl DeviceManager {
                 num_queues: net_cfg.num_queues,
                 queue_size: net_cfg.queue_size,
             };
+            let server = match net_cfg.vhost_mode {
+                VhostMode::Client => false,
+                VhostMode::Server => true,
+            };
             let vhost_user_net_device = Arc::new(Mutex::new(
                 match virtio_devices::vhost_user::Net::new(
                     id.clone(),
                     net_cfg.mac,
                     vu_cfg,
                     self.seccomp_action.clone(),
+                    server,
                 ) {
                     Ok(vun_device) => vun_device,
                     Err(e) => {


### PR DESCRIPTION
This PR adds global support for `vhost-user-net` backends using the `client` mode. This means the backend is running as the client instead of running as the server by default. This is useful for OVS-DPDK, as it is deprecated to run in `server` mode.

Fixes #1745