### PR TITLE
Turn on AArch64 CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,7 +127,6 @@ pipeline {
                         }
                     }
                 }
-                /* Temporarily turn off AArch64 integration test in Jenkins for server maintainance
                 stage('AArch64 worker build') {
                     agent { node { label 'bionic-arm64' } }
                     when {
@@ -203,7 +202,6 @@ pipeline {
                         }
                     }
                 }
-                */
                 stage('Worker build - Windows guest') {
                     agent { node { label 'jammy' } }
                     when {


### PR DESCRIPTION
Reverts cloud-hypervisor/cloud-hypervisor#4885

The AArch64 server maintenance is done. Now we can enable the CI again.