### PR TITLE
Revert "build: drop clap from dev-dependencies"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,52 +1,51 @@
 name: Cloud Hypervisor Release
-on: [create]
+on: [pull_request, create]
 
 jobs:
   release:
-    if: github.event_name == 'create' && github.event.ref_type == 'tag'
     name: Release
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
       - name: Install musl-gcc
-        run: sudo apt install -y musl-tools      
+        run: sudo apt install -y musl-tools
       - name: Create release directory
         run: rsync -rv --exclude=.git . ../cloud-hypervisor-${{ github.event.ref }}
       - name: Install Rust toolchain (x86_64-unknown-linux-gnu)
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: "1.62"
-            target: x86_64-unknown-linux-gnu
+          toolchain: "1.62"
+          target: x86_64-unknown-linux-gnu
       - name: Install Rust toolchain (x86_64-unknown-linux-musl)
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: "1.62"
-            target: x86_64-unknown-linux-musl
+          toolchain: "1.62"
+          target: x86_64-unknown-linux-musl
       - name: Build
         uses: actions-rs/cargo@v1
         with:
-            toolchain: "1.62"
-            command: build
-            args: --all --release --no-default-features --features "kvm,mshv" --target=x86_64-unknown-linux-gnu
+          toolchain: "1.62"
+          command: build
+          args: --all --release --no-default-features --features "kvm,mshv" --target=x86_64-unknown-linux-gnu
       - name: Static Build
         uses: actions-rs/cargo@v1
         with:
-            toolchain: "1.62"
-            command: build
-            args: --all --release --no-default-features --features "kvm,mshv" --target=x86_64-unknown-linux-musl
+          toolchain: "1.62"
+          command: build
+          args: --all --release --no-default-features --features "kvm,mshv" --target=x86_64-unknown-linux-musl
       - name: Install Rust toolchain (aarch64-unknown-linux-musl)
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: "1.62"
-            target: aarch64-unknown-linux-musl
-            override: true
+          toolchain: "1.62"
+          target: aarch64-unknown-linux-musl
+          override: true
       - name: Static Build (AArch64)
         uses: actions-rs/cargo@v1
         with:
-            use-cross: true
-            command: build
-            args: --all --release --target=aarch64-unknown-linux-musl
+          use-cross: true
+          command: build
+          args: --all --release --target=aarch64-unknown-linux-musl
       - name: Vendor
         working-directory: ../cloud-hypervisor-${{ github.event.ref }}
         run: |
@@ -55,6 +54,7 @@ jobs:
           mkdir .cargo
           cargo vendor > .cargo/config.toml
       - name: Create Release
+        if: github.event_name == 'create' && github.event.ref_type == 'tag'
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -66,8 +66,9 @@ jobs:
           prerelease: true
       - name: Create vendored source archive
         working-directory: ../
-        run:  tar cJf cloud-hypervisor-${{ github.event.ref }}.tar.xz cloud-hypervisor-${{ github.event.ref }}
+        run: tar cJf cloud-hypervisor-${{ github.event.ref }}.tar.xz cloud-hypervisor-${{ github.event.ref }}
       - name: Upload cloud-hypervisor vendored source archive
+        if: github.event_name == 'create' && github.event.ref_type == 'tag'
         id: upload-release-cloud-hypervisor-vendored-sources
         uses: actions/upload-release-asset@v1
         env:
@@ -78,6 +79,7 @@ jobs:
           asset_name: cloud-hypervisor-${{ github.event.ref }}.tar.xz
           asset_content_type: application/x-xz
       - name: Upload cloud-hypervisor
+        if: github.event_name == 'create' && github.event.ref_type == 'tag'
         id: upload-release-cloud-hypervisor
         uses: actions/upload-release-asset@v1
         env:
@@ -88,6 +90,7 @@ jobs:
           asset_name: cloud-hypervisor
           asset_content_type: application/octet-stream
       - name: Upload static cloud-hypervisor
