### PR TITLE
Refactor VCPU creation

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -16,8 +16,10 @@ use crate::arch::x86::{
 };
 #[cfg(feature = "tdx")]
 use crate::kvm::{TdxExitDetails, TdxExitStatus};
+use crate::vm::VmOps;
 use crate::CpuState;
 use crate::MpState;
+use std::sync::Arc;
 use thiserror::Error;
 use vm_memory::GuestAddress;
 
@@ -296,6 +298,10 @@ pub trait Vcpu: Send + Sync {
     ///
     fn set_fpu(&self, fpu: &FpuState) -> Result<()>;
     #[cfg(target_arch = "x86_64")]
+    ///
+    /// Sets the vm ops struct for vcpu
+    ///
+    fn set_vm_ops(&mut self, vm_ops: Option<Arc<dyn VmOps>>);
     ///
     /// X86 specific call to setup the CPUID registers.
     ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -410,6 +410,7 @@ impl vm::Vm for KvmVm {
         };
         Ok(Arc::new(vcpu))
     }
+
     #[cfg(target_arch = "aarch64")]
     ///
     /// Creates a virtual GIC device.
@@ -1095,6 +1096,13 @@ pub struct KvmVcpu {
 /// vcpu.get/set().unwrap()
 ///
 impl cpu::Vcpu for KvmVcpu {
+    ///
+    /// Sets the vm ops struct for vcpu
+    ///
+    fn set_vm_ops(&mut self, vm_ops: Option<Arc<dyn vm::VmOps>>) {
+        self.vm_ops = vm_ops;
+    }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Returns the vCPU general purpose registers.

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -295,6 +295,12 @@ pub struct MshvVcpu {
 /// vcpu.get/set().unwrap()
 ///
 impl cpu::Vcpu for MshvVcpu {
+    ///
+    /// Sets the vm ops struct for vcpu
+    ///
+    fn set_vm_ops(&mut self, vm_ops: Option<Arc<dyn vm::VmOps>>) {
+        self.vm_ops = vm_ops;
+    }
     #[cfg(target_arch = "x86_64")]
     ///
     /// Returns the vCPU general purpose registers.

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -483,6 +483,17 @@ impl VcpuConfig {
         Ok(vcpu)
     }
 
+    pub fn setup_vm_ops(&mut self, vm_ops: Arc<dyn VmOps>) -> Result<()> {
+        for vcpu in self.vcpus.iter_mut() {
+            let mut vcpu_elem = vcpu.lock().unwrap();
+            if let Some(vcpu) = Arc::get_mut(&mut vcpu_elem.vcpu) {
+                vcpu.set_vm_ops(Some(vm_ops.clone()));
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn create_vcpus(&mut self, desired_vcpus: u8) -> Result<Vec<Arc<Mutex<Vcpu>>>> {
         let mut vcpus: Vec<Arc<Mutex<Vcpu>>> = vec![];
         info!(

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1220,6 +1220,7 @@ impl Vmm {
 
         let timestamp = Instant::now();
         let hypervisor_vm = mm.lock().unwrap().vm.clone();
+
         let cpus_config = {
             &self
                 .vm_config
@@ -1230,7 +1231,9 @@ impl Vmm {
                 .cpus
                 .clone()
         };
-        let vcpu_config = cpu::VcpuConfig::new(cpus_config, hypervisor_vm.clone());
+        let mut vcpu_config = cpu::VcpuConfig::new(cpus_config, hypervisor_vm.clone());
+
+        vcpu_config.create_boot_vcpus().unwrap();
 
         let mut vm = Vm::new_from_memory_manager(
             self.vm_config.clone().unwrap(),

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1220,6 +1220,18 @@ impl Vmm {
 
         let timestamp = Instant::now();
         let hypervisor_vm = mm.lock().unwrap().vm.clone();
+        let cpus_config = {
+            &self
+                .vm_config
+                .clone()
+                .expect("CpuConfig missing")
+                .lock()
+                .unwrap()
+                .cpus
+                .clone()
+        };
+        let vcpu_config = cpu::VcpuConfig::new(cpus_config, hypervisor_vm.clone());
+
         let mut vm = Vm::new_from_memory_manager(
             self.vm_config.clone().unwrap(),
             mm,
@@ -1234,6 +1246,7 @@ impl Vmm {
             true,
             timestamp,
             Some(&snapshot),
+            vcpu_config,
         )
         .map_err(|e| {
             MigratableError::MigrateReceive(anyhow!("Error creating VM from snapshot: {:?}", e))

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -521,20 +521,21 @@ impl Vm {
         });
 
         let cpus_config = { &config.lock().unwrap().cpus.clone() };
+
+        let vcpu_config = cpu::VcpuConfig::new(cpus_config, vm.clone(), vm_ops);
+
         let cpu_manager = cpu::CpuManager::new(
-            cpus_config,
             &memory_manager,
-            vm.clone(),
             exit_evt.try_clone().map_err(Error::EventFdClone)?,
             reset_evt.try_clone().map_err(Error::EventFdClone)?,
             #[cfg(feature = "guest_debug")]
             vm_debug_evt,
             hypervisor.clone(),
             seccomp_action.clone(),
-            vm_ops,
             #[cfg(feature = "tdx")]
             tdx_enabled,
             &numa_nodes,
+            vcpu_config,
         )
         .map_err(Error::CpuManager)?;
 


### PR DESCRIPTION
Currently vCPUs creation is tied to memory manager which implies guest memory must be allocated and mapped before creating vCPUs. I would like to propose, let's untangle vCPU creation from memory manager. This is a requirement for MSHV to create SEV-SNP enabled VMs.

By changing this workflow we should not affect any of the existing use cases.