### PR TITLE
deps: Bump to virtio queue 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,8 +1181,7 @@ dependencies = [
 [[package]]
 name = "vhost-user-backend"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1490f2028d4f119b2292efe218b5f8cfc6471f039b53b6a6eb5d9513e964facc"
+source = "git+https://github.com/rust-vmm/vhost-user-backend?rev=14f58eda14076e973704d4f904850be1146fbb05#14f58eda14076e973704d4f904850be1146fbb05"
 dependencies = [
  "libc",
  "log",
@@ -1273,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3785325315e6496fa88673842ee6cd198b9658e88e8b0e1ad48a5dc818b221dc"
+checksum = "88f2d73c184c18f8acc32dab77fcb6e3af92d53262538d3a68aa474810d6863c"
 dependencies = [
  "log",
  "vm-memory",
@@ -1313,9 +1312,9 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#ca35d96191f8232bd7a
 
 [[package]]
 name = "vm-memory"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339d4349c126fdcd87e034631d7274370cf19eb0e87b33166bcd956589fc72c5"
+checksum = "767ed8aaebbff902e02e6d3749dc2baef55e46565f8a6414a065e5baee4b4a81"
 dependencies = [
  "arc-swap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ signal-hook = "0.3.13"
 thiserror = "1.0.31"
 vmm = { path = "vmm" }
 vmm-sys-util = "0.9.0"
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 
 [build-dependencies]
 clap = { version = "3.1.17", features = ["cargo"] }

--- a/acpi_tables/Cargo.toml
+++ b/acpi_tables/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2021"
 
 [dependencies]
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -21,7 +21,7 @@ serde_derive = "1.0.137"
 thiserror = "1.0.31"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }
 

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -17,8 +17,8 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vhdx = { path = "../vhdx" }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.2.0"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.3.0"
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"
 

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.17"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-device = { path = "../vm-device" }
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = "0.9.0"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -865,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3785325315e6496fa88673842ee6cd198b9658e88e8b0e1ad48a5dc818b221dc"
+checksum = "88f2d73c184c18f8acc32dab77fcb6e3af92d53262538d3a68aa474810d6863c"
 dependencies = [
  "log",
  "vm-memory",
@@ -888,6 +888,7 @@ name = "vm-device"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "hypervisor",
  "serde",
  "serde_derive",
  "serde_json",
@@ -904,9 +905,9 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#720e48e435b791ec6cb
 
 [[package]]
 name = "vm-memory"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339d4349c126fdcd87e034631d7274370cf19eb0e87b33166bcd956589fc72c5"
+checksum = "767ed8aaebbff902e02e6d3749dc2baef55e46565f8a6414a065e5baee4b4a81"
 dependencies = [
  "arc-swap",
  "libc",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,10 +16,10 @@ qcow = { path = "../qcow" }
 seccompiler = "0.2.0"
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.2.0"
+virtio-queue = "0.3.0"
 vmm-sys-util = "0.9.0"
 vm-virtio = { path = "../vm-virtio" }
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 
 [dependencies.cloud-hypervisor]
 path = ".."

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -23,7 +23,7 @@ mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optio
 serde = { version = "1.0.137", features = ["rc"] }
 serde_derive = "1.0.137"
 serde_json = "1.0.81"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -15,8 +15,8 @@ serde = "1.0.137"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 virtio-bindings = "0.1.0"
-virtio-queue = "0.2.0"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.3.0"
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"
 

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -25,7 +25,7 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 vm-migration = { path = "../vm-migration" }
 
 [dependencies.vfio-bindings]

--- a/vfio_user/Cargo.toml
+++ b/vfio_user/Cargo.toml
@@ -12,7 +12,7 @@ serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 thiserror = "1.0.31"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = ">=0.3.1"
 
 [dependencies.vfio-bindings]

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -14,9 +14,9 @@ log = "0.4.17"
 option_parser = { path = "../option_parser" }
 qcow = { path = "../qcow" }
 vhost = { version = "0.4.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.3.0"
+vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", rev = "14f58eda14076e973704d4f904850be1146fbb05" }
 virtio-bindings = "0.1.0"
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 vmm-sys-util = "0.9.0"
 
 [build-dependencies]

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -13,9 +13,9 @@ log = "0.4.17"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
 vhost = { version = "0.4.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.3.0"
+vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", rev = "14f58eda14076e973704d4f904850be1146fbb05" }
 virtio-bindings = "0.1.0"
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 vmm-sys-util = "0.9.0"
 
 [build-dependencies]

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -31,10 +31,10 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vhost = { version = "0.4.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern", "vhost-vdpa"] }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.2.0"
+virtio-queue = "0.3.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.9.0"

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -672,7 +672,8 @@ impl VirtioPciDevice {
                 let mem = self.memory.as_ref().unwrap().clone();
                 let mut device = self.device.lock().unwrap();
                 let mut queue_evts = Vec::new();
-                let mut queues = self.queues.clone();
+                let mut queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>>> =
+                    self.queues.iter().map(vm_virtio::clone_queue).collect();
                 queues.retain(|q| q.state.ready);
                 for (i, queue) in queues.iter().enumerate() {
                     queue_evts.push(self.queue_evts[i].try_clone().unwrap());

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -224,7 +224,7 @@ impl<S: VhostUserMasterReqHandler> VhostUserEpollHandler<S> {
         vhost_user
             .reinitialize_vhost_user(
                 self.mem.memory().deref(),
-                self.queues.clone(),
+                self.queues.iter().map(vm_virtio::clone_queue).collect(),
                 self.queue_evts
                     .iter()
                     .map(|q| q.try_clone().unwrap())
@@ -324,7 +324,7 @@ impl VhostUserCommon {
             .unwrap()
             .setup_vhost_user(
                 &mem.memory(),
-                queues.clone(),
+                queues.iter().map(vm_virtio::clone_queue).collect(),
                 queue_evts.iter().map(|q| q.try_clone().unwrap()).collect(),
                 &interrupt_cb,
                 acked_features,

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.125"
-vm-memory = "0.7.0"
+vm-memory = "0.8.0"
 arch = { path = "../arch" }

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -17,6 +17,6 @@ serde = { version = "1.0.137", features = ["rc"] }
 serde_derive = "1.0.137"
 serde_json = "1.0.81"
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap"] }
 vmm-sys-util = "0.9.0"
 

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -12,4 +12,4 @@ serde_derive = "1.0.137"
 serde_json = "1.0.81"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic"] }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -10,5 +10,5 @@ default = []
 [dependencies]
 log = "0.4.17"
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.2.0"
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.3.0"
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -135,7 +135,7 @@ pub fn clone_queue(
             next_avail: queue.state.next_avail,
             next_used: queue.state.next_used,
             event_idx_enabled: queue.state.event_idx_enabled,
-            signalled_used: queue.state.signalled_used,
+            num_added: queue.state.num_added,
             size: queue.state.size,
             ready: queue.state.ready,
             desc_table: queue.state.desc_table,

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -50,10 +50,10 @@ vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", defau
 vfio_user = { path = "../vfio_user" }
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.2.0"
+virtio-queue = "0.3.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }


### PR DESCRIPTION
The main goal of this PR is to move to `virtio-queue` 0.3.0. To do so, it needs to update the dependency on `vhost-user-backend` to the latest revision from the main branch. It also need to patch the Cloud Hypervisor code to keep cloning the `Queue` now that the `QueueState` doesn't implement `Clone` anymore.
Just a note that from a Rust perspective, it'd be cleaner to use the `QueueStateSync` approach, placing the `QueueState` behind an `Arc<Mutex<>>`, and allowing for cloning the reference. But this would involve many locks to be taken on the hotpath of handling the virtio queues, affecting directly the performance.
After some analysis, we confirmed that the current design present in Cloud Hypervisor isn't introducing any issue, even when relying on copies of the Queue. That's because at the time the virtio driver activates the device, most of the information in the Queue isn't going to change. And for the few information that are still likely to change (such as `avail_idx` and `used_idx`), they can be retrieved from the guest memory directly.