### PR TITLE
Improve virtio-iommu & dedicated IOMMU segment handling

### DIFF
--- a/docs/iommu.md
+++ b/docs/iommu.md
@@ -231,3 +231,38 @@ Last thing is to start the L2 guest with the huge pages memory backend.
     --cmdline "console=ttyS0 console=hvc0 root=/dev/vda1 rw" \
     --device path=/sys/bus/pci/devices/0000:00:04.0
 ```
+
+### Dedicated IOMMU PCI segments
+
+To facilitate hotplug of devices that require being behind an IOMMU it is
+possible to mark entire PCI segments as behind the IOMMU.
+
+This is accomplished through `--platform
+num_pci_segments=<number_of_segments>,iommu_segments=<range of segments>` or
+via the equivalents in `PlatformConfig` for the API.
+
+e.g.
+
+```bash
+./cloud-hypervisor \
+    --api-socket=/tmp/api \
+    --cpus boot=1 \
+    --memory size=4G,hugepages=on \
+    --disk path=focal-server-cloudimg-amd64.raw \
+    --kernel custom-vmlinux \
+    --cmdline "console=ttyS0 console=hvc0 root=/dev/vda1 rw" \
+    --platform num_pci_segments=2,iommu_segments=1
+```
+
+This adds a second PCI segment to the platform behind the IOMMU. A VFIO device
+requiring the IOMMU then may be hotplugged:
+
+e.g.
+
+```bash
+./ch-remote --api-socket=/tmp/api add-device path=/sys/bus/pci/devices/0000:00:04.0,iommu=on,pci_segment=1
+```
+
+Devices that cannot be placed behind an IOMMU (e.g. lacking an `iommu=` option)
+cannot be placed on the IOMMU segments.
+

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2130,7 +2130,13 @@ mod parallel {
             let (cmd_success, cmd_output) = remote_command_w_output(
                 &api_socket,
                 "add-disk",
-                Some(format!("path={},id=test0,pci_segment=1", test_disk_path.as_str()).as_str()),
+                Some(
+                    format!(
+                        "path={},id=test0,pci_segment=1,iommu=on",
+                        test_disk_path.as_str()
+                    )
+                    .as_str(),
+                ),
             );
             assert!(cmd_success);
             assert!(String::from_utf8_lossy(&cmd_output)

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2306,6 +2306,12 @@ impl VmConfig {
             }
         }
 
+        if let Some(vdpa_devices) = &self.vdpa {
+            for vdpa_device in vdpa_devices {
+                vdpa_device.validate(self)?;
+            }
+        }
+
         if let Some(balloon) = &self.balloon {
             let mut ram_size = self.memory.size;
 


### PR DESCRIPTION
* Return an error if trying to hotplug a device behind an IOMMU when not using an IOMMU segment
* Validate configuration for devices on IOMMU segments to ensure they are fully behind the IOMMU
* Actually setup mappings for virtio devices that are actually behind the IOMMU when hotplugged.