### PR TITLE
Improve ACPI platform device address handling

### DIFF
--- a/acpi_tables/src/sdt.rs
+++ b/acpi_tables/src/sdt.rs
@@ -4,6 +4,7 @@
 //
 
 #[repr(packed)]
+#[derive(Clone, Copy)]
 pub struct GenericAddress {
     pub address_space_id: u8,
     pub register_bit_width: u8,


### PR DESCRIPTION
Make it easier to change the bus addresses by storing them in one canonical place.

- vmm: device_manager: Store ACPI platform addresses for later use
- vmm: acpi: Use ACPI platform device addresses from DeviceManager
