### PR TITLE
build: Bulk update rust-vmm dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vm-fdt",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -152,9 +152,9 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vhdx",
- "virtio-bindings 0.2.0",
+ "virtio-bindings",
  "virtio-queue",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -201,7 +201,7 @@ dependencies = [
  "thiserror",
  "tpm",
  "tracer",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vmm",
  "vmm-sys-util",
  "wait-timeout",
@@ -274,7 +274,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vm-device",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -457,7 +457,7 @@ dependencies = [
  "serde_with",
  "thiserror",
  "vfio-ioctls",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -593,11 +593,11 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9259ddbfbb52cc918f6bbc60390004ddd0228cf1d85f402009ff2b3d95de83f"
+checksum = "8d3adb7b28e189741eca3b1a4a27de0bf15e0907c9d4b0c74bd2d7d84ef72e08"
 dependencies = [
- "vm-memory 0.10.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -712,9 +712,9 @@ dependencies = [
  "thiserror",
  "versionize",
  "versionize_derive",
- "virtio-bindings 0.2.0",
+ "virtio-bindings",
  "virtio-queue",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -848,7 +848,7 @@ dependencies = [
  "vfio_user",
  "vm-allocator",
  "vm-device",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -1376,7 +1376,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#ea8f710464a24690ce109e6b7dfaa623dc518304"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#89f8e77dd1a2829197ecde65b686bafcc8a1def4"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -1387,7 +1387,7 @@ dependencies = [
  "mshv-ioctls",
  "thiserror",
  "vfio-bindings",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1404,7 +1404,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "vfio-bindings",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1423,28 +1423,28 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b791c5b0717a0558888a4cf7240cea836f39a99cb342e12ce633dcaa078072"
+checksum = "84f81f436bca4541f4d33172e1202882c9d437db34ed17fc6d84c8ff2bde21f5"
 dependencies = [
  "bitflags",
  "libc",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f237b91db4ac339d639fb43398b52d785fa51e3c7760ac9425148863c1f4303"
+checksum = "a5d3b7affe04f61d19b03c5db823287855789b687218fec139699a0c7f7f2790"
 dependencies = [
  "libc",
  "log",
  "vhost",
- "virtio-bindings 0.1.0",
+ "virtio-bindings",
  "virtio-queue",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1462,9 +1462,9 @@ dependencies = [
  "qcow",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings 0.2.0",
+ "virtio-bindings",
  "virtio-queue",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1481,16 +1481,10 @@ dependencies = [
  "option_parser",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings 0.2.0",
- "vm-memory 0.10.0",
+ "virtio-bindings",
+ "vm-memory",
  "vmm-sys-util",
 ]
-
-[[package]]
-name = "virtio-bindings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
 
 [[package]]
 name = "virtio-bindings"
@@ -1523,11 +1517,11 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vhost",
- "virtio-bindings 0.2.0",
+ "virtio-bindings",
  "virtio-queue",
  "vm-allocator",
  "vm-device",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
@@ -1535,13 +1529,13 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ba81e2bcc21c0d2fc5e6683e79367e26ad219197423a498df801d79d5ba77bd"
+checksum = "91aebb1df33db33cbf04d4c2445e4f78d0b0c8e65acfd16a4ee95ef63ca252f8"
 dependencies = [
  "log",
- "virtio-bindings 0.1.0",
- "vm-memory 0.10.0",
+ "virtio-bindings",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1551,7 +1545,7 @@ version = "0.1.0"
 dependencies = [
  "arch",
  "libc",
- "vm-memory 0.10.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -1563,7 +1557,7 @@ dependencies = [
  "serde",
  "thiserror",
  "vfio-ioctls",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1571,17 +1565,6 @@ dependencies = [
 name = "vm-fdt"
 version = "0.2.0"
 source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#ad21ede0ddb4cc97448eeb64c1dfc27803b9ec08"
-
-[[package]]
-name = "vm-memory"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688a70366615b45575a424d9c665561c1b5ab2224d494f706b6a6812911a827c"
-dependencies = [
- "arc-swap",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "vm-memory"
@@ -1604,7 +1587,7 @@ dependencies = [
  "thiserror",
  "versionize",
  "versionize_derive",
- "vm-memory 0.10.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -1613,7 +1596,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "virtio-queue",
- "vm-memory 0.10.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -1658,7 +1641,7 @@ dependencies = [
  "virtio-queue",
  "vm-allocator",
  "vm-device",
- "vm-memory 0.10.0",
+ "vm-memory",
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tpm = { path = "tpm"}
 tracer = { path = "tracer" }
 vmm = { path = "vmm" }
 vmm-sys-util = "0.11.0"
-vm-memory = "0.10.0"
+vm-memory = "0.11.0"
 
 # List of patched crates
 [patch.crates-io]

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -13,14 +13,14 @@ anyhow = "1.0.71"
 byteorder = "1.4.3"
 hypervisor = { path = "../hypervisor" }
 libc = "0.2.139"
-linux-loader = { version = "0.8.1", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.9.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.17"
 serde = { version = "1.0.156", features = ["rc", "derive"] }
 thiserror = "1.0.40"
 uuid = "1.3.3"
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { version = "0.11.0", features = ["with-serde"] }
 

--- a/block_util/Cargo.toml
+++ b/block_util/Cargo.toml
@@ -18,8 +18,8 @@ versionize = "0.1.10"
 versionize_derive = "0.1.4"
 vhdx = { path = "../vhdx" }
 virtio-bindings = { version = "0.2.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.7.1"
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.8.0"
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.11.0"
 

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -18,7 +18,7 @@ tpm = { path = "../tpm" }
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
 vm-device = { path = "../vm-device" }
-vm-memory = "0.10.0"
+vm-memory = "0.11.0"
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = "0.11.0"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vhdx",
- "virtio-bindings 0.2.0",
+ "virtio-bindings",
  "virtio-queue",
  "vm-memory",
  "vm-virtio",
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9259ddbfbb52cc918f6bbc60390004ddd0228cf1d85f402009ff2b3d95de83f"
+checksum = "8d3adb7b28e189741eca3b1a4a27de0bf15e0907c9d4b0c74bd2d7d84ef72e08"
 dependencies = [
  "vm-memory",
 ]
@@ -453,7 +453,7 @@ dependencies = [
  "thiserror",
  "versionize",
  "versionize_derive",
- "virtio-bindings 0.2.0",
+ "virtio-bindings",
  "virtio-queue",
  "vm-memory",
  "vm-virtio",
@@ -771,7 +771,7 @@ dependencies = [
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#43439e056ddfa84a4f7906ee7f2f58be70505c08"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#89f8e77dd1a2829197ecde65b686bafcc8a1def4"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -779,7 +779,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#43439e056ddfa84a4f7906ee7f2f58be70505c08"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#89f8e77dd1a2829197ecde65b686bafcc8a1def4"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -795,7 +795,7 @@ dependencies = [
 [[package]]
 name = "vfio_user"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio-user?branch=main#afbbd5722885e961ce12baea12efe01d52ce14b0"
+source = "git+https://github.com/rust-vmm/vfio-user?branch=main#eef6bec4d421f08ed1688fe67c5ea33aabbf5069"
 dependencies = [
  "bitflags",
  "libc",
@@ -824,21 +824,15 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b791c5b0717a0558888a4cf7240cea836f39a99cb342e12ce633dcaa078072"
+checksum = "84f81f436bca4541f4d33172e1202882c9d437db34ed17fc6d84c8ff2bde21f5"
 dependencies = [
  "bitflags",
  "libc",
  "vm-memory",
  "vmm-sys-util",
 ]
-
-[[package]]
-name = "virtio-bindings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
 
 [[package]]
 name = "virtio-bindings"
@@ -871,7 +865,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vhost",
- "virtio-bindings 0.2.0",
+ "virtio-bindings",
  "virtio-queue",
  "vm-allocator",
  "vm-device",
@@ -883,12 +877,12 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ba81e2bcc21c0d2fc5e6683e79367e26ad219197423a498df801d79d5ba77bd"
+checksum = "91aebb1df33db33cbf04d4c2445e4f78d0b0c8e65acfd16a4ee95ef63ca252f8"
 dependencies = [
  "log",
- "virtio-bindings 0.1.0",
+ "virtio-bindings",
  "vm-memory",
  "vmm-sys-util",
 ]
@@ -922,9 +916,9 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#c5a99ab71b130435927
 
 [[package]]
 name = "vm-memory"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688a70366615b45575a424d9c665561c1b5ab2224d494f706b6a6812911a827c"
+checksum = "9d6ea57fe00f9086c59eeeb68e102dd611686bc3c28520fa465996d4d4bdce07"
 dependencies = [
  "arc-swap",
  "libc",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,7 +14,7 @@ devices = { path = "../devices" }
 epoll = "4.3.1"
 libc = "0.2.144"
 libfuzzer-sys = "0.4.6"
-linux-loader = { version = "0.8.1", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.9.0", features = ["elf", "bzimage", "pe"] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 net_util = { path = "../net_util" }
 once_cell = "1.17.2"
@@ -22,10 +22,10 @@ qcow = { path = "../qcow" }
 seccompiler = "0.3.0"
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.7.1"
+virtio-queue = "0.8.0"
 vmm = { path = "../vmm" }
 vmm-sys-util = "0.11.1"
-vm-memory = "0.10.0"
+vm-memory = "0.11.0"
 vm-device = { path = "../vm-device" }
 vm-virtio = { path = "../vm-virtio" }
 

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -23,7 +23,7 @@ mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optio
 serde = { version = "1.0.156", features = ["rc", "derive"] }
 serde_with = { version = "2.3.2", default-features = false, features = ["macros"] }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = "0.11.0", features = ["with-serde"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -16,8 +16,8 @@ thiserror = "1.0.40"
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
 virtio-bindings = "0.2.0"
-virtio-queue = "0.7.1"
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.8.0"
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.11.0"
 

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -26,5 +26,5 @@ versionize = "0.1.10"
 versionize_derive = "0.1.4"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -14,10 +14,10 @@ libc = "0.2.139"
 log = "0.4.17"
 option_parser = { path = "../option_parser" }
 qcow = { path = "../qcow" }
-vhost = { version = "0.6.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.8.0"
+vhost = { version = "0.7.0", features = ["vhost-user-slave"] }
+vhost-user-backend = "0.9.0"
 virtio-bindings = "0.2.0"
-virtio-queue = "0.7.1"
-vm-memory = "0.10.0"
+virtio-queue = "0.8.0"
+vm-memory = "0.11.0"
 vmm-sys-util = "0.11.0"
 

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -13,9 +13,9 @@ libc = "0.2.139"
 log = "0.4.17"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
-vhost = { version = "0.6.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.8.0"
+vhost = { version = "0.7.0", features = ["vhost-user-slave"] }
+vhost-user-backend = "0.9.0"
 virtio-bindings = "0.2.0"
-vm-memory = "0.10.0"
+vm-memory = "0.11.0"
 vmm-sys-util = "0.11.0"
 

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -28,12 +28,12 @@ serial_buffer = { path = "../serial_buffer" }
 thiserror = "1.0.40"
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
-vhost = { version = "0.6.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern", "vhost-vdpa"] }
+vhost = { version = "0.7.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern", "vhost-vdpa"] }
 virtio-bindings = { version = "0.2.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.7.1"
+virtio-queue = "0.8.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.11.0"

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.139"
-vm-memory = "0.10.0"
+vm-memory = "0.11.0"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 arch = { path = "../arch" }

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -15,6 +15,6 @@ hypervisor = { path = "../hypervisor" }
 thiserror = "1.0.40"
 serde = { version = "1.0.156", features = ["rc", "derive"] }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vm-memory = { version = "0.10.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap"] }
 vmm-sys-util = "0.11.0"
 

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -11,4 +11,4 @@ serde = { version = "1.0.156", features = ["rc", "derive"] }
 serde_json = "1.0.96"
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -9,5 +9,5 @@ default = []
 
 [dependencies]
 log = "0.4.17"
-virtio-queue = "0.7.1"
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.8.0"
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -26,7 +26,7 @@ gdbstub = { version = "0.6.4", optional = true }
 gdbstub_arch = { version = "0.2.4", optional = true }
 hypervisor = { path = "../hypervisor" }
 libc = "0.2.139"
-linux-loader = { version = "0.8.1", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.9.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.17"
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 net_util = { path = "../net_util" }
@@ -48,10 +48,10 @@ vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", defau
 vfio_user = { git = "https://github.com/rust-vmm/vfio-user", branch = "main" }
 vhdx = { path = "../vhdx" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.7.1"
+virtio-queue = "0.8.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { version = "0.11.0", features = ["with-serde"] }


### PR DESCRIPTION
Bump to the latest rust-vmm crates, including vm-memory, vfio,
vfio-bindings, vfio-user, virtio-bindings, virtio-queue, linux-loader,
vhost, and vhost-user-backend,

Signed-off-by: Bo Chen <chen.bo@intel.com>