### PR TITLE
build: update to the latest kvm-ioctls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "kvm-ioctls"
 version = "0.11.0"
-source = "git+https://github.com/rust-vmm/kvm-ioctls?branch=main#6705a619970fb0b2be47f1781f2ccf856cd5ce6a"
+source = "git+https://github.com/rust-vmm/kvm-ioctls?branch=main#e6739aeebcc56dfea62216b2cc4cddd13d0a1182"
 dependencies = [
  "kvm-bindings",
  "libc",


### PR DESCRIPTION
The latest kvm-ioctls contains a breaking change to its API. Now Arm's get/set_one_reg use u128 instead of u64.

Signed-off-by: Wei Liu <liuwe@microsoft.com>