### PR TITLE
tests: Use default timeout for booting in live migration tests

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7697,7 +7697,7 @@ mod live_migration {
             .unwrap();
 
         let r = std::panic::catch_unwind(|| {
-            guest.wait_vm_boot(Some(30)).unwrap();
+            guest.wait_vm_boot(None).unwrap();
 
             // Make sure the source VM is functaionl
             // Check the number of vCPUs


### PR DESCRIPTION
From the logs it appears that booting the VM to the point at which it
can signal to the host can sometimes take longer than then 30 seconds
specified.

Fixes: #4136

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
