### PR TITLE
virtio-devices: vhost-user: Send set_vring_base before setup inflight…

### DIFF
--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -128,15 +128,6 @@ impl Blk {
             config.num_queues = num_queues as u16;
         }
 
-        // Send set_vring_base here, since it could tell backends, like SPDK,
-        // how many virt queues to be handled, which backend required to know
-        // at early stage.
-        for i in 0..num_queues {
-            vu.socket_handle()
-                .set_vring_base(i, 0)
-                .map_err(Error::VhostUserSetVringBase)?;
-        }
-
         Ok(Blk {
             common: VirtioCommon {
                 device_type: VirtioDeviceType::Block as u32,

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -143,6 +143,15 @@ impl VhostUserHandle {
 
         // Setup for inflight I/O tracking shared memory.
         if let Some(inflight) = inflight {
+            // Send set_vring_base here, since it could tell backends, like SPDK,
+            // how many virt queues to be handled, which backend required to know
+            // at early stage.
+            for i in 0..queues.len() {
+                self.vu
+                    .set_vring_base(i, 0)
+                    .map_err(Error::VhostUserSetVringBase)?;
+            }
+
             if inflight.fd.is_none() {
                 let inflight_req_info = VhostUserInflight {
                     mmap_size: 0,


### PR DESCRIPTION
just send a set_vring_base let vhost_user_check_and_alloc_queue_pair(DPDK) alloc a vring queue before set_inflight_fd.
fix dpdk core dump while processing vhost_user_set_inflight_fd:

#0  0x00007fffef47c347 in vhost_user_set_inflight_fd (pdev=0x7fffe2895998, msg=0x7fffe28956f0, main_fd=545) at ../lib/librte_vhost/vhost_user.c:1570
#1  0x00007fffef47e7b9 in vhost_user_msg_handler (vid=0, fd=545) at ../lib/librte_vhost/vhost_user.c:2735
#2  0x00007fffef46bac0 in vhost_user_read_cb (connfd=545, dat=0x7fffdc0008c0, remove=0x7fffe2895a64) at ../lib/librte_vhost/socket.c:309
#3  0x00007fffef45b3f6 in fdset_event_dispatch (arg=0x7fffef6dc2e0 <vhost_user+8192>) at ../lib/librte_vhost/fd_man.c:286
#4  0x00007ffff09926f3 in rte_thread_init (arg=0x15ee180) at ../lib/librte_eal/common/eal_common_thread.c:175

Could you review it out, thanks.