### PR TITLE
build: Use merge queue for some integration tests

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -4,6 +4,7 @@ on:
     paths: 
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+
 jobs:
   security_audit:
     name: Audit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 name: Cloud Hypervisor Build
 on: [pull_request, merge_group]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,8 @@
 name: Cloud Hypervisor Build
-on: [pull_request, create]
+on: [pull_request, merge_group]
 
 jobs:
   build:
-    if: github.event_name == 'pull_request'
     name: Build
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -12,6 +12,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Check DCO
+      if: ${{ github.event_name == 'pull_request' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -1,6 +1,6 @@
 name: DCO
-on:
-  pull_request:
+on: [pull_request, merge_group]
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -3,6 +3,7 @@ on: [pull_request, merge_group]
 
 jobs:
   check:
+    name: DCO Check ("Signed-Off-By")
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -5,6 +5,9 @@ on:
     paths: resources/Dockerfile
   pull_request:
     paths: resources/Dockerfile
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,5 +1,4 @@
 name: Cloud Hypervisor's Docker image update
-
 on:
   push:
     branches: main

--- a/.github/workflows/fuzz-build.yaml
+++ b/.github/workflows/fuzz-build.yaml
@@ -1,9 +1,8 @@
 name: Cloud Hypervisor Cargo Fuzz Build
-on: [pull_request, create]
+on: [pull_request, merge_group]
 
 jobs:
   build:
-    if: github.event_name == 'pull_request'
     name: Cargo Fuzz Build
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/fuzz-build.yaml
+++ b/.github/workflows/fuzz-build.yaml
@@ -1,5 +1,8 @@
 name: Cloud Hypervisor Cargo Fuzz Build
 on: [pull_request, merge_group]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -1,5 +1,4 @@
 name: Commit messages check
-
 on:
   pull_request:
 

--- a/.github/workflows/hadolint.yaml
+++ b/.github/workflows/hadolint.yaml
@@ -1,5 +1,4 @@
 name: Lint Dockerfile
-
 on:
   push:
     paths:

--- a/.github/workflows/integration-arm64.yaml
+++ b/.github/workflows/integration-arm64.yaml
@@ -1,10 +1,9 @@
 name: Cloud Hypervisor Tests (ARM64)
-on: [pull_request, create]
+on: [pull_request, merge_group]
 
 jobs:
   build:
     timeout-minutes: 60
-    if: github.event_name == 'pull_request'
     name: Tests (ARM64)
     runs-on: focal-arm64
     steps:

--- a/.github/workflows/integration-sgx.yaml
+++ b/.github/workflows/integration-sgx.yaml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   build:
-    if: github.event_name == 'push'
     name: Tests (SGX)
     runs-on: jammy-sgx
     steps:

--- a/.github/workflows/integration-vfio.yaml
+++ b/.github/workflows/integration-vfio.yaml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   build:
-    if: github.event_name == 'push'
     name: Tests (VFIO)
     runs-on: jammy-vfio
     steps:

--- a/.github/workflows/integration-windows.yaml
+++ b/.github/workflows/integration-windows.yaml
@@ -1,5 +1,5 @@
 name: Cloud Hypervisor Tests (Windows Guest)
-on: [pull_request, create]
+on: [merge_group]
 
 jobs:
   build:

--- a/.github/workflows/integration-windows.yaml
+++ b/.github/workflows/integration-windows.yaml
@@ -1,16 +1,18 @@
 name: Cloud Hypervisor Tests (Windows Guest)
-on: [merge_group]
+on: [merge_group, pull_request]
 
 jobs:
   build:
     name: Tests (Windows Guest)
-    runs-on: garm-jammy
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'garm-jammy' }}
     steps:
       - name: Code checkout
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Docker
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           sudo apt-get update
           sudo apt-get -y install ca-certificates curl gnupg
@@ -20,6 +22,7 @@ jobs:
           sudo apt-get update
           sudo apt install -y docker-ce docker-ce-cli
       - name: Install Azure CLI
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           sudo apt install -y ca-certificates curl apt-transport-https lsb-release gnupg
           curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
@@ -27,12 +30,18 @@ jobs:
           sudo apt update
           sudo apt install -y azure-cli
       - name: Download Windows image
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           mkdir $HOME/workloads
           az storage blob download --container-name private-images --file "$HOME/workloads/windows-server-2022-amd64-2.raw" --name windows-server-2022-amd64-2.raw --connection-string "${{ secrets.CH_PRIVATE_IMAGES }}"
       - name: Run Windows guest integration tests
+        if: ${{ github.event_name != 'pull_request' }}
         timeout-minutes: 15
         run: scripts/dev_cli.sh tests --integration-windows
       - name: Run Windows guest integration tests for musl
+        if: ${{ github.event_name != 'pull_request' }}
         timeout-minutes: 15
         run: scripts/dev_cli.sh tests --integration-windows --libc musl
