### PR TITLE
Update TDX according to latest version

### DIFF
--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -324,10 +324,10 @@ impl TdHob {
             },
             /* TODO:
              * QEMU currently fills it in like this:
-             * EFI_RESOURCE_ATTRIBUTE_PRESENT | EFI_RESOURCE_ATTRIBUTE_INITIALIZED | EFI_RESOURCE_ATTRIBUTE_ENCRYPTED | EFI_RESOURCE_ATTRIBUTE_TESTED
+             * EFI_RESOURCE_ATTRIBUTE_PRESENT | EFI_RESOURCE_ATTRIBUTE_INITIALIZED | EFI_RESOURCE_ATTRIBUTE_TESTED
              * which differs from the spec (due to TDVF implementation issue?)
              */
-            0x04000007,
+            0x7,
         )
     }
 

--- a/docs/intel_tdx.md
+++ b/docs/intel_tdx.md
@@ -55,9 +55,9 @@ cargo build --features tdx
 ```
 
 And run a TDX VM by providing the firmware previously built, along with the
-guest image containing the TDX enlightened kernel. Assuming the guest kernel
-command line contains `console=hvc0` (printing to the `virtio-console` device),
-run Cloud Hypervisor as follows:
+guest image containing the TDX enlightened kernel. The latest image
+`td-guest-rhel8.5.raw` contains `console=hvc0` on the kernel boot parameters,
+meaning it will be printing guest kernel logs to the `virtio-console` device.
 
 ```bash
 ./cloud-hypervisor \
@@ -67,8 +67,8 @@ run Cloud Hypervisor as follows:
     --disk path=tdx_guest_img
 ```
 
-And here is the alternative command when looking for debug logs (assuming the
-guest kernel command line contains `console=ttyS0`):
+And here is the alternative command when looking for debug logs from the
+firmware:
 
 ```bash
 ./cloud-hypervisor \
@@ -76,8 +76,8 @@ guest kernel command line contains `console=ttyS0`):
     --cpus boot=1 \
     --memory size=1G \
     --disk path=tdx_guest_img \
-    --serial tty \
-    --console off
+    --serial file=/tmp/ch_serial \
+    --console tty
 ```
 
 ### TDShim
@@ -97,8 +97,14 @@ option as well.
 ./cloud-hypervisor \
     --tdx firmware=tdshim \
     --kernel bzImage \
-    --cmdline "root=/dev/vda1 console=hvc0 rw tdx_allow_acpi=MCFG"
+    --cmdline "root=/dev/vda3 console=hvc0 rw"
     --cpus boot=1 \
     --memory size=1G \
     --disk path=tdx_guest_img
 ```
+
+### Guest kernel disables serial ports
+
+The latest guest kernel that can be found in the latest image
+`td-guest-rhel8.5.raw` disabled the support for serial ports. This means adding
+`console=ttyS0` will have no effect and will not print any log from the guest.

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1865,6 +1865,10 @@ impl Vm {
 
                 next_start_addr = start + size;
 
+                if region_start > next_start_addr {
+                    next_start_addr = region_start;
+                }
+
                 if next_start_addr > region_end {
                     break;
                 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1829,9 +1829,7 @@ impl Vm {
         let mut hob = TdHob::start(hob_offset.unwrap());
 
         let mut sorted_sections = sections.to_vec();
-        sorted_sections.retain(|section| {
-            !matches!(section.r#type, TdvfSectionType::Bfv | TdvfSectionType::Cfv)
-        });
+        sorted_sections.retain(|section| matches!(section.r#type, TdvfSectionType::TempMem));
 
         sorted_sections.sort_by_key(|section| section.address);
         sorted_sections.reverse();


### PR DESCRIPTION
Based on QEMU patches from branch `tdx-qemu-2022.03.29-v7.0.0-rc1` and based on latest guest kernel/image, let's update the Cloud Hypervisor support for TDX with this PR.