### PR TITLE
acpi: aarch64: Implement DBG2 table

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4065,6 +4065,7 @@ impl Aml for DeviceManager {
                         &"ARMH0011",
                     ),
                     &aml::Name::new("_UID".into(), &aml::ZERO),
+                    &aml::Name::new("_DDN".into(), &"COM1"),
                     &aml::Name::new(
                         "_CRS".into(),
                         &aml::ResourceTemplate::new(vec![


### PR DESCRIPTION
This table is listed as required in the ARM Base Boot Requirements
document. The particular need arises to make the serial debugging of
Windows guest functional.=

/cc @jongwu  

Signed-off-by: Anatol Belski <anbelski@linux.microsoft.com>