### PR TITLE
tests: Extend existing tests with checks on event monitor

### DIFF
--- a/event_monitor/src/lib.rs
+++ b/event_monitor/src/lib.rs
@@ -9,6 +9,7 @@ extern crate serde_derive;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs::File;
+use std::io::Write;
 use std::os::unix::io::AsRawFd;
 use std::time::{Duration, Instant};
 
@@ -50,6 +51,9 @@ pub fn event_log(source: &str, event: &str, properties: Option<&HashMap<Cow<str>
             properties,
         };
         serde_json::to_writer_pretty(file, &e).ok();
+
+        let mut file = file;
+        file.write_all(b"\n\n").ok();
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -503,26 +503,16 @@ impl MetaEvent {
 }
 
 // Parse the event_monitor file based on the format that each event
-// is surrounded by '{' and '}'
+// is followed by a double newline
 fn parse_event_file(event_file: &str) -> Vec<serde_json::Value> {
     let content = fs::read(event_file).unwrap();
-
     let mut ret = Vec::new();
-    let mut entry_start = 0;
-    let mut count = 0;
-    for (idx, &c) in content.iter().enumerate() {
-        if c as char == '{' {
-            count += 1;
-        } else if c as char == '}' {
-            assert!(count > 0);
-            count -= 1;
-        }
-
-        if count == 0 {
-            let entry = String::from_utf8_lossy(&content[entry_start..idx + 1]);
-            ret.push(serde_json::from_str(&entry).unwrap());
-            entry_start = idx + 1;
-        }
+    for entry in String::from_utf8_lossy(&content)
+        .trim()
+        .split("\n\n")
+        .collect::<Vec<&str>>()
+    {
+        ret.push(serde_json::from_str(entry).unwrap());
     }
 
     ret


### PR DESCRIPTION
In this way, we can cover a broad range of events from the event monitor
while avoiding code duplication.

Fixes: #4054

Signed-off-by: Bo Chen <chen.bo@intel.com>