### PR TITLE
Speed up restore by mmap memory-ranges with MAP_PRIVATE

### DIFF
--- a/fuzz/fuzz_targets/mem.rs
+++ b/fuzz/fuzz_targets/mem.rs
@@ -137,6 +137,8 @@ fn create_dummy_virtio_mem(bytes: &[u8; VIRTIO_MEM_DATA_SIZE]) -> (Mem, Arc<Gues
         None,
         numa_id,
         None,
+        None,
+        0,
         false,
     )
     .unwrap();

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1125,6 +1125,8 @@ components:
           type: string
         prefault:
           type: boolean
+        mmap_file:
+          type: boolean
 
     ReceiveMigrationData:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1649,6 +1649,8 @@ pub struct RestoreConfig {
     pub source_url: PathBuf,
     #[serde(default)]
     pub prefault: bool,
+    #[serde(default)]
+    pub mmap_file: bool,
 }
 
 impl RestoreConfig {
@@ -1666,10 +1668,16 @@ impl RestoreConfig {
             .map_err(Error::ParseRestore)?
             .unwrap_or(Toggle(false))
             .0;
+        let mmap_file = parser
+            .convert::<Toggle>("mmap_file")
+            .map_err(Error::ParseRestore)?
+            .unwrap_or(Toggle(false))
+            .0;
 
         Ok(RestoreConfig {
             source_url,
             prefault,
+            mmap_file,
         })
     }
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -741,6 +741,22 @@ impl MemoryConfig {
 
         size
     }
+
+    pub fn backed_by_private_memory(&self) -> bool {
+        if self.shared {
+            return false;
+        }
+
+        if let Some(zones) = &self.zones {
+            for zone in zones.iter() {
+                if zone.shared {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
 }
 
 impl DiskConfig {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1223,6 +1223,7 @@ impl Vmm {
             false,
             Some(&vm_migration_config.memory_manager_data),
             existing_memory_files,
+            None,
             #[cfg(target_arch = "x86_64")]
             None,
         )

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -602,6 +602,7 @@ impl Vmm {
                         None,
                         None,
                         None,
+                        None,
                     )?;
 
                     self.vm = Some(vm);
@@ -701,6 +702,7 @@ impl Vmm {
             Some(snapshot),
             Some(source_url),
             Some(restore_cfg.prefault),
+            Some(restore_cfg.mmap_file),
         )?;
         self.vm = Some(vm);
 
@@ -779,6 +781,7 @@ impl Vmm {
             console_pty,
             console_resize_pipe,
             Arc::clone(&self.on_tty),
+            None,
             None,
             None,
             None,

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1191,13 +1191,15 @@ impl MemoryManager {
         config: &MemoryConfig,
         source_url: Option<&str>,
         prefault: bool,
+        mmap_file: bool,
         phys_bits: u8,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
         if let Some(source_url) = source_url {
             let mut memory_file_path = url_to_path(source_url).map_err(Error::Restore)?;
             memory_file_path.push(String::from(SNAPSHOT_FILENAME));
 
-            let (mmap_memory_file, memory_file) = if config.backed_by_private_memory() {
+            let (mmap_memory_file, memory_file) = if mmap_file && config.backed_by_private_memory()
+            {
                 info!("restore non-shared map, speed up restore base map memory file");
                 (
                     true,

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -321,6 +321,9 @@ pub enum Error {
     // Error copying snapshot into region
     SnapshotCopy(GuestMemoryError),
 
+    // Error dup snapshot file.
+    SnapshotDup(io::Error),
+
     /// Failed to allocate MMIO address
     AllocateMmioAddress,
 
@@ -503,6 +506,8 @@ impl MemoryManager {
                     zone.hugepage_size,
                     zone.host_numa_node,
                     None,
+                    None,
+                    0,
                     thp,
                 )?;
 
@@ -553,9 +558,11 @@ impl MemoryManager {
     // Restore both GuestMemory regions along with MemoryZone zones.
     fn restore_memory_regions_and_zones(
         guest_ram_mappings: &[GuestRamMapping],
+        saved_regions: &MemoryRangeTable,
         zones_config: &[MemoryZoneConfig],
         prefault: Option<bool>,
         mut existing_memory_files: HashMap<u32, File>,
+        saved_file: Option<File>,
         thp: bool,
     ) -> Result<(Vec<Arc<GuestRegionMmap>>, MemoryZones), Error> {
         let mut memory_regions = Vec::new();
@@ -568,6 +575,19 @@ impl MemoryManager {
         for guest_ram_mapping in guest_ram_mappings {
             for zone_config in zones_config {
                 if guest_ram_mapping.zone_id == zone_config.id {
+                    let mut file = None;
+                    let mut offset = 0;
+                    if let Some(ref f) = saved_file {
+                        for range in saved_regions.regions() {
+                            if guest_ram_mapping.gpa == range.gpa
+                                && guest_ram_mapping.size == range.length
+                            {
+                                file = Some(f.try_clone().map_err(Error::SnapshotDup)?);
+                                break;
+                            }
+                            offset += range.length;
+                        }
+                    }
                     let region = MemoryManager::create_ram_region(
                         &zone_config.file,
                         guest_ram_mapping.file_offset,
@@ -582,6 +602,8 @@ impl MemoryManager {
                         zone_config.hugepage_size,
                         zone_config.host_numa_node,
                         existing_memory_files.remove(&guest_ram_mapping.slot),
+                        file,
+                        offset,
                         thp,
                     )?;
                     memory_regions.push(Arc::clone(&region));
@@ -883,6 +905,7 @@ impl MemoryManager {
         #[cfg(feature = "tdx")] tdx_enabled: bool,
         restore_data: Option<&MemoryManagerSnapshotData>,
         existing_memory_files: Option<HashMap<u32, File>>,
+        snap_file: Option<File>,
         #[cfg(target_arch = "x86_64")] sgx_epc_config: Option<Vec<SgxEpcConfig>>,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
         trace_scoped!("MemoryManager::new");
@@ -916,9 +939,11 @@ impl MemoryManager {
         ) = if let Some(data) = restore_data {
             let (regions, memory_zones) = Self::restore_memory_regions_and_zones(
                 &data.guest_ram_mappings,
+                &data.memory_ranges,
                 &zones,
                 prefault,
                 existing_memory_files.unwrap_or_default(),
+                snap_file,
                 config.thp,
             )?;
             let guest_memory =
@@ -1006,6 +1031,8 @@ impl MemoryManager {
                                 zone.hugepage_size,
                                 zone.host_numa_node,
                                 None,
+                                None,
+                                0,
                                 config.thp,
                             )?;
 
@@ -1170,6 +1197,21 @@ impl MemoryManager {
             let mut memory_file_path = url_to_path(source_url).map_err(Error::Restore)?;
             memory_file_path.push(String::from(SNAPSHOT_FILENAME));
 
+            let (mmap_memory_file, memory_file) = if config.backed_by_private_memory() {
+                info!("restore non-shared map, speed up restore base map memory file");
+                (
+                    true,
+                    Some(
+                        OpenOptions::new()
+                            .read(true)
+                            .open(memory_file_path.clone())
+                            .map_err(Error::SnapshotOpen)?,
+                    ),
+                )
+            } else {
+                (false, None)
+            };
+
             let mem_snapshot: MemoryManagerSnapshotData =
                 snapshot.to_versioned_state().map_err(Error::Restore)?;
 
@@ -1182,13 +1224,16 @@ impl MemoryManager {
                 false,
                 Some(&mem_snapshot),
                 None,
+                memory_file,
                 #[cfg(target_arch = "x86_64")]
                 None,
             )?;
 
-            mm.lock()
-                .unwrap()
-                .fill_saved_regions(memory_file_path, mem_snapshot.memory_ranges)?;
+            if !mmap_memory_file {
+                mm.lock()
+                    .unwrap()
+                    .fill_saved_regions(memory_file_path, mem_snapshot.memory_ranges)?;
+            }
 
             Ok(mm)
         } else {
@@ -1300,13 +1345,18 @@ impl MemoryManager {
         hugepage_size: Option<u64>,
         host_numa_node: Option<u32>,
         existing_memory_file: Option<File>,
+        snap_file: Option<File>,
+        snap_offset: u64,
         thp: bool,
     ) -> Result<Arc<GuestRegionMmap>, Error> {
         let mut mmap_flags = libc::MAP_NORESERVE;
 
         // The duplication of mmap_flags ORing here is unfortunate but it also makes
         // the complexity of the handling clear.
-        let fo = if let Some(f) = existing_memory_file {
+        let fo = if let Some(f) = snap_file {
+            mmap_flags |= libc::MAP_PRIVATE;
+            Some(FileOffset::new(f, snap_offset))
+        } else if let Some(f) = existing_memory_file {
             // It must be MAP_SHARED as we wouldn't already have an FD
             mmap_flags |= libc::MAP_SHARED;
             Some(FileOffset::new(f, file_offset))
@@ -1442,6 +1492,8 @@ impl MemoryManager {
             self.hugepage_size,
             None,
             None,
+            None,
+            0,
             self.thp,
         )?;
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -785,6 +785,7 @@ impl Vm {
                 tdx_enabled,
                 None,
                 None,
+                None,
                 #[cfg(target_arch = "x86_64")]
                 sgx_epc_config,
             )

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -740,6 +740,7 @@ impl Vm {
         snapshot: Option<Snapshot>,
         source_url: Option<&str>,
         prefault: Option<bool>,
+        mmap_file: Option<bool>,
     ) -> Result<Self> {
         trace_scoped!("Vm::new");
 
@@ -769,6 +770,7 @@ impl Vm {
                 &vm_config.lock().unwrap().memory.clone(),
                 source_url,
                 prefault.unwrap(),
+                mmap_file.unwrap(),
                 phys_bits,
             )
             .map_err(Error::MemoryManager)?


### PR DESCRIPTION
Now cloud hypervisor save all guest memory into file <memory-ranges>, then fill guest memory with file <memroy-ranges> in restore. Current restore implementation is time costing, in my environment restore 512 MB memory will need 160ms+.

This PR introduce an optimize method, restore guest memory base mmap of memory-ranges file with MAP_PRIVATE, like COW in fork system call, VMs restored from same SNAP will share the memory-ranges for read access to guest memory, and lazy page allocation base COW in write access to guest memory.

The optimization does not support VM guest memory configured as shared mapping, such as vhost environment.