### PR TITLE
tests: Re-enable vfio_user integration test

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6105,7 +6105,6 @@ mod tests {
         }
 
         #[cfg(target_arch = "x86_64")]
-        #[ignore]
         #[test]
         fn test_vfio_user() {
             let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
@@ -6114,14 +6113,12 @@ mod tests {
             let spdk_nvme_dir = guest.tmp_dir.as_path().join("test-vfio-user");
             setup_spdk_nvme(spdk_nvme_dir.as_path());
 
-            let kernel_path = direct_kernel_boot_path();
             let api_socket = temp_api_path(&guest.tmp_dir);
             let mut child = GuestCommand::new(&guest)
                 .args(&["--api-socket", &api_socket])
                 .args(&["--cpus", "boot=1"])
                 .args(&["--memory", "size=512M,shared=on"])
-                .args(&["--kernel", kernel_path.to_str().unwrap()])
-                .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+                .args(&["--kernel", guest.fw_path.as_str()])
                 .default_disks()
                 .default_net()
                 .capture_output()

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4008,19 +4008,27 @@ impl Aml for DeviceManager {
             segment.append_aml_bytes(bytes);
         }
 
+        let mut mbrd_memory = Vec::new();
+
+        for segment in &self.pci_segments {
+            mbrd_memory.push(aml::Memory32Fixed::new(
+                true,
+                segment.mmio_config_address as u32,
+                layout::PCI_MMIO_CONFIG_SIZE_PER_SEGMENT as u32,
+            ))
+        }
+
+        let mut mbrd_memory_refs = Vec::new();
+        for mbrd_memory_ref in &mbrd_memory {
+            mbrd_memory_refs.push(mbrd_memory_ref as &dyn Aml);
+        }
+
         aml::Device::new(
             "_SB_.MBRD".into(),
             vec![
                 &aml::Name::new("_HID".into(), &aml::EisaName::new("PNP0C02")),
                 &aml::Name::new("_UID".into(), &aml::ZERO),
-                &aml::Name::new(
-                    "_CRS".into(),
-                    &aml::ResourceTemplate::new(vec![&aml::Memory32Fixed::new(
-                        true,
-                        layout::PCI_MMCONFIG_START.0 as u32,
-                        layout::PCI_MMCONFIG_SIZE as u32,
-                    )]),
-                ),
+                &aml::Name::new("_CRS".into(), &aml::ResourceTemplate::new(mbrd_memory_refs)),
             ],
         )
         .append_aml_bytes(bytes);


### PR DESCRIPTION
This time we use the Rust Hypervisor Firmware for test_vfio_user() in
order to fix the systemd issues we've seen so far.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>