### PR TITLE
Unblock some vhost-user tests on AArch64

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2544,7 +2544,6 @@ mod tests {
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_vhost_user_net_host_mac() {
             test_vhost_user_net(None, 2, &prepare_vhost_user_net_daemon, true, false)
         }
@@ -2555,25 +2554,21 @@ mod tests {
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_vhost_user_blk_default() {
             test_vhost_user_blk(2, false, false, Some(&prepare_vubd))
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_vhost_user_blk_readonly() {
             test_vhost_user_blk(1, true, false, Some(&prepare_vubd))
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_vhost_user_blk_direct() {
             test_vhost_user_blk(1, false, true, Some(&prepare_vubd))
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_boot_from_vhost_user_blk_default() {
             test_boot_from_vhost_user_blk(1, false, false, Some(&prepare_vubd))
         }


### PR DESCRIPTION
Some vhost-user test cases used to be unstable in the early stage of AArch64 enabling.

But a recent test revealed good result. No failure was seen in 20 reruns.