### PR TITLE
Be more explicit with hypervisor crate interface

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -64,16 +64,16 @@ pub struct EntryPoint {
 
 /// Configure the specified VCPU, and return its MPIDR.
 pub fn configure_vcpu(
-    fd: &Arc<dyn hypervisor::Vcpu>,
+    vcpu: &Arc<dyn hypervisor::Vcpu>,
     id: u8,
     kernel_entry_point: Option<EntryPoint>,
 ) -> super::Result<u64> {
     if let Some(kernel_entry_point) = kernel_entry_point {
-        regs::setup_regs(fd, id, kernel_entry_point.entry_addr.raw_value())
+        regs::setup_regs(vcpu, id, kernel_entry_point.entry_addr.raw_value())
             .map_err(Error::RegsConfiguration)?;
     }
 
-    let mpidr = fd.read_mpidr().map_err(Error::VcpuRegMpidr)?;
+    let mpidr = vcpu.read_mpidr().map_err(Error::VcpuRegMpidr)?;
     Ok(mpidr)
 }
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -15,7 +15,8 @@ pub mod regs;
 use crate::GuestMemoryMmap;
 use crate::InitramfsConfig;
 use crate::RegionType;
-use hypervisor::{CpuId, CpuIdEntry, HypervisorError, CPUID_FLAG_VALID_INDEX};
+use hypervisor::x86_64::{CpuId, CpuIdEntry, CPUID_FLAG_VALID_INDEX};
+use hypervisor::HypervisorError;
 use linux_loader::loader::bootparam::boot_params;
 use linux_loader::loader::elf::start_info::{
     hvm_memmap_table_entry, hvm_modlist_entry, hvm_start_info,

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -9,7 +9,7 @@
 use crate::layout::{BOOT_GDT_START, BOOT_IDT_START, PVH_INFO_START};
 use crate::GuestMemoryMmap;
 use hypervisor::arch::x86::gdt::{gdt_entry, segment_from_gdt};
-use hypervisor::arch::x86::regs::*;
+use hypervisor::arch::x86::regs::CR0_PE;
 use hypervisor::x86_64::{FpuState, SpecialRegisters, StandardRegisters};
 use std::sync::Arc;
 use std::{mem, result};

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -6,9 +6,8 @@
 
 use crate::arch::emulator::{EmulationError, EmulationResult, PlatformEmulator, PlatformError};
 use crate::arch::x86::emulator::instructions::*;
-use crate::arch::x86::regs::*;
-use crate::arch::x86::*;
-use crate::arch::x86::{Exception, SegmentRegisterOps};
+use crate::arch::x86::regs::{CR0_PE, EFER_LMA};
+use crate::arch::x86::{segment_type_expand_down, segment_type_ro, Exception, SegmentRegisterOps};
 use crate::x86_64::{SegmentRegister, SpecialRegisters, StandardRegisters};
 use anyhow::Context;
 use iced_x86::*;

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -12,6 +12,12 @@
 use crate::aarch64::VcpuInit;
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::{RegList, Register, StandardRegisters};
+#[cfg(feature = "tdx")]
+use crate::kvm::{TdxExitDetails, TdxExitStatus};
+#[cfg(all(feature = "mshv", target_arch = "x86_64"))]
+use crate::x86_64::SuspendRegisters;
+#[cfg(target_arch = "x86_64")]
+use crate::x86_64::Xsave;
 #[cfg(target_arch = "x86_64")]
 use crate::x86_64::{CpuId, LapicState};
 #[cfg(target_arch = "x86_64")]
@@ -23,12 +29,6 @@ use crate::CpuState;
 use crate::DeviceAttr;
 #[cfg(feature = "kvm")]
 use crate::MpState;
-#[cfg(all(feature = "mshv", target_arch = "x86_64"))]
-use crate::SuspendRegisters;
-#[cfg(target_arch = "x86_64")]
-use crate::Xsave;
-#[cfg(feature = "tdx")]
-use crate::{TdxExitDetails, TdxExitStatus};
 use thiserror::Error;
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
 use vm_memory::GuestAddress;

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -7,13 +7,13 @@
 // Copyright 2018-2019 CrowdStrike, Inc.
 //
 //
+#[cfg(feature = "tdx")]
+use crate::kvm::TdxCapabilities;
 use crate::vm::Vm;
 #[cfg(target_arch = "x86_64")]
 use crate::x86_64::CpuId;
 #[cfg(target_arch = "x86_64")]
 use crate::x86_64::MsrList;
-#[cfg(feature = "tdx")]
-use crate::TdxCapabilities;
 use std::sync::Arc;
 use thiserror::Error;
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -305,7 +305,7 @@ impl vm::Vm for KvmVm {
                 kvm_route.u.msi.address_hi = cfg.high_addr;
                 kvm_route.u.msi.data = cfg.data;
 
-                if self.check_extension(crate::Cap::MsiDevid) {
+                if self.check_extension(crate::kvm::Cap::MsiDevid) {
                     // On AArch64, there is limitation on the range of the 'devid',
                     // it can not be greater than 65536 (the max of u16).
                     //

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -40,7 +40,7 @@ pub mod mshv;
 pub mod hypervisor;
 
 /// Vm related module
-pub mod vm;
+mod vm;
 
 /// CPU related module
 mod cpu;
@@ -48,16 +48,19 @@ mod cpu;
 /// Device related module
 mod device;
 
-pub use crate::hypervisor::{Hypervisor, HypervisorError};
 pub use cpu::{HypervisorCpuError, Vcpu, VmExit};
 pub use device::{Device, HypervisorDeviceError};
+pub use hypervisor::{Hypervisor, HypervisorError};
 #[cfg(feature = "tdx")]
 pub use kvm::TdxCapabilities;
 #[cfg(feature = "kvm")]
 pub use kvm::*;
 #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
 pub use mshv::*;
-pub use vm::{DataMatch, HypervisorVmError, Vm};
+pub use vm::{
+    DataMatch, HypervisorVmError, InterruptSourceConfig, LegacyIrqSourceConfig, MsiIrqSourceConfig,
+    Vm, VmOps,
+};
 
 use std::sync::Arc;
 

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -37,7 +37,7 @@ pub mod kvm;
 pub mod mshv;
 
 /// Hypevisor related module
-pub mod hypervisor;
+mod hypervisor;
 
 /// Vm related module
 mod vm;

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -51,18 +51,29 @@ mod device;
 pub use cpu::{HypervisorCpuError, Vcpu, VmExit};
 pub use device::{Device, HypervisorDeviceError};
 pub use hypervisor::{Hypervisor, HypervisorError};
-#[cfg(feature = "tdx")]
-pub use kvm::TdxCapabilities;
+#[cfg(all(feature = "kvm", target_arch = "aarch64"))]
+pub use kvm::aarch64;
+#[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+pub use kvm::x86_64;
+// Aliased types exposed from both hypervisors
 #[cfg(feature = "kvm")]
-pub use kvm::*;
+pub use kvm::{
+    ClockData, CpuState, CreateDevice, DeviceAttr, DeviceFd, IoEventAddress, IrqRoutingEntry,
+    MemoryRegion, MpState, VcpuEvents, VcpuExit, VmState,
+};
 #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
-pub use mshv::*;
+pub use mshv::x86_64;
+// Aliased types exposed from both hypervisors
+#[cfg(all(feature = "mshv", target_arch = "x86_64"))]
+pub use mshv::{
+    CpuState, CreateDevice, DeviceAttr, DeviceFd, IoEventAddress, IrqRoutingEntry, MemoryRegion,
+    MpState, VcpuEvents, VcpuExit, VmState,
+};
+use std::sync::Arc;
 pub use vm::{
     DataMatch, HypervisorVmError, InterruptSourceConfig, LegacyIrqSourceConfig, MsiIrqSourceConfig,
     Vm, VmOps,
 };
-
-use std::sync::Arc;
 
 pub fn new() -> std::result::Result<Arc<dyn Hypervisor>, HypervisorError> {
     #[cfg(feature = "kvm")]

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1048,6 +1048,3 @@ impl vm::Vm for MshvVm {
             .map_err(|e| vm::HypervisorVmError::GetDirtyLog(e.into()))
     }
 }
-pub use hv_cpuid_entry as CpuIdEntry;
-
-pub const CPUID_FLAG_VALID_INDEX: u32 = 0;

--- a/hypervisor/src/mshv/x86_64/mod.rs
+++ b/hypervisor/src/mshv/x86_64/mod.rs
@@ -15,6 +15,7 @@ use std::fmt;
 /// Export generically-named wrappers of mshv_bindings for Unix-based platforms
 ///
 pub use {
+    mshv_bindings::hv_cpuid_entry as CpuIdEntry,
     mshv_bindings::mshv_user_mem_region as MemoryRegion, mshv_bindings::msr_entry as MsrEntry,
     mshv_bindings::CpuId, mshv_bindings::DebugRegisters,
     mshv_bindings::FloatingPointUnit as FpuState, mshv_bindings::LapicState,
@@ -24,6 +25,8 @@ pub use {
     mshv_bindings::SuspendRegisters, mshv_bindings::VcpuEvents, mshv_bindings::XSave as Xsave,
     mshv_bindings::Xcrs as ExtendedControlRegisters,
 };
+
+pub const CPUID_FLAG_VALID_INDEX: u32 = 0;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct VcpuMshvState {

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -12,15 +12,15 @@
 use crate::aarch64::VcpuInit;
 use crate::cpu::Vcpu;
 use crate::device::Device;
+#[cfg(feature = "kvm")]
+use crate::kvm::KvmVmState as VmState;
+#[cfg(feature = "mshv")]
+use crate::mshv::HvState as VmState;
 #[cfg(feature = "tdx")]
 use crate::x86_64::CpuId;
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
 use crate::ClockData;
 use crate::CreateDevice;
-#[cfg(feature = "mshv")]
-use crate::HvState as VmState;
-#[cfg(feature = "kvm")]
-use crate::KvmVmState as VmState;
 use crate::{IoEventAddress, IrqRoutingEntry, MemoryRegion};
 #[cfg(feature = "kvm")]
 use kvm_ioctls::Cap;

--- a/vm-device/src/interrupt/mod.rs
+++ b/vm-device/src/interrupt/mod.rs
@@ -57,7 +57,7 @@
 //! * The virtual device backend requests the interrupt manager to create an interrupt group
 //!   according to guest configuration information
 
-pub use hypervisor::vm::{InterruptSourceConfig, LegacyIrqSourceConfig, MsiIrqSourceConfig};
+pub use hypervisor::{InterruptSourceConfig, LegacyIrqSourceConfig, MsiIrqSourceConfig};
 use std::sync::Arc;
 use vmm_sys_util::eventfd::EventFd;
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -989,8 +989,8 @@ impl CpuManager {
                                     }
                                     #[cfg(feature = "tdx")]
                                     VmExit::Tdx => {
-                                        if let Some(vcpu_fd) = Arc::get_mut(&mut vcpu.vcpu) {
-                                            match vcpu_fd.get_tdx_exit_details() {
+                                        if let Some(vcpu) = Arc::get_mut(&mut vcpu.vcpu) {
+                                            match vcpu.get_tdx_exit_details() {
                                                 Ok(details) => match details {
                                                     TdxExitDetails::GetQuote => warn!("TDG_VP_VMCALL_GET_QUOTE not supported"),
                                                     TdxExitDetails::SetupEventNotifyInterrupt => {
@@ -999,7 +999,7 @@ impl CpuManager {
                                                 },
                                                 Err(e) => error!("Unexpected TDX VMCALL: {}", e),
                                             }
-                                            vcpu_fd.set_tdx_status(TdxExitStatus::InvalidOperand);
+                                            vcpu.set_tdx_status(TdxExitStatus::InvalidOperand);
                                         } else {
                                             // We should never reach this code as
                                             // this means the design from the code

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -30,13 +30,13 @@ use devices::interrupt_controller::InterruptController;
 use gdbstub_arch::x86::reg::{X86SegmentRegs, X86_64CoreRegs};
 #[cfg(target_arch = "aarch64")]
 use hypervisor::kvm::kvm_bindings;
+#[cfg(feature = "tdx")]
+use hypervisor::kvm::{TdxExitDetails, TdxExitStatus};
 #[cfg(target_arch = "x86_64")]
 use hypervisor::x86_64::CpuId;
 #[cfg(all(target_arch = "x86_64", feature = "gdb"))]
 use hypervisor::x86_64::{SpecialRegisters, StandardRegisters};
 use hypervisor::{CpuState, HypervisorCpuError, VmExit, VmOps};
-#[cfg(feature = "tdx")]
-use hypervisor::{TdxExitDetails, TdxExitStatus};
 use libc::{c_void, siginfo_t};
 use seccompiler::{apply_filter, SeccompAction};
 use std::collections::BTreeMap;

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -30,10 +30,10 @@ use devices::interrupt_controller::InterruptController;
 use gdbstub_arch::x86::reg::{X86SegmentRegs, X86_64CoreRegs};
 #[cfg(target_arch = "aarch64")]
 use hypervisor::kvm::kvm_bindings;
+#[cfg(target_arch = "x86_64")]
+use hypervisor::x86_64::CpuId;
 #[cfg(all(target_arch = "x86_64", feature = "gdb"))]
 use hypervisor::x86_64::{SpecialRegisters, StandardRegisters};
-#[cfg(target_arch = "x86_64")]
-use hypervisor::CpuId;
 use hypervisor::{CpuState, HypervisorCpuError, VmExit, VmOps};
 #[cfg(feature = "tdx")]
 use hypervisor::{TdxExitDetails, TdxExitStatus};

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -34,7 +34,7 @@ use hypervisor::kvm::kvm_bindings;
 use hypervisor::x86_64::{SpecialRegisters, StandardRegisters};
 #[cfg(target_arch = "x86_64")]
 use hypervisor::CpuId;
-use hypervisor::{vm::VmOps, CpuState, HypervisorCpuError, VmExit};
+use hypervisor::{CpuState, HypervisorCpuError, VmExit, VmOps};
 #[cfg(feature = "tdx")]
 use hypervisor::{TdxExitDetails, TdxExitStatus};
 use libc::{c_void, siginfo_t};

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -53,7 +53,7 @@ use devices::legacy::Serial;
 use devices::{
     interrupt_controller, interrupt_controller::InterruptController, AcpiNotificationFlags,
 };
-use hypervisor::{DeviceFd, IoEventAddress};
+use hypervisor::{DeviceFd, HypervisorVmError, IoEventAddress};
 use libc::{
     cfmakeraw, isatty, tcgetattr, tcsetattr, termios, MAP_NORESERVE, MAP_PRIVATE, MAP_SHARED,
     O_TMPFILE, PROT_READ, PROT_WRITE, TCSANOW,
@@ -468,7 +468,7 @@ pub enum DeviceManagerError {
     InvalidIommuHotplug,
 
     /// Failed to create UEFI flash
-    CreateUefiFlash(hypervisor::vm::HypervisorVmError),
+    CreateUefiFlash(HypervisorVmError),
 
     /// Invalid identifier as it is not unique.
     IdentifierNotUnique(String),

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -340,7 +340,7 @@ pub fn start_vmm_thread(
 struct VmMigrationConfig {
     vm_config: Arc<Mutex<VmConfig>>,
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-    common_cpuid: hypervisor::CpuId,
+    common_cpuid: hypervisor::x86_64::CpuId,
     memory_manager_data: MemoryManagerSnapshotData,
 }
 
@@ -1498,7 +1498,7 @@ impl Vmm {
     fn vm_check_cpuid_compatibility(
         &self,
         src_vm_config: &Arc<Mutex<VmConfig>>,
-        src_vm_cpuid: &hypervisor::CpuId,
+        src_vm_cpuid: &hypervisor::x86_64::CpuId,
     ) -> result::Result<(), MigratableError> {
         // We check the `CPUID` compatibility of between the source vm and destination, which is
         // mostly about feature compatibility and "topology/sgx" leaves are not relevant.

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2603,7 +2603,7 @@ pub struct VmSnapshot {
     pub clock: Option<hypervisor::ClockData>,
     pub state: Option<hypervisor::VmState>,
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-    pub common_cpuid: hypervisor::CpuId,
+    pub common_cpuid: hypervisor::x86_64::CpuId,
 }
 
 pub const VM_SNAPSHOT_ID: &str = "vm";


### PR DESCRIPTION
The goal is to make it more obvious what the types are that are exported from the hypervisor crate in order to facilitate building with both mshv and kvm in the same binary:

- hypervisor: Make vm module private
- hypervisor: Make hypervisor module private
- hypervisor: mshv: Move CpuIdEntry alias into x86_64 module
- vmm, arch: CpuId is x86_64 specific so import from the x86_64 module
- hypervisor: Explicitly `pub use` at the hypervisor crate top-level
- arch: Use more descriptive name for hypervisor::Vcpu than fd
- vmm: cpu: tdx: Don't use fd suffix for something not an FD
