### PR TITLE
arch: aarch64: vm_memory is not required when configuring vcpu

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -21,9 +21,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::sync::Arc;
-use vm_memory::{
-    Address, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, GuestUsize,
-};
+use vm_memory::{Address, GuestAddress, GuestMemory, GuestUsize};
 
 /// Errors thrown while configuring aarch64 system.
 #[derive(Debug)]
@@ -66,16 +64,10 @@ pub fn configure_vcpu(
     fd: &Arc<dyn hypervisor::Vcpu>,
     id: u8,
     kernel_entry_point: Option<EntryPoint>,
-    vm_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
 ) -> super::Result<u64> {
     if let Some(kernel_entry_point) = kernel_entry_point {
-        regs::setup_regs(
-            fd,
-            id,
-            kernel_entry_point.entry_addr.raw_value(),
-            &vm_memory.memory(),
-        )
-        .map_err(Error::RegsConfiguration)?;
+        regs::setup_regs(fd, id, kernel_entry_point.entry_addr.raw_value())
+            .map_err(Error::RegsConfiguration)?;
     }
 
     let mpidr = fd.read_mpidr().map_err(Error::VcpuRegMpidr)?;

--- a/arch/src/aarch64/regs.rs
+++ b/arch/src/aarch64/regs.rs
@@ -6,7 +6,6 @@
 // found in the THIRD-PARTY file.
 
 use super::get_fdt_addr;
-use crate::GuestMemoryMmap;
 use hypervisor::kvm::kvm_bindings::{
     kvm_regs, user_pt_regs, KVM_REG_ARM64, KVM_REG_ARM_CORE, KVM_REG_SIZE_U64,
 };
@@ -43,12 +42,7 @@ const PSTATE_FAULT_BITS_64: u64 = PSR_MODE_EL1h | PSR_A_BIT | PSR_F_BIT | PSR_I_
 /// * `cpu_id` - Index of current vcpu.
 /// * `boot_ip` - Starting instruction pointer.
 /// * `mem` - Reserved DRAM for current VM.
-pub fn setup_regs(
-    vcpu: &Arc<dyn hypervisor::Vcpu>,
-    cpu_id: u8,
-    boot_ip: u64,
-    _mem: &GuestMemoryMmap,
-) -> Result<()> {
+pub fn setup_regs(vcpu: &Arc<dyn hypervisor::Vcpu>, cpu_id: u8, boot_ip: u64) -> Result<()> {
     let kreg_off = offset__of!(kvm_regs, regs);
 
     // Get the register index of the PSTATE (Processor State) register.


### PR DESCRIPTION
Drop the unused parameter throughout the code base.

Also take the chance to drop a needless clone.

No functional change intended.

Signed-off-by: Wei Liu <liuwe@microsoft.com>