### PR TITLE
Add live upgrade tests

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -192,6 +192,15 @@ update_workloads() {
     fi
     popd
 
+    # Download Cloud Hypervisor binary from its last stable release
+    LAST_RELEASE_VERSION="v23.0"
+    CH_RELEASE_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$LAST_RELEASE_VERSION/cloud-hypervisor-static-aarch64"
+    CH_RELEASE_NAME="cloud-hypervisor-static-aarch64"
+    pushd $WORKLOADS_DIR
+    time wget --quiet $CH_RELEASE_URL -O "$CH_RELEASE_NAME" || exit 1
+    chmod +x $CH_RELEASE_NAME
+    popd
+
     # Build custom kernel for guest VMs
     build_custom_linux
 

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -45,6 +45,15 @@ if [ $? -ne 0 ]; then
 fi
 popd
 
+# Download Cloud Hypervisor binary from its last stable release
+LAST_RELEASE_VERSION="v23.0"
+CH_RELEASE_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$LAST_RELEASE_VERSION/cloud-hypervisor-static"
+CH_RELEASE_NAME="cloud-hypervisor-static"
+pushd $WORKLOADS_DIR
+time wget --quiet $CH_RELEASE_URL -O "$CH_RELEASE_NAME" || exit 1
+chmod +x $CH_RELEASE_NAME
+popd
+
 # Build custom kernel based on virtio-pmem and virtio-fs upstream patches
 VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
 

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1190,12 +1190,12 @@ pub struct GuestCommand<'a> {
 
 impl<'a> GuestCommand<'a> {
     pub fn new(guest: &'a Guest) -> Self {
-        Self::new_with_binary_name(guest, "cloud-hypervisor")
+        Self::new_with_binary_path(guest, &clh_command("cloud-hypervisor"))
     }
 
-    pub fn new_with_binary_name(guest: &'a Guest, binary_name: &str) -> Self {
+    pub fn new_with_binary_path(guest: &'a Guest, binary_path: &str) -> Self {
         Self {
-            command: Command::new(clh_command(binary_name)),
+            command: Command::new(binary_path),
             guest,
             capture_output: false,
             print_cmd: true,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7629,22 +7629,26 @@ mod live_migration {
     }
 
     #[test]
+    #[ignore]
     fn test_live_upgrade_basic() {
         _test_live_migration(true, false, false)
     }
 
     #[test]
+    #[ignore]
     fn test_live_upgrade_local() {
         _test_live_migration(true, false, true)
     }
 
     #[test]
+    #[ignore]
     #[cfg(not(feature = "mshv"))]
     fn test_live_upgrade_numa() {
         _test_live_migration(true, true, false)
     }
 
     #[test]
+    #[ignore]
     #[cfg(not(feature = "mshv"))]
     fn test_live_upgrade_numa_local() {
         _test_live_migration(true, true, true)
@@ -7865,12 +7869,14 @@ mod live_migration {
     }
 
     #[test]
+    #[ignore]
     #[cfg(not(feature = "mshv"))]
     fn test_live_upgrade_ovs_dpdk() {
         _test_live_migration_ovs_dpdk(true, false);
     }
 
     #[test]
+    #[ignore]
     #[cfg(not(feature = "mshv"))]
     fn test_live_upgrade_ovs_dpdk_local() {
         _test_live_migration_ovs_dpdk(true, true);


### PR DESCRIPTION
By augmenting existing set of tests, this patch added a set of tests for live-upgrade that covers use cases with NUMA, vhost-user (OVS-DPDK), and local-migration.

Fixes: #3949

Signed-off-by: Bo Chen <chen.bo@intel.com>