### PR TITLE
tests: Re-enable virtiofsd tests

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -128,6 +128,20 @@ update_workloads() {
     cp $SRCDIR/resources/linux-config-aarch64 $LINUX_CUSTOM_DIR/.config
     build_custom_linux_kernel
 
+    VIRTIOFSD="$WORKLOADS_DIR/virtiofsd"
+    QEMU_DIR="qemu_build"
+
+    if [ ! -f "$VIRTIOFSD" ]; then
+        pushd $WORKLOADS_DIR
+        git clone --depth 1 "https://gitlab.com/virtio-fs/qemu.git" -b "qemu5.0-virtiofs-dax" $QEMU_DIR
+        pushd $QEMU_DIR
+        time ./configure --prefix=$PWD --target-list=aarch64-softmmu
+        time make virtiofsd -j `nproc`
+        cp virtiofsd $VIRTIOFSD || exit 1
+        popd
+        rm -rf $QEMU_DIR
+        popd
+    fi
 
     VIRTIOFSD_RS="$WORKLOADS_DIR/virtiofsd-rs"
     VIRTIOFSD_RS_DIR="virtiofsd_rs_build"

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -118,6 +118,19 @@ if [ -d "$LINUX_CUSTOM_DIR" ]; then
     rm -rf $LINUX_CUSTOM_DIR
 fi
 
+VIRTIOFSD="$WORKLOADS_DIR/virtiofsd"
+QEMU_DIR="qemu_build"
+if [ ! -f "$VIRTIOFSD" ]; then
+    pushd $WORKLOADS_DIR
+    git clone --depth 1 "https://gitlab.com/virtio-fs/qemu.git" -b "qemu5.0-virtiofs-dax" $QEMU_DIR
+    pushd $QEMU_DIR
+    time ./configure --prefix=$PWD --target-list=x86_64-softmmu
+    time make virtiofsd -j `nproc`
+    cp virtiofsd $VIRTIOFSD || exit 1
+    popd
+    rm -rf $QEMU_DIR
+    popd
+fi
 
 VIRTIOFSD_RS="$WORKLOADS_DIR/virtiofsd-rs"
 VIRTIOFSD_RS_DIR="virtiofsd_rs_build"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -93,6 +93,34 @@ mod tests {
         )
     }
 
+    fn prepare_virtiofsd(
+        tmp_dir: &TempDir,
+        shared_dir: &str,
+        cache: &str,
+    ) -> (std::process::Child, String) {
+        let mut workload_path = dirs::home_dir().unwrap();
+        workload_path.push("workloads");
+
+        let mut virtiofsd_path = workload_path;
+        virtiofsd_path.push("virtiofsd");
+        let virtiofsd_path = String::from(virtiofsd_path.to_str().unwrap());
+
+        let virtiofsd_socket_path =
+            String::from(tmp_dir.as_path().join("virtiofs.sock").to_str().unwrap());
+
+        // Start the daemon
+        let child = Command::new(virtiofsd_path.as_str())
+            .args(&[format!("--socket-path={}", virtiofsd_socket_path).as_str()])
+            .args(&["-o", format!("source={}", shared_dir).as_str()])
+            .args(&["-o", format!("cache={}", cache).as_str()])
+            .spawn()
+            .unwrap();
+
+        thread::sleep(std::time::Duration::new(10, 0));
+
+        (child, virtiofsd_socket_path)
+    }
+
     fn prepare_virtofsd_rs_daemon(
         tmp_dir: &TempDir,
         shared_dir: &str,
@@ -2598,6 +2626,21 @@ mod tests {
         }
 
         #[test]
+        fn test_virtio_fs_dax_on_default_cache_size() {
+            test_virtio_fs(true, None, "none", &prepare_virtiofsd, false)
+        }
+
+        #[test]
+        fn test_virtio_fs_dax_on_cache_size_1_gib() {
+            test_virtio_fs(true, Some(0x4000_0000), "none", &prepare_virtiofsd, false)
+        }
+
+        #[test]
+        fn test_virtio_fs_dax_off() {
+            test_virtio_fs(false, None, "none", &prepare_virtiofsd, false)
+        }
+
+        #[test]
         fn test_virtio_fs_dax_on_default_cache_size_w_virtiofsd_rs_daemon() {
             test_virtio_fs(true, None, "none", &prepare_virtofsd_rs_daemon, false)
         }
@@ -2616,6 +2659,18 @@ mod tests {
         #[test]
         fn test_virtio_fs_dax_off_w_virtiofsd_rs_daemon() {
             test_virtio_fs(false, None, "none", &prepare_virtofsd_rs_daemon, false)
+        }
+
+        #[test]
+        #[cfg(target_arch = "x86_64")]
+        fn test_virtio_fs_hotplug_dax_on() {
+            test_virtio_fs(true, None, "none", &prepare_virtiofsd, true)
+        }
+
+        #[test]
+        #[cfg(target_arch = "x86_64")]
+        fn test_virtio_fs_hotplug_dax_off() {
+            test_virtio_fs(false, None, "none", &prepare_virtiofsd, true)
         }
 
         #[test]


### PR DESCRIPTION
Re-enable virtiofsd testing now that issues with capstone repository
have been resolved.

This reverts commit a14c70019aad6ecb20e43d3146bff799d000ab7d.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>