### PR TITLE
Update Kernel pre-requisite information for iommu

### DIFF
--- a/docs/iommu.md
+++ b/docs/iommu.md
@@ -60,10 +60,7 @@ implement a full emulation of a physical IOMMU.
 
 ### Kernel
 
-Since virtio-iommu has landed partially into the version 5.3 of the Linux
-kernel, a special branch is needed to get things working with Cloud Hypervisor.
-By partially, we are talking about x86 specifically, as it is already fully
-functional for ARM architectures.
+As of Kernel 5.14, virtio-iommu is available for both X86-64 and Aarch64.
 
 ## Usage
 


### PR DESCRIPTION
Since 5.3, 5.14 merged x86 support.

By the way, I haven't, like, tried this out or anything, but I noticed the information appears out of date.