### PR TITLE
docker: Add ntfs-3g to the package list

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update \
 	dosfstools \
 	cpio \
 	python3-setuptools \
+	ntfs-3g \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This will make `mkfs.ntfs` available in the next image update, so then
it can be used in the tests.

Signed-off-by: Anatol Belski <anbelski@linux.microsoft.com>