### PR TITLE
devices: add debug-console device

### DIFF
--- a/devices/src/debug_console.rs
+++ b/devices/src/debug_console.rs
@@ -1,0 +1,64 @@
+// Copyright © 2023 Cyberus Technology
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Module for [`DebugconState`].
+
+use std::io;
+use std::io::Write;
+use std::sync::{Arc, Barrier};
+use vm_device::BusDevice;
+use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
+
+/// I/O-port.
+pub const DEFAULT_PORT: u64 = 0xe9;
+
+#[derive(Default)]
+pub struct DebugconState {}
+
+/// Emulates a debug console similar to the QEMU debugcon device. This device
+/// is stateless and only prints the bytes (usually text) that are written to
+/// it.
+///
+/// This device is only available on x86.
+///
+/// Reference:
+/// - https://github.com/qemu/qemu/blob/master/hw/char/debugcon.c
+/// - https://phip1611.de/blog/how-to-use-qemus-debugcon-feature-and-write-to-a-file/
+pub struct DebugConsole {
+    id: String,
+    out: Box<dyn io::Write + Send>,
+}
+
+impl DebugConsole {
+    pub fn new(id: String, out: Box<dyn io::Write + Send>) -> Self {
+        Self { id, out }
+    }
+}
+
+impl BusDevice for DebugConsole {
+    fn read(&mut self, _base: u64, _offset: u64, _data: &mut [u8]) {}
+
+    fn write(&mut self, _base: u64, _offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        if let Err(e) = self.out.write_all(data) {
+            // unlikely
+            error!("debug-console: failed writing data: {e:?}");
+        }
+        None
+    }
+}
+
+impl Snapshottable for DebugConsole {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+
+    fn snapshot(&mut self) -> Result<Snapshot, MigratableError> {
+        Snapshot::new_from_state(&())
+    }
+}
+
+impl Pausable for DebugConsole {}
+impl Transportable for DebugConsole {}
+impl Migratable for DebugConsole {}

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -15,6 +15,8 @@ extern crate event_monitor;
 extern crate log;
 
 pub mod acpi;
+#[cfg(target_arch = "x86_64")]
+pub mod debug_console;
 #[cfg(target_arch = "aarch64")]
 pub mod gic;
 pub mod interrupt_controller;

--- a/docs/debug-port.md
+++ b/docs/debug-port.md
@@ -1,7 +1,16 @@
-# `cloud-hypervisor` debug IO port
+# `cloud-hypervisor` debug IO ports
 
