### PR TITLE
vmm: Don't use kvm_ioctls directly

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -56,11 +56,7 @@ use devices::legacy::Serial;
 use devices::{
     interrupt_controller, interrupt_controller::InterruptController, AcpiNotificationFlags,
 };
-#[cfg(feature = "kvm")]
-use hypervisor::kvm_ioctls::*;
-use hypervisor::DeviceFd;
-#[cfg(feature = "mshv")]
-use hypervisor::IoEventAddress;
+use hypervisor::{DeviceFd, IoEventAddress};
 use libc::{
     cfmakeraw, isatty, tcgetattr, tcsetattr, termios, MAP_NORESERVE, MAP_PRIVATE, MAP_SHARED,
     O_TMPFILE, PROT_READ, PROT_WRITE, TCSANOW,


### PR DESCRIPTION
The IoEventAddress is re-exported through the crate at the top-level.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
