### PR TITLE
Unify payload load chain on AArch64 with x86

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -21,8 +21,6 @@ use crate::pci_segment::PciSegment;
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
 use crate::serial_manager::{Error as SerialManagerError, SerialManager};
 use crate::sigwinch_listener::start_sigwinch_listener;
-#[cfg(target_arch = "aarch64")]
-use crate::GuestMemoryMmap;
 use crate::GuestRegionMmap;
 use crate::PciDeviceInfo;
 use crate::{device_node, DEVICE_MANAGER_SNAPSHOT_ID};
@@ -51,7 +49,7 @@ use devices::legacy::Serial;
 use devices::{
     interrupt_controller, interrupt_controller::InterruptController, AcpiNotificationFlags,
 };
-use hypervisor::{HypervisorType, HypervisorVmError, IoEventAddress};
+use hypervisor::{HypervisorType, IoEventAddress};
 use libc::{
     cfmakeraw, isatty, tcgetattr, tcsetattr, termios, MAP_NORESERVE, MAP_PRIVATE, MAP_SHARED,
     O_TMPFILE, PROT_READ, PROT_WRITE, TCSANOW,
@@ -92,8 +90,6 @@ use vm_device::interrupt::{
 };
 use vm_device::{Bus, BusDevice, Resource};
 use vm_memory::guest_memory::FileOffset;
-#[cfg(target_arch = "aarch64")]
-use vm_memory::GuestMemoryAtomic;
 use vm_memory::GuestMemoryRegion;
 use vm_memory::{Address, GuestAddress, GuestUsize, MmapRegion};
 #[cfg(target_arch = "x86_64")]
@@ -463,9 +459,6 @@ pub enum DeviceManagerError {
 
     /// Cannot hotplug device behind vIOMMU
     InvalidIommuHotplug,
-
-    /// Failed to create UEFI flash
-    CreateUefiFlash(HypervisorVmError),
 
     /// Invalid identifier as it is not unique.
     IdentifierNotUnique(String),
@@ -929,10 +922,6 @@ pub struct DeviceManager {
     // GPIO device for AArch64
     gpio_device: Option<Arc<Mutex<devices::legacy::Gpio>>>,
 
-    #[cfg(target_arch = "aarch64")]
-    // Flash device for UEFI on AArch64
-    uefi_flash: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
-
     // Flag to force setting the iommu on virtio devices
     force_iommu: bool,
 
@@ -1089,8 +1078,6 @@ impl DeviceManager {
             virtio_mem_devices: Vec::new(),
             #[cfg(target_arch = "aarch64")]
             gpio_device: None,
-            #[cfg(target_arch = "aarch64")]
-            uefi_flash: None,
             force_iommu,
             restoring,
             io_uring_supported: None,
@@ -1684,38 +1671,6 @@ impl DeviceManager {
             .lock()
             .unwrap()
             .insert(id.clone(), device_node!(id, gpio_device));
-
-        // On AArch64, the UEFI binary requires a flash device at address 0.
-        // 4 MiB memory is mapped to simulate the flash.
-        let uefi_mem_slot = self.memory_manager.lock().unwrap().allocate_memory_slot();
-        let uefi_region = GuestRegionMmap::new(
-            MmapRegion::new(arch::layout::UEFI_SIZE as usize).unwrap(),
-            arch::layout::UEFI_START,
-        )
-        .unwrap();
-        let uefi_mem_region = self
-            .memory_manager
-            .lock()
-            .unwrap()
-            .vm
-            .make_user_memory_region(
-                uefi_mem_slot,
-                uefi_region.start_addr().raw_value(),
-                uefi_region.len() as u64,
-                uefi_region.as_ptr() as u64,
-                false,
-                false,
-            );
-        self.memory_manager
-            .lock()
-            .unwrap()
-            .vm
-            .create_user_memory_region(uefi_mem_region)
-            .map_err(DeviceManagerError::CreateUefiFlash)?;
-
-        let uefi_flash =
-            GuestMemoryAtomic::new(GuestMemoryMmap::from_regions(vec![uefi_region]).unwrap());
-        self.uefi_flash = Some(uefi_flash);
 
         Ok(())
     }
@@ -4160,11 +4115,6 @@ impl DeviceManager {
 
     pub fn iommu_attached_devices(&self) -> &Option<(PciBdf, Vec<PciBdf>)> {
         &self.iommu_attached_devices
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    pub fn uefi_flash(&self) -> GuestMemoryAtomic<GuestMemoryMmap> {
-        self.uefi_flash.as_ref().unwrap().clone()
     }
 
     fn validate_identifier(&self, id: &Option<String>) -> DeviceManagerResult<()> {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -953,7 +953,7 @@ impl Vm {
 
     #[cfg(target_arch = "aarch64")]
     fn load_firmware(&self, mut firmware: &File) -> Result<()> {
-        let uefi_flash = self.device_manager.lock().as_ref().unwrap().uefi_flash();
+        let uefi_flash = self.memory_manager.lock().as_ref().unwrap().uefi_flash();
         let mem = uefi_flash.memory();
         arch::aarch64::uefi::load_uefi(mem.deref(), arch::layout::UEFI_START, &mut firmware)
             .map_err(Error::UefiLoad)?;


### PR DESCRIPTION
A new payload struct, including "kernel", "firmware" ..., is introduced and used in kernel load on x86 while aarch64 stays in the old way.
This PR try to eliminate the divergency by unifying the payload chain on aarch64 with x86. The big change for payload loading on aarch64 is that uses async way, like x86 does, to load payload instead of sync.