### PR TITLE
vmm: openapi: use the right default values

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -567,7 +567,7 @@ components:
           default: false
         hotplug_method:
           type: string
-          default: "acpi"
+          default: "Acpi"
         shared:
           type: boolean
           default: false
@@ -714,7 +714,7 @@ components:
           type: string
         vhost_mode:
           type: string
-          default: "client"
+          default: "Client"
         id:
           type: string
         fd:


### PR DESCRIPTION
This patch fixes couple of typos for the default values from the openapi
yaml file.

Signed-off-by: Bo Chen <chen.bo@intel.com>