### PR TITLE
vmm: ch-remote: replace deprecated zbus macros with new equivalents

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -15,7 +15,7 @@ use std::marker::PhantomData;
 use std::os::unix::net::UnixStream;
 use std::process;
 #[cfg(feature = "dbus_api")]
-use zbus::{dbus_proxy, zvariant::Optional};
+use zbus::{proxy, zvariant::Optional};
 
 type ApiResult = Result<(), Error>;
 
@@ -72,7 +72,7 @@ enum TargetApi<'a> {
 }
 
 #[cfg(feature = "dbus_api")]
-#[dbus_proxy(name = "org.cloudhypervisor.DBusApi1", assume_defaults = false)]
+#[proxy(name = "org.cloudhypervisor.DBusApi1", assume_defaults = false)]
 trait DBusApi1 {
     fn vmm_ping(&self) -> zbus::Result<String>;
     fn vmm_shutdown(&self) -> zbus::Result<()>;

--- a/vmm/src/api/dbus/mod.rs
+++ b/vmm/src/api/dbus/mod.rs
@@ -25,7 +25,7 @@ use std::thread;
 use vmm_sys_util::eventfd::EventFd;
 use zbus::fdo::{self, Result};
 use zbus::zvariant::Optional;
-use zbus::{dbus_interface, ConnectionBuilder};
+use zbus::{interface, ConnectionBuilder};
 
 pub type DBusApiShutdownChannels = (oneshot::Sender<()>, oneshot::Receiver<()>);
 
@@ -105,7 +105,7 @@ impl DBusApi {
     }
 }
 
-#[dbus_interface(name = "org.cloudhypervisor.DBusApi1")]
+#[interface(name = "org.cloudhypervisor.DBusApi1")]
 impl DBusApi {
     async fn vmm_ping(&self) -> Result<String> {
         let api_sender = self.clone_api_sender().await;
@@ -301,8 +301,8 @@ impl DBusApi {
             .map(|_| ())
     }
 
-    // implementation of this function is provided by the `dbus_interface` macro
-    #[dbus_interface(signal)]
+    // implementation of this function is provided by the `#[zbus(signal)]` macro call
+    #[zbus(signal)]
     async fn event(ctxt: &zbus::SignalContext<'_>, event: Arc<String>) -> zbus::Result<()>;
 }
 


### PR DESCRIPTION
Fixes deprecation related warnings introduced in #6400.