### PR TITLE
vfio_user: Shutdown the communication with the backend

### DIFF
--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -506,6 +506,10 @@ impl Drop for VfioUserPciDevice {
         if self.common.interrupt.intx_in_use() {
             self.common.disable_intx(&self.vfio_wrapper);
         }
+
+        if let Err(e) = self.client.lock().unwrap().shutdown() {
+            error!("Failed shutting down vfio-user client: {}", e);
+        }
     }
 }
 

--- a/vfio_user/src/lib.rs
+++ b/vfio_user/src/lib.rs
@@ -255,6 +255,8 @@ pub enum Error {
     StreamWrite(#[source] std::io::Error),
     #[error("Error reading from stream: {0}")]
     StreamRead(#[source] std::io::Error),
+    #[error("Error shutting down stream: {0}")]
+    StreamShutdown(#[source] std::io::Error),
     #[error("Error writing with file descriptors: {0}")]
     SendWithFd(#[source] vmm_sys_util::errno::Error),
     #[error("Error reading with file descriptors: {0}")]
@@ -664,5 +666,11 @@ impl Client {
 
     pub fn resettable(&self) -> bool {
         self.resettable
+    }
+
+    pub fn shutdown(&self) -> Result<(), Error> {
+        self.stream
+            .shutdown(std::net::Shutdown::Both)
+            .map_err(Error::StreamShutdown)
     }
 }


### PR DESCRIPTION
Whenever a vfio-user device is dropped, the communication between the
VMM and the backend should be shutdown.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>