### PR TITLE
vmm: add pci_segment mmio aperture configs

### DIFF
--- a/docs/vfio.md
+++ b/docs/vfio.md
@@ -123,3 +123,30 @@ $ ls /sys/kernel/iommu_groups/22/devices/
 This means these two devices are under the same IOMMU group 22. In such case,
 it is important to bind both devices to VFIO and pass them both through the
 VM, otherwise this could cause some functional and security issues.
+
+### Advanced Configuration Options
+
+Some VFIO devices have a 32-bit mmio BAR. When using many such devices, it is
+possible to exhaust the 32-bit mmio space available on a PCI segment. The
+following example demonstrates an example device with a 16 MiB 32-bit mmio BAR.
+```
+lspci -s 0000:01:00.0  -v
+0000:01:00.0 3D controller: NVIDIA Corporation Device 26b9 (rev a1)
+    [...]
+    Memory at f9000000 (32-bit, non-prefetchable) [size=16M]
+    Memory at 46000000000 (64-bit, prefetchable) [size=64G]
+    Memory at 48040000000 (64-bit, prefetchable) [size=32M]
+    [...]
+```
+
+When using multiple PCI segments, the 32-bit mmio address space available to
+be allocated to VFIO devices is equally split between all PCI segments by
+default. This can be tuned with the `--pci-segment` flag. The following example
+demonstrates a guest with two PCI segments. 2/3 of the 32-bit mmio address
+space is available for use by devices on PCI segment 0 and 1/3 of the 32-bit
+mmio address space is available for use by devices on PCI segment 1.
+```
+--platform num_pci_segments=2
+--pci-segment pci_segment=0,mmio32_aperture_weight=2
+--pci-segment pci_segment=1,mmio32_aperture_weight=1
+```

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -187,6 +187,7 @@ impl RequestHandler for StubApiRequestHandler {
                 watchdog: false,
                 #[cfg(feature = "guest_debug")]
                 gdb: false,
+                pci_segments: None,
                 platform: None,
                 tpm: None,
                 preserved_fds: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,6 +356,13 @@ fn create_app(default_vcpus: String, default_memory: String, default_rng: String
                 .group("vm-config"),
         )
         .arg(
+            Arg::new("pci-segment")
+                .long("pci-segment")
+                .help(config::PciSegmentConfig::SYNTAX)
+                .num_args(1..)
+                .group("vm-config"),
+        )
+        .arg(
             Arg::new("watchdog")
                 .long("watchdog")
                 .help("Enable virtio-watchdog")
@@ -934,6 +941,7 @@ mod unit_tests {
             watchdog: false,
             #[cfg(feature = "guest_debug")]
             gdb: false,
+            pci_segments: None,
             platform: None,
             tpm: None,
             preserved_fds: None,

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -618,6 +618,10 @@ components:
         pvpanic:
           type: boolean
           default: false
+        pci_segments:
+          type: array
+          items:
+            $ref: "#/components/schemas/PciSegmentConfig"
         platform:
           $ref: "#/components/schemas/PlatformConfig"
         tpm:
@@ -682,6 +686,21 @@ components:
             $ref: "#/components/schemas/CpuAffinity"
         features:
           $ref: "#/components/schemas/CpuFeatures"
+
+    PciSegmentConfig:
+      required:
+        - pci_segment
+      type: object
+      properties:
+        pci_segment:
+          type: integer
+          format: int16
+        mmio32_aperture_weight:
+          type: integer
+          format: int32
+        mmio64_aperture_weight:
+          type: integer
+          format: int32
 
     PlatformConfig:
       type: object

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2151,6 +2151,7 @@ mod unit_tests {
             watchdog: false,
             #[cfg(feature = "guest_debug")]
             gdb: false,
+            pci_segments: None,
             platform: None,
             tpm: None,
             preserved_fds: None,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -94,6 +94,22 @@ pub struct PlatformConfig {
     pub sev_snp: bool,
 }
 
+pub const DEFAULT_PCI_SEGMENT_APERTURE_WEIGHT: u32 = 1;
+
+fn default_pci_segment_aperture_weight() -> u32 {
+    DEFAULT_PCI_SEGMENT_APERTURE_WEIGHT
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct PciSegmentConfig {
+    #[serde(default)]
+    pub pci_segment: u16,
+    #[serde(default = "default_pci_segment_aperture_weight")]
+    pub mmio32_aperture_weight: u32,
+    #[serde(default = "default_pci_segment_aperture_weight")]
+    pub mmio64_aperture_weight: u32,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct MemoryZoneConfig {
     pub id: String,
@@ -620,6 +636,7 @@ pub struct VmConfig {
     #[cfg(feature = "guest_debug")]
     #[serde(default)]
     pub gdb: bool,
+    pub pci_segments: Option<Vec<PciSegmentConfig>>,
     pub platform: Option<PlatformConfig>,
     pub tpm: Option<TpmConfig>,
     // Preserved FDs are the ones that share the same life-time as its holding


### PR DESCRIPTION
When using multiple PCI segments, the 32-bit and 64-bit mmio aperture is split equally between each segment. Add an option to configure the 'weight'. For example, a PCI segment with a `mmio32_aperture_weight` of 2 will be allocated twice as much 32-bit mmio space as a normal PCI segment.

## Alternatives Considered
I considered adding a `mmio32_aperture_size` config instead of `mmio32_aperture_weight` config to precisely configure the size of the mmio apertures for each segment. I chose to not implement this because the logic to implement that correctly was a lot more complicated. Also, allocating mmio space between PCI segments does not actually require that level of precision.

##  Use Case
Unfortunately, some devices actually use quite a bit of 32-bit MMIO space. For example, a NVIDIA NVSwitch device uses 32 MB of 32-bit mmio. When using a few PCI segments and a few NVSwitch VFIO devices, you can quickly overwhelm the default 32-bit mmio allocation for a PCI segment. 

## Example
The following example allocates 2 PCI segments. The first segment is allocated 1/4 of the available mmio32 space. The second segment is allocated 3/4 of the available mmio32 space.
```
--platform pci_segments=3
--pci-segment pci_segment=1,mmio32_aperture_weight=1
--pci-segment pci_segment=2,mmio32_aperture_weight=3
```

## Backward Compatability
This is completely backwards compatible. By default, each PCI segment has a aperture weight of 1. 