### PR TITLE
vmm: support setting cpu affinity with host cpu indices >255

### DIFF
--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -290,6 +290,17 @@ impl TupleValue for Vec<u64> {
     }
 }
 
+impl TupleValue for Vec<usize> {
+    fn parse_value(input: &str) -> Result<Self, TupleError> {
+        Ok(IntegerList::from_str(input)
+            .map_err(TupleError::InvalidIntegerList)?
+            .0
+            .iter()
+            .map(|v| *v as usize)
+            .collect())
+    }
+}
+
 pub struct Tuple<S, T>(pub Vec<(S, T)>);
 
 pub enum TupleError {

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -590,7 +590,7 @@ impl CpusConfig {
             .map_err(Error::ParseCpus)?
             .unwrap_or(DEFAULT_MAX_PHYS_BITS);
         let affinity = parser
-            .convert::<Tuple<u8, Vec<u8>>>("affinity")
+            .convert::<Tuple<u8, Vec<usize>>>("affinity")
             .map_err(Error::ParseCpus)?
             .map(|v| {
                 v.0.iter()

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -479,7 +479,7 @@ pub struct CpuManager {
     #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     acpi_address: Option<GuestAddress>,
     proximity_domain_per_cpu: BTreeMap<u8, u32>,
-    affinity: BTreeMap<u8, Vec<u8>>,
+    affinity: BTreeMap<u8, Vec<usize>>,
     dynamic: bool,
     hypervisor: Arc<dyn hypervisor::Hypervisor>,
 }
@@ -921,7 +921,7 @@ impl CpuManager {
             unsafe { libc::CPU_ZERO(&mut cpuset) };
             for host_cpu in host_cpus {
                 // SAFETY: FFI call, trivially safe
-                unsafe { libc::CPU_SET(*host_cpu as usize, &mut cpuset) };
+                unsafe { libc::CPU_SET(*host_cpu, &mut cpuset) };
             }
             cpuset
         });

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -10,7 +10,7 @@ use virtio_devices::RateLimiterConfig;
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct CpuAffinity {
     pub vcpu: u8,
-    pub host_cpus: Vec<u8>,
+    pub host_cpus: Vec<usize>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]


### PR DESCRIPTION
On hosts with >256 cpus, setting the vcpu affinity to a host cpu index >255 will return an error.
This commit changes the host_cpu type to a u16 to support setting the vcpu affinity to a host cpu with an index >255.

For example, on a host with 384 cpus, setting the vcpu affinity to host cpu 256 results in the following error:
```
400 : SerdeJsonDeserialize(Error(\"invalid value: integer `256`, expected u8\", line: 1, column: 3397))
```