### PR TITLE
build: migrate to Rust 2021 edition

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.54
+          - 1.56
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2018"
+edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cloud-hypervisor"
 version = "22.0.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 default-run = "cloud-hypervisor"
 build = "build.rs"
 license = "LICENSE-APACHE & LICENSE-BSD-3-Clause"
@@ -10,7 +10,7 @@ description = "Open source Virtual Machine Monitor (VMM) that runs on top of KVM
 homepage = "https://github.com/cloud-hypervisor/cloud-hypervisor"
 # Minimum buildable version:
 # Keep in sync with version in .github/workflows/build.yaml
-rust-version = "1.54"
+rust-version = "1.56"
 
 [profile.release]
 lto = true
@@ -34,7 +34,7 @@ vmm-sys-util = "0.9.0"
 vm-memory = "0.7.0"
 
 [build-dependencies]
-clap = { version = "3.1.8", features = ["wrap_help"] }
+clap = { version = "3.1.8", features = ["cargo"] }
 
 # List of patched crates
 [patch.crates-io]

--- a/acpi_tables/Cargo.toml
+++ b/acpi_tables/Cargo.toml
@@ -2,7 +2,7 @@
 name = "acpi_tables"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 vm-memory = "0.7.0"

--- a/api_client/Cargo.toml
+++ b/api_client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "api_client"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 vmm-sys-util = "0.9.0"

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arch"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -2,7 +2,7 @@
 name = "block_util"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -2,7 +2,7 @@
 name = "devices"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 acpi_tables = { path = "../acpi_tables" }

--- a/event_monitor/Cargo.toml
+++ b/event_monitor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "event_monitor"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libc = "0.2.121"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "cloud-hypervisor-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hypervisor"
 version = "0.1.0"
 authors = ["Microsoft Authors"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0 OR BSD-3-Clause"
 
 [features]

--- a/net_gen/Cargo.toml
+++ b/net_gen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "net_gen"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 vmm-sys-util = "0.9.0"

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -2,7 +2,7 @@
 name = "net_util"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 epoll = "4.3.1"

--- a/option_parser/Cargo.toml
+++ b/option_parser/Cargo.toml
@@ -2,4 +2,4 @@
 name = "option_parser"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pci"
 version = "0.1.0"
 authors = ["Samuel Ortiz <sameo@linux.intel.com>"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -2,7 +2,7 @@
 name = "performance-metrics"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 
 [dependencies]

--- a/qcow/Cargo.toml
+++ b/qcow/Cargo.toml
@@ -2,7 +2,7 @@
 name = "qcow"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
-edition = "2018"
+edition = "2021"
 license = "BSD-3-Clause"
 
 [lib]

--- a/rate_limiter/Cargo.toml
+++ b/rate_limiter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rate_limiter"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libc = "0.2.121"

--- a/test_infra/Cargo.toml
+++ b/test_infra/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_infra"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 dirs = "4.0.0"

--- a/vfio_user/Cargo.toml
+++ b/vfio_user/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vfio_user"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0.56"

--- a/vhdx/Cargo.toml
+++ b/vhdx/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vhdx"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vhost_user_block"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 block_util = { path = "../block_util" }

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vhost_user_net"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 clap = { version = "3.1.8", features = ["wrap_help"] }

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -2,7 +2,7 @@
 name = "virtio-devices"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vm-allocator"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libc = "0.2.121"

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vm-device"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vm-migration"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0.56"

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vm-virtio"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vmm"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []


### PR DESCRIPTION
Rust 2021 edition has a few improvements over the 2018 edition. Migrate
the project to 2021 edition by following recommended migration steps.
Luckily, the code itself doesn't require fixing.

Bump MSRV to 1.56 as it is required by the 2021 edition. Also fix the
clap build dependency to make Cloud Hypervisor build again.

Signed-off-by: Wei Liu <liuwe@microsoft.com>