### PR TITLE
tests: Make test_windows_guest_disk_hotplug more reliable

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7571,7 +7571,7 @@ mod windows {
             // Unmount disk device
             let cmd_success = remote_command(&api_socket, "remove-device", Some("_disk2"));
             assert!(cmd_success);
-            thread::sleep(std::time::Duration::new(5, 0));
+            thread::sleep(std::time::Duration::new(20, 0));
             // Verify the device has been removed
             let disk_num = 1;
             assert_eq!(windows_guest.disk_count(), disk_num);
@@ -7690,9 +7690,9 @@ mod windows {
                 let disk_id = it[0].as_str();
                 let cmd_success = remote_command(&api_socket, "remove-device", Some(disk_id));
                 assert!(cmd_success);
-                thread::sleep(std::time::Duration::new(5, 0));
             }
 
+            thread::sleep(std::time::Duration::new(20, 0));
             // Verify the devices have been removed
             let disk_num = 1;
             assert_eq!(windows_guest.disk_count(), disk_num);


### PR DESCRIPTION
The Windows guest test test_windows_guest_disk_hotplug was flaky. It
consistently failed on same codepath, related to the disk not being
removed as expected. On slow systems, it might take some time for a
device to be removed and make sure this is seen from the guest.

Let's increase the sleep time from 5 to 20 seconds in order to give the
guest more time to properly remove the device.

Fixes #4583

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>