### PR TITLE
Add macvtap hotplug support and validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,9 @@ checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 [[package]]
 name = "api_client"
 version = "0.1.0"
+dependencies = [
+ "vmm-sys-util",
+]
 
 [[package]]
 name = "arc-swap"

--- a/api_client/Cargo.toml
+++ b/api_client/Cargo.toml
@@ -3,3 +3,6 @@ name = "api_client"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
+
+[dependencies]
+vmm-sys-util = "0.8.0"

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -588,6 +588,7 @@ fn api_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         #[cfg(target_arch = "x86_64")]
         allow_syscall(libc::SYS_epoll_wait),
         allow_syscall(libc::SYS_exit),
+        allow_syscall(libc::SYS_fcntl),
         allow_syscall(libc::SYS_futex),
         allow_syscall(libc::SYS_getrandom),
         allow_syscall_if(libc::SYS_ioctl, create_api_ioctl_seccomp_rule()?),


### PR DESCRIPTION
By adding the support for sending file descriptor along with the `add-net` command through the `ch-remote` tool, we are now able to provide a dedicated integration test validating that a `macvtap` interface can be hotplugged after the VMM has been started.