### PR TITLE
virtio-devices: Add VIRTIO_RING_F_EVENT_IDX to virtio-block

### DIFF
--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -122,6 +122,8 @@ pub enum Error {
     QueueAddUsed(virtio_queue::Error),
     #[error("Failed to : {0}")]
     QueueIterator(virtio_queue::Error),
+    #[error("Failed to check if queue needs notification: {0}")]
+    QueueNeedsNotification(virtio_queue::Error),
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]


### PR DESCRIPTION
Suppress notifications on the used ring through the
VIRTIO_RING_F_EVENT_IDX support that is included in virtio-queue's
Queue.

This should reduce the number of notifications in the guest and
potentially improve performance.

Fixes: #6580

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
