### PR TITLE
github: Install missing musl tools

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
+      - name: Install musl-gcc
+        run: sudo apt install -y musl-tools      
       - name: Create release directory
         run: rsync -rv --exclude=.git . ../cloud-hypervisor-${{ github.event.ref }}
       - name: Install Rust toolchain (x86_64-unknown-linux-gnu)


### PR DESCRIPTION
Needed since:

commit 0ab4097606000181d0763a376cdc05011243ecc2
Author: Bo Chen <chen.bo@intel.com>
Date:   Thu Feb 10 18:29:53 2022 -0800

    test_infra: Enable cross-build for "musl" and "aarch64" targets

    With enabling the `vendered-openssl` feature, we can now cross-build the
    `test_infra` crate for  "musl" and "aarch64" targets. In this way, we
    can remove the `test_infra` crate from the "exclude" list, so that this
    crate can be checked and processed by "cargo clippy" and "cargo fmt".

    More details can be found: https://docs.rs/openssl/latest/openssl/#vendored

    As 'musl-gcc' is required, this commit also installs the `musl-tools`
    package for our "build" github action on the musl target [1].

    [1] https://github.com/actions-rs/toolchain/issues/102

    Signed-off-by: Bo Chen <chen.bo@intel.com>

Signed-off-by: Rob Bradford <robert.bradford@intel.com>