### PR TITLE
virtio-devices: Update seccomp filters for vhost-user-net control queue

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -348,6 +348,7 @@ fn virtio_vhost_net_ctl_thread_rules() -> Vec<SyscallRuleSet> {
         allow_syscall(libc::SYS_munmap),
         allow_syscall(libc::SYS_madvise),
         allow_syscall(libc::SYS_read),
+        allow_syscall(libc::SYS_rt_sigprocmask),
         allow_syscall(libc::SYS_sigaltstack),
         allow_syscall(libc::SYS_write),
     ]


### PR DESCRIPTION
The control queue was missing rt_sigprocmask syscall, which was causing
a crash when the VM was shutdown.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>