### PR TITLE
fuzz: Reduce the guest memory size for balloon fuzzer

### DIFF
--- a/fuzz/fuzz_targets/balloon.rs
+++ b/fuzz/fuzz_targets/balloon.rs
@@ -16,8 +16,8 @@ use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 
 const QUEUE_DATA_SIZE: usize = 4;
-const MEM_SIZE: usize = 256 * 1024 * 1024;
-const BALLOON_SIZE: u64 = 128 * 1024 * 1024;
+const MEM_SIZE: usize = 1 * 1024 * 1024;
+const BALLOON_SIZE: u64 = 512 * 1024;
 // Number of queues
 const QUEUE_NUM: usize = 3;
 // Max entries in the queue.


### PR DESCRIPTION
As the virt queues are initialized with random bytes from the fuzzing engine, a descriptor buffer for the available ring can have a very large length (e.g. up to 4GB). This means there can be up to 1 billion entries (e.g. page frame number) for virtio-balloon to process a signal available descriptor (given each entry is 4 bytes). This is the reason why oss-fuzz reported a hanging issue for this fuzzer, where the generated descriptor buffer length is 4,278,321,152.

We can avoid this kind of long execution by reducing the size of guest memory. For example, with 1MB of guest memory, the number of descriptor entries for processing is limited ~256K.

Signed-off-by: Bo Chen <chen.bo@intel.com>