### PR TITLE
arch: Bump vm-fdt from 13ab882 to 956b5a5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "vm-fdt"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vm-fdt?branch=master#13ab882e2f8387753064351c69fbe35c422b448b"
+source = "git+https://github.com/rust-vmm/vm-fdt?branch=master#956b5a5ea1d7b92026e82bef2aa6a85b0c2200b5"
 
 [[package]]
 name = "vm-memory"

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -16,7 +16,7 @@ use super::super::InitramfsConfig;
 use super::get_fdt_addr;
 use super::gic::GicDevice;
 use super::layout::{
-    FDT_MAX_SIZE, IRQ_BASE, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START, PCI_MMCONFIG_SIZE,
+    IRQ_BASE, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START, PCI_MMCONFIG_SIZE,
     PCI_MMCONFIG_START,
 };
 use vm_fdt::{FdtWriter, FdtWriterResult};
@@ -107,7 +107,7 @@ pub fn create_fdt<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHash
     // End Header node.
     fdt.end_node(root_node)?;
 
-    let fdt_final = fdt.finish(FDT_MAX_SIZE)?;
+    let fdt_final = fdt.finish()?;
 
     Ok(fdt_final)
 }


### PR DESCRIPTION
Replaces https://github.com/cloud-hypervisor/cloud-hypervisor/pull/2684.

Interface of vm-fdt changed.
Updated aarch64 code to adapt.
