### PR TITLE
vmm: igvm: Generate memory map for SEV-SNP guests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -733,6 +733,9 @@ fn main() {
     #[cfg(all(feature = "tdx", feature = "sev_snp"))]
     compile_error!("Feature 'tdx' and 'sev_snp' are mutually exclusive.");
 
+    #[cfg(all(feature = "sev_snp", not(target_arch = "x86_64")))]
+    compile_error!("Feature 'sev_snp' needs target 'x86_64'");
+
     #[cfg(feature = "dhat-heap")]
     let _profiler = dhat::Profiler::new_heap();
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -998,8 +998,6 @@ impl Vm {
         memory_manager: Arc<Mutex<MemoryManager>>,
         cpu_manager: Arc<Mutex<cpu::CpuManager>>,
     ) -> Result<EntryPoint> {
-        //TODO: see issue https://github.com/cloud-hypervisor/cloud-hypervisor/issues/5993
-
         let res = igvm_loader::load_igvm(&igvm, memory_manager, cpu_manager, "")
             .map_err(Error::IgvmLoad)?;
 


### PR DESCRIPTION
For SEV-SNP guests we need to provide the extended memory. It follows a very simple layout and very similar to other x86 guests.

First segment: [HIGH_RAM_START - MEM_32BIT_RESERVED_START]
PCI hole: [MEM_32BIT_RESERVED_START - RAM_64BIT_START]
Second segment: [RAM_64BIT_START - RAM_END]

Fixes #5993