### PR TITLE
scripts: dev_cli: Add the ability to pass `--features foo` to the dev_cli.sh script

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -241,6 +241,10 @@ cmd_build() {
             shift
             hypervisor="$1"
             ;;
+        "--features")
+            shift
+            features_build="--features $1"
+            ;;
         "--") {
             shift
             break

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -283,7 +283,7 @@ cmd_build() {
         --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" $exported_volumes \
         --env RUSTFLAGS="$rustflags" \
         "$CTR_IMAGE" \
-        cargo build --all "$features_build" \
+        cargo build --all $features_build \
         --target-dir "$CTR_CLH_CARGO_TARGET" \
         "${cargo_args[@]}" && say "Binaries placed under $CLH_CARGO_TARGET/$target/$build"
 }


### PR DESCRIPTION
This series addresses a regression in the `dev_cli.sh` script, which was noticed when bumping the Cloud Hypervisor version used by Kata containers.

scripts: dev_cli: Don't quote $features_build

2805e7b1dc203ff4468e3743afe2fe77f444a0a8 quoted enclose variables to
prevent globbing or incorrect splitting.  However, by doing with with
$features_build it broke the capability to call the script as:
```
$ ./scripts/dev_cli.sh build --release --libc musl -- --features tdx

```

Before 2805e7b1dc203ff4468e3743afe2fe77f444a0a8 it simply worked, after,
the result is:
```
docker run --user 1000:1000 --workdir /cloud-hypervisor --rm --volume /dev/kvm --volume /home/ffidenci/go/src/github.com/cloud-hypervisor/cloud-hypervisor:/cloud-hypervisor --env RUSTFLAGS= cloudhypervisor/dev:20220223-0 cargo build --all '' --target-dir /cloud-hypervisor/build/cargo_target --features tdx --release --target x86_64-unknown-linux-musl
error: Found argument '' which wasn't expected, or isn't valid in this context


USAGE:
    cargo build --all

For more information try --help
```
----

And also adds the possibility to easily pass `--features` in a more official way than just pasing `-- --features foo` to the `dev_cli.sh` script.

scripts: dev_cli: Add `--features` option

Let's officially have a way to pass the features used to build
cloud-hypervisor to the dev_cli.sh script.

This doesn't invalidate the previous commit, as we still don't what the
features_build variable to be quoted, otherwise we face the following
issue:
```
error: Found argument '--features tdx' which wasn't expected, or isn't valid in this context
        Did you mean --features?

USAGE:
    cargo build --all --features <FEATURES>...
```