### PR TITLE
virtio-devices: Print error on notification BAR read/write

### DIFF
--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -974,6 +974,7 @@ impl PciDevice for VirtioPciDevice {
                 && o < NOTIFICATION_BAR_OFFSET + NOTIFICATION_SIZE =>
             {
                 // Handled with ioeventfds.
+                error!("Unexpected read from notification BAR: offset = 0x{:x}", o);
             }
             o if MSIX_TABLE_BAR_OFFSET <= o && o < MSIX_TABLE_BAR_OFFSET + MSIX_TABLE_SIZE => {
                 if let Some(msix_config) = &self.msix_config {
@@ -1019,6 +1020,7 @@ impl PciDevice for VirtioPciDevice {
                 && o < NOTIFICATION_BAR_OFFSET + NOTIFICATION_SIZE =>
             {
                 // Handled with ioeventfds.
+                error!("Unexpected write to notification BAR: offset = 0x{:x}", o);
             }
             o if MSIX_TABLE_BAR_OFFSET <= o && o < MSIX_TABLE_BAR_OFFSET + MSIX_TABLE_SIZE => {
                 if let Some(msix_config) = &self.msix_config {


### PR DESCRIPTION
This should not occur as ioeventfd is used for notification. Such an
error message would have made the discovery of the underlying cause of

Signed-off-by: Rob Bradford <robert.bradford@intel.com>