### PR TITLE
hypervisor: Fix few register names on MSHV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "mshv-bindings"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#66531ba242be0b744ee2e4cd602ab0000377bdf7"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#c1230f282c2836ba89ee112146bf638343424de8"
 dependencies = [
  "libc",
  "serde",
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "mshv-ioctls"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#66531ba242be0b744ee2e4cd602ab0000377bdf7"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#c1230f282c2836ba89ee112146bf638343424de8"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -454,10 +454,10 @@ impl cpu::Vcpu for MshvVcpu {
                             /* Advance RIP and update RAX */
                             let arr_reg_name_value = [
                                 (
-                                    hv_x64_register_name_HV_X64_REGISTER_RIP,
+                                    hv_register_name_HV_X64_REGISTER_RIP,
                                     info.header.rip + insn_len,
                                 ),
-                                (hv_x64_register_name_HV_X64_REGISTER_RAX, ret_rax),
+                                (hv_register_name_HV_X64_REGISTER_RAX, ret_rax),
                             ];
                             set_registers_64!(self.fd, arr_reg_name_value)
                                 .map_err(|e| cpu::HypervisorCpuError::SetRegister(e.into()))?;
@@ -503,10 +503,10 @@ impl cpu::Vcpu for MshvVcpu {
                     /* Advance RIP and update RAX */
                     let arr_reg_name_value = [
                         (
-                            hv_x64_register_name_HV_X64_REGISTER_RIP,
+                            hv_register_name_HV_X64_REGISTER_RIP,
                             info.header.rip + insn_len,
                         ),
-                        (hv_x64_register_name_HV_X64_REGISTER_RAX, ret_rax),
+                        (hv_register_name_HV_X64_REGISTER_RAX, ret_rax),
                     ];
                     set_registers_64!(self.fd, arr_reg_name_value)
                         .map_err(|e| cpu::HypervisorCpuError::SetRegister(e.into()))?;


### PR DESCRIPTION
Recently generated mshv-bindings has most of the registers
renamed. This patch renames some of the MSHV registers.