### PR TITLE
README: Use MAINTAINERS.md for security issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,5 +377,4 @@ and [join us on Slack](https://cloud-hypervisor.slack.com/).
 
 ## Security issues
 
-Please use the GitHub security advisories feature for reporting issues:
-https://github.com/cloud-hypervisor/cloud-hypervisor/security/advisories/new
+Please contact the maintainers listed in the MAINTAINERS.md file with security issues.


### PR DESCRIPTION
The GitHub security reporting link only works for those who are
repository owners.

Fixes: #3701

Signed-off-by: Rob Bradford <robert.bradford@intel.com>