### PR TITLE
build: Bump MSRV to 1.64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.62"
+          - "1.64"
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://github.com/cloud-hypervisor/cloud-hypervisor"
 # a.) A dependency requires it,
 # b.) If we want to use a new feature and that MSRV is at least 6 months old,
 # c.) There is a security issue that is addressed by the toolchain update.
-rust-version = "1.62"
+rust-version = "1.64"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
This is required for openssl-src crate as it now uses functionality
first released in this version.

See: https://github.com/alexcrichton/openssl-src-rs/pull/184

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
