### PR TITLE
Enable performance-metrics tests on AArch64

### DIFF
--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -447,8 +447,16 @@ fn main() {
         )
         .get_matches();
 
+    // It seems that the tool (ethr) used for testing the virtio-net latency
+    // is not stable on AArch64, and therefore the latency test is currently
+    // skipped on AArch64.
+    let test_list: Vec<&PerformanceTest> = TEST_LIST
+        .iter()
+        .filter(|t| !(cfg!(target_arch = "aarch64") && t.name == "virtio_net_latency_us"))
+        .collect();
+
     if cmd_arguments.is_present("list-tests") {
-        for test in TEST_LIST.iter() {
+        for test in test_list.iter() {
             println!("\"{}\" ({})", test.name, test.control);
         }
 
@@ -465,7 +473,7 @@ fn main() {
 
     init_tests();
 
-    for test in TEST_LIST.iter() {
+    for test in test_list.iter() {
         if test_filter.is_empty() || test_filter.iter().any(|&s| test.name.contains(s)) {
             match run_test_with_timeout(test) {
                 Ok(r) => {

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -11,46 +11,6 @@ WORKLOADS_LOCK="$WORKLOADS_DIR/integration_test.lock"
 
 mkdir -p "$WORKLOADS_DIR"
 
-# Checkout source code of a GIT repo with specified branch and commit
-# Args:
-#   $1: Target directory
-#   $2: GIT URL of the repo
-#   $3: Required branch
-#   $4: Required commit (optional)
-checkout_repo() {
-    SRC_DIR="$1"
-    GIT_URL="$2"
-    GIT_BRANCH="$3"
-    GIT_COMMIT="$4"
-
-    # Check whether the local HEAD commit same as the requested commit or not.
-    # If commit is not specified, compare local HEAD and remote HEAD.
-    # Remove the folder if there is difference.
-    if [ -d "$SRC_DIR" ]; then
-        pushd $SRC_DIR
-        git fetch
-        SRC_LOCAL_COMMIT=$(git rev-parse HEAD)
-        if [ -z "$GIT_COMMIT" ]; then
-            GIT_COMMIT=$(git rev-parse remotes/origin/"$GIT_BRANCH")
-        fi
-        popd
-        if [ "$SRC_LOCAL_COMMIT" != "$GIT_COMMIT" ]; then
-            rm -rf "$SRC_DIR"
-        fi
-    fi
-
-    # Checkout the specified branch and commit (if required)
-    if [ ! -d "$SRC_DIR" ]; then
-        git clone --depth 1 "$GIT_URL" -b "$GIT_BRANCH" "$SRC_DIR"
-        if [ "$GIT_COMMIT" ]; then
-            pushd "$SRC_DIR"
-            git fetch --depth 1 origin "$GIT_COMMIT"
-            git reset --hard FETCH_HEAD
-            popd
-        fi
-    fi
-}
-
 build_custom_linux() {
     SRCDIR=$PWD
     LINUX_CUSTOM_DIR="$WORKLOADS_DIR/linux-custom"

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -4,7 +4,9 @@ set -x
 source $HOME/.cargo/env
 source $(dirname "$0")/test-util.sh
 
-export BUILD_TARGET=${BUILD_TARGET-x86_64-unknown-linux-gnu}
+export TEST_ARCH=$(uname -m)
+export BUILD_TARGET=${BUILD_TARGET-${TEST_ARCH}-unknown-linux-gnu}
+
 
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
@@ -18,9 +20,14 @@ if [ "$hypervisor" = "mshv" ]; then
     features="--no-default-features --features mshv,common"
 fi
 
-cp scripts/sha1sums-x86_64 $WORKLOADS_DIR
+cp scripts/sha1sums-${TEST_ARCH} $WORKLOADS_DIR
 
-FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
+if [ ${TEST_ARCH} == "aarch64" ]; then
+     FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-arm64-custom-20210929-0.qcow2"
+else
+     FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
+fi
+
 FOCAL_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$FOCAL_OS_IMAGE_NAME"
 FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_IMAGE" ]; then
@@ -29,7 +36,12 @@ if [ ! -f "$FOCAL_OS_IMAGE" ]; then
     popd
 fi
 
-FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.raw"
+if [ ${TEST_ARCH} == "aarch64" ]; then
+    FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-arm64-custom-20210929-0.raw"
+else
+    FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.raw"
+fi
+
 FOCAL_OS_RAW_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_RAW_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_RAW_IMAGE" ]; then
     pushd $WORKLOADS_DIR
@@ -38,7 +50,7 @@ if [ ! -f "$FOCAL_OS_RAW_IMAGE" ]; then
 fi
 
 pushd $WORKLOADS_DIR
-grep focal sha1sums-x86_64 | sha1sum --check
+grep focal sha1sums-${TEST_ARCH} | sha1sum --check
 if [ $? -ne 0 ]; then
     echo "sha1sum validation of images failed, remove invalid images to fix the issue."
     exit 1
@@ -46,7 +58,11 @@ fi
 popd
 
 # Build custom kernel based on virtio-pmem and virtio-fs upstream patches
-VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
+if [ ${TEST_ARCH} == "aarch64" ]; then
+       VMLINUX_IMAGE="$WORKLOADS_DIR/Image"
+else
+       VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
+fi
 
 LINUX_CUSTOM_DIR="$WORKLOADS_DIR/linux-custom"
 
@@ -54,14 +70,19 @@ if [ ! -f "$VMLINUX_IMAGE" ]; then
     SRCDIR=$PWD
     pushd $WORKLOADS_DIR
     time git clone --depth 1 "https://github.com/cloud-hypervisor/linux.git" -b "ch-5.15.12" $LINUX_CUSTOM_DIR
-    cp $SRCDIR/resources/linux-config-x86_64 $LINUX_CUSTOM_DIR/.config
+    cp $SRCDIR/resources/linux-config-${TEST_ARCH} $LINUX_CUSTOM_DIR/.config
     popd
 fi
 
 if [ ! -f "$VMLINUX_IMAGE" ]; then
     pushd $LINUX_CUSTOM_DIR
-    time make bzImage -j $(nproc)
-    cp vmlinux $VMLINUX_IMAGE || exit 1
+    if [ ${TEST_ARCH} == "x86_64" ]; then
+       make bzImage -j `nproc`
+       cp vmlinux $VMLINUX_IMAGE || exit 1
+    elif [ ${TEST_ARCH} == "aarch64" ]; then
+       make Image -j `nproc`
+       cp arch/arm64/boot/Image $VMLINUX_IMAGE || exit 1
+    fi
     popd
 fi
 
@@ -69,12 +90,12 @@ if [ -d "$LINUX_CUSTOM_DIR" ]; then
     rm -rf $LINUX_CUSTOM_DIR
 fi
 
-BUILD_TARGET="$(uname -m)-unknown-linux-${CH_LIBC}"
+BUILD_TARGET="${TEST_ARCH}-unknown-linux-${CH_LIBC}"
 CFLAGS=""
 TARGET_CC=""
-if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
+if [[ "${BUILD_TARGET}" == "${TEST_ARCH}-unknown-linux-musl" ]]; then
     TARGET_CC="musl-gcc"
-    CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
+    CFLAGS="-I /usr/include/${TEST_ARCH}-linux-musl/ -idirafter /usr/include/"
 fi
 
 cargo build --all --release $features --target $BUILD_TARGET

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -2,6 +2,46 @@
 hypervisor="kvm"
 test_filter=""
 
+# Checkout source code of a GIT repo with specified branch and commit
+# Args:
+#   $1: Target directory
+#   $2: GIT URL of the repo
+#   $3: Required branch
+#   $4: Required commit (optional)
+checkout_repo() {
+    SRC_DIR="$1"
+    GIT_URL="$2"
+    GIT_BRANCH="$3"
+    GIT_COMMIT="$4"
+
+    # Check whether the local HEAD commit same as the requested commit or not.
+    # If commit is not specified, compare local HEAD and remote HEAD.
+    # Remove the folder if there is difference.
+    if [ -d "$SRC_DIR" ]; then
+        pushd $SRC_DIR
+        git fetch
+        SRC_LOCAL_COMMIT=$(git rev-parse HEAD)
+        if [ -z "$GIT_COMMIT" ]; then
+            GIT_COMMIT=$(git rev-parse remotes/origin/"$GIT_BRANCH")
+        fi
+        popd
+        if [ "$SRC_LOCAL_COMMIT" != "$GIT_COMMIT" ]; then
+            rm -rf "$SRC_DIR"
+        fi
+    fi
+
+    # Checkout the specified branch and commit (if required)
+    if [ ! -d "$SRC_DIR" ]; then
+        git clone --depth 1 "$GIT_URL" -b "$GIT_BRANCH" "$SRC_DIR"
+        if [ "$GIT_COMMIT" ]; then
+            pushd "$SRC_DIR"
+            git fetch --depth 1 origin "$GIT_COMMIT"
+            git reset --hard FETCH_HEAD
+            popd
+        fi
+    fi
+}
+
 cmd_help() {
     echo ""
     echo "Cloud Hypervisor $(basename $0)"


### PR DESCRIPTION
Enable current performance-metrics tests on arm64.

boot up time test: trap from guest to vmm base on pl011 reserved mmio region. this need support from guest kernel, so using a temporary linux branch which will be removed on merge.
fio test: build fio from source code as the default one doesn't work well with iouring on arm64.
network latency test: build ethr from source code as there is no such binary for arm64 and do some twists to let the test work as ethr is not stable on arm64.

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>