### PR TITLE
hypervisor: x86: Emulator is only needed on `mshv`, not `kvm`

### DIFF
--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -26,7 +26,7 @@ vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", defau
 vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = "0.11.0", features = ["with-serde"] }
 
-[target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]
+[target.'cfg(all(target_arch = "x86_64", target_os = "windows"))'.dependencies.iced-x86]
 version = "1.19.0"
 default-features = false
 features = ["std", "decoder", "op_code_info", "instr_info", "fast_fmt"]

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -11,6 +11,7 @@
 // Copyright © 2020, Microsoft Corporation
 //
 
+#[cfg(all(feature = "mshv", target_arch = "x86_64"))]
 pub mod emulator;
 pub mod gdt;
 #[allow(non_camel_case_types)]


### PR DESCRIPTION
On x86-64, when the underlying hypervisor platform is KVM, no instruction emulator is necessary. KVM handles instruction boundaries internally.

This change allows to skip the iced-x86 dependency on KVM, improving build times, prunes the dependency graph and reduces network traffic during the initial build.

For Hyper-V, the emulator is still necessary on x86-64, so nothing changes there.