### PR TITLE
devices: acpi: Add OpRegion range to _CRS

### DIFF
--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -111,13 +111,15 @@ impl Aml for AcpiGedDevice {
                 &aml::Name::new("_UID".into(), &aml::ZERO),
                 &aml::Name::new(
                     "_CRS".into(),
-                    &aml::ResourceTemplate::new(vec![&aml::Interrupt::new(
-                        true,
-                        true,
-                        false,
-                        false,
-                        self.ged_irq,
-                    )]),
+                    &aml::ResourceTemplate::new(vec![
+                        &aml::Interrupt::new(true, true, false, false, self.ged_irq),
+                        &aml::AddressSpace::new_memory(
+                            aml::AddressSpaceCachable::NotCacheable,
+                            true,
+                            self.address.0 as u64,
+                            self.address.0 + GED_DEVICE_ACPI_SIZE as u64 - 1,
+                        ),
+                    ]),
                 ),
                 &aml::OpRegion::new(
                     "GDST".into(),


### PR DESCRIPTION
Consistent with other devices that have an OpRegion specified in the
DSDT (like the memory controller) add the memory range used for the
OpRegion to the _CRS.

This ensures that the kernel knows that this memory range is in use for
this device.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
