### PR TITLE
Enable vcpu hotplug on aarch64

### DIFF
--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -46,9 +46,11 @@ build_custom_linux() {
     ARCH=$(uname -m)
     SRCDIR=$PWD
     LINUX_CUSTOM_DIR="$WORKLOADS_DIR/linux-custom"
-    LINUX_CUSTOM_BRANCH="ch-5.15.12"
-    LINUX_CUSTOM_URL="https://github.com/cloud-hypervisor/linux.git"
+    LINUX_CUSTOM_BRANCH="vcpu_hotplug_arm_5.15.12"
+#    LINUX_CUSTOM_BRANCH="ch-5.15.12"
+    LINUX_CUSTOM_URL="https://github.com/jongwu/linux.git"
 
+    rm -rf "$LINUX_CUSTOM_DIR"
     checkout_repo "$LINUX_CUSTOM_DIR" "$LINUX_CUSTOM_URL" "$LINUX_CUSTOM_BRANCH"
 
     cp $SRCDIR/resources/linux-config-${ARCH} $LINUX_CUSTOM_DIR/.config

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4271,12 +4271,18 @@ mod parallel {
     }
 
     #[test]
-    #[cfg(target_arch = "x86_64")]
     fn test_cpu_hotplug() {
-        let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+        #[cfg(target_arch = "aarch64")]
+        let focal_image = FOCAL_IMAGE_UPDATE_KERNEL_NAME.to_string();
+        #[cfg(target_arch = "x86_64")]
+        let focal_image = FOCAL_IMAGE_NAME.to_string();
+        let focal = UbuntuDiskConfig::new(focal_image);
         let guest = Guest::new(Box::new(focal));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
+        #[cfg(target_arch = "aarch64")]
+        let kernel_path = edk2_path();
+        #[cfg(target_arch = "x86_64")]
         let kernel_path = direct_kernel_boot_path();
 
         let mut child = GuestCommand::new(&guest)
@@ -4513,14 +4519,20 @@ mod parallel {
     }
 
     #[test]
-    #[cfg(target_arch = "x86_64")]
     #[cfg(not(feature = "mshv"))]
     // Test both vCPU and memory resizing together
     fn test_resize() {
-        let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+        #[cfg(target_arch = "aarch64")]
+        let focal_image = FOCAL_IMAGE_UPDATE_KERNEL_NAME.to_string();
+        #[cfg(target_arch = "x86_64")]
+        let focal_image = FOCAL_IMAGE_NAME.to_string();
+        let focal = UbuntuDiskConfig::new(focal_image);
         let guest = Guest::new(Box::new(focal));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
+        #[cfg(target_arch = "aarch64")]
+        let kernel_path = edk2_path();
+        #[cfg(target_arch = "x86_64")]
         let kernel_path = direct_kernel_boot_path();
 
         let mut child = GuestCommand::new(&guest)

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1317,7 +1317,7 @@ impl CpuManager {
              */
 
             // See section 5.2.12.14 GIC CPU Interface (GICC) Structure in ACPI spec.
-            for cpu in 0..self.config.boot_vcpus {
+            for cpu in 0..self.config.max_vcpus {
                 let vcpu = &self.vcpus[cpu as usize];
                 let mpidr = vcpu.lock().unwrap().get_mpidr();
                 /* ARMv8 MPIDR format:
@@ -1335,7 +1335,7 @@ impl CpuManager {
                     reserved0: 0,
                     cpu_interface_number: cpu as u32,
                     uid: cpu as u32,
-                    flags: 1,
+                    flags: if cpu < self.config.boot_vcpus { 1 } else { 0 },
                     parking_version: 0,
                     performance_interrupt: 0,
                     parked_address: 0,
@@ -1367,7 +1367,7 @@ impl CpuManager {
             madt.append(gicd);
 
             // See 5.2.12.17 GIC Redistributor (GICR) Structure in ACPI spec.
-            let gicr_size: u32 = 0x0001_0000 * 2 * (self.config.boot_vcpus as u32);
+            let gicr_size: u32 = 0x0001_0000 * 2 * (self.config.max_vcpus as u32);
             let gicr_base: u64 =
                 arch::layout::MAPPED_IO_START.raw_value() - 0x0001_0000 - gicr_size as u64;
             let gicr = GicR {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -778,7 +778,11 @@ impl CpuManager {
         }
 
         // Only create vCPUs in excess of all the allocated vCPUs.
-        for cpu_id in self.vcpus.len() as u8..desired_vcpus {
+        #[cfg(target_arch = "aarch64")]
+        let possible_cpus = self.config.max_vcpus;
+        #[cfg(target_arch = "x86_64")]
+        let possible_cpus = desired_vcpus;
+        for cpu_id in self.vcpus.len() as u8..possible_cpus {
             self.create_vcpu(cpu_id, entry_point, None)?;
         }
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1337,7 +1337,11 @@ impl CpuManager {
                     uid: cpu as u32,
                     flags: if cpu < self.config.boot_vcpus { 1 } else { 0 },
                     parking_version: 0,
-                    performance_interrupt: 0,
+                    performance_interrupt: if cpu < self.config.boot_vcpus {
+                        arch::aarch64::fdt::AARCH64_PMU_IRQ + 16
+                    } else {
+                        0
+                    },
                     parked_address: 0,
                     base_address: 0,
                     gicv_base_address: 0,
@@ -1570,7 +1574,7 @@ impl Cpu {
             uid: self.cpu_id as u32,
             flags: 1,
             parking_version: 0,
-            performance_interrupt: 0,
+            performance_interrupt: arch::aarch64::fdt::AARCH64_PMU_IRQ + 16,
             parked_address: 0,
             base_address: 0,
             gicv_base_address: 0,

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1248,6 +1248,16 @@ impl CpuManager {
     }
 
     #[cfg(target_arch = "aarch64")]
+    pub fn get_presented_mpidrs(&self) -> Vec<u64> {
+        let online_cpus = self.config.boot_vcpus;
+        self.vcpus
+            .iter()
+            .filter(|cpu| cpu.lock().unwrap().id < online_cpus)
+            .map(|cpu| cpu.lock().unwrap().get_mpidr())
+            .collect()
+    }
+
+    #[cfg(target_arch = "aarch64")]
     pub fn get_vcpu_topology(&self) -> Option<(u8, u8, u8)> {
         self.config
             .topology

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1146,7 +1146,7 @@ impl Vm {
     #[cfg(target_arch = "aarch64")]
     fn configure_system(&mut self, _rsdp_addr: GuestAddress) -> Result<()> {
         let cmdline = Self::generate_cmdline(&self.config, &self.device_manager)?;
-        let vcpu_mpidrs = self.cpu_manager.lock().unwrap().get_mpidrs();
+        let vcpu_mpidrs = self.cpu_manager.lock().unwrap().get_presented_mpidrs();
         let vcpu_topology = self.cpu_manager.lock().unwrap().get_vcpu_topology();
         let mem = self.memory_manager.lock().unwrap().boot_guest_memory();
         let mut pci_space_info: Vec<PciSpaceInfo> = Vec::new();

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1192,7 +1192,7 @@ impl Vm {
             .unwrap()
             .create_vgic(
                 &self.memory_manager.lock().as_ref().unwrap().vm,
-                self.cpu_manager.lock().unwrap().boot_vcpus() as u64,
+                self.cpu_manager.lock().unwrap().max_vcpus() as u64,
             )
             .map_err(|_| {
                 Error::ConfigureSystem(arch::Error::PlatformSpecific(


### PR DESCRIPTION
This PR try to enable Vcpu Hotplug on aarch64.  This PR do as the following:

- create Vcpus up to the number of max_vcpus but only boot the present vcpu;
- create Gicc & Gicr for the whole created Vcpus;
- add some Vcpu Hotplug related objects in ACPI table;
- add pmu irq info in ACPI table

Also we need Vcpu Hotplug support in guest kernel for arm64.  see https://github.com/cloud-hypervisor/linux/pull/13