### PR TITLE
.github: Avoid excessive rebase & rebuilds from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 3
+  open-pull-requests-limit: 1
   allow:
   - dependency-type: direct
   - dependency-type: indirect
@@ -12,7 +12,7 @@ updates:
   directory: "/fuzz"
   schedule:
     interval: daily
-  open-pull-requests-limit: 3
+  open-pull-requests-limit: 1
   allow:
   - dependency-type: direct
   - dependency-type: indirect


### PR DESCRIPTION
Reduce the number of open pull requests dependabot will create to avoid
excessive rebase and rebuilds of PRs. This avoids a situation with a 2nd
PR being rebased after a 1st is merged resulting in a wasteful rebuild.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>