### PR TITLE
pci: Support DWORD/4-byte writes to the MSI-X control register

### DIFF
--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -742,6 +742,11 @@ impl PciConfiguration {
                         .lock()
                         .unwrap()
                         .set_msg_ctl(LittleEndian::read_u16(data));
+                } else if msix_cap_reg_idx == reg_idx && offset == 0 && data.len() == 4 {
+                    msix_config
+                        .lock()
+                        .unwrap()
+                        .set_msg_ctl((LittleEndian::read_u32(data) >> 16) as u16);
                 }
             }
         }


### PR DESCRIPTION
The PCI spec does not specify that the access has to be of a specific
size.

Fixes: #3714

Signed-off-by: Rob Bradford <robert.bradford@intel.com>