### PR TITLE
Cleanup ovs-dpdk setup correctly

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8871,11 +8871,12 @@ mod live_migration {
         let _ = dest_child.kill();
         let _ = ovs_child.kill();
         let dest_output = dest_child.wait_with_output().unwrap();
-        handle_child_output(r, &dest_output);
         let ovs_output = ovs_child.wait_with_output().unwrap();
-        handle_child_output(Ok(()), &ovs_output);
 
         cleanup_ovs_dpdk();
+
+        handle_child_output(r, &dest_output);
+        handle_child_output(Ok(()), &ovs_output);
     }
 
     mod live_migration_parallel {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6433,13 +6433,13 @@ mod common_parallel {
             guest2.ssh_command("nc -vz 172.100.0.1 12345").unwrap();
         });
 
-        cleanup_ovs_dpdk();
-
         let _ = child1.kill();
         let _ = child2.kill();
 
         let output = child1.wait_with_output().unwrap();
         child2.wait().unwrap();
+
+        cleanup_ovs_dpdk();
 
         handle_child_output(r, &output);
     }


### PR DESCRIPTION
As 'handle_child_output()' may terminate the test on panic, we need to
cleanup ovs-dpdk setup in advance.

see: #4555

Also, we need to wait for VM termination to cleanup the ovs-dpdk.

Signed-off-by: Bo Chen <chen.bo@intel.com>