### PR TITLE
tests: Fix test_virtio_balloon_deflate_on_oom()

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5069,6 +5069,10 @@ mod parallel {
                 .ssh_command("stress --vm 25 --vm-keep --vm-bytes 1G --timeout 20")
                 .unwrap();
 
+            // Give some time for the OOM to happen in the guest and be reported
+            // back to the host.
+            thread::sleep(std::time::Duration::new(20, 0));
+
             // 2nd: check balloon_mem's value to verify balloon has been automatically deflated
             let deflated_balloon = balloon_size(&api_socket);
             println!(


### PR DESCRIPTION
It might sometimes take a few seconds for the guest to trigger the OOM
and report it back to the host. That's why this patch adds some sleep
time between the command in the guest supposedly triggering the OOM and
the check of the balloon size from the host.

Fixes #4336

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>