### PR TITLE
tests: disable virtio_balloon_free_page_reporting on mshv

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5199,6 +5199,7 @@ mod common_parallel {
     }
 
     #[test]
+    #[cfg(not(feature = "mshv"))]
     fn test_virtio_balloon_free_page_reporting() {
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(focal));


### PR DESCRIPTION
balloon_free_page_reporting test case should not work as expected. The reason is that MSHV pins  all the pages during the memory map for the guest. Those pages can not be altered without unpinning the pages. MSHV does not support modifying the pages during the guest life cycle. This test case can be enabled once we add VA backed VM support.