### PR TITLE
vmm: Move CpuManager and Vcpu to the new restore design

### DIFF
--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -736,10 +736,15 @@ impl Mem {
             ));
         }
 
-        let (avail_features, acked_features, config) = if let Some(state) = state {
+        let (avail_features, acked_features, config, paused) = if let Some(state) = state {
             info!("Restoring virtio-mem {}", id);
             *(blocks_state.lock().unwrap()) = state.blocks_state.clone();
-            (state.avail_features, state.acked_features, state.config)
+            (
+                state.avail_features,
+                state.acked_features,
+                state.config,
+                true,
+            )
         } else {
             let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;
 
@@ -779,7 +784,7 @@ impl Mem {
                 )
             })?;
 
-            (avail_features, 0, config)
+            (avail_features, 0, config, false)
         };
 
         let host_fd = region
@@ -794,6 +799,7 @@ impl Mem {
                 paused_sync: Some(Arc::new(Barrier::new(2))),
                 queue_sizes: QUEUE_SIZES.to_vec(),
                 min_queues: 1,
+                paused: Arc::new(AtomicBool::new(paused)),
                 ..Default::default()
             },
             id,

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -451,57 +451,65 @@ impl Net {
 
         let mtu = taps[0].mtu().map_err(Error::TapError)? as u16;
 
-        let (avail_features, acked_features, config, queue_sizes) = if let Some(state) = state {
-            info!("Restoring virtio-net {}", id);
-            (
-                state.avail_features,
-                state.acked_features,
-                state.config,
-                state.queue_size,
-            )
-        } else {
-            let mut avail_features = 1 << VIRTIO_NET_F_CSUM
-                | 1 << VIRTIO_NET_F_CTRL_GUEST_OFFLOADS
-                | 1 << VIRTIO_NET_F_GUEST_CSUM
-                | 1 << VIRTIO_NET_F_GUEST_ECN
-                | 1 << VIRTIO_NET_F_GUEST_TSO4
-                | 1 << VIRTIO_NET_F_GUEST_TSO6
-                | 1 << VIRTIO_NET_F_GUEST_UFO
-                | 1 << VIRTIO_NET_F_HOST_ECN
-                | 1 << VIRTIO_NET_F_HOST_TSO4
-                | 1 << VIRTIO_NET_F_HOST_TSO6
-                | 1 << VIRTIO_NET_F_HOST_UFO
-                | 1 << VIRTIO_NET_F_MTU
-                | 1 << VIRTIO_RING_F_EVENT_IDX
-                | 1 << VIRTIO_F_VERSION_1;
-
-            if iommu {
-                avail_features |= 1u64 << VIRTIO_F_IOMMU_PLATFORM;
-            }
-
-            avail_features |= 1 << VIRTIO_NET_F_CTRL_VQ;
-            let queue_num = num_queues + 1;
-
-            let mut config = VirtioNetConfig::default();
-            if let Some(mac) = guest_mac {
-                build_net_config_space(
-                    &mut config,
-                    mac,
-                    num_queues,
-                    Some(mtu),
-                    &mut avail_features,
-                );
+        let (avail_features, acked_features, config, queue_sizes, paused) =
+            if let Some(state) = state {
+                info!("Restoring virtio-net {}", id);
+                (
+                    state.avail_features,
+                    state.acked_features,
+                    state.config,
+                    state.queue_size,
+                    true,
+                )
             } else {
-                build_net_config_space_with_mq(
-                    &mut config,
-                    num_queues,
-                    Some(mtu),
-                    &mut avail_features,
-                );
-            }
+                let mut avail_features = 1 << VIRTIO_NET_F_CSUM
+                    | 1 << VIRTIO_NET_F_CTRL_GUEST_OFFLOADS
+                    | 1 << VIRTIO_NET_F_GUEST_CSUM
+                    | 1 << VIRTIO_NET_F_GUEST_ECN
+                    | 1 << VIRTIO_NET_F_GUEST_TSO4
+                    | 1 << VIRTIO_NET_F_GUEST_TSO6
+                    | 1 << VIRTIO_NET_F_GUEST_UFO
+                    | 1 << VIRTIO_NET_F_HOST_ECN
+                    | 1 << VIRTIO_NET_F_HOST_TSO4
+                    | 1 << VIRTIO_NET_F_HOST_TSO6
+                    | 1 << VIRTIO_NET_F_HOST_UFO
+                    | 1 << VIRTIO_NET_F_MTU
+                    | 1 << VIRTIO_RING_F_EVENT_IDX
+                    | 1 << VIRTIO_F_VERSION_1;
 
-            (avail_features, 0, config, vec![queue_size; queue_num])
-        };
+                if iommu {
+                    avail_features |= 1u64 << VIRTIO_F_IOMMU_PLATFORM;
+                }
+
+                avail_features |= 1 << VIRTIO_NET_F_CTRL_VQ;
+                let queue_num = num_queues + 1;
+
+                let mut config = VirtioNetConfig::default();
+                if let Some(mac) = guest_mac {
+                    build_net_config_space(
+                        &mut config,
+                        mac,
+                        num_queues,
+                        Some(mtu),
+                        &mut avail_features,
+                    );
+                } else {
+                    build_net_config_space_with_mq(
+                        &mut config,
+                        num_queues,
+                        Some(mtu),
+                        &mut avail_features,
+                    );
+                }
+
+                (
+                    avail_features,
+                    0,
+                    config,
+                    vec![queue_size; queue_num],
+                    false,
+                )
+            };
 
         Ok(Net {
             common: VirtioCommon {
@@ -511,6 +519,7 @@ impl Net {
                 queue_sizes,
                 paused_sync: Some(Arc::new(Barrier::new((num_queues / 2) + 1))),
                 min_queues: 2,
+                paused: Arc::new(AtomicBool::new(paused)),
                 ..Default::default()
             },
             id,

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -178,9 +178,9 @@ impl Rng {
     ) -> io::Result<Rng> {
         let random_file = File::open(path)?;
 
-        let (avail_features, acked_features) = if let Some(state) = state {
+        let (avail_features, acked_features, paused) = if let Some(state) = state {
             info!("Restoring virtio-rng {}", id);
-            (state.avail_features, state.acked_features)
+            (state.avail_features, state.acked_features, true)
         } else {
             let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;
 
@@ -188,7 +188,7 @@ impl Rng {
                 avail_features |= 1u64 << VIRTIO_F_IOMMU_PLATFORM;
             }
 
-            (avail_features, 0)
+            (avail_features, 0, false)
         };
 
         Ok(Rng {
@@ -199,6 +199,7 @@ impl Rng {
                 avail_features,
                 acked_features,
                 min_queues: 1,
+                paused: Arc::new(AtomicBool::new(paused)),
                 ..Default::default()
             },
             id,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4135,7 +4135,6 @@ impl DeviceManager {
             if let Some(migratable) = &node.migratable {
                 info!("Restoring {} from DeviceManager", node.id);
                 if let Some(snapshot) = snapshot.snapshots.get(&node.id) {
-                    migratable.lock().unwrap().pause()?;
                     migratable.lock().unwrap().restore(*snapshot.clone())?;
                 } else {
                     return Err(MigratableError::Restore(anyhow!(

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -541,7 +541,7 @@ impl Vm {
         cpu_manager
             .lock()
             .unwrap()
-            .create_boot_vcpus()
+            .create_boot_vcpus(snapshot_from_id(snapshot, CPU_MANAGER_SNAPSHOT_ID))
             .map_err(Error::CpuManager)?;
 
         #[cfg(feature = "tdx")]
@@ -2083,7 +2083,7 @@ impl Vm {
             self.cpu_manager
                 .lock()
                 .unwrap()
-                .configure_vcpu(vcpu, entry_point, None)
+                .configure_vcpu(vcpu, entry_point)
                 .map_err(Error::CpuManager)?;
         }
 
@@ -2633,17 +2633,6 @@ impl Snapshottable for Vm {
         } else {
             return Err(MigratableError::Restore(anyhow!(
                 "Missing device manager snapshot"
-            )));
-        }
-
-        if let Some(cpu_manager_snapshot) = snapshot.snapshots.get(CPU_MANAGER_SNAPSHOT_ID) {
-            self.cpu_manager
-                .lock()
-                .unwrap()
-                .restore(*cpu_manager_snapshot.clone())?;
-        } else {
-            return Err(MigratableError::Restore(anyhow!(
-                "Missing CPU manager snapshot"
             )));
         }
 


### PR DESCRIPTION
Every Vcpu is now created with the right state if there's an available snapshot associated with it. This simplifies the restore logic.