### PR TITLE
workflow: Add vendored source release content

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
+      - name: Create release directory
+        run: rsync -rv --exclude=.git . ../cloud-hypervisor-${{ github.event.ref }}
       - name: Install Rust toolchain (x86_64-unknown-linux-gnu)
         uses: actions-rs/toolchain@v1
         with:
@@ -37,6 +39,13 @@ jobs:
             use-cross: true
             command: build
             args: --all --release --target=aarch64-unknown-linux-musl
+      - name: Vendor
+        working-directory: ../cloud-hypervisor-${{ github.event.ref }}
+        run: |
+          mkdir ../vendor-cargo-home
+          export CARGO_HOME=$(realpath ../vendor-cargo-home)
+          mkdir .cargo
+          cargo vendor > .cargo/config.toml
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -47,6 +56,19 @@ jobs:
           release_name: ${{ github.ref }}
           draft: true
           prerelease: true
+      - name: Create vendored source archive
+        working-directory: ../
+        run:  tar cJf cloud-hypervisor-${{ github.event.ref }}.tar.xz cloud-hypervisor-${{ github.event.ref }}
+      - name: Upload cloud-hypervisor vendored source archive
+        id: upload-release-cloud-hypervisor-vendored-sources
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ../cloud-hypervisor-${{ github.event.ref }}.tar.xz
+          asset_name: cloud-hypervisor-${{ github.event.ref }}.tar.xz
+          asset_content_type: application/x-xz
       - name: Upload cloud-hypervisor
         id: upload-release-cloud-hypervisor
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Create a source archive with vendored sources as part of the release
workflow. This is to enable building the release offline for distros.

Signed-off-by: William Douglas <william.douglas@intel.com>