### PR TITLE
build: enable size optimization for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ rust-version = "1.60"
 
 [profile.release]
 lto = true
+codegen-units = 1
+opt-level = "s"
 
 [dependencies]
 anyhow = "1.0.65"


### PR DESCRIPTION
This reduces the binary size from 7.3M to 6.5M.

Also the build time for a clean build shrinks from 1m28s to 1m14s on my
development machine (an eight-core VM on Azure). This goes against the
conventional wisdom but it is what it is.

Signed-off-by: Wei Liu <liuwe@microsoft.com>