### PR TITLE
Avoid fuzzing timeout

### DIFF
--- a/fuzz/fuzz_targets/balloon.rs
+++ b/fuzz/fuzz_targets/balloon.rs
@@ -104,7 +104,7 @@ fuzz_target!(|bytes| {
         .ok();
 
     // Wait for the events to finish and balloon device worker thread to return
-    balloon.reset();
+    balloon.wait_for_epoll_threads();
 });
 
 pub struct NoopVirtioInterrupt {}

--- a/fuzz/fuzz_targets/block.rs
+++ b/fuzz/fuzz_targets/block.rs
@@ -88,7 +88,7 @@ fuzz_target!(|bytes| {
         .ok();
 
     // Wait for the events to finish and block device worker thread to return
-    block.reset();
+    block.wait_for_epoll_threads();
 });
 
 fn memfd_create(name: &ffi::CStr, flags: u32) -> Result<RawFd, io::Error> {

--- a/fuzz/fuzz_targets/pmem.rs
+++ b/fuzz/fuzz_targets/pmem.rs
@@ -67,7 +67,7 @@ fuzz_target!(|bytes| {
     .ok();
 
     // Wait for the events to finish and pmem device worker thread to return
-    pmem.reset();
+    pmem.wait_for_epoll_threads();
 });
 
 fn memfd_create_with_size(name: &ffi::CStr, flags: u32, size: usize) -> Result<RawFd, io::Error> {

--- a/fuzz/fuzz_targets/rng.rs
+++ b/fuzz/fuzz_targets/rng.rs
@@ -104,7 +104,7 @@ fuzz_target!(|bytes| {
     .ok();
 
     // Wait for the events to finish and rng device worker thread to return
-    rng.reset();
+    rng.wait_for_epoll_threads();
 });
 
 pub struct NoopVirtioInterrupt {}

--- a/fuzz/fuzz_targets/watchdog.rs
+++ b/fuzz/fuzz_targets/watchdog.rs
@@ -69,7 +69,7 @@ fuzz_target!(|bytes| {
         .ok();
 
     // Wait for the events to finish and watchdog device worker thread to return
-    watchdog.reset();
+    watchdog.wait_for_epoll_threads();
 });
 
 pub struct NoopVirtioInterrupt {}

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -423,6 +423,11 @@ impl Balloon {
         self.common.acked_features = state.acked_features;
         self.config = state.config;
     }
+
+    #[cfg(fuzzing)]
+    pub fn wait_for_epoll_threads(&mut self) {
+        self.common.wait_for_epoll_threads();
+    }
 }
 
 impl Drop for Balloon {

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -537,6 +537,11 @@ impl Block {
         );
         self.writeback.store(writeback, Ordering::Release);
     }
+
+    #[cfg(fuzzing)]
+    pub fn wait_for_epoll_threads(&mut self) {
+        self.common.wait_for_epoll_threads();
+    }
 }
 
 impl Drop for Block {

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -258,7 +258,6 @@ impl VirtioCommon {
         Ok(())
     }
 
-    #[cfg(not(fuzzing))]
     pub fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         // We first must resume the virtio thread if it was paused.
         if self.pause_evt.take().is_some() {
@@ -282,9 +281,9 @@ impl VirtioCommon {
         Some(self.interrupt_cb.take().unwrap())
     }
 
-    #[cfg(fuzzing)]
     // Wait for the worker thread to finish and return
-    pub fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
+    #[cfg(fuzzing)]
+    pub fn wait_for_epoll_threads(&mut self) {
         if let Some(mut threads) = self.epoll_threads.take() {
             for t in threads.drain(..) {
                 if let Err(e) = t.join() {
@@ -292,8 +291,6 @@ impl VirtioCommon {
                 }
             }
         }
-
-        None
     }
 
     pub fn dup_eventfds(&self) -> (EventFd, EventFd) {

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -286,8 +286,17 @@ impl VirtioCommon {
     pub fn wait_for_epoll_threads(&mut self) {
         if let Some(mut threads) = self.epoll_threads.take() {
             for t in threads.drain(..) {
-                if let Err(e) = t.join() {
-                    error!("Error joining thread: {:?}", e);
+                let mut counter = 0;
+                while counter < 5 {
+                    if t.is_finished() {
+                        if let Err(e) = t.join() {
+                            error!("Error joining thread: {:?}", e);
+                        }
+                        break;
+                    } else {
+                        std::thread::sleep(std::time::Duration::from_millis(500));
+                        counter += 1;
+                    }
                 }
             }
         }

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -883,6 +883,11 @@ impl Mem {
         *(self.config.lock().unwrap()) = state.config;
         *(self.blocks_state.lock().unwrap()) = state.blocks_state.clone();
     }
+
+    #[cfg(fuzzing)]
+    pub fn wait_for_epoll_threads(&mut self) {
+        self.common.wait_for_epoll_threads();
+    }
 }
 
 impl Drop for Mem {

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -343,6 +343,11 @@ impl Pmem {
         self.common.acked_features = state.acked_features;
         self.config = state.config;
     }
+
+    #[cfg(fuzzing)]
+    pub fn wait_for_epoll_threads(&mut self) {
+        self.common.wait_for_epoll_threads();
+    }
 }
 
 impl Drop for Pmem {

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -203,6 +203,11 @@ impl Rng {
         self.common.avail_features = state.avail_features;
         self.common.acked_features = state.acked_features;
     }
+
+    #[cfg(fuzzing)]
+    pub fn wait_for_epoll_threads(&mut self) {
+        self.common.wait_for_epoll_threads();
+    }
 }
 
 impl Drop for Rng {

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -248,6 +248,11 @@ impl Watchdog {
             self.last_ping_time.lock().unwrap().replace(Instant::now());
         }
     }
+
+    #[cfg(fuzzing)]
+    pub fn wait_for_epoll_threads(&mut self) {
+        self.common.wait_for_epoll_threads();
+    }
 }
 
 impl Drop for Watchdog {


### PR DESCRIPTION
- fuzz: Don't overload meaning of reset()
- virtio-devices: fuzzing: Don't block forever if the threads do not exit
