### PR TITLE
Avoid excessive vector allocations in ACPI DSDT generation code

### DIFF
--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -354,15 +354,13 @@ impl Memory32Fixed {
 }
 
 impl Aml for Memory32Fixed {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x86]; /* Memory32Fixed */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x86); /* Memory32Fixed */
         bytes.append(&mut 9u16.to_le_bytes().to_vec());
-
         // 9 bytes of payload
         bytes.push(self.read_write as u8);
         bytes.append(&mut self.base.to_le_bytes().to_vec());
         bytes.append(&mut self.length.to_le_bytes().to_vec());
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -6,7 +6,15 @@
 use std::marker::PhantomData;
 
 pub trait Aml {
-    fn to_aml_bytes(&self) -> Vec<u8>;
+    fn append_aml_bytes(&self, _v: &mut Vec<u8>) {
+        unimplemented!()
+    }
+
+    fn to_aml_bytes(&self) -> Vec<u8> {
+        let mut v = Vec::new();
+        self.append_aml_bytes(&mut v);
+        v
+    }
 }
 
 pub const ZERO: Zero = Zero {};

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -303,36 +303,31 @@ pub struct ResourceTemplate<'a> {
 }
 
 impl<'a> Aml for ResourceTemplate<'a> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        let mut tmp = Vec::new();
         // Add buffer data
         for child in &self.children {
-            bytes.append(&mut child.to_aml_bytes());
+            tmp.append(&mut child.to_aml_bytes());
         }
 
         // Mark with end and mark checksum as as always valid
-        bytes.push(0x79); /* EndTag */
-        bytes.push(0); /* zero checksum byte */
+        tmp.push(0x79); /* EndTag */
+        tmp.push(0); /* zero checksum byte */
 
         // Buffer length is an encoded integer including buffer data
         // and EndTag and checksum byte
-        let mut buffer_length = bytes.len().to_aml_bytes();
+        let mut buffer_length = tmp.len().to_aml_bytes();
         buffer_length.reverse();
         for byte in buffer_length {
-            bytes.insert(0, byte);
+            tmp.insert(0, byte);
         }
 
         // PkgLength is everything else
-        let mut pkg_length = create_pkg_length(&bytes, true);
-        pkg_length.reverse();
-        for byte in pkg_length {
-            bytes.insert(0, byte);
-        }
+        let mut pkg_length = create_pkg_length(&tmp, true);
 
