### PR TITLE
arch, hypervisor, vmm: Explicitly place the TSS in the 32-bit space

### DIFF
--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -94,15 +94,16 @@ pub const PCI_MMCONFIG_START: GuestAddress =
     GuestAddress(MEM_32BIT_DEVICES_START.0 + MEM_32BIT_DEVICES_SIZE);
 pub const PCI_MMCONFIG_SIZE: u64 = 256 << 20;
 
+// TSS is 3 pages after the PCI MMCONFIG space
+pub const KVM_TSS_START: GuestAddress = GuestAddress(PCI_MMCONFIG_START.0 + PCI_MMCONFIG_SIZE);
+pub const KVM_TSS_SIZE: u64 = (3 * 4) << 10;
+
 // IOAPIC
 pub const IOAPIC_START: GuestAddress = GuestAddress(0xfec0_0000);
 pub const IOAPIC_SIZE: u64 = 0x20;
 
 // APIC
 pub const APIC_START: GuestAddress = GuestAddress(0xfee0_0000);
-
-/// Address for the TSS setup.
-pub const KVM_TSS_ADDRESS: GuestAddress = GuestAddress(0xfffb_d000);
 
 // == End of "32-bit reserved" range. ==
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -32,8 +32,6 @@ use std::result;
 #[cfg(target_arch = "x86_64")]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
-#[cfg(target_arch = "x86_64")]
-use vm_memory::Address;
 use vmm_sys_util::eventfd::EventFd;
 // x86_64 dependencies
 #[cfg(target_arch = "x86_64")]
@@ -47,9 +45,7 @@ use kvm_bindings::{
     kvm_enable_cap, kvm_msr_entry, MsrList, KVM_CAP_HYPERV_SYNIC, KVM_CAP_SPLIT_IRQCHIP,
 };
 #[cfg(target_arch = "x86_64")]
-use x86_64::{
-    check_required_kvm_extensions, FpuState, SpecialRegisters, StandardRegisters, KVM_TSS_ADDRESS,
-};
+use x86_64::{check_required_kvm_extensions, FpuState, SpecialRegisters, StandardRegisters};
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
     CpuId, CpuIdEntry, ExtendedControlRegisters, LapicState, MsrEntries, VcpuKvmState as CpuState,
@@ -353,10 +349,6 @@ impl vm::Vm for KvmVm {
     }
     #[cfg(target_arch = "x86_64")]
     fn enable_split_irq(&self) -> vm::Result<()> {
-        // Set TSS
-        self.fd
-            .set_tss_address(KVM_TSS_ADDRESS.raw_value() as usize)
-            .map_err(|e| vm::HypervisorVmError::EnableSplitIrq(e.into()))?;
         // Create split irqchip
         // Only the local APIC is emulated in kernel, both PICs and IOAPIC
         // are not.

--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -11,7 +11,6 @@
 use crate::arch::x86::{msr_index, SegmentRegisterOps, MTRR_ENABLE, MTRR_MEM_TYPE_WB};
 use crate::kvm::{Cap, Kvm, KvmError, KvmResult};
 use serde_derive::{Deserialize, Serialize};
-use vm_memory::GuestAddress;
 
 ///
 /// Export generically-named wrappers of kvm-bindings for Unix-based platforms
@@ -92,8 +91,6 @@ impl SegmentRegisterOps for SegmentRegister {
     }
 }
 
-pub const KVM_TSS_ADDRESS: GuestAddress = GuestAddress(0xfffb_d000);
-
 pub fn boot_msr_entries() -> MsrEntries {
     MsrEntries::from_entries(&[
         msr!(msr_index::MSR_IA32_SYSENTER_CS),
@@ -126,6 +123,9 @@ pub fn check_required_kvm_extensions(kvm: &Kvm) -> KvmResult<()> {
     }
     if !kvm.check_extension(Cap::SplitIrqchip) {
         return Err(KvmError::CapabilityMissing(Cap::SplitIrqchip));
+    }
+    if !kvm.check_extension(Cap::SetTssAddr) {
+        return Err(KvmError::CapabilityMissing(Cap::SetTssAddr));
     }
     Ok(())
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -31,6 +31,8 @@ use crate::{
 };
 use anyhow::anyhow;
 use arch::get_host_cpu_phys_bits;
+#[cfg(target_arch = "x86_64")]
+use arch::layout::KVM_TSS_START;
 #[cfg(all(feature = "tdx", feature = "acpi"))]
 use arch::x86_64::tdx::TdVmmDataRegionType;
 #[cfg(feature = "tdx")]
@@ -753,7 +755,11 @@ impl Vm {
         let vm = hypervisor.create_vm().unwrap();
 
         #[cfg(target_arch = "x86_64")]
-        vm.enable_split_irq().unwrap();
+        {
+            vm.set_tss_address(KVM_TSS_START.0 as usize).unwrap();
+            vm.enable_split_irq().unwrap();
+        }
+
         let phys_bits = physical_bits(config.lock().unwrap().cpus.max_phys_bits);
 
         #[cfg(target_arch = "x86_64")]
@@ -810,8 +816,13 @@ impl Vm {
     ) -> Result<Self> {
         hypervisor.check_required_extensions().unwrap();
         let vm = hypervisor.create_vm().unwrap();
+
         #[cfg(target_arch = "x86_64")]
-        vm.enable_split_irq().unwrap();
+        {
+            vm.set_tss_address(KVM_TSS_START.0 as usize).unwrap();
+            vm.enable_split_irq().unwrap();
+        }
+
         let vm_snapshot = get_vm_snapshot(snapshot).map_err(Error::Restore)?;
         let config = vm_snapshot.config;
         if let Some(state) = vm_snapshot.state {
@@ -864,8 +875,13 @@ impl Vm {
     ) -> Result<Self> {
         hypervisor.check_required_extensions().unwrap();
         let vm = hypervisor.create_vm().unwrap();
+
         #[cfg(target_arch = "x86_64")]
-        vm.enable_split_irq().unwrap();
+        {
+            vm.set_tss_address(KVM_TSS_START.0 as usize).unwrap();
+            vm.enable_split_irq().unwrap();
+        }
+
         let phys_bits = physical_bits(config.lock().unwrap().cpus.max_phys_bits);
 
         let memory_manager = MemoryManager::new(


### PR DESCRIPTION
Place the 3 page TSS at an explicit location in the 32-bit address space
to avoid conflicting with the loaded raw firmware.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>