### PR TITLE
vmm: Add migratable option

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -557,6 +557,7 @@ pub fn generate_common_cpuid(
     phys_bits: u8,
     kvm_hyperv: bool,
     #[cfg(feature = "tdx")] tdx_enabled: bool,
+    migratable: bool,
 ) -> super::Result<Vec<CpuIdEntry>> {
     // SAFETY: cpuid called with valid leaves
     if unsafe { x86_64::__cpuid(1) }.ecx & 1 << HYPERVISOR_ECX_BIT == 1 << HYPERVISOR_ECX_BIT {
@@ -670,6 +671,13 @@ pub fn generate_common_cpuid(
                     }
                 }
             }
+            // Set Invariant TSC
+            0x8000_0007 => {
+                if migratable {
+                    entry.edx &= !(1 << INVARIANT_TSC_EDX_BIT);
+                }
+            }
+
             // Set CPU physical bits
             0x8000_0008 => {
                 entry.eax = (entry.eax & 0xffff_ff00) | (phys_bits as u32 & 0xff);

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,6 +295,10 @@ pub struct TopLevel {
     #[argh(switch, short = 'V', long = "version")]
     /// print version information
     version: bool,
+
+    #[argh(option, long = "migratable", default = "String::from(\"on\")")]
+    /// migratable on|off
+    migratable: String,
 }
 
 impl TopLevel {
@@ -375,6 +379,11 @@ impl TopLevel {
         #[cfg(feature = "guest_debug")]
         let gdb = self.gdb.is_some();
         let tpm = self.tpm.as_deref();
+        let migratable = match &self.migratable as &str {
+            "on" => true,
+            "off" => false,
+            _ => panic!("Invalid migratable parameter, on|off is needed"),
+        };
 
         config::VmParams {
             cpus,
@@ -405,6 +414,7 @@ impl TopLevel {
             gdb,
             platform,
             tpm,
+            migratable,
         }
     }
 }
@@ -802,6 +812,7 @@ mod unit_tests {
             platform: None,
             tpm: None,
             preserved_fds: None,
+            migratable: true,
         };
 
         assert_eq!(expected_vm_config, result_vm_config);

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -379,6 +379,7 @@ pub struct VmParams<'a> {
     pub gdb: bool,
     pub platform: Option<&'a str>,
     pub tpm: Option<&'a str>,
+    pub migratable: bool,
 }
 
 #[derive(Debug)]
@@ -2096,6 +2097,7 @@ impl VmConfig {
             platform,
             tpm,
             preserved_fds: None,
+            migratable: vm_params.migratable,
         };
         config.validate().map_err(Error::Validation)?;
         Ok(config)
@@ -2843,6 +2845,7 @@ mod tests {
             platform: None,
             tpm: None,
             preserved_fds: None,
+            migratable: true,
         };
 
         assert!(valid_config.validate().is_ok());

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -460,6 +460,8 @@ pub struct CpuManager {
     proximity_domain_per_cpu: BTreeMap<u8, u32>,
     affinity: BTreeMap<u8, Vec<u8>>,
     dynamic: bool,
+    #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
+    migratable: bool,
 }
 
 const CPU_ENABLE_FLAG: usize = 0;
@@ -607,6 +609,7 @@ impl CpuManager {
         vm_ops: Arc<dyn VmOps>,
         #[cfg(feature = "tdx")] tdx_enabled: bool,
         numa_nodes: &NumaNodes,
+        migratable: bool,
     ) -> Result<Arc<Mutex<CpuManager>>> {
         if u32::from(config.max_vcpus) > hypervisor.get_max_vcpus() {
             return Err(Error::MaximumVcpusExceeded);
@@ -696,6 +699,7 @@ impl CpuManager {
             proximity_domain_per_cpu,
             affinity,
             dynamic,
+            migratable,
         })))
     }
 
@@ -734,6 +738,7 @@ impl CpuManager {
                 self.config.kvm_hyperv,
                 #[cfg(feature = "tdx")]
                 tdx_enabled,
+                self.migratable,
             )
             .map_err(Error::CommonCpuId)?
         };

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1631,14 +1631,16 @@ impl Vmm {
         let common_cpuid = {
             let phys_bits =
                 vm::physical_bits(&hypervisor, vm_config.lock().unwrap().cpus.max_phys_bits);
+            let config = &vm_config.lock().unwrap();
             arch::generate_common_cpuid(
                 &hypervisor,
                 None,
                 None,
                 phys_bits,
-                vm_config.lock().unwrap().cpus.kvm_hyperv,
+                config.cpus.kvm_hyperv,
                 #[cfg(feature = "tdx")]
                 vm_config.lock().unwrap().is_tdx_enabled(),
+                config.migratable,
             )
             .map_err(|e| {
                 MigratableError::MigrateReceive(anyhow!("Error generating common cpuid': {:?}", e))
@@ -1829,6 +1831,7 @@ impl Vmm {
                 vm_config.cpus.kvm_hyperv,
                 #[cfg(feature = "tdx")]
                 vm_config.is_tdx_enabled(),
+                vm_config.migratable,
             )
             .map_err(|e| {
                 MigratableError::MigrateReceive(anyhow!("Error generating common cpuid: {:?}", e))
@@ -2261,6 +2264,7 @@ mod unit_tests {
             platform: None,
             tpm: None,
             preserved_fds: None,
+            migratable: true,
         }))
     }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -527,6 +527,7 @@ impl Vm {
             #[cfg(feature = "tdx")]
             tdx_enabled,
             &numa_nodes,
+            config.lock().unwrap().migratable,
         )
         .map_err(Error::CpuManager)?;
 
@@ -2378,14 +2379,16 @@ impl Snapshottable for Vm {
                 &self.hypervisor,
                 self.config.lock().unwrap().cpus.max_phys_bits,
             );
+            let vm_config = &self.config.lock().unwrap();
             arch::generate_common_cpuid(
                 &self.hypervisor,
                 None,
                 None,
                 phys_bits,
-                self.config.lock().unwrap().cpus.kvm_hyperv,
+                vm_config.cpus.kvm_hyperv,
                 #[cfg(feature = "tdx")]
                 tdx_enabled,
+                vm_config.migratable,
             )
             .map_err(|e| {
                 MigratableError::MigrateReceive(anyhow!("Error generating common cpuid: {:?}", e))

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -605,4 +605,6 @@ pub struct VmConfig {
     // valid, and will be closed when the holding VmConfig instance is destroyed.
     #[serde(skip)]
     pub preserved_fds: Option<Vec<i32>>,
+    #[serde(default)]
+    pub migratable: bool,
 }


### PR DESCRIPTION
As kernel introduced commit 7539b174aef40(x86: kvmguest: use TSC clocksource if invariant TSC is exposed), the current_clocksource is set to tsc in guest of Cloud Hypervisor.

Add a invtsc feature in CPU option to make kvm-clock as default current_clocksource.