### PR TITLE
hypervisor: simplify LapicState

### DIFF
--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -298,18 +298,13 @@ impl From<FpuState> for kvm_fpu {
 
 impl From<LapicState> for kvm_lapic_state {
     fn from(s: LapicState) -> Self {
-        match s {
-            LapicState::Kvm(s) => s,
-            /* Needed in case other hypervisors are enabled */
-            #[allow(unreachable_patterns)]
-            _ => panic!("LapicState is not valid"),
-        }
+        Self { regs: s.regs }
     }
 }
 
 impl From<kvm_lapic_state> for LapicState {
     fn from(s: kvm_lapic_state) -> Self {
-        LapicState::Kvm(s)
+        Self { regs: s.regs }
     }
 }
 

--- a/hypervisor/src/mshv/x86_64/mod.rs
+++ b/hypervisor/src/mshv/x86_64/mod.rs
@@ -289,18 +289,13 @@ impl From<FpuState> for FloatingPointUnit {
 
 impl From<LapicState> for MshvLapicState {
     fn from(s: LapicState) -> Self {
-        match s {
-            LapicState::Mshv(s) => s,
-            /* Needed in case other hypervisors are enabled */
-            #[allow(unreachable_patterns)]
-            _ => panic!("LapicState is not valid"),
-        }
+        Self { regs: s.regs }
     }
 }
 
 impl From<MshvLapicState> for LapicState {
     fn from(s: MshvLapicState) -> Self {
-        LapicState::Mshv(s)
+        Self { regs: s.regs }
     }
 }
 


### PR DESCRIPTION
Both KVM and MSHV share the same layout. We can drop one level of
indirection.

See #4377 