### PR TITLE
vfio_user: Fix the issue of 'Too many open files' when start VM with spdk

### DIFF
--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -858,6 +858,12 @@ impl VfioCommon {
 
         let mut pci_express_cap_found = false;
         let mut power_management_cap_found = false;
+        let limit = libc::rlimit {
+            rlim_cur: 2048,
+            rlim_max: 2048,
+        };
+        // SAFETY: FFI call with correct arguments
+        unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limit) };
 
         while cap_next != 0 {
             let cap_id = self.vfio_wrapper.read_config_byte(cap_next.into());


### PR DESCRIPTION
The SPDK-NVMe backend needs 512 FDs (sent from the VMM) for enabling irq.
The VM returns "Too many open files" when start it with spdk.
Increase the number of open files limit will fix this error.
 
More info:[5426](https://github.com/cloud-hypervisor/cloud-hypervisor/issues/5426#issuecomment-1577819963)