### PR TITLE
main: Support igvm as a payload

### DIFF
--- a/scripts/gitlint/rules.py
+++ b/scripts/gitlint/rules.py
@@ -43,6 +43,7 @@ class TitleStartsWithComponent(LineRule):
             'gitlint',
             'hypervisor',
             'Jenkinsfile',
+            'main',
             'misc',
             'net_gen',
             'net_util',

--- a/src/main.rs
+++ b/src/main.rs
@@ -697,6 +697,11 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
     .map_err(Error::StartVmmThread)?;
 
     let r: Result<(), Error> = (|| {
+        #[cfg(feature = "igvm")]
+        let payload_present = cmd_arguments.contains_id("kernel")
+            || cmd_arguments.contains_id("firmware")
+            || cmd_arguments.contains_id("igvm");
+        #[cfg(not(feature = "igvm"))]
         let payload_present =
             cmd_arguments.contains_id("kernel") || cmd_arguments.contains_id("firmware");
 


### PR DESCRIPTION
Currently kernel and firmware are checked as a payload. IGVM should be checked as well. Otherwise, it hangs indefinitely.