### PR TITLE
virtio-devices: remove incorrect "blk" references

### DIFF
--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -86,8 +86,8 @@ pub enum ActivateError {
     ThreadSpawn(std::io::Error),
     #[error("Failed to setup vhost-user-fs daemon: {0}")]
     VhostUserFsSetup(vhost_user::Error),
-    #[error("Failed to setup vhost-user-blk daemon: {0}")]
-    VhostUserBlkSetup(vhost_user::Error),
+    #[error("Failed to setup vhost-user daemon: {0}")]
+    VhostUserSetup(vhost_user::Error),
     #[error("Failed to create seccomp filter: {0}")]
     CreateSeccompFilter(seccompiler::Error),
     #[error("Failed to create rate limiter: {0}")]

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -340,7 +340,7 @@ impl VhostUserCommon {
                 &slave_req_handler,
                 inflight.as_mut(),
             )
-            .map_err(ActivateError::VhostUserBlkSetup)?;
+            .map_err(ActivateError::VhostUserSetup)?;
 
         Ok(VhostUserEpollHandler {
             vu: vu.clone(),
@@ -413,7 +413,7 @@ impl VhostUserCommon {
     pub fn pause(&mut self) -> std::result::Result<(), MigratableError> {
         if let Some(vu) = &self.vu {
             vu.lock().unwrap().pause_vhost_user().map_err(|e| {
-                MigratableError::Pause(anyhow!("Error pausing vhost-user-blk backend: {:?}", e))
+                MigratableError::Pause(anyhow!("Error pausing vhost-user backend: {:?}", e))
             })
         } else {
             Ok(())
@@ -423,7 +423,7 @@ impl VhostUserCommon {
     pub fn resume(&mut self) -> std::result::Result<(), MigratableError> {
         if let Some(vu) = &self.vu {
             vu.lock().unwrap().resume_vhost_user().map_err(|e| {
-                MigratableError::Resume(anyhow!("Error resuming vhost-user-blk backend: {:?}", e))
+                MigratableError::Resume(anyhow!("Error resuming vhost-user backend: {:?}", e))
             })
         } else {
             Ok(())


### PR DESCRIPTION
This code is shared between all vhost-user devices, not just vhost-user-blk.