### PR TITLE
Jenkinsfile: Enforce global execution timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
 def runWorkers = true
 pipeline {
     agent none
+    options {
+        timeout(time: 4, unit: 'HOURS')
+    }
     stages {
         stage('Early checks') {
             agent { node { label 'built-in' } }


### PR DESCRIPTION
This patch adds a global execution timeout to the Jenkinsfile to avoid infinite pending Jenkins pipelines, such as when certain worker nodes are not available. The global execution timeout is now set to 4 hours which is derived from total timeout of our longest stage (e.g. the `Worker build`).

Fixes: #5148

Signed-off-by: Bo Chen <chen.bo@intel.com>