### PR TITLE
vmm: only use KVM_ARM_VCPU_PMU_V3 if available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,8 +545,7 @@ dependencies = [
 [[package]]
 name = "kvm-ioctls"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8dc9c1896e5f144ec5d07169bc29f39a047686d29585a91f30489abfaeb6b"
+source = "git+https://github.com/rust-vmm/kvm-ioctls?branch=main#23a3bb045a467e60bb00328a0b13cea13b5815d0"
 dependencies = [
  "kvm-bindings",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ vm-memory = "0.10.0"
 # List of patched crates
 [patch.crates-io]
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.6.0-tdx" }
+kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "main" }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
 
 [dev-dependencies]

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -330,7 +330,7 @@ impl KvmVm {
         Ok(VfioDeviceFd::new_from_kvm(device_fd))
     }
     /// Checks if a particular `Cap` is available.
-    fn check_extension(&self, c: Cap) -> bool {
+    pub fn check_extension(&self, c: Cap) -> bool {
         self.fd.check_extension(c)
     }
 }


### PR DESCRIPTION
Having PMU in guests isn't critical, and not all hardware supports it (e.g. Apple Silicon).

CpuManager::init_pmu already has a fallback for if PMU is not supported by the VCPU, but we weren't getting that far, because we would always try to initialise the VCPU with KVM_ARM_VCPU_PMU_V3, and then bail when it returned with EINVAL.