### PR TITLE
arch: x86_64: Refactor the way to generate e820 RAM maps

### DIFF
--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -91,8 +91,9 @@ pub mod x86_64;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
     arch_memory_regions, configure_system, configure_vcpu, generate_common_cpuid,
-    get_host_cpu_phys_bits, initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE,
-    layout::CMDLINE_START, regs, CpuidConfig, CpuidFeatureEntry, EntryPoint, _NSIG,
+    generate_ram_ranges, get_host_cpu_phys_bits, initramfs_load_addr, layout,
+    layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START, regs, CpuidConfig, CpuidFeatureEntry,
+    EntryPoint, _NSIG,
 };
 
 /// Safe wrapper for `sysconf(_SC_PAGESIZE)`.


### PR DESCRIPTION
This patch defines a new function 'generate_ram_ranges', to generate usable physical memory ranges for the guest based on the existing guest memory managed by VMM. This function is also made public, so that it can be reused, say by the IGVM loader in the future [1].

See: #6020