### PR TITLE
github,Cargo.toml: Strip release binaries using toolchain

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,8 +35,6 @@ jobs:
             toolchain: "1.62"
             command: build
             args: --all --release --no-default-features --features "kvm,mshv" --target=x86_64-unknown-linux-musl
-      - name: Strip cloud-hypervisor binaries
-        run: strip target/*/release/cloud-hypervisor
       - name: Install Rust toolchain (aarch64-unknown-linux-musl)
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.60"
 lto = true
 codegen-units = 1
 opt-level = "s"
+strip = true
 
 [dependencies]
 anyhow = "1.0.66"


### PR DESCRIPTION
From Rust 1.59, the cargo command is now able to strip a binary [1]. This can be enabled in Cargo.toml by adding a `strip = "true"` to the `[profile.release]` section.

Adding such binary stripping support in Cargo.toml of the project, also change the stripping process in the release workflow to the one using toolchain, so that the AArch64 release binaries can also be stripped.

Fixes: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/4916

[1] https://doc.rust-lang.org/beta/cargo/reference/profiles.html#strip

Signed-off-by: Henry Wang <Henry.Wang@arm.com>