### PR TITLE
build: Remove "fwdebug" and "common" feature flags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,8 +36,8 @@ jobs:
       - name: Build (default features)
         run: cargo rustc --locked --bin cloud-hypervisor -- -D warnings
 
-      - name: Build (common + kvm)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "common,kvm"  -- -D warnings
+      - name: Build (kvm)
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "kvm"  -- -D warnings
 
       - name: Build (default features + tdx)
         run: cargo rustc --locked --bin cloud-hypervisor --features "tdx" -- -D warnings
@@ -48,11 +48,11 @@ jobs:
       - name: Build (default features + guest_debug)
         run: cargo rustc --locked --bin cloud-hypervisor --features "guest_debug" -- -D warnings
 
-      - name: Build (common + mshv)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "common,mshv"  -- -D warnings
+      - name: Build (mshv)
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv"  -- -D warnings
 
-      - name: Build (common + mshv + kvm)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "common,mshv,kvm"  -- -D warnings
+      - name: Build (mshv + kvm)
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv,kvm"  -- -D warnings
 
       - name: Release Build (default features)
         run: cargo build --locked --all --release --target=${{ matrix.target }}

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -48,12 +48,12 @@ jobs:
       - name: Formatting (rustfmt)
         run: cargo fmt -- --check
 
-      - name: Clippy (common + kvm)
+      - name: Clippy (kvm)
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --locked --all --all-targets --no-default-features --tests --features "common,kvm" -- -D warnings
+          args: --locked --all --all-targets --no-default-features --tests --features "kvm" -- -D warnings
 
       - name: Clippy (default features)
         uses: actions-rs/cargo@v1
@@ -83,29 +83,29 @@ jobs:
           command: clippy
           args: --locked --all --all-targets --tests --features "tracing" -- -D warnings
 
-      - name: Clippy (common + mshv)
+      - name: Clippy (mshv)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --locked --all --all-targets --no-default-features --tests --features "common,mshv" -- -D warnings
+          args: --locked --all --all-targets --no-default-features --tests --features "mshv" -- -D warnings
 
-      - name: Clippy (common + mshv + kvm)
+      - name: Clippy (mshv + kvm)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --locked --all --all-targets --no-default-features --tests --features "common,mshv,kvm" -- -D warnings
+          args: --locked --all --all-targets --no-default-features --tests --features "mshv,kvm" -- -D warnings
 
-      - name: Clippy (common + kvm + tdx)
+      - name: Clippy (kvm + tdx)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --locked --all --all-targets --no-default-features --tests --features "common,tdx,kvm" -- -D warnings
+          args: --locked --all --all-targets --no-default-features --tests --features "tdx,kvm" -- -D warnings
 
       - name: Check build did not modify any files
         run: test -z "$(git status --porcelain)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,10 +54,7 @@ test_infra = { path = "test_infra" }
 wait-timeout = "0.2.0"
 
 [features]
-default = ["common", "kvm"]
-# Common features for all hypervisors
-common = ["fwdebug"]
-fwdebug = ["vmm/fwdebug"]
+default = ["kvm"]
 gdb = ["vmm/gdb"]
 guest_debug = ["vmm/guest_debug"]
 kvm = ["vmm/kvm"]

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -25,4 +25,3 @@ arch = { path = "../arch" }
 
 [features]
 default = []
-fwdebug = []

--- a/devices/src/legacy/mod.rs
+++ b/devices/src/legacy/mod.rs
@@ -8,7 +8,7 @@
 mod cmos;
 #[cfg(target_arch = "x86_64")]
 mod debug_port;
-#[cfg(feature = "fwdebug")]
+#[cfg(target_arch = "x86_64")]
 mod fwdebug;
 #[cfg(target_arch = "aarch64")]
 mod gpio_pl061;
@@ -22,7 +22,7 @@ mod uart_pl011;
 pub use self::cmos::Cmos;
 #[cfg(target_arch = "x86_64")]
 pub use self::debug_port::DebugPort;
-#[cfg(feature = "fwdebug")]
+#[cfg(target_arch = "x86_64")]
 pub use self::fwdebug::FwDebugDevice;
 pub use self::i8042::I8042Device;
 pub use self::serial::Serial;

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [features]
 default = []
-fwdebug = ["devices/fwdebug"]
 gdb = ["kvm", "gdbstub", "gdbstub_arch"]
 guest_debug = ["kvm"]
 kvm = ["hypervisor/kvm", "vfio-ioctls/kvm", "vm-device/kvm", "pci/kvm"]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1560,9 +1560,7 @@ impl DeviceManager {
                 .io_bus
                 .insert(cmos, 0x70, 0x2)
                 .map_err(DeviceManagerError::BusError)?;
-        }
-        #[cfg(feature = "fwdebug")]
-        {
+
             let fwdebug = Arc::new(Mutex::new(devices::legacy::FwDebugDevice::new()));
 
             self.bus_devices


### PR DESCRIPTION
This simplifes the buld and checks with very little overhead and the
fwdebug device is I/O port device on 0x402 that can be used by edk2 as a
very simple character device.

See: #4679

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
