### PR TITLE
vmm: Don't error if live resizing is not possible

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -122,9 +122,6 @@ pub enum Error {
     /// Failed to translate guest virtual address.
     TranslateVirtualAddress(hypervisor::HypervisorCpuError),
 
-    /// CPU hotplug/unplug not supported
-    ResizingNotSupported,
-
     #[cfg(all(feature = "amx", target_arch = "x86_64"))]
     /// "Failed to setup AMX.
     AmxEnable(anyhow::Error),
@@ -1134,7 +1131,7 @@ impl CpuManager {
         }
 
         if !self.dynamic {
-            return Err(Error::ResizingNotSupported);
+            return Ok(false);
         }
 
         match desired_vcpus.cmp(&self.present_vcpus()) {

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -307,9 +307,6 @@ pub enum Error {
 
     /// Failed to allocate MMIO address
     AllocateMmioAddress,
-
-    /// Memory resizing not supported
-    ResizingNotSupported,
 }
 
 const ENABLE_FLAG: usize = 0;
@@ -1618,7 +1615,7 @@ impl MemoryManager {
             HotplugMethod::VirtioMem => {
                 if desired_ram >= self.boot_ram {
                     if !self.dynamic {
-                        return Err(Error::ResizingNotSupported);
+                        return Ok(region);
                     }
 
                     self.virtio_mem_resize(DEFAULT_MEMORY_ZONE, desired_ram - self.boot_ram)?;
@@ -1628,7 +1625,7 @@ impl MemoryManager {
             HotplugMethod::Acpi => {
                 if desired_ram > self.current_ram {
                     if !self.dynamic {
-                        return Err(Error::ResizingNotSupported);
+                        return Ok(region);
                     }
 
                     region =


### PR DESCRIPTION
The introduction of errror if live resizing is not possible is a
regression compared to the original behaviour where the new size would
be stored in the config and reflected in the next boot. This behaviour
was also inconsistent with the effect of resizing with no VM booted.

Instead of generating an error allow the code to go ahead and update the
config so that the new size will be available upon the reboot.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>