### PR TITLE
docs: Add documentation for CPU parameter

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,4 +1,4 @@
-name: Cloud-Hypervisor's Docker image update
+name: Cloud Hypervisor's Docker image update
 
 on:
   push:

--- a/docs/cpu.md
+++ b/docs/cpu.md
@@ -1,0 +1,189 @@
+# CPU
+
+Cloud Hypervisor has many options when it comes to the creation of virtual
+CPUs. This document aims to explain what Cloud Hypervisor is capable of and
+how it can be used to meet the needs of very different use cases.
+
+## Options
+
+`CpusConfig` or what is known as `--cpus` from the CLI perspective is the way
+to set vCPUs options for Cloud Hypervisor.
+
+```rust
+struct CpusConfig {
+    boot_vcpus: u8,
+    max_vcpus: u8,
+    topology: Option<CpuTopology>,
+    kvm_hyperv: bool,
+    max_phys_bits: u8,
+    affinity: Option<Vec<CpuAffinity>>,
+}
+```
+
+```
+--cpus boot=<boot_vcpus>,max=<max_vcpus>,topology=<threads_per_core>:<cores_per_die>:<dies_per_package>:<packages>,kvm_hyperv=on|off,max_phys_bits=<maximum_number_of_physical_bits>,affinity=<list_of_vcpus_with_their_associated_cpuset>
+```
+
+### `boot`
+
+Number of vCPUs present at boot time.
+
+This option allows to define a specific number of vCPUs to be present at the
+time the VM is started. This option is mandatory when using the `--cpus`
+parameter. If `--cpus` is not specified, this option takes the default value
+of `1`, starting the VM with a single vCPU.
+
+Value is an unsigned integer of 8 bits.
+
+_Example_
+
+```
+--cpus boot=2
+```
+
+### `max`
+
+Maximum number of vCPUs.
+
+This option defines the maximum number of vCPUs that can be assigned to the VM.
+In particular, this option is used when looking for CPU hotplug as it lets the
+provide an indication about how many vCPUs might be needed later during the
+runtime of the VM.
+For instance, if booting the VM with 2 vCPUs and a maximum of 6 vCPUs, it means
+up to 4 vCPUs can be added later at runtime by resizing the VM.
+
+The value must be greater than or equal to the number of boot vCPUs.
+The value is an unsigned integer of 8 bits.
+
+By default this option takes the value of `boot`, meaning vCPU hotplug is not
+expected and can't be performed.
+
+_Example_
+
+```
+--cpus max=3
+```
+
+### `topology`
+
+Topology of the guest platform.
+
+This option gives the user a way to describe the exact topology that should be
+exposed to the guest. It can be useful to describe to the guest the same
+topology found on the host as it allows for proper usage of the resources and
+is a way to achieve better performances.
+
+The topology is described through the following structure:
+
+```rust
+struct CpuTopology {
+    threads_per_core: u8,
+    cores_per_die: u8,
+    dies_per_package: u8,
+    packages: u8,
+}
+```
+
+or the following syntax through the CLI:
+
+```
+topology=<threads_per_core>:<cores_per_die>:<dies_per_package>:<packages>
+```
+
+By default the topology will be `1:1:1:1`.
+
+_Example_
+
+```
+--cpus boot=2,topology=1:1:2:1
+```
+
+### `kvm_hyperv`
+
+Enable KVM Hyper-V emulation.
+
+When turned on, this option relies on KVM to emulate the synthetic interrupt
+controller (SynIC) along with synthetic timers expected by a Windows guest.
+A Windows guest usually runs on top of Microsoft Hyper-V, therefore expects
+these synthetic devices to be present. That's why KVM provides a way to emulate
+them and avoids failures running a Windows guest with Cloud Hypervisor.
+
+By default this option is turned off.
+
+_Example_
+
+```
+--cpus kvm_hyperv=on
+```
+
+### `max_phys_bits`
+
+Maximum size for guest's addressable space.
+
+This option defines the maximum number of physical bits for all vCPUs, which
+sets a limit for the size of the guest's addressable space. This is mainly
+useful for debug purpose.
+
+The value is an unsigned integer of 8 bits.
+
+_Example_
+
+```
+--cpus max_phys_bits=40
+```
+
+### `affinity`
+
+Affinity of each vCPU.
+
+This option gives the user a way to provide the host CPU set associated with
+each vCPU. It is useful for achieving CPU pinning, ensuring multiple VMs won't
+affect the performance of each other. It might also be used in the context of
+NUMA as it is way of making sure the VM can run on a specific host NUMA node.
+In general, this option is used to increase the performances of a VM depending
+on the host platform and the type of workload running in the guest.
+
+The affinity is described through the following structure:
+
+```rust
+struct CpuAffinity {
+    vcpu: u8,
+    host_cpus: Vec<u8>,
+}
+```
+
+or the following syntax through the CLI:
+
+```
+affinity=[<vcpu_id1>@[<host_cpu_id1>, <host_cpu_id2>], <vcpu_id2>@[<host_cpu_id3>, <host_cpu_id4>]]
+```
+
+The outer brackets define the list of vCPUs. And for each vCPU, the inner
+brackets attached to `@` define the list of host CPUs the vCPU is allowed to
+run onto.
+
+Multiple values can be provided to define each list. Each value is an unsigned
+integer of 8 bits.
+
+For instance, if one needs to run vCPU 0 on host CPUs from 0 to 4, the syntax
+using `-` will help define a contiguous range with `affinity=0@[0-4]`. The
+same example could also be described with `affinity=0@[0,1,2,3,4]`.
+
+A combination of both `-` and `,` separators is useful when one might need to
+describe a list containing host CPUs from 0 to 99 and the host CPU 255, as it
+could simply be described with `affinity=0@[0-99,255]`.
+
+As soon as one tries to describe a list of values, `[` and `]` must be used to
+demarcate the list.
+
+By default each vCPU runs on the entire host CPU set.
+
+_Example_
+
+```
+--cpus boot=3,affinity=[0@[2,3],1@[0,1]]
+```
+
+In this example, assuming the host has 4 CPUs, vCPU 0 will run exclusively on
+host CPUs 2 and 3, while vCPU 1 will run exclusively on host CPUs 0 and 1.
+Because nothing is defined for vCPU 2, it can run on any of the 4 host CPUs.

