### PR TITLE
build: Mark release as draft when creating GitHub releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,6 +88,7 @@ jobs:
         if: github.event_name == 'create' && github.event.ref_type == 'tag'
         uses: softprops/action-gh-release@v1
         with:
+          draft: true
           files: |
             ./${{ matrix.platform.name_ch }}
             ./${{ matrix.platform.name_ch_remote }}


### PR DESCRIPTION
The maintainer can then replace the plaintext body (derived from the
tag) with a markdown version and then publish.

As part of 6c4144e94301923ade98ee81fa53e5d655a3e7dc creating a draft
release was accidentally dropped.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
