### PR TITLE
ch-remote: Fix crash when run with no subcommand

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -898,6 +898,7 @@ fn main() {
         .author(env!("CARGO_PKG_AUTHORS"))
         .version(env!("BUILD_VERSION"))
         .about("Remotely control a cloud-hypervisor VMM.")
+        .subcommand_required(true)
         .args([
             Arg::new("api-socket")
                 .long("api-socket")

--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -898,6 +898,7 @@ fn main() {
         .author(env!("CARGO_PKG_AUTHORS"))
         .version(env!("BUILD_VERSION"))
         .about("Remotely control a cloud-hypervisor VMM.")
+        .arg_required_else_help(true)
         .subcommand_required(true)
         .args([
             Arg::new("api-socket")

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,7 @@ fn create_app(default_vcpus: String, default_memory: String, default_rng: String
         // compile time
         .author(env!("CARGO_PKG_AUTHORS"))
         .about("Launch a cloud-hypervisor VMM.")
+        .arg_required_else_help(true)
         .group(ArgGroup::new("vm-config").multiple(true))
         .group(ArgGroup::new("vmm-config").multiple(true))
         .group(ArgGroup::new("logging").multiple(true))

--- a/vhost_user_block/src/main.rs
+++ b/vhost_user_block/src/main.rs
@@ -20,6 +20,7 @@ fn main() {
         .version(env!("CARGO_PKG_VERSION"))
         .author(env!("CARGO_PKG_AUTHORS"))
         .about("Launch a vhost-user-blk backend.")
+        .arg_required_else_help(true)
         .arg(
             Arg::new("block-backend")
                 .long("block-backend")

--- a/vhost_user_net/src/main.rs
+++ b/vhost_user_net/src/main.rs
@@ -16,6 +16,7 @@ fn main() {
         .version(env!("CARGO_PKG_VERSION"))
         .author(env!("CARGO_PKG_AUTHORS"))
         .about("Launch a vhost-user-net backend.")
+        .arg_required_else_help(true)
         .arg(
             Arg::new("net-backend")
                 .long("net-backend")


### PR DESCRIPTION
ch-remote crashes when run with `--api-socket` but no subcommand:
```
$ target/release/ch-remote --api-socket /tmp/api
thread 'main' panicked at src/bin/ch-remote.rs:509:14:
internal error: entered unreachable code
```

Use `clap::Command::subcommand_required(true)` to yield a more friendly error in this case.