### PR TITLE
hypervisor, vmm: Limit max number of vCPUs to hypervisor maximum

### DIFF
--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -133,4 +133,7 @@ pub trait Hypervisor: Send + Sync {
     fn get_guest_debug_hw_bps(&self) -> usize {
         unimplemented!()
     }
+
+    /// Get maximum number of vCPUs
+    fn get_max_vcpus(&self) -> u32;
 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1084,6 +1084,11 @@ impl hypervisor::Hypervisor for KvmHypervisor {
             self.kvm.get_guest_debug_hw_bps() as usize
         }
     }
+
+    /// Get maximum number of vCPUs
+    fn get_max_vcpus(&self) -> u32 {
+        self.kvm.get_max_vcpus().min(u32::MAX as usize) as u32
+    }
 }
 /// Vcpu struct for KVM
 pub struct KvmVcpu {

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -279,6 +279,13 @@ impl hypervisor::Hypervisor for MshvHypervisor {
     fn get_supported_cpuid(&self) -> hypervisor::Result<Vec<CpuIdEntry>> {
         Ok(Vec::new())
     }
+
+    /// Get maximum number of vCPUs
+    fn get_max_vcpus(&self) -> u32 {
+        // TODO: Using HV_MAXIMUM_PROCESSORS would be better
+        // but the ioctl API is limited to u8
+        256
+    }
 }
 
 /// Vcpu struct for Microsoft Hypervisor


### PR DESCRIPTION
On KVM this is provided by an ioctl, on MSHV this is constant. Although
there is a HV_MAXIMUM_PROCESSORS constant the MSHV ioctl API is limited
to u8.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
