### PR TITLE
pci: vfio: naturally align bar

### DIFF
--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -696,8 +696,11 @@ impl VfioCommon {
                         .allocate(
                             restored_bar_addr,
                             region_size,
-                            // SAFETY: FFI call. Trivially safe.
-                            Some(unsafe { sysconf(_SC_PAGESIZE) as GuestUsize }),
+                            Some(std::cmp::max(
+                                // SAFETY: FFI call. Trivially safe.
+                                unsafe { sysconf(_SC_PAGESIZE) as GuestUsize },
+                                region_size,
+                            )),
                         )
                         .ok_or(PciDeviceError::IoAllocationFailed(region_size))?
                 }


### PR DESCRIPTION
According to PCIe specification, a 64-bit MMIO BAR should be naturally aligned. In addition to being more compliant with the specification, natural aligned BARs are mapped with the largest possible page size by the host iommu driver, which should speed up boot time and reduce IOTLB thrashing for PCIe P2P traffic on virtual machines with VFIO devices.

Props to @acarp-crusoe for finding this.
