### PR TITLE
vmm: Extend mshv ioctls in seccomp filters

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -170,6 +170,8 @@ mod mshv {
     pub const MSHV_GET_GPA_ACCESS_STATES: u64 = 0xc01c_b812;
     pub const MSHV_VP_TRANSLATE_GVA: u64 = 0xc020_b80e;
     pub const MSHV_CREATE_PARTITION: u64 = 0x4030_b801;
+    pub const MSHV_CREATE_DEVICE: u64 = 0xc00c_b813;
+    pub const MSHV_SET_DEVICE_ATTR: u64 = 0x4018_b814;
     pub const MSHV_VP_REGISTER_INTERCEPT_RESULT: u64 = 0x4030_b817;
 }
 #[cfg(feature = "mshv")]
@@ -206,6 +208,8 @@ fn create_vmm_ioctl_seccomp_rule_common_mshv() -> Result<Vec<SeccompRule>, Backe
             Eq,
             MSHV_VP_REGISTER_INTERCEPT_RESULT
         )?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_CREATE_DEVICE)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_DEVICE_ATTR)?],
     ])
 }
 


### PR DESCRIPTION
Add MSHV_CREATE_DEVICE, MSHV_SET_DEVICE_ATTR ioctls to filters. These ioctls are required to passthrough PCI devices on mshv.