### PR TITLE
pci: Move VfioPciDevice and VfioUserPciDevice to new restore design

### DIFF
--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -644,18 +644,6 @@ impl PciConfiguration {
         }
     }
 
-    fn set_state(&mut self, state: &PciConfigurationState) {
-        self.registers.clone_from_slice(state.registers.as_slice());
-        self.writable_bits
-            .clone_from_slice(state.writable_bits.as_slice());
-        self.bars.clone_from_slice(state.bars.as_slice());
-        self.rom_bar_addr = state.rom_bar_addr;
-        self.rom_bar_size = state.rom_bar_size;
-        self.rom_bar_used = state.rom_bar_used;
-        self.last_capability = state.last_capability;
-        self.msix_cap_reg_idx = state.msix_cap_reg_idx;
-    }
-
     /// Reads a 32bit register from `reg_idx` in the register map.
     pub fn read_reg(&self, reg_idx: usize) -> u32 {
         *(self.registers.get(reg_idx).unwrap_or(&0xffff_ffff))
@@ -1085,11 +1073,6 @@ impl Snapshottable for PciConfiguration {
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         Snapshot::new_from_versioned_state(&self.id(), &self.state())
-    }
-
-    fn restore(&mut self, snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
-        self.set_state(&snapshot.to_versioned_state(&self.id())?);
-        Ok(())
     }
 }
 

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -735,7 +735,7 @@ impl VfioCommon {
             })
             .unwrap();
 
-        let msi_config = MsiConfig::new(msg_ctl, interrupt_source_group.clone());
+        let msi_config = MsiConfig::new(msg_ctl, interrupt_source_group.clone(), None).unwrap();
 
         self.interrupt.msi = Some(VfioMsi {
             cfg: msi_config,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -931,9 +931,6 @@ pub struct DeviceManager {
     // Flag to force setting the iommu on virtio devices
     force_iommu: bool,
 
-    // Helps identify if the VM is currently being restored
-    restoring: bool,
-
     // io_uring availability if detected
     io_uring_supported: Option<bool>,
 
@@ -968,7 +965,6 @@ impl DeviceManager {
         numa_nodes: NumaNodes,
         activate_evt: &EventFd,
         force_iommu: bool,
-        restoring: bool,
         boot_id_list: BTreeSet<String>,
         timestamp: Instant,
         snapshot: Option<Snapshot>,
@@ -1115,7 +1111,6 @@ impl DeviceManager {
             #[cfg(target_arch = "aarch64")]
             gpio_device: None,
             force_iommu,
-            restoring,
             io_uring_supported: None,
             boot_id_list,
             timestamp,
@@ -4150,10 +4145,6 @@ impl DeviceManager {
                 }
             }
         }
-
-        // The devices have been fully restored, we can now update the
-        // restoring state of the DeviceManager.
-        self.restoring = false;
 
         Ok(())
     }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -564,7 +564,6 @@ impl Vm {
             numa_nodes.clone(),
             &activate_evt,
             force_iommu,
-            restoring,
             boot_id_list,
             timestamp,
             snapshot_from_id(snapshot, DEVICE_MANAGER_SNAPSHOT_ID),


### PR DESCRIPTION
This PR moves both `VfioPciDevice` and `VfioUserPciDevice` to the new restore design. Given it completes all PCI devices (`VirtioPciDevice` was moved earlier), the old way of restoring `MsiConfig`, `MsixConfig` and `PciConfiguration` can be removed as well. 