### PR TITLE
Initial patches to add support for MSHV based SEV-SNP guest.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,6 +51,9 @@ jobs:
       - name: Build (mshv)
         run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv"  -- -D warnings -D clippy::undocumented_unsafe_blocks
 
+      - name: Build (sev_snp)
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "sev_snp"  -- -D warnings -D clippy::undocumented_unsafe_blocks
+
       - name: Build (mshv + kvm)
         run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv,kvm"  -- -D warnings -D clippy::undocumented_unsafe_blocks
 

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -101,6 +101,14 @@ jobs:
           command: clippy
           args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "mshv,kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks
 
+      - name: Clippy (sev_snp)
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
+          command: clippy
+          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "sev_snp" -- -D warnings -D clippy::undocumented_unsafe_blocks
+
       - name: Clippy (kvm + tdx)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,6 +2340,7 @@ dependencies = [
  "bitflags 2.3.3",
  "block",
  "blocking",
+ "cfg-if",
  "devices",
  "epoll",
  "event_monitor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ guest_debug = ["vmm/guest_debug"]
 io_uring = ["vmm/io_uring"]
 kvm = ["vmm/kvm"]
 mshv = ["vmm/mshv"]
+sev_snp = ["vmm/sev_snp", "mshv"]
 tdx = ["vmm/tdx"]
 tracing = ["vmm/tracing", "tracer/tracing"]
 

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [features]
 default = []
+sev_snp = []
 tdx = []
 
 [dependencies]

--- a/docs/amd_sev_snp.md
+++ b/docs/amd_sev_snp.md
@@ -1,0 +1,38 @@
+# AMD SEV-SNP
+
+### WARNING
+This feature is only currently supported on MSHV.
+
+AMD Secure Encrypted Virtualization & Secure Nested Paging (SEV-SNP) is an AMD
+technology designed to add strong memory integrity protection to help prevent
+malicious hypervisor-based attacks like data replay, memory-remapping and more
+in order to create an isolated execution environment. Here are some useful
+links:
+
+* [SNP Homepage] (https://www.amd.com/en/processors/amd-secure-encrypted-virtualization)
+more information about SEV-SNP technical aspects, design and specification.
+
+## Cloud Hypervisor support
+
+It is required to use a machine which has enabled support for AMD SEV-SNP in
+the BIOS.
+
+On the Cloud Hypervisor side, all you need is to build the project with the
+`sev_snp` feature enabled:
+
+```bash
+cargo build --no-default-features --features "sev_snp"
+```
+
+**Note**
+Please note that `sev_snp` cannot be enabled in conjunction with `tdx` feature flag.
+
+You can run a SEV-SNP VM using the following command:
+
+```bash
+./cloud-hypervisor \
+     --platform sev_snp=on \
+     --cpus boot=1 \
+     --memory size=1G \
+     --disk path=ubuntu.img
+```

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0 OR BSD-3-Clause"
 [features]
 kvm = ["kvm-ioctls", "kvm-bindings", "vfio-ioctls/kvm"]
 mshv = ["mshv-ioctls", "mshv-bindings", "vfio-ioctls/mshv", "iced-x86"]
+sev_snp = []
 tdx = []
 
 [dependencies]

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -84,6 +84,11 @@ pub enum HypervisorError {
     ///
     #[error("Unsupported CPU:{0}")]
     UnsupportedCpu(#[source] anyhow::Error),
+    ///
+    /// Launching a VM with unsupported VM Type
+    ///
+    #[error("Unsupported VmType")]
+    UnsupportedVmType(),
 }
 
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -662,6 +662,9 @@ fn start_vmm(toplevel: TopLevel) -> Result<Option<String>, Error> {
 }
 
 fn main() {
+    #[cfg(all(feature = "tdx", feature = "sev_snp"))]
+    compile_error!("Feature 'tdx' and 'sev_snp' are mutually exclusive.");
+
     #[cfg(feature = "dhat-heap")]
     let _profiler = dhat::Profiler::new_heap();
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -11,6 +11,7 @@ guest_debug = ["kvm", "gdbstub", "gdbstub_arch"]
 io_uring = ["block/io_uring"]
 kvm = ["hypervisor/kvm", "vfio-ioctls/kvm", "vm-device/kvm", "pci/kvm"]
 mshv = ["hypervisor/mshv", "vfio-ioctls/mshv", "vm-device/mshv", "pci/mshv"]
+sev_snp = ["arch/sev_snp", "hypervisor/sev_snp"]
 tdx = ["arch/tdx", "hypervisor/tdx"]
 tracing = ["tracer/tracing"]
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -23,6 +23,7 @@ arch = { path = "../arch" }
 bitflags = "2.3.3"
 block = { path = "../block" }
 blocking = { version = "1.3.0", optional = true }
+cfg-if = "1.0.0"
 devices = { path = "../devices" }
 epoll = "4.3.3"
 event_monitor = { path = "../event_monitor" }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1312,6 +1312,8 @@ impl Vmm {
             &self.hypervisor,
             #[cfg(feature = "tdx")]
             false,
+            #[cfg(feature = "sev_snp")]
+            false,
         )
         .map_err(|e| {
             MigratableError::MigrateReceive(anyhow!(

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -89,6 +89,9 @@ pub struct PlatformConfig {
     #[cfg(feature = "tdx")]
     #[serde(default)]
     pub tdx: bool,
+    #[cfg(feature = "sev_snp")]
+    #[serde(default)]
+    pub sev_snp: bool,
 }
 
 impl Default for PlatformConfig {
@@ -101,6 +104,8 @@ impl Default for PlatformConfig {
             oem_strings: None,
             #[cfg(feature = "tdx")]
             tdx: false,
+            #[cfg(feature = "sev_snp")]
+            sev_snp: false,
         }
     }
 }


### PR DESCRIPTION
In this patch set, I am introducing a new feature flag called "snp" to barricade all SNP related features under it. Also refactored the VM creation workflow to make way for SEV-SNP guest creation. Along with it added support for setting the initial SNP guest policy required from MSHV prospective.

This fixes in task 1 for #4761 

CC: @liuw @russell-islam 