### PR TITLE
docs/arm64: Document the hardware constraints

### DIFF
--- a/docs/arm64.md
+++ b/docs/arm64.md
@@ -1,16 +1,27 @@
 # How to build and test Cloud Hypervisor on AArch64
 
-This document introduces how to build and test Cloud Hypervisor on AArch64
-servers. Currently Cloud Hypervisor cannot be tested on Raspberry PI. Because
-on AArch64, Cloud Hypervisor requires GICv3-ITS device for PCIe MSI interrupt
-handling. But GICv3-ITS has not been equipped on any Raspberry PI product so
-far.
-
-Now Cloud Hypervisor supports 2 ways of booting on AArch64: UEFI booting and
-direct-kernel booting. The document covers both of the ways.
+This document introduces how to build and test Cloud Hypervisor on AArch64.
+Currently, Cloud Hypervisor supports 2 methods of booting on AArch64: UEFI
+booting and direct-kernel booting. The document covers both methods.
 
 All the steps are based on Ubuntu. We use the Ubuntu cloud image for guest VM
 disk.
+
+## Hardware requirements
+
+- AArch64 servers (recommended) or development boards equipped with the GICv3
+interrupt controller.
+
+- On development boards that have constrained RAM resources, if the creation of
+a VM consumes a large portion of the free memory on the host, it may be required
+to enable swap. For example, this was required on a board with 3 GB of RAM
+booting a 2 GB VM at a point in time when 2.8 GB were free. Without enabling
+swap the `cloud-hypervisor` process was terminated by the OOM killer. In this
+situation memory was allocated for the virtual machine using memfd while the
+page cache was filled, leading to a situation where the kernel could not even
+drop caches. Making a small section of swap available (observably, 1 to 15 MB),
+this situation can be resolved and the resulting memory footprint of
+`cloud-hypervisor` is as expected.
 
 ## Getting started
 


### PR DESCRIPTION
There is a corner case of using the Cloud Hypervisor on AArch64:
If the VM is started on a device where RAM is limited, and if the user allocates nearly as much memory for the guest as is still free on the host, we need to enable the swap memory.

Also, this commit corrects the hardware requirement of the GIC interrupt controller for running the Cloud Hypervisor on AArch64, according to [1].

Fixes: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/3419

Signed-off-by: Henry Wang <Henry.Wang@arm.com>

[1] https://www.kernel.org/doc/html/latest/virt/kvm/devices/arm-vgic-its.html