### PR TITLE
vmm: Don't block on writes to serial PTYs

### DIFF
--- a/devices/src/legacy/mod.rs
+++ b/devices/src/legacy/mod.rs
@@ -15,6 +15,7 @@ mod i8042;
 #[cfg(target_arch = "aarch64")]
 mod rtc_pl031;
 mod serial;
+mod serial_buffer;
 #[cfg(target_arch = "aarch64")]
 mod uart_pl011;
 

--- a/devices/src/legacy/serial_buffer.rs
+++ b/devices/src/legacy/serial_buffer.rs
@@ -1,0 +1,110 @@
+// Copyright © 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::io::Write;
+
+// Circular buffer implementation for serial output.
+// Read from head; push to tail
+pub(crate) struct SerialBuffer {
+    buffer: Vec<u8>,
+    head: usize,
+    tail: usize,
+}
+
+const MAX_BUFFER_SIZE: usize = 16 << 10;
+
+impl SerialBuffer {
+    pub(crate) fn new() -> Self {
+        Self {
+            buffer: vec![],
+            head: 0,
+            tail: 0,
+        }
+    }
+
+    pub(crate) fn flush_buffer(&mut self, writer: &mut dyn Write) -> Result<(), std::io::Error> {
+        if self.tail <= self.head {
+            // The buffer to be written is in two parts
+            let buf = &self.buffer[self.head..];
+            match writer.write(buf) {
+                Ok(bytes_written) => {
+                    if bytes_written == buf.len() {
+                        self.head = 0;
+                        // Can now proceed to write the other part of the buffer
+                    } else {
+                        self.head += bytes_written;
+                        writer.flush()?;
+                        return Ok(());
+                    }
+                }
+                Err(e) => {
+                    if !matches!(e.kind(), std::io::ErrorKind::WouldBlock) {
+                        return Err(e);
+                    }
+                    return Ok(());
+                }
+            }
+        }
+
+        let buf = &self.buffer[self.head..self.tail];
+        match writer.write(buf) {
+            Ok(bytes_written) => {
+                if bytes_written == buf.len() {
+                    self.buffer.clear();
+                    self.buffer.shrink_to_fit();
+                    self.head = 0;
+                    self.tail = 0;
+                } else {
+                    self.head += bytes_written;
+                }
+                writer.flush()?;
+            }
+            Err(e) => {
+                if !matches!(e.kind(), std::io::ErrorKind::WouldBlock) {
+                    return Err(e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn write_to(&mut self, v: u8, writer: &mut dyn Write) -> Result<(), std::io::Error> {
+        if self.buffer.is_empty() {
+            // This case exists to avoid allocating the buffer if it's not needed
+            if let Err(e) = writer.write(&[v]) {
+                if !matches!(e.kind(), std::io::ErrorKind::WouldBlock) {
+                    return Err(e);
+                }
+                self.buffer.push(v);
+                self.tail += 1;
+            } else {
+                writer.flush()?;
+            }
+        } else {
+            // Buffer is completely full, lose the oldest byte by moving head forward
+            if self.head == self.tail {
+                self.head = self.tail + 1;
+                if self.head == MAX_BUFFER_SIZE {
+                    self.head = 0;
+                }
+            }
+
+            if self.buffer.len() < MAX_BUFFER_SIZE {
+                self.buffer.push(v);
+            } else {
+                self.buffer[self.tail] = v;
+            }
+
+            self.tail += 1;
+            if self.tail == MAX_BUFFER_SIZE {
+                self.tail = 0;
+            }
+
+            self.flush_buffer(writer)?;
+        }
+        Ok(())
+    }
+}

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -236,6 +236,9 @@ pub enum Error {
     /// Kernel lacks PVH header
     KernelMissingPvhHeader,
 
+    /// Error flushing serial PTY
+    FlushSerialPty(vmm_sys_util::errno::Error),
+
     /// Error doing I/O on TDX firmware file
     #[cfg(feature = "tdx")]
     LoadTdvf(std::io::Error),
@@ -1940,6 +1943,15 @@ impl Vm {
         }
 
         Ok(())
+    }
+
+    pub fn flush_serial_pty(&self) -> Result<()> {
+        self.device_manager
+            .lock()
+            .unwrap()
+            .console()
+            .flush_serial_buffer()
+            .map_err(Error::FlushSerialPty)
     }
 
     pub fn handle_stdin(&self) -> Result<()> {


### PR DESCRIPTION
The Linux kernel boot will block if the writes to the output associated
with the serial device blocks. This is a particular issue with PTY as
the the PTY may not be connected for some time and thus delay the boot
once the internal PTY buffer is full.

Solve this issue by making the PTY FD non-blocking and then so as to
minimise the amount of data lost use a circular buffer (16KiB that will
be freed when not in use) for the writes to the serial output. The use
of the circular buffer prevents costly movements of memory whilst
keeping the contents consistent.

An epoll handler for flushing the buffer to the PTY is also added for
when the PTY becomes writable as otherwise it will be necessary to
trigger a write on the serial.

Fixes: #3004

Signed-off-by: Rob Bradford <robert.bradford@intel.com>