### PR TITLE
Enable virtio-iommu on AArch64 (FDT only)

### DIFF
--- a/arch/src/aarch64/gic/gicv3.rs
+++ b/arch/src/aarch64/gic/gicv3.rs
@@ -78,23 +78,17 @@ pub mod kvm {
     impl VersionMapped for Gicv3State {}
 
     impl KvmGicV3 {
-        // Unfortunately bindgen omits defines that are based on other defines.
-        // See arch/arm64/include/uapi/asm/kvm.h file from the linux kernel.
-        pub const SZ_64K: u64 = 0x0001_0000;
-        const KVM_VGIC_V3_DIST_SIZE: u64 = KvmGicV3::SZ_64K;
-        const KVM_VGIC_V3_REDIST_SIZE: u64 = (2 * KvmGicV3::SZ_64K);
-
         // Device trees specific constants
         pub const ARCH_GIC_V3_MAINT_IRQ: u32 = 9;
 
         /// Get the address of the GIC distributor.
         pub fn get_dist_addr() -> u64 {
-            layout::MAPPED_IO_START - KvmGicV3::KVM_VGIC_V3_DIST_SIZE
+            layout::GIC_V3_DIST_START
         }
 
         /// Get the size of the GIC distributor.
         pub fn get_dist_size() -> u64 {
-            KvmGicV3::KVM_VGIC_V3_DIST_SIZE
+            layout::GIC_V3_DIST_SIZE
         }
 
         /// Get the address of the GIC redistributors.
@@ -104,7 +98,7 @@ pub mod kvm {
 
         /// Get the size of the GIC redistributors.
         pub fn get_redists_size(vcpu_count: u64) -> u64 {
-            vcpu_count * KvmGicV3::KVM_VGIC_V3_REDIST_SIZE
+            vcpu_count * layout::GIC_V3_REDIST_SIZE
         }
 
         /// Save the state of GIC.

--- a/arch/src/aarch64/gic/gicv3_its.rs
+++ b/arch/src/aarch64/gic/gicv3_its.rs
@@ -13,6 +13,7 @@ pub mod kvm {
     use crate::aarch64::gic::gicv3::kvm::KvmGicV3;
     use crate::aarch64::gic::kvm::{save_pending_tables, KvmGicDevice};
     use crate::aarch64::gic::GicDevice;
+    use crate::layout;
     use anyhow::anyhow;
     use hypervisor::kvm::kvm_bindings;
     use hypervisor::CpuState;
@@ -179,10 +180,8 @@ pub mod kvm {
     impl VersionMapped for Gicv3ItsState {}
 
     impl KvmGicV3Its {
-        const KVM_VGIC_V3_ITS_SIZE: u64 = (2 * KvmGicV3::SZ_64K);
-
         fn get_msi_size() -> u64 {
-            KvmGicV3Its::KVM_VGIC_V3_ITS_SIZE
+            layout::GIC_V3_ITS_SIZE
         }
 
         fn get_msi_addr(vcpu_count: u64) -> u64 {

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -55,6 +55,17 @@ pub const UEFI_SIZE: u64 = 0x040_0000;
 /// Below this address will reside the GIC, above this address will reside the MMIO devices.
 pub const MAPPED_IO_START: u64 = 0x0900_0000;
 
+/// See kernel file arch/arm64/include/uapi/asm/kvm.h for the GIC related definitions.
+/// 0x08ff_0000 ~ 0x0900_0000 is reserved for GICv3 Distributor
+pub const GIC_V3_DIST_SIZE: u64 = 0x01_0000;
+pub const GIC_V3_DIST_START: u64 = MAPPED_IO_START - GIC_V3_DIST_SIZE;
+/// Below 0x08ff_0000 is reserved for GICv3 Redistributor.
+/// The size defined here is for each vcpu.
+/// The total size is 'number_of_vcpu * GIC_V3_REDIST_SIZE'
+pub const GIC_V3_REDIST_SIZE: u64 = 0x02_0000;
+/// Below Redistributor area is GICv3 ITS
+pub const GIC_V3_ITS_SIZE: u64 = 0x02_0000;
+
 /// Space 0x0900_0000 ~ 0x0905_0000 is reserved for legacy devices.
 pub const LEGACY_SERIAL_MAPPED_IO_START: u64 = 0x0900_0000;
 pub const LEGACY_RTC_MAPPED_IO_START: u64 = 0x0901_0000;

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -142,6 +142,7 @@ pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::Bui
     device_info: &HashMap<(DeviceType, String), T, S>,
     initrd: &Option<super::InitramfsConfig>,
     pci_space_address: &(u64, u64),
+    virtio_iommu_bdf: Option<u32>,
     gic_device: &dyn GicDevice,
     numa_nodes: &NumaNodes,
 ) -> super::Result<()> {
@@ -155,6 +156,7 @@ pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::Bui
         initrd,
         pci_space_address,
         numa_nodes,
+        virtio_iommu_bdf,
     )
     .map_err(|_| Error::SetupFdt)?;
 

--- a/docs/iommu.md
+++ b/docs/iommu.md
@@ -121,6 +121,29 @@ lspci
 00:04.0 Unassigned class [ffff]: Red Hat, Inc. Virtio RNG
 ```
 
+### Work with FDT on AArch64
+
+On AArch64 architecture, the virtual IOMMU can still be used even if ACPI is not
+enabled. But the effect is different with what the aforementioned test showed.
+
+When ACPI is disabled, virtual IOMMU is supported through Flattened Device Tree
+(FDT). In this case, the guest kernel can not tell which device should be
+IOMMU-attached and which should not. No matter how many devices you attached to
+the virtual IOMMU by setting `iommu=on` option, all the devices on the PCI bus
+will be attached to the virtual IOMMU (except the IOMMU itself). Each of the
+devices will be added into a IOMMU group.
+
+As a result, the directory content of `/sys/kernel/iommu_groups` would be:
+
+```bash
+ls /sys/kernel/iommu_groups/0/devices/
+0000:00:02.0
+ls /sys/kernel/iommu_groups/1/devices/
+0000:00:03.0
+ls /sys/kernel/iommu_groups/2/devices/
+0000:00:04.0
+```
+
 ## Faster mappings
 
 By default, the guest memory is mapped with 4k pages and no huge pages, which

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1077,6 +1077,14 @@ impl Vm {
 
         let pci_space = (pci_space_start.0, pci_space_size);
 
+        let virtio_iommu_bdf = self
+            .device_manager
+            .lock()
+            .unwrap()
+            .iommu_attached_devices()
+            .as_ref()
+            .map(|(v, _)| *v);
+
         #[cfg(feature = "acpi")]
         {
             let _ = crate::acpi::create_acpi_tables(
@@ -1104,6 +1112,7 @@ impl Vm {
             device_info,
             &initramfs_config,
             &pci_space,
+            virtio_iommu_bdf,
             &*gic_device,
             &self.numa_nodes,
         )
@@ -2631,6 +2640,7 @@ mod tests {
             &None,
             &(0x1_0000_0000, 0x1_0000),
             &BTreeMap::new(),
+            None,
         )
         .is_ok())
     }


### PR DESCRIPTION
The PR enables virtio-iommu and its test case on AArch64.
Now virtio-iommu only works when FDT is used. The work on ACPI is on-going.

The PR includes:
- Adding IOMMU node in FDT
- Refactoring virtio-iommu and GIC code to receive architecture specific MSI-IOVA address
- Adapting the test case
- Documentation