### PR TITLE
.github: Re-order release steps to ensure binaries are available

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,23 +40,6 @@ jobs:
           toolchain: "1.62"
           target: aarch64-unknown-linux-musl
           override: true
-      - name: Clean build tree ahead of cross build
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
-      - name: Static Build (AArch64)
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --all --release --target=aarch64-unknown-linux-musl
-      - name: Vendor
-        working-directory: ../cloud-hypervisor-${{ github.event.ref }}
-        run: |
-          mkdir ../vendor-cargo-home
-          export CARGO_HOME=$(realpath ../vendor-cargo-home)
-          mkdir .cargo
-          cargo vendor > .cargo/config.toml
       - name: Create Release
         if: github.event_name == 'create' && github.event.ref_type == 'tag'
         id: create_release
@@ -68,20 +51,6 @@ jobs:
           release_name: ${{ github.ref }}
           draft: true
           prerelease: true
-      - name: Create vendored source archive
-        working-directory: ../
-        run: tar cJf cloud-hypervisor-${{ github.event.ref }}.tar.xz cloud-hypervisor-${{ github.event.ref }}
-      - name: Upload cloud-hypervisor vendored source archive
-        if: github.event_name == 'create' && github.event.ref_type == 'tag'
-        id: upload-release-cloud-hypervisor-vendored-sources
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ../cloud-hypervisor-${{ github.event.ref }}.tar.xz
-          asset_name: cloud-hypervisor-${{ github.event.ref }}.tar.xz
-          asset_content_type: application/x-xz
       - name: Upload cloud-hypervisor
         if: github.event_name == 'create' && github.event.ref_type == 'tag'
         id: upload-release-cloud-hypervisor
@@ -126,6 +95,16 @@ jobs:
           asset_path: target/x86_64-unknown-linux-musl/release/ch-remote
           asset_name: ch-remote-static
           asset_content_type: application/octet-stream
+      - name: Clean build tree ahead of cross build
+        uses: actions-rs/cargo@v1
+        with:
+          command: clean
+      - name: Static Build (AArch64)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --all --release --target=aarch64-unknown-linux-musl
       - name: Upload static AArch64 cloud-hypervisor
         if: github.event_name == 'create' && github.event.ref_type == 'tag'
         id: upload-release-static-aarch64-cloud-hypervisor
@@ -148,3 +127,24 @@ jobs:
           asset_path: target/aarch64-unknown-linux-musl/release/ch-remote
           asset_name: ch-remote-static-aarch64
           asset_content_type: application/octet-stream
+      - name: Vendor
+        working-directory: ../cloud-hypervisor-${{ github.event.ref }}
+        run: |
+          mkdir ../vendor-cargo-home
+          export CARGO_HOME=$(realpath ../vendor-cargo-home)
+          mkdir .cargo
+          cargo vendor > .cargo/config.toml
+      - name: Create vendored source archive
+        working-directory: ../
+        run: tar cJf cloud-hypervisor-${{ github.event.ref }}.tar.xz cloud-hypervisor-${{ github.event.ref }}
+      - name: Upload cloud-hypervisor vendored source archive
+        if: github.event_name == 'create' && github.event.ref_type == 'tag'
+        id: upload-release-cloud-hypervisor-vendored-sources
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ../cloud-hypervisor-${{ github.event.ref }}.tar.xz
+          asset_name: cloud-hypervisor-${{ github.event.ref }}.tar.xz
+          asset_content_type: application/x-xz


### PR DESCRIPTION
Since we run "cargo clean" before running the aarch64 build we need to
create the release and upload the x86-64 assets before the clean.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
