### PR TITLE
rpm: Make the RPM installable on OSTree based systems

### DIFF
--- a/rpm/cloud-hypervisor.spec
+++ b/rpm/cloud-hypervisor.spec
@@ -98,25 +98,17 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root,-)
 %{_bindir}/ch-remote
-%{_bindir}/cloud-hypervisor
+%caps(cap_net_admin=ep) %{_bindir}/cloud-hypervisor
 %{_libdir}/cloud-hypervisor/vhost_user_block
-%{_libdir}/cloud-hypervisor/vhost_user_net
+%caps(cap_net_admin=ep) %{_libdir}/cloud-hypervisor/vhost_user_net
 %if 0%{?using_musl_libc}
 %{_libdir}/cloud-hypervisor/static/ch-remote
-%{_libdir}/cloud-hypervisor/static/cloud-hypervisor
+%caps(cap_net_admim=ep) %{_libdir}/cloud-hypervisor/static/cloud-hypervisor
 %{_libdir}/cloud-hypervisor/static/vhost_user_block
-%{_libdir}/cloud-hypervisor/static/vhost_user_net
+%caps(cap_net_admin=ep) %{_libdir}/cloud-hypervisor/static/vhost_user_net
 %endif
 %license LICENSE-APACHE
 %license LICENSE-BSD-3-Clause
-
-%post
-setcap cap_net_admin+ep %{_bindir}/cloud-hypervisor
-setcap cap_net_admin+ep %{_libdir}/cloud-hypervisor/vhost_user_net
-%if 0%{?using_musl_libc}
-setcap cap_net_admin+ep %{_libdir}/cloud-hypervisor/static/cloud-hypervisor
-setcap cap_net_admin+ep %{_libdir}/cloud-hypervisor/static/vhost_user_net
-%endif
 
 
 %changelog

--- a/rpm/cloud-hypervisor.spec
+++ b/rpm/cloud-hypervisor.spec
@@ -97,8 +97,16 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%{_bindir}/*
-%{_libdir}/cloud-hypervisor
+%{_bindir}/ch-remote
+%{_bindir}/cloud-hypervisor
+%{_libdir}/cloud-hypervisor/vhost_user_block
+%{_libdir}/cloud-hypervisor/vhost_user_net
+%if 0%{?using_musl_libc}
+%{_libdir}/cloud-hypervisor/static/ch-remote
+%{_libdir}/cloud-hypervisor/static/cloud-hypervisor
+%{_libdir}/cloud-hypervisor/static/vhost_user_block
+%{_libdir}/cloud-hypervisor/static/vhost_user_net
+%endif
 %license LICENSE-APACHE
 %license LICENSE-BSD-3-Clause
 


### PR DESCRIPTION
OSTree based systems (such as Fedora CoreOS) behave differently than yum
based systems (such as Fedora) with regarding to the RPM installations.

While the latter will install the RPM on the running system, modifying
it; the former will be layered (installed in a "chroot") and only will
be present on the system after the user boots this layer up.

While in theory there shouldn't be much differences on the installation
itself, when installing cloud-hypervisor on RHCOS, the following issue
would be seen:
 ```
$ sudo sudo rpm-ostree install cloud-hypervisor
Checking out tree 9c1cdf9... done
Enabled rpm-md repositories: copr:copr.fedorainfracloud.org:fidencio:cloud-hypervisor
Updating metadata for 'copr:copr.fedorainfracloud.org:fidencio:cloud-hypervisor'... done
rpm-md repo 'copr:copr.fedorainfracloud.org:fidencio:cloud-hypervisor'; generated: 2021-11-08T19:02:32Z
Importing rpm-md... done
Resolving dependencies... done
Will download: 1 package (3.1 MB)
Downloading from 'copr:copr.fedorainfracloud.org:fidencio:cloud-hypervisor'... done
Importing packages... done
Checking out packages... done
Running pre scripts... done
Running post scripts... done
error: Running %post for cloud-hypervisor: Executing bwrap(/bin/sh): Child process killed by signal 1; run `journalctl -t 'rpm-ostree(cloud-hypervisor.post)'` for more information

$ sudo journalctl -t 'rpm-ostree(cloud-hypervisor.post)'
-- Logs begin at Fri 2021-11-12 12:18:33 UTC, end at Fri 2021-11-12 12:22:55 UTC. --
Nov 12 12:22:40 rhcoslatest rpm-ostree(cloud-hypervisor.post)[1637]: Failed to set capabilities on file `/usr/bin/cloud-hypervisor' (Operation not supported)
Nov 12 12:22:40 rhcoslatest rpm-ostree(cloud-hypervisor.post)[1637]: usage: setcap [-q] [-v] [-n <rootid>] (-r|-|<caps>) <filename> [ ... (-r|-|<capsN>) <filenameN> ]
Nov 12 12:22:40 rhcoslatest rpm-ostree(cloud-hypervisor.post)[1637]: Note <filename> must be a regular (non-symlink) file.
Nov 12 12:22:40 rhcoslatest rpm-ostree(cloud-hypervisor.post)[1637]: Failed to set capabilities on file `/usr/lib64/cloud-hypervisor/vhost_user_net' (Operation not supported)
Nov 12 12:22:40 rhcoslatest rpm-ostree(cloud-hypervisor.post)[1637]: usage: setcap [-q] [-v] [-n <rootid>] (-r|-|<caps>) <filename> [ ... (-r|-|<capsN>) <filenameN> ]
Nov 12 12:22:40 rhcoslatest rpm-ostree(cloud-hypervisor.post)[1637]: Note <filename> must be a regular (non-symlink) file.
```

It seems to happen as the "chroot" where the package is installed does
not have enough privileges to set the binaries capabilities during the
`%post` step.

Considering this, and also considering that calling `setcap` during
`%post` may not be the most elegant solution when speaking RPM spec
files, let's take advantage of the already existent `%caps()` directive
for the `%files` list to do so.

With that change applied, cloud-hypervisor could be successfully
installed on RHCOS, as shown below:
```
$ sudo rpm-ostree install cloud-hypervisor-19.0-2.el8.x86_64.rpm
Checking out tree 9c1cdf9... done
Enabled rpm-md repositories: copr:copr.fedorainfracloud.org:fidencio:cloud-hypervisor
rpm-md repo 'copr:copr.fedorainfracloud.org:fidencio:cloud-hypervisor' (cached); generated: 2021-11-08T19:02:32Z
Importing rpm-md... done
Resolving dependencies... done
Checking out packages... done
Running pre scripts... done
Running post scripts... done
Running posttrans scripts... done
Writing rpmdb... done
Writing OSTree commit... done
Staging deployment... done
Freed: 18.2 MB (pkgcache branches: 2)
Added:
cloud-hypervisor-19.0-2.el8.x86_64
Run "systemctl reboot" to start a reboot

...

$ getcap /usr/bin/cloud-hypervisor
/usr/bin/cloud-hypervisor = cap_net_admin+ep
$ getcap /usr/lib64/cloud-hypervisor/vhost_user_net
/usr/lib64/cloud-hypervisor/vhost_user_net = cap_net_admin+ep
```