### PR TITLE
Add initial tracing support

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -55,6 +55,9 @@ jobs:
       - name: Clippy (default features + guest_debug)
         run: cargo clippy --locked --all --all-targets --tests --features "guest_debug" -- -D warnings
 
+      - name: Clippy (default features + tracing)
+        run: cargo clippy --locked --all --all-targets --tests --features "tracing" -- -D warnings
+
       - name: Clippy (common + mshv)
         run: cargo clippy --locked --all --all-targets --no-default-features --tests --features "common,mshv" -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "signal-hook",
  "test_infra",
  "thiserror",
+ "tracer",
  "vm-memory",
  "vmm",
  "vmm-sys-util",
@@ -1198,6 +1199,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracer"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "log",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1528,7 @@ dependencies = [
  "serial_buffer",
  "signal-hook",
  "thiserror",
+ "tracer",
  "uuid",
  "versionize",
  "versionize_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ seccompiler = "0.3.0"
 serde_json = "1.0.85"
 signal-hook = "0.3.14"
 thiserror = "1.0.35"
+tracer = { path = "tracer" }
 vmm = { path = "vmm" }
 vmm-sys-util = "0.10.0"
 vm-memory = "0.9.0"
@@ -62,6 +63,7 @@ guest_debug = ["vmm/guest_debug"]
 kvm = ["vmm/kvm"]
 mshv = ["vmm/mshv"]
 tdx = ["vmm/tdx"]
