### PR TITLE
vmm: config: fix ConsoleOutputMode input_enabled

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1454,7 +1454,7 @@ pub enum ConsoleOutputMode {
 
 impl ConsoleOutputMode {
     pub fn input_enabled(&self) -> bool {
-        matches!(self, ConsoleOutputMode::Tty | ConsoleOutputMode::Pty)
+        matches!(self, ConsoleOutputMode::Tty)
     }
 }
 


### PR DESCRIPTION
See https://github.com/cloud-hypervisor/cloud-hypervisor/issues/3005

ConsoleOutputMode's input_enabled treated both TTY and PTY as valid
input. That's wrong in the context of device manager, because what it
really does is to handle input from stdin. In that case, only Tty mode
should count.

Signed-off-by: Wei Liu <liuwe@microsoft.com>