### PR TITLE
vmm: Pull in gdb dependencies only when building with feature

### DIFF
--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 amx = []
 cmos = ["devices/cmos"]
 fwdebug = ["devices/fwdebug"]
-gdb = ["kvm"]
+gdb = ["kvm", "gdbstub", "gdbstub_arch"]
 guest_debug = ["kvm"]
 kvm = ["hypervisor/kvm", "vfio-ioctls/kvm", "vm-device/kvm", "pci/kvm"]
 mshv = ["hypervisor/mshv", "virtio-devices/mshv", "vfio-ioctls/mshv", "vm-device/mshv", "pci/mshv"]
@@ -26,8 +26,8 @@ clap = "3.1.18"
 devices = { path = "../devices" }
 epoll = "4.3.1"
 event_monitor = { path = "../event_monitor" }
-gdbstub = "0.6.1"
-gdbstub_arch = "0.2.2"
+gdbstub = { version = "0.6.1", optional = true }
+gdbstub_arch = { version = "0.2.2", optional = true }
 hypervisor = { path = "../hypervisor" }
 lazy_static = "1.4.0"
 libc = "0.2.126"


### PR DESCRIPTION
Signed-off-by: Rob Bradford <robert.bradford@intel.com>
