### PR TITLE
build: add shell script linter workflow

### DIFF
--- a/.github/workflows/shlint.yaml
+++ b/.github/workflows/shlint.yaml
@@ -1,0 +1,20 @@
+name: Shell scripts check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  sh-checker:
+    name: Check shell scripts
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Run the shell script checkers
+      uses: luizm/action-sh-checker@master
+      env:
+        SHFMT_OPTS: -i 4 -d
+        SHELLCHECK_OPTS: -x --source-path scripts

--- a/scripts/check-image-compatibility.sh
+++ b/scripts/check-image-compatibility.sh
@@ -8,8 +8,6 @@
     a message about the compatibility of the image.
 '
 
-
-
 usage="$(basename "$0") [-h] -f -w -- program to check Cloud Hypervisor compatible image
 
 where:
@@ -18,12 +16,11 @@ where:
     -w  directory to be used for temporary files"
 
 function check_command {
-    if ! command -v  $1 &> /dev/null
-        then
-            echo "Command $1 could not be found"
+    if ! command -v $1 &>/dev/null; then
+        echo "Command $1 could not be found"
         exit 1
     fi
-};
+}
 
 function check_if_root {
     if [ "$EUID" -ne 0 ]; then
@@ -31,27 +28,32 @@ function check_if_root {
         exit 1
     fi
 
-};
+}
 
 check_if_root
 working_dir=""
 while getopts ':hf:w:' option; do
     case "$option" in
-        h) echo "$usage"
-            exit
-            ;;
-        f) file_name=$OPTARG
-            ;;
-        w) working_dir=$OPTARG
-            ;;
-        :) printf "missing argument for -%s\n" "$OPTARG" >&2
-            echo "$usage" >&2
-            exit 1
-            ;;
-        \?) printf "illegal option: -%s\n" "$OPTARG" >&2
-            echo "$usage" >&2
-            exit 1
-            ;;
+    h)
+        echo "$usage"
+        exit
+        ;;
+    f)
+        file_name=$OPTARG
+        ;;
+    w)
+        working_dir=$OPTARG
+        ;;
+    :)
+        printf "missing argument for -%s\n" "$OPTARG" >&2
+        echo "$usage" >&2
+        exit 1
+        ;;
+    \?)
+        printf "illegal option: -%s\n" "$OPTARG" >&2
+        echo "$usage" >&2
+        exit 1
+        ;;
     esac
 done
 
@@ -59,22 +61,22 @@ shift $((OPTIND - 1))
 
 if [ -z "${file_name}" ]; then
     echo "You must provide the image file name"
-	exit 1
+    exit 1
 fi
 if [[ ! -f ${file_name} ]]; then
     echo "File ${file_name} does not exist"
     exit 1
 fi
 
-file_abs_path=`readlink -m ${file_name}`
+file_abs_path=$(readlink -m ${file_name})
 if [[ "${working_dir}" != "" && ! -d "${working_dir}" ]]; then
     echo "Directory ${working_dir} does not exist"
     exit 1
 elif [[ "${working_dir}" == "" ]]; then
-    working_dir=`mktemp -d`
+    working_dir=$(mktemp -d)
     tmp_created=1
 else
-    working_dir=`readlink -m ${working_dir}`
+    working_dir=$(readlink -m ${working_dir})
 fi
 
 filename="${file_name%.*}"
@@ -82,11 +84,10 @@ dest_file=${working_dir}/${filename}.raw
 image_type=$(qemu-img info ${file_abs_path} | grep 'file format:' | awk '{ print $3 }')
 echo "Image type detected as ${image_type}"
 
-
 if [[ "${image_type}" == "raw" ]]; then
-	dest_file=${file_abs_path}
+    dest_file=${file_abs_path}
 elif [[ "$image_type" == "qcow2" ]]; then
-    if lsmod | grep "nbd" &> /dev/null ; then
+    if lsmod | grep "nbd" &>/dev/null; then
         echo "Module nbd is loaded!"
     else
         echo "Module nbd is not loaded. Trying to load the module"
@@ -106,18 +107,18 @@ check_command blkid
 part_type=$(blkid -o value -s PTTYPE ${dest_file})
 
 check_command partx
-nr_partitions=`partx -g ${dest_file}  | wc -l`
+nr_partitions=$(partx -g ${dest_file} | wc -l)
 
 check_command fdisk
-out=`fdisk -l  ${dest_file} --bytes | grep -i -A ${nr_partitions} 'Device' | tail -n +2`
+out=$(fdisk -l ${dest_file} --bytes | grep -i -A ${nr_partitions} 'Device' | tail -n +2)
 
 IFS='
 '
 i=0
 declare -A lines
-for x in $out ; do
-	lines[$i]=$x
-	i=$((i+1))
+for x in $out; do
+    lines[$i]=$x
+    i=$((i + 1))
 done
 
 declare -A partitions
