### PR TITLE
tests: Re-enable test_ovs_dpdk

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5272,7 +5272,7 @@ mod tests {
                 let guest_ip = guest1.network.guest_ip.clone();
                 thread::spawn(move || {
                     ssh_command_ip(
-                        "iperf3 -s -p 4444",
+                        "nc -l 12345",
                         &guest_ip,
                         DEFAULT_SSH_RETRIES,
                         DEFAULT_SSH_TIMEOUT,
@@ -5315,9 +5315,7 @@ mod tests {
                     .unwrap());
 
                 // Check the connection works properly between the two VMs
-                assert!(guest2
-                    .ssh_command_ok("iperf3 -c 172.100.0.1 -t 10 -p 4444")
-                    .unwrap());
+                assert!(guest2.ssh_command_ok("nc -vz 172.100.0.1 12345").unwrap());
             });
 
             let _ = child1.kill();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5205,7 +5205,6 @@ mod tests {
         }
 
         #[test]
-        #[ignore]
         fn test_ovs_dpdk() {
             // Create OVS-DPDK bridge and ports
             std::process::Command::new("bash")
@@ -5242,7 +5241,8 @@ mod tests {
             let guest1 = Guest::new(Box::new(focal1));
             let mut child1 = GuestCommand::new(&guest1)
                 .args(&["--cpus", "boot=2"])
-                .args(&["--memory", "size=1G,shared=on"])
+                .args(&["--memory", "size=0,shared=on"])
+                .args(&["--memory-zone", "id=mem0,size=1G,shared=on,host_numa_node=0"])
                 .args(&["--kernel", direct_kernel_boot_path().to_str().unwrap()])
                 .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
@@ -5291,7 +5291,8 @@ mod tests {
             let guest2 = Guest::new(Box::new(focal2));
             let mut child2 = GuestCommand::new(&guest2)
                 .args(&["--cpus", "boot=2"])
-                .args(&["--memory", "size=1G,shared=on"])
+                .args(&["--memory", "size=0,shared=on"])
+                .args(&["--memory-zone", "id=mem0,size=1G,shared=on,host_numa_node=0"])
                 .args(&["--kernel", direct_kernel_boot_path().to_str().unwrap()])
                 .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5217,17 +5217,17 @@ mod tests {
             std::process::Command::new("bash")
                 .args(&[
                     "-c",
-                    "ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuser",
+                    "ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient1",
                 ])
                 .status()
-                .expect("Expected 'ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuser' to work");
+                .expect("Expected 'ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient1' to work");
             std::process::Command::new("bash")
                 .args(&[
                     "-c",
-                    "ovs-vsctl add-port ovsbr0 vhost-user2 -- set Interface vhost-user2 type=dpdkvhostuser",
+                    "ovs-vsctl add-port ovsbr0 vhost-user2 -- set Interface vhost-user2 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient2",
                 ])
                 .status()
-                .expect("Expected 'ovs-vsctl add-port ovsbr0 vhost-user2 -- set Interface vhost-user2 type=dpdkvhostuser' to work");
+                .expect("Expected 'ovs-vsctl add-port ovsbr0 vhost-user2 -- set Interface vhost-user2 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient2' to work");
             std::process::Command::new("bash")
                 .args(&["-c", "ip link set up dev ovsbr0"])
                 .status()
@@ -5246,7 +5246,7 @@ mod tests {
                 .args(&["--kernel", direct_kernel_boot_path().to_str().unwrap()])
                 .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
-                .args(&["--net", guest1.default_net_string().as_str(), "vhost_user=true,socket=/var/run/openvswitch/vhost-user1,num_queues=2,queue_size=256,vhost_mode=client"])
+                .args(&["--net", guest1.default_net_string().as_str(), "vhost_user=true,socket=/tmp/dpdkvhostclient1,num_queues=2,queue_size=256,vhost_mode=server"])
                 .capture_output()
                 .spawn()
                 .unwrap();
@@ -5296,7 +5296,7 @@ mod tests {
                 .args(&["--kernel", direct_kernel_boot_path().to_str().unwrap()])
                 .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
-                .args(&["--net", guest2.default_net_string().as_str(), "vhost_user=true,socket=/var/run/openvswitch/vhost-user2,num_queues=2,queue_size=256,vhost_mode=client"])
+                .args(&["--net", guest2.default_net_string().as_str(), "vhost_user=true,socket=/tmp/dpdkvhostclient2,num_queues=2,queue_size=256,vhost_mode=server"])
                 .capture_output()
                 .spawn()
                 .unwrap();


### PR DESCRIPTION
Enable `test_ovs_dpdk` now that it's been fixed by assigning the VMs to NUMA node 0.
Also improves the test by using OVS in client mode since server mode is deprecated, along with using `netcat` to simplify the validation about connectivity being functional.