### PR TITLE
vmm: Split VM config and VM state for snapshot/restore

### DIFF
--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -43,17 +43,22 @@ ll /home/foo/snapshot/
 total 4194536
 drwxrwxr-x  2 foo bar       4096 Jul 22 11:50 ./
 drwxr-xr-x 47 foo bar       4096 Jul 22 11:47 ../
+-rw-------  1 foo bar       1084 Jul 22 11:19 config.json
 -rw-------  1 foo bar 4294967296 Jul 22 11:19 memory-ranges
--rw-------  1 foo bar     217853 Jul 22 11:19 vm.json
+-rw-------  1 foo bar     217853 Jul 22 11:19 state.json
 ```
+
+`config.json` contains the virtual machine configuration. It is used to create
+a similar virtual machine with the correct amount of CPUs, RAM, and other
+expected devices. It is stored in a human readable format so that it could be
+modified between the snapshot and restore phases to achieve some very special
+use cases. But for most cases, manually modifying the configuration should not
+be needed.
 
 `memory-ranges` stores the content of the guest RAM.
 
-`vm.json` gathers all information related to the virtual machine configuration
-and state. The configuration bits are used to create a similar virtual machine
-with the correct amount of CPUs, RAM, and other expected devices. The state
-bits are used to restore each component in the state it was left before the
-snapshot occurred.
+`state.json` contains the virtual machine state. It is used to restore each
+component in the state it was left before the snapshot occurred.
 
 ## Restore a Cloud Hypervisor VM
 

--- a/vmm/src/migration.rs
+++ b/vmm/src/migration.rs
@@ -2,14 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::vm::{VmSnapshot, VM_SNAPSHOT_ID};
+use crate::{
+    config::VmConfig,
+    vm::{VmSnapshot, VM_SNAPSHOT_ID},
+};
 use anyhow::anyhow;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
 use vm_migration::{MigratableError, Snapshot};
 
-pub const VM_SNAPSHOT_FILE: &str = "vm.json";
+pub const SNAPSHOT_STATE_FILE: &str = "state.json";
+pub const SNAPSHOT_CONFIG_FILE: &str = "config.json";
 
 pub fn url_to_path(url: &str) -> std::result::Result<PathBuf, MigratableError> {
     let path: PathBuf = url
@@ -28,19 +32,28 @@ pub fn url_to_path(url: &str) -> std::result::Result<PathBuf, MigratableError> {
     Ok(path)
 }
 
-pub fn recv_vm_snapshot(source_url: &str) -> std::result::Result<Snapshot, MigratableError> {
-    let mut vm_snapshot_path = url_to_path(source_url)?;
+pub fn recv_vm_config(source_url: &str) -> std::result::Result<VmConfig, MigratableError> {
+    let mut vm_config_path = url_to_path(source_url)?;
 
-    vm_snapshot_path.push(VM_SNAPSHOT_FILE);
+    vm_config_path.push(SNAPSHOT_CONFIG_FILE);
 
     // Try opening the snapshot file
-    let vm_snapshot_file =
-        File::open(vm_snapshot_path).map_err(|e| MigratableError::MigrateSend(e.into()))?;
-    let vm_snapshot_reader = BufReader::new(vm_snapshot_file);
-    let vm_snapshot = serde_json::from_reader(vm_snapshot_reader)
-        .map_err(|e| MigratableError::MigrateReceive(e.into()))?;
+    let vm_config_file =
+        File::open(vm_config_path).map_err(|e| MigratableError::MigrateSend(e.into()))?;
+    let vm_config_reader = BufReader::new(vm_config_file);
+    serde_json::from_reader(vm_config_reader).map_err(|e| MigratableError::MigrateReceive(e.into()))
+}
 
-    Ok(vm_snapshot)
+pub fn recv_vm_state(source_url: &str) -> std::result::Result<Snapshot, MigratableError> {
+    let mut vm_state_path = url_to_path(source_url)?;
+
+    vm_state_path.push(SNAPSHOT_STATE_FILE);
+
+    // Try opening the snapshot file
+    let vm_state_file =
+        File::open(vm_state_path).map_err(|e| MigratableError::MigrateSend(e.into()))?;
+    let vm_state_reader = BufReader::new(vm_state_file);
+    serde_json::from_reader(vm_state_reader).map_err(|e| MigratableError::MigrateReceive(e.into()))
 }
 
 pub fn get_vm_snapshot(snapshot: &Snapshot) -> std::result::Result<VmSnapshot, MigratableError> {


### PR DESCRIPTION
In order to allow for human readable output for the VM configuration, we
pull it out of the snapshot, which becomes effectively the list of
states from the VM. The configuration is stored through a dedicated file
in JSON format (not including any binary output).

Having the ability to read and modify the VM configuration manually
between the snapshot and restore phases makes debugging easier, as well
as empowers users for extending the use cases relying on the
snapshot/restore feature.