### PR TITLE
.github: Use 1.60 toolchain consistently in release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,12 +16,12 @@ jobs:
       - name: Install Rust toolchain (x86_64-unknown-linux-gnu)
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
+            toolchain: "1.60"
             target: x86_64-unknown-linux-gnu
       - name: Install Rust toolchain (x86_64-unknown-linux-musl)
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
+            toolchain: "1.60"
             target: x86_64-unknown-linux-musl
       - name: Build
         uses: actions-rs/cargo@v1
@@ -40,7 +40,7 @@ jobs:
       - name: Install Rust toolchain (aarch64-unknown-linux-musl)
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
+            toolchain: "1.60"
             target: aarch64-unknown-linux-musl
             override: true
       - name: Static Build (AArch64)


### PR DESCRIPTION
Signed-off-by: Rob Bradford <robert.bradford@intel.com>
