### PR TITLE
Enable GDB support on AArch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "kvm-ioctls"
 version = "0.11.0"
-source = "git+https://github.com/rust-vmm/kvm-ioctls?branch=main#ccf0bda07485b2433616de998c000aa5f04ce806"
+source = "git+https://github.com/rust-vmm/kvm-ioctls?branch=main#63f2f1231d49478197e15b8e9ff5d4e827aa288f"
 dependencies = [
  "kvm-bindings",
  "libc",

--- a/arch/src/aarch64/regs.rs
+++ b/arch/src/aarch64/regs.rs
@@ -39,3 +39,6 @@ macro_rules! arm64_sys_reg {
 }
 
 arm64_sys_reg!(MPIDR_EL1, 3, 0, 0, 0, 5);
+arm64_sys_reg!(ID_AA64MMFR0_EL1, 3, 0, 0, 7, 0);
+arm64_sys_reg!(TTBR1_EL1, 3, 0, 2, 0, 1);
+arm64_sys_reg!(TCR_EL1, 3, 0, 2, 0, 2);

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -19,7 +19,6 @@ use crate::kvm::{TdxExitDetails, TdxExitStatus};
 use crate::CpuState;
 use crate::MpState;
 use thiserror::Error;
-#[cfg(target_arch = "x86_64")]
 use vm_memory::GuestAddress;
 
 #[derive(Error, Debug)]
@@ -347,7 +346,6 @@ pub trait Vcpu: Send + Sync {
     fn notify_guest_clock_paused(&self) -> Result<()> {
         Ok(())
     }
-    #[cfg(target_arch = "x86_64")]
     ///
     /// Sets debug registers to set hardware breakpoints and/or enable single step.
     ///

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -29,6 +29,8 @@ use crate::GuestMemoryMmap;
 use crate::CPU_MANAGER_SNAPSHOT_ID;
 use acpi_tables::{aml, aml::Aml, sdt::Sdt};
 use anyhow::anyhow;
+#[cfg(all(target_arch = "aarch64", feature = "gdb"))]
+use arch::aarch64::regs;
 use arch::EntryPoint;
 use arch::NumaNodes;
 use devices::interrupt_controller::InterruptController;
@@ -77,6 +79,18 @@ use vm_migration::{
 };
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::{register_signal_handler, SIGRTMIN};
+
+#[cfg(all(target_arch = "aarch64", feature = "gdb"))]
+/// Extract the specified bits of a 64-bit integer.
+/// For example, to extrace 2 bits from offset 1 (zero based) of `6u64`,
+/// following expression should return 3 (`0b11`):
+/// `extract_bits_64!(0b0000_0110u64, 1, 2)`
+///
+macro_rules! extract_bits_64 {
+    ($value: tt, $offset: tt, $length: tt) => {
+        ($value >> $offset) & (!0u64 >> (64 - $length))
+    };
+}
 
 pub const CPU_MANAGER_ACPI_SIZE: usize = 0xc;
 
@@ -144,6 +158,10 @@ pub enum Error {
     #[cfg(all(target_arch = "x86_64", feature = "gdb"))]
     #[error("Error translating virtual address: {0}")]
     TranslateVirtualAddress(#[source] hypervisor::HypervisorCpuError),
+
+    #[cfg(all(target_arch = "aarch64", feature = "gdb"))]
+    #[error("Error translating virtual address: {0}")]
+    TranslateVirtualAddress(#[source] anyhow::Error),
 
     #[cfg(all(feature = "amx", target_arch = "x86_64"))]
     #[error("Error setting up AMX: {0}")]
@@ -1492,9 +1510,168 @@ impl CpuManager {
         Ok(gpa)
     }
 
+    ///
+    /// On AArch64, `translate_gva` API is not provided by KVM. We implemented
+    /// it in VMM by walking through translation tables.
+    ///
+    /// Address translation is big topic, here we only focus the scenario that
+    /// happens in VMM while debugging kernel. This `translate_gva`
+    /// implementation is restricted to:
+    /// - Exception Level 1
+    /// - Translate high address range only (kernel space)
+    ///
+    /// This implementation supports following Arm-v8a features related to
+    /// address translation:
+    /// - FEAT_LPA
+    /// - FEAT_LVA
+    /// - FEAT_LPA2
+    ///
     #[cfg(all(target_arch = "aarch64", feature = "gdb"))]
     fn translate_gva(&self, cpu_id: u8, gva: u64) -> Result<u64> {
-        unimplemented!()
+        let tcr_el1: u64 = self.vcpus[usize::from(cpu_id)]
+            .lock()
+            .unwrap()
+            .vcpu
+            .get_sys_reg(regs::TCR_EL1)
+            .map_err(|e| Error::TranslateVirtualAddress(e.into()))?;
+        let ttbr1_el1: u64 = self.vcpus[usize::from(cpu_id)]
+            .lock()
+            .unwrap()
+            .vcpu
+            .get_sys_reg(regs::TTBR1_EL1)
+            .map_err(|e| Error::TranslateVirtualAddress(e.into()))?;
+        let id_aa64mmfr0_el1: u64 = self.vcpus[usize::from(cpu_id)]
+            .lock()
+            .unwrap()
+            .vcpu
+            .get_sys_reg(regs::ID_AA64MMFR0_EL1)
+            .map_err(|e| Error::TranslateVirtualAddress(e.into()))?;
+
+        // Bit 55 of the VA determines the range, high (0xFFFxxx...)
+        // or low (0x000xxx...).
+        let high_range = extract_bits_64!(gva, 55, 1);
+        if high_range == 0 {
+            info!("VA (0x{:x}) range is not supported!", gva);
+            return Ok(gva);
+        }
+
+        // High range size offset
+        let tsz = extract_bits_64!(tcr_el1, 16, 6);
+        // Granule size
+        let tg = extract_bits_64!(tcr_el1, 30, 2);
+        // Indication of 48-bits (0) or 52-bits (1) for FEAT_LPA2
+        let ds = extract_bits_64!(tcr_el1, 59, 1);
+
+        if tsz == 0 {
+            info!("VA translation is not ready!");
+            return Ok(gva);
+        }
+
+        // VA size is determined by TCR_BL1.T1SZ
+        let va_size = 64 - tsz;
+        // Number of bits in VA consumed in each level of translation
+        let stride = match tg {
+            3 => 13, // 64KB granule size
+            1 => 11, // 16KB granule size
+            _ => 9,  // 4KB, default
+        };
+        // Starting level of walking
+        let mut level = 4 - (va_size - 4) / stride;
+
+        // PA or IPA size is determined
+        let tcr_ips = extract_bits_64!(tcr_el1, 32, 3);
+        #[allow(clippy::identity_op)]
+        let pa_range = extract_bits_64!(id_aa64mmfr0_el1, 0, 4);
+        // The IPA size in TCR_BL1 and PA Range in ID_AA64MMFR0_EL1 should match.
+        // To be safe, we use the minimum value if they are different.
+        let pa_range = std::cmp::min(tcr_ips, pa_range);
+        // PA size in bits
+        let pa_size = match pa_range {
+            0 => 32,
+            1 => 36,
+            2 => 40,
+            3 => 42,
+            4 => 44,
+            5 => 48,
+            6 => 52,
+            _ => {
+                return Err(Error::TranslateVirtualAddress(anyhow!(format!(
+                    "PA range not supported {}",
+                    pa_range
+                ))))
+            }
+        };
+
+        let indexmask_grainsize = (!0u64) >> (64 - (stride + 3));
+        let mut indexmask = (!0u64) >> (64 - (va_size - (stride * (4 - level))));
+        // If FEAT_LPA2 is present, the translation table descriptor holds
+        // 50 bits of the table address of next level.
+        // Otherwise, it is 48 bits.
+        let descaddrmask = if ds == 1 {
+            !0u64 >> (64 - 50) // mask with 50 least significant bits
+        } else {
+            !0u64 >> (64 - 48) // mask with 48 least significant bits
+        };
+        let descaddrmask = descaddrmask & !indexmask_grainsize;
+
+        // Translation table base address
+        #[allow(clippy::identity_op)]
+        let mut descaddr: u64 = extract_bits_64!(ttbr1_el1, 0, 48);
+        // In the case of FEAT_LPA and FEAT_LPA2, the initial translation table
+        // addresss bits [48:51] comes from TTBR1_EL1 bits [2:5].
+        if pa_size == 52 {
+            descaddr |= extract_bits_64!(ttbr1_el1, 2, 4) << 48;
+        }
+
+        // Loop through tables of each level
+        loop {
+            // Table offset for current level
+            let table_offset: u64 = (gva >> (stride * (4 - level))) & indexmask;
+            descaddr |= table_offset;
+            descaddr &= !7u64;
+
+            let mut buf = [0; 8];
+            self.vm_memory
+                .memory()
+                .read(&mut buf, GuestAddress(descaddr))
+                .map_err(|e| Error::TranslateVirtualAddress(e.into()))?;
+            let descriptor = u64::from_le_bytes(buf);
+
+            descaddr = descriptor & descaddrmask;
+            // In the case of FEAT_LPA, the next-level translation table address
+            // bits [48:51] comes from bits [12:15] of the current descriptor.
+            // For FEAT_LPA2, the next-level translation table address
+            // bits [50:51] comes from bits [8:9] of the current descriptor,
+            // bits [48:49] comes from bits [48:49] of the descriptor which was
+            // handled previously.
+            if pa_size == 52 {
+                if ds == 1 {
+                    // FEAT_LPA2
+                    descaddr |= extract_bits_64!(descriptor, 8, 2) << 50;
+                } else {
+                    // FEAT_LPA
+                    descaddr |= extract_bits_64!(descriptor, 12, 4) << 48;
+                }
+            }
+
+            if (descriptor & 2) != 0 && (level < 3) {
+                // This is a table entry. Go down to next level.
+                level += 1;
+                indexmask = indexmask_grainsize;
+                continue;
+            }
+
+            break;
+        }
+
+        // We have reached either:
+        // - a page entry at level 3 or
+        // - a block entry at level 1 or 2
+        let page_size = 1u64 << ((stride * (4 - level)) + 3);
+        descaddr &= !(page_size - 1);
+        descaddr |= gva & (page_size - 1);
+
+        Ok(descaddr)
     }
 }
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -32,8 +32,12 @@ use anyhow::anyhow;
 use arch::EntryPoint;
 use arch::NumaNodes;
 use devices::interrupt_controller::InterruptController;
+#[cfg(all(target_arch = "aarch64", feature = "gdb"))]
+use gdbstub_arch::aarch64::reg::AArch64CoreRegs as CoreRegs;
 #[cfg(all(target_arch = "x86_64", feature = "gdb"))]
-use gdbstub_arch::x86::reg::{X86SegmentRegs, X86_64CoreRegs};
+use gdbstub_arch::x86::reg::{X86SegmentRegs, X86_64CoreRegs as CoreRegs};
+#[cfg(all(target_arch = "aarch64", feature = "gdb"))]
+use hypervisor::aarch64::StandardRegisters;
 #[cfg(feature = "guest_debug")]
 use hypervisor::arch::x86::msr_index;
 #[cfg(target_arch = "x86_64")]
@@ -133,7 +137,7 @@ pub enum Error {
     #[error("Error initializing PMU: {0}")]
     InitPmu(#[source] hypervisor::HypervisorCpuError),
 
-    #[cfg(all(target_arch = "x86_64", feature = "gdb"))]
+    #[cfg(feature = "gdb")]
     #[error("Error during CPU debug: {0}")]
     CpuDebug(#[source] hypervisor::HypervisorCpuError),
 
@@ -950,7 +954,7 @@ impl CpuManager {
                             // vcpu.run() returns false on a triple-fault so trigger a reset
                             match vcpu.run() {
                                 Ok(run) => match run {
-                                    #[cfg(all(target_arch = "x86_64", feature = "kvm"))]
+                                    #[cfg(feature = "kvm")]
                                     VmExit::Debug => {
                                         info!("VmExit::Debug");
                                         #[cfg(feature = "gdb")]
@@ -1437,7 +1441,7 @@ impl CpuManager {
         pptt
     }
 
-    #[cfg(all(target_arch = "x86_64", feature = "gdb"))]
+    #[cfg(feature = "gdb")]
     fn get_regs(&self, cpu_id: u8) -> Result<StandardRegisters> {
         self.vcpus[usize::from(cpu_id)]
             .lock()
@@ -1447,7 +1451,7 @@ impl CpuManager {
             .map_err(Error::CpuDebug)
     }
 
-    #[cfg(all(target_arch = "x86_64", feature = "gdb"))]
+    #[cfg(feature = "gdb")]
     fn set_regs(&self, cpu_id: u8, regs: &StandardRegisters) -> Result<()> {
         self.vcpus[usize::from(cpu_id)]
             .lock()
@@ -1486,6 +1490,11 @@ impl CpuManager {
             .translate_gva(gva, /* flags: unused */ 0)
             .map_err(Error::TranslateVirtualAddress)?;
         Ok(gpa)
+    }
+
+    #[cfg(all(target_arch = "aarch64", feature = "gdb"))]
+    fn translate_gva(&self, cpu_id: u8, gva: u64) -> Result<u64> {
+        unimplemented!()
     }
 }
 
@@ -1932,7 +1941,7 @@ impl Debuggable for CpuManager {
     }
 
     #[cfg(target_arch = "x86_64")]
-    fn read_regs(&self, cpu_id: usize) -> std::result::Result<X86_64CoreRegs, DebuggableError> {
+    fn read_regs(&self, cpu_id: usize) -> std::result::Result<CoreRegs, DebuggableError> {
         // General registers: RAX, RBX, RCX, RDX, RSI, RDI, RBP, RSP, r8-r15
         let gregs = self
             .get_regs(cpu_id as u8)
@@ -1962,7 +1971,7 @@ impl Debuggable for CpuManager {
 
         // TODO: Add other registers
 
-        Ok(X86_64CoreRegs {
+        Ok(CoreRegs {
             regs,
             eflags,
             rip,
@@ -1971,11 +1980,24 @@ impl Debuggable for CpuManager {
         })
     }
 
+    #[cfg(target_arch = "aarch64")]
+    fn read_regs(&self, cpu_id: usize) -> std::result::Result<CoreRegs, DebuggableError> {
+        let gregs = self
+            .get_regs(cpu_id as u8)
+            .map_err(DebuggableError::ReadRegs)?;
+        Ok(CoreRegs {
+            x: gregs.regs.regs,
+            sp: gregs.regs.sp,
+            pc: gregs.regs.pc,
+            ..Default::default()
+        })
+    }
+
     #[cfg(target_arch = "x86_64")]
     fn write_regs(
         &self,
         cpu_id: usize,
-        regs: &X86_64CoreRegs,
+        regs: &CoreRegs,
     ) -> std::result::Result<(), DebuggableError> {
         let orig_gregs = self
             .get_regs(cpu_id as u8)
@@ -2025,7 +2047,26 @@ impl Debuggable for CpuManager {
         Ok(())
     }
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(target_arch = "aarch64")]
+    fn write_regs(
+        &self,
+        cpu_id: usize,
+        regs: &CoreRegs,
+    ) -> std::result::Result<(), DebuggableError> {
+        let mut gregs = self
+            .get_regs(cpu_id as u8)
+            .map_err(DebuggableError::ReadRegs)?;
+
+        gregs.regs.regs = regs.x;
+        gregs.regs.sp = regs.sp;
+        gregs.regs.pc = regs.pc;
+
+        self.set_regs(cpu_id as u8, &gregs)
+            .map_err(DebuggableError::WriteRegs)?;
+
+        Ok(())
+    }
+
     fn read_mem(
         &self,
         cpu_id: usize,
@@ -2056,7 +2097,6 @@ impl Debuggable for CpuManager {
         Ok(buf)
     }
 
-    #[cfg(target_arch = "x86_64")]
     fn write_mem(
         &self,
         cpu_id: usize,

--- a/vmm/src/gdb.rs
+++ b/vmm/src/gdb.rs
@@ -24,6 +24,10 @@ use gdbstub::{
         Target, TargetError, TargetResult,
     },
 };
+#[cfg(target_arch = "aarch64")]
+use gdbstub_arch::aarch64::reg::AArch64CoreRegs as CoreRegs;
+#[cfg(target_arch = "aarch64")]
+use gdbstub_arch::aarch64::AArch64 as GdbArch;
 #[cfg(target_arch = "x86_64")]
 use gdbstub_arch::x86::reg::X86_64CoreRegs as CoreRegs;
 #[cfg(target_arch = "x86_64")]
@@ -31,7 +35,6 @@ use gdbstub_arch::x86::X86_64_SSE as GdbArch;
 use std::{os::unix::net::UnixListener, sync::mpsc};
 use vm_memory::{GuestAddress, GuestMemoryError};
 
-#[cfg(target_arch = "x86_64")]
 type ArchUsize = u64;
 
 #[derive(Debug)]
@@ -121,7 +124,6 @@ pub struct GdbStub {
     gdb_sender: mpsc::Sender<GdbRequest>,
     gdb_event: vmm_sys_util::eventfd::EventFd,
     vm_event: vmm_sys_util::eventfd::EventFd,
-
     hw_breakpoints: Vec<GuestAddress>,
     single_step: bool,
 }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -382,11 +382,13 @@ fn create_vmm_ioctl_seccomp_rule_kvm() -> Result<Vec<SeccompRule>, BackendError>
 fn create_vmm_ioctl_seccomp_rule_kvm() -> Result<Vec<SeccompRule>, BackendError> {
     const KVM_ARM_PREFERRED_TARGET: u64 = 0x8020_aeaf;
     const KVM_ARM_VCPU_INIT: u64 = 0x4020_aeae;
+    const KVM_SET_GUEST_DEBUG: u64 = 0x4208_ae9b;
 
     let common_rules = create_vmm_ioctl_seccomp_rule_common(HypervisorType::Kvm)?;
     let mut arch_rules = or![
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_ARM_PREFERRED_TARGET,)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_ARM_VCPU_INIT,)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_GUEST_DEBUG,)?],
     ];
     arch_rules.extend(common_rules);
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -51,8 +51,10 @@ use devices::gic::GIC_V3_ITS_SNAPSHOT_ID;
 #[cfg(target_arch = "aarch64")]
 use devices::interrupt_controller::{self, InterruptController};
 use devices::AcpiNotificationFlags;
+#[cfg(all(target_arch = "aarch64", feature = "gdb"))]
+use gdbstub_arch::aarch64::reg::AArch64CoreRegs as CoreRegs;
 #[cfg(all(target_arch = "x86_64", feature = "gdb"))]
-use gdbstub_arch::x86::reg::X86_64CoreRegs;
+use gdbstub_arch::x86::reg::X86_64CoreRegs as CoreRegs;
 use hypervisor::{HypervisorVmError, VmOps};
 use linux_loader::cmdline::Cmdline;
 #[cfg(feature = "guest_debug")]
@@ -2522,7 +2524,7 @@ impl Vm {
         self.memory_manager.lock().unwrap().snapshot_data()
     }
 
-    #[cfg(all(target_arch = "x86_64", feature = "gdb"))]
+    #[cfg(feature = "gdb")]
     pub fn debug_request(
         &mut self,
         gdb_request: &GdbRequestPayload,
@@ -2973,14 +2975,14 @@ impl Debuggable for Vm {
         Ok(())
     }
 
-    fn read_regs(&self, cpu_id: usize) -> std::result::Result<X86_64CoreRegs, DebuggableError> {
+    fn read_regs(&self, cpu_id: usize) -> std::result::Result<CoreRegs, DebuggableError> {
         self.cpu_manager.lock().unwrap().read_regs(cpu_id)
     }
 
     fn write_regs(
         &self,
         cpu_id: usize,
-        regs: &X86_64CoreRegs,
+        regs: &CoreRegs,
     ) -> std::result::Result<(), DebuggableError> {
         self.cpu_manager.lock().unwrap().write_regs(cpu_id, regs)
     }


### PR DESCRIPTION
Fixes https://github.com/cloud-hypervisor/cloud-hypervisor/issues/3980

This PR enables the support of GDB to debug guest kernel.

Following GDB commands were tested:
- `info registers` command: Checking general purposed registers
- `hb`: Setting HW breakpoints
- `ctrl+c`: Interrupting
- `bt`: Checking backtrack
- `nexti(n)`: Next line
- `stepi(s)`: Next line (into function)

Following functionalities are known not ready:
- `info registers`: More registers (mainly system registers) are to be added
- `w`: HW watchpoints

On AArch64, API `KVM_CAP_GUEST_DEBUG_HW_BPS` should be checked for the max number of HW breakpoints. A PR https://github.com/rust-vmm/kvm-ioctls/pull/202 was created to `kvm-ioctls` for the support. Before that improvement, the hardcoded limit `4` should be practical enough.