### PR TITLE
.github: do release build with both KVM and MSHV enabled

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,13 +28,13 @@ jobs:
         with:
             toolchain: "1.62"
             command: build
-            args: --all --release --target=x86_64-unknown-linux-gnu
+            args: --all --release --no-default-features --features "kvm,mshv" --target=x86_64-unknown-linux-gnu
       - name: Static Build
         uses: actions-rs/cargo@v1
         with:
             toolchain: "1.62"
             command: build
-            args: --all --release --target=x86_64-unknown-linux-musl
+            args: --all --release --no-default-features --features "kvm,mshv" --target=x86_64-unknown-linux-musl
       - name: Strip cloud-hypervisor binaries
         run: strip target/*/release/cloud-hypervisor
       - name: Install Rust toolchain (aarch64-unknown-linux-musl)


### PR DESCRIPTION
Fixes: #4678

Currently release build is done on kvm feature only, that makes live upgrade test on MSHV failing since
it does not find /dev/kvm. As Cloud-Hypervisor supports both kvm and mshv in a single binary we should
make the release build with both KVM/MSHV feature enabled.  That way live upgrade test does not fail on MSHV.


Signed-off-by: Muminul Islam <muislam@microsoft.com>