### PR TITLE
tests: Enable live-upgrade tests based on v30.0

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -148,7 +148,7 @@ update_workloads() {
     popd
 
     # Download Cloud Hypervisor binary from its last stable release
-    LAST_RELEASE_VERSION="v26.0"
+    LAST_RELEASE_VERSION="v30.0"
     CH_RELEASE_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$LAST_RELEASE_VERSION/cloud-hypervisor-static-aarch64"
     CH_RELEASE_NAME="cloud-hypervisor-static-aarch64"
     pushd $WORKLOADS_DIR

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -46,7 +46,7 @@ fi
 popd
 
 # Download Cloud Hypervisor binary from its last stable release
-LAST_RELEASE_VERSION="v26.0"
+LAST_RELEASE_VERSION="v30.0"
 CH_RELEASE_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$LAST_RELEASE_VERSION/cloud-hypervisor-static"
 CH_RELEASE_NAME="cloud-hypervisor-static"
 pushd $WORKLOADS_DIR

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9335,51 +9335,43 @@ mod live_migration {
         }
 
         #[test]
-        #[ignore]
         fn test_live_upgrade_basic() {
             _test_live_migration(true, false)
         }
 
         #[test]
-        #[ignore]
         fn test_live_upgrade_local() {
             _test_live_migration(true, true)
         }
 
         #[test]
-        #[ignore]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_numa() {
             _test_live_migration_numa(true, false)
         }
 
         #[test]
-        #[ignore]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_numa_local() {
             _test_live_migration_numa(true, true)
         }
 
         #[test]
-        #[ignore]
         fn test_live_upgrade_watchdog() {
             _test_live_migration_watchdog(true, false)
         }
 
         #[test]
-        #[ignore]
         fn test_live_upgrade_watchdog_local() {
             _test_live_migration_watchdog(true, true)
         }
 
         #[test]
-        #[ignore]
         fn test_live_upgrade_balloon() {
             _test_live_migration_balloon(true, false)
         }
 
         #[test]
-        #[ignore]
         fn test_live_upgrade_balloon_local() {
             _test_live_migration_balloon(true, true)
         }
@@ -9406,7 +9398,6 @@ mod live_migration {
         }
 
         #[test]
-        #[ignore]
         #[cfg(target_arch = "x86_64")]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_ovs_dpdk() {
@@ -9414,7 +9405,6 @@ mod live_migration {
         }
 
         #[test]
-        #[ignore]
         #[cfg(target_arch = "x86_64")]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_ovs_dpdk_local() {


### PR DESCRIPTION
Due to refactoring on snapshot/restore support #4960 #4970 and CLI changes #5086, the live-upgrade tests were disabled since release v28.0. Now we are ready to re-enable them based on release v30.0