### PR TITLE
ci: Cleanup and factorize a few functions in the integration tests

### DIFF
--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -11,6 +11,7 @@ use std::net::TcpListener;
 use std::net::TcpStream;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
+use std::process::ExitStatus;
 use std::str::FromStr;
 use std::thread;
 use vmm_sys_util::tempdir::TempDir;
@@ -588,4 +589,11 @@ pub fn ssh_command_ip(
         retries,
         timeout,
     )
+}
+
+pub fn exec_host_command_status(command: &str) -> ExitStatus {
+    std::process::Command::new("bash")
+        .args(&["-c", command])
+        .status()
+        .expect(&format!("Expected '{}' to run", command))
 }

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -11,7 +11,7 @@ use std::net::TcpListener;
 use std::net::TcpStream;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
-use std::process::ExitStatus;
+use std::process::{ExitStatus, Output};
 use std::str::FromStr;
 use std::thread;
 use vmm_sys_util::tempdir::TempDir;
@@ -595,5 +595,12 @@ pub fn exec_host_command_status(command: &str) -> ExitStatus {
     std::process::Command::new("bash")
         .args(&["-c", command])
         .status()
+        .expect(&format!("Expected '{}' to run", command))
+}
+
+pub fn exec_host_command_output(command: &str) -> Output {
+    std::process::Command::new("bash")
+        .args(&["-c", command])
+        .output()
         .expect(&format!("Expected '{}' to run", command))
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -964,20 +964,14 @@ mod tests {
             guest.wait_vm_boot(None).unwrap();
 
             if let Some(tap_name) = tap {
-                let tap_count = std::process::Command::new("bash")
-                    .arg("-c")
-                    .arg(format!("ip link | grep -c {}", tap_name))
-                    .output()
-                    .expect("Expected checking of tap count to succeed");
+                let tap_count =
+                    exec_host_command_output(&format!("ip link | grep -c {}", tap_name));
                 assert_eq!(String::from_utf8_lossy(&tap_count.stdout).trim(), "1");
             }
 
             if let Some(host_mac) = tap {
-                let mac_count = std::process::Command::new("bash")
-                    .arg("-c")
-                    .arg(format!("ip link | grep -c {}", host_mac))
-                    .output()
-                    .expect("Expected checking of host mac to succeed");
+                let mac_count =
+                    exec_host_command_output(&format!("ip link | grep -c {}", host_mac));
                 assert_eq!(String::from_utf8_lossy(&mac_count.stdout).trim(), "1");
             }
 
@@ -2740,11 +2734,7 @@ mod tests {
             let r = std::panic::catch_unwind(|| {
                 guest.wait_vm_boot(None).unwrap();
 
-                let tap_count = std::process::Command::new("bash")
-                    .arg("-c")
-                    .arg("ip link | grep -c mytap1")
-                    .output()
-                    .expect("Expected checking of tap count to succeed");
+                let tap_count = exec_host_command_output("ip link | grep -c mytap1");
                 assert_eq!(String::from_utf8_lossy(&tap_count.stdout).trim(), "1");
 
                 // 3 network interfaces + default localhost ==> 4 interfaces

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -643,10 +643,11 @@ mod tests {
             thread::sleep(std::time::Duration::new(10, 0));
 
             // Write something to vsock from the host
-            exec_host_command_status(&format!(
+            assert!(exec_host_command_status(&format!(
                 "echo -e \"CONNECT 16\\nHelloWorld!\" | socat - UNIX-CONNECT:{}",
                 socket
-            ));
+            ))
+            .success());
 
             // Wait for the thread to terminate.
             listen_socat.join().unwrap();
@@ -1821,34 +1822,34 @@ mod tests {
     // We reserve a different IP class for it: 172.18.0.0/24.
     fn setup_vfio_network_interfaces() {
         // 'vfio-br0'
-        exec_host_command_status("sudo ip link add name vfio-br0 type bridge");
-        exec_host_command_status("sudo ip link set vfio-br0 up");
-        exec_host_command_status("sudo ip addr add 172.18.0.1/24 dev vfio-br0");
+        assert!(exec_host_command_status("sudo ip link add name vfio-br0 type bridge").success());
+        assert!(exec_host_command_status("sudo ip link set vfio-br0 up").success());
+        assert!(exec_host_command_status("sudo ip addr add 172.18.0.1/24 dev vfio-br0").success());
         // 'vfio-tap0'
-        exec_host_command_status("sudo ip tuntap add vfio-tap0 mode tap");
-        exec_host_command_status("sudo ip link set vfio-tap0 master vfio-br0");
-        exec_host_command_status("sudo ip link set vfio-tap0 up");
+        assert!(exec_host_command_status("sudo ip tuntap add vfio-tap0 mode tap").success());
+        assert!(exec_host_command_status("sudo ip link set vfio-tap0 master vfio-br0").success());
+        assert!(exec_host_command_status("sudo ip link set vfio-tap0 up").success());
         // 'vfio-tap1'
-        exec_host_command_status("sudo ip tuntap add vfio-tap1 mode tap");
-        exec_host_command_status("sudo ip link set vfio-tap1 master vfio-br0");
-        exec_host_command_status("sudo ip link set vfio-tap1 up");
+        assert!(exec_host_command_status("sudo ip tuntap add vfio-tap1 mode tap").success());
+        assert!(exec_host_command_status("sudo ip link set vfio-tap1 master vfio-br0").success());
+        assert!(exec_host_command_status("sudo ip link set vfio-tap1 up").success());
         // 'vfio-tap2'
-        exec_host_command_status("sudo ip tuntap add vfio-tap2 mode tap");
-        exec_host_command_status("sudo ip link set vfio-tap2 master vfio-br0");
-        exec_host_command_status("sudo ip link set vfio-tap2 up");
+        assert!(exec_host_command_status("sudo ip tuntap add vfio-tap2 mode tap").success());
+        assert!(exec_host_command_status("sudo ip link set vfio-tap2 master vfio-br0").success());
+        assert!(exec_host_command_status("sudo ip link set vfio-tap2 up").success());
         // 'vfio-tap3'
-        exec_host_command_status("sudo ip tuntap add vfio-tap3 mode tap");
-        exec_host_command_status("sudo ip link set vfio-tap3 master vfio-br0");
-        exec_host_command_status("sudo ip link set vfio-tap3 up");
+        assert!(exec_host_command_status("sudo ip tuntap add vfio-tap3 mode tap").success());
+        assert!(exec_host_command_status("sudo ip link set vfio-tap3 master vfio-br0").success());
+        assert!(exec_host_command_status("sudo ip link set vfio-tap3 up").success());
     }
 
     // Tear VFIO test network down
     fn cleanup_vfio_network_interfaces() {
-        exec_host_command_status("sudo ip link del vfio-br0");
-        exec_host_command_status("sudo ip link del vfio-tap0");
-        exec_host_command_status("sudo ip link del vfio-tap1");
-        exec_host_command_status("sudo ip link del vfio-tap2");
-        exec_host_command_status("sudo ip link del vfio-tap3");
+        assert!(exec_host_command_status("sudo ip link del vfio-br0").success());
+        assert!(exec_host_command_status("sudo ip link del vfio-tap0").success());
+        assert!(exec_host_command_status("sudo ip link del vfio-tap1").success());
+        assert!(exec_host_command_status("sudo ip link del vfio-tap2").success());
+        assert!(exec_host_command_status("sudo ip link del vfio-tap3").success());
     }
 
     mod parallel {
@@ -5105,13 +5106,14 @@ mod tests {
         #[test]
         fn test_ovs_dpdk() {
             // Create OVS-DPDK bridge and ports
-            exec_host_command_status(
+            assert!(exec_host_command_status(
                 "ovs-vsctl add-br ovsbr0 -- set bridge ovsbr0 datapath_type=netdev",
-            );
-            exec_host_command_status("ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient1");
-            exec_host_command_status("ovs-vsctl add-port ovsbr0 vhost-user2 -- set Interface vhost-user2 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient2");
-            exec_host_command_status("ip link set up dev ovsbr0");
-            exec_host_command_status("service openvswitch-switch restart");
+            )
+            .success());
+            assert!(exec_host_command_status("ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient1").success());
+            assert!(exec_host_command_status("ovs-vsctl add-port ovsbr0 vhost-user2 -- set Interface vhost-user2 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient2").success());
+            assert!(exec_host_command_status("ip link set up dev ovsbr0").success());
+            assert!(exec_host_command_status("service openvswitch-switch restart").success());
 
             let focal1 = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
             let guest1 = Guest::new(Box::new(focal1));
@@ -5194,7 +5196,7 @@ mod tests {
                 guest2.ssh_command("nc -vz 172.100.0.1 12345").unwrap();
 
                 // Remove one of the two ports from the OVS bridge
-                exec_host_command_status("ovs-vsctl del-port vhost-user1");
+                assert!(exec_host_command_status("ovs-vsctl del-port vhost-user1").success());
 
                 // Spawn a new netcat listener in the first VM
                 let guest_ip = guest1.network.guest_ip.clone();
@@ -5212,7 +5214,7 @@ mod tests {
                 assert!(guest2.ssh_command("nc -vz 172.100.0.1 12345").is_err());
 
                 // Add the OVS port back
-                exec_host_command_status("ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient1");
+                assert!(exec_host_command_status("ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient1").success());
 
                 // And finally check the connection is functional again
                 guest2.ssh_command("nc -vz 172.100.0.1 12345").unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -643,17 +643,10 @@ mod tests {
             thread::sleep(std::time::Duration::new(10, 0));
 
             // Write something to vsock from the host
-            Command::new("bash")
-                .arg("-c")
-                .arg(
-                    format!(
-                        "echo -e \"CONNECT 16\\nHelloWorld!\" | socat - UNIX-CONNECT:{}",
-                        socket
-                    )
-                    .as_str(),
-                )
-                .output()
-                .unwrap();
+            exec_host_command_status(&format!(
+                "echo -e \"CONNECT 16\\nHelloWorld!\" | socat - UNIX-CONNECT:{}",
+                socket
+            ));
 
             // Wait for the thread to terminate.
             listen_socat.join().unwrap();
@@ -1828,114 +1821,34 @@ mod tests {
     // We reserve a different IP class for it: 172.18.0.0/24.
     fn setup_vfio_network_interfaces() {
         // 'vfio-br0'
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link add name vfio-br0 type bridge")
-            .output()
-            .expect("Failed to create 'vfio-br0'");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link set vfio-br0 up")
-            .output()
-            .expect("Failed to create 'vfio-br0'");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip addr add 172.18.0.1/24 dev vfio-br0")
-            .output()
-            .expect("Failed to create 'vfio-br0'");
+        exec_host_command_status("sudo ip link add name vfio-br0 type bridge");
+        exec_host_command_status("sudo ip link set vfio-br0 up");
+        exec_host_command_status("sudo ip addr add 172.18.0.1/24 dev vfio-br0");
         // 'vfio-tap0'
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip tuntap add vfio-tap0 mode tap")
-            .output()
-            .expect("Failed to create 'vfio-tap0'");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link set vfio-tap0 master vfio-br0")
-            .output()
-            .expect("Failed to create 'vfio-tap0'");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link set vfio-tap0 up")
-            .output()
-            .expect("Failed to create 'vfio-tap0'");
+        exec_host_command_status("sudo ip tuntap add vfio-tap0 mode tap");
+        exec_host_command_status("sudo ip link set vfio-tap0 master vfio-br0");
+        exec_host_command_status("sudo ip link set vfio-tap0 up");
         // 'vfio-tap1'
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip tuntap add vfio-tap1 mode tap")
-            .output()
-            .expect("Failed to create 'vfio-tap1'");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link set vfio-tap1 master vfio-br0")
-            .output()
-            .expect("Failed to create 'vfio-tap1'");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link set vfio-tap1 up")
-            .output()
-            .expect("Failed to create 'vfio-tap1'");
+        exec_host_command_status("sudo ip tuntap add vfio-tap1 mode tap");
+        exec_host_command_status("sudo ip link set vfio-tap1 master vfio-br0");
+        exec_host_command_status("sudo ip link set vfio-tap1 up");
         // 'vfio-tap2'
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip tuntap add vfio-tap2 mode tap")
-            .output()
-            .expect("Failed to create 'vfio-tap2'");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link set vfio-tap2 master vfio-br0")
-            .output()
-            .expect("Failed to create 'vfio-tap2'");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link set vfio-tap2 up")
-            .output()
-            .expect("Failed to create 'vfio-tap2'");
+        exec_host_command_status("sudo ip tuntap add vfio-tap2 mode tap");
+        exec_host_command_status("sudo ip link set vfio-tap2 master vfio-br0");
+        exec_host_command_status("sudo ip link set vfio-tap2 up");
         // 'vfio-tap3'
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip tuntap add vfio-tap3 mode tap")
-            .output()
-            .expect("Failed to create 'vfio-tap3'");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link set vfio-tap3 master vfio-br0")
-            .output()
-            .expect("Failed to create 'vfio-tap3'");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link set vfio-tap3 up")
-            .output()
-            .expect("Failed to create 'vfio-tap3'");
+        exec_host_command_status("sudo ip tuntap add vfio-tap3 mode tap");
+        exec_host_command_status("sudo ip link set vfio-tap3 master vfio-br0");
+        exec_host_command_status("sudo ip link set vfio-tap3 up");
     }
 
     // Tear VFIO test network down
     fn cleanup_vfio_network_interfaces() {
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link del vfio-br0")
-            .output()
-            .expect("Failed to delete 'vfio-br0'");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link del vfio-tap0")
-            .output()
-            .expect("Failed to delete ''");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link del vfio-tap1")
-            .output()
-            .expect("Failed to delete ''");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link del vfio-tap2")
-            .output()
-            .expect("Failed to delete ''");
-        Command::new("bash")
-            .arg("-c")
-            .arg("sudo ip link del vfio-tap3")
-            .output()
-            .expect("Failed to delete ''");
+        exec_host_command_status("sudo ip link del vfio-br0");
+        exec_host_command_status("sudo ip link del vfio-tap0");
+        exec_host_command_status("sudo ip link del vfio-tap1");
+        exec_host_command_status("sudo ip link del vfio-tap2");
+        exec_host_command_status("sudo ip link del vfio-tap3");
     }
 
     mod parallel {
@@ -5192,35 +5105,13 @@ mod tests {
         #[test]
         fn test_ovs_dpdk() {
             // Create OVS-DPDK bridge and ports
-            std::process::Command::new("bash")
-                .args(&[
-                    "-c",
-                    "ovs-vsctl add-br ovsbr0 -- set bridge ovsbr0 datapath_type=netdev",
-                ])
-                .status()
-                .expect("Expected 'ovs-vsctl add-br ovsbr0 -- set bridge ovsbr0 datapath_type=netdev' to work");
-            std::process::Command::new("bash")
-                .args(&[
-                    "-c",
-                    "ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient1",
-                ])
-                .status()
-                .expect("Expected 'ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient1' to work");
-            std::process::Command::new("bash")
-                .args(&[
-                    "-c",
-                    "ovs-vsctl add-port ovsbr0 vhost-user2 -- set Interface vhost-user2 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient2",
-                ])
-                .status()
-                .expect("Expected 'ovs-vsctl add-port ovsbr0 vhost-user2 -- set Interface vhost-user2 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient2' to work");
-            std::process::Command::new("bash")
-                .args(&["-c", "ip link set up dev ovsbr0"])
-                .status()
-                .expect("Expected 'ip link set up dev ovsbr0' to work");
-            std::process::Command::new("bash")
-                .args(&["-c", "service openvswitch-switch restart"])
-                .status()
-                .expect("Expected 'service openvswitch-switch restart' to work");
+            exec_host_command_status(
+                "ovs-vsctl add-br ovsbr0 -- set bridge ovsbr0 datapath_type=netdev",
+            );
+            exec_host_command_status("ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient1");
+            exec_host_command_status("ovs-vsctl add-port ovsbr0 vhost-user2 -- set Interface vhost-user2 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient2");
+            exec_host_command_status("ip link set up dev ovsbr0");
+            exec_host_command_status("service openvswitch-switch restart");
 
             let focal1 = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
             let guest1 = Guest::new(Box::new(focal1));
@@ -5303,10 +5194,7 @@ mod tests {
                 guest2.ssh_command("nc -vz 172.100.0.1 12345").unwrap();
 
                 // Remove one of the two ports from the OVS bridge
-                std::process::Command::new("bash")
-                    .args(&["-c", "ovs-vsctl del-port vhost-user1"])
-                    .status()
-                    .expect("Expected 'ovs-vsctl del-port vhost-user1' to work");
+                exec_host_command_status("ovs-vsctl del-port vhost-user1");
 
                 // Spawn a new netcat listener in the first VM
                 let guest_ip = guest1.network.guest_ip.clone();
@@ -5324,13 +5212,7 @@ mod tests {
                 assert!(guest2.ssh_command("nc -vz 172.100.0.1 12345").is_err());
 
                 // Add the OVS port back
-                std::process::Command::new("bash")
-                .args(&[
-                    "-c",
-                    "ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient1",
-                ])
-                .status()
-                .expect("Expected 'ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient1' to work");
+                exec_host_command_status("ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient1");
 
                 // And finally check the connection is functional again
                 guest2.ssh_command("nc -vz 172.100.0.1 12345").unwrap();


### PR DESCRIPTION
This PR simplifies a bit the integration tests code by replacing `ssh_command_ok()` with `ssh_command()` now that it returns an actual error if the exit code is not 0.
Also, it factorizes some code executing commands on the host, by introducing two new wrapper functions in `test_infra`.