### PR TITLE
devices, vmm: Move Ioapic to new restore design

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1408,6 +1408,8 @@ impl DeviceManager {
                 id.clone(),
                 APIC_START,
                 Arc::clone(&self.msi_interrupt_manager),
+                versioned_state_from_id(self.snapshot.as_ref(), id.as_str())
+                    .map_err(DeviceManagerError::RestoreGetState)?,
             )
             .map_err(DeviceManagerError::CreateInterruptController)?,
         ));


### PR DESCRIPTION
Moving the Ioapic object to the new restore design, meaning the Ioapic is created directly with the right state, and it shares the same codepath as when it's created from scratch.