### PR TITLE
Expose platform serial number to guest (for cloud-init)

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -838,13 +838,14 @@ pub fn configure_system(
     _num_cpus: u8,
     rsdp_addr: Option<GuestAddress>,
     sgx_epc_region: Option<SgxEpcRegion>,
+    serial_number: Option<&str>,
 ) -> super::Result<()> {
     // Write EBDA address to location where ACPICA expects to find it
     guest_mem
         .write_obj((layout::EBDA_START.0 >> 4) as u16, layout::EBDA_POINTER)
         .map_err(Error::EbdaSetup)?;
 
-    let size = smbios::setup_smbios(guest_mem).map_err(Error::SmbiosSetup)?;
+    let size = smbios::setup_smbios(guest_mem, serial_number).map_err(Error::SmbiosSetup)?;
 
     // Place the MP table after the SMIOS table aligned to 16 bytes
     let offset = GuestAddress(layout::SMBIOS_START).unchecked_add(size);
@@ -1193,6 +1194,7 @@ mod tests {
             1,
             Some(layout::RSDP_POINTER),
             None,
+            None,
         );
         assert!(config_err.is_err());
 
@@ -1206,7 +1208,7 @@ mod tests {
             .collect();
         let gm = GuestMemoryMmap::from_ranges(&ram_regions).unwrap();
 
-        configure_system(&gm, GuestAddress(0), &None, no_vcpus, None, None).unwrap();
+        configure_system(&gm, GuestAddress(0), &None, no_vcpus, None, None, None).unwrap();
 
         // Now assigning some memory that is equal to the start of the 32bit memory hole.
         let mem_size = 3328 << 20;
@@ -1217,9 +1219,9 @@ mod tests {
             .map(|r| (r.0, r.1))
             .collect();
         let gm = GuestMemoryMmap::from_ranges(&ram_regions).unwrap();
-        configure_system(&gm, GuestAddress(0), &None, no_vcpus, None, None).unwrap();
+        configure_system(&gm, GuestAddress(0), &None, no_vcpus, None, None, None).unwrap();
 
-        configure_system(&gm, GuestAddress(0), &None, no_vcpus, None, None).unwrap();
+        configure_system(&gm, GuestAddress(0), &None, no_vcpus, None, None, None).unwrap();
 
         // Now assigning some memory that falls after the 32bit memory hole.
         let mem_size = 3330 << 20;
@@ -1230,9 +1232,9 @@ mod tests {
             .map(|r| (r.0, r.1))
             .collect();
         let gm = GuestMemoryMmap::from_ranges(&ram_regions).unwrap();
-        configure_system(&gm, GuestAddress(0), &None, no_vcpus, None, None).unwrap();
+        configure_system(&gm, GuestAddress(0), &None, no_vcpus, None, None, None).unwrap();
 
-        configure_system(&gm, GuestAddress(0), &None, no_vcpus, None, None).unwrap();
+        configure_system(&gm, GuestAddress(0), &None, no_vcpus, None, None, None).unwrap();
     }
 
     #[test]

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -77,7 +77,7 @@ impl OptionParser {
         }
 
         for option in split_commas_outside_brackets(input)?.iter() {
-            let parts: Vec<&str> = option.split('=').collect();
+            let parts: Vec<&str> = option.splitn(2, '=').collect();
 
             match self.options.get_mut(parts[0]) {
                 None => return Err(OptionParserError::UnknownOption(parts[0].to_owned())),

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ fn create_app<'a>(
             Arg::new("platform")
                 .long("platform")
                 .help(
-                    "num_pci_segments=<num pci segments>,iommu_segments=<list_of_segments>",
+                    "num_pci_segments=<num pci segments>,iommu_segments=<list_of_segments>,serial_number=<(DMI) device serial number>",
                 )
                 .takes_value(true)
                 .group("vm-config"),

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -616,6 +616,8 @@ components:
           items:
             type: integer
             format: int16
+        serial_number:
+          type: string
 
     MemoryZoneConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -621,6 +621,8 @@ pub struct PlatformConfig {
     pub num_pci_segments: u16,
     #[serde(default)]
     pub iommu_segments: Option<Vec<u16>>,
+    #[serde(default)]
+    pub serial_number: Option<String>,
 }
 
 impl PlatformConfig {
@@ -628,6 +630,7 @@ impl PlatformConfig {
         let mut parser = OptionParser::new();
         parser.add("num_pci_segments");
         parser.add("iommu_segments");
+        parser.add("serial_number");
         parser.parse(platform).map_err(Error::ParsePlatform)?;
 
         let num_pci_segments: u16 = parser
@@ -638,9 +641,13 @@ impl PlatformConfig {
             .convert::<IntegerList>("iommu_segments")
             .map_err(Error::ParsePlatform)?
             .map(|v| v.0.iter().map(|e| *e as u16).collect());
+        let serial_number = parser
+            .convert("serial_number")
+            .map_err(Error::ParsePlatform)?;
         Ok(PlatformConfig {
             num_pci_segments,
             iommu_segments,
+            serial_number,
         })
     }
 
@@ -668,6 +675,7 @@ impl Default for PlatformConfig {
         PlatformConfig {
             num_pci_segments: DEFAULT_NUM_PCI_SEGMENTS,
             iommu_segments: None,
+            serial_number: None,
         }
     }
 }
@@ -3498,6 +3506,7 @@ mod tests {
         still_valid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         assert!(still_valid_config.validate().is_ok());
 
@@ -3505,6 +3514,7 @@ mod tests {
         invalid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![17, 18]),
+            ..Default::default()
         });
         assert_eq!(
             invalid_config.validate(),
@@ -3515,6 +3525,7 @@ mod tests {
         still_valid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         still_valid_config.disks = Some(vec![DiskConfig {
             iommu: true,
@@ -3527,6 +3538,7 @@ mod tests {
         still_valid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         still_valid_config.net = Some(vec![NetConfig {
             iommu: true,
@@ -3539,6 +3551,7 @@ mod tests {
         still_valid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         still_valid_config.pmem = Some(vec![PmemConfig {
             iommu: true,
@@ -3551,6 +3564,7 @@ mod tests {
         still_valid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         still_valid_config.devices = Some(vec![DeviceConfig {
             iommu: true,
@@ -3563,6 +3577,7 @@ mod tests {
         still_valid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         still_valid_config.vsock = Some(VsockConfig {
             iommu: true,
@@ -3575,6 +3590,7 @@ mod tests {
         invalid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         invalid_config.disks = Some(vec![DiskConfig {
             iommu: false,
@@ -3590,6 +3606,7 @@ mod tests {
         invalid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         invalid_config.net = Some(vec![NetConfig {
             iommu: false,
@@ -3605,6 +3622,7 @@ mod tests {
         invalid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         invalid_config.pmem = Some(vec![PmemConfig {
             iommu: false,
@@ -3620,6 +3638,7 @@ mod tests {
         invalid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         invalid_config.devices = Some(vec![DeviceConfig {
             iommu: false,
@@ -3635,6 +3654,7 @@ mod tests {
         invalid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         invalid_config.vsock = Some(VsockConfig {
             iommu: false,
@@ -3651,6 +3671,7 @@ mod tests {
         invalid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         invalid_config.user_devices = Some(vec![UserDeviceConfig {
             pci_segment: 1,
@@ -3665,6 +3686,7 @@ mod tests {
         invalid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         invalid_config.vdpa = Some(vec![VdpaConfig {
             pci_segment: 1,
@@ -3680,6 +3702,7 @@ mod tests {
         invalid_config.platform = Some(PlatformConfig {
             num_pci_segments: 16,
             iommu_segments: Some(vec![1, 2, 3]),
+            ..Default::default()
         });
         invalid_config.fs = Some(vec![FsConfig {
             pci_segment: 1,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1115,6 +1115,14 @@ impl Vm {
             .as_ref()
             .cloned();
 
+        let serial_number = self
+            .config
+            .lock()
+            .unwrap()
+            .platform
+            .as_ref()
+            .and_then(|p| p.serial_number.clone());
+
         arch::configure_system(
             &mem,
             arch::layout::CMDLINE_START,
@@ -1122,6 +1130,7 @@ impl Vm {
             boot_vcpus,
             rsdp_addr,
             sgx_epc_region,
+            serial_number.as_deref(),
         )
         .map_err(Error::ConfigureSystem)?;
         Ok(())


### PR DESCRIPTION
- option_parser: Support having "=" inside option values
- vmm: config: Add "serial_number" option to "--platform"
- arch, vmm: Expose platform serial_number via SMBIOS
- vmm: openapi: Add serial_number to PlatformConfig

Fixes: #4002
