### PR TITLE
scripts: dev_cli: add possibly to use different container registry

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -8,7 +8,7 @@ CLI_NAME="Cloud Hypervisor"
 
 CTR_IMAGE_TAG="ghcr.io/cloud-hypervisor/cloud-hypervisor"
 CTR_IMAGE_VERSION="20230620-0"
-CTR_IMAGE="${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}"
+: "${CTR_IMAGE:=${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}}"
 
 DOCKER_RUNTIME="docker"
 


### PR DESCRIPTION
Currently if container registry is inaccessible the image will be built locally and that takes time. This patch adds support to use mirror registry. To use a different registry CTR_IMAGE environment variable must be set. For example:

CTR_IMAGE="registry/cloud-hypervisor" scripts/dev_cli.sh

or

export CTR_IMAGE="registry/cloud-hypervisor"
scripts/dev_cli.sh