### PR TITLE
hypervisor: do not export VcpuExit

### DIFF
--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -61,7 +61,7 @@ pub use kvm::{aarch64, GicState};
 #[cfg(feature = "kvm")]
 pub use kvm::{
     ClockData, CpuState, CreateDevice, DeviceAttr, DeviceFd, IoEventAddress, IrqRoutingEntry,
-    MpState, VcpuEvents, VcpuExit, VmState,
+    MpState, VcpuEvents, VmState,
 };
 #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
 pub use mshv::x86_64;
@@ -69,7 +69,7 @@ pub use mshv::x86_64;
 #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
 pub use mshv::{
     CpuState, CreateDevice, DeviceAttr, DeviceFd, IoEventAddress, IrqRoutingEntry, MpState,
-    VcpuEvents, VcpuExit, VmState,
+    VcpuEvents, VmState,
 };
 use std::sync::Arc;
 pub use vm::{

--- a/hypervisor/src/mshv/x86_64/mod.rs
+++ b/hypervisor/src/mshv/x86_64/mod.rs
@@ -67,7 +67,6 @@ impl fmt::Display for VcpuMshvState {
 }
 
 pub struct IrqRouting {}
-pub enum VcpuExit {}
 pub struct MpState {}
 
 impl SegmentRegisterOps for SegmentRegister {


### PR DESCRIPTION
It is not used anywhere outside of the hypervisor crate.

Signed-off-by: Wei Liu <liuwe@microsoft.com>