### PR TITLE
Enable some more test cases (pmem, user defined memory regions) on Arm

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2277,7 +2277,6 @@ mod tests {
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_user_defined_memory_regions() {
             let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
             let guest = Guest::new(Box::new(focal));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2853,19 +2853,16 @@ mod tests {
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_virtio_pmem_persist_writes() {
             test_virtio_pmem(false, false)
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_virtio_pmem_discard_writes() {
             test_virtio_pmem(true, false)
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
         fn test_virtio_pmem_with_size() {
             test_virtio_pmem(true, true)
         }


### PR DESCRIPTION
We current support virtio-mem on Arm and therefore user defined memory regions test can be enabled.

Also some virtio-pmem test cases can be enabled.