### PR TITLE
virtio-devices: seccomp: allow unix socket connect in vsock thread

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -392,6 +392,7 @@ fn virtio_vsock_thread_rules() -> Vec<SyscallRuleSet> {
         #[cfg(feature = "mshv")]
         allow_syscall(libc::SYS_clock_gettime),
         allow_syscall(libc::SYS_close),
+        allow_syscall(libc::SYS_connect),
         allow_syscall(libc::SYS_dup),
         allow_syscall(libc::SYS_epoll_create1),
         allow_syscall(libc::SYS_epoll_ctl),
@@ -402,11 +403,13 @@ fn virtio_vsock_thread_rules() -> Vec<SyscallRuleSet> {
         allow_syscall_if(libc::SYS_ioctl, create_vsock_ioctl_seccomp_rule()),
         allow_syscall(libc::SYS_futex),
         allow_syscall(libc::SYS_madvise),
+        allow_syscall(libc::SYS_mmap),
         allow_syscall(libc::SYS_munmap),
         allow_syscall(libc::SYS_read),
         allow_syscall(libc::SYS_recvfrom),
         allow_syscall(libc::SYS_rt_sigprocmask),
         allow_syscall(libc::SYS_sigaltstack),
+        allow_syscall(libc::SYS_socket),
         allow_syscall(libc::SYS_write),
     ]
 }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -562,6 +562,7 @@ fn vcpu_thread_rules() -> Result<Vec<SyscallRuleSet>, Error> {
         allow_syscall_if(libc::SYS_ioctl, create_vcpu_ioctl_seccomp_rule()?),
         allow_syscall(libc::SYS_lseek),
         allow_syscall(libc::SYS_madvise),
+        allow_syscall(libc::SYS_mmap),
         allow_syscall(libc::SYS_mprotect),
         allow_syscall(libc::SYS_munmap),
         allow_syscall(libc::SYS_nanosleep),


### PR DESCRIPTION
Allow vsocks to connect to Unix sockets on the host running
cloud-hypervisor with enabled seccomp.

Reported-by: Philippe Schaaf <philippe.schaaf@secunet.com>
Tested-by: Franz Girlich <franz.girlich@tu-ilmenau.de>
Signed-off-by: Markus Theil <markus.theil@tu-ilmenau.de>