### PR TITLE
tests: Temporarily disable test_vdpa_net

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6853,6 +6853,7 @@ mod common_parallel {
 
     #[test]
     #[cfg(target_arch = "x86_64")]
+    #[ignore = "See #5756"]
     fn test_vdpa_net() {
         // Before trying to run the test, verify the vdpa_sim_net module is correctly loaded.
         if !exec_host_command_status("lsmod | grep vdpa_sim_net").success() {


### PR DESCRIPTION
This test is consistently failing after the on demand worker kernel
upgrade.

See: #5756

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
