### PR TITLE
virtio-devices: net: Tweaks and improvements

### DIFF
--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -60,7 +60,7 @@ impl CtrlQueue {
         &mut self,
         queue: &mut Queue<GuestMemoryAtomic<GuestMemoryMmap>>,
         access_platform: Option<&Arc<dyn AccessPlatform>>,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         let mut used_desc_heads = Vec::new();
         loop {
             for mut desc_chain in queue.iter().map_err(Error::QueueIterator)? {
@@ -156,7 +156,7 @@ impl CtrlQueue {
             }
         }
 
-        Ok(!used_desc_heads.is_empty())
+        Ok(())
     }
 }
 

--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -62,92 +62,98 @@ impl CtrlQueue {
         access_platform: Option<&Arc<dyn AccessPlatform>>,
     ) -> Result<bool> {
         let mut used_desc_heads = Vec::new();
-        for mut desc_chain in queue.iter().map_err(Error::QueueIterator)? {
-            let ctrl_desc = desc_chain.next().ok_or(Error::NoControlHeaderDescriptor)?;
+        loop {
+            for mut desc_chain in queue.iter().map_err(Error::QueueIterator)? {
+                let ctrl_desc = desc_chain.next().ok_or(Error::NoControlHeaderDescriptor)?;
 
-            let ctrl_hdr: ControlHeader = desc_chain
-                .memory()
-                .read_obj(
-                    ctrl_desc
-                        .addr()
-                        .translate(access_platform, ctrl_desc.len() as usize),
-                )
-                .map_err(Error::GuestMemory)?;
-            let data_desc = desc_chain.next().ok_or(Error::NoDataDescriptor)?;
+                let ctrl_hdr: ControlHeader = desc_chain
+                    .memory()
+                    .read_obj(
+                        ctrl_desc
+                            .addr()
+                            .translate(access_platform, ctrl_desc.len() as usize),
+                    )
+                    .map_err(Error::GuestMemory)?;
+                let data_desc = desc_chain.next().ok_or(Error::NoDataDescriptor)?;
 
-            let data_desc_addr = data_desc
-                .addr()
-                .translate(access_platform, data_desc.len() as usize);
+                let data_desc_addr = data_desc
+                    .addr()
+                    .translate(access_platform, data_desc.len() as usize);
 
-            let status_desc = desc_chain.next().ok_or(Error::NoStatusDescriptor)?;
+                let status_desc = desc_chain.next().ok_or(Error::NoStatusDescriptor)?;
 
-            let ok = match u32::from(ctrl_hdr.class) {
-                VIRTIO_NET_CTRL_MQ => {
-                    let queue_pairs = desc_chain
-                        .memory()
-                        .read_obj::<u16>(data_desc_addr)
-                        .map_err(Error::GuestMemory)?;
-                    if u32::from(ctrl_hdr.cmd) != VIRTIO_NET_CTRL_MQ_VQ_PAIRS_SET {
-                        warn!("Unsupported command: {}", ctrl_hdr.cmd);
-                        false
-                    } else if (queue_pairs < VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MIN as u16)
-                        || (queue_pairs > VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MAX as u16)
-                    {
-                        warn!("Number of MQ pairs out of range: {}", queue_pairs);
-                        false
-                    } else {
-                        info!("Number of MQ pairs requested: {}", queue_pairs);
-                        true
-                    }
-                }
-                VIRTIO_NET_CTRL_GUEST_OFFLOADS => {
-                    let features = desc_chain
-                        .memory()
-                        .read_obj::<u64>(data_desc_addr)
-                        .map_err(Error::GuestMemory)?;
-                    if u32::from(ctrl_hdr.cmd) != VIRTIO_NET_CTRL_GUEST_OFFLOADS_SET {
-                        warn!("Unsupported command: {}", ctrl_hdr.cmd);
-                        false
-                    } else {
-                        let mut ok = true;
-                        for tap in self.taps.iter_mut() {
-                            info!("Reprogramming tap offload with features: {}", features);
-                            tap.set_offload(virtio_features_to_tap_offload(features))
-                                .map_err(|e| {
-                                    error!("Error programming tap offload: {:?}", e);
-                                    ok = false
-                                })
-                                .ok();
+                let ok = match u32::from(ctrl_hdr.class) {
+                    VIRTIO_NET_CTRL_MQ => {
+                        let queue_pairs = desc_chain
+                            .memory()
+                            .read_obj::<u16>(data_desc_addr)
+                            .map_err(Error::GuestMemory)?;
+                        if u32::from(ctrl_hdr.cmd) != VIRTIO_NET_CTRL_MQ_VQ_PAIRS_SET {
+                            warn!("Unsupported command: {}", ctrl_hdr.cmd);
+                            false
+                        } else if (queue_pairs < VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MIN as u16)
+                            || (queue_pairs > VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MAX as u16)
+                        {
+                            warn!("Number of MQ pairs out of range: {}", queue_pairs);
+                            false
+                        } else {
+                            info!("Number of MQ pairs requested: {}", queue_pairs);
+                            true
                         }
-                        ok
                     }
-                }
-                _ => {
-                    warn!("Unsupported command {:?}", ctrl_hdr);
-                    false
-                }
-            };
+                    VIRTIO_NET_CTRL_GUEST_OFFLOADS => {
+                        let features = desc_chain
+                            .memory()
+                            .read_obj::<u64>(data_desc_addr)
+                            .map_err(Error::GuestMemory)?;
+                        if u32::from(ctrl_hdr.cmd) != VIRTIO_NET_CTRL_GUEST_OFFLOADS_SET {
+                            warn!("Unsupported command: {}", ctrl_hdr.cmd);
+                            false
+                        } else {
+                            let mut ok = true;
+                            for tap in self.taps.iter_mut() {
+                                info!("Reprogramming tap offload with features: {}", features);
+                                tap.set_offload(virtio_features_to_tap_offload(features))
+                                    .map_err(|e| {
+                                        error!("Error programming tap offload: {:?}", e);
+                                        ok = false
+                                    })
+                                    .ok();
+                            }
+                            ok
+                        }
+                    }
+                    _ => {
+                        warn!("Unsupported command {:?}", ctrl_hdr);
+                        false
+                    }
+                };
 
-            desc_chain
-                .memory()
-                .write_obj(
-                    if ok { VIRTIO_NET_OK } else { VIRTIO_NET_ERR } as u8,
-                    status_desc
-                        .addr()
-                        .translate(access_platform, status_desc.len() as usize),
-                )
-                .map_err(Error::GuestMemory)?;
-            let len = ctrl_desc.len() + data_desc.len() + status_desc.len();
-            used_desc_heads.push((desc_chain.head_index(), len));
-        }
+                desc_chain
+                    .memory()
+                    .write_obj(
+                        if ok { VIRTIO_NET_OK } else { VIRTIO_NET_ERR } as u8,
+                        status_desc
+                            .addr()
+                            .translate(access_platform, status_desc.len() as usize),
+                    )
+                    .map_err(Error::GuestMemory)?;
+                let len = ctrl_desc.len() + data_desc.len() + status_desc.len();
+                used_desc_heads.push((desc_chain.head_index(), len));
+            }
 
-        for (desc_index, len) in used_desc_heads.iter() {
-            queue
-                .add_used(*desc_index, *len)
-                .map_err(Error::QueueAddUsed)?;
-            queue
+            for (desc_index, len) in used_desc_heads.iter() {
+                queue
+                    .add_used(*desc_index, *len)
+                    .map_err(Error::QueueAddUsed)?;
+            }
+
+            if !queue
                 .enable_notification()
-                .map_err(Error::QueueEnableNotification)?;
+                .map_err(Error::QueueEnableNotification)?
+            {
+                break;
+            }
         }
 
         Ok(!used_desc_heads.is_empty())

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -130,9 +130,12 @@ impl TxVirtio {
             queue
                 .add_used(used_desc_head.0, used_desc_head.1)
                 .map_err(NetQueuePairError::QueueAddUsed)?;
-            queue
+            if !queue
                 .enable_notification()
-                .map_err(NetQueuePairError::QueueEnableNotification)?;
+                .map_err(NetQueuePairError::QueueEnableNotification)?
+            {
+                break;
+            }
         }
 
         Ok(retry_write)
@@ -275,9 +278,12 @@ impl RxVirtio {
             queue
                 .add_used(used_desc_head.0, used_desc_head.1)
                 .map_err(NetQueuePairError::QueueAddUsed)?;
-            queue
+            if !queue
                 .enable_notification()
-                .map_err(NetQueuePairError::QueueEnableNotification)?;
+                .map_err(NetQueuePairError::QueueEnableNotification)?
+            {
+                break;
+            }
         }
 
         Ok(exhausted_descs)

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -53,8 +53,8 @@ pub struct NetCtrlEpollHandler {
     pub queue_evt: EventFd,
     pub queue: Queue<GuestMemoryAtomic<GuestMemoryMmap>>,
     pub access_platform: Option<Arc<dyn AccessPlatform>>,
-    interrupt_cb: Arc<dyn VirtioInterrupt>,
-    queue_index: u16,
+    pub interrupt_cb: Arc<dyn VirtioInterrupt>,
+    pub queue_index: u16,
 }
 
 impl NetCtrlEpollHandler {

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -568,18 +568,18 @@ impl VirtioDevice for Net {
         let num_queues = queues.len();
         let event_idx = self.common.feature_acked(VIRTIO_RING_F_EVENT_IDX.into());
         if self.common.feature_acked(VIRTIO_NET_F_CTRL_VQ.into()) && num_queues % 2 != 0 {
-            let mut cvq_queue = queues.remove(num_queues - 1);
-            let cvq_queue_evt = queue_evts.remove(num_queues - 1);
+            let mut ctrl_queue = queues.remove(num_queues - 1);
+            let ctrl_queue_evt = queue_evts.remove(num_queues - 1);
 
-            cvq_queue.set_event_idx(event_idx);
+            ctrl_queue.set_event_idx(event_idx);
 
             let (kill_evt, pause_evt) = self.common.dup_eventfds();
             let mut ctrl_handler = NetCtrlEpollHandler {
                 kill_evt,
                 pause_evt,
                 ctrl_q: CtrlQueue::new(self.taps.clone()),
-                queue: cvq_queue,
-                queue_evt: cvq_queue_evt,
+                queue: ctrl_queue,
+                queue_evt: ctrl_queue_evt,
                 access_platform: self.common.access_platform.clone(),
             };
 

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -75,19 +75,19 @@ impl EpollHelperHandler for NetCtrlEpollHandler {
         match ev_type {
             CTRL_QUEUE_EVENT => {
                 if let Err(e) = self.queue_evt.read() {
-                    error!("failed to get ctl queue event: {:?}", e);
+                    error!("Failed to get control queue event: {:?}", e);
                     return true;
                 }
                 if let Err(e) = self
                     .ctrl_q
                     .process(&mut self.queue, self.access_platform.as_ref())
                 {
-                    error!("failed to process ctrl queue: {:?}", e);
+                    error!("Failed to process control queue: {:?}", e);
                     return true;
                 }
             }
             _ => {
-                error!("Unknown event for virtio-net");
+                error!("Unknown event for virtio-net control queue");
                 return true;
             }
         }

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -565,11 +565,11 @@ impl VirtioDevice for Net {
     ) -> ActivateResult {
         self.common.activate(&queues, &queue_evts, &interrupt_cb)?;
 
-        let queue_num = queues.len();
+        let num_queues = queues.len();
         let event_idx = self.common.feature_acked(VIRTIO_RING_F_EVENT_IDX.into());
-        if self.common.feature_acked(VIRTIO_NET_F_CTRL_VQ.into()) && queue_num % 2 != 0 {
-            let mut cvq_queue = queues.remove(queue_num - 1);
-            let cvq_queue_evt = queue_evts.remove(queue_num - 1);
+        if self.common.feature_acked(VIRTIO_NET_F_CTRL_VQ.into()) && num_queues % 2 != 0 {
+            let mut cvq_queue = queues.remove(num_queues - 1);
+            let cvq_queue_evt = queue_evts.remove(num_queues - 1);
 
             cvq_queue.set_event_idx(event_idx);
 


### PR DESCRIPTION
* Use `Queue::enable_notifications()` as advised in documentation
* Generate control queue interrupt if necessary
* Use virtio-net implementation of `NetCtrlEpollHandler` inside vhost-user-net