### PR TITLE
misc: Unify error message punctuation

### DIFF
--- a/block_util/src/lib.rs
+++ b/block_util/src/lib.rs
@@ -51,23 +51,23 @@ pub const SECTOR_SIZE: u64 = 0x01 << SECTOR_SHIFT;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Guest gave us bad memory addresses.")]
+    #[error("Guest gave us bad memory addresses")]
     GuestMemory(GuestMemoryError),
-    #[error("Guest gave us offsets that would have overflowed a usize.")]
+    #[error("Guest gave us offsets that would have overflowed a usize")]
     CheckedOffset(GuestAddress, usize),
-    #[error("Guest gave us a write only descriptor that protocol says to read from.")]
+    #[error("Guest gave us a write only descriptor that protocol says to read from")]
     UnexpectedWriteOnlyDescriptor,
-    #[error("Guest gave us a read only descriptor that protocol says to write to.")]
+    #[error("Guest gave us a read only descriptor that protocol says to write to")]
     UnexpectedReadOnlyDescriptor,
-    #[error("Guest gave us too few descriptors in a descriptor chain.")]
+    #[error("Guest gave us too few descriptors in a descriptor chain")]
     DescriptorChainTooShort,
-    #[error("Guest gave us a descriptor that was too short to use.")]
+    #[error("Guest gave us a descriptor that was too short to use")]
     DescriptorLengthTooSmall,
-    #[error("Getting a block's metadata fails for any reason.")]
+    #[error("Getting a block's metadata fails for any reason")]
     GetFileMetadata,
-    #[error("The requested operation would cause a seek beyond disk end.")]
+    #[error("The requested operation would cause a seek beyond disk end")]
     InvalidOffset,
-    #[error("The requested operation does not support multiple descriptors.")]
+    #[error("The requested operation does not support multiple descriptors")]
     TooManyDescriptors,
 }
 

