### PR TITLE
build: Disable SGX build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -205,47 +205,6 @@ pipeline{
 						}
 					}
 				}
-				stage ('Worker build SGX') {
-					agent { node { label 'bionic-sgx' } }
-					when {
-						beforeAgent true
-						allOf {
-							branch 'main'
-							expression {
-								return runWorkers
-							}
-						}
-					}
-					stages {
-						stage ('Checkout') {
-							steps {
-								checkout scm
-							}
-						}
-						stage ('Run SGX integration tests') {
-							options {
-								timeout(time: 1, unit: 'HOURS')
-							}
-							steps {
-								sh "scripts/dev_cli.sh tests --integration-sgx"
-							}
-						}
-						stage ('Run SGX integration tests for musl') {
-							options {
-								timeout(time: 1, unit: 'HOURS')
-							}
-							steps {
-								sh "scripts/dev_cli.sh tests --integration-sgx --libc musl"
-							}
-						}
-					}
-					post {
-						always {
-							sh "sudo chown -R jenkins.jenkins ${WORKSPACE}"
-							deleteDir()
-						}
-					}
-				}
 				stage ('Worker build - Windows guest') {
 					agent { node { label 'jammy' } }
 					when {


### PR DESCRIPTION
This was unfortunately missing from
430bfd38bed635cd26ffeddd501345b0661a511f which disabled the other builds
that rely on the bare metal systems.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
