### PR TITLE
Provide downcasting ability to DeviceFd trait

### DIFF
--- a/hypervisor/src/device.rs
+++ b/hypervisor/src/device.rs
@@ -10,6 +10,7 @@
 //
 
 use crate::DeviceAttr;
+use std::any::Any;
 use std::os::unix::io::AsRawFd;
 use thiserror::Error;
 
@@ -44,4 +45,6 @@ pub trait Device: Send + Sync + AsRawFd {
     fn set_device_attr(&self, attr: &DeviceAttr) -> Result<()>;
     /// Get device attribute.
     fn get_device_attr(&self, attr: &mut DeviceAttr) -> Result<()>;
+    /// Provide a way to downcast to the device fd.
+    fn as_any(&self) -> &dyn Any;
 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -32,7 +32,10 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 #[cfg(target_arch = "x86_64")]
 use std::fs::File;
-use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(target_arch = "x86_64")]
+use std::os::unix::io::AsRawFd;
+#[cfg(feature = "tdx")]
+use std::os::unix::io::RawFd;
 use std::result;
 #[cfg(target_arch = "x86_64")]
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -481,12 +484,11 @@ impl vm::Vm for KvmVm {
     ///
     /// See the documentation for `KVM_CREATE_DEVICE`.
     fn create_device(&self, device: &mut CreateDevice) -> vm::Result<Arc<dyn device::Device>> {
-        let fd = self
+        let device_fd = self
             .fd
             .create_device(device)
             .map_err(|e| vm::HypervisorVmError::CreateDevice(e.into()))?;
-        let device = KvmDevice { fd };
-        Ok(Arc::new(device))
+        Ok(Arc::new(device_fd))
     }
     ///
     /// Returns the preferred CPU target type which can be emulated by KVM on underlying host.
@@ -1935,25 +1937,21 @@ impl cpu::Vcpu for KvmVcpu {
 }
 
 /// Device struct for KVM
-pub struct KvmDevice {
-    fd: DeviceFd,
-}
+pub type KvmDevice = DeviceFd;
 
 impl device::Device for KvmDevice {
     ///
     /// Set device attribute
     ///
     fn set_device_attr(&self, attr: &DeviceAttr) -> device::Result<()> {
-        self.fd
-            .set_device_attr(attr)
+        self.set_device_attr(attr)
             .map_err(|e| device::HypervisorDeviceError::SetDeviceAttribute(e.into()))
     }
     ///
     /// Get device attribute
     ///
     fn get_device_attr(&self, attr: &mut DeviceAttr) -> device::Result<()> {
-        self.fd
-            .get_device_attr(attr)
+        self.get_device_attr(attr)
             .map_err(|e| device::HypervisorDeviceError::GetDeviceAttribute(e.into()))
     }
     ///
@@ -1961,11 +1959,5 @@ impl device::Device for KvmDevice {
     ///
     fn as_any(&self) -> &dyn Any {
         self
-    }
-}
-
-impl AsRawFd for KvmDevice {
-    fn as_raw_fd(&self) -> RawFd {
-        self.fd.as_raw_fd()
     }
 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -26,6 +26,7 @@ use crate::vm::{self, InterruptSourceConfig, VmOps};
 use crate::{arm64_core_reg_id, offset__of};
 use kvm_ioctls::{NoDatamatch, VcpuFd, VmFd};
 use serde::{Deserialize, Serialize};
+use std::any::Any;
 use std::collections::HashMap;
 #[cfg(target_arch = "aarch64")]
 use std::convert::TryInto;
@@ -1954,6 +1955,12 @@ impl device::Device for KvmDevice {
         self.fd
             .get_device_attr(attr)
             .map_err(|e| device::HypervisorDeviceError::GetDeviceAttribute(e.into()))
+    }
+    ///
+    /// Cast to the underlying KVM device fd
+    ///
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -16,6 +16,7 @@ pub use mshv_bindings::*;
 pub use mshv_ioctls::IoEventAddress;
 use mshv_ioctls::{set_registers_64, Mshv, NoDatamatch, VcpuFd, VmFd};
 use serde::{Deserialize, Serialize};
+use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use vm::DataMatch;
@@ -637,6 +638,12 @@ impl device::Device for MshvDevice {
         self.fd
             .get_device_attr(attr)
             .map_err(|e| device::HypervisorDeviceError::GetDeviceAttribute(e.into()))
+    }
+    ///
+    /// Cast to the underlying MSHV device fd
+    ///
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2959,6 +2959,8 @@ impl DeviceManager {
             return vmm_sys_util::errno::errno_result().map_err(DeviceManagerError::DupFd);
         }
 
+        assert!(passthrough_device.as_any().is::<DeviceFd>());
+
         // SAFETY the raw fd conversion here is safe because:
         //   1. When running on KVM or MSHV, passthrough_device wraps around DeviceFd.
         //   2. The conversion here extracts the raw fd and then turns the raw fd into a DeviceFd


### PR DESCRIPTION
When going through Dev's code, I noticed vfio-ioctls is also leaking KVM / MSHV types.

I've thought of a way to fix it there too. It is probably going to break the existing APIs in vfio-ioctls, but I do want to make it more type-safe when I do that.

On the Cloud Hypervisor side, I want to access the underlying DeviceFd type from either KVM or MSHV. That means I need to use `Any`. Although its full potential can only be fulfilled when vfio-ioctls is fixed, we can use it immediately to catch type mismatch issues.