### PR TITLE
clippy: Fix redundant allocations

### DIFF
--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -62,7 +62,7 @@ impl BusDevice for AcpiShutdownDevice {
 
 /// A device for handling ACPI GED event generation
 pub struct AcpiGedDevice {
-    interrupt: Arc<Box<dyn InterruptSourceGroup>>,
+    interrupt: Arc<dyn InterruptSourceGroup>,
     notification_type: AcpiNotificationFlags,
     ged_irq: u32,
     address: GuestAddress,
@@ -70,7 +70,7 @@ pub struct AcpiGedDevice {
 
 impl AcpiGedDevice {
     pub fn new(
-        interrupt: Arc<Box<dyn InterruptSourceGroup>>,
+        interrupt: Arc<dyn InterruptSourceGroup>,
         ged_irq: u32,
         address: GuestAddress,
     ) -> AcpiGedDevice {

--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -26,7 +26,7 @@ pub const IRQ_LEGACY_COUNT: usize = 32;
 //   1. Move Gic*.rs from arch/ folder here.
 //   2. Move this file and ioapic.rs to arch/, as they are architecture specific.
 pub struct Gic {
-    interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+    interrupt_source_group: Arc<dyn InterruptSourceGroup>,
     gic_device: Option<Arc<Mutex<Box<dyn GicDevice>>>>,
 }
 

--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -134,7 +134,7 @@ pub struct Ioapic {
     reg_entries: [RedirectionTableEntry; NUM_IOAPIC_PINS],
     used_entries: [bool; NUM_IOAPIC_PINS],
     apic_address: GuestAddress,
-    interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+    interrupt_source_group: Arc<dyn InterruptSourceGroup>,
 }
 
 #[derive(Versionize)]

--- a/devices/src/legacy/gpio_pl061.rs
+++ b/devices/src/legacy/gpio_pl061.rs
@@ -86,7 +86,7 @@ pub struct Gpio {
     // Mode Control Select Register
     afsel: u32,
     // GPIO irq_field
-    interrupt: Arc<Box<dyn InterruptSourceGroup>>,
+    interrupt: Arc<dyn InterruptSourceGroup>,
 }
 
 #[derive(Versionize)]
@@ -106,7 +106,7 @@ impl VersionMapped for GpioState {}
 
 impl Gpio {
     /// Constructs an PL061 GPIO device.
-    pub fn new(id: String, interrupt: Arc<Box<dyn InterruptSourceGroup>>) -> Self {
+    pub fn new(id: String, interrupt: Arc<dyn InterruptSourceGroup>) -> Self {
         Self {
             id,
             data: 0,
@@ -376,7 +376,7 @@ mod tests {
         let intr_evt = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let mut gpio = Gpio::new(
             String::from(GPIO_NAME),
-            Arc::new(Box::new(TestInterrupt::new(intr_evt.try_clone().unwrap()))),
+            Arc::new(TestInterrupt::new(intr_evt.try_clone().unwrap())),
         );
         let mut data = [0; 4];
 

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -224,12 +224,12 @@ pub struct Rtc {
     load: u32,
     imsc: u32,
     ris: u32,
-    interrupt: Arc<Box<dyn InterruptSourceGroup>>,
+    interrupt: Arc<dyn InterruptSourceGroup>,
 }
 
 impl Rtc {
     /// Constructs an AMBA PL031 RTC device.
-    pub fn new(interrupt: Arc<Box<dyn InterruptSourceGroup>>) -> Self {
+    pub fn new(interrupt: Arc<dyn InterruptSourceGroup>) -> Self {
         Self {
             // This is used only for duration measuring purposes.
             previous_now: Instant::now(),
@@ -450,9 +450,7 @@ mod tests {
     fn test_rtc_read_write_and_event() {
         let intr_evt = EventFd::new(libc::EFD_NONBLOCK).unwrap();
 
-        let mut rtc = Rtc::new(Arc::new(Box::new(TestInterrupt::new(
-            intr_evt.try_clone().unwrap(),
-        ))));
+        let mut rtc = Rtc::new(Arc::new(TestInterrupt::new(intr_evt.try_clone().unwrap())));
         let mut data = [0; 4];
 
         // Read and write to the MR register.

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -63,7 +63,7 @@ pub struct Serial {
     id: String,
     interrupt_enable: u8,
     interrupt_identification: u8,
-    interrupt: Arc<Box<dyn InterruptSourceGroup>>,
+    interrupt: Arc<dyn InterruptSourceGroup>,
     line_control: u8,
     line_status: u8,
     modem_control: u8,
@@ -91,7 +91,7 @@ impl VersionMapped for SerialState {}
 impl Serial {
     pub fn new(
         id: String,
-        interrupt: Arc<Box<dyn InterruptSourceGroup>>,
+        interrupt: Arc<dyn InterruptSourceGroup>,
         out: Option<Box<dyn io::Write + Send>>,
     ) -> Serial {
         Serial {
@@ -113,14 +113,14 @@ impl Serial {
     /// Constructs a Serial port ready for output.
     pub fn new_out(
         id: String,
-        interrupt: Arc<Box<dyn InterruptSourceGroup>>,
+        interrupt: Arc<dyn InterruptSourceGroup>,
         out: Box<dyn io::Write + Send>,
     ) -> Serial {
         Self::new(id, interrupt, Some(out))
     }
 
     /// Constructs a Serial port with no connected output.
-    pub fn new_sink(id: String, interrupt: Arc<Box<dyn InterruptSourceGroup>>) -> Serial {
+    pub fn new_sink(id: String, interrupt: Arc<dyn InterruptSourceGroup>) -> Serial {
         Self::new(id, interrupt, None)
     }
 
@@ -370,7 +370,7 @@ mod tests {
         let serial_out = SharedBuffer::new();
         let mut serial = Serial::new_out(
             String::from(SERIAL_NAME),
-            Arc::new(Box::new(TestInterrupt::new(intr_evt.try_clone().unwrap()))),
+            Arc::new(TestInterrupt::new(intr_evt.try_clone().unwrap())),
             Box::new(serial_out.clone()),
         );
 
@@ -390,7 +390,7 @@ mod tests {
         let serial_out = SharedBuffer::new();
         let mut serial = Serial::new_out(
             String::from(SERIAL_NAME),
-            Arc::new(Box::new(TestInterrupt::new(intr_evt.try_clone().unwrap()))),
+            Arc::new(TestInterrupt::new(intr_evt.try_clone().unwrap())),
             Box::new(serial_out),
         );
 
@@ -427,7 +427,7 @@ mod tests {
         let intr_evt = EventFd::new(0).unwrap();
         let mut serial = Serial::new_sink(
             String::from(SERIAL_NAME),
-            Arc::new(Box::new(TestInterrupt::new(intr_evt.try_clone().unwrap()))),
+            Arc::new(TestInterrupt::new(intr_evt.try_clone().unwrap())),
         );
 
         // write 1 to the interrupt event fd, so that read doesn't block in case the event fd
@@ -449,7 +449,7 @@ mod tests {
         let intr_evt = EventFd::new(0).unwrap();
         let mut serial = Serial::new_sink(
             String::from(SERIAL_NAME),
-            Arc::new(Box::new(TestInterrupt::new(intr_evt.try_clone().unwrap()))),
+            Arc::new(TestInterrupt::new(intr_evt.try_clone().unwrap())),
         );
 
         serial.write(0, LCR as u64, &[LCR_DLAB_BIT]);
@@ -470,7 +470,7 @@ mod tests {
         let intr_evt = EventFd::new(0).unwrap();
         let mut serial = Serial::new_sink(
             String::from(SERIAL_NAME),
-            Arc::new(Box::new(TestInterrupt::new(intr_evt.try_clone().unwrap()))),
+            Arc::new(TestInterrupt::new(intr_evt.try_clone().unwrap())),
         );
 
         serial.write(0, MCR as u64, &[MCR_LOOP_BIT]);
@@ -496,7 +496,7 @@ mod tests {
         let intr_evt = EventFd::new(0).unwrap();
         let mut serial = Serial::new_sink(
             String::from(SERIAL_NAME),
-            Arc::new(Box::new(TestInterrupt::new(intr_evt.try_clone().unwrap()))),
+            Arc::new(TestInterrupt::new(intr_evt.try_clone().unwrap())),
         );
 
         serial.write(0, SCR as u64, &[0x12]);

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -86,7 +86,7 @@ pub struct Pl011 {
     ifl: u32,
     read_count: u32,
     read_trigger: u32,
-    irq: Arc<Box<dyn InterruptSourceGroup>>,
+    irq: Arc<dyn InterruptSourceGroup>,
     out: Option<Box<dyn io::Write + Send>>,
 }
 
@@ -114,7 +114,7 @@ impl Pl011 {
     /// Constructs an AMBA PL011 UART device.
     pub fn new(
         id: String,
-        irq: Arc<Box<dyn InterruptSourceGroup>>,
+        irq: Arc<dyn InterruptSourceGroup>,
         out: Option<Box<dyn io::Write + Send>>,
     ) -> Self {
         Self {
@@ -440,7 +440,7 @@ mod tests {
         let pl011_out = SharedBuffer::new();
         let mut pl011 = Pl011::new(
             String::from(SERIAL_NAME),
-            Arc::new(Box::new(TestInterrupt::new(intr_evt.try_clone().unwrap()))),
+            Arc::new(TestInterrupt::new(intr_evt.try_clone().unwrap())),
             Some(Box::new(pl011_out.clone())),
         );
 
@@ -460,7 +460,7 @@ mod tests {
         let pl011_out = SharedBuffer::new();
         let mut pl011 = Pl011::new(
             String::from(SERIAL_NAME),
-            Arc::new(Box::new(TestInterrupt::new(intr_evt.try_clone().unwrap()))),
+            Arc::new(TestInterrupt::new(intr_evt.try_clone().unwrap())),
             Some(Box::new(pl011_out)),
         );
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -178,7 +178,7 @@ impl vm::Vm for KvmVm {
     fn create_vcpu(
         &self,
         id: u8,
-        vmmops: Option<Arc<Box<dyn VmmOps>>>,
+        vmmops: Option<Arc<dyn VmmOps>>,
     ) -> vm::Result<Arc<dyn cpu::Vcpu>> {
         let vc = self
             .fd
@@ -731,7 +731,7 @@ pub struct KvmVcpu {
     fd: VcpuFd,
     #[cfg(target_arch = "x86_64")]
     msrs: MsrEntries,
-    vmmops: Option<Arc<Box<dyn vm::VmmOps>>>,
+    vmmops: Option<Arc<dyn vm::VmmOps>>,
     #[cfg(target_arch = "x86_64")]
     hyperv_synic: AtomicBool,
 }

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -133,7 +133,7 @@ pub struct MshvVcpu {
     cpuid: CpuId,
     msrs: MsrEntries,
     hv_state: Arc<RwLock<HvState>>, // Mshv State
-    vmmops: Option<Arc<Box<dyn vm::VmmOps>>>,
+    vmmops: Option<Arc<dyn vm::VmmOps>>,
 }
 
 /// Implementation of Vcpu trait for Microsoft Hypervisor
@@ -680,7 +680,7 @@ pub struct MshvVm {
     msrs: MsrEntries,
     // Hypervisor State
     hv_state: Arc<RwLock<HvState>>,
-    vmmops: Option<Arc<Box<dyn vm::VmmOps>>>,
+    vmmops: Option<Arc<dyn vm::VmmOps>>,
 }
 
 fn hv_state_init() -> Arc<RwLock<HvState>> {
@@ -742,7 +742,7 @@ impl vm::Vm for MshvVm {
     fn create_vcpu(
         &self,
         id: u8,
-        vmmops: Option<Arc<Box<dyn VmmOps>>>,
+        vmmops: Option<Arc<dyn VmmOps>>,
     ) -> vm::Result<Arc<dyn cpu::Vcpu>> {
         let vcpu_fd = self
             .fd

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -228,7 +228,7 @@ pub trait Vm: Send + Sync {
     /// Unregister an event that will, when signaled, trigger the `gsi` IRQ.
     fn unregister_irqfd(&self, fd: &EventFd, gsi: u32) -> Result<()>;
     /// Creates a new KVM vCPU file descriptor and maps the memory corresponding
-    fn create_vcpu(&self, id: u8, vmmops: Option<Arc<Box<dyn VmmOps>>>) -> Result<Arc<dyn Vcpu>>;
+    fn create_vcpu(&self, id: u8, vmmops: Option<Arc<dyn VmmOps>>) -> Result<Arc<dyn Vcpu>>;
     /// Registers an event to be signaled whenever a certain address is written to.
     fn register_ioevent(
         &self,

--- a/pci/src/msi.rs
+++ b/pci/src/msi.rs
@@ -159,11 +159,11 @@ impl MsiCap {
 
 pub struct MsiConfig {
     cap: MsiCap,
-    interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+    interrupt_source_group: Arc<dyn InterruptSourceGroup>,
 }
 
 impl MsiConfig {
-    pub fn new(msg_ctl: u16, interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>) -> Self {
+    pub fn new(msg_ctl: u16, interrupt_source_group: Arc<dyn InterruptSourceGroup>) -> Self {
         let cap = MsiCap {
             msg_ctl,
             ..Default::default()

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -74,7 +74,7 @@ pub struct MsixConfig {
     pub table_entries: Vec<MsixTableEntry>,
     pub pba_entries: Vec<u64>,
     pub devid: u32,
-    interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+    interrupt_source_group: Arc<dyn InterruptSourceGroup>,
     masked: bool,
     enabled: bool,
 }
@@ -82,7 +82,7 @@ pub struct MsixConfig {
 impl MsixConfig {
     pub fn new(
         msix_vectors: u16,
-        interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+        interrupt_source_group: Arc<dyn InterruptSourceGroup>,
         devid: u32,
     ) -> Self {
         assert!(msix_vectors <= MAX_MSIX_VECTORS_PER_DEVICE);

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -89,14 +89,14 @@ enum InterruptUpdateAction {
 }
 
 struct VfioIntx {
-    interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+    interrupt_source_group: Arc<dyn InterruptSourceGroup>,
     enabled: bool,
 }
 
 struct VfioMsi {
     cfg: MsiConfig,
     cap_offset: u32,
-    interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+    interrupt_source_group: Arc<dyn InterruptSourceGroup>,
 }
 
 impl VfioMsi {
@@ -123,7 +123,7 @@ struct VfioMsix {
     bar: MsixConfig,
     cap: MsixCap,
     cap_offset: u32,
-    interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+    interrupt_source_group: Arc<dyn InterruptSourceGroup>,
 }
 
 impl VfioMsix {
@@ -309,7 +309,7 @@ impl VfioPciDevice {
         device: VfioDevice,
         container: Arc<VfioContainer>,
         msi_interrupt_manager: &Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>>,
-        legacy_interrupt_group: Option<Arc<Box<dyn InterruptSourceGroup>>>,
+        legacy_interrupt_group: Option<Arc<dyn InterruptSourceGroup>>,
         iommu_attached: bool,
     ) -> Result<Self> {
         let device = Arc::new(device);
@@ -438,7 +438,7 @@ impl VfioPciDevice {
 
     fn initialize_legacy_interrupt(
         &mut self,
-        legacy_interrupt_group: Option<Arc<Box<dyn InterruptSourceGroup>>>,
+        legacy_interrupt_group: Option<Arc<dyn InterruptSourceGroup>>,
     ) -> Result<()> {
         if let Some(irq_info) = self.device.get_irq_info(VFIO_PCI_INTX_IRQ_INDEX) {
             if irq_info.count == 0 {

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -306,7 +306,7 @@ pub struct VirtioPciDevice {
     // PCI interrupts.
     interrupt_status: Arc<AtomicUsize>,
     virtio_interrupt: Option<Arc<dyn VirtioInterrupt>>,
-    interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+    interrupt_source_group: Arc<dyn InterruptSourceGroup>,
 
     // virtio queues
     queues: Vec<Queue>,
@@ -722,14 +722,14 @@ impl VirtioTransport for VirtioPciDevice {
 pub struct VirtioInterruptMsix {
     msix_config: Arc<Mutex<MsixConfig>>,
     config_vector: Arc<AtomicU16>,
-    interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+    interrupt_source_group: Arc<dyn InterruptSourceGroup>,
 }
 
 impl VirtioInterruptMsix {
     pub fn new(
         msix_config: Arc<Mutex<MsixConfig>>,
         config_vector: Arc<AtomicU16>,
-        interrupt_source_group: Arc<Box<dyn InterruptSourceGroup>>,
+        interrupt_source_group: Arc<dyn InterruptSourceGroup>,
     ) -> Self {
         VirtioInterruptMsix {
             msix_config,

--- a/vm-device/src/interrupt/mod.rs
+++ b/vm-device/src/interrupt/mod.rs
@@ -136,8 +136,7 @@ pub trait InterruptManager: Send + Sync {
     /// * interrupt_type: type of interrupt source.
     /// * base: base Interrupt Source ID to be managed by the group object.
     /// * count: number of Interrupt Sources to be managed by the group object.
-    fn create_group(&self, config: Self::GroupConfig)
-        -> Result<Arc<Box<dyn InterruptSourceGroup>>>;
+    fn create_group(&self, config: Self::GroupConfig) -> Result<Arc<dyn InterruptSourceGroup>>;
 
     /// Destroy an [InterruptSourceGroup](trait.InterruptSourceGroup.html) object created by
     /// [create_group()](trait.InterruptManager.html#tymethod.create_group).
@@ -145,7 +144,7 @@ pub trait InterruptManager: Send + Sync {
     /// Assume the caller takes the responsibility to disable all interrupt sources of the group
     /// before calling destroy_group(). This assumption helps to simplify InterruptSourceGroup
     /// implementations.
-    fn destroy_group(&self, group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()>;
+    fn destroy_group(&self, group: Arc<dyn InterruptSourceGroup>) -> Result<()>;
 }
 
 pub trait InterruptSourceGroup: Send + Sync {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -224,7 +224,7 @@ impl Vcpu {
     pub fn new(
         id: u8,
         vm: &Arc<dyn hypervisor::Vm>,
-        vmmops: Option<Arc<Box<dyn VmmOps>>>,
+        vmmops: Option<Arc<dyn VmmOps>>,
     ) -> Result<Arc<Mutex<Self>>> {
         let vcpu = vm
             .create_vcpu(id, vmmops)
@@ -374,7 +374,7 @@ pub struct CpuManager {
     selected_cpu: u8,
     vcpus: Vec<Arc<Mutex<Vcpu>>>,
     seccomp_action: SeccompAction,
-    vmmops: Arc<Box<dyn VmmOps>>,
+    vmmops: Arc<dyn VmmOps>,
     #[cfg(feature = "acpi")]
     #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     acpi_address: GuestAddress,
@@ -516,7 +516,7 @@ impl CpuManager {
         reset_evt: EventFd,
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
         seccomp_action: SeccompAction,
-        vmmops: Arc<Box<dyn VmmOps>>,
+        vmmops: Arc<dyn VmmOps>,
         #[cfg(feature = "tdx")] tdx_enabled: bool,
         #[cfg(feature = "acpi")] numa_nodes: &NumaNodes,
     ) -> Result<Arc<Mutex<CpuManager>>> {

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -291,17 +291,14 @@ impl MsiInterruptManager<IrqRoutingEntry> {
 impl InterruptManager for LegacyUserspaceInterruptManager {
     type GroupConfig = LegacyIrqGroupConfig;
 
-    fn create_group(
-        &self,
-        config: Self::GroupConfig,
-    ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
-        Ok(Arc::new(Box::new(LegacyUserspaceInterruptGroup::new(
+    fn create_group(&self, config: Self::GroupConfig) -> Result<Arc<dyn InterruptSourceGroup>> {
+        Ok(Arc::new(LegacyUserspaceInterruptGroup::new(
             self.ioapic.clone(),
             config.irq as u32,
-        ))))
+        )))
     }
 
-    fn destroy_group(&self, _group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()> {
+    fn destroy_group(&self, _group: Arc<dyn InterruptSourceGroup>) -> Result<()> {
         Ok(())
     }
 }
@@ -309,10 +306,7 @@ impl InterruptManager for LegacyUserspaceInterruptManager {
 impl InterruptManager for MsiInterruptManager<IrqRoutingEntry> {
     type GroupConfig = MsiIrqGroupConfig;
 
-    fn create_group(
-        &self,
-        config: Self::GroupConfig,
-    ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
+    fn create_group(&self, config: Self::GroupConfig) -> Result<Arc<dyn InterruptSourceGroup>> {
         let mut allocator = self.allocator.lock().unwrap();
         let mut irq_routes: HashMap<InterruptIndex, InterruptRoute> =
             HashMap::with_capacity(config.count as usize);
@@ -320,14 +314,14 @@ impl InterruptManager for MsiInterruptManager<IrqRoutingEntry> {
             irq_routes.insert(i, InterruptRoute::new(&mut allocator)?);
         }
 
-        Ok(Arc::new(Box::new(MsiInterruptGroup::new(
+        Ok(Arc::new(MsiInterruptGroup::new(
             self.vm.clone(),
             self.gsi_msi_routes.clone(),
             irq_routes,
-        ))))
+        )))
     }
 
-    fn destroy_group(&self, _group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()> {
+    fn destroy_group(&self, _group: Arc<dyn InterruptSourceGroup>) -> Result<()> {
         Ok(())
     }
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -580,14 +580,14 @@ impl Vm {
         let mmio_bus = Arc::clone(device_manager.lock().unwrap().mmio_bus());
         // Create the VmOps structure, which implements the VmmOps trait.
         // And send it to the hypervisor.
-        let vm_ops: Arc<Box<dyn VmmOps>> = Arc::new(Box::new(VmOps {
+        let vm_ops: Arc<dyn VmmOps> = Arc::new(VmOps {
             memory,
             #[cfg(target_arch = "x86_64")]
             io_bus,
             mmio_bus,
             #[cfg(target_arch = "x86_64")]
             timestamp: std::time::Instant::now(),
-        }));
+        });
 
         let exit_evt_clone = exit_evt.try_clone().map_err(Error::EventFdClone)?;
         #[cfg(feature = "tdx")]


### PR DESCRIPTION
With the new beta version, clippy complains about redundant allocation
when using `Arc<Box<dyn T>>`, and suggests replacing it simply with
`Arc<dyn T>`.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>