### PR TITLE
Dockerfile: Build and install virtiofsd to the docker image

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -91,3 +91,11 @@ RUN export ARCH="$(uname -m)" \
 RUN echo 'source $CARGO_HOME/env' >> $HOME/.bashrc \
     && mkdir $HOME/.cargo \
     && ln -s $CARGO_HOME/env $HOME/.cargo/env
+
+# install virtiofsd
+RUN git clone --depth 1 https://gitlab.com/virtio-fs/qemu.git -b qemu5.0-virtiofs-dax \
+    && cd qemu \
+    && ./configure --prefix=$PWD --target-list=x86_64-softmmu \
+    && make virtiofsd -j `nproc` \
+    && cp virtiofsd /usr/local/bin \
+    && cd .. && rm -rf qemu


### PR DESCRIPTION
Given the 'virtiofsd' and 'virtiofsd-rs' executable are used in multiple
CI workers, installing them directly to the docker image is more
efficient and can save CI time.

Signed-off-by: Bo Chen <chen.bo@intel.com>