### PR TITLE
Streamline dev container

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -67,7 +67,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
         && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends --no-install-suggests \
         libcap2-bin \
         libguestfs-tools \
-        linux-image-5.8.0-63-generic \
+        linux-image-generic \
         autotools-dev \
         autoconf \
         automake \

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -92,7 +92,6 @@ RUN export ARCH="$(uname -m)" \
     && if [ "$TARGETARCH" = "amd64" ]; then rustup toolchain add $RUST_TOOLCHAIN-x86_64-unknown-linux-musl; fi \
     && if [ "$TARGETARCH" = "amd64" ]; then rustup component add rustfmt; fi \
     && if [ "$TARGETARCH" = "amd64" ]; then rustup component add clippy; fi \
-    && cargo install cargo-audit \
     && rm -rf "$CARGO_HOME/registry" \
     && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \
     && rm -rf "$CARGO_HOME/git" \

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -14,38 +14,37 @@ ENV PATH="$PATH:$CARGO_HOME/bin"
 # Install all CI dependencies
 RUN apt-get update \
 	&& apt-get -yq upgrade \
-	&& DEBIAN_FRONTEND=noninteractive apt-get install -yq \
-	build-essential \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --no-install-suggests -yq \
 	bc \
-	docker.io \
+	bison \
+	build-essential \
+	ca-certificates \
+	cpio \
 	curl \
-	wget \
-	sudo \
+	dosfstools \
+	flex \
+	git-core \
+	iperf3 \
+	libcap-ng-dev \
+	libelf-dev \
+	libseccomp-dev \
+	libssl-dev \
 	mtools \
 	musl-tools \
-	libssl-dev \
-	pkg-config \
-	flex \
-	bison \
-	libelf-dev \
-	qemu-utils \
-	qemu-system \
-	libglib2.0-dev \
-	libpixman-1-dev \
-	libseccomp-dev \
-	libcap-ng-dev \
-	socat \
-	dosfstools \
-	cpio \
-	python \
-	python3 \
-	python3-setuptools \
 	ntfs-3g \
 	openvswitch-switch-dpdk \
+	pkg-config \
+	python \
+	python3 \
 	python3-distutils \
+	python3-setuptools \
+	qemu-system-common \
+	qemu-utils \
+	socat \
+	sudo \
+	unzip \
 	uuid-dev \
-	iperf3 \
-	zip \
+	wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -54,7 +53,7 @@ RUN update-alternatives --set ovs-vswitchd /usr/lib/openvswitch-switch-dpdk/ovs-
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
 	apt-get update \
 	&& apt-get -yq upgrade \
-	&& DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc-multilib \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends --no-install-suggests gcc-multilib \
 	&& apt-get clean \
     && rm -rf /var/lib/apt/lists/*;	fi
 
@@ -65,7 +64,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
         # kernel (any version) image in `/boot` and modules in `/lib/modules`.
         apt-get update \
         && apt-get -yq upgrade \
-        && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+        && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends --no-install-suggests \
         libcap2-bin \
         libguestfs-tools \
         linux-image-5.8.0-63-generic \
@@ -104,13 +103,6 @@ RUN echo 'source $CARGO_HOME/env' >> $HOME/.bashrc \
     && mkdir $HOME/.cargo \
     && ln -s $CARGO_HOME/env $HOME/.cargo/env
 
-# install virtiofsd
-RUN git clone --depth 1 https://gitlab.com/virtio-fs/qemu.git -b qemu5.0-virtiofs-dax \
-    && cd qemu \
-    && ./configure --prefix=$PWD --target-list=x86_64-softmmu \
-    && make virtiofsd -j `nproc` \
-    && cp virtiofsd /usr/local/bin \
-    && cd .. && rm -rf qemu
 
 # install SPDK NVMe
 # only for 'x86_64' platform images as 'docker buildx' can't build 'spdk'

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -122,7 +122,8 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
        && cd .. && rm -rf spdk; fi
 
 # install ethr tool for performance tests
-RUN wget https://github.com/microsoft/ethr/releases/latest/download/ethr_linux.zip \
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+    wget https://github.com/microsoft/ethr/releases/latest/download/ethr_linux.zip \
     && unzip ethr_linux.zip \
     && cp ethr /usr/local/bin \
-    && rm ethr_linux.zip
+    && rm ethr_linux.zip; fi

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as dev
+FROM ubuntu:21.10 as dev
 
 ARG TARGETARCH
 ARG RUST_TOOLCHAIN="1.58.1"


### PR DESCRIPTION
Simplify the dev container to both reduce the build time (from over 1hr50) but also to reduce the binary size.