### PR TITLE
vmm: Allow IP configuration on named TAP interfaces

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2464,8 +2464,8 @@ impl DeviceManager {
                     virtio_devices::Net::new(
                         id.clone(),
                         Some(tap_if_name),
-                        None,
-                        None,
+                        Some(net_cfg.ip),
+                        Some(net_cfg.mask),
                         Some(net_cfg.mac),
                         &mut net_cfg.host_mac,
                         net_cfg.mtu,


### PR DESCRIPTION
Hi,

this PR fixes an issue with named tap devices. In the current implementation, tap devices with an explicit name cannot be assigned an IP/netmask. The creation of the VM works and the TAP interface is silently created without any ip configuration. This fix will assign the IP address given by the user in the `NetConfig` struct.

Caveat: This might have an impact on existing use-cases as `"tap=customTap,mac=,ip=,mask="` will now set the default IP on that interface as it would on an "unnamed" interface.

Creating a TAP device without an IP configuration seems to therefore become impossible (?) with this change.

I have not found any documentation that this behavior was intentional. I'd find it preferable to make creation of TAP interfaces without an IP explicitly possible (e.g. by not setting IP configuration by default in any case).

**Examples**

When setting up a standard TAP device:

```bash
$ ./target/debug/cloud-hypervisor \
    --kernel ./hypervisor-fw \
    --disk path=focal-server-cloudimg-amd64.raw \
    --cpus boot=4 --memory size=1024M \
    --net "tap=,mac=,ip=,mask="
```

```bash
$ ip a show vmtap0
7: vmtap0: <BROADCAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 1000
    link/ether c6:49:a2:4b:aa:4e brd ff:ff:ff:ff:ff:ff                                                                                           
    inet 192.168.249.1/24 brd 192.168.249.255 scope global vmtap0
       valid_lft forever preferred_lft forever      
    inet6 fe80::98bc:3ff:feea:bb17/64 scope link
       valid_lft forever preferred_lft forever
```

When setting up a TAP device with an explicit name:

```bash
$ ./target/debug/cloud-hypervisor \
    --kernel ./hypervisor-fw \
    --disk path=focal-server-cloudimg-amd64.raw \
    --cpus boot=4 \
    --memory size=1024M \
    --net "tap=customTap,mac=,ip=,mask="
```

```bash
$ ip a show customTap
9: customTap: <BROADCAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 1000
    link/ether 56:12:bc:3d:88:50 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::24b1:50ff:fe46:c30d/64 scope link
       valid_lft forever preferred_lft forever
```

With this fix, the same command now sets an IP for that interface as it would with an "unnamed" TAP:

```bash
$ ip a show customTap
8: customTap: <BROADCAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 1000
    link/ether 56:12:bc:3d:88:50 brd ff:ff:ff:ff:ff:ff
    inet 192.168.249.1/24 brd 192.168.249.255 scope global customTap
       valid_lft forever preferred_lft forever
    inet6 fe80::6886:3bff:fe50:4d10/64 scope link
       valid_lft forever preferred_lft forever
```

This also works with an explicit IP:

```bash
$ ./target/debug/cloud-hypervisor \
    --kernel ./hypervisor-fw \
    --disk path=focal-server-cloudimg-amd64.raw \
    --cpus boot=4 \
    --memory size=1024M \
    --net "tap=customTap,mac=,ip=10.0.0.5,mask=255.255.255.0"
```

```bash
$ ip a show customTap
10: customTap: <BROADCAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 1000
    link/ether 56:12:bc:3d:88:50 brd ff:ff:ff:ff:ff:ff
    inet 10.0.0.5/24 brd 10.0.0.255 scope global customTap
       valid_lft forever preferred_lft forever
    inet6 fe80::50a4:18ff:fe36:d4f8/64 scope link 
       valid_lft forever preferred_lft forever
```

@blitz