### PR TITLE
build: introduce rust-version in Cargo.toml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,7 @@ jobs:
           - stable
           - beta
           - nightly
+          - 1.54
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ build = "build.rs"
 license = "LICENSE-APACHE & LICENSE-BSD-3-Clause"
 description = "Open source Virtual Machine Monitor (VMM) that runs on top of KVM"
 homepage = "https://github.com/cloud-hypervisor/cloud-hypervisor"
+# Minimum buildable version:
+# Keep in sync with version in .github/workflows/build.yaml
 rust-version = "1.54"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ build = "build.rs"
 license = "LICENSE-APACHE & LICENSE-BSD-3-Clause"
 description = "Open source Virtual Machine Monitor (VMM) that runs on top of KVM"
 homepage = "https://github.com/cloud-hypervisor/cloud-hypervisor"
+rust-version = "1.54"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Starting from Rust 1.56 Cargo supports specifying the minimum supported
rust version (MSRV) via "rust-version". If the compiler version is not
satisfied, Cargo prints an error and exits early.

MSRV is useful information to packagers. Using this field also saves us
from adding another file to the tree.

The version is currently set to 1.54, which is tested to build Cloud
Hypervisor successfully. Although anyone who uses 1.54 will see a
warning because "rust-version" is only introduced in 1.56. The warning
can be safely ignored.

Signed-off-by: Wei Liu <liuwe@microsoft.com>