### PR TITLE
block_util: Avoid reallocation of Vec on push

### DIFF
--- a/block_util/src/lib.rs
+++ b/block_util/src/lib.rs
@@ -249,6 +249,7 @@ impl Request {
                 return Err(Error::DescriptorChainTooShort);
             }
         } else {
+            req.data_descriptors.reserve_exact(1);
             while desc.has_next() {
                 if desc.is_write_only() && req.request_type == RequestType::Out {
                     return Err(Error::UnexpectedWriteOnlyDescriptor);
@@ -353,7 +354,7 @@ impl Request {
         let request_type = self.request_type;
         let offset = (sector << SECTOR_SHIFT) as libc::off_t;
 
-        let mut iovecs = Vec::new();
+        let mut iovecs = Vec::with_capacity(self.data_descriptors.len());
         for (data_addr, data_len) in &self.data_descriptors {
             if *data_len == 0 {
                 continue;

--- a/block_util/src/raw_async.rs
+++ b/block_util/src/raw_async.rs
@@ -156,9 +156,8 @@ impl AsyncIo for RawFileAsync {
     }
 
     fn complete(&mut self) -> Vec<(u64, i32)> {
-        let mut completion_list = Vec::new();
-
         let cq = self.io_uring.completion();
+        let mut completion_list = Vec::with_capacity(cq.len());
         for cq_entry in cq {
             completion_list.push((cq_entry.user_data(), cq_entry.result()));
         }


### PR DESCRIPTION
When using DHAT[1] for analysis the amount heap allocations change from:

dhat: Total:     3,186,536 bytes in 41,452 blocks

 to

dhat: Total:     1,059,816 bytes in 34,747 blocks

When running against virtio-block; this still more allocations than
virtio-pmem but a significant improvement without any cost.

[1] https://docs.rs/dhat/latest/dhat/

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
