### PR TITLE
vmm: Fix live-migration on AArch64 platform

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4142,14 +4142,19 @@ impl Pausable for DeviceManager {
                     .get_gic_device()
                     .unwrap(),
             );
-            gic_device
+            if let Some(gicv3_its) = gic_device
                 .lock()
                 .unwrap()
                 .as_any_concrete_mut()
                 .downcast_mut::<KvmGicV3Its>()
-                .unwrap()
-                .pause()?;
-        }
+            {
+                gicv3_its.pause()?;
+            } else {
+                return Err(MigratableError::Pause(anyhow!(
+                    "GicDevice downcast to KvmGicV3Its failed when pausing device manager!"
+                )));
+            };
+        };
 
         Ok(())
     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -28,6 +28,8 @@ use crate::{device_node, DEVICE_MANAGER_SNAPSHOT_ID};
 #[cfg(feature = "acpi")]
 use acpi_tables::{aml, aml::Aml};
 use anyhow::anyhow;
+#[cfg(target_arch = "aarch64")]
+use arch::aarch64::gic::gicv3_its::kvm::KvmGicV3Its;
 #[cfg(feature = "acpi")]
 use arch::layout;
 #[cfg(target_arch = "x86_64")]
@@ -4126,6 +4128,27 @@ impl Pausable for DeviceManager {
             if let Some(migratable) = &device_node.migratable {
                 migratable.lock().unwrap().pause()?;
             }
+        }
+        // On AArch64, the pause of device manager needs to trigger
+        // a "pause" of GIC, which will flush the GIC pending tables
+        // and ITS tables to guest RAM.
+        #[cfg(target_arch = "aarch64")]
+        {
+            let gic_device = Arc::clone(
+                self.get_interrupt_controller()
+                    .unwrap()
+                    .lock()
+                    .unwrap()
+                    .get_gic_device()
+                    .unwrap(),
+            );
+            gic_device
+                .lock()
+                .unwrap()
+                .as_any_concrete_mut()
+                .downcast_mut::<KvmGicV3Its>()
+                .unwrap()
+                .pause()?;
         }
 
         Ok(())


### PR DESCRIPTION
On AArch64 platform, before starting live-migration, we need to flush the GICv3ITS tables to the guest RAM, otherwise the PCI/MSI
interrupts will not be functional after migration.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>