### PR TITLE
vmm: optimize snapshot memory file size

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -694,6 +694,7 @@ mod unit_tests {
                 prefault: false,
                 zones: None,
                 thp: true,
+                dirty_log: false,
             },
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1123,6 +1123,9 @@ components:
           type: string
         prefault:
           type: boolean
+        dirty_log:
+          type: boolean
+          default: false
 
     ReceiveMigrationData:
       required:

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -734,6 +734,9 @@ components:
         thp:
           type: boolean
           default: true
+        dirty_log:
+          type: boolean
+          default: false
         zones:
           type: array
           items:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1671,6 +1671,8 @@ pub struct RestoreConfig {
     pub source_url: PathBuf,
     #[serde(default)]
     pub prefault: bool,
+    #[serde(default)]
+    pub dirty_log: bool,
 }
 
 impl RestoreConfig {
@@ -1688,10 +1690,16 @@ impl RestoreConfig {
             .map_err(Error::ParseRestore)?
             .unwrap_or(Toggle(false))
             .0;
+        let dirty_log = parser
+            .convert::<Toggle>("dirty_log")
+            .map_err(Error::ParseRestore)?
+            .unwrap_or(Toggle(false))
+            .0;
 
         Ok(RestoreConfig {
             source_url,
             prefault,
+            dirty_log,
         })
     }
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -634,6 +634,11 @@ impl MemoryConfig {
             .map_err(Error::ParseMemory)?
             .unwrap_or(Toggle(true))
             .0;
+        let dirty_log = parser
+            .convert::<Toggle>("dirty_log")
+            .map_err(Error::ParseMemory)?
+            .unwrap_or(Toggle(false))
+            .0;
 
         let zones: Option<Vec<MemoryZoneConfig>> = if let Some(memory_zones) = &memory_zones {
             let mut zones = Vec::new();
@@ -721,6 +726,7 @@ impl MemoryConfig {
             prefault,
             zones,
             thp,
+            dirty_log,
         })
     }
 
@@ -2737,6 +2743,7 @@ mod tests {
                 prefault: false,
                 zones: None,
                 thp: true,
+                dirty_log: false,
             },
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -644,7 +644,9 @@ impl Vmm {
         let source_url = source_url.unwrap();
 
         let vm_config = Arc::new(Mutex::new({
-            recv_vm_config(source_url).map_err(VmError::Restore)?
+            let mut vm_config = recv_vm_config(source_url).map_err(VmError::Restore)?;
+            vm_config.memory.dirty_log = restore_cfg.dirty_log;
+            vm_config
         }));
         let snapshot = recv_vm_state(source_url).map_err(VmError::Restore)?;
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -643,9 +643,9 @@ impl Vmm {
         // Safe to unwrap as we checked it was Some(&str).
         let source_url = source_url.unwrap();
 
-        let vm_config = Arc::new(Mutex::new(
-            recv_vm_config(source_url).map_err(VmError::Restore)?,
-        ));
+        let vm_config = Arc::new(Mutex::new({
+            recv_vm_config(source_url).map_err(VmError::Restore)?
+        }));
         let snapshot = recv_vm_state(source_url).map_err(VmError::Restore)?;
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         let vm_snapshot = get_vm_snapshot(&snapshot).map_err(VmError::Restore)?;
@@ -2093,6 +2093,7 @@ mod unit_tests {
                 prefault: false,
                 zones: None,
                 thp: true,
+                dirty_log: false,
             },
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -207,6 +207,9 @@ pub enum Error {
     #[error("Cannot send VM snapshot: {0}")]
     SnapshotSend(#[source] MigratableError),
 
+    #[error("Cannot enable dirty_log: {0}")]
+    Dirtylog(#[source] MigratableError),
+
     #[error("Invalid restore source URL")]
     InvalidRestoreSourceUrl,
 
@@ -2133,6 +2136,12 @@ impl Vm {
             .allocate_address_space()
             .map_err(Error::MemoryManager)?;
 
+        self.memory_manager
+            .lock()
+            .unwrap()
+            .init_dirty_log()
+            .map_err(Error::Dirtylog)?;
+
         self.cpu_manager
             .lock()
             .unwrap()
@@ -2159,6 +2168,12 @@ impl Vm {
             .unwrap()
             .allocate_address_space()
             .map_err(Error::MemoryManager)?;
+
+        self.memory_manager
+            .lock()
+            .unwrap()
+            .init_dirty_log()
+            .map_err(Error::Dirtylog)?;
 
         // Now we can start all vCPUs from here.
         self.cpu_manager

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -161,6 +161,8 @@ pub struct MemoryConfig {
     pub zones: Option<Vec<MemoryZoneConfig>>,
     #[serde(default = "default_memoryconfig_thp")]
     pub thp: bool,
+    #[serde(default)]
+    pub dirty_log: bool,
 }
 
 pub const DEFAULT_MEMORY_MB: u64 = 512;
@@ -179,6 +181,7 @@ impl Default for MemoryConfig {
             prefault: false,
             zones: None,
             thp: true,
+            dirty_log: false,
         }
     }
 }


### PR DESCRIPTION
In snapshot, cloud hypervisor will save all guest memory as
a memory file. And the file will be used to restore the
guest memory when restore VM. The memory file size is always
same as the configuration of VM memory size.

This patch does some optimize to reduce the memory file size.
When snapshot the VM, guest may not touch all memory, so we
could identify the touched guest memory via KVM dirty log
feature, then only save the touched guest memory range into
file, leave untouched range as file holes, then reduce the
memory file size on disk.

In my case, an Ubuntu VM configured with 512MB memory, with
this patch reduces the memory file into about 254MB.