### PR TITLE
vmm: allow getdents64 in seccomp filter

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -523,6 +523,7 @@ fn vmm_thread_rules(
         #[cfg(target_arch = "aarch64")]
         (libc::SYS_newfstatat, vec![]),
         (libc::SYS_futex, vec![]),
+        (libc::SYS_getdents64, vec![]),
         (libc::SYS_getpgid, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_getpgrp, vec![]),


### PR DESCRIPTION
This is used on older kernels where close_range() is not available.

So far I've only checked glibc x86_64.  It's possible we'll need to allow additional syscalls for aarch64/musl.

Fixes #5389.