### PR TITLE
build: Remove the exposed "cmos" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ wait-timeout = "0.2.0"
 default = ["common", "kvm"]
 # Common features for all hypervisors
 common = ["fwdebug"]
-cmos = ["vmm/cmos"]
 fwdebug = ["vmm/fwdebug"]
 gdb = ["vmm/gdb"]
 guest_debug = ["vmm/guest_debug"]

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -25,5 +25,4 @@ arch = { path = "../arch" }
 
 [features]
 default = []
-cmos = []
 fwdebug = []

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [features]
 default = []
-cmos = ["devices/cmos"]
 fwdebug = ["devices/fwdebug"]
 gdb = ["kvm", "gdbstub", "gdbstub_arch"]
 guest_debug = ["kvm"]


### PR DESCRIPTION
This only affects the build system; the feature was already always
compiled in with ca68b9e7a90c9e25e8d9399dea059c9b63cd0419

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
