### PR TITLE
docs: Fix the name of the I/O operations knobs

### DIFF
--- a/docs/io_throttling.md
+++ b/docs/io_throttling.md
@@ -24,8 +24,8 @@ bucket is unbounded in speed which allows for bursts bound in size by
 the amount of tokens available. Once the token bucket is empty,
 consumption speed is bound by the "refill-rate". Similarly, Cloud
 Hypervisor provides another three options for limiting I/O operations,
-i.e., `ops_size` (I/O operations), `bw_one_time_burst` (I/O operations),
-and `bw_refill_time` (ms).
+i.e., `ops_size` (I/O operations), `ops_one_time_burst` (I/O operations),
+and `ops_refill_time` (ms).
 
 One caveat in the I/O throttling is that every-time the bucket gets
 empty, it will stop I/O operations for a fixed amount of time


### PR DESCRIPTION
The I/O operations knobs are prefixed `ops_` rather than `bw_`, as `bw_`
refers to the "bandwidth" knobs.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>