### PR TITLE
vmm: Ensure identifiers are unique

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2329,7 +2329,9 @@ pub struct VmConfig {
 
 impl VmConfig {
     // Also enables virtio-iommu if the config needs it
-    pub fn validate(&mut self) -> ValidationResult<()> {
+    // Returns the list of unique identifiers provided through the
+    // configuration.
+    pub fn validate(&mut self) -> ValidationResult<BTreeSet<String>> {
         let mut id_list = BTreeSet::new();
 
         #[cfg(not(feature = "tdx"))]
@@ -2578,7 +2580,7 @@ impl VmConfig {
             .map(|p| p.iommu_segments.is_some())
             .unwrap_or_default();
 
-        Ok(())
+        Ok(id_list)
     }
 
     pub fn parse(vm_params: VmParams) -> Result<Self> {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -570,7 +570,7 @@ impl Vm {
             None
         };
 
-        config
+        let boot_id_list = config
             .lock()
             .unwrap()
             .validate()
@@ -603,6 +603,7 @@ impl Vm {
             &activate_evt,
             force_iommu,
             restoring,
+            boot_id_list,
         )
         .map_err(Error::DeviceManager)?;
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1541,6 +1541,11 @@ impl Vm {
             disks.retain(|dev| dev.id.as_ref() != Some(&id));
         }
 
+        // Remove if fs device
+        if let Some(fs) = config.fs.as_mut() {
+            fs.retain(|dev| dev.id.as_ref() != Some(&id));
+        }
+
         // Remove if net device
         if let Some(net) = config.net.as_mut() {
             net.retain(|dev| dev.id.as_ref() != Some(&id));


### PR DESCRIPTION
We must verify that identifiers provided through cold boot as well as hotplug mechanism are unique.

Fixes #4024