### PR TITLE
vmm: Naturally align PCI BARs on relocation

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -593,7 +593,7 @@ impl DeviceRelocation for AddressManager {
                         .allocate_mmio_hole_addresses(
                             Some(GuestAddress(new_base)),
                             len as GuestUsize,
-                            None,
+                            Some(len),
                         )
                         .ok_or_else(|| {
                             io::Error::new(
@@ -613,7 +613,7 @@ impl DeviceRelocation for AddressManager {
                         .allocate_mmio_addresses(
                             Some(GuestAddress(new_base)),
                             len as GuestUsize,
-                            None,
+                            Some(len),
                         )
                         .ok_or_else(|| {
                             io::Error::new(


### PR DESCRIPTION
When allocating PCI MMIO BARs they should always be naturally aligned
(i.e. aligned to the size of the BAR itself.)

Signed-off-by: Rob Bradford <robert.bradford@intel.com>