### PR TITLE
build: Release v31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cloud-hypervisor"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "api_client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloud-hypervisor"
-version = "30.0.0"
+version = "31.0.0"
 authors = ["The Cloud Hypervisor Authors"]
 edition = "2021"
 default-run = "cloud-hypervisor"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,10 +1,18 @@
+- [v31.0](#v310)
+    - [Update to Latest `acpi_tables`](#update-to-latest-acpi_tables)
+    - [Update Reference Kernel to 6.2](#update-reference-kernel-to-62)
+    - [Improvements on Console `SIGWINCH` Handler](#improvements-on-console-sigwinch-handler)
+    - [Remove Directory Support from `MemoryZoneConfig::file`](#remove-directory-support-from-memoryzoneconfigfile)
+    - [Documentation Improvements](#documentation-improvements)
+    - [Notable Bug Fixes](#notable-bug-fixes)
+    - [Contributors](#contributors)
 - [v30.0](#v300)
     - [Command Line Changes for Reduced Binary Size](#command-line-changes-for-reduced-binary-size)
     - [Basic vfio-user Server Support](#basic-vfio-user-server-support)
     - [Heap Profiling Support](#heap-profiling-support)
-    - [Documentation Improvements](#documentation-improvements)
-    - [Notable Bug Fixes](#notable-bug-fixes)
-    - [Contributors](#contributors)
+    - [Documentation Improvements](#documentation-improvements-1)
+    - [Notable Bug Fixes](#notable-bug-fixes-1)
+    - [Contributors](#contributors-1)
 - [v28.2](#v282)
 - [v29.0](#v290)
     - [Release Binary Supports Both MSHV and KVM](#release-binary-supports-both-mshv-and-kvm)
@@ -14,10 +22,10 @@
     - [`AArch64` Documentation Integration](#aarch64-documentation-integration)
     - [`virtio-block` Counters Enhancement](#virtio-block-counters-enhancement)
     - [TCP Offload Control](#tcp-offload-control)
-    - [Notable Bug Fixes](#notable-bug-fixes-1)
+    - [Notable Bug Fixes](#notable-bug-fixes-2)
     - [Removals](#removals)
     - [Deprecations](#deprecations)
-    - [Contributors](#contributors-1)
+    - [Contributors](#contributors-2)
 - [v28.1](#v281)
 - [v28.0](#v280)
     - [Community Engagement (Reminder)](#community-engagement-reminder)
@@ -25,9 +33,9 @@
     - [Virtualised TPM Support](#virtualised-tpm-support)
     - [Transparent Huge Page Support](#transparent-huge-page-support)
     - [README Quick Start Improved](#readme-quick-start-improved)
-    - [Notable Bug Fixes](#notable-bug-fixes-2)
+    - [Notable Bug Fixes](#notable-bug-fixes-3)
     - [Removals](#removals-1)
-    - [Contributors](#contributors-2)
+    - [Contributors](#contributors-3)
 - [v27.0](#v270)
     - [Community Engagement](#community-engagement)
     - [Prebuilt Packages](#prebuilt-packages)
@@ -36,41 +44,41 @@
     - [Simplified Build Feature Flags](#simplified-build-feature-flags)
     - [Asynchronous Kernel Loading](#asynchronous-kernel-loading)
     - [GDB Support for AArch64](#gdb-support-for-aarch64)
-    - [Notable Bug Fixes](#notable-bug-fixes-3)
-    - [Deprecations](#deprecations-1)
-    - [Contributors](#contributors-3)
-- [v26.0](#v260)
-    - [SMBIOS Improvements via `--platform`](#smbios-improvements-via-platform)
-    - [Unified Binary MSHV and KVM Support](#unified-binary-mshv-and-kvm-support)
     - [Notable Bug Fixes](#notable-bug-fixes-4)
+    - [Deprecations](#deprecations-1)
+    - [Contributors](#contributors-4)
+- [v26.0](#v260)
+    - [SMBIOS Improvements via `--platform`](#smbios-improvements-via---platform)
+    - [Unified Binary MSHV and KVM Support](#unified-binary-mshv-and-kvm-support)
+    - [Notable Bug Fixes](#notable-bug-fixes-5)
     - [Deprecations](#deprecations-2)
     - [Removals](#removals-2)
-    - [Contributors](#contributors-4)
+    - [Contributors](#contributors-5)
 - [v25.0](#v250)
     - [`ch-remote` Improvements](#ch-remote-improvements-1)
     - [VM "Coredump" Support](#vm-coredump-support)
-    - [Notable Bug Fixes](#notable-bug-fixes-5)
+    - [Notable Bug Fixes](#notable-bug-fixes-6)
     - [Removals](#removals-3)
-    - [Contributors](#contributors-5)
+    - [Contributors](#contributors-6)
 - [v24.0](#v240)
     - [Bypass Mode for `virtio-iommu`](#bypass-mode-for-virtio-iommu)
     - [Ensure Identifiers Uniqueness](#ensure-identifiers-uniqueness)
     - [Sparse Mmap support](#sparse-mmap-support)
     - [Expose Platform Serial Number](#expose-platform-serial-number)
-    - [Notable Bug Fixes](#notable-bug-fixes-6)
+    - [Notable Bug Fixes](#notable-bug-fixes-7)
     - [Notable Improvements](#notable-improvements)
     - [Deprecations](#deprecations-3)
     - [New on the Website](#new-on-the-website)
-    - [Contributors](#contributors-6)
+    - [Contributors](#contributors-7)
 - [v23.1](#v231)
 - [v23.0](#v230)
     - [vDPA Support](#vdpa-support)
     - [Updated OS Support list](#updated-os-support-list)
     - [`AArch64` Memory Map Improvements](#aarch64-memory-map-improvements)
     - [`AMX` Support](#amx-support)
-    - [Notable Bug Fixes](#notable-bug-fixes-7)
+    - [Notable Bug Fixes](#notable-bug-fixes-8)
     - [Deprecations](#deprecations-4)
-    - [Contributors](#contributors-7)
+    - [Contributors](#contributors-8)
 - [v22.1](#v221)
 - [v22.0](#v220)
     - [GDB Debug Stub Support](#gdb-debug-stub-support)
@@ -81,13 +89,13 @@
     - [PMU Support for AArch64](#pmu-support-for-aarch64)
     - [Documentation Under CC-BY-4.0 License](#documentation-under-cc-by-40-license)
     - [Deprecation of "Classic" `virtiofsd`](#deprecation-of-classic-virtiofsd)
-    - [Notable Bug Fixes](#notable-bug-fixes-8)
-    - [Contributors](#contributors-8)
+    - [Notable Bug Fixes](#notable-bug-fixes-9)
+    - [Contributors](#contributors-9)
 - [v21.0](#v210)
     - [Efficient Local Live Migration (for Live Upgrade)](#efficient-local-live-migration-for-live-upgrade)
     - [Recommended Kernel is Now 5.15](#recommended-kernel-is-now-515)
-    - [Notable Bug fixes](#notable-bug-fixes-9)
-    - [Contributors](#contributors-9)
+    - [Notable Bug fixes](#notable-bug-fixes-10)
+    - [Contributors](#contributors-10)
 - [v20.2](#v202)
 - [v20.1](#v201)
 - [v20.0](#v200)
@@ -96,8 +104,8 @@
     - [Improved VFIO support](#improved-vfio-support)
     - [Safer code](#safer-code)
     - [Extended documentation](#extended-documentation)
-    - [Notable bug fixes](#notable-bug-fixes-10)
-    - [Contributors](#contributors-10)
+    - [Notable bug fixes](#notable-bug-fixes-11)
+    - [Contributors](#contributors-11)
 - [v19.0](#v190)
     - [Improved PTY handling for serial and `virtio-console`](#improved-pty-handling-for-serial-and-virtio-console)
     - [PCI boot time optimisations](#pci-boot-time-optimisations)
@@ -105,8 +113,8 @@
     - [Live migration enhancements](#live-migration-enhancements)
     - [`virtio-mem` support with `vfio-user`](#virtio-mem-support-with-vfio-user)
     - [AArch64 for `virtio-iommu`](#aarch64-for-virtio-iommu)
-    - [Notable bug fixes](#notable-bug-fixes-11)
-    - [Contributors](#contributors-11)
+    - [Notable bug fixes](#notable-bug-fixes-12)
+    - [Contributors](#contributors-12)
 - [v18.0](#v180)
     - [Experimental User Device (`vfio-user`) support](#experimental-user-device-vfio-user-support)
     - [Migration support for `vhost-user` devices](#migration-support-for-vhost-user-devices)
@@ -116,31 +124,31 @@
     - [Live migration on MSHV hypervisor](#live-migration-on-mshv-hypervisor)
     - [AArch64 CPU topology support](#aarch64-cpu-topology-support)
     - [Power button support on AArch64](#power-button-support-on-aarch64)
-    - [Notable bug fixes](#notable-bug-fixes-12)
-    - [Contributors](#contributors-12)
+    - [Notable bug fixes](#notable-bug-fixes-13)
+    - [Contributors](#contributors-13)
 - [v17.0](#v170)
     - [ARM64 NUMA support using ACPI](#arm64-numa-support-using-acpi)
     - [`Seccomp` support for MSHV backend](#seccomp-support-for-mshv-backend)
     - [Hotplug of `macvtap` devices](#hotplug-of-macvtap-devices)
     - [Improved SGX support](#improved-sgx-support)
     - [Inflight tracking for `vhost-user` devices](#inflight-tracking-for-vhost-user-devices)
-    - [Notable bug fixes](#notable-bug-fixes-13)
-    - [Contributors](#contributors-13)
+    - [Notable bug fixes](#notable-bug-fixes-14)
+    - [Contributors](#contributors-14)
 - [v16.0](#v160)
     - [Improved live migration support](#improved-live-migration-support)
     - [Improved `vhost-user` support](#improved-vhost-user-support)
     - [ARM64 ACPI and UEFI support](#arm64-acpi-and-uefi-support)
-    - [Notable bug fixes](#notable-bug-fixes-14)
+    - [Notable bug fixes](#notable-bug-fixes-15)
     - [Removed functionality](#removed-functionality)
-    - [Contributors](#contributors-14)
+    - [Contributors](#contributors-15)
 - [v15.0](#v150)
     - [Version numbering and stability guarantees](#version-numbering-and-stability-guarantees)
     - [Network device rate limiting](#network-device-rate-limiting)
     - [Support for runtime control of `virtio-net` guest offload](#support-for-runtime-control-of-virtio-net-guest-offload)
-    - [`--api-socket` supports file descriptor parameter](#-api-socket-supports-file-descriptor-parameter)
+    - [`--api-socket` supports file descriptor parameter](#--api-socket-supports-file-descriptor-parameter)
     - [Bug fixes](#bug-fixes)
     - [Deprecations](#deprecations-5)
-    - [Contributors](#contributors-15)
+    - [Contributors](#contributors-16)
 - [v0.14.1](#v0141)
 - [v0.14.0](#v0140)
     - [Structured event monitoring](#structured-event-monitoring)
@@ -150,7 +158,7 @@
     - [PTY control for serial and `virtio-console`](#pty-control-for-serial-and-virtio-console)
     - [Block device rate limiting](#block-device-rate-limiting)
     - [Deprecations](#deprecations-6)
-    - [Contributors](#contributors-16)
+    - [Contributors](#contributors-17)
 - [v0.13.0](#v0130)
     - [Wider VFIO device support](#wider-vfio-device-support)
     - [Improved huge page support](#improved-huge-page-support)
@@ -158,13 +166,13 @@
     - [VHD disk image support](#vhd-disk-image-support)
     - [Improved Virtio device threading](#improved-virtio-device-threading)
     - [Clean shutdown support via synthetic power button](#clean-shutdown-support-via-synthetic-power-button)
-    - [Contributors](#contributors-17)
+    - [Contributors](#contributors-18)
 - [v0.12.0](#v0120)
     - [ARM64 enhancements](#arm64-enhancements)
     - [Removal of `vhost-user-net` and `vhost-user-block` self spawning](#removal-of-vhost-user-net-and-vhost-user-block-self-spawning)
     - [Migration of `vhost-user-fs` backend](#migration-of-vhost-user-fs-backend)
     - [Enhanced "info" API](#enhanced-info-api)
-    - [Contributors](#contributors-18)
+    - [Contributors](#contributors-19)
 - [v0.11.0](#v0110)
     - [`io_uring` support by default for `virtio-block`](#io_uring-support-by-default-for-virtio-block)
     - [Windows Guest Support](#windows-guest-support)
@@ -174,17 +182,17 @@
     - [Improved Linux Boot Time](#improved-linux-boot-time)
     - [`SIGTERM/SIGINT` Interrupt Signal Handling](#sigtermsigint-interrupt-signal-handling)
     - [Default Log Level Changed](#default-log-level-changed)
-    - [New `--balloon` Parameter Added](#new-balloon-parameter-added)
+    - [New `--balloon` Parameter Added](#new---balloon-parameter-added)
     - [Experimental `virtio-watchdog` Support](#experimental-virtio-watchdog-support)
-    - [Notable Bug Fixes](#notable-bug-fixes-15)
-    - [Contributors](#contributors-19)
+    - [Notable Bug Fixes](#notable-bug-fixes-16)
+    - [Contributors](#contributors-20)
 - [v0.10.0](#v0100)
     - [`virtio-block` Support for Multiple Descriptors](#virtio-block-support-for-multiple-descriptors)
     - [Memory Zones](#memory-zones)
     - [`Seccomp` Sandbox Improvements](#seccomp-sandbox-improvements)
     - [Preliminary KVM HyperV Emulation Control](#preliminary-kvm-hyperv-emulation-control)
-    - [Notable Bug Fixes](#notable-bug-fixes-16)
-    - [Contributors](#contributors-20)
+    - [Notable Bug Fixes](#notable-bug-fixes-17)
+    - [Contributors](#contributors-21)
 - [v0.9.0](#v090)
     - [`io_uring` Based Block Device Support](#io_uring-based-block-device-support)
     - [Block and Network Device Statistics](#block-and-network-device-statistics)
@@ -197,17 +205,17 @@
     - [Enhancements to ARM64 Support](#enhancements-to-arm64-support)
     - [Intel SGX Support](#intel-sgx-support)
     - [`Seccomp` Sandbox Improvements](#seccomp-sandbox-improvements-1)
-    - [Notable Bug Fixes](#notable-bug-fixes-17)
-    - [Contributors](#contributors-21)
+    - [Notable Bug Fixes](#notable-bug-fixes-18)
+    - [Contributors](#contributors-22)
 - [v0.8.0](#v080)
     - [Experimental Snapshot and Restore Support](#experimental-snapshot-and-restore-support)
     - [Experimental ARM64 Support](#experimental-arm64-support)
     - [Support for Using 5-level Paging in Guests](#support-for-using-5-level-paging-in-guests)
     - [Virtio Device Interrupt Suppression for Network Devices](#virtio-device-interrupt-suppression-for-network-devices)
     - [`vhost_user_fs` Improvements](#vhost_user_fs-improvements)
-    - [Notable Bug Fixes](#notable-bug-fixes-18)
+    - [Notable Bug Fixes](#notable-bug-fixes-19)
     - [Command Line and API Changes](#command-line-and-api-changes)
-    - [Contributors](#contributors-22)
+    - [Contributors](#contributors-23)
 - [v0.7.0](#v070)
     - [Block, Network, Persistent Memory (PMEM), VirtioFS and Vsock hotplug](#block-network-persistent-memory-pmem-virtiofs-and-vsock-hotplug)
     - [Alternative `libc` Support](#alternative-libc-support)
@@ -217,14 +225,14 @@
     - [`Seccomp` Sandboxing](#seccomp-sandboxing)
     - [Updated Distribution Support](#updated-distribution-support)
     - [Command Line and API Changes](#command-line-and-api-changes-1)
-    - [Contributors](#contributors-23)
+    - [Contributors](#contributors-24)
 - [v0.6.0](#v060)
     - [Directly Assigned Devices Hotplug](#directly-assigned-devices-hotplug)
     - [Shared Filesystem Improvements](#shared-filesystem-improvements)
     - [Block and Networking IO Self Offloading](#block-and-networking-io-self-offloading)
     - [Command Line Interface](#command-line-interface)
     - [PVH Boot](#pvh-boot)
-    - [Contributors](#contributors-24)
+    - [Contributors](#contributors-25)
 - [v0.5.1](#v051)
 - [v0.5.0](#v050)
     - [Virtual Machine Dynamic Resizing](#virtual-machine-dynamic-resizing)
@@ -232,7 +240,7 @@
     - [New Interrupt Management Framework](#new-interrupt-management-framework)
     - [Development Tools](#development-tools)
     - [Kata Containers Integration](#kata-containers-integration)
-    - [Contributors](#contributors-25)
+    - [Contributors](#contributors-26)
 - [v0.4.0](#v040)
     - [Dynamic virtual CPUs addition](#dynamic-virtual-cpus-addition)
     - [Programmatic firmware tables generation](#programmatic-firmware-tables-generation)
@@ -241,7 +249,7 @@
     - [Userspace IOAPIC by default](#userspace-ioapic-by-default)
     - [PCI BAR reprogramming](#pci-bar-reprogramming)
     - [New `cloud-hypervisor` organization](#new-cloud-hypervisor-organization)
-    - [Contributors](#contributors-26)
+    - [Contributors](#contributors-27)
 - [v0.3.0](#v030)
     - [Block device offloading](#block-device-offloading)
     - [Network device backend](#network-device-backend)
@@ -267,6 +275,72 @@
     - [Console over virtio](#console-over-virtio)
     - [Unit testing](#unit-testing)
     - [Integration tests parallelization](#integration-tests-parallelization)
+
+# v31.0
+
+This release has been tracked in our [roadmap
+project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
+v31.0. The following user visible changes have been made:
+
+### Update to Latest `acpi_tables`
+
+Adapted to the latest [acpi_tables](https://github.com/rust-vmm/acpi_tables).
+There has been significant API changes in the crate.
+
+### Update Reference Kernel to 6.2
+
+Updated the recommended guest kernel version from 6.1.6 to 6.2.
+
+### Improvements on Console `SIGWINCH` Handler
+
+A separate thread had been created to capture the `SIGWINCH` signal and resize
+the guest console. Now the thread is skipped if the console is not resizable.
+
+Two completely different code paths existed for handling console resizing, one
+for `tty` and the other for `pty`. That makes the understanding of the console
+handling code unnecessarily complicated. Now the code paths are unified. Both
+`tty` and `pty` are supported in single `SIGWINCH` handler. And the new handler
+can works with kernel versions earlier than v5.5.
+
+### Remove Directory Support from `MemoryZoneConfig::file`
+
+Setting a directory to `MemoryZoneConfig::file` is no longer supported.
+
+Before this change, user can set a directory to `file` of the `--memory-zone`
+option. In that case, a temporary file will be created as the backing file for
+the `mmap(2)` operation. This functionality has been unnecessary since we had
+the native support for hugepages and allocating anonymous shared memory.
+
+### Documentation Improvements
+
+* Various improvements in API document
+* Improvements in Doc comments
+* Updated Slack channel information in README
+
+### Notable Bug Fixes
+
+* Fixed the offset setting while removing the entire mapping of `vhost-user` FS
+  client.
+* Fixed the `ShutdownVmm` and `Shutdown` commands to call the correct API
+  endpoint.
+
+### Contributors
+
+Many thanks to everyone who has contributed to our release:
+
+* Alyssa Ross <hi@alyssa.is>
+* Bo Chen <chen.bo@intel.com>
+* Daniel Farina <daniel@fdr.io>
+* Dom <peng6662001@163.com>
+* Hao Xu <howeyxu@tencent.com>
+* Muminul Islam <muislam@microsoft.com>
+* Omer Faruk Bayram <omer.faruk@sartura.hr>
+* Ravi kumar Veeramally <ravikumar.veeramally@intel.com>
+* Rob Bradford <rbradford@rivosinc.com>
+* Ruslan Mstoi <ruslan.mstoi@intel.com>
+* Smit Gardhariya <gardhariya.smit@gmail.com>
+* Yang <ailin.yang@intel.com>
+* Yong He <alexyonghe@tencent.com>
 
 # v30.0
 

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -12,7 +12,7 @@ use versionize::{VersionMap, Versionize};
 pub mod protocol;
 
 /// Global VMM version for versioning
-const MAJOR_VERSION: u16 = 30;
+const MAJOR_VERSION: u16 = 31;
 const MINOR_VERSION: u16 = 0;
 const VMM_VERSION: u16 = MAJOR_VERSION << 12 | MINOR_VERSION & 0b1111;
 


### PR DESCRIPTION
Please review but do not merge before April 6. There may be update.

Please also take a look whether the scope of `https://github.com/orgs/cloud-hypervisor/projects/6/views/4` is proper. I applied a filter `is:pr is:closed merged:>2023-02-23 -label:dependencies` to search the PR's (not for dependency) that have been merged since our last release, and picked items from the search result. 
