### PR TITLE
block_util, vmm: Propagate error on QcowDiskSync creation

### DIFF
--- a/block_util/src/qcow_sync.rs
+++ b/block_util/src/qcow_sync.rs
@@ -4,7 +4,7 @@
 
 use crate::async_io::{AsyncIo, AsyncIoResult, DiskFile, DiskFileResult};
 use crate::{disk_size, fsync_sync, read_vectored_sync, write_vectored_sync};
-use qcow::{QcowFile, RawFile};
+use qcow::{QcowFile, RawFile, Result as QcowResult};
 use std::fs::File;
 use std::sync::{Arc, Mutex};
 use vmm_sys_util::eventfd::EventFd;
@@ -15,12 +15,11 @@ pub struct QcowDiskSync {
 }
 
 impl QcowDiskSync {
-    pub fn new(file: File, direct_io: bool) -> Self {
-        QcowDiskSync {
-            qcow_file: QcowFile::from(RawFile::new(file, direct_io))
-                .expect("Failed creating QcowFile"),
+    pub fn new(file: File, direct_io: bool) -> QcowResult<Self> {
+        Ok(QcowDiskSync {
+            qcow_file: QcowFile::from(RawFile::new(file, direct_io))?,
             semaphore: Arc::new(Mutex::new(())),
-        }
+        })
     }
 }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -417,6 +417,9 @@ pub enum DeviceManagerError {
     /// Failed to create FixedVhdDiskSync
     CreateFixedVhdDiskSync(io::Error),
 
+    /// Failed to create QcowDiskSync
+    CreateQcowDiskSync(qcow::Error),
+
     /// Failed adding DMA mapping handler to virtio-mem device.
     AddDmaMappingHandlerVirtioMem(virtio_devices::mem::Error),
 
@@ -1936,7 +1939,10 @@ impl DeviceManager {
                 }
                 ImageType::Qcow2 => {
                     info!("Using synchronous QCOW disk file");
-                    Box::new(QcowDiskSync::new(file, disk_cfg.direct)) as Box<dyn DiskFile>
+                    Box::new(
+                        QcowDiskSync::new(file, disk_cfg.direct)
+                            .map_err(DeviceManagerError::CreateQcowDiskSync)?,
+                    ) as Box<dyn DiskFile>
                 }
             };
 


### PR DESCRIPTION
Instead of panicking with an expect() function, the QcowDiskSync::new
function now propagates the error properly. This ensures the VMM will
not panic, which might be the source of weird errors if only one thread
exits while the VMM continues to run.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>