### PR TITLE
build: Fix license string to comply with SPDX list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-run = "cloud-hypervisor"
 description = "Open source Virtual Machine Monitor (VMM) that runs on top of KVM & MSHV"
 edition = "2021"
 homepage = "https://github.com/cloud-hypervisor/cloud-hypervisor"
-license = "LICENSE-APACHE & LICENSE-BSD-3-Clause"
+license = "Apache-2.0 AND BSD-3-Clause"
 name = "cloud-hypervisor"
 version = "40.0.0"
 # Minimum buildable version:


### PR DESCRIPTION
[cargo-cyclonedx](https://github.com/CycloneDX/cyclonedx-rust-cargo) rejects the current license key in Cargo.toml, because it doesn't comply with the SPDX standard:

```
  Package cloud-hypervisor has an invalid license expression (LICENSE-APACHE & LICENSE-BSD-3-Clause), using as named license: Invalid Lax SPDX expression: unknown term
```

Fix by using the names from the SPDX list: https://spdx.github.io/license-list-data/