### PR TITLE
resources: Add autotools and texinfo for AArch64

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -67,6 +67,11 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
         libcap2-bin \
         libguestfs-tools \
         linux-image-5.8.0-63-generic \
+        autotools-dev \
+        autoconf \
+        automake \
+        perl \
+        texinfo \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*;	fi
 


### PR DESCRIPTION
These packages will be used to compile `stress` from source, and the `stress` will be used by the virtio-balloon integration test.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>