### PR TITLE
AArch64: Enable the FDT support of PCI multiple segments

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -608,6 +608,19 @@ fn create_pci_nodes(
             pci_device_info_elem.mmio_config_address,
             PCI_MMIO_CONFIG_SIZE_PER_SEGMENT,
         ];
+        // See kernel document Documentation/devicetree/bindings/pci/pci-msi.txt
+        let msi_map = [
+            // rid-base: A single cell describing the first RID matched by the entry.
+            0x0,
+            // msi-controller: A single phandle to an MSI controller.
+            MSI_PHANDLE,
+            // msi-base: An msi-specifier describing the msi-specifier produced for the
+            // first RID matched by the entry.
+            (pci_device_info_elem.pci_segment_id as u32) << 8,
+            // length: A single cell describing how many consecutive RIDs are matched
+            // following the rid-base.
+            0x100,
+        ];
 
         let pci_node_name = format!("pci@{:x}", pci_device_info_elem.mmio_config_address);
         let pci_node = fdt.begin_node(&pci_node_name)?;
@@ -627,6 +640,7 @@ fn create_pci_nodes(
         fdt.property_null("interrupt-map")?;
         fdt.property_null("interrupt-map-mask")?;
         fdt.property_null("dma-coherent")?;
+        fdt.property_array_u32("msi-map", &msi_map)?;
         fdt.property_u32("msi-parent", MSI_PHANDLE)?;
 
         if pci_device_info_elem.pci_segment_id == 0 {

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -104,7 +104,7 @@ pub const RSDP_POINTER: GuestAddress = GuestAddress(ACPI_START);
 pub const KERNEL_START: u64 = ACPI_START + ACPI_MAX_SIZE as u64;
 
 /// Pci high memory base
-pub const PCI_HIGH_BASE: u64 = 0x80_0000_0000_u64;
+pub const PCI_HIGH_BASE: u64 = 0x2_0000_0000_u64;
 
 // As per virt/kvm/arm/vgic/vgic-kvm-device.c we need
 // the number of interrupts our GIC will support to be:

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -82,6 +82,8 @@ pub const MEM_32BIT_DEVICES_SIZE: u64 = 0x2000_0000;
 /// PCI MMCONFIG space (start: after the device space at 1 GiB, length: 256MiB)
 pub const PCI_MMCONFIG_START: GuestAddress = GuestAddress(0x3000_0000);
 pub const PCI_MMCONFIG_SIZE: u64 = 256 << 20;
+// One bus with potentially 256 devices (32 slots x 8 functions).
+pub const PCI_MMIO_CONFIG_SIZE_PER_SEGMENT: u64 = 4096 * 256;
 
 /// Start of RAM on 64 bit ARM.
 pub const RAM_64BIT_START: u64 = 0x4000_0000;

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -14,7 +14,7 @@ pub mod regs;
 pub mod uefi;
 
 pub use self::fdt::DeviceInfoForFdt;
-use crate::{DeviceType, GuestMemoryMmap, NumaNodes, RegionType};
+use crate::{DeviceType, GuestMemoryMmap, NumaNodes, PciSpaceInfo, RegionType};
 use gic::GicDevice;
 use log::{log_enabled, Level};
 use std::collections::HashMap;
@@ -140,7 +140,7 @@ pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::Bui
     vcpu_topology: Option<(u8, u8, u8)>,
     device_info: &HashMap<(DeviceType, String), T, S>,
     initrd: &Option<super::InitramfsConfig>,
-    pci_space_address: &(u64, u64),
+    pci_space_info: &[PciSpaceInfo],
     virtio_iommu_bdf: Option<u32>,
     gic_device: &dyn GicDevice,
     numa_nodes: &NumaNodes,
@@ -153,7 +153,7 @@ pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::Bui
         device_info,
         gic_device,
         initrd,
-        pci_space_address,
+        pci_space_info,
         numa_nodes,
         virtio_iommu_bdf,
     )

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -162,6 +162,16 @@ pub struct MmioDeviceInfo {
     pub irq: u32,
 }
 
+/// Structure to describe PCI space information
+#[derive(Clone, Debug)]
+#[cfg(target_arch = "aarch64")]
+pub struct PciSpaceInfo {
+    pub pci_segment_id: u16,
+    pub mmio_config_address: u64,
+    pub pci_device_space_start: u64,
+    pub pci_device_space_size: u64,
+}
+
 #[cfg(target_arch = "aarch64")]
 impl DeviceInfoForFdt for MmioDeviceInfo {
     fn addr(&self) -> u64 {

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -93,6 +93,8 @@ pub const MEM_32BIT_DEVICES_SIZE: u64 = 640 << 20;
 pub const PCI_MMCONFIG_START: GuestAddress =
     GuestAddress(MEM_32BIT_DEVICES_START.0 + MEM_32BIT_DEVICES_SIZE);
 pub const PCI_MMCONFIG_SIZE: u64 = 256 << 20;
+// One bus with potentially 256 devices (32 slots x 8 functions).
+pub const PCI_MMIO_CONFIG_SIZE_PER_SEGMENT: u64 = 4096 * 256;
 
 // TSS is 3 pages after the PCI MMCONFIG space
 pub const KVM_TSS_START: GuestAddress = GuestAddress(PCI_MMCONFIG_START.0 + PCI_MMCONFIG_SIZE);

--- a/docs/device_model.md
+++ b/docs/device_model.md
@@ -89,7 +89,9 @@ feature is enabled by default.
 ## Virtio devices
 
 For all virtio devices listed below, only `virtio-pci` transport layer is
-supported.
+supported. Cloud Hypervisor supports multiple PCI segments, and users can
+append `,pci_segment=<PCI_segment_number>` to the device flag in the Cloud
+Hypervisor command line to assign devices to a specific PCI segment.
 
 ### virtio-block
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3407,7 +3407,7 @@ impl DeviceManager {
         Arc::clone(self.pci_segments[0].pci_config_io.as_ref().unwrap())
     }
 
-    #[cfg(feature = "acpi")]
+    #[cfg(any(target_arch = "aarch64", feature = "acpi"))]
     pub(crate) fn pci_segments(&self) -> &Vec<PciSegment> {
         &self.pci_segments
     }


### PR DESCRIPTION
This PR enables the FDT support of PCI multiple segments, and should be dependent on https://github.com/cloud-hypervisor/cloud-hypervisor/pull/3356/commits/731ad9b8db7cccc4ab20b6c66585c39a60c6d436 of https://github.com/cloud-hypervisor/cloud-hypervisor/pull/3356.

- Adds the FDT support of PCI multiple segments
- Adds some more documentation to describe how to assign device to PCI segment
- Enhances the PCI multiple segment test cases