### PR TITLE
memory_manager: use MFD_CLOEXEC flag when creating memory fd

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1252,9 +1252,8 @@ impl MemoryManager {
                 }
             }
             None => {
-                let fd = Self::memfd_create(
-                    &ffi::CString::new("ch_ram").unwrap(),
-                    if hugepages {
+                let flags = libc::MFD_CLOEXEC
+                    | if hugepages {
                         libc::MFD_HUGETLB
                             | if let Some(hugepage_size) = hugepage_size {
                                 /*
@@ -1274,9 +1273,9 @@ impl MemoryManager {
                             }
                     } else {
                         0
-                    },
-                )
-                .map_err(Error::SharedFileCreate)?;
+                    };
+                let fd = Self::memfd_create(&ffi::CString::new("ch_ram").unwrap(), flags)
+                    .map_err(Error::SharedFileCreate)?;
 
                 let f = unsafe { File::from_raw_fd(fd) };
                 f.set_len(size as u64).map_err(Error::SharedFileSetLen)?;


### PR DESCRIPTION
Until there is a need for sharing the memory fd with a child process, we should err on the safe side to close it on exec.

Signed-off-by: Wei Liu <liuwe@microsoft.com>