### PR TITLE
scripts: dev_cli: remove unused cargo variable

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -361,7 +361,6 @@ cmd_tests() {
             hypervisor="$1"
             ;;
         "--all") {
-            cargo=true
             unit=true
             integration=true
         } ;;


### PR DESCRIPTION
Variable cargo is unused, hence remove it.