### PR TITLE
Move Gic to the new restore path

### DIFF
--- a/devices/src/interrupt_controller.rs
+++ b/devices/src/interrupt_controller.rs
@@ -24,8 +24,12 @@ pub enum Error {
     UpdateInterrupt(io::Error),
     /// Failed enabling the interrupt.
     EnableInterrupt(io::Error),
+    #[cfg(target_arch = "aarch64")]
     /// Failed creating GIC device.
     CreateGic(hypervisor::HypervisorVmError),
+    #[cfg(target_arch = "aarch64")]
+    /// Failed restoring GIC device.
+    RestoreGic(hypervisor::arch::aarch64::gic::Error),
 }
 
 type Result<T> = result::Result<T, Error>;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9280,43 +9280,51 @@ mod live_migration {
         }
 
         #[test]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_basic() {
             _test_live_migration(true, false)
         }
 
         #[test]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_local() {
             _test_live_migration(true, true)
         }
 
         #[test]
+        #[cfg(target_arch = "x86_64")]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_numa() {
             _test_live_migration_numa(true, false)
         }
 
         #[test]
+        #[cfg(target_arch = "x86_64")]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_numa_local() {
             _test_live_migration_numa(true, true)
         }
 
         #[test]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_watchdog() {
             _test_live_migration_watchdog(true, false)
         }
 
         #[test]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_watchdog_local() {
             _test_live_migration_watchdog(true, true)
         }
 
         #[test]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_balloon() {
             _test_live_migration_balloon(true, false)
         }
 
         #[test]
+        #[cfg(target_arch = "x86_64")]
         fn test_live_upgrade_balloon_local() {
             _test_live_migration_balloon(true, true)
         }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2141,16 +2141,6 @@ impl Vm {
         &self,
         vm_snapshot: &mut Snapshot,
     ) -> std::result::Result<(), MigratableError> {
-        let saved_vcpu_states = self.cpu_manager.lock().unwrap().get_saved_states();
-        self.device_manager
-            .lock()
-            .unwrap()
-            .get_interrupt_controller()
-            .unwrap()
-            .lock()
-            .unwrap()
-            .set_gicr_typers(&saved_vcpu_states);
-
         vm_snapshot.add_snapshot(
             self.device_manager
                 .lock()


### PR DESCRIPTION
The PR:
- Moves the snapshotting and restoring of Gic (AArch64) from `Vm` to `DeviceManager`
- Moves the occasion of Gic restoration earlier from after `DeviceManager::restore()` to `DeviceManager::add_interrupt_controller()` which is in the very beginning of `DeviceManager::restore()`

