### PR TITLE
Revert "build: Bump vm-memory from 0.11.0 to 0.12.0 in /fuzz"

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vm-fdt",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -121,7 +121,7 @@ dependencies = [
  "vhdx",
  "virtio-bindings",
  "virtio-queue",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -166,7 +166,7 @@ dependencies = [
  "thiserror",
  "tpm",
  "tracer",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vmm",
  "vmm-sys-util",
 ]
@@ -191,7 +191,7 @@ dependencies = [
  "virtio-devices",
  "virtio-queue",
  "vm-device",
- "vm-memory 0.12.0",
+ "vm-memory",
  "vm-virtio",
  "vmm",
  "vmm-sys-util",
@@ -264,7 +264,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vm-device",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -325,7 +325,7 @@ dependencies = [
  "serde_with",
  "thiserror",
  "vfio-ioctls",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -404,7 +404,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3adb7b28e189741eca3b1a4a27de0bf15e0907c9d4b0c74bd2d7d84ef72e08"
 dependencies = [
- "vm-memory 0.11.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -445,7 +445,7 @@ dependencies = [
  "versionize_derive",
  "virtio-bindings",
  "virtio-queue",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -478,7 +478,7 @@ dependencies = [
  "vfio_user",
  "vm-allocator",
  "vm-device",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -778,7 +778,7 @@ dependencies = [
  "log",
  "thiserror",
  "vfio-bindings",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -795,7 +795,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "vfio-bindings",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -820,7 +820,7 @@ checksum = "84f81f436bca4541f4d33172e1202882c9d437db34ed17fc6d84c8ff2bde21f5"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -859,7 +859,7 @@ dependencies = [
  "virtio-queue",
  "vm-allocator",
  "vm-device",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
@@ -873,7 +873,7 @@ checksum = "91aebb1df33db33cbf04d4c2445e4f78d0b0c8e65acfd16a4ee95ef63ca252f8"
 dependencies = [
  "log",
  "virtio-bindings",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -883,7 +883,7 @@ version = "0.1.0"
 dependencies = [
  "arch",
  "libc",
- "vm-memory 0.11.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -895,7 +895,7 @@ dependencies = [
  "serde",
  "thiserror",
  "vfio-ioctls",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -916,17 +916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vm-memory"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c7a0891cbac53618f5f6eec650ed1dc4f7e506bbe14877aff49d94b8408b0"
-dependencies = [
- "libc",
- "thiserror",
- "winapi",
-]
-
-[[package]]
 name = "vm-migration"
 version = "0.1.0"
 dependencies = [
@@ -936,7 +925,7 @@ dependencies = [
  "thiserror",
  "versionize",
  "versionize_derive",
- "vm-memory 0.11.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -945,7 +934,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "virtio-queue",
- "vm-memory 0.11.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -988,7 +977,7 @@ dependencies = [
  "virtio-queue",
  "vm-allocator",
  "vm-device",
- "vm-memory 0.11.0",
+ "vm-memory",
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ virtio-devices = { path = "../virtio-devices" }
 virtio-queue = "0.8.0"
 vmm = { path = "../vmm" }
 vmm-sys-util = "0.11.1"
-vm-memory = "0.12.0"
+vm-memory = "0.11.0"
 vm-device = { path = "../vm-device" }
 vm-virtio = { path = "../vm-virtio" }
 


### PR DESCRIPTION
This reverts commit efb579b2247ffa523db5677c463ea809d65108db.

This PR was mistakenly merged due to the confusion around nightly
builds. The vm-memory update needs to be done in both the root workspace
and fuzz workspace together.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
