### PR TITLE
net_util: queue_pair: Rewind queue upon EAGAIN

### DIFF
--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -98,6 +98,7 @@ impl TxVirtio {
                     /* EAGAIN */
                     if e.kind() == std::io::ErrorKind::WouldBlock {
                         warn!("net: tx: (recoverable) failed writing to tap: {}", e);
+                        queue.go_to_previous_position();
                         break;
                     }
                     error!("net: tx: failed writing to tap: {}", e);


### PR DESCRIPTION
If writing to the TAP device triggers EAGAIN then it is necessary to
rewind the queue to the previous position. Failing to rewind the queue
whilst also not updating the queue used pointer (because we've broken
out of the loop) will result in a starvation of available descriptors.

Rewinding before breaking out of the loop is also consistent with the
rate limiter behaviour.

Probably fixes: #2807

Signed-off-by: Rob Bradford <robert.bradford@intel.com>