### PR TITLE
rpm: Document and extend the spec file so it can be built on Copr

### DIFF
--- a/rpm/cloud-hypervisor.spec
+++ b/rpm/cloud-hypervisor.spec
@@ -5,6 +5,7 @@
 #   targets installed.
 
 %define using_rustup 1
+%define using_musl_libc 1
 
 Name:           cloud-hypervisor
 Summary:        Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM.
@@ -47,11 +48,13 @@ install -d %{buildroot}%{_libdir}/cloud-hypervisor
 install -D -m755 target/x86_64-unknown-linux-gnu/release/vhost_user_block %{buildroot}%{_libdir}/cloud-hypervisor
 install -D -m755 target/x86_64-unknown-linux-gnu/release/vhost_user_net %{buildroot}%{_libdir}/cloud-hypervisor
 
+%if 0%{?using_musl_libc}
 install -d %{buildroot}%{_libdir}/cloud-hypervisor/static
 install -D -m755 target/x86_64-unknown-linux-musl/release/cloud-hypervisor %{buildroot}%{_libdir}/cloud-hypervisor/static
 install -D -m755 target/x86_64-unknown-linux-musl/release/vhost_user_block %{buildroot}%{_libdir}/cloud-hypervisor/static
 install -D -m755 target/x86_64-unknown-linux-musl/release/vhost_user_net %{buildroot}%{_libdir}/cloud-hypervisor/static
 install -D -m755 target/x86_64-unknown-linux-musl/release/ch-remote %{buildroot}%{_libdir}/cloud-hypervisor/static
+%endif
 
 
 %build
@@ -75,14 +78,18 @@ rustup target list --installed | grep x86_64-unknown-linux-gnu
 if [[ $? -ne 0 ]]; then
          echo "Target  x86_64-unknown-linux-gnu not found, please install(#rustup target add x86_64-unknown-linux-gnu). exiting"
 fi
+	%if 0%{?using_musl_libc}
 rustup target list --installed | grep x86_64-unknown-linux-musl
 if [[ $? -ne 0 ]]; then
          echo "Target  x86_64-unknown-linux-musl not found, please install(#rustup target add x86_64-unknown-linux-musl). exiting"
 fi
+	%endif
 %endif
 
 cargo build --release --target=x86_64-unknown-linux-gnu --all
+%if 0%{?using_musl_libc}
 cargo build --release --target=x86_64-unknown-linux-musl --all
+%endif
 
 
 %clean
@@ -98,8 +105,10 @@ rm -rf %{buildroot}
 %post
 setcap cap_net_admin+ep %{_bindir}/cloud-hypervisor
 setcap cap_net_admin+ep %{_libdir}/cloud-hypervisor/vhost_user_net
+%if 0%{?using_musl_libc}
 setcap cap_net_admin+ep %{_libdir}/cloud-hypervisor/static/cloud-hypervisor
 setcap cap_net_admin+ep %{_libdir}/cloud-hypervisor/static/vhost_user_net
+%endif
 
 
 %changelog

--- a/rpm/cloud-hypervisor.spec
+++ b/rpm/cloud-hypervisor.spec
@@ -4,6 +4,8 @@
 # * You have both x86_64-unknown-linux-gnu and  x86_64-unknown-linux-musl
 #   targets installed.
 
+%define using_rustup 1
+
 Name:           cloud-hypervisor
 Summary:        Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM.
 Version:        19.0
@@ -18,7 +20,7 @@ BuildRequires:  glibc-devel
 BuildRequires:  binutils
 BuildRequires:  git
 
-%if 0%{?fedora} || 0%{?rhel}
+%if ! 0%{?using_rustup}
 BuildRequires:  rust
 BuildRequires:  cargo
 %endif
@@ -58,11 +60,17 @@ if [[ $? -ne 0 ]]; then
 	echo "Cargo not found, please install cargo. exiting"
 	exit 0
 fi
+
+%if 0%{?using_rustup}
 which rustup
 if [[ $? -ne 0 ]]; then
 	echo "Rustup not found please install rustup #curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
 fi
+%endif
+
 echo ${cargo_version}
+
+%if 0%{?using_rustup}
 rustup target list --installed | grep x86_64-unknown-linux-gnu
 if [[ $? -ne 0 ]]; then
          echo "Target  x86_64-unknown-linux-gnu not found, please install(#rustup target add x86_64-unknown-linux-gnu). exiting"
@@ -71,6 +79,7 @@ rustup target list --installed | grep x86_64-unknown-linux-musl
 if [[ $? -ne 0 ]]; then
          echo "Target  x86_64-unknown-linux-musl not found, please install(#rustup target add x86_64-unknown-linux-musl). exiting"
 fi
+%endif
 
 cargo build --release --target=x86_64-unknown-linux-gnu --all
 cargo build --release --target=x86_64-unknown-linux-musl --all

--- a/rpm/cloud-hypervisor.spec
+++ b/rpm/cloud-hypervisor.spec
@@ -1,3 +1,9 @@
+# This spec file assumes you're building on an environment where:
+# * You have access to the internet during the build
+# * You have rustup installed on your system
+# * You have both x86_64-unknown-linux-gnu and  x86_64-unknown-linux-musl
+#   targets installed.
+
 Name:           cloud-hypervisor
 Summary:        Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM.
 Version:        19.0


### PR DESCRIPTION
This PR documents the basic assumptions on the environment that users will use to build the Cloud Hypervisor RPM, and together with this adds two definitions to the spec file: `using_rustup` and `using_musl_libc`.

With those two definitions we can easily ensure the RPM will be built on Copr using the (basic) distro dependencies.

Copr repo: https://copr.fedorainfracloud.org/coprs/fidencio/cloud-hypervisor/

Note that this is the very first part of a work that will, at the very first, allow us to figure out which are possible / obvious problems we could and will face when installing and running this on Fedora and, possibly, on Fedora CoreOS.

I am super fine on having this PR as a draft for now if that's the preference of the maintainers.  The same way I'm fine about dropping small fixes here and there while I dive a little bit deeper on this.