### PR TITLE
vmm: tdx: Make sure a TDX enabled binary can be used for non-TDX

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1989,7 +1989,11 @@ impl Vm {
             .map_err(Error::CpuManager)?;
 
         #[cfg(feature = "tdx")]
-        let sections = self.extract_tdvf_sections()?;
+        let sections = if self.config.lock().unwrap().tdx.is_some() {
+            self.extract_tdvf_sections()?
+        } else {
+            Vec::new()
+        };
 
         #[cfg(feature = "acpi")]
         let rsdp_addr = {


### PR DESCRIPTION
It's important to maintain the ability to run in a non-TDX environment
a Cloud Hypervisor binary with the 'tdx' feature enabled.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>