### PR TITLE
build: Run integration tests on smaller VMs

### DIFF
--- a/.github/workflows/integration-windows.yaml
+++ b/.github/workflows/integration-windows.yaml
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   build:
     name: Tests (Windows Guest)
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'garm-jammy' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'garm-jammy-16' }}
     steps:
       - name: Code checkout
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/integration-x86-64.yaml
+++ b/.github/workflows/integration-x86-64.yaml
@@ -13,7 +13,7 @@ jobs:
         runner: ['garm-jammy', "garm-jammy-amd"]
         libc: ["musl", 'gnu']
     name: Tests (x86-64)
-    runs-on: ${{ github.event_name == 'pull_request' && !(matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') && 'ubuntu-latest' || matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && !(matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') && 'ubuntu-latest' || format('{0}-16', matrix.runner) }}
     steps:
       - name: Code checkout
         if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6197,7 +6197,7 @@ mod common_parallel {
             .unwrap();
 
         // Wait for the VM to be restored
-        thread::sleep(std::time::Duration::new(10, 0));
+        thread::sleep(std::time::Duration::new(20, 0));
         let expected_events = [
             &MetaEvent {
                 event: "starting".to_string(),


### PR DESCRIPTION
The x86 intel worker on glibc build now takes around 30 mins on a 16 cores VM while it was around 21 mins when using a 64 cores VM. By reducing the size of VMs to run a single worker, we are able to run more workers in parallel with the same vCPU quota from Azure.