### PR TITLE
virtio-devices: Use a common method for spawning virtio threads

### DIFF
--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -4,14 +4,14 @@
 
 use super::Error as DeviceError;
 use super::{
-    ActivateError, ActivateResult, DescriptorChain, EpollHelper, EpollHelperError,
-    EpollHelperHandler, Queue, VirtioCommon, VirtioDevice, VirtioDeviceType,
-    EPOLL_HELPER_EVENT_LAST, VIRTIO_F_VERSION_1,
+    ActivateResult, DescriptorChain, EpollHelper, EpollHelperError, EpollHelperHandler, Queue,
+    VirtioCommon, VirtioDevice, VirtioDeviceType, EPOLL_HELPER_EVENT_LAST, VIRTIO_F_VERSION_1,
 };
-use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::seccomp_filters::Thread;
+use crate::thread_helper::spawn_virtio_thread;
 use crate::GuestMemoryMmap;
 use crate::{DmaRemapping, VirtioInterrupt, VirtioInterruptType};
-use seccompiler::{apply_filter, SeccompAction};
+use seccompiler::SeccompAction;
 use std::collections::BTreeMap;
 use std::fmt::{self, Display};
 use std::io;
@@ -21,7 +21,6 @@ use std::os::unix::io::AsRawFd;
 use std::result;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier, RwLock};
-use std::thread;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use vm_device::dma_mapping::ExternalDmaMapping;
@@ -843,29 +842,17 @@ impl VirtioDevice for Iommu {
         let paused = self.common.paused.clone();
         let paused_sync = self.common.paused_sync.clone();
         let mut epoll_threads = Vec::new();
-        // Retrieve seccomp filter for virtio_iommu thread
-        let virtio_iommu_seccomp_filter =
-            get_seccomp_filter(&self.seccomp_action, Thread::VirtioIommu)
-                .map_err(ActivateError::CreateSeccompFilter)?;
-        thread::Builder::new()
-            .name(self.id.clone())
-            .spawn(move || {
-                if !virtio_iommu_seccomp_filter.is_empty() {
-                    if let Err(e) = apply_filter(&virtio_iommu_seccomp_filter) {
-                        error!("Error applying seccomp filter: {:?}", e);
-                        return;
-                    }
-                }
-
+        spawn_virtio_thread(
+            &self.id,
+            &self.seccomp_action,
+            Thread::VirtioIommu,
+            &mut epoll_threads,
+            move || {
                 if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
                     error!("Error running worker: {:?}", e);
                 }
-            })
-            .map(|thread| epoll_threads.push(thread))
-            .map_err(|e| {
-                error!("failed to clone the virtio-iommu epoll thread: {}", e);
-                ActivateError::BadActivate
-            })?;
+            },
+        )?;
 
         self.common.epoll_threads = Some(epoll_threads);
 

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -32,6 +32,7 @@ pub mod net;
 mod pmem;
 mod rng;
 pub mod seccomp_filters;
+mod thread_helper;
 pub mod transport;
 pub mod vhost_user;
 pub mod vsock;

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -18,12 +18,13 @@ use super::{
     EpollHelperHandler, Queue, VirtioCommon, VirtioDevice, VirtioDeviceType,
     EPOLL_HELPER_EVENT_LAST, VIRTIO_F_VERSION_1,
 };
-use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::seccomp_filters::Thread;
+use crate::thread_helper::spawn_virtio_thread;
 use crate::{GuestMemoryMmap, GuestRegionMmap};
 use crate::{VirtioInterrupt, VirtioInterruptType};
 use anyhow::anyhow;
 use libc::EFD_NONBLOCK;
-use seccompiler::{apply_filter, SeccompAction};
+use seccompiler::SeccompAction;
 use std::collections::BTreeMap;
 use std::io;
 use std::mem::size_of;
