### PR TITLE
Measure UDP PPS in performance metrics

### DIFF
--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -78,7 +78,7 @@ fn direct_kernel_boot_path() -> PathBuf {
 
 pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
     let test_timeout = control.test_timeout;
-    let rx = control.net_rx.unwrap();
+    let (rx, bandwidth) = control.net_control.unwrap();
 
     let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
     let guest = performance_test_new_guest(Box::new(focal));
@@ -105,7 +105,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
 
     let r = std::panic::catch_unwind(|| {
         guest.wait_vm_boot(None).unwrap();
-        measure_virtio_net_throughput(test_timeout, num_queues / 2, &guest, rx, true).unwrap()
+        measure_virtio_net_throughput(test_timeout, num_queues / 2, &guest, rx, bandwidth).unwrap()
     });
 
     let _ = child.kill();

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -105,7 +105,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
 
     let r = std::panic::catch_unwind(|| {
         guest.wait_vm_boot(None).unwrap();
-        measure_virtio_net_throughput(test_timeout, num_queues / 2, &guest, rx).unwrap()
+        measure_virtio_net_throughput(test_timeout, num_queues / 2, &guest, rx, true).unwrap()
     });
 
     let _ = child.kill();
@@ -429,7 +429,7 @@ mod tests {
 }
        "#;
         assert_eq!(
-            parse_iperf3_output(output.as_bytes(), true).unwrap(),
+            parse_iperf3_output(output.as_bytes(), true, true).unwrap(),
             23957198874.604115
         );
 
@@ -448,8 +448,30 @@ mod tests {
 }
               "#;
         assert_eq!(
-            parse_iperf3_output(output.as_bytes(), false).unwrap(),
+            parse_iperf3_output(output.as_bytes(), false, true).unwrap(),
             39520744482.79
+        );
+        let output = r#"
+{
+    "end":	{
+        "sum":  {
+            "start":        0,
+            "end":  5.000036,
+            "seconds":      5.000036,
+            "bytes":        29944971264,
+            "bits_per_second":      47911877363.396217,
+            "jitter_ms":    0.0038609822983198556,
+            "lost_packets": 16,
+            "packets":      913848,
+            "lost_percent": 0.0017508382137948542,
+            "sender":       true
+        }
+    }
+}
+              "#;
+        assert_eq!(
+            parse_iperf3_output(output.as_bytes(), true, false).unwrap(),
+            182765.08409139456
         );
     }
 

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1517,6 +1517,8 @@ pub fn measure_virtio_net_throughput(
             &format!("{}", default_port + n),
             "-t",
             &format!("{test_timeout}"),
+            "-i",
+            "0",
         ]);
         // For measuring the guest transmit throughput (as a sender),
         // use reverse mode of the iperf3 client on the host

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9423,7 +9423,8 @@ mod rate_limiter {
         let r = std::panic::catch_unwind(|| {
             guest.wait_vm_boot(None).unwrap();
             let measured_bps =
-                measure_virtio_net_throughput(test_timeout, num_queues / 2, &guest, rx).unwrap();
+                measure_virtio_net_throughput(test_timeout, num_queues / 2, &guest, rx, true)
+                    .unwrap();
             assert!(check_rate_limit(measured_bps, limit_bps, 0.1));
         });
 


### PR DESCRIPTION
Pump as many packets as possible through the link. Account for only the packets that are not lost.

Output looks like this:

```
Test 'virtio_net_throughput_single_queue_tx_pps' running .. (control: test_timeout = 10s, test_iterations = 5, num_queues = 2, queue_size = 256, rx = false, bandwidth = false, overrides: )
Test 'virtio_net_throughput_single_queue_tx_pps' .. ok: mean = 495612.1093586601, std_dev = 34035.03688487209
Test 'virtio_net_throughput_single_queue_rx_pps' running .. (control: test_timeout = 10s, test_iterations = 5, num_queues = 2, queue_size = 256, rx = true, bandwidth = false, overrides: )
Test 'virtio_net_throughput_single_queue_rx_pps' .. ok: mean = 237217.9915156765, std_dev = 2578.1319394996667
Test 'virtio_net_throughput_multi_queue_tx_pps' running .. (control: test_timeout = 10s, test_iterations = 5, num_queues = 4, queue_size = 256, rx = false, bandwidth = false, overrides: )
Test 'virtio_net_throughput_multi_queue_tx_pps' .. ok: mean = 530321.4940044105, std_dev = 33546.872191479095
Test 'virtio_net_throughput_multi_queue_rx_pps' running .. (control: test_timeout = 10s, test_iterations = 5, num_queues = 4, queue_size = 256, rx = true, bandwidth = false, overrides: )
Test 'virtio_net_throughput_multi_queue_rx_pps' .. ok: mean = 240654.67634990936, std_dev = 51097.366007567005
```