### PR TITLE
hypervisor: mshv: Guard x86 features under x86_64 feature flag

### DIFF
--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -20,7 +20,7 @@
 
 #[macro_use]
 extern crate anyhow;
-#[cfg(target_arch = "x86_64")]
+#[allow(unused_imports)]
 #[macro_use]
 extern crate log;
 

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -706,6 +706,7 @@ impl cpu::Vcpu for MshvVcpu {
                     debug!("Exception Info {:?}", { info.exception_vector });
                     Ok(cpu::VmExit::Ignore)
                 }
+                #[cfg(target_arch = "x86_64")]
                 hv_message_type_HVMSG_X64_APIC_EOI => {
                     let info = x.to_apic_eoi_info().unwrap();
                     // The kernel should dispatch the EOI to the correct thread.

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1361,6 +1361,7 @@ impl cpu::Vcpu for MshvVcpu {
             .set_sev_control_register(sev_control_reg)
             .map_err(|e| cpu::HypervisorCpuError::SetSevControlRegister(e.into()))
     }
+    #[cfg(target_arch = "x86_64")]
     ///
     /// Trigger NMI interrupt
     ///

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -598,6 +598,7 @@ impl cpu::Vcpu for MshvVcpu {
                         .map_err(|e| cpu::HypervisorCpuError::SetRegister(e.into()))?;
                     Ok(cpu::VmExit::Ignore)
                 }
+                #[cfg(target_arch = "x86_64")]
                 hv_message_type_HVMSG_UNMAPPED_GPA => {
                     let info = x.to_memory_info().unwrap();
                     let insn_len = info.instruction_byte_count as usize;

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -507,6 +507,7 @@ impl cpu::Vcpu for MshvVcpu {
                     warn!("TRIPLE FAULT");
                     Ok(cpu::VmExit::Shutdown)
                 }
+                #[cfg(target_arch = "x86_64")]
                 hv_message_type_HVMSG_X64_IO_PORT_INTERCEPT => {
                     let info = x.to_ioport_info().unwrap();
                     let access_info = info.access_info;


### PR DESCRIPTION
Currently there are bunch of VMExits which can only happen for x86 guests so guard them with x86_64 feature flag. This will help in future when we add support for aarch64 guests on MSHV.