### PR TITLE
vmm: virtio-devices: Restore every VirtioDevice upon creation

### DIFF
--- a/fuzz/fuzz_targets/balloon.rs
+++ b/fuzz/fuzz_targets/balloon.rs
@@ -49,6 +49,7 @@ fuzz_target!(|bytes| {
         true,
         SeccompAction::Allow,
         EventFd::new(EFD_NONBLOCK).unwrap(),
+        None,
     )
     .unwrap();
 

--- a/fuzz/fuzz_targets/block.rs
+++ b/fuzz/fuzz_targets/block.rs
@@ -60,6 +60,7 @@ fuzz_target!(|bytes| {
         SeccompAction::Allow,
         None,
         EventFd::new(EFD_NONBLOCK).unwrap(),
+        None,
     )
     .unwrap();
 

--- a/fuzz/fuzz_targets/iommu.rs
+++ b/fuzz/fuzz_targets/iommu.rs
@@ -64,6 +64,7 @@ fuzz_target!(|bytes| {
         SeccompAction::Allow,
         EventFd::new(EFD_NONBLOCK).unwrap(),
         ((MEM_SIZE - IOVA_SPACE_SIZE) as u64, (MEM_SIZE - 1) as u64),
+        None,
     )
     .unwrap();
 

--- a/fuzz/fuzz_targets/mem.rs
+++ b/fuzz/fuzz_targets/mem.rs
@@ -152,6 +152,7 @@ fn create_dummy_virtio_mem(bytes: &[u8; VIRTIO_MEM_DATA_SIZE]) -> (Mem, Arc<Gues
             false,
             EventFd::new(EFD_NONBLOCK).unwrap(),
             blocks_state.clone(),
+            None,
         )
         .unwrap(),
         region,

--- a/fuzz/fuzz_targets/pmem.rs
+++ b/fuzz/fuzz_targets/pmem.rs
@@ -127,6 +127,7 @@ fn create_dummy_pmem() -> Pmem {
         false,
         SeccompAction::Allow,
         EventFd::new(EFD_NONBLOCK).unwrap(),
+        None,
     )
     .unwrap()
 }

--- a/fuzz/fuzz_targets/rng.rs
+++ b/fuzz/fuzz_targets/rng.rs
@@ -63,6 +63,7 @@ fuzz_target!(|bytes| {
         false,
         SeccompAction::Allow,
         EventFd::new(EFD_NONBLOCK).unwrap(),
+        None,
     )
     .unwrap();
 

--- a/fuzz/fuzz_targets/watchdog.rs
+++ b/fuzz/fuzz_targets/watchdog.rs
@@ -38,6 +38,7 @@ fuzz_target!(|bytes| {
         EventFd::new(EFD_NONBLOCK).unwrap(),
         SeccompAction::Allow,
         EventFd::new(EFD_NONBLOCK).unwrap(),
+        None,
     )
     .unwrap();
 

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -416,72 +416,86 @@ impl Block {
         seccomp_action: SeccompAction,
         rate_limiter_config: Option<RateLimiterConfig>,
         exit_evt: EventFd,
+        state: Option<BlockState>,
     ) -> io::Result<Self> {
-        let disk_size = disk_image.size().map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("Failed getting disk size: {}", e),
+        let (disk_nsectors, avail_features, acked_features, config) = if let Some(state) = state {
+            info!("Restoring virtio-block {}", id);
+            (
+                state.disk_nsectors,
+                state.avail_features,
+                state.acked_features,
+                state.config,
             )
-        })?;
-        if disk_size % SECTOR_SIZE != 0 {
-            warn!(
-                "Disk size {} is not a multiple of sector size {}; \
-                 the remainder will not be visible to the guest.",
-                disk_size, SECTOR_SIZE
-            );
-        }
-
-        let mut avail_features = (1u64 << VIRTIO_F_VERSION_1)
-            | (1u64 << VIRTIO_BLK_F_FLUSH)
-            | (1u64 << VIRTIO_BLK_F_CONFIG_WCE)
-            | (1u64 << VIRTIO_BLK_F_BLK_SIZE)
-            | (1u64 << VIRTIO_BLK_F_TOPOLOGY);
-
-        if iommu {
-            avail_features |= 1u64 << VIRTIO_F_IOMMU_PLATFORM;
-        }
-
-        if is_disk_read_only {
-            avail_features |= 1u64 << VIRTIO_BLK_F_RO;
-        }
-
-        let topology = disk_image.topology();
-        info!("Disk topology: {:?}", topology);
-
-        let logical_block_size = if topology.logical_block_size > 512 {
-            topology.logical_block_size
         } else {
-            512
+            let disk_size = disk_image.size().map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Failed getting disk size: {}", e),
+                )
+            })?;
+            if disk_size % SECTOR_SIZE != 0 {
+                warn!(
+                    "Disk size {} is not a multiple of sector size {}; \
+                 the remainder will not be visible to the guest.",
+                    disk_size, SECTOR_SIZE
+                );
+            }
+
+            let mut avail_features = (1u64 << VIRTIO_F_VERSION_1)
+                | (1u64 << VIRTIO_BLK_F_FLUSH)
+                | (1u64 << VIRTIO_BLK_F_CONFIG_WCE)
+                | (1u64 << VIRTIO_BLK_F_BLK_SIZE)
+                | (1u64 << VIRTIO_BLK_F_TOPOLOGY);
+
+            if iommu {
+                avail_features |= 1u64 << VIRTIO_F_IOMMU_PLATFORM;
+            }
+
+            if is_disk_read_only {
+                avail_features |= 1u64 << VIRTIO_BLK_F_RO;
+            }
+
+            let topology = disk_image.topology();
+            info!("Disk topology: {:?}", topology);
+
+            let logical_block_size = if topology.logical_block_size > 512 {
+                topology.logical_block_size
+            } else {
+                512
+            };
+
+            // Calculate the exponent that maps physical block to logical block
+            let mut physical_block_exp = 0;
+            let mut size = logical_block_size;
+            while size < topology.physical_block_size {
+                physical_block_exp += 1;
+                size <<= 1;
+            }
+
+            let disk_nsectors = disk_size / SECTOR_SIZE;
+            let mut config = VirtioBlockConfig {
+                capacity: disk_nsectors,
+                writeback: 1,
+                blk_size: topology.logical_block_size as u32,
+                physical_block_exp,
+                min_io_size: (topology.minimum_io_size / logical_block_size) as u16,
+                opt_io_size: (topology.optimal_io_size / logical_block_size) as u32,
+                ..Default::default()
+            };
+
+            if num_queues > 1 {
+                avail_features |= 1u64 << VIRTIO_BLK_F_MQ;
+                config.num_queues = num_queues as u16;
+            }
+
+            (disk_nsectors, avail_features, 0, config)
         };
-
-        // Calculate the exponent that maps physical block to logical block
-        let mut physical_block_exp = 0;
-        let mut size = logical_block_size;
-        while size < topology.physical_block_size {
-            physical_block_exp += 1;
-            size <<= 1;
-        }
-
-        let disk_nsectors = disk_size / SECTOR_SIZE;
-        let mut config = VirtioBlockConfig {
-            capacity: disk_nsectors,
-            writeback: 1,
-            blk_size: topology.logical_block_size as u32,
-            physical_block_exp,
-            min_io_size: (topology.minimum_io_size / logical_block_size) as u16,
-            opt_io_size: (topology.optimal_io_size / logical_block_size) as u32,
-            ..Default::default()
-        };
-
-        if num_queues > 1 {
-            avail_features |= 1u64 << VIRTIO_BLK_F_MQ;
-            config.num_queues = num_queues as u16;
-        }
 
         Ok(Block {
             common: VirtioCommon {
                 device_type: VirtioDeviceType::Block as u32,
                 avail_features,
+                acked_features,
                 paused_sync: Some(Arc::new(Barrier::new(num_queues + 1))),
                 queue_sizes: vec![queue_size; num_queues],
                 min_queues: 1,
@@ -508,14 +522,6 @@ impl Block {
             acked_features: self.common.acked_features,
             config: self.config,
         }
-    }
-
-    fn set_state(&mut self, state: &BlockState) {
-        self.disk_path = state.disk_path.clone().into();
-        self.disk_nsectors = state.disk_nsectors;
-        self.common.avail_features = state.avail_features;
-        self.common.acked_features = state.acked_features;
-        self.config = state.config;
     }
 
     fn update_writeback(&mut self) {
@@ -709,11 +715,6 @@ impl Snapshottable for Block {
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         Snapshot::new_from_versioned_state(&self.id(), &self.state())
-    }
-
-    fn restore(&mut self, snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
-        self.set_state(&snapshot.to_versioned_state(&self.id)?);
-        Ok(())
     }
 }
 impl Transportable for Block {}

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -276,6 +276,7 @@ mod tests {
                     false,
                     seccompiler::SeccompAction::Trap,
                     EventFd::new(EFD_NONBLOCK).unwrap(),
+                    None,
                 )
                 .unwrap(),
             }

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -236,6 +236,23 @@ impl Snapshot {
     }
 }
 
+pub fn snapshot_from_id(snapshot: Option<&Snapshot>, id: &str) -> Option<Snapshot> {
+    snapshot.and_then(|s| s.snapshots.get(id).map(|s| *s.clone()))
+}
+
+pub fn versioned_state_from_id<T>(
+    snapshot: Option<&Snapshot>,
+    id: &str,
+) -> Result<Option<T>, MigratableError>
+where
+    T: Versionize + VersionMapped,
+{
+    snapshot
+        .and_then(|s| s.snapshots.get(id).map(|s| *s.clone()))
+        .map(|s| s.to_versioned_state(id))
+        .transpose()
+}
+
 /// A snapshottable component can be snapshotted.
 pub trait Snapshottable: Pausable {
     /// The snapshottable component id.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1232,6 +1232,7 @@ impl Vmm {
             activate_evt,
             true,
             timestamp,
+            Some(&snapshot),
         )
         .map_err(|e| {
             MigratableError::MigrateReceive(anyhow!("Error creating VM from snapshot: {:?}", e))

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -94,7 +94,7 @@ use vm_memory::{Address, ByteValued, GuestMemory, GuestMemoryRegion};
 use vm_memory::{Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::protocol::{Request, Response, Status};
 use vm_migration::{
-    protocol::MemoryRangeTable, Migratable, MigratableError, Pausable, Snapshot,
+    protocol::MemoryRangeTable, snapshot_from_id, Migratable, MigratableError, Pausable, Snapshot,
     SnapshotDataSection, Snapshottable, Transportable,
 };
 use vmm_sys_util::eventfd::EventFd;
@@ -497,6 +497,7 @@ impl Vm {
         activate_evt: EventFd,
         restoring: bool,
         timestamp: Instant,
+        snapshot: Option<&Snapshot>,
     ) -> Result<Self> {
         trace_scoped!("Vm::new_from_memory_manager");
 
@@ -544,6 +545,7 @@ impl Vm {
             restoring,
             boot_id_list,
             timestamp,
+            snapshot_from_id(snapshot, DEVICE_MANAGER_SNAPSHOT_ID),
         )
         .map_err(Error::DeviceManager)?;
 
@@ -769,6 +771,7 @@ impl Vm {
             activate_evt,
             false,
             timestamp,
+            None,
         )?;
 
         // The device manager must create the devices from here as it is part
@@ -835,6 +838,7 @@ impl Vm {
             activate_evt,
             true,
             timestamp,
+            Some(snapshot),
         )
     }
 


### PR DESCRIPTION
Following the new design proposal to improve the restore codepath when
migrating a VM, all virtio devices are supplied with an optional state
they can use to restore from. The restore() implementation every device
was providing has been removed in order to prevent from going through
the restoration twice.

Here is the list of devices now following the new restore design:

- Block (virtio-block)
- Net (virtio-net)
- Rng (virtio-rng)
- Fs (vhost-user-fs)
- Blk (vhost-user-block)
- Net (vhost-user-net)
- Pmem (virtio-pmem)
- Vsock (virtio-vsock)
- Mem (virtio-mem)
- Balloon (virtio-balloon)
- Watchdog (virtio-watchdog)
- Vdpa (vDPA)
- Console (virtio-console)
- Iommu (virtio-iommu)

See #4783 