### PR TITLE
tests: vfio: Increase time for memory hotplug

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5951,7 +5951,7 @@ mod tests {
                 // Add RAM to the VM
                 let desired_ram = 6 << 30;
                 resize_command(&api_socket, None, Some(desired_ram), None);
-                thread::sleep(std::time::Duration::new(10, 0));
+                thread::sleep(std::time::Duration::new(30, 0));
                 assert!(guest.get_total_memory().unwrap_or_default() > 5_760_000);
 
                 // Check the VFIO device works when RAM is increased to 6GiB


### PR DESCRIPTION
Bump the sleep time before checking the guest RAM size from 10 to 30
seconds. This will help the VFIO baremetal CI passing more consistently.

Fixes #2606

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>