### PR TITLE
Enable ACPI on AArch64

### DIFF
--- a/acpi_tables/Cargo.toml
+++ b/acpi_tables/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2018"
 
 [dependencies]
 vm-memory = "0.5.0"
-

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -413,7 +413,23 @@ fn create_pci_nodes(
     // Add node for PCIe controller.
     // See Documentation/devicetree/bindings/pci/host-generic-pci.txt in the kernel
     // and https://elinux.org/Device_Tree_Usage.
-    let pci_device_base = pci_device_base + PCI_HIGH_BASE;
+
+    // EDK2 requires the PCIe high space above 4G address.
+    // The actual space in CLH follows the RAM. If the RAM space is small, the PCIe high space
+    // could fall bellow 4G.
+    // Here we put it above 512G in FDT to workaround the EDK2 check.
+    // But the address written in ACPI is not impacted.
+    let pci_device_base_64bit: u64 = if cfg!(feature = "acpi") {
+        pci_device_base + PCI_HIGH_BASE
+    } else {
+        pci_device_base
+    };
+    let pci_device_size_64bit: u64 = if cfg!(feature = "acpi") {
+        pci_device_size - PCI_HIGH_BASE
+    } else {
+        pci_device_size
+    };
+
     let ranges = [
         // io addresses
         0x1000000,
@@ -432,13 +448,13 @@ fn create_pci_nodes(
         (MEM_32BIT_DEVICES_SIZE >> 32) as u32, // size
         MEM_32BIT_DEVICES_SIZE as u32,
         // device addresses
-        0x3000000,                      // (ss = 11: 64-bit memory space)
-        (pci_device_base >> 32) as u32, // PCI address
-        pci_device_base as u32,
-        (pci_device_base >> 32) as u32, // CPU address
-        pci_device_base as u32,
-        (pci_device_size >> 32) as u32, // size
-        pci_device_size as u32,
+        0x3000000,                            // (ss = 11: 64-bit memory space)
+        (pci_device_base_64bit >> 32) as u32, // PCI address
+        pci_device_base_64bit as u32,
+        (pci_device_base_64bit >> 32) as u32, // CPU address
+        pci_device_base_64bit as u32,
+        (pci_device_size_64bit >> 32) as u32, // size
+        pci_device_size_64bit as u32,
     ];
     let bus_range = [0, 0]; // Only bus 0
     let reg = [PCI_MMCONFIG_START.0, PCI_MMCONFIG_SIZE];

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -17,8 +17,8 @@ use super::super::InitramfsConfig;
 use super::get_fdt_addr;
 use super::gic::GicDevice;
 use super::layout::{
-    IRQ_BASE, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START, PCI_MMCONFIG_SIZE,
-    PCI_MMCONFIG_START,
+    IRQ_BASE, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START, MEM_PCI_IO_SIZE, MEM_PCI_IO_START,
+    PCI_HIGH_BASE, PCI_MMCONFIG_SIZE, PCI_MMCONFIG_START,
 };
 use vm_fdt::{FdtWriter, FdtWriterResult};
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryError};
@@ -413,7 +413,16 @@ fn create_pci_nodes(
     // Add node for PCIe controller.
     // See Documentation/devicetree/bindings/pci/host-generic-pci.txt in the kernel
     // and https://elinux.org/Device_Tree_Usage.
+    let pci_device_base = pci_device_base + PCI_HIGH_BASE;
     let ranges = [
+        // io addresses
+        0x1000000,
+        0_u32,
+        0_u32,
+        (MEM_PCI_IO_START.0 >> 32) as u32,
+        MEM_PCI_IO_START.0 as u32,
+        (MEM_PCI_IO_SIZE >> 32) as u32,
+        MEM_PCI_IO_SIZE as u32,
         // mmio addresses
         0x2000000,                                // (ss = 10: 32-bit memory space)
         (MEM_32BIT_DEVICES_START.0 >> 32) as u32, // PCI address

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -54,12 +54,12 @@ pub const UEFI_SIZE: u64 = 0x0400_0000;
 /// Below this address will reside the GIC, above this address will reside the MMIO devices.
 pub const MAPPED_IO_START: u64 = 0x0900_0000;
 
-/// Space 0x0900_0000 ~ 0x1000_0000 is reserved for legacy devices.
+/// Space 0x0900_0000 ~ 0x0905_0000 is reserved for legacy devices.
 pub const LEGACY_SERIAL_MAPPED_IO_START: u64 = 0x0900_0000;
 pub const LEGACY_RTC_MAPPED_IO_START: u64 = 0x0901_0000;
 pub const LEGACY_GPIO_MAPPED_IO_START: u64 = 0x0902_0000;
 
-/// Space 0x0905_0000 ~ 0x906_0000 is reserved for pcie io address
+/// Space 0x0905_0000 ~ 0x0906_0000 is reserved for pcie io address
 pub const MEM_PCI_IO_START: GuestAddress = GuestAddress(0x0905_0000);
 pub const MEM_PCI_IO_SIZE: u64 = 0x10000;
 
@@ -90,6 +90,9 @@ pub const RSDP_POINTER: GuestAddress = GuestAddress(ACPI_START);
 
 /// Kernel start after FDT and ACPI
 pub const KERNEL_START: u64 = ACPI_START + ACPI_MAX_SIZE as u64;
+
+/// Pci high memory base
+pub const PCI_HIGH_BASE: u64 = 0x80_0000_0000_u64;
 
 // As per virt/kvm/arm/vgic/vgic-kvm-device.c we need
 // the number of interrupts our GIC will support to be:

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -10,6 +10,8 @@ pub mod gic;
 pub mod layout;
 /// Logic for configuring aarch64 registers.
 pub mod regs;
+/// Module for loading UEFI binary.
+pub mod uefi;
 
 pub use self::fdt::DeviceInfoForFdt;
 use crate::DeviceType;
@@ -180,6 +182,11 @@ pub fn initramfs_load_addr(
 /// Returns the memory address where the kernel could be loaded.
 pub fn get_kernel_start() -> u64 {
     layout::KERNEL_START
+}
+
+///Return guest memory address where the uefi should be loaded.
+pub fn get_uefi_start() -> u64 {
+    layout::UEFI_START
 }
 
 // Auxiliary function to get the address where the device tree blob is loaded.

--- a/arch/src/aarch64/uefi.rs
+++ b/arch/src/aarch64/uefi.rs
@@ -1,0 +1,43 @@
+// Copyright 2020 Arm Limited (or its affiliates). All rights reserved.
+
+use std::io::{Read, Seek, SeekFrom};
+use std::result;
+use vm_memory::{Bytes, GuestAddress, GuestMemory};
+
+/// Errors thrown while loading UEFI binary
+#[derive(Debug)]
+pub enum Error {
+    /// Unable to seek to UEFI image start.
+    SeekUefiStart,
+    /// Unable to seek to UEFI image end.
+    SeekUefiEnd,
+    /// UEFI image too big.
+    UefiTooBig,
+    /// Unable to read UEFI image
+    ReadUefiImage,
+}
+type Result<T> = result::Result<T, Error>;
+
+pub fn load_uefi<F, M: GuestMemory>(
+    guest_mem: &M,
+    guest_addr: GuestAddress,
+    uefi_image: &mut F,
+) -> Result<()>
+where
+    F: Read + Seek,
+{
+    let uefi_size = uefi_image
+        .seek(SeekFrom::End(0))
+        .map_err(|_| Error::SeekUefiEnd)? as usize;
+
+    // edk2 image on virtual platform is smaller than 3M
+    if uefi_size > 0x300000 {
+        return Err(Error::UefiTooBig);
+    }
+    uefi_image
+        .seek(SeekFrom::Start(0))
+        .map_err(|_| Error::SeekUefiStart)?;
+    guest_mem
+        .read_exact_from(guest_addr, uefi_image, uefi_size)
+        .map_err(|_| Error::ReadUefiImage)
+}

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -74,8 +74,8 @@ pub mod aarch64;
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
     arch_memory_regions, configure_system, configure_vcpu, fdt::DeviceInfoForFdt,
-    get_host_cpu_phys_bits, get_kernel_start, initramfs_load_addr, layout,
-    layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, EntryPoint,
+    get_host_cpu_phys_bits, get_kernel_start, get_uefi_start, initramfs_load_addr, layout,
+    layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, uefi, EntryPoint,
 };
 
 #[cfg(target_arch = "x86_64")]

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -37,9 +37,13 @@ RUN apt-get update \
 	socat \
 	dosfstools \
 	cpio \
+	python \
+	python3 \
 	python3-setuptools \
 	ntfs-3g \
 	openvswitch-switch-dpdk \
+	python3-distutils \
+	uuid-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -308,6 +308,11 @@ echo "Integration test on FDT finished with result $RES."
 if [ $RES -eq 0 ]; then
     # Test with EDK2 + ACPI
     cargo build --all --release $features_build_acpi --target $BUILD_TARGET
+    strip target/$BUILD_TARGET/release/cloud-hypervisor
+    strip target/$BUILD_TARGET/release/vhost_user_net
+    strip target/$BUILD_TARGET/release/ch-remote
+
+    time cargo test $features_test_acpi "tests::parallel::test_edk2_acpi_launch"
     RES=$?
     echo "Integration test on UEFI & ACPI finished with result $RES."
 fi

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1917,6 +1917,45 @@ mod tests {
         }
 
         #[test]
+        #[cfg(all(target_arch = "aarch64", feature = "acpi"))]
+        fn test_edk2_acpi_launch() {
+            let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+            let mut workload_path = dirs::home_dir().unwrap();
+            workload_path.push("workloads");
+            let mut edk2_path = workload_path;
+            edk2_path.push("CLOUDHV_EFI.fd");
+
+            vec![Box::new(focal)].drain(..).for_each(|disk_config| {
+                let guest = Guest::new(disk_config);
+
+                let mut child = GuestCommand::new(&guest)
+                    .args(&["--cpus", "boot=1"])
+                    .args(&["--memory", "size=512M"])
+                    .args(&["--kernel", edk2_path.to_str().unwrap()])
+                    .default_disks()
+                    .default_net()
+                    .args(&["--serial", "tty", "--console", "off"])
+                    .capture_output()
+                    .spawn()
+                    .unwrap();
+
+                let r = std::panic::catch_unwind(|| {
+                    guest.wait_vm_boot(Some(120)).unwrap();
+
+                    assert_eq!(guest.get_cpu_count().unwrap_or_default(), 1);
+                    assert!(guest.get_total_memory().unwrap_or_default() > 400_000);
+                    assert!(guest.get_entropy().unwrap_or_default() >= 900);
+                    assert_eq!(guest.get_pci_bridge_class().unwrap_or_default(), "0x060000");
+                });
+
+                let _ = child.kill();
+                let output = child.wait_with_output().unwrap();
+
+                handle_child_output(r, &output);
+            });
+        }
+
+        #[test]
         fn test_multi_cpu() {
             let bionic = UbuntuDiskConfig::new(BIONIC_IMAGE_NAME.to_string());
             let guest = Guest::new(Box::new(bionic));

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -41,6 +41,7 @@ serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 signal-hook = "0.3.9"
 thiserror = "1.0"
+uuid = "0.8"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "master" }


### PR DESCRIPTION
Partially fixes #2178.

This PR enabled ACPI on AArch64 and integrated with EDK2.

What's included:
- Updating some AML and FDT code
- Introducing EDK2 in CI
- Adding a basic test case

The PR is not totally ready. There are some issues to fix and discuss. Please see my comments.