### PR TITLE
Handle virtio queues addresses translation from Cloud Hypervisor

### DIFF
--- a/block_util/src/lib.rs
+++ b/block_util/src/lib.rs
@@ -35,11 +35,12 @@ use std::sync::MutexGuard;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_bindings::bindings::virtio_blk::*;
-use virtio_queue::{AccessPlatform, DescriptorChain};
+use virtio_queue::DescriptorChain;
 use vm_memory::{
     bitmap::AtomicBitmap, bitmap::Bitmap, ByteValued, Bytes, GuestAddress, GuestMemory,
     GuestMemoryError, GuestMemoryLoadGuard,
 };
+use vm_virtio::AccessPlatform;
 use vmm_sys_util::eventfd::EventFd;
 
 type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;

--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -13,8 +13,9 @@ use virtio_bindings::bindings::virtio_net::{
     VIRTIO_NET_F_GUEST_ECN, VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_TSO6,
     VIRTIO_NET_F_GUEST_UFO, VIRTIO_NET_OK,
 };
-use virtio_queue::{AccessPlatform, Queue};
+use virtio_queue::Queue;
 use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemoryAtomic, GuestMemoryError};
+use vm_virtio::AccessPlatform;
 
 #[derive(Debug)]
 pub enum Error {

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -10,8 +10,9 @@ use std::num::Wrapping;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use virtio_queue::{AccessPlatform, Queue};
+use virtio_queue::Queue;
 use vm_memory::{Bytes, GuestAddress, GuestMemory, GuestMemoryAtomic};
+use vm_virtio::AccessPlatform;
 
 #[derive(Clone)]
 pub struct TxVirtio {

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -117,7 +117,7 @@ impl VhostUserBlkThread {
         while let Some(mut desc_chain) = vring.mut_queue().iter().unwrap().next() {
             debug!("got an element in the queue");
             let len;
-            match Request::parse(&mut desc_chain) {
+            match Request::parse(&mut desc_chain, None) {
                 Ok(mut request) => {
                     debug!("element is a valid request");
                     request.set_writeback(self.writeback.load(Ordering::Acquire));

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -93,6 +93,7 @@ impl VhostUserNetThread {
                 rx_desc_avail: false,
                 rx_rate_limiter: None,
                 tx_rate_limiter: None,
+                access_platform: None,
             },
         })
     }

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -35,10 +35,11 @@ use std::{collections::HashMap, convert::TryInto};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_bindings::bindings::virtio_blk::*;
-use virtio_queue::{AccessPlatform, Queue};
+use virtio_queue::Queue;
 use vm_memory::{ByteValued, Bytes, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
+use vm_virtio::AccessPlatform;
 use vmm_sys_util::eventfd::EventFd;
 
 const SECTOR_SHIFT: u8 = 9;

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -24,10 +24,11 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::{AccessPlatform, Queue};
+use virtio_queue::Queue;
 use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
+use vm_virtio::AccessPlatform;
 use vmm_sys_util::eventfd::EventFd;
 
 const QUEUE_SIZE: u16 = 256;

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -127,10 +127,6 @@ pub trait VirtioDevice: Send {
         std::unimplemented!()
     }
 
-    fn iommu_translate(&self, addr: u64) -> u64 {
-        addr
-    }
-
     /// Some devices may need to do some explicit shutdown work. This method
     /// may be implemented to do this. The VMM should call shutdown() on
     /// every device as part of shutting down the VM. Acting on the device

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -19,9 +19,10 @@ use std::sync::{
     Arc, Barrier,
 };
 use std::thread;
-use virtio_queue::{AccessPlatform, Queue};
+use virtio_queue::Queue;
 use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestUsize};
 use vm_migration::{MigratableError, Pausable};
+use vm_virtio::AccessPlatform;
 use vm_virtio::VirtioDeviceType;
 use vmm_sys_util::eventfd::EventFd;
 

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -23,7 +23,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier, RwLock};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::{AccessPlatform, DescriptorChain, Queue};
+use virtio_queue::{DescriptorChain, Queue};
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestMemoryAtomic, GuestMemoryError,
@@ -31,6 +31,7 @@ use vm_memory::{
 };
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
+use vm_virtio::AccessPlatform;
 use vmm_sys_util::eventfd::EventFd;
 
 /// Queues sizes

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -35,10 +35,11 @@ use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_bindings::bindings::virtio_net::*;
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use virtio_queue::{AccessPlatform, Queue};
+use virtio_queue::Queue;
 use vm_memory::{ByteValued, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
+use vm_virtio::AccessPlatform;
 use vmm_sys_util::eventfd::EventFd;
 
 /// Control queue

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -27,13 +27,14 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::{AccessPlatform, DescriptorChain, Queue};
+use virtio_queue::{DescriptorChain, Queue};
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestMemoryAtomic, GuestMemoryError,
     GuestMemoryLoadGuard,
 };
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
+use vm_virtio::AccessPlatform;
 use vmm_sys_util::eventfd::EventFd;
 
 const QUEUE_SIZE: u16 = 256;

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -21,10 +21,11 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::{AccessPlatform, Queue};
+use virtio_queue::Queue;
 use vm_memory::{Bytes, GuestAddress, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
+use vm_virtio::AccessPlatform;
 use vmm_sys_util::eventfd::EventFd;
 
 const QUEUE_SIZE: u16 = 256;

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -12,9 +12,10 @@ use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Arc, Mutex};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::{AccessPlatform, Queue};
+use virtio_queue::Queue;
 use vm_memory::{GuestAddress, GuestMemoryAtomic};
 use vm_migration::{MigratableError, Pausable, Snapshot, Snapshottable, VersionMapped};
+use vm_virtio::AccessPlatform;
 
 #[derive(Clone, Versionize)]
 pub struct VirtioPciCommonConfigState {

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -29,7 +29,6 @@ use std::sync::atomic::{AtomicBool, AtomicU16, AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::AccessPlatform;
 use virtio_queue::{defs::VIRTQ_MSI_NO_VECTOR, Error as QueueError, Queue};
 use vm_allocator::{AddressAllocator, SystemAllocator};
 use vm_device::interrupt::{
@@ -40,6 +39,7 @@ use vm_memory::{Address, ByteValued, GuestAddress, GuestMemoryAtomic, GuestUsize
 use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable, VersionMapped,
 };
+use vm_virtio::AccessPlatform;
 use vmm_sys_util::{errno::Result, eventfd::EventFd};
 
 #[derive(Debug)]

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -423,6 +423,7 @@ impl VirtioPciDevice {
             id,
             configuration,
             common_config: VirtioPciCommonConfig {
+                access_platform,
                 driver_status: 0,
                 config_generation: 0,
                 device_feature_select: 0,

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -89,7 +89,7 @@ impl EpollHelperHandler for NetCtrlEpollHandler {
                     error!("failed to get ctl queue event: {:?}", e);
                     return true;
                 }
-                if let Err(e) = self.ctrl_q.process(&mut self.queue) {
+                if let Err(e) = self.ctrl_q.process(&mut self.queue, None) {
                     error!("failed to process ctrl queue: {:?}", e);
                     return true;
                 }

--- a/virtio-devices/src/vsock/csm/connection.rs
+++ b/virtio-devices/src/vsock/csm/connection.rs
@@ -823,6 +823,7 @@ mod tests {
                     .unwrap()
                     .next()
                     .unwrap(),
+                None,
             )
             .unwrap();
             let conn = match conn_state {

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -47,11 +47,12 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier, RwLock};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::{AccessPlatform, Queue};
+use virtio_queue::Queue;
 use vm_memory::GuestMemoryAtomic;
 use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable, VersionMapped,
 };
+use vm_virtio::AccessPlatform;
 use vmm_sys_util::eventfd::EventFd;
 
 const QUEUE_SIZE: u16 = 256;

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -328,6 +328,7 @@ mod tests {
                     pause_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
                     interrupt_cb,
                     backend: Arc::new(RwLock::new(TestBackend::new())),
+                    access_platform: None,
                 },
             }
         }

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -21,8 +21,9 @@ use std::sync::Arc;
 use super::defs;
 use super::{Result, VsockError};
 use crate::{get_host_address_range, GuestMemoryMmap};
-use virtio_queue::{AccessPlatform, DescriptorChain};
+use virtio_queue::DescriptorChain;
 use vm_memory::{GuestAddress, GuestMemoryLoadGuard};
+use vm_virtio::AccessPlatform;
 
 // The vsock packet header is defined by the C struct:
 //

--- a/virtio-devices/src/vsock/unix/muxer.rs
+++ b/virtio-devices/src/vsock/unix/muxer.rs
@@ -846,6 +846,7 @@ mod tests {
                     .unwrap()
                     .next()
                     .unwrap(),
+                None,
             )
             .unwrap();
             let uds_path = format!("test_vsock_{}.sock", name);

--- a/virtio-queue/src/iterator.rs
+++ b/virtio-queue/src/iterator.rs
@@ -13,12 +13,11 @@
 use std::num::Wrapping;
 use std::ops::Deref;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemory};
 
 use crate::defs::{VIRTQ_AVAIL_ELEMENT_SIZE, VIRTQ_AVAIL_RING_HEADER_SIZE};
-use crate::{error, AccessPlatform, DescriptorChain, QueueState};
+use crate::{error, DescriptorChain, QueueState};
 
 /// Consuming iterator over all available descriptor chain heads in the queue.
 ///
@@ -98,7 +97,6 @@ pub struct AvailIter<'b, M> {
     queue_size: u16,
     last_index: Wrapping<u16>,
     next_avail: &'b mut Wrapping<u16>,
-    access_platform: &'b Option<Arc<dyn AccessPlatform>>,
 }
 
 impl<'b, M> AvailIter<'b, M>
@@ -122,7 +120,6 @@ where
             queue_size: state.size,
             last_index: idx,
             next_avail: &mut state.next_avail,
-            access_platform: &state.access_platform,
         }
     }
 
@@ -170,7 +167,6 @@ where
             self.desc_table,
             self.queue_size,
             head_index,
-            self.access_platform.clone(),
         ))
     }
 }

