### PR TITLE
Temporarily turn off AArch64 CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,6 +127,7 @@ pipeline {
                         }
                     }
                 }
+                /* Temporarily turn off AArch64 integration test in Jenkins for server maintainance
                 stage('AArch64 worker build') {
                     agent { node { label 'bionic-arm64' } }
                     when {
@@ -202,6 +203,7 @@ pipeline {
                         }
                     }
                 }
+                */
                 stage('Worker build - Windows guest') {
                     agent { node { label 'jammy' } }
                     when {


### PR DESCRIPTION
Temporarily turn off AArch64 integration test in Jenkins for server maintenance.

The server will be absent for about 1 week.