### PR TITLE
tests: test_vdpa_block: fix false positive

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6869,9 +6869,7 @@ mod common_parallel {
     #[cfg(target_arch = "x86_64")]
     fn test_vdpa_block() {
         // Before trying to run the test, verify the vdpa_sim_blk module is correctly loaded.
-        if !exec_host_command_status("lsmod | grep vdpa_sim_blk").success() {
-            return;
-        }
+        assert!(exec_host_command_status("lsmod | grep vdpa_sim_blk").success());
 
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(focal));


### PR DESCRIPTION
Running on host where vdpa_sim_blk module is not correctly loaded test_vdpa_block passes.

"test common_parallel::test_vdpa_block ... ok"

This commit fixes the vdpa_sim_blk test to fail in that case.