### PR TITLE
Proposal: add virtio-block process latency accounting

### DIFF
--- a/block_util/src/lib.rs
+++ b/block_util/src/lib.rs
@@ -32,6 +32,7 @@ use std::path::Path;
 use std::result;
 use std::sync::Arc;
 use std::sync::MutexGuard;
+use std::time::Instant;
 use thiserror::Error;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
@@ -199,6 +200,7 @@ pub struct Request {
     pub status_addr: GuestAddress,
     pub writeback: bool,
     pub aligned_operations: Vec<AlignedOperation>,
+    pub start: Instant,
 }
 
 impl Request {
@@ -230,6 +232,7 @@ impl Request {
             status_addr: GuestAddress(0),
             writeback: true,
             aligned_operations: Vec::new(),
+            start: Instant::now(),
         };
 
         let status_desc;


### PR DESCRIPTION
Once IO jitter occurs inside VM, we need some metric to show the virtio-block process latency to do help investigate.

This PR adds latency counters for virtio-block base request, so that we could get virtio-block process latency by counters, the feature is disabled by default, you have to add these configs to disks `"latency":{"low":30,"mid":60,"hig":100}`, this mean enables latency accounting, now support three thresholds, this mean there will be four latency range.

The latency counters could be got via counter API, the result will be something like this.

`{"_disk0":{"read_latency_huge":0,"write_ops":0,"read_bytes":4096,"write_bytes":0,"read_latency_low":1,"write_latency_mid":0,"write_latency_huge":0,"read_latency_high":0,"write_latency_low":0,"write_latency_high":0,"read_ops":1,"read_latency_mid":0},"_fs1":{"read_bytes":0,"read_ops":0,"write_ops":0,"write_bytes":0}}`