-        bytes.insert(0, 0x11); /* BufferOp */
-
-        bytes
+        bytes.push(0x11); /* BufferOp */
+        bytes.append(&mut pkg_length);
+        bytes.append(&mut tmp);
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -842,11 +842,9 @@ impl<'a> Aml for LessThan<'a> {
 pub struct Arg(pub u8);
 
 impl Aml for Arg {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         assert!(self.0 <= 6);
         bytes.push(0x68 + self.0); /* Arg0Op */
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -851,11 +851,9 @@ impl Aml for Arg {
 pub struct Local(pub u8);
 
 impl Aml for Local {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         assert!(self.0 <= 7);
         bytes.push(0x60 + self.0); /* Local0Op */
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -494,16 +494,14 @@ impl Io {
 }
 
 impl Aml for Io {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x47]; /* Io Port Descriptor */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x47); /* Io Port Descriptor */
 
         bytes.push(1); /* IODecode16 */
         bytes.append(&mut self.min.to_le_bytes().to_vec());
         bytes.append(&mut self.max.to_le_bytes().to_vec());
         bytes.push(self.alignment);
         bytes.push(self.length);
-
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -531,8 +531,8 @@ impl Interrupt {
 }
 
 impl Aml for Interrupt {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x89]; /* Extended IRQ Descriptor */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x89); /* Extended IRQ Descriptor */
         bytes.append(&mut 6u16.to_le_bytes().to_vec());
         let flags = (self.shared as u8) << 3
             | (self.active_low as u8) << 2
@@ -541,8 +541,6 @@ impl Aml for Interrupt {
         bytes.push(flags);
         bytes.push(1u8); /* count */
         bytes.append(&mut self.number.to_le_bytes().to_vec());
-
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -1037,13 +1037,11 @@ impl<'a> MethodCall<'a> {
 }
 
 impl<'a> Aml for MethodCall<'a> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(&self.name.to_aml_bytes());
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        self.name.append_aml_bytes(bytes);
         for arg in self.args.iter() {
             bytes.extend_from_slice(&arg.to_aml_bytes());
         }
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -136,8 +136,10 @@ pub struct Name {
 }
 
 impl Aml for Name {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        self.bytes.clone()
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        // TODO: Refactor this to make more efficient but there are
+        // lifetime/ownership challenges.
+        bytes.append(&mut self.bytes.clone())
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -578,21 +578,18 @@ pub struct Scope<'a> {
 }
 
 impl<'a> Aml for Scope<'a> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        bytes.append(&mut self.path.to_aml_bytes());
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        let mut tmp = Vec::new();
+        tmp.append(&mut self.path.to_aml_bytes());
         for child in &self.children {
-            bytes.append(&mut child.to_aml_bytes());
+            tmp.append(&mut child.to_aml_bytes());
         }
 
-        let mut pkg_length = create_pkg_length(&bytes, true);
-        pkg_length.reverse();
-        for byte in pkg_length {
-            bytes.insert(0, byte);
-        }
+        let mut pkg_length = create_pkg_length(&tmp, true);
 
-        bytes.insert(0, 0x10); /* ScopeOp */
-        bytes
+        bytes.push(0x10); /* ScopeOp */
+        bytes.append(&mut pkg_length);
+        bytes.append(&mut tmp)
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -927,11 +927,10 @@ impl Release {
 }
 
 impl Aml for Release {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x5b]; /* ExtOpPrefix */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x5b); /* ExtOpPrefix */
         bytes.push(0x27); /* ReleaseOp */
-        bytes.extend_from_slice(&self.mutex.to_aml_bytes());
-        bytes
+        self.mutex.append_aml_bytes(bytes);
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -908,12 +908,11 @@ impl Acquire {
 }
 
 impl Aml for Acquire {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x5b]; /* ExtOpPrefix */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x5b); /* ExtOpPrefix */
         bytes.push(0x23); /* AcquireOp */
-        bytes.extend_from_slice(&self.mutex.to_aml_bytes());
+        self.mutex.append_aml_bytes(bytes);
         bytes.extend_from_slice(&self.timeout.to_le_bytes());
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -533,14 +533,14 @@ impl Interrupt {
 impl Aml for Interrupt {
     fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         bytes.push(0x89); /* Extended IRQ Descriptor */
-        bytes.append(&mut 6u16.to_le_bytes().to_vec());
+        bytes.extend_from_slice(&6u16.to_le_bytes());
         let flags = (self.shared as u8) << 3
             | (self.active_low as u8) << 2
             | (self.edge_triggered as u8) << 1
             | self.consumer as u8;
         bytes.push(flags);
         bytes.push(1u8); /* count */
-        bytes.append(&mut self.number.to_le_bytes().to_vec());
+        bytes.extend_from_slice(&self.number.to_le_bytes());
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -786,21 +786,18 @@ impl<'a> If<'a> {
 }
 
 impl<'a> Aml for If<'a> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(&self.predicate.to_aml_bytes());
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        let mut tmp = Vec::new();
+        tmp.extend_from_slice(&self.predicate.to_aml_bytes());
         for child in self.if_children.iter() {
-            bytes.extend_from_slice(&child.to_aml_bytes());
+            tmp.extend_from_slice(&child.to_aml_bytes());
         }
 
-        let mut pkg_length = create_pkg_length(&bytes, true);
-        pkg_length.reverse();
-        for byte in pkg_length {
-            bytes.insert(0, byte);
-        }
+        let mut pkg_length = create_pkg_length(&tmp, true);
 
-        bytes.insert(0, 0xa0); /* IfOp */
-        bytes
+        bytes.push(0xa0); /* IfOp */
+        bytes.append(&mut pkg_length);
+        bytes.append(&mut tmp);
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -646,10 +646,9 @@ impl<'a> Return<'a> {
 }
 
 impl<'a> Aml for Return<'a> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0xa4]; /* ReturnOp */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0xa4); /* ReturnOp */
         bytes.append(&mut self.value.to_aml_bytes());
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -68,7 +68,7 @@ impl Aml for Path {
         };
 
         for part in self.name_parts.clone().iter_mut() {
-            bytes.append(&mut part.to_vec());
+            bytes.extend_from_slice(&part.to_vec());
         }
     }
 }
@@ -139,7 +139,7 @@ impl Aml for Name {
     fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         // TODO: Refactor this to make more efficient but there are
         // lifetime/ownership challenges.
-        bytes.append(&mut self.bytes.clone())
+        bytes.extend_from_slice(&self.bytes.clone())
     }
 }
 
@@ -163,11 +163,11 @@ impl<'a> Aml for Package<'a> {
             child.append_aml_bytes(&mut tmp);
         }
 
-        let mut pkg_length = create_pkg_length(&tmp, true);
+        let pkg_length = create_pkg_length(&tmp, true);
 
         bytes.push(0x12); /* PackageOp */
-        bytes.append(&mut pkg_length);
-        bytes.append(&mut tmp);
+        bytes.extend_from_slice(&pkg_length);
+        bytes.extend_from_slice(&tmp);
     }
 }
 
@@ -323,11 +323,11 @@ impl<'a> Aml for ResourceTemplate<'a> {
         }
 
         // PkgLength is everything else
-        let mut pkg_length = create_pkg_length(&tmp, true);
+        let pkg_length = create_pkg_length(&tmp, true);
 
         bytes.push(0x11); /* BufferOp */
