### PR TITLE
hypervisor: Use MSHV crates from rust-vmm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "mshv-bindings"
 version = "0.1.0"
-source = "git+https://github.com/cloud-hypervisor/mshv?branch=master#9481c711c329e1e004eb13dc3f1df946316afda0"
+source = "git+https://github.com/rust-vmm/mshv?branch=master#39a77bc8e4ed50fcfb5bc9f5ab540c7039278fb6"
 dependencies = [
  "libc",
  "serde",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "mshv-ioctls"
 version = "0.1.0"
-source = "git+https://github.com/cloud-hypervisor/mshv?branch=master#9481c711c329e1e004eb13dc3f1df946316afda0"
+source = "git+https://github.com/rust-vmm/mshv?branch=master#39a77bc8e4ed50fcfb5bc9f5ab540c7039278fb6"
 dependencies = [
  "libc",
  "mshv-bindings",
@@ -1382,9 +1382,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zerocopy"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6580539ad917b7c026220c4b3f2c08d52ce54d6ce0dc491e66002e35388fab46"
+checksum = "5e59ec1d2457bd6c0dd89b50e7d9d6b0b647809bf3f0a59ac85557046950b7b2"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -1392,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"
+checksum = "0af017aca1fa6181f5dd7a802456fe6f7666ecdcc18d0910431f0fc89d474e51"
 dependencies = [
  "proc-macro2",
  "syn",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -18,8 +18,8 @@ libc = "0.2.98"
 log = "0.4.14"
 kvm-ioctls = {  version = "0.9.0", optional = true }
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.4.0", features = ["with-serde", "fam-wrappers"], optional  = true }
-mshv-bindings = {git = "https://github.com/cloud-hypervisor/mshv", branch = "master", features = ["with-serde", "fam-wrappers"], optional  = true }
-mshv-ioctls = { git = "https://github.com/cloud-hypervisor/mshv", branch = "master", optional  = true}
+mshv-bindings = {git = "https://github.com/rust-vmm/mshv", branch = "master", features = ["with-serde", "fam-wrappers"], optional  = true }
+mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "master", optional  = true}
 serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"


### PR DESCRIPTION
Moving the MSHV crate form Cloud Hypervisor to rust-vmm
is done. This patch update the MSHV referent to rust-vmm

Signed-off-by: Muminul Islam <muislam@microsoft.com>