### PR TITLE
vmm: Create vCPUs before the DeviceManager

### DIFF
--- a/devices/src/interrupt_controller.rs
+++ b/devices/src/interrupt_controller.rs
@@ -55,8 +55,6 @@ pub struct MsiMessage {
 // IOAPIC (X86) or GIC (Arm).
 pub trait InterruptController: Send {
     fn service_irq(&mut self, irq: usize) -> Result<()>;
-    #[cfg(target_arch = "aarch64")]
-    fn enable(&self) -> Result<()>;
     #[cfg(target_arch = "x86_64")]
     fn end_of_interrupt(&mut self, vec: u8);
     fn notifier(&self, irq: usize) -> Option<EventFd>;

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -2082,10 +2082,9 @@ impl Snapshottable for CpuManager {
 
     fn restore(&mut self, snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
         for (cpu_id, snapshot) in snapshot.snapshots.iter() {
+            let cpu_id = cpu_id.parse::<usize>().unwrap();
             info!("Restoring VCPU {}", cpu_id);
-            let vcpu = self
-                .create_vcpu(cpu_id.parse::<u8>().unwrap())
-                .map_err(|e| MigratableError::Restore(anyhow!("Could not create vCPU {:?}", e)))?;
+            let vcpu = self.vcpus[cpu_id].clone();
             self.configure_vcpu(vcpu, None, Some(*snapshot.clone()))
                 .map_err(|e| {
                     MigratableError::Restore(anyhow!("Could not configure vCPU {:?}", e))

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -18,7 +18,6 @@ use crate::coredump::{
     GuestDebuggableError, NoteDescType, X86_64ElfPrStatus, X86_64UserRegs, COREDUMP_NAME_SIZE,
     NT_PRSTATUS,
 };
-use crate::device_manager::DeviceManager;
 #[cfg(feature = "guest_debug")]
 use crate::gdb::{get_raw_tid, Debuggable, DebuggableError};
 use crate::memory_manager::MemoryManager;
@@ -597,7 +596,6 @@ impl CpuManager {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: &CpusConfig,
-        device_manager: &Arc<Mutex<DeviceManager>>,
         memory_manager: &Arc<Mutex<MemoryManager>>,
         vm: Arc<dyn hypervisor::Vm>,
         exit_evt: EventFd,
@@ -670,8 +668,6 @@ impl CpuManager {
             }
         }
 
-        let device_manager = device_manager.lock().unwrap();
-
         let proximity_domain_per_cpu: BTreeMap<u8, u32> = {
             let mut cpu_list = Vec::new();
             for (proximity_domain, numa_node) in numa_nodes.iter() {
@@ -698,23 +694,10 @@ impl CpuManager {
         #[cfg(not(feature = "tdx"))]
         let dynamic = true;
 
-        let acpi_address = if dynamic {
-            Some(
-                device_manager
-                    .allocator()
-                    .lock()
-                    .unwrap()
-                    .allocate_platform_mmio_addresses(None, CPU_MANAGER_ACPI_SIZE as u64, None)
-                    .ok_or(Error::AllocateMmmioAddress)?,
-            )
-        } else {
-            None
-        };
-
-        let cpu_manager = Arc::new(Mutex::new(CpuManager {
+        Ok(Arc::new(Mutex::new(CpuManager {
             hypervisor_type,
             config: config.clone(),
-            interrupt_controller: device_manager.interrupt_controller().clone(),
+            interrupt_controller: None,
             vm_memory: guest_memory,
             #[cfg(target_arch = "x86_64")]
             cpuid,
@@ -730,24 +713,11 @@ impl CpuManager {
             vcpus: Vec::with_capacity(usize::from(config.max_vcpus)),
             seccomp_action,
             vm_ops,
-            acpi_address,
+            acpi_address: None,
             proximity_domain_per_cpu,
             affinity,
             dynamic,
-        }));
-
-        if let Some(acpi_address) = acpi_address {
-            device_manager
-                .mmio_bus()
-                .insert(
-                    cpu_manager.clone(),
-                    acpi_address.0,
-                    CPU_MANAGER_ACPI_SIZE as u64,
-                )
-                .map_err(Error::BusError)?;
-        }
-
-        Ok(cpu_manager)
+        })))
     }
 
     fn create_vcpu(
@@ -1675,6 +1645,17 @@ impl CpuManager {
         descaddr |= gva & (page_size - 1);
 
         Ok(descaddr)
+    }
+
+    pub(crate) fn set_acpi_address(&mut self, acpi_address: GuestAddress) {
+        self.acpi_address = Some(acpi_address);
+    }
+
+    pub(crate) fn set_interrupt_controller(
+        &mut self,
+        interrupt_controller: Arc<Mutex<dyn InterruptController>>,
+    ) {
+        self.interrupt_controller = Some(interrupt_controller);
     }
 }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -549,7 +549,7 @@ pub(crate) struct AddressManager {
     #[cfg(target_arch = "x86_64")]
     pub(crate) io_bus: Arc<Bus>,
     pub(crate) mmio_bus: Arc<Bus>,
-    vm: Arc<dyn hypervisor::Vm>,
+    pub(crate) vm: Arc<dyn hypervisor::Vm>,
     device_tree: Arc<Mutex<DeviceTree>>,
     pci_mmio_allocators: Vec<Arc<Mutex<AddressAllocator>>>,
 }
@@ -1376,6 +1376,7 @@ impl DeviceManager {
             gic::Gic::new(
                 self.config.lock().unwrap().cpus.boot_vcpus,
                 Arc::clone(&self.msi_interrupt_manager),
+                self.address_manager.vm.clone(),
             )
             .map_err(DeviceManagerError::CreateInterruptController)?,
         ));

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2087,12 +2087,15 @@ impl Vm {
             self.init_tdx()?;
         }
 
-        // Create and configure vcpus
-        self.cpu_manager
-            .lock()
-            .unwrap()
-            .create_boot_vcpus(entry_point)
-            .map_err(Error::CpuManager)?;
+        // Configure the vcpus that have been created
+        let vcpus = self.cpu_manager.lock().unwrap().vcpus();
+        for vcpu in vcpus {
+            self.cpu_manager
+                .lock()
+                .unwrap()
+                .configure_vcpu(vcpu, entry_point, None)
+                .map_err(Error::CpuManager)?;
+        }
 
         #[cfg(feature = "tdx")]
         let sections = if tdx_enabled {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -538,6 +538,12 @@ impl Vm {
         )
         .map_err(Error::CpuManager)?;
 
+        cpu_manager
+            .lock()
+            .unwrap()
+            .create_boot_vcpus()
+            .map_err(Error::CpuManager)?;
+
         #[cfg(feature = "tdx")]
         let dynamic = !tdx_enabled;
         #[cfg(not(feature = "tdx"))]


### PR DESCRIPTION
This PR moves lots of code around to be able to create both the CpuManager and associated Vcpus before the DeviceManager's creation. The reason is to unify the boot sequence for both x86_64 and aarch64 architectures. And given aarch64 requires the vCPU to be created in order to create the vGIC (equivalent of the vLAPIC in case of x86_64), we decided to defer the creation of the DeviceManager as much as possible.

It includes a patch from @michael2012z (specifically for aarch64) that is required to move the vGIC creation out of the Gic object, and make sure the vGIC is created before the DeviceManager. At the time the DeviceManager gets created, all vCPUs and associated vGIC are ready so that registering irqfds and setting up GSI routes can succeed.