### PR TITLE
Dockerfile: Build SPDK for skylake

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -136,7 +136,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
        && ./scripts/pkgdep.sh \
        && apt-get clean \
        && ./configure --with-vfio-user \
-       && make -j $(nproc) \
+       && make -j $(nproc) TARGET_ARCHITECTURE=skylake \
        && mkdir /usr/local/bin/spdk-nvme \
        && cp ./build/bin/nvmf_tgt /usr/local/bin/spdk-nvme \
        && cp ./scripts/rpc.py /usr/local/bin/spdk-nvme \

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -7,7 +7,7 @@
 CLI_NAME="Cloud Hypervisor"
 
 CTR_IMAGE_TAG="ghcr.io/cloud-hypervisor/cloud-hypervisor"
-CTR_IMAGE_VERSION="20230620-0"
+CTR_IMAGE_VERSION="20230804-0"
 : "${CTR_IMAGE:=${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}}"
 
 DOCKER_RUNTIME="docker"


### PR DESCRIPTION
As the container image can be used on both Intel and AMD, ensure the SPDK binaries are compatible. This implies -march=skylake passed to the underlaying toolchain.

Ref: https://github.com/cloud-hypervisor/cloud-hypervisor/pull/5627#issuecomment-1665095193