### PR TITLE
vmm, hypervisor: Initialize SEV-SNP VM

### DIFF
--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1266,4 +1266,14 @@ impl vm::Vm for MshvVm {
     fn as_any(&self) -> &dyn Any {
         self
     }
+    /// Initialize the SEV-SNP VM
+    #[cfg(feature = "sev_snp")]
+    fn sev_snp_init(&self) -> vm::Result<()> {
+        self.fd
+            .set_partition_property(
+                hv_partition_property_code_HV_PARTITION_PROPERTY_ISOLATION_STATE,
+                hv_partition_isolation_state_HV_PARTITION_ISOLATION_SECURE as u64,
+            )
+            .map_err(|e| vm::HypervisorVmError::InitializeSevSnp(e.into()))
+    }
 }

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -190,6 +190,13 @@ pub enum HypervisorVmError {
     #[error("Failed to assert virtual Interrupt: {0}")]
     AsserttVirtualInterrupt(#[source] anyhow::Error),
 
+    #[cfg(feature = "sev_snp")]
+    ///
+    /// Error initializing SEV-SNP on the VM
+    ///
+    #[error("Failed to initialize SEV-SNP: {0}")]
+    InitializeSevSnp(#[source] std::io::Error),
+
     #[cfg(feature = "tdx")]
     ///
     /// Error initializing TDX on the VM
@@ -324,6 +331,11 @@ pub trait Vm: Send + Sync + Any {
     fn stop_dirty_log(&self) -> Result<()>;
     /// Get dirty pages bitmap
     fn get_dirty_log(&self, slot: u32, base_gpa: u64, memory_size: u64) -> Result<Vec<u64>>;
+    #[cfg(feature = "sev_snp")]
+    /// Initialize SEV-SNP on this VM
+    fn sev_snp_init(&self) -> Result<()> {
+        unimplemented!()
+    }
     #[cfg(feature = "tdx")]
     /// Initialize TDX on this VM
     fn tdx_init(&self, _cpuid: &[CpuIdEntry], _max_vcpus: u32) -> Result<()> {


### PR DESCRIPTION
As part of this initialization for a SEV-SNP VM on MSHV, it is required that we transition the guest state to secure state using partition hypercall. This implies all the created VPs will transition to secure state and could access the guest encrypted memory.