### PR TITLE
build: Avoid cancellation of release build workflow on MQ

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor Release
 on: [create, merge_group]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
When running on the merge group this workflow is run twice - once for
the create event (merge queue creates a new branch) and once for the
merge_group event. Unfortunately the second event would cause the first
to be cancelled - unfortunately sometimes that second event is the
create event where the job in the workflow only runs if it is also a
tag.

By creating distinct concurrency groups for each event type then the
cross cancellation can be avoided.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