-`cloud-hypervisor` uses the [`0x80`](https://www.intel.com/content/www/us/en/support/articles/000005500/boards-and-kits.html)
-I/O port to trace user defined guest events.
+When running x86 guests, `cloud-hypervisor` provides different kinds of debug ports:
+- [`0x80` debug port](https://www.intel.com/content/www/us/en/support/articles/000005500/boards-and-kits.html) 
+- Debug console (by default at `0xe9`). 
+- Firmware debug port at `0x402`.
+
+All of them can be used to trace user-defined guest events and all of them can
+be used simultaneously.
+
+## Debug Ports Overview
+
+### `0x80` I/O port
 
 Whenever the guest write one byte between `0x0` and `0xF` on this particular
 I/O port, `cloud-hypervisor` will log and timestamp that event at the `debug`
@@ -30,7 +39,7 @@ guest will have `cloud-hypervisor` generate timestamped logs of all those steps.
 That provides a basic but convenient way of measuring not only the overall guest
 boot time but all intermediate steps as well.
 
-## Logging
+#### Logging
 
 Assuming parts of the guest software stack have been instrumented to use the
 `cloud-hypervisor` debug I/O port, we may want to gather the related logs.
@@ -59,3 +68,29 @@ $ grep "Debug I/O port" /tmp/ch-fw.log
 cloud-hypervisor: 19.762449ms: DEBUG:vmm/src/vm.rs:510 -- [Debug I/O port: Firmware code 0x0] 0.019004 seconds
 cloud-hypervisor: 403.499628ms: DEBUG:vmm/src/vm.rs:510 -- [Debug I/O port: Firmware code 0x1] 0.402744 seconds
 ```
+
+### Debug console port
+
+The debug console is inspired by QEMU and Bochs, which have a similar feature. 
+By default, the I/O port `0xe9` is used. This port can be configured like a 
+console. Thus, it can print to a tty, a file, or a pty, for example.
+
+### Firmware debug port
+
+The firmware debug port is also a simple port that prints all bytes written to
+it. The firmware debug port only prints to stdout.
+
+## When do I need these ports?
+
+The ports are on the one hand interesting for firmware or kernel developers, as
+they provide an easy way to print debug information from within a guest. 
+Furthermore, you can patch "normal" software to measure certain events, such as
+the boot time of a guest.
+
+## Which port should I choose?
+
+The `0x80` debug port and the port of the firmware debug device are always
+available. The debug console must be activated via the command line, but
+provides more configuration options. 
+
+You can use different ports for different aspect of your logging messages. 

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -173,6 +173,8 @@ impl RequestHandler for StubApiRequestHandler {
                     iommu: false,
                     socket: None,
                 },
+                #[cfg(target_arch = "x86_64")]
+                debug_console: DebugConsoleConfig::default(),
                 devices: None,
                 user_devices: None,
                 vdpa: None,

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -582,6 +582,8 @@ components:
           $ref: "#/components/schemas/ConsoleConfig"
         console:
           $ref: "#/components/schemas/ConsoleConfig"
+        debug_console:
+          $ref: "#/components/schemas/DebugConsoleConfig"
         devices:
           type: array
           items:
@@ -998,6 +1000,19 @@ components:
         iommu:
           type: boolean
           default: false
+
+    DebugConsoleConfig:
+      required:
+        - mode
+      type: object
+      properties:
+        file:
+          type: string
+        mode:
+          type: string
+          enum: ["Off", "Pty", "Tty", "File", "Null"]
+        iobase:
+          type: integer
 
     DeviceConfig:
       required:

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -479,6 +479,7 @@ impl Vm {
         timestamp: Instant,
         serial_pty: Option<PtyPair>,
         console_pty: Option<PtyPair>,
+        debug_console_pty: Option<PtyPair>,
         console_resize_pipe: Option<File>,
         original_termios: Arc<Mutex<Option<termios>>>,
         snapshot: Option<Snapshot>,
@@ -631,6 +632,7 @@ impl Vm {
             .create_devices(
                 serial_pty,
                 console_pty,
+                debug_console_pty,
                 console_resize_pipe,
                 original_termios,
             )
@@ -786,6 +788,7 @@ impl Vm {
         activate_evt: EventFd,
         serial_pty: Option<PtyPair>,
         console_pty: Option<PtyPair>,
+        debug_console_pty: Option<PtyPair>,
         console_resize_pipe: Option<File>,
         original_termios: Arc<Mutex<Option<termios>>>,
         snapshot: Option<Snapshot>,
@@ -865,6 +868,7 @@ impl Vm {
             timestamp,
             serial_pty,
             console_pty,
+            debug_console_pty,
             console_resize_pipe,
             original_termios,
             snapshot,
@@ -1297,6 +1301,10 @@ impl Vm {
 
     pub fn console_pty(&self) -> Option<PtyPair> {
         self.device_manager.lock().unwrap().console_pty()
+    }
+
+    pub fn debug_console_pty(&self) -> Option<PtyPair> {
+        self.device_manager.lock().unwrap().debug_console_pty()
     }
 
     pub fn console_resize_pipe(&self) -> Option<Arc<File>> {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -396,6 +396,27 @@ pub fn default_consoleconfig_file() -> Option<PathBuf> {
     None
 }
 
+#[cfg(target_arch = "x86_64")]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct DebugConsoleConfig {
+    #[serde(default)]
+    pub file: Option<PathBuf>,
+    pub mode: ConsoleOutputMode,
+    /// Optionally dedicated I/O-port, if the default port should not be used.
+    pub iobase: Option<u16>,
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Default for DebugConsoleConfig {
+    fn default() -> Self {
+        Self {
+            file: None,
+            mode: ConsoleOutputMode::Off,
+            iobase: Some(devices::debug_console::DEFAULT_PORT as u16),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DeviceConfig {
     pub path: PathBuf,
@@ -537,6 +558,9 @@ pub struct VmConfig {
     pub serial: ConsoleConfig,
     #[serde(default = "default_console")]
     pub console: ConsoleConfig,
+    #[cfg(target_arch = "x86_64")]
+    #[serde(default)]
+    pub debug_console: DebugConsoleConfig,
     pub devices: Option<Vec<DeviceConfig>>,
     pub user_devices: Option<Vec<UserDeviceConfig>>,
     pub vdpa: Option<Vec<VdpaConfig>>,


### PR DESCRIPTION
This commit adds the debugcon device to CHV. The debugcon device is a very simple device on I/O port 0xe9 supported by QEMU and BOCHS. It is meant for printing information as easy as possible, without any configuration from the guest at all.

The device is configured on the cmdline like this: `--debugcon file=<path>`

It is primarily interesting to OS/kernel developers as they can produce output as soon as the guest starts without any configuration of a serial device or so. Furthermore, a kernel hacker might use this device for information of type B whereas information of type A are printed to the serial device.

This device is not used by default by Linux, Windows, or any other "real" OS. It is for developers.

-- 
More info:
- https://phip1611.de/blog/how-to-use-qemus-debugcon-feature-and-write-to-a-file/
- https://github.com/qemu/qemu/blob/master/hw/char/debugcon.c