### PR TITLE
openapi: Add 'firmware' to 'PayloadConfig'

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -502,6 +502,8 @@ components:
     PayloadConfig:
       type: object
       properties:
+        firmware:
+          type: string
         kernel:
           type: string
         cmdline:


### PR DESCRIPTION
This option is needed for the openapi consumer (e.g. Kata Containers) to load firmware (e.g. td-shim) for booting.

Signed-off-by: Bo Chen <chen.bo@intel.com>