### PR TITLE
emulator: bugfix wrapping add

### DIFF
--- a/hypervisor/src/arch/x86/emulator/instructions/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mod.rs
@@ -124,7 +124,7 @@ fn memory_operand_address<T: CpuStateManager>(
         address += index;
     }
 
-    address += insn.memory_displacement64();
+    address = address.wrapping_add(insn.memory_displacement64());
 
     // Translate to a linear address.
     state.linearize(insn.memory_segment(), address, write)


### PR DESCRIPTION
This is a bugfix for the emulator that we discovered when executing our test suite in debug mode.

Example instruction:
`c7 40 a0 00 10 00 00    movl   $0x1000,-0x60(%rax)`

rax is 0xfee003e0 and the displacement is negative 0x60. The effective address is then 0xfee00380. This is perfectly valid.

