### PR TITLE
event_monitor: Replace unsound `static mut MONITOR`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,7 @@ version = "0.1.0"
 dependencies = [
  "flume",
  "libc",
+ "once_cell",
  "serde",
  "serde_json",
 ]

--- a/event_monitor/Cargo.toml
+++ b/event_monitor/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 [dependencies]
 flume = "0.10.14"
 libc = "0.2.147"
+once_cell = "1.18.0"
 serde = { version = "1.0.168", features = ["rc", "derive"] }
 serde_json = "1.0.96"


### PR DESCRIPTION
See discussion in https://github.com/rust-lang/rust/issues/53639. This came up during an internal review.