### PR TITLE
Prepare for chained booting (firmware -> kernel)

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -989,7 +989,7 @@ impl Vm {
     }
 
     #[cfg(target_arch = "x86_64")]
-    fn load_firmware(
+    fn load_legacy_firmware(
         mut firmware: File,
         memory_manager: &Arc<Mutex<MemoryManager>>,
     ) -> Result<EntryPoint> {
@@ -1055,7 +1055,9 @@ impl Vm {
         ) {
             Ok(entry_addr) => entry_addr,
             Err(e) => match e {
-                Elf(InvalidElfMagicNumber) => return Self::load_firmware(kernel, &memory_manager),
+                Elf(InvalidElfMagicNumber) => {
+                    return Self::load_legacy_firmware(kernel, &memory_manager)
+                }
                 _ => {
                     return Err(Error::KernelLoad(e));
                 }


### PR DESCRIPTION
This prepares the ground work for chained booting as required on aarch64 by
adding explicit firmware controls and using them on x86_64. This is just a
start as I think it would be nice if this could be split into a new struct as
vmm::payload::Payload which might help simplify the vmm::Vm code.

- vmm: x86_64: Split legacy firmware loading into own function
- vmm: x86_64: Use more general name for payload handling
- vmm: x86_64: Make kernel loading use PayloadConfig
- vmm: x86_64: Split payload loading into it's own function
- main, vmm: Add option to pass firmware parameter in payload
- vmm: x86_64: Add support for firmware loading
- vmm: x86_64: Rename load_firmware() to reflect its purpose

See: #4445
