### PR TITLE
log: align log message timestamp

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ impl log::Log for Logger {
         if record.file().is_some() && record.line().is_some() {
             writeln!(
                 *(*(self.output.lock().unwrap())),
-                "cloud-hypervisor: {:?}: <{}> {}:{}:{} -- {}",
+                "cloud-hypervisor: {:.6?}: <{}> {}:{}:{} -- {}",
                 duration,
                 std::thread::current().name().unwrap_or("anonymous"),
                 record.level(),
@@ -100,7 +100,7 @@ impl log::Log for Logger {
         } else {
             writeln!(
                 *(*(self.output.lock().unwrap())),
-                "cloud-hypervisor: {:?}: <{}> {}:{} -- {}",
+                "cloud-hypervisor: {:.6?}: <{}> {}:{} -- {}",
                 duration,
                 std::thread::current().name().unwrap_or("anonymous"),
                 record.level(),


### PR DESCRIPTION
With this change, all log messages will have the same width for the timestamp. The amount of ms is rounded to 6 decimal places.


**Before (not aligned in every case):**
![image](https://user-images.githubusercontent.com/5737016/211335399-23d26cb0-45a0-4c14-ad4b-926bda66ab17.png)


**After:**
![image](https://user-images.githubusercontent.com/5737016/211335299-d8cab28b-902a-44f9-85b9-fdd8e2fe0888.png)
