### PR TITLE
virtio-devices: Fix high overhead of creating virtio-blk caused by io_uring

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2100,7 +2100,7 @@ impl DeviceManager {
                 ImageType::FixedVhd => {
                     // Use asynchronous backend relying on io_uring if the
                     // syscalls are supported.
-                    if self.io_uring_is_supported() && !disk_cfg.disable_io_uring {
+                    if !disk_cfg.disable_io_uring && self.io_uring_is_supported() {
                         info!("Using asynchronous fixed VHD disk file (io_uring)");
                         Box::new(
                             FixedVhdDiskAsync::new(file)
@@ -2117,7 +2117,7 @@ impl DeviceManager {
                 ImageType::Raw => {
                     // Use asynchronous backend relying on io_uring if the
                     // syscalls are supported.
-                    if self.io_uring_is_supported() && !disk_cfg.disable_io_uring {
+                    if !disk_cfg.disable_io_uring && self.io_uring_is_supported() {
                         info!("Using asynchronous RAW disk file (io_uring)");
                         Box::new(RawFileDisk::new(file)) as Box<dyn DiskFile>
                     } else {


### PR DESCRIPTION
After several tests, `io_uring_is_supported()` causes about 38ms of overhead when creating virtio-blk. By modifying the position of `io_uring_is_supported()`, the overhead of creating virtio-blk is reduced to less than 1ms when close io_uring.

Added debug information to vmm/src/device_manager.rs. Disabling io_uring and mounting virtio-blk with "--disk", the log shows the following message.
```
cloud-hypervisor: 6.728455ms: <vmm> DEBUG:vmm/src/device_manager.rs:2118 -- point 1
cloud-hypervisor: 45.277803ms: <vmm> DEBUG:vmm/src/device_manager.rs:2125 -- point 2
```
After the fix, the log shows the following message when disabling io_uring and mounting virtio-blk with "--disk".
```
cloud-hypervisor: 6.693065ms: <vmm> DEBUG:vmm/src/device_manager.rs:2118 -- point 1
cloud-hypervisor: 6.718652ms: <vmm> DEBUG:vmm/src/device_manager.rs:2125 -- point 2
```