### PR TITLE
vmm: skip unsupported migration scene

### DIFF
--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -453,8 +453,8 @@ impl VirtioDevice for Vdpa {
 impl Pausable for Vdpa {
     fn pause(&mut self) -> std::result::Result<(), MigratableError> {
         if !self.migrating {
-            Err(MigratableError::Pause(anyhow!(
-                "Can't pause a vDPA device outside live migration"
+            Err(MigratableError::UnSupported(anyhow!(
+                "Not support to pause a vDPA device outside live migration"
             )))
         } else {
             Ok(())
@@ -463,8 +463,8 @@ impl Pausable for Vdpa {
 
     fn resume(&mut self) -> std::result::Result<(), MigratableError> {
         if !self.migrating {
-            Err(MigratableError::Resume(anyhow!(
-                "Can't resume a vDPA device outside live migration"
+            Err(MigratableError::UnSupported(anyhow!(
+                "Not support to resume a vDPA device outside live migration"
             )))
         } else {
             Ok(())
@@ -479,8 +479,8 @@ impl Snapshottable for Vdpa {
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
         if !self.migrating {
-            return Err(MigratableError::Snapshot(anyhow!(
-                "Can't snapshot a vDPA device outside live migration"
+            return Err(MigratableError::UnSupported(anyhow!(
+                "Not support to snapshot a vDPA device outside live migration"
             )));
         }
 

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -47,6 +47,9 @@ pub enum MigratableError {
 
     #[error("Failed to complete migration for migratable component: {0}")]
     CompleteMigration(#[source] anyhow::Error),
+
+    #[error("Unsupported migration: {0}")]
+    UnSupported(#[source] anyhow::Error),
 }
 
 /// A Pausable component can be paused and resumed.


### PR DESCRIPTION
vmm: skip unsupported migration scene

Fixes: #6516

This patch will fix the error in CI: https://github.com/cloud-hypervisor/cloud-hypervisor/actions/runs/9364108614/job/25808474744?pr=6508

Signed-off-by: Songqian Li <sionli@tencent.com>