@@ -32,7 +33,6 @@ use std::result;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Barrier, Mutex};
-use std::thread;
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
@@ -955,27 +955,18 @@ impl VirtioDevice for Mem {
         let paused = self.common.paused.clone();
         let paused_sync = self.common.paused_sync.clone();
         let mut epoll_threads = Vec::new();
-        // Retrieve seccomp filter for virtio_mem thread
-        let virtio_mem_seccomp_filter = get_seccomp_filter(&self.seccomp_action, Thread::VirtioMem)
-            .map_err(ActivateError::CreateSeccompFilter)?;
-        thread::Builder::new()
-            .name(self.id.clone())
-            .spawn(move || {
-                if !virtio_mem_seccomp_filter.is_empty() {
-                    if let Err(e) = apply_filter(&virtio_mem_seccomp_filter) {
-                        error!("Error applying seccomp filter: {:?}", e);
-                        return;
-                    }
-                }
+
+        spawn_virtio_thread(
+            &self.id,
+            &self.seccomp_action,
+            Thread::VirtioMem,
+            &mut epoll_threads,
+            move || {
                 if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
                     error!("Error running worker: {:?}", e);
                 }
-            })
-            .map(|thread| epoll_threads.push(thread))
-            .map_err(|e| {
-                error!("failed to clone virtio-mem epoll thread: {}", e);
-                ActivateError::BadActivate
-            })?;
+            },
+        )?;
         self.common.epoll_threads = Some(epoll_threads);
 
         event!("virtio-device", "activated", "id", &self.id);

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -12,10 +12,11 @@ use super::{
     EpollHelperHandler, Queue, UserspaceMapping, VirtioCommon, VirtioDevice, VirtioDeviceType,
     EPOLL_HELPER_EVENT_LAST, VIRTIO_F_IOMMU_PLATFORM, VIRTIO_F_VERSION_1,
 };
-use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::seccomp_filters::Thread;
+use crate::thread_helper::spawn_virtio_thread;
 use crate::{GuestMemoryMmap, MmapRegion};
 use crate::{VirtioInterrupt, VirtioInterruptType};
-use seccompiler::{apply_filter, SeccompAction};
+use seccompiler::SeccompAction;
 use std::fmt::{self, Display};
 use std::fs::File;
 use std::io;
@@ -24,7 +25,6 @@ use std::os::unix::io::AsRawFd;
 use std::result;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier};
-use std::thread;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use vm_memory::{
@@ -390,28 +390,18 @@ impl VirtioDevice for Pmem {
             let paused = self.common.paused.clone();
             let paused_sync = self.common.paused_sync.clone();
             let mut epoll_threads = Vec::new();
-            // Retrieve seccomp filter for virtio_pmem thread
-            let virtio_pmem_seccomp_filter =
-                get_seccomp_filter(&self.seccomp_action, Thread::VirtioPmem)
-                    .map_err(ActivateError::CreateSeccompFilter)?;
-            thread::Builder::new()
-                .name(self.id.clone())
-                .spawn(move || {
-                    if !virtio_pmem_seccomp_filter.is_empty() {
-                        if let Err(e) = apply_filter(&virtio_pmem_seccomp_filter) {
-                            error!("Error applying seccomp filter: {:?}", e);
-                            return;
-                        }
-                    }
+
+            spawn_virtio_thread(
+                &self.id,
+                &self.seccomp_action,
+                Thread::VirtioPmem,
+                &mut epoll_threads,
+                move || {
                     if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
                         error!("Error running worker: {:?}", e);
                     }
-                })
-                .map(|thread| epoll_threads.push(thread))
-                .map_err(|e| {
-                    error!("failed to clone virtio-pmem epoll thread: {}", e);
-                    ActivateError::BadActivate
-                })?;
+                },
+            )?;
 
             self.common.epoll_threads = Some(epoll_threads);
 

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -20,7 +20,9 @@ pub enum Thread {
     VirtioNetCtl,
     VirtioPmem,
     VirtioRng,
+    VirtioVhostBlock,
     VirtioVhostFs,
+    VirtioVhostNet,
     VirtioVhostNetCtl,
     VirtioVsock,
     VirtioWatchdog,
@@ -372,6 +374,65 @@ fn virtio_vhost_net_ctl_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     ]
 }
 
