### PR TITLE
[DO NOT MERGE] Update reworked MSHV hypervisor interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
  "log",
  "micro_http",
  "mshv-bindings",
+ "mshv-ioctls",
  "net_util",
  "once_cell",
  "option_parser",

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -52,9 +52,6 @@ use std::os::unix::io::AsRawFd;
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::{CpuIdEntry, FpuState, MsrEntry};
 
-const DIRTY_BITMAP_CLEAR_DIRTY: u64 = 0x4;
-const DIRTY_BITMAP_SET_DIRTY: u64 = 0x8;
-
 ///
 /// Export generically-named wrappers of mshv-bindings for Unix-based platforms
 ///
@@ -67,18 +64,12 @@ pub const PAGE_SHIFT: usize = 12;
 
 impl From<mshv_user_mem_region> for UserMemoryRegion {
     fn from(region: mshv_user_mem_region) -> Self {
-        let mut flags: u32 = 0;
-        if region.flags & HV_MAP_GPA_READABLE != 0 {
-            flags |= USER_MEMORY_REGION_READ;
-        }
-        if region.flags & HV_MAP_GPA_WRITABLE != 0 {
+        let mut flags: u32 = USER_MEMORY_REGION_READ | USER_MEMORY_REGION_ADJUSTABLE;
+        if region.flags & (1 << MSHV_MAP_GPA_BIT_WRITABLE) != 0 {
             flags |= USER_MEMORY_REGION_WRITE;
         }
-        if region.flags & HV_MAP_GPA_EXECUTABLE != 0 {
+        if region.flags & (1 << MSHV_MAP_GPA_BIT_EXECUTABLE) != 0 {
             flags |= USER_MEMORY_REGION_EXECUTE;
-        }
-        if region.flags & HV_MAP_GPA_ADJUSTABLE != 0 {
-            flags |= USER_MEMORY_REGION_ADJUSTABLE;
         }
 
         UserMemoryRegion {
@@ -113,18 +104,12 @@ impl From<ClockData> for MshvClockData {
 
 impl From<UserMemoryRegion> for mshv_user_mem_region {
     fn from(region: UserMemoryRegion) -> Self {
-        let mut flags: u32 = 0;
-        if region.flags & USER_MEMORY_REGION_READ != 0 {
-            flags |= HV_MAP_GPA_READABLE;
-        }
+        let mut flags: u8 = 0;
         if region.flags & USER_MEMORY_REGION_WRITE != 0 {
-            flags |= HV_MAP_GPA_WRITABLE;
+            flags |= 1 << MSHV_MAP_GPA_BIT_WRITABLE;
         }
         if region.flags & USER_MEMORY_REGION_EXECUTE != 0 {
-            flags |= HV_MAP_GPA_EXECUTABLE;
-        }
-        if region.flags & USER_MEMORY_REGION_ADJUSTABLE != 0 {
-            flags |= HV_MAP_GPA_ADJUSTABLE;
+            flags |= 1 << MSHV_MAP_GPA_BIT_EXECUTABLE;
         }
 
         mshv_user_mem_region {
@@ -132,6 +117,7 @@ impl From<UserMemoryRegion> for mshv_user_mem_region {
             size: region.memory_size,
             userspace_addr: region.userspace_addr,
             flags,
+            ..Default::default()
         }
     }
 }
@@ -516,8 +502,7 @@ impl cpu::Vcpu for MshvVcpu {
 
     #[allow(non_upper_case_globals)]
     fn run(&self) -> std::result::Result<cpu::VmExit, cpu::HypervisorCpuError> {
-        let hv_message: hv_message = hv_message::default();
-        match self.fd.run(hv_message) {
+        match self.fd.run() {
             Ok(x) => match x.header.message_type {
                 hv_message_type_HVMSG_X64_HALT => {
                     debug!("HALT");
@@ -677,16 +662,21 @@ impl cpu::Vcpu for MshvVcpu {
 
                     let mut gpa_list =
                         vec_with_array_field::<mshv_modify_gpa_host_access, u64>(gpas.len());
-                    gpa_list[0].gpa_list_size = gpas.len() as u64;
-                    gpa_list[0].host_access = host_vis;
-                    gpa_list[0].acquire = 0;
+                    gpa_list[0].page_count = gpas.len() as u64;
                     gpa_list[0].flags = 0;
+                    if host_vis & HV_MAP_GPA_READABLE != 0 {
+                        gpa_list[0].flags |= 1 << MSHV_GPA_HOST_ACCESS_BIT_READABLE;
+                    }
+                    if host_vis & HV_MAP_GPA_WRITABLE != 0 {
+                        gpa_list[0].flags |= 1 << MSHV_GPA_HOST_ACCESS_BIT_WRITABLE;
+                    }
 
                     // SAFETY: gpa_list initialized with gpas.len() and now it is being turned into
                     // gpas_slice with gpas.len() again. It is guaranteed to be large enough to hold
                     // everything from gpas.
                     unsafe {
-                        let gpas_slice: &mut [u64] = gpa_list[0].gpa_list.as_mut_slice(gpas.len());
+                        let gpas_slice: &mut [u64] =
+                            gpa_list[0].guest_pfns.as_mut_slice(gpas.len());
                         gpas_slice.copy_from_slice(gpas.as_slice());
                     }
 
@@ -1834,9 +1824,9 @@ impl vm::Vm for MshvVm {
         readonly: bool,
         _log_dirty_pages: bool,
     ) -> UserMemoryRegion {
-        let mut flags = HV_MAP_GPA_READABLE | HV_MAP_GPA_EXECUTABLE | HV_MAP_GPA_ADJUSTABLE;
+        let mut flags = 1 << MSHV_MAP_GPA_BIT_EXECUTABLE;
         if !readonly {
-            flags |= HV_MAP_GPA_WRITABLE;
+            flags |= 1 << MSHV_MAP_GPA_BIT_WRITABLE;
         }
 
         mshv_user_mem_region {
@@ -1844,6 +1834,7 @@ impl vm::Vm for MshvVm {
             guest_pfn: guest_phys_addr >> PAGE_SHIFT,
             size: memory_size,
             userspace_addr,
+            ..Default::default()
         }
         .into()
     }
@@ -1924,7 +1915,11 @@ impl vm::Vm for MshvVm {
         // This is a requirement from Microsoft Hypervisor
         for (_, s) in dirty_log_slots.iter() {
             self.fd
-                .get_dirty_log(s.guest_pfn, s.memory_size as usize, DIRTY_BITMAP_SET_DIRTY)
+                .get_dirty_log(
+                    s.guest_pfn,
+                    s.memory_size as usize,
+                    MSHV_GPAP_ACCESS_OP_SET as u8,
+                )
                 .map_err(|e| vm::HypervisorVmError::StartDirtyLog(e.into()))?;
         }
         self.fd
@@ -1941,7 +1936,7 @@ impl vm::Vm for MshvVm {
             .get_dirty_log(
                 base_gpa >> PAGE_SHIFT,
                 memory_size as usize,
-                DIRTY_BITMAP_CLEAR_DIRTY,
+                MSHV_GPAP_ACCESS_OP_CLEAR as u8,
             )
             .map_err(|e| vm::HypervisorVmError::GetDirtyLog(e.into()))
     }
@@ -1994,20 +1989,20 @@ impl vm::Vm for MshvVm {
         page_size: u32,
         pages: &[u64],
     ) -> vm::Result<()> {
+        debug_assert!(page_size == hv_isolated_page_size_HV_ISOLATED_PAGE_SIZE_4KB);
         if pages.is_empty() {
             return Ok(());
         }
 
         let mut isolated_pages =
             vec_with_array_field::<mshv_import_isolated_pages, u64>(pages.len());
-        isolated_pages[0].num_pages = pages.len() as u64;
-        isolated_pages[0].page_type = page_type;
-        isolated_pages[0].page_size = page_size;
+        isolated_pages[0].page_type = page_type as u8;
+        isolated_pages[0].page_count = pages.len() as u64;
         // SAFETY: isolated_pages initialized with pages.len() and now it is being turned into
         // pages_slice with pages.len() again. It is guaranteed to be large enough to hold
         // everything from pages.
         unsafe {
-            let pages_slice: &mut [u64] = isolated_pages[0].page_number.as_mut_slice(pages.len());
+            let pages_slice: &mut [u64] = isolated_pages[0].guest_pfns.as_mut_slice(pages.len());
             pages_slice.copy_from_slice(pages);
         }
         self.fd

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -11,7 +11,7 @@ guest_debug = ["kvm", "gdbstub", "gdbstub_arch"]
 igvm = ["hex", "dep:igvm", "igvm_defs",  "mshv-bindings", "range_map_vec"]
 io_uring = ["block/io_uring"]
 kvm = ["hypervisor/kvm", "vfio-ioctls/kvm", "vm-device/kvm", "pci/kvm"]
-mshv = ["hypervisor/mshv", "vfio-ioctls/mshv", "vm-device/mshv", "pci/mshv"]
+mshv = ["mshv-ioctls", "hypervisor/mshv", "vfio-ioctls/mshv", "vm-device/mshv", "pci/mshv"]
 sev_snp = ["arch/sev_snp", "hypervisor/sev_snp"]
 tdx = ["arch/tdx", "hypervisor/tdx"]
 tracing = ["tracer/tracing"]
@@ -42,6 +42,7 @@ linux-loader = { version = "0.11.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.21"
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
+mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional  = true }
 net_util = { path = "../net_util" }
 once_cell = "1.19.0"
 option_parser = { path = "../option_parser" }

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -153,106 +153,80 @@ use kvm::*;
 
 // MSHV IOCTL code. This is unstable until the kernel code has been declared stable.
 #[cfg(feature = "mshv")]
-mod mshv {
-    pub const MSHV_GET_API_VERSION: u64 = 0xb800;
-    pub const MSHV_CREATE_VM: u64 = 0x4028_b801;
-    pub const MSHV_MAP_GUEST_MEMORY: u64 = 0x4020_b802;
-    pub const MSHV_UNMAP_GUEST_MEMORY: u64 = 0x4020_b803;
-    pub const MSHV_CREATE_VP: u64 = 0x4004_b804;
-    pub const MSHV_IRQFD: u64 = 0x4010_b80e;
-    pub const MSHV_IOEVENTFD: u64 = 0x4020_b80f;
-    pub const MSHV_SET_MSI_ROUTING: u64 = 0x4008_b811;
-    pub const MSHV_GET_VP_REGISTERS: u64 = 0xc010_b805;
-    pub const MSHV_SET_VP_REGISTERS: u64 = 0x4010_b806;
-    pub const MSHV_RUN_VP: u64 = 0x8100_b807;
-    pub const MSHV_GET_VP_STATE: u64 = 0xc010_b80a;
-    pub const MSHV_SET_VP_STATE: u64 = 0xc010_b80b;
-    pub const MSHV_SET_PARTITION_PROPERTY: u64 = 0x4010_b80c;
-    pub const MSHV_GET_PARTITION_PROPERTY: u64 = 0xc010_b80d;
-    pub const MSHV_GET_GPA_ACCESS_STATES: u64 = 0xc01c_b812;
-    pub const MSHV_VP_TRANSLATE_GVA: u64 = 0xc020_b80e;
-    pub const MSHV_CREATE_PARTITION: u64 = 0x4030_b801;
-    pub const MSHV_CREATE_DEVICE: u64 = 0xc00c_b813;
-    pub const MSHV_SET_DEVICE_ATTR: u64 = 0x4018_b814;
-    pub const MSHV_VP_REGISTER_INTERCEPT_RESULT: u64 = 0x4030_b817;
-    pub const MSHV_GET_VP_CPUID_VALUES: u64 = 0xc028_b81b;
-    pub const MSHV_MODIFY_GPA_HOST_ACCESS: u64 = 0x4018_b828;
-    pub const MSHV_IMPORT_ISOLATED_PAGES: u64 = 0x4010_b829;
-    pub const MSHV_COMPLETE_ISOLATED_IMPORT: u64 = 0x4d06_b830;
-    pub const MSHV_READ_GPA: u64 = 0xc020_b832;
-    pub const MSHV_WRITE_GPA: u64 = 0x4020_b833;
-    pub const MSHV_SEV_SNP_AP_CREATE: u64 = 0x4010_b834;
-    pub const MSHV_ISSUE_PSP_GUEST_REQUEST: u64 = 0x4010_b831;
-    pub const MSHV_ASSERT_INTERRUPT: u64 = 0x4018_b809;
-    pub const MSHV_ROOT_HVCALL: u64 = 0xc020_b835;
-}
-#[cfg(feature = "mshv")]
-use mshv::*;
+use mshv_ioctls::*;
 
 #[cfg(feature = "mshv")]
 fn create_vmm_ioctl_seccomp_rule_common_mshv() -> Result<Vec<SeccompRule>, BackendError> {
     Ok(or![
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_API_VERSION,)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_CREATE_VM)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_MAP_GUEST_MEMORY)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_UNMAP_GUEST_MEMORY)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_CREATE_VP)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_IRQFD)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_IOEVENTFD)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_MSI_ROUTING)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_REGISTERS)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_VP_REGISTERS)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_RUN_VP)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_ASSERT_INTERRUPT)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_STATE)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_VP_STATE)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VERSION_INFO(),)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_CREATE_PARTITION())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_MAP_GUEST_MEMORY())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_UNMAP_GUEST_MEMORY())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_CREATE_VP())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_IRQFD())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_IOEVENTFD())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_MSI_ROUTING())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_REGISTERS())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_VP_REGISTERS())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_RUN_VP())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_STATE())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_VP_STATE())?],
         and![Cond::new(
             1,
             ArgLen::Dword,
             Eq,
-            MSHV_SET_PARTITION_PROPERTY
+            MSHV_SET_PARTITION_PROPERTY()
         )?],
         and![Cond::new(
             1,
             ArgLen::Dword,
             Eq,
-            MSHV_GET_PARTITION_PROPERTY
+            MSHV_VP_REGISTER_INTERCEPT_RESULT()
         )?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_GPA_ACCESS_STATES)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_VP_TRANSLATE_GVA)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_CREATE_PARTITION)?],
         and![Cond::new(
             1,
             ArgLen::Dword,
             Eq,
-            MSHV_VP_REGISTER_INTERCEPT_RESULT
+            MSHV_GET_PARTITION_PROPERTY()
         )?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_CREATE_DEVICE)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_DEVICE_ATTR)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_CPUID_VALUES)?],
         and![Cond::new(
             1,
             ArgLen::Dword,
             Eq,
-            MSHV_MODIFY_GPA_HOST_ACCESS
+            MSHV_GET_GPAP_ACCESS_BITMAP()
         )?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_IMPORT_ISOLATED_PAGES)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_VP_TRANSLATE_GVA())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_CREATE_DEVICE())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_DEVICE_ATTR())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_CPUID_VALUES())?],
         and![Cond::new(
             1,
             ArgLen::Dword,
             Eq,
-            MSHV_COMPLETE_ISOLATED_IMPORT
+            MSHV_MODIFY_GPA_HOST_ACCESS()
         )?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_READ_GPA)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_WRITE_GPA)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SEV_SNP_AP_CREATE)?],
         and![Cond::new(
             1,
             ArgLen::Dword,
             Eq,
-            MSHV_ISSUE_PSP_GUEST_REQUEST
+            MSHV_IMPORT_ISOLATED_PAGES()
         )?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_ROOT_HVCALL)?],
