### PR TITLE
Reduce hypervisor specific leaks into vmm crate

### DIFF
--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -83,11 +83,12 @@ pub trait Hypervisor: Send + Sync {
     /// Get the supported CpuID
     ///
     fn get_cpuid(&self) -> Result<CpuId>;
-    #[cfg(not(feature = "mshv"))]
     ///
     /// Check particular extensions if any
     ///
-    fn check_required_extensions(&self) -> Result<()>;
+    fn check_required_extensions(&self) -> Result<()> {
+        Ok(())
+    }
     #[cfg(target_arch = "x86_64")]
     ///
     /// Retrieve the list of MSRs supported by the hypervisor.

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -54,6 +54,11 @@ pub enum HypervisorError {
     ///
     #[error("Incompatible API version")]
     IncompatibleApiVersion,
+    ///
+    /// Checking extensions failed
+    ///
+    #[error("Checking extensions:{0}")]
+    CheckExtensions(#[source] anyhow::Error),
 }
 
 ///

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -72,12 +72,13 @@ pub trait Hypervisor: Send + Sync {
     /// Return a hypervisor-agnostic Vm trait object
     ///
     fn create_vm(&self) -> Result<Arc<dyn Vm>>;
-    #[cfg(feature = "kvm")]
     ///
     /// Create a Vm of a specific type using the underlying hypervisor
     /// Return a hypervisor-agnostic Vm trait object
     ///
-    fn create_vm_with_type(&self, vm_type: u64) -> Result<Arc<dyn Vm>>;
+    fn create_vm_with_type(&self, _vm_type: u64) -> Result<Arc<dyn Vm>> {
+        unreachable!()
+    }
     #[cfg(target_arch = "x86_64")]
     ///
     /// Get the supported CpuID

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -12,8 +12,6 @@ use crate::vm::Vm;
 use crate::x86_64::CpuId;
 #[cfg(target_arch = "x86_64")]
 use crate::x86_64::MsrList;
-#[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-use kvm_ioctls::Cap;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -41,16 +39,6 @@ pub enum HypervisorError {
     ///
     #[error("Failed to get API Version: {0}")]
     GetApiVersion(#[source] anyhow::Error),
-    ///
-    /// Vcpu mmap error
-    ///
-    #[error("Failed to get Vcpu Mmap: {0}")]
-    GetVcpuMmap(#[source] anyhow::Error),
-    ///
-    /// Max Vcpu error
-    ///
-    #[error("Failed to get number of max vcpus: {0}")]
-    GetMaxVcpu(#[source] anyhow::Error),
     ///
     /// CpuId error
     ///
@@ -90,26 +78,6 @@ pub trait Hypervisor: Send + Sync {
     /// Return a hypervisor-agnostic Vm trait object
     ///
     fn create_vm_with_type(&self, vm_type: u64) -> Result<Arc<dyn Vm>>;
-    #[cfg(feature = "kvm")]
-    ///
-    /// Returns the size of the memory mapping required to use the vcpu's structures
-    ///
-    fn get_vcpu_mmap_size(&self) -> Result<usize>;
-    #[cfg(feature = "kvm")]
-    ///
-    /// Gets the recommended maximum number of VCPUs per VM.
-    ///
-    fn get_max_vcpus(&self) -> Result<usize>;
-    #[cfg(feature = "kvm")]
-    ///
-    /// Gets the recommended number of VCPUs per VM.
-    ///
-    fn get_nr_vcpus(&self) -> Result<usize>;
-    #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-    ///
-    /// Checks if a particular `Cap` is available.
-    ///
-    fn check_capability(&self, c: Cap) -> bool;
     #[cfg(target_arch = "x86_64")]
     ///
     /// Get the supported CpuID

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -565,33 +565,6 @@ impl hypervisor::Hypervisor for KvmHypervisor {
         Ok(())
     }
 
-    ///
-    ///  Returns the size of the memory mapping required to use the vcpu's `kvm_run` structure.
-    ///
-    fn get_vcpu_mmap_size(&self) -> hypervisor::Result<usize> {
-        self.kvm
-            .get_vcpu_mmap_size()
-            .map_err(|e| hypervisor::HypervisorError::GetVcpuMmap(e.into()))
-    }
-    ///
-    /// Gets the recommended maximum number of VCPUs per VM.
-    ///
-    fn get_max_vcpus(&self) -> hypervisor::Result<usize> {
-        Ok(self.kvm.get_max_vcpus())
-    }
-    ///
-    /// Gets the recommended number of VCPUs per VM.
-    ///
-    fn get_nr_vcpus(&self) -> hypervisor::Result<usize> {
-        Ok(self.kvm.get_nr_vcpus())
-    }
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// Checks if a particular `Cap` is available.
-    ///
-    fn check_capability(&self, c: Cap) -> bool {
-        self.kvm.check_extension(c)
-    }
     #[cfg(target_arch = "x86_64")]
     ///
     /// X86 specific call to get the system supported CPUID values.

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1502,7 +1502,7 @@ mod tests {
     fn test_setlint() {
         let hv = hypervisor::new().unwrap();
         let vm = hv.create_vm().expect("new VM fd creation failed");
-        assert!(hv.check_capability(hypervisor::kvm::Cap::Irqchip));
+        assert!(hv.check_required_extensions().is_ok());
         // Calling get_lapic will fail if there is no irqchip before hand.
         assert!(vm.create_irq_chip().is_ok());
         let vcpu = vm.create_vcpu(0, None).unwrap();

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -674,7 +674,7 @@ impl Vm {
     ) -> Result<Self> {
         #[cfg(feature = "tdx")]
         let tdx_enabled = config.lock().unwrap().tdx.is_some();
-        #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+        #[cfg(target_arch = "x86_64")]
         hypervisor.check_required_extensions().unwrap();
         #[cfg(feature = "tdx")]
         let vm = hypervisor
@@ -746,7 +746,7 @@ impl Vm {
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
         activate_evt: EventFd,
     ) -> Result<Self> {
-        #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+        #[cfg(target_arch = "x86_64")]
         hypervisor.check_required_extensions().unwrap();
         let vm = hypervisor.create_vm().unwrap();
         #[cfg(target_arch = "x86_64")]
@@ -799,7 +799,7 @@ impl Vm {
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
         activate_evt: EventFd,
     ) -> Result<Self> {
-        #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+        #[cfg(target_arch = "x86_64")]
         hypervisor.check_required_extensions().unwrap();
         let vm = hypervisor.create_vm().unwrap();
         #[cfg(target_arch = "x86_64")]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -674,7 +674,6 @@ impl Vm {
     ) -> Result<Self> {
         #[cfg(feature = "tdx")]
         let tdx_enabled = config.lock().unwrap().tdx.is_some();
-        #[cfg(target_arch = "x86_64")]
         hypervisor.check_required_extensions().unwrap();
         #[cfg(feature = "tdx")]
         let vm = hypervisor
@@ -746,7 +745,6 @@ impl Vm {
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
         activate_evt: EventFd,
     ) -> Result<Self> {
-        #[cfg(target_arch = "x86_64")]
         hypervisor.check_required_extensions().unwrap();
         let vm = hypervisor.create_vm().unwrap();
         #[cfg(target_arch = "x86_64")]
@@ -799,7 +797,6 @@ impl Vm {
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
         activate_evt: EventFd,
     ) -> Result<Self> {
-        #[cfg(target_arch = "x86_64")]
         hypervisor.check_required_extensions().unwrap();
         let vm = hypervisor.create_vm().unwrap();
         #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
Slowly working towards #2542 by removing the requirement for the vmm crate to know hypervisor specific details.