### PR TITLE
vmm: Don't assume that resize_pipe is initialised

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1742,7 +1742,7 @@ impl DeviceManager {
                     self.config.lock().unwrap().console.file = Some(pty.path.clone());
                     let file = pty.main.try_clone().unwrap();
                     self.console_pty = Some(Arc::new(Mutex::new(pty)));
-                    self.console_resize_pipe = Some(Arc::new(resize_pipe.unwrap()));
+                    self.console_resize_pipe = resize_pipe.map(Arc::new);
                     Endpoint::FilePair(file.try_clone().unwrap(), file)
                 } else {
                     let (main, mut sub, path) =


### PR DESCRIPTION
If the underlying kernel is old PTY resize is disabled and this is
represented by the use of None in the provided Option<File> type. In the
virtio-console PTY path don't blindly unwrap() the value.

Fixes: #3496

Signed-off-by: Rob Bradford <robert.bradford@intel.com>