### PR TITLE
vmm: config: fix incorrect values of error

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1010,27 +1010,27 @@ impl NetConfig {
             .unwrap_or_default();
         let bw_size = parser
             .convert("bw_size")
-            .map_err(Error::ParseDisk)?
+            .map_err(Error::ParseNetwork)?
             .unwrap_or_default();
         let bw_one_time_burst = parser
             .convert("bw_one_time_burst")
-            .map_err(Error::ParseDisk)?
+            .map_err(Error::ParseNetwork)?
             .unwrap_or_default();
         let bw_refill_time = parser
             .convert("bw_refill_time")
-            .map_err(Error::ParseDisk)?
+            .map_err(Error::ParseNetwork)?
             .unwrap_or_default();
         let ops_size = parser
             .convert("ops_size")
-            .map_err(Error::ParseDisk)?
+            .map_err(Error::ParseNetwork)?
             .unwrap_or_default();
         let ops_one_time_burst = parser
             .convert("ops_one_time_burst")
-            .map_err(Error::ParseDisk)?
+            .map_err(Error::ParseNetwork)?
             .unwrap_or_default();
         let ops_refill_time = parser
             .convert("ops_refill_time")
-            .map_err(Error::ParseDisk)?
+            .map_err(Error::ParseNetwork)?
             .unwrap_or_default();
         let bw_tb_config = if bw_size != 0 && bw_refill_time != 0 {
             Some(TokenBucketConfig {


### PR DESCRIPTION
The PR #2333 added I/O rate limiter on block device, with some options in `DiskConfig`.  And the PR #2401 added rate limiter on virtio-net device with same options, but it still throws `Error::ParseDisk`.

This commit fixes it with correct values.

Fixes: #2401