### PR TITLE
MSHV: handle GPA intercepts

### DIFF
--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -588,6 +588,7 @@ impl<'a, T: CpuStateManager> Emulator<'a, T> {
                 // Once we have the new stream, we must create a new decoder
                 // and emulate one last instruction from the last decoded IP.
                 decoder = Decoder::new(64, &fetched_insn_stream, DecoderOptions::NONE);
+                decoder.set_ip(last_decoded_ip);
                 decoder.decode_out(&mut insn);
                 if decoder.last_error() != DecoderError::None {
                     return Err(EmulationError::InstructionFetchingError(anyhow!(

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -641,7 +641,6 @@ impl cpu::Vcpu for MshvVcpu {
                 hv_message_type_HVMSG_UNMAPPED_GPA => {
                     let info = x.to_memory_info().unwrap();
                     let insn_len = info.instruction_byte_count as usize;
-                    assert!(insn_len > 0 && insn_len <= 16);
 
                     let mut context = MshvEmulatorContext {
                         vcpu: self,
@@ -653,7 +652,10 @@ impl cpu::Vcpu for MshvVcpu {
 
                     // Emulate the trapped instruction, and only the first one.
                     let new_state = emul
-                        .emulate_first_insn(self.vp_index as usize, &info.instruction_bytes)
+                        .emulate_first_insn(
+                            self.vp_index as usize,
+                            &info.instruction_bytes[..insn_len],
+                        )
                         .map_err(|e| cpu::HypervisorCpuError::RunVcpu(e.into()))?;
 
                     // Set CPU state back.

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1526,8 +1526,10 @@ impl<'a> MshvEmulatorContext<'a> {
             return Ok(self.map.1);
         }
 
-        // TODO: More fine-grained control for the flags
-        let flags = HV_TRANSLATE_GVA_VALIDATE_READ | HV_TRANSLATE_GVA_VALIDATE_WRITE;
+        // We can only get into here when executing guest code. Check for R and X permissions. In
+        // the future if we have other use cases, we may want to allow the caller to specify the
+        // flags.
+        let flags = HV_TRANSLATE_GVA_VALIDATE_READ | HV_TRANSLATE_GVA_VALIDATE_EXECUTE;
 
         let (gpa, result_code) = self
             .vcpu

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -638,13 +638,18 @@ impl cpu::Vcpu for MshvVcpu {
                     Ok(cpu::VmExit::Ignore)
                 }
                 #[cfg(target_arch = "x86_64")]
-                hv_message_type_HVMSG_UNMAPPED_GPA => {
+                msg_type @ (hv_message_type_HVMSG_UNMAPPED_GPA
+                | hv_message_type_HVMSG_GPA_INTERCEPT) => {
                     let info = x.to_memory_info().unwrap();
                     let insn_len = info.instruction_byte_count as usize;
+                    let gva = info.guest_virtual_address;
+                    let gpa = info.guest_physical_address;
+
+                    debug!("Exit ({:?}) GVA {:x} GPA {:x}", msg_type, gva, gpa);
 
                     let mut context = MshvEmulatorContext {
                         vcpu: self,
-                        map: (info.guest_virtual_address, info.guest_physical_address),
+                        map: (gva, gpa),
                     };
 
                     // Create a new emulator.


### PR DESCRIPTION
We have a new use case coming soon. It requires Cloud Hypervisor to handle a new intercept. This new intercept exposed some shortcomings in MSHV's instruction emulation.