### PR TITLE
virtio-devices: Removing all mappings found in an unmap request

### DIFF
--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -563,7 +563,7 @@ impl Request {
                         }
                     }
 
-                    // Remove mapping associated with the domain
+                    // Remove all mappings associated with the domain within the requested range
                     mapping
                         .domains
                         .write()
@@ -571,7 +571,7 @@ impl Request {
                         .get_mut(&domain_id)
                         .unwrap()
                         .mappings
-                        .remove(&virt_start);
+                        .retain(|&x, _| (x < req.virt_start || x > req.virt_end));
                 }
                 VIRTIO_IOMMU_T_PROBE => {
                     if desc_size_left != size_of::<VirtioIommuReqProbe>() {


### PR DESCRIPTION
According to the virtio iommu spec (section 5.13.6.6), all mappings within the entire range from virt_start to virt_end in an unmap request must be removed. This change adds this functionality, iterating through all mappings that fall within an unmap request for that domain and removing them.