### PR TITLE
Build: Seccompiler: Move to use the released version from crate.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,8 +903,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "seccompiler"
-version = "0.1.0"
-source = "git+https://github.com/rust-vmm/seccompiler#da5788d52f1ae8886d8ed4624199b7e9fa64ac04"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01d1292a1131b22ccea49f30bd106f1238b5ddeec1a98d39268dcc31d540e68"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hypervisor = { path = "hypervisor" }
 libc = "0.2.103"
 log = { version = "0.4.14", features = ["std"] }
 option_parser = { path = "option_parser" }
-seccompiler = { git = "https://github.com/rust-vmm/seccompiler"}
+seccompiler = "0.2.0"
 serde_json = "1.0.68"
 signal-hook = "0.3.10"
 thiserror = "1.0.29"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -503,8 +503,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "seccompiler"
-version = "0.1.0"
-source = "git+https://github.com/rust-vmm/seccompiler#da5788d52f1ae8886d8ed4624199b7e9fa64ac04"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01d1292a1131b22ccea49f30bd106f1238b5ddeec1a98d39268dcc31d540e68"
 dependencies = [
  "libc",
 ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ block_util = { path = "../block_util" }
 libc = "0.2.103"
 libfuzzer-sys = "0.4.2"
 qcow = { path = "../qcow" }
-seccompiler = { git = "https://github.com/rust-vmm/seccompiler"}
+seccompiler = "0.2.0"
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
 vmm-sys-util = "0.9.0"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -23,7 +23,7 @@ net_gen = { path = "../net_gen" }
 net_util = { path = "../net_util" }
 pci = { path = "../pci" }
 rate_limiter = { path = "../rate_limiter" }
-seccompiler = { git = "https://github.com/rust-vmm/seccompiler"}
+seccompiler = "0.2.0"
 serde = "1.0.130"
 serde_derive = "1.0.130"
 serde_json = "1.0.68"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -35,7 +35,7 @@ net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
 pci = { path = "../pci" }
 qcow = { path = "../qcow" }
-seccompiler = { git = "https://github.com/rust-vmm/seccompiler"}
+seccompiler = "0.2.0"
 serde = { version = "1.0.130", features = ["rc"] }
 serde_derive = "1.0.130"
 serde_json = "1.0.68"


### PR DESCRIPTION
The `Seccompiler` crate has been published on crates.io: https://crates.io/crates/seccompiler

Reference: https://github.com/rust-vmm/seccompiler/issues/24

Signed-off-by: Bo Chen <chen.bo@intel.com>