### PR TITLE
performance-metrics: Add boot time metrics using multiple vCPUs

### DIFF
--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -91,6 +91,7 @@ pub struct PerformanceTestControl {
     queue_size: Option<u32>,
     net_rx: Option<bool>,
     fio_ops: Option<FioOps>,
+    num_boot_vcpus: Option<u8>,
 }
 
 impl fmt::Display for PerformanceTestControl {
@@ -125,6 +126,7 @@ impl PerformanceTestControl {
             queue_size: None,
             net_rx: None,
             fio_ops: None,
+            num_boot_vcpus: Some(1),
         }
     }
 }
@@ -216,7 +218,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 15] = [
+const TEST_LIST: [PerformanceTest; 17] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -233,6 +235,28 @@ const TEST_LIST: [PerformanceTest; 15] = [
         control: PerformanceTestControl {
             test_timeout: 2,
             test_iterations: 10,
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_ms,
+    },
+    PerformanceTest {
+        name: "boot_time_16_vcpus_ms",
+        func_ptr: performance_boot_time,
+        control: PerformanceTestControl {
+            test_timeout: 2,
+            test_iterations: 10,
+            num_boot_vcpus: Some(16),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_ms,
+    },
+    PerformanceTest {
+        name: "boot_time_16_vcpus_pmem_ms",
+        func_ptr: performance_boot_time_pmem,
+        control: PerformanceTestControl {
+            test_timeout: 2,
+            test_iterations: 10,
+            num_boot_vcpus: Some(16),
             ..PerformanceTestControl::default()
         },
         unit_adjuster: adjuster::s_to_ms,

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -499,6 +499,10 @@ pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
         let mut cmd = GuestCommand::new(&guest);
 
         let c = cmd
+            .args(&[
+                "--cpus",
+                &format!("boot={}", control.num_boot_vcpus.unwrap_or(1)),
+            ])
             .args(&["--memory", "size=1G"])
             .args(&["--kernel", direct_kernel_boot_path().to_str().unwrap()])
             .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
@@ -522,6 +526,10 @@ pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
         let guest = performance_test_new_guest(Box::new(focal));
         let mut cmd = GuestCommand::new(&guest);
         let c = cmd
+            .args(&[
+                "--cpus",
+                &format!("boot={}", control.num_boot_vcpus.unwrap_or(1)),
+            ])
             .args(&["--memory", "size=1G,hugepages=on"])
             .args(&["--kernel", direct_kernel_boot_path().to_str().unwrap()])
             .args(&["--cmdline", "root=/dev/pmem0p1 console=ttyS0 quiet rw"])


### PR DESCRIPTION
Signed-off-by: Rob Bradford <robert.bradford@intel.com>
