### PR TITLE
tests: Disable test_windows_guest_snapshot_restore for now

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6969,6 +6969,7 @@ mod windows {
 
     #[test]
     #[cfg(not(feature = "mshv"))]
+    #[ignore = "See #4327"]
     fn test_windows_guest_snapshot_restore() {
         let windows_guest = WindowsGuest::new();
 


### PR DESCRIPTION
See: #4327

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
