### PR TITLE
virtio-mem: Implement snapshot/restore and migration

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5015,7 +5015,10 @@ mod tests {
             let mut child = GuestCommand::new(&guest)
                 .args(&["--api-socket", &api_socket])
                 .args(&["--cpus", "boot=4"])
-                .args(&["--memory", "size=4G"])
+                .args(&[
+                    "--memory",
+                    "size=4G,hotplug_method=virtio-mem,hotplug_size=32G",
+                ])
                 .args(&["--balloon", "size=0"])
                 .args(&["--kernel", kernel_path.to_str().unwrap()])
                 .args(&[
@@ -5045,12 +5048,16 @@ mod tests {
                 assert_eq!(guest.get_cpu_count().unwrap_or_default(), 4);
                 // Check the guest RAM
                 assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+                // Increase guest RAM with virtio-mem
+                resize_command(&api_socket, None, Some(6 << 30), None);
+                thread::sleep(std::time::Duration::new(5, 0));
+                assert!(guest.get_total_memory().unwrap_or_default() > 5_760_000);
                 // Use balloon to remove RAM from the VM
                 resize_command(&api_socket, None, None, Some(1 << 30));
                 thread::sleep(std::time::Duration::new(5, 0));
                 let total_memory = guest.get_total_memory().unwrap_or_default();
-                assert!(total_memory > 2_880_000);
-                assert!(total_memory < 3_840_000);
+                assert!(total_memory > 4_800_000);
+                assert!(total_memory < 5_760_000);
                 // Check the guest virtio-devices, e.g. block, rng, vsock, console, and net
                 guest.check_devices_common(Some(&socket), Some(&console_text));
 
@@ -5128,12 +5135,19 @@ mod tests {
                 // Perform same checks to validate VM has been properly restored
                 assert_eq!(guest.get_cpu_count().unwrap_or_default(), 4);
                 let total_memory = guest.get_total_memory().unwrap_or_default();
-                assert!(total_memory > 2_880_000);
-                assert!(total_memory < 3_840_000);
+                assert!(total_memory > 4_800_000);
+                assert!(total_memory < 5_760_000);
                 // Deflate balloon to restore entire RAM to the VM
                 resize_command(&api_socket, None, None, Some(0));
                 thread::sleep(std::time::Duration::new(5, 0));
-                assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+                assert!(guest.get_total_memory().unwrap_or_default() > 5_760_000);
+                // Decrease guest RAM with virtio-mem
+                resize_command(&api_socket, None, Some(5 << 30), None);
+                thread::sleep(std::time::Duration::new(5, 0));
+                let total_memory = guest.get_total_memory().unwrap_or_default();
+                assert!(total_memory > 4_800_000);
+                assert!(total_memory < 5_760_000);
+
                 guest.check_devices_common(Some(&socket), Some(&console_text));
             });
             // Shutdown the target VM and check console output

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -393,7 +393,7 @@ pub struct BlocksState {
 }
 
 impl BlocksState {
-    fn new(region_size: u64) -> Self {
+    pub fn new(region_size: u64) -> Self {
         BlocksState {
             bitmap: vec![false; (region_size / VIRTIO_MEM_DEFAULT_BLOCK_SIZE) as usize],
         }
@@ -810,6 +810,7 @@ impl Mem {
         initial_size: u64,
         hugepages: bool,
         exit_evt: EventFd,
+        blocks_state: Arc<Mutex<BlocksState>>,
     ) -> io::Result<Mem> {
         let region_len = region.len();
 
@@ -882,7 +883,7 @@ impl Mem {
             seccomp_action,
             hugepages,
             dma_mapping_handlers: Arc::new(Mutex::new(BTreeMap::new())),
-            blocks_state: Arc::new(Mutex::new(BlocksState::new(config.region_size))),
+            blocks_state,
             exit_evt,
         })
     }

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -392,6 +392,12 @@ pub struct BlocksState {
 }
 
 impl BlocksState {
+    fn new(region_size: u64) -> Self {
+        BlocksState {
+            bitmap: vec![false; (region_size / VIRTIO_MEM_DEFAULT_BLOCK_SIZE) as usize],
+        }
+    }
+
     fn is_range_state(&self, first_block_index: usize, nb_blocks: u16, plug: bool) -> bool {
         for state in self
             .bitmap
@@ -855,9 +861,7 @@ impl Mem {
             seccomp_action,
             hugepages,
             dma_mapping_handlers: Arc::new(Mutex::new(BTreeMap::new())),
-            blocks_state: Arc::new(Mutex::new(BlocksState {
-                bitmap: vec![false; (config.region_size / config.block_size) as usize],
-            })),
+            blocks_state: Arc::new(Mutex::new(BlocksState::new(config.region_size))),
             exit_evt,
         })
     }

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -554,7 +554,7 @@ impl VhostUserHandle {
                 let ptr = region.as_ptr() as *const u64;
                 std::slice::from_raw_parts(ptr, len).to_vec()
             };
-            Ok(MemoryRangeTable::from_bitmap(bitmap, 0))
+            Ok(MemoryRangeTable::from_bitmap(bitmap, 0, 4096))
         } else {
             Err(Error::MissingShmLogRegion)
         }

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -184,8 +184,7 @@ pub struct MemoryRangeTable {
 }
 
 impl MemoryRangeTable {
-    pub fn from_bitmap(bitmap: Vec<u64>, start_addr: u64) -> Self {
-        let page_size = 4096;
+    pub fn from_bitmap(bitmap: Vec<u64>, start_addr: u64, page_size: u64) -> Self {
         let mut table = MemoryRangeTable::default();
         let mut entry: Option<MemoryRange> = None;
         for (i, block) in bitmap.iter().enumerate() {

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::MigratableError;
+use crate::{MigratableError, VersionMapped};
+use std::io::{Read, Write};
+use versionize::{VersionMap, Versionize, VersionizeResult};
+use versionize_derive::Versionize;
 use vm_memory::ByteValued;
 
 // Migration protocol
@@ -27,8 +30,6 @@ use vm_memory::ByteValued;
 
 // The destination can at any time send an "error response" to cancel
 // The source can at any time send an "abandon request" to cancel
-
-use std::io::{Read, Write};
 
 #[repr(u16)]
 #[derive(Copy, Clone)]
@@ -173,15 +174,18 @@ impl Response {
 unsafe impl ByteValued for Response {}
 
 #[repr(C)]
+#[derive(Clone, Versionize)]
 pub struct MemoryRange {
     pub gpa: u64,
     pub length: u64,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default, Versionize)]
 pub struct MemoryRangeTable {
     data: Vec<MemoryRange>,
 }
+
+impl VersionMapped for MemoryRangeTable {}
 
 impl MemoryRangeTable {
     pub fn from_bitmap(bitmap: Vec<u64>, start_addr: u64, page_size: u64) -> Self {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2694,6 +2694,7 @@ impl DeviceManager {
                         self.exit_evt
                             .try_clone()
                             .map_err(DeviceManagerError::EventFd)?,
+                        virtio_mem_zone.blocks_state().clone(),
                     )
                     .map_err(DeviceManagerError::CreateVirtioMem)?,
                 ));

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -698,11 +698,12 @@ impl MemoryManager {
 
                         virtio_mem_regions.push(region.clone());
 
+                        let hotplugged_size = zone.hotplugged_size.unwrap_or(0);
                         memory_zone.virtio_mem_zone = Some(VirtioMemZone {
                             region,
-                            resize_handler: virtio_devices::Resize::new()
+                            resize_handler: virtio_devices::Resize::new(hotplugged_size)
                                 .map_err(Error::EventFdFail)?,
-                            hotplugged_size: zone.hotplugged_size.unwrap_or(0),
+                            hotplugged_size,
                             hugepages: zone.hugepages,
                         });
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1314,11 +1314,14 @@ impl MemoryManager {
 
     pub fn virtio_mem_resize(&mut self, id: &str, size: u64) -> Result<(), Error> {
         if let Some(memory_zone) = self.memory_zones.get_mut(id) {
-            if let Some(virtio_mem_zone) = memory_zone.virtio_mem_zone() {
+            if let Some(virtio_mem_zone) = &mut memory_zone.virtio_mem_zone {
                 virtio_mem_zone
                     .resize_handler()
                     .work(size)
                     .map_err(Error::VirtioMemResizeFail)?;
+
+                // Keep the hotplugged_size up to date.
+                virtio_mem_zone.hotplugged_size = size;
             } else {
                 error!("Failed resizing virtio-mem region: No virtio-mem handler");
                 return Err(Error::MissingVirtioMemHandler);

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -2038,7 +2038,7 @@ impl Migratable for MemoryManager {
                 .map(|(x, y)| x | y)
                 .collect();
 
-            let sub_table = MemoryRangeTable::from_bitmap(dirty_bitmap, r.gpa);
+            let sub_table = MemoryRangeTable::from_bitmap(dirty_bitmap, r.gpa, 4096);
 
             if sub_table.regions().is_empty() {
                 info!("Dirty Memory Range Table is empty");

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2188,7 +2188,10 @@ impl Vm {
     }
 
     pub fn memory_range_table(&self) -> std::result::Result<MemoryRangeTable, MigratableError> {
-        self.memory_manager.lock().unwrap().memory_range_table()
+        self.memory_manager
+            .lock()
+            .unwrap()
+            .memory_range_table(false)
     }
 
     pub fn device_tree(&self) -> Arc<Mutex<DeviceTree>> {


### PR DESCRIPTION
This PR adds the missing bits for supporting snapshot/restore along with migration for virtio-mem devices.

Fixes #1595 #1312