### PR TITLE
vmm: api: Support multiple fds with add-net

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "micro_http"
 version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/micro-http?branch=main#0a58eb1ece68e326e68365c4297d0a7c08ecd9bc"
+source = "git+https://github.com/firecracker-microvm/micro-http?branch=main#a730d86940081ad044cdfbc1285c1db6d3048392"
 dependencies = [
  "libc",
  "vmm-sys-util",


### PR DESCRIPTION
Based on the latest code from the micro-http crate, this PR adds the support for multiple file descriptors to be sent along with the add-net request. This means we can now hotplug multiqueue network interface to the VM.

The macvtap integration test has been updated so that both coldplug and hotplug codepath now use multiqueue network device.