### PR TITLE
WIP: virtio-devices: vsock: add vsock_mode option

### DIFF
--- a/docs/vsock.md
+++ b/docs/vsock.md
@@ -50,14 +50,14 @@ The examples use __socat__ `>=1.7.4` to illustrate the VSOCK functionality. Howe
 
 ### Connecting from Host to Guest
 
-The host starts to listen on the defined port:
+The guest starts to listen on the defined port:
 
 `$ socat - VSOCK-LISTEN:1234`
 
-Once the host is listening, the guest can send data:
+Once the guest is listening, the host can send data:
 
 `echo -e "CONNECT 1234\\nHello from host!" | socat - UNIX-CONNECT:/tmp/ch.vsock
- 
+
 Note the string `CONNECT <port>` prepended to the actual data. It is possible for the guest to start listening on different ports, thus the specific command is needed to instruct VSOCK to which listener the host wants to connect. It needs to be sent once per connection. Once the connection established, data transfers can take place directly.
 
 ### Connecting from Guest to Host

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,7 +224,7 @@ pub struct TopLevel {
     vdpa: Vec<String>,
 
     #[argh(option, long = "vsock")]
-    /// cid=<context_id>, socket=<socket_path>, iommu=on|off, id=<device_id>, pci_segment=<segment_id>
+    /// cid=<context_id>, socket=<socket_path>, iommu=on|off, id=<device_id>, pci_segment=<segment_id>, vsock_mode=bidirectional|host2guest|guest2host
     vsock: Option<String>,
 
     #[argh(switch, long = "pvpanic")]

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1522,7 +1522,8 @@ impl VsockConfig {
             .add("cid")
             .add("iommu")
             .add("id")
-            .add("pci_segment");
+            .add("pci_segment")
+            .add("vsock_mode");
         parser.parse(vsock).map_err(Error::ParseVsock)?;
 
         let socket = parser
@@ -1543,6 +1544,10 @@ impl VsockConfig {
             .convert("pci_segment")
             .map_err(Error::ParseVsock)?
             .unwrap_or_default();
+        let vsock_mode = parser
+            .convert("vsock_mode")
+            .map_err(Error::ParseNetwork)?
+            .unwrap_or_default();
 
         Ok(VsockConfig {
             cid,
@@ -1550,6 +1555,7 @@ impl VsockConfig {
             iommu,
             id,
             pci_segment,
+            vsock_mode,
         })
     }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -11,7 +11,7 @@
 
 use crate::config::{
     ConsoleOutputMode, DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, UserDeviceConfig,
-    VdpaConfig, VhostMode, VmConfig, VsockConfig,
+    VdpaConfig, VhostMode, VmConfig, VsockConfig, VsockMode,
 };
 use crate::cpu::{CpuManager, CPU_MANAGER_ACPI_SIZE};
 use crate::device_tree::{DeviceNode, DeviceTree};
@@ -2858,9 +2858,13 @@ impl DeviceManager {
             .socket
             .to_str()
             .ok_or(DeviceManagerError::CreateVsockConvertPath)?;
-        let backend =
-            virtio_devices::vsock::VsockUnixBackend::new(vsock_cfg.cid, socket_path.to_string())
-                .map_err(DeviceManagerError::CreateVsockBackend)?;
+        let guest_to_host = matches!(vsock_cfg.vsock_mode, VsockMode::GuestToHost);
+        let backend = virtio_devices::vsock::VsockUnixBackend::new(
+            vsock_cfg.cid,
+            socket_path.to_string(),
+            guest_to_host,
+        )
+        .map_err(DeviceManagerError::CreateVsockBackend)?;
 
         let vsock_device = Arc::new(Mutex::new(
             virtio_devices::Vsock::new(


### PR DESCRIPTION
When starting a vm with vsock, Cloud hypervisor creates a new unix socket and bind it, no matter vsock application use it or not. However, sometimes we create a vm with vsock and never uses it as guest-listen mode, so it's useful to add a host_listen option to turn that off.

Also, fix a trival description in vsock.md.