### PR TITLE
Add support for enabling AMX in vm guests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,10 @@ jobs:
 
       - name: Build (mshv)
         run: cargo rustc --bin cloud-hypervisor --no-default-features --features "mshv"  -- -D warnings
-        
+
+      - name: Build (default + amx)
+        run: cargo rustc --bin cloud-hypervisor --features "amx" -- -D warnings
+
       - name: Release Build (default features)
         run: cargo build --all --release --target=${{ matrix.target }}
 

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -54,6 +54,9 @@ jobs:
       - name: Clippy (mshv)
         run: cargo clippy --all --all-targets --no-default-features --tests --features "mshv" -- -D warnings
 
+      - name: Clippy (default + amx)
+        run: cargo clippy --all --all-targets --tests --features "amx" -- -D warnings
+
       - name: Clippy (integration tests)
         run: cargo clippy --all --all-targets --tests -- -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ default = ["common", "kvm"]
 # Common features for all hypervisors
 common = ["acpi", "cmos", "fwdebug"]
 acpi = ["vmm/acpi"]
+amx = ["vmm/amx"]
 cmos = ["vmm/cmos"]
 fwdebug = ["vmm/fwdebug"]
 gdb = ["vmm/gdb"]

--- a/docs/cpu.md
+++ b/docs/cpu.md
@@ -17,11 +17,12 @@ struct CpusConfig {
     kvm_hyperv: bool,
     max_phys_bits: u8,
     affinity: Option<Vec<CpuAffinity>>,
+    features: CpuFeatures,
 }
 ```
 
 ```
---cpus boot=<boot_vcpus>,max=<max_vcpus>,topology=<threads_per_core>:<cores_per_die>:<dies_per_package>:<packages>,kvm_hyperv=on|off,max_phys_bits=<maximum_number_of_physical_bits>,affinity=<list_of_vcpus_with_their_associated_cpuset>
+--cpus boot=<boot_vcpus>,max=<max_vcpus>,topology=<threads_per_core>:<cores_per_die>:<dies_per_package>:<packages>,kvm_hyperv=on|off,max_phys_bits=<maximum_number_of_physical_bits>,affinity=<list_of_vcpus_with_their_associated_cpuset>,features=<list_of_features_to_enable>
 ```
 
 ### `boot`
@@ -187,3 +188,24 @@ _Example_
 In this example, assuming the host has 4 CPUs, vCPU 0 will run exclusively on
 host CPUs 2 and 3, while vCPU 1 will run exclusively on host CPUs 0 and 1.
 Because nothing is defined for vCPU 2, it can run on any of the 4 host CPUs.
+
+### `features`
+
+Set of CPU features to enable.
+
+This option allows the user to enable a set of CPU features that are disabled
+by default otherwise.
+
+The currently available feature set is: `amx`.
+
+The `amx` feature will enable the x86 extension adding hardware units for
+matrix operations (int and float dot products). The goal of the extension is to
+provide performance enhancements for these common operations.
+
+_Example_
+
+```
+--cpus features=amx
+```
+
+In this example the amx CPU feature will be enabled for the VMM.

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -313,6 +313,7 @@ impl<S: FromStr, T: TupleValue> FromStr for Tuple<S, T> {
     }
 }
 
+#[derive(Default)]
 pub struct StringList(pub Vec<String>);
 
 pub enum StringListParseError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,8 @@ fn create_app<'a>(
                     "boot=<boot_vcpus>,max=<max_vcpus>,\
                     topology=<threads_per_core>:<cores_per_die>:<dies_per_package>:<packages>,\
                     kvm_hyperv=on|off,max_phys_bits=<maximum_number_of_physical_bits>,\
-                    affinity=<list_of_vcpus_with_their_associated_cpuset>",
+                    affinity=<list_of_vcpus_with_their_associated_cpuset>,\
+                    features=<list_of_features_to_enable>",
                 )
                 .default_value(default_vcpus)
                 .group("vm-config"),
@@ -631,8 +632,8 @@ mod unit_tests {
     use crate::{create_app, prepare_default_values};
     use std::path::PathBuf;
     use vmm::config::{
-        CmdlineConfig, ConsoleConfig, ConsoleOutputMode, CpusConfig, KernelConfig, MemoryConfig,
-        RngConfig, VmConfig, VmParams,
+        CmdlineConfig, ConsoleConfig, ConsoleOutputMode, CpuFeatures, CpusConfig, KernelConfig,
+        MemoryConfig, RngConfig, VmConfig, VmParams,
     };
 
     fn get_vm_config_from_vec(args: &[&str]) -> VmConfig {
@@ -679,6 +680,7 @@ mod unit_tests {
                 kvm_hyperv: false,
                 max_phys_bits: 46,
                 affinity: None,
+                features: CpuFeatures::default(),
             },
             memory: MemoryConfig {
                 size: 536_870_912,

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [features]
 default = []
 acpi = ["acpi_tables","devices/acpi", "arch/acpi"]
+amx = []
 cmos = ["devices/cmos"]
 fwdebug = ["devices/fwdebug"]
 gdb = ["kvm"]

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -562,6 +562,12 @@ components:
           items:
             type: integer
 
+    CpuFeatures:
+      type: object
+      properties:
+        amx:
+          type: boolean
+
     CpuTopology:
       type: object
       properties:
@@ -596,6 +602,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CpuAffinity'
+        features:
+          $ref: '#/components/schemas/CpuFeatures'
 
     PlatformConfig:
       type: object

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1885,6 +1885,7 @@ mod unit_tests {
                 kvm_hyperv: false,
                 max_phys_bits: 46,
                 affinity: None,
+                features: config::CpuFeatures::default(),
             },
             memory: MemoryConfig {
                 size: 536_870_912,


### PR DESCRIPTION
Adds support for an x86_64 only --amx option that will attempt to
enable AMX usage for guests (needs a 5.16+ kernel) or exit with
failure.

Might be worthwhile moving this to the vmm thread and checking for the
option in migrations but letting this be as simple as possible for the
first pass.

Signed-off-by: William Douglas <william.douglas@intel.com>