### PR TITLE
hypervisor: rework VP state components

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -107,13 +107,27 @@ pub enum HypervisorCpuError {
     ///
     /// Setting Saved Processor Extended States error
     ///
+    #[cfg(feature = "kvm")]
     #[error("Failed to set Saved Processor Extended States: {0}")]
     SetXsaveState(#[source] anyhow::Error),
     ///
     /// Getting Saved Processor Extended States error
     ///
+    #[cfg(feature = "kvm")]
     #[error("Failed to get Saved Processor Extended States: {0}")]
     GetXsaveState(#[source] anyhow::Error),
+    ///
+    /// Getting the VP state components error
+    ///
+    #[cfg(feature = "mshv")]
+    #[error("Failed to get VP State Components: {0}")]
+    GetAllVpStateComponents(#[source] anyhow::Error),
+    ///
+    /// Setting the VP state components error
+    ///
+    #[cfg(feature = "mshv")]
+    #[error("Failed to set VP State Components: {0}")]
+    SetAllVpStateComponents(#[source] anyhow::Error),
     ///
     /// Setting Extended Control Registers error
     ///

--- a/hypervisor/src/mshv/x86_64/mod.rs
+++ b/hypervisor/src/mshv/x86_64/mod.rs
@@ -19,10 +19,10 @@ use std::fmt;
 ///
 pub use {
     mshv_bindings::hv_cpuid_entry, mshv_bindings::mshv_user_mem_region as MemoryRegion,
-    mshv_bindings::msr_entry, mshv_bindings::CpuId, mshv_bindings::DebugRegisters,
-    mshv_bindings::FloatingPointUnit, mshv_bindings::LapicState as MshvLapicState,
-    mshv_bindings::MiscRegs as MiscRegisters, mshv_bindings::MsrList,
-    mshv_bindings::Msrs as MsrEntries, mshv_bindings::Msrs,
+    mshv_bindings::msr_entry, mshv_bindings::AllVpStateComponents, mshv_bindings::CpuId,
+    mshv_bindings::DebugRegisters, mshv_bindings::FloatingPointUnit,
+    mshv_bindings::LapicState as MshvLapicState, mshv_bindings::MiscRegs as MiscRegisters,
+    mshv_bindings::MsrList, mshv_bindings::Msrs as MsrEntries, mshv_bindings::Msrs,
     mshv_bindings::SegmentRegister as MshvSegmentRegister,
     mshv_bindings::SpecialRegisters as MshvSpecialRegisters,
     mshv_bindings::StandardRegisters as MshvStandardRegisters, mshv_bindings::SuspendRegisters,
@@ -38,10 +38,9 @@ pub struct VcpuMshvState {
     pub sregs: MshvSpecialRegisters,
     pub fpu: FpuState,
     pub xcrs: ExtendedControlRegisters,
-    pub lapic: LapicState,
     pub dbg: DebugRegisters,
-    pub xsave: Xsave,
     pub misc: MiscRegisters,
+    pub vp_states: AllVpStateComponents,
 }
 
 impl fmt::Display for VcpuMshvState {
@@ -53,7 +52,7 @@ impl fmt::Display for VcpuMshvState {
             msr_entries[i][1] = entry.data;
             msr_entries[i][0] = entry.index as u64;
         }
-        write!(f, "Number of MSRs: {}: MSRs: {:#010X?}, -- VCPU Events: {:?} -- Standard registers: {:?} Special Registers: {:?} ---- Floating Point Unit: {:?} --- Extended Control Register: {:?} --- Local APIC: {:?} --- DBG: {:?} --- Xsave: {:?}",
+        write!(f, "Number of MSRs: {}: MSRs: {:#010X?}, -- VCPU Events: {:?} -- Standard registers: {:?} Special Registers: {:?} ---- Floating Point Unit: {:?} --- Extended Control Register: {:?} --- DBG: {:?} --- VP States: {:?}",
                 msr_entries.len(),
                 msr_entries,
                 self.vcpu_events,
@@ -61,9 +60,8 @@ impl fmt::Display for VcpuMshvState {
                 self.sregs,
                 self.fpu,
                 self.xcrs,
-                self.lapic,
                 self.dbg,
-                self.xsave,
+                self.vp_states,
         )
     }
 }


### PR DESCRIPTION
On Microsoft Hypervisor, we need to save/restore five VP state components which are as follows:
	1. Local APIC
	2. Xsave
	3. Synthetic Message Page
	4. Synthetic Event Flags Page
	5. Synthetic Timers

In the MSHV crate we created a single struct for all the components and API to get/set the states.