### PR TITLE
arch: x86_64: handle npot CPU topology

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1035,6 +1035,40 @@ fn test_cpu_topology(threads_per_core: u8, cores_per_package: u8, packages: u8, 
                 .unwrap_or(0),
             packages
         );
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            let mut cpu_id = 0;
+            for package_id in 0..packages {
+                for core_id in 0..cores_per_package {
+                    for _ in 0..threads_per_core {
+                        assert_eq!(
+                            guest
+                                .ssh_command(&format!("cat /sys/devices/system/cpu/cpu{cpu_id}/topology/physical_package_id"))
+                                .unwrap()
+                                .trim()
+                                .parse::<u8>()
+                                .unwrap_or(0),
+                            package_id
+                        );
+
+                        assert_eq!(
+                            guest
+                                .ssh_command(&format!(
+                                    "cat /sys/devices/system/cpu/cpu{cpu_id}/topology/core_id"
+                                ))
+                                .unwrap()
+                                .trim()
+                                .parse::<u8>()
+                                .unwrap_or(0),
+                            core_id
+                        );
+
+                        cpu_id += 1;
+                    }
+                }
+            }
+        }
     });
 
     let _ = child.kill();

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1175,6 +1175,8 @@ impl Vm {
             .as_deref()
             .map(|strings| strings.iter().map(|s| s.as_ref()).collect::<Vec<&str>>());
 
+        let topology = self.cpu_manager.lock().unwrap().get_vcpu_topology();
+
         arch::configure_system(
             &mem,
             arch::layout::CMDLINE_START,
@@ -1185,6 +1187,7 @@ impl Vm {
             serial_number.as_deref(),
             uuid.as_deref(),
             oem_strings.as_deref(),
+            topology,
         )
         .map_err(Error::ConfigureSystem)?;
         Ok(())


### PR DESCRIPTION
This PR addresses a bug in which the cpu topology reported by a guest with non power-of-two number of cores is incorrect. For example, in some contexts, a virtual machine with 2-sockets and 12-cores will report believe that 16 cores are on socket 1 and 8 cores are on socket 2. In other cases, common topology enumeration software such as `hwloc` will crash.

The root of the problem is the way that cloud-hypervisor generates apic_id. On x86_64, the (x2) apic_id embeds information about cpu topology. The `cpuid` instruction is primarily used to discover the number of sockets, dies, cores, threads, etc. Using this information, the (x2) apic_id is masked to determine which {core, die, socket} the cpu belongs to on. When the cpu topology is not a power of two (e.g. a 12-core machine), this requires a non-contiguous (x2) apic_id.

Unfortunately, the assumption that the "(x2) apic id" is equal to the "contiguous cpu index" is assumed in multiple places throughout the codebase, so its hard to guarantee that I found them all.
