### PR TITLE
Enable multiple PCI segments

### DIFF
--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -151,7 +151,7 @@ impl Aml for AcpiGedDevice {
                         &aml::And::new(&aml::Local(1), &aml::Local(0), &4usize),
                         &aml::If::new(
                             &aml::Equal::new(&aml::Local(1), &4usize),
-                            vec![&aml::MethodCall::new("\\_SB_.PCI0.PCNT".into(), vec![])],
+                            vec![&aml::MethodCall::new("\\_SB_.PHPR.PSCN".into(), vec![])],
                         ),
                         &aml::And::new(&aml::Local(1), &aml::Local(0), &8usize),
                         &aml::If::new(

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -140,12 +140,8 @@ impl PciBus {
         Ok(())
     }
 
-    pub fn add_device(
-        &mut self,
-        pci_device_bdf: u32,
-        device: Arc<Mutex<dyn PciDevice>>,
-    ) -> Result<()> {
-        self.devices.insert(pci_device_bdf >> 3, device);
+    pub fn add_device(&mut self, device_id: u32, device: Arc<Mutex<dyn PciDevice>>) -> Result<()> {
+        self.devices.insert(device_id, device);
         Ok(())
     }
 

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -7,7 +7,7 @@ use std::any::Any;
 use std::fmt::{self, Display};
 use std::sync::{Arc, Barrier};
 use std::{self, io, result};
-use vm_allocator::SystemAllocator;
+use vm_allocator::{AddressAllocator, SystemAllocator};
 use vm_device::BusDevice;
 use vm_memory::{GuestAddress, GuestUsize};
 
@@ -52,12 +52,17 @@ pub trait PciDevice: BusDevice {
     fn allocate_bars(
         &mut self,
         _allocator: &mut SystemAllocator,
+        _mmio_allocator: &mut AddressAllocator,
     ) -> Result<Vec<(GuestAddress, GuestUsize, PciBarRegionType)>> {
         Ok(Vec::new())
     }
 
     /// Frees the PCI BARs previously allocated with a call to allocate_bars().
-    fn free_bars(&mut self, _allocator: &mut SystemAllocator) -> Result<()> {
+    fn free_bars(
+        &mut self,
+        _allocator: &mut SystemAllocator,
+        _mmio_allocator: &mut AddressAllocator,
+    ) -> Result<()> {
         Ok(())
     }
 

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -27,6 +27,7 @@ pub use self::msi::{msi_num_enabled_vectors, MsiCap, MsiConfig};
 pub use self::msix::{MsixCap, MsixConfig, MsixTableEntry, MSIX_TABLE_ENTRY_SIZE};
 pub use self::vfio::{VfioPciDevice, VfioPciError};
 pub use self::vfio_user::{VfioUserDmaMapping, VfioUserPciDevice, VfioUserPciDeviceError};
+use std::fmt::Display;
 
 /// PCI has four interrupt pins A->D.
 #[derive(Copy, Clone)]
@@ -47,3 +48,76 @@ impl PciInterruptPin {
 pub const PCI_CONFIG_IO_PORT: u64 = 0xcf8;
 #[cfg(target_arch = "x86_64")]
 pub const PCI_CONFIG_IO_PORT_SIZE: u64 = 0x8;
+
+#[derive(Clone, Copy, PartialEq, PartialOrd)]
+pub struct PciBdf(u32);
+
+impl PciBdf {
+    pub fn segment(&self) -> u16 {
+        ((self.0 >> 16) & 0xffff) as u16
+    }
+
+    pub fn bus(&self) -> u8 {
+        ((self.0 >> 8) & 0xff) as u8
+    }
+
+    pub fn device(&self) -> u8 {
+        ((self.0 >> 3) & 0x1f) as u8
+    }
+
+    pub fn function(&self) -> u8 {
+        (self.0 & 0x7) as u8
+    }
+
+    pub fn new(segment: u16, bus: u8, device: u8, function: u8) -> Self {
+        Self(
+            (segment as u32) << 16
+                | (bus as u32) << 8
+                | ((device & 0x1f) as u32) << 3
+                | (function & 0x7) as u32,
+        )
+    }
+}
+
+impl From<u32> for PciBdf {
+    fn from(bdf: u32) -> Self {
+        Self(bdf)
+    }
+}
+
+impl From<PciBdf> for u32 {
+    fn from(bdf: PciBdf) -> Self {
+        bdf.0
+    }
+}
+
+impl From<&PciBdf> for u32 {
+    fn from(bdf: &PciBdf) -> Self {
+        bdf.0
+    }
+}
+
+impl From<PciBdf> for u16 {
+    fn from(bdf: PciBdf) -> Self {
+        (bdf.0 & 0xffff) as u16
+    }
+}
+
+impl From<&PciBdf> for u16 {
+    fn from(bdf: &PciBdf) -> Self {
+        (bdf.0 & 0xffff) as u16
+    }
+}
+
+impl Display for PciBdf {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:04x}:{:02x}:{:02x}.{:01x}",
+            self.segment(),
+            self.bus(),
+            self.device(),
+            self.function()
+        )
+    }
+}

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use vfio_bindings::bindings::vfio::*;
 use vfio_ioctls::VfioIrq;
 use vfio_user::{Client, Error as VfioUserError};
-use vm_allocator::SystemAllocator;
+use vm_allocator::{AddressAllocator, SystemAllocator};
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_device::interrupt::{InterruptManager, InterruptSourceGroup, MsiIrqGroupConfig};
 use vm_device::BusDevice;
@@ -234,12 +234,18 @@ impl PciDevice for VfioUserPciDevice {
     fn allocate_bars(
         &mut self,
         allocator: &mut SystemAllocator,
+        mmio_allocator: &mut AddressAllocator,
     ) -> Result<Vec<(GuestAddress, GuestUsize, PciBarRegionType)>, PciDeviceError> {
-        self.common.allocate_bars(allocator, &self.vfio_wrapper)
+        self.common
+            .allocate_bars(allocator, mmio_allocator, &self.vfio_wrapper)
     }
 
-    fn free_bars(&mut self, allocator: &mut SystemAllocator) -> Result<(), PciDeviceError> {
-        self.common.free_bars(allocator)
+    fn free_bars(
+        &mut self,
+        allocator: &mut SystemAllocator,
+        mmio_allocator: &mut AddressAllocator,
+    ) -> Result<(), PciDeviceError> {
+        self.common.free_bars(allocator, mmio_allocator)
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,15 @@ fn create_app<'a, 'b>(
                 .group("vm-config"),
         )
         .arg(
+            Arg::with_name("platform")
+                .long("platform")
+                .help(
+                    "num_pci_segments=<num pci segments>",
+                )
+                .takes_value(true)
+                .group("vm-config"),
+        )
+        .arg(
             Arg::with_name("memory")
                 .long("memory")
                 .help(
@@ -687,6 +696,7 @@ mod unit_tests {
                 watchdog: false,
                 #[cfg(feature = "tdx")]
                 tdx: None,
+                platform: None,
             };
 
             aver_eq!(tb, expected_vm_config, result_vm_config);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1607,6 +1607,7 @@ mod tests {
         virtiofsd_cache: &str,
         prepare_daemon: &dyn Fn(&TempDir, &str, &str) -> (std::process::Child, String),
         hotplug: bool,
+        pci_segment: Option<u16>,
     ) {
         #[cfg(target_arch = "aarch64")]
         let focal_image = if hotplug {
@@ -1657,10 +1658,20 @@ mod tests {
             .default_disks()
             .default_net()
             .args(&["--api-socket", &api_socket]);
+        if pci_segment.is_some() {
+            guest_command.args(&["--platform", "num_pci_segments=16"]);
+        }
 
         let fs_params = format!(
-            "id=myfs0,tag=myfs,socket={},num_queues=1,queue_size=1024,dax={}{}",
-            virtiofsd_socket_path, dax_vmm_param, cache_size_vmm_param
+            "id=myfs0,tag=myfs,socket={},num_queues=1,queue_size=1024,dax={}{}{}",
+            virtiofsd_socket_path,
+            dax_vmm_param,
+            cache_size_vmm_param,
+            if let Some(pci_segment) = pci_segment {
+                format!(",pci_segment={}", pci_segment)
+            } else {
+                "".to_owned()
+            }
         );
 
         if !hotplug {
@@ -1677,8 +1688,16 @@ mod tests {
                 let (cmd_success, cmd_output) =
                     remote_command_w_output(&api_socket, "add-fs", Some(&fs_params));
                 assert!(cmd_success);
-                assert!(String::from_utf8_lossy(&cmd_output)
-                    .contains("{\"id\":\"myfs0\",\"bdf\":\"0000:00:06.0\"}"));
+
+                if let Some(pci_segment) = pci_segment {
+                    assert!(String::from_utf8_lossy(&cmd_output).contains(&format!(
+                        "{{\"id\":\"myfs0\",\"bdf\":\"{:04x}:00:01.0\"}}",
+                        pci_segment
+                    )));
+                } else {
+                    assert!(String::from_utf8_lossy(&cmd_output)
+                        .contains("{\"id\":\"myfs0\",\"bdf\":\"0000:00:06.0\"}"));
+                }
 
                 thread::sleep(std::time::Duration::new(10, 0));
             }
@@ -1749,16 +1768,31 @@ mod tests {
             let r = std::panic::catch_unwind(|| {
                 thread::sleep(std::time::Duration::new(10, 0));
                 let fs_params = format!(
-                    "id=myfs0,tag=myfs,socket={},num_queues=1,queue_size=1024,dax={}{}",
-                    virtiofsd_socket_path, dax_vmm_param, cache_size_vmm_param
+                    "id=myfs0,tag=myfs,socket={},num_queues=1,queue_size=1024,dax={}{}{}",
+                    virtiofsd_socket_path,
+                    dax_vmm_param,
+                    cache_size_vmm_param,
+                    if let Some(pci_segment) = pci_segment {
+                        format!(",pci_segment={}", pci_segment)
+                    } else {
+                        "".to_owned()
+                    }
                 );
 
                 // Add back and check it works
                 let (cmd_success, cmd_output) =
                     remote_command_w_output(&api_socket, "add-fs", Some(&fs_params));
                 assert!(cmd_success);
-                assert!(String::from_utf8_lossy(&cmd_output)
-                    .contains("{\"id\":\"myfs0\",\"bdf\":\"0000:00:06.0\"}"));
+                if let Some(pci_segment) = pci_segment {
+                    assert!(String::from_utf8_lossy(&cmd_output).contains(&format!(
+                        "{{\"id\":\"myfs0\",\"bdf\":\"{:04x}:00:01.0\"}}",
+                        pci_segment
+                    )));
+                } else {
+                    assert!(String::from_utf8_lossy(&cmd_output)
+                        .contains("{\"id\":\"myfs0\",\"bdf\":\"0000:00:06.0\"}"));
+                }
+
                 thread::sleep(std::time::Duration::new(10, 0));
                 // Mount shared directory through virtio_fs filesystem
                 let mount_cmd = format!(
@@ -3059,24 +3093,38 @@ mod tests {
         #[test]
         #[cfg(not(feature = "mshv"))]
         fn test_virtio_fs_dax_on_default_cache_size() {
-            test_virtio_fs(true, None, "none", &prepare_virtiofsd, false)
+            test_virtio_fs(true, None, "none", &prepare_virtiofsd, false, None)
         }
 
         #[test]
         #[cfg(not(feature = "mshv"))]
         fn test_virtio_fs_dax_on_cache_size_1_gib() {
-            test_virtio_fs(true, Some(0x4000_0000), "none", &prepare_virtiofsd, false)
+            test_virtio_fs(
+                true,
+                Some(0x4000_0000),
+                "none",
+                &prepare_virtiofsd,
+                false,
+                None,
+            )
         }
 
         #[test]
         fn test_virtio_fs_dax_off() {
-            test_virtio_fs(false, None, "none", &prepare_virtiofsd, false)
+            test_virtio_fs(false, None, "none", &prepare_virtiofsd, false, None)
         }
 
         #[test]
         #[cfg(not(feature = "mshv"))]
         fn test_virtio_fs_dax_on_default_cache_size_w_virtiofsd_rs_daemon() {
-            test_virtio_fs(true, None, "never", &prepare_virtiofsd_rs_daemon, false)
+            test_virtio_fs(
+                true,
+                None,
+                "never",
+                &prepare_virtiofsd_rs_daemon,
+                false,
+                None,
+            )
         }
 
         #[test]
@@ -3088,34 +3136,82 @@ mod tests {
                 "never",
                 &prepare_virtiofsd_rs_daemon,
                 false,
+                None,
             )
         }
 
         #[test]
         fn test_virtio_fs_dax_off_w_virtiofsd_rs_daemon() {
-            test_virtio_fs(false, None, "never", &prepare_virtiofsd_rs_daemon, false)
+            test_virtio_fs(
+                false,
+                None,
+                "never",
+                &prepare_virtiofsd_rs_daemon,
+                false,
+                None,
+            )
         }
 
         #[test]
         #[cfg(not(feature = "mshv"))]
         fn test_virtio_fs_hotplug_dax_on() {
-            test_virtio_fs(true, None, "none", &prepare_virtiofsd, true)
+            test_virtio_fs(true, None, "none", &prepare_virtiofsd, true, None)
         }
 
         #[test]
         fn test_virtio_fs_hotplug_dax_off() {
-            test_virtio_fs(false, None, "none", &prepare_virtiofsd, true)
+            test_virtio_fs(false, None, "none", &prepare_virtiofsd, true, None)
         }
 
         #[test]
         #[cfg(not(feature = "mshv"))]
         fn test_virtio_fs_hotplug_dax_on_w_virtiofsd_rs_daemon() {
-            test_virtio_fs(true, None, "never", &prepare_virtiofsd_rs_daemon, true)
+            test_virtio_fs(
+                true,
+                None,
+                "never",
+                &prepare_virtiofsd_rs_daemon,
+                true,
+                None,
+            )
         }
 
         #[test]
         fn test_virtio_fs_hotplug_dax_off_w_virtiofsd_rs_daemon() {
-            test_virtio_fs(false, None, "never", &prepare_virtiofsd_rs_daemon, true)
+            test_virtio_fs(
+                false,
+                None,
+                "never",
+                &prepare_virtiofsd_rs_daemon,
+                true,
+                None,
+            )
+        }
+
+        #[test]
+        #[cfg(all(not(feature = "mshv"), target_arch = "x86_64"))]
+        fn test_virtio_fs_multi_segment_hotplug() {
+            test_virtio_fs(
+                true,
+                Some(0x4000_0000),
+                "none",
+                &prepare_virtiofsd,
+                true,
+                Some(15),
+            )
+        }
+
+        #[test]
+        #[cfg(all(not(feature = "mshv"), target_arch = "x86_64"))]
+        fn test_virtio_fs_multi_segment() {
+            test_virtio_fs(
+                true,
+                Some(0x4000_0000),
+                "none",
+                &prepare_virtiofsd,
+                false,
+                Some(15),
+            )
         }
 
         #[test]

--- a/vm-allocator/src/address.rs
+++ b/vm-allocator/src/address.rs
@@ -201,6 +201,16 @@ impl AddressAllocator {
             }
         }
     }
+
+    /// Start address of the allocator
+    pub fn base(&self) -> GuestAddress {
+        self.base
+    }
+
+    /// Last address of the allocator
+    pub fn end(&self) -> GuestAddress {
+        self.end
+    }
 }
 
 #[cfg(test)]

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -687,6 +687,9 @@ components:
           default: true
         rate_limiter_config:
             $ref: '#/components/schemas/RateLimiterConfig'
+        pci_segment:
+          type: integer
+          format: int16
         id:
           type: string
 
@@ -728,6 +731,9 @@ components:
           items:
             type: integer
             format: int32
+        pci_segment:
+          type: integer
+          format: int16
         rate_limiter_config:
             $ref: '#/components/schemas/RateLimiterConfig'
 
@@ -783,6 +789,9 @@ components:
           type: integer
           format: int64
           default: 8589934592
+        pci_segment:
+          type: integer
+          format: int16
         id:
           type: string
 
@@ -805,6 +814,9 @@ components:
         discard_writes:
           type: boolean
           default: false
+        pci_segment:
+          type: integer
+          format: int16
         id:
           type: string
 
@@ -832,6 +844,9 @@ components:
         iommu:
           type: boolean
           default: false
+        pci_segment:
+          type: integer
+          format: int16
         id:
           type: string
 
@@ -852,6 +867,9 @@ components:
         iommu:
           type: boolean
           default: false
+        pci_segment:
+          type: integer
+          format: int16
         id:
           type: string
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1695,23 +1695,33 @@ pub struct UserDeviceConfig {
     pub socket: PathBuf,
     #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
+    pub pci_segment: u16,
 }
 
 impl UserDeviceConfig {
-    pub const SYNTAX: &'static str = "Userspace device socket=<socket_path>,id=<device_id>\"";
+    pub const SYNTAX: &'static str =
+        "Userspace device socket=<socket_path>,id=<device_id>,pci_segment=<segment_id>\"";
     pub fn parse(user_device: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
-        parser.add("socket").add("id");
+        parser.add("socket").add("id").add("pci_segment");
         parser.parse(user_device).map_err(Error::ParseUserDevice)?;
 
         let socket = parser
             .get("socket")
             .map(PathBuf::from)
             .ok_or(Error::ParseUserDeviceSocketMissing)?;
-
         let id = parser.get("id");
+        let pci_segment = parser
+            .convert::<u16>("pci_segment")
+            .map_err(Error::ParseUserDevice)?
+            .unwrap_or_default();
 
-        Ok(UserDeviceConfig { socket, id })
+        Ok(UserDeviceConfig {
+            socket,
+            id,
+            pci_segment,
+        })
     }
 }
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Default)]

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -575,7 +575,7 @@ impl CpuManager {
             .allocator()
             .lock()
             .unwrap()
-            .allocate_mmio_addresses(None, CPU_MANAGER_ACPI_SIZE as u64, None)
+            .allocate_platform_mmio_addresses(None, CPU_MANAGER_ACPI_SIZE as u64, None)
             .ok_or(Error::AllocateMmmioAddress)?;
 
         #[cfg(feature = "acpi")]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3063,8 +3063,7 @@ impl DeviceManager {
         &mut self,
         device_cfg: &mut UserDeviceConfig,
     ) -> DeviceManagerResult<(u32, String)> {
-        // TODO: Fill with PCI segment ID from config when available
-        let pci_segment_id = 0;
+        let pci_segment_id = device_cfg.pci_segment;
         let pci_device_bdf = self.pci_segments[pci_segment_id as usize].next_device_bdf()?;
 
         let legacy_interrupt_group =
@@ -3449,7 +3448,7 @@ impl DeviceManager {
         let (device_id, device_name) = self.add_vfio_user_device(device_cfg)?;
 
         // Update the PCIU bitmap
-        self.pci_segments[0].pci_devices_up |= 1 << (device_id >> 3);
+        self.pci_segments[device_cfg.pci_segment as usize].pci_devices_up |= 1 << (device_id >> 3);
 
         Ok(PciDeviceInfo {
             id: device_name,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -975,7 +975,7 @@ impl DeviceManager {
             .allocator
             .lock()
             .unwrap()
-            .allocate_mmio_addresses(None, DEVICE_MANAGER_ACPI_SIZE as u64, None)
+            .allocate_platform_mmio_addresses(None, DEVICE_MANAGER_ACPI_SIZE as u64, None)
             .ok_or(DeviceManagerError::AllocateIoPort)?;
 
         let mut pci_irq_slots = [0; 32];
@@ -1366,7 +1366,11 @@ impl DeviceManager {
             .allocator
             .lock()
             .unwrap()
-            .allocate_mmio_addresses(None, devices::acpi::GED_DEVICE_ACPI_SIZE as u64, None)
+            .allocate_platform_mmio_addresses(
+                None,
+                devices::acpi::GED_DEVICE_ACPI_SIZE as u64,
+                None,
+            )
             .ok_or(DeviceManagerError::AllocateMmioAddress)?;
         let ged_device = Arc::new(Mutex::new(devices::AcpiGedDevice::new(
             interrupt_group,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1188,14 +1188,16 @@ impl DeviceManager {
             }
         }
 
-        #[cfg(target_arch = "x86_64")]
-        self.bus_devices.push(
-            Arc::clone(self.pci_segments[0].pci_config_io.as_ref().unwrap())
-                as Arc<Mutex<dyn BusDevice>>,
-        );
+        for segment in &self.pci_segments {
+            #[cfg(target_arch = "x86_64")]
+            if let Some(pci_config_io) = segment.pci_config_io.as_ref() {
+                self.bus_devices
+                    .push(Arc::clone(pci_config_io) as Arc<Mutex<dyn BusDevice>>);
+            }
 
-        self.bus_devices
-            .push(Arc::clone(&self.pci_segments[0].pci_config_mmio) as Arc<Mutex<dyn BusDevice>>);
+            self.bus_devices
+                .push(Arc::clone(&segment.pci_config_mmio) as Arc<Mutex<dyn BusDevice>>);
+        }
 
         Ok(())
     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2923,6 +2923,7 @@ impl DeviceManager {
         self.add_pci_device(
             vfio_pci_device.clone(),
             vfio_pci_device.clone(),
+            0,
             pci_device_bdf,
         )?;
 
@@ -2958,6 +2959,7 @@ impl DeviceManager {
         &mut self,
         bus_device: Arc<Mutex<dyn BusDevice>>,
         pci_device: Arc<Mutex<dyn PciDevice>>,
+        segment_id: u16,
         bdf: u32,
     ) -> DeviceManagerResult<Vec<(GuestAddress, GuestUsize, PciBarRegionType)>> {
         let bars = pci_device
@@ -2966,7 +2968,10 @@ impl DeviceManager {
             .allocate_bars(&mut self.address_manager.allocator.lock().unwrap())
             .map_err(DeviceManagerError::AllocateBars)?;
 
-        let mut pci_bus = self.pci_segments[0].pci_bus.lock().unwrap();
+        let mut pci_bus = self.pci_segments[segment_id as usize]
+            .pci_bus
+            .lock()
+            .unwrap();
 
         pci_bus
             .add_device(bdf, pci_device)
@@ -3083,6 +3088,7 @@ impl DeviceManager {
         self.add_pci_device(
             vfio_user_pci_device.clone(),
             vfio_user_pci_device.clone(),
+            0,
             pci_device_bdf,
         )?;
 
@@ -3213,6 +3219,7 @@ impl DeviceManager {
         let bars = self.add_pci_device(
             virtio_pci_device.clone(),
             virtio_pci_device.clone(),
+            0,
             pci_device_bdf,
         )?;
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2851,8 +2851,7 @@ impl DeviceManager {
         &mut self,
         device_cfg: &mut DeviceConfig,
     ) -> DeviceManagerResult<(u32, String)> {
-        // TODO: Fill with PCI segment ID from config when available
-        let pci_segment_id = 0;
+        let pci_segment_id = device_cfg.pci_segment;
         let pci_device_bdf = self.pci_segments[pci_segment_id as usize].next_device_bdf()?;
 
         let mut needs_dma_mapping = false;
@@ -3435,7 +3434,7 @@ impl DeviceManager {
         let (device_id, device_name) = self.add_passthrough_device(device_cfg)?;
 
         // Update the PCIU bitmap
-        self.pci_segments[0].pci_devices_up |= 1 << (device_id >> 3);
+        self.pci_segments[device_cfg.pci_segment as usize].pci_devices_up |= 1 << (device_id >> 3);
 
         Ok(PciDeviceInfo {
             id: device_name,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3435,7 +3435,11 @@ impl DeviceManager {
 
         let pci_device_bdf = pci_device_node
             .pci_bdf
-            .ok_or(DeviceManagerError::MissingPciDevice)?;
+            .ok_or(DeviceManagerError::MissingDeviceNodePciBdf)?;
+        let pci_segment_id = pci_device_node
+            .pci_segment_id
+            .ok_or(DeviceManagerError::MissingDeviceNodePciSegmentId)?;
+
         let pci_device_handle = pci_device_node
             .pci_device_handle
             .as_ref()
@@ -3462,7 +3466,7 @@ impl DeviceManager {
         }
 
         // Update the PCID bitmap
-        self.pci_segments[0].pci_devices_down |= 1 << (pci_device_bdf >> 3);
+        self.pci_segments[pci_segment_id as usize].pci_devices_down |= 1 << (pci_device_bdf >> 3);
 
         Ok(())
     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3903,8 +3903,11 @@ impl Aml for DeviceManager {
             .unwrap()
             .to_aml_bytes();
 
-        let pci_dsdt_data = self.pci_segments[0].to_aml_bytes();
-        bytes.extend_from_slice(pci_dsdt_data.as_slice());
+        for segment in &self.pci_segments {
+            let pci_dsdt_data = segment.to_aml_bytes();
+            bytes.extend_from_slice(pci_dsdt_data.as_slice());
+        }
+
         bytes.extend_from_slice(mbrd_dsdt_data.as_slice());
         if self.config.lock().unwrap().serial.mode != ConsoleOutputMode::Off {
             bytes.extend_from_slice(com1_dsdt_data.as_slice());

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2293,11 +2293,11 @@ impl DeviceManager {
                 let (cache_base, cache_size) = if let Some((base, size)) = cache_range {
                     // The memory needs to be 2MiB aligned in order to support
                     // hugepages.
-                    self.address_manager
+                    self.pci_segments[fs_cfg.pci_segment as usize]
                         .allocator
                         .lock()
                         .unwrap()
-                        .allocate_mmio_addresses(
+                        .allocate(
                             Some(GuestAddress(base)),
                             size as GuestUsize,
                             Some(0x0020_0000),
@@ -2309,12 +2309,11 @@ impl DeviceManager {
                     let size = fs_cfg.cache_size;
                     // The memory needs to be 2MiB aligned in order to support
                     // hugepages.
-                    let base = self
-                        .address_manager
+                    let base = self.pci_segments[fs_cfg.pci_segment as usize]
                         .allocator
                         .lock()
                         .unwrap()
-                        .allocate_mmio_addresses(None, size as GuestUsize, Some(0x0020_0000))
+                        .allocate(None, size as GuestUsize, Some(0x0020_0000))
                         .ok_or(DeviceManagerError::FsRangeAllocation)?;
 
                     (base.raw_value(), size)
@@ -2491,11 +2490,11 @@ impl DeviceManager {
         let (region_base, region_size) = if let Some((base, size)) = region_range {
             // The memory needs to be 2MiB aligned in order to support
             // hugepages.
-            self.address_manager
+            self.pci_segments[pmem_cfg.pci_segment as usize]
                 .allocator
                 .lock()
                 .unwrap()
-                .allocate_mmio_addresses(
+                .allocate(
                     Some(GuestAddress(base)),
                     size as GuestUsize,
                     Some(0x0020_0000),
@@ -2506,12 +2505,11 @@ impl DeviceManager {
         } else {
             // The memory needs to be 2MiB aligned in order to support
             // hugepages.
-            let base = self
-                .address_manager
+            let base = self.pci_segments[pmem_cfg.pci_segment as usize]
                 .allocator
                 .lock()
                 .unwrap()
-                .allocate_mmio_addresses(None, size as GuestUsize, Some(0x0020_0000))
+                .allocate(None, size as GuestUsize, Some(0x0020_0000))
                 .ok_or(DeviceManagerError::PmemRangeAllocation)?;
 
             (base.raw_value(), size)

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3265,6 +3265,11 @@ impl DeviceManager {
         Arc::clone(self.pci_segments[0].pci_config_io.as_ref().unwrap())
     }
 
+    #[cfg(feature = "acpi")]
+    pub(crate) fn pci_segments(&self) -> &Vec<PciSegment> {
+        &self.pci_segments
+    }
+
     pub fn console(&self) -> &Arc<Console> {
         &self.console
     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -948,10 +948,17 @@ impl DeviceManager {
         let start_of_device_area = memory_manager.lock().unwrap().start_of_device_area().0;
         let end_of_device_area = memory_manager.lock().unwrap().end_of_device_area().0;
 
+        let mut pci_irq_slots = [0; 32];
+        PciSegment::reserve_legacy_interrupts_for_pci_devices(
+            &address_manager,
+            &mut pci_irq_slots,
+        )?;
+
         let mut pci_segments = vec![PciSegment::new_default_segment(
             &address_manager,
             start_of_device_area,
             end_of_device_area,
+            &pci_irq_slots,
         )?];
 
         if let Some(platform_config) = config.lock().unwrap().platform.as_ref() {
@@ -961,6 +968,7 @@ impl DeviceManager {
                     &address_manager,
                     start_of_device_area,
                     end_of_device_area,
+                    &pci_irq_slots,
                 )?);
             }
         }

--- a/vmm/src/device_tree.rs
+++ b/vmm/src/device_tree.rs
@@ -16,7 +16,6 @@ pub struct DeviceNode {
     pub children: Vec<String>,
     #[serde(skip)]
     pub migratable: Option<Arc<Mutex<dyn Migratable>>>,
-    pub pci_segment_id: Option<u16>,
     pub pci_bdf: Option<u32>,
     #[serde(skip)]
     pub pci_device_handle: Option<PciDeviceHandle>,
@@ -32,7 +31,6 @@ impl DeviceNode {
             migratable,
             pci_bdf: None,
             pci_device_handle: None,
-            pci_segment_id: None,
         }
     }
 }
@@ -81,20 +79,14 @@ impl DeviceTree {
     pub fn pci_devices(&self) -> Vec<&DeviceNode> {
         self.0
             .values()
-            .filter(|v| {
-                v.pci_bdf.is_some() && v.pci_segment_id.is_some() && v.pci_device_handle.is_some()
-            })
+            .filter(|v| v.pci_bdf.is_some() && v.pci_device_handle.is_some())
             .collect()
     }
 
-    pub fn remove_node_by_pci_bdf(
-        &mut self,
-        pci_segment_id: u16,
-        pci_bdf: u32,
-    ) -> Option<DeviceNode> {
+    pub fn remove_node_by_pci_bdf(&mut self, pci_bdf: u32) -> Option<DeviceNode> {
         let mut id = None;
         for (k, v) in self.0.iter() {
-            if v.pci_segment_id == Some(pci_segment_id) && v.pci_bdf == Some(pci_bdf) {
+            if v.pci_bdf == Some(pci_bdf) {
                 id = Some(k.clone());
                 break;
             }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -29,6 +29,7 @@ use crate::vm::{Error as VmError, Vm, VmState};
 use anyhow::anyhow;
 use libc::EFD_NONBLOCK;
 use memory_manager::MemoryManagerSnapshotData;
+use pci::PciBdf;
 use seccompiler::{apply_filter, SeccompAction};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use std::fs::File;
@@ -206,7 +207,7 @@ impl AsRawFd for EpollContext {
 
 pub struct PciDeviceInfo {
     pub id: String,
-    pub bdf: u32,
+    pub bdf: PciBdf,
 }
 
 impl Serialize for PciDeviceInfo {
@@ -214,15 +215,7 @@ impl Serialize for PciDeviceInfo {
     where
         S: Serializer,
     {
-        // Transform the PCI b/d/f into a standardized string.
-        let segment = (self.bdf >> 16) & 0xffff;
-        let bus = (self.bdf >> 8) & 0xff;
-        let device = (self.bdf >> 3) & 0x1f;
-        let function = self.bdf & 0x7;
-        let bdf_str = format!(
-            "{:04x}:{:02x}:{:02x}.{:01x}",
-            segment, bus, device, function
-        );
+        let bdf_str = self.bdf.to_string();
 
         // Serialize the structure.
         let mut state = serializer.serialize_struct("PciDeviceInfo", 2)?;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1632,6 +1632,10 @@ impl MemoryManager {
             .ok_or(Error::GuestAddressOverFlow)?;
 
         let mut sgx_epc_region = SgxEpcRegion::new(epc_region_start, epc_region_size as GuestUsize);
+        info!(
+            "SGX EPC region: 0x{:x} (0x{:x})",
+            epc_region_start.0, epc_region_size
+        );
 
         // Each section can be memory mapped into the allocated region.
         let mut epc_section_start = epc_region_start.raw_value();
@@ -1664,6 +1668,11 @@ impl MemoryManager {
                     0,
                 )
             } as u64;
+
+            info!(
+                "Adding SGX EPC section: 0x{:x} (0x{:x})",
+                epc_section_start, epc_section.size
+            );
 
             let _mem_slot = self.create_userspace_mapping(
                 epc_section_start,

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -10,10 +10,15 @@
 //
 
 use crate::device_manager::{AddressManager, DeviceManagerError, DeviceManagerResult};
+#[cfg(feature = "acpi")]
+use acpi_tables::aml::{self, Aml};
+use arch::layout;
 use pci::{DeviceRelocation, PciBus, PciConfigMmio, PciRoot};
 #[cfg(target_arch = "x86_64")]
 use pci::{PciConfigIo, PCI_CONFIG_IO_PORT, PCI_CONFIG_IO_PORT_SIZE};
 use std::sync::{Arc, Mutex};
+#[cfg(feature = "acpi")]
+use uuid::Uuid;
 use vm_device::BusDevice;
 
 pub(crate) struct PciSegment {
@@ -31,11 +36,17 @@ pub(crate) struct PciSegment {
     pub(crate) pci_devices_down: u32,
     // List of allocated IRQs for each PCI slot.
     pub(crate) pci_irq_slots: [u8; 32],
+
+    // Device memory covered by this segment
+    pub(crate) start_of_device_area: u64,
+    pub(crate) end_of_device_area: u64,
 }
 
 impl PciSegment {
     pub(crate) fn new_default_segment(
         address_manager: &Arc<AddressManager>,
+        start_of_device_area: u64,
+        end_of_device_area: u64,
     ) -> DeviceManagerResult<PciSegment> {
         let pci_root = PciRoot::new(None);
         let pci_bus = Arc::new(Mutex::new(PciBus::new(
@@ -76,14 +87,16 @@ impl PciSegment {
             pci_irq_slots: [0; 32],
             #[cfg(target_arch = "x86_64")]
             pci_config_io: Some(pci_config_io),
+            start_of_device_area,
+            end_of_device_area,
         };
 
         // Reserve some IRQs for PCI devices in case they need to support INTx.
         segment.reserve_legacy_interrupts_for_pci_devices(address_manager)?;
 
         info!(
-            "Adding PCI segment: id={}, PCI MMIO config address: 0x{:x}",
-            segment.id, segment.mmio_config_address
+            "Adding PCI segment: id={}, PCI MMIO config address: 0x{:x}, device area [0x{:x}-0x{:x}",
+            segment.id, segment.mmio_config_address, segment.start_of_device_area, segment.end_of_device_area
         );
         Ok(segment)
     }
@@ -127,5 +140,259 @@ impl PciSegment {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "acpi")]
+struct PciDevSlot {
+    device_id: u8,
+}
+
+#[cfg(feature = "acpi")]
+impl Aml for PciDevSlot {
+    fn to_aml_bytes(&self) -> Vec<u8> {
+        let sun = self.device_id;
+        let adr: u32 = (self.device_id as u32) << 16;
+        aml::Device::new(
+            format!("S{:03}", self.device_id).as_str().into(),
+            vec![
+                &aml::Name::new("_SUN".into(), &sun),
+                &aml::Name::new("_ADR".into(), &adr),
+                &aml::Method::new(
+                    "_EJ0".into(),
+                    1,
+                    true,
+                    vec![&aml::MethodCall::new(
+                        "\\_SB_.PHPR.PCEJ".into(),
+                        vec![&aml::Path::new("_SUN")],
+                    )],
+                ),
+            ],
+        )
+        .to_aml_bytes()
+    }
+}
+
+#[cfg(feature = "acpi")]
+struct PciDevSlotNotify {
+    device_id: u8,
+}
+
+#[cfg(feature = "acpi")]
+impl Aml for PciDevSlotNotify {
+    fn to_aml_bytes(&self) -> Vec<u8> {
+        let device_id_mask: u32 = 1 << self.device_id;
+        let object = aml::Path::new(&format!("S{:03}", self.device_id));
+        let mut bytes = aml::And::new(&aml::Local(0), &aml::Arg(0), &device_id_mask).to_aml_bytes();
+        bytes.extend_from_slice(
+            &aml::If::new(
+                &aml::Equal::new(&aml::Local(0), &device_id_mask),
+                vec![&aml::Notify::new(&object, &aml::Arg(1))],
+            )
+            .to_aml_bytes(),
+        );
+        bytes
+    }
+}
+
+#[cfg(feature = "acpi")]
+struct PciDevSlotMethods {}
+
+#[cfg(feature = "acpi")]
+impl Aml for PciDevSlotMethods {
+    fn to_aml_bytes(&self) -> Vec<u8> {
+        let mut device_notifies = Vec::new();
+        for device_id in 0..32 {
+            device_notifies.push(PciDevSlotNotify { device_id });
+        }
+
+        let mut device_notifies_refs: Vec<&dyn aml::Aml> = Vec::new();
+        for device_notify in device_notifies.iter() {
+            device_notifies_refs.push(device_notify);
+        }
+
+        let mut bytes =
+            aml::Method::new("DVNT".into(), 2, true, device_notifies_refs).to_aml_bytes();
+
+        bytes.extend_from_slice(
+            &aml::Method::new(
+                "PCNT".into(),
+                0,
+                true,
+                vec![
+                    &aml::MethodCall::new(
+                        "DVNT".into(),
+                        vec![&aml::Path::new("\\_SB_.PHPR.PCIU"), &aml::ONE],
+                    ),
+                    &aml::MethodCall::new(
+                        "DVNT".into(),
+                        vec![&aml::Path::new("\\_SB_.PHPR.PCID"), &3usize],
+                    ),
+                ],
+            )
+            .to_aml_bytes(),
+        );
+        bytes
+    }
+}
+
+#[cfg(feature = "acpi")]
+struct PciDsmMethod {}
+
+#[cfg(feature = "acpi")]
+impl Aml for PciDsmMethod {
+    fn to_aml_bytes(&self) -> Vec<u8> {
+        // Refer to ACPI spec v6.3 Ch 9.1.1 and PCI Firmware spec v3.3 Ch 4.6.1
+        // _DSM (Device Specific Method), the following is the implementation in ASL.
+        /*
+        Method (_DSM, 4, NotSerialized)  // _DSM: Device-Specific Method
+        {
+              If ((Arg0 == ToUUID ("e5c937d0-3553-4d7a-9117-ea4d19c3434d") /* Device Labeling Interface */))
+              {
+                  If ((Arg2 == Zero))
+                  {
+                      Return (Buffer (One) { 0x21 })
+                  }
+                  If ((Arg2 == 0x05))
+                  {
+                      Return (Zero)
+                  }
+              }
+
+              Return (Buffer (One) { 0x00 })
+        }
+         */
+        /*
+         * As per ACPI v6.3 Ch 19.6.142, the UUID is required to be in mixed endian:
+         * Among the fields of a UUID:
+         *   {d1 (8 digits)} - {d2 (4 digits)} - {d3 (4 digits)} - {d4 (16 digits)}
+         * d1 ~ d3 need to be little endian, d4 be big endian.
+         * See https://en.wikipedia.org/wiki/Universally_unique_identifier#Encoding .
+         */
+        let uuid = Uuid::parse_str("E5C937D0-3553-4D7A-9117-EA4D19C3434D").unwrap();
+        let (uuid_d1, uuid_d2, uuid_d3, uuid_d4) = uuid.as_fields();
+        let mut uuid_buf = vec![];
+        uuid_buf.extend(&uuid_d1.to_le_bytes());
+        uuid_buf.extend(&uuid_d2.to_le_bytes());
+        uuid_buf.extend(&uuid_d3.to_le_bytes());
+        uuid_buf.extend(uuid_d4);
+        aml::Method::new(
+            "_DSM".into(),
+            4,
+            false,
+            vec![
+                &aml::If::new(
+                    &aml::Equal::new(&aml::Arg(0), &aml::Buffer::new(uuid_buf)),
+                    vec![
+                        &aml::If::new(
+                            &aml::Equal::new(&aml::Arg(2), &aml::ZERO),
+                            vec![&aml::Return::new(&aml::Buffer::new(vec![0x21]))],
+                        ),
+                        &aml::If::new(
+                            &aml::Equal::new(&aml::Arg(2), &0x05u8),
+                            vec![&aml::Return::new(&aml::ZERO)],
+                        ),
+                    ],
+                ),
+                &aml::Return::new(&aml::Buffer::new(vec![0])),
+            ],
+        )
+        .to_aml_bytes()
+    }
+}
+
+#[cfg(feature = "acpi")]
+impl Aml for PciSegment {
+    fn to_aml_bytes(&self) -> Vec<u8> {
+        let mut pci_dsdt_inner_data: Vec<&dyn aml::Aml> = Vec::new();
+        let hid = aml::Name::new("_HID".into(), &aml::EisaName::new("PNP0A08"));
+        pci_dsdt_inner_data.push(&hid);
+        let cid = aml::Name::new("_CID".into(), &aml::EisaName::new("PNP0A03"));
+        pci_dsdt_inner_data.push(&cid);
+        let adr = aml::Name::new("_ADR".into(), &aml::ZERO);
+        pci_dsdt_inner_data.push(&adr);
+        let seg = aml::Name::new("_SEG".into(), &aml::ZERO);
+        pci_dsdt_inner_data.push(&seg);
+        let uid = aml::Name::new("_UID".into(), &aml::ZERO);
+        pci_dsdt_inner_data.push(&uid);
+        let cca = aml::Name::new("_CCA".into(), &aml::ONE);
+        pci_dsdt_inner_data.push(&cca);
+        let supp = aml::Name::new("SUPP".into(), &aml::ZERO);
+        pci_dsdt_inner_data.push(&supp);
+
+        // Since Cloud Hypervisor supports only one PCI bus, it can be tied
+        // to the NUMA node 0. It's up to the user to organize the NUMA nodes
+        // so that the PCI bus relates to the expected vCPUs and guest RAM.
+        let proximity_domain = 0u32;
+        let pxm_return = aml::Return::new(&proximity_domain);
+        let pxm = aml::Method::new("_PXM".into(), 0, false, vec![&pxm_return]);
+        pci_dsdt_inner_data.push(&pxm);
+
+        let pci_dsm = PciDsmMethod {};
+        pci_dsdt_inner_data.push(&pci_dsm);
+
+        let crs = aml::Name::new(
+            "_CRS".into(),
+            &aml::ResourceTemplate::new(vec![
+                &aml::AddressSpace::new_bus_number(0x0u16, 0x0u16),
+                #[cfg(target_arch = "x86_64")]
+                &aml::Io::new(0xcf8, 0xcf8, 1, 0x8),
+                #[cfg(target_arch = "aarch64")]
+                &aml::Memory32Fixed::new(
+                    true,
+                    layout::PCI_MMCONFIG_START.0 as u32,
+                    layout::PCI_MMCONFIG_SIZE as u32,
+                ),
+                &aml::AddressSpace::new_memory(
+                    aml::AddressSpaceCachable::NotCacheable,
+                    true,
+                    layout::MEM_32BIT_DEVICES_START.0 as u32,
+                    (layout::MEM_32BIT_DEVICES_START.0 + layout::MEM_32BIT_DEVICES_SIZE - 1) as u32,
+                ),
+                &aml::AddressSpace::new_memory(
+                    aml::AddressSpaceCachable::NotCacheable,
+                    true,
+                    self.start_of_device_area,
+                    self.end_of_device_area,
+                ),
+                #[cfg(target_arch = "x86_64")]
+                &aml::AddressSpace::new_io(0u16, 0x0cf7u16),
+                #[cfg(target_arch = "x86_64")]
+                &aml::AddressSpace::new_io(0x0d00u16, 0xffffu16),
+            ]),
+        );
+        pci_dsdt_inner_data.push(&crs);
+
+        let mut pci_devices = Vec::new();
+        for device_id in 0..32 {
+            let pci_device = PciDevSlot { device_id };
+            pci_devices.push(pci_device);
+        }
+        for pci_device in pci_devices.iter() {
+            pci_dsdt_inner_data.push(pci_device);
+        }
+
+        let pci_device_methods = PciDevSlotMethods {};
+        pci_dsdt_inner_data.push(&pci_device_methods);
+
+        // Build PCI routing table, listing IRQs assigned to PCI devices.
+        let prt_package_list: Vec<(u32, u32)> = self
+            .pci_irq_slots
+            .iter()
+            .enumerate()
+            .map(|(i, irq)| (((((i as u32) & 0x1fu32) << 16) | 0xffffu32), *irq as u32))
+            .collect();
+        let prt_package_list: Vec<aml::Package> = prt_package_list
+            .iter()
+            .map(|(bdf, irq)| aml::Package::new(vec![bdf, &0u8, &0u8, irq]))
+            .collect();
+        let prt_package_list: Vec<&dyn Aml> = prt_package_list
+            .iter()
+            .map(|item| item as &dyn Aml)
+            .collect();
+        let prt = aml::Name::new("_PRT".into(), &aml::Package::new(prt_package_list));
+        pci_dsdt_inner_data.push(&prt);
+
+        aml::Device::new("_SB_.PCI0".into(), pci_dsdt_inner_data).to_aml_bytes()
     }
 }

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -393,6 +393,10 @@ impl Aml for PciSegment {
         let prt = aml::Name::new("_PRT".into(), &aml::Package::new(prt_package_list));
         pci_dsdt_inner_data.push(&prt);
 
-        aml::Device::new("_SB_.PCI0".into(), pci_dsdt_inner_data).to_aml_bytes()
+        aml::Device::new(
+            format!("_SB_.PCI{:X}", self.id).as_str().into(),
+            pci_dsdt_inner_data,
+        )
+        .to_aml_bytes()
     }
 }

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -346,11 +346,10 @@ impl Aml for PciSegment {
                 &aml::AddressSpace::new_bus_number(0x0u16, 0x0u16),
                 #[cfg(target_arch = "x86_64")]
                 &aml::Io::new(0xcf8, 0xcf8, 1, 0x8),
-                #[cfg(target_arch = "aarch64")]
                 &aml::Memory32Fixed::new(
                     true,
-                    layout::PCI_MMCONFIG_START.0 as u32,
-                    layout::PCI_MMCONFIG_SIZE as u32,
+                    self.mmio_config_address as u32,
+                    PCI_MMIO_CONFIG_SIZE as u32,
                 ),
                 &aml::AddressSpace::new_memory(
                     aml::AddressSpaceCachable::NotCacheable,

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -311,7 +311,7 @@ impl Aml for PciSegment {
         pci_dsdt_inner_data.push(&cid);
         let adr = aml::Name::new("_ADR".into(), &aml::ZERO);
         pci_dsdt_inner_data.push(&adr);
-        let seg = aml::Name::new("_SEG".into(), &aml::ZERO);
+        let seg = aml::Name::new("_SEG".into(), &self.id);
         pci_dsdt_inner_data.push(&seg);
         let uid = aml::Name::new("_UID".into(), &aml::ZERO);
         pci_dsdt_inner_data.push(&uid);

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -356,35 +356,56 @@ impl Aml for PciSegment {
         let pci_dsm = PciDsmMethod {};
         pci_dsdt_inner_data.push(&pci_dsm);
 
-        let crs = aml::Name::new(
-            "_CRS".into(),
-            &aml::ResourceTemplate::new(vec![
-                &aml::AddressSpace::new_bus_number(0x0u16, 0x0u16),
-                #[cfg(target_arch = "x86_64")]
-                &aml::Io::new(0xcf8, 0xcf8, 1, 0x8),
-                &aml::Memory32Fixed::new(
-                    true,
-                    self.mmio_config_address as u32,
-                    PCI_MMIO_CONFIG_SIZE as u32,
-                ),
-                &aml::AddressSpace::new_memory(
-                    aml::AddressSpaceCachable::NotCacheable,
-                    true,
-                    layout::MEM_32BIT_DEVICES_START.0 as u32,
-                    (layout::MEM_32BIT_DEVICES_START.0 + layout::MEM_32BIT_DEVICES_SIZE - 1) as u32,
-                ),
-                &aml::AddressSpace::new_memory(
-                    aml::AddressSpaceCachable::NotCacheable,
-                    true,
-                    self.start_of_device_area,
-                    self.end_of_device_area,
-                ),
-                #[cfg(target_arch = "x86_64")]
-                &aml::AddressSpace::new_io(0u16, 0x0cf7u16),
-                #[cfg(target_arch = "x86_64")]
-                &aml::AddressSpace::new_io(0x0d00u16, 0xffffu16),
-            ]),
-        );
+        let crs = if self.id == 0 {
+            aml::Name::new(
+                "_CRS".into(),
+                &aml::ResourceTemplate::new(vec![
+                    &aml::AddressSpace::new_bus_number(0x0u16, 0x0u16),
+                    #[cfg(target_arch = "x86_64")]
+                    &aml::Io::new(0xcf8, 0xcf8, 1, 0x8),
+                    &aml::Memory32Fixed::new(
+                        true,
+                        self.mmio_config_address as u32,
+                        PCI_MMIO_CONFIG_SIZE as u32,
+                    ),
+                    &aml::AddressSpace::new_memory(
+                        aml::AddressSpaceCachable::NotCacheable,
+                        true,
+                        layout::MEM_32BIT_DEVICES_START.0 as u32,
+                        (layout::MEM_32BIT_DEVICES_START.0 + layout::MEM_32BIT_DEVICES_SIZE - 1)
+                            as u32,
+                    ),
+                    &aml::AddressSpace::new_memory(
+                        aml::AddressSpaceCachable::NotCacheable,
+                        true,
+                        self.start_of_device_area,
+                        self.end_of_device_area,
+                    ),
+                    #[cfg(target_arch = "x86_64")]
+                    &aml::AddressSpace::new_io(0u16, 0x0cf7u16),
+                    #[cfg(target_arch = "x86_64")]
+                    &aml::AddressSpace::new_io(0x0d00u16, 0xffffu16),
+                ]),
+            )
+        } else {
+            aml::Name::new(
+                "_CRS".into(),
+                &aml::ResourceTemplate::new(vec![
+                    &aml::AddressSpace::new_bus_number(0x0u16, 0x0u16),
+                    &aml::Memory32Fixed::new(
+                        true,
+                        self.mmio_config_address as u32,
+                        PCI_MMIO_CONFIG_SIZE as u32,
+                    ),
+                    &aml::AddressSpace::new_memory(
+                        aml::AddressSpaceCachable::NotCacheable,
+                        true,
+                        self.start_of_device_area,
+                        self.end_of_device_area,
+                    ),
+                ]),
+            )
+        };
         pci_dsdt_inner_data.push(&crs);
 
         let mut pci_devices = Vec::new();

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -189,7 +189,7 @@ impl Aml for PciDevSlot {
                     true,
                     vec![&aml::MethodCall::new(
                         "\\_SB_.PHPR.PCEJ".into(),
-                        vec![&aml::Path::new("_SUN")],
+                        vec![&aml::Path::new("_SUN"), &aml::Path::new("_SEG")],
                     )],
                 ),
             ],
@@ -245,6 +245,8 @@ impl Aml for PciDevSlotMethods {
                 0,
                 true,
                 vec![
+                    &aml::Acquire::new("\\_SB_.PHPR.BLCK".into(), 0xffff),
+                    &aml::Store::new(&aml::Path::new("\\_SB_.PHPR.PSEG"), &aml::Path::new("_SEG")),
                     &aml::MethodCall::new(
                         "DVNT".into(),
                         vec![&aml::Path::new("\\_SB_.PHPR.PCIU"), &aml::ONE],
@@ -253,6 +255,7 @@ impl Aml for PciDevSlotMethods {
                         "DVNT".into(),
                         vec![&aml::Path::new("\\_SB_.PHPR.PCID"), &3usize],
                     ),
+                    &aml::Release::new("\\_SB_.PHPR.BLCK".into()),
                 ],
             )
             .to_aml_bytes(),

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -25,10 +25,10 @@ use vm_device::BusDevice;
 const PCI_MMIO_CONFIG_SIZE: u64 = 4096 * 256;
 
 pub(crate) struct PciSegment {
-    id: u16,
+    pub(crate) id: u16,
     pub(crate) pci_bus: Arc<Mutex<PciBus>>,
     pub(crate) pci_config_mmio: Arc<Mutex<PciConfigMmio>>,
-    mmio_config_address: u64,
+    pub(crate) mmio_config_address: u64,
 
     #[cfg(target_arch = "x86_64")]
     pub(crate) pci_config_io: Option<Arc<Mutex<PciConfigIo>>>,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1096,7 +1096,7 @@ impl Vm {
             device_info,
             &initramfs_config,
             &pci_space,
-            virtio_iommu_bdf,
+            virtio_iommu_bdf.map(|bdf| bdf.into()),
             &*gic_device,
             &self.numa_nodes,
         )


### PR DESCRIPTION
Enable support for multiple PCI segments. This PR adds a new global option `--platform num_pci_segments=<n>` which can be combined with `pci_segment` options added to the majority of device types (console, rng & watchdog are the exceptions) which can then be used to choose which segment to add the chosen device to.

Fixes: #1400 