### PR TITLE
vfio_user: DmaUnmap expects a reply with payload

### DIFF
--- a/vfio_user/src/lib.rs
+++ b/vfio_user/src/lib.rs
@@ -410,7 +410,7 @@ impl Client {
             .write_all(dma_unmap.as_slice())
             .map_err(Error::StreamWrite)?;
 
-        let mut reply = Header::default();
+        let mut reply = DmaUnmap::default();
         self.stream
             .read_exact(reply.as_mut_slice())
             .map_err(Error::StreamRead)?;


### PR DESCRIPTION
The current code was expecting a reply with only the header, which
wasn't reading the rest of payload that was provided. This was causing
the following replies to be completely wrong as they were shifted by the
previous payload that wasn't read.

The simple way to fix this issue is by reading the header and the
expected payload when getting a reply from a DmaUnmap request.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>