### PR TITLE
deps: Update Cargo.lock to include uuid crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,6 +1041,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1298,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "thiserror",
+ "uuid",
  "versionize",
  "versionize_derive",
  "vfio-ioctls",


### PR DESCRIPTION
`Cargo.lock` should have been updated when the PR #2680 introduced the dependency onto the `uuid` crate. This PR is here to fix this.