### PR TITLE
Simplify TPM code

### DIFF
--- a/devices/src/tpm.rs
+++ b/devices/src/tpm.rs
@@ -472,10 +472,8 @@ impl BusDevice for Tpm {
                         self.regs[CRB_CTRL_START as usize] |= CRB_START_INVOKE;
 
                         let mut cmd = BackendCmd {
-                            locality: locality as u8,
                             buffer: &mut self.data_buff,
                             input_len: cmp::min(self.data_buff_len, TPM_CRB_BUFFER_MAX),
-                            selftest_done: false,
                         };
 
                         let _ = self.emulator.deliver_request(&mut cmd);

--- a/devices/src/tpm.rs
+++ b/devices/src/tpm.rs
@@ -471,22 +471,14 @@ impl BusDevice for Tpm {
                     {
                         self.regs[CRB_CTRL_START as usize] |= CRB_START_INVOKE;
 
-                        let cmd = BackendCmd {
+                        let mut cmd = BackendCmd {
                             locality: locality as u8,
-                            input: self.data_buff[0..self.data_buff_len].to_vec(),
+                            buffer: &mut self.data_buff,
                             input_len: cmp::min(self.data_buff_len, TPM_CRB_BUFFER_MAX),
-                            output: self.data_buff.to_vec(),
-                            output_len: TPM_CRB_BUFFER_MAX,
                             selftest_done: false,
                         };
 
-                        let mut cmd = cmd.clone();
-
-                        if let Ok(output) = self.emulator.deliver_request(&mut cmd) {
-                            // TODO: drop the copy here
-                            self.data_buff.fill(0);
-                            self.data_buff.clone_from_slice(output.as_slice());
-                        }
+                        let _ = self.emulator.deliver_request(&mut cmd);
 
                         self.request_completed(TPM_SUCCESS as isize);
                     }

--- a/devices/src/tpm.rs
+++ b/devices/src/tpm.rs
@@ -259,7 +259,7 @@ impl Tpm {
     }
 
     fn reset(&mut self) -> Result<()> {
-        let cur_buff_size = self.emulator.get_buffer_size().unwrap();
+        let cur_buff_size = self.emulator.get_buffer_size();
         self.regs = [0; TPM_CRB_R_MAX];
         set_reg_field(
             &mut self.regs,

--- a/tpm/src/emulator.rs
+++ b/tpm/src/emulator.rs
@@ -454,12 +454,12 @@ impl Emulator {
         Ok(())
     }
 
-    pub fn get_buffer_size(&mut self) -> Result<usize> {
+    pub fn get_buffer_size(&mut self) -> usize {
         let mut curr_buf_size: usize = 0;
 
         match self.set_buffer_size(0, &mut curr_buf_size) {
-            Err(_) => Ok(TPM_CRB_BUFFER_MAX),
-            _ => Ok(curr_buf_size),
+            Err(_) => TPM_CRB_BUFFER_MAX,
+            _ => curr_buf_size,
         }
     }
 }


### PR DESCRIPTION
Drop unused things. Simplify code. Make code more idiomatic. Avoid unnecessary allocations.