### PR TITLE
Enable virtio-iommu on AArch64

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4116,6 +4116,8 @@ impl Aml for DeviceManager {
         pci_dsdt_inner_data.push(&seg);
         let uid = aml::Name::new("_UID".into(), &aml::ZERO);
         pci_dsdt_inner_data.push(&uid);
+        let cca = aml::Name::new("_CCA".into(), &aml::ONE);
+        pci_dsdt_inner_data.push(&cca);
         let supp = aml::Name::new("SUPP".into(), &aml::ZERO);
         pci_dsdt_inner_data.push(&supp);
 


### PR DESCRIPTION
Enabled virtio-iommu on AArch64 when ACPI is used:
- Added Cache Coherence (_CCA) field in DSDT
- Updated Focal cloud image kernel to 5.14
- Enabled test cases

This PR depends on https://github.com/cloud-hypervisor/cloud-hypervisor/pull/3150. After the Dockerfile change is merged and new container images pushed to Dockerhub, the integration test should be able to run.
