### PR TITLE
Optimize ACPI on AArch64

### DIFF
--- a/.github/workflows/quality-aarch64.yaml
+++ b/.github/workflows/quality-aarch64.yaml
@@ -31,9 +31,31 @@ jobs:
             components: rustfmt, clippy
       - name: Formatting (rustfmt)
         run: cargo fmt -- --check
+
       - name: Clippy (kvm)
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: clippy
           args: --target=${{ matrix.target }} --no-default-features --features "kvm" -- -D warnings
+
+      - name: Clippy (kvm,acpi)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: clippy
+          args: --target=${{ matrix.target }} --no-default-features --features "kvm,acpi" -- -D warnings
+
+      - name: Clippy (all features,kvm)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: clippy
+          args: --target=${{ matrix.target }} --no-default-features --features "common,kvm" -- -D warnings
+
+      - name: Clippy (default)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: clippy
+          args: --target=${{ matrix.target }} -- -D warnings

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -46,10 +46,11 @@
 
 use vm_memory::GuestAddress;
 
-/// 0x0 ~ 0x400_0000 is reserved to uefi
+/// 0x0 ~ 0x40_0000 (4 MiB) is reserved to UEFI
+/// UEFI binary size is required less than 3 MiB, reserving 4 MiB is enough.
 pub const UEFI_START: u64 = 0x0;
 pub const MEM_UEFI_START: GuestAddress = GuestAddress(0);
