### PR TITLE
Add GitHub action for metrics tests

### DIFF
--- a/.github/workflows/integration-metrics.yaml
+++ b/.github/workflows/integration-metrics.yaml
@@ -1,0 +1,17 @@
+name: Cloud Hypervisor Tests (Metrics)
+on: [pull_request, create]
+
+jobs:
+  build:
+    name: Tests (Metrics)
+    runs-on: jammy-metrics
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run metrics tests
+        timeout-minutes: 60
+        run: scripts/dev_cli.sh tests --metrics -- -- --report-file /root/workloads/metrics.json
+      - name: Upload metrics report
+        run: echo "Uploading setup in Azure not done"


### PR DESCRIPTION
Currently it applies on pull request, once testing is done, I will update it to only main branch.

Uploading to metrics report setup in new Azure subscription and provisioning of metrics uploading key is not done. 