### PR TITLE
build: Bump vm-memory and its consumers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3adb7b28e189741eca3b1a4a27de0bf15e0907c9d4b0c74bd2d7d84ef72e08"
+checksum = "1db6a725c8000971f83fa93ed7ee1b600e55a1471a2a653379d3c84f72effdcf"
 dependencies = [
  "vm-memory",
 ]
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#89f8e77dd1a2829197ecde65b686bafcc8a1def4"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#847b0aa504ac6367efe42ba7e96a2d050737d4f0"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#89f8e77dd1a2829197ecde65b686bafcc8a1def4"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#847b0aa504ac6367efe42ba7e96a2d050737d4f0"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -2140,7 +2140,7 @@ dependencies = [
 [[package]]
 name = "vfio_user"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio-user?branch=main#eef6bec4d421f08ed1688fe67c5ea33aabbf5069"
+source = "git+https://github.com/rust-vmm/vfio-user?branch=main#2d96b90a7279547356ad8f83aaa3115ad5497302"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -2156,8 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.7.0"
-source = "git+https://github.com/rust-vmm/vhost?branch=main#bdc6f2ab2b3dbd3b9574100ac641a2f8e9667400"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61957aeb36daf0b00b87fff9c10dd28a161bd35ab157553d340d183b3d8756e6"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -2167,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d3b7affe04f61d19b03c5db823287855789b687218fec139699a0c7f7f2790"
+checksum = "ab069cdedaf18a0673766eb0a07a0f4ee3ed1b8e17fbfe4aafe5b988e2de1d01"
 dependencies = [
  "libc",
  "log",
@@ -2219,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-bindings"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9084faf91b9aa9676ae2cac8f1432df2839d9566e6f19f29dbc13a8b831dff"
+checksum = "c18d7b74098a946470ea265b5bacbbf877abc3373021388454de0d47735a5b98"
 
 [[package]]
 name = "virtio-devices"
@@ -2259,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91aebb1df33db33cbf04d4c2445e4f78d0b0c8e65acfd16a4ee95ef63ca252f8"
+checksum = "35aca00da06841bd99162c381ec65893cace23ca0fb89254302cfe4bec4c300f"
 dependencies = [
  "log",
  "virtio-bindings",
@@ -2298,12 +2299,13 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#77212bd0d62913e445c
 
 [[package]]
 name = "vm-memory"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6ea57fe00f9086c59eeeb68e102dd611686bc3c28520fa465996d4d4bdce07"
+checksum = "9dc276f0d00c17b9aeb584da0f1e1c673df0d183cc2539e3636ec8cbc5eae99b"
 dependencies = [
  "arc-swap",
  "libc",
+ "thiserror",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tpm = { path = "tpm"}
 tracer = { path = "tracer" }
 vmm = { path = "vmm" }
 vmm-sys-util = "0.11.0"
-vm-memory = "0.11.0"
+vm-memory = "0.12.2"
 zbus = { version = "3.11.1", optional = true }
 
 # List of patched crates
@@ -55,7 +55,6 @@ zbus = { version = "3.11.1", optional = true }
 kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.6.0-tdx" }
 kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "main" }
 versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
-vhost = { git = "https://github.com/rust-vmm/vhost", branch = "main" }
 
 [dev-dependencies]
 dirs = "5.0.0"

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -14,14 +14,14 @@ anyhow = "1.0.75"
 byteorder = "1.4.3"
 hypervisor = { path = "../hypervisor" }
 libc = "0.2.147"
-linux-loader = { version = "0.9.0", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.9.1", features = ["elf", "bzimage", "pe"] }
 log = "0.4.17"
 serde = { version = "1.0.168", features = ["rc", "derive"] }
 thiserror = "1.0.40"
 uuid = "1.3.4"
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { version = "0.11.0", features = ["with-serde"] }
 

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -21,7 +21,7 @@ uuid = { version = "1.3.4", features = ["v4"] }
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
 virtio-bindings = { version = "0.2.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.8.0"
-vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.9.0"
+vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.11.0"

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -21,7 +21,7 @@ versionize = "0.1.10"
 versionize_derive = "0.1.4"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = "0.11.0"
+vm-memory = "0.12.2"
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = "0.11.0"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3adb7b28e189741eca3b1a4a27de0bf15e0907c9d4b0c74bd2d7d84ef72e08"
+checksum = "1db6a725c8000971f83fa93ed7ee1b600e55a1471a2a653379d3c84f72effdcf"
 dependencies = [
  "vm-memory",
 ]
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#89f8e77dd1a2829197ecde65b686bafcc8a1def4"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#847b0aa504ac6367efe42ba7e96a2d050737d4f0"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -868,7 +868,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#89f8e77dd1a2829197ecde65b686bafcc8a1def4"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#847b0aa504ac6367efe42ba7e96a2d050737d4f0"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "vfio_user"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio-user?branch=main#eef6bec4d421f08ed1688fe67c5ea33aabbf5069"
+source = "git+https://github.com/rust-vmm/vfio-user?branch=main#2d96b90a7279547356ad8f83aaa3115ad5497302"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -900,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f81f436bca4541f4d33172e1202882c9d437db34ed17fc6d84c8ff2bde21f5"
+checksum = "61957aeb36daf0b00b87fff9c10dd28a161bd35ab157553d340d183b3d8756e6"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91aebb1df33db33cbf04d4c2445e4f78d0b0c8e65acfd16a4ee95ef63ca252f8"
+checksum = "35aca00da06841bd99162c381ec65893cace23ca0fb89254302cfe4bec4c300f"
 dependencies = [
  "log",
  "virtio-bindings",
@@ -991,12 +991,13 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#c5a99ab71b130435927
 
 [[package]]
 name = "vm-memory"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6ea57fe00f9086c59eeeb68e102dd611686bc3c28520fa465996d4d4bdce07"
+checksum = "9dc276f0d00c17b9aeb584da0f1e1c673df0d183cc2539e3636ec8cbc5eae99b"
 dependencies = [
  "arc-swap",
  "libc",
+ "thiserror",
  "winapi",
 ]
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,16 +14,16 @@ devices = { path = "../devices" }
 epoll = "4.3.1"
 libc = "0.2.147"
 libfuzzer-sys = "0.4.7"
-linux-loader = { version = "0.9.0", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.9.1", features = ["elf", "bzimage", "pe"] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 net_util = { path = "../net_util" }
 once_cell = "1.18.0"
 seccompiler = "0.3.0"
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.8.0"
+virtio-queue = "0.9.0"
 vmm = { path = "../vmm" }
 vmm-sys-util = "0.11.1"
-vm-memory = "0.11.0"
+vm-memory = "0.12.2"
 vm-device = { path = "../vm-device" }
 vm-virtio = { path = "../vm-virtio" }
 

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -24,7 +24,7 @@ mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optio
 serde = { version = "1.0.168", features = ["rc", "derive"] }
 serde_with = { version = "3.0.0", default-features = false, features = ["macros"] }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = "0.11.0", features = ["with-serde"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -16,8 +16,8 @@ thiserror = "1.0.40"
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
 virtio-bindings = "0.2.0"
-virtio-queue = "0.8.0"
-vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.9.0"
+vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.11.0"
 

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -64,9 +64,9 @@ impl TxVirtio {
                         .memory()
                         .get_slice(desc_addr, desc.len() as usize)
                         .map_err(NetQueuePairError::GuestMemory)?
-                        .as_ptr();
+                        .ptr_guard_mut();
                     let iovec = libc::iovec {
-                        iov_base: buf as *mut libc::c_void,
+                        iov_base: buf.as_ptr() as *mut libc::c_void,
                         iov_len: desc.len() as libc::size_t,
                     };
                     iovecs.push(iovec);
@@ -203,9 +203,9 @@ impl RxVirtio {
                         .memory()
                         .get_slice(desc_addr, desc.len() as usize)
                         .map_err(NetQueuePairError::GuestMemory)?
-                        .as_ptr();
+                        .ptr_guard_mut();
                     let iovec = libc::iovec {
-                        iov_base: buf as *mut libc::c_void,
+                        iov_base: buf.as_ptr() as *mut libc::c_void,
                         iov_len: desc.len() as libc::size_t,
                     };
                     iovecs.push(iovec);

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -26,5 +26,5 @@ versionize = "0.1.10"
 versionize_derive = "0.1.4"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -13,10 +13,10 @@ epoll = "4.3.3"
 libc = "0.2.147"
 log = "0.4.17"
 option_parser = { path = "../option_parser" }
-vhost = { version = "0.7.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.9.0"
+vhost = { version = "0.8.1", features = ["vhost-user-slave"] }
+vhost-user-backend = "0.10.1"
 virtio-bindings = "0.2.0"
-virtio-queue = "0.8.0"
-vm-memory = "0.11.0"
+virtio-queue = "0.9.0"
+vm-memory = "0.12.2"
 vmm-sys-util = "0.11.0"
 

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -13,9 +13,9 @@ libc = "0.2.147"
 log = "0.4.17"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
-vhost = { version = "0.7.0", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.9.0"
+vhost = { version = "0.8.1", features = ["vhost-user-slave"] }
+vhost-user-backend = "0.10.1"
 virtio-bindings = "0.2.0"
-vm-memory = "0.11.0"
+vm-memory = "0.12.2"
 vmm-sys-util = "0.11.0"
 

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -27,12 +27,12 @@ serial_buffer = { path = "../serial_buffer" }
 thiserror = "1.0.40"
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
-vhost = { version = "0.7.0", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern", "vhost-vdpa"] }
+vhost = { version = "0.8.1", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern", "vhost-vdpa"] }
 virtio-bindings = { version = "0.2.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.8.0"
+virtio-queue = "0.9.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.11.0"

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.147"
-vm-memory = "0.11.0"
+vm-memory = "0.12.2"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 arch = { path = "../arch" }

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -15,6 +15,6 @@ hypervisor = { path = "../hypervisor" }
 thiserror = "1.0.40"
 serde = { version = "1.0.168", features = ["rc", "derive"] }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vm-memory = { version = "0.11.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.12.2", features = ["backend-mmap"] }
 vmm-sys-util = "0.11.0"
 

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -11,4 +11,4 @@ serde = { version = "1.0.168", features = ["rc", "derive"] }
 serde_json = "1.0.96"
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic"] }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -9,5 +9,5 @@ default = []
 
 [dependencies]
 log = "0.4.17"
-virtio-queue = "0.8.0"
-vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.9.0"
+vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -33,7 +33,7 @@ gdbstub = { version = "0.6.4", optional = true }
 gdbstub_arch = { version = "0.2.4", optional = true }
 hypervisor = { path = "../hypervisor" }
 libc = "0.2.147"
-linux-loader = { version = "0.9.0", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.9.1", features = ["elf", "bzimage", "pe"] }
 log = "0.4.17"
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 net_util = { path = "../net_util" }
@@ -53,10 +53,10 @@ versionize_derive = "0.1.4"
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
 vfio_user = { git = "https://github.com/rust-vmm/vfio-user", branch = "main" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.8.0"
+virtio-queue = "0.9.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { version = "0.11.0", features = ["with-serde"] }


### PR DESCRIPTION
Update to the latest vm-memory and all the crates that also depend upon
it.

Fix some deprecation warnings.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
