### PR TITLE
Only advertise AMX feature bits to guest when the AMX cpu feature is enabled

### DIFF
--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -92,7 +92,7 @@ pub mod x86_64;
 pub use x86_64::{
     arch_memory_regions, configure_system, configure_vcpu, generate_common_cpuid,
     get_host_cpu_phys_bits, initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE,
-    layout::CMDLINE_START, regs, CpuidFeatureEntry, EntryPoint, _NSIG,
+    layout::CMDLINE_START, regs, CpuidConfig, CpuidFeatureEntry, EntryPoint, _NSIG,
 };
 
 /// Safe wrapper for `sysconf(_SC_PAGESIZE)`.

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -745,6 +745,7 @@ impl CpuManager {
                     kvm_hyperv: self.config.kvm_hyperv,
                     #[cfg(feature = "tdx")]
                     tdx,
+                    amx: self.config.features.amx,
                 },
             )
             .map_err(Error::CommonCpuId)?

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -726,7 +726,7 @@ impl CpuManager {
         &mut self,
         memory_manager: &Arc<Mutex<MemoryManager>>,
         hypervisor: &Arc<dyn hypervisor::Hypervisor>,
-        #[cfg(feature = "tdx")] tdx_enabled: bool,
+        #[cfg(feature = "tdx")] tdx: bool,
     ) -> Result<()> {
         let sgx_epc_sections = memory_manager
             .lock()
@@ -739,11 +739,13 @@ impl CpuManager {
             let phys_bits = physical_bits(hypervisor, self.config.max_phys_bits);
             arch::generate_common_cpuid(
                 hypervisor,
-                sgx_epc_sections,
-                phys_bits,
-                self.config.kvm_hyperv,
-                #[cfg(feature = "tdx")]
-                tdx_enabled,
+                &arch::CpuidConfig {
+                    sgx_epc_sections,
+                    phys_bits,
+                    kvm_hyperv: self.config.kvm_hyperv,
+                    #[cfg(feature = "tdx")]
+                    tdx,
+                },
             )
             .map_err(Error::CommonCpuId)?
         };

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1665,6 +1665,7 @@ impl Vmm {
         let common_cpuid = {
             #[cfg(feature = "tdx")]
             let tdx = vm_config.lock().unwrap().is_tdx_enabled();
+            let amx = vm_config.lock().unwrap().cpus.features.amx;
             let phys_bits =
                 vm::physical_bits(&hypervisor, vm_config.lock().unwrap().cpus.max_phys_bits);
             arch::generate_common_cpuid(
@@ -1675,6 +1676,7 @@ impl Vmm {
                     kvm_hyperv: vm_config.lock().unwrap().cpus.kvm_hyperv,
                     #[cfg(feature = "tdx")]
                     tdx,
+                    amx,
                 },
             )
             .map_err(|e| {
@@ -1866,6 +1868,7 @@ impl Vmm {
                     kvm_hyperv: vm_config.cpus.kvm_hyperv,
                     #[cfg(feature = "tdx")]
                     tdx: vm_config.is_tdx_enabled(),
+                    amx: vm_config.cpus.features.amx,
                 },
             )
             .map_err(|e| {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2415,11 +2415,13 @@ impl Snapshottable for Vm {
             );
             arch::generate_common_cpuid(
                 &self.hypervisor,
-                None,
-                phys_bits,
-                self.config.lock().unwrap().cpus.kvm_hyperv,
-                #[cfg(feature = "tdx")]
-                tdx_enabled,
+                &arch::CpuidConfig {
+                    sgx_epc_sections: None,
+                    phys_bits,
+                    kvm_hyperv: self.config.lock().unwrap().cpus.kvm_hyperv,
+                    #[cfg(feature = "tdx")]
+                    tdx: tdx_enabled,
+                },
             )
             .map_err(|e| {
                 MigratableError::MigrateReceive(anyhow!("Error generating common cpuid: {:?}", e))

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2409,6 +2409,7 @@ impl Snapshottable for Vm {
 
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         let common_cpuid = {
+            let amx = self.config.lock().unwrap().cpus.features.amx;
             let phys_bits = physical_bits(
                 &self.hypervisor,
                 self.config.lock().unwrap().cpus.max_phys_bits,
@@ -2421,6 +2422,7 @@ impl Snapshottable for Vm {
                     kvm_hyperv: self.config.lock().unwrap().cpus.kvm_hyperv,
                     #[cfg(feature = "tdx")]
                     tdx: tdx_enabled,
+                    amx,
                 },
             )
             .map_err(|e| {


### PR DESCRIPTION
This PR fixes #5833 with a refactoring for easier generation of common CPUIDs based on guest VM configurations.