### PR TITLE
Dockerfile: Build and install SPDK NVMe to the docker image

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -109,3 +109,20 @@ RUN git clone --depth 1 https://gitlab.com/virtio-fs/qemu.git -b qemu5.0-virtiof
     && make virtiofsd -j `nproc` \
     && cp virtiofsd /usr/local/bin \
     && cd .. && rm -rf qemu
+
+# install SPDK NVMe
+# only for 'x86_64' platform images as 'docker buildx' can't build 'spdk'
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+       git clone https://github.com/spdk/spdk \
+       && cd spdk \
+       && git checkout a827fd7eeca67209d4c0aaad9a3ed55692e7e36e \
+       && git submodule update --init \
+       && apt-get update \
+       && ./scripts/pkgdep.sh \
+       && ./configure --with-vfio-user \
+       && make -j `nproc` \
+       && mkdir /usr/local/bin/spdk-nvme \
+       && cp ./build/bin/nvmf_tgt /usr/local/bin/spdk-nvme \
+       && cp ./scripts/rpc.py /usr/local/bin/spdk-nvme \
+       && cp -r ./scripts/rpc /usr/local/bin/spdk-nvme \
+       && cd .. && rm -rf spdk; fi


### PR DESCRIPTION
We now build SPDK-NVMe inside the container only for the x86_64
platform, as the cross-platform build with 'docker buildx' does not work
for SPDK. For aarch64 the platform, we will build it as a part of the CI
workflow (which is running on the bare-metal machine).

Signed-off-by: Bo Chen <chen.bo@intel.com>