### PR TITLE
vmm: Limit physical address space for TDX

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -533,7 +533,11 @@ impl CpuManager {
             .map(|sgx_epc_region| sgx_epc_region.epc_sections().values().cloned().collect());
         #[cfg(target_arch = "x86_64")]
         let cpuid = {
-            let phys_bits = physical_bits(config.max_phys_bits);
+            let phys_bits = physical_bits(
+                config.max_phys_bits,
+                #[cfg(feature = "tdx")]
+                tdx_enabled,
+            );
             arch::generate_common_cpuid(
                 hypervisor,
                 config


### PR DESCRIPTION
When running TDX guest, the Guest Physical Address space is limited by
a shared bit that is located on bit 47 for 4 level paging, and on bit 51
for 5 level paging (when GPAW bit is 1). In order to keep things simple,
and since a 47 bits address space is 128TiB large, we ensure to limit
the physical addressable space to 47 bits when runnning TDX.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>