### PR TITLE
hypervisor: mshv: fix a comment

### DIFF
--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -134,7 +134,7 @@ impl hypervisor::Hypervisor for MshvHypervisor {
     }
     #[cfg(target_arch = "x86_64")]
     ///
-    /// Retrieve the list of MSRs supported by KVM.
+    /// Retrieve the list of MSRs supported by MSHV.
     ///
     fn get_msr_list(&self) -> hypervisor::Result<MsrList> {
         self.mshv


### PR DESCRIPTION
It should have said MSHV in the comment.

Signed-off-by: Wei Liu <liuwe@microsoft.com>