### PR TITLE
Deny undocumented unsafe blocks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,22 +34,22 @@ jobs:
           override: true
 
       - name: Build (default features)
-        run: cargo rustc --locked --bin cloud-hypervisor -- -D warnings
+        run: cargo rustc --locked --bin cloud-hypervisor -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Build (kvm)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "kvm"  -- -D warnings
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "kvm"  -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Build (default features + tdx)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "tdx" -- -D warnings
+        run: cargo rustc --locked --bin cloud-hypervisor --features "tdx" -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Build (default features + guest_debug)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "guest_debug" -- -D warnings
+        run: cargo rustc --locked --bin cloud-hypervisor --features "guest_debug" -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Build (mshv)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv"  -- -D warnings
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv"  -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Build (mshv + kvm)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv,kvm"  -- -D warnings
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv,kvm"  -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Release Build (default features)
         run: cargo build --locked --all --release --target=${{ matrix.target }}

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -53,28 +53,28 @@ jobs:
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --locked --all --all-targets --no-default-features --tests --features "kvm" -- -D warnings
+          args: --locked --all --all-targets --no-default-features --tests --features "kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Clippy (default features)
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --locked --all --all-targets --tests -- -D warnings
+          args: --locked --all --all-targets --tests -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Clippy (default features + guest_debug)
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --locked --all --all-targets --tests --features "guest_debug" -- -D warnings
+          args: --locked --all --all-targets --tests --features "guest_debug" -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Clippy (default features + tracing)
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --locked --all --all-targets --tests --features "tracing" -- -D warnings
+          args: --locked --all --all-targets --tests --features "tracing" -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Clippy (mshv)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
@@ -82,7 +82,7 @@ jobs:
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --locked --all --all-targets --no-default-features --tests --features "mshv" -- -D warnings
+          args: --locked --all --all-targets --no-default-features --tests --features "mshv" -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Clippy (mshv + kvm)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
@@ -90,7 +90,7 @@ jobs:
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --locked --all --all-targets --no-default-features --tests --features "mshv,kvm" -- -D warnings
+          args: --locked --all --all-targets --no-default-features --tests --features "mshv,kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Clippy (kvm + tdx)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
@@ -98,7 +98,7 @@ jobs:
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --locked --all --all-targets --no-default-features --tests --features "tdx,kvm" -- -D warnings
+          args: --locked --all --all-targets --no-default-features --tests --features "tdx,kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Check build did not modify any files
         run: test -z "$(git status --porcelain)"

