### PR TITLE
arch: x86_64: allow more than 2 E820_RAM ranges.

### DIFF
--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -92,15 +92,10 @@ fn generate_memory_map(
     let mut memory_map = Vec::new();
 
     // Get usable physical memory ranges
-    let (first_ram_range, second_ram_range) =
-        arch::generate_ram_ranges(guest_mem).map_err(Error::InvalidGuestMemmap)?;
+    let ram_ranges = arch::generate_ram_ranges(guest_mem).map_err(Error::InvalidGuestMemmap)?;
 
-    // Create the memory map entry for memory region before the gap
-    memory_map.push(igvm_memmap_from_ram_range(first_ram_range));
-
-    // Create the memory map entry for memory region after the gap if any
-    if let Some(second_ram_range) = second_ram_range {
-        memory_map.push(igvm_memmap_from_ram_range(second_ram_range));
+    for ram_range in ram_ranges {
+        memory_map.push(igvm_memmap_from_ram_range(ram_range));
     }
 
     Ok(memory_map)


### PR DESCRIPTION
The 'generate_ram_ranges' function currently hardcodes the assumption that there are only 2 E820 RAM entries. This is not flexible enough to handle vendor specific (AMD) memory holes. Returning a Vec is also more convenient for users of this function.

Refactor this method to return a Vec instead of a 2-tuple to relax this assumption.