### PR TITLE
virtio-devices: Ensure queue indexes are correct

### DIFF
--- a/fuzz/fuzz_targets/block.rs
+++ b/fuzz/fuzz_targets/block.rs
@@ -84,9 +84,8 @@ fuzz_target!(|bytes| {
     q.state.ready = true;
     q.state.size = QUEUE_SIZE / 2;
 
-    let queue_evts: Vec<EventFd> = vec![EventFd::new(0).unwrap()];
-    let queue_fd = queue_evts[0].as_raw_fd();
-    let queue_evt = unsafe { EventFd::from_raw_fd(libc::dup(queue_fd)) };
+    let evt = EventFd::new(0).unwrap();
+    let queue_evt = unsafe { EventFd::from_raw_fd(libc::dup(evt.as_raw_fd())) };
 
     let shm = memfd_create(&ffi::CString::new("fuzz").unwrap(), 0).unwrap();
     let disk_file: File = unsafe { File::from_raw_fd(shm) };
@@ -110,8 +109,7 @@ fuzz_target!(|bytes| {
         .activate(
             guest_memory,
             Arc::new(NoopVirtioInterrupt {}),
-            vec![q],
-            queue_evts,
+            vec![(0, q, evt)],
         )
         .ok();
 

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -385,8 +385,7 @@ mod tests {
             &mut self,
             _mem: GuestMemoryAtomic<GuestMemoryMmap>,
             _interrupt_evt: Arc<dyn VirtioInterrupt>,
-            _queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
-            _queue_evts: Vec<EventFd>,
+            _queues: Vec<(usize, Queue<GuestMemoryAtomic<GuestMemoryMmap>>, EventFd)>,
         ) -> ActivateResult {
             Ok(())
         }

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -342,11 +342,7 @@ impl VirtioDevice for Blk {
         }
 
         if let Some(vu) = &self.vu_common.vu {
-            if let Err(e) = vu
-                .lock()
-                .unwrap()
-                .reset_vhost_user(self.common.queue_sizes.len())
-            {
+            if let Err(e) = vu.lock().unwrap().reset_vhost_user() {
                 error!("Failed to reset vhost-user daemon: {:?}", e);
                 return None;
             }

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -292,10 +292,9 @@ impl VirtioDevice for Blk {
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
         interrupt_cb: Arc<dyn VirtioInterrupt>,
-        queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
-        queue_evts: Vec<EventFd>,
+        queues: Vec<(usize, Queue<GuestMemoryAtomic<GuestMemoryMmap>>, EventFd)>,
     ) -> ActivateResult {
-        self.common.activate(&queues, &queue_evts, &interrupt_cb)?;
+        self.common.activate(&queues, &interrupt_cb)?;
         self.guest_memory = Some(mem.clone());
 
         let slave_req_handler: Option<MasterReqHandler<SlaveReqHandler>> = None;
@@ -307,7 +306,6 @@ impl VirtioDevice for Blk {
         let mut handler = self.vu_common.activate(
             mem,
             queues,
-            queue_evts,
             interrupt_cb,
             self.common.acked_features,
             slave_req_handler,

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -333,7 +333,7 @@ impl Fs {
                     device_type: VirtioDeviceType::Fs as u32,
                     queue_sizes: vec![queue_size; num_queues],
                     paused_sync: Some(Arc::new(Barrier::new(2))),
-                    min_queues: DEFAULT_QUEUE_NUMBER as u16,
+                    min_queues: 1,
                     ..Default::default()
                 },
                 vu_common: VhostUserCommon {
@@ -413,7 +413,7 @@ impl Fs {
                 acked_features: acked_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits(),
                 queue_sizes: vec![queue_size; num_queues],
                 paused_sync: Some(Arc::new(Barrier::new(2))),
-                min_queues: DEFAULT_QUEUE_NUMBER as u16,
+                min_queues: 1,
                 ..Default::default()
             },
             vu_common: VhostUserCommon {

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -582,11 +582,7 @@ impl VirtioDevice for Fs {
         }
 
         if let Some(vu) = &self.vu_common.vu {
-            if let Err(e) = vu
-                .lock()
-                .unwrap()
-                .reset_vhost_user(self.common.queue_sizes.len())
-            {
+            if let Err(e) = vu.lock().unwrap().reset_vhost_user() {
                 error!("Failed to reset vhost-user daemon: {:?}", e);
                 return None;
             }

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -504,10 +504,9 @@ impl VirtioDevice for Fs {
         &mut self,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
         interrupt_cb: Arc<dyn VirtioInterrupt>,
-        queues: Vec<Queue<GuestMemoryAtomic<GuestMemoryMmap>>>,
-        queue_evts: Vec<EventFd>,
+        queues: Vec<(usize, Queue<GuestMemoryAtomic<GuestMemoryMmap>>, EventFd)>,
     ) -> ActivateResult {
-        self.common.activate(&queues, &queue_evts, &interrupt_cb)?;
+        self.common.activate(&queues, &interrupt_cb)?;
         self.guest_memory = Some(mem.clone());
 
         // Initialize slave communication.
@@ -547,7 +546,6 @@ impl VirtioDevice for Fs {
         let mut handler = self.vu_common.activate(
             mem,
             queues,
-            queue_evts,
             interrupt_cb,
             self.common.acked_features,
             slave_req_handler,

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -401,12 +401,9 @@ impl VhostUserCommon {
 
     pub fn pause(&mut self) -> std::result::Result<(), MigratableError> {
         if let Some(vu) = &self.vu {
-            vu.lock()
-                .unwrap()
-                .pause_vhost_user(self.vu_num_queues)
-                .map_err(|e| {
-                    MigratableError::Pause(anyhow!("Error pausing vhost-user-blk backend: {:?}", e))
-                })
+            vu.lock().unwrap().pause_vhost_user().map_err(|e| {
+                MigratableError::Pause(anyhow!("Error pausing vhost-user-blk backend: {:?}", e))
+            })
         } else {
             Ok(())
         }
@@ -414,15 +411,9 @@ impl VhostUserCommon {
 
     pub fn resume(&mut self) -> std::result::Result<(), MigratableError> {
         if let Some(vu) = &self.vu {
-            vu.lock()
-                .unwrap()
-                .resume_vhost_user(self.vu_num_queues)
-                .map_err(|e| {
-                    MigratableError::Resume(anyhow!(
-                        "Error resuming vhost-user-blk backend: {:?}",
-                        e
-                    ))
-                })
+            vu.lock().unwrap().resume_vhost_user().map_err(|e| {
+                MigratableError::Resume(anyhow!("Error resuming vhost-user-blk backend: {:?}", e))
+            })
         } else {
             Ok(())
         }

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -369,11 +369,7 @@ impl VirtioDevice for Net {
         }
 
         if let Some(vu) = &self.vu_common.vu {
-            if let Err(e) = vu
-                .lock()
-                .unwrap()
-                .reset_vhost_user(self.common.queue_sizes.len())
-            {
+            if let Err(e) = vu.lock().unwrap().reset_vhost_user() {
                 error!("Failed to reset vhost-user daemon: {:?}", e);
                 return None;
             }

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -294,6 +294,11 @@ impl VhostUserHandle {
             self.vu
                 .set_vring_enable(queue_index, false)
                 .map_err(Error::VhostUserSetVringEnable)?;
+
+            let _ = self
+                .vu
+                .get_vring_base(queue_index)
+                .map_err(Error::VhostUserGetVringBase)?;
         }
 
         Ok(())


### PR DESCRIPTION
There were some assumptions in the code preventing some virtio queues from not being activated. This was mainly related to the fact that in such case the queue index would be determined in the wrong way and lead to unexpected behaviors.

This PR is also taking care of fixing the vhost-user common code so that virtio-fs can handle not having the `hiprio` queue activated and also be able to support a virtio reset. All these fixes allows to boot a Cloud Hypervisor VM with a virtio-fs backend attached along with using the EDK2 firmware. (Some patches from vhost-user-backend will be needed to fix `virtiofsd` as well).