--- a/docs/custom-image.md
+++ b/docs/custom-image.md
@@ -72,7 +72,7 @@ mount -t devpts devpts /dev/pts
 
 ### Install needed packages
 
-In the context Cloud-Hypervisor's integration tests, we need several utilities.
+In the context Cloud Hypervisor's integration tests, we need several utilities.
 Here is the way to install them for a Ubuntu image. This step is specific to
 Ubuntu distributions.
 

--- a/docs/intel_sgx.md
+++ b/docs/intel_sgx.md
@@ -1,7 +1,7 @@
 # Intel SGX
 
 Intel® Software Guard Extensions (Intel® SGX) is an Intel technology designed
-to increase the security of application code and data. Cloud-Hypervisor supports
+to increase the security of application code and data. Cloud Hypervisor supports
 SGX virtualization through KVM. Because SGX is built on hardware features that
 cannot be emulated in software, virtualizing SGX requires support in KVM and in
 the host kernel. The required Linux and KVM changes can be found in the
@@ -17,12 +17,12 @@ For more information about SGX, please refer to the [SGX Homepage](https://softw
 For more information about SGX SDK and how to test SGX, please refer to the
 following [instructions](https://github.com/intel/linux-sgx).
 
-## Cloud-Hypervisor support
+## Cloud Hypervisor support
 
 Assuming the host exposes `/dev/sgx_vepc`, we can pass SGX enclaves through
 the guest.
 
-In order to use SGX enclaves within a Cloud-Hypervisor VM, we must define one
+In order to use SGX enclaves within a Cloud Hypervisor VM, we must define one
 or several Enclave Page Cache (EPC) sections. Here is an example of a VM being
 created with 2 EPC sections, the first one being 64MiB with pre-allocated
 memory, the second one being 32MiB with no pre-allocated memory.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,13 +1,13 @@
 # Memory
 
-Cloud-Hypervisor has many ways to expose memory to the guest VM. This document
-aims to explain what Cloud-Hypervisor is capable of and how it can be used to
+Cloud Hypervisor has many ways to expose memory to the guest VM. This document
+aims to explain what Cloud Hypervisor is capable of and how it can be used to
 meet the needs of very different use cases.
 
 ## Basic Parameters
 
 `MemoryConfig` or what is known as `--memory` from the CLI perspective is the
-easiest way to get started with Cloud-Hypervisor.
+easiest way to get started with Cloud Hypervisor.
 
 ```rust
 struct MemoryConfig {

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -11,9 +11,9 @@ before the snapshot was performed.
 This feature is important for the project as it establishes the first step
 towards the support for live migration.
 
-## Snapshot a Cloud-Hypervisor VM
+## Snapshot a Cloud Hypervisor VM
 
-First thing, we must run a Cloud-Hypervisor VM:
+First thing, we must run a Cloud Hypervisor VM:
 
 ```bash
 ./cloud-hypervisor \
@@ -54,7 +54,7 @@ drwxr-xr-x 47 foo bar       4096 Jul 22 11:47 ../
 In this particular example, we can observe that 2 memory region files were
 created. That is explained by the size of the guest RAM, which is 4GiB in this
 case. Because it exceeds 3GiB (which is where we can find a ~1GiB memory hole),
-Cloud-Hypervisor needs 2 distinct memory regions to be created. Each memory
+Cloud Hypervisor needs 2 distinct memory regions to be created. Each memory
 region's content is stored through a dedicated file, which explains why we end
 up with 2 different files, the first one containing the guest RAM range 0-3GiB
 and the second one containing the guest RAM range 3-4GiB.
@@ -65,7 +65,7 @@ with the correct amount of CPUs, RAM, and other expected devices. The state
 bits are used to restore each component in the state it was left before the
 snapshot occurred.
 
-## Restore a Cloud-Hypervisor VM
+## Restore a Cloud Hypervisor VM
 
 Given that one has access to an existing snapshot in `/home/foo/snapshot`,
 it is possible to create a new VM based on this snapshot with the following 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1244,7 +1244,7 @@ Highlights for `cloud-hypervisor` version 0.4.0 include:
 
 ### Dynamic virtual CPUs addition
 
-As a way to vertically scale Cloud-Hypervisor guests, we now support dynamically
+As a way to vertically scale Cloud Hypervisor guests, we now support dynamically
 adding virtual CPUs to the guests, a mechanism also known as CPU hot plug.
 Through hardware-reduced ACPI notifications, Cloud Hypervisor can now add CPUs
 to an already running guest and the high level operations for that process are

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,8 @@ fn create_app<'a, 'b>(
                 .help(
                     "boot=<boot_vcpus>,max=<max_vcpus>,\
                     topology=<threads_per_core>:<cores_per_die>:<dies_per_package>:<packages>,\
-                    kvm_hyperv=on|off,max_phys_bits=<maximum_number_of_physical_bits>",
+                    kvm_hyperv=on|off,max_phys_bits=<maximum_number_of_physical_bits>,\
+                    affinity=<list_of_vcpus_with_their_associated_cpuset>",
                 )
                 .default_value(default_vcpus)
                 .group("vm-config"),

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -169,7 +169,7 @@ impl fmt::Display for ValidationError {
             DoubleTtyMode => write!(f, "Console mode tty specified for both serial and console"),
             KernelMissing => write!(f, "No kernel specified"),
             ConsoleFileMissing => write!(f, "Path missing when using file console mode"),
-            CpusMaxLowerThanBoot => write!(f, "Max CPUs greater than boot CPUs"),
+            CpusMaxLowerThanBoot => write!(f, "Max CPUs lower than boot CPUs"),
             DiskSocketAndPath => write!(f, "Disk path and vhost socket both provided"),
             VhostUserRequiresSharedMemory => {
                 write!(f, "Using vhost-user requires using shared memory")


### PR DESCRIPTION
This new document describes the available options for the parameter `--cpus`, how to use them and what is their usage.

Fixes #3317