### PR TITLE
[RFC] Native virtiofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +113,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cb94155d965e3d37ffbbe7cc5b82c3dd79dd33bd48e536f73d2cfb8d85506f"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +186,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "capng"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f8e9448233603643e42606121d95f5f8d4e015b3e7619a51593864dd902575"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +206,21 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
 
 [[package]]
 name = "cloud-hypervisor"
@@ -242,7 +287,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -360,6 +405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "event_monitor"
 version = "0.1.0"
 dependencies = [
@@ -379,6 +433,96 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+ "num_cpus",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+
+[[package]]
+name = "futures-task"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+
+[[package]]
+name = "futures-util"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "gdbstub"
@@ -417,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "glob"
@@ -428,10 +572,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
 
 [[package]]
 name = "humantime"
@@ -487,19 +669,19 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "io-uring"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c85eff7f7c8d3ab8c7ec87313c0c194bbaf4371bb7d40f80293ba01bce8264"
+checksum = "dd1e1a01cfb924fd8c5c43b6827965db394f5a3a16c599ce03452266e1cf984c"
 dependencies = [
  "bitflags",
  "libc",
@@ -516,14 +698,14 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -564,6 +746,12 @@ name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "libseccomp-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7cbbd4ad467251987c6e5b47d53b11a5a05add08f2447a9e2d70aef1e0d138"
 
 [[package]]
 name = "libssh2-sys"
@@ -632,6 +820,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e212582ede878b109755efd0773a4f0f4ec851584cf0aefbeb4d9ecc114822"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -668,7 +862,7 @@ dependencies = [
 [[package]]
 name = "mshv-bindings"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#0b2af251285385f8e39c2cd0fe8ffacab534932f"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#66531ba242be0b744ee2e4cd602ab0000377bdf7"
 dependencies = [
  "libc",
  "serde",
@@ -680,7 +874,7 @@ dependencies = [
 [[package]]
 name = "mshv-ioctls"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#0b2af251285385f8e39c2cd0fe8ffacab534932f"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#66531ba242be0b744ee2e4cd602ab0000377bdf7"
 dependencies = [
  "libc",
  "mshv-bindings",
@@ -732,6 +926,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -794,7 +1007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.6",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -813,15 +1026,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -865,6 +1078,18 @@ dependencies = [
  "thiserror",
  "wait-timeout",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -961,6 +1186,30 @@ dependencies = [
  "pnet_base",
  "pnet_packet",
  "pnet_sys",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1081,7 +1330,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1170,9 +1419,9 @@ version = "0.1.0"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1185,6 +1434,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1207,15 +1465,45 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "syn"
-version = "1.0.107"
+name = "structopt"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e159d99e6c2b93995d171050271edb50ecc5288fbc7cc17de8fdce4e58c14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1230,6 +1518,19 @@ checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "syslog"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978044cc68150ad5e40083c9f6a725e6fd02d7ba1bcf691ec2ff0d66c0b41acc"
+dependencies = [
+ "error-chain",
+ "hostname",
+ "libc",
+ "log",
+ "time",
 ]
 
 [[package]]
@@ -1257,6 +1558,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1591,35 @@ name = "thousands"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
+name = "time"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tpm"
@@ -1313,6 +1652,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "uuid"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1677,18 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "versionize"
@@ -1357,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#43439e056ddfa84a4f7906ee7f2f58be70505c08"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#ea8f710464a24690ce109e6b7dfaa623dc518304"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -1365,7 +1728,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#43439e056ddfa84a4f7906ee7f2f58be70505c08"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#ea8f710464a24690ce109e6b7dfaa623dc518304"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -1514,6 +1877,7 @@ dependencies = [
  "vhost",
  "virtio-bindings 0.2.0",
  "virtio-queue",
+ "virtiofsd",
  "vm-allocator",
  "vm-device",
  "vm-memory",
@@ -1524,12 +1888,34 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e927d93d54c365034fd7f31a5f458a1f540de4a37c52e892670dad9692173c"
+checksum = "3ba81e2bcc21c0d2fc5e6683e79367e26ad219197423a498df801d79d5ba77bd"
 dependencies = [
  "log",
  "virtio-bindings 0.1.0",
+ "vm-memory",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "virtiofsd"
+version = "1.5.0"
+source = "git+https://gitlab.com/HowHsu/virtiofsd?branch=ch_remove_vhost#6b7036ac310ab7e6d2cd769a92681676f58c7348"
+dependencies = [
+ "bitflags",
+ "capng",
+ "env_logger",
+ "futures",
+ "libc",
+ "libseccomp-sys",
+ "log",
+ "structopt",
+ "syslog",
+ "vhost",
+ "vhost-user-backend",
+ "virtio-bindings 0.1.0",
+ "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
 ]
@@ -1559,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "vm-fdt"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#c5a99ab71b130435927d19b50c85fcd5ce904a8c"
+source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#3709ca63363fc98d708ac9232dce47ee5a3b8f89"
 
 [[package]]
 name = "vm-memory"
@@ -1634,6 +2020,7 @@ dependencies = [
  "vhdx",
  "virtio-devices",
  "virtio-queue",
+ "virtiofsd",
  "vm-allocator",
  "vm-device",
  "vm-memory",
@@ -1699,21 +2086,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
 
 [[package]]
 name = "windows-sys"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -37,3 +37,4 @@ vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic", 
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.11.0"
+virtiofsd = { git = "https://gitlab.com/HowHsu/virtiofsd", branch = "ch_remove_vhost" }

--- a/virtio-devices/src/fs.rs
+++ b/virtio-devices/src/fs.rs
@@ -1,0 +1,237 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::seccomp_filters::Thread;
+use crate::thread_helper::spawn_virtio_thread;
+use crate::GuestMemoryMmap;
+use crate::{
+    ActivateResult, VirtioCommon, VirtioDevice, VirtioDeviceType, VirtioInterrupt,
+    VIRTIO_F_IOMMU_PLATFORM, VIRTIO_F_VERSION_1,
+};
+use seccompiler::SeccompAction;
+use std::io;
+use std::result;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Barrier};
+use versionize::{VersionMap, Versionize, VersionizeResult};
+use versionize_derive::Versionize;
+use virtio_queue::Queue;
+use vm_memory::{ByteValued, GuestMemoryAtomic};
+use vm_migration::{
+    Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable, VersionMapped,
+};
+use vmm_sys_util::eventfd::EventFd;
+
+const NUM_QUEUE_OFFSET: usize = 1;
+const DEFAULT_QUEUE_NUMBER: usize = 2;
+
+#[derive(Versionize)]
+pub struct State {
+    pub avail_features: u64,
+    pub acked_features: u64,
+    pub config: VirtioFsConfig,
+}
+
+impl VersionMapped for State {}
+
+#[derive(Copy, Clone, Versionize)]
+#[repr(C, packed)]
+pub struct VirtioFsConfig {
+    pub tag: [u8; 36],
+    pub num_request_queues: u32,
+}
+
+impl Default for VirtioFsConfig {
+    fn default() -> Self {
+        VirtioFsConfig {
+            tag: [0; 36],
+            num_request_queues: 0,
+        }
+    }
+}
+
+// SAFETY: only a series of integers
+unsafe impl ByteValued for VirtioFsConfig {}
+
+pub struct Fs {
+    common: VirtioCommon,
+    id: String,
+    config: VirtioFsConfig,
+    seccomp_action: SeccompAction,
+    exit_evt: EventFd,
+    iommu: bool,
+}
+
+impl Fs {
+    /// Create a new virtio-fs device.
+    #[allow(clippy::too_many_arguments)]
+    #[allow(unused)]
+    pub fn new(
+        id: String,
+        tag: &str,
+        req_num_queues: usize,
+        queue_size: u16,
+        seccomp_action: SeccompAction,
+        exit_evt: EventFd,
+        iommu: bool,
+        state: Option<State>,
+    ) -> io::Result<Fs> {
+        // Calculate the actual number of queues needed.
+        let num_queues = NUM_QUEUE_OFFSET + req_num_queues;
+        if num_queues > DEFAULT_QUEUE_NUMBER {
+            error!(
+                "virtio-fs requested too many queues ({}) since the backend only supports {}\n",
+                num_queues, DEFAULT_QUEUE_NUMBER
+            );
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("requested too many queues"),
+            ));
+        }
+
+        let (avail_features, acked_features, config, paused) = if let Some(state) = state {
+            info!("Restoring virtio-fs {}", id);
+            (
+                state.avail_features,
+                state.acked_features,
+                state.config,
+                true,
+            )
+        } else {
+            // Filling device and vring features VMM supports.
+            let avail_features: u64 = 1 << VIRTIO_F_VERSION_1;
+
+            // Create virtio-fs device configuration.
+            let mut config = VirtioFsConfig::default();
+            let tag_bytes_vec = tag.to_string().into_bytes();
+            config.tag[..tag_bytes_vec.len()].copy_from_slice(tag_bytes_vec.as_slice());
+            config.num_request_queues = req_num_queues as u32;
+
+            (avail_features, 0, config, false)
+        };
+        Ok(Fs {
+            common: VirtioCommon {
+                device_type: VirtioDeviceType::Fs as u32,
+                avail_features,
+                acked_features,
+                queue_sizes: vec![queue_size; num_queues],
+                paused_sync: Some(Arc::new(Barrier::new(2))),
+                min_queues: 1,
+                paused: Arc::new(AtomicBool::new(paused)),
+                ..Default::default()
+            },
+            id,
+            config,
+            seccomp_action,
+            exit_evt,
+            iommu,
+        })
+    }
+
+    fn state(&self) -> State {
+        State {
+            avail_features: self.common.avail_features,
+            acked_features: self.common.acked_features,
+            config: self.config,
+        }
+    }
+}
+
+impl Drop for Fs {
+    fn drop(&mut self) {
+        if let Some(kill_evt) = self.common.kill_evt.take() {
+            // Ignore the result because there is nothing we can do about it.
+            let _ = kill_evt.write(1);
+        }
+    }
+}
+
+impl VirtioDevice for Fs {
+    fn device_type(&self) -> u32 {
+        self.common.device_type
+    }
+
+    fn queue_max_sizes(&self) -> &[u16] {
+        &self.common.queue_sizes
+    }
+
+    fn features(&self) -> u64 {
+        let mut features = self.common.avail_features;
+        if self.iommu {
+            features |= 1u64 << VIRTIO_F_IOMMU_PLATFORM;
+        }
+        features
+    }
+
+    fn ack_features(&mut self, value: u64) {
+        self.common.ack_features(value)
+    }
+
+    fn read_config(&self, offset: u64, data: &mut [u8]) {
+        self.read_config_from_slice(self.config.as_slice(), offset, data);
+    }
+
+    fn activate(
+        &mut self,
+        #[allow(unused_variables)] mem: GuestMemoryAtomic<GuestMemoryMmap>,
+        interrupt_cb: Arc<dyn VirtioInterrupt>,
+        #[allow(unused_mut)] mut queues: Vec<(usize, Queue, EventFd)>,
+    ) -> ActivateResult {
+        self.common.activate(&queues, &interrupt_cb)?;
+        let mut epoll_threads = Vec::new();
+        for i in 0..queues.len() {
+            spawn_virtio_thread(
+                &format!("{}_q{}", self.id.clone(), i),
+                &self.seccomp_action,
+                Thread::VirtioFs,
+                &mut epoll_threads,
+                &self.exit_evt,
+                move || return Ok(()),
+            )?;
+        }
+
+        self.common.epoll_threads = Some(epoll_threads);
+        event!("virtio-device", "activated", "id", &self.id);
+
+        Ok(())
+    }
+
+    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
+        // We first must resume the virtio thread if it was paused.
+        if self.common.pause_evt.take().is_some() {
+            self.common.resume().ok()?;
+        }
+
+        if let Some(kill_evt) = self.common.kill_evt.take() {
+            // Ignore the result because there is nothing we can do about it.
+            let _ = kill_evt.write(1);
+        }
+
+        event!("virtio-device", "reset", "id", &self.id);
+
+        // Return the interrupt
+        Some(self.common.interrupt_cb.take().unwrap())
+    }
+}
+
+impl Pausable for Fs {
+    fn pause(&mut self) -> result::Result<(), MigratableError> {
+        self.common.pause()
+    }
+
+    fn resume(&mut self) -> result::Result<(), MigratableError> {
+        self.common.resume()
+    }
+}
+
+impl Snapshottable for Fs {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+
+    fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
+        Snapshot::new_from_versioned_state(&self.state())
+    }
+}
+impl Transportable for Fs {}
+impl Migratable for Fs {}

--- a/virtio-devices/src/fs.rs
+++ b/virtio-devices/src/fs.rs
@@ -240,7 +240,6 @@ pub struct Fs {
 impl Fs {
     /// Create a new virtio-fs device.
     #[allow(clippy::too_many_arguments)]
-    #[allow(unused)]
     pub fn new(
         id: String,
         tag: &str,

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -45,6 +45,7 @@ pub use self::block::*;
 pub use self::console::*;
 pub use self::device::*;
 pub use self::epoll_helper::*;
+pub use self::fs::*;
 pub use self::iommu::*;
 pub use self::mem::*;
 pub use self::net::*;

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -26,7 +26,7 @@ pub mod balloon;
 pub mod block;
 mod console;
 pub mod epoll_helper;
-mod fs;
+pub mod fs;
 mod iommu;
 pub mod mem;
 pub mod net;

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -95,6 +95,8 @@ pub enum ActivateError {
     CreateRateLimiter(std::io::Error),
     #[error("Failed to activate the vDPA device: {0}")]
     ActivateVdpa(vdpa::Error),
+    #[error("Failed to activate the virtio-fs device: {0}")]
+    ActivateVirtioFs(std::io::Error),
 }
 
 pub type ActivateResult = std::result::Result<(), ActivateError>;

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -26,6 +26,7 @@ pub mod balloon;
 pub mod block;
 mod console;
 pub mod epoll_helper;
+mod fs;
 mod iommu;
 pub mod mem;
 pub mod net;

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -212,7 +212,134 @@ fn virtio_watchdog_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
 }
 
 fn virtio_fs_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
-    vec![]
+    vec![
+        (libc::SYS_accept4, vec![]),
+        (libc::SYS_brk, vec![]),
+        (libc::SYS_capget, vec![]), // For CAP_FSETID
+        (libc::SYS_capset, vec![]),
+        (libc::SYS_clock_gettime, vec![]),
+        (libc::SYS_clone, vec![]),
+        (libc::SYS_clone3, vec![]),
+        (libc::SYS_close, vec![]),
+        (libc::SYS_copy_file_range, vec![]),
+        (libc::SYS_dup, vec![]),
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "s390x",
+            target_arch = "powerpc64le"
+        ))]
+        (libc::SYS_epoll_create, vec![]),
+        (libc::SYS_epoll_create1, vec![]),
+        (libc::SYS_epoll_ctl, vec![]),
+        (libc::SYS_epoll_pwait, vec![]),
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "s390x",
+            target_arch = "powerpc64le"
+        ))]
+        (libc::SYS_epoll_wait, vec![]),
+        (libc::SYS_eventfd2, vec![]),
+        (libc::SYS_exit, vec![]),
+        (libc::SYS_exit_group, vec![]),
+        (libc::SYS_fallocate, vec![]),
+        (libc::SYS_fchdir, vec![]),
+        (libc::SYS_fchmod, vec![]),
+        (libc::SYS_fchmodat, vec![]),
+        (libc::SYS_fchownat, vec![]),
+        (libc::SYS_fcntl, vec![]),
+        (libc::SYS_fdatasync, vec![]),
+        (libc::SYS_fgetxattr, vec![]),
+        (libc::SYS_flistxattr, vec![]),
+        (libc::SYS_flock, vec![]),
+        (libc::SYS_fremovexattr, vec![]),
+        (libc::SYS_fsetxattr, vec![]),
+        (libc::SYS_fstat, vec![]),
+        #[cfg(target_arch = "s390x")]
+        (libc::SYS_fstatfs64, vec![]),
+        (libc::SYS_fstatfs, vec![]),
+        (libc::SYS_fsync, vec![]),
+        (libc::SYS_ftruncate, vec![]),
+        (libc::SYS_futex, vec![]),
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "s390x",
+            target_arch = "powerpc64le"
+        ))]
+        (libc::SYS_getdents, vec![]),
+        (libc::SYS_getdents64, vec![]),
+        (libc::SYS_getegid, vec![]),
+        (libc::SYS_geteuid, vec![]),
+        (libc::SYS_getpid, vec![]),
+        (libc::SYS_gettid, vec![]),
+        (libc::SYS_gettimeofday, vec![]),
+        (libc::SYS_getxattr, vec![]),
+        (libc::SYS_linkat, vec![]),
+        (libc::SYS_listxattr, vec![]),
+        (libc::SYS_lseek, vec![]),
+        (libc::SYS_madvise, vec![]),
+        (libc::SYS_mkdirat, vec![]),
+        (libc::SYS_mknodat, vec![]),
+        (libc::SYS_mmap, vec![]),
+        (libc::SYS_mprotect, vec![]),
+        (libc::SYS_mremap, vec![]),
+        (libc::SYS_munmap, vec![]),
+        (libc::SYS_name_to_handle_at, vec![]),
+        (libc::SYS_newfstatat, vec![]),
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "s390x",
+            target_arch = "powerpc64le"
+        ))]
+        (libc::SYS_open, vec![]),
+        (libc::SYS_openat, vec![]),
+        (libc::SYS_openat2, vec![]),
+        (libc::SYS_open_by_handle_at, vec![]),
+        (libc::SYS_prctl, vec![]), // TODO restrict to just PR_SET_NAME?
+        (libc::SYS_preadv, vec![]),
+        (libc::SYS_pread64, vec![]),
+        (libc::SYS_pwritev2, vec![]),
+        (libc::SYS_pwrite64, vec![]),
+        (libc::SYS_read, vec![]),
+        (libc::SYS_readlinkat, vec![]),
+        (libc::SYS_recvmsg, vec![]),
+        (libc::SYS_renameat, vec![]),
+        (libc::SYS_renameat2, vec![]),
+        (libc::SYS_removexattr, vec![]),
+        #[cfg(target_env = "gnu")]
+        (libc::SYS_rseq, vec![]),
+        (libc::SYS_rt_sigaction, vec![]),
+        (libc::SYS_rt_sigprocmask, vec![]),
+        (libc::SYS_rt_sigreturn, vec![]),
+        (libc::SYS_sched_getaffinity, vec![]), // used by thread_pool
+        (libc::SYS_sendmsg, vec![]),
+        (libc::SYS_setresgid, vec![]),
+        (libc::SYS_setresuid, vec![]),
+        //(libc::SYS_setresgid32);  Needed on some platforms,
+        //(libc::SYS_setresuid32);  Needed on some platforms
+        (libc::SYS_set_robust_list, vec![]),
+        (libc::SYS_setxattr, vec![]),
+        (libc::SYS_sigaltstack, vec![]),
+        #[cfg(target_arch = "s390x")]
+        (libc::SYS_sigreturn, vec![]),
+        (libc::SYS_statx, vec![]),
+        (libc::SYS_symlinkat, vec![]),
+        (libc::SYS_syncfs, vec![]),
+        #[cfg(target_arch = "x86_64")]
+        (libc::SYS_time, vec![]), // Rarely needed, except on static builds
+        (libc::SYS_tgkill, vec![]),
+        (libc::SYS_umask, vec![]),
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "s390x",
+            target_arch = "powerpc64le"
+        ))]
+        (libc::SYS_unlink, vec![]),
+        (libc::SYS_unlinkat, vec![]),
+        (libc::SYS_unshare, vec![]),
+        (libc::SYS_utimensat, vec![]),
+        (libc::SYS_write, vec![]),
+        (libc::SYS_writev, vec![]),
+    ]
 }
 
 fn get_seccomp_rules(thread_type: Thread) -> Vec<(i64, Vec<SeccompRule>)> {

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -26,6 +26,7 @@ pub enum Thread {
     VirtioVhostNetCtl,
     VirtioVsock,
     VirtioWatchdog,
+    VirtioFs,
 }
 
 /// Shorthand for chaining `SeccompCondition`s with the `and` operator  in a `SeccompRule`.
@@ -210,6 +211,10 @@ fn virtio_watchdog_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     ]
 }
 
