### PR TITLE
Fix warning emitted by Github CI

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
           - x86_64-unknown-linux-musl
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -5,7 +5,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.x
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/fuzz-build.yaml
+++ b/.github/workflows/fuzz-build.yaml
@@ -14,7 +14,7 @@ jobs:
           - x86_64-unknown-linux-gnu
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/hadolint.yaml
+++ b/.github/workflows/hadolint.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@master

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     container: openapitools/openapi-generator-cli
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Validate OpenAPI
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -34,7 +34,7 @@ jobs:
             experimental: true
     steps:
       - name: Code checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -133,6 +133,6 @@ jobs:
     name: Typos / Spellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Executes "typos ."
       - uses: crate-ci/typos@v1.16.11

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install musl-gcc
         run: sudo apt install -y musl-tools
       - name: Create release directory

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -14,8 +14,8 @@ tdx = []
 [dependencies]
 anyhow = "1.0.75"
 byteorder = "1.4.3"
-igvm_defs = { git = "https://github.com/microsoft/igvm", branch = "main" , package = "igvm_defs", optional  = true }
-igvm_parser = { git = "https://github.com/microsoft/igvm", branch = "main" , package = "igvm", optional  = true }
+igvm_defs = { git = "https://github.com/microsoft/igvm", branch = "main", package = "igvm_defs", optional  = true }
+igvm_parser = { git = "https://github.com/microsoft/igvm", branch = "main", package = "igvm", optional  = true }
 libc = "0.2.147"
 log = "0.4.20"
 kvm-ioctls = { version = "0.13.0", optional = true }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -35,8 +35,8 @@ gdbstub = { version = "0.7.0", optional = true }
 gdbstub_arch = { version = "0.3.0", optional = true }
 hex = { version = "0.4.3", optional = true }
 hypervisor = { path = "../hypervisor" }
-igvm_defs = { git = "https://github.com/microsoft/igvm", branch = "main" , package = "igvm_defs", optional  = true }
-igvm_parser = { git = "https://github.com/microsoft/igvm", branch = "main" , package = "igvm", optional  = true }
+igvm_defs = { git = "https://github.com/microsoft/igvm", branch = "main", package = "igvm_defs", optional  = true }
+igvm_parser = { git = "https://github.com/microsoft/igvm", branch = "main", package = "igvm", optional  = true }
 libc = "0.2.147"
 linux-loader = { version = "0.10.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.20"


### PR DESCRIPTION
Currently Github CI complains about two things:

- There are few inconsistencies in Cargo.toml which is causing warnings while parsing it.
- actions/checkout@v2 is using a deprecated version of nodejs so we should update it.