### PR TITLE
scripts: Use date tagged docker container in dev_cli.sh

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -7,7 +7,7 @@
 CLI_NAME="Cloud Hypervisor"
 
 CTR_IMAGE_TAG="cloudhypervisor/dev"
-CTR_IMAGE_VERSION="latest"
+CTR_IMAGE_VERSION="20220218-0"
 CTR_IMAGE="${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}"
 
 DOCKER_RUNTIME="docker"


### PR DESCRIPTION
This allows more predictable use of the container.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>