### PR TITLE
Fix beta clippy issues

### DIFF
--- a/block_util/src/raw_sync.rs
+++ b/block_util/src/raw_sync.rs
@@ -73,7 +73,7 @@ impl AsyncIo for RawFileSync {
         let result = unsafe {
             libc::preadv(
                 self.fd as libc::c_int,
-                iovecs.as_ptr() as *const libc::iovec,
+                iovecs.as_ptr(),
                 iovecs.len() as libc::c_int,
                 offset,
             )
@@ -98,7 +98,7 @@ impl AsyncIo for RawFileSync {
         let result = unsafe {
             libc::pwritev(
                 self.fd as libc::c_int,
-                iovecs.as_ptr() as *const libc::iovec,
+                iovecs.as_ptr(),
                 iovecs.len() as libc::c_int,
                 offset,
             )

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -38,9 +38,7 @@ use std::fs::File;
 use std::os::unix::io::AsRawFd;
 
 #[cfg(target_arch = "x86_64")]
-use crate::arch::x86::{
-    CpuIdEntry, FpuState, LapicState, MsrEntry, SpecialRegisters, StandardRegisters,
-};
+use crate::arch::x86::{CpuIdEntry, FpuState, MsrEntry};
 
 const DIRTY_BITMAP_CLEAR_DIRTY: u64 = 0x4;
 const DIRTY_BITMAP_SET_DIRTY: u64 = 0x8;
@@ -314,7 +312,7 @@ impl cpu::Vcpu for MshvVcpu {
     ///
     /// Returns the vCPU general purpose registers.
     ///
-    fn get_regs(&self) -> cpu::Result<StandardRegisters> {
+    fn get_regs(&self) -> cpu::Result<crate::arch::x86::StandardRegisters> {
         Ok(self
             .fd
             .get_regs()
@@ -325,7 +323,7 @@ impl cpu::Vcpu for MshvVcpu {
     ///
     /// Sets the vCPU general purpose registers.
     ///
-    fn set_regs(&self, regs: &StandardRegisters) -> cpu::Result<()> {
+    fn set_regs(&self, regs: &crate::arch::x86::StandardRegisters) -> cpu::Result<()> {
         let regs = (*regs).into();
         self.fd
             .set_regs(&regs)
@@ -335,7 +333,7 @@ impl cpu::Vcpu for MshvVcpu {
     ///
     /// Returns the vCPU special registers.
     ///
-    fn get_sregs(&self) -> cpu::Result<SpecialRegisters> {
+    fn get_sregs(&self) -> cpu::Result<crate::arch::x86::SpecialRegisters> {
         Ok(self
             .fd
             .get_sregs()
@@ -346,7 +344,7 @@ impl cpu::Vcpu for MshvVcpu {
     ///
     /// Sets the vCPU special registers.
     ///
-    fn set_sregs(&self, sregs: &SpecialRegisters) -> cpu::Result<()> {
+    fn set_sregs(&self, sregs: &crate::arch::x86::SpecialRegisters) -> cpu::Result<()> {
         let sregs = (*sregs).into();
         self.fd
             .set_sregs(&sregs)
@@ -603,7 +601,7 @@ impl cpu::Vcpu for MshvVcpu {
     ///
     /// Returns the state of the LAPIC (Local Advanced Programmable Interrupt Controller).
     ///
-    fn get_lapic(&self) -> cpu::Result<LapicState> {
+    fn get_lapic(&self) -> cpu::Result<crate::arch::x86::LapicState> {
         Ok(self
             .fd
             .get_lapic()
@@ -614,7 +612,7 @@ impl cpu::Vcpu for MshvVcpu {
     ///
     /// Sets the state of the LAPIC (Local Advanced Programmable Interrupt Controller).
     ///
-    fn set_lapic(&self, lapic: &LapicState) -> cpu::Result<()> {
+    fn set_lapic(&self, lapic: &crate::arch::x86::LapicState) -> cpu::Result<()> {
         let lapic: mshv_bindings::LapicState = (*lapic).clone().into();
         self.fd
             .set_lapic(&lapic)

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -87,7 +87,7 @@ impl TxVirtio {
                 let result = unsafe {
                     libc::writev(
                         tap.as_raw_fd() as libc::c_int,
-                        iovecs.as_ptr() as *const libc::iovec,
+                        iovecs.as_ptr(),
                         iovecs.len() as libc::c_int,
                     )
                 };
@@ -226,7 +226,7 @@ impl RxVirtio {
                 let result = unsafe {
                     libc::readv(
                         tap.as_raw_fd() as libc::c_int,
-                        iovecs.as_ptr() as *const libc::iovec,
+                        iovecs.as_ptr(),
                         iovecs.len() as libc::c_int,
                     )
                 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -799,7 +799,7 @@ mod unit_tests {
 
     #[test]
     fn test_valid_vm_config_cpus() {
-        vec![
+        [
             (
                 vec![
                     "cloud-hypervisor",
@@ -917,7 +917,7 @@ mod unit_tests {
 
     #[test]
     fn test_valid_vm_config_kernel() {
-        vec![(
+        [(
             vec!["cloud-hypervisor", "--kernel", "/path/to/kernel"],
             r#"{
                 "payload": {"kernel": "/path/to/kernel"}
@@ -932,7 +932,7 @@ mod unit_tests {
 
     #[test]
     fn test_valid_vm_config_cmdline() {
-        vec![(
+        [(
             vec![
                 "cloud-hypervisor",
                 "--kernel",
@@ -953,7 +953,7 @@ mod unit_tests {
 
     #[test]
     fn test_valid_vm_config_disks() {
-        vec![
+        [
             (
                 vec![
                     "cloud-hypervisor",
@@ -1227,7 +1227,7 @@ mod unit_tests {
 
     #[test]
     fn test_valid_vm_config_rng() {
-        vec![(
+        [(
             vec![
                 "cloud-hypervisor",
                 "--kernel",
@@ -1249,8 +1249,7 @@ mod unit_tests {
 
     #[test]
     fn test_valid_vm_config_fs() {
-        vec![
-            (
+        [(
                 vec![
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--memory", "shared=true",
@@ -1320,8 +1319,7 @@ mod unit_tests {
                     ]
                 }"#,
                 true,
-            ),
-        ]
+            )]
         .iter()
         .for_each(|(cli, openapi, equal)| {
             compare_vm_config_cli_vs_json(cli, openapi, *equal);
@@ -1330,7 +1328,7 @@ mod unit_tests {
 
     #[test]
     fn test_valid_vm_config_pmem() {
-        vec![
+        [
             (
                 vec![
                     "cloud-hypervisor",
@@ -1394,7 +1392,7 @@ mod unit_tests {
 
     #[test]
     fn test_valid_vm_config_serial_console() {
-        vec![
+        [
             (
                 vec!["cloud-hypervisor", "--kernel", "/path/to/kernel"],
                 r#"{
@@ -1445,7 +1443,7 @@ mod unit_tests {
 
     #[test]
     fn test_valid_vm_config_serial_pty_console_pty() {
-        vec![
+        [
             (
                 vec!["cloud-hypervisor", "--kernel", "/path/to/kernel"],
                 r#"{
@@ -1593,7 +1591,7 @@ mod unit_tests {
 
     #[test]
     fn test_valid_vm_config_vdpa() {
-        vec![
+        [
             (
                 vec![
                     "cloud-hypervisor",
@@ -1640,7 +1638,7 @@ mod unit_tests {
 
     #[test]
     fn test_valid_vm_config_vsock() {
-        vec![
+        [
             (
                 vec![
                     "cloud-hypervisor",
@@ -1723,7 +1721,7 @@ mod unit_tests {
 
     #[test]
     fn test_valid_vm_config_tpm_socket() {
-        vec![(
+        [(
             vec![
                 "cloud-hypervisor",
                 "--kernel",

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -108,7 +108,7 @@ impl GuestNetworkConfig {
                 epoll::Event::new(epoll::Events::EPOLLIN, 0),
             )
             .expect("Cannot add 'tcp_listener' event to epoll");
-            let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); 1];
+            let mut events = [epoll::Event::new(epoll::Events::empty(), 0); 1];
             loop {
                 let num_events = match epoll::wait(epoll_fd, timeout * 1000_i32, &mut events[..]) {
                     Ok(num_events) => Ok(num_events),
@@ -252,7 +252,7 @@ impl DiskConfig for UbuntuDiskConfig {
             .join("ubuntu")
             .join("ci");
 
-        vec!["meta-data"].iter().for_each(|x| {
+        ["meta-data"].iter().for_each(|x| {
             rate_limited_copy(source_file_dir.join(x), cloud_init_directory.join(x))
                 .expect("Expect copying cloud-init meta-data to succeed");
         });
@@ -308,7 +308,7 @@ impl DiskConfig for UbuntuDiskConfig {
             .output()
             .expect("Expect creating disk image to succeed");
 
-        vec!["user-data", "meta-data", "network-config"]
+        ["user-data", "meta-data", "network-config"]
             .iter()
             .for_each(|x| {
                 std::process::Command::new("mcopy")

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -333,7 +333,7 @@ impl VersionMapped for VsockState {}
 
 impl<B> Vsock<B>
 where
-    B: VsockBackend,
+    B: VsockBackend + Sync,
 {
     /// Create a new virtio-vsock device with the given VM CID and vsock
     /// backend.

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -136,7 +136,7 @@ impl VsockPacket {
                     .translate_gva(access_platform, head.len() as usize),
                 VSOCK_PKT_HDR_SIZE,
             )
-            .ok_or(VsockError::GuestMemory)? as *mut u8,
+            .ok_or(VsockError::GuestMemory)?,
             buf: None,
             buf_size: 0,
         };
@@ -175,7 +175,7 @@ impl VsockPacket {
                     .translate_gva(access_platform, buf_desc.len() as usize),
                 pkt.buf_size,
             )
-            .ok_or(VsockError::GuestMemory)? as *mut u8,
+            .ok_or(VsockError::GuestMemory)?,
         );
 
         Ok(pkt)
@@ -221,7 +221,7 @@ impl VsockPacket {
                     .translate_gva(access_platform, head.len() as usize),
                 VSOCK_PKT_HDR_SIZE,
             )
-            .ok_or(VsockError::GuestMemory)? as *mut u8,
+            .ok_or(VsockError::GuestMemory)?,
             buf: Some(
                 get_host_address_range(
                     desc_chain.memory(),
@@ -230,7 +230,7 @@ impl VsockPacket {
                         .translate_gva(access_platform, buf_desc.len() as usize),
                     buf_size,
                 )
-                .ok_or(VsockError::GuestMemory)? as *mut u8,
+                .ok_or(VsockError::GuestMemory)?,
             ),
             buf_size,
         })
@@ -428,8 +428,8 @@ mod tests {
 
     fn set_pkt_len(len: u32, guest_desc: &GuestQDesc, mem: &GuestMemoryMmap) {
         let hdr_gpa = guest_desc.addr.get();
-        let hdr_ptr = get_host_address_range(mem, GuestAddress(hdr_gpa), VSOCK_PKT_HDR_SIZE)
-            .unwrap() as *mut u8;
+        let hdr_ptr =
+            get_host_address_range(mem, GuestAddress(hdr_gpa), VSOCK_PKT_HDR_SIZE).unwrap();
         let len_ptr = unsafe { hdr_ptr.add(HDROFF_LEN) };
 
         LittleEndian::write_u32(unsafe { std::slice::from_raw_parts_mut(len_ptr, 4) }, len);

--- a/virtio-devices/src/vsock/unix/muxer.rs
+++ b/virtio-devices/src/vsock/unix/muxer.rs
@@ -971,7 +971,7 @@ mod tests {
             self.init_pkt(local_port, peer_port, uapi::VSOCK_OP_RESPONSE);
             self.send();
 
-            let mut buf = vec![0u8; 32];
+            let mut buf = [0u8; 32];
             let len = stream.read(&mut buf[..]).unwrap();
             assert_eq!(&buf[..len], format!("OK {local_port}\n").as_bytes());
 

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -276,10 +276,7 @@ impl MemoryRangeTable {
     pub fn write_to(&self, fd: &mut dyn Write) -> Result<(), MigratableError> {
         // SAFETY: the slice is construted with the correct arguments
         fd.write_all(unsafe {
-            std::slice::from_raw_parts(
-                self.data.as_ptr() as *const MemoryRange as *const u8,
-                self.length() as usize,
-            )
+            std::slice::from_raw_parts(self.data.as_ptr() as *const u8, self.length() as usize)
         })
         .map_err(MigratableError::MigrateSocket)
     }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -43,6 +43,7 @@ use std::os::unix::net::UnixListener;
 use std::os::unix::net::UnixStream;
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::sync::mpsc::{Receiver, RecvError, SendError, Sender};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -347,9 +348,9 @@ pub fn start_vmm_thread(
                 vmm.setup_signal_handler()?;
 
                 vmm.control_loop(
-                    Arc::new(api_receiver),
+                    Rc::new(api_receiver),
                     #[cfg(feature = "guest_debug")]
-                    Arc::new(gdb_receiver),
+                    Rc::new(gdb_receiver),
                 )
             })
             .map_err(Error::VmmThreadSpawn)?
@@ -1791,8 +1792,8 @@ impl Vmm {
 
     fn control_loop(
         &mut self,
-        api_receiver: Arc<Receiver<ApiRequest>>,
-        #[cfg(feature = "guest_debug")] gdb_receiver: Arc<Receiver<gdb::GdbRequest>>,
+        api_receiver: Rc<Receiver<ApiRequest>>,
+        #[cfg(feature = "guest_debug")] gdb_receiver: Rc<Receiver<gdb::GdbRequest>>,
     ) -> Result<()> {
         const EPOLL_EVENTS_LEN: usize = 100;
 

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -229,7 +229,7 @@ impl SerialManager {
                     const EPOLL_EVENTS_LEN: usize = 3;
 
                     let mut events =
-                        vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
+                        [epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 
                     loop {
                         let num_events = match epoll::wait(epoll_fd, timeout, &mut events[..]) {


### PR DESCRIPTION
This PR fixes 4 clippy issues:

- [`unnecessary_cast`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast)
- [`useless_vec`](https://rust-lang.github.io/rust-clippy/master/index.html#/useless_vec)
- [`arc_with_non_send_sync`](https://rust-lang.github.io/rust-clippy/master/index.html#/arc_with_non_send_sync)
- `hidden-glob-reexports` (this rule has no link currently)

Most of these changes will not affect the behavior of the code, but to fix `arc_with_non_send_sync`, the `Arc` for `api_receiver` and `gdb_receiver` in `vmm/src/lib.rs` were replaced with `Rc` because these `Receiver` are only used in `vmm` thread.
