### PR TITLE
Clean up serde dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,6 @@ dependencies = [
  "linux-loader",
  "log",
  "serde",
- "serde_derive",
  "thiserror",
  "versionize",
  "versionize_derive",
@@ -266,7 +265,6 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "serde",
- "serde_derive",
  "serde_json",
 ]
 
@@ -353,7 +351,6 @@ dependencies = [
  "mshv-bindings",
  "mshv-ioctls",
  "serde",
- "serde_derive",
  "serde_json",
  "thiserror",
  "vm-memory",
@@ -656,7 +653,6 @@ dependencies = [
  "libc",
  "log",
  "serde",
- "serde_derive",
  "thiserror",
  "versionize",
  "versionize_derive",
@@ -677,7 +673,6 @@ dependencies = [
  "clap",
  "dirs",
  "serde",
- "serde_derive",
  "serde_json",
  "test_infra",
  "thiserror",
@@ -905,6 +900,9 @@ name = "serde"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -1260,7 +1258,6 @@ dependencies = [
  "rate_limiter",
  "seccompiler",
  "serde",
- "serde_derive",
  "serde_json",
  "thiserror",
  "versionize",
@@ -1303,7 +1300,6 @@ dependencies = [
  "anyhow",
  "hypervisor",
  "serde",
- "serde_derive",
  "serde_json",
  "thiserror",
  "vfio-ioctls",
@@ -1333,7 +1329,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "serde",
- "serde_derive",
  "serde_json",
  "thiserror",
  "versionize",
@@ -1379,7 +1374,6 @@ dependencies = [
  "qcow",
  "seccompiler",
  "serde",
- "serde_derive",
  "serde_json",
  "signal-hook",
  "thiserror",

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -16,8 +16,7 @@ hypervisor = { path = "../hypervisor" }
 libc = "0.2.125"
 linux-loader = { version = "0.4.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.17"
-serde = { version = "1.0.137", features = ["rc"] }
-serde_derive = "1.0.137"
+serde = { version = "1.0.137", features = ["rc", "derive"] }
 thiserror = "1.0.31"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -9,11 +9,10 @@
 
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate serde_derive;
 
 #[cfg(target_arch = "x86_64")]
 use crate::x86_64::SgxEpcSection;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::result;

--- a/event_monitor/Cargo.toml
+++ b/event_monitor/Cargo.toml
@@ -6,6 +6,5 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.125"
-serde = { version = "1.0.137", features = ["rc"] }
-serde_derive = "1.0.137"
+serde = { version = "1.0.137", features = ["rc", "derive"] }
 serde_json = "1.0.81"

--- a/event_monitor/src/lib.rs
+++ b/event_monitor/src/lib.rs
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#[macro_use]
-extern crate serde_derive;
-
+use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs::File;

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -20,8 +20,7 @@ kvm-ioctls = { version = "0.11.0", optional = true }
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0-tdx", features = ["with-serde", "fam-wrappers"], optional  = true }
 mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
 mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional  = true}
-serde = { version = "1.0.137", features = ["rc"] }
-serde_derive = "1.0.137"
+serde = { version = "1.0.137", features = ["rc", "derive"] }
 serde_json = "1.0.81"
 vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = "0.9.0", features = ["with-serde"] }

--- a/hypervisor/src/kvm/aarch64/mod.rs
+++ b/hypervisor/src/kvm/aarch64/mod.rs
@@ -23,7 +23,7 @@ use kvm_bindings::{
 pub use kvm_bindings::{
     kvm_one_reg as Register, kvm_regs as StandardRegisters, kvm_vcpu_init as VcpuInit, RegList,
 };
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 pub use {kvm_ioctls::Cap, kvm_ioctls::Kvm};
 
 // This macro gets the offset of a structure (i.e `str`) member (i.e `field`) without having

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -21,7 +21,7 @@ use crate::vm::{self, InterruptSourceConfig, VmOps};
 #[cfg(target_arch = "aarch64")]
 use crate::{arm64_core_reg_id, offset__of};
 use kvm_ioctls::{NoDatamatch, VcpuFd, VmFd};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 #[cfg(target_arch = "aarch64")]
 use std::convert::TryInto;

--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -10,7 +10,7 @@
 
 use crate::arch::x86::{msr_index, SegmentRegisterOps, MTRR_ENABLE, MTRR_MEM_TYPE_WB};
 use crate::kvm::{Cap, Kvm, KvmError, KvmResult};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 ///
 /// Export generically-named wrappers of kvm-bindings for Unix-based platforms

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -15,7 +15,7 @@ use crate::vm::{self, InterruptSourceConfig, VmOps};
 pub use mshv_bindings::*;
 pub use mshv_ioctls::IoEventAddress;
 use mshv_ioctls::{set_registers_64, Mshv, NoDatamatch, VcpuFd, VmFd};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use vm::DataMatch;

--- a/hypervisor/src/mshv/x86_64/mod.rs
+++ b/hypervisor/src/mshv/x86_64/mod.rs
@@ -8,7 +8,7 @@
 //
 //
 use crate::arch::x86::{msr_index, SegmentRegisterOps, MTRR_ENABLE, MTRR_MEM_TYPE_WB};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 ///

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -18,8 +18,7 @@ vfio_user = { path = "../vfio_user" }
 vmm-sys-util = "0.9.0"
 libc = "0.2.125"
 log = "0.4.17"
-serde = "1.0.137"
-serde_derive = "1.0.137"
+serde = { version="1.0.137", features=["derive"] }
 thiserror = "1.0.31"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -8,8 +8,7 @@ build = "build.rs"
 [dependencies]
 clap = { version = "3.1.18", features = ["wrap_help","cargo"] }
 dirs = "4.0.0"
-serde = { version = "1.0.137", features = ["rc"] }
-serde_derive = "1.0.137"
+serde = { version = "1.0.137", features = ["rc", "derive"] }
 serde_json = "1.0.81"
 test_infra = { path = "../test_infra" }
 thiserror = "1.0.31"

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -12,7 +12,7 @@ mod performance_tests;
 
 use clap::{Arg, Command as ClapCommand};
 use performance_tests::*;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::{env, fmt, process::Command, sync::mpsc::channel, thread, time::Duration};
 use thiserror::Error;
 

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -23,8 +23,7 @@ net_util = { path = "../net_util" }
 pci = { path = "../pci" }
 rate_limiter = { path = "../rate_limiter" }
 seccompiler = "0.2.0"
-serde = "1.0.137"
-serde_derive = "1.0.137"
+serde = { version="1.0.137", features=["derive"] }
 serde_json = "1.0.81"
 thiserror = "1.0.31"
 versionize = "0.1.6"

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -14,9 +14,8 @@
 extern crate event_monitor;
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate serde_derive;
 
+use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::io;
 

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -13,8 +13,7 @@ mshv = ["vfio-ioctls/mshv"]
 anyhow = "1.0.57"
 hypervisor = { path = "../hypervisor" }
 thiserror = "1.0.31"
-serde = { version = "1.0.137", features = ["rc"] }
-serde_derive = "1.0.137"
+serde = { version = "1.0.137", features = ["rc", "derive"] }
 serde_json = "1.0.81"
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
 vm-memory = { version = "0.8.0", features = ["backend-mmap"] }

--- a/vm-device/src/lib.rs
+++ b/vm-device/src/lib.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#[macro_use]
-extern crate serde_derive;
+use serde::{Deserialize, Serialize};
 
 mod bus;
 pub mod dma_mapping;

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.57"
 thiserror = "1.0.31"
-serde = { version = "1.0.137", features = ["rc"] }
-serde_derive = "1.0.137"
+serde = { version = "1.0.137", features = ["rc", "derive"] }
 serde_json = "1.0.81"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 //
 
-#[macro_use]
-extern crate serde_derive;
-
 use crate::protocol::MemoryRangeTable;
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -4,6 +4,7 @@
 //
 
 use crate::{MigratableError, VersionMapped};
+use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -38,8 +38,7 @@ option_parser = { path = "../option_parser" }
 pci = { path = "../pci" }
 qcow = { path = "../qcow" }
 seccompiler = "0.2.0"
-serde = { version = "1.0.137", features = ["rc"] }
-serde_derive = "1.0.137"
+serde = { version = "1.0.137", features = ["rc", "derive"] }
 serde_json = "1.0.81"
 signal-hook = "0.3.14"
 thiserror = "1.0.31"

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -41,6 +41,7 @@ use crate::config::{
 use crate::device_tree::DeviceTree;
 use crate::vm::{Error as VmError, VmState};
 use micro_http::Body;
+use serde::{Deserialize, Serialize};
 use std::io;
 use std::sync::mpsc::{channel, RecvError, SendError, Sender};
 use std::sync::{Arc, Mutex};

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -8,6 +8,7 @@ use net_util::MacAddr;
 use option_parser::{
     ByteSized, IntegerList, OptionParser, OptionParserError, StringList, Toggle, Tuple,
 };
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
 use std::convert::From;
 use std::fmt;

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -65,6 +65,7 @@ use pci::{
     VfioUserPciDevice, VfioUserPciDeviceError,
 };
 use seccompiler::SeccompAction;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
 use std::convert::TryInto;
 use std::fs::{read_link, File, OpenOptions};

--- a/vmm/src/device_tree.rs
+++ b/vmm/src/device_tree.rs
@@ -4,6 +4,7 @@
 
 use crate::device_manager::PciDeviceHandle;
 use pci::PciBdf;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use vm_device::Resource;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -9,8 +9,6 @@ extern crate event_monitor;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate serde_derive;
 
 use crate::api::{
     ApiError, ApiRequest, ApiResponse, ApiResponsePayload, VmInfo, VmReceiveMigrationData,
@@ -30,7 +28,8 @@ use libc::EFD_NONBLOCK;
 use memory_manager::MemoryManagerSnapshotData;
 use pci::PciBdf;
 use seccompiler::{apply_filter, SeccompAction};
-use serde::ser::{Serialize, SerializeStruct, Serializer};
+use serde::ser::{SerializeStruct, Serializer};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -17,6 +17,7 @@ use arch::{layout, RegionType};
 use devices::ioapic;
 #[cfg(target_arch = "x86_64")]
 use libc::{MAP_NORESERVE, MAP_POPULATE, MAP_SHARED, PROT_READ, PROT_WRITE};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::ffi;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -57,6 +57,7 @@ use linux_loader::loader::elf::PvhBootCapability::PvhEntryPresent;
 use linux_loader::loader::pe::Error::InvalidImageMagicNumber;
 use linux_loader::loader::KernelLoader;
 use seccompiler::{apply_filter, SeccompAction};
+use serde::{Deserialize, Serialize};
 use signal_hook::{
     consts::{SIGINT, SIGTERM, SIGWINCH},
     iterator::backend::Handle,


### PR DESCRIPTION
There is no need to include `serde_derive` separately,
as it can be specified as serde feature instead.

Also this PRs removes relevant `extern crate` imports as these are
[deprecated](https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html) in 2015 edition.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>