### PR TITLE
vmm: Split signal handling for VM and VMM signals

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -521,7 +521,13 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
     // Before we start any threads, mask the signals we'll be
     // installing handlers for, to make sure they only ever run on the
     // dedicated signal handling thread we'll start in a bit.
-    for sig in &vmm::vm::HANDLED_SIGNALS {
+    for sig in &vmm::vm::Vm::HANDLED_SIGNALS {
+        if let Err(e) = block_signal(*sig) {
+            eprintln!("Error blocking signals: {}", e);
+        }
+    }
+
+    for sig in &vmm::Vmm::HANDLED_SIGNALS {
         if let Err(e) = block_signal(*sig) {
             eprintln!("Error blocking signals: {}", e);
         }


### PR DESCRIPTION
The VM specific signal (currently only SIGWINCH) should only be handled
when the VM is running.

The generic VMM signals (SIGINT and SIGTERM) need handling at all times.

Split the signal handling into two separate threads which have differing
lifetimes.

Tested by:
1.) Boot full VM and check resize handling (SIGWINCH) works & sending
    SIGTERM leads to cleanup (tested that API socket is removed.)
2.) Start without a VM and send SIGTERM/SIGINT and observe cleanup (API
    socket removed)
3.) Boot full VM, delete VM and observe 2.) holds.
4.) Boot full VM, delete VM, recreate VM and observe 1.) holds.

Fixes: #4269

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
