### PR TITLE
Support forcing all devices on a segment behind the IOMMU

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ fn create_app<'a>(
             Arg::new("platform")
                 .long("platform")
                 .help(
-                    "num_pci_segments=<num pci segments>",
+                    "num_pci_segments=<num pci segments>,iommu_segments=<list_of_segments>",
                 )
                 .takes_value(true)
                 .group("vm-config"),

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -510,6 +510,8 @@ components:
         watchdog:
           type: boolean
           default: false
+        platform:
+          $ref: '#/components/schemas/PlatformConfig'
       description: Virtual machine configuration
 
     CpuAffinity:
@@ -556,6 +558,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CpuAffinity'
+
+    PlatformConfig:
+      type: object
+      properties:
+        num_pci_segments:
+          type: integer
+          format: int16
+        iommu_segments:
+          type: array
+          items:
+            type: integer
+            format: int16
 
     MemoryZoneConfig:
       required:


### PR DESCRIPTION
This allows the hotplugging of devices behind the IOMMU provided they are assigned to a segment that is in the list.