### PR TITLE
hypervisor: mshv: Reduce the scope of VMEXITs to x86_64

### DIFF
--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -704,6 +704,7 @@ impl cpu::Vcpu for MshvVcpu {
                         )))?;
                     Ok(cpu::VmExit::Ignore)
                 }
+                #[cfg(target_arch = "x86_64")]
                 hv_message_type_HVMSG_UNACCEPTED_GPA => {
                     let info = x.to_memory_info().unwrap();
                     let gva = info.guest_virtual_address;
@@ -715,11 +716,13 @@ impl cpu::Vcpu for MshvVcpu {
                         gva,
                     )))
                 }
+                #[cfg(target_arch = "x86_64")]
                 hv_message_type_HVMSG_X64_CPUID_INTERCEPT => {
                     let info = x.to_cpuid_info().unwrap();
                     debug!("cpuid eax: {:x}", { info.rax });
                     Ok(cpu::VmExit::Ignore)
                 }
+                #[cfg(target_arch = "x86_64")]
                 hv_message_type_HVMSG_X64_MSR_INTERCEPT => {
                     let info = x.to_msr_info().unwrap();
                     if info.header.intercept_access_type == 0 {
@@ -729,6 +732,7 @@ impl cpu::Vcpu for MshvVcpu {
                     }
                     Ok(cpu::VmExit::Ignore)
                 }
+                #[cfg(target_arch = "x86_64")]
                 hv_message_type_HVMSG_X64_EXCEPTION_INTERCEPT => {
                     //TODO: Handler for VMCALL here.
                     let info = x.to_exception_info().unwrap();


### PR DESCRIPTION
Certain VMEXITs can only happen for x86 guests, thus reduce the scope to x86_64 at the compilation stage.