### PR TITLE
hypervisor: fix few typos and cosmetic issues

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -95,12 +95,12 @@ pub enum HypervisorCpuError {
     #[error("Failed to get Msr entries: {0}")]
     GetMsrEntries(#[source] anyhow::Error),
     ///
-    /// Setting MSR entries error
+    /// Setting multi-processing  state error
     ///
     #[error("Failed to set MP state: {0}")]
     SetMpState(#[source] anyhow::Error),
     ///
-    /// Getting Msr entries error
+    /// Getting multi-processing  state error
     ///
     #[error("Failed to get MP state: {0}")]
     GetMpState(#[source] anyhow::Error),

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -356,6 +356,7 @@ impl vm::Vm for KvmVm {
             .set_identity_map_address(address)
             .map_err(|e| vm::HypervisorVmError::SetIdentityMapAddress(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Sets the address of the three-page region in the VM's address space.
@@ -365,6 +366,7 @@ impl vm::Vm for KvmVm {
             .set_tss_address(offset)
             .map_err(|e| vm::HypervisorVmError::SetTssAddress(e.into()))
     }
+
     ///
     /// Creates an in-kernel interrupt controller.
     ///
@@ -373,6 +375,7 @@ impl vm::Vm for KvmVm {
             .create_irq_chip()
             .map_err(|e| vm::HypervisorVmError::CreateIrq(e.into()))
     }
+
     ///
     /// Registers an event that will, when signaled, trigger the `gsi` IRQ.
     ///
@@ -381,6 +384,7 @@ impl vm::Vm for KvmVm {
             .register_irqfd(fd, gsi)
             .map_err(|e| vm::HypervisorVmError::RegisterIrqFd(e.into()))
     }
+
     ///
     /// Unregisters an event that will, when signaled, trigger the `gsi` IRQ.
     ///
@@ -389,6 +393,7 @@ impl vm::Vm for KvmVm {
             .unregister_irqfd(fd, gsi)
             .map_err(|e| vm::HypervisorVmError::UnregisterIrqFd(e.into()))
     }
+
     ///
     /// Creates a VcpuFd object from a vcpu RawFd.
     ///
@@ -411,6 +416,7 @@ impl vm::Vm for KvmVm {
         };
         Ok(Arc::new(vcpu))
     }
+
     #[cfg(target_arch = "aarch64")]
     ///
     /// Creates a virtual GIC device.
@@ -420,6 +426,7 @@ impl vm::Vm for KvmVm {
             .map_err(|e| vm::HypervisorVmError::CreateVgic(anyhow!("Vgic error {:?}", e)))?;
         Ok(Arc::new(Mutex::new(gic_device)))
     }
+
     ///
     /// Registers an event to be signaled whenever a certain address is written to.
     ///
@@ -447,6 +454,7 @@ impl vm::Vm for KvmVm {
                 .map_err(|e| vm::HypervisorVmError::RegisterIoEvent(e.into()))
         }
     }
+
     ///
     /// Unregisters an event from a certain address it has been previously registered to.
     ///
@@ -541,6 +549,7 @@ impl vm::Vm for KvmVm {
             .set_gsi_routing(&irq_routing[0])
             .map_err(|e| vm::HypervisorVmError::SetGsiRouting(e.into()))
     }
+
     ///
     /// Creates a memory region structure that can be used with {create/remove}_user_memory_region
     ///
@@ -567,6 +576,7 @@ impl vm::Vm for KvmVm {
         }
         .into()
     }
+
     ///
     /// Creates a guest physical memory region.
     ///
@@ -603,6 +613,7 @@ impl vm::Vm for KvmVm {
                 .map_err(|e| vm::HypervisorVmError::CreateUserMemory(e.into()))
         }
     }
+
     ///
     /// Removes a guest physical memory region.
     ///
@@ -621,6 +632,7 @@ impl vm::Vm for KvmVm {
                 .map_err(|e| vm::HypervisorVmError::RemoveUserMemory(e.into()))
         }
     }
+
     ///
     /// Returns the preferred CPU target type which can be emulated by KVM on underlying host.
     ///
@@ -630,6 +642,7 @@ impl vm::Vm for KvmVm {
             .get_preferred_target(kvi)
             .map_err(|e| vm::HypervisorVmError::GetPreferredTarget(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     fn enable_split_irq(&self) -> vm::Result<()> {
         // Create split irqchip
@@ -645,6 +658,7 @@ impl vm::Vm for KvmVm {
             .map_err(|e| vm::HypervisorVmError::EnableSplitIrq(e.into()))?;
         Ok(())
     }
+
     #[cfg(target_arch = "x86_64")]
     fn enable_sgx_attribute(&self, file: File) -> vm::Result<()> {
         let mut cap = kvm_enable_cap {
@@ -657,6 +671,7 @@ impl vm::Vm for KvmVm {
             .map_err(|e| vm::HypervisorVmError::EnableSgxAttribute(e.into()))?;
         Ok(())
     }
+
     /// Retrieve guest clock.
     #[cfg(target_arch = "x86_64")]
     fn get_clock(&self) -> vm::Result<ClockData> {
@@ -666,6 +681,7 @@ impl vm::Vm for KvmVm {
             .map_err(|e| vm::HypervisorVmError::GetClock(e.into()))?
             .into())
     }
+
     /// Set guest clock.
     #[cfg(target_arch = "x86_64")]
     fn set_clock(&self, data: &ClockData) -> vm::Result<()> {
@@ -674,6 +690,7 @@ impl vm::Vm for KvmVm {
             .set_clock(&data)
             .map_err(|e| vm::HypervisorVmError::SetClock(e.into()))
     }
+
     /// Create a device that is used for passthrough
     fn create_passthrough_device(&self) -> vm::Result<VfioDeviceFd> {
         let mut vfio_dev = kvm_create_device {
@@ -685,6 +702,7 @@ impl vm::Vm for KvmVm {
         self.create_device(&mut vfio_dev)
             .map_err(|e| vm::HypervisorVmError::CreatePassthroughDevice(e.into()))
     }
+
     ///
     /// Start logging dirty pages
     ///
@@ -826,6 +844,7 @@ impl vm::Vm for KvmVm {
         )
         .map_err(vm::HypervisorVmError::InitMemRegionTdx)
     }
+
     /// Downcast to the underlying KvmVm type
     fn as_any(&self) -> &dyn Any {
         self
@@ -892,7 +911,9 @@ pub enum KvmError {
     #[error("Capability missing: {0:?}")]
     CapabilityMissing(Cap),
 }
+
 pub type KvmResult<T> = result::Result<T, KvmError>;
+
 impl KvmHypervisor {
     /// Create a hypervisor based on Kvm
     #[allow(clippy::new_ret_no_self)]
@@ -906,6 +927,7 @@ impl KvmHypervisor {
 
         Ok(Arc::new(KvmHypervisor { kvm: kvm_obj }))
     }
+
     /// Check if the hypervisor is available
     pub fn is_available() -> hypervisor::Result<bool> {
         match std::fs::metadata("/dev/kvm") {
@@ -917,6 +939,7 @@ impl KvmHypervisor {
         }
     }
 }
+
 /// Implementation of Hypervisor trait for KVM
 ///
 /// # Examples
@@ -935,6 +958,7 @@ impl hypervisor::Hypervisor for KvmHypervisor {
     fn hypervisor_type(&self) -> HypervisorType {
         HypervisorType::Kvm
     }
+
     /// Create a KVM vm object of a specific VM type and return the object as Vm trait object
     ///
     /// # Examples
@@ -1090,6 +1114,7 @@ impl hypervisor::Hypervisor for KvmHypervisor {
         self.kvm.get_max_vcpus().min(u32::MAX as usize) as u32
     }
 }
+
 /// Vcpu struct for KVM
 pub struct KvmVcpu {
     fd: VcpuFd,
@@ -1099,6 +1124,7 @@ pub struct KvmVcpu {
     #[cfg(target_arch = "x86_64")]
     hyperv_synic: AtomicBool,
 }
+
 /// Implementation of Vcpu trait for KVM
 ///
 /// # Examples
@@ -1123,6 +1149,7 @@ impl cpu::Vcpu for KvmVcpu {
             .map_err(|e| cpu::HypervisorCpuError::GetStandardRegs(e.into()))?
             .into())
     }
+
     ///
     /// Returns the vCPU general purpose registers.
     /// The `KVM_GET_REGS` ioctl is not available on AArch64, `KVM_GET_ONE_REG`
@@ -1235,6 +1262,7 @@ impl cpu::Vcpu for KvmVcpu {
             .unwrap();
         Ok(state)
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Sets the vCPU general purpose registers using the `KVM_SET_REGS` ioctl.
@@ -1357,6 +1385,7 @@ impl cpu::Vcpu for KvmVcpu {
             .map_err(|e| cpu::HypervisorCpuError::GetSpecialRegs(e.into()))?
             .into())
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Sets the vCPU special registers using the `KVM_SET_SREGS` ioctl.
@@ -1367,6 +1396,7 @@ impl cpu::Vcpu for KvmVcpu {
             .set_sregs(&sregs)
             .map_err(|e| cpu::HypervisorCpuError::SetSpecialRegs(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Returns the floating point state (FPU) from the vCPU.
@@ -1378,6 +1408,7 @@ impl cpu::Vcpu for KvmVcpu {
             .map_err(|e| cpu::HypervisorCpuError::GetFloatingPointRegs(e.into()))?
             .into())
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Set the floating point state (FPU) of a vCPU using the `KVM_SET_FPU` ioct.
@@ -1388,6 +1419,7 @@ impl cpu::Vcpu for KvmVcpu {
             .set_fpu(&fpu)
             .map_err(|e| cpu::HypervisorCpuError::SetFloatingPointRegs(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// X86 specific call to setup the CPUID registers.
@@ -1402,6 +1434,7 @@ impl cpu::Vcpu for KvmVcpu {
             .set_cpuid2(&kvm_cpuid)
             .map_err(|e| cpu::HypervisorCpuError::SetCpuid(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// X86 specific call to enable HyperV SynIC
@@ -1419,6 +1452,7 @@ impl cpu::Vcpu for KvmVcpu {
             .enable_cap(&cap)
             .map_err(|e| cpu::HypervisorCpuError::EnableHyperVSyncIc(e.into()))
     }
+
     ///
     /// X86 specific call to retrieve the CPUID registers.
     ///
@@ -1433,6 +1467,7 @@ impl cpu::Vcpu for KvmVcpu {
 
         Ok(v)
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Returns the state of the LAPIC (Local Advanced Programmable Interrupt Controller).
@@ -1444,6 +1479,7 @@ impl cpu::Vcpu for KvmVcpu {
             .map_err(|e| cpu::HypervisorCpuError::GetlapicState(e.into()))?
             .into())
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Sets the state of the LAPIC (Local Advanced Programmable Interrupt Controller).
@@ -1454,6 +1490,7 @@ impl cpu::Vcpu for KvmVcpu {
             .set_lapic(&klapic)
             .map_err(|e| cpu::HypervisorCpuError::SetLapicState(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Returns the model-specific registers (MSR) for this vCPU.
@@ -1475,6 +1512,7 @@ impl cpu::Vcpu for KvmVcpu {
 
         Ok(succ)
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Setup the model-specific registers (MSR) for this vCPU.
@@ -1487,6 +1525,7 @@ impl cpu::Vcpu for KvmVcpu {
             .set_msrs(&kvm_msrs)
             .map_err(|e| cpu::HypervisorCpuError::SetMsrEntries(e.into()))
     }
+
     ///
     /// Returns the vcpu's current "multiprocessing state".
     ///
@@ -1497,6 +1536,7 @@ impl cpu::Vcpu for KvmVcpu {
             .map_err(|e| cpu::HypervisorCpuError::GetMpState(e.into()))?
             .into())
     }
+
     ///
     /// Sets the vcpu's current "multiprocessing state".
     ///
@@ -1505,6 +1545,7 @@ impl cpu::Vcpu for KvmVcpu {
             .set_mp_state(mp_state.into())
             .map_err(|e| cpu::HypervisorCpuError::SetMpState(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Translates guest virtual address to guest physical address using the `KVM_TRANSLATE` ioctl.
@@ -1523,6 +1564,7 @@ impl cpu::Vcpu for KvmVcpu {
             _ => Ok((tr.physical_address, 0)),
         }
     }
+
     ///
     /// Triggers the running of the current virtual CPU returning an exit reason.
     ///
@@ -1614,6 +1656,7 @@ impl cpu::Vcpu for KvmVcpu {
             },
         }
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Let the guest know that it has been paused, which prevents from
@@ -1631,6 +1674,7 @@ impl cpu::Vcpu for KvmVcpu {
 
         Ok(())
     }
+
     ///
     /// Sets debug registers to set hardware breakpoints and/or enable single step.
     ///
@@ -1684,12 +1728,14 @@ impl cpu::Vcpu for KvmVcpu {
             .set_guest_debug(&dbg)
             .map_err(|e| cpu::HypervisorCpuError::SetDebugRegs(e.into()))
     }
+
     #[cfg(target_arch = "aarch64")]
     fn vcpu_init(&self, kvi: &VcpuInit) -> cpu::Result<()> {
         self.fd
             .vcpu_init(kvi)
             .map_err(|e| cpu::HypervisorCpuError::VcpuInit(e.into()))
     }
+
     ///
     /// Gets a list of the guest registers that are supported for the
     /// KVM_GET_ONE_REG/KVM_SET_ONE_REG calls.
@@ -1700,6 +1746,7 @@ impl cpu::Vcpu for KvmVcpu {
             .get_reg_list(reg_list)
             .map_err(|e| cpu::HypervisorCpuError::GetRegList(e.into()))
     }
+
     ///
     /// Gets the value of a system register
     ///
@@ -1733,6 +1780,7 @@ impl cpu::Vcpu for KvmVcpu {
             .try_into()
             .unwrap())
     }
+
     ///
     /// Configure core registers for a given CPU.
     ///
@@ -1907,6 +1955,7 @@ impl cpu::Vcpu for KvmVcpu {
         }
         .into())
     }
+
     ///
     /// Get the current AArch64 CPU state
     ///
@@ -1956,6 +2005,7 @@ impl cpu::Vcpu for KvmVcpu {
 
         Ok(state.into())
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Restore the previously saved CPU state
@@ -2045,6 +2095,7 @@ impl cpu::Vcpu for KvmVcpu {
 
         Ok(())
     }
+
     ///
     /// Restore the previously saved AArch64 CPU state
     ///
@@ -2119,6 +2170,7 @@ impl cpu::Vcpu for KvmVcpu {
             TdxExitStatus::InvalidOperand => TDG_VP_VMCALL_INVALID_OPERAND,
         };
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Return the list of initial MSR entries for a VCPU
@@ -2144,6 +2196,7 @@ impl cpu::Vcpu for KvmVcpu {
         ]
         .to_vec()
     }
+
     #[cfg(target_arch = "aarch64")]
     fn has_pmu_support(&self) -> bool {
         let cpu_attr = kvm_bindings::kvm_device_attr {
@@ -2154,6 +2207,7 @@ impl cpu::Vcpu for KvmVcpu {
         };
         self.fd.has_device_attr(&cpu_attr).is_ok()
     }
+
     #[cfg(target_arch = "aarch64")]
     fn init_pmu(&self, irq: u32) -> cpu::Result<()> {
         let cpu_attr = kvm_bindings::kvm_device_attr {
@@ -2221,6 +2275,7 @@ impl KvmVcpu {
             .get_xsave()
             .map_err(|e| cpu::HypervisorCpuError::GetXsaveState(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// X86 specific call that sets the vcpu's current "xsave struct".
@@ -2230,6 +2285,7 @@ impl KvmVcpu {
             .set_xsave(xsave)
             .map_err(|e| cpu::HypervisorCpuError::SetXsaveState(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// X86 specific call that returns the vcpu's current "xcrs".
@@ -2239,6 +2295,7 @@ impl KvmVcpu {
             .get_xcrs()
             .map_err(|e| cpu::HypervisorCpuError::GetXcsr(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// X86 specific call that sets the vcpu's current "xcrs".
@@ -2248,6 +2305,7 @@ impl KvmVcpu {
             .set_xcrs(xcrs)
             .map_err(|e| cpu::HypervisorCpuError::SetXcsr(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Returns currently pending exceptions, interrupts, and NMIs as well as related
@@ -2258,6 +2316,7 @@ impl KvmVcpu {
             .get_vcpu_events()
             .map_err(|e| cpu::HypervisorCpuError::GetVcpuEvents(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Sets pending exceptions, interrupts, and NMIs as well as related states

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -200,6 +200,7 @@ impl MshvHypervisor {
         }
     }
 }
+
 /// Implementation of Hypervisor trait for Mshv
 ///
 /// # Examples
@@ -366,6 +367,7 @@ impl cpu::Vcpu for MshvVcpu {
             .map_err(|e| cpu::HypervisorCpuError::GetStandardRegs(e.into()))?
             .into())
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Sets the vCPU general purpose registers.
@@ -376,6 +378,7 @@ impl cpu::Vcpu for MshvVcpu {
             .set_regs(&regs)
             .map_err(|e| cpu::HypervisorCpuError::SetStandardRegs(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Returns the vCPU special registers.
@@ -387,6 +390,7 @@ impl cpu::Vcpu for MshvVcpu {
             .map_err(|e| cpu::HypervisorCpuError::GetSpecialRegs(e.into()))?
             .into())
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Sets the vCPU special registers.
@@ -397,6 +401,7 @@ impl cpu::Vcpu for MshvVcpu {
             .set_sregs(&sregs)
             .map_err(|e| cpu::HypervisorCpuError::SetSpecialRegs(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Returns the floating point state (FPU) from the vCPU.
@@ -408,6 +413,7 @@ impl cpu::Vcpu for MshvVcpu {
             .map_err(|e| cpu::HypervisorCpuError::GetFloatingPointRegs(e.into()))?
             .into())
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Set the floating point state (FPU) of a vCPU.
@@ -440,6 +446,7 @@ impl cpu::Vcpu for MshvVcpu {
 
         Ok(succ)
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Setup the model-specific registers (MSR) for this vCPU.
@@ -461,6 +468,7 @@ impl cpu::Vcpu for MshvVcpu {
         /* We always have SynIC enabled on MSHV */
         Ok(())
     }
+
     #[allow(non_upper_case_globals)]
     fn run(&self) -> std::result::Result<cpu::VmExit, cpu::HypervisorCpuError> {
         let hv_message: hv_message = hv_message::default();
@@ -1057,6 +1065,7 @@ impl cpu::Vcpu for MshvVcpu {
             },
         }
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// X86 specific call to setup the CPUID registers.
@@ -1070,6 +1079,7 @@ impl cpu::Vcpu for MshvVcpu {
             .register_intercept_result_cpuid(&mshv_cpuid)
             .map_err(|e| cpu::HypervisorCpuError::SetCpuid(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// X86 specific call to retrieve the CPUID registers.
@@ -1105,6 +1115,7 @@ impl cpu::Vcpu for MshvVcpu {
             .map_err(|e| cpu::HypervisorCpuError::GetlapicState(e.into()))?
             .into())
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Sets the state of the LAPIC (Local Advanced Programmable Interrupt Controller).
@@ -1115,18 +1126,21 @@ impl cpu::Vcpu for MshvVcpu {
             .set_lapic(&lapic)
             .map_err(|e| cpu::HypervisorCpuError::SetLapicState(e.into()))
     }
+
     ///
     /// Returns the vcpu's current "multiprocessing state".
     ///
     fn get_mp_state(&self) -> cpu::Result<MpState> {
         Ok(MpState::Mshv)
     }
+
     ///
     /// Sets the vcpu's current "multiprocessing state".
     ///
     fn set_mp_state(&self, _mp_state: MpState) -> cpu::Result<()> {
         Ok(())
     }
+
     ///
     /// Set CPU state
     ///
@@ -1152,6 +1166,7 @@ impl cpu::Vcpu for MshvVcpu {
             .map_err(|e| cpu::HypervisorCpuError::SetDebugRegs(e.into()))?;
         Ok(())
     }
+
     ///
     /// Get CPU State
     ///
@@ -1188,6 +1203,7 @@ impl cpu::Vcpu for MshvVcpu {
         }
         .into())
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Translate guest virtual address to guest physical address
@@ -1204,6 +1220,7 @@ impl cpu::Vcpu for MshvVcpu {
 
         Ok((gpa, result_code))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Return the list of initial MSR entries for a VCPU
@@ -1236,6 +1253,7 @@ impl MshvVcpu {
             .get_xsave()
             .map_err(|e| cpu::HypervisorCpuError::GetXsaveState(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// X86 specific call that sets the vcpu's current "xsave struct".
@@ -1245,6 +1263,7 @@ impl MshvVcpu {
             .set_xsave(xsave)
             .map_err(|e| cpu::HypervisorCpuError::SetXsaveState(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// X86 specific call that returns the vcpu's current "xcrs".
@@ -1254,6 +1273,7 @@ impl MshvVcpu {
             .get_xcrs()
             .map_err(|e| cpu::HypervisorCpuError::GetXcsr(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// X86 specific call that sets the vcpu's current "xcrs".
@@ -1263,6 +1283,7 @@ impl MshvVcpu {
             .set_xcrs(xcrs)
             .map_err(|e| cpu::HypervisorCpuError::SetXcsr(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Returns currently pending exceptions, interrupts, and NMIs as well as related
@@ -1273,6 +1294,7 @@ impl MshvVcpu {
             .get_vcpu_events()
             .map_err(|e| cpu::HypervisorCpuError::GetVcpuEvents(e.into()))
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Sets pending exceptions, interrupts, and NMIs as well as related states
@@ -1452,6 +1474,7 @@ impl vm::Vm for MshvVm {
     fn set_identity_map_address(&self, _address: u64) -> vm::Result<()> {
         Ok(())
     }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Sets the address of the three-page region in the VM's address space.
@@ -1459,12 +1482,14 @@ impl vm::Vm for MshvVm {
     fn set_tss_address(&self, _offset: usize) -> vm::Result<()> {
         Ok(())
     }
+
     ///
     /// Creates an in-kernel interrupt controller.
     ///
     fn create_irq_chip(&self) -> vm::Result<()> {
         Ok(())
     }
+
     ///
     /// Registers an event that will, when signaled, trigger the `gsi` IRQ.
     ///
@@ -1477,6 +1502,7 @@ impl vm::Vm for MshvVm {
 
         Ok(())
     }
+
     ///
     /// Unregisters an event that will, when signaled, trigger the `gsi` IRQ.
     ///
@@ -1489,6 +1515,7 @@ impl vm::Vm for MshvVm {
 
         Ok(())
     }
+
     ///
     /// Creates a VcpuFd object from a vcpu RawFd.
     ///
@@ -1512,14 +1539,17 @@ impl vm::Vm for MshvVm {
         };
         Ok(Arc::new(vcpu))
     }
+
     #[cfg(target_arch = "x86_64")]
     fn enable_split_irq(&self) -> vm::Result<()> {
         Ok(())
     }
+
     #[cfg(target_arch = "x86_64")]
     fn enable_sgx_attribute(&self, _file: File) -> vm::Result<()> {
         Ok(())
     }
+
     fn register_ioevent(
         &self,
         fd: &EventFd,
@@ -1550,6 +1580,7 @@ impl vm::Vm for MshvVm {
                 .map_err(|e| vm::HypervisorVmError::RegisterIoEvent(e.into()))
         }
     }
+
     /// Unregister an event from a certain address it has been previously registered to.
     fn unregister_ioevent(&self, fd: &EventFd, addr: &IoEventAddress) -> vm::Result<()> {
         let addr = &mshv_ioctls::IoEventAddress::from(*addr);
@@ -1674,6 +1705,7 @@ impl vm::Vm for MshvVm {
             .set_msi_routing(&msi_routing[0])
             .map_err(|e| vm::HypervisorVmError::SetGsiRouting(e.into()))
     }
+
     ///
     /// Start logging dirty pages
     ///
@@ -1682,6 +1714,7 @@ impl vm::Vm for MshvVm {
             .enable_dirty_page_tracking()
             .map_err(|e| vm::HypervisorVmError::StartDirtyLog(e.into()))
     }
+
     ///
     /// Stop logging dirty pages
     ///
@@ -1700,6 +1733,7 @@ impl vm::Vm for MshvVm {
             .map_err(|e| vm::HypervisorVmError::StartDirtyLog(e.into()))?;
         Ok(())
     }
+
     ///
     /// Get dirty pages bitmap (one bit per page)
     ///
@@ -1712,20 +1746,24 @@ impl vm::Vm for MshvVm {
             )
             .map_err(|e| vm::HypervisorVmError::GetDirtyLog(e.into()))
     }
+
     /// Retrieve guest clock.
     #[cfg(target_arch = "x86_64")]
     fn get_clock(&self) -> vm::Result<ClockData> {
         Ok(ClockData::Mshv)
     }
+
     /// Set guest clock.
     #[cfg(target_arch = "x86_64")]
     fn set_clock(&self, _data: &ClockData) -> vm::Result<()> {
         Ok(())
     }
+
     /// Downcast to the underlying MshvVm type
     fn as_any(&self) -> &dyn Any {
         self
     }
+
     /// Initialize the SEV-SNP VM
     #[cfg(feature = "sev_snp")]
     fn sev_snp_init(&self) -> vm::Result<()> {
@@ -1737,6 +1775,9 @@ impl vm::Vm for MshvVm {
             .map_err(|e| vm::HypervisorVmError::InitializeSevSnp(e.into()))
     }
 
+    ///
+    /// Importing isolated pages, these pages will be used
+    /// for the PSP(Platform Security Processor) measurement.
     #[cfg(feature = "sev_snp")]
     fn import_isolated_pages(
         &self,
@@ -1764,6 +1805,11 @@ impl vm::Vm for MshvVm {
             .import_isolated_pages(&isolated_pages[0])
             .map_err(|e| vm::HypervisorVmError::ImportIsolatedPages(e.into()))
     }
+
+    ///
+    /// Complete isolated import, telling the hypervisor that
+    /// importing the pages to guest memory is complete.
+    ///
     #[cfg(feature = "sev_snp")]
     fn complete_isolated_import(
         &self,


### PR DESCRIPTION
This patch adds missing new lines after functions, fixes few typos in the comments, adds few missing
comments to SNP related functions.