### PR TITLE
fix(virtq): only enable_notification when about to stop consumption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,6 +1318,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "virtio-bindings",
+ "virtio-ext",
  "virtio-queue",
  "vm-memory",
  "vm-virtio",
@@ -2368,6 +2369,7 @@ dependencies = [
  "thiserror",
  "vhost",
  "virtio-bindings",
+ "virtio-ext",
  "virtio-queue",
  "vm-allocator",
  "vm-device",
@@ -2375,6 +2377,14 @@ dependencies = [
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
+]
+
+[[package]]
+name = "virtio-ext"
+version = "0.1.0"
+dependencies = [
+ "virtio-queue",
+ "vm-memory",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ members = [
   "vhost_user_block",
   "vhost_user_net",
   "virtio-devices",
+  "virtio-ext",
   "vm-allocator",
   "vm-device",
   "vm-migration",

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -14,6 +14,7 @@ rate_limiter = { path = "../rate_limiter" }
 serde = { version = "1.0.197", features = ["derive"] }
 thiserror = "1.0.62"
 virtio-bindings = "0.2.2"
+virtio-ext = { path = "../virtio-ext" }
 virtio-queue = "0.12.0"
 vm-memory = { version = "0.14.1", features = [
   "backend-atomic",

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -384,11 +384,12 @@ impl VhostUserBackendMut for VhostUserBlkBackend {
                     // calling process_queue() until it stops finding new
                     // requests on the queue.
                     loop {
-                        vring
+                        thread.process_queue(&mut vring);
+                        if !vring
                             .get_queue_mut()
                             .enable_notification(self.mem.memory().deref())
-                            .unwrap();
-                        if !thread.process_queue(&mut vring) {
+                            .unwrap()
+                        {
                             break;
                         }
                     }

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -36,6 +36,7 @@ vhost = { version = "0.11.0", features = [
   "vhost-vdpa",
 ] }
 virtio-bindings = { version = "0.2.2", features = ["virtio-v5_0_0"] }
+virtio-ext = { path = "../virtio-ext" }
 virtio-queue = "0.12.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }

--- a/virtio-ext/Cargo.toml
+++ b/virtio-ext/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+authors = ["The Cloud Hypervisor Authors"]
+edition = "2021"
+name = "virtio-ext"
+version = "0.1.0"
+
+description = "virtio helper traits"
+
+[dependencies]
+virtio-queue = "0.12.0"
+vm-memory = "0.14.1"

--- a/virtio-ext/src/lib.rs
+++ b/virtio-ext/src/lib.rs
@@ -1,0 +1,32 @@
+use std::ops::Deref;
+
+use virtio_queue::{DescriptorChain, Error, Queue, QueueT};
+use vm_memory::GuestMemory;
+
+pub trait QueueExt {
+    fn pop_desc_chain_with_notification<M>(
+        &mut self,
+        mem: M,
+    ) -> Result<Option<DescriptorChain<M>>, Error>
+    where
+        // TODO: remove Sized bound once `Queue::enable_notification<M>` add `?Sized` for `M`.
+        M: Clone + Deref<Target: GuestMemory + Sized>;
+}
+
+impl QueueExt for Queue {
+    fn pop_desc_chain_with_notification<M>(
+        &mut self,
+        mem: M,
+    ) -> Result<Option<DescriptorChain<M>>, Error>
+    where
+        M: Clone + Deref<Target: GuestMemory + Sized>,
+    {
+        if let Some(dc) = self.pop_descriptor_chain(mem.clone()) {
+            return Ok(Some(dc));
+        }
+        if self.enable_notification(mem.deref())? {
+            return Ok(self.pop_descriptor_chain(mem));
+        }
+        Ok(None)
+    }
+}


### PR DESCRIPTION
### Problem

Current usage for virtqueue is like:
```rust
while let Some(desc_chain) = q.pop_descriptor_chain(mem) {
    // handle desc_chain
    if !queue
        .enable_notification(mem)
        .map_err(Error::QueueEnableNotification)?
    {
        break;
    }
}
```
However, it will bring not only more guest memory write and fence cost, but also more guest kick count.

According to `virtio-queue`'s doc of `enable_notification`, it advises:
```
  // With the current implementation, a common way of consuming entries from the available ring
  // while also leveraging notification suppression is to use a loop, for example:
  //
  // loop {
  //     // We have to explicitly disable notifications if `VIRTIO_F_EVENT_IDX` has not been
  //     // negotiated.
  //     self.disable_notification()?;
  //
  //     for chain in self.iter()? {
  //         // Do something with each chain ...
  //         // Let's assume we process all available chains here.
  //     }
  //
  //     // If `enable_notification` returns `true`, the driver has added more entries to the
  //     // available ring.
  //     if !self.enable_notification()? {
  //         break;
  //     }
  // }
```

The `enable_notification` needs to be called if and only if we are about to stop consuming the queue.

### Solution
I tried to change the code as the style suggested above, but it makes code confusing because there are many exit branches in complicated functions.

However, the caller must consume the queue until empty or it guarentees there would be another event source triggers the consumption like timer fd. So it's a good idea to add a function like `pop_desc_chain_with_notification`, when it returns None, it means the notification is enabled. And the caller won't have to worry about when and whether to `enable_notification`.

### Implementation
The `Queue` is not defined by us. So the only way to extend it is to adding a extension trait and implement it.

I didn't find a proper crate to put it in, so I added a new crate called virtio-ext and put the trait and impl in, and replaced nearly all `pop_descriptor_chain` with `enable_notification` to `pop_desc_chain_with_notification`.

### Another Fix(maybe?) about block.rs
During the replacing, I found the `enable_notification` at L395 of block.rs is redundant because it does not consume any descriptor. And when handling `COMPLETION_EVENT`, if the rate_limiter not pass, there would be no notification to guest(for completions that already pushed into the queue). Since the code is related and small, I fixed(maybe?) it in the same commit. I can split it into another PR if needed.

I'm not familiar with the block device, if I'm wrong please point it out.