### PR TITLE
vmm: acpi: Add DSDT address to XSDT

### DIFF
--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -467,6 +467,7 @@ pub fn create_acpi_tables(
     guest_mem
         .write_slice(dsdt.as_slice(), dsdt_offset)
         .expect("Error writing DSDT table");
+    tables.push(dsdt_offset.0);
 
     // FACP aka FADT
     let facp = create_facp_table(dsdt_offset);


### PR DESCRIPTION
The XSDT must contain each table address where it can be found. We were
missing the DSDT address in this list.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>