+fn virtio_vhost_net_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
+    vec![
+        (libc::SYS_accept4, vec![]),
+        (libc::SYS_bind, vec![]),
+        (libc::SYS_brk, vec![]),
+        #[cfg(feature = "mshv")]
+        (libc::SYS_clock_gettime, vec![]),
+        (libc::SYS_close, vec![]),
+        (libc::SYS_dup, vec![]),
+        (libc::SYS_epoll_create1, vec![]),
+        (libc::SYS_epoll_ctl, vec![]),
+        (libc::SYS_epoll_pwait, vec![]),
+        #[cfg(target_arch = "x86_64")]
+        (libc::SYS_epoll_wait, vec![]),
+        (libc::SYS_exit, vec![]),
+        (libc::SYS_futex, vec![]),
+        (libc::SYS_getcwd, vec![]),
+        (libc::SYS_listen, vec![]),
+        (libc::SYS_munmap, vec![]),
+        (libc::SYS_madvise, vec![]),
+        (libc::SYS_read, vec![]),
+        (libc::SYS_recvmsg, vec![]),
+        (libc::SYS_rt_sigprocmask, vec![]),
+        (libc::SYS_rt_sigreturn, vec![]),
+        (libc::SYS_sendmsg, vec![]),
+        (libc::SYS_sendto, vec![]),
+        (libc::SYS_sigaltstack, vec![]),
+        (libc::SYS_socket, vec![]),
+        #[cfg(target_arch = "x86_64")]
+        (libc::SYS_unlink, vec![]),
+        #[cfg(target_arch = "aarch64")]
+        (libc::SYS_unlinkat, vec![]),
+        (libc::SYS_write, vec![]),
+    ]
+}
+
+fn virtio_vhost_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
+    vec![
+        (libc::SYS_brk, vec![]),
+        #[cfg(feature = "mshv")]
+        (libc::SYS_clock_gettime, vec![]),
+        (libc::SYS_close, vec![]),
+        (libc::SYS_dup, vec![]),
+        (libc::SYS_epoll_create1, vec![]),
+        (libc::SYS_epoll_ctl, vec![]),
+        (libc::SYS_epoll_pwait, vec![]),
+        #[cfg(target_arch = "x86_64")]
+        (libc::SYS_epoll_wait, vec![]),
+        (libc::SYS_exit, vec![]),
+        (libc::SYS_futex, vec![]),
+        (libc::SYS_munmap, vec![]),
+        (libc::SYS_madvise, vec![]),
+        (libc::SYS_read, vec![]),
+        (libc::SYS_rt_sigprocmask, vec![]),
+        (libc::SYS_sigaltstack, vec![]),
+        (libc::SYS_write, vec![]),
+    ]
+}
+
 fn create_vsock_ioctl_seccomp_rule() -> Vec<SeccompRule> {
     or![and![Cond::new(1, ArgLen::Dword, Eq, FIONBIO,).unwrap()],]
 }
@@ -445,7 +506,9 @@ fn get_seccomp_rules(thread_type: Thread) -> Vec<(i64, Vec<SeccompRule>)> {
         Thread::VirtioNetCtl => virtio_net_ctl_thread_rules(),
         Thread::VirtioPmem => virtio_pmem_thread_rules(),
         Thread::VirtioRng => virtio_rng_thread_rules(),
+        Thread::VirtioVhostBlock => virtio_vhost_block_thread_rules(),
         Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules(),
+        Thread::VirtioVhostNet => virtio_vhost_net_thread_rules(),
         Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules(),
         Thread::VirtioVsock => virtio_vsock_thread_rules(),
         Thread::VirtioWatchdog => virtio_watchdog_thread_rules(),

--- a/virtio-devices/src/thread_helper.rs
+++ b/virtio-devices/src/thread_helper.rs
@@ -1,0 +1,43 @@
+// Copyright © 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::{
+    seccomp_filters::{get_seccomp_filter, Thread},
+    ActivateError,
+};
+use seccompiler::{apply_filter, SeccompAction};
+use std::thread::{self, JoinHandle};
+
+pub(crate) fn spawn_virtio_thread<F>(
+    name: &str,
+    seccomp_action: &SeccompAction,
+    thread_type: Thread,
+    epoll_threads: &mut Vec<JoinHandle<()>>,
+    f: F,
+) -> Result<(), ActivateError>
+where
+    F: FnOnce(),
+    F: Send + 'static,
+{
+    let seccomp_filter = get_seccomp_filter(seccomp_action, thread_type)
+        .map_err(ActivateError::CreateSeccompFilter)?;
+
+    thread::Builder::new()
+        .name(name.to_string())
+        .spawn(move || {
+            if !seccomp_filter.is_empty() {
+                if let Err(e) = apply_filter(&seccomp_filter) {
+                    error!("Error applying seccomp filter: {:?}", e);
+                    return;
+                }
+            }
+            f()
+        })
+        .map(|thread| epoll_threads.push(thread))
+        .map_err(|e| {
+            error!("Failed to spawn thread for {}: {}", name, e);
+            ActivateError::BadActivate
+        })
+}

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -10,18 +10,18 @@ use super::{
     ActivateError, ActivateResult, EpollHelper, EpollHelperError, EpollHelperHandler, Queue,
     VirtioCommon, VirtioDevice, VirtioDeviceType, EPOLL_HELPER_EVENT_LAST, VIRTIO_F_VERSION_1,
 };
