### PR TITLE
block: Replace use of crc32c crate with crc-any

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ name = "block"
 version = "0.1.0"
 dependencies = [
  "byteorder",
- "crc32c",
+ "crc-any",
  "io-uring",
  "libc",
  "log",
@@ -493,12 +493,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32c"
-version = "0.6.4"
+name = "crc-any"
+version = "2.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f48d60e5b4d2c53d5c2b1d8a58c849a70ae5e5509b08a48d047e3b65714a74"
+checksum = "c01a5e1f881f6fb6099a7bdf949e946719fd4f1fefa56264890574febf0eb6d0"
 dependencies = [
- "rustc_version",
+ "debug-helper",
 ]
 
 [[package]]
@@ -566,6 +566,12 @@ dependencies = [
  "quote",
  "syn 2.0.31",
 ]
+
+[[package]]
+name = "debug-helper"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
 name = "derivative"
@@ -1868,15 +1874,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,12 +1920,6 @@ checksum = "345a3e4dddf721a478089d4697b83c6c0a8f5bf16086f6c13397e4534eb6e2e5"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -10,7 +10,7 @@ io_uring = ["dep:io-uring"]
 
 [dependencies]
 byteorder = "1.4.3"
-crc32c = "0.6.4"
+crc-any = "2.4.4"
 io-uring = { version = "0.6.2", optional = true }
 libc = "0.2.147"
 log = "0.4.20"

--- a/block/src/vhdx/vhdx_header.rs
+++ b/block/src/vhdx/vhdx_header.rs
@@ -192,7 +192,9 @@ impl Header {
         };
 
         new_header.get_header_as_buffer(&mut buffer);
-        new_header.checksum = crc32c::crc32c(&buffer);
+        let mut crc = crc_any::CRC::crc32c();
+        crc.digest(&buffer);
+        new_header.checksum = crc.get_crc() as u32;
         new_header.get_header_as_buffer(&mut buffer);
 
         f.seek(SeekFrom::Start(start))
@@ -480,7 +482,10 @@ pub fn calculate_checksum(buffer: &mut [u8], csum_offset: usize) -> Result<u32> 
     // Zero the checksum in the buffer
     LittleEndian::write_u32(csum_buf, 0);
     // Calculate the checksum on the resulting buffer
-    let new_csum = crc32c::crc32c(buffer);
+    let mut crc = crc_any::CRC::crc32c();
+    crc.digest(&buffer);
+    let new_csum = crc.get_crc() as u32;
+
     // Put back the original checksum in the buffer
     LittleEndian::write_u32(&mut buffer[csum_offset..csum_offset + 4], orig_csum);
 


### PR DESCRIPTION
According to crates.io the crc-any crate is actively maintained which
avoids issues with the crc32c crate and the nightly compiler.

Fixes: #6168

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
