### PR TITLE
scripts: Show wget details for aarch64 worker

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -163,7 +163,7 @@ update_workloads() {
     CH_RELEASE_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$LAST_RELEASE_VERSION/cloud-hypervisor-static-aarch64"
     CH_RELEASE_NAME="cloud-hypervisor-static-aarch64"
     pushd $WORKLOADS_DIR
-    time wget --quiet $CH_RELEASE_URL -O "$CH_RELEASE_NAME" || exit 1
+    time wget $CH_RELEASE_URL -O "$CH_RELEASE_NAME" || exit 1
     chmod +x $CH_RELEASE_NAME
     popd
 


### PR DESCRIPTION
The wget has been causing frequent CI failure for the past few days, while it can't be reproduced manually. Let's show the wget details in our CI pipeline to understand better future errors.