-        bytes.append(&mut pkg_length);
-        bytes.append(&mut tmp);
+        bytes.extend_from_slice(&pkg_length);
+        bytes.extend_from_slice(&tmp);
     }
 }
 
@@ -558,12 +558,12 @@ impl<'a> Aml for Device<'a> {
             child.append_aml_bytes(&mut tmp);
         }
 
-        let mut pkg_length = create_pkg_length(&tmp, true);
+        let pkg_length = create_pkg_length(&tmp, true);
 
         bytes.push(0x5b); /* ExtOpPrefix */
         bytes.push(0x82); /* DeviceOp */
-        bytes.append(&mut pkg_length);
-        bytes.append(&mut tmp);
+        bytes.extend_from_slice(&pkg_length);
+        bytes.extend_from_slice(&tmp);
     }
 }
 
@@ -586,11 +586,11 @@ impl<'a> Aml for Scope<'a> {
             child.append_aml_bytes(&mut tmp);
         }
 
-        let mut pkg_length = create_pkg_length(&tmp, true);
+        let pkg_length = create_pkg_length(&tmp, true);
 
         bytes.push(0x10); /* ScopeOp */
-        bytes.append(&mut pkg_length);
-        bytes.append(&mut tmp)
+        bytes.extend_from_slice(&pkg_length);
+        bytes.extend_from_slice(&tmp)
     }
 }
 
@@ -628,11 +628,11 @@ impl<'a> Aml for Method<'a> {
             child.append_aml_bytes(&mut tmp);
         }
 
-        let mut pkg_length = create_pkg_length(&tmp, true);
+        let pkg_length = create_pkg_length(&tmp, true);
 
         bytes.push(0x14); /* MethodOp */
-        bytes.append(&mut pkg_length);
-        bytes.append(&mut tmp)
+        bytes.extend_from_slice(&pkg_length);
+        bytes.extend_from_slice(&tmp)
     }
 }
 
@@ -711,21 +711,21 @@ impl Aml for Field {
             match field {
                 FieldEntry::Named(name, length) => {
                     tmp.extend_from_slice(name);
-                    tmp.append(&mut create_pkg_length(&vec![0; *length], false));
+                    tmp.extend_from_slice(&create_pkg_length(&vec![0; *length], false));
                 }
                 FieldEntry::Reserved(length) => {
                     tmp.push(0x0);
-                    tmp.append(&mut create_pkg_length(&vec![0; *length], false));
+                    tmp.extend_from_slice(&create_pkg_length(&vec![0; *length], false));
                 }
             }
         }
 
-        let mut pkg_length = create_pkg_length(&tmp, true);
+        let pkg_length = create_pkg_length(&tmp, true);
 
         bytes.push(0x5b); /* ExtOpPrefix */
         bytes.push(0x81); /* FieldOp */
-        bytes.append(&mut pkg_length);
-        bytes.append(&mut tmp)
+        bytes.extend_from_slice(&pkg_length);
+        bytes.extend_from_slice(&tmp)
     }
 }
 
@@ -794,11 +794,11 @@ impl<'a> Aml for If<'a> {
             child.append_aml_bytes(&mut tmp);
         }
 
-        let mut pkg_length = create_pkg_length(&tmp, true);
+        let pkg_length = create_pkg_length(&tmp, true);
 
         bytes.push(0xa0); /* IfOp */
-        bytes.append(&mut pkg_length);
-        bytes.append(&mut tmp);
+        bytes.extend_from_slice(&pkg_length);
+        bytes.extend_from_slice(&tmp);
     }
 }
 
@@ -976,11 +976,11 @@ impl<'a> Aml for While<'a> {
             child.append_aml_bytes(&mut tmp)
         }
 
-        let mut pkg_length = create_pkg_length(&tmp, true);
+        let pkg_length = create_pkg_length(&tmp, true);
 
         bytes.push(0xa2); /* WhileOp */
-        bytes.append(&mut pkg_length);
-        bytes.append(&mut tmp);
+        bytes.extend_from_slice(&pkg_length);
+        bytes.extend_from_slice(&tmp);
     }
 }
 
