### PR TITLE
test_infra: Fix clippy warning (expect_fun_call)

### DIFF
--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -595,12 +595,12 @@ pub fn exec_host_command_status(command: &str) -> ExitStatus {
     std::process::Command::new("bash")
         .args(&["-c", command])
         .status()
-        .expect(&format!("Expected '{}' to run", command))
+        .unwrap_or_else(|_| panic!("Expected '{}' to run", command))
 }
 
 pub fn exec_host_command_output(command: &str) -> Output {
     std::process::Command::new("bash")
         .args(&["-c", command])
         .output()
-        .expect(&format!("Expected '{}' to run", command))
+        .unwrap_or_else(|_| panic!("Expected '{}' to run", command))
 }


### PR DESCRIPTION
warning: use of `expect` followed by a function call
   --> test_infra/src/lib.rs:598:10
    |
598 |         .expect(&format!("Expected '{}' to run", command))
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| panic!("Expected '{}' to run", command))`
    |
    = note: `#[warn(clippy::expect_fun_call)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#expect_fun_call

warning: use of `expect` followed by a function call
   --> test_infra/src/lib.rs:605:10
    |
605 |         .expect(&format!("Expected '{}' to run", command))
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| panic!("Expected '{}' to run", command))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#expect_fun_call

Signed-off-by: Rob Bradford <robert.bradford@intel.com>