### PR TITLE
hypervisor: Add infrastructure to detect host CPU vendor

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -198,11 +198,8 @@ pub fn initramfs_load_addr(
     }
 }
 
-pub fn get_host_cpu_phys_bits() -> u8 {
-    // A dummy hypervisor created only for querying the host IPA size and will
-    // be freed after the query.
-    let hv = hypervisor::new().unwrap();
-    let host_cpu_phys_bits = hv.get_host_ipa_limit().try_into().unwrap();
+pub fn get_host_cpu_phys_bits(hypervisor: &Arc<dyn hypervisor::Hypervisor>) -> u8 {
+    let host_cpu_phys_bits = hypervisor.get_host_ipa_limit().try_into().unwrap();
     if host_cpu_phys_bits == 0 {
         // Host kernel does not support `get_host_ipa_limit`,
         // we return the default value 40 here.

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -21,6 +21,15 @@ use crate::MpState;
 use thiserror::Error;
 use vm_memory::GuestAddress;
 
+#[cfg(target_arch = "x86_64")]
+#[derive(Copy, Clone, Default)]
+pub enum CpuVendor {
+    #[default]
+    Unknown,
+    Intel,
+    AMD,
+}
+
 #[derive(Error, Debug)]
 ///
 /// Enum for CPU error

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -49,6 +49,8 @@ mod cpu;
 mod device;
 
 pub use crate::hypervisor::{Hypervisor, HypervisorError};
+#[cfg(target_arch = "x86_64")]
+pub use cpu::CpuVendor;
 pub use cpu::{HypervisorCpuError, Vcpu, VmExit};
 pub use device::HypervisorDeviceError;
 #[cfg(all(feature = "kvm", target_arch = "aarch64"))]

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -716,7 +716,7 @@ impl CpuManager {
         );
 
         self.cpuid = {
-            let phys_bits = physical_bits(self.config.max_phys_bits);
+            let phys_bits = physical_bits(hypervisor, self.config.max_phys_bits);
             arch::generate_common_cpuid(
                 hypervisor,
                 topology,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1219,7 +1219,8 @@ impl Vmm {
             ))
         })?;
 
-        let phys_bits = vm::physical_bits(config.lock().unwrap().cpus.max_phys_bits);
+        let phys_bits =
+            vm::physical_bits(&self.hypervisor, config.lock().unwrap().cpus.max_phys_bits);
 
         let memory_manager = MemoryManager::new(
             vm,
@@ -1535,7 +1536,8 @@ impl Vmm {
         let vm_config = vm.get_config();
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         let common_cpuid = {
-            let phys_bits = vm::physical_bits(vm_config.lock().unwrap().cpus.max_phys_bits);
+            let phys_bits =
+                vm::physical_bits(&hypervisor, vm_config.lock().unwrap().cpus.max_phys_bits);
             arch::generate_common_cpuid(
                 &hypervisor,
                 None,
@@ -1725,7 +1727,7 @@ impl Vmm {
         let dest_cpuid = &{
             let vm_config = &src_vm_config.lock().unwrap();
 
-            let phys_bits = vm::physical_bits(vm_config.cpus.max_phys_bits);
+            let phys_bits = vm::physical_bits(&self.hypervisor, vm_config.cpus.max_phys_bits);
             arch::generate_common_cpuid(
                 &self.hypervisor.clone(),
                 None,


### PR DESCRIPTION
CPU vendor identification is required to correctly determine available host features and do necessary fine tuning at runtime. For x86, the current code in most case assumes an `Intel` based host. This patch initially adds support for detecting `Intel` and `AMD`, while other processors can be of course added. Later on, there might be a least some interest determining features for two other processors - `Hygon` and `Zhaoxin`. For Hygon, there's already #5305 reported, which can require some specific handling. This functionality can be also extended to support `ARM` processors, if makes sense.

In general, with the functionality to determine the host CPU vendor, the potential is also to improve the portability and extend the range of compatible hosts where CH can be used. Currently there seems to be just one place making use of CPU vendor where addressable space size is calculated. There is a further need on this already for extending the topology configuration to be compatible with AMD processors and this should come once the CPU vendor mechanism is in place.

Things done in tihs PR:

- Add functionality to determine host CPU vendor
- Move `get_host_cpu_phys_bits` to using the CPU vendor detection functionality

Signed-off-by: Anatol Belski <anbelski@linux.microsoft.com>