### PR TITLE
build: Bump MSRV to 1.62

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.60"
+          - "1.62"
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://github.com/cloud-hypervisor/cloud-hypervisor"
 # a.) A dependency requires it, 
 # b.) If we want to use a new feature and that MSRV is at least 6 months old,
 # c.) There is a security issue that is addressed by the toolchain update.
-rust-version = "1.60"
+rust-version = "1.62"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Needed for #[derive(Default)] on enums which is now clippy checked in
1.68.

Fixes: #5140

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
