### PR TITLE
misc: Remove unnecessary clippy directives

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -210,7 +210,6 @@ impl From<Error> for super::Error {
     }
 }
 
-#[allow(clippy::upper_case_acronyms)]
 #[derive(Copy, Clone, Debug)]
 pub enum CpuidReg {
     EAX,

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -26,7 +26,6 @@ pub const MTRR_MEM_TYPE_WB: u64 = 0x6;
 pub const NUM_IOAPIC_PINS: usize = 24;
 
 // X86 Exceptions
-#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Debug)]
 pub enum Exception {
     DE = 0,  // Divide Error

--- a/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -243,7 +243,6 @@ impl KvmGicV3Its {
     }
 
     /// Method to initialize the GIC device
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(vm: &dyn Vm, config: VgicConfig) -> Result<KvmGicV3Its> {
         // This is inside KVM module
         let vm = vm.as_any().downcast_ref::<KvmVm>().expect("Wrong VM type?");

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -436,7 +436,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_tx_packet_assembly() {
         // Test case: successful TX packet assembly.
         {
@@ -581,7 +580,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn test_packet_hdr_accessors() {
         const SRC_CID: u64 = 1;
         const DST_CID: u64 = 2;

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -232,7 +232,6 @@ pub enum ApiResponsePayload {
 /// This is the response sent by the VMM API server through the mpsc channel.
 pub type ApiResponse = std::result::Result<ApiResponsePayload, ApiError>;
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum ApiRequest {
     /// Create the virtual machine. This request payload is a VM configuration

--- a/vmm/src/gdb.rs
+++ b/vmm/src/gdb.rs
@@ -435,7 +435,6 @@ impl run_blocking::BlockingEventLoop for GdbEventLoop {
     type Connection = Box<dyn ConnectionExt<Error = std::io::Error>>;
     type StopReason = MultiThreadStopReason<ArchUsize>;
 
-    #[allow(clippy::type_complexity)]
     fn wait_for_stop_reason(
         target: &mut Self::Target,
         conn: &mut Self::Connection,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -82,7 +82,6 @@ type GuestRegionMmap = vm_memory::GuestRegionMmap<AtomicBitmap>;
 
 /// Errors associated with VMM management
 #[derive(Debug, Error)]
-#[allow(clippy::large_enum_variant)]
 pub enum Error {
     /// API request receive error
     #[error("Error receiving API request: {0}")]


### PR DESCRIPTION
As the code has evolved these clippy overrides are no longer needed.

See #4986