### PR TITLE
Support vhost-user-fs socket reconnection handling

### DIFF
--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -247,6 +247,13 @@ impl VirtioDevice for Blk {
             acked_protocol_features: self.acked_protocol_features,
             socket_path: self.socket_path.clone(),
             server: false,
+            paused: None,
+            paused_sync: None,
+            slave_req_handler: None,
+            seccomp_action: None,
+            slave_thread: Arc::new(Mutex::new(None)),
+            id: self.id.clone(),
+            disconnect_evt: None,
         };
 
         let paused = self.common.paused.clone();

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -316,6 +316,13 @@ impl VirtioDevice for Net {
             acked_protocol_features: self.acked_protocol_features,
             socket_path: self.socket_path.clone(),
             server: self.server,
+            paused: None,
+            paused_sync: None,
+            slave_req_handler: None,
+            seccomp_action: None,
+            slave_thread: Arc::new(Mutex::new(None)),
+            id: self.id.clone(),
+            disconnect_evt: None,
         };
 
         let paused = self.common.paused.clone();


### PR DESCRIPTION
This PR enables virtio-fs backend socket reconnection based on shared socket reconnection code path proposed in PR #2694 .

- The re-establish of the slave communication channel is not supported yet. So the socket reconnection does not support virtiofsd with DAX enabled. I am developing to enable the re-establish of the slave channel on this branch.

- Inflight I/O tracking and restoring is not supported. 

- To make the restarted virtiofsd work normally after reconnection, the internal status of virtiofsd should also be recovered. This is not the work of cloud-hypervisor. If the virtio-fs daemon does not support saving or restoring its internal status, then a re-mount in guest after socket reconnection should be performed.

-  I tested the limited reconnection support in this commit with the C language version virtiofsd.

**Update:** 

The new second commit is pushed to this PR to support slave channel re-establishment.

The main idea of enabling the slave channel reconnection is to let the ReconnectEpollHandler thread spawn a new slave thread when doing reconnection and reinitialization of the master vhost-user channel.

Some new fields are added to the `struct ReconnectEpollHandler`, these fields are needed for the slave channel reconnection, as they are only used by vhost-user-fs, I simply set them to `None` for vhost-user-blk and vhost-user-net implementation.

To handle the quit of the old slave thread, the ReconnectEpollHandler thread will write a newly added `disconnect_evt` eventfd after the HUP is detected. A slave thread will exit after a `disconnect_evt` event is polled, and we should expect a new slave thread being created by the `setup_slave_channel` function.

Signed-off-by: Jiachen Zhang <zhangjiachen.jaycee@bytedance.com>