@@ -125,40 +126,38 @@ IFS=' '
 i=0
 ROWS=${#lines[@]}
 
-for line in "${lines[@]}";
-do
-	j=0
-	read -a str_arr <<< "$line"
-	for val in "${str_arr[@]}";
-	do
-		if [[ "$val" != "*" ]]; then
-			partitions[$i,$j]=$val
-			j=$((j+1))
-		fi
-	done
-	i=$((i+1))
+for line in "${lines[@]}"; do
+    j=0
+    read -a str_arr <<<"$line"
+    for val in "${str_arr[@]}"; do
+        if [[ "$val" != "*" ]]; then
+            partitions[$i, $j]=$val
+            j=$((j + 1))
+        fi
+    done
+    i=$((i + 1))
 done
 
 COLUMNS=$j
 START_ADDRESS_INDEX=1
-FILE_SYS_INDEX2=$((COLUMNS-1))
-FILE_SYS_INDEX1=$((COLUMNS-2))
+FILE_SYS_INDEX2=$((COLUMNS - 1))
+FILE_SYS_INDEX1=$((COLUMNS - 2))
 DEVICE_INDEX=0
 # Here we have all the partition info now lets mount and analyze the contents
-for ((i=0;i<ROWS;i++)) do
-	if [[ "$part_type" == "gpt" && "${partitions[$i,${FILE_SYS_INDEX1}]}" == "Linux" && "${partitions[$i,${FILE_SYS_INDEX2}]}" == "filesystem" ]]; then
+for ((i = 0; i < ROWS; i++)); do
+    if [[ "$part_type" == "gpt" && "${partitions[$i, ${FILE_SYS_INDEX1}]}" == "Linux" && "${partitions[$i, ${FILE_SYS_INDEX2}]}" == "filesystem" ]]; then
         echo "The image has GPT partitions"
         MOUNT_ROW=$i
-		break
-	elif [[ "$part_type" == "dos" && "${partitions[$i,${FILE_SYS_INDEX1}]}" == "Linux" && "${partitions[$i,${FILE_SYS_INDEX2}]}" == "" ]]; then
+        break
+    elif [[ "$part_type" == "dos" && "${partitions[$i, ${FILE_SYS_INDEX1}]}" == "Linux" && "${partitions[$i, ${FILE_SYS_INDEX2}]}" == "" ]]; then
         echo "The image has DOS partitions"
         MOUNT_ROW=$i
         break
-	fi
+    fi
 done
 
-start_address=${partitions[${MOUNT_ROW},${START_ADDRESS_INDEX}]}
-offset=$((start_address*512))
+start_address=${partitions[${MOUNT_ROW}, ${START_ADDRESS_INDEX}]}
+offset=$((start_address * 512))
 
 MOUNT_DIR=/mnt/clh-img-check/
 rm -rf ${MOUNT_DIR}
@@ -166,22 +165,22 @@ mkdir ${MOUNT_DIR}
 if [[ "${image_type}" == "raw" ]]; then
     mount -o ro,loop,offset=$offset ${dest_file} ${MOUNT_DIR}
 elif [[ "${image_type}" == "qcow2" ]]; then
-    mount -o ro ${partitions[${MOUNT_ROW},${DEVICE_INDEX}]} ${MOUNT_DIR}
+    mount -o ro ${partitions[${MOUNT_ROW}, ${DEVICE_INDEX}]} ${MOUNT_DIR}
 fi
 
 CONFIG_DIR=${MOUNT_DIR}boot/
 if [[ "$part_type" == "dos" ]]; then
-	CONFIG_DIR=${MOUNT_DIR}
+    CONFIG_DIR=${MOUNT_DIR}
 fi
 
 #check VIRTIO
 HAS_VIRTIO=1
 for conf_file in ${CONFIG_DIR}config*; do
-    out=`grep -E "CONFIG_VIRTIO=y|CONFIG_VIRTIO_BLK=y|CONFIG_VIRTIO_BLK=m" ${conf_file} | wc -l`
+    out=$(grep -E "CONFIG_VIRTIO=y|CONFIG_VIRTIO_BLK=y|CONFIG_VIRTIO_BLK=m" ${conf_file} | wc -l)
     if [[ "$out" != "2" ]]; then
-	    echo "VIRTIO not found"
-		HAS_VIRTIO=0
-	fi
+        echo "VIRTIO not found"
+        HAS_VIRTIO=0
+    fi
 done
 
 #clean up
@@ -191,22 +190,22 @@ if [[ "${tmp_created}" == "1" ]]; then
     rm -rf ${working_dir}
 fi
 
-if [[ "${image_type}" == "qcow2" ]];then
-    qemu-nbd --disconnect ${dest_file} > /dev/null
+if [[ "${image_type}" == "qcow2" ]]; then
+    qemu-nbd --disconnect ${dest_file} >/dev/null
 fi
 
 result=""
 if [[ "${part_type}" == "dos" ]]; then
-	result="dos mode not supported"
+    result="dos mode not supported"
 fi
 if [[ "${HAS_VIRTIO}" == "0" ]]; then
-	if [[ "$result" != "" ]]; then
-		result="${result},"
-	fi
-	result="$result VirtIO module not found in the image"
+    if [[ "$result" != "" ]]; then
+        result="${result},"
+    fi
+    result="$result VirtIO module not found in the image"
 fi
-if [[ "$result" == "" ]];then
-	echo "No incompatibilities found"
+if [[ "$result" == "" ]]; then
+    echo "No incompatibilities found"
 else
-	echo "$result"
+    echo "$result"
 fi

--- a/scripts/common-aarch64.sh
+++ b/scripts/common-aarch64.sh
@@ -22,25 +22,26 @@ build_edk2() {
 
     # Prepare source code
     checkout_repo "$EDK2_DIR" "$EDK2_REPO" master "46b4606ba23498d3d0e66b53e498eb3d5d592586"
-    pushd "$EDK2_DIR"
+    pushd "$EDK2_DIR" || exit
     git submodule update --init
-    popd
+    popd || exit
     checkout_repo "$EDK2_PLAT_DIR" "$EDK2_PLAT_REPO" master "8227e9e9f6a8aefbd772b40138f835121ccb2307"
     checkout_repo "$ACPICA_DIR" "$ACPICA_REPO" master "b9c69f81a05c45611c91ea9cbce8756078d76233"
 
     if [[ ! -f "$EDK2_DIR/.built" ||
         ! -f "$EDK2_PLAT_DIR/.built" ||
         ! -f "$ACPICA_DIR/.built" ]]; then
-        pushd "$EDK2_BUILD_DIR"
+        pushd "$EDK2_BUILD_DIR" || exit
         # Build
-        make -C acpica -j $(nproc)
+        make -C acpica -j "$(nproc)"
+        # shellcheck disable=SC1091
         source edk2/edksetup.sh
-        make -C edk2/BaseTools -j $(nproc)
+        make -C edk2/BaseTools -j "$(nproc)"
         build -a AARCH64 -t GCC5 -p ArmVirtPkg/ArmVirtCloudHv.dsc -b RELEASE -n 0
         cp Build/ArmVirtCloudHv-AARCH64/RELEASE_GCC5/FV/CLOUDHV_EFI.fd "$WORKLOADS_DIR"
         touch "$EDK2_DIR"/.built
         touch "$EDK2_PLAT_DIR"/.built
         touch "$ACPICA_DIR"/.built
-        popd
+        popd || exit
     fi
 }

--- a/scripts/common-aarch64.sh
+++ b/scripts/common-aarch64.sh
@@ -28,14 +28,14 @@ build_edk2() {
     checkout_repo "$EDK2_PLAT_DIR" "$EDK2_PLAT_REPO" master "8227e9e9f6a8aefbd772b40138f835121ccb2307"
     checkout_repo "$ACPICA_DIR" "$ACPICA_REPO" master "b9c69f81a05c45611c91ea9cbce8756078d76233"
 
-    if [[ ! -f "$EDK2_DIR/.built" || \
-          ! -f "$EDK2_PLAT_DIR/.built" || \
-          ! -f "$ACPICA_DIR/.built" ]]; then
+    if [[ ! -f "$EDK2_DIR/.built" ||
+        ! -f "$EDK2_PLAT_DIR/.built" ||
+        ! -f "$ACPICA_DIR/.built" ]]; then
         pushd "$EDK2_BUILD_DIR"
         # Build
-        make -C acpica -j `nproc`
+        make -C acpica -j $(nproc)
         source edk2/edksetup.sh
-        make -C edk2/BaseTools -j `nproc`
+        make -C edk2/BaseTools -j $(nproc)
         build -a AARCH64 -t GCC5 -p ArmVirtPkg/ArmVirtCloudHv.dsc -b RELEASE -n 0
         cp Build/ArmVirtCloudHv-AARCH64/RELEASE_GCC5/FV/CLOUDHV_EFI.fd "$WORKLOADS_DIR"
         touch "$EDK2_DIR"/.built
@@ -44,4 +44,3 @@ build_edk2() {
         popd
     fi
 }
-

--- a/scripts/create-cloud-init.sh
+++ b/scripts/create-cloud-init.sh
@@ -6,4 +6,3 @@ mkdosfs -n CIDATA -C /tmp/ubuntu-cloudinit.img 8192
 mcopy -oi /tmp/ubuntu-cloudinit.img -s test_data/cloud-init/ubuntu/local/user-data ::
 mcopy -oi /tmp/ubuntu-cloudinit.img -s test_data/cloud-init/ubuntu/local/meta-data ::
 mcopy -oi /tmp/ubuntu-cloudinit.img -s test_data/cloud-init/ubuntu/local/network-config ::
-

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -233,10 +233,10 @@ cmd_build() {
         "--debug") { build="debug"; } ;;
         "--release") { build="release"; } ;;
         "--runtime")
