### PR TITLE
option_parser: Allow commas for lists

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -446,17 +446,20 @@ integer of 8 bits.
 
 For instance, if one needs to attach all CPUs from 0 to 4 to a specific node,
 the syntax using `-` will help define a contiguous range with `cpus=0-4`. The
-same example could also be described with `cpus=0:1:2:3:4`.
+same example could also be described with `cpus=[0,1,2,3,4]`.
 
-A combination of both `-` and `:` separators is useful when one might need to
+A combination of both `-` and `,` separators is useful when one might need to
 describe a list containing all CPUs from 0 to 99 and the CPU 255, as it could
-simply be described with `cpus=0-99:255`.
+simply be described with `cpus=[0-99,255]`.
+
+As soon as one tries to describe a list of values, `[` and `]` must be used to
+demarcate the list.
 
 _Example_
 
 ```
 --cpus boot=8
---numa guest_numa_id=0,cpus=1-3:7 guest_numa_id=1,cpus=0:4-6
+--numa guest_numa_id=0,cpus=[1-3,7] guest_numa_id=1,cpus=[0,4-6]
 ```
 
 ### `distances`
@@ -473,7 +476,10 @@ node. The second value is an unsigned integer of 8 bits as it represents the
 distance between the current NUMA node and the destination NUMA node. The two
 values are separated by `@` (`value1@value2`), meaning the destination NUMA
 node `value1` is located at a distance of `value2`. Each tuple is separated
-from the others with `:` separator.
+from the others with `,` separator.
+
+As soon as one tries to describe a list of values, `[` and `]` must be used to
+demarcate the list.
 
 For instance, if one wants to define 3 NUMA nodes, with each node located at
 different distances, it can be described with the following example.
@@ -481,7 +487,7 @@ different distances, it can be described with the following example.
 _Example_
 
 ```
---numa guest_numa_id=0,distances=1@15:2@25 guest_numa_id=1,distances=0@15:2@20 guest_numa_id=2,distances=0@25:1@20
+--numa guest_numa_id=0,distances=[1@15,2@25] guest_numa_id=1,distances=[0@15,2@20] guest_numa_id=2,distances=[0@25,1@20]
 ```
 
 ### `memory_zones`
@@ -498,7 +504,10 @@ workload run more efficiently.
 
 Multiple values can be provided to define the list. Each value is a string
 referring to an existing memory zone identifier. Values are separated from
-each other with the `:` separator.
+each other with the `,` separator.
+
+As soon as one tries to describe a list of values, `[` and `]` must be used to
+demarcate the list.
 
 Note that a memory zone must belong to a single NUMA node. The following
 configuration is incorrect, therefore not allowed:
@@ -509,7 +518,7 @@ _Example_
 ```
 --memory size=0
 --memory-zone id=mem0,size=1G id=mem1,size=1G id=mem2,size=1G
---numa guest_numa_id=0,memory_zones=mem0:mem2 guest_numa_id=1,memory_zones=mem1
+--numa guest_numa_id=0,memory_zones=[mem0,mem2] guest_numa_id=1,memory_zones=mem1
 ```
 
 ### `sgx_epc_sections`
@@ -520,13 +529,16 @@ which must be seen by the guest as belonging to the NUMA node `guest_numa_id`.
 
 Multiple values can be provided to define the list. Each value is a string
 referring to an existing SGX EPC section identifier. Values are separated from
-each other with the `:` separator.
+each other with the `,` separator.
+
+As soon as one tries to describe a list of values, `[` and `]` must be used to
+demarcate the list.
 
 _Example_
 
 ```
 --sgx-epc id=epc0,size=32M id=epc1,size=64M id=epc2,size=32M
---numa guest_numa_id=0,sgx_epc_sections=epc1 guest_numa_id=1,sgx_epc_sections=epc0:epc2
+--numa guest_numa_id=0,sgx_epc_sections=epc1 guest_numa_id=1,sgx_epc_sections=[epc0,epc2]
 ```
 
 ### PCI bus

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -49,7 +49,26 @@ impl OptionParser {
             return Ok(());
         }
 
