### PR TITLE
Add log for FDT debugging on AArch64

### DIFF
--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -21,7 +21,9 @@ serde = {version = ">=1.0.27", features = ["rc"] }
 thiserror = "1.0"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vm-fdt = { git = "https://github.com/rust-vmm/vm-fdt", branch = "master" }
 vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+fdt_parser = { version = "0.1.3", package = 'fdt'}
+vm-fdt = { git = "https://github.com/rust-vmm/vm-fdt", branch = "master" }

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -18,6 +18,7 @@ use crate::DeviceType;
 use crate::GuestMemoryMmap;
 use crate::RegionType;
 use gic::GicDevice;
+use log::{log_enabled, Level};
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::ffi::CStr;
@@ -153,6 +154,10 @@ pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::Bui
         pci_space_address,
     )
     .map_err(|_| Error::SetupFdt)?;
+
+    if log_enabled!(Level::Debug) {
+        fdt::print_fdt(&fdt_final);
+    }
 
     fdt::write_fdt_to_memory(fdt_final, guest_mem).map_err(Error::WriteFdtToMemory)?;
 


### PR DESCRIPTION
To debug the FDT (Flattened Device Tree), we usually need to modify source code to save the generted DTB data to disk, and use `dtc` command to decode the binary file into a text file to analyze.

It would be ideal if the FDT content can be seen in log.

This commit makes it real by:
- Introducing `fdt` crate for parsing FDT.
- Printing the content of the FDT in tree view.

The parsing and printing only happen when Debug level logging enabled. With these log, debugging issues like https://github.com/cloud-hypervisor/cloud-hypervisor/pull/2762 would be convenient.