### PR TITLE
build: update Cargo for rust-vmm branch renames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "mshv-bindings"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/mshv?branch=master#e83d66e94f219ace46f33e78ff3b6eb3016dfab3"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#4e9a304b049d1e92d794e209987670d2277608a7"
 dependencies = [
  "libc",
  "serde",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "mshv-ioctls"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/mshv?branch=master#e83d66e94f219ace46f33e78ff3b6eb3016dfab3"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#4e9a304b049d1e92d794e209987670d2277608a7"
 dependencies = [
  "libc",
  "mshv-bindings",
@@ -1147,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio-ioctls?branch=master#bc30df33beb35d56b04658f7733bc9832c623fe1"
+source = "git+https://github.com/rust-vmm/vfio-ioctls?branch=main#bc30df33beb35d56b04658f7733bc9832c623fe1"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -1316,7 +1316,7 @@ dependencies = [
 [[package]]
 name = "vm-fdt"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vm-fdt?branch=master#031572a6edc2f566a7278f1e17088fc5308d27ab"
+source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#fbf4f7f054cb92690544dd44c83a9572519beed0"
 
 [[package]]
 name = "vm-memory"

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -27,4 +27,4 @@ vmm-sys-util = { version = "0.8.0", features = ["with-serde"] }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 fdt_parser = { version = "0.1.3", package = 'fdt'}
-vm-fdt = { git = "https://github.com/rust-vmm/vm-fdt", branch = "master" }
+vm-fdt = { git = "https://github.com/rust-vmm/vm-fdt", branch = "main" }

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -18,8 +18,8 @@ libc = "0.2.101"
 log = "0.4.14"
 kvm-ioctls = { version = "0.9.0", optional = true }
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.4.0", features = ["with-serde", "fam-wrappers"], optional  = true }
-mshv-bindings = {git = "https://github.com/rust-vmm/mshv", branch = "master", features = ["with-serde", "fam-wrappers"], optional  = true }
-mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "master", optional  = true}
+mshv-bindings = {git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
+mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional  = true}
 serde = { version = "1.0.130", features = ["rc"] }
 serde_derive = "1.0.130"
 serde_json = "1.0.67"

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 anyhow = "1.0.43"
 byteorder = "1.4.3"
 hypervisor = { path = "../hypervisor" }
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "master" }
+vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "main" }
 vfio_user = { path = "../vfio_user" }
 vmm-sys-util = "0.8.0"
 libc = "0.2.101"

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -14,7 +14,7 @@ thiserror = "1.0.28"
 serde = { version = "1.0.130", features = ["rc"] }
 serde_derive = "1.0.130"
 serde_json = "1.0.67"
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "master", default-features = false }
+vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "main", default-features = false }
 vm-memory = { version = "0.6.0", features = ["backend-mmap"] }
 vmm-sys-util = "0.8.0"
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -44,7 +44,7 @@ thiserror = "1.0.28"
 uuid = "0.8.2"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "master", default-features = false }
+vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "main", default-features = false }
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
 vm-allocator = { path = "../vm-allocator" }


### PR DESCRIPTION
The rust-vmm crates we're pulling from git have renamed their main branches.  We need to update the branch names we're giving to Cargo, or people who don't have these dependencies cached will get errors like this when trying to build:

    error: failed to get `vm-fdt` as a dependency of package `arch v0.1.0 (/home/src/cloud-hypervisor/arch)`

    Caused by:
      failed to load source for dependency `vm-fdt`

    Caused by:
      Unable to update https://github.com/rust-vmm/vm-fdt?branch=master#031572a6

    Caused by:
      object not found - no match for id (031572a6edc2f566a7278f1e17088fc5308d27ab); class=Odb (9); code=NotFound (-3)

Signed-off-by: Alyssa Ross <hi@alyssa.is>
