### PR TITLE
Add integration test for live migration with ovs-dpdk

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,6 +228,7 @@ pipeline{
 								timeout(time: 1, unit: 'HOURS')
 							}
 							steps {
+								sh "sudo modprobe openvswitch"
 								sh "scripts/dev_cli.sh tests --integration-live-migration"
 							}
 						}
@@ -236,6 +237,7 @@ pipeline{
 								timeout(time: 1, unit: 'HOURS')
 							}
 							steps {
+								sh "sudo modprobe openvswitch"
 								sh "scripts/dev_cli.sh tests --integration-live-migration --libc musl"
 							}
 						}

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -292,12 +292,8 @@ sudo bash -c "echo 1000000 > /sys/kernel/mm/ksm/pages_to_scan"
 sudo bash -c "echo 10 > /sys/kernel/mm/ksm/sleep_millisecs"
 sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 
-# Setup ovs-dpdk
+# Setup huge-pages for ovs-dpdk
 echo 2048 | sudo tee /proc/sys/vm/nr_hugepages
-service openvswitch-switch start
-ovs-vsctl init
-ovs-vsctl set Open_vSwitch . other_config:dpdk-init=true
-service openvswitch-switch restart
 
 # Run all direct kernel boot (Device Tree) test cases in mod `parallel`
 time cargo test $features_test "tests::parallel::$test_filter"

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -83,12 +83,6 @@ strip target/$BUILD_TARGET/release/ch-remote
 echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
-# Setup ovs-dpdk
-service openvswitch-switch start
-ovs-vsctl init
-ovs-vsctl set Open_vSwitch . other_config:dpdk-init=true
-service openvswitch-switch restart
-
 export RUST_BACKTRACE=1
 time cargo test $features_test "tests::live_migration::$test_filter" -- --test-threads=1
 RES=$?

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -79,8 +79,17 @@ strip target/$BUILD_TARGET/release/cloud-hypervisor
 strip target/$BUILD_TARGET/release/vhost_user_net
 strip target/$BUILD_TARGET/release/ch-remote
 
-export RUST_BACKTRACE=1
+# Test ovs-dpdk relies on hugepages
+echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
+sudo chmod a+rwX /dev/hugepages
 
+# Setup ovs-dpdk
+service openvswitch-switch start
+ovs-vsctl init
+ovs-vsctl set Open_vSwitch . other_config:dpdk-init=true
+service openvswitch-switch restart
+
+export RUST_BACKTRACE=1
 time cargo test $features_test "tests::live_migration::$test_filter" -- --test-threads=1
 RES=$?
 

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -202,12 +202,6 @@ sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
-# Setup ovs-dpdk
-service openvswitch-switch start
-ovs-vsctl init
-ovs-vsctl set Open_vSwitch . other_config:dpdk-init=true
-service openvswitch-switch restart
-
 export RUST_BACKTRACE=1
 time cargo test $features_test "tests::parallel::$test_filter"
 RES=$?


### PR DESCRIPTION
This patch adds the integration test for live migration with ovs-dpdk. 
It also adds a separate function to launch two guest VMs and ensure
they are connected through ovs-dpdk, so that we can reuse this function
in multiple tests.

Signed-off-by: Bo Chen <chen.bo@intel.com>
