### PR TITLE
Properly validate and close FDs for TAP devices

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1134,22 +1134,6 @@ impl NetConfig {
     }
 }
 
-impl Clone for NetConfig {
-    fn clone(&self) -> Self {
-        NetConfig {
-            tap: self.tap.clone(),
-            vhost_socket: self.vhost_socket.clone(),
-            id: self.id.clone(),
-            fds: self
-                .fds
-                .as_ref()
-                // SAFETY: We have been handed these FDs through the API
-                .map(|fds| fds.iter().map(|fd| unsafe { libc::dup(*fd) }).collect()),
-            ..*self
-        }
-    }
-}
-
 impl Drop for NetConfig {
     fn drop(&mut self) {
         if let Some(mut fds) = self.fds.take() {

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2418,19 +2418,18 @@ mod tests {
         // SAFETY: Safe as the file was just opened
         let fd2 = unsafe { libc::dup(File::open("/dev/null").unwrap().as_raw_fd()) };
 
-        assert_eq!(
-            &format!(
-                "{:?}",
-                NetConfig::parse(&format!(
-                    "mac=de:ad:be:ef:12:34,fd=[{fd1},{fd2}],num_queues=4"
-                ))?
-            ),
-            &format!("NetConfig {{ tap: None, ip: 192.168.249.1, mask: 255.255.255.0, \
-                mac: MacAddr {{ bytes: [222, 173, 190, 239, 18, 52] }}, host_mac: None, mtu: None, \
-                iommu: false, num_queues: 4, queue_size: 256, vhost_user: false, vhost_socket: None, \
-                vhost_mode: Client, id: None, fds: Some([{fd1}, {fd2}]), \
-                rate_limiter_config: None, pci_segment: 0, offload_tso: true, offload_ufo: true, offload_csum: true }}")
-        );
+        let mut net = NetConfig::parse(&format!(
+            "mac=de:ad:be:ef:12:34,fd=[{fd1},{fd2}],num_queues=4"
+        ))?;
+        net.fds_validated = true;
+
+        let net_string = format!("NetConfig {{ tap: None, ip: 192.168.249.1, mask: 255.255.255.0, \
+            mac: MacAddr {{ bytes: [222, 173, 190, 239, 18, 52] }}, host_mac: None, mtu: None, \
+            iommu: false, num_queues: 4, queue_size: 256, vhost_user: false, vhost_socket: None, \
+            vhost_mode: Client, id: None, fds: Some([{fd1}, {fd2}]), fds_validated: true, \
+            rate_limiter_config: None, pci_segment: 0, offload_tso: true, offload_ufo: true, offload_csum: true }}");
+
+        assert_eq!(&format!("{:?}", net), &net_string);
 
         Ok(())
     }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -248,7 +248,7 @@ impl Default for DiskConfig {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct NetConfig {
     #[serde(default = "default_netconfig_tap")]
     pub tap: Option<String>,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -277,6 +277,8 @@ pub struct NetConfig {
     pub id: Option<String>,
     #[serde(default)]
     pub fds: Option<Vec<i32>>,
+    #[serde(skip)]
+    pub fds_validated: bool,
     #[serde(default)]
     pub rate_limiter_config: Option<RateLimiterConfig>,
     #[serde(default)]
@@ -338,6 +340,7 @@ impl Default for NetConfig {
             vhost_mode: VhostMode::Client,
             id: None,
             fds: None,
+            fds_validated: false,
             rate_limiter_config: None,
             pci_segment: 0,
             offload_tso: true,


### PR DESCRIPTION
### vmm: config: Do not 'dup' tap FDs from NetConfig::clone()
A new file descriptor (FD) is created from duplicating the input FDs
for NetConfig. This accidentally fooled the validation logic used on
hotplug (which takes a clone of the NetConfig), particularly for
rejecting reserved FDs.

### vmm: Close FDs for TAP devices only if they are validated
The input FDs from NetConfig are valid if and only if TAP devices can be
created successfully using them.