### PR TITLE
virtio-devices: typo fixes

### DIFF
--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -138,7 +138,7 @@ pub enum Error {
     #[error("Not activated by the guest")]
     NotActivatedByGuest,
     #[error("Unknown request type: {0}")]
-    UnkownRequestType(u16),
+    UnknownRequestType(u16),
     #[error("Failed adding used index: {0}")]
     QueueAddUsed(virtio_queue::Error),
 }
@@ -618,7 +618,7 @@ impl MemEpollHandler {
                 VIRTIO_MEM_REQ_UNPLUG_ALL => (self.unplug_all(), 0u16),
                 VIRTIO_MEM_REQ_STATE => self.state_request(r.req.addr, r.req.nb_blocks),
                 _ => {
-                    return Err(Error::UnkownRequestType(r.req.req_type));
+                    return Err(Error::UnknownRequestType(r.req.req_type));
                 }
             };
             let len = r.send_response(desc_chain.memory(), resp_type, resp_state)?;

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -43,12 +43,12 @@ use vm_virtio::{AccessPlatform, Translatable};
 // };
 // ```
 //
-// This structed will occupy the buffer pointed to by the head descriptor. We'll be accessing it
+// This struct will occupy the buffer pointed to by the head descriptor. We'll be accessing it
 // as a byte slice. To that end, we define below the offsets for each field struct, as well as the
 // packed struct size, as a bunch of `usize` consts.
 // Note that these offsets are only used privately by the `VsockPacket` struct, the public interface
 // consisting of getter and setter methods, for each struct field, that will also handle the correct
-// endianess.
+// endianness.
 
 /// The vsock packet header struct size (when packed).
 pub const VSOCK_PKT_HDR_SIZE: usize = 44;


### PR DESCRIPTION
Fixed few typos in `virtio-device`. I found them using <https://github.com/crate-ci/typos>
One typo fix is probably a breaking change.