### PR TITLE
Replace "clippy::all" with correct ones

### DIFF
--- a/net_gen/src/if_tun.rs
+++ b/net_gen/src/if_tun.rs
@@ -10,6 +10,7 @@
 #[repr(C)]
 #[derive(Default)]
 pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+#[allow(clippy::missing_safety_doc)]
 impl<T> __IncompleteArrayField<T> {
     #[inline]
     pub const fn new() -> Self {

--- a/net_gen/src/iff.rs
+++ b/net_gen/src/iff.rs
@@ -10,6 +10,7 @@
 #[repr(C)]
 #[derive(Default)]
 pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+#[allow(clippy::missing_safety_doc)]
 impl<T> __IncompleteArrayField<T> {
     #[inline]
     pub const fn new() -> Self {

--- a/net_gen/src/lib.rs
+++ b/net_gen/src/lib.rs
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
-#![allow(clippy::all)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
Remove clippy:all and update it with correct clippy audit, so that it gives proper information. This PR doesn't completely remove clippy but gives some clarity on it.

See: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/4986 