### PR TITLE
vmm, virtio-devices: allow mremap for consoles

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -259,6 +259,7 @@ fn virtio_thread_common() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_madvise, vec![]),
         (libc::SYS_mmap, vec![]),
         (libc::SYS_mprotect, vec![]),
+        (libc::SYS_mremap, vec![]),
         (libc::SYS_munmap, vec![]),
         (libc::SYS_openat, vec![]),
         (libc::SYS_read, vec![]),

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -717,6 +717,7 @@ fn vcpu_thread_rules(
         (libc::SYS_madvise, vec![]),
         (libc::SYS_mmap, vec![]),
         (libc::SYS_mprotect, vec![]),
+        (libc::SYS_mremap, vec![]),
         (libc::SYS_munmap, vec![]),
         (libc::SYS_nanosleep, vec![]),
         (libc::SYS_newfstatat, vec![]),


### PR DESCRIPTION
SerialBuffer uses VecDeque::extend, which calls realloc, which a maximum buffer size of 1 MiB.  Starting at allocation sizes of 128 KiB, musl's mallocng allocator will use mremap for the allocation. Since this was not permitted by the seccomp rules, heavy write load could crash cloud-hypervisor with a seccomp failure.  (Encountered using virtio-console, but I don't see any reason it wouldn't happen for the legacy serial device too.)