### PR TITLE
hypervisor: use proper doc tests for examples

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -335,16 +335,17 @@ impl KvmVm {
     }
 }
 
-///
 /// Implementation of Vm trait for KVM
-/// Example:
-/// #[cfg(feature = "kvm")]
-/// extern crate hypervisor
-/// let kvm = hypervisor::kvm::KvmHypervisor::new().unwrap();
-/// let hypervisor: Arc<dyn hypervisor::Hypervisor> = Arc::new(kvm);
-/// let vm = hypervisor.create_vm().expect("new VM fd creation failed");
-/// vm.set/get().unwrap()
 ///
+/// # Examples
+///
+/// ```
+/// # use hypervisor::kvm::KvmHypervisor;
+/// # use std::sync::Arc;
+/// let kvm = KvmHypervisor::new().unwrap();
+/// let hypervisor = Arc::new(kvm);
+/// let vm = hypervisor.create_vm().expect("new VM fd creation failed");
+/// ```
 impl vm::Vm for KvmVm {
     #[cfg(target_arch = "x86_64")]
     ///
@@ -917,13 +918,16 @@ impl KvmHypervisor {
     }
 }
 /// Implementation of Hypervisor trait for KVM
-/// Example:
-/// #[cfg(feature = "kvm")]
-/// extern crate hypervisor
-/// let kvm = hypervisor::kvm::KvmHypervisor::new().unwrap();
-/// let hypervisor: Arc<dyn hypervisor::Hypervisor> = Arc::new(kvm);
-/// let vm = hypervisor.create_vm().expect("new VM fd creation failed");
 ///
