### PR TITLE
Simplify config.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -631,8 +631,8 @@ mod unit_tests {
     use crate::{create_app, prepare_default_values};
     use std::path::PathBuf;
     use vmm::config::{
-        CmdlineConfig, ConsoleConfig, ConsoleOutputMode, CpuFeatures, CpusConfig, MemoryConfig,
-        PayloadConfig, RngConfig, VmConfig, VmParams,
+        ConsoleConfig, ConsoleOutputMode, CpuFeatures, CpusConfig, MemoryConfig, PayloadConfig,
+        RngConfig, VmConfig, VmParams,
     };
 
     fn get_vm_config_from_vec(args: &[&str]) -> VmConfig {
@@ -693,11 +693,6 @@ mod unit_tests {
                 prefault: false,
                 zones: None,
             },
-            kernel: None,
-            cmdline: CmdlineConfig {
-                args: String::default(),
-            },
-            initramfs: None,
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),
                 ..Default::default()

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -18,11 +18,6 @@ use std::str::FromStr;
 use thiserror::Error;
 use virtio_devices::{RateLimiterConfig, TokenBucketConfig};
 
-pub const DEFAULT_VCPUS: u8 = 1;
-pub const DEFAULT_MEMORY_MB: u64 = 512;
-
-pub const DEFAULT_RNG_SOURCE: &str = "/dev/urandom";
-
 const MAX_NUM_PCI_SEGMENTS: u16 = 16;
 
 /// Errors associated with VM configuration parameters.
@@ -433,12 +428,6 @@ impl<'a> VmParams<'a> {
     }
 }
 
-impl Default for HotplugMethod {
-    fn default() -> Self {
-        HotplugMethod::Acpi
-    }
-}
-
 #[derive(Debug)]
 pub enum ParseHotplugMethodError {
     InvalidValue(String),
@@ -565,20 +554,6 @@ impl CpusConfig {
     }
 }
 
-impl Default for CpusConfig {
-    fn default() -> Self {
-        CpusConfig {
-            boot_vcpus: DEFAULT_VCPUS,
-            max_vcpus: DEFAULT_VCPUS,
-            topology: None,
-            kvm_hyperv: false,
-            max_phys_bits: DEFAULT_MAX_PHYS_BITS,
-            affinity: None,
-            features: CpuFeatures::default(),
-        }
-    }
-}
-
 impl PlatformConfig {
     pub fn parse(platform: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -641,20 +616,6 @@ impl PlatformConfig {
         }
 
         Ok(())
-    }
-}
-
-impl Default for PlatformConfig {
-    fn default() -> Self {
-        PlatformConfig {
-            num_pci_segments: DEFAULT_NUM_PCI_SEGMENTS,
-            iommu_segments: None,
-            serial_number: None,
-            uuid: None,
-            oem_strings: None,
-            #[cfg(feature = "tdx")]
-            tdx: false,
-        }
     }
 }
 
@@ -823,23 +784,6 @@ impl MemoryConfig {
     }
 }
 
-impl Default for MemoryConfig {
-    fn default() -> Self {
-        MemoryConfig {
-            size: DEFAULT_MEMORY_MB << 20,
-            mergeable: false,
-            hotplug_method: HotplugMethod::Acpi,
-            hotplug_size: None,
-            hotplugged_size: None,
-            shared: false,
-            hugepages: false,
-            hugepage_size: None,
-            prefault: false,
-            zones: None,
-        }
-    }
-}
-
 impl CmdlineConfig {
     pub fn parse(cmdline: Option<&str>) -> Result<Self> {
         let args = cmdline
@@ -847,25 +791,6 @@ impl CmdlineConfig {
             .unwrap_or_else(String::new);
 
         Ok(CmdlineConfig { args })
-    }
-}
-
-impl Default for DiskConfig {
-    fn default() -> Self {
-        Self {
-            path: None,
-            readonly: false,
-            direct: false,
-            iommu: false,
-            num_queues: default_diskconfig_num_queues(),
-            queue_size: default_diskconfig_queue_size(),
-            vhost_user: false,
-            vhost_socket: None,
-            id: None,
-            disable_io_uring: false,
-            rate_limiter_config: None,
-            pci_segment: 0,
-        }
     }
 }
 
@@ -1032,12 +957,6 @@ impl DiskConfig {
     }
 }
 
