### PR TITLE
vmm: add prefault option in memory and memory-zone

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,8 @@ fn create_app<'a, 'b>(
                      hugepages=on|off,hugepage_size=<hugepage_size>,\
                      hotplug_method=acpi|virtio-mem,\
                      hotplug_size=<hotpluggable_memory_size>,\
-                     hotplugged_size=<hotplugged_memory_size>\"",
+                     hotplugged_size=<hotplugged_memory_size>,\
+                     prefault=on|off\"",
                 )
                 .default_value(default_memory)
                 .group("vm-config"),
@@ -178,7 +179,8 @@ fn create_app<'a, 'b>(
                      hugepages=on|off,hugepage_size=<hugepage_size>,\
                      host_numa_node=<node_id>,\
                      id=<zone_identifier>,hotplug_size=<hotpluggable_memory_size>,\
-                     hotplugged_size=<hotplugged_memory_size>\"",
+                     hotplugged_size=<hotplugged_memory_size>,\
+                     prefault=on|off\"",
                 )
                 .takes_value(true)
                 .min_values(1)
@@ -644,8 +646,9 @@ mod unit_tests {
                     hotplugged_size: None,
                     shared: false,
                     hugepages: false,
-                    zones: None,
                     hugepage_size: None,
+                    prefault: false,
+                    zones: None,
                 },
                 kernel: Some(KernelConfig {
                     path: PathBuf::from("/path/to/kernel"),

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -546,6 +546,9 @@ components:
         hotplugged_size:
           type: integer
           format: int64
+        prefault:
+          type: boolean
+          default: false
 
     MemoryConfig:
       required:
@@ -577,6 +580,9 @@ components:
         hugepage_size:
           type: integer
           format: int64
+        prefault:
+          type: boolean
+          default: false
         zones:
           type: array
           items:

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -762,7 +762,7 @@ impl Vm {
         let memory_manager = MemoryManager::new(
             vm.clone(),
             &config.lock().unwrap().memory.clone(),
-            false,
+            None,
             phys_bits,
             #[cfg(feature = "tdx")]
             tdx_enabled,
@@ -886,7 +886,7 @@ impl Vm {
         let memory_manager = MemoryManager::new(
             vm.clone(),
             &config.lock().unwrap().memory.clone(),
-            false,
+            None,
             phys_bits,
             #[cfg(feature = "tdx")]
             false,


### PR DESCRIPTION
The argument `prefault` is provided in MemoryManager, but it can only be used by SGX and restore.

With prefault (`MAP_POPULATE`) set, subsequent page faults will decrease during running, although it will make boot slower.

This commit adds `prefault` in `MemoryConfig` and `MemoryZoneConfig`.

To resolve conflict between memory and restore, argument `prefault` has been changed from `bool` to `Option<bool>`, when its value is `None`, config from memory will be used, otherwise the value in `Option` will be used.

Ref: #3186 