### PR TITLE
build: bump vm-fdt from `bbfd1e7` to `02d1b8f`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,7 +1239,7 @@ dependencies = [
 [[package]]
 name = "vm-fdt"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vm-fdt?branch=master#bbfd1e7719eef34e42f7853b37a871abbd96cafe"
+source = "git+https://github.com/rust-vmm/vm-fdt?branch=master#02d1b8fde288f42b4e2c0a0ec036f70ab797141c"
 
 [[package]]
 name = "vm-memory"

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -82,7 +82,7 @@ pub fn create_fdt<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHash
     pci_space_address: &(u64, u64),
 ) -> FdtWriterResult<Vec<u8>> {
     // Allocate stuff necessary for the holding the blob.
-    let mut fdt = FdtWriter::new(&[]).unwrap();
+    let mut fdt = FdtWriter::new().unwrap();
 
     // For an explanation why these nodes were introduced in the blob take a look at
     // https://github.com/torvalds/linux/blob/master/Documentation/devicetree/booting-without-of.txt#L845


### PR DESCRIPTION
Upstream commit `02d1b8f` changed the definition of `FdtWriter::new()`, and therefore we need a manual bump to avoid clippy issue (see https://github.com/cloud-hypervisor/cloud-hypervisor/pull/2831).

Bumps [vm-fdt](https://github.com/rust-vmm/vm-fdt) from `bbfd1e7` to `02d1b8f`.
- [Release notes](https://github.com/rust-vmm/vm-fdt/releases)
- [Commits](https://github.com/rust-vmm/vm-fdt/compare/bbfd1e7719eef34e42f7853b37a871abbd96cafe...02d1b8fde288f42b4e2c0a0ec036f70ab797141c)

---
updated-dependencies:
- dependency-name: vm-fdt
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>
Signed-off-by: Henry Wang <Henry.Wang@arm.com>