### PR TITLE
Add parameters to fix the stuck problem of ovs-vsctl.

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -350,7 +350,7 @@ fn setup_ovs_dpdk() {
     assert!(exec_host_command_status("service openvswitch-switch start").success());
     assert!(exec_host_command_status("ovs-vsctl init").success());
     assert!(
-        exec_host_command_status("ovs-vsctl set Open_vSwitch . other_config:dpdk-init=true")
+        exec_host_command_status("ovs-vsctl set Open_vSwitch . other_config:dpdk-init=true other_config:dpdk-socket-mem=1024")
             .success()
     );
     assert!(exec_host_command_status("service openvswitch-switch restart").success());


### PR DESCRIPTION
The following command gets stuck while testing test_ovs_dpdk: 
```
"ovs-vsctl set Open_vSwitch . other_config:dpdk-init=true" /var/log/openvswitch/ovs-vswitchd.log shows:
dpdk(ovs-vswitchd)|INFO|EAL ARGS:ovs-vswitchd --socket-mem 1024,1024,1024,1024,1024,1024,1024,1024 --socket-limit 1024,1024,1024,1024,1024,1024,1024,1024 -l 0. 
dpdk(ovs-vswitchd)|ERR|EAL: invalid parameters for --socket-mem 
dpdk(ovs-vswitchd)|ERR|EAL: Invalid 'command line' arguments. 
dpdk(ovs-vswitchd)|EMER|Unable to initialize DPDK: Invalid argument
```
The version of ovs-vsctl in the docker image of ubuntu20.04 is 2.13.8

The ovs-vsctl 2.17.5 version on ubuntu22.04 does not have this problem.

Comma for --socket-mem separated list of memory to pre-allocate from hugepages on specific sockets. If not specified, this option will not be set by default. DPDK default will be used instead. 

If allocating more than one GB hugepage, we can configure the amount of memory used from any given NUMA nodes. For example, to use 1GB from NUMA node 0 and 0GB for all other NUMA nodes

Incidentally, changing the ANC mode from `Quadrant` to `Monolithic` in the Ampera Altra's BIOS also fixed the issue.