### PR TITLE
Refactor GIC (AArch64) related source code

### DIFF
--- a/arch/src/aarch64/gic/gicv3.rs
+++ b/arch/src/aarch64/gic/gicv3.rs
@@ -5,11 +5,14 @@ pub mod kvm {
     use crate::aarch64::gic::dist_regs::{get_dist_regs, read_ctlr, set_dist_regs, write_ctlr};
     use crate::aarch64::gic::icc_regs::{get_icc_regs, set_icc_regs};
     use crate::aarch64::gic::kvm::{save_pending_tables, KvmGicDevice};
-    use crate::aarch64::gic::redist_regs::{get_redist_regs, set_redist_regs};
+    use crate::aarch64::gic::redist_regs::{
+        construct_gicr_typers, get_redist_regs, set_redist_regs,
+    };
     use crate::aarch64::gic::GicDevice;
     use crate::layout;
     use anyhow::anyhow;
     use hypervisor::kvm::kvm_bindings;
+    use hypervisor::CpuState;
     use std::any::Any;
     use std::convert::TryInto;
     use std::sync::Arc;
@@ -165,7 +168,8 @@ pub mod kvm {
             self.vcpu_count
         }
 
-        fn set_gicr_typers(&mut self, gicr_typers: Vec<u64>) {
+        fn set_gicr_typers(&mut self, vcpu_states: &[CpuState]) {
+            let gicr_typers = construct_gicr_typers(vcpu_states);
             self.gicr_typers = gicr_typers;
         }
 

--- a/arch/src/aarch64/gic/gicv3_its.rs
+++ b/arch/src/aarch64/gic/gicv3_its.rs
@@ -10,6 +10,7 @@ pub mod kvm {
     use crate::aarch64::gic::kvm::KvmGicDevice;
     use crate::aarch64::gic::{Error, GicDevice};
     use hypervisor::kvm::kvm_bindings;
+    use hypervisor::CpuState;
 
     pub struct KvmGicV3Its {
         /// The hypervisor agnostic device
@@ -70,7 +71,7 @@ pub mod kvm {
             self.vcpu_count
         }
 
-        fn set_gicr_typers(&mut self, _gicr_typers: Vec<u64>) {}
+        fn set_gicr_typers(&mut self, _vcpu_states: &[CpuState]) {}
 
         fn as_any_concrete_mut(&mut self) -> &mut dyn Any {
             self

--- a/arch/src/aarch64/gic/mod.rs
+++ b/arch/src/aarch64/gic/mod.rs
@@ -10,6 +10,7 @@ pub mod redist_regs;
 pub use self::dist_regs::{get_dist_regs, read_ctlr, set_dist_regs, write_ctlr};
 pub use self::icc_regs::{get_icc_regs, set_icc_regs};
 pub use self::redist_regs::{get_redist_regs, set_redist_regs};
+use hypervisor::CpuState;
 use std::any::Any;
 use std::result;
 use std::sync::Arc;
@@ -58,7 +59,7 @@ pub trait GicDevice: Send {
     }
 
     /// Get the values of GICR_TYPER for each vCPU.
-    fn set_gicr_typers(&mut self, gicr_typers: Vec<u64>);
+    fn set_gicr_typers(&mut self, vcpu_states: &[CpuState]);
 
     /// Downcast the trait object to its concrete type.
     fn as_any_concrete_mut(&mut self) -> &mut dyn Any;

--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -4,8 +4,9 @@
 
 use super::interrupt_controller::{Error, InterruptController};
 extern crate arch;
+use arch::aarch64::gic::GicDevice;
 use std::result;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceConfig, InterruptSourceGroup,
     LegacyIrqSourceConfig, MsiIrqGroupConfig,
@@ -26,6 +27,7 @@ pub const IRQ_LEGACY_COUNT: usize = 32;
 //   2. Move this file and ioapic.rs to arch/, as they are architecture specific.
 pub struct Gic {
     interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+    gic_device: Option<Arc<Mutex<Box<dyn GicDevice>>>>,
 }
 
 impl Gic {
@@ -42,7 +44,16 @@ impl Gic {
 
         Ok(Gic {
             interrupt_source_group,
+            gic_device: None,
         })
+    }
+
+    pub fn set_gic_device(&mut self, gic_device: Arc<Mutex<Box<dyn GicDevice>>>) {
+        self.gic_device = Some(gic_device);
+    }
+
+    pub fn get_gic_device(&self) -> Option<&Arc<Mutex<Box<dyn GicDevice>>>> {
+        self.gic_device.as_ref()
     }
 }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1257,14 +1257,6 @@ impl DeviceManager {
         self.interrupt_controller.as_ref()
     }
 
-    #[cfg(target_arch = "aarch64")]
-    pub fn enable_interrupt_controller(&self) -> DeviceManagerResult<()> {
-        if let Some(interrupt_controller) = &self.interrupt_controller {
-            interrupt_controller.lock().unwrap().enable().unwrap();
-        }
-        Ok(())
-    }
-
     #[cfg(target_arch = "x86_64")]
     fn add_interrupt_controller(
         &mut self,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1262,6 +1262,11 @@ impl DeviceManager {
     }
 
     #[cfg(target_arch = "aarch64")]
+    pub fn get_interrupt_controller(&mut self) -> Option<&Arc<Mutex<gic::Gic>>> {
+        self.interrupt_controller.as_ref()
+    }
+
+    #[cfg(target_arch = "aarch64")]
     pub fn set_gic_device_entity(&mut self, device_entity: Arc<Mutex<Box<dyn GicDevice>>>) {
         self.gic_device_entity = Some(device_entity);
     }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1044,7 +1044,11 @@ impl Vm {
         self.device_manager
             .lock()
             .unwrap()
-            .set_gic_device_entity(Arc::new(Mutex::new(gic_device)));
+            .get_interrupt_controller()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .set_gic_device(Arc::new(Mutex::new(gic_device)));
 
         self.device_manager
             .lock()
@@ -1865,7 +1869,11 @@ impl Vm {
             self.device_manager
                 .lock()
                 .unwrap()
-                .get_gic_device_entity()
+                .get_interrupt_controller()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .get_gic_device()
                 .unwrap()
                 .lock()
                 .unwrap()
@@ -1898,7 +1906,11 @@ impl Vm {
         self.device_manager
             .lock()
             .unwrap()
-            .set_gic_device_entity(Arc::new(Mutex::new(gic_device)));
+            .get_interrupt_controller()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .set_gic_device(Arc::new(Mutex::new(gic_device)));
 
         // Here we prepare the GICR_TYPER registers from the restored vCPU states.
         self.device_manager
@@ -1911,7 +1923,11 @@ impl Vm {
             self.device_manager
                 .lock()
                 .unwrap()
-                .get_gic_device_entity()
+                .get_interrupt_controller()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .get_gic_device()
                 .unwrap()
                 .lock()
                 .unwrap()


### PR DESCRIPTION
This PR refactored the GIC (Generic Interrupt Controller) related code in `vmm/` (mainly `DeviceManager`)  and `arch/` for better design.

Issues to resolve:
- An AArch64 GIC device instance was held in DeviceManager, it's better to move it somewhere architecture specific;
- A function for calculating `gicr-typer` was also added in DeviceManager, but in fact it is totally arch specific and it has nothing with DeviceManager.