### PR TITLE
vmm: properly set vcpu state when thread exited

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1011,12 +1011,16 @@ impl CpuManager {
                                             "VCPU generated error: {:?}",
                                             Error::UnexpectedVmExit
                                         );
+                                        vcpu_run_interrupted.store(true, Ordering::SeqCst);
+                                        exit_evt.write(1).unwrap();
                                         break;
                                     }
                                 },
 
                                 Err(e) => {
                                     error!("VCPU generated error: {:?}", Error::VcpuRun(e.into()));
+                                    vcpu_run_interrupted.store(true, Ordering::SeqCst);
+                                    exit_evt.write(1).unwrap();
                                     break;
                                 }
                             }


### PR DESCRIPTION
Once error occur, vcpu thread may exit, this should be critical event for the whole VM, we should fire exit event and set vcpu state.

If we don't set vcpu state, the shutdown process
will hang at signal_thread, which is waiting the
vcpu state to change.