### PR TITLE
Reduce snap image file size by using mincore

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -625,6 +625,7 @@ fn vmm_thread_rules(
         (libc::SYS_wait4, vec![]),
         (libc::SYS_write, vec![]),
         (libc::SYS_writev, vec![]),
+        (libc::SYS_mincore, vec![]),
     ])
 }
 


### PR DESCRIPTION
In snapshot, cloud hypervisor will save all guest memory as a memory
file. And the file will be used to restore the guest memory when
restore VM. The memory file size is always the same as the configuration
of VM memory size.

This patch does some optimization to reduce the memory file size. When
snapshot the VM, guest may not touch all memory, so we could identify
the touched guest memory via mincore syscall, then only save the
touched guest memory range into file, leave untouched range as file
holes, then reduce the memory file size on disk.

In my case, an Ubuntu VM configured with 512MB memory, with this patch
reduces the memory file into about 345MB.

Fix [5410](https://github.com/cloud-hypervisor/cloud-hypervisor/issues/5410)