### PR TITLE
vmm: Always reset the console mode on VMM exit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use thiserror::Error;
 use vmm::config;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::block_signal;
+use vmm_sys_util::terminal::Terminal;
 
 #[derive(Error, Debug)]
 enum Error {
@@ -622,6 +623,13 @@ fn main() {
             1
         }
     };
+
+    let on_tty = unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0;
+    if on_tty {
+        // Don't forget to set the terminal in canonical mode
+        // before to exit.
+        std::io::stdin().lock().set_canon_mode().unwrap();
+    }
 
     std::process::exit(exit_code);
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1694,13 +1694,14 @@ impl Vm {
                     console_input_clone.update_console_size();
                 }
                 SIGTERM | SIGINT => {
-                    if on_tty {
-                        io::stdin()
-                            .lock()
-                            .set_canon_mode()
-                            .expect("failed to restore terminal mode");
-                    }
                     if exit_evt.write(1).is_err() {
+                        // Resetting the terminal is usually done as the VMM exits
+                        if on_tty {
+                            io::stdin()
+                                .lock()
+                                .set_canon_mode()
+                                .expect("failed to restore terminal mode");
+                        }
                         std::process::exit(1);
                     }
                 }


### PR DESCRIPTION
Tested:

1. SIGTERM based
2. VM shutdown/poweroff
3. Injected VM boot failure after calling Vm::setup_tty()

Fixes: #4248

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
