### PR TITLE
virtio-devices: vhost-user: Don't run threads for net and block

### DIFF
--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -439,7 +439,7 @@ impl VirtioDevice for Fs {
                 ActivateError::BadActivate
             })?;
 
-        let vu_call_evt_queue_list = setup_vhost_user(
+        setup_vhost_user(
             &mut self.vu,
             &mem.memory(),
             queues,
@@ -478,8 +478,6 @@ impl VirtioDevice for Fs {
         };
 
         let mut handler = VhostUserEpollHandler::new(VhostUserEpollConfig {
-            vu_interrupt_list: vu_call_evt_queue_list,
-            interrupt_cb,
             kill_evt,
             pause_evt,
             slave_req_handler,

--- a/virtio-devices/src/vhost_user/handler.rs
+++ b/virtio-devices/src/vhost_user/handler.rs
@@ -7,18 +7,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use super::super::{
-    EpollHelper, EpollHelperError, EpollHelperHandler, Queue, VirtioInterruptType,
-    EPOLL_HELPER_EVENT_LAST,
-};
-use super::{Error, Result};
-use vmm_sys_util::eventfd::EventFd;
-
-use crate::VirtioInterrupt;
+use super::super::{EpollHelper, EpollHelperError, EpollHelperHandler, EPOLL_HELPER_EVENT_LAST};
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier};
 use vhost::vhost_user::{MasterReqHandler, VhostUserMasterReqHandler};
+use vmm_sys_util::eventfd::EventFd;
 
 /// Collection of common parameters required by vhost-user devices while
 /// call Epoll handler.
@@ -28,16 +22,13 @@ use vhost::vhost_user::{MasterReqHandler, VhostUserMasterReqHandler};
 /// * `kill_evt` - EventFd used to kill the vhost-user device.
 /// * `vu_interrupt_list` - virtqueue and EventFd to signal when buffer used.
 pub struct VhostUserEpollConfig<S: VhostUserMasterReqHandler> {
-    pub interrupt_cb: Arc<dyn VirtioInterrupt>,
     pub kill_evt: EventFd,
     pub pause_evt: EventFd,
-    pub vu_interrupt_list: Vec<(Option<EventFd>, Queue)>,
     pub slave_req_handler: Option<MasterReqHandler<S>>,
 }
 
 pub struct VhostUserEpollHandler<S: VhostUserMasterReqHandler> {
     vu_epoll_cfg: VhostUserEpollConfig<S>,
-    queue_evt_start_idx: u16,
     slave_evt_idx: u16,
 }
 
@@ -50,21 +41,10 @@ impl<S: VhostUserMasterReqHandler> VhostUserEpollHandler<S> {
     /// # Return
     /// * `VhostUserEpollHandler` - epoll handler for vhost-user based devices
     pub fn new(vu_epoll_cfg: VhostUserEpollConfig<S>) -> VhostUserEpollHandler<S> {
-        let queue_evt_start_idx = EPOLL_HELPER_EVENT_LAST + 1;
-        let slave_evt_idx = queue_evt_start_idx + vu_epoll_cfg.vu_interrupt_list.len() as u16;
-
         VhostUserEpollHandler {
             vu_epoll_cfg,
-            queue_evt_start_idx,
-            slave_evt_idx,
+            slave_evt_idx: EPOLL_HELPER_EVENT_LAST + 1,
         }
-    }
-
-    fn signal_used_queue(&self, queue: &Queue) -> Result<()> {
-        self.vu_epoll_cfg
-            .interrupt_cb
-            .trigger(&VirtioInterruptType::Queue, Some(queue))
-            .map_err(Error::FailedSignalingUsedQueue)
     }
 
     pub fn run(
@@ -74,12 +54,6 @@ impl<S: VhostUserMasterReqHandler> VhostUserEpollHandler<S> {
     ) -> std::result::Result<(), EpollHelperError> {
         let mut helper =
             EpollHelper::new(&self.vu_epoll_cfg.kill_evt, &self.vu_epoll_cfg.pause_evt)?;
-
-        for (i, vhost_user_interrupt) in self.vu_epoll_cfg.vu_interrupt_list.iter().enumerate() {
-            if let Some(eventfd) = &vhost_user_interrupt.0 {
-                helper.add_event(eventfd.as_raw_fd(), self.queue_evt_start_idx + i as u16)?;
-            }
-        }
 
         if let Some(self_req_handler) = &self.vu_epoll_cfg.slave_req_handler {
             helper.add_event(self_req_handler.as_raw_fd(), self.slave_evt_idx)?;
@@ -95,21 +69,6 @@ impl<S: VhostUserMasterReqHandler> EpollHelperHandler for VhostUserEpollHandler<
     fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
         let ev_type = event.data as u16;
         match ev_type {
-            x if (x >= self.queue_evt_start_idx && x < self.slave_evt_idx) => {
-                let idx = (x - self.queue_evt_start_idx) as usize;
-                if let Some(eventfd) = &self.vu_epoll_cfg.vu_interrupt_list[idx].0 {
-                    if let Err(e) = eventfd.read() {
-                        error!("Failed to read queue: {:?}", e);
-                        return true;
-                    }
-                    if let Err(e) =
-                        self.signal_used_queue(&self.vu_epoll_cfg.vu_interrupt_list[idx].1)
-                    {
-                        error!("Failed to signal used queue: {:?}", e);
-                        return true;
-                    }
-                }
-            }
             x if x == self.slave_evt_idx => {
                 if let Some(slave_req_handler) = self.vu_epoll_cfg.slave_req_handler.as_mut() {
                     if let Err(e) = slave_req_handler.handle_request() {

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -90,5 +90,7 @@ pub enum Error {
     InvalidFeatures,
     /// Missing file descriptor for the region.
     MissingRegionFd,
+    /// Missing IrqFd
+    MissingIrqFd,
 }
 type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
Some refactoring is performed in order to always expect the irqfd to be
provided by VirtioInterrupt trait. In case no irqfd is available, we
simply fail initializing the vhost-user device. This allows for further
simplification since we can assume the interrupt will always be
triggered directly by the vhost-user backend without proxying through
the VMM. This allows for complete removal of the dedicated thread for
both block and net.

vhost-user-fs is a bit more complex as it requires the slave request
protocol feature in order to support DAX. That's why we still need the
VMM to interfere and therefore run a dedicated thread for it.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>