### PR TITLE
ci: Try to identify if change in locking is causing the CI to fail

### DIFF
--- a/block_util/src/qcow_sync.rs
+++ b/block_util/src/qcow_sync.rs
@@ -3,50 +3,62 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use crate::async_io::{AsyncIo, AsyncIoResult, DiskFile, DiskFileError, DiskFileResult};
-use crate::{fsync_sync, read_vectored_sync, write_vectored_sync, ReadWriteSeekFile};
+use crate::{fsync_sync, read_vectored_sync, write_vectored_sync};
 use qcow::{QcowFile, RawFile, Result as QcowResult};
 use std::fs::File;
-use std::io::SeekFrom;
+use std::io::{Seek, SeekFrom};
 use std::sync::{Arc, Mutex};
 use vmm_sys_util::eventfd::EventFd;
 
 pub struct QcowDiskSync {
-    qcow_file: Arc<Mutex<dyn ReadWriteSeekFile + Send + Sync>>,
+    qcow_file: QcowFile,
+    semaphore: Arc<Mutex<()>>,
 }
 
 impl QcowDiskSync {
     pub fn new(file: File, direct_io: bool) -> QcowResult<Self> {
         Ok(QcowDiskSync {
-            qcow_file: Arc::new(Mutex::new(QcowFile::from(RawFile::new(file, direct_io))?)),
+            qcow_file: QcowFile::from(RawFile::new(file, direct_io))?,
+            semaphore: Arc::new(Mutex::new(())),
         })
     }
 }
 
 impl DiskFile for QcowDiskSync {
     fn size(&mut self) -> DiskFileResult<u64> {
-        let mut file = self.qcow_file.lock().unwrap();
+        // Take the semaphore to ensure other threads are not interacting with
+        // the underlying file.
+        let _lock = self.semaphore.lock().unwrap();
 
-        Ok(file.seek(SeekFrom::End(0)).map_err(DiskFileError::Size)? as u64)
+        Ok(self
+            .qcow_file
+            .seek(SeekFrom::End(0))
+            .map_err(DiskFileError::Size)? as u64)
     }
 
     fn new_async_io(&self, _ring_depth: u32) -> DiskFileResult<Box<dyn AsyncIo>> {
-        Ok(Box::new(QcowSync::new(self.qcow_file.clone())) as Box<dyn AsyncIo>)
+        Ok(Box::new(QcowSync::new(
+            self.qcow_file.clone(),
+            self.semaphore.clone(),
+        )) as Box<dyn AsyncIo>)
     }
 }
 
 pub struct QcowSync {
-    qcow_file: Arc<Mutex<dyn ReadWriteSeekFile + Send + Sync>>,
+    qcow_file: QcowFile,
     eventfd: EventFd,
     completion_list: Vec<(u64, i32)>,
+    semaphore: Arc<Mutex<()>>,
 }
 
 impl QcowSync {
-    pub fn new(qcow_file: Arc<Mutex<dyn ReadWriteSeekFile + Send + Sync>>) -> Self {
+    pub fn new(qcow_file: QcowFile, semaphore: Arc<Mutex<()>>) -> Self {
         QcowSync {
             qcow_file,
             eventfd: EventFd::new(libc::EFD_NONBLOCK)
                 .expect("Failed creating EventFd for QcowSync"),
             completion_list: Vec::new(),
+            semaphore,
         }
     }
 }
@@ -69,6 +81,7 @@ impl AsyncIo for QcowSync {
             &mut self.qcow_file,
             &self.eventfd,
             &mut self.completion_list,
+            &mut self.semaphore,
         )
     }
 
@@ -85,6 +98,7 @@ impl AsyncIo for QcowSync {
             &mut self.qcow_file,
             &self.eventfd,
             &mut self.completion_list,
+            &mut self.semaphore,
         )
     }
 
@@ -94,6 +108,7 @@ impl AsyncIo for QcowSync {
             &mut self.qcow_file,
             &self.eventfd,
             &mut self.completion_list,
+            &mut self.semaphore,
         )
     }
 

