### PR TITLE
API: fix http hang for vmm.ping/vm.create/vm.info/vmm.shutdown

### DIFF
--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -54,7 +54,7 @@ impl EndpointHandler for VmCreate {
                 }
             }
 
-            _ => Response::new(Version::Http11, StatusCode::BadRequest),
+            _ => error_response(HttpError::BadRequest, StatusCode::BadRequest),
         }
     }
 }
@@ -237,7 +237,7 @@ impl EndpointHandler for VmInfo {
                 }
                 Err(e) => error_response(e, StatusCode::InternalServerError),
             },
-            _ => Response::new(Version::Http11, StatusCode::BadRequest),
+            _ => error_response(HttpError::BadRequest, StatusCode::BadRequest),
         }
     }
 }
@@ -263,7 +263,8 @@ impl EndpointHandler for VmmPing {
                 }
                 Err(e) => error_response(e, StatusCode::InternalServerError),
             },
-            _ => Response::new(Version::Http11, StatusCode::BadRequest),
+
+            _ => error_response(HttpError::BadRequest, StatusCode::BadRequest),
         }
     }
 }
@@ -285,7 +286,7 @@ impl EndpointHandler for VmmShutdown {
                     Err(e) => error_response(e, StatusCode::InternalServerError),
                 }
             }
-            _ => Response::new(Version::Http11, StatusCode::BadRequest),
+            _ => error_response(HttpError::BadRequest, StatusCode::BadRequest),
         }
     }
 }


### PR DESCRIPTION
vmm.ping/vm.info will hang for PUT method, vm.create/vmm.shutdonw hang for GET method.
Because these four APIs do not write the response body when the HTTP method does not match.

Signed-off-by: LiHui <andrewli@kubesphere.io>