### PR TITLE
openapi: Expose TDx configuration

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -500,6 +500,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SgxEpcConfig'
+        tdx:
+          $ref: '#/components/schemas/TdxConfig'
         numa:
           type: array
           items:
@@ -945,6 +947,15 @@ components:
         prefault:
           type: boolean
           default: false
+
+    TdxConfig:
+      required:
+      - firmware
+      type: object
+      properties:
+        firmware:
+          type: string
+          description: Path to the firmware that will be used to boot the TDx guest up.
 
     NumaDistance:
       required:


### PR DESCRIPTION
TDx support is already present on the project for quite some time, but
the TDx configuration was not yet exposed to the ones using CH via the
OpenAPI auto generated code.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>