### PR TITLE
docs: api: document `receive-migration` and `send-migration`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -78,33 +78,35 @@ The Cloud Hypervisor API exposes the following actions through its endpoints:
 
 #### Virtual Machine (VM) Actions
 
-| Action                             | Endpoint              | Request Body                | Response Body            | Prerequisites                    |
-| ---------------------------------- | --------------------- | --------------------------- | ------------------------ | -------------------------------- |
-| Create the VM                      | `/vm.create`          | `/schemas/VmConfig`         | N/A                      | The VM is not created yet        |
-| Delete the VM                      | `/vm.delete`          | N/A                         | N/A                      | N/A                              |
-| Boot the VM                        | `/vm.boot`            | N/A                         | N/A                      | The VM is created but not booted |
-| Shut the VM down                   | `/vm.shutdown`        | N/A                         | N/A                      | The VM is booted                 |
-| Reboot the VM                      | `/vm.reboot`          | N/A                         | N/A                      | The VM is booted                 |
-| Trigger power button of the VM     | `/vm.power-button`    | N/A                         | N/A                      | The VM is booted                 |
-| Pause the VM                       | `/vm.pause`           | N/A                         | N/A                      | The VM is booted                 |
-| Resume the VM                      | `/vm.resume`          | N/A                         | N/A                      | The VM is paused                 |
-| Task a snapshot of the VM          | `/vm.snapshot`        | `/schemas/VmSnapshotConfig` | N/A                      | The VM is paused                 |
-| Perform a coredump of the VM*      | `/vm.coredump`        | `/schemas/VmCoredumpData`   | N/A                      | The VM is paused                 |
-| Restore the VM from a snapshot     | `/vm.restore`         | `/schemas/RestoreConfig`    | N/A                      | The VM is created but not booted |
-| Add/remove CPUs to/from the VM     | `/vm.resize`          | `/schemas/VmResize`         | N/A                      | The VM is booted                 |
-| Add/remove memory from the VM      | `/vm.resize`          | `/schemas/VmResize`         | N/A                      | The VM is booted                 |
-| Add/remove memory from a zone      | `/vm.resize-zone`     | `/schemas/VmResizeZone`     | N/A                      | The VM is booted                 |
-| Dump the VM information            | `/vm.info`            | N/A                         | `/schemas/VmInfo`        | The VM is created                |
-| Add VFIO PCI device to the VM      | `/vm.add-device`      | `/schemas/VmAddDevice`      | `/schemas/PciDeviceInfo` | The VM is booted                 |
-| Add disk device to the VM          | `/vm.add-disk`        | `/schemas/DiskConfig`       | `/schemas/PciDeviceInfo` | The VM is booted                 |
-| Add fs device to the VM            | `/vm.add-fs`          | `/schemas/FsConfig`         | `/schemas/PciDeviceInfo` | The VM is booted                 |
-| Add pmem device to the VM          | `/vm.add-pmem`        | `/schemas/PmemConfig`       | `/schemas/PciDeviceInfo` | The VM is booted                 |
-| Add network device to the VM       | `/vm.add-net`         | `/schemas/NetConfig`        | `/schemas/PciDeviceInfo` | The VM is booted                 |
-| Add userspace PCI device to the VM | `/vm.add-user-device` | `/schemas/VmAddUserDevice`  | `/schemas/PciDeviceInfo` | The VM is booted                 |
-| Add vdpa device to the VM          | `/vm.add-vdpa`        | `/schemas/VdpaConfig`       | `/schemas/PciDeviceInfo` | The VM is booted                 |
-| Add vsock device to the VM         | `/vm.add-vsock`       | `/schemas/VsockConfig`      | `/schemas/PciDeviceInfo` | The VM is booted                 |
-| Remove device from the VM          | `/vm.remove-device`   | `/schemas/VmRemoveDevice`   | N/A                      | The VM is booted                 |
-| Dump the VM counters               | `/vm.counters`        | N/A                         | `/schemas/VmCounters`    | The VM is booted                 |
+| Action                             | Endpoint                | Request Body                    | Response Body            | Prerequisites                                          |
+| ---------------------------------- | ----------------------- | ------------------------------- | ------------------------ | ------------------------------------------------------ |
+| Create the VM                      | `/vm.create`            | `/schemas/VmConfig`             | N/A                      | The VM is not created yet                              |
+| Delete the VM                      | `/vm.delete`            | N/A                             | N/A                      | N/A                                                    |
+| Boot the VM                        | `/vm.boot`              | N/A                             | N/A                      | The VM is created but not booted                       |
+| Shut the VM down                   | `/vm.shutdown`          | N/A                             | N/A                      | The VM is booted                                       |
+| Reboot the VM                      | `/vm.reboot`            | N/A                             | N/A                      | The VM is booted                                       |
+| Trigger power button of the VM     | `/vm.power-button`      | N/A                             | N/A                      | The VM is booted                                       |
+| Pause the VM                       | `/vm.pause`             | N/A                             | N/A                      | The VM is booted                                       |
+| Resume the VM                      | `/vm.resume`            | N/A                             | N/A                      | The VM is paused                                       |
+| Task a snapshot of the VM          | `/vm.snapshot`          | `/schemas/VmSnapshotConfig`     | N/A                      | The VM is paused                                       |
+| Perform a coredump of the VM*      | `/vm.coredump`          | `/schemas/VmCoredumpData`       | N/A                      | The VM is paused                                       |
+| Restore the VM from a snapshot     | `/vm.restore`           | `/schemas/RestoreConfig`        | N/A                      | The VM is created but not booted                       |
+| Add/remove CPUs to/from the VM     | `/vm.resize`            | `/schemas/VmResize`             | N/A                      | The VM is booted                                       |
+| Add/remove memory from the VM      | `/vm.resize`            | `/schemas/VmResize`             | N/A                      | The VM is booted                                       |
+| Add/remove memory from a zone      | `/vm.resize-zone`       | `/schemas/VmResizeZone`         | N/A                      | The VM is booted                                       |
+| Dump the VM information            | `/vm.info`              | N/A                             | `/schemas/VmInfo`        | The VM is created                                      |
+| Add VFIO PCI device to the VM      | `/vm.add-device`        | `/schemas/VmAddDevice`          | `/schemas/PciDeviceInfo` | The VM is booted                                       |
+| Add disk device to the VM          | `/vm.add-disk`          | `/schemas/DiskConfig`           | `/schemas/PciDeviceInfo` | The VM is booted                                       |
+| Add fs device to the VM            | `/vm.add-fs`            | `/schemas/FsConfig`             | `/schemas/PciDeviceInfo` | The VM is booted                                       |
+| Add pmem device to the VM          | `/vm.add-pmem`          | `/schemas/PmemConfig`           | `/schemas/PciDeviceInfo` | The VM is booted                                       |
+| Add network device to the VM       | `/vm.add-net`           | `/schemas/NetConfig`            | `/schemas/PciDeviceInfo` | The VM is booted                                       |
+| Add userspace PCI device to the VM | `/vm.add-user-device`   | `/schemas/VmAddUserDevice`      | `/schemas/PciDeviceInfo` | The VM is booted                                       |
+| Add vdpa device to the VM          | `/vm.add-vdpa`          | `/schemas/VdpaConfig`           | `/schemas/PciDeviceInfo` | The VM is booted                                       |
+| Add vsock device to the VM         | `/vm.add-vsock`         | `/schemas/VsockConfig`          | `/schemas/PciDeviceInfo` | The VM is booted                                       |
+| Remove device from the VM          | `/vm.remove-device`     | `/schemas/VmRemoveDevice`       | N/A                      | The VM is booted                                       |
+| Dump the VM counters               | `/vm.counters`          | N/A                             | `/schemas/VmCounters`    | The VM is booted                                       |
+| Prepare to receive a migration     | `/vm.receive-migration` | `/schemas/ReceiveMigrationData` | N/A                      | N/A                                                    |
+| Start to send migration to target  | `/vm.send-migration`    | `/schemas/SendMigrationData`    | N/A                      | The VM is booted and (shared mem or hugepages enabled) |
 
 * The `vmcoredump` action is available exclusively for the `x86_64`
 architecture and can be executed only when the `guest_debug` feature is


### PR DESCRIPTION
I noticed that `/vm.receive-migration` and `/vm.send-migration` endpoints are not documented in the API docs. I did go through the source code for the `VmReceiveMigration` call and there doesn't seem to be any prerequisite, happy to correct the commit if there's any.