+        and![Cond::new(
+            1,
+            ArgLen::Dword,
+            Eq,
+            MSHV_COMPLETE_ISOLATED_IMPORT()
+        )?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_READ_GPA())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_WRITE_GPA())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SEV_SNP_AP_CREATE())?],
+        and![Cond::new(
+            1,
+            ArgLen::Dword,
+            Eq,
+            MSHV_ISSUE_PSP_GUEST_REQUEST()
+        )?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_ROOT_HVCALL())?],
     ])
 }
 
@@ -708,33 +682,32 @@ fn create_vcpu_ioctl_seccomp_rule_kvm() -> Result<Vec<SeccompRule>, BackendError
 #[cfg(feature = "mshv")]
 fn create_vcpu_ioctl_seccomp_rule_mshv() -> Result<Vec<SeccompRule>, BackendError> {
     Ok(or![
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_MSI_ROUTING)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_IOEVENTFD)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_IRQFD)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_RUN_VP)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_REGISTERS)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_VP_REGISTERS)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_MAP_GUEST_MEMORY)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_UNMAP_GUEST_MEMORY)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_ASSERT_INTERRUPT)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_VP_TRANSLATE_GVA)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_CPUID_VALUES)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_MSI_ROUTING())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_IOEVENTFD())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_IRQFD())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_RUN_VP())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_REGISTERS())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_VP_REGISTERS())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_MAP_GUEST_MEMORY())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_UNMAP_GUEST_MEMORY())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_VP_TRANSLATE_GVA())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_CPUID_VALUES())?],
         and![Cond::new(
             1,
             ArgLen::Dword,
             Eq,
-            MSHV_MODIFY_GPA_HOST_ACCESS
+            MSHV_MODIFY_GPA_HOST_ACCESS()
         )?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_READ_GPA)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_WRITE_GPA)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SEV_SNP_AP_CREATE)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_READ_GPA())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_WRITE_GPA())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SEV_SNP_AP_CREATE())?],
         and![Cond::new(
             1,
             ArgLen::Dword,
             Eq,
-            MSHV_ISSUE_PSP_GUEST_REQUEST
+            MSHV_ISSUE_PSP_GUEST_REQUEST()
         )?],
-        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_ROOT_HVCALL)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, MSHV_ROOT_HVCALL())?],
     ])
 }
 


### PR DESCRIPTION
Several kernel (and mshv crate) interfaces have been reworked. Update these.
Also, change the mshv seccomp IOCTL numbers so that they are no longer hardcoded but are pulled directly from the mshv crate.

See: https://github.com/rust-vmm/mshv/pull/149
This PR will be ready once the other components are merged (and an additional commit added to update the mshv crate version).

