### PR TITLE
Use hugepagesize of the current device to calculate nr_hugepages

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -240,7 +240,9 @@ sudo bash -c "echo 10 > /sys/kernel/mm/ksm/sleep_millisecs"
 sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 
 # Both test_vfio and ovs-dpdk rely on hugepages
-echo 6144 | sudo tee /proc/sys/vm/nr_hugepages
+HUGEPAGESIZE=`grep Hugepagesize /proc/meminfo | awk '{print $2}'`
+PAGE_NUM=`echo $((12288 * 1024 / $HUGEPAGESIZE))`
+echo $PAGE_NUM | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 # Run all direct kernel boot (Device Tree) test cases in mod `parallel`


### PR DESCRIPTION
On aarch64 server,cat /proc/meminfo
```
Hugepagesize:     524288 kB
Hugetlb:          524288 kB
```
On x86 server,cat /proc/meminfo
```
Hugepagesize:       2048 kB
Hugetlb:            2048 kB
```
2048kB x 6144 = 524288kB x 24.
We should dynamically configure nr_ hugepages。