### PR TITLE
vmm, virtio-devices: Add missing seccomp rules for MSHV

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -77,6 +77,8 @@ fn create_virtio_mem_ioctl_seccomp_rule() -> Vec<SeccompRule> {
 fn virtio_balloon_thread_rules() -> Vec<SyscallRuleSet> {
     vec![
         allow_syscall(libc::SYS_brk),
+        #[cfg(feature = "mshv")]
+        allow_syscall(libc::SYS_clock_gettime),
         allow_syscall(libc::SYS_close),
         allow_syscall(libc::SYS_dup),
         allow_syscall(libc::SYS_epoll_create1),
@@ -329,6 +331,8 @@ fn virtio_rng_thread_rules() -> Vec<SyscallRuleSet> {
 fn virtio_vhost_fs_thread_rules() -> Vec<SyscallRuleSet> {
     vec![
         allow_syscall(libc::SYS_brk),
+        #[cfg(feature = "mshv")]
+        allow_syscall(libc::SYS_clock_gettime),
         allow_syscall(libc::SYS_close),
         allow_syscall(libc::SYS_connect),
         allow_syscall(libc::SYS_dup),
@@ -357,6 +361,8 @@ fn virtio_vhost_fs_thread_rules() -> Vec<SyscallRuleSet> {
 fn virtio_vhost_net_ctl_thread_rules() -> Vec<SyscallRuleSet> {
     vec![
         allow_syscall(libc::SYS_brk),
+        #[cfg(feature = "mshv")]
+        allow_syscall(libc::SYS_clock_gettime),
         allow_syscall(libc::SYS_close),
         allow_syscall(libc::SYS_dup),
         allow_syscall(libc::SYS_epoll_create1),
@@ -383,6 +389,8 @@ fn virtio_vsock_thread_rules() -> Vec<SyscallRuleSet> {
     vec![
         allow_syscall(libc::SYS_accept4),
         allow_syscall(libc::SYS_brk),
+        #[cfg(feature = "mshv")]
+        allow_syscall(libc::SYS_clock_gettime),
         allow_syscall(libc::SYS_close),
         allow_syscall(libc::SYS_dup),
         allow_syscall(libc::SYS_epoll_create1),
@@ -406,6 +414,8 @@ fn virtio_vsock_thread_rules() -> Vec<SyscallRuleSet> {
 fn virtio_watchdog_thread_rules() -> Vec<SyscallRuleSet> {
     vec![
         allow_syscall(libc::SYS_brk),
+        #[cfg(feature = "mshv")]
+        allow_syscall(libc::SYS_clock_gettime),
         allow_syscall(libc::SYS_close),
         allow_syscall(libc::SYS_dup),
         allow_syscall(libc::SYS_epoll_create1),

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -517,6 +517,9 @@ fn create_vcpu_ioctl_seccomp_rule_mshv() -> Result<Vec<SeccompRule>, Error> {
         and![Cond::new(1, ArgLen::DWORD, Eq, MSHV_RUN_VP)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, MSHV_GET_VP_REGISTERS)?],
         and![Cond::new(1, ArgLen::DWORD, Eq, MSHV_SET_VP_REGISTERS)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, MSHV_MAP_GUEST_MEMORY)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, MSHV_UNMAP_GUEST_MEMORY)?],
+        and![Cond::new(1, ArgLen::DWORD, Eq, MSHV_VP_TRANSLATE_GVA)?],
     ])
 }
 


### PR DESCRIPTION
This patch adds all the seccomp rules missing for MSHV.
With this patch MSFT internal CI runs with seccomp enabled.

Signed-off-by: Muminul Islam <muislam@microsoft.com>