### PR TITLE
Fix vfio test

### DIFF
--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -89,7 +89,12 @@ echo $PAGE_NUM | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 export RUST_BACKTRACE=1
-time cargo test "vfio::test_nvidia" -- --test-threads=1 ${test_binary_args[*]}
+time cargo test "vfio::test_vfio" -- ${test_binary_args[*]}
 RES=$?
+
+if [ $RES -eq 0 ]; then
+	time cargo test "vfio::test_nvidia" -- --test-threads=1 ${test_binary_args[*]}
+	RES=$?
+fi
 
 exit $RES

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4295,7 +4295,7 @@ mod common_parallel {
                 .ssh_command_l1(
                     "sudo /mnt/ch-remote \
                  --api-socket /tmp/ch_api.sock \
-                 resize --memory=1073741824",
+                 resize --memory 1073741824",
                 )
                 .unwrap();
             assert!(guest.get_total_memory_l2().unwrap_or_default() > 960_000);
@@ -8286,7 +8286,7 @@ mod vfio {
                 .ssh_command_l1(
                     "sudo /mnt/ch-remote \
                  --api-socket /tmp/ch_api.sock \
-                 resize --memory=1073741824",
+                 resize --memory 1073741824",
                 )
                 .unwrap();
             assert!(guest.get_total_memory_l2().unwrap_or_default() > 960_000);


### PR DESCRIPTION
Test was failing due to regression caused by commit
https://github.com/cloud-hypervisor/cloud-hypervisor/commit/d5558aea2a4205564b00ee8796a8ab47879df337

Failing command:
sudo /mnt/ch-remote --api-socket /tmp/ch_api.sock resize --memory=1073741824"