### PR TITLE
tests: Enable AArch64 API pause/resume test case

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3601,7 +3601,6 @@ mod tests {
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         // Start cloud-hypervisor with no VM parameters, only the API server running.
         // From the API: Create a VM, boot it and check that it looks as expected.
         // Then we pause the VM, check that it's no longer available.


### PR DESCRIPTION
We somehow both missed this one last time.... @michael2012z 