### PR TITLE
tests: Ensure sufficient nofile limit for VFIO tests

### DIFF
--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -185,6 +185,9 @@ sudo chmod a+rwX /dev/hugepages
 # Update max locked memory to 'unlimited' to avoid issues with vDPA
 ulimit -l unlimited
 
+# Set number of open descriptors high enough for VFIO tests to run
+ulimit -n 4096
+
 export RUST_BACKTRACE=1
 time cargo test $test_features "common_parallel::$test_filter" -- ${test_binary_args[*]}
 RES=$?


### PR DESCRIPTION
The VFIO tests based on the NVMe emulation framework require cause a high number of file descriptors to be opened on the system. On systems with a low limit on opened files, tests like test_vfio_user can possibly fail with "too many open files" exeption. This issue is fixed by raising the corresponding limit.

A tricky detail here is, that the limit has to be changed in the test container and not on the host. As the the container is executed in the privileged mode, the setting in it will override the host value.

Related: #5426