### PR TITLE
virtio-devices: vhost_user: Refactor through VhostUserCommon

### DIFF
--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -3,17 +3,15 @@
 
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
 use crate::vhost_user::vu_common_ctrl::{VhostUserConfig, VhostUserHandle};
-use crate::vhost_user::{Error, Inflight, Result, VhostUserEpollHandler};
+use crate::vhost_user::{Error, Result, VhostUserCommon};
 use crate::{
     ActivateError, ActivateResult, EpollHelper, EpollHelperError, EpollHelperHandler, Queue,
     VirtioCommon, VirtioDevice, VirtioDeviceType, VirtioInterrupt, EPOLL_HELPER_EVENT_LAST,
     VIRTIO_F_RING_EVENT_IDX, VIRTIO_F_VERSION_1,
 };
 use crate::{GuestMemoryMmap, GuestRegionMmap};
-use anyhow::anyhow;
 use net_util::{build_net_config_space, CtrlQueue, MacAddr, VirtioNetConfig};
 use seccomp::{SeccompAction, SeccompFilter};
-use std::ops::Deref;
 use std::os::unix::io::AsRawFd;
 use std::result;
 use std::sync::atomic::AtomicBool;
@@ -30,7 +28,7 @@ use virtio_bindings::bindings::virtio_net::{
     VIRTIO_NET_F_HOST_ECN, VIRTIO_NET_F_HOST_TSO4, VIRTIO_NET_F_HOST_TSO6, VIRTIO_NET_F_HOST_UFO,
     VIRTIO_NET_F_MAC, VIRTIO_NET_F_MRG_RXBUF,
 };
