### PR TITLE
.github: Add Gihub action 'CIFuzz' using OSS-FUZZ

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -1,0 +1,26 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'cloud-hypervisor'
+        language: rust
+        dry-run: false
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'cloud-hypervisor'
+        language: rust
+        fuzz-seconds: 1200
+        dry-run: false
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
In this way, we can run the fuzzers (that being integrated to OSS-FUZZ) On each pull request. The default timeout for fuzzing now is 1200 seconds (which is shared by all fuzzers).

Signed-off-by: Bo Chen <chen.bo@intel.com>