### PR TITLE
Shutdown VMM upon errors from virtio-device workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
  "rate_limiter",
  "serde",
  "serde_json",
+ "thiserror",
  "versionize",
  "versionize_derive",
  "virtio-bindings",

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -12,6 +12,7 @@ log = "0.4.17"
 net_gen = { path = "../net_gen" }
 rate_limiter = { path = "../rate_limiter" }
 serde = "1.0.143"
+thiserror = "1.0.32"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 virtio-bindings = "0.1.0"

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -18,6 +18,7 @@ use std::io::Error as IoError;
 use std::os::raw::c_uint;
 use std::os::unix::io::{FromRawFd, RawFd};
 use std::{io, mem, net};
+use thiserror::Error;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_bindings::bindings::virtio_net::{
@@ -35,9 +36,9 @@ pub use open_tap::{open_tap, Error as OpenTapError};
 pub use queue_pair::{NetCounters, NetQueuePair, NetQueuePairError, RxVirtio, TxVirtio};
 pub use tap::{Error as TapError, Tap};
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-    /// Failed to create a socket.
+    #[error("Failed to create a socket: {0}")]
     CreateSocket(IoError),
 }
 

--- a/net_util/src/open_tap.rs
+++ b/net_util/src/open_tap.rs
@@ -6,30 +6,31 @@ use super::{vnet_hdr_len, MacAddr, Tap, TapError};
 use std::net::Ipv4Addr;
 use std::path::Path;
 use std::{fs, io};
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-    /// Failed to convert an hexadecimal string into an integer.
+    #[error("Failed to convert an hexadecimal string into an integer: {0}")]
     ConvertHexStringToInt(std::num::ParseIntError),
-    /// Error related to the multiqueue support (no support TAP side).
+    #[error("Error related to the multiqueue support (no support TAP side).")]
     MultiQueueNoTapSupport,
-    /// Error related to the multiqueue support (no support device side).
+    #[error("Error related to the multiqueue support (no support device side).")]
     MultiQueueNoDeviceSupport,
-    /// Failed to read the TAP flags from sysfs.
+    #[error("Failed to read the TAP flags from sysfs: {0}")]
     ReadSysfsTunFlags(io::Error),
-    /// Open tap device failed.
+    #[error("Open tap device failed: {0}")]
     TapOpen(TapError),
-    /// Setting tap IP failed.
+    #[error("Setting tap IP failed: {0}")]
     TapSetIp(TapError),
-    /// Setting tap netmask failed.
+    #[error("Setting tap netmask failed: {0}")]
     TapSetNetmask(TapError),
-    /// Setting MAC address failed
+    #[error("Setting MAC address failed: {0}")]
     TapSetMac(TapError),
-    /// Getting MAC address failed
+    #[error("Getting MAC address failed: {0}")]
     TapGetMac(TapError),
-    /// Setting vnet header size failed.
+    #[error("Setting vnet header size failed: {0}")]
     TapSetVnetHdrSize(TapError),
-    /// Enabling tap interface failed.
+    #[error("Enabling tap interface failed: {0}")]
     TapEnable(TapError),
 }
 

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -10,6 +10,7 @@ use std::num::Wrapping;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use thiserror::Error;
 use virtio_queue::{Queue, QueueOwnedT, QueueT};
 use vm_memory::{Bytes, GuestMemory};
 use vm_virtio::{AccessPlatform, Translatable};
