### PR TITLE
hypervisor: Support compiling "tdx" and "mshv" feature together

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -406,7 +406,9 @@ pub trait Vcpu: Send + Sync {
     /// Initialize TDX support on the vCPU
     ///
     #[cfg(feature = "tdx")]
-    fn tdx_init(&self, hob_address: u64) -> Result<()>;
+    fn tdx_init(&self, _hob_address: u64) -> Result<()> {
+        unimplemented!()
+    }
     ///
     /// Set the "immediate_exit" state
     ///
@@ -415,12 +417,16 @@ pub trait Vcpu: Send + Sync {
     ///
     /// Returns the details about TDX exit reason
     ///
-    fn get_tdx_exit_details(&mut self) -> Result<TdxExitDetails>;
+    fn get_tdx_exit_details(&mut self) -> Result<TdxExitDetails> {
+        unimplemented!()
+    }
     #[cfg(feature = "tdx")]
     ///
     /// Set the status code for TDX exit
     ///
-    fn set_tdx_status(&mut self, status: TdxExitStatus);
+    fn set_tdx_status(&mut self, _status: TdxExitStatus) {
+        unimplemented!()
+    }
     #[cfg(target_arch = "x86_64")]
     ///
     /// Return the list of initial MSR entries for a VCPU

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -124,7 +124,9 @@ pub trait Hypervisor: Send + Sync {
     /// Retrieve TDX capabilities
     ///
     #[cfg(feature = "tdx")]
-    fn tdx_capabilities(&self) -> Result<TdxCapabilities>;
+    fn tdx_capabilities(&self) -> Result<TdxCapabilities> {
+        unimplemented!()
+    }
     ///
     /// Get the number of supported hardware breakpoints
     ///

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -326,19 +326,25 @@ pub trait Vm: Send + Sync + Any {
     fn get_dirty_log(&self, slot: u32, base_gpa: u64, memory_size: u64) -> Result<Vec<u64>>;
     #[cfg(feature = "tdx")]
     /// Initalize TDX on this VM
-    fn tdx_init(&self, cpuid: &[CpuIdEntry], max_vcpus: u32) -> Result<()>;
+    fn tdx_init(&self, _cpuid: &[CpuIdEntry], _max_vcpus: u32) -> Result<()> {
+        unimplemented!()
+    }
     #[cfg(feature = "tdx")]
     /// Finalize the configuration of TDX on this VM
-    fn tdx_finalize(&self) -> Result<()>;
+    fn tdx_finalize(&self) -> Result<()> {
+        unimplemented!()
+    }
     #[cfg(feature = "tdx")]
     /// Initalize a TDX memory region for this VM
     fn tdx_init_memory_region(
         &self,
-        host_address: u64,
-        guest_address: u64,
-        size: u64,
-        measure: bool,
-    ) -> Result<()>;
+        _host_address: u64,
+        _guest_address: u64,
+        _size: u64,
+        _measure: bool,
+    ) -> Result<()> {
+        unimplemented!()
+    }
     /// Downcast to the underlying hypervisor VM type
     fn as_any(&self) -> &dyn Any;
 }


### PR DESCRIPTION
TDX functionality is not currently available on MSHV but we should not
preclude building a binary that can run on both.

Fixes: #4677

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
