### PR TITLE
performance-metrics: add restore latency performance metric

### DIFF
--- a/docs/performance_metrics.md
+++ b/docs/performance_metrics.md
@@ -31,6 +31,7 @@ $ ./scripts/dev_cli.sh tests --metrics -- -- --report-file /tmp/metrics.json --t
 ```
 
 To set custom timeout or test iterations for all performance tests:
+
 ```
 $ ./scripts/dev_cli.sh tests --metrics -- -- --timeout 5 --iterations 10
 ```
@@ -70,6 +71,7 @@ data.
 |            | block_multi_queue_write_IOPS               | 10             | 5              |
 |            | block_multi_queue_random_read_IOPS         | 10             | 5              |
 |            | block_multi_queue_random_write_IOPS        | 10             | 5              |
+| Other      | restore_latency_time_ms                    | 2              | 10             |
 
 ## Output Format
 
@@ -83,7 +85,6 @@ param is set. The fields included in JSON include:
 | git_commit_date    | Commit date of HEAD                      |
 | date               | Date for executing the program           |
 | results            | A list of metrics                        |
-
 
 ## Example
 

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -274,7 +274,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 29] = [
+const TEST_LIST: [PerformanceTest; 30] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -305,6 +305,16 @@ const TEST_LIST: [PerformanceTest; 29] = [
             ..PerformanceTestControl::default()
         },
         unit_adjuster: adjuster::s_to_ms,
+    },
+    PerformanceTest {
+        name: "restore_latency_time_ms",
+        func_ptr: performance_restore_latency,
+        control: PerformanceTestControl {
+            test_timeout: 2,
+            test_iterations: 10,
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::identity,
     },
     PerformanceTest {
         name: "boot_time_16_vcpus_pmem_ms",


### PR DESCRIPTION
performance-metrics: add restore latency performance metric

This patch calculates the recovery latency from the start of recovery program to the end of restore.

Signed-off-by: Songqian Li <sionli@tencent.com>