### PR TITLE
build: Use "common" feature in default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ test_infra = { path = "test_infra" }
 wait-timeout = "0.2.0"
 
 [features]
-default = ["acpi", "cmos", "io_uring", "kvm"]
+default = ["common", "kvm"]
 # Common features for all hypervisors
 common = ["acpi", "cmos", "fwdebug", "io_uring"]
 acpi = ["vmm/acpi"]


### PR DESCRIPTION
This has the side effect of turning "fwdebug" on but that is
advantageous.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>