-	    shift
-	    DOCKER_RUNTIME="$1"
-	    export DOCKER_RUNTIME
-	    ;;
+            shift
+            DOCKER_RUNTIME="$1"
+            export DOCKER_RUNTIME
+            ;;
         "--libc")
             shift
             [[ "$1" =~ ^(musl|gnu)$ ]] ||
@@ -382,7 +382,7 @@ cmd_tests() {
         exported_device="/dev/mshv"
     fi
 
-    if [ ! -e "${exported_device}" ] ; then
+    if [ ! -e "${exported_device}" ]; then
         die "${exported_device} does not exist on the system"
     fi
 

--- a/scripts/prepare_vdpa.sh
+++ b/scripts/prepare_vdpa.sh
@@ -4,17 +4,17 @@ set -x
 sudo apt install -y libncurses-dev gawk flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev libiberty-dev autoconf git make dpkg-dev libmnl-dev pkg-config iproute2
 sudo sed -i -- 's/# deb-src/deb-src/g' /etc/apt/sources.list
 sudo apt update
-apt-get source linux-image-unsigned-$(uname -r)
-pushd linux-azure*/drivers/vdpa/vdpa_sim/
+apt-get source linux-image-unsigned-"$(uname -r)"
+pushd linux-azure*/drivers/vdpa/vdpa_sim/ || exit
 cat <<'EOF' >Makefile
 # SPDX-License-Identifier: GPL-2.0
 obj-m += vdpa_sim.o
 obj-m += vdpa_sim_net.o
 obj-m += vdpa_sim_blk.o
 EOF
-make -C /lib/modules/$(uname -r)/build M=$PWD
-sudo make -C /lib/modules/$(uname -r)/build M=$PWD modules_install
-popd
+make -C /lib/modules/"$(uname -r)"/build M="$PWD"
+sudo make -C /lib/modules/"$(uname -r)"/build M="$PWD" modules_install
+popd || exit
 sudo depmod -a
 sudo modprobe vdpa
 sudo modprobe vhost_vdpa

--- a/scripts/prepare_vdpa.sh
+++ b/scripts/prepare_vdpa.sh
@@ -4,16 +4,16 @@ set -x
 sudo apt install -y libncurses-dev gawk flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev libiberty-dev autoconf git make dpkg-dev libmnl-dev pkg-config iproute2
 sudo sed -i -- 's/# deb-src/deb-src/g' /etc/apt/sources.list
 sudo apt update
-apt-get source linux-image-unsigned-`uname -r`
+apt-get source linux-image-unsigned-$(uname -r)
 pushd linux-azure*/drivers/vdpa/vdpa_sim/
-cat <<'EOF' > Makefile
+cat <<'EOF' >Makefile
 # SPDX-License-Identifier: GPL-2.0
 obj-m += vdpa_sim.o
 obj-m += vdpa_sim_net.o
 obj-m += vdpa_sim_blk.o
 EOF
-make -C /lib/modules/`uname -r`/build M=$PWD
-sudo make -C /lib/modules/`uname -r`/build M=$PWD modules_install
+make -C /lib/modules/$(uname -r)/build M=$PWD
+sudo make -C /lib/modules/$(uname -r)/build M=$PWD modules_install
 popd
 sudo depmod -a
 sudo modprobe vdpa

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -21,7 +21,7 @@ build_spdk_nvme() {
         ./scripts/pkgdep.sh
         ./configure --with-vfio-user
         chmod +x /usr/local/lib/python3.10/dist-packages/ninja/data/bin/ninja
-        make -j `nproc` || exit 1
+        make -j $(nproc) || exit 1
         touch .built
         popd
     fi
@@ -137,7 +137,7 @@ update_workloads() {
         pushd $WORKLOADS_DIR
         mkdir alpine-minirootfs
         tar xf "$ALPINE_MINIROOTFS_TARBALL" -C alpine-minirootfs
-        cat > alpine-minirootfs/init <<-EOF
+        cat >alpine-minirootfs/init <<-EOF
 			#! /bin/sh
 			mount -t devtmpfs dev /dev
 			echo \$TEST_STRING > /dev/console
@@ -146,7 +146,7 @@ update_workloads() {
         chmod +x alpine-minirootfs/init
         cd alpine-minirootfs
         find . -print0 |
-            cpio --null --create --verbose --owner root:root --format=newc > "$ALPINE_INITRAMFS_IMAGE"
+            cpio --null --create --verbose --owner root:root --format=newc >"$ALPINE_INITRAMFS_IMAGE"
         popd
     fi
 
@@ -167,10 +167,9 @@ update_workloads() {
     WGET_RETRY_MAX=10
     wget_retry=0
 
-    until [ "$wget_retry" -ge "$WGET_RETRY_MAX" ]
-    do
+    until [ "$wget_retry" -ge "$WGET_RETRY_MAX" ]; do
         time wget $CH_RELEASE_URL -O "$CH_RELEASE_NAME" && break
-        wget_retry=$((wget_retry+1))
+        wget_retry=$((wget_retry + 1))
     done
 
     if [ $wget_retry -ge "$WGET_RETRY_MAX" ]; then
@@ -213,8 +212,8 @@ update_workloads() {
     SHARED_DIR="$WORKLOADS_DIR/shared_dir"
     if [ ! -d "$SHARED_DIR" ]; then
         mkdir -p $SHARED_DIR
-        echo "foo" > "$SHARED_DIR/file1"
-        echo "bar" > "$SHARED_DIR/file3" || exit 1
+        echo "foo" >"$SHARED_DIR/file1"
+        echo "bar" >"$SHARED_DIR/file3" || exit 1
     fi
 
     # Checkout and build SPDK NVMe
@@ -231,7 +230,6 @@ if [[ "$hypervisor" = "mshv" ]]; then
     echo "AArch64 is not supported in Microsoft Hypervisor"
     exit 1
 fi
-
 
 # lock the workloads folder to avoid parallel updating by different containers
 (
@@ -258,8 +256,8 @@ sudo bash -c "echo 10 > /sys/kernel/mm/ksm/sleep_millisecs"
 sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 
 # Both test_vfio and ovs-dpdk rely on hugepages
-HUGEPAGESIZE=`grep Hugepagesize /proc/meminfo | awk '{print $2}'`
-PAGE_NUM=`echo $((12288 * 1024 / $HUGEPAGESIZE))`
+HUGEPAGESIZE=$(grep Hugepagesize /proc/meminfo | awk '{print $2}')
+PAGE_NUM=$(echo $((12288 * 1024 / $HUGEPAGESIZE)))
 echo $PAGE_NUM | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2048,SC2086
 set -x
 
-source $HOME/.cargo/env
-source $(dirname "$0")/test-util.sh
+# shellcheck source=/dev/null
+source "$HOME"/.cargo/env
+source "$(dirname "$0")"/test-util.sh
 
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
@@ -16,41 +18,40 @@ if [ "$hypervisor" = "mshv" ]; then
     test_features="--features mshv"
 fi
 
-cp scripts/sha1sums-x86_64 $WORKLOADS_DIR
+cp scripts/sha1sums-x86_64 "$WORKLOADS_DIR"
 
 FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
 FOCAL_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$FOCAL_OS_IMAGE_NAME"
 FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
+    pushd "$WORKLOADS_DIR" || exit
     time wget --quiet $FOCAL_OS_IMAGE_URL || exit 1
-    popd
+    popd || exit
 fi
 
 FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.raw"
 FOCAL_OS_RAW_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_RAW_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_RAW_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
+    pushd "$WORKLOADS_DIR" || exit
     time qemu-img convert -p -f qcow2 -O raw $FOCAL_OS_IMAGE_NAME $FOCAL_OS_RAW_IMAGE_NAME || exit 1
-    popd
+    popd || exit
 fi
 
-pushd $WORKLOADS_DIR
-grep focal sha1sums-x86_64 | sha1sum --check
-if [ $? -ne 0 ]; then
+pushd "$WORKLOADS_DIR" || exit
+if ! grep focal sha1sums-x86_64 | sha1sum --check; then
     echo "sha1sum validation of images failed, remove invalid images to fix the issue."
     exit 1
 fi
-popd
+popd || exit
 
 # Download Cloud Hypervisor binary from its last stable release
 LAST_RELEASE_VERSION="v36.0"
 CH_RELEASE_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$LAST_RELEASE_VERSION/cloud-hypervisor-static"
 CH_RELEASE_NAME="cloud-hypervisor-static"
-pushd $WORKLOADS_DIR
+pushd "$WORKLOADS_DIR" || exit
 time wget --quiet $CH_RELEASE_URL -O "$CH_RELEASE_NAME" || exit 1
 chmod +x $CH_RELEASE_NAME
-popd
+popd || exit
 
 # Build custom kernel based on virtio-pmem and virtio-fs upstream patches
 VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
@@ -60,15 +61,16 @@ fi
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
+    # shellcheck disable=SC2034
     CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
 fi
 
-cargo build --features mshv --all --release --target $BUILD_TARGET
+cargo build --features mshv --all --release --target "$BUILD_TARGET"
 
 # Test ovs-dpdk relies on hugepages
 HUGEPAGESIZE=$(grep Hugepagesize /proc/meminfo | awk '{print $2}')
-PAGE_NUM=$(echo $((12288 * 1024 / $HUGEPAGESIZE)))
-echo $PAGE_NUM | sudo tee /proc/sys/vm/nr_hugepages
+PAGE_NUM=$((12288 * 1024 / HUGEPAGESIZE))
+echo "$PAGE_NUM" | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 export RUST_BACKTRACE=1

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -12,7 +12,7 @@ process_common_args "$@"
 # For now these values are default for kvm
 test_features=""
 
-if [ "$hypervisor" = "mshv" ] ;  then
+if [ "$hypervisor" = "mshv" ]; then
     test_features="--features mshv"
 fi
 
@@ -66,8 +66,8 @@ fi
 cargo build --features mshv --all --release --target $BUILD_TARGET
 
 # Test ovs-dpdk relies on hugepages
-HUGEPAGESIZE=`grep Hugepagesize /proc/meminfo | awk '{print $2}'`
-PAGE_NUM=`echo $((12288 * 1024 / $HUGEPAGESIZE))`
+HUGEPAGESIZE=$(grep Hugepagesize /proc/meminfo | awk '{print $2}')
+PAGE_NUM=$(echo $((12288 * 1024 / $HUGEPAGESIZE)))
 echo $PAGE_NUM | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2048,SC2086
 set -x
 
-source $HOME/.cargo/env
-source $(dirname "$0")/test-util.sh
+# shellcheck source=/dev/null
+source "$HOME"/.cargo/env
+source "$(dirname "$0")"/test-util.sh
 
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
@@ -16,41 +18,41 @@ if [ "$hypervisor" = "mshv" ]; then
     test_features="--features mshv"
 fi
 
-cp scripts/sha1sums-x86_64 $WORKLOADS_DIR
+cp scripts/sha1sums-x86_64 "$WORKLOADS_DIR"
 
 FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
 FOCAL_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$FOCAL_OS_IMAGE_NAME"
 FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
+    pushd "$WORKLOADS_DIR" || exit
     time wget --quiet $FOCAL_OS_IMAGE_URL || exit 1
-    popd
+    popd || exit
 fi
 
 FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.raw"
 FOCAL_OS_RAW_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_RAW_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_RAW_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
+    pushd "$WORKLOADS_DIR" || exit
     time qemu-img convert -p -f qcow2 -O raw $FOCAL_OS_IMAGE_NAME $FOCAL_OS_RAW_IMAGE_NAME || exit 1
-    popd
+    popd || exit
 fi
 
-pushd $WORKLOADS_DIR
-grep focal sha1sums-x86_64 | sha1sum --check
-if [ $? -ne 0 ]; then
+pushd "$WORKLOADS_DIR" || exit
+if ! grep focal sha1sums-x86_64 | sha1sum --check; then
     echo "sha1sum validation of images failed, remove invalid images to fix the issue."
     exit 1
 fi
-popd
+popd || exit
 
 build_custom_linux
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
+    # shellcheck disable=SC2034
     CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
 fi
 
-cargo build --features mshv --all --release --target $BUILD_TARGET
+cargo build --features mshv --all --release --target "$BUILD_TARGET"
 
 export RUST_BACKTRACE=1
 time cargo test $test_features "rate_limiter::$test_filter" -- --test-threads=1 ${test_binary_args[*]}

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -12,7 +12,7 @@ process_common_args "$@"
 # For now these values are default for kvm
 test_features=""
 
-if [ "$hypervisor" = "mshv" ] ;  then
+if [ "$hypervisor" = "mshv" ]; then
     test_features="--features mshv"
 fi
 

--- a/scripts/run_integration_tests_sgx.sh
+++ b/scripts/run_integration_tests_sgx.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2048,SC2086
 set -x
 
-source $HOME/.cargo/env
-source $(dirname "$0")/test-util.sh
+# shellcheck source=/dev/null
+source "$HOME"/.cargo/env
+source "$(dirname "$0")"/test-util.sh
 
 process_common_args "$@"
 
@@ -20,25 +22,26 @@ JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20230119-0.qcow2"
 JAMMY_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$JAMMY_OS_IMAGE_NAME"
 JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"
 if [ ! -f "$JAMMY_OS_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
+    pushd "$WORKLOADS_DIR" || exit
     time wget --quiet $JAMMY_OS_IMAGE_URL || exit 1
-    popd
+    popd || exit
 fi
 
 JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20230119-0.raw"
 JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
 if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
+    pushd "$WORKLOADS_DIR" || exit
     time qemu-img convert -p -f qcow2 -O raw $JAMMY_OS_IMAGE_NAME $JAMMY_OS_RAW_IMAGE_NAME || exit 1
-    popd
+    popd || exit
 fi
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
+    # shellcheck disable=SC2034
     CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
 fi
 
-cargo build --features mshv --all --release --target $BUILD_TARGET
+cargo build --features mshv --all --release --target "$BUILD_TARGET"
 
 export RUST_BACKTRACE=1
 

--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2048,SC2086
 set -x
 
 # This set of vfio tests require to be ran on a specific machine with
@@ -7,8 +8,9 @@ set -x
 # out of the scope of this script, including the custom guest image with
 # Nvidia drivers installed, and properly configured Nvidia Tesla T4 card.
 
-source $HOME/.cargo/env
-source $(dirname "$0")/test-util.sh
+# shellcheck source=/dev/null
+source "$HOME"/.cargo/env
+source "$(dirname "$0")"/test-util.sh
 
 process_common_args "$@"
 
@@ -18,10 +20,11 @@ download_hypervisor_fw
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
+    # shellcheck disable=SC2034
     CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
 fi
 
-cargo build --features mshv --all --release --target $BUILD_TARGET
+cargo build --features mshv --all --release --target "$BUILD_TARGET"
 
 export RUST_BACKTRACE=1
 time cargo test "vfio::test_nvidia" -- --test-threads=1 ${test_binary_args[*]}

--- a/scripts/run_integration_tests_windows_aarch64.sh
+++ b/scripts/run_integration_tests_windows_aarch64.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2048,SC2086
 set -x
 
-source $HOME/.cargo/env
-source $(dirname "$0")/test-util.sh
-source $(dirname "$0")/common-aarch64.sh
+# shellcheck source=/dev/null
+source "$HOME"/.cargo/env
+source "$(dirname "$0")"/test-util.sh
+source "$(dirname "$0")"/common-aarch64.sh
 
 process_common_args "$@"
 
@@ -27,8 +29,8 @@ if [[ ! -f ${WIN_IMAGE_FILE} || ! -f ${OVMF_FW} ]]; then
 fi
 
 # Use device mapper to create a snapshot of the Windows image
-img_blk_size=$(du -b -B 512 ${WIN_IMAGE_FILE} | awk '{print $1;}')
-loop_device=$(losetup --find --show --read-only ${WIN_IMAGE_FILE})
+img_blk_size=$(du -b -B 512 "${WIN_IMAGE_FILE}" | awk '{print $1;}')
+loop_device=$(losetup --find --show --read-only "${WIN_IMAGE_FILE}")
 dmsetup create windows-base --table "0 $img_blk_size linear $loop_device 0"
 dmsetup mknodes
 dmsetup create windows-snapshot-base --table "0 $img_blk_size snapshot-origin /dev/mapper/windows-base"
@@ -36,11 +38,11 @@ dmsetup mknodes
 
 export RUST_BACKTRACE=1
 
-cargo build --all --release --target $BUILD_TARGET
+cargo build --all --release --target "$BUILD_TARGET"
 
 # Only run with 1 thread to avoid tests interfering with one another because
 # Windows has a static IP configured
-time cargo test "windows::$test_filter" --target $BUILD_TARGET -- ${test_binary_args[*]}
+time cargo test "windows::$test_filter" --target "$BUILD_TARGET" -- ${test_binary_args[*]}
 RES=$?
 
 dmsetup remove_all -f

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2048,SC2086
 set -x
 
-source $HOME/.cargo/env
-source $(dirname "$0")/test-util.sh
+# shellcheck source=/dev/null
+source "$HOME"/.cargo/env
+source "$(dirname "$0")"/test-util.sh
 
 process_common_args "$@"
 # For now these values are default for kvm
@@ -19,6 +21,7 @@ download_ovmf
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then
+    # shellcheck disable=SC2034
     CFLAGS="-I /usr/include/x86_64-linux-musl/ -idirafter /usr/include/"
 fi
 
@@ -36,7 +39,7 @@ dmsetup mknodes
 dmsetup create windows-snapshot-base --table "0 $img_blk_size snapshot-origin /dev/mapper/windows-base"
 dmsetup mknodes
 
-cargo build --features mshv --all --release --target $BUILD_TARGET
+cargo build --features mshv --all --release --target "$BUILD_TARGET"
 
 export RUST_BACKTRACE=1
 

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -8,7 +8,7 @@ process_common_args "$@"
 # For now these values are default for kvm
 test_features=""
 
-if [ "$hypervisor" = "mshv" ] ;  then
+if [ "$hypervisor" = "mshv" ]; then
     test_features="--features mshv"
 fi
 WIN_IMAGE_FILE="/root/workloads/windows-server-2022-amd64-2.raw"

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -12,7 +12,7 @@ process_common_args "$@"
 # For now these values are default for kvm
 test_features=""
 
-if [ "$hypervisor" = "mshv" ] ;  then
+if [ "$hypervisor" = "mshv" ]; then
     test_features="--features mshv"
 fi
 
@@ -77,7 +77,7 @@ if [ ! -f "$ALPINE_INITRAMFS_IMAGE" ]; then
     pushd $WORKLOADS_DIR
     mkdir alpine-minirootfs
     tar xf "$ALPINE_MINIROOTFS_TARBALL" -C alpine-minirootfs
-    cat > alpine-minirootfs/init <<-EOF
+    cat >alpine-minirootfs/init <<-EOF
 		#! /bin/sh
 		mount -t devtmpfs dev /dev
 		echo \$TEST_STRING > /dev/console
@@ -86,7 +86,7 @@ if [ ! -f "$ALPINE_INITRAMFS_IMAGE" ]; then
     chmod +x alpine-minirootfs/init
     cd alpine-minirootfs
     find . -print0 |
-        cpio --null --create --verbose --owner root:root --format=newc > "$ALPINE_INITRAMFS_IMAGE"
+        cpio --null --create --verbose --owner root:root --format=newc >"$ALPINE_INITRAMFS_IMAGE"
     popd
 fi
 
@@ -118,26 +118,25 @@ if [ ! -f "$VIRTIOFSD" ]; then
     popd
 fi
 
-
 BLK_IMAGE="$WORKLOADS_DIR/blk.img"
 MNT_DIR="mount_image"
 if [ ! -f "$BLK_IMAGE" ]; then
-   pushd $WORKLOADS_DIR
-   fallocate -l 16M $BLK_IMAGE
-   mkfs.ext4 -j $BLK_IMAGE
-   mkdir $MNT_DIR
-   sudo mount -t ext4 $BLK_IMAGE $MNT_DIR
-   sudo bash -c "echo bar > $MNT_DIR/foo" || exit 1
-   sudo umount $BLK_IMAGE
-   rm -r $MNT_DIR
-   popd
+    pushd $WORKLOADS_DIR
+    fallocate -l 16M $BLK_IMAGE
+    mkfs.ext4 -j $BLK_IMAGE
+    mkdir $MNT_DIR
+    sudo mount -t ext4 $BLK_IMAGE $MNT_DIR
+    sudo bash -c "echo bar > $MNT_DIR/foo" || exit 1
+    sudo umount $BLK_IMAGE
+    rm -r $MNT_DIR
+    popd
 fi
 
 SHARED_DIR="$WORKLOADS_DIR/shared_dir"
 if [ ! -d "$SHARED_DIR" ]; then
     mkdir -p $SHARED_DIR
-    echo "foo" > "$SHARED_DIR/file1"
-    echo "bar" > "$SHARED_DIR/file3" || exit 1
+    echo "foo" >"$SHARED_DIR/file1"
+    echo "bar" >"$SHARED_DIR/file3" || exit 1
 fi
 
 VFIO_DIR="$WORKLOADS_DIR/vfio"
@@ -148,7 +147,7 @@ cp $FOCAL_OS_RAW_IMAGE $VFIO_DIR
 cp $FW $VFIO_DIR
 cp $VMLINUX_IMAGE $VFIO_DIR || exit 1
 
-cargo build --features mshv --all  --release --target $BUILD_TARGET
+cargo build --features mshv --all --release --target $BUILD_TARGET
 
 # We always copy a fresh version of our binary for our L2 guest.
 cp target/$BUILD_TARGET/release/cloud-hypervisor $VFIO_DIR
@@ -161,8 +160,8 @@ sudo bash -c "echo 10 > /sys/kernel/mm/ksm/sleep_millisecs"
 sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 
 # Both test_vfio, ovs-dpdk and vDPA tests rely on hugepages
-HUGEPAGESIZE=`grep Hugepagesize /proc/meminfo | awk '{print $2}'`
-PAGE_NUM=`echo $((12288 * 1024 / $HUGEPAGESIZE))`
+HUGEPAGESIZE=$(grep Hugepagesize /proc/meminfo | awk '{print $2}')
+PAGE_NUM=$(echo $((12288 * 1024 / $HUGEPAGESIZE)))
 echo $PAGE_NUM | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
@@ -186,7 +185,7 @@ fi
 
 # Run tests on dbus_api
 if [ $RES -eq 0 ]; then
-    cargo build --features "mshv,dbus_api" --all  --release --target $BUILD_TARGET
+    cargo build --features "mshv,dbus_api" --all --release --target $BUILD_TARGET
     export RUST_BACKTRACE=1
     # integration tests now do not reply on build feature "dbus_api"
     time cargo test $test_features "dbus_api::$test_filter" -- ${test_binary_args[*]}

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2048,SC2086
 set -x
 
-source $HOME/.cargo/env
-source $(dirname "$0")/test-util.sh
+# shellcheck source=/dev/null
+source "$HOME"/.cargo/env
+source "$(dirname "$0")"/test-util.sh
 
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
@@ -16,7 +18,7 @@ if [ "$hypervisor" = "mshv" ]; then
     test_features="--features mshv"
 fi
 
-cp scripts/sha1sums-x86_64 $WORKLOADS_DIR
+cp scripts/sha1sums-x86_64 "$WORKLOADS_DIR"
 
 download_hypervisor_fw
 
@@ -26,55 +28,55 @@ FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
 FOCAL_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$FOCAL_OS_IMAGE_NAME"
 FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
+    pushd "$WORKLOADS_DIR" || exit
     time wget --quiet $FOCAL_OS_IMAGE_URL || exit 1
-    popd
+    popd || exit
 fi
 
 FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.raw"
 FOCAL_OS_RAW_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_RAW_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_RAW_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
+    pushd "$WORKLOADS_DIR" || exit
     time qemu-img convert -p -f qcow2 -O raw $FOCAL_OS_IMAGE_NAME $FOCAL_OS_RAW_IMAGE_NAME || exit 1
-    popd
+    popd || exit
 fi
 
 FOCAL_OS_QCOW_BACKING_FILE_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0-backing.qcow2"
 FOCAL_OS_QCOW_BACKING_FILE_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_QCOW_BACKING_FILE_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_QCOW_BACKING_FILE_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
-    time qemu-img create -f qcow2 -b $FOCAL_OS_IMAGE -F qcow2 $FOCAL_OS_QCOW_BACKING_FILE_IMAGE_NAME
-    popd
+    pushd "$WORKLOADS_DIR" || exit
+    time qemu-img create -f qcow2 -b "$FOCAL_OS_IMAGE" -F qcow2 $FOCAL_OS_QCOW_BACKING_FILE_IMAGE_NAME
+    popd || exit
 fi
 
 JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20230119-0.qcow2"
 JAMMY_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$JAMMY_OS_IMAGE_NAME"
 JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"
 if [ ! -f "$JAMMY_OS_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
+    pushd "$WORKLOADS_DIR" || exit
     time wget --quiet $JAMMY_OS_IMAGE_URL || exit 1
-    popd
+    popd || exit
 fi
 
 JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20230119-0.raw"
 JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
 if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
+    pushd "$WORKLOADS_DIR" || exit
     time qemu-img convert -p -f qcow2 -O raw $JAMMY_OS_IMAGE_NAME $JAMMY_OS_RAW_IMAGE_NAME || exit 1
-    popd
+    popd || exit
 fi
 
 ALPINE_MINIROOTFS_URL="http://dl-cdn.alpinelinux.org/alpine/v3.11/releases/x86_64/alpine-minirootfs-3.11.3-x86_64.tar.gz"
 ALPINE_MINIROOTFS_TARBALL="$WORKLOADS_DIR/alpine-minirootfs-x86_64.tar.gz"
 if [ ! -f "$ALPINE_MINIROOTFS_TARBALL" ]; then
-    pushd $WORKLOADS_DIR
-    time wget --quiet $ALPINE_MINIROOTFS_URL -O $ALPINE_MINIROOTFS_TARBALL || exit 1
-    popd
+    pushd "$WORKLOADS_DIR" || exit
+    time wget --quiet $ALPINE_MINIROOTFS_URL -O "$ALPINE_MINIROOTFS_TARBALL" || exit 1
+    popd || exit
 fi
 
 ALPINE_INITRAMFS_IMAGE="$WORKLOADS_DIR/alpine_initramfs.img"
 if [ ! -f "$ALPINE_INITRAMFS_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
+    pushd "$WORKLOADS_DIR" || exit
     mkdir alpine-minirootfs
     tar xf "$ALPINE_MINIROOTFS_TARBALL" -C alpine-minirootfs
     cat >alpine-minirootfs/init <<-EOF
@@ -84,19 +86,18 @@ if [ ! -f "$ALPINE_INITRAMFS_IMAGE" ]; then
 		poweroff -f
 	EOF
     chmod +x alpine-minirootfs/init
-    cd alpine-minirootfs
+    cd alpine-minirootfs || exit
     find . -print0 |
         cpio --null --create --verbose --owner root:root --format=newc >"$ALPINE_INITRAMFS_IMAGE"
-    popd
+    popd || exit
 fi
 
-pushd $WORKLOADS_DIR
-sha1sum sha1sums-x86_64 --check
-if [ $? -ne 0 ]; then
+pushd "$WORKLOADS_DIR" || exit
+if ! sha1sum sha1sums-x86_64 --check; then
     echo "sha1sum validation of images failed, remove invalid images to fix the issue."
     exit 1
 fi
-popd
+popd || exit
 
 # Build custom kernel based on virtio-pmem and virtio-fs upstream patches
 VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
@@ -107,51 +108,51 @@ fi
 VIRTIOFSD="$WORKLOADS_DIR/virtiofsd"
 VIRTIOFSD_DIR="virtiofsd_build"
 if [ ! -f "$VIRTIOFSD" ]; then
-    pushd $WORKLOADS_DIR
+    pushd "$WORKLOADS_DIR" || exit
     git clone "https://gitlab.com/virtio-fs/virtiofsd.git" $VIRTIOFSD_DIR
-    pushd $VIRTIOFSD_DIR
+    pushd $VIRTIOFSD_DIR || exit
     git checkout v1.8.0
     time cargo build --release
-    cp target/release/virtiofsd $VIRTIOFSD || exit 1
-    popd
+    cp target/release/virtiofsd "$VIRTIOFSD" || exit 1
+    popd || exit
     rm -rf $VIRTIOFSD_DIR
-    popd
+    popd || exit
 fi
 
 BLK_IMAGE="$WORKLOADS_DIR/blk.img"
 MNT_DIR="mount_image"
 if [ ! -f "$BLK_IMAGE" ]; then
-    pushd $WORKLOADS_DIR
-    fallocate -l 16M $BLK_IMAGE
-    mkfs.ext4 -j $BLK_IMAGE
+    pushd "$WORKLOADS_DIR" || exit
+    fallocate -l 16M "$BLK_IMAGE"
+    mkfs.ext4 -j "$BLK_IMAGE"
     mkdir $MNT_DIR
-    sudo mount -t ext4 $BLK_IMAGE $MNT_DIR
+    sudo mount -t ext4 "$BLK_IMAGE" $MNT_DIR
     sudo bash -c "echo bar > $MNT_DIR/foo" || exit 1
-    sudo umount $BLK_IMAGE
+    sudo umount "$BLK_IMAGE"
     rm -r $MNT_DIR
-    popd
+    popd || exit
 fi
 
 SHARED_DIR="$WORKLOADS_DIR/shared_dir"
 if [ ! -d "$SHARED_DIR" ]; then
-    mkdir -p $SHARED_DIR
+    mkdir -p "$SHARED_DIR"
     echo "foo" >"$SHARED_DIR/file1"
     echo "bar" >"$SHARED_DIR/file3" || exit 1
 fi
 
 VFIO_DIR="$WORKLOADS_DIR/vfio"
 VFIO_DISK_IMAGE="$WORKLOADS_DIR/vfio.img"
-rm -rf $VFIO_DIR $VFIO_DISK_IMAGE
-mkdir -p $VFIO_DIR
-cp $FOCAL_OS_RAW_IMAGE $VFIO_DIR
-cp $FW $VFIO_DIR
-cp $VMLINUX_IMAGE $VFIO_DIR || exit 1
+rm -rf "$VFIO_DIR" "$VFIO_DISK_IMAGE"
+mkdir -p "$VFIO_DIR"
+cp "$FOCAL_OS_RAW_IMAGE" "$VFIO_DIR"
+cp "$FW" "$VFIO_DIR"
+cp "$VMLINUX_IMAGE" "$VFIO_DIR" || exit 1
 
-cargo build --features mshv --all --release --target $BUILD_TARGET
+cargo build --features mshv --all --release --target "$BUILD_TARGET"
 
 # We always copy a fresh version of our binary for our L2 guest.
-cp target/$BUILD_TARGET/release/cloud-hypervisor $VFIO_DIR
-cp target/$BUILD_TARGET/release/ch-remote $VFIO_DIR
+cp target/"$BUILD_TARGET"/release/cloud-hypervisor "$VFIO_DIR"
+cp target/"$BUILD_TARGET"/release/ch-remote "$VFIO_DIR"
 
 # Enable KSM with some reasonable parameters so that it won't take too long
 # for the memory to be merged between two processes.
@@ -161,8 +162,8 @@ sudo bash -c "echo 1 > /sys/kernel/mm/ksm/run"
 
 # Both test_vfio, ovs-dpdk and vDPA tests rely on hugepages
 HUGEPAGESIZE=$(grep Hugepagesize /proc/meminfo | awk '{print $2}')
-PAGE_NUM=$(echo $((12288 * 1024 / $HUGEPAGESIZE)))
-echo $PAGE_NUM | sudo tee /proc/sys/vm/nr_hugepages
+PAGE_NUM=$((12288 * 1024 / HUGEPAGESIZE))
+echo "$PAGE_NUM" | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 # Update max locked memory to 'unlimited' to avoid issues with vDPA
@@ -185,7 +186,7 @@ fi
 
 # Run tests on dbus_api
 if [ $RES -eq 0 ]; then
-    cargo build --features "mshv,dbus_api" --all --release --target $BUILD_TARGET
+    cargo build --features "mshv,dbus_api" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
     # integration tests now do not reply on build feature "dbus_api"
     time cargo test $test_features "dbus_api::$test_filter" -- ${test_binary_args[*]}

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -17,7 +17,7 @@ build_fio() {
     if [ ! -f "$FIO_DIR/.built" ]; then
         pushd $FIO_DIR
         ./configure
-        make -j `nproc`
+        make -j $(nproc)
         cp fio "$WORKLOADS_DIR/fio"
         touch .built
         popd
@@ -29,9 +29,9 @@ process_common_args "$@"
 cp scripts/sha1sums-${TEST_ARCH} $WORKLOADS_DIR
 
 if [ ${TEST_ARCH} == "aarch64" ]; then
-     FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-arm64-custom-20210929-0.qcow2"
+    FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-arm64-custom-20210929-0.qcow2"
 else
-     FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
+    FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
 fi
 
 FOCAL_OS_IMAGE_URL="https://cloud-hypervisor.azureedge.net/$FOCAL_OS_IMAGE_NAME"
@@ -90,8 +90,8 @@ fi
 cargo build --features mshv --all --release --target $BUILD_TARGET
 
 # setup hugepages
-HUGEPAGESIZE=`grep Hugepagesize /proc/meminfo | awk '{print $2}'`
-PAGE_NUM=`echo $((12288 * 1024 / $HUGEPAGESIZE))`
+HUGEPAGESIZE=$(grep Hugepagesize /proc/meminfo | awk '{print $2}')
+PAGE_NUM=$(echo $((12288 * 1024 / $HUGEPAGESIZE)))
 echo $PAGE_NUM | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
@@ -102,11 +102,11 @@ fi
 # Ensure that git commands can be run in this directory (for metrics report)
 git config --global --add safe.directory $PWD
 
-RUST_BACKTRACE_VALUE=`echo $RUST_BACKTRACE`
-if [ -z $RUST_BACKTRACE_VALUE ];then
-	export RUST_BACKTRACE=1
+RUST_BACKTRACE_VALUE=$(echo $RUST_BACKTRACE)
+if [ -z $RUST_BACKTRACE_VALUE ]; then
+    export RUST_BACKTRACE=1
 else
-	echo "RUST_BACKTRACE is set to: $RUST_BACKTRACE_VALUE"
+    echo "RUST_BACKTRACE is set to: $RUST_BACKTRACE_VALUE"
 fi
 time target/$BUILD_TARGET/release/performance-metrics ${test_binary_args[*]}
 RES=$?

--- a/scripts/run_openapi_tests.sh
+++ b/scripts/run_openapi_tests.sh
@@ -2,4 +2,4 @@
 set -e
 set -x
 
-sudo docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli validate -i /local/vmm/src/api/openapi/cloud-hypervisor.yaml
+sudo docker run --rm -v "${PWD}":/local openapitools/openapi-generator-cli validate -i /local/vmm/src/api/openapi/cloud-hypervisor.yaml

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2068
 
-source $HOME/.cargo/env
-source $(dirname "$0")/test-util.sh
+# shellcheck source=/dev/null
+source "$HOME"/.cargo/env
+source "$(dirname "$0")"/test-util.sh
 
 process_common_args "$@"
 
 cargo_args=("")
 
+# shellcheck disable=SC2154
 if [[ $hypervisor = "mshv" ]]; then
     cargo_args+=("--features $hypervisor")
 elif [[ $(uname -m) = "x86_64" ]]; then
@@ -14,5 +17,5 @@ elif [[ $(uname -m) = "x86_64" ]]; then
 fi
 
 export RUST_BACKTRACE=1
-cargo test --lib --bins --target $BUILD_TARGET --workspace ${cargo_args[@]} || exit 1
-cargo test --doc --target $BUILD_TARGET --workspace ${cargo_args[@]} || exit 1
+cargo test --lib --bins --target "$BUILD_TARGET" --workspace ${cargo_args[@]} || exit 1
+cargo test --doc --target "$BUILD_TARGET" --workspace ${cargo_args[@]} || exit 1

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -54,12 +54,12 @@ build_custom_linux() {
     cp $SRCDIR/resources/linux-config-${ARCH} $LINUX_CUSTOM_DIR/.config
 
     pushd $LINUX_CUSTOM_DIR
-    make -j `nproc`
+    make -j $(nproc)
     if [ ${ARCH} == "x86_64" ]; then
-       cp vmlinux "$WORKLOADS_DIR/" || exit 1
+        cp vmlinux "$WORKLOADS_DIR/" || exit 1
     elif [ ${ARCH} == "aarch64" ]; then
-       cp arch/arm64/boot/Image "$WORKLOADS_DIR/" || exit 1
-       cp arch/arm64/boot/Image.gz "$WORKLOADS_DIR/" || exit 1
+        cp arch/arm64/boot/Image "$WORKLOADS_DIR/" || exit 1
+        cp arch/arm64/boot/Image.gz "$WORKLOADS_DIR/" || exit 1
     fi
     popd
 }
@@ -80,28 +80,31 @@ cmd_help() {
 
 process_common_args() {
     while [ $# -gt 0 ]; do
-	case "$1" in
-            "-h"|"--help")  { cmd_help; exit 1; } ;;
-            "--hypervisor")
-                shift
-                hypervisor="$1"
-                ;;
-            "--test-filter")
-                shift
-                test_filter="$1"
-                ;;
-            "--") {
-                shift
-                break
-            } ;;
-            *)
-                echo "Unknown test scripts argument: $1. Please use '-- --help' for help."
-                exit
-                ;;
-	esac
-	shift
+        case "$1" in
+        "-h" | "--help") {
+            cmd_help
+            exit 1
+        } ;;
+        "--hypervisor")
+            shift
+            hypervisor="$1"
+            ;;
+        "--test-filter")
+            shift
+            test_filter="$1"
+            ;;
+        "--") {
+            shift
+            break
+        } ;;
+        *)
+            echo "Unknown test scripts argument: $1. Please use '-- --help' for help."
+            exit
+            ;;
+        esac
+        shift
     done
-    if [[ ! ("$hypervisor" = "kvm" ||  "$hypervisor" = "mshv") ]]; then
+    if [[ ! ("$hypervisor" = "kvm" || "$hypervisor" = "mshv") ]]; then
         die "Hypervisor value must be kvm or mshv"
     fi
 
@@ -112,8 +115,8 @@ download_hypervisor_fw() {
     if [ -n "$AUTH_DOWNLOAD_TOKEN" ]; then
         echo "Using authenticated download from GitHub"
         FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/rust-hypervisor-firmware/releases/latest \
-                 --header "Authorization: Token $AUTH_DOWNLOAD_TOKEN" \
-                 --header "X-GitHub-Api-Version: 2022-11-28" | grep "browser_download_url" | grep -o 'https://.*[^ "]')
+            --header "Authorization: Token $AUTH_DOWNLOAD_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" | grep "browser_download_url" | grep -o 'https://.*[^ "]')
     else
         echo "Using anonymous download from GitHub"
         FW_URL=$(curl --silent https://api.github.com/repos/cloud-hypervisor/rust-hypervisor-firmware/releases/latest | grep "browser_download_url" | grep -o 'https://.*[^ "]')


### PR DESCRIPTION
Implement workflow to to run static analysis and linting of all shell scripts by using shfmt and shellcheck.
Also, fix shell scripts according to shfmt and shellcheck errors.

Fixes: #5396