### PR TITLE
Implement hypervisor agnostic variant of definitions from kvm_bindings

### DIFF
--- a/hypervisor/src/arch/aarch64/mod.rs
+++ b/hypervisor/src/arch/aarch64/mod.rs
@@ -1,3 +1,18 @@
 // Copyright 2022 Arm Limited (or its affiliates). All rights reserved.
 
 pub mod gic;
+
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
+pub struct StandardRegisters {
+    pub gpr: [u64; 31usize],    // 31 General Purpose Registers
+    pub sp: u64,                // Stack Pointer
+    pub pc: u64,                // Program Counter
+    pub pstate: u64,            // Program Status Register
+    pub sp_el1: u64,            // Stack Pointer for EL1
+    pub elr_el1: u64,           // Exception Link Register for EL1
+    pub spsr: [u64; 5usize],    // Saved Program Status Registers
+    pub vregs: [u128; 32usize], // 32 Floating Point Registers
+    pub fpsr: u64,              // Floating point status register
+    pub fpcr: u64,              // Floating point control register
+}

--- a/hypervisor/src/arch/aarch64/mod.rs
+++ b/hypervisor/src/arch/aarch64/mod.rs
@@ -30,3 +30,7 @@ pub struct VcpuInit {
     pub target: u32,
     pub features: [u32; 7usize],
 }
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
+pub struct RegList(pub Vec<u64>);

--- a/hypervisor/src/arch/aarch64/mod.rs
+++ b/hypervisor/src/arch/aarch64/mod.rs
@@ -23,3 +23,10 @@ pub struct Register {
     pub id: u64,
     pub addr: u64,
 }
+
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
+pub struct VcpuInit {
+    pub target: u32,
+    pub features: [u32; 7usize],
+}

--- a/hypervisor/src/arch/aarch64/mod.rs
+++ b/hypervisor/src/arch/aarch64/mod.rs
@@ -16,3 +16,10 @@ pub struct StandardRegisters {
     pub fpsr: u64,              // Floating point status register
     pub fpcr: u64,              // Floating point control register
 }
+
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
+pub struct Register {
+    pub id: u64,
+    pub addr: u64,
+}

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -9,9 +9,7 @@
 //
 
 #[cfg(target_arch = "aarch64")]
