### PR TITLE
vmm: Move KVM clock saving to common Vm::restore() method

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -826,10 +826,6 @@ impl Vmm {
             MigratableError::MigrateReceive(anyhow!("Error deserialising snapshot: {}", e))
         })?;
 
-        #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-        vm.load_clock_from_snapshot(&snapshot)
-            .map_err(|e| MigratableError::MigrateReceive(anyhow!("Error resume clock: {:?}", e)))?;
-
         // Create VM
         vm.restore(snapshot).map_err(|e| {
             Response::error().write_to(socket).ok();


### PR DESCRIPTION
Saving the KVM clock and restoring it is key for correct behaviour of
the VM when doing snapshot/restore or live migration. The clock is
restored to the KVM state as part of the Vm::resume() method prior to
that it must be extracted from the state object and stored for later use
by this method. This change simplifies the extraction and storage part
so that it is done in the same way for both snapshot/restore and live
migration.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>