### PR TITLE
block: Add support for user specified ID_SERIAL

### DIFF
--- a/fuzz/fuzz_targets/block.rs
+++ b/fuzz/fuzz_targets/block.rs
@@ -57,6 +57,7 @@ fuzz_target!(|bytes| {
         false,
         2,
         256,
+        None,
         SeccompAction::Allow,
         None,
         EventFd::new(EFD_NONBLOCK).unwrap(),

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -820,6 +820,8 @@ components:
           format: int16
         id:
           type: string
+        serial:
+          type: string
 
     NetConfig:
       type: object

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -779,7 +779,8 @@ impl DiskConfig {
             .add("ops_refill_time")
             .add("id")
             .add("_disable_io_uring")
-            .add("pci_segment");
+            .add("pci_segment")
+            .add("serial");
         parser.parse(disk).map_err(Error::ParseDisk)?;
 
         let path = parser.get("path").map(PathBuf::from);
@@ -846,6 +847,7 @@ impl DiskConfig {
             .convert("ops_refill_time")
             .map_err(Error::ParseDisk)?
             .unwrap_or_default();
+        let serial = parser.get("serial");
         let bw_tb_config = if bw_size != 0 && bw_refill_time != 0 {
             Some(TokenBucketConfig {
                 size: bw_size,
@@ -886,6 +888,7 @@ impl DiskConfig {
             id,
             disable_io_uring,
             pci_segment,
+            serial,
         })
     }
 
@@ -2462,7 +2465,14 @@ mod tests {
                 ..Default::default()
             }
         );
-
+        assert_eq!(
+            DiskConfig::parse("path=/path/to_file,serial=test")?,
+            DiskConfig {
+                path: Some(PathBuf::from("/path/to_file")),
+                serial: Some(String::from("test")),
+                ..Default::default()
+            }
+        );
         Ok(())
     }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2315,6 +2315,7 @@ impl DeviceManager {
                     self.force_iommu | disk_cfg.iommu,
                     disk_cfg.num_queues,
                     disk_cfg.queue_size,
+                    disk_cfg.serial.clone(),
                     self.seccomp_action.clone(),
                     disk_cfg.rate_limiter_config,
                     self.exit_evt

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -220,6 +220,8 @@ pub struct DiskConfig {
     pub disable_io_uring: bool,
     #[serde(default)]
     pub pci_segment: u16,
+    #[serde(default)]
+    pub serial: Option<String>,
 }
 
 pub const DEFAULT_DISK_NUM_QUEUES: usize = 1;
@@ -249,6 +251,7 @@ impl Default for DiskConfig {
             disable_io_uring: false,
             rate_limiter_config: None,
             pci_segment: 0,
+            serial: None,
         }
     }
 }


### PR DESCRIPTION
This PR adds support for explicitly specifying the serial number of a virtio-blk device. To enable easy automation, hyperscale cloud providers [such as GCP](https://medium.com/@DazWilkin/compute-engine-identifying-your-devices-aeae6c01a4d7) offer a convenient way to identify disks within a virtual machine. Qemu allows the ID_SERIAL property of virtio-blk devices to be specified with a `serial` argument.

A disk can be specified with serial number `abcdefghijklmnopqrst` in cloud hypervisor using the following arguments.
```
--disk path=focal-server-cloudimg-amd64.raw,serial=abcdefghijklmnopqrst
```

Within a virtual machine, the disk is available as `virtio-abcdefghijklmnopqrst`
```
ls /dev/disk/by-id/virtio-abcdefghijklmnopqrst
/dev/disk/by-id/virtio-abcdefghijklmnopqrst
```

The exact format can be customized from within the virtual machine using dev rules. For example, on Ubuntu focal, the udev rules for virtio-blk devices are:
```
cat /usr/lib/udev/rules.d/60-persistent-storage.rules | grep disk/by-id/virtio-
KERNEL=="vd*[!0-9]", ATTRS{serial}=="?*", ENV{ID_SERIAL}="$attr{serial}", SYMLINK+="disk/by-id/virtio-$env{ID_SERIAL}"
```
