### PR TITLE
Fix `boot_time` tests of `performance_metrics`

### DIFF
--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -286,6 +286,7 @@ pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
             .args(&["--kernel", direct_kernel_boot_path().to_str().unwrap()])
             .args(&["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .args(&["--console", "off"])
+            .args(&["-v"])
             .default_disks();
 
         measure_boot_time(c, control.test_timeout).unwrap()
@@ -313,6 +314,7 @@ pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
             .args(&["--kernel", direct_kernel_boot_path().to_str().unwrap()])
             .args(&["--cmdline", "root=/dev/pmem0p1 console=ttyS0 quiet rw"])
             .args(&["--console", "off"])
+            .args(&["-v"])
             .args(&[
                 "--pmem",
                 format!(


### PR DESCRIPTION
When I followed the `performance_metrics.md` doc and tried:
`./scripts/dev_cli.sh tests --metrics -- -- --report-file /tmp/metrics.json --test-filter boot_time`

An error was seen:
`[Other logs are ignored] 
Expecting two matching lines for 'Debug I/O port: Kernel code'', performance-metrics/src/performance_tests.rs:177:9`

The reason is that no log was captured, except appending `-v` to parameters. Not sure when it began to break.