### PR TITLE
Additional fields for `VmmPingResponse`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,8 +17,8 @@ fn main() {
     }
 
     // This println!() has a special behavior, as it will set the environment
-    // variable BUILT_VERSION, so that it can be reused from the binary.
+    // variable BUILD_VERSION, so that it can be reused from the binary.
     // Particularly, this is used from src/main.rs to display the exact
     // version.
-    println!("cargo:rustc-env=BUILT_VERSION={version}");
+    println!("cargo:rustc-env=BUILD_VERSION={version}");
 }

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -671,7 +671,7 @@ fn main() {
     let opts: Options = argh::from_env();
 
     if opts.version {
-        println!("{} {}", env!("CARGO_BIN_NAME"), env!("BUILT_VERSION"));
+        println!("{} {}", env!("CARGO_BIN_NAME"), env!("BUILD_VERSION"));
         return;
     }
 

--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -688,7 +688,7 @@ fn main() {
     let toplevel: TopLevel = argh::from_env();
 
     if matches!(toplevel.command, SubCommandEnum::Version(_)) {
-        println!("{} {}", env!("CARGO_BIN_NAME"), env!("BUILT_VERSION"));
+        println!("{} {}", env!("CARGO_BIN_NAME"), env!("BUILD_VERSION"));
         return;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -511,7 +511,7 @@ fn start_vmm(toplevel: TopLevel) -> Result<Option<String>, Error> {
     let vm_debug_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::CreateDebugEventFd)?;
 
     let vmm_thread = vmm::start_vmm_thread(
-        env!("CARGO_PKG_VERSION").to_string(),
+        vmm::VmmVersionInfo::new(env!("BUILD_VERSION"), env!("CARGO_PKG_VERSION")),
         &api_socket_path,
         api_socket_fd,
         api_evt.try_clone().unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -571,7 +571,7 @@ fn main() {
     let toplevel: TopLevel = argh::from_env();
 
     if toplevel.version {
-        println!("{} {}", env!("CARGO_BIN_NAME"), env!("BUILT_VERSION"));
+        println!("{} {}", env!("CARGO_BIN_NAME"), env!("BUILD_VERSION"));
         return;
     }
 

--- a/vhost_user_block/src/main.rs
+++ b/vhost_user_block/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
     let toplevel: TopLevel = argh::from_env();
 
     if toplevel.version {
-        println!("{} {}", env!("CARGO_BIN_NAME"), env!("BUILT_VERSION"));
+        println!("{} {}", env!("CARGO_BIN_NAME"), env!("BUILD_VERSION"));
         return;
     }
 

--- a/vhost_user_net/src/main.rs
+++ b/vhost_user_net/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
     let toplevel: TopLevel = argh::from_env();
 
     if toplevel.version {
-        println!("{} {}", env!("CARGO_BIN_NAME"), env!("BUILT_VERSION"));
+        println!("{} {}", env!("CARGO_BIN_NAME"), env!("BUILD_VERSION"));
         return;
     }
 

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -165,7 +165,9 @@ pub struct VmInfo {
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct VmmPingResponse {
+    pub build_version: String,
     pub version: String,
+    pub pid: i64,
 }
 
 #[derive(Clone, Deserialize, Serialize, Default, Debug)]

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -438,8 +438,13 @@ components:
         - version
       type: object
       properties:
+        build_version:
+          type: string
         version:
           type: string
+        pid:
+          type: integer
+          format: int64
       description: Virtual Machine Monitor information
 
     VmInfo:


### PR DESCRIPTION
This PR introduces several additional fields to the `VmmPingResponse` struct beyond the `version` information. The updated response now includes the `build_version` and `pid` fields as shown below:
```json
{
  "build_version": "v31.0-4-g48084c33-dirty",
  "version": "31.0.0",
  "pid": 60639
}
```