### PR TITLE
pci, virtio-devices: Move VirtioPciDevice to the new restore design

### DIFF
--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -62,6 +62,7 @@ impl PciRoot {
                     0,
                     0,
                     None,
+                    None,
                 ),
             }
         }

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -19,12 +19,13 @@ pub use self::configuration::{
     PciBarConfiguration, PciBarPrefetchable, PciBarRegionType, PciCapability, PciCapabilityId,
     PciClassCode, PciConfiguration, PciExpressCapabilityId, PciHeaderType, PciMassStorageSubclass,
     PciNetworkControllerSubclass, PciProgrammingInterface, PciSerialBusSubClass, PciSubclass,
+    PCI_CONFIGURATION_ID,
 };
 pub use self::device::{
     BarReprogrammingParams, DeviceRelocation, Error as PciDeviceError, PciDevice,
 };
 pub use self::msi::{msi_num_enabled_vectors, MsiCap, MsiConfig};
-pub use self::msix::{MsixCap, MsixConfig, MsixTableEntry, MSIX_TABLE_ENTRY_SIZE};
+pub use self::msix::{MsixCap, MsixConfig, MsixTableEntry, MSIX_CONFIG_ID, MSIX_TABLE_ENTRY_SIZE};
 pub use self::vfio::{VfioPciDevice, VfioPciError};
 pub use self::vfio_user::{VfioUserDmaMapping, VfioUserPciDevice, VfioUserPciDeviceError};
 use serde::de::Visitor;

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -663,7 +663,9 @@ impl VfioCommon {
             msix_cap.table_size(),
             interrupt_source_group.clone(),
             bdf.into(),
-        );
+            None,
+        )
+        .unwrap();
 
         self.interrupt.msix = Some(VfioMsix {
             bar: msix_config,
@@ -1234,6 +1236,7 @@ impl VfioPciDevice {
             PciHeaderType::Device,
             0,
             0,
+            None,
             None,
         );
 

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -88,6 +88,7 @@ impl VfioUserPciDevice {
             0,
             0,
             None,
+            None,
         );
         let resettable = client.lock().unwrap().resettable();
         if resettable {

--- a/virtio-devices/src/transport/mod.rs
+++ b/virtio-devices/src/transport/mod.rs
@@ -5,7 +5,7 @@
 use vmm_sys_util::eventfd::EventFd;
 mod pci_common_config;
 mod pci_device;
-pub use pci_common_config::VirtioPciCommonConfig;
+pub use pci_common_config::{VirtioPciCommonConfig, VIRTIO_PCI_COMMON_CONFIG_ID};
 pub use pci_device::{VirtioPciDevice, VirtioPciDeviceActivator};
 
 pub trait VirtioTransport {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3450,6 +3450,7 @@ impl DeviceManager {
                 pci_segment_id > 0 || device_type != VirtioDeviceType::Block as u32,
                 dma_handler,
                 self.pending_activations.clone(),
+                vm_migration::snapshot_from_id(self.snapshot.as_ref(), id.as_str()),
             )
             .map_err(DeviceManagerError::VirtioDevice)?,
         ));


### PR DESCRIPTION
The code for restoring a VirtioPciDevice has been updated, including the dependencies VirtioPciCommonConfig, MsixConfig and PciConfiguration.

It's important to note that both PciConfiguration and MsixConfig still have restore() implementations because Vfio and VfioUser devices still rely on the old way for restore.