### PR TITLE
arch: do not hardcode MMIO region length in MmioDeviceInfo

### DIFF
--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -158,6 +158,7 @@ impl fmt::Display for DeviceType {
 #[cfg(target_arch = "aarch64")]
 pub struct MmioDeviceInfo {
     pub addr: u64,
+    pub len: u64,
     pub irq: u32,
 }
 
@@ -180,6 +181,6 @@ impl DeviceInfoForFdt for MmioDeviceInfo {
         self.irq
     }
     fn length(&self) -> u64 {
-        4096
+        self.len
     }
 }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1527,6 +1527,7 @@ impl DeviceManager {
             (DeviceType::Rtc, "rtc".to_string()),
             MmioDeviceInfo {
                 addr: addr.0,
+                len: MMIO_LEN,
                 irq: rtc_irq,
             },
         );
@@ -1568,6 +1569,7 @@ impl DeviceManager {
             (DeviceType::Gpio, "gpio".to_string()),
             MmioDeviceInfo {
                 addr: addr.0,
+                len: MMIO_LEN,
                 irq: gpio_irq,
             },
         );
@@ -1671,6 +1673,7 @@ impl DeviceManager {
             (DeviceType::Serial, DeviceType::Serial.to_string()),
             MmioDeviceInfo {
                 addr: addr.0,
+                len: MMIO_LEN,
                 irq: serial_irq,
             },
         );

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2997,17 +2997,23 @@ mod tests {
                 (DeviceType::Serial, DeviceType::Serial.to_string()),
                 MmioDeviceInfo {
                     addr: 0x00,
+                    len: LEN,
                     irq: 33,
                 },
             ),
             (
                 (DeviceType::Virtio(1), "virtio".to_string()),
-                MmioDeviceInfo { addr: LEN, irq: 34 },
+                MmioDeviceInfo {
+                    addr: LEN,
+                    len: LEN,
+                    irq: 34,
+                },
             ),
             (
                 (DeviceType::Rtc, "rtc".to_string()),
                 MmioDeviceInfo {
                     addr: 2 * LEN,
+                    len: LEN,
                     irq: 35,
                 },
             ),


### PR DESCRIPTION
Add a field for its length and fix up users.

Things work just because all hardcoded values agree with each other.
This is prone to breakage.

No functional change.

Signed-off-by: Wei Liu <liuwe@microsoft.com>