### PR TITLE
[RFC] Single-shot VMs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -408,6 +408,14 @@ fn create_app(default_vcpus: String, default_memory: String, default_rng: String
                 .num_args(1)
                 .help(config::TpmConfig::SYNTAX)
                 .group("vmm-config"),
+        )
+        .arg(
+            Arg::new("once")
+                .long("once")
+                .help("Exit on VM reboot or reset")
+                .num_args(0)
+                .action(ArgAction::SetTrue)
+                .group("vmm-config"),
         );
 
     #[cfg(target_arch = "x86_64")]
@@ -707,6 +715,7 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
         exit_evt.try_clone().unwrap(),
         &seccomp_action,
         hypervisor,
+        cmd_arguments.get_flag("once"),
     )
     .map_err(Error::StartVmmThread)?;
 


### PR DESCRIPTION
(The attached demo patch is mainly intended to illustrate the discussion.)

When I first built firecracker into a hosting product, I was surprised that the vmm exits when a vm reboots or resets, vs 'rebooting like a physical machine' which I was accustomed to from qemu.

However, the practical advantages of this behaviour grew on me. For long running guests, running a single-shot vmm under a process supervisor means that you can pick up the latest version of both hypervisor and kernel with a simple reboot in the guest, without having to provide any kind of out-of-band vmm interface to the guest's user.

It's also super-handy for automated testing or quick command-line use. For example, I build initramfs images for my hosts which offer an emergency repair shell, timeout at the prompt then assemble lvm raid, mount the root filesystem and continue normal boot. With a single-shot vmm, I run ./test (which starts a VM), get dropped into ramfs image to test it out, and when I've done testing I can reboot to exit back to my shell. With a persistent vmm, I would need to open a second shell and pkill the hypervisor instead.

I thought about implementing this on cloud-hypervisor with a wrapper that monitors the event stream, but you can't intercept a reboot without racing against the new vm starting up again. (Being JSON, the event stream is a bit of a pain to monitor cleanly from a shell script too, although maybe a string match on `"event": "shutdown"` would be an adequate hack in practice.)

So as an experiment, I tried adding a `--once` flag to cloud-hypervisor to optionally enable the firecracker-style single shot behaviour, as in the attached patch. It was less invasive than I expected. I wonder whether you feel something along these lines might be of wider interest, or is too niche a use-case for upstream?