-use crate::aarch64::RegList;
-#[cfg(target_arch = "aarch64")]
-use crate::arch::aarch64::{StandardRegisters, VcpuInit};
+use crate::arch::aarch64::{RegList, StandardRegisters, VcpuInit};
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::{
     CpuIdEntry, FpuState, LapicState, MsrEntry, SpecialRegisters, StandardRegisters,

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -9,9 +9,9 @@
 //
 
 #[cfg(target_arch = "aarch64")]
-use crate::aarch64::{RegList, VcpuInit};
+use crate::aarch64::RegList;
 #[cfg(target_arch = "aarch64")]
-use crate::arch::aarch64::StandardRegisters;
+use crate::arch::aarch64::{StandardRegisters, VcpuInit};
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::{
     CpuIdEntry, FpuState, LapicState, MsrEntry, SpecialRegisters, StandardRegisters,

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -9,7 +9,9 @@
 //
 
 #[cfg(target_arch = "aarch64")]
-use crate::aarch64::{RegList, StandardRegisters, VcpuInit};
+use crate::aarch64::{RegList, VcpuInit};
+#[cfg(target_arch = "aarch64")]
+use crate::arch::aarch64::StandardRegisters;
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::{
     CpuIdEntry, FpuState, LapicState, MsrEntry, SpecialRegisters, StandardRegisters,

--- a/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
+++ b/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
@@ -206,6 +206,7 @@ pub fn construct_gicr_typers(vcpu_states: &[CpuState]) -> Vec<u64> {
             .sys_regs
             .into_iter()
             .filter(|reg| reg.id == KVM_ARM64_SYSREG_MPIDR_EL1)
+            .map(|reg| reg.into())
             .collect();
         //calculate affinity
         let mut cpu_affid = mpidr[0].addr & 1095233437695;

--- a/hypervisor/src/kvm/aarch64/mod.rs
+++ b/hypervisor/src/kvm/aarch64/mod.rs
@@ -16,7 +16,7 @@ use kvm_bindings::{
     kvm_mp_state, kvm_one_reg, kvm_regs, KVM_REG_ARM_COPROC_MASK, KVM_REG_ARM_CORE,
     KVM_REG_SIZE_MASK, KVM_REG_SIZE_U32, KVM_REG_SIZE_U64,
 };
-pub use kvm_bindings::{kvm_vcpu_init, user_fpsimd_state, user_pt_regs, RegList};
+pub use kvm_bindings::{kvm_vcpu_init, user_fpsimd_state, user_pt_regs};
 use serde::{Deserialize, Serialize};
 pub use {kvm_ioctls::Cap, kvm_ioctls::Kvm};
 

--- a/hypervisor/src/kvm/aarch64/mod.rs
+++ b/hypervisor/src/kvm/aarch64/mod.rs
@@ -10,13 +10,14 @@
 
 pub mod gic;
 
+use crate::arch::aarch64::StandardRegisters;
 use crate::kvm::{KvmError, KvmResult};
 use kvm_bindings::{
     kvm_mp_state, kvm_one_reg, kvm_regs, KVM_REG_ARM_COPROC_MASK, KVM_REG_ARM_CORE,
     KVM_REG_SIZE_MASK, KVM_REG_SIZE_U32, KVM_REG_SIZE_U64,
 };
 pub use kvm_bindings::{
-    kvm_one_reg as Register, kvm_regs as StandardRegisters, kvm_vcpu_init as VcpuInit, RegList,
+    kvm_one_reg as Register, kvm_vcpu_init as VcpuInit, user_fpsimd_state, user_pt_regs, RegList,
 };
 use serde::{Deserialize, Serialize};
 pub use {kvm_ioctls::Cap, kvm_ioctls::Kvm};
@@ -120,4 +121,44 @@ pub struct VcpuKvmState {
     pub mp_state: kvm_mp_state,
     pub core_regs: kvm_regs,
     pub sys_regs: Vec<kvm_one_reg>,
+}
+
+impl From<StandardRegisters> for kvm_regs {
+    fn from(regs: StandardRegisters) -> Self {
+        Self {
+            regs: user_pt_regs {
+                regs: regs.gpr,
+                sp: regs.sp,
+                pc: regs.pc,
+                pstate: regs.pstate,
+            },
+            sp_el1: regs.sp_el1,
+            elr_el1: regs.elr_el1,
+            spsr: regs.spsr,
+            fp_regs: user_fpsimd_state {
+                vregs: regs.vregs,
+                fpsr: regs.fpsr as u32,
+                fpcr: regs.fpcr as u32,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+}
+
+impl From<kvm_regs> for StandardRegisters {
+    fn from(regs: kvm_regs) -> Self {
+        Self {
+            gpr: regs.regs.regs,
+            sp: regs.regs.sp,
+            pc: regs.regs.pc,
+            pstate: regs.regs.pstate,
+            sp_el1: regs.sp_el1,
+            elr_el1: regs.elr_el1,
+            spsr: regs.spsr,
+            vregs: regs.fp_regs.vregs,
+            fpsr: regs.fp_regs.fpsr as u64,
+            fpcr: regs.fp_regs.fpcr as u64,
+        }
+    }
 }

--- a/hypervisor/src/kvm/aarch64/mod.rs
+++ b/hypervisor/src/kvm/aarch64/mod.rs
@@ -10,15 +10,13 @@
 
 pub mod gic;
 
-use crate::arch::aarch64::StandardRegisters;
+use crate::arch::aarch64::{Register, StandardRegisters};
 use crate::kvm::{KvmError, KvmResult};
 use kvm_bindings::{
     kvm_mp_state, kvm_one_reg, kvm_regs, KVM_REG_ARM_COPROC_MASK, KVM_REG_ARM_CORE,
     KVM_REG_SIZE_MASK, KVM_REG_SIZE_U32, KVM_REG_SIZE_U64,
 };
-pub use kvm_bindings::{
-    kvm_one_reg as Register, kvm_vcpu_init as VcpuInit, user_fpsimd_state, user_pt_regs, RegList,
-};
+pub use kvm_bindings::{kvm_vcpu_init as VcpuInit, user_fpsimd_state, user_pt_regs, RegList};
 use serde::{Deserialize, Serialize};
 pub use {kvm_ioctls::Cap, kvm_ioctls::Kvm};
 
@@ -159,6 +157,24 @@ impl From<kvm_regs> for StandardRegisters {
             vregs: regs.fp_regs.vregs,
             fpsr: regs.fp_regs.fpsr as u64,
             fpcr: regs.fp_regs.fpcr as u64,
+        }
+    }
+}
+
+impl From<Register> for kvm_one_reg {
+    fn from(reg: Register) -> Self {
+        Self {
+            id: reg.id,
+            addr: reg.addr,
+        }
+    }
+}
+
+impl From<kvm_one_reg> for Register {
+    fn from(reg: kvm_one_reg) -> Self {
+        Self {
+            id: reg.id,
+            addr: reg.addr,
         }
     }
 }

--- a/hypervisor/src/kvm/aarch64/mod.rs
+++ b/hypervisor/src/kvm/aarch64/mod.rs
@@ -10,13 +10,13 @@
 
 pub mod gic;
 
-use crate::arch::aarch64::{Register, StandardRegisters};
+use crate::arch::aarch64::{Register, StandardRegisters, VcpuInit};
 use crate::kvm::{KvmError, KvmResult};
 use kvm_bindings::{
     kvm_mp_state, kvm_one_reg, kvm_regs, KVM_REG_ARM_COPROC_MASK, KVM_REG_ARM_CORE,
     KVM_REG_SIZE_MASK, KVM_REG_SIZE_U32, KVM_REG_SIZE_U64,
 };
-pub use kvm_bindings::{kvm_vcpu_init as VcpuInit, user_fpsimd_state, user_pt_regs, RegList};
+pub use kvm_bindings::{kvm_vcpu_init, user_fpsimd_state, user_pt_regs, RegList};
 use serde::{Deserialize, Serialize};
 pub use {kvm_ioctls::Cap, kvm_ioctls::Kvm};
 
@@ -175,6 +175,24 @@ impl From<kvm_one_reg> for Register {
         Self {
             id: reg.id,
             addr: reg.addr,
+        }
+    }
+}
+
+impl From<VcpuInit> for kvm_vcpu_init {
+    fn from(vcpu_init: VcpuInit) -> Self {
+        Self {
+            target: vcpu_init.target,
+            features: vcpu_init.features,
+        }
+    }
+}
+
+impl From<kvm_vcpu_init> for VcpuInit {
+    fn from(vcpu_init: kvm_vcpu_init) -> Self {
+        Self {
+            target: vcpu_init.target,
+            features: vcpu_init.features,
         }
     }
 }

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -155,7 +155,7 @@ pub enum IoEventAddress {
 pub enum CpuState {
     #[cfg(feature = "kvm")]
     Kvm(kvm::VcpuKvmState),
-    #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
+    #[cfg(feature = "mshv")]
     Mshv(mshv::VcpuMshvState),
 }
 

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -33,7 +33,7 @@ pub mod arch;
 pub mod kvm;
 
 /// Microsoft Hypervisor implementation module
-#[cfg(all(feature = "mshv", target_arch = "x86_64"))]
+#[cfg(feature = "mshv")]
 pub mod mshv;
 
 /// Hypervisor related module
@@ -140,7 +140,7 @@ pub const USER_MEMORY_REGION_ADJUSTABLE: u32 = 1 << 4;
 pub enum MpState {
     #[cfg(feature = "kvm")]
     Kvm(kvm_bindings::kvm_mp_state),
-    #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
+    #[cfg(feature = "mshv")]
     Mshv, /* MSHV does not support MpState yet */
 }
 

--- a/hypervisor/src/mshv/aarch64/mod.rs
+++ b/hypervisor/src/mshv/aarch64/mod.rs
@@ -1,0 +1,6 @@
+// Copyright © 2024, Microsoft Corporation
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct VcpuMshvState {}

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1191,12 +1191,12 @@ impl cpu::Vcpu for MshvVcpu {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn set_regs(&self, regs: &StandardRegisters) -> cpu::Result<()> {
+    fn set_regs(&self, _regs: &crate::arch::aarch64::StandardRegisters) -> cpu::Result<()> {
         unimplemented!()
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn get_regs(&self) -> cpu::Result<StandardRegisters> {
+    fn get_regs(&self) -> cpu::Result<crate::arch::aarch64::StandardRegisters> {
         unimplemented!()
     }
 

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -3,18 +3,21 @@
 // Copyright © 2020, Microsoft Corporation
 //
 
+#[cfg(target_arch = "x86_64")]
 use crate::arch::emulator::{PlatformEmulator, PlatformError};
-
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::emulator::{Emulator, EmulatorCpuState};
 use crate::cpu;
+#[cfg(target_arch = "x86_64")]
 use crate::cpu::Vcpu;
 use crate::hypervisor;
 use crate::vec_with_array_field;
 use crate::vm::{self, InterruptSourceConfig, VmOps};
 use crate::HypervisorType;
 pub use mshv_bindings::*;
-use mshv_ioctls::{set_registers_64, InterruptRequest, Mshv, NoDatamatch, VcpuFd, VmFd, VmType};
+#[cfg(target_arch = "x86_64")]
+use mshv_ioctls::{set_registers_64, InterruptRequest};
+use mshv_ioctls::{Mshv, NoDatamatch, VcpuFd, VmFd, VmType};
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -61,6 +61,12 @@ use std::sync::Mutex;
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::gic::{Vgic, VgicConfig};
 
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
+
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::VcpuMshvState;
+
 const DIRTY_BITMAP_CLEAR_DIRTY: u64 = 0x4;
 const DIRTY_BITMAP_SET_DIRTY: u64 = 0x8;
 

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -53,7 +53,7 @@ use std::os::unix::io::AsRawFd;
 use crate::arch::x86::{CpuIdEntry, FpuState, MsrEntry};
 
 #[cfg(target_arch = "aarch64")]
-use crate::arch::aarch64::VcpuInit;
+use crate::arch::aarch64::{RegList, VcpuInit};
 
 const DIRTY_BITMAP_CLEAR_DIRTY: u64 = 0x4;
 const DIRTY_BITMAP_SET_DIRTY: u64 = 0x8;
@@ -1184,7 +1184,7 @@ impl cpu::Vcpu for MshvVcpu {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn get_reg_list(&self, reg_list: &mut RegList) -> cpu::Result<()> {
+    fn get_reg_list(&self, _reg_list: &mut RegList) -> cpu::Result<()> {
         unimplemented!()
     }
 

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -239,6 +239,11 @@ impl hypervisor::Hypervisor for MshvHypervisor {
         HypervisorType::Mshv
     }
 
+    #[cfg(target_arch = "aarch64")]
+    fn get_host_ipa_limit(&self) -> i32 {
+        unimplemented!()
+    }
+
     fn create_vm_with_type(&self, vm_type: u64) -> hypervisor::Result<Arc<dyn crate::Vm>> {
         let mshv_vm_type: VmType = match VmType::try_from(vm_type) {
             Ok(vm_type) => vm_type,

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -52,6 +52,9 @@ use std::os::unix::io::AsRawFd;
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::{CpuIdEntry, FpuState, MsrEntry};
 
+#[cfg(target_arch = "aarch64")]
+use crate::arch::aarch64::VcpuInit;
+
 const DIRTY_BITMAP_CLEAR_DIRTY: u64 = 0x4;
 const DIRTY_BITMAP_SET_DIRTY: u64 = 0x8;
 
@@ -1186,7 +1189,7 @@ impl cpu::Vcpu for MshvVcpu {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn vcpu_init(&self, kvi: &VcpuInit) -> cpu::Result<()> {
+    fn vcpu_init(&self, _kvi: &VcpuInit) -> cpu::Result<()> {
         unimplemented!()
     }
 
@@ -2062,7 +2065,7 @@ impl vm::Vm for MshvVm {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn get_preferred_target(&self, kvi: &mut VcpuInit) -> vm::Result<()> {
+    fn get_preferred_target(&self, _kvi: &mut VcpuInit) -> vm::Result<()> {
         unimplemented!()
     }
 }

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -55,6 +55,12 @@ use crate::arch::x86::{CpuIdEntry, FpuState, MsrEntry};
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::{RegList, VcpuInit};
 
+#[cfg(target_arch = "aarch64")]
+use std::sync::Mutex;
+
+#[cfg(target_arch = "aarch64")]
+use crate::arch::aarch64::gic::{Vgic, VgicConfig};
+
 const DIRTY_BITMAP_CLEAR_DIRTY: u64 = 0x4;
 const DIRTY_BITMAP_SET_DIRTY: u64 = 0x8;
 
@@ -1164,7 +1170,7 @@ impl cpu::Vcpu for MshvVcpu {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn init_pmu(&self, irq: u32) -> cpu::Result<()> {
+    fn init_pmu(&self, _irq: u32) -> cpu::Result<()> {
         unimplemented!()
     }
 
@@ -1174,12 +1180,12 @@ impl cpu::Vcpu for MshvVcpu {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn setup_regs(&self, cpu_id: u8, boot_ip: u64, fdt_start: u64) -> cpu::Result<()> {
+    fn setup_regs(&self, _cpu_id: u8, _boot_ip: u64, _fdt_start: u64) -> cpu::Result<()> {
         unimplemented!()
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn get_sys_reg(&self, sys_reg: u32) -> cpu::Result<u64> {
+    fn get_sys_reg(&self, _sys_reg: u32) -> cpu::Result<u64> {
         unimplemented!()
     }
 
@@ -1309,7 +1315,7 @@ impl cpu::Vcpu for MshvVcpu {
     ///
     /// Set CPU state for aarch64 guest.
     ///
-    fn set_state(&self, state: &CpuState) -> cpu::Result<()> {
+    fn set_state(&self, _state: &CpuState) -> cpu::Result<()> {
         unimplemented!()
     }
 
@@ -2060,7 +2066,7 @@ impl vm::Vm for MshvVm {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn create_vgic(&self, config: VgicConfig) -> vm::Result<Arc<Mutex<dyn Vgic>>> {
+    fn create_vgic(&self, _config: VgicConfig) -> vm::Result<Arc<Mutex<dyn Vgic>>> {
         unimplemented!()
     }
 

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -9,9 +9,9 @@
 //
 
 #[cfg(target_arch = "aarch64")]
-use crate::aarch64::VcpuInit;
-#[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::gic::{Vgic, VgicConfig};
+#[cfg(target_arch = "aarch64")]
+use crate::arch::aarch64::VcpuInit;
 #[cfg(feature = "tdx")]
 use crate::arch::x86::CpuIdEntry;
 use crate::cpu::Vcpu;

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -415,7 +415,7 @@ impl Vcpu {
     /// Initializes an aarch64 specific vcpu for booting Linux.
     #[cfg(target_arch = "aarch64")]
     pub fn init(&self, vm: &Arc<dyn hypervisor::Vm>) -> Result<()> {
-        let mut kvi: kvm_bindings::kvm_vcpu_init = kvm_bindings::kvm_vcpu_init::default();
+        let mut kvi = VcpuInit::default();
 
         // This reads back the kernel's preferred target type.
         vm.get_preferred_target(&mut kvi)
@@ -2891,11 +2891,10 @@ mod tests {
 #[cfg(test)]
 mod tests {
     use arch::{aarch64::regs, layout};
-    use hypervisor::arch::aarch64::StandardRegisters;
+    use hypervisor::arch::aarch64::{StandardRegisters, VcpuInit};
     use hypervisor::kvm::aarch64::is_system_register;
     use hypervisor::kvm::kvm_bindings::{
-        kvm_vcpu_init, user_pt_regs, KVM_REG_ARM64, KVM_REG_ARM64_SYSREG, KVM_REG_ARM_CORE,
-        KVM_REG_SIZE_U64,
+        user_pt_regs, KVM_REG_ARM64, KVM_REG_ARM64_SYSREG, KVM_REG_ARM_CORE, KVM_REG_SIZE_U64,
     };
     use hypervisor::{arm64_core_reg_id, offset_of};
     use std::mem;
@@ -2910,7 +2909,7 @@ mod tests {
         // Must fail when vcpu is not initialized yet.
         assert!(res.is_err());
 
-        let mut kvi: kvm_vcpu_init = kvm_vcpu_init::default();
+        let mut kvi = VcpuInit::default();
         vm.get_preferred_target(&mut kvi).unwrap();
         vcpu.vcpu_init(&kvi).unwrap();
 
@@ -2922,7 +2921,7 @@ mod tests {
         let hv = hypervisor::new().unwrap();
         let vm = hv.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0, None).unwrap();
-        let mut kvi: kvm_vcpu_init = kvm_vcpu_init::default();
+        let mut kvi = VcpuInit::default();
         vm.get_preferred_target(&mut kvi).unwrap();
 
         // Must fail when vcpu is not initialized yet.
@@ -2946,7 +2945,7 @@ mod tests {
         let hv = hypervisor::new().unwrap();
         let vm = hv.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0, None).unwrap();
-        let mut kvi: kvm_vcpu_init = kvm_vcpu_init::default();
+        let mut kvi = VcpuInit::default();
         vm.get_preferred_target(&mut kvi).unwrap();
 
         // Must fail when vcpu is not initialized yet.
@@ -2979,7 +2978,7 @@ mod tests {
         let hv = hypervisor::new().unwrap();
         let vm = hv.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0, None).unwrap();
-        let mut kvi: kvm_vcpu_init = kvm_vcpu_init::default();
+        let mut kvi = VcpuInit::default();
         vm.get_preferred_target(&mut kvi).unwrap();
 
         let res = vcpu.get_mp_state();

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -43,7 +43,9 @@ use gdbstub_arch::aarch64::reg::AArch64CoreRegs as CoreRegs;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use gdbstub_arch::x86::reg::{X86SegmentRegs, X86_64CoreRegs as CoreRegs};
 #[cfg(all(target_arch = "aarch64", feature = "guest_debug"))]
-use hypervisor::aarch64::StandardRegisters;
+use hypervisor::arch::aarch64::StandardRegisters;
+#[cfg(target_arch = "aarch64")]
+use hypervisor::arch::aarch64::VcpuInit;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use hypervisor::arch::x86::msr_index;
 #[cfg(target_arch = "x86_64")]
@@ -2383,9 +2385,9 @@ impl Debuggable for CpuManager {
             .get_regs(cpu_id as u8)
             .map_err(DebuggableError::ReadRegs)?;
         Ok(CoreRegs {
-            x: gregs.regs.regs,
-            sp: gregs.regs.sp,
-            pc: gregs.regs.pc,
+            x: gregs.gpr,
+            sp: gregs.sp,
+            pc: gregs.pc,
             ..Default::default()
         })
     }
@@ -2454,9 +2456,9 @@ impl Debuggable for CpuManager {
             .get_regs(cpu_id as u8)
             .map_err(DebuggableError::ReadRegs)?;
 
-        gregs.regs.regs = regs.x;
-        gregs.regs.sp = regs.sp;
-        gregs.regs.pc = regs.pc;
+        gregs.gpr = regs.x;
+        gregs.sp = regs.sp;
+        gregs.pc = regs.pc;
 
         self.set_regs(cpu_id as u8, &gregs)
             .map_err(DebuggableError::WriteRegs)?;
@@ -2889,10 +2891,11 @@ mod tests {
 #[cfg(test)]
 mod tests {
     use arch::{aarch64::regs, layout};
+    use hypervisor::arch::aarch64::StandardRegisters;
     use hypervisor::kvm::aarch64::is_system_register;
     use hypervisor::kvm::kvm_bindings::{
-        kvm_regs, kvm_vcpu_init, user_pt_regs, KVM_REG_ARM64, KVM_REG_ARM64_SYSREG,
-        KVM_REG_ARM_CORE, KVM_REG_SIZE_U64,
+        kvm_vcpu_init, user_pt_regs, KVM_REG_ARM64, KVM_REG_ARM64_SYSREG, KVM_REG_ARM_CORE,
+        KVM_REG_SIZE_U64,
     };
     use hypervisor::{arm64_core_reg_id, offset_of};
     use std::mem;
@@ -2954,7 +2957,7 @@ mod tests {
             "Failed to get core register: Exec format error (os error 8)"
         );
 
-        let mut state = kvm_regs::default();
+        let mut state = StandardRegisters::default();
         let res = vcpu.set_regs(&state);
         assert!(res.is_err());
         assert_eq!(
@@ -2966,7 +2969,7 @@ mod tests {
         let res = vcpu.get_regs();
         assert!(res.is_ok());
         state = res.unwrap();
-        assert_eq!(state.regs.pstate, 0x3C5);
+        assert_eq!(state.pstate, 0x3C5);
 
         assert!(vcpu.set_regs(&state).is_ok());
     }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -459,7 +459,7 @@ fn create_vmm_ioctl_seccomp_rule_kvm() -> Result<Vec<SeccompRule>, BackendError>
     Ok(arch_rules)
 }
 
-#[cfg(all(target_arch = "x86_64", feature = "mshv"))]
+#[cfg(feature = "mshv")]
 fn create_vmm_ioctl_seccomp_rule_mshv() -> Result<Vec<SeccompRule>, BackendError> {
     create_vmm_ioctl_seccomp_rule_common(HypervisorType::Mshv)
 }


### PR DESCRIPTION
Some of these structs were left out on aarch64 when we were trying to unify CloudHypervisor binaries for MSHV and KVM. Currently we are using the structs defined in kvm_bindings which won't work for MSHV. Thus, define hypervisor agnostic variants for these structs.