### PR TITLE
Enable direct kernel boot when firmware boot on aarch64

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -150,6 +150,7 @@ pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::Bui
     gic_device: &Arc<Mutex<dyn Vgic>>,
     numa_nodes: &NumaNodes,
     pmu_supported: bool,
+    kernel_size: u64,
 ) -> super::Result<()> {
     let fdt_final = fdt::create_fdt(
         guest_mem,
@@ -163,6 +164,7 @@ pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::Bui
         numa_nodes,
         virtio_iommu_bdf,
         pmu_supported,
+        kernel_size,
     )
     .map_err(|_| Error::SetupFdt)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,6 +193,15 @@ fn create_app<'a>(
                 .group("vm-config"),
         )
         .arg(
+            Arg::new("firmware")
+                .long("firmware")
+                .help(
+                     "Path to firmware image, generally a UEFI image",
+                )
+                .takes_value(true)
+                .group("vm-config"),
+        )
+        .arg(
             Arg::new("kernel")
                 .long("kernel")
                 .help(

--- a/src/main.rs
+++ b/src/main.rs
@@ -583,7 +583,8 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
         cmd_arguments.is_present("kernel") || cmd_arguments.is_present("tdx");
 
     #[cfg(not(feature = "tdx"))]
-    let tdx_or_kernel_present = cmd_arguments.is_present("kernel");
+    let tdx_or_kernel_present =
+        cmd_arguments.is_present("firmware") || cmd_arguments.is_present("kernel");
 
     if tdx_or_kernel_present {
         let vm_params = config::VmParams::from_arg_matches(&cmd_arguments);

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2305,7 +2305,11 @@ impl VmConfig {
         let mut id_list = BTreeSet::new();
 
         #[cfg(not(feature = "tdx"))]
-        self.kernel.as_ref().ok_or(ValidationError::KernelMissing)?;
+        if let None = self.kernel.as_ref() {
+            if let None = self.firmware.as_ref() {
+                return Err(ValidationError::KernelMissing);
+            }
+        }
 
         #[cfg(feature = "tdx")]
         {


### PR DESCRIPTION
What's direct kernel boot in firmware boot?

- Currently, when VM start from firmware, it must retrieve kernel from disk. Direct kernel boot means loading kernel specified by command line parameter like "-kernel". E.g, start a VM using Qemu, using both "-kernel", to load kernel, and "-bios", to load firmware.

How to implement it in this PR?

- To offer both firmware image and kernel image in the same time, we need introduce a new parameter "-firmware" accompanying with "-kernel" to do this.
- We need a mechanism to pass kernel image to firmware. Here, kernel is stored into guest memory then use fdt to pass kernel info, including memory base and size, to firmware.

Limited:

- As fdt is not used for x86, this implementation is only for aarch64.

TODO:

- Enable it for x86.
- Change the old firmware boot to this new way in the integration test. 

