### PR TITLE
tests: Enable testing for multi PCI segment for mshv

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2796,7 +2796,6 @@ mod common_parallel {
     }
 
     #[test]
-    #[cfg(not(feature = "mshv"))]
     fn test_pci_multiple_segments() {
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(focal));


### PR DESCRIPTION
This test is now supported on MSHV so we can re-enable the support for it.