### PR TITLE
Bump acpi_tables version to fix unaligned write panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acpi_tables"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#0b892e2c2053c4ecfac8d9e5a52babae75114702"
+source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#98dcb0309d362dd83f6ffcac4f66914a2fbd5a73"
 dependencies = [
  "zerocopy",
 ]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acpi_tables"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#0b892e2c2053c4ecfac8d9e5a52babae75114702"
+source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#98dcb0309d362dd83f6ffcac4f66914a2fbd5a73"
 dependencies = [
  "zerocopy",
 ]

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -239,7 +239,7 @@ fn create_facp_table(dsdt_offset: GuestAddress, device_manager: &Arc<Mutex<Devic
     // X_DSDT
     facp.write(140, dsdt_offset.0);
     // Hypervisor Vendor Identity
-    facp.write(268, b"CLOUDHYP");
+    facp.write_bytes(268, b"CLOUDHYP");
 
     facp.update_checksum();
 

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -41,7 +41,7 @@ pub const ACPI_APIC_GENERIC_TRANSLATOR: u8 = 15;
 
 #[allow(dead_code)]
 #[repr(packed)]
-#[derive(Default)]
+#[derive(Default, AsBytes)]
 struct PciRangeEntry {
     pub base_address: u64,
     pub segment: u16,
@@ -52,7 +52,7 @@ struct PciRangeEntry {
 
 #[allow(dead_code)]
 #[repr(packed)]
-#[derive(Default)]
+#[derive(Default, AsBytes)]
 struct MemoryAffinity {
     pub type_: u8,
     pub length: u8,
@@ -69,7 +69,7 @@ struct MemoryAffinity {
 
 #[allow(dead_code)]
 #[repr(packed)]
-#[derive(Default)]
+#[derive(Default, AsBytes)]
 struct ProcessorLocalX2ApicAffinity {
     pub type_: u8,
     pub length: u8,
@@ -83,7 +83,7 @@ struct ProcessorLocalX2ApicAffinity {
 
 #[allow(dead_code)]
 #[repr(packed)]
-#[derive(Default)]
+#[derive(Default, AsBytes)]
 struct ProcessorGiccAffinity {
     pub type_: u8,
     pub length: u8,
@@ -143,7 +143,7 @@ impl MemoryAffinity {
 
 #[allow(dead_code)]
 #[repr(packed)]
-#[derive(Default)]
+#[derive(Default, AsBytes)]
 struct ViotVirtioPciNode {
     pub type_: u8,
     _reserved: u8,
@@ -155,7 +155,7 @@ struct ViotVirtioPciNode {
 
 #[allow(dead_code)]
 #[repr(packed)]
-#[derive(Default)]
+#[derive(Default, AsBytes)]
 struct ViotPciRangeNode {
     pub type_: u8,
     _reserved: u8,

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -84,6 +84,7 @@ use vm_migration::{
 };
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::{register_signal_handler, SIGRTMIN};
+use zerocopy::AsBytes;
 
 #[cfg(all(target_arch = "aarch64", feature = "guest_debug"))]
 /// Extract the specified bits of a 64-bit integer.
@@ -176,6 +177,7 @@ pub type Result<T> = result::Result<T, Error>;
 #[cfg(target_arch = "x86_64")]
 #[allow(dead_code)]
 #[repr(packed)]
+#[derive(AsBytes)]
 struct LocalApic {
     pub r#type: u8,
     pub length: u8,
@@ -186,7 +188,7 @@ struct LocalApic {
 
 #[allow(dead_code)]
 #[repr(packed)]
-#[derive(Default)]
+#[derive(Default, AsBytes)]
 struct Ioapic {
     pub r#type: u8,
     pub length: u8,
@@ -199,6 +201,7 @@ struct Ioapic {
 #[cfg(target_arch = "aarch64")]
 #[allow(dead_code)]
 #[repr(packed)]
+#[derive(AsBytes)]
 struct GicC {
     pub r#type: u8,
     pub length: u8,
@@ -223,6 +226,7 @@ struct GicC {
 #[cfg(target_arch = "aarch64")]
 #[allow(dead_code)]
 #[repr(packed)]
+#[derive(AsBytes)]
 struct GicD {
     pub r#type: u8,
     pub length: u8,
@@ -237,6 +241,7 @@ struct GicD {
 #[cfg(target_arch = "aarch64")]
 #[allow(dead_code)]
 #[repr(packed)]
+#[derive(AsBytes)]
 struct GicR {
     pub r#type: u8,
     pub length: u8,
@@ -248,6 +253,7 @@ struct GicR {
 #[cfg(target_arch = "aarch64")]
 #[allow(dead_code)]
 #[repr(packed)]
+#[derive(AsBytes)]
 struct GicIts {
     pub r#type: u8,
     pub length: u8,
@@ -260,6 +266,7 @@ struct GicIts {
 #[cfg(target_arch = "aarch64")]
 #[allow(dead_code)]
 #[repr(packed)]
+#[derive(AsBytes)]
 struct ProcessorHierarchyNode {
     pub r#type: u8,
     pub length: u8,
@@ -272,7 +279,7 @@ struct ProcessorHierarchyNode {
 
 #[allow(dead_code)]
 #[repr(packed)]
-#[derive(Default)]
+#[derive(Default, AsBytes)]
 struct InterruptSourceOverride {
     pub r#type: u8,
     pub length: u8,

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1274,7 +1274,7 @@ impl CpuManager {
         let mut madt = Sdt::new(*b"APIC", 44, 5, *b"CLOUDH", *b"CHMADT  ", 1);
         #[cfg(target_arch = "x86_64")]
         {
-            madt.write(36, arch::layout::APIC_START);
+            madt.write(36, arch::layout::APIC_START.0);
 
             for cpu in 0..self.config.max_vcpus {
                 let lapic = LocalApic {


### PR DESCRIPTION
- vmm: Implemented zerocopy::AsBytes for SDT structures
- vmm: Update for new acpi_tables version
