### PR TITLE
mshv: Implement set_cpuid2 call and ensure topology

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2046,19 +2046,16 @@ mod common_parallel {
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_cpu_topology_421() {
         test_cpu_topology(4, 2, 1, false);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_cpu_topology_142() {
         test_cpu_topology(1, 4, 2, false);
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_cpu_topology_262() {
         test_cpu_topology(2, 6, 2, false);
     }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -168,6 +168,7 @@ mod mshv {
     pub const MSHV_GET_GPA_ACCESS_STATES: u64 = 0xc01c_b812;
     pub const MSHV_VP_TRANSLATE_GVA: u64 = 0xc020_b80e;
     pub const MSHV_CREATE_PARTITION: u64 = 0x4030_b801;
+    pub const MSHV_VP_REGISTER_INTERCEPT_RESULT: u64 = 0x4030_b817;
 }
 #[cfg(feature = "mshv")]
 use mshv::*;
@@ -197,6 +198,12 @@ fn create_vmm_ioctl_seccomp_rule_common_mshv() -> Result<Vec<SeccompRule>, Backe
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_GPA_ACCESS_STATES)?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_VP_TRANSLATE_GVA)?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_CREATE_PARTITION)?],
+        and![Cond::new(
+            1,
+            ArgLen::Dword,
+            Eq,
+            MSHV_VP_REGISTER_INTERCEPT_RESULT
+        )?],
     ])
 }
 


### PR DESCRIPTION
This set of patches implements the `set_cpuid2` for MSHV based on the `HvCallRegisterInterceptResult` hypercall. 

Summary of the implementation and accompanying fixes:

- Implement `set_cpuid2` for MSHV
- [moved to mshv crate] Handle topology leafs `0xb` and `0x1f` for Intel processors
- Topology related integration tests can be enabled on MSHV
- Seccomp filter is extended for `HvCallRegisterInterceptResult` hypercall

This enablement of this functionality will mean, that all the entries passed through `CpuidPatch` and other CPUID modifications will be registered for the interception through MSHV and then delivered directly to the guest. Depending on a concrete CPUID entries, some additional handling might need to be implemented (like in this case for the topology leafs).

Please note also, that this PR pulls an updated version of the MSHV crate. It seems that it was not pulled by the bot within a couple of days, but the particular `mshv` crate version is required.

Fixes: #3175
