### PR TITLE
ch-remote: Add support for vmm.ping

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -8,6 +8,7 @@ extern crate clap;
 
 use api_client::simple_api_command;
 use api_client::simple_api_command_with_fds;
+use api_client::simple_api_full_command_with_fds;
 use api_client::Error as ApiClientError;
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use option_parser::{ByteSized, ByteSizedParseError};
@@ -337,6 +338,11 @@ fn do_command(matches: &ArgMatches) -> Result<(), Error> {
         }
         Some("counters") => {
             simple_api_command(&mut socket, "GET", "counters", None).map_err(Error::ApiClient)
+        }
+        Some("vmm-ping") => {
+            simple_api_full_command_with_fds(
+                &mut socket, "GET", &"vmm.ping", None, Vec::new()
+            ).map_err(Error::ApiClient)
         }
         Some("resize") => resize_api_command(
             &mut socket,
@@ -675,7 +681,8 @@ fn main() {
             Command::new("create")
                 .about("Create VM from a JSON configuration")
                 .arg(Arg::new("path").index(1).default_value("-")),
-        );
+        )
+        .subcommand(Command::new("vmm-ping").about("Request the VMM API server status"));
 
     let matches = app.get_matches();
 


### PR DESCRIPTION
Add vmm-ping subcommand to ch-remote.