### PR TITLE
pci, vmm: Update DeviceNode to store PciBdf instead of u32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,6 +602,8 @@ dependencies = [
  "hypervisor",
  "libc",
  "log",
+ "serde",
+ "serde_derive",
  "thiserror",
  "versionize",
  "versionize_derive",

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -18,6 +18,8 @@ vfio_user = { path = "../vfio_user" }
 vmm-sys-util = "0.9.0"
 libc = "0.2.118"
 log = "0.4.14"
+serde = "1.0.136"
+serde_derive = "1.0.136"
 thiserror = "1.0.30"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3082,7 +3082,7 @@ impl DeviceManager {
             });
         }
 
-        node.pci_bdf = Some(pci_device_bdf.into());
+        node.pci_bdf = Some(pci_device_bdf);
         node.pci_device_handle = Some(PciDeviceHandle::Vfio(vfio_pci_device));
 
         self.device_tree
@@ -3241,7 +3241,7 @@ impl DeviceManager {
 
         let mut node = device_node!(vfio_user_name);
 
-        node.pci_bdf = Some(pci_device_bdf.into());
+        node.pci_bdf = Some(pci_device_bdf);
         node.pci_device_handle = Some(PciDeviceHandle::VfioUser(vfio_user_pci_device));
 
         self.device_tree
@@ -3288,8 +3288,7 @@ impl DeviceManager {
             info!("Restoring virtio-pci {} resources", id);
             let pci_device_bdf: PciBdf = node
                 .pci_bdf
-                .ok_or(DeviceManagerError::MissingDeviceNodePciBdf)?
-                .into();
+                .ok_or(DeviceManagerError::MissingDeviceNodePciBdf)?;
             let pci_segment_id = pci_device_bdf.segment();
 
             self.pci_segments[pci_segment_id as usize]
@@ -3397,7 +3396,7 @@ impl DeviceManager {
             });
         }
         node.migratable = Some(Arc::clone(&virtio_pci_device) as Arc<Mutex<dyn Migratable>>);
-        node.pci_bdf = Some(pci_device_bdf.into());
+        node.pci_bdf = Some(pci_device_bdf);
         node.pci_device_handle = Some(PciDeviceHandle::Virtio(virtio_pci_device));
         self.device_tree.lock().unwrap().insert(id, node);
 
@@ -3570,8 +3569,7 @@ impl DeviceManager {
 
         let pci_device_bdf: PciBdf = pci_device_node
             .pci_bdf
-            .ok_or(DeviceManagerError::MissingDeviceNodePciBdf)?
-            .into();
+            .ok_or(DeviceManagerError::MissingDeviceNodePciBdf)?;
         let pci_segment_id = pci_device_bdf.segment();
 
         let pci_device_handle = pci_device_node
@@ -3625,7 +3623,7 @@ impl DeviceManager {
         // Remove the device from the device tree along with its children.
         let mut device_tree = self.device_tree.lock().unwrap();
         let pci_device_node = device_tree
-            .remove_node_by_pci_bdf(pci_device_bdf.into())
+            .remove_node_by_pci_bdf(pci_device_bdf)
             .ok_or(DeviceManagerError::MissingPciDevice)?;
         for child in pci_device_node.children.iter() {
             device_tree.remove(child);

--- a/vmm/src/device_tree.rs
+++ b/vmm/src/device_tree.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::device_manager::PciDeviceHandle;
+use pci::PciBdf;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use vm_device::Resource;
@@ -16,7 +17,7 @@ pub struct DeviceNode {
     pub children: Vec<String>,
     #[serde(skip)]
     pub migratable: Option<Arc<Mutex<dyn Migratable>>>,
-    pub pci_bdf: Option<u32>,
+    pub pci_bdf: Option<PciBdf>,
     #[serde(skip)]
     pub pci_device_handle: Option<PciDeviceHandle>,
 }
@@ -83,7 +84,7 @@ impl DeviceTree {
             .collect()
     }
 
-    pub fn remove_node_by_pci_bdf(&mut self, pci_bdf: u32) -> Option<DeviceNode> {
+    pub fn remove_node_by_pci_bdf(&mut self, pci_bdf: PciBdf) -> Option<DeviceNode> {
         let mut id = None;
         for (k, v) in self.0.iter() {
             if v.pci_bdf == Some(pci_bdf) {


### PR DESCRIPTION
By having the DeviceNode storing a PciBdf, we simplify the internal code
as well as allow for custom Serialize/Deserialize implementation for the
PciBdf structure. These custom implementations let us display the PCI
s/b/d/f in a human readable format.

Fixes https://github.com/cloud-hypervisor/cloud-hypervisor/issues/3711