### PR TITLE
deps: Update vhost and vhost-user-backend dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b56bf8f178fc500fe14505fca8b00dec76fc38f2304f461c8d9d7547982311d"
+checksum = "53567fd9ab820e4f3cc156f24146882fee3c365194c3e1dea74723265f27fc88"
 dependencies = [
  "bitflags",
  "libc",
@@ -1173,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf4c8d6fc1560ac01051bd09b744887665b25adeb390bb7de6bbfb4d2ad8b12"
+checksum = "1490f2028d4f119b2292efe218b5f8cfc6471f039b53b6a6eb5d9513e964facc"
 dependencies = [
  "libc",
  "log",

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -13,8 +13,8 @@ libc = "0.2.121"
 log = "0.4.14"
 option_parser = { path = "../option_parser" }
 qcow = { path = "../qcow" }
-vhost = { version = "0.3.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.2.0"
+vhost = { version = "0.4.0", features = ["vhost-user-slave"] }
+vhost-user-backend = "0.3.0"
 virtio-bindings = "0.1.0"
 vm-memory = "0.7.0"
 vmm-sys-util = "0.9.0"

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -12,8 +12,8 @@ libc = "0.2.121"
 log = "0.4.14"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
-vhost = { version = "0.3.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.2.0"
+vhost = { version = "0.4.0", features = ["vhost-user-slave"] }
+vhost-user-backend = "0.3.0"
 virtio-bindings = "0.1.0"
 vm-memory = "0.7.0"
 vmm-sys-util = "0.9.0"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0.79"
 thiserror = "1.0.30"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vhost = { version = "0.3.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern", "vhost-vdpa"] }
+vhost = { version = "0.4.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern", "vhost-vdpa"] }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
 virtio-queue = "0.2.0"
 vm-allocator = { path = "../vm-allocator" }


### PR DESCRIPTION
Rely on newly released versions of the vhost and vhost-user-backend
crates from rust-vmm.

The new vhost version includes the fixes needed for vDPA.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>