### PR TITLE
docs: update fs.md virtiofs command

### DIFF
--- a/docs/fs.md
+++ b/docs/fs.md
@@ -29,7 +29,7 @@ mkdir /tmp/shared_dir
 _Run virtiofsd_
 ```bash
 ./virtiofsd \
-    -d \
+    --log-level debug \
     --socket-path=/tmp/virtiofs \
     --shared-dir=/tmp/shared_dir \
     --cache=never


### PR DESCRIPTION
The `-d` option is deprecated.

Signed-off-by: Wei Liu <liuwe@microsoft.com>