### PR TITLE
hypervisor: tdx: Unconditionally enable TDX debug

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -373,7 +373,7 @@ impl vm::Vm for KvmVm {
         let data = TdxInitVm {
             max_vcpus,
             reserved: 0,
-            attributes: 0,
+            attributes: 1, // TDX1_TD_ATTRIBUTE_DEBUG,
             cpuid: cpuid.as_fam_struct_ptr() as u64,
         };
 


### PR DESCRIPTION
For now enable the TDX attribute for TDX debug.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>