### PR TITLE
Support fast local live migration

### DIFF
--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -8,13 +8,13 @@ support in Cloud Hypervisor:
 1. nested-vm migration - migrating between two nested VMs whose host VMs
    are running on the same machine.
 
-## Local Migration
+## Local Migration (Suitable for Live Upgrade of VMM)
 Launch the source VM (on the host machine):
 ```bash
 $ target/release/cloud-hypervisor
     --kernel ~/workloads/vmlinux \
     --disk path=~/workloads/focal.raw \
-    --cpus boot=1 --memory size=1G \
+    --cpus boot=1 --memory size=1G,shared=on \
     --cmdline "root=/dev/vda1 console=ttyS0"  \
     --serial tty --console off --api-socket=/tmp/api1
 ```
@@ -31,7 +31,7 @@ $ target/release/ch-remote --api-socket=/tmp/api2 receive-migration unix:/tmp/so
 
 Start to send migration for the source VM (on the host machine):
 ```bash
-$ target/release/ch-remote --api-socket=/tmp/api1 send-migration unix:/tmp/sock
+$ target/release/ch-remote --api-socket=/tmp/api1 send-migration --local unix:/tmp/sock
 ```
 
 When the above commands completed, the source VM should be successfully

--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -263,9 +263,14 @@ fn receive_migration_api_command(socket: &mut UnixStream, url: &str) -> Result<(
     .map_err(Error::ApiClient)
 }
 
