### PR TITLE
virtio-devices: vhost-user: fs: Don't close file descriptor

### DIFF
--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -108,11 +108,6 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
             if ret == libc::MAP_FAILED {
                 return Err(io::Error::last_os_error());
             }
-
-            let ret = unsafe { libc::close(fd.as_raw_fd()) };
-            if ret == -1 {
-                return Err(io::Error::last_os_error());
-            }
         }
 
         Ok(0)
@@ -269,11 +264,6 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
                 ptr += ret as u64;
                 done += ret as u64;
             }
-        }
-
-        let ret = unsafe { libc::close(fd.as_raw_fd()) };
-        if ret == -1 {
-            return Err(io::Error::last_os_error());
         }
 
         Ok(done)


### PR DESCRIPTION
The file descriptor provided to fs_slave_map() and fs_slave_io() is
passed as a AsRawFd trait, meaning the caller owns it. For that reason,
there's no need for these functions to close the file descriptor as it
will be closed later on anyway.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>