### PR TITLE
tests: Remove support for Ubuntu Bionic

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,9 +296,8 @@ Currently the following items are **not** guaranteed across updates:
 
 Further details can be found in the [release documentation](docs/releases.md).
 
-As of 2022-10-13, the following cloud images are supported:
+As of 2023-01-03, the following cloud images are supported:
 
-- [Ubuntu Bionic](https://cloud-images.ubuntu.com/bionic/current/) (bionic-server-cloudimg-{amd64,arm64}.img)
 - [Ubuntu Focal](https://cloud-images.ubuntu.com/focal/current/) (focal-server-cloudimg-{amd64,arm64}.img)
 - [Ubuntu Jammy](https://cloud-images.ubuntu.com/jammy/current/) (jammy-server-cloudimg-{amd64,arm64}.img )
 - [Fedora 36](https://fedora.mirrorservice.org/fedora/linux/releases/36/Cloud/) ([Fedora-Cloud-Base-36-1.5.x86_64.raw.xz](https://fedora.mirrorservice.org/fedora/linux/releases/36/Cloud/x86_64/images/) / [Fedora-Cloud-Base-36-1.5.aarch64.raw.xz](https://fedora.mirrorservice.org/fedora/linux/releases/36/Cloud/aarch64/images/))

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -36,24 +36,6 @@ if [ ! -f "$OVMF_FW" ]; then
     popd
 fi
 
-BIONIC_OS_IMAGE_NAME="bionic-server-cloudimg-amd64.qcow2"
-BIONIC_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$BIONIC_OS_IMAGE_NAME"
-BIONIC_OS_IMAGE="$WORKLOADS_DIR/$BIONIC_OS_IMAGE_NAME"
-if [ ! -f "$BIONIC_OS_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
-    time wget --quiet $BIONIC_OS_IMAGE_URL || exit 1
-    popd
-fi
-
-BIONIC_OS_RAW_IMAGE_NAME="bionic-server-cloudimg-amd64.raw"
-BIONIC_OS_RAW_IMAGE="$WORKLOADS_DIR/$BIONIC_OS_RAW_IMAGE_NAME"
-if [ ! -f "$BIONIC_OS_RAW_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
-    time qemu-img convert -p -f qcow2 -O raw $BIONIC_OS_IMAGE_NAME $BIONIC_OS_RAW_IMAGE_NAME || exit 1
-    popd
-fi
-
-
 FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
 FOCAL_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$FOCAL_OS_IMAGE_NAME"
 FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"

--- a/scripts/sha1sums-x86_64
+++ b/scripts/sha1sums-x86_64
@@ -1,5 +1,3 @@
-27f3b17962ace69b51f0ddc2012095e3109e6ed8 bionic-server-cloudimg-amd64.qcow2
-8db9cc58b01452ce2d06c313177e6e74d8582d93 bionic-server-cloudimg-amd64.raw
 d4a44acc6014d5f83dea1c625c43d677a95fa75f alpine-minirootfs-x86_64.tar.gz
 f1eccdc5e1b515dbad294426ab081b47ebfb97c0 focal-server-cloudimg-amd64-custom-20210609-0.qcow2
 7f5a8358243a96adf61f5c20139b29f308f2c0e3 focal-server-cloudimg-amd64-custom-20210609-0.raw

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -32,7 +32,6 @@ use wait_timeout::ChildExt;
 
 #[cfg(target_arch = "x86_64")]
 mod x86_64 {
-    pub const BIONIC_IMAGE_NAME: &str = "bionic-server-cloudimg-amd64.raw";
     pub const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-custom-20210609-0.raw";
     pub const FOCAL_SGX_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-sgx.raw";
     pub const JAMMY_NVIDIA_IMAGE_NAME: &str = "jammy-server-cloudimg-amd64-nvidia.raw";
@@ -1891,20 +1890,8 @@ mod common_parallel {
 
     #[test]
     #[cfg(target_arch = "x86_64")]
-    fn test_bionic_hypervisor_fw() {
-        test_simple_launch(fw_path(FwType::RustHypervisorFirmware), BIONIC_IMAGE_NAME)
-    }
-
-    #[test]
-    #[cfg(target_arch = "x86_64")]
     fn test_focal_hypervisor_fw() {
         test_simple_launch(fw_path(FwType::RustHypervisorFirmware), FOCAL_IMAGE_NAME)
-    }
-
-    #[test]
-    #[cfg(target_arch = "x86_64")]
-    fn test_bionic_ovmf() {
-        test_simple_launch(fw_path(FwType::Ovmf), BIONIC_IMAGE_NAME)
     }
 
     #[test]


### PR DESCRIPTION
This OS is EOL this year and is well tested by the Rust Hypervisor
Firmware CI so there is no need to duplicate this effort.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
