### PR TITLE
Revert "vmm, openapi: Token Bucket fields should be uint64"

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -729,17 +729,17 @@ components:
       properties:
         size:
           type: integer
-          format: uint64
+          format: int64
           minimum: 0
           description: The total number of tokens this bucket can hold.
         one_time_burst:
           type: integer
-          format: uint64
+          format: int64
           minimum: 0
           description: The initial size of a token bucket.
         refill_time:
           type: integer
-          format: uint64
+          format: int64
           minimum: 0
           description: The amount of milliseconds it takes for the bucket to refill.
       description:


### PR DESCRIPTION
This reverts commit 87eed369cd091db76ed8542750803659e729b239.

The reason we're reverting this is that OpenAPI doesn't know how to deal
with unsigned types. :-/

Right now the best to do is keep it as it's, as an int64, and try to fix
OpenAPI, or even switch to swagger, as the latter knows how to properly
deal with those.  However, switching to swagger is far from being an 1:1
transition and will require time to experiment, thus reverting this for
now seems the best approach.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>