### PR TITLE
arch: Add default NUMA distance on aarch64

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -1059,7 +1059,7 @@ fn create_distance_map_node(fdt: &mut FdtWriter, numa_nodes: &NumaNodes) -> FdtW
                     .unwrap()
                     .distances
                     .get(&(dest_numa_node as u32))
-                    .unwrap() as u32,
+                    .unwrap_or(20) as u32,
             );
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2930,6 +2930,7 @@ mod common_parallel {
         handle_child_output(r, &output);
     }
 
+    #[test]
     fn test_pci_multiple_segments_numa_node() {
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(focal));
@@ -2958,16 +2959,10 @@ mod common_parallel {
             .args(["--platform", "num_pci_segments=2"])
             .args(["--cpus", "boot=2"])
             .args(["--memory", "size=0"])
-            .args([
-                "--memory-zone",
-                "id=mem0,size=256M",
-                "--memory-zone",
-                "id=mem1,size=256M",
-            ])
+            .args(["--memory-zone", "id=mem0,size=256M", "id=mem1,size=256M"])
             .args([
                 "--numa",
                 "guest_numa_id=0,cpus=[0],memory_zones=mem0,pci_segments=[0]",
-                "--numa",
                 "guest_numa_id=1,cpus=[1],memory_zones=mem1,pci_segments=[1]",
             ])
             .args(["--kernel", kernel_path.to_str().unwrap()])
@@ -2981,13 +2976,11 @@ mod common_parallel {
                     guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
                 )
                 .as_str(),
-                "--disk",
                 format!(
                     "path={}",
                     guest.disk_config.disk(DiskType::CloudInit).unwrap()
                 )
                 .as_str(),
-                "--disk",
                 format!("path={test_disk_path},pci_segment={TEST_DISK_NODE}").as_str(),
             ])
             .default_net()


### PR DESCRIPTION
This PR makes the `distances` property of `numa` optional (with a default distance of 20) to match the behavior on x86_64.

See https://github.com/cloud-hypervisor/cloud-hypervisor/pull/5864 https://github.com/cloud-hypervisor/cloud-hypervisor/pull/5868