### PR TITLE
virtio-devices: pmem: Avoid panic and propagate errors properly 

### DIFF
--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -90,6 +90,8 @@ enum Error {
     BufferLengthTooSmall,
     #[error("Invalid request")]
     InvalidRequest,
+    #[error("Failed adding used index: {0}")]
+    QueueAddUsed(virtio_queue::Error),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -197,7 +199,7 @@ impl PmemEpollHandler {
 
             self.queue
                 .add_used(desc_chain.memory(), desc_chain.head_index(), len)
-                .unwrap();
+                .map_err(Error::QueueAddUsed)?;
             used_descs = true;
         }
 


### PR DESCRIPTION
To have a more robust error handling, this patch ensures errors are properly
reported and propagated from the virtio-pmem worker thread, which avoids 
to panic when processing virt queues.

Signed-off-by: Bo Chen <chen.bo@intel.com>
