### PR TITLE
virtio-devices: rng: correctly indicate number of bytes written

### DIFF
--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -58,17 +58,13 @@ impl RngEpollHandler {
             // Drivers can only read from the random device.
             if desc.is_write_only() {
                 // Fill the read with data from the random device on the host.
-                if desc_chain
-                    .memory()
-                    .read_from(
-                        desc.addr()
-                            .translate_gva(self.access_platform.as_ref(), desc.len() as usize),
-                        &mut self.random_file,
-                        desc.len() as usize,
-                    )
-                    .is_ok()
-                {
-                    len = desc.len();
+                if let Ok(number_of_bytes) = desc_chain.memory().read_from(
+                    desc.addr()
+                        .translate_gva(self.access_platform.as_ref(), desc.len() as usize),
+                    &mut self.random_file,
+                    desc.len() as usize,
+                ) {
+                    len = number_of_bytes as u32;
                 }
             }
 


### PR DESCRIPTION
When configuring Cloud Hypervisor with an RNG device that is not backed by a character device, but by an ordinary text file, reads from that file may only be partial.

When that happens, the device needs to signal to the driver that only parts of the buffer have been overwritten, but right now it marks the whole buffer as used.

Even after this change, the device is still not fully compliant with the [virtio specification](https://web.archive.org/web/20220719215721/https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.pdf) for Entropy Devices (Section 5.4), which states:

> When the driver requires random bytes, it places the descriptor of one or more buffers in the queue. It will be completely filled by random data by the device. 
> [...]
> The device MUST place one or more random bytes into the buffer, but it MAY use less than the entire buffer length.

When the provided source file is read to the end, the virtio device will write zero bytes, but since there are none available in the source, this seems to be the only sensible behavior. In Linux, this eventually causes `hwrng: no data available` to appear in the kernel log.