### PR TITLE
vmm: Remove unlink/unlinkat from vCPU seccomp filter

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -569,10 +569,6 @@ fn vcpu_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError> {
         (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_tgkill, vec![]),
         (libc::SYS_tkill, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_unlink, vec![]),
-        #[cfg(target_arch = "aarch64")]
-        (libc::SYS_unlinkat, vec![]),
         (libc::SYS_write, vec![]),
         (libc::SYS_writev, vec![]),
     ])


### PR DESCRIPTION
This was added in c02a02edfc29788834d012639f66a9686ae2d324 but device
handling now is now in the VMM thread not the vCPU one.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>