### PR TITLE
virtio-devices: block: Correct the latency for the first op

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -307,7 +307,7 @@ impl BlockEpollHandler {
 
                         // Special case the first real latency report
                         read_avg = if read_avg == u64::MAX {
-                            latency
+                            latency * LATENCY_SCALE
                         } else {
                             read_avg
                                 + ((latency * LATENCY_SCALE) - read_avg)
@@ -337,7 +337,7 @@ impl BlockEpollHandler {
 
                         // Special case the first real latency report
                         write_avg = if write_avg == u64::MAX {
-                            latency
+                            latency * LATENCY_SCALE
                         } else {
                             write_avg
                                 + ((latency * LATENCY_SCALE) - write_avg)


### PR DESCRIPTION
There is a "LATENCY_SCALE" being used for calculating cumulative average latency, so it should also be used for the latency of the first op.

See: #5712