### PR TITLE
build: Migrate from DockerHub to ghcr

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
     paths: resources/Dockerfile
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -20,19 +24,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
-        if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@v1 
+      - name: Login to ghcr
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
-          # list of Docker images to use as base name for tags
-          images: cloudhypervisor/dev
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=raw,value={{date 'YYYYMMDD'}}-0

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+#
 # When changing this file don't forget to update the tag name in the
 # .github/workflows/docker-image.yaml file if doing multiple per day
 

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -6,8 +6,8 @@
 
 CLI_NAME="Cloud Hypervisor"
 
-CTR_IMAGE_TAG="cloudhypervisor/dev"
-CTR_IMAGE_VERSION="20230301-0"
+CTR_IMAGE_TAG="ghcr.io/cloud-hypervisor/cloud-hypervisor"
+CTR_IMAGE_VERSION="20230315-0"
 CTR_IMAGE="${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}"
 
 DOCKER_RUNTIME="docker"


### PR DESCRIPTION
It is necessary to transition away from DockerHub as the small
organisation plan in being EOLed.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
