### PR TITLE
README: add instructions for booting bzImages

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,17 @@ For x86-64, the `vmlinux` kernel image will then be located at
 For AArch64, the `Image` kernel image will then be located at
 `linux-cloud-hypervisor/arch/arm64/boot/Image`.
 
+#### Handling bzImage
+
+On x86-64, `bzImage` is a common format for Linux kernels. Cloud Hypervisor does not support booting `bzImage` directly. To boot a `bzImage`, you either have to wrap it in a disk image (see below) or unpack the contained `vmlinux` file using a script from the Linux kernel source directory.
+
+The `vmlinux` can be unpacked from a `bzImage` using:
+
+```shell
+# In the Linux source tree
+$ ./scripts/extract-vmlinux bzImage > vmlinux
+```
+
 #### Disk image
 
 For the disk image the same Ubuntu image as before can be used. This contains


### PR DESCRIPTION
Booting from existing bzImages is a common problem for people new to CHV. Adding a short section in the README hopefully reduces the steepness of the learning curve a bit.

Btw, would it be interesting to re-add bzImage boot support to CHV if someone puts in the work? I see that linux-loader is already included with the bzImage feature enabled (for TDX?), so that would be a small amount of code that would make some people's life a bit easier.

@0xf09f95b4 @phip1611 