### PR TITLE
Fix wrong alignment calculation for qcow and vhdx

### DIFF
--- a/qcow/src/raw_file.rs
+++ b/qcow/src/raw_file.rs
@@ -69,7 +69,7 @@ impl RawFile {
 
     fn round_up(&self, offset: u64) -> u64 {
         let align: u64 = self.alignment.try_into().unwrap();
-        ((offset / (align + 1)) + 1) * align
+        ((offset + align - 1) / align) * align
     }
 
     fn round_down(&self, offset: u64) -> u64 {

--- a/vhdx/src/vhdx_io.rs
+++ b/vhdx/src/vhdx_io.rs
@@ -34,12 +34,7 @@ pub type Result<T> = std::result::Result<T, VhdxIoError>;
 
 macro_rules! align {
     ($n:expr, $align:expr) => {{
-        if $align > $n {
-            $align
-        } else {
-            let rem = $n % $align;
-            (($n / $align) + rem) * $align
-        }
+        (($n + $align - 1) / $align) * $align
     }};
 }
 


### PR DESCRIPTION
Found these issues while code review. Counter examples provided 
in the commit message to explain why they were wrong.

Signed-off-by: Bo Chen <chen.bo@intel.com>
