### PR TITLE
virtio-devices vhost-user: fs: Set default number of queues

### DIFF
--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -38,7 +38,7 @@ use vm_migration::{
 use vmm_sys_util::eventfd::EventFd;
 
 const NUM_QUEUE_OFFSET: usize = 1;
-const DEFAULT_QUEUE_NUMBER: usize = 2;
+const DEFAULT_QUEUE_NUMBER: usize = 1;
 
 #[derive(Versionize)]
 pub struct State {


### PR DESCRIPTION
Set the default number of queues to 1. Which matches with the spec and
also aligns with our testing.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
