### PR TITLE
Gate "coredump" functionality behind x86_64 architecture

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -63,7 +63,6 @@ jobs:
           args: --target=${{ matrix.target }} --locked --all --all-targets --tests -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       - name: Clippy (default features + guest_debug)
-        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -238,7 +238,7 @@ pub static HTTP_ROUTES: Lazy<HttpRoutes> = Lazy::new(|| {
         endpoint!("/vm.snapshot"),
         Box::new(VmActionHandler::new(VmAction::Snapshot(Arc::default()))),
     );
-    #[cfg(feature = "guest_debug")]
+    #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
     r.routes.insert(
         endpoint!("/vm.coredump"),
         Box::new(VmActionHandler::new(VmAction::Coredump(Arc::default()))),

--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -4,7 +4,7 @@
 //
 
 use crate::api::http::{error_response, EndpointHandler, HttpError};
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::api::vm_coredump;
 use crate::api::{
     vm_add_device, vm_add_disk, vm_add_fs, vm_add_net, vm_add_pmem, vm_add_user_device,
@@ -153,7 +153,7 @@ impl EndpointHandler for VmActionHandler {
                     api_sender,
                     Arc::new(serde_json::from_slice(body.raw())?),
                 ),
-                #[cfg(feature = "guest_debug")]
+                #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
                 Coredump(_) => vm_coredump(
                     api_notifier,
                     api_sender,

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -320,7 +320,7 @@ pub enum ApiRequest {
     VmRestore(Arc<RestoreConfig>, Sender<ApiResponse>),
 
     /// Take a VM coredump
-    #[cfg(feature = "guest_debug")]
+    #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
     VmCoredump(Arc<VmCoredumpData>, Sender<ApiResponse>),
 
     /// Incoming migration
@@ -416,7 +416,7 @@ pub enum VmAction {
     Snapshot(Arc<VmSnapshotConfig>),
 
     /// Coredump VM
-    #[cfg(feature = "guest_debug")]
+    #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
     Coredump(Arc<VmCoredumpData>),
 
     /// Incoming migration
@@ -458,7 +458,7 @@ fn vm_action(
         ResizeZone(v) => ApiRequest::VmResizeZone(v, response_sender),
         Restore(v) => ApiRequest::VmRestore(v, response_sender),
         Snapshot(v) => ApiRequest::VmSnapshot(v, response_sender),
-        #[cfg(feature = "guest_debug")]
+        #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
         Coredump(v) => ApiRequest::VmCoredump(v, response_sender),
         ReceiveMigration(v) => ApiRequest::VmReceiveMigration(v, response_sender),
         SendMigration(v) => ApiRequest::VmSendMigration(v, response_sender),
@@ -545,7 +545,7 @@ pub fn vm_restore(
     vm_action(api_evt, api_sender, VmAction::Restore(data))
 }
 
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 pub fn vm_coredump(
     api_evt: EventFd,
     api_sender: Sender<ApiRequest>,

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -12,7 +12,7 @@
 //
 
 use crate::config::CpusConfig;
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::coredump::{
     CpuElf64Writable, CpuSegment, CpuState as DumpCpusState, DumpState, Elf64Writable,
     GuestDebuggableError, NoteDescType, X86_64ElfPrStatus, X86_64UserRegs, COREDUMP_NAME_SIZE,
@@ -42,11 +42,11 @@ use gdbstub_arch::aarch64::reg::AArch64CoreRegs as CoreRegs;
 use gdbstub_arch::x86::reg::{X86SegmentRegs, X86_64CoreRegs as CoreRegs};
 #[cfg(all(target_arch = "aarch64", feature = "guest_debug"))]
 use hypervisor::aarch64::StandardRegisters;
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use hypervisor::arch::x86::msr_index;
 #[cfg(target_arch = "x86_64")]
 use hypervisor::arch::x86::CpuIdEntry;
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use hypervisor::arch::x86::MsrEntry;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use hypervisor::arch::x86::{SpecialRegisters, StandardRegisters};
@@ -56,13 +56,13 @@ use hypervisor::kvm::kvm_bindings;
 use hypervisor::kvm::{TdxExitDetails, TdxExitStatus};
 use hypervisor::{CpuState, HypervisorCpuError, HypervisorType, VmExit, VmOps};
 use libc::{c_void, siginfo_t};
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use linux_loader::elf::Elf64_Nhdr;
 use seccompiler::{apply_filter, SeccompAction};
 use std::collections::BTreeMap;
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use std::io::Write;
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use std::mem::size_of;
 use std::os::unix::thread::JoinHandleExt;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -71,7 +71,7 @@ use std::{cmp, io, result, thread};
 use thiserror::Error;
 use tracer::trace_scoped;
 use vm_device::BusDevice;
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use vm_memory::ByteValued;
 #[cfg(feature = "guest_debug")]
 use vm_memory::{Bytes, GuestAddressSpace};
@@ -277,7 +277,7 @@ struct InterruptSourceOverride {
     pub flags: u16,
 }
 
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 macro_rules! round_up {
     ($n:expr,$d:expr) => {
         (($n / ($d + 1)) + 1) * $d
@@ -2315,10 +2315,10 @@ impl Debuggable for CpuManager {
     }
 }
 
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 impl Elf64Writable for CpuManager {}
 
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 impl CpuElf64Writable for CpuManager {
     fn cpu_write_elf64_note(
         &mut self,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -18,7 +18,7 @@ use crate::config::{
     add_to_config, DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, RestoreConfig,
     UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
 };
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::coredump::GuestDebuggable;
 use crate::memory_manager::MemoryManager;
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
@@ -61,7 +61,7 @@ mod acpi;
 pub mod api;
 mod clone3;
 pub mod config;
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 mod coredump;
 pub mod cpu;
 pub mod device_manager;
@@ -696,7 +696,7 @@ impl Vmm {
         }
     }
 
-    #[cfg(feature = "guest_debug")]
+    #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
     fn vm_coredump(&mut self, destination_url: &str) -> result::Result<(), VmError> {
         if let Some(ref mut vm) = self.vm {
             vm.coredump(destination_url).map_err(VmError::Coredump)
@@ -1868,7 +1868,7 @@ impl Vmm {
 
                                     sender.send(response).map_err(Error::ApiResponseSend)?;
                                 }
-                                #[cfg(feature = "guest_debug")]
+                                #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
                                 ApiRequest::VmCoredump(coredump_data, sender) => {
                                     let response = self
                                         .vm_coredump(&coredump_data.destination_url)

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -5,10 +5,10 @@
 #[cfg(target_arch = "x86_64")]
 use crate::config::SgxEpcConfig;
 use crate::config::{HotplugMethod, MemoryConfig, MemoryZoneConfig};
-#[cfg(feature = "guest_debug")]
-use crate::coredump::{CoredumpMemoryRegion, CoredumpMemoryRegions};
-#[cfg(feature = "guest_debug")]
-use crate::coredump::{DumpState, GuestDebuggableError};
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
+use crate::coredump::{
+    CoredumpMemoryRegion, CoredumpMemoryRegions, DumpState, GuestDebuggableError,
+};
 use crate::migration::url_to_path;
 use crate::MEMORY_MANAGER_SNAPSHOT_ID;
 use crate::{GuestMemoryMmap, GuestRegionMmap};
@@ -24,7 +24,7 @@ use hypervisor::HypervisorVmError;
 #[cfg(target_arch = "x86_64")]
 use libc::{MAP_NORESERVE, MAP_POPULATE, MAP_SHARED, PROT_READ, PROT_WRITE};
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -1960,7 +1960,7 @@ impl MemoryManager {
         self.uefi_flash.as_ref().unwrap().clone()
     }
 
-    #[cfg(feature = "guest_debug")]
+    #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
     pub fn coredump_memory_regions(&self, mem_offset: u64) -> CoredumpMemoryRegions {
         let mut mapping_sorted_by_gpa = self.guest_ram_mappings.clone();
         mapping_sorted_by_gpa.sort_by_key(|m| m.gpa);
@@ -1981,7 +1981,7 @@ impl MemoryManager {
         CoredumpMemoryRegions { ram_maps }
     }
 
-    #[cfg(feature = "guest_debug")]
+    #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
     pub fn coredump_iterate_save_mem(
         &mut self,
         dump_state: &DumpState,

--- a/vmm/src/migration.rs
+++ b/vmm/src/migration.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::coredump::GuestDebuggableError;
 use crate::{
     config::VmConfig,
@@ -34,7 +34,7 @@ pub fn url_to_path(url: &str) -> std::result::Result<PathBuf, MigratableError> {
     Ok(path)
 }
 
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 pub fn url_to_file(url: &str) -> std::result::Result<PathBuf, GuestDebuggableError> {
     let file: PathBuf = url
         .strip_prefix("file://")

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -16,7 +16,7 @@ use crate::config::{
     UserDeviceConfig, ValidationError, VdpaConfig, VmConfig, VsockConfig,
 };
 use crate::config::{NumaConfig, PayloadConfig};
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::coredump::{
     CpuElf64Writable, DumpState, Elf64Writable, GuestDebuggable, GuestDebuggableError, NoteDescType,
 };
@@ -30,7 +30,7 @@ use crate::memory_manager::{
 };
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
 use crate::migration::get_vm_snapshot;
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::migration::url_to_file;
 use crate::migration::{url_to_path, SNAPSHOT_CONFIG_FILE, SNAPSHOT_STATE_FILE};
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
@@ -57,7 +57,7 @@ use gdbstub_arch::aarch64::reg::AArch64CoreRegs as CoreRegs;
 use gdbstub_arch::x86::reg::X86_64CoreRegs as CoreRegs;
 use hypervisor::{HypervisorVmError, VmOps};
 use linux_loader::cmdline::Cmdline;
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use linux_loader::elf;
 #[cfg(target_arch = "x86_64")]
 use linux_loader::loader::elf::PvhBootCapability::PvhEntryPresent;
@@ -75,7 +75,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, Seek, SeekFrom, Write};
 #[cfg(feature = "tdx")]
 use std::mem;
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use std::mem::size_of;
 use std::num::Wrapping;
 use std::ops::Deref;
@@ -305,7 +305,7 @@ pub enum Error {
     #[error("Payload configuration is not bootable")]
     InvalidPayload,
 
-    #[cfg(feature = "guest_debug")]
+    #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
     #[error("Error coredumping VM: {0:?}")]
     Coredump(GuestDebuggableError),
 }
@@ -2341,7 +2341,7 @@ impl Vm {
         Ok(GdbResponsePayload::CommandComplete)
     }
 
-    #[cfg(feature = "guest_debug")]
+    #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
     fn get_dump_state(
         &mut self,
         destination_url: &str,
@@ -2382,7 +2382,7 @@ impl Vm {
         })
     }
 
-    #[cfg(feature = "guest_debug")]
+    #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
     fn coredump_get_mem_offset(&self, phdr_num: u16, note_size: isize) -> u64 {
         size_of::<elf::Elf64_Ehdr>() as u64
             + note_size as u64
@@ -2710,10 +2710,10 @@ impl Debuggable for Vm {
 #[cfg(feature = "guest_debug")]
 pub const UINT16_MAX: u32 = 65535;
 
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 impl Elf64Writable for Vm {}
 
-#[cfg(feature = "guest_debug")]
+#[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 impl GuestDebuggable for Vm {
     fn coredump(&mut self, destination_url: &str) -> std::result::Result<(), GuestDebuggableError> {
         event!("vm", "coredumping");


### PR DESCRIPTION
- vmm: guest_debug: Mark coredump functionality x86_64 only
- .github: Enable "guest_debug" clippy on aarch64
