### PR TITLE
virtio-devices: vhost_user: Set NEED_REPLY when REPLY_ACK is supported

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vhost?branch=master#a8ff939161d41fc2f449b80e461d013c1e19f666"
+source = "git+https://github.com/rust-vmm/vhost?branch=master#e294ed66fcc12e033957f20034ae5fef5bb9eeac"
 dependencies = [
  "bitflags",
  "libc",


### PR DESCRIPTION
Now that vhost crate allows the caller to set the header flags, we can
set NEED_REPLY whenever the REPLY_ACK protocol feature is supported from
both ends.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>