### PR TITLE
virtio-devices: iommu: Specify minimum number of queues to avoid OOB

### DIFF
--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -905,6 +905,7 @@ impl Iommu {
                         | 1u64 << VIRTIO_IOMMU_F_PROBE
                         | 1u64 << VIRTIO_IOMMU_F_BYPASS_CONFIG,
                     paused_sync: Some(Arc::new(Barrier::new(2))),
+                    min_queues: NUM_QUEUES as u16,
                     ..Default::default()
                 },
                 config,


### PR DESCRIPTION
In this way, the virtio-iommu code can properly report an error when
a wrong number of queues is provided, instead of triggering an
out-of-bound error.

Signed-off-by: Bo Chen <chen.bo@intel.com>
