### PR TITLE
Decouple CpuManager/MemoryManager creation

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
-use vm_memory::{Address, GuestAddress, GuestMemory, GuestUsize};
+use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryAtomic, GuestUsize};
 
 /// Errors thrown while configuring aarch64 system.
 #[derive(Debug)]
@@ -64,9 +64,9 @@ pub struct EntryPoint {
 pub fn configure_vcpu(
     vcpu: &Arc<dyn hypervisor::Vcpu>,
     id: u8,
-    kernel_entry_point: Option<EntryPoint>,
+    boot_setup: Option<(EntryPoint, &GuestMemoryAtomic<GuestMemoryMmap>)>,
 ) -> super::Result<u64> {
-    if let Some(kernel_entry_point) = kernel_entry_point {
+    if let Some((kernel_entry_point, _guest_memory)) = boot_setup {
         vcpu.setup_regs(
             id,
             kernel_entry_point.entry_addr.raw_value(),

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -547,7 +547,7 @@ impl CpuidFeatureEntry {
 }
 
 pub fn generate_common_cpuid(
-    hypervisor: Arc<dyn hypervisor::Hypervisor>,
+    hypervisor: &Arc<dyn hypervisor::Hypervisor>,
     topology: Option<(u8, u8, u8)>,
     sgx_epc_sections: Option<Vec<SgxEpcSection>>,
     phys_bits: u8,

--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -67,7 +67,7 @@ impl Gic {
     pub fn restore_vgic(
         &mut self,
         state: Option<GicState>,
-        saved_vcpu_states: &Vec<CpuState>,
+        saved_vcpu_states: &[CpuState],
     ) -> Result<()> {
         self.set_gicr_typers(saved_vcpu_states);
         self.vgic

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -746,12 +746,10 @@ impl CpuManager {
         assert!(!self.cpuid.is_empty());
 
         #[cfg(target_arch = "x86_64")]
-        vcpu.configure(boot_setup, self.cpuid.clone(), self.config.kvm_hyperv)
-            .expect("Failed to configure vCPU");
+        vcpu.configure(boot_setup, self.cpuid.clone(), self.config.kvm_hyperv)?;
 
         #[cfg(target_arch = "aarch64")]
-        vcpu.configure(&self.vm, boot_setup)
-            .expect("Failed to configure vCPU");
+        vcpu.configure(&self.vm, boot_setup)?;
 
         Ok(())
     }

--- a/vmm/src/gdb.rs
+++ b/vmm/src/gdb.rs
@@ -5,6 +5,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+use crate::GuestMemoryMmap;
 use gdbstub::{
     arch::Arch,
     common::{Signal, Tid},
@@ -33,7 +34,7 @@ use gdbstub_arch::x86::reg::X86_64CoreRegs as CoreRegs;
 #[cfg(target_arch = "x86_64")]
 use gdbstub_arch::x86::X86_64_SSE as GdbArch;
 use std::{os::unix::net::UnixListener, sync::mpsc};
-use vm_memory::{GuestAddress, GuestMemoryError};
+use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryError};
 
 type ArchUsize = u64;
 
@@ -67,12 +68,14 @@ pub trait Debuggable: vm_migration::Pausable {
     ) -> std::result::Result<(), DebuggableError>;
     fn read_mem(
         &self,
+        guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
         cpu_id: usize,
         vaddr: GuestAddress,
         len: usize,
     ) -> std::result::Result<Vec<u8>, DebuggableError>;
     fn write_mem(
         &self,
+        guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
         cpu_id: usize,
         vaddr: &GuestAddress,
         data: &[u8],

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1506,7 +1506,7 @@ impl Vmm {
         let common_cpuid = {
             let phys_bits = vm::physical_bits(vm_config.lock().unwrap().cpus.max_phys_bits);
             arch::generate_common_cpuid(
-                hypervisor,
+                &hypervisor,
                 None,
                 None,
                 phys_bits,
@@ -1696,7 +1696,7 @@ impl Vmm {
 
             let phys_bits = vm::physical_bits(vm_config.cpus.max_phys_bits);
             arch::generate_common_cpuid(
-                self.hypervisor.clone(),
+                &self.hypervisor.clone(),
                 None,
                 None,
                 phys_bits,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2054,10 +2054,12 @@ impl Vm {
         // Configure the vcpus that have been created
         let vcpus = self.cpu_manager.lock().unwrap().vcpus();
         for vcpu in vcpus {
+            let guest_memory = &self.memory_manager.lock().as_ref().unwrap().guest_memory();
+            let boot_setup = entry_point.map(|e| (e, guest_memory));
             self.cpu_manager
                 .lock()
                 .unwrap()
-                .configure_vcpu(vcpu, entry_point)
+                .configure_vcpu(vcpu, boot_setup)
                 .map_err(Error::CpuManager)?;
         }
 


### PR DESCRIPTION
- vmm: cpu: Rename "vm_memory" parameter/member to "guest_memory"
- aarch, vmm: Reduce requirement for guest memory to vCPU boot only
- vmm: Don't store GuestMemoryMmap for "guest_debug" functionality
- vmm: Seperate the CPUID setup from the CpuManager::new()
- vmm: Propagate vCPU configure error correctly
