### PR TITLE
vhost-user: Migration support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,7 @@ source = "git+https://github.com/rust-vmm/vhost?branch=master#37a6a8e46444e9e4b5
 dependencies = [
  "bitflags",
  "libc",
+ "vm-memory",
  "vmm-sys-util",
 ]
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -662,7 +662,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vhost?branch=master#9982541776a603d30556a06df55e8c0491072763"
+source = "git+https://github.com/rust-vmm/vhost?branch=master#37a6a8e46444e9e4b59be5bff82e5c22a879f0c4"
 dependencies = [
  "bitflags",
  "libc",

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -29,7 +29,7 @@ serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vhost = { git = "https://github.com/rust-vmm/vhost", branch = "master", package = "vhost", features = ["vhost-user-master", "vhost-user-slave"] }
+vhost = { git = "https://github.com/rust-vmm/vhost", branch = "master", package = "vhost", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern"] }
 virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"]}
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -29,9 +29,10 @@ use virtio_bindings::bindings::virtio_blk::{
     VIRTIO_BLK_F_GEOMETRY, VIRTIO_BLK_F_MQ, VIRTIO_BLK_F_RO, VIRTIO_BLK_F_SEG_MAX,
     VIRTIO_BLK_F_SIZE_MAX, VIRTIO_BLK_F_TOPOLOGY, VIRTIO_BLK_F_WRITE_ZEROES,
 };
-use vm_memory::{ByteValued, GuestAddressSpace, GuestMemoryAtomic};
+use vm_memory::{Address, ByteValued, GuestAddressSpace, GuestMemory, GuestMemoryAtomic};
 use vm_migration::{
-    Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable, VersionMapped,
+    protocol::MemoryRangeTable, Migratable, MigratableError, Pausable, Snapshot, Snapshottable,
+    Transportable, VersionMapped,
 };
 use vmm_sys_util::eventfd::EventFd;
 
@@ -399,4 +400,54 @@ impl Snapshottable for Blk {
     }
 }
 impl Transportable for Blk {}
-impl Migratable for Blk {}
+
+impl Migratable for Blk {
+    fn start_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
+        if let Some(guest_memory) = &self.guest_memory {
+            let last_ram_addr = guest_memory.memory().last_addr().raw_value();
+            self.vu
+                .lock()
+                .unwrap()
+                .start_dirty_log(last_ram_addr)
+                .map_err(|e| {
+                    MigratableError::MigrateStart(anyhow!(
+                        "Error starting migration for vhost-user-blk backend: {:?}",
+                        e
+                    ))
+                })
+        } else {
+            Err(MigratableError::MigrateStart(anyhow!(
+                "Missing guest memory"
+            )))
+        }
+    }
+
+    fn stop_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
+        self.vu.lock().unwrap().stop_dirty_log().map_err(|e| {
+            MigratableError::MigrateStop(anyhow!(
+                "Error stopping migration for vhost-user-blk backend: {:?}",
+                e
+            ))
+        })
+    }
+
+    fn dirty_log(&mut self) -> std::result::Result<MemoryRangeTable, MigratableError> {
+        if let Some(guest_memory) = &self.guest_memory {
+            let last_ram_addr = guest_memory.memory().last_addr().raw_value();
+            self.vu
+                .lock()
+                .unwrap()
+                .dirty_log(last_ram_addr)
+                .map_err(|e| {
+                    MigratableError::MigrateDirtyRanges(anyhow!(
+                        "Error retrieving dirty ranges from vhost-user-blk backend: {:?}",
+                        e
+                    ))
+                })
+        } else {
+            Err(MigratableError::MigrateDirtyRanges(anyhow!(
+                "Missing guest memory"
+            )))
+        }
+    }
+}

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -32,7 +32,8 @@ use vm_memory::{
     Address, ByteValued, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
 };
 use vm_migration::{
-    Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable, VersionMapped,
+    protocol::MemoryRangeTable, Migratable, MigratableError, Pausable, Snapshot, Snapshottable,
+    Transportable, VersionMapped,
 };
 use vmm_sys_util::eventfd::EventFd;
 
@@ -680,4 +681,54 @@ impl Snapshottable for Fs {
     }
 }
 impl Transportable for Fs {}
