### PR TITLE
block: vhdx: Remove unused 'struct RegionEntry'

### DIFF
--- a/block/src/vhdx/vhdx_header.rs
+++ b/block/src/vhdx/vhdx_header.rs
@@ -353,12 +353,6 @@ impl RegionTableEntry {
     }
 }
 
-#[derive(Clone, Debug)]
-struct RegionEntry {
-    _start: u64,
-    _end: u64,
-}
-
 enum HeaderNo {
     First,
     Second,


### PR DESCRIPTION
This also fixes the following clippy warning on nightly build from cargo fuzz:

warning: struct `RegionEntry` is never constructed
   --> /home/chenb/project/cloud-hypervisor/cloud-hypervisor/block/src/vhdx/vhdx_header.rs:357:8
    |
357 | struct RegionEntry {
    |        ^^^^^^^^^^^
    |
    = note: `RegionEntry` has derived impls for the traits `Debug` and `Clone`, but these are intentionally ignored during dead code analysis
    = note: `#[warn(dead_code)]` on by default