### PR TITLE
tests: Update the virtiofsd-rs cmdline

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -141,7 +141,7 @@ mod tests {
         // Start the daemon
         let child = Command::new(virtiofsd_path.as_str())
             .args(&["--shared-dir", shared_dir])
-            .args(&["--socket", virtiofsd_socket_path.as_str()])
+            .args(&["--socket-path", virtiofsd_socket_path.as_str()])
             .args(&["--cache", cache])
             .spawn()
             .unwrap();


### PR DESCRIPTION
Commit ac2517217634ca8b89e441f5769ab6b916868ee1 bumps the rust version of virtiofsd named `virtiofsd-rs`, which causes a warning:
```
warning: use of deprecated parameter '--socket':
Please use the '--socket-path' option instead.
```

This commit updates the cmdline parameter accordingly.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>