### PR TITLE
build: Bump acpi_tables version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acpi_tables"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#05a609136387cc1cc9b499cee4320020325c263f"
+source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#1029d22777f07b04849234bbe756da34a6df2913"
 dependencies = [
  "zerocopy 0.6.1",
 ]

--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -134,7 +134,7 @@ impl Aml for AcpiGedDevice {
                 &aml::Name::new(
                     "_CRS".into(),
                     &aml::ResourceTemplate::new(vec![&aml::AddressSpace::new_memory(
-                        aml::AddressSpaceCachable::NotCacheable,
+                        aml::AddressSpaceCacheable::NotCacheable,
                         true,
                         self.address.0,
                         self.address.0 + GED_DEVICE_ACPI_SIZE as u64 - 1,

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acpi_tables"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#05a609136387cc1cc9b499cee4320020325c263f"
+source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#1029d22777f07b04849234bbe756da34a6df2913"
 dependencies = [
  "zerocopy",
 ]
@@ -1032,6 +1032,7 @@ dependencies = [
  "arch",
  "bitflags 2.3.3",
  "block",
+ "cfg-if",
  "devices",
  "epoll",
  "event_monitor",

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -2019,7 +2019,7 @@ impl Aml for CpuManager {
                     &aml::Name::new(
                         "_CRS".into(),
                         &aml::ResourceTemplate::new(vec![&aml::AddressSpace::new_memory(
-                            aml::AddressSpaceCachable::NotCacheable,
+                            aml::AddressSpaceCacheable::NotCacheable,
                             true,
                             acpi_address.0,
                             acpi_address.0 + CPU_MANAGER_ACPI_SIZE as u64 - 1,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4383,7 +4383,7 @@ impl Aml for DeviceManager {
                 &aml::Name::new(
                     "_CRS".into(),
                     &aml::ResourceTemplate::new(vec![&aml::AddressSpace::new_memory(
-                        aml::AddressSpaceCachable::NotCacheable,
+                        aml::AddressSpaceCacheable::NotCacheable,
                         true,
                         self.acpi_address.0,
                         self.acpi_address.0 + DEVICE_MANAGER_ACPI_SIZE as u64 - 1,

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -2331,7 +2331,7 @@ impl Aml for MemoryMethods {
                 &aml::Name::new(
                     "MR64".into(),
                     &aml::ResourceTemplate::new(vec![&aml::AddressSpace::new_memory(
-                        aml::AddressSpaceCachable::Cacheable,
+                        aml::AddressSpaceCacheable::Cacheable,
                         true,
                         0x0000_0000_0000_0000u64,
                         0xFFFF_FFFF_FFFF_FFFEu64,
@@ -2414,7 +2414,7 @@ impl Aml for MemoryManager {
                     &aml::Name::new(
                         "_CRS".into(),
                         &aml::ResourceTemplate::new(vec![&aml::AddressSpace::new_memory(
-                            aml::AddressSpaceCachable::NotCacheable,
+                            aml::AddressSpaceCacheable::NotCacheable,
                             true,
                             acpi_address.0,
                             acpi_address.0 + MEMORY_MANAGER_ACPI_SIZE as u64 - 1,
@@ -2510,7 +2510,7 @@ impl Aml for MemoryManager {
                         &aml::Name::new(
                             "_CRS".into(),
                             &aml::ResourceTemplate::new(vec![&aml::AddressSpace::new_memory(
-                                aml::AddressSpaceCachable::NotCacheable,
+                                aml::AddressSpaceCacheable::NotCacheable,
                                 true,
                                 min,
                                 max,

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -348,7 +348,7 @@ impl Aml for PciSegment {
                     #[cfg(target_arch = "x86_64")]
                     &aml::IO::new(0xcf8, 0xcf8, 1, 0x8),
                     &aml::AddressSpace::new_memory(
-                        aml::AddressSpaceCachable::NotCacheable,
+                        aml::AddressSpaceCacheable::NotCacheable,
                         true,
                         layout::MEM_32BIT_DEVICES_START.0 as u32,
                         (layout::MEM_32BIT_DEVICES_START.0 + layout::MEM_32BIT_DEVICES_SIZE - 1)
@@ -356,7 +356,7 @@ impl Aml for PciSegment {
                         None,
                     ),
                     &aml::AddressSpace::new_memory(
-                        aml::AddressSpaceCachable::NotCacheable,
+                        aml::AddressSpaceCacheable::NotCacheable,
                         true,
                         self.start_of_device_area,
                         self.end_of_device_area,
@@ -379,7 +379,7 @@ impl Aml for PciSegment {
                         layout::PCI_MMIO_CONFIG_SIZE_PER_SEGMENT as u32,
                     ),
                     &aml::AddressSpace::new_memory(
-                        aml::AddressSpaceCachable::NotCacheable,
+                        aml::AddressSpaceCacheable::NotCacheable,
                         true,
                         self.start_of_device_area,
                         self.end_of_device_area,


### PR DESCRIPTION
Fix newly added deprecation for mispelling of cacheable.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
