### PR TITLE
virtio-devices: vhost_user: blk: add VhostUserVirtioFeatures in restore

### DIFF
--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -205,10 +205,9 @@ impl Blk {
         self.vu_common.acked_protocol_features = state.acked_protocol_features;
         self.vu_common.vu_num_queues = state.vu_num_queues;
 
-        if let Err(e) = self
-            .vu_common
-            .restore_backend_connection(self.common.acked_features)
-        {
+        if let Err(e) = self.vu_common.restore_backend_connection(
+            self.common.acked_features | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits(),
+        ) {
             error!(
                 "Failed restoring connection with vhost-user backend: {:?}",
                 e


### PR DESCRIPTION
When VM startup with vhost-user blk, in negotiate_features_vhost_user,
acked_features contains VhostUserVirtioFeatures::PROTOCOL_FEATURES,
so in set_protocol_features, node.acked_protocol_features contains
VhostUserProtocolFeatures::INFLIGHT_SHMFD.

When activate, in get_inflight_fd, node.acked_protocol_features contains
INFLIGHT_SHMFD, so vhost-user blk can be activated.

But when migration, in restore_backend_connection, acked_features doesn't
contain PROTOCOL_FEATURES, cause node.acked_protocol_features doesn't
contain INFLIGHT_SHMFD. So in get_inflight_fd, target process report error.

Signed-off-by: lizhaoxin1 <Lxiaoyouling@163.com>