### PR TITLE
vmm: Move logging output for the debug (0x80) port to info!()

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -372,7 +372,7 @@ impl VmOps {
     fn log_debug_ioport(&self, code: u8) {
         let elapsed = self.timestamp.elapsed();
 
-        debug!(
+        info!(
             "[{} code 0x{:x}] {}.{:>06} seconds",
             DebugIoPortRange::from_u8(code),
             code,


### PR DESCRIPTION
This makes it much easier to use since the info!() level produces far
fewer messages and thus has less overhead.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>