### PR TITLE
tests: Dynamically assign IPs for Windows integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,7 +170,7 @@ pipeline{
 					}
 				}
 				stage ('Worker build - Windows guest') {
-					agent { node { label 'groovy-win' } }
+					agent { node { label 'groovy' } }
 					stages {
 						stage ('Checkout') {
 							steps {

--- a/scripts/run_integration_tests_windows.sh
+++ b/scripts/run_integration_tests_windows.sh
@@ -44,7 +44,7 @@ export RUST_BACKTRACE=1
 
 # Only run with 1 thread to avoid tests interfering with one another because
 # Windows has a static IP configured
-time cargo test $features_test "tests::windows::$test_filter" -- --test-threads=1
+time cargo test $features_test "tests::windows::$test_filter"
 RES=$?
 
 dmsetup remove_all -f


### PR DESCRIPTION
Relying on dnsmasq running on the host, the Windows guest are now
getting allocated with the expected IP addresses. This allows for
multiple VMs, therefore multiple tests to run in parallel.

The end goal is to reduce the time spent running Windows integration
tests.

Fixes #1891

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>