### PR TITLE
pci: vfio_user: Merge duplicate 'impl VfioUserPciDevice' block

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -900,7 +900,7 @@ pub struct DeviceManager {
     #[cfg(feature = "acpi")]
     selected_segment: usize,
 
-    // Possible handle to the virtio-balloon device
+    // Possible handle to the virtio-mem device
     virtio_mem_devices: Vec<Arc<Mutex<virtio_devices::Mem>>>,
 
     #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
I found it is easier to read when having a single `impl VfioUserPciDevice` block. Also, it fixed a trivial comment typo.

No functional change.

Signed-off-by: Bo Chen <chen.bo@intel.com>
