### PR TITLE
[WIP] arch: x86_64: add support for AMD AVIC

### DIFF
--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -113,6 +113,8 @@ pub struct NumaNode {
     pub memory_zones: Vec<String>,
     #[cfg(target_arch = "x86_64")]
     pub sgx_epc_sections: Vec<SgxEpcSection>,
+    #[cfg(target_arch = "x86_64")]
+    pub x2apic: bool,
 }
 
 pub type NumaNodes = BTreeMap<u32, NumaNode>;

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -155,6 +155,7 @@ pub struct CpuidConfig {
     #[cfg(feature = "tdx")]
     pub tdx: bool,
     pub amx: bool,
+    pub x2apic: bool,
 }
 
 #[derive(Debug)]
@@ -644,6 +645,11 @@ pub fn generate_common_cpuid(
     // Update some existing CPUID
     for entry in cpuid.as_mut_slice().iter_mut() {
         match entry.function {
+            0x1 => {
+                if !config.x2apic {
+                    entry.ecx &= !(1u32 << 21);
+                }
+            }
             // Clear AMX related bits if the AMX feature is not enabled
             0x7 => {
                 if !config.amx && entry.index == 0 {

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -604,6 +604,9 @@ components:
       properties:
         amx:
           type: boolean
+        x2apic:
+          type: boolean
+          default: true
 
     CpuTopology:
       type: object

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -588,10 +588,18 @@ impl CpusConfig {
         #[allow(unused_mut)]
         let mut features = CpuFeatures::default();
         for s in features_list.0 {
-            match <std::string::String as AsRef<str>>::as_ref(&s) {
+            let feature: String = s.chars().filter(|c| *c != '+' && *c != '-').collect();
+            let feature_ref: &str = &feature;
+            let enable = s.chars().next().unwrap_or('+') != '-';
+            match (feature_ref, enable) {
                 #[cfg(target_arch = "x86_64")]
-                "amx" => {
-                    features.amx = true;
+                ("amx", enable) => {
+                    features.amx = enable;
+                    Ok(())
+                }
+                #[cfg(target_arch = "x86_64")]
+                ("x2apic", enable) => {
+                    features.x2apic = enable;
                     Ok(())
                 }
                 _ => Err(Error::InvalidCpuFeatures(s)),

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1667,6 +1667,7 @@ impl Vmm {
             #[cfg(feature = "tdx")]
             let tdx = vm_config.lock().unwrap().is_tdx_enabled();
             let amx = vm_config.lock().unwrap().cpus.features.amx;
+            let x2apic = vm_config.lock().unwrap().cpus.features.x2apic;
             let phys_bits =
                 vm::physical_bits(&hypervisor, vm_config.lock().unwrap().cpus.max_phys_bits);
             arch::generate_common_cpuid(
@@ -1678,6 +1679,7 @@ impl Vmm {
                     #[cfg(feature = "tdx")]
                     tdx,
                     amx,
+                    x2apic,
                 },
             )
             .map_err(|e| {
@@ -1870,6 +1872,7 @@ impl Vmm {
                     #[cfg(feature = "tdx")]
                     tdx: vm_config.is_tdx_enabled(),
                     amx: vm_config.cpus.features.amx,
+                    x2apic: vm_config.cpus.features.x2apic,
                 },
             )
             .map_err(|e| {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -13,11 +13,19 @@ pub struct CpuAffinity {
     pub host_cpus: Vec<u8>,
 }
 
+#[cfg(target_arch = "x86_64")]
+pub fn default_x2apic() -> bool {
+    true
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct CpuFeatures {
     #[cfg(target_arch = "x86_64")]
     #[serde(default)]
     pub amx: bool,
+    #[cfg(target_arch = "x86_64")]
+    #[serde(default = "default_x2apic")]
+    pub x2apic: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]


### PR DESCRIPTION
AVIC (the AMD equivalent of Intel APICv) is supported on AMD Zen 4 hardware. This has the potential to boost VFIO performance on 4th Gen AMD hardware by avoiding a VMEXIT for IPI and device interrupts. 

- As of Linux 5.6, [support for AVIC is disabled when nested virtualization is enabled](https://patchwork.kernel.org/project/kvm/patch/1573762520-80328-13-git-send-email-suravee.suthikulpanit@amd.com/). [This restriction is be loosened in Linux 5.19](https://github.com/torvalds/linux/commit/f44509f849fe55bbd81bd3f099b9aecd19002243).
- While AVIC support for Linux landed [as far back as 2016](https://lwn.net/Articles/682939/), support for x2AVIC (virtualized x2APIC) is [only supported in Linux 6.0+ ](https://lwn.net/Articles/887196/). When AVIC is enabled on Linux 5.6 - 6.0, x2APIC must be disabled in the guest. This PR (plans to) detect x2APIC support and write the correct ACPI tables based on whether xAPIC or x2APIC is being used.

To enable AVIC on Zen 4 hardware on the Linux 5.6 - 5.19 kernel, the following module parameters must be set. 
```
options kvm-amd nested=0 avic=1 npt=1
```


With this goal in mind, this PR makes it possible to disable `x2apic` with the following flag.
```
--cpu features=-x2apic
```