### PR TITLE
SGX: Allow EPC sections to be attached to specific NUMA nodes

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -20,6 +20,7 @@ use linux_loader::loader::bootparam::boot_params;
 use linux_loader::loader::elf::start_info::{
     hvm_memmap_table_entry, hvm_modlist_entry, hvm_start_info,
 };
+use std::collections::BTreeMap;
 use std::mem;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
@@ -64,7 +65,7 @@ impl SgxEpcSection {
 pub struct SgxEpcRegion {
     start: GuestAddress,
     size: GuestUsize,
-    epc_sections: Vec<SgxEpcSection>,
+    epc_sections: BTreeMap<String, SgxEpcSection>,
 }
 
 impl SgxEpcRegion {
@@ -72,7 +73,7 @@ impl SgxEpcRegion {
         SgxEpcRegion {
             start,
             size,
-            epc_sections: Vec::new(),
+            epc_sections: BTreeMap::new(),
         }
     }
     pub fn start(&self) -> GuestAddress {
@@ -81,11 +82,11 @@ impl SgxEpcRegion {
     pub fn size(&self) -> GuestUsize {
         self.size
     }
-    pub fn epc_sections(&self) -> &Vec<SgxEpcSection> {
+    pub fn epc_sections(&self) -> &BTreeMap<String, SgxEpcSection> {
         &self.epc_sections
     }
-    pub fn push(&mut self, epc_section: SgxEpcSection) {
-        self.epc_sections.push(epc_section);
+    pub fn insert(&mut self, id: String, epc_section: SgxEpcSection) {
+        self.epc_sections.insert(id, epc_section);
     }
 }
 

--- a/docs/intel_sgx.md
+++ b/docs/intel_sgx.md
@@ -34,7 +34,7 @@ memory, the second one being 32MiB with no pre-allocated memory.
     --disk path=focal-server-cloudimg-amd64.raw \
     --kernel vmlinux \
     --cmdline "console=ttyS0 console=hvc0 root=/dev/vda1 rw" \
-    --sgx-epc size=64M,prefault=on size=32M,prefault=off
+    --sgx-epc id=epc0,size=64M,prefault=on id=epc1,size=32M,prefault=off
 ```
 
 Once booted, and assuming your guest kernel contains the patches from the

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -347,11 +347,12 @@ struct NumaConfig {
     cpus: Option<Vec<u8>>,
     distances: Option<Vec<NumaDistance>>,
     memory_zones: Option<Vec<String>>,
+    sgx_epc_sections: Option<Vec<String>>,
 }
 ```
 
 ```
---numa <numa>	Settings related to a given NUMA node "guest_numa_id=<node_id>,cpus=<cpus_id>,distances=<list_of_distances_to_destination_nodes>,memory_zones=<list_of_memory_zones>"
+--numa <numa>	Settings related to a given NUMA node "guest_numa_id=<node_id>,cpus=<cpus_id>,distances=<list_of_distances_to_destination_nodes>,memory_zones=<list_of_memory_zones>,sgx_epc_sections=<list_of_sgx_epc_sections>"
 ```
 
 ### `guest_numa_id`
@@ -444,6 +445,23 @@ _Example_
 --memory size=0
 --memory-zone id=mem0,size=1G id=mem1,size=1G id=mem2,size=1G
 --numa guest_numa_id=0,memory_zones=mem0:mem2 guest_numa_id=1,memory_zones=mem1
+```
+
+### `sgx_epc_sections`
+
+List of SGX EPC sections attached to the guest NUMA node identified by the
+`guest_numa_id` option. This allows for describing a list of SGX EPC sections
+which must be seen by the guest as belonging to the NUMA node `guest_numa_id`.
+
+Multiple values can be provided to define the list. Each value is a string
+referring to an existing SGX EPC section identifier. Values are separated from
+each other with the `:` separator.
+
+_Example_
+
+```
+--sgx-epc id=epc0,size=32M id=epc1,size=64M id=epc2,size=32M
+--numa guest_numa_id=0,sgx_epc_sections=epc1 guest_numa_id=1,sgx_epc_sections=epc0:epc2
 ```
 
 ### PCI bus

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -343,7 +343,7 @@ it allows for specifying the distance between each NUMA node.
 
 ```rust
 struct NumaConfig {
-    id: u32,
+    guest_numa_id: u32,
     cpus: Option<Vec<u8>>,
     distances: Option<Vec<NumaDistance>>,
     memory_zones: Option<Vec<String>>,
@@ -351,7 +351,7 @@ struct NumaConfig {
 ```
 
 ```
---numa <numa>	Settings related to a given NUMA node "id=<node_id>,cpus=<cpus_id>,distances=<list_of_distances_to_destination_nodes>,memory_zones=<list_of_memory_zones>"
+--numa <numa>	Settings related to a given NUMA node "guest_numa_id=<node_id>,cpus=<cpus_id>,distances=<list_of_distances_to_destination_nodes>,memory_zones=<list_of_memory_zones>"
 ```
 
 ### `guest_numa_id`
@@ -394,8 +394,7 @@ _Example_
 
 ```
 --cpus boot=8
---numa guest_numa_id=0,cpus=1-3:7
---numa guest_numa_id=1,cpus=0:4-6
+--numa guest_numa_id=0,cpus=1-3:7 guest_numa_id=1,cpus=0:4-6
 ```
 
 ### `distances`
@@ -420,9 +419,7 @@ different distances, it can be described with the following example.
 _Example_
 
 ```
---numa guest_numa_id=0,distances=1@15:2@25
---numa guest_numa_id=1,distances=0@15:2@20
---numa guest_numa_id=2,distances=0@25:1@20
+--numa guest_numa_id=0,distances=1@15:2@25 guest_numa_id=1,distances=0@15:2@20 guest_numa_id=2,distances=0@25:1@20
 ```
 
 ### `memory_zones`
@@ -445,11 +442,8 @@ _Example_
 
 ```
 --memory size=0
---memory-zone id=mem0,size=1G
---memory-zone id=mem1,size=1G
---memory-zone id=mem2,size=1G
---numa guest_numa_id=0,memory_zones=mem0:mem2
---numa guest_numa_id=1,memory_zones=mem1
+--memory-zone id=mem0,size=1G id=mem1,size=1G id=mem2,size=1G
+--numa guest_numa_id=0,memory_zones=mem0:mem2 guest_numa_id=1,memory_zones=mem1
 ```
 
 ### PCI bus

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6358,7 +6358,7 @@ mod tests {
                 .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
                 .default_disks()
                 .default_net()
-                .args(&["--sgx-epc", "size=64M"])
+                .args(&["--sgx-epc", "id=epc0,size=64M"])
                 .capture_output()
                 .spawn()
                 .unwrap();

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -898,6 +898,10 @@ components:
           type: array
           items:
             type: string
+        sgx_epc_sections:
+          type: array
+          items:
+            type: string
 
     VmResize:
       type: object

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -851,9 +851,12 @@ components:
 
     SgxEpcConfig:
       required:
+      - id
       - size
       type: object
       properties:
+        id:
+          type: string
         size:
           type: integer
           format: int64

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -218,6 +218,7 @@ impl fmt::Display for Error {
             ParseRestore(o) => write!(f, "Error parsing --restore: {}", o),
             #[cfg(target_arch = "x86_64")]
             ParseSgxEpc(o) => write!(f, "Error parsing --sgx-epc: {}", o),
+            #[cfg(target_arch = "x86_64")]
             ParseSgxEpcIdMissing => write!(f, "Error parsing --sgx-epc: id missing"),
             ParseNuma(o) => write!(f, "Error parsing --numa: {}", o),
             ParseRestoreSourceUrlMissing => {
@@ -1647,19 +1648,23 @@ pub struct NumaConfig {
     pub distances: Option<Vec<NumaDistance>>,
     #[serde(default)]
     pub memory_zones: Option<Vec<String>>,
+    #[cfg(target_arch = "x86_64")]
+    #[serde(default)]
+    pub sgx_epc_sections: Option<Vec<String>>,
 }
 
 impl NumaConfig {
     pub const SYNTAX: &'static str = "Settings related to a given NUMA node \
         \"guest_numa_id=<node_id>,cpus=<cpus_id>,distances=<list_of_distances_to_destination_nodes>,\
-        memory_zones=<list_of_memory_zones>\"";
+        memory_zones=<list_of_memory_zones>,sgx_epc_sections=<list_of_sgx_epc_sections>\"";
     pub fn parse(numa: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser
             .add("guest_numa_id")
             .add("cpus")
             .add("distances")
-            .add("memory_zones");
+            .add("memory_zones")
+            .add("sgx_epc_sections");
         parser.parse(numa).map_err(Error::ParseNuma)?;
 
         let guest_numa_id = parser
@@ -1685,12 +1690,19 @@ impl NumaConfig {
             .convert::<StringList>("memory_zones")
             .map_err(Error::ParseNuma)?
             .map(|v| v.0);
+        #[cfg(target_arch = "x86_64")]
+        let sgx_epc_sections = parser
+            .convert::<StringList>("sgx_epc_sections")
+            .map_err(Error::ParseNuma)?
+            .map(|v| v.0);
 
         Ok(NumaConfig {
             guest_numa_id,
             cpus,
             distances,
             memory_zones,
+            #[cfg(target_arch = "x86_64")]
+            sgx_epc_sections,
         })
     }
 }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -572,7 +572,7 @@ impl CpuManager {
             .unwrap()
             .sgx_epc_region()
             .as_ref()
-            .map(|sgx_epc_region| sgx_epc_region.epc_sections().clone());
+            .map(|sgx_epc_region| sgx_epc_region.epc_sections().values().cloned().collect());
         #[cfg(target_arch = "x86_64")]
         let cpuid = {
             let phys_bits = physical_bits(config.max_phys_bits);

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1458,10 +1458,13 @@ impl MemoryManager {
                 false,
             )?;
 
-            sgx_epc_region.push(SgxEpcSection::new(
-                GuestAddress(epc_section_start),
-                epc_section.size as GuestUsize,
-            ));
+            sgx_epc_region.insert(
+                epc_section.id.clone(),
+                SgxEpcSection::new(
+                    GuestAddress(epc_section_start),
+                    epc_section.size as GuestUsize,
+                ),
+            );
 
             epc_section_start += epc_section.size;
         }


### PR DESCRIPTION
This PR gives the user the ability to choose the NUMA node related to each SGX EPC section.

Fixes #2757