### PR TITLE
vmm: add configuration for network offloading features

### DIFF
--- a/fuzz/fuzz_targets/net.rs
+++ b/fuzz/fuzz_targets/net.rs
@@ -76,6 +76,9 @@ fuzz_target!(|bytes| {
         None,
         EventFd::new(EFD_NONBLOCK).unwrap(),
         None,
+        true,
+        true,
+        true,
     )
     .unwrap();
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -134,6 +134,8 @@ pub enum ValidationError {
     VnetQueueFdMismatch,
     /// Using reserved fd
     VnetReservedFd,
+    /// Hardware checksum offload is disabled.
+    NoHardwareChecksumOffload,
     /// Hugepages not turned on
     HugePageSizeWithoutHugePages,
     /// Huge page size is not power of 2
@@ -205,6 +207,10 @@ impl fmt::Display for ValidationError {
                 "Number of queues to virtio_net does not match the number of input FDs"
             ),
             VnetReservedFd => write!(f, "Reserved fd number (<= 2)"),
+            NoHardwareChecksumOffload => write!(
+                f,
+                "\"offload_tso\" and \"offload_ufo\" depend on \"offload_tso\""
+            ),
             HugePageSizeWithoutHugePages => {
                 write!(f, "Huge page size specified but huge pages not enabled")
             }
@@ -1006,7 +1012,8 @@ impl NetConfig {
     num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,id=<device_id>,\
     vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>,vhost_mode=client|server,\
     bw_size=<bytes>,bw_one_time_burst=<bytes>,bw_refill_time=<ms>,\
-    ops_size=<io_ops>,ops_one_time_burst=<io_ops>,ops_refill_time=<ms>,pci_segment=<segment_id>\"";
+    ops_size=<io_ops>,ops_one_time_burst=<io_ops>,ops_refill_time=<ms>,pci_segment=<segment_id>\
+    offload_tso=on|off,offload_ufo=on|off,offload_csum=on|off\"";
 
     pub fn parse(net: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -1017,6 +1024,9 @@ impl NetConfig {
             .add("mask")
             .add("mac")
             .add("host_mac")
+            .add("offload_tso")
+            .add("offload_ufo")
+            .add("offload_csum")
             .add("mtu")
             .add("iommu")
             .add("queue_size")
@@ -1049,6 +1059,21 @@ impl NetConfig {
             .map_err(Error::ParseNetwork)?
             .unwrap_or_else(default_netconfig_mac);
         let host_mac = parser.convert("host_mac").map_err(Error::ParseNetwork)?;
+        let offload_tso = parser
+            .convert::<Toggle>("offload_tso")
+            .map_err(Error::ParseNetwork)?
+            .unwrap_or(Toggle(true))
+            .0;
+        let offload_ufo = parser
+            .convert::<Toggle>("offload_ufo")
+            .map_err(Error::ParseNetwork)?
+            .unwrap_or(Toggle(true))
+            .0;
+        let offload_csum = parser
+            .convert::<Toggle>("offload_csum")
+            .map_err(Error::ParseNetwork)?
+            .unwrap_or(Toggle(true))
+            .0;
         let mtu = parser.convert("mtu").map_err(Error::ParseNetwork)?;
         let iommu = parser
             .convert::<Toggle>("iommu")
@@ -1150,6 +1175,9 @@ impl NetConfig {
             fds,
             rate_limiter_config,
             pci_segment,
+            offload_tso,
+            offload_ufo,
+            offload_csum,
         };
         Ok(config)
     }
@@ -1195,6 +1223,10 @@ impl NetConfig {
             if mtu < virtio_devices::net::MIN_MTU {
                 return Err(ValidationError::InvalidMtu(mtu));
             }
+        }
+
+        if !self.offload_csum && (self.offload_tso || self.offload_ufo) {
+            return Err(ValidationError::NoHardwareChecksumOffload);
         }
 
         Ok(())
@@ -2934,6 +2966,16 @@ mod tests {
         assert_eq!(
             invalid_config.validate(),
             Err(ValidationError::VnetReservedFd)
+        );
+
+        let mut invalid_config = valid_config.clone();
+        invalid_config.net = Some(vec![NetConfig {
+            offload_csum: false,
+            ..Default::default()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::NoHardwareChecksumOffload)
         );
 
         let mut invalid_config = valid_config.clone();

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2334,6 +2334,9 @@ impl DeviceManager {
                         .map(|s| s.to_versioned_state())
                         .transpose()
                         .map_err(DeviceManagerError::RestoreGetState)?,
+                    net_cfg.offload_tso,
+                    net_cfg.offload_ufo,
+                    net_cfg.offload_csum,
                 ) {
                     Ok(vun_device) => vun_device,
                     Err(e) => {
@@ -2371,6 +2374,9 @@ impl DeviceManager {
                             .try_clone()
                             .map_err(DeviceManagerError::EventFd)?,
                         state,
+                        net_cfg.offload_tso,
+                        net_cfg.offload_ufo,
+                        net_cfg.offload_csum,
                     )
                     .map_err(DeviceManagerError::CreateVirtioNet)?,
                 ))
@@ -2389,6 +2395,9 @@ impl DeviceManager {
                             .try_clone()
                             .map_err(DeviceManagerError::EventFd)?,
                         state,
+                        net_cfg.offload_tso,
+                        net_cfg.offload_ufo,
+                        net_cfg.offload_csum,
                     )
                     .map_err(DeviceManagerError::CreateVirtioNet)?,
                 ))
@@ -2411,6 +2420,9 @@ impl DeviceManager {
                             .try_clone()
                             .map_err(DeviceManagerError::EventFd)?,
                         state,
+                        net_cfg.offload_tso,
+                        net_cfg.offload_ufo,
+                        net_cfg.offload_csum,
                     )
                     .map_err(DeviceManagerError::CreateVirtioNet)?,
                 ))

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -291,6 +291,16 @@ pub struct NetConfig {
     pub rate_limiter_config: Option<RateLimiterConfig>,
     #[serde(default)]
     pub pci_segment: u16,
+    #[serde(default = "default_netconfig_true")]
+    pub offload_tso: bool,
+    #[serde(default = "default_netconfig_true")]
+    pub offload_ufo: bool,
+    #[serde(default = "default_netconfig_true")]
+    pub offload_csum: bool,
+}
+
+pub fn default_netconfig_true() -> bool {
+    true
 }
 
 pub fn default_netconfig_tap() -> Option<String> {
@@ -340,6 +350,9 @@ impl Default for NetConfig {
             fds: None,
             rate_limiter_config: None,
             pci_segment: 0,
+            offload_tso: true,
+            offload_ufo: true,
+            offload_csum: true,
         }
     }
 }


### PR DESCRIPTION
Add new configuration for offloading features, including Checksum/TSO/UFO, and set these offloading features as disabled by default.

Fixes: #4792.

Signed-off-by: Yong He <alexyonghe@tencent.com>