-        let options_list: Vec<&str> = input.trim().split(',').collect();
+        let mut options_list: Vec<String> = Vec::new();
+        let mut merge_elements = false;
+        for element in input.trim().split(',') {
+            if merge_elements {
+                if let Some(last) = options_list.last_mut() {
+                    *last = format!("{},{}", last, element);
+                } else {
+                    return Err(OptionParserError::InvalidSyntax(input.to_owned()));
+                }
+            } else {
+                options_list.push(element.to_string());
+            }
+
+            if element.contains('[') {
+                merge_elements = true;
+            }
+            if element.contains(']') {
+                merge_elements = false;
+            }
+        }
 
         for option in options_list.iter() {
             let parts: Vec<&str> = option.split('=').collect();

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -50,9 +50,9 @@ impl OptionParser {
         }
 
         let mut options_list: Vec<String> = Vec::new();
-        let mut merge_elements = false;
+        let mut opened_brackets: usize = 0;
         for element in input.trim().split(',') {
-            if merge_elements {
+            if opened_brackets > 0 {
                 if let Some(last) = options_list.last_mut() {
                     *last = format!("{},{}", last, element);
                 } else {
@@ -62,11 +62,12 @@ impl OptionParser {
                 options_list.push(element.to_string());
             }
 
-            if element.contains('[') {
-                merge_elements = true;
-            }
-            if element.contains(']') {
-                merge_elements = false;
+            opened_brackets += element.matches('[').count();
+            let closing_brackets = element.matches(']').count();
+            if closing_brackets > opened_brackets {
+                return Err(OptionParserError::InvalidSyntax(input.to_owned()));
+            } else {
+                opened_brackets -= closing_brackets;
             }
         }
 

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -202,7 +202,11 @@ impl FromStr for IntegerList {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let mut integer_list = Vec::new();
-        let ranges_list: Vec<&str> = s.trim().split(':').collect();
+        let ranges_list: Vec<&str> = s
+            .trim()
+            .trim_matches(|c| c == '[' || c == ']')
+            .split(',')
+            .collect();
 
         for range in ranges_list.iter() {
             let items: Vec<&str> = range.split('-').collect();
@@ -246,7 +250,11 @@ impl FromStr for TupleTwoIntegers {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let mut list = Vec::new();
-        let tuples_list: Vec<&str> = s.trim().split(':').collect();
+        let tuples_list: Vec<&str> = s
+            .trim()
+            .trim_matches(|c| c == '[' || c == ']')
+            .split(',')
+            .collect();
 
         for tuple in tuples_list.iter() {
             let items: Vec<&str> = tuple.split('@').collect();
@@ -281,7 +289,12 @@ impl FromStr for StringList {
     type Err = StringListParseError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        let string_list: Vec<String> = s.trim().split(':').map(|e| e.to_owned()).collect();
+        let string_list: Vec<String> = s
+            .trim()
+            .trim_matches(|c| c == '[' || c == ']')
+            .split(',')
+            .map(|e| e.to_owned())
+            .collect();
 
         Ok(StringList(string_list))
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1136,9 +1136,9 @@ mod tests {
             ])
             .args(&[
                 "--numa",
-                "guest_numa_id=0,cpus=0-2:9,distances=1@15:2@20,memory_zones=mem0",
-                "guest_numa_id=1,cpus=3-4:6-8,distances=0@20:2@25,memory_zones=mem1",
-                "guest_numa_id=2,cpus=5:10-11,distances=0@25:1@30,memory_zones=mem2",
+                "guest_numa_id=0,cpus=[0-2,9],distances=[1@15,2@20],memory_zones=mem0",
+                "guest_numa_id=1,cpus=[3-4,6-8],distances=[0@20,2@25],memory_zones=mem1",
+                "guest_numa_id=2,cpus=[5,10-11],distances=[0@25,1@30],memory_zones=mem2",
             ])
             .args(&["--kernel", kernel_path.to_str().unwrap()])
             .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
@@ -5580,7 +5580,7 @@ mod tests {
                 .args(&[
                     "--net",
                     &format!(
-                        "fd={}:{},mac={},num_queues={}",
+                        "fd=[{},{}],mac={},num_queues={}",
                         taps[0].as_raw_fd(),
                         taps[1].as_raw_fd(),
                         guest.network.guest_mac,
@@ -7114,9 +7114,9 @@ mod tests {
                     "id=mem1,size=1G,hotplug_size=32G",
                     "id=mem2,size=1G,hotplug_size=32G",
                     "--numa",
-                    "guest_numa_id=0,cpus=0-2:9,distances=1@15:2@20,memory_zones=mem0",
-                    "guest_numa_id=1,cpus=3-4:6-8,distances=0@20:2@25,memory_zones=mem1",
-                    "guest_numa_id=2,cpus=5:10-11,distances=0@25:1@30,memory_zones=mem2",
+                    "guest_numa_id=0,cpus=[0-2,9],distances=[1@15,2@20],memory_zones=mem0",
+                    "guest_numa_id=1,cpus=[3-4,6-8],distances=[0@20,2@25],memory_zones=mem1",
+                    "guest_numa_id=2,cpus=[5,10-11],distances=[0@25,1@30],memory_zones=mem2",
                 ]
             } else {
                 &["--memory", "size=4G"]

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -6,7 +6,7 @@
 use clap::ArgMatches;
 use net_util::MacAddr;
 use option_parser::{
-    ByteSized, IntegerList, OptionParser, OptionParserError, StringList, Toggle, TupleTwoIntegers,
+    ByteSized, IntegerList, OptionParser, OptionParserError, StringList, Toggle, Tuple,
 };
 use std::collections::HashMap;
 use std::convert::From;
@@ -1942,7 +1942,7 @@ impl NumaConfig {
             .map_err(Error::ParseNuma)?
             .map(|v| v.0.iter().map(|e| *e as u8).collect());
         let distances = parser
-            .convert::<TupleTwoIntegers>("distances")
+            .convert::<Tuple<u64>>("distances")
             .map_err(Error::ParseNuma)?
             .map(|v| {
                 v.0.iter()

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1136,7 +1136,7 @@ impl Default for NetConfig {
 
 impl NetConfig {
     pub const SYNTAX: &'static str = "Network parameters \
-    \"tap=<if_name>,ip=<ip_addr>,mask=<net_mask>,mac=<mac_addr>,fd=<fd1:fd2...>,iommu=on|off,\
+    \"tap=<if_name>,ip=<ip_addr>,mask=<net_mask>,mac=<mac_addr>,fd=<fd1,fd2...>,iommu=on|off,\
     num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,id=<device_id>,\
     vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>,vhost_mode=client|server,\
     bw_size=<bytes>,bw_one_time_burst=<bytes>,bw_refill_time=<ms>,\
@@ -2653,7 +2653,7 @@ mod tests {
         );
 
         assert_eq!(
-            NetConfig::parse("mac=de:ad:be:ef:12:34,fd=3:7,num_queues=4")?,
+            NetConfig::parse("mac=de:ad:be:ef:12:34,fd=[3,7],num_queues=4")?,
             NetConfig {
                 mac: MacAddr::parse_str("de:ad:be:ef:12:34").unwrap(),
                 fds: Some(vec![3, 7]),


### PR DESCRIPTION
Extend the parser by allowing lists to be defined with commas as the delimiter. This can only work when lists are demarcated with `[` and `]` in order to identify them.
This PR allows for something like this to work:
```
--param option1=v1,option2=[v2,v3,v4],option3=v5
```