### PR TITLE
AArch64: Use rust native FDT methods and remove libfdt

### DIFF
--- a/.github/workflows/quality-aarch64.yaml
+++ b/.github/workflows/quality-aarch64.yaml
@@ -29,8 +29,6 @@ jobs:
             target: ${{ matrix.target }}
             override: true
             components: rustfmt, clippy
-      - name: Install arm64 libfdt
-        run: wget http://ftp.us.debian.org/debian/pool/main/d/device-tree-compiler/libfdt-dev_1.6.0-1_arm64.deb && dpkg-deb -xv libfdt-dev_1.6.0-1_arm64.deb ./tlibfdtdev && mkdir -p target/debug/deps && sudo cp ./tlibfdtdev/usr/lib/aarch64-linux-gnu/libfdt.a target/debug/deps/libfdt.a && echo "libfdt installed"
       - name: Formatting (rustfmt)
         run: cargo fmt -- --check
       - name: Clippy (kvm)

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -21,6 +21,7 @@ serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 thiserror = "1.0"
+vm-fdt = { git = "https://github.com/rust-vmm/vm-fdt", branch = "master" }
 vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
 vm-migration = { path = "../vm-migration" }
 

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -19,6 +19,8 @@ extern crate acpi_tables;
 extern crate arch_gen;
 extern crate linux_loader;
 extern crate serde;
+#[cfg(target_arch = "aarch64")]
+extern crate vm_fdt;
 extern crate vm_memory;
 extern crate vm_migration;
 #[cfg(target_arch = "aarch64")]

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -37,7 +37,6 @@ RUN apt-get update \
 	socat \
 	dosfstools \
 	cpio \
-	libfdt-dev \
 	python3-setuptools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -56,14 +55,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
         && apt-get -yq upgrade \
         && DEBIAN_FRONTEND=noninteractive apt-get install -yq libcap2-bin \
         && apt-get clean \
-        && rm -rf /var/lib/apt/lists/* \
-        # Build and install the musl-gcc version of libfdt. This is to ensure
-        # the cloud-hypervisor binary can be built and linked using musl toolchain.
-        && git clone https://github.com/dgibson/dtc.git && cd dtc \
-        && sed -i 's/$(LIBFDT_archive) $(LIBFDT_lib)/$(LIBFDT_archive)/g' Makefile \
-        && export CC=musl-gcc && make libfdt \
-        && cp libfdt/libfdt.a /usr/lib/aarch64-linux-musl \
-        && rm -rf /dtc;	fi
+        && rm -rf /var/lib/apt/lists/*;	fi
 
 # Fix the libssl-dev install
 RUN export ARCH="$(uname -m)" \


### PR DESCRIPTION
This PR move the libfdt methods to rust native helpers from rust-vmm `vm-fdt` crate when creating the FDT. Also this PR removes the redundant libfdt in github action and docker images.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>