### PR TITLE
Add a new binary target for generating performance metrics

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install musl-gcc
+        run: sudo apt install -y musl-tools
+
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
 name = "performance-metrics"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "dirs 4.0.0",
  "lazy_static",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "test_infra",
- "vmm-sys-util",
  "wait-timeout",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,8 @@ version = "0.1.0"
 dependencies = [
  "dirs 4.0.0",
  "lazy_static",
+ "serde",
+ "serde_derive",
  "serde_json",
  "test_infra",
  "vmm-sys-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "test_infra",
+ "thiserror",
  "wait-timeout",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "performance-metrics"
+version = "0.1.0"
+dependencies = [
+ "dirs 4.0.0",
+ "lazy_static",
+ "serde_json",
+ "test_infra",
+ "vmm-sys-util",
+ "wait-timeout",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-src"
+version = "111.17.0+1.1.1m"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +560,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ members = [
     "net_util",
     "option_parser",
     "pci",
+    "performance-metrics",
     "qcow",
     "rate_limiter",
     "vfio_user",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,4 +85,3 @@ members = [
     "vm-migration",
     "vm-virtio"
 ]
-exclude = ["test_infra"]

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "performance-metrics"
+version = "0.1.0"
+authors = ["The Cloud Hypervisor Authors"]
+edition = "2018"
+
+[dependencies]
+dirs = "4.0.0"
+lazy_static= "1.4.0"
+serde_json = "1.0.78"
+test_infra = { path = "../test_infra" }
+vmm-sys-util = "0.9.0"
+wait-timeout = "0.2.0"

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 [dependencies]
 dirs = "4.0.0"
 lazy_static= "1.4.0"
+serde = { version = "1.0.136", features = ["rc"] }
+serde_derive = "1.0.136"
 serde_json = "1.0.78"
 test_infra = { path = "../test_infra" }
 vmm-sys-util = "0.9.0"

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -3,6 +3,7 @@ name = "performance-metrics"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
+build = "build.rs"
 
 [dependencies]
 dirs = "4.0.0"
@@ -12,3 +13,6 @@ serde_derive = "1.0.136"
 serde_json = "1.0.78"
 test_infra = { path = "../test_infra" }
 wait-timeout = "0.2.0"
+
+[build-dependencies]
+clap = { version = "3.0.14", features = ["wrap_help"] }

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
+clap = { version = "3.1.0", features = ["wrap_help","cargo"] }
 dirs = "4.0.0"
 lazy_static= "1.4.0"
 serde = { version = "1.0.136", features = ["rc"] }
@@ -15,4 +16,4 @@ test_infra = { path = "../test_infra" }
 wait-timeout = "0.2.0"
 
 [build-dependencies]
-clap = { version = "3.0.14", features = ["wrap_help"] }
+clap = { version = "3.1.0", features = ["wrap_help"] }

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -11,5 +11,4 @@ serde = { version = "1.0.136", features = ["rc"] }
 serde_derive = "1.0.136"
 serde_json = "1.0.78"
 test_infra = { path = "../test_infra" }
-vmm-sys-util = "0.9.0"
 wait-timeout = "0.2.0"

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0.136", features = ["rc"] }
 serde_derive = "1.0.136"
 serde_json = "1.0.78"
 test_infra = { path = "../test_infra" }
+thiserror = "1.0.30"
 wait-timeout = "0.2.0"
 
 [build-dependencies]

--- a/performance-metrics/build.rs
+++ b/performance-metrics/build.rs
@@ -18,32 +18,9 @@ fn main() {
         }
     }
 
-    let mut git_revision = "".to_string();
-    if let Ok(git_out) = Command::new("git").args(&["rev-parse", "HEAD"]).output() {
-        if git_out.status.success() {
-            if let Ok(git_out_str) = String::from_utf8(git_out.stdout) {
-                git_revision = git_out_str;
-            }
-        }
-    }
-
-    let mut git_committer_date = "".to_string();
-    if let Ok(git_out) = Command::new("git")
-        .args(&["show", "-s", "--format=%cd"])
-        .output()
-    {
-        if git_out.status.success() {
-            if let Ok(git_out_str) = String::from_utf8(git_out.stdout) {
-                git_committer_date = git_out_str;
-            }
-        }
-    }
-
     // This println!() has a special behavior, as it will set the environment
-    // variable GIT_human_readable, so that it can be reused from the binary.
+    // variable GIT_HUMAN_READABLE, so that it can be reused from the binary.
     // Particularly, this is used from the main.rs to display the exact
     // version information.
     println!("cargo:rustc-env=GIT_HUMAN_READABLE={}", git_human_readable);
-    println!("cargo:rustc-env=GIT_REVISION={}", git_revision);
-    println!("cargo:rustc-env=GIT_COMMITER_DATE={}", git_committer_date);
 }

--- a/performance-metrics/build.rs
+++ b/performance-metrics/build.rs
@@ -1,0 +1,36 @@
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#[macro_use(crate_version)]
+extern crate clap;
+
+use std::process::Command;
+
+fn main() {
+    let mut git_human_readable = "v".to_owned() + crate_version!();
+    if let Ok(git_out) = Command::new("git").args(&["describe", "--dirty"]).output() {
+        if git_out.status.success() {
+            if let Ok(git_out_str) = String::from_utf8(git_out.stdout) {
+                git_human_readable = git_out_str;
+            }
+        }
+    }
+
+    let mut git_revision = "".to_string();
+    if let Ok(git_out) = Command::new("git").args(&["rev-parse", "HEAD"]).output() {
+        if git_out.status.success() {
+            if let Ok(git_out_str) = String::from_utf8(git_out.stdout) {
+                git_revision = git_out_str;
+            }
+        }
+    }
+
+    // This println!() has a special behavior, as it will set the environment
+    // variable GIT_human_readable, so that it can be reused from the binary.
+    // Particularly, this is used from the main.rs to display the exact
+    // version information.
+    println!("cargo:rustc-env=GIT_HUMAN_READABLE={}", git_human_readable);
+    println!("cargo:rustc-env=GIT_REVISION={}", git_revision);
+}

--- a/performance-metrics/build.rs
+++ b/performance-metrics/build.rs
@@ -27,10 +27,23 @@ fn main() {
         }
     }
 
