### PR TITLE
vmm: Always apply 47 bit address size limit

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -553,11 +553,7 @@ impl CpuManager {
             .map(|sgx_epc_region| sgx_epc_region.epc_sections().values().cloned().collect());
         #[cfg(target_arch = "x86_64")]
         let cpuid = {
-            let phys_bits = physical_bits(
-                config.max_phys_bits,
-                #[cfg(feature = "tdx")]
-                tdx_enabled,
-            );
+            let phys_bits = physical_bits(config.max_phys_bits);
             arch::generate_common_cpuid(
                 hypervisor,
                 config

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1038,11 +1038,7 @@ impl Vmm {
         let common_cpuid = {
             #[cfg(feature = "tdx")]
             let tdx_enabled = vm_config.lock().unwrap().tdx.is_some();
-            let phys_bits = vm::physical_bits(
-                vm_config.lock().unwrap().cpus.max_phys_bits,
-                #[cfg(feature = "tdx")]
-                tdx_enabled,
-            );
+            let phys_bits = vm::physical_bits(vm_config.lock().unwrap().cpus.max_phys_bits);
             arch::generate_common_cpuid(
                 hypervisor,
                 None,
@@ -1210,11 +1206,7 @@ impl Vmm {
 
             #[cfg(feature = "tdx")]
             let tdx_enabled = vm_config.tdx.is_some();
-            let phys_bits = vm::physical_bits(
-                vm_config.cpus.max_phys_bits,
-                #[cfg(feature = "tdx")]
-                tdx_enabled,
-            );
+            let phys_bits = vm::physical_bits(vm_config.cpus.max_phys_bits);
             arch::generate_common_cpuid(
                 self.hypervisor.clone(),
                 None,


### PR DESCRIPTION
This limit needs to be applied whenever we are running on a platform
that has TDX. Unfortunately we currently have no way to know if we are
running on such a platform. Therefore limiting the address space to
128TiB is the best solution for now. There is also now some added debug
to indicate this situation.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>