### PR TITLE
Add IOAPIC & PCI config fast path

### DIFF
--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -188,18 +188,23 @@ impl PciBus {
     }
 }
 
+#[derive(Default)]
 pub struct PciConfigIo {
     /// Config space register.
     config_address: u32,
-    pci_bus: Arc<Mutex<PciBus>>,
+    pci_bus: Option<Arc<Mutex<PciBus>>>,
 }
 
 impl PciConfigIo {
-    pub fn new(pci_bus: Arc<Mutex<PciBus>>) -> Self {
+    pub fn new() -> Self {
         PciConfigIo {
-            pci_bus,
             config_address: 0,
+            pci_bus: None,
         }
+    }
+
+    pub fn set_bus(&mut self, pci_bus: Arc<Mutex<PciBus>>) {
+        self.pci_bus = Some(pci_bus)
     }
 
     pub fn config_space_read(&self) -> u32 {
@@ -222,6 +227,8 @@ impl PciConfigIo {
         }
 
         self.pci_bus
+            .as_ref()
+            .unwrap()
             .lock()
             .unwrap()
             .devices
@@ -249,7 +256,7 @@ impl PciConfigIo {
             return None;
         }
 
-        let pci_bus = self.pci_bus.lock().unwrap();
+        let pci_bus = self.pci_bus.as_ref().unwrap().lock().unwrap();
         if let Some(d) = pci_bus.devices.get(&(device as u32)) {
             let mut device = d.lock().unwrap();
 

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -42,3 +42,8 @@ impl PciInterruptPin {
         self as u32
     }
 }
+
+#[cfg(target_arch = "x86_64")]
+pub const PCI_CONFIG_IO_PORT: u64 = 0xcf8;
+#[cfg(target_arch = "x86_64")]
+pub const PCI_CONFIG_IO_PORT_SIZE: u64 = 0x8;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7028,7 +7028,7 @@ mod tests {
                         // Resize to the maximum amount of CPUs and check each NUMA
                         // node has been assigned the right CPUs set.
                         resize_command(&dest_api_socket, Some(12), None, None);
-                        thread::sleep(std::time::Duration::new(5, 0));
+                        thread::sleep(std::time::Duration::new(10, 0));
 
                         guest.check_numa_common(
                             None,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -67,11 +67,12 @@ use libc::{
     isatty, tcgetattr, tcsetattr, termios, ECHO, ICANON, ISIG, MAP_NORESERVE, MAP_PRIVATE,
     MAP_SHARED, O_TMPFILE, PROT_READ, PROT_WRITE, TCSANOW,
 };
-use pci::VfioPciDevice;
 use pci::{
-    DeviceRelocation, PciBarRegionType, PciBus, PciConfigIo, PciConfigMmio, PciDevice, PciRoot,
+    DeviceRelocation, PciBarRegionType, PciBus, PciConfigMmio, PciDevice, PciRoot, VfioPciDevice,
     VfioUserPciDevice, VfioUserPciDeviceError,
 };
+#[cfg(target_arch = "x86_64")]
+use pci::{PciConfigIo, PCI_CONFIG_IO_PORT, PCI_CONFIG_IO_PORT_SIZE};
 use seccompiler::SeccompAction;
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -826,6 +827,9 @@ pub struct DeviceManager {
     // Keep a reference to the PCI bus
     pci_bus: Option<Arc<Mutex<PciBus>>>,
 
+    #[cfg(target_arch = "x86_64")]
+    pci_config_io: Arc<Mutex<PciConfigIo>>,
+
     #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     // MSI Interrupt Manager
     msi_interrupt_manager: Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>>,
@@ -959,6 +963,9 @@ impl DeviceManager {
             bus_devices: Vec::new(),
             device_id_cnt: Wrapping(0),
             pci_bus: None,
+            #[cfg(target_arch = "x86_64")]
+            // Create early so ready for use in `VmmOps`
+            pci_config_io: Arc::new(Mutex::new(PciConfigIo::new())),
             msi_interrupt_manager,
             legacy_interrupt_manager: None,
             passthrough_device: None,
@@ -1222,13 +1229,22 @@ impl DeviceManager {
         }
 
         let pci_bus = Arc::new(Mutex::new(pci_bus));
-        let pci_config_io = Arc::new(Mutex::new(PciConfigIo::new(Arc::clone(&pci_bus))));
+        #[cfg(target_arch = "x86_64")]
+        self.pci_config_io
+            .lock()
+            .unwrap()
+            .set_bus(Arc::clone(&pci_bus));
+        #[cfg(target_arch = "x86_64")]
         self.bus_devices
-            .push(Arc::clone(&pci_config_io) as Arc<Mutex<dyn BusDevice>>);
+            .push(Arc::clone(&self.pci_config_io) as Arc<Mutex<dyn BusDevice>>);
         #[cfg(target_arch = "x86_64")]
         self.address_manager
             .io_bus
-            .insert(pci_config_io, 0xcf8, 0x8)
+            .insert(
+                self.pci_config_io.clone(),
+                PCI_CONFIG_IO_PORT,
+                PCI_CONFIG_IO_PORT_SIZE,
+            )
             .map_err(DeviceManagerError::BusError)?;
         let pci_config_mmio = Arc::new(Mutex::new(PciConfigMmio::new(Arc::clone(&pci_bus))));
         self.bus_devices
@@ -3318,6 +3334,12 @@ impl DeviceManager {
     // Used to provide a fast path for handling MMIO exits
     pub fn ioapic(&self) -> Option<Arc<Mutex<ioapic::Ioapic>>> {
         self.interrupt_controller.clone()
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    // Used to provide a fast path for handling PIO exits
+    pub fn pci_config_io(&self) -> Arc<Mutex<PciConfigIo>> {
+        self.pci_config_io.clone()
     }
 
     pub fn console(&self) -> &Arc<Console> {


### PR DESCRIPTION
Looking up devices on the port I/O bus is time consuming during the
boot at there is an O(lg n) tree lookup and the overhead from taking a
lock on the bus contents.

Avoid this by adding a fast path uses the hardcoded port address and
size and directs PCI config requests directly to the device.

The results here are for the MMIO IOAPIC optimisation and PIO PCI
optimation combined:

Command line:
`
target/release/cloud-hypervisor --kernel ~/src/linux/vmlinux --cmdline "root=/dev/vda1 console=ttyS0" --serial tty --console off --disk path=~/workloads/focal-server-cloudimg-amd64-custom-20210609-0.raw --api-socket /tmp/api
`

MMIO exit: 604
IOAPIC fast path: 212
PIO exit: 17913
PCI fast path: 17871
Percentage on fast path: 98%

perf before:

`
marvin:~/src/cloud-hypervisor (main *)$ perf report -g | grep resolve
     6.20%     6.20%  vcpu0            cloud-hypervisor    [.] vm_device:bus:Bus::resolve
`

perf after:

`
marvin:~/src/cloud-hypervisor (2021-09-17-ioapic-fast-path *)$ perf report -g | grep resolve
     0.08%     0.08%  vcpu0            cloud-hypervisor    [.] vm_device:bus:Bus::resolve
`

The compromise required to implement these fast paths is bringing the
device creation earlier so that they are ready in the `DeviceManager` constructor.