--- a/net_util/src/open_tap.rs
+++ b/net_util/src/open_tap.rs
@@ -12,9 +12,9 @@ use thiserror::Error;
 pub enum Error {
     #[error("Failed to convert an hexadecimal string into an integer: {0}")]
     ConvertHexStringToInt(std::num::ParseIntError),
-    #[error("Error related to the multiqueue support (no support TAP side).")]
+    #[error("Error related to the multiqueue support (no support TAP side)")]
     MultiQueueNoTapSupport,
-    #[error("Error related to the multiqueue support (no support device side).")]
+    #[error("Error related to the multiqueue support (no support device side)")]
     MultiQueueNoDeviceSupport,
     #[error("Failed to read the TAP flags from sysfs: {0}")]
     ReadSysfsTunFlags(io::Error),

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -288,7 +288,7 @@ pub struct NetCounters {
 
 #[derive(Error, Debug)]
 pub enum NetQueuePairError {
-    #[error("No memory configured.")]
+    #[error("No memory configured")]
     NoMemoryConfigured,
     #[error("Error registering listener: {0}")]
     RegisterListener(io::Error),
@@ -302,9 +302,9 @@ pub enum NetQueuePairError {
     GuestMemory(vm_memory::GuestMemoryError),
     #[error("Returned an error while iterating through the queue: {0}")]
     QueueIteratorFailed(virtio_queue::Error),
-    #[error("Descriptor chain is too short.")]
+    #[error("Descriptor chain is too short")]
     DescriptorChainTooShort,
-    #[error("Descriptor chain does not contain valid descriptors.")]
+    #[error("Descriptor chain does not contain valid descriptors")]
     DescriptorChainInvalid,
     #[error("Failed to determine if queue needed notification: {0}")]
     QueueNeedsNotification(virtio_queue::Error),

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -26,13 +26,13 @@ pub enum Error {
     ConfigureTap(IoError),
     #[error("Unable to retrieve features: {0}")]
     GetFeatures(IoError),
-    #[error("Missing multiqueue support in the kernel.")]
+    #[error("Missing multiqueue support in the kernel")]
     MultiQueueKernelSupport,
     #[error("ioctl failed: {0}")]
     IoctlError(IoError),
     #[error("Failed to create a socket: {0}")]
     NetUtil(NetUtilError),
-    #[error("Invalid interface name.")]
+    #[error("Invalid interface name")]
     InvalidIfname,
     #[error("Error parsing MAC data: {0}")]
     MacParsing(IoError),

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -62,9 +62,9 @@ const VIRTIO_BALLOON_F_REPORTING: u64 = 5;
 pub enum Error {
     #[error("Guest gave us bad memory addresses.: {0}")]
     GuestMemory(GuestMemoryError),
-    #[error("Guest gave us a write only descriptor that protocol says to read from.")]
+    #[error("Guest gave us a write only descriptor that protocol says to read from")]
     UnexpectedWriteOnlyDescriptor,
-    #[error("Guest sent us invalid request.")]
+    #[error("Guest sent us invalid request")]
     InvalidRequest,
     #[error("Fallocate fail.: {0}")]
     FallocateFail(std::io::Error),

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -284,39 +284,39 @@ unsafe impl ByteValued for VirtioIommuFault {}
 
 #[derive(Error, Debug)]
 enum Error {
-    #[error("Guest gave us bad memory addresses: {0}.")]
+    #[error("Guest gave us bad memory addresses: {0}")]
     GuestMemory(GuestMemoryError),
-    #[error("Guest gave us a write only descriptor that protocol says to read from.")]
+    #[error("Guest gave us a write only descriptor that protocol says to read from")]
     UnexpectedWriteOnlyDescriptor,
-    #[error("Guest gave us a read only descriptor that protocol says to write to.")]
+    #[error("Guest gave us a read only descriptor that protocol says to write to")]
     UnexpectedReadOnlyDescriptor,
-    #[error("Guest gave us too few descriptors in a descriptor chain.")]
+    #[error("Guest gave us too few descriptors in a descriptor chain")]
     DescriptorChainTooShort,
-    #[error("Guest gave us a buffer that was too short to use.")]
+    #[error("Guest gave us a buffer that was too short to use")]
     BufferLengthTooSmall,
-    #[error("Guest sent us invalid request.")]
+    #[error("Guest sent us invalid request")]
     InvalidRequest,
-    #[error("Guest sent us invalid ATTACH request.")]
+    #[error("Guest sent us invalid ATTACH request")]
     InvalidAttachRequest,
-    #[error("Guest sent us invalid DETACH request.")]
+    #[error("Guest sent us invalid DETACH request")]
     InvalidDetachRequest,
-    #[error("Guest sent us invalid MAP request.")]
+    #[error("Guest sent us invalid MAP request")]
     InvalidMapRequest,
-    #[error("Invalid to map because the domain is in bypass mode.")]
+    #[error("Invalid to map because the domain is in bypass mode")]
     InvalidMapRequestBypassDomain,
-    #[error("Invalid to map because the domain is missing.")]
+    #[error("Invalid to map because the domain is missing")]
     InvalidMapRequestMissingDomain,
-    #[error("Guest sent us invalid UNMAP request.")]
+    #[error("Guest sent us invalid UNMAP request")]
     InvalidUnmapRequest,
-    #[error("Invalid to unmap because the domain is in bypass mode.")]
+    #[error("Invalid to unmap because the domain is in bypass mode")]
     InvalidUnmapRequestBypassDomain,
-    #[error("Invalid to unmap because the domain is missing.")]
+    #[error("Invalid to unmap because the domain is missing")]
     InvalidUnmapRequestMissingDomain,
-    #[error("Guest sent us invalid PROBE request.")]
+    #[error("Guest sent us invalid PROBE request")]
     InvalidProbeRequest,
-    #[error("Failed to performing external mapping: {0}.")]
+    #[error("Failed to performing external mapping: {0}")]
     ExternalMapping(io::Error),
-    #[error("Failed to performing external unmapping: {0}.")]
+    #[error("Failed to performing external unmapping: {0}")]
     ExternalUnmapping(io::Error),
     #[error("Failed adding used index: {0}")]
     QueueAddUsed(virtio_queue::Error),

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -80,7 +80,7 @@ const VIRTIO_F_NOTIFICATION_DATA: u32 = 38;
 
 #[derive(Error, Debug)]
 pub enum ActivateError {
-    #[error("Failed to activate virtio device.")]
+    #[error("Failed to activate virtio device")]
     BadActivate,
     #[error("Failed to clone exit event fd: {0}")]
     CloneExitEventFd(std::io::Error),
@@ -112,7 +112,7 @@ pub enum Error {
     VhostUserUpdateMemory(vhost_user::Error),
     #[error("Failed to add memory region vhost-user: {0}")]
     VhostUserAddMemoryRegion(vhost_user::Error),
-    #[error("Failed to set shared memory region.")]
+    #[error("Failed to set shared memory region")]
     SetShmRegionsNotSupported,
     #[error("Failed to process net queue: {0}")]
     NetQueuePair(::net_util::NetQueuePairError),

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -105,15 +105,15 @@ const VIRTIO_MEM_F_ACPI_PXM: u8 = 0;
 pub enum Error {
     #[error("Guest gave us bad memory addresses: {0}")]
     GuestMemory(GuestMemoryError),
-    #[error("Guest gave us a write only descriptor that protocol says to read from.")]
+    #[error("Guest gave us a write only descriptor that protocol says to read from")]
     UnexpectedWriteOnlyDescriptor,
-    #[error("Guest gave us a read only descriptor that protocol says to write to.")]
+    #[error("Guest gave us a read only descriptor that protocol says to write to")]
     UnexpectedReadOnlyDescriptor,
-    #[error("Guest gave us too few descriptors in a descriptor chain.")]
+    #[error("Guest gave us too few descriptors in a descriptor chain")]
     DescriptorChainTooShort,
-    #[error("Guest gave us a buffer that was too short to use.")]
+    #[error("Guest gave us a buffer that was too short to use")]
     BufferLengthTooSmall,
-    #[error("Guest sent us invalid request.")]
+    #[error("Guest sent us invalid request")]
     InvalidRequest,
     #[error("Failed to EventFd write: {0}")]
     EventFdWriteFail(std::io::Error),
@@ -133,9 +133,9 @@ pub enum Error {
     DmaMap(std::io::Error),
     #[error("Failed DMA unmapping: {0}")]
     DmaUnmap(std::io::Error),
-    #[error("Invalid DMA mapping handler.")]
+    #[error("Invalid DMA mapping handler")]
     InvalidDmaMappingHandler,
-    #[error("Not activated by the guest.")]
+    #[error("Not activated by the guest")]
     NotActivatedByGuest,
     #[error("Unknown request type: {0}")]
     UnkownRequestType(u16),

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -43,9 +43,9 @@ pub use self::vu_common_ctrl::VhostUserConfig;
 pub enum Error {
     #[error("Failed accepting connection: {0}")]
     AcceptConnection(io::Error),
-    #[error("Invalid available address.")]
+    #[error("Invalid available address")]
     AvailAddress,
-    #[error("Queue number  is not correct.")]
+    #[error("Queue number  is not correct")]
     BadQueueNum,
     #[error("Failed binding vhost-user socket: {0}")]
     BindSocket(io::Error),
@@ -53,7 +53,7 @@ pub enum Error {
     CreateKillEventFd(io::Error),
     #[error("Cloning kill eventfd failed: {0}")]
     CloneKillEventFd(io::Error),
-    #[error("Invalid descriptor table address.")]
+    #[error("Invalid descriptor table address")]
     DescriptorTableAddress,
     #[error("Signal used queue failed: {0}")]
     FailedSignalingUsedQueue(io::Error),
@@ -65,7 +65,7 @@ pub enum Error {
     VhostUserCreateMaster(VhostError),
     #[error("Failed to open vhost device: {0}")]
     VhostUserOpen(VhostError),
-    #[error("Connection to socket failed.")]
+    #[error("Connection to socket failed")]
     VhostUserConnect,
     #[error("Get features failed: {0}")]
     VhostUserGetFeatures(VhostError),
@@ -75,7 +75,7 @@ pub enum Error {
     VhostUserGetProtocolFeatures(VhostError),
     #[error("Get vring base failed: {0}")]
     VhostUserGetVringBase(VhostError),
-    #[error("Vhost-user Backend not support vhost-user protocol.")]
+    #[error("Vhost-user Backend not support vhost-user protocol")]
     VhostUserProtocolNotSupport,
     #[error("Set owner failed: {0}")]
     VhostUserSetOwner(VhostError),
@@ -121,17 +121,17 @@ pub enum Error {
     VhostUserSetInflight(VhostError),
     #[error("Failed setting the log base: {0}")]
     VhostUserSetLogBase(VhostError),
-    #[error("Invalid used address.")]
+    #[error("Invalid used address")]
     UsedAddress,
-    #[error("Invalid features provided from vhost-user backe.")]
+    #[error("Invalid features provided from vhost-user backe")]
     InvalidFeatures,
-    #[error("Missing file descriptor for the region.")]
+    #[error("Missing file descriptor for the region")]
     MissingRegionFd,
-    #[error("Missing IrqFd.")]
+    #[error("Missing IrqFd")]
     MissingIrqFd,
     #[error("Failed getting the available index: {0}")]
     GetAvailableIndex(QueueError),
-    #[error("Migration is not supported by this vhost-user device.")]
+    #[error("Migration is not supported by this vhost-user device")]
     MigrationNotSupported,
     #[error("Failed creating memfd: {0}")]
     MemfdCreate(io::Error),
@@ -141,7 +141,7 @@ pub enum Error {
     SetSeals(io::Error),
     #[error("Failed creating new mmap region: {0}")]
     NewMmapRegion(MmapRegionError),
-    #[error("Could not find the shm log region.")]
+    #[error("Could not find the shm log region")]
     MissingShmLogRegion,
 }
 type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
Considering error messages will be mostly nested, ensuring no
punctuation at the end will make the error log more readable.

Signed-off-by: Bo Chen <chen.bo@intel.com>
