### PR TITLE
vmm: Only advertise a single PCI bus

### DIFF
--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -233,7 +233,7 @@ fn create_mcfg_table() -> Sdt {
         base_address: arch::layout::PCI_MMCONFIG_START.0,
         segment: 0,
         start: 0,
-        end: ((arch::layout::PCI_MMCONFIG_SIZE - 1) >> 20) as u8,
+        end: 0,
         ..Default::default()
     });
     mcfg

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4135,7 +4135,7 @@ impl Aml for DeviceManager {
         let crs = aml::Name::new(
             "_CRS".into(),
             &aml::ResourceTemplate::new(vec![
-                &aml::AddressSpace::new_bus_number(0x0u16, 0xffu16),
+                &aml::AddressSpace::new_bus_number(0x0u16, 0x0u16),
                 #[cfg(target_arch = "x86_64")]
                 &aml::Io::new(0xcf8, 0xcf8, 1, 0x8),
                 #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
Since we only support a single PCI bus right now advertise only a single
bus in the ACPI tables. This reduces the number of VM exits from probing
substantially.

Number of PCI config I/O port exits: 17871 -> 1551 (91% reduction) with
direct kernel boot.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>