### PR TITLE
test_data: Use bash TCP support instead of netcat for boot check

### DIFF
--- a/test_data/cloud-init/ubuntu/user-data
+++ b/test_data/cloud-init/ubuntu/user-data
@@ -73,4 +73,4 @@ write_files:
         #!/bin/bash
         set -e
 
-        echo -n "@DEFAULT_TCP_LISTENER_MESSAGE" | nc -w0 @HOST_IP @TCP_LISTENER_PORT
+        echo -n "@DEFAULT_TCP_LISTENER_MESSAGE" > /dev/tcp/@HOST_IP/@TCP_LISTENER_PORT


### PR DESCRIPTION
This means that the guest image does not need to have netcat installed
making it easiert to use unmodified images.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
