### PR TITLE
tests: Temporarily disable test_vfio_user

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5975,6 +5975,7 @@ mod tests {
         }
 
         #[cfg(target_arch = "x86_64")]
+        #[ignore]
         #[test]
         fn test_vfio_user() {
             let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());


### PR DESCRIPTION
This test is flaky (#3400) while we are experiencing a bug of using the latest
SPDK/NVMe backend as VFIO user device (#3401). Let's disable this test
before we fix the above two issues.

Signed-off-by: Bo Chen <chen.bo@intel.com>