--- a/block_util/src/vhdx_sync.rs
+++ b/block_util/src/vhdx_sync.rs
@@ -3,58 +3,57 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::async_io::{AsyncIo, AsyncIoResult, DiskFile, DiskFileError, DiskFileResult};
-use crate::{fsync_sync, read_vectored_sync, write_vectored_sync, ReadWriteSeekFile};
+use crate::{fsync_sync, read_vectored_sync, write_vectored_sync};
 use std::fs::File;
+use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
 use vhdx::vhdx::{Result as VhdxResult, Vhdx};
 use vmm_sys_util::eventfd::EventFd;
 
 pub struct VhdxDiskSync {
-    vhdx_file: Arc<Mutex<dyn ReadWriteSeekFile + Sync + Send>>,
+    vhdx_file: Arc<Mutex<Vhdx>>,
+    semaphore: Arc<Mutex<()>>,
 }
 
 impl VhdxDiskSync {
     pub fn new(f: File) -> VhdxResult<Self> {
+        let vhdx = Vhdx::new(f)?;
+        let vhdx_file = Arc::new(Mutex::new(vhdx));
+
         Ok(VhdxDiskSync {
-            vhdx_file: Arc::new(Mutex::new(Vhdx::new(f)?)),
+            vhdx_file,
+            semaphore: Arc::new(Mutex::new(())),
         })
     }
 }
 
 impl DiskFile for VhdxDiskSync {
     fn size(&mut self) -> DiskFileResult<u64> {
-        Ok(self
-            .vhdx_file
-            .lock()
-            .unwrap()
-            .as_any()
-            .downcast_ref::<Vhdx>()
-            .unwrap()
-            .virtual_disk_size())
+        Ok(self.vhdx_file.lock().unwrap().virtual_disk_size())
     }
 
     fn new_async_io(&self, _ring_depth: u32) -> DiskFileResult<Box<dyn AsyncIo>> {
-        Ok(
-            Box::new(VhdxSync::new(self.vhdx_file.clone()).map_err(DiskFileError::NewAsyncIo)?)
-                as Box<dyn AsyncIo>,
-        )
+        Ok(Box::new(
+            VhdxSync::new(self.vhdx_file.clone(), self.semaphore.clone())
+                .map_err(DiskFileError::NewAsyncIo)?,
+        ) as Box<dyn AsyncIo>)
     }
 }
 
 pub struct VhdxSync {
-    vhdx_file: Arc<Mutex<dyn ReadWriteSeekFile + Sync + Send>>,
+    vhdx_file: Arc<Mutex<Vhdx>>,
     eventfd: EventFd,
     completion_list: Vec<(u64, i32)>,
+    semaphore: Arc<Mutex<()>>,
 }
 
 impl VhdxSync {
-    pub fn new(
-        vhdx_file: Arc<Mutex<dyn ReadWriteSeekFile + Sync + Send>>,
-    ) -> std::io::Result<Self> {
+    pub fn new(vhdx_file: Arc<Mutex<Vhdx>>, semaphore: Arc<Mutex<()>>) -> std::io::Result<Self> {
         Ok(VhdxSync {
             vhdx_file,
             eventfd: EventFd::new(libc::EFD_NONBLOCK)?,
             completion_list: Vec::new(),
+            semaphore,
         })
     }
 }
@@ -74,9 +73,10 @@ impl AsyncIo for VhdxSync {
             offset,
             iovecs,
             user_data,
-            &mut self.vhdx_file,
+            self.vhdx_file.lock().unwrap().deref_mut(),
             &self.eventfd,
             &mut self.completion_list,
+            &mut self.semaphore,
         )
     }
 
@@ -90,18 +90,20 @@ impl AsyncIo for VhdxSync {
             offset,
             iovecs,
             user_data,
-            &mut self.vhdx_file,
+            self.vhdx_file.lock().unwrap().deref_mut(),
             &self.eventfd,
             &mut self.completion_list,
+            &mut self.semaphore,
         )
     }
 
     fn fsync(&mut self, user_data: Option<u64>) -> AsyncIoResult<()> {
         fsync_sync(
             user_data,
-            &mut self.vhdx_file,
+            self.vhdx_file.lock().unwrap().deref_mut(),
             &self.eventfd,
             &mut self.completion_list,
+            &mut self.semaphore,
         )
     }
 