@@ -285,31 +286,31 @@ pub struct NetCounters {
     pub rx_frames: Arc<AtomicU64>,
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum NetQueuePairError {
-    /// No memory configured
+    #[error("No memory configured.")]
     NoMemoryConfigured,
-    /// Error registering listener
+    #[error("Error registering listener: {0}")]
     RegisterListener(io::Error),
-    /// Error unregistering listener
+    #[error("Error unregistering listener: {0}")]
     UnregisterListener(io::Error),
-    /// Error writing to the TAP device
+    #[error("Error writing to the TAP device: {0}")]
     WriteTap(io::Error),
-    /// Error reading from the TAP device
+    #[error("Error reading from the TAP device: {0}")]
     ReadTap(io::Error),
-    /// Error related to guest memory
+    #[error("Error related to guest memory: {0}")]
     GuestMemory(vm_memory::GuestMemoryError),
-    /// Returned an error while iterating through the queue
+    #[error("Returned an error while iterating through the queue: {0}")]
     QueueIteratorFailed(virtio_queue::Error),
-    /// Descriptor chain is too short
+    #[error("Descriptor chain is too short.")]
     DescriptorChainTooShort,
-    /// Descriptor chain does not contain valid descriptors
+    #[error("Descriptor chain does not contain valid descriptors.")]
     DescriptorChainInvalid,
-    /// Failed to determine if queue needed notification
+    #[error("Failed to determine if queue needed notification: {0}")]
     QueueNeedsNotification(virtio_queue::Error),
-    /// Failed to enable notification on the queue
+    #[error("Failed to enable notification on the queue: {0}")]
     QueueEnableNotification(virtio_queue::Error),
-    /// Failed to add used index to the queue
+    #[error("Failed to add used index to the queue: {0}")]
     QueueAddUsed(virtio_queue::Error),
 }
 

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -15,24 +15,26 @@ use std::io::{Error as IoError, Read, Result as IoResult, Write};
 use std::net;
 use std::os::raw::*;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use thiserror::Error;
 use vmm_sys_util::ioctl::{ioctl_with_mut_ref, ioctl_with_ref, ioctl_with_val};
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-    /// Couldn't open /dev/net/tun.
+    #[error("Couldn't open /dev/net/tun: {0}")]
     OpenTun(IoError),
-    /// Unable to configure tap interface.
+    #[error("Unable to configure tap interface: {0}")]
     ConfigureTap(IoError),
-    /// Unable to retrieve features.
+    #[error("Unable to retrieve features: {0}")]
     GetFeatures(IoError),
-    /// Missing multiqueue support in the kernel.
+    #[error("Missing multiqueue support in the kernel.")]
     MultiQueueKernelSupport,
-    /// ioctl failed.
+    #[error("ioctl failed: {0}")]
     IoctlError(IoError),
-    /// Failed to create a socket.
+    #[error("Failed to create a socket: {0}")]
     NetUtil(NetUtilError),
+    #[error("Invalid interface name.")]
     InvalidIfname,
-    /// Error parsing MAC data
+    #[error("Error parsing MAC data: {0}")]
     MacParsing(IoError),
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8961,8 +8961,6 @@ mod live_migration {
             migration_guest
                 .ssh_command("nc -vz 172.100.0.1 12345")
                 .unwrap();
-
-            cleanup_ovs_dpdk();
         });
 
         // Clean-up the destination VM and OVS VM, and make sure they terminated correctly
@@ -8972,6 +8970,8 @@ mod live_migration {
         handle_child_output(r, &dest_output);
         let ovs_output = ovs_child.wait_with_output().unwrap();
         handle_child_output(Ok(()), &ovs_output);
+
+        cleanup_ovs_dpdk();
     }
 
     #[test]

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -603,11 +603,7 @@ impl VirtioDevice for Balloon {
             Thread::VirtioBalloon,
             &mut epoll_threads,
             &self.exit_evt,
-            move || {
-                if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
-                    error!("Error running worker: {:?}", e);
-                }
-            },
+            move || handler.run(paused, paused_sync.unwrap()),
         )?;
         self.common.epoll_threads = Some(epoll_threads);
 

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -28,6 +28,7 @@ use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
     mpsc, Arc, Barrier, Mutex,
 };
+use thiserror::Error;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_queue::{Queue, QueueT};
@@ -62,35 +63,35 @@ const VIRTIO_BALLOON_F_DEFLATE_ON_OOM: u64 = 2;
 // pages.
 const VIRTIO_BALLOON_F_REPORTING: u64 = 5;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-    // Guest gave us bad memory addresses.
+    #[error("Guest gave us bad memory addresses.: {0}")]
     GuestMemory(GuestMemoryError),
-    // Guest gave us a write only descriptor that protocol says to read from.
+    #[error("Guest gave us a write only descriptor that protocol says to read from.")]
     UnexpectedWriteOnlyDescriptor,
-    // Guest sent us invalid request.
+    #[error("Guest sent us invalid request.")]
     InvalidRequest,
-    // Fallocate fail.
+    #[error("Fallocate fail.: {0}")]
     FallocateFail(std::io::Error),
-    // Madvise fail.
+    #[error("Madvise fail.: {0}")]
     MadviseFail(std::io::Error),
-    // Failed to EventFd write.
+    #[error("Failed to EventFd write.: {0}")]
     EventFdWriteFail(std::io::Error),
-    // Failed to EventFd try_clone.
+    #[error("Failed to EventFd try_clone.: {0}")]
     EventFdTryCloneFail(std::io::Error),
