### PR TITLE
Add quality checks for cargo-doc

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -4,7 +4,7 @@ on: [pull_request, create]
 jobs:
   build:
     if: github.event_name == 'pull_request'
-    name: Quality (clippy, rustfmt)
+    name: Quality (clippy, rustfmt, rustdoc)
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -56,6 +56,12 @@ jobs:
 
       - name: Clippy (integration tests)
         run: cargo clippy --all --all-targets --tests --features "integration_tests" -- -D warnings
+
+      - name: Doc (all features,kvm)
+        run: RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --no-default-features --features "common,kvm"
+
+      - name: Doc (all features,mshv)
+        run: RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --no-default-features --features "common,mshv"
 
       - name: Check build did not modify any files
         run: test -z "$(git status --porcelain)"

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -318,7 +318,7 @@ const DEBUG_IOPORT_PREFIX: &str = "Debug I/O port";
 
 #[cfg(target_arch = "x86_64")]
 /// Debug I/O port, see:
-/// https://www.intel.com/content/www/us/en/support/articles/000005500/boards-and-kits.html
+/// <https://www.intel.com/content/www/us/en/support/articles/000005500/boards-and-kits.html>
 ///
 /// Since we're not a physical platform, we can freely assign code ranges for
 /// debugging specific parts of our virtual platform.


### PR DESCRIPTION
I was recently asked how one could navigate Cloud Hypervisor's source code. I was about to suggest reading the output from `cargo-doc` but found out the docs generated were not very good.

Nonetheless, I would like to put in some checks such that it at least conform to `cargo-doc`'s standard. The contents themselves can be improved in the future.