-fn send_migration_api_command(socket: &mut UnixStream, url: &str) -> Result<(), Error> {
+fn send_migration_api_command(
+    socket: &mut UnixStream,
+    url: &str,
+    local: bool,
+) -> Result<(), Error> {
     let send_migration_data = vmm::api::VmSendMigrationData {
         destination_url: url.to_owned(),
+        local,
     };
     simple_api_command(
         socket,
@@ -402,6 +407,10 @@ fn do_command(matches: &ArgMatches) -> Result<(), Error> {
                 .unwrap()
                 .value_of("send_migration_config")
                 .unwrap(),
+            matches
+                .subcommand_matches("send-migration")
+                .unwrap()
+                .is_present("send_migration_local"),
         ),
         Some("receive-migration") => receive_migration_api_command(
             &mut socket,
@@ -560,6 +569,11 @@ fn main() {
                     Arg::new("send_migration_config")
                         .index(1)
                         .help("<destination_url>"),
+                )
+                .arg(
+                    Arg::new("send_migration_local")
+                        .long("local")
+                        .takes_value(false),
                 ),
         )
         .subcommand(

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -41,6 +41,7 @@ pub enum Command {
     Memory,
     Complete,
     Abandon,
+    MemoryFd,
 }
 
 impl Default for Command {
@@ -83,6 +84,10 @@ impl Request {
 
     pub fn memory(length: u64) -> Self {
         Self::new(Command::Memory, length)
+    }
+
+    pub fn memory_fd(length: u64) -> Self {
+        Self::new(Command::MemoryFd, length)
     }
 
     pub fn complete() -> Self {

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -27,7 +27,24 @@ use vm_memory::ByteValued;
 // (n-2): Dest -> Source : sends "ok response"
 // (n-1): Source -> Dest : send "complete command"
 // n: Dest -> Source: sends "ok response"
-
+//
+// "Local version": (Handing FDs across socket for memory)
+// 1: Source establishes communication with destination (file socket or TCP connection.)
+// (The establishment is out of scope.)
+// 2: Source -> Dest : send "start command"
+// 3: Dest -> Source : sends "ok response" when read to accept state data
+// 4: Source -> Dest : sends "config command" followed by config data, length
+//                     in command is length of config data
+// 5: Dest -> Source : sends "ok response" when ready to accept memory data
+// 6: Source -> Dest : send "memory fd command" followed by u16 slot ID and FD for memory
+// 7: Dest -> Source : sends "ok response" when received
+// 8..(n-4): Repeat steps 6 and 7 until source has no more memory to send
+// (n-3): Source -> Dest : sends "state command" followed by state data, length
+//                     in command is length of config data
+// (n-2): Dest -> Source : sends "ok response"
+// (n-1): Source -> Dest : send "complete command"
+// n: Dest -> Source: sends "ok response"
+//
 // The destination can at any time send an "error response" to cancel
 // The source can at any time send an "abandon request" to cancel
 

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -195,6 +195,8 @@ pub struct VmReceiveMigrationData {
 pub struct VmSendMigrationData {
     /// URL to migrate the VM to
     pub destination_url: String,
+    /// Send memory across socket without copying
+    pub local: bool,
 }
 
 pub enum ApiResponsePayload {

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1041,3 +1041,5 @@ components:
       properties:
         destination_url:
           type: string
+        local:
+          type: boolean

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1153,6 +1153,22 @@ impl Vmm {
             "Sending migration: destination_url = {}, local = {}",
             send_data_migration.destination_url, send_data_migration.local
         );
+
+        if !self
+            .vm_config
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .memory
+            .shared
+            && send_data_migration.local
+        {
+            return Err(MigratableError::MigrateSend(anyhow!(
+                "Local migration requires shared memory enabled"
+            )));
+        }
+
         if let Some(vm) = self.vm.as_mut() {
             Self::send_migration(
                 vm,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -937,6 +937,9 @@ impl Vmm {
                         Response::error().write_to(&mut socket)?;
                     }
                 }
+                Command::MemoryFd => {
+                    unimplemented!()
+                }
                 Command::Complete => {
                     info!("Complete Command Received");
                     if let Some(ref mut vm) = self.vm.as_mut() {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1140,8 +1140,8 @@ impl Vmm {
         send_data_migration: VmSendMigrationData,
     ) -> result::Result<(), MigratableError> {
         info!(
-            "Sending migration: destination_url = {}",
-            send_data_migration.destination_url
+            "Sending migration: destination_url = {}, local = {}",
+            send_data_migration.destination_url, send_data_migration.local
         );
         if let Some(vm) = self.vm.as_mut() {
             Self::send_migration(

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -480,6 +480,7 @@ impl MemoryManager {
                     zone.hugepages,
                     zone.hugepage_size,
                     zone.host_numa_node,
+                    None,
                 )?;
 
                 // Add region to the list of regions associated with the
@@ -555,6 +556,7 @@ impl MemoryManager {
                         zone_config.hugepages,
                         zone_config.hugepage_size,
                         zone_config.host_numa_node,
+                        None,
                     )?;
                     memory_regions.push(Arc::clone(&region));
                     if let Some(memory_zone) = memory_zones.get_mut(&guest_ram_mapping.zone_id) {
@@ -939,6 +941,7 @@ impl MemoryManager {
                                 zone.hugepages,
                                 zone.hugepage_size,
                                 zone.host_numa_node,
+                                None,
                             )?;
 
                             guest_memory = guest_memory
@@ -1227,9 +1230,13 @@ impl MemoryManager {
         hugepages: bool,
         hugepage_size: Option<u64>,
         host_numa_node: Option<u32>,
+        existing_memory_file: Option<File>,
     ) -> Result<Arc<GuestRegionMmap>, Error> {
-        let (f, f_off) =
-            Self::open_memory_file(backing_file, file_offset, size, hugepages, hugepage_size)?;
+        let (f, f_off) = if let Some(f) = existing_memory_file {
+            (f, file_offset)
+        } else {
+            Self::open_memory_file(backing_file, file_offset, size, hugepages, hugepage_size)?
+        };
 
         let mut mmap_flags = libc::MAP_NORESERVE
             | if shared {
@@ -1342,6 +1349,7 @@ impl MemoryManager {
             self.shared,
             self.hugepages,
             self.hugepage_size,
+            None,
             None,
         )?;
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1813,6 +1813,22 @@ impl MemoryManager {
             next_hotplug_slot: self.next_hotplug_slot,
         }
     }
+
+    pub fn memory_slot_fds(&self) -> HashMap<u32, RawFd> {
+        let mut memory_slot_fds = HashMap::new();
+        for guest_ram_mapping in &self.guest_ram_mappings {
+            let slot = guest_ram_mapping.slot;
+            let guest_memory = self.guest_memory.memory();
+            let file = guest_memory
+                .find_region(GuestAddress(guest_ram_mapping.gpa))
+                .unwrap()
+                .file_offset()
+                .unwrap()
+                .file();
+            memory_slot_fds.insert(slot, file.as_raw_fd());
+        }
+        memory_slot_fds
+    }
 }
 
 #[cfg(feature = "acpi")]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -867,6 +867,7 @@ impl Vm {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new_from_migration(
         config: Arc<Mutex<VmConfig>>,
         exit_evt: EventFd,
@@ -875,6 +876,7 @@ impl Vm {
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
         activate_evt: EventFd,
         memory_manager_data: &MemoryManagerSnapshotData,
+        existing_memory_files: Option<HashMap<u32, File>>,
     ) -> Result<Self> {
         hypervisor.check_required_extensions().unwrap();
         let vm = hypervisor.create_vm().unwrap();
@@ -897,7 +899,7 @@ impl Vm {
             #[cfg(feature = "tdx")]
             false,
             Some(memory_manager_data),
-            None,
+            existing_memory_files,
             #[cfg(target_arch = "x86_64")]
             None,
         )

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -777,6 +777,7 @@ impl Vm {
             #[cfg(feature = "tdx")]
             tdx_enabled,
             None,
+            None,
             #[cfg(target_arch = "x86_64")]
             sgx_epc_config,
         )
@@ -896,6 +897,7 @@ impl Vm {
             #[cfg(feature = "tdx")]
             false,
             Some(memory_manager_data),
+            None,
             #[cfg(target_arch = "x86_64")]
             None,
         )


### PR DESCRIPTION
Pass the FDs for the guest memory across the socket allowing very fast live migration (and for live upgrade.)

Fixes: #3566 