+    let mut git_committer_date = "".to_string();
+    if let Ok(git_out) = Command::new("git")
+        .args(&["show", "-s", "--format=%cd"])
+        .output()
+    {
+        if git_out.status.success() {
+            if let Ok(git_out_str) = String::from_utf8(git_out.stdout) {
+                git_committer_date = git_out_str;
+            }
+        }
+    }
+
     // This println!() has a special behavior, as it will set the environment
     // variable GIT_human_readable, so that it can be reused from the binary.
     // Particularly, this is used from the main.rs to display the exact
     // version information.
     println!("cargo:rustc-env=GIT_HUMAN_READABLE={}", git_human_readable);
     println!("cargo:rustc-env=GIT_REVISION={}", git_revision);
+    println!("cargo:rustc-env=GIT_COMMITER_DATE={}", git_committer_date);
 }

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -1,0 +1,265 @@
+// Custom harness to run performance tests
+
+#[macro_use]
+extern crate lazy_static;
+extern crate test_infra;
+
+mod performance_tests;
+
+use performance_tests::*;
+use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
+
+pub struct PerformanceTestControl {
+    test_time: u32,
+    test_iterations: u32,
+    queue_num: Option<u32>,
+    queue_size: Option<u32>,
+    net_rx: Option<bool>,
+    fio_ops: Option<FioOps>,
+}
+
+impl Default for PerformanceTestControl {
+    fn default() -> Self {
+        Self {
+            test_time: 10,
+            test_iterations: 30,
+            queue_num: Default::default(),
+            queue_size: Default::default(),
+            net_rx: Default::default(),
+            fio_ops: Default::default(),
+        }
+    }
+}
+
+/// A performance test should finish within the a certain time-out and
+/// return a performance metrics number (including the average number and
+/// standard deviation)
+struct PerformanceTest {
+    pub name: &'static str,
+    pub func_ptr: fn(&PerformanceTestControl) -> f64,
+    pub control: PerformanceTestControl,
+}
+
+impl Hash for PerformanceTest {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
+}
+
+impl PartialEq for PerformanceTest {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Eq for PerformanceTest {}
+
+impl PerformanceTest {
+    pub fn run(&self) -> (f64, f64) {
+        println!("Running test: '{}' ...", self.name);
+
+        let mut metrics = Vec::new();
+        for _ in 0..self.control.test_iterations {
+            metrics.push((self.func_ptr)(&self.control));
+        }
+
+        let mean = mean(&metrics).unwrap();
+        let std_dev = std_deviation(&metrics).unwrap();
+
+        println!(
+            "{} ... ok: mean = {}, std_dev = {}",
+            self.name, mean, std_dev
+        );
+
+        (mean, std_dev)
+    }
+}
+
+fn mean(data: &[f64]) -> Option<f64> {
+    let count = data.len();
+
+    if count > 0 {
+        Some(data.iter().sum::<f64>() / count as f64)
+    } else {
+        None
+    }
+}
+
+fn std_deviation(data: &[f64]) -> Option<f64> {
+    let count = data.len();
+
+    if count > 0 {
+        let mean = mean(data).unwrap();
+        let variance = data
+            .iter()
+            .map(|value| {
+                let diff = mean - *value;
+                diff * diff
+            })
+            .sum::<f64>()
+            / count as f64;
+
+        Some(variance.sqrt())
+    } else {
+        None
+    }
+}
+
+lazy_static! {
+    static ref TEST_LIST: HashSet<PerformanceTest> = {
+        let mut m = HashSet::new();
+        m.insert(PerformanceTest {
+            name: "performance_boot_time",
+            func_ptr: performance_boot_time,
+            control: PerformanceTestControl {
+                test_time: 2,
+                test_iterations: 10,
+                ..Default::default()
+            }
+        });
+        m.insert(PerformanceTest {
+            name: "performance_boot_time_pmem",
+            func_ptr: performance_boot_time_pmem,
+            control: PerformanceTestControl {
+                test_time: 2,
+                test_iterations: 10,
+                ..Default::default()
+            }
+        });
+        m.insert(PerformanceTest {
+            name: "performance_virtio_net_latency",
+            func_ptr: performance_net_latency,
+            control: Default::default(),
+        });
+        m.insert(PerformanceTest {
+            name: "performance_virtio_net_throughput_single_queue_rx",
+            func_ptr: performance_net_throughput,
+            control: PerformanceTestControl {
+                queue_num: Some(1), // used as 'queue_pairs'
+                queue_size: Some(256),
+                net_rx: Some(true),
+                ..Default::default()
+            }
+        });
+        m.insert(PerformanceTest {
+            name: "performance_virtio_net_throughput_single_queue_tx",
+            func_ptr: performance_net_throughput,
+            control: PerformanceTestControl {
+                queue_num: Some(1), // used as 'queue_pairs'
+                queue_size: Some(256),
+                net_rx: Some(false),
+                ..Default::default()
+            }
+        });
+        m.insert(PerformanceTest {
+            name: "performance_virtio_net_throughput_multi_queue_rx",
+            func_ptr: performance_net_throughput,
+            control: PerformanceTestControl {
+                queue_num: Some(2), // used as 'queue_pairs'
+                queue_size: Some(1024),
+                net_rx: Some(true),
+                ..Default::default()
+            }
+        });
+        m.insert(PerformanceTest {
+            name: "performance_virtio_net_throughput_multi_queue_tx",
+            func_ptr: performance_net_throughput,
+            control: PerformanceTestControl {
+                queue_num: Some(2), // used as 'queue_pairs'
+                queue_size: Some(1024),
+                net_rx: Some(false),
+                ..Default::default()
+            }
+        });
+        m.insert(PerformanceTest {
+            name: "performance_block_io_read",
+            func_ptr: performance_block_io,
+            control: PerformanceTestControl {
+                queue_num: Some(1),
+                queue_size: Some(1024),
+                fio_ops: Some(FioOps::Read),
+                ..Default::default()
+            }
+        });
+        m.insert(PerformanceTest {
+            name: "performance_block_io_write",
+            func_ptr: performance_block_io,
+            control: PerformanceTestControl {
+                queue_num: Some(1),
+                queue_size: Some(1024),
+                fio_ops: Some(FioOps::Write),
+                ..Default::default()
+            }
+        });
+        m.insert(PerformanceTest {
+            name: "performance_block_io_random_read",
+            func_ptr: performance_block_io,
+            control: PerformanceTestControl {
+                queue_num: Some(1),
+                queue_size: Some(1024),
+                fio_ops: Some(FioOps::RandomRead),
+                ..Default::default()
+            }
+        });
+        m.insert(PerformanceTest {
+            name: "performance_block_io_random_write",
+            func_ptr: performance_block_io,
+            control: PerformanceTestControl {
+                queue_num: Some(1),
+                queue_size: Some(1024),
+                fio_ops: Some(FioOps::RandomWrite),
+                ..Default::default()
+            }
+        });
+        m.insert(PerformanceTest {
+            name: "performance_block_io_multi_queue_read",
+            func_ptr: performance_block_io,
+            control: PerformanceTestControl {
+                queue_num: Some(2),
+                queue_size: Some(1024),
+                fio_ops: Some(FioOps::Read),
+                ..Default::default()
+            }
+        });
+        m.insert(PerformanceTest {
+            name: "performance_block_io_multi_queue_write",
+            func_ptr: performance_block_io,
+            control: PerformanceTestControl {
+                queue_num: Some(2),
+                queue_size: Some(1024),
+                fio_ops: Some(FioOps::Write),
+                ..Default::default()
+            }
+        });
+        m.insert(PerformanceTest {
+            name: "performance_block_io_multi_queue_random_read",
+            func_ptr: performance_block_io,
+            control: PerformanceTestControl {
+                queue_num: Some(2),
+                queue_size: Some(1024),
+                fio_ops: Some(FioOps::RandomRead),
+                ..Default::default()
+            }
+        });
+        m.insert(PerformanceTest {
+            name: "performance_block_io_multi_queue_random_write",
+            func_ptr: performance_block_io,
+            control: PerformanceTestControl {
+                queue_num: Some(2),
+                queue_size: Some(1024),
+                fio_ops: Some(FioOps::RandomWrite),
+                ..Default::default()
+            }
+        });
+        m
+    };
+}
+
+fn main() {
+    // Run performance tests sequentially and report results (in both readable/json format)
+    // Todo: test filter, report in readable/json format, capture test output unless failed;
+    for test in TEST_LIST.iter() {
+        test.run();
+    }
+}

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -336,6 +336,8 @@ fn run_test_with_timetout(test: &'static PerformanceTest) -> Result<String, Erro
 fn main() {
     let test_filter = env::var("TEST_FILTER").map_or("".to_string(), |o| o);
 
+    init_tests();
+
     // Run performance tests sequentially and report results (in both readable/json format)
     let mut json_output = String::new();
     for test in TEST_LIST.iter() {
@@ -351,6 +353,8 @@ fn main() {
             };
         }
     }
+
+    cleanup_tests();
 
     // Todo: Report/upload to the metrics database
     println!("\n\nTests result in json format: \n {}", json_output);

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -27,6 +27,8 @@ pub struct PerformanceTestResult {
     name: String,
     mean: f64,
     std_dev: f64,
+    max: f64,
+    min: f64,
 }
 
 pub struct PerformanceTestControl {
@@ -106,11 +108,15 @@ impl PerformanceTest {
 
         let mean = mean(&metrics).unwrap();
         let std_dev = std_deviation(&metrics).unwrap();
+        let max = metrics.clone().into_iter().reduce(f64::max).unwrap();
+        let min = metrics.clone().into_iter().reduce(f64::min).unwrap();
 
         PerformanceTestResult {
             name: self.name.to_string(),
             mean,
             std_dev,
+            max,
+            min,
         }
     }
 

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -178,7 +178,7 @@ lazy_static! {
             control: Default::default(),
         });
         m.insert(PerformanceTest {
-            name: "performance_virtio_net_throughput_single_queue_rx",
+            name: "performance_virtio_net_throughput_bps_single_queue_rx",
             func_ptr: performance_net_throughput,
             control: PerformanceTestControl {
                 queue_num: Some(1), // used as 'queue_pairs'
@@ -188,7 +188,7 @@ lazy_static! {
             }
         });
         m.insert(PerformanceTest {
-            name: "performance_virtio_net_throughput_single_queue_tx",
+            name: "performance_virtio_net_throughput_bps_single_queue_tx",
             func_ptr: performance_net_throughput,
             control: PerformanceTestControl {
                 queue_num: Some(1), // used as 'queue_pairs'
@@ -198,7 +198,7 @@ lazy_static! {
             }
         });
         m.insert(PerformanceTest {
-            name: "performance_virtio_net_throughput_multi_queue_rx",
+            name: "performance_virtio_net_throughput_bps_multi_queue_rx",
             func_ptr: performance_net_throughput,
             control: PerformanceTestControl {
                 queue_num: Some(2), // used as 'queue_pairs'
@@ -208,7 +208,7 @@ lazy_static! {
             }
         });
         m.insert(PerformanceTest {
-            name: "performance_virtio_net_throughput_multi_queue_tx",
+            name: "performance_virtio_net_throughput_bps_multi_queue_tx",
             func_ptr: performance_net_throughput,
             control: PerformanceTestControl {
                 queue_num: Some(2), // used as 'queue_pairs'
@@ -218,7 +218,7 @@ lazy_static! {
             }
         });
         m.insert(PerformanceTest {
-            name: "performance_block_io_read",
+            name: "performance_block_io_bps_read",
             func_ptr: performance_block_io,
             control: PerformanceTestControl {
                 queue_num: Some(1),
@@ -228,7 +228,7 @@ lazy_static! {
             }
         });
         m.insert(PerformanceTest {
-            name: "performance_block_io_write",
+            name: "performance_block_io_bps_write",
             func_ptr: performance_block_io,
             control: PerformanceTestControl {
                 queue_num: Some(1),
@@ -238,7 +238,7 @@ lazy_static! {
             }
         });
         m.insert(PerformanceTest {
-            name: "performance_block_io_random_read",
+            name: "performance_block_io_bps_random_read",
             func_ptr: performance_block_io,
             control: PerformanceTestControl {
                 queue_num: Some(1),
@@ -248,7 +248,7 @@ lazy_static! {
             }
         });
         m.insert(PerformanceTest {
-            name: "performance_block_io_random_write",
+            name: "performance_block_io_bps_random_write",
             func_ptr: performance_block_io,
             control: PerformanceTestControl {
                 queue_num: Some(1),
@@ -258,7 +258,7 @@ lazy_static! {
             }
         });
         m.insert(PerformanceTest {
-            name: "performance_block_io_multi_queue_read",
+            name: "performance_block_io_bps_multi_queue_read",
             func_ptr: performance_block_io,
             control: PerformanceTestControl {
                 queue_num: Some(2),
@@ -268,7 +268,7 @@ lazy_static! {
             }
         });
         m.insert(PerformanceTest {
-            name: "performance_block_io_multi_queue_write",
+            name: "performance_block_io_bps_multi_queue_write",
             func_ptr: performance_block_io,
             control: PerformanceTestControl {
                 queue_num: Some(2),
@@ -278,7 +278,7 @@ lazy_static! {
             }
         });
         m.insert(PerformanceTest {
-            name: "performance_block_io_multi_queue_random_read",
+            name: "performance_block_io_bps_multi_queue_random_read",
             func_ptr: performance_block_io,
             control: PerformanceTestControl {
                 queue_num: Some(2),
@@ -288,7 +288,7 @@ lazy_static! {
             }
         });
         m.insert(PerformanceTest {
-            name: "performance_block_io_multi_queue_random_write",
+            name: "performance_block_io_bps_multi_queue_random_write",
             func_ptr: performance_block_io,
             control: PerformanceTestControl {
                 queue_num: Some(2),

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -38,6 +38,7 @@ pub struct PerformanceTestResult {
 pub struct MetricsReport {
     pub git_human_readable: String,
     pub git_revision: String,
+    pub git_committer_date: String,
     pub date: String,
     pub results: Vec<PerformanceTestResult>,
 }
@@ -396,6 +397,7 @@ fn main() {
     let mut metrics_report = MetricsReport {
         git_human_readable: env!("GIT_HUMAN_READABLE").to_string(),
         git_revision: env!("GIT_REVISION").to_string(),
+        git_committer_date: env!("GIT_COMMITER_DATE").to_string(),
         date: date(),
         results: Vec::new(),
     };

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -1,0 +1,676 @@
+// Performance tests
+
+use crate::{mean, PerformanceTestControl};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::string::String;
+use std::thread;
+use std::time::Duration;
+use std::{fmt, fs};
+use test_infra::Error as InfraError;
+use test_infra::*;
+use vmm_sys_util::tempdir::TempDir;
+use wait_timeout::ChildExt;
+
+pub const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-custom-20210609-0.raw";
+
+#[derive(Debug)]
+enum WaitTimeoutError {
+    Timedout,
+    ExitStatus,
+    General(std::io::Error),
+}
+
+#[derive(Debug)]
+enum Error {
+    BootTimeParse,
+    EthrLogFile(std::io::Error),
+    EthrLogParse,
+    FioOutputParse,
+    Iperf3Parse,
+    Infra(InfraError),
+    Spawn(std::io::Error),
+    Scp(SshCommandError),
+    WaitTimeout(WaitTimeoutError),
+}
+
+impl From<InfraError> for Error {
+    fn from(e: InfraError) -> Self {
+        Self::Infra(e)
+    }
+}
+
+const DIRECT_KERNEL_BOOT_CMDLINE: &str =
+    "root=/dev/vda1 console=hvc0 rw systemd.journald.forward_to_console=1";
+
+// Creates the path for direct kernel boot and return the path.
+// For x86_64, this function returns the vmlinux kernel path.
+// For AArch64, this function returns the PE kernel path.
+fn direct_kernel_boot_path() -> PathBuf {
+    let mut workload_path = dirs::home_dir().unwrap();
+    workload_path.push("workloads");
+
+    let mut kernel_path = workload_path;
+    #[cfg(target_arch = "x86_64")]
+    kernel_path.push("vmlinux");
+    #[cfg(target_arch = "aarch64")]
+    kernel_path.push("Image");
+
+    kernel_path
+}
+
+// Wait the child process for a given timeout
+fn child_wait_timeout(child: &mut Child, timeout: u64) -> Result<(), WaitTimeoutError> {
+    match child.wait_timeout(Duration::from_secs(timeout)) {
+        Err(e) => {
+            return Err(WaitTimeoutError::General(e));
+        }
+        Ok(s) => match s {
+            None => {
+                return Err(WaitTimeoutError::Timedout);
+            }
+            Some(s) => {
+                if !s.success() {
+                    return Err(WaitTimeoutError::ExitStatus);
+                }
+            }
+        },
+    }
+
+    Ok(())
+}
+
+fn parse_iperf3_output(output: &[u8], sender: bool) -> Result<f64, Error> {
+    std::panic::catch_unwind(|| {
+        let s = String::from_utf8_lossy(output);
+        let v: Value = serde_json::from_str(&s).expect("'iperf3' parse error: invalid json output");
+
+        let bps: f64 = if sender {
+            v["end"]["sum_sent"]["bits_per_second"]
+                .as_f64()
+                .expect("'iperf3' parse error: missing entry 'end.sum_sent.bits_per_second'")
+        } else {
+            v["end"]["sum_received"]["bits_per_second"]
+                .as_f64()
+                .expect("'iperf3' parse error: missing entry 'end.sum_received.bits_per_second'")
+        };
+
+        bps
+    })
+    .map_err(|_| {
+        eprintln!(
+            "=============== iperf3 output ===============\n\n{}\n\n===========end============\n\n",
+            String::from_utf8_lossy(output)
+        );
+        Error::Iperf3Parse
+    })
+}
+
+fn measure_virtio_net_throughput(
+    test_time: u32,
+    queue_pairs: u32,
+    guest: &Guest,
+    receive: bool,
+) -> Result<f64, Error> {
+    let default_port = 5201;
+
+    // 1. start the iperf3 server on the guest
+    for n in 0..queue_pairs {
+        guest
+            .ssh_command(&format!("iperf3 -s -p {} -D", default_port + n))
+            .map_err(InfraError::SshCommand)?;
+    }
+
+    thread::sleep(Duration::new(1, 0));
+
+    // 2. start the iperf3 client on host to measure RX through-put
+    let mut clients = Vec::new();
+    for n in 0..queue_pairs {
+        let mut cmd = Command::new("iperf3");
+        cmd.args(&[
+            "-J", // Output in JSON format
+            "-c",
+            &guest.network.guest_ip,
+            "-p",
+            &format!("{}", default_port + n),
+            "-t",
+            &format!("{}", test_time),
+        ]);
+        // For measuring the guest transmit throughput (as a sender),
+        // use reverse mode of the iperf3 client on the host
+        if !receive {
+            cmd.args(&["-R"]);
+        }
+        let client = cmd
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .map_err(Error::Spawn)?;
+
+        clients.push(client);
+    }
+
+    let mut err: Option<Error> = None;
+    let mut bps = Vec::new();
+    let mut failed = false;
+    for c in clients {
+        let mut c = c;
+        if let Err(e) = child_wait_timeout(&mut c, test_time as u64 + 5) {
+            err = Some(Error::WaitTimeout(e));
+            failed = true;
+        }
+
+        if !failed {
+            // Safe to unwrap as we know the child has terminated succesffully
+            let output = c.wait_with_output().unwrap();
+            bps.push(parse_iperf3_output(&output.stdout, receive)?);
+        } else {
+            let _ = c.kill();
+            let output = c.wait_with_output().unwrap();
+            println!(
+                "=============== Client output [Error] ===============\n\n{}\n\n===========end============\n\n",
+                String::from_utf8_lossy(&output.stdout)
+            );
+        }
+    }
+
+    if let Some(e) = err {
+        Err(e)
+    } else {
+        Ok(bps.iter().sum())
+    }
+}
+
+pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
+    let test_time = control.test_time;
+    let queue_pairs = control.queue_num.unwrap();
+    let queue_size = control.queue_size.unwrap();
+    let rx = control.net_rx.unwrap();
+
+    let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+    let guest = Guest::new(Box::new(focal));
+
+    let net_params = format!(
+        "tap=,mac={},ip={},mask=255.255.255.0,num_queues={},queue_size={}",
+        guest.network.guest_mac,
+        guest.network.host_ip,
+        queue_pairs * 2,
+        queue_size,
+    );
+
+    let mut child = GuestCommand::new(&guest)
+        .args(&["--cpus", &format!("boot={}", queue_pairs * 2)])
+        .args(&["--memory", "size=4G"])
+        .args(&["--kernel", direct_kernel_boot_path().to_str().unwrap()])
+        .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+        .default_disks()
+        .args(&["--net", net_params.as_str()])
+        .capture_output()
+        .set_print_cmd(false)
+        .spawn()
+        .unwrap();
+
+    let r = std::panic::catch_unwind(|| {
+        guest.wait_vm_boot(None).unwrap();
+        measure_virtio_net_throughput(test_time, queue_pairs, &guest, rx).unwrap()
+    });
+
+    let _ = child.kill();
+    let output = child.wait_with_output().unwrap();
+
+    match r {
+        Ok(r) => r,
+        Err(e) => {
+            handle_child_output(Err(e), &output);
+            panic!("test failed!");
+        }
+    }
+}
+
+fn parse_ethr_latency_output(output: &[u8]) -> Result<Vec<f64>, Error> {
+    std::panic::catch_unwind(|| {
+        let s = String::from_utf8_lossy(output);
+        let mut latency = Vec::new();
+        for l in s.lines() {
+            let v: Value = serde_json::from_str(l).expect("'ethr' parse error: invalid json line");
+            // Skip header/summary lines
+            if let Some(avg) = v["Avg"].as_str() {
+                // Assume the latency unit is always "us"
+                latency.push(
+                    avg.split("us").collect::<Vec<&str>>()[0]
+                        .parse::<f64>()
+                        .expect("'ethr' parse error: invalid 'Avg' entry"),
+                );
+            }
+        }
+
+        assert!(
+            !latency.is_empty(),
+            "'ethr' parse error: no valid latency data found"
+        );
+
+        latency
+    })
+    .map_err(|_| {
+        eprintln!(
+            "=============== ethr output ===============\n\n{}\n\n===========end============\n\n",
+            String::from_utf8_lossy(output)
+        );
+        Error::EthrLogParse
+    })
+}
+
+fn measure_virtio_net_latency(guest: &Guest, test_time: u32) -> Result<Vec<f64>, Error> {
+    // copy the 'ethr' tool to the guest image
+    let ethr_path = "/usr/local/bin/ethr";
+    let ethr_remote_path = "/tmp/ethr";
+    scp_to_guest(
+        Path::new(ethr_path),
+        Path::new(ethr_remote_path),
+        &guest.network.guest_ip,
+        //DEFAULT_SSH_RETRIES,
+        1,
+        DEFAULT_SSH_TIMEOUT,
+    )
+    .map_err(Error::Scp)?;
+
+    // Start the ethr server on the guest
+    guest
+        .ssh_command(&format!("{} -s &> /dev/null &", ethr_remote_path))
+        .map_err(InfraError::SshCommand)?;
+
+    thread::sleep(Duration::new(1, 0));
+
+    // Start the ethr client on the host
+    let log_file = guest
+        .tmp_dir
+        .as_path()
+        .join("ethr.client.log")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let mut c = Command::new(ethr_path)
+        .args(&[
+            "-c",
+            &guest.network.guest_ip,
+            "-t",
+            "l",
+            "-o",
+            &log_file, // file output is JSON format
+            "-d",
+            &format!("{}s", test_time),
+        ])
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(Error::Spawn)?;
+
+    if let Err(e) = child_wait_timeout(&mut c, test_time as u64 + 5).map_err(Error::WaitTimeout) {
+        let _ = c.kill();
+        return Err(e);
+    }
+
+    // Parse the ethr latency test output
+    let content = fs::read(log_file).map_err(Error::EthrLogFile)?;
+    parse_ethr_latency_output(&content)
+}
+
+pub fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
+    let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+    let guest = Guest::new(Box::new(focal));
+    let mut child = GuestCommand::new(&guest)
+        .args(&["--cpus", "boot=2"])
+        .args(&["--memory", "size=4G"])
+        .args(&["--kernel", direct_kernel_boot_path().to_str().unwrap()])
+        .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+        .default_disks()
+        .default_net()
+        .capture_output()
+        .set_print_cmd(false)
+        .spawn()
+        .unwrap();
+
+    let r = std::panic::catch_unwind(|| {
+        guest.wait_vm_boot(None).unwrap();
+
+        // 'ethr' tool will measure the latency multiple times with provided test time
+        let latency = measure_virtio_net_latency(&guest, control.test_time).unwrap();
+        mean(&latency).unwrap()
+    });
+
+    let _ = child.kill();
+    let output = child.wait_with_output().unwrap();
+
+    match r {
+        Ok(r) => r,
+        Err(e) => {
+            handle_child_output(Err(e), &output);
+            panic!("test failed!");
+        }
+    }
+}
+
+fn parse_boot_time_output(output: &[u8]) -> Result<f64, Error> {
+    std::panic::catch_unwind(|| {
+        let l: Vec<String> = String::from_utf8_lossy(output)
+            .lines()
+            .into_iter()
+            .filter(|l| l.contains("Debug I/O port: Kernel code"))
+            .map(|l| l.to_string())
+            .collect();
+
+        assert_eq!(
+            l.len(),
+            2,
+            "Expecting two matching lines for 'Debug I/O port: Kernel code'"
+        );
+
+        let time_stamp_kernel_start = {
+            let s = l[0].split("--").collect::<Vec<&str>>();
+            assert_eq!(
+                s.len(),
+                2,
+                "Expecting '--' for the matching line of 'Debug I/O port' output"
+            );
+
+            // Sample output: "[Debug I/O port: Kernel code 0x40] 0.096537 seconds"
+            assert!(
+                s[1].contains("0x40"),
+                "Expecting kernel code '0x40' for 'linux_kernel_start' time stamp output"
+            );
+            let t = s[1].split_whitespace().collect::<Vec<&str>>();
+            assert_eq!(
+                t.len(),
+                8,
+                "Expecting exact '8' words from the 'Debug I/O port' output"
+            );
+            assert!(
+                t[7].eq("seconds"),
+                "Expecting 'seconds' as the the last word of the 'Debug I/O port' output"
+            );
+
+            t[6].parse::<f64>().unwrap()
+        };
+
+        let time_stamp_user_start = {
+            let s = l[1].split("--").collect::<Vec<&str>>();
+            assert_eq!(
+                s.len(),
+                2,
+                "Expecting '--' for the matching line of 'Debug I/O port' output"
+            );
+
+            // Sample output: "Debug I/O port: Kernel code 0x41] 0.198980 seconds"
+            assert!(
+                s[1].contains("0x41"),
+                "Expecting kernel code '0x41' for 'linux_kernel_start' time stamp output"
+            );
+            let t = s[1].split_whitespace().collect::<Vec<&str>>();
+            assert_eq!(
+                t.len(),
+                8,
+                "Expecting exact '8' words from the 'Debug I/O port' output"
+            );
+            assert!(
+                t[7].eq("seconds"),
+                "Expecting 'seconds' as the the last word of the 'Debug I/O port' output"
+            );
+
+            t[6].parse::<f64>().unwrap()
+        };
+
+        time_stamp_user_start - time_stamp_kernel_start
+    })
+    .map_err(|_| {
+        eprintln!(
+            "=============== boot-time output ===============\n\n{}\n\n===========end============\n\n",
+            String::from_utf8_lossy(output)
+        );
+        Error::BootTimeParse
+    })
+}
+
+fn measure_boot_time(cmd: &mut GuestCommand, test_time: u32) -> Result<f64, Error> {
+    let mut child = cmd.capture_output().set_print_cmd(false).spawn().unwrap();
+
+    thread::sleep(Duration::new(test_time as u64, 0));
+    let _ = child.kill();
+    let output = child.wait_with_output().unwrap();
+
+    parse_boot_time_output(&output.stderr).map_err(|e| {
+        eprintln!(
+            "\n\n==== Start child stdout ====\n\n{}\n\n==== End child stdout ====",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        eprintln!(
+            "\n\n==== Start child stderr ====\n\n{}\n\n==== End child stderr ====",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        e
+    })
+}
+
+pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
+    let r = std::panic::catch_unwind(|| {
+        let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(focal));
+        let mut cmd = GuestCommand::new(&guest);
+
+        let c = cmd
+            .args(&["--memory", "size=1G"])
+            .args(&["--kernel", direct_kernel_boot_path().to_str().unwrap()])
+            .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .args(&["--console", "off"])
+            .default_disks();
+
+        measure_boot_time(c, control.test_time).unwrap()
+    });
+
+    match r {
+        Ok(r) => r,
+        Err(_) => {
+            panic!("test failed!");
+        }
+    }
+}
+
+pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
+    let r = std::panic::catch_unwind(|| {
+        let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(focal));
+        let mut cmd = GuestCommand::new(&guest);
+        let c = cmd
+            .args(&["--memory", "size=1G,hugepages=on"])
+            .args(&["--kernel", direct_kernel_boot_path().to_str().unwrap()])
+            .args(&["--cmdline", "root=/dev/pmem0p1 console=ttyS0 quiet rw"])
+            .args(&["--console", "off"])
+            .args(&[
+                "--pmem",
+                format!(
+                    "file={}",
+                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
+                )
+                .as_str(),
+            ]);
+
+        measure_boot_time(c, control.test_time).unwrap()
+    });
+
+    match r {
+        Ok(r) => r,
+        Err(_) => {
+            panic!("test failed!");
+        }
+    }
+}
+
+pub enum FioOps {
+    Read,
+    RandomRead,
+    Write,
+    RandomWrite,
+}
+
+impl fmt::Display for FioOps {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            FioOps::Read => write!(f, "read"),
+            FioOps::RandomRead => write!(f, "randread"),
+            FioOps::Write => write!(f, "write"),
+            FioOps::RandomWrite => write!(f, "randwrite"),
+        }
+    }
+}
+
+fn parse_fio_output(output: &str, fio_ops: &FioOps, num_jobs: u32) -> Result<f64, Error> {
+    std::panic::catch_unwind(|| {
+        let v: Value =
+            serde_json::from_str(output).expect("'fio' parse error: invalid json output");
+        let jobs = v["jobs"]
+            .as_array()
+            .expect("'fio' parse error: missing entry 'jobs'");
+        assert_eq!(
+            jobs.len(),
+            num_jobs as usize,
+            "'fio' parse error: Unexpected number of 'fio' jobs."
+        );
+
+        let read = match fio_ops {
+            FioOps::Read | FioOps::RandomRead => true,
+            FioOps::Write | FioOps::RandomWrite => false,
+        };
+
+        let mut total_bps = 0_f64;
+        for j in jobs {
+            if read {
+                let bytes = j["read"]["io_bytes"]
+                    .as_u64()
+                    .expect("'fio' parse error: missing entry 'read.io_bytes'");
+                let runtime = j["read"]["runtime"]
+                    .as_u64()
+                    .expect("'fio' parse error: missing entry 'read.runtime'")
+                    as f64
+                    / 1000_f64;
+                total_bps += bytes as f64 / runtime as f64;
+            } else {
+                let bytes = j["write"]["io_bytes"]
+                    .as_u64()
+                    .expect("'fio' parse error: missing entry 'write.io_bytes'");
+                let runtime = j["write"]["runtime"]
+                    .as_u64()
+                    .expect("'fio' parse error: missing entry 'write.runtime'")
+                    as f64
+                    / 1000_f64;
+                total_bps += bytes as f64 / runtime as f64;
+            }
+        }
+
+        total_bps
+    })
+    .map_err(|_| {
+        eprintln!(
+            "=============== Fio output ===============\n\n{}\n\n===========end============\n\n",
+            output
+        );
+        Error::FioOutputParse
+    })
+}
+
+pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
+    let test_time = control.test_time;
+    let queue_num = control.queue_num.unwrap();
+    let queue_size = control.queue_size.unwrap();
+    let fio_ops = control.fio_ops.as_ref().unwrap();
+
+    let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+    let guest = Guest::new(Box::new(focal));
+    let api_socket = guest
+        .tmp_dir
+        .as_path()
+        .join("cloud-hypervisor.sock")
+        .to_str()
+        .unwrap()
+        .to_string();
+    // The test image can not be created on tmpfs (e.g. /tmp) filesystem,
+    // as tmpfs does not support O_DIRECT
+    let test_dir = TempDir::new_with_prefix("/home/ch").unwrap();
+    let test_img = test_dir
+        .as_path()
+        .join("tmp.img")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let mut child = GuestCommand::new(&guest)
+        .args(&["--cpus", &format!("boot={}", queue_num * 2)])
+        .args(&["--memory", "size=4G"])
+        .args(&["--kernel", direct_kernel_boot_path().to_str().unwrap()])
+        .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+        .default_disks()
+        .default_net()
+        .args(&["--api-socket", &api_socket])
+        .capture_output()
+        .set_print_cmd(false)
+        .spawn()
+        .unwrap();
+
+    let r = std::panic::catch_unwind(|| {
+        // Generate a image file for testing
+        assert!(exec_host_command_output(&format!(
+            "dd if=/dev/zero of={} bs=1M count=4096",
+            test_img
+        ))
+        .status
+        .success());
+
+        guest.wait_vm_boot(None).unwrap();
+
+        // Hotplug test disk
+        assert!(Command::new(clh_command("ch-remote"))
+            .args(&[&format!("--api-socket={}", api_socket)])
+            .args(&[
+                "add-disk",
+                &format!(
+                    "path={},num_queues={},queue_size={},direct=on",
+                    test_img, queue_num, queue_size
+                )
+            ])
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap()
+            .wait_timeout(Duration::from_secs(5))
+            .unwrap()
+            .expect("Failed to hotplug test disk image")
+            .success());
+
+        let fio_command = format!(
+            "sudo fio --filename=/dev/vdc --name=test --output-format=json \
+            --direct=1 --bs=4k --ioengine=io_uring --iodepth=64 \
+            --rw={} --runtime={} --numjobs={}",
+            fio_ops, test_time, queue_num
+        );
+        let output = guest
+            .ssh_command(&fio_command)
+            .map_err(InfraError::SshCommand)
+            .unwrap();
+
+        // Parse fio output
+        parse_fio_output(&output, fio_ops, queue_num).unwrap()
+    });
+
+    test_dir.remove().unwrap();
+
+    let _ = child.kill();
+    let output = child.wait_with_output().unwrap();
+
+    match r {
+        Ok(r) => r,
+        Err(e) => {
+            handle_child_output(Err(e), &output);
+            panic!("test failed!");
+        }
+    }
+}

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -44,6 +44,8 @@ RUN apt-get update \
 	openvswitch-switch-dpdk \
 	python3-distutils \
 	uuid-dev \
+	iperf3 \
+	zip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -126,3 +128,9 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
        && cp ./scripts/rpc.py /usr/local/bin/spdk-nvme \
        && cp -r ./scripts/rpc /usr/local/bin/spdk-nvme \
        && cd .. && rm -rf spdk; fi
+
+# install ethr tool for performance tests
+RUN wget https://github.com/microsoft/ethr/releases/latest/download/ethr_linux.zip \
+    && unzip ethr_linux.zip \
+    && cp ethr /usr/local/bin \
+    && rm ethr_linux.zip

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -354,12 +354,6 @@ cmd_tests() {
 
     process_volumes_args
     target="$(uname -m)-unknown-linux-${libc}"
-    cflags=""
-    target_cc=""
-    if [[ "$target" == "x86_64-unknown-linux-musl" ]]; then
-	target_cc="musl-gcc"
-	cflags="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
-    fi
 
     if [[ "$unit" = true  ]] ;  then
 	say "Running unit tests for $target..."
@@ -371,8 +365,6 @@ cmd_tests() {
 	       --cap-add net_admin \
 	       --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" $exported_volumes \
 	       --env BUILD_TARGET="$target" \
-	       --env CFLAGS="$cflags" \
-	       --env TARGET_CC="$target_cc" \
 	       "$CTR_IMAGE" \
 	       ./scripts/run_unit_tests.sh "$@" || fix_dir_perms $? || exit $?
     fi

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -x
+
+source $HOME/.cargo/env
+source $(dirname "$0")/test-util.sh
+
+export BUILD_TARGET=${BUILD_TARGET-x86_64-unknown-linux-gnu}
+
+WORKLOADS_DIR="$HOME/workloads"
+mkdir -p "$WORKLOADS_DIR"
+
+process_common_args "$@"
+
+# For now these values are default for kvm
+features=""
+
+if [ "$hypervisor" = "mshv" ] ;  then
+    features="--no-default-features --features mshv,common"
+fi
+
+cp scripts/sha1sums-x86_64 $WORKLOADS_DIR
+
+FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
+FOCAL_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$FOCAL_OS_IMAGE_NAME"
+FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"
+if [ ! -f "$FOCAL_OS_IMAGE" ]; then
+    pushd $WORKLOADS_DIR
+    time wget --quiet $FOCAL_OS_IMAGE_URL || exit 1
+    popd
+fi
+
+FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.raw"
+FOCAL_OS_RAW_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_RAW_IMAGE_NAME"
+if [ ! -f "$FOCAL_OS_RAW_IMAGE" ]; then
+    pushd $WORKLOADS_DIR
+    time qemu-img convert -p -f qcow2 -O raw $FOCAL_OS_IMAGE_NAME $FOCAL_OS_RAW_IMAGE_NAME || exit 1
+    popd
+fi
+
+pushd $WORKLOADS_DIR
+grep focal sha1sums-x86_64 | sha1sum --check
+if [ $? -ne 0 ]; then
+    echo "sha1sum validation of images failed, remove invalid images to fix the issue."
+    exit 1
+fi
+popd
+
+# Build custom kernel based on virtio-pmem and virtio-fs upstream patches
+VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
+
+LINUX_CUSTOM_DIR="$WORKLOADS_DIR/linux-custom"
+
+if [ ! -f "$VMLINUX_IMAGE" ]; then
+    SRCDIR=$PWD
+    pushd $WORKLOADS_DIR
+    time git clone --depth 1 "https://github.com/cloud-hypervisor/linux.git" -b "ch-5.15.12" $LINUX_CUSTOM_DIR
+    cp $SRCDIR/resources/linux-config-x86_64 $LINUX_CUSTOM_DIR/.config
+    popd
+fi
+
+if [ ! -f "$VMLINUX_IMAGE" ]; then
+    pushd $LINUX_CUSTOM_DIR
+    time make bzImage -j `nproc`
+    cp vmlinux $VMLINUX_IMAGE || exit 1
+    popd
+fi
+
+if [ -d "$LINUX_CUSTOM_DIR" ]; then
+    rm -rf $LINUX_CUSTOM_DIR
+fi
+
+BUILD_TARGET="$(uname -m)-unknown-linux-${CH_LIBC}"
+CFLAGS=""
+TARGET_CC=""
+if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
+    TARGET_CC="musl-gcc"
+    CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
+fi
+
+cargo build --all --release $features --target $BUILD_TARGET
+strip target/$BUILD_TARGET/release/cloud-hypervisor
+strip target/$BUILD_TARGET/release/vhost_user_net
+strip target/$BUILD_TARGET/release/ch-remote
+strip target/$BUILD_TARGET/release/performance-metrics
+
+# setup hugepages
+echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
+sudo chmod a+rwX /dev/hugepages
+
+export RUST_BACKTRACE=1
+time target/$BUILD_TARGET/release/performance-metrics
+RES=$?
+
+exit $RES

--- a/test_infra/Cargo.toml
+++ b/test_infra/Cargo.toml
@@ -9,6 +9,6 @@ dirs = "3.0.1"
 epoll = "4.3.1"
 lazy_static= "1.4.0"
 libc = "0.2.91"
-ssh2 = "0.9.1"
+ssh2 = { version = "0.9.1", features = ["vendored-openssl"]}
 vmm-sys-util = "0.9.0"
 wait-timeout = "0.2.0"

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1185,6 +1185,7 @@ pub struct GuestCommand<'a> {
     command: Command,
     guest: &'a Guest,
     capture_output: bool,
+    print_cmd: bool,
 }
 
 impl<'a> GuestCommand<'a> {
@@ -1197,6 +1198,7 @@ impl<'a> GuestCommand<'a> {
             command: Command::new(clh_command(binary_name)),
             guest,
             capture_output: false,
+            print_cmd: true,
         }
     }
 
@@ -1205,13 +1207,20 @@ impl<'a> GuestCommand<'a> {
         self
     }
 
+    pub fn set_print_cmd(&mut self, print_cmd: bool) -> &mut Self {
+        self.print_cmd = print_cmd;
+        self
+    }
+
     pub fn spawn(&mut self) -> io::Result<Child> {
-        println!(
-            "\n\n==== Start cloud-hypervisor command-line ====\n\n\
-                 {:?}\n\
-                 \n==== End cloud-hypervisor command-line ====\n\n",
-            self.command
-        );
+        if self.print_cmd {
+            println!(
+                "\n\n==== Start cloud-hypervisor command-line ====\n\n\
+                     {:?}\n\
+                     \n==== End cloud-hypervisor command-line ====\n\n",
+                self.command
+            );
+        }
 
         if self.capture_output {
             let child = self

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -834,7 +834,7 @@ impl Guest {
     pub fn api_create_body(
         &self,
         cpu_count: u8,
-        fw_path: &str,
+        _fw_path: &str,
         _kernel_path: &str,
         _kernel_cmd: &str,
     ) -> String {
@@ -842,7 +842,7 @@ impl Guest {
         format! {"{{\"cpus\":{{\"boot_vcpus\":{},\"max_vcpus\":{}}},\"kernel\":{{\"path\":\"{}\"}},\"cmdline\":{{\"args\": \"\"}},\"net\":[{{\"ip\":\"{}\", \"mask\":\"255.255.255.0\", \"mac\":\"{}\"}}], \"disks\":[{{\"path\":\"{}\"}}, {{\"path\":\"{}\"}}]}}",
                  cpu_count,
                  cpu_count,
-                 fw_path,
+                 _fw_path,
                  self.network.host_ip,
                  self.network.guest_mac,
                  self.disk_config.disk(DiskType::OperatingSystem).unwrap().as_str(),


### PR DESCRIPTION
This patch adds a new binary target `performance-metrics` for generating performance metrics data, including boot time, network throughput & latency, and block I/O. 

The new target can be compiled from: 
`$ cargo build --all --bin performance-metrics`

Also, we provide a quick way to generate the performance metrics via our dev container:
`$ ./scripts/dev_cli.sh tests --metrics`

The output is in both human-readable and JSON format:

```
root@7439288450fd:/cloud-hypervisor# ./target/debug/performance-metrics  --test-filter pmem
Test 'performance_boot_time_pmem' running .. (test_time = 2s, test_iterations = 10)
Test 'performance_boot_time_pmem' .. ok: mean = 0.0791802, std_dev = 0.007185693728513626
{
  "git_human_readable": "v21.0-135-g8c9d5b01-dirty",
  "git_revision": "8c9d5b01b2230d02c98e9bc058530e2420469f7e",
  "git_committer_date": "Tue Feb 15 07:51:44 2022 -0800",
  "date": "Tue Feb 15 16:23:22 UTC 2022",
  "results": [
    {
      "name": "performance_boot_time_pmem",
      "mean": 0.0791802,
      "std_dev": 0.007185693728513626,
      "max": 0.09367700000000001,
      "min": 0.07286700000000002
    }
  ]
}
```

Fixes: #3637

Signed-off-by: Bo Chen <chen.bo@intel.com>