### PR TITLE
Bring back bzImage direct kernel boot support for x86_64

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ do not wish to use the pre-built binaries.
 ## Booting Linux
 
 Cloud Hypervisor supports direct kernel boot (the x86-64 kernel requires the kernel
-built with PVH support) or booting via a firmware (either [Rust Hypervisor
+built with PVH support or a bzImage) or booting via a firmware (either [Rust Hypervisor
 Firmware](https://github.com/cloud-hypervisor/rust-hypervisor-firmware) or an
 edk2 UEFI firmware called `CLOUDHV` / `CLOUDHV_EFI`.)
 
@@ -175,7 +175,7 @@ $ ./cloud-hypervisor \
 
 #### Building your Kernel
 
-Cloud Hypervisor also supports direct kernel boot. For x86-64, a `vmlinux` ELF kernel (compiled with PVH support) is needed. In order to support development there is a custom branch; however provided the required options are enabled any recent kernel will suffice.
+Cloud Hypervisor also supports direct kernel boot. For x86-64, a `vmlinux` ELF kernel (compiled with PVH support) or a regular bzImage are supported. In order to support development there is a custom branch; however provided the required options are enabled any recent kernel will suffice.
 
 To build the kernel:
 

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -48,6 +48,10 @@ pub enum Error {
     ModlistSetup(#[source] vm_memory::GuestMemoryError),
     #[error("RSDP extends past the end of guest memory")]
     RsdpPastRamEnd,
+    #[error("Failed to setup Zero Page for bzImage")]
+    ZeroPageSetup(#[source] vm_memory::GuestMemoryError),
+    #[error("Zero Page for bzImage past RAM end")]
+    ZeroPagePastRamEnd,
 }
 
 /// Type for returning public functions outcome.

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -17,6 +17,7 @@ use crate::InitramfsConfig;
 use crate::RegionType;
 use hypervisor::arch::x86::{CpuIdEntry, CPUID_FLAG_VALID_INDEX};
 use hypervisor::{CpuVendor, HypervisorCpuError, HypervisorError};
+use linux_loader::loader::bootparam::{boot_params, setup_header};
 use linux_loader::loader::elf::start_info::{
     hvm_memmap_table_entry, hvm_modlist_entry, hvm_start_info,
 };
@@ -63,6 +64,8 @@ pub const _NSIG: i32 = 65;
 pub struct EntryPoint {
     /// Address in guest memory where the guest must start execution
     pub entry_addr: GuestAddress,
+    /// This field is used for bzImage to fill the zero page
+    pub setup_header: Option<setup_header>,
 }
 
 const E820_RAM: u32 = 1;
@@ -180,6 +183,9 @@ pub enum Error {
     /// Error retrieving TDX capabilities through the hypervisor (kvm/mshv) API
     #[cfg(feature = "tdx")]
     TdxCapabilities(HypervisorError),
+
+    /// Failed to configure E820 map for bzImage
+    E820Configuration,
 }
 
 impl From<Error> for super::Error {
@@ -842,8 +848,7 @@ pub fn configure_vcpu(
 
     regs::setup_msrs(vcpu).map_err(Error::MsrsConfiguration)?;
     if let Some((kernel_entry_point, guest_memory)) = boot_setup {
-        regs::setup_regs(vcpu, kernel_entry_point.entry_addr.raw_value())
-            .map_err(Error::RegsConfiguration)?;
+        regs::setup_regs(vcpu, kernel_entry_point).map_err(Error::RegsConfiguration)?;
         regs::setup_fpu(vcpu).map_err(Error::FpuConfiguration)?;
         regs::setup_sregs(&guest_memory.memory(), vcpu).map_err(Error::SregsConfiguration)?;
     }
@@ -892,8 +897,10 @@ pub fn arch_memory_regions() -> Vec<(GuestAddress, usize, RegionType)> {
 pub fn configure_system(
     guest_mem: &GuestMemoryMmap,
     cmdline_addr: GuestAddress,
+    cmdline_size: usize,
     initramfs: &Option<InitramfsConfig>,
     _num_cpus: u8,
+    setup_header: Option<setup_header>,
     rsdp_addr: Option<GuestAddress>,
     sgx_epc_region: Option<SgxEpcRegion>,
     serial_number: Option<&str>,
@@ -921,13 +928,24 @@ pub fn configure_system(
         }
     }
 
-    configure_pvh(
-        guest_mem,
-        cmdline_addr,
-        initramfs,
-        rsdp_addr,
-        sgx_epc_region,
-    )
+    match setup_header {
+        Some(hdr) => configure_32bit_entry(
+            guest_mem,
+            cmdline_addr,
+            cmdline_size,
+            initramfs,
+            hdr,
+            rsdp_addr,
+            sgx_epc_region,
+        ),
+        None => configure_pvh(
+            guest_mem,
+            cmdline_addr,
+            initramfs,
+            rsdp_addr,
+            sgx_epc_region,
+        ),
+    }
 }
 
 type RamRange = (u64, u64);
@@ -1128,6 +1146,113 @@ fn configure_pvh(
     guest_mem
         .write_obj(start_info, start_info_addr)
         .map_err(|_| super::Error::StartInfoSetup)?;
+
+    Ok(())
+}
+
+fn configure_32bit_entry(
+    guest_mem: &GuestMemoryMmap,
+    cmdline_addr: GuestAddress,
+    cmdline_size: usize,
+    initramfs: &Option<InitramfsConfig>,
+    setup_hdr: setup_header,
+    rsdp_addr: Option<GuestAddress>,
+    sgx_epc_region: Option<SgxEpcRegion>,
+) -> super::Result<()> {
+    const KERNEL_LOADER_OTHER: u8 = 0xff;
+
+    // Use the provided setup header
+    let mut params = boot_params {
+        hdr: setup_hdr,
+        ..Default::default()
+    };
+
+    // Common bootparams settings
+    if params.hdr.type_of_loader == 0 {
+        params.hdr.type_of_loader = KERNEL_LOADER_OTHER;
+    }
+    params.hdr.cmd_line_ptr = cmdline_addr.raw_value() as u32;
+    params.hdr.cmdline_size = cmdline_size as u32;
+
+    if let Some(initramfs_config) = initramfs {
+        params.hdr.ramdisk_image = initramfs_config.address.raw_value() as u32;
+        params.hdr.ramdisk_size = initramfs_config.size as u32;
+    }
+
+    add_e820_entry(&mut params, 0, layout::EBDA_START.raw_value(), E820_RAM)?;
+
+    let mem_end = guest_mem.last_addr();
+    if mem_end < layout::MEM_32BIT_RESERVED_START {
+        add_e820_entry(
+            &mut params,
+            layout::HIGH_RAM_START.raw_value(),
+            mem_end.unchecked_offset_from(layout::HIGH_RAM_START) + 1,
+            E820_RAM,
+        )?;
+    } else {
+        add_e820_entry(
+            &mut params,
+            layout::HIGH_RAM_START.raw_value(),
+            layout::MEM_32BIT_RESERVED_START.unchecked_offset_from(layout::HIGH_RAM_START),
+            E820_RAM,
+        )?;
+        if mem_end > layout::RAM_64BIT_START {
+            add_e820_entry(
+                &mut params,
+                layout::RAM_64BIT_START.raw_value(),
+                mem_end.unchecked_offset_from(layout::RAM_64BIT_START) + 1,
+                E820_RAM,
+            )?;
+        }
+    }
+
+    add_e820_entry(
+        &mut params,
+        layout::PCI_MMCONFIG_START.0,
+        layout::PCI_MMCONFIG_SIZE,
+        E820_RESERVED,
+    )?;
+
+    if let Some(sgx_epc_region) = sgx_epc_region {
+        add_e820_entry(
+            &mut params,
+            sgx_epc_region.start().raw_value(),
+            sgx_epc_region.size(),
+            E820_RESERVED,
+        )?;
+    }
+
+    if let Some(rsdp_addr) = rsdp_addr {
+        params.acpi_rsdp_addr = rsdp_addr.0;
+    }
+
+    let zero_page_addr = layout::ZERO_PAGE_START;
+    guest_mem
+        .checked_offset(zero_page_addr, mem::size_of::<boot_params>())
+        .ok_or(super::Error::ZeroPagePastRamEnd)?;
+    guest_mem
+        .write_obj(params, zero_page_addr)
+        .map_err(super::Error::ZeroPageSetup)?;
+
+    Ok(())
+}
+
+/// Add an e820 region to the e820 map.
+/// Returns Ok(()) if successful, or an error if there is no space left in the map.
+fn add_e820_entry(
+    params: &mut boot_params,
+    addr: u64,
+    size: u64,
+    mem_type: u32,
+) -> Result<(), Error> {
+    if params.e820_entries >= params.e820_table.len() as u8 {
+        return Err(Error::E820Configuration);
+    }
+
+    params.e820_table[params.e820_entries as usize].addr = addr;
+    params.e820_table[params.e820_entries as usize].size = size;
+    params.e820_table[params.e820_entries as usize].type_ = mem_type;
+    params.e820_entries += 1;
 
     Ok(())
 }
@@ -1378,6 +1503,7 @@ fn update_cpuid_sgx(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use linux_loader::loader::bootparam::boot_e820_entry;
 
     #[test]
     fn regions_base_addr() {
@@ -1394,8 +1520,10 @@ mod tests {
         let config_err = configure_system(
             &gm,
             GuestAddress(0),
+            0,
             &None,
             1,
+            None,
             Some(layout::RSDP_POINTER),
             None,
             None,
@@ -1417,8 +1545,10 @@ mod tests {
         configure_system(
             &gm,
             GuestAddress(0),
+            0,
             &None,
             no_vcpus,
+            None,
             None,
             None,
             None,
@@ -1445,8 +1575,10 @@ mod tests {
         configure_system(
             &gm,
             GuestAddress(0),
+            0,
             &None,
             no_vcpus,
+            None,
             None,
             None,
             None,
@@ -1459,6 +1591,7 @@ mod tests {
         configure_system(
             &gm,
             GuestAddress(0),
+            0,
             &None,
             no_vcpus,
             None,
@@ -1467,8 +1600,49 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn test_add_e820_entry() {
+        let e820_table = [(boot_e820_entry {
+            addr: 0x1,
+            size: 4,
+            type_: 1,
+        }); 128];
+
+        let expected_params = boot_params {
+            e820_table,
+            e820_entries: 1,
+            ..Default::default()
+        };
+
+        let mut params: boot_params = Default::default();
+        add_e820_entry(
+            &mut params,
+            e820_table[0].addr,
+            e820_table[0].size,
+            e820_table[0].type_,
+        )
+        .unwrap();
+        assert_eq!(
+            format!("{:?}", params.e820_table[0]),
+            format!("{:?}", expected_params.e820_table[0])
+        );
+        assert_eq!(params.e820_entries, expected_params.e820_entries);
+
+        // Exercise the scenario where the field storing the length of the e820 entry table is
+        // is bigger than the allocated memory.
+        params.e820_entries = params.e820_table.len() as u8 + 1;
+        assert!(add_e820_entry(
+            &mut params,
+            e820_table[0].addr,
+            e820_table[0].size,
+            e820_table[0].type_
+        )
+        .is_err());
     }
 
     #[test]

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -57,6 +57,7 @@ build_custom_linux() {
     make -j "$(nproc)"
     if [ "${ARCH}" == "x86_64" ]; then
         cp vmlinux "$WORKLOADS_DIR/" || exit 1
+        cp arch/x86/boot/bzImage "$WORKLOADS_DIR/" || exit 1
     elif [ "${ARCH}" == "aarch64" ]; then
         cp arch/arm64/boot/Image "$WORKLOADS_DIR/" || exit 1
         cp arch/arm64/boot/Image.gz "$WORKLOADS_DIR/" || exit 1

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3173,6 +3173,56 @@ mod common_parallel {
         handle_child_output(r, &output);
     }
 
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_direct_kernel_boot_bzimage() {
+        let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(focal));
+
+        let mut kernel_path = direct_kernel_boot_path();
+        // Replace the default kernel with the bzImage.
+        kernel_path.pop();
+        kernel_path.push("bzImage");
+
+        let mut child = GuestCommand::new(&guest)
+            .args(["--cpus", "boot=1"])
+            .args(["--memory", "size=512M"])
+            .args(["--kernel", kernel_path.to_str().unwrap()])
+            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_disks()
+            .default_net()
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = std::panic::catch_unwind(|| {
+            guest.wait_vm_boot(None).unwrap();
+
+            assert_eq!(guest.get_cpu_count().unwrap_or_default(), 1);
+            assert!(guest.get_total_memory().unwrap_or_default() > 480_000);
+
+            let grep_cmd = if cfg!(target_arch = "x86_64") {
+                "grep -c PCI-MSI /proc/interrupts"
+            } else {
+                "grep -c ITS-MSI /proc/interrupts"
+            };
+            assert_eq!(
+                guest
+                    .ssh_command(grep_cmd)
+                    .unwrap()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default(),
+                12
+            );
+        });
+
+        let _ = child.kill();
+        let output = child.wait_with_output().unwrap();
+
+        handle_child_output(r, &output);
+    }
+
     fn _test_virtio_block(image_name: &str, disable_io_uring: bool, disable_aio: bool) {
         let focal = UbuntuDiskConfig::new(image_name.to_string());
         let guest = Guest::new(Box::new(focal));

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -62,6 +62,8 @@ use linux_loader::cmdline::Cmdline;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use linux_loader::elf;
 #[cfg(target_arch = "x86_64")]
+use linux_loader::loader::bzimage::BzImage;
+#[cfg(target_arch = "x86_64")]
 use linux_loader::loader::elf::PvhBootCapability::PvhEntryPresent;
 #[cfg(target_arch = "aarch64")]
 use linux_loader::loader::pe::Error::InvalidImageMagicNumber;
@@ -1012,12 +1014,12 @@ impl Vm {
         cfg_if::cfg_if! {
             if #[cfg(feature = "sev_snp")] {
                 let entry_point = if cpu_manager.lock().unwrap().sev_snp_enabled() {
-                    EntryPoint { entry_addr: vm_memory::GuestAddress(res.vmsa_gpa) }
+                    EntryPoint { entry_addr: vm_memory::GuestAddress(res.vmsa_gpa), setup_header: None }
                 } else {
-                    EntryPoint {entry_addr: vm_memory::GuestAddress(res.vmsa.rip) }
+                    EntryPoint {entry_addr: vm_memory::GuestAddress(res.vmsa.rip), setup_header: None }
                 };
             } else {
-               let entry_point = EntryPoint { entry_addr: vm_memory::GuestAddress(res.vmsa.rip) };
+               let entry_point = EntryPoint { entry_addr: vm_memory::GuestAddress(res.vmsa.rip), setup_header: None };
             }
         };
         Ok(entry_point)
@@ -1035,12 +1037,23 @@ impl Vm {
             let guest_memory = memory_manager.lock().as_ref().unwrap().guest_memory();
             guest_memory.memory()
         };
+
+        // Try ELF binary with PVH boot.
         let entry_addr = linux_loader::loader::elf::Elf::load(
             mem.deref(),
             None,
             &mut kernel,
             Some(arch::layout::HIGH_RAM_START),
         )
+        // Try loading kernel as bzImage.
+        .or_else(|_| {
+            BzImage::load(
+                mem.deref(),
+                None,
+                &mut kernel,
+                Some(arch::layout::HIGH_RAM_START),
+            )
+        })
         .map_err(Error::KernelLoad)?;
 
         if let Some(cmdline) = cmdline {
@@ -1050,8 +1063,21 @@ impl Vm {
 
         if let PvhEntryPresent(entry_addr) = entry_addr.pvh_boot_cap {
             // Use the PVH kernel entry point to boot the guest
-            info!("Kernel loaded: entry_addr = 0x{:x}", entry_addr.0);
-            Ok(EntryPoint { entry_addr })
+            info!("PVH kernel loaded: entry_addr = 0x{:x}", entry_addr.0);
+            Ok(EntryPoint {
+                entry_addr,
+                setup_header: None,
+            })
+        } else if entry_addr.setup_header.is_some() {
+            // Use the bzImage 32bit entry point to boot the guest
+            info!(
+                "bzImage kernel loaded: entry_addr = 0x{:x}",
+                entry_addr.kernel_load.0
+            );
+            Ok(EntryPoint {
+                entry_addr: entry_addr.kernel_load,
+                setup_header: entry_addr.setup_header,
+            })
         } else {
             Err(Error::KernelMissingPvhHeader)
         }
@@ -1144,7 +1170,7 @@ impl Vm {
     }
 
     #[cfg(target_arch = "x86_64")]
-    fn configure_system(&mut self, rsdp_addr: GuestAddress) -> Result<()> {
+    fn configure_system(&mut self, rsdp_addr: GuestAddress, entry_addr: EntryPoint) -> Result<()> {
         trace_scoped!("configure_system");
         info!("Configuring system");
         let mem = self.memory_manager.lock().unwrap().boot_guest_memory();
@@ -1197,8 +1223,10 @@ impl Vm {
         arch::configure_system(
             &mem,
             arch::layout::CMDLINE_START,
+            arch::layout::CMDLINE_MAX_SIZE,
             &initramfs_config,
             boot_vcpus,
+            entry_addr.setup_header,
             rsdp_addr,
             sgx_epc_region,
             serial_number.as_deref(),
@@ -1211,7 +1239,11 @@ impl Vm {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn configure_system(&mut self, _rsdp_addr: GuestAddress) -> Result<()> {
+    fn configure_system(
+        &mut self,
+        _rsdp_addr: GuestAddress,
+        _entry_addr: EntryPoint,
+    ) -> Result<()> {
         let cmdline = Self::generate_cmdline(
             self.config.lock().unwrap().payload.as_ref().unwrap(),
             &self.device_manager,
@@ -2082,10 +2114,10 @@ impl Vm {
 
         // Configure shared state based on loaded kernel
         entry_point
-            .map(|_| {
+            .map(|entry_point| {
                 // Safe to unwrap rsdp_addr as we know it can't be None when
                 // the entry_point is Some.
-                self.configure_system(rsdp_addr.unwrap())
+                self.configure_system(rsdp_addr.unwrap(), entry_point)
             })
             .transpose()?;
 


### PR DESCRIPTION
Fixes: #5766 

This feature was [previously removed](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/2569) in favor of just supporting uncompressed PVH ELF binaries for simplicity. However, direct bzImage support has a couple benefits that would be nice.
 * No need to keep uncompressed images around
 * Ability to use the distro provided kernel from `/boot` directly

By using the [regular 32 bit entry point](https://docs.kernel.org/arch/x86/boot.html#bit-boot-protocol), the necessary code changes are rather small. Most of the machine setup can be shared with the PVH setup. We just need to provide the zero page and point to it in the initial register state. The boot variant is auto-detected with no further switches needed. I opted to just use the availability of the `setup_header` as a marker for the boot protocol instead of an explicit enum (as was done before). While being explicit is mostly good, here it would lead to more code churn and more special cases to handle.

Most of this code is a partial revert of the previously existing code.

I ran the x86_64 integration tests using both `vmlinux` and `bzImage` as the direct boot kernel with the same results as far as I could get those to work (using `./scripts/dev_cli.sh` docker setup). I added one simple boot test that uses the bzImage explicitly in the integration tests.

For visibility: @parthy @blitz 