### PR TITLE
tests: Enable live upgrade tests

### DIFF
--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -46,7 +46,7 @@ fi
 popd
 
 # Download Cloud Hypervisor binary from its last stable release
-LAST_RELEASE_VERSION="v23.0"
+LAST_RELEASE_VERSION="v26.0"
 CH_RELEASE_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$LAST_RELEASE_VERSION/cloud-hypervisor-static"
 CH_RELEASE_NAME="cloud-hypervisor-static"
 pushd $WORKLOADS_DIR

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8927,82 +8927,85 @@ mod live_migration {
         }
 
         #[test]
-        #[ignore]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_basic() {
             _test_live_migration(true, false, false, false, false)
         }
 
         #[test]
-        #[ignore]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_local() {
             _test_live_migration(true, false, true, false, false)
         }
 
         #[test]
-        #[ignore]
         #[cfg(not(feature = "mshv"))]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_numa() {
             _test_live_migration(true, true, false, false, false)
         }
 
         #[test]
-        #[ignore]
         #[cfg(not(feature = "mshv"))]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_numa_local() {
             _test_live_migration(true, true, true, false, false)
         }
 
         #[test]
-        #[ignore]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_watchdog() {
             _test_live_migration(true, false, false, true, false)
         }
 
         #[test]
-        #[ignore]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_watchdog_local() {
             _test_live_migration(true, false, true, true, false)
         }
 
         #[test]
-        #[ignore]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_balloon() {
             _test_live_migration(true, false, false, false, true)
         }
 
         #[test]
-        #[ignore]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_balloon_local() {
             _test_live_migration(true, false, true, false, true)
         }
     }
 
     mod live_migration_sequential {
+        #[cfg(target_arch = "x86_64")]
         #[cfg(not(feature = "mshv"))]
         use super::*;
 
         // Require to run ovs-dpdk tests sequentially because they rely on the same ovs-dpdk setup
         #[test]
+        #[cfg(target_arch = "x86_64")]
         #[cfg(not(feature = "mshv"))]
         fn test_live_migration_ovs_dpdk() {
             _test_live_migration_ovs_dpdk(false, false);
         }
 
         #[test]
+        #[cfg(target_arch = "x86_64")]
         #[cfg(not(feature = "mshv"))]
         fn test_live_migration_ovs_dpdk_local() {
             _test_live_migration_ovs_dpdk(false, true);
         }
 
         #[test]
-        #[ignore]
+        #[cfg(target_arch = "x86_64")]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_ovs_dpdk() {
             _test_live_migration_ovs_dpdk(true, false);
         }
 
         #[test]
-        #[ignore]
+        #[cfg(target_arch = "x86_64")]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_ovs_dpdk_local() {
             _test_live_migration_ovs_dpdk(true, true);


### PR DESCRIPTION
Following our recent v26.0 release we can re-enable our live upgrade
tests to try and make it possible for us to move to making LTS releases.

Fixes: #3949

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
