### PR TITLE
virtio-devices: Revert to previous interrupt management

### DIFF
--- a/fuzz/fuzz_targets/block.rs
+++ b/fuzz/fuzz_targets/block.rs
@@ -139,7 +139,8 @@ pub struct NoopVirtioInterrupt {}
 impl VirtioInterrupt for NoopVirtioInterrupt {
     fn trigger(
         &self,
-        _int_type: VirtioInterruptType,
+        _int_type: &VirtioInterruptType,
+        _queue: Option<&Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
     ) -> std::result::Result<(), std::io::Error> {
         Ok(())
     }

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -82,7 +82,6 @@ pub struct BlockCounters {
 }
 
 struct BlockEpollHandler {
-    queue_index: u16,
     queue: Queue<GuestMemoryAtomic<GuestMemoryMmap>>,
     mem: GuestMemoryAtomic<GuestMemoryMmap>,
     disk_image: Box<dyn AsyncIo>,
@@ -259,7 +258,7 @@ impl BlockEpollHandler {
 
     fn signal_used_queue(&self) -> result::Result<(), DeviceError> {
         self.interrupt_cb
-            .trigger(VirtioInterruptType::Queue(self.queue_index))
+            .trigger(&VirtioInterruptType::Queue, Some(&self.queue))
             .map_err(|e| {
                 error!("Failed to signal used queue: {:?}", e);
                 DeviceError::FailedSignalingUsedQueue(e)
@@ -606,7 +605,6 @@ impl VirtioDevice for Block {
                 .map_err(ActivateError::CreateRateLimiter)?;
 
             let mut handler = BlockEpollHandler {
-                queue_index: i as u16,
                 queue,
                 mem: mem.clone(),
                 disk_image: self

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -25,12 +25,20 @@ use vmm_sys_util::eventfd::EventFd;
 
 pub enum VirtioInterruptType {
     Config,
-    Queue(u16),
+    Queue,
 }
 
 pub trait VirtioInterrupt: Send + Sync {
-    fn trigger(&self, int_type: VirtioInterruptType) -> std::result::Result<(), std::io::Error>;
-    fn notifier(&self, _int_type: VirtioInterruptType) -> Option<EventFd> {
+    fn trigger(
+        &self,
+        int_type: &VirtioInterruptType,
+        queue: Option<&Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
+    ) -> std::result::Result<(), std::io::Error>;
+    fn notifier(
+        &self,
+        _int_type: &VirtioInterruptType,
+        _queue: Option<&Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
+    ) -> Option<EventFd> {
         None
     }
 }

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -644,11 +644,13 @@ impl MemEpollHandler {
         (resp_type, resp_state)
     }
 
-    fn signal(&self, int_type: VirtioInterruptType) -> result::Result<(), DeviceError> {
-        self.interrupt_cb.trigger(int_type).map_err(|e| {
-            error!("Failed to signal used queue: {:?}", e);
-            DeviceError::FailedSignalingUsedQueue(e)
-        })
+    fn signal(&self, int_type: &VirtioInterruptType) -> result::Result<(), DeviceError> {
+        self.interrupt_cb
+            .trigger(int_type, Some(&self.queue))
+            .map_err(|e| {
+                error!("Failed to signal used queue: {:?}", e);
+                DeviceError::FailedSignalingUsedQueue(e)
+            })
     }
 
     fn process_queue(&mut self) -> bool {
@@ -732,7 +734,7 @@ impl EpollHelperHandler for MemEpollHandler {
                     let mut r = config.resize(size);
                     r = match r {
                         Err(e) => Err(e),
-                        _ => match self.signal(VirtioInterruptType::Config) {
+                        _ => match self.signal(&VirtioInterruptType::Config) {
                             Err(e) => {
                                 signal_error = true;
                                 Err(Error::ResizeTriggerFail(e))
@@ -754,7 +756,7 @@ impl EpollHelperHandler for MemEpollHandler {
                     error!("Failed to get queue event: {:?}", e);
                     return true;
                 } else if self.process_queue() {
-                    if let Err(e) = self.signal(VirtioInterruptType::Queue(0)) {
+                    if let Err(e) = self.signal(&VirtioInterruptType::Queue) {
                         error!("Failed to signal used queue: {:?}", e);
                         return true;
                     }

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -213,7 +213,7 @@ impl PmemEpollHandler {
 
     fn signal_used_queue(&self) -> result::Result<(), DeviceError> {
         self.interrupt_cb
-            .trigger(VirtioInterruptType::Queue(0))
+            .trigger(&VirtioInterruptType::Queue, Some(&self.queue))
             .map_err(|e| {
                 error!("Failed to signal used queue: {:?}", e);
                 DeviceError::FailedSignalingUsedQueue(e)

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -76,7 +76,7 @@ impl RngEpollHandler {
 
     fn signal_used_queue(&self) -> result::Result<(), DeviceError> {
         self.interrupt_cb
-            .trigger(VirtioInterruptType::Queue(0))
+            .trigger(&VirtioInterruptType::Queue, Some(&self.queues[0]))
             .map_err(|e| {
                 error!("Failed to signal used queue: {:?}", e);
                 DeviceError::FailedSignalingUsedQueue(e)

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -24,7 +24,6 @@ pub struct VirtioPciCommonConfigState {
     pub driver_feature_select: u32,
     pub queue_select: u16,
     pub msix_config: u16,
-    pub msix_queues: Vec<u16>,
 }
 
 impl VersionMapped for VirtioPciCommonConfigState {}
@@ -58,7 +57,6 @@ pub struct VirtioPciCommonConfig {
     pub driver_feature_select: u32,
     pub queue_select: u16,
     pub msix_config: Arc<AtomicU16>,
-    pub msix_queues: Arc<Mutex<Vec<u16>>>,
 }
 
 impl VirtioPciCommonConfig {
@@ -70,7 +68,6 @@ impl VirtioPciCommonConfig {
             driver_feature_select: self.driver_feature_select,
             queue_select: self.queue_select,
             msix_config: self.msix_config.load(Ordering::Acquire),
-            msix_queues: self.msix_queues.lock().unwrap().clone(),
         }
     }
 
@@ -81,7 +78,6 @@ impl VirtioPciCommonConfig {
         self.driver_feature_select = state.driver_feature_select;
         self.queue_select = state.queue_select;
         self.msix_config.store(state.msix_config, Ordering::Release);
-        *(self.msix_queues.lock().unwrap()) = state.msix_queues.clone();
     }
 
     pub fn read(
@@ -168,7 +164,7 @@ impl VirtioPciCommonConfig {
             0x12 => queues.len() as u16, // num_queues
             0x16 => self.queue_select,
             0x18 => self.with_queue(queues, |q| q.state.size).unwrap_or(0),
-            0x1a => self.msix_queues.lock().unwrap()[self.queue_select as usize],
+            0x1a => self.with_queue(queues, |q| q.state.vector).unwrap_or(0),
             0x1c => {
                 if self.with_queue(queues, |q| q.state.ready).unwrap_or(false) {
                     1
@@ -195,7 +191,7 @@ impl VirtioPciCommonConfig {
             0x10 => self.msix_config.store(value, Ordering::Release),
             0x16 => self.queue_select = value,
             0x18 => self.with_queue_mut(queues, |q| q.state.size = value),
-            0x1a => self.msix_queues.lock().unwrap()[self.queue_select as usize] = value,
+            0x1a => self.with_queue_mut(queues, |q| q.state.vector = value),
             0x1c => self.with_queue_mut(queues, |q| q.enable(value == 1)),
             _ => {
                 warn!("invalid virtio register word write: 0x{:x}", offset);
@@ -380,7 +376,6 @@ mod tests {
             driver_feature_select: 0x0,
             queue_select: 0xff,
             msix_config: Arc::new(AtomicU16::new(0)),
-            msix_queues: Arc::new(Mutex::new(vec![0; 3])),
         };
 
         let dev = Arc::new(Mutex::new(DummyDevice(0)));

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -253,7 +253,7 @@ impl VhostUserHandle {
                 .map_err(Error::VhostUserSetVringBase)?;
 
             if let Some(eventfd) =
-                virtio_interrupt.notifier(VirtioInterruptType::Queue(queue_index as u16))
+                virtio_interrupt.notifier(&VirtioInterruptType::Queue, Some(&queue))
             {
                 self.vu
                     .set_vring_call(queue_index, &eventfd)

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -170,7 +170,7 @@ mod tests {
     use std::os::unix::io::AsRawFd;
     use std::path::PathBuf;
     use std::sync::{Arc, RwLock};
-    use virtio_queue::{defs::VIRTQ_DESC_F_NEXT, defs::VIRTQ_DESC_F_WRITE};
+    use virtio_queue::{defs::VIRTQ_DESC_F_NEXT, defs::VIRTQ_DESC_F_WRITE, Queue};
     use vm_memory::{GuestAddress, GuestMemoryAtomic};
     use vm_virtio::queue::testing::VirtQueue as GuestQ;
     use vmm_sys_util::eventfd::EventFd;
@@ -180,7 +180,8 @@ mod tests {
     impl VirtioInterrupt for NoopVirtioInterrupt {
         fn trigger(
             &self,
-            _int_type: VirtioInterruptType,
+            _int_type: &VirtioInterruptType,
+            _queue: Option<&Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
         ) -> std::result::Result<(), std::io::Error> {
             Ok(())
         }

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -96,7 +96,7 @@ impl WatchdogEpollHandler {
 
     fn signal_used_queue(&self) -> result::Result<(), DeviceError> {
         self.interrupt_cb
-            .trigger(VirtioInterruptType::Queue(0))
+            .trigger(&VirtioInterruptType::Queue, Some(&self.queues[0]))
             .map_err(|e| {
                 error!("Failed to signal used queue: {:?}", e);
                 DeviceError::FailedSignalingUsedQueue(e)


### PR DESCRIPTION
Reverting new way of handling virtio interrupts just to check if this
the cause of CI failures.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>