### PR TITLE
.github: Move per-commit check (using --tests) to quality checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,14 +29,9 @@ jobs:
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: ${{ matrix.rust }}
-            target: ${{ matrix.target }}
-            override: true
-
-      - name: Debug Check (default features)
-        run: |
-          git rev-list origin/main..$GITHUB_SHA | xargs -t -I % sh -c 'git checkout %; cargo check --tests --all --target=${{ matrix.target }}'
-          git checkout $GITHUB_SHA
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
 
       - name: Build (default features)
         run: cargo rustc --locked --bin cloud-hypervisor -- -D warnings

--- a/.github/workflows/quality-aarch64.yaml
+++ b/.github/workflows/quality-aarch64.yaml
@@ -25,10 +25,16 @@ jobs:
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: ${{ matrix.rust }}
-            target: ${{ matrix.target }}
-            override: true
-            components: rustfmt, clippy
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+          components: rustfmt, clippy
+
+      - name: Debug Check (default features)
+        run: |
+          git rev-list origin/main..$GITHUB_SHA | xargs -t -I % sh -c 'git checkout %; cargo check --tests --all --target=${{ matrix.target }}'
+          git checkout $GITHUB_SHA
+
       - name: Formatting (rustfmt)
         run: cargo fmt -- --check
 

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -30,6 +30,11 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - name: Debug Check (default features)
+        run: |
+          git rev-list origin/main..$GITHUB_SHA | xargs -t -I % sh -c 'git checkout %; cargo check --tests --all --target=${{ matrix.target }}'
+          git checkout $GITHUB_SHA
+
       - name: Formatting (rustfmt)
         run: cargo fmt -- --check
 


### PR DESCRIPTION
This removes the requirement for the tests (dev-dependencies) to build
with all supported toolchains including the MSRV.

See: #4318

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
