### PR TITLE
AArch64: Remove hardcoded host IPA size

### DIFF
--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -100,4 +100,9 @@ pub trait Hypervisor: Send + Sync {
     /// Retrieve the list of MSRs supported by the hypervisor.
     ///
     fn get_msr_list(&self) -> Result<MsrList>;
+    #[cfg(target_arch = "aarch64")]
+    ///
+    /// Retrieve AArch64 host maximum IPA size supported by KVM.
+    ///
+    fn get_host_ipa_limit(&self) -> i32;
 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -584,6 +584,13 @@ impl hypervisor::Hypervisor for KvmHypervisor {
             .get_msr_index_list()
             .map_err(|e| hypervisor::HypervisorError::GetMsrList(e.into()))
     }
+    #[cfg(target_arch = "aarch64")]
+    ///
+    /// Retrieve AArch64 host maximum IPA size supported by KVM.
+    ///
+    fn get_host_ipa_limit(&self) -> i32 {
+        self.kvm.get_host_ipa_limit()
+    }
 }
 /// Vcpu struct for KVM
 pub struct KvmVcpu {


### PR DESCRIPTION
https://github.com/rust-vmm/kvm-ioctls/pull/94 has provided us with the ability to get `Host_IPA_Limit` for AArch64, and hence the current hardcoded host IPA size for AArch64 can be removed.