+tracing = ["vmm/tracing", "tracer/tracing"]
 
 [workspace]
 members = [
@@ -81,6 +83,7 @@ members = [
     "rate_limiter",
     "serial_buffer",
     "test_infra",
+    "tracer",
     "vfio_user",
     "vhdx",
     "vhost_user_block",

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,42 @@
+# Tracing
+
+Cloud Hypervisor has a basic tracing infrastucture, particularly focussed on
+the tracing of the initial VM setup.
+
+## Usage
+
+To enabling tracing, build with "tracing" feature. When compiled without the
+feature the tracing is compiled out.
+
+```bash
+cargo build --features "tracing"
+```
+
+And then run Cloud Hypervisor as you wish, the trace will be written to the current directory as `cloud-hypervisor-<pid>.trace`. This is JSON file which you can inspect yourself.
+
+Alternatively you can use the provided script in
+`scripts/ch-trace-visualiser.py` to generate an SVG:
+
+For example: 
+
+```bash
+scripts/ch-trace-visualiser.py cloud-hypervisor-39466.trace output.svg
+```
+
+## Tracing in the codebase
+
+There are existing tracepoints in the code base; extra ones can be added for
+more detailed tracing.
+
+The `tracer::trace_scoped!()` macro is used to add the current existing scope
+appears as a block in the trace. Other than providing a useful name for the
+event nothing else is required from the developer.
+
+The `tracer::start()` and `tracer::end()` functions are already in place for
+generating traces of the boot. These can be relocated for focus tracing on a
+narrow part of the code base.
+
+A `tracer::trace_point!()` macro is also provided for an instantaneous trace
+point however this is not in use in the code base currently nor is handled by
+the visualisation script due to the difficulty in representation in the SVG.
+

--- a/scripts/ch-trace-visualiser.py
+++ b/scripts/ch-trace-visualiser.py
@@ -1,0 +1,98 @@
+#!/bin/env python3
+#
+# Copyright © 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from colorsys import hsv_to_rgb
+from random import random
+import xml
+import json
+from sys import argv, stderr
+import xml.etree.ElementTree as ET
+
+width = 1000
+height = 200
+padding = 10
+
+if len(argv) < 3:
+    stderr.write("./ch-trace-visualiser <trace file> <output file>\n")
+    exit(1)
+
+
+def nano_time(duration):
+    return (duration["secs"] * 10 ** 9) + duration["nanos"]
+
+
+def duration_to_px_x(start):
+    return (nano_time(start) * (width - 2 * padding)) / total_time
+
+
+def duration_to_px_width(start, end):
+    return ((nano_time(end) - nano_time(start)) * (width - 2 * padding)) / total_time
+
+
+def duration_ms(start, end):
+    return (nano_time(end) - nano_time(start)) // 1000000
+
+
+f = open(argv[1])
+report = json.load(f)
+total_time = nano_time(report["duration"])
+
+svg = ET.Element("svg", attrib={"width": str(width), "height": str(height),
+                                "xmlns": "http://www.w3.org/2000/svg",
+                                "xmlns:svg": "http://www.w3.org/2000/svg"
+                                })
+
+
+def add_traced_block(thread_group, depth, traced_block):
+    g = ET.SubElement(thread_group, "g",
+                      attrib={"transform": "translate(%d,%d)" % (
+                          duration_to_px_x(traced_block["timestamp"]),
+                          (depth * 18))})
+    width = str(duration_to_px_width(
+        traced_block["timestamp"], traced_block["end_timestamp"]))
+
+    clip = ET.SubElement(g, "clipPath", attrib={
+        "id": "clip_%s" % (traced_block["event"]),
+    })
+    ET.SubElement(clip, "rect", attrib={
+        "width": width,
+        "height": "1.5em",
+        "x": "0",
+        "y": "0"
+    })
+
+    (red, green, blue) = hsv_to_rgb(random(), 0.3, 0.75)
+    ET.SubElement(g, "rect", attrib={
+        "width": width,
+        "height": "1.5em",
+        "fill": "#%x%x%x" % (int(red * 255), int(green * 255), int(blue * 255))
+    })
+    text = ET.SubElement(g, "text", attrib={
+        "x": "0.2em", "y": "1em", "clip-path": "url(#clip_%s)" % (traced_block["event"])})
+    text.text = "%s (%dms)" % (traced_block["event"], duration_ms(
+        traced_block["timestamp"], traced_block["end_timestamp"]))
+
+
+thread_size = (height - (2 * padding)) / len(report["events"])
+thread_offset = padding
+
+for thread in report["events"]:
+    thread_events = report["events"][thread]
+    thread_events = sorted(
+        thread_events, key=lambda traced_block: nano_time(traced_block["timestamp"]))
+    thread_group = ET.SubElement(
+        svg, "g", attrib={"transform": "translate(%d,%d)" % (padding, thread_offset)})
+    thread_text = ET.SubElement(thread_group, "text", attrib={
+                                "y": "1em"}).text = "Thread: %s" % (thread)
+    thread_children = ET.SubElement(thread_group, "g", attrib={
+        "transform": "translate(0, 18)"})
+    for traced_block in thread_events:
+        add_traced_block(thread_children, traced_block["depth"], traced_block)
+    thread_offset += thread_size + padding
+
+xml = ET.ElementTree(element=svg)
+xml.write(argv[2], xml_declaration=True)

--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tracer"
+version = "0.1.0"
+authors = ["The Cloud Hypervisor Authors"]
+edition = "2021"
+
+[dependencies]
+libc = "0.2.126"
+log = "0.4.17"
+once_cell = "1.12.0"
+serde = { version = "1.0.137", features = ["rc", "derive"] }
+serde_json = "1.0.81"
+
+[features]
+tracing = []

--- a/tracer/src/lib.rs
+++ b/tracer/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright © 2022 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#[cfg(feature = "tracing")]
+#[macro_use]
+extern crate log;
+
+#[cfg(not(feature = "tracing"))]
+mod tracer_noop;
+#[cfg(not(feature = "tracing"))]
+pub use tracer_noop::*;
+
+#[cfg(feature = "tracing")]
+mod tracer;
+#[cfg(feature = "tracing")]
+pub use tracer::*;

--- a/tracer/src/tracer.rs
+++ b/tracer/src/tracer.rs
@@ -1,0 +1,170 @@
+// Copyright © 2022 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use once_cell::unsync::OnceCell;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+#[derive(Debug)]
+struct Tracer {
+    events: Arc<Mutex<HashMap<String, Vec<TraceEvent>>>>,
+    thread_depths: HashMap<String, Arc<AtomicU64>>,
+    start: Instant,
+}
+
+impl Tracer {
+    fn new() -> Self {
+        Self {
+            events: Arc::new(Mutex::new(HashMap::default())),
+            start: Instant::now(),
+            thread_depths: HashMap::default(),
+        }
+    }
+
+    fn end(&self) {
+        let end = Instant::now();
+        let path = format!("cloud-hypervisor-{}.trace", unsafe { libc::getpid() });
+        let mut file = File::create(&path).unwrap();
+
+        #[derive(Serialize)]
+        struct TraceReport {
+            duration: Duration,
+            events: Arc<Mutex<HashMap<String, Vec<TraceEvent>>>>,
+        }
+
+        let trace_report = TraceReport {
+            duration: end.duration_since(self.start),
+            events: self.events.clone(),
+        };
+
+        serde_json::to_writer_pretty(&file, &trace_report).unwrap();
+
+        file.flush().unwrap();
+
+        warn!("Trace output: {}", path);
+    }
+
+    fn add_event(&mut self, event: TraceEvent) {
+        let thread_name = std::thread::current().name().unwrap_or("").to_string();
+        let mut events = self.events.lock().unwrap();
+        if let Some(thread_events) = events.get_mut(&thread_name) {
+            thread_events.push(event);
+        } else {
+            events.insert(thread_name.to_string(), vec![event]);
+        }
+    }
+
+    fn increase_thread_depth(&mut self) {
+        let thread_name = std::thread::current().name().unwrap_or("").to_string();
+        if let Some(depth) = self.thread_depths.get_mut(&thread_name) {
+            depth.fetch_add(1, Ordering::SeqCst);
+        } else {
+            self.thread_depths
+                .insert(thread_name, Arc::new(AtomicU64::new(0)));
+        }
+    }
+
+    fn decrease_thread_depth(&mut self) {
+        let thread_name = std::thread::current().name().unwrap_or("").to_string();
+        if let Some(depth) = self.thread_depths.get_mut(&thread_name) {
+            depth.fetch_sub(1, Ordering::SeqCst);
+        } else {
+            panic!("Unmatched decreas for thread: {}", thread_name);
+        }
+    }
+
+    fn thread_depth(&self) -> u64 {
+        let thread_name = std::thread::current().name().unwrap_or("").to_string();
+        self.thread_depths
+            .get(&thread_name)
+            .map(|v| v.load(Ordering::SeqCst))
+            .unwrap_or_default()
+    }
+}
+
+static mut TRACER: OnceCell<Tracer> = OnceCell::new();
+
+#[derive(Clone, Debug, Serialize)]
+struct TraceEvent {
+    timestamp: Duration,
+    event: &'static str,
+    end_timestamp: Option<Duration>,
+    depth: u64,
+}
+
+pub fn trace_point_log(event: &'static str) {
+    let trace_event = TraceEvent {
+        timestamp: Instant::now().duration_since(unsafe { TRACER.get().unwrap().start }),
+        event,
+        end_timestamp: None,
+        depth: unsafe { TRACER.get().unwrap().thread_depth() },
+    };
+    unsafe {
+        TRACER.get_mut().unwrap().add_event(trace_event);
+    }
+}
+
+pub struct TraceBlock {
+    start: Instant,
+    event: &'static str,
+}
+
+impl TraceBlock {
+    pub fn new(event: &'static str) -> Self {
+        unsafe {
+            TRACER.get_mut().unwrap().increase_thread_depth();
+        }
+        Self {
+            start: Instant::now(),
+            event,
+        }
+    }
+}
+
+impl Drop for TraceBlock {
+    fn drop(&mut self) {
+        let trace_event = TraceEvent {
+            timestamp: self
+                .start
+                .duration_since(unsafe { TRACER.get().unwrap().start }),
+            event: self.event,
+            end_timestamp: Some(
+                Instant::now().duration_since(unsafe { TRACER.get().unwrap().start }),
+            ),
+            depth: unsafe { TRACER.get().unwrap().thread_depth() },
+        };
+        unsafe {
+            TRACER.get_mut().unwrap().add_event(trace_event);
+            TRACER.get_mut().unwrap().decrease_thread_depth();
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! trace_point {
+    ($event:expr) => {
+        $crate::trace_point_log($event)
+    };
+}
+
+#[macro_export]
+macro_rules! trace_scoped {
+    ($event:expr) => {
+        let _trace_scoped = $crate::TraceBlock::new($event);
+    };
+}
+
+pub fn end() {
+    unsafe { TRACER.get().unwrap().end() }
+}
+
+pub fn start() {
+    unsafe { TRACER.set(Tracer::new()).unwrap() }
+}

--- a/tracer/src/tracer_noop.rs
+++ b/tracer/src/tracer_noop.rs
@@ -1,0 +1,17 @@
+// Copyright © 2022 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#[macro_export]
+macro_rules! trace_scoped {
+    ($event:expr) => {};
+}
+
+#[macro_export]
+macro_rules! trace_point {
+    ($event:expr) => {};
+}
+
+pub fn end() {}
+pub fn start() {}

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -12,6 +12,7 @@ guest_debug = ["kvm"]
 kvm = ["hypervisor/kvm", "vfio-ioctls/kvm", "vm-device/kvm", "pci/kvm"]
 mshv = ["hypervisor/mshv", "vfio-ioctls/mshv", "vm-device/mshv", "pci/mshv"]
 tdx = ["arch/tdx", "hypervisor/tdx"]
+tracing = ["tracer/tracing"]
 
 [dependencies]
 acpi_tables = { path = "../acpi_tables" }
@@ -42,6 +43,7 @@ serde_json = "1.0.85"
 serial_buffer = { path = "../serial_buffer" }
 signal-hook = "0.3.14"
 thiserror = "1.0.35"
+tracer = { path = "../tracer" }
 uuid = "1.1.2"
 versionize = "0.1.6"
 versionize_derive = "0.1.4"

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -19,6 +19,7 @@ use bitflags::bitflags;
 use pci::PciBdf;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use tracer::trace_scoped;
 use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryRegion};
 
 /* Values for Type in APIC sub-headers */
@@ -172,6 +173,7 @@ pub fn create_dsdt_table(
     cpu_manager: &Arc<Mutex<CpuManager>>,
     memory_manager: &Arc<Mutex<MemoryManager>>,
 ) -> Sdt {
+    trace_scoped!("create_dsdt_table");
     // DSDT
     let mut dsdt = Sdt::new(*b"DSDT", 36, 6, *b"CLOUDH", *b"CHDSDT  ", 1);
 
@@ -186,6 +188,8 @@ pub fn create_dsdt_table(
 }
 
 fn create_facp_table(dsdt_offset: GuestAddress, device_manager: &Arc<Mutex<DeviceManager>>) -> Sdt {
+    trace_scoped!("create_facp_table");
+
     // Revision 6 of the ACPI FADT table is 276 bytes long
     let mut facp = Sdt::new(*b"FACP", 276, 6, *b"CLOUDH", *b"CHFACP  ", 1);
 
@@ -606,6 +610,8 @@ pub fn create_acpi_tables(
     memory_manager: &Arc<Mutex<MemoryManager>>,
     numa_nodes: &NumaNodes,
 ) -> GuestAddress {
+    trace_scoped!("create_acpi_tables");
+
     let start_time = Instant::now();
     let rsdp_offset = arch::layout::RSDP_POINTER;
     let mut tables: Vec<u64> = Vec::new();

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -69,6 +69,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use std::{cmp, io, result, thread};
 use thiserror::Error;
+use tracer::trace_scoped;
 use vm_device::BusDevice;
 #[cfg(feature = "guest_debug")]
 use vm_memory::ByteValued;
@@ -1127,6 +1128,8 @@ impl CpuManager {
     }
 
     pub fn create_boot_vcpus(&mut self, entry_point: Option<EntryPoint>) -> Result<()> {
+        trace_scoped!("create_boot_vcpus");
+
         self.create_vcpus(self.boot_vcpus(), entry_point)
     }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -74,6 +74,7 @@ use std::path::PathBuf;
 use std::result;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use tracer::trace_scoped;
 use vfio_ioctls::{VfioContainer, VfioDevice, VfioDeviceFd};
 use virtio_devices::transport::VirtioTransport;
 use virtio_devices::transport::{VirtioPciDevice, VirtioPciDeviceActivator};
@@ -958,6 +959,8 @@ impl DeviceManager {
         boot_id_list: BTreeSet<String>,
         timestamp: Instant,
     ) -> DeviceManagerResult<Arc<Mutex<Self>>> {
+        trace_scoped!("DeviceManager::new");
+
         let device_tree = Arc::new(Mutex::new(DeviceTree::new()));
 
         let num_pci_segments =
@@ -1120,6 +1123,8 @@ impl DeviceManager {
         console_pty: Option<PtyPair>,
         console_resize_pipe: Option<File>,
     ) -> DeviceManagerResult<()> {
+        trace_scoped!("create_devices");
+
         let mut virtio_devices: Vec<MetaVirtioDevice> = Vec::new();
 
         let interrupt_controller = self.add_interrupt_controller()?;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -36,6 +36,7 @@ use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::PathBuf;
 use std::result;
 use std::sync::{Arc, Barrier, Mutex};
+use tracer::trace_scoped;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_devices::BlocksState;
@@ -876,6 +877,8 @@ impl MemoryManager {
         existing_memory_files: Option<HashMap<u32, File>>,
         #[cfg(target_arch = "x86_64")] sgx_epc_config: Option<Vec<SgxEpcConfig>>,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
+        trace_scoped!("MemoryManager::new");
+
         let user_provided_zones = config.size == 0;
 
         let mmio_address_space_size = mmio_address_space_size(phys_bits);

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -86,6 +86,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 use std::{result, str, thread};
 use thiserror::Error;
+use tracer::trace_scoped;
 use vm_device::Bus;
 #[cfg(target_arch = "x86_64")]
 use vm_device::BusDevice;
@@ -500,6 +501,8 @@ impl Vm {
         restoring: bool,
         timestamp: Instant,
     ) -> Result<Self> {
+        trace_scoped!("Vm::new_from_memory_manager");
+
         let boot_id_list = config
             .lock()
             .unwrap()
@@ -724,6 +727,8 @@ impl Vm {
         console_pty: Option<PtyPair>,
         console_resize_pipe: Option<File>,
     ) -> Result<Self> {
+        trace_scoped!("Vm::new");
+
         let timestamp = Instant::now();
 
         #[cfg(feature = "tdx")]
@@ -1097,6 +1102,7 @@ impl Vm {
         payload: &PayloadConfig,
         memory_manager: Arc<Mutex<MemoryManager>>,
     ) -> Result<EntryPoint> {
+        trace_scoped!("load_payload");
         match (
             &payload.firmware,
             &payload.kernel,
@@ -1163,6 +1169,7 @@ impl Vm {
 
     #[cfg(target_arch = "x86_64")]
     fn configure_system(&mut self, rsdp_addr: GuestAddress) -> Result<()> {
+        trace_scoped!("configure_system");
         info!("Configuring system");
         let mem = self.memory_manager.lock().unwrap().boot_guest_memory();
 
@@ -2155,6 +2162,8 @@ impl Vm {
     }
 
     fn entry_point(&mut self) -> Result<Option<EntryPoint>> {
+        trace_scoped!("entry_point");
+
         self.load_payload_handle
             .take()
             .map(|handle| handle.join().map_err(Error::KernelLoadThreadJoin)?)
@@ -2162,6 +2171,7 @@ impl Vm {
     }
 
     pub fn boot(&mut self) -> Result<()> {
+        trace_scoped!("Vm::boot");
         info!("Booting VM");
         event!("vm", "booting");
         let current_state = self.get_state()?;


### PR DESCRIPTION
Add basic support for tracing the boot. The tracing only has overhead if
compiled in with the "tracing" feature.

- tracing: Add initial basic tracing support
- vmm: Add some tracing
- scripts: Add tracing visualisation script
- docs: Add documentation of tracing infrastructure
- .github: Add clippy check of tracing feature
