### PR TITLE
Add or adjust safety comments for `impl ByteValued`

### DIFF
--- a/acpi_tables/src/rsdp.rs
+++ b/acpi_tables/src/rsdp.rs
@@ -19,6 +19,7 @@ pub struct Rsdp {
     _reserved: [u8; 3],
 }
 
+// SAFETY: Rsdp only contains a series of integers
 unsafe impl ByteValued for Rsdp {}
 
 impl Rsdp {

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -118,17 +118,15 @@ impl SgxEpcRegion {
 #[derive(Copy, Clone, Default)]
 struct StartInfoWrapper(hvm_start_info);
 
-// It is safe to initialize StartInfoWrapper which is a wrapper over `hvm_start_info` (a series of ints).
-unsafe impl ByteValued for StartInfoWrapper {}
-
 #[derive(Copy, Clone, Default)]
 struct MemmapTableEntryWrapper(hvm_memmap_table_entry);
-
-unsafe impl ByteValued for MemmapTableEntryWrapper {}
 
 #[derive(Copy, Clone, Default)]
 struct ModlistEntryWrapper(hvm_modlist_entry);
 
+// SAFETY: These data structures only contain a series of integers
+unsafe impl ByteValued for StartInfoWrapper {}
+unsafe impl ByteValued for MemmapTableEntryWrapper {}
 unsafe impl ByteValued for ModlistEntryWrapper {}
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
@@ -139,7 +137,7 @@ unsafe impl ByteValued for ModlistEntryWrapper {}
 #[derive(Copy, Clone, Default)]
 struct BootParamsWrapper(boot_params);
 
-// It is safe to initialize BootParamsWrap which is a wrapper over `boot_params` (a series of ints).
+// SAFETY: BootParamsWrap is a wrapper over `boot_params` (a series of ints).
 unsafe impl ByteValued for BootParamsWrapper {}
 
 #[derive(Debug)]

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -35,7 +35,7 @@ struct MpcLintsrcWrapper(mpspec::mpc_lintsrc);
 #[derive(Copy, Clone, Default)]
 struct MpfIntelWrapper(mpspec::mpf_intel);
 
-// These `mpspec` wrapper types are only data, reading them from data is a safe initialization.
+// SAFETY: These `mpspec` wrapper types are only data, reading them from data is a safe initialization.
 unsafe impl ByteValued for MpcBusWrapper {}
 unsafe impl ByteValued for MpcCpuWrapper {}
 unsafe impl ByteValued for MpcIntsrcWrapper {}

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -82,7 +82,6 @@ pub struct Smbios30Entrypoint {
     pub max_size: u32,
     pub physptr: u64,
 }
-unsafe impl ByteValued for Smbios30Entrypoint {}
 
 impl Clone for Smbios30Entrypoint {
     fn clone(&self) -> Self {
@@ -112,8 +111,6 @@ impl Clone for SmbiosBiosInfo {
     }
 }
 
-unsafe impl ByteValued for SmbiosBiosInfo {}
-
 #[repr(packed)]
 #[derive(Default, Copy)]
 pub struct SmbiosSysInfo {
@@ -136,6 +133,9 @@ impl Clone for SmbiosSysInfo {
     }
 }
 
+// SAFETY: These data structures only contain a series of integers
+unsafe impl ByteValued for Smbios30Entrypoint {}
+unsafe impl ByteValued for SmbiosBiosInfo {}
 unsafe impl ByteValued for SmbiosSysInfo {}
 
 fn write_and_incr<T: ByteValued>(

--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -69,8 +69,6 @@ pub struct TdVmmDataRegion {
     pub region_type: TdVmmDataRegionType,
 }
 
-unsafe impl ByteValued for TdVmmDataRegion {}
-
 #[repr(u16)]
 #[derive(Clone, Copy, Debug)]
 pub enum TdVmmDataRegionType {
@@ -192,7 +190,6 @@ struct HobHeader {
     length: u16,
     reserved: u32,
 }
-unsafe impl ByteValued for HobHeader {}
 
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
@@ -206,7 +203,6 @@ struct HobHandoffInfoTable {
     efi_free_memory_bottom: u64,
     efi_end_of_hob_list: u64,
 }
-unsafe impl ByteValued for HobHandoffInfoTable {}
 
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
@@ -227,7 +223,6 @@ struct HobResourceDescriptor {
     physical_start: u64,
     resource_length: u64,
 }
-unsafe impl ByteValued for HobResourceDescriptor {}
 
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
@@ -235,7 +230,6 @@ struct HobGuidType {
     header: HobHeader,
     name: EfiGuid,
 }
-unsafe impl ByteValued for HobGuidType {}
 
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
@@ -243,6 +237,13 @@ struct TdVmmData {
     guid_type: HobGuidType,
     region: TdVmmDataRegion,
 }
+
+// SAFETY: These data structures only contain a series of integers
+unsafe impl ByteValued for TdVmmDataRegion {}
+unsafe impl ByteValued for HobHeader {}
+unsafe impl ByteValued for HobHandoffInfoTable {}
+unsafe impl ByteValued for HobResourceDescriptor {}
+unsafe impl ByteValued for HobGuidType {}
 unsafe impl ByteValued for TdVmmData {}
 
 pub struct TdHob {

--- a/block_util/src/lib.rs
+++ b/block_util/src/lib.rs
@@ -409,8 +409,6 @@ pub struct VirtioBlockConfig {
     pub write_zeroes_may_unmap: u8,
     pub unused1: [u8; 3],
 }
-unsafe impl ByteValued for VirtioBlockConfig {}
-
 #[derive(Copy, Clone, Debug, Default, Versionize)]
 #[repr(C, packed)]
 pub struct VirtioBlockGeometry {
@@ -418,6 +416,9 @@ pub struct VirtioBlockGeometry {
     pub heads: u8,
     pub sectors: u8,
 }
+
+// SAFETY: these data structures only contain a series of integers
+unsafe impl ByteValued for VirtioBlockConfig {}
 unsafe impl ByteValued for VirtioBlockGeometry {}
 
 /// Check if io_uring for block device can be used on the current system, as

--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -42,6 +42,7 @@ pub struct ControlHeader {
     pub cmd: u8,
 }
 
+// SAFETY: ControlHeader only contains a series of integers
 unsafe impl ByteValued for ControlHeader {}
 
 pub struct CtrlQueue {

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -59,7 +59,7 @@ pub struct VirtioNetConfig {
     pub duplex: u8,
 }
 
-// Safe because it only has data and has no implicit padding.
+// SAFETY: it only has data and has no implicit padding.
 unsafe impl ByteValued for VirtioNetConfig {}
 
 /// Create a sockaddr_in from an IPv4 address, and expose it as

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -961,7 +961,7 @@ mod tests {
         foo: u8,
     }
 
-    // It is safe to implement BytesValued; all members are simple numbers and any value is valid.
+    // SAFETY: All members are simple numbers and any value is valid.
     unsafe impl ByteValued for TestCap {}
 
     impl PciCapability for TestCap {

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -468,7 +468,7 @@ pub struct MsixCap {
     pub pba: u32,
 }
 
-// It is safe to implement ByteValued. All members are simple numbers and any value is valid.
+// SAFETY: All members are simple numbers and any value is valid.
 unsafe impl ByteValued for MsixCap {}
 
 impl PciCapability for MsixCap {

--- a/vfio_user/src/lib.rs
+++ b/vfio_user/src/lib.rs
@@ -73,8 +73,6 @@ struct Header {
     error: u32,
 }
 
-unsafe impl ByteValued for Header {}
-
 #[repr(C)]
 #[derive(Default, Clone, Copy, Debug)]
 struct Version {
@@ -82,7 +80,6 @@ struct Version {
     major: u16,
     minor: u16,
 }
-unsafe impl ByteValued for Version {}
 
 #[derive(Serialize, Deserialize, Debug)]
 struct MigrationCapabilities {
@@ -128,8 +125,6 @@ struct DmaMap {
     size: u64,
 }
 
-unsafe impl ByteValued for DmaMap {}
-
 #[repr(C)]
 #[derive(Default, Clone, Copy, Debug)]
 struct DmaUnmap {
@@ -139,8 +134,6 @@ struct DmaUnmap {
     address: u64,
     size: u64,
 }
-
-unsafe impl ByteValued for DmaUnmap {}
 
 #[repr(C)]
 #[derive(Default, Clone, Copy, Debug)]
@@ -152,16 +145,12 @@ struct DeviceGetInfo {
     num_irqs: u32,
 }
 
-unsafe impl ByteValued for DeviceGetInfo {}
-
 #[repr(C)]
 #[derive(Default, Clone, Copy, Debug)]
 struct DeviceGetRegionInfo {
     header: Header,
     region_info: vfio_region_info,
 }
-
-unsafe impl ByteValued for DeviceGetRegionInfo {}
 
 #[repr(C)]
 #[derive(Default, Clone, Copy, Debug)]
@@ -172,8 +161,6 @@ struct RegionAccess {
     count: u32,
 }
 
-unsafe impl ByteValued for RegionAccess {}
-
 #[repr(C)]
 #[derive(Default, Clone, Copy, Debug)]
 struct GetIrqInfo {
@@ -183,8 +170,6 @@ struct GetIrqInfo {
     index: u32,
     count: u32,
 }
-
-unsafe impl ByteValued for GetIrqInfo {}
 
 #[repr(C)]
 #[derive(Default, Clone, Copy, Debug)]
@@ -197,14 +182,22 @@ struct SetIrqs {
     count: u32,
 }
 
-unsafe impl ByteValued for SetIrqs {}
-
 #[repr(C)]
 #[derive(Default, Clone, Copy, Debug)]
 struct DeviceReset {
     header: Header,
 }
 
+// SAFETY: these data structures only contain a sereis of integers
+unsafe impl ByteValued for Header {}
+unsafe impl ByteValued for Version {}
+unsafe impl ByteValued for DmaMap {}
+unsafe impl ByteValued for DmaUnmap {}
+unsafe impl ByteValued for DeviceGetInfo {}
+unsafe impl ByteValued for DeviceGetRegionInfo {}
+unsafe impl ByteValued for RegionAccess {}
+unsafe impl ByteValued for GetIrqInfo {}
+unsafe impl ByteValued for SetIrqs {}
 unsafe impl ByteValued for DeviceReset {}
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -100,7 +100,7 @@ pub struct VirtioBalloonConfig {
 const CONFIG_ACTUAL_OFFSET: u64 = 4;
 const CONFIG_ACTUAL_SIZE: usize = 4;
 
-// Safe because it only has data and has no implicit padding.
+// SAFETY: it only has data and has no implicit padding.
 unsafe impl ByteValued for VirtioBalloonConfig {}
 
 struct VirtioBalloonResizeReceiver {

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -69,7 +69,7 @@ impl Default for VirtioConsoleConfig {
     }
 }
 
-// Safe because it only has data and has no implicit padding.
+// SAFETY: it only has data and has no implicit padding.
 unsafe impl ByteValued for VirtioConsoleConfig {}
 
 struct ConsoleEpollHandler {

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -79,8 +79,6 @@ struct VirtioIommuRange32 {
     end: u32,
 }
 
-unsafe impl ByteValued for VirtioIommuRange32 {}
-
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(packed)]
 #[allow(dead_code)]
@@ -88,8 +86,6 @@ struct VirtioIommuRange64 {
     start: u64,
     end: u64,
 }
-
-unsafe impl ByteValued for VirtioIommuRange64 {}
 
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(packed)]
@@ -102,8 +98,6 @@ struct VirtioIommuConfig {
     bypass: u8,
     _reserved: [u8; 7],
 }
-
-unsafe impl ByteValued for VirtioIommuConfig {}
 
 /// Virtio IOMMU request type
 const VIRTIO_IOMMU_T_ATTACH: u8 = 1;
@@ -118,8 +112,6 @@ struct VirtioIommuReqHead {
     type_: u8,
     _reserved: [u8; 3],
 }
-
-unsafe impl ByteValued for VirtioIommuReqHead {}
 
 /// Virtio IOMMU request status
 const VIRTIO_IOMMU_S_OK: u8 = 0;
@@ -148,8 +140,6 @@ struct VirtioIommuReqTail {
     _reserved: [u8; 3],
 }
 
-unsafe impl ByteValued for VirtioIommuReqTail {}
-
 /// ATTACH request
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(packed)]
@@ -159,8 +149,6 @@ struct VirtioIommuReqAttach {
     _reserved: [u8; 8],
 }
 
-unsafe impl ByteValued for VirtioIommuReqAttach {}
-
 /// DETACH request
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(packed)]
@@ -169,8 +157,6 @@ struct VirtioIommuReqDetach {
     endpoint: u32,
     _reserved: [u8; 8],
 }
-
-unsafe impl ByteValued for VirtioIommuReqDetach {}
 
 /// Virtio IOMMU request MAP flags
 #[allow(unused)]
@@ -194,8 +180,6 @@ struct VirtioIommuReqMap {
     _flags: u32,
 }
 
-unsafe impl ByteValued for VirtioIommuReqMap {}
-
 /// UNMAP request
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(packed)]
@@ -205,8 +189,6 @@ struct VirtioIommuReqUnmap {
     virt_end: u64,
     _reserved: [u8; 4],
 }
-
-unsafe impl ByteValued for VirtioIommuReqUnmap {}
 
 /// Virtio IOMMU request PROBE types
 #[allow(unused)]
@@ -224,8 +206,6 @@ struct VirtioIommuReqProbe {
     _reserved: [u64; 8],
 }
 
-unsafe impl ByteValued for VirtioIommuReqProbe {}
-
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(packed)]
 #[allow(dead_code)]
@@ -233,8 +213,6 @@ struct VirtioIommuProbeProperty {
     type_: u16,
     length: u16,
 }
-
-unsafe impl ByteValued for VirtioIommuProbeProperty {}
 
 /// Virtio IOMMU request PROBE property RESV_MEM subtypes
 #[allow(unused)]
@@ -250,8 +228,6 @@ struct VirtioIommuProbeResvMem {
     start: u64,
     end: u64,
 }
-
-unsafe impl ByteValued for VirtioIommuProbeResvMem {}
 
 /// Virtio IOMMU fault flags
 #[allow(unused)]
@@ -284,6 +260,19 @@ struct VirtioIommuFault {
     address: u64,
 }
 
+// SAFETY: these data structures only contain integers and have no implicit padding
+unsafe impl ByteValued for VirtioIommuRange32 {}
+unsafe impl ByteValued for VirtioIommuRange64 {}
+unsafe impl ByteValued for VirtioIommuConfig {}
+unsafe impl ByteValued for VirtioIommuReqHead {}
+unsafe impl ByteValued for VirtioIommuReqTail {}
+unsafe impl ByteValued for VirtioIommuReqAttach {}
+unsafe impl ByteValued for VirtioIommuReqDetach {}
+unsafe impl ByteValued for VirtioIommuReqMap {}
+unsafe impl ByteValued for VirtioIommuReqUnmap {}
+unsafe impl ByteValued for VirtioIommuReqProbe {}
+unsafe impl ByteValued for VirtioIommuProbeProperty {}
+unsafe impl ByteValued for VirtioIommuProbeResvMem {}
 unsafe impl ByteValued for VirtioIommuFault {}
 
 #[derive(Debug)]

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -149,7 +149,7 @@ struct VirtioMemReq {
     padding_1: [u16; 3],
 }
 
-// Safe because it only has data and has no implicit padding.
+// SAFETY: it only has data and has no implicit padding.
 unsafe impl ByteValued for VirtioMemReq {}
 
 #[repr(C)]
@@ -160,7 +160,7 @@ struct VirtioMemResp {
     state: u16,
 }
 
-// Safe because it only has data and has no implicit padding.
+// SAFETY: it only has data and has no implicit padding.
 unsafe impl ByteValued for VirtioMemResp {}
 
 #[repr(C)]
@@ -186,7 +186,7 @@ pub struct VirtioMemConfig {
     requested_size: u64,
 }
 
-// Safe because it only has data and has no implicit padding.
+// SAFETY: it only has data and has no implicit padding.
 unsafe impl ByteValued for VirtioMemConfig {}
 
 impl VirtioMemConfig {

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -50,7 +50,7 @@ struct VirtioPmemConfig {
     size: u64,
 }
 
-// Safe because it only has data and has no implicit padding.
+// SAFETY: it only has data and has no implicit padding.
 unsafe impl ByteValued for VirtioPmemConfig {}
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -59,7 +59,7 @@ struct VirtioPmemReq {
     type_: u32,
 }
 
-// Safe because it only has data and has no implicit padding.
+// SAFETY: it only has data and has no implicit padding.
 unsafe impl ByteValued for VirtioPmemReq {}
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -68,7 +68,7 @@ struct VirtioPmemResp {
     ret: u32,
 }
 
-// Safe because it only has data and has no implicit padding.
+// SAFETY: it only has data and has no implicit padding.
 unsafe impl ByteValued for VirtioPmemResp {}
 
 #[derive(Debug)]

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -75,7 +75,7 @@ struct VirtioPciCap {
     offset: Le32,     // Offset within bar.
     length: Le32,     // Length of the structure, in bytes.
 }
-// It is safe to implement ByteValued. All members are simple numbers and any value is valid.
+// SAFETY: All members are simple numbers and any value is valid.
 unsafe impl ByteValued for VirtioPciCap {}
 
 impl PciCapability for VirtioPciCap {
@@ -111,7 +111,7 @@ struct VirtioPciNotifyCap {
     cap: VirtioPciCap,
     notify_off_multiplier: Le32,
 }
-// It is safe to implement ByteValued. All members are simple numbers and any value is valid.
+// SAFETY: All members are simple numbers and any value is valid.
 unsafe impl ByteValued for VirtioPciNotifyCap {}
 
 impl PciCapability for VirtioPciNotifyCap {
@@ -156,7 +156,7 @@ struct VirtioPciCap64 {
     offset_hi: Le32,
     length_hi: Le32,
 }
-// It is safe to implement ByteValued. All members are simple numbers and any value is valid.
+// SAFETY: All members are simple numbers and any value is valid.
 unsafe impl ByteValued for VirtioPciCap64 {}
 
 impl PciCapability for VirtioPciCap64 {
@@ -194,7 +194,7 @@ struct VirtioPciCfgCap {
     cap: VirtioPciCap,
     pci_cfg_data: [u8; 4],
 }
-// It is safe to implement ByteValued. All members are simple numbers and any value is valid.
+// SAFETY: All members are simple numbers and any value is valid.
 unsafe impl ByteValued for VirtioPciCfgCap {}
 
 impl PciCapability for VirtioPciCfgCap {

--- a/virtio-queue/src/lib.rs
+++ b/virtio-queue/src/lib.rs
@@ -94,6 +94,9 @@ pub struct Descriptor {
     next: u16,
 }
 
+// SAFETY: Descriptor only contains a series of integers and has no implicit padding
+unsafe impl ByteValued for Descriptor {}
+
 #[allow(clippy::len_without_is_empty)]
 impl Descriptor {
     /// Creates a new descriptor
@@ -148,8 +151,6 @@ impl Descriptor {
         self.flags & VIRTQ_DESC_F_WRITE != 0
     }
 }
-
-unsafe impl ByteValued for Descriptor {}
 
 /// A virtio descriptor chain.
 #[derive(Clone, Debug)]
@@ -421,6 +422,9 @@ pub struct VirtqUsedElem {
     len: u32,
 }
 
+// SAFETY: VirtqUsedElem only contains a series of integers and has no implicit padding
+unsafe impl ByteValued for VirtqUsedElem {}
+
 impl VirtqUsedElem {
     /// Create a new `VirtqUsedElem` instance.
     pub fn new(id: u16, len: u32) -> Self {
@@ -430,8 +434,6 @@ impl VirtqUsedElem {
         }
     }
 }
-
-unsafe impl ByteValued for VirtqUsedElem {}
 
 /// Struct to hold an exclusive reference to the underlying `QueueState` object.
 pub enum QueueStateGuard<'a, M: GuestAddressSpace> {

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -57,6 +57,9 @@ pub struct Request {
     length: u64, // Length of payload for command excluding the Request struct
 }
 
+// SAFETY: Request contains a series of integers with no implicit padding
+unsafe impl ByteValued for Request {}
+
 impl Request {
     pub fn new(command: Command, length: u64) -> Self {
         Self {
@@ -112,8 +115,6 @@ impl Request {
     }
 }
 
-unsafe impl ByteValued for Request {}
-
 #[repr(u16)]
 #[derive(Copy, Clone, PartialEq)]
 pub enum Status {
@@ -135,6 +136,9 @@ pub struct Response {
     padding: [u8; 6],
     length: u64, // Length of payload for command excluding the Response struct
 }
+
+// SAFETY: Response contains a series of integers with no implicit padding
+unsafe impl ByteValued for Response {}
 
 impl Response {
     pub fn new(status: Status, length: u64) -> Self {
@@ -170,8 +174,6 @@ impl Response {
             .map_err(MigratableError::MigrateSocket)
     }
 }
-
-unsafe impl ByteValued for Response {}
 
 #[repr(C)]
 #[derive(Clone, Default, Serialize, Deserialize, Versionize)]

--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -11,7 +11,7 @@
 pub mod testing {
     use std::marker::PhantomData;
     use std::mem;
-    use virtio_queue::{Queue, QueueState};
+    use virtio_queue::{Queue, QueueState, VirtqUsedElem};
     use vm_memory::{bitmap::AtomicBitmap, Address, GuestAddress, GuestUsize};
     use vm_memory::{Bytes, GuestMemoryAtomic};
 
@@ -162,15 +162,6 @@ pub mod testing {
             self.event.end()
         }
     }
-
-    #[repr(C)]
-    #[derive(Clone, Copy, Default)]
-    pub struct VirtqUsedElem {
-        pub id: u32,
-        pub len: u32,
-    }
-
-    unsafe impl vm_memory::ByteValued for VirtqUsedElem {}
 
     pub type VirtqAvail<'a> = VirtqRing<'a, u16>;
     pub type VirtqUsed<'a> = VirtqRing<'a, VirtqUsedElem>;


### PR DESCRIPTION
This is a group of low hanging fruits -- it is trivial to verify the safety requirements are met.