--- a/acpi_tables/src/sdt.rs
+++ b/acpi_tables/src/sdt.rs
@@ -98,6 +98,7 @@ impl Sdt {
     /// Write a value at the given offset
     pub fn write<T>(&mut self, offset: usize, value: T) {
         assert!((offset + (std::mem::size_of::<T>() - 1)) < self.data.len());
+        // SAFETY: The assertion above makes sure we don't do out of bounds write.
         unsafe {
             *(((self.data.as_mut_ptr() as usize) + offset) as *mut T) = value;
         }

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -99,7 +99,7 @@ pub use x86_64::{
 #[cfg(target_arch = "x86_64")]
 #[inline(always)]
 fn pagesize() -> usize {
-    // Trivially safe
+    // SAFETY: Trivially safe
     unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }
 }
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -125,9 +125,11 @@ struct MemmapTableEntryWrapper(hvm_memmap_table_entry);
 #[derive(Copy, Clone, Default)]
 struct ModlistEntryWrapper(hvm_modlist_entry);
 
-// SAFETY: These data structures only contain a series of integers
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for StartInfoWrapper {}
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for MemmapTableEntryWrapper {}
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for ModlistEntryWrapper {}
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
@@ -661,6 +663,7 @@ pub fn generate_common_cpuid(
     // Copy CPU identification string
     for i in 0x8000_0002..=0x8000_0004 {
         cpuid.retain(|c| c.function != i);
+        // SAFETY: call cpuid with valid leaves
         let leaf = unsafe { std::arch::x86_64::__cpuid(i) };
         cpuid.push(CpuIdEntry {
             function: i,
@@ -1011,6 +1014,7 @@ pub fn initramfs_load_addr(
 }
 
 pub fn get_host_cpu_phys_bits() -> u8 {
+    // SAFETY: call cpuid with valid leaves
     unsafe {
         let leaf = x86_64::__cpuid(0x8000_0000);
 
@@ -1121,6 +1125,7 @@ fn update_cpuid_sgx(
 
     // Get host CPUID for leaf 0x12, subleaf 0x2. This is to retrieve EPC
     // properties such as confidentiality and integrity.
+    // SAFETY: call cpuid with valid leaves
     let leaf = unsafe { std::arch::x86_64::__cpuid_count(0x12, 0x2) };
 
     for (i, epc_section) in epc_sections.iter().enumerate() {

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -37,11 +37,17 @@ struct MpfIntelWrapper(mpspec::mpf_intel);
 
 // SAFETY: These `mpspec` wrapper types are only data, reading them from data is a safe initialization.
 unsafe impl ByteValued for MpcBusWrapper {}
+// SAFETY: see above
 unsafe impl ByteValued for MpcCpuWrapper {}
+// SAFETY: see above
 unsafe impl ByteValued for MpcIntsrcWrapper {}
+// SAFETY: see above
 unsafe impl ByteValued for MpcIoapicWrapper {}
+// SAFETY: see above
 unsafe impl ByteValued for MpcTableWrapper {}
+// SAFETY: see above
 unsafe impl ByteValued for MpcLintsrcWrapper {}
+// SAFETY: see above
 unsafe impl ByteValued for MpfIntelWrapper {}
 
 #[derive(Debug)]
@@ -95,7 +101,7 @@ const CPU_FEATURE_APIC: u32 = 0x200;
 const CPU_FEATURE_FPU: u32 = 0x001;
 
 fn compute_checksum<T: Copy>(v: &T) -> u8 {
-    // Safe because we are only reading the bytes within the size of the `T` reference `v`.
+    // SAFETY: we are only reading the bytes within the size of the `T` reference `v`.
     let v_slice = unsafe { slice::from_raw_parts(v as *const T as *const u8, mem::size_of::<T>()) };
     let mut checksum: u8 = 0;
     for i in v_slice.iter() {

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -67,7 +67,7 @@ const PCI_SUPPORTED: u64 = 1 << 7;
 const IS_VIRTUAL_MACHINE: u8 = 1 << 4;
 
 fn compute_checksum<T: Copy>(v: &T) -> u8 {
-    // Safe because we are only reading the bytes within the size of the `T` reference `v`.
+    // SAFETY: we are only reading the bytes within the size of the `T` reference `v`.
     let v_slice = unsafe { slice::from_raw_parts(v as *const T as *const u8, mem::size_of::<T>()) };
     let mut checksum: u8 = 0;
     for i in v_slice.iter() {
@@ -145,11 +145,15 @@ struct SmbiosEndOfTable {
     handle: u16,
 }
 
-// SAFETY: These data structures only contain a series of integers
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for Smbios30Entrypoint {}
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for SmbiosBiosInfo {}
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for SmbiosSysInfo {}
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for SmbiosOemStrings {}
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for SmbiosEndOfTable {}
 
 fn write_and_incr<T: ByteValued>(

--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -80,7 +80,7 @@ pub fn parse_tdvf_sections(file: &mut File) -> Result<Vec<TdvfSection>, TdvfErro
         .map_err(TdvfError::ReadDescriptor)?;
 
     let mut descriptor: TdvfDescriptor = Default::default();
-    // Safe as we read exactly the size of the descriptor header
+    // SAFETY: we read exactly the size of the descriptor header
     file.read_exact(unsafe {
         std::slice::from_raw_parts_mut(
             &mut descriptor as *mut _ as *mut u8,
@@ -107,7 +107,7 @@ pub fn parse_tdvf_sections(file: &mut File) -> Result<Vec<TdvfSection>, TdvfErro
     let mut sections = Vec::new();
     sections.resize_with(descriptor.num_sections as usize, TdvfSection::default);
 
-    // Safe as we read exactly the advertised sections
+    // SAFETY: we read exactly the advertised sections
     file.read_exact(unsafe {
         std::slice::from_raw_parts_mut(
             sections.as_mut_ptr() as *mut u8,
@@ -211,12 +211,17 @@ struct TdPayload {
     payload_info: PayloadInfo,
 }
 
-// SAFETY: These data structures only contain a series of integers
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for HobHeader {}
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for HobHandoffInfoTable {}
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for HobResourceDescriptor {}
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for HobGuidType {}
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for PayloadInfo {}
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for TdPayload {}
 
 pub struct TdHob {

--- a/block_util/src/async_io.rs
+++ b/block_util/src/async_io.rs
@@ -54,11 +54,13 @@ enum BlockSize {
 impl DiskTopology {
     fn is_block_device(f: &mut File) -> std::io::Result<bool> {
         let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: FFI call with a valid fd and buffer
         let ret = unsafe { libc::fstat(f.as_raw_fd(), stat.as_mut_ptr()) };
         if ret != 0 {
             return Err(std::io::Error::last_os_error());
         }
 
+        // SAFETY: stat is valid at this point
         let is_block = unsafe { (*stat.as_ptr()).st_mode & S_IFMT == S_IFBLK };
         Ok(is_block)
     }
@@ -67,6 +69,7 @@ impl DiskTopology {
     #[allow(clippy::useless_conversion)]
     fn query_block_size(f: &mut File, block_size_type: BlockSize) -> std::io::Result<u64> {
         let mut block_size = 0;
+        // SAFETY: FFI call with correct arguments
         let ret = unsafe {
             ioctl(
                 f.as_raw_fd(),

--- a/block_util/src/lib.rs
+++ b/block_util/src/lib.rs
@@ -381,7 +381,7 @@ impl Request {
             let iov_base = if (origin_ptr as u64) % SECTOR_SIZE != 0 {
                 let layout =
                     Layout::from_size_align(*data_len as usize, SECTOR_SIZE as usize).unwrap();
-                // Safe because layout has non-zero size
+                // SAFETY: layout has non-zero size
                 let aligned_ptr = unsafe { alloc_zeroed(layout) };
                 if aligned_ptr.is_null() {
                     return Err(ExecuteError::TemporaryBufferAllocation(
@@ -392,7 +392,7 @@ impl Request {
                 // We need to perform the copy beforehand in case we're writing
                 // data out.
                 if request_type == RequestType::Out {
-                    // Safe because destination buffer has been allocated with
+                    // SAFETY: destination buffer has been allocated with
                     // the proper size.
                     unsafe {
                         std::ptr::copy(origin_ptr as *const u8, aligned_ptr, *data_len as usize)
@@ -467,7 +467,7 @@ impl Request {
             // We need to perform the copy after the data has been read inside
             // the aligned buffer in case we're reading data in.
             if self.request_type == RequestType::In {
-                // Safe because origin buffer has been allocated with the
+                // SAFETY: origin buffer has been allocated with the
                 // proper size.
                 unsafe {
                     std::ptr::copy(
@@ -479,7 +479,7 @@ impl Request {
             }
 
             // Free the temporary aligned buffer.
-            // Safe because aligned_ptr was allocated by alloc_zeroed with the same
+            // SAFETY: aligned_ptr was allocated by alloc_zeroed with the same
             // layout
             unsafe {
                 dealloc(
@@ -528,8 +528,9 @@ pub struct VirtioBlockGeometry {
     pub sectors: u8,
 }
 
-// SAFETY: these data structures only contain a series of integers
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for VirtioBlockConfig {}
+// SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for VirtioBlockGeometry {}
 
 /// Check if io_uring for block device can be used on the current system, as
@@ -596,6 +597,7 @@ where
         // Convert libc::iovec into IoSliceMut
         let mut slices = Vec::new();
         for iovec in iovecs.iter() {
+            // SAFETY: on Linux IoSliceMut wraps around libc::iovec
             slices.push(IoSliceMut::new(unsafe { std::mem::transmute(*iovec) }));
         }
 
@@ -628,6 +630,7 @@ where
         // Convert libc::iovec into IoSlice
         let mut slices = Vec::new();
         for iovec in iovecs.iter() {
+            // SAFETY: on Linux IoSliceMut wraps around libc::iovec
             slices.push(IoSlice::new(unsafe { std::mem::transmute(*iovec) }));
         }
 

--- a/block_util/src/raw_async.rs
+++ b/block_util/src/raw_async.rs
@@ -81,7 +81,7 @@ impl AsyncIo for RawFileAsync {
     ) -> AsyncIoResult<()> {
         let (submitter, mut sq, _) = self.io_uring.split();
 
-        // Safe because we know the file descriptor is valid and we
+        // SAFETY: we know the file descriptor is valid and we
         // relied on vm-memory to provide the buffer address.
         let _ = unsafe {
             sq.push(
@@ -109,7 +109,7 @@ impl AsyncIo for RawFileAsync {
     ) -> AsyncIoResult<()> {
         let (submitter, mut sq, _) = self.io_uring.split();
 
-        // Safe because we know the file descriptor is valid and we
+        // SAFETY: we know the file descriptor is valid and we
         // relied on vm-memory to provide the buffer address.
         let _ = unsafe {
             sq.push(
@@ -133,7 +133,7 @@ impl AsyncIo for RawFileAsync {
         if let Some(user_data) = user_data {
             let (submitter, mut sq, _) = self.io_uring.split();
 
-            // Safe because we know the file descriptor is valid.
+            // SAFETY: we know the file descriptor is valid.
             let _ = unsafe {
                 sq.push(
                     &opcode::Fsync::new(types::Fd(self.fd))
@@ -148,6 +148,7 @@ impl AsyncIo for RawFileAsync {
             sq.sync();
             submitter.submit().map_err(AsyncIoError::Fsync)?;
         } else {
+            // SAFETY: FFI call with a valid fd
             unsafe { libc::fsync(self.fd) };
         }
 

--- a/block_util/src/raw_sync.rs
+++ b/block_util/src/raw_sync.rs
@@ -68,6 +68,7 @@ impl AsyncIo for RawFileSync {
         iovecs: Vec<libc::iovec>,
         user_data: u64,
     ) -> AsyncIoResult<()> {
+        // SAFETY: FFI call with valid arguments
         let result = unsafe {
             libc::preadv(
                 self.fd as libc::c_int,
@@ -92,6 +93,7 @@ impl AsyncIo for RawFileSync {
         iovecs: Vec<libc::iovec>,
         user_data: u64,
     ) -> AsyncIoResult<()> {
+        // SAFETY: FFI call with valid arguments
         let result = unsafe {
             libc::pwritev(
                 self.fd as libc::c_int,
@@ -111,6 +113,7 @@ impl AsyncIo for RawFileSync {
     }
 
     fn fsync(&mut self, user_data: Option<u64>) -> AsyncIoResult<()> {
+        // SAFETY: FFI call
         let result = unsafe { libc::fsync(self.fd as libc::c_int) };
         if result < 0 {
             return Err(AsyncIoError::Fsync(std::io::Error::last_os_error()));

--- a/devices/src/legacy/cmos.rs
+++ b/devices/src/legacy/cmos.rs
@@ -97,7 +97,7 @@ impl BusDevice for Cmos {
                 let day;
                 let month;
                 let year;
-                // The clock_gettime and gmtime_r calls are safe as long as the structs they are
+                // SAFETY: The clock_gettime and gmtime_r calls are safe as long as the structs they are
                 // given are large enough, and neither of them fail. It is safe to zero initialize
                 // the tm and timespec struct because it contains only plain data.
                 let update_in_progress = unsafe {

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -121,7 +121,7 @@ impl LocalTime {
             tm_zone: std::ptr::null(),
         };
 
-        // Safe because the parameters are valid.
+        // SAFETY: the parameters are valid.
         unsafe {
             libc::clock_gettime(libc::CLOCK_REALTIME, &mut timespec);
             libc::localtime_r(&timespec.tv_sec, &mut tm);
@@ -179,7 +179,7 @@ impl Default for TimestampUs {
 #[allow(dead_code)]
 pub fn timestamp_cycles() -> u64 {
     #[cfg(target_arch = "x86_64")]
-    // Safe because there's nothing that can go wrong with this call.
+    // SAFETY: there's nothing that can go wrong with this call.
     unsafe {
         std::arch::x86_64::_rdtsc() as u64
     }
@@ -199,7 +199,7 @@ pub fn get_time(clock_type: ClockType) -> u64 {
         tv_sec: 0,
         tv_nsec: 0,
     };
-    // Safe because the parameters are valid.
+    // SAFETY: the parameters are valid.
     unsafe { libc::clock_gettime(clock_type.into(), &mut time_struct) };
     seconds_to_nanoseconds(time_struct.tv_sec).unwrap() as u64 + (time_struct.tv_nsec as u64)
 }

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -272,6 +272,7 @@ impl LapicState {
         use std::io::Cursor;
         use std::mem;
 
+        // SAFETY: plain old data type
         let sliceu8 = unsafe {
             // This array is only accessed as parts of a u32 word, so interpret it as a u8 array.
             // Cursors are only readable on arrays of u8, not i8(c_char).
@@ -290,6 +291,7 @@ impl LapicState {
         use std::io::Cursor;
         use std::mem;
 
+        // SAFETY: plain old data type
         let sliceu8 = unsafe {
             // This array is only accessed as parts of a u32 word, so interpret it as a u8 array.
             // Cursors are only readable on arrays of u8, not i8(c_char).

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -2066,6 +2066,7 @@ impl cpu::Vcpu for KvmVcpu {
     #[cfg(feature = "tdx")]
     fn get_tdx_exit_details(&mut self) -> cpu::Result<TdxExitDetails> {
         let kvm_run = self.fd.get_kvm_run();
+        // SAFETY: accessing a union field in a valid structure
         let tdx_vmcall = unsafe { &mut kvm_run.__bindgen_anon_1.tdx.u.vmcall };
 
         tdx_vmcall.status_code = TDG_VP_VMCALL_INVALID_OPERAND;
@@ -2089,6 +2090,7 @@ impl cpu::Vcpu for KvmVcpu {
     #[cfg(feature = "tdx")]
     fn set_tdx_status(&mut self, status: TdxExitStatus) {
         let kvm_run = self.fd.get_kvm_run();
+        // SAFETY: accessing a union field in a valid structure
         let tdx_vmcall = unsafe { &mut kvm_run.__bindgen_anon_1.tdx.u.vmcall };
 
         tdx_vmcall.status_code = match status {

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -458,12 +458,13 @@ impl cpu::Vcpu for MshvVcpu {
                         _ => {}
                     }
 
-                    // SAFETY: access_info is valid, otherwise we won't be here
                     assert!(
+                        // SAFETY: access_info is valid, otherwise we won't be here
                         (unsafe { access_info.__bindgen_anon_1.string_op() } != 1),
                         "String IN/OUT not supported"
                     );
                     assert!(
+                        // SAFETY: access_info is valid, otherwise we won't be here
                         (unsafe { access_info.__bindgen_anon_1.rep_prefix() } != 1),
                         "Rep IN/OUT not supported"
                     );

--- a/net_gen/src/iff.rs
+++ b/net_gen/src/iff.rs
@@ -1187,6 +1187,7 @@ pub struct ifreq {
 
 impl Default for ifreq {
     fn default() -> Self {
+        // SAFETY: all zeros is a valid pattern for this data type
         unsafe { std::mem::zeroed() }
     }
 }

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -66,32 +66,34 @@ fn create_sockaddr(ip_addr: net::Ipv4Addr) -> net_gen::sockaddr {
     let addr_in = net_gen::sockaddr_in {
         sin_family: net_gen::AF_INET as u16,
         sin_port: 0,
+        // SAFETY: ip_addr can be safely transmute to in_addr
         sin_addr: unsafe { mem::transmute(ip_addr.octets()) },
         __pad: [0; 8usize],
     };
 
+    // SAFETY: addr_in can be safely transmute to sockaddr
     unsafe { mem::transmute(addr_in) }
 }
 
 fn create_inet_socket() -> Result<net::UdpSocket> {
-    // This is safe since we check the return value.
+    // SAFETY: we check the return value.
     let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
     if sock < 0 {
         return Err(Error::CreateSocket(IoError::last_os_error()));
     }
 
-    // This is safe; nothing else will use or hold onto the raw sock fd.
+    // SAFETY: nothing else will use or hold onto the raw sock fd.
     Ok(unsafe { net::UdpSocket::from_raw_fd(sock) })
 }
 
 fn create_unix_socket() -> Result<net::UdpSocket> {
-    // This is safe since we check the return value.
+    // SAFETY: we check the return value.
     let sock = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_DGRAM, 0) };
     if sock < 0 {
         return Err(Error::CreateSocket(IoError::last_os_error()));
     }
 
-    // This is safe; nothing else will use or hold onto the raw sock fd.
+    // SAFETY: nothing else will use or hold onto the raw sock fd.
     Ok(unsafe { net::UdpSocket::from_raw_fd(sock) })
 }
 

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -83,6 +83,7 @@ impl TxVirtio {
             }
 
             let len = if !iovecs.is_empty() {
+                // SAFETY: FFI call with correct arguments
                 let result = unsafe {
                     libc::writev(
                         tap.as_raw_fd() as libc::c_int,
@@ -217,6 +218,7 @@ impl RxVirtio {
             }
 
             let len = if !iovecs.is_empty() {
+                // SAFETY: FFI call with correct arguments
                 let result = unsafe {
                     libc::readv(
                         tap.as_raw_fd() as libc::c_int,

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1422,6 +1422,7 @@ impl VfioPciDevice {
                 )?;
 
                 for area in sparse_areas.iter() {
+                    // SAFETY: FFI call with correct arguments
                     let host_addr = unsafe {
                         libc::mmap(
                             null_mut(),
@@ -1488,6 +1489,7 @@ impl VfioPciDevice {
                     error!("Could not remove the userspace memory region: {}", e);
                 }
 
+                // SAFETY: FFI call with correct arguments
                 let ret = unsafe {
                     libc::munmap(
                         user_memory_region.host_addr as *mut libc::c_void,

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -181,6 +181,7 @@ impl VfioUserPciDevice {
                 };
 
                 for s in mmaps.iter() {
+                    // SAFETY: FFI call with correct arguments
                     let host_addr = unsafe {
                         libc::mmap(
                             null_mut(),
@@ -247,6 +248,7 @@ impl VfioUserPciDevice {
                 }
 
                 // Remove mmaps
+                // SAFETY: FFI call with correct arguments
                 let ret = unsafe {
                     libc::munmap(
                         user_memory_region.host_addr as *mut libc::c_void,

--- a/qcow/src/raw_file.rs
+++ b/qcow/src/raw_file.rs
@@ -231,6 +231,7 @@ impl Write for RawFile {
                 return Err(io::Error::last_os_error());
             }
 
+            // SAFETY: tmp_ptr is at least rounded_len long
             let tmp_buf = unsafe { slice::from_raw_parts_mut(tmp_ptr, rounded_len) };
 
             // This can eventually replaced with read_at once its interface

--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -343,6 +343,7 @@ impl RateLimiter {
         let timer_fd = TimerFd::new()?;
         // Note: vmm_sys_util::TimerFd::new() open the fd w/o O_NONBLOCK. We manually add this flag
         // so that `Self::event_handler` won't be blocked with `vmm_sys_util::TimerFd::wait()`.
+        // SAFETY: FFI calls.
         let ret = unsafe {
             let fd = timer_fd.as_raw_fd();
             let mut flags = libc::fcntl(fd, libc::F_GETFL);

--- a/src/main.rs
+++ b/src/main.rs
@@ -453,6 +453,7 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
                 .convert("fd")
                 .map_err(Error::ParsingEventMonitor)?
                 .unwrap();
+            // SAFETY: fd is valid
             unsafe { File::from_raw_fd(fd) }
         } else if parser.is_set("path") {
             std::fs::OpenOptions::new()
@@ -592,6 +593,7 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
 
 fn main() {
     // Ensure all created files (.e.g sockets) are only accessible by this user
+    // SAFETY: trivially safe
     let _ = unsafe { libc::umask(0o077) };
 
     let (default_vcpus, default_memory, default_rng) = prepare_default_values();
@@ -607,6 +609,7 @@ fn main() {
         }
     };
 
+    // SAFETY: trivially safe
     let on_tty = unsafe { libc::isatty(libc::STDIN_FILENO) } != 0;
     if on_tty {
         // Don't forget to set the terminal in canonical mode

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#![allow(clippy::undocumented_unsafe_blocks)]
+
 use once_cell::sync::Lazy;
 use serde_json::Value;
 use ssh2::Session;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-
+#![allow(clippy::undocumented_unsafe_blocks)]
 // When enabling the `mshv` feature, we skip quite some tests and
 // hence have known dead-code. This annotation silences dead-code
 // related warnings for our quality workflow to pass.

--- a/tpm/src/emulator.rs
+++ b/tpm/src/emulator.rs
@@ -133,7 +133,7 @@ impl Emulator {
         let mut res: PtmResult = 0;
 
         let mut fds = [-1, -1];
-        // Safe because return value of the unsafe call is checked
+        // SAFETY: FFI calls and return value of the unsafe call is checked
         unsafe {
             let ret = libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr());
             if ret == -1 {
@@ -289,7 +289,7 @@ impl Emulator {
     /// Function to write to data socket and read the response from it
     fn unix_tx_bufs(&mut self) -> Result<()> {
         let isselftest: bool;
-        // Safe as type "sockaddr_storage" is valid with an all-zero byte-pattern value
+        // SAFETY: type "sockaddr_storage" is valid with an all-zero byte-pattern value
         let mut addr: sockaddr_storage = unsafe { mem::zeroed() };
         let mut len = mem::size_of::<sockaddr_storage>() as socklen_t;
 
@@ -307,7 +307,7 @@ impl Emulator {
                 iov_len: cmd.input.len(),
             }; 1];
 
-            // Safe because all zero values from the unsafe method are updated before usage
+            // SAFETY: all zero values from the unsafe method are updated before usage
             let mut msghdr: libc::msghdr = unsafe { mem::zeroed() };
             msghdr.msg_name = ptr::null_mut();
             msghdr.msg_namelen = 0;
@@ -316,7 +316,7 @@ impl Emulator {
             msghdr.msg_control = ptr::null_mut();
             msghdr.msg_controllen = 0;
             msghdr.msg_flags = 0;
-            // Safe as the return value of the unsafe method is checked
+            // SAFETY: FFI call and the return value of the unsafe method is checked
             unsafe {
                 let ret = libc::sendmsg(self.data_fd, &msghdr, 0);
                 if ret == -1 {
@@ -328,7 +328,7 @@ impl Emulator {
             }
 
             cmd.output.fill(0);
-            // Safe as return value from unsafe method is checked
+            // SAFETY: FFI calls and return value from unsafe method is checked
             unsafe {
                 let ret = libc::recvfrom(
                     self.data_fd,

--- a/vfio_user/src/lib.rs
+++ b/vfio_user/src/lib.rs
@@ -190,16 +190,25 @@ struct DeviceReset {
     header: Header,
 }
 
-// SAFETY: these data structures only contain a sereis of integers
+// SAFETY: data structure only contain a sereis of integers
 unsafe impl ByteValued for Header {}
+// SAFETY: data structure only contain a sereis of integers
 unsafe impl ByteValued for Version {}
+// SAFETY: data structure only contain a sereis of integers
 unsafe impl ByteValued for DmaMap {}
+// SAFETY: data structure only contain a sereis of integers
 unsafe impl ByteValued for DmaUnmap {}
+// SAFETY: data structure only contain a sereis of integers
 unsafe impl ByteValued for DeviceGetInfo {}
+// SAFETY: data structure only contain a sereis of integers
 unsafe impl ByteValued for DeviceGetRegionInfo {}
+// SAFETY: data structure only contain a sereis of integers
 unsafe impl ByteValued for RegionAccess {}
+// SAFETY: data structure only contain a sereis of integers
 unsafe impl ByteValued for GetIrqInfo {}
+// SAFETY: data structure only contain a sereis of integers
 unsafe impl ByteValued for SetIrqs {}
+// SAFETY: data structure only contain a sereis of integers
 unsafe impl ByteValued for DeviceReset {}
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -591,8 +600,9 @@ impl Client {
                 break;
             }
 
-            // Safe because the `cap_data_ptr` is valid and the `cap_offset` is checked above
+            // SAFETY: `cap_data_ptr` is valid and the `cap_offset` is checked above
             let cap_ptr = unsafe { cap_data_ptr.offset(cap_offset as isize) };
+            // SAFETY: `cap_ptr` is valid
             let cap_header = unsafe { &*(cap_ptr as *const vfio_info_cap_header) };
             match cap_header.id as u32 {
                 VFIO_REGION_INFO_CAP_SPARSE_MMAP => {
@@ -604,7 +614,7 @@ impl Client {
                         );
                         break;
                     }
-                    // Safe because the `cap_ptr` is valid and its size is also checked above
+                    // SAFETY: `cap_ptr` is valid and its size is also checked above
                     let sparse_mmap = unsafe {
                         &*(cap_ptr as *mut u8 as *const vfio_region_info_cap_sparse_mmap)
                     };
@@ -616,8 +626,8 @@ impl Client {
                         cap_offset, mmap_cap_size, area_num, mmap_area_size, cap_size);
                         break;
                     }
-                    // Safe because the `sparse_mmap` is valid and its size is also checked above
                     let areas =
+                        // SAFETY: `sparse_mmap` is valid and its size is also checked above
                         unsafe { sparse_mmap.areas.as_slice(sparse_mmap.nr_areas as usize) };
                     for area in areas.iter() {
                         sparse_areas.push(*area);

--- a/vhdx/src/vhdx_header.rs
+++ b/vhdx/src/vhdx_header.rs
@@ -136,6 +136,7 @@ impl Header {
         f.read_exact(&mut buffer)
             .map_err(VhdxHeaderError::ReadHeader)?;
 
+        // SAFETY: buffer is of correct size and has been successfully filled.
         let header = unsafe { *(buffer.as_ptr() as *mut Header) };
         if header.signature != HEADER_SIGN {
             return Err(VhdxHeaderError::InvalidHeaderSign);
@@ -151,6 +152,7 @@ impl Header {
 
     /// Converts the header structure into a buffer
     fn get_header_as_buffer(&self, buffer: &mut [u8; HEADER_SIZE as usize]) {
+        // SAFETY: self is a valid header.
         let reference = unsafe {
             std::slice::from_raw_parts(self as *const Header as *const u8, HEADER_SIZE as usize)
         };
@@ -221,6 +223,7 @@ impl RegionTableHeader {
         f.read_exact(&mut buffer)
             .map_err(VhdxHeaderError::ReadRegionTableHeader)?;
 
+        // SAFETY: buffer is of correct size and has been successfully filled.
         let region_table_header = unsafe { *(buffer.as_ptr() as *mut RegionTableHeader) };
         if region_table_header.signature != REGION_SIGN {
             return Err(VhdxHeaderError::InvalidRegionSign);
@@ -337,6 +340,8 @@ pub struct RegionTableEntry {
 impl RegionTableEntry {
     /// Reads one Region Entry from a Region Table index that starts from 0
     pub fn new(buffer: &[u8]) -> Result<RegionTableEntry> {
+        assert!(buffer.len() == std::mem::size_of::<RegionTableEntry>());
+        // SAFETY: the assertion above makes sure the buffer size is correct.
         let mut region_table_entry = unsafe { *(buffer.as_ptr() as *mut RegionTableEntry) };
 
         let uuid = crate::uuid_from_guid(buffer);

--- a/vhdx/src/vhdx_metadata.rs
+++ b/vhdx/src/vhdx_metadata.rs
@@ -270,6 +270,8 @@ struct MetadataTableHeader {
 
 impl MetadataTableHeader {
     pub fn new(buffer: &[u8]) -> Result<MetadataTableHeader> {
+        assert!(buffer.len() == std::mem::size_of::<MetadataTableHeader>());
+        // SAFETY: the assertion above makes sure the buffer size is correct.
         let metadata_table_header = unsafe { *(buffer.as_ptr() as *mut MetadataTableHeader) };
 
         if metadata_table_header.signature != METADATA_SIGN {
@@ -301,6 +303,8 @@ pub struct MetadataTableEntry {
 impl MetadataTableEntry {
     /// Parse one metadata entry from the buffer
     fn new(buffer: &[u8]) -> Result<MetadataTableEntry> {
+        assert!(buffer.len() == std::mem::size_of::<MetadataTableEntry>());
+        // SAFETY: the assertion above makes sure the buffer size is correct.
         let mut metadata_table_entry = unsafe { *(buffer.as_ptr() as *mut MetadataTableEntry) };
 
         let uuid = crate::uuid_from_guid(buffer);

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -128,8 +128,8 @@ impl BalloonEpollHandler {
         let hva = memory
             .get_host_address(range_base)
             .map_err(Error::GuestMemory)?;
-        // Need unsafe to do syscall madvise
         let res =
+            // SAFETY: Need unsafe to do syscall madvise
             unsafe { libc::madvise(hva as *mut libc::c_void, range_len as libc::size_t, advice) };
         if res != 0 {
             return Err(Error::MadviseFail(io::Error::last_os_error()));
@@ -147,6 +147,7 @@ impl BalloonEpollHandler {
         ))?;
         if let Some(f_off) = region.file_offset() {
             let offset = range_base.0 - region.start_addr().0;
+            // SAFETY: FFI call with valid arguments
             let res = unsafe {
                 libc::fallocate64(
                     f_off.file().as_raw_fd(),

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -607,6 +607,7 @@ fn get_win_size(tty: &dyn AsRawFd) -> (u16, u16) {
     }
     let ws: WindowSize = WindowSize::default();
 
+    // SAFETY: FFI call with correct arguments
     unsafe {
         libc::ioctl(tty.as_raw_fd(), TIOCGWINSZ, &ws);
     }

--- a/virtio-devices/src/epoll_helper.rs
+++ b/virtio-devices/src/epoll_helper.rs
@@ -87,6 +87,7 @@ impl EpollHelper {
         // Create the epoll file descriptor
         let epoll_fd = epoll::create(true).map_err(EpollHelperError::CreateFd)?;
         // Use 'File' to enforce closing on 'epoll_fd'
+        // SAFETY: epoll_fd is a valid fd
         let epoll_file = unsafe { File::from_raw_fd(epoll_fd) };
 
         let mut helper = Self {

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -267,19 +267,31 @@ struct VirtioIommuFault {
     address: u64,
 }
 
-// SAFETY: these data structures only contain integers and have no implicit padding
+// SAFETY: data structure only contain integers and have no implicit padding
 unsafe impl ByteValued for VirtioIommuRange32 {}
+// SAFETY: data structure only contain integers and have no implicit padding
 unsafe impl ByteValued for VirtioIommuRange64 {}
+// SAFETY: data structure only contain integers and have no implicit padding
 unsafe impl ByteValued for VirtioIommuConfig {}
+// SAFETY: data structure only contain integers and have no implicit padding
 unsafe impl ByteValued for VirtioIommuReqHead {}
+// SAFETY: data structure only contain integers and have no implicit padding
 unsafe impl ByteValued for VirtioIommuReqTail {}
+// SAFETY: data structure only contain integers and have no implicit padding
 unsafe impl ByteValued for VirtioIommuReqAttach {}
+// SAFETY: data structure only contain integers and have no implicit padding
 unsafe impl ByteValued for VirtioIommuReqDetach {}
+// SAFETY: data structure only contain integers and have no implicit padding
 unsafe impl ByteValued for VirtioIommuReqMap {}
+// SAFETY: data structure only contain integers and have no implicit padding
 unsafe impl ByteValued for VirtioIommuReqUnmap {}
+// SAFETY: data structure only contain integers and have no implicit padding
 unsafe impl ByteValued for VirtioIommuReqProbe {}
+// SAFETY: data structure only contain integers and have no implicit padding
 unsafe impl ByteValued for VirtioIommuProbeProperty {}
+// SAFETY: data structure only contain integers and have no implicit padding
 unsafe impl ByteValued for VirtioIommuProbeResvMem {}
+// SAFETY: data structure only contain integers and have no implicit padding
 unsafe impl ByteValued for VirtioIommuFault {}
 
 #[derive(Error, Debug)]

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -417,6 +417,7 @@ impl MemEpollHandler {
     fn discard_memory_range(&self, offset: u64, size: u64) -> Result<(), Error> {
         // Use fallocate if the memory region is backed by a file.
         if let Some(fd) = self.host_fd {
+            // SAFETY: FFI call with valid arguments
             let res = unsafe {
                 libc::fallocate64(
                     fd,
@@ -435,6 +436,7 @@ impl MemEpollHandler {
         // Only use madvise if the memory region is not allocated with
         // hugepages.
         if !self.hugepages {
+            // SAFETY: FFI call with valid arguments
             let res = unsafe {
                 libc::madvise(
                     (self.host_addr + offset) as *mut libc::c_void,

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -666,8 +666,8 @@ impl VirtioPciDevice {
                     .unwrap();
             }
         } else {
-            // Safe since we know self.cap_pci_cfg_info.cap.cap.offset is 32bits long.
             let bar_offset: u32 =
+                // SAFETY: we know self.cap_pci_cfg_info.cap.cap.offset is 32bits long.
                 unsafe { std::mem::transmute(self.cap_pci_cfg_info.cap.cap.offset) };
             self.read_bar(0, bar_offset as u64, data)
         }
@@ -687,8 +687,8 @@ impl VirtioPciDevice {
             right[..data_len].copy_from_slice(data);
             None
         } else {
-            // Safe since we know self.cap_pci_cfg_info.cap.cap.offset is 32bits long.
             let bar_offset: u32 =
+                // SAFETY: we know self.cap_pci_cfg_info.cap.cap.offset is 32bits long.
                 unsafe { std::mem::transmute(self.cap_pci_cfg_info.cap.cap.offset) };
             self.write_bar(0, bar_offset as u64, data)
         }

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -95,6 +95,7 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
 
             let addr = self.mmap_cache_addr + offset;
             let flags = fs.flags[i];
+            // SAFETY: FFI call with valid arguments
             let ret = unsafe {
                 libc::mmap(
                     addr as *mut libc::c_void,
@@ -136,6 +137,7 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
             }
 
             let addr = self.mmap_cache_addr + offset;
+            // SAFETY: FFI call with valid arguments
             let ret = unsafe {
                 libc::mmap(
                     addr as *mut libc::c_void,
@@ -172,6 +174,7 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
 
             let addr = self.mmap_cache_addr + offset;
             let ret =
+                // SAFETY: FFI call with valid arguments
                 unsafe { libc::msync(addr as *mut libc::c_void, len as usize, libc::MS_SYNC) };
             if ret == -1 {
                 return Err(io::Error::last_os_error());
@@ -228,6 +231,7 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
                     == VhostUserFSSlaveMsgFlags::MAP_W
                 {
                     debug!("write: foffset={}, len={}", foffset, len);
+                    // SAFETY: FFI call with valid arguments
                     unsafe {
                         pwrite64(
                             fd.as_raw_fd(),
@@ -238,6 +242,7 @@ impl VhostUserMasterReqHandler for SlaveReqHandler {
                     }
                 } else {
                     debug!("read: foffset={}, len={}", foffset, len);
+                    // SAFETY: FFI call with valid arguments
                     unsafe { pread64(fd.as_raw_fd(), ptr as *mut c_void, len, foffset as off64_t) }
                 };
 
@@ -279,6 +284,7 @@ impl Default for VirtioFsConfig {
     }
 }
 
+// SAFETY: only a series of integers
 unsafe impl ByteValued for VirtioFsConfig {}
 
 pub struct Fs {

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -375,6 +375,7 @@ impl VhostUserCommon {
 
     pub fn shutdown(&mut self) {
         if let Some(vu) = &self.vu {
+            // SAFETY: trivially safe
             let _ = unsafe { libc::close(vu.lock().unwrap().socket_handle().as_raw_fd()) };
         }
 

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -451,7 +451,7 @@ impl VhostUserHandle {
         )
         .map_err(Error::MemfdCreate)?;
 
-        // Safe because we checked the file descriptor is valid
+        // SAFETY: we checked the file descriptor is valid
         let file = unsafe { File::from_raw_fd(fd) };
         // The size of the memory mapping corresponds to the size of a bitmap
         // covering all guest pages for addresses from 0 to the last physical
@@ -465,6 +465,7 @@ impl VhostUserHandle {
         file.set_len(mmap_size).map_err(Error::SetFileSize)?;
 
         // Set the seals
+        // SAFETY: FFI call with valid arguments
         let res = unsafe {
             libc::fcntl(
                 file.as_raw_fd(),
@@ -569,6 +570,7 @@ impl VhostUserHandle {
             // Be careful with the size, as it was based on u8, meaning we must
             // divide it by 8.
             let len = region.size() / 8;
+            // SAFETY: region is of size len
             let bitmap = unsafe {
                 // Cast the pointer to u64
                 let ptr = region.as_ptr() as *const u64;
@@ -582,6 +584,7 @@ impl VhostUserHandle {
 }
 
 fn memfd_create(name: &ffi::CStr, flags: u32) -> std::result::Result<RawFd, std::io::Error> {
+    // SAFETY: FFI call with valid arguments
     let res = unsafe { libc::syscall(libc::SYS_memfd_create, name.as_ptr(), flags) };
 
     if res < 0 {

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -239,7 +239,7 @@ impl VsockPacket {
     /// Provides in-place, byte-slice, access to the vsock packet header.
     ///
     pub fn hdr(&self) -> &[u8] {
-        // This is safe since bound checks have already been performed when creating the packet
+        // SAFETY: bound checks have already been performed when creating the packet
         // from the virtq descriptor.
         unsafe { std::slice::from_raw_parts(self.hdr as *const u8, VSOCK_PKT_HDR_SIZE) }
     }
@@ -247,7 +247,7 @@ impl VsockPacket {
     /// Provides in-place, byte-slice, mutable access to the vsock packet header.
     ///
     pub fn hdr_mut(&mut self) -> &mut [u8] {
-        // This is safe since bound checks have already been performed when creating the packet
+        // SAFETY: bound checks have already been performed when creating the packet
         // from the virtq descriptor.
         unsafe { std::slice::from_raw_parts_mut(self.hdr, VSOCK_PKT_HDR_SIZE) }
     }
@@ -261,7 +261,7 @@ impl VsockPacket {
     ///            is stored in the packet header, and accessible via `VsockPacket::len()`.
     pub fn buf(&self) -> Option<&[u8]> {
         self.buf.map(|ptr| {
-            // This is safe since bound checks have already been performed when creating the packet
+            // SAFETY: bound checks have already been performed when creating the packet
             // from the virtq descriptor.
             unsafe { std::slice::from_raw_parts(ptr as *const u8, self.buf_size) }
         })
@@ -276,7 +276,7 @@ impl VsockPacket {
     ///            is stored in the packet header, and accessible via `VsockPacket::len()`.
     pub fn buf_mut(&mut self) -> Option<&mut [u8]> {
         self.buf.map(|ptr| {
-            // This is safe since bound checks have already been performed when creating the packet
+            // SAFETY: bound checks have already been performed when creating the packet
             // from the virtq descriptor.
             unsafe { std::slice::from_raw_parts_mut(ptr, self.buf_size) }
         })
@@ -383,6 +383,7 @@ impl VsockPacket {
 }
 
 #[cfg(test)]
+#[allow(clippy::undocumented_unsafe_blocks)]
 mod tests {
     use super::super::tests::TestContext;
     use super::*;

--- a/virtio-devices/src/vsock/unix/muxer.rs
+++ b/virtio-devices/src/vsock/unix/muxer.rs
@@ -334,6 +334,7 @@ impl VsockMuxer {
         // device activation time.
         let epoll_fd = epoll::create(true).map_err(Error::EpollFdCreate)?;
         // Use 'File' to enforce closing on 'epoll_fd'
+        // SAFETY: epoll_fd is a valid fd
         let epoll_file = unsafe { File::from_raw_fd(epoll_fd) };
 
         // Open/bind/listen on the host Unix socket, so we can accept host-initiated

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -235,6 +235,7 @@ impl Watchdog {
             error!("Failed to create timer fd {}", e);
             e
         })?;
+        // SAFETY: timer_fd is a valid fd
         let timer = unsafe { File::from_raw_fd(timer_fd) };
 
         Ok(Watchdog {
@@ -280,6 +281,7 @@ impl Drop for Watchdog {
 }
 
 fn timerfd_create() -> Result<RawFd, io::Error> {
+    // SAFETY: FFI call, trivially safe
     let res = unsafe { libc::timerfd_create(libc::CLOCK_MONOTONIC, 0) };
     if res < 0 {
         Err(io::Error::last_os_error())
@@ -301,6 +303,7 @@ fn timerfd_setup(timer: &File, secs: i64) -> Result<(), io::Error> {
     };
 
     let res =
+        // SAFETY: FFI call with correct arguments
         unsafe { libc::timerfd_settime(timer.as_raw_fd(), 0, &periodic, std::ptr::null_mut()) };
 
     if res < 0 {

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -19,7 +19,7 @@ use libc::{sysconf, _SC_PAGESIZE};
 /// Safe wrapper for `sysconf(_SC_PAGESIZE)`.
 #[inline(always)]
 fn pagesize() -> usize {
-    // Trivially safe
+    // SAFETY: FFI call. Trivially safe.
     unsafe { sysconf(_SC_PAGESIZE) as usize }
 }
 

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -257,6 +257,7 @@ impl MemoryRangeTable {
             length as usize / (std::mem::size_of::<MemoryRange>()),
             Default::default,
         );
+        // SAFETY: the slice is construted with the correct arguments
         fd.read_exact(unsafe {
             std::slice::from_raw_parts_mut(
                 data.as_ptr() as *mut MemoryRange as *mut u8,
@@ -273,6 +274,7 @@ impl MemoryRangeTable {
     }
 
     pub fn write_to(&self, fd: &mut dyn Write) -> Result<(), MigratableError> {
+        // SAFETY: the slice is construted with the correct arguments
         fd.write_all(unsafe {
             std::slice::from_raw_parts(
                 self.data.as_ptr() as *const MemoryRange as *const u8,

--- a/vmm/src/coredump.rs
+++ b/vmm/src/coredump.rs
@@ -74,6 +74,7 @@ pub struct X86_64UserRegs {
     pub gs: u64,
 }
 
+// SAFETY: This is just a series of bytes
 unsafe impl ByteValued for X86_64UserRegs {}
 
 #[repr(C)]
@@ -169,6 +170,7 @@ pub struct CpuState {
     pub kernel_gs_base: u64,
 }
 
+// SAFETY: This is just a series of bytes
 unsafe impl ByteValued for CpuState {}
 
 pub enum NoteDescType {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1784,6 +1784,7 @@ impl DeviceManager {
         // SAFETY: The following pair are safe because termios gets totally overwritten by tcgetattr
         // and we check the return result.
         let mut termios: termios = unsafe { zeroed() };
+        // SAFETY: see above
         let ret = unsafe { tcgetattr(fd, &mut termios as *mut _) };
         if ret < 0 {
             return vmm_sys_util::errno::errno_result();

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -424,6 +424,7 @@ impl Vmm {
             Ok(signals) => {
                 self.signals = Some(signals.handle());
                 let exit_evt = self.exit_evt.try_clone().map_err(Error::EventFdClone)?;
+                // SAFETY: trivially safe
                 let on_tty = unsafe { libc::isatty(libc::STDIN_FILENO) } != 0;
 
                 let signal_handler_seccomp_filter = get_seccomp_filter(

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -110,8 +110,11 @@ impl SerialManager {
             }
             ConsoleOutputMode::Tty => {
                 // If running on an interactive TTY then accept input
+                // SAFETY: trivially safe
                 if unsafe { libc::isatty(libc::STDIN_FILENO) == 1 } {
+                    // SAFETY: STDIN_FILENO is a valid fd
                     let stdin_clone = unsafe { File::from_raw_fd(libc::dup(libc::STDIN_FILENO)) };
+                    // SAFETY: FFI calls with correct arguments
                     let ret = unsafe {
                         let mut flags = libc::fcntl(stdin_clone.as_raw_fd(), libc::F_GETFL);
                         flags |= libc::O_NONBLOCK;
@@ -159,6 +162,7 @@ impl SerialManager {
         }
 
         // Use 'File' to enforce closing on 'epoll_fd'
+        // SAFETY: epoll_fd is valid
         let epoll_file = unsafe { File::from_raw_fd(epoll_fd) };
 
         Ok(Some(SerialManager {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2932,10 +2932,12 @@ impl GuestDebuggable for Vm {
 
         #[cfg(feature = "tdx")]
         {
-            if self.config.lock().unwrap().tdx.is_some() {
-                return Err(GuestDebuggableError::Coredump(anyhow!(
-                    "Coredump not possible with TDX VM"
-                )));
+            if let Some(ref platform) = self.config.lock().unwrap().platform {
+                if platform.tdx {
+                    return Err(GuestDebuggableError::Coredump(anyhow!(
+                        "Coredump not possible with TDX VM"
+                    )));
+                }
             }
         }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -589,6 +589,7 @@ impl Vm {
         )
         .map_err(Error::CpuManager)?;
 
+        // SAFETY: trivially safe
         let on_tty = unsafe { libc::isatty(libc::STDIN_FILENO) } != 0;
 
         #[cfg(feature = "tdx")]


### PR DESCRIPTION
Tighten the requirement for documented unsafe blocks by using Clippy's `undocumented_unsafe_blocks` lint.

The slight downside of this lint is it is a bit rigid in the form of the safety comment, but the upside is it is very thorough and basically leaves no stone unturned.

Fix some existing comments to meet the style requirement, and more importantly, document all unsafe blocks which did not have safety comments before.