### PR TITLE
build: Fix cargo patch warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ clap = { version = "3.0.14", features = ["wrap_help"] }
 
 # List of patched crates
 [patch.crates-io]
-kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0", features = ["with-serde", "fam-wrappers"] }
+kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0" }
 kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "main" }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
 virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio", branch = "main" }


### PR DESCRIPTION
The patch mechanism in Cargo.toml doesn't support features to be
specified, and was leading to the following warning:

    warning: patch for `kvm-bindings` uses the features mechanism.
    default-features and features will not take effect because the patch
    dependency does not support this mechanism

Removing the "features" parameter from the patch fixes this warning
without breaking the build.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>