### PR TITLE
Don't block boot due to serial output blocking

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -473,7 +473,7 @@ pub fn get_win_size() -> (u16, u16) {
 const TIOCSPTLCK: libc::c_int = 0x4004_5431;
 const TIOCGTPEER: libc::c_int = 0x5441;
 
-pub fn create_pty() -> io::Result<(File, File, PathBuf)> {
+pub fn create_pty(non_blocking: bool) -> io::Result<(File, File, PathBuf)> {
     // Try to use /dev/pts/ptmx first then fall back to /dev/ptmx
     // This is done to try and use the devpts filesystem that
     // could be available for use in the process's namespace first.
@@ -481,17 +481,19 @@ pub fn create_pty() -> io::Result<(File, File, PathBuf)> {
     // kernels could have things setup differently.
     // See https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
     // for further details.
+
+    let custom_flags = libc::O_NOCTTY | if non_blocking { libc::O_NONBLOCK } else { 0 };
     let main = match OpenOptions::new()
         .read(true)
         .write(true)
-        .custom_flags(libc::O_NOCTTY)
+        .custom_flags(custom_flags)
         .open("/dev/pts/ptmx")
     {
         Ok(f) => f,
         _ => OpenOptions::new()
             .read(true)
             .write(true)
-            .custom_flags(libc::O_NOCTTY)
+            .custom_flags(custom_flags)
             .open("/dev/ptmx")?,
     };
     let mut unlock: libc::c_ulong = 0;
@@ -1713,7 +1715,7 @@ impl DeviceManager {
                     Some(Box::new(buffer))
                 } else {
                     let (main, mut sub, path) =
-                        create_pty().map_err(DeviceManagerError::SerialPtyOpen)?;
+                        create_pty(true).map_err(DeviceManagerError::SerialPtyOpen)?;
                     self.set_raw_mode(&mut sub)
                         .map_err(DeviceManagerError::SetPtyRaw)?;
                     self.config.lock().unwrap().serial.file = Some(path.clone());
@@ -1747,7 +1749,7 @@ impl DeviceManager {
                     Some(Box::new(writer))
                 } else {
                     let (main, mut sub, path) =
-                        create_pty().map_err(DeviceManagerError::ConsolePtyOpen)?;
+                        create_pty(false).map_err(DeviceManagerError::ConsolePtyOpen)?;
                     self.set_raw_mode(&mut sub)
                         .map_err(DeviceManagerError::SetPtyRaw)?;
                     self.config.lock().unwrap().console.file = Some(path.clone());

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -59,6 +59,7 @@ pub mod vm;
 
 #[cfg(feature = "acpi")]
 mod acpi;
+mod serial_buffer;
 
 type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 type GuestRegionMmap = vm_memory::GuestRegionMmap<AtomicBitmap>;

--- a/vmm/src/serial_buffer.rs
+++ b/vmm/src/serial_buffer.rs
@@ -1,0 +1,121 @@
+// Copyright © 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::io::Write;
+
+// Circular buffer implementation for serial output.
+// Read from head; push to tail
+pub(crate) struct SerialBuffer {
+    buffer: Vec<u8>,
+    head: usize,
+    tail: usize,
+    out: Box<dyn Write + Send>,
+}
+
+const MAX_BUFFER_SIZE: usize = 16 << 10;
+
+impl SerialBuffer {
+    pub(crate) fn new(out: Box<dyn Write + Send>) -> Self {
+        Self {
+            buffer: vec![],
+            head: 0,
+            tail: 0,
+            out,
+        }
+    }
+
+    pub(crate) fn flush_buffer(&mut self) -> Result<(), std::io::Error> {
+        if self.tail <= self.head {
+            // The buffer to be written is in two parts
+            let buf = &self.buffer[self.head..];
+            match self.out.write(buf) {
+                Ok(bytes_written) => {
+                    if bytes_written == buf.len() {
+                        self.head = 0;
+                        // Can now proceed to write the other part of the buffer
+                    } else {
+                        self.head += bytes_written;
+                        self.out.flush()?;
+                        return Ok(());
+                    }
+                }
+                Err(e) => {
+                    if !matches!(e.kind(), std::io::ErrorKind::WouldBlock) {
+                        return Err(e);
+                    }
+                    return Ok(());
+                }
+            }
+        }
+
+        let buf = &self.buffer[self.head..self.tail];
+        match self.out.write(buf) {
+            Ok(bytes_written) => {
+                if bytes_written == buf.len() {
+                    self.buffer.clear();
+                    self.buffer.shrink_to_fit();
+                    self.head = 0;
+                    self.tail = 0;
+                } else {
+                    self.head += bytes_written;
+                }
+                self.out.flush()?;
+            }
+            Err(e) => {
+                if !matches!(e.kind(), std::io::ErrorKind::WouldBlock) {
+                    return Err(e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+impl Write for SerialBuffer {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
+        // The serial output only writes one byte at a time
+        for v in buf {
+            if self.buffer.is_empty() {
+                // This case exists to avoid allocating the buffer if it's not needed
+                if let Err(e) = self.out.write(&[*v]) {
+                    if !matches!(e.kind(), std::io::ErrorKind::WouldBlock) {
+                        return Err(e);
+                    }
+                    self.buffer.push(*v);
+                    self.tail += 1;
+                } else {
+                    self.out.flush()?;
+                }
+            } else {
+                // Buffer is completely full, lose the oldest byte by moving head forward
+                if self.head == self.tail {
+                    self.head = self.tail + 1;
+                    if self.head == MAX_BUFFER_SIZE {
+                        self.head = 0;
+                    }
+                }
+
+                if self.buffer.len() < MAX_BUFFER_SIZE {
+                    self.buffer.push(*v);
+                } else {
+                    self.buffer[self.tail] = *v;
+                }
+
+                self.tail += 1;
+                if self.tail == MAX_BUFFER_SIZE {
+                    self.tail = 0;
+                }
+
+                self.flush_buffer()?;
+            }
+        }
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<(), std::io::Error> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
When booting with the serial port attached to a PTY then the boot will be blocked until the PTY is connected to. This PR introduces a buffer for that output.

However since the serial buffer is only flushed upon attempted writes by the guest it will not be flushed immediately upon the connection of the PTY to an output. This should be possible by utilising an epoll loop and checking for writable however that requires further refactoring. So in order to address the bug in #3004 the focus is on not blocking the boot so far.

Fixes: #3004