### PR TITLE
vmm: separate set and clear migration_started

### DIFF
--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -417,6 +417,10 @@ impl Migratable for Blk {
         self.vu_common.dirty_log(&self.guest_memory)
     }
 
+    fn start_migration(&mut self) {
+        self.vu_common.start_migration();
+    }
+
     fn complete_migration(&mut self) -> std::result::Result<(), MigratableError> {
         self.vu_common
             .complete_migration(self.common.kill_evt.take())

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -698,6 +698,10 @@ impl Migratable for Fs {
         self.vu_common.dirty_log(&self.guest_memory)
     }
 
+    fn start_migration(&mut self) {
+        self.vu_common.start_migration();
+    }
+
     fn complete_migration(&mut self) -> std::result::Result<(), MigratableError> {
         self.vu_common
             .complete_migration(self.common.kill_evt.take())

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -451,7 +451,6 @@ impl VhostUserCommon {
         &mut self,
         guest_memory: &Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     ) -> std::result::Result<(), MigratableError> {
-        self.migration_started = true;
         if let Some(vu) = &self.vu {
             if let Some(guest_memory) = guest_memory {
                 let last_ram_addr = guest_memory.memory().last_addr().raw_value();
@@ -475,7 +474,6 @@ impl VhostUserCommon {
     }
 
     pub fn stop_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
-        self.migration_started = false;
         if let Some(vu) = &self.vu {
             vu.lock().unwrap().stop_dirty_log().map_err(|e| {
                 MigratableError::StopDirtyLog(anyhow!(
@@ -509,10 +507,16 @@ impl VhostUserCommon {
         }
     }
 
+    pub fn start_migration (&mut self) {
+        self.migration_started = true;
+    }
+
     pub fn complete_migration(
         &mut self,
         kill_evt: Option<EventFd>,
     ) -> std::result::Result<(), MigratableError> {
+        self.migration_started = false;
+
         // Make sure the device thread is killed in order to prevent from
         // reconnections to the socket.
         if let Some(kill_evt) = kill_evt {

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -488,6 +488,10 @@ impl Migratable for Net {
         self.vu_common.dirty_log(&self.guest_memory)
     }
 
+    fn start_migration(&mut self) {
+        self.vu_common.start_migration();
+    }
+
     fn complete_migration(&mut self) -> std::result::Result<(), MigratableError> {
         self.vu_common
             .complete_migration(self.common.kill_evt.take())

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -305,6 +305,9 @@ pub trait Migratable: Send + Pausable + Snapshottable + Transportable {
         Ok(MemoryRangeTable::default())
     }
 
+    fn start_migration(&mut self) {
+    }
+
     fn complete_migration(&mut self) -> std::result::Result<(), MigratableError> {
         Ok(())
     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4221,6 +4221,14 @@ impl Migratable for DeviceManager {
         Ok(MemoryRangeTable::new_from_tables(tables))
     }
 
+    fn start_migration(&mut self) {
+        for (_, device_node) in self.device_tree.lock().unwrap().iter() {
+            if let Some(migratable) = &device_node.migratable {
+                migratable.lock().unwrap().start_migration();
+            }
+        }
+    }
+
     fn complete_migration(&mut self) -> std::result::Result<(), MigratableError> {
         for (_, device_node) in self.device_tree.lock().unwrap().iter() {
             if let Some(migratable) = &device_node.migratable {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1100,6 +1100,8 @@ impl Vmm {
             )));
         }
 
+        vm.start_migration();
+
         if send_data_migration.local {
             // Now pause VM
             vm.pause()?;
@@ -1139,6 +1141,9 @@ impl Vmm {
 
             // Send last batch of dirty pages
             Self::vm_maybe_send_dirty_pages(vm, &mut socket)?;
+
+            // Stop logging dirty pages
+            vm.stop_dirty_log()?;
         }
         // Capture snapshot and send it
         let vm_snapshot = vm.snapshot()?;
@@ -1172,9 +1177,6 @@ impl Vmm {
 
         // Let every Migratable object know about the migration being complete
         vm.complete_migration()?;
-
-        // Stop logging dirty pages
-        vm.stop_dirty_log()?;
 
         Ok(())
     }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2675,6 +2675,11 @@ impl Migratable for Vm {
         ]))
     }
 
+    fn start_migration(&mut self) {
+        self.memory_manager.lock().unwrap().start_migration();
+        self.device_manager.lock().unwrap().start_migration();
+    }
+
     fn complete_migration(&mut self) -> std::result::Result<(), MigratableError> {
         self.memory_manager.lock().unwrap().complete_migration()?;
         self.device_manager.lock().unwrap().complete_migration()


### PR DESCRIPTION
When using --local live migration with vhost-user-net(mode is server),
we don't call start_dirty_log, so migration_started is false.
When restoring VM, an address is used error occurs.

Signed-off-by: lizhaoxin1 <lizhaoxin1@kingsoft.com>