### PR TITLE
tdx: Update method to expose ACPI tables to TDVF

### DIFF
--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -61,57 +61,6 @@ impl Default for TdvfSectionType {
     }
 }
 
-#[repr(C)]
-#[derive(Clone, Copy, Default, Debug)]
-pub struct TdVmmDataRegion {
-    pub start_address: u64,
-    pub length: u64,
-    pub region_type: TdVmmDataRegionType,
-}
-
-#[repr(u16)]
-#[derive(Clone, Copy, Debug)]
-pub enum TdVmmDataRegionType {
-    Signature = 0x0000,
-    InterfaceVersion = 0x0001,
-    SystemUuid = 0x0002,
-    RamSize = 0x0003,
-    GraphicsEnabled = 0x0004,
-    SmpCpuCount = 0x0005,
-    MachineId = 0x0006,
-    KernelAddress = 0x0007,
-    KernelSize = 0x0008,
-    KernelCommandLine = 0x0009,
-    InitrdAddress = 0x000a,
-    InitrdSize = 0x000b,
-    BootDevice = 0x000c,
-    NumaData = 0x000d,
-    BootMenu = 0x000e,
-    MaximumCpuCount = 0x000f,
-    KernelEntry = 0x0010,
-    KernelData = 0x0011,
-    InitrdData = 0x0012,
-    CommandLineAddress = 0x0013,
-    CommandLineSize = 0x0014,
-    CommandLineData = 0x0015,
-    KernelSetupAddress = 0x0016,
-    KernelSetupSize = 0x0017,
-    KernelSetupData = 0x0018,
-    FileDir = 0x0019,
-    AcpiTables = 0x8000,
-    SmbiosTables = 0x8001,
-    Irq0Override = 0x8002,
-    E820Table = 0x8003,
-    HpetData = 0x8004,
-    Reserved = 0xffff,
-}
-
-impl Default for TdVmmDataRegionType {
-    fn default() -> Self {
-        TdVmmDataRegionType::Reserved
-    }
-}
-
 pub fn parse_tdvf_sections(file: &mut File) -> Result<Vec<TdvfSection>, TdvfError> {
     // The 32-bit offset to the TDVF metadata is located 32 bytes from
     // the end of the file.
@@ -231,20 +180,11 @@ struct HobGuidType {
     name: EfiGuid,
 }
 
-#[repr(C)]
-#[derive(Copy, Clone, Default, Debug)]
-struct TdVmmData {
-    guid_type: HobGuidType,
-    region: TdVmmDataRegion,
-}
-
 // SAFETY: These data structures only contain a series of integers
-unsafe impl ByteValued for TdVmmDataRegion {}
 unsafe impl ByteValued for HobHeader {}
 unsafe impl ByteValued for HobHandoffInfoTable {}
 unsafe impl ByteValued for HobResourceDescriptor {}
 unsafe impl ByteValued for HobGuidType {}
-unsafe impl ByteValued for TdVmmData {}
 
 pub struct TdHob {
     start_offset: u64,
@@ -374,38 +314,6 @@ impl TdHob {
              */
             0x403,
         )
-    }
-
-    pub fn add_td_vmm_data(
-        &mut self,
-        mem: &GuestMemoryMmap,
-        region: TdVmmDataRegion,
-    ) -> Result<(), TdvfError> {
-        let td_vmm_data = TdVmmData {
-            guid_type: HobGuidType {
-                header: HobHeader {
-                    r#type: HobType::GuidExtension,
-                    length: std::mem::size_of::<TdVmmData>() as u16,
-                    reserved: 0,
-                },
-                // TD_VMM_DATA_GUID CF2643E4-C0D3-46FF-0000-72EE623DDE38
-                name: EfiGuid {
-                    data1: 0xcf26_43e4,
-                    data2: 0xc0d3,
-                    data3: 0x46ff,
-                    data4: [0x00, 0x00, 0x72, 0xee, 0x62, 0x3d, 0xde, 0x38],
-                },
-            },
-            region,
-        };
-        info!(
-            "Writing HOB TD_VMM_DATA {:x} {:x?}",
-            self.current_offset, td_vmm_data
-        );
-        mem.write_obj(td_vmm_data, GuestAddress(self.current_offset))
-            .map_err(TdvfError::GuestMemoryWriteHob)?;
-        self.update_offset::<TdVmmData>();
-        Ok(())
     }
 }
 

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -778,7 +778,6 @@ pub fn create_acpi_tables(
 }
 
 #[cfg(feature = "tdx")]
-#[allow(unused)]
 pub fn create_acpi_tables_tdx(
     device_manager: &Arc<Mutex<DeviceManager>>,
     cpu_manager: &Arc<Mutex<CpuManager>>,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1841,6 +1841,18 @@ impl Vm {
         )
         .map_err(Error::PopulateHob)?;
 
+        // Loop over the ACPI tables and copy them to the HOB.
+        #[cfg(feature = "acpi")]
+        for acpi_table in crate::acpi::create_acpi_tables_tdx(
+            &self.device_manager,
+            &self.cpu_manager,
+            &self.memory_manager,
+            &self.numa_nodes,
+        ) {
+            hob.add_acpi_table(&mem, acpi_table.as_slice())
+                .map_err(Error::PopulateHob)?;
+        }
+
         hob.finish(&mem).map_err(Error::PopulateHob)?;
 
         Ok(hob_offset)


### PR DESCRIPTION
This PR updates the way to expose the ACPI tables to the TDVF firmware, which is used in TDShim as well. Each table content is individually passed through the HOB so that it can be parsed, analyzed and measured from the firmware before being passed to the TD guest OS.
After removing the previous method, this PR implements the new way of passing the tables.

It's been tested with the TDVF counterpart: https://github.com/tianocore/edk2-staging/pull/269 