### PR TITLE
Refactor interrupt handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "thiserror",
- "vm-device",
  "vm-memory",
  "vmm-sys-util",
 ]
@@ -1297,6 +1296,7 @@ name = "vm-device"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "hypervisor",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "thiserror",
+ "vm-device",
  "vm-memory",
  "vmm-sys-util",
 ]

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -18,11 +18,12 @@ libc = "0.2.125"
 log = "0.4.17"
 kvm-ioctls = { version = "0.11.0", optional = true }
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0-tdx", features = ["with-serde", "fam-wrappers"], optional  = true }
-mshv-bindings = {git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
+mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
 mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional  = true}
 serde = { version = "1.0.137", features = ["rc"] }
 serde_derive = "1.0.137"
 serde_json = "1.0.81"
+vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }
 

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -23,7 +23,6 @@ mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optio
 serde = { version = "1.0.137", features = ["rc"] }
 serde_derive = "1.0.137"
 serde_json = "1.0.81"
-vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -17,7 +17,7 @@ use crate::cpu;
 use crate::device;
 use crate::hypervisor;
 use crate::vec_with_array_field;
-use crate::vm::{self, VmOps};
+use crate::vm::{self, InterruptSourceConfig, VmOps};
 #[cfg(target_arch = "aarch64")]
 use crate::{arm64_core_reg_id, offset__of};
 use kvm_ioctls::{NoDatamatch, VcpuFd, VmFd};
@@ -32,7 +32,6 @@ use std::result;
 #[cfg(target_arch = "x86_64")]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
-use vm_device::interrupt::InterruptSourceConfig;
 use vmm_sys_util::eventfd::EventFd;
 // x86_64 dependencies
 #[cfg(target_arch = "x86_64")]

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -11,7 +11,7 @@ use crate::cpu;
 use crate::cpu::Vcpu;
 use crate::hypervisor;
 use crate::vec_with_array_field;
-use crate::vm::{self, VmOps};
+use crate::vm::{self, InterruptSourceConfig, VmOps};
 pub use mshv_bindings::*;
 pub use mshv_ioctls::IoEventAddress;
 use mshv_ioctls::{set_registers_64, Mshv, NoDatamatch, VcpuFd, VmFd};
@@ -23,7 +23,6 @@ use vm::DataMatch;
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 use crate::device;
-use vm_device::interrupt::InterruptSourceConfig;
 use vmm_sys_util::eventfd::EventFd;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::VcpuMshvState as CpuState;

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -28,7 +28,6 @@ use kvm_ioctls::Cap;
 use std::fs::File;
 use std::sync::Arc;
 use thiserror::Error;
-use vm_device::interrupt::InterruptSourceConfig;
 use vmm_sys_util::eventfd::EventFd;
 
 ///
@@ -216,6 +215,39 @@ pub enum HypervisorVmError {
 /// Result type for returning from a function
 ///
 pub type Result<T> = std::result::Result<T, HypervisorVmError>;
+
+/// Configuration data for legacy interrupts.
+///
+/// On x86 platforms, legacy interrupts means those interrupts routed through PICs or IOAPICs.
+#[derive(Copy, Clone, Debug)]
+pub struct LegacyIrqSourceConfig {
+    pub irqchip: u32,
+    pub pin: u32,
+}
+
+/// Configuration data for MSI/MSI-X interrupts.
+///
+/// On x86 platforms, these interrupts are vectors delivered directly to the LAPIC.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct MsiIrqSourceConfig {
+    /// High address to delivery message signaled interrupt.
+    pub high_addr: u32,
+    /// Low address to delivery message signaled interrupt.
+    pub low_addr: u32,
+    /// Data to write to delivery message signaled interrupt.
+    pub data: u32,
+    /// Unique ID of the device to delivery message signaled interrupt.
+    pub devid: u32,
+}
+
+/// Configuration data for an interrupt source.
+#[derive(Copy, Clone, Debug)]
+pub enum InterruptSourceConfig {
+    /// Configuration data for Legacy interrupts.
+    LegacyIrq(LegacyIrqSourceConfig),
+    /// Configuration data for PciMsi, PciMsix and generic MSI interrupts.
+    MsiIrq(MsiIrqSourceConfig),
+}
 
 ///
 /// Trait to represent a Vm

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -28,6 +28,7 @@ use kvm_ioctls::Cap;
 use std::fs::File;
 use std::sync::Arc;
 use thiserror::Error;
