### PR TITLE
scripts: export code coverage information

### DIFF
--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -x
+
+# shellcheck source=/dev/null
+source "$HOME"/.cargo/env
+
+PROJECT_DIR="/cloud-hypervisor"
+TARGET_DIR="$PROJECT_DIR/target"
+
+pushd $PROJECT_DIR || exit
+
+export BUILD_TARGET=${BUILD_TARGET-$(uname -m)-unknown-linux-gnu}
+
+# GLIBC > 2.31
+GRCOV_RELEASE_URL="https://github.com/mozilla/grcov/releases/download/v0.8.19/grcov-$BUILD_TARGET.tar.bz2"
+wget --quiet "$GRCOV_RELEASE_URL" || exit 1
+tar -xjf "grcov-$BUILD_TARGET.tar.bz2"
+
+rustup component add llvm-tools-preview
+
+export_lcov() {
+    rm "coverage.info"
+
+    ./grcov "$(find . -name 'ch-*.profraw' -print)" -s . \
+        --ignore "tests/*" \
+        --ignore "test_infra/*" \
+        --ignore "performance-metrics/*" \
+        --binary-path "$TARGET_DIR/$BUILD_TARGET/release/" \
+        --branch --ignore-not-existing -t lcov \
+        -o "coverage.info"
+
+    find . -type f -name 'ch-*.profraw' -exec rm {} \;
+}
+
+# Generate HTML report
+export_html() {
+    OUTPUT_DIR="$TARGET_DIR/coverage"
+    rm -rf $OUTPUT_DIR
+    ./grcov "$(find . -name 'ch-*.profraw' -print)" -s . \
+        --ignore "tests/*" \
+        --ignore "test_infra/*" \
+        --ignore "performance-metrics/*" \
+        --binary-path "$TARGET_DIR/$BUILD_TARGET/release/" \
+        --branch --ignore-not-existing -t html \
+        -o $OUTPUT_DIR
+    find . -type f -name 'ch-*.profraw' -exec rm {} \;
+}
+
+# $1 is now a command name. Check if it is a valid command and, if so,
+# run it.
+#
+declare -f "export_$1" >/dev/null
+code=$?
+[[ $code == 0 ]] || echo "Unknown command: $1. Only support \"lcov\" and \"html\". Change to default command: html"
+type=${1-html}
+
+func=export_$type
+shift
+
+$func "$@"
+
+popd || exit 1

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -174,14 +174,14 @@ ulimit -l unlimited
 ulimit -n 4096
 
 export RUST_BACKTRACE=1
-time cargo test $test_features "common_parallel::$test_filter" -- ${test_binary_args[*]}
+time cargo test --release --target "$BUILD_TARGET" $test_features "common_parallel::$test_filter" -- ${test_binary_args[*]}
 RES=$?
 
 # Run some tests in sequence since the result could be affected by other tests
 # running in parallel.
 if [ $RES -eq 0 ]; then
     export RUST_BACKTRACE=1
-    time cargo test $test_features "common_sequential::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
+    time cargo test --release --target "$BUILD_TARGET" $test_features "common_sequential::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
     RES=$?
 fi
 

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -17,5 +17,5 @@ elif [[ $(uname -m) = "x86_64" ]]; then
 fi
 
 export RUST_BACKTRACE=1
-cargo test --lib --bins --target "$BUILD_TARGET" --workspace ${cargo_args[@]} || exit 1
-cargo test --doc --target "$BUILD_TARGET" --workspace ${cargo_args[@]} || exit 1
+cargo test --lib --bins --target "$BUILD_TARGET" --release --workspace ${cargo_args[@]} || exit 1
+cargo test --doc --target "$BUILD_TARGET" --release --workspace ${cargo_args[@]} || exit 1

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -809,8 +809,12 @@ pub fn kill_child(child: &mut Child) {
     }
 
     // The timeout period elapsed without the child exiting
-    if child.wait_timeout(Duration::new(5, 0)).unwrap().is_none() {
+    if child.wait_timeout(Duration::new(10, 0)).unwrap().is_none() {
         let _ = child.kill();
+        let rust_flags = env::var("RUSTFLAGS").unwrap_or_default();
+        if rust_flags.contains("-Cinstrument-coverage") {
+            panic!("Wait child timeout, please check the reason.")
+        }
     }
 }
 


### PR DESCRIPTION
scripts: export code coverage information

In this patch, we add a code coverage script to support exporting code coverage information.

Fixes: #6507

Signed-off-by: Songqian Li <sionli@tencent.com>