### PR TITLE
vmm: tdx: Fix a deadlock while accessing `vm_config`

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1663,6 +1663,8 @@ impl Vmm {
         let vm_config = vm.get_config();
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         let common_cpuid = {
+            #[cfg(feature = "tdx")]
+            let tdx_enabled = vm_config.lock().unwrap().is_tdx_enabled();
             let phys_bits =
                 vm::physical_bits(&hypervisor, vm_config.lock().unwrap().cpus.max_phys_bits);
             arch::generate_common_cpuid(
@@ -1672,7 +1674,7 @@ impl Vmm {
                 phys_bits,
                 vm_config.lock().unwrap().cpus.kvm_hyperv,
                 #[cfg(feature = "tdx")]
-                vm_config.lock().unwrap().is_tdx_enabled(),
+                tdx_enabled,
             )
             .map_err(|e| {
                 MigratableError::MigrateReceive(anyhow!("Error generating common cpuid': {:?}", e))


### PR DESCRIPTION
The lock to `vm_config` is held for accessing `cpus.kvm_hyperv` passing as a reference to `arch::generate_common_cpuid()`, so acquiring the same lock again while calling to the same function is a deadlock.

Fixes: https://github.com/cloud-hypervisor/cloud-hypervisor/commit/3793ffe888dbc9c4aaf929d1b4846e50f1122d6c

Reported-by: Yi Wang <foxywang@tencent.com>