### PR TITLE
virtio-console: Fix lost output when connected to a PTY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_buffer"
+version = "0.1.0"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1348,7 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
+ "serial_buffer",
  "thiserror",
  "versionize",
  "versionize_derive",
@@ -1459,6 +1464,7 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
+ "serial_buffer",
  "signal-hook",
  "thiserror",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
     "performance-metrics",
     "qcow",
     "rate_limiter",
+    "serial_buffer",
     "test_infra",
     "vfio_user",
     "vhdx",

--- a/serial_buffer/Cargo.toml
+++ b/serial_buffer/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "serial_buffer"
+version = "0.1.0"
+authors = ["The Cloud Hypervisor Authors"]
+edition = "2021"

--- a/serial_buffer/src/lib.rs
+++ b/serial_buffer/src/lib.rs
@@ -16,14 +16,14 @@ const MAX_BUFFER_SIZE: usize = 1 << 20;
 
 // Circular buffer implementation for serial output.
 // Read from head; push to tail
-pub(crate) struct SerialBuffer {
+pub struct SerialBuffer {
     buffer: VecDeque<u8>,
     out: Box<dyn Write + Send>,
     write_out: Arc<AtomicBool>,
 }
 
 impl SerialBuffer {
-    pub(crate) fn new(out: Box<dyn Write + Send>, write_out: Arc<AtomicBool>) -> Self {
+    pub fn new(out: Box<dyn Write + Send>, write_out: Arc<AtomicBool>) -> Self {
         Self {
             buffer: VecDeque::new(),
             out,

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -24,6 +24,7 @@ rate_limiter = { path = "../rate_limiter" }
 seccompiler = "0.2.0"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
+serial_buffer = { path = "../serial_buffer" }
 thiserror = "1.0.32"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -41,6 +41,7 @@ qcow = { path = "../qcow" }
 seccompiler = "0.2.0"
 serde = { version = "1.0.144", features = ["rc", "derive"] }
 serde_json = "1.0.85"
+serial_buffer = { path = "../serial_buffer" }
 signal-hook = "0.3.14"
 thiserror = "1.0.32"
 uuid = "1.1.2"

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -70,7 +70,6 @@ pub mod memory_manager;
 pub mod migration;
 mod pci_segment;
 pub mod seccomp_filters;
-mod serial_buffer;
 mod serial_manager;
 mod sigwinch_listener;
 pub mod vm;

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -239,7 +239,7 @@ impl SerialManager {
                                     // returns an error of type EINTR, but this should not
                                     // be considered as a regular error. Instead it is more
                                     // appropriate to retry, by calling into epoll_wait().
-                                    0
+                                    continue;
                                 } else {
                                     return Err(Error::Epoll(e));
                                 }

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -5,12 +5,12 @@
 
 use crate::config::ConsoleOutputMode;
 use crate::device_manager::PtyPair;
-use crate::serial_buffer::SerialBuffer;
 #[cfg(target_arch = "aarch64")]
 use devices::legacy::Pl011;
 #[cfg(target_arch = "x86_64")]
 use devices::legacy::Serial;
 use libc::EFD_NONBLOCK;
+use serial_buffer::SerialBuffer;
 use std::fs::File;
 use std::io::Read;
 use std::os::unix::io::{AsRawFd, FromRawFd};


### PR DESCRIPTION
Through multiple changes, this PR aims at providing a reliable solution for detecting the state of the PTY's connection. Being able to find out when the other end of the PTY is connected is essential to prevent the loss of data being output through the PTY. When the PTY isn't connected, the output is buffered through the SerialBuffer, the same solution that was created for the serial port initially.

Fixes #4521