### PR TITLE
vmm: Move Vm to the new restore design

### DIFF
--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -264,11 +264,6 @@ pub trait Snapshottable: Pausable {
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         Ok(Snapshot::new(""))
     }
-
-    /// Restore a component from its snapshot.
-    fn restore(&mut self, _snapshot: Snapshot) -> std::result::Result<(), MigratableError> {
-        Ok(())
-    }
 }
 
 /// A transportable component can be sent or receive to a specific URL.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -682,7 +682,7 @@ impl Vmm {
             None,
             None,
             None,
-            Some(snapshot.clone()),
+            Some(snapshot),
             Some(source_url),
             Some(restore_cfg.prefault),
         )?;
@@ -690,7 +690,7 @@ impl Vmm {
 
         // Now we can restore the rest of the VM.
         if let Some(ref mut vm) = self.vm {
-            vm.restore(snapshot).map_err(VmError::Restore)
+            vm.restore()
         } else {
             Err(VmError::VmNotCreated)
         }
@@ -1272,9 +1272,9 @@ impl Vmm {
         })?;
 
         // Create VM
-        vm.restore(snapshot).map_err(|e| {
+        vm.restore().map_err(|e| {
             Response::error().write_to(socket).ok();
-            e
+            MigratableError::MigrateReceive(anyhow!("Failed restoring the Vm: {}", e))
         })?;
         self.vm = Some(vm);
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1264,7 +1264,7 @@ impl Vmm {
             None,
             None,
             None,
-            Some(&snapshot),
+            Some(snapshot),
         )
         .map_err(|e| {
             MigratableError::MigrateReceive(anyhow!("Error creating VM from snapshot: {:?}", e))

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1260,7 +1260,6 @@ impl Vmm {
             &self.seccomp_action,
             self.hypervisor.clone(),
             activate_evt,
-            true,
             timestamp,
             None,
             None,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -479,7 +479,7 @@ impl Vm {
         serial_pty: Option<PtyPair>,
         console_pty: Option<PtyPair>,
         console_resize_pipe: Option<File>,
-        snapshot: Option<&Snapshot>,
+        snapshot: Option<Snapshot>,
     ) -> Result<Self> {
         trace_scoped!("Vm::new_from_memory_manager");
 
@@ -546,7 +546,7 @@ impl Vm {
         cpu_manager
             .lock()
             .unwrap()
-            .create_boot_vcpus(snapshot_from_id(snapshot, CPU_MANAGER_SNAPSHOT_ID))
+            .create_boot_vcpus(snapshot_from_id(snapshot.as_ref(), CPU_MANAGER_SNAPSHOT_ID))
             .map_err(Error::CpuManager)?;
 
         #[cfg(feature = "tdx")]
@@ -571,7 +571,7 @@ impl Vm {
             force_iommu,
             boot_id_list,
             timestamp,
-            snapshot_from_id(snapshot, DEVICE_MANAGER_SNAPSHOT_ID),
+            snapshot_from_id(snapshot.as_ref(), DEVICE_MANAGER_SNAPSHOT_ID),
             dynamic,
         )
         .map_err(Error::DeviceManager)?;
@@ -799,7 +799,7 @@ impl Vm {
             serial_pty,
             console_pty,
             console_resize_pipe,
-            snapshot.as_ref(),
+            snapshot,
         )
     }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -475,7 +475,6 @@ impl Vm {
         seccomp_action: &SeccompAction,
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
         activate_evt: EventFd,
-        restoring: bool,
         timestamp: Instant,
         serial_pty: Option<PtyPair>,
         console_pty: Option<PtyPair>,
@@ -490,7 +489,7 @@ impl Vm {
             .validate()
             .map_err(Error::ConfigValidation)?;
 
-        let load_payload_handle = if !restoring {
+        let load_payload_handle = if snapshot.is_none() {
             Self::load_payload_async(&memory_manager, &config)?
         } else {
             None
@@ -796,7 +795,6 @@ impl Vm {
             seccomp_action,
             hypervisor,
             activate_evt,
-            snapshot.is_some(),
             timestamp,
             serial_pty,
             console_pty,


### PR DESCRIPTION
Now the entire codebase has been moved to the new restore design, we can complete the work by creating a dedicated restore() function for the Vm object and get rid of the method restore() from the Snapshottable trait.