### PR TITLE
vmm: release tun FD when destroying vmconfig

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -817,6 +817,10 @@ impl Vmm {
             self.vm_shutdown()?;
         }
 
+        if let Some(ref mut vm_config) = self.vm_config {
+            vm_config.lock().unwrap().release();
+        }
+
         self.vm_config = None;
 
         event!("vm", "deleted");


### PR DESCRIPTION
Now we support initial tap device via FD donated from other process. And the donated FD will be hold in NetConfig of VmConfig as raw FD. This mean rust language itself will not automatic 'close' this FD, we must close the donate fd munally.

Fixes: #5197

Signed-off-by: Yong He <alexyonghe@tencent.com>