### PR TITLE
tests: Add the integration test for live migration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,6 +143,32 @@ pipeline{
 						}
 					}
 				}
+				stage ('Worker build - Live Migration') {
+					agent { node { label 'hirsute-small' } }
+					stages {
+						stage ('Checkout') {
+							steps {
+								checkout scm
+							}
+						}
+						stage ('Run live-migration integration tests') {
+							options {
+								timeout(time: 1, unit: 'HOURS')
+							}
+							steps {
+								sh "scripts/dev_cli.sh tests --integration-live-migration"
+							}
+						}
+						stage ('Run live-migration integration tests for musl') {
+							options {
+								timeout(time: 1, unit: 'HOURS')
+							}
+							steps {
+								sh "scripts/dev_cli.sh tests --integration-live-migration --libc musl"
+							}
+						}
+					}
+				}
 			}
 		}
 	}

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -178,16 +178,17 @@ cmd_help() {
     echo ""
     echo "    tests [--unit|--cargo|--all] [--libc musl|gnu] [-- [<cargo test args>]]"
     echo "        Run the Cloud Hypervisor tests."
-    echo "        --unit                Run the unit tests."
-    echo "        --cargo               Run the cargo tests."
-    echo "        --integration         Run the integration tests."
-    echo "        --integration-sgx     Run the SGX integration tests."
-    echo "        --integration-vfio    Run the VFIO integration tests."
-    echo "        --integration-windows Run the Windows guest integration tests."
-    echo "        --libc                Select the C library Cloud Hypervisor will be built against. Default is gnu"
-    echo "        --volumes             Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
-    echo "        --hypervisor          Underlying hypervisor. Options kvm, mshv"
-    echo "        --all                 Run all tests."
+    echo "        --unit                       Run the unit tests."
+    echo "        --cargo                      Run the cargo tests."
+    echo "        --integration                Run the integration tests."
+    echo "        --integration-sgx            Run the SGX integration tests."
+    echo "        --integration-vfio           Run the VFIO integration tests."
+    echo "        --integration-windows        Run the Windows guest integration tests."
+    echo "        --integration-live-migration Run the live-migration integration tests."
+    echo "        --libc                       Select the C library Cloud Hypervisor will be built against. Default is gnu"
+    echo "        --volumes                    Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
+    echo "        --hypervisor                 Underlying hypervisor. Options kvm, mshv"
+    echo "        --all                        Run all tests."
     echo ""
     echo "    build-container [--type]"
     echo "        Build the Cloud Hypervisor container."
@@ -298,19 +299,21 @@ cmd_tests() {
     integration_sgx=false
     integration_vfio=false
     integration_windows=false
+    integration_live_migration=false
     libc="gnu"
     arg_vols=""
     hypervisor="kvm"
     exported_device="/dev/kvm"
     while [ $# -gt 0 ]; do
 	case "$1" in
-            "-h"|"--help")           { cmd_help; exit 1; } ;;
-            "--unit")                { unit=true; } ;;
-            "--cargo")               { cargo=true; } ;;
-            "--integration")         { integration=true; } ;;
-            "--integration-sgx")     { integration_sgx=true; } ;;
-            "--integration-vfio")    { integration_vfio=true; } ;;
-            "--integration-windows") { integration_windows=true; } ;;
+            "-h"|"--help")                  { cmd_help; exit 1; } ;;
+            "--unit")                       { unit=true; } ;;
+            "--cargo")                      { cargo=true; } ;;
+            "--integration")                { integration=true; } ;;
+            "--integration-sgx")            { integration_sgx=true; } ;;
+            "--integration-vfio")           { integration_vfio=true; } ;;
+            "--integration-windows")        { integration_windows=true; } ;;
+            "--integration-live-migration") { integration_live_migration=true; } ;;
             "--libc")
                 shift
                 [[ "$1" =~ ^(musl|gnu)$ ]] || \
