### PR TITLE
vm-allicator: Remove "new_without_default" clippy

### DIFF
--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -63,7 +63,6 @@ impl GsiAllocator {
     }
 
     #[cfg(target_arch = "aarch64")]
-    #[allow(clippy::new_without_default)]
     /// New GSI allocator
     pub fn new() -> Self {
         GsiAllocator {
@@ -104,5 +103,12 @@ impl GsiAllocator {
         let irq = self.next_irq;
         self.next_irq = self.next_irq.checked_add(1).ok_or(Error::Overflow)?;
         Ok(irq)
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+impl Default for GsiAllocator {
+    fn default() -> Self {
+        GsiAllocator::new()
     }
 }


### PR DESCRIPTION
Add a Default implementation that delegates to new, so that clippy can be removed.

https://rust-lang.github.io/rust-clippy/master/index.html#/new_without_default

See https://github.com/cloud-hypervisor/cloud-hypervisor/issues/4986