### PR TITLE
Reapply "Jenkinsfile: Bypass running CI for fuzzer Cargo file changes"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,19 @@ pipeline{
 						}
 					}
 				}
+				stage ('Check for fuzzer cargo files only changes') {
+					when {
+						expression {
+							return fuzzCargoFileOnly()
+						}
+					}
+					steps {
+						script {
+							runWorkers = false
+							echo "Fuzzer cargo files only changes, no need to run the CI"
+						}
+					}
+				}
 				stage ('Check for RFC/WIP builds') {
 					when {
   						changeRequest comparator: 'REGEXP', title: '.*(rfc|RFC|wip|WIP).*'
@@ -285,5 +298,16 @@ def boolean docsFileOnly() {
     return sh(
         returnStatus: true,
         script: "git diff --name-only origin/${env.CHANGE_TARGET}... | grep -v '\\.md'"
+    ) != 0
+}
+
+def boolean fuzzCargoFileOnly() {
+    if (env.CHANGE_TARGET == null) {
+        return false;
+    }
+
+    return sh(
+        returnStatus: true,
+        script: "git diff --name-only origin/${env.CHANGE_TARGET}... | grep -v -E 'fuzz\\/Cargo.(toml|lock)'"
     ) != 0
 }


### PR DESCRIPTION
This reverts commit 0d0013c46e86c18d383f3e180fa8959091bba8b9.

Grovvy shell script execution engine does not like backslash as the
escape character. So we need to put another backslash to escape the
backslash character. This would most likely fix the issue that we saw
with the CI.

Signed-off-by: Jinank Jain <jinankjain@microsoft.com>