### PR TITLE
gitignore: ignore .cargo directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build
+/.cargo
 /target
 **/*.rs.bk
 **/Cargo.lock


### PR DESCRIPTION
This allows developers to have their local Cargo configurations for
Cloud Hypervisor.

Signed-off-by: Wei Liu <liuwe@microsoft.com>