### PR TITLE
Support vhost-user inflight I/O tracking shmfd transferring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vhost?branch=master#30ba3e7bbe9e0542cf480f44bc6845a8dbd2a6ba"
+source = "git+https://github.com/rust-vmm/vhost?branch=master#a8ff939161d41fc2f449b80e461d013c1e19f666"
 dependencies = [
  "bitflags",
  "libc",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vhost?branch=master#e5b930b73a47cbdd79858e2e68bcb57123d1c1f3"
+source = "git+https://github.com/rust-vmm/vhost?branch=master#a8ff939161d41fc2f449b80e461d013c1e19f666"
 dependencies = [
  "bitflags",
  "libc",

--- a/vhost_user_backend/src/lib.rs
+++ b/vhost_user_backend/src/lib.rs
@@ -959,6 +959,24 @@ impl<S: VhostUserBackend> VhostUserSlaveReqHandlerMut for VhostUserHandler<S> {
 
         Ok(())
     }
+
+    fn get_inflight_fd(
+        &mut self,
+        _: &vhost::vhost_user::message::VhostUserInflight,
+    ) -> std::result::Result<
+        (vhost::vhost_user::message::VhostUserInflight, i32),
+        vhost::vhost_user::Error,
+    > {
+        std::unimplemented!()
+    }
+
+    fn set_inflight_fd(
+        &mut self,
+        _: &vhost::vhost_user::message::VhostUserInflight,
+        _: std::fs::File,
+    ) -> std::result::Result<(), vhost::vhost_user::Error> {
+        std::unimplemented!()
+    }
 }
 
 impl<S: VhostUserBackend> Drop for VhostUserHandler<S> {

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -231,6 +231,7 @@ impl VirtioDevice for Blk {
             &interrupt_cb,
             backend_acked_features,
             &slave_req_handler,
+            None,
         )
         .map_err(ActivateError::VhostUserBlkSetup)?;
 
@@ -251,6 +252,7 @@ impl VirtioDevice for Blk {
             socket_path: self.socket_path.clone(),
             server: false,
             slave_req_handler: None,
+            inflight: None,
         };
 
         let paused = self.common.paused.clone();

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -452,6 +452,7 @@ impl VirtioDevice for Fs {
             &interrupt_cb,
             backend_acked_features,
             &slave_req_handler,
+            None,
         )
         .map_err(ActivateError::VhostUserFsSetup)?;
 
@@ -471,6 +472,7 @@ impl VirtioDevice for Fs {
             socket_path: self.socket_path.clone(),
             server: false,
             slave_req_handler,
+            inflight: None,
         };
 
         let paused = self.common.paused.clone();

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -300,6 +300,7 @@ impl VirtioDevice for Net {
             &interrupt_cb,
             backend_acked_features,
             &slave_req_handler,
+            None,
         )
         .map_err(ActivateError::VhostUserNetSetup)?;
 
@@ -320,6 +321,7 @@ impl VirtioDevice for Net {
             socket_path: self.socket_path.clone(),
             server: self.server,
             slave_req_handler: None,
+            inflight: None,
         };
 
         let paused = self.common.paused.clone();


### PR DESCRIPTION
The first commit supports inflight shmfd transferring, and the second commit enables this support for vhost-user-blk.