### PR TITLE
scripts: Use Rust specified toolchain for virtiofsd

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -42,7 +42,7 @@ build_virtiofsd() {
 
     if [ ! -f "$VIRTIOFSD_DIR/.built" ]; then
         pushd $VIRTIOFSD_DIR
-        time cargo build --release
+        time cargo build --release --target $BUILD_TARGET
         cp target/release/virtiofsd "$WORKLOADS_DIR/" || exit 1
         touch .built
         popd


### PR DESCRIPTION
Various environment variables are set (e.g. target_cc) that are used for
building the CH binary and test framework with musl. Those environment
variables can cause issues when compiling against the default gnu
toolchain.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
