### PR TITLE
virtio-devices: vhost_user: Enable most virtio reserved features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,7 @@ version = "0.1.0"
 dependencies = [
  "acpi_tables",
  "anyhow",
+ "arch",
  "bitflags",
  "byteorder",
  "epoll",

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -59,9 +59,16 @@ const DEVICE_DRIVER_OK: u32 = 0x04;
 const DEVICE_FEATURES_OK: u32 = 0x08;
 const DEVICE_FAILED: u32 = 0x80;
 
+const VIRTIO_F_RING_INDIRECT_DESC: u32 = 28;
+const VIRTIO_F_RING_EVENT_IDX: u32 = 29;
 const VIRTIO_F_VERSION_1: u32 = 32;
 const VIRTIO_F_IOMMU_PLATFORM: u32 = 33;
+const VIRTIO_F_RING_PACKED: u32 = 34;
 const VIRTIO_F_IN_ORDER: u32 = 35;
+const VIRTIO_F_ORDER_PLATFORM: u32 = 36;
+#[allow(dead_code)]
+const VIRTIO_F_SR_IOV: u32 = 37;
+const VIRTIO_F_NOTIFICATION_DATA: u32 = 38;
 
 #[derive(Debug)]
 pub enum ActivateError {

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -5,12 +5,12 @@ use super::vu_common_ctrl::{
     add_memory_region, negotiate_features_vhost_user, reset_vhost_user, setup_vhost_user,
     update_mem_table,
 };
-use super::{Error, Result};
+use super::{Error, Result, DEFAULT_VIRTIO_FEATURES};
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
 use crate::vhost_user::handler::{VhostUserEpollConfig, VhostUserEpollHandler};
 use crate::{
     ActivateError, ActivateResult, Queue, UserspaceMapping, VirtioCommon, VirtioDevice,
-    VirtioDeviceType, VirtioInterrupt, VirtioSharedMemoryList, VIRTIO_F_VERSION_1,
+    VirtioDeviceType, VirtioInterrupt, VirtioSharedMemoryList,
 };
 use libc::{self, c_void, off64_t, pread64, pwrite64};
 use seccomp::{SeccompAction, SeccompFilter};
@@ -26,9 +26,6 @@ use vhost::vhost_user::message::{
 };
 use vhost::vhost_user::{
     HandlerResult, Master, MasterReqHandler, VhostUserMaster, VhostUserMasterReqHandler,
-};
-use virtio_bindings::bindings::virtio_ring::{
-    VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC,
 };
 use vm_memory::{
     Address, ByteValued, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
@@ -307,10 +304,7 @@ impl Fs {
             Master::connect(path, num_queues as u64).map_err(Error::VhostUserCreateMaster)?;
 
         // Filling device and vring features VMM supports.
-        let avail_features = 1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_RING_F_EVENT_IDX
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
-            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
+        let avail_features = DEFAULT_VIRTIO_FEATURES;
 
         let mut avail_protocol_features = VhostUserProtocolFeatures::MQ
             | VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -1,7 +1,12 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::{
+    VIRTIO_F_IN_ORDER, VIRTIO_F_NOTIFICATION_DATA, VIRTIO_F_ORDER_PLATFORM,
+    VIRTIO_F_RING_EVENT_IDX, VIRTIO_F_RING_INDIRECT_DESC, VIRTIO_F_RING_PACKED, VIRTIO_F_VERSION_1,
+};
 use std::io;
+use vhost::vhost_user::message::VhostUserVirtioFeatures;
 use vhost::Error as VhostError;
 use vm_memory::Error as MmapError;
 
@@ -98,3 +103,12 @@ pub enum Error {
     MissingIrqFd,
 }
 type Result<T> = std::result::Result<T, Error>;
+
+pub const DEFAULT_VIRTIO_FEATURES: u64 = 1 << VIRTIO_F_RING_INDIRECT_DESC
+    | 1 << VIRTIO_F_RING_EVENT_IDX
+    | 1 << VIRTIO_F_VERSION_1
+    | 1 << VIRTIO_F_RING_PACKED
+    | 1 << VIRTIO_F_IN_ORDER
+    | 1 << VIRTIO_F_ORDER_PLATFORM
+    | 1 << VIRTIO_F_NOTIFICATION_DATA
+    | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();


### PR DESCRIPTION
A lot of the VIRTIO reserved features should be supported or not by the
vhost-user backend. That means on the VMM side, these features should be
available, so that they don't get lost during the negotiation.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>