### PR TITLE
Unix Socket backend for Serial Port

### DIFF
--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -166,8 +166,8 @@ impl Serial {
         Self::new(id, interrupt, None, state)
     }
 
-    pub fn set_out(&mut self, out: Box<dyn io::Write + Send>) {
-        self.out = Some(out);
+    pub fn set_out(&mut self, out: Option<Box<dyn io::Write + Send>>) {
+        self.out = out;
     }
 
     /// Queues raw bytes for the guest to read and signals the interrupt if the line status would

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -201,8 +201,8 @@ impl Pl011 {
         }
     }
 
-    pub fn set_out(&mut self, out: Box<dyn io::Write + Send>) {
-        self.out = Some(out);
+    pub fn set_out(&mut self, out: Option<Box<dyn io::Write + Send>>) {
+        self.out = out;
     }
 
     fn state(&self) -> Pl011State {

--- a/src/main.rs
+++ b/src/main.rs
@@ -808,11 +808,13 @@ mod unit_tests {
                 file: None,
                 mode: ConsoleOutputMode::Null,
                 iommu: false,
+                socket: None,
             },
             console: ConsoleConfig {
                 file: None,
                 mode: ConsoleOutputMode::Tty,
                 iommu: false,
+                socket: None,
             },
             devices: None,
             user_devices: None,

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -947,9 +947,11 @@ components:
       properties:
         file:
           type: string
+        socket:
+          type: string
         mode:
           type: string
-          enum: [Off, Pty, Tty, File, Null]
+          enum: [Off, Pty, Tty, File, Socket, Null]
         iommu:
           type: boolean
           default: false

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -395,6 +395,9 @@ pub enum DeviceManagerError {
     /// No support for device passthrough
     NoDevicePassthroughSupport,
 
+    /// No socket option support for console device
+    NoSocketOptionSupportForConsoleDevice,
+
     /// Failed to resize virtio-balloon
     VirtioBalloonResize(virtio_devices::balloon::Error),
 
@@ -1995,6 +1998,9 @@ impl DeviceManager {
                     Endpoint::File(stdout)
                 }
             }
+            ConsoleOutputMode::Socket => {
+                return Err(DeviceManagerError::NoSocketOptionSupportForConsoleDevice);
+            }
             ConsoleOutputMode::Null => Endpoint::Null,
             ConsoleOutputMode::Off => return Ok(None),
         };
@@ -2074,15 +2080,19 @@ impl DeviceManager {
                 let _ = self.set_raw_mode(&out);
                 Some(Box::new(out))
             }
-            ConsoleOutputMode::Off | ConsoleOutputMode::Null => None,
+            ConsoleOutputMode::Off | ConsoleOutputMode::Null | ConsoleOutputMode::Socket => None,
         };
         if serial_config.mode != ConsoleOutputMode::Off {
             let serial = self.add_serial_device(interrupt_manager, serial_writer)?;
             self.serial_manager = match serial_config.mode {
-                ConsoleOutputMode::Pty | ConsoleOutputMode::Tty => {
-                    let serial_manager =
-                        SerialManager::new(serial, self.serial_pty.clone(), serial_config.mode)
-                            .map_err(DeviceManagerError::CreateSerialManager)?;
+                ConsoleOutputMode::Pty | ConsoleOutputMode::Tty | ConsoleOutputMode::Socket => {
+                    let serial_manager = SerialManager::new(
+                        serial,
+                        self.serial_pty.clone(),
+                        serial_config.mode,
+                        serial_config.socket,
+                    )
+                    .map_err(DeviceManagerError::CreateSerialManager)?;
                     if let Some(mut serial_manager) = serial_manager {
                         serial_manager
                             .start_thread(

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2250,11 +2250,13 @@ mod unit_tests {
                 file: None,
                 mode: ConsoleOutputMode::Null,
                 iommu: false,
+                socket: None,
             },
             console: ConsoleConfig {
                 file: None,
                 mode: ConsoleOutputMode::Tty,
                 iommu: false,
+                socket: None,
             },
             devices: None,
             user_devices: None,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -440,6 +440,7 @@ pub enum ConsoleOutputMode {
     Pty,
     Tty,
     File,
+    Socket,
     Null,
 }
 
@@ -450,6 +451,7 @@ pub struct ConsoleConfig {
     pub mode: ConsoleOutputMode,
     #[serde(default)]
     pub iommu: bool,
+    pub socket: Option<PathBuf>,
 }
 
 pub fn default_consoleconfig_file() -> Option<PathBuf> {
@@ -555,6 +557,7 @@ pub fn default_serial() -> ConsoleConfig {
         file: None,
         mode: ConsoleOutputMode::Null,
         iommu: false,
+        socket: None,
     }
 }
 
@@ -563,6 +566,7 @@ pub fn default_console() -> ConsoleConfig {
         file: None,
         mode: ConsoleOutputMode::Tty,
         iommu: false,
+        socket: None,
     }
 }
 


### PR DESCRIPTION
Cloud-Hypervisor takes a path for Unix Socket, where it will listen
on. Users can connect to the other end of the socket and access serial
port on the guest.

"--serial unix=/path/to/socket" is the cmdline option to pass to
    cloud-hypervisor.

Users can use socat like below to access guest's serial port once the
guest starts to boot:

        socat -,crnl UNIX-CONNECT:/path/to/socket