### PR TITLE
docs: Mention that virtio-fs does not work with snapshot/restore

### DIFF
--- a/docs/fs.md
+++ b/docs/fs.md
@@ -6,6 +6,12 @@ directory from the host with the guest.
 __virtio-fs__, also known as __vhost-user-fs__ is a virtual device defined by
 the VIRTIO specification which allows any VMM to perform filesystem sharing.
 
+## Limitations
+
+Using __virtio-fs__ devices in combination snapshot/restore is currently not supported.
+
+The reason is that virtio-fs doesn't support migration. And more specifically, the virtiofsd daemon described below doesn't implement the migration mechanisms that are exposed by vhost-user. Only DPDK and SPDK (vhost-user-net and vhost-user-block respectively) implement the migration mechanism.
+
 ## Pre-requisites
 
 ### The daemon

--- a/docs/fs.md
+++ b/docs/fs.md
@@ -8,9 +8,13 @@ the VIRTIO specification which allows any VMM to perform filesystem sharing.
 
 ## Limitations
 
-Using __virtio-fs__ devices in combination snapshot/restore is currently not supported.
+Using __virtio-fs__ devices in combination snapshot/restore is currently not
+supported.
 
-The reason is that virtio-fs doesn't support migration. And more specifically, the virtiofsd daemon described below doesn't implement the migration mechanisms that are exposed by vhost-user. Only DPDK and SPDK (vhost-user-net and vhost-user-block respectively) implement the migration mechanism.
+The reason is that virtio-fs doesn't support migration. And more specifically,
+the virtiofsd daemon described below doesn't implement the migration mechanisms
+that are exposed by vhost-user. Only DPDK and SPDK (vhost-user-net and
+vhost-user-block respectively) implement the migration mechanism.
 
 ## Pre-requisites
 

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -8,6 +8,10 @@ snapshot and creates the exact same virtual machine, restoring the previously
 saved states. The new virtual machine is restored in a paused state, as it was
 before the snapshot was performed.
 
+## Limitations
+
+VFIO devices and Intel SGX are out of scope. For example, this includes the `--fs` option for `virtio-fs`.
+
 ## Snapshot a Cloud Hypervisor VM
 
 First thing, we must run a Cloud Hypervisor VM:
@@ -107,7 +111,3 @@ need to be provided along with the VM restore command in the following syntax:
 In the example above, the net device with id `net1` will be backed by FDs '23'
 and '24', and the net device with id `net2` will be backed by FDs '25' and '26'
 from the restored VM.
-
-## Limitations
-
-VFIO devices and Intel SGX are out of scope.

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -10,7 +10,8 @@ before the snapshot was performed.
 
 ## Limitations
 
-VFIO devices and Intel SGX are out of scope. For example, this includes the `--fs` option for `virtio-fs`.
+VFIO devices and Intel SGX are out of scope. For example, this includes the
+`--fs` option for `virtio-fs`.
 
 ## Snapshot a Cloud Hypervisor VM
 


### PR DESCRIPTION
I was looking into `--fs`, having not seen that this will not work with snapshot/restore.

This PR updates the docs for `fs.md` and `snapshot_restore.md` based on https://github.com/cloud-hypervisor/cloud-hypervisor/issues/4994#issuecomment-1346152325 to make this more apparent.