### PR TITLE
Jenkinsfile: Update the way to download private images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,6 +180,9 @@ pipeline{
 				}
 				stage ('Worker build - Windows guest') {
 					agent { node { label 'hirsute' } }
+					environment {
+        					AZURE_CONNECTION_STRING = credentials('46b4e7d6-315f-4cc1-8333-b58780863b9b')
+					}
 					stages {
 						stage ('Checkout') {
 							steps {
@@ -188,17 +191,10 @@ pipeline{
 						}
 						stage ('Download assets') {
 							steps {
+								sh "sudo apt install -y azure-cli"
 								sh "mkdir ${env.HOME}/workloads"
-								azureDownload(storageCredentialId: 'ch-image-store',
-											  containerName: 'private-images',
-											  includeFilesPattern: 'OVMF-4b47d0c6c8.fd',
-											  downloadType: 'container',
-											  downloadDirLoc: "${env.HOME}/workloads")
-								azureDownload(storageCredentialId: 'ch-image-store',
-											  containerName: 'private-images',
-											  includeFilesPattern: 'windows-server-2019.raw',
-											  downloadType: 'container',
-											  downloadDirLoc: "${env.HOME}/workloads")
+								sh 'az storage blob download --container-name private-images --file "$HOME/workloads/OVMF-4b47d0c6c8.fd" --name OVMF-4b47d0c6c8.fd --connection-string "$AZURE_CONNECTION_STRING"'
+								sh 'az storage blob download --container-name private-images --file "$HOME/workloads/windows-server-2019.raw" --name windows-server-2019.raw --connection-string "$AZURE_CONNECTION_STRING"'
 							}
 						}
 						stage ('Run Windows guest integration tests') {


### PR DESCRIPTION
Since we ran into issues while using the Azure credentials plugin for
Jenkins, let's rely directly on the Azure CLI to download the Windows
guest image along with the modified OVMF firmware.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>