### PR TITLE
AArch64 ACPI tables

### DIFF
--- a/acpi_tables/src/sdt.rs
+++ b/acpi_tables/src/sdt.rs
@@ -22,6 +22,15 @@ impl GenericAddress {
             address: u64::from(address),
         }
     }
+    pub fn mmio_address<T>(address: u64) -> Self {
+        GenericAddress {
+            address_space_id: 0,
+            register_bit_width: 8 * std::mem::size_of::<T>() as u8,
+            register_bit_offset: 0,
+            access_size: std::mem::size_of::<T>() as u8,
+            address,
+        }
+    }
 }
 
 pub struct Sdt {

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -16,7 +16,7 @@ use super::super::InitramfsConfig;
 use super::get_fdt_addr;
 use super::gic::GicDevice;
 use super::layout::{
-    FDT_MAX_SIZE, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START, PCI_MMCONFIG_SIZE,
+    FDT_MAX_SIZE, IRQ_BASE, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START, PCI_MMCONFIG_SIZE,
     PCI_MMCONFIG_START,
 };
 use vm_fdt::{FdtWriter, FdtWriterResult};
@@ -293,7 +293,11 @@ fn create_serial_node<T: DeviceInfoForFdt + Clone + Debug>(
 ) -> FdtWriterResult<()> {
     let compatible = b"arm,pl011\0arm,primecell\0";
     let serial_reg_prop = [dev_info.addr(), dev_info.length()];
-    let irq = [GIC_FDT_IRQ_TYPE_SPI, dev_info.irq(), IRQ_TYPE_EDGE_RISING];
+    let irq = [
+        GIC_FDT_IRQ_TYPE_SPI,
+        dev_info.irq() - IRQ_BASE,
+        IRQ_TYPE_EDGE_RISING,
+    ];
 
     let serial_node = fdt.begin_node(&format!("pl011@{:x}", dev_info.addr()))?;
     fdt.property("compatible", compatible)?;
@@ -312,7 +316,11 @@ fn create_rtc_node<T: DeviceInfoForFdt + Clone + Debug>(
 ) -> FdtWriterResult<()> {
     let compatible = b"arm,pl031\0arm,primecell\0";
     let rtc_reg_prop = [dev_info.addr(), dev_info.length()];
-    let irq = [GIC_FDT_IRQ_TYPE_SPI, dev_info.irq(), IRQ_TYPE_LEVEL_HI];
+    let irq = [
+        GIC_FDT_IRQ_TYPE_SPI,
+        dev_info.irq() - IRQ_BASE,
+        IRQ_TYPE_LEVEL_HI,
+    ];
 
     let rtc_node = fdt.begin_node(&format!("rtc@{:x}", dev_info.addr()))?;
     fdt.property("compatible", compatible)?;
@@ -332,7 +340,11 @@ fn create_gpio_node<T: DeviceInfoForFdt + Clone + Debug>(
     // PL061 GPIO controller node
     let compatible = b"arm,pl061\0arm,primecell\0";
     let gpio_reg_prop = [dev_info.addr(), dev_info.length()];
-    let irq = [GIC_FDT_IRQ_TYPE_SPI, dev_info.irq(), IRQ_TYPE_EDGE_RISING];
+    let irq = [
+        GIC_FDT_IRQ_TYPE_SPI,
+        dev_info.irq() - IRQ_BASE,
+        IRQ_TYPE_EDGE_RISING,
+    ];
 
     let gpio_node = fdt.begin_node(&format!("pl061@{:x}", dev_info.addr()))?;
     fdt.property("compatible", compatible)?;

--- a/arch/src/aarch64/gic/mod.rs
+++ b/arch/src/aarch64/gic/mod.rs
@@ -149,7 +149,7 @@ pub mod kvm {
             /* We need to tell the kernel how many irqs to support with this vgic.
              * See the `layout` module for details.
              */
-            let nr_irqs: u32 = layout::IRQ_MAX - layout::IRQ_BASE + 1;
+            let nr_irqs: u32 = layout::IRQ_NUM;
             let nr_irqs_ptr = &nr_irqs as *const u32;
             Self::set_device_attribute(
                 gic_device.device(),

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -97,8 +97,8 @@ pub const KERNEL_START: u64 = ACPI_START + ACPI_MAX_SIZE as u64;
 // * less than 1023 and
 // * a multiple of 32.
 // We are setting up our interrupt controller to support a maximum of 256 interrupts.
-/// First usable interrupt on aarch64.
-pub const IRQ_BASE: u32 = 0;
+/// First usable interrupt on aarch64
+pub const IRQ_BASE: u32 = 32;
 
-/// Last usable interrupt on aarch64.
-pub const IRQ_MAX: u32 = 255;
+/// Number of supported interrupts
+pub const IRQ_NUM: u32 = 256;

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -76,7 +76,7 @@ pub mod aarch64;
 pub use aarch64::{
     arch_memory_regions, configure_system, configure_vcpu, fdt::DeviceInfoForFdt,
     get_host_cpu_phys_bits, get_kernel_start, initramfs_load_addr, layout,
-    layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, layout::IRQ_MAX, EntryPoint,
+    layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, EntryPoint,
 };
 
 #[cfg(target_arch = "x86_64")]

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 acpi_tables = { path = "../acpi_tables", optional = true }
 anyhow = "1.0"
+arch = { path = "../arch" }
 bitflags = ">=1.2.1"
 byteorder = "1.4.3"
 epoll = ">=4.0.1"

--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use super::interrupt_controller::{Error, InterruptController};
+extern crate arch;
 use std::result;
 use std::sync::Arc;
 use vm_device::interrupt::{
@@ -14,7 +15,7 @@ use vmm_sys_util::eventfd::EventFd;
 type Result<T> = result::Result<T, Error>;
 
 // Reserve 32 IRQs for legacy device.
-pub const IRQ_LEGACY_BASE: usize = 0;
+pub const IRQ_LEGACY_BASE: usize = arch::layout::IRQ_BASE as usize;
 pub const IRQ_LEGACY_COUNT: usize = 32;
 
 // This Gic struct implements InterruptController to provide interrupt delivery service.
@@ -58,7 +59,7 @@ impl InterruptController for Gic {
         for i in IRQ_LEGACY_BASE..(IRQ_LEGACY_BASE + IRQ_LEGACY_COUNT) {
             let config = LegacyIrqSourceConfig {
                 irqchip: 0,
-                pin: i as u32,
+                pin: (i - IRQ_LEGACY_BASE) as u32,
             };
             self.interrupt_source_group
                 .update(

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -42,11 +42,11 @@ fn pagesize() -> usize {
 ///   #[cfg(target_arch = "x86_64")]
 ///   assert_eq!(allocator.allocate_irq(), Some(5));
 ///   #[cfg(target_arch = "aarch64")]
-///   assert_eq!(allocator.allocate_irq(), Some(0));
+///   assert_eq!(allocator.allocate_irq(), Some(32));
 ///   #[cfg(target_arch = "x86_64")]
 ///   assert_eq!(allocator.allocate_irq(), Some(6));
 ///   #[cfg(target_arch = "aarch64")]
-///   assert_eq!(allocator.allocate_irq(), Some(1));
+///   assert_eq!(allocator.allocate_irq(), Some(33));
 ///   assert_eq!(allocator.allocate_mmio_addresses(None, 0x1000, Some(0x1000)), Some(GuestAddress(0x1fff_f000)));
 ///
 /// ```

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -15,6 +15,22 @@ use std::sync::{Arc, Mutex};
 use vm_memory::GuestRegionMmap;
 use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryMmap, GuestMemoryRegion};
 
+/* Values for Type in APIC sub-headers */
+#[cfg(target_arch = "x86_64")]
+pub const ACPI_APIC_PROCESSOR: u8 = 0;
+#[cfg(target_arch = "x86_64")]
+pub const ACPI_APIC_IO: u8 = 1;
+#[cfg(target_arch = "x86_64")]
+pub const ACPI_APIC_XRUPT_OVERRIDE: u8 = 2;
+#[cfg(target_arch = "aarch64")]
+pub const ACPI_APIC_GENERIC_CPU_INTERFACE: u8 = 11;
+#[cfg(target_arch = "aarch64")]
+pub const ACPI_APIC_GENERIC_DISTRIBUTOR: u8 = 12;
+#[cfg(target_arch = "aarch64")]
+pub const ACPI_APIC_GENERIC_REDISTRIBUTOR: u8 = 14;
+#[cfg(target_arch = "aarch64")]
+pub const ACPI_APIC_GENERIC_TRANSLATOR: u8 = 15;
+
 #[repr(packed)]
 #[derive(Default)]
 struct PciRangeEntry {

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -169,7 +169,7 @@ fn create_mcfg_table() -> Sdt {
         base_address: arch::layout::PCI_MMCONFIG_START.0,
         segment: 0,
         start: 0,
-        end: 0,
+        end: ((arch::layout::PCI_MMCONFIG_SIZE - 1) >> 20) as u8,
         ..Default::default()
     });
     mcfg

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -145,6 +145,11 @@ fn create_facp_table(dsdt_offset: GuestAddress) -> Sdt {
         facp.write(256, GenericAddress::io_port_address::<u8>(0x3c0));
     }
 
+    // aarch64 specific fields
+    #[cfg(target_arch = "aarch64")]
+    // ARM_BOOT_ARCH: enable PSCI with HVC enable-method
+    facp.write(129, 3u16);
+
     // Architecture common fields
     // HW_REDUCED_ACPI, RESET_REG_SUP, TMR_VAL_EXT
     let fadt_flags: u32 = 1 << 20 | 1 << 10 | 1 << 8;

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -153,6 +153,63 @@ struct Ioapic {
     pub gsi_base: u32,
 }
 
+#[cfg(all(target_arch = "aarch64", feature = "acpi"))]
+#[repr(packed)]
+struct GicC {
+    pub r#type: u8,
+    pub length: u8,
+    pub reserved0: u16,
+    pub cpu_interface_number: u32,
+    pub uid: u32,
+    pub flags: u32,
+    pub parking_version: u32,
+    pub performance_interrupt: u32,
+    pub parked_address: u64,
+    pub base_address: u64,
+    pub gicv_base_address: u64,
+    pub gich_base_address: u64,
+    pub vgic_interrupt: u32,
+    pub gicr_base_address: u64,
+    pub mpidr: u64,
+    pub proc_power_effi_class: u8,
+    pub reserved1: u8,
+    pub spe_overflow_interrupt: u16,
+}
+
+#[cfg(all(target_arch = "aarch64", feature = "acpi"))]
+#[repr(packed)]
+struct GicD {
+    pub r#type: u8,
+    pub length: u8,
+    pub reserved0: u16,
+    pub gic_id: u32,
+    pub base_address: u64,
+    pub global_irq_base: u32,
+    pub version: u8,
+    pub reserved1: [u8; 3],
+}
+
+#[cfg(all(target_arch = "aarch64", feature = "acpi"))]
+#[repr(packed)]
+struct GicR {
+    pub r#type: u8,
+    pub length: u8,
+    pub reserved: u16,
+    pub base_address: u64,
+    pub range_length: u32,
+}
+
+#[cfg(all(target_arch = "aarch64", feature = "acpi"))]
+#[repr(packed)]
+struct GicIts {
+    pub r#type: u8,
+    pub length: u8,
+    pub reserved0: u16,
+    pub translation_id: u32,
+    pub base_address: u64,
+    pub reserved1: u32,
+}
+
 #[repr(packed)]
 #[derive(Default)]
 struct InterruptSourceOverride {
@@ -1069,6 +1126,7 @@ impl CpuManager {
 
     #[cfg(feature = "acpi")]
     pub fn create_madt(&self) -> Sdt {
+        use crate::acpi;
         // This is also checked in the commandline parsing.
         assert!(self.config.boot_vcpus <= self.config.max_vcpus);
 
@@ -1079,7 +1137,7 @@ impl CpuManager {
 
             for cpu in 0..self.config.max_vcpus {
                 let lapic = LocalApic {
-                    r#type: 0,
+                    r#type: acpi::ACPI_APIC_PROCESSOR,
                     length: 8,
                     processor_id: cpu,
                     apic_id: cpu,
@@ -1093,7 +1151,7 @@ impl CpuManager {
             }
 
             madt.append(Ioapic {
-                r#type: 1,
+                r#type: acpi::ACPI_APIC_IO,
                 length: 12,
                 ioapic_id: 0,
                 apic_address: arch::layout::IOAPIC_START.0 as u32,
@@ -1102,7 +1160,7 @@ impl CpuManager {
             });
 
             madt.append(InterruptSourceOverride {
-                r#type: 2,
+                r#type: acpi::ACPI_APIC_XRUPT_OVERRIDE,
                 length: 10,
                 bus: 0,
                 source: 4,
@@ -1113,6 +1171,83 @@ impl CpuManager {
 
         #[cfg(target_arch = "aarch64")]
         {
+            /* Notes:
+             * Ignore Local Interrupt Controller Address at byte offset 36 of MADT table.
+             */
+
+            // See section 5.2.12.14 GIC CPU Interface (GICC) Structure in ACPI spec.
+            for cpu in 0..self.config.boot_vcpus {
+                let vcpu = &self.vcpus[cpu as usize];
+                let mpidr = vcpu.lock().unwrap().get_mpidr();
+                /* ARMv8 MPIDR format:
+                     Bits [63:40] Must be zero
+                     Bits [39:32] Aff3 : Match Aff3 of target processor MPIDR
+                     Bits [31:24] Must be zero
+                     Bits [23:16] Aff2 : Match Aff2 of target processor MPIDR
+                     Bits [15:8] Aff1 : Match Aff1 of target processor MPIDR
+                     Bits [7:0] Aff0 : Match Aff0 of target processor MPIDR
+                */
+                let mpidr_mask = 0xff_00ff_ffff;
+                let gicc = GicC {
+                    r#type: acpi::ACPI_APIC_GENERIC_CPU_INTERFACE,
+                    length: 80,
+                    reserved0: 0,
+                    cpu_interface_number: cpu as u32,
+                    uid: cpu as u32,
+                    flags: 1,
+                    parking_version: 0,
+                    performance_interrupt: 0,
+                    parked_address: 0,
+                    base_address: 0,
+                    gicv_base_address: 0,
+                    gich_base_address: 0,
+                    vgic_interrupt: 0,
+                    gicr_base_address: 0,
+                    mpidr: mpidr & mpidr_mask,
+                    proc_power_effi_class: 0,
+                    reserved1: 0,
+                    spe_overflow_interrupt: 0,
+                };
+
+                madt.append(gicc);
+            }
+
+            // GIC Distributor structure. See section 5.2.12.15 in ACPI spec.
+            let gicd = GicD {
+                r#type: acpi::ACPI_APIC_GENERIC_DISTRIBUTOR,
+                length: 24,
+                reserved0: 0,
+                gic_id: 0,
+                base_address: arch::layout::MAPPED_IO_START - 0x0001_0000,
+                global_irq_base: 0,
+                version: 3,
+                reserved1: [0; 3],
+            };
+            madt.append(gicd);
+
+            // See 5.2.12.17 GIC Redistributor (GICR) Structure in ACPI spec.
+            let gicr_size: u32 = 0x0001_0000 * 2 * (self.config.boot_vcpus as u32);
+            let gicr_base: u64 = arch::layout::MAPPED_IO_START - 0x0001_0000 - gicr_size as u64;
+            let gicr = GicR {
+                r#type: acpi::ACPI_APIC_GENERIC_REDISTRIBUTOR,
+                length: 16,
+                reserved: 0,
+                base_address: gicr_base,
+                range_length: gicr_size,
+            };
+            madt.append(gicr);
+
+            // See 5.2.12.18 GIC Interrupt Translation Service (ITS) Structure in ACPI spec.
+            let gicits = GicIts {
+                r#type: acpi::ACPI_APIC_GENERIC_TRANSLATOR,
+                length: 20,
+                reserved0: 0,
+                translation_id: 0,
+                base_address: gicr_base - 2 * 0x0001_0000,
+                reserved1: 0,
+            };
+            madt.append(gicits);
+
             madt.update_checksum();
         }
 

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -456,7 +456,7 @@ mod tests {
         let res = get_dist_regs(gic.device());
         assert!(res.is_ok());
         let state = res.unwrap();
-        assert_eq!(state.len(), 649);
+        assert_eq!(state.len(), 568);
 
         let res = set_dist_regs(gic.device(), &state);
         assert!(res.is_ok());

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2425,20 +2425,23 @@ mod tests {
         let dev_info: HashMap<(DeviceType, std::string::String), MmioDeviceInfo> = [
             (
                 (DeviceType::Serial, DeviceType::Serial.to_string()),
-                MmioDeviceInfo { addr: 0x00, irq: 1 },
+                MmioDeviceInfo {
+                    addr: 0x00,
+                    irq: 33,
+                },
             ),
             (
                 (DeviceType::Virtio(1), "virtio".to_string()),
                 MmioDeviceInfo {
                     addr: 0x00 + LEN,
-                    irq: 2,
+                    irq: 34,
                 },
             ),
             (
                 (DeviceType::Rtc, "rtc".to_string()),
                 MmioDeviceInfo {
                     addr: 0x00 + 2 * LEN,
-                    irq: 3,
+                    irq: 35,
                 },
             ),
         ]


### PR DESCRIPTION
Partially fixes #2178.

This PR implements all the ACPI tables needed on AArch64:
1. MADT
2. DSDT
3. MCFG
4. GTDT
5. SPCR
6. IORT

The new code has not been covered by integration test case. The test requires integrating EDK2. It will be added in a separate PR latter.
For the correctness of the code here, please refer to the original PR https://github.com/cloud-hypervisor/cloud-hypervisor/pull/2241. 