### PR TITLE
Introduce and use generic UserMemoryRegion

### DIFF
--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -61,15 +61,15 @@ pub use kvm::{aarch64, GicState};
 #[cfg(feature = "kvm")]
 pub use kvm::{
     ClockData, CpuState, CreateDevice, DeviceAttr, DeviceFd, IoEventAddress, IrqRoutingEntry,
-    MemoryRegion, MpState, VcpuEvents, VcpuExit, VmState,
+    MpState, VcpuEvents, VcpuExit, VmState,
 };
 #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
 pub use mshv::x86_64;
 // Aliased types exposed from both hypervisors
 #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
 pub use mshv::{
-    CpuState, CreateDevice, DeviceAttr, DeviceFd, IoEventAddress, IrqRoutingEntry, MemoryRegion,
-    MpState, VcpuEvents, VcpuExit, VmState,
+    CpuState, CreateDevice, DeviceAttr, DeviceFd, IoEventAddress, IrqRoutingEntry, MpState,
+    VcpuEvents, VcpuExit, VmState,
 };
 use std::sync::Arc;
 pub use vm::{

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -116,3 +116,23 @@ pub fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
     let vec_size_bytes = size_of::<T>() + element_space;
     vec_with_size_in_bytes(vec_size_bytes)
 }
+
+///
+/// User memory region structure
+///
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct UserMemoryRegion {
+    pub slot: u32,
+    pub guest_phys_addr: u64,
+    pub memory_size: u64,
+    pub userspace_addr: u64,
+    pub flags: u32,
+}
+
+///
+/// Flags for user memory region
+///
+pub const USER_MEMORY_REGION_READ: u32 = 1;
+pub const USER_MEMORY_REGION_WRITE: u32 = 1 << 1;
+pub const USER_MEMORY_REGION_EXECUTE: u32 = 1 << 2;
+pub const USER_MEMORY_REGION_LOG_DIRTY: u32 = 1 << 3;

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -960,7 +960,8 @@ impl vm::Vm for MshvVm {
     }
 
     /// Creates a guest physical memory region.
-    fn create_user_memory_region(&self, user_memory_region: MemoryRegion) -> vm::Result<()> {
+    fn create_user_memory_region(&self, user_memory_region: UserMemoryRegion) -> vm::Result<()> {
+        let user_memory_region: mshv_user_mem_region = user_memory_region.into();
         // No matter read only or not we keep track the slots.
         // For readonly hypervisor can enable the dirty bits,
         // but a VM exit happens before setting the dirty bits
@@ -979,7 +980,8 @@ impl vm::Vm for MshvVm {
     }
 
     /// Removes a guest physical memory region.
-    fn remove_user_memory_region(&self, user_memory_region: MemoryRegion) -> vm::Result<()> {
+    fn remove_user_memory_region(&self, user_memory_region: UserMemoryRegion) -> vm::Result<()> {
+        let user_memory_region: mshv_user_mem_region = user_memory_region.into();
         // Remove the corresponding entry from "self.dirty_log_slots" if needed
         self.dirty_log_slots
             .write()
@@ -1000,7 +1002,7 @@ impl vm::Vm for MshvVm {
         userspace_addr: u64,
         readonly: bool,
         _log_dirty_pages: bool,
-    ) -> MemoryRegion {
+    ) -> UserMemoryRegion {
         let mut flags = HV_MAP_GPA_READABLE | HV_MAP_GPA_EXECUTABLE;
         if !readonly {
             flags |= HV_MAP_GPA_WRITABLE;
@@ -1012,6 +1014,7 @@ impl vm::Vm for MshvVm {
             size: memory_size,
             userspace_addr: userspace_addr as u64,
         }
+        .into()
     }
 
     ///

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -23,7 +23,8 @@ use crate::x86_64::CpuId;
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
 use crate::ClockData;
 use crate::CreateDevice;
-use crate::{IoEventAddress, IrqRoutingEntry, MemoryRegion};
+use crate::UserMemoryRegion;
+use crate::{IoEventAddress, IrqRoutingEntry};
 #[cfg(feature = "kvm")]
 use kvm_ioctls::Cap;
 #[cfg(target_arch = "x86_64")]
@@ -311,11 +312,11 @@ pub trait Vm: Send + Sync {
         userspace_addr: u64,
         readonly: bool,
         log_dirty_pages: bool,
-    ) -> MemoryRegion;
+    ) -> UserMemoryRegion;
     /// Creates a guest physical memory slot.
-    fn create_user_memory_region(&self, user_memory_region: MemoryRegion) -> Result<()>;
+    fn create_user_memory_region(&self, user_memory_region: UserMemoryRegion) -> Result<()>;
     /// Removes a guest physical memory slot.
-    fn remove_user_memory_region(&self, user_memory_region: MemoryRegion) -> Result<()>;
+    fn remove_user_memory_region(&self, user_memory_region: UserMemoryRegion) -> Result<()>;
     /// Creates an emulated device in the kernel.
     fn create_device(&self, device: &mut CreateDevice) -> Result<Arc<dyn Device>>;
     /// Returns the preferred CPU target type which can be emulated by KVM on underlying host.


### PR DESCRIPTION
This avoids leaking hypervisor specific types into the wider VMM code.

Based on Dev's patches.