### PR TITLE
arch: x86_64: create hole for AMD HyperTransport

### DIFF
--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -123,3 +123,6 @@ pub const APIC_START: GuestAddress = GuestAddress(0xfee0_0000);
 
 // ** 64-bit RAM start (start: 4GiB, length: varies) **
 pub const RAM_64BIT_START: GuestAddress = GuestAddress(0x1_0000_0000);
+
+pub const AMD_HYPER_TRANSPORT_HOLE_START: GuestAddress = GuestAddress(0xfd_0000_0000);
+pub const AMD_HYPER_TRANSPORT_HOLE_SIZE: u64 = 0x300000000;

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -126,8 +126,8 @@ download_hypervisor_fw() {
 }
 
 download_ovmf() {
-    OVMF_FW_TAG="ch-6624aa331f"
-    OVMF_FW_URL="https://github.com/cloud-hypervisor/edk2/releases/download/$OVMF_FW_TAG/CLOUDHV.fd"
+    OVMF_FW_TAG="ch-highmem"
+    OVMF_FW_URL="https://github.com/thomasbarrett/edk2/releases/download/$OVMF_FW_TAG/CLOUDHV.fd"
     OVMF_FW="$WORKLOADS_DIR/CLOUDHV.fd"
     pushd $WORKLOADS_DIR
     rm -f $OVMF_FW

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -92,15 +92,10 @@ fn generate_memory_map(
     let mut memory_map = Vec::new();
 
     // Get usable physical memory ranges
-    let (first_ram_range, second_ram_range) =
-        arch::generate_ram_ranges(guest_mem).map_err(Error::InvalidGuestMemmap)?;
+    let ram_ranges = arch::generate_ram_ranges(guest_mem).map_err(Error::InvalidGuestMemmap)?;
 
-    // Create the memory map entry for memory region before the gap
-    memory_map.push(igvm_memmap_from_ram_range(first_ram_range));
-
-    // Create the memory map entry for memory region after the gap if any
-    if let Some(second_ram_range) = second_ram_range {
-        memory_map.push(igvm_memmap_from_ram_range(second_ram_range));
+    for ram_range in ram_ranges {
+        memory_map.push(igvm_memmap_from_ram_range(ram_range));
     }
 
     Ok(memory_map)

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -738,6 +738,8 @@ impl Vmm {
             existing_memory_files,
             #[cfg(target_arch = "x86_64")]
             None,
+            #[cfg(target_arch = "x86_64")]
+            self.hypervisor.get_cpu_vendor(),
         )
         .map_err(|e| {
             MigratableError::MigrateReceive(anyhow!(

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -19,6 +19,8 @@ use arch::x86_64::{SgxEpcRegion, SgxEpcSection};
 use arch::RegionType;
 #[cfg(target_arch = "x86_64")]
 use devices::ioapic;
+#[cfg(target_arch = "x86_64")]
+use hypervisor::CpuVendor;
 #[cfg(target_arch = "aarch64")]
 use hypervisor::HypervisorVmError;
 #[cfg(target_arch = "x86_64")]
@@ -929,13 +931,13 @@ impl MemoryManager {
                 // based on the GuestMemory regions.
                 continue;
             }
-            self.ram_allocator
-                .allocate(
-                    Some(GuestAddress(region.base)),
-                    region.size as GuestUsize,
-                    None,
-                )
-                .ok_or(Error::MemoryRangeAllocation)?;
+            // This allocation may fail for reserved regions that are above the
+            // maximum hotpluggable memory threshold.
+            self.ram_allocator.allocate(
+                Some(GuestAddress(region.base)),
+                region.size as GuestUsize,
+                None,
+            );
         }
 
         Ok(())
@@ -981,6 +983,7 @@ impl MemoryManager {
         restore_data: Option<&MemoryManagerSnapshotData>,
         existing_memory_files: Option<HashMap<u32, File>>,
         #[cfg(target_arch = "x86_64")] sgx_epc_config: Option<Vec<SgxEpcConfig>>,
+        #[cfg(target_arch = "x86_64")] cpu_vendor: CpuVendor,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
         trace_scoped!("MemoryManager::new");
 
@@ -1036,6 +1039,9 @@ impl MemoryManager {
             )
         } else {
             // Init guest memory
+            #[cfg(target_arch = "x86_64")]
+            let arch_mem_regions = arch::arch_memory_regions(cpu_vendor);
+            #[cfg(not(target_arch = "x86_64"))]
             let arch_mem_regions = arch::arch_memory_regions();
 
             let ram_regions: Vec<(GuestAddress, usize)> = arch_mem_regions
@@ -1257,6 +1263,7 @@ impl MemoryManager {
         source_url: Option<&str>,
         prefault: bool,
         phys_bits: u8,
+        #[cfg(target_arch = "x86_64")] cpu_vendor: CpuVendor,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
         if let Some(source_url) = source_url {
             let mut memory_file_path = url_to_path(source_url).map_err(Error::Restore)?;
@@ -1276,6 +1283,8 @@ impl MemoryManager {
                 None,
                 #[cfg(target_arch = "x86_64")]
                 None,
+                #[cfg(target_arch = "x86_64")]
+                cpu_vendor,
             )?;
 
             mm.lock()

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -833,6 +833,8 @@ impl Vm {
                 source_url,
                 prefault.unwrap(),
                 phys_bits,
+                #[cfg(target_arch = "x86_64")]
+                hypervisor.get_cpu_vendor(),
             )
             .map_err(Error::MemoryManager)?
         } else {
@@ -850,6 +852,8 @@ impl Vm {
                 None,
                 #[cfg(target_arch = "x86_64")]
                 sgx_epc_config,
+                #[cfg(target_arch = "x86_64")]
+                hypervisor.get_cpu_vendor(),
             )
             .map_err(Error::MemoryManager)?
         };


### PR DESCRIPTION
This is the first in a small series of PRs to add support for AMD guest with >1TiB of RAM.

## Problem Overview
The AMD IOMMU [has a reserved memory region](https://github.com/torvalds/linux/blob/6c1dd1fe5d8a1d43ed96e2e0ed44a88c73c5c039/drivers/iommu/amd/iommu.c#L2517) between `0xFD_0000_0000` and `0xFF_FFFF_FFFF`. 

[As of Linux 5.4+](https://github.com/torvalds/linux/commit/9b77e5c79840fc334a5b7f770c5ab0c09dc0e028
), the VFIO framework verifies that all memory ranges provided to VFIO_IOMMU_MAP_DMA are valid.

Attempting to create a guest with >1TiB of RAM fails when VFIO devices are used during the VFIO_IOMMU_MAP_DMA step with EINVAL. 

Existing AMD guests with <1TiB of RAM and VFIO devices may experience weird behavior and / or crashes if their mmio64 BARs overlap with the HyperTransport window (although I haven't personally experienced this).

## Solution Overview
This PR adds a new hole around 1 TiB when creating x86_64 AMD hosts. There are now up to 3 non-contiguous RAM address ranges on x86_64 AMD guests instead of just 2. To support this, we replace the `(RamRange, Option<RamRange>)` tuple construct with a `Vec<RamRange>` in a few places in the codebase.
