### PR TITLE
build: Temporarily disable metrics and rate-limiter tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,64 +238,64 @@ pipeline {
                 //         }
                 //     }
                 // }
-                stage('Worker build - Metrics') {
-                    agent { node { label 'jammy-metrics' } }
-                    when {
-                        branch 'main'
-                        beforeAgent true
-                        expression {
-                            return runWorkers
-                        }
-                    }
-                    environment {
-                        METRICS_PUBLISH_KEY = credentials('52e0945f-ce7a-43d1-87af-67d1d87cc40f')
-                    }
-                    stages {
-                        stage('Checkout') {
-                            steps {
-                                checkout scm
-                            }
-                        }
-                        stage('Run metrics tests') {
-                            options {
-                                timeout(time: 1, unit: 'HOURS')
-                            }
-                            steps {
-                                sh 'scripts/dev_cli.sh tests --metrics -- -- --report-file /root/workloads/metrics.json'
-                            }
-                        }
-                        stage('Upload metrics report') {
-                            steps {
-                                sh 'curl -X PUT https://cloud-hypervisor-metrics.azurewebsites.net/api/publishmetrics -H "x-functions-key: $METRICS_PUBLISH_KEY" -T ~/workloads/metrics.json'
-                            }
-                        }
-                    }
-                }
-                stage('Worker build - Rate Limiter') {
-                    agent { node { label 'focal-metrics' } }
-                    when {
-                        branch 'main'
-                        beforeAgent true
-                        expression {
-                            return runWorkers
-                        }
-                    }
-                    stages {
-                        stage('Checkout') {
-                            steps {
-                                checkout scm
-                            }
-                        }
-                        stage('Run rate-limiter integration tests') {
-                            options {
-                                timeout(time: 10, unit: 'MINUTES')
-                            }
-                            steps {
-                                sh 'scripts/dev_cli.sh tests --integration-rate-limiter'
-                            }
-                        }
-                    }
-                }
+                // stage('Worker build - Metrics') {
+                //     agent { node { label 'jammy-metrics' } }
+                //     when {
+                //         branch 'main'
+                //         beforeAgent true
+                //         expression {
+                //             return runWorkers
+                //         }
+                //     }
+                //     environment {
+                //         METRICS_PUBLISH_KEY = credentials('52e0945f-ce7a-43d1-87af-67d1d87cc40f')
+                //     }
+                //     stages {
+                //         stage('Checkout') {
+                //             steps {
+                //                 checkout scm
+                //             }
+                //         }
+                //         stage('Run metrics tests') {
+                //             options {
+                //                 timeout(time: 1, unit: 'HOURS')
+                //             }
+                //             steps {
+                //                 sh 'scripts/dev_cli.sh tests --metrics -- -- --report-file /root/workloads/metrics.json'
+                //             }
+                //         }
+                //         stage('Upload metrics report') {
+                //             steps {
+                //                 sh 'curl -X PUT https://cloud-hypervisor-metrics.azurewebsites.net/api/publishmetrics -H "x-functions-key: $METRICS_PUBLISH_KEY" -T ~/workloads/metrics.json'
+                //             }
+                //         }
+                //     }
+                // }
+                // stage('Worker build - Rate Limiter') {
+                //     agent { node { label 'focal-metrics' } }
+                //     when {
+                //         branch 'main'
+                //         beforeAgent true
+                //         expression {
+                //             return runWorkers
+                //         }
+                //     }
+                //     stages {
+                //         stage('Checkout') {
+                //             steps {
+                //                 checkout scm
+                //             }
+                //         }
+                //         stage('Run rate-limiter integration tests') {
+                //             options {
+                //                 timeout(time: 10, unit: 'MINUTES')
+                //             }
+                //             steps {
+                //                 sh 'scripts/dev_cli.sh tests --integration-rate-limiter'
+                //             }
+                //         }
+                //     }
+                // }
                 stage('Worker build - SGX') {
                     agent { node { label 'jammy-sgx' } }
                     when {


### PR DESCRIPTION
The bare-metal machine being used for these tests is temporarily unavailable. Let's disable theses tests until the system is back online.