### PR TITLE
vmm: Don't check for presence of tdx parameter when not built with tdx

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -525,9 +525,16 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
     )
     .map_err(Error::StartVmmThread)?;
 
-    // Can't test for "vm-config" group as some have default values. The kernel
+    // Can't test for "vm-config" group as some have default values. The kernel (or tdx if enabled)
     // is the only required option for booting the VM.
-    if cmd_arguments.is_present("kernel") || cmd_arguments.is_present("tdx") {
+    #[cfg(feature = "tdx")]
+    let tdx_or_kernel_present =
+        cmd_arguments.is_present("kernel") || cmd_arguments.is_present("tdx");
+
+    #[cfg(not(feature = "tdx"))]
+    let tdx_or_kernel_present = cmd_arguments.is_present("kernel");
+
+    if tdx_or_kernel_present {
         let vm_params = config::VmParams::from_arg_matches(&cmd_arguments);
         let vm_config = config::VmConfig::parse(vm_params).map_err(Error::ParsingConfig)?;
 


### PR DESCRIPTION
Passing no boot related parameters (e.g. no --kernel) is used for e.g.
receiving a live migration or an API based boot.

```
marvin:~/src/cloud-hypervisor (2022-01-11-live-migration-with-fds *)$ target/debug/cloud-hypervisor --api-socket /tmp/api2
thread 'main' panicked at '`tdx` is not a name of an argument or a group.
Make sure you're using the name of the argument itself and not the name of short or long flags.', /home/rob/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.0.6/src/parse/matches/arg_matches.rs:598:14
stack backtrace:
   0: rust_begin_unwind
             at /rustc/7d6f948173ccb18822bab13d548c65632db5f0aa/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/7d6f948173ccb18822bab13d548c65632db5f0aa/library/core/src/panicking.rs:107:14
   2: clap::parse::matches::arg_matches::ArgMatches::get_arg
             at /home/rob/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.0.6/src/parse/matches/arg_matches.rs:1052:17
   3: clap::parse::matches::arg_matches::ArgMatches::is_present
             at /home/rob/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.0.6/src/parse/matches/arg_matches.rs:598:9
   4: cloud_hypervisor::start_vmm
             at ./src/main.rs:530:46
   5: cloud_hypervisor::main
             at ./src/main.rs:566:27
   6: core::ops::function::FnOnce::call_once
             at /rustc/7d6f948173ccb18822bab13d548c65632db5f0aa/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

Signed-off-by: Rob Bradford <robert.bradford@intel.com>