### PR TITLE
TTY reset fixes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ extern crate event_monitor;
 
 use argh::FromArgs;
 use libc::EFD_NONBLOCK;
-use log::LevelFilter;
+use log::{warn, LevelFilter};
 use option_parser::OptionParser;
 use seccompiler::SeccompAction;
 use signal_hook::consts::SIGSYS;
@@ -33,6 +33,8 @@ enum Error {
     #[cfg(feature = "guest_debug")]
     #[error("Failed to create Debug EventFd: {0}")]
     CreateDebugEventFd(#[source] std::io::Error),
+    #[error("Failed to create exit EventFd: {0}")]
+    CreateExitEventFd(#[source] std::io::Error),
     #[error("Failed to open hypervisor interface (is hypervisor interface available?): {0}")]
     CreateHypervisor(#[source] hypervisor::HypervisorError),
     #[error("Failed to start the VMM thread: {0}")]
@@ -509,6 +511,8 @@ fn start_vmm(toplevel: TopLevel) -> Result<Option<String>, Error> {
     #[cfg(feature = "guest_debug")]
     let vm_debug_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::CreateDebugEventFd)?;
 
+    let exit_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::CreateExitEventFd)?;
+
     let vmm_thread = vmm::start_vmm_thread(
         vmm::VmmVersionInfo::new(env!("BUILD_VERSION"), env!("CARGO_PKG_VERSION")),
         &api_socket_path,
@@ -522,33 +526,46 @@ fn start_vmm(toplevel: TopLevel) -> Result<Option<String>, Error> {
         debug_evt.try_clone().unwrap(),
         #[cfg(feature = "guest_debug")]
         vm_debug_evt.try_clone().unwrap(),
+        exit_evt.try_clone().unwrap(),
         &seccomp_action,
         hypervisor,
     )
     .map_err(Error::StartVmmThread)?;
 
-    let payload_present = toplevel.kernel.is_some() || toplevel.firmware.is_some();
+    let r: Result<(), Error> = (|| {
+        let payload_present = toplevel.kernel.is_some() || toplevel.firmware.is_some();
 
-    if payload_present {
-        let vm_params = toplevel.to_vm_params();
-        let vm_config = config::VmConfig::parse(vm_params).map_err(Error::ParsingConfig)?;
+        if payload_present {
+            let vm_params = toplevel.to_vm_params();
+            let vm_config = config::VmConfig::parse(vm_params).map_err(Error::ParsingConfig)?;
 
-        // Create and boot the VM based off the VM config we just built.
-        let sender = api_request_sender.clone();
-        vmm::api::vm_create(
-            api_evt.try_clone().unwrap(),
-            api_request_sender,
-            Arc::new(Mutex::new(vm_config)),
-        )
-        .map_err(Error::VmCreate)?;
-        vmm::api::vm_boot(api_evt.try_clone().unwrap(), sender).map_err(Error::VmBoot)?;
-    } else if let Some(restore_params) = toplevel.restore {
-        vmm::api::vm_restore(
-            api_evt.try_clone().unwrap(),
-            api_request_sender,
-            Arc::new(config::RestoreConfig::parse(&restore_params).map_err(Error::ParsingRestore)?),
-        )
-        .map_err(Error::VmRestore)?;
+            // Create and boot the VM based off the VM config we just built.
+            let sender = api_request_sender.clone();
+            vmm::api::vm_create(
+                api_evt.try_clone().unwrap(),
+                api_request_sender,
+                Arc::new(Mutex::new(vm_config)),
+            )
+            .map_err(Error::VmCreate)?;
+            vmm::api::vm_boot(api_evt.try_clone().unwrap(), sender).map_err(Error::VmBoot)?;
+        } else if let Some(restore_params) = toplevel.restore {
+            vmm::api::vm_restore(
+                api_evt.try_clone().unwrap(),
+                api_request_sender,
+                Arc::new(
+                    config::RestoreConfig::parse(&restore_params).map_err(Error::ParsingRestore)?,
+                ),
+            )
+            .map_err(Error::VmRestore)?;
+        }
+
+        Ok(())
+    })();
+
+    if r.is_err() {
+        if let Err(e) = exit_evt.write(1) {
+            warn!("writing to exit EventFd: {e}");
+        }
     }
 
     vmm_thread

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -314,10 +314,10 @@ impl VmState {
     fn valid_transition(self, new_state: VmState) -> Result<()> {
         match self {
             VmState::Created => match new_state {
-                VmState::Created | VmState::Shutdown => {
-                    Err(Error::InvalidStateTransition(self, new_state))
+                VmState::Created => Err(Error::InvalidStateTransition(self, new_state)),
+                VmState::Running | VmState::Paused | VmState::BreakPoint | VmState::Shutdown => {
+                    Ok(())
                 }
-                VmState::Running | VmState::Paused | VmState::BreakPoint => Ok(()),
             },
 
             VmState::Running => match new_state {
@@ -2694,7 +2694,7 @@ mod tests {
                 // Check the transitions from Created
                 assert!(state.valid_transition(VmState::Created).is_err());
                 assert!(state.valid_transition(VmState::Running).is_ok());
-                assert!(state.valid_transition(VmState::Shutdown).is_err());
+                assert!(state.valid_transition(VmState::Shutdown).is_ok());
                 assert!(state.valid_transition(VmState::Paused).is_ok());
                 assert!(state.valid_transition(VmState::BreakPoint).is_ok());
             }


### PR DESCRIPTION
I discovered a couple of cases where https://github.com/cloud-hypervisor/cloud-hypervisor/pull/5343 was not doing quite the right thing:

- The OPOST flag was being set but not unset.
- If an error happened in `start_vmm` after starting the vmm thread, the tty was not reset.

More details are in the commit messages.

Getting TTY handling right is really hard, but I think we're gradually converging towards getting it right in all circumstances.