### PR TITLE
virtio-devices, vmm: Remove unused macro rules

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6535,7 +6535,7 @@ mod windows {
                 .spawn()
                 .unwrap();
             let stdin = child.stdin.as_mut().expect("failed to open stdin");
-            let _ = stdin
+            stdin
                 .write_all("type=7".as_bytes())
                 .expect("failed to write stdin");
             let out = child.wait_with_output().expect("sfdisk failed").stdout;

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -34,7 +34,6 @@ pub enum Thread {
 /// [`SeccompCondition`]: struct.SeccompCondition.html
 /// [`SeccompRule`]: struct.SeccompRule.html
 macro_rules! and {
-    ($($x:expr,)*) => (SeccompRule::new(vec![$($x),*]).unwrap());
     ($($x:expr),*) => (SeccompRule::new(vec![$($x),*]).unwrap())
 }
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -24,7 +24,6 @@ pub enum Thread {
 /// [`SeccompCondition`]: struct.SeccompCondition.html
 /// [`SeccompRule`]: struct.SeccompRule.html
 macro_rules! and {
-    ($($x:expr,)*) => (SeccompRule::new(vec![$($x),*]).unwrap());
     ($($x:expr),*) => (SeccompRule::new(vec![$($x),*]).unwrap())
 }
 


### PR DESCRIPTION
Latest cargo beta version raises warnings about unused macro rules.
Simply remove them to fix the beta build.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>