### PR TITLE
virtio-devices: iommu: Implement bypass mode for virtio devices

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7982,9 +7982,7 @@ mod aarch64_acpi {
         _test_power_button(true);
     }
 
-    // https://github.com/cloud-hypervisor/cloud-hypervisor/issues/3941
     #[test]
-    #[ignore]
     fn test_virtio_iommu() {
         _test_virtio_iommu(true)
     }


### PR DESCRIPTION
Implement the bypass mode for virtio devices sitting behind a virtual IOMMU. This mode allows such devices to be accessed by a firmware that wouldn't know anything about `virtio-iommu` without breaking the boot.

Fixes #3941 
Partially fixes #3987 