### PR TITLE
virtio-devices: seccomp: Split out common seccomp rules

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -72,171 +72,62 @@ fn create_virtio_mem_ioctl_seccomp_rule() -> Vec<SeccompRule> {
 }
 
 fn virtio_balloon_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
-    vec![
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
-        (libc::SYS_futex, vec![]),
-        (libc::SYS_fallocate, vec![]),
-        (libc::SYS_madvise, vec![]),
-        (libc::SYS_munmap, vec![]),
-        (libc::SYS_read, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
-        (libc::SYS_write, vec![]),
-    ]
+    vec![(libc::SYS_fallocate, vec![])]
 }
 
 fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
         (libc::SYS_fallocate, vec![]),
         (libc::SYS_fdatasync, vec![]),
         (libc::SYS_fsync, vec![]),
         (libc::SYS_ftruncate, vec![]),
-        (libc::SYS_futex, vec![]),
         (libc::SYS_getrandom, vec![]),
         (libc::SYS_io_uring_enter, vec![]),
         (libc::SYS_lseek, vec![]),
-        (libc::SYS_madvise, vec![]),
         (libc::SYS_mmap, vec![]),
         (libc::SYS_mprotect, vec![]),
-        (libc::SYS_munmap, vec![]),
         (libc::SYS_openat, vec![]),
         (libc::SYS_prctl, vec![]),
         (libc::SYS_pread64, vec![]),
         (libc::SYS_preadv, vec![]),
         (libc::SYS_pwritev, vec![]),
         (libc::SYS_pwrite64, vec![]),
-        (libc::SYS_read, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_sched_getaffinity, vec![]),
         (libc::SYS_set_robust_list, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_timerfd_settime, vec![]),
-        (libc::SYS_write, vec![]),
     ]
 }
 
 fn virtio_console_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
-        (libc::SYS_futex, vec![]),
-        (libc::SYS_madvise, vec![]),
         (libc::SYS_mmap, vec![]),
         (libc::SYS_mprotect, vec![]),
-        (libc::SYS_munmap, vec![]),
         (libc::SYS_prctl, vec![]),
-        (libc::SYS_read, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_sched_getaffinity, vec![]),
         (libc::SYS_set_robust_list, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
-        (libc::SYS_write, vec![]),
     ]
 }
 
 fn virtio_iommu_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
-        (libc::SYS_futex, vec![]),
         (libc::SYS_ioctl, create_virtio_iommu_ioctl_seccomp_rule()),
-        (libc::SYS_madvise, vec![]),
         (libc::SYS_mmap, vec![]),
         (libc::SYS_mprotect, vec![]),
-        (libc::SYS_munmap, vec![]),
-        (libc::SYS_read, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
-        (libc::SYS_write, vec![]),
     ]
 }
 
 fn virtio_mem_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
         (libc::SYS_fallocate, vec![]),
-        (libc::SYS_futex, vec![]),
         (libc::SYS_ioctl, create_virtio_mem_ioctl_seccomp_rule()),
-        (libc::SYS_madvise, vec![]),
-        (libc::SYS_munmap, vec![]),
-        (libc::SYS_read, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
-        (libc::SYS_write, vec![]),
     ]
 }
 
 fn virtio_net_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
-        (libc::SYS_futex, vec![]),
-        (libc::SYS_madvise, vec![]),
-        (libc::SYS_munmap, vec![]),
         (libc::SYS_openat, vec![]),
-        (libc::SYS_read, vec![]),
         (libc::SYS_readv, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_timerfd_settime, vec![]),
-        (libc::SYS_write, vec![]),
         (libc::SYS_writev, vec![]),
     ]
 }
@@ -246,191 +137,59 @@ fn create_virtio_net_ctl_ioctl_seccomp_rule() -> Vec<SeccompRule> {
 }
 
 fn virtio_net_ctl_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
