### PR TITLE
tests: Temporarily disable flaky tests

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4997,6 +4997,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg(target_arch = "x86_64")]
         fn test_virtio_block_topology() {
             let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
             let guest = Guest::new(Box::new(focal));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6206,6 +6206,7 @@ mod tests {
             exec_host_command_status("pkill -f nvmf_tgt");
         }
 
+        #[ignore]
         #[cfg(target_arch = "x86_64")]
         #[test]
         fn test_vfio_user() {


### PR DESCRIPTION
Two tests in our CI are flaky, let's disable them until we find the right way to fix them.