### PR TITLE
Fix resizing virtio-console pty

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -48,6 +48,7 @@ macro_rules! or {
 }
 
 // See include/uapi/asm-generic/ioctls.h in the kernel code.
+const TIOCGWINSZ: u64 = 0x5413;
 const FIONBIO: u64 = 0x5421;
 
 // See include/uapi/linux/vfio.h in the kernel code.
@@ -56,6 +57,10 @@ const VFIO_IOMMU_UNMAP_DMA: u64 = 0x3b72;
 
 // See include/uapi/linux/if_tun.h in the kernel code.
 const TUNSETOFFLOAD: u64 = 0x4004_54d0;
+
+fn create_virtio_console_ioctl_seccomp_rule() -> Vec<SeccompRule> {
+    or![and![Cond::new(1, ArgLen::Dword, Eq, TIOCGWINSZ).unwrap()]]
+}
 
 fn create_virtio_iommu_ioctl_seccomp_rule() -> Vec<SeccompRule> {
     or![
@@ -99,6 +104,7 @@ fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
 
 fn virtio_console_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
+        (libc::SYS_ioctl, create_virtio_console_ioctl_seccomp_rule()),
         (libc::SYS_mprotect, vec![]),
         (libc::SYS_prctl, vec![]),
         (libc::SYS_sched_getaffinity, vec![]),

--- a/vmm/src/clone3.rs
+++ b/vmm/src/clone3.rs
@@ -1,0 +1,27 @@
+// Copyright 2021 Alyssa Ross <hi@alyssa.is>
+// SPDX-License-Identifier: Apache-2.0
+
+use libc::{c_long, size_t, syscall, SYS_clone3};
+
+pub const CLONE_CLEAR_SIGHAND: u64 = 0x100000000;
+
+#[repr(C)]
+#[derive(Default)]
+#[allow(non_camel_case_types)]
+pub struct clone_args {
+    pub flags: u64,
+    pub pidfd: u64,
+    pub child_tid: u64,
+    pub parent_tid: u64,
+    pub exit_signal: u64,
+    pub stack: u64,
+    pub stack_size: u64,
+    pub tls: u64,
+    pub set_tid: u64,
+    pub set_tid_size: u64,
+    pub cgroup: u64,
+}
+
+pub unsafe fn clone3(args: &mut clone_args, size: size_t) -> c_long {
+    syscall(SYS_clone3, args, size)
+}

--- a/vmm/src/sigwinch_listener.rs
+++ b/vmm/src/sigwinch_listener.rs
@@ -1,0 +1,135 @@
+// Copyright 2021 Alyssa Ross <hi@alyssa.is>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::clone3::{clone3, clone_args, CLONE_CLEAR_SIGHAND};
+use libc::{
+    c_int, c_void, close, getpgrp, ioctl, pipe2, poll, pollfd, setsid, sigemptyset, siginfo_t,
+    sigprocmask, tcsetpgrp, O_CLOEXEC, POLLERR, SIGWINCH, SIG_SETMASK, STDIN_FILENO, STDOUT_FILENO,
+    TIOCSCTTY,
+};
+use seccompiler::{apply_filter, BpfProgram};
+use std::cell::RefCell;
+use std::fs::File;
+use std::io::{self, ErrorKind, Read, Write};
+use std::mem::size_of;
+use std::mem::MaybeUninit;
+use std::os::unix::prelude::*;
+use std::process::exit;
+use std::ptr::null_mut;
+use vmm_sys_util::signal::register_signal_handler;
+
+thread_local! {
+    // The tty file descriptor is stored in a global variable so it
+    // can be accessed by a signal handler.
+    static TX: RefCell<Option<File>> = RefCell::new(None);
+}
+
+fn with_tx<R, F: FnOnce(&File) -> R>(f: F) -> R {
+    TX.with(|tx| f(tx.borrow().as_ref().unwrap()))
+}
+
+// This function has to be safe to call from a signal handler, and
+// therefore must not panic.
+fn notify() {
+    if let Err(e) = with_tx(|mut tx| tx.write_all(b"\n")) {
+        if e.kind() == ErrorKind::BrokenPipe {
+            exit(0);
+        }
+        exit(1);
+    }
+}
+
+extern "C" fn sigwinch_handler(_signo: c_int, _info: *mut siginfo_t, _unused: *mut c_void) {
+    notify();
+}
+
+fn unblock_all_signals() -> io::Result<()> {
+    let mut set = MaybeUninit::uninit();
+    if unsafe { sigemptyset(set.as_mut_ptr()) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    let set = unsafe { set.assume_init() };
+
+    if unsafe { sigprocmask(SIG_SETMASK, &set, null_mut()) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(())
+}
+
+fn sigwinch_listener_main(seccomp_filter: BpfProgram, tx: File, tty: &File) -> ! {
+    TX.with(|opt| opt.replace(Some(tx)));
+
+    unsafe {
+        close(STDIN_FILENO);
+        close(STDOUT_FILENO);
+    }
+
+    unblock_all_signals().unwrap();
+
+    apply_filter(&seccomp_filter).unwrap();
+
+    register_signal_handler(SIGWINCH, sigwinch_handler).unwrap();
+
+    unsafe {
+        // Create a new session (and therefore a new process group).
+        assert_ne!(setsid(), -1);
+
+        // Set the tty to be this process's controlling terminal.
+        assert_ne!(ioctl(tty.as_raw_fd(), TIOCSCTTY, 0), -1);
+
+        // Become the foreground process group of the tty.
+        assert_ne!(tcsetpgrp(tty.as_raw_fd(), getpgrp()), -1);
+    }
+
+    notify();
+
+    // Wait for the pipe to close, indicating the parent has exited.
+    with_tx(|tx| {
+        let mut pollfd = pollfd {
+            fd: tx.as_raw_fd(),
+            events: 0,
+            revents: 0,
+        };
+
+        while unsafe { poll(&mut pollfd, 1, -1) } == -1 {
+            let e = io::Error::last_os_error();
+            if !matches!(e.kind(), ErrorKind::Interrupted | ErrorKind::WouldBlock) {
+                panic!("poll: {}", e);
+            }
+        }
+
+        assert_eq!(pollfd.revents, POLLERR);
+    });
+
+    exit(0);
+}
+
+pub fn start_sigwinch_listener(seccomp_filter: BpfProgram, pty: &File) -> io::Result<File> {
+    let mut pipe = [-1; 2];
+    if unsafe { pipe2(pipe.as_mut_ptr(), O_CLOEXEC) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut rx = unsafe { File::from_raw_fd(pipe[0]) };
+    let tx = unsafe { File::from_raw_fd(pipe[1]) };
+
+    let mut args = clone_args::default();
+    args.flags |= CLONE_CLEAR_SIGHAND;
+
+    match unsafe { clone3(&mut args, size_of::<clone_args>()) } {
+        -1 => return Err(io::Error::last_os_error()),
+        0 => {
+            drop(rx);
+            sigwinch_listener_main(seccomp_filter, tx, pty);
+        }
+        _ => (),
+    }
+
+    drop(tx);
+
+    // Wait for a notification indicating readiness.
+    rx.read_exact(&mut [0])?;
+
+    Ok(rx)
+}

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -17,9 +17,7 @@ use crate::config::{
     ConsoleOutputMode, DeviceConfig, DiskConfig, FsConfig, HotplugMethod, NetConfig, PmemConfig,
     UserDeviceConfig, ValidationError, VmConfig, VsockConfig,
 };
-use crate::device_manager::{
-    self, get_win_size, Console, DeviceManager, DeviceManagerError, PtyPair,
-};
+use crate::device_manager::{self, Console, DeviceManager, DeviceManagerError, PtyPair};
 use crate::device_tree::DeviceTree;
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 use crate::migration::{get_vm_snapshot, url_to_path, VM_SNAPSHOT_FILE};
@@ -1602,8 +1600,7 @@ impl Vm {
         for signal in signals.forever() {
             match signal {
                 SIGWINCH => {
-                    let (col, row) = get_win_size();
-                    console_input_clone.update_console_size(col, row);
+                    console_input_clone.update_console_size();
                 }
                 SIGTERM | SIGINT => {
                     if on_tty {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -708,6 +708,7 @@ impl Vm {
         activate_evt: EventFd,
         serial_pty: Option<PtyPair>,
         console_pty: Option<PtyPair>,
+        console_resize_pipe: Option<File>,
     ) -> Result<Self> {
         #[cfg(feature = "tdx")]
         let tdx_enabled = config.lock().unwrap().tdx.is_some();
@@ -771,7 +772,7 @@ impl Vm {
             .device_manager
             .lock()
             .unwrap()
-            .create_devices(serial_pty, console_pty)
+            .create_devices(serial_pty, console_pty, console_resize_pipe)
             .map_err(Error::DeviceManager)?;
         Ok(new_vm)
     }
@@ -1138,6 +1139,10 @@ impl Vm {
 
     pub fn console_pty(&self) -> Option<PtyPair> {
         self.device_manager.lock().unwrap().console_pty()
+    }
+
+    pub fn console_resize_pipe(&self) -> Option<Arc<File>> {
+        self.device_manager.lock().unwrap().console_resize_pipe()
     }
 
     pub fn shutdown(&mut self) -> Result<()> {


### PR DESCRIPTION
Previously, terminal resize with virtio-console worked great when the console was connected to the terminal running cloud-hypervisor, but it didn't work at all when the console was using a different pty.  Here, I make it work by fixing two different but related problems: setting the console size to the size of the connected terminal rather than always using stdin, and listening for resize notifications from the console's pty.  The details of each fix are explained in the respective commit messages, which provide important background.  In particular, it might seem surprising that listening for pty resize notifications requires a subprocess, but I'm confident after having researched it (and reading the appropriate kernel source code) that due to how ttys work in Linux, there's no other way.

Signed-off-by: Alyssa Ross <hi@alyssa.is>
