### PR TITLE
tests: Disable test_windows_guest_disk_hotplug for aarch64

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7511,6 +7511,7 @@ mod windows {
 
     #[test]
     #[cfg(not(feature = "mshv"))]
+    #[cfg(not(target_arch = "aarch64"))]
     fn test_windows_guest_disk_hotplug() {
         let windows_guest = WindowsGuest::new();
 


### PR DESCRIPTION
Until the issue #4583 is resolved, we must disable this test given it's
failing quite often on the aarch64 worker.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>