### PR TITLE
vmm, openapi: Token Bucket fields should be uint64

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -729,17 +729,17 @@ components:
       properties:
         size:
           type: integer
-          format: int64
+          format: uint64
           minimum: 0
           description: The total number of tokens this bucket can hold.
         one_time_burst:
           type: integer
-          format: int64
+          format: uint64
           minimum: 0
           description: The initial size of a token bucket.
         refill_time:
           type: integer
-          format: int64
+          format: uint64
           minimum: 0
           description: The amount of milliseconds it takes for the bucket to refill.
       description:


### PR DESCRIPTION
The Token Bucket fields are, on the Cloud Hypervisor side, u64.
However, we expose those for Kata Containers as int64.

Let's take the same approach as Firecracker and expose those as uint64.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>