-    // Failed to MpscRecv.
+    #[error("Failed to MpscRecv.: {0}")]
     MpscRecvFail(mpsc::RecvError),
-    // Resize invalid argument
+    #[error("Resize invalid argument: {0}")]
     ResizeInval(String),
-    // Invalid queue index
+    #[error("Invalid queue index: {0}")]
     InvalidQueueIndex(usize),
-    // Fail tp signal
+    #[error("Fail tp signal: {0}")]
     FailedSignal(io::Error),
-    /// Descriptor chain is too short
+    #[error("Descriptor chain is too short")]
     DescriptorChainTooShort,
-    /// Failed adding used index
+    #[error("Failed adding used index: {0}")]
     QueueAddUsed(virtio_queue::Error),
-    /// Failed creating an iterator over the queue
+    #[error("Failed creating an iterator over the queue: {0}")]
     QueueIterator(virtio_queue::Error),
 }
 

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -33,6 +33,7 @@ use std::result;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Barrier};
 use std::{collections::HashMap, convert::TryInto};
+use thiserror::Error;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_bindings::bindings::virtio_blk::*;
@@ -53,25 +54,25 @@ const COMPLETION_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 2;
 // New 'wake up' event from the rate limiter
 const RATE_LIMITER_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 3;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-    /// Failed to parse the request.
+    #[error("Failed to parse the request: {0}")]
     RequestParsing(block_util::Error),
-    /// Failed to execute the request.
+    #[error("Failed to execute the request: {0}")]
     RequestExecuting(block_util::ExecuteError),
-    /// Failed to complete the request.
+    #[error("Failed to complete the request: {0}")]
     RequestCompleting(block_util::Error),
-    /// Missing the expected entry in the list of requests.
+    #[error("Missing the expected entry in the list of requests")]
     MissingEntryRequestList,
-    /// The asynchronous request returned with failure.
+    #[error("The asynchronous request returned with failure")]
     AsyncRequestFailure,
-    /// Failed synchronizing the file
+    #[error("Failed synchronizing the file: {0}")]
     Fsync(AsyncIoError),
-    /// Failed adding used index
+    #[error("Failed adding used index: {0}")]
     QueueAddUsed(virtio_queue::Error),
-    /// Failed creating an iterator over the queue
+    #[error("Failed creating an iterator over the queue: {0}")]
     QueueIterator(virtio_queue::Error),
-    /// Failed to update request status
+    #[error("Failed to update request status: {0}")]
     RequestStatus(GuestMemoryError),
 }
 

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -647,11 +647,7 @@ impl VirtioDevice for Block {
                 Thread::VirtioBlock,
                 &mut epoll_threads,
                 &self.exit_evt,
-                move || {
-                    if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
-                        error!("Error running worker: {:?}", e);
-                    }
-                },
+                move || handler.run(paused, paused_sync.unwrap()),
             )?;
         }
 

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -559,11 +559,7 @@ impl VirtioDevice for Console {
             Thread::VirtioConsole,
             &mut epoll_threads,
             &self.exit_evt,
-            move || {
-                if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
-                    error!("Error running worker: {:?}", e);
-                }
-            },
+            move || handler.run(paused, paused_sync.unwrap()),
         )?;
 
         self.common.epoll_threads = Some(epoll_threads);

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -1097,11 +1097,7 @@ impl VirtioDevice for Iommu {
             Thread::VirtioIommu,
             &mut epoll_threads,
             &self.exit_evt,
-            move || {
-                if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
-                    error!("Error running worker: {:?}", e);
-                }
-            },
+            move || handler.run(paused, paused_sync.unwrap()),
         )?;
 
         self.common.epoll_threads = Some(epoll_threads);

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -20,6 +20,7 @@ extern crate log;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::io;
+use thiserror::Error;
 
 #[macro_use]
 mod device;
