### PR TITLE
mshv: Pin mshv crates to release tag v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,8 +1326,8 @@ checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
 name = "mshv-bindings"
-version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#76bbc508a4152d020dd42061d4505c64e320ba94"
+version = "0.2.0"
+source = "git+https://github.com/rust-vmm/mshv?tag=v0.2.0#dd0a9f5ab9c32673e88d6de200af788dbfca6a72"
 dependencies = [
  "libc",
  "num_enum",
@@ -1339,8 +1339,8 @@ dependencies = [
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#76bbc508a4152d020dd42061d4505c64e320ba94"
+version = "0.2.0"
+source = "git+https://github.com/rust-vmm/mshv?tag=v0.2.0#dd0a9f5ab9c32673e88d6de200af788dbfca6a72"
 dependencies = [
  "libc",
  "mshv-bindings",
@@ -2339,7 +2339,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#df7de6b256a1ece422804119938f6a325b2ce99b"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#64171f3da1af7926adf162ecf545cb05fb9243c9"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -2347,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#df7de6b256a1ece422804119938f6a325b2ce99b"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#64171f3da1af7926adf162ecf545cb05fb9243c9"
 dependencies = [
  "byteorder",
  "kvm-bindings",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -20,11 +20,11 @@ kvm-bindings = { version = "0.8.1", optional = true, features = ["serde"] }
 kvm-ioctls = { version = "0.17.0", optional = true }
 libc = "0.2.153"
 log = "0.4.21"
-mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = [
+mshv-bindings = { git = "https://github.com/rust-vmm/mshv", tag = "v0.2.0", features = [
   "with-serde",
   "fam-wrappers",
 ], optional = true }
-mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional = true }
+mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", tag = "v0.2.0", optional = true }
 serde = { version = "1.0.197", features = ["rc", "derive"] }
 serde_with = { version = "3.7.0", default-features = false, features = [
   "macros",

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -43,7 +43,7 @@ libc = "0.2.153"
 linux-loader = { version = "0.11.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.21"
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
-mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = [
+mshv-bindings = { git = "https://github.com/rust-vmm/mshv", tag = "v0.2.0", features = [
   "with-serde",
   "fam-wrappers",
 ], optional = true }


### PR DESCRIPTION
And bump vfio commit in Cargo.lock to align, since it should also point to mshv v0.2.0.