### PR TITLE
Jenkinsfile: Bypass running CI for fuzzer Cargo file changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,19 @@ pipeline{
 						}
 					}
 				}
+				stage ('Check for fuzzer cargo files only changes') {
+					when {
+						expression {
+							return fuzzCargoFileOnly()
+						}
+					}
+					steps {
+						script {
+							runWorkers = false
+							echo "Fuzzer cargo files only changes, no need to run the CI"
+						}
+					}
+				}
 				stage ('Check for RFC/WIP builds') {
 					when {
   						changeRequest comparator: 'REGEXP', title: '.*(rfc|RFC|wip|WIP).*'
@@ -285,5 +298,16 @@ def boolean docsFileOnly() {
     return sh(
         returnStatus: true,
         script: "git diff --name-only origin/${env.CHANGE_TARGET}... | grep -v '\\.md'"
+    ) != 0
+}
+
+def boolean fuzzCargoFileOnly() {
+    if (env.CHANGE_TARGET == null) {
+        return false;
+    }
+
+    return sh(
+        returnStatus: true,
+        script: "git diff --name-only origin/${env.CHANGE_TARGET}... | grep -v -E 'fuzz\/Cargo.(toml|lock)'"
     ) != 0
 }


### PR DESCRIPTION
In order to conserve resources it is better to not run CI, whenever there
are changes only in fuzz/Cargo.toml or fuzz/Cargo.lock.

Fixes #4148

Signed-off-by: Jinank Jain <jinankjain@microsoft.com>