### PR TITLE
D-Bus API and `event-monitor` integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,6 +2319,7 @@ dependencies = [
  "devices",
  "epoll",
  "event_monitor",
+ "flume",
  "futures",
  "gdbstub",
  "gdbstub_arch",

--- a/docs/api.md
+++ b/docs/api.md
@@ -206,11 +206,14 @@ curl --unix-socket /tmp/cloud-hypervisor.sock -i -X PUT 'http://localhost/api/v1
 
 ### D-Bus API
 
-Cloud Hypervisor offers a D-Bus API as an alternative to its REST API. As of
-writing this document, the D-Bus API mirrors the functionality of the REST
-API and shares the same set of endpoints, meaning that it supports every call
-that is supported by the REST API and can be a drop-in replacement since it
-also consumes/produces JSON.
+Cloud Hypervisor offers a D-Bus API as an alternative to its REST API. This
+D-Bus API fully reflects the functionality of the REST API, exposing the
+same group of endpoints. It can be a drop-in replacement since it also
+consumes/produces JSON.
+
+In addition, the D-Bus API also exposes events from `event-monitor` in the
+form of a D-Bus signal to which users can subscribe. For more information,
+see [D-Bus API Interface](#d-bus-api-interface).
 
 #### D-Bus API Location and availability
 
@@ -245,8 +248,23 @@ which in turn can be used to control and manage Cloud Hypervisor.
 
 #### D-Bus API Interface
 
-Please refer to the [REST API](#rest-api) documentation. As previously
-mentioned, the D-Bus API currently mirrors the behaviour of the REST API.
+Please refer to the [REST API](#rest-api) documentation for everything that
+is in common with the REST API. As previously mentioned, the D-Bus API can
+be used as a drop-in replacement for the [REST API](#rest-api).
+
+The D-Bus interface also exposes a signal, named `Event`, which is emitted
+whenever a new event is published from the `event-monitor` crate. Here is its
+definition in XML format:
+
+```xml
+<node>
+  <interface name="org.cloudhypervisor.DBusApi1">
+    <signal name="Event">
+      <arg name="event" type="s"/>
+    </signal>
+  </interface>
+</node>
+```
 
 ### Command Line Interface
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -25,6 +25,7 @@ blocking = { version = "1.3.0", optional = true }
 devices = { path = "../devices" }
 epoll = "4.3.3"
 event_monitor = { path = "../event_monitor" }
+flume = "0.10.14"
 futures = { version = "0.3.27", optional = true }
 gdbstub = { version = "0.6.4", optional = true }
 gdbstub_arch = { version = "0.2.4", optional = true }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -321,8 +321,10 @@ pub fn start_event_monitor_thread(
                 while let Ok(event) = monitor.rx.recv() {
                     let event = Arc::new(event);
 
-                    monitor.file.write_all(event.as_bytes().as_ref()).ok();
-                    monitor.file.write_all(b"\n\n").ok();
+                    if let Some(ref mut file) = monitor.file {
+                        file.write_all(event.as_bytes().as_ref()).ok();
+                        file.write_all(b"\n\n").ok();
+                    }
 
                     for tx in monitor.broadcast.iter() {
                         tx.send(event.clone()).ok();


### PR DESCRIPTION
~This PR enables the `event-monitor` crate to broadcast events to other subsystems of the project. It accomplishes this by making use of an unbounded MPMC channel ([`flume`](https://crates.io/crates/flume)).~

~The broadcasted events are then emitted on the D-Bus API using a signal called `Event`, which users can subscribe to.~

~We chose to use an MPMC channel instead of an MPSC channel because publishing events from `event-monitor` to a single consumer didn't seem like a good API design choice. This decision also future-proofs the feature, allowing other subsystems to subscribe to those events. `flume` being lightweight and widely adopted also contributed to this decision.~

Implementation is substantially changed, see comment: https://github.com/cloud-hypervisor/cloud-hypervisor/pull/5517#issuecomment-1676470307

The `event-monitor` crate is not yet mature enough and we would like to take on improving it - there will be subsequent PRs to improve the functionality and usage of the `event-monitor` crate throughout the project as we get feedback from the community/finalize the design we have in mind.