### PR TITLE
openapi: Mark ReceiveMigrationData.receiver_url as required

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1066,6 +1066,8 @@ components:
           type: boolean
 
     ReceiveMigrationData:
+      required:
+      - receiver_url
       type: object
       properties:
         receiver_url:


### PR DESCRIPTION
Related to #3758 