### PR TITLE
vmm: Refactor slightly 'vm_create', 'vm_boot', and 'control_loop'

### DIFF
--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -73,9 +73,6 @@ pub enum ApiError {
     /// The VM info is not available.
     VmInfo(VmError),
 
-    /// The VM config is missing.
-    VmMissingConfig,
-
     /// The VM could not be paused.
     VmPause(VmError),
 

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -64,9 +64,6 @@ pub enum ApiError {
     /// The VM could not boot.
     VmBoot(VmError),
 
-    /// The VM is already created.
-    VmAlreadyCreated,
-
     /// The VM could not be created.
     VmCreate(VmError),
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -355,6 +355,11 @@ impl Vmm {
     }
 
     fn vm_boot(&mut self) -> result::Result<(), VmError> {
+        // If we don't have a config, we can not boot a VM.
+        if self.vm_config.is_none() {
+            return Err(VmError::VmMissingConfig);
+        };
+
         // Create a new VM if we don't have one yet.
         if self.vm.is_none() {
             let exit_evt = self.exit_evt.try_clone().map_err(VmError::EventFdClone)?;
@@ -1169,14 +1174,6 @@ impl Vmm {
                                     sender.send(response).map_err(Error::ApiResponseSend)?;
                                 }
                                 ApiRequest::VmBoot(sender) => {
-                                    // If we don't have a config, we can not boot a VM.
-                                    if self.vm_config.is_none() {
-                                        sender
-                                            .send(Err(ApiError::VmMissingConfig))
-                                            .map_err(Error::ApiResponseSend)?;
-                                        continue;
-                                    }
-
                                     let response = self
                                         .vm_boot()
                                         .map_err(ApiError::VmBoot)

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -142,6 +142,9 @@ pub enum Error {
     /// Failed to join on vCPU threads
     ThreadCleanup(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
 
+    /// VM config is missing.
+    VmMissingConfig,
+
     /// VM is not created
     VmNotCreated,
 


### PR DESCRIPTION
Couple of refactoring to ensure all handlers for `ApiRequest` in `control_loop` are
consistent and minimum. Hope it makes the code simpler and read better.

No functional changes.

Signed-off-by: Bo Chen <chen.bo@intel.com>