### PR TITLE
Docs: Change :negative_squared_cross_mark: to :x: emoji in device_model.md.

### DIFF
--- a/docs/device_model.md
+++ b/docs/device_model.md
@@ -6,22 +6,22 @@ This document describes the device model supported by `cloud-hypervisor`.
 
 | Device | Build configurable | Enabled by default | Runtime configurable |
 | :----: | :----: | :----: | :----: |
-| Serial port | :negative_squared_cross_mark: | :negative_squared_cross_mark: | :heavy_check_mark: |
-| RTC/CMOS | :heavy_check_mark: | :heavy_check_mark: | :negative_squared_cross_mark: |
-| I/O APIC | :negative_squared_cross_mark: | :negative_squared_cross_mark: | :heavy_check_mark: |
-| i8042 shutdown/reboot | :negative_squared_cross_mark: | :negative_squared_cross_mark: | :negative_squared_cross_mark: |
-| ACPI shutdown/reboot | :negative_squared_cross_mark: | :heavy_check_mark: | :negative_squared_cross_mark: |
-| virtio-blk | :negative_squared_cross_mark: | :negative_squared_cross_mark: | :heavy_check_mark: |
-| virtio-console | :negative_squared_cross_mark: | :negative_squared_cross_mark: | :heavy_check_mark: |
-| virtio-iommu | :negative_squared_cross_mark: | :negative_squared_cross_mark: | :heavy_check_mark: |
-| virtio-net | :negative_squared_cross_mark: | :negative_squared_cross_mark: | :heavy_check_mark: |
-| virtio-pmem | :negative_squared_cross_mark: | :negative_squared_cross_mark: | :heavy_check_mark: |
-| virtio-rng | :negative_squared_cross_mark: | :negative_squared_cross_mark: | :heavy_check_mark: |
-| virtio-vsock | :negative_squared_cross_mark: | :negative_squared_cross_mark: | :heavy_check_mark: |
-| vhost-user-blk | :negative_squared_cross_mark: | :negative_squared_cross_mark: | :heavy_check_mark: |
-| vhost-user-fs | :negative_squared_cross_mark: | :negative_squared_cross_mark: | :heavy_check_mark: |
-| vhost-user-net | :negative_squared_cross_mark: | :negative_squared_cross_mark: | :heavy_check_mark: |
-| VFIO | :heavy_check_mark: | :negative_squared_cross_mark: | :heavy_check_mark: |
+| Serial port | :x: | :x: | :heavy_check_mark: |
+| RTC/CMOS | :heavy_check_mark: | :heavy_check_mark: | :x: |
+| I/O APIC | :x: | :x: | :heavy_check_mark: |
+| i8042 shutdown/reboot | :x: | :x: | :x: |
+| ACPI shutdown/reboot | :x: | :heavy_check_mark: | :x: |
+| virtio-blk | :x: | :x: | :heavy_check_mark: |
+| virtio-console | :x: | :x: | :heavy_check_mark: |
+| virtio-iommu | :x: | :x: | :heavy_check_mark: |
+| virtio-net | :x: | :x: | :heavy_check_mark: |
+| virtio-pmem | :x: | :x: | :heavy_check_mark: |
+| virtio-rng | :x: | :x: | :heavy_check_mark: |
+| virtio-vsock | :x: | :x: | :heavy_check_mark: |
+| vhost-user-blk | :x: | :x: | :heavy_check_mark: |
+| vhost-user-fs | :x: | :x: | :heavy_check_mark: |
+| vhost-user-net | :x: | :x: | :heavy_check_mark: |
+| VFIO | :heavy_check_mark: | :x: | :heavy_check_mark: |
 
 ## Legacy devices
 


### PR DESCRIPTION
In the [Summary table of the device model documentation](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/docs/device_model.md#summary), the Negative Squared Cross Mark emoji (❎) indicates that a device does not support build/runtime configuration, or is not enabled by default. Unfortunately, [many platforms render the Negative Squared Cross Mark emoji as a white X with a green background](https://emojipedia.org/cross-mark-button/), which is a bit confusing to me - in my experience, green/white indicate "yes" or "OK", and red/black indicate "no" or "not OK".

This PR updates the table to use the Cross Mark emoji (❌), which [appears as a red or black X against a transparent background for all platforms](https://emojipedia.org/cross-mark/).

Fixes #4240 
	
Signed-off-by: Dylan Bargatze <dylan@bargatze.net>