### PR TITLE
vhost_user_block: Rely on upstream vhost-user-backend crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,6 +1108,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "vhost-user-backend"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8db00e93514caa8987bb8b536fe962c9b66b4068583abc4c531eb97988477cd"
+dependencies = [
+ "libc",
+ "log",
+ "vhost",
+ "virtio-bindings",
+ "virtio-queue",
+ "vm-memory",
+ "vmm-sys-util",
+]
+
+[[package]]
 name = "vhost_user_backend"
 version = "0.1.0"
 dependencies = [
@@ -1135,7 +1150,7 @@ dependencies = [
  "option_parser",
  "qcow",
  "vhost",
- "vhost_user_backend",
+ "vhost-user-backend",
  "virtio-bindings",
  "vm-memory",
  "vmm-sys-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ clap = { version = "3.0.14", features = ["wrap_help"] }
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0", features = ["with-serde", "fam-wrappers"] }
 kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "main" }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
+virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio", branch = "main" }
 
 [dev-dependencies]
 dirs = "4.0.0"

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -13,8 +13,8 @@ libc = "0.2.116"
 log = "0.4.14"
 option_parser = { path = "../option_parser" }
 qcow = { path = "../qcow" }
-vhost_user_backend = { path = "../vhost_user_backend" }
 vhost = { version = "0.3.0", features = ["vhost-user-slave"] }
+vhost-user-backend = "0.1.0"
 virtio-bindings = "0.1.0"
 vm-memory = "0.7.0"
 vmm-sys-util = "0.9.0"


### PR DESCRIPTION
Instead of relying on the local version of vhost-user-backend, this
patch allows the block backend implementation to rely on the upstream
version of the crate from rust-vmm.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>