### PR TITLE
deps: Update vhost crate from 1a03a2a to 9982541

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vhost?branch=master#1a03a2aca700421f258b094b1a845f6420d8cfa9"
+source = "git+https://github.com/rust-vmm/vhost?branch=master#9982541776a603d30556a06df55e8c0491072763"
 dependencies = [
  "bitflags",
  "libc",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vhost?branch=master#a8ff939161d41fc2f449b80e461d013c1e19f666"
+source = "git+https://github.com/rust-vmm/vhost?branch=master#9982541776a603d30556a06df55e8c0491072763"
 dependencies = [
  "bitflags",
  "libc",

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -197,7 +197,7 @@ pub fn setup_vhost_user<S: VhostUserMasterReqHandler>(
     }
 
     if let Some(slave_req_handler) = slave_req_handler {
-        vu.set_slave_request_fd(slave_req_handler.get_tx_raw_fd())
+        vu.set_slave_request_fd(&slave_req_handler.get_tx_raw_fd())
             .map_err(Error::VhostUserSetSlaveRequestFd)
     } else {
         Ok(())


### PR DESCRIPTION
This dependency bump needed some manual handling since the API changed
quite a lot regarding some RawFd being changed into either File or
AsRawFd traits.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>