### PR TITLE
virtio: Port codebase to the latest virtio-queue version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded8a9f15b09e61bb8a501d0a7a38056f4c1bd7f51cedcd41081c0e4233d5aa6"
+checksum = "558ac5ca9569fb03f518b2bdd17606809ffdc894b619b92d30df6c40c33d15f3"
 dependencies = [
  "libc",
  "log",
@@ -1293,6 +1293,7 @@ dependencies = [
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
+ "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
 ]
@@ -1357,11 +1358,12 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519c0a333c871650269cba303bc108075d52a0c0d64f9b91fae61829b53725af"
+checksum = "b4f59652909f276e6edd8bf36e9f106480b2202f5f046717b3de14f1b4072a28"
 dependencies = [
  "log",
+ "virtio-bindings",
  "vm-memory",
  "vmm-sys-util",
 ]

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -17,7 +17,7 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vhdx = { path = "../vhdx" }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.4.0"
+virtio-queue = "0.5.0"
 vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.10.0"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -817,11 +817,12 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519c0a333c871650269cba303bc108075d52a0c0d64f9b91fae61829b53725af"
+checksum = "b4f59652909f276e6edd8bf36e9f106480b2202f5f046717b3de14f1b4072a28"
 dependencies = [
  "log",
+ "virtio-bindings",
  "vm-memory",
  "vmm-sys-util",
 ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,7 +17,7 @@ qcow = { path = "../qcow" }
 seccompiler = "0.2.0"
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.4.0"
+virtio-queue = "0.5.0"
 vmm-sys-util = "0.10.0"
 vm-memory = "0.8.0"
 vm-device = { path = "../vm-device" }

--- a/fuzz/fuzz_targets/block.rs
+++ b/fuzz/fuzz_targets/block.rs
@@ -15,7 +15,7 @@ use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::PathBuf;
 use std::sync::Arc;
 use virtio_devices::{Block, VirtioDevice, VirtioInterrupt, VirtioInterruptType};
-use virtio_queue::{Queue, QueueState};
+use virtio_queue::{Queue, QueueT};
 use vm_memory::{bitmap::AtomicBitmap, Bytes, GuestAddress, GuestMemoryAtomic};
 use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 
@@ -77,12 +77,9 @@ fuzz_target!(|bytes| {
 
     let guest_memory = GuestMemoryAtomic::new(mem);
 
-    let mut q = Queue::<
-        GuestMemoryAtomic<GuestMemoryMmap>,
-        QueueState,
-    >::new(guest_memory.clone(), QUEUE_SIZE);
-    q.state.ready = true;
-    q.state.size = QUEUE_SIZE / 2;
+    let mut q = Queue::new(QUEUE_SIZE).unwrap();
+    q.set_ready(true);
+    q.set_size(QUEUE_SIZE / 2);
 
     let evt = EventFd::new(0).unwrap();
     let queue_evt = unsafe { EventFd::from_raw_fd(libc::dup(evt.as_raw_fd())) };

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -15,7 +15,7 @@ serde = "1.0.140"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 virtio-bindings = "0.1.0"
-virtio-queue = "0.4.0"
+virtio-queue = "0.5.0"
 vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.10.0"

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -120,7 +120,7 @@ impl TxVirtio {
             }
 
             queue
-                .add_used(mem, desc_chain.head_index(), len)
+                .add_used(desc_chain.memory(), desc_chain.head_index(), len)
                 .map_err(NetQueuePairError::QueueAddUsed)?;
 
             if !queue
@@ -262,7 +262,7 @@ impl RxVirtio {
             }
 
             queue
-                .add_used(mem, desc_chain.head_index(), len)
+                .add_used(desc_chain.memory(), desc_chain.head_index(), len)
                 .map_err(NetQueuePairError::QueueAddUsed)?;
 
             if !queue

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -14,8 +14,9 @@ log = "0.4.17"
 option_parser = { path = "../option_parser" }
 qcow = { path = "../qcow" }
 vhost = { version = "0.4.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.5.1"
+vhost-user-backend = "0.6.0"
 virtio-bindings = "0.1.0"
+virtio-queue = "0.5.0"
 vm-memory = "0.8.0"
 vmm-sys-util = "0.10.0"
 

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -19,6 +19,7 @@ use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::Read;
 use std::io::{Seek, SeekFrom, Write};
+use std::ops::Deref;
 use std::ops::DerefMut;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
@@ -34,6 +35,8 @@ use vhost::vhost_user::Listener;
 use vhost_user_backend::{VhostUserBackendMut, VhostUserDaemon, VringRwLock, VringState, VringT};
 use virtio_bindings::bindings::virtio_blk::*;
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
+use virtio_queue::{QueueOwnedT, QueueT};
+use vm_memory::GuestAddressSpace;
 use vm_memory::{bitmap::AtomicBitmap, ByteValued, Bytes, GuestMemoryAtomic};
 use vmm_sys_util::{epoll::EventSet, eventfd::EventFd};
 
@@ -95,6 +98,7 @@ struct VhostUserBlkThread {
     event_idx: bool,
     kill_evt: EventFd,
     writeback: Arc<AtomicBool>,
+    mem: GuestMemoryAtomic<GuestMemoryMmap>,
 }
 
 impl VhostUserBlkThread {
@@ -103,6 +107,7 @@ impl VhostUserBlkThread {
         disk_image_id: Vec<u8>,
         disk_nsectors: u64,
         writeback: Arc<AtomicBool>,
+        mem: GuestMemoryAtomic<GuestMemoryMmap>,
     ) -> Result<Self> {
         Ok(VhostUserBlkThread {
             disk_image,
@@ -111,6 +116,7 @@ impl VhostUserBlkThread {
             event_idx: false,
             kill_evt: EventFd::new(EFD_NONBLOCK).map_err(Error::CreateKillEventFd)?,
             writeback,
+            mem,
         })
     }
 
@@ -120,7 +126,7 @@ impl VhostUserBlkThread {
     ) -> bool {
         let mut used_desc_heads = Vec::new();
 
-        for mut desc_chain in vring.get_queue_mut().iter().unwrap() {
+        for mut desc_chain in vring.get_queue_mut().iter(self.mem.memory()).unwrap() {
             debug!("got an element in the queue");
             let len;
             match Request::parse(&mut desc_chain, None) {
@@ -156,12 +162,13 @@ impl VhostUserBlkThread {
             used_desc_heads.push((desc_chain.head_index(), len));
         }
 
+        let mem = self.mem.memory();
         let mut needs_signalling = false;
         for (desc_head, len) in used_desc_heads.iter() {
             if self.event_idx {
                 let queue = vring.get_queue_mut();
-                if queue.add_used(*desc_head, *len).is_ok() {
-                    if queue.needs_notification().unwrap() {
+                if queue.add_used(mem.deref(), *desc_head, *len).is_ok() {
+                    if queue.needs_notification(mem.deref()).unwrap() {
                         debug!("signalling queue");
                         needs_signalling = true;
                     } else {
@@ -170,7 +177,10 @@ impl VhostUserBlkThread {
                 }
             } else {
                 debug!("signalling queue");
-                vring.get_queue_mut().add_used(*desc_head, *len).unwrap();
+                vring
+                    .get_queue_mut()
+                    .add_used(mem.deref(), *desc_head, *len)
+                    .unwrap();
                 needs_signalling = true;
             }
         }
@@ -192,6 +202,7 @@ struct VhostUserBlkBackend {
     queue_size: usize,
     acked_features: u64,
     writeback: Arc<AtomicBool>,
+    mem: GuestMemoryAtomic<GuestMemoryMmap>,
 }
 
 impl VhostUserBlkBackend {
@@ -202,6 +213,7 @@ impl VhostUserBlkBackend {
         direct: bool,
         poll_queue: bool,
         queue_size: usize,
+        mem: GuestMemoryAtomic<GuestMemoryMmap>,
     ) -> Result<Self> {
         let mut options = OpenOptions::new();
         options.read(true);
@@ -243,6 +255,7 @@ impl VhostUserBlkBackend {
                 image_id.clone(),
                 nsectors,
                 writeback.clone(),
+                mem.clone(),
             )?);
             threads.push(thread);
             queues_per_thread.push(0b1 << i);
@@ -257,6 +270,7 @@ impl VhostUserBlkBackend {
             queue_size,
             acked_features: 0,
             writeback,
+            mem,
         })
     }
 
@@ -364,7 +378,10 @@ impl VhostUserBackendMut<VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>, Atomic
                     // calling process_queue() until it stops finding new
                     // requests on the queue.
                     loop {
-                        vring.get_queue_mut().enable_notification().unwrap();
+                        vring
+                            .get_queue_mut()
+                            .enable_notification(self.mem.memory().deref())
+                            .unwrap();
                         if !thread.process_queue(&mut vring) {
                             break;
                         }
@@ -491,6 +508,8 @@ pub fn start_block_backend(backend_command: &str) {
         }
     };
 
+    let mem = GuestMemoryAtomic::new(GuestMemoryMmap::new());
+
     let blk_backend = Arc::new(RwLock::new(
         VhostUserBlkBackend::new(
             backend_config.path,
@@ -499,6 +518,7 @@ pub fn start_block_backend(backend_command: &str) {
             backend_config.direct,
             backend_config.poll_queue,
             backend_config.queue_size,
+            mem.clone(),
         )
         .unwrap(),
     ));
@@ -508,12 +528,7 @@ pub fn start_block_backend(backend_command: &str) {
     let listener = Listener::new(&backend_config.socket, true).unwrap();
 
     let name = "vhost-user-blk-backend";
-    let mut blk_daemon = VhostUserDaemon::new(
-        name.to_string(),
-        blk_backend.clone(),
-        GuestMemoryAtomic::new(GuestMemoryMmap::new()),
-    )
-    .unwrap();
+    let mut blk_daemon = VhostUserDaemon::new(name.to_string(), blk_backend.clone(), mem).unwrap();
 
     debug!("blk_daemon is created!\n");
 

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4.17"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
 vhost = { version = "0.4.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.5.1"
+vhost-user-backend = "0.6.0"
 virtio-bindings = "0.1.0"
 vm-memory = "0.8.0"
 vmm-sys-util = "0.10.0"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -30,7 +30,7 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vhost = { version = "0.4.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern", "vhost-vdpa"] }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.4.0"
+virtio-queue = "0.5.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -247,11 +247,9 @@ impl BalloonEpollHandler {
     }
 
     fn process_queue(&mut self, queue_index: usize) -> result::Result<(), Error> {
-        let mem = self.mem.memory();
         let mut used_descs = Vec::new();
-        for mut desc_chain in self.queues[queue_index]
-            .iter(mem)
-            .map_err(Error::QueueIterator)?
+        while let Some(mut desc_chain) =
+            self.queues[queue_index].pop_descriptor_chain(self.mem.memory())
         {
             let desc = desc_chain.next().ok_or(Error::DescriptorChainTooShort)?;
 

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -107,7 +107,7 @@ pub trait VirtioDevice: Send {
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
         interrupt_evt: Arc<dyn VirtioInterrupt>,
-        queues: Vec<(usize, Queue<GuestMemoryAtomic<GuestMemoryMmap>>, EventFd)>,
+        queues: Vec<(usize, Queue, EventFd)>,
     ) -> ActivateResult;
 
     /// Optionally deactivates this device and returns ownership of the guest memory map, interrupt
@@ -250,7 +250,7 @@ impl VirtioCommon {
 
     pub fn activate(
         &mut self,
-        queues: &[(usize, Queue<GuestMemoryAtomic<GuestMemoryMmap>>, EventFd)],
+        queues: &[(usize, Queue, EventFd)],
         interrupt_cb: &Arc<dyn VirtioInterrupt>,
     ) -> ActivateResult {
         if queues.len() < self.min_queues.into() {

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -24,7 +24,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex, RwLock};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::{DescriptorChain, Queue, QueueOwnedT, QueueT};
+use virtio_queue::{DescriptorChain, Queue, QueueT};
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
@@ -676,7 +676,7 @@ impl IommuEpollHandler {
     fn request_queue(&mut self) -> bool {
         let mut used_desc_heads = [(0, 0); QUEUE_SIZE as usize];
         let mut used_count = 0;
-        for mut desc_chain in self.queues[0].iter(self.mem.memory()).unwrap() {
+        while let Some(mut desc_chain) = self.queues[0].pop_descriptor_chain(self.mem.memory()) {
             let len = match Request::parse(
                 &mut desc_chain,
                 &self.mapping,

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -160,7 +160,7 @@ impl TryInto<rate_limiter::RateLimiter> for RateLimiterConfig {
 /// to a host pointer and verify that the provided size define a valid
 /// range within a single memory region.
 /// Return None if it is out of bounds or if addr+size overlaps a single region.
-pub fn get_host_address_range<M: GuestMemory>(
+pub fn get_host_address_range<M: GuestMemory + ?Sized>(
     mem: &M,
     addr: GuestAddress,
     size: usize,

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -35,7 +35,7 @@ use std::sync::mpsc;
 use std::sync::{Arc, Barrier, Mutex};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::{DescriptorChain, Queue, QueueOwnedT, QueueT};
+use virtio_queue::{DescriptorChain, Queue, QueueT};
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
@@ -668,7 +668,7 @@ impl MemEpollHandler {
         let mut request_list = Vec::new();
         let mut used_count = 0;
 
-        for mut desc_chain in self.queue.iter(self.mem.memory()).unwrap() {
+        while let Some(mut desc_chain) = self.queue.pop_descriptor_chain(self.mem.memory()) {
             request_list.push((
                 desc_chain.head_index(),
                 Request::parse(&mut desc_chain),

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -28,7 +28,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::{DescriptorChain, Queue, QueueOwnedT, QueueT};
+use virtio_queue::{DescriptorChain, Queue, QueueT};
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
     GuestMemoryError, GuestMemoryLoadGuard,
@@ -180,7 +180,7 @@ impl PmemEpollHandler {
     fn process_queue(&mut self) -> bool {
         let mut used_desc_heads = [(0, 0); QUEUE_SIZE as usize];
         let mut used_count = 0;
-        for mut desc_chain in self.queue.iter(self.mem.memory()).unwrap() {
+        while let Some(mut desc_chain) = self.queue.pop_descriptor_chain(self.mem.memory()) {
             let len = match Request::parse(&mut desc_chain, self.access_platform.as_ref()) {
                 Ok(ref req) if (req.type_ == RequestType::Flush) => {
                     let status_code = match self.disk.sync_all() {

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -22,7 +22,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::{Queue, QueueOwnedT, QueueT};
+use virtio_queue::{Queue, QueueT};
 use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
@@ -52,7 +52,7 @@ impl RngEpollHandler {
 
         let mut used_desc_heads = [(0, 0); QUEUE_SIZE as usize];
         let mut used_count = 0;
-        for mut desc_chain in queue.iter(self.mem.memory()).unwrap() {
+        while let Some(mut desc_chain) = queue.pop_descriptor_chain(self.mem.memory()) {
             let desc = desc_chain.next().unwrap();
             let mut len = 0;
 

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -6,14 +6,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use crate::{GuestMemoryMmap, VirtioDevice};
+use crate::VirtioDevice;
 use byteorder::{ByteOrder, LittleEndian};
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Arc, Mutex};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::Queue;
-use vm_memory::{GuestAddress, GuestMemoryAtomic};
+use virtio_queue::{Queue, QueueT};
 use vm_migration::{MigratableError, Pausable, Snapshot, Snapshottable, VersionMapped};
 use vm_virtio::AccessPlatform;
 
@@ -90,7 +89,7 @@ impl VirtioPciCommonConfig {
         &mut self,
         offset: u64,
         data: &mut [u8],
-        queues: &mut [Queue<GuestMemoryAtomic<GuestMemoryMmap>>],
+        queues: &mut [Queue],
         device: Arc<Mutex<dyn VirtioDevice>>,
     ) {
         assert!(data.len() <= 8);
@@ -120,7 +119,7 @@ impl VirtioPciCommonConfig {
         &mut self,
         offset: u64,
         data: &[u8],
-        queues: &mut [Queue<GuestMemoryAtomic<GuestMemoryMmap>>],
+        queues: &mut [Queue],
         device: Arc<Mutex<dyn VirtioDevice>>,
     ) {
         assert!(data.len() <= 8);
@@ -159,20 +158,16 @@ impl VirtioPciCommonConfig {
         }
     }
 
-    fn read_common_config_word(
-        &self,
-        offset: u64,
-        queues: &[Queue<GuestMemoryAtomic<GuestMemoryMmap>>],
-    ) -> u16 {
+    fn read_common_config_word(&self, offset: u64, queues: &[Queue]) -> u16 {
         debug!("read_common_config_word: offset 0x{:x}", offset);
         match offset {
             0x10 => self.msix_config.load(Ordering::Acquire),
             0x12 => queues.len() as u16, // num_queues
             0x16 => self.queue_select,
-            0x18 => self.with_queue(queues, |q| q.state.size).unwrap_or(0),
+            0x18 => self.with_queue(queues, |q| q.size()).unwrap_or(0),
             0x1a => self.msix_queues.lock().unwrap()[self.queue_select as usize],
             0x1c => {
-                if self.with_queue(queues, |q| q.state.ready).unwrap_or(false) {
+                if self.with_queue(queues, |q| q.ready()).unwrap_or(false) {
                     1
                 } else {
                     0
@@ -186,17 +181,12 @@ impl VirtioPciCommonConfig {
         }
     }
 
-    fn write_common_config_word(
-        &mut self,
-        offset: u64,
-        value: u16,
-        queues: &mut [Queue<GuestMemoryAtomic<GuestMemoryMmap>>],
-    ) {
+    fn write_common_config_word(&mut self, offset: u64, value: u16, queues: &mut [Queue]) {
         debug!("write_common_config_word: offset 0x{:x}", offset);
         match offset {
             0x10 => self.msix_config.store(value, Ordering::Release),
             0x16 => self.queue_select = value,
-            0x18 => self.with_queue_mut(queues, |q| q.state.size = value),
+            0x18 => self.with_queue_mut(queues, |q| q.set_size(value)),
             0x1a => self.msix_queues.lock().unwrap()[self.queue_select as usize] = value,
             0x1c => self.with_queue_mut(queues, |q| {
                 let ready = value == 1;
@@ -204,15 +194,9 @@ impl VirtioPciCommonConfig {
                 // Translate address of descriptor table and vrings.
                 if let Some(access_platform) = &self.access_platform {
                     if ready {
-                        let desc_table = access_platform
-                            .translate_gva(q.state.desc_table.0, 0)
-                            .unwrap();
-                        let avail_ring = access_platform
-                            .translate_gva(q.state.avail_ring.0, 0)
-                            .unwrap();
-                        let used_ring = access_platform
-                            .translate_gva(q.state.used_ring.0, 0)
-                            .unwrap();
+                        let desc_table = access_platform.translate_gva(q.desc_table(), 0).unwrap();
+                        let avail_ring = access_platform.translate_gva(q.avail_ring(), 0).unwrap();
+                        let used_ring = access_platform.translate_gva(q.used_ring(), 0).unwrap();
                         q.set_desc_table_address(
                             Some((desc_table & 0xffff_ffff) as u32),
                             Some((desc_table >> 32) as u32),
@@ -260,17 +244,10 @@ impl VirtioPciCommonConfig {
         &mut self,
         offset: u64,
         value: u32,
-        queues: &mut [Queue<GuestMemoryAtomic<GuestMemoryMmap>>],
+        queues: &mut [Queue],
         device: Arc<Mutex<dyn VirtioDevice>>,
     ) {
         debug!("write_common_config_dword: offset 0x{:x}", offset);
-        fn hi(v: &mut GuestAddress, x: u32) {
-            *v = (*v & 0xffff_ffff) | ((u64::from(x)) << 32)
-        }
-
-        fn lo(v: &mut GuestAddress, x: u32) {
-            *v = (*v & !0xffff_ffff) | (u64::from(x))
-        }
 
         match offset {
             0x00 => self.device_feature_select = value,
@@ -287,12 +264,12 @@ impl VirtioPciCommonConfig {
                     );
                 }
             }
-            0x20 => self.with_queue_mut(queues, |q| lo(&mut q.state.desc_table, value)),
-            0x24 => self.with_queue_mut(queues, |q| hi(&mut q.state.desc_table, value)),
-            0x28 => self.with_queue_mut(queues, |q| lo(&mut q.state.avail_ring, value)),
-            0x2c => self.with_queue_mut(queues, |q| hi(&mut q.state.avail_ring, value)),
-            0x30 => self.with_queue_mut(queues, |q| lo(&mut q.state.used_ring, value)),
-            0x34 => self.with_queue_mut(queues, |q| hi(&mut q.state.used_ring, value)),
+            0x20 => self.with_queue_mut(queues, |q| q.set_desc_table_address(Some(value), None)),
+            0x24 => self.with_queue_mut(queues, |q| q.set_desc_table_address(None, Some(value))),
+            0x28 => self.with_queue_mut(queues, |q| q.set_avail_ring_address(Some(value), None)),
+            0x2c => self.with_queue_mut(queues, |q| q.set_avail_ring_address(None, Some(value))),
+            0x30 => self.with_queue_mut(queues, |q| q.set_used_ring_address(Some(value), None)),
+            0x34 => self.with_queue_mut(queues, |q| q.set_used_ring_address(None, Some(value))),
             _ => {
                 warn!("invalid virtio register dword write: 0x{:x}", offset);
             }
@@ -304,39 +281,30 @@ impl VirtioPciCommonConfig {
         0 // Assume the guest has no reason to read write-only registers.
     }
 
-    fn write_common_config_qword(
-        &mut self,
-        offset: u64,
-        value: u64,
-        queues: &mut [Queue<GuestMemoryAtomic<GuestMemoryMmap>>],
-    ) {
+    fn write_common_config_qword(&mut self, offset: u64, value: u64, queues: &mut [Queue]) {
         debug!("write_common_config_qword: offset 0x{:x}", offset);
+
+        let low = Some((value & 0xffff_ffff) as u32);
+        let high = Some((value >> 32) as u32);
+
         match offset {
-            0x20 => self.with_queue_mut(queues, |q| q.state.desc_table = GuestAddress(value)),
-            0x28 => self.with_queue_mut(queues, |q| q.state.avail_ring = GuestAddress(value)),
-            0x30 => self.with_queue_mut(queues, |q| q.state.used_ring = GuestAddress(value)),
+            0x20 => self.with_queue_mut(queues, |q| q.set_desc_table_address(low, high)),
+            0x28 => self.with_queue_mut(queues, |q| q.set_avail_ring_address(low, high)),
+            0x30 => self.with_queue_mut(queues, |q| q.set_used_ring_address(low, high)),
             _ => {
                 warn!("invalid virtio register qword write: 0x{:x}", offset);
             }
         }
     }
 
-    fn with_queue<U, F>(
-        &self,
-        queues: &[Queue<GuestMemoryAtomic<GuestMemoryMmap>>],
-        f: F,
-    ) -> Option<U>
+    fn with_queue<U, F>(&self, queues: &[Queue], f: F) -> Option<U>
     where
-        F: FnOnce(&Queue<GuestMemoryAtomic<GuestMemoryMmap>>) -> U,
+        F: FnOnce(&Queue) -> U,
     {
         queues.get(self.queue_select as usize).map(f)
     }
 
-    fn with_queue_mut<F: FnOnce(&mut Queue<GuestMemoryAtomic<GuestMemoryMmap>>)>(
-        &self,
-        queues: &mut [Queue<GuestMemoryAtomic<GuestMemoryMmap>>],
-        f: F,
-    ) {
+    fn with_queue_mut<F: FnOnce(&mut Queue)>(&self, queues: &mut [Queue], f: F) {
         if let Some(queue) = queues.get_mut(self.queue_select as usize) {
             f(queue);
         }
@@ -385,7 +353,7 @@ mod tests {
             &mut self,
             _mem: GuestMemoryAtomic<GuestMemoryMmap>,
             _interrupt_evt: Arc<dyn VirtioInterrupt>,
-            _queues: Vec<(usize, Queue<GuestMemoryAtomic<GuestMemoryMmap>>, EventFd)>,
+            _queues: Vec<(usize, Queue, EventFd)>,
         ) -> ActivateResult {
             Ok(())
         }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -24,19 +24,20 @@ use pci::{
 use std::any::Any;
 use std::cmp;
 use std::io::Write;
+use std::ops::Deref;
 use std::result;
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::{Error as QueueError, Queue};
+use virtio_queue::{Error as QueueError, Queue, QueueT};
 use vm_allocator::{AddressAllocator, SystemAllocator};
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceGroup, MsiIrqGroupConfig,
 };
 use vm_device::{BusDevice, Resource};
-use vm_memory::{Address, ByteValued, GuestAddress, GuestMemoryAtomic, Le32};
+use vm_memory::{Address, ByteValued, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, Le32};
 use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable, VersionMapped,
 };
@@ -292,8 +293,7 @@ pub struct VirtioPciDeviceActivator {
     memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     device: Arc<Mutex<dyn VirtioDevice>>,
     device_activated: Arc<AtomicBool>,
-    #[allow(clippy::type_complexity)]
-    queues: Option<Vec<(usize, Queue<GuestMemoryAtomic<GuestMemoryMmap>>, EventFd)>>,
+    queues: Option<Vec<(usize, Queue, EventFd)>>,
     barrier: Option<Arc<Barrier>>,
     id: String,
 }
@@ -342,11 +342,11 @@ pub struct VirtioPciDevice {
     interrupt_source_group: Arc<dyn InterruptSourceGroup>,
 
     // virtio queues
-    queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
+    queues: Vec<Queue>,
     queue_evts: Vec<EventFd>,
 
     // Guest memory
-    memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
+    memory: GuestMemoryAtomic<GuestMemoryMmap>,
 
     // Settings PCI BAR
     settings_bar: u8,
@@ -406,12 +406,7 @@ impl VirtioPciDevice {
         let queues = locked_device
             .queue_max_sizes()
             .iter()
-            .map(|&s| {
-                Queue::<GuestMemoryAtomic<GuestMemoryMmap>, virtio_queue::QueueState>::new(
-                    memory.clone(),
-                    s,
-                )
-            })
+            .map(|&s| Queue::new(s).unwrap())
             .collect();
 
         let pci_device_id = VIRTIO_PCI_DEVICE_ID_BASE + locked_device.device_type() as u16;
@@ -482,7 +477,7 @@ impl VirtioPciDevice {
             virtio_interrupt: None,
             queues,
             queue_evts,
-            memory: Some(memory),
+            memory,
             settings_bar: 0,
             use_64bit_bar,
             interrupt_source_group,
@@ -514,11 +509,11 @@ impl VirtioPciDevice {
                 .iter()
                 .map(|q| QueueState {
                     max_size: q.max_size(),
-                    size: q.state.size,
-                    ready: q.state.ready,
-                    desc_table: q.state.desc_table.0,
-                    avail_ring: q.state.avail_ring.0,
-                    used_ring: q.state.used_ring.0,
+                    size: q.size(),
+                    ready: q.ready(),
+                    desc_table: q.desc_table(),
+                    avail_ring: q.avail_ring(),
+                    used_ring: q.used_ring(),
                 })
                 .collect(),
         }
@@ -532,20 +527,26 @@ impl VirtioPciDevice {
 
         // Update virtqueues indexes for both available and used rings.
         for (i, queue) in self.queues.iter_mut().enumerate() {
-            queue.state.size = state.queues[i].size;
-            queue.state.ready = state.queues[i].ready;
-            queue.state.desc_table = GuestAddress(state.queues[i].desc_table);
-            queue.state.avail_ring = GuestAddress(state.queues[i].avail_ring);
-            queue.state.used_ring = GuestAddress(state.queues[i].used_ring);
+            queue.set_size(state.queues[i].size);
+            queue.set_ready(state.queues[i].ready);
+            queue
+                .try_set_desc_table_address(GuestAddress(state.queues[i].desc_table))
+                .unwrap();
+            queue
+                .try_set_avail_ring_address(GuestAddress(state.queues[i].avail_ring))
+                .unwrap();
+            queue
+                .try_set_used_ring_address(GuestAddress(state.queues[i].used_ring))
+                .unwrap();
             queue.set_next_avail(
                 queue
-                    .used_idx(Ordering::Acquire)
+                    .used_idx(self.memory.memory().deref(), Ordering::Acquire)
                     .map_err(Error::QueueRingIndex)?
                     .0,
             );
             queue.set_next_used(
                 queue
-                    .used_idx(Ordering::Acquire)
+                    .used_idx(self.memory.memory().deref(), Ordering::Acquire)
                     .map_err(Error::QueueRingIndex)?
                     .0,
             );
@@ -701,11 +702,11 @@ impl VirtioPciDevice {
         let mut queues = Vec::new();
 
         for (queue_index, queue) in self.queues.iter().enumerate() {
-            if !queue.state.ready {
+            if !queue.ready() {
                 continue;
             }
 
-            if !queue.is_valid() {
+            if !queue.is_valid(self.memory.memory().deref()) {
                 error!("Queue {} is not valid", queue_index);
             }
 
@@ -718,7 +719,7 @@ impl VirtioPciDevice {
 
         VirtioPciDeviceActivator {
             interrupt: self.virtio_interrupt.take(),
-            memory: self.memory.clone(),
+            memory: Some(self.memory.clone()),
             device: self.device.clone(),
             queues: Some(queues),
             device_activated: self.device_activated.clone(),

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -292,7 +292,7 @@ impl VirtioDevice for Blk {
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
         interrupt_cb: Arc<dyn VirtioInterrupt>,
-        queues: Vec<(usize, Queue<GuestMemoryAtomic<GuestMemoryMmap>>, EventFd)>,
+        queues: Vec<(usize, Queue, EventFd)>,
     ) -> ActivateResult {
         self.common.activate(&queues, &interrupt_cb)?;
         self.guest_memory = Some(mem.clone());

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -504,7 +504,7 @@ impl VirtioDevice for Fs {
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
         interrupt_cb: Arc<dyn VirtioInterrupt>,
-        queues: Vec<(usize, Queue<GuestMemoryAtomic<GuestMemoryMmap>>, EventFd)>,
+        queues: Vec<(usize, Queue, EventFd)>,
     ) -> ActivateResult {
         self.common.activate(&queues, &interrupt_cb)?;
         self.guest_memory = Some(mem.clone());

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -167,7 +167,7 @@ pub struct VhostUserEpollHandler<S: VhostUserMasterReqHandler> {
     pub mem: GuestMemoryAtomic<GuestMemoryMmap>,
     pub kill_evt: EventFd,
     pub pause_evt: EventFd,
-    pub queues: Vec<(usize, Queue<GuestMemoryAtomic<GuestMemoryMmap>>, EventFd)>,
+    pub queues: Vec<(usize, Queue, EventFd)>,
     pub virtio_interrupt: Arc<dyn VirtioInterrupt>,
     pub acked_features: u64,
     pub acked_protocol_features: u64,
@@ -297,7 +297,7 @@ impl VhostUserCommon {
     pub fn activate<T: VhostUserMasterReqHandler>(
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
-        queues: Vec<(usize, Queue<GuestMemoryAtomic<GuestMemoryMmap>>, EventFd)>,
+        queues: Vec<(usize, Queue, EventFd)>,
         interrupt_cb: Arc<dyn VirtioInterrupt>,
         acked_features: u64,
         slave_req_handler: Option<MasterReqHandler<T>>,

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -27,7 +27,7 @@ use virtio_bindings::bindings::virtio_net::{
     VIRTIO_NET_F_MAC, VIRTIO_NET_F_MRG_RXBUF,
 };
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
-use virtio_queue::Queue;
+use virtio_queue::{Queue, QueueT};
 use vm_memory::{ByteValued, GuestMemoryAtomic};
 use vm_migration::{
     protocol::MemoryRangeTable, Migratable, MigratableError, Pausable, Snapshot, Snapshottable,
@@ -272,7 +272,7 @@ impl VirtioDevice for Net {
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
         interrupt_cb: Arc<dyn VirtioInterrupt>,
-        mut queues: Vec<(usize, Queue<GuestMemoryAtomic<GuestMemoryMmap>>, EventFd)>,
+        mut queues: Vec<(usize, Queue, EventFd)>,
     ) -> ActivateResult {
         self.common.activate(&queues, &interrupt_cb)?;
         self.guest_memory = Some(mem.clone());
@@ -288,6 +288,7 @@ impl VirtioDevice for Net {
             let (kill_evt, pause_evt) = self.common.dup_eventfds();
 
             let mut ctrl_handler = NetCtrlEpollHandler {
+                mem: mem.clone(),
                 kill_evt,
                 pause_evt,
                 ctrl_q: CtrlQueue::new(Vec::new()),

--- a/virtio-devices/src/vsock/csm/connection.rs
+++ b/virtio-devices/src/vsock/csm/connection.rs
@@ -673,6 +673,7 @@ where
 #[cfg(test)]
 mod tests {
     use libc::EFD_NONBLOCK;
+    use virtio_queue::QueueOwnedT;
 
     use std::io::{Error as IoError, ErrorKind, Read, Result as IoResult, Write};
     use std::os::unix::io::RawFd;
@@ -819,7 +820,7 @@ mod tests {
             let stream = TestStream::new();
             let mut pkt = VsockPacket::from_rx_virtq_head(
                 &mut handler_ctx.handler.queues[0]
-                    .iter()
+                    .iter(&vsock_test_ctx.mem)
                     .unwrap()
                     .next()
                     .unwrap(),

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -170,7 +170,7 @@ mod tests {
     use std::os::unix::io::AsRawFd;
     use std::path::PathBuf;
     use std::sync::{Arc, RwLock};
-    use virtio_queue::{defs::VIRTQ_DESC_F_NEXT, defs::VIRTQ_DESC_F_WRITE};
+    use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
     use vm_memory::{GuestAddress, GuestMemoryAtomic};
     use vm_virtio::queue::testing::VirtQueue as GuestQ;
     use vmm_sys_util::eventfd::EventFd;
@@ -295,15 +295,20 @@ mod tests {
             guest_rxvq.dtable[0].set(
                 0x0040_0000,
                 VSOCK_PKT_HDR_SIZE as u32,
-                VIRTQ_DESC_F_WRITE | VIRTQ_DESC_F_NEXT,
+                (VRING_DESC_F_WRITE | VRING_DESC_F_NEXT).try_into().unwrap(),
                 1,
             );
-            guest_rxvq.dtable[1].set(0x0040_1000, 4096, VIRTQ_DESC_F_WRITE, 0);
+            guest_rxvq.dtable[1].set(0x0040_1000, 4096, VRING_DESC_F_WRITE.try_into().unwrap(), 0);
             guest_rxvq.avail.ring[0].set(0);
             guest_rxvq.avail.idx.set(1);
 
             // Set up one available descriptor in the TX queue.
-            guest_txvq.dtable[0].set(0x0050_0000, VSOCK_PKT_HDR_SIZE as u32, VIRTQ_DESC_F_NEXT, 1);
+            guest_txvq.dtable[0].set(
+                0x0050_0000,
+                VSOCK_PKT_HDR_SIZE as u32,
+                VRING_DESC_F_NEXT.try_into().unwrap(),
+                1,
+            );
             guest_txvq.dtable[1].set(0x0050_1000, 4096, 0, 0);
             guest_txvq.avail.ring[0].set(0);
             guest_txvq.avail.idx.set(1);

--- a/virtio-devices/src/vsock/unix/muxer.rs
+++ b/virtio-devices/src/vsock/unix/muxer.rs
@@ -817,6 +817,8 @@ mod tests {
     use std::os::unix::net::{UnixListener, UnixStream};
     use std::path::{Path, PathBuf};
 
+    use virtio_queue::QueueOwnedT;
+
     use super::super::super::csm::defs as csm_defs;
     use super::super::super::tests::TestContext as VsockTestContext;
     use super::*;
@@ -842,7 +844,7 @@ mod tests {
             let mut handler_ctx = vsock_test_ctx.create_epoll_handler_context();
             let pkt = VsockPacket::from_rx_virtq_head(
                 &mut handler_ctx.handler.queues[0]
-                    .iter()
+                    .iter(&vsock_test_ctx.mem)
                     .unwrap()
                     .next()
                     .unwrap(),

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -26,7 +26,7 @@ use std::sync::{Arc, Barrier, Mutex};
 use std::time::Instant;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
-use virtio_queue::{Queue, QueueOwnedT, QueueT};
+use virtio_queue::{Queue, QueueT};
 use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
@@ -66,7 +66,7 @@ impl WatchdogEpollHandler {
         let queue = &mut self.queue;
         let mut used_desc_heads = [(0, 0); QUEUE_SIZE as usize];
         let mut used_count = 0;
-        for mut desc_chain in queue.iter(self.mem.memory()).unwrap() {
+        while let Some(mut desc_chain) = queue.pop_descriptor_chain(self.mem.memory()) {
             let desc = desc_chain.next().unwrap();
 
             let mut len = 0;

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -9,5 +9,5 @@ default = []
 
 [dependencies]
 log = "0.4.17"
-virtio-queue = "0.4.0"
+virtio-queue = "0.5.0"
 vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -50,7 +50,7 @@ vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", defau
 vfio_user = { path = "../vfio_user" }
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.4.0"
+virtio-queue = "0.5.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }


### PR DESCRIPTION
 The new virtio-queue version introduced some breaking changes which need
to be addressed so that Cloud Hypervisor can still work with this
version.

The most important change is about removing a handle to the guest memory
from the Queue, meaning the caller has to provide the guest memory
handle for multiple methods from the QueueT trait.

One interesting aspect is that QueueT has been widely extended to
provide every getter and setter we need to access and update the Queue
structure without having direct access to its internal fields.

This patch ports all the virtio and vhost-user devices to this new crate
definition. It also updates both vhost-user-block and vhost-user-net
backends based on the updated vhost-user-backend crate. It also updates
the fuzz directory.