### PR TITLE
build: Extend x86-64 GitHub action to AMD runner

### DIFF
--- a/.github/workflows/integration-x86-64.yaml
+++ b/.github/workflows/integration-x86-64.yaml
@@ -3,9 +3,12 @@ on: [pull_request, create]
 
 jobs:
   build:
+    strategy:
+      matrix:
+          runner: ["garm-jammy", "garm-jammy-amd"]
     if: github.event_name == 'pull_request'
     name: Tests (x86-64)
-    runs-on: garm-jammy
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Code checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Use the matrix to add a build runnind on the AMD variant of the garm
runner.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
