### PR TITLE
vmm: Force VIRTIO_F_IOMMU_PLATFORM when running TDX

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -538,6 +538,11 @@ impl Vm {
         let numa_nodes =
             Self::create_numa_nodes(config.lock().unwrap().numa.clone(), &memory_manager)?;
 
+        #[cfg(feature = "tdx")]
+        let force_iommu = config.lock().unwrap().tdx.is_some();
+        #[cfg(not(feature = "tdx"))]
+        let force_iommu = false;
+
         let device_manager = DeviceManager::new(
             vm.clone(),
             config.clone(),
@@ -548,6 +553,7 @@ impl Vm {
             #[cfg(feature = "acpi")]
             numa_nodes.clone(),
             &activate_evt,
+            force_iommu,
         )
         .map_err(Error::DeviceManager)?;
 


### PR DESCRIPTION
When running a TDX guest, we need the virtio drivers to use the DMA API
to share specific memory pages with the VMM on the host. The point is to
let the VMM get access to the pages related to the buffers pointed by
the virtqueues.

The way to force the virtio drivers to use the DMA API is by exposing
the virtio devices with the feature VIRTIO_F_IOMMU_PLATFORM. This is a
feature indicating the device will require some address translation, as
it will not deal directly with physical addresses.

Cloud Hypervisor takes care of this requirement by adding a generic
parameter called "force_iommu". This parameter value is decided based on
the "tdx" feature gate, and then passed to the DeviceManager. It's up to
the DeviceManager to use this parameter on every virtio device creation,
which will imply setting the VIRTIO_F_IOMMU_PLATFORM feature.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>