### PR TITLE
Adjust and Enable 'test_vfio_user'

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -56,7 +56,7 @@ build_spdk_nvme() {
     SPDK_DIR="$WORKLOADS_DIR/spdk"
     SPDK_REPO="https://github.com/spdk/spdk.git"
     SPDK_DEPLOY_DIR="/usr/local/bin/spdk-nvme"
-    checkout_repo "$SPDK_DIR" "$SPDK_REPO" master "f9c496b8e21a8f499df268818bf8b5d8e2b19f04"
+    checkout_repo "$SPDK_DIR" "$SPDK_REPO" master "59f3cdacb13bd2a19c4a86be04792b0ee4491172"
 
     if [ ! -f "$SPDK_DIR/.built" ]; then
         pushd $SPDK_DIR

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5772,7 +5772,7 @@ mod parallel {
         let mut child = GuestCommand::new(&guest)
             .args(&["--api-socket", &api_socket])
             .args(&["--cpus", "boot=1"])
-            .args(&["--memory", "size=512M,shared=on"])
+            .args(&["--memory", "size=512M,shared=on,hugepages=on"])
             .args(&["--kernel", fw_path(FwType::RustHypervisorFirmware).as_str()])
             .default_disks()
             .default_net()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5798,7 +5798,7 @@ mod parallel {
             assert!(String::from_utf8_lossy(&cmd_output)
                 .contains("{\"id\":\"vfio_user0\",\"bdf\":\"0000:00:06.0\"}"));
 
-            thread::sleep(std::time::Duration::new(1, 0));
+            thread::sleep(std::time::Duration::new(10, 0));
 
             // Check both if /dev/nvme exists and if the block size is 128M.
             assert_eq!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5754,9 +5754,7 @@ mod parallel {
         exec_host_command_status("pkill -f nvmf_tgt");
     }
 
-    #[ignore]
     #[test]
-    #[cfg(target_arch = "aarch64")]
     fn test_vfio_user() {
         #[cfg(target_arch = "aarch64")]
         let focal_image = FOCAL_IMAGE_UPDATE_KERNEL_NAME.to_string();
@@ -5813,7 +5811,7 @@ mod parallel {
                 1
             );
 
-            // Check changes persist after reboot
+            // Check changes persist after umount
             assert_eq!(
                 guest.ssh_command("sudo mount /dev/nvme0n1 /mnt").unwrap(),
                 ""
@@ -5825,7 +5823,6 @@ mod parallel {
             assert_eq!(guest.ssh_command("sudo umount /mnt").unwrap(), "");
             assert_eq!(guest.ssh_command("ls /mnt").unwrap(), "");
 
-            guest.reboot_linux(0, None);
             assert_eq!(
                 guest.ssh_command("sudo mount /dev/nvme0n1 /mnt").unwrap(),
                 ""


### PR DESCRIPTION
This patch enables the `test_vfio_user` test with couple of adjustments:

1. Use 'hugepages' for the guest memory to fix warnings reported by the SPDK/NVMe backend (that requires 2M alignment of the shared memory);
2. Remove the `reboot` from the test for better stability.

Signed-off-by: Bo Chen <chen.bo@intel.com>