### PR TITLE
vmm: Enable THP when using anonymous memory

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -20,12 +20,13 @@ struct MemoryConfig {
     hugepages: bool,
     hugepage_size: Option<u64>,
     prefault: bool,
+    thp: bool
     zones: Option<Vec<MemoryZoneConfig>>,
 }
 ```
 
 ```
---memory <memory>	Memory parameters "size=<guest_memory_size>,mergeable=on|off,shared=on|off,hugepages=on|off,hugepage_size=<hugepage_size>,hotplug_method=acpi|virtio-mem,hotplug_size=<hotpluggable_memory_size>,hotplugged_size=<hotplugged_memory_size>,prefault=on|off" [default: size=512M]
+--memory <memory>	Memory parameters "size=<guest_memory_size>,mergeable=on|off,shared=on|off,hugepages=on|off,hugepage_size=<hugepage_size>,hotplug_method=acpi|virtio-mem,hotplug_size=<hotpluggable_memory_size>,hotplugged_size=<hotplugged_memory_size>,prefault=on|off,thp=on|off" [default: size=512M,thp=on]
 ```
 
 ### `size`
@@ -175,6 +176,25 @@ _Example_
 
 ```
 --memory size=1G,prefault=on
+```
+
+### `thp`
+
+Specifies if private anonymous memory for the guest (i.e. `shared=off` and no
+backing file) should be labelled `MADV_HUGEPAGE` with `madvise(2)` indicating
+to the kernel that this memory may be backed with huge pages transparently.
+
+The use of transparent huge pages can improve the performance of the guest as
+there will fewer virtualisation related page faults. Unlike using
+`hugepages=on` a specific number of huge pages do not need to be allocated by
+the kernel.
+
+By default this option is turned on.
+
+_Example_
+
+```
+--memory size=1G,thp=on
 ```
 
 ## Advanced Parameters

--- a/fuzz/fuzz_targets/mem.rs
+++ b/fuzz/fuzz_targets/mem.rs
@@ -137,6 +137,7 @@ fn create_dummy_virtio_mem(bytes: &[u8; VIRTIO_MEM_DATA_SIZE]) -> (Mem, Arc<Gues
         None,
         numa_id,
         None,
+        false,
     )
     .unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ fn create_app(default_vcpus: String, default_memory: String, default_rng: String
                      hotplug_method=acpi|virtio-mem,\
                      hotplug_size=<hotpluggable_memory_size>,\
                      hotplugged_size=<hotplugged_memory_size>,\
-                     prefault=on|off\"",
+                     prefault=on|off,thp=on|off\"",
                 )
                 .default_value(default_memory)
                 .group("vm-config"),
@@ -676,6 +676,7 @@ mod unit_tests {
                 hugepage_size: None,
                 prefault: false,
                 zones: None,
+                thp: true,
             },
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -726,6 +726,9 @@ components:
         prefault:
           type: boolean
           default: false
+        thp:
+          type: boolean
+          default: true
         zones:
           type: array
           items:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -658,7 +658,8 @@ impl MemoryConfig {
             .add("shared")
             .add("hugepages")
             .add("hugepage_size")
-            .add("prefault");
+            .add("prefault")
+            .add("thp");
         parser.parse(memory).map_err(Error::ParseMemory)?;
 
         let size = parser
@@ -701,6 +702,11 @@ impl MemoryConfig {
             .convert::<Toggle>("prefault")
             .map_err(Error::ParseMemory)?
             .unwrap_or(Toggle(false))
+            .0;
+        let thp = parser
+            .convert::<Toggle>("thp")
+            .map_err(Error::ParseMemory)?
+            .unwrap_or(Toggle(true))
             .0;
 
         let zones: Option<Vec<MemoryZoneConfig>> = if let Some(memory_zones) = &memory_zones {
@@ -788,6 +794,7 @@ impl MemoryConfig {
             hugepage_size,
             prefault,
             zones,
+            thp,
         })
     }
 
@@ -2727,6 +2734,7 @@ mod tests {
                 hugepage_size: None,
                 prefault: false,
                 zones: None,
+                thp: true,
             },
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2062,6 +2062,7 @@ mod unit_tests {
                 hugepage_size: None,
                 prefault: false,
                 zones: None,
+                thp: true,
             },
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -139,6 +139,10 @@ impl Default for HotplugMethod {
     }
 }
 
+fn default_memoryconfig_thp() -> bool {
+    true
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct MemoryConfig {
     pub size: u64,
@@ -160,6 +164,8 @@ pub struct MemoryConfig {
     pub prefault: bool,
     #[serde(default)]
     pub zones: Option<Vec<MemoryZoneConfig>>,
+    #[serde(default = "default_memoryconfig_thp")]
+    pub thp: bool,
 }
 
 pub const DEFAULT_MEMORY_MB: u64 = 512;
@@ -177,6 +183,7 @@ impl Default for MemoryConfig {
             hugepage_size: None,
             prefault: false,
             zones: None,
+            thp: true,
         }
     }
 }


### PR DESCRIPTION
If the memory is not backed by a file then it is possible to enable
Transparent Huge Pages on the memory and take advantage of the benefits
of huge pages without requiring the specific allocation of an appropriate
number of huge pages.

TEST=Boot and see that in /proc/`pidof cloud-hypervisor`/smaps that the
region is now THPeligible (and that also pages are being used.)

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
