### PR TITLE
Partially fix beta clippy issues

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -124,11 +124,11 @@ impl SgxEpcRegion {
 #[derive(Copy, Clone, Default)]
 struct StartInfoWrapper(hvm_start_info);
 
-#[cfg_attr(fuzzing, allow(dead_code))]
+#[allow(dead_code)]
 #[derive(Copy, Clone, Default)]
 struct MemmapTableEntryWrapper(hvm_memmap_table_entry);
 
-#[cfg_attr(fuzzing, allow(dead_code))]
+#[allow(dead_code)]
 #[derive(Copy, Clone, Default)]
 struct ModlistEntryWrapper(hvm_modlist_entry);
 
@@ -144,7 +144,7 @@ unsafe impl ByteValued for ModlistEntryWrapper {}
 // *    the type that is implementing the trait is foreign or
 // *    all of the parameters being passed to the trait (if there are any) are also foreign
 // is prohibited.
-#[cfg_attr(fuzzing, allow(dead_code))]
+#[allow(dead_code)]
 #[derive(Copy, Clone, Default)]
 struct BootParamsWrapper(boot_params);
 

--- a/block/src/qcow/vec_cache.rs
+++ b/block/src/qcow/vec_cache.rs
@@ -136,7 +136,7 @@ impl<T: Cacheable> CacheMap<T> {
 mod tests {
     use super::*;
 
-    struct NumCache(pub u64);
+    struct NumCache(());
     impl Cacheable for NumCache {
         fn dirty(&self) -> bool {
             true
@@ -148,28 +148,28 @@ mod tests {
         let mut cache = CacheMap::<NumCache>::new(3);
         let mut evicted = None;
         cache
-            .insert(0, NumCache(5), |index, _| {
+            .insert(0, NumCache(()), |index, _| {
                 evicted = Some(index);
                 Ok(())
             })
             .unwrap();
         assert_eq!(evicted, None);
         cache
-            .insert(1, NumCache(6), |index, _| {
+            .insert(1, NumCache(()), |index, _| {
                 evicted = Some(index);
                 Ok(())
             })
             .unwrap();
         assert_eq!(evicted, None);
         cache
-            .insert(2, NumCache(7), |index, _| {
+            .insert(2, NumCache(()), |index, _| {
                 evicted = Some(index);
                 Ok(())
             })
             .unwrap();
         assert_eq!(evicted, None);
         cache
-            .insert(3, NumCache(8), |index, _| {
+            .insert(3, NumCache(()), |index, _| {
                 evicted = Some(index);
                 Ok(())
             })

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -137,7 +137,7 @@ name = "block"
 version = "0.1.0"
 dependencies = [
  "byteorder",
- "crc32c",
+ "crc-any",
  "io-uring",
  "libc",
  "log",
@@ -265,12 +265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "crc32c"
-version = "0.6.4"
+name = "crc-any"
+version = "2.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f48d60e5b4d2c53d5c2b1d8a58c849a70ae5e5509b08a48d047e3b65714a74"
+checksum = "c01a5e1f881f6fb6099a7bdf949e946719fd4f1fefa56264890574febf0eb6d0"
 dependencies = [
- "rustc_version",
+ "debug-helper",
 ]
 
 [[package]]
@@ -313,6 +313,12 @@ dependencies = [
  "quote",
  "syn 2.0.47",
 ]
+
+[[package]]
+name = "debug-helper"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
 name = "devices"
@@ -672,15 +678,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,12 +697,6 @@ checksum = "345a3e4dddf721a478089d4697b83c6c0a8f5bf16086f6c13397e4534eb6e2e5"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -19,6 +19,7 @@ pub const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-custom-20210609-
 #[cfg(target_arch = "aarch64")]
 pub const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-arm64-custom-20210929-0-update-tool.raw";
 
+#[allow(dead_code)]
 #[derive(Debug)]
 enum Error {
     BootTimeParse,

--- a/src/main.rs
+++ b/src/main.rs
@@ -622,6 +622,7 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
                     std::fs::OpenOptions::new()
                         .write(true)
                         .create(true)
+                        .truncate(true)
                         .open(parser.get("path").unwrap())
                         .map_err(Error::EventMonitorIo)?,
                 ))

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2119,7 +2119,7 @@ fn pty_read(mut pty: std::fs::File) -> Receiver<String> {
         thread::sleep(std::time::Duration::new(1, 0));
         let mut buf = [0; 512];
         match pty.read(&mut buf) {
-            Ok(_) => {
+            Ok(_bytes) => {
                 let output = std::str::from_utf8(&buf).unwrap().to_string();
                 match tx.send(output) {
                     Ok(_) => (),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5842,7 +5842,7 @@ mod common_parallel {
         #[cfg(target_arch = "x86_64")]
         let mut kernels = vec![direct_kernel_boot_path()];
         #[cfg(target_arch = "aarch64")]
-        let kernels = vec![direct_kernel_boot_path()];
+        let kernels = [direct_kernel_boot_path()];
 
         #[cfg(target_arch = "x86_64")]
         {

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -58,6 +58,7 @@ impl<D: Read + Seek + Write + Send> DiskFile for D {}
 type Result<T> = std::result::Result<T, Error>;
 type VhostUserBackendResult<T> = std::result::Result<T, std::io::Error>;
 
+#[allow(dead_code)]
 #[derive(Debug)]
 enum Error {
     /// Failed to create kill eventfd

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1231,7 +1231,7 @@ impl DeviceManager {
     }
 
     pub fn console_resize_pipe(&self) -> Option<Arc<File>> {
-        self.console_resize_pipe.as_ref().map(Arc::clone)
+        self.console_resize_pipe.clone()
     }
 
     pub fn create_devices(

--- a/vmm/src/sigwinch_listener.rs
+++ b/vmm/src/sigwinch_listener.rs
@@ -24,7 +24,7 @@ use vmm_sys_util::signal::register_signal_handler;
 thread_local! {
     // The tty file descriptor is stored in a global variable so it
     // can be accessed by a signal handler.
-    static TX: RefCell<Option<File>> = RefCell::new(None);
+    static TX: RefCell<Option<File>> = const { RefCell::new(None) };
 }
 
 fn with_tx<R, F: FnOnce(&File) -> R>(f: F) -> R {


### PR DESCRIPTION
Fix some of the new clippy issues from the latest update:

- vmm: Directly clone console resize pipe
- vmm: Make thread local initialiser constant
- tests: Remove unnecessary use of vec![] macro
- arch: x86_64: Disable dead code detection for embedded struct
- block: qcow: Fix beta clippy issue
- performance-metrics: Allow dead_code for embedded error
- vhost_user_block: Allow dead_code for embedded error
