### PR TITLE
deps: Move to vhost 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,8 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vhost?branch=main#354dd56adf00614f606ff39257a1257c2f6c5b82"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d23ddeb452fb4f837526c6298cc8a2f4948e5595b0328a3d61b5eebe51874d7"
 dependencies = [
  "bitflags",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ clap = { version = "2.33.3", features = ["wrap_help"] }
 [patch.crates-io]
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0", features = ["with-serde", "fam-wrappers"] }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
-vhost = { git = "https://github.com/rust-vmm/vhost", branch = "main", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern"] }
 
 [dev-dependencies]
 credibility = "0.1.3"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "linux-loader",
  "log",
  "serde",
+ "serde_derive",
  "thiserror",
  "versionize",
  "versionize_derive",
@@ -744,8 +745,9 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vhost?branch=main#354dd56adf00614f606ff39257a1257c2f6c5b82"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d23ddeb452fb4f837526c6298cc8a2f4948e5595b0328a3d61b5eebe51874d7"
 dependencies = [
  "bitflags",
  "libc",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,7 +26,6 @@ path = ".."
 [patch.crates-io]
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0", features = ["with-serde", "fam-wrappers"] }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
-vhost = { git = "https://github.com/rust-vmm/vhost", branch = "main", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern"] }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/vhost_user_backend/Cargo.toml
+++ b/vhost_user_backend/Cargo.toml
@@ -15,4 +15,4 @@ virtio-bindings = "0.1.0"
 vm-memory = { version = "0.6.0", features = ["backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"
-vhost = { version = "0.1.0", features = ["vhost-user-slave"] }
+vhost = { version = "0.2.0", features = ["vhost-user-slave"] }

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4.14"
 option_parser = { path = "../option_parser" }
 qcow = { path = "../qcow" }
 vhost_user_backend = { path = "../vhost_user_backend" }
-vhost = { version = "0.1.0", features = ["vhost-user-slave"] }
+vhost = { version = "0.2.0", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
 vm-memory = "0.6.0"
 vmm-sys-util = "0.9.0"

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4.14"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
 vhost_user_backend = { path = "../vhost_user_backend" }
-vhost = { version = "0.1.0", features = ["vhost-user-slave"] }
+vhost = { version = "0.2.0", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
 vm-memory = "0.6.0"
 vmm-sys-util = "0.9.0"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -29,7 +29,7 @@ serde_derive = "1.0.130"
 serde_json = "1.0.68"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vhost = { version = "0.1.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern"] }
+vhost = { version = "0.2.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern"] }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }


### PR DESCRIPTION
There's no need to patch the vhost crate anymore since the fixes we were
looking for have been released as part of 0.2.0 on crates.io.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>