### PR TITLE
build: Bump mshv-ioctls from `10d0c52` to `ef01a5a`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 [[package]]
 name = "mshv-bindings"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#10d0c5208cc41a3958e0fd31fabf2c88b18a97b5"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#ef01a5abd0377701b3cee7ed6c69d7353db78a9f"
 dependencies = [
  "libc",
  "serde",
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "mshv-ioctls"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#10d0c5208cc41a3958e0fd31fabf2c88b18a97b5"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#ef01a5abd0377701b3cee7ed6c69d7353db78a9f"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -446,10 +446,10 @@ impl cpu::Vcpu for MshvVcpu {
                             /* Advance RIP and update RAX */
                             let arr_reg_name_value = [
                                 (
-                                    hv_register_name::HV_X64_REGISTER_RIP,
+                                    hv_x64_register_name_HV_X64_REGISTER_RIP,
                                     info.header.rip + insn_len,
                                 ),
-                                (hv_register_name::HV_X64_REGISTER_RAX, ret_rax),
+                                (hv_x64_register_name_HV_X64_REGISTER_RAX, ret_rax),
                             ];
                             set_registers_64!(self.fd, arr_reg_name_value)
                                 .map_err(|e| cpu::HypervisorCpuError::SetRegister(e.into()))?;
@@ -495,10 +495,10 @@ impl cpu::Vcpu for MshvVcpu {
                     /* Advance RIP and update RAX */
                     let arr_reg_name_value = [
                         (
-                            hv_register_name::HV_X64_REGISTER_RIP,
+                            hv_x64_register_name_HV_X64_REGISTER_RIP,
                             info.header.rip + insn_len,
                         ),
-                        (hv_register_name::HV_X64_REGISTER_RAX, ret_rax),
+                        (hv_x64_register_name_HV_X64_REGISTER_RAX, ret_rax),
                     ];
                     set_registers_64!(self.fd, arr_reg_name_value)
                         .map_err(|e| cpu::HypervisorCpuError::SetRegister(e.into()))?;


### PR DESCRIPTION
With this bump there was a change in one of the externally exposed variable. Thus, the use of that variable in CLH must be adjusted accordingly.

Signed-off-by: Jinank Jain <jinankjain@microsoft.com>