### PR TITLE
virtio-mem: Support multiple mappings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,10 +144,6 @@ pipeline{
 				}
 				stage ('Worker build VFIO') {
 					agent { node { label 'bionic-vfio' } }
-					when {
-						beforeAgent true
-						branch 'main'
-					}
 					stages {
 						stage ('Checkout') {
 							steps {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -91,6 +91,7 @@ use vfio_ioctls::{VfioContainer, VfioDevice};
 use virtio_devices::transport::VirtioPciDevice;
 use virtio_devices::transport::VirtioTransport;
 use virtio_devices::vhost_user::VhostUserConfig;
+use virtio_devices::VirtioMemMappingSource;
 use virtio_devices::{DmaRemapping, Endpoint, IommuMapping};
 use virtio_devices::{VirtioSharedMemory, VirtioSharedMemoryList};
 use vm_allocator::SystemAllocator;
@@ -2950,7 +2951,10 @@ impl DeviceManager {
                 virtio_mem_device
                     .lock()
                     .unwrap()
-                    .add_dma_mapping_handler(vfio_mapping.clone())
+                    .add_dma_mapping_handler(
+                        VirtioMemMappingSource::Container,
+                        vfio_mapping.clone(),
+                    )
                     .map_err(DeviceManagerError::AddDmaMappingHandlerVirtioMem)?;
             }
         }


### PR DESCRIPTION
For vfio-user the mapping handler is per device and needs to be removed
when the device in unplugged.

For VFIO the mapping handler is for the default VFIO container (used
when no vIOMMU is used - using a vIOMMU does not require mappings with
virtio-mem)

To represent these two use cases use an enum for the handlers that are
stored.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>