@@ -1062,11 +1062,11 @@ impl Aml for Buffer {
         self.data.len().append_aml_bytes(&mut tmp);
         tmp.extend_from_slice(&self.data);
 
-        let mut pkg_length = create_pkg_length(&tmp, true);
+        let pkg_length = create_pkg_length(&tmp, true);
 
         bytes.push(0x11); /* BufferOp */
-        bytes.append(&mut pkg_length);
-        bytes.append(&mut tmp);
+        bytes.extend_from_slice(&pkg_length);
+        bytes.extend_from_slice(&tmp);
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -416,7 +416,7 @@ impl<T> AddressSpace<T> {
 
     fn push_header(&self, bytes: &mut Vec<u8>, descriptor: u8, length: usize) {
         bytes.push(descriptor); /* Word Address Space Descriptor */
-        bytes.append(&mut (length as u16).to_le_bytes().to_vec());
+        bytes.extend_from_slice(&(length as u16).to_le_bytes());
         bytes.push(self.r#type as u8); /* type */
         let generic_flags = 1 << 2 /* Min Fixed */ | 1 << 3; /* Max Fixed */
         bytes.push(generic_flags);
@@ -425,65 +425,53 @@ impl<T> AddressSpace<T> {
 }
 
 impl Aml for AddressSpace<u16> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         self.push_header(
-            &mut bytes,
+            bytes,
             0x88,                               /* Word Address Space Descriptor */
             3 + 5 * std::mem::size_of::<u16>(), /* 3 bytes of header + 5 u16 fields */
         );
 
-        bytes.append(&mut 0u16.to_le_bytes().to_vec()); /* Granularity */
-        bytes.append(&mut self.min.to_le_bytes().to_vec()); /* Min */
-        bytes.append(&mut self.max.to_le_bytes().to_vec()); /* Max */
-        bytes.append(&mut 0u16.to_le_bytes().to_vec()); /* Translation */
+        bytes.extend_from_slice(&0u16.to_le_bytes()); /* Granularity */
+        bytes.extend_from_slice(&self.min.to_le_bytes()); /* Min */
+        bytes.extend_from_slice(&self.max.to_le_bytes()); /* Max */
+        bytes.extend_from_slice(&0u16.to_le_bytes()); /* Translation */
         let len = self.max - self.min + 1;
-        bytes.append(&mut len.to_le_bytes().to_vec()); /* Length */
-
-        bytes
+        bytes.extend_from_slice(&len.to_le_bytes()); /* Length */
     }
 }
 
 impl Aml for AddressSpace<u32> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         self.push_header(
-            &mut bytes,
+            bytes,
             0x87,                               /* DWord Address Space Descriptor */
             3 + 5 * std::mem::size_of::<u32>(), /* 3 bytes of header + 5 u32 fields */
         );
 
-        bytes.append(&mut 0u32.to_le_bytes().to_vec()); /* Granularity */
-        bytes.append(&mut self.min.to_le_bytes().to_vec()); /* Min */
-        bytes.append(&mut self.max.to_le_bytes().to_vec()); /* Max */
-        bytes.append(&mut 0u32.to_le_bytes().to_vec()); /* Translation */
+        bytes.extend_from_slice(&0u32.to_le_bytes()); /* Granularity */
+        bytes.extend_from_slice(&self.min.to_le_bytes()); /* Min */
+        bytes.extend_from_slice(&self.max.to_le_bytes()); /* Max */
+        bytes.extend_from_slice(&0u32.to_le_bytes()); /* Translation */
         let len = self.max - self.min + 1;
-        bytes.append(&mut len.to_le_bytes().to_vec()); /* Length */
-
-        bytes
+        bytes.extend_from_slice(&len.to_le_bytes()); /* Length */
     }
 }
 
 impl Aml for AddressSpace<u64> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         self.push_header(
-            &mut bytes,
+            bytes,
             0x8A,                               /* QWord Address Space Descriptor */
             3 + 5 * std::mem::size_of::<u64>(), /* 3 bytes of header + 5 u64 fields */
         );
 
-        bytes.append(&mut 0u64.to_le_bytes().to_vec()); /* Granularity */
-        bytes.append(&mut self.min.to_le_bytes().to_vec()); /* Min */
-        bytes.append(&mut self.max.to_le_bytes().to_vec()); /* Max */
-        bytes.append(&mut 0u64.to_le_bytes().to_vec()); /* Translation */
+        bytes.extend_from_slice(&0u64.to_le_bytes()); /* Granularity */
+        bytes.extend_from_slice(&self.min.to_le_bytes()); /* Min */
+        bytes.extend_from_slice(&self.max.to_le_bytes()); /* Max */
+        bytes.extend_from_slice(&0u64.to_le_bytes()); /* Translation */
         let len = self.max - self.min + 1;
-        bytes.append(&mut len.to_le_bytes().to_vec()); /* Length */
-
-        bytes
+        bytes.extend_from_slice(&len.to_le_bytes()); /* Length */
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -109,7 +109,7 @@ pub type Word = u16;
 impl Aml for Word {
     fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         bytes.push(0x0b); /* WordPrefix */
-        bytes.append(&mut self.to_le_bytes().to_vec());
+        bytes.extend_from_slice(&self.to_le_bytes())
     }
 }
 
@@ -118,7 +118,7 @@ pub type DWord = u32;
 impl Aml for DWord {
     fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         bytes.push(0x0c); /* DWordPrefix */
-        bytes.append(&mut self.to_le_bytes().to_vec());
+        bytes.extend_from_slice(&self.to_le_bytes())
     }
 }
 