+fn virtio_fs_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
+    vec![]
+}
+
 fn get_seccomp_rules(thread_type: Thread) -> Vec<(i64, Vec<SeccompRule>)> {
     let mut rules = match thread_type {
         Thread::VirtioBalloon => virtio_balloon_thread_rules(),
@@ -227,6 +232,7 @@ fn get_seccomp_rules(thread_type: Thread) -> Vec<(i64, Vec<SeccompRule>)> {
         Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules(),
         Thread::VirtioVsock => virtio_vsock_thread_rules(),
         Thread::VirtioWatchdog => virtio_watchdog_thread_rules(),
+        Thread::VirtioFs => virtio_fs_thread_rules(),
     };
     rules.append(&mut virtio_thread_common());
     rules

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -55,3 +55,4 @@ vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic", 
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { version = "0.11.0", features = ["with-serde"] }
+virtiofsd = { git = "https://gitlab.com/HowHsu/virtiofsd", branch = "ch_remove_vhost" }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -175,6 +175,8 @@ pub enum ValidationError {
     DuplicateDevicePath(String),
     /// Provided MTU is lower than what the VIRTIO specification expects
     InvalidMtu(u16),
+    /// native virtio-fs shouldn't have socket argument
+    NativeVirtioFsSocket,
 }
 
 type ValidationResult<T> = std::result::Result<T, ValidationError>;
@@ -285,6 +287,9 @@ impl fmt::Display for ValidationError {
                     f,
                     "Provided MTU {mtu} is lower than 1280 (expected by VIRTIO specification)"
                 )
+            }
+            NativeVirtioFsSocket => {
+                write!(f, "Native virtio-fs shouldn't have socket argument")
             }
         }
     }
