### PR TITLE
Add integration tests for rate limiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,8 @@ dependencies = [
  "epoll",
  "libc",
  "once_cell",
+ "serde",
+ "serde_json",
  "ssh2",
  "vmm-sys-util",
  "wait-timeout",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -400,6 +400,31 @@ pipeline{
 						}
 					}
 				}
+				stage ('Worker build - Rate Limiter') {
+					agent { node { label 'focal-metrics' } }
+					when {
+						branch 'main'
+						beforeAgent true
+						expression {
+							return runWorkers
+						}
+					}
+					stages {
+						stage ('Checkout') {
+							steps {
+								checkout scm
+							}
+						}
+						stage ('Run rate-limiter integration tests') {
+							options {
+								timeout(time: 10, unit: 'MINUTES')
+							}
+							steps {
+								sh "scripts/dev_cli.sh tests --integration-rate-limiter"
+							}
+						}
+					}
+				}
 			}
 		}
 	}

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -20,6 +20,7 @@ use std::{
     thread,
     time::Duration,
 };
+use test_infra::FioOps;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -191,6 +191,7 @@ cmd_help() {
     echo "        --integration-vfio           Run the VFIO integration tests."
     echo "        --integration-windows        Run the Windows guest integration tests."
     echo "        --integration-live-migration Run the live-migration integration tests."
+    echo "        --integration-rate-limiter   Run the rate-limiter integration tests."
     echo "        --libc                       Select the C library Cloud Hypervisor will be built against. Default is gnu"
     echo "        --metrics                    Generate performance metrics"
     echo "        --volumes                    Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
@@ -226,7 +227,7 @@ cmd_build() {
         } ;;
         "--debug") { build="debug"; } ;;
         "--release") { build="release"; } ;;
-        "--runtime") 
+        "--runtime")
 	    shift
 	    DOCKER_RUNTIME="$1"
 	    export DOCKER_RUNTIME
@@ -321,6 +322,7 @@ cmd_tests() {
     integration_vfio=false
     integration_windows=false
     integration_live_migration=false
+    integration_rate_limiter=false
     metrics=false
     libc="gnu"
     arg_vols=""
@@ -338,6 +340,7 @@ cmd_tests() {
         "--integration-vfio") { integration_vfio=true; } ;;
         "--integration-windows") { integration_windows=true; } ;;
         "--integration-live-migration") { integration_live_migration=true; } ;;
+        "--integration-rate-limiter") { integration_rate_limiter=true; } ;;
         "--metrics") { metrics=true; } ;;
         "--libc")
             shift
