### PR TITLE
vmm: config: Move TDX to rely on PayloadConfig

### DIFF
--- a/docs/intel_tdx.md
+++ b/docs/intel_tdx.md
@@ -61,7 +61,8 @@ meaning it will be printing guest kernel logs to the `virtio-console` device.
 
 ```bash
 ./cloud-hypervisor \
-    --tdx firmware=edk2-staging/Build/OvmfCh/RELEASE_GCC5/FV/OVMF.fd \
+    --platform tdx=on
+    --firmware edk2-staging/Build/OvmfCh/RELEASE_GCC5/FV/OVMF.fd \
     --cpus boot=1 \
     --memory size=1G \
     --disk path=tdx_guest_img
@@ -72,7 +73,8 @@ firmware:
 
 ```bash
 ./cloud-hypervisor \
-    --tdx firmware=edk2-staging/Build/OvmfCh/DEBUG_GCC5/FV/OVMF.fd \
+    --platform tdx=on
+    --firmware edk2-staging/Build/OvmfCh/DEBUG_GCC5/FV/OVMF.fd \
     --cpus boot=1 \
     --memory size=1G \
     --disk path=tdx_guest_img \
@@ -95,7 +97,8 @@ option as well.
 
 ```bash
 ./cloud-hypervisor \
-    --tdx firmware=tdshim \
+    --platform tdx=on
+    --firmware tdshim \
     --kernel bzImage \
     --cmdline "root=/dev/vda3 console=hvc0 rw"
     --cpus boot=1 \

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,15 +400,6 @@ fn create_app<'a>(
             .group("vmm-config"),
     );
 
-    #[cfg(feature = "tdx")]
-    let app = app.arg(
-        Arg::new("tdx")
-            .long("tdx")
-            .help("TDX Support: firmware=<tdvf path>")
-            .takes_value(true)
-            .group("vm-config"),
-    );
-
     app
 }
 
@@ -577,11 +568,6 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
     let payload_present =
         cmd_arguments.is_present("kernel") || cmd_arguments.is_present("firmware");
 
-    // Can't test for "vm-config" group as some have default values. The kernel (or tdx if enabled)
-    // is the only required option for booting the VM.
-    #[cfg(feature = "tdx")]
-    let payload_present = payload_present || cmd_arguments.is_present("tdx");
-
     if payload_present {
         let vm_params = config::VmParams::from_arg_matches(&cmd_arguments);
         let vm_config = config::VmConfig::parse(vm_params).map_err(Error::ParsingConfig)?;
@@ -744,8 +730,6 @@ mod unit_tests {
             sgx_epc: None,
             numa: None,
             watchdog: false,
-            #[cfg(feature = "tdx")]
-            tdx: None,
             #[cfg(feature = "gdb")]
             gdb: false,
             platform: None,

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -559,8 +559,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/SgxEpcConfig"
-        tdx:
-          $ref: "#/components/schemas/TdxConfig"
         numa:
           type: array
           items:
@@ -650,6 +648,9 @@ components:
           type: array
           items:
             type: string
+        tdx:
+          type: boolean
+          default: false
 
     MemoryZoneConfig:
       required:
@@ -1005,15 +1006,6 @@ components:
         prefault:
           type: boolean
           default: false
-
-    TdxConfig:
-      required:
-        - firmware
-      type: object
-      properties:
-        firmware:
-          type: string
-          description: Path to the firmware that will be used to boot the TDx guest up.
 
     NumaDistance:
       required:

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1419,8 +1419,6 @@ impl Vmm {
         let vm_config = vm.get_config();
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         let common_cpuid = {
-            #[cfg(feature = "tdx")]
-            let tdx_enabled = vm_config.lock().unwrap().tdx.is_some();
             let phys_bits = vm::physical_bits(vm_config.lock().unwrap().cpus.max_phys_bits);
             arch::generate_common_cpuid(
                 hypervisor,
@@ -1429,7 +1427,7 @@ impl Vmm {
                 phys_bits,
                 vm_config.lock().unwrap().cpus.kvm_hyperv,
                 #[cfg(feature = "tdx")]
-                tdx_enabled,
+                vm_config.lock().unwrap().is_tdx_enabled(),
             )
             .map_err(|e| {
                 MigratableError::MigrateReceive(anyhow!("Error generating common cpuid': {:?}", e))
@@ -1612,8 +1610,6 @@ impl Vmm {
         let dest_cpuid = &{
             let vm_config = &src_vm_config.lock().unwrap();
 
-            #[cfg(feature = "tdx")]
-            let tdx_enabled = vm_config.tdx.is_some();
             let phys_bits = vm::physical_bits(vm_config.cpus.max_phys_bits);
             arch::generate_common_cpuid(
                 self.hypervisor.clone(),
@@ -1622,7 +1618,7 @@ impl Vmm {
                 phys_bits,
                 vm_config.cpus.kvm_hyperv,
                 #[cfg(feature = "tdx")]
-                tdx_enabled,
+                vm_config.is_tdx_enabled(),
             )
             .map_err(|e| {
                 MigratableError::MigrateReceive(anyhow!("Error generating common cpuid: {:?}", e))
@@ -2053,8 +2049,6 @@ mod unit_tests {
             sgx_epc: None,
             numa: None,
             watchdog: false,
-            #[cfg(feature = "tdx")]
-            tdx: None,
             #[cfg(feature = "gdb")]
             gdb: false,
             platform: None,


### PR DESCRIPTION
Removing the option --tdx to specify that we want to run a TD VM. Rely
on --platform option by adding the "tdx" boolean parameter. This is the
new way for enabling TDX with Cloud Hypervisor.

Along with this change, the way to retrieve the firmware path has been
updated to rely on the recently introduced PayloadConfig structure.

Fixes #4556

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>