### PR TITLE
build: bump seccomp from v0.24.4 to v0.24.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "seccomp"
 version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/firecracker?tag=v0.24.4#8f44986a0e956a77f2b2324c12f73bec16130c82"
+source = "git+https://github.com/firecracker-microvm/firecracker?tag=v0.24.5#cd36c699f3cb3d531289aadee26c45c1306edcfc"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hypervisor = { path = "hypervisor" }
 libc = "0.2.98"
 log = { version = "0.4.14", features = ["std"] }
 option_parser = { path = "option_parser" }
-seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.24.4" }
+seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.24.5" }
 serde_json = "1.0.64"
 signal-hook = "0.3.9"
 thiserror = "1.0.26"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -470,7 +470,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 [[package]]
 name = "seccomp"
 version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/firecracker?tag=v0.24.4#8f44986a0e956a77f2b2324c12f73bec16130c82"
+source = "git+https://github.com/firecracker-microvm/firecracker?tag=v0.24.5#cd36c699f3cb3d531289aadee26c45c1306edcfc"
 dependencies = [
  "libc",
 ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ block_util = { path = "../block_util" }
 libc = "0.2.98"
 libfuzzer-sys = "0.4.2"
 qcow = { path = "../qcow" }
-seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.24.4" }
+seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.24.5" }
 virtio-devices = { path = "../virtio-devices" }
 vmm-sys-util = "0.8.0"
 vm-virtio = { path = "../vm-virtio" }

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -23,7 +23,7 @@ net_gen = { path = "../net_gen" }
 net_util = { path = "../net_util" }
 pci = { path = "../pci" }
 rate_limiter = { path = "../rate_limiter" }
-seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.24.4" }
+seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.24.5" }
 serde = ">=1.0.27"
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -35,7 +35,7 @@ net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
 pci = { path = "../pci" }
 qcow = { path = "../qcow" }
-seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.24.4" }
+seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.24.5" }
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"


### PR DESCRIPTION
Updating both the global `Cargo.lock` and the one in `fuzz` crate to bump `seccomp` from v0.24.4 to v0.24.5.