### PR TITLE
virtio-devices: vhost_user: Fix wrong naming regarding reconnection

### DIFF
--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -251,7 +251,7 @@ impl<S: VhostUserMasterReqHandler> EpollHelperHandler for VhostUserEpollHandler<
                 }
             }
             _ => {
-                error!("Unknown event for vhost-user reconnection thread");
+                error!("Unknown event for vhost-user thread");
                 return true;
             }
         }


### PR DESCRIPTION
Since the reconnection thread took on the responsibility to handle
backend initiated requests as well, the variable naming should reflect
this by avoiding the "reconnect" prefix.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>