### PR TITLE
Bump kvm-bindings and required changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,19 +1162,20 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.7.0"
-source = "git+https://github.com/cloud-hypervisor/kvm-bindings?branch=ch-v0.7.0#2dcf85d4f8aa55befcaa996b699ddb18ec9ed059"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82e7e8725a39a0015e511a46cc1f7d90cecc180db1610c4d0d4339a9e48bd21"
 dependencies = [
  "serde",
- "serde_derive",
  "vmm-sys-util",
+ "zerocopy",
 ]
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9002dff009755414f22b962ec6ae6980b07d6d8b06e5297b1062019d72bd6a8c"
+checksum = "bedae2ca4a531bebe311abaf9691f5cc14eaa21475243caa2e39c43bb872947d"
 dependencies = [
  "bitflags 2.5.0",
  "kvm-bindings",
@@ -1324,7 +1325,7 @@ checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 [[package]]
 name = "mshv-bindings"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#ef8fd01cf48b2e72bd6405a613a6ef65b43729d7"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#fed467ffa4e910d37fc5cd0012f6d59f4a8009d8"
 dependencies = [
  "libc",
  "num_enum",
@@ -1337,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "mshv-ioctls"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#ef8fd01cf48b2e72bd6405a613a6ef65b43729d7"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#fed467ffa4e910d37fc5cd0012f6d59f4a8009d8"
 dependencies = [
  "libc",
  "mshv-bindings",
@@ -2336,7 +2337,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#4e937a514d9025f953eeb837fb8dafe035d9a8fd"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#da8c5b67095fb70f5ef237ca63d316219888f015"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -2344,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#4e937a514d9025f953eeb837fb8dafe035d9a8fd"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#da8c5b67095fb70f5ef237ca63d316219888f015"
 dependencies = [
  "byteorder",
  "kvm-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,6 @@ vmm-sys-util = "0.12.1"
 vm-memory = "0.14.1"
 zbus = { version = "3.15.2", optional = true }
 
-# List of patched crates
-[patch.crates-io]
-kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.7.0" }
-
 [dev-dependencies]
 dirs = "5.0.1"
 net_util = { path = "net_util" }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -456,19 +456,20 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.7.0"
-source = "git+https://github.com/cloud-hypervisor/kvm-bindings?branch=ch-v0.7.0#2dcf85d4f8aa55befcaa996b699ddb18ec9ed059"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82e7e8725a39a0015e511a46cc1f7d90cecc180db1610c4d0d4339a9e48bd21"
 dependencies = [
  "serde",
- "serde_derive",
  "vmm-sys-util",
+ "zerocopy",
 ]
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9002dff009755414f22b962ec6ae6980b07d6d8b06e5297b1062019d72bd6a8c"
+checksum = "bedae2ca4a531bebe311abaf9691f5cc14eaa21475243caa2e39c43bb872947d"
 dependencies = [
  "bitflags 2.5.0",
  "kvm-bindings",
@@ -837,7 +838,7 @@ dependencies = [
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#0daff4d4c159e842cf18b8b90457a45032b2df5a"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#da8c5b67095fb70f5ef237ca63d316219888f015"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -845,7 +846,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#0daff4d4c159e842cf18b8b90457a45032b2df5a"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#da8c5b67095fb70f5ef237ca63d316219888f015"
 dependencies = [
  "byteorder",
  "kvm-bindings",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -34,9 +34,6 @@ vm-virtio = { path = "../vm-virtio" }
 [dependencies.cloud-hypervisor]
 path = ".."
 
-[patch.crates-io]
-kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.7.0" }
-
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -18,8 +18,8 @@ igvm_defs = { git = "https://github.com/microsoft/igvm", branch = "main", packag
 igvm_parser = { git = "https://github.com/microsoft/igvm", branch = "main", package = "igvm", optional  = true }
 libc = "0.2.153"
 log = "0.4.21"
-kvm-ioctls = { version = "0.16.0", optional = true }
-kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.7.0", features = ["with-serde", "fam-wrappers"], optional  = true }
+kvm-bindings = { version = "0.8.1", optional = true, features = ["serde"] }
+kvm-ioctls = { version = "0.17.0", optional = true }
 mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
 mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional  = true}
 serde = { version = "1.0.197", features = ["rc", "derive"] }

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -286,15 +286,9 @@ pub enum HypervisorCpuError {
 }
 
 #[derive(Debug)]
-pub enum VmExit<'a> {
-    #[cfg(target_arch = "x86_64")]
-    IoOut(u16 /* port */, &'a [u8] /* data */),
-    #[cfg(target_arch = "x86_64")]
-    IoIn(u16 /* port */, &'a mut [u8] /* data */),
+pub enum VmExit {
     #[cfg(target_arch = "x86_64")]
     IoapicEoi(u8 /* vector */),
-    MmioRead(u64 /* address */, &'a mut [u8]),
-    MmioWrite(u64 /* address */, &'a [u8]),
     Ignore,
     Reset,
     Shutdown,

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1625,7 +1625,7 @@ impl cpu::Vcpu for KvmVcpu {
                             .map_err(|e| cpu::HypervisorCpuError::RunVcpu(e.into()));
                     }
 
-                    Ok(cpu::VmExit::IoIn(addr, data))
+                    Ok(cpu::VmExit::Ignore)
                 }
                 #[cfg(target_arch = "x86_64")]
                 VcpuExit::IoOut(addr, data) => {
@@ -1636,7 +1636,7 @@ impl cpu::Vcpu for KvmVcpu {
                             .map_err(|e| cpu::HypervisorCpuError::RunVcpu(e.into()));
                     }
 
-                    Ok(cpu::VmExit::IoOut(addr, data))
+                    Ok(cpu::VmExit::Ignore)
                 }
                 #[cfg(target_arch = "x86_64")]
                 VcpuExit::IoapicEoi(vector) => Ok(cpu::VmExit::IoapicEoi(vector)),
@@ -1669,7 +1669,7 @@ impl cpu::Vcpu for KvmVcpu {
                             .map_err(|e| cpu::HypervisorCpuError::RunVcpu(e.into()));
                     }
 
-                    Ok(cpu::VmExit::MmioRead(addr, data))
+                    Ok(cpu::VmExit::Ignore)
                 }
                 VcpuExit::MmioWrite(addr, data) => {
                     if let Some(vm_ops) = &self.vm_ops {
@@ -1679,7 +1679,7 @@ impl cpu::Vcpu for KvmVcpu {
                             .map_err(|e| cpu::HypervisorCpuError::RunVcpu(e.into()));
                     }
 
-                    Ok(cpu::VmExit::MmioWrite(addr, data))
+                    Ok(cpu::VmExit::Ignore)
                 }
                 VcpuExit::Hyperv => Ok(cpu::VmExit::Hyperv),
                 #[cfg(feature = "tdx")]

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -13,7 +13,7 @@ use crate::hypervisor;
 use crate::vec_with_array_field;
 use crate::vm::{self, InterruptSourceConfig, VmOps};
 use crate::HypervisorType;
-pub use mshv_bindings::*;
+use mshv_bindings::*;
 use mshv_ioctls::{set_registers_64, InterruptRequest, Mshv, NoDatamatch, VcpuFd, VmFd, VmType};
 use std::any::Any;
 use std::collections::HashMap;

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1147,15 +1147,6 @@ impl CpuManager {
                                             unreachable!("Couldn't get a mutable reference from Arc<dyn Vcpu> as there are multiple instances");
                                         }
                                     }
-                                    _ => {
-                                        error!(
-                                            "VCPU generated error: {:?}",
-                                            Error::UnexpectedVmExit
-                                        );
-                                        vcpu_run_interrupted.store(true, Ordering::SeqCst);
-                                        exit_evt.write(1).unwrap();
-                                        break;
-                                    }
                                 },
 
                                 Err(e) => {

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -20,7 +20,7 @@ use igvm_defs::IGVM_VHS_PARAMETER;
 use igvm_defs::IGVM_VHS_PARAMETER_INSERT;
 
 use igvm_parser::snp_defs::SevVmsa;
-pub use mshv_bindings::*;
+use mshv_bindings::*;
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::io::Read;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3246,17 +3246,11 @@ pub fn test_vm() {
 
     loop {
         match vcpu.run().expect("run failed") {
-            VmExit::IoOut(addr, data) => {
-                println!(
-                    "IO out -- addr: {:#x} data [{:?}]",
-                    addr,
-                    str::from_utf8(data).unwrap()
-                );
-            }
             VmExit::Reset => {
                 println!("HLT");
                 break;
             }
+            VmExit::Ignore => {}
             r => panic!("unexpected exit reason: {r:?}"),
         }
     }


### PR DESCRIPTION
- **hypervisor: Remove unused VmExit enum members**
- **hypervisor: kvm: Introduce Mutex around VcpuFd**
- **build: Bump kvm-bindings and crates that depend on it**
