### PR TITLE
main: Don't panic() if blocking signals fails

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -501,7 +501,9 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
     // installing handlers for, to make sure they only ever run on the
     // dedicated signal handling thread we'll start in a bit.
     for sig in vmm::vm::HANDLED_SIGNALS {
-        block_signal(sig).unwrap();
+        if let Err(e) = block_signal(sig) {
+            eprintln!("Error blocking signals: {}", e);
+        }
     }
 
     event!("vmm", "starting");


### PR DESCRIPTION
This allows Cloud Hypervisor to be run under `perf` as some of the
signals will already be blocked in the child process.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>