-    vec![
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
-        (libc::SYS_futex, vec![]),
-        (libc::SYS_ioctl, create_virtio_net_ctl_ioctl_seccomp_rule()),
-        (libc::SYS_madvise, vec![]),
-        (libc::SYS_munmap, vec![]),
-        (libc::SYS_read, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
-        (libc::SYS_write, vec![]),
-    ]
+    vec![(libc::SYS_ioctl, create_virtio_net_ctl_ioctl_seccomp_rule())]
 }
 
 fn virtio_pmem_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
-    vec![
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
-        (libc::SYS_fsync, vec![]),
-        (libc::SYS_futex, vec![]),
-        (libc::SYS_madvise, vec![]),
-        (libc::SYS_munmap, vec![]),
-        (libc::SYS_read, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
-        (libc::SYS_write, vec![]),
-    ]
+    vec![(libc::SYS_fsync, vec![])]
 }
 
 fn virtio_rng_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
-        (libc::SYS_futex, vec![]),
-        (libc::SYS_madvise, vec![]),
         (libc::SYS_mmap, vec![]),
         (libc::SYS_mprotect, vec![]),
-        (libc::SYS_munmap, vec![]),
         (libc::SYS_prctl, vec![]),
-        (libc::SYS_read, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_sched_getaffinity, vec![]),
         (libc::SYS_set_robust_list, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
-        (libc::SYS_write, vec![]),
     ]
 }
 
 fn virtio_vhost_fs_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
         (libc::SYS_connect, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
-        (libc::SYS_futex, vec![]),
-        (libc::SYS_madvise, vec![]),
         (libc::SYS_mmap, vec![]),
-        (libc::SYS_munmap, vec![]),
         (libc::SYS_nanosleep, vec![]),
-        (libc::SYS_read, vec![]),
         (libc::SYS_recvmsg, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_sendmsg, vec![]),
         (libc::SYS_sendto, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_socket, vec![]),
-        (libc::SYS_write, vec![]),
     ]
 }
 
 fn virtio_vhost_net_ctl_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
-    vec![
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
-        (libc::SYS_futex, vec![]),
-        (libc::SYS_munmap, vec![]),
-        (libc::SYS_madvise, vec![]),
-        (libc::SYS_read, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
-        (libc::SYS_write, vec![]),
-    ]
+    vec![]
 }
 
 fn virtio_vhost_net_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
         (libc::SYS_accept4, vec![]),
         (libc::SYS_bind, vec![]),
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
-        (libc::SYS_futex, vec![]),
         (libc::SYS_getcwd, vec![]),
         (libc::SYS_listen, vec![]),
-        (libc::SYS_munmap, vec![]),
-        (libc::SYS_madvise, vec![]),
-        (libc::SYS_read, vec![]),
         (libc::SYS_recvmsg, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_rt_sigreturn, vec![]),
         (libc::SYS_sendmsg, vec![]),
         (libc::SYS_sendto, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_socket, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_unlink, vec![]),
         #[cfg(target_arch = "aarch64")]
         (libc::SYS_unlinkat, vec![]),
-        (libc::SYS_write, vec![]),
     ]
 }
 
 fn virtio_vhost_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
