### PR TITLE
vmm: ignore and warn TAP FDs in more situations

### DIFF
--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -36,12 +36,21 @@ impl EndpointHandler for VmCreate {
                 match &req.body {
                     Some(body) => {
                         // Deserialize into a VmConfig
-                        let vm_config: VmConfig = match serde_json::from_slice(body.raw())
+                        let mut vm_config: VmConfig = match serde_json::from_slice(body.raw())
                             .map_err(HttpError::SerdeJsonDeserialize)
                         {
                             Ok(config) => config,
                             Err(e) => return error_response(e, StatusCode::BadRequest),
                         };
+
+                        if let Some(ref mut nets) = vm_config.net {
+                            if nets.iter().any(|net| net.fds.is_some()) {
+                                warn!("Ignoring FDs sent via the HTTP request body");
+                            }
+                            for net in nets {
+                                net.fds = None;
+                            }
+                        }
 
                         // Call vm_create()
                         match vm_create(api_notifier, api_sender, Arc::new(Mutex::new(vm_config)))


### PR DESCRIPTION
Port of https://github.com/cloud-hypervisor/cloud-hypervisor/pull/5350 to D-Bus and the VM creation endpoints.