### PR TITLE
tests: Remove "initial apicid" check from test_simple_launch

### DIFF
--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -868,14 +868,6 @@ impl Guest {
             .map_err(Error::Parsing)
     }
 
-    #[cfg(target_arch = "x86_64")]
-    pub fn get_initial_apicid(&self) -> Result<u32, Error> {
-        self.ssh_command("grep \"initial apicid\" /proc/cpuinfo | grep -o \"[0-9]*\"")?
-            .trim()
-            .parse()
-            .map_err(Error::Parsing)
-    }
-
     pub fn get_total_memory(&self) -> Result<u32, Error> {
         self.ssh_command("grep MemTotal /proc/meminfo | grep -o \"[0-9]*\"")?
             .trim()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1942,7 +1942,6 @@ mod common_parallel {
             guest.wait_vm_boot(Some(120)).unwrap();
 
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), 1);
-            assert_eq!(guest.get_initial_apicid().unwrap_or(1), 0);
             assert!(guest.get_total_memory().unwrap_or_default() > 480_000);
             assert_eq!(guest.get_pci_bridge_class().unwrap_or_default(), "0x060000");
 


### PR DESCRIPTION
This fixes the following tests that have been consistently failing on
the CI:

[2023-04-22T07:00:53.760Z] failures:
[2023-04-22T07:00:53.760Z]     common_parallel::test_focal_hypervisor_fw
[2023-04-22T07:00:53.760Z]     common_parallel::test_focal_ovmf

I'm not sure of the origin of this check but it obviously dependent on
the underlying platform as the guest OS has not changed. Since it
depends on the host environment it doesn't make sense to assert for it.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