-impl Migratable for Fs {}
+
+impl Migratable for Fs {
+    fn start_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
+        if let Some(guest_memory) = &self.guest_memory {
+            let last_ram_addr = guest_memory.memory().last_addr().raw_value();
+            self.vu
+                .lock()
+                .unwrap()
+                .start_dirty_log(last_ram_addr)
+                .map_err(|e| {
+                    MigratableError::MigrateStart(anyhow!(
+                        "Error starting migration for vhost-user-fs backend: {:?}",
+                        e
+                    ))
+                })
+        } else {
+            Err(MigratableError::MigrateStart(anyhow!(
+                "Missing guest memory"
+            )))
+        }
+    }
+
+    fn stop_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
+        self.vu.lock().unwrap().stop_dirty_log().map_err(|e| {
+            MigratableError::MigrateStop(anyhow!(
+                "Error stopping migration for vhost-user-fs backend: {:?}",
+                e
+            ))
+        })
+    }
+
+    fn dirty_log(&mut self) -> std::result::Result<MemoryRangeTable, MigratableError> {
+        if let Some(guest_memory) = &self.guest_memory {
+            let last_ram_addr = guest_memory.memory().last_addr().raw_value();
+            self.vu
+                .lock()
+                .unwrap()
+                .dirty_log(last_ram_addr)
+                .map_err(|e| {
+                    MigratableError::MigrateDirtyRanges(anyhow!(
+                        "Error retrieving dirty ranges from vhost-user-fs backend: {:?}",
+                        e
+                    ))
+                })
+        } else {
+            Err(MigratableError::MigrateDirtyRanges(anyhow!(
+                "Missing guest memory"
+            )))
+        }
+    }
+}

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -14,7 +14,7 @@ use std::sync::{atomic::AtomicBool, Arc, Barrier, Mutex};
 use vhost::vhost_user::message::{VhostUserInflight, VhostUserVirtioFeatures};
 use vhost::vhost_user::{MasterReqHandler, VhostUserMasterReqHandler};
 use vhost::Error as VhostError;
-use vm_memory::{Error as MmapError, GuestAddressSpace, GuestMemoryAtomic};
+use vm_memory::{mmap::MmapRegionError, Error as MmapError, GuestAddressSpace, GuestMemoryAtomic};
 use vm_virtio::Error as VirtioError;
 use vmm_sys_util::eventfd::EventFd;
 use vu_common_ctrl::VhostUserHandle;
