### PR TITLE
dev_cli: Enable pulling latest dev container on Arm

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -239,9 +239,7 @@ cmd_build() {
     done
 
     ensure_build_dir
-    if [ $(uname -m) = "x86_64" ]; then
-	ensure_latest_ctr
-    fi
+    ensure_latest_ctr
 
     process_volumes_args
     if [[ "$hypervisor" != "kvm" ]]; then
@@ -280,9 +278,7 @@ cmd_clean() {
     cargo_args=("$@")
 
     ensure_build_dir
-    if [ $(uname -m) = "x86_64" ]; then
-	ensure_latest_ctr
-    fi
+    ensure_latest_ctr
 
     $DOCKER_RUNTIME run \
 	   --user "$(id -u):$(id -g)" \
@@ -346,9 +342,7 @@ cmd_tests() {
     set -- "$@" '--hypervisor' $hypervisor
 
     ensure_build_dir
-    if [ $(uname -m) = "x86_64" ]; then
-	ensure_latest_ctr
-    fi
+    ensure_latest_ctr
 
     process_volumes_args
     target="$(uname -m)-unknown-linux-${libc}"
@@ -479,9 +473,7 @@ cmd_build-container() {
     done
 
     ensure_build_dir
-    if [ $(uname -m) = "x86_64" ]; then
-	ensure_latest_ctr
-    fi
+    ensure_latest_ctr
 
     BUILD_DIR=/tmp/cloud-hypervisor/container/
 
@@ -514,9 +506,7 @@ cmd_shell() {
 	shift
     done
     ensure_build_dir
-    if [ $(uname -m) = "x86_64" ]; then
-	ensure_latest_ctr
-    fi
+    ensure_latest_ctr
     process_volumes_args
     say_warn "Starting a privileged shell prompt as root ..."
     say_warn "WARNING: Your $CLH_ROOT_DIR folder will be bind-mounted in the container under $CTR_CLH_ROOT_DIR"


### PR DESCRIPTION
Currently the latest cloudhypervisor/dev docker container is the multi-arch image. We can pull the arm image directly.

Fixes: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/3021

Signed-off-by: Henry Wang <Henry.Wang@arm.com>