### PR TITLE
vmm: Fix panic in SIGWINCH listener thread when no seccomp filter set

### DIFF
--- a/vmm/src/sigwinch_listener.rs
+++ b/vmm/src/sigwinch_listener.rs
@@ -67,7 +67,9 @@ fn sigwinch_listener_main(seccomp_filter: BpfProgram, tx: File, tty: &File) -> !
 
     unblock_all_signals().unwrap();
 
-    apply_filter(&seccomp_filter).unwrap();
+    if !seccomp_filter.is_empty() {
+        apply_filter(&seccomp_filter).unwrap();
+    }
 
     register_signal_handler(SIGWINCH, sigwinch_handler).unwrap();
 


### PR DESCRIPTION
When running with `--serial pty --console pty --seccomp=false` the
SIGWICH listener thread would panic as the seccomp filter was empty.
Adopt the mechanism used in the rest of the code and check for non-empty
filter before trying to apply it.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>