### PR TITLE
build: Use single version of vhost-user-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,21 +1173,6 @@ dependencies = [
 [[package]]
 name = "vhost-user-backend"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8db00e93514caa8987bb8b536fe962c9b66b4068583abc4c531eb97988477cd"
-dependencies = [
- "libc",
- "log",
- "vhost",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
-]
-
-[[package]]
-name = "vhost-user-backend"
-version = "0.1.0"
 source = "git+https://github.com/rust-vmm/vhost-user-backend?branch=main#bbc892ba4526bdf8101252f7aa51832d1f2eeabd"
 dependencies = [
  "libc",
@@ -1212,7 +1197,7 @@ dependencies = [
  "option_parser",
  "qcow",
  "vhost",
- "vhost-user-backend 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend",
  "virtio-bindings",
  "vm-memory",
  "vmm-sys-util",
@@ -1230,7 +1215,7 @@ dependencies = [
  "net_util",
  "option_parser",
  "vhost",
- "vhost-user-backend 0.1.0 (git+https://github.com/rust-vmm/vhost-user-backend?branch=main)",
+ "vhost-user-backend",
  "virtio-bindings",
  "vm-memory",
  "vmm-sys-util",

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4.14"
 option_parser = { path = "../option_parser" }
 qcow = { path = "../qcow" }
 vhost = { version = "0.3.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.1.0"
+vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", branch = "main" }
 virtio-bindings = "0.1.0"
 vm-memory = "0.7.0"
 vmm-sys-util = "0.9.0"


### PR DESCRIPTION
Using multiple different versions breaks vendoring.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>