### PR TITLE
vmm: Add I/O port range to PCI bus resources

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3779,6 +3779,10 @@ impl Aml for DeviceManager {
                     start_of_device_area,
                     end_of_device_area,
                 ),
+                #[cfg(target_arch = "x86_64")]
+                &aml::AddressSpace::new_io(0u16, 0x0cf7u16),
+                #[cfg(target_arch = "x86_64")]
+                &aml::AddressSpace::new_io(0x0d00u16, 0xffffu16),
             ]),
         );
         pci_dsdt_inner_data.push(&crs);


### PR DESCRIPTION
The Linux kernel expects that any PCI devices that advertise I/O bars
have use an address that is within the range advertised by the bus
itself. Unfortunately we were not advertising any I/O ports associated
with the PCI bus in the ACPI tables.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>