+        if: github.event_name == 'create' && github.event.ref_type == 'tag'
         id: upload-release-static-cloud-hypervisor
         uses: actions/upload-release-asset@v1
         env:
@@ -98,6 +101,7 @@ jobs:
           asset_name: cloud-hypervisor-static
           asset_content_type: application/octet-stream
       - name: Upload ch-remote
+        if: github.event_name == 'create' && github.event.ref_type == 'tag'
         id: upload-release-ch-remote
         uses: actions/upload-release-asset@v1
         env:
@@ -108,6 +112,7 @@ jobs:
           asset_name: ch-remote
           asset_content_type: application/octet-stream
       - name: Upload static-ch-remote
+        if: github.event_name == 'create' && github.event.ref_type == 'tag'
         id: upload-release-static-ch-remote
         uses: actions/upload-release-asset@v1
         env:
@@ -118,6 +123,7 @@ jobs:
           asset_name: ch-remote-static
           asset_content_type: application/octet-stream
       - name: Upload static AArch64 cloud-hypervisor
+        if: github.event_name == 'create' && github.event.ref_type == 'tag'
         id: upload-release-static-aarch64-cloud-hypervisor
         uses: actions/upload-release-asset@v1
         env:
@@ -128,6 +134,7 @@ jobs:
           asset_name: cloud-hypervisor-static-aarch64
           asset_content_type: application/octet-stream
       - name: Upload static AArch64 ch-remote
+        if: github.event_name == 'create' && github.event.ref_type == 'tag'
         id: upload-release-static-aarch64-ch-remote
         uses: actions/upload-release-asset@v1
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ vmm = { path = "vmm" }
 vmm-sys-util = "0.11.0"
 vm-memory = "0.10.0"
 
+[build-dependencies]
+clap = { version = "4.0.29", features = ["cargo"] }
+
 # List of patched crates
 [patch.crates-io]
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.6.0-tdx" }

--- a/build.rs
+++ b/build.rs
@@ -3,10 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#[macro_use(crate_version)]
+extern crate clap;
+
 use std::process::Command;
 
 fn main() {
-    let mut version = "v".to_owned() + env!("CARGO_PKG_VERSION");
+    let mut version = "v".to_owned() + crate_version!();
 
     if let Ok(git_out) = Command::new("git").args(["describe", "--dirty"]).output() {
         if git_out.status.success() {

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -13,3 +13,6 @@ serde_json = "1.0.89"
 test_infra = { path = "../test_infra" }
 thiserror = "1.0.37"
 wait-timeout = "0.2.0"
+
+[build-dependencies]
+clap = { version = "4.0.29", features = ["cargo"] }

--- a/performance-metrics/build.rs
+++ b/performance-metrics/build.rs
@@ -3,11 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#[macro_use(crate_version)]
+extern crate clap;
+
 use std::process::Command;
 
 fn main() {
-    let mut git_human_readable = "v".to_owned() + env!("CARGO_PKG_VERSION");
-
+    let mut git_human_readable = "v".to_owned() + crate_version!();
     if let Ok(git_out) = Command::new("git").args(["describe", "--dirty"]).output() {
         if git_out.status.success() {
             if let Ok(git_out_str) = String::from_utf8(git_out.stdout) {

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -20,3 +20,5 @@ virtio-queue = "0.7.0"
 vm-memory = "0.10.0"
 vmm-sys-util = "0.11.0"
 
+[build-dependencies]
+clap = { version = "4.0.29", features = ["cargo"] }

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -18,3 +18,5 @@ virtio-bindings = "0.1.0"
 vm-memory = "0.10.0"
 vmm-sys-util = "0.11.0"
 
+[build-dependencies]
+clap = { version = "4.0.29", features = ["cargo"] }


### PR DESCRIPTION
This reverts commit 998fb48ff276821f3b3ced6d07d492130eef7fec.

This is breaking the release build process (cross build for aarch64
musl) so temporarily reverting until we can identify the cause to allow
the release proceeed.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
