### PR TITLE
openapi: add  missing pvpanic property to VmConfig

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -615,6 +615,9 @@ components:
         watchdog:
           type: boolean
           default: false
+        pvpanic:
+          type: boolean
+          default: false
         platform:
           $ref: "#/components/schemas/PlatformConfig"
         tpm:


### PR DESCRIPTION
Hello, if i'm not wrong, the pvpanic boolean is missing in the api specification on the VmConfig model.