### PR TITLE
vhost_user_*: mark --*-backend as required

### DIFF
--- a/vhost_user_block/src/main.rs
+++ b/vhost_user_block/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
                 .long("block-backend")
                 .help(vhost_user_block::SYNTAX)
                 .takes_value(true)
-                .min_values(1),
+                .required(true),
         )
         .get_matches();
 

--- a/vhost_user_net/src/main.rs
+++ b/vhost_user_net/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
                 .long("net-backend")
                 .help(vhost_user_net::SYNTAX)
                 .takes_value(true)
-                .min_values(1),
+                .required(true),
         )
         .get_matches();
 


### PR DESCRIPTION
I don't think the `min_values(1)` was doing anything, since `takes_value(true)` was already set, and after this change I still get an error if I try to supply the argument with no value.

But the unwrap below would fail if the argument wasn't supplied at all.  By setting `required(true)` we get a nice message from clap instead.

Signed-off-by: Alyssa Ross <hi@alyssa.is>
