### PR TITLE
vmm, devices: Update to latest acpi_tables crate API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,9 +5,9 @@ version = 3
 [[package]]
 name = "acpi_tables"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#12bb6d7b252831527e630f8b3ef48877dbb11924"
+source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#0b892e2c2053c4ecfac8d9e5a52babae75114702"
 dependencies = [
- "vm-memory",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1640,6 +1640,7 @@ dependencies = [
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
+ "zerocopy",
 ]
 
 [[package]]

--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -4,7 +4,7 @@
 //
 
 use super::AcpiNotificationFlags;
-use acpi_tables::{aml, aml::Aml};
+use acpi_tables::{aml, Aml, AmlSink};
 use std::sync::{Arc, Barrier};
 use std::time::Instant;
 use vm_device::interrupt::InterruptSourceGroup;
@@ -103,11 +103,11 @@ impl BusDevice for AcpiGedDevice {
 }
 
 impl Aml for AcpiGedDevice {
-    fn append_aml_bytes(&self, bytes: &mut Vec<u8>) {
+    fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
         aml::Device::new(
             "_SB_.GEC_".into(),
             vec![
-                &aml::Name::new("_HID".into(), &aml::EisaName::new("PNP0A06")),
+                &aml::Name::new("_HID".into(), &aml::EISAName::new("PNP0A06")),
                 &aml::Name::new("_UID".into(), &"Generic Event Controller"),
                 &aml::Name::new(
                     "_CRS".into(),
@@ -121,12 +121,13 @@ impl Aml for AcpiGedDevice {
                 &aml::OpRegion::new(
                     "GDST".into(),
                     aml::OpRegionSpace::SystemMemory,
-                    self.address.0 as usize,
-                    GED_DEVICE_ACPI_SIZE,
+                    &(self.address.0 as usize),
+                    &GED_DEVICE_ACPI_SIZE,
                 ),
                 &aml::Field::new(
                     "GDST".into(),
                     aml::FieldAccessType::Byte,
+                    aml::FieldLockRule::NoLock,
                     aml::FieldUpdateRule::WriteAsZeroes,
                     vec![aml::FieldEntry::Named(*b"GDAT", 8)],
                 ),
@@ -163,7 +164,7 @@ impl Aml for AcpiGedDevice {
                 ),
             ],
         )
-        .append_aml_bytes(bytes);
+        .to_aml_bytes(sink);
         aml::Device::new(
             "_SB_.GED_".into(),
             vec![
@@ -187,7 +188,7 @@ impl Aml for AcpiGedDevice {
                 ),
             ],
         )
-        .append_aml_bytes(bytes)
+        .to_aml_bytes(sink)
     }
 }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -5,9 +5,9 @@ version = 3
 [[package]]
 name = "acpi_tables"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#4fd38dd5f746730ec5ae848dafcf8c2f50a13fc3"
+source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#0b892e2c2053c4ecfac8d9e5a52babae75114702"
 dependencies = [
- "vm-memory",
+ "zerocopy",
 ]
 
 [[package]]
@@ -989,6 +989,7 @@ dependencies = [
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1030,3 +1031,24 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -55,3 +55,4 @@ vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic", 
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { version = "0.11.0", features = ["with-serde"] }
+zerocopy = "0.6.1"


### PR DESCRIPTION
Significant API changes have occured, most significantly is the switch
to an approach which does not require vm-memory and can run no_std.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>


