### PR TITLE
tpm: Add recv timeout while running recvmsg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,7 @@ dependencies = [
  "byteorder",
  "libc",
  "log",
+ "net_gen",
  "thiserror",
  "vmm-sys-util",
 ]

--- a/tpm/Cargo.toml
+++ b/tpm/Cargo.toml
@@ -10,5 +10,6 @@ anyhow = "1.0.66"
 byteorder = "1.4.3"
 libc = "0.2.138"
 log = "0.4.17"
+net_gen = { path = "../net_gen" }
 thiserror = "1.0.37"
 vmm-sys-util = "0.11.0"

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -582,6 +582,7 @@ fn vmm_thread_rules(
         (libc::SYS_sendto, vec![]),
         (libc::SYS_set_robust_list, vec![]),
         (libc::SYS_setsid, vec![]),
+        (libc::SYS_setsockopt, vec![]),
         (libc::SYS_shutdown, vec![]),
         (libc::SYS_sigaltstack, vec![]),
         (


### PR DESCRIPTION
While running tpm commands, if swtpm becomes unresponsive, guest gets blocked at "recvmsg" on tpm's data FD. This change adds a timeout to the data fd socket. If swtpm becomes unresponsive guest waits for "timeout" (secs) and continues to run after returning an I/O error to tpm commands.

Signed-off-by: Praveen K Paladugu <prapal@linux.microsoft.com>