@@ -127,7 +127,7 @@ pub type QWord = u64;
 impl Aml for QWord {
     fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         bytes.push(0x0e); /* QWordPrefix */
-        bytes.append(&mut self.to_le_bytes().to_vec());
+        bytes.extend_from_slice(&self.to_le_bytes())
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -813,11 +813,10 @@ impl<'a> Equal<'a> {
 }
 
 impl<'a> Aml for Equal<'a> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x93]; /* LEqualOp */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x93); /* LEqualOp */
         bytes.extend_from_slice(&self.left.to_aml_bytes());
         bytes.extend_from_slice(&self.right.to_aml_bytes());
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -356,11 +356,11 @@ impl Memory32Fixed {
 impl Aml for Memory32Fixed {
     fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         bytes.push(0x86); /* Memory32Fixed */
-        bytes.append(&mut 9u16.to_le_bytes().to_vec());
+        bytes.extend_from_slice(&9u16.to_le_bytes());
         // 9 bytes of payload
         bytes.push(self.read_write as u8);
-        bytes.append(&mut self.base.to_le_bytes().to_vec());
-        bytes.append(&mut self.length.to_le_bytes().to_vec());
+        bytes.extend_from_slice(&self.base.to_le_bytes());
+        bytes.extend_from_slice(&self.length.to_le_bytes());
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -1056,20 +1056,16 @@ impl Buffer {
 }
 
 impl Aml for Buffer {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(&self.data.len().to_aml_bytes());
-        bytes.extend_from_slice(&self.data);
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        let mut tmp = Vec::new();
+        tmp.extend_from_slice(&self.data.len().to_aml_bytes());
+        tmp.extend_from_slice(&self.data);
 
-        let mut pkg_length = create_pkg_length(&bytes, true);
-        pkg_length.reverse();
-        for byte in pkg_length {
-            bytes.insert(0, byte);
-        }
+        let mut pkg_length = create_pkg_length(&tmp, true);
 
-        bytes.insert(0, 0x11); /* BufferOp */
-
-        bytes
+        bytes.push(0x11); /* BufferOp */
+        bytes.append(&mut pkg_length);
+        bytes.append(&mut tmp);
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -968,21 +968,18 @@ impl<'a> While<'a> {
 }
 
 impl<'a> Aml for While<'a> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(&self.predicate.to_aml_bytes());
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        let mut tmp = Vec::new();
+        tmp.extend_from_slice(&self.predicate.to_aml_bytes());
         for child in self.while_children.iter() {
-            bytes.extend_from_slice(&child.to_aml_bytes());
+            tmp.extend_from_slice(&child.to_aml_bytes());
         }
 
-        let mut pkg_length = create_pkg_length(&bytes, true);
-        pkg_length.reverse();
-        for byte in pkg_length {
-            bytes.insert(0, byte);
-        }
+        let mut pkg_length = create_pkg_length(&tmp, true);
 
-        bytes.insert(0, 0xa2); /* WhileOp */
-        bytes
+        bytes.push(0xa2); /* WhileOp */
+        bytes.append(&mut pkg_length);
+        bytes.append(&mut tmp);
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -832,11 +832,10 @@ impl<'a> LessThan<'a> {
 }
 
 impl<'a> Aml for LessThan<'a> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x95]; /* LLessOp */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x95); /* LLessOp */
         bytes.extend_from_slice(&self.left.to_aml_bytes());
         bytes.extend_from_slice(&self.right.to_aml_bytes());
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -618,23 +618,20 @@ impl<'a> Method<'a> {
 }
 
 impl<'a> Aml for Method<'a> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        bytes.append(&mut self.path.to_aml_bytes());
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        let mut tmp = Vec::new();
+        tmp.append(&mut self.path.to_aml_bytes());
         let flags: u8 = (self.args & 0x7) | (self.serialized as u8) << 3;
-        bytes.push(flags);
+        tmp.push(flags);
         for child in &self.children {
-            bytes.append(&mut child.to_aml_bytes());
+            tmp.append(&mut child.to_aml_bytes());
         }
 
-        let mut pkg_length = create_pkg_length(&bytes, true);
-        pkg_length.reverse();
-        for byte in pkg_length {
-            bytes.insert(0, byte);
-        }
+        let mut pkg_length = create_pkg_length(&tmp, true);
 
-        bytes.insert(0, 0x14); /* MethodOp */
-        bytes
+        bytes.push(0x14); /* MethodOp */
+        bytes.append(&mut pkg_length);
+        bytes.append(&mut tmp)
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -1088,22 +1088,20 @@ impl<'a, T> CreateField<'a, T> {
 }
 
 impl<'a> Aml for CreateField<'a, u64> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x8f]; /* CreateQWordFieldOp */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x8f); /* CreateQWordFieldOp */
         bytes.extend_from_slice(&self.buffer.to_aml_bytes());
         bytes.extend_from_slice(&self.offset.to_aml_bytes());
