### PR TITLE
vmm: default GDB to false when deserializing

### DIFF
--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -595,6 +595,7 @@ pub struct VmConfig {
     #[serde(default)]
     pub watchdog: bool,
     #[cfg(feature = "guest_debug")]
+    #[serde(default)]
     pub gdb: bool,
     pub platform: Option<PlatformConfig>,
     pub tpm: Option<TpmConfig>,


### PR DESCRIPTION
This fixes the valid VM config unit tests, which would otherwise fail to deserialize their expected JSON config due to the missing "gdb" field.