### PR TITLE
hypervisor: Fix MSHV set_xsave API call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
 [[package]]
 name = "mshv-bindings"
 version = "0.1.0"
-source = "git+https://github.com/cloud-hypervisor/mshv?branch=master#936e2e34af0af50f4383ab8a208e03dfba7ed206"
+source = "git+https://github.com/cloud-hypervisor/mshv?branch=master#1024e9a821d33079452c20477b6ecb976ff795ad"
 dependencies = [
  "libc",
  "serde",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "mshv-ioctls"
 version = "0.1.0"
-source = "git+https://github.com/cloud-hypervisor/mshv?branch=master#936e2e34af0af50f4383ab8a208e03dfba7ed206"
+source = "git+https://github.com/cloud-hypervisor/mshv?branch=master#1024e9a821d33079452c20477b6ecb976ff795ad"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -473,7 +473,7 @@ impl cpu::Vcpu for MshvVcpu {
     ///
     fn set_xsave(&self, xsave: &Xsave) -> cpu::Result<()> {
         self.fd
-            .set_xsave(*xsave)
+            .set_xsave(xsave)
             .map_err(|e| cpu::HypervisorCpuError::SetXsaveState(e.into()))
     }
     ///


### PR DESCRIPTION
MSHV set_xsave got changed to fix the Snapshot and restore issue.
This patch fixes the API call.

Signed-off-by: Muminul Islam <muislam@microsoft.com>