### PR TITLE
Enhance AArch64 clippy

### DIFF
--- a/.github/workflows/quality-aarch64.yaml
+++ b/.github/workflows/quality-aarch64.yaml
@@ -37,25 +37,25 @@ jobs:
         with:
           use-cross: true
           command: clippy
-          args: --target=${{ matrix.target }} --no-default-features --features "kvm" -- -D warnings
+          args: --target=${{ matrix.target }} --all --no-default-features --features "kvm" -- -D warnings
 
       - name: Clippy (kvm,acpi)
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: clippy
-          args: --target=${{ matrix.target }} --no-default-features --features "kvm,acpi" -- -D warnings
+          args: --target=${{ matrix.target }} --all --no-default-features --features "kvm,acpi" -- -D warnings
 
       - name: Clippy (all features,kvm)
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: clippy
-          args: --target=${{ matrix.target }} --no-default-features --features "common,kvm" -- -D warnings
+          args: --target=${{ matrix.target }} --all --no-default-features --features "common,kvm" -- -D warnings
 
       - name: Clippy (default)
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: clippy
-          args: --target=${{ matrix.target }} -- -D warnings
+          args: --target=${{ matrix.target }} --all -- -D warnings

--- a/devices/src/legacy/gpio_pl061.rs
+++ b/devices/src/legacy/gpio_pl061.rs
@@ -383,7 +383,7 @@ mod tests {
         // Read and write to the GPIODIR register.
         // Set pin 0 output pin.
         write_le_u32(&mut data, 1);
-        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIODIR, &mut data);
+        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIODIR, &data);
         gpio.read(LEGACY_GPIO_MAPPED_IO_START, GPIODIR, &mut data);
         let v = read_le_u32(&data);
         assert_eq!(v, 1);
@@ -391,8 +391,8 @@ mod tests {
         // Read and write to the GPIODATA register.
         write_le_u32(&mut data, 1);
         // Set pin 0 high.
-        let offset = 0x00000004 as u64;
-        gpio.write(LEGACY_GPIO_MAPPED_IO_START, offset, &mut data);
+        let offset = 0x00000004_u64;
+        gpio.write(LEGACY_GPIO_MAPPED_IO_START, offset, &data);
         gpio.read(LEGACY_GPIO_MAPPED_IO_START, offset, &mut data);
         let v = read_le_u32(&data);
         assert_eq!(v, 1);
@@ -400,7 +400,7 @@ mod tests {
         // Read and write to the GPIOIS register.
         // Configure pin 0 detecting level interrupt.
         write_le_u32(&mut data, 1);
-        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIOIS, &mut data);
+        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIOIS, &data);
         gpio.read(LEGACY_GPIO_MAPPED_IO_START, GPIOIS, &mut data);
         let v = read_le_u32(&data);
         assert_eq!(v, 1);
@@ -408,7 +408,7 @@ mod tests {
         // Read and write to the GPIOIBE register.
         // Configure pin 1 detecting both falling and rising edges.
         write_le_u32(&mut data, 2);
-        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIOIBE, &mut data);
+        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIOIBE, &data);
         gpio.read(LEGACY_GPIO_MAPPED_IO_START, GPIOIBE, &mut data);
         let v = read_le_u32(&data);
         assert_eq!(v, 2);
@@ -416,7 +416,7 @@ mod tests {
         // Read and write to the GPIOIEV register.
         // Configure pin 2 detecting both falling and rising edges.
         write_le_u32(&mut data, 4);
-        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIOIEV, &mut data);
+        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIOIEV, &data);
         gpio.read(LEGACY_GPIO_MAPPED_IO_START, GPIOIEV, &mut data);
         let v = read_le_u32(&data);
         assert_eq!(v, 4);
@@ -425,12 +425,12 @@ mod tests {
         // Configure pin 0...2 capable of triggering their individual interrupts
         // and then the combined GPIOINTR line.
         write_le_u32(&mut data, 7);
-        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIOIE, &mut data);
+        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIOIE, &data);
         gpio.read(LEGACY_GPIO_MAPPED_IO_START, GPIOIE, &mut data);
         let v = read_le_u32(&data);
         assert_eq!(v, 7);
 
