### PR TITLE
clippy: Make sure to initialize data

### DIFF
--- a/net_util/src/mac.rs
+++ b/net_util/src/mac.rs
@@ -161,7 +161,7 @@ mod tests {
 
         let mac = MacAddr::parse_str("12:34:56:78:9a:BC").unwrap();
 
-        println!("parsed MAC address: {}", mac.to_string());
+        println!("parsed MAC address: {}", mac);
 
         let bytes = mac.get_bytes();
         assert_eq!(bytes, [0x12u8, 0x34, 0x56, 0x78, 0x9a, 0xbc]);

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -174,7 +174,7 @@ impl Response {
 unsafe impl ByteValued for Response {}
 
 #[repr(C)]
-#[derive(Clone, Serialize, Deserialize, Versionize)]
+#[derive(Clone, Default, Serialize, Deserialize, Versionize)]
 pub struct MemoryRange {
     pub gpa: u64,
     pub length: u64,
@@ -227,10 +227,11 @@ impl MemoryRangeTable {
     pub fn read_from(fd: &mut dyn Read, length: u64) -> Result<MemoryRangeTable, MigratableError> {
         assert!(length as usize % std::mem::size_of::<MemoryRange>() == 0);
 
-        let mut data = Vec::with_capacity(length as usize / (std::mem::size_of::<MemoryRange>()));
-        unsafe {
-            data.set_len(length as usize / (std::mem::size_of::<MemoryRange>()));
-        }
+        let mut data: Vec<MemoryRange> = Vec::new();
+        data.resize_with(
+            length as usize / (std::mem::size_of::<MemoryRange>()),
+            Default::default,
+        );
         fd.read_exact(unsafe {
             std::slice::from_raw_parts_mut(
                 data.as_ptr() as *mut MemoryRange as *mut u8,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -760,10 +760,8 @@ impl Vmm {
         T: Read + Write,
     {
         // Read in config data along with memory manager data
-        let mut data = Vec::with_capacity(req.length() as usize);
-        unsafe {
-            data.set_len(req.length() as usize);
-        }
+        let mut data: Vec<u8> = Vec::new();
+        data.resize_with(req.length() as usize, Default::default);
         socket
             .read_exact(&mut data)
             .map_err(MigratableError::MigrateSocket)?;
@@ -818,10 +816,8 @@ impl Vmm {
         T: Read + Write,
     {
         // Read in state data
-        let mut data = Vec::with_capacity(req.length() as usize);
-        unsafe {
-            data.set_len(req.length() as usize);
-        }
+        let mut data: Vec<u8> = Vec::new();
+        data.resize_with(req.length() as usize, Default::default);
         socket
             .read_exact(&mut data)
             .map_err(MigratableError::MigrateSocket)?;


### PR DESCRIPTION
Always properly initialize vectors so that we don't run in undefined behaviors when the vector gets dropped.

Fixes #3311