### PR TITLE
virtio-devices: net: Loop over enabled queue pairs when activating

### DIFF
--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -546,7 +546,7 @@ impl VirtioDevice for Net {
 
         let mut epoll_threads = Vec::new();
         let mut taps = self.taps.clone();
-        for i in 0..taps.len() {
+        for i in 0..queues.len() / 2 {
             let rx = RxVirtio::new();
             let tx = TxVirtio::new();
             let rx_tap_listening = false;


### PR DESCRIPTION
In some situations (booting with OVMF) fewer queues will be enabled
therefore we should iterate over the number of enabled queues (as passed
into VirtioDevice::activate()) rather than the number of create tap
devices.

Fixes: #2578

Signed-off-by: Rob Bradford <robert.bradford@intel.com>