### PR TITLE
scripts: create-cloud-init: use `rm -f` instead of `rm`

### DIFF
--- a/scripts/create-cloud-init.sh
+++ b/scripts/create-cloud-init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-rm /tmp/ubuntu-cloudinit.img
+rm -f /tmp/ubuntu-cloudinit.img
 mkdosfs -n cidata -C /tmp/ubuntu-cloudinit.img 8192
 mcopy -oi /tmp/ubuntu-cloudinit.img -s test_data/cloud-init/ubuntu/user-data ::
 mcopy -oi /tmp/ubuntu-cloudinit.img -s test_data/cloud-init/ubuntu/meta-data ::


### PR DESCRIPTION
Ignore removing a non-existing file instead of bailing out.

Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
