### PR TITLE
tdx: Add direct kernel boot support for TD firmwares

### DIFF
--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -52,6 +52,9 @@ pub enum TdvfSectionType {
     Cfv,
     TdHob,
     TempMem,
+    PermMem,
+    Payload,
+    PayloadParam,
     Reserved = 0xffffffff,
 }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -145,9 +145,6 @@ pub enum ValidationError {
     /// CPU Hotplug is not permitted with TDX
     #[cfg(feature = "tdx")]
     TdxNoCpuHotplug,
-    /// Specifying kernel is not permitted with TDX
-    #[cfg(feature = "tdx")]
-    TdxKernelSpecified,
     /// Insuffient vCPUs for queues
     TooManyQueues,
     /// Need shared memory for vfio-user
@@ -197,10 +194,6 @@ impl fmt::Display for ValidationError {
             #[cfg(feature = "tdx")]
             TdxNoCpuHotplug => {
                 write!(f, "CPU hotplug is not permitted with TDX")
-            }
-            #[cfg(feature = "tdx")]
-            TdxKernelSpecified => {
-                write!(f, "Direct kernel boot is not permitted with TDX")
             }
             TooManyQueues => {
                 write!(f, "Number of vCPUs is insufficient for number of queues")
@@ -2079,9 +2072,6 @@ impl VmConfig {
             }
             if tdx_enabled && (self.cpus.max_vcpus != self.cpus.boot_vcpus) {
                 return Err(ValidationError::TdxNoCpuHotplug);
-            }
-            if tdx_enabled && self.kernel.is_some() {
-                return Err(ValidationError::TdxKernelSpecified);
             }
         }
 


### PR DESCRIPTION
Relying on newly defined TDVF sections from the metadata, Cloud Hypervisor can provide its users a way to boot a TD VM with direct kernel boot.