### PR TITLE
build: Use focal version of azure-cli client on aarch64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,7 +207,7 @@ pipeline {
                         }
                         stage('Install azure-cli') {
                             steps {
-                                installAzureCli('bionic', 'arm64')
+                                installAzureCli('focal', 'arm64')
                             }
                         }
                         stage('Download Windows image') {


### PR DESCRIPTION
The worker is running focal not bionic - this fixes build issues on that
worker machine due to the bionic version not being installable.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