-        bytes.extend_from_slice(&self.field.to_aml_bytes());
-        bytes
+        self.field.append_aml_bytes(bytes);
     }
 }
 
 impl<'a> Aml for CreateField<'a, u32> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x8a]; /* CreateDWordFieldOp */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x8a); /* CreateDWordFieldOp */
         bytes.extend_from_slice(&self.buffer.to_aml_bytes());
         bytes.extend_from_slice(&self.offset.to_aml_bytes());
-        bytes.extend_from_slice(&self.field.to_aml_bytes());
-        bytes
+        self.field.append_aml_bytes(bytes);
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -998,12 +998,11 @@ macro_rules! binary_op {
         }
 
         impl<'a> Aml for $name<'a> {
-            fn to_aml_bytes(&self) -> Vec<u8> {
-                let mut bytes = vec![$opcode]; /* Op for the binary operator */
+            fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+                bytes.push($opcode); /* Op for the binary operator */
                 bytes.extend_from_slice(&self.a.to_aml_bytes());
                 bytes.extend_from_slice(&self.b.to_aml_bytes());
                 bytes.extend_from_slice(&self.target.to_aml_bytes());
-                bytes
             }
         }
     };

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -157,21 +157,17 @@ pub struct Package<'a> {
 }
 
 impl<'a> Aml for Package<'a> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![self.children.len() as u8];
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        let mut tmp = vec![self.children.len() as u8];
         for child in &self.children {
-            bytes.append(&mut child.to_aml_bytes());
+            tmp.append(&mut child.to_aml_bytes());
         }
 
-        let mut pkg_length = create_pkg_length(&bytes, true);
-        pkg_length.reverse();
-        for byte in pkg_length {
-            bytes.insert(0, byte);
-        }
+        let mut pkg_length = create_pkg_length(&tmp, true);
 
-        bytes.insert(0, 0x12); /* PackageOp */
-
-        bytes
+        bytes.push(0x12); /* PackageOp */
+        bytes.append(&mut pkg_length);
+        bytes.append(&mut tmp);
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -260,23 +260,19 @@ impl Aml for EisaName {
     }
 }
 
-fn create_integer(v: usize) -> Vec<u8> {
-    if v <= u8::max_value().into() {
-        (v as u8).to_aml_bytes()
-    } else if v <= u16::max_value().into() {
-        (v as u16).to_aml_bytes()
-    } else if v <= u32::max_value() as usize {
-        (v as u32).to_aml_bytes()
-    } else {
-        (v as u64).to_aml_bytes()
-    }
-}
-
 pub type Usize = usize;
 
 impl Aml for Usize {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        create_integer(*self)
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        if *self <= u8::max_value().into() {
+            (*self as u8).append_aml_bytes(bytes)
+        } else if *self <= u16::max_value().into() {
+            (*self as u16).append_aml_bytes(bytes)
+        } else if *self <= u32::max_value() as usize {
+            (*self as u32).append_aml_bytes(bytes)
+        } else {
+            (*self as u64).append_aml_bytes(bytes)
+        }
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -761,15 +761,13 @@ impl OpRegion {
 }
 
 impl Aml for OpRegion {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        bytes.append(&mut self.path.to_aml_bytes());
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x5b); /* ExtOpPrefix */
+        bytes.push(0x80); /* OpRegionOp */
+        self.path.append_aml_bytes(bytes);
         bytes.push(self.space as u8);
-        bytes.extend_from_slice(&self.offset.to_aml_bytes()); /* RegionOffset */
-        bytes.extend_from_slice(&self.length.to_aml_bytes()); /* RegionLen */
-        bytes.insert(0, 0x80); /* OpRegionOp */
-        bytes.insert(0, 0x5b); /* ExtOpPrefix */
-        bytes
+        self.offset.append_aml_bytes(bytes); /* RegionOffset */
+        self.length.append_aml_bytes(bytes); /* RegionLen */
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -276,26 +276,25 @@ impl Aml for Usize {
     }
 }
 
-fn create_aml_string(v: &str) -> Vec<u8> {
-    let mut data = vec![0x0D]; /* String Op */
-    data.extend_from_slice(v.as_bytes());
-    data.push(0x0); /* NullChar */
-    data
+fn append_aml_string(v: &str, bytes: &mut Vec<u8>) {
+    bytes.push(0x0D); /* String Op */
+    bytes.extend_from_slice(v.as_bytes());
+    bytes.push(0x0); /* NullChar */
 }
 
 pub type AmlStr = &'static str;
 
 impl Aml for AmlStr {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        create_aml_string(self)
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        append_aml_string(self, bytes)
     }
 }
 
 pub type AmlString = String;
 
 impl Aml for AmlString {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        create_aml_string(self)
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        append_aml_string(self, bytes)
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -550,22 +550,19 @@ pub struct Device<'a> {
 }
 
 impl<'a> Aml for Device<'a> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        bytes.append(&mut self.path.to_aml_bytes());
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        let mut tmp = Vec::new();
+        tmp.append(&mut self.path.to_aml_bytes());
         for child in &self.children {
-            bytes.append(&mut child.to_aml_bytes());
+            tmp.append(&mut child.to_aml_bytes());
         }
 
