### PR TITLE
vmm: allow coredump no need pause firstly

### DIFF
--- a/vmm/src/coredump.rs
+++ b/vmm/src/coredump.rs
@@ -36,6 +36,8 @@ pub struct DumpState {
 pub enum GuestDebuggableError {
     Coredump(anyhow::Error),
     CoredumpFile(std::io::Error),
+    Pause(vm_migration::MigratableError),
+    Resume(vm_migration::MigratableError),
 }
 
 pub trait GuestDebuggable: vm_migration::Pausable {


### PR DESCRIPTION
It makes sense pause/resume in coredump() method, so api caller doesn't  need to pause vm firstly.

Also, add integration test of this modification.