### PR TITLE
deps: Bump vm-memory to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,9 +1337,9 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#9cfa0c8d7c3032f7958
 
 [[package]]
 name = "vm-memory"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a8ebcb86ca457f9d6e14cf97009f679952eba42f0113de5db596e514cd0e43b"
+checksum = "339d4349c126fdcd87e034631d7274370cf19eb0e87b33166bcd956589fc72c5"
 dependencies = [
  "arc-swap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ signal-hook = "0.3.13"
 thiserror = "1.0.30"
 vmm = { path = "vmm" }
 vmm-sys-util = "0.9.0"
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 
 [build-dependencies]
 clap = { version = "2.34.0", features = ["wrap_help"] }

--- a/acpi_tables/Cargo.toml
+++ b/acpi_tables/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 
 [dependencies]
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -22,7 +22,7 @@ serde_derive = "1.0.132"
 thiserror = "1.0.30"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }
 

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -18,7 +18,7 @@ versionize_derive = "0.1.4"
 vhdx = { path = "../vhdx" }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
 virtio-queue = { path = "../virtio-queue" }
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"
 

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.14"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-device = { path = "../vm-device" }
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = "0.9.0"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -836,9 +836,9 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#720e48e435b791ec6cb
 
 [[package]]
 name = "vm-memory"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a8ebcb86ca457f9d6e14cf97009f679952eba42f0113de5db596e514cd0e43b"
+checksum = "339d4349c126fdcd87e034631d7274370cf19eb0e87b33166bcd956589fc72c5"
 dependencies = [
  "arc-swap",
  "libc",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,7 +19,7 @@ virtio-devices = { path = "../virtio-devices" }
 virtio-queue = { path = "../virtio-queue" }
 vmm-sys-util = "0.9.0"
 vm-virtio = { path = "../vm-virtio" }
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 
 [dependencies.cloud-hypervisor]
 path = ".."

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -23,7 +23,7 @@ mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optio
 serde = { version = "1.0.132", features = ["rc"] }
 serde_derive = "1.0.132"
 serde_json = "1.0.73"
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -16,7 +16,7 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 virtio-bindings = "0.1.0"
 virtio-queue = { path = "../virtio-queue" }
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"
 

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -23,7 +23,7 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 vm-migration = { path = "../vm-migration" }
 
 [dependencies.vfio-bindings]

--- a/vfio_user/Cargo.toml
+++ b/vfio_user/Cargo.toml
@@ -12,7 +12,7 @@ serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 thiserror = "1.0.30"
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = ">=0.3.1"
 
 [dependencies.vfio-bindings]

--- a/vhost_user_backend/Cargo.toml
+++ b/vhost_user_backend/Cargo.toml
@@ -13,7 +13,7 @@ libc = "0.2.112"
 log = "0.4.14"
 virtio-bindings = "0.1.0"
 virtio-queue = { path = "../virtio-queue" }
-vm-memory = { version = "0.6.0", features = ["backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"
 vhost = { version = "0.3.0", features = ["vhost-user-slave"] }

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -16,5 +16,5 @@ qcow = { path = "../qcow" }
 vhost_user_backend = { path = "../vhost_user_backend" }
 vhost = { version = "0.3.0", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 vmm-sys-util = "0.9.0"

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -15,5 +15,5 @@ option_parser = { path = "../option_parser" }
 vhost_user_backend = { path = "../vhost_user_backend" }
 vhost = { version = "0.3.0", features = ["vhost-user-slave"] }
 virtio-bindings = "0.1.0"
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 vmm-sys-util = "0.9.0"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -33,7 +33,7 @@ virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
 virtio-queue = { path = "../virtio-queue" }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"

--- a/virtio-queue/Cargo.toml
+++ b/virtio-queue/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2018"
 test-utils = []
 
 [dependencies]
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 vmm-sys-util = ">=0.8.0"
 log = ">=0.4.6"

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.112"
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 arch = { path = "../arch" }

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -16,6 +16,6 @@ serde = { version = "1.0.132", features = ["rc"] }
 serde_derive = "1.0.132"
 serde_json = "1.0.73"
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "main", default-features = false }
-vm-memory = { version = "0.6.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
 vmm-sys-util = "0.9.0"
 

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -12,4 +12,4 @@ serde_derive = "1.0.132"
 serde_json = "1.0.73"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -11,4 +11,4 @@ default = []
 log = "0.4.14"
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
 virtio-queue = { path = "../virtio-queue" }
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -50,7 +50,7 @@ virtio-devices = { path = "../virtio-devices" }
 virtio-queue = { path = "../virtio-queue" }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }


### PR DESCRIPTION
Updating Cloud Hypervisor to rely on vm-memory version 0.7.0.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>