### PR TITLE
vhost-user-net: Move the control queue to the backend

### DIFF
--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -1,0 +1,140 @@
+// Copyright (c) 2021 Intel Corporation. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+use crate::Tap;
+use libc::c_uint;
+use virtio_bindings::bindings::virtio_net::{
+    VIRTIO_NET_CTRL_GUEST_OFFLOADS, VIRTIO_NET_CTRL_GUEST_OFFLOADS_SET, VIRTIO_NET_CTRL_MQ,
+    VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MAX, VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MIN,
+    VIRTIO_NET_CTRL_MQ_VQ_PAIRS_SET, VIRTIO_NET_ERR, VIRTIO_NET_F_GUEST_CSUM,
+    VIRTIO_NET_F_GUEST_ECN, VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_TSO6,
+    VIRTIO_NET_F_GUEST_UFO, VIRTIO_NET_OK,
+};
+use vm_memory::{ByteValued, Bytes, GuestMemoryError, GuestMemoryMmap};
+use vm_virtio::Queue;
+
+#[derive(Debug)]
+pub enum Error {
+    /// Read queue failed.
+    GuestMemory(GuestMemoryError),
+    /// No queue pairs number.
+    NoQueuePairsDescriptor,
+    /// No status descriptor
+    NoStatusDescriptor,
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ControlHeader {
+    pub class: u8,
+    pub cmd: u8,
+}
+
+unsafe impl ByteValued for ControlHeader {}
+
+pub struct CtrlQueue {
+    pub taps: Vec<Tap>,
+}
+
+impl CtrlQueue {
+    pub fn new(taps: Vec<Tap>) -> Self {
+        CtrlQueue { taps }
+    }
+
+    pub fn process(&mut self, mem: &GuestMemoryMmap, queue: &mut Queue) -> Result<bool> {
+        let mut used_desc_heads = Vec::new();
+        for avail_desc in queue.iter(&mem) {
+            let ctrl_hdr: ControlHeader =
+                mem.read_obj(avail_desc.addr).map_err(Error::GuestMemory)?;
+            let data_desc = avail_desc
+                .next_descriptor()
+                .ok_or(Error::NoQueuePairsDescriptor)?;
+            let status_desc = data_desc
+                .next_descriptor()
+                .ok_or(Error::NoStatusDescriptor)?;
+
+            let ok = match u32::from(ctrl_hdr.class) {
+                VIRTIO_NET_CTRL_MQ => {
+                    let queue_pairs = mem
+                        .read_obj::<u16>(data_desc.addr)
+                        .map_err(Error::GuestMemory)?;
+                    if u32::from(ctrl_hdr.cmd) != VIRTIO_NET_CTRL_MQ_VQ_PAIRS_SET {
+                        warn!("Unsupported command: {}", ctrl_hdr.cmd);
+                        false
+                    } else if (queue_pairs < VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MIN as u16)
+                        || (queue_pairs > VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MAX as u16)
+                    {
+                        warn!("Number of MQ pairs out of range: {}", queue_pairs);
+                        false
+                    } else {
+                        info!("Number of MQ pairs requested: {}", queue_pairs);
+                        true
+                    }
+                }
+                VIRTIO_NET_CTRL_GUEST_OFFLOADS => {
+                    let features = mem
+                        .read_obj::<u64>(data_desc.addr)
+                        .map_err(Error::GuestMemory)?;
+                    if u32::from(ctrl_hdr.cmd) != VIRTIO_NET_CTRL_GUEST_OFFLOADS_SET {
+                        warn!("Unsupported command: {}", ctrl_hdr.cmd);
+                        false
+                    } else {
+                        let mut ok = true;
+                        for tap in self.taps.iter_mut() {
+                            info!("Reprogramming tap offload with features: {}", features);
+                            tap.set_offload(virtio_features_to_tap_offload(features))
+                                .map_err(|e| {
+                                    error!("Error programming tap offload: {:?}", e);
+                                    ok = false
+                                })
+                                .ok();
+                        }
+                        ok
+                    }
+                }
+                _ => {
+                    warn!("Unsupported command {:?}", ctrl_hdr);
+                    false
+                }
+            };
+
+            mem.write_obj(
+                if ok { VIRTIO_NET_OK } else { VIRTIO_NET_ERR } as u8,
+                status_desc.addr,
+            )
+            .map_err(Error::GuestMemory)?;
+            used_desc_heads.push((avail_desc.index, avail_desc.len));
+        }
+
+        for (desc_index, len) in used_desc_heads.iter() {
+            queue.add_used(&mem, *desc_index, *len);
+            queue.update_avail_event(&mem);
+        }
+
+        Ok(!used_desc_heads.is_empty())
+    }
+}
+
+pub fn virtio_features_to_tap_offload(features: u64) -> c_uint {
+    let mut tap_offloads: c_uint = 0;
+    if features & (1 << VIRTIO_NET_F_GUEST_CSUM) != 0 {
+        tap_offloads |= net_gen::TUN_F_CSUM;
+    }
+    if features & (1 << VIRTIO_NET_F_GUEST_TSO4) != 0 {
+        tap_offloads |= net_gen::TUN_F_TSO4;
+    }
+    if features & (1 << VIRTIO_NET_F_GUEST_TSO6) != 0 {
+        tap_offloads |= net_gen::TUN_F_TSO6;
+    }
+    if features & (1 << VIRTIO_NET_F_GUEST_ECN) != 0 {
+        tap_offloads |= net_gen::TUN_F_TSO_ECN;
+    }
+    if features & (1 << VIRTIO_NET_F_GUEST_UFO) != 0 {
+        tap_offloads |= net_gen::TUN_F_UFO;
+    }
+
+    tap_offloads
+}

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -13,6 +13,7 @@ extern crate lazy_static;
 #[macro_use]
 extern crate log;
 
+mod ctrl_queue;
 mod mac;
 mod open_tap;
 mod queue_pair;
@@ -22,6 +23,7 @@ use std::io::Error as IoError;
 use std::os::unix::io::{FromRawFd, RawFd};
 use std::{io, mem, net};
 
+pub use ctrl_queue::{CtrlQueue, Error as CtrlQueueError};
 pub use mac::{MacAddr, MAC_ADDR_LEN};
 pub use open_tap::{open_tap, Error as OpenTapError};
 pub use queue_pair::{NetCounters, NetQueuePair, NetQueuePairError, RxVirtio, TxVirtio};

--- a/vhost_user_backend/src/lib.rs
+++ b/vhost_user_backend/src/lib.rs
@@ -295,15 +295,15 @@ impl<S: VhostUserBackend> VringEpollHandler<S> {
 
         let num_queues = self.vrings.len();
         if (device_event as usize) < num_queues {
+            // If the vring is not enabled, it should not be processed.
+            // But let's not read it (hence lose it) in case it is later enabled.
+            if !self.vrings[device_event as usize].read().unwrap().enabled {
+                return Ok(false);
+            }
+
             if let Some(kick) = &self.vrings[device_event as usize].read().unwrap().kick {
                 kick.read()
                     .map_err(VringEpollHandlerError::HandleEventReadKick)?;
-            }
-
-            // If the vring is not enabled, it should not be processed.
-            // The event is only read to be discarded.
-            if !self.vrings[device_event as usize].read().unwrap().enabled {
-                return Ok(false);
             }
         }
 

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -21,10 +21,7 @@ pub enum Thread {
     VirtioNetCtl,
     VirtioPmem,
     VirtioRng,
-    VirtioVhostBlk,
     VirtioVhostFs,
-    VirtioVhostNet,
-    VirtioVhostNetCtl,
     VirtioVsock,
     VirtioWatchdog,
 }
@@ -311,27 +308,6 @@ fn virtio_rng_thread_rules() -> Vec<SyscallRuleSet> {
     ]
 }
 
-fn virtio_vhost_blk_thread_rules() -> Vec<SyscallRuleSet> {
-    vec![
-        allow_syscall(libc::SYS_brk),
-        allow_syscall(libc::SYS_close),
-        allow_syscall(libc::SYS_dup),
-        allow_syscall(libc::SYS_epoll_create1),
-        allow_syscall(libc::SYS_epoll_ctl),
-        allow_syscall(libc::SYS_epoll_pwait),
-        #[cfg(target_arch = "x86_64")]
-        allow_syscall(libc::SYS_epoll_wait),
-        allow_syscall(libc::SYS_exit),
-        allow_syscall(libc::SYS_futex),
-        allow_syscall(libc::SYS_madvise),
-        allow_syscall(libc::SYS_munmap),
-        allow_syscall(libc::SYS_read),
-        allow_syscall(libc::SYS_rt_sigprocmask),
-        allow_syscall(libc::SYS_sigaltstack),
-        allow_syscall(libc::SYS_write),
-    ]
-}
-
 fn virtio_vhost_fs_thread_rules() -> Vec<SyscallRuleSet> {
     vec![
         allow_syscall(libc::SYS_brk),
@@ -351,46 +327,6 @@ fn virtio_vhost_fs_thread_rules() -> Vec<SyscallRuleSet> {
         allow_syscall(libc::SYS_recvmsg),
         allow_syscall(libc::SYS_rt_sigprocmask),
         allow_syscall(libc::SYS_sendmsg),
-        allow_syscall(libc::SYS_sigaltstack),
-        allow_syscall(libc::SYS_write),
-    ]
-}
-
-fn virtio_vhost_net_thread_rules() -> Vec<SyscallRuleSet> {
-    vec![
-        allow_syscall(libc::SYS_brk),
-        allow_syscall(libc::SYS_close),
-        allow_syscall(libc::SYS_dup),
-        allow_syscall(libc::SYS_epoll_create1),
-        allow_syscall(libc::SYS_epoll_ctl),
-        allow_syscall(libc::SYS_epoll_pwait),
-        #[cfg(target_arch = "x86_64")]
-        allow_syscall(libc::SYS_epoll_wait),
-        allow_syscall(libc::SYS_futex),
-        allow_syscall(libc::SYS_read),
-        allow_syscall(libc::SYS_write),
-        allow_syscall(libc::SYS_sigaltstack),
-        allow_syscall(libc::SYS_munmap),
-        allow_syscall(libc::SYS_madvise),
-        allow_syscall(libc::SYS_exit),
-    ]
-}
-
-fn virtio_vhost_net_ctl_thread_rules() -> Vec<SyscallRuleSet> {
-    vec![
-        allow_syscall(libc::SYS_brk),
-        allow_syscall(libc::SYS_close),
-        allow_syscall(libc::SYS_dup),
-        allow_syscall(libc::SYS_epoll_create1),
-        allow_syscall(libc::SYS_epoll_ctl),
-        allow_syscall(libc::SYS_epoll_pwait),
-        #[cfg(target_arch = "x86_64")]
-        allow_syscall(libc::SYS_epoll_wait),
-        allow_syscall(libc::SYS_exit),
-        allow_syscall(libc::SYS_futex),
-        allow_syscall(libc::SYS_munmap),
-        allow_syscall(libc::SYS_madvise),
-        allow_syscall(libc::SYS_read),
         allow_syscall(libc::SYS_sigaltstack),
         allow_syscall(libc::SYS_write),
     ]
@@ -462,10 +398,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
         Thread::VirtioNetCtl => virtio_net_ctl_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules(),
         Thread::VirtioRng => virtio_rng_thread_rules(),
-        Thread::VirtioVhostBlk => virtio_vhost_blk_thread_rules(),
         Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules(),
-        Thread::VirtioVhostNet => virtio_vhost_net_thread_rules(),
-        Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules(),
         Thread::VirtioVsock => virtio_vsock_thread_rules(),
         Thread::VirtioWatchdog => virtio_watchdog_thread_rules(),
     };
@@ -484,10 +417,7 @@ fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
         Thread::VirtioNetCtl => virtio_net_ctl_thread_rules()?,
         Thread::VirtioPmem => virtio_pmem_thread_rules(),
         Thread::VirtioRng => virtio_rng_thread_rules(),
-        Thread::VirtioVhostBlk => virtio_vhost_blk_thread_rules(),
         Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules(),
-        Thread::VirtioVhostNet => virtio_vhost_net_thread_rules(),
-        Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules(),
         Thread::VirtioVsock => virtio_vsock_thread_rules(),
         Thread::VirtioWatchdog => virtio_watchdog_thread_rules(),
     };

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -222,7 +222,6 @@ impl VirtioDevice for Blk {
             queues,
             queue_evts,
             &interrupt_cb,
-            self.common.acked_features,
         )
         .map_err(ActivateError::VhostUserBlkSetup)?;
 

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -445,7 +445,6 @@ impl VirtioDevice for Fs {
             queues,
             queue_evts,
             &interrupt_cb,
-            self.common.acked_features,
         )
         .map_err(ActivateError::VhostUserFsSetup)?;
 

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -223,7 +223,6 @@ impl VirtioDevice for Net {
             queues,
             queue_evts,
             &interrupt_cb,
-            self.common.acked_features,
         )
         .map_err(ActivateError::VhostUserNetSetup)?;
 

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -68,7 +68,7 @@ pub fn add_memory_region(vu: &mut Master, region: &Arc<GuestRegionMmap>) -> Resu
         .map_err(Error::VhostUserAddMemReg)
 }
 
