### PR TITLE
vmm: Wait for the completion of PCI device removal

### DIFF
--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -52,7 +52,7 @@ pub const PCI_CONFIG_IO_PORT: u64 = 0xcf8;
 #[cfg(target_arch = "x86_64")]
 pub const PCI_CONFIG_IO_PORT_SIZE: u64 = 0x8;
 
-#[derive(Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub struct PciBdf(u32);
 
 struct PciBdfVisitor;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1516,7 +1516,8 @@ impl Vm {
     }
 
     pub fn remove_device(&mut self, id: String) -> Result<()> {
-        self.device_manager
+        let barrier = self
+            .device_manager
             .lock()
             .unwrap()
             .remove_device(id.clone())
@@ -1573,6 +1574,11 @@ impl Vm {
             .unwrap()
             .notify_hotplug(AcpiNotificationFlags::PCI_DEVICES_CHANGED)
             .map_err(Error::DeviceManager)?;
+
+        // Once the ACPI notification has been triggered, let's wait on the
+        // barrier to consider the removal complete.
+        barrier.wait();
+
         Ok(())
     }
 


### PR DESCRIPTION
Whenever a PCI device was unplugged from the VM, the HTTP thread was
returning right after the internal logic was updated and the ACPI
notification was triggered. This means at this point, the OS didn't
fully removed the device, which also means the function eject_device()
in the DeviceManager wasn't invoked yet. Since this function performs
all the necessary cleaning required to really consider the device as
removed, it's important to wait for this codepath to be executed before
to let the HTTP request return.

By relying on a mechanism of barriers, the vmm thread (from the HTTP
request) and the vCPU thread (from the OS triggering the eject of the
device) have a way to wait for each other. Especially, this allows the
vmm thread to know when the removal is complete, which avoid potential
race conditions if someone wants to add a new device right after this.

Fixes #4038

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>