### PR TITLE
scripts: Pin OVMF EDK2 version

### DIFF
--- a/scripts/run_integration_tests_windows.sh
+++ b/scripts/run_integration_tests_windows.sh
@@ -14,7 +14,7 @@ fi
 WIN_IMAGE_FILE="/root/workloads/windows-server-2019.raw"
 
 WORKLOADS_DIR="/root/workloads"
-OVMF_FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/edk2/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
+OVMF_FW_URL="https://github.com/cloud-hypervisor/edk2/releases/download/ch-e6d6251eb6/OVMF.fd"
 OVMF_FW="$WORKLOADS_DIR/OVMF.fd"
 if [ ! -f "$OVMF_FW" ]; then
     pushd $WORKLOADS_DIR

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -28,7 +28,7 @@ if [ ! -f "$FW" ]; then
     popd
 fi
 
-OVMF_FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/edk2/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
+OVMF_FW_URL="https://github.com/cloud-hypervisor/edk2/releases/download/ch-e6d6251eb6/OVMF.fd"
 OVMF_FW="$WORKLOADS_DIR/OVMF.fd"
 if [ ! -f "$OVMF_FW" ]; then
     pushd $WORKLOADS_DIR


### PR DESCRIPTION
By pinning the OVMF version, we will be able to update the EDK2 fork
with a new version without potentially breaking our Cloud Hypervisor CI.

Once the new version is ready on the EDK2 fork, we'll be able to update
Cloud Hypervisor codebase, replacing the fixed version with the latest,
as well as replacing OVMF.fd with CLOUDHV.fd. This is because we'll
start building from the new target CloudHvX64.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>