### PR TITLE
virtio-devices: seccomp: Move mprotect() to virtio common rules

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -88,7 +88,6 @@ fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_getrandom, vec![]),
         (libc::SYS_io_uring_enter, vec![]),
         (libc::SYS_lseek, vec![]),
-        (libc::SYS_mprotect, vec![]),
         (libc::SYS_prctl, vec![]),
         (libc::SYS_pread64, vec![]),
         (libc::SYS_preadv, vec![]),
@@ -103,7 +102,6 @@ fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
 fn virtio_console_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
         (libc::SYS_ioctl, create_virtio_console_ioctl_seccomp_rule()),
-        (libc::SYS_mprotect, vec![]),
         (libc::SYS_prctl, vec![]),
         (libc::SYS_sched_getaffinity, vec![]),
         (libc::SYS_set_robust_list, vec![]),
@@ -111,10 +109,7 @@ fn virtio_console_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
 }
 
 fn virtio_iommu_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
-    vec![
-        (libc::SYS_ioctl, create_virtio_iommu_ioctl_seccomp_rule()),
-        (libc::SYS_mprotect, vec![]),
-    ]
+    vec![(libc::SYS_ioctl, create_virtio_iommu_ioctl_seccomp_rule())]
 }
 
 fn virtio_mem_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
@@ -148,7 +143,6 @@ fn virtio_pmem_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
 
 fn virtio_rng_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
-        (libc::SYS_mprotect, vec![]),
         (libc::SYS_prctl, vec![]),
         (libc::SYS_sched_getaffinity, vec![]),
         (libc::SYS_set_robust_list, vec![]),
@@ -209,7 +203,6 @@ fn virtio_vsock_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
 
 fn virtio_watchdog_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
-        (libc::SYS_mprotect, vec![]),
         (libc::SYS_prctl, vec![]),
         (libc::SYS_sched_getaffinity, vec![]),
         (libc::SYS_set_robust_list, vec![]),
@@ -254,6 +247,7 @@ fn virtio_thread_common() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_futex, vec![]),
         (libc::SYS_madvise, vec![]),
         (libc::SYS_mmap, vec![]),
+        (libc::SYS_mprotect, vec![]),
         (libc::SYS_munmap, vec![]),
         (libc::SYS_openat, vec![]),
         (libc::SYS_read, vec![]),


### PR DESCRIPTION
It's perfectly reasonable to expect if that some virtio threads trigger
libc behaviour that needs mprotect() that all virtio threads would do
the same.

Fixes: #4874

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
