### PR TITLE
vmm: only touch the tty flags if it's being used

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ use thiserror::Error;
 use vmm::config;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::block_signal;
-use vmm_sys_util::terminal::Terminal;
 
 #[cfg(feature = "dhat-heap")]
 #[global_allocator]
@@ -585,14 +584,6 @@ fn main() {
             1
         }
     };
-
-    // SAFETY: trivially safe
-    let on_tty = unsafe { libc::isatty(libc::STDIN_FILENO) } != 0;
-    if on_tty {
-        // Don't forget to set the terminal in canonical mode
-        // before to exit.
-        std::io::stdin().lock().set_canon_mode().unwrap();
-    }
 
     #[cfg(feature = "dhat-heap")]
     drop(_profiler);

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -41,6 +41,7 @@ use std::os::unix::net::UnixListener;
 use std::os::unix::net::UnixStream;
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, RecvError, SendError, Sender};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -407,12 +408,13 @@ pub struct Vmm {
     activate_evt: EventFd,
     signals: Option<Handle>,
     threads: Vec<thread::JoinHandle<()>>,
+    on_tty: Arc<AtomicBool>,
 }
 
 impl Vmm {
     pub const HANDLED_SIGNALS: [i32; 2] = [SIGTERM, SIGINT];
 
-    fn signal_handler(mut signals: Signals, on_tty: bool, exit_evt: &EventFd) {
+    fn signal_handler(mut signals: Signals, on_tty: Arc<AtomicBool>, exit_evt: &EventFd) {
         for sig in &Self::HANDLED_SIGNALS {
             unblock_signal(*sig).unwrap();
         }
@@ -422,7 +424,7 @@ impl Vmm {
                 SIGTERM | SIGINT => {
                     if exit_evt.write(1).is_err() {
                         // Resetting the terminal is usually done as the VMM exits
-                        if on_tty {
+                        if on_tty.load(Ordering::SeqCst) {
                             io::stdin()
                                 .lock()
                                 .set_canon_mode()
@@ -442,8 +444,7 @@ impl Vmm {
             Ok(signals) => {
                 self.signals = Some(signals.handle());
                 let exit_evt = self.exit_evt.try_clone().map_err(Error::EventFdClone)?;
-                // SAFETY: trivially safe
-                let on_tty = unsafe { libc::isatty(libc::STDIN_FILENO) } != 0;
+                let on_tty = Arc::clone(&self.on_tty);
 
                 let signal_handler_seccomp_filter = get_seccomp_filter(
                     &self.seccomp_action,
@@ -532,6 +533,7 @@ impl Vmm {
             activate_evt,
             signals: None,
             threads: vec![],
+            on_tty: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -582,6 +584,7 @@ impl Vmm {
                         None,
                         None,
                         None,
+                        Arc::clone(&self.on_tty),
                         None,
                         None,
                         None,
@@ -680,6 +683,7 @@ impl Vmm {
             None,
             None,
             None,
+            Arc::clone(&self.on_tty),
             Some(snapshot),
             Some(source_url),
             Some(restore_cfg.prefault),
@@ -760,6 +764,7 @@ impl Vmm {
             serial_pty,
             console_pty,
             console_resize_pipe,
+            Arc::clone(&self.on_tty),
             None,
             None,
             None,
@@ -1262,6 +1267,7 @@ impl Vmm {
             None,
             None,
             None,
+            Arc::clone(&self.on_tty),
             Some(snapshot),
         )
         .map_err(|e| {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -141,9 +141,6 @@ pub enum Error {
     #[error("Cannot setup terminal in raw mode: {0}")]
     SetTerminalRaw(#[source] vmm_sys_util::errno::Error),
 
-    #[error("Cannot setup terminal in canonical mode.: {0}")]
-    SetTerminalCanon(#[source] vmm_sys_util::errno::Error),
-
     #[error("Cannot spawn a signal handler thread: {0}")]
     SignalHandlerSpawn(#[source] io::Error),
 
@@ -1204,15 +1201,6 @@ impl Vm {
         let new_state = VmState::Shutdown;
 
         state.valid_transition(new_state)?;
-
-        if self.on_tty {
-            // Don't forget to set the terminal in canonical mode
-            // before to exit.
-            io::stdin()
-                .lock()
-                .set_canon_mode()
-                .map_err(Error::SetTerminalCanon)?;
-        }
 
         // Wake up the DeviceManager threads so they will get terminated cleanly
         self.device_manager


### PR DESCRIPTION
When neither serial nor console are connected to the tty, cloud-hypervisor shouldn't touch the tty at all.  One way in which this is annoying is that if I am running cloud-hypervisor without it using my terminal, I expect to be able to suspend it with ^Z like any other process, but that doesn't work if it's put the terminal into raw mode.

Instead of putting the tty into raw mode when a VM is created or restored, do it when a serial or console device is created.  Since we now know it can't be put into raw mode until the Vm object is created, we can move setting it back to canon mode into the drop handler for that object, which should always be run in normal operation.  We still also put the tty into canon mode in the SIGTERM / SIGINT handler, but check whether the tty was actually used, rather than whether stdin is a tty.  This requires passing on_tty around as an atomic boolean.

I explored more of an abstraction over the tty — having an object that encapsulated stdout and put the tty into raw mode when initialized and into canon mode when dropped — but it wasn't practical, mostly due to the special requirements of the signal handler.  I also investigated whether the SIGWINCH listener process could be used here, which I think would have worked but I'm hesitant to involve it in serial handling as well as conosle handling.

There's no longer a check for whether the file descriptor is a tty before setting it into canon mode — it's redundant, because if it's not a tty it just won't respond to the ioctl.

Tested by shutting down through the API, SIGTERM, and an error injected after setting raw mode.