### PR TITLE
Add image type argument

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -799,6 +799,8 @@ components:
         direct:
           type: boolean
           default: false
+        image_type:
+          type: string
         iommu:
           type: boolean
           default: false

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -744,6 +744,25 @@ impl MemoryConfig {
     }
 }
 
+#[derive(Debug)]
+pub enum ParseImageTypeError {
+    InvalidValue(String),
+}
+
+impl FromStr for ImageType {
+    type Err = ParseImageTypeError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "raw" => Ok(ImageType::Raw),
+            "qcow2" => Ok(ImageType::Qcow2),
+            "vhdx" => Ok(ImageType::Vhdx),
+            "fixed_vhd" => Ok(ImageType::FixedVhd),
+            _ => Err(ParseImageTypeError::InvalidValue(s.to_owned())),
+        }
+    }
+}
+
 impl DiskConfig {
     pub fn parse(disk: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -751,6 +770,7 @@ impl DiskConfig {
             .add("path")
             .add("readonly")
             .add("direct")
+            .add("image_type")
             .add("iommu")
             .add("queue_size")
             .add("num_queues")
@@ -778,6 +798,9 @@ impl DiskConfig {
             .map_err(Error::ParseDisk)?
             .unwrap_or(Toggle(false))
             .0;
+        let image_type = parser
+            .convert("image_type")
+            .map_err(Error::ParseDisk)?;
         let iommu = parser
             .convert::<Toggle>("iommu")
             .map_err(Error::ParseDisk)?
@@ -862,6 +885,7 @@ impl DiskConfig {
             path,
             readonly,
             direct,
+            image_type,
             iommu,
             num_queues,
             queue_size,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -191,12 +191,22 @@ pub enum VhostMode {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum ImageType {
+    FixedVhd,
+    Qcow2,
+    Raw,
+    Vhdx,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DiskConfig {
     pub path: Option<PathBuf>,
     #[serde(default)]
     pub readonly: bool,
     #[serde(default)]
     pub direct: bool,
+    #[serde(default)]
+    pub image_type: Option<ImageType>,
     #[serde(default)]
     pub iommu: bool,
     #[serde(default = "default_diskconfig_num_queues")]
@@ -236,6 +246,7 @@ impl Default for DiskConfig {
             readonly: false,
             direct: false,
             iommu: false,
+            image_type: None,
             num_queues: default_diskconfig_num_queues(),
             queue_size: default_diskconfig_queue_size(),
             vhost_user: false,


### PR DESCRIPTION
cloud-hypervisor fails to detect the image type for disks with a 4k sector size due to misaligned reads in the `block::detect_image_type` and `VhdFooter::new` functions. To fix this, I added a new optional 'type' argument to the block device parameter. If provided, the `detect_image_log` logic will not be used. If not provided, the `detect_image_type` logic will be used.

```
--disk path=/dev/nvme1n1,num_queues=8,queue_size=128,direct=true,type=raw
```