-    vec![
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
-        (libc::SYS_futex, vec![]),
-        (libc::SYS_munmap, vec![]),
-        (libc::SYS_madvise, vec![]),
-        (libc::SYS_read, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
-        (libc::SYS_write, vec![]),
-    ]
+    vec![]
 }
 
 fn create_vsock_ioctl_seccomp_rule() -> Vec<SeccompRule> {
@@ -440,63 +199,27 @@ fn create_vsock_ioctl_seccomp_rule() -> Vec<SeccompRule> {
 fn virtio_vsock_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
         (libc::SYS_accept4, vec![]),
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
         (libc::SYS_connect, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
         (libc::SYS_ioctl, create_vsock_ioctl_seccomp_rule()),
-        (libc::SYS_futex, vec![]),
-        (libc::SYS_madvise, vec![]),
         (libc::SYS_mmap, vec![]),
-        (libc::SYS_munmap, vec![]),
-        (libc::SYS_read, vec![]),
         (libc::SYS_recvfrom, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_socket, vec![]),
-        (libc::SYS_write, vec![]),
     ]
 }
 
 fn virtio_watchdog_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
-        (libc::SYS_brk, vec![]),
-        #[cfg(feature = "mshv")]
-        (libc::SYS_clock_gettime, vec![]),
-        (libc::SYS_close, vec![]),
-        (libc::SYS_dup, vec![]),
-        (libc::SYS_epoll_create1, vec![]),
-        (libc::SYS_epoll_ctl, vec![]),
-        (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_epoll_wait, vec![]),
-        (libc::SYS_exit, vec![]),
-        (libc::SYS_futex, vec![]),
-        (libc::SYS_madvise, vec![]),
         (libc::SYS_mmap, vec![]),
         (libc::SYS_mprotect, vec![]),
-        (libc::SYS_munmap, vec![]),
         (libc::SYS_prctl, vec![]),
-        (libc::SYS_read, vec![]),
-        (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_sched_getaffinity, vec![]),
         (libc::SYS_set_robust_list, vec![]),
-        (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_timerfd_settime, vec![]),
-        (libc::SYS_write, vec![]),
     ]
 }
 
 fn get_seccomp_rules(thread_type: Thread) -> Vec<(i64, Vec<SeccompRule>)> {
-    match thread_type {
+    let mut rules = match thread_type {
         Thread::VirtioBalloon => virtio_balloon_thread_rules(),
         Thread::VirtioBlock => virtio_block_thread_rules(),
         Thread::VirtioConsole => virtio_console_thread_rules(),
@@ -512,7 +235,32 @@ fn get_seccomp_rules(thread_type: Thread) -> Vec<(i64, Vec<SeccompRule>)> {
         Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules(),
         Thread::VirtioVsock => virtio_vsock_thread_rules(),
         Thread::VirtioWatchdog => virtio_watchdog_thread_rules(),
-    }
+    };
+    rules.append(&mut virtio_thread_common());
+    rules
+}
+
+fn virtio_thread_common() -> Vec<(i64, Vec<SeccompRule>)> {
+    vec![
+        (libc::SYS_brk, vec![]),
+        #[cfg(feature = "mshv")]
+        (libc::SYS_clock_gettime, vec![]),
+        (libc::SYS_close, vec![]),
+        (libc::SYS_dup, vec![]),
+        (libc::SYS_epoll_create1, vec![]),
+        (libc::SYS_epoll_ctl, vec![]),
+        (libc::SYS_epoll_pwait, vec![]),
+        #[cfg(target_arch = "x86_64")]
+        (libc::SYS_epoll_wait, vec![]),
+        (libc::SYS_exit, vec![]),
+        (libc::SYS_futex, vec![]),
+        (libc::SYS_madvise, vec![]),
+        (libc::SYS_munmap, vec![]),
+        (libc::SYS_read, vec![]),
+        (libc::SYS_rt_sigprocmask, vec![]),
+        (libc::SYS_sigaltstack, vec![]),
+        (libc::SYS_write, vec![]),
+    ]
 }
 
 /// Generate a BPF program based on the seccomp_action value


### PR DESCRIPTION
As well as reducing the amount of code this also improves the binary
size slightly:

cargo bloat --release -n 2000 --bin cloud-hypervisor | grep virtio_devices::seccomp_filters::get_seccomp_rules

Before:
 0.1%   0.2%   7.8KiB       virtio_devices virtio_devices::seccomp_filters::get_seccomp_rules
After:
 0.0%   0.1%   3.0KiB       virtio_devices virtio_devices::seccomp_filters::get_seccomp_rules

Signed-off-by: Rob Bradford <robert.bradford@intel.com>