### PR TITLE
Enable multiple PCI segments on AArch64

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3231,7 +3231,7 @@ mod tests {
         }
 
         #[test]
-        #[cfg(all(not(feature = "mshv"), target_arch = "x86_64"))]
+        #[cfg(not(feature = "mshv"))]
         fn test_virtio_fs_multi_segment_hotplug() {
             test_virtio_fs(
                 true,
@@ -4930,7 +4930,6 @@ mod tests {
             _test_pmem_hotplug(None)
         }
 
-        #[cfg(target_arch = "x86_64")]
         #[test]
         fn test_pmem_multi_segment_hotplug() {
             _test_pmem_hotplug(Some(15))
@@ -5072,7 +5071,6 @@ mod tests {
             _test_net_hotplug(None)
         }
 
-        #[cfg(target_arch = "x86_64")]
         #[test]
         fn test_net_multi_segment_hotplug() {
             _test_net_hotplug(Some(15))

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -439,6 +439,8 @@ fn create_iort_table(pci_segments: &[PciSegment]) -> Sdt {
         );
         // Revision
         iort.write(node_offset + 3, (3u8).to_le());
+        // Node ID
+        iort.write(node_offset + 4, (segment.id as u32).to_le());
         // Mapping counts
         iort.write(node_offset + 8, (1u32).to_le());
         // Offset from the start of the RC node to the start of its Array of ID mappings
@@ -449,6 +451,8 @@ fn create_iort_table(pci_segments: &[PciSegment]) -> Sdt {
         iort.write(node_offset + 24, 3u8);
         // PCI segment number
         iort.write(node_offset + 28, (segment.id as u32).to_le());
+        // Memory address size limit
+        iort.write(node_offset + 32, (64u8).to_le());
 
         // From offset 32 onward is the space for ID mappings Array.
         // Now we have only one mapping.


### PR DESCRIPTION
Fixes https://github.com/cloud-hypervisor/cloud-hypervisor/issues/3296

The PR enabled multiple PCI segments support on ACPI only. 
The enabling on FDT depends on some modifications in this PR, will come soon.