-impl Default for VhostMode {
-    fn default() -> Self {
-        VhostMode::Client
-    }
-}
-
 #[derive(Debug)]
 pub enum ParseVhostModeError {
     InvalidValue(String),
@@ -1051,29 +970,6 @@ impl FromStr for VhostMode {
             "client" => Ok(VhostMode::Client),
             "server" => Ok(VhostMode::Server),
             _ => Err(ParseVhostModeError::InvalidValue(s.to_owned())),
-        }
-    }
-}
-
-impl Default for NetConfig {
-    fn default() -> Self {
-        Self {
-            tap: default_netconfig_tap(),
-            ip: default_netconfig_ip(),
-            mask: default_netconfig_mask(),
-            mac: default_netconfig_mac(),
-            host_mac: None,
-            mtu: None,
-            iommu: false,
-            num_queues: default_netconfig_num_queues(),
-            queue_size: default_netconfig_queue_size(),
-            vhost_user: false,
-            vhost_socket: None,
-            vhost_mode: VhostMode::Client,
-            id: None,
-            fds: None,
-            rate_limiter_config: None,
-            pci_segment: 0,
         }
     }
 }
@@ -1300,15 +1196,6 @@ impl RngConfig {
     }
 }
 
-impl Default for RngConfig {
-    fn default() -> Self {
-        RngConfig {
-            src: PathBuf::from(DEFAULT_RNG_SOURCE),
-            iommu: false,
-        }
-    }
-}
-
 impl BalloonConfig {
     pub const SYNTAX: &'static str =
         "Balloon parameters \"size=<balloon_size>,deflate_on_oom=on|off,\
@@ -1344,19 +1231,6 @@ impl BalloonConfig {
             deflate_on_oom,
             free_page_reporting,
         })
-    }
-}
-
-impl Default for FsConfig {
-    fn default() -> Self {
-        Self {
-            tag: "".to_owned(),
-            socket: PathBuf::new(),
-            num_queues: default_fsconfig_num_queues(),
-            queue_size: default_fsconfig_queue_size(),
-            id: None,
-            pci_segment: 0,
-        }
     }
 }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -784,16 +784,6 @@ impl MemoryConfig {
     }
 }
 