@@ -1422,8 +1427,17 @@ impl FsConfig {
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
-        if !self.backendfs_config.is_some() && !vm_config.backed_by_shared_memory() {
-            return Err(ValidationError::VhostUserRequiresSharedMemory);
+        if self.backendfs_config.is_some() {
+            if self.socket.to_str() != Some("") {
+                return Err(ValidationError::NativeVirtioFsSocket);
+            }
+        } else {
+            if self.socket.to_str() == Some("") {
+                return Err(ValidationError::VhostUserMissingSocket);
+            }
+            if !vm_config.backed_by_shared_memory() {
+                return Err(ValidationError::VhostUserRequiresSharedMemory);
+            }
         }
 
         if self.num_queues > vm_config.cpus.boot_vcpus as usize {

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1422,6 +1422,10 @@ impl FsConfig {
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
+        if !self.backendfs_config.is_some() && !vm_config.backed_by_shared_memory() {
+            return Err(ValidationError::VhostUserRequiresSharedMemory);
+        }
+
         if self.num_queues > vm_config.cpus.boot_vcpus as usize {
             return Err(ValidationError::TooManyQueues);
         }
@@ -1967,9 +1971,6 @@ impl VmConfig {
         }
 
         if let Some(fses) = &self.fs {
-            if !fses.is_empty() && !self.backed_by_shared_memory() {
-                return Err(ValidationError::VhostUserRequiresSharedMemory);
-            }
             for fs in fses {
                 fs.validate(self)?;
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1259,6 +1259,7 @@ impl FsConfig {
             queue_size,
             id,
             pci_segment,
+            backendfs_config: None,
         })
     }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2577,6 +2577,7 @@ impl DeviceManager {
                 versioned_state_from_id(self.snapshot.as_ref(), id.as_str())
                     .map_err(DeviceManagerError::RestoreGetState)?,
                 bfs_cfg,
+                None,
             )
             .map_err(DeviceManagerError::CreateNativeVirtioFs)?,
         ));

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -503,7 +503,11 @@ fn vmm_thread_rules(
         (libc::SYS_epoll_create1, vec![]),
         (libc::SYS_epoll_ctl, vec![]),
         (libc::SYS_epoll_pwait, vec![]),
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "s390x",
+            target_arch = "powerpc64le"
+        ))]
         (libc::SYS_epoll_wait, vec![]),
         (libc::SYS_eventfd2, vec![]),
         (libc::SYS_exit, vec![]),
