### PR TITLE
[RFC] vTPM support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "1.0.31"
 vmm = { path = "vmm" }
 vmm-sys-util = "0.9.0"
 vm-memory = "0.8.0"
+vtpm = { path = "vtpm" }
 
 [build-dependencies]
 clap = { version = "3.1.18", features = ["cargo"] }
@@ -88,5 +89,6 @@ members = [
     "vm-allocator",
     "vm-device",
     "vm-migration",
-    "vm-virtio"
+    "vm-virtio",
+    "vtpm"
 ]

--- a/vtpm/Cargo.toml
+++ b/vtpm/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vtpm"
+version = "0.1.0"
+edition = "2018"
+
+
+[dependencies]
+log = "0.4.14"
+nix = "0.22.0"
+byteorder = "1.4.3"
+libc = "0.2.98"
+thiserror = "1.0.30"
+anyhow = "1.0.56"
+#filedescriptor = "0.8.0"

--- a/vtpm/src/char.rs
+++ b/vtpm/src/char.rs
@@ -1,23 +1,42 @@
-use std::sync::{Arc, Mutex};
-use std::cmp;
-use std::io;
-use std::io::{BufRead, BufReader};
-use std::os::unix::net::{UnixStream,UnixListener};
-use std::thread;
-use std::time::{Duration, Instant};
-use std::thread::sleep;
-use std::str;
+// Copyright © 2022, Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+//
+
+use anyhow::anyhow;
+use nix::sys::socket::{recv, recvfrom, sendmsg, ControlMessage, MsgFlags};
+use nix::sys::uio::IoVec;
 use std::io::prelude::*;
 use std::io::Write;
-use std::os::unix::io::{RawFd, AsRawFd};
-use nix::unistd::{read, write};
-use nix::sys::socket::{socketpair, AddressFamily, SockType, SockFlag, recv, sendmsg, recvfrom, ControlMessage, MsgFlags };
-use nix::sys::uio::IoVec;
-use libc;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::str;
+//use std::sync::{Arc, Mutex};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+use thiserror::Error;
 
 const TPM_TIS_BUFFER_MAX: usize = 4096;
 
