### PR TITLE
arch: x86_64: tdx: Fix HobHandoffInfoTable

### DIFF
--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -144,6 +144,7 @@ unsafe impl ByteValued for HobHeader {}
 struct HobHandoffInfoTable {
     header: HobHeader,
     version: u32,
+    boot_mode: u32,
     efi_memory_top: u64,
     efi_memory_bottom: u64,
     efi_free_memory_top: u64,
@@ -218,6 +219,7 @@ impl TdHob {
                 reserved: 0,
             },
             version: 0x9,
+            boot_mode: 0,
             efi_memory_top: 0,
             efi_memory_bottom: 0,
             efi_free_memory_top: 0,


### PR DESCRIPTION
The handoff table was missing the boot_mode field.

Suggested-by: Jiaqi Gao <jiaqi.gao@intel.com>
Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>