@@ -77,33 +78,23 @@ const VIRTIO_F_ORDER_PLATFORM: u32 = 36;
 const VIRTIO_F_SR_IOV: u32 = 37;
 const VIRTIO_F_NOTIFICATION_DATA: u32 = 38;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ActivateError {
-    EpollCtl(std::io::Error),
+    #[error("Failed to activate virtio device.")]
     BadActivate,
-    /// Queue number is not correct
-    BadQueueNum,
-    /// Failed to clone Kill event fd
-    CloneKillEventFd,
-    /// Failed to clone exit event fd
+    #[error("Failed to clone exit event fd: {0}")]
     CloneExitEventFd(std::io::Error),
-    // Failed to spawn thread
+    #[error("Failed to spawn thread: {0}")]
     ThreadSpawn(std::io::Error),
-    /// Failed to create Vhost-user interrupt eventfd
-    VhostIrqCreate,
-    /// Failed to setup vhost-user-fs daemon.
+    #[error("Failed to setup vhost-user-fs daemon: {0}")]
     VhostUserFsSetup(vhost_user::Error),
-    /// Failed to setup vhost-user-net daemon.
-    VhostUserNetSetup(vhost_user::Error),
-    /// Failed to setup vhost-user-blk daemon.
+    #[error("Failed to setup vhost-user-blk daemon: {0}")]
     VhostUserBlkSetup(vhost_user::Error),
-    /// Failed to reset vhost-user daemon.
-    VhostUserReset(vhost_user::Error),
-    /// Cannot create seccomp filter
+    #[error("Failed to create seccomp filter: {0}")]
     CreateSeccompFilter(seccompiler::Error),
-    /// Cannot create rate limiter
+    #[error("Failed to create rate limiter: {0}")]
     CreateRateLimiter(std::io::Error),
-    /// Failed activating the vDPA device
+    #[error("Failed to activate the vDPA device: {0}")]
     ActivateVdpa(vdpa::Error),
 }
 
@@ -111,17 +102,23 @@ pub type ActivateResult = std::result::Result<(), ActivateError>;
 
 pub type DeviceEventT = u16;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
+    #[error("Failed to single used queue: {0}")]
     FailedSignalingUsedQueue(io::Error),
+    #[error("I/O Error: {0}")]
     IoError(io::Error),
-    VdpaUpdateMemory(vdpa::Error),
+    #[error("Failed to update memory vhost-user: {0}")]
     VhostUserUpdateMemory(vhost_user::Error),
+    #[error("Failed to add memory region vhost-user: {0}")]
     VhostUserAddMemoryRegion(vhost_user::Error),
+    #[error("Failed to set shared memory region.")]
     SetShmRegionsNotSupported,
+    #[error("Failed to process net queue: {0}")]
     NetQueuePair(::net_util::NetQueuePairError),
-    ApplySeccompFilter(seccompiler::Error),
+    #[error("Failed to : {0}")]
     QueueAddUsed(virtio_queue::Error),
+    #[error("Failed to : {0}")]
     QueueIterator(virtio_queue::Error),
 }
 

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -32,6 +32,7 @@ use std::result;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Barrier, Mutex};
+use thiserror::Error;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_queue::{DescriptorChain, Queue, QueueT};
@@ -103,41 +104,41 @@ const QUEUE_AVAIL_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 2;
 // Virtio features
 const VIRTIO_MEM_F_ACPI_PXM: u8 = 0;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-    // Guest gave us bad memory addresses.
+    #[error("Guest gave us bad memory addresses: {0}")]
     GuestMemory(GuestMemoryError),
-    // Guest gave us a write only descriptor that protocol says to read from.
+    #[error("Guest gave us a write only descriptor that protocol says to read from.")]
     UnexpectedWriteOnlyDescriptor,
-    // Guest gave us a read only descriptor that protocol says to write to.
+    #[error("Guest gave us a read only descriptor that protocol says to write to.")]
     UnexpectedReadOnlyDescriptor,
-    // Guest gave us too few descriptors in a descriptor chain.
+    #[error("Guest gave us too few descriptors in a descriptor chain.")]
     DescriptorChainTooShort,
-    // Guest gave us a buffer that was too short to use.
+    #[error("Guest gave us a buffer that was too short to use.")]
     BufferLengthTooSmall,
-    // Guest sent us invalid request.
+    #[error("Guest sent us invalid request.")]
     InvalidRequest,
-    // Failed to EventFd write.
+    #[error("Failed to EventFd write: {0}")]
     EventFdWriteFail(std::io::Error),
-    // Failed to EventFd try_clone.
+    #[error("Failed to EventFd try_clone: {0}")]
     EventFdTryCloneFail(std::io::Error),
-    // Failed to MpscRecv.
+    #[error("Failed to MpscRecv: {0}")]
     MpscRecvFail(mpsc::RecvError),
-    // Resize invalid argument
+    #[error("Resize invalid argument: {0}")]
     ResizeError(anyhow::Error),
-    // Fail to resize trigger
+    #[error("Fail to resize trigger: {0}")]
     ResizeTriggerFail(DeviceError),
