### PR TITLE
event_monitor: add functionality to broadcast events with a mpmc channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +614,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 name = "event_monitor"
 version = "0.1.0"
 dependencies = [
+ "flume",
  "libc",
  "serde",
  "serde_json",
@@ -627,6 +634,19 @@ name = "fdt"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
+
+[[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -779,8 +799,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -922,6 +944,15 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "js-sys"
+version = "0.3.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kvm-bindings"
@@ -1084,6 +1115,15 @@ dependencies = [
  "libc",
  "mshv-bindings",
  "vmm-sys-util",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1300,6 +1340,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -1748,6 +1808,15 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -2259,6 +2328,7 @@ dependencies = [
  "devices",
  "epoll",
  "event_monitor",
+ "flume",
  "futures",
  "gdbstub",
  "gdbstub_arch",
@@ -2329,6 +2399,60 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "winapi"

--- a/event_monitor/Cargo.toml
+++ b/event_monitor/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2021"
 
 [dependencies]
+flume = "0.10.14"
 libc = "0.2.139"
 serde = { version = "1.0.164", features = ["rc", "derive"] }
 serde_json = "1.0.96"

--- a/event_monitor/src/lib.rs
+++ b/event_monitor/src/lib.rs
@@ -11,28 +11,64 @@ use std::io::Write;
 use std::os::unix::io::AsRawFd;
 use std::time::{Duration, Instant};
 
-static mut MONITOR: Option<(File, Instant)> = None;
+static mut MONITOR: Option<Monitor> = None;
+
+struct Monitor {
+    broadcaster: Option<flume::Sender<String>>,
+    file: Option<File>,
+    start: Instant,
+}
 
 /// This function must only be called once from the main process before any threads
 /// are created to avoid race conditions
-pub fn set_monitor(file: File) -> Result<(), std::io::Error> {
+pub fn set_monitor(
+    file: Option<File>,
+    broadcast: bool,
+) -> Result<Option<flume::Receiver<String>>, std::io::Error> {
     // SAFETY: there is only one caller of this function, so MONITOR is written to only once
     assert!(unsafe { MONITOR.is_none() });
-    let fd = file.as_raw_fd();
-    // SAFETY: FFI call to configure the fd
-    let ret = unsafe {
-        let mut flags = libc::fcntl(fd, libc::F_GETFL);
-        flags |= libc::O_NONBLOCK;
-        libc::fcntl(fd, libc::F_SETFL, flags)
-    };
-    if ret < 0 {
-        return Err(std::io::Error::last_os_error());
+
+    // return early if we do not want to write
+    // events to a file or broadcast them
+    if file.is_none() && !broadcast {
+        return Ok(None);
     }
+
+    if let Some(ref file) = file {
+        let fd = file.as_raw_fd();
+        // SAFETY: FFI call to configure the fd
+        let ret = unsafe {
+            let mut flags = libc::fcntl(fd, libc::F_GETFL);
+            flags |= libc::O_NONBLOCK;
+            libc::fcntl(fd, libc::F_SETFL, flags)
+        };
+        if ret < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+
+    // `event_monitor` uses an unbounded MPMC channel for event
+    // publication. Despite being `unbounded`, the actual limitation is the
+    // available memory. Since each subscriber must receive the message,
+    // a value transmitted will not be dropped until all receivers have
+    // acknowledged it. This could potentially use up a lot of memory
+    // over time, so use this carefully.
+    let (broadcast_tx, broadcast_rx) = broadcast
+        .then(flume::unbounded)
+        .map_or((None, None), |(tx, rx)| (Some(tx), Some(rx)));
+
+    let monitor = Monitor {
+        broadcaster: broadcast_tx,
+        file,
+        start: Instant::now(),
+    };
+
     // SAFETY: MONITOR is None. Nobody else can hold a reference to it.
     unsafe {
-        MONITOR = Some((file, Instant::now()));
+        MONITOR = Some(monitor);
     };
-    Ok(())
+
+    Ok(broadcast_rx)
 }
 
 #[derive(Serialize)]
@@ -45,17 +81,25 @@ struct Event<'a> {
 
 pub fn event_log(source: &str, event: &str, properties: Option<&HashMap<Cow<str>, Cow<str>>>) {
     // SAFETY: MONITOR is always in a valid state (None or Some).
-    if let Some((file, start)) = unsafe { MONITOR.as_ref() } {
+    if let Some(monitor) = unsafe { MONITOR.as_ref() } {
         let e = Event {
-            timestamp: start.elapsed(),
+            timestamp: monitor.start.elapsed(),
             source,
             event,
             properties,
         };
-        serde_json::to_writer_pretty(file, &e).ok();
 
-        let mut file = file;
-        file.write_all(b"\n\n").ok();
+        if let Ok(event_json) = serde_json::to_string_pretty(&e) {
+            if let Some(ref file) = monitor.file {
+                let mut file = file;
+                file.write_all(event_json.as_bytes()).ok();
+                file.write_all(b"\n\n").ok();
+            }
+
+            if let Some(ref broadcaster) = monitor.broadcaster {
+                broadcaster.send(event_json).ok();
+            }
+        }
     }
 }
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -24,6 +24,7 @@ blocking = { version = "1.3.0", optional = true }
 devices = { path = "../devices" }
 epoll = "4.3.1"
 event_monitor = { path = "../event_monitor" }
+flume = "0.10.14"
 futures = { version = "0.3.27", optional = true }
 gdbstub = { version = "0.6.4", optional = true }
 gdbstub_arch = { version = "0.2.4", optional = true }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -298,6 +298,7 @@ pub fn start_vmm_thread(
     api_event: EventFd,
     api_sender: Sender<ApiRequest>,
     api_receiver: Receiver<ApiRequest>,
+    event_monitor_receiver: Option<flume::Receiver<String>>,
     #[cfg(feature = "guest_debug")] debug_path: Option<PathBuf>,
     #[cfg(feature = "guest_debug")] debug_event: EventFd,
     #[cfg(feature = "guest_debug")] vm_debug_event: EventFd,


### PR DESCRIPTION
We use an MPMC channel pulled in from the [flume](https://crates.io/crates/flume) crate to enable the `event_monitor` to broadcast events to the interested subsystems of the project.