### PR TITLE
vTPM Support in Cloud-Hypervisor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,9 @@ dependencies = [
  "hypervisor",
  "libc",
  "log",
+ "phf",
+ "thiserror",
+ "tpm",
  "versionize",
  "versionize_derive",
  "vm-device",
@@ -759,6 +762,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +926,21 @@ checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rate_limiter"
@@ -1064,6 +1124,12 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "signal-hook",
  "test_infra",
  "thiserror",
+ "tpm",
  "tracer",
  "vm-memory",
  "vmm",
@@ -1157,6 +1158,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tpm"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "log",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,8 +1166,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
+ "libc",
  "log",
  "thiserror",
+ "vmm-sys-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ seccompiler = "0.3.0"
 serde_json = "1.0.87"
 signal-hook = "0.3.14"
 thiserror = "1.0.37"
+tpm = { path = "tpm"}
 tracer = { path = "tracer" }
 vmm = { path = "vmm" }
 vmm-sys-util = "0.10.0"

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -98,6 +98,11 @@ pub const RAM_START: GuestAddress = GuestAddress(0x4000_0000);
 pub const MEM_32BIT_RESERVED_START: GuestAddress = GuestAddress(0xfc00_0000);
 pub const MEM_32BIT_RESERVED_SIZE: u64 = 0x0400_0000;
 
+/// TPM Address Range
+/// This Address range is specific to CRB Interface
+pub const TPM_START: GuestAddress = GuestAddress(0xfed4_0000);
+pub const TPM_SIZE: u64 = 0x1000;
+
 /// Start of 64-bit RAM.
 pub const RAM_64BIT_START: GuestAddress = GuestAddress(0x1_0000_0000);
 

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -107,6 +107,11 @@ pub const KVM_TSS_SIZE: u64 = (3 * 4) << 10;
 pub const KVM_IDENTITY_MAP_START: GuestAddress = GuestAddress(KVM_TSS_START.0 + KVM_TSS_SIZE);
 pub const KVM_IDENTITY_MAP_SIZE: u64 = 4 << 10;
 
+/// TPM Address Range
+/// This Address range is specific to CRB Interface
+pub const TPM_START: GuestAddress = GuestAddress(0xfed4_0000);
+pub const TPM_SIZE: u64 = 0x1000;
+
 // IOAPIC
 pub const IOAPIC_START: GuestAddress = GuestAddress(0xfec0_0000);
 pub const IOAPIC_SIZE: u64 = 0x20;

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -13,6 +13,9 @@ byteorder = "1.4.3"
 hypervisor = { path = "../hypervisor" }
 libc = "0.2.137"
 log = "0.4.17"
+phf = { version = "0.11", features = ["macros"] }
+thiserror = "1.0.30"
+tpm = { path = "../tpm" }
 versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-device = { path = "../vm-device" }

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -19,6 +19,7 @@ pub mod interrupt_controller;
 #[cfg(target_arch = "x86_64")]
 pub mod ioapic;
 pub mod legacy;
+pub mod tpm;
 
 pub use self::acpi::{AcpiGedDevice, AcpiPmTimerDevice, AcpiShutdownDevice};
 

--- a/devices/src/tpm.rs
+++ b/devices/src/tpm.rs
@@ -1,0 +1,470 @@
+// Copyright © 2022, Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::anyhow;
+#[cfg(target_arch = "aarch64")]
+use arch::aarch64::layout::{TPM_SIZE, TPM_START};
+#[cfg(target_arch = "x86_64")]
+use arch::x86_64::layout::{TPM_SIZE, TPM_START};
+use phf::phf_map;
+use std::cmp;
+use std::sync::{Arc, Barrier};
+use thiserror::Error;
+use tpm::emulator::{BackendCmd, Emulator};
+use tpm::TPM_CRB_BUFFER_MAX;
+use tpm::TPM_SUCCESS;
+use vm_device::BusDevice;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Emulator doesn't implement min required capabilities: {0}")]
+    CheckCaps(#[source] anyhow::Error),
+    #[error("Failed to initialize tpm: {0}")]
+    Init(#[source] anyhow::Error),
+    #[error("Failed to deliver tpm Command: {0}")]
+    DeliverRequest(#[source] anyhow::Error),
+}
+type Result<T> = anyhow::Result<T, Error>;
+
+/* crb 32-bit registers */
+const CRB_LOC_STATE: u32 = 0x0;
+//Register Fields
+// Field => (start, length)
+// start: lowest bit in the bit field numbered from 0
+// length: length of the bit field
+const CRB_LOC_STATE_FIELDS: phf::Map<&str, [u32; 2]> = phf_map! {
+    "tpmEstablished" => [0, 1],
+    "locAssigned" => [1,1],
+    "activeLocality"=> [2, 3],
+    "reserved" => [5, 2],
+    "tpmRegValidSts" => [7, 1]
+};
+const CRB_LOC_CTRL: u32 = 0x08;
+const CRB_LOC_CTRL_REQUEST_ACCESS: u32 = 1 << 0;
+const CRB_LOC_CTRL_RELINQUISH: u32 = 1 << 1;
+const CRB_LOC_CTRL_RESET_ESTABLISHMENT_BIT: u32 = 1 << 3;
+const CRB_LOC_STS: u32 = 0x0C;
+const CRB_LOC_STS_FIELDS: phf::Map<&str, [u32; 2]> = phf_map! {
+    "Granted" => [0, 1],
+    "beenSeized" => [1,1]
+};
+const CRB_INTF_ID: u32 = 0x30;
+const CRB_INTF_ID_FIELDS: phf::Map<&str, [u32; 2]> = phf_map! {
+    "InterfaceType" => [0, 4],
+    "InterfaceVersion" => [4, 4],
+    "CapLocality" =>  [8, 1],
+    "CapCRBIdleBypass" => [9, 1],
+    "Reserved1" => [10, 1],
+    "CapDataXferSizeSupport" => [11, 2],
+    "CapFIFO" =>  [13, 1],
+    "CapCRB" => [14, 1],
+    "CapIFRes" => [15, 2],
+    "InterfaceSelector" => [17, 2],
+    "IntfSelLock" =>  [19, 1],
+    "Reserved2" => [20, 4],
+    "RID" => [24, 8]
+};
+const CRB_INTF_ID2: u32 = 0x34;
+const CRB_INTF_ID2_FIELDS: phf::Map<&str, [u32; 2]> = phf_map! {
+    "VID" => [0, 16],
+    "DID" => [16, 16]
+};
+const CRB_CTRL_REQ: u32 = 0x40;
+const CRB_CTRL_REQ_CMD_READY: u32 = 1 << 0;
+const CRB_CTRL_REQ_GO_IDLE: u32 = 1 << 1;
+const CRB_CTRL_STS: u32 = 0x44;
+const CRB_CTRL_STS_FIELDS: phf::Map<&str, [u32; 2]> = phf_map! {
+    "tpmSts" => [0, 1],
+    "tpmIdle" => [1, 1]
+};
+const CRB_CTRL_CANCEL: u32 = 0x48;
+const CRB_CANCEL_INVOKE: u32 = 1 << 0;
+const CRB_CTRL_START: u32 = 0x4C;
+const CRB_START_INVOKE: u32 = 1 << 0;
+const CRB_CTRL_CMD_LADDR: u32 = 0x5C;
+const CRB_CTRL_CMD_HADDR: u32 = 0x60;
+const CRB_CTRL_RSP_SIZE: u32 = 0x64;
+const CRB_CTRL_RSP_ADDR: u32 = 0x68;
+const CRB_DATA_BUFFER: u32 = 0x80;
+
+const TPM_CRB_NO_LOCALITY: u32 = 0xff;
+
+const TPM_CRB_ADDR_BASE: u32 = TPM_START.0 as u32;
+const TPM_CRB_ADDR_SIZE: usize = TPM_SIZE as usize;
+
+const TPM_CRB_R_MAX: u32 = CRB_DATA_BUFFER;
+
+// CRB Protocol details
+const CRB_INTF_TYPE_CRB_ACTIVE: u32 = 0b1;
+const CRB_INTF_VERSION_CRB: u32 = 0b1;
+const CRB_INTF_CAP_LOCALITY_0_ONLY: u32 = 0b0;
+const CRB_INTF_CAP_IDLE_FAST: u32 = 0b0;
+const CRB_INTF_CAP_XFER_SIZE_64: u32 = 0b11;
+const CRB_INTF_CAP_FIFO_NOT_SUPPORTED: u32 = 0b0;
+const CRB_INTF_CAP_CRB_SUPPORTED: u32 = 0b1;
+const CRB_INTF_IF_SELECTOR_CRB: u32 = 0b1;
+const PCI_VENDOR_ID_IBM: u32 = 0x1014;
+const CRB_CTRL_CMD_SIZE_REG: u32 = 0x58;
+const CRB_CTRL_CMD_SIZE: usize = TPM_CRB_ADDR_SIZE - CRB_DATA_BUFFER as usize;
+
+fn get_fields_map(reg: u32) -> phf::Map<&'static str, [u32; 2]> {
+    match reg {
+        CRB_LOC_STATE => CRB_LOC_STATE_FIELDS,
+        CRB_LOC_STS => CRB_LOC_STS_FIELDS,
+        CRB_INTF_ID => CRB_INTF_ID_FIELDS,
+        CRB_INTF_ID2 => CRB_INTF_ID2_FIELDS,
+        CRB_CTRL_STS => CRB_CTRL_STS_FIELDS,
+        _ => {
+            panic!(
+                "Fields in '{:?}' register were accessed which are Invalid",
+                reg
+            );
+        }
+    }
+}
+
+/// Set a particular field in a Register
+fn set_reg_field(regs: &mut [u32; TPM_CRB_R_MAX as usize], reg: u32, field: &str, value: u32) {
+    let reg_fields = get_fields_map(reg);
+    if reg_fields.contains_key(field) {
+        let start = reg_fields.get(field).unwrap()[0];
+        let len = reg_fields.get(field).unwrap()[1];
+        let mask = (!(0_u32) >> (32 - len)) << start;
+        regs[reg as usize] = (regs[reg as usize] & !mask) | ((value << start) & mask);
+    } else {
+        error!(
+            "Failed to tpm Register. {:?} is not a valid field in Reg {:#X}",
+            field, reg
+        )
+    }
+}
+
+/// Get the value of a particular field in a Register
+fn get_reg_field(regs: &[u32; TPM_CRB_R_MAX as usize], reg: u32, field: &str) -> u32 {
+    let reg_fields = get_fields_map(reg);
+    if reg_fields.contains_key(field) {
+        let start = reg_fields.get(field).unwrap()[0];
+        let len = reg_fields.get(field).unwrap()[1];
+        let mask = (!(0_u32) >> (32 - len)) << start;
+        (regs[reg as usize] & mask) >> start
+    } else {
+        // TODO: Sensible return value if fields do not exist
+        0x0
+    }
+}
+
+fn locality_from_addr(addr: u32) -> u8 {
+    (addr >> 12) as u8
+}
+
+pub struct Tpm {
+    emulator: Emulator,
+    cmd: Option<BackendCmd>,
+    regs: [u32; TPM_CRB_R_MAX as usize],
+    backend_buff_size: usize,
+    data_buff: [u8; TPM_CRB_BUFFER_MAX],
+    data_buff_len: usize,
+}
+
+impl Tpm {
+    pub fn new(path: String) -> Result<Self> {
+        let emulator = Emulator::new(path)
+            .map_err(|e| Error::Init(anyhow!("Failed while initializing tpm Emulator: {:?}", e)))?;
+        let mut tpm = Tpm {
+            emulator,
+            cmd: None,
+            regs: [0; TPM_CRB_R_MAX as usize],
+            backend_buff_size: TPM_CRB_BUFFER_MAX,
+            data_buff: [0; TPM_CRB_BUFFER_MAX],
+            data_buff_len: 0,
+        };
+        tpm.reset()?;
+        Ok(tpm)
+    }
+
+    fn get_active_locality(&mut self) -> u32 {
+        if get_reg_field(&self.regs, CRB_LOC_STATE, "locAssigned") == 0 {
+            return TPM_CRB_NO_LOCALITY;
+        }
+        get_reg_field(&self.regs, CRB_LOC_STATE, "activeLocality")
+    }
+
+    fn request_completed(&mut self, result: isize) {
+        self.regs[CRB_CTRL_START as usize] = !CRB_START_INVOKE;
+        if result != 0 {
+            set_reg_field(&mut self.regs, CRB_CTRL_STS, "tpmSts", 1);
+        }
+    }
+
+    fn reset(&mut self) -> Result<()> {
+        let cur_buff_size = self.emulator.get_buffer_size().unwrap();
+        self.regs = [0; TPM_CRB_R_MAX as usize];
+        set_reg_field(&mut self.regs, CRB_LOC_STATE, "tpmRegValidSts", 1);
+        set_reg_field(&mut self.regs, CRB_CTRL_STS, "tpmIdle", 1);
+        set_reg_field(
+            &mut self.regs,
+            CRB_INTF_ID,
+            "InterfaceType",
+            CRB_INTF_TYPE_CRB_ACTIVE,
+        );
+        set_reg_field(
+            &mut self.regs,
+            CRB_INTF_ID,
+            "InterfaceVersion",
+            CRB_INTF_VERSION_CRB,
+        );
+        set_reg_field(
+            &mut self.regs,
+            CRB_INTF_ID,
+            "CapLocality",
+            CRB_INTF_CAP_LOCALITY_0_ONLY,
+        );
+        set_reg_field(
+            &mut self.regs,
+            CRB_INTF_ID,
+            "CapCRBIdleBypass",
+            CRB_INTF_CAP_IDLE_FAST,
+        );
+        set_reg_field(
+            &mut self.regs,
+            CRB_INTF_ID,
+            "CapDataXferSizeSupport",
+            CRB_INTF_CAP_XFER_SIZE_64,
+        );
+        set_reg_field(
+            &mut self.regs,
+            CRB_INTF_ID,
+            "CapFIFO",
+            CRB_INTF_CAP_FIFO_NOT_SUPPORTED,
+        );
+        set_reg_field(
+            &mut self.regs,
+            CRB_INTF_ID,
+            "CapCRB",
+            CRB_INTF_CAP_CRB_SUPPORTED,
+        );
+        set_reg_field(
+            &mut self.regs,
+            CRB_INTF_ID,
+            "InterfaceSelector",
+            CRB_INTF_IF_SELECTOR_CRB,
+        );
+        set_reg_field(&mut self.regs, CRB_INTF_ID, "RID", 0b0000);
+        set_reg_field(&mut self.regs, CRB_INTF_ID2, "VID", PCI_VENDOR_ID_IBM);
+
+        self.regs[CRB_CTRL_CMD_SIZE_REG as usize] = CRB_CTRL_CMD_SIZE as u32;
+        self.regs[CRB_CTRL_CMD_LADDR as usize] = TPM_CRB_ADDR_BASE + CRB_DATA_BUFFER;
+        self.regs[CRB_CTRL_RSP_SIZE as usize] = CRB_CTRL_CMD_SIZE as u32;
+        self.regs[CRB_CTRL_RSP_ADDR as usize] = TPM_CRB_ADDR_BASE + CRB_DATA_BUFFER;
+
+        self.backend_buff_size = cmp::min(cur_buff_size, TPM_CRB_BUFFER_MAX);
+
+        if let Err(e) = self.emulator.startup_tpm(self.backend_buff_size) {
+            return Err(Error::Init(anyhow!(
+                "Failed while running Startup TPM. Error: {:?}",
+                e
+            )));
+        }
+        Ok(())
+    }
+}
+
+//impl BusDevice for TPM
+impl BusDevice for Tpm {
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
+        let mut offset: u32 = offset as u32;
+        let read_len: usize = data.len();
+
+        if offset >= CRB_DATA_BUFFER
+            && (offset + read_len as u32) < (CRB_DATA_BUFFER + self.data_buff.len() as u32)
+        {
+            // Read from Data Buffer
+            let start: usize = (offset as usize) - (CRB_DATA_BUFFER as usize);
+            let end: usize = start + read_len;
+            data[..].clone_from_slice(&self.data_buff[start..end]);
+        } else {
+            offset &= 0xff;
+            let mut val = self.regs[offset as usize];
+
+            if offset == CRB_LOC_STATE && !self.emulator.get_established_flag() {
+                val |= 0x1;
+            }
+
+            if data.len() <= 4 {
+                data.clone_from_slice(val.to_ne_bytes()[0..read_len].as_ref());
+            } else {
+                error!(
+                    "Invalid tpm read: offset {:#X}, data length {:?}",
+                    offset,
+                    data.len()
+                );
+            }
+        }
+        debug!(
+            "MMIO Read: offset {:#X} len {:?} val = {:02X?}  ",
+            offset,
+            data.len(),
+            data
+        );
+    }
+
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        debug!(
+            "MMIO Write: offset {:#X} len {:?} input data {:02X?}",
+            offset,
+            data.len(),
+            data
+        );
+        let mut offset: u32 = offset as u32;
+        if offset < CRB_DATA_BUFFER {
+            offset &= 0xff;
+        }
+        let locality = locality_from_addr(offset) as u32;
+        let write_len = data.len();
+
+        if offset >= CRB_DATA_BUFFER
+            && (offset + write_len as u32) < (CRB_DATA_BUFFER + self.data_buff.len() as u32)
+        {
+            let start: usize = (offset as usize) - (CRB_DATA_BUFFER as usize);
+            if start == 0 {
+                // If filling data_buff at index 0, reset length to 0
+                self.data_buff_len = 0;
+                self.data_buff.fill(0);
+            }
+            let end: usize = start + data.len();
+            self.data_buff[start..end].clone_from_slice(data);
+            self.data_buff_len += data.len();
+        } else {
+            // Ctrl Commands that take more than 4 bytes as input are not yet supported
+            // CTRL_RSP_ADDR usually gets 8 byte write request. Last 4 bytes are zeros.
+            if write_len > 4 && offset != CRB_CTRL_RSP_ADDR {
+                error!(
+                    "Invalid tpm write: offset {:#X}, data length {}",
+                    offset,
+                    data.len()
+                );
+                return None;
+            }
+
+            let mut input: [u8; 4] = [0; 4];
+            input.copy_from_slice(&data[0..4]);
+            let v = u32::from_le_bytes(input);
+
+            match offset {
+                CRB_CTRL_CMD_SIZE_REG => {
+                    self.regs[CRB_CTRL_CMD_SIZE_REG as usize] = v;
+                }
+                CRB_CTRL_CMD_LADDR => {
+                    self.regs[CRB_CTRL_CMD_LADDR as usize] = v;
+                }
+                CRB_CTRL_CMD_HADDR => {
+                    self.regs[CRB_CTRL_CMD_HADDR as usize] = v;
+                }
+                CRB_CTRL_RSP_SIZE => {
+                    self.regs[CRB_CTRL_RSP_SIZE as usize] = v;
+                }
+                CRB_CTRL_RSP_ADDR => {
+                    self.regs[CRB_CTRL_RSP_ADDR as usize] = v;
+                }
+                CRB_CTRL_REQ => match v {
+                    CRB_CTRL_REQ_CMD_READY => {
+                        set_reg_field(&mut self.regs, CRB_CTRL_STS, "tpmIdle", 0);
+                    }
+                    CRB_CTRL_REQ_GO_IDLE => {
+                        set_reg_field(&mut self.regs, CRB_CTRL_STS, "tpmIdle", 1);
+                    }
+                    _ => {
+                        error!("Invalid value passed to CRTL_REQ register");
+                        return None;
+                    }
+                },
+                CRB_CTRL_CANCEL => {
+                    if v == CRB_CANCEL_INVOKE
+                        && (self.regs[CRB_CTRL_START as usize] & CRB_START_INVOKE != 0)
+                    {
+                        if let Err(e) = self.emulator.cancel_cmd() {
+                            error!("Failed to run cancel command. Error: {:?}", e);
+                        }
+                    }
+                }
+                CRB_CTRL_START => {
+                    if v == CRB_START_INVOKE
+                        && ((self.regs[CRB_CTRL_START as usize] & CRB_START_INVOKE) == 0)
+                        && self.get_active_locality() == locality
+                    {
+                        self.regs[CRB_CTRL_START as usize] |= CRB_START_INVOKE;
+
+                        self.cmd = Some(BackendCmd {
+                            locality: locality as u8,
+                            input: self.data_buff[0..self.data_buff_len].to_vec(),
+                            input_len: cmp::min(self.data_buff_len, TPM_CRB_BUFFER_MAX),
+                            output: self.data_buff.to_vec(),
+                            output_len: TPM_CRB_BUFFER_MAX,
+                            selftest_done: false,
+                        });
+
+                        let mut cmd = self.cmd.as_ref().unwrap().clone();
+                        let output = self.emulator.deliver_request(&mut cmd).map_err(|e| {
+                            Error::DeliverRequest(anyhow!(
+                                "Failed to deliver tpm request. Error :{:?}",
+                                e
+                            ))
+                        });
+                        //TODO: drop the copy here
+                        self.data_buff.fill(0);
+                        self.data_buff.clone_from_slice(output.unwrap().as_slice());
+
+                        self.request_completed(TPM_SUCCESS as isize);
+                    }
+                }
+                CRB_LOC_CTRL => {
+                    warn!(
+                        "CRB_LOC_CTRL locality to write = {:?} val = {:?}",
+                        locality, v
+                    );
+                    match v {
+                        CRB_LOC_CTRL_RESET_ESTABLISHMENT_BIT => {}
+                        CRB_LOC_CTRL_RELINQUISH => {
+                            set_reg_field(&mut self.regs, CRB_LOC_STATE, "locAssigned", 0);
+                            set_reg_field(&mut self.regs, CRB_LOC_STS, "Granted", 0);
+                        }
+                        CRB_LOC_CTRL_REQUEST_ACCESS => {
+                            set_reg_field(&mut self.regs, CRB_LOC_STS, "Granted", 1);
+                            set_reg_field(&mut self.regs, CRB_LOC_STS, "beenSeized", 0);
+                            set_reg_field(&mut self.regs, CRB_LOC_STATE, "locAssigned", 1);
+                        }
+                        _ => {
+                            error!("Invalid value to write in CRB_LOC_CTRL {:#X} ", v);
+                        }
+                    }
+                }
+                _ => {
+                    error!(
+                        "Invalid tpm write: offset {:#X}, data length {:?}",
+                        offset,
+                        data.len()
+                    );
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_set_get_reg_field() {
+        let mut regs: [u32; TPM_CRB_R_MAX as usize] = [0; TPM_CRB_R_MAX as usize];
+        set_reg_field(&mut regs, CRB_INTF_ID, "RID", 0xAC);
+        assert_eq!(
+            get_reg_field(&regs, CRB_INTF_ID, "RID"),
+            0xAC,
+            concat!("Test: ", stringify!(set_get_reg_field))
+        );
+    }
+}

--- a/docs/tpm.md
+++ b/docs/tpm.md
@@ -1,0 +1,122 @@
+# TPM
+Tpm in Cloud-Hypervisor is emulated using `swtpm` as the backend. [swtpm](https://github.com/stefanberger/swtpm) is the link to swtpm project.
+
+Current implementation only supports TPM `2.0` version. At the moment only
+`CRB Interface` is implemented. This interface is described in
+[TCG PC Client Platform TPM Profile Specification for TPM 2.0, Revision 01.05 v4](https://trustedcomputinggroup.org/wp-content/uploads/PC-Client-Specific-Platform-TPM-Profile-for-TPM-2p0-v1p05p_r14_pub.pdf).
+
+
+## Usage
+`--tpm`, an optional argument, can be passed to enable tpm device.
+This argument takes an UNIX domain Socket as a `socket` value.
+
+_Example_
+
+An Example invocation with `--tpm` argument:
+
+```
+ ./cloud-hypervisor/target/release/cloud-hypervisor \
+	--kernel ./hypervisor-fw \
+	--disk path=focal-server-cloudimg-amd64.raw \
+	--cpus boot=4 \
+	--memory size=1024M \
+	--net "tap=,mac=,ip=,mask=" \
+	--tpm socket="/var/run/swtpm.socket"
+```
+
+## swtpm
+Before invoking cloud-hypervisor with `--tpm` argument, a `swtpm`
+process should be started to listen at the input socket. Below is an
+example invocation of swtpm process.
+
+```
+swtpm socket --tmpstate dir=/var/run/swtpm \
+	--ctrl type=unixio,path="/var/run/swtpm.socket" \
+	--flags startup-clear \
+	--tpm2
+```
+
+## Guest
+After starting a guest with the above commands, ensure below listed modules are
+loaded in the guest:
+
+```
+# lsmod | grep tpm
+tpm_crb                20480  0
+tpm                    81920  1 tpm_crb
+```
+
+Below is the IO Memory map configured in the guest:
+
+```
+# cat /proc/iomem  | grep MSFT
+fed40000-fed40fff : MSFT0101:00
+  fed40000-fed40fff : MSFT0101:00
+```
+Below are the devices created in the guest:
+
+```
+# ls /dev/tpm*
+/dev/tpm0  /dev/tpmrm0
+```
+
+
+## Testing
+
+Inside the guest install `tpm2-tools` package. This package provides some
+commands to run against TPM that supports 2.0 version.
+
+_Examples_
+```
+// Run Self Test
+# tpm2_selftest -f
+# echo $?
+0
+
+
+# echo "hello" > input.txt
+// this command generates hash of the input file using all the algos supported by TPM
+
+# tpm2_pcrevent input.txt
+sha1: f572d396fae9206628714fb2ce00f72e94f2258f
+sha256: 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
+sha384: 1d0f284efe3edea4b9ca3bd514fa134b17eae361ccc7a1eefeff801b9bd6604e01f21f6bf249ef030599f0c
+218f2ba8c
+sha512: e7c22b994c59d9cf2b48e549b1e24666636045930d3da7c1acb299d1c3b7f931f94aae41edda2c2b207a36e
+10f8bcb8d45223e54878f5b316e7ce3b6bc019629
+
+// verify one of the hashes
+# sha256sum input.txt
+5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03  input.txt
+```
+
+### Bundled Functional Test
+
+Build time dependencies for `tpm2-tss` are captured in [INSTALL](https://github.com/tpm2-software/tpm2-tss/blob/master/INSTALL.md).
+
+```
+# git clone https://github.com/tpm2-software/tpm2-tss.git
+# cd tpm2-tss
+# ./configure --enable-integration --with-devicetests="mandatory,optional" --with-device=/dev/tpm0
+# sudo make check-device
+.
+.
+.
+.
+============================================================================
+Testsuite summary for tpm2-tss 3.2.0-74-ge03617d9
+============================================================================
+# TOTAL: 154
+# PASS:  88
+# SKIP:  7
+# XFAIL: 0
+# FAIL:  59
+# XPASS: 0
+# ERROR: 0
+============================================================================
+See ./test-suite.log
+Please report to https://github.com/tpm2-software/tpm2-tss/issues
+============================================================================
+```
+The same set of failures are noticed while running these tests on `Qemu` with
+its TPM implementation.

--- a/src/main.rs
+++ b/src/main.rs
@@ -362,6 +362,14 @@ fn create_app(default_vcpus: String, default_memory: String, default_rng: String
                 .num_args(1)
                 .value_parser(["true", "false", "log"])
                 .default_value("true"),
+        )
+        .arg(
+            Arg::new("tpm")
+                .long("tpm")
+                .num_args(1)
+                .help(config::TpmConfig::SYNTAX)
+                .group("vmm-config"),
+
         );
 
     #[cfg(target_arch = "x86_64")]
@@ -713,6 +721,7 @@ mod unit_tests {
             #[cfg(feature = "guest_debug")]
             gdb: false,
             platform: None,
+            tpm: None,
         };
 
         assert_eq!(expected_vm_config, result_vm_config);
@@ -1627,6 +1636,28 @@ mod unit_tests {
                 true,
             ),
         ]
+        .iter()
+        .for_each(|(cli, openapi, equal)| {
+            compare_vm_config_cli_vs_json(cli, openapi, *equal);
+        });
+    }
+
+    #[test]
+    fn test_valid_vm_config_tpm_socket() {
+        vec![(
+            vec![
+                "cloud-hypervisor",
+                "--kernel",
+                "/path/to/kernel",
+                "--tpm",
+                "socket=/path/to/tpm/sock",
+            ],
+            r#"{
+                    "payload": {"kernel": "/path/to/kernel"},
+                    "tpm": {"socket": "/path/to/tpm/sock"}
+                }"#,
+            true,
+        )]
         .iter()
         .for_each(|(cli, openapi, equal)| {
             compare_vm_config_cli_vs_json(cli, openapi, *equal);

--- a/tpm/Cargo.toml
+++ b/tpm/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tpm"
+edition = "2021"
+authors = ["Microsoft Authors"]
+license = "Apache-2.0"
+version = "0.1.0"
+
+[dependencies]
+anyhow = "1.0.56"
+byteorder = "1.4.3"
+log = "0.4.14"
+thiserror = "1.0.30"

--- a/tpm/Cargo.toml
+++ b/tpm/Cargo.toml
@@ -8,5 +8,7 @@ version = "0.1.0"
 [dependencies]
 anyhow = "1.0.56"
 byteorder = "1.4.3"
+libc = "0.2.133"
 log = "0.4.14"
 thiserror = "1.0.30"
+vmm-sys-util = "0.10.0"

--- a/tpm/src/emulator.rs
+++ b/tpm/src/emulator.rs
@@ -1,0 +1,465 @@
+// Copyright © 2022, Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::socket::SocketDev;
+use crate::{Commands, MemberType, Ptm, PtmCap, PtmEst, PtmInit, PtmResult, PtmSetBufferSize};
+use crate::{TPM_CRB_BUFFER_MAX, TPM_SUCCESS};
+use anyhow::anyhow;
+use libc::c_void;
+use libc::{sockaddr_storage, socklen_t};
+use std::convert::TryInto;
+use std::os::unix::io::RawFd;
+use std::path::Path;
+use std::{mem, ptr};
+use thiserror::Error;
+
+const TPM_REQ_HDR_SIZE: usize = 10;
+
+/* capability flags returned by PTM_GET_CAPABILITY */
+const PTM_CAP_INIT: u64 = 1;
+const PTM_CAP_SHUTDOWN: u64 = 1 << 1;
+const PTM_CAP_GET_TPMESTABLISHED: u64 = 1 << 2;
+const PTM_CAP_SET_LOCALITY: u64 = 1 << 3;
+const PTM_CAP_CANCEL_TPM_CMD: u64 = 1 << 5;
+const PTM_CAP_RESET_TPMESTABLISHED: u64 = 1 << 7;
+const PTM_CAP_STOP: u64 = 1 << 10;
+const PTM_CAP_SET_DATAFD: u64 = 1 << 12;
+const PTM_CAP_SET_BUFFERSIZE: u64 = 1 << 13;
+
+///Check if the input command is selftest
+///
+pub fn is_selftest(input: Vec<u8>, in_len: usize) -> bool {
+    if in_len >= TPM_REQ_HDR_SIZE {
+        let ordinal: &[u8; 4] = input[6..6 + 4]
+            .try_into()
+            .expect("slice with incorrect length");
+
+        return u32::from_ne_bytes(*ordinal).to_be() == 0x143;
+    }
+    false
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Could not initialize emulator's backend: {0}")]
+    InitializeEmulator(#[source] anyhow::Error),
+    #[error("Failed to create data fd to pass to swtpm: {0}")]
+    PrepareDataFd(#[source] anyhow::Error),
+    #[error("Failed to run Control Cmd: {0}")]
+    RunControlCmd(#[source] anyhow::Error),
+    #[error("Emulator doesn't implement min required capabilities: {0}")]
+    CheckCaps(#[source] anyhow::Error),
+    #[error("Emulator failed to deliver request: {0}")]
+    DeliverRequest(#[source] anyhow::Error),
+    #[error("Emulator failed to send/receive msg on data fd: {0}")]
+    SendReceive(#[source] anyhow::Error),
+    #[error("Incorrect response to Self Test: {0}")]
+    SelfTest(#[source] anyhow::Error),
+}
+
+type Result<T> = anyhow::Result<T, Error>;
+
+#[derive(Clone)]
+pub struct BackendCmd {
+    pub locality: u8,
+    pub input: Vec<u8>,
+    pub input_len: usize,
+    pub output: Vec<u8>,
+    pub output_len: usize,
+    pub selftest_done: bool,
+}
+
+pub struct Emulator {
+    cmd: Option<BackendCmd>,
+    caps: PtmCap, /* capabilities of the TPM */
+    control_socket: SocketDev,
+    data_fd: RawFd,
+    established_flag_cached: bool,
+    established_flag: bool,
+}
+
+impl Emulator {
+    /// Create Emulator Instance
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - A path to the Unix Domain Socket swtpm is listening on
+    ///
+    pub fn new(path: String) -> Result<Self> {
+        if !Path::new(&path).exists() {
+            return Err(Error::InitializeEmulator(anyhow!(
+                "The input TPM Socket path: {:?} does not exist",
+                path
+            )));
+        }
+        let mut socket = SocketDev::new();
+        socket.init(path).map_err(|e| {
+            Error::InitializeEmulator(anyhow!("Failed while initializing tpm emulator: {:?}", e))
+        })?;
+
+        let mut emulator = Self {
+            cmd: None,
+            caps: 0,
+            control_socket: socket,
+            data_fd: -1,
+            established_flag_cached: false,
+            established_flag: false,
+        };
+
+        emulator.prepare_data_fd()?;
+
+        emulator.probe_caps()?;
+        if !emulator.check_caps() {
+            return Err(Error::InitializeEmulator(anyhow!(
+                "Required capabilities not supported by tpm backend"
+            )));
+        }
+
+        if !emulator.get_established_flag() {
+            return Err(Error::InitializeEmulator(anyhow!(
+                "TPM not in established state"
+            )));
+        }
+
+        Ok(emulator)
+    }
+
+    /// Create socketpair, assign one socket/FD as data_fd to Control Socket
+    /// The other socket/FD will be assigned to msg_fd, which will be sent to swtpm
+    /// via CmdSetDatafd control command
+    fn prepare_data_fd(&mut self) -> Result<()> {
+        let mut res: PtmResult = 0;
+
+        let mut fds = [-1, -1];
+        // Safe because return value of the unsafe call is checked
+        unsafe {
+            let ret = libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr());
+            if ret == -1 {
+                return Err(Error::PrepareDataFd(anyhow!(
+                    "Failed to prepare data fd for tpm emulator. Error Code {:?}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+        }
+        self.control_socket.set_msgfd(fds[1]);
+        debug!("data fd to be configured in swtpm = {:?}", fds[1]);
+        self.run_control_cmd(Commands::CmdSetDatafd, &mut res, 0, mem::size_of::<u32>())?;
+        debug!("data fd in cloud-hypervisor = {:?}", fds[0]);
+        self.data_fd = fds[0];
+        self.control_socket.set_datafd(fds[0]);
+        Ok(())
+    }
+
+    /// Gather TPM Capabilities and cache them in Emulator
+    ///
+    fn probe_caps(&mut self) -> Result<()> {
+        let mut caps: u64 = 0;
+        self.run_control_cmd(
+            Commands::CmdGetCapability,
+            &mut caps,
+            0,
+            mem::size_of::<u64>(),
+        )?;
+        self.caps = caps;
+        Ok(())
+    }
+
+    /// Check if minimum set of capabitlies are supported
+    fn check_caps(&mut self) -> bool {
+        /* min. required capabilities for TPM 2.0*/
+        let caps: PtmCap = PTM_CAP_INIT
+            | PTM_CAP_SHUTDOWN
+            | PTM_CAP_GET_TPMESTABLISHED
+            | PTM_CAP_SET_LOCALITY
+            | PTM_CAP_RESET_TPMESTABLISHED
+            | PTM_CAP_SET_DATAFD
+            | PTM_CAP_STOP
+            | PTM_CAP_SET_BUFFERSIZE;
+
+        if (self.caps & caps) != caps {
+            return false;
+        }
+        true
+    }
+
+    ///
+    /// # Arguments
+    ///
+    /// * `cmd` - Control Command to run
+    /// * `msg` - Optional msg to be sent along with Control Command
+    /// * `msg_len_in` - len of 'msg' in bytes, if passed
+    /// * `msg_len_out` - length of expected output from Control Command in bytes
+    ///
+    fn run_control_cmd(
+        &mut self,
+        cmd: Commands,
+        msg: &mut dyn Ptm,
+        msg_len_in: usize,
+        msg_len_out: usize,
+    ) -> Result<()> {
+        debug!("Control Cmd to send : {:02X?}", cmd);
+
+        let cmd_no = (cmd as u32).to_be_bytes();
+        let n: isize = (mem::size_of::<u32>() + msg_len_in) as isize;
+
+        let converted_req = msg.ptm_to_request();
+        debug!("converted request: {:02X?}", converted_req);
+
+        let mut buf = Vec::<u8>::with_capacity(n as usize);
+
+        buf.extend(cmd_no);
+        buf.extend(converted_req);
+        debug!("full Control request {:02X?}", buf);
+
+        let _res = self.control_socket.write(&buf).map_err(|e| {
+            Error::RunControlCmd(anyhow!(
+                "Failed while running {:02X?} Control Cmd. Error: {:?}",
+                cmd,
+                e
+            ))
+        })?;
+
+        let mut output = [0_u8; TPM_CRB_BUFFER_MAX];
+
+        // Every Control Cmd gets atleast a result code in response. Read it
+        let read_size = self.control_socket.read(&mut output).map_err(|e| {
+            Error::RunControlCmd(anyhow!(
+                "Failed while reading response for Control Cmd: {:02X?}. Error: {:?}",
+                cmd,
+                e
+            ))
+        })?;
+
+        if msg_len_out != 0 {
+            msg.update_ptm_with_response(&output[0..read_size])
+                .map_err(|e| {
+                    Error::RunControlCmd(anyhow!(
+                        "Failed while converting response of Control Cmd: {:02X?} to PTM. Error: {:?}",
+                        cmd,
+                        e
+                    ))
+                })?;
+        } else {
+            // No response expected, only handle return code
+            msg.set_member_type(MemberType::Response);
+        }
+
+        if msg.get_result_code() != TPM_SUCCESS {
+            return Err(Error::RunControlCmd(anyhow!(
+                "Control Cmd returned error code : {:?}",
+                msg.get_result_code()
+            )));
+        }
+        debug!("Control Cmd Response : {:02X?}", &output[0..read_size]);
+        Ok(())
+    }
+
+    pub fn get_established_flag(&mut self) -> bool {
+        let mut est: PtmEst = PtmEst::new();
+
+        if self.established_flag_cached {
+            return self.established_flag;
+        }
+
+        if let Err(e) = self.run_control_cmd(
+            Commands::CmdGetTpmEstablished,
+            &mut est,
+            0,
+            2 * mem::size_of::<u32>(),
+        ) {
+            error!(
+                "Failed to run CmdGetTpmEstablished Control Cmd. Error: {:?}",
+                e
+            );
+            return false;
+        }
+
+        self.established_flag_cached = true;
+        if est.resp.bit != 0 {
+            self.established_flag = false;
+        } else {
+            self.established_flag = true;
+        }
+
+        self.established_flag
+    }
+
+    /// Function to write to data socket and read the response from it
+    fn unix_tx_bufs(&mut self) -> Result<()> {
+        let isselftest: bool;
+        // Safe as type "sockaddr_storage" is valid with an all-zero byte-pattern value
+        let mut addr: sockaddr_storage = unsafe { mem::zeroed() };
+        let mut len = mem::size_of::<sockaddr_storage>() as socklen_t;
+
+        if let Some(ref mut cmd) = self.cmd {
+            cmd.selftest_done = false;
+            isselftest = is_selftest(cmd.input.to_vec(), cmd.input_len);
+
+            debug!(
+                "Send cmd: {:02X?}  of len {:?} on data_ioc ",
+                cmd.input, cmd.input_len
+            );
+
+            let data_vecs = [libc::iovec {
+                iov_base: cmd.input.as_mut_ptr() as *mut libc::c_void,
+                iov_len: cmd.input.len(),
+            }; 1];
+
+            // Safe because all zero values from the unsafe method are updated before usage
+            let mut msghdr: libc::msghdr = unsafe { mem::zeroed() };
+            msghdr.msg_name = ptr::null_mut();
+            msghdr.msg_namelen = 0;
+            msghdr.msg_iov = data_vecs.as_ptr() as *mut libc::iovec;
+            msghdr.msg_iovlen = data_vecs.len() as _;
+            msghdr.msg_control = ptr::null_mut();
+            msghdr.msg_controllen = 0;
+            msghdr.msg_flags = 0;
+            // Safe as the return value of the unsafe method is checked
+            unsafe {
+                let ret = libc::sendmsg(self.data_fd, &msghdr, 0);
+                if ret == -1 {
+                    return Err(Error::SendReceive(anyhow!(
+                        "Failed to send tpm command over Data FD. Error Code {:?}",
+                        std::io::Error::last_os_error()
+                    )));
+                }
+            }
+
+            cmd.output.fill(0);
+            // Safe as return value from unsafe method is checked
+            unsafe {
+                let ret = libc::recvfrom(
+                    self.data_fd,
+                    cmd.output.as_ptr() as *mut c_void,
+                    cmd.output.len(),
+                    0,
+                    &mut addr as *mut libc::sockaddr_storage as *mut libc::sockaddr,
+                    &mut len as *mut socklen_t,
+                );
+                if ret == -1 {
+                    return Err(Error::SendReceive(anyhow!(
+                        "Failed to receive response for tpm command over Data FD. Error Code {:?}",
+                        std::io::Error::last_os_error()
+                    )));
+                }
+                cmd.output_len = ret as usize;
+            }
+            debug!(
+                "response = {:02X?} len = {:?} selftest = {:?}",
+                cmd.output, cmd.output_len, isselftest
+            );
+
+            if isselftest {
+                if cmd.output_len < 10 {
+                    return Err(Error::SelfTest(anyhow!(
+                        "Self test response should have 10 bytes. Only {:?} returned",
+                        cmd.output_len
+                    )));
+                }
+                let mut errcode: [u8; 4] = [0; 4];
+                errcode.copy_from_slice(&cmd.output[6..6 + 4]);
+                cmd.selftest_done = u32::from_ne_bytes(errcode).to_be() == 0;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn deliver_request(&mut self, in_cmd: &mut BackendCmd) -> Result<Vec<u8>> {
+        if self.cmd.is_some() {
+            //previous request did not finish cleanly
+            return Err(Error::DeliverRequest(anyhow!(
+                "Cannot deliver tpm Request as previous cmd did not complete."
+            )));
+        }
+        self.cmd = Some(in_cmd.clone());
+
+        self.unix_tx_bufs()?;
+
+        let output = self.cmd.as_ref().unwrap().output.clone();
+        in_cmd.output.fill(0);
+        in_cmd.output.clone_from(&output);
+
+        self.backend_request_completed();
+        Ok(output)
+    }
+
+    pub fn backend_request_completed(&mut self) {
+        self.cmd = None;
+    }
+
+    pub fn cancel_cmd(&mut self) -> Result<()> {
+        let mut res: PtmResult = 0;
+
+        // Check if emulator implements Cancel Cmd
+        if (self.caps & PTM_CAP_CANCEL_TPM_CMD) != PTM_CAP_CANCEL_TPM_CMD {
+            return Err(Error::CheckCaps(anyhow!(
+                "Emulator does not implement 'Cancel Command' Capability"
+            )));
+        }
+        self.run_control_cmd(
+            Commands::CmdCancelTpmCmd,
+            &mut res,
+            0,
+            mem::size_of::<u32>(),
+        )?;
+        Ok(())
+    }
+
+    /// Configure buffersize to use while communicating with swtpm
+    fn set_buffer_size(&mut self, wantedsize: usize, actualsize: &mut usize) -> Result<()> {
+        let mut psbs: PtmSetBufferSize = PtmSetBufferSize::new(wantedsize as u32);
+
+        self.stop_tpm()?;
+
+        self.run_control_cmd(
+            Commands::CmdSetBufferSize,
+            &mut psbs,
+            mem::size_of::<u32>(),
+            4 * mem::size_of::<u32>(),
+        )?;
+
+        *actualsize = psbs.get_bufsize() as usize;
+
+        Ok(())
+    }
+
+    pub fn startup_tpm(&mut self, buffersize: usize) -> Result<()> {
+        let mut init: PtmInit = PtmInit::new();
+
+        let mut actual_size: usize = 0;
+
+        if buffersize != 0 {
+            self.set_buffer_size(buffersize, &mut actual_size)?;
+            debug!("set tpm buffersize to {:?} during Startup", buffersize);
+        }
+
+        self.run_control_cmd(
+            Commands::CmdInit,
+            &mut init,
+            mem::size_of::<u32>(),
+            mem::size_of::<u32>(),
+        )?;
+
+        Ok(())
+    }
+
+    fn stop_tpm(&mut self) -> Result<()> {
+        let mut res: PtmResult = 0;
+
+        self.run_control_cmd(Commands::CmdStop, &mut res, 0, mem::size_of::<u32>())?;
+
+        Ok(())
+    }
+
+    pub fn get_buffer_size(&mut self) -> Result<usize> {
+        let mut curr_buf_size: usize = 0;
+
+        match self.set_buffer_size(0, &mut curr_buf_size) {
+            Err(_) => Ok(TPM_CRB_BUFFER_MAX),
+            _ => Ok(curr_buf_size),
+        }
+    }
+}

--- a/tpm/src/lib.rs
+++ b/tpm/src/lib.rs
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#[macro_use]
+extern crate log;
+
+pub mod socket;
+
 use anyhow::anyhow;
 use byteorder::{BigEndian, ReadBytesExt};
 use std::convert::TryInto;

--- a/tpm/src/lib.rs
+++ b/tpm/src/lib.rs
@@ -1,0 +1,434 @@
+// Copyright © 2022, Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::anyhow;
+use byteorder::{BigEndian, ReadBytesExt};
+use std::convert::TryInto;
+use thiserror::Error;
+
+pub const TPM_CRB_BUFFER_MAX: usize = 3968; // 0x1_000 - 0x80
+pub const TPM_SUCCESS: u32 = 0x0;
+
+/*
+ * Structures required to process Request and Responses of Control commands
+ * used by control channel over UNIX socket interface
+ *
+ * All messages contain big-endian data.
+ *
+ * Reference: https://github.com/stefanberger/swtpm/blob/master/man/man3/swtpm_ioctls.pod
+ */
+#[derive(Debug, Clone, Copy)]
+pub enum Commands {
+    CmdGetCapability = 1,
+    CmdInit,
+    CmdShutdown,
+    CmdGetTpmEstablished,
+    CmdSetLocality,
+    CmdHashStart,
+    CmdHashData,
+    CmdHashEnd,
+    CmdCancelTpmCmd,
+    CmdStoreVolatile,
+    CmdResetTpmEstablished,
+    CmdGetStateBlob,
+    CmdSetStateBlob,
+    CmdStop,
+    CmdGetConfig,
+    CmdSetDatafd,
+    CmdSetBufferSize,
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Failed converting buf to PTM : {0}")]
+    ConvertToPtm(#[source] anyhow::Error),
+}
+type Result<T> = anyhow::Result<T, Error>;
+
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub enum MemberType {
+    Request,
+    Response,
+    Error,
+    Cap,
+}
+
+pub trait Ptm {
+    // Get Member Type
+    fn get_member_type(&self) -> MemberType;
+
+    // Set Member Type
+    fn set_member_type(&mut self, mem: MemberType);
+
+    // Convert PTM Request to bytes to be sent to tpm
+    fn ptm_to_request(&self) -> Vec<u8>;
+
+    // Update PTM from tpm's reponse
+    fn update_ptm_with_response(&mut self, buf: &[u8]) -> Result<()>;
+
+    // Update tpm result
+    fn set_result_code(&mut self, res: u32);
+
+    fn get_result_code(&self) -> u32;
+}
+
+/*
+ * Every response for a tpm Control Command execution must hold tpm return
+ * code (PtmResult) as its first element.
+ * Based on the type of input Control Command additional data could be
+ * appended to the response.
+ */
+pub type PtmResult = u32;
+
+impl Ptm for PtmResult {
+    fn ptm_to_request(&self) -> Vec<u8> {
+        let buf: Vec<u8> = Vec::<u8>::new();
+        buf
+    }
+
+    fn get_member_type(&self) -> MemberType {
+        MemberType::Response
+    }
+
+    fn update_ptm_with_response(&mut self, buf: &[u8]) -> Result<()> {
+        if buf.len() < 4 {
+            return Err(Error::ConvertToPtm(anyhow!(
+                "PtmRes buffer is of insufficient length. Buffer length should be atleast 4"
+            )));
+        }
+
+        *self = u32::from_be_bytes(buf[0..4].try_into().unwrap());
+        Ok(())
+    }
+
+    fn set_member_type(&mut self, _mem: MemberType) {}
+
+    fn set_result_code(&mut self, res: u32) {
+        *self = res;
+    }
+
+    fn get_result_code(&self) -> u32 {
+        *self
+    }
+}
+
+/* GET_CAPABILITY Response */
+pub type PtmCap = u64;
+impl Ptm for PtmCap {
+    fn ptm_to_request(&self) -> Vec<u8> {
+        // tpm's GetCapability call doesn't need any supporting message
+        // return an empty Buffer
+        let buf: Vec<u8> = Vec::<u8>::new();
+        buf
+    }
+
+    fn get_member_type(&self) -> MemberType {
+        MemberType::Cap
+    }
+
+    fn update_ptm_with_response(&mut self, mut buf: &[u8]) -> Result<()> {
+        let buf_len = buf.len();
+        if buf_len != 8 {
+            return Err(Error::ConvertToPtm(anyhow!(
+                "Response for GetCapability cmd is of incorrect length: {:?}. Response buffer should be 8 bytes long",
+            buf_len)));
+        }
+        *self = buf.read_u64::<BigEndian>().unwrap();
+        Ok(())
+    }
+
+    fn set_member_type(&mut self, _mem: MemberType) {}
+
+    fn set_result_code(&mut self, _res: u32) {}
+
+    fn get_result_code(&self) -> u32 {
+        ((*self) >> 32) as u32
+    }
+}
+
+/* GET_TPMESTABLISHED Reponse */
+#[derive(Debug)]
+pub struct PtmEstResp {
+    pub bit: u8,
+}
+
+#[derive(Debug)]
+pub struct PtmEst {
+    member: MemberType,
+    pub resp: PtmEstResp,
+    pub result_code: PtmResult,
+}
+
+impl PtmEst {
+    pub fn new() -> Self {
+        Self {
+            member: MemberType::Response,
+            result_code: 0,
+            resp: PtmEstResp { bit: 0 },
+        }
+    }
+}
+
+impl Default for PtmEst {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Ptm for PtmEst {
+    fn ptm_to_request(&self) -> Vec<u8> {
+        // tpm's GetTpmEstablished call doesn't need any supporting message
+        // return an empty Buffer
+        let buf: Vec<u8> = Vec::<u8>::new();
+        buf
+    }
+
+    fn get_member_type(&self) -> MemberType {
+        self.member
+    }
+
+    fn update_ptm_with_response(&mut self, buf: &[u8]) -> Result<()> {
+        if buf.len() < 5 {
+            return Err(Error::ConvertToPtm(anyhow!(
+                "Response for GetTpmEstablished cmd is of incorrect length. Response buffer should be 5 bytes long"
+            )));
+        }
+        let mut res = &buf[0..4];
+        self.set_result_code(res.read_u32::<BigEndian>().unwrap());
+        let bit = &buf[4];
+        self.resp.bit = *bit;
+        Ok(())
+    }
+
+    fn set_member_type(&mut self, _mem: MemberType) {}
+
+    fn set_result_code(&mut self, res: u32) {
+        self.result_code = res
+    }
+
+    fn get_result_code(&self) -> u32 {
+        self.result_code
+    }
+}
+
+/* INIT Response */
+
+#[derive(Debug)]
+pub struct PtmInit {
+    pub member: MemberType,
+    /* request */
+    pub init_flags: u32,
+    /* response */
+    pub result_code: PtmResult,
+}
+
+impl Default for PtmInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PtmInit {
+    pub fn new() -> Self {
+        Self {
+            member: MemberType::Request,
+            init_flags: 0,
+            result_code: 0,
+        }
+    }
+}
+
+impl Ptm for PtmInit {
+    fn ptm_to_request(&self) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::<u8>::new();
+        buf.extend_from_slice(&self.init_flags.to_be_bytes());
+        buf
+    }
+
+    fn get_member_type(&self) -> MemberType {
+        self.member
+    }
+
+    fn update_ptm_with_response(&mut self, buf: &[u8]) -> Result<()> {
+        if buf.len() != 4 {
+            return Err(Error::ConvertToPtm(anyhow!(
+                "Response for Init cmd is of incorrect length. Response buffer should be 4 bytes long"
+            )));
+        }
+        self.set_member_type(MemberType::Response);
+        let mut res = &buf[0..4];
+        self.set_result_code(res.read_u32::<BigEndian>().unwrap());
+        Ok(())
+    }
+
+    fn set_member_type(&mut self, mem: MemberType) {
+        self.member = mem
+    }
+
+    fn set_result_code(&mut self, res: u32) {
+        self.result_code = res
+    }
+
+    fn get_result_code(&self) -> u32 {
+        self.result_code
+    }
+}
+
+/*
+ * PTM_SET_BUFFERSIZE: Set the buffer size to be used by the tpm.
+ * A 0 on input queries for the current buffer size. Any other
+ * number will try to set the buffer size. The returned number is
+ * the buffer size that will be used, which can be larger than the
+ * requested one, if it was below the minimum, or smaller than the
+ * requested one, if it was above the maximum.
+ *
+ * SET_BUFFERSIZE Response
+ */
+#[derive(Debug)]
+pub struct PtmSBSReq {
+    buffersize: u32,
+}
+
+#[derive(Debug)]
+pub struct PtmSBSResp {
+    bufsize: u32,
+    minsize: u32,
+    maxsize: u32,
+}
+
+#[derive(Debug)]
+pub struct PtmSetBufferSize {
+    pub mem: MemberType,
+    /* request */
+    pub req: PtmSBSReq,
+    /* response */
+    pub resp: PtmSBSResp,
+    pub result_code: PtmResult,
+}
+
+impl PtmSetBufferSize {
+    pub fn new(req_buffsize: u32) -> Self {
+        Self {
+            mem: MemberType::Request,
+            req: PtmSBSReq {
+                buffersize: req_buffsize,
+            },
+            resp: PtmSBSResp {
+                bufsize: 0,
+                minsize: 0,
+                maxsize: 0,
+            },
+            result_code: 0,
+        }
+    }
+    pub fn get_bufsize(&self) -> u32 {
+        self.resp.bufsize
+    }
+}
+
+impl Ptm for PtmSetBufferSize {
+    fn ptm_to_request(&self) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::<u8>::new();
+        buf.extend_from_slice(&self.req.buffersize.to_be_bytes());
+        buf
+    }
+
+    fn get_member_type(&self) -> MemberType {
+        self.mem
+    }
+
+    fn update_ptm_with_response(&mut self, buf: &[u8]) -> Result<()> {
+        if buf.len() != 16 {
+            return Err(Error::ConvertToPtm(anyhow!(
+                "Response for CmdSetBufferSize cmd is of incorrect length. Response buffer should be 16 bytes long"
+            )));
+        }
+        self.set_member_type(MemberType::Response);
+        let mut res = &buf[0..4];
+        self.set_result_code(res.read_u32::<BigEndian>().unwrap());
+
+        let mut bufsize = &buf[4..8];
+        self.resp.bufsize = bufsize.read_u32::<BigEndian>().unwrap();
+
+        let mut minsize = &buf[8..12];
+        self.resp.minsize = minsize.read_u32::<BigEndian>().unwrap();
+
+        let mut maxsize = &buf[12..16];
+        self.resp.maxsize = maxsize.read_u32::<BigEndian>().unwrap();
+
+        Ok(())
+    }
+
+    fn set_member_type(&mut self, mem: MemberType) {
+        self.mem = mem
+    }
+
+    fn set_result_code(&mut self, res: u32) {
+        self.result_code = res
+    }
+
+    fn get_result_code(&self) -> u32 {
+        self.result_code
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_ptmresult() -> Result<()> {
+        let buf: &[u8] = &[0, 0, 0, 1];
+        let mut result_code: PtmResult = 0;
+        result_code.update_ptm_with_response(buf)?;
+        assert_eq!(result_code.get_result_code(), 0x1);
+        Ok(())
+    }
+    #[test]
+    fn test_ptmcap() -> Result<()> {
+        let mut cap: PtmCap = 0x0;
+        let buf: &[u8] = &[0, 0, 0, 0xE, 0, 0, 0xFF, 0xFF];
+        cap.update_ptm_with_response(buf)?;
+        assert_eq!(cap.get_result_code(), 0xE);
+        Ok(())
+    }
+    #[test]
+    fn test_ptmest() -> Result<()> {
+        let mut est: PtmEst = PtmEst::new();
+        let buf: &[u8] = &[0, 0, 0xE, 0, 0xC, 0, 1, 1];
+        est.update_ptm_with_response(buf)?;
+        assert_eq!(est.get_result_code(), 0xE00);
+        assert_eq!(est.resp.bit, 0xC);
+        Ok(())
+    }
+    #[test]
+    /*PtmInit Testing */
+    fn test_ptminit() -> Result<()> {
+        let mut init: PtmInit = PtmInit::new();
+        init.init_flags = 0x1;
+        let buf = init.ptm_to_request();
+        assert_eq!(buf, [0x0, 0x0, 0x0, 0x1]);
+        let response_buf: &[u8] = &[0, 0, 0xE, 0];
+        init.update_ptm_with_response(response_buf)?;
+        assert_eq!(init.get_result_code(), 0xE00);
+        Ok(())
+    }
+    #[test]
+    /* PtmSetBufferSize Testing */
+    fn test_ptmsetbuffersize() -> Result<()> {
+        let mut psbs: PtmSetBufferSize = PtmSetBufferSize::new(1024);
+        // Member type should be Request after initialization
+        assert_eq!(psbs.get_member_type(), MemberType::Request);
+        let buf: &[u8] = &[
+            0, 0x12, 0x34, 0x56, 0, 0, 0, 0xA, 0, 0, 0, 0xB, 0, 0, 0, 0xC,
+        ];
+        psbs.update_ptm_with_response(buf)?;
+        assert_eq!(psbs.get_member_type(), MemberType::Response);
+        assert_eq!(psbs.get_result_code(), 0x123456);
+        assert_eq!(psbs.resp.bufsize, 0xA);
+        assert_eq!(psbs.resp.minsize, 0xB);
+        assert_eq!(psbs.resp.maxsize, 0xC);
+        Ok(())
+    }
+}

--- a/tpm/src/lib.rs
+++ b/tpm/src/lib.rs
@@ -6,6 +6,7 @@
 #[macro_use]
 extern crate log;
 
+pub mod emulator;
 pub mod socket;
 
 use anyhow::anyhow;

--- a/tpm/src/socket.rs
+++ b/tpm/src/socket.rs
@@ -1,0 +1,144 @@
+// Copyright © 2022, Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::TPM_CRB_BUFFER_MAX;
+use anyhow::anyhow;
+use std::io::Read;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::net::UnixStream;
+use thiserror::Error;
+use vmm_sys_util::sock_ctrl_msg::ScmSocket;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Cannot connect to tpm Socket: {0}")]
+    ConnectToSocket(#[source] anyhow::Error),
+    #[error("Failed to read from socket: {0}")]
+    ReadFromSocket(#[source] anyhow::Error),
+    #[error("Failed to write to socket: {0}")]
+    WriteToSocket(#[source] anyhow::Error),
+}
+type Result<T> = anyhow::Result<T, Error>;
+
+#[derive(PartialEq)]
+enum SocketDevState {
+    Disconnected,
+    Connecting,
+    Connected,
+}
+
+pub struct SocketDev {
+    state: SocketDevState,
+    stream: Option<UnixStream>,
+    // Fd sent to swtpm process for Data Channel
+    write_msgfd: RawFd,
+    // Data Channel used by Cloud-Hypervisor
+    data_fd: RawFd,
+    // Control Channel used by Cloud-Hypervisor
+    control_fd: RawFd,
+}
+
+impl Default for SocketDev {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SocketDev {
+    pub fn new() -> Self {
+        Self {
+            state: SocketDevState::Disconnected,
+            stream: None,
+            write_msgfd: -1,
+            control_fd: -1,
+            data_fd: -1,
+        }
+    }
+
+    pub fn init(&mut self, path: String) -> Result<()> {
+        self.connect(&path)?;
+        Ok(())
+    }
+
+    pub fn connect(&mut self, socket_path: &str) -> Result<()> {
+        self.state = SocketDevState::Connecting;
+
+        let s = UnixStream::connect(socket_path).map_err(|e| {
+            Error::ConnectToSocket(anyhow!("Failed to connect to tpm Socket. Error: {:?}", e))
+        })?;
+        self.control_fd = s.as_raw_fd();
+        self.stream = Some(s);
+        self.state = SocketDevState::Connected;
+        debug!("Connected to tpm socket path : {:?}", socket_path);
+        Ok(())
+    }
+
+    pub fn set_datafd(&mut self, fd: RawFd) {
+        self.data_fd = fd;
+    }
+
+    pub fn set_msgfd(&mut self, fd: RawFd) {
+        self.write_msgfd = fd;
+    }
+
+    pub fn send_full(&self, buf: &[u8]) -> Result<usize> {
+        let write_fd = self.write_msgfd;
+
+        let size = self
+            .stream
+            .as_ref()
+            .unwrap()
+            .send_with_fd(buf, write_fd)
+            .map_err(|e| {
+                Error::WriteToSocket(anyhow!("Failed to write to Socket. Error: {:?}", e))
+            })?;
+
+        Ok(size)
+    }
+
+    pub fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        if self.stream.is_none() {
+            return Err(Error::WriteToSocket(anyhow!(
+                "Stream for tpm socket was not initialized"
+            )));
+        }
+
+        if matches!(self.state, SocketDevState::Connected) {
+            let ret = self.send_full(buf)?;
+            // swtpm will receive data Fd after a successful send
+            // Reset cached write_msgfd after a successful send
+            // Ideally, write_msgfd is reset after first Ctrl Command
+            if ret > 0 && self.write_msgfd != 0 {
+                self.write_msgfd = 0;
+            }
+            Ok(ret)
+        } else {
+            Err(Error::WriteToSocket(anyhow!(
+                "TPM Socket was not in Connected State"
+            )))
+        }
+    }
+
+    pub fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let newbuf: &mut [u8] = &mut [0; TPM_CRB_BUFFER_MAX];
+
+        if self.stream.is_none() {
+            return Err(Error::ReadFromSocket(anyhow!(
+                "Stream for tpm socket was not initialized"
+            )));
+        }
+        let mut socket = self.stream.as_ref().unwrap();
+        let size: usize = socket.read(newbuf).map_err(|e| {
+            Error::ReadFromSocket(anyhow!("Failed to read from socket. Error Code {:?}", e))
+        })?;
+        if buf.len() < size {
+            return Err(Error::ReadFromSocket(anyhow!(
+                "Input buffer is of insufficient size"
+            )));
+        }
+        buf[0..size].clone_from_slice(&newbuf[0..size]);
+        Ok(size)
+    }
+}

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -573,6 +573,8 @@ components:
           default: false
         platform:
           $ref: "#/components/schemas/PlatformConfig"
+        tpm:
+          $ref: "#/components/schemas/TpmConfig"
       description: Virtual machine configuration
 
     CpuAffinity:
@@ -956,6 +958,14 @@ components:
           type: integer
           format: int16
         id:
+          type: string
+
+    TpmConfig:
+      required:
+        - socket
+      type: object
+      properties:
+        socket:
           type: string
 
     VdpaConfig:

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2099,6 +2099,7 @@ mod unit_tests {
             #[cfg(feature = "guest_debug")]
             gdb: false,
             platform: None,
+            tpm: None,
         }))
     }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2048,15 +2048,15 @@ impl Vm {
         if self.config.lock().unwrap().is_tdx_enabled() {
             return None;
         }
-
         let mem = self.memory_manager.lock().unwrap().guest_memory().memory();
-
+        let tpm_enabled = self.config.lock().unwrap().tpm.is_some();
         let rsdp_addr = crate::acpi::create_acpi_tables(
             &mem,
             &self.device_manager,
             &self.cpu_manager,
             &self.memory_manager,
             &self.numa_nodes,
+            tpm_enabled,
         );
         info!("Created ACPI tables: rsdp_addr = 0x{:x}", rsdp_addr.0);
 

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -556,6 +556,11 @@ pub fn default_console() -> ConsoleConfig {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct TpmConfig {
+    pub socket: PathBuf,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct VmConfig {
     #[serde(default)]
     pub cpus: CpusConfig,
@@ -587,4 +592,5 @@ pub struct VmConfig {
     #[cfg(feature = "guest_debug")]
     pub gdb: bool,
     pub platform: Option<PlatformConfig>,
+    pub tpm: Option<TpmConfig>,
 }


### PR DESCRIPTION
This patchset enables vTPM device that supports CRB Interface with version TPM 2.0.

Sending this version out for review. There are some TODOs in tpm.rs that still need to be addressed. I will address the TODOs while waiting for feedback.

V5:
* drop  dependency on `nix` crate

V4:  
* Add TPM ACPI tables only if tpm parameter is passed at cmdline
 
V3:
* modified the input argument to --tpm following the suggestions below
* Addressed github and CI failures

V2:
* Ran basic checks: cargo fmt, cargo clippy
* Add missing copyright header
