### PR TITLE
Fix issues reported by beta clippy

### DIFF
--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -248,9 +248,8 @@ impl Request {
         let hdr_desc = desc_chain
             .next()
             .ok_or(Error::DescriptorChainTooShort)
-            .map_err(|e| {
+            .inspect_err(|_| {
                 error!("Missing head descriptor");
-                e
             })?;
 
         // The head contains the request type which MUST be readable.
@@ -276,9 +275,8 @@ impl Request {
         let mut desc = desc_chain
             .next()
             .ok_or(Error::DescriptorChainTooShort)
-            .map_err(|e| {
+            .inspect_err(|_| {
                 error!("Only head descriptor present: request = {:?}", req);
-                e
             })?;
 
         if !desc.has_next() {
@@ -309,9 +307,8 @@ impl Request {
                 desc = desc_chain
                     .next()
                     .ok_or(Error::DescriptorChainTooShort)
-                    .map_err(|e| {
+                    .inspect_err(|_| {
                         error!("DescriptorChain corrupted: request = {:?}", req);
-                        e
                     })?;
             }
             status_desc = desc;

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -411,14 +411,11 @@ mod tests {
             None,
         );
 
-        serial.write(0, DATA as u64, &[b'x', b'y']);
-        serial.write(0, DATA as u64, &[b'a']);
-        serial.write(0, DATA as u64, &[b'b']);
-        serial.write(0, DATA as u64, &[b'c']);
-        assert_eq!(
-            serial_out.buf.lock().unwrap().as_slice(),
-            &[b'a', b'b', b'c']
-        );
+        serial.write(0, DATA as u64, b"xy");
+        serial.write(0, DATA as u64, b"a");
+        serial.write(0, DATA as u64, b"b");
+        serial.write(0, DATA as u64, b"c");
+        assert_eq!(serial_out.buf.lock().unwrap().as_slice(), b"abc");
     }
 
     #[test]
@@ -436,7 +433,7 @@ mod tests {
         // counter doesn't change (for 0 it blocks)
         assert!(intr_evt.write(1).is_ok());
         serial.write(0, IER as u64, &[IER_RECV_BIT]);
-        serial.queue_input_bytes(&[b'a', b'b', b'c']).unwrap();
+        serial.queue_input_bytes(b"abc").unwrap();
 
         assert_eq!(intr_evt.read().unwrap(), 2);
 
@@ -473,7 +470,7 @@ mod tests {
         // counter doesn't change (for 0 it blocks)
         assert!(intr_evt.write(1).is_ok());
         serial.write(0, IER as u64, &[IER_THR_BIT]);
-        serial.write(0, DATA as u64, &[b'a']);
+        serial.write(0, DATA as u64, b"a");
 
         assert_eq!(intr_evt.read().unwrap(), 2);
         let mut data = [0u8];
@@ -515,9 +512,9 @@ mod tests {
         );
 
         serial.write(0, MCR as u64, &[MCR_LOOP_BIT]);
-        serial.write(0, DATA as u64, &[b'a']);
-        serial.write(0, DATA as u64, &[b'b']);
-        serial.write(0, DATA as u64, &[b'c']);
+        serial.write(0, DATA as u64, b"a");
+        serial.write(0, DATA as u64, b"b");
+        serial.write(0, DATA as u64, b"c");
 
         let mut data = [0u8];
         serial.read(0, MSR as u64, &mut data[..]);

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -524,14 +524,11 @@ mod tests {
             None,
         );
 
-        pl011.write(0, UARTDR, &[b'x', b'y']);
-        pl011.write(0, UARTDR, &[b'a']);
-        pl011.write(0, UARTDR, &[b'b']);
-        pl011.write(0, UARTDR, &[b'c']);
-        assert_eq!(
-            pl011_out.buf.lock().unwrap().as_slice(),
-            &[b'x', b'a', b'b', b'c']
-        );
+        pl011.write(0, UARTDR, b"xy");
+        pl011.write(0, UARTDR, b"a");
+        pl011.write(0, UARTDR, b"b");
+        pl011.write(0, UARTDR, b"c");
+        assert_eq!(pl011_out.buf.lock().unwrap().as_slice(), b"xabc");
     }
 
     #[test]
@@ -549,7 +546,7 @@ mod tests {
         // write 1 to the interrupt event fd, so that read doesn't block in case the event fd
         // counter doesn't change (for 0 it blocks)
         assert!(intr_evt.write(1).is_ok());
-        pl011.queue_input_bytes(&[b'a', b'b', b'c']).unwrap();
+        pl011.queue_input_bytes(b"abc").unwrap();
 
         assert_eq!(intr_evt.read().unwrap(), 2);
 

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -205,7 +205,7 @@ impl FromStr for ByteSized {
                 0
             };
 
-            let s = s.trim_end_matches(|c| c == 'K' || c == 'M' || c == 'G');
+            let s = s.trim_end_matches(['K', 'M', 'G']);
             s.parse::<u64>()
                 .map_err(|_| ByteSizedParseError::InvalidValue(s.to_owned()))?
                 << shift

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -255,7 +255,7 @@ fn measure_boot_time(cmd: &mut GuestCommand, test_timeout: u32) -> Result<f64, E
     let _ = child.kill();
     let output = child.wait_with_output().unwrap();
 
-    parse_boot_time_output(&output.stderr).map_err(|e| {
+    parse_boot_time_output(&output.stderr).inspect_err(|_| {
         eprintln!(
             "\n\n==== Start child stdout ====\n\n{}\n\n==== End child stdout ====",
             String::from_utf8_lossy(&output.stdout)
@@ -264,8 +264,6 @@ fn measure_boot_time(cmd: &mut GuestCommand, test_timeout: u32) -> Result<f64, E
             "\n\n==== Start child stderr ====\n\n{}\n\n==== End child stderr ====",
             String::from_utf8_lossy(&output.stderr)
         );
-
-        e
     })
 }
 

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -352,9 +352,8 @@ impl Request {
         let desc = desc_chain
             .next()
             .ok_or(Error::DescriptorChainTooShort)
-            .map_err(|e| {
+            .inspect_err(|_| {
                 error!("Missing head descriptor");
-                e
             })?;
 
         // The descriptor contains the request type which MUST be readable.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -913,9 +913,8 @@ impl Vmm {
         // And then read the memory itself
         memory_manager
             .receive_memory_regions(&table, socket)
-            .map_err(|e| {
+            .inspect_err(|_| {
                 Response::error().write_to(socket).ok();
-                e
             })?;
         Response::ok().write_to(socket)?;
         Ok(())


### PR DESCRIPTION
`inspect_err` was recently stabilized in 1.76, but MSRV is already 1.77 for us, so it is fine to use that.