### PR TITLE
pci: Store BARs addresses through a list of PCI resources

### DIFF
--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -88,6 +88,10 @@ impl PciDevice for PciRoot {
     fn as_any(&mut self) -> &mut dyn Any {
         self
     }
+
+    fn id(&self) -> Option<String> {
+        None
+    }
 }
 
 pub struct PciBus {

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -8,7 +8,7 @@ use std::fmt::{self, Display};
 use std::sync::{Arc, Barrier, Mutex};
 use std::{self, io, result};
 use vm_allocator::{AddressAllocator, SystemAllocator};
-use vm_device::BusDevice;
+use vm_device::{BusDevice, Resource};
 use vm_memory::{GuestAddress, GuestUsize};
 
 #[derive(Debug)]
@@ -19,6 +19,10 @@ pub enum Error {
     IoAllocationFailed(u64),
     /// Registering an IO BAR failed.
     IoRegistrationFailed(u64, configuration::Error),
+    /// Not enough resources
+    MissingResource,
+    /// Invalid type of resource
+    InvalidResourceType,
 }
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -34,6 +38,8 @@ impl Display for Error {
             IoRegistrationFailed(addr, e) => {
                 write!(f, "failed to register an IO BAR, addr={} err={}", addr, e)
             }
+            MissingResource => write!(f, "Missing resource"),
+            InvalidResourceType => write!(f, "Invalid type of resource"),
         }
     }
 }
@@ -53,6 +59,7 @@ pub trait PciDevice: BusDevice {
         &mut self,
         _allocator: &Arc<Mutex<SystemAllocator>>,
         _mmio_allocator: &mut AddressAllocator,
+        _resources: Option<Vec<Resource>>,
     ) -> Result<Vec<(GuestAddress, GuestUsize, PciBarRegionType)>> {
         Ok(Vec::new())
     }

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -110,6 +110,9 @@ pub trait PciDevice: BusDevice {
     /// Provides a mutable reference to the Any trait. This is useful to let
     /// the caller have access to the underlying type behind the trait.
     fn as_any(&mut self) -> &mut dyn Any;
+
+    /// Optionally returns a unique identifier.
+    fn id(&self) -> Option<String>;
 }
 
 /// This trait defines a set of functions which can be triggered whenever a

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -23,7 +23,7 @@ use vm_allocator::{AddressAllocator, SystemAllocator};
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceGroup, MsiIrqGroupConfig,
 };
