### PR TITLE
github: Use tag derived from date for docker image

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -27,6 +27,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: cloudhypervisor/dev
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=raw,value={{date 'YYYYMMDD'}}-0
+            type=sha
+
       - name: Build and push
         if: ${{ github.event_name == 'push' }}
         uses: docker/build-push-action@v2
@@ -34,7 +45,7 @@ jobs:
           file: ./resources/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: cloudhypervisor/dev:latest
+          tags: ${{ steps.meta.outputs.tags }}
 
       - name: Build only
         if: ${{ github.event_name == 'pull_request' }}
@@ -42,7 +53,7 @@ jobs:
         with:
           file: ./resources/Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: cloudhypervisor/dev:latest
+          tags: ${{ steps.meta.outputs.tags }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,3 +1,6 @@
+# When changing this file don't forget to update the tag name in the
+# .github/workflows/docker-image.yaml file if doing multiple per day
+
 FROM ubuntu:20.04 as dev
 
 ARG TARGETARCH


### PR DESCRIPTION
This will allow easier transitioning between versions of the container.
A later PR will update the CI to use this new tag.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>