### PR TITLE
Allow specifying translation flags in MSHV's x86 instruction emulator

### DIFF
--- a/hypervisor/src/arch/emulator/mod.rs
+++ b/hypervisor/src/arch/emulator/mod.rs
@@ -137,14 +137,6 @@ pub trait PlatformEmulator {
     ///
     fn set_cpu_state(&self, cpu_id: usize, state: Self::CpuState) -> Result<(), PlatformError>;
 
-    /// Translate a guest virtual address into a physical one
-    ///
-    /// # Arguments
-    ///
-    /// * `gva` - Guest virtual address to translate.
-    ///
-    fn gva_to_gpa(&self, gva: u64) -> Result<u64, PlatformError>;
-
     /// Fetch instruction bytes from memory.
     ///
     /// # Arguments

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -750,10 +750,6 @@ mod mock_vmm {
             Ok(())
         }
 
-        fn gva_to_gpa(&self, gva: u64) -> Result<u64, PlatformError> {
-            Ok(gva)
-        }
-
         fn fetch(&self, ip: u64, instruction_bytes: &mut [u8]) -> Result<(), PlatformError> {
             let rip = self
                 .state

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1640,10 +1640,6 @@ impl<'a> PlatformEmulator for MshvEmulatorContext<'a> {
             .map_err(|e| PlatformError::SetCpuStateFailure(e.into()))
     }
 
-    fn gva_to_gpa(&self, gva: u64) -> Result<u64, PlatformError> {
-        self.translate(gva)
-    }
-
     fn fetch(&self, ip: u64, instruction_bytes: &mut [u8]) -> Result<(), PlatformError> {
         let rip =
             self.cpu_state(self.vcpu.vp_index as usize)?


### PR DESCRIPTION
Our testing reveals some issues. Remove the broken assumption in code.