### PR TITLE
Refactor system-registers related code on AArch64

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -75,7 +75,9 @@ pub fn configure_vcpu(
         .map_err(Error::RegsConfiguration)?;
     }
 
-    let mpidr = vcpu.read_mpidr().map_err(Error::VcpuRegMpidr)?;
+    let mpidr = vcpu
+        .get_sys_reg(regs::MPIDR_EL1)
+        .map_err(Error::VcpuRegMpidr)?;
     Ok(mpidr)
 }
 

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -6,6 +6,8 @@
 pub mod fdt;
 /// Layout for this aarch64 system.
 pub mod layout;
+/// Module for system registers definition
+pub mod regs;
 /// Module for loading UEFI binary.
 pub mod uefi;
 

--- a/arch/src/aarch64/regs.rs
+++ b/arch/src/aarch64/regs.rs
@@ -1,0 +1,41 @@
+// Copyright 2022 Arm Limited (or its affiliates). All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+///
+/// AArch64 system register encoding:
+/// See https://developer.arm.com/documentation/ddi0487 (chapter D12)
+///
+///   31      22  21 20 19 18 16 15 12 11  8 7   5 4  0
+///  +----------+---+-----+-----+-----+-----+-----+----+
+///  |1101010100| L | op0 | op1 | CRn | CRm | op2 | Rt |
+///  +----------+---+-----+-----+-----+-----+-----+----+
+///
+/// Notes:
+/// - L and Rt are reserved as implementation defined fields, ignored.
+///
+const SYSREG_HEAD: u32 = 0b1101010100u32 << 22;
+const SYSREG_OP0_SHIFT: u32 = 19;
+const SYSREG_OP0_MASK: u32 = 0b11u32 << 19;
+const SYSREG_OP1_SHIFT: u32 = 16;
+const SYSREG_OP1_MASK: u32 = 0b111u32 << 16;
+const SYSREG_CRN_SHIFT: u32 = 12;
+const SYSREG_CRN_MASK: u32 = 0b1111u32 << 12;
+const SYSREG_CRM_SHIFT: u32 = 8;
+const SYSREG_CRM_MASK: u32 = 0b1111u32 << 8;
+const SYSREG_OP2_SHIFT: u32 = 5;
+const SYSREG_OP2_MASK: u32 = 0b111u32 << 5;
+
+/// Define the ID of system registers
+#[macro_export]
+macro_rules! arm64_sys_reg {
+    ($name: tt, $op0: tt, $op1: tt, $crn: tt, $crm: tt, $op2: tt) => {
+        pub const $name: u32 = SYSREG_HEAD
+            | ((($op0 as u32) << SYSREG_OP0_SHIFT) & SYSREG_OP0_MASK as u32)
+            | ((($op1 as u32) << SYSREG_OP1_SHIFT) & SYSREG_OP1_MASK as u32)
+            | ((($crn as u32) << SYSREG_CRN_SHIFT) & SYSREG_CRN_MASK as u32)
+            | ((($crm as u32) << SYSREG_CRM_SHIFT) & SYSREG_CRM_MASK as u32)
+            | ((($op2 as u32) << SYSREG_OP2_SHIFT) & SYSREG_OP2_MASK as u32);
+    };
+}
+
+arm64_sys_reg!(MPIDR_EL1, 3, 0, 0, 0, 5);

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -371,6 +371,11 @@ pub trait Vcpu: Send + Sync {
     #[cfg(target_arch = "aarch64")]
     fn read_mpidr(&self) -> Result<u64>;
     ///
+    /// Gets the value of a system register
+    ///
+    #[cfg(target_arch = "aarch64")]
+    fn get_sys_reg(&self, sys_reg: u32) -> Result<u64>;
+    ///
     /// Configure core registers for a given CPU.
     ///
     #[cfg(target_arch = "aarch64")]

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -9,9 +9,7 @@
 //
 
 #[cfg(target_arch = "aarch64")]
-use crate::aarch64::VcpuInit;
-#[cfg(target_arch = "aarch64")]
-use crate::aarch64::{RegList, Register, StandardRegisters};
+use crate::aarch64::{RegList, StandardRegisters, VcpuInit};
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::{
     CpuIdEntry, FpuState, LapicState, MsrEntry, SpecialRegisters, StandardRegisters,
@@ -377,16 +375,6 @@ pub trait Vcpu: Send + Sync {
     ///
     #[cfg(target_arch = "aarch64")]
     fn get_reg_list(&self, reg_list: &mut RegList) -> Result<()>;
-    ///
-    /// Save the state of the system registers.
-    ///
-    #[cfg(target_arch = "aarch64")]
-    fn get_sys_regs(&self) -> Result<Vec<Register>>;
-    ///
-    /// Restore the state of the system registers.
-    ///
-    #[cfg(target_arch = "aarch64")]
-    fn set_sys_regs(&self, state: &[Register]) -> Result<()>;
     ///
     /// Read the MPIDR - Multiprocessor Affinity Register.
     ///

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -360,16 +360,6 @@ pub trait Vcpu: Send + Sync {
     #[cfg(target_arch = "aarch64")]
     fn vcpu_init(&self, kvi: &VcpuInit) -> Result<()>;
     ///
-    /// Sets the value of one register for this vCPU.
-    ///
-    #[cfg(target_arch = "aarch64")]
-    fn set_reg(&self, reg_id: u64, data: u64) -> Result<()>;
-    ///
-    /// Sets the value of one register for this vCPU.
-    ///
-    #[cfg(target_arch = "aarch64")]
-    fn get_reg(&self, reg_id: u64) -> Result<u64>;
-    ///
     /// Gets a list of the guest registers that are supported for the
     /// KVM_GET_ONE_REG/KVM_SET_ONE_REG calls.
     ///

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -366,11 +366,6 @@ pub trait Vcpu: Send + Sync {
     #[cfg(target_arch = "aarch64")]
     fn get_reg_list(&self, reg_list: &mut RegList) -> Result<()>;
     ///
-    /// Read the MPIDR - Multiprocessor Affinity Register.
-    ///
-    #[cfg(target_arch = "aarch64")]
-    fn read_mpidr(&self) -> Result<u64>;
-    ///
     /// Gets the value of a system register
     ///
     #[cfg(target_arch = "aarch64")]

--- a/hypervisor/src/kvm/aarch64/mod.rs
+++ b/hypervisor/src/kvm/aarch64/mod.rs
@@ -12,12 +12,8 @@ pub mod gic;
 
 use crate::kvm::{KvmError, KvmResult};
 use kvm_bindings::{
-    kvm_mp_state, kvm_one_reg, kvm_regs, KVM_REG_ARM64, KVM_REG_ARM64_SYSREG,
-    KVM_REG_ARM64_SYSREG_CRM_MASK, KVM_REG_ARM64_SYSREG_CRM_SHIFT, KVM_REG_ARM64_SYSREG_CRN_MASK,
-    KVM_REG_ARM64_SYSREG_CRN_SHIFT, KVM_REG_ARM64_SYSREG_OP0_MASK, KVM_REG_ARM64_SYSREG_OP0_SHIFT,
-    KVM_REG_ARM64_SYSREG_OP1_MASK, KVM_REG_ARM64_SYSREG_OP1_SHIFT, KVM_REG_ARM64_SYSREG_OP2_MASK,
-    KVM_REG_ARM64_SYSREG_OP2_SHIFT, KVM_REG_ARM_COPROC_MASK, KVM_REG_ARM_CORE, KVM_REG_SIZE_MASK,
-    KVM_REG_SIZE_U32, KVM_REG_SIZE_U64,
+    kvm_mp_state, kvm_one_reg, kvm_regs, KVM_REG_ARM_COPROC_MASK, KVM_REG_ARM_CORE,
+    KVM_REG_SIZE_MASK, KVM_REG_SIZE_U32, KVM_REG_SIZE_U64,
 };
 pub use kvm_bindings::{
     kvm_one_reg as Register, kvm_regs as StandardRegisters, kvm_vcpu_init as VcpuInit, RegList,
@@ -85,32 +81,6 @@ macro_rules! arm64_core_reg_id {
     };
 }
 
-// This macro computes the ID of a specific ARM64 system register similar to how
-// the kernel C macro does.
-// https://elixir.bootlin.com/linux/v4.20.17/source/arch/arm64/include/uapi/asm/kvm.h#L203
-#[macro_export]
-macro_rules! arm64_sys_reg {
-    ($name: tt, $op0: tt, $op1: tt, $crn: tt, $crm: tt, $op2: tt) => {
-        pub const $name: u64 = KVM_REG_ARM64 as u64
-            | KVM_REG_SIZE_U64 as u64
-            | KVM_REG_ARM64_SYSREG as u64
-            | ((($op0 as u64) << KVM_REG_ARM64_SYSREG_OP0_SHIFT)
-                & KVM_REG_ARM64_SYSREG_OP0_MASK as u64)
-            | ((($op1 as u64) << KVM_REG_ARM64_SYSREG_OP1_SHIFT)
-                & KVM_REG_ARM64_SYSREG_OP1_MASK as u64)
-            | ((($crn as u64) << KVM_REG_ARM64_SYSREG_CRN_SHIFT)
-                & KVM_REG_ARM64_SYSREG_CRN_MASK as u64)
-            | ((($crm as u64) << KVM_REG_ARM64_SYSREG_CRM_SHIFT)
-                & KVM_REG_ARM64_SYSREG_CRM_MASK as u64)
-            | ((($op2 as u64) << KVM_REG_ARM64_SYSREG_OP2_SHIFT)
-                & KVM_REG_ARM64_SYSREG_OP2_MASK as u64);
-    };
-}
-
-// Constant imported from the Linux kernel:
-// https://elixir.bootlin.com/linux/v4.20.17/source/arch/arm64/include/asm/sysreg.h#L135
-arm64_sys_reg!(MPIDR_EL1, 3, 0, 0, 0, 5);
-
 /// Specifies whether a particular register is a system register or not.
 /// The kernel splits the registers on aarch64 in core registers and system registers.
 /// So, below we get the system registers by checking that they are not core registers.
@@ -149,8 +119,4 @@ pub struct VcpuKvmState {
     pub mp_state: kvm_mp_state,
     pub core_regs: kvm_regs,
     pub sys_regs: Vec<kvm_one_reg>,
-    // We will be using the mpidr for passing it to the VmState.
-    // The VmState will give this away for saving restoring the icc and redistributor
-    // registers.
-    pub mpidr: u64,
 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -13,7 +13,7 @@ use crate::aarch64::gic::KvmGicV3Its;
 #[cfg(target_arch = "aarch64")]
 pub use crate::aarch64::{
     check_required_kvm_extensions, gic::Gicv3ItsState as GicState, is_system_register, VcpuInit,
-    VcpuKvmState, MPIDR_EL1,
+    VcpuKvmState,
 };
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::gic::Vgic;
@@ -1638,15 +1638,6 @@ impl cpu::Vcpu for KvmVcpu {
             .map_err(|e| cpu::HypervisorCpuError::GetRegList(e.into()))
     }
     ///
-    /// Read the MPIDR - Multiprocessor Affinity Register.
-    ///
-    #[cfg(target_arch = "aarch64")]
-    fn read_mpidr(&self) -> cpu::Result<u64> {
-        self.fd
-            .get_one_reg(MPIDR_EL1)
-            .map_err(|e| cpu::HypervisorCpuError::GetSysRegister(e.into()))
-    }
-    ///
     /// Gets the value of a system register
     ///
     #[cfg(target_arch = "aarch64")]
@@ -1853,7 +1844,6 @@ impl cpu::Vcpu for KvmVcpu {
     fn state(&self) -> cpu::Result<CpuState> {
         let mut state = VcpuKvmState {
             mp_state: self.get_mp_state()?.into(),
-            mpidr: self.read_mpidr()?,
             ..Default::default()
         };
         // Get core registers

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -2491,11 +2491,6 @@ mod tests {
         assert_eq!(state.regs.pstate, 0x3C5);
 
         assert!(vcpu.set_regs(&state).is_ok());
-        let off = offset__of!(user_pt_regs, pstate);
-        let pstate = vcpu
-            .get_reg(arm64_core_reg_id!(KVM_REG_SIZE_U64, off))
-            .expect("Failed to call kvm get one reg");
-        assert_eq!(state.regs.pstate, pstate);
     }
 
     #[test]

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -2410,7 +2410,7 @@ mod tests {
 #[cfg(target_arch = "aarch64")]
 #[cfg(test)]
 mod tests {
-    use arch::layout;
+    use arch::{aarch64::regs, layout};
     use hypervisor::kvm::aarch64::is_system_register;
     use hypervisor::kvm::kvm_bindings::{
         kvm_regs, kvm_vcpu_init, user_pt_regs, KVM_REG_ARM64, KVM_REG_ARM64_SYSREG,
@@ -2445,10 +2445,10 @@ mod tests {
         vm.get_preferred_target(&mut kvi).unwrap();
 
         // Must fail when vcpu is not initialized yet.
-        assert!(vcpu.read_mpidr().is_err());
+        assert!(vcpu.get_sys_reg(regs::MPIDR_EL1).is_err());
 
         vcpu.vcpu_init(&kvi).unwrap();
-        assert_eq!(vcpu.read_mpidr().unwrap(), 0x80000000);
+        assert_eq!(vcpu.get_sys_reg(regs::MPIDR_EL1).unwrap(), 0x80000000);
     }
 
     #[test]


### PR DESCRIPTION
This PR contains some cleanup work of system registers related functions in `hypervisor`:
- Removing redundant functions `Vcpu::get/set_sys_regs()`, they were only used internally in `hypervisor` crate
- Removing redundant functions `Vcpu::get/set_reg()`, they were also only used internally in `hypervisor` crate

And a refactoring proposal for improving the way to get the system register:
- The problem to resolve: ARM64 defines a big collection of system registers for various purposes. So far we have only used `MPIDR`, we accessed it via the `hypervisor::Vcpu::read_mpidr()` function. But now there is increasing requirements to access more system registers, see https://github.com/cloud-hypervisor/cloud-hypervisor/pull/4355/commits/badb93351dba1d3b3269295d4de873e854ff63f0. In implementing the GDB support, we need to access 3 more system regs. In future there could be more. It's a bad idea to add a function for each register.
- My idea is to move the declarations of system registers from `hypervisor` to `arch` (the system registers ID encoding is standard, defined in ARM Architecture Reference Manual D12), and to add a function `Vcpu::get_sys_reg()`  in `hypervisor` crate to fetch the value of the specified system register. 
- A small problem to resolve is: although the ID encoding of system registers is standard, hypervisors may define a different ID for APIs. But mapping relation exists, we can easily convert between them (`Vcpu::get_sys_reg()` does the conversion). 