### PR TITLE
vmm: Fix loading RAW firmware

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1031,7 +1031,12 @@ impl Vm {
                     kernel
                         .seek(SeekFrom::Start(0))
                         .map_err(Error::FirmwareFile)?;
-                    mem.read_exact_from(load_address, &mut kernel, size as usize)
+                    memory_manager
+                        .lock()
+                        .unwrap()
+                        .guest_memory()
+                        .memory()
+                        .read_exact_from(load_address, &mut kernel, size as usize)
                         .map_err(Error::FirmwareLoad)?;
 
                     return Ok(EntryPoint { entry_addr: None });


### PR DESCRIPTION
Whenever going through the codepath of loading a RAW firmware, we always
add an extra RAM region to the guest memory through the memory manager.
But we must be careful to use the updated guest memory rather than a
previous reference that wasn't containing the new region, as this can
lead to the following error:

VmBoot(FirmwareLoad(InvalidGuestAddress(GuestAddress(4290772992))))

This is fixed by the current patch, getting the latest reference onto
the guest memory from the memory manager right after the new region has
been added.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>