### PR TITLE
block: Block Device Virtqueue Thread Pinning

### DIFF
--- a/fuzz/fuzz_targets/block.rs
+++ b/fuzz/fuzz_targets/block.rs
@@ -21,6 +21,7 @@ use virtio_devices::{Block, VirtioDevice, VirtioInterrupt, VirtioInterruptType};
 use virtio_queue::{Queue, QueueT};
 use vm_memory::{bitmap::AtomicBitmap, Bytes, GuestAddress, GuestMemoryAtomic};
 use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
+use std::collections::BTreeMap;
 
 type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 
@@ -49,6 +50,7 @@ fuzz_target!(|bytes| {
     let shm = memfd_create(&ffi::CString::new("fuzz").unwrap(), 0).unwrap();
     let disk_file: File = unsafe { File::from_raw_fd(shm) };
     let qcow_disk = Box::new(RawFileDiskSync::new(disk_file)) as Box<dyn DiskFile>;
+    let queue_affinity = BTreeMap::new();
     let mut block = Block::new(
         "tmp".to_owned(),
         qcow_disk,
@@ -62,6 +64,7 @@ fuzz_target!(|bytes| {
         None,
         EventFd::new(EFD_NONBLOCK).unwrap(),
         None,
+        queue_affinity,
     )
     .unwrap();
 

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -96,6 +96,7 @@ fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_pwritev, vec![]),
         (libc::SYS_pwrite64, vec![]),
         (libc::SYS_sched_getaffinity, vec![]),
+        (libc::SYS_sched_setaffinity, vec![]),
         (libc::SYS_set_robust_list, vec![]),
         (libc::SYS_timerfd_settime, vec![]),
     ]

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -828,6 +828,19 @@ components:
           type: string
         rate_limiter_config:
           $ref: "#/components/schemas/RateLimiterConfig"
+    
+    VirtQueueAffinity:
+      required:
+        - queue_index
+        - host_cpus
+      type: object
+      properties:
+        queue_index:
+          type: integer
+        host_cpus:
+          type: array
+          items:
+            type: integer
 
     DiskConfig:
       required:
@@ -867,6 +880,10 @@ components:
           type: string
         rate_limit_group:
           type: string
+        affinity:
+          type: array
+          items:
+            $ref: "#/components/schemas/VirtQueueAffinity"
 
     NetConfig:
       type: object

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -188,6 +188,12 @@ pub struct RateLimiterGroupConfig {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct VirtQueueAffinity {
+    pub queue_index: u16,
+    pub host_cpus: Vec<usize>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DiskConfig {
     pub path: Option<PathBuf>,
     #[serde(default)]
@@ -219,6 +225,8 @@ pub struct DiskConfig {
     pub pci_segment: u16,
     #[serde(default)]
     pub serial: Option<String>,
+    #[serde(default)]
+    pub queue_affinity: Option<Vec<VirtQueueAffinity>>,
 }
 
 pub const DEFAULT_DISK_NUM_QUEUES: usize = 1;


### PR DESCRIPTION
This PR adds Rest + CLI options to pin virtqueue threads for block devices to specific host cpus. The relevant struct to store this information is included below:

```
pub struct VirtQueueAffinity {
    pub queue_index: u16,
    pub host_cpus: Vec<usize>,
}
```

The CLI has been updated to include a queue_affinity option to the --desk flag:
```
./cloud-hypervisor \
    --kernel ./hypervisor-fw \
    --disk path={image_path},num_queues=4,queue_affinity=[0@[1],1@[2],2@[3],3@[4] \
    --cpus boot=4 \
    --memory size=1024M \
    --net "tap=,mac=,ip=,mask="
```

Related issue: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/5728