### PR TITLE
build: Re-enable test_vfio on AMD workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ pipeline {
                             }
                             steps {
                                 sh 'sudo modprobe openvswitch'
-                                sh 'scripts/dev_cli.sh tests --integration -- -- --skip common_parallel::test_vfio'
+                                sh 'scripts/dev_cli.sh tests --integration'
                             }
                         }
                         stage('Run live-migration integration tests') {
@@ -161,7 +161,7 @@ pipeline {
                             }
                             steps {
                                 sh 'sudo modprobe openvswitch'
-                                sh 'scripts/dev_cli.sh tests --integration --libc musl -- -- --skip common_parallel::test_vfio'
+                                sh 'scripts/dev_cli.sh tests --integration --libc musl'
                             }
                         }
                         stage('Run live-migration integration tests for musl') {


### PR DESCRIPTION
With the change in 7bc764d to expose the SVM bit for nested
virtualisation test_vfio can be re-enabled on the AMD workers.

Fixes: #5895

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
