### PR TITLE
vmm: Set KVM identity map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,8 +464,7 @@ dependencies = [
 [[package]]
 name = "kvm-ioctls"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97422ba48d7ffb66fd4d18130f72ab66f9bbbf791fb7a87b9291cdcfec437593"
+source = "git+https://github.com/rust-vmm/kvm-ioctls?branch=main#d22ef1f51852dfb055da38004e1a4fed81246f81"
 dependencies = [
  "kvm-bindings",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ clap = { version = "2.34.0", features = ["wrap_help"] }
 # List of patched crates
 [patch.crates-io]
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0", features = ["with-serde", "fam-wrappers"] }
+kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "main" }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
 
 [dev-dependencies]

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -98,6 +98,10 @@ pub const PCI_MMCONFIG_SIZE: u64 = 256 << 20;
 pub const KVM_TSS_START: GuestAddress = GuestAddress(PCI_MMCONFIG_START.0 + PCI_MMCONFIG_SIZE);
 pub const KVM_TSS_SIZE: u64 = (3 * 4) << 10;
 
+// Identity map is a one page region after the TSS
+pub const KVM_IDENTITY_MAP_START: GuestAddress = GuestAddress(KVM_TSS_START.0 + KVM_TSS_SIZE);
+pub const KVM_IDENTITY_MAP_SIZE: u64 = 4 << 10;
+
 // IOAPIC
 pub const IOAPIC_START: GuestAddress = GuestAddress(0xfec0_0000);
 pub const IOAPIC_SIZE: u64 = 0x20;

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "cloud-hypervisor"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "api_client",
@@ -324,8 +324,7 @@ dependencies = [
 [[package]]
 name = "kvm-ioctls"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97422ba48d7ffb66fd4d18130f72ab66f9bbbf791fb7a87b9291cdcfec437593"
+source = "git+https://github.com/rust-vmm/kvm-ioctls?branch=main#d22ef1f51852dfb055da38004e1a4fed81246f81"
 dependencies = [
  "kvm-bindings",
  "libc",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,6 +26,7 @@ path = ".."
 
 [patch.crates-io]
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0", features = ["with-serde", "fam-wrappers"] }
+kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "main" }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
 
 # Prevent this from interfering with workspaces

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -137,6 +137,15 @@ pub struct KvmVm {
 impl vm::Vm for KvmVm {
     #[cfg(target_arch = "x86_64")]
     ///
+    /// Sets the address of the one-page region in the VM's address space.
+    ///
+    fn set_identity_map_address(&self, address: u64) -> vm::Result<()> {
+        self.fd
+            .set_identity_map_address(address)
+            .map_err(|e| vm::HypervisorVmError::SetIdentityMapAddress(e.into()))
+    }
+    #[cfg(target_arch = "x86_64")]
+    ///
     /// Sets the address of the three-page region in the VM's address space.
     ///
     fn set_tss_address(&self, offset: usize) -> vm::Result<()> {

--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -124,6 +124,9 @@ pub fn check_required_kvm_extensions(kvm: &Kvm) -> KvmResult<()> {
     if !kvm.check_extension(Cap::SplitIrqchip) {
         return Err(KvmError::CapabilityMissing(Cap::SplitIrqchip));
     }
+    if !kvm.check_extension(Cap::SetIdentityMapAddr) {
+        return Err(KvmError::CapabilityMissing(Cap::SetIdentityMapAddr));
+    }
     if !kvm.check_extension(Cap::SetTssAddr) {
         return Err(KvmError::CapabilityMissing(Cap::SetTssAddr));
     }

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -766,6 +766,13 @@ fn hv_state_init() -> Arc<RwLock<HvState>> {
 impl vm::Vm for MshvVm {
     #[cfg(target_arch = "x86_64")]
     ///
+    /// Sets the address of the one-page region in the VM's address space.
+    ///
+    fn set_identity_map_address(&self, _address: u64) -> vm::Result<()> {
+        Ok(())
+    }
+    #[cfg(target_arch = "x86_64")]
+    ///
     /// Sets the address of the three-page region in the VM's address space.
     ///
     fn set_tss_address(&self, _offset: usize) -> vm::Result<()> {

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -58,6 +58,11 @@ pub enum HypervisorVmError {
     #[error("Failed to create Vcpu: {0}")]
     CreateVcpu(#[source] anyhow::Error),
     ///
+    /// Identity map address error
+    ///
+    #[error("Failed to set identity map address: {0}")]
+    SetIdentityMapAddress(#[source] anyhow::Error),
+    ///
     /// TSS address error
     ///
     #[error("Failed to set TSS address: {0}")]
@@ -217,6 +222,9 @@ pub type Result<T> = std::result::Result<T, HypervisorVmError>;
 /// This crate provides a hypervisor-agnostic interfaces for Vm
 ///
 pub trait Vm: Send + Sync {
+    #[cfg(target_arch = "x86_64")]
+    /// Sets the address of the one-page region in the VM's address space.
+    fn set_identity_map_address(&self, address: u64) -> Result<()>;
     #[cfg(target_arch = "x86_64")]
     /// Sets the address of the three-page region in the VM's address space.
     fn set_tss_address(&self, offset: usize) -> Result<()>;

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -275,6 +275,7 @@ fn create_vmm_ioctl_seccomp_rule_kvm() -> Result<Vec<SeccompRule>, BackendError>
     const KVM_SET_CLOCK: u64 = 0x4030_ae7b;
     const KVM_SET_CPUID2: u64 = 0x4008_ae90;
     const KVM_SET_FPU: u64 = 0x41a0_ae8d;
+    const KVM_SET_IDENTITY_MAP_ADDR: u64 = 0x4008_ae48;
     const KVM_SET_LAPIC: u64 = 0x4400_ae8f;
     const KVM_SET_MSRS: u64 = 0x4008_ae89;
     const KVM_SET_SREGS: u64 = 0x4138_ae84;
@@ -298,6 +299,7 @@ fn create_vmm_ioctl_seccomp_rule_kvm() -> Result<Vec<SeccompRule>, BackendError>
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_CLOCK)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_CPUID2)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_FPU)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_IDENTITY_MAP_ADDR)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_LAPIC)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_SREGS)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_TSS_ADDR,)?],

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -32,7 +32,7 @@ use crate::{
 use anyhow::anyhow;
 use arch::get_host_cpu_phys_bits;
 #[cfg(target_arch = "x86_64")]
-use arch::layout::KVM_TSS_START;
+use arch::layout::{KVM_IDENTITY_MAP_START, KVM_TSS_START};
 #[cfg(all(feature = "tdx", feature = "acpi"))]
 use arch::x86_64::tdx::TdVmmDataRegionType;
 #[cfg(feature = "tdx")]
@@ -756,6 +756,8 @@ impl Vm {
 
         #[cfg(target_arch = "x86_64")]
         {
+            vm.set_identity_map_address(KVM_IDENTITY_MAP_START.0)
+                .unwrap();
             vm.set_tss_address(KVM_TSS_START.0 as usize).unwrap();
             vm.enable_split_irq().unwrap();
         }
@@ -819,6 +821,8 @@ impl Vm {
 
         #[cfg(target_arch = "x86_64")]
         {
+            vm.set_identity_map_address(KVM_IDENTITY_MAP_START.0)
+                .unwrap();
             vm.set_tss_address(KVM_TSS_START.0 as usize).unwrap();
             vm.enable_split_irq().unwrap();
         }
@@ -878,6 +882,8 @@ impl Vm {
 
         #[cfg(target_arch = "x86_64")]
         {
+            vm.set_identity_map_address(KVM_IDENTITY_MAP_START.0)
+                .unwrap();
             vm.set_tss_address(KVM_TSS_START.0 as usize).unwrap();
             vm.enable_split_irq().unwrap();
         }


### PR DESCRIPTION
In order to avoid any conflict with the firmware loaded at the last 4MiB of the 4GiB space, we explicitly set the identity map address so that the corresponding one-page region is placed right after the TSS region.