+/// # Examples
+///
+/// ```
+/// # use hypervisor::kvm::KvmHypervisor;
+/// # use std::sync::Arc;
+/// let kvm = KvmHypervisor::new().unwrap();
+/// let hypervisor = Arc::new(kvm);
+/// let vm = hypervisor.create_vm().expect("new VM fd creation failed");
+/// ```
 impl hypervisor::Hypervisor for KvmHypervisor {
     ///
     /// Returns the type of the hypervisor
@@ -932,13 +936,15 @@ impl hypervisor::Hypervisor for KvmHypervisor {
         HypervisorType::Kvm
     }
     /// Create a KVM vm object of a specific VM type and return the object as Vm trait object
-    /// Example
-    /// # extern crate hypervisor;
-    /// # use hypervisor::KvmHypervisor;
-    /// use hypervisor::KvmVm;
-    /// let hypervisor = KvmHypervisor::new().unwrap();
-    /// let vm = hypervisor.create_vm_with_type(KvmVmType::LegacyVm).unwrap()
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hypervisor::kvm::KvmHypervisor;
+    /// use hypervisor::kvm::KvmVm;
+    /// let hypervisor = KvmHypervisor::new().unwrap();
+    /// let vm = hypervisor.create_vm_with_type(0).unwrap();
+    /// ```
     fn create_vm_with_type(&self, vm_type: u64) -> hypervisor::Result<Arc<dyn vm::Vm>> {
         let fd: VmFd;
         loop {
@@ -992,13 +998,15 @@ impl hypervisor::Hypervisor for KvmHypervisor {
     }
 
     /// Create a KVM vm object and return the object as Vm trait object
-    /// Example
-    /// # extern crate hypervisor;
-    /// # use hypervisor::KvmHypervisor;
-    /// use hypervisor::KvmVm;
-    /// let hypervisor = KvmHypervisor::new().unwrap();
-    /// let vm = hypervisor.create_vm().unwrap()
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hypervisor::kvm::KvmHypervisor;
+    /// use hypervisor::kvm::KvmVm;
+    /// let hypervisor = KvmHypervisor::new().unwrap();
+    /// let vm = hypervisor.create_vm().unwrap();
+    /// ```
     fn create_vm(&self) -> hypervisor::Result<Arc<dyn vm::Vm>> {
         #[allow(unused_mut)]
         let mut vm_type: u64 = 0; // Create with default platform type
@@ -1087,15 +1095,17 @@ pub struct KvmVcpu {
     hyperv_synic: AtomicBool,
 }
 /// Implementation of Vcpu trait for KVM
-/// Example:
-/// #[cfg(feature = "kvm")]
-/// extern crate hypervisor
-/// let kvm = hypervisor::kvm::KvmHypervisor::new().unwrap();
-/// let hypervisor: Arc<dyn hypervisor::Hypervisor> = Arc::new(kvm);
+///
+/// # Examples
+///
+/// ```
+/// # use hypervisor::kvm::KvmHypervisor;
+/// # use std::sync::Arc;
+/// let kvm = KvmHypervisor::new().unwrap();
+/// let hypervisor = Arc::new(kvm);
 /// let vm = hypervisor.create_vm().expect("new VM fd creation failed");
 /// let vcpu = vm.create_vcpu(0, None).unwrap();
-/// vcpu.get/set().unwrap()
-///
+/// ```
 impl cpu::Vcpu for KvmVcpu {
     #[cfg(target_arch = "x86_64")]
     ///
@@ -1797,11 +1807,10 @@ impl cpu::Vcpu for KvmVcpu {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate hypervisor;
-    /// # use hypervisor::KvmHypervisor;
+    /// # use hypervisor::kvm::KvmHypervisor;
     /// # use std::sync::Arc;
-    /// let kvm = hypervisor::kvm::KvmHypervisor::new().unwrap();
-    /// let hv: Arc<dyn hypervisor::Hypervisor> = Arc::new(kvm);
+    /// let kvm = KvmHypervisor::new().unwrap();
+    /// let hv = Arc::new(kvm);
     /// let vm = hv.create_vm().expect("new VM fd creation failed");
     /// vm.enable_split_irq().unwrap();
     /// let vcpu = vm.create_vcpu(0, None).unwrap();
@@ -1969,11 +1978,10 @@ impl cpu::Vcpu for KvmVcpu {
     /// # Example
     ///
     /// ```rust
-    /// # extern crate hypervisor;
-    /// # use hypervisor::KvmHypervisor;
+    /// # use hypervisor::kvm::KvmHypervisor;
     /// # use std::sync::Arc;
-    /// let kvm = hypervisor::kvm::KvmHypervisor::new().unwrap();
-    /// let hv: Arc<dyn hypervisor::Hypervisor> = Arc::new(kvm);
+    /// let kvm = KvmHypervisor::new().unwrap();
+    /// let hv = Arc::new(kvm);
     /// let vm = hv.create_vm().expect("new VM fd creation failed");
     /// vm.enable_split_irq().unwrap();
     /// let vcpu = vm.create_vcpu(0, None).unwrap();

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -48,9 +48,9 @@ mod cpu;
 /// Device related module
 mod device;
 
+pub use crate::hypervisor::{Hypervisor, HypervisorError};
 pub use cpu::{HypervisorCpuError, Vcpu, VmExit};
 pub use device::HypervisorDeviceError;
-pub use hypervisor::{Hypervisor, HypervisorError};
 #[cfg(all(feature = "kvm", target_arch = "aarch64"))]
 pub use kvm::{aarch64, GicState};
 use std::sync::Arc;

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -195,13 +195,16 @@ impl MshvHypervisor {
     }
 }
 /// Implementation of Hypervisor trait for Mshv
-/// Example:
-/// #[cfg(feature = "mshv")]
-/// extern crate hypervisor
-/// let mshv = hypervisor::mshv::MshvHypervisor::new().unwrap();
-/// let hypervisor: Arc<dyn hypervisor::Hypervisor> = Arc::new(mshv);
-/// let vm = hypervisor.create_vm().expect("new VM fd creation failed");
 ///
+/// # Examples
+///
+/// ```
+/// # use hypervisor::mshv::MshvHypervisor;
+/// # use std::sync::Arc;
+/// let mshv = MshvHypervisor::new().unwrap();
+/// let hypervisor = Arc::new(mshv);
+/// let vm = hypervisor.create_vm().expect("new VM fd creation failed");
+/// ```
 impl hypervisor::Hypervisor for MshvHypervisor {
     ///
     /// Returns the type of the hypervisor
@@ -210,13 +213,16 @@ impl hypervisor::Hypervisor for MshvHypervisor {
         HypervisorType::Mshv
     }
     /// Create a mshv vm object and return the object as Vm trait object
-    /// Example
-    /// # extern crate hypervisor;
-    /// # use hypervisor::MshvHypervisor;
-    /// use hypervisor::MshvVm;
-    /// let hypervisor = MshvHypervisor::new().unwrap();
-    /// let vm = hypervisor.create_vm().unwrap()
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate hypervisor;
+    /// # use hypervisor::mshv::MshvHypervisor;
+    /// use hypervisor::mshv::MshvVm;
+    /// let hypervisor = MshvHypervisor::new().unwrap();
+    /// let vm = hypervisor.create_vm().unwrap();
+    /// ```
     fn create_vm(&self) -> hypervisor::Result<Arc<dyn vm::Vm>> {
         let fd: VmFd;
         loop {
@@ -285,15 +291,17 @@ pub struct MshvVcpu {
 }
 
 /// Implementation of Vcpu trait for Microsoft Hypervisor
-/// Example:
-/// #[cfg(feature = "mshv")]
-/// extern crate hypervisor
-/// let mshv = hypervisor::mshv::MshvHypervisor::new().unwrap();
-/// let hypervisor: Arc<dyn hypervisor::Hypervisor> = Arc::new(mshv);
-/// let vm = hypervisor.create_vm().expect("new VM fd creation failed");
-/// let vcpu = vm.create_vcpu(0).unwrap();
-/// vcpu.get/set().unwrap()
 ///
+/// # Examples
+///
+/// ```
+/// # use hypervisor::mshv::MshvHypervisor;
+/// # use std::sync::Arc;
+/// let mshv = MshvHypervisor::new().unwrap();
+/// let hypervisor = Arc::new(mshv);
+/// let vm = hypervisor.create_vm().expect("new VM fd creation failed");
+/// let vcpu = vm.create_vcpu(0, None).unwrap();
+/// ```
 impl cpu::Vcpu for MshvVcpu {
     #[cfg(target_arch = "x86_64")]
     ///
@@ -917,15 +925,17 @@ impl MshvVm {
 
 ///
 /// Implementation of Vm trait for Mshv
-/// Example:
-/// #[cfg(feature = "mshv")]
-/// # extern crate hypervisor;
-/// # use hypervisor::MshvHypervisor;
-/// let mshv = MshvHypervisor::new().unwrap();
-/// let hypervisor: Arc<dyn hypervisor::Hypervisor> = Arc::new(mshv);
-/// let vm = hypervisor.create_vm().expect("new VM fd creation failed");
-/// vm.set/get().unwrap()
 ///
+/// # Examples
+///
+/// ```
+/// # extern crate hypervisor;
+/// # use hypervisor::mshv::MshvHypervisor;
+/// # use std::sync::Arc;
+/// let mshv = MshvHypervisor::new().unwrap();
+/// let hypervisor = Arc::new(mshv);
+/// let vm = hypervisor.create_vm().expect("new VM fd creation failed");
+/// ```
 impl vm::Vm for MshvVm {
     #[cfg(target_arch = "x86_64")]
     ///

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -22,3 +22,4 @@ fi
 
 export RUST_BACKTRACE=1
 cargo test --lib --bins --target $BUILD_TARGET --workspace ${cargo_args[@]} || exit 1
+cargo test --doc --target $BUILD_TARGET --workspace ${cargo_args[@]} || exit 1


### PR DESCRIPTION
It seems like these examples were always intended to be doctests, since there are lines marked with "#" so that they are excluded from the generated documentation, but they were not recognised as doc tests because they were not formatted correctly.

The code needed some adjustments so that it would actually compile and run as doctests.