### PR TITLE
Jenkinsfile: Re-enable x86-64 bare metal testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -205,6 +205,88 @@ pipeline{
 						}
 					}
 				}
+				stage ('Worker build SGX') {
+					agent { node { label 'bionic-sgx' } }
+					when {
+						beforeAgent true
+						allOf {
+							branch 'main'
+							expression {
+								return runWorkers
+							}
+						}
+					}
+					stages {
+						stage ('Checkout') {
+							steps {
+								checkout scm
+							}
+						}
+						stage ('Run SGX integration tests') {
+							options {
+								timeout(time: 1, unit: 'HOURS')
+							}
+							steps {
+								sh "scripts/dev_cli.sh tests --integration-sgx"
+							}
+						}
+						stage ('Run SGX integration tests for musl') {
+							options {
+								timeout(time: 1, unit: 'HOURS')
+							}
+							steps {
+								sh "scripts/dev_cli.sh tests --integration-sgx --libc musl"
+							}
+						}
+					}
+					post {
+						always {
+							sh "sudo chown -R jenkins.jenkins ${WORKSPACE}"
+							deleteDir()
+						}
+					}
+				}
+				stage ('Worker build VFIO') {
+					agent { node { label 'bionic-vfio' } }
+					when {
+						beforeAgent true
+						allOf {
+							branch 'main'
+							expression {
+								return runWorkers
+							}
+						}
+					}
+					stages {
+						stage ('Checkout') {
+							steps {
+								checkout scm
+							}
+						}
+						stage ('Run VFIO integration tests') {
+							options {
+								timeout(time: 1, unit: 'HOURS')
+							}
+							steps {
+								sh "scripts/dev_cli.sh tests --integration-vfio"
+							}
+						}
+						stage ('Run VFIO integration tests for musl') {
+							options {
+								timeout(time: 1, unit: 'HOURS')
+							}
+							steps {
+								sh "scripts/dev_cli.sh tests --integration-vfio --libc musl"
+							}
+						}
+					}
+					post {
+						always {
+							sh "sudo chown -R jenkins.jenkins ${WORKSPACE}"
+							deleteDir()
+						}
+					}
+				}
 				stage ('Worker build - Windows guest') {
 					agent { node { label 'jammy' } }
 					when {
@@ -281,6 +363,39 @@ pipeline{
 							steps {
 								sh "sudo modprobe openvswitch"
 								sh "scripts/dev_cli.sh tests --integration-live-migration --libc musl"
+							}
+						}
+					}
+				}
+				stage ('Worker build - Metrics') {
+					agent { node { label 'focal-metrics' } }
+					when {
+						branch 'main'
+						beforeAgent true
+						expression {
+							return runWorkers
+						}
+					}
+					environment {
+						METRICS_PUBLISH_KEY = credentials('52e0945f-ce7a-43d1-87af-67d1d87cc40f')
+					}
+					stages {
+						stage ('Checkout') {
+							steps {
+								checkout scm
+							}
+						}
+						stage ('Run metrics tests') {
+							options {
+								timeout(time: 1, unit: 'HOURS')
+							}
+							steps {
+								sh 'scripts/dev_cli.sh tests --metrics -- -- --report-file /root/workloads/metrics.json'
+							}
+						}
+						stage ('Upload metrics report') {
+							steps {
+								sh 'curl -X PUT https://cloud-hypervisor-metrics.azurewebsites.net/api/publishmetrics -H "x-functions-key: $METRICS_PUBLISH_KEY" -T ~/workloads/metrics.json'
 							}
 						}
 					}


### PR DESCRIPTION
The baremetal CI for x86-64 was disabled while the machines were out for maintenance. Now that the machines are back up, let's re-enable the full CI.

This reverts commit 476e30f5cb563f38002610005aeb8fc459a70101.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>