### PR TITLE
Jenkinsfile: Don't wait for a node that is not being used

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,10 @@ pipeline{
 				}
 				stage ('Worker build SGX') {
 					agent { node { label 'bionic-sgx' } }
-					when { branch 'master' }
+					when {
+						beforeAgent true
+						branch 'master'
+					}
 					stages {
 						stage ('Checkout') {
 							steps {
@@ -138,7 +141,10 @@ pipeline{
 				}
 				stage ('Worker build VFIO') {
 					agent { node { label 'bionic-vfio' } }
-					when { branch 'master' }
+					when {
+						beforeAgent true
+						branch 'master'
+					}
 					stages {
 						stage ('Checkout') {
 							steps {


### PR DESCRIPTION
Since SGX and VFIO tests don't need to be run on pull requests, we
should not have to wait for the corresponding node (bionic-sgx or
bionic-vfio) to become available in order to skip them.

Fixes #2607

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>