### PR TITLE
vm-device, pci, devices: Remove InterruptSourceGroup::{un}mask

### DIFF
--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -76,6 +76,7 @@ impl InterruptController for Gic {
                 .update(
                     i as InterruptIndex,
                     InterruptSourceConfig::LegacyIrq(config),
+                    false,
                 )
                 .map_err(Error::EnableInterrupt)?;
         }

--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -367,18 +367,12 @@ impl Ioapic {
         };
 
         self.interrupt_source_group
-            .update(irq as InterruptIndex, InterruptSourceConfig::MsiIrq(config))
+            .update(
+                irq as InterruptIndex,
+                InterruptSourceConfig::MsiIrq(config),
+                interrupt_mask(entry) == 1,
+            )
             .map_err(Error::UpdateInterrupt)?;
-
-        if interrupt_mask(entry) == 1 {
-            self.interrupt_source_group
-                .mask(irq as InterruptIndex)
-                .map_err(Error::MaskInterrupt)?;
-        } else {
-            self.interrupt_source_group
-                .unmask(irq as InterruptIndex)
-                .map_err(Error::UnmaskInterrupt)?;
-        }
 
         Ok(())
     }

--- a/devices/src/legacy/gpio_pl061.rs
+++ b/devices/src/legacy/gpio_pl061.rs
@@ -356,6 +356,7 @@ mod tests {
             &self,
             _index: InterruptIndex,
             _config: InterruptSourceConfig,
+            _masked: bool,
         ) -> result::Result<(), std::io::Error> {
             Ok(())
         }

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -430,6 +430,7 @@ mod tests {
             &self,
             _index: InterruptIndex,
             _config: InterruptSourceConfig,
+            _masked: bool,
         ) -> result::Result<(), std::io::Error> {
             Ok(())
         }

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -339,6 +339,7 @@ mod tests {
             &self,
             _index: InterruptIndex,
             _config: InterruptSourceConfig,
+            _masked: bool,
         ) -> result::Result<(), std::io::Error> {
             Ok(())
         }

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -450,6 +450,7 @@ mod tests {
             &self,
             _index: InterruptIndex,
             _config: InterruptSourceConfig,
+            _masked: bool,
         ) -> result::Result<(), std::io::Error> {
             Ok(())
         }

--- a/pci/src/msi.rs
+++ b/pci/src/msi.rs
@@ -201,19 +201,12 @@ impl MsiConfig {
                     devid: 0,
                 };
 
-                if let Err(e) = self
-                    .interrupt_source_group
-                    .update(idx as InterruptIndex, InterruptSourceConfig::MsiIrq(config))
-                {
+                if let Err(e) = self.interrupt_source_group.update(
+                    idx as InterruptIndex,
+                    InterruptSourceConfig::MsiIrq(config),
+                    self.cap.vector_masked(idx),
+                ) {
                     error!("Failed updating vector: {:?}", e);
-                }
-
-                if self.cap.vector_masked(idx) {
-                    if let Err(e) = self.interrupt_source_group.mask(idx as InterruptIndex) {
-                        error!("Failed masking vector: {:?}", e);
-                    }
-                } else if let Err(e) = self.interrupt_source_group.unmask(idx as InterruptIndex) {
-                    error!("Failed unmasking vector: {:?}", e);
                 }
             }
 

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -132,7 +132,11 @@ impl MsixConfig {
                 };
 
                 self.interrupt_source_group
-                    .update(idx as InterruptIndex, InterruptSourceConfig::MsiIrq(config))
+                    .update(
+                        idx as InterruptIndex,
+                        InterruptSourceConfig::MsiIrq(config),
+                        self.masked,
+                    )
                     .map_err(Error::UpdateInterruptRoute)?;
 
                 self.interrupt_source_group
@@ -171,20 +175,12 @@ impl MsixConfig {
                         devid: self.devid,
                     };
 
-                    if let Err(e) = self
-                        .interrupt_source_group
-                        .update(idx as InterruptIndex, InterruptSourceConfig::MsiIrq(config))
-                    {
+                    if let Err(e) = self.interrupt_source_group.update(
+                        idx as InterruptIndex,
+                        InterruptSourceConfig::MsiIrq(config),
+                        table_entry.masked(),
+                    ) {
                         error!("Failed updating vector: {:?}", e);
-                    }
-
-                    if table_entry.masked() {
-                        if let Err(e) = self.interrupt_source_group.mask(idx as InterruptIndex) {
-                            error!("Failed masking vector: {:?}", e);
-                        }
-                    } else if let Err(e) = self.interrupt_source_group.unmask(idx as InterruptIndex)
-                    {
-                        error!("Failed unmasking vector: {:?}", e);
                     }
                 }
             } else if old_enabled || !old_masked {
@@ -314,16 +310,9 @@ impl MsixConfig {
             if let Err(e) = self.interrupt_source_group.update(
                 index as InterruptIndex,
                 InterruptSourceConfig::MsiIrq(config),
+                table_entry.masked(),
             ) {
                 error!("Failed updating vector: {:?}", e);
-            }
-
-            if table_entry.masked() {
-                if let Err(e) = self.interrupt_source_group.mask(index as InterruptIndex) {
-                    error!("Failed masking vector: {:?}", e);
-                }
-            } else if let Err(e) = self.interrupt_source_group.unmask(index as InterruptIndex) {
-                error!("Failed unmasking vector: {:?}", e);
             }
         }
 

--- a/vm-device/src/interrupt/mod.rs
+++ b/vm-device/src/interrupt/mod.rs
@@ -178,19 +178,11 @@ pub trait InterruptSourceGroup: Send + Sync {
     /// # Arguments
     /// * index: sub-index into the group.
     /// * config: configuration data for the interrupt source.
-    fn update(&self, index: InterruptIndex, config: InterruptSourceConfig) -> Result<()>;
-
-    /// Mask an interrupt from this interrupt source.
-    fn mask(&self, _index: InterruptIndex) -> Result<()> {
-        // Not all interrupt sources can be disabled.
-        // To accommodate this, we can have a no-op here.
-        Ok(())
-    }
-
-    /// Unmask an interrupt from this interrupt source.
-    fn unmask(&self, _index: InterruptIndex) -> Result<()> {
-        // Not all interrupt sources can be disabled.
-        // To accommodate this, we can have a no-op here.
-        Ok(())
-    }
+    /// * masked: if the interrupt is masked
+    fn update(
+        &self,
+        index: InterruptIndex,
+        config: InterruptSourceConfig,
+        masked: bool,
+    ) -> Result<()>;
 }


### PR DESCRIPTION
The calls to these functions are always preceded by a call to
InterruptSourceGroup::update(). By adding a masked boolean to that
function call it possible to remove 50% of the calls to the
KVM_SET_GSI_ROUTING ioctl as the the update will correctly handle the
masked or unmasked case.

This causes the ioctl to disappear from the perf report for a boot of
the VM.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>