### PR TITLE
vmm: use the tty raw mode implementation from libc

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -64,8 +64,8 @@ use hypervisor::DeviceFd;
 #[cfg(feature = "mshv")]
 use hypervisor::IoEventAddress;
 use libc::{
-    isatty, tcgetattr, tcsetattr, termios, ECHO, ICANON, ISIG, MAP_NORESERVE, MAP_PRIVATE,
-    MAP_SHARED, O_TMPFILE, PROT_READ, PROT_WRITE, TCSANOW,
+    cfmakeraw, isatty, tcgetattr, tcsetattr, termios, MAP_NORESERVE, MAP_PRIVATE, MAP_SHARED,
+    O_TMPFILE, PROT_READ, PROT_WRITE, TCSANOW,
 };
 #[cfg(target_arch = "x86_64")]
 use pci::PciConfigIo;
@@ -1697,7 +1697,7 @@ impl DeviceManager {
     }
 
     fn set_raw_mode(&self, f: &mut File) -> vmm_sys_util::errno::Result<()> {
-        self.modify_mode(f.as_raw_fd(), |t| t.c_lflag &= !(ICANON | ECHO | ISIG))
+        self.modify_mode(f.as_raw_fd(), |t| unsafe { cfmakeraw(t) })
     }
 
     fn listen_for_sigwinch_on_tty(&mut self, pty: &File) -> std::io::Result<()> {


### PR DESCRIPTION
I encountered some trouble trying to use a virtio-console hooked up to
a PTY.  Reading from the PTY would produce stuff like this
"\n\nsh-5.1# \n\nsh-5.1# " (where I'm just pressing enter at a shell
prompt), and a terminal would render that like this:

```

sh-5.1#

       sh-5.1#
```

This was because we weren't disabling the ICRNL termios iflag, which
turns carriage returns (\r) into line feeds (\n).  Other raw mode
implementations (like QEMU's) set this flag, and don't have this
problem.

Instead of fixing our raw mode implementation to just disable ICRNL,
or copy the flags from QEMU's, though, here I've changed it to use the
raw mode implementation in libc.  It seems to work correctly in my
testing, and means we don't have to worry about what exactly raw mode
looks like under the hood any more.

Signed-off-by: Alyssa Ross <hi@alyssa.is>
