### PR TITLE
net_util: Change libc::getrandom to getrandom::getrandom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ name = "net_util"
 version = "0.1.0"
 dependencies = [
  "epoll",
+ "getrandom",
  "lazy_static",
  "libc",
  "log",

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 epoll = "4.3.1"
+getrandom = "0.2"
 libc = "0.2.102"
 log = "0.4.14"
 net_gen = { path = "../net_gen" }

--- a/net_util/src/mac.rs
+++ b/net_util/src/mac.rs
@@ -82,21 +82,12 @@ impl MacAddr {
     pub fn local_random() -> MacAddr {
         // Generate a fully random MAC
         let mut random_bytes = [0u8; MAC_ADDR_LEN];
-        unsafe {
-            // Man page says this function will not be interrupted by a signal
-            // for requests less than 256 bytes
-            if libc::getrandom(
-                random_bytes.as_mut_ptr() as *mut _ as *mut libc::c_void,
-                MAC_ADDR_LEN,
-                0,
-            ) < 0
-            {
-                error!(
-                    "Error populating MAC address with random data: {}",
-                    std::io::Error::last_os_error()
-                )
-            }
-        };
+        if let Err(e) = getrandom::getrandom(&mut random_bytes) {
+            error!(
+                "Error populating MAC address with random data: {}",
+                e.to_string()
+            );
+        }
 
         // Set the first byte to make the OUI a locally administered OUI
         random_bytes[0] = 0x2e;


### PR DESCRIPTION
libc::getrandom need to be called inside unsafe and it is not
cross-platform friendly.
Change it to getrandom::getrandom that is safe and cross-platform
friendly.

Signed-off-by: Hui Zhu <teawater@antfin.com>