### PR TITLE
pci: vfio: Support mapping BAR containing MSI-X

### DIFF
--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -533,4 +533,16 @@ impl MsixCap {
     pub fn table_size(&self) -> u16 {
         (self.msg_ctl & 0x7ff) + 1
     }
+
+    pub fn table_range(&self) -> (u64, u64) {
+        // The table takes 16 bytes per entry.
+        let size = self.table_size() as u64 * 16;
+        (self.table_offset() as u64, size)
+    }
+
+    pub fn pba_range(&self) -> (u64, u64) {
+        // The table takes 1 bit per entry modulo 8 bytes.
+        let size = ((self.table_size() as u64 / 64) + 1) * 8;
+        (self.pba_offset() as u64, size)
+    }
 }


### PR DESCRIPTION
In order to get proper performance out of hardware that might be passed
through the VM with VFIO, we decide to try mapping any region marked as
mappable, ignoring the failure and moving on to the next region. When
the mapping succeeds, we establish a list of user memory regions so that
we enable only subparts of the global mapping through the hypervisor.
This allows MSI-X table and PBA to keep trapping accesses from the guest
so that the VMM can properly emulate MSI-X.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>