### PR TITLE
tests: fix issue running vfio tests with empty worlkoads directory

### DIFF
--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -7,9 +7,42 @@ source $(dirname "$0")/test-util.sh
 process_common_args "$@"
 
 WORKLOADS_DIR="$HOME/workloads"
-FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.raw"
-FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"
+mkdir -p "$WORKLOADS_DIR"
+
+cp scripts/sha1sums-x86_64 $WORKLOADS_DIR
+
+FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/rust-hypervisor-firmware/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
 FW="$WORKLOADS_DIR/hypervisor-fw"
+if [ ! -f "$FW" ]; then
+    pushd $WORKLOADS_DIR
+    time wget --quiet $FW_URL || exit 1
+    popd
+fi
+
+FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
+FOCAL_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$FOCAL_OS_IMAGE_NAME"
+FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"
+if [ ! -f "$FOCAL_OS_IMAGE" ]; then
+    pushd $WORKLOADS_DIR
+    time wget --quiet $FOCAL_OS_IMAGE_URL || exit 1
+    popd
+fi
+
+FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.raw"
+FOCAL_OS_RAW_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_RAW_IMAGE_NAME"
+if [ ! -f "$FOCAL_OS_RAW_IMAGE" ]; then
+    pushd $WORKLOADS_DIR
+    time qemu-img convert -p -f qcow2 -O raw $FOCAL_OS_IMAGE_NAME $FOCAL_OS_RAW_IMAGE_NAME || exit 1
+    popd
+fi
+
+pushd $WORKLOADS_DIR
+sha1sum sha1sums-x86_64 --check --ignore-missing
+if [ $? -ne 0 ]; then
+    echo "sha1sum validation of images failed, remove invalid images to fix the issue."
+    exit 1
+fi
+popd
 
 VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
 build_custom_linux
@@ -31,7 +64,7 @@ VFIO_DIR="$WORKLOADS_DIR/vfio"
 VFIO_DISK_IMAGE="$WORKLOADS_DIR/vfio.img"
 rm -rf $VFIO_DIR $VFIO_DISK_IMAGE
 mkdir -p $VFIO_DIR
-cp $FOCAL_OS_IMAGE $VFIO_DIR
+cp $FOCAL_OS_RAW_IMAGE $VFIO_DIR
 cp $FW $VFIO_DIR
 cp $VMLINUX_IMAGE $VFIO_DIR || exit 1
 


### PR DESCRIPTION
Download firmware and focal image to fix issue of running vfio tests with empty worlkoads directory:

$ scripts/dev_cli.sh tests --integration-vfio
  cp /root/workloads/focal-server-cloudimg-amd64-custom-20210609-0.raw /root/workloads/vfio cp: cannot stat '/root/workloads/focal-server-cloudimg-amd64-custom-20210609-0.raw': No such file or directory
  cp /root/workloads/hypervisor-fw /root/workloads/vfio cp: cannot stat '/root/workloads/hypervisor-fw': No such file or directory
