### PR TITLE
tests: disable test_memory_mergeable_on for mshv

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6731,9 +6731,11 @@ mod common_parallel {
 }
 
 mod common_sequential {
+    #[cfg(not(feature = "mshv"))]
     use crate::*;
 
     #[test]
+    #[cfg(not(feature = "mshv"))]
     fn test_memory_mergeable_on() {
         test_memory_mergeable(true)
     }


### PR DESCRIPTION
KSM doesn't work with MSHV stack since guest memory is pinned (`pin_user_pages`) and pinned pages cannot be merged.

So, don't run the test for mshv.

Signed-off-by: Anirudh Rayabharam <anrayabh@linux.microsoft.com>