### PR TITLE
scripts: create download_ovmf helper function

### DIFF
--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -14,13 +14,8 @@ fi
 WIN_IMAGE_FILE="/root/workloads/windows-server-2022-amd64-2.raw"
 
 WORKLOADS_DIR="/root/workloads"
-OVMF_FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/edk2/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
-OVMF_FW="$WORKLOADS_DIR/CLOUDHV.fd"
-if [ ! -f "$OVMF_FW" ]; then
-    pushd $WORKLOADS_DIR
-    time wget --quiet $OVMF_FW_URL || exit 1
-    popd
-fi
+
+download_ovmf
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -20,13 +20,7 @@ cp scripts/sha1sums-x86_64 $WORKLOADS_DIR
 
 download_hypervisor_fw
 
-OVMF_FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/edk2/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
-OVMF_FW="$WORKLOADS_DIR/CLOUDHV.fd"
-if [ ! -f "$OVMF_FW" ]; then
-    pushd $WORKLOADS_DIR
-    time wget --quiet $OVMF_FW_URL || exit 1
-    popd
-fi
+download_ovmf
 
 FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
 FOCAL_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$FOCAL_OS_IMAGE_NAME"

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -124,3 +124,13 @@ download_hypervisor_fw() {
     time wget --quiet $FW_URL || exit 1
     popd
 }
+
+download_ovmf() {
+    OVMF_FW_TAG="ch-6624aa331f"
+    OVMF_FW_URL="https://github.com/cloud-hypervisor/edk2/releases/download/$OVMF_FW_TAG/CLOUDHV.fd"
+    OVMF_FW="$WORKLOADS_DIR/CLOUDHV.fd"
+    pushd $WORKLOADS_DIR
+    rm -f $OVMF_FW
+    time wget --quiet $OVMF_FW_URL || exit 1
+    popd
+}


### PR DESCRIPTION
Move the duplicated logic to download OVMF into a helper function. Explicitly specify the OVMF_FW_TAG instead of downloading the latest so that new OVMF versions can be easily tested.
