### PR TITLE
docs: Fix some typos in docs and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ $ popd
 #### Booting the guest VM
 
 Now we can directly boot into our custom kernel and make it use the Ubuntu root partition.
-If we want to have 4 vCPUs and 512 MBytes of memory:
+If we want to have 4 vCPUs and 1024 MBytes of memory:
 
 ```shell
 $ pushd $CLOUDH

--- a/docs/hotplug.md
+++ b/docs/hotplug.md
@@ -31,7 +31,7 @@ $ ./cloud-hypervisor/target/release/cloud-hypervisor \
 $ popd
 ```
 
-Notice the addition of `--api-socket=/tmp/ch-socket` and a `max` parameter on `--cpus boot=4.max=8`.
+Notice the addition of `--api-socket=/tmp/ch-socket` and a `max` parameter on `--cpus boot=4,max=8`.
 
 To ask the VMM to add additional vCPUs then use the resize API:
 

--- a/docs/macvtap-bridge.md
+++ b/docs/macvtap-bridge.md
@@ -1,6 +1,6 @@
 # Using MACVTAP to Bridge onto Host Network
 
-Cloud Hypervisor supports using a MACVTAP device which is derived from a MACVLAN. Full details of configuring MACVLAN or MACVTAP is out of scope of this document. However the example below indicates how to bridge the guest directly onto the the network the host is on. Due to the lack of hairpin mode it not usually possible to reach the guest directly from the host.
+Cloud Hypervisor supports using a MACVTAP device which is derived from a MACVLAN. Full details of configuring MACVLAN or MACVTAP is out of scope of this document. However the example below indicates how to bridge the guest directly onto the network the host is on. Due to the lack of hairpin mode it not usually possible to reach the guest directly from the host.
 
 ```bash
 # The MAC address must be attached to the macvtap and be used inside the guest

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,6 +1,6 @@
 # Profiling
 
-`perf` can be used to profile the `cloud-hypervisor` binary but it is necessary to make some modifications to the the build in order to produce a binary that gives useful results.
+`perf` can be used to profile the `cloud-hypervisor` binary but it is necessary to make some modifications to the build in order to produce a binary that gives useful results.
 
 ## Building a suitable binary
 

--- a/docs/vfio.md
+++ b/docs/vfio.md
@@ -11,7 +11,7 @@ by the VFIO kernel drivers. However, by default, a host device will be bound to
 its native driver, which is not the VFIO one.
 
 As a consequence, a device must be unbound from its native driver before passing
-it to `cloud-hypervisor` for assigning it to a guess.
+it to `cloud-hypervisor` for assigning it to a guest.
 
 ### Example
 

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -469,7 +469,7 @@ mod tests {
             expect_asm_error!(tx, test_ctx, handler_ctx, VsockError::UnreadableDescriptor);
         }
 
-        // Test case: the buffer descriptor cannot fit all the data advertised by the the
+        // Test case: the buffer descriptor cannot fit all the data advertised by the
         // packet header `len` field.
         {
             create_context!(test_ctx, handler_ctx);

--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -277,7 +277,7 @@ impl<'a> DescriptorChain<'a> {
     /// If the driver designated this as a write only descriptor.
     ///
     /// If this is false, this descriptor is read only.
-    /// Write only means the the emulated device can write and the driver can read.
+    /// Write only means that the emulated device can write and the driver can read.
     pub fn is_write_only(&self) -> bool {
         self.flags & VIRTQ_DESC_F_WRITE != 0
     }
@@ -1003,7 +1003,7 @@ pub mod tests {
             // the first desc has a normal len now, and the next_descriptor flag is set
             vq.dtable[0].len.set(0x1000);
             vq.dtable[0].flags.set(VIRTQ_DESC_F_NEXT);
-            //..but the the index of the next descriptor is too large
+            //..but the index of the next descriptor is too large
             vq.dtable[0].next.set(16);
 
             assert!(DescriptorChain::checked_new(m, vq.start(), 16, 0, None).is_none());

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -340,7 +340,7 @@ impl Vmm {
     }
 
     fn vm_boot(&mut self) -> result::Result<(), VmError> {
-        // Create a new VM is we don't have one yet.
+        // Create a new VM if we don't have one yet.
         if self.vm.is_none() {
             let exit_evt = self.exit_evt.try_clone().map_err(VmError::EventFdClone)?;
             let reset_evt = self.reset_evt.try_clone().map_err(VmError::EventFdClone)?;


### PR DESCRIPTION
Fix some typos or misspellings without functional change.

Signed-off-by: Dayu Liu <liu.dayu@zte.com.cn>