### PR TITLE
build: Exclude dependabot from DCO check workflow

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -15,4 +15,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         pip3 install -U dco-check
-        dco-check
+        dco-check -e "49699333+dependabot[bot]@users.noreply.github.com"


### PR DESCRIPTION
PRs from dependabot are failing to meet the check from DCO as the
Signed-Off-By is now a GitHub support email address.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>