### PR TITLE
vmm: Don't configure vcpu in case of SEV-SNP

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -829,7 +829,12 @@ impl CpuManager {
                     kernel_entry_point.entry_addr.0 / crate::igvm::HV_PAGE_SIZE,
                 )?;
             }
+
+            // Traditional way to configure vcpu doesn't work for SEV-SNP guests.
+            // All the vCPU configuration for SEV-SNP guest is provided via VMSA.
+            return Ok(());
         }
+
         #[cfg(target_arch = "x86_64")]
         assert!(!self.cpuid.is_empty());
 


### PR DESCRIPTION
Traditional way to configure vcpu don't work for sev-snp guests. All the vCPU configuration for SEV-SNP guest is provided via VMSA.