### PR TITLE
doc: Add musl-tools to instructions for build

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -27,7 +27,7 @@ distributions please replace the package manager and package name.
 # Install basic packages needed. For a package list targeting for more
 # functionalities for example the test, please see resources/Dockerfile.
 $ sudo apt-get update
-$ sudo apt install git build-essential m4 bison flex uuid-dev qemu-utils
+$ sudo apt install git build-essential m4 bison flex uuid-dev qemu-utils musl-tools
 # Install rust tool chain
 $ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 # If you want to build statically linked binary please add musl target


### PR DESCRIPTION
As a first time user of cloud-hypervisor and Rust environment you get build errors for this instruction.

$ cargo build --release --target=x86_64-unknown-linux-musl --all
...
  running: "musl-gcc" "-Os" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "-I" "src/zlib" "-fvisibility=hidden" "-DSTDC" "-D_LARGEFILE64_SOURCE" "-D_POSIX_SOURCE" "-o" "/home/rveerama/src/github/CH/cloud-hypervisor/cloud-hypervisor/target/x86_64-unknown-linux-musl/release/build/libz-sys-96e9774dc769c364/out/lib/src/zlib/adler32.o" "-c" "src/zlib/adler32.c"

  --- stderr

  error occurred: Failed to find tool. Is `musl-gcc` installed?

warning: build failed, waiting for other jobs to finish...
