### PR TITLE
vmm: tdx: Only allocate TDVF TempMem if outside range

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1579,7 +1579,13 @@ impl Vm {
             let mem = guest_memory.memory();
             mem.last_addr()
         };
+
         for section in sections {
+            // TempMem section is inside the RAM range so no allocation needed
+            if matches!(section.r#type, TdvfSectionType::TempMem) && section.address < mem_end.0 {
+                continue;
+            }
+
             info!("Allocating TDVF Section: {:?}", section);
             self.memory_manager
                 .lock()


### PR DESCRIPTION
If the TDVF specifies temporary memory it wants to use that is inside
the VMs memory range then do not attempt to allocate new RAM for that.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>