### PR TITLE
tests: Temporarily disable test_live_{migration,upgrade}_watchdog{_local}

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9305,11 +9305,13 @@ mod live_migration {
         }
 
         #[test]
+        #[ignore = "See #4749"]
         fn test_live_migration_watchdog() {
             _test_live_migration_watchdog(false, false)
         }
 
         #[test]
+        #[ignore = "See #4749"]
         fn test_live_migration_watchdog_local() {
             _test_live_migration_watchdog(false, true)
         }
@@ -9347,11 +9349,13 @@ mod live_migration {
         }
 
         #[test]
+        #[ignore = "See #4749"]
         fn test_live_upgrade_watchdog() {
             _test_live_migration_watchdog(true, false)
         }
 
         #[test]
+        #[ignore = "See #4749"]
         fn test_live_upgrade_watchdog_local() {
             _test_live_migration_watchdog(true, true)
         }


### PR DESCRIPTION
This test has been identified as flaky and is creating CI churn.

See: #4749

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
