### PR TITLE
vmm: Allow assignment of PCI segments to NUMA node

### DIFF
--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -108,6 +108,7 @@ pub struct NumaNode {
     pub memory_regions: Vec<Arc<GuestRegionMmap>>,
     pub hotplug_regions: Vec<Arc<GuestRegionMmap>>,
     pub cpus: Vec<u8>,
+    pub pci_segments: Vec<u16>,
     pub distances: BTreeMap<u32, u8>,
     pub memory_zones: Vec<String>,
     #[cfg(target_arch = "x86_64")]

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -572,7 +572,16 @@ _Example_
 
 ### PCI bus
 
-Cloud Hypervisor supports only one PCI bus, which is why it has been tied to
-the NUMA node 0 by default. It is the user responsibility to organize the NUMA
-nodes correctly so that vCPUs and guest RAM which should be located on the same
-NUMA node as the PCI bus end up on the NUMA node 0.
+Cloud Hypervisor supports guests with one or more PCI segments. The default PCI segment always
+has affinity to NUMA node 0. Be default, all other PCI segments have afffinity to NUMA node 0.
+The user may configure the NUMA affinity for any additional PCI segments.
+
+_Example_
+
+```
+--platform num_pci_segments=2
+--memory-zone size=16G,host_numa_node=0,id=mem0
+--memory-zone size=16G,host_numa_node=1,id=mem1
+--numa guest_numa_id=0,memory_zones=mem0,pci_segments=[0]
+--numa guest_numa_id=1,memory_zones=mem1,pci_segments=[1]
+```

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1080,6 +1080,11 @@ components:
           type: array
           items:
             type: string
+        pci_segments:
+          type: array
+          items:
+            type: integer
+            format: int32
 
     VmResize:
       type: object

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1065,6 +1065,7 @@ impl DeviceManager {
         for i in 1..num_pci_segments as usize {
             pci_segments.push(PciSegment::new(
                 i as u16,
+                numa_node_id_from_pci_segment_id(&numa_nodes, i as u16),
                 &address_manager,
                 Arc::clone(&address_manager.pci_mmio_allocators[i]),
                 &pci_irq_slots,
@@ -4341,6 +4342,16 @@ fn numa_node_id_from_memory_zone_id(numa_nodes: &NumaNodes, memory_zone_id: &str
     }
 
     None
+}
+
+fn numa_node_id_from_pci_segment_id(numa_nodes: &NumaNodes, pci_segment_id: u16) -> u32 {
+    for (numa_node_id, numa_node) in numa_nodes.iter() {
+        if numa_node.pci_segments.contains(&pci_segment_id) {
+            return *numa_node_id;
+        }
+    }
+
+    0
 }
 
 struct TpmDevice {}

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -701,6 +701,10 @@ impl Vm {
                     node.cpus.extend(cpus);
                 }
 
+                if let Some(pci_segments) = &config.pci_segments {
+                    node.pci_segments.extend(pci_segments);
+                }
+
                 if let Some(distances) = &config.distances {
                     for distance in distances.iter() {
                         let dest = distance.destination;

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -538,6 +538,8 @@ pub struct NumaConfig {
     #[cfg(target_arch = "x86_64")]
     #[serde(default)]
     pub sgx_epc_sections: Option<Vec<String>>,
+    #[serde(default)]
+    pub pci_segments: Option<Vec<u16>>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]


### PR DESCRIPTION
Although multiple PCI segments are supported, all PCI segments have an affinity to NUMA node 0. This PR supports assigning non-default PCI segments to non-zero NUMA nodes.

For example, the following command will start cloud-hypervisor with two NUMA nodes and two PCI segments (one for each NUMA node).  The addition of the `pci_segments` argument to `NumaConfig` allows the user to specify the relationship between PCI Segments and NUMA nodes.

- An error is returned if the default PCI Segment (0) is not assigned to NUMA node zero.
- All PCI Segments default to NUMA node 0 if unspecified.

## Example 1
```
./cloud-hypervisor \
--platform num_pci_segments=2 \
--kernel /var/lib/cloud-hypervisor/CLOUDHV.fd \
--cpus boot=20,topology=2:5:1:2,affinity=[0@[2],2@[3],4@[4],6@[5],8@[6],10@[7],12@[8],14@[9],16@[10],18@[11],1@[14],3@[15],5@[16],7@[17],9@[18],11@[19],13@[20],15@[21],17@[22],19@[23]] \
--memory size=0 \
--memory-zone size=16G,hugepages=on,hugepage_size=1G,prefault=on,host_numa_node=0,id=mem0 \
--memory-zone size=16G,hugepages=on,hugepage_size=1G,prefault=on,host_numa_node=0,id=mem1 \
--numa guest_numa_id=0,cpus=[0-9],memory_zones=[mem0],pci_segments=[0] \
--numa guest_numa_id=1,cpus=[10-19],memory_zones=[mem1],pci_segments=[1] \
--disk path=~/ubuntu.raw \
--console off \
--net "tap="
```

Before this change.
```
> cat /sys/class/pci_bus/0000:00/cpuaffinity
003ff
> cat /sys/class/pci_bus/0001:00/cpuaffinity
003ff
```

After this change.
```
> cat /sys/class/pci_bus/0000:00/cpuaffinity
003ff
> cat /sys/class/pci_bus/0001:00/cpuaffinity
ffc00
```

## Example 2
In this example, a disk is assigned to PCI Segment 1, which is located on NUMA node 1. 
```
./cloud-hypervisor \
--platform num_pci_segments=2 \
--kernel /var/lib/cloud-hypervisor/CLOUDHV.fd \
--cpus boot=20,topology=2:5:1:2,affinity=[0@[2],2@[3],4@[4],6@[5],8@[6],10@[7],12@[8],14@[9],16@[10],18@[11],1@[14],3@[15],5@[16],7@[17],9@[18],11@[19],13@[20],15@[21],17@[22],19@[23]] \
--memory size=0 \
--memory-zone size=16G,hugepages=on,hugepage_size=1G,prefault=on,host_numa_node=0,id=mem0 \
--memory-zone size=16G,hugepages=on,hugepage_size=1G,prefault=on,host_numa_node=0,id=mem1 \
--numa guest_numa_id=0,cpus=[0-9],memory_zones=[mem0],pci_segments=[0] \
--numa guest_numa_id=1,cpus=[10-19],memory_zones=[mem1],pci_segments=[1] \
--disk path=~/ubuntu.raw \
--disk path=~/empty.raw,pci_segment=1 \
--console off \
--net "tap="
```

After this change, the disk correctly reports that it is located on NUMA node 0.
```
cat /sys/bus/pci/devices/0001:00:01.0/numa_node
0
```

After this change, the disk correctly reports that it is located on NUMA node 1.
```
cat /sys/bus/pci/devices/0001:00:01.0/numa_node
1
```
