### PR TITLE
vmm: pass host data to SevSnp guest

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -468,6 +468,14 @@ fn create_app(default_vcpus: String, default_memory: String, default_rng: String
             .num_args(1)
             .group("vm-config"),
     );
+    #[cfg(feature = "sev_snp")]
+    let app = app.arg(
+        Arg::new("host-data")
+            .long("host-data")
+            .help("Host specific data to SEV SNP guest")
+            .num_args(1)
+            .group("vm-config"),
+    );
     app.arg(
         Arg::new("version")
             .short('V')
@@ -879,6 +887,8 @@ mod unit_tests {
                 initramfs: None,
                 #[cfg(feature = "igvm")]
                 igvm: None,
+                #[cfg(feature = "sev_snp")]
+                host_data: None,
             }),
             rate_limit_groups: None,
             disks: None,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -435,6 +435,8 @@ pub struct VmParams<'a> {
     pub tpm: Option<&'a str>,
     #[cfg(feature = "igvm")]
     pub igvm: Option<&'a str>,
+    #[cfg(feature = "sev_snp")]
+    pub host_data: Option<&'a str>,
 }
 
 impl<'a> VmParams<'a> {
@@ -495,6 +497,8 @@ impl<'a> VmParams<'a> {
         let tpm: Option<&str> = args.get_one::<String>("tpm").map(|x| x as &str);
         #[cfg(feature = "igvm")]
         let igvm = args.get_one::<String>("igvm").map(|x| x as &str);
+        #[cfg(feature = "sev_snp")]
+        let host_data = args.get_one::<String>("host-data").map(|x| x as &str);
         VmParams {
             cpus,
             memory,
@@ -529,6 +533,8 @@ impl<'a> VmParams<'a> {
             tpm,
             #[cfg(feature = "igvm")]
             igvm,
+            #[cfg(feature = "sev_snp")]
+            host_data,
         }
     }
 }
@@ -2558,6 +2564,8 @@ impl VmConfig {
                 firmware: vm_params.firmware.map(PathBuf::from),
                 #[cfg(feature = "igvm")]
                 igvm: vm_params.igvm.map(PathBuf::from),
+                #[cfg(feature = "sev_snp")]
+                host_data: vm_params.host_data.map(|s| s.to_string()),
             })
         } else {
             None
@@ -3452,6 +3460,8 @@ mod tests {
                 initramfs: None,
                 #[cfg(feature = "igvm")]
                 igvm: None,
+                #[cfg(feature = "sev_snp")]
+                host_data: None,
             }),
             rate_limit_groups: None,
             disks: None,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2084,6 +2084,8 @@ mod unit_tests {
                 initramfs: None,
                 #[cfg(feature = "igvm")]
                 igvm: None,
+                #[cfg(feature = "sev_snp")]
+                host_data: None,
             }),
             rate_limit_groups: None,
             disks: None,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -522,6 +522,9 @@ pub struct PayloadConfig {
     #[cfg(feature = "igvm")]
     #[serde(default)]
     pub igvm: Option<PathBuf>,
+    #[cfg(feature = "sev_snp")]
+    #[serde(default)]
+    pub host_data: Option<String>,
 }
 
 pub fn default_serial() -> ConsoleConfig {


### PR DESCRIPTION
    The host data provided at launch. Data is passed to the hypervisor during the completion of the
    isolated import. Host Data provided by the hypervisor during guest launch.
    The firmware includes this value in all attestation reports for the guest.
