### PR TITLE
virtio-devices: Forward correct evset in vsock muxer

### DIFF
--- a/virtio-devices/src/vsock/unix/muxer.rs
+++ b/virtio-devices/src/vsock/unix/muxer.rs
@@ -362,25 +362,24 @@ impl VsockMuxer {
 
     /// Handle/dispatch an epoll event to its listener.
     ///
-    fn handle_event(&mut self, fd: RawFd, evset: epoll::Events) {
+    fn handle_event(&mut self, fd: RawFd, event_set: epoll::Events) {
         debug!(
-            "vsock: muxer processing event: fd={}, evset={:?}",
-            fd, evset
+            "vsock: muxer processing event: fd={}, event_set={:?}",
+            fd, event_set
         );
 
         match self.listener_map.get_mut(&fd) {
             // This event needs to be forwarded to a `MuxerConnection` that is listening for
             // it.
             //
-            Some(EpollListener::Connection { key, evset }) => {
+            Some(EpollListener::Connection { key, evset: _ }) => {
                 let key_copy = *key;
-                let evset_copy = *evset;
                 // The handling of this event will most probably mutate the state of the
                 // receiving connection. We'll need to check for new pending RX, event set
                 // mutation, and all that, so we're wrapping the event delivery inside those
                 // checks.
                 self.apply_conn_mutation(key_copy, |conn| {
-                    conn.notify(evset_copy);
+                    conn.notify(event_set);
                 });
             }
 
@@ -443,7 +442,10 @@ impl VsockMuxer {
             }
 
             _ => {
-                info!("vsock: unexpected event: fd={:?}, evset={:?}", fd, evset);
+                info!(
+                    "vsock: unexpected event: fd={:?}, event_set={:?}",
+                    fd, event_set
+                );
             }
         }
     }


### PR DESCRIPTION
When forwarding an epoll event from the unix muxer to the
targeted connection event handler, the eventset the connection
registered is forwarded instead of the actual epoll
operation (IN/OUT).

For example, if the connection was registered for EPOLLIN,
and receives an EPOLLOUT, the connection will actually handle
an EPOLLOUT.

This is the root cause of previous bug, which caused the
introduction of some workarounds (i.e: handling ewouldblock
when reading after receiving EPOLLIN, which should never happen).

When matching the connection, we retrieve and use the evset of
the connection instead of the one passed as a parameter.
The compiler does not complain for an unused variable because
it was first logged in a debug! statement.

This is an unfortunate naming mistake that caused a lot of problems.

Signed-off-by: Eduard Kyvenko <eduard.kyvenko@gmail.com>
Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>

Fixes #3497 