--- a/virtio-queue/src/lib.rs
+++ b/virtio-queue/src/lib.rs
@@ -41,13 +41,6 @@ mod queue_guard;
 mod state;
 mod state_sync;
 
-/// Trait for devices with access to data in memory being limited and/or
-/// translated.
-pub trait AccessPlatform: Send + Sync + Debug {
-    /// Provide a way to translate address ranges.
-    fn translate(&self, base: u64, size: u64) -> std::result::Result<u64, std::io::Error>;
-}
-
 /// Virtio Queue related errors.
 #[derive(Debug)]
 pub enum Error {

--- a/virtio-queue/src/queue.rs
+++ b/virtio-queue/src/queue.rs
@@ -271,12 +271,6 @@ impl<M: GuestAddressSpace> Queue<M, QueueState> {
     pub fn iter(&mut self) -> Result<AvailIter<'_, M::T>, Error> {
         self.state.iter(self.mem.memory())
     }
-
-    /// Set the queue to "ready", and update desc_table, avail_ring and
-    /// used_ring addresses based on the AccessPlatform handler.
-    pub fn enable(&mut self, set: bool) {
-        self.state.enable(set)
-    }
 }
 
 #[cfg(test)]

--- a/virtio-queue/src/state.rs
+++ b/virtio-queue/src/state.rs
@@ -156,28 +156,6 @@ impl QueueState {
             .map(Wrapping)
             .map_err(Error::GuestMemory)
     }
