### PR TITLE
scripts: dev_cli.sh: add option to specify container runtime

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -226,6 +226,11 @@ cmd_build() {
         } ;;
         "--debug") { build="debug"; } ;;
         "--release") { build="release"; } ;;
+        "--runtime") 
+	    shift
+	    DOCKER_RUNTIME="$1"
+	    export DOCKER_RUNTIME
+	    ;;
         "--libc")
             shift
             [[ "$1" =~ ^(musl|gnu)$ ]] ||


### PR DESCRIPTION
For example:

```shell
./scripts/dev_cli.sh build --release --libc musl --runtime "sudo nerdctl"
```

works. And presumably podman as well.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>