### PR TITLE
Extend 'VmConfig' with 'preserved_fds'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -731,6 +731,7 @@ mod unit_tests {
             gdb: false,
             platform: None,
             tpm: None,
+            preserved_fds: None,
         };
 
         assert_eq!(expected_vm_config, result_vm_config);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6238,6 +6238,18 @@ mod common_parallel {
                     .unwrap_or_default(),
                 2
             );
+
+            guest.reboot_linux(0, None);
+
+            assert_eq!(
+                guest
+                    .ssh_command("ip -o link | wc -l")
+                    .unwrap()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default(),
+                2
+            );
         });
 
         let _ = child.kill();

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1134,22 +1134,6 @@ impl NetConfig {
     }
 }
 
-impl Clone for NetConfig {
-    fn clone(&self) -> Self {
-        NetConfig {
-            tap: self.tap.clone(),
-            vhost_socket: self.vhost_socket.clone(),
-            id: self.id.clone(),
-            fds: self
-                .fds
-                .as_ref()
-                // SAFETY: We have been handed these FDs through the API
-                .map(|fds| fds.iter().map(|fd| unsafe { libc::dup(*fd) }).collect()),
-            ..*self
-        }
-    }
-}
-
 impl RngConfig {
     pub fn parse(rng: &str) -> Result<Self> {
         let mut parser = OptionParser::new();

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2351,17 +2351,6 @@ mod tests {
         Ok(())
     }
 
-    fn memfd_create(name: &std::ffi::CStr, flags: u32) -> std::result::Result<i32, std::io::Error> {
-        // SAFETY: FFI call with correct arguments
-        let res = unsafe { libc::syscall(libc::SYS_memfd_create, name.as_ptr(), flags) };
-
-        if res < 0 {
-            Err(std::io::Error::last_os_error())
-        } else {
-            Ok(res as i32)
-        }
-    }
-
     #[test]
     fn test_net_parsing() -> Result<()> {
         // mac address is random
@@ -2440,23 +2429,17 @@ mod tests {
             }
         );
 
-        let fd1 =
-            memfd_create(&std::ffi::CString::new("test_net_parsing_fd1").unwrap(), 0).unwrap();
-        let fd2 =
-            memfd_create(&std::ffi::CString::new("test_net_parsing_fd2").unwrap(), 0).unwrap();
-
         assert_eq!(
-            &format!(
-                "{:?}",
-                NetConfig::parse(&format!(
-                    "mac=de:ad:be:ef:12:34,fd=[{fd1},{fd2}],num_queues=4"
-                ))?
-            ),
-            &format!("NetConfig {{ tap: None, ip: 192.168.249.1, mask: 255.255.255.0, \
-                mac: MacAddr {{ bytes: [222, 173, 190, 239, 18, 52] }}, host_mac: None, mtu: None, \
-                iommu: false, num_queues: 4, queue_size: 256, vhost_user: false, vhost_socket: None, \
-                vhost_mode: Client, id: None, fds: Some([{fd1}, {fd2}]), \
-                rate_limiter_config: None, pci_segment: 0, offload_tso: true, offload_ufo: true, offload_csum: true }}")
+            NetConfig::parse("mac=de:ad:be:ef:12:34,fd=[3,7],num_queues=4")?,
+            NetConfig {
+                mac: MacAddr::parse_str("de:ad:be:ef:12:34").unwrap(),
+                fds: Some(vec![3, 7]),
+                num_queues: 4,
+                id: None,
+                tap: None,
+                vhost_socket: None,
+                ..Default::default()
+            }
         );
 
         Ok(())

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2120,6 +2120,50 @@ impl VmConfig {
     }
 }
 
+impl Clone for VmConfig {
+    fn clone(&self) -> Self {
+        VmConfig {
+            cpus: self.cpus.clone(),
+            memory: self.memory.clone(),
+            payload: self.payload.clone(),
+            disks: self.disks.clone(),
+            net: self.net.clone(),
+            rng: self.rng.clone(),
+            balloon: self.balloon.clone(),
+            fs: self.fs.clone(),
+            pmem: self.pmem.clone(),
+            serial: self.serial.clone(),
+            console: self.console.clone(),
+            devices: self.devices.clone(),
+            user_devices: self.user_devices.clone(),
+            vdpa: self.vdpa.clone(),
+            vsock: self.vsock.clone(),
+            #[cfg(target_arch = "x86_64")]
+            sgx_epc: self.sgx_epc.clone(),
+            numa: self.numa.clone(),
+            platform: self.platform.clone(),
+            tpm: self.tpm.clone(),
+            preserved_fds: self
+                .preserved_fds
+                .as_ref()
+                // SAFETY: FFI call with valid FDs
+                .map(|fds| fds.iter().map(|fd| unsafe { libc::dup(*fd) }).collect()),
+            ..*self
+        }
+    }
+}
+
+impl Drop for VmConfig {
+    fn drop(&mut self) {
+        if let Some(mut fds) = self.preserved_fds.take() {
+            for fd in fds.drain(..) {
+                // SAFETY: FFI call with valid FDs
+                unsafe { libc::close(fd) };
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1150,17 +1150,6 @@ impl Clone for NetConfig {
     }
 }
 
-impl Drop for NetConfig {
-    fn drop(&mut self) {
-        if let Some(mut fds) = self.fds.take() {
-            for fd in fds.drain(..) {
-                // SAFETY: Safe as the fd was given to the config by the API
-                unsafe { libc::close(fd) };
-            }
-        }
-    }
-}
-
 impl RngConfig {
     pub fn parse(rng: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -2354,10 +2343,6 @@ mod tests {
             NetConfig {
                 mac: MacAddr::parse_str("de:ad:be:ef:12:34").unwrap(),
                 host_mac: Some(MacAddr::parse_str("12:34:de:ad:be:ef").unwrap()),
-                fds: None,
-                id: None,
-                tap: None,
-                vhost_socket: None,
                 ..Default::default()
             }
         );
@@ -2368,9 +2353,6 @@ mod tests {
                 mac: MacAddr::parse_str("de:ad:be:ef:12:34").unwrap(),
                 host_mac: Some(MacAddr::parse_str("12:34:de:ad:be:ef").unwrap()),
                 id: Some("mynet0".to_owned()),
-                fds: None,
-                tap: None,
-                vhost_socket: None,
                 ..Default::default()
             }
         );
@@ -2385,9 +2367,6 @@ mod tests {
                 tap: Some("tap0".to_owned()),
                 ip: "192.168.100.1".parse().unwrap(),
                 mask: "255.255.255.128".parse().unwrap(),
-                fds: None,
-                id: None,
-                vhost_socket: None,
                 ..Default::default()
             }
         );
@@ -2401,9 +2380,6 @@ mod tests {
                 host_mac: Some(MacAddr::parse_str("12:34:de:ad:be:ef").unwrap()),
                 vhost_user: true,
                 vhost_socket: Some("/tmp/sock".to_owned()),
-                fds: None,
-                id: None,
-                tap: None,
                 ..Default::default()
             }
         );
@@ -2416,10 +2392,6 @@ mod tests {
                 num_queues: 4,
                 queue_size: 1024,
                 iommu: true,
-                fds: None,
-                id: None,
-                tap: None,
-                vhost_socket: None,
                 ..Default::default()
             }
         );
@@ -2430,9 +2402,6 @@ mod tests {
                 mac: MacAddr::parse_str("de:ad:be:ef:12:34").unwrap(),
                 fds: Some(vec![3, 7]),
                 num_queues: 4,
-                id: None,
-                tap: None,
-                vhost_socket: None,
                 ..Default::default()
             }
         );
@@ -2855,10 +2824,6 @@ mod tests {
         let mut invalid_config = valid_config.clone();
         invalid_config.net = Some(vec![NetConfig {
             vhost_user: true,
-            fds: None,
-            id: None,
-            tap: None,
-            vhost_socket: None,
             ..Default::default()
         }]);
         assert_eq!(
@@ -2870,9 +2835,6 @@ mod tests {
         still_valid_config.net = Some(vec![NetConfig {
             vhost_user: true,
             vhost_socket: Some("/path/to/sock".to_owned()),
-            fds: None,
-            id: None,
-            tap: None,
             ..Default::default()
         }]);
         still_valid_config.memory.shared = true;
@@ -2881,9 +2843,6 @@ mod tests {
         let mut invalid_config = valid_config.clone();
         invalid_config.net = Some(vec![NetConfig {
             fds: Some(vec![0]),
-            id: None,
-            tap: None,
-            vhost_socket: None,
             ..Default::default()
         }]);
         assert_eq!(
@@ -2894,10 +2853,6 @@ mod tests {
         let mut invalid_config = valid_config.clone();
         invalid_config.net = Some(vec![NetConfig {
             offload_csum: false,
-            fds: None,
-            id: None,
-            tap: None,
-            vhost_socket: None,
             ..Default::default()
         }]);
         assert_eq!(
@@ -3001,10 +2956,6 @@ mod tests {
         still_valid_config.net = Some(vec![NetConfig {
             iommu: true,
             pci_segment: 1,
-            fds: None,
-            id: None,
-            tap: None,
-            vhost_socket: None,
             ..Default::default()
         }]);
         assert!(still_valid_config.validate().is_ok());
@@ -3073,10 +3024,6 @@ mod tests {
         invalid_config.net = Some(vec![NetConfig {
             iommu: false,
             pci_segment: 1,
-            fds: None,
-            id: None,
-            tap: None,
-            vhost_socket: None,
             ..Default::default()
         }]);
         assert_eq!(

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1154,11 +1154,6 @@ impl Drop for NetConfig {
     fn drop(&mut self) {
         if let Some(mut fds) = self.fds.take() {
             for fd in fds.drain(..) {
-                // Skip reserved FDs
-                if fd <= 2 {
-                    continue;
-                }
-
                 // SAFETY: Safe as the fd was given to the config by the API
                 unsafe { libc::close(fd) };
             }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2168,6 +2168,8 @@ impl Drop for VmConfig {
 mod tests {
     use super::*;
     use net_util::MacAddr;
+    use std::fs::File;
+    use std::os::unix::io::AsRawFd;
 
     #[test]
     fn test_cpu_parsing() -> Result<()> {
@@ -3184,7 +3186,7 @@ mod tests {
         ]);
         assert!(still_valid_config.validate().is_ok());
 
-        let mut invalid_config = valid_config;
+        let mut invalid_config = valid_config.clone();
         invalid_config.devices = Some(vec![
             DeviceConfig {
                 path: "/device1".into(),
@@ -3196,5 +3198,16 @@ mod tests {
             },
         ]);
         assert!(invalid_config.validate().is_err());
+
+        let mut still_valid_config = valid_config;
+        // SAFETY: Safe as the file was just opened
+        let fd1 = unsafe { libc::dup(File::open("/dev/null").unwrap().as_raw_fd()) };
+        // SAFETY: Safe as the file was just opened
+        let fd2 = unsafe { libc::dup(File::open("/dev/null").unwrap().as_raw_fd()) };
+        // SAFETY: safe as both FDs are valid
+        unsafe {
+            still_valid_config.add_preserved_fds(vec![fd1, fd2]);
+        }
+        let _still_valid_config = still_valid_config.clone();
     }
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2093,9 +2093,25 @@ impl VmConfig {
             gdb,
             platform,
             tpm,
+            preserved_fds: None,
         };
         config.validate().map_err(Error::Validation)?;
         Ok(config)
+    }
+
+    /// # Safety
+    /// To use this safely, the caller must guarantee that the input
+    /// fds are all valid.
+    pub unsafe fn add_preserved_fds(&mut self, mut fds: Vec<i32>) {
+        if fds.is_empty() {
+            return;
+        }
+
+        if let Some(preserved_fds) = &self.preserved_fds {
+            fds.append(&mut preserved_fds.clone());
+        }
+
+        self.preserved_fds = Some(fds);
     }
 
     #[cfg(feature = "tdx")]
@@ -2714,6 +2730,7 @@ mod tests {
             gdb: false,
             platform: None,
             tpm: None,
+            preserved_fds: None,
         };
 
         assert!(valid_config.validate().is_ok());

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2388,26 +2388,31 @@ impl DeviceManager {
                     .map_err(DeviceManagerError::CreateVirtioNet)?,
                 ))
             } else if let Some(fds) = &net_cfg.fds {
-                Arc::new(Mutex::new(
-                    virtio_devices::Net::from_tap_fds(
-                        id.clone(),
-                        fds,
-                        Some(net_cfg.mac),
-                        net_cfg.mtu,
-                        self.force_iommu | net_cfg.iommu,
-                        net_cfg.queue_size,
-                        self.seccomp_action.clone(),
-                        net_cfg.rate_limiter_config,
-                        self.exit_evt
-                            .try_clone()
-                            .map_err(DeviceManagerError::EventFd)?,
-                        state,
-                        net_cfg.offload_tso,
-                        net_cfg.offload_ufo,
-                        net_cfg.offload_csum,
-                    )
-                    .map_err(DeviceManagerError::CreateVirtioNet)?,
-                ))
+                let net = virtio_devices::Net::from_tap_fds(
+                    id.clone(),
+                    fds,
+                    Some(net_cfg.mac),
+                    net_cfg.mtu,
+                    self.force_iommu | net_cfg.iommu,
+                    net_cfg.queue_size,
+                    self.seccomp_action.clone(),
+                    net_cfg.rate_limiter_config,
+                    self.exit_evt
+                        .try_clone()
+                        .map_err(DeviceManagerError::EventFd)?,
+                    state,
+                    net_cfg.offload_tso,
+                    net_cfg.offload_ufo,
+                    net_cfg.offload_csum,
+                )
+                .map_err(DeviceManagerError::CreateVirtioNet)?;
+
+                // SAFETY: 'fds' are valid because TAP devices are created successfully
+                unsafe {
+                    self.config.lock().unwrap().add_preserved_fds(fds.clone());
+                }
+
+                Arc::new(Mutex::new(net))
             } else {
                 Arc::new(Mutex::new(
                     virtio_devices::Net::new(

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2152,6 +2152,7 @@ mod unit_tests {
             gdb: false,
             platform: None,
             tpm: None,
+            preserved_fds: None,
         }))
     }
 

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -596,4 +596,10 @@ pub struct VmConfig {
     pub gdb: bool,
     pub platform: Option<PlatformConfig>,
     pub tpm: Option<TpmConfig>,
+    // Preseved FDs are the ones that share the same life-time as its holding
+    // VmConfig instance, such as FDs for creating TAP devices.
+    // Perserved FDs will stay open as long as the holding VmConfig instance is
+    // valid, and will be closed when the holding VmConfig instance is destroyed.
+    #[serde(skip)]
+    pub preserved_fds: Option<Vec<i32>>,
 }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -563,7 +563,7 @@ pub struct TpmConfig {
     pub socket: PathBuf,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct VmConfig {
     #[serde(default)]
     pub cpus: CpusConfig,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -183,7 +183,7 @@ impl Default for MemoryConfig {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub enum VhostMode {
     #[default]
     Client,
@@ -248,7 +248,7 @@ impl Default for DiskConfig {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct NetConfig {
     #[serde(default = "default_netconfig_tap")]
     pub tap: Option<String>,


### PR DESCRIPTION
Preserved FDs are the ones that share the same life-time as its holding
VmConfig instance, such as FDs for creating TAP devices.

Preserved FDs will stay open as long as the holding VmConfig instance is
valid, and will be closed when the holding VmConfig instance is destroyed.