### PR TITLE
tests: live_migration: Run most tests in parallel

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -272,7 +272,14 @@ fi
 
 # Run all test cases related to live migration
 if [ $RES -eq 0 ]; then
-    time cargo test $features "live_migration::$test_filter" --target $BUILD_TARGET -- --test-threads=1 ${test_binary_args[*]}
+    time cargo test $features "live_migration_parallel::$test_filter" --target $BUILD_TARGET -- ${test_binary_args[*]}
+    RES=$?
+else
+    exit $RES
+fi
+
+if [ $RES -eq 0 ]; then
+    time cargo test $features "live_migration_sequential::$test_filter" --target $BUILD_TARGET -- --test-threads=1 ${test_binary_args[*]}
     RES=$?
 else
     exit $RES

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -250,13 +250,13 @@ echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 # Run all direct kernel boot (Device Tree) test cases in mod `parallel`
-time cargo test $features "parallel::$test_filter" --target $BUILD_TARGET -- ${test_binary_args[*]}
+time cargo test $features "common_parallel::$test_filter" --target $BUILD_TARGET -- ${test_binary_args[*]}
 RES=$?
 
 # Run some tests in sequence since the result could be affected by other tests
 # running in parallel.
 if [ $RES -eq 0 ]; then
-    time cargo test $features "sequential::$test_filter" --target $BUILD_TARGET -- --test-threads=1 ${test_binary_args[*]}
+    time cargo test $features "common_sequential::$test_filter" --target $BUILD_TARGET -- --test-threads=1 ${test_binary_args[*]}
     RES=$?
 else
     exit $RES

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -96,7 +96,15 @@ echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 export RUST_BACKTRACE=1
-time cargo test $features "live_migration::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
+time cargo test $features "live_migration_parallel::$test_filter" -- ${test_binary_args[*]}
 RES=$?
+
+# Run some tests in sequence since the result could be affected by other tests
+# running in parallel.
+if [ $RES -eq 0 ]; then
+    export RUST_BACKTRACE=1
+    time cargo test $features "live_migration_sequential::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
+    RES=$?
+fi
 
 exit $RES

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -195,14 +195,14 @@ sudo chmod a+rwX /dev/hugepages
 ulimit -l unlimited
 
 export RUST_BACKTRACE=1
-time cargo test $features "parallel::$test_filter" -- ${test_binary_args[*]}
+time cargo test $features "common_parallel::$test_filter" -- ${test_binary_args[*]}
 RES=$?
 
 # Run some tests in sequence since the result could be affected by other tests
 # running in parallel.
 if [ $RES -eq 0 ]; then
     export RUST_BACKTRACE=1
-    time cargo test $features "sequential::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
+    time cargo test $features "common_sequential::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
     RES=$?
 fi
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1950,7 +1950,7 @@ fn check_guest_watchdog_one_reboot(
     }
 }
 
