### PR TITLE
tests: performance-metrics: Add timeout parameter as runtime argument.

### DIFF
--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1352,6 +1352,7 @@ pub fn parse_iperf3_output(output: &[u8], sender: bool, bandwidth: bool) -> Resu
     })
 }
 
+#[derive(Clone)]
 pub enum FioOps {
     Read,
     RandomRead,


### PR DESCRIPTION
This commit will add timeout parameter to performance metrics testcases as runtime argument. Testcases are facing the timeout issue sometimes when we run it with MSHV hypervisor. This change will provide mechanism to pass the timeout as per the need while running the testcases. If nothing is passed, default timeout or timeout set as per the testcase will be followed.