### PR TITLE
vmm: openapi: Remove mention to net fds

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -771,11 +771,6 @@ components:
           default: "Client"
         id:
           type: string
-        fds:
-          type: array
-          items:
-            type: integer
-            format: int32
         pci_segment:
           type: integer
           format: int16


### PR DESCRIPTION
While cloud-hypervisor does support receiving the file descriptors of a
tuntap device, advertising the fds structure via the openAPI can lead to
misinterpretations of what can and what should be done.

An unadvertised consumer will think that they could rather just set the
file descriptors there directly, or even pass them as a byte array.
However, the proper way to go in those cases would be actually sending
those via send_msg(), together with the request.

As hacking the openAPI auto-generated code to properly do this is not
*that* trivial, and as doing so during a `create VM` request is not
supported, we better not advertising those.

Please, for more details, also check:
https://github.com/cloud-hypervisor/cloud-hypervisor/pull/3607#issuecomment-1020935523

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>