### PR TITLE
Reduce clippy/compiler overrides

### DIFF
--- a/acpi_tables/src/sdt.rs
+++ b/acpi_tables/src/sdt.rs
@@ -38,7 +38,6 @@ pub struct Sdt {
     data: Vec<u8>,
 }
 
-#[allow(clippy::len_without_is_empty)]
 impl Sdt {
     pub fn new(
         signature: [u8; 4],
@@ -123,6 +122,10 @@ impl Sdt {
 
     pub fn len(&self) -> usize {
         self.data.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
     }
 }
 

--- a/block_util/src/async_io.rs
+++ b/block_util/src/async_io.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use libc::{ioctl, S_IFBLK, S_IFMT};
-use std::convert::TryInto;
 use std::fs::File;
 use std::os::unix::io::AsRawFd;
 use thiserror::Error;
@@ -66,7 +65,6 @@ impl DiskTopology {
     }
 
     // libc::ioctl() takes different types on different architectures
-    #[allow(clippy::useless_conversion)]
     fn query_block_size(f: &mut File, block_size_type: BlockSize) -> std::io::Result<u64> {
         let mut block_size = 0;
         // SAFETY: FFI call with correct arguments
@@ -78,9 +76,7 @@ impl DiskTopology {
                     BlockSize::PhysicalBlock => BLKPBSZGET(),
                     BlockSize::MinimumIo => BLKIOMIN(),
                     BlockSize::OptimalIo => BLKIOOPT(),
-                }
-                .try_into()
-                .unwrap(),
+                } as _,
                 &mut block_size,
             )
         };

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -61,12 +61,10 @@ pub enum ClockType {
     /// Equivalent to `libc::CLOCK_MONOTONIC`.
     Monotonic,
     /// Equivalent to `libc::CLOCK_REALTIME`.
-    #[allow(dead_code)]
     Real,
     /// Equivalent to `libc::CLOCK_PROCESS_CPUTIME_ID`.
     ProcessCpu,
     /// Equivalent to `libc::CLOCK_THREAD_CPUTIME_ID`.
-    #[allow(dead_code)]
     ThreadCpu,
 }
 
@@ -101,7 +99,7 @@ pub struct LocalTime {
 
 impl LocalTime {
     /// Returns the [LocalTime](struct.LocalTime.html) structure for the calling moment.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn now() -> LocalTime {
         let mut timespec = libc::timespec {
             tv_sec: 0,
@@ -170,22 +168,6 @@ impl Default for TimestampUs {
             time_us: get_time(ClockType::Monotonic) / 1000,
             cputime_us: get_time(ClockType::ProcessCpu) / 1000,
         }
-    }
-}
-
-/// Returns a timestamp in nanoseconds from a monotonic clock.
-///
-/// Uses `_rdstc` on `x86_64` and [`get_time`](fn.get_time.html) on other architectures.
-#[allow(dead_code)]
-pub fn timestamp_cycles() -> u64 {
-    #[cfg(target_arch = "x86_64")]
-    // SAFETY: there's nothing that can go wrong with this call.
-    unsafe {
-        std::arch::x86_64::_rdtsc() as u64
-    }
-    #[cfg(not(target_arch = "x86_64"))]
-    {
-        get_time(ClockType::Monotonic)
     }
 }
 
@@ -525,7 +507,6 @@ mod tests {
         ($test_name: ident, $write_fn_name: ident, $read_fn_name: ident, $is_be: expr, $data_type: ty) => {
             #[test]
             fn $test_name() {
-                #[allow(overflowing_literals)]
                 let test_cases = [
                     (
                         0x0123_4567_89AB_CDEF as u64,

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -33,11 +33,9 @@ bitflags! {
     }
 }
 
-#[allow(unused_macros)]
 #[cfg(target_arch = "aarch64")]
 macro_rules! generate_read_fn {
     ($fn_name: ident, $data_type: ty, $byte_type: ty, $type_size: expr, $endian_type: ident) => {
-        #[allow(dead_code)]
         pub fn $fn_name(input: &[$byte_type]) -> $data_type {
             assert!($type_size == std::mem::size_of::<$data_type>());
             let mut array = [0u8; $type_size];
@@ -49,11 +47,9 @@ macro_rules! generate_read_fn {
     };
 }
 
-#[allow(unused_macros)]
 #[cfg(target_arch = "aarch64")]
 macro_rules! generate_write_fn {
     ($fn_name: ident, $data_type: ty, $byte_type: ty, $endian_type: ident) => {
-        #[allow(dead_code)]
         pub fn $fn_name(buf: &mut [$byte_type], n: $data_type) {
             for (byte, read) in buf
                 .iter_mut()

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -61,7 +61,9 @@ pub use vm::{
 
 #[derive(Debug, Copy, Clone)]
 pub enum HypervisorType {
+    #[cfg(feature = "kvm")]
     Kvm,
+    #[cfg(feature = "mshv")]
     Mshv,
 }
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -241,8 +241,6 @@ fn create_vmm_ioctl_seccomp_rule_hypervisor(
         HypervisorType::Kvm => create_vmm_ioctl_seccomp_rule_common_kvm(),
         #[cfg(feature = "mshv")]
         HypervisorType::Mshv => create_vmm_ioctl_seccomp_rule_common_mshv(),
-        #[allow(unreachable_patterns)]
-        _ => panic!("Invalid hypervisor {:?}", hypervisor_type),
     }
 }
 
@@ -418,8 +416,6 @@ fn create_vmm_ioctl_seccomp_rule(
         HypervisorType::Kvm => create_vmm_ioctl_seccomp_rule_kvm(),
         #[cfg(feature = "mshv")]
         HypervisorType::Mshv => create_vmm_ioctl_seccomp_rule_mshv(),
-        #[allow(unreachable_patterns)]
-        _ => panic!("Invalid hypervisor {:?}", hypervisor_type),
     }
 }
 
@@ -653,8 +649,6 @@ fn create_vcpu_ioctl_seccomp_rule_hypervisor(
         HypervisorType::Kvm => create_vcpu_ioctl_seccomp_rule_kvm(),
         #[cfg(feature = "mshv")]
         HypervisorType::Mshv => create_vcpu_ioctl_seccomp_rule_mshv(),
-        #[allow(unreachable_patterns)]
-        _ => panic!("Invalid hypervisor {:?}", hypervisor_type),
     }
 }
 


### PR DESCRIPTION
Not a complete set of clippy oriented improvements but a small start

- acpi_tables: sdt: Implement Std::is_empty()
- block_util: Use anonymous case to handle ioctl signature difference
- devices: Remove unnecessary clippy directives
- vmm: seccomp: Remove unreachable patterns

See #4986 
