### PR TITLE
vmm: Force enable IOMMU incase of SEV-SNP guest

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -511,7 +511,9 @@ impl Vm {
         let sev_snp_enabled = config.lock().unwrap().is_sev_snp_enabled();
         #[cfg(feature = "tdx")]
         let force_iommu = tdx_enabled;
-        #[cfg(not(feature = "tdx"))]
+        #[cfg(feature = "sev_snp")]
+        let force_iommu = sev_snp_enabled;
+        #[cfg(not(any(feature = "tdx", feature = "sev_snp")))]
         let force_iommu = false;
 
         #[cfg(feature = "guest_debug")]


### PR DESCRIPTION
In case of SEV-SNP guest devices use sw-iotlb to gain access guest memory for DMA. For that F_IOMMU/F_ACCESS_PLATFORM must be exposed in the feature set of virtio devices.