### PR TITLE
vmm: allow restart_syscall() in PTY process

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -486,6 +486,7 @@ fn pty_foreground_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, Backend
         #[cfg(target_arch = "aarch64")]
         (libc::SYS_ppoll, vec![]),
         (libc::SYS_read, vec![]),
+        (libc::SYS_restart_syscall, vec![]),
         (libc::SYS_rt_sigaction, vec![]),
         (libc::SYS_rt_sigreturn, vec![]),
         (libc::SYS_setsid, vec![]),


### PR DESCRIPTION
This can be triggered by debugging cloud-hypervisor using gdb, or probably if the process is suspended and restarted.

Fixes https://github.com/cloud-hypervisor/cloud-hypervisor/issues/5489.