### PR TITLE
build: Upgrade vm-memory crates and its consumers 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db6a725c8000971f83fa93ed7ee1b600e55a1471a2a653379d3c84f72effdcf"
+checksum = "132a531b85b3a164012ab682c72f8f2cce7757f187be5f60782fd2b4cda9cb34"
 dependencies = [
  "vm-memory",
 ]
@@ -2288,7 +2288,7 @@ dependencies = [
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#847b0aa504ac6367efe42ba7e96a2d050737d4f0"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#59c604fa6e42080f0a47c124ba29454fe4cb7475"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#847b0aa504ac6367efe42ba7e96a2d050737d4f0"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#59c604fa6e42080f0a47c124ba29454fe4cb7475"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -2314,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "vfio_user"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio-user?branch=main#2d96b90a7279547356ad8f83aaa3115ad5497302"
+source = "git+https://github.com/rust-vmm/vfio-user?branch=main#6c72e997e61d9e84b8ee691ad63ece6c717cf5aa"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -2330,11 +2330,11 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61957aeb36daf0b00b87fff9c10dd28a161bd35ab157553d340d183b3d8756e6"
+checksum = "289adfce099c71f8310f895932ccd978f352ca494ea47496dbe20d4241888b82"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "libc",
  "vm-memory",
  "vmm-sys-util",
@@ -2342,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab069cdedaf18a0673766eb0a07a0f4ee3ed1b8e17fbfe4aafe5b988e2de1d01"
+checksum = "61255322e3ebe93fb77d9f6d99577eca7089bbea4174076c5353a8024a463061"
 dependencies = [
  "libc",
  "log",
@@ -2394,9 +2394,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-bindings"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c18d7b74098a946470ea265b5bacbbf877abc3373021388454de0d47735a5b98"
+checksum = "878bcb1b2812a10c30d53b0ed054999de3d98f25ece91fc173973f9c57aaae86"
 
 [[package]]
 name = "virtio-devices"
@@ -2434,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35aca00da06841bd99162c381ec65893cace23ca0fb89254302cfe4bec4c300f"
+checksum = "73a01db2cfb6c4b9bc20608b1336263d16714ea8db05de9fec2a254e076f9385"
 dependencies = [
  "log",
  "virtio-bindings",
@@ -2473,9 +2473,9 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#77212bd0d62913e445c
 
 [[package]]
 name = "vm-memory"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc276f0d00c17b9aeb584da0f1e1c673df0d183cc2539e3636ec8cbc5eae99b"
+checksum = "5376c9ee5ebe2103a310d8241936cfb93c946734b0479a4fa5bdf7a64abbacd8"
 dependencies = [
  "arc-swap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tpm = { path = "tpm"}
 tracer = { path = "tracer" }
 vmm = { path = "vmm" }
 vmm-sys-util = "0.11.0"
-vm-memory = "0.12.2"
+vm-memory = "0.13.1"
 zbus = { version = "3.11.1", optional = true }
 
 # List of patched crates

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -14,14 +14,14 @@ anyhow = "1.0.75"
 byteorder = "1.4.3"
 hypervisor = { path = "../hypervisor" }
 libc = "0.2.147"
-linux-loader = { version = "0.9.1", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.10.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.17"
 serde = { version = "1.0.168", features = ["rc", "derive"] }
 thiserror = "1.0.40"
 uuid = "1.3.4"
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-bitmap"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { version = "0.11.0", features = ["with-serde"] }
 

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -21,7 +21,7 @@ uuid = { version = "1.3.4", features = ["v4"] }
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
 virtio-bindings = { version = "0.2.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.9.0"
-vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.10.0"
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.11.0"

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -143,10 +143,14 @@ pub enum ExecuteError {
     Flush(io::Error),
     #[error("Failed to read: {0}")]
     Read(GuestMemoryError),
+    #[error("Failed to read_exact: {0}")]
+    ReadExact(io::Error),
     #[error("Failed to seek: {0}")]
     Seek(io::Error),
     #[error("Failed to write: {0}")]
     Write(GuestMemoryError),
+    #[error("Failed to write_all: {0}")]
+    WriteAll(io::Error),
     #[error("Unsupported request: {0}")]
     Unsupported(u32),
     #[error("Failed to submit io uring: {0}")]
@@ -169,8 +173,10 @@ impl ExecuteError {
             ExecuteError::BadRequest(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::Flush(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::Read(_) => VIRTIO_BLK_S_IOERR,
+            ExecuteError::ReadExact(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::Seek(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::Write(_) => VIRTIO_BLK_S_IOERR,
+            ExecuteError::WriteAll(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::Unsupported(_) => VIRTIO_BLK_S_UNSUPP,
             ExecuteError::SubmitIoUring(_) => VIRTIO_BLK_S_IOERR,
             ExecuteError::GetHostAddress(_) => VIRTIO_BLK_S_IOERR,
@@ -351,13 +357,23 @@ impl Request {
 
             match self.request_type {
                 RequestType::In => {
-                    mem.read_exact_from(*data_addr, disk, *data_len as usize)
-                        .map_err(ExecuteError::Read)?;
+                    let mut buf = vec![0u8; *data_len as usize];
+                    buf.shrink_to_fit();
+                    disk.read_exact(&mut buf).map_err(ExecuteError::ReadExact)?;
+                    mem.read_exact_volatile_from(
+                        *data_addr,
+                        &mut buf.as_slice(),
+                        *data_len as usize,
+                    )
+                    .map_err(ExecuteError::Read)?;
                     len += data_len;
                 }
                 RequestType::Out => {
-                    mem.write_all_to(*data_addr, disk, *data_len as usize)
+                    let mut buf = vec![0u8; *data_len as usize];
+                    buf.shrink_to_fit();
+                    mem.write_all_volatile_to(*data_addr, &mut buf, *data_len as usize)
                         .map_err(ExecuteError::Write)?;
+                    disk.write_all(&buf).map_err(ExecuteError::WriteAll)?;
                     if !self.writeback {
                         disk.flush().map_err(ExecuteError::Flush)?;
                     }

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -21,7 +21,7 @@ versionize = "0.1.10"
 versionize_derive = "0.1.4"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = "0.12.2"
+vm-memory = "0.13.1"
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = "0.11.0"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db6a725c8000971f83fa93ed7ee1b600e55a1471a2a653379d3c84f72effdcf"
+checksum = "132a531b85b3a164012ab682c72f8f2cce7757f187be5f60782fd2b4cda9cb34"
 dependencies = [
  "vm-memory",
 ]
@@ -917,7 +917,7 @@ dependencies = [
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#847b0aa504ac6367efe42ba7e96a2d050737d4f0"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#59c604fa6e42080f0a47c124ba29454fe4cb7475"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -925,7 +925,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#847b0aa504ac6367efe42ba7e96a2d050737d4f0"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#59c604fa6e42080f0a47c124ba29454fe4cb7475"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -941,7 +941,7 @@ dependencies = [
 [[package]]
 name = "vfio_user"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio-user?branch=main#2d96b90a7279547356ad8f83aaa3115ad5497302"
+source = "git+https://github.com/rust-vmm/vfio-user?branch=main#6c72e997e61d9e84b8ee691ad63ece6c717cf5aa"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -957,11 +957,11 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61957aeb36daf0b00b87fff9c10dd28a161bd35ab157553d340d183b3d8756e6"
+checksum = "289adfce099c71f8310f895932ccd978f352ca494ea47496dbe20d4241888b82"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "libc",
  "vm-memory",
  "vmm-sys-util",
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-bindings"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c18d7b74098a946470ea265b5bacbbf877abc3373021388454de0d47735a5b98"
+checksum = "878bcb1b2812a10c30d53b0ed054999de3d98f25ece91fc173973f9c57aaae86"
 
 [[package]]
 name = "virtio-devices"
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35aca00da06841bd99162c381ec65893cace23ca0fb89254302cfe4bec4c300f"
+checksum = "73a01db2cfb6c4b9bc20608b1336263d16714ea8db05de9fec2a254e076f9385"
 dependencies = [
  "log",
  "virtio-bindings",
@@ -1048,9 +1048,9 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#c5a99ab71b130435927
 
 [[package]]
 name = "vm-memory"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc276f0d00c17b9aeb584da0f1e1c673df0d183cc2539e3636ec8cbc5eae99b"
+checksum = "5376c9ee5ebe2103a310d8241936cfb93c946734b0479a4fa5bdf7a64abbacd8"
 dependencies = [
  "arc-swap",
  "libc",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,16 +14,16 @@ devices = { path = "../devices" }
 epoll = "4.3.1"
 libc = "0.2.149"
 libfuzzer-sys = "0.4.7"
-linux-loader = { version = "0.9.1", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.10.0", features = ["elf", "bzimage", "pe"] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 net_util = { path = "../net_util" }
 once_cell = "1.18.0"
 seccompiler = "0.4.0"
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.9.0"
+virtio-queue = "0.10.0"
 vmm = { path = "../vmm" }
 vmm-sys-util = "0.11.2"
-vm-memory = "0.12.2"
+vm-memory = "0.13.1"
 vm-device = { path = "../vm-device" }
 vm-virtio = { path = "../vm-virtio" }
 

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -25,7 +25,7 @@ mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optio
 serde = { version = "1.0.168", features = ["rc", "derive"] }
 serde_with = { version = "3.4.0", default-features = false, features = ["macros"] }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { version = "0.11.0", features = ["with-serde"] }
 thiserror = "1.0.40"
 

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -16,8 +16,8 @@ thiserror = "1.0.40"
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
 virtio-bindings = "0.2.0"
-virtio-queue = "0.9.0"
-vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.10.0"
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.11.0"
 

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -26,5 +26,5 @@ versionize = "0.1.10"
 versionize_derive = "0.1.4"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -13,10 +13,9 @@ epoll = "4.3.3"
 libc = "0.2.147"
 log = "0.4.17"
 option_parser = { path = "../option_parser" }
-vhost = { version = "0.8.1", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.10.1"
+vhost = { version = "0.9.0", features = ["vhost-user-backend"] }
+vhost-user-backend = "0.11.0"
 virtio-bindings = "0.2.0"
-virtio-queue = "0.9.0"
-vm-memory = "0.12.2"
+virtio-queue = "0.10.0"
+vm-memory = "0.13.1"
 vmm-sys-util = "0.11.0"
-

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -299,9 +299,10 @@ impl VhostUserBlkBackend {
     }
 }
 
-impl VhostUserBackendMut<VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>, AtomicBitmap>
-    for VhostUserBlkBackend
-{
+impl VhostUserBackendMut for VhostUserBlkBackend {
+    type Bitmap = AtomicBitmap;
+    type Vring = VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>;
+
     fn num_queues(&self) -> usize {
         self.config.num_queues as usize
     }
@@ -350,7 +351,7 @@ impl VhostUserBackendMut<VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>, Atomic
         evset: EventSet,
         vrings: &[VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>],
         thread_id: usize,
-    ) -> VhostUserBackendResult<bool> {
+    ) -> VhostUserBackendResult<()> {
         if evset != EventSet::IN {
             return Err(Error::HandleEventNotEpollIn.into());
         }
@@ -394,7 +395,7 @@ impl VhostUserBackendMut<VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>, Atomic
                     thread.process_queue(&mut vring);
                 }
 
-                Ok(false)
+                Ok(())
             }
             _ => Err(Error::HandleEventUnknownEvent.into()),
         }

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -13,9 +13,9 @@ libc = "0.2.147"
 log = "0.4.17"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
-vhost = { version = "0.8.1", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.10.1"
+vhost = { version = "0.9.0", features = ["vhost-user-backend"] }
+vhost-user-backend = "0.11.0"
 virtio-bindings = "0.2.0"
-vm-memory = "0.12.2"
+vm-memory = "0.13.1"
 vmm-sys-util = "0.11.0"
 

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -158,9 +158,10 @@ impl VhostUserNetBackend {
     }
 }
 
-impl VhostUserBackendMut<VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>, AtomicBitmap>
-    for VhostUserNetBackend
-{
+impl VhostUserBackendMut for VhostUserNetBackend {
+    type Bitmap = AtomicBitmap;
+    type Vring = VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>;
+
     fn num_queues(&self) -> usize {
         self.num_queues
     }
@@ -203,7 +204,7 @@ impl VhostUserBackendMut<VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>, Atomic
         _evset: EventSet,
         vrings: &[VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>],
         thread_id: usize,
-    ) -> VhostUserBackendResult<bool> {
+    ) -> VhostUserBackendResult<()> {
         let mut thread = self.threads[thread_id].lock().unwrap();
         match device_event {
             0 => {
@@ -245,7 +246,7 @@ impl VhostUserBackendMut<VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>, Atomic
             _ => return Err(Error::HandleEventUnknownEvent.into()),
         }
 
-        Ok(false)
+        Ok(())
     }
 
     fn exit_event(&self, thread_index: usize) -> Option<EventFd> {

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -27,12 +27,12 @@ serial_buffer = { path = "../serial_buffer" }
 thiserror = "1.0.40"
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
-vhost = { version = "0.8.1", features = ["vhost-user-master", "vhost-user-slave", "vhost-kern", "vhost-vdpa"] }
+vhost = { version = "0.9.0", features = ["vhost-user-frontend", "vhost-user-backend", "vhost-kern", "vhost-vdpa"] }
 virtio-bindings = { version = "0.2.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.9.0"
+virtio-queue = "0.10.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.11.0"

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -24,7 +24,7 @@ use thiserror::Error;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use virtio_queue::{Queue, QueueT};
-use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryAtomic};
+use vm_memory::{GuestAddressSpace, GuestMemory, GuestMemoryAtomic};
 use vm_migration::VersionMapped;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vm_virtio::{AccessPlatform, Translatable};
@@ -75,7 +75,7 @@ impl RngEpollHandler {
             // Fill the read with data from the random device on the host.
             let len = desc_chain
                 .memory()
-                .read_from(
+                .read_volatile_from(
                     desc.addr()
                         .translate_gva(self.access_platform.as_ref(), desc.len() as usize),
                     &mut self.random_file,

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -23,7 +23,7 @@ use vhost::vhost_user::message::{
     VhostUserConfigFlags, VhostUserProtocolFeatures, VhostUserVirtioFeatures,
     VHOST_USER_CONFIG_OFFSET,
 };
-use vhost::vhost_user::{MasterReqHandler, VhostUserMaster, VhostUserMasterReqHandler};
+use vhost::vhost_user::{FrontendReqHandler, VhostUserFrontend, VhostUserFrontendReqHandler};
 use virtio_bindings::virtio_blk::{
     VIRTIO_BLK_F_BLK_SIZE, VIRTIO_BLK_F_CONFIG_WCE, VIRTIO_BLK_F_DISCARD, VIRTIO_BLK_F_FLUSH,
     VIRTIO_BLK_F_GEOMETRY, VIRTIO_BLK_F_MQ, VIRTIO_BLK_F_RO, VIRTIO_BLK_F_SEG_MAX,
@@ -50,8 +50,8 @@ pub struct State {
 
 impl VersionMapped for State {}
 
-struct SlaveReqHandler {}
-impl VhostUserMasterReqHandler for SlaveReqHandler {}
+struct BackendReqHandler {}
+impl VhostUserFrontendReqHandler for BackendReqHandler {}
 
 pub struct Blk {
     common: VirtioCommon,
@@ -294,7 +294,7 @@ impl VirtioDevice for Blk {
         self.common.activate(&queues, &interrupt_cb)?;
         self.guest_memory = Some(mem.clone());
 
-        let slave_req_handler: Option<MasterReqHandler<SlaveReqHandler>> = None;
+        let backend_req_handler: Option<FrontendReqHandler<BackendReqHandler>> = None;
 
         // Run a dedicated thread for handling potential reconnections with
         // the backend.
@@ -305,7 +305,7 @@ impl VirtioDevice for Blk {
             queues,
             interrupt_cb,
             self.common.acked_features,
-            slave_req_handler,
+            backend_req_handler,
             kill_evt,
             pause_evt,
         )?;

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -20,7 +20,7 @@ use std::vec::Vec;
 use versionize::{VersionMap, Versionize, VersionizeResult};
 use versionize_derive::Versionize;
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
-use vhost::vhost_user::{MasterReqHandler, VhostUserMaster, VhostUserMasterReqHandler};
+use vhost::vhost_user::{FrontendReqHandler, VhostUserFrontend, VhostUserFrontendReqHandler};
 use virtio_bindings::virtio_net::{
     VIRTIO_NET_F_CSUM, VIRTIO_NET_F_CTRL_VQ, VIRTIO_NET_F_GUEST_CSUM, VIRTIO_NET_F_GUEST_ECN,
     VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_TSO6, VIRTIO_NET_F_GUEST_UFO,
@@ -49,8 +49,8 @@ pub struct State {
 
 impl VersionMapped for State {}
 
-struct SlaveReqHandler {}
-impl VhostUserMasterReqHandler for SlaveReqHandler {}
+struct BackendReqHandler {}
+impl VhostUserFrontendReqHandler for BackendReqHandler {}
 
 pub struct Net {
     common: VirtioCommon,
@@ -342,7 +342,7 @@ impl VirtioDevice for Net {
             self.ctrl_queue_epoll_thread = Some(epoll_threads.remove(0));
         }
 
-        let slave_req_handler: Option<MasterReqHandler<SlaveReqHandler>> = None;
+        let backend_req_handler: Option<FrontendReqHandler<BackendReqHandler>> = None;
 
         // The backend acknowledged features must not contain VIRTIO_NET_F_MAC
         // since we don't expect the backend to handle it.
@@ -357,7 +357,7 @@ impl VirtioDevice for Net {
             queues,
             interrupt_cb,
             backend_acked_features,
-            slave_req_handler,
+            backend_req_handler,
             kill_evt,
             pause_evt,
         )?;

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -21,7 +21,9 @@ use vhost::vhost_kern::vhost_binding::{VHOST_F_LOG_ALL, VHOST_VRING_F_LOG};
 use vhost::vhost_user::message::{
     VhostUserHeaderFlag, VhostUserInflight, VhostUserProtocolFeatures, VhostUserVirtioFeatures,
 };
-use vhost::vhost_user::{Master, MasterReqHandler, VhostUserMaster, VhostUserMasterReqHandler};
+use vhost::vhost_user::{
+    Frontend, FrontendReqHandler, VhostUserFrontend, VhostUserFrontendReqHandler,
+};
 use vhost::{VhostBackend, VhostUserDirtyLogRegion, VhostUserMemoryRegionInfo, VringConfigData};
 use virtio_queue::{Descriptor, Queue, QueueT};
 use vm_memory::{
@@ -48,7 +50,7 @@ struct VringInfo {
 
 #[derive(Clone)]
 pub struct VhostUserHandle {
-    vu: Master,
+    vu: Frontend,
     ready: bool,
     supports_migration: bool,
     shm_log: Option<Arc<MmapRegion>>,
@@ -149,13 +151,13 @@ impl VhostUserHandle {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn setup_vhost_user<S: VhostUserMasterReqHandler>(
+    pub fn setup_vhost_user<S: VhostUserFrontendReqHandler>(
         &mut self,
         mem: &GuestMemoryMmap,
         queues: Vec<(usize, Queue, EventFd)>,
         virtio_interrupt: &Arc<dyn VirtioInterrupt>,
         acked_features: u64,
-        slave_req_handler: &Option<MasterReqHandler<S>>,
+        backend_req_handler: &Option<FrontendReqHandler<S>>,
         inflight: Option<&mut Inflight>,
     ) -> Result<()> {
         self.vu
@@ -267,10 +269,10 @@ impl VhostUserHandle {
 
         self.enable_vhost_user_vrings(self.queue_indexes.clone(), true)?;
 
-        if let Some(slave_req_handler) = slave_req_handler {
+        if let Some(backend_req_handler) = backend_req_handler {
             self.vu
-                .set_slave_request_fd(&slave_req_handler.get_tx_raw_fd())
-                .map_err(Error::VhostUserSetSlaveRequestFd)?;
+                .set_backend_request_fd(&backend_req_handler.get_tx_raw_fd())
+                .map_err(Error::VhostUserSetBackendRequestFd)?;
         }
 
         self.vrings_info = Some(vrings_info);
@@ -334,14 +336,14 @@ impl VhostUserHandle {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn reinitialize_vhost_user<S: VhostUserMasterReqHandler>(
+    pub fn reinitialize_vhost_user<S: VhostUserFrontendReqHandler>(
         &mut self,
         mem: &GuestMemoryMmap,
         queues: Vec<(usize, Queue, EventFd)>,
         virtio_interrupt: &Arc<dyn VirtioInterrupt>,
         acked_features: u64,
         acked_protocol_features: u64,
-        slave_req_handler: &Option<MasterReqHandler<S>>,
+        backend_req_handler: &Option<FrontendReqHandler<S>>,
         inflight: Option<&mut Inflight>,
     ) -> Result<()> {
         self.set_protocol_features_vhost_user(acked_features, acked_protocol_features)?;
@@ -351,7 +353,7 @@ impl VhostUserHandle {
             queues,
             virtio_interrupt,
             acked_features,
-            slave_req_handler,
+            backend_req_handler,
             inflight,
         )
     }
@@ -373,7 +375,7 @@ impl VhostUserHandle {
             let (stream, _) = listener.accept().map_err(Error::AcceptConnection)?;
 
             Ok(VhostUserHandle {
-                vu: Master::from_stream(stream, num_queues),
+                vu: Frontend::from_stream(stream, num_queues),
                 ready: false,
                 supports_migration: false,
                 shm_log: None,
@@ -386,7 +388,7 @@ impl VhostUserHandle {
 
             // Retry connecting for a full minute
             let err = loop {
-                let err = match Master::connect(socket_path, num_queues) {
+                let err = match Frontend::connect(socket_path, num_queues) {
                     Ok(m) => {
                         return Ok(VhostUserHandle {
                             vu: m,
@@ -415,7 +417,7 @@ impl VhostUserHandle {
         }
     }
 
-    pub fn socket_handle(&mut self) -> &mut Master {
+    pub fn socket_handle(&mut self) -> &mut Frontend {
         &mut self.vu
     }
 

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.147"
-vm-memory = "0.12.2"
+vm-memory = "0.13.1"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 arch = { path = "../arch" }

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -15,6 +15,5 @@ hypervisor = { path = "../hypervisor" }
 thiserror = "1.0.40"
 serde = { version = "1.0.168", features = ["rc", "derive"] }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vm-memory = { version = "0.12.2", features = ["backend-mmap"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap"] }
 vmm-sys-util = "0.11.0"
-

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -11,4 +11,4 @@ serde = { version = "1.0.168", features = ["rc", "derive"] }
 serde_json = "1.0.107"
 versionize = "0.1.10"
 versionize_derive = "0.1.4"
-vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -9,5 +9,5 @@ default = []
 
 [dependencies]
 log = "0.4.17"
-virtio-queue = "0.9.0"
-vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+virtio-queue = "0.10.0"
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -34,7 +34,7 @@ gdbstub = { version = "0.6.4", optional = true }
 gdbstub_arch = { version = "0.2.4", optional = true }
 hypervisor = { path = "../hypervisor" }
 libc = "0.2.147"
-linux-loader = { version = "0.9.1", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.10.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.17"
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 net_util = { path = "../net_util" }
@@ -54,10 +54,10 @@ versionize_derive = "0.1.4"
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
 vfio_user = { git = "https://github.com/rust-vmm/vfio-user", branch = "main" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.9.0"
+virtio-queue = "0.10.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.12.2", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { version = "0.11.0", features = ["with-serde"] }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -51,6 +51,7 @@ use std::{result, thread};
 use thiserror::Error;
 use tracer::trace_scoped;
 use vm_memory::bitmap::AtomicBitmap;
+use vm_memory::{ReadVolatile, WriteVolatile};
 use vm_migration::{protocol::*, Migratable};
 use vm_migration::{MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
@@ -1449,7 +1450,7 @@ impl Vmm {
         memory_manager: &mut MemoryManager,
     ) -> std::result::Result<(), MigratableError>
     where
-        T: Read + Write,
+        T: Read + ReadVolatile + Write,
     {
         // Read table
         let table = MemoryRangeTable::read_from(socket, req.length())?;
@@ -1608,7 +1609,7 @@ impl Vmm {
         socket: &mut T,
     ) -> result::Result<bool, MigratableError>
     where
-        T: Read + Write,
+        T: Read + Write + WriteVolatile,
     {
         // Send (dirty) memory table
         let table = vm.dirty_log()?;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -30,7 +30,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::ffi;
 use std::fs::{File, OpenOptions};
-use std::io::{self, Read};
+use std::io::{self};
 use std::ops::{BitAnd, Deref, Not, Sub};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::PathBuf;
@@ -47,8 +47,9 @@ use vm_device::BusDevice;
 use vm_memory::bitmap::AtomicBitmap;
 use vm_memory::guest_memory::FileOffset;
 use vm_memory::{
-    mmap::MmapRegionError, Address, Bytes, Error as MmapError, GuestAddress, GuestAddressSpace,
+    mmap::MmapRegionError, Address, Error as MmapError, GuestAddress, GuestAddressSpace,
     GuestMemory, GuestMemoryAtomic, GuestMemoryError, GuestMemoryRegion, GuestUsize, MmapRegion,
+    ReadVolatile,
 };
 use vm_migration::{
     protocol::MemoryRange, protocol::MemoryRangeTable, Migratable, MigratableError, Pausable,
@@ -728,7 +729,7 @@ impl MemoryManager {
             // see: https://github.com/rust-vmm/vm-memory/issues/174
             loop {
                 let bytes_read = guest_memory
-                    .read_from(
+                    .read_volatile_from(
                         GuestAddress(range.gpa + offset),
                         &mut memory_file,
                         (range.length - offset) as usize,
@@ -2093,7 +2094,7 @@ impl MemoryManager {
             let mut offset: u64 = 0;
             loop {
                 let bytes_written = guest_memory
-                    .write_to(
+                    .write_volatile_to(
                         GuestAddress(range.gpa + offset),
                         &mut coredump_file,
                         (range.length - offset) as usize,
@@ -2118,7 +2119,7 @@ impl MemoryManager {
         fd: &mut F,
     ) -> std::result::Result<(), MigratableError>
     where
-        F: Read,
+        F: ReadVolatile,
     {
         let guest_memory = self.guest_memory();
         let mem = guest_memory.memory();
@@ -2132,7 +2133,7 @@ impl MemoryManager {
             // see: https://github.com/rust-vmm/vm-memory/issues/174
             loop {
                 let bytes_read = mem
-                    .read_from(
+                    .read_volatile_from(
                         GuestAddress(range.gpa + offset),
                         fd,
                         (range.length - offset) as usize,
@@ -2600,7 +2601,7 @@ impl Transportable for MemoryManager {
             // see: https://github.com/rust-vmm/vm-memory/issues/174
             loop {
                 let bytes_written = guest_memory
-                    .write_to(
+                    .write_volatile_to(
                         GuestAddress(range.gpa + offset),
                         &mut memory_file,
                         (range.length - offset) as usize,


### PR DESCRIPTION
This PR also accommodates the API changes from vhost (https://github.com/rust-vmm/vhost/pull/187), vhost-user-backend (https://github.com/rust-vmm/vhost/pull/155) and vm-memory crate (https://github.com/rust-vmm/vm-memory/pull/247).