### PR TITLE
docs: Fix broken link to macvtap doc in custom-image.md

### DIFF
--- a/docs/custom-image.md
+++ b/docs/custom-image.md
@@ -225,7 +225,7 @@ Number  Start   End     Size    File system  Name  Flags
 
 ### Create a macvtap interface
 
-Rely on the following [documentation](docs/macvtap-bridge.md) to set up a
+Rely on the following [documentation](macvtap-bridge.md) to set up a
 macvtap interface to provide your VM with proper connectivity.
 
 ### Boot the image


### PR DESCRIPTION
We get a "404 - page not found" when clicking on this link on github.