### PR TITLE
tests: Enable VFIO integration tests

### DIFF
--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -12,7 +12,11 @@ WORKLOADS_DIR="$HOME/workloads"
 FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.raw"
 FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"
 FW="$WORKLOADS_DIR/hypervisor-fw"
+
 VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
+if [ ! -f "$VMLINUX_IMAGE" ]; then
+    build_custom_linux
+fi
 
 BLK_IMAGE="$WORKLOADS_DIR/blk.img"
 MNT_DIR="mount_image"

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1063,27 +1063,7 @@ impl Guest {
 
     #[cfg(target_arch = "x86_64")]
     pub fn check_nvidia_gpu(&self) {
-        // Run CUDA sample to validate it can find the device
-        let device_query_result = self
-            .ssh_command("sudo /root/NVIDIA_CUDA-11.3_Samples/bin/x86_64/linux/release/deviceQuery")
-            .unwrap();
-        assert!(device_query_result.contains("Detected 1 CUDA Capable device"));
-        assert!(device_query_result.contains("Device 0: \"NVIDIA Tesla T4\""));
-        assert!(device_query_result.contains("Result = PASS"));
-
-        // Run NVIDIA DCGM Diagnostics to validate the device is functional
-        self.ssh_command("sudo nv-hostengine").unwrap();
-
-        assert!(self
-            .ssh_command("sudo dcgmi discovery -l")
-            .unwrap()
-            .contains("Name: NVIDIA Tesla T4"));
-        assert_eq!(
-            self.ssh_command("sudo dcgmi diag -r 'diagnostic' | grep Pass | wc -l")
-                .unwrap()
-                .trim(),
-            "10"
-        );
+        assert!(self.ssh_command("nvidia-smi").unwrap().contains("Tesla T4"));
     }
 
     pub fn reboot_linux(&self, current_reboot_count: u32, custom_timeout: Option<i32>) {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -35,7 +35,7 @@ mod x86_64 {
     pub const BIONIC_IMAGE_NAME: &str = "bionic-server-cloudimg-amd64.raw";
     pub const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-custom-20210609-0.raw";
     pub const FOCAL_SGX_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-sgx.raw";
-    pub const HIRSUTE_NVIDIA_IMAGE_NAME: &str = "hirsute-server-cloudimg-amd64-nvidia.raw";
+    pub const JAMMY_NVIDIA_IMAGE_NAME: &str = "jammy-server-cloudimg-amd64-nvidia.raw";
     pub const FOCAL_IMAGE_NAME_QCOW2: &str = "focal-server-cloudimg-amd64-custom-20210609-0.qcow2";
     pub const FOCAL_IMAGE_NAME_VHD: &str = "focal-server-cloudimg-amd64-custom-20210609-0.vhd";
     pub const FOCAL_IMAGE_NAME_VHDX: &str = "focal-server-cloudimg-amd64-custom-20210609-0.vhdx";
@@ -8075,8 +8075,8 @@ mod vfio {
     }
 
     fn test_nvidia_card_memory_hotplug(hotplug_method: &str) {
-        let hirsute = UbuntuDiskConfig::new(HIRSUTE_NVIDIA_IMAGE_NAME.to_string());
-        let guest = Guest::new(Box::new(hirsute));
+        let jammy = UbuntuDiskConfig::new(JAMMY_NVIDIA_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(jammy));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
         let mut child = GuestCommand::new(&guest)
@@ -8129,8 +8129,8 @@ mod vfio {
 
     #[test]
     fn test_nvidia_card_pci_hotplug() {
-        let hirsute = UbuntuDiskConfig::new(HIRSUTE_NVIDIA_IMAGE_NAME.to_string());
-        let guest = Guest::new(Box::new(hirsute));
+        let jammy = UbuntuDiskConfig::new(JAMMY_NVIDIA_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(jammy));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
         let mut child = GuestCommand::new(&guest)
@@ -8171,8 +8171,8 @@ mod vfio {
 
     #[test]
     fn test_nvidia_card_reboot() {
-        let hirsute = UbuntuDiskConfig::new(HIRSUTE_NVIDIA_IMAGE_NAME.to_string());
-        let guest = Guest::new(Box::new(hirsute));
+        let jammy = UbuntuDiskConfig::new(JAMMY_NVIDIA_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(jammy));
         let api_socket = temp_api_path(&guest.tmp_dir);
 
         let mut child = GuestCommand::new(&guest)


### PR DESCRIPTION
Re-enable the VFIO integration now the machine is back online.

The image has been updated to rely on Ubuntu 22.04 (Jammy) and it's smaller given only the NVIDIA drivers along with the nvidia-smi tool are installed.

The test to verify the GPU is functional has been simplified given it only relies on nvidia-smi to validate it has been able to find the Tesla T4 card, meaning the associated driver was loaded correctly.