### PR TITLE
tests: Re-enable live migration tests for AMD

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -151,7 +151,7 @@ pipeline {
                             }
                             steps {
                                 sh 'sudo modprobe openvswitch'
-                                sh 'scripts/dev_cli.sh tests --integration-live-migration --integration -- -- --skip live_migration::live_migration_parallel::test_live_upgrade_watchdog --skip live_migration::live_migration_parallel::test_live_upgrade_watchdog_local'
+                                sh 'scripts/dev_cli.sh tests --integration-live-migration'
                             }
                         }
                         stage('Run integration tests for musl') {
@@ -169,7 +169,7 @@ pipeline {
                             }
                             steps {
                                 sh 'sudo modprobe openvswitch'
-                                sh 'scripts/dev_cli.sh tests --integration-live-migration --libc musl -- -- --skip live_migration::live_migration_parallel::test_live_upgrade_watchdog --skip live_migration::live_migration_parallel::test_live_upgrade_watchdog_local'
+                                sh 'scripts/dev_cli.sh tests --integration-live-migration --libc musl'
                             }
                         }
                     }

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -156,7 +156,7 @@ update_workloads() {
     popd
 
     # Download Cloud Hypervisor binary from its last stable release
-    LAST_RELEASE_VERSION="v30.0"
+    LAST_RELEASE_VERSION="v34.0"
     CH_RELEASE_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$LAST_RELEASE_VERSION/cloud-hypervisor-static-aarch64"
     CH_RELEASE_NAME="cloud-hypervisor-static-aarch64"
     pushd $WORKLOADS_DIR

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -46,7 +46,7 @@ fi
 popd
 
 # Download Cloud Hypervisor binary from its last stable release
-LAST_RELEASE_VERSION="v30.0"
+LAST_RELEASE_VERSION="v34.0"
 CH_RELEASE_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$LAST_RELEASE_VERSION/cloud-hypervisor-static"
 CH_RELEASE_NAME="cloud-hypervisor-static"
 pushd $WORKLOADS_DIR


### PR DESCRIPTION
These had to be previously disabled because a released binary has to be used in course of the test scenario. The necessary functionality is now supported with the release 34.0, thus these tests should now pass.

Fixes: #5660

Signed-off-by: Anatol Belski <anbelski@linux.microsoft.com>