### PR TITLE
devices: Move legacy devices to new restore design

### DIFF
--- a/fuzz/fuzz_targets/serial.rs
+++ b/fuzz/fuzz_targets/serial.rs
@@ -15,6 +15,7 @@ fuzz_target!(|bytes| {
     let mut serial = Serial::new_sink(
         "serial".into(),
         Arc::new(TestInterrupt::new(EventFd::new(EFD_NONBLOCK).unwrap())),
+        None,
     );
 
     let mut i = 0;

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1664,6 +1664,8 @@ impl DeviceManager {
         let gpio_device = Arc::new(Mutex::new(devices::legacy::Gpio::new(
             id.clone(),
             interrupt_group,
+            versioned_state_from_id(self.snapshot.as_ref(), id.as_str())
+                .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
         self.bus_devices

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1773,6 +1773,8 @@ impl DeviceManager {
             interrupt_group,
             serial_writer,
             self.timestamp,
+            versioned_state_from_id(self.snapshot.as_ref(), id.as_str())
+                .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
         self.bus_devices

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1716,6 +1716,8 @@ impl DeviceManager {
             id.clone(),
             interrupt_group,
             serial_writer,
+            versioned_state_from_id(self.snapshot.as_ref(), id.as_str())
+                .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
         self.bus_devices


### PR DESCRIPTION
Moving legacy devices objects to the new restore design, meaning they are created directly with the right state, and they share the same codepath as when they are created from scratch.