### PR TITLE
Revert "virtio-devices: net: Improve throughput with virtio features"

### DIFF
--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -34,9 +34,7 @@ use std::{collections::HashMap, convert::TryInto};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_bindings::bindings::virtio_net::*;
-use virtio_bindings::bindings::virtio_ring::{
-    VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC,
-};
+use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use virtio_queue::Queue;
 use vm_memory::{ByteValued, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
@@ -400,9 +398,7 @@ impl Net {
             | 1 << VIRTIO_NET_F_HOST_TSO4
             | 1 << VIRTIO_NET_F_HOST_TSO6
             | 1 << VIRTIO_NET_F_HOST_UFO
-            | 1 << VIRTIO_NET_F_MRG_RXBUF
             | 1 << VIRTIO_RING_F_EVENT_IDX
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
             | 1 << VIRTIO_F_VERSION_1;
 
         if iommu {


### PR DESCRIPTION
This reverts commit 58d25b3cccff967aa10a56f8f87692ca946aad7d.

This change introduced a regression when running iperf with the guest
running as the server:

```
marvin:~/src/cloud-hypervisor ((58d25b3c...))$ iperf  -c 192.168.249.2
------------------------------------------------------------
Client connecting to 192.168.249.2, TCP port 5001
TCP window size: 85.0 KByte (default)
------------------------------------------------------------
[  1] local 192.168.249.1 port 47078 connected with 192.168.249.2 port 5001
[ ID] Interval       Transfer     Bandwidth
[  1] 0.00-10.40 sec  14.0 MBytes  11.3 Mbits/sec
marvin:~/src/cloud-hypervisor ((58d25b3c...))$ iperf -s
------------------------------------------------------------
Server listening on TCP port 5001
TCP window size:  128 KByte (default)
------------------------------------------------------------
[  1] local 192.168.249.1 port 5001 connected with 192.168.249.2 port 42866
[ ID] Interval       Transfer     Bandwidth
[  1] 0.00-10.01 sec  51.2 GBytes  44.0 Gbits/sec
```

Fixes: #3450

Signed-off-by: Rob Bradford <robert.bradford@intel.com>