### PR TITLE
virtio-devices: Implement live migration support for Vdpa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,8 +1276,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79243657c76e5c90dcbf60187c842614f6dfc7123972c55bb3bcc446792aca93"
+source = "git+https://github.com/rust-vmm/vhost?branch=main#f87156b77662af63b9fc9f116a213dd69e16007b"
 dependencies = [
  "bitflags",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ clap = { version = "4.0.14", features = ["cargo"] }
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0-tdx" }
 kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "main" }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
+vhost = { git = "https://github.com/rust-vmm/vhost", branch = "main" }
 
 [dev-dependencies]
 dirs = "4.0.0"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -884,8 +884,7 @@ dependencies = [
 [[package]]
 name = "vhost"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79243657c76e5c90dcbf60187c842614f6dfc7123972c55bb3bcc446792aca93"
+source = "git+https://github.com/rust-vmm/vhost?branch=main#f87156b77662af63b9fc9f116a213dd69e16007b"
 dependencies = [
  "bitflags",
  "libc",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -34,6 +34,7 @@ path = ".."
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.5.0-tdx" }
 kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "main" }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
+vhost = { git = "https://github.com/rust-vmm/vhost", branch = "main" }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -21,6 +21,8 @@ pub enum Error {
     IoRegistrationFailed(u64, configuration::Error),
     /// Expected resource not found.
     MissingResource,
+    /// Invalid resource.
+    InvalidResource(Resource),
 }
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -37,6 +39,7 @@ impl Display for Error {
                 write!(f, "failed to register an IO BAR, addr={} err={}", addr, e)
             }
             MissingResource => write!(f, "failed to find expected resource"),
+            InvalidResource(r) => write!(f, "invalid resource {:?}", r),
         }
     }
 }

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -54,6 +54,9 @@ pub enum MigratableError {
     #[error("Failed to retrieve dirty ranges for migratable component: {0}")]
     DirtyLog(#[source] anyhow::Error),
 
+    #[error("Failed to start migration for migratable component: {0}")]
+    StartMigration(#[source] anyhow::Error),
+
     #[error("Failed to complete migration for migratable component: {0}")]
     CompleteMigration(#[source] anyhow::Error),
 }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2852,6 +2852,7 @@ impl DeviceManager {
                 device_path,
                 self.memory_manager.lock().unwrap().guest_memory(),
                 vdpa_cfg.num_queues as u16,
+                self.restoring,
             )
             .map_err(DeviceManagerError::CreateVdpa)?,
         ));
@@ -2865,7 +2866,7 @@ impl DeviceManager {
         self.device_tree
             .lock()
             .unwrap()
-            .insert(id.clone(), device_node!(id));
+            .insert(id.clone(), device_node!(id, vdpa_device));
 
         Ok(MetaVirtioDevice {
             virtio_device: vdpa_device as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -108,6 +108,8 @@ const VHOST_VDPA_SET_VRING_ENABLE: u64 = 0x4008af75;
 const VHOST_VDPA_GET_VRING_NUM: u64 = 0x8002af76;
 const VHOST_VDPA_SET_CONFIG_CALL: u64 = 0x4004af77;
 const VHOST_VDPA_GET_IOVA_RANGE: u64 = 0x8010af78;
+const VHOST_VDPA_GET_CONFIG_SIZE: u64 = 0x8004af79;
+const VHOST_VDPA_SUSPEND: u64 = 0xaf7d;
 
 // See include/uapi/linux/kvm.h in the kernel code.
 #[cfg(feature = "kvm")]
@@ -318,6 +320,8 @@ fn create_vmm_ioctl_seccomp_rule_common(
         and![Cond::new(1, ArgLen::Dword, Eq, VHOST_VDPA_GET_VRING_NUM)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VHOST_VDPA_SET_CONFIG_CALL)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VHOST_VDPA_GET_IOVA_RANGE)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, VHOST_VDPA_GET_CONFIG_SIZE)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, VHOST_VDPA_SUSPEND)?],
     ];
 
     let hypervisor_rules = create_vmm_ioctl_seccomp_rule_hypervisor(hypervisor_type)?;


### PR DESCRIPTION
Vdpa now implements the Migratable trait, which allows the device to be
added to the DeviceTree and therefore allows live migrating any vDPA
device that supports being suspended.

Given a vDPA device can't be resumed from a suspended state without
having to reset everything, we don't support pause/resume for a vDPA
device, as well as snapshot/restore (which requires resume to be
supported).