### PR TITLE
Report enabled features via api endpoint and CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,8 @@ serde_json = "1.0.107"
 test_infra = { path = "test_infra" }
 wait-timeout = "0.2.0"
 
+# Please adjust `vmm::feature_list()` accordingly when changing the
+# feature list below
 [features]
 default = ["kvm", "io_uring"]
 dbus_api = ["zbus", "vmm/dbus_api"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -676,6 +676,11 @@ fn main() {
 
     if toplevel.version {
         println!("{} {}", env!("CARGO_BIN_NAME"), env!("BUILD_VERSION"));
+
+        if toplevel.verbosity != 0 {
+            println!("Enabled features: {:?}", vmm::feature_list());
+        }
+
         return;
     }
 

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -171,6 +171,7 @@ pub struct VmmPingResponse {
     pub build_version: String,
     pub version: String,
     pub pid: i64,
+    pub features: Vec<String>,
 }
 
 #[derive(Clone, Deserialize, Serialize, Default, Debug)]

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -445,6 +445,10 @@ components:
         pid:
           type: integer
           format: int64
+        features:
+          type: array
+          items:
+            type: string
       description: Virtual Machine Monitor information
 
     VmInfo:

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -293,6 +293,29 @@ impl Serialize for PciDeviceInfo {
     }
 }
 
+pub fn feature_list() -> Vec<String> {
+    vec![
+        #[cfg(feature = "dbus_api")]
+        "dbus_api".to_string(),
+        #[cfg(feature = "dhat-heap")]
+        "dhat-heap".to_string(),
+        #[cfg(feature = "guest_debug")]
+        "guest_debug".to_string(),
+        #[cfg(feature = "io_uring")]
+        "io_uring".to_string(),
+        #[cfg(feature = "kvm")]
+        "kvm".to_string(),
+        #[cfg(feature = "mshv")]
+        "mshv".to_string(),
+        #[cfg(feature = "sev_snp")]
+        "sev_snp".to_string(),
+        #[cfg(feature = "tdx")]
+        "tdx".to_string(),
+        #[cfg(feature = "tracing")]
+        "tracing".to_string(),
+    ]
+}
+
 pub fn start_event_monitor_thread(
     mut monitor: event_monitor::Monitor,
     seccomp_action: &SeccompAction,
@@ -931,6 +954,7 @@ impl Vmm {
             build_version,
             version,
             pid: std::process::id() as i64,
+            features: feature_list(),
         }
     }
 


### PR DESCRIPTION
vmm: Report enabled features from the '/vmm.ping' endpoint
main: Report enabled features from CLI with "--version -v"

Fixes: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/5817

Signed-off-by: Bo Chen <chen.bo@intel.com>