### PR TITLE
devices: fix pv_panic alignment

### DIFF
--- a/devices/src/pvpanic.rs
+++ b/devices/src/pvpanic.rs
@@ -26,6 +26,7 @@ const PVPANIC_VENDOR_ID: u16 = 0x1b36;
 const PVPANIC_DEVICE_ID: u16 = 0x0011;
 
 pub const PVPANIC_DEVICE_MMIO_SIZE: u64 = 0x2;
+pub const PVPANIC_DEVICE_MMIO_ALIGNMENT: u64 = 0x10;
 
 const PVPANIC_PANICKED: u8 = 1 << 0;
 const PVPANIC_CRASH_LOADED: u8 = 1 << 1;
@@ -192,7 +193,7 @@ impl PciDevice for PvPanicDevice {
         let bar_addr = allocator
             .lock()
             .unwrap()
-            .allocate_mmio_hole_addresses(None, region_size, None)
+            .allocate_mmio_hole_addresses(None, region_size, Some(PVPANIC_DEVICE_MMIO_ALIGNMENT))
             .ok_or(PciDeviceError::IoAllocationFailed(region_size))?;
 
         let bar = PciBarConfiguration::default()


### PR DESCRIPTION
The PvPanicDevice has a 2-byte BAR size, which is smaller than the 16-byte minimum legacy PCI-Express BAR size and the 128-byte minimum modern PCI-Express BAR size. The base address register masks off the lower four bits, so all BARs must be at least 16-byte aligned (although the PCI specification requires that devices are aligned to their size). Despite being smaller than the minimum BAR size, the PvPanic device appears to work as long as it's BAR is 16-byte aligned.