### PR TITLE
vmm: Create vCPUs before the DeviceManager

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -291,6 +291,7 @@ pub struct Vcpu {
     #[cfg(target_arch = "aarch64")]
     mpidr: u64,
     saved_state: Option<CpuState>,
+    configured: bool,
 }
 
 impl Vcpu {
@@ -316,6 +317,7 @@ impl Vcpu {
             #[cfg(target_arch = "aarch64")]
             mpidr: 0,
             saved_state: None,
+            configured: false,
         })
     }
 
@@ -719,15 +721,28 @@ impl CpuManager {
         })))
     }
 
-    fn create_vcpu(
-        &mut self,
-        cpu_id: u8,
+    fn create_vcpu(&mut self, cpu_id: u8) -> Result<Arc<Mutex<Vcpu>>> {
+        info!("Creating vCPU: cpu_id = {}", cpu_id);
+
+        let vcpu = Arc::new(Mutex::new(Vcpu::new(
+            cpu_id,
+            &self.vm,
+            Some(self.vm_ops.clone()),
+        )?));
+
+        // Adding vCPU to the CpuManager's vCPU list.
+        self.vcpus.push(vcpu.clone());
+
+        Ok(vcpu)
+    }
+
+    fn configure_vcpu(
+        &self,
+        vcpu: Arc<Mutex<Vcpu>>,
         entry_point: Option<EntryPoint>,
         snapshot: Option<Snapshot>,
     ) -> Result<()> {
-        info!("Creating vCPU: cpu_id = {}", cpu_id);
-
-        let mut vcpu = Vcpu::new(cpu_id, &self.vm, Some(self.vm_ops.clone()))?;
+        let mut vcpu = vcpu.lock().unwrap();
 
         if let Some(snapshot) = snapshot {
             // AArch64 vCPUs should be initialized after created.
@@ -750,15 +765,13 @@ impl CpuManager {
                 .expect("Failed to configure vCPU");
         }
 
-        // Adding vCPU to the CpuManager's vCPU list.
-        let vcpu = Arc::new(Mutex::new(vcpu));
-        self.vcpus.push(vcpu);
+        vcpu.configured = true;
 
         Ok(())
     }
 
     /// Only create new vCPUs if there aren't any inactive ones to reuse
-    fn create_vcpus(&mut self, desired_vcpus: u8, entry_point: Option<EntryPoint>) -> Result<()> {
+    fn create_vcpus(&mut self, desired_vcpus: u8) -> Result<()> {
         info!(
             "Request to create new vCPUs: desired = {}, max = {}, allocated = {}, present = {}",
             desired_vcpus,
@@ -773,7 +786,18 @@ impl CpuManager {
 
         // Only create vCPUs in excess of all the allocated vCPUs.
         for cpu_id in self.vcpus.len() as u8..desired_vcpus {
-            self.create_vcpu(cpu_id, entry_point, None)?;
+            self.create_vcpu(cpu_id)?;
+        }
+
+        Ok(())
+    }
+
+    fn configure_vcpus(&mut self, entry_point: Option<EntryPoint>) -> Result<()> {
+        for vcpu in self.vcpus.clone() {
+            if vcpu.lock().unwrap().configured {
+                continue;
+            }
+            self.configure_vcpu(vcpu, entry_point, None)?;
         }
 
         Ok(())
@@ -1100,7 +1124,8 @@ impl CpuManager {
     pub fn create_boot_vcpus(&mut self, entry_point: Option<EntryPoint>) -> Result<()> {
         trace_scoped!("create_boot_vcpus");
 
-        self.create_vcpus(self.boot_vcpus(), entry_point)
+        self.create_vcpus(self.boot_vcpus())?;
+        self.configure_vcpus(entry_point)
     }
 
     // Starts all the vCPUs that the VM is booting with. Blocks until all vCPUs are running.
@@ -1128,7 +1153,8 @@ impl CpuManager {
 
         match desired_vcpus.cmp(&self.present_vcpus()) {
             cmp::Ordering::Greater => {
-                self.create_vcpus(desired_vcpus, None)?;
+                self.create_vcpus(desired_vcpus)?;
+                self.configure_vcpus(None)?;
                 self.activate_vcpus(desired_vcpus, true, None)?;
                 Ok(true)
             }
@@ -2060,8 +2086,13 @@ impl Snapshottable for CpuManager {
     fn restore(&mut self, snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
         for (cpu_id, snapshot) in snapshot.snapshots.iter() {
             info!("Restoring VCPU {}", cpu_id);
-            self.create_vcpu(cpu_id.parse::<u8>().unwrap(), None, Some(*snapshot.clone()))
+            let vcpu = self
+                .create_vcpu(cpu_id.parse::<u8>().unwrap())
                 .map_err(|e| MigratableError::Restore(anyhow!("Could not create vCPU {:?}", e)))?;
+            self.configure_vcpu(vcpu, None, Some(*snapshot.clone()))
+                .map_err(|e| {
+                    MigratableError::Restore(anyhow!("Could not configure vCPU {:?}", e))
+                })?
         }
 
         Ok(())

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -13,6 +13,7 @@ use crate::config::{
     ConsoleOutputMode, DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, UserDeviceConfig,
     VdpaConfig, VhostMode, VmConfig, VsockConfig,
 };
+use crate::cpu::{CpuManager, CPU_MANAGER_ACPI_SIZE};
 use crate::device_tree::{DeviceNode, DeviceTree};
 use crate::interrupt::LegacyUserspaceInterruptManager;
 use crate::interrupt::MsiInterruptManager;
@@ -848,6 +849,9 @@ pub struct DeviceManager {
     // Memory Manager
     memory_manager: Arc<Mutex<MemoryManager>>,
 
+    // CPU Manager
+    cpu_manager: Arc<Mutex<CpuManager>>,
+
     // The virtio devices on the system
     virtio_devices: Vec<MetaVirtioDevice>,
 
@@ -950,12 +954,15 @@ pub struct DeviceManager {
 impl DeviceManager {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        #[cfg(target_arch = "x86_64")] io_bus: Arc<Bus>,
+        mmio_bus: Arc<Bus>,
         hypervisor_type: HypervisorType,
         vm: Arc<dyn hypervisor::Vm>,
         config: Arc<Mutex<VmConfig>>,
         memory_manager: Arc<Mutex<MemoryManager>>,
-        exit_evt: &EventFd,
-        reset_evt: &EventFd,
+        cpu_manager: Arc<Mutex<CpuManager>>,
+        exit_evt: EventFd,
+        reset_evt: EventFd,
         seccomp_action: SeccompAction,
         numa_nodes: NumaNodes,
         activate_evt: &EventFd,
@@ -964,6 +971,7 @@ impl DeviceManager {
         boot_id_list: BTreeSet<String>,
         timestamp: Instant,
         snapshot: Option<Snapshot>,
+        dynamic: bool,
     ) -> DeviceManagerResult<Arc<Mutex<Self>>> {
         trace_scoped!("DeviceManager::new");
 
@@ -996,8 +1004,8 @@ impl DeviceManager {
         let address_manager = Arc::new(AddressManager {
             allocator: memory_manager.lock().unwrap().allocator(),
             #[cfg(target_arch = "x86_64")]
-            io_bus: Arc::new(Bus::new()),
-            mmio_bus: Arc::new(Bus::new()),
+            io_bus,
+            mmio_bus,
             vm: vm.clone(),
             device_tree: Arc::clone(&device_tree),
             pci_mmio_allocators,
@@ -1043,6 +1051,26 @@ impl DeviceManager {
             )?);
         }
 
+        if dynamic {
+            let acpi_address = address_manager
+                .allocator
+                .lock()
+                .unwrap()
+                .allocate_platform_mmio_addresses(None, CPU_MANAGER_ACPI_SIZE as u64, None)
+                .ok_or(DeviceManagerError::AllocateMmioAddress)?;
+
+            address_manager
+                .mmio_bus
+                .insert(
+                    cpu_manager.clone(),
+                    acpi_address.0,
+                    CPU_MANAGER_ACPI_SIZE as u64,
+                )
+                .map_err(DeviceManagerError::BusError)?;
+
+            cpu_manager.lock().unwrap().set_acpi_address(acpi_address);
+        }
+
         let device_manager = DeviceManager {
             hypervisor_type,
             address_manager: Arc::clone(&address_manager),
@@ -1053,6 +1081,7 @@ impl DeviceManager {
             ged_notification_device: None,
             config,
             memory_manager,
+            cpu_manager,
             virtio_devices: Vec::new(),
             bus_devices: Vec::new(),
             device_id_cnt: Wrapping(0),
@@ -1065,8 +1094,8 @@ impl DeviceManager {
             iommu_attached_devices: None,
             pci_segments,
             device_tree,
-            exit_evt: exit_evt.try_clone().map_err(DeviceManagerError::EventFd)?,
-            reset_evt: reset_evt.try_clone().map_err(DeviceManagerError::EventFd)?,
+            exit_evt,
+            reset_evt,
             #[cfg(target_arch = "aarch64")]
             id_to_dev_info: HashMap::new(),
             seccomp_action,
@@ -1135,6 +1164,11 @@ impl DeviceManager {
         let mut virtio_devices: Vec<MetaVirtioDevice> = Vec::new();
 
         let interrupt_controller = self.add_interrupt_controller()?;
+
+        self.cpu_manager
+            .lock()
+            .unwrap()
+            .set_interrupt_controller(interrupt_controller.clone());
 
         // Now we can create the legacy interrupt manager, which needs the freshly
         // formed IOAPIC device.

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -87,8 +87,6 @@ use std::{result, str, thread};
 use thiserror::Error;
 use tracer::trace_scoped;
 use vm_device::Bus;
-#[cfg(target_arch = "x86_64")]
-use vm_device::BusDevice;
 #[cfg(feature = "tdx")]
 use vm_memory::{Address, ByteValued, GuestMemory, GuestMemoryRegion};
 use vm_memory::{Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic};
@@ -365,8 +363,6 @@ struct VmOpsHandler {
     #[cfg(target_arch = "x86_64")]
     io_bus: Arc<Bus>,
     mmio_bus: Arc<Bus>,
-    #[cfg(target_arch = "x86_64")]
-    pci_config_io: Arc<Mutex<dyn BusDevice>>,
 }
 
 impl VmOps for VmOpsHandler {
@@ -408,17 +404,6 @@ impl VmOps for VmOpsHandler {
 
     #[cfg(target_arch = "x86_64")]
     fn pio_read(&self, port: u64, data: &mut [u8]) -> result::Result<(), HypervisorVmError> {
-        use pci::{PCI_CONFIG_IO_PORT, PCI_CONFIG_IO_PORT_SIZE};
-
-        if (PCI_CONFIG_IO_PORT..(PCI_CONFIG_IO_PORT + PCI_CONFIG_IO_PORT_SIZE)).contains(&port) {
-            self.pci_config_io.lock().unwrap().read(
-                PCI_CONFIG_IO_PORT,
-                port - PCI_CONFIG_IO_PORT,
-                data,
-            );
-            return Ok(());
-        }
-
         if let Err(vm_device::BusError::MissingAddressRange) = self.io_bus.read(port, data) {
             info!("Guest PIO read to unregistered address 0x{:x}", port);
         }
@@ -427,17 +412,6 @@ impl VmOps for VmOpsHandler {
 
     #[cfg(target_arch = "x86_64")]
     fn pio_write(&self, port: u64, data: &[u8]) -> result::Result<(), HypervisorVmError> {
-        use pci::{PCI_CONFIG_IO_PORT, PCI_CONFIG_IO_PORT_SIZE};
-
-        if (PCI_CONFIG_IO_PORT..(PCI_CONFIG_IO_PORT + PCI_CONFIG_IO_PORT_SIZE)).contains(&port) {
-            self.pci_config_io.lock().unwrap().write(
-                PCI_CONFIG_IO_PORT,
-                port - PCI_CONFIG_IO_PORT,
-                data,
-            );
-            return Ok(());
-        }
-
         match self.io_bus.write(port, data) {
             Err(vm_device::BusError::MissingAddressRange) => {
                 info!("Guest PIO write to unregistered address 0x{:x}", port);
@@ -534,50 +508,25 @@ impl Vm {
         #[cfg(not(feature = "guest_debug"))]
         let stop_on_boot = false;
 
-        let device_manager = DeviceManager::new(
-            hypervisor.hypervisor_type(),
-            vm.clone(),
-            config.clone(),
-            memory_manager.clone(),
-            &exit_evt,
-            &reset_evt,
-            seccomp_action.clone(),
-            numa_nodes.clone(),
-            &activate_evt,
-            force_iommu,
-            restoring,
-            boot_id_list,
-            timestamp,
-            snapshot_from_id(snapshot, DEVICE_MANAGER_SNAPSHOT_ID),
-        )
-        .map_err(Error::DeviceManager)?;
-
         let memory = memory_manager.lock().unwrap().guest_memory();
         #[cfg(target_arch = "x86_64")]
-        let io_bus = Arc::clone(device_manager.lock().unwrap().io_bus());
-        let mmio_bus = Arc::clone(device_manager.lock().unwrap().mmio_bus());
+        let io_bus = Arc::new(Bus::new());
+        let mmio_bus = Arc::new(Bus::new());
 
-        #[cfg(target_arch = "x86_64")]
-        let pci_config_io =
-            device_manager.lock().unwrap().pci_config_io() as Arc<Mutex<dyn BusDevice>>;
         let vm_ops: Arc<dyn VmOps> = Arc::new(VmOpsHandler {
             memory,
             #[cfg(target_arch = "x86_64")]
-            io_bus,
-            mmio_bus,
-            #[cfg(target_arch = "x86_64")]
-            pci_config_io,
+            io_bus: io_bus.clone(),
+            mmio_bus: mmio_bus.clone(),
         });
 
-        let exit_evt_clone = exit_evt.try_clone().map_err(Error::EventFdClone)?;
         let cpus_config = { &config.lock().unwrap().cpus.clone() };
         let cpu_manager = cpu::CpuManager::new(
             cpus_config,
-            &device_manager,
             &memory_manager,
             vm.clone(),
-            exit_evt_clone,
-            reset_evt,
+            exit_evt.try_clone().map_err(Error::EventFdClone)?,
+            reset_evt.try_clone().map_err(Error::EventFdClone)?,
             #[cfg(feature = "guest_debug")]
             vm_debug_evt,
             hypervisor.clone(),
@@ -588,6 +537,34 @@ impl Vm {
             &numa_nodes,
         )
         .map_err(Error::CpuManager)?;
+
+        #[cfg(feature = "tdx")]
+        let dynamic = !tdx_enabled;
+        #[cfg(not(feature = "tdx"))]
+        let dynamic = true;
+
+        let device_manager = DeviceManager::new(
+            #[cfg(target_arch = "x86_64")]
+            io_bus,
+            mmio_bus,
+            hypervisor.hypervisor_type(),
+            vm.clone(),
+            config.clone(),
+            memory_manager.clone(),
+            cpu_manager.clone(),
+            exit_evt.try_clone().map_err(Error::EventFdClone)?,
+            reset_evt,
+            seccomp_action.clone(),
+            numa_nodes.clone(),
+            &activate_evt,
+            force_iommu,
+            restoring,
+            boot_id_list,
+            timestamp,
+            snapshot_from_id(snapshot, DEVICE_MANAGER_SNAPSHOT_ID),
+            dynamic,
+        )
+        .map_err(Error::DeviceManager)?;
 
         let on_tty = unsafe { libc::isatty(libc::STDIN_FILENO) } != 0;
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -538,6 +538,12 @@ impl Vm {
         )
         .map_err(Error::CpuManager)?;
 
+        cpu_manager
+            .lock()
+            .unwrap()
+            .create_boot_vcpus()
+            .map_err(Error::CpuManager)?;
+
         #[cfg(feature = "tdx")]
         let dynamic = !tdx_enabled;
         #[cfg(not(feature = "tdx"))]
@@ -2090,7 +2096,7 @@ impl Vm {
         self.cpu_manager
             .lock()
             .unwrap()
-            .create_boot_vcpus(entry_point)
+            .configure_vcpus(entry_point)
             .map_err(Error::CpuManager)?;
 
         #[cfg(feature = "tdx")]


### PR DESCRIPTION
This PR moves lots of code around to be able to create both the `CpuManager` and associated `Vcpu`s before the `DeviceManager`'s creation. The reason is to unify the boot sequence for both `x86_64` and `aarch64` architectures. And given `aarch64` requires the vCPU to be created in order to create the vGIC (equivalent of the vLAPIC in case of `x86_64`), we decided to defer the creation of the `DeviceManager` as much as possible.

A follow up PR (specifically for `aarch64`) will be required to move the vGIC creation out of the `Gic` object, and make sure the vGIC is created before the `DeviceManager`. At the time the `DeviceManager` gets created, all vCPUs and associated vGIC will be ready so that registering `irqfd`s and setting up GSI routes will succeed.

/cc @michael2012z 