### PR TITLE
vhost-user-net: Move control queue handling back to the VMM

### DIFF
--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -122,12 +122,12 @@ pub fn build_net_config_space(
     mut config: &mut VirtioNetConfig,
     mac: MacAddr,
     num_queues: usize,
-    mut avail_features: &mut u64,
+    avail_features: &mut u64,
 ) {
     config.mac.copy_from_slice(mac.get_bytes());
     *avail_features |= 1 << VIRTIO_NET_F_MAC;
 
-    build_net_config_space_with_mq(&mut config, num_queues, &mut avail_features);
+    build_net_config_space_with_mq(&mut config, num_queues, avail_features);
 }
 
 pub fn build_net_config_space_with_mq(

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -8,7 +8,6 @@
 
 use libc::{self, EFD_NONBLOCK};
 use log::*;
-use net_util::CtrlQueue;
 use net_util::{
     open_tap, MacAddr, NetCounters, NetQueuePair, OpenTapError, RxVirtio, Tap, TxVirtio,
 };
@@ -26,7 +25,7 @@ use vhost::vhost_user::Listener;
 use vhost_user_backend::{VhostUserBackend, VhostUserDaemon, Vring, VringWorker};
 use virtio_bindings::bindings::virtio_net::*;
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use vm_memory::{GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 use vmm_sys_util::eventfd::EventFd;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -52,8 +51,6 @@ pub enum Error {
     NetQueuePair(net_util::NetQueuePairError),
     /// Failed registering the TAP listener
     RegisterTapListener(io::Error),
-    /// Failed processing control queue
-    ProcessCtrlQueue(net_util::CtrlQueueError),
 }
 
 pub const SYNTAX: &str = "vhost-user-net backend parameters \
@@ -100,32 +97,13 @@ impl VhostUserNetThread {
         })
     }
 
