### PR TITLE
vmm: Only warn on error when setting up SIGWINCH handler

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1712,9 +1712,14 @@ impl DeviceManager {
         let seccomp_filter =
             get_seccomp_filter(&self.seccomp_action, Thread::PtyForeground).unwrap();
 
-        let pipe = start_sigwinch_listener(seccomp_filter, pty)?;
-
-        self.console_resize_pipe = Some(Arc::new(pipe));
+        match start_sigwinch_listener(seccomp_filter, pty) {
+            Ok(pipe) => {
+                self.console_resize_pipe = Some(Arc::new(pipe));
+            }
+            Err(e) => {
+                warn!("Ignoring error from setting up SIGWINCH listener: {}", e)
+            }
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Setting up the SIGWINCH handler requires at least Linux 5.7. However
this functionality is not required for basic PTY operation.

Fixes: #3456

Signed-off-by: Rob Bradford <robert.bradford@intel.com>