### PR TITLE
vmm: add an event for VM reboot

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1384,6 +1384,8 @@ impl RequestHandler for Vmm {
     }
 
     fn vm_reboot(&mut self) -> result::Result<(), VmError> {
+        event!("vm", "rebooting");
+
         // First we stop the current VM
         let (config, serial_pty, console_pty, debug_console_pty, console_resize_pipe) =
             if let Some(mut vm) = self.vm.take() {
@@ -1450,6 +1452,8 @@ impl RequestHandler for Vmm {
         vm.boot()?;
 
         self.vm = Some(vm);
+
+        event!("vm", "rebooted");
 
         Ok(())
     }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1381,11 +1381,17 @@ impl RequestHandler for Vmm {
     }
 
     fn vm_shutdown(&mut self) -> result::Result<(), VmError> {
-        if let Some(ref mut vm) = self.vm.take() {
+        let r = if let Some(ref mut vm) = self.vm.take() {
             vm.shutdown()
         } else {
             Err(VmError::VmNotRunning)
+        };
+
+        if r.is_ok() {
+            event!("vm", "shutdown");
         }
+
+        r
     }
 
     fn vm_reboot(&mut self) -> result::Result<(), VmError> {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1216,6 +1216,8 @@ impl RequestHandler for Vmm {
 
     fn vm_boot(&mut self) -> result::Result<(), VmError> {
         tracer::start();
+        info!("Booting VM");
+        event!("vm", "booting");
         let r = {
             trace_scoped!("vm_boot");
             // If we don't have a config, we can not boot a VM.
@@ -1269,6 +1271,9 @@ impl RequestHandler for Vmm {
             }
         };
         tracer::end();
+        if r.is_ok() {
+            event!("vm", "booted");
+        }
         r
     }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2067,8 +2067,6 @@ impl Vm {
 
     pub fn boot(&mut self) -> Result<()> {
         trace_scoped!("Vm::boot");
-        info!("Booting VM");
-        event!("vm", "booting");
         let current_state = self.get_state()?;
         if current_state == VmState::Paused {
             return self.resume().map_err(Error::Resume);
@@ -2185,7 +2183,6 @@ impl Vm {
 
         let mut state = self.state.try_write().map_err(|_| Error::PoisonedState)?;
         *state = new_state;
-        event!("vm", "booted");
         Ok(())
     }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1397,8 +1397,6 @@ impl Vm {
         }
         *state = new_state;
 
-        event!("vm", "shutdown");
-
         Ok(())
     }
 


### PR DESCRIPTION
See https://github.com/cloud-hypervisor/cloud-hypervisor/issues/6274.

There is already an event for shutdown. There is no event for reboot.

@alexellis can you please check if this meets your need?