### PR TITLE
api-client: Handle body_offset is None

### DIFF
--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -127,7 +127,7 @@ fn parse_http_response(socket: &mut dyn Read) -> Result<Option<String>, Error> {
             }
         }
     }
-    let body_string = content_length.and(Some(String::from(&res[body_offset.unwrap()..])));
+    let body_string = content_length.and(body_offset.map(|o| String::from(&res[o..])));
     let status_code = get_status_code(&res)?;
 
     if status_code.is_server_error() {


### PR DESCRIPTION
Introduce a match expression for `body_offset` to handle the `None`
case instead of calling `unwrap()` which leads to a panic.