-pub fn setup_vhost_user_vring(
+pub fn setup_vhost_user(
     vu: &mut Master,
     mem: &GuestMemoryMmap,
     queues: Vec<Queue>,
@@ -114,8 +114,6 @@ pub fn setup_vhost_user_vring(
         {
             vu.set_vring_call(queue_index, &eventfd)
                 .map_err(Error::VhostUserSetVringCall)?;
-        } else {
-            return Err(Error::MissingIrqFd);
         }
 
         vu.set_vring_kick(queue_index, &queue_evts[queue_index])
@@ -126,21 +124,6 @@ pub fn setup_vhost_user_vring(
     }
 
     Ok(())
-}
-
-pub fn setup_vhost_user(
-    vu: &mut Master,
-    mem: &GuestMemoryMmap,
-    queues: Vec<Queue>,
-    queue_evts: Vec<EventFd>,
-    virtio_interrupt: &Arc<dyn VirtioInterrupt>,
-    acked_features: u64,
-) -> Result<()> {
-    // Set features based on the acked features from the guest driver.
-    vu.set_features(acked_features)
-        .map_err(Error::VhostUserSetFeatures)?;
-
-    setup_vhost_user_vring(vu, mem, queues, queue_evts, virtio_interrupt)
 }
 
 pub fn reset_vhost_user(vu: &mut Master, num_queues: usize) -> Result<()> {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2043,13 +2043,8 @@ impl DeviceManager {
                 VhostMode::Server => true,
             };
             let vhost_user_net_device = Arc::new(Mutex::new(
-                match virtio_devices::vhost_user::Net::new(
-                    id.clone(),
-                    net_cfg.mac,
-                    vu_cfg,
-                    self.seccomp_action.clone(),
-                    server,
-                ) {
+                match virtio_devices::vhost_user::Net::new(id.clone(), net_cfg.mac, vu_cfg, server)
+                {
                     Ok(vun_device) => vun_device,
                     Err(e) => {
                         return Err(DeviceManagerError::CreateVhostUserNet(e));


### PR DESCRIPTION
Having the control queue running as a VMM thread while the worker queues were running in the backend was an incorrect design. This PR fixes this issue by moving the control queue handling to the vhost-user-net backend, allowing for further simplification of the vhost-user-net device in the VMM codebase.

Fixes #2562 