### PR TITLE
Add vIOMMU support to vDPA devices

### DIFF
--- a/block_util/src/lib.rs
+++ b/block_util/src/lib.rs
@@ -209,7 +209,7 @@ impl Request {
 
         let hdr_desc_addr = hdr_desc
             .addr()
-            .translate(access_platform, hdr_desc.len() as usize);
+            .translate_gva(access_platform, hdr_desc.len() as usize);
 
         let mut req = Request {
             request_type: request_type(desc_chain.memory(), hdr_desc_addr)?,
@@ -249,7 +249,8 @@ impl Request {
                 }
 
                 req.data_descriptors.push((
-                    desc.addr().translate(access_platform, desc.len() as usize),
+                    desc.addr()
+                        .translate_gva(access_platform, desc.len() as usize),
                     desc.len(),
                 ));
                 desc = desc_chain
@@ -274,7 +275,7 @@ impl Request {
 
         req.status_addr = status_desc
             .addr()
-            .translate(access_platform, status_desc.len() as usize);
+            .translate_gva(access_platform, status_desc.len() as usize);
 
         Ok(req)
     }

--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -71,14 +71,14 @@ impl CtrlQueue {
                     .read_obj(
                         ctrl_desc
                             .addr()
-                            .translate(access_platform, ctrl_desc.len() as usize),
+                            .translate_gva(access_platform, ctrl_desc.len() as usize),
                     )
                     .map_err(Error::GuestMemory)?;
                 let data_desc = desc_chain.next().ok_or(Error::NoDataDescriptor)?;
 
                 let data_desc_addr = data_desc
                     .addr()
-                    .translate(access_platform, data_desc.len() as usize);
+                    .translate_gva(access_platform, data_desc.len() as usize);
 
                 let status_desc = desc_chain.next().ok_or(Error::NoStatusDescriptor)?;
 
@@ -135,7 +135,7 @@ impl CtrlQueue {
                         if ok { VIRTIO_NET_OK } else { VIRTIO_NET_ERR } as u8,
                         status_desc
                             .addr()
-                            .translate(access_platform, status_desc.len() as usize),
+                            .translate_gva(access_platform, status_desc.len() as usize),
                     )
                     .map_err(Error::GuestMemory)?;
                 let len = ctrl_desc.len() + data_desc.len() + status_desc.len();

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -60,7 +60,9 @@ impl TxVirtio {
 
                 let mut iovecs = Vec::new();
                 while let Some(desc) = next_desc {
-                    let desc_addr = desc.addr().translate(access_platform, desc.len() as usize);
+                    let desc_addr = desc
+                        .addr()
+                        .translate_gva(access_platform, desc.len() as usize);
                     if !desc.is_write_only() && desc.len() > 0 {
                         let buf = desc_chain
                             .memory()
@@ -192,7 +194,8 @@ impl RxVirtio {
                 let num_buffers_addr = desc_chain
                     .memory()
                     .checked_offset(
-                        desc.addr().translate(access_platform, desc.len() as usize),
+                        desc.addr()
+                            .translate_gva(access_platform, desc.len() as usize),
                         10,
                     )
                     .unwrap();
@@ -200,7 +203,9 @@ impl RxVirtio {
 
                 let mut iovecs = Vec::new();
                 while let Some(desc) = next_desc {
-                    let desc_addr = desc.addr().translate(access_platform, desc.len() as usize);
+                    let desc_addr = desc
+                        .addr()
+                        .translate_gva(access_platform, desc.len() as usize);
                     if desc.is_write_only() && desc.len() > 0 {
                         let buf = desc_chain
                             .memory()

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -151,7 +151,7 @@ impl ConsoleEpollHandler {
             if let Err(e) = desc_chain.memory().write_slice(
                 &source_slice[..],
                 desc.addr()
-                    .translate(self.access_platform.as_ref(), desc.len() as usize),
+                    .translate_gva(self.access_platform.as_ref(), desc.len() as usize),
             ) {
                 error!("Failed to write slice: {:?}", e);
                 avail_iter.go_to_previous_position();
@@ -190,7 +190,7 @@ impl ConsoleEpollHandler {
             if let Some(ref mut out) = self.endpoint.out_file() {
                 let _ = desc_chain.memory().write_to(
                     desc.addr()
-                        .translate(self.access_platform.as_ref(), desc.len() as usize),
+                        .translate_gva(self.access_platform.as_ref(), desc.len() as usize),
                     out,
                     desc.len() as usize,
                 );

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -207,7 +207,8 @@ pub trait VirtioDevice: Send {
 /// On the other side, the implementation itself should be provided by the code
 /// emulating the IOMMU for the guest.
 pub trait DmaRemapping: Send + Sync {
-    fn translate(&self, id: u32, addr: u64) -> std::result::Result<u64, std::io::Error>;
+    /// Provide a way to translate GVA address ranges into GPAs.
+    fn translate_gva(&self, id: u32, addr: u64) -> std::result::Result<u64, std::io::Error>;
 }
 
 /// Structure to handle device state common to all devices

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -209,6 +209,8 @@ pub trait VirtioDevice: Send {
 pub trait DmaRemapping: Send + Sync {
     /// Provide a way to translate GVA address ranges into GPAs.
     fn translate_gva(&self, id: u32, addr: u64) -> std::result::Result<u64, std::io::Error>;
+    /// Provide a way to translate GPA address ranges into GVAs.
+    fn translate_gpa(&self, id: u32, addr: u64) -> std::result::Result<u64, std::io::Error>;
 }
 
 /// Structure to handle device state common to all devices

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -683,7 +683,7 @@ pub struct IommuMapping {
 }
 
 impl DmaRemapping for IommuMapping {
-    fn translate(&self, id: u32, addr: u64) -> std::result::Result<u64, std::io::Error> {
+    fn translate_gva(&self, id: u32, addr: u64) -> std::result::Result<u64, std::io::Error> {
         debug!("Translate addr 0x{:x}", addr);
         if let Some(domain) = self.endpoints.read().unwrap().get(&id) {
             if let Some(mapping) = self.mappings.read().unwrap().get(domain) {
@@ -720,8 +720,8 @@ impl AccessPlatformMapping {
 }
 
 impl AccessPlatform for AccessPlatformMapping {
-    fn translate(&self, base: u64, _size: u64) -> std::result::Result<u64, std::io::Error> {
-        self.mapping.translate(self.id, base)
+    fn translate_gva(&self, base: u64, _size: u64) -> std::result::Result<u64, std::io::Error> {
+        self.mapping.translate_gva(self.id, base)
     }
 }
 

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -133,7 +133,10 @@ impl Request {
 
         let request: VirtioPmemReq = desc_chain
             .memory()
-            .read_obj(desc.addr().translate(access_platform, desc.len() as usize))
+            .read_obj(
+                desc.addr()
+                    .translate_gva(access_platform, desc.len() as usize),
+            )
             .map_err(Error::GuestMemory)?;
 
         let request_type = match request.type_ {
@@ -156,7 +159,7 @@ impl Request {
             type_: request_type,
             status_addr: status_desc
                 .addr()
-                .translate(access_platform, status_desc.len() as usize),
+                .translate_gva(access_platform, status_desc.len() as usize),
         })
     }
 }

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -61,7 +61,7 @@ impl RngEpollHandler {
                     .memory()
                     .read_from(
                         desc.addr()
-                            .translate(self.access_platform.as_ref(), desc.len() as usize),
+                            .translate_gva(self.access_platform.as_ref(), desc.len() as usize),
                         &mut self.random_file,
                         desc.len() as usize,
                     )

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -204,11 +204,15 @@ impl VirtioPciCommonConfig {
                 // Translate address of descriptor table and vrings.
                 if let Some(access_platform) = &self.access_platform {
                     if ready {
-                        let desc_table =
-                            access_platform.translate(q.state.desc_table.0, 0).unwrap();
-                        let avail_ring =
-                            access_platform.translate(q.state.avail_ring.0, 0).unwrap();
-                        let used_ring = access_platform.translate(q.state.used_ring.0, 0).unwrap();
+                        let desc_table = access_platform
+                            .translate_gva(q.state.desc_table.0, 0)
+                            .unwrap();
+                        let avail_ring = access_platform
+                            .translate_gva(q.state.avail_ring.0, 0)
+                            .unwrap();
+                        let used_ring = access_platform
+                            .translate_gva(q.state.used_ring.0, 0)
+                            .unwrap();
                         q.set_desc_table_address(
                             Some((desc_table & 0xffff_ffff) as u32),
                             Some((desc_table >> 32) as u32),

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -334,6 +334,10 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VdpaDmaMapping<M
             ));
         };
 
+        debug!(
+            "DMA map iova 0x{:x}, gpa 0x{:x}, size 0x{:x}, host_addr 0x{:x}",
+            iova, gpa, size, user_addr as u64
+        );
         self.device
             .lock()
             .unwrap()
@@ -351,6 +355,7 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VdpaDmaMapping<M
     }
 
     fn unmap(&self, iova: u64, size: u64) -> std::result::Result<(), std::io::Error> {
+        debug!("DMA unmap iova 0x{:x} size 0x{:x}", iova, size);
         self.device
             .lock()
             .unwrap()

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -127,7 +127,8 @@ impl VsockPacket {
         let mut pkt = Self {
             hdr: get_host_address_range(
                 desc_chain.memory(),
-                head.addr().translate(access_platform, head.len() as usize),
+                head.addr()
+                    .translate_gva(access_platform, head.len() as usize),
                 VSOCK_PKT_HDR_SIZE,
             )
             .ok_or(VsockError::GuestMemory)? as *mut u8,
@@ -166,7 +167,7 @@ impl VsockPacket {
                 desc_chain.memory(),
                 buf_desc
                     .addr()
-                    .translate(access_platform, buf_desc.len() as usize),
+                    .translate_gva(access_platform, buf_desc.len() as usize),
                 pkt.buf_size,
             )
             .ok_or(VsockError::GuestMemory)? as *mut u8,
@@ -207,7 +208,8 @@ impl VsockPacket {
         Ok(Self {
             hdr: get_host_address_range(
                 desc_chain.memory(),
-                head.addr().translate(access_platform, head.len() as usize),
+                head.addr()
+                    .translate_gva(access_platform, head.len() as usize),
                 VSOCK_PKT_HDR_SIZE,
             )
             .ok_or(VsockError::GuestMemory)? as *mut u8,
@@ -216,7 +218,7 @@ impl VsockPacket {
                     desc_chain.memory(),
                     buf_desc
                         .addr()
-                        .translate(access_platform, buf_desc.len() as usize),
+                        .translate_gva(access_platform, buf_desc.len() as usize),
                     buf_size,
                 )
                 .ok_or(VsockError::GuestMemory)? as *mut u8,

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -96,16 +96,26 @@ impl fmt::Display for VirtioDeviceType {
 pub trait AccessPlatform: Send + Sync + Debug {
     /// Provide a way to translate GVA address ranges into GPAs.
     fn translate_gva(&self, base: u64, size: u64) -> std::result::Result<u64, std::io::Error>;
+    /// Provide a way to translate GPA address ranges into GVAs.
+    fn translate_gpa(&self, base: u64, size: u64) -> std::result::Result<u64, std::io::Error>;
 }
 
 pub trait Translatable {
     fn translate_gva(&self, access_platform: Option<&Arc<dyn AccessPlatform>>, len: usize) -> Self;
+    fn translate_gpa(&self, access_platform: Option<&Arc<dyn AccessPlatform>>, len: usize) -> Self;
 }
 
 impl Translatable for GuestAddress {
     fn translate_gva(&self, access_platform: Option<&Arc<dyn AccessPlatform>>, len: usize) -> Self {
         if let Some(access_platform) = access_platform {
             GuestAddress(access_platform.translate_gva(self.0, len as u64).unwrap())
+        } else {
+            *self
+        }
+    }
+    fn translate_gpa(&self, access_platform: Option<&Arc<dyn AccessPlatform>>, len: usize) -> Self {
+        if let Some(access_platform) = access_platform {
+            GuestAddress(access_platform.translate_gpa(self.0, len as u64).unwrap())
         } else {
             *self
         }

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -94,19 +94,18 @@ impl fmt::Display for VirtioDeviceType {
 /// Trait for devices with access to data in memory being limited and/or
 /// translated.
 pub trait AccessPlatform: Send + Sync + Debug {
-    /// Provide a way to translate address ranges.
-    fn translate(&self, base: u64, size: u64) -> std::result::Result<u64, std::io::Error>;
+    /// Provide a way to translate GVA address ranges into GPAs.
+    fn translate_gva(&self, base: u64, size: u64) -> std::result::Result<u64, std::io::Error>;
 }
 
 pub trait Translatable {
-    #[must_use]
-    fn translate(&self, access_platform: Option<&Arc<dyn AccessPlatform>>, len: usize) -> Self;
+    fn translate_gva(&self, access_platform: Option<&Arc<dyn AccessPlatform>>, len: usize) -> Self;
 }
 
 impl Translatable for GuestAddress {
-    fn translate(&self, access_platform: Option<&Arc<dyn AccessPlatform>>, len: usize) -> Self {
+    fn translate_gva(&self, access_platform: Option<&Arc<dyn AccessPlatform>>, len: usize) -> Self {
         if let Some(access_platform) = access_platform {
-            GuestAddress(access_platform.translate(self.0, len as u64).unwrap())
+            GuestAddress(access_platform.translate_gva(self.0, len as u64).unwrap())
         } else {
             *self
         }

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -965,6 +965,9 @@ components:
         num_queues:
           type: integer
           default: 1
+        iommu:
+          type: boolean
+          default: false
         pci_segment:
           type: integer
           format: int16

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2947,7 +2947,7 @@ impl DeviceManager {
 
         Ok(MetaVirtioDevice {
             virtio_device: vdpa_device as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-            iommu: false,
+            iommu: vdpa_cfg.iommu,
             id,
             pci_segment: vdpa_cfg.pci_segment,
             dma_handler: Some(vdpa_mapping),
@@ -4010,6 +4010,10 @@ impl DeviceManager {
     }
 
     pub fn add_vdpa(&mut self, vdpa_cfg: &mut VdpaConfig) -> DeviceManagerResult<PciDeviceInfo> {
+        if vdpa_cfg.iommu && !self.is_iommu_segment(vdpa_cfg.pci_segment) {
+            return Err(DeviceManagerError::InvalidIommuHotplug);
+        }
+
         let device = self.make_vdpa_device(vdpa_cfg)?;
         self.hotplug_virtio_pci_device(device)
     }


### PR DESCRIPTION
Adding the support for placing a vDPA device behind a virtual IOMMU, making the guest seeing the device as being attached to an IOMMU.

Partially fixes #3809