### PR TITLE
vmm: seccomp: Remove arch_prctl syscall from seccomp filter

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -420,8 +420,6 @@ fn vmm_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError> {
         (libc::SYS_accept4, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_access, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (libc::SYS_arch_prctl, vec![]),
         (libc::SYS_bind, vec![]),
         (libc::SYS_brk, vec![]),
         (libc::SYS_clock_gettime, vec![]),


### PR DESCRIPTION
The origins of the requirement for this syscall in the seccomp filter
list are unknown.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>