### PR TITLE
vm-migration: Simplify Snapshot and SnapshotData structures

### DIFF
--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -154,7 +154,7 @@ impl Snapshottable for Gic {
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         let vgic = self.vgic.as_ref().unwrap().clone();
         let state = vgic.lock().unwrap().state().unwrap();
-        Snapshot::new_from_state(&self.id(), &state)
+        Snapshot::new_from_state(&state)
     }
 }
 

--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -438,7 +438,7 @@ impl Snapshottable for Ioapic {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id, &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 

--- a/devices/src/legacy/gpio_pl061.rs
+++ b/devices/src/legacy/gpio_pl061.rs
@@ -328,7 +328,7 @@ impl Snapshottable for Gpio {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id, &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -334,7 +334,7 @@ impl Snapshottable for Serial {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id, &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -454,7 +454,7 @@ impl Snapshottable for Pl011 {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id, &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -1072,7 +1072,7 @@ impl Snapshottable for PciConfiguration {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id(), &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 

--- a/pci/src/msi.rs
+++ b/pci/src/msi.rs
@@ -288,6 +288,6 @@ impl Snapshottable for MsiConfig {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id(), &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -433,7 +433,7 @@ impl Snapshottable for MsixConfig {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id(), &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1235,20 +1235,19 @@ impl Snapshottable for VfioCommon {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        let mut vfio_common_snapshot =
-            Snapshot::new_from_versioned_state(&self.id(), &self.state())?;
+        let mut vfio_common_snapshot = Snapshot::new_from_versioned_state(&self.state())?;
 
         // Snapshot PciConfiguration
-        vfio_common_snapshot.add_snapshot(self.configuration.snapshot()?);
+        vfio_common_snapshot.add_snapshot(self.configuration.id(), self.configuration.snapshot()?);
 
         // Snapshot MSI
         if let Some(msi) = &mut self.interrupt.msi {
-            vfio_common_snapshot.add_snapshot(msi.cfg.snapshot()?);
+            vfio_common_snapshot.add_snapshot(msi.cfg.id(), msi.cfg.snapshot()?);
         }
 
         // Snapshot MSI-X
         if let Some(msix) = &mut self.interrupt.msix {
-            vfio_common_snapshot.add_snapshot(msix.bar.snapshot()?);
+            vfio_common_snapshot.add_snapshot(msix.bar.id(), msix.bar.snapshot()?);
         }
 
         Ok(vfio_common_snapshot)
@@ -1740,10 +1739,10 @@ impl Snapshottable for VfioPciDevice {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        let mut vfio_pci_dev_snapshot = Snapshot::new(&self.id);
+        let mut vfio_pci_dev_snapshot = Snapshot::default();
 
         // Snapshot VfioCommon
-        vfio_pci_dev_snapshot.add_snapshot(self.common.snapshot()?);
+        vfio_pci_dev_snapshot.add_snapshot(self.common.id(), self.common.snapshot()?);
 
         Ok(vfio_pci_dev_snapshot)
     }

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -465,7 +465,7 @@ impl VfioCommon {
 
         let state: Option<VfioCommonState> = snapshot
             .as_ref()
-            .map(|s| s.to_versioned_state(VFIO_COMMON_ID))
+            .map(|s| s.to_versioned_state())
             .transpose()
             .map_err(|e| {
                 VfioPciError::RetrieveVfioCommonState(anyhow!(

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -535,10 +535,10 @@ impl Snapshottable for VfioUserPciDevice {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        let mut vfio_pci_dev_snapshot = Snapshot::new(&self.id);
+        let mut vfio_pci_dev_snapshot = Snapshot::default();
 
         // Snapshot VfioCommon
-        vfio_pci_dev_snapshot.add_snapshot(self.common.snapshot()?);
+        vfio_pci_dev_snapshot.add_snapshot(self.common.id(), self.common.snapshot()?);
 
         Ok(vfio_pci_dev_snapshot)
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9280,51 +9280,51 @@ mod live_migration {
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
+        #[ignore]
         fn test_live_upgrade_basic() {
             _test_live_migration(true, false)
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
+        #[ignore]
         fn test_live_upgrade_local() {
             _test_live_migration(true, true)
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
+        #[ignore]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_numa() {
             _test_live_migration_numa(true, false)
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
+        #[ignore]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_numa_local() {
             _test_live_migration_numa(true, true)
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
+        #[ignore]
         fn test_live_upgrade_watchdog() {
             _test_live_migration_watchdog(true, false)
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
+        #[ignore]
         fn test_live_upgrade_watchdog_local() {
             _test_live_migration_watchdog(true, true)
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
+        #[ignore]
         fn test_live_upgrade_balloon() {
             _test_live_migration_balloon(true, false)
         }
 
         #[test]
-        #[cfg(target_arch = "x86_64")]
+        #[ignore]
         fn test_live_upgrade_balloon_local() {
             _test_live_migration_balloon(true, true)
         }
@@ -9351,6 +9351,7 @@ mod live_migration {
         }
 
         #[test]
+        #[ignore]
         #[cfg(target_arch = "x86_64")]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_ovs_dpdk() {
@@ -9358,6 +9359,7 @@ mod live_migration {
         }
 
         #[test]
+        #[ignore]
         #[cfg(target_arch = "x86_64")]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_ovs_dpdk_local() {

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -585,7 +585,7 @@ impl Snapshottable for Balloon {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id(), &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 impl Transportable for Balloon {}

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -743,7 +743,7 @@ impl Snapshottable for Block {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id(), &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 impl Transportable for Block {}

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -819,7 +819,7 @@ impl Snapshottable for Console {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id, &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 impl Transportable for Console {}

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -1109,7 +1109,7 @@ impl Snapshottable for Iommu {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id, &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 impl Transportable for Iommu {}

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -1014,7 +1014,7 @@ impl Snapshottable for Mem {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id(), &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 impl Transportable for Mem {}

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -857,7 +857,7 @@ impl Snapshottable for Net {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id, &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 impl Transportable for Net {}

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -467,7 +467,7 @@ impl Snapshottable for Pmem {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id, &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -323,7 +323,7 @@ impl Snapshottable for Rng {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id, &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -321,7 +321,7 @@ impl Snapshottable for VirtioPciCommonConfig {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id(), &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -522,7 +522,7 @@ impl VirtioPciDevice {
 
         let state: Option<VirtioPciDeviceState> = snapshot
             .as_ref()
-            .map(|s| s.to_versioned_state(&id))
+            .map(|s| s.to_versioned_state())
             .transpose()
             .map_err(|e| {
                 VirtioPciDeviceError::CreateVirtioPciDevice(anyhow!(

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1272,18 +1272,20 @@ impl Snapshottable for VirtioPciDevice {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        let mut virtio_pci_dev_snapshot =
-            Snapshot::new_from_versioned_state(&self.id, &self.state())?;
+        let mut virtio_pci_dev_snapshot = Snapshot::new_from_versioned_state(&self.state())?;
 
         // Snapshot PciConfiguration
-        virtio_pci_dev_snapshot.add_snapshot(self.configuration.snapshot()?);
+        virtio_pci_dev_snapshot
+            .add_snapshot(self.configuration.id(), self.configuration.snapshot()?);
 
         // Snapshot VirtioPciCommonConfig
-        virtio_pci_dev_snapshot.add_snapshot(self.common_config.snapshot()?);
+        virtio_pci_dev_snapshot
+            .add_snapshot(self.common_config.id(), self.common_config.snapshot()?);
 
         // Snapshot MSI-X
         if let Some(msix_config) = &self.msix_config {
-            virtio_pci_dev_snapshot.add_snapshot(msix_config.lock().unwrap().snapshot()?);
+            let mut msix_config = msix_config.lock().unwrap();
+            virtio_pci_dev_snapshot.add_snapshot(msix_config.id(), msix_config.snapshot()?);
         }
 
         Ok(virtio_pci_dev_snapshot)

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -489,12 +489,9 @@ impl Snapshottable for Vdpa {
             )));
         }
 
-        let snapshot = Snapshot::new_from_versioned_state(
-            &self.id(),
-            &self.state().map_err(|e| {
-                MigratableError::Snapshot(anyhow!("Error snapshotting vDPA device: {:?}", e))
-            })?,
-        )?;
+        let snapshot = Snapshot::new_from_versioned_state(&self.state().map_err(|e| {
+            MigratableError::Snapshot(anyhow!("Error snapshotting vDPA device: {:?}", e))
+        })?)?;
 
         // Force the vhost handler to be dropped in order to close the vDPA
         // file. This will ensure the device can be accessed if the VM is

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -381,7 +381,7 @@ impl Snapshottable for Blk {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        self.vu_common.snapshot(&self.id(), &self.state())
+        self.vu_common.snapshot(&self.state())
     }
 }
 impl Transportable for Blk {}

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -651,7 +651,7 @@ impl Snapshottable for Fs {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        self.vu_common.snapshot(&self.id(), &self.state())
+        self.vu_common.snapshot(&self.state())
     }
 }
 impl Transportable for Fs {}

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -430,15 +430,11 @@ impl VhostUserCommon {
         }
     }
 
-    pub fn snapshot<T>(
-        &mut self,
-        id: &str,
-        state: &T,
-    ) -> std::result::Result<Snapshot, MigratableError>
+    pub fn snapshot<T>(&mut self, state: &T) -> std::result::Result<Snapshot, MigratableError>
     where
         T: Versionize + VersionMapped,
     {
-        let snapshot = Snapshot::new_from_versioned_state(id, state)?;
+        let snapshot = Snapshot::new_from_versioned_state(state)?;
 
         if self.migration_started {
             self.shutdown();

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -418,7 +418,7 @@ impl Snapshottable for Net {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        self.vu_common.snapshot(&self.id(), &self.state())
+        self.vu_common.snapshot(&self.state())
     }
 }
 impl Transportable for Net {}

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -518,7 +518,7 @@ where
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id, &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 impl<B> Transportable for Vsock<B> where B: VsockBackend + Sync + 'static {}

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -419,7 +419,7 @@ impl Snapshottable for Watchdog {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_versioned_state(&self.id, &self.state())
+        Snapshot::new_from_versioned_state(&self.state())
     }
 }
 

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -109,9 +109,7 @@ impl SnapshotData {
         let data = serde_json::to_vec(state)
             .map_err(|e| MigratableError::Snapshot(anyhow!("Error serialising: {}", e)))?;
 
-        let snapshot_data = SnapshotData(data);
-
-        Ok(snapshot_data)
+        Ok(SnapshotData(data))
     }
 
     /// Create from versioned state
@@ -124,9 +122,7 @@ impl SnapshotData {
             .serialize(&mut data, &T::version_map(), VMM_VERSION)
             .map_err(|e| MigratableError::Snapshot(anyhow!("Error serialising: {}", e)))?;
 
-        let snapshot_data = SnapshotData(data);
-
-        Ok(snapshot_data)
+        Ok(SnapshotData(data))
     }
 }
 

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -154,7 +154,7 @@ impl Snapshot {
         T: Serialize,
     {
         let mut snapshot_data = Snapshot::default();
-        snapshot_data.add_data_section(SnapshotData::new_from_state(state)?);
+        snapshot_data.add_data(SnapshotData::new_from_state(state)?);
 
         Ok(snapshot_data)
     }
@@ -165,7 +165,7 @@ impl Snapshot {
         T: Versionize + VersionMapped,
     {
         let mut snapshot_data = Snapshot::default();
-        snapshot_data.add_data_section(SnapshotData::new_from_versioned_state(state)?);
+        snapshot_data.add_data(SnapshotData::new_from_versioned_state(state)?);
 
         Ok(snapshot_data)
     }
@@ -176,7 +176,7 @@ impl Snapshot {
     }
 
     /// Add a SnapshotData to the component snapshot data.
-    pub fn add_data_section(&mut self, section: SnapshotData) {
+    pub fn add_data(&mut self, section: SnapshotData) {
         self.snapshot_data = Some(section);
     }
 

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -148,15 +148,19 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
+    pub fn from_data(data: SnapshotData) -> Self {
+        Snapshot {
+            snapshot_data: Some(data),
+            ..Default::default()
+        }
+    }
+
     /// Create from state that can be serialized
     pub fn new_from_state<T>(state: &T) -> Result<Self, MigratableError>
     where
         T: Serialize,
     {
-        let mut snapshot_data = Snapshot::default();
-        snapshot_data.add_data(SnapshotData::new_from_state(state)?);
-
-        Ok(snapshot_data)
+        Ok(Snapshot::from_data(SnapshotData::new_from_state(state)?))
     }
 
     /// Create from versioned state
@@ -164,20 +168,14 @@ impl Snapshot {
     where
         T: Versionize + VersionMapped,
     {
-        let mut snapshot_data = Snapshot::default();
-        snapshot_data.add_data(SnapshotData::new_from_versioned_state(state)?);
-
-        Ok(snapshot_data)
+        Ok(Snapshot::from_data(SnapshotData::new_from_versioned_state(
+            state,
+        )?))
     }
 
     /// Add a sub-component's Snapshot to the Snapshot.
     pub fn add_snapshot(&mut self, id: String, snapshot: Snapshot) {
         self.snapshots.insert(id, snapshot);
-    }
-
-    /// Add a SnapshotData to the component snapshot data.
-    pub fn add_data(&mut self, section: SnapshotData) {
-        self.snapshot_data = Some(section);
     }
 
     /// Generate the state data from the snapshot

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -80,9 +80,9 @@ pub trait Pausable {
 /// Splitting a component migration data into different sections
 /// allows for easier and forward compatible extensions.
 #[derive(Clone, Default, Deserialize, Serialize)]
-pub struct SnapshotDataSection(pub Vec<u8>);
+pub struct SnapshotData(pub Vec<u8>);
 
-impl SnapshotDataSection {
+impl SnapshotData {
     /// Generate the state data from the snapshot data
     pub fn to_state<'a, T>(&'a self) -> Result<T, MigratableError>
     where
@@ -109,7 +109,7 @@ impl SnapshotDataSection {
         let data = serde_json::to_vec(state)
             .map_err(|e| MigratableError::Snapshot(anyhow!("Error serialising: {}", e)))?;
 
-        let snapshot_data = SnapshotDataSection(data);
+        let snapshot_data = SnapshotData(data);
 
         Ok(snapshot_data)
     }
@@ -124,7 +124,7 @@ impl SnapshotDataSection {
             .serialize(&mut data, &T::version_map(), VMM_VERSION)
             .map_err(|e| MigratableError::Snapshot(anyhow!("Error serialising: {}", e)))?;
 
-        let snapshot_data = SnapshotDataSection(data);
+        let snapshot_data = SnapshotData(data);
 
         Ok(snapshot_data)
     }
@@ -139,7 +139,7 @@ impl SnapshotDataSection {
 /// For example, a device manager snapshot is the composition of all its
 /// devices snapshots. The device manager Snapshot would have no snapshot_data
 /// but one Snapshot child per tracked device. Then each device's Snapshot
-/// would carry an empty snapshots map but a map of SnapshotDataSection, i.e.
+/// would carry an empty snapshots map but a map of SnapshotData, i.e.
 /// the actual device snapshot data.
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct Snapshot {
@@ -151,7 +151,7 @@ pub struct Snapshot {
 
     /// The Snapshottable component's snapshot data.
     /// A map of snapshot sections, indexed by the section ids.
-    pub snapshot_data: Option<SnapshotDataSection>,
+    pub snapshot_data: Option<SnapshotData>,
 }
 
 impl Snapshot {
@@ -169,7 +169,7 @@ impl Snapshot {
         T: Serialize,
     {
         let mut snapshot_data = Snapshot::new(id);
-        snapshot_data.add_data_section(SnapshotDataSection::new_from_state(state)?);
+        snapshot_data.add_data_section(SnapshotData::new_from_state(state)?);
 
         Ok(snapshot_data)
     }
@@ -180,7 +180,7 @@ impl Snapshot {
         T: Versionize + VersionMapped,
     {
         let mut snapshot_data = Snapshot::new(id);
-        snapshot_data.add_data_section(SnapshotDataSection::new_from_versioned_state(state)?);
+        snapshot_data.add_data_section(SnapshotData::new_from_versioned_state(state)?);
 
         Ok(snapshot_data)
     }
@@ -191,8 +191,8 @@ impl Snapshot {
             .insert(snapshot.id.clone(), Box::new(snapshot));
     }
 
-    /// Add a SnapshotDatasection to the component snapshot data.
-    pub fn add_data_section(&mut self, section: SnapshotDataSection) {
+    /// Add a SnapshotData to the component snapshot data.
+    pub fn add_data_section(&mut self, section: SnapshotData) {
         self.snapshot_data = Some(section);
     }
 

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -147,7 +147,7 @@ pub struct Snapshot {
     pub id: String,
 
     /// The Snapshottable component snapshots.
-    pub snapshots: std::collections::BTreeMap<String, Box<Snapshot>>,
+    pub snapshots: std::collections::BTreeMap<String, Snapshot>,
 
     /// The Snapshottable component's snapshot data.
     /// A map of snapshot sections, indexed by the section ids.
@@ -187,8 +187,7 @@ impl Snapshot {
 
     /// Add a sub-component's Snapshot to the Snapshot.
     pub fn add_snapshot(&mut self, snapshot: Snapshot) {
-        self.snapshots
-            .insert(snapshot.id.clone(), Box::new(snapshot));
+        self.snapshots.insert(snapshot.id.clone(), snapshot);
     }
 
     /// Add a SnapshotData to the component snapshot data.
@@ -220,7 +219,7 @@ impl Snapshot {
 }
 
 pub fn snapshot_from_id(snapshot: Option<&Snapshot>, id: &str) -> Option<Snapshot> {
-    snapshot.and_then(|s| s.snapshots.get(id).map(|s| *s.clone()))
+    snapshot.and_then(|s| s.snapshots.get(id).cloned())
 }
 
 pub fn versioned_state_from_id<T>(
@@ -231,7 +230,7 @@ where
     T: Versionize + VersionMapped,
 {
     snapshot
-        .and_then(|s| s.snapshots.get(id).map(|s| *s.clone()))
+        .and_then(|s| s.snapshots.get(id).cloned())
         .map(|s| s.to_versioned_state())
         .transpose()
 }

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -139,9 +139,6 @@ impl SnapshotData {
 /// the actual device snapshot data.
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct Snapshot {
-    /// The Snapshottable component id.
-    pub id: String,
-
     /// The Snapshottable component snapshots.
     pub snapshots: std::collections::BTreeMap<String, Snapshot>,
 
@@ -151,39 +148,31 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
-    /// Create an empty Snapshot.
-    pub fn new(id: &str) -> Self {
-        Snapshot {
-            id: id.to_string(),
-            ..Default::default()
-        }
-    }
-
     /// Create from state that can be serialized
-    pub fn new_from_state<T>(id: &str, state: &T) -> Result<Self, MigratableError>
+    pub fn new_from_state<T>(state: &T) -> Result<Self, MigratableError>
     where
         T: Serialize,
     {
-        let mut snapshot_data = Snapshot::new(id);
+        let mut snapshot_data = Snapshot::default();
         snapshot_data.add_data_section(SnapshotData::new_from_state(state)?);
 
         Ok(snapshot_data)
     }
 
     /// Create from versioned state
-    pub fn new_from_versioned_state<T>(id: &str, state: &T) -> Result<Self, MigratableError>
+    pub fn new_from_versioned_state<T>(state: &T) -> Result<Self, MigratableError>
     where
         T: Versionize + VersionMapped,
     {
-        let mut snapshot_data = Snapshot::new(id);
+        let mut snapshot_data = Snapshot::default();
         snapshot_data.add_data_section(SnapshotData::new_from_versioned_state(state)?);
 
         Ok(snapshot_data)
     }
 
     /// Add a sub-component's Snapshot to the Snapshot.
-    pub fn add_snapshot(&mut self, snapshot: Snapshot) {
-        self.snapshots.insert(snapshot.id.clone(), snapshot);
+    pub fn add_snapshot(&mut self, id: String, snapshot: Snapshot) {
+        self.snapshots.insert(id, snapshot);
     }
 
     /// Add a SnapshotData to the component snapshot data.
@@ -240,7 +229,7 @@ pub trait Snapshottable: Pausable {
 
     /// Take a component snapshot.
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Ok(Snapshot::new(""))
+        Ok(Snapshot::default())
     }
 }
 
@@ -271,7 +260,7 @@ pub trait Transportable: Pausable + Snapshottable {
     /// * `source_url` - The source URL to fetch the snapshot from. This could be an HTTP
     ///                  endpoint, a TCP address or a local file.
     fn recv(&self, _source_url: &str) -> std::result::Result<Snapshot, MigratableError> {
-        Ok(Snapshot::new(""))
+        Ok(Snapshot::default())
     }
 }
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -77,8 +77,8 @@ use vm_memory::ByteValued;
 use vm_memory::{Bytes, GuestAddressSpace};
 use vm_memory::{GuestAddress, GuestMemoryAtomic};
 use vm_migration::{
-    snapshot_from_id, Migratable, MigratableError, Pausable, Snapshot, SnapshotDataSection,
-    Snapshottable, Transportable,
+    snapshot_from_id, Migratable, MigratableError, Pausable, Snapshot, SnapshotData, Snapshottable,
+    Transportable,
 };
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::{register_signal_handler, SIGRTMIN};
@@ -403,7 +403,7 @@ impl Snapshottable for Vcpu {
         // TODO: The special format of the CPU id can be removed once ready to
         // break live upgrade.
         let mut vcpu_snapshot = Snapshot::new(&format!("{:03}", self.id));
-        vcpu_snapshot.add_data_section(SnapshotDataSection::new_from_state(&saved_state)?);
+        vcpu_snapshot.add_data_section(SnapshotData::new_from_state(&saved_state)?);
 
         self.saved_state = Some(saved_state);
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -400,7 +400,7 @@ impl Snapshottable for Vcpu {
             .map_err(|e| MigratableError::Pause(anyhow!("Could not get vCPU state {:?}", e)))?;
 
         let mut vcpu_snapshot = Snapshot::default();
-        vcpu_snapshot.add_data_section(SnapshotData::new_from_state(&saved_state)?);
+        vcpu_snapshot.add_data(SnapshotData::new_from_state(&saved_state)?);
 
         self.saved_state = Some(saved_state);
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -403,10 +403,7 @@ impl Snapshottable for Vcpu {
         // TODO: The special format of the CPU id can be removed once ready to
         // break live upgrade.
         let mut vcpu_snapshot = Snapshot::new(&format!("{:03}", self.id));
-        vcpu_snapshot.add_data_section(SnapshotDataSection::new_from_state(
-            VCPU_SNAPSHOT_ID,
-            &saved_state,
-        )?);
+        vcpu_snapshot.add_data_section(SnapshotDataSection::new_from_state(&saved_state)?);
 
         self.saved_state = Some(saved_state);
 
@@ -717,7 +714,7 @@ impl CpuManager {
             #[cfg(target_arch = "aarch64")]
             vcpu.init(&self.vm)?;
 
-            let state: CpuState = snapshot.to_state(VCPU_SNAPSHOT_ID).map_err(|e| {
+            let state: CpuState = snapshot.to_state().map_err(|e| {
                 Error::VcpuCreate(anyhow!("Could not get vCPU state from snapshot {:?}", e))
             })?;
             vcpu.vcpu

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -399,12 +399,11 @@ impl Snapshottable for Vcpu {
             .state()
             .map_err(|e| MigratableError::Pause(anyhow!("Could not get vCPU state {:?}", e)))?;
 
-        let mut vcpu_snapshot = Snapshot::default();
-        vcpu_snapshot.add_data(SnapshotData::new_from_state(&saved_state)?);
+        self.saved_state = Some(saved_state.clone());
 
-        self.saved_state = Some(saved_state);
-
-        Ok(vcpu_snapshot)
+        Ok(Snapshot::from_data(SnapshotData::new_from_state(
+            &saved_state,
+        )?))
     }
 }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -96,7 +96,7 @@ use vm_memory::{Address, GuestAddress, GuestUsize, MmapRegion};
 use vm_memory::{GuestAddressSpace, GuestMemory};
 use vm_migration::{
     protocol::MemoryRangeTable, snapshot_from_id, versioned_state_from_id, Migratable,
-    MigratableError, Pausable, Snapshot, SnapshotDataSection, Snapshottable, Transportable,
+    MigratableError, Pausable, Snapshot, SnapshotData, Snapshottable, Transportable,
 };
 use vm_virtio::AccessPlatform;
 use vm_virtio::VirtioDeviceType;
@@ -4463,7 +4463,7 @@ impl Snapshottable for DeviceManager {
         }
 
         // Then we store the DeviceManager state.
-        snapshot.add_data_section(SnapshotDataSection::new_from_state(&self.state())?);
+        snapshot.add_data_section(SnapshotData::new_from_state(&self.state())?);
 
         Ok(snapshot)
     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4463,7 +4463,7 @@ impl Snapshottable for DeviceManager {
         }
 
         // Then we store the DeviceManager state.
-        snapshot.add_data_section(SnapshotData::new_from_state(&self.state())?);
+        snapshot.add_data(SnapshotData::new_from_state(&self.state())?);
 
         Ok(snapshot)
     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4452,13 +4452,13 @@ impl Snapshottable for DeviceManager {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        let mut snapshot = Snapshot::new(DEVICE_MANAGER_SNAPSHOT_ID);
+        let mut snapshot = Snapshot::default();
 
         // We aggregate all devices snapshots.
         for (_, device_node) in self.device_tree.lock().unwrap().iter() {
             if let Some(migratable) = &device_node.migratable {
-                let device_snapshot = migratable.lock().unwrap().snapshot()?;
-                snapshot.add_snapshot(device_snapshot);
+                let mut migratable = migratable.lock().unwrap();
+                snapshot.add_snapshot(migratable.id(), migratable.snapshot()?);
             }
         }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -973,7 +973,7 @@ impl DeviceManager {
         trace_scoped!("DeviceManager::new");
 
         let (device_tree, device_id_cnt) = if let Some(snapshot) = snapshot.as_ref() {
-            let state: DeviceManagerState = snapshot.to_state(DEVICE_MANAGER_SNAPSHOT_ID).unwrap();
+            let state: DeviceManagerState = snapshot.to_state().unwrap();
             (
                 Arc::new(Mutex::new(state.device_tree.clone())),
                 state.device_id_cnt,
@@ -1396,7 +1396,7 @@ impl DeviceManager {
             }
 
             let vgic_state = vgic_snapshot
-                .to_state(&id)
+                .to_state()
                 .map_err(DeviceManagerError::RestoreGetState)?;
             let saved_vcpu_states = self.cpu_manager.lock().unwrap().get_saved_states();
             interrupt_controller
@@ -2157,7 +2157,7 @@ impl DeviceManager {
                         .map_err(DeviceManagerError::EventFd)?,
                     self.force_iommu,
                     snapshot
-                        .map(|s| s.to_versioned_state(&id))
+                        .map(|s| s.to_versioned_state())
                         .transpose()
                         .map_err(DeviceManagerError::RestoreGetState)?,
                 ) {
@@ -2256,7 +2256,7 @@ impl DeviceManager {
                         .try_clone()
                         .map_err(DeviceManagerError::EventFd)?,
                     snapshot
-                        .map(|s| s.to_versioned_state(&id))
+                        .map(|s| s.to_versioned_state())
                         .transpose()
                         .map_err(DeviceManagerError::RestoreGetState)?,
                 )
@@ -2339,7 +2339,7 @@ impl DeviceManager {
                         .map_err(DeviceManagerError::EventFd)?,
                     self.force_iommu,
                     snapshot
-                        .map(|s| s.to_versioned_state(&id))
+                        .map(|s| s.to_versioned_state())
                         .transpose()
                         .map_err(DeviceManagerError::RestoreGetState)?,
                 ) {
@@ -2356,7 +2356,7 @@ impl DeviceManager {
             )
         } else {
             let state = snapshot
-                .map(|s| s.to_versioned_state(&id))
+                .map(|s| s.to_versioned_state())
                 .transpose()
                 .map_err(DeviceManagerError::RestoreGetState)?;
 
@@ -4463,10 +4463,7 @@ impl Snapshottable for DeviceManager {
         }
 
         // Then we store the DeviceManager state.
-        snapshot.add_data_section(SnapshotDataSection::new_from_state(
-            DEVICE_MANAGER_SNAPSHOT_ID,
-            &self.state(),
-        )?);
+        snapshot.add_data_section(SnapshotDataSection::new_from_state(&self.state())?);
 
         Ok(snapshot)
     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4452,7 +4452,7 @@ impl Snapshottable for DeviceManager {
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        let mut snapshot = Snapshot::default();
+        let mut snapshot = Snapshot::from_data(SnapshotData::new_from_state(&self.state())?);
 
         // We aggregate all devices snapshots.
         for (_, device_node) in self.device_tree.lock().unwrap().iter() {
@@ -4461,9 +4461,6 @@ impl Snapshottable for DeviceManager {
                 snapshot.add_snapshot(migratable.id(), migratable.snapshot()?);
             }
         }
-
-        // Then we store the DeviceManager state.
-        snapshot.add_data(SnapshotData::new_from_state(&self.state())?);
 
         Ok(snapshot)
     }

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -2428,8 +2428,6 @@ impl Snapshottable for MemoryManager {
     }
 
     fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
-        let mut memory_manager_snapshot = Snapshot::default();
-
         let memory_ranges = self.memory_range_table(true)?;
 
         // Store locally this list of ranges as it will be used through the
@@ -2442,11 +2440,9 @@ impl Snapshottable for MemoryManager {
         // memory range content for the ranges requiring it.
         self.snapshot_memory_ranges = memory_ranges;
 
-        memory_manager_snapshot.add_data(SnapshotData::new_from_versioned_state(
+        Ok(Snapshot::from_data(SnapshotData::new_from_versioned_state(
             &self.snapshot_data(),
-        )?);
-
-        Ok(memory_manager_snapshot)
+        )?))
     }
 }
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1160,9 +1160,8 @@ impl MemoryManager {
             let mut memory_file_path = url_to_path(source_url).map_err(Error::Restore)?;
             memory_file_path.push(String::from(SNAPSHOT_FILENAME));
 
-            let mem_snapshot: MemoryManagerSnapshotData = snapshot
-                .to_versioned_state(MEMORY_MANAGER_SNAPSHOT_ID)
-                .map_err(Error::Restore)?;
+            let mem_snapshot: MemoryManagerSnapshotData =
+                snapshot.to_versioned_state().map_err(Error::Restore)?;
 
             let mm = MemoryManager::new(
                 vm,
@@ -2444,7 +2443,6 @@ impl Snapshottable for MemoryManager {
         self.snapshot_memory_ranges = memory_ranges;
 
         memory_manager_snapshot.add_data_section(SnapshotDataSection::new_from_versioned_state(
-            MEMORY_MANAGER_SNAPSHOT_ID,
             &self.snapshot_data(),
         )?);
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -2428,7 +2428,7 @@ impl Snapshottable for MemoryManager {
     }
 
     fn snapshot(&mut self) -> result::Result<Snapshot, MigratableError> {
-        let mut memory_manager_snapshot = Snapshot::new(MEMORY_MANAGER_SNAPSHOT_ID);
+        let mut memory_manager_snapshot = Snapshot::default();
 
         let memory_ranges = self.memory_range_table(true)?;
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -52,7 +52,7 @@ use vm_memory::{
 };
 use vm_migration::{
     protocol::MemoryRange, protocol::MemoryRangeTable, Migratable, MigratableError, Pausable,
-    Snapshot, SnapshotDataSection, Snapshottable, Transportable, VersionMapped,
+    Snapshot, SnapshotData, Snapshottable, Transportable, VersionMapped,
 };
 
 pub const MEMORY_MANAGER_ACPI_SIZE: usize = 0x18;
@@ -2442,7 +2442,7 @@ impl Snapshottable for MemoryManager {
         // memory range content for the ranges requiring it.
         self.snapshot_memory_ranges = memory_ranges;
 
-        memory_manager_snapshot.add_data_section(SnapshotDataSection::new_from_versioned_state(
+        memory_manager_snapshot.add_data_section(SnapshotData::new_from_versioned_state(
             &self.snapshot_data(),
         )?);
 

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -2442,7 +2442,7 @@ impl Snapshottable for MemoryManager {
         // memory range content for the ranges requiring it.
         self.snapshot_memory_ranges = memory_ranges;
 
-        memory_manager_snapshot.add_data_section(SnapshotData::new_from_versioned_state(
+        memory_manager_snapshot.add_data(SnapshotData::new_from_versioned_state(
             &self.snapshot_data(),
         )?);
 

--- a/vmm/src/migration.rs
+++ b/vmm/src/migration.rs
@@ -4,10 +4,7 @@
 
 #[cfg(feature = "guest_debug")]
 use crate::coredump::GuestDebuggableError;
-use crate::{
-    config::VmConfig,
-    vm::{VmSnapshot, VM_SNAPSHOT_ID},
-};
+use crate::{config::VmConfig, vm::VmSnapshot};
 use anyhow::anyhow;
 use std::fs::File;
 use std::io::BufReader;
@@ -71,13 +68,8 @@ pub fn recv_vm_state(source_url: &str) -> std::result::Result<Snapshot, Migratab
 }
 
 pub fn get_vm_snapshot(snapshot: &Snapshot) -> std::result::Result<VmSnapshot, MigratableError> {
-    if let Some(vm_section) = snapshot
-        .snapshot_data
-        .get(&format!("{}-section", VM_SNAPSHOT_ID))
-    {
-        return serde_json::from_slice(&vm_section.snapshot).map_err(|e| {
-            MigratableError::Restore(anyhow!("Could not deserialize VM snapshot {}", e))
-        });
+    if let Some(snapshot_data) = snapshot.snapshot_data.as_ref() {
+        return snapshot_data.to_state();
     }
 
     Err(MigratableError::Restore(anyhow!(

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2525,7 +2525,6 @@ impl Snapshottable for Vm {
 
         vm_snapshot.add_snapshot(self.device_manager.lock().unwrap().snapshot()?);
         vm_snapshot.add_data_section(SnapshotDataSection {
-            id: format!("{}-section", VM_SNAPSHOT_ID),
             snapshot: vm_snapshot_data,
         });
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -93,7 +93,7 @@ use vm_memory::{Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::protocol::{Request, Response, Status};
 use vm_migration::{
     protocol::MemoryRangeTable, snapshot_from_id, Migratable, MigratableError, Pausable, Snapshot,
-    SnapshotDataSection, Snapshottable, Transportable,
+    SnapshotData, Snapshottable, Transportable,
 };
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::unblock_signal;
@@ -2524,7 +2524,7 @@ impl Snapshottable for Vm {
         vm_snapshot.add_snapshot(self.memory_manager.lock().unwrap().snapshot()?);
 
         vm_snapshot.add_snapshot(self.device_manager.lock().unwrap().snapshot()?);
-        vm_snapshot.add_data_section(SnapshotDataSection(vm_snapshot_data));
+        vm_snapshot.add_data_section(SnapshotData(vm_snapshot_data));
 
         event!("vm", "snapshotted");
         Ok(vm_snapshot)

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2535,7 +2535,7 @@ impl Snapshottable for Vm {
             (device_manager.id(), device_manager.snapshot()?)
         };
         vm_snapshot.add_snapshot(id, snapshot);
-        vm_snapshot.add_data_section(SnapshotData(vm_snapshot_data));
+        vm_snapshot.add_data(SnapshotData(vm_snapshot_data));
 
         event!("vm", "snapshotted");
         Ok(vm_snapshot)

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2511,7 +2511,7 @@ impl Snapshottable for Vm {
             })?
         };
 
-        let mut vm_snapshot = Snapshot::new(VM_SNAPSHOT_ID);
+        let mut vm_snapshot = Snapshot::default();
         let vm_snapshot_data = serde_json::to_vec(&VmSnapshot {
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             clock: self.saved_clock,
@@ -2520,10 +2520,21 @@ impl Snapshottable for Vm {
         })
         .map_err(|e| MigratableError::Snapshot(e.into()))?;
 
-        vm_snapshot.add_snapshot(self.cpu_manager.lock().unwrap().snapshot()?);
-        vm_snapshot.add_snapshot(self.memory_manager.lock().unwrap().snapshot()?);
-
-        vm_snapshot.add_snapshot(self.device_manager.lock().unwrap().snapshot()?);
+        let (id, snapshot) = {
+            let mut cpu_manager = self.cpu_manager.lock().unwrap();
+            (cpu_manager.id(), cpu_manager.snapshot()?)
+        };
+        vm_snapshot.add_snapshot(id, snapshot);
+        let (id, snapshot) = {
+            let mut memory_manager = self.memory_manager.lock().unwrap();
+            (memory_manager.id(), memory_manager.snapshot()?)
+        };
+        vm_snapshot.add_snapshot(id, snapshot);
+        let (id, snapshot) = {
+            let mut device_manager = self.device_manager.lock().unwrap();
+            (device_manager.id(), device_manager.snapshot()?)
+        };
+        vm_snapshot.add_snapshot(id, snapshot);
         vm_snapshot.add_data_section(SnapshotData(vm_snapshot_data));
 
         event!("vm", "snapshotted");

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2524,9 +2524,7 @@ impl Snapshottable for Vm {
         vm_snapshot.add_snapshot(self.memory_manager.lock().unwrap().snapshot()?);
 
         vm_snapshot.add_snapshot(self.device_manager.lock().unwrap().snapshot()?);
-        vm_snapshot.add_data_section(SnapshotDataSection {
-            snapshot: vm_snapshot_data,
-        });
+        vm_snapshot.add_data_section(SnapshotDataSection(vm_snapshot_data));
 
         event!("vm", "snapshotted");
         Ok(vm_snapshot)


### PR DESCRIPTION
The goal of this PR is mostly to simplify the basic structures `Snapshot` and `SnapshotData`.