### PR TITLE
Remove identity_op audit clippy

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -98,6 +98,13 @@ macro_rules! extract_bits_64 {
     };
 }
 
+#[cfg(all(target_arch = "aarch64", feature = "guest_debug"))]
+macro_rules! extract_bits_64_without_offset {
+    ($value: tt, $length: tt) => {
+        $value & (!0u64 >> (64 - $length))
+    };
+}
+
 pub const CPU_MANAGER_ACPI_SIZE: usize = 0xc;
 
 #[derive(Debug, Error)]
@@ -1611,8 +1618,7 @@ impl CpuManager {
 
         // PA or IPA size is determined
         let tcr_ips = extract_bits_64!(tcr_el1, 32, 3);
-        #[allow(clippy::identity_op)]
-        let pa_range = extract_bits_64!(id_aa64mmfr0_el1, 0, 4);
+        let pa_range = extract_bits_64_without_offset!(id_aa64mmfr0_el1, 4);
         // The IPA size in TCR_BL1 and PA Range in ID_AA64MMFR0_EL1 should match.
         // To be safe, we use the minimum value if they are different.
         let pa_range = std::cmp::min(tcr_ips, pa_range);
@@ -1645,8 +1651,7 @@ impl CpuManager {
         let descaddrmask = descaddrmask & !indexmask_grainsize;
 
         // Translation table base address
-        #[allow(clippy::identity_op)]
-        let mut descaddr: u64 = extract_bits_64!(ttbr1_el1, 0, 48);
+        let mut descaddr: u64 = extract_bits_64_without_offset!(ttbr1_el1, 48);
         // In the case of FEAT_LPA and FEAT_LPA2, the initial translation table
         // addresss bits [48:51] comes from TTBR1_EL1 bits [2:5].
         if pa_size == 52 {


### PR DESCRIPTION
Avoid identity operations with 0.

https://rust-lang.github.io/rust-clippy/master/index.html#/identity_op

See https://github.com/cloud-hypervisor/cloud-hypervisor/issues/4986
