### PR TITLE
Performance-metrics: Store test list with a `const` array and pass custom arguments to the test binary from "dev_cli.sh"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "dirs 4.0.0",
- "lazy_static",
  "serde",
  "serde_derive",
  "serde_json",

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -8,7 +8,6 @@ build = "build.rs"
 [dependencies]
 clap = { version = "3.1.1", features = ["wrap_help","cargo"] }
 dirs = "4.0.0"
-lazy_static= "1.4.0"
 serde = { version = "1.0.136", features = ["rc"] }
 serde_derive = "1.0.136"
 serde_json = "1.0.78"

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -183,7 +183,7 @@ cmd_help() {
     echo "        --volumes             Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
     echo "        --hypervisor          Underlying hypervisor. Options kvm, mshv"
     echo ""
-    echo "    tests [--unit|--cargo|--all] [--libc musl|gnu] [-- [<cargo test args>]]"
+    echo "    tests [--unit|--cargo|--all] [--libc musl|gnu] [-- [<test scripts args>] [-- [<test binary args>]]] "
     echo "        Run the Cloud Hypervisor tests."
     echo "        --unit                       Run the unit tests."
     echo "        --cargo                      Run the cargo tests."
@@ -369,7 +369,7 @@ cmd_tests() {
         exported_device="/dev/mshv"
     fi
 
-    set -- "$@" '--hypervisor' "$hypervisor"
+    set -- '--hypervisor' "$hypervisor" "$@"
 
     ensure_build_dir
     ensure_latest_ctr

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -311,13 +311,13 @@ echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 # Run all direct kernel boot (Device Tree) test cases in mod `parallel`
-time cargo test $features "parallel::$test_filter"
+time cargo test $features "parallel::$test_filter" -- ${test_binary_args[*]}
 RES=$?
 
 # Run some tests in sequence since the result could be affected by other tests
 # running in parallel.
 if [ $RES -eq 0 ]; then
-    time cargo test $features "sequential::$test_filter" -- --test-threads=1
+    time cargo test $features "sequential::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
     RES=$?
 else
     exit $RES
@@ -325,7 +325,7 @@ fi
 
 # Run all ACPI test cases
 if [ $RES -eq 0 ]; then
-    time cargo test $features "aarch64_acpi::$test_filter"
+    time cargo test $features "aarch64_acpi::$test_filter" -- ${test_binary_args[*]}
     RES=$?
 else
     exit $RES
@@ -333,7 +333,7 @@ fi
 
 # Run all test cases related to live migration
 if [ $RES -eq 0 ]; then
-    time cargo test $features "live_migration::$test_filter" -- --test-threads=1
+    time cargo test $features "live_migration::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
     RES=$?
 else
     exit $RES

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -87,7 +87,7 @@ echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 export RUST_BACKTRACE=1
-time cargo test $features "live_migration::$test_filter" -- --test-threads=1
+time cargo test $features "live_migration::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
 RES=$?
 
 exit $RES

--- a/scripts/run_integration_tests_sgx.sh
+++ b/scripts/run_integration_tests_sgx.sh
@@ -27,7 +27,7 @@ strip target/$BUILD_TARGET/release/cloud-hypervisor
 
 export RUST_BACKTRACE=1
 
-time cargo test $features "sgx::$test_filter"
+time cargo test $features "sgx::$test_filter" -- ${test_binary_args[*]}
 RES=$?
 
 exit $RES

--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -21,7 +21,7 @@ strip target/$BUILD_TARGET/release/cloud-hypervisor
 
 export RUST_BACKTRACE=1
 
-time cargo test $features "vfio::$test_filter" -- --test-threads=1
+time cargo test $features "vfio::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
 RES=$?
 
 exit $RES

--- a/scripts/run_integration_tests_windows.sh
+++ b/scripts/run_integration_tests_windows.sh
@@ -51,7 +51,7 @@ export RUST_BACKTRACE=1
 
 # Only run with 1 thread to avoid tests interfering with one another because
 # Windows has a static IP configured
-time cargo test $features "windows::$test_filter"
+time cargo test $features "windows::$test_filter" -- ${test_binary_args[*]}
 RES=$?
 
 dmsetup remove_all -f

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -201,14 +201,14 @@ echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 export RUST_BACKTRACE=1
-time cargo test $features "parallel::$test_filter"
+time cargo test $features "parallel::$test_filter" -- ${test_binary_args[*]}
 RES=$?
 
 # Run some tests in sequence since the result could be affected by other tests
 # running in parallel.
 if [ $RES -eq 0 ]; then
     export RUST_BACKTRACE=1
-    time cargo test $features "sequential::$test_filter" -- --test-threads=1
+    time cargo test $features "sequential::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
     RES=$?
 fi
 

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -88,7 +88,7 @@ echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 export RUST_BACKTRACE=1
-time target/$BUILD_TARGET/release/performance-metrics
+time target/$BUILD_TARGET/release/performance-metrics ${test_binary_args[*]}
 RES=$?
 
 exit $RES

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 hypervisor="kvm"
 test_filter=""
+test_binary_args=()
 
 cmd_help() {
     echo ""
@@ -28,12 +29,20 @@ process_common_args() {
                 shift
                 test_filter="$1"
                 ;;
+            "--") {
+                shift
+                break
+            } ;;
             *)
-		;;
+                echo "Unknown test scripts argument: $1. Please use '-- --help' for help."
+                exit
+                ;;
 	esac
 	shift
     done
     if [[ ! ("$hypervisor" = "kvm" ||  "$hypervisor" = "mshv") ]]; then
         die "Hypervisor value must be kvm or mshv"
     fi
+
+    test_binary_args="$@"
 }


### PR DESCRIPTION
Fixes: #3740 #3739 