### PR TITLE
arch: x86_64: re-enable KVM_FEATURE_ASYNC_PF_INT in CPUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ The following sections describe how to build and run Cloud Hypervisor.
 
 ## Host OS
 
-For required KVM functionality the minimum host kernel version is 4.11.  For
-adequate performance the minimum recommended host kernel version is 5.6. The
-majority of the CI currently tests with kernel version 5.15.
+For required KVM functionality and adequate performance the recommended host
+kernel version is 5.13. The majority of the CI currently tests with kernel
+version 5.15.
 
 ## Use Pre-built Binaries
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -39,7 +39,6 @@ const MTRR_EDX_BIT: u8 = 12; // Hypervisor ecx bit.
 const INVARIANT_TSC_EDX_BIT: u8 = 8; // Invariant TSC bit on 0x8000_0007 EDX
 
 // KVM feature bits
-const KVM_FEATURE_ASYNC_PF_INT_BIT: u8 = 14;
 #[cfg(feature = "tdx")]
 const KVM_FEATURE_CLOCKSOURCE_BIT: u8 = 0;
 #[cfg(feature = "tdx")]
@@ -675,14 +674,7 @@ pub fn generate_common_cpuid(
             0x8000_0008 => {
                 entry.eax = (entry.eax & 0xffff_ff00) | (phys_bits as u32 & 0xff);
             }
-            // Disable KVM_FEATURE_ASYNC_PF_INT
-            // This is required until we find out why the asynchronous page
-            // fault is generating unexpected behavior when using interrupt
-            // mechanism.
-            // TODO: Re-enable KVM_FEATURE_ASYNC_PF_INT (#2277)
             0x4000_0001 => {
-                entry.eax &= !(1 << KVM_FEATURE_ASYNC_PF_INT_BIT);
-
                 // These features are not supported by TDX
                 #[cfg(feature = "tdx")]
                 if tdx_enabled {


### PR DESCRIPTION
The commit b92fe648e925 (vmm: cpu: Disable KVM_FEATURE_ASYNC_PF_INT in CPUID) disabled APF (Asynchronous Page Fault) mechanism to address problem that makes vcpu thread spin 100%. As the actual issue is in KVM, which has been merged in commit 2f15d027c05f (KVM: x86: Properly handle APF vs disabled LAPIC situation) since 2021, so it's okay to re-enable APF now.