### PR TITLE
Set prefetchable bit with VFIO devices

### DIFF
--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -999,6 +999,12 @@ impl PciBarConfiguration {
         self
     }
 
+    #[must_use]
+    pub fn set_prefetchable(mut self, prefetchable: PciBarPrefetchable) -> Self {
+        self.prefetchable = prefetchable;
+        self
+    }
+
     pub fn idx(&self) -> usize {
         self.idx
     }

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -5,8 +5,9 @@
 
 use crate::{
     msi_num_enabled_vectors, BarReprogrammingParams, MsiCap, MsiConfig, MsixCap, MsixConfig,
-    PciBarConfiguration, PciBarRegionType, PciBdf, PciCapabilityId, PciClassCode, PciConfiguration,
-    PciDevice, PciDeviceError, PciHeaderType, PciSubclass, MSIX_TABLE_ENTRY_SIZE,
+    PciBarConfiguration, PciBarPrefetchable, PciBarRegionType, PciBdf, PciCapabilityId,
+    PciClassCode, PciConfiguration, PciDevice, PciDeviceError, PciHeaderType, PciSubclass,
+    MSIX_TABLE_ENTRY_SIZE,
 };
 use anyhow::anyhow;
 use byteorder::{ByteOrder, LittleEndian};
@@ -566,7 +567,8 @@ impl VfioCommon {
                 .set_index(bar_id as usize)
                 .set_address(bar_addr.raw_value())
                 .set_size(region_size)
-                .set_region_type(region_type);
+                .set_region_type(region_type)
+                .set_prefetchable(PciBarPrefetchable::Prefetchable);
 
             if bar_id == VFIO_PCI_ROM_REGION_INDEX {
                 self.configuration


### PR DESCRIPTION
Resolves: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/4451

Fix problem where NVIDIA devices are not usable with PCI VFIO
passthrough. See related NVIDIA kernel driver bug:
 https://github.com/NVIDIA/open-gpu-kernel-modules/issues/344.

The PCI Express Base Specification 4.0 R1.0 September 27, 2017 states
on page 704:

PCI Express adapters with Memory Space BARs that request a large amount
of non-prefetchable Memory Space (e.g., over 64 MB) may cause shortages
of that Space on certain scalable platforms, since many platforms support
a total of only 1 GB or less of non-prefetchable Memory Space. This may
limit the number of such adapters that can be supported on those platforms.
For this reason, it is especially encouraged for BARs requesting large
amounts of Memory Space to have their Prefetchable bit Set, since
prefetchable Memory Space is more bountiful on most scalable platform.

As such, set the prefetch state for all BARs. This may not be precisely
correct. It may be more accurate to retreive the host BAR's prefetch
state, and then set based upon that. There is a design note in that same
sectino that may eliminate the possiblity of using prefetchable
meory entirely on a PCI bus (since cloud-hypervisor's bus is emulated,
this also may not matter):

The design note states:

Here are criteria that are sufficient to guarantee correctness for a
given candidate BAR:
- The entire path from the host to the adapter is over PCI Express.
- No conventional PCI or PCI-X devices do peer-to-peer reads to
  the range mapped by the BAR.
- The PCI Express Host Bridge does no byte merging. (This is believed
  to be true on most platforms.)
- Any locations with read side-effects are never the target of Memory
  Reads with the TH bit Set.  See Section 2.2.5.
- The range mapped by the BAR is never the target of a speculative
  Memory Read, either Host initiated or peer-to-peer.

Signed-off-by: Steven Dake <sdake@lambdal.com>