### PR TITLE
vmm: Deprecate mergeable option from virtio-pmem

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1702,7 +1702,7 @@ pub struct PmemConfig {
 impl PmemConfig {
     pub const SYNTAX: &'static str = "Persistent memory parameters \
     \"file=<backing_file_path>,size=<persistent_memory_size>,iommu=on|off,\
-    mergeable=on|off,discard_writes=on|off,id=<device_id>,pci_segment=<segment_id>\"";
+    discard_writes=on|off,id=<device_id>,pci_segment=<segment_id>\"";
     pub fn parse(pmem: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser
@@ -1753,6 +1753,10 @@ impl PmemConfig {
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
+        if self.mergeable {
+            warn!("Enabling mergable pages for PMEM devices is ineffectual. This option is deprecated and will be removed in a later release");
+        }
+
         if let Some(platform_config) = vm_config.platform.as_ref() {
             if self.pci_segment >= platform_config.num_pci_segments {
                 return Err(ValidationError::InvalidPciSegment(self.pci_segment));

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2681,14 +2681,7 @@ impl DeviceManager {
             .memory_manager
             .lock()
             .unwrap()
-            .create_userspace_mapping(
-                region_base,
-                region_size,
-                host_addr,
-                pmem_cfg.mergeable,
-                false,
-                false,
-            )
+            .create_userspace_mapping(region_base, region_size, host_addr, false, false, false)
             .map_err(DeviceManagerError::MemoryManager)?;
 
         let mapping = virtio_devices::UserspaceMapping {
@@ -2696,7 +2689,7 @@ impl DeviceManager {
             mem_slot,
             addr: GuestAddress(region_base),
             len: region_size,
-            mergeable: pmem_cfg.mergeable,
+            mergeable: false,
         };
 
         let virtio_pmem_device = Arc::new(Mutex::new(


### PR DESCRIPTION
KSM would never merge the file backed pages so this option has no
effect.

See: #3968

Signed-off-by: Rob Bradford <robert.bradford@intel.com>