### PR TITLE
Release v23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "cloud-hypervisor"
-version = "23.0.0"
+version = "23.1.0"
 dependencies = [
  "anyhow",
  "api_client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloud-hypervisor"
-version = "23.0.0"
+version = "23.1.0"
 authors = ["The Cloud Hypervisor Authors"]
 edition = "2021"
 default-run = "cloud-hypervisor"

--- a/docs/io_throttling.md
+++ b/docs/io_throttling.md
@@ -24,8 +24,8 @@ bucket is unbounded in speed which allows for bursts bound in size by
 the amount of tokens available. Once the token bucket is empty,
 consumption speed is bound by the "refill-rate". Similarly, Cloud
 Hypervisor provides another three options for limiting I/O operations,
-i.e., `ops_size` (I/O operations), `bw_one_time_burst` (I/O operations),
-and `bw_refill_time` (ms).
+i.e., `ops_size` (I/O operations), `ops_one_time_burst` (I/O operations),
+and `ops_refill_time` (ms).
 
 One caveat in the I/O throttling is that every-time the bucket gets
 empty, it will stop I/O operations for a fixed amount of time

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,4 @@
+- [v23.1](#v231)
 - [v23.0](#v230)
     - [vDPA Support](#vdpa-support)
     - [Updated OS Support list](#updated-os-support-list)
@@ -202,6 +203,15 @@
     - [Console over virtio](#console-over-virtio)
     - [Unit testing](#unit-testing)
     - [Integration tests parallelization](#integration-tests-parallelization)
+# v23.1
+
+This is a bug fix release. The following issues have been addressed:
+
+* Add some missing seccomp rules
+* Remove `virtio-fs` filesystem entries from config on removal
+* Do not delete API socket on API server start (#4026)
+* Reject `virtio-mem` resize if the guest doesn't activate the device
+* Fix OpenAPI naming of I/O throttling knobs
 
 # v23.0
 

--- a/rpm/cloud-hypervisor.spec
+++ b/rpm/cloud-hypervisor.spec
@@ -9,7 +9,7 @@
 
 Name:           cloud-hypervisor
 Summary:        Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM.
-Version:        23.0
+Version:        23.1
 Release:        0%{?dist}
 License:        ASL 2.0 or BSD-3-clause
 Group:          Applications/System
@@ -112,6 +112,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+*   Mon May 09 2022 Rob Bradford <robert.bradford@intel.com> 23.1-0
+-   Update to 23.1
+
 *   Thu Apr 13 2022 Rob Bradford <robert.bradford@intel.com> 23.0-0
 -   Update to 23.0
 

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -336,7 +336,6 @@ pub fn start_http_path_thread(
     seccomp_action: &SeccompAction,
     exit_evt: EventFd,
 ) -> Result<thread::JoinHandle<Result<()>>> {
-    std::fs::remove_file(path).unwrap_or_default();
     let socket_path = PathBuf::from(path);
     let socket_fd = UnixListener::bind(socket_path).map_err(Error::CreateApiServerSocket)?;
     let server =

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -546,6 +546,12 @@ fn vmm_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError> {
         (libc::SYS_recvfrom, vec![]),
         (libc::SYS_recvmsg, vec![]),
         (libc::SYS_restart_syscall, vec![]),
+        // musl is missing this constant
+        // (libc::SYS_rseq, vec![]),
+        #[cfg(target_arch = "x86_64")]
+        (334, vec![]),
+        #[cfg(target_arch = "aarch64")]
+        (293, vec![]),
         (libc::SYS_rt_sigaction, vec![]),
         (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_rt_sigreturn, vec![]),

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -686,6 +686,7 @@ fn vcpu_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError> {
         (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_rt_sigreturn, vec![]),
         (libc::SYS_sendmsg, vec![]),
+        (libc::SYS_shutdown, vec![]),
         (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_tgkill, vec![]),
         (libc::SYS_tkill, vec![]),

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1477,6 +1477,11 @@ impl Vm {
             disks.retain(|dev| dev.id.as_ref() != Some(&id));
         }
 
+        // Remove if fs device
+        if let Some(fs) = config.fs.as_mut() {
+            fs.retain(|dev| dev.id.as_ref() != Some(&id));
+        }
+
         // Remove if net device
         if let Some(net) = config.net.as_mut() {
             net.retain(|dev| dev.id.as_ref() != Some(&id));


### PR DESCRIPTION
- docs: Fix the name of the I/O operations knobs
- virtio-devices: mem: Reject resize if device not activated by guest
- vmm: seccomp: Allow SYS_rseq as required by newer glibc
- vmm: api: Do not delete the API socket on API server creation
- vmm: Remove FsConfig from VmConfig when unplugging fs device
- vmm: Add 'shutdown()' to vCPU seccomp filter
- build: Release v23.1 (bug fix release)
