### PR TITLE
vmm: fix HANDLED_SIGNALS build error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -513,8 +513,8 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
     // Before we start any threads, mask the signals we'll be
     // installing handlers for, to make sure they only ever run on the
     // dedicated signal handling thread we'll start in a bit.
-    for sig in vmm::vm::HANDLED_SIGNALS {
-        if let Err(e) = block_signal(sig) {
+    for sig in &vmm::vm::HANDLED_SIGNALS {
+        if let Err(e) = block_signal(*sig) {
             eprintln!("Error blocking signals: {}", e);
         }
     }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1654,8 +1654,8 @@ impl Vm {
         on_tty: bool,
         exit_evt: &EventFd,
     ) {
-        for sig in HANDLED_SIGNALS {
-            unblock_signal(sig).unwrap();
+        for sig in &HANDLED_SIGNALS {
+            unblock_signal(*sig).unwrap();
         }
 
         for signal in signals.forever() {


### PR DESCRIPTION
The error was:

	borrow the array with `&` or call `.iter()` on it to iterate
	over it

Fixes #3348
Signed-off-by: Barret Rhoden <brho@google.com>