### PR TITLE
Only deny cpu and memory resizing if the request amount has changed.

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1129,6 +1129,10 @@ impl CpuManager {
     }
 
     pub fn resize(&mut self, desired_vcpus: u8) -> Result<bool> {
+        if desired_vcpus.cmp(&self.present_vcpus()) == cmp::Ordering::Equal {
+            return Ok(false);
+        }
+
         if !self.dynamic {
             return Err(Error::ResizingNotSupported);
         }


### PR DESCRIPTION
vmm,cpu: Deny resizing only if the vcpu amount has changed

188078467db42f50f5b7e7a7969738ebf8aec95c made clear that resize should
only happen when dealing with a "dynamic" CpuManager.  Although this is
very much correct, it causes a regression on Kata Containers (and on any
other consumer of Cloud Hypervisor) in cases where a resize would be
triggered but the vCPUs values wouldn't be changed.

There's no doubt Kata Containers could do better and do not call a
resize in such situations, and that's something that should **also** be
solved there.  However, we should also work this around on Cloud
Hypervisor side as it introduces a regression with the current Kata
Containers code.

--- 

vmm,memory_manager: Deny resizing only if the ram amount has changed

Similarly to the previous commit restricting the cpu resizing error only
to the situations where the vcpu amount has changed, let's do the same
with the memory and be consistent throughout our code base.

---

@rbradford, please, take a look at this one.