-
-    /// Set the queue to "ready", and update desc_table, avail_ring and
-    /// used_ring addresses based on the AccessPlatform handler.
-    pub fn enable(&mut self, set: bool) {
-        self.ready = set;
-
-        if set {
-            // Translate address of descriptor table and vrings.
-            if let Some(access_platform) = &self.access_platform {
-                self.desc_table =
-                    GuestAddress(access_platform.translate(self.desc_table.0, 0).unwrap());
-                self.avail_ring =
-                    GuestAddress(access_platform.translate(self.avail_ring.0, 0).unwrap());
-                self.used_ring =
-                    GuestAddress(access_platform.translate(self.used_ring.0, 0).unwrap());
-            }
-        } else {
-            self.desc_table = GuestAddress(0);
-            self.avail_ring = GuestAddress(0);
-            self.used_ring = GuestAddress(0);
-        }
-    }
 }
 
 impl<'a> QueueStateGuard<'a> for QueueState {

--- a/virtio-queue/src/state.rs
+++ b/virtio-queue/src/state.rs
@@ -10,7 +10,6 @@ use std::mem::size_of;
 use std::num::Wrapping;
 use std::ops::Deref;
 use std::sync::atomic::{fence, Ordering};
-use std::sync::Arc;
 
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemory};
 
