### PR TITLE
scripts: Fix an obselete sha1sum

### DIFF
--- a/scripts/sha1sums-aarch64
+++ b/scripts/sha1sums-aarch64
@@ -1,6 +1,6 @@
 6fee67adbfed8db7a225be23ee9d90b5bd7f19e6  bionic-server-cloudimg-arm64.img
 786fe1c33588334e92b35c65e414da068df180bc  bionic-server-cloudimg-arm64.raw
-34039f2fc4242acff0d42af82fbee91070978da3  bionic-server-cloudimg-arm64.qcow2
+6e66f9f4b01adc72c884c1c1111e60afadc9c871  bionic-server-cloudimg-arm64.qcow2
 e4addb6e212a298144f9eb0eb6e36019d013f0e7  alpine-minirootfs-aarch64.tar.gz
 063d1a9f32db641138e6e0c53f58e6545a3d48e6  focal-server-cloudimg-arm64-custom.raw
 013837926872f1c7d1b3a1a95305e4a31c8600ab  focal-server-cloudimg-arm64-custom.qcow2


### PR DESCRIPTION
The sha1sum of bionic-server-cloudimg-arm64.qcow2 was obsolete.

The failing signature was first found in local test. After refreshing the file on CI server, the fault was seen in CI.