### PR TITLE
tests:Migrate docker container to Ubuntu22.04 for integration test cases.

### DIFF
--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -858,6 +858,14 @@ impl VfioCommon {
 
         let mut pci_express_cap_found = false;
         let mut power_management_cap_found = false;
+        
+        let limit = libc::rlimit
+        {
+            rlim_cur: 2048,
+            rlim_max: 2048,
+        };
+        // SAFETY: FFI call with correct arguments
+        unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limit) };
 
         while cap_next != 0 {
             let cap_id = self.vfio_wrapper.read_config_byte(cap_next.into());


### PR DESCRIPTION
Integration test's docker image is currently based on 20.04. This commit migrates the docker image to 22.04.
All integration test cases pass on Ampere Altra.