### PR TITLE
set SEV control register for SEV-Enabled guest

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -272,6 +272,12 @@ pub enum HypervisorCpuError {
     ///
     #[error("Failed to get CPUID entries: {0}")]
     GetCpuidVales(#[source] anyhow::Error),
+    ///
+    /// Setting SEV control register error
+    ///
+    #[cfg(feature = "sev_snp")]
+    #[error("Failed to set sev control register: {0}")]
+    SetSevControlRegister(#[source] anyhow::Error),
 }
 
 #[derive(Debug)]
@@ -493,6 +499,10 @@ pub trait Vcpu: Send + Sync {
         _xfem: u64,
         _xss: u64,
     ) -> Result<[u32; 4]> {
+        unimplemented!()
+    }
+    #[cfg(feature = "mshv")]
+    fn set_sev_control_register(&self, _reg: u64) -> Result<()> {
         unimplemented!()
     }
 }

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1241,6 +1241,18 @@ impl cpu::Vcpu for MshvVcpu {
         ]
         .to_vec()
     }
+
+    ///
+    /// Sets the AMD specific vcpu's sev control register.
+    ///
+    #[cfg(feature = "sev_snp")]
+    fn set_sev_control_register(&self, vmsa_pfn: u64) -> cpu::Result<()> {
+        let sev_control_reg = snp::get_sev_control_register(vmsa_pfn);
+
+        self.fd
+            .set_sev_control_register(sev_control_reg)
+            .map_err(|e| cpu::HypervisorCpuError::SetSevControlRegister(e.into()))
+    }
 }
 
 impl MshvVcpu {


### PR DESCRIPTION
Set the SEV control register so we know where to start running.  This register configures the SEV feature control state on a virtual processor.
    
