### PR TITLE
vhost_user_*: set up logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,6 +1150,7 @@ version = "0.1.0"
 dependencies = [
  "block_util",
  "clap",
+ "env_logger",
  "epoll",
  "libc",
  "log",
@@ -1167,6 +1168,7 @@ name = "vhost_user_net"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "env_logger",
  "epoll",
  "libc",
  "log",

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 block_util = { path = "../block_util" }
 clap = { version = "2.33.3", features=["wrap_help"] }
+env_logger = "0.9.0"
 epoll = ">=4.0.1"
 libc = "0.2.98"
 log = "0.4.14"

--- a/vhost_user_block/src/main.rs
+++ b/vhost_user_block/src/main.rs
@@ -16,6 +16,8 @@ use clap::{App, Arg};
 use vhost_user_block::start_block_backend;
 
 fn main() {
+    env_logger::init();
+
     let cmd_arguments = App::new("vhost-user-blk backend")
         .version(crate_version!())
         .author(crate_authors!())

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 clap = { version = "2.33.3", features=["wrap_help"] }
+env_logger = "0.9.0"
 epoll = ">=4.0.1"
 libc = "0.2.98"
 log = "0.4.14"

--- a/vhost_user_net/src/main.rs
+++ b/vhost_user_net/src/main.rs
@@ -13,6 +13,8 @@ use clap::{App, Arg};
 use vhost_user_net::start_net_backend;
 
 fn main() {
+    env_logger::init();
+
     let cmd_arguments = App::new("vhost-user-net backend")
         .version(crate_version!())
         .author(crate_authors!())


### PR DESCRIPTION
These crates are written to produce log messages using the error!
macro, but their logs didn't actually go anywhere, which made it very
difficult to debug when they're not working.

I've used env_logger here because it's the same log implementation
that the hypervisor crate uses.

Signed-off-by: Alyssa Ross <hi@alyssa.is>
