### PR TITLE
vmm: Remove "amx" feature gate

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,9 +42,6 @@ jobs:
       - name: Build (default features + tdx)
         run: cargo rustc --locked --bin cloud-hypervisor --features "tdx" -- -D warnings
 
-      - name: Build (default features + amx)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "amx" -- -D warnings
-
       - name: Build (default features + gdb)
         run: cargo rustc --locked --bin cloud-hypervisor --features "gdb" -- -D warnings
 

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -49,9 +49,6 @@ jobs:
       - name: Clippy (default features)
         run: cargo clippy --locked --all --all-targets --tests -- -D warnings
 
-      - name: Clippy (default features + amx)
-        run: cargo clippy --locked --all --all-targets --tests --features "amx" -- -D warnings
-
       - name: Clippy (default features + gdb)
         run: cargo clippy --locked --all --all-targets --tests --features "gdb" -- -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ wait-timeout = "0.2.0"
 default = ["common", "kvm"]
 # Common features for all hypervisors
 common = ["fwdebug"]
-amx = ["vmm/amx"]
 cmos = ["vmm/cmos"]
 fwdebug = ["vmm/fwdebug"]
 gdb = ["vmm/gdb"]

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [features]
 default = []
-amx = []
 cmos = ["devices/cmos"]
 fwdebug = ["devices/fwdebug"]
 gdb = ["kvm", "gdbstub", "gdbstub_arch"]

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -472,7 +472,7 @@ pub struct CpuAffinity {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct CpuFeatures {
-    #[cfg(all(feature = "amx", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     #[serde(default)]
     pub amx: bool,
 }
@@ -593,7 +593,7 @@ impl CpusConfig {
         let mut features = CpuFeatures::default();
         for s in features_list.0 {
             match <std::string::String as AsRef<str>>::as_ref(&s) {
-                #[cfg(all(feature = "amx", target_arch = "x86_64"))]
+                #[cfg(target_arch = "x86_64")]
                 "amx" => {
                     features.amx = true;
                     Ok(())

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -473,6 +473,7 @@ pub struct CpuAffinity {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct CpuFeatures {
     #[cfg(all(feature = "amx", target_arch = "x86_64"))]
+    #[serde(default)]
     pub amx: bool,
 }
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -161,7 +161,7 @@ pub enum Error {
     #[error("Error translating virtual address: {0}")]
     TranslateVirtualAddress(#[source] anyhow::Error),
 
-    #[cfg(all(feature = "amx", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     #[error("Error setting up AMX: {0}")]
     AmxEnable(#[source] anyhow::Error),
 }
@@ -636,7 +636,7 @@ impl CpuManager {
             )
             .map_err(Error::CommonCpuId)?
         };
-        #[cfg(all(feature = "amx", target_arch = "x86_64"))]
+        #[cfg(target_arch = "x86_64")]
         if config.features.amx {
             const ARCH_GET_XCOMP_GUEST_PERM: usize = 0x1024;
             const ARCH_REQ_XCOMP_GUEST_PERM: usize = 0x1025;


### PR DESCRIPTION
Given the AMX x86 feature has been made available since kernel v5.17, and given we don't have any test validating this feature, there's no need to keep it behing a Rust feature gate.

Fixes #3996

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>