### PR TITLE
clippy: fix needless_late_init warnings

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -315,21 +315,12 @@ impl CpuidPatch {
 
         for entry in entries.iter() {
             if entry.function == function && entry.index == index {
-                let reg_val: u32;
-                match reg {
-                    CpuidReg::EAX => {
-                        reg_val = entry.eax;
-                    }
-                    CpuidReg::EBX => {
-                        reg_val = entry.ebx;
-                    }
-                    CpuidReg::ECX => {
-                        reg_val = entry.ecx;
-                    }
-                    CpuidReg::EDX => {
-                        reg_val = entry.edx;
-                    }
-                }
+                let reg_val = match reg {
+                    CpuidReg::EAX => entry.eax,
+                    CpuidReg::EBX => entry.ebx,
+                    CpuidReg::ECX => entry.ecx,
+                    CpuidReg::EDX => entry.edx,
+                };
 
                 return (reg_val & mask) == mask;
             }
@@ -522,19 +513,14 @@ impl CpuidFeatureEntry {
             .enumerate()
         {
             let entry = &feature_entry_list[i];
-            let entry_compatible;
-            match entry.compatible_check {
+            let entry_compatible = match entry.compatible_check {
                 CpuidCompatibleCheck::BitwiseSubset => {
                     let different_feature_bits = src_vm_feature ^ dest_vm_feature;
                     let src_vm_feature_bits_only = different_feature_bits & src_vm_feature;
-                    entry_compatible = src_vm_feature_bits_only == 0;
+                    src_vm_feature_bits_only == 0
                 }
-                CpuidCompatibleCheck::Equal => {
-                    entry_compatible = src_vm_feature == dest_vm_feature;
-                }
-                CpuidCompatibleCheck::NumNotGreater => {
-                    entry_compatible = src_vm_feature <= dest_vm_feature;
-                }
+                CpuidCompatibleCheck::Equal => src_vm_feature == dest_vm_feature,
+                CpuidCompatibleCheck::NumNotGreater => src_vm_feature <= dest_vm_feature,
             };
             if !entry_compatible {
                 error!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,7 @@ fn prepare_default_values() -> (String, String, String) {
     (default_vcpus, default_memory, default_rng)
 }
 
+#[allow(clippy::needless_late_init)]
 fn create_app<'a, 'b>(
     default_vcpus: &'a str,
     default_memory: &'a str,

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -522,8 +522,6 @@ pub fn create_acpi_tables(
     numa_nodes: &NumaNodes,
 ) -> GuestAddress {
     let start_time = Instant::now();
-    let mut prev_tbl_len: u64;
-    let mut prev_tbl_off: GuestAddress;
     let rsdp_offset = arch::layout::RSDP_POINTER;
     let mut tables: Vec<u64> = Vec::new();
 
@@ -549,8 +547,8 @@ pub fn create_acpi_tables(
         .write_slice(madt.as_slice(), madt_offset)
         .expect("Error writing MADT table");
     tables.push(madt_offset.0);
-    prev_tbl_len = madt.len() as u64;
-    prev_tbl_off = madt_offset;
+    let mut prev_tbl_len = madt.len() as u64;
+    let mut prev_tbl_off = madt_offset;
 
     // PPTT
     #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
Nightly clippy warns about needless late initialization in a few places.
Restructure the code to fix those warnings.

`create_app` is a special case because the mutability of `app` differs
on x86 and arm64. Short of splitting the function into two, explicitly
allowing late initialization is the easiest thing to do.

Signed-off-by: Wei Liu <liuwe@microsoft.com>