### PR TITLE
vmm: Replace device tree value when restoring DeviceManager

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1167,7 +1167,7 @@ impl DeviceManager {
     }
 
     fn set_state(&mut self, state: &DeviceManagerState) {
-        self.device_tree = Arc::new(Mutex::new(state.device_tree.clone()));
+        *self.device_tree.lock().unwrap() = state.device_tree.clone();
         self.device_id_cnt = state.device_id_cnt;
     }
 


### PR DESCRIPTION
When restoring replace the internal value of the device tree rather than
replacing the Arc<Mutex<DeviceTree>> itself. This is fixes an issue
where the AddressManager has a copy of the the original
Arc<Mutex<DeviceTree>> from when the DeviceManager was created. The
original restore path only replaced the DeviceManager's version of the
Arc<Mutex<DeviceTree>>. Instead replace the contents of the
Arc<Mutex<DeviceTree>> so all users see the updated version.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>