### PR TITLE
Improve RAM memory allocation

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -117,6 +117,9 @@ needing access to the guest RAM content.
 By default this option is turned off, which results in performing `mmap(2)`
 with `MAP_PRIVATE` flag.
 
+If `hugepages=on` then the value of this field is ignored as huge pages always
+requires `MAP_SHARED`.
+
 _Example_
 
 ```
@@ -139,6 +142,9 @@ specified size for the VMM to use. Failure to do so may result in strange VMM
 behaviour, e.g. error with `ReadKernelImage` is common. If there is a strange
 error with `hugepages` enabled, just disable it or check whether there are enough
 huge pages.
+
+If `hugepages=on` then the value of `shared` is ignored as huge pages always
+requires `MAP_SHARED`.
 
 By default this option is turned off.
 
@@ -271,6 +277,9 @@ other processes running on the host. One can use this option when running
 vhost-user devices as part of the VM device model, as they will be driven
 by standalone daemons needing access to the guest RAM content.
 
+If `hugepages=on` then the value of this field is ignored as huge pages always
+requires `MAP_SHARED`.
+
 By default this option is turned off, which result in performing `mmap(2)`
 with `MAP_PRIVATE` flag.
 
@@ -297,6 +306,9 @@ specified size for the VMM to use. Failure to do so may result in strange VMM
 behaviour, e.g. error with `ReadKernelImage` is common. If there is a strange
 error with `hugepages` enabled, just disable it or check whether there are enough
 huge pages.
+
+If `hugepages=on` then the value of `shared` is ignored as huge pages always
+requires `MAP_SHARED`.
 
 By default this option is turned off.
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1606,12 +1606,11 @@ impl Vmm {
             .unwrap()
             .lock()
             .unwrap()
-            .memory
-            .shared
+            .backed_by_shared_memory()
             && send_data_migration.local
         {
             return Err(MigratableError::MigrateSend(anyhow!(
-                "Local migration requires shared memory enabled"
+                "Local migration requires shared memory or hugepages enabled"
             )));
         }
 


### PR DESCRIPTION
- vmm: Refactor creation of the FileOffset for GuestRegionMmap::new()
- vmm: memory_manager: Split filesystem backed and anonymous RAM creation
- vmm: memory_manager: Only file back memory when required
- vmm: memory_manager: Avoid MAP_PRIVATE CoW with VFIO for hugepages too

Fixes: #4805
