### PR TITLE
arch, vmm: Move "generate_common_cpuid" from "CpuManager" to "arch"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "vm-fdt",
  "vm-memory",
  "vm-migration",
+ "vmm-sys-util",
 ]
 
 [[package]]

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -23,6 +23,7 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
+vmm-sys-util = { version = ">=0.5.0", features = ["with-serde"] }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 fdt_parser = { version = "0.1.3", package = 'fdt'}

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -83,9 +83,9 @@ pub mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
-    arch_memory_regions, configure_system, configure_vcpu, get_host_cpu_phys_bits,
-    initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START, regs, CpuidPatch,
-    CpuidReg, EntryPoint,
+    arch_memory_regions, configure_system, configure_vcpu, generate_common_cpuid,
+    get_host_cpu_phys_bits, initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE,
+    layout::CMDLINE_START, regs, EntryPoint,
 };
 
 /// Safe wrapper for `sysconf(_SC_PAGESIZE)`.


### PR DESCRIPTION
This refactoring ensures all CPUID related operations are centralized in
`arch::x86_64` module, and exposes only two related public functions to
the vmm crate, e.g. `generate_common_cpuid` and `configure_vcpu`.

Signed-off-by: Bo Chen <chen.bo@intel.com>