### PR TITLE
vmm: openapi: Do not provide default values for required fields

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -667,11 +667,9 @@ components:
       properties:
         boot_vcpus:
           minimum: 1
-          default: 1
           type: integer
         max_vcpus:
           minimum: 1
-          default: 1
           type: integer
         topology:
           $ref: "#/components/schemas/CpuTopology"
@@ -736,7 +734,6 @@ components:
         size:
           type: integer
           format: int64
-          default: 512 MB
         file:
           type: string
         mergeable:
@@ -772,7 +769,6 @@ components:
         size:
           type: integer
           format: int64
-          default: 512 MB
         hotplug_size:
           type: integer
           format: int64
@@ -857,7 +853,7 @@ components:
           type: string
         rate_limiter_config:
           $ref: "#/components/schemas/RateLimiterConfig"
-    
+
     VirtQueueAffinity:
       required:
         - queue_index
@@ -963,7 +959,6 @@ components:
       properties:
         src:
           type: string
-          default: "/dev/urandom"
         iommu:
           type: boolean
           default: false


### PR DESCRIPTION
This is to resolve the inconsistencies from our openapi specification, as default values do not make sense for required fields.

Reported-by: James O. D. Hunt <james.o.hunt@intel.com>