### PR TITLE
vmm: use trait objects for API actions

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "virtio-queue",
  "vm-device",
  "vm-memory",
+ "vm-migration",
  "vm-virtio",
  "vmm",
  "vmm-sys-util 0.11.2",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -27,6 +27,7 @@ virtio-queue = "0.10.0"
 vmm = { path = "../vmm" }
 vmm-sys-util = "0.11.2"
 vm-memory = "0.13.1"
+vm-migration = { path = "../vm-migration" }
 vm-device = { path = "../vm-device" }
 vm-virtio = { path = "../vm-virtio" }
 


### PR DESCRIPTION
Uses of the old ApiRequest enum conflated two different concerns: identifying an API request endpoint, and storing data for an API request.  This led to ApiRequest values being passed around with junk data just to communicate a request type, which forced all API request body types to implement Default, which in some cases doesn't make any sense — what's the "default" path for a vhost-user socket?  The nonsensical Default values have led to tests relying on being able to use nonsensical data, which is an impediment to adding better validation for these types.

Rather than having API request types be represented by an enum, which has to carry associated body data everywhere it's used, it makes more sense to represent API request types as trait objects.  These can have an associated type for the type of the request body, and this makes it possible to pass API request types and data around as siblings in a type-safe way without forcing them into a single value even where it doesn't make sense.  Trait objects also give us dynamic dispatch, which lets us get rid of several large match blocks.