-use crate::seccomp_filters::{get_seccomp_filter, Thread};
+use crate::seccomp_filters::Thread;
+use crate::thread_helper::spawn_virtio_thread;
 use crate::GuestMemoryMmap;
 use crate::{VirtioInterrupt, VirtioInterruptType};
 use anyhow::anyhow;
-use seccompiler::{apply_filter, SeccompAction};
+use seccompiler::SeccompAction;
 use std::fs::File;
 use std::io::{self, Read};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::result;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier, Mutex};
-use std::thread;
 use std::time::Instant;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
@@ -318,29 +318,18 @@ impl VirtioDevice for Watchdog {
         let paused = self.common.paused.clone();
         let paused_sync = self.common.paused_sync.clone();
         let mut epoll_threads = Vec::new();
-        // Retrieve seccomp filter for virtio_watchdog thread
-        let virtio_watchdog_seccomp_filter =
-            get_seccomp_filter(&self.seccomp_action, Thread::VirtioWatchdog)
-                .map_err(ActivateError::CreateSeccompFilter)?;
-        thread::Builder::new()
-            .name(self.id.clone())
-            .spawn(move || {
-                if !virtio_watchdog_seccomp_filter.is_empty() {
-                    if let Err(e) = apply_filter(&virtio_watchdog_seccomp_filter) {
-                        error!("Error applying seccomp filter: {:?}", e);
-                        return;
-                    }
-                }
 
+        spawn_virtio_thread(
+            &self.id,
+            &self.seccomp_action,
+            Thread::VirtioWatchdog,
+            &mut epoll_threads,
+            move || {
                 if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
                     error!("Error running worker: {:?}", e);
                 }
-            })
-            .map(|thread| epoll_threads.push(thread))
-            .map_err(|e| {
-                error!("failed to clone the virtio-watchdog epoll thread: {}", e);
-                ActivateError::BadActivate
-            })?;
+            },
+        )?;
 
         self.common.epoll_threads = Some(epoll_threads);
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1867,7 +1867,12 @@ impl DeviceManager {
                 queue_size: disk_cfg.queue_size,
             };
             let vhost_user_block_device = Arc::new(Mutex::new(
-                match virtio_devices::vhost_user::Blk::new(id.clone(), vu_cfg, self.restoring) {
+                match virtio_devices::vhost_user::Blk::new(
+                    id.clone(),
+                    vu_cfg,
+                    self.restoring,
+                    self.seccomp_action.clone(),
+                ) {
                     Ok(vub_device) => vub_device,
                     Err(e) => {
                         return Err(DeviceManagerError::CreateVhostUserBlk(e));


### PR DESCRIPTION
Introduce a common solution for spawning the virtio threads which will
make it easier to add the panic handling.

During this effort I discovered that there were no seccomp filters
registered for the vhost-user-net thread nor the vhost-user-block
thread. This change also incorporates basic seccomp filters for those as
part of the refactoring.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>