### PR TITLE
tests: Re-enable live upgrade tests

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -134,7 +134,7 @@ update_workloads() {
     popd || exit
 
     # Download Cloud Hypervisor binary from its last stable release
-    LAST_RELEASE_VERSION="v36.0"
+    LAST_RELEASE_VERSION="v39.0"
     CH_RELEASE_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$LAST_RELEASE_VERSION/cloud-hypervisor-static-aarch64"
     CH_RELEASE_NAME="cloud-hypervisor-static-aarch64"
     pushd "$WORKLOADS_DIR" || exit

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -45,7 +45,7 @@ fi
 popd || exit
 
 # Download Cloud Hypervisor binary from its last stable release
-LAST_RELEASE_VERSION="v36.0"
+LAST_RELEASE_VERSION="v39.0"
 CH_RELEASE_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$LAST_RELEASE_VERSION/cloud-hypervisor-static"
 CH_RELEASE_NAME="cloud-hypervisor-static"
 pushd "$WORKLOADS_DIR" || exit

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9757,51 +9757,43 @@ mod live_migration {
         }
 
         #[test]
-        #[ignore = "See #6134"]
         fn test_live_upgrade_basic() {
             _test_live_migration(true, false)
         }
 
         #[test]
-        #[ignore = "See #6134"]
         fn test_live_upgrade_local() {
             _test_live_migration(true, true)
         }
 
         #[test]
-        #[ignore = "See #6134"]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_numa() {
             _test_live_migration_numa(true, false)
         }
 
         #[test]
-        #[ignore = "See #6134"]
         #[cfg(not(feature = "mshv"))]
         fn test_live_upgrade_numa_local() {
             _test_live_migration_numa(true, true)
         }
 
         #[test]
-        #[ignore = "See #6134"]
         fn test_live_upgrade_watchdog() {
             _test_live_migration_watchdog(true, false)
         }
 
         #[test]
-        #[ignore = "See #6134"]
         fn test_live_upgrade_watchdog_local() {
             _test_live_migration_watchdog(true, true)
         }
 
         #[test]
-        #[ignore = "See #6134"]
         fn test_live_upgrade_balloon() {
             _test_live_migration_balloon(true, false)
         }
 
         #[test]
-        #[ignore = "See #6134"]
         fn test_live_upgrade_balloon_local() {
             _test_live_migration_balloon(true, true)
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9725,18 +9725,6 @@ mod live_migration {
         }
 
         #[test]
-        #[cfg(not(feature = "mshv"))]
-        fn test_live_migration_numa() {
-            _test_live_migration_numa(false, false)
-        }
-
-        #[test]
-        #[cfg(not(feature = "mshv"))]
-        fn test_live_migration_numa_local() {
-            _test_live_migration_numa(false, true)
-        }
-
-        #[test]
         fn test_live_migration_watchdog() {
             _test_live_migration_watchdog(false, false)
         }
@@ -9744,16 +9732,6 @@ mod live_migration {
         #[test]
         fn test_live_migration_watchdog_local() {
             _test_live_migration_watchdog(false, true)
-        }
-
-        #[test]
-        fn test_live_migration_balloon() {
-            _test_live_migration_balloon(false, false)
-        }
-
-        #[test]
-        fn test_live_migration_balloon_local() {
-            _test_live_migration_balloon(false, true)
         }
 
         #[test]
@@ -9767,18 +9745,6 @@ mod live_migration {
         }
 
         #[test]
-        #[cfg(not(feature = "mshv"))]
-        fn test_live_upgrade_numa() {
-            _test_live_migration_numa(true, false)
-        }
-
-        #[test]
-        #[cfg(not(feature = "mshv"))]
-        fn test_live_upgrade_numa_local() {
-            _test_live_migration_numa(true, true)
-        }
-
-        #[test]
         fn test_live_upgrade_watchdog() {
             _test_live_migration_watchdog(true, false)
         }
@@ -9786,6 +9752,22 @@ mod live_migration {
         #[test]
         fn test_live_upgrade_watchdog_local() {
             _test_live_migration_watchdog(true, true)
+        }
+    }
+
+    mod live_migration_sequential {
+        use super::*;
+
+        // NUMA & baalloon live migration tests are large so run sequentially
+
+        #[test]
+        fn test_live_migration_balloon() {
+            _test_live_migration_balloon(false, false)
+        }
+
+        #[test]
+        fn test_live_migration_balloon_local() {
+            _test_live_migration_balloon(false, true)
         }
 
         #[test]
@@ -9797,12 +9779,30 @@ mod live_migration {
         fn test_live_upgrade_balloon_local() {
             _test_live_migration_balloon(true, true)
         }
-    }
 
-    mod live_migration_sequential {
-        #[cfg(target_arch = "x86_64")]
+        #[test]
         #[cfg(not(feature = "mshv"))]
-        use super::*;
+        fn test_live_migration_numa() {
+            _test_live_migration_numa(false, false)
+        }
+
+        #[test]
+        #[cfg(not(feature = "mshv"))]
+        fn test_live_migration_numa_local() {
+            _test_live_migration_numa(false, true)
+        }
+
+        #[test]
+        #[cfg(not(feature = "mshv"))]
+        fn test_live_upgrade_numa() {
+            _test_live_migration_numa(true, false)
+        }
+
+        #[test]
+        #[cfg(not(feature = "mshv"))]
+        fn test_live_upgrade_numa_local() {
+            _test_live_migration_numa(true, true)
+        }
 
         // Require to run ovs-dpdk tests sequentially because they rely on the same ovs-dpdk setup
         #[test]


### PR DESCRIPTION
And bump release verion used to v39.0

Fixes: #6134

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