-pub const UEFI_SIZE: u64 = 0x0400_0000;
+pub const UEFI_SIZE: u64 = 0x040_0000;
 
 /// Below this address will reside the GIC, above this address will reside the MMIO devices.
 pub const MAPPED_IO_START: u64 = 0x0900_0000;

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -88,7 +88,7 @@ pub fn configure_vcpu(
 pub fn arch_memory_regions(size: GuestUsize) -> Vec<(GuestAddress, usize, RegionType)> {
     // Normally UEFI should be loaded to a flash area at the beginning of memory.
     // But now flash memory type is not supported.
-    // As a workaround, we take 64 MiB memory from the main RAM for UEFI.
+    // As a workaround, we take 4 MiB memory from the main RAM for UEFI.
     // As a result, the RAM that the guest can see is less than what has been
     // assigned in command line, when ACPI and UEFI is enabled.
     let ram_deduction = if cfg!(feature = "acpi") {
@@ -98,7 +98,7 @@ pub fn arch_memory_regions(size: GuestUsize) -> Vec<(GuestAddress, usize, Region
     };
 
     vec![
-        // 0 ~ 64 MiB: Reserved for UEFI space
+        // 0 ~ 4 MiB: Reserved for UEFI space
         #[cfg(feature = "acpi")]
         (GuestAddress(0), layout::UEFI_SIZE as usize, RegionType::Ram),
         #[cfg(not(feature = "acpi"))]
@@ -107,7 +107,7 @@ pub fn arch_memory_regions(size: GuestUsize) -> Vec<(GuestAddress, usize, Region
             layout::UEFI_SIZE as usize,
             RegionType::Reserved,
         ),
-        // 64 MiB ~ 256 MiB: Gic and legacy devices
+        // 4 MiB ~ 256 MiB: Gic and legacy devices
         (
             GuestAddress(layout::UEFI_SIZE),
             (layout::MEM_32BIT_DEVICES_START.0 - layout::UEFI_SIZE) as usize,

--- a/docs/arm64.md
+++ b/docs/arm64.md
@@ -29,6 +29,16 @@ $ sudo apt-get update
 $ sudo apt-get install git build-essential m4 bison flex uuid-dev qemu-utils
 ```
 
+### Building Cloud Hypervisor
+
+```bash
+$ pushd $CLOUDH
+$ git clone https://github.com/cloud-hypervisor/cloud-hypervisor.git
+$ cd cloud-hypervisor
+$ cargo build
+$ popd
+```
+
 ### Disk image
 
 Download the Ubuntu cloud image and convert the image type.
@@ -43,16 +53,6 @@ $ popd
 ## UEFI booting
 
 This part introduces how to build EDK2 firmware and boot Cloud Hypervisor with it.
-
-### Building Cloud Hypervisor
-
-```bash
-$ pushd $CLOUDH
-$ git clone https://github.com/cloud-hypervisor/cloud-hypervisor.git
-$ cd cloud-hypervisor
-$ cargo build --no-default-features --features kvm,acpi
-$ popd
-```
 
 ### Building EDK2
 
@@ -95,16 +95,6 @@ $ popd
 ## Direct-kernel booting
 
 Alternativelly, you can build your own kernel for guest VM. This way, UEFI is not involved and ACPI cannot be enabled.
-
-### Building Cloud Hypervisor
-
-```bash
-$ pushd $CLOUDH
-$ git clone https://github.com/cloud-hypervisor/cloud-hypervisor.git
-$ cd cloud-hypervisor
-$ cargo build --no-default-features --features kvm
-$ popd
-```
 
 ### Building kernel
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1039,7 +1039,7 @@ mod tests {
             );
 
             // ACPI feature is needed.
-            #[cfg(feature = "acpi")]
+            #[cfg(all(target_arch = "x86_64", feature = "acpi"))]
             {
                 guest.enable_memory_hotplug();
 
@@ -1179,7 +1179,7 @@ mod tests {
             );
 
             // ACPI feature is needed.
-            #[cfg(feature = "acpi")]
+            #[cfg(all(target_arch = "x86_64", feature = "acpi"))]
             {
                 guest.enable_memory_hotplug();
 
@@ -1383,7 +1383,7 @@ mod tests {
             );
 
             // ACPI feature is needed.
-            #[cfg(feature = "acpi")]
+            #[cfg(all(target_arch = "x86_64", feature = "acpi"))]
             {
                 guest.enable_memory_hotplug();
 
@@ -4165,6 +4165,12 @@ mod tests {
             thread::sleep(std::time::Duration::new(20, 0));
 
             let r = std::panic::catch_unwind(|| {
+                // On AArch64 when acpi is enabled, there is a 4 MiB gap between the RAM
+                // that the VMM gives and the guest can see.
+                // This is a temporary solution, will be fixed in future.
+                #[cfg(all(target_arch = "aarch64", feature = "acpi"))]
+                let guest_memory_size_kb = guest_memory_size_kb - 4 * 1024;
+
                 let overhead = get_vmm_overhead(child.id(), guest_memory_size_kb);
                 eprintln!(
                     "Guest memory overhead: {} vs {}",

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -173,6 +173,7 @@ struct Ioapic {
 }
 
 #[cfg(all(target_arch = "aarch64", feature = "acpi"))]
+#[allow(dead_code)]
 #[repr(packed)]
 struct GicC {
     pub r#type: u8,
@@ -196,6 +197,7 @@ struct GicC {
 }
 
 #[cfg(all(target_arch = "aarch64", feature = "acpi"))]
+#[allow(dead_code)]
 #[repr(packed)]
 struct GicD {
     pub r#type: u8,
@@ -209,6 +211,7 @@ struct GicD {
 }
 
 #[cfg(all(target_arch = "aarch64", feature = "acpi"))]
+#[allow(dead_code)]
 #[repr(packed)]
 struct GicR {
     pub r#type: u8,
@@ -219,6 +222,7 @@ struct GicR {
 }
 
 #[cfg(all(target_arch = "aarch64", feature = "acpi"))]
+#[allow(dead_code)]
 #[repr(packed)]
 struct GicIts {
     pub r#type: u8,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -97,7 +97,7 @@ use vm_memory::guest_memory::FileOffset;
 #[cfg(feature = "kvm")]
 use vm_memory::GuestMemoryRegion;
 use vm_memory::{Address, GuestAddress, GuestUsize, MmapRegion};
-#[cfg(feature = "cmos")]
+#[cfg(all(target_arch = "x86_64", feature = "cmos"))]
 use vm_memory::{GuestAddressSpace, GuestMemory};
 use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, SnapshotDataSection, Snapshottable,


### PR DESCRIPTION
This PR optimize ACPI on AArch64 in following aspects:
- Reduced the UEFI space from 64M to 4M.
- Simplified build instructions. After enabling ACPI, we can build with default features on AArch64.
- Simplified integration test steps.
- Simplified document.
