### PR TITLE
build: Bulk dependencies update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5e77493808403a6bd56a301a64ea6b9342e36ea845044bf0dfdf56fe52fa08"
+checksum = "85feaf25cc99be9662ab951bc68a10ae4436dbc9ba931b7fcb4e8fde67d9aa24"
 dependencies = [
  "vm-memory",
 ]
@@ -1259,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53567fd9ab820e4f3cc156f24146882fee3c365194c3e1dea74723265f27fc88"
+checksum = "79243657c76e5c90dcbf60187c842614f6dfc7123972c55bb3bcc446792aca93"
 dependencies = [
  "bitflags",
  "libc",
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558ac5ca9569fb03f518b2bdd17606809ffdc894b619b92d30df6c40c33d15f3"
+checksum = "6a0fc7d5f8e2943cd9f2ecd58be3f2078add863a49573d14dd9d64e1ab26544c"
 dependencies = [
  "libc",
  "log",
@@ -1365,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f59652909f276e6edd8bf36e9f106480b2202f5f046717b3de14f1b4072a28"
+checksum = "6e2b7bea73248006630c9611a61ac3b8e44eece09342801fe1faec583b7a9f02"
 dependencies = [
  "log",
  "virtio-bindings",
@@ -1404,9 +1404,9 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#8a19dcc94a4fb0044ff
 
 [[package]]
 name = "vm-memory"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767ed8aaebbff902e02e6d3749dc2baef55e46565f8a6414a065e5baee4b4a81"
+checksum = "583f213899e8a5eea23d9c507252d4bed5bc88f0ecbe0783262f80034630744b"
 dependencies = [
  "arc-swap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ signal-hook = "0.3.14"
 thiserror = "1.0.35"
 vmm = { path = "vmm" }
 vmm-sys-util = "0.10.0"
-vm-memory = "0.8.0"
+vm-memory = "0.9.0"
 
 [build-dependencies]
 clap = { version = "3.2.21", features = ["cargo"] }

--- a/acpi_tables/Cargo.toml
+++ b/acpi_tables/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2021"
 
 [dependencies]
-vm-memory = "0.8.0"
+vm-memory = "0.9.0"

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -13,14 +13,14 @@ anyhow = "1.0.65"
 byteorder = "1.4.3"
 hypervisor = { path = "../hypervisor" }
 libc = "0.2.132"
-linux-loader = { version = "0.4.0", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.5.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.17"
 serde = { version = "1.0.144", features = ["rc", "derive"] }
 thiserror = "1.0.35"
 uuid = "1.1.2"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { version = "0.10.0", features = ["with-serde"] }
 

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -17,8 +17,8 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vhdx = { path = "../vhdx" }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.5.0"
-vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.6.0"
+vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.10.0"
 

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.17"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-device = { path = "../vm-device" }
-vm-memory = "0.8.0"
+vm-memory = "0.9.0"
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = "0.10.0"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5e77493808403a6bd56a301a64ea6b9342e36ea845044bf0dfdf56fe52fa08"
+checksum = "85feaf25cc99be9662ab951bc68a10ae4436dbc9ba931b7fcb4e8fde67d9aa24"
 dependencies = [
  "vm-memory",
 ]
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#1ff2324e5cb0fccab825f9c96bb9387a1a01863f"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#bf7c9b997b4ad0ca1ab4bfe96dc1b10d4bc5be24"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53567fd9ab820e4f3cc156f24146882fee3c365194c3e1dea74723265f27fc88"
+checksum = "79243657c76e5c90dcbf60187c842614f6dfc7123972c55bb3bcc446792aca93"
 dependencies = [
  "bitflags",
  "libc",
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f59652909f276e6edd8bf36e9f106480b2202f5f046717b3de14f1b4072a28"
+checksum = "6e2b7bea73248006630c9611a61ac3b8e44eece09342801fe1faec583b7a9f02"
 dependencies = [
  "log",
  "virtio-bindings",
@@ -949,9 +949,9 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#720e48e435b791ec6cb
 
 [[package]]
 name = "vm-memory"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767ed8aaebbff902e02e6d3749dc2baef55e46565f8a6414a065e5baee4b4a81"
+checksum = "583f213899e8a5eea23d9c507252d4bed5bc88f0ecbe0783262f80034630744b"
 dependencies = [
  "arc-swap",
  "libc",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,10 +20,10 @@ qcow = { path = "../qcow" }
 seccompiler = "0.2.0"
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.5.0"
+virtio-queue = "0.6.0"
 vmm = { path = "../vmm" }
 vmm-sys-util = "0.10.0"
-vm-memory = "0.8.0"
+vm-memory = "0.9.0"
 vm-device = { path = "../vm-device" }
 vm-virtio = { path = "../vm-virtio" }
 

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -23,7 +23,7 @@ mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optio
 serde = { version = "1.0.144", features = ["rc", "derive"] }
 serde_with = { version = "2.0.1", default-features = false, features = ["macros"] }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = "0.10.0", features = ["with-serde"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -16,8 +16,8 @@ thiserror = "1.0.35"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 virtio-bindings = "0.1.0"
-virtio-queue = "0.5.0"
-vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.6.0"
+vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.10.0"
 

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -24,7 +24,7 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = "0.8.0"
+vm-memory = "0.9.0"
 vm-migration = { path = "../vm-migration" }
 
 [dependencies.vfio-bindings]

--- a/vfio_user/Cargo.toml
+++ b/vfio_user/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1.0.144", features = ["rc"] }
 serde_derive = "1.0.142"
 serde_json = "1.0.85"
 thiserror = "1.0.35"
-vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = "0.10.0"
 
 [dependencies.vfio-bindings]

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -13,11 +13,11 @@ libc = "0.2.132"
 log = "0.4.17"
 option_parser = { path = "../option_parser" }
 qcow = { path = "../qcow" }
-vhost = { version = "0.4.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.6.0"
+vhost = { version = "0.5.0", features = ["vhost-user-slave"] }
+vhost-user-backend = "0.7.0"
 virtio-bindings = "0.1.0"
-virtio-queue = "0.5.0"
-vm-memory = "0.8.0"
+virtio-queue = "0.6.0"
+vm-memory = "0.9.0"
 vmm-sys-util = "0.10.0"
 
 [build-dependencies]

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -12,10 +12,10 @@ libc = "0.2.132"
 log = "0.4.17"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
-vhost = { version = "0.4.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.6.0"
+vhost = { version = "0.5.0", features = ["vhost-user-slave"] }
+vhost-user-backend = "0.7.0"
 virtio-bindings = "0.1.0"
-vm-memory = "0.8.0"
+vm-memory = "0.9.0"
 vmm-sys-util = "0.10.0"
 
 [build-dependencies]

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -28,12 +28,12 @@ serial_buffer = { path = "../serial_buffer" }
 thiserror = "1.0.35"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vhost = { version = "0.4.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern", "vhost-vdpa"] }
+vhost = { version = "0.5.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern", "vhost-vdpa"] }
 virtio-bindings = { version = "0.1.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.5.0"
+virtio-queue = "0.6.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.10.0"

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.132"
-vm-memory = "0.8.0"
+vm-memory = "0.9.0"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 arch = { path = "../arch" }

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -15,6 +15,6 @@ hypervisor = { path = "../hypervisor" }
 thiserror = "1.0.35"
 serde = { version = "1.0.144", features = ["rc", "derive"] }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vm-memory = { version = "0.8.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.9.0", features = ["backend-mmap"] }
 vmm-sys-util = "0.10.0"
 

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -11,4 +11,4 @@ serde = { version = "1.0.144", features = ["rc", "derive"] }
 serde_json = "1.0.85"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-atomic"] }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -9,5 +9,5 @@ default = []
 
 [dependencies]
 log = "0.4.17"
-virtio-queue = "0.5.0"
-vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.6.0"
+vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -30,7 +30,7 @@ gdbstub = { version = "0.6.3", optional = true }
 gdbstub_arch = { version = "0.2.4", optional = true }
 hypervisor = { path = "../hypervisor" }
 libc = "0.2.132"
-linux-loader = { version = "0.4.0", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.5.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.17"
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 net_util = { path = "../net_util" }
@@ -51,10 +51,10 @@ vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", defau
 vfio_user = { path = "../vfio_user" }
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.5.0"
+virtio-queue = "0.6.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.8.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { version = "0.10.0", features = ["with-serde"] }


### PR DESCRIPTION
Multiple rust-vmm crates must be updated at once given the vm-memory one has been updated and they all rely on vm-memory.

- vm-memory from 0.8.0 to 0.9.0
- vhost from 0.4.0 to 0.5.0
- virtio-queue from 0.5.0 to 0.6.0
- vhost-user-backend from 0.6.0 to 0.7.0

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>