### PR TITLE
Export RUST_BACKTRACE when it is not set explicitly

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -539,6 +539,7 @@ cmd_tests() {
             --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
             --env USER="root" \
             --env CH_LIBC="${libc}" \
+            --env RUST_BACKTRACE="${RUST_BACKTRACE}" \
             "$CTR_IMAGE" \
             ./scripts/run_metrics.sh "$@" || fix_dir_perms $? || exit $?
     fi

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -107,7 +107,12 @@ fi
 # Ensure that git commands can be run in this directory (for metrics report)
 git config --global --add safe.directory $PWD
 
-export RUST_BACKTRACE=1
+RUST_BACKTRACE_VALUE=`echo $RUST_BACKTRACE`
+if [ -z $RUST_BACKTRACE_VALUE ];then
+	export RUST_BACKTRACE=1
+else
+	echo "RUST_BACKTRACE is set to: $RUST_BACKTRACE_VALUE"
+fi
 time target/$BUILD_TARGET/release/performance-metrics ${test_binary_args[*]}
 RES=$?
 


### PR DESCRIPTION
Currently we are overwriting the RUST_BACKTRACE if set explicitly by user while running performance metrics tests using dev_cli.sh

This change will allow user to set the RUST_BACKTRACE while running performance metrics tests with dev_cli.sh which invokes run_metrics.sh to run the performance binary. We will set RUST_BACKTRACE to 1 if not set explicitly.

We will pass RUST_BACKTRACE as env variable while running the docker container.