### PR TITLE
arch: x86_64: Write EBDA address to BIOS data area

### DIFF
--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -24,6 +24,9 @@ pub const LOW_RAM_START: GuestAddress = GuestAddress(0x0);
 
 // == Fixed addresses within the "Low RAM" range: ==
 
+// Location of EBDA address
+pub const EBDA_POINTER: GuestAddress = GuestAddress(0x40e);
+
 // Initial GDT/IDT needed to boot kernel
 pub const BOOT_GDT_START: GuestAddress = GuestAddress(0x500);
 pub const BOOT_IDT_START: GuestAddress = GuestAddress(0x520);

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -186,6 +186,9 @@ pub enum Error {
 
     /// Error checking CPUID compatibility
     CpuidCheckCompatibility,
+
+    // Error writing EBDA address
+    EbdaSetup(vm_memory::GuestMemoryError),
 }
 
 impl From<Error> for super::Error {
@@ -802,6 +805,11 @@ pub fn configure_system(
     rsdp_addr: Option<GuestAddress>,
     sgx_epc_region: Option<SgxEpcRegion>,
 ) -> super::Result<()> {
+    // Write EBDA address to location where ACPICA expects to find it
+    guest_mem
+        .write_obj((layout::EBDA_START.0 >> 4) as u16, layout::EBDA_POINTER)
+        .map_err(Error::EbdaSetup)?;
+
     let size = smbios::setup_smbios(guest_mem).map_err(Error::SmbiosSetup)?;
 
     // Place the MP table after the SMIOS table aligned to 16 bytes


### PR DESCRIPTION
This allows ACPICA to find the EBDA and load the ACPI tables when
scanning for them.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>