### PR TITLE
build: Fix Cargo.toml formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,17 +61,17 @@ wait-timeout = "0.2.0"
 # Please adjust `vmm::feature_list()` accordingly when changing the
 # feature list below
 [features]
-dbus_api = ["zbus", "vmm/dbus_api"]
-default = ["kvm", "io_uring"]
+dbus_api = ["vmm/dbus_api", "zbus"]
+default = ["io_uring", "kvm"]
 dhat-heap = ["dhat", "vmm/dhat-heap"]       # For heap profiling
 guest_debug = ["vmm/guest_debug"]
-igvm = ["vmm/igvm", "mshv"]
+igvm = ["mshv", "vmm/igvm"]
 io_uring = ["vmm/io_uring"]
 kvm = ["vmm/kvm"]
 mshv = ["vmm/mshv"]
-sev_snp = ["igvm", "vmm/sev_snp", "mshv"]
+sev_snp = ["igvm", "mshv", "vmm/sev_snp"]
 tdx = ["vmm/tdx"]
-tracing = ["vmm/tracing", "tracer/tracing"]
+tracing = ["tracer/tracing", "vmm/tracing"]
 
 [workspace]
 members = [
@@ -93,9 +93,9 @@ members = [
   "vhost_user_block",
   "vhost_user_net",
   "virtio-devices",
-  "vmm",
   "vm-allocator",
   "vm-device",
   "vm-migration",
   "vm-virtio",
+  "vmm",
 ]

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -14,14 +14,14 @@ anyhow = "1.0.81"
 byteorder = "1.5.0"
 hypervisor = { path = "../hypervisor" }
 libc = "0.2.153"
-linux-loader = { version = "0.11.0", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.11.0", features = ["bzimage", "elf", "pe"] }
 log = "0.4.21"
-serde = { version = "1.0.197", features = ["rc", "derive"] }
+serde = { version = "1.0.197", features = ["derive", "rc"] }
 thiserror = "1.0.60"
 uuid = "1.8.0"
 vm-memory = { version = "0.14.1", features = [
-  "backend-mmap",
   "backend-bitmap",
+  "backend-mmap",
 ] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { version = "0.12.1", features = ["with-serde"] }

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["The Cloud Hypervisor Authors", "The Chromium OS Authors"]
+authors = ["The Chromium OS Authors", "The Cloud Hypervisor Authors"]
 edition = "2021"
 name = "block"
 version = "0.1.0"
@@ -22,9 +22,9 @@ uuid = { version = "1.8.0", features = ["v4"] }
 virtio-bindings = { version = "0.2.2", features = ["virtio-v5_0_0"] }
 virtio-queue = "0.12.0"
 vm-memory = { version = "0.14.1", features = [
-  "backend-mmap",
   "backend-atomic",
   "backend-bitmap",
+  "backend-mmap",
 ] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.12.1"

--- a/event_monitor/Cargo.toml
+++ b/event_monitor/Cargo.toml
@@ -8,5 +8,5 @@ version = "0.1.0"
 flume = "0.11.0"
 libc = "0.2.153"
 once_cell = "1.19.0"
-serde = { version = "1.0.197", features = ["rc", "derive"] }
+serde = { version = "1.0.197", features = ["derive", "rc"] }
 serde_json = "1.0.115"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,7 +17,7 @@ devices = { path = "../devices" }
 epoll = "4.3.3"
 libc = "0.2.155"
 libfuzzer-sys = "0.4.7"
-linux-loader = { version = "0.11.0", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.11.0", features = ["bzimage", "elf", "pe"] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 net_util = { path = "../net_util" }
 once_cell = "1.19.0"

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -6,8 +6,8 @@ name = "hypervisor"
 version = "0.1.0"
 
 [features]
-kvm = ["kvm-ioctls", "kvm-bindings", "vfio-ioctls/kvm"]
-mshv = ["mshv-ioctls", "mshv-bindings", "vfio-ioctls/mshv", "iced-x86"]
+kvm = ["kvm-bindings", "kvm-ioctls", "vfio-ioctls/kvm"]
+mshv = ["iced-x86", "mshv-bindings", "mshv-ioctls", "vfio-ioctls/mshv"]
 sev_snp = ["igvm", "igvm_defs"]
 tdx = []
 
@@ -21,25 +21,25 @@ kvm-ioctls = { version = "0.17.0", optional = true }
 libc = "0.2.153"
 log = "0.4.21"
 mshv-bindings = { git = "https://github.com/rust-vmm/mshv", tag = "v0.2.0", features = [
-  "with-serde",
   "fam-wrappers",
+  "with-serde",
 ], optional = true }
 mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", tag = "v0.2.0", optional = true }
-serde = { version = "1.0.197", features = ["rc", "derive"] }
+serde = { version = "1.0.197", features = ["derive", "rc"] }
 serde_with = { version = "3.7.0", default-features = false, features = [
   "macros",
 ] }
 thiserror = "1.0.60"
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
 vm-memory = { version = "0.14.1", features = [
-  "backend-mmap",
   "backend-atomic",
+  "backend-mmap",
 ] }
 vmm-sys-util = { version = "0.12.1", features = ["with-serde"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]
 default-features = false
-features = ["std", "decoder", "op_code_info", "instr_info", "fast_fmt"]
+features = ["decoder", "fast_fmt", "instr_info", "op_code_info", "std"]
 optional = true
 version = "1.21.0"
 

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -16,9 +16,9 @@ thiserror = "1.0.60"
 virtio-bindings = "0.2.2"
 virtio-queue = "0.12.0"
 vm-memory = { version = "0.14.1", features = [
-  "backend-mmap",
   "backend-atomic",
   "backend-bitmap",
+  "backend-mmap",
 ] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.12.1"

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -25,9 +25,9 @@ vfio_user = { git = "https://github.com/rust-vmm/vfio-user", branch = "main" }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.14.1", features = [
-  "backend-mmap",
   "backend-atomic",
   "backend-bitmap",
+  "backend-mmap",
 ] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = "0.12.1"

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 [dependencies]
 clap = { version = "4.5.4", features = ["wrap_help"] }
 dirs = "5.0.1"
-serde = { version = "1.0.197", features = ["rc", "derive"] }
+serde = { version = "1.0.197", features = ["derive", "rc"] }
 serde_json = "1.0.115"
 test_infra = { path = "../test_infra" }
 thiserror = "1.0.60"

--- a/test_infra/Cargo.toml
+++ b/test_infra/Cargo.toml
@@ -9,7 +9,7 @@ dirs = "5.0.1"
 epoll = "4.3.3"
 libc = "0.2.153"
 once_cell = "1.19.0"
-serde = { version = "1.0.197", features = ["rc", "derive"] }
+serde = { version = "1.0.197", features = ["derive", "rc"] }
 serde_json = "1.0.115"
 ssh2 = { version = "0.9.4", features = ["vendored-openssl"] }
 vmm-sys-util = "0.12.1"

--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 libc = "0.2.153"
 log = "0.4.21"
 once_cell = "1.19.0"
-serde = { version = "1.0.197", features = ["rc", "derive"] }
+serde = { version = "1.0.197", features = ["derive", "rc"] }
 serde_json = "1.0.115"
 
 [features]

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 block = { path = "../block" }
-clap = { version = "4.5.4", features = ["wrap_help", "cargo"] }
+clap = { version = "4.5.4", features = ["cargo", "wrap_help"] }
 env_logger = "0.11.3"
 epoll = "4.3.3"
 libc = "0.2.153"

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -6,7 +6,7 @@ name = "vhost_user_net"
 version = "0.1.0"
 
 [dependencies]
-clap = { version = "4.5.4", features = ["wrap_help", "cargo"] }
+clap = { version = "4.5.4", features = ["cargo", "wrap_help"] }
 env_logger = "0.11.3"
 epoll = "4.3.3"
 libc = "0.2.153"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -30,9 +30,9 @@ serde_with = { version = "3.7.0", default-features = false, features = [
 serial_buffer = { path = "../serial_buffer" }
 thiserror = "1.0.60"
 vhost = { version = "0.11.0", features = [
-  "vhost-user-frontend",
-  "vhost-user-backend",
   "vhost-kern",
+  "vhost-user-backend",
+  "vhost-user-frontend",
   "vhost-vdpa",
 ] }
 virtio-bindings = { version = "0.2.2", features = ["virtio-v5_0_0"] }
@@ -40,9 +40,9 @@ virtio-queue = "0.12.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.14.1", features = [
-  "backend-mmap",
   "backend-atomic",
   "backend-bitmap",
+  "backend-mmap",
 ] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -12,7 +12,7 @@ mshv = ["vfio-ioctls/mshv"]
 [dependencies]
 anyhow = "1.0.81"
 hypervisor = { path = "../hypervisor" }
-serde = { version = "1.0.197", features = ["rc", "derive"] }
+serde = { version = "1.0.197", features = ["derive", "rc"] }
 thiserror = "1.0.60"
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
 vm-memory = { version = "0.14.1", features = ["backend-mmap"] }

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -6,10 +6,10 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1.0.81"
-serde = { version = "1.0.197", features = ["rc", "derive"] }
+serde = { version = "1.0.197", features = ["derive", "rc"] }
 serde_json = "1.0.115"
 thiserror = "1.0.60"
 vm-memory = { version = "0.14.1", features = [
-  "backend-mmap",
   "backend-atomic",
+  "backend-mmap",
 ] }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 log = "0.4.21"
 virtio-queue = "0.12.0"
 vm-memory = { version = "0.14.1", features = [
-  "backend-mmap",
   "backend-atomic",
   "backend-bitmap",
+  "backend-mmap",
 ] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -8,11 +8,11 @@ version = "0.1.0"
 dbus_api = ["blocking", "futures", "zbus"]
 default = []
 dhat-heap = ["dhat"]                                                         # For heap profiling
-guest_debug = ["kvm", "gdbstub", "gdbstub_arch"]
-igvm = ["hex", "dep:igvm", "igvm_defs", "mshv-bindings", "range_map_vec"]
+guest_debug = ["gdbstub", "gdbstub_arch", "kvm"]
+igvm = ["dep:igvm", "hex", "igvm_defs", "mshv-bindings", "range_map_vec"]
 io_uring = ["block/io_uring"]
-kvm = ["hypervisor/kvm", "vfio-ioctls/kvm", "vm-device/kvm", "pci/kvm"]
-mshv = ["hypervisor/mshv", "vfio-ioctls/mshv", "vm-device/mshv", "pci/mshv"]
+kvm = ["hypervisor/kvm", "pci/kvm", "vfio-ioctls/kvm", "vm-device/kvm"]
+mshv = ["hypervisor/mshv", "pci/mshv", "vfio-ioctls/mshv", "vm-device/mshv"]
 sev_snp = ["arch/sev_snp", "hypervisor/sev_snp", "virtio-devices/sev_snp"]
 tdx = ["arch/tdx", "hypervisor/tdx"]
 tracing = ["tracer/tracing"]
@@ -40,12 +40,12 @@ hypervisor = { path = "../hypervisor" }
 igvm = { version = "0.3.1", optional = true }
 igvm_defs = { version = "0.3.1", optional = true }
 libc = "0.2.153"
-linux-loader = { version = "0.11.0", features = ["elf", "bzimage", "pe"] }
+linux-loader = { version = "0.11.0", features = ["bzimage", "elf", "pe"] }
 log = "0.4.21"
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 mshv-bindings = { git = "https://github.com/rust-vmm/mshv", tag = "v0.2.0", features = [
-  "with-serde",
   "fam-wrappers",
+  "with-serde",
 ], optional = true }
 net_util = { path = "../net_util" }
 once_cell = "1.19.0"
@@ -54,7 +54,7 @@ pci = { path = "../pci" }
 range_map_vec = { version = "0.2.0", optional = true }
 rate_limiter = { path = "../rate_limiter" }
 seccompiler = "0.4.0"
-serde = { version = "1.0.197", features = ["rc", "derive"] }
+serde = { version = "1.0.197", features = ["derive", "rc"] }
 serde_json = "1.0.115"
 serial_buffer = { path = "../serial_buffer" }
 signal-hook = "0.3.17"
@@ -68,9 +68,9 @@ virtio-queue = "0.12.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.14.1", features = [
-  "backend-mmap",
   "backend-atomic",
   "backend-bitmap",
+  "backend-mmap",
 ] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }


### PR DESCRIPTION
In 42e9632c53d14cd0040db4952d40ba806c4b6ee9 a fix was made to address a
typo in the taplo configuration file. Fixing this typo indicated that
many Cargo.toml files were no longer adhering to the formatting rules.
Fix the formatting by running `taplo fmt`.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
