### PR TITLE
scripts: Remove stripping from testing scripts

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -235,9 +235,6 @@ export RUST_BACKTRACE=1
 
 # Test without ACPI
 cargo build --all --release $features --target $BUILD_TARGET
-strip target/$BUILD_TARGET/release/cloud-hypervisor
-strip target/$BUILD_TARGET/release/vhost_user_net
-strip target/$BUILD_TARGET/release/ch-remote
 
 # Enable KSM with some reasonable parameters so that it won't take too long
 # for the memory to be merged between two processes.

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -87,9 +87,6 @@ if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
 fi
 
 cargo build --all --release $features --target $BUILD_TARGET
-strip target/$BUILD_TARGET/release/cloud-hypervisor
-strip target/$BUILD_TARGET/release/vhost_user_net
-strip target/$BUILD_TARGET/release/ch-remote
 
 # Test ovs-dpdk relies on hugepages
 echo 6144 | sudo tee /proc/sys/vm/nr_hugepages

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -78,9 +78,6 @@ if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
 fi
 
 cargo build --all --release $features --target $BUILD_TARGET
-strip target/$BUILD_TARGET/release/cloud-hypervisor
-strip target/$BUILD_TARGET/release/vhost_user_net
-strip target/$BUILD_TARGET/release/ch-remote
 
 export RUST_BACKTRACE=1
 time cargo test $features "rate_limiter::$test_filter" -- --test-threads=1 ${test_binary_args[*]}

--- a/scripts/run_integration_tests_sgx.sh
+++ b/scripts/run_integration_tests_sgx.sh
@@ -50,7 +50,6 @@ CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
 fi
 
 cargo build --all --release $features --target $BUILD_TARGET
-strip target/$BUILD_TARGET/release/cloud-hypervisor
 
 export RUST_BACKTRACE=1
 

--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -44,8 +44,6 @@ CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
 fi
 
 cargo build --all --release $features --target $BUILD_TARGET
-strip target/$BUILD_TARGET/release/cloud-hypervisor
-strip target/$BUILD_TARGET/release/ch-remote
 
 # We always copy a fresh version of our binary for our L2 guest.
 cp target/$BUILD_TARGET/release/cloud-hypervisor $VFIO_DIR

--- a/scripts/run_integration_tests_windows_aarch64.sh
+++ b/scripts/run_integration_tests_windows_aarch64.sh
@@ -47,7 +47,6 @@ dmsetup mknodes
 export RUST_BACKTRACE=1
 
 cargo build --all --release $features --target $BUILD_TARGET
-strip target/$BUILD_TARGET/release/cloud-hypervisor
 
 # Only run with 1 thread to avoid tests interfering with one another because
 # Windows has a static IP configured

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -45,7 +45,6 @@ dmsetup create windows-snapshot-base --table "0 $img_blk_size snapshot-origin /d
 dmsetup mknodes
 
 cargo build --all --release $features --target $BUILD_TARGET
-strip target/$BUILD_TARGET/release/cloud-hypervisor
 
 export RUST_BACKTRACE=1
 

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -175,9 +175,6 @@ cp $VMLINUX_IMAGE $VFIO_DIR || exit 1
 BUILD_TARGET="$(uname -m)-unknown-linux-${CH_LIBC}"
 
 cargo build --all  --release $features --target $BUILD_TARGET
-strip target/$BUILD_TARGET/release/cloud-hypervisor
-strip target/$BUILD_TARGET/release/vhost_user_net
-strip target/$BUILD_TARGET/release/ch-remote
 
 # We always copy a fresh version of our binary for our L2 guest.
 cp target/$BUILD_TARGET/release/cloud-hypervisor $VFIO_DIR

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -100,10 +100,6 @@ if [[ "${BUILD_TARGET}" == "${TEST_ARCH}-unknown-linux-musl" ]]; then
 fi
 
 cargo build --all --release $features --target $BUILD_TARGET
-strip target/$BUILD_TARGET/release/cloud-hypervisor
-strip target/$BUILD_TARGET/release/vhost_user_net
-strip target/$BUILD_TARGET/release/ch-remote
-strip target/$BUILD_TARGET/release/performance-metrics
 
 # setup hugepages
 echo 6144 | sudo tee /proc/sys/vm/nr_hugepages


### PR DESCRIPTION
The binary stripping is now done by the toolchain for release builds.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
