### PR TITLE
Refactoring MemoryRegion code

### DIFF
--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -121,10 +121,18 @@ pub trait Hypervisor: Send + Sync {
 ///
 /// Generic MemoryRegion struct
 ///
-pub struct MemoryRegion {
+#[derive(Debug, Default, PartialEq)]
+pub struct UserMemoryRegion {
     pub slot: u32,
     pub guest_phys_addr: u64,
     pub memory_size: u64,
     pub userspace_addr: u64,
     pub flags: u32,
+}
+
+pub mod user_memory_region_flags {
+    pub const READ: u32 = 1;
+    pub const WRITE: u32 = 2;
+    pub const EXECUTE: u32 = 4;
+    pub const LOG_DIRTY_PAGES: u32 = 8;
 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -88,9 +88,8 @@ pub use {
     kvm_bindings::kvm_clock_data as ClockData, kvm_bindings::kvm_create_device as CreateDevice,
     kvm_bindings::kvm_device_attr as DeviceAttr,
     kvm_bindings::kvm_irq_routing_entry as IrqRoutingEntry, kvm_bindings::kvm_mp_state as MpState,
-    kvm_bindings::kvm_run, kvm_bindings::kvm_userspace_memory_region as MemoryRegion,
-    kvm_bindings::kvm_vcpu_events as VcpuEvents, kvm_ioctls::DeviceFd, kvm_ioctls::IoEventAddress,
-    kvm_ioctls::VcpuExit,
+    kvm_bindings::kvm_run, kvm_bindings::kvm_vcpu_events as VcpuEvents, kvm_ioctls::DeviceFd,
+    kvm_ioctls::IoEventAddress, kvm_ioctls::VcpuExit,
 };
 
 #[cfg(target_arch = "x86_64")]
@@ -158,6 +157,55 @@ pub struct TdxCapabilities {
     pub nr_cpuid_configs: u32,
     pub padding: u32,
     pub cpuid_configs: [TdxCpuidConfig; TDX_MAX_NR_CPUID_CONFIGS],
+}
+
+impl From<kvm_userspace_memory_region> for hypervisor::UserMemoryRegion {
+    fn from(region: kvm_userspace_memory_region) -> hypervisor::UserMemoryRegion {
+        hypervisor::UserMemoryRegion {
+            slot: region.slot,
+            guest_phys_addr: region.guest_phys_addr,
+            memory_size: region.memory_size,
+            userspace_addr: region.userspace_addr,
+            flags: hypervisor::user_memory_region_flags::READ
+                | if region.flags & KVM_MEM_READONLY != 0 {
+                    0
+                } else {
+                    hypervisor::user_memory_region_flags::WRITE
+                        | hypervisor::user_memory_region_flags::EXECUTE
+                }
+                | if region.flags & KVM_MEM_LOG_DIRTY_PAGES != 0 {
+                    hypervisor::user_memory_region_flags::LOG_DIRTY_PAGES
+                } else {
+                    0
+                },
+        }
+    }
+}
+
+impl From<hypervisor::UserMemoryRegion> for kvm_userspace_memory_region {
+    fn from(region: hypervisor::UserMemoryRegion) -> kvm_userspace_memory_region {
+        assert!(
+            region.flags & hypervisor::user_memory_region_flags::READ != 0,
+            "KVM mapped memory is always readable"
+        );
+
+        kvm_userspace_memory_region {
+            slot: region.slot,
+            guest_phys_addr: region.guest_phys_addr,
+            memory_size: region.memory_size,
+            userspace_addr: region.userspace_addr,
+            flags: if region.flags & hypervisor::user_memory_region_flags::WRITE != 0 {
+                0
+            } else {
+                KVM_MEM_READONLY
+            } | if region.flags & hypervisor::user_memory_region_flags::LOG_DIRTY_PAGES != 0
+            {
+                KVM_MEM_LOG_DIRTY_PAGES
+            } else {
+                0
+            },
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
@@ -405,27 +453,29 @@ impl vm::Vm for KvmVm {
         guest_phys_addr: u64,
         memory_size: u64,
         userspace_addr: u64,
-        readonly: bool,
-        log_dirty_pages: bool,
-    ) -> MemoryRegion {
-        MemoryRegion {
+        flags: u32,
+    ) -> hypervisor::UserMemoryRegion {
+        // KVM doesn't have individual flags for write and execute so some flag configurations are not valid, these are checked here using asserts.
+        assert!(
+            flags & hypervisor::user_memory_region_flags::READ != 0,
+            "KVM mapped memory is always readable"
+        );
+        hypervisor::UserMemoryRegion {
             slot,
             guest_phys_addr,
             memory_size,
             userspace_addr,
-            flags: if readonly { KVM_MEM_READONLY } else { 0 }
-                | if log_dirty_pages {
-                    KVM_MEM_LOG_DIRTY_PAGES
-                } else {
-                    0
-                },
+            flags,
         }
     }
     ///
     /// Creates a guest physical memory region.
     ///
-    fn create_user_memory_region(&self, user_memory_region: MemoryRegion) -> vm::Result<()> {
-        let mut region = user_memory_region;
+    fn create_user_memory_region(
+        &self,
+        user_memory_region: hypervisor::UserMemoryRegion,
+    ) -> vm::Result<()> {
+        let mut region: kvm_userspace_memory_region = user_memory_region.into();
 
         if (region.flags & KVM_MEM_LOG_DIRTY_PAGES) != 0 {
             if (region.flags & KVM_MEM_READONLY) != 0 {
@@ -460,8 +510,11 @@ impl vm::Vm for KvmVm {
     ///
     /// Removes a guest physical memory region.
     ///
-    fn remove_user_memory_region(&self, user_memory_region: MemoryRegion) -> vm::Result<()> {
-        let mut region = user_memory_region;
+    fn remove_user_memory_region(
+        &self,
+        user_memory_region: hypervisor::UserMemoryRegion,
+    ) -> vm::Result<()> {
+        let mut region: kvm_userspace_memory_region = user_memory_region.into();
 
         // Remove the corresponding entry from "self.dirty_log_slots" if needed
         self.dirty_log_slots.write().unwrap().remove(&region.slot);
@@ -571,17 +624,20 @@ impl vm::Vm for KvmVm {
     fn start_dirty_log(&self) -> vm::Result<()> {
         let dirty_log_slots = self.dirty_log_slots.read().unwrap();
         for (_, s) in dirty_log_slots.iter() {
-            let region = MemoryRegion {
+            let region = hypervisor::UserMemoryRegion {
                 slot: s.slot,
                 guest_phys_addr: s.guest_phys_addr,
                 memory_size: s.memory_size,
                 userspace_addr: s.userspace_addr,
-                flags: KVM_MEM_LOG_DIRTY_PAGES,
+                flags: hypervisor::user_memory_region_flags::LOG_DIRTY_PAGES
+                    | hypervisor::user_memory_region_flags::WRITE
+                    | hypervisor::user_memory_region_flags::READ
+                    | hypervisor::user_memory_region_flags::EXECUTE,
             };
             // SAFETY: Safe because guest regions are guaranteed not to overlap.
             unsafe {
                 self.fd
-                    .set_user_memory_region(region)
+                    .set_user_memory_region(region.into())
                     .map_err(|e| vm::HypervisorVmError::StartDirtyLog(e.into()))?;
             }
         }
@@ -595,17 +651,19 @@ impl vm::Vm for KvmVm {
     fn stop_dirty_log(&self) -> vm::Result<()> {
         let dirty_log_slots = self.dirty_log_slots.read().unwrap();
         for (_, s) in dirty_log_slots.iter() {
-            let region = MemoryRegion {
+            let region = hypervisor::UserMemoryRegion {
                 slot: s.slot,
                 guest_phys_addr: s.guest_phys_addr,
                 memory_size: s.memory_size,
                 userspace_addr: s.userspace_addr,
-                flags: 0,
+                flags: hypervisor::user_memory_region_flags::WRITE
+                    | hypervisor::user_memory_region_flags::READ
+                    | hypervisor::user_memory_region_flags::EXECUTE,
             };
             // SAFETY: Safe because guest regions are guaranteed not to overlap.
             unsafe {
                 self.fd
-                    .set_user_memory_region(region)
+                    .set_user_memory_region(region.into())
                     .map_err(|e| vm::HypervisorVmError::StartDirtyLog(e.into()))?;
             }
         }

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -50,7 +50,7 @@ mod device;
 
 pub use cpu::{HypervisorCpuError, Vcpu, VmExit};
 pub use device::{Device, HypervisorDeviceError};
-pub use hypervisor::{Hypervisor, HypervisorError};
+pub use hypervisor::{user_memory_region_flags, Hypervisor, HypervisorError, UserMemoryRegion};
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
 pub use kvm::x86_64;
 #[cfg(all(feature = "kvm", target_arch = "aarch64"))]
@@ -59,15 +59,15 @@ pub use kvm::{aarch64, GicState};
 #[cfg(feature = "kvm")]
 pub use kvm::{
     ClockData, CpuState, CreateDevice, DeviceAttr, DeviceFd, IoEventAddress, IrqRoutingEntry,
-    MemoryRegion, MpState, VcpuEvents, VcpuExit, VmState,
+    MpState, VcpuEvents, VcpuExit, VmState,
 };
 #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
 pub use mshv::x86_64;
 // Aliased types exposed from both hypervisors
 #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
 pub use mshv::{
-    CpuState, CreateDevice, DeviceAttr, DeviceFd, IoEventAddress, IrqRoutingEntry, MemoryRegion,
-    MpState, VcpuEvents, VcpuExit, VmState,
+    CpuState, CreateDevice, DeviceAttr, DeviceFd, IoEventAddress, IrqRoutingEntry, MpState,
+    VcpuEvents, VcpuExit, VmState,
 };
 use std::sync::Arc;
 pub use vm::{

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -47,6 +47,52 @@ pub use {
 
 pub const PAGE_SHIFT: usize = 12;
 
+impl From<mshv_user_mem_region> for hypervisor::UserMemoryRegion {
+    fn from(region: mshv_user_mem_region) -> Self {
+        let mut flags: u32 = 0;
+        if region.flags & HV_MAP_GPA_READABLE != 0 {
+            flags |= hypervisor::user_memory_region_flags::READ;
+        }
+        if region.flags & HV_MAP_GPA_WRITABLE != 0 {
+            flags |= hypervisor::user_memory_region_flags::WRITE;
+        }
+        if region.flags & HV_MAP_GPA_EXECUTABLE != 0 {
+            flags |= hypervisor::user_memory_region_flags::EXECUTE;
+        }
+
+        hypervisor::UserMemoryRegion {
+            guest_phys_addr: (region.guest_pfn << PAGE_SHIFT as u64)
+                + (region.userspace_addr & ((1 << PAGE_SHIFT) - 1)),
+            memory_size: region.size,
+            userspace_addr: region.userspace_addr,
+            flags: flags,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<hypervisor::UserMemoryRegion> for mshv_user_mem_region {
+    fn from(region: hypervisor::UserMemoryRegion) -> Self {
+        let mut flags: u32 = 0;
+        if region.flags & hypervisor::user_memory_region_flags::READ != 0 {
+            flags |= HV_MAP_GPA_READABLE;
+        }
+        if region.flags & hypervisor::user_memory_region_flags::WRITE != 0 {
+            flags |= HV_MAP_GPA_WRITABLE;
+        }
+        if region.flags & hypervisor::user_memory_region_flags::EXECUTE != 0 {
+            flags |= HV_MAP_GPA_EXECUTABLE;
+        }
+
+        mshv_user_mem_region {
+            guest_pfn: region.guest_phys_addr >> PAGE_SHIFT,
+            size: region.memory_size,
+            userspace_addr: region.userspace_addr,
+            flags: flags,
+        }
+    }
+}
+
 #[derive(Debug, Default, Copy, Clone, Serialize, Deserialize)]
 pub struct HvState {
     hypercall_page: u64,
@@ -879,7 +925,11 @@ impl vm::Vm for MshvVm {
     }
 
     /// Creates a guest physical memory region.
-    fn create_user_memory_region(&self, user_memory_region: MemoryRegion) -> vm::Result<()> {
+    fn create_user_memory_region(
+        &self,
+        user_memory_region: hypervisor::UserMemoryRegion,
+    ) -> vm::Result<()> {
+        let user_memory_region: mshv_user_mem_region = user_memory_region.into();
         // No matter read only or not we keep track the slots.
         // For readonly hypervisor can enable the dirty bits,
         // but a VM exit happens before setting the dirty bits
@@ -898,12 +948,16 @@ impl vm::Vm for MshvVm {
     }
 
     /// Removes a guest physical memory region.
-    fn remove_user_memory_region(&self, user_memory_region: MemoryRegion) -> vm::Result<()> {
+    fn remove_user_memory_region(
+        &self,
+        user_memory_region: hypervisor::UserMemoryRegion,
+    ) -> vm::Result<()> {
+        let user_memory_region: mshv_user_mem_region = user_memory_region.into();
         // Remove the corresponding entry from "self.dirty_log_slots" if needed
         self.dirty_log_slots
             .write()
             .unwrap()
-            .remove(&user_memory_region.guest_pfn);
+            .remove(&(user_memory_region.guest_pfn));
 
         self.fd
             .unmap_user_memory(user_memory_region)
@@ -917,19 +971,14 @@ impl vm::Vm for MshvVm {
         guest_phys_addr: u64,
         memory_size: u64,
         userspace_addr: u64,
-        readonly: bool,
-        _log_dirty_pages: bool,
-    ) -> MemoryRegion {
-        let mut flags = HV_MAP_GPA_READABLE | HV_MAP_GPA_EXECUTABLE;
-        if !readonly {
-            flags |= HV_MAP_GPA_WRITABLE;
-        }
-
-        mshv_user_mem_region {
+        flags: u32,
+    ) -> hypervisor::UserMemoryRegion {
+        hypervisor::UserMemoryRegion {
+            guest_phys_addr,
+            memory_size,
+            userspace_addr,
             flags,
-            guest_pfn: guest_phys_addr >> PAGE_SHIFT,
-            size: memory_size,
-            userspace_addr: userspace_addr as u64,
+            ..Default::default()
         }
     }
 

--- a/hypervisor/src/mshv/x86_64/mod.rs
+++ b/hypervisor/src/mshv/x86_64/mod.rs
@@ -15,9 +15,8 @@ use std::fmt;
 /// Export generically-named wrappers of mshv_bindings for Unix-based platforms
 ///
 pub use {
-    mshv_bindings::hv_cpuid_entry as CpuIdEntry,
-    mshv_bindings::mshv_user_mem_region as MemoryRegion, mshv_bindings::msr_entry as MsrEntry,
-    mshv_bindings::CpuId, mshv_bindings::DebugRegisters,
+    mshv_bindings::hv_cpuid_entry as CpuIdEntry, mshv_bindings::mshv_user_mem_region,
+    mshv_bindings::msr_entry as MsrEntry, mshv_bindings::CpuId, mshv_bindings::DebugRegisters,
     mshv_bindings::FloatingPointUnit as FpuState, mshv_bindings::LapicState,
     mshv_bindings::MiscRegs as MiscRegisters, mshv_bindings::MsrList,
     mshv_bindings::Msrs as MsrEntries, mshv_bindings::Msrs, mshv_bindings::SegmentRegister,

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -23,7 +23,7 @@ use crate::x86_64::CpuId;
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
 use crate::ClockData;
 use crate::CreateDevice;
-use crate::{IoEventAddress, IrqRoutingEntry, MemoryRegion};
+use crate::{IoEventAddress, IrqRoutingEntry, UserMemoryRegion};
 #[cfg(feature = "kvm")]
 use kvm_ioctls::Cap;
 #[cfg(target_arch = "x86_64")]
@@ -309,13 +309,12 @@ pub trait Vm: Send + Sync {
         guest_phys_addr: u64,
         memory_size: u64,
         userspace_addr: u64,
-        readonly: bool,
-        log_dirty_pages: bool,
-    ) -> MemoryRegion;
+        flags: u32,
+    ) -> UserMemoryRegion;
     /// Creates a guest physical memory slot.
-    fn create_user_memory_region(&self, user_memory_region: MemoryRegion) -> Result<()>;
+    fn create_user_memory_region(&self, user_memory_region: UserMemoryRegion) -> Result<()>;
     /// Removes a guest physical memory slot.
-    fn remove_user_memory_region(&self, user_memory_region: MemoryRegion) -> Result<()>;
+    fn remove_user_memory_region(&self, user_memory_region: UserMemoryRegion) -> Result<()>;
     /// Creates an emulated device in the kernel.
     fn create_device(&self, device: &mut CreateDevice) -> Result<Arc<dyn Device>>;
     /// Returns the preferred CPU target type which can be emulated by KVM on underlying host.

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1236,8 +1236,9 @@ impl VfioPciDevice {
                         user_memory_region.start,
                         user_memory_region.size,
                         user_memory_region.host_addr,
-                        false,
-                        false,
+                        hypervisor::user_memory_region_flags::READ
+                            | hypervisor::user_memory_region_flags::WRITE
+                            | hypervisor::user_memory_region_flags::EXECUTE,
                     );
 
                     vm.create_user_memory_region(mem_region)
@@ -1258,8 +1259,9 @@ impl VfioPciDevice {
                     user_memory_region.start,
                     user_memory_region.size,
                     user_memory_region.host_addr,
-                    false,
-                    false,
+                    hypervisor::user_memory_region_flags::READ
+                        | hypervisor::user_memory_region_flags::WRITE
+                        | hypervisor::user_memory_region_flags::EXECUTE,
                 );
 
                 if let Err(e) = self.vm.remove_user_memory_region(r) {
@@ -1421,8 +1423,9 @@ impl PciDevice for VfioPciDevice {
                         user_memory_region.start,
                         user_memory_region.size,
                         user_memory_region.host_addr,
-                        false,
-                        false,
+                        hypervisor::user_memory_region_flags::READ
+                            | hypervisor::user_memory_region_flags::WRITE
+                            | hypervisor::user_memory_region_flags::EXECUTE,
                     );
 
                     self.vm
@@ -1442,8 +1445,9 @@ impl PciDevice for VfioPciDevice {
                         user_memory_region.start,
                         user_memory_region.size,
                         user_memory_region.host_addr,
-                        false,
-                        false,
+                        hypervisor::user_memory_region_flags::READ
+                            | hypervisor::user_memory_region_flags::WRITE
+                            | hypervisor::user_memory_region_flags::EXECUTE,
                     );
 
                     self.vm

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -208,8 +208,9 @@ impl VfioUserPciDevice {
                         user_memory_region.start,
                         user_memory_region.size,
                         user_memory_region.host_addr,
-                        false,
-                        false,
+                        hypervisor::user_memory_region_flags::READ
+                            | hypervisor::user_memory_region_flags::WRITE
+                            | hypervisor::user_memory_region_flags::EXECUTE,
                     );
 
                     vm.create_user_memory_region(mem_region)
@@ -230,8 +231,9 @@ impl VfioUserPciDevice {
                     user_memory_region.start,
                     user_memory_region.size,
                     user_memory_region.host_addr,
-                    false,
-                    false,
+                    hypervisor::user_memory_region_flags::READ
+                        | hypervisor::user_memory_region_flags::WRITE
+                        | hypervisor::user_memory_region_flags::EXECUTE,
                 );
 
                 if let Err(e) = self.vm.remove_user_memory_region(r) {
@@ -484,8 +486,9 @@ impl PciDevice for VfioUserPciDevice {
                         user_memory_region.start,
                         user_memory_region.size,
                         user_memory_region.host_addr,
-                        false,
-                        false,
+                        hypervisor::user_memory_region_flags::READ
+                            | hypervisor::user_memory_region_flags::WRITE
+                            | hypervisor::user_memory_region_flags::EXECUTE,
                     );
 
                     self.vm
@@ -505,8 +508,9 @@ impl PciDevice for VfioUserPciDevice {
                         user_memory_region.start,
                         user_memory_region.size,
                         user_memory_region.host_addr,
-                        false,
-                        false,
+                        hypervisor::user_memory_region_flags::READ
+                            | hypervisor::user_memory_region_flags::WRITE
+                            | hypervisor::user_memory_region_flags::EXECUTE,
                     );
 
                     self.vm

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -726,8 +726,9 @@ impl DeviceRelocation for AddressManager {
                             old_base,
                             shm_regions.len,
                             shm_regions.host_addr,
-                            false,
-                            false,
+                            hypervisor::user_memory_region_flags::READ
+                                | hypervisor::user_memory_region_flags::WRITE
+                                | hypervisor::user_memory_region_flags::EXECUTE,
                         );
 
                         self.vm.remove_user_memory_region(mem_region).map_err(|e| {
@@ -743,8 +744,9 @@ impl DeviceRelocation for AddressManager {
                             new_base,
                             shm_regions.len,
                             shm_regions.host_addr,
-                            false,
-                            false,
+                            hypervisor::user_memory_region_flags::READ
+                                | hypervisor::user_memory_region_flags::WRITE
+                                | hypervisor::user_memory_region_flags::EXECUTE,
                         );
 
                         self.vm.create_user_memory_region(mem_region).map_err(|e| {
@@ -1645,8 +1647,9 @@ impl DeviceManager {
                 uefi_region.start_addr().raw_value(),
                 uefi_region.len() as u64,
                 uefi_region.as_ptr() as u64,
-                false,
-                false,
+                hypervisor::user_memory_region_flags::READ
+                    | hypervisor::user_memory_region_flags::WRITE
+                    | hypervisor::user_memory_region_flags::EXECUTE,
             );
         self.memory_manager
             .lock()

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1480,8 +1480,18 @@ impl MemoryManager {
             guest_phys_addr,
             memory_size,
             userspace_addr,
-            readonly,
-            log_dirty,
+            hypervisor::user_memory_region_flags::READ
+                | if readonly {
+                    0
+                } else {
+                    hypervisor::user_memory_region_flags::WRITE
+                        | hypervisor::user_memory_region_flags::EXECUTE
+                }
+                | if log_dirty {
+                    hypervisor::user_memory_region_flags::LOG_DIRTY_PAGES
+                } else {
+                    0
+                },
         );
 
         info!(
@@ -1539,8 +1549,9 @@ impl MemoryManager {
             guest_phys_addr,
             memory_size,
             userspace_addr,
-            false, /* readonly -- don't care */
-            false, /* log dirty */
+            hypervisor::user_memory_region_flags::READ
+                | hypervisor::user_memory_region_flags::WRITE
+                | hypervisor::user_memory_region_flags::EXECUTE,
         );
 
         self.vm

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3429,8 +3429,9 @@ pub fn test_vm() {
             region.start_addr().raw_value(),
             region.len() as u64,
             region.as_ptr() as u64,
-            false,
-            false,
+            hypervisor::user_memory_region_flags::READ
+                | hypervisor::user_memory_region_flags::WRITE
+                | hypervisor::user_memory_region_flags::EXECUTE,
         );
 
         vm.create_user_memory_region(mem_region)


### PR DESCRIPTION
This PR contains initial work for #4079, by abstracting the MemoryRegion structure.

- Add a generic MemoryRegion structure in hypervisor
- Implement From trait to convert between MemoryRegion and kvm_userspace_memory_region or mshv_user_mem_region
- Change function definitions and prototype for functions which use this structure