### PR TITLE
ci: Update the OVMF version the tests rely on

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -201,7 +201,7 @@ pipeline{
 						stage ('Download assets') {
 							steps {
 								sh "mkdir ${env.HOME}/workloads"
-								sh 'az storage blob download --container-name private-images --file "$HOME/workloads/OVMF-4b47d0c6c8.fd" --name OVMF-4b47d0c6c8.fd --connection-string "$AZURE_CONNECTION_STRING"'
+								sh 'az storage blob download --container-name private-images --file "$HOME/workloads/OVMF-83041af43c.fd" --name OVMF-83041af43c.fd --connection-string "$AZURE_CONNECTION_STRING"'
 								sh 'az storage blob download --container-name private-images --file "$HOME/workloads/windows-server-2019.raw" --name windows-server-2019.raw --connection-string "$AZURE_CONNECTION_STRING"'
 							}
 						}

--- a/docs/uefi.md
+++ b/docs/uefi.md
@@ -17,7 +17,7 @@ cd edk2
 . edksetup.sh
 git submodule update --init
 
-echo "ACTIVE_PLATFORM=OvmfPkg/OvmfCh.dsc" >> Conf/target.txt
+echo "ACTIVE_PLATFORM=OvmfPkg/OvmfPkgX64.dsc" >> Conf/target.txt
 echo "TARGET_ARCH=X64" >> Conf/target.txt
 echo "TOOL_CHAIN_TAG=GCC5" >> Conf/target.txt
 
@@ -25,7 +25,7 @@ make -C ./BaseTools
 build
 ```
 
-After the successful build, the resulting firmware binaries are available under `Build/OvmfCh/DEBUG_GCC5/FV` underneath the edk2 checkout.
+After the successful build, the resulting firmware binaries are available under `Build/OvmfX64/DEBUG_GCC5/FV` underneath the edk2 checkout.
 
 ## Using OVMF Binaries
 
@@ -57,7 +57,7 @@ cd edk2
 git submodule update --init --recursive
 cp ../seabios/out/Csm16.bin OvmfPkg/Csm/Csm16/
 
-echo "ACTIVE_PLATFORM=OvmfPkg/OvmfCh.dsc" >> Conf/target.txt
+echo "ACTIVE_PLATFORM=OvmfPkg/OvmfPkgX64.dsc" >> Conf/target.txt
 echo "TARGET_ARCH=X64" >> Conf/target.txt
 echo "TOOL_CHAIN_TAG=GCC5" >> Conf/target.txt
 

--- a/scripts/run_integration_tests_windows.sh
+++ b/scripts/run_integration_tests_windows.sh
@@ -14,7 +14,7 @@ if [ "$hypervisor" = "mshv" ] ;  then
     features_test="--no-default-features --features mshv,common,integration_tests"
 fi
 WIN_IMAGE_FILE="/root/workloads/windows-server-2019.raw"
-OVMF_FW_FILE="/root/workloads/OVMF-4b47d0c6c8.fd"
+OVMF_FW_FILE="/root/workloads/OVMF-83041af43c.fd"
 BUILD_TARGET="$(uname -m)-unknown-linux-${CH_LIBC}"
 CFLAGS=""
 TARGET_CC=""

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -138,6 +138,7 @@ pub trait DiskConfig {
     fn disk(&self, disk_type: DiskType) -> Option<String>;
 }
 
+#[derive(Clone)]
 pub struct UbuntuDiskConfig {
     osdisk_path: String,
     cloudinit_path: String,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -63,7 +63,7 @@ mod tests {
         pub const FOCAL_IMAGE_NAME_VHDX: &str =
             "focal-server-cloudimg-amd64-custom-20210609-0.vhdx";
         pub const WINDOWS_IMAGE_NAME: &str = "windows-server-2019.raw";
-        pub const OVMF_NAME: &str = "OVMF-4b47d0c6c8.fd";
+        pub const OVMF_NAME: &str = "OVMF-83041af43c.fd";
         pub const GREP_SERIAL_IRQ_CMD: &str = "grep -c 'IO-APIC.*ttyS0' /proc/interrupts || true";
     }
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1444,6 +1444,11 @@ impl MemoryManager {
             log_dirty,
         );
 
+        info!(
+            "Creating userspace mapping: {:x} -> {:x} {:x}, slot {}",
+            guest_phys_addr, userspace_addr, memory_size, slot
+        );
+
         self.vm
             .create_user_memory_region(mem_region)
             .map_err(Error::CreateUserMemoryRegion)?;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1021,6 +1021,12 @@ impl Vm {
                         .checked_sub(size)
                         .ok_or(Error::FirmwareTooLarge)?;
 
+                    info!(
+                        "Loading RAW firmware at 0x{:x} (size: {})",
+                        load_address.raw_value(),
+                        size
+                    );
+
                     self.memory_manager
                         .lock()
                         .unwrap()


### PR DESCRIPTION
Bumping the OVMF binary version to reflect the latest set of patches on
top of tianocore/edk2 'master' branch, which can be found on the Cloud
Hypervisor fork on 'ch' branch.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>