### PR TITLE
vmm: Avoid deadlock between virtio device activation and vcpu pausing

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2411,6 +2411,13 @@ impl Pausable for Vm {
             clock.flags = 0;
             self.saved_clock = Some(clock);
         }
+
+        // Before pausing the vCPUs activate any pending virtio devices that might
+        // need activation between starting the pause (or e.g. a migration it's part of)
+        self.activate_virtio_devices().map_err(|e| {
+            MigratableError::Pause(anyhow!("Error activating pending virtio devices: {:?}", e))
+        })?;
+
         self.cpu_manager.lock().unwrap().pause()?;
         self.device_manager.lock().unwrap().pause()?;
 


### PR DESCRIPTION
Ensure all pending virtio activations (as triggered by MMIO write on the
vCPU threads leading to a barrier wait) are completed before pausing the
vCPUs as otherwise there will a deadlock with the VMM waiting for the
vCPU to acknowledge it's pause and the vCPU waiting for the VMM to
activate the device and release the barrier.

Fixes: #3585

Signed-off-by: Rob Bradford <robert.bradford@intel.com>