### PR TITLE
tests: Increase timeout when booting with firmware

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3147,7 +3147,7 @@ mod parallel {
             .unwrap();
 
         let r = std::panic::catch_unwind(|| {
-            guest.wait_vm_boot(None).unwrap();
+            guest.wait_vm_boot(Some(120)).unwrap();
         });
 
         let _ = child.kill();


### PR DESCRIPTION
As it might take more time for the VM to boot (especially under high
load) when using the firmware, let's increase the timeout waiting for
the VM to be reachable.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>