### PR TITLE
vmm:api: add add-user-device support in cloud-hypervisor.yaml

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -347,6 +347,28 @@ paths:
         500:
           description: The new vDPA device could not be added to the VM instance.
 
+  /vm.add-user-device:
+    put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VmAddUserDevice'
+        description: The path of the new device
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PciDeviceInfo'
+          description: The new device was successfully added to the VM instance.
+        "204":
+          description: The new device was successfully (cold) added to the VM instance.
+        "404":
+          description: The new device could not be added to the VM instance.
+      summary: Add a new userspace device to the VM
+
   /vm.snapshot:
     put:
       summary: Returns a VM snapshot.
@@ -1156,3 +1178,11 @@ components:
           type: string
         local:
           type: boolean
+
+    VmAddUserDevice:
+      required:
+        - socket
+      type: object
+      properties:
+        socket:
+          type: string


### PR DESCRIPTION
The change is missed when add "add-user-device" support in 53b2e19934abfe2920258e586e627498653b2371, use this commit to fix it.


Change-Id: Ifcfa4e94ce2342cc6c0723f65326f04b88bf2664