### PR TITLE
scripts: Clear the toolchain environment variables for virtiofsd

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -42,7 +42,8 @@ build_virtiofsd() {
 
     if [ ! -f "$VIRTIOFSD_DIR/.built" ]; then
         pushd $VIRTIOFSD_DIR
-        time cargo build --release
+        rm -rf target/
+        time RUSTFLAGS="" TARGET_CC="" cargo build --release
         cp target/release/virtiofsd "$WORKLOADS_DIR/" || exit 1
         touch .built
         popd


### PR DESCRIPTION
virtiofsd must be built with the default gnu toolchain so clear the
environment variables that may poisoned by the alternative C library
support.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
