### PR TITLE
scripts: Download 'hypervisor-fw' from Azure storage

### DIFF
--- a/scripts/run_integration_tests_sgx.sh
+++ b/scripts/run_integration_tests_sgx.sh
@@ -14,11 +14,9 @@ fi
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
 
-FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/rust-hypervisor-firmware/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
-FW="$WORKLOADS_DIR/hypervisor-fw"
+FW_URL="https://cloud-hypervisor.azureedge.net/hypervisor-fw-0.4.2"
 pushd $WORKLOADS_DIR
-rm -f $FW
-time wget --quiet $FW_URL || exit 1
+time wget --quiet $FW_URL -O hypervisor-fw || exit 1
 popd
 
 JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20230119-0.qcow2"

--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -15,7 +15,7 @@ process_common_args "$@"
 WORKLOADS_DIR="$HOME/workloads"
 
 # Always download the latest "hypervisor-fw"
-FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/rust-hypervisor-firmware/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
+FW_URL="https://cloud-hypervisor.azureedge.net/hypervisor-fw-0.4.2"
 pushd $WORKLOADS_DIR
 time wget --quiet $FW_URL -O hypervisor-fw || exit 1
 popd

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -18,11 +18,11 @@ fi
 
 cp scripts/sha1sums-x86_64 $WORKLOADS_DIR
 
-FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/rust-hypervisor-firmware/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
+FW_URL="https://cloud-hypervisor.azureedge.net/hypervisor-fw-0.4.2"
 FW="$WORKLOADS_DIR/hypervisor-fw"
 if [ ! -f "$FW" ]; then
     pushd $WORKLOADS_DIR
-    time wget --quiet $FW_URL || exit 1
+    time wget --quiet $FW_URL -O hypervisor-fw|| exit 1
     popd
 fi
 


### PR DESCRIPTION
Our baremetal workers on VFIO and SGX failed frequently due to errors of downloading 'hypervisor-fw' binary from GitHub website directly. To avoid these errors, this patch downloaded the same 'hypervisor-fw' binary from Azure storage. Considering 'hypervisor-fw' does not cut new release very frequently, the overhead of maintaining to its latest release on Azure storage won't be very high.

Fixes: #5759