@@ -546,7 +550,11 @@ fn vmm_thread_rules(
         (libc::SYS_munmap, vec![]),
         (libc::SYS_nanosleep, vec![]),
         (libc::SYS_newfstatat, vec![]),
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "s390x",
+            target_arch = "powerpc64le"
+        ))]
         (libc::SYS_open, vec![]),
         (libc::SYS_openat, vec![]),
         (libc::SYS_pipe2, vec![]),
@@ -564,13 +572,12 @@ fn vmm_thread_rules(
         (libc::SYS_readv, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_readlink, vec![]),
-        #[cfg(target_arch = "aarch64")]
         (libc::SYS_readlinkat, vec![]),
         (libc::SYS_recvfrom, vec![]),
         (libc::SYS_recvmsg, vec![]),
         (libc::SYS_restart_syscall, vec![]),
-        // musl is missing this constant
-        // (libc::SYS_rseq, vec![]),
+        #[cfg(target_env = "gnu")]
+        (libc::SYS_rseq, vec![]),
         #[cfg(target_arch = "x86_64")]
         (334, vec![]),
         #[cfg(target_arch = "aarch64")]
@@ -602,17 +609,75 @@ fn vmm_thread_rules(
         (libc::SYS_timerfd_create, vec![]),
         (libc::SYS_timerfd_settime, vec![]),
         (libc::SYS_tkill, vec![]),
-        (
-            libc::SYS_umask,
-            or![and![Cond::new(0, ArgLen::Dword, Eq, 0o077)?]],
-        ),
-        #[cfg(target_arch = "x86_64")]
+        (libc::SYS_umask, vec![]),
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "s390x",
+            target_arch = "powerpc64le"
+        ))]
         (libc::SYS_unlink, vec![]),
