### PR TITLE
fuzz: patch versionize_derive in Cargo.toml

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -625,8 +625,7 @@ dependencies = [
 [[package]]
 name = "versionize_derive"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140aa9fd298f667ea50fa1cb0d8530076924079285c623b18b8f8a1c28386b4a"
+source = "git+https://github.com/cloud-hypervisor/versionize_derive?branch=ch#ae35ef7a3ddabd3371ab8ac0193a383aff6e4b1b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,6 +25,7 @@ path = ".."
 [patch.crates-io]
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.4.0", features = ["with-serde", "fam-wrappers"] }
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory", rev = "5bd7138758183a73ac0da27ce40c004d95f1a7e9"}
+versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
Just like how it is done in the top-level Cargo.toml.

This fixes a warning [0] when building the fuzzer binaries.

[0] https://github.com/rust-lang/rust/issues/82523

Signed-off-by: Wei Liu <liuwe@microsoft.com>