### PR TITLE
scripts: check if /dev/{mshv,kvm} exists before test run

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -379,6 +379,10 @@ cmd_tests() {
         exported_device="/dev/mshv"
     fi
 
+    if [ ! -d "${exported_device}" ] ; then
+        die "${exported_device} does not exist on the system"
+    fi
+
     set -- '--hypervisor' "$hypervisor" "$@"
 
     ensure_build_dir


### PR DESCRIPTION
Right now integration test fails during the test run if /dev/mshv or /dev/kvm does not exist. We should not progress and exit early if not present.

Signed-off-by: Muminul Islam <muislam@microsoft.com>