### PR TITLE
using resamplefd to auto-unmask vfio INTx interrupt

### DIFF
--- a/devices/src/interrupt_controller.rs
+++ b/devices/src/interrupt_controller.rs
@@ -24,6 +24,10 @@ pub enum Error {
     UpdateInterrupt(io::Error),
     /// Failed enabling the interrupt.
     EnableInterrupt(io::Error),
+    /// Failed enabling the resample eventfd.
+    EnableResampleFd(io::Error),
+    /// Failed disabling the resample eventfd.
+    DisableResampleFd(io::Error),
     #[cfg(target_arch = "aarch64")]
     /// Failed creating GIC device.
     CreateGic(hypervisor::HypervisorVmError),
@@ -62,4 +66,10 @@ pub trait InterruptController: Send {
     #[cfg(target_arch = "x86_64")]
     fn end_of_interrupt(&mut self, vec: u8);
     fn notifier(&self, irq: usize) -> Option<EventFd>;
+    #[cfg(target_arch = "x86_64")]
+    fn enable_resamplefd(&self, irq: usize) -> Result<()>;
+    #[cfg(target_arch = "x86_64")]
+    fn disable_resamplefd(&self, irq: usize) -> Result<()>;
+    #[cfg(target_arch = "x86_64")]
+    fn resamplefd_notifier(&self, irq: usize) -> Option<EventFd>;
 }

--- a/vm-device/src/interrupt/mod.rs
+++ b/vm-device/src/interrupt/mod.rs
@@ -141,6 +141,35 @@ pub trait InterruptSourceGroup: Send + Sync {
     #[allow(unused_variables)]
     fn notifier(&self, index: InterruptIndex) -> Option<EventFd>;
 
+    /// Enable the resamplefd.
+    /// With the resamplefd, vfio INTx interrupt can be automatically unamsk in EOI
+    #[cfg(target_arch = "x86_64")]
+    fn enable_resamplefd(&self, _index: InterruptIndex) -> Result<()> {
+        // Not all interrupt sources need resamplefd.
+        // If not, we can have a no-op here.
+        Ok(())
+    }
+
+    /// Disable the resamplefd.
+    #[cfg(target_arch = "x86_64")]
+    fn disable_resamplefd(&self, _index: InterruptIndex) -> Result<()> {
+        // Not all interrupt sources need resamplefd.
+        // If not, we can have a no-op here.
+        Ok(())
+    }
+
+    /// Returns an interrupt resample notifier from this interrupt.
+    ///
+    /// An interrupt resample notifier allows for kvm re-enable level triggered
+    /// interrupt automatically without userspace intervention.
+    #[allow(unused_variables)]
+    #[cfg(target_arch = "x86_64")]
+    fn resamplefd_notifier(&self, index: InterruptIndex) -> Option<EventFd> {
+        // Not all interrupt sources have a unmask notifier.
+        // If not, we can return None here.
+        None
+    }
+
     /// Update the interrupt source group configuration.
     ///
     /// # Arguments

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -691,6 +691,7 @@ fn vcpu_thread_rules(
         (libc::SYS_dup, vec![]),
         (libc::SYS_exit, vec![]),
         (libc::SYS_epoll_ctl, vec![]),
+        (libc::SYS_eventfd2, vec![]),
         (libc::SYS_fstat, vec![]),
         (libc::SYS_futex, vec![]),
         (libc::SYS_getrandom, vec![]),


### PR DESCRIPTION
Fixes: #4999 
Current implementation is only for x86_64 and KVM.