### PR TITLE
performance-metrics: Rename virtio_net_latency_ns->virtio_net_latency_us

### DIFF
--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -220,7 +220,7 @@ const TEST_LIST: [PerformanceTest; 15] = [
         },
     },
     PerformanceTest {
-        name: "virtio_net_latency_ns",
+        name: "virtio_net_latency_us",
         func_ptr: performance_net_latency,
         control: PerformanceTestControl {
             num_queues: Some(2),


### PR DESCRIPTION
The unit from ethr is microseconds.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>