### PR TITLE
test: Check latest kvm-bindings works correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 [[package]]
 name = "kvm-bindings"
 version = "0.4.0"
-source = "git+https://github.com/cloud-hypervisor/kvm-bindings?branch=ch-v0.4.0#1a68725639283e622f4bb64584885b30bfe8be44"
+source = "git+https://github.com/sboeuf/kvm-bindings?branch=update_ch_bindings#98c4f033e28059657baf8d171cadc4ec995bf45e"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ clap = { version = "2.33.3", features = ["wrap_help"] }
 
 # List of patched crates
 [patch.crates-io]
-kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.4.0", features = ["with-serde", "fam-wrappers"] }
+#kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.4.0", features = ["with-serde", "fam-wrappers"] }
+kvm-bindings = { git = "https://github.com/sboeuf/kvm-bindings", branch = "update_ch_bindings", features = ["with-serde", "fam-wrappers"] }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory", rev = "5bd7138758183a73ac0da27ce40c004d95f1a7e9"}
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -23,7 +23,8 @@ vm-memory = "0.5.0"
 path = ".."
 
 [patch.crates-io]
-kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.4.0", features = ["with-serde", "fam-wrappers"] }
+#kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.4.0", features = ["with-serde", "fam-wrappers"] }
+kvm-bindings = { git = "https://github.com/sboeuf/kvm-bindings", branch = "update_ch_bindings", features = ["with-serde", "fam-wrappers"], optional = true }
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory", rev = "5bd7138758183a73ac0da27ce40c004d95f1a7e9"}
 
 # Prevent this from interfering with workspaces

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -17,7 +17,8 @@ thiserror = "1.0"
 libc = "0.2.98"
 log = "0.4.14"
 kvm-ioctls = {  version = "0.9.0", optional = true }
-kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.4.0", features = ["with-serde", "fam-wrappers"], optional  = true }
+#kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.4.0", features = ["with-serde", "fam-wrappers"], optional  = true }
+kvm-bindings = { git = "https://github.com/sboeuf/kvm-bindings", branch = "update_ch_bindings", features = ["with-serde", "fam-wrappers"], optional = true }
 mshv-bindings = {git = "https://github.com/cloud-hypervisor/mshv", branch = "master", features = ["with-serde", "fam-wrappers"], optional  = true }
 mshv-ioctls = { git = "https://github.com/cloud-hypervisor/mshv", branch = "master", optional  = true}
 serde = {version = ">=1.0.27", features = ["rc"] }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1057,10 +1057,11 @@ impl cpu::Vcpu for KvmVcpu {
         // https://elixir.free-electrons.com/linux/v4.9.62/source/arch/arm64/include/uapi/asm/kvm.h#L53
         let mut off = offset__of!(kvm_regs, fp_regs) + offset__of!(user_fpsimd_state, vregs);
         for i in 0..32 {
-            state.fp_regs.vregs[i][0] = self
+            state.fp_regs.vregs[i] = self
                 .fd
                 .get_one_reg(arm64_core_reg_id!(KVM_REG_SIZE_U128, off))
-                .map_err(|e| cpu::HypervisorCpuError::GetCoreRegister(e.into()))?;
+                .map_err(|e| cpu::HypervisorCpuError::GetCoreRegister(e.into()))?
+                .into();
             off += mem::size_of::<u128>();
         }
 
@@ -1137,7 +1138,7 @@ impl cpu::Vcpu for KvmVcpu {
             self.fd
                 .set_one_reg(
                     arm64_core_reg_id!(KVM_REG_SIZE_U128, off),
-                    state.fp_regs.vregs[i][0],
+                    state.fp_regs.vregs[i] as u64,
                 )
                 .map_err(|e| cpu::HypervisorCpuError::SetCoreRegister(e.into()))?;
             off += mem::size_of::<u128>();


### PR DESCRIPTION
Rely on branch "update_ch_bindings" from sboeuf's repo in order to
validate the latest kvm-bindings 5.13 work correctly.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>