### PR TITLE
vmm: Remove unused "poll_queue" from DiskConfig

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -811,9 +811,6 @@ components:
           default: false
         vhost_socket:
           type: string
-        poll_queue:
-          type: boolean
-          default: true
         rate_limiter_config:
             $ref: '#/components/schemas/RateLimiterConfig'
         pci_segment:


### PR DESCRIPTION
The parameter "poll_queue" was useful at the time Cloud Hypervisor was
responsible for spawning vhost-user backends, as it was carrying the
information the vhost-user-block backend should have this option enabled
or not.

It's been quite some time that we walked away from this design, as we
now expect a management layer to be responsible for running vhost-user
backends.

That's the reason why we can remove "poll_queue" from the DiskConfig
structure.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>