### PR TITLE
build: fix performance-metrics build

### DIFF
--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -16,4 +16,4 @@ thiserror = "1.0.30"
 wait-timeout = "0.2.0"
 
 [build-dependencies]
-clap = { version = "3.1.8", features = ["wrap_help"] }
+clap = { version = "3.1.8", features = ["cargo"] }


### PR DESCRIPTION
It suffered from the same issue like the main program after switching to
Rust 2021 edition, but the issue was not caught by the CI.

Signed-off-by: Wei Liu <liuwe@microsoft.com>