-use vm_memory::{Address, ByteValued, GuestAddressSpace, GuestMemory, GuestMemoryAtomic};
+use vm_memory::{ByteValued, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::{
     protocol::MemoryRangeTable, Migratable, MigratableError, Pausable, Snapshot, Snapshottable,
     Transportable, VersionMapped,
@@ -107,18 +105,13 @@ impl EpollHelperHandler for NetCtrlEpollHandler {
 
 pub struct Net {
     common: VirtioCommon,
+    vu_common: VhostUserCommon,
     id: String,
-    vu: Option<Arc<Mutex<VhostUserHandle>>>,
     config: VirtioNetConfig,
     guest_memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
-    acked_protocol_features: u64,
-    socket_path: String,
-    server: bool,
     ctrl_queue_epoll_thread: Option<thread::JoinHandle<()>>,
     epoll_thread: Option<thread::JoinHandle<()>>,
     seccomp_action: SeccompAction,
-    vu_num_queues: usize,
-    migration_started: bool,
 }
 
 impl Net {
@@ -139,7 +132,6 @@ impl Net {
             // queue (with +1) will guarantee that. VirtioPciDevice::new() will
             // create the actual queues based on this information.
             return Ok(Net {
-                id,
                 common: VirtioCommon {
                     device_type: VirtioDeviceType::Net as u32,
                     queue_sizes: vec![vu_cfg.queue_size; num_queues + 1],
@@ -147,17 +139,18 @@ impl Net {
                     min_queues: DEFAULT_QUEUE_NUMBER as u16,
                     ..Default::default()
                 },
-                vu: None,
+                vu_common: VhostUserCommon {
+                    socket_path: vu_cfg.socket,
+                    vu_num_queues: num_queues,
+                    server,
+                    ..Default::default()
+                },
+                id,
                 config: VirtioNetConfig::default(),
                 guest_memory: None,
-                acked_protocol_features: 0,
-                socket_path: vu_cfg.socket,
-                server,
                 ctrl_queue_epoll_thread: None,
                 epoll_thread: None,
                 seccomp_action,
-                vu_num_queues: num_queues,
-                migration_started: false,
             });
         }
 
@@ -230,17 +223,19 @@ impl Net {
                 min_queues: DEFAULT_QUEUE_NUMBER as u16,
                 ..Default::default()
             },
-            vu: Some(Arc::new(Mutex::new(vu))),
+            vu_common: VhostUserCommon {
+                vu: Some(Arc::new(Mutex::new(vu))),
+                acked_protocol_features,
+                socket_path: vu_cfg.socket,
+                vu_num_queues,
+                server,
+                ..Default::default()
+            },
             config,
             guest_memory: None,
-            acked_protocol_features,
-            socket_path: vu_cfg.socket,
-            server,
             ctrl_queue_epoll_thread: None,
             epoll_thread: None,
             seccomp_action,
-            vu_num_queues,
-            migration_started: false,
         })
     }
 
@@ -249,8 +244,8 @@ impl Net {
             avail_features: self.common.avail_features,
             acked_features: self.common.acked_features,
             config: self.config,
-            acked_protocol_features: self.acked_protocol_features,
-            vu_num_queues: self.vu_num_queues,
+            acked_protocol_features: self.vu_common.acked_protocol_features,
+            vu_num_queues: self.vu_common.vu_num_queues,
         }
     }
 
@@ -258,31 +253,18 @@ impl Net {
         self.common.avail_features = state.avail_features;
         self.common.acked_features = state.acked_features;
         self.config = state.config;
-        self.acked_protocol_features = state.acked_protocol_features;
-        self.vu_num_queues = state.vu_num_queues;
+        self.vu_common.acked_protocol_features = state.acked_protocol_features;
+        self.vu_common.vu_num_queues = state.vu_num_queues;
 
-        let mut vu = match VhostUserHandle::connect_vhost_user(
-            self.server,
-            &self.socket_path,
-            self.vu_num_queues as u64,
-            false,
-        ) {
-            Ok(r) => r,
-            Err(e) => {
-                error!("Failed connecting vhost-user backend: {:?}", e);
-                return;
-            }
-        };
-
-        if let Err(e) = vu.set_protocol_features_vhost_user(
-            self.common.acked_features,
-            self.acked_protocol_features,
-        ) {
-            error!("Failed setting up vhost-user backend: {:?}", e);
-            return;
+        if let Err(e) = self
+            .vu_common
+            .restore_backend_connection(self.common.acked_features)
+        {
+            error!(
+                "Failed restoring connection with vhost-user backend: {:?}",
+                e
+            );
         }
-
-        self.vu = Some(Arc::new(Mutex::new(vu)));
     }
 }
 
@@ -379,51 +361,20 @@ impl VirtioDevice for Net {
         let backend_acked_features = self.common.acked_features & !(1 << VIRTIO_NET_F_MAC)
             | (self.common.avail_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits());
 
-        let mut inflight: Option<Inflight> =
-            if self.acked_protocol_features & VhostUserProtocolFeatures::INFLIGHT_SHMFD.bits() != 0
-            {
-                Some(Inflight::default())
-            } else {
-                None
-            };
-
-        if self.vu.is_none() {
-            error!("Missing vhost-user handle");
-            return Err(ActivateError::BadActivate);
-        }
-        let vu = self.vu.as_ref().unwrap();
-        vu.lock()
-            .unwrap()
-            .setup_vhost_user(
-                &mem.memory(),
-                queues.clone(),
-                queue_evts.iter().map(|q| q.try_clone().unwrap()).collect(),
-                &interrupt_cb,
-                backend_acked_features,
-                &slave_req_handler,
-                inflight.as_mut(),
-            )
-            .map_err(ActivateError::VhostUserNetSetup)?;
-
         // Run a dedicated thread for handling potential reconnections with
         // the backend.
         let (kill_evt, pause_evt) = self.common.dup_eventfds();
 
-        let mut handler: VhostUserEpollHandler<SlaveReqHandler> = VhostUserEpollHandler {
-            vu: vu.clone(),
+        let mut handler = self.vu_common.activate(
             mem,
-            kill_evt,
-            pause_evt,
             queues,
             queue_evts,
-            virtio_interrupt: interrupt_cb,
-            acked_features: backend_acked_features,
-            acked_protocol_features: self.acked_protocol_features,
-            socket_path: self.socket_path.clone(),
-            server: self.server,
-            slave_req_handler: None,
-            inflight,
-        };
+            interrupt_cb,
+            backend_acked_features,
+            slave_req_handler,
+            kill_evt,
+            pause_evt,
+        )?;
 
         let paused = self.common.paused.clone();
         let paused_sync = self.common.paused_sync.clone();
@@ -450,7 +401,7 @@ impl VirtioDevice for Net {
             self.common.resume().ok()?;
         }
 
-        if let Some(vu) = &self.vu {
+        if let Some(vu) = &self.vu_common.vu {
             if let Err(e) = vu
                 .lock()
                 .unwrap()
@@ -473,52 +424,20 @@ impl VirtioDevice for Net {
     }
 
     fn shutdown(&mut self) {
-        if let Some(vu) = &self.vu {
-            let _ = unsafe { libc::close(vu.lock().unwrap().socket_handle().as_raw_fd()) };
-        }
-
-        // Remove socket path if needed
-        if self.server {
-            let _ = std::fs::remove_file(&self.socket_path);
-        }
+        self.vu_common.shutdown();
     }
 
     fn add_memory_region(
         &mut self,
         region: &Arc<GuestRegionMmap>,
     ) -> std::result::Result<(), crate::Error> {
-        if let Some(vu) = &self.vu {
-            if self.acked_protocol_features & VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS.bits()
-                != 0
-            {
-                return vu
-                    .lock()
-                    .unwrap()
-                    .add_memory_region(region)
-                    .map_err(crate::Error::VhostUserAddMemoryRegion);
-            } else if let Some(guest_memory) = &self.guest_memory {
-                return vu
-                    .lock()
-                    .unwrap()
-                    .update_mem_table(guest_memory.memory().deref())
-                    .map_err(crate::Error::VhostUserUpdateMemory);
-            }
-        }
-        Ok(())
+        self.vu_common.add_memory_region(&self.guest_memory, region)
     }
 }
 
 impl Pausable for Net {
     fn pause(&mut self) -> result::Result<(), MigratableError> {
-        if let Some(vu) = &self.vu {
-            vu.lock()
-                .unwrap()
-                .pause_vhost_user(self.vu_num_queues)
-                .map_err(|e| {
-                    MigratableError::Pause(anyhow!("Error pausing vhost-user-net backend: {:?}", e))
-                })?;
-        }
-
+        self.vu_common.pause()?;
         self.common.pause()
     }
 
@@ -533,19 +452,7 @@ impl Pausable for Net {
             ctrl_queue_epoll_thread.thread().unpark();
         }
 
-        if let Some(vu) = &self.vu {
-            vu.lock()
-                .unwrap()
-                .resume_vhost_user(self.vu_num_queues)
-                .map_err(|e| {
-                    MigratableError::Resume(anyhow!(
-                        "Error resuming vhost-user-net backend: {:?}",
-                        e
-                    ))
-                })
-        } else {
-            Ok(())
-        }
+        self.vu_common.resume()
     }
 }
 
@@ -555,13 +462,7 @@ impl Snapshottable for Net {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        let snapshot = Snapshot::new_from_versioned_state(&self.id(), &self.state())?;
-
-        if self.migration_started {
-            self.shutdown();
-        }
-
-        Ok(snapshot)
+        self.vu_common.snapshot(&self.id(), &self.state())
     }
 
     fn restore(&mut self, snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
@@ -573,77 +474,19 @@ impl Transportable for Net {}
 
 impl Migratable for Net {
     fn start_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
-        self.migration_started = true;
-        if let Some(vu) = &self.vu {
-            if let Some(guest_memory) = &self.guest_memory {
-                let last_ram_addr = guest_memory.memory().last_addr().raw_value();
-                vu.lock()
-                    .unwrap()
-                    .start_dirty_log(last_ram_addr)
-                    .map_err(|e| {
-                        MigratableError::StartDirtyLog(anyhow!(
-                            "Error starting migration for vhost-user-net backend: {:?}",
-                            e
-                        ))
-                    })
-            } else {
-                Err(MigratableError::StartDirtyLog(anyhow!(
-                    "Missing guest memory"
-                )))
-            }
-        } else {
-            Ok(())
-        }
+        self.vu_common.start_dirty_log(&self.guest_memory)
     }
 
     fn stop_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
-        self.migration_started = false;
-        if let Some(vu) = &self.vu {
-            vu.lock().unwrap().stop_dirty_log().map_err(|e| {
-                MigratableError::StopDirtyLog(anyhow!(
-                    "Error stopping migration for vhost-user-net backend: {:?}",
-                    e
-                ))
-            })
-        } else {
-            Ok(())
-        }
+        self.vu_common.stop_dirty_log()
     }
 
     fn dirty_log(&mut self) -> std::result::Result<MemoryRangeTable, MigratableError> {
-        if let Some(vu) = &self.vu {
-            if let Some(guest_memory) = &self.guest_memory {
-                let last_ram_addr = guest_memory.memory().last_addr().raw_value();
-                vu.lock().unwrap().dirty_log(last_ram_addr).map_err(|e| {
-                    MigratableError::DirtyLog(anyhow!(
-                        "Error retrieving dirty ranges from vhost-user-net backend: {:?}",
-                        e
-                    ))
-                })
-            } else {
-                Err(MigratableError::DirtyLog(anyhow!("Missing guest memory")))
-            }
-        } else {
-            Ok(MemoryRangeTable::default())
-        }
+        self.vu_common.dirty_log(&self.guest_memory)
     }
 
     fn complete_migration(&mut self) -> std::result::Result<(), MigratableError> {
-        // Make sure the device thread is killed in order to prevent from
-        // reconnections to the socket.
-        if let Some(kill_evt) = self.common.kill_evt.take() {
-            kill_evt.write(1).map_err(|e| {
-                MigratableError::CompleteMigration(anyhow!(
-                    "Error killing vhost-user-net threads: {:?}",
-                    e
-                ))
-            })?;
-        }
-
-        // Drop the vhost-user handler to avoid further calls to fail because
-        // the connection with the backend has been closed.
-        self.vu = None;
-
-        Ok(())
+        self.vu_common
+            .complete_migration(self.common.kill_evt.take())
     }
 }


### PR DESCRIPTION
Introducing a new structure VhostUserCommon allowing to factorize a lot
of the code shared between the vhost-user devices (block, fs and net).

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>