### PR TITLE
scripts: dev_cli: Bump container version

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -7,7 +7,7 @@
 CLI_NAME="Cloud Hypervisor"
 
 CTR_IMAGE_TAG="ghcr.io/cloud-hypervisor/cloud-hypervisor"
-CTR_IMAGE_VERSION="20230315-0"
+CTR_IMAGE_VERSION="20230316-0"
 CTR_IMAGE="${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}"
 
 DOCKER_RUNTIME="docker"


### PR DESCRIPTION
Unfortunately the build had a transient error and so needed to be
restarted which generated a build with a different date tag.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