-    // Invalid configuration
+    #[error("Invalid configuration: {0}")]
     ValidateError(anyhow::Error),
-    // Failed discarding memory range
+    #[error("Failed discarding memory range: {0}")]
     DiscardMemoryRange(std::io::Error),
-    // Failed DMA mapping.
+    #[error("Failed DMA mapping: {0}")]
     DmaMap(std::io::Error),
-    // Failed DMA unmapping.
+    #[error("Failed DMA unmapping: {0}")]
     DmaUnmap(std::io::Error),
-    // Invalid DMA mapping handler
+    #[error("Invalid DMA mapping handler.")]
     InvalidDmaMappingHandler,
-    // Not activated by the guest
+    #[error("Not activated by the guest.")]
     NotActivatedByGuest,
 }
 

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -1063,11 +1063,7 @@ impl VirtioDevice for Mem {
             Thread::VirtioMem,
             &mut epoll_threads,
             &self.exit_evt,
-            move || {
-                if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
-                    error!("Error running worker: {:?}", e);
-                }
-            },
+            move || handler.run(paused, paused_sync.unwrap()),
         )?;
         self.common.epoll_threads = Some(epoll_threads);
 

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -32,6 +32,7 @@ use std::sync::{Arc, Barrier};
 use std::thread;
 use std::vec::Vec;
 use std::{collections::HashMap, convert::TryInto};
+use thiserror::Error;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_bindings::bindings::virtio_net::*;
@@ -138,15 +139,13 @@ pub const RX_RATE_LIMITER_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 5;
 // New 'wake up' event from the tx rate limiter
 pub const TX_RATE_LIMITER_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 6;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-    /// Failed to open taps.
+    #[error("Failed to open taps: {0}")]
     OpenTap(OpenTapError),
-
-    // Using existing tap
+    #[error("Using existing tap: {0}")]
     TapError(TapError),
-
-    // Error calling dup() on tap fd
+    #[error("Error calling dup() on tap fd: {0}")]
     DuplicateTapFd(std::io::Error),
 }
 

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -655,11 +655,7 @@ impl VirtioDevice for Net {
                 Thread::VirtioNetCtl,
                 &mut epoll_threads,
                 &self.exit_evt,
-                move || {
-                    if let Err(e) = ctrl_handler.run_ctrl(paused, paused_sync.unwrap()) {
-                        error!("Error running worker: {:?}", e);
-                    }
-                },
+                move || ctrl_handler.run_ctrl(paused, paused_sync.unwrap()),
             )?;
             self.ctrl_queue_epoll_thread = Some(epoll_threads.remove(0));
         }
@@ -736,11 +732,7 @@ impl VirtioDevice for Net {
                 Thread::VirtioNet,
                 &mut epoll_threads,
                 &self.exit_evt,
-                move || {
-                    if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
-                        error!("Error running worker: {:?}", e);
-                    }
-                },
+                move || handler.run(paused, paused_sync.unwrap()),
             )?;
         }
 

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -421,11 +421,7 @@ impl VirtioDevice for Pmem {
                 Thread::VirtioPmem,
                 &mut epoll_threads,
                 &self.exit_evt,
-                move || {
-                    if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
-                        error!("Error running worker: {:?}", e);
-                    }
-                },
+                move || handler.run(paused, paused_sync.unwrap()),
             )?;
 
             self.common.epoll_threads = Some(epoll_threads);

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -260,11 +260,7 @@ impl VirtioDevice for Rng {
                 Thread::VirtioRng,
                 &mut epoll_threads,
                 &self.exit_evt,
-                move || {
-                    if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
-                        error!("Error running worker: {:?}", e);
-                    }
-                },
+                move || handler.run(paused, paused_sync.unwrap()),
             )?;
 
             self.common.epoll_threads = Some(epoll_threads);

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -12,6 +12,7 @@ use crate::seccomp_filters::Thread;
 use crate::thread_helper::spawn_virtio_thread;
 use crate::GuestMemoryMmap;
 use crate::{VirtioInterrupt, VirtioInterruptType};
+use anyhow::anyhow;
 use seccompiler::SeccompAction;
 use std::fs::File;
 use std::io;
