### PR TITLE
pci, vmm: Allow VFIO and vfio-user devices to be migrated

### DIFF
--- a/pci/src/msi.rs
+++ b/pci/src/msi.rs
@@ -179,7 +179,7 @@ struct MsiConfigState {
 impl VersionMapped for MsiConfigState {}
 
 pub struct MsiConfig {
-    cap: MsiCap,
+    pub cap: MsiCap,
     interrupt_source_group: Arc<dyn InterruptSourceGroup>,
 }
 

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -441,7 +441,7 @@ impl Snapshottable for MsixConfig {
 
 #[allow(dead_code)]
 #[repr(packed)]
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Versionize)]
 pub struct MsixCap {
     // Message Control Register
     //   10-0:  MSI-X Table size

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1153,6 +1153,7 @@ impl VfioPciDevice {
         legacy_interrupt_group: Option<Arc<dyn InterruptSourceGroup>>,
         iommu_attached: bool,
         bdf: PciBdf,
+        restoring: bool,
     ) -> Result<Self, VfioPciError> {
         let device = Arc::new(device);
         device.reset();
@@ -1185,8 +1186,13 @@ impl VfioPciDevice {
             vfio_wrapper: Arc::new(vfio_wrapper) as Arc<dyn Vfio>,
         };
 
-        common.parse_capabilities(bdf);
-        common.initialize_legacy_interrupt()?;
+        // No need to parse capabilities from the device if on the restore path.
+        // The initialization will be performed later when restore() will be
+        // called.
+        if !restoring {
+            common.parse_capabilities(bdf);
+            common.initialize_legacy_interrupt()?;
+        }
 
         let vfio_pci_device = VfioPciDevice {
             id,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2978,10 +2978,6 @@ impl DeviceManager {
         device_cfg: &mut DeviceConfig,
     ) -> DeviceManagerResult<(PciBdf, String)> {
         let vfio_name = if let Some(id) = &device_cfg.id {
-            if self.device_tree.lock().unwrap().contains_key(id) {
-                return Err(DeviceManagerError::DeviceIdAlreadyInUse);
-            }
-
             id.clone()
         } else {
             let id = self.next_device_name(VFIO_DEVICE_NAME_PREFIX)?;
@@ -3090,6 +3086,7 @@ impl DeviceManager {
             legacy_interrupt_group,
             device_cfg.iommu,
             pci_device_bdf,
+            self.restoring,
         )
         .map_err(DeviceManagerError::VfioPciCreate)?;
 
@@ -3111,7 +3108,7 @@ impl DeviceManager {
             })
             .map_err(DeviceManagerError::VfioMapRegion)?;
 
-        let mut node = device_node!(vfio_name);
+        let mut node = device_node!(vfio_name, vfio_pci_device);
 
         // Update the device tree with correct resource information.
         node.resources = new_resources;


### PR DESCRIPTION
This PR doesn't provide full support for VFIO migration since it still requires the implementation of the VFIO migration API to be implemented. This will be responsible for storing the device's internal state.

It provides the first bits to let the VMM accept to snapshot and restore a VFIO device, by storing VMM internal states related to this device.