### PR TITLE
Revert "Jenkinsfile: Bypass running CI for fuzzer Cargo file changes"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,19 +23,6 @@ pipeline{
 						}
 					}
 				}
-				stage ('Check for fuzzer cargo files only changes') {
-					when {
-						expression {
-							return fuzzCargoFileOnly()
-						}
-					}
-					steps {
-						script {
-							runWorkers = false
-							echo "Fuzzer cargo files only changes, no need to run the CI"
-						}
-					}
-				}
 				stage ('Check for RFC/WIP builds') {
 					when {
   						changeRequest comparator: 'REGEXP', title: '.*(rfc|RFC|wip|WIP).*'
@@ -298,16 +285,5 @@ def boolean docsFileOnly() {
     return sh(
         returnStatus: true,
         script: "git diff --name-only origin/${env.CHANGE_TARGET}... | grep -v '\\.md'"
-    ) != 0
-}
-
-def boolean fuzzCargoFileOnly() {
-    if (env.CHANGE_TARGET == null) {
-        return false;
-    }
-
-    return sh(
-        returnStatus: true,
-        script: "git diff --name-only origin/${env.CHANGE_TARGET}... | grep -v -E 'fuzz\/Cargo.(toml|lock)'"
     ) != 0
 }


### PR DESCRIPTION
This reverts commit 86d243938e878abe134bf174f32a7816bb5ccef0.

Build error:

Obtained Jenkinsfile from 86d243938e878abe134bf174f32a7816bb5ccef0
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 311: unexpected char: '\' @ line 311, column 88.
   _TARGET}... | grep -v -E 'fuzz\/Cargo.(t

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
