### PR TITLE
vmm: Only create ACPI memory manager DSDT when resizable

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -419,7 +419,7 @@ impl<'a> VmParams<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
 pub enum HotplugMethod {
     Acpi,
     VirtioMem,

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1023,9 +1023,10 @@ impl MemoryManager {
         #[cfg(feature = "tdx")]
         let dynamic = !tdx_enabled;
 
-        let hotplug_method = config.hotplug_method.clone();
-
-        let acpi_address = if dynamic && hotplug_method == HotplugMethod::Acpi {
+        let acpi_address = if dynamic
+            && config.hotplug_method == HotplugMethod::Acpi
+            && (config.hotplug_size.unwrap_or_default() > 0)
+        {
             Some(
                 allocator
                     .lock()
@@ -1054,7 +1055,7 @@ impl MemoryManager {
             selected_slot,
             mergeable: config.mergeable,
             allocator,
-            hotplug_method,
+            hotplug_method: config.hotplug_method,
             boot_ram,
             current_ram,
             next_hotplug_slot,
@@ -1068,7 +1069,6 @@ impl MemoryManager {
             snapshot_memory_ranges: MemoryRangeTable::default(),
             memory_zones,
             guest_ram_mappings: Vec::new(),
-
             acpi_address,
             log_dirty: dynamic, // Cannot log dirty pages on a TD
             arch_mem_regions,


### PR DESCRIPTION
If using the ACPI based hotplug only memory can be added so if the
hotplug RAM size is the same as the boot RAM size then do not include
the memory manager DSDT entries.

Also: this change simplifies the code marginally by making the
HotplugMethod enum Copyable.

This was identified from the following perf output:

     1.78%     0.00%  vmm              cloud-hypervisor      [.] <vmm::memory_manager::MemorySlots as acpi_tables::aml::Aml>::append_aml_bytes
            |
            ---<vmm::memory_manager::MemorySlots as acpi_tables::aml::Aml>::append_aml_bytes
               <vmm::memory_manager::MemorySlot as acpi_tables::aml::Aml>::append_aml_bytes
               acpi_tables::aml::Name::new
               <acpi_tables::aml::Path as acpi_tables::aml::Aml>::append_aml_bytes
               __libc_malloc

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
