### PR TITLE
gitignore: ignore vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 **/rusty-tags.vi
 /rpm/SOURCES
 /.vscode
+/vendor


### PR DESCRIPTION
This is the default output directory for `cargo vendor`.