### PR TITLE
Unified binary -- part 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ name = "hypervisor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "byteorder",
  "env_logger",
  "epoll",
  "iced-x86",

--- a/arch/src/x86_64/interrupts.rs
+++ b/arch/src/x86_64/interrupts.rs
@@ -5,10 +5,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use hypervisor::x86_64::LapicState;
-use std::io::Cursor;
-use std::mem;
 use std::result;
 use std::sync::Arc;
 
@@ -19,32 +15,6 @@ pub const APIC_LVT0: usize = 0x350;
 pub const APIC_LVT1: usize = 0x360;
 pub const APIC_MODE_NMI: u32 = 0x4;
 pub const APIC_MODE_EXTINT: u32 = 0x7;
-
-pub fn get_klapic_reg(klapic: &LapicState, reg_offset: usize) -> u32 {
-    let sliceu8 = unsafe {
-        // This array is only accessed as parts of a u32 word, so interpret it as a u8 array.
-        // Cursors are only readable on arrays of u8, not i8(c_char).
-        mem::transmute::<&[i8], &[u8]>(&klapic.regs[reg_offset..])
-    };
-    let mut reader = Cursor::new(sliceu8);
-    // Following call can't fail if the offsets defined above are correct.
-    reader
-        .read_u32::<LittleEndian>()
-        .expect("Failed to read klapic register")
-}
-
-pub fn set_klapic_reg(klapic: &mut LapicState, reg_offset: usize, value: u32) {
-    let sliceu8 = unsafe {
-        // This array is only accessed as parts of a u32 word, so interpret it as a u8 array.
-        // Cursors are only readable on arrays of u8, not i8(c_char).
-        mem::transmute::<&mut [i8], &mut [u8]>(&mut klapic.regs[reg_offset..])
-    };
-    let mut writer = Cursor::new(sliceu8);
-    // Following call can't fail if the offsets defined above are correct.
-    writer
-        .write_u32::<LittleEndian>(value)
-        .expect("Failed to write klapic register")
-}
 
 pub fn set_apic_delivery_mode(reg: u32, mode: u32) -> u32 {
     ((reg) & !0x700) | ((mode) << 8)
@@ -57,42 +27,13 @@ pub fn set_apic_delivery_mode(reg: u32, mode: u32) -> u32 {
 pub fn set_lint(vcpu: &Arc<dyn hypervisor::Vcpu>) -> Result<()> {
     let mut klapic = vcpu.get_lapic()?;
 
-    let lvt_lint0 = get_klapic_reg(&klapic, APIC_LVT0);
-    set_klapic_reg(
-        &mut klapic,
+    let lvt_lint0 = klapic.get_klapic_reg(APIC_LVT0);
+    klapic.set_klapic_reg(
         APIC_LVT0,
         set_apic_delivery_mode(lvt_lint0, APIC_MODE_EXTINT),
     );
-    let lvt_lint1 = get_klapic_reg(&klapic, APIC_LVT1);
-    set_klapic_reg(
-        &mut klapic,
-        APIC_LVT1,
-        set_apic_delivery_mode(lvt_lint1, APIC_MODE_NMI),
-    );
+    let lvt_lint1 = klapic.get_klapic_reg(APIC_LVT1);
+    klapic.set_klapic_reg(APIC_LVT1, set_apic_delivery_mode(lvt_lint1, APIC_MODE_NMI));
 
     vcpu.set_lapic(&klapic)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    const KVM_APIC_REG_SIZE: usize = 0x400;
-
-    #[test]
-    fn test_set_and_get_klapic_reg() {
-        let reg_offset = 0x340;
-        let mut klapic = LapicState::default();
-        set_klapic_reg(&mut klapic, reg_offset, 3);
-        let value = get_klapic_reg(&klapic, reg_offset);
-        assert_eq!(value, 3);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_set_and_get_klapic_out_of_bounds() {
-        let reg_offset = KVM_APIC_REG_SIZE + 10;
-        let mut klapic = LapicState::default();
-        set_klapic_reg(&mut klapic, reg_offset, 3);
-    }
 }

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -12,6 +12,7 @@ tdx = []
 
 [dependencies]
 anyhow = "1.0.58"
+byteorder = "1.4.3"
 epoll = "4.3.1"
 thiserror = "1.0.31"
 libc = "0.2.126"

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -19,7 +19,7 @@ use crate::kvm::{TdxExitDetails, TdxExitStatus};
 #[cfg(target_arch = "x86_64")]
 use crate::x86_64::LapicState;
 #[cfg(target_arch = "x86_64")]
-use crate::x86_64::{MsrEntries, VcpuEvents};
+use crate::x86_64::MsrEntries;
 use crate::CpuState;
 #[cfg(target_arch = "aarch64")]
 use crate::DeviceAttr;
@@ -349,18 +349,6 @@ pub trait Vcpu: Send + Sync {
     /// Sets the vcpu's current "multiprocessing state".
     ///
     fn set_mp_state(&self, mp_state: MpState) -> Result<()>;
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// Returns currently pending exceptions, interrupts, and NMIs as well as related
-    /// states of the vcpu.
-    ///
-    fn get_vcpu_events(&self) -> Result<VcpuEvents>;
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// Sets pending exceptions, interrupts, and NMIs as well as related states
-    /// of the vcpu.
-    ///
-    fn set_vcpu_events(&self, events: &VcpuEvents) -> Result<()>;
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
     ///
     /// Let the guest know that it has been paused, which prevents from

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -19,7 +19,7 @@ use crate::kvm::{TdxExitDetails, TdxExitStatus};
 #[cfg(target_arch = "x86_64")]
 use crate::x86_64::LapicState;
 #[cfg(target_arch = "x86_64")]
-use crate::x86_64::{ExtendedControlRegisters, MsrEntries, VcpuEvents};
+use crate::x86_64::{MsrEntries, VcpuEvents};
 use crate::CpuState;
 #[cfg(target_arch = "aarch64")]
 use crate::DeviceAttr;
@@ -349,16 +349,6 @@ pub trait Vcpu: Send + Sync {
     /// Sets the vcpu's current "multiprocessing state".
     ///
     fn set_mp_state(&self, mp_state: MpState) -> Result<()>;
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// X86 specific call that returns the vcpu's current "xcrs".
-    ///
-    fn get_xcrs(&self) -> Result<ExtendedControlRegisters>;
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// X86 specific call that sets the vcpu's current "xcrs".
-    ///
-    fn set_xcrs(&self, xcrs: &ExtendedControlRegisters) -> Result<()>;
     #[cfg(target_arch = "x86_64")]
     ///
     /// Returns currently pending exceptions, interrupts, and NMIs as well as related

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -19,8 +19,6 @@ use crate::kvm::{TdxExitDetails, TdxExitStatus};
 #[cfg(target_arch = "x86_64")]
 use crate::x86_64::LapicState;
 #[cfg(target_arch = "x86_64")]
-use crate::x86_64::Xsave;
-#[cfg(target_arch = "x86_64")]
 use crate::x86_64::{ExtendedControlRegisters, MsrEntries, VcpuEvents};
 use crate::CpuState;
 #[cfg(target_arch = "aarch64")]
@@ -351,16 +349,6 @@ pub trait Vcpu: Send + Sync {
     /// Sets the vcpu's current "multiprocessing state".
     ///
     fn set_mp_state(&self, mp_state: MpState) -> Result<()>;
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// X86 specific call that returns the vcpu's current "xsave struct".
-    ///
-    fn get_xsave(&self) -> Result<Xsave>;
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// X86 specific call that sets the vcpu's current "xsave struct".
-    ///
-    fn set_xsave(&self, xsave: &Xsave) -> Result<()>;
     #[cfg(target_arch = "x86_64")]
     ///
     /// X86 specific call that returns the vcpu's current "xcrs".

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -13,11 +13,9 @@ use crate::aarch64::VcpuInit;
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::{RegList, Register, StandardRegisters};
 #[cfg(target_arch = "x86_64")]
-use crate::arch::x86::{CpuIdEntry, FpuState, SpecialRegisters, StandardRegisters};
+use crate::arch::x86::{CpuIdEntry, FpuState, LapicState, SpecialRegisters, StandardRegisters};
 #[cfg(feature = "tdx")]
 use crate::kvm::{TdxExitDetails, TdxExitStatus};
-#[cfg(target_arch = "x86_64")]
-use crate::x86_64::LapicState;
 #[cfg(target_arch = "x86_64")]
 use crate::x86_64::MsrEntries;
 use crate::CpuState;

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -12,8 +12,6 @@ use crate::arch::x86::CpuIdEntry;
 #[cfg(feature = "tdx")]
 use crate::kvm::TdxCapabilities;
 use crate::vm::Vm;
-#[cfg(target_arch = "x86_64")]
-use crate::x86_64::MsrList;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -107,11 +105,6 @@ pub trait Hypervisor: Send + Sync {
     fn check_required_extensions(&self) -> Result<()> {
         Ok(())
     }
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// Retrieve the list of MSRs supported by the hypervisor.
-    ///
-    fn get_msr_list(&self) -> Result<MsrList>;
     #[cfg(target_arch = "aarch64")]
     ///
     /// Retrieve AArch64 host maximum IPA size supported by KVM.

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1426,24 +1426,6 @@ impl cpu::Vcpu for KvmVcpu {
     }
     #[cfg(target_arch = "x86_64")]
     ///
-    /// X86 specific call that returns the vcpu's current "xcrs".
-    ///
-    fn get_xcrs(&self) -> cpu::Result<ExtendedControlRegisters> {
-        self.fd
-            .get_xcrs()
-            .map_err(|e| cpu::HypervisorCpuError::GetXcsr(e.into()))
-    }
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// X86 specific call that sets the vcpu's current "xcrs".
-    ///
-    fn set_xcrs(&self, xcrs: &ExtendedControlRegisters) -> cpu::Result<()> {
-        self.fd
-            .set_xcrs(xcrs)
-            .map_err(|e| cpu::HypervisorCpuError::SetXcsr(e.into()))
-    }
-    #[cfg(target_arch = "x86_64")]
-    ///
     /// Translates guest virtual address to guest physical address using the `KVM_TRANSLATE` ioctl.
     ///
     fn translate_gva(&self, gva: u64, _flags: u64) -> cpu::Result<(u64, u32)> {
@@ -2105,6 +2087,24 @@ impl KvmVcpu {
         self.fd
             .set_xsave(xsave)
             .map_err(|e| cpu::HypervisorCpuError::SetXsaveState(e.into()))
+    }
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// X86 specific call that returns the vcpu's current "xcrs".
+    ///
+    fn get_xcrs(&self) -> cpu::Result<ExtendedControlRegisters> {
+        self.fd
+            .get_xcrs()
+            .map_err(|e| cpu::HypervisorCpuError::GetXcsr(e.into()))
+    }
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// X86 specific call that sets the vcpu's current "xcrs".
+    ///
+    fn set_xcrs(&self, xcrs: &ExtendedControlRegisters) -> cpu::Result<()> {
+        self.fd
+            .set_xcrs(xcrs)
+            .map_err(|e| cpu::HypervisorCpuError::SetXcsr(e.into()))
     }
 }
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1535,26 +1535,6 @@ impl cpu::Vcpu for KvmVcpu {
     }
     #[cfg(target_arch = "x86_64")]
     ///
-    /// Returns currently pending exceptions, interrupts, and NMIs as well as related
-    /// states of the vcpu.
-    ///
-    fn get_vcpu_events(&self) -> cpu::Result<VcpuEvents> {
-        self.fd
-            .get_vcpu_events()
-            .map_err(|e| cpu::HypervisorCpuError::GetVcpuEvents(e.into()))
-    }
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// Sets pending exceptions, interrupts, and NMIs as well as related states
-    /// of the vcpu.
-    ///
-    fn set_vcpu_events(&self, events: &VcpuEvents) -> cpu::Result<()> {
-        self.fd
-            .set_vcpu_events(events)
-            .map_err(|e| cpu::HypervisorCpuError::SetVcpuEvents(e.into()))
-    }
-    #[cfg(target_arch = "x86_64")]
-    ///
     /// Let the guest know that it has been paused, which prevents from
     /// potential soft lockups when being resumed.
     ///
@@ -2105,6 +2085,26 @@ impl KvmVcpu {
         self.fd
             .set_xcrs(xcrs)
             .map_err(|e| cpu::HypervisorCpuError::SetXcsr(e.into()))
+    }
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// Returns currently pending exceptions, interrupts, and NMIs as well as related
+    /// states of the vcpu.
+    ///
+    fn get_vcpu_events(&self) -> cpu::Result<VcpuEvents> {
+        self.fd
+            .get_vcpu_events()
+            .map_err(|e| cpu::HypervisorCpuError::GetVcpuEvents(e.into()))
+    }
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// Sets pending exceptions, interrupts, and NMIs as well as related states
+    /// of the vcpu.
+    ///
+    fn set_vcpu_events(&self, events: &VcpuEvents) -> cpu::Result<()> {
+        self.fd
+            .set_vcpu_events(events)
+            .map_err(|e| cpu::HypervisorCpuError::SetVcpuEvents(e.into()))
     }
 }
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1426,24 +1426,6 @@ impl cpu::Vcpu for KvmVcpu {
     }
     #[cfg(target_arch = "x86_64")]
     ///
-    /// X86 specific call that returns the vcpu's current "xsave struct".
-    ///
-    fn get_xsave(&self) -> cpu::Result<Xsave> {
-        self.fd
-            .get_xsave()
-            .map_err(|e| cpu::HypervisorCpuError::GetXsaveState(e.into()))
-    }
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// X86 specific call that sets the vcpu's current "xsave struct".
-    ///
-    fn set_xsave(&self, xsave: &Xsave) -> cpu::Result<()> {
-        self.fd
-            .set_xsave(xsave)
-            .map_err(|e| cpu::HypervisorCpuError::SetXsaveState(e.into()))
-    }
-    #[cfg(target_arch = "x86_64")]
-    ///
     /// X86 specific call that returns the vcpu's current "xcrs".
     ///
     fn get_xcrs(&self) -> cpu::Result<ExtendedControlRegisters> {
@@ -2102,6 +2084,27 @@ impl cpu::Vcpu for KvmVcpu {
             msr_data!(msr_index::MSR_MTRRdefType, MTRR_ENABLE | MTRR_MEM_TYPE_WB),
         ])
         .unwrap()
+    }
+}
+
+impl KvmVcpu {
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// X86 specific call that returns the vcpu's current "xsave struct".
+    ///
+    fn get_xsave(&self) -> cpu::Result<Xsave> {
+        self.fd
+            .get_xsave()
+            .map_err(|e| cpu::HypervisorCpuError::GetXsaveState(e.into()))
+    }
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// X86 specific call that sets the vcpu's current "xsave struct".
+    ///
+    fn set_xsave(&self, xsave: &Xsave) -> cpu::Result<()> {
+        self.fd
+            .set_xsave(xsave)
+            .map_err(|e| cpu::HypervisorCpuError::SetXsaveState(e.into()))
     }
 }
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -875,6 +875,19 @@ fn tdx_command(
 pub struct KvmHypervisor {
     kvm: Kvm,
 }
+
+impl KvmHypervisor {
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// Retrieve the list of MSRs supported by the hypervisor.
+    ///
+    fn get_msr_list(&self) -> hypervisor::Result<MsrList> {
+        self.kvm
+            .get_msr_index_list()
+            .map_err(|e| hypervisor::HypervisorError::GetMsrList(e.into()))
+    }
+}
+
 /// Enum for KVM related error
 #[derive(Debug, Error)]
 pub enum KvmError {
@@ -1003,15 +1016,6 @@ impl hypervisor::Hypervisor for KvmHypervisor {
         Ok(v)
     }
 
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// Retrieve the list of MSRs supported by KVM.
-    ///
-    fn get_msr_list(&self) -> hypervisor::Result<MsrList> {
-        self.kvm
-            .get_msr_index_list()
-            .map_err(|e| hypervisor::HypervisorError::GetMsrList(e.into()))
-    }
     #[cfg(target_arch = "aarch64")]
     ///
     /// Retrieve AArch64 host maximum IPA size supported by KVM.

--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -9,8 +9,8 @@
 //
 
 use crate::arch::x86::{
-    CpuIdEntry, DescriptorTable, FpuState, SegmentRegister, SpecialRegisters, StandardRegisters,
-    CPUID_FLAG_VALID_INDEX,
+    CpuIdEntry, DescriptorTable, FpuState, LapicState, SegmentRegister, SpecialRegisters,
+    StandardRegisters, CPUID_FLAG_VALID_INDEX,
 };
 use crate::kvm::{Cap, Kvm, KvmError, KvmResult};
 use serde::{Deserialize, Serialize};
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///
 pub use {
     kvm_bindings::kvm_cpuid_entry2, kvm_bindings::kvm_dtable, kvm_bindings::kvm_fpu,
-    kvm_bindings::kvm_lapic_state as LapicState, kvm_bindings::kvm_mp_state as MpState,
+    kvm_bindings::kvm_lapic_state, kvm_bindings::kvm_mp_state as MpState,
     kvm_bindings::kvm_msr_entry as MsrEntry, kvm_bindings::kvm_regs, kvm_bindings::kvm_segment,
     kvm_bindings::kvm_sregs, kvm_bindings::kvm_vcpu_events as VcpuEvents,
     kvm_bindings::kvm_xcrs as ExtendedControlRegisters, kvm_bindings::kvm_xsave as Xsave,
@@ -293,5 +293,22 @@ impl From<FpuState> for kvm_fpu {
             mxcsr: s.mxcsr,
             ..Default::default()
         }
+    }
+}
+
+impl From<LapicState> for kvm_lapic_state {
+    fn from(s: LapicState) -> Self {
+        match s {
+            LapicState::Kvm(s) => s,
+            /* Needed in case other hypervisors are enabled */
+            #[allow(unreachable_patterns)]
+            _ => panic!("LapicState is not valid"),
+        }
+    }
+}
+
+impl From<kvm_lapic_state> for LapicState {
+    fn from(s: kvm_lapic_state) -> Self {
+        LapicState::Kvm(s)
     }
 }

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -161,6 +161,18 @@ pub struct MshvHypervisor {
 }
 
 impl MshvHypervisor {
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// Retrieve the list of MSRs supported by MSHV.
+    ///
+    fn get_msr_list(&self) -> hypervisor::Result<MsrList> {
+        self.mshv
+            .get_msr_index_list()
+            .map_err(|e| hypervisor::HypervisorError::GetMsrList(e.into()))
+    }
+}
+
+impl MshvHypervisor {
     /// Create a hypervisor based on Mshv
     pub fn new() -> hypervisor::Result<MshvHypervisor> {
         let mshv_obj =
@@ -237,15 +249,6 @@ impl hypervisor::Hypervisor for MshvHypervisor {
     ///
     fn get_cpuid(&self) -> hypervisor::Result<Vec<CpuIdEntry>> {
         Ok(Vec::new())
-    }
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// Retrieve the list of MSRs supported by MSHV.
-    ///
-    fn get_msr_list(&self) -> hypervisor::Result<MsrList> {
-        self.mshv
-            .get_msr_index_list()
-            .map_err(|e| hypervisor::HypervisorError::GetMsrList(e.into()))
     }
 }
 

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -606,24 +606,6 @@ impl cpu::Vcpu for MshvVcpu {
     fn set_mp_state(&self, _mp_state: MpState) -> cpu::Result<()> {
         Ok(())
     }
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// X86 specific call that returns the vcpu's current "xsave struct".
-    ///
-    fn get_xsave(&self) -> cpu::Result<Xsave> {
-        self.fd
-            .get_xsave()
-            .map_err(|e| cpu::HypervisorCpuError::GetXsaveState(e.into()))
-    }
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// X86 specific call that sets the vcpu's current "xsave struct".
-    ///
-    fn set_xsave(&self, xsave: &Xsave) -> cpu::Result<()> {
-        self.fd
-            .set_xsave(xsave)
-            .map_err(|e| cpu::HypervisorCpuError::SetXsaveState(e.into()))
-    }
     ///
     /// Set CPU state
     ///
@@ -721,6 +703,27 @@ impl cpu::Vcpu for MshvVcpu {
             msr_data!(msr_index::MSR_MTRRdefType, MTRR_ENABLE | MTRR_MEM_TYPE_WB),
         ])
         .unwrap()
+    }
+}
+
+impl MshvVcpu {
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// X86 specific call that returns the vcpu's current "xsave struct".
+    ///
+    fn get_xsave(&self) -> cpu::Result<Xsave> {
+        self.fd
+            .get_xsave()
+            .map_err(|e| cpu::HypervisorCpuError::GetXsaveState(e.into()))
+    }
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// X86 specific call that sets the vcpu's current "xsave struct".
+    ///
+    fn set_xsave(&self, xsave: &Xsave) -> cpu::Result<()> {
+        self.fd
+            .set_xsave(xsave)
+            .map_err(|e| cpu::HypervisorCpuError::SetXsaveState(e.into()))
     }
 }
 

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -356,24 +356,6 @@ impl cpu::Vcpu for MshvVcpu {
 
     #[cfg(target_arch = "x86_64")]
     ///
-    /// X86 specific call that returns the vcpu's current "xcrs".
-    ///
-    fn get_xcrs(&self) -> cpu::Result<ExtendedControlRegisters> {
-        self.fd
-            .get_xcrs()
-            .map_err(|e| cpu::HypervisorCpuError::GetXcsr(e.into()))
-    }
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// X86 specific call that sets the vcpu's current "xcrs".
-    ///
-    fn set_xcrs(&self, xcrs: &ExtendedControlRegisters) -> cpu::Result<()> {
-        self.fd
-            .set_xcrs(xcrs)
-            .map_err(|e| cpu::HypervisorCpuError::SetXcsr(e.into()))
-    }
-    #[cfg(target_arch = "x86_64")]
-    ///
     /// Returns currently pending exceptions, interrupts, and NMIs as well as related
     /// states of the vcpu.
     ///
@@ -724,6 +706,24 @@ impl MshvVcpu {
         self.fd
             .set_xsave(xsave)
             .map_err(|e| cpu::HypervisorCpuError::SetXsaveState(e.into()))
+    }
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// X86 specific call that returns the vcpu's current "xcrs".
+    ///
+    fn get_xcrs(&self) -> cpu::Result<ExtendedControlRegisters> {
+        self.fd
+            .get_xcrs()
+            .map_err(|e| cpu::HypervisorCpuError::GetXcsr(e.into()))
+    }
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// X86 specific call that sets the vcpu's current "xcrs".
+    ///
+    fn set_xcrs(&self, xcrs: &ExtendedControlRegisters) -> cpu::Result<()> {
+        self.fd
+            .set_xcrs(xcrs)
+            .map_err(|e| cpu::HypervisorCpuError::SetXcsr(e.into()))
     }
 }
 

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -356,26 +356,6 @@ impl cpu::Vcpu for MshvVcpu {
 
     #[cfg(target_arch = "x86_64")]
     ///
-    /// Returns currently pending exceptions, interrupts, and NMIs as well as related
-    /// states of the vcpu.
-    ///
-    fn get_vcpu_events(&self) -> cpu::Result<VcpuEvents> {
-        self.fd
-            .get_vcpu_events()
-            .map_err(|e| cpu::HypervisorCpuError::GetVcpuEvents(e.into()))
-    }
-    #[cfg(target_arch = "x86_64")]
-    ///
-    /// Sets pending exceptions, interrupts, and NMIs as well as related states
-    /// of the vcpu.
-    ///
-    fn set_vcpu_events(&self, events: &VcpuEvents) -> cpu::Result<()> {
-        self.fd
-            .set_vcpu_events(events)
-            .map_err(|e| cpu::HypervisorCpuError::SetVcpuEvents(e.into()))
-    }
-    #[cfg(target_arch = "x86_64")]
-    ///
     /// X86 specific call to enable HyperV SynIC
     ///
     fn enable_hyperv_synic(&self) -> cpu::Result<()> {
@@ -724,6 +704,26 @@ impl MshvVcpu {
         self.fd
             .set_xcrs(xcrs)
             .map_err(|e| cpu::HypervisorCpuError::SetXcsr(e.into()))
+    }
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// Returns currently pending exceptions, interrupts, and NMIs as well as related
+    /// states of the vcpu.
+    ///
+    fn get_vcpu_events(&self) -> cpu::Result<VcpuEvents> {
+        self.fd
+            .get_vcpu_events()
+            .map_err(|e| cpu::HypervisorCpuError::GetVcpuEvents(e.into()))
+    }
+    #[cfg(target_arch = "x86_64")]
+    ///
+    /// Sets pending exceptions, interrupts, and NMIs as well as related states
+    /// of the vcpu.
+    ///
+    fn set_vcpu_events(&self, events: &VcpuEvents) -> cpu::Result<()> {
+        self.fd
+            .set_vcpu_events(events)
+            .map_err(|e| cpu::HypervisorCpuError::SetVcpuEvents(e.into()))
     }
 }
 

--- a/hypervisor/src/mshv/x86_64/mod.rs
+++ b/hypervisor/src/mshv/x86_64/mod.rs
@@ -8,7 +8,8 @@
 //
 //
 use crate::arch::x86::{
-    CpuIdEntry, DescriptorTable, FpuState, SegmentRegister, SpecialRegisters, StandardRegisters,
+    CpuIdEntry, DescriptorTable, FpuState, LapicState, SegmentRegister, SpecialRegisters,
+    StandardRegisters,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -19,7 +20,7 @@ use std::fmt;
 pub use {
     mshv_bindings::hv_cpuid_entry, mshv_bindings::mshv_user_mem_region as MemoryRegion,
     mshv_bindings::msr_entry as MsrEntry, mshv_bindings::CpuId, mshv_bindings::DebugRegisters,
-    mshv_bindings::FloatingPointUnit, mshv_bindings::LapicState,
+    mshv_bindings::FloatingPointUnit, mshv_bindings::LapicState as MshvLapicState,
     mshv_bindings::MiscRegs as MiscRegisters, mshv_bindings::MsrList,
     mshv_bindings::Msrs as MsrEntries, mshv_bindings::Msrs,
     mshv_bindings::SegmentRegister as MshvSegmentRegister,
@@ -283,5 +284,22 @@ impl From<FpuState> for FloatingPointUnit {
             mxcsr: s.mxcsr,
             ..Default::default()
         }
+    }
+}
+
+impl From<LapicState> for MshvLapicState {
+    fn from(s: LapicState) -> Self {
+        match s {
+            LapicState::Mshv(s) => s,
+            /* Needed in case other hypervisors are enabled */
+            #[allow(unreachable_patterns)]
+            _ => panic!("LapicState is not valid"),
+        }
+    }
+}
+
+impl From<MshvLapicState> for LapicState {
+    fn from(s: MshvLapicState) -> Self {
+        LapicState::Mshv(s)
     }
 }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -2336,8 +2336,7 @@ impl CpuElf64Writable for CpuManager {
 mod tests {
     use arch::x86_64::interrupts::*;
     use arch::x86_64::regs::*;
-    use hypervisor::arch::x86::{FpuState, StandardRegisters};
-    use hypervisor::x86_64::LapicState;
+    use hypervisor::arch::x86::{FpuState, LapicState, StandardRegisters};
 
     #[test]
     fn test_setlint() {
@@ -2350,8 +2349,8 @@ mod tests {
         let klapic_before: LapicState = vcpu.get_lapic().unwrap();
 
         // Compute the value that is expected to represent LVT0 and LVT1.
-        let lint0 = get_klapic_reg(&klapic_before, APIC_LVT0);
-        let lint1 = get_klapic_reg(&klapic_before, APIC_LVT1);
+        let lint0 = klapic_before.get_klapic_reg(APIC_LVT0);
+        let lint1 = klapic_before.get_klapic_reg(APIC_LVT1);
         let lint0_mode_expected = set_apic_delivery_mode(lint0, APIC_MODE_EXTINT);
         let lint1_mode_expected = set_apic_delivery_mode(lint1, APIC_MODE_NMI);
 
@@ -2359,8 +2358,8 @@ mod tests {
 
         // Compute the value that represents LVT0 and LVT1 after set_lint.
         let klapic_actual: LapicState = vcpu.get_lapic().unwrap();
-        let lint0_mode_actual = get_klapic_reg(&klapic_actual, APIC_LVT0);
-        let lint1_mode_actual = get_klapic_reg(&klapic_actual, APIC_LVT1);
+        let lint0_mode_actual = klapic_actual.get_klapic_reg(APIC_LVT0);
+        let lint1_mode_actual = klapic_actual.get_klapic_reg(APIC_LVT1);
         assert_eq!(lint0_mode_expected, lint0_mode_actual);
         assert_eq!(lint1_mode_expected, lint1_mode_actual);
     }


### PR DESCRIPTION
In this PR I attempted to reduce the amount of generic structures needed by dropping some of the trait methods.

If there are needs in the future for those structures outside of the hypervisor crate we can always introduce them back to the trait.