@@ -103,26 +104,34 @@ impl RngEpollHandler {
 }
 
 impl EpollHelperHandler for RngEpollHandler {
-    fn handle_event(&mut self, _helper: &mut EpollHelper, event: &epoll::Event) -> bool {
+    fn handle_event(
+        &mut self,
+        _helper: &mut EpollHelper,
+        event: &epoll::Event,
+    ) -> result::Result<(), EpollHelperError> {
         let ev_type = event.data as u16;
         match ev_type {
             QUEUE_AVAIL_EVENT => {
-                if let Err(e) = self.queue_evt.read() {
-                    error!("Failed to get queue event: {:?}", e);
-                    return true;
-                } else if self.process_queue() {
-                    if let Err(e) = self.signal_used_queue() {
-                        error!("Failed to signal used queue: {:?}", e);
-                        return true;
-                    }
+                self.queue_evt.read().map_err(|e| {
+                    EpollHelperError::HandleEvent(anyhow!("Failed to get queue event: {:?}", e))
+                })?;
+                if self.process_queue() {
+                    self.signal_used_queue().map_err(|e| {
+                        EpollHelperError::HandleEvent(anyhow!(
+                            "Failed to signal used queue: {:?}",
+                            e
+                        ))
+                    })?;
                 }
             }
             _ => {
-                error!("Unexpected event: {}", ev_type);
-                return true;
+                return Err(EpollHelperError::HandleEvent(anyhow!(
+                    "Unexpected event: {}",
+                    ev_type
+                )));
             }
         }
-        false
+        Ok(())
     }
 }
 

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -324,11 +324,7 @@ impl VirtioDevice for Blk {
             Thread::VirtioVhostBlock,
             &mut epoll_threads,
             &self.exit_evt,
-            move || {
-                if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
-                    error!("Error running worker: {:?}", e);
-                }
-            },
+            move || handler.run(paused, paused_sync.unwrap()),
         )?;
         self.epoll_thread = Some(epoll_threads.remove(0));
 

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -563,11 +563,7 @@ impl VirtioDevice for Fs {
             Thread::VirtioVhostFs,
             &mut epoll_threads,
             &self.exit_evt,
-            move || {
-                if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
-                    error!("Error running worker: {:?}", e);
-                }
-            },
+            move || handler.run(paused, paused_sync.unwrap()),
         )?;
         self.epoll_thread = Some(epoll_threads.remove(0));
 

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -216,7 +216,7 @@ impl<S: VhostUserMasterReqHandler> VhostUserEpollHandler<S> {
         .map_err(|e| {
             EpollHelperError::IoError(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                format!("failed connecting vhost-user backend{:?}", e),
+                format!("failed connecting vhost-user backend {:?}", e),
             ))
         })?;
 

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -12,6 +12,7 @@ use std::io;
 use std::ops::Deref;
 use std::os::unix::io::AsRawFd;
 use std::sync::{atomic::AtomicBool, Arc, Barrier, Mutex};
