### PR TITLE
tests: limit max_phys_bits to 39 on windows guest tests

### DIFF
--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -14,13 +14,12 @@ fi
 WIN_IMAGE_FILE="/root/workloads/windows-server-2022-amd64-2.raw"
 
 WORKLOADS_DIR="/root/workloads"
-OVMF_FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/edk2/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
+OVMF_FW_URL=$(curl --silent https://api.github.com/repos/thomasbarrett/edk2/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
 OVMF_FW="$WORKLOADS_DIR/CLOUDHV.fd"
-if [ ! -f "$OVMF_FW" ]; then
-    pushd $WORKLOADS_DIR
-    time wget --quiet $OVMF_FW_URL || exit 1
-    popd
-fi
+pushd $WORKLOADS_DIR
+rm -f $OVMF_FW
+time wget --quiet $OVMF_FW_URL || exit 1
+popd
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -20,7 +20,7 @@ cp scripts/sha1sums-x86_64 $WORKLOADS_DIR
 
 download_hypervisor_fw
 
-OVMF_FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/edk2/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
+OVMF_FW_URL=$(curl --silent https://api.github.com/repos/thomasbarrett/edk2/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')
 OVMF_FW="$WORKLOADS_DIR/CLOUDHV.fd"
 if [ ! -f "$OVMF_FW" ]; then
     pushd $WORKLOADS_DIR

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7642,7 +7642,7 @@ mod windows {
         let windows_guest = WindowsGuest::new();
 
         let mut child = GuestCommand::new(windows_guest.guest())
-            .args(["--cpus", "boot=2,kvm_hyperv=on"])
+            .args(["--cpus", "boot=2,kvm_hyperv=on,max_phys_bits=39"])
             .args(["--memory", "size=4G"])
             .args(["--kernel", edk2_path().to_str().unwrap()])
             .args(["--serial", "tty"])
@@ -7688,7 +7688,7 @@ mod windows {
         ovmf_path.push(OVMF_NAME);
 
         let mut child = GuestCommand::new(windows_guest.guest())
-            .args(["--cpus", "boot=4,kvm_hyperv=on"])
+            .args(["--cpus", "boot=4,kvm_hyperv=on,max_phys_bits=39"])
             .args(["--memory", "size=4G"])
             .args(["--kernel", ovmf_path.to_str().unwrap()])
             .args(["--serial", "tty"])
@@ -7759,7 +7759,7 @@ mod windows {
 
         let mut child = GuestCommand::new(windows_guest.guest())
             .args(["--api-socket", &api_socket_source])
-            .args(["--cpus", "boot=2,kvm_hyperv=on"])
+            .args(["--cpus", "boot=2,kvm_hyperv=on,max_phys_bits=39"])
             .args(["--memory", "size=4G"])
             .args(["--kernel", ovmf_path.to_str().unwrap()])
             .args(["--serial", "tty"])
@@ -7848,7 +7848,7 @@ mod windows {
 
         let mut child = GuestCommand::new(windows_guest.guest())
             .args(["--api-socket", &api_socket])
-            .args(["--cpus", "boot=2,max=8,kvm_hyperv=on"])
+            .args(["--cpus", "boot=2,max=8,kvm_hyperv=on,max_phys_bits=39"])
             .args(["--memory", "size=4G"])
             .args(["--kernel", ovmf_path.to_str().unwrap()])
             .args(["--serial", "tty"])
@@ -7923,7 +7923,7 @@ mod windows {
 
         let mut child = GuestCommand::new(windows_guest.guest())
             .args(["--api-socket", &api_socket])
-            .args(["--cpus", "boot=2,kvm_hyperv=on"])
+            .args(["--cpus", "boot=2,kvm_hyperv=on,max_phys_bits=39"])
             .args(["--memory", "size=2G,hotplug_size=5G"])
             .args(["--kernel", ovmf_path.to_str().unwrap()])
             .args(["--serial", "tty"])
@@ -7997,7 +7997,7 @@ mod windows {
 
         let mut child = GuestCommand::new(windows_guest.guest())
             .args(["--api-socket", &api_socket])
-            .args(["--cpus", "boot=2,kvm_hyperv=on"])
+            .args(["--cpus", "boot=2,kvm_hyperv=on,max_phys_bits=39"])
             .args(["--memory", "size=4G"])
             .args(["--kernel", ovmf_path.to_str().unwrap()])
             .args(["--serial", "tty"])
@@ -8071,7 +8071,7 @@ mod windows {
 
         let mut child = GuestCommand::new(windows_guest.guest())
             .args(["--api-socket", &api_socket])
-            .args(["--cpus", "boot=2,kvm_hyperv=on"])
+            .args(["--cpus", "boot=2,kvm_hyperv=on,max_phys_bits=39"])
             .args(["--memory", "size=4G"])
             .args(["--kernel", ovmf_path.to_str().unwrap()])
             .args(["--serial", "tty"])
@@ -8167,7 +8167,7 @@ mod windows {
 
         let mut child = GuestCommand::new(windows_guest.guest())
             .args(["--api-socket", &api_socket])
-            .args(["--cpus", "boot=2,kvm_hyperv=on"])
+            .args(["--cpus", "boot=2,kvm_hyperv=on,max_phys_bits=39"])
             .args(["--memory", "size=2G"])
             .args(["--kernel", ovmf_path.to_str().unwrap()])
             .args(["--serial", "tty"])
@@ -8297,7 +8297,7 @@ mod windows {
 
         let mut child = GuestCommand::new(windows_guest.guest())
             .args(["--api-socket", &api_socket])
-            .args(["--cpus", "boot=2,kvm_hyperv=on"])
+            .args(["--cpus", "boot=2,kvm_hyperv=on,max_phys_bits=39"])
             .args(["--memory", "size=4G"])
             .args(["--kernel", ovmf_path.to_str().unwrap()])
             .args(["--serial", "tty"])


### PR DESCRIPTION
cloud-hypervisor only supports max_phys_bits of 39 for Windows guests.