### PR TITLE
vmm: api: Make 'local' optional in SendMigrationData

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1072,6 +1072,8 @@ components:
           type: string
 
     SendMigrationData:
+      required:
+      - destination_url
       type: object
       properties:
         destination_url:


### PR DESCRIPTION
Make sure the OpenAPI definition matches the code.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>