### PR TITLE
devices: legacy: cmos: Fix register D emulation

### DIFF
--- a/devices/src/legacy/cmos.rs
+++ b/devices/src/legacy/cmos.rs
@@ -121,6 +121,9 @@ impl BusDevice for Cmos {
                     0x09 => to_bcd((year % 100) as u8),
                     // Bit 5 for 32kHz clock. Bit 7 for Update in Progress
                     0x0a => 1 << 5 | (update_in_progress as u8) << 7,
+                    // Bit 0-6 are reserved and must be 0.
+                    // Bit 7 must be 1 (CMOS has power)
+                    0x0d => 1 << 7,
                     0x32 => to_bcd(((year + 1900) / 100) as u8),
                     _ => {
                         // self.index is always guaranteed to be in range via INDEX_MASK.


### PR DESCRIPTION
The register D has only one bit that is not reserved, and its purpose is
to report if the RTC/CMOS device is powered or not.

The OVMF firmware was failing to boot as it was getting the information
that the device was powered off from the register D.

The simple way to fix this issue is by always returning the bit 7 from
register D as 1, indicating the device is always powered.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>