### PR TITLE
vmm: assign each pci segment 32-bit mmio allocator

### DIFF
--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -58,7 +58,8 @@ pub trait PciDevice: BusDevice {
     fn allocate_bars(
         &mut self,
         _allocator: &Arc<Mutex<SystemAllocator>>,
-        _mmio_allocator: &mut AddressAllocator,
+        _mmio32_allocator: &mut AddressAllocator,
+        _mmio64_allocator: &mut AddressAllocator,
         _resources: Option<Vec<Resource>>,
     ) -> Result<Vec<PciBarConfiguration>> {
         Ok(Vec::new())
@@ -68,7 +69,8 @@ pub trait PciDevice: BusDevice {
     fn free_bars(
         &mut self,
         _allocator: &mut SystemAllocator,
-        _mmio_allocator: &mut AddressAllocator,
+        _mmio32_allocator: &mut AddressAllocator,
+        _mmio64_allocator: &mut AddressAllocator,
     ) -> Result<()> {
         Ok(())
     }

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -397,19 +397,22 @@ impl PciDevice for VfioUserPciDevice {
     fn allocate_bars(
         &mut self,
         allocator: &Arc<Mutex<SystemAllocator>>,
-        mmio_allocator: &mut AddressAllocator,
+        mmio32_allocator: &mut AddressAllocator,
+        mmio64_allocator: &mut AddressAllocator,
         resources: Option<Vec<Resource>>,
     ) -> Result<Vec<PciBarConfiguration>, PciDeviceError> {
         self.common
-            .allocate_bars(allocator, mmio_allocator, resources)
+            .allocate_bars(allocator, mmio32_allocator, mmio64_allocator, resources)
     }
 
     fn free_bars(
         &mut self,
         allocator: &mut SystemAllocator,
-        mmio_allocator: &mut AddressAllocator,
+        mmio32_allocator: &mut AddressAllocator,
+        mmio64_allocator: &mut AddressAllocator,
     ) -> Result<(), PciDeviceError> {
-        self.common.free_bars(allocator, mmio_allocator)
+        self.common
+            .free_bars(allocator, mmio32_allocator, mmio64_allocator)
     }
 
     fn as_any(&mut self) -> &mut dyn Any {

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -16,7 +16,7 @@ use acpi_tables::{aml, Aml};
 use anyhow::anyhow;
 #[cfg(target_arch = "x86_64")]
 use arch::x86_64::{SgxEpcRegion, SgxEpcSection};
-use arch::{layout, RegionType};
+use arch::RegionType;
 #[cfg(target_arch = "x86_64")]
 use devices::ioapic;
 #[cfg(target_arch = "aarch64")]
@@ -1160,8 +1160,6 @@ impl MemoryManager {
                 },
                 start_of_platform_device_area,
                 PLATFORM_DEVICE_AREA_SIZE,
-                layout::MEM_32BIT_DEVICES_START,
-                layout::MEM_32BIT_DEVICES_SIZE,
                 #[cfg(target_arch = "x86_64")]
                 vec![GsiApic::new(
                     X86_64_IRQ_BASE,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1162,9 +1162,9 @@ impl Vm {
             let pci_space = PciSpaceInfo {
                 pci_segment_id: pci_segment.id,
                 mmio_config_address: pci_segment.mmio_config_address,
-                pci_device_space_start: pci_segment.start_of_device_area,
-                pci_device_space_size: pci_segment.end_of_device_area
-                    - pci_segment.start_of_device_area
+                pci_device_space_start: pci_segment.start_of_mem64_area,
+                pci_device_space_size: pci_segment.end_of_mem64_area
+                    - pci_segment.start_of_mem64_area
                     + 1,
             };
             pci_space_info.push(pci_space);


### PR DESCRIPTION
This PR is a fix for https://github.com/cloud-hypervisor/cloud-hypervisor/issues/5952. I have followed the pattern established for 64-bit memory regions to creating a separate 32-bit memory area allocator for each PCI segment (as opposed to assigning the entire 32-bit memory area to PCI segment 0). This allows passthrough of VFIO devices w/ 32-bit memory BARs to non-zero PCI segments.