### PR TITLE
hypervisor: do not get and set MSR_IA32_TSC for MSHV

### DIFF
--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -703,7 +703,6 @@ impl cpu::Vcpu for MshvVcpu {
             msr!(msr_index::MSR_LSTAR),
             msr!(msr_index::MSR_KERNEL_GS_BASE),
             msr!(msr_index::MSR_SYSCALL_MASK),
-            msr!(msr_index::MSR_IA32_TSC),
             msr_data!(msr_index::MSR_MTRRdefType, MTRR_ENABLE | MTRR_MEM_TYPE_WB),
         ]
         .to_vec()


### PR DESCRIPTION
Setting that MSR causes the reference TSC page to be disabled.

That's giving a huge perf hit to the guest.