### PR TITLE
aarch64:fdt: correct vcpu topology related value

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -290,10 +290,7 @@ fn create_cpu_nodes(
     fdt.property_u32("#size-cells", 0x0)?;
 
     let num_cpus = vcpu_mpidr.len();
-    let threads_per_core = vcpu_topology.unwrap_or_default().0;
-    let cores_per_package = vcpu_topology.unwrap_or_default().1;
-    let packages = vcpu_topology.unwrap_or_default().2;
-
+    let (threads_per_core, cores_per_package, packages) = vcpu_topology.unwrap_or((1, 1, 1));
     let max_cpus: u32 = (threads_per_core * cores_per_package * packages).into();
 
     // Add cache info.


### PR DESCRIPTION
Once vcpu_topology is None, values, like cores_per_package, will be set to zero.
Correct it by setting them to 1s when vcpu_topology is none.

Also add check in case one or more of these values are zero.

Fixes: #5892