### PR TITLE
AArch64: Enable snapshot/restore

### DIFF
--- a/arch/src/aarch64/gic/gicv3.rs
+++ b/arch/src/aarch64/gic/gicv3.rs
@@ -1,5 +1,8 @@
+// Copyright 2021 Arm Limited (or its affiliates). All rights reserved.
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+//
+// This file implements the GicV3 device.
 
 pub mod kvm {
     use crate::aarch64::gic::dist_regs::{get_dist_regs, read_ctlr, set_dist_regs, write_ctlr};
@@ -50,7 +53,7 @@ pub mod kvm {
     type Result<T> = result::Result<T, Error>;
 
     pub struct KvmGicV3 {
-        /// The hypervisor agnostic device
+        /// The hypervisor agnostic device for the GicV3
         device: Arc<dyn hypervisor::Device>,
 
         /// Vector holding values of GICR_TYPER for each vCPU
@@ -168,6 +171,8 @@ pub mod kvm {
             self.vcpu_count
         }
 
+        fn set_its_device(&mut self, _its_device: Option<Arc<dyn hypervisor::Device>>) {}
+
         fn set_gicr_typers(&mut self, vcpu_states: &[CpuState]) {
             let gicr_typers = construct_gicr_typers(vcpu_states);
             self.gicr_typers = gicr_typers;
@@ -202,7 +207,7 @@ pub mod kvm {
 
         fn init_device_attributes(
             _vm: &Arc<dyn hypervisor::Vm>,
-            gic_device: &dyn GicDevice,
+            gic_device: &mut dyn GicDevice,
         ) -> crate::aarch64::gic::Result<()> {
             /* Setting up the distributor attribute.
              We are placing the GIC below 1GB so we need to substract the size of the distributor.

--- a/arch/src/aarch64/gic/gicv3_its.rs
+++ b/arch/src/aarch64/gic/gicv3_its.rs
@@ -4,15 +4,88 @@
 // This file implements the GicV3 device with ITS (Virtual Interrupt Translation Service).
 
 pub mod kvm {
-    use std::any::Any;
-    use std::sync::Arc;
-    use std::{boxed::Box, result};
-    type Result<T> = result::Result<T, Error>;
+    use crate::aarch64::gic::dist_regs::{get_dist_regs, read_ctlr, set_dist_regs, write_ctlr};
+    use crate::aarch64::gic::icc_regs::{get_icc_regs, set_icc_regs};
+    use crate::aarch64::gic::redist_regs::{
+        construct_gicr_typers, get_redist_regs, set_redist_regs,
+    };
+
     use crate::aarch64::gic::gicv3::kvm::KvmGicV3;
-    use crate::aarch64::gic::kvm::KvmGicDevice;
-    use crate::aarch64::gic::{Error, GicDevice};
+    use crate::aarch64::gic::kvm::{save_pending_tables, KvmGicDevice};
+    use crate::aarch64::gic::GicDevice;
+    use anyhow::anyhow;
     use hypervisor::kvm::kvm_bindings;
     use hypervisor::CpuState;
+    use std::any::Any;
+    use std::convert::TryInto;
+    use std::sync::Arc;
+    use std::{boxed::Box, result};
+    use versionize::{VersionMap, Versionize, VersionizeResult};
+    use versionize_derive::Versionize;
+    use vm_migration::{
+        Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable,
+        VersionMapped,
+    };
+
+    const GITS_CTLR: u32 = 0x0000;
+    const GITS_IIDR: u32 = 0x0004;
+    const GITS_CBASER: u32 = 0x0080;
+    const GITS_CWRITER: u32 = 0x0088;
+    const GITS_CREADR: u32 = 0x0090;
+    const GITS_BASER: u32 = 0x0100;
+
+    /// Errors thrown while saving/restoring the GICv3ITS.
+    #[derive(Debug)]
+    pub enum Error {
+        /// Error in saving RDIST pending tables into guest RAM.
+        SavePendingTables(crate::aarch64::gic::Error),
+        /// Error in saving GIC distributor registers.
+        SaveDistributorRegisters(crate::aarch64::gic::Error),
+        /// Error in restoring GIC distributor registers.
+        RestoreDistributorRegisters(crate::aarch64::gic::Error),
+        /// Error in saving GIC distributor control registers.
+        SaveDistributorCtrlRegisters(crate::aarch64::gic::Error),
+        /// Error in restoring GIC distributor control registers.
+        RestoreDistributorCtrlRegisters(crate::aarch64::gic::Error),
+        /// Error in saving GIC redistributor registers.
+        SaveRedistributorRegisters(crate::aarch64::gic::Error),
+        /// Error in restoring GIC redistributor registers.
+        RestoreRedistributorRegisters(crate::aarch64::gic::Error),
+        /// Error in saving GIC CPU interface registers.
+        SaveIccRegisters(crate::aarch64::gic::Error),
+        /// Error in restoring GIC CPU interface registers.
+        RestoreIccRegisters(crate::aarch64::gic::Error),
+        /// Error in saving GICv3ITS IIDR register.
+        SaveITSIIDR(crate::aarch64::gic::Error),
+        /// Error in restoring GICv3ITS IIDR register.
+        RestoreITSIIDR(crate::aarch64::gic::Error),
+        /// Error in saving GICv3ITS CBASER register.
+        SaveITSCBASER(crate::aarch64::gic::Error),
+        /// Error in restoring GICv3ITS CBASER register.
+        RestoreITSCBASER(crate::aarch64::gic::Error),
+        /// Error in saving GICv3ITS CREADR register.
+        SaveITSCREADR(crate::aarch64::gic::Error),
+        /// Error in restoring GICv3ITS CREADR register.
+        RestoreITSCREADR(crate::aarch64::gic::Error),
+        /// Error in saving GICv3ITS CWRITER register.
+        SaveITSCWRITER(crate::aarch64::gic::Error),
+        /// Error in restoring GICv3ITS CWRITER register.
+        RestoreITSCWRITER(crate::aarch64::gic::Error),
+        /// Error in saving GICv3ITS BASER register.
+        SaveITSBASER(crate::aarch64::gic::Error),
+        /// Error in restoring GICv3ITS BASER register.
+        RestoreITSBASER(crate::aarch64::gic::Error),
+        /// Error in saving GICv3ITS CTLR register.
+        SaveITSCTLR(crate::aarch64::gic::Error),
+        /// Error in restoring GICv3ITS CTLR register.
+        RestoreITSCTLR(crate::aarch64::gic::Error),
+        /// Error in saving GICv3ITS restore tables.
+        SaveITSTables(crate::aarch64::gic::Error),
+        /// Error in restoring GICv3ITS restore tables.
+        RestoreITSTables(crate::aarch64::gic::Error),
+    }
+
+    type Result<T> = result::Result<T, Error>;
 
     /// Access an ITS device attribute.
     ///
@@ -75,6 +148,9 @@ pub mod kvm {
         /// The hypervisor agnostic device for the Its device
         its_device: Option<Arc<dyn hypervisor::Device>>,
 
+        /// Vector holding values of GICR_TYPER for each vCPU
+        gicr_typers: Vec<u64>,
+
         /// GIC device properties, to be used for setting up the fdt entry
         gic_properties: [u64; 4],
 
@@ -85,6 +161,23 @@ pub mod kvm {
         vcpu_count: u64,
     }
 
+    #[derive(Versionize)]
+    pub struct Gicv3ItsState {
+        dist: Vec<u32>,
+        rdist: Vec<u32>,
+        icc: Vec<u32>,
+        // special register that enables interrupts and affinity routing
+        gicd_ctlr: u32,
+        its_ctlr: u64,
+        its_iidr: u64,
+        its_cbaser: u64,
+        its_cwriter: u64,
+        its_creadr: u64,
+        its_baser: [u64; 8],
+    }
+
+    impl VersionMapped for Gicv3ItsState {}
+
     impl KvmGicV3Its {
         const KVM_VGIC_V3_ITS_SIZE: u64 = (2 * KvmGicV3::SZ_64K);
 
@@ -94,6 +187,181 @@ pub mod kvm {
 
         fn get_msi_addr(vcpu_count: u64) -> u64 {
             KvmGicV3::get_redists_addr(vcpu_count) - KvmGicV3Its::get_msi_size()
+        }
+
+        /// Save the state of GICv3ITS.
+        fn state(&self, gicr_typers: &[u64]) -> Result<Gicv3ItsState> {
+            // Flush redistributors pending tables to guest RAM.
+            save_pending_tables(self.device()).map_err(Error::SavePendingTables)?;
+
+            let gicd_ctlr =
+                read_ctlr(self.device()).map_err(Error::SaveDistributorCtrlRegisters)?;
+
+            let dist_state =
+                get_dist_regs(self.device()).map_err(Error::SaveDistributorRegisters)?;
+
+            let rdist_state = get_redist_regs(self.device(), gicr_typers)
+                .map_err(Error::SaveRedistributorRegisters)?;
+
+            let icc_state =
+                get_icc_regs(self.device(), gicr_typers).map_err(Error::SaveIccRegisters)?;
+
+            // Save GICv3ITS registers
+            gicv3_its_tables_access(self.its_device().unwrap(), true)
+                .map_err(Error::SaveITSTables)?;
+
+            let its_baser_state: [u64; 8] = [0; 8];
+            for i in 0..8 {
+                gicv3_its_attr_access(
+                    self.its_device().unwrap(),
+                    kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
+                    GITS_BASER + i * 8,
+                    &its_baser_state[i as usize],
+                    false,
+                )
+                .map_err(Error::SaveITSBASER)?;
+            }
+
+            let its_ctlr_state: u64 = 0;
+            gicv3_its_attr_access(
+                self.its_device().unwrap(),
+                kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
+                GITS_CTLR,
+                &its_ctlr_state,
+                false,
+            )
+            .map_err(Error::SaveITSCTLR)?;
+
+            let its_cbaser_state: u64 = 0;
+            gicv3_its_attr_access(
+                self.its_device().unwrap(),
+                kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
+                GITS_CBASER,
+                &its_cbaser_state,
+                false,
+            )
+            .map_err(Error::SaveITSCBASER)?;
+
+            let its_creadr_state: u64 = 0;
+            gicv3_its_attr_access(
+                self.its_device().unwrap(),
+                kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
+                GITS_CREADR,
+                &its_creadr_state,
+                false,
+            )
+            .map_err(Error::SaveITSCREADR)?;
+
+            let its_cwriter_state: u64 = 0;
+            gicv3_its_attr_access(
+                self.its_device().unwrap(),
+                kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
+                GITS_CWRITER,
+                &its_cwriter_state,
+                false,
+            )
+            .map_err(Error::SaveITSCWRITER)?;
+
+            let its_iidr_state: u64 = 0;
+            gicv3_its_attr_access(
+                self.its_device().unwrap(),
+                kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
+                GITS_IIDR,
+                &its_iidr_state,
+                false,
+            )
+            .map_err(Error::SaveITSIIDR)?;
+
+            Ok(Gicv3ItsState {
+                dist: dist_state,
+                rdist: rdist_state,
+                icc: icc_state,
+                gicd_ctlr,
+                its_ctlr: its_ctlr_state,
+                its_iidr: its_iidr_state,
+                its_cbaser: its_cbaser_state,
+                its_cwriter: its_cwriter_state,
+                its_creadr: its_creadr_state,
+                its_baser: its_baser_state,
+            })
+        }
+
+        /// Restore the state of GICv3ITS.
+        fn set_state(&mut self, gicr_typers: &[u64], state: &Gicv3ItsState) -> Result<()> {
+            write_ctlr(self.device(), state.gicd_ctlr)
+                .map_err(Error::RestoreDistributorCtrlRegisters)?;
+
+            set_dist_regs(self.device(), &state.dist)
+                .map_err(Error::RestoreDistributorRegisters)?;
+
+            set_redist_regs(self.device(), gicr_typers, &state.rdist)
+                .map_err(Error::RestoreRedistributorRegisters)?;
+
+            set_icc_regs(self.device(), gicr_typers, &state.icc)
+                .map_err(Error::RestoreIccRegisters)?;
+
+            //Restore GICv3ITS registers
+            gicv3_its_attr_access(
+                self.its_device().unwrap(),
+                kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
+                GITS_IIDR,
+                &state.its_iidr,
+                true,
+            )
+            .map_err(Error::RestoreITSIIDR)?;
+
+            gicv3_its_attr_access(
+                self.its_device().unwrap(),
+                kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
+                GITS_CBASER,
+                &state.its_cbaser,
+                true,
+            )
+            .map_err(Error::RestoreITSCBASER)?;
+
+            gicv3_its_attr_access(
+                self.its_device().unwrap(),
+                kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
+                GITS_CREADR,
+                &state.its_creadr,
+                true,
+            )
+            .map_err(Error::RestoreITSCREADR)?;
+
+            gicv3_its_attr_access(
+                self.its_device().unwrap(),
+                kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
+                GITS_CWRITER,
+                &state.its_cwriter,
+                true,
+            )
+            .map_err(Error::RestoreITSCWRITER)?;
+
+            for i in 0..8 {
+                gicv3_its_attr_access(
+                    self.its_device().unwrap(),
+                    kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
+                    GITS_BASER + i * 8,
+                    &state.its_baser[i as usize],
+                    true,
+                )
+                .map_err(Error::RestoreITSBASER)?;
+            }
+
+            // Restore ITS tables
+            gicv3_its_tables_access(self.its_device().unwrap(), false)
+                .map_err(Error::RestoreITSTables)?;
+
+            gicv3_its_attr_access(
+                self.its_device().unwrap(),
+                kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ITS_REGS,
+                GITS_CTLR,
+                &state.its_ctlr,
+                true,
+            )
+            .map_err(Error::RestoreITSCTLR)?;
+
+            Ok(())
         }
     }
 
@@ -138,7 +406,10 @@ pub mod kvm {
             self.its_device = its_device;
         }
 
-        fn set_gicr_typers(&mut self, _vcpu_states: &[CpuState]) {}
+        fn set_gicr_typers(&mut self, vcpu_states: &[CpuState]) {
+            let gicr_typers = construct_gicr_typers(vcpu_states);
+            self.gicr_typers = gicr_typers;
+        }
 
         fn as_any_concrete_mut(&mut self) -> &mut dyn Any {
             self
@@ -157,6 +428,7 @@ pub mod kvm {
             Box::new(KvmGicV3Its {
                 device,
                 its_device: None,
+                gicr_typers: vec![0; vcpu_count.try_into().unwrap()],
                 gic_properties: [
                     KvmGicV3::get_dist_addr(),
                     KvmGicV3::get_dist_size(),
@@ -174,7 +446,7 @@ pub mod kvm {
         fn init_device_attributes(
             vm: &Arc<dyn hypervisor::Vm>,
             gic_device: &mut dyn GicDevice,
-        ) -> Result<()> {
+        ) -> crate::aarch64::gic::Result<()> {
             KvmGicV3::init_device_attributes(vm, gic_device)?;
 
             let mut its_device = kvm_bindings::kvm_create_device {
@@ -185,7 +457,7 @@ pub mod kvm {
 
             let its_fd = vm
                 .create_device(&mut its_device)
-                .map_err(Error::CreateGic)?;
+                .map_err(crate::aarch64::gic::Error::CreateGic)?;
 
             Self::set_device_attribute(
                 &its_fd,
@@ -208,4 +480,28 @@ pub mod kvm {
             Ok(())
         }
     }
+
+    pub const GIC_V3_ITS_SNAPSHOT_ID: &str = "gic-v3-its";
+    impl Snapshottable for KvmGicV3Its {
+        fn id(&self) -> String {
+            GIC_V3_ITS_SNAPSHOT_ID.to_string()
+        }
+
+        fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+            let gicr_typers = self.gicr_typers.clone();
+            Snapshot::new_from_versioned_state(&self.id(), &self.state(&gicr_typers).unwrap())
+        }
+
+        fn restore(&mut self, snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
+            let gicr_typers = self.gicr_typers.clone();
+            self.set_state(&gicr_typers, &snapshot.to_versioned_state(&self.id())?)
+                .map_err(|e| {
+                    MigratableError::Restore(anyhow!("Could not restore GICv3ITS state {:?}", e))
+                })
+        }
+    }
+
+    impl Pausable for KvmGicV3Its {}
+    impl Transportable for KvmGicV3Its {}
+    impl Migratable for KvmGicV3Its {}
 }

--- a/arch/src/aarch64/gic/mod.rs
+++ b/arch/src/aarch64/gic/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2021 Arm Limited (or its affiliates). All rights reserved.
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/arch/src/aarch64/gic/redist_regs.rs
+++ b/arch/src/aarch64/gic/redist_regs.rs
@@ -62,11 +62,11 @@ macro_rules! VGIC_RDIST_REG {
 
 // List with relevant distributor registers that we will be restoring.
 static VGIC_RDIST_REGS: &'static [RdistReg] = &[
-    VGIC_RDIST_REG!(GICR_CTLR, 4),
     VGIC_RDIST_REG!(GICR_STATUSR, 4),
     VGIC_RDIST_REG!(GICR_WAKER, 4),
     VGIC_RDIST_REG!(GICR_PROPBASER, 8),
     VGIC_RDIST_REG!(GICR_PENDBASER, 8),
+    VGIC_RDIST_REG!(GICR_CTLR, 4),
 ];
 
 // List with relevant distributor registers that we will be restoring.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4677,7 +4677,6 @@ mod tests {
         // through each ssh command. There's no need to perform a dedicated test to
         // verify the migration went well for virtio-net.
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_snapshot_restore() {
             let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
             let guest = Guest::new(Box::new(focal));
@@ -4748,22 +4747,26 @@ mod tests {
 
                 guest.ssh_command(&console_cmd).unwrap();
 
-                // We check that removing and adding back the virtio-net device
+                // x86_64: We check that removing and adding back the virtio-net device
                 // does not break the snapshot/restore support for virtio-pci.
                 // This is an important thing to test as the hotplug will
                 // trigger a PCI BAR reprogramming, which is a good way of
                 // checking if the stored resources are correctly restored.
                 // Unplug the virtio-net device
-                assert!(remote_command(&api_socket, "remove-device", Some(net_id),));
-                thread::sleep(std::time::Duration::new(10, 0));
+                // AArch64: Device hotplug is currently not supported, skipping here.
+                #[cfg(target_arch = "x86_64")]
+                {
+                    assert!(remote_command(&api_socket, "remove-device", Some(net_id),));
+                    thread::sleep(std::time::Duration::new(10, 0));
 
-                // Plug the virtio-net device again
-                assert!(remote_command(
-                    &api_socket,
-                    "add-net",
-                    Some(net_params.as_str()),
-                ));
-                thread::sleep(std::time::Duration::new(10, 0));
+                    // Plug the virtio-net device again
+                    assert!(remote_command(
+                        &api_socket,
+                        "add-net",
+                        Some(net_params.as_str()),
+                    ));
+                    thread::sleep(std::time::Duration::new(10, 0));
+                }
 
                 // Pause the VM
                 assert!(remote_command(&api_socket, "pause", None));

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2277,6 +2277,17 @@ impl Snapshottable for Vm {
         #[cfg(target_arch = "aarch64")]
         self.restore_vgic_and_enable_interrupt(&snapshot)?;
 
+        if let Some(device_manager_snapshot) = snapshot.snapshots.get(DEVICE_MANAGER_SNAPSHOT_ID) {
+            self.device_manager
+                .lock()
+                .unwrap()
+                .restore_devices(*device_manager_snapshot.clone())?;
+        } else {
+            return Err(MigratableError::Restore(anyhow!(
+                "Missing device manager snapshot"
+            )));
+        }
+
         // Now we can start all vCPUs from here.
         self.cpu_manager
             .lock()

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -75,7 +75,7 @@ use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::terminal::Terminal;
 
 #[cfg(target_arch = "aarch64")]
-use arch::aarch64::gic::gicv3::kvm::{KvmGicV3, GIC_V3_SNAPSHOT_ID};
+use arch::aarch64::gic::gicv3_its::kvm::{KvmGicV3Its, GIC_V3_ITS_SNAPSHOT_ID};
 #[cfg(target_arch = "aarch64")]
 use arch::aarch64::gic::kvm::create_gic;
 #[cfg(target_arch = "aarch64")]
@@ -1919,7 +1919,7 @@ impl Vm {
                 .lock()
                 .unwrap()
                 .as_any_concrete_mut()
-                .downcast_mut::<KvmGicV3>()
+                .downcast_mut::<KvmGicV3Its>()
                 .unwrap()
                 .snapshot()?,
         );
@@ -1958,16 +1958,18 @@ impl Vm {
             .set_gic_device(Arc::clone(&gic_device));
 
         // Restore GIC states.
-        if let Some(gic_v3_snapshot) = vm_snapshot.snapshots.get(GIC_V3_SNAPSHOT_ID) {
+        if let Some(gicv3_its_snapshot) = vm_snapshot.snapshots.get(GIC_V3_ITS_SNAPSHOT_ID) {
             gic_device
                 .lock()
                 .unwrap()
                 .as_any_concrete_mut()
-                .downcast_mut::<KvmGicV3>()
+                .downcast_mut::<KvmGicV3Its>()
                 .unwrap()
-                .restore(*gic_v3_snapshot.clone())?;
+                .restore(*gicv3_its_snapshot.clone())?;
         } else {
-            return Err(MigratableError::Restore(anyhow!("Missing GICv3 snapshot")));
+            return Err(MigratableError::Restore(anyhow!(
+                "Missing GicV3Its snapshot"
+            )));
         }
 
         // Activate gic device


### PR DESCRIPTION
Finally we have something works...

As the `virtio-mmio` snapshot/restore code has been merged before, this PR is mainly focusing on the missing `virtio-pci` and GICv3ITS support.

Thanks @jongwu for debugging and testing the prototype :))