-        let mask = 0x00000002 as u32;
+        let mask = 0x00000002_u32;
         // emulate an rising pulse in pin 1.
         gpio.data |= !(gpio.data & mask) & mask;
         gpio.pl061_internal_update();
@@ -443,14 +443,14 @@ mod tests {
         // Read and Write to the GPIOIC register.
         // clear interrupt in pin 1.
         write_le_u32(&mut data, 2);
-        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIOIC, &mut data);
+        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIOIC, &data);
         gpio.read(LEGACY_GPIO_MAPPED_IO_START, GPIOIC, &mut data);
         let v = read_le_u32(&data);
         assert_eq!(v, 2);
 
         // Attempts to write beyond the writable space.
         write_le_u32(&mut data, 0);
-        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIO_ID_LOW, &mut data);
+        gpio.write(LEGACY_GPIO_MAPPED_IO_START, GPIO_ID_LOW, &data);
 
         let mut data = [0; 4];
         gpio.read(LEGACY_GPIO_MAPPED_IO_START, GPIO_ID_LOW, &mut data);

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -457,7 +457,7 @@ mod tests {
 
         // Read and write to the MR register.
         write_le_u32(&mut data, 123);
-        rtc.write(LEGACY_RTC_MAPPED_IO_START, RTCMR, &mut data);
+        rtc.write(LEGACY_RTC_MAPPED_IO_START, RTCMR, &data);
         rtc.read(LEGACY_RTC_MAPPED_IO_START, RTCMR, &mut data);
         let v = read_le_u32(&data);
         assert_eq!(v, 123);
@@ -466,7 +466,7 @@ mod tests {
         let v = get_time(ClockType::Real);
         write_le_u32(&mut data, (v / NANOS_PER_SECOND) as u32);
         let previous_now_before = rtc.previous_now;
-        rtc.write(LEGACY_RTC_MAPPED_IO_START, RTCLR, &mut data);
+        rtc.write(LEGACY_RTC_MAPPED_IO_START, RTCLR, &data);
 
         assert!(rtc.previous_now > previous_now_before);
 
@@ -478,7 +478,7 @@ mod tests {
         // Test with non zero value.
         let non_zero = 1;
         write_le_u32(&mut data, non_zero);
-        rtc.write(LEGACY_RTC_MAPPED_IO_START, RTCIMSC, &mut data);
+        rtc.write(LEGACY_RTC_MAPPED_IO_START, RTCIMSC, &data);
         // The interrupt line should be on.
         assert!(rtc.interrupt.notifier(0).unwrap().read().unwrap() == 1);
         rtc.read(LEGACY_RTC_MAPPED_IO_START, RTCIMSC, &mut data);
@@ -487,14 +487,14 @@ mod tests {
 
         // Now test with 0.
         write_le_u32(&mut data, 0);
-        rtc.write(LEGACY_RTC_MAPPED_IO_START, RTCIMSC, &mut data);
+        rtc.write(LEGACY_RTC_MAPPED_IO_START, RTCIMSC, &data);
         rtc.read(LEGACY_RTC_MAPPED_IO_START, RTCIMSC, &mut data);
         let v = read_le_u32(&data);
         assert_eq!(0, v);
 
         // Read and write to the ICR register.
         write_le_u32(&mut data, 1);
-        rtc.write(LEGACY_RTC_MAPPED_IO_START, RTCICR, &mut data);
+        rtc.write(LEGACY_RTC_MAPPED_IO_START, RTCICR, &data);
         // The interrupt line should be on.
         assert!(rtc.interrupt.notifier(0).unwrap().read().unwrap() > 1);
         let v_before = read_le_u32(&data);
@@ -506,7 +506,7 @@ mod tests {
 
         // Attempts to turn off the RTC should not go through.
         write_le_u32(&mut data, 0);
-        rtc.write(LEGACY_RTC_MAPPED_IO_START, RTCCR, &mut data);
+        rtc.write(LEGACY_RTC_MAPPED_IO_START, RTCCR, &data);
         rtc.read(LEGACY_RTC_MAPPED_IO_START, RTCCR, &mut data);
         let v = read_le_u32(&data);
         assert_eq!(v, 1);
@@ -514,7 +514,7 @@ mod tests {
         // Attempts to write beyond the writable space. Using here the space used to read
         // the CID and PID from.
         write_le_u32(&mut data, 0);
-        rtc.write(LEGACY_RTC_MAPPED_IO_START, AMBA_ID_LOW, &mut data);
+        rtc.write(LEGACY_RTC_MAPPED_IO_START, AMBA_ID_LOW, &data);
         // However, reading from the AMBA_ID_LOW should succeed upon read.
 
         let mut data = [0; 4];

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1837,11 +1837,10 @@ mod tests {
         let hv = hypervisor::new().unwrap();
         let vm = hv.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0, None).unwrap();
-        let mut regions = Vec::new();
-        regions.push((
+        let regions = vec![(
             GuestAddress(layout::RAM_64BIT_START),
             (layout::FDT_MAX_SIZE + 0x1000) as usize,
-        ));
+        )];
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
 
         let res = setup_regs(&vcpu, 0, 0x0, &mem);
@@ -1896,7 +1895,7 @@ mod tests {
             "Failed to get core register: Exec format error (os error 8)"
         );
 
-        let res = vcpu.set_core_registers(&mut state);
+        let res = vcpu.set_core_registers(&state);
         assert!(res.is_err());
         assert_eq!(
             format!("{}", res.unwrap_err()),
@@ -1936,7 +1935,7 @@ mod tests {
             id: MPIDR_EL1,
             addr: 0x00,
         });
-        let res = vcpu.set_system_registers(&mut state);
+        let res = vcpu.set_system_registers(&state);
         assert!(res.is_err());
         assert_eq!(
             format!("{}", res.unwrap_err()),

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -469,8 +469,7 @@ mod tests {
         let _ = vm.create_vcpu(0, None).unwrap();
         let gic = create_gic(&vm, 1).expect("Cannot create gic");
 
-        let mut gicr_typer = Vec::new();
-        gicr_typer.push(123);
+        let gicr_typer = vec![123];
         let res = get_redist_regs(gic.device(), &gicr_typer);
         assert!(res.is_ok());
         let state = res.unwrap();
@@ -487,8 +486,7 @@ mod tests {
         let _ = vm.create_vcpu(0, None).unwrap();
         let gic = create_gic(&vm, 1).expect("Cannot create gic");
 
-        let mut gicr_typer = Vec::new();
-        gicr_typer.push(123);
+        let gicr_typer = vec![123];
         let res = get_icc_regs(gic.device(), &gicr_typer);
         assert!(res.is_ok());
         let state = res.unwrap();

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2458,10 +2458,10 @@ mod tests {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{GuestMemoryMmap, GuestRegionMmap};
+    use crate::GuestMemoryMmap;
     use arch::aarch64::fdt::create_fdt;
     use arch::aarch64::gic::kvm::create_gic;
-    use arch::aarch64::{layout, DeviceInfoForFdt};
+    use arch::aarch64::layout;
     use arch::{DeviceType, MmioDeviceInfo};
     use vm_memory::GuestAddress;
 
@@ -2469,11 +2469,10 @@ mod tests {
 
     #[test]
     fn test_create_fdt_with_devices() {
-        let mut regions = Vec::new();
-        regions.push((
+        let regions = vec![(
             GuestAddress(layout::RAM_64BIT_START),
             (layout::FDT_MAX_SIZE + 0x1000) as usize,
-        ));
+        )];
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
 
         let dev_info: HashMap<(DeviceType, std::string::String), MmioDeviceInfo> = [
@@ -2486,15 +2485,12 @@ mod tests {
             ),
             (
                 (DeviceType::Virtio(1), "virtio".to_string()),
-                MmioDeviceInfo {
-                    addr: 0x00 + LEN,
-                    irq: 34,
-                },
+                MmioDeviceInfo { addr: LEN, irq: 34 },
             ),
             (
                 (DeviceType::Rtc, "rtc".to_string()),
                 MmioDeviceInfo {
-                    addr: 0x00 + 2 * LEN,
+                    addr: 2 * LEN,
                     irq: 35,
                 },
             ),


### PR DESCRIPTION
Enabled `--all` option in clippy test and fixed all errors.