### PR TITLE
vmm: add NVIDIA GPUDirect P2P support.

### DIFF
--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -94,6 +94,7 @@ impl VfioUserPciDevice {
             &PciVfioUserSubclass::VfioUserSubclass,
             bdf,
             vm_migration::snapshot_from_id(snapshot.as_ref(), VFIO_COMMON_ID),
+            None,
         )
         .map_err(VfioUserPciDeviceError::CreateVfioCommon)?;
 

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1046,7 +1046,9 @@ components:
           format: int16
         id:
           type: string
-
+        x_nv_gpudirect_clique:
+          type: integer
+          format: int8
     TpmConfig:
       required:
         - socket

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1746,7 +1746,12 @@ impl DeviceConfig {
 
     pub fn parse(device: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
-        parser.add("path").add("id").add("iommu").add("pci_segment");
+        parser
+            .add("path")
+            .add("id")
+            .add("iommu")
+            .add("pci_segment")
+            .add("x_nv_gpudirect_clique");
         parser.parse(device).map_err(Error::ParseDevice)?;
 
         let path = parser
@@ -1763,12 +1768,15 @@ impl DeviceConfig {
             .convert::<u16>("pci_segment")
             .map_err(Error::ParseDevice)?
             .unwrap_or_default();
-
+        let x_nv_gpudirect_clique = parser
+            .convert::<u8>("x_nv_gpudirect_clique")
+            .map_err(Error::ParseDevice)?;
         Ok(DeviceConfig {
             path,
             iommu,
             id,
             pci_segment,
+            x_nv_gpudirect_clique,
         })
     }
 
@@ -3324,6 +3332,7 @@ mod tests {
             id: None,
             iommu: false,
             pci_segment: 0,
+            x_nv_gpudirect_clique: None,
         }
     }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3510,6 +3510,7 @@ impl DeviceManager {
             pci_device_bdf,
             Arc::new(move || memory_manager.lock().unwrap().allocate_memory_slot()),
             vm_migration::snapshot_from_id(self.snapshot.as_ref(), vfio_name.as_str()),
+            device_cfg.x_nv_gpudirect_clique,
         )
         .map_err(DeviceManagerError::VfioPciCreate)?;
 

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -434,6 +434,8 @@ pub struct DeviceConfig {
     pub id: Option<String>,
     #[serde(default)]
     pub pci_segment: u16,
+    #[serde(default)]
+    pub x_nv_gpudirect_clique: Option<u8>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]


### PR DESCRIPTION
On platforms where PCIe P2P is supported, inject a PCI capability into NVIDIA GPU to indicate support.

A [previous PR](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/6175) added support for PCIe P2P between VFIO devices. The NVIDIA driver does not utilize PCIe P2P unless it detects hardware support. The PCIe specification doesn't require platforms to support PCIe P2P traffic between root ports (although many systems do). Within a virtual machine, information about the host PCIe bridge is lost, so NVIDIA recommends the use of an injected PCI capability to signal support for PCIe P2P between GPUs.

This PR adds a new argument `x_nv_gpudirect_clique` to VFIO devices `--device path=<PCI_DEVICE_PATH>,x_nv_gpudirect_clique=<CLIQUE_ID>` that injects a PCI capability indicating the "P2P clique" that the GPU belongs to.  This option is only valid for modern datacenter NVIDIA GPUs (NVIDIA Turing, Ampere, Hopper, and Lovelace). The NVIDIA provided specification can be found [here](https://lists.gnu.org/archive/html/qemu-devel/2023-06/pdf142OR4O4c2.pdf).

After enabling this feature, we benchmarked a decrease in GPU P2P latency from `12 us` to `1.4 us` compared to the fallback shared memory communication mechanism.

The `nvidia-smi` utility can be used to confirm that the P2P support. For example, the following cloud-hypervisor guest has 4 NVIDIA L40S GPUS.
```
nvidia-smi topo -p2p r
 	GPU0	GPU1	GPU2	GPU3	
 GPU0	X	OK	OK	OK	
 GPU1	OK	X	OK	OK	
 GPU2	OK	OK	X	OK	
 GPU3	OK	OK	OK	X	

Legend:

  X    = Self
  OK   = Status Ok
  CNS  = Chipset not supported
  GNS  = GPU not supported
  TNS  = Topology not supported
  NS   = Not supported
  U    = Unknown
```