### PR TITLE
devices: pvpanic: Clean up struct visibility

### DIFF
--- a/devices/src/pvpanic.rs
+++ b/devices/src/pvpanic.rs
@@ -38,9 +38,8 @@ pub enum PvPanicError {
     RetrievePciConfigurationState(#[source] anyhow::Error),
 }
 
-#[allow(dead_code)]
 #[derive(Copy, Clone)]
-pub enum PvPanicSubclass {
+enum PvPanicSubclass {
     Other = 0x80,
 }
 


### PR DESCRIPTION
There is no need for this struct to be public and since it is used in
this module the #[allow(dead_code)] invocation can be removed.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
