### PR TITLE
ci: Add AMD pass

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -151,7 +151,7 @@ pipeline {
                             }
                             steps {
                                 sh 'sudo modprobe openvswitch'
-                                sh 'scripts/dev_cli.sh tests --integration-live-migration'
+                                sh 'scripts/dev_cli.sh tests --integration-live-migration --integration -- -- --skip live_migration::live_migration_parallel::test_live_upgrade_watchdog --skip live_migration::live_migration_parallel::test_live_upgrade_watchdog_local'
                             }
                         }
                         stage('Run integration tests for musl') {
@@ -169,7 +169,7 @@ pipeline {
                             }
                             steps {
                                 sh 'sudo modprobe openvswitch'
-                                sh 'scripts/dev_cli.sh tests --integration-live-migration --libc musl'
+                                sh 'scripts/dev_cli.sh tests --integration-live-migration --libc musl -- -- --skip live_migration::live_migration_parallel::test_live_upgrade_watchdog --skip live_migration::live_migration_parallel::test_live_upgrade_watchdog_local'
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,6 +117,63 @@ pipeline {
                         }
                     }
                 }
+                stage('Worker build - AMD') {
+                    agent { node { label 'jammy-amd' } }
+                    when {
+                        beforeAgent true
+                        expression {
+                            return runWorkers
+                        }
+                    }
+                    stages {
+                        stage('Checkout') {
+                            steps {
+                                checkout scm
+                            }
+                        }
+                        stage('Prepare environment') {
+                            steps {
+                                sh 'scripts/prepare_vdpa.sh'
+                            }
+                        }
+                        stage('Run integration tests') {
+                            options {
+                                timeout(time: 1, unit: 'HOURS')
+                            }
+                            steps {
+                                sh 'sudo modprobe openvswitch'
+                                sh 'scripts/dev_cli.sh tests --integration'
+                            }
+                        }
+                        stage('Run live-migration integration tests') {
+                            options {
+                                timeout(time: 1, unit: 'HOURS')
+                            }
+                            steps {
+                                sh 'sudo modprobe openvswitch'
+                                sh 'scripts/dev_cli.sh tests --integration-live-migration'
+                            }
+                        }
+                        stage('Run integration tests for musl') {
+                            options {
+                                timeout(time: 1, unit: 'HOURS')
+                            }
+                            steps {
+                                sh 'sudo modprobe openvswitch'
+                                sh 'scripts/dev_cli.sh tests --integration --libc musl'
+                            }
+                        }
+                        stage('Run live-migration integration tests for musl') {
+                            options {
+                                timeout(time: 1, unit: 'HOURS')
+                            }
+                            steps {
+                                sh 'sudo modprobe openvswitch'
+                                sh 'scripts/dev_cli.sh tests --integration-live-migration --libc musl'
+                            }
+                        }
+                    }
+                }
                 stage('AArch64 worker build') {
                     agent { node { label 'bionic-arm64' } }
                     when {


### PR DESCRIPTION
Add jobs to run some tests on AMD. Jet it is a minimal run for Linux only glibc/musl.

Test failures:

<strike>common_parallel::test_cpu_hotplug
common_parallel::test_macvtap
common_parallel::test_macvtap_hotplug
common_parallel::test_memory_hotplug
common_parallel::test_tap_from_fd
common_parallel::test_virtio_mem

live_migration::live_migration_parallel::test_live_upgrade_watchdog
live_migration::live_migration_parallel::test_live_upgrade_watchdog_local</strike>
Failed duo to CMOS reset at reboot, fixed by #5645

<strike>common_parallel::test_vfio_user</strike>
Failing due to the SPDK build, fixed by updating the builds in the Docker container, see #5654.

live_migration::live_migration_parallel::test_live_migration_watchdog
live_migration::live_migration_parallel::test_live_migration_watchdog_local
Skip until the next release, see https://github.com/cloud-hypervisor/cloud-hypervisor/pull/5627#issuecomment-1665290738
