### PR TITLE
Revert "vmm: Deprecate MemoryZoneConfig::file"

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -207,6 +207,7 @@ describing how every memory region is backed and exposed to the guest.
 struct MemoryZoneConfig {
     id: String,
     size: u64,
+    file: Option<PathBuf>,
     shared: bool,
     hugepages: bool,
     hugepage_size: Option<u64>,
@@ -218,7 +219,7 @@ struct MemoryZoneConfig {
 ```
 
 ```
---memory-zone <memory-zone>	User defined memory zone parameters "size=<guest_memory_region_size>,shared=on|off,hugepages=on|off,hugepage_size=<hugepage_size>,host_numa_node=<node_id>,id=<zone_identifier>,hotplug_size=<hotpluggable_memory_size>,hotplugged_size=<hotplugged_memory_size>,prefault=on|off"
+--memory-zone <memory-zone>	User defined memory zone parameters "size=<guest_memory_region_size>,file=<backing_file>,shared=on|off,hugepages=on|off,hugepage_size=<hugepage_size>,host_numa_node=<node_id>,id=<zone_identifier>,hotplug_size=<hotpluggable_memory_size>,hotplugged_size=<hotplugged_memory_size>,prefault=on|off"
 ```
 
 This parameter expects one or more occurences, allowing for a list of memory
@@ -261,6 +262,30 @@ _Example_
 ```
 --memory size=0
 --memory-zone id=mem0,size=1G
+```
+
+### `file`
+
+Path to the file backing the memory zone. This can be either a file or a
+directory. In case of a file, it will be opened and used as the backing file
+for the `mmap(2)` operation. In case of a directory, a temporary file with no
+hard link on the filesystem will be created. This file will be used as the
+backing file for the `mmap(2)` operation.
+
+This option can be particularly useful when trying to back a part of the guest
+RAM with a well known file. In the context of the snapshot/restore feature, and
+if the provided path is a file, the snapshot operation will not perform any
+copy of the guest RAM content for this specific memory zone since the user has
+access to it and it would duplicate data already stored on the current
+filesystem.
+
+Value is a string.
+
+_Example_
+
+```
+--memory size=0
+--memory-zone id=mem0,size=1G,file=/foo/bar
 ```
 
 ### `shared`

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,7 @@ fn create_app(default_vcpus: String, default_memory: String, default_rng: String
                 .long("memory-zone")
                 .help(
                     "User defined memory zone parameters \
-                     \"size=<guest_memory_region_size>,\
+                     \"size=<guest_memory_region_size>,file=<backing_file>,\
                      shared=on|off,\
                      hugepages=on|off,hugepage_size=<hugepage_size>,\
                      host_numa_node=<node_id>,\

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -668,6 +668,8 @@ components:
           type: integer
           format: int64
           default: 512 MB
+        file:
+          type: string
         mergeable:
           type: boolean
           default: false

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2009,10 +2009,6 @@ impl VmConfig {
 
         if let Some(zones) = &self.memory.zones {
             for zone in zones.iter() {
-                if zone.file.is_some() {
-                    warn!("MemoryZoneConfig::file is deprecated and will be removed in future release (#4837)");
-                }
-
                 let id = zone.id.clone();
                 Self::validate_identifier(&mut id_list, &Some(id))?;
             }


### PR DESCRIPTION
This reverts commit 9fb0274479afe2bcebdf53245b542b1261ad0985.

A user was identified of this functionality.

See: #4837