+use thiserror::Error;
 use versionize::Versionize;
 use vhost::vhost_user::message::{
     VhostUserInflight, VhostUserProtocolFeatures, VhostUserVirtioFeatures,
@@ -38,109 +39,109 @@ pub use self::fs::*;
 pub use self::net::Net;
 pub use self::vu_common_ctrl::VhostUserConfig;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
-    /// Failed accepting connection.
+    #[error("Failed accepting connection: {0}")]
     AcceptConnection(io::Error),
-    /// Invalid available address.
+    #[error("Invalid available address.")]
     AvailAddress,
-    /// Queue number  is not correct
+    #[error("Queue number  is not correct.")]
     BadQueueNum,
-    /// Failed binding vhost-user socket.
+    #[error("Failed binding vhost-user socket: {0}")]
     BindSocket(io::Error),
-    /// Creating kill eventfd failed.
+    #[error("Creating kill eventfd failed: {0}")]
     CreateKillEventFd(io::Error),
-    /// Cloning kill eventfd failed.
+    #[error("Cloning kill eventfd failed: {0}")]
     CloneKillEventFd(io::Error),
-    /// Invalid descriptor table address.
+    #[error("Invalid descriptor table address.")]
     DescriptorTableAddress,
-    /// Signal used queue failed.
+    #[error("Signal used queue failed: {0}")]
     FailedSignalingUsedQueue(io::Error),
-    /// Failed to read vhost eventfd.
+    #[error("Failed to read vhost eventfd: {0}")]
     MemoryRegions(MmapError),
-    /// Failed removing socket path
+    #[error("Failed removing socket path: {0}")]
     RemoveSocketPath(io::Error),
-    /// Failed to create master.
+    #[error("Failed to create master: {0}")]
     VhostUserCreateMaster(VhostError),
-    /// Failed to open vhost device.
+    #[error("Failed to open vhost device: {0}")]
     VhostUserOpen(VhostError),
-    /// Connection to socket failed.
+    #[error("Connection to socket failed.")]
     VhostUserConnect,
-    /// Get features failed.
+    #[error("Get features failed: {0}")]
     VhostUserGetFeatures(VhostError),
-    /// Get queue max number failed.
+    #[error("Get queue max number failed: {0}")]
     VhostUserGetQueueMaxNum(VhostError),
-    /// Get protocol features failed.
+    #[error("Get protocol features failed: {0}")]
     VhostUserGetProtocolFeatures(VhostError),
-    /// Get vring base failed.
+    #[error("Get vring base failed: {0}")]
     VhostUserGetVringBase(VhostError),
-    /// Vhost-user Backend not support vhost-user protocol.
+    #[error("Vhost-user Backend not support vhost-user protocol.")]
     VhostUserProtocolNotSupport,
-    /// Set owner failed.
+    #[error("Set owner failed: {0}")]
     VhostUserSetOwner(VhostError),
-    /// Reset owner failed.
+    #[error("Reset owner failed: {0}")]
     VhostUserResetOwner(VhostError),
-    /// Set features failed.
+    #[error("Set features failed: {0}")]
     VhostUserSetFeatures(VhostError),
-    /// Set protocol features failed.
+    #[error("Set protocol features failed: {0}")]
     VhostUserSetProtocolFeatures(VhostError),
-    /// Set mem table failed.
+    #[error("Set mem table failed: {0}")]
     VhostUserSetMemTable(VhostError),
-    /// Set vring num failed.
+    #[error("Set vring num failed: {0}")]
     VhostUserSetVringNum(VhostError),
-    /// Set vring addr failed.
+    #[error("Set vring addr failed: {0}")]
     VhostUserSetVringAddr(VhostError),
-    /// Set vring base failed.
+    #[error("Set vring base failed: {0}")]
     VhostUserSetVringBase(VhostError),
-    /// Set vring call failed.
+    #[error("Set vring call failed: {0}")]
     VhostUserSetVringCall(VhostError),
-    /// Set vring kick failed.
+    #[error("Set vring kick failed: {0}")]
     VhostUserSetVringKick(VhostError),
-    /// Set vring enable failed.
+    #[error("Set vring enable failed: {0}")]
     VhostUserSetVringEnable(VhostError),
-    /// Failed to create vhost eventfd.
+    #[error("Failed to create vhost eventfd: {0}")]
     VhostIrqCreate(io::Error),
-    /// Failed to read vhost eventfd.
+    #[error("Failed to read vhost eventfd: {0}")]
     VhostIrqRead(io::Error),
-    /// Failed to read vhost eventfd.
+    #[error("Failed to read vhost eventfd: {0}")]
     VhostUserMemoryRegion(MmapError),
-    /// Failed to create the master request handler from slave.
+    #[error("Failed to create the master request handler from slave: {0}")]
     MasterReqHandlerCreation(vhost::vhost_user::Error),
-    /// Set slave request fd failed.
+    #[error("Set slave request fd failed: {0}")]
     VhostUserSetSlaveRequestFd(vhost::Error),
-    /// Add memory region failed.
+    #[error("Add memory region failed: {0}")]
     VhostUserAddMemReg(VhostError),
-    /// Failed getting the configuration.
+    #[error("Failed getting the configuration: {0}")]
     VhostUserGetConfig(VhostError),
-    /// Failed setting the configuration.
+    #[error("Failed setting the configuration: {0}")]
     VhostUserSetConfig(VhostError),
-    /// Failed getting inflight shm log.
+    #[error("Failed getting inflight shm log: {0}")]
     VhostUserGetInflight(VhostError),
-    /// Failed setting inflight shm log.
+    #[error("Failed setting inflight shm log: {0}")]
     VhostUserSetInflight(VhostError),
-    /// Failed setting the log base.
+    #[error("Failed setting the log base: {0}")]
     VhostUserSetLogBase(VhostError),
-    /// Invalid used address.
+    #[error("Invalid used address.")]
     UsedAddress,
-    /// Invalid features provided from vhost-user backend
+    #[error("Invalid features provided from vhost-user backe.")]
     InvalidFeatures,
-    /// Missing file descriptor for the region.
+    #[error("Missing file descriptor for the region.")]
     MissingRegionFd,
-    /// Missing IrqFd
+    #[error("Missing IrqFd.")]
     MissingIrqFd,
-    /// Failed getting the available index.
+    #[error("Failed getting the available index: {0}")]
     GetAvailableIndex(QueueError),
-    /// Migration is not supported by this vhost-user device.
+    #[error("Migration is not supported by this vhost-user device.")]
     MigrationNotSupported,
-    /// Failed creating memfd.
+    #[error("Failed creating memfd: {0}")]
     MemfdCreate(io::Error),
-    /// Failed truncating the file size to the expected size.
+    #[error("Failed truncating the file size to the expected size: {0}")]
     SetFileSize(io::Error),
-    /// Failed to set the seals on the file.
+    #[error("Failed to set the seals on the file: {0}")]
     SetSeals(io::Error),
-    /// Failed creating new mmap region
+    #[error("Failed creating new mmap region: {0}")]
     NewMmapRegion(MmapRegionError),
-    /// Could not find the shm log region
+    #[error("Could not find the shm log region.")]
     MissingShmLogRegion,
 }
 type Result<T> = std::result::Result<T, Error>;

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -313,11 +313,7 @@ impl VirtioDevice for Net {
                 Thread::VirtioVhostNetCtl,
                 &mut epoll_threads,
                 &self.exit_evt,
-                move || {
-                    if let Err(e) = ctrl_handler.run_ctrl(paused, paused_sync.unwrap()) {
-                        error!("Error running worker: {:?}", e);
-                    }
-                },
+                move || ctrl_handler.run_ctrl(paused, paused_sync.unwrap()),
             )?;
             self.ctrl_queue_epoll_thread = Some(epoll_threads.remove(0));
         }
