### PR TITLE
Add live migration support on MSHV

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -472,7 +472,7 @@ impl vm::Vm for KvmVm {
     ///
     /// Get dirty pages bitmap (one bit per page)
     ///
-    fn get_dirty_log(&self, slot: u32, memory_size: u64) -> vm::Result<Vec<u64>> {
+    fn get_dirty_log(&self, slot: u32, _base_gpa: u64, memory_size: u64) -> vm::Result<Vec<u64>> {
         self.fd
             .get_dirty_log(slot, memory_size as usize)
             .map_err(|e| vm::HypervisorVmError::GetDirtyLog(e.into()))

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -285,7 +285,7 @@ pub trait Vm: Send + Sync {
     /// Stop logging dirty pages
     fn stop_dirty_log(&self) -> Result<()>;
     /// Get dirty pages bitmap
-    fn get_dirty_log(&self, slot: u32, memory_size: u64) -> Result<Vec<u64>>;
+    fn get_dirty_log(&self, slot: u32, base_gpa: u64, memory_size: u64) -> Result<Vec<u64>>;
     #[cfg(feature = "tdx")]
     /// Initalize TDX on this VM
     fn tdx_init(&self, cpuid: &CpuId, max_vcpus: u32) -> Result<()>;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1502,7 +1502,7 @@ impl MemoryManager {
         let page_size = 4096; // TODO: Does this need to vary?
         let mut table = MemoryRangeTable::default();
         for r in &self.guest_ram_mappings {
-            let vm_dirty_bitmap = self.vm.get_dirty_log(r.slot, r.size).map_err(|e| {
+            let vm_dirty_bitmap = self.vm.get_dirty_log(r.slot, r.gpa, r.size).map_err(|e| {
                 MigratableError::MigrateSend(anyhow!("Error getting VM dirty log {}", e))
             })?;
             let vmm_dirty_bitmap = match self.guest_memory.memory().find_region(GuestAddress(r.gpa))

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -141,6 +141,8 @@ mod mshv {
     pub const MSHV_RUN_VP: u64 = 0x8100_b807;
     pub const MSHV_GET_VP_STATE: u64 = 0xc028_b80a;
     pub const MSHV_SET_VP_STATE: u64 = 0xc028_b80b;
+    pub const MSHV_SET_PARTITION_PROPERTY: u64 = 0x4010_b80c;
+    pub const MSHV_GET_GPA_ACCESS_STATES: u64 = 0xc01c_b812;
 }
 #[cfg(feature = "mshv")]
 use mshv::*;
@@ -161,6 +163,13 @@ fn create_vmm_ioctl_seccomp_rule_common_mshv() -> Result<Vec<SeccompRule>, Error
         and![Cond::new(1, ArgLen::DWORD, Eq, MSHV_RUN_VP)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, MSHV_GET_VP_STATE)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, MSHV_SET_VP_STATE)?],
+        and![Cond::new(
+            1,
+            ArgLen::DWORD,
+            Eq,
+            MSHV_SET_PARTITION_PROPERTY
+        )?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, MSHV_GET_GPA_ACCESS_STATES)?],
     ])
 }
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -143,6 +143,7 @@ mod mshv {
     pub const MSHV_SET_VP_STATE: u64 = 0xc028_b80b;
     pub const MSHV_SET_PARTITION_PROPERTY: u64 = 0x4010_b80c;
     pub const MSHV_GET_GPA_ACCESS_STATES: u64 = 0xc01c_b812;
+    pub const MSHV_VP_TRANSLATE_GVA: u64 = 0xc020_b80e;
 }
 #[cfg(feature = "mshv")]
 use mshv::*;
@@ -170,6 +171,7 @@ fn create_vmm_ioctl_seccomp_rule_common_mshv() -> Result<Vec<SeccompRule>, Error
             MSHV_SET_PARTITION_PROPERTY
         )?],
         and![Cond::new(1, ArgLen::DWORD, Eq, MSHV_GET_GPA_ACCESS_STATES)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, MSHV_VP_TRANSLATE_GVA)?],
     ])
 }
 


### PR DESCRIPTION
This PR adds the APIs needed for live migrations on MSHV. Modifies existing get_dirty_log function to accept extra parameters needed for MSHV. Implement start/stop_dirty_log for MSHV. For this PR I have tested Live migrations and measures some numbers. The numbers are very close to KVM.  Steps used to test this on MSHV:

Source VM:

sudo ./cloud-hypervisor/target/release/cloud-hypervisor --kernel ./linux-cloud-hypervisor/arch/x86/boot/compressed/vmlinux.bin --disk path=focal-server-cloudimg-amd64.raw --cpus boot=4 --memory size=1G --cmdline "root=/dev/vda1 console=ttyS0" --serial tty --console off --api-socket=/tmp/api1 


Destination VM: 
sudo ./cloud-hypervisor/target/release/cloud-hypervisor --api-socket=/tmp/api2

#Receiving migration for the destination

sudo ./cloud-hypervisor/target/release/ch-remote --api-socket=/tmp/api2 receive-migration unix:/tmp/sock

#Send migration
time sudo ./cloud-hypervisor/target/release/ch-remote --api-socket=/tmp/api1 send-migration unix:/tmp/sock
