### PR TITLE
vmm: Make gdb break/resuming more resilient

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1487,10 +1487,6 @@ impl CpuManager {
             .map_err(Error::TranslateVirtualAddress)?;
         Ok(gpa)
     }
-
-    pub fn vcpus_paused(&self) -> bool {
-        self.vcpus_pause_signalled.load(Ordering::SeqCst)
-    }
 }
 
 struct Cpu {


### PR DESCRIPTION
When starting the VM such that it is already on a breakpoint (via
stop_on_boot) when attached to gdb then start the vCPUs in a paused
state rather than starting the vCPUs later (upon resume).

Further, make the resumption/break of the VM more resilient by only
attempting to resume the vCPUs if were are already in a break point and
only attempting to pause/break if we were already running.

Fixes: #4354

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
