### PR TITLE
tests: Stabilize 'test_vfio_user' with retries to run host commands

### DIFF
--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -718,6 +718,20 @@ pub fn ssh_command_ip(
     )
 }
 
+pub fn exec_host_command_with_retries(command: &str, retries: u32, interval: Duration) -> bool {
+    for _ in 0..retries {
+        let s = exec_host_command_output(command).status;
+        if !s.success() {
+            eprintln!("\n\n==== retrying in {:?} ===\n\n", interval);
+            thread::sleep(interval);
+        } else {
+            return true;
+        }
+    }
+
+    false
+}
+
 pub fn exec_host_command_status(command: &str) -> ExitStatus {
     exec_host_command_output(command).status
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6776,10 +6776,11 @@ mod common_parallel {
             .unwrap();
         thread::sleep(std::time::Duration::new(2, 0));
 
-        assert!(exec_host_command_status(
-            "/usr/local/bin/spdk-nvme/rpc.py nvmf_create_transport -t VFIOUSER"
-        )
-        .success());
+        assert!(exec_host_command_with_retries(
+            "/usr/local/bin/spdk-nvme/rpc.py nvmf_create_transport -t VFIOUSER",
+            3,
+            std::time::Duration::new(5, 0),
+        ));
         assert!(exec_host_command_status(&format!(
             "/usr/local/bin/spdk-nvme/rpc.py bdev_aio_create {} test 512",
             nvme_dir.join("test-disk.raw").to_str().unwrap()


### PR DESCRIPTION
The 'test_vfio_user' is prone to fail when the system is under high workloads with errors:

```
Error while connecting to /var/tmp/spdk.sock
Is SPDK application running?
Error details: Invalid or non-existing address: '/var/tmp/spdk.sock'
```

This is because SPDK is not fully functional before we request to create a nvme device using the vfio_user protocol. This patch stabilize this test with allowing retires to execute host commands.