### PR TITLE
build: Enable default features for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,13 +28,13 @@ jobs:
         with:
           toolchain: "1.67.1"
           command: build
-          args: --all --release --no-default-features --features "kvm,mshv" --target=x86_64-unknown-linux-gnu
+          args: --all --release --features mshv --target=x86_64-unknown-linux-gnu
       - name: Static Build
         uses: actions-rs/cargo@v1
         with:
           toolchain: "1.67.1"
           command: build
-          args: --all --release --no-default-features --features "kvm,mshv" --target=x86_64-unknown-linux-musl
+          args: --all --release --features mshv --target=x86_64-unknown-linux-musl
       - name: Install Rust toolchain (aarch64-unknown-linux-musl)
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
In this way, we are releasing binaries with all default features plus feature "mshv".