### PR TITLE
vmm: Explicitly set NetConfig FDs as invalid for (de)serialization

### DIFF
--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -268,7 +268,11 @@ pub struct NetConfig {
     pub vhost_mode: VhostMode,
     #[serde(default)]
     pub id: Option<String>,
-    #[serde(default)]
+    #[serde(
+        default,
+        serialize_with = "serialize_netconfig_fds",
+        deserialize_with = "deserialize_netconfig_fds"
+    )]
     pub fds: Option<Vec<i32>>,
     #[serde(default)]
     pub rate_limiter_config: Option<RateLimiterConfig>,
@@ -312,6 +316,32 @@ pub const DEFAULT_NET_QUEUE_SIZE: u16 = 256;
 
 pub fn default_netconfig_queue_size() -> u16 {
     DEFAULT_NET_QUEUE_SIZE
+}
+
+fn serialize_netconfig_fds<S>(x: &Option<Vec<i32>>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    if let Some(x) = x {
+        warn!("'NetConfig' contains FDs that can't be serialized correctly. Serializing them as invalid FDs.");
+        let invalid_fds = vec![-1; x.len()];
+        s.serialize_some(&invalid_fds)
+    } else {
+        s.serialize_none()
+    }
+}
+
+fn deserialize_netconfig_fds<'de, D>(d: D) -> Result<Option<Vec<i32>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let invalid_fds: Option<Vec<i32>> = Option::deserialize(d)?;
+    if let Some(invalid_fds) = invalid_fds {
+        warn!("'NetConfig' contains FDs that can't be deserialized correctly. Deserializing them as invalid FDs.");
+        Ok(Some(vec![-1; invalid_fds.len()]))
+    } else {
+        Ok(None)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]


### PR DESCRIPTION
The 'NetConfig' may contain FDs which can't be serialized correctly, as FDs can only be donated from another process via a Unix domain socket with `SCM_RIGHTS`. To avoid false use of the serialized FDs, this patch explicitly set 'NetConfig' FDs as invalid for (de)serialization.

See: #6286