### PR TITLE
scripts: Use the same linux kernel build function everywhere

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -11,23 +11,6 @@ WORKLOADS_LOCK="$WORKLOADS_DIR/integration_test.lock"
 
 mkdir -p "$WORKLOADS_DIR"
 
-build_custom_linux() {
-    SRCDIR=$PWD
-    LINUX_CUSTOM_DIR="$WORKLOADS_DIR/linux-custom"
-    LINUX_CUSTOM_BRANCH="ch-5.15.12"
-    LINUX_CUSTOM_URL="https://github.com/cloud-hypervisor/linux.git"
-
-    checkout_repo "$LINUX_CUSTOM_DIR" "$LINUX_CUSTOM_URL" "$LINUX_CUSTOM_BRANCH"
-
-    cp $SRCDIR/resources/linux-config-aarch64 $LINUX_CUSTOM_DIR/.config
-
-    pushd $LINUX_CUSTOM_DIR
-    time make -j `nproc`
-    cp arch/arm64/boot/Image "$WORKLOADS_DIR/" || exit 1
-    cp arch/arm64/boot/Image.gz "$WORKLOADS_DIR/" || exit 1
-    popd
-}
-
 build_edk2() {
     EDK2_BUILD_DIR="$WORKLOADS_DIR/edk2_build"
     EDK2_REPO="https://github.com/tianocore/edk2.git"

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -107,27 +107,7 @@ popd
 
 # Build custom kernel based on virtio-pmem and virtio-fs upstream patches
 VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
-
-LINUX_CUSTOM_DIR="$WORKLOADS_DIR/linux-custom"
-
-if [ ! -f "$VMLINUX_IMAGE" ]; then
-    SRCDIR=$PWD
-    pushd $WORKLOADS_DIR
-    time git clone --depth 1 "https://github.com/cloud-hypervisor/linux.git" -b "ch-5.15.12" $LINUX_CUSTOM_DIR
-    cp $SRCDIR/resources/linux-config-x86_64 $LINUX_CUSTOM_DIR/.config
-    popd
-fi
-
-if [ ! -f "$VMLINUX_IMAGE" ]; then
-    pushd $LINUX_CUSTOM_DIR
-    time make bzImage -j `nproc`
-    cp vmlinux $VMLINUX_IMAGE || exit 1
-    popd
-fi
-
-if [ -d "$LINUX_CUSTOM_DIR" ]; then
-    rm -rf $LINUX_CUSTOM_DIR
-fi
+build_custom_linux
 
 VIRTIOFSD="$WORKLOADS_DIR/virtiofsd"
 VIRTIOFSD_DIR="virtiofsd_build"

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -11,30 +11,6 @@ export BUILD_TARGET=${BUILD_TARGET-${TEST_ARCH}-unknown-linux-gnu}
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
 
-build_custom_linux() {
-    SRCDIR=$PWD
-    LINUX_CUSTOM_DIR="$WORKLOADS_DIR/linux-custom"
-    LINUX_CUSTOM_BRANCH="ch-5.15.12"
-    LINUX_CUSTOM_URL="https://github.com/cloud-hypervisor/linux.git"
-
-    checkout_repo "$LINUX_CUSTOM_DIR" "$LINUX_CUSTOM_URL" "$LINUX_CUSTOM_BRANCH"
-
-    cp $SRCDIR/resources/linux-config-${TEST_ARCH} $LINUX_CUSTOM_DIR/.config
-
-    pushd $LINUX_CUSTOM_DIR
-    make -j `nproc`
-    if [ ${TEST_ARCH} == "x86_64" ]; then
-       cp vmlinux "$WORKLOADS_DIR/" || exit 1
-    elif [ ${TEST_ARCH} == "aarch64" ]; then
-       cp arch/arm64/boot/Image "$WORKLOADS_DIR/" || exit 1
-    fi
-    popd
-
-    if [ -d "$LINUX_CUSTOM_DIR" ]; then
-        rm -rf $LINUX_CUSTOM_DIR
-    fi
-}
-
 build_fio() {
     FIO_DIR="$WORKLOADS_DIR/fio_build"
     FIO_REPO="https://github.com/axboe/fio.git"

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -42,6 +42,28 @@ checkout_repo() {
     fi
 }
 
+build_custom_linux() {
+    ARCH=$(uname -m)
+    SRCDIR=$PWD
+    LINUX_CUSTOM_DIR="$WORKLOADS_DIR/linux-custom"
+    LINUX_CUSTOM_BRANCH="ch-5.15.12"
+    LINUX_CUSTOM_URL="https://github.com/cloud-hypervisor/linux.git"
+
+    checkout_repo "$LINUX_CUSTOM_DIR" "$LINUX_CUSTOM_URL" "$LINUX_CUSTOM_BRANCH"
+
+    cp $SRCDIR/resources/linux-config-${ARCH} $LINUX_CUSTOM_DIR/.config
+
+    pushd $LINUX_CUSTOM_DIR
+    make -j `nproc`
+    if [ ${ARCH} == "x86_64" ]; then
+       cp vmlinux "$WORKLOADS_DIR/" || exit 1
+    elif [ ${ARCH} == "aarch64" ]; then
+       cp arch/arm64/boot/Image "$WORKLOADS_DIR/" || exit 1
+       cp arch/arm64/boot/Image.gz "$WORKLOADS_DIR/" || exit 1
+    fi
+    popd
+}
+
 cmd_help() {
     echo ""
     echo "Cloud Hypervisor $(basename $0)"


### PR DESCRIPTION
This commit unifies the custom linux kernel build in x86, Arm, and
performance metrics to the same function. Therefore, when bumping
the kernel version, we can make sure we only need to make the change
in one place.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>