### PR TITLE
Fix beta clippy issues

### DIFF
--- a/block/src/async_io.rs
+++ b/block/src/async_io.rs
@@ -51,7 +51,7 @@ enum BlockSize {
 }
 
 impl DiskTopology {
-    fn is_block_device(f: &mut File) -> std::io::Result<bool> {
+    fn is_block_device(f: &File) -> std::io::Result<bool> {
         let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
         // SAFETY: FFI call with a valid fd and buffer
         let ret = unsafe { libc::fstat(f.as_raw_fd(), stat.as_mut_ptr()) };
@@ -65,7 +65,7 @@ impl DiskTopology {
     }
 
     // libc::ioctl() takes different types on different architectures
-    fn query_block_size(f: &mut File, block_size_type: BlockSize) -> std::io::Result<u64> {
+    fn query_block_size(f: &File, block_size_type: BlockSize) -> std::io::Result<u64> {
         let mut block_size = 0;
         // SAFETY: FFI call with correct arguments
         let ret = unsafe {
@@ -87,7 +87,7 @@ impl DiskTopology {
         Ok(block_size)
     }
 
-    pub fn probe(f: &mut File) -> std::io::Result<Self> {
+    pub fn probe(f: &File) -> std::io::Result<Self> {
         if !Self::is_block_device(f)? {
             return Ok(DiskTopology::default());
         }

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -36,7 +36,7 @@ impl DiskFile for RawFileDisk {
     }
 
     fn topology(&mut self) -> DiskTopology {
-        if let Ok(topology) = DiskTopology::probe(&mut self.file) {
+        if let Ok(topology) = DiskTopology::probe(&self.file) {
             topology
         } else {
             warn!("Unable to get device topology. Using default topology");

--- a/block/src/raw_sync.rs
+++ b/block/src/raw_sync.rs
@@ -33,7 +33,7 @@ impl DiskFile for RawFileDiskSync {
     }
 
     fn topology(&mut self) -> DiskTopology {
-        if let Ok(topology) = DiskTopology::probe(&mut self.file) {
+        if let Ok(topology) = DiskTopology::probe(&self.file) {
             topology
         } else {
             warn!("Unable to get device topology. Using default topology");

--- a/block/src/vhdx/vhdx_metadata.rs
+++ b/block/src/vhdx/vhdx_metadata.rs
@@ -133,7 +133,7 @@ impl DiskSpec {
                     .map_err(VhdxMetadataError::ReadMetadata)?;
 
                 // MUST be at least 1 MiB and not greater than 256 MiB
-                if disk_spec.block_size < BLOCK_SIZE_MIN && disk_spec.block_size > BLOCK_SIZE_MAX {
+                if disk_spec.block_size < BLOCK_SIZE_MIN || disk_spec.block_size > BLOCK_SIZE_MAX {
                     return Err(VhdxMetadataError::InvalidBlockSize);
                 }
 

--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -18,8 +18,8 @@ fn get_op<T: CpuStateManager>(
     insn: &Instruction,
     op_index: u32,
     op_size: usize,
-    state: &mut T,
-    platform: &mut dyn PlatformEmulator<CpuState = T>,
+    state: &T,
+    platform: &dyn PlatformEmulator<CpuState = T>,
 ) -> Result<u64, PlatformError> {
     if insn.op_count() < op_index + 1 {
         return Err(PlatformError::InvalidOperand(anyhow!(

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -38,7 +38,7 @@ impl TxVirtio {
     pub fn process_desc_chain(
         &mut self,
         mem: &GuestMemoryMmap,
-        tap: &mut Tap,
+        tap: &Tap,
         queue: &mut Queue,
         rate_limiter: &mut Option<RateLimiter>,
         access_platform: Option<&Arc<dyn AccessPlatform>>,
@@ -164,7 +164,7 @@ impl RxVirtio {
     pub fn process_desc_chain(
         &mut self,
         mem: &GuestMemoryMmap,
-        tap: &mut Tap,
+        tap: &Tap,
         queue: &mut Queue,
         rate_limiter: &mut Option<RateLimiter>,
         access_platform: Option<&Arc<dyn AccessPlatform>>,
@@ -357,7 +357,7 @@ impl NetQueuePair {
     ) -> Result<bool, NetQueuePairError> {
         let tx_tap_retry = self.tx.process_desc_chain(
             mem,
-            &mut self.tap,
+            &self.tap,
             queue,
             &mut self.tx_rate_limiter,
             self.access_platform.as_ref(),
@@ -407,7 +407,7 @@ impl NetQueuePair {
     ) -> Result<bool, NetQueuePairError> {
         self.rx_desc_avail = !self.rx.process_desc_chain(
             mem,
-            &mut self.tap,
+            &self.tap,
             queue,
             &mut self.rx_rate_limiter,
             self.access_platform.as_ref(),

--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -394,7 +394,7 @@ fn rest_api_do_command(toplevel: &TopLevel, socket: &mut UnixStream) -> ApiResul
 }
 
 #[cfg(feature = "dbus_api")]
-fn dbus_api_do_command(toplevel: &TopLevel, proxy: &mut DBusApi1ProxyBlocking<'_>) -> ApiResult {
+fn dbus_api_do_command(toplevel: &TopLevel, proxy: &DBusApi1ProxyBlocking<'_>) -> ApiResult {
     match toplevel.command {
         SubCommandEnum::Boot(_) => proxy.api_vm_boot(),
         SubCommandEnum::Delete(_) => proxy.api_vm_delete(),

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -97,7 +97,7 @@ impl VirtioPciCommonConfig {
         &mut self,
         offset: u64,
         data: &mut [u8],
-        queues: &mut [Queue],
+        queues: &[Queue],
         device: Arc<Mutex<dyn VirtioDevice>>,
     ) {
         assert!(data.len() <= 8);
@@ -385,35 +385,35 @@ mod tests {
         // Can set all bits of driver_status.
         regs.write(0x14, &[0x55], &mut queues, dev.clone());
         let mut read_back = vec![0x00];
-        regs.read(0x14, &mut read_back, &mut queues, dev.clone());
+        regs.read(0x14, &mut read_back, &queues, dev.clone());
         assert_eq!(read_back[0], 0x55);
 
         // The config generation register is read only.
         regs.write(0x15, &[0xaa], &mut queues, dev.clone());
         let mut read_back = vec![0x00];
-        regs.read(0x15, &mut read_back, &mut queues, dev.clone());
+        regs.read(0x15, &mut read_back, &queues, dev.clone());
         assert_eq!(read_back[0], 0x55);
 
         // Device features is read-only and passed through from the device.
         regs.write(0x04, &[0, 0, 0, 0], &mut queues, dev.clone());
         let mut read_back = vec![0, 0, 0, 0];
-        regs.read(0x04, &mut read_back, &mut queues, dev.clone());
+        regs.read(0x04, &mut read_back, &queues, dev.clone());
         assert_eq!(LittleEndian::read_u32(&read_back), DUMMY_FEATURES as u32);
 
         // Feature select registers are read/write.
         regs.write(0x00, &[1, 2, 3, 4], &mut queues, dev.clone());
         let mut read_back = vec![0, 0, 0, 0];
-        regs.read(0x00, &mut read_back, &mut queues, dev.clone());
+        regs.read(0x00, &mut read_back, &queues, dev.clone());
         assert_eq!(LittleEndian::read_u32(&read_back), 0x0403_0201);
         regs.write(0x08, &[1, 2, 3, 4], &mut queues, dev.clone());
         let mut read_back = vec![0, 0, 0, 0];
-        regs.read(0x08, &mut read_back, &mut queues, dev.clone());
+        regs.read(0x08, &mut read_back, &queues, dev.clone());
         assert_eq!(LittleEndian::read_u32(&read_back), 0x0403_0201);
 
         // 'queue_select' can be read and written.
         regs.write(0x16, &[0xaa, 0x55], &mut queues, dev.clone());
         let mut read_back = vec![0x00, 0x00];
-        regs.read(0x16, &mut read_back, &mut queues, dev);
+        regs.read(0x16, &mut read_back, &queues, dev);
         assert_eq!(read_back[0], 0xaa);
         assert_eq!(read_back[1], 0x55);
     }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1116,7 +1116,7 @@ impl PciDevice for VirtioPciDevice {
             o if o < COMMON_CONFIG_BAR_OFFSET + COMMON_CONFIG_SIZE => self.common_config.read(
                 o - COMMON_CONFIG_BAR_OFFSET,
                 data,
-                &mut self.queues,
+                &self.queues,
                 self.device.clone(),
             ),
             o if (ISR_CONFIG_BAR_OFFSET..ISR_CONFIG_BAR_OFFSET + ISR_CONFIG_SIZE).contains(&o) => {

--- a/virtio-devices/src/vsock/csm/txbuf.rs
+++ b/virtio-devices/src/vsock/csm/txbuf.rs
@@ -213,9 +213,7 @@ mod tests {
     fn test_push_wrap() {
         let mut txbuf = TxBuf::new();
         let mut sink = TestSink::new();
-        let mut tmp: Vec<u8> = Vec::new();
-
-        tmp.resize(TxBuf::SIZE - 2, 0);
+        let tmp: Vec<u8> = vec![0; TxBuf::SIZE - 2];
         txbuf.push(tmp.as_slice()).unwrap();
         txbuf.flush_to(&mut sink).unwrap();
         sink.clear();

--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -85,7 +85,7 @@ impl Ord for BusRange {
 
 impl PartialOrd for BusRange {
     fn partial_cmp(&self, other: &BusRange) -> Option<Ordering> {
-        self.base.partial_cmp(&other.base)
+        Some(self.cmp(other))
     }
 }
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1776,8 +1776,7 @@ impl Cpu {
             _reserved: 0,
         };
 
-        let mut mat_data: Vec<u8> = Vec::new();
-        mat_data.resize(std::mem::size_of_val(&lapic), 0);
+        let mut mat_data: Vec<u8> = vec![0; std::mem::size_of_val(&lapic)];
         // SAFETY: mat_data is large enough to hold lapic
         unsafe { *(mat_data.as_mut_ptr() as *mut LocalX2Apic) = lapic };
 

--- a/vmm/src/sigwinch_listener.rs
+++ b/vmm/src/sigwinch_listener.rs
@@ -118,7 +118,7 @@ unsafe fn close_unused_fds(keep_fds: &mut [RawFd]) {
     }
 }
 
-fn set_foreground_process_group(tty: &mut File) -> io::Result<()> {
+fn set_foreground_process_group(tty: &File) -> io::Result<()> {
     // SAFETY: trivially safe.
     let my_pgrp = unsafe { getpgrp() };
     // SAFETY: we have borrowed tty.
@@ -155,7 +155,7 @@ fn set_foreground_process_group(tty: &mut File) -> io::Result<()> {
     Ok(())
 }
 
-fn sigwinch_listener_main(seccomp_filter: BpfProgram, tx: File, mut tty: File) -> ! {
+fn sigwinch_listener_main(seccomp_filter: BpfProgram, tx: File, tty: File) -> ! {
     // SAFETY: any references to these file descriptors are
     // unreachable, because this function never returns.
     unsafe {
@@ -172,7 +172,7 @@ fn sigwinch_listener_main(seccomp_filter: BpfProgram, tx: File, mut tty: File) -
 
     register_signal_handler(SIGWINCH, sigwinch_handler).unwrap();
 
-    set_foreground_process_group(&mut tty).unwrap();
+    set_foreground_process_group(&tty).unwrap();
     drop(tty);
 
     notify();


### PR DESCRIPTION
- block: vhdx: Fix block size check
- block: async_io: Remove unnecessary mut from reference
- net_util: queue_pair: Remove unnecessary mut from reference
- hypervisor: x86: emulator: Remove unncessary mut from reference
- vm-device: bus: Fix incorrect partial_cmp implementation
- virtio-devices: transport: Remove unnecessary mut from reference
- virtio-devices: vsock: Fix slow vector initialization
- vmm: cpu: Fix slow vector initialization
- ch-remote: dbus: Remove unnecessary mut from reference
- vmm: device_manager: Remove unnecessary mut from reference
- vmm: sigwinch_listener: Remove unncessary mut from reference