-type Result<T> = std::result::Result<T, Error>;
+#[derive(Error, Debug)]
+pub enum TPMCharError {
+    #[error("Cannot connect to TPM Socket even after retrying for 1 min")]
+    TPMCharCannotConnect(#[source] anyhow::Error),
+    #[error("Failed to read from TPM socket")]
+    TPMCharFailedRead(#[source] anyhow::Error),
+    #[error("Failed to write to TPM socket")]
+    TPMCharFailedWrite(#[source] anyhow::Error),
+    #[error("Failed to configure TPM Char backend")]
+    CharBackendConfigureFailed(#[source] anyhow::Error)
+}
+type Result<T> = anyhow::Result<T, TPMCharError>;
+
+#[derive(PartialEq)]
+enum ChardevState {
+    ChardevStateDisconnected,
+    ChardevStateConnecting,
+    ChardevStateConnected,
+}
 
 /// Copy data in `from` into `to`, until the shortest
 /// of the two slices.
@@ -27,22 +46,16 @@ fn byte_copy(from: &[u8], mut to: &mut [u8]) -> usize {
     to.write(from).unwrap()
 }
 
-#[derive(PartialEq)]
-enum ChardevState {
-    ChardevStateDisconnected,
-    ChardevStateConnecting,
-    ChardevStateConnected,
-}
-
 pub struct SocketCharDev {
     state: ChardevState,
     stream: Option<UnixStream>,
+    /// Fd sent to swtpm process for Data
     write_msgfd: RawFd,
-    /* Control Channel */
+    /// Control Channel
     ctrl_fd: RawFd,
-    /* Command Channel */
-    data_ioc: RawFd,
-    chr_write_lock: Arc<Mutex<usize>>,
+    /// Data Channel
+    data_fd: RawFd,
+   // chr_write_lock: Arc<Mutex<usize>>,
 }
 
 impl SocketCharDev {
@@ -52,138 +65,124 @@ impl SocketCharDev {
             stream: None,
             write_msgfd: -1,
             ctrl_fd: -1,
-            data_ioc: -1,
-            chr_write_lock: Arc::new(Mutex::new(0))
+            data_fd: -1,
+            //chr_write_lock: Arc::new(Mutex::new(0)),
         }
     }
 
-    pub fn debugmessage(&mut self) {
-        {
-            let mut buf = (44 as u32).to_be_bytes();
-            let iov = &[IoVec::from_slice(&buf)];
-            let res = sendmsg(self.ctrl_fd, iov, &[ControlMessage::ScmRights(&[])], MsgFlags::empty(), None).expect("Error sending");
-            let mut buf2: &mut [u8] = &mut [1 as u8; 4];
-            println!("before: {:?}", buf2);
-            let (n, s) = recvfrom(self.ctrl_fd, buf2).expect("Hello");
-        }
-    }
-
-    pub fn connect(&mut self, socket_path: &str) -> isize {
+    pub fn connect(&mut self, socket_path: &str) -> Result<isize> {
         self.state = ChardevState::ChardevStateConnecting;
 
         let now = Instant::now();
 
         // Retry connecting for a full minute
-        let err = loop {
-            let err = match UnixStream::connect(socket_path) {
+        loop {
+            match UnixStream::connect(socket_path) {
                 Ok(s) => {
                     let fd = s.as_raw_fd();
                     self.ctrl_fd = fd;
                     self.stream = Some(s);
                     self.state = ChardevState::ChardevStateConnected;
-             warn!("PPK: Connected to socket path : {:?}\n", socket_path);
-
-                    return 0
+                    debug!("Connected to vTPM socket path : {:?}\n", socket_path);
+                    return Ok(0);
                 }
-                Err(e) => e,
+                Err(_e) => {}
             };
             sleep(Duration::from_millis(100));
 
             if now.elapsed().as_secs() >= 60 {
-                break err;
+                break;
             }
-        };
-        
-        // error!(
-        //     "Failed connecting the backend after trying for 1 minute: {:?}",
-        //     err
-        // );
-        -1
+        }
+        Err(TPMCharError::TPMCharCannotConnect(anyhow!(
+            "Failed to connect to vTPM socket path"
+        )))
     }
 
-    pub fn set_dataioc(&mut self, fd: RawFd) {
-        self.data_ioc = fd;
+    pub fn set_datafd(&mut self, fd: RawFd) {
+        self.data_fd = fd;
     }
 
-    pub fn set_msgfd(&mut self, fd: RawFd){
+    pub fn set_msgfd(&mut self, fd: RawFd) {
         self.write_msgfd = fd;
     }
 
-    pub fn chr_sync_read(&self, buf: &mut [u8], len: usize) -> isize {
+    pub fn chr_sync_read(&self, buf: &mut [u8], _len: usize) -> Result<usize> {
         if self.state != ChardevState::ChardevStateConnected {
-            return 0
+            return Ok(0);
         }
-        //SET BLOCKING
-        warn!("sync read state connected");
-        let size = recv(self.ctrl_fd, buf, MsgFlags::empty()).expect("char.rs: sync_read recvmsg error");
-        warn!("success recv");
-        size as isize
+        debug!("synchronous read from vTPM Socket");
+        let size = recv(self.ctrl_fd, buf, MsgFlags::empty()).map_err(|e| {
+            TPMCharError::TPMCharFailedRead(anyhow!(
+                "Failed to read from vTPM socket. Error Code {:?}",
+                e
+            ))
+        })?;
+        debug!("sync read completed");
+        Ok(size as usize)
     }
 
-    pub fn send_full(&self, buf: &mut [u8], len: usize) -> isize {
+    pub fn send_full(&self, buf: &mut [u8], _len: usize) -> Result<usize> {
         let iov = &[IoVec::from_slice(buf)];
         let write_fd = self.write_msgfd;
         let write_vec = &[write_fd];
         let cmsgs = &[ControlMessage::ScmRights(write_vec)];
-        warn!("send full message");
+        debug!("send full message");
 
-        sendmsg(self.ctrl_fd, iov, cmsgs, MsgFlags::empty(), None).expect("char.rs: ERROR ON send_full sendmsg") as isize
+        // Send Ancillary data, along with cmds and data
+        let size = sendmsg(self.ctrl_fd, iov, cmsgs, MsgFlags::empty(), None).map_err(|e| {
+            TPMCharError::TPMCharFailedWrite(anyhow!(
+                "Failed to write to vTPM Socket. Error Code {:?}",
+                e
+            ))
+        })?;
+        Ok(size as usize)
     }
 
-    pub fn chr_write(&mut self, buf: &mut [u8], len:usize) -> isize {
-        let mut res = 0;
-        warn!("CHR_WRITE HAPPENED");
+    pub fn chr_write(&mut self, buf: &mut [u8], len:usize) -> Result<usize> {
+        debug!("chr_write initialized");
 
-        if let Some(ref mut sock) = self.stream {
-            // let guard = self.chr_write_lock.lock().unwrap();
-            {
-                res = match self.state {
+        if let Some(ref mut _sock) = self.stream {
+               let res = match self.state {
                     ChardevState::ChardevStateConnected => {
                         warn!("State Connected");
-                        let ret = self.send_full(buf, len);
-                        /* free the written msgfds in any cases
-                        * other than ret < 0 */
-                        if ret >= 0 {
-                            self.write_msgfd = 0;
-                        }
-
-                        // if (ret < 0 && errno != EAGAIN) {
-                        //     if (tcp_chr_read_poll(chr) <= 0) {
-                        //         /* Perform disconnect and return error. */
-                        //         tcp_chr_disconnect_locked(chr);
-                        //     } /* else let the read handler finish it properly */
-                        // }
-
+                        let ret = self.send_full(buf, len)?;
+                        // swtpm will receive data Fd after a successful send
+                        // reset write_msgfd after a successful send
+                        self.write_msgfd = 0;
                         ret
-                    }
-                    _ => -1,
-                };
-            }
-            warn!("WRITE SUCCESS");
-            // std::mem::drop(guard);
+                    },
+                    _ => return Err(TPMCharError::TPMCharFailedWrite(anyhow!(
+                        "TPM Socket was not in Connected State"))),
+            };
+            debug!("chr_write succeeded");
 
-            res
+            Ok(res)
         } else {
-            -1
+            return Err(TPMCharError::TPMCharFailedWrite(anyhow!("Stream for TPM Socket was not initialized")))
         }
     }
 
-    pub fn chr_read(&mut self, buf: &mut [u8], len: usize) -> isize {
+    pub fn chr_read(&mut self, buf: &mut [u8], _len: usize) -> Result<usize> {
         //Grab all response bytes so none is left behind
-        warn!("CHR_READ HAPPENED");
+        debug!("chr_read initialized");
 
         let mut newbuf: &mut [u8] = &mut [0; TPM_TIS_BUFFER_MAX];
-        
+
         if let Some(ref mut sock) = self.stream {
-            sock.read(&mut newbuf);
+            let size:usize = sock.read(&mut newbuf).map_err(|e| TPMCharError::TPMCharFailedRead(anyhow!(
+                "Failed to read from vTPM Socket. Error Code {:?}",
+                e
+            )))?;
             byte_copy(&newbuf, buf);
-            0
+            Ok(size)
         } else {
-            -1
+            return Err(TPMCharError::TPMCharFailedRead(anyhow!("Stream for TPM Socket was not initialized")))
         }
     }
 }
-
+/// This is the backend seen by frontend
+/// Actual Backend is SocketCharDev
 pub struct CharBackend {
     pub chr: Option<SocketCharDev>,
     fe_open: bool,
@@ -197,39 +196,35 @@ impl CharBackend {
         }
     }
 
-    pub fn chr_fe_init(&mut self) -> isize {
+    pub fn chr_be_init(&mut self, path: String) -> Result<()> {
         let mut sockdev = SocketCharDev::new();
-        warn!("PPK: chr_fe_init invoked\n");
-        let res = sockdev.connect("/tmp/swtpm/swtpm-sock");
+        let _ = sockdev.connect(&path)?;
+
         self.chr = Some(sockdev);
-        if res < 0 {
-            return -1
-        }
-        
         self.fe_open = true;
-        0
+        Ok(())
     }
 
-    pub fn chr_fe_set_msgfd(&mut self, fd: RawFd) -> isize {
+    pub fn chr_be_set_msgfd(&mut self, fd: RawFd) -> Result<()> {
         if let Some(ref mut dev) = self.chr {
             dev.set_msgfd(fd);
-            0
+            Ok(())
         } else {
-            -1
+            return Err(TPMCharError::CharBackendConfigureFailed(anyhow!("SocketCharDev was not initialized")))
         }
     }
 
-    pub fn chr_fe_set_dataioc(&mut self, fd: RawFd) -> isize {
+    pub fn chr_be_set_datafd(&mut self, fd: RawFd) -> Result<isize> {
         if let Some(ref mut dev) = self.chr {
-            dev.set_dataioc(fd);
-            0
+            dev.set_datafd(fd);
+            Ok(0)
         } else {
-            -1
+            return Err(TPMCharError::CharBackendConfigureFailed(anyhow!("SocketCharDev was not initialized")))
         }
     }
 
     /**
-     * qemu_chr_fe_write_all:
+     * chr_be_write_all:
      * @buf: the data
      * @len: the number of bytes to send
      *
@@ -240,17 +235,16 @@ impl CharBackend {
      *
      * Returns: the number of bytes consumed (0 if no associated Chardev)
      */
-    pub fn chr_fe_write_all(&mut self, buf: &mut [u8], len: usize) -> isize {
+    pub fn chr_be_write_all(&mut self, buf: &mut [u8], len: usize) -> Result<usize> {
         if let Some(ref mut dev) = self.chr {
             dev.chr_write(buf, len)
         } else {
-            -1
+            return Err(TPMCharError::CharBackendConfigureFailed(anyhow!("SocketCharDev was not initialized")))
         }
     }
 
-
     /**
-     * chr_fe_read_all:
+     * chr_be_read_all:
      * @buf: the data buffer
      * @len: the number of bytes to read
      *
@@ -258,20 +252,16 @@ impl CharBackend {
      *
      * Returns: the number of bytes read (0 if no associated Chardev)
      */
-    pub fn chr_fe_read_all(&mut self, mut buf: &mut [u8], len: usize) -> isize {
+    pub fn chr_be_read_all(&mut self, mut buf: &mut [u8]) -> Result<usize> {
         if let Some(ref mut dev) = self.chr {
-            warn!("Made it to sync");
-            let (s,_) = recvfrom(dev.ctrl_fd, &mut buf).expect("char.rs: sync_read recvmsg error");
-            s as isize
-            // dev.chr_sync_read(&mut buf, len)
+            let (s, _) = recvfrom(dev.ctrl_fd, &mut buf).map_err(|e| TPMCharError::TPMCharFailedRead(anyhow!(
+                "Failed to read from vTPM Socket. Error Code {:?}",
+                e
+            )))?;
+            //expect("char.rs: sync_read recvmsg error");
+            Ok(s)
         } else {
-            -1
+            return Err(TPMCharError::CharBackendConfigureFailed(anyhow!("SocketCharDev was not initialized")))
         }
     }
-
-
-}
-
-pub enum Error {
-    BindSocket()
 }

--- a/vtpm/src/char.rs
+++ b/vtpm/src/char.rs
@@ -1,0 +1,277 @@
+use std::sync::{Arc, Mutex};
+use std::cmp;
+use std::io;
+use std::io::{BufRead, BufReader};
+use std::os::unix::net::{UnixStream,UnixListener};
+use std::thread;
+use std::time::{Duration, Instant};
+use std::thread::sleep;
+use std::str;
+use std::io::prelude::*;
+use std::io::Write;
+use std::os::unix::io::{RawFd, AsRawFd};
+use nix::unistd::{read, write};
+use nix::sys::socket::{socketpair, AddressFamily, SockType, SockFlag, recv, sendmsg, recvfrom, ControlMessage, MsgFlags };
+use nix::sys::uio::IoVec;
+use libc;
+
+const TPM_TIS_BUFFER_MAX: usize = 4096;
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// Copy data in `from` into `to`, until the shortest
+/// of the two slices.
+///
+/// Return the number of bytes written.
+fn byte_copy(from: &[u8], mut to: &mut [u8]) -> usize {
+    to.write(from).unwrap()
+}
+
+#[derive(PartialEq)]
+enum ChardevState {
+    ChardevStateDisconnected,
+    ChardevStateConnecting,
+    ChardevStateConnected,
+}
+
+pub struct SocketCharDev {
+    state: ChardevState,
+    stream: Option<UnixStream>,
+    write_msgfd: RawFd,
+    /* Control Channel */
+    ctrl_fd: RawFd,
+    /* Command Channel */
+    data_ioc: RawFd,
+    chr_write_lock: Arc<Mutex<usize>>,
+}
+
+impl SocketCharDev {
+    pub fn new() -> Self {
+        Self {
+            state: ChardevState::ChardevStateDisconnected,
+            stream: None,
+            write_msgfd: -1,
+            ctrl_fd: -1,
+            data_ioc: -1,
+            chr_write_lock: Arc::new(Mutex::new(0))
+        }
+    }
+
+    pub fn debugmessage(&mut self) {
+        {
+            let mut buf = (44 as u32).to_be_bytes();
+            let iov = &[IoVec::from_slice(&buf)];
+            let res = sendmsg(self.ctrl_fd, iov, &[ControlMessage::ScmRights(&[])], MsgFlags::empty(), None).expect("Error sending");
+            let mut buf2: &mut [u8] = &mut [1 as u8; 4];
+            println!("before: {:?}", buf2);
+            let (n, s) = recvfrom(self.ctrl_fd, buf2).expect("Hello");
+        }
+    }
+
+    pub fn connect(&mut self, socket_path: &str) -> isize {
+        self.state = ChardevState::ChardevStateConnecting;
+
+        let now = Instant::now();
+
+        // Retry connecting for a full minute
+        let err = loop {
+            let err = match UnixStream::connect(socket_path) {
+                Ok(s) => {
+                    let fd = s.as_raw_fd();
+                    self.ctrl_fd = fd;
+                    self.stream = Some(s);
+                    self.state = ChardevState::ChardevStateConnected;
+             warn!("PPK: Connected to socket path : {:?}\n", socket_path);
+
+                    return 0
+                }
+                Err(e) => e,
+            };
+            sleep(Duration::from_millis(100));
+
+            if now.elapsed().as_secs() >= 60 {
+                break err;
+            }
+        };
+        
+        // error!(
+        //     "Failed connecting the backend after trying for 1 minute: {:?}",
+        //     err
+        // );
+        -1
+    }
+
+    pub fn set_dataioc(&mut self, fd: RawFd) {
+        self.data_ioc = fd;
+    }
+
+    pub fn set_msgfd(&mut self, fd: RawFd){
+        self.write_msgfd = fd;
+    }
+
+    pub fn chr_sync_read(&self, buf: &mut [u8], len: usize) -> isize {
+        if self.state != ChardevState::ChardevStateConnected {
+            return 0
+        }
+        //SET BLOCKING
+        warn!("sync read state connected");
+        let size = recv(self.ctrl_fd, buf, MsgFlags::empty()).expect("char.rs: sync_read recvmsg error");
+        warn!("success recv");
+        size as isize
+    }
+
+    pub fn send_full(&self, buf: &mut [u8], len: usize) -> isize {
+        let iov = &[IoVec::from_slice(buf)];
+        let write_fd = self.write_msgfd;
+        let write_vec = &[write_fd];
+        let cmsgs = &[ControlMessage::ScmRights(write_vec)];
+        warn!("send full message");
+
+        sendmsg(self.ctrl_fd, iov, cmsgs, MsgFlags::empty(), None).expect("char.rs: ERROR ON send_full sendmsg") as isize
+    }
+
+    pub fn chr_write(&mut self, buf: &mut [u8], len:usize) -> isize {
+        let mut res = 0;
+        warn!("CHR_WRITE HAPPENED");
+
+        if let Some(ref mut sock) = self.stream {
+            // let guard = self.chr_write_lock.lock().unwrap();
+            {
+                res = match self.state {
+                    ChardevState::ChardevStateConnected => {
+                        warn!("State Connected");
+                        let ret = self.send_full(buf, len);
+                        /* free the written msgfds in any cases
+                        * other than ret < 0 */
+                        if ret >= 0 {
+                            self.write_msgfd = 0;
+                        }
+
+                        // if (ret < 0 && errno != EAGAIN) {
+                        //     if (tcp_chr_read_poll(chr) <= 0) {
+                        //         /* Perform disconnect and return error. */
+                        //         tcp_chr_disconnect_locked(chr);
+                        //     } /* else let the read handler finish it properly */
+                        // }
+
+                        ret
+                    }
+                    _ => -1,
+                };
+            }
+            warn!("WRITE SUCCESS");
+            // std::mem::drop(guard);
+
+            res
+        } else {
+            -1
+        }
+    }
+
+    pub fn chr_read(&mut self, buf: &mut [u8], len: usize) -> isize {
+        //Grab all response bytes so none is left behind
+        warn!("CHR_READ HAPPENED");
+
+        let mut newbuf: &mut [u8] = &mut [0; TPM_TIS_BUFFER_MAX];
+        
+        if let Some(ref mut sock) = self.stream {
+            sock.read(&mut newbuf);
+            byte_copy(&newbuf, buf);
+            0
+        } else {
+            -1
+        }
+    }
+}
+
+pub struct CharBackend {
+    pub chr: Option<SocketCharDev>,
+    fe_open: bool,
+}
+
+impl CharBackend {
+    pub fn new() -> Self {
+        Self {
+            chr: None,
+            fe_open: false,
+        }
+    }
+
+    pub fn chr_fe_init(&mut self) -> isize {
+        let mut sockdev = SocketCharDev::new();
+        warn!("PPK: chr_fe_init invoked\n");
+        let res = sockdev.connect("/tmp/swtpm/swtpm-sock");
+        self.chr = Some(sockdev);
+        if res < 0 {
+            return -1
+        }
+        
+        self.fe_open = true;
+        0
+    }
+
+    pub fn chr_fe_set_msgfd(&mut self, fd: RawFd) -> isize {
+        if let Some(ref mut dev) = self.chr {
+            dev.set_msgfd(fd);
+            0
+        } else {
+            -1
+        }
+    }
+
+    pub fn chr_fe_set_dataioc(&mut self, fd: RawFd) -> isize {
+        if let Some(ref mut dev) = self.chr {
+            dev.set_dataioc(fd);
+            0
+        } else {
+            -1
+        }
+    }
+
+    /**
+     * qemu_chr_fe_write_all:
+     * @buf: the data
+     * @len: the number of bytes to send
+     *
+     * Write data to a character backend from the front end.  This function will
+     * send data from the front end to the back end.  Unlike @chr_fe_write,
+     * this function will block if the back end cannot consume all of the data
+     * attempted to be written.  This function is thread-safe.
+     *
+     * Returns: the number of bytes consumed (0 if no associated Chardev)
+     */
+    pub fn chr_fe_write_all(&mut self, buf: &mut [u8], len: usize) -> isize {
+        if let Some(ref mut dev) = self.chr {
+            dev.chr_write(buf, len)
+        } else {
+            -1
+        }
+    }
+
+
+    /**
+     * chr_fe_read_all:
+     * @buf: the data buffer
+     * @len: the number of bytes to read
+     *
+     * Read data to a buffer from the back end.
+     *
+     * Returns: the number of bytes read (0 if no associated Chardev)
+     */
+    pub fn chr_fe_read_all(&mut self, mut buf: &mut [u8], len: usize) -> isize {
+        if let Some(ref mut dev) = self.chr {
+            warn!("Made it to sync");
+            let (s,_) = recvfrom(dev.ctrl_fd, &mut buf).expect("char.rs: sync_read recvmsg error");
+            s as isize
+            // dev.chr_sync_read(&mut buf, len)
+        } else {
+            -1
+        }
+    }
+
+
+}
+
+pub enum Error {
+    BindSocket()
+}

--- a/vtpm/src/lib.rs
+++ b/vtpm/src/lib.rs
@@ -1,0 +1,6 @@
+#[macro_use]
+extern crate log;
+
+//pub mod tpm_backend;
+pub mod char;
+//pub mod tpm_ioctl;


### PR DESCRIPTION
Team,

I created this "RFC" PR to get some early feedback on how the code is organized. The working code is at https://github.com/praveen-pk/cloud-hypervisor/tree/vtpm. This version does not have any Error Handling. I am working on adding Error Handling and stripping out unused code.

The final code will be organized as follows:

***vtpm/src/char.rs***     : **CharBackend** for talking to socket device created by swtpm process. I stripped out some unused code and added some Error Handling in this version.

***vtpm/src/tpm_ioctl.rs***:  TPM command/data formatting is handled in this module

***vtpm/src/tpm_backend.rs***: This is the vTPM Backend used by vTPM device defined in devices/src/tpm_tis.rs

***devices/src/tpm_tis.rs***: vTPM device in cloud-hypervisor

# Run
With the current implementation swtpm will be used as the backend for vTPM. To use vTPM an user will start swtpm process with a command like below:
```
mkdir -p /tmp/swtpm
sock_path='/tmp/swtpm/swtpm-sock'
/usr/bin/swtpm \
 socket --tpmstate dir=/tmp/swtpm \
 --ctrl type=unixio,path=${sock_path} \
 --tpm2 \
 --flags not-need-init,startup-clear
```
After starting the swtpm process, user will start cloud-hypervisor with below options:

```
IMAGE="guest-image.raw"
FW="CLOUDHV_EFI.fd"  # OVMF Firmware

cloud-hypervisor \
 --cpus boot=4 \
 --kernel ${FW} \
  --disk path=${IMAGE} \
  --memory size=3096M \
  --net "tap=vmtap0,mac=2e:de:7a:2e:5d:e0,ip=192.168.249.1,mask=255.255.255.0" \
  --serial tty \
 --vtpm type=emulator,model=tis,path=/tmp/swtpm/swtpm-sock \   # Socket path from swtpm process
  --console off

```
This implementation uses Domain Socket for communication between swtpm and cloud-hypervisor. swtpm also supports TCP/IP and CUSE (character device in userspace). Reference doc: https://github.com/stefanberger/swtpm/blob/master/man/man8/swtpm.pod.

The protocol and byte ordering details for communication over swtpm socket are captured at https://www.trustedcomputinggroup.org/wp-content/uploads/PCClientPlatform-TPM-Profile-for-TPM-2-0-v1-03-20-161114_public-review.pdf.

One more protocol level detail to note. During startup cloud-hypervisor will send some Control Commands over Domain Socket, this includes initializing the vTPM and setting up a DataFD (SetDataFD). DataFD is a socketpair that is opened in cloud-hypervisor. One end of the socket pair it sent to swtpm over the Domain Socket. Cloud-hypervisor will retain the other side. This socket pair will be used for sending commands and data to swtpm. The above mentioned domain socket will be used for control commands only.


## Arguments:

Following will be the arguments for vTPM device
```
--vtpm type={emulator,passthrough},model={tis,crb},path={file_path}
```

***type*** : emulator/passthrough are possible values. **Emulator** option to be used when swtpm is used as the backend to emulate vTPM.  **Passthrough** option should be used when lpassing through TPM device from host (/dev/tpm0) to guest.

***model***:  tis/crb are possible values. TIS and CRB are different specifications for TPM devices. Reference docs https://qemu.readthedocs.io/en/latest/specs/tpm.html, https://cateee.net/lkddb/web-lkddb/TCG_TIS.html, https://cateee.net/lkddb/web-lkddb/TCG_CRB.html. Current implementation only suppport TIS spec, so we can drop this option and hardcode it for now.

***path***: The Unix Socket or the CUSE device path.

vTPM device will be activated only if cloud-hypervisor invocation receives **--vtpm** args.


Please let me know if you have any early feedback regarding the structure of this vTPM Crate.
