### PR TITLE
ci: Switch to Windows Server 2022

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -217,7 +217,7 @@ pipeline {
                         stage('Download assets') {
                             steps {
                                 sh "mkdir ${env.HOME}/workloads"
-                                sh 'az storage blob download --container-name private-images --file "$HOME/workloads/windows-server-2019.raw" --name windows-server-2019.raw --connection-string "$AZURE_CONNECTION_STRING"'
+                                sh 'az storage blob download --container-name private-images --file "$HOME/workloads/windows-server-2022-amd64-2.raw" --name windows-server-2022-amd64-2.raw --connection-string "$AZURE_CONNECTION_STRING"'
                             }
                         }
                         stage('Run Windows guest integration tests') {

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -11,7 +11,7 @@ test_features=""
 if [ "$hypervisor" = "mshv" ] ;  then
     test_features="--no-default-features --features mshv"
 fi
-WIN_IMAGE_FILE="/root/workloads/windows-server-2019.raw"
+WIN_IMAGE_FILE="/root/workloads/windows-server-2022-amd64-2.raw"
 
 WORKLOADS_DIR="/root/workloads"
 OVMF_FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/edk2/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -38,7 +38,7 @@ mod x86_64 {
     pub const FOCAL_IMAGE_NAME_VHD: &str = "focal-server-cloudimg-amd64-custom-20210609-0.vhd";
     pub const FOCAL_IMAGE_NAME_VHDX: &str = "focal-server-cloudimg-amd64-custom-20210609-0.vhdx";
     pub const JAMMY_IMAGE_NAME: &str = "jammy-server-cloudimg-amd64-custom-20230119-0.raw";
-    pub const WINDOWS_IMAGE_NAME: &str = "windows-server-2019.raw";
+    pub const WINDOWS_IMAGE_NAME: &str = "windows-server-2022-amd64-2.raw";
     pub const OVMF_NAME: &str = "CLOUDHV.fd";
     pub const GREP_SERIAL_IRQ_CMD: &str = "grep -c 'IO-APIC.*ttyS0' /proc/interrupts || true";
 }


### PR DESCRIPTION
The updated image is configured in a same way as the prev used 2019, it has same

- Credentials
- Services configured, like SAC, SSH, RDP
- Size

All the Windows updates are applied so the state is current to the date. Also, the latest stable version 0.1.229 of the VirtIO Windows drivers is installed.

Fixes: #5126

Signed-off-by: Anatol Belski <anbelski@linux.microsoft.com>