### PR TITLE
use one address allocator for all address allocations

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1378,6 +1378,11 @@ impl DeviceManager {
         self.interrupt_controller = Some(interrupt_controller.clone());
 
         self.address_manager
+            .allocator
+            .lock()
+            .unwrap()
+            .allocate_addresses(Some(IOAPIC_START), IOAPIC_SIZE, None);
+        self.address_manager
             .mmio_bus
             .insert(interrupt_controller.clone(), IOAPIC_START.0, IOAPIC_SIZE)
             .map_err(DeviceManagerError::BusError)?;
@@ -1590,6 +1595,11 @@ impl DeviceManager {
         let addr = arch::layout::LEGACY_RTC_MAPPED_IO_START;
 
         self.address_manager
+            .allocator
+            .lock()
+            .unwrap()
+            .allocate_addresses(Some(addr), MMIO_LEN, None);
+        self.address_manager
             .mmio_bus
             .insert(rtc_device, addr.0, MMIO_LEN)
             .map_err(DeviceManagerError::BusError)?;
@@ -1629,6 +1639,11 @@ impl DeviceManager {
 
         let addr = arch::layout::LEGACY_GPIO_MAPPED_IO_START;
 
+        self.address_manager
+            .allocator
+            .lock()
+            .unwrap()
+            .allocate_addresses(Some(addr), MMIO_LEN, None);
         self.address_manager
             .mmio_bus
             .insert(gpio_device.clone(), addr.0, MMIO_LEN)
@@ -1768,6 +1783,11 @@ impl DeviceManager {
 
         let addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START;
 
+        self.address_manager
+            .allocator
+            .lock()
+            .unwrap()
+            .allocate_addresses(Some(addr), MMIO_LEN, None);
         self.address_manager
             .mmio_bus
             .insert(serial.clone(), addr.0, MMIO_LEN)

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -608,7 +608,7 @@ impl DeviceRelocation for AddressManager {
                     self.allocator
                         .lock()
                         .unwrap()
-                        .allocate_mmio_hole_addresses(
+                        .allocate_addresses(
                             Some(GuestAddress(new_base)),
                             len as GuestUsize,
                             Some(len),

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1027,7 +1027,7 @@ impl DeviceManager {
             .lock()
             .unwrap()
             .allocate_platform_mmio_addresses(None, DEVICE_MANAGER_ACPI_SIZE as u64, None)
-            .ok_or(DeviceManagerError::AllocateIoPort)?;
+            .ok_or(DeviceManagerError::AllocateMmioAddress)?;
 
         let mut pci_irq_slots = [0; 32];
         PciSegment::reserve_legacy_interrupts_for_pci_devices(

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -805,23 +805,6 @@ impl MemoryManager {
                     .ok_or(Error::MemoryRangeAllocation)?;
             }
         }
-
-        // Allocate SubRegion and Reserved address ranges.
-        for region in self.arch_mem_regions.iter() {
-            if region.r_type == RegionType::Ram {
-                // Ignore the RAM type since ranges have already been allocated
-                // based on the GuestMemory regions.
-                continue;
-            }
-            self.ram_allocator
-                .allocate(
-                    Some(GuestAddress(region.base)),
-                    region.size as GuestUsize,
-                    None,
-                )
-                .ok_or(Error::MemoryRangeAllocation)?;
-        }
-
         Ok(())
     }
 


### PR DESCRIPTION
Let ram_allocator be managed by system allocator, in a first step to unify address allocation to one place in the code.
TODO: let PCI segments be allocated from the system allocator.

https://github.com/cloud-hypervisor/cloud-hypervisor/issues/4391