@@ -453,6 +456,25 @@ cmd_tests() {
 	       --env CH_LIBC="${libc}" \
 	       "$CTR_IMAGE" \
 	       ./scripts/run_integration_tests_windows.sh "$@" || fix_dir_perms $? || exit $?
+    fi
+
+    if [ "$integration_live_migration" = true ] ;  then
+	say "Running 'live migration' integration tests for $target..."
+	$DOCKER_RUNTIME run \
+	       --workdir "$CTR_CLH_ROOT_DIR" \
+	       --rm \
+	       --privileged \
+	       --security-opt seccomp=unconfined \
+	       --ipc=host \
+	       --net="$CTR_CLH_NET" \
+	       --mount type=tmpfs,destination=/tmp \
+	       --volume /dev:/dev \
+	       --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR"  $exported_volumes \
+	       --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+	       --env USER="root" \
+	       --env CH_LIBC="${libc}" \
+	       "$CTR_IMAGE" \
+	       ./scripts/run_integration_tests_live_migration.sh "$@" || fix_dir_perms $? || exit $?
     fi
     fix_dir_perms $?
 }

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -x
+
+source $HOME/.cargo/env
+source $(dirname "$0")/test-util.sh
+
+export BUILD_TARGET=${BUILD_TARGET-x86_64-unknown-linux-gnu}
+
+WORKLOADS_DIR="$HOME/workloads"
+mkdir -p "$WORKLOADS_DIR"
+
+process_common_args "$@"
+
+# For now these values are deafult for kvm
+features_build=""
+features_test="--features integration_tests"
+
+cp scripts/sha1sums-x86_64 $WORKLOADS_DIR
+
+FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
+FOCAL_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$FOCAL_OS_IMAGE_NAME"
+FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"
+if [ ! -f "$FOCAL_OS_IMAGE" ]; then
+    pushd $WORKLOADS_DIR
+    time wget --quiet $FOCAL_OS_IMAGE_URL || exit 1
+    popd
+fi
+
+FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.raw"
+FOCAL_OS_RAW_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_RAW_IMAGE_NAME"
+if [ ! -f "$FOCAL_OS_RAW_IMAGE" ]; then
+    pushd $WORKLOADS_DIR
+    time qemu-img convert -p -f qcow2 -O raw $FOCAL_OS_IMAGE_NAME $FOCAL_OS_RAW_IMAGE_NAME || exit 1
+    popd
+fi
+
+pushd $WORKLOADS_DIR
+grep focal sha1sums-x86_64 | sha1sum --check
+if [ $? -ne 0 ]; then
+    echo "sha1sum validation of images failed, remove invalid images to fix the issue."
+    exit 1
+fi
+popd
+
+# Build custom kernel based on virtio-pmem and virtio-fs upstream patches
+VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
+
+LINUX_CUSTOM_DIR="$WORKLOADS_DIR/linux-custom"
+
+if [ ! -f "$VMLINUX_IMAGE" ]; then
+    SRCDIR=$PWD
+    pushd $WORKLOADS_DIR
+    time git clone --depth 1 "https://github.com/cloud-hypervisor/linux.git" -b "ch-5.14" $LINUX_CUSTOM_DIR
+    cp $SRCDIR/resources/linux-config-x86_64 $LINUX_CUSTOM_DIR/.config
+    popd
+fi
+
+if [ ! -f "$VMLINUX_IMAGE" ]; then
+    pushd $LINUX_CUSTOM_DIR
+    time make bzImage -j `nproc`
+    cp vmlinux $VMLINUX_IMAGE || exit 1
+    popd
+fi
+
+if [ -d "$LINUX_CUSTOM_DIR" ]; then
+    rm -rf $LINUX_CUSTOM_DIR
+fi
+
+BUILD_TARGET="$(uname -m)-unknown-linux-${CH_LIBC}"
+CFLAGS=""
+TARGET_CC=""
+if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
+    TARGET_CC="musl-gcc"
+    CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
+fi
+
+cargo build --all --release $features_build --target $BUILD_TARGET
+strip target/$BUILD_TARGET/release/cloud-hypervisor
+strip target/$BUILD_TARGET/release/vhost_user_net
+strip target/$BUILD_TARGET/release/ch-remote
+
+export RUST_BACKTRACE=1
+
+time cargo test $features_test "tests::live_migration::$test_filter" -- --test-threads=1
+RES=$?
+
+exit $RES


### PR DESCRIPTION
This test exercises the local live-migration between two Cloud
Hypervisor VMs on the same host. It ensures the following behaviors:
1. The source VM is up and functional (including various virtio-devices
are working properly);
2. The 'send-migration' and 'receive-migration' command finished
successfully;
3. The source VM terminated gracefully after live migration;
4. The destination VM is functional (including various virtio-devices
are working properly) after live migration.

Note: This test does not use vsock as we can't create two identical
vsock on the same host.

Fixes: #2965

Signed-off-by: Bo Chen <chen.bo@intel.com>
