### PR TITLE
vm-device: support batch update interrupt source group GSI

### DIFF
--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -98,9 +98,14 @@ impl Gic {
                     i as InterruptIndex,
                     InterruptSourceConfig::LegacyIrq(config),
                     false,
+                    false,
                 )
                 .map_err(Error::EnableInterrupt)?;
         }
+
+        self.interrupt_source_group
+            .set_gsi()
+            .map_err(Error::EnableInterrupt)?;
         Ok(())
     }
 

--- a/devices/src/legacy/gpio_pl061.rs
+++ b/devices/src/legacy/gpio_pl061.rs
@@ -361,7 +361,12 @@ mod tests {
             _index: InterruptIndex,
             _config: InterruptSourceConfig,
             _masked: bool,
+            _set_gsi: bool,
         ) -> result::Result<(), std::io::Error> {
+            Ok(())
+        }
+
+        fn set_gsi(&self) -> result::Result<(), std::io::Error> {
             Ok(())
         }
 

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -413,7 +413,12 @@ mod tests {
             _index: InterruptIndex,
             _config: InterruptSourceConfig,
             _masked: bool,
+            _set_gsi: bool,
         ) -> result::Result<(), std::io::Error> {
+            Ok(())
+        }
+
+        fn set_gsi(&self) -> result::Result<(), std::io::Error> {
             Ok(())
         }
 

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -365,7 +365,11 @@ mod tests {
             _index: InterruptIndex,
             _config: InterruptSourceConfig,
             _masked: bool,
+            _set_gsi: bool,
         ) -> result::Result<(), std::io::Error> {
+            Ok(())
+        }
+        fn set_gsi(&self) -> result::Result<(), std::io::Error> {
             Ok(())
         }
         fn notifier(&self, _index: InterruptIndex) -> Option<EventFd> {

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -485,7 +485,11 @@ mod tests {
             _index: InterruptIndex,
             _config: InterruptSourceConfig,
             _masked: bool,
+            _set_gsi: bool,
         ) -> result::Result<(), std::io::Error> {
+            Ok(())
+        }
+        fn set_gsi(&self) -> result::Result<(), std::io::Error> {
             Ok(())
         }
         fn notifier(&self, _index: InterruptIndex) -> Option<EventFd> {

--- a/fuzz/fuzz_targets/serial.rs
+++ b/fuzz/fuzz_targets/serial.rs
@@ -59,7 +59,11 @@ impl InterruptSourceGroup for TestInterrupt {
         _index: InterruptIndex,
         _config: InterruptSourceConfig,
         _masked: bool,
+        _set_gsi: bool,
     ) -> Result<(), std::io::Error> {
+        Ok(())
+    }
+    fn set_gsi(&self) -> Result<(), std::io::Error> {
         Ok(())
     }
     fn notifier(&self, _index: InterruptIndex) -> Option<EventFd> {

--- a/pci/src/msi.rs
+++ b/pci/src/msi.rs
@@ -205,9 +205,14 @@ impl MsiConfig {
                             idx as InterruptIndex,
                             InterruptSourceConfig::MsiIrq(config),
                             state.cap.vector_masked(idx),
+                            false,
                         )
                         .map_err(Error::UpdateInterruptRoute)?;
                 }
+
+                interrupt_source_group
+                    .set_gsi()
+                    .map_err(Error::EnableInterruptRoute)?;
 
                 interrupt_source_group
                     .enable()
@@ -262,6 +267,7 @@ impl MsiConfig {
                     idx as InterruptIndex,
                     InterruptSourceConfig::MsiIrq(config),
                     self.cap.vector_masked(idx),
+                    true,
                 ) {
                     error!("Failed updating vector: {:?}", e);
                 }

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -107,6 +107,7 @@ impl MsixConfig {
                             idx as InterruptIndex,
                             InterruptSourceConfig::MsiIrq(config),
                             state.masked,
+                            true,
                         )
                         .map_err(Error::UpdateInterruptRoute)?;
 
@@ -182,6 +183,7 @@ impl MsixConfig {
                         idx as InterruptIndex,
                         InterruptSourceConfig::MsiIrq(config),
                         table_entry.masked(),
+                        true,
                     ) {
                         error!("Failed updating vector: {:?}", e);
                     }
@@ -320,6 +322,7 @@ impl MsixConfig {
                 index as InterruptIndex,
                 InterruptSourceConfig::MsiIrq(config),
                 table_entry.masked(),
+                true,
             ) {
                 error!("Failed updating vector: {:?}", e);
             }

--- a/vm-device/src/interrupt/mod.rs
+++ b/vm-device/src/interrupt/mod.rs
@@ -147,10 +147,15 @@ pub trait InterruptSourceGroup: Send + Sync {
     /// * index: sub-index into the group.
     /// * config: configuration data for the interrupt source.
     /// * masked: if the interrupt is masked
+    /// * set_gsi: whehter update the GSI routing table.
     fn update(
         &self,
         index: InterruptIndex,
         config: InterruptSourceConfig,
         masked: bool,
+        set_gsi: bool,
     ) -> Result<()>;
+
+    /// Set the interrupt group GSI routing table.
+    fn set_gsi(&self) -> Result<()>;
 }


### PR DESCRIPTION
Split interrupt source group restore into two steps, first restore the irqfd for each interrupt source entry, and second restore the GSI routing of the entire interrupt source group.

This patch will reduce restore latency of the interrupt source group, and in a 200-concurrent restore test, the patch reduced the average IOAPIC restore time from 15ms to 1ms.