### PR TITLE
scripts: Fix musl build error in integration tests on AArch64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ pipeline{
 						}
 						stage ('Run unit tests') {
 							steps {
-								sh "scripts/dev_cli.sh tests --unit"
+								sh "scripts/dev_cli.sh tests --unit --libc musl"
 							}
 						}
 						stage ('Run integration tests') {
@@ -103,7 +103,7 @@ pipeline{
 							}
 							steps {
 								sh "sudo modprobe openvswitch"
-								sh "scripts/dev_cli.sh tests --integration"
+								sh "scripts/dev_cli.sh tests --integration --libc musl"
 							}
 						}
 					}

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -174,12 +174,6 @@ cp $FW $VFIO_DIR
 cp $VMLINUX_IMAGE $VFIO_DIR || exit 1
 
 BUILD_TARGET="$(uname -m)-unknown-linux-${CH_LIBC}"
-CFLAGS=""
-TARGET_CC=""
-if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
-TARGET_CC="musl-gcc"
-CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
-fi
 
 cargo build --all  --release $features --target $BUILD_TARGET
 strip target/$BUILD_TARGET/release/cloud-hypervisor

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -12,5 +12,11 @@ if [[ $(uname -m) = "aarch64" || $hypervisor = "mshv" ]]; then
     cargo_args+=("--no-default-features")
     cargo_args+=("--features $hypervisor")
 fi
+
+if [[ "${BUILD_TARGET}" == "aarch64-unknown-linux-musl" ]]; then
+    export TARGET_CC="musl-gcc"
+    export RUSTFLAGS="-C link-arg=-lgcc -C link_arg=-specs -C link_arg=/usr/lib/aarch64-linux-musl/musl-gcc.specs"
+fi
+
 export RUST_BACKTRACE=1
 cargo test --lib --bins --target $BUILD_TARGET --workspace ${cargo_args[@]} || exit 1;


### PR DESCRIPTION
Follow up https://github.com/cloud-hypervisor/cloud-hypervisor/pull/3777. 

Same errors can also be reproduced in AArch64 integration tests with command: `./scripts/dev_cli.sh tests --libc musl --integration`
