### PR TITLE
tests: Fix virtio_balloon integration test

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4385,8 +4385,8 @@ mod tests {
                     "After deflating, balloon memory size is {} bytes",
                     deflated_balloon
                 );
-                // Verify the balloon size deflated by 10% at least
-                assert!(deflated_balloon > 0 && deflated_balloon < 1932735283);
+                // Verify the balloon size deflated
+                assert!(deflated_balloon < 2147483648);
             });
 
             let _ = child.kill();


### PR DESCRIPTION
The virtio_balloon test is a bit flaky since we can't really know how
much the balloon is gonna be deflated when the guest is under memory
pressure. That's why it's safer to simply check that the balloon is not
the initial size anymore.

One small detail, but we don't need to check for the balloon size to be
higher than 0 since the returned value is a u64.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>