### PR TITLE
Add ratelimit counter for virtio device

### DIFF
--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -849,12 +849,28 @@ impl VirtioDevice for Net {
             Wrapping(self.counters.rx_frames.load(Ordering::Acquire)),
         );
         counters.insert(
+            "rx_limit_bytes",
+            Wrapping(self.counters.rx_limit_bytes.load(Ordering::Acquire)),
+        );
+        counters.insert(
+            "rx_limit_frames",
+            Wrapping(self.counters.rx_limit_frames.load(Ordering::Acquire)),
+        );
+        counters.insert(
             "tx_bytes",
             Wrapping(self.counters.tx_bytes.load(Ordering::Acquire)),
         );
         counters.insert(
             "tx_frames",
             Wrapping(self.counters.tx_frames.load(Ordering::Acquire)),
+        );
+        counters.insert(
+            "tx_limit_bytes",
+            Wrapping(self.counters.tx_limit_bytes.load(Ordering::Acquire)),
+        );
+        counters.insert(
+            "tx_limit_frames",
+            Wrapping(self.counters.tx_limit_frames.load(Ordering::Acquire)),
         );
 
         Some(counters)


### PR DESCRIPTION
Now cloud hypervisor support rate limit for virtio block device IO and virtio net device TX/RX, but no counter or log when block IO / net IO exceeds the rate limit, this patch adds counter for the rate limit events, so that we could track when and how many times block IO / net IO exceeds limit, then we may adjust the rate limit configurations.