### PR TITLE
x86: set ApicId in cpuid for each vcpu

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -775,6 +775,13 @@ pub fn configure_vcpu(
     CpuidPatch::set_cpuid_reg(&mut cpuid, 0xb, None, CpuidReg::EDX, u32::from(id));
     CpuidPatch::set_cpuid_reg(&mut cpuid, 0x1f, None, CpuidReg::EDX, u32::from(id));
 
+    // Set ApicId in cpuid for each vcpu
+    // SAFETY: get host cpuid when eax=1
+    let mut cpu_ebx = unsafe { core::arch::x86_64::__cpuid(1) }.ebx;
+    cpu_ebx &= 0xffffff;
+    cpu_ebx |= (id as u32) << 24;
+    CpuidPatch::set_cpuid_reg(&mut cpuid, 0x1, None, CpuidReg::EBX, cpu_ebx);
+
     // The TSC frequency CPUID leaf should not be included when running with HyperV emulation
     if !kvm_hyperv {
         if let Some(tsc_khz) = vcpu.tsc_khz().map_err(Error::GetTscFrequency)? {


### PR DESCRIPTION
When start clh from edk2 with vcpu number larger than 2, edk2 will crash at Ap initialization. The root cause is that when get ApicId from cpuid, it returns a wrong value that ApicId is the same for each Ap. Further more, stack selection depends on ApicId, that leads to all Aps share the same stack space.

Explicitly set ApicId in cpuid for each vcpu can solve this issue.

Fixes: #5475