### PR TITLE
scripts: Pass-through '--test-filter' option to `performance-metrics`

### DIFF
--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -88,7 +88,7 @@ echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 export RUST_BACKTRACE=1
-time target/$BUILD_TARGET/release/performance-metrics ${test_binary_args[*]}
+time target/$BUILD_TARGET/release/performance-metrics ${test_binary_args[*]} --test-filter $test_filter
 RES=$?
 
 exit $RES


### PR DESCRIPTION
To be consistently with the integration scripts, we now pass through the
`--test-filter` option of the test scripts to the `performance-metrics`
binary. Now the following two commands achieve the same results:

`$./scripts/dev_cli.sh tests --metrics -- --test-filter boot_time_ -- --test-filter latency`
`$./scripts/dev_cli.sh tests --metrics -- -- --test-filter boot_time_ --test-filter latency`

Note that, the test scripts support only single occurrence of the
`--test-filter` option while the `performance-metrics` binary allows
multiple occurrences for filtering based on different keywords.

Fixes: #3787

Signed-off-by: Bo Chen <chen.bo@intel.com>