### PR TITLE
tests: Enable more Windows guest tests for aarch64

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7134,7 +7134,6 @@ mod windows {
     }
 
     #[test]
-    #[cfg(not(target_arch = "aarch64"))]
     fn test_windows_guest_multiple_queues() {
         let windows_guest = WindowsGuest::new();
 
@@ -7201,7 +7200,6 @@ mod windows {
 
     #[test]
     #[cfg(not(feature = "mshv"))]
-    #[cfg(not(target_arch = "aarch64"))]
     #[ignore = "See #4327"]
     fn test_windows_guest_snapshot_restore() {
         let windows_guest = WindowsGuest::new();
@@ -7441,7 +7439,6 @@ mod windows {
 
     #[test]
     #[cfg(not(feature = "mshv"))]
-    #[cfg(not(target_arch = "aarch64"))]
     fn test_windows_guest_netdev_hotplug() {
         let windows_guest = WindowsGuest::new();
 
@@ -7514,7 +7511,6 @@ mod windows {
 
     #[test]
     #[cfg(not(feature = "mshv"))]
-    #[cfg(not(target_arch = "aarch64"))]
     fn test_windows_guest_disk_hotplug() {
         let windows_guest = WindowsGuest::new();
 


### PR DESCRIPTION
Enabled 3 more tests on AARCH64. Excluded CPU/RAM hotplug and other unsupported or currently unstable cases.

The runtime for the specific test run climbs from ~33 seconds to ~3 minutes. The total test time doesn't seem to be impacted, though. There are stages still demanding more resources than the AARCH64 one.
