### PR TITLE
pci: vfio_user: Free BARs associated with vfio-user device

### DIFF
--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -234,6 +234,10 @@ impl PciDevice for VfioUserPciDevice {
         self.common.allocate_bars(allocator, &self.vfio_wrapper)
     }
 
+    fn free_bars(&mut self, allocator: &mut SystemAllocator) -> Result<(), PciDeviceError> {
+        self.common.free_bars(allocator)
+    }
+
     fn as_any(&mut self) -> &mut dyn Any {
         self
     }


### PR DESCRIPTION
This resolves an issue with hotplug -> removal -> hotplug of a vfio-user
device as the allocator was not updated with the now unused entries.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>