### PR TITLE
build: Bump proc-macro2 crate to fix nightly builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
