### PR TITLE
pci: vfio: Preserve prefetchable flag on BAR

### DIFF
--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -999,6 +999,12 @@ impl PciBarConfiguration {
         self
     }
 
+    #[must_use]
+    pub fn set_prefetchable(mut self, prefetchable: PciBarPrefetchable) -> Self {
+        self.prefetchable = prefetchable;
+        self
+    }
+
     pub fn idx(&self) -> usize {
         self.idx
     }


### PR DESCRIPTION
- Set prefetchable bit with VFIO devices
- pci: vfio: Preserve prefetchable state of BAR across
- HACK: Run VFIO worker on this PR
