### PR TITLE
hypervisor, vmm: Abstract the interfaces to start/stop dirty log to support both KVM and MSHV

### DIFF
--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -879,13 +879,7 @@ impl vm::Vm for MshvVm {
     ///
     /// Start logging dirty pages
     ///
-    fn start_dirty_log(
-        &self,
-        _slot: u32,
-        _guest_phys_addr: u64,
-        _memory_size: u64,
-        _userspace_addr: u64,
-    ) -> vm::Result<()> {
+    fn start_dirty_log(&self) -> vm::Result<()> {
         Err(vm::HypervisorVmError::StartDirtyLog(anyhow!(
             "functionality not implemented"
         )))
@@ -893,13 +887,7 @@ impl vm::Vm for MshvVm {
     ///
     /// Stop logging dirty pages
     ///
-    fn stop_dirty_log(
-        &self,
-        _slot: u32,
-        _guest_phys_addr: u64,
-        _memory_size: u64,
-        _userspace_addr: u64,
-    ) -> vm::Result<()> {
+    fn stop_dirty_log(&self) -> vm::Result<()> {
         Err(vm::HypervisorVmError::StopDirtyLog(anyhow!(
             "functionality not implemented"
         )))

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -281,21 +281,9 @@ pub trait Vm: Send + Sync {
     /// Set the VM state
     fn set_state(&self, state: VmState) -> Result<()>;
     /// Start logging dirty pages
-    fn start_dirty_log(
-        &self,
-        slot: u32,
-        guest_phys_addr: u64,
-        memory_size: u64,
-        userspace_addr: u64,
-    ) -> Result<()>;
+    fn start_dirty_log(&self) -> Result<()>;
     /// Stop logging dirty pages
-    fn stop_dirty_log(
-        &self,
-        slot: u32,
-        guest_phys_addr: u64,
-        memory_size: u64,
-        userspace_addr: u64,
-    ) -> Result<()>;
+    fn stop_dirty_log(&self) -> Result<()>;
     /// Get dirty pages bitmap
     fn get_dirty_log(&self, slot: u32, memory_size: u64) -> Result<Vec<u64>>;
     #[cfg(feature = "tdx")]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2233,7 +2233,9 @@ impl DeviceManager {
                     .memory_manager
                     .lock()
                     .unwrap()
-                    .create_userspace_mapping(cache_base, cache_size, host_addr, false, false)
+                    .create_userspace_mapping(
+                        cache_base, cache_size, host_addr, false, false, false,
+                    )
                     .map_err(DeviceManagerError::MemoryManager)?;
 
                 let region_list = vec![VirtioSharedMemory {
@@ -2424,6 +2426,7 @@ impl DeviceManager {
                 region_size,
                 host_addr,
                 pmem_cfg.mergeable,
+                false,
                 false,
             )
             .map_err(DeviceManagerError::MemoryManager)?;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -139,6 +139,7 @@ pub struct MemoryManager {
     user_provided_zones: bool,
     snapshot_memory_regions: Vec<MemoryRegion>,
     memory_zones: MemoryZones,
+    log_dirty: bool, // Enable dirty logging for created RAM regions
 
     // Keep track of calls to create_userspace_mapping() for guest RAM.
     // This is useful for getting the dirty pages as we need to know the
@@ -509,6 +510,7 @@ impl MemoryManager {
         config: &MemoryConfig,
         prefault: bool,
         phys_bits: u8,
+        #[cfg(feature = "tdx")] tdx_enabled: bool,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
         let user_provided_zones = config.size == 0;
         let mut allow_mem_hotplug: bool = false;
@@ -747,6 +749,11 @@ impl MemoryManager {
             .allocate_mmio_addresses(None, MEMORY_MANAGER_ACPI_SIZE as u64, None)
             .ok_or(Error::AllocateMmioAddress)?;
 
+        #[cfg(not(feature = "tdx"))]
+        let log_dirty = true;
+        #[cfg(feature = "tdx")]
+        let log_dirty = !tdx_enabled; // Cannot log dirty pages on a TD
+
         let memory_manager = Arc::new(Mutex::new(MemoryManager {
             boot_guest_memory,
             guest_memory: guest_memory.clone(),
@@ -774,6 +781,7 @@ impl MemoryManager {
             guest_ram_mappings: Vec::new(),
             #[cfg(feature = "acpi")]
             acpi_address,
+            log_dirty,
         }));
 
         for region in guest_memory.memory().iter() {
@@ -784,6 +792,7 @@ impl MemoryManager {
                 region.as_ptr() as u64,
                 config.mergeable,
                 false,
+                log_dirty,
             )?;
             mm.guest_ram_mappings.push(GuestRamMapping {
                 gpa: region.start_addr().raw_value(),
@@ -800,6 +809,7 @@ impl MemoryManager {
                 region.as_ptr() as u64,
                 config.mergeable,
                 false,
+                log_dirty,
             )?;
 
             mm.guest_ram_mappings.push(GuestRamMapping {
@@ -835,7 +845,14 @@ impl MemoryManager {
         prefault: bool,
         phys_bits: u8,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
-        let mm = MemoryManager::new(vm, config, prefault, phys_bits)?;
+        let mm = MemoryManager::new(
+            vm,
+            config,
+            prefault,
+            phys_bits,
+            #[cfg(feature = "tdx")]
+            false,
+        )?;
 
         if let Some(source_url) = source_url {
             let vm_snapshot_path = url_to_path(source_url).map_err(Error::Restore)?;
@@ -1101,6 +1118,7 @@ impl MemoryManager {
             region.as_ptr() as u64,
             self.mergeable,
             false,
+            self.log_dirty,
         )?;
         self.guest_ram_mappings.push(GuestRamMapping {
             gpa: region.start_addr().raw_value(),
@@ -1192,6 +1210,7 @@ impl MemoryManager {
         userspace_addr: u64,
         mergeable: bool,
         readonly: bool,
+        log_dirty: bool,
     ) -> Result<u32, Error> {
         let slot = self.allocate_memory_slot();
         let mem_region = self.vm.make_user_memory_region(
@@ -1200,7 +1219,7 @@ impl MemoryManager {
             memory_size,
             userspace_addr,
             readonly,
-            false, // Always create memory regions without dirty pages log
+            log_dirty,
         );
 
         self.vm
@@ -1434,6 +1453,7 @@ impl MemoryManager {
                 epc_section_start,
                 epc_section.size,
                 host_addr,
+                false,
                 false,
                 false,
             )?;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -765,6 +765,8 @@ impl Vm {
             &config.lock().unwrap().memory.clone(),
             false,
             phys_bits,
+            #[cfg(feature = "tdx")]
+            tdx_enabled,
         )
         .map_err(Error::MemoryManager)?;
 
@@ -885,6 +887,8 @@ impl Vm {
             &config.lock().unwrap().memory.clone(),
             false,
             phys_bits,
+            #[cfg(feature = "tdx")]
+            false,
         )
         .map_err(Error::MemoryManager)?;
 


### PR DESCRIPTION
Following KVM interfaces, the `hypervisor` crate now provides interfaces
to start/stop the dirty pages logging on a per region basis, and asks
its users (e.g. the `vmm` crate) to iterate over the regions that needs
dirty pages log. MSHV only has a global control to start/stop dirty
pages log on all regions at once.

This patch refactors related APIs from the `hypervisor` crate to provide
a global control to start/stop dirty pages log (following MSHV's
behaviors), and keeps tracking the regions need dirty pages log for
KVM. It avoids leaking hypervisor-specific behaviors out of the
`hypervisor` crate.

This use the above changes, we also need to explicitly tell the hypervisor (KVM)
whether a region needs dirty-pages-log when it is created. This is done through
reverting commit  f063346.

Signed-off-by: Bo Chen <chen.bo@intel.com>
