### PR TITLE
Remove "from_over_into" clippy

### DIFF
--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -452,10 +452,9 @@ impl From<PciBarType> for PciBarRegionType {
     }
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<PciBarType> for PciBarRegionType {
-    fn into(self) -> PciBarType {
-        match self {
+impl From<PciBarRegionType> for PciBarType {
+    fn from(val: PciBarRegionType) -> Self {
+        match val {
             PciBarRegionType::IoRegion => PciBarType::Io,
             PciBarRegionType::Memory32BitRegion => PciBarType::Mmio32,
             PciBarRegionType::Memory64BitRegion => PciBarType::Mmio64,
@@ -469,10 +468,9 @@ pub enum PciBarPrefetchable {
     Prefetchable = 0x08,
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<bool> for PciBarPrefetchable {
-    fn into(self) -> bool {
-        match self {
+impl From<PciBarPrefetchable> for bool {
+    fn from(val: PciBarPrefetchable) -> Self {
+        match val {
             PciBarPrefetchable::NotPrefetchable => false,
             PciBarPrefetchable::Prefetchable => true,
         }


### PR DESCRIPTION
According the std docs implementing From<..> is preferred since it gives you Into<..> for free where the reverse isn’t true.

https://rust-lang.github.io/rust-clippy/master/index.html#/from_over_into

See: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/4986