### PR TITLE
virtio-devices: Force the processing of the virtio-block queue on resume

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -287,6 +287,34 @@ impl BlockEpollHandler {
 }
 
 impl EpollHelperHandler for BlockEpollHandler {
+    fn resume(&mut self) {
+        match self.process_queue_submit() {
+            Ok(needs_notification) => {
+                if needs_notification {
+                    if let Err(e) = self.signal_used_queue() {
+                        error!("Failed to signal used queue: {:?}", e);
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to process queue (submit): {:?}", e);
+            }
+        }
+
+        match self.process_queue_complete() {
+            Ok(needs_notification) => {
+                if needs_notification {
+                    if let Err(e) = self.signal_used_queue() {
+                        error!("Failed to signal used queue: {:?}", e);
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to process queue (complete): {:?}", e);
+            }
+        }
+    }
+
     fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
         let ev_type = event.data as u16;
         match ev_type {

--- a/virtio-devices/src/epoll_helper.rs
+++ b/virtio-devices/src/epoll_helper.rs
@@ -36,6 +36,9 @@ pub const EPOLL_HELPER_EVENT_LAST: u16 = 15;
 pub trait EpollHelperHandler {
     // Return true if the loop execution should be stopped
     fn handle_event(&mut self, helper: &mut EpollHelper, event: &epoll::Event) -> bool;
+
+    // Called when the epoll loop is resumed after a pause
+    fn resume(&mut self) {}
 }
 
 impl EpollHelper {
@@ -153,6 +156,8 @@ impl EpollHelper {
                         // This ensures the pause event has been seen by each
                         // thread related to this virtio device.
                         let _ = self.pause_evt.read();
+
+                        handler.resume();
                     }
                     _ => {
                         if handler.handle_event(self, event) {


### PR DESCRIPTION
When running with rust-hypervisor-firmware which has a trivial
virtio-block implementation it is necessary to try and process the queue
as it does not use interrupts for knowing if the queue has been
processed.

Fixes: #3658

Signed-off-by: Rob Bradford <robert.bradford@intel.com>