### PR TITLE
Reland: build: drop clap from dev-dependencies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,10 @@ jobs:
           toolchain: "1.62"
           target: aarch64-unknown-linux-musl
           override: true
+      - name: Clean build tree ahead of cross build
+        uses: actions-rs/cargo@v1
+        with:
+          command: clean
       - name: Static Build (AArch64)
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,6 @@ vmm = { path = "vmm" }
 vmm-sys-util = "0.11.0"
 vm-memory = "0.10.0"
 
-[build-dependencies]
-clap = { version = "4.0.29", features = ["cargo"] }
-
 # List of patched crates
 [patch.crates-io]
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.6.0-tdx" }

--- a/build.rs
+++ b/build.rs
@@ -3,13 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#[macro_use(crate_version)]
-extern crate clap;
-
 use std::process::Command;
 
 fn main() {
-    let mut version = "v".to_owned() + crate_version!();
+    let mut version = "v".to_owned() + env!("CARGO_PKG_VERSION");
 
     if let Ok(git_out) = Command::new("git").args(["describe", "--dirty"]).output() {
         if git_out.status.success() {

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -13,6 +13,3 @@ serde_json = "1.0.89"
 test_infra = { path = "../test_infra" }
 thiserror = "1.0.38"
 wait-timeout = "0.2.0"
-
-[build-dependencies]
-clap = { version = "4.0.29", features = ["cargo"] }

--- a/performance-metrics/build.rs
+++ b/performance-metrics/build.rs
@@ -3,13 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#[macro_use(crate_version)]
-extern crate clap;
-
 use std::process::Command;
 
 fn main() {
-    let mut git_human_readable = "v".to_owned() + crate_version!();
+    let mut git_human_readable = "v".to_owned() + env!("CARGO_PKG_VERSION");
+
     if let Ok(git_out) = Command::new("git").args(["describe", "--dirty"]).output() {
         if git_out.status.success() {
             if let Ok(git_out_str) = String::from_utf8(git_out.stdout) {

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -20,5 +20,3 @@ virtio-queue = "0.7.0"
 vm-memory = "0.10.0"
 vmm-sys-util = "0.11.0"
 
-[build-dependencies]
-clap = { version = "4.0.29", features = ["cargo"] }

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -18,5 +18,3 @@ virtio-bindings = "0.1.0"
 vm-memory = "0.10.0"
 vmm-sys-util = "0.11.0"
 
-[build-dependencies]
-clap = { version = "4.0.29", features = ["cargo"] }


### PR DESCRIPTION
Some crates don't need it at all.

Some crates are using it for a simple functionality which can be
replaced easily.

Signed-off-by: Wei Liu <liuwe@microsoft.com>

This was causing issues with the release build process but we now have a
fix to clean residual build assets.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
