### PR TITLE
ci: Initial Windows image integration

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -59,6 +59,7 @@ mod aarch64 {
     pub const FOCAL_IMAGE_NAME_VHD: &str = "focal-server-cloudimg-arm64-custom-20210929-0.vhd";
     pub const FOCAL_IMAGE_NAME_VHDX: &str = "focal-server-cloudimg-arm64-custom-20210929-0.vhdx";
     pub const JAMMY_IMAGE_NAME: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.raw";
+    pub const WINDOWS_IMAGE_NAME: &str = "windows-11-iot-enterprise-aarch64.raw";
     pub const GREP_SERIAL_IRQ_CMD: &str = "grep -c 'GICv3.*uart-pl011' /proc/interrupts || true";
     pub const GREP_PMU_IRQ_CMD: &str = "grep -c 'GICv3.*arm-pmu' /proc/interrupts || true";
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6932,12 +6932,10 @@ mod windows {
     fn test_windows_guest() {
         let windows_guest = WindowsGuest::new();
 
-        let ovmf_path = edk2_path();
-
         let mut child = GuestCommand::new(windows_guest.guest())
             .args(&["--cpus", "boot=2,kvm_hyperv=on"])
             .args(&["--memory", "size=4G"])
-            .args(&["--kernel", ovmf_path.to_str().unwrap()])
+            .args(&["--kernel", edk2_path().to_str().unwrap()])
             .args(&["--serial", "tty"])
             .args(&["--console", "off"])
             .default_disks()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -59,6 +59,7 @@ mod aarch64 {
     pub const FOCAL_IMAGE_NAME_VHDX: &str = "focal-server-cloudimg-arm64-custom-20210929-0.vhdx";
     pub const JAMMY_IMAGE_NAME: &str = "jammy-server-cloudimg-arm64-custom-20220329-0.raw";
     pub const WINDOWS_IMAGE_NAME: &str = "windows-11-iot-enterprise-aarch64.raw";
+    pub const OVMF_NAME: &str = "CLOUDHV_EFI.fd";
     pub const GREP_SERIAL_IRQ_CMD: &str = "grep -c 'GICv3.*uart-pl011' /proc/interrupts || true";
     pub const GREP_PMU_IRQ_CMD: &str = "grep -c 'GICv3.*arm-pmu' /proc/interrupts || true";
 }
@@ -175,12 +176,11 @@ fn direct_kernel_boot_path() -> PathBuf {
     kernel_path
 }
 
-#[cfg(target_arch = "aarch64")]
 fn edk2_path() -> PathBuf {
     let mut workload_path = dirs::home_dir().unwrap();
     workload_path.push("workloads");
     let mut edk2_path = workload_path;
-    edk2_path.push("CLOUDHV_EFI.fd");
+    edk2_path.push(OVMF_NAME);
 
     edk2_path
 }
@@ -6932,16 +6932,7 @@ mod windows {
     fn test_windows_guest() {
         let windows_guest = WindowsGuest::new();
 
-        let ovmf_path;
-        #[cfg(target_arch = "aarch64")]
-        ovmf_path = edk2_path();
-        #[cfg(target_arch = "x86_64")]
-        ovmf_path = {
-            let mut _tmp = dirs::home_dir().unwrap();
-            _tmp.push("workloads");
-            _tmp.push(OVMF_NAME);
-            _tmp
-        };
+        let ovmf_path = edk2_path();
 
         let mut child = GuestCommand::new(windows_guest.guest())
             .args(&["--cpus", "boot=2,kvm_hyperv=on"])

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6943,7 +6943,6 @@ mod windows {
             .ovmf_path
             .push(OVMF_NAME);
 
-
         let mut child = GuestCommand::new(windows_guest.guest())
             .args(&["--cpus", "boot=2,kvm_hyperv=on"])
             .args(&["--memory", "size=4G"])

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6935,12 +6935,12 @@ mod windows {
         #[cfg(target_arch = "aarch64")]
         let ovmf_path = edk2_path();
         #[cfg(target_arch = "x86_64")]
-        let mut ovmf_path = dirs::home_dir()
-            .unwrap()
-            .ovmf_path
-            .push("workloads")
-            .ovmf_path
-            .push(OVMF_NAME);
+        let ovmf_path = {
+            let mut _tmp = dirs::home_dir().unwrap();
+            _tmp.push("workloads");
+            _tmp.push(OVMF_NAME);
+            _tmp
+        };
 
         let mut child = GuestCommand::new(windows_guest.guest())
             .args(&["--cpus", "boot=2,kvm_hyperv=on"])

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6932,10 +6932,11 @@ mod windows {
     fn test_windows_guest() {
         let windows_guest = WindowsGuest::new();
 
+        let ovmf_path;
         #[cfg(target_arch = "aarch64")]
-        let ovmf_path = edk2_path();
+        ovmf_path = edk2_path();
         #[cfg(target_arch = "x86_64")]
-        let ovmf_path = {
+        ovmf_path = {
             let mut _tmp = dirs::home_dir().unwrap();
             _tmp.push("workloads");
             _tmp.push(OVMF_NAME);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6627,7 +6627,6 @@ mod sequential {
     }
 }
 
-#[cfg(target_arch = "x86_64")]
 mod windows {
     use crate::*;
     use once_cell::sync::Lazy;
@@ -6652,6 +6651,12 @@ mod windows {
         fn new() -> Self {
             let disk = WindowsDiskConfig::new(WINDOWS_IMAGE_NAME.to_string());
             let guest = Guest::new(Box::new(disk));
+            #[cfg(target_arch = "aarch64")]
+            let auth = PasswordAuth {
+                username: String::from("cloud"),
+                password: String::from("Cloud123"),
+            };
+            #[cfg(target_arch = "x86_64")]
             let auth = PasswordAuth {
                 username: String::from("administrator"),
                 password: String::from("Admin123"),
@@ -6971,6 +6976,7 @@ mod windows {
     }
 
     #[test]
+    #[cfg(not(target_arch = "aarch64"))]
     fn test_windows_guest_multiple_queues() {
         let windows_guest = WindowsGuest::new();
 
@@ -7037,6 +7043,7 @@ mod windows {
 
     #[test]
     #[cfg(not(feature = "mshv"))]
+    #[cfg(not(target_arch = "aarch64"))]
     #[ignore = "See #4327"]
     fn test_windows_guest_snapshot_restore() {
         let windows_guest = WindowsGuest::new();
@@ -7126,6 +7133,7 @@ mod windows {
 
     #[test]
     #[cfg(not(feature = "mshv"))]
+    #[cfg(not(target_arch = "aarch64"))]
     fn test_windows_guest_cpu_hotplug() {
         let windows_guest = WindowsGuest::new();
 
@@ -7200,6 +7208,7 @@ mod windows {
 
     #[test]
     #[cfg(not(feature = "mshv"))]
+    #[cfg(not(target_arch = "aarch64"))]
     fn test_windows_guest_ram_hotplug() {
         let windows_guest = WindowsGuest::new();
 
@@ -7274,6 +7283,7 @@ mod windows {
 
     #[test]
     #[cfg(not(feature = "mshv"))]
+    #[cfg(not(target_arch = "aarch64"))]
     fn test_windows_guest_netdev_hotplug() {
         let windows_guest = WindowsGuest::new();
 
@@ -7346,6 +7356,7 @@ mod windows {
 
     #[test]
     #[cfg(not(feature = "mshv"))]
+    #[cfg(not(target_arch = "aarch64"))]
     fn test_windows_guest_disk_hotplug() {
         let windows_guest = WindowsGuest::new();
 
@@ -7440,6 +7451,7 @@ mod windows {
 
     #[test]
     #[cfg(not(feature = "mshv"))]
+    #[cfg(not(target_arch = "aarch64"))]
     fn test_windows_guest_disk_hotplug_multi() {
         let windows_guest = WindowsGuest::new();
 
@@ -7569,6 +7581,7 @@ mod windows {
 
     #[test]
     #[cfg(not(feature = "mshv"))]
+    #[cfg(not(target_arch = "aarch64"))]
     fn test_windows_guest_netdev_multi() {
         let windows_guest = WindowsGuest::new();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6933,7 +6933,7 @@ mod windows {
         let windows_guest = WindowsGuest::new();
 
         #[cfg(target_arch = "aarch64")]
-        let mut ovmf_path = edk2_path();
+        let ovmf_path = edk2_path();
         #[cfg(target_arch = "x86_64")]
         let mut ovmf_path = dirs::home_dir()
             .unwrap()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -24,7 +24,6 @@ use std::process::{Child, Command, Stdio};
 use std::string::String;
 use std::sync::mpsc;
 use std::sync::mpsc::Receiver;
-#[cfg(target_arch = "x86_64")]
 use std::sync::Mutex;
 use std::thread;
 use test_infra::*;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6933,9 +6933,16 @@ mod windows {
     fn test_windows_guest() {
         let windows_guest = WindowsGuest::new();
 
-        let mut ovmf_path = dirs::home_dir().unwrap();
-        ovmf_path.push("workloads");
-        ovmf_path.push(OVMF_NAME);
+        #[cfg(target_arch = "aarch64")]
+        let mut ovmf_path = edk2_path();
+        #[cfg(target_arch = "x86_64")]
+        let mut ovmf_path = dirs::home_dir()
+            .unwrap()
+            .ovmf_path
+            .push("workloads")
+            .ovmf_path
+            .push(OVMF_NAME);
+
 
         let mut child = GuestCommand::new(windows_guest.guest())
             .args(&["--cpus", "boot=2,kvm_hyperv=on"])


### PR DESCRIPTION
This enables the Windows test module. One basic test is enabled, while all others are disabled yet for aarch64. Jenkins file is extended with the corresponding step for aarch64, no musl for now. Any other initial CI integration efforts for aarch64 Windows guest are also to be handled in this PR.

Signed-off-by: Anatol Belski <ab@php.net> 