### PR TITLE
vfio-ioctls: Move away from archived crate rust-vmm/vfio-ioctls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio-ioctls?branch=main#19e5b83ddfad430109ce3e8d51f4a24796099127"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#4630612f2ff300e78b6d55be324fb5481aa84661"
 dependencies = [
  "byteorder",
  "kvm-bindings",

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -13,7 +13,7 @@ mshv = ["vfio-ioctls/mshv"]
 anyhow = "1.0.53"
 byteorder = "1.4.3"
 hypervisor = { path = "../hypervisor" }
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "main", default-features = false }
+vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
 vfio_user = { path = "../vfio_user" }
 vmm-sys-util = "0.9.0"
 libc = "0.2.117"

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = "1.0.30"
 serde = { version = "1.0.136", features = ["rc"] }
 serde_derive = "1.0.136"
 serde_json = "1.0.78"
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "main", default-features = false }
+vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
 vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
 vmm-sys-util = "0.9.0"
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = "1.0.30"
 uuid = "0.8.2"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio-ioctls", branch = "main", default-features = false }
+vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
 vfio_user = { path = "../vfio_user" }
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }


### PR DESCRIPTION
Make sure Cloud Hypervisor relies on upstream and actively maintained
vfio-ioctls crate from the rust-vmm/vfio repository instead of the
deprecated version coming from rust-vmm/vfio-ioctls repository.

Fixes #3673

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>