--- a/block_util/src/vhdx_sync.rs
+++ b/block_util/src/vhdx_sync.rs
@@ -3,14 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::async_io::{AsyncIo, AsyncIoResult, DiskFile, DiskFileError, DiskFileResult};
-use crate::AsyncAdaptor;
+use crate::{fsync_sync, read_vectored_sync, write_vectored_sync, ReadWriteSeekFile};
 use std::fs::File;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex};
 use vhdx::vhdx::{Result as VhdxResult, Vhdx};
 use vmm_sys_util::eventfd::EventFd;
 
 pub struct VhdxDiskSync {
-    vhdx_file: Arc<Mutex<Vhdx>>,
+    vhdx_file: Arc<Mutex<dyn ReadWriteSeekFile + Sync + Send>>,
 }
 
 impl VhdxDiskSync {
@@ -23,7 +23,14 @@ impl VhdxDiskSync {
 
 impl DiskFile for VhdxDiskSync {
     fn size(&mut self) -> DiskFileResult<u64> {
-        Ok(self.vhdx_file.lock().unwrap().virtual_disk_size())
+        Ok(self
+            .vhdx_file
+            .lock()
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Vhdx>()
+            .unwrap()
+            .virtual_disk_size())
     }
 
     fn new_async_io(&self, _ring_depth: u32) -> DiskFileResult<Box<dyn AsyncIo>> {
@@ -35,24 +42,20 @@ impl DiskFile for VhdxDiskSync {
 }
 
 pub struct VhdxSync {
-    vhdx_file: Arc<Mutex<Vhdx>>,
+    vhdx_file: Arc<Mutex<dyn ReadWriteSeekFile + Sync + Send>>,
     eventfd: EventFd,
     completion_list: Vec<(u64, i32)>,
 }
 
 impl VhdxSync {
-    pub fn new(vhdx_file: Arc<Mutex<Vhdx>>) -> std::io::Result<Self> {
+    pub fn new(
+        vhdx_file: Arc<Mutex<dyn ReadWriteSeekFile + Sync + Send>>,
+    ) -> std::io::Result<Self> {
         Ok(VhdxSync {
             vhdx_file,
             eventfd: EventFd::new(libc::EFD_NONBLOCK)?,
             completion_list: Vec::new(),
         })
-    }
-}
-
-impl AsyncAdaptor<Vhdx> for Arc<Mutex<Vhdx>> {
-    fn file(&mut self) -> MutexGuard<Vhdx> {
-        self.lock().unwrap()
     }
 }
 
@@ -67,10 +70,11 @@ impl AsyncIo for VhdxSync {
         iovecs: Vec<libc::iovec>,
         user_data: u64,
     ) -> AsyncIoResult<()> {
-        self.vhdx_file.read_vectored_sync(
+        read_vectored_sync(
             offset,
             iovecs,
             user_data,
+            &mut self.vhdx_file,
             &self.eventfd,
             &mut self.completion_list,
         )
@@ -82,18 +86,23 @@ impl AsyncIo for VhdxSync {
         iovecs: Vec<libc::iovec>,
         user_data: u64,
     ) -> AsyncIoResult<()> {
-        self.vhdx_file.write_vectored_sync(
+        write_vectored_sync(
             offset,
             iovecs,
             user_data,
+            &mut self.vhdx_file,
             &self.eventfd,
             &mut self.completion_list,
         )
     }
 
     fn fsync(&mut self, user_data: Option<u64>) -> AsyncIoResult<()> {
-        self.vhdx_file
-            .fsync_sync(user_data, &self.eventfd, &mut self.completion_list)
+        fsync_sync(
+            user_data,
+            &mut self.vhdx_file,
+            &self.eventfd,
+            &mut self.completion_list,
+        )
     }
 
     fn complete(&mut self) -> Vec<(u64, i32)> {


### PR DESCRIPTION
The CI is currently failing with some builds timing out, and this PR checks if reverting some recent changes related to disk mutexes removes the failures or not.