@@ -109,6 +109,8 @@ pub enum Error {
     VhostUserGetInflight(VhostError),
     /// Failed setting inflight shm log.
     VhostUserSetInflight(VhostError),
+    /// Failed setting the log base.
+    VhostUserSetLogBase(VhostError),
     /// Invalid used address.
     UsedAddress,
     /// Invalid features provided from vhost-user backend
@@ -119,6 +121,18 @@ pub enum Error {
     MissingIrqFd,
     /// Failed getting the available index.
     GetAvailableIndex(VirtioError),
+    /// Migration is not supported by this vhost-user device.
+    MigrationNotSupported,
+    /// Failed creating memfd.
+    MemfdCreate(io::Error),
+    /// Failed truncating the file size to the expected size.
+    SetFileSize(io::Error),
+    /// Failed to set the seals on the file.
+    SetSeals(io::Error),
+    /// Failed creating new mmap region
+    NewMmapRegion(MmapRegionError),
+    /// Could not find the shm log region
+    MissingShmLogRegion,
 }
 type Result<T> = std::result::Result<T, Error>;
 

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -4,22 +4,31 @@
 use super::super::{Descriptor, Queue};
 use super::{Error, Result};
 use crate::vhost_user::Inflight;
-use crate::{get_host_address_range, VirtioInterrupt, VirtioInterruptType};
-use crate::{GuestMemoryMmap, GuestRegionMmap};
+use crate::{
+    get_host_address_range, GuestMemoryMmap, GuestRegionMmap, MmapRegion, VirtioInterrupt,
+    VirtioInterruptType,
+};
 use std::convert::TryInto;
-use std::os::unix::io::AsRawFd;
+use std::ffi;
+use std::fs::File;
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::net::UnixListener;
 use std::sync::Arc;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 use std::vec::Vec;
+use vhost::vhost_kern::vhost_binding::{VHOST_F_LOG_ALL, VHOST_VRING_F_LOG};
 use vhost::vhost_user::message::{
     VhostUserHeaderFlag, VhostUserInflight, VhostUserProtocolFeatures, VhostUserVirtioFeatures,
 };
 use vhost::vhost_user::{Master, MasterReqHandler, VhostUserMaster, VhostUserMasterReqHandler};
-use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
-use vm_memory::{Address, Error as MmapError, GuestMemory, GuestMemoryRegion};
+use vhost::{VhostBackend, VhostUserDirtyLogRegion, VhostUserMemoryRegionInfo, VringConfigData};
+use vm_memory::{Address, Error as MmapError, FileOffset, GuestMemory, GuestMemoryRegion};
+use vm_migration::protocol::MemoryRangeTable;
 use vmm_sys_util::eventfd::EventFd;
+
+// Size of a dirty page for vhost-user.
+const VHOST_LOG_PAGE: u64 = 0x1000;
 
 #[derive(Debug, Clone)]
 pub struct VhostUserConfig {
@@ -29,10 +38,19 @@ pub struct VhostUserConfig {
 }
 
 #[derive(Clone)]
+struct VringInfo {
+    config_data: VringConfigData,
+    used_guest_addr: u64,
+}
+
+#[derive(Clone)]
 pub struct VhostUserHandle {
     vu: Master,
     ready: bool,
     supports_migration: bool,
+    shm_log: Option<Arc<MmapRegion>>,
+    acked_features: u64,
+    vrings_info: Option<Vec<VringInfo>>,
 }
 
 impl VhostUserHandle {
@@ -141,6 +159,9 @@ impl VhostUserHandle {
             .set_features(acked_features)
             .map_err(Error::VhostUserSetFeatures)?;
 
+        // Update internal value after it's been sent to the backend.
+        self.acked_features = acked_features;
+
         // Let's first provide the memory table to the backend.
         self.update_mem_table(mem)?;
 
@@ -177,6 +198,7 @@ impl VhostUserHandle {
 
         let num_queues = queues.len() as usize;
 
+        let mut vrings_info = Vec::new();
         for (queue_index, queue) in queues.into_iter().enumerate() {
             let actual_size: usize = queue.actual_size().try_into().unwrap();
 
@@ -200,6 +222,11 @@ impl VhostUserHandle {
                     .ok_or(Error::AvailAddress)? as u64,
                 log_addr: None,
             };
+
+            vrings_info.push(VringInfo {
+                config_data,
+                used_guest_addr: queue.used_ring.raw_value(),
+            });
 
             self.vu
                 .set_vring_addr(queue_index, &config_data)
@@ -234,6 +261,7 @@ impl VhostUserHandle {
                 .map_err(Error::VhostUserSetSlaveRequestFd)?;
         }
 
+        self.vrings_info = Some(vrings_info);
         self.ready = true;
 
         Ok(())
@@ -320,6 +348,9 @@ impl VhostUserHandle {
                 vu: Master::from_stream(stream, num_queues),
                 ready: false,
                 supports_migration: false,
+                shm_log: None,
+                acked_features: 0,
+                vrings_info: None,
             })
         } else {
             let now = Instant::now();
@@ -332,6 +363,9 @@ impl VhostUserHandle {
                             vu: m,
                             ready: false,
                             supports_migration: false,
+                            shm_log: None,
+                            acked_features: 0,
+                            vrings_info: None,
                         })
                     }
                     Err(e) => e,
@@ -377,5 +411,151 @@ impl VhostUserHandle {
         {
             self.supports_migration = true;
         }
+    }
+
+    fn update_log_base(&mut self, last_ram_addr: u64) -> Result<Option<Arc<MmapRegion>>> {
+        // Create the memfd
+        let fd = memfd_create(
+            &ffi::CString::new("vhost_user_dirty_log").unwrap(),
+            libc::MFD_CLOEXEC | libc::MFD_ALLOW_SEALING,
+        )
+        .map_err(Error::MemfdCreate)?;
+
+        // Safe because we checked the file descriptor is valid
+        let file = unsafe { File::from_raw_fd(fd) };
+        // The size of the memory mapping corresponds to the size of a bitmap
+        // covering all guest pages for addresses from 0 to the last physical
+        // address in guest RAM.
+        // A page is always 4kiB from a vhost-user perspective, and each bit is
+        // a page. That's how we can compute mmap_size from the last address.
+        let mmap_size = (last_ram_addr / (VHOST_LOG_PAGE * 8)) + 1;
+        let mmap_handle = file.as_raw_fd();
+
+        // Set shm_log region size
+        file.set_len(mmap_size).map_err(Error::SetFileSize)?;
+
+        // Set the seals
+        let res = unsafe {
+            libc::fcntl(
+                file.as_raw_fd(),
+                libc::F_ADD_SEALS,
+                libc::F_SEAL_GROW | libc::F_SEAL_SHRINK | libc::F_SEAL_SEAL,
+            )
+        };
+        if res < 0 {
+            return Err(Error::SetSeals(std::io::Error::last_os_error()));
+        }
+
+        // Mmap shm_log region
+        let region = MmapRegion::build(
+            Some(FileOffset::new(file, 0)),
+            mmap_size as usize,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_SHARED,
+        )
+        .map_err(Error::NewMmapRegion)?;
+
+        // Make sure we hold onto the region to prevent the mapping from being
+        // released.
+        let old_region = self.shm_log.take();
+        self.shm_log = Some(Arc::new(region));
+
+        // Send the shm_log fd over to the backend
+        let log = VhostUserDirtyLogRegion {
+            mmap_size,
+            mmap_offset: 0,
+            mmap_handle,
+        };
+        self.vu
+            .set_log_base(0, Some(log))
+            .map_err(Error::VhostUserSetLogBase)?;
+
+        Ok(old_region)
+    }
+
+    fn set_vring_logging(&mut self, enable: bool) -> Result<()> {
+        if let Some(vrings_info) = &self.vrings_info {
+            for (i, vring_info) in vrings_info.iter().enumerate() {
+                let mut config_data = vring_info.config_data;
+                config_data.flags = if enable { 1 << VHOST_VRING_F_LOG } else { 0 };
+                config_data.log_addr = if enable {
+                    Some(vring_info.used_guest_addr)
+                } else {
+                    None
+                };
+
+                self.vu
+                    .set_vring_addr(i, &config_data)
+                    .map_err(Error::VhostUserSetVringAddr)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn start_dirty_log(&mut self, last_ram_addr: u64) -> Result<()> {
+        if !self.supports_migration {
+            return Err(Error::MigrationNotSupported);
+        }
+
+        // Set the shm log region
+        self.update_log_base(last_ram_addr)?;
+
+        // Enable VHOST_F_LOG_ALL feature
+        let features = self.acked_features | (1 << VHOST_F_LOG_ALL);
+        self.vu
+            .set_features(features)
+            .map_err(Error::VhostUserSetFeatures)?;
+
+        // Enable dirty page logging of used ring for all queues
+        self.set_vring_logging(true)
+    }
+
+    pub fn stop_dirty_log(&mut self) -> Result<()> {
+        if !self.supports_migration {
+            return Err(Error::MigrationNotSupported);
+        }
+
+        // Disable dirty page logging of used ring for all queues
+        self.set_vring_logging(false)?;
+
+        // Disable VHOST_F_LOG_ALL feature
+        self.vu
+            .set_features(self.acked_features)
+            .map_err(Error::VhostUserSetFeatures)?;
+
+        // This is important here since the log region goes out of scope,
+        // invoking the Drop trait, hence unmapping the memory.
+        self.shm_log = None;
+
+        Ok(())
+    }
+
+    pub fn dirty_log(&mut self, last_ram_addr: u64) -> Result<MemoryRangeTable> {
+        // The log region is updated by creating a new region that is sent to
+        // the backend. This ensures the backend stops logging to the previous
+        // region. The previous region is returned and processed to create the
+        // bitmap representing the dirty pages.
+        if let Some(region) = self.update_log_base(last_ram_addr)? {
+            // Cast the pointer to u64
+            let ptr = region.as_ptr() as *mut u64;
+            // Be careful with the size, as it was based on u8, meaning we must
+            // divide it by 8.
+            let len = region.size() / 8;
+            let bitmap = unsafe { Vec::from_raw_parts(ptr, len, len) };
+            Ok(MemoryRangeTable::from_bitmap(bitmap, 0))
+        } else {
+            Err(Error::MissingShmLogRegion)
+        }
+    }
+}
+
+fn memfd_create(name: &ffi::CStr, flags: u32) -> std::result::Result<RawFd, std::io::Error> {
+    let res = unsafe { libc::syscall(libc::SYS_memfd_create, name.as_ptr(), flags) };
+
+    if res < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(res as RawFd)
     }
 }

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -6,6 +6,7 @@
 #[macro_use]
 extern crate serde_derive;
 
+use crate::protocol::MemoryRangeTable;
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -46,6 +47,15 @@ pub enum MigratableError {
 
     #[error("Socket error: {0}")]
     MigrateSocket(#[source] std::io::Error),
+
+    #[error("Failed to start migration for migratable component: {0}")]
+    MigrateStart(#[source] anyhow::Error),
+
+    #[error("Failed to stop migration for migratable component: {0}")]
+    MigrateStop(#[source] anyhow::Error),
+
+    #[error("Failed to retrieve dirty ranges for migratable component: {0}")]
+    MigrateDirtyRanges(#[source] anyhow::Error),
 }
 
 /// A Pausable component can be paused and resumed.
@@ -279,4 +289,16 @@ pub trait Transportable: Pausable + Snapshottable {
 /// and Snapshottable.
 /// Moreover a migratable component can be transported to a remote or local
 /// destination and thus must be Transportable.
-pub trait Migratable: Send + Pausable + Snapshottable + Transportable {}
+pub trait Migratable: Send + Pausable + Snapshottable + Transportable {
+    fn start_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
+        Ok(())
+    }
+
+    fn stop_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
+        Ok(())
+    }
+
+    fn dirty_log(&mut self) -> std::result::Result<MemoryRangeTable, MigratableError> {
+        Ok(MemoryRangeTable::default())
+    }
+}

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2525,15 +2525,20 @@ impl Transportable for Vm {
 
 impl Migratable for Vm {
     fn start_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
-        self.memory_manager.lock().unwrap().start_dirty_log()
+        self.memory_manager.lock().unwrap().start_dirty_log()?;
+        self.device_manager.lock().unwrap().start_dirty_log()
     }
 
     fn stop_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
-        self.memory_manager.lock().unwrap().stop_dirty_log()
+        self.memory_manager.lock().unwrap().stop_dirty_log()?;
+        self.device_manager.lock().unwrap().stop_dirty_log()
     }
 
     fn dirty_log(&mut self) -> std::result::Result<MemoryRangeTable, MigratableError> {
-        self.memory_manager.lock().unwrap().dirty_log()
+        Ok(MemoryRangeTable::new_from_tables(vec![
+            self.memory_manager.lock().unwrap().dirty_log()?,
+            self.device_manager.lock().unwrap().dirty_log()?,
+        ]))
     }
 }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2156,23 +2156,6 @@ impl Vm {
         Ok(table)
     }
 
-    pub fn start_memory_dirty_log(&self) -> std::result::Result<(), MigratableError> {
-        self.memory_manager.lock().unwrap().start_memory_dirty_log()
-    }
-
-    pub fn stop_memory_dirty_log(&self) -> std::result::Result<(), MigratableError> {
-        self.memory_manager.lock().unwrap().stop_memory_dirty_log()
-    }
-
-    pub fn dirty_memory_range_table(
-        &self,
-    ) -> std::result::Result<MemoryRangeTable, MigratableError> {
-        self.memory_manager
-            .lock()
-            .unwrap()
-            .dirty_memory_range_table()
-    }
-
     pub fn device_tree(&self) -> Arc<Mutex<DeviceTree>> {
         self.device_manager.lock().unwrap().device_tree()
     }
@@ -2539,7 +2522,20 @@ impl Transportable for Vm {
         Ok(())
     }
 }
-impl Migratable for Vm {}
+
+impl Migratable for Vm {
+    fn start_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
+        self.memory_manager.lock().unwrap().start_dirty_log()
+    }
+
+    fn stop_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
+        self.memory_manager.lock().unwrap().stop_dirty_log()
+    }
+
+    fn dirty_log(&mut self) -> std::result::Result<MemoryRangeTable, MigratableError> {
+        self.memory_manager.lock().unwrap().dirty_log()
+    }
+}
 
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
 #[cfg(test)]


### PR DESCRIPTION
This PR provides the migration support to all vhost-user devices through the extension of the `Migratable` trait.

Fixes #2813 