### PR TITLE
scripts: ch-trace-visualiser.py: remove unused import 'xml'

### DIFF
--- a/scripts/ch-trace-visualiser.py
+++ b/scripts/ch-trace-visualiser.py
@@ -7,7 +7,6 @@
 
 from colorsys import hsv_to_rgb
 from random import random
-import xml
 import json
 from sys import argv, stderr
 import xml.etree.ElementTree as ET


### PR DESCRIPTION
Unused import 'xml' is redefined at:

> xml = ET.ElementTree(element=svg)

Hence, remove unused xml import.