### PR TITLE
option_parser: Parsing improvements

### DIFF
--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -346,15 +346,37 @@ mod tests {
             .add("size")
             .add("mergeable")
             .add("hotplug_method")
-            .add("hotplug_size");
+            .add("hotplug_size")
+            .add("topology");
 
         assert!(parser.parse("size=128M,hanging_param").is_err());
         assert!(parser.parse("size=128M,too_many_equals=foo=bar").is_err());
         assert!(parser.parse("size=128M,file=/dev/shm").is_err());
-        assert!(parser.parse("size=128M").is_ok());
 
+        assert!(parser.parse("size=128M").is_ok());
         assert_eq!(parser.get("size"), Some("128M".to_owned()));
         assert!(!parser.is_set("mergeable"));
         assert!(parser.is_set("size"));
+
+        assert!(parser.parse("size=128M,mergeable=on").is_ok());
+        assert_eq!(parser.get("size"), Some("128M".to_owned()));
+        assert_eq!(parser.get("mergeable"), Some("on".to_owned()));
+
+        assert!(parser
+            .parse("size=128M,mergeable=on,topology=[1,2]")
+            .is_ok());
+        assert_eq!(parser.get("size"), Some("128M".to_owned()));
+        assert_eq!(parser.get("mergeable"), Some("on".to_owned()));
+        assert_eq!(parser.get("topology"), Some("[1,2]".to_owned()));
+
+        assert!(parser
+            .parse("size=128M,mergeable=on,topology=[[1,2],[3,4]]")
+            .is_ok());
+        assert_eq!(parser.get("size"), Some("128M".to_owned()));
+        assert_eq!(parser.get("mergeable"), Some("on".to_owned()));
+        assert_eq!(parser.get("topology"), Some("[[1,2],[3,4]]".to_owned()));
+
+        assert!(parser.parse("topology=[").is_err());
+        assert!(parser.parse("topology=[[[]]]]").is_err())
     }
 }

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -334,3 +334,27 @@ impl FromStr for StringList {
         Ok(StringList(string_list))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_option_parser() {
+        let mut parser = OptionParser::new();
+        parser
+            .add("size")
+            .add("mergeable")
+            .add("hotplug_method")
+            .add("hotplug_size");
+
+        assert!(parser.parse("size=128M,hanging_param").is_err());
+        assert!(parser.parse("size=128M,too_many_equals=foo=bar").is_err());
+        assert!(parser.parse("size=128M,file=/dev/shm").is_err());
+        assert!(parser.parse("size=128M").is_ok());
+
+        assert_eq!(parser.get("size"), Some("128M".to_owned()));
+        assert!(!parser.is_set("mergeable"));
+        assert!(parser.is_set("size"));
+    }
+}

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -38,7 +38,7 @@ impl fmt::Display for OptionParserError {
 }
 type OptionParserResult<T> = std::result::Result<T, OptionParserError>;
 
-fn split_commas_outside_brackets(s: &str) -> OptionParserResult<Vec<String>> {
+fn split_commas(s: &str) -> OptionParserResult<Vec<String>> {
     let mut list: Vec<String> = Vec::new();
     let mut opened_brackets = 0;
     let mut current = String::new();
@@ -88,7 +88,7 @@ impl OptionParser {
             return Ok(());
         }
 
-        for option in split_commas_outside_brackets(input)?.iter() {
+        for option in split_commas(input)?.iter() {
             let parts: Vec<&str> = option.splitn(2, '=').collect();
 
             match self.options.get_mut(parts[0]) {
@@ -303,9 +303,8 @@ impl<S: FromStr, T: TupleValue> FromStr for Tuple<S, T> {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let mut list: Vec<(S, T)> = Vec::new();
 
-        let tuples_list =
-            split_commas_outside_brackets(s.trim().trim_matches(|c| c == '[' || c == ']'))
-                .map_err(TupleError::SplitOutsideBrackets)?;
+        let tuples_list = split_commas(s.trim().trim_matches(|c| c == '[' || c == ']'))
+            .map_err(TupleError::SplitOutsideBrackets)?;
         for tuple in tuples_list.iter() {
             let items: Vec<&str> = tuple.split('@').collect();
 

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -31,7 +31,7 @@ impl fmt::Display for OptionParserError {
             OptionParserError::UnknownOption(s) => write!(f, "unknown option: {}", s),
             OptionParserError::InvalidSyntax(s) => write!(f, "invalid syntax:{}", s),
             OptionParserError::Conversion(field, value) => {
-                write!(f, "unable to parse {} for {}", value, field)
+                write!(f, "unable to convert {} for {}", value, field)
             }
         }
     }

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -305,8 +305,13 @@ impl<S: FromStr, T: TupleValue> FromStr for Tuple<S, T> {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let mut list: Vec<(S, T)> = Vec::new();
 
-        let tuples_list = split_commas(s.trim().trim_matches(|c| c == '[' || c == ']'))
-            .map_err(TupleError::SplitOutsideBrackets)?;
+        let body = s
+            .trim()
+            .strip_prefix('[')
+            .and_then(|s| s.strip_suffix(']'))
+            .ok_or_else(|| TupleError::InvalidValue(s.to_string()))?;
+
+        let tuples_list = split_commas(body).map_err(TupleError::SplitOutsideBrackets)?;
         for tuple in tuples_list.iter() {
             let items: Vec<&str> = tuple.split('@').collect();
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2693,25 +2693,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_option_parser() {
-        let mut parser = OptionParser::new();
-        parser
-            .add("size")
-            .add("mergeable")
-            .add("hotplug_method")
-            .add("hotplug_size");
-
-        assert!(parser.parse("size=128M,hanging_param").is_err());
-        assert!(parser.parse("size=128M,too_many_equals=foo=bar").is_err());
-        assert!(parser.parse("size=128M,file=/dev/shm").is_err());
-        assert!(parser.parse("size=128M").is_ok());
-
-        assert_eq!(parser.get("size"), Some("128M".to_owned()));
-        assert!(!parser.is_set("mergeable"));
-        assert!(parser.is_set("size"));
-    }
-
-    #[test]
     fn test_cpu_parsing() -> Result<()> {
         assert_eq!(CpusConfig::parse("")?, CpusConfig::default());
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2738,6 +2738,25 @@ mod tests {
                 ..Default::default()
             }
         );
+        assert_eq!(
+            CpusConfig::parse("boot=2,affinity=[0@[0,2],1@[1,3]]")?,
+            CpusConfig {
+                boot_vcpus: 2,
+                max_vcpus: 2,
+                affinity: Some(vec![
+                    CpuAffinity {
+                        vcpu: 0,
+                        host_cpus: vec![0, 2],
+                    },
+                    CpuAffinity {
+                        vcpu: 1,
+                        host_cpus: vec![1, 3],
+                    }
+                ]),
+                ..Default::default()
+            },
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
- option_parser: Move test_option_parser to option_parser crate
- option_parser: Enhance test_option_parser
- option_parser: Simplify code for splitting on commas
- option_parser: Rename split_commas_outside_brackets to split_commas
- option_parser: Support quoting to avoid splitting
