### PR TITLE
virtio-devices: drop mshv feature

### DIFF
--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [features]
 default = []
-mshv = []
 
 [dependencies]
 anyhow = "1.0.59"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -12,7 +12,7 @@ fwdebug = ["devices/fwdebug"]
 gdb = ["kvm", "gdbstub", "gdbstub_arch"]
 guest_debug = ["kvm"]
 kvm = ["hypervisor/kvm", "vfio-ioctls/kvm", "vm-device/kvm", "pci/kvm"]
-mshv = ["hypervisor/mshv", "virtio-devices/mshv", "vfio-ioctls/mshv", "vm-device/mshv", "pci/mshv"]
+mshv = ["hypervisor/mshv", "vfio-ioctls/mshv", "vm-device/mshv", "pci/mshv"]
 tdx = ["arch/tdx", "hypervisor/tdx"]
 
 [dependencies]


### PR DESCRIPTION
There is no code that needs it.

Signed-off-by: Wei Liu <liuwe@microsoft.com>