### PR TITLE
ci: Enable OpenAPI validate action

### DIFF
--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -1,0 +1,16 @@
+name: Cloud Hypervisor OpenAPI Validation
+
+on:
+  pull_request:
+
+jobs:
+  Validate:
+    runs-on: ubuntu-latest
+    container: openapitools/openapi-generator-cli
+    steps:
+    - uses: actions/checkout@v2
+    - name: Validate OpenAPI
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        /usr/local/bin/docker-entrypoint.sh validate -i vmm/src/api/openapi/cloud-hypervisor.yaml


### PR DESCRIPTION
Fixes https://github.com/cloud-hypervisor/cloud-hypervisor/issues/5960

Create an action to run the OpenAPI validation.