### PR TITLE
virtio-devices, net_util, vhost_user_net: Retry writing to TAP

### DIFF
--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -92,12 +92,12 @@ impl TxVirtio {
                         iovecs.len() as libc::c_int,
                     )
                 };
+
                 if result < 0 {
                     let e = std::io::Error::last_os_error();
 
                     /* EAGAIN */
                     if e.kind() == std::io::ErrorKind::WouldBlock {
-                        warn!("net: tx: (recoverable) failed writing to tap: {}", e);
                         queue.go_to_previous_position();
                         retry_write = true;
                         break;

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -257,7 +257,7 @@ pub struct NetQueuePair {
     pub epoll_fd: Option<RawFd>,
     pub rx_tap_listening: bool,
     pub counters: NetCounters,
-    pub tap_event_id: u16,
+    pub tap_rx_event_id: u16,
     pub rx_desc_avail: bool,
     pub rx_rate_limiter: Option<RateLimiter>,
     pub tx_rate_limiter: Option<RateLimiter>,
@@ -312,7 +312,7 @@ impl NetQueuePair {
                 self.epoll_fd.unwrap(),
                 self.tap.as_raw_fd(),
                 epoll::Events::EPOLLIN,
-                u64::from(self.tap_event_id),
+                u64::from(self.tap_rx_event_id),
             )
             .map_err(NetQueuePairError::UnregisterListener)?;
             self.rx_tap_listening = false;

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -83,13 +83,16 @@ impl VhostUserNetThread {
             kill_evt: EventFd::new(EFD_NONBLOCK).map_err(Error::CreateKillEventFd)?,
             net: NetQueuePair {
                 mem: None,
+                tap_for_write_epoll: tap.clone(),
                 tap,
                 rx: RxVirtio::new(),
                 tx: TxVirtio::new(),
                 rx_tap_listening: false,
+                tx_tap_listening: false,
                 epoll_fd: None,
                 counters: NetCounters::default(),
                 tap_rx_event_id: 2,
+                tap_tx_event_id: 3,
                 rx_desc_avail: false,
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
@@ -193,14 +196,10 @@ impl VhostUserBackend for VhostUserNetBackend {
     fn handle_event(
         &self,
         device_event: u16,
-        evset: epoll::Events,
+        _evset: epoll::Events,
         vrings: &[Arc<RwLock<Vring>>],
         thread_id: usize,
     ) -> VhostUserBackendResult<bool> {
-        if evset != epoll::Events::EPOLLIN {
-            return Err(Error::HandleEventNotEpollIn.into());
-        }
-
         let mut thread = self.threads[thread_id].lock().unwrap();
         match device_event {
             0 => {
@@ -215,7 +214,7 @@ impl VhostUserBackend for VhostUserNetBackend {
                     thread.net.rx_tap_listening = true;
                 }
             }
-            1 => {
+            1 | 3 => {
                 let mut vring = vrings[1].write().unwrap();
                 if thread
                     .net

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -89,7 +89,7 @@ impl VhostUserNetThread {
                 rx_tap_listening: false,
                 epoll_fd: None,
                 counters: NetCounters::default(),
-                tap_event_id: 2,
+                tap_rx_event_id: 2,
                 rx_desc_avail: false,
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
@@ -209,7 +209,7 @@ impl VhostUserBackend for VhostUserNetBackend {
                         thread.net.epoll_fd.unwrap(),
                         thread.net.tap.as_raw_fd(),
                         epoll::Events::EPOLLIN,
-                        u64::from(thread.net.tap_event_id),
+                        u64::from(thread.net.tap_rx_event_id),
                     )
                     .map_err(Error::RegisterTapListener)?;
                     thread.net.rx_tap_listening = true;

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -161,7 +161,7 @@ impl NetEpollHandler {
                 self.net.epoll_fd.unwrap(),
                 self.net.tap.as_raw_fd(),
                 epoll::Events::EPOLLIN,
-                u64::from(self.net.tap_event_id),
+                u64::from(self.net.tap_rx_event_id),
             )
             .map_err(DeviceError::IoError)?;
             self.net.rx_tap_listening = true;
@@ -289,7 +289,7 @@ impl EpollHelperHandler for NetEpollHandler {
                                     self.net.epoll_fd.unwrap(),
                                     self.net.tap.as_raw_fd(),
                                     epoll::Events::EPOLLIN,
-                                    u64::from(self.net.tap_event_id),
+                                    u64::from(self.net.tap_rx_event_id),
                                 ) {
                                     error!("Error register_listener with `RX_RATE_LIMITER_EVENT`: {:?}", e);
                                     return true;
@@ -627,7 +627,7 @@ impl VirtioDevice for Net {
                     epoll_fd: None,
                     rx_tap_listening,
                     counters: self.counters.clone(),
-                    tap_event_id: RX_TAP_EVENT,
+                    tap_rx_event_id: RX_TAP_EVENT,
                     rx_desc_avail: false,
                     rx_rate_limiter,
                     tx_rate_limiter,


### PR DESCRIPTION
If writing to the TAP returns EAGAIN then listen for the TAP to be
writable. When the TAP becomes writable attempt to process the TX queue
again.

Fixes: #2807
