### PR TITLE
deps: Move to virtio-queue 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,8 +1181,7 @@ dependencies = [
 [[package]]
 name = "vhost-user-backend"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1490f2028d4f119b2292efe218b5f8cfc6471f039b53b6a6eb5d9513e964facc"
+source = "git+https://github.com/rust-vmm/vhost-user-backend?branch=main#14f58eda14076e973704d4f904850be1146fbb05"
 dependencies = [
  "libc",
  "log",
@@ -1273,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3785325315e6496fa88673842ee6cd198b9658e88e8b0e1ad48a5dc818b221dc"
+checksum = "88f2d73c184c18f8acc32dab77fcb6e3af92d53262538d3a68aa474810d6863c"
 dependencies = [
  "log",
  "vm-memory",
@@ -1312,9 +1311,9 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#ca35d96191f8232bd7a
 
 [[package]]
 name = "vm-memory"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339d4349c126fdcd87e034631d7274370cf19eb0e87b33166bcd956589fc72c5"
+checksum = "767ed8aaebbff902e02e6d3749dc2baef55e46565f8a6414a065e5baee4b4a81"
 dependencies = [
  "arc-swap",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,8 +1273,7 @@ dependencies = [
 [[package]]
 name = "virtio-queue"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f2d73c184c18f8acc32dab77fcb6e3af92d53262538d3a68aa474810d6863c"
+source = "git+https://github.com/sboeuf/vm-virtio?branch=fix_virtio-queue#bb959428d3176198ca2ca0bc4984dba154ceefb1"
 dependencies = [
  "log",
  "vm-memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ signal-hook = "0.3.13"
 thiserror = "1.0.31"
 vmm = { path = "vmm" }
 vmm-sys-util = "0.9.0"
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 
 [build-dependencies]
 clap = { version = "3.1.17", features = ["cargo"] }
@@ -41,6 +41,7 @@ clap = { version = "3.1.17", features = ["cargo"] }
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0-tdx" }
 kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "main" }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
+vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", branch = "main" }
 
 [dev-dependencies]
 dirs = "4.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branc
 kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "main" }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
 vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", branch = "main" }
+virtio-queue = { git = "https://github.com/sboeuf/vm-virtio", branch = "fix_virtio-queue" }
 
 [dev-dependencies]
 dirs = "4.0.0"

--- a/acpi_tables/Cargo.toml
+++ b/acpi_tables/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2021"
 
 [dependencies]
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -21,7 +21,7 @@ serde_derive = "1.0.137"
 thiserror = "1.0.31"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }
 

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -17,8 +17,8 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vhdx = { path = "../vhdx" }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.2.0"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.3.0"
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"
 

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.17"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-device = { path = "../vm-device" }
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = "0.9.0"
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,7 +19,7 @@ virtio-devices = { path = "../virtio-devices" }
 virtio-queue = "0.2.0"
 vmm-sys-util = "0.9.0"
 vm-virtio = { path = "../vm-virtio" }
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 
 [dependencies.cloud-hypervisor]
 path = ".."

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -23,7 +23,7 @@ mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optio
 serde = { version = "1.0.137", features = ["rc"] }
 serde_derive = "1.0.137"
 serde_json = "1.0.81"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -15,8 +15,8 @@ serde = "1.0.137"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 virtio-bindings = "0.1.0"
-virtio-queue = "0.2.0"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.3.0"
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"
 

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -25,7 +25,7 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 vm-migration = { path = "../vm-migration" }
 
 [dependencies.vfio-bindings]

--- a/vfio_user/Cargo.toml
+++ b/vfio_user/Cargo.toml
@@ -12,7 +12,7 @@ serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 thiserror = "1.0.31"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = ">=0.3.1"
 
 [dependencies.vfio-bindings]

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -14,9 +14,9 @@ log = "0.4.17"
 option_parser = { path = "../option_parser" }
 qcow = { path = "../qcow" }
 vhost = { version = "0.4.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.3.0"
+vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", branch = "main" }
 virtio-bindings = "0.1.0"
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 vmm-sys-util = "0.9.0"
 
 [build-dependencies]

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -13,9 +13,9 @@ log = "0.4.17"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
 vhost = { version = "0.4.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.3.0"
+vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", branch = "main" }
 virtio-bindings = "0.1.0"
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 vmm-sys-util = "0.9.0"
 
 [build-dependencies]

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -31,10 +31,10 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vhost = { version = "0.4.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern", "vhost-vdpa"] }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.2.0"
+virtio-queue = "0.3.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -19,7 +19,7 @@ use std::sync::{
     Arc, Barrier,
 };
 use std::thread;
-use virtio_queue::Queue;
+use virtio_queue::{Queue, QueueStateSync};
 use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestUsize};
 use vm_migration::{MigratableError, Pausable};
 use vm_virtio::AccessPlatform;
@@ -107,7 +107,7 @@ pub trait VirtioDevice: Send {
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
         interrupt_evt: Arc<dyn VirtioInterrupt>,
-        queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
+        queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>, QueueStateSync>>,
         queue_evts: Vec<EventFd>,
     ) -> ActivateResult;
 
@@ -251,7 +251,7 @@ impl VirtioCommon {
 
     pub fn activate(
         &mut self,
-        queues: &[Queue<GuestMemoryAtomic<GuestMemoryMmap>>],
+        queues: &[Queue<GuestMemoryAtomic<GuestMemoryMmap>, QueueStateSync>],
         queue_evts: &[EventFd],
         interrupt_cb: &Arc<dyn VirtioInterrupt>,
     ) -> ActivateResult {

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -35,7 +35,7 @@ use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_bindings::bindings::virtio_net::*;
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use virtio_queue::Queue;
+use virtio_queue::{Queue, QueueStateSync};
 use vm_memory::{ByteValued, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
@@ -51,7 +51,7 @@ pub struct NetCtrlEpollHandler {
     pub pause_evt: EventFd,
     pub ctrl_q: CtrlQueue,
     pub queue_evt: EventFd,
-    pub queue: Queue<GuestMemoryAtomic<GuestMemoryMmap>>,
+    pub queue: Queue<GuestMemoryAtomic<GuestMemoryMmap>, QueueStateSync>,
     pub access_platform: Option<Arc<dyn AccessPlatform>>,
     pub interrupt_cb: Arc<dyn VirtioInterrupt>,
     pub queue_index: u16,
@@ -155,7 +155,7 @@ struct NetEpollHandler {
     kill_evt: EventFd,
     pause_evt: EventFd,
     queue_index_base: u16,
-    queue_pair: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
+    queue_pair: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>, QueueStateSync>>,
     queue_evt_pair: Vec<EventFd>,
     // Always generate interrupts until the driver has signalled to the device.
     // This mitigates a problem with interrupts from tap events being "lost" upon
@@ -585,7 +585,7 @@ impl VirtioDevice for Net {
         &mut self,
         _mem: GuestMemoryAtomic<GuestMemoryMmap>,
         interrupt_cb: Arc<dyn VirtioInterrupt>,
-        mut queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
+        mut queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>, QueueStateSync>>,
         mut queue_evts: Vec<EventFd>,
     ) -> ActivateResult {
         self.common.activate(&queues, &queue_evts, &interrupt_cb)?;

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -28,7 +28,7 @@ use virtio_bindings::bindings::virtio_blk::{
     VIRTIO_BLK_F_GEOMETRY, VIRTIO_BLK_F_MQ, VIRTIO_BLK_F_RO, VIRTIO_BLK_F_SEG_MAX,
     VIRTIO_BLK_F_SIZE_MAX, VIRTIO_BLK_F_TOPOLOGY, VIRTIO_BLK_F_WRITE_ZEROES,
 };
-use virtio_queue::Queue;
+use virtio_queue::{Queue, QueueStateSync};
 use vm_memory::{ByteValued, GuestMemoryAtomic};
 use vm_migration::{
     protocol::MemoryRangeTable, Migratable, MigratableError, Pausable, Snapshot, Snapshottable,
@@ -292,7 +292,7 @@ impl VirtioDevice for Blk {
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
         interrupt_cb: Arc<dyn VirtioInterrupt>,
-        queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
+        queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>, QueueStateSync>>,
         queue_evts: Vec<EventFd>,
     ) -> ActivateResult {
         self.common.activate(&queues, &queue_evts, &interrupt_cb)?;

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -27,7 +27,7 @@ use vhost::vhost_user::message::{
 use vhost::vhost_user::{
     HandlerResult, MasterReqHandler, VhostUserMaster, VhostUserMasterReqHandler,
 };
-use virtio_queue::Queue;
+use virtio_queue::{Queue, QueueStateSync};
 use vm_memory::{
     Address, ByteValued, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
 };
@@ -504,7 +504,7 @@ impl VirtioDevice for Fs {
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
         interrupt_cb: Arc<dyn VirtioInterrupt>,
-        queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
+        queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>, QueueStateSync>>,
         queue_evts: Vec<EventFd>,
     ) -> ActivateResult {
         self.common.activate(&queues, &queue_evts, &interrupt_cb)?;

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -18,8 +18,8 @@ use vhost::vhost_user::message::{
 };
 use vhost::vhost_user::{MasterReqHandler, VhostUserMasterReqHandler};
 use vhost::Error as VhostError;
-use virtio_queue::Error as QueueError;
 use virtio_queue::Queue;
+use virtio_queue::{Error as QueueError, QueueStateSync};
 use vm_memory::{
     mmap::MmapRegionError, Address, Error as MmapError, GuestAddressSpace, GuestMemory,
     GuestMemoryAtomic,
@@ -167,7 +167,7 @@ pub struct VhostUserEpollHandler<S: VhostUserMasterReqHandler> {
     pub mem: GuestMemoryAtomic<GuestMemoryMmap>,
     pub kill_evt: EventFd,
     pub pause_evt: EventFd,
-    pub queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
+    pub queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>, QueueStateSync>>,
     pub queue_evts: Vec<EventFd>,
     pub virtio_interrupt: Arc<dyn VirtioInterrupt>,
     pub acked_features: u64,
@@ -299,7 +299,7 @@ impl VhostUserCommon {
     pub fn activate<T: VhostUserMasterReqHandler>(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
-        queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
+        queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>, QueueStateSync>>,
         queue_evts: Vec<EventFd>,
         interrupt_cb: Arc<dyn VirtioInterrupt>,
         acked_features: u64,

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -27,7 +27,7 @@ use virtio_bindings::bindings::virtio_net::{
     VIRTIO_NET_F_MAC, VIRTIO_NET_F_MRG_RXBUF,
 };
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use virtio_queue::Queue;
+use virtio_queue::{Queue, QueueStateSync};
 use vm_memory::{ByteValued, GuestMemoryAtomic};
 use vm_migration::{
     protocol::MemoryRangeTable, Migratable, MigratableError, Pausable, Snapshot, Snapshottable,
@@ -272,7 +272,7 @@ impl VirtioDevice for Net {
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
         interrupt_cb: Arc<dyn VirtioInterrupt>,
-        mut queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
+        mut queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>, QueueStateSync>>,
         mut queue_evts: Vec<EventFd>,
     ) -> ActivateResult {
         self.common.activate(&queues, &queue_evts, &interrupt_cb)?;

--- a/virtio-devices/src/vsock/csm/connection.rs
+++ b/virtio-devices/src/vsock/csm/connection.rs
@@ -819,6 +819,7 @@ mod tests {
             let stream = TestStream::new();
             let mut pkt = VsockPacket::from_rx_virtq_head(
                 &mut handler_ctx.handler.queues[0]
+                    .lock_with_memory()
                     .iter()
                     .unwrap()
                     .next()

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -402,6 +402,7 @@ mod tests {
         ($test_ctx:expr, $handler_ctx:expr, $err:pat, $ctor:ident, $vq:expr) => {
             match VsockPacket::$ctor(
                 &mut $handler_ctx.handler.queues[$vq]
+                    .lock_with_memory()
                     .iter()
                     .unwrap()
                     .next()
@@ -433,6 +434,7 @@ mod tests {
 
             let pkt = VsockPacket::from_tx_virtq_head(
                 &mut handler_ctx.handler.queues[1]
+                    .lock_with_memory()
                     .iter()
                     .unwrap()
                     .next()
@@ -471,6 +473,7 @@ mod tests {
             set_pkt_len(0, &handler_ctx.guest_txvq.dtable[0], &test_ctx.mem);
             let mut pkt = VsockPacket::from_tx_virtq_head(
                 &mut handler_ctx.handler.queues[1]
+                    .lock_with_memory()
                     .iter()
                     .unwrap()
                     .next()
@@ -529,6 +532,7 @@ mod tests {
             create_context!(test_ctx, handler_ctx);
             let pkt = VsockPacket::from_rx_virtq_head(
                 &mut handler_ctx.handler.queues[0]
+                    .lock_with_memory()
                     .iter()
                     .unwrap()
                     .next()
@@ -586,6 +590,7 @@ mod tests {
         create_context!(test_ctx, handler_ctx);
         let mut pkt = VsockPacket::from_rx_virtq_head(
             &mut handler_ctx.handler.queues[0]
+                .lock_with_memory()
                 .iter()
                 .unwrap()
                 .next()
@@ -677,6 +682,7 @@ mod tests {
         create_context!(test_ctx, handler_ctx);
         let mut pkt = VsockPacket::from_rx_virtq_head(
             &mut handler_ctx.handler.queues[0]
+                .lock_with_memory()
                 .iter()
                 .unwrap()
                 .next()

--- a/virtio-devices/src/vsock/unix/muxer.rs
+++ b/virtio-devices/src/vsock/unix/muxer.rs
@@ -842,6 +842,7 @@ mod tests {
             let mut handler_ctx = vsock_test_ctx.create_epoll_handler_context();
             let pkt = VsockPacket::from_rx_virtq_head(
                 &mut handler_ctx.handler.queues[0]
+                    .lock_with_memory()
                     .iter()
                     .unwrap()
                     .next()

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.125"
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 arch = { path = "../arch" }

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -16,6 +16,6 @@ serde = { version = "1.0.137", features = ["rc"] }
 serde_derive = "1.0.137"
 serde_json = "1.0.81"
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap"] }
 vmm-sys-util = "0.9.0"
 

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -12,4 +12,4 @@ serde_derive = "1.0.137"
 serde_json = "1.0.81"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic"] }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -10,5 +10,5 @@ default = []
 [dependencies]
 log = "0.4.17"
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.2.0"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.3.0"
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -50,10 +50,10 @@ vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", defau
 vfio_user = { path = "../vfio_user" }
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.2.0"
+virtio-queue = "0.3.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }


### PR DESCRIPTION
[WIP] Moving to virtio-queue 0.3.0 with some dependency on my personal fork of virtio-queue as we need the method `lock_state()` to be public.
Also, the big change in this PR is to move to `QueueStateSync` since `QueueState` doesn't derive `Clone` anymore. We have to use the locked API since we have multiple threads (vcpu and any virtio-device) that can potentially access the Queue concurrently.
We need to assess if the locked API is introducing any performance drop. 