### PR TITLE
vmm, build: Remove use of "credibility" from unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,21 +10,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,21 +76,6 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "backtrace"
-version = "0.3.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "bincode"
@@ -183,7 +153,6 @@ dependencies = [
  "anyhow",
  "api_client",
  "clap",
- "credibility",
  "dirs 4.0.0",
  "epoll",
  "event_monitor",
@@ -218,16 +187,6 @@ name = "crc64"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55626594feae15d266d52440b26ff77de0e22230cf0c113abe619084c1ddc910"
-
-[[package]]
-name = "credibility"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae7a162fd5b462bc49704873a89950a655d44161add4be07e00e64c4c83a5bf"
-dependencies = [
- "failure",
- "failure_derive",
-]
 
 [[package]]
 name = "devices"
@@ -312,28 +271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fdt"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,12 +286,6 @@ dependencies = [
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glob"
@@ -560,16 +491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
 name = "mshv-bindings"
 version = "0.1.0"
 source = "git+https://github.com/rust-vmm/mshv?branch=main#8770516859e7d05193c496b77ac5ddad3ca5943a"
@@ -619,15 +540,6 @@ dependencies = [
  "vm-memory",
  "vm-virtio",
  "vmm-sys-util",
-]
-
-[[package]]
-name = "object"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -881,12 +793,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
@@ -1385,7 +1291,6 @@ dependencies = [
  "bitflags",
  "block_util",
  "clap",
- "credibility",
  "devices",
  "epoll",
  "event_monitor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "main" }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
 
 [dev-dependencies]
-credibility = "0.1.3"
 dirs = "4.0.0"
 lazy_static= "1.4.0"
 net_util = { path = "net_util" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -587,10 +587,6 @@ fn main() {
 }
 
 #[cfg(test)]
-#[macro_use]
-extern crate credibility;
-
-#[cfg(test)]
 mod unit_tests {
     use crate::config::HotplugMethod;
     use crate::{create_app, prepare_default_values};
@@ -618,15 +614,11 @@ mod unit_tests {
         let cli_vm_config = get_vm_config_from_vec(cli);
         let openapi_vm_config: VmConfig = serde_json::from_str(openapi).unwrap();
 
-        test_block!(tb, "", {
-            if equal {
-                aver_eq!(tb, cli_vm_config, openapi_vm_config);
-            } else {
-                aver_ne!(tb, cli_vm_config, openapi_vm_config);
-            }
-
-            Ok(())
-        });
+        if equal {
+            assert_eq!(cli_vm_config, openapi_vm_config);
+        } else {
+            assert_ne!(cli_vm_config, openapi_vm_config);
+        }
 
         (cli_vm_config, openapi_vm_config)
     }
@@ -640,70 +632,67 @@ mod unit_tests {
         let (result_vm_config, _) = compare_vm_config_cli_vs_json(&cli, openapi, true);
 
         // As a second step, we validate all the default values.
-        test_block!(tb, "", {
-            let expected_vm_config = VmConfig {
-                cpus: CpusConfig {
-                    boot_vcpus: 1,
-                    max_vcpus: 1,
-                    topology: None,
-                    kvm_hyperv: false,
-                    max_phys_bits: 46,
-                    affinity: None,
-                },
-                memory: MemoryConfig {
-                    size: 536_870_912,
-                    mergeable: false,
-                    hotplug_method: HotplugMethod::Acpi,
-                    hotplug_size: None,
-                    hotplugged_size: None,
-                    shared: false,
-                    hugepages: false,
-                    hugepage_size: None,
-                    prefault: false,
-                    zones: None,
-                },
-                kernel: Some(KernelConfig {
-                    path: PathBuf::from("/path/to/kernel"),
-                }),
-                initramfs: None,
-                cmdline: CmdlineConfig {
-                    args: String::from(""),
-                },
-                disks: None,
-                net: None,
-                rng: RngConfig {
-                    src: PathBuf::from("/dev/urandom"),
-                    iommu: false,
-                },
-                balloon: None,
-                fs: None,
-                pmem: None,
-                serial: ConsoleConfig {
-                    file: None,
-                    mode: ConsoleOutputMode::Null,
-                    iommu: false,
-                },
-                console: ConsoleConfig {
-                    file: None,
-                    mode: ConsoleOutputMode::Tty,
-                    iommu: false,
-                },
-                devices: None,
-                user_devices: None,
-                vsock: None,
+        let expected_vm_config = VmConfig {
+            cpus: CpusConfig {
+                boot_vcpus: 1,
+                max_vcpus: 1,
+                topology: None,
+                kvm_hyperv: false,
+                max_phys_bits: 46,
+                affinity: None,
+            },
+            memory: MemoryConfig {
+                size: 536_870_912,
+                mergeable: false,
+                hotplug_method: HotplugMethod::Acpi,
+                hotplug_size: None,
+                hotplugged_size: None,
+                shared: false,
+                hugepages: false,
+                hugepage_size: None,
+                prefault: false,
+                zones: None,
+            },
+            kernel: Some(KernelConfig {
+                path: PathBuf::from("/path/to/kernel"),
+            }),
+            initramfs: None,
+            cmdline: CmdlineConfig {
+                args: String::from(""),
+            },
+            disks: None,
+            net: None,
+            rng: RngConfig {
+                src: PathBuf::from("/dev/urandom"),
                 iommu: false,
-                #[cfg(target_arch = "x86_64")]
-                sgx_epc: None,
-                numa: None,
-                watchdog: false,
-                #[cfg(feature = "tdx")]
-                tdx: None,
-                platform: None,
-            };
+            },
+            balloon: None,
+            fs: None,
+            pmem: None,
+            serial: ConsoleConfig {
+                file: None,
+                mode: ConsoleOutputMode::Null,
+                iommu: false,
+            },
+            console: ConsoleConfig {
+                file: None,
+                mode: ConsoleOutputMode::Tty,
+                iommu: false,
+            },
+            devices: None,
+            user_devices: None,
+            vsock: None,
+            iommu: false,
+            #[cfg(target_arch = "x86_64")]
+            sgx_epc: None,
+            numa: None,
+            watchdog: false,
+            #[cfg(feature = "tdx")]
+            tdx: None,
+            platform: None,
+        };
 
-            aver_eq!(tb, expected_vm_config, result_vm_config);
-            Ok(())
-        })
+        assert_eq!(expected_vm_config, result_vm_config);
     }
 
     #[test]

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -54,6 +54,3 @@ vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }
-
-[dev-dependencies]
-credibility = "0.1.3"

--- a/vmm/src/device_tree.rs
+++ b/vmm/src/device_tree.rs
@@ -165,121 +165,117 @@ mod tests {
 
     #[test]
     fn test_device_tree() {
-        test_block!(tb, "", {
-            // Check new()
-            let mut device_tree = DeviceTree::new();
-            aver_eq!(tb, device_tree.0.len(), 0);
+        // Check new()
+        let mut device_tree = DeviceTree::new();
+        assert_eq!(device_tree.0.len(), 0);
 
-            // Check insert()
-            let id = String::from("id1");
-            device_tree.insert(id.clone(), DeviceNode::new(id.clone(), None));
-            aver_eq!(tb, device_tree.0.len(), 1);
-            let node = device_tree.0.get(&id);
-            aver!(tb, node.is_some());
-            let node = node.unwrap();
-            aver_eq!(tb, node.id, id);
+        // Check insert()
+        let id = String::from("id1");
+        device_tree.insert(id.clone(), DeviceNode::new(id.clone(), None));
+        assert_eq!(device_tree.0.len(), 1);
+        let node = device_tree.0.get(&id);
+        assert!(node.is_some());
+        let node = node.unwrap();
+        assert_eq!(node.id, id);
 
-            // Check get()
-            let id2 = String::from("id2");
-            aver!(tb, device_tree.get(&id).is_some());
-            aver!(tb, device_tree.get(&id2).is_none());
+        // Check get()
+        let id2 = String::from("id2");
+        assert!(device_tree.get(&id).is_some());
+        assert!(device_tree.get(&id2).is_none());
 
-            // Check get_mut()
-            let node = device_tree.get_mut(&id).unwrap();
-            node.id = id2.clone();
-            let node = device_tree.0.get(&id).unwrap();
-            aver_eq!(tb, node.id, id2);
+        // Check get_mut()
+        let node = device_tree.get_mut(&id).unwrap();
+        node.id = id2.clone();
+        let node = device_tree.0.get(&id).unwrap();
+        assert_eq!(node.id, id2);
 
-            // Check remove()
-            let node = device_tree.remove(&id).unwrap();
-            aver_eq!(tb, node.id, id2);
-            aver_eq!(tb, device_tree.0.len(), 0);
+        // Check remove()
+        let node = device_tree.remove(&id).unwrap();
+        assert_eq!(node.id, id2);
+        assert_eq!(device_tree.0.len(), 0);
 
-            // Check iter()
-            let disk_id = String::from("disk0");
-            let net_id = String::from("net0");
-            let rng_id = String::from("rng0");
-            let device_list = vec![
-                (disk_id.clone(), device_node!(disk_id)),
-                (net_id.clone(), device_node!(net_id)),
-                (rng_id.clone(), device_node!(rng_id)),
-            ];
-            device_tree.0.extend(device_list);
-            for (id, node) in device_tree.iter() {
-                if id == &disk_id {
-                    aver_eq!(tb, node.id, disk_id);
-                } else if id == &net_id {
-                    aver_eq!(tb, node.id, net_id);
-                } else if id == &rng_id {
-                    aver_eq!(tb, node.id, rng_id);
-                } else {
-                    aver!(tb, false);
-                }
+        // Check iter()
+        let disk_id = String::from("disk0");
+        let net_id = String::from("net0");
+        let rng_id = String::from("rng0");
+        let device_list = vec![
+            (disk_id.clone(), device_node!(disk_id)),
+            (net_id.clone(), device_node!(net_id)),
+            (rng_id.clone(), device_node!(rng_id)),
+        ];
+        device_tree.0.extend(device_list);
+        for (id, node) in device_tree.iter() {
+            if id == &disk_id {
+                assert_eq!(node.id, disk_id);
+            } else if id == &net_id {
+                assert_eq!(node.id, net_id);
+            } else if id == &rng_id {
+                assert_eq!(node.id, rng_id);
+            } else {
+                unreachable!()
             }
+        }
 
-            // Check breadth_first_traversal() based on the following hierarchy
-            //
-            // 0
-            // | \
-            // 1  2
-            // |  | \
-            // 3  4  5
-            //
-            let mut device_tree = DeviceTree::new();
-            let child_1_id = String::from("child1");
-            let child_2_id = String::from("child2");
-            let child_3_id = String::from("child3");
-            let parent_1_id = String::from("parent1");
-            let parent_2_id = String::from("parent2");
-            let root_id = String::from("root");
-            let mut child_1_node = device_node!(child_1_id);
-            let mut child_2_node = device_node!(child_2_id);
-            let mut child_3_node = device_node!(child_3_id);
-            let mut parent_1_node = device_node!(parent_1_id);
-            let mut parent_2_node = device_node!(parent_2_id);
-            let mut root_node = device_node!(root_id);
-            child_1_node.parent = Some(parent_1_id.clone());
-            child_2_node.parent = Some(parent_2_id.clone());
-            child_3_node.parent = Some(parent_2_id.clone());
-            parent_1_node.children = vec![child_1_id.clone()];
-            parent_1_node.parent = Some(root_id.clone());
-            parent_2_node.children = vec![child_2_id.clone(), child_3_id.clone()];
-            parent_2_node.parent = Some(root_id.clone());
-            root_node.children = vec![parent_1_id.clone(), parent_2_id.clone()];
-            let device_list = vec![
-                (child_1_id.clone(), child_1_node),
-                (child_2_id.clone(), child_2_node),
-                (child_3_id.clone(), child_3_node),
-                (parent_1_id.clone(), parent_1_node),
-                (parent_2_id.clone(), parent_2_node),
-                (root_id.clone(), root_node),
-            ];
-            device_tree.0.extend(device_list);
+        // Check breadth_first_traversal() based on the following hierarchy
+        //
+        // 0
+        // | \
+        // 1  2
+        // |  | \
+        // 3  4  5
+        //
+        let mut device_tree = DeviceTree::new();
+        let child_1_id = String::from("child1");
+        let child_2_id = String::from("child2");
+        let child_3_id = String::from("child3");
+        let parent_1_id = String::from("parent1");
+        let parent_2_id = String::from("parent2");
+        let root_id = String::from("root");
+        let mut child_1_node = device_node!(child_1_id);
+        let mut child_2_node = device_node!(child_2_id);
+        let mut child_3_node = device_node!(child_3_id);
+        let mut parent_1_node = device_node!(parent_1_id);
+        let mut parent_2_node = device_node!(parent_2_id);
+        let mut root_node = device_node!(root_id);
+        child_1_node.parent = Some(parent_1_id.clone());
+        child_2_node.parent = Some(parent_2_id.clone());
+        child_3_node.parent = Some(parent_2_id.clone());
+        parent_1_node.children = vec![child_1_id.clone()];
+        parent_1_node.parent = Some(root_id.clone());
+        parent_2_node.children = vec![child_2_id.clone(), child_3_id.clone()];
+        parent_2_node.parent = Some(root_id.clone());
+        root_node.children = vec![parent_1_id.clone(), parent_2_id.clone()];
+        let device_list = vec![
+            (child_1_id.clone(), child_1_node),
+            (child_2_id.clone(), child_2_node),
+            (child_3_id.clone(), child_3_node),
+            (parent_1_id.clone(), parent_1_node),
+            (parent_2_id.clone(), parent_2_node),
+            (root_id.clone(), root_node),
+        ];
+        device_tree.0.extend(device_list);
 
-            let iter_vec = device_tree
-                .breadth_first_traversal()
-                .collect::<Vec<&DeviceNode>>();
-            aver_eq!(tb, iter_vec.len(), 6);
-            aver_eq!(tb, iter_vec[0].id, root_id);
-            aver_eq!(tb, iter_vec[1].id, parent_1_id);
-            aver_eq!(tb, iter_vec[2].id, parent_2_id);
-            aver_eq!(tb, iter_vec[3].id, child_1_id);
-            aver_eq!(tb, iter_vec[4].id, child_2_id);
-            aver_eq!(tb, iter_vec[5].id, child_3_id);
+        let iter_vec = device_tree
+            .breadth_first_traversal()
+            .collect::<Vec<&DeviceNode>>();
+        assert_eq!(iter_vec.len(), 6);
+        assert_eq!(iter_vec[0].id, root_id);
+        assert_eq!(iter_vec[1].id, parent_1_id);
+        assert_eq!(iter_vec[2].id, parent_2_id);
+        assert_eq!(iter_vec[3].id, child_1_id);
+        assert_eq!(iter_vec[4].id, child_2_id);
+        assert_eq!(iter_vec[5].id, child_3_id);
 
-            let iter_vec = device_tree
-                .breadth_first_traversal()
-                .rev()
-                .collect::<Vec<&DeviceNode>>();
-            aver_eq!(tb, iter_vec.len(), 6);
-            aver_eq!(tb, iter_vec[5].id, root_id);
-            aver_eq!(tb, iter_vec[4].id, parent_1_id);
-            aver_eq!(tb, iter_vec[3].id, parent_2_id);
-            aver_eq!(tb, iter_vec[2].id, child_1_id);
-            aver_eq!(tb, iter_vec[1].id, child_2_id);
-            aver_eq!(tb, iter_vec[0].id, child_3_id);
-
-            Ok(())
-        })
+        let iter_vec = device_tree
+            .breadth_first_traversal()
+            .rev()
+            .collect::<Vec<&DeviceNode>>();
+        assert_eq!(iter_vec.len(), 6);
+        assert_eq!(iter_vec[5].id, root_id);
+        assert_eq!(iter_vec[4].id, parent_1_id);
+        assert_eq!(iter_vec[3].id, parent_2_id);
+        assert_eq!(iter_vec[2].id, child_1_id);
+        assert_eq!(iter_vec[1].id, child_2_id);
+        assert_eq!(iter_vec[0].id, child_3_id);
     }
 }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -11,9 +11,6 @@ extern crate lazy_static;
 extern crate log;
 #[macro_use]
 extern crate serde_derive;
-#[cfg(test)]
-#[macro_use]
-extern crate credibility;
 
 use crate::api::{
     ApiError, ApiRequest, ApiResponse, ApiResponsePayload, VmInfo, VmReceiveMigrationData,


### PR DESCRIPTION
This crate was used in the integration tests to allow the tests to
continue and clean up after a failure. This isn't necessary in the unit
tests and adds a large build dependency chain including an unmaintained
crate.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>