### PR TITLE
build: bump vm-memory from 0.6.0 to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = 3
 name = "acpi_tables"
 version = "0.1.0"
 dependencies = [
- "vm-memory",
+ "vm-memory 0.7.0",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vm-fdt",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -144,7 +144,7 @@ dependencies = [
  "versionize_derive",
  "vhdx",
  "virtio-bindings",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -205,7 +205,7 @@ dependencies = [
  "signal-hook",
  "test_infra",
  "thiserror",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vmm",
  "vmm-sys-util",
  "wait-timeout",
@@ -251,7 +251,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vm-device",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -402,7 +402,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "thiserror",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vmm-sys-util",
 ]
 
@@ -515,7 +515,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a5e77493808403a6bd56a301a64ea6b9342e36ea845044bf0dfdf56fe52fa08"
 dependencies = [
- "vm-memory",
+ "vm-memory 0.7.0",
 ]
 
 [[package]]
@@ -607,7 +607,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "virtio-bindings",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -680,7 +680,7 @@ dependencies = [
  "vfio_user",
  "vm-allocator",
  "vm-device",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -1157,7 +1157,7 @@ dependencies = [
  "mshv-bindings",
  "mshv-ioctls",
  "vfio-bindings",
- "vm-memory",
+ "vm-memory 0.6.0",
  "vmm-sys-util",
 ]
 
@@ -1173,7 +1173,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "vfio-bindings",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vmm-sys-util",
 ]
 
@@ -1199,7 +1199,7 @@ checksum = "2d23ddeb452fb4f837526c6298cc8a2f4948e5595b0328a3d61b5eebe51874d7"
 dependencies = [
  "bitflags",
  "libc",
- "vm-memory",
+ "vm-memory 0.6.0",
  "vmm-sys-util",
 ]
 
@@ -1212,7 +1212,7 @@ dependencies = [
  "log",
  "vhost",
  "virtio-bindings",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -1232,7 +1232,7 @@ dependencies = [
  "vhost",
  "vhost_user_backend",
  "virtio-bindings",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vmm-sys-util",
 ]
 
@@ -1250,7 +1250,7 @@ dependencies = [
  "vhost",
  "vhost_user_backend",
  "virtio-bindings",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vmm-sys-util",
 ]
 
@@ -1287,7 +1287,7 @@ dependencies = [
  "virtio-bindings",
  "vm-allocator",
  "vm-device",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
@@ -1299,7 +1299,7 @@ version = "0.1.0"
 dependencies = [
  "arch",
  "libc",
- "vm-memory",
+ "vm-memory 0.7.0",
 ]
 
 [[package]]
@@ -1312,7 +1312,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "vfio-ioctls",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vmm-sys-util",
 ]
 
@@ -1326,6 +1326,16 @@ name = "vm-memory"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a8ebcb86ca457f9d6e14cf97009f679952eba42f0113de5db596e514cd0e43b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "vm-memory"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339d4349c126fdcd87e034631d7274370cf19eb0e87b33166bcd956589fc72c5"
 dependencies = [
  "arc-swap",
  "libc",
@@ -1343,7 +1353,7 @@ dependencies = [
  "thiserror",
  "versionize",
  "versionize_derive",
- "vm-memory",
+ "vm-memory 0.7.0",
 ]
 
 [[package]]
@@ -1352,7 +1362,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "virtio-bindings",
- "vm-memory",
+ "vm-memory 0.7.0",
 ]
 
 [[package]]
@@ -1395,7 +1405,7 @@ dependencies = [
  "virtio-devices",
  "vm-allocator",
  "vm-device",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ signal-hook = "0.3.10"
 thiserror = "1.0.30"
 vmm = { path = "vmm" }
 vmm-sys-util = "0.9.0"
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 
 [build-dependencies]
 clap = { version = "2.33.3", features = ["wrap_help"] }

--- a/acpi_tables/Cargo.toml
+++ b/acpi_tables/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 
 [dependencies]
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -22,7 +22,7 @@ serde_derive = "1.0.130"
 thiserror = "1.0.30"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }
 

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -18,7 +18,7 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vhdx = { path = "../vhdx" }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"
 

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.14"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-device = { path = "../vm-device" }
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = "0.9.0"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -6,7 +6,7 @@ version = 3
 name = "acpi_tables"
 version = "0.1.0"
 dependencies = [
- "vm-memory",
+ "vm-memory 0.7.0",
 ]
 
 [[package]]
@@ -61,7 +61,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vm-fdt",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -105,7 +105,7 @@ dependencies = [
  "versionize_derive",
  "vhdx",
  "virtio-bindings",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -161,7 +161,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "thiserror",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vmm",
  "vmm-sys-util",
 ]
@@ -178,7 +178,7 @@ dependencies = [
  "seccompiler",
  "vhdx",
  "virtio-devices",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -213,7 +213,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vm-device",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -279,7 +279,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "thiserror",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vmm-sys-util",
 ]
 
@@ -359,7 +359,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a5e77493808403a6bd56a301a64ea6b9342e36ea845044bf0dfdf56fe52fa08"
 dependencies = [
- "vm-memory",
+ "vm-memory 0.6.0",
 ]
 
 [[package]]
@@ -401,7 +401,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "virtio-bindings",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -433,7 +433,7 @@ dependencies = [
  "vfio_user",
  "vm-allocator",
  "vm-device",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -709,7 +709,7 @@ dependencies = [
  "kvm-ioctls",
  "log",
  "vfio-bindings",
- "vm-memory",
+ "vm-memory 0.6.0",
  "vmm-sys-util",
 ]
 
@@ -725,7 +725,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "vfio-bindings",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vmm-sys-util",
 ]
 
@@ -751,7 +751,7 @@ checksum = "2d23ddeb452fb4f837526c6298cc8a2f4948e5595b0328a3d61b5eebe51874d7"
 dependencies = [
  "bitflags",
  "libc",
- "vm-memory",
+ "vm-memory 0.6.0",
  "vmm-sys-util",
 ]
 
@@ -788,7 +788,7 @@ dependencies = [
  "virtio-bindings",
  "vm-allocator",
  "vm-device",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
@@ -800,7 +800,7 @@ version = "0.1.0"
 dependencies = [
  "arch",
  "libc",
- "vm-memory",
+ "vm-memory 0.7.0",
 ]
 
 [[package]]
@@ -813,7 +813,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "vfio-ioctls",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vmm-sys-util",
 ]
 
@@ -827,6 +827,16 @@ name = "vm-memory"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a8ebcb86ca457f9d6e14cf97009f679952eba42f0113de5db596e514cd0e43b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "vm-memory"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339d4349c126fdcd87e034631d7274370cf19eb0e87b33166bcd956589fc72c5"
 dependencies = [
  "arc-swap",
  "libc",
@@ -844,7 +854,7 @@ dependencies = [
  "thiserror",
  "versionize",
  "versionize_derive",
- "vm-memory",
+ "vm-memory 0.7.0",
 ]
 
 [[package]]
@@ -853,7 +863,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "virtio-bindings",
- "vm-memory",
+ "vm-memory 0.7.0",
 ]
 
 [[package]]
@@ -895,7 +905,7 @@ dependencies = [
  "virtio-devices",
  "vm-allocator",
  "vm-device",
- "vm-memory",
+ "vm-memory 0.7.0",
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,7 +18,7 @@ vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
 vmm-sys-util = "0.9.0"
 vm-virtio = { path = "../vm-virtio" }
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 
 [dependencies.cloud-hypervisor]
 path = ".."

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -23,7 +23,7 @@ mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optio
 serde = { version = "1.0.130", features = ["rc"] }
 serde_derive = "1.0.130"
 serde_json = "1.0.68"
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -15,7 +15,7 @@ serde = "1.0.130"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 virtio-bindings = "0.1.0"
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"
 

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -23,7 +23,7 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 vm-migration = { path = "../vm-migration" }
 
 [dependencies.vfio-bindings]

--- a/vfio_user/Cargo.toml
+++ b/vfio_user/Cargo.toml
@@ -12,7 +12,7 @@ serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 thiserror = "1.0.30"
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = ">=0.3.1"
 
 [dependencies.vfio-bindings]

--- a/vhost_user_backend/Cargo.toml
+++ b/vhost_user_backend/Cargo.toml
@@ -12,7 +12,7 @@ epoll = "4.3.1"
 libc = "0.2.104"
 log = "0.4.14"
 virtio-bindings = "0.1.0"
-vm-memory = { version = "0.6.0", features = ["backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"
 vhost = { version = "0.2.0", features = ["vhost-user-slave"] }

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -16,5 +16,5 @@ qcow = { path = "../qcow" }
 vhost_user_backend = { path = "../vhost_user_backend" }
 vhost = { version = "0.2.0", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 vmm-sys-util = "0.9.0"

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -15,5 +15,5 @@ option_parser = { path = "../option_parser" }
 vhost_user_backend = { path = "../vhost_user_backend" }
 vhost = { version = "0.2.0", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 vmm-sys-util = "0.9.0"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -33,7 +33,7 @@ vhost = { version = "0.2.0", features = ["vhost-user-master", "vhost-user-slave"
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.104"
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 arch = { path = "../arch" }

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -16,6 +16,6 @@ serde = { version = "1.0.130", features = ["rc"] }
 serde_derive = "1.0.130"
 serde_json = "1.0.68"
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "main", default-features = false }
-vm-memory = { version = "0.6.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
 vmm-sys-util = "0.9.0"
 

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -12,4 +12,4 @@ serde_derive = "1.0.130"
 serde_json = "1.0.68"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -10,4 +10,4 @@ default = []
 [dependencies]
 log = "0.4.14"
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -50,7 +50,7 @@ vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }


### PR DESCRIPTION
We need to bump both Cloud Hypervisor and fuzz building targets at the same time to avoid errors.

Signed-off-by: Bo Chen <chen.bo@intel.com>