### PR TITLE
vmm: simplify EntryPoint

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -60,7 +60,7 @@ pub const _NSIG: i32 = 65;
 /// is to be used to configure the guest initial state.
 pub struct EntryPoint {
     /// Address in guest memory where the guest must start execution
-    pub entry_addr: Option<GuestAddress>,
+    pub entry_addr: GuestAddress,
 }
 
 const E820_RAM: u32 = 1;
@@ -811,12 +811,10 @@ pub fn configure_vcpu(
 
     regs::setup_msrs(vcpu).map_err(Error::MsrsConfiguration)?;
     if let Some((kernel_entry_point, guest_memory)) = boot_setup {
-        if let Some(entry_addr) = kernel_entry_point.entry_addr {
-            // Safe to unwrap because this method is called after the VM is configured
-            regs::setup_regs(vcpu, entry_addr.raw_value()).map_err(Error::RegsConfiguration)?;
-            regs::setup_fpu(vcpu).map_err(Error::FpuConfiguration)?;
-            regs::setup_sregs(&guest_memory.memory(), vcpu).map_err(Error::SregsConfiguration)?;
-        }
+        regs::setup_regs(vcpu, kernel_entry_point.entry_addr.raw_value())
+            .map_err(Error::RegsConfiguration)?;
+        regs::setup_fpu(vcpu).map_err(Error::FpuConfiguration)?;
+        regs::setup_sregs(&guest_memory.memory(), vcpu).map_err(Error::SregsConfiguration)?;
     }
     interrupts::set_lint(vcpu).map_err(|e| Error::LocalIntConfiguration(e.into()))?;
     Ok(())

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -980,9 +980,7 @@ impl Vm {
         if let PvhEntryPresent(entry_addr) = entry_addr.pvh_boot_cap {
             // Use the PVH kernel entry point to boot the guest
             info!("Kernel loaded: entry_addr = 0x{:x}", entry_addr.0);
-            Ok(EntryPoint {
-                entry_addr: Some(entry_addr),
-            })
+            Ok(EntryPoint { entry_addr })
         } else {
             Err(Error::KernelMissingPvhHeader)
         }


### PR DESCRIPTION
`EntryPoint` had an optional `entry_addr`, but there is no usage of this struct that makes it necessary that the address is optional.

Remove the `Option` to avoid being able to express things that are not useful.
