### PR TITLE
.github: Don't try and create releases for created branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ on: [pull_request, create]
 
 jobs:
   release:
+    if: (github.event_name == 'create' && github.event.ref_type == 'tag') || github.event_name == 'pull_request'
     name: Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Dependabot will create a branch on the repo for it's updates this
triggers the release action (because it's the same event as a tag) which
will then fail leading to dependabot PRs not being automerged. Instead
only run the release check test on PRs or tag creation.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
