### PR TITLE
fuzz, vmm: Avoid infinite loop in CMOS fuzzer

### DIFF
--- a/fuzz/fuzz_targets/cmos.rs
+++ b/fuzz/fuzz_targets/cmos.rs
@@ -27,7 +27,7 @@ fuzz_target!(|bytes| {
         u64::from_le_bytes(below_4g),
         u64::from_le_bytes(above_4g),
         EventFd::new(EFD_NONBLOCK).unwrap(),
-        Arc::new(AtomicBool::default()),
+        None,
     );
 
     let mut i = 16;

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1630,7 +1630,7 @@ impl DeviceManager {
                 mem_below_4g,
                 mem_above_4g,
                 reset_evt,
-                vcpus_kill_signalled,
+                Some(vcpus_kill_signalled),
             )));
 
             self.bus_devices


### PR DESCRIPTION
With the addition of the spinning waiting for the exit event to be
received in the CMOS device a regression was introduced into the CMOS
fuzzer. Since there is nothing to receive the event in the fuzzer and
there is nothing to update the bit the that the device is looping on;
introducing an infinite loop.

Use an Option<> type so that when running the device in the fuzzer no
Arc<AtomicBool> is provided effectively disabling the spinning logic.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=61165

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
