### PR TITLE
add memory bind policy

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -649,7 +649,8 @@ impl MemoryConfig {
                     .add("host_numa_node")
                     .add("hotplug_size")
                     .add("hotplugged_size")
-                    .add("prefault");
+                    .add("prefault")
+                    .add("policy");
                 parser.parse(memory_zone).map_err(Error::ParseMemoryZone)?;
 
                 let id = parser.get("id").ok_or(Error::ParseMemoryZoneIdMissing)?;
@@ -690,6 +691,9 @@ impl MemoryConfig {
                     .map_err(Error::ParseMemoryZone)?
                     .unwrap_or(Toggle(false))
                     .0;
+                let policy = parser
+                    .convert::<u32>("policy")
+                    .map_err(Error::ParseMemoryZone)?;
 
                 zones.push(MemoryZoneConfig {
                     id,
@@ -702,6 +706,7 @@ impl MemoryConfig {
                     hotplug_size,
                     hotplugged_size,
                     prefault,
+                    policy,
                 });
             }
             Some(zones)

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -54,6 +54,7 @@ pub struct CpusConfig {
 }
 
 pub const DEFAULT_VCPUS: u8 = 1;
+pub const DEFAULT_MEMORY_POLICY: u32 = 1; // MPOL_PREFERRED
 
 impl Default for CpusConfig {
     fn default() -> Self {
@@ -125,6 +126,7 @@ pub struct MemoryZoneConfig {
     pub hotplugged_size: Option<u64>,
     #[serde(default)]
     pub prefault: bool,
+    pub policy: Option<u32>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]


### PR DESCRIPTION
Currently, cloud hypervisor use mbind to bind memory for memory zones. The parameter "mode" of mbind cannot be specified by user and its value is hard coded to MPOL_BIND.

> The  MPOL_BIND  mode  specifies  a  strict  policy that restricts memory allocation to the nodes specified in nodemask.  If nodemask specifies more than one node, page allocations will come from the node with the lowest
       numeric node ID first, until that node contains no free memory.  Allocations will then come from the node with the next highest node ID specified in nodemask and so forth, until none of the specified nodes contain  free
       memory.  Pages will not be allocated from any node not specified in the nodemask.

You can only specify one numa node for one memory zone, If there's no enough memory on the numa node for the memory zone, the vm will be fail to start. In fact, there are other options for memory bind, like MPOL_PREFERRED

>  MPOL_PREFERRED  sets  the preferred node for allocation.  The kernel will try to allocate pages from this node first and fall back to other nodes if the preferred nodes is low on free memory.  If nodemask specifies more
       than one node ID, the first node in the mask will be selected as the preferred node.  If the nodemask and maxnode arguments specify the empty set, then the memory is allocated on the node of the CPU that  triggered  the
       allocation.  This is the only way to specify "local allocation" for a range of memory via mbind().

https://github.com/cloud-hypervisor/cloud-hypervisor/blob/681a30bd15abcfc2a60aaa39816f704d1f158dc7/vmm/src/memory_manager.rs#LL1356C1-L1386C10
So, this patch just export this parameter to user. You can specify the value (policy) in the command line
```shell
[zhangyanlin@qd01-test-ec2177009039.qd01.ksyun.com ~]$ cloud-hypervisor \
-vvv \
--cpus boot=1 --serial tty --console off --seccomp false \
--log-file /tmp/ch-fw.log \
--kernel /usr/share/cloud-hypervisor/ovmf.fd \
--disk path=/home/zhangyanlin/centos_8.2.ch.img.base \ --memory size=0 \
--memory-zone id=mem0,hugepages=on,size=4G,policy=1,host_numa_node=0 \ 
--numa guest_numa_id=0,memory_zones=mem0

[zhangyanlin@qd01-test-ec2177009039.qd01.ksyun.com ~]$ sudo numastat -p 20151
 
Per-node process memory usage (in MBs) for PID 20151 (cloud-hyperviso)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                      3160.00            0.00         3160.00
Heap                         0.00            0.14            0.14
Stack                        0.00            0.02            0.02
Private                      0.00           12.30           12.30
----------------  --------------- --------------- ---------------
Total                     3160.00           12.46         3172.46
```
The value of "policy": 0-->MPOL_DEFAULT, 1-->MPOL_PREFERRED, 2-->MPOL_BIND, 3-->MPOL_INTERLEAVE