-        let mut pkg_length = create_pkg_length(&bytes, true);
-        pkg_length.reverse();
-        for byte in pkg_length {
-            bytes.insert(0, byte);
-        }
+        let mut pkg_length = create_pkg_length(&tmp, true);
 
-        bytes.insert(0, 0x82); /* DeviceOp */
-        bytes.insert(0, 0x5b); /* ExtOpPrefix */
-        bytes
+        bytes.push(0x5b); /* ExtOpPrefix */
+        bytes.push(0x82); /* DeviceOp */
+        bytes.append(&mut pkg_length);
+        bytes.append(&mut tmp);
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -21,8 +21,8 @@ pub const ZERO: Zero = Zero {};
 pub struct Zero {}
 
 impl Aml for Zero {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        vec![0u8]
+    fn append_aml_bytes(&self, v: &mut Vec<u8>) {
+        v.push(0u8)
     }
 }
 
@@ -30,8 +30,8 @@ pub const ONE: One = One {};
 pub struct One {}
 
 impl Aml for One {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        vec![1u8]
+    fn append_aml_bytes(&self, v: &mut Vec<u8>) {
+        v.push(1u8)
     }
 }
 
@@ -39,8 +39,8 @@ pub const ONES: Ones = Ones {};
 pub struct Ones {}
 
 impl Aml for Ones {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        vec![0xffu8]
+    fn append_aml_bytes(&self, v: &mut Vec<u8>) {
+        v.push(0xffu8)
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -869,11 +869,10 @@ impl<'a> Store<'a> {
 }
 
 impl<'a> Aml for Store<'a> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x70]; /* StoreOp */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x70); /* StoreOp */
         bytes.extend_from_slice(&self.value.to_aml_bytes());
         bytes.extend_from_slice(&self.name.to_aml_bytes());
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -255,8 +255,8 @@ impl EisaName {
 }
 
 impl Aml for EisaName {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        self.value.to_aml_bytes()
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        self.value.append_aml_bytes(bytes)
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -946,11 +946,10 @@ impl<'a> Notify<'a> {
 }
 
 impl<'a> Aml for Notify<'a> {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x86]; /* NotifyOp */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x86); /* NotifyOp */
         bytes.extend_from_slice(&self.object.to_aml_bytes());
         bytes.extend_from_slice(&self.value.to_aml_bytes());
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -496,10 +496,9 @@ impl Io {
 impl Aml for Io {
     fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         bytes.push(0x47); /* Io Port Descriptor */
-
         bytes.push(1); /* IODecode16 */
-        bytes.append(&mut self.min.to_le_bytes().to_vec());
-        bytes.append(&mut self.max.to_le_bytes().to_vec());
+        bytes.extend_from_slice(&self.min.to_le_bytes());
+        bytes.extend_from_slice(&self.max.to_le_bytes());
         bytes.push(self.alignment);
         bytes.push(self.length);
     }

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -50,9 +50,7 @@ pub struct Path {
 }
 
 impl Aml for Path {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         if self.root {
             bytes.push(b'\\');
         }
@@ -72,8 +70,6 @@ impl Aml for Path {
         for part in self.name_parts.clone().iter_mut() {
             bytes.append(&mut part.to_vec());
         }
-
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -98,40 +98,36 @@ impl From<&str> for Path {
 pub type Byte = u8;
 
 impl Aml for Byte {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x0a]; /* BytePrefix */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x0a); /* BytePrefix */
         bytes.push(*self);
-        bytes
     }
 }
 
 pub type Word = u16;
 
 impl Aml for Word {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x0bu8]; /* WordPrefix */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x0b); /* WordPrefix */
         bytes.append(&mut self.to_le_bytes().to_vec());
-        bytes
     }
 }
 
 pub type DWord = u32;
 
 impl Aml for DWord {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x0c]; /* DWordPrefix */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x0c); /* DWordPrefix */
         bytes.append(&mut self.to_le_bytes().to_vec());
-        bytes
     }
 }
 
 pub type QWord = u64;
 
 impl Aml for QWord {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x0e]; /* QWordPrefix */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x0e); /* QWordPrefix */
         bytes.append(&mut self.to_le_bytes().to_vec());
-        bytes
     }
 }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -888,12 +888,11 @@ impl Mutex {
 }
 
 impl Aml for Mutex {
-    fn to_aml_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0x5b]; /* ExtOpPrefix */
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(0x5b); /* ExtOpPrefix */
         bytes.push(0x01); /* MutexOp */
