### PR TITLE
block: qcow: support compressed image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "crc32c",
  "io-uring",
  "libc",
+ "libdeflater",
  "log",
  "remain",
  "smallvec",
@@ -1174,6 +1175,24 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "libdeflate-sys"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67921a7f85100c1559efc3d1c7c472091b7da05f304b4bbd5356f075e97f1cc2"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libdeflater"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a31b22f662350ec294b13859f935aea772ba7b2bc8776269f4a5627308eab7d"
+dependencies = [
+ "libdeflate-sys",
+]
 
 [[package]]
 name = "libssh2-sys"

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -25,3 +25,4 @@ virtio-queue = "0.10.0"
 vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.11.0"
+libdeflater = "1.19.0"

--- a/block/src/qcow/qcow_raw_file.rs
+++ b/block/src/qcow/qcow_raw_file.rs
@@ -125,6 +125,11 @@ impl QcowRawFile {
         self.cluster_size
     }
 
+    /// Returns the start offset of address that aligned a cluster
+    pub fn start_of_cluster(&self, address: u64) -> u64 {
+        address & !(self.cluster_mask)
+    }
+
     /// Returns the offset of `address` within a cluster.
     pub fn cluster_offset(&self, address: u64) -> u64 {
         address & self.cluster_mask


### PR DESCRIPTION
This PR does the following:
1 Introduce ClusterType, divide cluster into five type, cluster type decides it's read/write logic。
2 Support compressed image(zlib based compression). 
3 Chose libdeflater as the decompression library, it performs best.
4 Add simple test of cluster.