### PR TITLE
vmm: hypervisor: Add support for injecting NMI for MSHV guest

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -515,7 +515,5 @@ pub trait Vcpu: Send + Sync {
     ///
     /// Trigger NMI interrupt
     ///
-    fn nmi(&self) -> Result<()> {
-        unimplemented!()
-    }
+    fn nmi(&self) -> Result<()>;
 }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -182,6 +182,7 @@ mod mshv {
     pub const MSHV_WRITE_GPA: u64 = 0x4020_b833;
     pub const MSHV_SEV_SNP_AP_CREATE: u64 = 0x4010_b834;
     pub const MSHV_ISSUE_PSP_GUEST_REQUEST: u64 = 0x4010_b831;
+    pub const MSHV_ASSERT_INTERRUPT: u64 = 0x4018_b809;
 }
 #[cfg(feature = "mshv")]
 use mshv::*;
@@ -200,6 +201,7 @@ fn create_vmm_ioctl_seccomp_rule_common_mshv() -> Result<Vec<SeccompRule>, Backe
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_REGISTERS)?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_VP_REGISTERS)?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_RUN_VP)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_ASSERT_INTERRUPT)?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_STATE)?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_VP_STATE)?],
         and![Cond::new(
@@ -705,6 +707,7 @@ fn create_vcpu_ioctl_seccomp_rule_mshv() -> Result<Vec<SeccompRule>, BackendErro
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_VP_REGISTERS)?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_MAP_GUEST_MEMORY)?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_UNMAP_GUEST_MEMORY)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_ASSERT_INTERRUPT)?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_VP_TRANSLATE_GVA)?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_CPUID_VALUES)?],
         and![Cond::new(


### PR DESCRIPTION
Currently, we only support injecting NMI for KVM guests but we can do the same for MSHV guests as well to have feature parity.

I actually tested manually for a MSVH guest and here is a sample backtrace which I obtained in the process:

```
[  OK  ] Finished Update UTMP about System Runlevel Changes.
[    4.178592] Uhhuh. NMI received for unknown reason 20 on CPU 0.
[    4.178595] Kernel panic - not syncing: NMI: Not continuing
[    4.178596] CPU: 0 PID: 0 Comm: swapper/0 Not tainted 6.1.58.mshv1 #1
[    4.178598] Hardware name: Cloud Hypervisor cloud-hypervisor, BIOS 0
[    4.178598] Call Trace:
[    4.178610]  <NMI>
[    4.178611]  dump_stack_lvl+0x3b/0x59
[    4.178615]  panic+0xfb/0x274
[    4.178617]  ? _printk+0x53/0x6e
[    4.178619]  nmi_panic.cold+0xc/0xc
[    4.178620]  default_do_nmi+0x209/0x250
[    4.178622]  exc_nmi+0x11d/0x160
[    4.178623]  end_repeat_nmi+0x16/0x67
[    4.178625] RIP: 0010:default_idle+0x13/0x20
[    4.178634] Code: f7 e8 91 0e c5 ff eb d5 e8 6a 2d ff ff cc cc cc cc cc cc cc cc cc cc 8b 05 fa d6 fe 00 85 c0 7e 07 0f 00 2d cf 6c 55 00 fb f4 <31> ff e9 06 94 79 ff 66 0f 1f 44 00 00 65 48 8b 04 25 00 2c 02 00
[    4.178634] RSP: 0018:ffffffff82203ea0 EFLAGS: 00000242
[    4.178636] RAX: 0000000000000001 RBX: ffffffff82215640 RCX: 0000000000000000
[    4.178636] RDX: 0000000000000000 RSI: ffff88803ec25e20 RDI: 000000000000b054
[    4.178637] RBP: 0000000000000000 R08: 00000000f76a0e30 R09: 0000000000000281
[    4.178637] R10: 0000000000000001 R11: 0000000000000000 R12: 0000000000000000
[    4.178638] R13: 0000000000000000 R14: 0000000000000000 R15: 0000000000000000
[    4.178639]  ? default_idle+0x13/0x20
[    4.178640]  ? default_idle+0x13/0x20
[    4.178641]  </NMI>
[    4.178642]  <TASK>
[    4.178642]  default_idle_call+0x27/0x40
[    4.178643]  do_idle+0x1d5/0x1e0
[    4.178645]  cpu_startup_entry+0x21/0x30
[    4.178646]  rest_init+0xac/0xb0
[    4.178648]  arch_call_rest_init+0x5/0xa
[    4.178650]  start_kernel+0x5f2/0x61b
[    4.178651]  secondary_startup_64_no_verify+0xd2/0xdb
[    4.178652]  </TASK>
[    4.178976] Kernel Offset: disabled
[    4.296020] ---[ end Kernel panic - not syncing: NMI: Not continuing ]---

```

Fixes: #5909