### PR TITLE
arch: x86_64: fall back to host cpuid l1 cache info if omitted by kvm

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -702,6 +702,20 @@ pub fn generate_common_cpuid(
                     }
                 }
             }
+            // Copy host L1 cache details if not populated by KVM
+            0x8000_0005 => {
+                if entry.eax == 0 && entry.ebx == 0 && entry.ecx == 0 && entry.edx == 0 {
+                    // SAFETY: cpuid called with valid leaves
+                    if unsafe { std::arch::x86_64::__cpuid(0x8000_0000).eax } >= 0x8000_0005 {
+                        // SAFETY: cpuid called with valid leaves
+                        let leaf = unsafe { std::arch::x86_64::__cpuid(0x8000_0005) };
+                        entry.eax = leaf.eax;
+                        entry.ebx = leaf.ebx;
+                        entry.ecx = leaf.ecx;
+                        entry.edx = leaf.edx;
+                    }
+                }
+            }
             // Copy host L2 cache details if not populated by KVM
             0x8000_0006 => {
                 if entry.eax == 0 && entry.ebx == 0 && entry.ecx == 0 && entry.edx == 0 {


### PR DESCRIPTION
If the KVM version is older than v6.6, `KVM_GET_SUPPORTED_CPUID` will omit the L1 cache information reported by  CPUID function `0x8000_0005` on amd64 machines. We should fall back to the host L1 cache information if it is omitted because the KVM version is older than [this commit](https://github.com/torvalds/linux/commit/af8e2ccfa6f101f505add076c1a4d56c718e0d50).

This PR is analogous to [this merged PR](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/4920) merged which added the equivalent behavior for the L2 cache information reported by CPUID function `0x8000_0006` in case it was omitted because the KVM version is older than [this commit](https://github.com/torvalds/linux/commit/43d05de2bee7561b7958628b7c27c89b779de990).