### PR TITLE
tests: fix sha1sum check warning

### DIFF
--- a/scripts/sha1sums-x86_64
+++ b/scripts/sha1sums-x86_64
@@ -3,4 +3,3 @@ f1eccdc5e1b515dbad294426ab081b47ebfb97c0 focal-server-cloudimg-amd64-custom-2021
 7f5a8358243a96adf61f5c20139b29f308f2c0e3 focal-server-cloudimg-amd64-custom-20210609-0.raw
 864c074e2f1bd753667a35188b510d83a1d62793 jammy-server-cloudimg-amd64-custom-20230119-0.qcow2
 24358ee053f94e7f710ea4ce9e7a63eff2a1eb25 jammy-server-cloudimg-amd64-custom-20230119-0.raw
-


### PR DESCRIPTION
Remove empty line to fix warning:
"sha1sum: WARNING: 1 line is improperly formatted"