### PR TITLE
hypervisor: make buildable independently

### DIFF
--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 license = "Apache-2.0 OR BSD-3-Clause"
 
 [features]
-kvm = ["kvm-ioctls", "kvm-bindings"]
-mshv = ["mshv-ioctls", "mshv-bindings"]
+kvm = ["kvm-ioctls", "kvm-bindings", "vfio-ioctls/kvm"]
+mshv = ["mshv-ioctls", "mshv-bindings", "vfio-ioctls/mshv"]
 tdx = []
 
 [dependencies]


### PR DESCRIPTION
It was not possible to build just hypervisor with Cargo's -p flag, because it was not properly specifying the features it requires from vfio-ioctls.