### PR TITLE
build: Remove io_uring feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,13 +51,12 @@ wait-timeout = "0.2.0"
 [features]
 default = ["common", "kvm"]
 # Common features for all hypervisors
-common = ["acpi", "cmos", "fwdebug", "io_uring"]
+common = ["acpi", "cmos", "fwdebug"]
 acpi = ["vmm/acpi"]
 cmos = ["vmm/cmos"]
 fwdebug = ["vmm/fwdebug"]
 kvm = ["vmm/kvm"]
 mshv = ["vmm/mshv"]
-io_uring = ["vmm/io_uring"]
 tdx = ["vmm/tdx"]
 
 # Integration tests require a special environment to run in

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [features]
 default = []
-io_uring = []
 
 [dependencies]
 io-uring = "0.5.2"

--- a/block_util/src/lib.rs
+++ b/block_util/src/lib.rs
@@ -21,7 +21,6 @@ pub mod vhd;
 pub mod vhdx_sync;
 
 use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
-#[cfg(feature = "io_uring")]
 use io_uring::{opcode, IoUring, Probe};
 use std::cmp;
 use std::convert::TryInto;
@@ -423,7 +422,6 @@ unsafe impl ByteValued for VirtioBlockGeometry {}
 
 /// Check if io_uring for block device can be used on the current system, as
 /// it correctly supports the expected io_uring features.
-#[cfg(feature = "io_uring")]
 pub fn block_io_uring_is_supported() -> bool {
     let error_msg = "io_uring not supported:";
 
@@ -469,11 +467,6 @@ pub fn block_io_uring_is_supported() -> bool {
     }
 
     true
-}
-
-#[cfg(not(feature = "io_uring"))]
-pub fn block_io_uring_is_supported() -> bool {
-    false
 }
 
 pub trait AsyncAdaptor<F>

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [features]
 default = []
-io_uring = ["block_util/io_uring"]
 mshv = []
 
 [dependencies]

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -11,7 +11,6 @@ cmos = ["devices/cmos"]
 fwdebug = ["devices/fwdebug"]
 kvm = ["hypervisor/kvm", "vfio-ioctls/kvm", "vm-device/kvm", "pci/kvm"]
 mshv = ["hypervisor/mshv", "virtio-devices/mshv", "vfio-ioctls/mshv", "vm-device/mshv", "pci/mshv"]
-io_uring = ["virtio-devices/io_uring"]
 tdx = ["arch/tdx", "hypervisor/tdx"]
 
 [dependencies]


### PR DESCRIPTION
This has been part of the default features for a long time and is widely
tested.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>