### PR TITLE
edk2: Rely on latest OVMF based on CloudHvX64 target

### DIFF
--- a/docs/uefi.md
+++ b/docs/uefi.md
@@ -17,7 +17,7 @@ cd edk2
 . edksetup.sh
 git submodule update --init
 
-echo "ACTIVE_PLATFORM=OvmfPkg/OvmfPkgX64.dsc" >> Conf/target.txt
+echo "ACTIVE_PLATFORM=OvmfPkg/CloudHv/CloudHvX64.dsc" >> Conf/target.txt
 echo "TARGET_ARCH=X64" >> Conf/target.txt
 echo "TOOL_CHAIN_TAG=GCC5" >> Conf/target.txt
 
@@ -25,48 +25,15 @@ make -C ./BaseTools
 build
 ```
 
-After the successful build, the resulting firmware binaries are available under `Build/OvmfX64/DEBUG_GCC5/FV` underneath the edk2 checkout.
+After the successful build, the resulting firmware binaries are available under `Build/CloudHvX64/DEBUG_GCC5/FV` underneath the edk2 checkout.
 
 ## Using OVMF Binaries
 
 Any UEFI capable image can be booted using the Cloud Hypervisor specific firmware. Windows guests under Cloud Hypervisor only support UEFI boot, therefore OVMF is mandatory there.
 
-To make Cloud Hypervisor use UEFI boot, pass the `OVMF.fd` file path as an argument to the `--kernel` option. The firmware file will be opened in read only mode.
+To make Cloud Hypervisor use UEFI boot, pass the `CLOUDHV.fd` file path as an argument to the `--kernel` option. The firmware file will be opened in read only mode.
 
 The same firmware can be used with Cloud Hypervisor or with QEMU. This is particularly useful if using QEMU for the preparation phase.
-
-## Building UEFI Firmware with Compatibility Support Module (CSM)
-
-CSM is a module that allows to boot legacy operating systems using the OVMF firmware. OVMF can embed a CSM build of SeaBIOS. To build the SeaBIOS with CSM support, add `CONFIG_CSM=y` to `.config` before the build. The outcome `out/Csm16.bin` is to be moved into `OvmfPkg/Csm/Csm16/Csm16.bin` before OVMF is built. Then, the OVMF build will have to be passed the `-D CSM_ENABLE` option in order to generate a legacy aware UEFI firmware. At the current stage, all the necessary patches are included in the Cloud Hypervisor specific [SeaBIOS branch](https://github.com/cloud-hypervisor/seabios/tree/ch). Taking into account the previous instructions, the modified command sequence to compile an OVMF binary with CSM support is the following one:
-
-```shell
-sudo apt-get update
-sudo apt-get install uuid-dev nasm iasl build-essential python3-distutils git libncurses-dev
-
-git clone https://github.com/cloud-hypervisor/seabios -b ch
-cd seabios
-make menuconfig
-# Enable `CONFIG_CSM` and `CONFIG_QEMU_HARDWARE`
-# Please make sure `python` is in your path
-make CONFIG_CSM=y CONFIG_QEMU_HARDWARE=y
-cd ..
-
-git clone https://github.com/cloud-hypervisor/edk2 -b ch
-cd edk2
-. edksetup.sh
-git submodule update --init --recursive
-cp ../seabios/out/Csm16.bin OvmfPkg/Csm/Csm16/
-
-echo "ACTIVE_PLATFORM=OvmfPkg/OvmfPkgX64.dsc" >> Conf/target.txt
-echo "TARGET_ARCH=X64" >> Conf/target.txt
-echo "TOOL_CHAIN_TAG=GCC5" >> Conf/target.txt
-
-make -C ./BaseTools
-build -DCSM_ENABLE
-
-```
-
-Please note, that the CSM support has currently only been tested with Linux guests. There are no plans to provide legacy support for other OSes (e.g. Windows).
 
 # Links
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -67,7 +67,7 @@ The basic command to boot a Windows image. The configuration section should be c
 
 ```shell
 cloud-hypervisor \
-	--kernel ./$OVMF_DIR/OVMF.fd \
+	--kernel ./$OVMF_DIR/CLOUDHV.fd \
 	--disk path=./$IMG_FILE \
 	--cpus boot=1,kvm_hyperv=on \
 	--memory size=4G \

--- a/scripts/run_integration_tests_windows.sh
+++ b/scripts/run_integration_tests_windows.sh
@@ -14,8 +14,8 @@ fi
 WIN_IMAGE_FILE="/root/workloads/windows-server-2019.raw"
 
 WORKLOADS_DIR="/root/workloads"
-OVMF_FW_URL="https://github.com/cloud-hypervisor/edk2/releases/download/ch-e6d6251eb6/OVMF.fd"
-OVMF_FW="$WORKLOADS_DIR/OVMF.fd"
+OVMF_FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/edk2/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
+OVMF_FW="$WORKLOADS_DIR/CLOUDHV.fd"
 if [ ! -f "$OVMF_FW" ]; then
     pushd $WORKLOADS_DIR
     time wget --quiet $OVMF_FW_URL || exit 1

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -28,8 +28,8 @@ if [ ! -f "$FW" ]; then
     popd
 fi
 
-OVMF_FW_URL="https://github.com/cloud-hypervisor/edk2/releases/download/ch-e6d6251eb6/OVMF.fd"
-OVMF_FW="$WORKLOADS_DIR/OVMF.fd"
+OVMF_FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/edk2/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
+OVMF_FW="$WORKLOADS_DIR/CLOUDHV.fd"
 if [ ! -f "$OVMF_FW" ]; then
     pushd $WORKLOADS_DIR
     time wget --quiet $OVMF_FW_URL || exit 1

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -59,7 +59,7 @@ mod x86_64 {
     pub const FOCAL_IMAGE_NAME_VHD: &str = "focal-server-cloudimg-amd64-custom-20210609-0.vhd";
     pub const FOCAL_IMAGE_NAME_VHDX: &str = "focal-server-cloudimg-amd64-custom-20210609-0.vhdx";
     pub const WINDOWS_IMAGE_NAME: &str = "windows-server-2019.raw";
-    pub const OVMF_NAME: &str = "OVMF.fd";
+    pub const OVMF_NAME: &str = "CLOUDHV.fd";
     pub const GREP_SERIAL_IRQ_CMD: &str = "grep -c 'IO-APIC.*ttyS0' /proc/interrupts || true";
 }
 


### PR DESCRIPTION
Update documentation and CI to rely on the new CLOUDHV.fd firmware built
from the newly introduced target CloudHvX64.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>