### PR TITLE
x86 emulator: add `Mov_moffs_AX` & `Mov_AX_moffs` (16,32,64)

### DIFF
--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -524,6 +524,13 @@ impl<'a, T: CpuStateManager> Emulator<'a, T> {
             (mov, Movzx_r64_rm8),
             (mov, Movzx_r32_rm16),
             (mov, Movzx_r64_rm16),
+            // MOV MOFFS
+            (mov, Mov_moffs16_AX),
+            (mov, Mov_AX_moffs16),
+            (mov, Mov_moffs32_EAX),
+            (mov, Mov_EAX_moffs32),
+            (mov, Mov_moffs64_RAX),
+            (mov, Mov_RAX_moffs64),
             // MOVS
             (movs, Movsd_m32_m32),
             (movs, Movsw_m16_m16),

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -36,7 +36,7 @@ pub mod kvm;
 #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
 pub mod mshv;
 
-/// Hypevisor related module
+/// Hypervisor related module
 mod hypervisor;
 
 /// Vm related module


### PR DESCRIPTION
Hi! While playing with some toy kernels as boot payload, I noticed that the emulator is not capable of emulating the following instructions:

- Mov_moffs16_AX
- Mov_AX_moffs16
- Mov_moffs32_EAX
- Mov_EAX_moffs32
- Mov_moffs64_RAX
- Mov_RAX_moffs64

This PR also adds unit tests.