### PR TITLE
Revert ".github: Fix Rust version for release to 1.58"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,12 +16,12 @@ jobs:
       - name: Install Rust toolchain (x86_64-unknown-linux-gnu)
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.58
+            toolchain: stable
             target: x86_64-unknown-linux-gnu
       - name: Install Rust toolchain (x86_64-unknown-linux-musl)
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.58
+            toolchain: stable
             target: x86_64-unknown-linux-musl
       - name: Build
         uses: actions-rs/cargo@v1
@@ -40,7 +40,7 @@ jobs:
       - name: Install Rust toolchain (aarch64-unknown-linux-musl)
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.58
+            toolchain: stable
             target: aarch64-unknown-linux-musl
             override: true
       - name: Static Build (AArch64)


### PR DESCRIPTION
This reverts commit 6a099257e8e9222c53e19fa3858e9211ae943f95.

It is now clear that pinning the toolchain for cross compilation is not
necessary since we only use it for building to aarch64:

https://github.com/rust-lang/rust/issues/95926#issue-1199547707

"This problem doesn't currently show up when cross-compiling from x86_64
to aarch64, since aarch64 doesn't use static-pie by default, but
enabling PIE with -C relocation-model=pie triggers the same bug and
makes the resulting binaries segfault."

Fixes: #3962

Signed-off-by: Rob Bradford <robert.bradford@intel.com>