-impl CmdlineConfig {
-    pub fn parse(cmdline: Option<&str>) -> Result<Self> {
-        let args = cmdline
-            .map(std::string::ToString::to_string)
-            .unwrap_or_else(String::new);
-
-        Ok(CmdlineConfig { args })
-    }
-}
-
 impl DiskConfig {
     pub const SYNTAX: &'static str = "Disk parameters \
          \"path=<disk_image_path>,readonly=on|off,direct=on|off,iommu=on|off,\
@@ -1768,20 +1758,6 @@ impl VmConfig {
     pub fn validate(&mut self) -> ValidationResult<BTreeSet<String>> {
         let mut id_list = BTreeSet::new();
 
-        if self.kernel.is_some() {
-            warn!("The \"VmConfig\" members \"kernel\", \"cmdline\" and \"initramfs\" are deprecated. Use \"payload\" member instead.");
-            self.payload = Some(PayloadConfig {
-                kernel: self.kernel.take().map(|k| k.path),
-                cmdline: if self.cmdline.args.is_empty() {
-                    None
-                } else {
-                    Some(self.cmdline.args.drain(..).collect())
-                },
-                initramfs: self.initramfs.take().map(|i| i.path),
-                ..Default::default()
-            })
-        }
-
         self.payload
             .as_ref()
             .ok_or(ValidationError::KernelMissing)?;
@@ -2133,9 +2109,6 @@ impl VmConfig {
         let mut config = VmConfig {
             cpus: CpusConfig::parse(vm_params.cpus)?,
             memory: MemoryConfig::parse(vm_params.memory, vm_params.memory_zones)?,
-            kernel: None,
-            initramfs: None,
-            cmdline: CmdlineConfig::default(),
             payload,
             disks,
             net,
@@ -2728,11 +2701,6 @@ mod tests {
                 prefault: false,
                 zones: None,
             },
-            kernel: None,
-            cmdline: CmdlineConfig {
-                args: String::default(),
-            },
-            initramfs: None,
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),
                 ..Default::default()

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -74,6 +74,7 @@ pub mod seccomp_filters;
 mod serial_manager;
 mod sigwinch_listener;
 pub mod vm;
+pub mod vm_config;
 
 type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 type GuestRegionMmap = vm_memory::GuestRegionMmap<AtomicBitmap>;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1978,8 +1978,8 @@ const DEVICE_MANAGER_SNAPSHOT_ID: &str = "device-manager";
 mod unit_tests {
     use super::*;
     use config::{
-        CmdlineConfig, ConsoleConfig, ConsoleOutputMode, CpusConfig, HotplugMethod, MemoryConfig,
-        PayloadConfig, RngConfig, VmConfig,
+        ConsoleConfig, ConsoleOutputMode, CpusConfig, HotplugMethod, MemoryConfig, PayloadConfig,
+        RngConfig, VmConfig,
     };
 
     fn create_dummy_vmm() -> Vmm {
@@ -2020,11 +2020,6 @@ mod unit_tests {
                 prefault: false,
                 zones: None,
             },
-            kernel: None,
-            cmdline: CmdlineConfig {
-                args: String::default(),
-            },
-            initramfs: None,
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),
                 ..Default::default()

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -53,6 +53,22 @@ pub struct CpusConfig {
     pub features: CpuFeatures,
 }
 
+pub const DEFAULT_VCPUS: u8 = 1;
+
+impl Default for CpusConfig {
+    fn default() -> Self {
+        CpusConfig {
+            boot_vcpus: DEFAULT_VCPUS,
+            max_vcpus: DEFAULT_VCPUS,
+            topology: None,
+            kvm_hyperv: false,
+            max_phys_bits: DEFAULT_MAX_PHYS_BITS,
+            affinity: None,
+            features: CpuFeatures::default(),
+        }
+    }
+}
+
 pub const DEFAULT_NUM_PCI_SEGMENTS: u16 = 1;
 pub fn default_platformconfig_num_pci_segments() -> u16 {
     DEFAULT_NUM_PCI_SEGMENTS
@@ -73,6 +89,20 @@ pub struct PlatformConfig {
     #[cfg(feature = "tdx")]
     #[serde(default)]
     pub tdx: bool,
+}
+
+impl Default for PlatformConfig {
+    fn default() -> Self {
+        PlatformConfig {
+            num_pci_segments: DEFAULT_NUM_PCI_SEGMENTS,
+            iommu_segments: None,
+            serial_number: None,
+            uuid: None,
+            oem_strings: None,
+            #[cfg(feature = "tdx")]
+            tdx: false,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -103,6 +133,12 @@ pub enum HotplugMethod {
     VirtioMem,
 }
 
+impl Default for HotplugMethod {
+    fn default() -> Self {
+        HotplugMethod::Acpi
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct MemoryConfig {
     pub size: u64,
@@ -126,10 +162,35 @@ pub struct MemoryConfig {
     pub zones: Option<Vec<MemoryZoneConfig>>,
 }
 
+pub const DEFAULT_MEMORY_MB: u64 = 512;
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        MemoryConfig {
+            size: DEFAULT_MEMORY_MB << 20,
+            mergeable: false,
+            hotplug_method: HotplugMethod::Acpi,
+            hotplug_size: None,
+            hotplugged_size: None,
+            shared: false,
+            hugepages: false,
+            hugepage_size: None,
+            prefault: false,
+            zones: None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum VhostMode {
     Client,
     Server,
+}
+
+impl Default for VhostMode {
+    fn default() -> Self {
+        VhostMode::Client
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -183,6 +244,25 @@ pub fn default_diskconfig_num_queues() -> usize {
 pub const DEFAULT_QUEUE_SIZE_VUBLK: u16 = 128;
 pub fn default_diskconfig_queue_size() -> u16 {
     DEFAULT_QUEUE_SIZE_VUBLK
+}
+
+impl Default for DiskConfig {
+    fn default() -> Self {
+        Self {
+            path: None,
+            readonly: false,
+            direct: false,
+            iommu: false,
+            num_queues: default_diskconfig_num_queues(),
+            queue_size: default_diskconfig_queue_size(),
+            vhost_user: false,
+            vhost_socket: None,
+            id: None,
+            disable_io_uring: false,
+            rate_limiter_config: None,
+            pci_segment: 0,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -246,11 +326,45 @@ pub fn default_netconfig_queue_size() -> u16 {
     DEFAULT_QUEUE_SIZE_VUNET
 }
 
+impl Default for NetConfig {
+    fn default() -> Self {
+        Self {
+            tap: default_netconfig_tap(),
+            ip: default_netconfig_ip(),
+            mask: default_netconfig_mask(),
+            mac: default_netconfig_mac(),
+            host_mac: None,
+            mtu: None,
+            iommu: false,
+            num_queues: default_netconfig_num_queues(),
+            queue_size: default_netconfig_queue_size(),
+            vhost_user: false,
+            vhost_socket: None,
+            vhost_mode: VhostMode::Client,
+            id: None,
+            fds: None,
+            rate_limiter_config: None,
+            pci_segment: 0,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct RngConfig {
     pub src: PathBuf,
     #[serde(default)]
     pub iommu: bool,
+}
+
+pub const DEFAULT_RNG_SOURCE: &str = "/dev/urandom";
+
+impl Default for RngConfig {
+    fn default() -> Self {
+        RngConfig {
+            src: PathBuf::from(DEFAULT_RNG_SOURCE),
+            iommu: false,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -284,6 +398,19 @@ pub fn default_fsconfig_num_queues() -> usize {
 
 pub fn default_fsconfig_queue_size() -> u16 {
     1024
+}
+
+impl Default for FsConfig {
+    fn default() -> Self {
+        Self {
+            tag: "".to_owned(),
+            socket: PathBuf::new(),
+            num_queues: default_fsconfig_num_queues(),
+            queue_size: default_fsconfig_queue_size(),
+            id: None,
+            pci_segment: 0,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -1,0 +1,458 @@
+// Copyright © 2022 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+use net_util::MacAddr;
+use serde::{Deserialize, Serialize};
+use std::{net::Ipv4Addr, path::PathBuf};
+use virtio_devices::RateLimiterConfig;
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CpuAffinity {
+    pub vcpu: u8,
+    pub host_cpus: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CpuFeatures {
+    #[cfg(target_arch = "x86_64")]
+    #[serde(default)]
+    pub amx: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CpuTopology {
+    pub threads_per_core: u8,
+    pub cores_per_die: u8,
+    pub dies_per_package: u8,
+    pub packages: u8,
+}
+
+// When booting with PVH boot the maximum physical addressable size
+// is a 46 bit address space even when the host supports with 5-level
+// paging.
+pub const DEFAULT_MAX_PHYS_BITS: u8 = 46;
+
+pub fn default_cpuconfig_max_phys_bits() -> u8 {
+    DEFAULT_MAX_PHYS_BITS
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CpusConfig {
+    pub boot_vcpus: u8,
+    pub max_vcpus: u8,
+    #[serde(default)]
+    pub topology: Option<CpuTopology>,
+    #[serde(default)]
+    pub kvm_hyperv: bool,
+    #[serde(default = "default_cpuconfig_max_phys_bits")]
+    pub max_phys_bits: u8,
+    #[serde(default)]
+    pub affinity: Option<Vec<CpuAffinity>>,
+    #[serde(default)]
+    pub features: CpuFeatures,
+}
+
+pub const DEFAULT_NUM_PCI_SEGMENTS: u16 = 1;
+pub fn default_platformconfig_num_pci_segments() -> u16 {
+    DEFAULT_NUM_PCI_SEGMENTS
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct PlatformConfig {
+    #[serde(default = "default_platformconfig_num_pci_segments")]
+    pub num_pci_segments: u16,
+    #[serde(default)]
+    pub iommu_segments: Option<Vec<u16>>,
+    #[serde(default)]
+    pub serial_number: Option<String>,
+    #[serde(default)]
+    pub uuid: Option<String>,
+    #[serde(default)]
+    pub oem_strings: Option<Vec<String>>,
+    #[cfg(feature = "tdx")]
+    #[serde(default)]
+    pub tdx: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct MemoryZoneConfig {
+    pub id: String,
+    pub size: u64,
+    #[serde(default)]
+    pub file: Option<PathBuf>,
+    #[serde(default)]
+    pub shared: bool,
+    #[serde(default)]
+    pub hugepages: bool,
+    #[serde(default)]
+    pub hugepage_size: Option<u64>,
+    #[serde(default)]
+    pub host_numa_node: Option<u32>,
+    #[serde(default)]
+    pub hotplug_size: Option<u64>,
+    #[serde(default)]
+    pub hotplugged_size: Option<u64>,
+    #[serde(default)]
+    pub prefault: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum HotplugMethod {
+    Acpi,
+    VirtioMem,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct MemoryConfig {
+    pub size: u64,
+    #[serde(default)]
+    pub mergeable: bool,
+    #[serde(default)]
+    pub hotplug_method: HotplugMethod,
+    #[serde(default)]
+    pub hotplug_size: Option<u64>,
+    #[serde(default)]
+    pub hotplugged_size: Option<u64>,
+    #[serde(default)]
+    pub shared: bool,
+    #[serde(default)]
+    pub hugepages: bool,
+    #[serde(default)]
+    pub hugepage_size: Option<u64>,
+    #[serde(default)]
+    pub prefault: bool,
+    #[serde(default)]
+    pub zones: Option<Vec<MemoryZoneConfig>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum VhostMode {
+    Client,
+    Server,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct KernelConfig {
+    pub path: PathBuf,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct InitramfsConfig {
+    pub path: PathBuf,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CmdlineConfig {
+    pub args: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct DiskConfig {
+    pub path: Option<PathBuf>,
+    #[serde(default)]
+    pub readonly: bool,
+    #[serde(default)]
+    pub direct: bool,
+    #[serde(default)]
+    pub iommu: bool,
+    #[serde(default = "default_diskconfig_num_queues")]
+    pub num_queues: usize,
+    #[serde(default = "default_diskconfig_queue_size")]
+    pub queue_size: u16,
+    #[serde(default)]
+    pub vhost_user: bool,
+    pub vhost_socket: Option<String>,
+    #[serde(default)]
+    pub rate_limiter_config: Option<RateLimiterConfig>,
+    #[serde(default)]
+    pub id: Option<String>,
+    // For testing use only. Not exposed in API.
+    #[serde(default)]
+    pub disable_io_uring: bool,
+    #[serde(default)]
+    pub pci_segment: u16,
+}
+
+pub const DEFAULT_NUM_QUEUES_VUBLK: usize = 1;
+
+pub fn default_diskconfig_num_queues() -> usize {
+    DEFAULT_NUM_QUEUES_VUBLK
+}
+
+pub const DEFAULT_QUEUE_SIZE_VUBLK: u16 = 128;
+pub fn default_diskconfig_queue_size() -> u16 {
+    DEFAULT_QUEUE_SIZE_VUBLK
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct NetConfig {
+    #[serde(default = "default_netconfig_tap")]
+    pub tap: Option<String>,
+    #[serde(default = "default_netconfig_ip")]
+    pub ip: Ipv4Addr,
+    #[serde(default = "default_netconfig_mask")]
+    pub mask: Ipv4Addr,
+    #[serde(default = "default_netconfig_mac")]
+    pub mac: MacAddr,
+    #[serde(default)]
+    pub host_mac: Option<MacAddr>,
+    #[serde(default)]
+    pub mtu: Option<u16>,
+    #[serde(default)]
+    pub iommu: bool,
+    #[serde(default = "default_netconfig_num_queues")]
+    pub num_queues: usize,
+    #[serde(default = "default_netconfig_queue_size")]
+    pub queue_size: u16,
+    #[serde(default)]
+    pub vhost_user: bool,
+    pub vhost_socket: Option<String>,
+    #[serde(default)]
+    pub vhost_mode: VhostMode,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub fds: Option<Vec<i32>>,
+    #[serde(default)]
+    pub rate_limiter_config: Option<RateLimiterConfig>,
+    #[serde(default)]
+    pub pci_segment: u16,
+}
+
+pub fn default_netconfig_tap() -> Option<String> {
+    None
+}
+
+pub fn default_netconfig_ip() -> Ipv4Addr {
+    Ipv4Addr::new(192, 168, 249, 1)
+}
+
+pub fn default_netconfig_mask() -> Ipv4Addr {
+    Ipv4Addr::new(255, 255, 255, 0)
+}
+
+pub fn default_netconfig_mac() -> MacAddr {
+    MacAddr::local_random()
+}
+
+pub const DEFAULT_NUM_QUEUES_VUNET: usize = 2;
+pub fn default_netconfig_num_queues() -> usize {
+    DEFAULT_NUM_QUEUES_VUNET
+}
+
+pub const DEFAULT_QUEUE_SIZE_VUNET: u16 = 256;
+pub fn default_netconfig_queue_size() -> u16 {
+    DEFAULT_QUEUE_SIZE_VUNET
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct RngConfig {
+    pub src: PathBuf,
+    #[serde(default)]
+    pub iommu: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct BalloonConfig {
+    pub size: u64,
+    /// Option to deflate the balloon in case the guest is out of memory.
+    #[serde(default)]
+    pub deflate_on_oom: bool,
+    /// Option to enable free page reporting from the guest.
+    #[serde(default)]
+    pub free_page_reporting: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct FsConfig {
+    pub tag: String,
+    pub socket: PathBuf,
+    #[serde(default = "default_fsconfig_num_queues")]
+    pub num_queues: usize,
+    #[serde(default = "default_fsconfig_queue_size")]
+    pub queue_size: u16,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub pci_segment: u16,
+}
+
+pub fn default_fsconfig_num_queues() -> usize {
+    1
+}
+
+pub fn default_fsconfig_queue_size() -> u16 {
+    1024
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub struct PmemConfig {
+    pub file: PathBuf,
+    #[serde(default)]
+    pub size: Option<u64>,
+    #[serde(default)]
+    pub iommu: bool,
+    #[serde(default)]
+    pub discard_writes: bool,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub pci_segment: u16,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum ConsoleOutputMode {
+    Off,
+    Pty,
+    Tty,
+    File,
+    Null,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ConsoleConfig {
+    #[serde(default = "default_consoleconfig_file")]
+    pub file: Option<PathBuf>,
+    pub mode: ConsoleOutputMode,
+    #[serde(default)]
+    pub iommu: bool,
+}
+
+pub fn default_consoleconfig_file() -> Option<PathBuf> {
+    None
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub struct DeviceConfig {
+    pub path: PathBuf,
+    #[serde(default)]
+    pub iommu: bool,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub pci_segment: u16,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub struct UserDeviceConfig {
+    pub socket: PathBuf,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub pci_segment: u16,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub struct VdpaConfig {
+    pub path: PathBuf,
+    #[serde(default = "default_vdpaconfig_num_queues")]
+    pub num_queues: usize,
+    #[serde(default)]
+    pub iommu: bool,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub pci_segment: u16,
+}
+
+pub fn default_vdpaconfig_num_queues() -> usize {
+    1
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub struct VsockConfig {
+    pub cid: u64,
+    pub socket: PathBuf,
+    #[serde(default)]
+    pub iommu: bool,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub pci_segment: u16,
+}
+
+#[cfg(target_arch = "x86_64")]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub struct SgxEpcConfig {
+    pub id: String,
+    #[serde(default)]
+    pub size: u64,
+    #[serde(default)]
+    pub prefault: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub struct NumaDistance {
+    #[serde(default)]
+    pub destination: u32,
+    #[serde(default)]
+    pub distance: u8,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub struct NumaConfig {
+    #[serde(default)]
+    pub guest_numa_id: u32,
+    #[serde(default)]
+    pub cpus: Option<Vec<u8>>,
+    #[serde(default)]
+    pub distances: Option<Vec<NumaDistance>>,
+    #[serde(default)]
+    pub memory_zones: Option<Vec<String>>,
+    #[cfg(target_arch = "x86_64")]
+    #[serde(default)]
+    pub sgx_epc_sections: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct PayloadConfig {
+    #[serde(default)]
+    pub firmware: Option<PathBuf>,
+    #[serde(default)]
+    pub kernel: Option<PathBuf>,
+    #[serde(default)]
+    pub cmdline: Option<String>,
+    #[serde(default)]
+    pub initramfs: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct VmConfig {
+    #[serde(default)]
+    pub cpus: CpusConfig,
+    #[serde(default)]
+    pub memory: MemoryConfig,
+    pub kernel: Option<KernelConfig>,
+    #[serde(default)]
+    pub initramfs: Option<InitramfsConfig>,
+    #[serde(default)]
+    pub cmdline: CmdlineConfig,
+    #[serde(default)]
+    pub payload: Option<PayloadConfig>,
+    pub disks: Option<Vec<DiskConfig>>,
+    pub net: Option<Vec<NetConfig>>,
+    #[serde(default)]
+    pub rng: RngConfig,
+    pub balloon: Option<BalloonConfig>,
+    pub fs: Option<Vec<FsConfig>>,
+    pub pmem: Option<Vec<PmemConfig>>,
+    #[serde(default = "ConsoleConfig::default_serial")]
+    pub serial: ConsoleConfig,
+    #[serde(default = "ConsoleConfig::default_console")]
+    pub console: ConsoleConfig,
+    pub devices: Option<Vec<DeviceConfig>>,
+    pub user_devices: Option<Vec<UserDeviceConfig>>,
+    pub vdpa: Option<Vec<VdpaConfig>>,
+    pub vsock: Option<VsockConfig>,
+    #[serde(default)]
+    pub iommu: bool,
+    #[cfg(target_arch = "x86_64")]
+    pub sgx_epc: Option<Vec<SgxEpcConfig>>,
+    pub numa: Option<Vec<NumaConfig>>,
+    #[serde(default)]
+    pub watchdog: bool,
+    #[cfg(feature = "guest_debug")]
+    pub gdb: bool,
+    pub platform: Option<PlatformConfig>,
+}

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -194,21 +194,6 @@ impl Default for VhostMode {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct KernelConfig {
-    pub path: PathBuf,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct InitramfsConfig {
-    pub path: PathBuf,
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
-pub struct CmdlineConfig {
-    pub args: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DiskConfig {
     pub path: Option<PathBuf>,
     #[serde(default)]
@@ -553,12 +538,6 @@ pub struct VmConfig {
     pub cpus: CpusConfig,
     #[serde(default)]
     pub memory: MemoryConfig,
-    pub kernel: Option<KernelConfig>,
-    #[serde(default)]
-    pub initramfs: Option<InitramfsConfig>,
-    #[serde(default)]
-    pub cmdline: CmdlineConfig,
-    #[serde(default)]
     pub payload: Option<PayloadConfig>,
     pub disks: Option<Vec<DiskConfig>>,
     pub net: Option<Vec<NetConfig>>,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -235,15 +235,16 @@ pub struct DiskConfig {
     pub pci_segment: u16,
 }
 
-pub const DEFAULT_NUM_QUEUES_VUBLK: usize = 1;
+pub const DEFAULT_DISK_NUM_QUEUES: usize = 1;
 
 pub fn default_diskconfig_num_queues() -> usize {
-    DEFAULT_NUM_QUEUES_VUBLK
+    DEFAULT_DISK_NUM_QUEUES
 }
 
-pub const DEFAULT_QUEUE_SIZE_VUBLK: u16 = 128;
+pub const DEFAULT_DISK_QUEUE_SIZE: u16 = 128;
+
 pub fn default_diskconfig_queue_size() -> u16 {
-    DEFAULT_QUEUE_SIZE_VUBLK
+    DEFAULT_DISK_QUEUE_SIZE
 }
 
 impl Default for DiskConfig {
@@ -316,14 +317,16 @@ pub fn default_netconfig_mac() -> MacAddr {
     MacAddr::local_random()
 }
 
-pub const DEFAULT_NUM_QUEUES_VUNET: usize = 2;
+pub const DEFAULT_NET_NUM_QUEUES: usize = 2;
+
 pub fn default_netconfig_num_queues() -> usize {
-    DEFAULT_NUM_QUEUES_VUNET
+    DEFAULT_NET_NUM_QUEUES
 }
 
-pub const DEFAULT_QUEUE_SIZE_VUNET: u16 = 256;
+pub const DEFAULT_NET_QUEUE_SIZE: u16 = 256;
+
 pub fn default_netconfig_queue_size() -> u16 {
-    DEFAULT_QUEUE_SIZE_VUNET
+    DEFAULT_NET_QUEUE_SIZE
 }
 
 impl Default for NetConfig {


### PR DESCRIPTION
Simplify and clean-up config.rs by splitting it up to ease readability. Whilst
doing this I found some other items that needed fixing including removing
deprecated funtionality.

- vmm: Split structs from logic that make up VmConfig
- vmm: Move `impl Default for ...` to vm_config.rs
- vmm: Rename queue size / number of queues constants
- vmm: Remove deprecated VmConfig::{kernel, initramfs, cmdline} members
