### PR TITLE
Unsafe comments and fixes

### DIFF
--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -488,6 +488,7 @@ impl Net {
 
         for fd in fds.iter() {
             // Duplicate so that it can survive reboots
+            // SAFETY: FFI call to dup. Trivially safe.
             let fd = unsafe { libc::dup(*fd) };
             if fd < 0 {
                 return Err(Error::DuplicateTapFd(std::io::Error::last_os_error()));

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -178,6 +178,7 @@ impl EpollContext {
     pub fn new() -> result::Result<EpollContext, io::Error> {
         let epoll_fd = epoll::create(true)?;
         // Use 'File' to enforce closing on 'epoll_fd'
+        // SAFETY: the epoll_fd returned by epoll::create is valid and owned by us.
         let epoll_file = unsafe { File::from_raw_fd(epoll_fd) };
 
         Ok(EpollContext { epoll_file })


### PR DESCRIPTION
Some only require adding a comment.

There is one real issue in which -1 may be wrapped into File. Although panicking is safe in Rust, it is still better to have clear error messages.