### PR TITLE
virtio-devices: vhost-user: Add support for TDX

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2003,6 +2003,7 @@ impl DeviceManager {
                     self.exit_evt
                         .try_clone()
                         .map_err(DeviceManagerError::EventFd)?,
+                    self.force_iommu,
                 ) {
                     Ok(vub_device) => vub_device,
                     Err(e) => {
@@ -2184,6 +2185,7 @@ impl DeviceManager {
                     self.exit_evt
                         .try_clone()
                         .map_err(DeviceManagerError::EventFd)?,
+                    self.force_iommu,
                 ) {
                     Ok(vun_device) => vun_device,
                     Err(e) => {
@@ -2474,6 +2476,7 @@ impl DeviceManager {
                     self.exit_evt
                         .try_clone()
                         .map_err(DeviceManagerError::EventFd)?,
+                    self.force_iommu,
                 )
                 .map_err(DeviceManagerError::CreateVirtioFs)?,
             ));


### PR DESCRIPTION
By enabling the VIRTIO feature VIRTIO_F_IOMMU_PLATFORM for all
vhost-user devices when needed, we force the guest to use the DMA API,
making these devices compatible with TDX. By using DMA API, the guest
triggers the TDX codepath to share some of the guest memory, in
particular the virtqueues and associated buffers so that the VMM and
vhost-user backends/processes can access this memory.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>