### PR TITLE
Refactor AArch64 VCPU registers related code in `hypervisor`

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -429,12 +429,12 @@ pub trait Vcpu: Send + Sync {
     /// Save the state of the system registers.
     ///
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    fn system_registers(&self, state: &mut Vec<Register>) -> Result<()>;
+    fn get_sys_regs(&self) -> Result<Vec<Register>>;
     ///
     /// Restore the state of the system registers.
     ///
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    fn set_system_registers(&self, state: &[Register]) -> Result<()>;
+    fn set_sys_regs(&self, state: &[Register]) -> Result<()>;
     ///
     /// Read the MPIDR - Multiprocessor Affinity Register.
     ///

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -407,43 +407,43 @@ pub trait Vcpu: Send + Sync {
     ///
     /// Sets the type of CPU to be exposed to the guest and optional features.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn vcpu_init(&self, kvi: &VcpuInit) -> Result<()>;
     ///
     /// Sets the value of one register for this vCPU.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn set_reg(&self, reg_id: u64, data: u64) -> Result<()>;
     ///
     /// Sets the value of one register for this vCPU.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn get_reg(&self, reg_id: u64) -> Result<u64>;
     ///
     /// Gets a list of the guest registers that are supported for the
     /// KVM_GET_ONE_REG/KVM_SET_ONE_REG calls.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn get_reg_list(&self, reg_list: &mut RegList) -> Result<()>;
     ///
     /// Save the state of the system registers.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn get_sys_regs(&self) -> Result<Vec<Register>>;
     ///
     /// Restore the state of the system registers.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn set_sys_regs(&self, state: &[Register]) -> Result<()>;
     ///
     /// Read the MPIDR - Multiprocessor Affinity Register.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn read_mpidr(&self) -> Result<u64>;
     ///
     /// Configure core registers for a given CPU.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn setup_regs(&self, cpu_id: u8, boot_ip: u64, fdt_start: u64) -> Result<()>;
     ///
     /// Retrieve the vCPU state.

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -278,7 +278,6 @@ pub type Result<T> = anyhow::Result<T, HypervisorCpuError>;
 /// Trait to represent a generic Vcpu
 ///
 pub trait Vcpu: Send + Sync {
-    #[cfg(target_arch = "x86_64")]
     ///
     /// Returns the vCPU general purpose registers.
     ///
@@ -293,7 +292,6 @@ pub trait Vcpu: Send + Sync {
     /// Check if vcpu has attribute.
     ///
     fn has_vcpu_attr(&self, attr: &DeviceAttr) -> Result<()>;
-    #[cfg(target_arch = "x86_64")]
     ///
     /// Sets the vCPU general purpose registers.
     ///
@@ -427,16 +425,6 @@ pub trait Vcpu: Send + Sync {
     ///
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     fn get_reg_list(&self, reg_list: &mut RegList) -> Result<()>;
-    ///
-    /// Save the state of the core registers.
-    ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    fn core_registers(&self, state: &mut StandardRegisters) -> Result<()>;
-    ///
-    /// Restore the state of the core registers.
-    ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    fn set_core_registers(&self, state: &StandardRegisters) -> Result<()>;
     ///
     /// Save the state of the system registers.
     ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -542,7 +542,7 @@ impl vm::Vm for KvmVm {
     ///
     /// Returns the preferred CPU target type which can be emulated by KVM on underlying host.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn get_preferred_target(&self, kvi: &mut VcpuInit) -> vm::Result<()> {
         self.fd
             .get_preferred_target(kvi)
@@ -866,7 +866,7 @@ impl hypervisor::Hypervisor for KvmHypervisor {
             }))
         }
 
-        #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+        #[cfg(target_arch = "aarch64")]
         {
             Ok(Arc::new(KvmVm {
                 fd: vm_fd,
@@ -1535,7 +1535,7 @@ impl cpu::Vcpu for KvmVcpu {
             .set_guest_debug(&dbg)
             .map_err(|e| cpu::HypervisorCpuError::SetDebugRegs(e.into()))
     }
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn vcpu_init(&self, kvi: &VcpuInit) -> cpu::Result<()> {
         self.fd
             .vcpu_init(kvi)
@@ -1544,7 +1544,7 @@ impl cpu::Vcpu for KvmVcpu {
     ///
     /// Sets the value of one register for this vCPU.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn set_reg(&self, reg_id: u64, data: u64) -> cpu::Result<()> {
         self.fd
             .set_one_reg(reg_id, data)
@@ -1553,7 +1553,7 @@ impl cpu::Vcpu for KvmVcpu {
     ///
     /// Gets the value of one register for this vCPU.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn get_reg(&self, reg_id: u64) -> cpu::Result<u64> {
         self.fd
             .get_one_reg(reg_id)
@@ -1563,7 +1563,7 @@ impl cpu::Vcpu for KvmVcpu {
     /// Gets a list of the guest registers that are supported for the
     /// KVM_GET_ONE_REG/KVM_SET_ONE_REG calls.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn get_reg_list(&self, reg_list: &mut RegList) -> cpu::Result<()> {
         self.fd
             .get_reg_list(reg_list)
@@ -1572,7 +1572,7 @@ impl cpu::Vcpu for KvmVcpu {
     ///
     /// Save the state of the system registers.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn get_sys_regs(&self) -> cpu::Result<Vec<Register>> {
         // Call KVM_GET_REG_LIST to get all registers available to the guest. For ArmV8 there are
         // around 500 registers.
@@ -1607,7 +1607,7 @@ impl cpu::Vcpu for KvmVcpu {
     ///
     /// Restore the state of the system registers.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn set_sys_regs(&self, state: &[Register]) -> cpu::Result<()> {
         for reg in state {
             self.fd
@@ -1619,7 +1619,7 @@ impl cpu::Vcpu for KvmVcpu {
     ///
     /// Read the MPIDR - Multiprocessor Affinity Register.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn read_mpidr(&self) -> cpu::Result<u64> {
         self.fd
             .get_one_reg(MPIDR_EL1)
@@ -1628,7 +1628,7 @@ impl cpu::Vcpu for KvmVcpu {
     ///
     /// Configure core registers for a given CPU.
     ///
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn setup_regs(&self, cpu_id: u8, boot_ip: u64, fdt_start: u64) -> cpu::Result<()> {
         #[allow(non_upper_case_globals)]
         // PSR (Processor State Register) bits.

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -320,7 +320,7 @@ pub trait Vm: Send + Sync {
     /// Creates an emulated device in the kernel.
     fn create_device(&self, device: &mut CreateDevice) -> Result<Arc<dyn Device>>;
     /// Returns the preferred CPU target type which can be emulated by KVM on underlying host.
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     fn get_preferred_target(&self, kvi: &mut VcpuInit) -> Result<()>;
     /// Enable split Irq capability
     #[cfg(target_arch = "x86_64")]

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -2537,10 +2537,10 @@ mod tests {
 
         // Must fail when vcpu is not initialized yet.
         let mut state: Vec<kvm_one_reg> = Vec::new();
-        let res = vcpu.system_registers(&mut state);
+        let res = vcpu.get_sys_regs();
         assert!(res.is_err());
         assert_eq!(
-            format!("{}", res.unwrap_err()),
+            format!("{}", res.as_ref().unwrap_err()),
             "Failed to retrieve list of registers: Exec format error (os error 8)"
         );
 
@@ -2548,7 +2548,7 @@ mod tests {
             id: MPIDR_EL1,
             addr: 0x00,
         });
-        let res = vcpu.set_system_registers(&state);
+        let res = vcpu.set_sys_regs(&state);
         assert!(res.is_err());
         assert_eq!(
             format!("{}", res.unwrap_err()),
@@ -2556,14 +2556,17 @@ mod tests {
         );
 
         vcpu.vcpu_init(&kvi).unwrap();
-        assert!(vcpu.system_registers(&mut state).is_ok());
+        let res = vcpu.get_sys_regs();
+        assert!(res.is_ok());
+        state = res.unwrap();
+
         let initial_mpidr: u64 = vcpu.read_mpidr().expect("Fail to read mpidr");
         assert!(state.contains(&kvm_one_reg {
             id: MPIDR_EL1,
             addr: initial_mpidr
         }));
 
-        assert!(vcpu.set_system_registers(&state).is_ok());
+        assert!(vcpu.set_sys_regs(&state).is_ok());
         let mpidr: u64 = vcpu.read_mpidr().expect("Fail to read mpidr");
         assert_eq!(initial_mpidr, mpidr);
     }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -2498,15 +2498,15 @@ mod tests {
         vm.get_preferred_target(&mut kvi).unwrap();
 
         // Must fail when vcpu is not initialized yet.
-        let mut state = kvm_regs::default();
-        let res = vcpu.core_registers(&mut state);
+        let res = vcpu.get_regs();
         assert!(res.is_err());
         assert_eq!(
             format!("{}", res.unwrap_err()),
             "Failed to get core register: Exec format error (os error 8)"
         );
 
-        let res = vcpu.set_core_registers(&state);
+        let mut state = kvm_regs::default();
+        let res = vcpu.set_regs(&state);
         assert!(res.is_err());
         assert_eq!(
             format!("{}", res.unwrap_err()),
@@ -2514,10 +2514,12 @@ mod tests {
         );
 
         vcpu.vcpu_init(&kvi).unwrap();
-        assert!(vcpu.core_registers(&mut state).is_ok());
+        let res = vcpu.get_regs();
+        assert!(res.is_ok());
+        state = res.unwrap();
         assert_eq!(state.regs.pstate, 0x3C5);
 
-        assert!(vcpu.set_core_registers(&state).is_ok());
+        assert!(vcpu.set_regs(&state).is_ok());
         let off = offset__of!(user_pt_regs, pstate);
         let pstate = vcpu
             .get_reg(arm64_core_reg_id!(KVM_REG_SIZE_U64, off))


### PR DESCRIPTION
Part of the PR prepares for https://github.com/cloud-hypervisor/cloud-hypervisor/issues/3980

Refactor VCPU registers related code in `hypervisor` crate:
- Rename `(set_)core_registers` to `get/set_regs`, aligning to the equivalent functions on X86. Now we have following registers related functions:
  - `get/set_regs` (X86_64 & AArch64): Access general purposed registers
  - `get/set_sregs` (X86_64 only): Access special registers
  - `get/set_sys_regs` (AArch64 only): Access some system registers. (Now this group of function can not be aligned to `get/set_sregs` on X86_64, they are quite different.)
- Improve the name and parameter setting of `(set_)system_registers`.
- Replace `#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]` with `#[cfg(target_arch = "aarch64")]`. Because we do not support `arm` now; and some usages were not precise.