### PR TITLE
hypervisor: Add Misc register to Save/Restore state for MSHV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,7 +564,7 @@ dependencies = [
 [[package]]
 name = "mshv-bindings"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#99da566389546aedb56fc3d279e01c5dbde79bce"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#424f51a5fc40f30a7787576981dd549950677420"
 dependencies = [
  "libc",
  "serde",
@@ -576,7 +576,7 @@ dependencies = [
 [[package]]
 name = "mshv-ioctls"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#99da566389546aedb56fc3d279e01c5dbde79bce"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#424f51a5fc40f30a7787576981dd549950677420"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -174,6 +174,16 @@ pub enum HypervisorCpuError {
     #[error("Failed to get debug registers: {0}")]
     GetDebugRegs(#[source] anyhow::Error),
     ///
+    /// Setting misc register error
+    ///
+    #[error("Failed to set misc registers: {0}")]
+    SetMiscRegs(#[source] anyhow::Error),
+    ///
+    /// Getting misc register error
+    ///
+    #[error("Failed to get misc registers: {0}")]
+    GetMiscRegs(#[source] anyhow::Error),
+    ///
     /// Write to Guest Mem
     ///
     #[error("Failed to write to Guest Mem at: {0}")]

--- a/hypervisor/src/mshv/x86_64/mod.rs
+++ b/hypervisor/src/mshv/x86_64/mod.rs
@@ -18,10 +18,11 @@ pub use {
     mshv_bindings::mshv_user_mem_region as MemoryRegion, mshv_bindings::msr_entry as MsrEntry,
     mshv_bindings::CpuId, mshv_bindings::DebugRegisters,
     mshv_bindings::FloatingPointUnit as FpuState, mshv_bindings::LapicState,
-    mshv_bindings::MsrList, mshv_bindings::Msrs as MsrEntries, mshv_bindings::Msrs,
-    mshv_bindings::SegmentRegister, mshv_bindings::SpecialRegisters,
-    mshv_bindings::StandardRegisters, mshv_bindings::SuspendRegisters, mshv_bindings::VcpuEvents,
-    mshv_bindings::XSave as Xsave, mshv_bindings::Xcrs as ExtendedControlRegisters,
+    mshv_bindings::MiscRegs as MiscRegisters, mshv_bindings::MsrList,
+    mshv_bindings::Msrs as MsrEntries, mshv_bindings::Msrs, mshv_bindings::SegmentRegister,
+    mshv_bindings::SpecialRegisters, mshv_bindings::StandardRegisters,
+    mshv_bindings::SuspendRegisters, mshv_bindings::VcpuEvents, mshv_bindings::XSave as Xsave,
+    mshv_bindings::Xcrs as ExtendedControlRegisters,
 };
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -35,6 +36,7 @@ pub struct VcpuMshvState {
     pub lapic: LapicState,
     pub dbg: DebugRegisters,
     pub xsave: Xsave,
+    pub misc: MiscRegisters,
 }
 
 impl fmt::Display for VcpuMshvState {


### PR DESCRIPTION
Hypercall register needs to be saved and restored for
TLB flush and IPI synthetic features enablement.
Enabling these two synthetic features improves
guest performance.

Signed-off-by: Muminul Islam <muislam@microsoft.com>