### PR TITLE
vhost_user_net: Always set MTU to 1280

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -843,6 +843,22 @@ fn test_vhost_user_net(
             assert_eq!(String::from_utf8_lossy(&mac_count.stdout).trim(), "1");
         }
 
+        #[cfg(target_arch = "aarch64")]
+        let iface = "enp0s4";
+        #[cfg(target_arch = "x86_64")]
+        let iface = "ens4";
+
+        // Validates the vhost-user-net backend allows MTU configuration by
+        // checking the value is 1280 instead of 1500 that would have been set
+        // by default.
+        assert_eq!(
+            guest
+                .ssh_command(format!("cat /sys/class/net/{}/mtu", iface).as_str())
+                .unwrap()
+                .trim(),
+            "1280"
+        );
+
         // 1 network interface + default localhost ==> 2 interfaces
         // It's important to note that this test is fully exercising the
         // vhost-user-net implementation and the associated backend since

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -133,7 +133,7 @@ impl VhostUserNetBackend {
             Some(ip_addr),
             Some(netmask),
             &mut Some(host_mac),
-            None,
+            Some(1280),
             num_queues / 2,
             None,
         )
@@ -182,6 +182,7 @@ impl VhostUserBackendMut<VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>, Atomic
             | 1 << VIRTIO_NET_F_CTRL_VQ
             | 1 << VIRTIO_NET_F_MQ
             | 1 << VIRTIO_NET_F_MAC
+            | 1 << VIRTIO_NET_F_MTU
             | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
             | 1 << VIRTIO_F_VERSION_1
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()


### PR DESCRIPTION
Following the recent addition for supporting MTU being provided to the guest through the VIRTIO configuration, the vhost-user-net backend is extended with the missing VIRTIO feature for MTU to be read from the VIRTIO configuration. Additionally, the tap interface is always set to 1280 as the chosen value.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>