### PR TITLE
.github: Fix Rust version for release to 1.58

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,12 +16,12 @@ jobs:
       - name: Install Rust toolchain (x86_64-unknown-linux-gnu)
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
+            toolchain: 1.58
             target: x86_64-unknown-linux-gnu
       - name: Install Rust toolchain (x86_64-unknown-linux-musl)
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
+            toolchain: 1.58
             target: x86_64-unknown-linux-musl
       - name: Build
         run: cargo build --all --release --target=x86_64-unknown-linux-gnu
@@ -32,7 +32,7 @@ jobs:
       - name: Install Rust toolchain (aarch64-unknown-linux-musl)
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
+            toolchain: 1.58
             target: aarch64-unknown-linux-musl
             override: true
       - name: Static Build (AArch64)


### PR DESCRIPTION
Unfortunately Rust 1.59 produces binaries that segfault when compiled
with musl-gcc wrappers. Which is exactly how we produce out aarch64 and
musl binaries for the release.

See: https://github.com/rust-lang/rust/issues/95926

Signed-off-by: Rob Bradford <robert.bradford@intel.com>