### PR TITLE
Avoid closing reserved FDs and fix unit tests caused by closing invalid FDs

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1154,6 +1154,11 @@ impl Drop for NetConfig {
     fn drop(&mut self) {
         if let Some(mut fds) = self.fds.take() {
             for fd in fds.drain(..) {
+                // Skip reserved FDs
+                if fd <= 2 {
+                    continue;
+                }
+
                 // SAFETY: Safe as the fd was given to the config by the API
                 unsafe { libc::close(fd) };
             }


### PR DESCRIPTION
This PR fixed the following two issues that were introduced from #5199:

- Avoid closing reserved FDs from 'NetCOnfig::drop()'
- Avoid closing invalid FDs from 'test_net_parsing()'

Fixes: #5203

Signed-off-by: Bo Chen <chen.bo@intel.com>
