### PR TITLE
tests: ignore the result from test_vfio_user

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6172,6 +6172,7 @@ mod parallel {
         exec_host_command_status("pkill -f nvmf_tgt");
     }
 
+    #[ignore]
     #[test]
     #[cfg(target_arch = "aarch64")]
     fn test_vfio_user() {


### PR DESCRIPTION
As it is currently unstable.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>