### PR TITLE
scripts: more compatible shebangs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -147,7 +147,7 @@ We want to create a virtual machine with the following characteristics:
   `/opt/clh/images/focal-server-cloudimg-amd64.raw`
 
 ```shell
-#!/bin/bash
+#!/usr/bin/env bash
 
 curl --unix-socket /tmp/cloud-hypervisor.sock -i \
      -X PUT 'http://localhost/api/v1/vm.create'  \
@@ -167,7 +167,7 @@ curl --unix-socket /tmp/cloud-hypervisor.sock -i \
 Once the VM is created, we can boot it:
 
 ```shell
-#!/bin/bash
+#!/usr/bin/env bash
 
 curl --unix-socket /tmp/cloud-hypervisor.sock -i -X PUT 'http://localhost/api/v1/vm.boot'
 ```
@@ -177,7 +177,7 @@ curl --unix-socket /tmp/cloud-hypervisor.sock -i -X PUT 'http://localhost/api/v1
 We can fetch information about any VM, as soon as it's created:
 
 ```shell
-#!/bin/bash
+#!/usr/bin/env bash
 
 curl --unix-socket /tmp/cloud-hypervisor.sock -i \
      -X GET 'http://localhost/api/v1/vm.info' \
@@ -189,7 +189,7 @@ curl --unix-socket /tmp/cloud-hypervisor.sock -i \
 We can reboot a VM that's already booted:
 
 ```shell
-#!/bin/bash
+#!/usr/bin/env bash
 
 curl --unix-socket /tmp/cloud-hypervisor.sock -i -X PUT 'http://localhost/api/v1/vm.reboot'
 ```
@@ -199,7 +199,7 @@ curl --unix-socket /tmp/cloud-hypervisor.sock -i -X PUT 'http://localhost/api/v1
 Once booted, we can shut a VM down from the REST API:
 
 ```shell
-#!/bin/bash
+#!/usr/bin/env bash
 
 curl --unix-socket /tmp/cloud-hypervisor.sock -i -X PUT 'http://localhost/api/v1/vm.shutdown'
 ```
@@ -385,7 +385,7 @@ APIs work together, let's look at a complete VM creation flow, from the
    [REST API](#rest-api) in order to creates a virtual machine:
    ```
    shell
-   #!/bin/bash
+   #!/usr/bin/env bash
 
 	curl --unix-socket /tmp/cloud-hypervisor.sock -i \
 		-X PUT 'http://localhost/api/v1/vm.create'  \

--- a/scripts/check-image-compatibility.sh
+++ b/scripts/check-image-compatibility.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 : '
     This script checks if an image is compatible with Cloud Hypervisor.
     At first, it detects the image type(raw or qcow2),

--- a/scripts/common-aarch64.sh
+++ b/scripts/common-aarch64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 WORKLOADS_DIR="$HOME/workloads"
 

--- a/scripts/create-cloud-init.sh
+++ b/scripts/create-cloud-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 rm -f /tmp/ubuntu-cloudinit.img

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # Copyright © 2020 Intel Corporation

--- a/scripts/prepare_vdpa.sh
+++ b/scripts/prepare_vdpa.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 sudo apt install -y libncurses-dev gawk flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev libiberty-dev autoconf git make dpkg-dev libmnl-dev pkg-config iproute2

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 source $HOME/.cargo/env

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 source $HOME/.cargo/env

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 source $HOME/.cargo/env

--- a/scripts/run_integration_tests_sgx.sh
+++ b/scripts/run_integration_tests_sgx.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 source $HOME/.cargo/env

--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 # This set of vfio tests require to be ran on a specific machine with
@@ -14,7 +14,7 @@ process_common_args "$@"
 
 WORKLOADS_DIR="$HOME/workloads"
 
-download_hypervisor_fw 
+download_hypervisor_fw
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then

--- a/scripts/run_integration_tests_windows_aarch64.sh
+++ b/scripts/run_integration_tests_windows_aarch64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 source $HOME/.cargo/env

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 source $HOME/.cargo/env

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 source $HOME/.cargo/env

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 source $HOME/.cargo/env

--- a/scripts/run_openapi_tests.sh
+++ b/scripts/run_openapi_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source $HOME/.cargo/env
 source $(dirname "$0")/test-util.sh

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 hypervisor="kvm"
 test_filter=""
 


### PR DESCRIPTION
`#!/bin/bash` is not available on all systems, such as [NixOS](https://nixos.org/). Using `#!/usr/bin/env bash` is the most compatible way on all UNIX-like systems.

