### PR TITLE
openapi: Update the PciBdf type

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -440,8 +440,7 @@ components:
           items:
             type: string
         pci_bdf:
-          type: integer
-          format: int32
+          type: string
 
     VmCounters:
       type: object


### PR DESCRIPTION
42b5d4a2f7820469bd538ddd19d7f33eea6f68a8 has changed how the PciBdf
field of a DeviceNode is represented (from an int32 to its own struct).

To avoid marshelling / demarshelling issues for the projects relying on
the openapi auto generated code, let's propagate the change, updating
the yaml file accordingly.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>