-mod parallel {
+mod common_parallel {
     use std::{fs::OpenOptions, io::SeekFrom};
 
     use crate::*;
@@ -6786,7 +6786,7 @@ mod parallel {
     }
 }
 
-mod sequential {
+mod common_sequential {
     use crate::*;
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8680,98 +8680,6 @@ mod live_migration {
         handle_child_output(r, &dest_output);
     }
 
-    #[test]
-    fn test_live_migration_basic() {
-        _test_live_migration(false, false, false, false, false)
-    }
-
-    #[test]
-    fn test_live_migration_local() {
-        _test_live_migration(false, false, true, false, false)
-    }
-
-    #[test]
-    #[cfg(not(feature = "mshv"))]
-    fn test_live_migration_numa() {
-        _test_live_migration(false, true, false, false, false)
-    }
-
-    #[test]
-    #[cfg(not(feature = "mshv"))]
-    fn test_live_migration_numa_local() {
-        _test_live_migration(false, true, true, false, false)
-    }
-
-    #[test]
-    fn test_live_migration_watchdog() {
-        _test_live_migration(false, false, false, true, false)
-    }
-
-    #[test]
-    fn test_live_migration_watchdog_local() {
-        _test_live_migration(false, false, true, true, false)
-    }
-
-    #[test]
-    fn test_live_migration_balloon() {
-        _test_live_migration(false, false, false, false, true)
-    }
-
-    #[test]
-    fn test_live_migration_balloon_local() {
-        _test_live_migration(false, false, true, false, true)
-    }
-
-    #[test]
-    #[ignore]
-    fn test_live_upgrade_basic() {
-        _test_live_migration(true, false, false, false, false)
-    }
-
-    #[test]
-    #[ignore]
-    fn test_live_upgrade_local() {
-        _test_live_migration(true, false, true, false, false)
-    }
-
-    #[test]
-    #[ignore]
-    #[cfg(not(feature = "mshv"))]
-    fn test_live_upgrade_numa() {
-        _test_live_migration(true, true, false, false, false)
-    }
-
-    #[test]
-    #[ignore]
-    #[cfg(not(feature = "mshv"))]
-    fn test_live_upgrade_numa_local() {
-        _test_live_migration(true, true, true, false, false)
-    }
-
-    #[test]
-    #[ignore]
-    fn test_live_upgrade_watchdog() {
-        _test_live_migration(true, false, false, true, false)
-    }
-
-    #[test]
-    #[ignore]
-    fn test_live_upgrade_watchdog_local() {
-        _test_live_migration(true, false, true, true, false)
-    }
-
-    #[test]
-    #[ignore]
-    fn test_live_upgrade_balloon() {
-        _test_live_migration(true, false, false, false, true)
-    }
-
-    #[test]
-    #[ignore]
-    fn test_live_upgrade_balloon_local() {
-        _test_live_migration(true, false, true, false, true)
-    }
-
     fn _test_live_migration_ovs_dpdk(upgrade_test: bool, local: bool) {
         let ovs_focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
         let ovs_guest = Guest::new(Box::new(ovs_focal));
@@ -8974,30 +8882,131 @@ mod live_migration {
         cleanup_ovs_dpdk();
     }
 
-    #[test]
-    #[cfg(not(feature = "mshv"))]
-    fn test_live_migration_ovs_dpdk() {
-        _test_live_migration_ovs_dpdk(false, false);
+    mod live_migration_parallel {
+        use super::*;
+        #[test]
+        fn test_live_migration_basic() {
+            _test_live_migration(false, false, false, false, false)
+        }
+
+        #[test]
+        fn test_live_migration_local() {
+            _test_live_migration(false, false, true, false, false)
+        }
+
+        #[test]
+        #[cfg(not(feature = "mshv"))]
+        fn test_live_migration_numa() {
+            _test_live_migration(false, true, false, false, false)
+        }
+
+        #[test]
+        #[cfg(not(feature = "mshv"))]
+        fn test_live_migration_numa_local() {
+            _test_live_migration(false, true, true, false, false)
+        }
+
+        #[test]
+        fn test_live_migration_watchdog() {
+            _test_live_migration(false, false, false, true, false)
+        }
+
+        #[test]
+        fn test_live_migration_watchdog_local() {
+            _test_live_migration(false, false, true, true, false)
+        }
+
+        #[test]
+        fn test_live_migration_balloon() {
+            _test_live_migration(false, false, false, false, true)
+        }
+
+        #[test]
+        fn test_live_migration_balloon_local() {
+            _test_live_migration(false, false, true, false, true)
+        }
+
+        #[test]
+        #[ignore]
+        fn test_live_upgrade_basic() {
+            _test_live_migration(true, false, false, false, false)
+        }
+
+        #[test]
+        #[ignore]
+        fn test_live_upgrade_local() {
+            _test_live_migration(true, false, true, false, false)
+        }
+
+        #[test]
+        #[ignore]
+        #[cfg(not(feature = "mshv"))]
+        fn test_live_upgrade_numa() {
+            _test_live_migration(true, true, false, false, false)
+        }
+
+        #[test]
+        #[ignore]
+        #[cfg(not(feature = "mshv"))]
+        fn test_live_upgrade_numa_local() {
+            _test_live_migration(true, true, true, false, false)
+        }
+
+        #[test]
+        #[ignore]
+        fn test_live_upgrade_watchdog() {
+            _test_live_migration(true, false, false, true, false)
+        }
+
+        #[test]
+        #[ignore]
+        fn test_live_upgrade_watchdog_local() {
+            _test_live_migration(true, false, true, true, false)
+        }
+
+        #[test]
+        #[ignore]
+        fn test_live_upgrade_balloon() {
+            _test_live_migration(true, false, false, false, true)
+        }
+
+        #[test]
+        #[ignore]
+        fn test_live_upgrade_balloon_local() {
+            _test_live_migration(true, false, true, false, true)
+        }
     }
 
-    #[test]
-    #[cfg(not(feature = "mshv"))]
-    fn test_live_migration_ovs_dpdk_local() {
-        _test_live_migration_ovs_dpdk(false, true);
-    }
+    mod live_migration_sequential {
+        #[cfg(not(feature = "mshv"))]
+        use super::*;
 
-    #[test]
-    #[ignore]
-    #[cfg(not(feature = "mshv"))]
-    fn test_live_upgrade_ovs_dpdk() {
-        _test_live_migration_ovs_dpdk(true, false);
-    }
+        // Require to run ovs-dpdk tests sequentially because they rely on the same ovs-dpdk setup
+        #[test]
+        #[cfg(not(feature = "mshv"))]
+        fn test_live_migration_ovs_dpdk() {
+            _test_live_migration_ovs_dpdk(false, false);
+        }
 
-    #[test]
-    #[ignore]
-    #[cfg(not(feature = "mshv"))]
-    fn test_live_upgrade_ovs_dpdk_local() {
-        _test_live_migration_ovs_dpdk(true, true);
+        #[test]
+        #[cfg(not(feature = "mshv"))]
+        fn test_live_migration_ovs_dpdk_local() {
+            _test_live_migration_ovs_dpdk(false, true);
+        }
+
+        #[test]
+        #[ignore]
+        #[cfg(not(feature = "mshv"))]
+        fn test_live_upgrade_ovs_dpdk() {
+            _test_live_migration_ovs_dpdk(true, false);
+        }
+
+        #[test]
+        #[ignore]
+        #[cfg(not(feature = "mshv"))]
+        fn test_live_upgrade_ovs_dpdk_local() {
+            _test_live_migration_ovs_dpdk(true, true);
+        }
     }
 }
 


### PR DESCRIPTION
Only the ovs-dpdk live-migration tests need to run in sequential as they
use the same ovs-dpdk setup.

Signed-off-by: Bo Chen <chen.bo@intel.com>