### PR TITLE
vmm: forbid using special VSOCK CIDs for guests

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2673,7 +2673,7 @@ mod unit_tests {
     #[test]
     fn test_vmm_vm_cold_add_vsock() {
         let mut vmm = create_dummy_vmm();
-        let vsock_config = VsockConfig::parse("socket=/tmp/sock,cid=1,iommu=on").unwrap();
+        let vsock_config = VsockConfig::parse("socket=/tmp/sock,cid=3,iommu=on").unwrap();
 
         assert!(matches!(
             vmm.vm_add_vsock(vsock_config.clone()),


### PR DESCRIPTION
I accidentally ran a VM with CID 2 (VMADDR_CID_HOST), and very strange and difficult to debug behavior ensued.  I don't think a virtio-vsock device should be allowed to have any of the special CIDs (VMADDR_CID_ANY, VMADDR_CID_HYPERVISOR, VMADDR_CID_LOCAL, VMADDR_CID_HOST).