### PR TITLE
arch: x86_64: Only reserve used 32-bit address space

### DIFF
--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -79,9 +79,9 @@ pub const HIGH_RAM_START: GuestAddress = GuestAddress(0x100000);
 
 // == No fixed addresses in the "High RAM" range ==
 
-// ** 32-bit reserved area (start: 3GiB, length: 1GiB) **
+// ** 32-bit reserved area (start: 3GiB, length: 896MiB) **
 pub const MEM_32BIT_RESERVED_START: GuestAddress = GuestAddress(0xc000_0000);
-pub const MEM_32BIT_RESERVED_SIZE: u64 = 1024 << 20;
+pub const MEM_32BIT_RESERVED_SIZE: u64 = PCI_MMCONFIG_SIZE + MEM_32BIT_DEVICES_SIZE;
 
 // == Fixed constants within the "32-bit reserved" range ==
 


### PR DESCRIPTION
Reduce the size of the reserved 32-bit address space to the range used
by both the PCI MMIO config data and the 32-bit PCI device space.

This avoids issues when using firmware that is loaded into the very top
of the 32-bit address space as the RAM conflicts with the reserved
memory.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>