### PR TITLE
devices: cmos: Implement CMOS based reset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ wait-timeout = "0.2.0"
 [features]
 default = ["common", "kvm"]
 # Common features for all hypervisors
-common = ["cmos", "fwdebug"]
+common = ["fwdebug"]
 amx = ["vmm/amx"]
 cmos = ["vmm/cmos"]
 fwdebug = ["vmm/fwdebug"]

--- a/devices/src/legacy/mod.rs
+++ b/devices/src/legacy/mod.rs
@@ -5,7 +5,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
-#[cfg(feature = "cmos")]
 mod cmos;
 #[cfg(feature = "fwdebug")]
 mod fwdebug;
@@ -18,7 +17,6 @@ mod serial;
 #[cfg(target_arch = "aarch64")]
 mod uart_pl011;
 
-#[cfg(feature = "cmos")]
 pub use self::cmos::Cmos;
 #[cfg(feature = "fwdebug")]
 pub use self::fwdebug::FwDebugDevice;

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -98,7 +98,7 @@ use vm_device::{Bus, BusDevice, Resource};
 use vm_memory::guest_memory::FileOffset;
 use vm_memory::GuestMemoryRegion;
 use vm_memory::{Address, GuestAddress, GuestUsize, MmapRegion};
-#[cfg(all(target_arch = "x86_64", feature = "cmos"))]
+#[cfg(target_arch = "x86_64")]
 use vm_memory::{GuestAddressSpace, GuestMemory};
 use vm_migration::{
     protocol::MemoryRangeTable, Migratable, MigratableError, Pausable, Snapshot,
@@ -1470,7 +1470,6 @@ impl DeviceManager {
             .io_bus
             .insert(i8042, 0x61, 0x4)
             .map_err(DeviceManagerError::BusError)?;
-        #[cfg(feature = "cmos")]
         {
             // Add a CMOS emulated device
             let mem_size = self

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1459,7 +1459,9 @@ impl DeviceManager {
     #[cfg(target_arch = "x86_64")]
     fn add_legacy_devices(&mut self, reset_evt: EventFd) -> DeviceManagerResult<()> {
         // Add a shutdown device (i8042)
-        let i8042 = Arc::new(Mutex::new(devices::legacy::I8042Device::new(reset_evt)));
+        let i8042 = Arc::new(Mutex::new(devices::legacy::I8042Device::new(
+            reset_evt.try_clone().unwrap(),
+        )));
 
         self.bus_devices
             .push(Arc::clone(&i8042) as Arc<Mutex<dyn BusDevice>>);
@@ -1486,6 +1488,7 @@ impl DeviceManager {
             let cmos = Arc::new(Mutex::new(devices::legacy::Cmos::new(
                 mem_below_4g,
                 mem_above_4g,
+                reset_evt,
             )));
 
             self.bus_devices


### PR DESCRIPTION
If EFI reset fails on the Linux kernel then it will fallthrough to CMOS
reset. Implement this as one of our reset solutions.

Fixes: #3912

Signed-off-by: Rob Bradford <robert.bradford@intel.com>