### PR TITLE
tests: Disable test_vfio test

### DIFF
--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -56,12 +56,7 @@ echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 export RUST_BACKTRACE=1
-time cargo test "vfio::test_vfio" -- ${test_binary_args[*]}
+time cargo test "vfio::test_nvidia" -- --test-threads=1 ${test_binary_args[*]}
 RES=$?
-
-if [ $RES -eq 0 ]; then
-	time cargo test "vfio::test_nvidia" -- --test-threads=1 ${test_binary_args[*]}
-	RES=$?
-fi
 
 exit $RES


### PR DESCRIPTION
This test (which relies on nesting) is failing on the VFIO worker. The tests that use the
dedicated hardware pass fine.

See: #5190

Signed-off-by: Rob Bradford <robert.bradford@intel.com>
