### PR TITLE
Fix cargo fuzz (nightly) compiler warnings

### DIFF
--- a/block/src/vhdx/vhdx_header.rs
+++ b/block/src/vhdx/vhdx_header.rs
@@ -90,7 +90,7 @@ pub type Result<T> = std::result::Result<T, VhdxHeaderError>;
 
 #[derive(Clone, Debug)]
 pub struct FileTypeIdentifier {
-    pub signature: u64,
+    pub _signature: u64,
 }
 
 impl FileTypeIdentifier {
@@ -98,14 +98,14 @@ impl FileTypeIdentifier {
     pub fn new(f: &mut File) -> Result<FileTypeIdentifier> {
         f.seek(SeekFrom::Start(FILE_START))
             .map_err(VhdxHeaderError::SeekFileTypeIdentifier)?;
-        let signature = f
+        let _signature = f
             .read_u64::<LittleEndian>()
             .map_err(VhdxHeaderError::ReadFileTypeIdentifier)?;
-        if signature != VHDX_SIGN {
+        if _signature != VHDX_SIGN {
             return Err(VhdxHeaderError::InvalidVHDXSign);
         }
 
-        Ok(FileTypeIdentifier { signature })
+        Ok(FileTypeIdentifier { _signature })
     }
 }
 

--- a/virtio-devices/src/vsock/csm/mod.rs
+++ b/virtio-devices/src/vsock/csm/mod.rs
@@ -4,6 +4,8 @@
 //! This module implements our vsock connection state machine. The heavy lifting is done by
 //! `connection::VsockConnection`, while this file only defines some constants and helper structs.
 
+use thiserror::Error;
+
 mod connection;
 mod txbuf;
 
@@ -24,13 +26,16 @@ pub mod defs {
     pub const CONN_SHUTDOWN_TIMEOUT_MS: u64 = 2000;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// Attempted to push data to a full TX buffer.
+    #[error("TX buffer full")]
     TxBufFull,
     /// An I/O error occurred, when attempting to flush the connection TX buffer.
+    #[error("Error flushing TX buffer: {0}")]
     TxBufFlush(std::io::Error),
     /// An I/O error occurred, when attempting to write data to the host-side stream.
+    #[error("Error writing to host side stream: {0}")]
     StreamWrite(std::io::Error),
 }
 


### PR DESCRIPTION
- virtio-devices: vsock: csm: Use thiserror to provide error messages
- block: vhdx: "signature" field is unused
