### PR TITLE
Beta clippy fixes

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -16,7 +16,6 @@ use crate::{DeviceType, GuestMemoryMmap, NumaNodes, PciSpaceInfo, RegionType};
 use hypervisor::arch::aarch64::gic::Vgic;
 use log::{log_enabled, Level};
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
 use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryAtomic};

--- a/devices/src/legacy/gpio_pl061.rs
+++ b/devices/src/legacy/gpio_pl061.rs
@@ -339,8 +339,6 @@ impl Migratable for Gpio {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{read_le_u32, write_le_u32};
-    use std::sync::Arc;
     use vm_device::interrupt::{InterruptIndex, InterruptSourceConfig};
     use vmm_sys_util::eventfd::EventFd;
 

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -329,10 +329,9 @@ impl BusDevice for Rtc {
 mod tests {
     use super::*;
     use crate::{
-        read_be_u16, read_be_u32, read_le_i32, read_le_u16, read_le_u32, read_le_u64, write_be_u16,
-        write_be_u32, write_le_i32, write_le_u16, write_le_u32, write_le_u64,
+        read_be_u16, read_be_u32, read_le_i32, read_le_u16, read_le_u64, write_be_u16,
+        write_be_u32, write_le_i32, write_le_u16, write_le_u64,
     };
-    use std::sync::Arc;
     use vm_device::interrupt::{InterruptIndex, InterruptSourceConfig};
     use vmm_sys_util::eventfd::EventFd;
 

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -465,8 +465,7 @@ impl Migratable for Pl011 {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Mutex;
     use vm_device::interrupt::{InterruptIndex, InterruptSourceConfig};
     use vmm_sys_util::eventfd::EventFd;
 

--- a/devices/src/pvpanic.rs
+++ b/devices/src/pvpanic.rs
@@ -210,7 +210,7 @@ impl PciDevice for PvPanicDevice {
         }
 
         bars.push(bar);
-        self.bar_regions = bars.clone();
+        self.bar_regions.clone_from(&bars);
 
         Ok(bars)
     }

--- a/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
@@ -209,8 +209,6 @@ impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm64_imm8 {
 
 #[cfg(test)]
 mod tests {
-    #![allow(unused_mut)]
-
     use super::*;
     use crate::arch::x86::emulator::mock_vmm::*;
 

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -269,7 +269,6 @@ impl<T: CpuStateManager> InstructionHandler<T> for Mov_RAX_moffs64 {
 
 #[cfg(test)]
 mod tests {
-    #![allow(unused_mut)]
     use super::*;
     use crate::arch::x86::emulator::mock_vmm::*;
 

--- a/hypervisor/src/arch/x86/emulator/instructions/movs.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/movs.rs
@@ -100,7 +100,6 @@ impl<T: CpuStateManager> InstructionHandler<T> for Movsb_m8_m8 {
 
 #[cfg(test)]
 mod tests {
-    #![allow(unused_mut)]
     use super::*;
     use crate::arch::x86::emulator::mock_vmm::*;
 

--- a/hypervisor/src/arch/x86/emulator/instructions/or.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/or.rs
@@ -50,7 +50,6 @@ impl<T: CpuStateManager> InstructionHandler<T> for Or_rm8_r8 {
 
 #[cfg(test)]
 mod tests {
-    #![allow(unused_mut)]
     use super::*;
 
     use crate::arch::x86::emulator::mock_vmm::*;

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -648,8 +648,6 @@ impl<'a, T: CpuStateManager> Emulator<'a, T> {
 
 #[cfg(test)]
 mod mock_vmm {
-    #![allow(unused_mut)]
-
     use super::*;
     use crate::arch::x86::emulator::EmulatorCpuState as CpuState;
     use crate::arch::x86::gdt::{gdt_entry, segment_from_gdt};
@@ -770,7 +768,6 @@ mod mock_vmm {
 
 #[cfg(test)]
 mod tests {
-    #![allow(unused_mut)]
     use super::*;
     use crate::arch::x86::emulator::mock_vmm::*;
 

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -21,8 +21,6 @@ use std::sync::Arc;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-///
-///
 pub enum HypervisorError {
     ///
     /// Hypervisor availability check error

--- a/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -14,7 +14,6 @@ use kvm_ioctls::DeviceFd;
 use redist_regs::{construct_gicr_typers, get_redist_regs, set_redist_regs};
 use serde::{Deserialize, Serialize};
 use std::any::Any;
-use std::convert::TryInto;
 
 const GITS_CTLR: u32 = 0x0000;
 const GITS_IIDR: u32 = 0x0004;

--- a/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -6,7 +6,7 @@ mod redist_regs;
 
 use crate::arch::aarch64::gic::{Error, Result, Vgic, VgicConfig};
 use crate::device::HypervisorDeviceError;
-use crate::kvm::{kvm_bindings, KvmVm};
+use crate::kvm::KvmVm;
 use crate::{CpuState, Vm};
 use dist_regs::{get_dist_regs, read_ctlr, set_dist_regs, write_ctlr};
 use icc_regs::{get_icc_regs, set_icc_regs};

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -27,8 +27,6 @@ use crate::{arm64_core_reg_id, offset_of};
 use kvm_ioctls::{NoDatamatch, VcpuFd, VmFd};
 use std::any::Any;
 use std::collections::HashMap;
-#[cfg(target_arch = "aarch64")]
-use std::convert::TryInto;
 #[cfg(target_arch = "x86_64")]
 use std::fs::File;
 #[cfg(target_arch = "x86_64")]

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 use ssh2::Session;
 use std::env;
 use std::ffi::OsStr;
+use std::fmt::Display;
 use std::io;
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -1211,14 +1212,15 @@ impl Default for VerbosityLevel {
     }
 }
 
-impl ToString for VerbosityLevel {
-    fn to_string(&self) -> String {
+impl Display for VerbosityLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use VerbosityLevel::*;
         match self {
-            Warn => "".to_string(),
-            Info => "-v".to_string(),
-            Debug => "-vv".to_string(),
+            Warn => (),
+            Info => write!(f, "-v")?,
+            Debug => write!(f, "-vv")?,
         }
+        Ok(())
     }
 }
 

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1070,7 +1070,7 @@ impl PciDevice for VirtioPciDevice {
             bars.push(bar);
         }
 
-        self.bar_regions = bars.clone();
+        self.bar_regions.clone_from(&bars);
 
         Ok(bars)
     }

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -705,8 +705,7 @@ pub fn create_acpi_tables(
             .unwrap()
             .get_device_info()
             .clone()
-            .get(&(DeviceType::Serial, DeviceType::Serial.to_string()))
-            .is_some();
+            .contains_key(&(DeviceType::Serial, DeviceType::Serial.to_string()));
         let serial_device_addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START.raw_value();
         let serial_device_irq = if is_serial_on {
             device_manager

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4185,7 +4185,7 @@ impl DeviceManager {
             if !pci_device_node.children.is_empty() {
                 assert_eq!(pci_device_node.children.len(), 1);
                 let child_id = &pci_device_node.children[0];
-                id = child_id.clone();
+                id.clone_from(child_id);
             }
         }
         for child in pci_device_node.children.iter() {

--- a/vmm/src/device_tree.rs
+++ b/vmm/src/device_tree.rs
@@ -175,7 +175,7 @@ mod tests {
 
         // Check get_mut()
         let node = device_tree.get_mut(&id).unwrap();
-        node.id = id2.clone();
+        node.id.clone_from(&id2);
         let node = device_tree.0.get(&id).unwrap();
         assert_eq!(node.id, id2);
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3133,7 +3133,6 @@ mod tests {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::GuestMemoryMmap;
     use arch::aarch64::fdt::create_fdt;
     use arch::aarch64::layout;
     use arch::{DeviceType, MmioDeviceInfo};


### PR DESCRIPTION
- devices: Fix clippy warning for use of .clone()
- virtio-devices: Fix clippy warning for use of .clone()
- vmm: Fix clippy warnings for use of .clone()
- arch: aarch64: Remove import of TryInto
- hypervisor: Remove import of TryInto
- hypervisor: Remove empty doc comment
