### PR TITLE
vmm: add argument --dirty-log

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -91,6 +91,8 @@ The user is responsible for ensuring there are sufficient huge pages of the spec
 Failure to do so may result in strange VMM behaviour, e.g. error with `ReadKernelImage` is common.
 If there is a strange error with `hugepages` enabled, just disable it or check whether there are enough huge pages.
 
+Note that with `dirty-log` enabled, VMM still costs huge pages but KVM will never use them as huge pages.
+
 By default this option is turned off.
 
 _Example_

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,7 @@ fn create_app<'a, 'b>(
                 .long("kernel")
                 .help(
                     "Path to loaded kernel. This may be a kernel or firmware that supports a PVH \
-                entry point (e.g. vmlinux) or architecture equivalent",
+                    entry point (e.g. vmlinux) or architecture equivalent",
                 )
                 .takes_value(true)
                 .group("vm-config"),
@@ -356,6 +356,17 @@ fn create_app<'a, 'b>(
                 .takes_value(true)
                 .possible_values(&["true", "false", "log"])
                 .default_value("true"),
+        )
+        .arg(
+            Arg::with_name("dirty-log")
+                .long("dirty-log")
+                .help(
+                    "Enable dirty log. \
+                    With dirty log enabled, VM can migration but cannot use huge pages"
+                )
+                .takes_value(true)
+                .possible_values(&["on", "off"])
+                .default_value("on"),
         );
 
     #[cfg(target_arch = "x86_64")]
@@ -681,6 +692,7 @@ mod unit_tests {
                 watchdog: false,
                 #[cfg(feature = "tdx")]
                 tdx: None,
+                dirty_log: true,
             };
 
             aver_eq!(tb, expected_vm_config, result_vm_config);

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -478,6 +478,9 @@ components:
         watchdog:
           type: boolean
           default: false
+        dirty_log:
+          type: boolean
+          default: true
       description: Virtual machine configuration
 
     CpuTopology:

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1807,8 +1807,8 @@ impl DeviceManager {
 
         Ok(Arc::new(Console {
             serial,
-            input,
             console_resizer,
+            input,
         }))
     }
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -510,6 +510,7 @@ impl MemoryManager {
         prefault: bool,
         phys_bits: u8,
         #[cfg(feature = "tdx")] tdx_enabled: bool,
+        dirty_log: bool,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
         let user_provided_zones = config.size == 0;
         let mut allow_mem_hotplug: bool = false;
@@ -749,7 +750,7 @@ impl MemoryManager {
             .ok_or(Error::AllocateMmioAddress)?;
 
         #[cfg(not(feature = "tdx"))]
-        let log_dirty = true;
+        let log_dirty = dirty_log;
         #[cfg(feature = "tdx")]
         let log_dirty = !tdx_enabled; // Cannot log dirty pages on a TD
 
@@ -851,6 +852,7 @@ impl MemoryManager {
             phys_bits,
             #[cfg(feature = "tdx")]
             false,
+            true,
         )?;
 
         if let Some(source_url) = source_url {


### PR DESCRIPTION
Current memory_manager will always enable `KVM_MEM_LOG_DIRTY_PAGES` flag, this flag will prevent KVM from using huge pages.

But without this flag, VMM will never migration.

For above reasons, this flag should be an optional parameter for users to choose.

ref:
- [linux/arch/x86/kvm/mmu/mmu.c,L875](https://github.com/torvalds/linux/blob/4b93c544e90e2b28326182d31ee008eb80e02074/arch/x86/kvm/mmu/mmu.c#L875)
- [linux/arch/x86/kvm/mmu/mmu.c,L2886](https://github.com/torvalds/linux/blob/4b93c544e90e2b28326182d31ee008eb80e02074/arch/x86/kvm/mmu/mmu.c#L2886)

```c
static struct kvm_memory_slot *
gfn_to_memslot_dirty_bitmap(struct kvm_vcpu *vcpu, gfn_t gfn,
			    bool no_dirty_log)
{
	struct kvm_memory_slot *slot;

	slot = kvm_vcpu_gfn_to_memslot(vcpu, gfn);
	if (!slot || slot->flags & KVM_MEMSLOT_INVALID)
		return NULL;
	if (no_dirty_log && kvm_slot_dirty_track_enabled(slot))                     // NOTICE HERE
		return NULL;

	return slot;
}

int kvm_mmu_hugepage_adjust(struct kvm_vcpu *vcpu, gfn_t gfn,
			    int max_level, kvm_pfn_t *pfnp,
			    bool huge_page_disallowed, int *req_level)
{
	struct kvm_memory_slot *slot;
	kvm_pfn_t pfn = *pfnp;
	kvm_pfn_t mask;
	int level;

	*req_level = PG_LEVEL_4K;

	if (unlikely(max_level == PG_LEVEL_4K))
		return PG_LEVEL_4K;

	if (is_error_noslot_pfn(pfn) || kvm_is_reserved_pfn(pfn))
		return PG_LEVEL_4K;

	slot = gfn_to_memslot_dirty_bitmap(vcpu, gfn, true);                        // NOTICE HERE
	if (!slot)
		return PG_LEVEL_4K;

	level = kvm_mmu_max_mapping_level(vcpu->kvm, slot, gfn, pfn, max_level);
	if (level == PG_LEVEL_4K)
		return level;

	*req_level = level = min(level, max_level);

	/*
	 * Enforce the iTLB multihit workaround after capturing the requested
	 * level, which will be used to do precise, accurate accounting.
	 */
	if (huge_page_disallowed)
		return PG_LEVEL_4K;

	/*
	 * mmu_notifier_retry() was successful and mmu_lock is held, so
	 * the pmd can't be split from under us.
	 */
	mask = KVM_PAGES_PER_HPAGE(level) - 1;
	VM_BUG_ON((gfn & mask) != (pfn & mask));
	*pfnp = pfn & ~mask;

	return level;
}
```