### PR TITLE
tests: Update spdk commit id to support Ampere's new CPU

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -130,17 +130,18 @@ RUN echo 'source $CARGO_HOME/env' >> "$HOME"/.bashrc \
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
        git clone https://github.com/spdk/spdk \
        && cd spdk \
-       && git checkout 6301f8915de32baed10dba1eebed556a6749211a \
+       && git checkout ef8bcce58f3f02b79c0619a297e4f17e81e62b24 \
        && git submodule update --init \
        && apt-get update \
        && ./scripts/pkgdep.sh \
        && apt-get clean \
        && ./configure --with-vfio-user \
        && make -j $(nproc) TARGET_ARCHITECTURE=skylake \
+       && rm -rf /usr/local/bin/spdk-nvme \
        && mkdir /usr/local/bin/spdk-nvme \
-       && cp ./build/bin/nvmf_tgt /usr/local/bin/spdk-nvme \
-       && cp ./scripts/rpc.py /usr/local/bin/spdk-nvme \
-       && cp -r ./scripts/rpc /usr/local/bin/spdk-nvme \
+       && cp -f ./build/bin/nvmf_tgt /usr/local/bin/spdk-nvme \
+       && cp -f ./scripts/rpc.py /usr/local/bin/spdk-nvme \
+       && cp -rf ./python /usr/local/bin \
        && cd .. && rm -rf spdk; fi
 
 # install swtpm only for x86_64 arch

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -7,7 +7,7 @@
 CLI_NAME="Cloud Hypervisor"
 
 CTR_IMAGE_TAG="ghcr.io/cloud-hypervisor/cloud-hypervisor"
-CTR_IMAGE_VERSION="20230804-0"
+CTR_IMAGE_VERSION="20231012-0"
 : "${CTR_IMAGE:=${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}}"
 
 DOCKER_RUNTIME="docker"

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -11,12 +11,13 @@ build_spdk_nvme() {
     SPDK_DIR="$WORKLOADS_DIR/spdk"
     SPDK_REPO="https://github.com/spdk/spdk.git"
     SPDK_DEPLOY_DIR="/usr/local/bin/spdk-nvme"
-    checkout_repo "$SPDK_DIR" "$SPDK_REPO" master "6301f8915de32baed10dba1eebed556a6749211a"
+    checkout_repo "$SPDK_DIR" "$SPDK_REPO" master "ef8bcce58f3f02b79c0619a297e4f17e81e62b24"
 
     if [ ! -f "$SPDK_DIR/.built" ]; then
         pushd $SPDK_DIR
         git submodule update --init
         apt-get update
+        sed -i "/grpcio/d" scripts/pkgdep/debian.sh
         ./scripts/pkgdep.sh
         ./configure --with-vfio-user
         chmod +x /usr/local/lib/python3.8/dist-packages/ninja/data/bin/ninja
@@ -30,6 +31,7 @@ build_spdk_nvme() {
     cp "$WORKLOADS_DIR/spdk/build/bin/nvmf_tgt" $SPDK_DEPLOY_DIR/nvmf_tgt
     cp "$WORKLOADS_DIR/spdk/scripts/rpc.py" $SPDK_DEPLOY_DIR/rpc.py
     cp -r "$WORKLOADS_DIR/spdk/scripts/rpc" $SPDK_DEPLOY_DIR/rpc
+    cp -r "$WORKLOADS_DIR/spdk/python" $SPDK_DEPLOY_DIR/../
 }
 
 build_virtiofsd() {


### PR DESCRIPTION
When performing integration testing on the Ampere One server, an error occurred when compiling spdk and not recognizing the CPU ID. 
The latest spdk already contains fixes.