### PR TITLE
fuzz: Balloon: Reduce the guest memory size and queue size

### DIFF
--- a/fuzz/fuzz_targets/balloon.rs
+++ b/fuzz/fuzz_targets/balloon.rs
@@ -16,12 +16,12 @@ use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 
 const QUEUE_DATA_SIZE: usize = 4;
-const MEM_SIZE: usize = 1 * 1024 * 1024;
+const MEM_SIZE: usize = 512 * 1024;
 const BALLOON_SIZE: u64 = 512 * 1024;
 // Number of queues
 const QUEUE_NUM: usize = 3;
 // Max entries in the queue.
-const QUEUE_SIZE: u16 = 256;
+const QUEUE_SIZE: u16 = 64;
 // Descriptor table alignment
 const DESC_TABLE_ALIGN_SIZE: u64 = 16;
 // Avalable ring alignment


### PR DESCRIPTION
With the guest memory size of 1MB, a valid descriptor size can be close to the guest memory size (e.g. 1MB) and can contain close to 256k valid pfn entries (each entry is 4 bytes). Multiplying the queue size (e.g. 256), there can be close to 64 millions pfn entries to process in a single request. This is why the oss-fuzz reported a timeout (with a limit of 60s).

By reducing the guest memory size and the queue size, the worst-case now is 8 million pfn entries for fuzzing, which can be finished in around 20 seconds according to my local experiment.

Signed-off-by: Bo Chen <chen.bo@intel.com>