### PR TITLE
hypervisor: rename get_cpuid to get_supported_cpuid

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -609,7 +609,9 @@ pub fn generate_common_cpuid(
     ];
 
     // Supported CPUID
-    let mut cpuid = hypervisor.get_cpuid().map_err(Error::CpuidGetSupported)?;
+    let mut cpuid = hypervisor
+        .get_supported_cpuid()
+        .map_err(Error::CpuidGetSupported)?;
 
     CpuidPatch::patch_cpuid(&mut cpuid, cpuid_patches);
 

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -108,7 +108,7 @@ pub trait Hypervisor: Send + Sync {
     ///
     /// Get the supported CpuID
     ///
-    fn get_cpuid(&self) -> Result<Vec<CpuIdEntry>>;
+    fn get_supported_cpuid(&self) -> Result<Vec<CpuIdEntry>>;
     ///
     /// Check particular extensions if any
     ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1023,7 +1023,7 @@ impl hypervisor::Hypervisor for KvmHypervisor {
     ///
     /// X86 specific call to get the system supported CPUID values.
     ///
-    fn get_cpuid(&self) -> hypervisor::Result<Vec<CpuIdEntry>> {
+    fn get_supported_cpuid(&self) -> hypervisor::Result<Vec<CpuIdEntry>> {
         let kvm_cpuid = self
             .kvm
             .get_supported_cpuid(kvm_bindings::KVM_MAX_CPUID_ENTRIES)

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -270,7 +270,7 @@ impl hypervisor::Hypervisor for MshvHypervisor {
     ///
     /// Get the supported CpuID
     ///
-    fn get_cpuid(&self) -> hypervisor::Result<Vec<CpuIdEntry>> {
+    fn get_supported_cpuid(&self) -> hypervisor::Result<Vec<CpuIdEntry>> {
         Ok(Vec::new())
     }
 }


### PR DESCRIPTION
To better reflect its nature and avoid confusion with get_cpuid2.

No functional change.