### PR TITLE
Add support for SGX provisioning

### DIFF
--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -28,6 +28,8 @@ pub use x86_64::VcpuMshvState as CpuState;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::*;
 
+#[cfg(target_arch = "x86_64")]
+use std::fs::File;
 use std::os::unix::io::AsRawFd;
 use std::sync::RwLock;
 
@@ -758,6 +760,10 @@ impl vm::Vm for MshvVm {
     }
     #[cfg(target_arch = "x86_64")]
     fn enable_split_irq(&self) -> vm::Result<()> {
+        Ok(())
+    }
+    #[cfg(target_arch = "x86_64")]
+    fn enable_sgx_attribute(&self, _file: File) -> vm::Result<()> {
         Ok(())
     }
     fn register_ioevent(

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -25,6 +25,8 @@ use crate::KvmVmState as VmState;
 use crate::{IoEventAddress, IrqRoutingEntry, MemoryRegion};
 #[cfg(feature = "kvm")]
 use kvm_ioctls::Cap;
+#[cfg(target_arch = "x86_64")]
+use std::fs::File;
 use std::sync::Arc;
 use thiserror::Error;
 use vmm_sys_util::eventfd::EventFd;
@@ -116,6 +118,11 @@ pub enum HypervisorVmError {
     ///
     #[error("Failed to enable split Irq: {0}")]
     EnableSplitIrq(#[source] anyhow::Error),
+    ///
+    /// Enable SGX attribute error
+    ///
+    #[error("Failed to enable SGX attribute: {0}")]
+    EnableSgxAttribute(#[source] anyhow::Error),
     ///
     /// Get clock error
     ///
@@ -246,6 +253,8 @@ pub trait Vm: Send + Sync {
     /// Enable split Irq capability
     #[cfg(target_arch = "x86_64")]
     fn enable_split_irq(&self) -> Result<()>;
+    #[cfg(target_arch = "x86_64")]
+    fn enable_sgx_attribute(&self, file: File) -> Result<()>;
     /// Retrieve guest clock.
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
     fn get_clock(&self) -> Result<ClockData>;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -724,7 +724,7 @@ impl Vm {
                 memory_manager
                     .lock()
                     .unwrap()
-                    .setup_sgx(sgx_epc_config)
+                    .setup_sgx(sgx_epc_config, &vm)
                     .map_err(Error::MemoryManager)?;
             }
         }


### PR DESCRIPTION
The SGX provisioning feature was exposed to the guest but it was not correctly backed from a host perspective. This PR enables the feature by opening the provisioning device on the host and by enabling the feature through KVM.

Fixes #2756 