### PR TITLE
[RFC] Build profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ rust-version = "1.60"
 
 [profile.release]
 lto = true
+panic = "abort"
+
+[profile.dev]
+panic = "abort"
 
 [dependencies]
 anyhow = "1.0.60"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ panic = "abort"
 [profile.dev]
 panic = "abort"
 
+[profile.release-small]
+inherits = "release"
+opt-level = "s"
+codegen-units = 1
+
 [dependencies]
 anyhow = "1.0.60"
 api_client = { path = "api_client" }


### PR DESCRIPTION
After switching the panic behaviour from unwind to abort, the release binary goes from 7.1M unstripped to 6.1M, so it is 13% smaller.

The profile that optimizes for binary size can produce binaries that's only 5.7M unstripped. That's close to 20% size reduction.