### PR TITLE
vmm: Move 'default_serial/console()' to vm_config.rs

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1414,22 +1414,6 @@ impl ConsoleConfig {
 
         Ok(Self { file, mode, iommu })
     }
-
-    pub fn default_serial() -> Self {
-        ConsoleConfig {
-            file: None,
-            mode: ConsoleOutputMode::Null,
-            iommu: false,
-        }
-    }
-
-    pub fn default_console() -> Self {
-        ConsoleConfig {
-            file: None,
-            mode: ConsoleOutputMode::Tty,
-            iommu: false,
-        }
-    }
 }
 
 impl DeviceConfig {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -532,6 +532,22 @@ pub struct PayloadConfig {
     pub initramfs: Option<PathBuf>,
 }
 
+pub fn default_serial() -> ConsoleConfig {
+    ConsoleConfig {
+        file: None,
+        mode: ConsoleOutputMode::Null,
+        iommu: false,
+    }
+}
+
+pub fn default_console() -> ConsoleConfig {
+    ConsoleConfig {
+        file: None,
+        mode: ConsoleOutputMode::Tty,
+        iommu: false,
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct VmConfig {
     #[serde(default)]
@@ -546,9 +562,9 @@ pub struct VmConfig {
     pub balloon: Option<BalloonConfig>,
     pub fs: Option<Vec<FsConfig>>,
     pub pmem: Option<Vec<PmemConfig>>,
-    #[serde(default = "ConsoleConfig::default_serial")]
+    #[serde(default = "default_serial")]
     pub serial: ConsoleConfig,
-    #[serde(default = "ConsoleConfig::default_console")]
+    #[serde(default = "default_console")]
     pub console: ConsoleConfig,
     pub devices: Option<Vec<DeviceConfig>>,
     pub user_devices: Option<Vec<UserDeviceConfig>>,


### PR DESCRIPTION
In this way, we have all functions related to generate default values of vm-config structs in the same location.

Signed-off-by: Bo Chen <chen.bo@intel.com>