### PR TITLE
Revert "scripts: Pass-through '--test-filter' option to `performance-metrics`"

### DIFF
--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -88,7 +88,7 @@ echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 export RUST_BACKTRACE=1
-time target/$BUILD_TARGET/release/performance-metrics ${test_binary_args[*]} --test-filter $test_filter
+time target/$BUILD_TARGET/release/performance-metrics ${test_binary_args[*]}
 RES=$?
 
 exit $RES


### PR DESCRIPTION
Reverts cloud-hypervisor/cloud-hypervisor#3803