### PR TITLE
vmm: openapi: String quote the enum members of ConsoleConfig::Mode

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -994,7 +994,7 @@ components:
           type: string
         mode:
           type: string
-          enum: [Off, Pty, Tty, File, Socket, Null]
+          enum: ["Off", "Pty", "Tty", "File", "Socket", "Null"]
         iommu:
           type: boolean
           default: false


### PR DESCRIPTION
This disambiguates from the null keyword.

Fixes: #6107

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
