### PR TITLE
hypervisor, vmm: Add dynamic control of logging dirty pages for live-migration

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -384,6 +384,59 @@ impl vm::Vm for KvmVm {
     }
 
     ///
+    /// Start logging dirty pages
+    ///
+    fn start_dirty_log(
+        &self,
+        slot: u32,
+        guest_phys_addr: u64,
+        memory_size: u64,
+        userspace_addr: u64,
+    ) -> vm::Result<()> {
+        let region = self.make_user_memory_region(
+            slot,
+            guest_phys_addr,
+            memory_size,
+            userspace_addr,
+            false,
+            true,
+        );
+        // Safe because guest regions are guaranteed not to overlap.
+        unsafe {
+            self.fd
+                .set_user_memory_region(region)
+                .map_err(|e| vm::HypervisorVmError::StartDirtyLog(e.into()))
+        }
+    }
+
+    ///
+    /// Stop logging dirty pages
+    ///
+    fn stop_dirty_log(
+        &self,
+        slot: u32,
+        guest_phys_addr: u64,
+        memory_size: u64,
+        userspace_addr: u64,
+    ) -> vm::Result<()> {
+        let region = self.make_user_memory_region(
+            slot,
+            guest_phys_addr,
+            memory_size,
+            userspace_addr,
+            false,
+            false,
+        );
+
+        // Safe because guest regions are guaranteed not to overlap.
+        unsafe {
+            self.fd
+                .set_user_memory_region(region)
+                .map_err(|e| vm::HypervisorVmError::StopDirtyLog(e.into()))
+        }
+    }
+
+    ///
     /// Get dirty pages bitmap (one bit per page)
     ///
     fn get_dirty_log(&self, slot: u32, memory_size: u64) -> vm::Result<Vec<u64>> {

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -877,6 +877,34 @@ impl vm::Vm for MshvVm {
         Ok(())
     }
     ///
+    /// Start logging dirty pages
+    ///
+    fn start_dirty_log(
+        &self,
+        _slot: u32,
+        _guest_phys_addr: u64,
+        _memory_size: u64,
+        _userspace_addr: u64,
+    ) -> vm::Result<()> {
+        Err(vm::HypervisorVmError::StartDirtyLog(anyhow!(
+            "functionality not implemented"
+        )))
+    }
+    ///
+    /// Stop logging dirty pages
+    ///
+    fn stop_dirty_log(
+        &self,
+        _slot: u32,
+        _guest_phys_addr: u64,
+        _memory_size: u64,
+        _userspace_addr: u64,
+    ) -> vm::Result<()> {
+        Err(vm::HypervisorVmError::StopDirtyLog(anyhow!(
+            "functionality not implemented"
+        )))
+    }
+    ///
     /// Get dirty pages bitmap (one bit per page)
     ///
     fn get_dirty_log(&self, _slot: u32, _memory_size: u64) -> vm::Result<Vec<u64>> {

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -168,6 +168,16 @@ pub enum HypervisorVmError {
     #[error("Failed to write to IO Bus: {0}")]
     IoBusWrite(#[source] anyhow::Error),
     ///
+    /// Start dirty log error
+    ///
+    #[error("Failed to get dirty log: {0}")]
+    StartDirtyLog(#[source] anyhow::Error),
+    ///
+    /// Stop dirty log error
+    ///
+    #[error("Failed to get dirty log: {0}")]
+    StopDirtyLog(#[source] anyhow::Error),
+    ///
     /// Get dirty log error
     ///
     #[error("Failed to get dirty log: {0}")]
@@ -270,6 +280,22 @@ pub trait Vm: Send + Sync {
     fn state(&self) -> Result<VmState>;
     /// Set the VM state
     fn set_state(&self, state: VmState) -> Result<()>;
+    /// Start logging dirty pages
+    fn start_dirty_log(
+        &self,
+        slot: u32,
+        guest_phys_addr: u64,
+        memory_size: u64,
+        userspace_addr: u64,
+    ) -> Result<()>;
+    /// Stop logging dirty pages
+    fn stop_dirty_log(
+        &self,
+        slot: u32,
+        guest_phys_addr: u64,
+        memory_size: u64,
+        userspace_addr: u64,
+    ) -> Result<()>;
     /// Get dirty pages bitmap
     fn get_dirty_log(&self, slot: u32, memory_size: u64) -> Result<Vec<u64>>;
     #[cfg(feature = "tdx")]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2233,9 +2233,7 @@ impl DeviceManager {
                     .memory_manager
                     .lock()
                     .unwrap()
-                    .create_userspace_mapping(
-                        cache_base, cache_size, host_addr, false, false, false,
-                    )
+                    .create_userspace_mapping(cache_base, cache_size, host_addr, false, false)
                     .map_err(DeviceManagerError::MemoryManager)?;
 
                 let region_list = vec![VirtioSharedMemory {
@@ -2426,7 +2424,6 @@ impl DeviceManager {
                 region_size,
                 host_addr,
                 pmem_cfg.mergeable,
-                false,
                 false,
             )
             .map_err(DeviceManagerError::MemoryManager)?;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1049,6 +1049,9 @@ impl Vmm {
             // Send last batch of dirty pages
             Self::vm_maybe_send_dirty_pages(vm, &mut socket)?;
 
+            // Stop logging dirty pages
+            vm.stop_memory_dirty_log()?;
+
             // Capture snapshot and send it
             let vm_snapshot = vm.snapshot()?;
             let snapshot_data = serde_json::to_vec(&vm_snapshot).unwrap();

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2156,6 +2156,10 @@ impl Vm {
         self.memory_manager.lock().unwrap().start_memory_dirty_log()
     }
 
+    pub fn stop_memory_dirty_log(&self) -> std::result::Result<(), MigratableError> {
+        self.memory_manager.lock().unwrap().stop_memory_dirty_log()
+    }
+
     pub fn dirty_memory_range_table(
         &self,
     ) -> std::result::Result<MemoryRangeTable, MigratableError> {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -765,8 +765,6 @@ impl Vm {
             &config.lock().unwrap().memory.clone(),
             false,
             phys_bits,
-            #[cfg(feature = "tdx")]
-            tdx_enabled,
         )
         .map_err(Error::MemoryManager)?;
 
@@ -887,8 +885,6 @@ impl Vm {
             &config.lock().unwrap().memory.clone(),
             false,
             phys_bits,
-            #[cfg(feature = "tdx")]
-            false,
         )
         .map_err(Error::MemoryManager)?;
 


### PR DESCRIPTION
This patch extends slightly the current live-migration code path with
the ability to dynamically start and stop logging dirty-pages, which
relies on two new methods added to the `hypervisor::vm::Vm` Trait. This
patch also contains a complete implementation of the two new methods
based on `kvm` and placeholders for `mshv` in the `hypervisor` crate.

Fixes: #2858

Signed-off-by: Bo Chen <chen.bo@intel.com>