### PR TITLE
misc: Update description in Cargo.toml to include MSHV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["The Cloud Hypervisor Authors"]
 build = "build.rs"
 default-run = "cloud-hypervisor"
-description = "Open source Virtual Machine Monitor (VMM) that runs on top of KVM"
+description = "Open source Virtual Machine Monitor (VMM) that runs on top of KVM & MSHV"
 edition = "2021"
 homepage = "https://github.com/cloud-hypervisor/cloud-hypervisor"
 license = "LICENSE-APACHE & LICENSE-BSD-3-Clause"


### PR DESCRIPTION
Since CloudHypervisor also supports running on top of Microsoft Hypervisor (MSHV).