### PR TITLE
Revert "Dockerfile: Move to impish as base for packaged virtiofsd"

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.10 as dev
+FROM ubuntu:20.04 as dev
 
 ARG TARGETARCH
 ARG RUST_TOOLCHAIN="1.58.1"


### PR DESCRIPTION
This reverts commit 98bbfa97385b21526bf17c0a5bee2fa1af71b85a.

Some tests are continuing to fail even after reverting
d27316dab63c0e6e3d1e8ed2e5a7c11489fe283b. This is the only other
relevant change.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>