### PR TITLE
tests: Rely on wtmp (the login records) to count reboot times

### DIFF
--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1085,7 +1085,7 @@ impl Guest {
     }
 
     pub fn reboot_linux(&self, current_reboot_count: u32, custom_timeout: Option<i32>) {
-        let list_boots_cmd = "sudo journalctl --list-boots | wc -l";
+        let list_boots_cmd = "sudo last | grep -c reboot";
         let boot_count = self
             .ssh_command(list_boots_cmd)
             .unwrap()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1882,11 +1882,8 @@ fn _test_virtio_iommu(acpi: bool) {
 }
 
 fn get_reboot_count(guest: &Guest) -> u32 {
-    // Ensure that the current boot journal is written so reboot counts are valid
-    guest.ssh_command("sudo journalctl --sync").unwrap();
-
     guest
-        .ssh_command("sudo journalctl --list-boots | wc -l")
+        .ssh_command("sudo last | grep -c reboot")
         .unwrap()
         .trim()
         .parse::<u32>()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9302,13 +9302,11 @@ mod live_migration {
         }
 
         #[test]
-        #[ignore = "See #4749"]
         fn test_live_migration_watchdog() {
             _test_live_migration_watchdog(false, false)
         }
 
         #[test]
-        #[ignore = "See #4749"]
         fn test_live_migration_watchdog_local() {
             _test_live_migration_watchdog(false, true)
         }
@@ -9346,13 +9344,11 @@ mod live_migration {
         }
 
         #[test]
-        #[ignore = "See #4749"]
         fn test_live_upgrade_watchdog() {
             _test_live_migration_watchdog(true, false)
         }
 
         #[test]
-        #[ignore = "See #4749"]
         fn test_live_upgrade_watchdog_local() {
             _test_live_migration_watchdog(true, true)
         }


### PR DESCRIPTION
The systemd journal has a known issue of generating large size logs[1],
which makes it unreliable as a source for retrieving system
information, such as for counting reboot times. This is particularly
problematic on disk-constrained systems, like the VMs we launched for
our integration tests, where the disk size is normally 2GB. By default,
the systemd journal has a size limit of 10% of the size of the
underlying file system (e.g. around 200MB for the VMs of our integration
tests), which would remove archived journal files on demand.

A better alternative to count reboot times is based on information from
`wtmp` (e.g. the login records) which is much more concise and can be
accessed via the `last` command.

[1] https://github.com/systemd/systemd/issues/5285

Fixes: #4749

Signed-off-by: Bo Chen <chen.bo@intel.com>