### PR TITLE
virtio-devices: vdpa: Not error out on resume if not paused and not restore on paused state

### DIFF
--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -151,7 +151,7 @@ impl Vdpa {
                     last: state.iova_range_last,
                 },
                 state.backend_features,
-                true,
+                false,
             )
         } else {
             let device_type = vhost.get_device_id().map_err(Error::GetDeviceId)?;

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -462,6 +462,10 @@ impl Pausable for Vdpa {
     }
 
     fn resume(&mut self) -> std::result::Result<(), MigratableError> {
+        if !self.common.paused.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
         if !self.migrating {
             Err(MigratableError::Resume(anyhow!(
                 "Can't resume a vDPA device outside live migration"


### PR DESCRIPTION
Since vdpa device does not support pause/resume [1], it does not make
sense to restore on paused state.

[1] https://github.com/cloud-hypervisor/cloud-hypervisor/commit/099cdd2af88ac6a8ede490e73ff0eb58a812bde2
