### PR TITLE
Refactoring layout related code on AArch64

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -18,14 +18,13 @@ use std::str;
 use super::super::DeviceType;
 use super::super::GuestMemoryMmap;
 use super::super::InitramfsConfig;
-use super::get_fdt_addr;
 use super::gic::GicDevice;
 use super::layout::{
     IRQ_BASE, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START, MEM_PCI_IO_SIZE, MEM_PCI_IO_START,
     PCI_HIGH_BASE, PCI_MMIO_CONFIG_SIZE_PER_SEGMENT,
 };
 use vm_fdt::{FdtWriter, FdtWriterResult};
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryRegion};
+use vm_memory::{Address, Bytes, GuestMemory, GuestMemoryError, GuestMemoryRegion};
 
 // This is a value for uniquely identifying the FDT node declaring the interrupt controller.
 const GIC_PHANDLE: u32 = 1;
@@ -141,9 +140,8 @@ pub fn create_fdt<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHash
 
 pub fn write_fdt_to_memory(fdt_final: Vec<u8>, guest_mem: &GuestMemoryMmap) -> Result<()> {
     // Write FDT to memory.
-    let fdt_address = GuestAddress(get_fdt_addr());
     guest_mem
-        .write_slice(fdt_final.as_slice(), fdt_address)
+        .write_slice(fdt_final.as_slice(), super::layout::FDT_START)
         .map_err(Error::WriteFdtToMemory)?;
     Ok(())
 }

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -580,11 +580,11 @@ fn create_pci_nodes(
         // Here we cut off PCI device space below 8G in FDT to workaround the EDK2 check.
         // But the address written in ACPI is not impacted.
         let (pci_device_base_64bit, pci_device_size_64bit) =
-            if pci_device_info_elem.pci_device_space_start < PCI_HIGH_BASE {
+            if pci_device_info_elem.pci_device_space_start < PCI_HIGH_BASE.raw_value() {
                 (
-                    PCI_HIGH_BASE,
+                    PCI_HIGH_BASE.raw_value(),
                     pci_device_info_elem.pci_device_space_size
-                        - (PCI_HIGH_BASE - pci_device_info_elem.pci_device_space_start),
+                        - (PCI_HIGH_BASE.raw_value() - pci_device_info_elem.pci_device_space_start),
                 )
             } else {
                 (

--- a/arch/src/aarch64/gic/gicv3.rs
+++ b/arch/src/aarch64/gic/gicv3.rs
@@ -22,6 +22,7 @@ pub mod kvm {
     use std::{boxed::Box, result};
     use versionize::{VersionMap, Versionize, VersionizeResult};
     use versionize_derive::Versionize;
+    use vm_memory::Address;
     use vm_migration::{
         Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable,
         VersionMapped,
@@ -83,7 +84,7 @@ pub mod kvm {
 
         /// Get the address of the GIC distributor.
         pub fn get_dist_addr() -> u64 {
-            layout::GIC_V3_DIST_START
+            layout::GIC_V3_DIST_START.raw_value()
         }
 
         /// Get the size of the GIC distributor.

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -55,17 +55,16 @@ use vm_memory::GuestAddress;
 
 /// 0x0 ~ 0x40_0000 (4 MiB) is reserved to UEFI
 /// UEFI binary size is required less than 3 MiB, reserving 4 MiB is enough.
-pub const UEFI_START: u64 = 0x0;
-pub const MEM_UEFI_START: GuestAddress = GuestAddress(0);
+pub const UEFI_START: GuestAddress = GuestAddress(0);
 pub const UEFI_SIZE: u64 = 0x040_0000;
 
 /// Below this address will reside the GIC, above this address will reside the MMIO devices.
-pub const MAPPED_IO_START: u64 = 0x0900_0000;
+pub const MAPPED_IO_START: GuestAddress = GuestAddress(0x0900_0000);
 
 /// See kernel file arch/arm64/include/uapi/asm/kvm.h for the GIC related definitions.
 /// 0x08ff_0000 ~ 0x0900_0000 is reserved for GICv3 Distributor
 pub const GIC_V3_DIST_SIZE: u64 = 0x01_0000;
-pub const GIC_V3_DIST_START: u64 = MAPPED_IO_START - GIC_V3_DIST_SIZE;
+pub const GIC_V3_DIST_START: GuestAddress = GuestAddress(MAPPED_IO_START.0 - GIC_V3_DIST_SIZE);
 /// Below 0x08ff_0000 is reserved for GICv3 Redistributor.
 /// The size defined here is for each vcpu.
 /// The total size is 'number_of_vcpu * GIC_V3_REDIST_SIZE'
@@ -74,9 +73,9 @@ pub const GIC_V3_REDIST_SIZE: u64 = 0x02_0000;
 pub const GIC_V3_ITS_SIZE: u64 = 0x02_0000;
 
 /// Space 0x0900_0000 ~ 0x0905_0000 is reserved for legacy devices.
-pub const LEGACY_SERIAL_MAPPED_IO_START: u64 = 0x0900_0000;
-pub const LEGACY_RTC_MAPPED_IO_START: u64 = 0x0901_0000;
-pub const LEGACY_GPIO_MAPPED_IO_START: u64 = 0x0902_0000;
+pub const LEGACY_SERIAL_MAPPED_IO_START: GuestAddress = GuestAddress(0x0900_0000);
+pub const LEGACY_RTC_MAPPED_IO_START: GuestAddress = GuestAddress(0x0901_0000);
+pub const LEGACY_GPIO_MAPPED_IO_START: GuestAddress = GuestAddress(0x0902_0000);
 
 /// Space 0x0905_0000 ~ 0x0906_0000 is reserved for pcie io address
 pub const MEM_PCI_IO_START: GuestAddress = GuestAddress(0x0905_0000);
@@ -108,19 +107,19 @@ pub const CMDLINE_MAX_SIZE: usize = 2048;
 
 /// FDT is at the beginning of RAM.
 /// Maximum size of the device tree blob as specified in https://www.kernel.org/doc/Documentation/arm64/booting.txt.
-pub const FDT_START: u64 = RAM_START.0;
-pub const FDT_MAX_SIZE: usize = 0x20_0000;
+pub const FDT_START: GuestAddress = RAM_START;
+pub const FDT_MAX_SIZE: u64 = 0x20_0000;
 
 /// Put ACPI table above dtb
-pub const ACPI_START: u64 = RAM_START.0 + FDT_MAX_SIZE as u64;
-pub const ACPI_MAX_SIZE: usize = 0x20_0000;
-pub const RSDP_POINTER: GuestAddress = GuestAddress(ACPI_START);
+pub const ACPI_START: GuestAddress = GuestAddress(RAM_START.0 + FDT_MAX_SIZE);
+pub const ACPI_MAX_SIZE: u64 = 0x20_0000;
+pub const RSDP_POINTER: GuestAddress = ACPI_START;
 
 /// Kernel start after FDT and ACPI
-pub const KERNEL_START: u64 = ACPI_START + ACPI_MAX_SIZE as u64;
+pub const KERNEL_START: GuestAddress = GuestAddress(ACPI_START.0 + ACPI_MAX_SIZE);
 
 /// Pci high memory base
-pub const PCI_HIGH_BASE: u64 = 0x2_0000_0000_u64;
+pub const PCI_HIGH_BASE: GuestAddress = GuestAddress(0x2_0000_0000);
 
 // As per virt/kvm/arm/vgic/vgic-kvm-device.c we need
 // the number of interrupts our GIC will support to be:

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -202,17 +202,17 @@ pub fn initramfs_load_addr(
 
 /// Returns the memory address where the kernel could be loaded.
 pub fn get_kernel_start() -> u64 {
-    layout::KERNEL_START
+    layout::KERNEL_START.raw_value()
 }
 
 ///Return guest memory address where the uefi should be loaded.
 pub fn get_uefi_start() -> u64 {
-    layout::UEFI_START
+    layout::UEFI_START.raw_value()
 }
 
 // Auxiliary function to get the address where the device tree blob is loaded.
 fn get_fdt_addr() -> u64 {
-    layout::FDT_START
+    layout::FDT_START.raw_value()
 }
 
 pub fn get_host_cpu_phys_bits() -> u8 {

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -200,21 +200,6 @@ pub fn initramfs_load_addr(
     }
 }
 
-/// Returns the memory address where the kernel could be loaded.
-pub fn get_kernel_start() -> u64 {
-    layout::KERNEL_START.raw_value()
-}
-
-///Return guest memory address where the uefi should be loaded.
-pub fn get_uefi_start() -> u64 {
-    layout::UEFI_START.raw_value()
-}
-
-// Auxiliary function to get the address where the device tree blob is loaded.
-fn get_fdt_addr() -> u64 {
-    layout::FDT_START.raw_value()
-}
-
 pub fn get_host_cpu_phys_bits() -> u8 {
     // A dummy hypervisor created only for querying the host IPA size and will
     // be freed after the query.

--- a/arch/src/aarch64/regs.rs
+++ b/arch/src/aarch64/regs.rs
@@ -5,13 +5,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-use super::get_fdt_addr;
 use hypervisor::kvm::kvm_bindings::{
     kvm_regs, user_pt_regs, KVM_REG_ARM64, KVM_REG_ARM_CORE, KVM_REG_SIZE_U64,
 };
 use hypervisor::{arm64_core_reg_id, offset__of};
 use std::sync::Arc;
 use std::{mem, result};
+use vm_memory::Address;
 
 /// Errors thrown while setting aarch64 registers.
 #[derive(Debug)]
@@ -67,7 +67,7 @@ pub fn setup_regs(vcpu: &Arc<dyn hypervisor::Vcpu>, cpu_id: u8, boot_ip: u64) ->
         let regs0 = offset__of!(user_pt_regs, regs) + kreg_off;
         vcpu.set_reg(
             arm64_core_reg_id!(KVM_REG_SIZE_U64, regs0),
-            get_fdt_addr() as u64,
+            super::layout::FDT_START.raw_value(),
         )
         .map_err(Error::SetCoreRegister)?;
     }

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -85,8 +85,8 @@ pub mod aarch64;
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::{
     arch_memory_regions, configure_system, configure_vcpu, fdt::DeviceInfoForFdt,
-    get_host_cpu_phys_bits, get_kernel_start, get_uefi_start, initramfs_load_addr, layout,
-    layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, uefi, EntryPoint,
+    get_host_cpu_phys_bits, initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE,
+    layout::IRQ_BASE, uefi, EntryPoint,
 };
 
 #[cfg(target_arch = "x86_64")]

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -667,7 +667,7 @@ pub fn create_acpi_tables(
             .clone()
             .get(&(DeviceType::Serial, DeviceType::Serial.to_string()))
             .is_some();
-        let serial_device_addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START;
+        let serial_device_addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START.raw_value();
         let serial_device_irq = if is_serial_on {
             device_manager
                 .lock()

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1276,6 +1276,7 @@ impl CpuManager {
 
         #[cfg(target_arch = "aarch64")]
         {
+            use vm_memory::Address;
             /* Notes:
              * Ignore Local Interrupt Controller Address at byte offset 36 of MADT table.
              */
@@ -1323,7 +1324,7 @@ impl CpuManager {
                 length: 24,
                 reserved0: 0,
                 gic_id: 0,
-                base_address: arch::layout::MAPPED_IO_START - 0x0001_0000,
+                base_address: arch::layout::MAPPED_IO_START.raw_value() - 0x0001_0000,
                 global_irq_base: 0,
                 version: 3,
                 reserved1: [0; 3],
@@ -1332,7 +1333,8 @@ impl CpuManager {
 
             // See 5.2.12.17 GIC Redistributor (GICR) Structure in ACPI spec.
             let gicr_size: u32 = 0x0001_0000 * 2 * (self.config.boot_vcpus as u32);
-            let gicr_base: u64 = arch::layout::MAPPED_IO_START - 0x0001_0000 - gicr_size as u64;
+            let gicr_base: u64 =
+                arch::layout::MAPPED_IO_START.raw_value() - 0x0001_0000 - gicr_size as u64;
             let gicr = GicR {
                 r#type: acpi::ACPI_APIC_GENERIC_REDISTRIBUTOR,
                 length: 16,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1190,7 +1190,7 @@ impl DeviceManager {
         #[cfg(target_arch = "aarch64")]
         {
             let vcpus = self.config.lock().unwrap().cpus.boot_vcpus;
-            let msi_start = arch::layout::GIC_V3_DIST_START
+            let msi_start = arch::layout::GIC_V3_DIST_START.raw_value()
                 - arch::layout::GIC_V3_REDIST_SIZE * (vcpus as u64)
                 - arch::layout::GIC_V3_ITS_SIZE;
             let msi_end = msi_start + arch::layout::GIC_V3_ITS_SIZE - 1;
@@ -1539,7 +1539,7 @@ impl DeviceManager {
         self.bus_devices
             .push(Arc::clone(&rtc_device) as Arc<Mutex<dyn BusDevice>>);
 
-        let addr = GuestAddress(arch::layout::LEGACY_RTC_MAPPED_IO_START);
+        let addr = arch::layout::LEGACY_RTC_MAPPED_IO_START;
 
         self.address_manager
             .mmio_bus
@@ -1579,7 +1579,7 @@ impl DeviceManager {
         self.bus_devices
             .push(Arc::clone(&gpio_device) as Arc<Mutex<dyn BusDevice>>);
 
-        let addr = GuestAddress(arch::layout::LEGACY_GPIO_MAPPED_IO_START);
+        let addr = arch::layout::LEGACY_GPIO_MAPPED_IO_START;
 
         self.address_manager
             .mmio_bus
@@ -1685,7 +1685,7 @@ impl DeviceManager {
         self.bus_devices
             .push(Arc::clone(&serial) as Arc<Mutex<dyn BusDevice>>);
 
-        let addr = GuestAddress(arch::layout::LEGACY_SERIAL_MAPPED_IO_START);
+        let addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START;
 
         self.address_manager
             .mmio_bus
@@ -4293,7 +4293,7 @@ impl Aml for DeviceManager {
                             #[cfg(target_arch = "aarch64")]
                             &aml::Memory32Fixed::new(
                                 true,
-                                arch::layout::LEGACY_SERIAL_MAPPED_IO_START as u32,
+                                arch::layout::LEGACY_SERIAL_MAPPED_IO_START.raw_value() as u32,
                                 MMIO_LEN as u32,
                             ),
                         ]),


### PR DESCRIPTION
Some code optimization work:
-  Align the type of `*_START` constants to `GuestAddress`
- Remove some functions that only return a layout constant