### PR TITLE
vmm: Avoid zombie sigwinch_listener processes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -561,6 +561,11 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
         .ok();
     }
 
+    // SAFETY: Trivially safe.
+    unsafe {
+        libc::signal(libc::SIGCHLD, libc::SIG_IGN);
+    }
+
     // Before we start any threads, mask the signals we'll be
     // installing handlers for, to make sure they only ever run on the
     // dedicated signal handling thread we'll start in a bit.


### PR DESCRIPTION
When a guest running on a terminal reboots, the `sigwinch_listener` subprocess exits and a new one restarts. The parent never wait()s for children, so the old subprocess remains as a zombie. With further reboots, more and more zombies build up.

As there are no other children whose exit status we want, the easiest fix is to take advantage of the implicit reaping specified by POSIX when we set the disposition of `SIGCHLD` to `SIG_IGN`.

For this to work, we also need to set the correct default exit signal of `SIGCHLD` when using `clone3() CLONE_CLEAR_SIGHAND`. Unlike the fallback `fork()` path, `clone_args::default()` initialises the exit signal to zero, which results in a child with non-standard reaping behaviour.