### PR TITLE
WIP: Remove unnecessary clippy override

### DIFF
--- a/net_gen/src/lib.rs
+++ b/net_gen/src/lib.rs
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-#![allow(clippy::all)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
Clippy passes fine without this.