### PR TITLE
Vhost-user-blk socket reconnection

### DIFF
--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -15,6 +15,7 @@ use vhost::vhost_user::message::VhostUserVirtioFeatures;
 use vhost::vhost_user::Master;
 use vhost::Error as VhostError;
 use vm_memory::{Error as MmapError, GuestAddressSpace, GuestMemoryAtomic};
+use vm_virtio::Error as VirtioError;
 use vmm_sys_util::eventfd::EventFd;
 use vu_common_ctrl::{connect_vhost_user, reinitialize_vhost_user};
 
@@ -111,6 +112,8 @@ pub enum Error {
     MissingRegionFd,
     /// Missing IrqFd
     MissingIrqFd,
+    /// Failed getting the available index.
+    GetAvailableIndex(VirtioError),
 }
 type Result<T> = std::result::Result<T, Error>;
 

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -143,8 +143,13 @@ pub fn setup_vhost_user(
 
         vu.set_vring_addr(queue_index, &config_data)
             .map_err(Error::VhostUserSetVringAddr)?;
-        vu.set_vring_base(queue_index, 0u16)
-            .map_err(Error::VhostUserSetVringBase)?;
+        vu.set_vring_base(
+            queue_index,
+            queue
+                .avail_index_from_memory(mem)
+                .map_err(Error::GetAvailableIndex)?,
+        )
+        .map_err(Error::VhostUserSetVringBase)?;
 
         if let Some(eventfd) = virtio_interrupt.notifier(&VirtioInterruptType::Queue, Some(&queue))
         {


### PR DESCRIPTION
Based on the vhost-user-net reconnection implementation  #2694, this PR enables the socket reconnection support for vhost-user-blk backends. 

I tested it with both QEMU vhost-user-blk daemon and cloud-hypervisor vhost-user-blk daemon. If there is no inflight I/O requests in the virtqueue when crashing, the daemons work properly after reconnection.