### PR TITLE
removal of common feature reference from script files

### DIFF
--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -15,7 +15,7 @@ process_common_args "$@"
 features=""
 
 if [ "$hypervisor" = "mshv" ] ;  then
-    features="--no-default-features --features mshv,common"
+    features="--no-default-features --features mshv"
 fi
 
 cp scripts/sha1sums-x86_64 $WORKLOADS_DIR

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -15,7 +15,7 @@ process_common_args "$@"
 features=""
 
 if [ "$hypervisor" = "mshv" ] ;  then
-    features="--no-default-features --features mshv,common"
+    features="--no-default-features --features mshv"
 fi
 
 cp scripts/sha1sums-x86_64 $WORKLOADS_DIR

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -9,7 +9,7 @@ process_common_args "$@"
 features=""
 
 if [ "$hypervisor" = "mshv" ] ;  then
-    features="--no-default-features --features mshv,common"
+    features="--no-default-features --features mshv"
 fi
 WIN_IMAGE_FILE="/root/workloads/windows-server-2019.raw"
 

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -15,7 +15,7 @@ process_common_args "$@"
 features=""
 
 if [ "$hypervisor" = "mshv" ] ;  then
-    features="--no-default-features --features mshv,common"
+    features="--no-default-features --features mshv"
 fi
 
 cp scripts/sha1sums-x86_64 $WORKLOADS_DIR

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -32,7 +32,7 @@ process_common_args "$@"
 features=""
 
 if [ "$hypervisor" = "mshv" ]; then
-    features="--no-default-features --features mshv,common"
+    features="--no-default-features --features mshv"
 fi
 
 cp scripts/sha1sums-${TEST_ARCH} $WORKLOADS_DIR

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -10,7 +10,7 @@ cargo_args=("")
 
 if [[ $hypervisor = "mshv" ]]; then
     cargo_args+=("--no-default-features")
-    cargo_args+=("--features common,$hypervisor")
+    cargo_args+=("--features $hypervisor")
 elif [[ $(uname -m) = "x86_64" ]]; then
     cargo_args+=("--features tdx")
 fi


### PR DESCRIPTION
These changes are to remove references of common features from script files. Some of the scripts are still using that parameter specifically test related to mshv hypervisor. Thus fix those scripts by removing common feature flag.

Common feature was already removed as part of below commit : 

https://github.com/cloud-hypervisor/cloud-hypervisor/commit/b2d1dd65f399d0e3a2c4025a245062ee4fbcece7#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542