### PR TITLE
README: Fix contents entry indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   - [Install prerequisites](#install-prerequisites)
   - [Clone and build](#clone-and-build)
     - [Containerized builds and tests](#containerized-builds-and-tests)
-- [Use Prebuilt Binaries](#use-prebuilt-binaries)
+  - [Use Prebuilt Binaries](#use-prebuilt-binaries)
   - [Run](#run)
     - [Cloud image](#cloud-image)
     - [Custom kernel and disk image](#custom-kernel-and-disk-image)


### PR DESCRIPTION
The `#use-prebuilt-binaries` entry shifted to the left due to wrong markup.

Signed-off-by: Anatol Belski <anbelski@linux.microsoft.com>