### PR TITLE
tests: Correctly parse number of host cpus > 255

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2429,7 +2429,7 @@ mod common_parallel {
         assert!(
             String::from_utf8_lossy(&host_cpus_count.stdout)
                 .trim()
-                .parse::<u8>()
+                .parse::<u16>()
                 .unwrap_or(0)
                 >= 4
         );


### PR DESCRIPTION
test_cpu_affinity needs the number of host CPUs. Since it is possible
for the host to have more than 255 CPUs; increase the size of the
datatype used for parsing the string to accomodate this.