### PR TITLE
vmm: Fix format error info to correct device id

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2997,7 +2997,7 @@ impl DeviceManager {
                             std::io::ErrorKind::Other,
                             format!(
                                 "failed to translate addr 0x{:x} for device 00:{:02x}.0 {}",
-                                addr, pci_device_bdf, e
+                                addr, pci_device_bdf >> 3, e
                             ),
                         )
                     })


### PR DESCRIPTION
pci_device_bdf have already shift the device id since the 3 first bits are dedicated to the PCI function.
So we need to shift bdf to correct device id when formatting 00:{:02x}.0 info.

Signed-off-by: Dayu Liu <liu.dayu@zte.com.cn>