### PR TITLE
Make use of the new KVM feature gate in vfio-ioctls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio-ioctls?branch=master#0f7eb6f855b80d60a7e09ac6df43b46ba69f9e9e"
+source = "git+https://github.com/rust-vmm/vfio-ioctls?branch=master#9b84069e9f419c5369b9a313859cac7e9828d331"
 dependencies = [
  "byteorder",
  "kvm-bindings",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio-ioctls?branch=master#5cb8550556620546e74b9fe6d1174e0d1fc83888"
+source = "git+https://github.com/rust-vmm/vfio-ioctls?branch=master#9b84069e9f419c5369b9a313859cac7e9828d331"
 dependencies = [
  "byteorder",
  "kvm-bindings",

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -4,13 +4,17 @@ version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 
+[features]
+default = []
+kvm = ["vfio-ioctls/kvm"]
+
 [dependencies]
 anyhow = "1.0"
 thiserror = "1.0"
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "master" }
+vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "master", default-features = false }
 vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.3.1"
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 acpi = ["acpi_tables","devices/acpi", "arch/acpi"]
 cmos = ["devices/cmos"]
 fwdebug = ["devices/fwdebug"]
-kvm = ["hypervisor/kvm"]
+kvm = ["hypervisor/kvm", "vfio-ioctls/kvm", "vm-device/kvm"]
 mshv = ["hypervisor/mshv"]
 io_uring = ["virtio-devices/io_uring"]
 tdx = ["arch/tdx", "hypervisor/tdx"]
@@ -44,7 +44,7 @@ thiserror = "1.0"
 uuid = "0.8"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "master" }
+vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "master", default-features = false }
 virtio-devices = { path = "../virtio-devices" }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }


### PR DESCRIPTION
PR rust-vmm/vfio-ioctls#14 has been merged.

Make use of the new feature gate in Cloud Hypervisor.