### PR TITLE
build: Bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = 3
 name = "acpi_tables"
 version = "0.1.0"
 dependencies = [
- "vm-memory 0.6.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -78,7 +78,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vm-fdt",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -142,7 +142,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "virtio-bindings",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -209,7 +209,7 @@ dependencies = [
  "signal-hook",
  "test_infra",
  "thiserror",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vmm",
  "vmm-sys-util",
  "wait-timeout",
@@ -255,7 +255,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vm-device",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -397,7 +397,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "thiserror",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -465,9 +465,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libssh2-sys"
@@ -501,7 +501,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c819cc8275b0f2c1ed9feec455ca288b45d82932384a6a5f7a86812ee3427459"
 dependencies = [
- "vm-memory 0.6.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -592,7 +592,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "virtio-bindings",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -663,7 +663,7 @@ dependencies = [
  "vfio-ioctls",
  "vm-allocator",
  "vm-device",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -808,9 +808,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -822,7 +822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.8",
+ "redox_syscall 0.2.10",
 ]
 
 [[package]]
@@ -1109,14 +1109,14 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio-ioctls?branch=master#9b84069e9f419c5369b9a313859cac7e9828d331"
+source = "git+https://github.com/rust-vmm/vfio-ioctls?branch=master#d9ee82853814c7395460c9bf0078e42d26ea6244"
 dependencies = [
  "byteorder",
  "kvm-bindings",
  "kvm-ioctls",
  "log",
  "vfio-bindings",
- "vm-memory 0.5.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1128,7 +1128,7 @@ checksum = "8a6b90237e10f1a61b35fba73885c3567e1a5a8c40d44daae335f7710210a7dc"
 dependencies = [
  "bitflags",
  "libc",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1141,7 +1141,7 @@ dependencies = [
  "log",
  "vhost",
  "virtio-bindings",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -1161,7 +1161,7 @@ dependencies = [
  "vhost",
  "vhost_user_backend",
  "virtio-bindings",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1179,7 +1179,7 @@ dependencies = [
  "vhost",
  "vhost_user_backend",
  "virtio-bindings",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1216,7 +1216,7 @@ dependencies = [
  "virtio-bindings",
  "vm-allocator",
  "vm-device",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
@@ -1228,7 +1228,7 @@ version = "0.1.0"
 dependencies = [
  "arch",
  "libc",
- "vm-memory 0.6.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -1241,7 +1241,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "vfio-ioctls",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1249,16 +1249,6 @@ dependencies = [
 name = "vm-fdt"
 version = "0.1.0"
 source = "git+https://github.com/rust-vmm/vm-fdt?branch=master#af59838e5df826cd3153d92ed1546f0b2cc454f7"
-
-[[package]]
-name = "vm-memory"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625f401b1b8b3ac3d43f53903cd138cfe840bd985f8581e553027b31d2bb8ae8"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "vm-memory"
@@ -1282,7 +1272,7 @@ dependencies = [
  "thiserror",
  "versionize",
  "versionize_derive",
- "vm-memory 0.6.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -1291,7 +1281,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "virtio-bindings",
- "vm-memory 0.6.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -1332,7 +1322,7 @@ dependencies = [
  "virtio-devices",
  "vm-allocator",
  "vm-device",
- "vm-memory 0.6.0",
+ "vm-memory",
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ clap = { version = "2.33.3", features = ["wrap_help"] }
 epoll = "4.3.1"
 event_monitor = { path = "event_monitor" }
 hypervisor = { path = "hypervisor" }
-libc = "0.2.98"
+libc = "0.2.99"
 log = { version = "0.4.14", features = ["std"] }
 option_parser = { path = "option_parser" }
 seccomp = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v0.24.5" }

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -14,7 +14,7 @@ acpi_tables = { path = "../acpi_tables", optional = true }
 anyhow = "1.0.42"
 byteorder = "1.4.3"
 hypervisor = { path = "../hypervisor" }
-libc = "0.2.98"
+libc = "0.2.99"
 linux-loader = { version = "0.3.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.14"
 serde = { version = "1.0.127", features = ["rc"] }

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -10,7 +10,7 @@ io_uring = []
 
 [dependencies]
 io-uring = "0.5.1"
-libc = "0.2.98"
+libc = "0.2.99"
 log = "0.4.14"
 qcow = { path = "../qcow" }
 thiserror = "1.0.26"

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -11,7 +11,7 @@ arch = { path = "../arch" }
 bitflags = "1.2.1"
 byteorder = "1.4.3"
 epoll = "4.3.1"
-libc = "0.2.98"
+libc = "0.2.99"
 log = "0.4.14"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"

--- a/event_monitor/Cargo.toml
+++ b/event_monitor/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 
 [dependencies]
-libc = "0.2.98"
+libc = "0.2.99"
 serde = { version = "1.0.127", features = ["rc"] }
 serde_derive = "1.0.127"
 serde_json = "1.0.66"

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -14,7 +14,7 @@ tdx = []
 anyhow = "1.0.42"
 epoll = "4.3.1"
 thiserror = "1.0.26"
-libc = "0.2.98"
+libc = "0.2.99"
 log = "0.4.14"
 kvm-ioctls = { version = "0.9.0", optional = true }
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.4.0", features = ["with-serde", "fam-wrappers"], optional  = true }

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 epoll = "4.3.1"
-libc = "0.2.98"
+libc = "0.2.99"
 log = "0.4.14"
 net_gen = { path = "../net_gen" }
 rate_limiter = { path = "../rate_limiter" }

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -10,7 +10,7 @@ byteorder = "1.4.3"
 hypervisor = { path = "../hypervisor" }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "master" }
 vmm-sys-util = "0.8.0"
-libc = "0.2.98"
+libc = "0.2.99"
 log = "0.4.14"
 thiserror = "1.0.26"
 versionize = "0.1.6"

--- a/qcow/Cargo.toml
+++ b/qcow/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/qcow.rs"
 
 [dependencies]
 byteorder = "1.4.3"
-libc = "0.2.98"
+libc = "0.2.99"
 log = "0.4.14"
 remain = "0.2.2"
 vmm-sys-util = "0.8.0"

--- a/rate_limiter/Cargo.toml
+++ b/rate_limiter/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-libc = "0.2.98"
+libc = "0.2.99"
 log = "0.4.14"
 vmm-sys-util = "0.8.0"

--- a/vhost_user_backend/Cargo.toml
+++ b/vhost_user_backend/Cargo.toml
@@ -9,10 +9,10 @@ default = []
 
 [dependencies]
 epoll = "4.3.1"
-libc = "0.2.98"
+libc = "0.2.99"
 log = "0.4.14"
 virtio-bindings = "0.1.0"
 vm-memory = { version = "0.6.0", features = ["backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.8.0"
-vhost = { version = "0.1.0" , features = ["vhost-user-slave"] }
+vhost = { version = "0.1.0", features = ["vhost-user-slave"] }

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -9,12 +9,12 @@ block_util = { path = "../block_util" }
 clap = { version = "2.33.3", features = ["wrap_help"] }
 env_logger = "0.9.0"
 epoll = "4.3.1"
-libc = "0.2.98"
+libc = "0.2.99"
 log = "0.4.14"
 option_parser = { path = "../option_parser" }
 qcow = { path = "../qcow" }
 vhost_user_backend = { path = "../vhost_user_backend" }
-vhost = { version = "0.1.0" , features = ["vhost-user-slave"] }
+vhost = { version = "0.1.0", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
 vm-memory = "0.6.0"
 vmm-sys-util = "0.8.0"

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 clap = { version = "2.33.3", features = ["wrap_help"] }
 env_logger = "0.9.0"
 epoll = "4.3.1"
-libc = "0.2.98"
+libc = "0.2.99"
 log = "0.4.14"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
 vhost_user_backend = { path = "../vhost_user_backend" }
-vhost = { version = "0.1.0" , features = ["vhost-user-slave"] }
+vhost = { version = "0.1.0", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
 vm-memory = "0.6.0"
 vmm-sys-util = "0.8.0"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = "1.4.3"
 epoll = "4.3.1"
 event_monitor = { path = "../event_monitor" }
 io-uring = "0.5.1"
-libc = "0.2.98"
+libc = "0.2.99"
 log = "0.4.14"
 net_gen = { path = "../net_gen" }
 net_util = { path = "../net_util" }
@@ -29,8 +29,8 @@ serde_derive = "1.0.127"
 serde_json = "1.0.66"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vhost = { version = "0.1.0" , features = ["vhost-user-master", "vhost-user-slave", "vhost-kern"] }
-virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"]}
+vhost = { version = "0.1.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern"] }
+virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["The Chromium OS Authors"]
 edition = "2018"
 
 [dependencies]
-libc = "0.2.98"
+libc = "0.2.99"
 vm-memory = "0.6.0"
 arch = { path = "../arch" }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -27,7 +27,7 @@ epoll = "4.3.1"
 event_monitor = { path = "../event_monitor" }
 hypervisor = { path = "../hypervisor" }
 lazy_static = "1.4.0"
-libc = "0.2.98"
+libc = "0.2.99"
 linux-loader = { version = "0.3.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.14"
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }


### PR DESCRIPTION
This has the side effect of also removing the vm-memory 0.5.0
dependency.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>