### PR TITLE
ci: Add OVS-DPDK integration test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,7 @@ pipeline{
 								timeout(time: 1, unit: 'HOURS')
 							}
 							steps {
+								sh "sudo modprobe openvswitch"
 								sh "scripts/dev_cli.sh tests --integration"
 							}
 						}
@@ -69,6 +70,7 @@ pipeline{
 								timeout(time: 1, unit: 'HOURS')
 							}
 							steps {
+								sh "sudo modprobe openvswitch"
 								sh "scripts/dev_cli.sh tests --integration"
 							}
 						}
@@ -98,6 +100,7 @@ pipeline{
 								timeout(time: 1, unit: 'HOURS')
 							}
 							steps {
+								sh "sudo modprobe openvswitch"
 								sh "scripts/dev_cli.sh tests --integration --libc musl"
 							}
 						}

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -227,6 +227,13 @@ sudo bash -c "echo 1000000 > /sys/kernel/mm/ksm/pages_to_scan"
 sudo bash -c "echo 10 > /sys/kernel/mm/ksm/sleep_millisecs"
 sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 
+# Setup ovs-dpdk
+echo 2048 | sudo tee /proc/sys/vm/nr_hugepages
+service openvswitch-switch start
+ovs-vsctl init
+ovs-vsctl set Open_vSwitch . other_config:dpdk-init=true
+service openvswitch-switch restart
+
 time cargo test $features_test_fdt "tests::parallel::$test_filter"
 RES=$?
 echo "Integration test on FDT finished with result $RES."

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -198,9 +198,15 @@ sudo bash -c "echo 1000000 > /sys/kernel/mm/ksm/pages_to_scan"
 sudo bash -c "echo 10 > /sys/kernel/mm/ksm/sleep_millisecs"
 sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 
-# test_vfio relies on hugepages
-echo 4096 | sudo tee /proc/sys/vm/nr_hugepages
+# Both test_vfio and ovs-dpdk rely on hugepages
+echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
+
+# Setup ovs-dpdk
+service openvswitch-switch start
+ovs-vsctl init
+ovs-vsctl set Open_vSwitch . other_config:dpdk-init=true
+service openvswitch-switch restart
 
 export RUST_BACKTRACE=1
 time cargo test $features_test "tests::parallel::$test_filter"


### PR DESCRIPTION
In order to avoid regression regarding OVS-DPDK support, a new
integration test is added. This test consists of running two VMs, both
attached to a distinct OVS port, where both ports are connected to an
OVS bridge. Once the VM are running, the test validates the connection
between the two VMs works correctly.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>