-        bytes.extend_from_slice(&self.path.to_aml_bytes());
+        self.path.append_aml_bytes(bytes);
         bytes.push(self.sync_level);
-        bytes
     }
 }
 

--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -104,7 +104,7 @@ impl BusDevice for AcpiGedDevice {
 
 #[cfg(feature = "acpi")]
 impl Aml for AcpiGedDevice {
-    fn to_aml_bytes(&self) -> Vec<u8> {
+    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
         aml::Device::new(
             "_SB_.GED_".into(),
             vec![
@@ -165,7 +165,7 @@ impl Aml for AcpiGedDevice {
                 ),
             ],
         )
-        .to_aml_bytes()
+        .append_aml_bytes(bytes)
     }
 }
 

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -176,9 +176,12 @@ pub fn create_dsdt_table(
     // DSDT
     let mut dsdt = Sdt::new(*b"DSDT", 36, 6, *b"CLOUDH", *b"CHDSDT  ", 1);
 
-    dsdt.append_slice(device_manager.lock().unwrap().to_aml_bytes().as_slice());
-    dsdt.append_slice(cpu_manager.lock().unwrap().to_aml_bytes().as_slice());
-    dsdt.append_slice(memory_manager.lock().unwrap().to_aml_bytes().as_slice());
+    let mut bytes = Vec::new();
+
+    device_manager.lock().unwrap().append_aml_bytes(&mut bytes);
+    cpu_manager.lock().unwrap().append_aml_bytes(&mut bytes);
+    memory_manager.lock().unwrap().append_aml_bytes(&mut bytes);
+    dsdt.append_slice(&bytes);
 
     dsdt
 }

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -19,6 +19,7 @@ use arch::NumaNodes;
 use bitflags::bitflags;
 use pci::PciBdf;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryRegion};
 
 /* Values for Type in APIC sub-headers */
@@ -483,6 +484,7 @@ pub fn create_acpi_tables(
     memory_manager: &Arc<Mutex<MemoryManager>>,
     numa_nodes: &NumaNodes,
 ) -> GuestAddress {
+    let start_time = Instant::now();
     let mut prev_tbl_len: u64;
     let mut prev_tbl_off: GuestAddress;
     let rsdp_offset = arch::layout::RSDP_POINTER;
@@ -649,5 +651,9 @@ pub fn create_acpi_tables(
         .write_slice(rsdp.as_slice(), rsdp_offset)
         .expect("Error writing RSDP");
 
+    info!(
+        "Generated ACPI tables: took {}µs",
+        Instant::now().duration_since(start_time).as_micros()
+    );
     rsdp_offset
 }


### PR DESCRIPTION
Rather than merging lots of small vectors together instead append onto an existing vector.

With the very simple ACPI DSDT table using:

`target/debug/cloud-hypervisor --kernel ~/src/linux/arch/x86/boot/compressed/vmlinux.bin --cmdline "root=/dev/vda1 console=hvc0" --disk path=~/workloads/focal-server-cloudimg-amd64-custom-20210609-0.raw --api-socket /tmp/api -v`

Before: 
Release: cloud-hypervisor: 38.050611ms: <vmm> INFO:vmm/src/acpi.rs:654 -- Generated ACPI tables: took 351µs
Debug: cloud-hypervisor: 47.688808ms: <vmm> INFO:vmm/src/acpi.rs:654 -- Generated ACPI tables: took 3709µs

After:
Release: cloud-hypervisor: 36.574091ms: <vmm> INFO:vmm/src/acpi.rs:657 -- Generated ACPI tables: took 193µs
Debug: cloud-hypervisor: 42.434992ms: <vmm> INFO:vmm/src/acpi.rs:657 -- Generated ACPI tables: took 2192µs

More complex tables using multiple PCI segments and multiple vCPUs show more significant wins:

`target/debug/cloud-hypervisor --kernel ~/src/linux/arch/x86/boot/compressed/vmlinux.bin --cmdline "root=/dev/vda1 console=hvc0" --disk path=~/workloads/focal-server-cloudimg-amd64-custom-20210609-0.raw --api-socket /tmp/api -v --platform num_pci_segments=16 --cpus boot=8,max=64`

Before:
Release: cloud-hypervisor: 45.515136ms: <vmm> INFO:vmm/src/acpi.rs:654 -- Generated ACPI tables: took 2683µs
Debug: cloud-hypervisor: 77.225887ms: <vmm> INFO:vmm/src/acpi.rs:654 -- Generated ACPI tables: took 37072µs

After:
Release: cloud-hypervisor: 38.980083ms: <vmm> INFO:vmm/src/acpi.rs:657 -- Generated ACPI tables: took 1589µs
Debug: cloud-hypervisor: 63.856359ms: <vmm> INFO:vmm/src/acpi.rs:657 -- Generated ACPI tables: took 21926µs