-        #[cfg(target_arch = "aarch64")]
         (libc::SYS_unlinkat, vec![]),
         (libc::SYS_wait4, vec![]),
         (libc::SYS_write, vec![]),
         (libc::SYS_writev, vec![]),
+        // native virtiofs stuff
+        (libc::SYS_capget, vec![]), // For CAP_FSETID
+        (libc::SYS_capset, vec![]),
+        (libc::SYS_copy_file_range, vec![]),
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "s390x",
+            target_arch = "powerpc64le"
+        ))]
+        (libc::SYS_epoll_create, vec![]),
+        (libc::SYS_fchdir, vec![]),
+        (libc::SYS_fchmod, vec![]),
+        (libc::SYS_fchmodat, vec![]),
+        (libc::SYS_fchownat, vec![]),
+        (libc::SYS_fgetxattr, vec![]),
+        (libc::SYS_flistxattr, vec![]),
+        (libc::SYS_flock, vec![]),
+        (libc::SYS_fremovexattr, vec![]),
+        (libc::SYS_fsetxattr, vec![]),
+        #[cfg(target_arch = "s390x")]
+        (libc::SYS_fstatfs64, vec![]),
+        (libc::SYS_fstatfs, vec![]),
+        #[cfg(any(
+            target_arch = "x86_64",
+            target_arch = "s390x",
+            target_arch = "powerpc64le"
+        ))]
+        (libc::SYS_getdents, vec![]),
+        (libc::SYS_getdents64, vec![]),
+        (libc::SYS_getegid, vec![]),
+        (libc::SYS_geteuid, vec![]),
+        (libc::SYS_getxattr, vec![]),
+        (libc::SYS_linkat, vec![]),
+        (libc::SYS_listxattr, vec![]),
+        (libc::SYS_mkdirat, vec![]),
+        (libc::SYS_mknodat, vec![]),
+        (libc::SYS_name_to_handle_at, vec![]),
+        (libc::SYS_openat2, vec![]),
+        (libc::SYS_open_by_handle_at, vec![]),
+        (libc::SYS_pwritev2, vec![]),
+        (libc::SYS_renameat, vec![]),
+        (libc::SYS_renameat2, vec![]),
+        (libc::SYS_removexattr, vec![]),
+        (libc::SYS_setresgid, vec![]),
+        (libc::SYS_setresuid, vec![]),
+        //(libc::SYS_setresgid32);  Needed on some platforms,
+        //(libc::SYS_setresuid32);  Needed on some platforms
+        (libc::SYS_setxattr, vec![]),
+        #[cfg(target_arch = "s390x")]
+        (libc::SYS_sigreturn, vec![]),
+        (libc::SYS_symlinkat, vec![]),
+        (libc::SYS_syncfs, vec![]),
+        #[cfg(target_arch = "x86_64")]
+        (libc::SYS_time, vec![]), // Rarely needed, except on static builds
+        (libc::SYS_unshare, vec![]),
+        (libc::SYS_utimensat, vec![]),
+        // to support operations in init_backendfs()
+        (libc::SYS_lstat, vec![]),
     ])
 }
 

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -5,6 +5,7 @@
 use net_util::MacAddr;
 use serde::{Deserialize, Serialize};
 use std::{net::Ipv4Addr, path::PathBuf};
