### PR TITLE
docs, scripts: Use upstream edk2 for AArch64

### DIFF
--- a/docs/arm64.md
+++ b/docs/arm64.md
@@ -60,7 +60,7 @@ This part introduces how to build EDK2 firmware and boot Cloud Hypervisor with i
 $ pushd $CLOUDH
 
 # Clone source code repos
-$ git clone --depth 1 https://github.com/cloud-hypervisor/edk2.git -b ch-aarch64
+$ git clone --depth 1 https://github.com/tianocore/edk2.git -b master
 $ cd edk2
 $ git submodule update --init
 $ cd ..

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -13,9 +13,9 @@ EDK2_BUILD_DIR="$WORKLOADS_DIR/edk2_build"
 mkdir -p "$WORKLOADS_DIR"
 
 build_edk2() {
-    EDK2_REPO="https://github.com/cloud-hypervisor/edk2.git"
+    EDK2_REPO="https://github.com/tianocore/edk2.git"
     EDK2_DIR="edk2"
-    EDK2_BRANCH="ch-aarch64"
+    EDK2_BRANCH="master"
     EDK2_PLAT_REPO="https://github.com/tianocore/edk2-platforms.git"
     EDK2_PLAT_DIR="edk2-platforms"
     ACPICA_REPO="https://github.com/acpica/acpica.git"


### PR DESCRIPTION
The edk2 upstream has already suppoorted AArch64 Cloud Hypervisor (see https://github.com/tianocore/edk2/commit/0e3b6bd0ee753d77c957480657060ae1ea5172b0),
and hence we can use upstream edk2 in CI and doc.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>