### PR TITLE
Split Snapsot/restore test case for better separation

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5689,6 +5689,7 @@ mod common_parallel {
     // through each ssh command. There's no need to perform a dedicated test to
     // verify the migration went well for virtio-net.
     #[test]
+    #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_hotplug_virtiomem() {
         _test_snapshot_restore(true);
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5693,6 +5693,11 @@ mod common_parallel {
         _test_snapshot_restore(true);
     }
 
+    #[test]
+    fn test_snapshot_restore_basic() {
+        _test_snapshot_restore(false);
+    }
+
     fn _test_snapshot_restore(use_hotplug: bool) {
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(focal));


### PR DESCRIPTION
The current snapshot_restore test case has many things to test specifically balloon/hotplug.
We should have a basic snapshot/restore test case for better separation to verify if
basic test works. For example MSHV does not support hot plugging virtio-mem yet
but there is not way to run a test case to see if basic snapshot/restore works for MSHV.
This PR separates out these two scenario for better debugging/development.