+use virtio_devices::fs::BackendFsConfig;
 use virtio_devices::RateLimiterConfig;
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -388,6 +389,8 @@ pub struct FsConfig {
     pub id: Option<String>,
     #[serde(default)]
     pub pci_segment: u16,
+    #[serde(default)]
+    pub backendfs_config: Option<BackendFsConfig>,
 }
 
 pub fn default_fsconfig_num_queues() -> usize {
@@ -407,6 +410,7 @@ impl Default for FsConfig {
             queue_size: default_fsconfig_queue_size(),
             id: None,
             pci_segment: 0,
+            backendfs_config: None,
         }
     }
 }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -380,6 +380,7 @@ pub struct BalloonConfig {
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct FsConfig {
     pub tag: String,
+    #[serde(default)]
     pub socket: PathBuf,
     #[serde(default = "default_fsconfig_num_queues")]
     pub num_queues: usize,


### PR DESCRIPTION
Hi team, here comes a native virtio-fs approach, which removes vhost-user stuff and make virtio-fs a native device like virti0-block and virtio-net devices. 
**Good things are:**

- We don't need a seperate virtiofsd process to support virtio-fs
    service, which means virtio-fs now have same lifecycle with C-H itself.
- It supports Snapshot and Migration
- technologies like "vm template" can be applied because the memory can
    be private mmapped now even in virtio-fs used cases.
- it removes the vhost stuff, which makes the code path shorter, we
    don't rely a unix domain socket any more.
- A consistent virtio model. Now the most frequently used virtio
    devices: virtio-blk, virtio-net and virtio-fs are all native ones. This
    means it's easier to develop generic virtio features and they are easier
    to be applied to each devices.

**Tested with fio, looks the iops and bw is similar. But the booting time reduced.**

**Note1**: This approach relies on service/code from virtiofsd repo, but virtiofsd code should be modified to be generic so that this approach works. I currently hacked the virtiofsd code for a bit to make this work, (you can see the virtiofsd dependency in cargo.toml is my branch not the official one).
**Note2**: This is a RFC, there are some work to be done both for virtiofsd repo and here CH repo.

**TODO**:

-  add dax stuff (done)

-  add some arguments(the current approach removed some arguments)
- add thread_pool
           it's currently thread:queue = 1:1 , thread_pool feature is a todo.