@@ -491,6 +494,25 @@ cmd_tests() {
             --env CH_LIBC="${libc}" \
             "$CTR_IMAGE" \
             ./scripts/run_integration_tests_live_migration.sh "$@" || fix_dir_perms $? || exit $?
+    fi
+
+    if [ "$integration_rate_limiter" = true ]; then
+        say "Running 'rate limiter' integration tests for $target..."
+        $DOCKER_RUNTIME run \
+            --workdir "$CTR_CLH_ROOT_DIR" \
+            --rm \
+            --privileged \
+            --security-opt seccomp=unconfined \
+            --ipc=host \
+            --net="$CTR_CLH_NET" \
+            --mount type=tmpfs,destination=/tmp \
+            --volume /dev:/dev \
+            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" $exported_volumes \
+            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+            --env USER="root" \
+            --env CH_LIBC="${libc}" \
+            "$CTR_IMAGE" \
+            ./scripts/run_integration_tests_rate_limiter.sh "$@" || fix_dir_perms $? || exit $?
     fi
 
     if [ "$metrics" = true ]; then

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -x
+
+source $HOME/.cargo/env
+source $(dirname "$0")/test-util.sh
+
+export BUILD_TARGET=${BUILD_TARGET-x86_64-unknown-linux-gnu}
+
+WORKLOADS_DIR="$HOME/workloads"
+mkdir -p "$WORKLOADS_DIR"
+
+process_common_args "$@"
+
+# For now these values are default for kvm
+features=""
+
+if [ "$hypervisor" = "mshv" ] ;  then
+    features="--no-default-features --features mshv,common"
+fi
+
+cp scripts/sha1sums-x86_64 $WORKLOADS_DIR
+
+FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
+FOCAL_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$FOCAL_OS_IMAGE_NAME"
+FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"
+if [ ! -f "$FOCAL_OS_IMAGE" ]; then
+    pushd $WORKLOADS_DIR
+    time wget --quiet $FOCAL_OS_IMAGE_URL || exit 1
+    popd
+fi
+
+FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.raw"
+FOCAL_OS_RAW_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_RAW_IMAGE_NAME"
+if [ ! -f "$FOCAL_OS_RAW_IMAGE" ]; then
+    pushd $WORKLOADS_DIR
+    time qemu-img convert -p -f qcow2 -O raw $FOCAL_OS_IMAGE_NAME $FOCAL_OS_RAW_IMAGE_NAME || exit 1
+    popd
+fi
+
+pushd $WORKLOADS_DIR
+grep focal sha1sums-x86_64 | sha1sum --check
+if [ $? -ne 0 ]; then
+    echo "sha1sum validation of images failed, remove invalid images to fix the issue."
+    exit 1
+fi
+popd
+
+# Build custom kernel based on virtio-pmem and virtio-fs upstream patches
+VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
+
+LINUX_CUSTOM_DIR="$WORKLOADS_DIR/linux-custom"
+
+if [ ! -f "$VMLINUX_IMAGE" ]; then
+    SRCDIR=$PWD
+    pushd $WORKLOADS_DIR
+    time git clone --depth 1 "https://github.com/cloud-hypervisor/linux.git" -b "ch-5.15.12" $LINUX_CUSTOM_DIR
+    cp $SRCDIR/resources/linux-config-x86_64 $LINUX_CUSTOM_DIR/.config
+    popd
+fi
+
+if [ ! -f "$VMLINUX_IMAGE" ]; then
+    pushd $LINUX_CUSTOM_DIR
+    time make bzImage -j `nproc`
+    cp vmlinux $VMLINUX_IMAGE || exit 1
+    popd
+fi
+
+if [ -d "$LINUX_CUSTOM_DIR" ]; then
+    rm -rf $LINUX_CUSTOM_DIR
+fi
+
+BUILD_TARGET="$(uname -m)-unknown-linux-${CH_LIBC}"
+CFLAGS=""
+TARGET_CC=""
+if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
+    TARGET_CC="musl-gcc"
+    CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
+fi
+
+cargo build --all --release $features --target $BUILD_TARGET
+strip target/$BUILD_TARGET/release/cloud-hypervisor
+strip target/$BUILD_TARGET/release/vhost_user_net
+strip target/$BUILD_TARGET/release/ch-remote
+
+export RUST_BACKTRACE=1
+time cargo test $features "rate_limiter::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
+RES=$?
+
+exit $RES

--- a/test_infra/Cargo.toml
+++ b/test_infra/Cargo.toml
@@ -9,6 +9,8 @@ dirs = "4.0.0"
 epoll = "4.3.1"
 libc = "0.2.132"
 once_cell = "1.14.0"
+serde = { version = "1.0.144", features = ["rc", "derive"] }
+serde_json = "1.0.85"
 ssh2 = { version = "0.9.3", features = ["vendored-openssl"] }
 vmm-sys-util = "0.10.0"
 wait-timeout = "0.2.0"

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -4,11 +4,10 @@
 //
 
 use once_cell::sync::Lazy;
+use serde_json::Value;
 use ssh2::Session;
 use std::env;
 use std::ffi::OsStr;
-use std::fmt::Debug;
-use std::fs;
 use std::io;
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -20,13 +19,29 @@ use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::str::FromStr;
 use std::sync::Mutex;
 use std::thread;
+use std::time::Duration;
+use std::{fmt, fs};
 use vmm_sys_util::tempdir::TempDir;
+use wait_timeout::ChildExt;
+
+#[derive(Debug)]
+pub enum WaitTimeoutError {
+    Timedout,
+    ExitStatus,
+    General(std::io::Error),
+}
 
 #[derive(Debug)]
 pub enum Error {
     Parsing(std::num::ParseIntError),
     SshCommand(SshCommandError),
     WaitForBoot(WaitForBootError),
+    EthrLogFile(std::io::Error),
+    EthrLogParse,
+    FioOutputParse,
+    Iperf3Parse,
+    Spawn(std::io::Error),
+    WaitTimeout(WaitTimeoutError),
 }
 
 impl From<SshCommandError> for Error {
@@ -1319,4 +1334,282 @@ pub fn clh_command(cmd: &str) -> String {
         format!("target/x86_64-unknown-linux-gnu/release/{}", cmd),
         |target| format!("target/{}/release/{}", target, cmd),
     )
+}
+
+pub fn parse_iperf3_output(output: &[u8], sender: bool) -> Result<f64, Error> {
+    std::panic::catch_unwind(|| {
+        let s = String::from_utf8_lossy(output);
+        let v: Value = serde_json::from_str(&s).expect("'iperf3' parse error: invalid json output");
+
+        let bps: f64 = if sender {
+            v["end"]["sum_sent"]["bits_per_second"]
+                .as_f64()
+                .expect("'iperf3' parse error: missing entry 'end.sum_sent.bits_per_second'")
+        } else {
+            v["end"]["sum_received"]["bits_per_second"]
+                .as_f64()
+                .expect("'iperf3' parse error: missing entry 'end.sum_received.bits_per_second'")
+        };
+
+        bps
+    })
+    .map_err(|_| {
+        eprintln!(
+            "=============== iperf3 output ===============\n\n{}\n\n===========end============\n\n",
+            String::from_utf8_lossy(output)
+        );
+        Error::Iperf3Parse
+    })
+}
+
+pub enum FioOps {
+    Read,
+    RandomRead,
+    Write,
+    RandomWrite,
+}
+
+impl fmt::Display for FioOps {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            FioOps::Read => write!(f, "read"),
+            FioOps::RandomRead => write!(f, "randread"),
+            FioOps::Write => write!(f, "write"),
+            FioOps::RandomWrite => write!(f, "randwrite"),
+        }
+    }
+}
+
+pub fn parse_fio_output(output: &str, fio_ops: &FioOps, num_jobs: u32) -> Result<f64, Error> {
+    std::panic::catch_unwind(|| {
+        let v: Value =
+            serde_json::from_str(output).expect("'fio' parse error: invalid json output");
+        let jobs = v["jobs"]
+            .as_array()
+            .expect("'fio' parse error: missing entry 'jobs'");
+        assert_eq!(
+            jobs.len(),
+            num_jobs as usize,
+            "'fio' parse error: Unexpected number of 'fio' jobs."
+        );
+
+        let read = match fio_ops {
+            FioOps::Read | FioOps::RandomRead => true,
+            FioOps::Write | FioOps::RandomWrite => false,
+        };
+
+        let mut total_bps = 0_f64;
+        for j in jobs {
+            if read {
+                let bytes = j["read"]["io_bytes"]
+                    .as_u64()
+                    .expect("'fio' parse error: missing entry 'read.io_bytes'");
+                let runtime = j["read"]["runtime"]
+                    .as_u64()
+                    .expect("'fio' parse error: missing entry 'read.runtime'")
+                    as f64
+                    / 1000_f64;
+                total_bps += bytes as f64 / runtime as f64;
+            } else {
+                let bytes = j["write"]["io_bytes"]
+                    .as_u64()
+                    .expect("'fio' parse error: missing entry 'write.io_bytes'");
+                let runtime = j["write"]["runtime"]
+                    .as_u64()
+                    .expect("'fio' parse error: missing entry 'write.runtime'")
+                    as f64
+                    / 1000_f64;
+                total_bps += bytes as f64 / runtime as f64;
+            }
+        }
+
+        total_bps
+    })
+    .map_err(|_| {
+        eprintln!(
+            "=============== Fio output ===============\n\n{}\n\n===========end============\n\n",
+            output
+        );
+        Error::FioOutputParse
+    })
+}
+
+// Wait the child process for a given timeout
+fn child_wait_timeout(child: &mut Child, timeout: u64) -> Result<(), WaitTimeoutError> {
+    match child.wait_timeout(Duration::from_secs(timeout)) {
+        Err(e) => {
+            return Err(WaitTimeoutError::General(e));
+        }
+        Ok(s) => match s {
+            None => {
+                return Err(WaitTimeoutError::Timedout);
+            }
+            Some(s) => {
+                if !s.success() {
+                    return Err(WaitTimeoutError::ExitStatus);
+                }
+            }
+        },
+    }
+
+    Ok(())
+}
+
+pub fn measure_virtio_net_throughput(
+    test_timeout: u32,
+    queue_pairs: u32,
+    guest: &Guest,
+    receive: bool,
+) -> Result<f64, Error> {
+    let default_port = 5201;
+
+    // 1. start the iperf3 server on the guest
+    for n in 0..queue_pairs {
+        guest.ssh_command(&format!("iperf3 -s -p {} -D", default_port + n))?;
+    }
+
+    thread::sleep(Duration::new(1, 0));
+
+    // 2. start the iperf3 client on host to measure RX through-put
+    let mut clients = Vec::new();
+    for n in 0..queue_pairs {
+        let mut cmd = Command::new("iperf3");
+        cmd.args(&[
+            "-J", // Output in JSON format
+            "-c",
+            &guest.network.guest_ip,
+            "-p",
+            &format!("{}", default_port + n),
+            "-t",
+            &format!("{}", test_timeout),
+        ]);
+        // For measuring the guest transmit throughput (as a sender),
+        // use reverse mode of the iperf3 client on the host
+        if !receive {
+            cmd.args(&["-R"]);
+        }
+        let client = cmd
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .map_err(Error::Spawn)?;
+
+        clients.push(client);
+    }
+
+    let mut err: Option<Error> = None;
+    let mut bps = Vec::new();
+    let mut failed = false;
+    for c in clients {
+        let mut c = c;
+        if let Err(e) = child_wait_timeout(&mut c, test_timeout as u64 + 5) {
+            err = Some(Error::WaitTimeout(e));
+            failed = true;
+        }
+
+        if !failed {
+            // Safe to unwrap as we know the child has terminated succesffully
+            let output = c.wait_with_output().unwrap();
+            bps.push(parse_iperf3_output(&output.stdout, receive)?);
+        } else {
+            let _ = c.kill();
+            let output = c.wait_with_output().unwrap();
+            println!(
+                "=============== Client output [Error] ===============\n\n{}\n\n===========end============\n\n",
+                String::from_utf8_lossy(&output.stdout)
+            );
+        }
+    }
+
+    if let Some(e) = err {
+        Err(e)
+    } else {
+        Ok(bps.iter().sum())
+    }
+}
+
+pub fn parse_ethr_latency_output(output: &[u8]) -> Result<Vec<f64>, Error> {
+    std::panic::catch_unwind(|| {
+        let s = String::from_utf8_lossy(output);
+        let mut latency = Vec::new();
+        for l in s.lines() {
+            let v: Value = serde_json::from_str(l).expect("'ethr' parse error: invalid json line");
+            // Skip header/summary lines
+            if let Some(avg) = v["Avg"].as_str() {
+                // Assume the latency unit is always "us"
+                latency.push(
+                    avg.split("us").collect::<Vec<&str>>()[0]
+                        .parse::<f64>()
+                        .expect("'ethr' parse error: invalid 'Avg' entry"),
+                );
+            }
+        }
+
+        assert!(
+            !latency.is_empty(),
+            "'ethr' parse error: no valid latency data found"
+        );
+
+        latency
+    })
+    .map_err(|_| {
+        eprintln!(
+            "=============== ethr output ===============\n\n{}\n\n===========end============\n\n",
+            String::from_utf8_lossy(output)
+        );
+        Error::EthrLogParse
+    })
+}
+
+pub fn measure_virtio_net_latency(guest: &Guest, test_timeout: u32) -> Result<Vec<f64>, Error> {
+    // copy the 'ethr' tool to the guest image
+    let ethr_path = "/usr/local/bin/ethr";
+    let ethr_remote_path = "/tmp/ethr";
+    scp_to_guest(
+        Path::new(ethr_path),
+        Path::new(ethr_remote_path),
+        &guest.network.guest_ip,
+        //DEFAULT_SSH_RETRIES,
+        1,
+        DEFAULT_SSH_TIMEOUT,
+    )?;
+
+    // Start the ethr server on the guest
+    guest.ssh_command(&format!("{} -s &> /dev/null &", ethr_remote_path))?;
+
+    thread::sleep(Duration::new(10, 0));
+
+    // Start the ethr client on the host
+    let log_file = guest
+        .tmp_dir
+        .as_path()
+        .join("ethr.client.log")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let mut c = Command::new(ethr_path)
+        .args(&[
+            "-c",
+            &guest.network.guest_ip,
+            "-t",
+            "l",
+            "-o",
+            &log_file, // file output is JSON format
+            "-d",
+            &format!("{}s", test_timeout),
+        ])
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(Error::Spawn)?;
+
+    if let Err(e) = child_wait_timeout(&mut c, test_timeout as u64 + 5).map_err(Error::WaitTimeout)
+    {
+        let _ = c.kill();
+        return Err(e);
+    }
+
+    // Parse the ethr latency test output
+    let content = fs::read(log_file).map_err(Error::EthrLogFile)?;
+    parse_ethr_latency_output(&content)
 }


### PR DESCRIPTION
It covers rate limiter on both `block` (single-queue, throughput and IOPS) and `net` (single-queue, rx/tx throughput), which reproduces the results reported from #2333 and #2401.

Signed-off-by: Bo Chen <chen.bo@intel.com>