### PR TITLE
Restrict the number of GDB HW breakpoints on AArch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "kvm-ioctls"
 version = "0.11.0"
-source = "git+https://github.com/rust-vmm/kvm-ioctls?branch=main#63f2f1231d49478197e15b8e9ff5d4e827aa288f"
+source = "git+https://github.com/rust-vmm/kvm-ioctls?branch=main#6705a619970fb0b2be47f1781f2ccf856cd5ce6a"
 dependencies = [
  "kvm-bindings",
  "libc",

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -117,7 +117,7 @@ pub trait Hypervisor: Send + Sync {
     }
     #[cfg(target_arch = "aarch64")]
     ///
-    /// Retrieve AArch64 host maximum IPA size supported by KVM.
+    /// Retrieve AArch64 host maximum IPA size supported by KVM
     ///
     fn get_host_ipa_limit(&self) -> i32;
     ///
@@ -125,4 +125,10 @@ pub trait Hypervisor: Send + Sync {
     ///
     #[cfg(feature = "tdx")]
     fn tdx_capabilities(&self) -> Result<TdxCapabilities>;
+    ///
+    /// Get the number of supported hardware breakpoints
+    ///
+    fn get_guest_debug_hw_bps(&self) -> usize {
+        unimplemented!()
+    }
 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1605,13 +1605,6 @@ impl cpu::Vcpu for KvmVcpu {
         addrs: &[vm_memory::GuestAddress],
         singlestep: bool,
     ) -> cpu::Result<()> {
-        if addrs.len() > 4 {
-            return Err(cpu::HypervisorCpuError::SetDebugRegs(anyhow!(
-                "Support 4 breakpoints at most but {} addresses are passed",
-                addrs.len()
-            )));
-        }
-
         let mut dbg = kvm_guest_debug {
             #[cfg(target_arch = "x86_64")]
             control: KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_HW_BP,
@@ -1623,6 +1616,9 @@ impl cpu::Vcpu for KvmVcpu {
             dbg.control |= KVM_GUESTDBG_SINGLESTEP;
         }
 
+        // Set the debug registers.
+        // Here we assume that the number of addresses do not exceed what
+        // `Hypervisor::get_guest_debug_hw_bps()` specifies.
         #[cfg(target_arch = "x86_64")]
         {
             // Set bits 9 and 10.

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1076,6 +1076,20 @@ impl hypervisor::Hypervisor for KvmHypervisor {
 
         Ok(data)
     }
+
+    ///
+    /// Get the number of supported hardware breakpoints
+    ///
+    fn get_guest_debug_hw_bps(&self) -> usize {
+        #[cfg(target_arch = "x86_64")]
+        {
+            4
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            self.kvm.get_guest_debug_hw_bps() as usize
+        }
+    }
 }
 /// Vcpu struct for KVM
 pub struct KvmVcpu {


### PR DESCRIPTION
On AArch64 (KVM) the maximum number of GDB HW breakpoints should be determined by querying the return value of CAP KVM_CAP_GUEST_DEBUG_HW_BPS.