+      - name: Skipping build for PR
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "Skipping build for PR"

--- a/.github/workflows/integration-windows.yaml
+++ b/.github/workflows/integration-windows.yaml
@@ -1,5 +1,8 @@
 name: Cloud Hypervisor Tests (Windows Guest)
 on: [merge_group, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/integration-x86-64.yaml
+++ b/.github/workflows/integration-x86-64.yaml
@@ -1,5 +1,8 @@
 name: Cloud Hypervisor Tests (x86-64)
 on: [pull_request, merge_group]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/integration-x86-64.yaml
+++ b/.github/workflows/integration-x86-64.yaml
@@ -7,16 +7,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ["garm-jammy", "garm-jammy-amd"]
-        libc: ["musl", "gnu"]
+        runner: ['garm-jammy', "garm-jammy-amd"]
+        libc: ["musl", 'gnu']
     name: Tests (x86-64)
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && !(matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') && 'ubuntu-latest' || matrix.runner }}
     steps:
       - name: Code checkout
+        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Docker
+        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
         run: |
           sudo apt-get update
           sudo apt-get -y install ca-certificates curl gnupg
@@ -26,14 +28,22 @@ jobs:
           sudo apt-get update
           sudo apt install -y docker-ce docker-ce-cli
       - name: Prepare for VDPA
+        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
         run: scripts/prepare_vdpa.sh
       - name: Run unit tests
+        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
         run: scripts/dev_cli.sh tests --unit --libc ${{ matrix.libc }}
       - name: Load openvswitch module
+        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
         run: sudo modprobe openvswitch
       - name: Run integration tests
+        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
         timeout-minutes: 40
         run: scripts/dev_cli.sh tests --integration --libc ${{ matrix.libc }}
       - name: Run live-migration integration tests
+        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
         timeout-minutes: 20
         run: scripts/dev_cli.sh tests --integration-live-migration --libc ${{ matrix.libc }}
+      - name: Skipping build for PR
+        if: ${{ github.event_name == 'pull_request' && matrix.runner != 'garm-jammy' && matrix.libc != 'gnu' }}
+        run: echo "Skipping build for PR"

--- a/.github/workflows/integration-x86-64.yaml
+++ b/.github/workflows/integration-x86-64.yaml
@@ -1,5 +1,5 @@
 name: Cloud Hypervisor Tests (x86-64)
-on: [pull_request, create]
+on: [pull_request, merge_group]
 
 jobs:
   build:
@@ -9,7 +9,6 @@ jobs:
       matrix:
         runner: ["garm-jammy", "garm-jammy-amd"]
         libc: ["musl", "gnu"]
-    if: github.event_name == 'pull_request'
     name: Tests (x86-64)
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -1,7 +1,5 @@
 name: Cloud Hypervisor OpenAPI Validation
-
-on:
-  pull_request:
+on: [pull_request, merge_group]
 
 jobs:
   Validate:

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -1,5 +1,8 @@
 name: Cloud Hypervisor Quality Checks
 on: [pull_request, merge_group]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -1,9 +1,8 @@
 name: Cloud Hypervisor Quality Checks
-on: [pull_request, create]
+on: [pull_request, merge_group]
 
 jobs:
   build:
-    if: github.event_name == 'pull_request'
     name: Quality (clippy, rustfmt)
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -45,8 +45,8 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Debug Check (default features)
-        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+      - name: Bisectability Check (default features)
+        if: ${{ github.event_name == 'pull_request' && matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: |
           set -e
           commits=$(git rev-list origin/${{ github.base_ref }}..${{ github.sha }})

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 name: Cloud Hypervisor Release
-on: [pull_request, create]
+on: [pull_request, create, merge_group]
 
 jobs:
   release:
-    if: (github.event_name == 'create' && github.event.ref_type == 'tag') || github.event_name == 'pull_request'
+    if: (github.event_name == 'create' && github.event.ref_type == 'tag') || github.event_name == 'pull_request' || github.event_name == 'merge_group'
     name: Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 name: Cloud Hypervisor Release
-on: [pull_request, create, merge_group]
+on: [create, merge_group]
 
 jobs:
   release:
-    if: (github.event_name == 'create' && github.event.ref_type == 'tag') || github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: (github.event_name == 'create' && github.event.ref_type == 'tag') || github.event_name == 'merge_group'
     name: Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Cloud Hypervisor Release
 on: [create, merge_group]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release:

--- a/.github/workflows/shlint.yaml
+++ b/.github/workflows/shlint.yaml
@@ -1,7 +1,7 @@
 name: Shell scripts check
-
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
Move some jobs to the merge queue only: Windows guest + AMD x86-64 + musl. Unfortunately there is no way to have different status checks for PR and merge queue - so add dummy jobs to "pass" on the jobs that should be skipped because they are only  running on the merge queue.

This requires an extra sprinkling of conditions but this means that we can enforce Window Guest tests on merges as that job cannot be run from forks.