### PR TITLE
scripts: Avoid warning from mkdosfs command

### DIFF
--- a/scripts/create-cloud-init.sh
+++ b/scripts/create-cloud-init.sh
@@ -2,7 +2,7 @@
 set -x
 
 rm -f /tmp/ubuntu-cloudinit.img
-mkdosfs -n cidata -C /tmp/ubuntu-cloudinit.img 8192
+mkdosfs -n CIDATA -C /tmp/ubuntu-cloudinit.img 8192
 mcopy -oi /tmp/ubuntu-cloudinit.img -s test_data/cloud-init/ubuntu/user-data ::
 mcopy -oi /tmp/ubuntu-cloudinit.img -s test_data/cloud-init/ubuntu/meta-data ::
 mcopy -oi /tmp/ubuntu-cloudinit.img -s test_data/cloud-init/ubuntu/network-config ::

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -301,7 +301,7 @@ impl DiskConfig for UbuntuDiskConfig {
             .expect("Expected writing out network-config to succeed");
 
         std::process::Command::new("mkdosfs")
-            .args(["-n", "cidata"])
+            .args(["-n", "CIDATA"])
             .args(["-C", cloudinit_file_path.as_str()])
             .arg("8192")
             .output()


### PR DESCRIPTION
As per documentation step https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/README.md?plain=1#L147 produces warning. Fixing lowercase label will help to avoid warning "mkfs.fat: Warning: lowercase labels might not work properly on some systems".