### PR TITLE
docs: update hotplug.md

### DIFF
--- a/docs/hotplug.md
+++ b/docs/hotplug.md
@@ -1,6 +1,6 @@
 # Cloud Hypervisor Hot Plug
 
-Currently Cloud Hypervisor only supports hot plugging of CPU devices.
+Currently Cloud Hypervisor supports hot plugging of CPUs devices (x86 only), PCI devices and memory resizing.
 
 ## Kernel support
 


### PR DESCRIPTION
Currently cloud-hypervisor supports hotplug of CPUs, passthrough devices, virtio devices and memory resizing, 
but in hotplug.md it still mentiones: "Currently Cloud Hypervisor only supports hot plugging of CPU devices."
We need to remove the incorrect information from hotplug.md to reflect the true situation.

Fixes: #3504

Signed-off-by: Liang Zhou <zhoul110@chinatelecom.cn>