### PR TITLE
Reserve a memory hole in32-bit address space on AArch64

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -255,10 +255,10 @@ fn create_memory_node(
             }
         }
     } else {
-        let mem_size = guest_mem.last_addr().raw_value() - super::layout::RAM_64BIT_START + 1;
+        let mem_size = guest_mem.last_addr().raw_value() - super::layout::RAM_START + 1;
         // See https://github.com/torvalds/linux/blob/master/Documentation/devicetree/booting-without-of.txt#L960
         // for an explanation of this.
-        let mem_reg_prop = [super::layout::RAM_64BIT_START as u64, mem_size as u64];
+        let mem_reg_prop = [super::layout::RAM_START as u64, mem_size as u64];
         let memory_node = fdt.begin_node("memory")?;
 
         fdt.property_string("device_type", "memory")?;

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -255,10 +255,10 @@ fn create_memory_node(
             }
         }
     } else {
-        let mem_size = guest_mem.last_addr().raw_value() - super::layout::RAM_START + 1;
+        let mem_size = guest_mem.last_addr().raw_value() - super::layout::RAM_START.raw_value() + 1;
         // See https://github.com/torvalds/linux/blob/master/Documentation/devicetree/booting-without-of.txt#L960
         // for an explanation of this.
-        let mem_reg_prop = [super::layout::RAM_START as u64, mem_size as u64];
+        let mem_reg_prop = [super::layout::RAM_START.raw_value() as u64, mem_size as u64];
         let memory_node = fdt.begin_node("memory")?;
 
         fdt.property_string("device_type", "memory")?;

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -85,8 +85,8 @@ pub const PCI_MMCONFIG_SIZE: u64 = 256 << 20;
 // One bus with potentially 256 devices (32 slots x 8 functions).
 pub const PCI_MMIO_CONFIG_SIZE_PER_SEGMENT: u64 = 4096 * 256;
 
-/// Start of RAM on 64 bit ARM.
-pub const RAM_64BIT_START: u64 = 0x4000_0000;
+/// Start of RAM.
+pub const RAM_START: u64 = 0x4000_0000;
 
 /// Kernel command line maximum size.
 /// As per `arch/arm64/include/uapi/asm/setup.h`.
@@ -94,11 +94,11 @@ pub const CMDLINE_MAX_SIZE: usize = 2048;
 
 /// FDT is at the beginning of RAM.
 /// Maximum size of the device tree blob as specified in https://www.kernel.org/doc/Documentation/arm64/booting.txt.
-pub const FDT_START: u64 = RAM_64BIT_START;
+pub const FDT_START: u64 = RAM_START;
 pub const FDT_MAX_SIZE: usize = 0x20_0000;
 
 /// Put ACPI table above dtb
-pub const ACPI_START: u64 = RAM_64BIT_START + FDT_MAX_SIZE as u64;
+pub const ACPI_START: u64 = RAM_START + FDT_MAX_SIZE as u64;
 pub const ACPI_MAX_SIZE: usize = 0x20_0000;
 pub const RSDP_POINTER: GuestAddress = GuestAddress(ACPI_START);
 

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //
-// Memory layout of Aarch64 guest:
+// Memory layout of AArch64 guest:
 //
 // Physical  +---------------------------------------------------------------+
 // address   |                                                               |
@@ -19,6 +19,13 @@
 // memory)   |                                                               |
 //           |                            DRAM                               |
 //           |                                                               |
+//           |                                                               |
+// 4GB       +---------------------------------------------------------------+
+//           |                      32-bit devices hole                      |
+// 4GB-64M   +---------------------------------------------------------------+
+//           |                                                               |
+//           |                                                               |
+//           |                            DRAM                               |
 //           |                                                               |
 //           |                                                               |
 // 1GB       +---------------------------------------------------------------+
@@ -87,6 +94,13 @@ pub const PCI_MMIO_CONFIG_SIZE_PER_SEGMENT: u64 = 4096 * 256;
 
 /// Start of RAM.
 pub const RAM_START: GuestAddress = GuestAddress(0x4000_0000);
+
+/// 32-bit reserved area: 64MiB before 4GiB
+pub const MEM_32BIT_RESERVED_START: GuestAddress = GuestAddress(0xfc00_0000);
+pub const MEM_32BIT_RESERVED_SIZE: u64 = 0x0400_0000;
+
+/// Start of 64-bit RAM.
+pub const RAM_64BIT_START: GuestAddress = GuestAddress(0x1_0000_0000);
 
 /// Kernel command line maximum size.
 /// As per `arch/arm64/include/uapi/asm/setup.h`.

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -86,7 +86,7 @@ pub const PCI_MMCONFIG_SIZE: u64 = 256 << 20;
 pub const PCI_MMIO_CONFIG_SIZE_PER_SEGMENT: u64 = 4096 * 256;
 
 /// Start of RAM.
-pub const RAM_START: u64 = 0x4000_0000;
+pub const RAM_START: GuestAddress = GuestAddress(0x4000_0000);
 
 /// Kernel command line maximum size.
 /// As per `arch/arm64/include/uapi/asm/setup.h`.
@@ -94,11 +94,11 @@ pub const CMDLINE_MAX_SIZE: usize = 2048;
 
 /// FDT is at the beginning of RAM.
 /// Maximum size of the device tree blob as specified in https://www.kernel.org/doc/Documentation/arm64/booting.txt.
-pub const FDT_START: u64 = RAM_START;
+pub const FDT_START: u64 = RAM_START.0;
 pub const FDT_MAX_SIZE: usize = 0x20_0000;
 
 /// Put ACPI table above dtb
-pub const ACPI_START: u64 = RAM_START + FDT_MAX_SIZE as u64;
+pub const ACPI_START: u64 = RAM_START.0 + FDT_MAX_SIZE as u64;
 pub const ACPI_MAX_SIZE: usize = 0x20_0000;
 pub const RSDP_POINTER: GuestAddress = GuestAddress(ACPI_START);
 

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -108,7 +108,7 @@ pub fn arch_memory_regions(size: GuestUsize) -> Vec<(GuestAddress, usize, Region
         ),
         // 1 GiB ~ : Ram
         (
-            GuestAddress(layout::RAM_START),
+            layout::RAM_START,
             (size - ram_deduction) as usize,
             RegionType::Ram,
         ),
@@ -212,7 +212,7 @@ mod tests {
     fn test_arch_memory_regions_dram() {
         let regions = arch_memory_regions((1usize << 32) as u64); //4GB
         assert_eq!(5, regions.len());
-        assert_eq!(GuestAddress(layout::RAM_START), regions[4].0);
+        assert_eq!(layout::RAM_START, regions[4].0);
         assert_eq!(((1 << 32) - layout::UEFI_SIZE) as usize, regions[4].1);
         assert_eq!(RegionType::Ram, regions[4].2);
     }

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -108,7 +108,7 @@ pub fn arch_memory_regions(size: GuestUsize) -> Vec<(GuestAddress, usize, Region
         ),
         // 1 GiB ~ : Ram
         (
-            GuestAddress(layout::RAM_64BIT_START),
+            GuestAddress(layout::RAM_START),
             (size - ram_deduction) as usize,
             RegionType::Ram,
         ),
@@ -212,7 +212,7 @@ mod tests {
     fn test_arch_memory_regions_dram() {
         let regions = arch_memory_regions((1usize << 32) as u64); //4GB
         assert_eq!(5, regions.len());
-        assert_eq!(GuestAddress(layout::RAM_64BIT_START), regions[4].0);
+        assert_eq!(GuestAddress(layout::RAM_START), regions[4].0);
         assert_eq!(((1 << 32) - layout::UEFI_SIZE) as usize, regions[4].1);
         assert_eq!(RegionType::Ram, regions[4].2);
     }

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -234,11 +234,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_arch_memory_regions_dram() {
-        let regions = arch_memory_regions((1usize << 32) as u64); //4GB
-        assert_eq!(5, regions.len());
+    fn test_arch_memory_regions_dram_2gb() {
+        let regions = arch_memory_regions((1usize << 31) as u64); //2GB
+        assert_eq!(6, regions.len());
         assert_eq!(layout::RAM_START, regions[4].0);
-        assert_eq!(((1 << 32) - layout::UEFI_SIZE) as usize, regions[4].1);
+        assert_eq!(((1 << 31) - layout::UEFI_SIZE) as usize, regions[4].1);
         assert_eq!(RegionType::Ram, regions[4].2);
+        assert_eq!(RegionType::Reserved, regions[5].2);
+    }
+
+    #[test]
+    fn test_arch_memory_regions_dram_4gb() {
+        let regions = arch_memory_regions((1usize << 32) as u64); //4GB
+        let ram_32bit_space_size =
+            layout::MEM_32BIT_RESERVED_START.unchecked_offset_from(layout::RAM_START);
+        assert_eq!(7, regions.len());
+        assert_eq!(layout::RAM_START, regions[4].0);
+        assert_eq!(ram_32bit_space_size as usize, regions[4].1);
+        assert_eq!(RegionType::Ram, regions[4].2);
+        assert_eq!(RegionType::Reserved, regions[6].2);
+        assert_eq!(RegionType::Ram, regions[5].2);
+        assert_eq!(
+            ((1 << 32) - layout::UEFI_SIZE - ram_32bit_space_size) as usize,
+            regions[5].1
+        );
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7274,7 +7274,7 @@ mod live_migration {
                 "--memory-zone",
                 "id=mem0,size=1G,hotplug_size=32G",
                 "id=mem1,size=1G,hotplug_size=32G",
-                "id=mem2,size=1G,hotplug_size=32G",
+                "id=mem2,size=2G,hotplug_size=32G",
                 "--numa",
                 "guest_numa_id=0,cpus=[0-2,9],distances=[1@15,2@20],memory_zones=mem0",
                 "guest_numa_id=1,cpus=[3-4,6-8],distances=[0@20,2@25],memory_zones=mem1",
@@ -7325,7 +7325,7 @@ mod live_migration {
             // virtio-mem regions being used.
             if numa {
                 guest.check_numa_common(
-                    Some(&[960_000, 960_000, 960_000]),
+                    Some(&[960_000, 960_000, 1_920_000]),
                     Some(&[vec![0, 1, 2], vec![3, 4], vec![5]]),
                     Some(&["10 15 20", "20 10 25", "25 30 10"]),
                 );
@@ -7340,7 +7340,7 @@ mod live_migration {
                     // has been assigned the right amount of memory.
                     resize_zone_command(&src_api_socket, "mem0", "2G");
                     resize_zone_command(&src_api_socket, "mem1", "2G");
-                    resize_zone_command(&src_api_socket, "mem2", "2G");
+                    resize_zone_command(&src_api_socket, "mem2", "3G");
                     thread::sleep(std::time::Duration::new(5, 0));
 
                     guest.check_numa_common(Some(&[1_920_000, 1_920_000, 1_920_000]), None, None);
@@ -7498,9 +7498,9 @@ mod live_migration {
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), 6);
             if numa {
                 #[cfg(target_arch = "x86_64")]
-                assert!(guest.get_total_memory().unwrap_or_default() > 5_760_000);
+                assert!(guest.get_total_memory().unwrap_or_default() > 6_720_000);
                 #[cfg(target_arch = "aarch64")]
-                assert!(guest.get_total_memory().unwrap_or_default() > 2_880_000);
+                assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
             } else {
                 assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
             }
@@ -7511,7 +7511,7 @@ mod live_migration {
                 #[cfg(target_arch = "aarch64")]
                 {
                     guest.check_numa_common(
-                        Some(&[960_000, 960_000, 960_000]),
+                        Some(&[960_000, 960_000, 1_920_000]),
                         Some(&[vec![0, 1, 2], vec![3, 4], vec![5]]),
                         Some(&["10 15 20", "20 10 25", "25 30 10"]),
                     );
@@ -7522,7 +7522,7 @@ mod live_migration {
                 #[cfg(target_arch = "x86_64")]
                 {
                     guest.check_numa_common(
-                        Some(&[1_920_000, 1_920_000, 1_920_000]),
+                        Some(&[1_920_000, 1_920_000, 2_880_000]),
                         Some(&[vec![0, 1, 2], vec![3, 4], vec![5]]),
                         Some(&["10 15 20", "20 10 25", "25 30 10"]),
                     );

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1330,7 +1330,7 @@ impl MemoryManager {
     // If memory hotplug is allowed, the start address needs to be aligned
     // (rounded-up) to 128MiB boundary.
     // If memory hotplug is not allowed, there is no alignment required.
-    // On x86_64, it must also start at the 64bit start.
+    // And it must also start at the 64bit start.
     fn start_addr(mem_end: GuestAddress, allow_mem_hotplug: bool) -> Result<GuestAddress, Error> {
         let mut start_addr = if allow_mem_hotplug {
             GuestAddress(mem_end.0 | ((128 << 20) - 1))
@@ -1342,7 +1342,6 @@ impl MemoryManager {
             .checked_add(1)
             .ok_or(Error::GuestAddressOverFlow)?;
 
-        #[cfg(target_arch = "x86_64")]
         if mem_end < arch::layout::MEM_32BIT_RESERVED_START {
             return Ok(arch::layout::RAM_64BIT_START);
         }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2991,7 +2991,7 @@ mod tests {
     #[test]
     fn test_create_fdt_with_devices() {
         let regions = vec![(
-            GuestAddress(layout::RAM_64BIT_START),
+            GuestAddress(layout::RAM_START),
             (layout::FDT_MAX_SIZE + 0x1000) as usize,
         )];
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2984,16 +2984,12 @@ mod tests {
     use arch::aarch64::gic::kvm::create_gic;
     use arch::aarch64::layout;
     use arch::{DeviceType, MmioDeviceInfo};
-    use vm_memory::GuestAddress;
 
     const LEN: u64 = 4096;
 
     #[test]
     fn test_create_fdt_with_devices() {
-        let regions = vec![(
-            GuestAddress(layout::RAM_START),
-            (layout::FDT_MAX_SIZE + 0x1000) as usize,
-        )];
+        let regions = vec![(layout::RAM_START, (layout::FDT_MAX_SIZE + 0x1000) as usize)];
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
 
         let dev_info: HashMap<(DeviceType, std::string::String), MmioDeviceInfo> = [


### PR DESCRIPTION
Fixes https://github.com/cloud-hypervisor/cloud-hypervisor/issues/3890

Reserve the hole for some devices that have to be placed close to 4 GiB. Now this is only for TPM device (which requires 20KB between 0xfed40000-0xfed44fff). 

To make it generic for similar requirements, totally 64MiB is reserved.