### PR TITLE
vmm: seccomp: Remove set_tid_address syscall from seccomp filter

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -505,7 +505,6 @@ fn vmm_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError> {
         (libc::SYS_sendmsg, vec![]),
         (libc::SYS_sendto, vec![]),
         (libc::SYS_set_robust_list, vec![]),
-        (libc::SYS_set_tid_address, vec![]),
         (libc::SYS_setsid, vec![]),
         (libc::SYS_sigaltstack, vec![]),
         (


### PR DESCRIPTION
The origins of the requirement for this syscall in the seccomp filter
list are unknown.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>