### PR TITLE
virtio-devices: fix UB getting tty size

### DIFF
--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -608,11 +608,11 @@ fn get_win_size(tty: &dyn AsRawFd) -> (u16, u16) {
         xpixel: u16,
         ypixel: u16,
     }
-    let ws: WindowSize = WindowSize::default();
+    let mut ws: WindowSize = WindowSize::default();
 
     // SAFETY: FFI call with correct arguments
     unsafe {
-        libc::ioctl(tty.as_raw_fd(), TIOCGWINSZ, &ws);
+        libc::ioctl(tty.as_raw_fd(), TIOCGWINSZ, &mut ws);
     }
 
     (ws.cols, ws.rows)


### PR DESCRIPTION
`TIOCGWINSZ` modifies its argument, so it needs to mutably borrow it. Unfortunately, `ioctl()`'s signature is not able to enforce this, and the write happens in the kernel, so I don't think anything like miri, valgrind, UBSan, etc. would have been able to catch this.

The UB passing an immutable reference caused resulted, for me, in `get_win_size()` returning `(0, 0)` since LLVM commit
https://github.com/llvm/llvm-project/commit/9a09c737a052dc0e2b8c15a969d16cff7ea0c133 ("[BasicAA] Make isNotCapturedBeforeOrAt() check for calls more precise ([#69931](https://github.com/llvm/llvm-project/pull/69931))").

I've had a look through the other `ioctl()` calls in Cloud Hypervisor, and I don't think any others have the same problem.