### PR TITLE
tests: Fix flakiness in test_vdpa_block()

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5967,7 +5967,7 @@ mod parallel {
             // Unplug the device
             let cmd_success = remote_command(&api_socket, "remove-device", Some("myvdpa0"));
             assert!(cmd_success);
-            thread::sleep(std::time::Duration::new(10, 0));
+            thread::sleep(std::time::Duration::new(30, 0));
 
             // Check /dev/vdd doesn't exist anymore
             assert_eq!(


### PR DESCRIPTION
The test is sporadically failing whenever we try to hotplug the vDPA
device we've just unplugged. This is causing the kernel to complain with
EBUSY because the device hasn't been released yet. This is happening
because the CI system is under very high load, therefore taking quite
some time to the host to update the state of this device.

The easy way to fix such issue is by increasing the sleep time between
the unplug and the replug.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>