### PR TITLE
deps: Update kvm-ioctls to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2924454e22895c738e43331ae310459c74a11ded9c97dc250129ee10d2f9ca2"
+checksum = "48dc14f9047df1873cf6942caccc7431d19c3d496ca7a0d162260c4cf0f64b76"
 dependencies = [
  "kvm-bindings",
  "libc",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -16,7 +16,7 @@ epoll = "4.3.1"
 thiserror = "1.0.29"
 libc = "0.2.102"
 log = "0.4.14"
-kvm-ioctls = { version = "0.9.0", optional = true }
+kvm-ioctls = { version = "0.10.0", optional = true }
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0", features = ["with-serde", "fam-wrappers"], optional  = true }
 mshv-bindings = {git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
 mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional  = true}


### PR DESCRIPTION
Updating kvm-ioctls from 0.9.0 to 0.10.0 now that Cloud Hypervisor
relies on kvm-bindings 0.5.0.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>