### PR TITLE
virtio-devices: allow vsock to call fcntl in debug

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -209,6 +209,10 @@ fn virtio_vsock_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_ioctl, create_vsock_ioctl_seccomp_rule()),
         (libc::SYS_recvfrom, vec![]),
         (libc::SYS_socket, vec![]),
+        // If debug_assertions is enabled, closing a file first checks
+        // whether the FD is valid with fcntl.
+        #[cfg(debug_assertions)]
+        (libc::SYS_fcntl, vec![]),
     ]
 }
 


### PR DESCRIPTION
This fixes the vsock::device::tests::test_virtio_device with Rust 1.80.0 or later, where this check was introduced.