### PR TITLE
arch: Change the default topology for x86 guests

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -60,7 +60,9 @@ use hypervisor::kvm::kvm_ioctls::Cap;
 use hypervisor::kvm::{TdxExitDetails, TdxExitStatus};
 #[cfg(target_arch = "x86_64")]
 use hypervisor::CpuVendor;
-use hypervisor::{CpuState, HypervisorCpuError, HypervisorType, VmExit, VmOps};
+#[cfg(feature = "kvm")]
+use hypervisor::HypervisorType;
+use hypervisor::{CpuState, HypervisorCpuError, VmExit, VmOps};
 use libc::{c_void, siginfo_t};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use linux_loader::elf::Elf64_Nhdr;
@@ -846,13 +848,7 @@ impl CpuManager {
 
         #[cfg(target_arch = "x86_64")]
         let topology = self.config.topology.clone().map_or_else(
-            || {
-                #[cfg(feature = "mshv")]
-                if matches!(self.hypervisor.hypervisor_type(), HypervisorType::Mshv) {
-                    return Some((1, self.boot_vcpus(), 1));
-                }
-                None
-            },
+            || Some((1, self.boot_vcpus(), 1)),
             |t| Some((t.threads_per_core, t.cores_per_die, t.dies_per_package)),
         );
         #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
   Currently by default each core is allocated it's own socket. Basically
    it is n socket 1 core 1 thread/core kind of a structure as witnessed
    from within the guest.
```
    CPU(s):                             8
    On-line CPU(s) list:                0-7
    Thread(s) per core:                 1
    Core(s) per socket:                 1
    Socket(s):                          8
    NUMA node(s):                       1
```
   This is not a good default topology because resources are distributed
    across multiple sockets. For example, a Linux guest with multi socket
    configuration will have to calibrate TSC per socket due to which it
    might observe a higher amount of boot time than usual.

   A better idea for default topology would be 1 socket n core 1
    thread/core which ensure better resource locality.

   After this change topology would change to:

```
    CPU(s):                             8
    On-line CPU(s) list:                0-7
    Thread(s) per core:                 1
    Core(s) per socket:                 8
    Socket(s):                          1
    NUMA node(s):                       1
```

   Fixes: #6497