### PR TITLE
Further optimise heap allocations for block I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,7 @@ dependencies = [
  "libc",
  "log",
  "qcow",
+ "smallvec",
  "thiserror",
  "versionize",
  "versionize_derive",

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -12,6 +12,7 @@ io-uring = "0.5.9"
 libc = "0.2.139"
 log = "0.4.17"
 qcow = { path = "../qcow" }
+smallvec = "1.10.0"
 thiserror = "1.0.37"
 versionize = "0.1.9"
 versionize_derive = "0.1.4"

--- a/block_util/src/async_io.rs
+++ b/block_util/src/async_io.rs
@@ -131,13 +131,13 @@ pub trait AsyncIo: Send {
     fn read_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()>;
     fn write_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()>;
     fn fsync(&mut self, user_data: Option<u64>) -> AsyncIoResult<()>;

--- a/block_util/src/async_io.rs
+++ b/block_util/src/async_io.rs
@@ -141,5 +141,5 @@ pub trait AsyncIo: Send {
         user_data: u64,
     ) -> AsyncIoResult<()>;
     fn fsync(&mut self, user_data: Option<u64>) -> AsyncIoResult<()>;
-    fn complete(&mut self) -> Vec<(u64, i32)>;
+    fn next_completed_request(&mut self) -> Option<(u64, i32)>;
 }

--- a/block_util/src/fixed_vhd_async.rs
+++ b/block_util/src/fixed_vhd_async.rs
@@ -104,7 +104,7 @@ impl AsyncIo for FixedVhdAsync {
         self.raw_file_async.fsync(user_data)
     }
 
-    fn complete(&mut self) -> Vec<(u64, i32)> {
-        self.raw_file_async.complete()
+    fn next_completed_request(&mut self) -> Option<(u64, i32)> {
+        self.raw_file_async.next_completed_request()
     }
 }

--- a/block_util/src/fixed_vhd_async.rs
+++ b/block_util/src/fixed_vhd_async.rs
@@ -64,7 +64,7 @@ impl AsyncIo for FixedVhdAsync {
     fn read_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
         if offset as u64 >= self.size {
@@ -83,7 +83,7 @@ impl AsyncIo for FixedVhdAsync {
     fn write_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
         if offset as u64 >= self.size {

--- a/block_util/src/fixed_vhd_sync.rs
+++ b/block_util/src/fixed_vhd_sync.rs
@@ -101,7 +101,7 @@ impl AsyncIo for FixedVhdSync {
         self.raw_file_sync.fsync(user_data)
     }
 
-    fn complete(&mut self) -> Vec<(u64, i32)> {
-        self.raw_file_sync.complete()
+    fn next_completed_request(&mut self) -> Option<(u64, i32)> {
+        self.raw_file_sync.next_completed_request()
     }
 }

--- a/block_util/src/fixed_vhd_sync.rs
+++ b/block_util/src/fixed_vhd_sync.rs
@@ -62,7 +62,7 @@ impl AsyncIo for FixedVhdSync {
     fn read_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
         if offset as u64 >= self.size {
@@ -81,7 +81,7 @@ impl AsyncIo for FixedVhdSync {
     fn write_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
         if offset as u64 >= self.size {

--- a/block_util/src/lib.rs
+++ b/block_util/src/lib.rs
@@ -431,12 +431,12 @@ impl Request {
                         .mark_dirty(0, *data_len as usize);
                 }
                 disk_image
-                    .read_vectored(offset, iovecs, user_data)
+                    .read_vectored(offset, &iovecs, user_data)
                     .map_err(ExecuteError::AsyncRead)?;
             }
             RequestType::Out => {
                 disk_image
-                    .write_vectored(offset, iovecs, user_data)
+                    .write_vectored(offset, &iovecs, user_data)
                     .map_err(ExecuteError::AsyncWrite)?;
             }
             RequestType::Flush => {
@@ -590,7 +590,7 @@ where
     fn read_vectored_sync(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
         eventfd: &EventFd,
         completion_list: &mut Vec<(u64, i32)>,
@@ -623,7 +623,7 @@ where
     fn write_vectored_sync(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
         eventfd: &EventFd,
         completion_list: &mut Vec<(u64, i32)>,

--- a/block_util/src/qcow_sync.rs
+++ b/block_util/src/qcow_sync.rs
@@ -97,7 +97,7 @@ impl AsyncIo for QcowSync {
             .fsync_sync(user_data, &self.eventfd, &mut self.completion_list)
     }
 
-    fn complete(&mut self) -> Vec<(u64, i32)> {
-        self.completion_list.drain(..).collect()
+    fn next_completed_request(&mut self) -> Option<(u64, i32)> {
+        self.completion_list.pop()
     }
 }

--- a/block_util/src/qcow_sync.rs
+++ b/block_util/src/qcow_sync.rs
@@ -65,7 +65,7 @@ impl AsyncIo for QcowSync {
     fn read_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
         self.qcow_file.read_vectored_sync(
@@ -80,7 +80,7 @@ impl AsyncIo for QcowSync {
     fn write_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
         self.qcow_file.write_vectored_sync(

--- a/block_util/src/raw_async.rs
+++ b/block_util/src/raw_async.rs
@@ -155,13 +155,10 @@ impl AsyncIo for RawFileAsync {
         Ok(())
     }
 
-    fn complete(&mut self) -> Vec<(u64, i32)> {
-        let cq = self.io_uring.completion();
-        let mut completion_list = Vec::with_capacity(cq.len());
-        for cq_entry in cq {
-            completion_list.push((cq_entry.user_data(), cq_entry.result()));
-        }
-
-        completion_list
+    fn next_completed_request(&mut self) -> Option<(u64, i32)> {
+        self.io_uring
+            .completion()
+            .next()
+            .map(|entry| (entry.user_data(), entry.result()))
     }
 }

--- a/block_util/src/raw_async.rs
+++ b/block_util/src/raw_async.rs
@@ -76,7 +76,7 @@ impl AsyncIo for RawFileAsync {
     fn read_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
         let (submitter, mut sq, _) = self.io_uring.split();
@@ -104,7 +104,7 @@ impl AsyncIo for RawFileAsync {
     fn write_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
         let (submitter, mut sq, _) = self.io_uring.split();

--- a/block_util/src/raw_sync.rs
+++ b/block_util/src/raw_sync.rs
@@ -127,7 +127,7 @@ impl AsyncIo for RawFileSync {
         Ok(())
     }
 
-    fn complete(&mut self) -> Vec<(u64, i32)> {
-        self.completion_list.drain(..).collect()
+    fn next_completed_request(&mut self) -> Option<(u64, i32)> {
+        self.completion_list.pop()
     }
 }

--- a/block_util/src/raw_sync.rs
+++ b/block_util/src/raw_sync.rs
@@ -65,7 +65,7 @@ impl AsyncIo for RawFileSync {
     fn read_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
         // SAFETY: FFI call with valid arguments
@@ -90,7 +90,7 @@ impl AsyncIo for RawFileSync {
     fn write_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
         // SAFETY: FFI call with valid arguments

--- a/block_util/src/vhdx_sync.rs
+++ b/block_util/src/vhdx_sync.rs
@@ -64,7 +64,7 @@ impl AsyncIo for VhdxSync {
     fn read_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
         self.vhdx_file.read_vectored_sync(
@@ -79,7 +79,7 @@ impl AsyncIo for VhdxSync {
     fn write_vectored(
         &mut self,
         offset: libc::off_t,
-        iovecs: Vec<libc::iovec>,
+        iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
         self.vhdx_file.write_vectored_sync(

--- a/block_util/src/vhdx_sync.rs
+++ b/block_util/src/vhdx_sync.rs
@@ -4,6 +4,7 @@
 
 use crate::async_io::{AsyncIo, AsyncIoResult, DiskFile, DiskFileError, DiskFileResult};
 use crate::AsyncAdaptor;
+use std::collections::VecDeque;
 use std::fs::File;
 use std::sync::{Arc, Mutex, MutexGuard};
 use vhdx::vhdx::{Result as VhdxResult, Vhdx};
@@ -37,7 +38,7 @@ impl DiskFile for VhdxDiskSync {
 pub struct VhdxSync {
     vhdx_file: Arc<Mutex<Vhdx>>,
     eventfd: EventFd,
-    completion_list: Vec<(u64, i32)>,
+    completion_list: VecDeque<(u64, i32)>,
 }
 
 impl VhdxSync {
@@ -45,7 +46,7 @@ impl VhdxSync {
         Ok(VhdxSync {
             vhdx_file,
             eventfd: EventFd::new(libc::EFD_NONBLOCK)?,
-            completion_list: Vec::new(),
+            completion_list: VecDeque::new(),
         })
     }
 }
@@ -97,6 +98,6 @@ impl AsyncIo for VhdxSync {
     }
 
     fn next_completed_request(&mut self) -> Option<(u64, i32)> {
-        self.completion_list.pop()
+        self.completion_list.pop_front()
     }
 }

--- a/block_util/src/vhdx_sync.rs
+++ b/block_util/src/vhdx_sync.rs
@@ -96,7 +96,7 @@ impl AsyncIo for VhdxSync {
             .fsync_sync(user_data, &self.eventfd, &mut self.completion_list)
     }
 
-    fn complete(&mut self) -> Vec<(u64, i32)> {
-        self.completion_list.drain(..).collect()
+    fn next_completed_request(&mut self) -> Option<(u64, i32)> {
+        self.completion_list.pop()
     }
 }

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -244,8 +244,7 @@ impl BlockEpollHandler {
         let mut read_ops = Wrapping(0);
         let mut write_ops = Wrapping(0);
 
-        let completion_list = self.disk_image.complete();
-        for (user_data, result) in completion_list {
+        while let Some((user_data, result)) = self.disk_image.next_completed_request() {
             let desc_index = user_data as u16;
 
             let mut request = self.find_inflight_request(desc_index)?;


### PR DESCRIPTION
- block_util: Pass a reference to the slice of iovecs
- block_util: Use SmallVec for I/O requests
- block_util: Avoid intermediate completion queue allocation
- block_util: Preserve ordering of sync file backend completions

The total DHAT change is:

dhat: Total:     1,166,412 bytes in 40,383 blocks

to

dhat: Total:     380,444 bytes in 3,469 blocks
