### PR TITLE
github: use --locked in cargo invocations

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,25 +39,25 @@ jobs:
           git checkout $GITHUB_SHA
 
       - name: Build (default features)
-        run: cargo rustc --bin cloud-hypervisor -- -D warnings
+        run: cargo rustc --locked --bin cloud-hypervisor -- -D warnings
 
       - name: Build (common + kvm)
-        run: cargo rustc --bin cloud-hypervisor --no-default-features --features "common,kvm"  -- -D warnings
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "common,kvm"  -- -D warnings
 
       - name: Build (default features + tdx)
-        run: cargo rustc --bin cloud-hypervisor --features "tdx" -- -D warnings
+        run: cargo rustc --locked --bin cloud-hypervisor --features "tdx" -- -D warnings
 
       - name: Build (default features + amx)
-        run: cargo rustc --bin cloud-hypervisor --features "amx" -- -D warnings
+        run: cargo rustc --locked --bin cloud-hypervisor --features "amx" -- -D warnings
 
       - name: Build (default features + gdb)
-        run: cargo rustc --bin cloud-hypervisor --features "gdb" -- -D warnings
+        run: cargo rustc --locked --bin cloud-hypervisor --features "gdb" -- -D warnings
 
       - name: Build (common + mshv)
-        run: cargo rustc --bin cloud-hypervisor --no-default-features --features "common,mshv"  -- -D warnings
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "common,mshv"  -- -D warnings
 
       - name: Release Build (default features)
-        run: cargo build --all --release --target=${{ matrix.target }}
+        run: cargo build --locked --all --release --target=${{ matrix.target }}
 
       - name: Check build did not modify any files
         run: test -z "$(git status --porcelain)"

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -34,19 +34,19 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Clippy (common + kvm)
-        run: cargo clippy --all --all-targets --no-default-features --tests --features "common,kvm" -- -D warnings
+        run: cargo clippy --locked --all --all-targets --no-default-features --tests --features "common,kvm" -- -D warnings
 
       - name: Clippy (default features)
-        run: cargo clippy --all --all-targets --tests -- -D warnings
+        run: cargo clippy --locked --all --all-targets --tests -- -D warnings
 
       - name: Clippy (default features + amx)
-        run: cargo clippy --all --all-targets --tests --features "amx" -- -D warnings
+        run: cargo clippy --locked --all --all-targets --tests --features "amx" -- -D warnings
 
       - name: Clippy (default features + gdb)
-        run: cargo clippy --all --all-targets --tests --features "gdb" -- -D warnings
+        run: cargo clippy --locked --all --all-targets --tests --features "gdb" -- -D warnings
 
       - name: Clippy (common + mshv)
-        run: cargo clippy --all --all-targets --no-default-features --tests --features "common,mshv" -- -D warnings
+        run: cargo clippy --locked --all --all-targets --no-default-features --tests --features "common,mshv" -- -D warnings
 
       - name: Check build did not modify any files
         run: test -z "$(git status --porcelain)"


### PR DESCRIPTION
Cargo comes with a `--locked` option that makes sure Cargo.lock is not
changed.

Drop the `git status` check which is supposed to achieve the same thing
in the CI.

Signed-off-by: Wei Liu <liuwe@microsoft.com>