### PR TITLE
Update mshv crate commit and IOCTL numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,7 +1338,7 @@ checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 [[package]]
 name = "mshv-bindings"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#9d0c11fe9fedfbcf56a5d62fbf4bad80cdf91340"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#9f1e0cd775b30f36044bd045b27863b953c5988a"
 dependencies = [
  "libc",
  "serde",
@@ -1350,7 +1350,7 @@ dependencies = [
 [[package]]
 name = "mshv-ioctls"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#9d0c11fe9fedfbcf56a5d62fbf4bad80cdf91340"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#9f1e0cd775b30f36044bd045b27863b953c5988a"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -54,8 +54,6 @@ use crate::arch::x86::{CpuIdEntry, FpuState, MsrEntry};
 
 const DIRTY_BITMAP_CLEAR_DIRTY: u64 = 0x4;
 const DIRTY_BITMAP_SET_DIRTY: u64 = 0x8;
-#[cfg(feature = "sev_snp")]
-const HV_PAGE_SIZE: u64 = 4096;
 
 ///
 /// Export generically-named wrappers of mshv-bindings for Unix-based platforms
@@ -653,9 +651,9 @@ impl cpu::Vcpu for MshvVcpu {
                         "Releasing pages: gfn_start: {:x?}, gfn_count: {:?}",
                         gfn_start, gfn_count
                     );
-                    let gpa_start = gfn_start * HV_PAGE_SIZE;
+                    let gpa_start = gfn_start * HV_PAGE_SIZE as u64;
                     for i in 0..gfn_count {
-                        gpas.push(gpa_start + i * HV_PAGE_SIZE);
+                        gpas.push(gpa_start + i * HV_PAGE_SIZE as u64);
                     }
 
                     let mut gpa_list =

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -165,8 +165,8 @@ mod mshv {
     pub const MSHV_GET_VP_REGISTERS: u64 = 0xc010_b805;
     pub const MSHV_SET_VP_REGISTERS: u64 = 0x4010_b806;
     pub const MSHV_RUN_VP: u64 = 0x8100_b807;
-    pub const MSHV_GET_VP_STATE: u64 = 0xc028_b80a;
-    pub const MSHV_SET_VP_STATE: u64 = 0xc028_b80b;
+    pub const MSHV_GET_VP_STATE: u64 = 0xc010_b80a;
+    pub const MSHV_SET_VP_STATE: u64 = 0xc010_b80b;
     pub const MSHV_SET_PARTITION_PROPERTY: u64 = 0x4010_b80c;
     pub const MSHV_GET_GPA_ACCESS_STATES: u64 = 0xc01c_b812;
     pub const MSHV_VP_TRANSLATE_GVA: u64 = 0xc020_b80e;
@@ -183,6 +183,7 @@ mod mshv {
     pub const MSHV_SEV_SNP_AP_CREATE: u64 = 0x4010_b834;
     pub const MSHV_ISSUE_PSP_GUEST_REQUEST: u64 = 0x4010_b831;
     pub const MSHV_ASSERT_INTERRUPT: u64 = 0x4018_b809;
+    pub const MSHV_ROOT_HVCALL: u64 = 0xc020_b835;
 }
 #[cfg(feature = "mshv")]
 use mshv::*;
@@ -244,6 +245,7 @@ fn create_vmm_ioctl_seccomp_rule_common_mshv() -> Result<Vec<SeccompRule>, Backe
             Eq,
             MSHV_ISSUE_PSP_GUEST_REQUEST
         )?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_ROOT_HVCALL)?],
     ])
 }
 
@@ -725,6 +727,7 @@ fn create_vcpu_ioctl_seccomp_rule_mshv() -> Result<Vec<SeccompRule>, BackendErro
             Eq,
             MSHV_ISSUE_PSP_GUEST_REQUEST
         )?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_ROOT_HVCALL)?],
     ])
 }
 


### PR DESCRIPTION
Update mshv IOCTL numbers which have changed, and add a new seccomp rule for generic hvcall IOCTL.
Update mshv commit hash in Cargo.lock so the correct new get/set VP state IOCTLs are used.