### PR TITLE
Retrieve TDX capabilities to patch CPUID

### DIFF
--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -12,6 +12,8 @@ use crate::vm::Vm;
 use crate::x86_64::CpuId;
 #[cfg(target_arch = "x86_64")]
 use crate::x86_64::MsrList;
+#[cfg(feature = "tdx")]
+use crate::TdxCapabilities;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -59,6 +61,11 @@ pub enum HypervisorError {
     ///
     #[error("Checking extensions:{0}")]
     CheckExtensions(#[source] anyhow::Error),
+    ///
+    /// Failed to retrieve TDX capabilities
+    ///
+    #[error("Failed to retrieve TDX capabilities:{0}")]
+    TdxCapabilities(#[source] anyhow::Error),
 }
 
 ///
@@ -105,4 +112,9 @@ pub trait Hypervisor: Send + Sync {
     /// Retrieve AArch64 host maximum IPA size supported by KVM.
     ///
     fn get_host_ipa_limit(&self) -> i32;
+    ///
+    /// Retrieve TDX capabilities
+    ///
+    #[cfg(feature = "tdx")]
+    fn tdx_capabilities(&self) -> Result<TdxCapabilities>;
 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -525,7 +525,7 @@ impl vm::Vm for KvmVm {
         let data = TdxInitVm {
             max_vcpus,
             tsc_khz: 0,
-            attributes: 1, // TDX1_TD_ATTRIBUTE_DEBUG,
+            attributes: 0,
             cpuid: cpuid.as_fam_struct_ptr() as u64,
             mrconfigid: [0; 6],
             mrowner: [0; 6],

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -51,6 +51,8 @@ mod device;
 pub use crate::hypervisor::{Hypervisor, HypervisorError};
 pub use cpu::{HypervisorCpuError, Vcpu, VmExit};
 pub use device::{Device, HypervisorDeviceError};
+#[cfg(feature = "tdx")]
+pub use kvm::TdxCapabilities;
 #[cfg(feature = "kvm")]
 pub use kvm::*;
 #[cfg(all(feature = "mshv", target_arch = "x86_64"))]


### PR DESCRIPTION
Extends the `Hypervisor` API to retrieve the TDX capabilities from KVM, and patch the CPUID to expose a correct list of XFAM features.