### PR TITLE
Add support for GHCB handling for SEV-SNP guest on MSHV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
 [[package]]
 name = "mshv-bindings"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#c5a60508595dc504da469b89102b8b49e91714a9"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#af397ea8514303d3a19d21d33730e867f7415ba9"
 dependencies = [
  "libc",
  "serde",
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "mshv-ioctls"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#c5a60508595dc504da469b89102b8b49e91714a9"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#af397ea8514303d3a19d21d33730e867f7415ba9"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -257,6 +257,16 @@ pub enum HypervisorCpuError {
     ///
     #[error("Failed to set TSC frequency: {0}")]
     SetTscKhz(#[source] anyhow::Error),
+    ///
+    /// Error reading value at given GPA
+    ///
+    #[error("Failed to read from GPA: {0}")]
+    GpaRead(#[source] anyhow::Error),
+    ///
+    /// Error writing value at given GPA
+    ///
+    #[error("Failed to write to GPA: {0}")]
+    GpaWrite(#[source] anyhow::Error),
 }
 
 #[derive(Debug)]

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -948,6 +948,34 @@ impl cpu::Vcpu for MshvVcpu {
                                         .gpa_write(&mut arg)
                                         .map_err(|e| cpu::HypervisorCpuError::GpaWrite(e.into()))?;
                                 }
+                                SVM_EXITCODE_MMIO_WRITE => {
+                                    let dst_gpa =
+                                        info.__bindgen_anon_2.__bindgen_anon_1.sw_exit_info1;
+                                    let src_gpa = info.__bindgen_anon_2.__bindgen_anon_1.sw_scratch;
+                                    let data_len =
+                                        info.__bindgen_anon_2.__bindgen_anon_1.sw_exit_info2
+                                            as usize;
+                                    // Sanity check to make sure data len is within supported range.
+                                    assert!(data_len <= 0x8);
+                                    let mut arg: mshv_read_write_gpa =
+                                        mshv_bindings::mshv_read_write_gpa {
+                                            base_gpa: src_gpa,
+                                            byte_count: data_len as u32,
+                                            ..Default::default()
+                                        };
+
+                                    self.fd
+                                        .gpa_read(&mut arg)
+                                        .map_err(|e| cpu::HypervisorCpuError::GpaRead(e.into()))?;
+
+                                    if let Some(vm_ops) = &self.vm_ops {
+                                        vm_ops
+                                            .mmio_write(dst_gpa, &arg.data[0..data_len])
+                                            .map_err(|e| {
+                                                cpu::HypervisorCpuError::RunVcpu(e.into())
+                                            })?;
+                                    }
+                                }
                                 _ => panic!(
                                     "GHCB_INFO_NORMAL: Unhandled exit code: {:0x}",
                                     exit_code

--- a/hypervisor/src/mshv/snp_constants.rs
+++ b/hypervisor/src/mshv/snp_constants.rs
@@ -16,3 +16,8 @@ pub const ECDSA_SIG_X_COMPONENT_END: usize =
 pub const ECDSA_SIG_Y_COMPONENT_START: usize = ECDSA_SIG_X_COMPONENT_END;
 pub const ECDSA_SIG_Y_COMPONENT_END: usize =
     ECDSA_SIG_X_COMPONENT_END + ECDSA_SIG_Y_COMPONENT_SIZE_IN_BYTES;
+
+// These constants are derived from GHCB spec Sect. 2.6 Table 3 GHCB Layout
+// Link: https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56421.pdf
+pub const GHCB_SW_EXITINFO1_OFFSET: u64 = 0x398;
+pub const GHCB_SW_EXITINFO2_OFFSET: u64 = 0x3A0;

--- a/hypervisor/src/mshv/snp_constants.rs
+++ b/hypervisor/src/mshv/snp_constants.rs
@@ -19,5 +19,6 @@ pub const ECDSA_SIG_Y_COMPONENT_END: usize =
 
 // These constants are derived from GHCB spec Sect. 2.6 Table 3 GHCB Layout
 // Link: https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56421.pdf
+pub const GHCB_RAX_OFFSET: u64 = 0x01F8;
 pub const GHCB_SW_EXITINFO1_OFFSET: u64 = 0x398;
 pub const GHCB_SW_EXITINFO2_OFFSET: u64 = 0x3A0;


### PR DESCRIPTION
This PR implements the part 6 of #4761. There are still two things which are pending as part of GHCB handling:

- Adding support for secondary AP creation.
- Adding support for SNP guest request.

I will add support for these two things in the subsequent PRs as they require bit more restructuring around the existing codebase.