### PR TITLE
deps: Move to latest vm-virtio and vhost-user-backend releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,8 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vhost-user-backend?branch=main#6e66d2c1a4c460fa7306bd890e7a99e64a0254d6"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf4c8d6fc1560ac01051bd09b744887665b25adeb390bb7de6bbfb4d2ad8b12"
 dependencies = [
  "libc",
  "log",
@@ -1263,8 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vm-virtio?branch=main#bbb22d43558a76cc7cc9c262c4be870a9e682a86"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3785325315e6496fa88673842ee6cd198b9658e88e8b0e1ad48a5dc818b221dc"
 dependencies = [
  "log",
  "vm-memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ clap = { version = "3.1.5", features = ["wrap_help"] }
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0-tdx" }
 kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "main" }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
-virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio", branch = "main" }
 
 [dev-dependencies]
 dirs = "4.0.0"

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -17,7 +17,7 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vhdx = { path = "../vhdx" }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio", branch = "main" }
+virtio-queue = "0.2.0"
 vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -865,7 +865,8 @@ dependencies = [
 [[package]]
 name = "virtio-queue"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vm-virtio?branch=main#c1c4c0397809991e2149d8bc3591bca65082e53b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3785325315e6496fa88673842ee6cd198b9658e88e8b0e1ad48a5dc818b221dc"
 dependencies = [
  "log",
  "vm-memory",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,7 +16,7 @@ qcow = { path = "../qcow" }
 seccompiler = "0.2.0"
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio", branch = "main" }
+virtio-queue = "0.2.0"
 vmm-sys-util = "0.9.0"
 vm-virtio = { path = "../vm-virtio" }
 vm-memory = "0.7.0"

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -15,7 +15,7 @@ serde = "1.0.136"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 virtio-bindings = "0.1.0"
-virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio", branch = "main" }
+virtio-queue = "0.2.0"
 vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4.14"
 option_parser = { path = "../option_parser" }
 qcow = { path = "../qcow" }
 vhost = { version = "0.3.0", features = ["vhost-user-slave"] }
-vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", branch = "main" }
+vhost-user-backend = "0.2.0"
 virtio-bindings = "0.1.0"
 vm-memory = "0.7.0"
 vmm-sys-util = "0.9.0"

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4.14"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
 vhost = { version = "0.3.0", features = ["vhost-user-slave"] }
-vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", branch = "main" }
+vhost-user-backend = "0.2.0"
 virtio-bindings = "0.1.0"
 vm-memory = "0.7.0"
 vmm-sys-util = "0.9.0"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -30,7 +30,7 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vhost = { version = "0.3.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern"] }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio", branch = "main" }
+virtio-queue = "0.2.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -10,5 +10,5 @@ default = []
 [dependencies]
 log = "0.4.14"
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio", branch = "main" }
+virtio-queue = "0.2.0"
 vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -50,7 +50,7 @@ vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", defau
 vfio_user = { path = "../vfio_user" }
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio", branch = "main" }
+virtio-queue = "0.2.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }


### PR DESCRIPTION
Move to release version v0.2.0 for both vm-virtio and vhost-user-backend
crates rather than relying on their main branch, as they might be
subject to breaking changes.

Fixes #3800

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>