### PR TITLE
Update MSRV to 1.65

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.64"
+          - "1.65"
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://github.com/cloud-hypervisor/cloud-hypervisor"
 # a.) A dependency requires it,
 # b.) If we want to use a new feature and that MSRV is at least 6 months old,
 # c.) There is a security issue that is addressed by the toolchain update.
-rust-version = "1.64"
+rust-version = "1.65"
 
 [profile.release]
 lto = true

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -616,7 +616,9 @@ impl Block {
                 (disk_nsectors, avail_features, 0, config, false)
             };
 
-        let serial = serial.map(Vec::from).unwrap_or(build_serial(&disk_path));
+        let serial = serial
+            .map(Vec::from)
+            .unwrap_or_else(|| build_serial(&disk_path));
 
         Ok(Block {
             common: VirtioCommon {

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -119,7 +119,7 @@ impl SystemAllocator {
         self.platform_mmio_address_space.allocate(
             address,
             size,
-            Some(align_size.unwrap_or(get_page_size())),
+            Some(align_size.unwrap_or_else(get_page_size)),
         )
     }
 
@@ -133,7 +133,7 @@ impl SystemAllocator {
         self.mmio_hole_address_space.allocate(
             address,
             size,
-            Some(align_size.unwrap_or(get_page_size())),
+            Some(align_size.unwrap_or_else(get_page_size)),
         )
     }
 


### PR DESCRIPTION
Sev-Snp on MSHV uses igvm crate to parse the igvm file. igvm crate needs minimum rust version 1.65 to build.