### PR TITLE
vmm: fix openapi queue_affinity config

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -887,7 +887,7 @@ components:
           type: string
         rate_limit_group:
           type: string
-        affinity:
+        queue_affinity:
           type: array
           items:
             $ref: "#/components/schemas/VirtQueueAffinity"


### PR DESCRIPTION
The DiskConfig `queue_affinity` config is incorrectly specified as `affinity` in the OpenAPI yaml.