### PR TITLE
Windows disk hotplug test

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -192,6 +192,8 @@ RAM hotplug is supported. Note, that while the `pnpmem.sys` driver in use suppor
 
 Network device hotplug and hot-remove are supported.
 
+Disk hotplug and hot-remove are supported. After the device has been hotplugged, it will need to be onlined from within the guest. Among other tools, powershell applets `Get-Disk` and `Set-Disk` can be used for the disk configuration and activation.
+
 ## Debugging
 
 The Windows guest debugging process relies heavily on QEMU and [socat](http://www.dest-unreach.org/socat/). The procedure requires two Windows VMs:


### PR DESCRIPTION
This patch adds the necessary tooling, a test and a documentation note for the disk hotplug functionality.

The disk image is created on the fly. Yet FAT is used as the tooling to create NTFS is not present.

The tooling is to be made more flexible to support further tests for multiple disk device hotplug. Prior to that, `mkfs.ntfs` will need to be added to the docker image.

Closes #2539.