### PR TITLE
Export RUST_BACKTRACE when it is not set explicitly

### DIFF
--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -107,7 +107,12 @@ fi
 # Ensure that git commands can be run in this directory (for metrics report)
 git config --global --add safe.directory $PWD
 
-export RUST_BACKTRACE=1
+RUST_BACKTRACE_VALUE=`echo $RUST_BACKTRACE`
+if [ -z $RUST_BACKTRACE_VALUE ];then
+	export RUST_BACKTRACE=1
+else
+	echo "RUST_BACKTRACE is set to: $RUST_BACKTRACE_VALUE"
+fi
 time target/$BUILD_TARGET/release/performance-metrics ${test_binary_args[*]}
 RES=$?
 


### PR DESCRIPTION
Currently we are overwriting the RUST_BACKTRACE if set explicitly by user while running performance metrics tests using dev_cli.sh

This change will allow user to set the RUST_BACKTRACE while running performance metrics tests with dev_cli.sh which invokes run_metrics.sh to run the performance binary. We will set RUST_BACKTRACE to 1 only if not set explicitly.