### PR TITLE
Enable power button for ACPI on AArch64

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -85,6 +85,7 @@ Delete the VM                      | `/vm.delete`         | N/A                 
 Boot the VM                        | `/vm.boot`           | N/A                       | N/A                      | The VM is created but not booted
 Shut the VM down                   | `/vm.shutdown`       | N/A                       | N/A                      | The VM is booted
 Reboot the VM                      | `/vm.reboot`         | N/A                       | N/A                      | The VM is booted
+Trigger power button of the VM     | `/vm.power-button`   | N/A                       | N/A                      | The VM is booted
 Pause the VM                       | `/vm.pause`          | N/A                       | N/A                      | The VM is booted
 Resume the VM                      | `/vm.resume`         | N/A                       | N/A                      | The VM is paused
 Add/remove CPUs to/from the VM     | `/vm.resize`         | `/schemas/VmResize`       | N/A                      | The VM is booted


### PR DESCRIPTION
Current AArch64 power button is only for device tree using a PL061 GPIO controller device. Since AArch64 now supports ACPI, this
commit extend the power button on AArch64 to:
- Using GED for ACPI+UEFI boot.
- Using PL061 for device tree boot.

Also an integration test case is added to cover.

A question for @sboeuf and @rbradford: I didn't see any documentation about the `power-button` API in the API doc here (https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/docs/api.md), shall I add another commit to do this, or the missing of `power-button` is expected?