### PR TITLE
ch-remote "create" improvement and testing

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -321,9 +321,8 @@ fn create_api_command(socket: &mut UnixStream, path: &str) -> Result<(), Error> 
             .read_to_string(&mut data)
             .map_err(Error::ReadingStdin)?;
     } else {
-        let mut f = std::fs::File::open(path).map_err(Error::ReadingFile)?;
-        f.read_to_string(&mut data).map_err(Error::ReadingFile)?;
-    };
+        data = std::fs::read_to_string(path).map_err(Error::ReadingFile)?;
+    }
 
     simple_api_command(socket, "PUT", "create", Some(&data)).map_err(Error::ApiClient)
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4045,15 +4045,17 @@ mod parallel {
             DIRECT_KERNEL_BOOT_CMDLINE,
         );
 
-        curl_command(
+        let temp_config_path = guest.tmp_dir.as_path().join("config");
+        std::fs::write(&temp_config_path, http_body).unwrap();
+
+        remote_command(
             &api_socket,
-            "PUT",
-            "http://localhost/api/v1/vm.create",
-            Some(&http_body),
+            "create",
+            Some(temp_config_path.as_os_str().to_str().unwrap()),
         );
 
         // Then boot it
-        curl_command(&api_socket, "PUT", "http://localhost/api/v1/vm.boot", None);
+        remote_command(&api_socket, "boot", None);
         thread::sleep(std::time::Duration::new(20, 0));
 
         let r = std::panic::catch_unwind(|| {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -253,8 +253,15 @@ fn remote_command(api_socket: &str, command: &str, arg: Option<&str>) -> bool {
     if let Some(arg) = arg {
         cmd.arg(arg);
     }
-
-    cmd.status().expect("Failed to launch ch-remote").success()
+    let output = cmd.output().unwrap();
+    if output.status.success() {
+        true
+    } else {
+        eprintln!("Error running ch-remote command: {:?}", &cmd);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!("stderr: {}", stderr);
+        false
+    }
 }
 
 fn remote_command_w_output(api_socket: &str, command: &str, arg: Option<&str>) -> (bool, Vec<u8>) {


### PR DESCRIPTION
- ch-remote: Simplify ch-remote create from config file
- tests: tests_api_create_boot: Use ch-remote for creating and booting vm
- tests: Report stderr on ch-remote command failure
