### PR TITLE
vmm: aarch64: Use GIC_V3_* consts instead of magic numbers in create_madt()

### DIFF
--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -59,7 +59,7 @@ pub const UEFI_START: GuestAddress = GuestAddress(0);
 pub const UEFI_SIZE: u64 = 0x040_0000;
 
 /// Below this address will reside the GIC, above this address will reside the MMIO devices.
-pub const MAPPED_IO_START: GuestAddress = GuestAddress(0x0900_0000);
+const MAPPED_IO_START: GuestAddress = GuestAddress(0x0900_0000);
 
 /// See kernel file arch/arm64/include/uapi/asm/kvm.h for the GIC related definitions.
 /// 0x08ff_0000 ~ 0x0900_0000 is reserved for GICv3 Distributor
@@ -73,7 +73,7 @@ pub const GIC_V3_REDIST_SIZE: u64 = 0x02_0000;
 pub const GIC_V3_ITS_SIZE: u64 = 0x02_0000;
 
 /// Space 0x0900_0000 ~ 0x0905_0000 is reserved for legacy devices.
-pub const LEGACY_SERIAL_MAPPED_IO_START: GuestAddress = GuestAddress(0x0900_0000);
+pub const LEGACY_SERIAL_MAPPED_IO_START: GuestAddress = MAPPED_IO_START;
 pub const LEGACY_RTC_MAPPED_IO_START: GuestAddress = GuestAddress(0x0901_0000);
 pub const LEGACY_GPIO_MAPPED_IO_START: GuestAddress = GuestAddress(0x0902_0000);
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1275,7 +1275,6 @@ impl CpuManager {
 
         #[cfg(target_arch = "aarch64")]
         {
-            use vm_memory::Address;
             /* Notes:
              * Ignore Local Interrupt Controller Address at byte offset 36 of MADT table.
              */
@@ -1323,7 +1322,7 @@ impl CpuManager {
                 length: 24,
                 reserved0: 0,
                 gic_id: 0,
-                base_address: arch::layout::MAPPED_IO_START.raw_value() - 0x0001_0000,
+                base_address: arch::layout::GIC_V3_DIST_START.0,
                 global_irq_base: 0,
                 version: 3,
                 reserved1: [0; 3],
@@ -1331,9 +1330,9 @@ impl CpuManager {
             madt.append(gicd);
 
             // See 5.2.12.17 GIC Redistributor (GICR) Structure in ACPI spec.
-            let gicr_size: u32 = 0x0001_0000 * 2 * (self.config.boot_vcpus as u32);
-            let gicr_base: u64 =
-                arch::layout::MAPPED_IO_START.raw_value() - 0x0001_0000 - gicr_size as u64;
+            let gicr_size: u32 =
+                (arch::layout::GIC_V3_REDIST_SIZE * self.config.boot_vcpus as u64) as u32;
+            let gicr_base: u64 = arch::layout::GIC_V3_DIST_START.0 - gicr_size as u64;
             let gicr = GicR {
                 r#type: acpi::ACPI_APIC_GENERIC_REDISTRIBUTOR,
                 length: 16,
@@ -1349,7 +1348,7 @@ impl CpuManager {
                 length: 20,
                 reserved0: 0,
                 translation_id: 0,
-                base_address: gicr_base - 2 * 0x0001_0000,
+                base_address: gicr_base - arch::layout::GIC_V3_ITS_SIZE,
                 reserved1: 0,
             };
             madt.append(gicits);


### PR DESCRIPTION
There's no need to recompute GIC_V3_DIST_START etc in this function.
Remove `pub` from MAPPED_IO_START too since it's not needed outside layout.rs

Signed-off-by: Nuno Das Neves <nudasnev@microsoft.com>