### PR TITLE
vmm: http: graceful shutdown of the http api thread

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -838,6 +838,7 @@ fn http_api_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError>
         (libc::SYS_sched_yield, vec![]),
         (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_write, vec![]),
+        (libc::SYS_rt_sigprocmask, vec![]),
     ])
 }
 


### PR DESCRIPTION
This commit ensures that the HttpApi thread flushes all the responses before the application shuts down. Without this step, in case of a VmmShutdown request the application might terminate before the thread sends a response.

Fixes: #6247