### PR TITLE
vmm: Send tty input to correct destination

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -535,21 +535,6 @@ pub struct Console {
 }
 
 impl Console {
-    pub fn queue_input_bytes(&self, out: &[u8]) -> vmm_sys_util::errno::Result<()> {
-        match self.input {
-            Some(ConsoleInput::Serial) => {
-                self.queue_input_bytes_serial(out)?;
-            }
-
-            Some(ConsoleInput::VirtioConsole) => {
-                self.queue_input_bytes_console(out);
-            }
-            None => {}
-        }
-
-        Ok(())
-    }
-
     pub fn queue_input_bytes_serial(&self, out: &[u8]) -> vmm_sys_util::errno::Result<()> {
         if self.serial.is_some() {
             self.serial


### PR DESCRIPTION
Check the config to find out which device is attached to the tty and
then send the input from the user into that device (serial or
virtio-console.)

Fixes: #3005

Signed-off-by: Rob Bradford <robert.bradford@intel.com>