### PR TITLE
tdx: correct td-shim payload info structure layout

### DIFF
--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -197,7 +197,7 @@ impl Default for PayloadImageType {
     }
 }
 
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Copy, Clone, Default, Debug)]
 pub struct PayloadInfo {
     pub image_type: PayloadImageType,


### PR DESCRIPTION
As defined in TD Shim spec: https://github.com/confidential-containers/td-shim/blob/main/doc/tdshim_spec.md#td-payload-info-guid-extension-hob
the layout of TdPayload and PayloadInfo should be packed.

Signe-off-by: Jiaqi Gao <jiaqi.gao@intel.com>