### PR TITLE
virtio-devices: vhost_user: Don't set features before ACK from guest

### DIFF
--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -81,10 +81,6 @@ pub fn negotiate_features_vhost_user(
     // both VMM and backend support.
     let backend_features = vu.get_features().map_err(Error::VhostUserGetFeatures)?;
     let acked_features = avail_features & backend_features;
-    // Set features back is required by the vhost crate mechanism, since the
-    // later vhost call will check if features is filled in master before execution.
-    vu.set_features(acked_features)
-        .map_err(Error::VhostUserSetFeatures)?;
 
     let acked_protocol_features =
         if acked_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits() != 0 {


### PR DESCRIPTION
The VIRTIO features should not be set before they are acked from the
guest. This code was only present to overcome a vhost crate limitation
that was expecting the VIRTIO features to be set before we could fetch
and set the protocol features.

The vhost crate has been recently fixed by removing the limitation,
therefore there's no need for this workaround in the Cloud Hypervisor
codebase anymore.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>