### PR TITLE
vmm: tdx: Clear unsupported KVM PV features

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -555,6 +555,8 @@ impl Vm {
             hypervisor,
             seccomp_action.clone(),
             vm_ops,
+            #[cfg(feature = "tdx")]
+            config.lock().unwrap().tdx.is_some(),
         )
         .map_err(Error::CpuManager)?;
 


### PR DESCRIPTION
This matches with the features that QEMU clears as they are not
supported with TDX.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>