@@ -352,11 +348,7 @@ impl VirtioDevice for Net {
             Thread::VirtioVhostNet,
             &mut epoll_threads,
             &self.exit_evt,
-            move || {
-                if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
-                    error!("Error running worker: {:?}", e);
-                }
-            },
+            move || handler.run(paused, paused_sync.unwrap()),
         )?;
         self.epoll_thread = Some(epoll_threads.remove(0));
 

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -467,11 +467,7 @@ where
             Thread::VirtioVsock,
             &mut epoll_threads,
             &self.exit_evt,
-            move || {
-                if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
-                    error!("Error running worker: {:?}", e);
-                }
-            },
+            move || handler.run(paused, paused_sync.unwrap()),
         )?;
 
         self.common.epoll_threads = Some(epoll_threads);

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -353,7 +353,7 @@ mod tests {
             let event = epoll::Event::new(events, TX_QUEUE_EVENT as u64);
             let mut epoll_helper =
                 EpollHelper::new(&self.handler.kill_evt, &self.handler.pause_evt).unwrap();
-            self.handler.handle_event(&mut epoll_helper, &event);
+            self.handler.handle_event(&mut epoll_helper, &event).ok();
         }
         pub fn signal_rxq_event(&mut self) {
             self.handler.queue_evts[0].write(1).unwrap();
@@ -361,7 +361,7 @@ mod tests {
             let event = epoll::Event::new(events, RX_QUEUE_EVENT as u64);
             let mut epoll_helper =
                 EpollHelper::new(&self.handler.kill_evt, &self.handler.pause_evt).unwrap();
-            self.handler.handle_event(&mut epoll_helper, &event);
+            self.handler.handle_event(&mut epoll_helper, &event).ok();
         }
     }
 }

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -341,11 +341,7 @@ impl VirtioDevice for Watchdog {
             Thread::VirtioWatchdog,
             &mut epoll_threads,
             &self.exit_evt,
-            move || {
-                if let Err(e) = handler.run(paused, paused_sync.unwrap()) {
-                    error!("Error running worker: {:?}", e);
-                }
-            },
+            move || handler.run(paused, paused_sync.unwrap()),
         )?;
 
         self.common.epoll_threads = Some(epoll_threads);


### PR DESCRIPTION
This PR ensures VMM shutdown upon errors from virtio-device worker threads, through the following steps:

* Derive `this::error` for related Error enums from `virtio-device` and dependent crates
* Refactor `EpollHelperHandler::handler_event()` and all its implementations from various virtio devices to propagate errors properly
* Refactor `spawn_virtio_thread()` to shutdown VMM upon receiving errors from virtio-device worker threads

This PR also exposes a flaw from the integration test `test_live_migration_ovs` which is now being fixed.

Fixes: #4462

Signed-off-by: Bo Chen <chen.bo@intel.com>