### PR TITLE
hypervisor: mshv: Override hypervisor R/W behavior for unknown MSR

### DIFF
--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -66,6 +66,11 @@ pub enum HypervisorError {
     ///
     #[error("Failed to retrieve TDX capabilities:{0}")]
     TdxCapabilities(#[source] anyhow::Error),
+    ///
+    /// Failed to set partition property
+    ///
+    #[error("Failed to set partition property:{0}")]
+    SetPartitionProperty(#[source] anyhow::Error),
 }
 
 ///

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -108,6 +108,17 @@ impl hypervisor::Hypervisor for MshvHypervisor {
             break;
         }
 
+        // Default Microsoft Hypervisor behavior for unimplemented MSR is to
+        // send a fault to the guest if it tries to access it. It is possible
+        // to override this behavior with a more suitable option i.e., ignore
+        // writes from the guest and return zero in attempt to read unimplemented
+        // MSR.
+        fd.set_partition_property(
+            hv_partition_property_code_HV_PARTITION_PROPERTY_UNIMPLEMENTED_MSR_ACTION,
+            hv_unimplemented_msr_action_HV_UNIMPLEMENTED_MSR_ACTION_IGNORE_WRITE_READ_ZERO as u64,
+        )
+        .map_err(|e| hypervisor::HypervisorError::SetPartitionProperty(e.into()))?;
+
         let msr_list = self.get_msr_list()?;
         let num_msrs = msr_list.as_fam_struct_ref().nmsrs as usize;
         let mut msrs = MsrEntries::new(num_msrs).unwrap();


### PR DESCRIPTION
By default Microsoft Hypervisor send a GP to the guest if it tries
read/write an unimplemented MSR from the hypervisor prospective. Instead
change this behavior to ignore read/write operations for unimplemented
MSRs

Signed-off-by: Jinank Jain <jinankjain@microsoft.com>