### PR TITLE
boot from direct kernel when firmware boot

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -470,6 +470,20 @@ fn create_rtc_node<T: DeviceInfoForFdt + Clone + Debug>(
     Ok(())
 }
 
+fn create_fw_cfg_node<T: DeviceInfoForFdt + Clone + Debug>(
+    fdt: &mut FdtWriter,
+    dev_info: &T,
+) -> FdtWriterResult<()> {
+    let compatible = b"qemu,fw-cfg-mmio";
+    let fw_cfg_reg_prop = [dev_info.addr(), dev_info.length()];
+
+    let fw_cfg_node = fdt.begin_node(&format!("fw-cfg@{:x}", dev_info.addr()))?;
+    fdt.property("compatible", compatible)?;
+    fdt.property_array_u64("reg", &fw_cfg_reg_prop)?;
+    fdt.end_node(fw_cfg_node)?;
+    Ok(())
+}
+
 fn create_gpio_node<T: DeviceInfoForFdt + Clone + Debug>(
     fdt: &mut FdtWriter,
     dev_info: &T,
@@ -521,6 +535,7 @@ fn create_devices_node<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::Buil
         match device_type {
             DeviceType::Gpio => create_gpio_node(fdt, info)?,
             DeviceType::Rtc => create_rtc_node(fdt, info)?,
+            DeviceType::FwCfg => create_fw_cfg_node(fdt, info)?,
             DeviceType::Serial => create_serial_node(fdt, info)?,
             DeviceType::Virtio(_) => {
                 ordered_virtio_device.push(info);

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -76,6 +76,7 @@ pub const GIC_V3_ITS_SIZE: u64 = 0x02_0000;
 pub const LEGACY_SERIAL_MAPPED_IO_START: GuestAddress = GuestAddress(0x0900_0000);
 pub const LEGACY_RTC_MAPPED_IO_START: GuestAddress = GuestAddress(0x0901_0000);
 pub const LEGACY_GPIO_MAPPED_IO_START: GuestAddress = GuestAddress(0x0902_0000);
+pub const LEGACY_FW_CFG_MAPPED_IO_START: GuestAddress = GuestAddress(0x0903_0000);
 
 /// Space 0x0905_0000 ~ 0x0906_0000 is reserved for pcie io address
 pub const MEM_PCI_IO_START: GuestAddress = GuestAddress(0x0905_0000);

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -138,6 +138,9 @@ pub enum DeviceType {
     /// Device Type: GPIO.
     #[cfg(target_arch = "aarch64")]
     Gpio,
+    /// Device Type: fw_cfg.
+    #[cfg(target_arch = "aarch64")]
+    FwCfg,
 }
 
 /// Default (smallest) memory page size for the supported architectures.

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -1,0 +1,448 @@
+// Copyright 2022 Arm Limited (or its affiliates). All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Firmware Configuration (fw_cfg) Device
+//!
+//! Derived from QEMU. Introduced it here to conceal grub boot when boot from firmware
+//! and reuse fw_cfg device driver in edk2.
+//! This hardware interface allows the guest to retrieve various data items (blobs) that
+//! can influence how the firmware configures itself.
+//! More info see https://github.com/qemu/qemu/blob/master/docs/specs/fw_cfg.rst
+//!
+use crate::{read_be_u16, read_be_u32, read_be_u64, write_be_u16, write_be_u32, write_be_u64};
+use std::fmt;
+use std::sync::Arc;
+use std::sync::Barrier;
+use std::{io, result};
+use versionize::{VersionMap, Versionize, VersionizeResult};
+use versionize_derive::Versionize;
+use vm_device::BusDevice;
+use vm_memory::bitmap::AtomicBitmap;
+use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_migration::{
+    Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable, VersionMapped,
+};
+
+const FW_CFG_VERSION: u32 = 0x01;
+const FW_CFG_DMA_ENABLED: u32 = 0x02;
+const FW_CFG_DMA_SIGNATURE: u64 = 0x51454d5520434647;
+
+// Fw_cfg key used for identify the fw_cfg entry
+pub const FW_CFG_SIGNATURE: u16 = 0x00;
+pub const FW_CFG_ID: u16 = 0x01;
+pub const FW_CFG_KERNEL_ADDR: u16 = 0x07;
+pub const FW_CFG_KERNEL_SIZE: u16 = 0x08;
+pub const FW_CFG_KERNEL_CMDLINE: u16 = 0x09;
+pub const FW_CFG_KERNEL_ENTRY: u16 = 0x10;
+pub const FW_CFG_KERNEL_DATA: u16 = 0x11;
+pub const FW_CFG_CMDLINE_ADDR: u16 = 0x13;
+pub const FW_CFG_CMDLINE_SIZE: u16 = 0x14;
+pub const FW_CFG_CMDLINE_DATA: u16 = 0x15;
+const FW_CFG_LAST_KEY: u16 = 0x15;
+
+// Fw_cfg dma control bits
+const FW_CFG_DMA_CTL_ERROR: u32 = 0x01;
+const FW_CFG_DMA_CTL_READ: u32 = 0x02;
+const FW_CFG_DMA_CTL_SKIP: u32 = 0x04;
+const FW_CFG_DMA_CTL_SELECT: u32 = 0x08;
+
+// Fw_cfg register offset of its MMIO region
+const FW_CFG_REG_CTL_OFFSET: u64 = 8;
+const FW_CFG_REG_DATA_OFFSET: u64 = 0;
+const FW_CFG_REG_DMA_OFFSET: u64 = 16;
+
+#[derive(Debug)]
+pub enum Error {
+    FwCfgCtlSelectError(io::Error),
+    FwCfgGetDmaUserAddrErr,
+    FwCfgDmaReadErr(io::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::FwCfgCtlSelectError(e) => {
+                write!(f, "Write fw_cfg select register: {}", e)
+            }
+            Error::FwCfgGetDmaUserAddrErr => {
+                write!(f, "fw_cfg get dma user address error")
+            }
+            Error::FwCfgDmaReadErr(e) => {
+                write!(f, "fw_cfg dma read error: {}", e)
+            }
+        }
+    }
+}
+
+type Result<T> = result::Result<T, Error>;
+
+// Convert u64 from big endianness to little endianness
+fn be_to_le(data: u64, len: usize) -> u64 {
+    let mut ret: u64 = 0;
+    let mut d: u64 = data;
+
+    for _ in 0..len {
+        ret <<= 8;
+        ret |= d & 0xff;
+        d >>= 8;
+    }
+
+    ret
+}
+
+#[derive(Versionize, Clone)]
+pub struct FWCfgEntry {
+    pub len: u32,
+    pub data: Option<Box<Vec<u8>>>,
+}
+
+impl FWCfgEntry {
+    fn new() -> Self {
+        Self { len: 0, data: None }
+    }
+}
+
+#[derive(Versionize)]
+pub struct FWCfgStateSnapShotData {
+    id: String,
+    entries: Option<Box<Vec<FWCfgEntry>>>,
+    entry_order: i32,
+    pub cur_entry: u16,
+    cur_offset: u32,
+    dma_addr: u64,
+}
+
+impl FWCfgStateSnapShotData {
+    pub fn new(id: String) -> FWCfgStateSnapShotData {
+        Self {
+            id,
+            entries: None,
+            entry_order: 0,
+            cur_entry: 0,
+            cur_offset: 0,
+            dma_addr: 0,
+        }
+    }
+
+    fn state(&self) -> FWCfgStateSnapShotData {
+        let e = self.entries.as_ref().unwrap().clone();
+        let e = Some(e);
+        FWCfgStateSnapShotData {
+            id: self.id.clone(),
+            entries: e,
+            entry_order: self.entry_order,
+            cur_entry: self.cur_entry,
+            cur_offset: self.cur_offset,
+            dma_addr: self.dma_addr,
+        }
+    }
+
+    fn set_state(&mut self, state: &FWCfgStateSnapShotData) {
+        let e = state.entries.as_ref().unwrap().clone();
+        let e = Some(e);
+        self.id = state.id.clone();
+        self.entries = e;
+        self.entry_order = state.entry_order;
+        self.cur_entry = state.cur_entry;
+        self.cur_offset = state.cur_offset;
+        self.dma_addr = state.dma_addr;
+    }
+}
+
+pub struct FWCfgState {
+    core_data: FWCfgStateSnapShotData,
+    memory: GuestMemoryAtomic<GuestMemoryMmap<AtomicBitmap>>,
+}
+
+impl FWCfgState {
+    pub fn new(id: String, mem: GuestMemoryAtomic<GuestMemoryMmap<AtomicBitmap>>) -> Self {
+        let core = FWCfgStateSnapShotData::new(id);
+        Self {
+            core_data: core,
+            memory: mem,
+        }
+    }
+
+    pub fn init(&mut self) {
+        let vec: Vec<FWCfgEntry> = Vec::new();
+        let b = Box::new(vec);
+        self.core_data.entries = Some(b);
+
+        for _ in 0..FW_CFG_LAST_KEY + 1 {
+            let e = FWCfgEntry::new();
+            self.core_data.entries.as_mut().unwrap().push(e);
+        }
+        let mut version: u32 = FW_CFG_VERSION;
+        version |= FW_CFG_DMA_ENABLED;
+        self.add_string(FW_CFG_SIGNATURE, "QEMU");
+        self.add_i32(FW_CFG_ID, version as i32);
+    }
+
+    pub fn select(&mut self, key: u16) {
+        self.core_data.cur_entry = key;
+        self.core_data.cur_offset = 0;
+    }
+
+    pub fn add_bytes(&mut self, key: u16, data: Option<Box<Vec<u8>>>, len: u32) {
+        if let Some(e) = &mut self.core_data.entries {
+            e[key as usize].data = data;
+            e[key as usize].len = len;
+        }
+    }
+
+    pub fn add_string(&mut self, key: u16, value: &str) {
+        let v: Vec<u8> = value.as_bytes().to_vec();
+        let l = v.len();
+        let b = Box::new(v);
+        self.add_bytes(key, Some(b), l as u32);
+    }
+
+    pub fn add_i32(&mut self, key: u16, value: i32) {
+        let mut v = Vec::new();
+        let tmp = &mut v;
+        let mut val = value;
+        for _ in 0..4 {
+            tmp.push(val as u8 & 0xff);
+            val >>= 8;
+        }
+        let d = Box::new(v);
+        self.add_bytes(key, Some(d), 4);
+    }
+
+    // Read buff from location specified by source_va(HVA) to location specified by dest_gpa(GPA)
+    fn dma_read(
+        &self,
+        source_va: u64,
+        dest_gpa: u64,
+        size: usize,
+    ) -> std::result::Result<(), io::Error> {
+        let mem = self.memory.memory();
+        let guest_addr = GuestAddress(dest_gpa);
+        let user_addr = if mem.check_range(guest_addr, size) {
+            mem.get_host_address(guest_addr).unwrap() as u64
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "failed to convert guest address 0x{:x} into \
+                        host user virtual address",
+                    dest_gpa
+                ),
+            ));
+        };
+
+        // Copy memory region from source_va to dest_gpa
+        unsafe {
+            std::ptr::copy(source_va as *const u8, user_addr as *mut u8, size);
+        }
+
+        Ok(())
+    }
+
+    // Transfer data specified by self.cur_entry to buff specified by self.dam_addr(GPA)
+    fn dma_transfer(&mut self) -> Result<()> {
+        let mut control: u32;
+        let mut length: u32;
+        let mut address: u64;
+
+        let mem = self.memory.memory();
+        let guest_addr = GuestAddress(self.core_data.dma_addr);
+        let user_addr = if mem.check_range(guest_addr, 16) {
+            mem.get_host_address(guest_addr).unwrap() as u64
+        } else {
+            return Err(Error::FwCfgGetDmaUserAddrErr);
+        };
+        let pctl = user_addr as *mut u32;
+        let mut ret = 0;
+
+        // Get FWCfgDmaAccess feilds: control, length and address all of which are in big endianness mode.
+        unsafe {
+            let c = user_addr as *const u32;
+            control = *c;
+            control = be_to_le(control as u64, 4) as u32;
+
+            let l = (user_addr + 4) as *const u32;
+            length = *l;
+            length = be_to_le(length as u64, 4) as u32;
+
+            let a = (user_addr + 8) as *const u64;
+            address = *a;
+            address = be_to_le(address, 8);
+        }
+
+        // Let guest handle these error
+        if self.core_data.dma_addr == 0 {
+            ret |= FW_CFG_DMA_CTL_ERROR;
+        }
+        if ret & FW_CFG_DMA_CTL_ERROR != 0 || self.core_data.cur_entry > FW_CFG_LAST_KEY {
+            unsafe {
+                *pctl = ret;
+            }
+
+            return Ok(());
+        }
+
+        // FW_CFG_DMA_CTL_SELECT means the top 16bits of select register stores the selected entry key
+        if control & FW_CFG_DMA_CTL_SELECT != 0 {
+            self.select((control >> 16) as u16);
+        }
+
+        let len = self.core_data.entries.as_ref().unwrap()[self.core_data.cur_entry as usize].len;
+        if length > len - self.core_data.cur_offset {
+            length = len - self.core_data.cur_offset;
+        }
+
+        // Just handle dma read and skip
+        if control & FW_CFG_DMA_CTL_READ != 0 {
+            if let Some(e) = &self.core_data.entries {
+                if let Some(d) = &e[self.core_data.cur_entry as usize].data {
+                    let data_addr: u64 = d.as_ptr() as u64;
+                    // Read data from region start specified by data_addr to buff specified by address
+                    if let Err(e) = self.dma_read(
+                        (data_addr + self.core_data.cur_offset as u64) as u64,
+                        address,
+                        length as usize,
+                    ) {
+                        // Before return error we need tell the guest what happend
+                        unsafe {
+                            *pctl = FW_CFG_DMA_CTL_ERROR;
+                        }
+                        return Err(Error::FwCfgDmaReadErr(e));
+                    }
+                    self.core_data.cur_offset += length;
+                }
+            }
+        } else if control & FW_CFG_DMA_CTL_SKIP != 0 {
+            self.core_data.cur_offset += length;
+        } else {
+            ret |= FW_CFG_DMA_CTL_ERROR;
+        }
+
+        unsafe {
+            *pctl = ret;
+        }
+
+        Ok(())
+    }
+
+    fn data_read(&mut self, offset: u64, size: usize) -> Option<u64> {
+        let mut value: u64 = 0;
+
+        // Read dma register will return FW_CFG_DMA_SIGNATURE indicating dma is enabled
+        if offset == FW_CFG_REG_DMA_OFFSET {
+            value = FW_CFG_DMA_SIGNATURE;
+            return Some(value);
+        }
+
+        // Control register is write only
+        if offset != FW_CFG_REG_DATA_OFFSET
+            || self.core_data.cur_entry > FW_CFG_LAST_KEY
+            || size > 8
+        {
+            return Some(value);
+        }
+
+        // Read data from data register which the length of data specified by size.
+        let mut sz = size;
+        let len = self.core_data.entries.as_ref().unwrap()[self.core_data.cur_entry as usize].len;
+        if let Some(e) = &self.core_data.entries {
+            if let Some(d) = &e[self.core_data.cur_entry as usize].data {
+                while sz > 0 && self.core_data.cur_offset < len {
+                    value = value << 8 | d[self.core_data.cur_offset as usize] as u64;
+                    self.core_data.cur_offset += 1;
+                    sz -= 1;
+                }
+
+                if sz > 0 {
+                    value = value << (8 * sz);
+                }
+
+                return Some(value);
+            }
+        }
+
+        None
+    }
+
+    fn data_write(&mut self, offset: u64, value: u64, len: usize) -> Result<()> {
+        match offset {
+            // Data in Selector (Control) Register is big endianness for MMIO.
+            // Selector (Control) Register is 2 bytes wide.
+            // Data Register is read-only
+            FW_CFG_REG_CTL_OFFSET => self.select(value as u16),
+            // Dma write can be in one 8-bytes or two 4-bytes, after write is done, dma transfer will be fired off
+            FW_CFG_REG_DMA_OFFSET => {
+                if len == 8 {
+                    self.core_data.dma_addr = value;
+                    self.dma_transfer()?
+                } else if len == 4 {
+                    self.core_data.dma_addr = value << 32;
+                }
+            }
+            20 => {
+                if len == 4 {
+                    self.core_data.dma_addr |= value;
+                    self.dma_transfer()?
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+impl BusDevice for FWCfgState {
+    // Data for MMIO is in big endianness format
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
+        if let Some(d) = self.data_read(offset, data.len()) {
+            match data.len() {
+                1 => data[0] = d as u8,
+                2 => write_be_u16(data, d as u16),
+                4 => write_be_u32(data, d as u32),
+                8 => write_be_u64(data, d),
+                _ => {}
+            }
+        }
+    }
+
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        let mut len = data.len();
+        if len > 8 {
+            len = 8
+        }
+        let value: u64 = match len {
+            1 => data[0] as u64,
+            2 => read_be_u16(data) as u64,
+            4 => read_be_u32(data) as u64,
+            8 => read_be_u64(data),
+            _ => 0,
+        };
+        if let Err(e) = self.data_write(offset, value, len) {
+            warn!("Fail to write data to fw_cfg register: {}", e);
+        }
+
+        None
+    }
+}
+
+impl Snapshottable for FWCfgStateSnapShotData {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+        Snapshot::new_from_versioned_state(&self.id, &self.state())
+    }
+
+    fn restore(&mut self, snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
+        self.set_state(&snapshot.to_versioned_state(&self.id)?);
+        Ok(())
+    }
+}
+
+impl Pausable for FWCfgStateSnapShotData {}
+impl Transportable for FWCfgStateSnapShotData {}
+impl Migratable for FWCfgStateSnapShotData {}
+
+impl VersionMapped for FWCfgStateSnapShotData {}

--- a/devices/src/legacy/mod.rs
+++ b/devices/src/legacy/mod.rs
@@ -8,6 +8,8 @@
 mod cmos;
 #[cfg(target_arch = "x86_64")]
 mod debug_port;
+#[cfg(target_arch = "aarch64")]
+pub mod fw_cfg;
 #[cfg(feature = "fwdebug")]
 mod fwdebug;
 #[cfg(target_arch = "aarch64")]
@@ -27,6 +29,10 @@ pub use self::fwdebug::FwDebugDevice;
 pub use self::i8042::I8042Device;
 pub use self::serial::Serial;
 
+#[cfg(target_arch = "aarch64")]
+pub use self::fw_cfg::FWCfgState;
+#[cfg(target_arch = "aarch64")]
+pub use self::fw_cfg::FWCfgStateSnapShotData;
 #[cfg(target_arch = "aarch64")]
 pub use self::gpio_pl061::Error as GpioDeviceError;
 #[cfg(target_arch = "aarch64")]

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -77,6 +77,8 @@ generate_read_fn!(read_le_i32, i32, i8, 4, from_le_bytes);
 generate_read_fn!(read_be_u16, u16, u8, 2, from_be_bytes);
 #[cfg(target_arch = "aarch64")]
 generate_read_fn!(read_be_u32, u32, u8, 4, from_be_bytes);
+#[cfg(target_arch = "aarch64")]
+generate_read_fn!(read_be_u64, u64, u8, 8, from_be_bytes);
 
 #[cfg(target_arch = "aarch64")]
 generate_write_fn!(write_le_u16, u16, u8, to_le_bytes);
@@ -91,3 +93,5 @@ generate_write_fn!(write_le_i32, i32, i8, to_le_bytes);
 generate_write_fn!(write_be_u16, u16, u8, to_be_bytes);
 #[cfg(target_arch = "aarch64")]
 generate_write_fn!(write_be_u32, u32, u8, to_be_bytes);
+#[cfg(target_arch = "aarch64")]
+generate_write_fn!(write_be_u64, u64, u8, to_be_bytes);

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,6 +193,15 @@ fn create_app<'a>(
                 .group("vm-config"),
         )
         .arg(
+            Arg::new("firmware")
+                .long("firmware")
+                .help(
+                     "Path to firmware image, generally a UEFI image",
+                )
+                .takes_value(true)
+                .group("vm-config"),
+        )
+        .arg(
             Arg::new("kernel")
                 .long("kernel")
                 .help(

--- a/src/main.rs
+++ b/src/main.rs
@@ -713,6 +713,7 @@ mod unit_tests {
             kernel: Some(KernelConfig {
                 path: PathBuf::from("/path/to/kernel"),
             }),
+            firmware: None,
             initramfs: None,
             cmdline: CmdlineConfig {
                 args: String::from(""),

--- a/src/main.rs
+++ b/src/main.rs
@@ -583,7 +583,7 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
         cmd_arguments.is_present("kernel") || cmd_arguments.is_present("tdx");
 
     #[cfg(not(feature = "tdx"))]
-    let tdx_or_kernel_present = cmd_arguments.is_present("kernel");
+    let tdx_or_kernel_present = cmd_arguments.is_present("firmware") || cmd_arguments.is_present("kernel");
 
     if tdx_or_kernel_present {
         let vm_params = config::VmParams::from_arg_matches(&cmd_arguments);

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2317,7 +2317,11 @@ impl VmConfig {
         let mut id_list = BTreeSet::new();
 
         #[cfg(not(feature = "tdx"))]
-        self.kernel.as_ref().ok_or(ValidationError::KernelMissing)?;
+        if let None = self.kernel.as_ref() {
+            if let None = self.firmware.as_ref() {
+                return Err(ValidationError::KernelMissing);
+            }
+        }
 
         #[cfg(feature = "tdx")]
         {

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -340,6 +340,7 @@ pub struct VmParams<'a> {
     pub cpus: &'a str,
     pub memory: &'a str,
     pub memory_zones: Option<Vec<&'a str>>,
+    pub firmware: Option<&'a str>,
     pub kernel: Option<&'a str>,
     pub initramfs: Option<&'a str>,
     pub cmdline: Option<&'a str>,
@@ -375,6 +376,7 @@ impl<'a> VmParams<'a> {
         let rng = args.value_of("rng").unwrap();
         let serial = args.value_of("serial").unwrap();
 
+        let firmware = args.value_of("firmware");
         let kernel = args.value_of("kernel");
         let initramfs = args.value_of("initramfs");
         let cmdline = args.value_of("cmdline");
@@ -402,6 +404,7 @@ impl<'a> VmParams<'a> {
             cpus,
             memory,
             memory_zones,
+            firmware,
             kernel,
             initramfs,
             cmdline,
@@ -2254,6 +2257,7 @@ pub struct VmConfig {
     pub cpus: CpusConfig,
     #[serde(default)]
     pub memory: MemoryConfig,
+    pub firmware: Option<KernelConfig>,
     pub kernel: Option<KernelConfig>,
     #[serde(default)]
     pub initramfs: Option<InitramfsConfig>,
@@ -2637,6 +2641,13 @@ impl VmConfig {
             numa = Some(numa_config_list);
         }
 
+        let mut firmware: Option<KernelConfig> = None;
+        if let Some(f) = vm_params.firmware {
+            firmware = Some(KernelConfig {
+                path: PathBuf::from(f),
+            });
+        }
+
         let mut kernel: Option<KernelConfig> = None;
         if let Some(k) = vm_params.kernel {
             kernel = Some(KernelConfig {
@@ -2660,6 +2671,7 @@ impl VmConfig {
         let mut config = VmConfig {
             cpus: CpusConfig::parse(vm_params.cpus)?,
             memory: MemoryConfig::parse(vm_params.memory, vm_params.memory_zones)?,
+            firmware,
             kernel,
             initramfs,
             cmdline: CmdlineConfig::parse(vm_params.cmdline)?,
@@ -3266,6 +3278,9 @@ mod tests {
                 prefault: false,
                 zones: None,
             },
+            firmware: Some(KernelConfig {
+                path: PathBuf::from("/path/to/firmware"),
+            }),
             kernel: Some(KernelConfig {
                 path: PathBuf::from("/path/to/kernel"),
             }),


### PR DESCRIPTION
Currently, firmware boot need get kernel from disk which takes several or dozens of seconds. There is a way to boot kernel specified by the command line that is introducing a fw_cfg device (Qemu does this) to store the kernel info and pass it to firmware. It will largely reduce the kernel load time to dozens of ms.

What I have done in this PR:

- We should introduce a new command line interface "-firmware" to tear into the firmware image while get kernel image from "-kernel" as it's ugly to get both of firmware and kernel from one interface.
- Add fw_cfg device as the interface to talk to firmware and pass the kernel image. Luckily, there is fw_cfg driver in Edk2 part and we can reuse it directly.

TODO: 

- This PR only enable fw_cfg on aarch64 and should enable on x86 either if needed;
- Add integration test for it. We need abandon the old way of firmware boot and use this fast way instead.
 