### PR TITLE
Revert "virtio-devices, vmm: Optimised async virtio device activation"

### DIFF
--- a/virtio-devices/src/transport/mod.rs
+++ b/virtio-devices/src/transport/mod.rs
@@ -6,7 +6,7 @@ use vmm_sys_util::eventfd::EventFd;
 mod pci_common_config;
 mod pci_device;
 pub use pci_common_config::VirtioPciCommonConfig;
-pub use pci_device::{VirtioPciDevice, VirtioPciDeviceActivator};
+pub use pci_device::VirtioPciDevice;
 
 pub trait VirtioTransport {
     fn ioeventfds(&self, base_addr: u64) -> Vec<(&EventFd, u64)>;

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -79,12 +79,10 @@ use std::result;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use vfio_ioctls::{VfioContainer, VfioDevice};
+use virtio_devices::transport::VirtioPciDevice;
 use virtio_devices::transport::VirtioTransport;
-use virtio_devices::transport::{VirtioPciDevice, VirtioPciDeviceActivator};
 use virtio_devices::vhost_user::VhostUserConfig;
-use virtio_devices::{
-    AccessPlatformMapping, ActivateError, VdpaDmaMapping, VirtioMemMappingSource,
-};
+use virtio_devices::{AccessPlatformMapping, VdpaDmaMapping, VirtioMemMappingSource};
 use virtio_devices::{Endpoint, IommuMapping};
 use virtio_devices::{VirtioSharedMemory, VirtioSharedMemoryList};
 use vm_allocator::{AddressAllocator, SystemAllocator};
@@ -478,9 +476,6 @@ pub enum DeviceManagerError {
 
     /// Invalid identifier
     InvalidIdentifier(String),
-
-    /// Error activating virtio device
-    VirtioActivate(ActivateError),
 }
 pub type DeviceManagerResult<T> = result::Result<T, DeviceManagerError>;
 
@@ -944,9 +939,6 @@ pub struct DeviceManager {
 
     // Start time of the VM
     timestamp: Instant,
-
-    // Pending activations
-    pending_activations: Arc<Mutex<Vec<VirtioPciDeviceActivator>>>,
 }
 
 impl DeviceManager {
@@ -1088,7 +1080,6 @@ impl DeviceManager {
             io_uring_supported: None,
             boot_id_list,
             timestamp,
-            pending_activations: Arc::new(Mutex::new(Vec::default())),
         };
 
         let device_manager = Arc::new(Mutex::new(device_manager));
@@ -3529,7 +3520,6 @@ impl DeviceManager {
                 // The exception being if not on the default PCI segment.
                 pci_segment_id > 0 || device_type != VirtioDeviceType::Block as u32,
                 dma_handler,
-                self.pending_activations.clone(),
             )
             .map_err(DeviceManagerError::VirtioDevice)?,
         ));
@@ -3684,10 +3674,17 @@ impl DeviceManager {
     }
 
     pub fn activate_virtio_devices(&self) -> DeviceManagerResult<()> {
-        for mut activator in self.pending_activations.lock().unwrap().drain(..) {
-            activator
-                .activate()
-                .map_err(DeviceManagerError::VirtioActivate)?;
+        // Find virtio pci devices and activate any pending ones
+        let device_tree = self.device_tree.lock().unwrap();
+        for pci_device_node in device_tree.pci_devices() {
+            #[allow(irrefutable_let_patterns)]
+            if let PciDeviceHandle::Virtio(virtio_pci_device) = &pci_device_node
+                .pci_device_handle
+                .as_ref()
+                .ok_or(DeviceManagerError::MissingPciDevice)?
+            {
+                virtio_pci_device.lock().unwrap().maybe_activate();
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
This reverts commit f160572f9deed7735bb249c6a734c915e9bce432.

There has been increased flakiness around the live migration tests since
this was merged. Speculatively reverting to see if there is increased
stability.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