@@ -20,10 +19,7 @@ use crate::defs::{
     VIRTQ_USED_ELEMENT_SIZE, VIRTQ_USED_F_NO_NOTIFY, VIRTQ_USED_RING_HEADER_SIZE,
     VIRTQ_USED_RING_META_SIZE,
 };
-use crate::{
-    error, AccessPlatform, AvailIter, Descriptor, Error, QueueStateGuard, QueueStateT,
-    VirtqUsedElem,
-};
+use crate::{error, AvailIter, Descriptor, Error, QueueStateGuard, QueueStateT, VirtqUsedElem};
 
 /// Struct to maintain information and manipulate state of a virtio queue.
 #[derive(Clone, Debug)]
@@ -57,9 +53,6 @@ pub struct QueueState {
 
     /// Guest physical address of the used ring.
     pub used_ring: GuestAddress,
-
-    /// Access platform handler
-    pub access_platform: Option<Arc<dyn AccessPlatform>>,
 }
 
 impl QueueState {
@@ -175,7 +168,6 @@ impl QueueStateT for QueueState {
             next_used: Wrapping(0),
             event_idx_enabled: false,
             signalled_used: None,
-            access_platform: None,
         }
     }
 

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -10,7 +10,7 @@
 
 //! Implements virtio queues
 
-use std::fmt;
+use std::fmt::{self, Debug};
 
 pub mod queue;
 pub use queue::*;
@@ -86,4 +86,11 @@ impl fmt::Display for VirtioDeviceType {
         };
         write!(f, "{}", output)
     }
+}
+
+/// Trait for devices with access to data in memory being limited and/or
+/// translated.
+pub trait AccessPlatform: Send + Sync + Debug {
+    /// Provide a way to translate address ranges.
+    fn translate(&self, base: u64, size: u64) -> std::result::Result<u64, std::io::Error>;
 }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -92,7 +92,6 @@ use virtio_devices::vhost_user::VhostUserConfig;
 use virtio_devices::{AccessPlatformMapping, VirtioMemMappingSource};
 use virtio_devices::{Endpoint, IommuMapping};
 use virtio_devices::{VirtioSharedMemory, VirtioSharedMemoryList};
-use virtio_queue::AccessPlatform;
 use vm_allocator::{AddressAllocator, SystemAllocator};
 use vm_device::dma_mapping::vfio::VfioDmaMapping;
 use vm_device::interrupt::{
@@ -108,6 +107,7 @@ use vm_migration::{
     protocol::MemoryRangeTable, Migratable, MigratableError, Pausable, Snapshot,
     SnapshotDataSection, Snapshottable, Transportable,
 };
+use vm_virtio::AccessPlatform;
 use vm_virtio::VirtioDeviceType;
 use vmm_sys_util::eventfd::EventFd;
 


### PR DESCRIPTION
Instead of relying on the virtio-queue crate to perform the address translation when a virtio device is placed behind a vIOMMU, this PR moves the code to the Cloud Hypervisor codebase. This is the last step before we can move Cloud Hypervisor to the upstream version of `virtio-queue` (given that https://github.com/rust-vmm/vm-virtio/pull/132 will get merged).