### PR TITLE
build: Consolidate "gdb" build feature into "guest_debug"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,9 +42,6 @@ jobs:
       - name: Build (default features + tdx)
         run: cargo rustc --locked --bin cloud-hypervisor --features "tdx" -- -D warnings
 
-      - name: Build (default features + gdb)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "gdb" -- -D warnings
-
       - name: Build (default features + guest_debug)
         run: cargo rustc --locked --bin cloud-hypervisor --features "guest_debug" -- -D warnings
 

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -62,13 +62,6 @@ jobs:
           command: clippy
           args: --locked --all --all-targets --tests -- -D warnings
 
-      - name: Clippy (default features + gdb)
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
-          command: clippy
-          args: --locked --all --all-targets --tests --features "gdb" -- -D warnings
-
       - name: Clippy (default features + guest_debug)
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ wait-timeout = "0.2.0"
 
 [features]
 default = ["kvm"]
-gdb = ["vmm/gdb"]
 guest_debug = ["vmm/guest_debug"]
 kvm = ["vmm/kvm"]
 mshv = ["vmm/mshv"]

--- a/docs/gdb.md
+++ b/docs/gdb.md
@@ -2,10 +2,10 @@
 
 This feature allows remote guest debugging using GDB. Note that this feature is only supported on x86_64/KVM.
 
-To enable debugging with GDB, build with the `gdb` feature enabled:
+To enable debugging with GDB, build with the `guest_debug` feature enabled:
 
 ```bash
-cargo build --features gdb
+cargo build --features guest_debug
 ```
 
 To use the `--gdb` option, specify the Unix Domain Socket with `--path` that Cloud Hypervisor will use to communicate with the host's GDB:

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 
 [features]
 default = []
-gdb = ["kvm", "gdbstub", "gdbstub_arch"]
-guest_debug = ["kvm"]
+guest_debug = ["kvm", "gdbstub", "gdbstub_arch"]
 kvm = ["hypervisor/kvm", "vfio-ioctls/kvm", "vm-device/kvm", "pci/kvm"]
 mshv = ["hypervisor/mshv", "vfio-ioctls/mshv", "vm-device/mshv", "pci/mshv"]
 tdx = ["arch/tdx", "hypervisor/tdx"]

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -379,7 +379,7 @@ pub struct VmParams<'a> {
     pub sgx_epc: Option<Vec<&'a str>>,
     pub numa: Option<Vec<&'a str>>,
     pub watchdog: bool,
-    #[cfg(feature = "gdb")]
+    #[cfg(feature = "guest_debug")]
     pub gdb: bool,
     pub platform: Option<&'a str>,
 }
@@ -411,7 +411,7 @@ impl<'a> VmParams<'a> {
         let numa: Option<Vec<&str>> = args.values_of("numa").map(|x| x.collect());
         let watchdog = args.is_present("watchdog");
         let platform = args.value_of("platform");
-        #[cfg(feature = "gdb")]
+        #[cfg(feature = "guest_debug")]
         let gdb = args.is_present("gdb");
         VmParams {
             cpus,
@@ -437,7 +437,7 @@ impl<'a> VmParams<'a> {
             sgx_epc,
             numa,
             watchdog,
-            #[cfg(feature = "gdb")]
+            #[cfg(feature = "guest_debug")]
             gdb,
             platform,
         }
@@ -2315,7 +2315,7 @@ pub struct VmConfig {
     pub numa: Option<Vec<NumaConfig>>,
     #[serde(default)]
     pub watchdog: bool,
-    #[cfg(feature = "gdb")]
+    #[cfg(feature = "guest_debug")]
     pub gdb: bool,
     pub platform: Option<PlatformConfig>,
 }
@@ -2703,7 +2703,7 @@ impl VmConfig {
             None
         };
 
-        #[cfg(feature = "gdb")]
+        #[cfg(feature = "guest_debug")]
         let gdb = vm_params.gdb;
 
         let mut config = VmConfig {
@@ -2730,7 +2730,7 @@ impl VmConfig {
             sgx_epc,
             numa,
             watchdog: vm_params.watchdog,
-            #[cfg(feature = "gdb")]
+            #[cfg(feature = "guest_debug")]
             gdb,
             platform,
         };
@@ -3340,7 +3340,7 @@ mod tests {
             sgx_epc: None,
             numa: None,
             watchdog: false,
-            #[cfg(feature = "gdb")]
+            #[cfg(feature = "guest_debug")]
             gdb: false,
             platform: None,
         };


### PR DESCRIPTION
This simplifies the CI process but also logical with the existing
functionality under "guest_debug" (dumping guest memory).

Fixes: #4679

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