-use vm_device::BusDevice;
+use vm_device::{BusDevice, Resource};
 use vm_memory::{Address, GuestAddress, GuestUsize};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -363,6 +363,7 @@ impl VfioCommon {
         allocator: &Arc<Mutex<SystemAllocator>>,
         mmio_allocator: &mut AddressAllocator,
         vfio_wrapper: &dyn Vfio,
+        _resources: Option<Vec<Resource>>,
     ) -> Result<Vec<(GuestAddress, GuestUsize, PciBarRegionType)>, PciDeviceError> {
         let mut ranges = Vec::new();
         let mut bar_id = VFIO_PCI_BAR0_REGION_INDEX as u32;
@@ -1326,9 +1327,10 @@ impl PciDevice for VfioPciDevice {
         &mut self,
         allocator: &Arc<Mutex<SystemAllocator>>,
         mmio_allocator: &mut AddressAllocator,
+        resources: Option<Vec<Resource>>,
     ) -> Result<Vec<(GuestAddress, GuestUsize, PciBarRegionType)>, PciDeviceError> {
         self.common
-            .allocate_bars(allocator, mmio_allocator, &self.vfio_wrapper)
+            .allocate_bars(allocator, mmio_allocator, &self.vfio_wrapper, resources)
     }
 
     fn free_bars(

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -976,6 +976,7 @@ impl VfioCommon {
 /// The VMM creates a VfioDevice, then assigns it to a VfioPciDevice,
 /// which then gets added to the PCI bus.
 pub struct VfioPciDevice {
+    id: String,
     vm: Arc<dyn hypervisor::Vm>,
     device: Arc<VfioDevice>,
     container: Arc<VfioContainer>,
@@ -986,7 +987,9 @@ pub struct VfioPciDevice {
 
 impl VfioPciDevice {
     /// Constructs a new Vfio Pci device for the given Vfio device
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
+        id: String,
         vm: &Arc<dyn hypervisor::Vm>,
         device: VfioDevice,
         container: Arc<VfioContainer>,
@@ -1027,6 +1030,7 @@ impl VfioPciDevice {
         common.initialize_legacy_interrupt(legacy_interrupt_group, &vfio_wrapper)?;
 
         let vfio_pci_device = VfioPciDevice {
+            id,
             vm: vm.clone(),
             device,
             container,
@@ -1437,5 +1441,9 @@ impl PciDevice for VfioPciDevice {
 
     fn as_any(&mut self) -> &mut dyn Any {
         self
+    }
+
+    fn id(&self) -> Option<String> {
+        Some(self.id.clone())
     }
 }

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -21,7 +21,7 @@ use vfio_user::{Client, Error as VfioUserError};
 use vm_allocator::{AddressAllocator, SystemAllocator};
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_device::interrupt::{InterruptManager, InterruptSourceGroup, MsiIrqGroupConfig};
-use vm_device::BusDevice;
+use vm_device::{BusDevice, Resource};
 use vm_memory::bitmap::AtomicBitmap;
 use vm_memory::{
     Address, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryRegion, GuestRegionMmap,
@@ -392,9 +392,10 @@ impl PciDevice for VfioUserPciDevice {
         &mut self,
         allocator: &Arc<Mutex<SystemAllocator>>,
         mmio_allocator: &mut AddressAllocator,
+        resources: Option<Vec<Resource>>,
     ) -> Result<Vec<(GuestAddress, GuestUsize, PciBarRegionType)>, PciDeviceError> {
         self.common
-            .allocate_bars(allocator, mmio_allocator, &self.vfio_wrapper)
+            .allocate_bars(allocator, mmio_allocator, &self.vfio_wrapper, resources)
     }
 
     fn free_bars(

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -30,6 +30,7 @@ use vm_memory::{
 use vmm_sys_util::eventfd::EventFd;
 
 pub struct VfioUserPciDevice {
+    id: String,
     vm: Arc<dyn hypervisor::Vm>,
     client: Arc<Mutex<Client>>,
     vfio_wrapper: VfioUserClientWrapper,
@@ -63,6 +64,7 @@ impl PciSubclass for PciVfioUserSubclass {
 
 impl VfioUserPciDevice {
     pub fn new(
+        id: String,
         vm: &Arc<dyn hypervisor::Vm>,
         client: Arc<Mutex<Client>>,
         msi_interrupt_manager: &Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>>,
@@ -111,6 +113,7 @@ impl VfioUserPciDevice {
             .map_err(VfioUserPciDeviceError::InitializeLegacyInterrupts)?;
 
         Ok(Self {
+            id,
             vm: vm.clone(),
             client,
             vfio_wrapper,
@@ -485,6 +488,10 @@ impl PciDevice for VfioUserPciDevice {
         }
 
         Ok(())
+    }
+
+    fn id(&self) -> Option<String> {
+        Some(self.id.clone())
     }
 }
 

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1089,6 +1089,10 @@ impl PciDevice for VirtioPciDevice {
     fn as_any(&mut self) -> &mut dyn Any {
         self
     }
+
+    fn id(&self) -> Option<String> {
+        Some(self.id.clone())
+    }
 }
 
 impl BusDevice for VirtioPciDevice {


### PR DESCRIPTION
By relying on the `Resource` structure defined in the `vm-device` crate, we're able to factorize and reuse the same code from VIRTIO, VFIO and vfio-user, so that we can store the BARs addresses of every device. This is preparatory work to make sure all PCI devices can be eventually snapshot/restored/migrated.