### PR TITLE
performance-metrics: Improve reliability of virtio_net_latency_us

### DIFF
--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -312,7 +312,7 @@ fn measure_virtio_net_latency(guest: &Guest, test_timeout: u32) -> Result<Vec<f6
         .ssh_command(&format!("{} -s &> /dev/null &", ethr_remote_path))
         .map_err(InfraError::SshCommand)?;
 
-    thread::sleep(Duration::new(1, 0));
+    thread::sleep(Duration::new(10, 0));
 
     // Start the ethr client on the host
     let log_file = guest


### PR DESCRIPTION
The test virtio_net_latency_us recently failed because of the ethr tool
couldn't complete the latency measurement with the following error
message:

    Error dialing the latency connection: dial tcp4
    :0-\u003e172.19.0.2:8888: connect: connection refused

The "connection refused" error comes from the Golang Dial function which
couldn't complete as expected because there was no server listening on
the specified port at the specified destination.

In other words, the ethr server wasn't ready when the ethr client tried
to connect to it.

The easy way to avoid this problem is simply by increasing the sleep
time between the command spawning the ethr server in the guest and the
command running the ethr client from the host.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>