-    fn set_vring_worker(&mut self, vring_worker: Option<Arc<VringWorker>>) {
+    pub fn set_vring_worker(&mut self, vring_worker: Option<Arc<VringWorker>>) {
         self.net.epoll_fd = Some(vring_worker.as_ref().unwrap().as_raw_fd());
-    }
-}
-
-struct VhostUserNetCtrlThread {
-    ctrl: CtrlQueue,
-    kill_evt: EventFd,
-    id: usize,
-    mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
-}
-
-impl VhostUserNetCtrlThread {
-    fn new(taps: Vec<Tap>, id: usize) -> Result<Self> {
-        Ok(VhostUserNetCtrlThread {
-            ctrl: CtrlQueue::new(taps),
-            kill_evt: EventFd::new(EFD_NONBLOCK).map_err(Error::CreateKillEventFd)?,
-            id,
-            mem: None,
-        })
     }
 }
 
 pub struct VhostUserNetBackend {
     threads: Vec<Mutex<VhostUserNetThread>>,
-    ctrl_thread: Mutex<VhostUserNetCtrlThread>,
     num_queues: usize,
     queue_size: u16,
     queues_per_thread: Vec<u64>,
@@ -136,11 +114,11 @@ impl VhostUserNetBackend {
         ip_addr: Ipv4Addr,
         host_mac: MacAddr,
         netmask: Ipv4Addr,
-        mut num_queues: usize,
+        num_queues: usize,
         queue_size: u16,
         ifname: Option<&str>,
     ) -> Result<Self> {
-        let taps = open_tap(
+        let mut taps = open_tap(
             ifname,
             Some(ip_addr),
             Some(netmask),
@@ -152,34 +130,77 @@ impl VhostUserNetBackend {
 
         let mut queues_per_thread = Vec::new();
         let mut threads = Vec::new();
-        for (i, tap) in taps.clone().drain(..).enumerate() {
+        for (i, tap) in taps.drain(..).enumerate() {
             let thread = Mutex::new(VhostUserNetThread::new(tap)?);
             threads.push(thread);
             queues_per_thread.push(0b11 << (i * 2));
         }
 
-        // Create a dedicated thread for the control queue.
-        let ctrl_thread = Mutex::new(VhostUserNetCtrlThread::new(taps.clone(), taps.len())?);
-        queues_per_thread.push(1 << num_queues);
-
-        // Increase num_queues by 1 because of the control queue.
-        num_queues += 1;
-
         Ok(VhostUserNetBackend {
             threads,
-            ctrl_thread,
             num_queues,
             queue_size,
             queues_per_thread,
         })
     }
+}
 
-    fn handle_queue(
+impl VhostUserBackend for VhostUserNetBackend {
+    fn num_queues(&self) -> usize {
+        self.num_queues
+    }
+
+    fn max_queue_size(&self) -> usize {
+        self.queue_size as usize
+    }
+
+    fn features(&self) -> u64 {
+        1 << VIRTIO_NET_F_GUEST_CSUM
+            | 1 << VIRTIO_NET_F_CSUM
+            | 1 << VIRTIO_NET_F_GUEST_TSO4
+            | 1 << VIRTIO_NET_F_GUEST_TSO6
+            | 1 << VIRTIO_NET_F_GUEST_ECN
+            | 1 << VIRTIO_NET_F_GUEST_UFO
+            | 1 << VIRTIO_NET_F_HOST_TSO4
+            | 1 << VIRTIO_NET_F_HOST_TSO6
+            | 1 << VIRTIO_NET_F_HOST_ECN
+            | 1 << VIRTIO_NET_F_HOST_UFO
+            | 1 << VIRTIO_NET_F_MRG_RXBUF
+            | 1 << VIRTIO_NET_F_CTRL_VQ
+            | 1 << VIRTIO_NET_F_MQ
+            | 1 << VIRTIO_NET_F_MAC
+            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
+            | 1 << VIRTIO_F_VERSION_1
+            | 1 << VIRTIO_RING_F_EVENT_IDX
+            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
+    }
+
+    fn protocol_features(&self) -> VhostUserProtocolFeatures {
+        VhostUserProtocolFeatures::MQ
+            | VhostUserProtocolFeatures::REPLY_ACK
+            | VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS
+    }
+
+    fn set_event_idx(&mut self, _enabled: bool) {}
+
+    fn update_memory(&mut self, mem: GuestMemoryMmap) -> VhostUserBackendResult<()> {
+        for thread in self.threads.iter() {
+            thread.lock().unwrap().net.mem = Some(GuestMemoryAtomic::new(mem.clone()));
+        }
+        Ok(())
+    }
+
+    fn handle_event(
         &self,
         device_event: u16,
+        evset: epoll::Events,
         vrings: &[Arc<RwLock<Vring>>],
         thread_id: usize,
     ) -> VhostUserBackendResult<bool> {
+        if evset != epoll::Events::EPOLLIN {
+            return Err(Error::HandleEventNotEpollIn.into());
+        }
+
         let mut thread = self.threads[thread_id].lock().unwrap();
         match device_event {
             0 => {
@@ -224,129 +245,18 @@ impl VhostUserNetBackend {
         Ok(false)
     }
 
-    fn handle_ctrl_queue(
-        &self,
-        device_event: u16,
-        vrings: &[Arc<RwLock<Vring>>],
-    ) -> VhostUserBackendResult<bool> {
-        let mut thread = self.ctrl_thread.lock().unwrap();
-
-        let mem = thread.mem.as_ref().unwrap().memory();
-
-        match device_event {
-            0 => {
-                let mut vring = vrings[0].write().unwrap();
-                if thread
-                    .ctrl
-                    .process(&mem, &mut vring.mut_queue())
-                    .map_err(Error::ProcessCtrlQueue)?
-                {
-                    vring
-                        .signal_used_queue()
-                        .map_err(Error::FailedSignalingUsedQueue)?;
-                }
-            }
-            _ => return Err(Error::HandleEventUnknownEvent.into()),
-        }
-
-        Ok(false)
-    }
-}
-
-impl VhostUserBackend for VhostUserNetBackend {
-    fn num_queues(&self) -> usize {
-        self.num_queues
-    }
-
-    fn max_queue_size(&self) -> usize {
-        self.queue_size as usize
-    }
-
-    fn features(&self) -> u64 {
-        1 << VIRTIO_NET_F_GUEST_CSUM
-            | 1 << VIRTIO_NET_F_CSUM
-            | 1 << VIRTIO_NET_F_GUEST_TSO4
-            | 1 << VIRTIO_NET_F_GUEST_TSO6
-            | 1 << VIRTIO_NET_F_GUEST_ECN
-            | 1 << VIRTIO_NET_F_GUEST_UFO
-            | 1 << VIRTIO_NET_F_HOST_TSO4
-            | 1 << VIRTIO_NET_F_HOST_TSO6
-            | 1 << VIRTIO_NET_F_HOST_ECN
-            | 1 << VIRTIO_NET_F_HOST_UFO
-            | 1 << VIRTIO_NET_F_MRG_RXBUF
-            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
-            | 1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_RING_F_EVENT_IDX
-            | 1 << VIRTIO_NET_F_CTRL_VQ
-            | 1 << VIRTIO_NET_F_MQ
-            | 1 << VIRTIO_NET_F_MAC
-            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
-    }
-
-    fn protocol_features(&self) -> VhostUserProtocolFeatures {
-        VhostUserProtocolFeatures::MQ
-            | VhostUserProtocolFeatures::REPLY_ACK
-            | VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS
-    }
-
-    fn set_event_idx(&mut self, _enabled: bool) {}
-
-    fn update_memory(&mut self, mem: GuestMemoryMmap) -> VhostUserBackendResult<()> {
-        for thread in self.threads.iter() {
-            thread.lock().unwrap().net.mem = Some(GuestMemoryAtomic::new(mem.clone()));
-        }
-        self.ctrl_thread.lock().unwrap().mem = Some(GuestMemoryAtomic::new(mem));
-
-        Ok(())
-    }
-
-    fn handle_event(
-        &self,
-        device_event: u16,
-        evset: epoll::Events,
-        vrings: &[Arc<RwLock<Vring>>],
-        thread_id: usize,
-    ) -> VhostUserBackendResult<bool> {
-        if evset != epoll::Events::EPOLLIN {
-            return Err(Error::HandleEventNotEpollIn.into());
-        }
-
-        if thread_id == self.ctrl_thread.lock().unwrap().id {
-            self.handle_ctrl_queue(device_event, vrings)
-        } else {
-            self.handle_queue(device_event, vrings, thread_id)
-        }
-    }
-
     fn exit_event(&self, thread_index: usize) -> Option<(EventFd, Option<u16>)> {
-        let (exit_event_fd, exit_event_index) =
-            if thread_index == self.ctrl_thread.lock().unwrap().id {
-                // The exit event is placed after the control queue event, which is
-                // event index 1.
-                (
-                    self.ctrl_thread
-                        .lock()
-                        .unwrap()
-                        .kill_evt
-                        .try_clone()
-                        .unwrap(),
-                    1,
-                )
-            } else {
-                // The exit event is placed after the queues and the tap event, which
-                // is event index 3.
-                (
-                    self.threads[thread_index]
-                        .lock()
-                        .unwrap()
-                        .kill_evt
-                        .try_clone()
-                        .unwrap(),
-                    3,
-                )
-            };
-
-        Some((exit_event_fd, Some(exit_event_index)))
+        // The exit event is placed after the queues and the tap event, which
+        // is event index 3.
+        Some((
+            self.threads[thread_index]
+                .lock()
+                .unwrap()
+                .kill_evt
+                .try_clone()
+                .unwrap(),
+            Some(3),
+        ))
     }
 
     fn queues_per_thread(&self) -> Vec<u64> {
@@ -450,7 +360,7 @@ pub fn start_net_backend(backend_command: &str) {
 
     let mut vring_workers = net_daemon.get_vring_workers();
 
-    if vring_workers.len() != (net_backend.read().unwrap().threads.len() + 1) {
+    if vring_workers.len() != net_backend.read().unwrap().threads.len() {
         error!("Number of vring workers must be identical to the number of backend threads");
         process::exit(1);
     }
@@ -483,15 +393,4 @@ pub fn start_net_backend(backend_command: &str) {
             error!("Error shutting down worker thread: {:?}", e)
         }
     }
-    if let Err(e) = net_backend
-        .read()
-        .unwrap()
-        .ctrl_thread
-        .lock()
-        .unwrap()
-        .kill_evt
-        .write(1)
-    {
-        error!("Error shutting down control thread: {:?}", e);
-    };
 }

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -22,6 +22,7 @@ pub enum Thread {
     VirtioPmem,
     VirtioRng,
     VirtioVhostFs,
+    VirtioVhostNetCtl,
     VirtioVsock,
     VirtioWatchdog,
 }
@@ -332,6 +333,26 @@ fn virtio_vhost_fs_thread_rules() -> Vec<SyscallRuleSet> {
     ]
 }
 
+fn virtio_vhost_net_ctl_thread_rules() -> Vec<SyscallRuleSet> {
+    vec![
+        allow_syscall(libc::SYS_brk),
+        allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_dup),
+        allow_syscall(libc::SYS_epoll_create1),
+        allow_syscall(libc::SYS_epoll_ctl),
+        allow_syscall(libc::SYS_epoll_pwait),
+        #[cfg(target_arch = "x86_64")]
+        allow_syscall(libc::SYS_epoll_wait),
+        allow_syscall(libc::SYS_exit),
+        allow_syscall(libc::SYS_futex),
+        allow_syscall(libc::SYS_munmap),
+        allow_syscall(libc::SYS_madvise),
+        allow_syscall(libc::SYS_read),
+        allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_write),
+    ]
+}
+
 fn create_vsock_ioctl_seccomp_rule() -> Vec<SeccompRule> {
     or![and![Cond::new(1, ArgLen::DWORD, Eq, FIONBIO,).unwrap()],]
 }
@@ -399,6 +420,7 @@ fn get_seccomp_filter_trap(thread_type: Thread) -> Result<SeccompFilter, Error> 
         Thread::VirtioPmem => virtio_pmem_thread_rules(),
         Thread::VirtioRng => virtio_rng_thread_rules(),
         Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules(),
+        Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules(),
         Thread::VirtioVsock => virtio_vsock_thread_rules(),
         Thread::VirtioWatchdog => virtio_watchdog_thread_rules(),
     };
@@ -418,6 +440,7 @@ fn get_seccomp_filter_log(thread_type: Thread) -> Result<SeccompFilter, Error> {
         Thread::VirtioPmem => virtio_pmem_thread_rules(),
         Thread::VirtioRng => virtio_rng_thread_rules(),
         Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules(),
+        Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules(),
         Thread::VirtioVsock => virtio_vsock_thread_rules(),
         Thread::VirtioWatchdog => virtio_watchdog_thread_rules(),
     };

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -2,26 +2,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::{
-    ActivateError, ActivateResult, Queue, VirtioCommon, VirtioDevice, VirtioDeviceType,
+    ActivateError, ActivateResult, EpollHelper, EpollHelperError, EpollHelperHandler, Queue,
+    VirtioCommon, VirtioDevice, VirtioDeviceType, EPOLL_HELPER_EVENT_LAST,
 };
 use super::vu_common_ctrl::*;
-use super::{Error, Result, DEFAULT_VIRTIO_FEATURES};
-use crate::VirtioInterrupt;
-use net_util::{build_net_config_space, MacAddr, VirtioNetConfig};
+use super::{Error, Result};
+use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::{VirtioInterrupt, VIRTIO_F_RING_EVENT_IDX, VIRTIO_F_VERSION_1};
+use net_util::{build_net_config_space, CtrlQueue, MacAddr, VirtioNetConfig};
+use seccomp::{SeccompAction, SeccompFilter};
 use std::ops::Deref;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::UnixListener;
 use std::result;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier};
+use std::thread;
 use std::vec::Vec;
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
 use vhost::vhost_user::{Master, VhostUserMaster, VhostUserMasterReqHandler};
-use vhost::VhostBackend;
 use virtio_bindings::bindings::virtio_net::{
     VIRTIO_NET_F_CSUM, VIRTIO_NET_F_CTRL_VQ, VIRTIO_NET_F_GUEST_CSUM, VIRTIO_NET_F_GUEST_ECN,
     VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_TSO6, VIRTIO_NET_F_GUEST_UFO,
     VIRTIO_NET_F_HOST_ECN, VIRTIO_NET_F_HOST_TSO4, VIRTIO_NET_F_HOST_TSO6, VIRTIO_NET_F_HOST_UFO,
-    VIRTIO_NET_F_MRG_RXBUF,
+    VIRTIO_NET_F_MAC, VIRTIO_NET_F_MRG_RXBUF,
 };
 use vm_memory::{
     ByteValued, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap, GuestRegionMmap,
@@ -34,6 +38,58 @@ const DEFAULT_QUEUE_NUMBER: usize = 2;
 struct SlaveReqHandler {}
 impl VhostUserMasterReqHandler for SlaveReqHandler {}
 
+/// Control queue
+// Event available on the control queue.
+const CTRL_QUEUE_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 1;
+
+pub struct NetCtrlEpollHandler {
+    pub mem: GuestMemoryAtomic<GuestMemoryMmap>,
+    pub kill_evt: EventFd,
+    pub pause_evt: EventFd,
+    pub ctrl_q: CtrlQueue,
+    pub queue_evt: EventFd,
+    pub queue: Queue,
+}
+
+impl NetCtrlEpollHandler {
+    pub fn run_ctrl(
+        &mut self,
+        paused: Arc<AtomicBool>,
+        paused_sync: Arc<Barrier>,
+    ) -> std::result::Result<(), EpollHelperError> {
+        let mut helper = EpollHelper::new(&self.kill_evt, &self.pause_evt)?;
+        helper.add_event(self.queue_evt.as_raw_fd(), CTRL_QUEUE_EVENT)?;
+        helper.run(paused, paused_sync, self)?;
+
+        Ok(())
+    }
+}
+
+impl EpollHelperHandler for NetCtrlEpollHandler {
+    fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
+        let ev_type = event.data as u16;
+        match ev_type {
+            CTRL_QUEUE_EVENT => {
+                let mem = self.mem.memory();
+                if let Err(e) = self.queue_evt.read() {
+                    error!("failed to get ctl queue event: {:?}", e);
+                    return true;
+                }
+                if let Err(e) = self.ctrl_q.process(&mem, &mut self.queue) {
+                    error!("failed to process ctrl queue: {:?}", e);
+                    return true;
+                }
+            }
+            _ => {
+                error!("Unknown event for virtio-net");
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
 pub struct Net {
     common: VirtioCommon,
     id: String,
@@ -42,6 +98,8 @@ pub struct Net {
     guest_memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     acked_protocol_features: u64,
     socket_path: Option<String>,
+    ctrl_queue_epoll_thread: Option<thread::JoinHandle<()>>,
+    seccomp_action: SeccompAction,
 }
 
 impl Net {
@@ -51,6 +109,7 @@ impl Net {
         mac_addr: MacAddr,
         vu_cfg: VhostUserConfig,
         server: bool,
+        seccomp_action: SeccompAction,
     ) -> Result<Net> {
         let mut socket_path: Option<String> = None;
 
@@ -69,13 +128,12 @@ impl Net {
             | 1 << VIRTIO_NET_F_HOST_UFO
             | 1 << VIRTIO_NET_F_MRG_RXBUF
             | 1 << VIRTIO_NET_F_CTRL_VQ
-            | DEFAULT_VIRTIO_FEATURES;
+            | 1 << VIRTIO_F_RING_EVENT_IDX
+            | 1 << VIRTIO_F_VERSION_1
+            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
 
         let mut config = VirtioNetConfig::default();
         build_net_config_space(&mut config, mac_addr, num_queues, &mut avail_features);
-
-        // Adding one potential queue for the control queue.
-        num_queues += 1;
 
         let mut vhost_user_net = if server {
             info!("Binding vhost-user-net listener...");
@@ -95,25 +153,17 @@ impl Net {
             | VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS
             | VhostUserProtocolFeatures::REPLY_ACK;
 
-        let (acked_features, acked_protocol_features) = negotiate_features_vhost_user(
+        let (mut acked_features, acked_protocol_features) = negotiate_features_vhost_user(
             &mut vhost_user_net,
             avail_features,
             avail_protocol_features,
         )?;
-
-        // If the control queue feature has not been negotiated, let's decrease
-        // the number of queues.
-        if acked_features & (1 << VIRTIO_NET_F_CTRL_VQ) == 0 {
-            num_queues -= 1;
-        }
 
         let backend_num_queues =
             if acked_protocol_features & VhostUserProtocolFeatures::MQ.bits() != 0 {
                 vhost_user_net
                     .get_queue_num()
                     .map_err(Error::VhostUserGetQueueMaxNum)? as usize
-            } else if acked_features & (1 << VIRTIO_NET_F_CTRL_VQ) != 0 {
-                DEFAULT_QUEUE_NUMBER + 1
             } else {
                 DEFAULT_QUEUE_NUMBER
             };
@@ -124,13 +174,15 @@ impl Net {
             return Err(Error::BadQueueNum);
         }
 
-        // Send set_vring_base here, since it could tell backends, like OVS + DPDK,
-        // how many virt queues to be handled, which backend required to know at early stage.
-        for i in 0..num_queues {
-            vhost_user_net
-                .set_vring_base(i, 0)
-                .map_err(Error::VhostUserSetVringBase)?;
+        // If the control queue feature has been negotiated, let's increase
+        // the number of queues.
+        if acked_features & (1 << VIRTIO_NET_F_CTRL_VQ) != 0 {
+            num_queues += 1;
         }
+
+        // Make sure the virtio feature to set the MAC address is exposed to
+        // the guest, even if it hasn't been negotiated with the backend.
+        acked_features |= 1 << VIRTIO_NET_F_MAC;
 
         Ok(Net {
             id,
@@ -148,6 +200,8 @@ impl Net {
             guest_memory: None,
             acked_protocol_features,
             socket_path,
+            ctrl_queue_epoll_thread: None,
+            seccomp_action,
         })
     }
 }
@@ -187,12 +241,80 @@ impl VirtioDevice for Net {
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
         interrupt_cb: Arc<dyn VirtioInterrupt>,
-        queues: Vec<Queue>,
-        queue_evts: Vec<EventFd>,
+        mut queues: Vec<Queue>,
+        mut queue_evts: Vec<EventFd>,
     ) -> ActivateResult {
         self.common.activate(&queues, &queue_evts, &interrupt_cb)?;
 
         self.guest_memory = Some(mem.clone());
+
+        let num_queues = queues.len();
+        if self.common.feature_acked(VIRTIO_NET_F_CTRL_VQ.into()) && num_queues % 2 != 0 {
+            let cvq_queue = queues.remove(num_queues - 1);
+            let cvq_queue_evt = queue_evts.remove(num_queues - 1);
+
+            let kill_evt = self
+                .common
+                .kill_evt
+                .as_ref()
+                .unwrap()
+                .try_clone()
+                .map_err(|e| {
+                    error!("failed to clone kill_evt eventfd: {}", e);
+                    ActivateError::BadActivate
+                })?;
+            let pause_evt = self
+                .common
+                .pause_evt
+                .as_ref()
+                .unwrap()
+                .try_clone()
+                .map_err(|e| {
+                    error!("failed to clone pause_evt eventfd: {}", e);
+                    ActivateError::BadActivate
+                })?;
+
+            let mut ctrl_handler = NetCtrlEpollHandler {
+                mem: mem.clone(),
+                kill_evt,
+                pause_evt,
+                ctrl_q: CtrlQueue::new(Vec::new()),
+                queue: cvq_queue,
+                queue_evt: cvq_queue_evt,
+            };
+
+            let paused = self.common.paused.clone();
+            // Let's update the barrier as we need 1 for the control queue + 1
+            // for the main thread signalling the pause.
+            self.common.paused_sync = Some(Arc::new(Barrier::new(2)));
+            let paused_sync = self.common.paused_sync.clone();
+
+            // Retrieve seccomp filter for virtio_net_ctl thread
+            let virtio_vhost_net_ctl_seccomp_filter =
+                get_seccomp_filter(&self.seccomp_action, Thread::VirtioVhostNetCtl)
+                    .map_err(ActivateError::CreateSeccompFilter)?;
+            thread::Builder::new()
+                .name(format!("{}_ctrl", self.id))
+                .spawn(move || {
+                    if let Err(e) = SeccompFilter::apply(virtio_vhost_net_ctl_seccomp_filter) {
+                        error!("Error applying seccomp filter: {:?}", e);
+                    } else if let Err(e) = ctrl_handler.run_ctrl(paused, paused_sync.unwrap()) {
+                        error!("Error running worker: {:?}", e);
+                    }
+                })
+                .map(|thread| self.ctrl_queue_epoll_thread = Some(thread))
+                .map_err(|e| {
+                    error!("failed to clone queue EventFd: {}", e);
+                    ActivateError::BadActivate
+                })?;
+        }
+
+        // The backend acknowledged features must contain the protocol feature
+        // bit in case it was initially set but lost through the features
+        // negotiation with the guest. Additionally, it must not contain
+        // VIRTIO_NET_F_MAC since we don't expect the backend to handle it.
+        let backend_acked_features = self.common.acked_features & !(1 << VIRTIO_NET_F_MAC)
+            | (self.common.avail_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits());
 
         setup_vhost_user(
             &mut self.vhost_user_net,
@@ -200,8 +322,7 @@ impl VirtioDevice for Net {
             queues,
             queue_evts,
             &interrupt_cb,
-            self.common.acked_features
-                | (self.common.avail_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()),
+            backend_acked_features,
         )
         .map_err(ActivateError::VhostUserNetSetup)?;
 
@@ -262,7 +383,12 @@ impl Pausable for Net {
     }
 
     fn resume(&mut self) -> result::Result<(), MigratableError> {
-        self.common.resume()
+        self.common.resume()?;
+
+        if let Some(ctrl_queue_epoll_thread) = &self.ctrl_queue_epoll_thread {
+            ctrl_queue_epoll_thread.thread().unpark();
+        }
+        Ok(())
     }
 }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2039,8 +2039,13 @@ impl DeviceManager {
                 VhostMode::Server => true,
             };
             let vhost_user_net_device = Arc::new(Mutex::new(
-                match virtio_devices::vhost_user::Net::new(id.clone(), net_cfg.mac, vu_cfg, server)
-                {
+                match virtio_devices::vhost_user::Net::new(
+                    id.clone(),
+                    net_cfg.mac,
+                    vu_cfg,
+                    server,
+                    self.seccomp_action.clone(),
+                ) {
                     Ok(vun_device) => vun_device,
                     Err(e) => {
                         return Err(DeviceManagerError::CreateVhostUserNet(e));


### PR DESCRIPTION
We thought moving the control queue to the backend would be a good idea, as it simplified the VMM code and was moving all queue handling to the backend. Unfortunately, that's not how the existing backends are designed (such as OVS-DPDK), which means we have to roll some of our changes back.

Fixes #2671 