### PR TITLE
vmm: memory_manager: don't set backing_file for virtio_mem regions

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -671,7 +671,11 @@ impl MemoryManager {
             for zone_config in zones_config {
                 if guest_ram_mapping.zone_id == zone_config.id {
                     let region = MemoryManager::create_ram_region(
-                        &zone_config.file,
+                        if guest_ram_mapping.virtio_mem {
+                            &None
+                        } else {
+                            &zone_config.file
+                        },
                         guest_ram_mapping.file_offset,
                         GuestAddress(guest_ram_mapping.gpa),
                         guest_ram_mapping.size as usize,


### PR DESCRIPTION
The memory region that is associated with the hotpluggable part of a virtio-mem zone isn't backed by the file specified in the MemoryZoneConfig. The file is used only for the fixed part of the zone. When you try to restore a snapshot with virtio-mem, the backing file is used for all its regions. This results in the following error:

  VmRestore(MemoryManager(GuestMemoryRegion(MappingPastEof)))

This patch sets backing_file only for the fixed part of a virtio-mem zone.

Fixes: #6337