### PR TITLE
AArch64: Support CPU topology (ACPI and Device Tree)

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -135,10 +135,12 @@ pub fn arch_memory_regions(size: GuestUsize) -> Vec<(GuestAddress, usize, Region
 }
 
 /// Configures the system and should be called once per vm before starting vcpu threads.
+#[allow(clippy::too_many_arguments)]
 pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHasher>(
     guest_mem: &GuestMemoryMmap,
     cmdline_cstring: &CStr,
     vcpu_mpidr: Vec<u64>,
+    vcpu_topology: Option<(u8, u8, u8)>,
     device_info: &HashMap<(DeviceType, String), T, S>,
     initrd: &Option<super::InitramfsConfig>,
     pci_space_address: &(u64, u64),
@@ -148,6 +150,7 @@ pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::Bui
         guest_mem,
         cmdline_cstring,
         vcpu_mpidr,
+        vcpu_topology,
         device_info,
         gic_device,
         initrd,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2012,19 +2012,16 @@ mod tests {
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_cpu_topology_421() {
             test_cpu_topology(4, 2, 1);
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_cpu_topology_142() {
             test_cpu_topology(1, 4, 2);
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_cpu_topology_262() {
             test_cpu_topology(2, 6, 2);
         }

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -508,6 +508,19 @@ pub fn create_acpi_tables(
     prev_tbl_len = madt.len() as u64;
     prev_tbl_off = madt_offset;
 
+    // PPTT
+    #[cfg(target_arch = "aarch64")]
+    {
+        let pptt = cpu_manager.lock().unwrap().create_pptt();
+        let pptt_offset = prev_tbl_off.checked_add(prev_tbl_len).unwrap();
+        guest_mem
+            .write_slice(pptt.as_slice(), pptt_offset)
+            .expect("Error writing PPTT table");
+        tables.push(pptt_offset.0);
+        prev_tbl_len = pptt.len() as u64;
+        prev_tbl_off = pptt_offset;
+    }
+
     // GTDT
     #[cfg(target_arch = "aarch64")]
     {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -978,6 +978,14 @@ impl CpuManager {
             .collect()
     }
 
+    #[cfg(target_arch = "aarch64")]
+    pub fn get_vcpu_topology(&self) -> Option<(u8, u8, u8)> {
+        self.config
+            .topology
+            .clone()
+            .map(|t| (t.threads_per_core, t.cores_per_die, t.packages))
+    }
+
     #[cfg(feature = "acpi")]
     pub fn create_madt(&self) -> Sdt {
         use crate::acpi;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1072,6 +1072,7 @@ impl Vm {
     fn configure_system(&mut self) -> Result<()> {
         let cmdline_cstring = self.get_cmdline()?;
         let vcpu_mpidrs = self.cpu_manager.lock().unwrap().get_mpidrs();
+        let vcpu_topology = self.cpu_manager.lock().unwrap().get_vcpu_topology();
         let mem = self.memory_manager.lock().unwrap().boot_guest_memory();
         let initramfs_config = match self.initramfs {
             Some(_) => Some(self.load_initramfs(&mem)?),
@@ -1129,6 +1130,7 @@ impl Vm {
             &mem,
             &cmdline_cstring,
             vcpu_mpidrs,
+            vcpu_topology,
             device_info,
             &initramfs_config,
             &pci_space,
@@ -2652,6 +2654,7 @@ mod tests {
             &mem,
             &CString::new("console=tty0").unwrap(),
             vec![0],
+            Some((0, 0, 0)),
             &dev_info,
             &*gic,
             &None,


### PR DESCRIPTION
This PR adds the device tree and ACPI support for AArch64 CPU topology. Related ACPI integration test cases are also added.