### PR TITLE
vmm: support restore KVM clock in migration

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -776,6 +776,10 @@ impl Vmm {
             MigratableError::MigrateReceive(anyhow!("Error deserialising snapshot: {}", e))
         })?;
 
+        #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+        vm.load_clock_from_snapshot(&snapshot)
+            .map_err(|e| MigratableError::MigrateReceive(anyhow!("Error resume clock: {:?}", e)))?;
+
         // Create VM
         vm.restore(snapshot).map_err(|e| {
             Response::error().write_to(socket).ok();

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1833,6 +1833,17 @@ impl Vm {
             .map(|state| *state)
     }
 
+    /// Load saved clock from snapshot
+    #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+    pub fn load_clock_from_snapshot(
+        &mut self,
+        snapshot: &Snapshot,
+    ) -> Result<Option<hypervisor::ClockData>> {
+        let vm_snapshot = get_vm_snapshot(snapshot).map_err(Error::Restore)?;
+        self.saved_clock = vm_snapshot.clock;
+        Ok(self.saved_clock)
+    }
+
     #[cfg(target_arch = "aarch64")]
     /// Add the vGIC section to the VM snapshot.
     fn add_vgic_snapshot_section(


### PR DESCRIPTION
In migration, vm object is created by new_from_migration with
NULL kvm clock. so vm.set_clock will not be called during vm resume.
If the guest using kvm-clock, the ticks will be stopped after migration.

As clock was already saved to snapshot, add a method to restore it before
vm resume in migration. after that, guest's kvm-clock works well.

Signed-off-by: Ren Lei <ren.lei4@zte.com.cn>