### PR TITLE
api-client: Break the receive loop if the VMM shuts down the socket

### DIFF
--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -101,6 +101,10 @@ fn parse_http_response(socket: &mut dyn Read) -> Result<Option<String>, Error> {
     loop {
         let mut bytes = vec![0; 256];
         let count = socket.read(&mut bytes).map_err(Error::Socket)?;
+        // If the return value is 0, the peer has performed an orderly shutdown.
+        if count == 0 {
+            break;
+        }
         res.push_str(std::str::from_utf8(&bytes[0..count]).unwrap());
 
         // End of headers


### PR DESCRIPTION
Breaks the receive loop of the API client when the VMM shuts down the
socket connection. A shutdown is indicated by the return value 0 of the
`recv()` system call.[^1][^2] This case was not handled before, so the
API client tried infinitely to receive more bytes and did not return.

[^1]: https://linux.die.net/man/2/recv
[^2]: https://doc.rust-lang.org/std/io/trait.Read.html#tymethod.read