### PR TITLE
Enable guest to report free pages through virtio-balloon

### DIFF
--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -392,6 +392,7 @@ impl Balloon {
         id: String,
         size: u64,
         deflate_on_oom: bool,
+        _free_page_reporting: bool,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
     ) -> io::Result<Self> {

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -800,7 +800,11 @@ components:
         deflate_on_oom:
           type: boolean
           default: false
-          description: Whether the balloon should deflate when the guest is under memory pressure.
+          description: Deflate balloon when the guest is under memory pressure.
+        free_page_reporting:
+          type: boolean
+          default: false
+          description: Enable guest to report free pages.
 
     FsConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1383,16 +1383,21 @@ pub struct BalloonConfig {
     /// Option to deflate the balloon in case the guest is out of memory.
     #[serde(default)]
     pub deflate_on_oom: bool,
+    /// Option to enable free page reporting from the guest.
+    #[serde(default)]
+    pub free_page_reporting: bool,
 }
 
 impl BalloonConfig {
     pub const SYNTAX: &'static str =
-        "Balloon parameters \"size=<balloon_size>,deflate_on_oom=on|off\"";
+        "Balloon parameters \"size=<balloon_size>,deflate_on_oom=on|off,\
+        free_page_reporting=on|off\"";
 
     pub fn parse(balloon: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser.add("size");
         parser.add("deflate_on_oom");
+        parser.add("free_page_reporting");
         parser.parse(balloon).map_err(Error::ParseBalloon)?;
 
         let size = parser
@@ -1407,9 +1412,16 @@ impl BalloonConfig {
             .unwrap_or(Toggle(false))
             .0;
 
+        let free_page_reporting = parser
+            .convert::<Toggle>("free_page_reporting")
+            .map_err(Error::ParseBalloon)?
+            .unwrap_or(Toggle(false))
+            .0;
+
         Ok(BalloonConfig {
             size,
             deflate_on_oom,
+            free_page_reporting,
         })
     }
 }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2786,6 +2786,7 @@ impl DeviceManager {
                     id.clone(),
                     balloon_config.size,
                     balloon_config.deflate_on_oom,
+                    balloon_config.free_page_reporting,
                     self.seccomp_action.clone(),
                     self.exit_evt
                         .try_clone()


### PR DESCRIPTION
Adding a new parameter free_page_reporting=on|off to the balloon device
so that we can enable the corresponding feature from virtio-balloon.

Running a VM with a balloon device where this feature is enabled allows
the guest to report pages that are free from guest's perspective. This
information is used by the VMM to release the corresponding pages on the
host.