### PR TITLE
Jenkinsfile: Update to new Jenkins terminology

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline{
 	agent none
 	stages {
 		stage ('Early checks') {
-			agent { node { label 'master' } }
+			agent { node { label 'built-in' } }
 			stages {
 				stage ('Check for RFC/WIP builds') {
 					when {


### PR DESCRIPTION
The Jenkins master is now known as the controller and the agent it provides is
called "built-in".

Signed-off-by: Rob Bradford <robert.bradford@intel.com>