+use vm_device::interrupt::InterruptSourceConfig;
 use vmm_sys_util::eventfd::EventFd;
 
 ///
@@ -245,6 +246,8 @@ pub trait Vm: Send + Sync {
     ) -> Result<()>;
     /// Unregister an event from a certain address it has been previously registered to.
     fn unregister_ioevent(&self, fd: &EventFd, addr: &IoEventAddress) -> Result<()>;
+    // Construct a routing entry
+    fn make_routing_entry(&self, gsi: u32, config: &InterruptSourceConfig) -> IrqRoutingEntry;
     /// Sets the GSI routing table entries, overwriting any previously set
     fn set_gsi_routing(&self, entries: &[IrqRoutingEntry]) -> Result<()>;
     /// Creates a memory region structure that can be used with {create/remove}_user_memory_region

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -11,6 +11,7 @@ mshv = ["vfio-ioctls/mshv"]
 
 [dependencies]
 anyhow = "1.0.57"
+hypervisor = { path = "../hypervisor" }
 thiserror = "1.0.31"
 serde = { version = "1.0.137", features = ["rc"] }
 serde_derive = "1.0.137"

--- a/vm-device/src/interrupt/mod.rs
+++ b/vm-device/src/interrupt/mod.rs
@@ -57,6 +57,7 @@
 //! * The virtual device backend requests the interrupt manager to create an interrupt group
 //!   according to guest configuration information
 
+pub use hypervisor::vm::{InterruptSourceConfig, LegacyIrqSourceConfig, MsiIrqSourceConfig};
 use std::sync::Arc;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -65,39 +66,6 @@ pub type Result<T> = std::io::Result<T>;
 
 /// Data type to store an interrupt source identifier.
 pub type InterruptIndex = u32;
-
-/// Configuration data for legacy interrupts.
-///
-/// On x86 platforms, legacy interrupts means those interrupts routed through PICs or IOAPICs.
-#[derive(Copy, Clone, Debug)]
-pub struct LegacyIrqSourceConfig {
-    pub irqchip: u32,
-    pub pin: u32,
-}
-
-/// Configuration data for MSI/MSI-X interrupts.
-///
-/// On x86 platforms, these interrupts are vectors delivered directly to the LAPIC.
-#[derive(Copy, Clone, Debug, Default)]
-pub struct MsiIrqSourceConfig {
-    /// High address to delivery message signaled interrupt.
-    pub high_addr: u32,
-    /// Low address to delivery message signaled interrupt.
-    pub low_addr: u32,
-    /// Data to write to delivery message signaled interrupt.
-    pub data: u32,
-    /// Unique ID of the device to delivery message signaled interrupt.
-    pub devid: u32,
-}
-
-/// Configuration data for an interrupt source.
-#[derive(Copy, Clone, Debug)]
-pub enum InterruptSourceConfig {
-    /// Configuration data for Legacy interrupts.
-    LegacyIrq(LegacyIrqSourceConfig),
-    /// Configuration data for PciMsi, PciMsix and generic MSI interrupts.
-    MsiIrq(MsiIrqSourceConfig),
-}
 
 /// Configuration data for legacy, pin based interrupt groups.
 ///

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -14,11 +14,8 @@ use crate::config::{
     VdpaConfig, VhostMode, VmConfig, VsockConfig,
 };
 use crate::device_tree::{DeviceNode, DeviceTree};
-#[cfg(feature = "kvm")]
-use crate::interrupt::kvm::KvmMsiInterruptManager as MsiInterruptManager;
-#[cfg(feature = "mshv")]
-use crate::interrupt::mshv::MshvMsiInterruptManager as MsiInterruptManager;
 use crate::interrupt::LegacyUserspaceInterruptManager;
+use crate::interrupt::MsiInterruptManager;
 use crate::memory_manager::MEMORY_MANAGER_ACPI_SIZE;
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 use crate::pci_segment::PciSegment;


### PR DESCRIPTION
My goal is to reduce the amount of conditional hypervisor code present in the vmm crate:

- hypervisor: Move creation of irq routing struct to hypervisor crate
- vmm: Simplify MsiInterruptManager generics
