### PR TITLE
vmm: openapi: Fix default value for tap

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -744,7 +744,6 @@ components:
       properties:
         tap:
           type: string
-          default: ""
         ip:
           type: string
           default: "192.168.249.1"


### PR DESCRIPTION
`tap` has its default value set to `None`, but in the openapi yaml file
we've been setting it to `""`.

When using this code on the Kata Containers side we'd be hit by a non
expected behaviour of cloud-hypervisor, as even when using a different
method to initialise the `tuntap` device the code would be treated as if
using `--net tap` (which is a valid use-case).

Related: #3554

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>