### PR TITLE
pci: validate index before accessing MSI-X arrays

### DIFF
--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -213,6 +213,12 @@ impl MsixConfig {
         let index: usize = (offset / MSIX_TABLE_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_TABLE_ENTRIES_MODULO;
 
+        if index >= self.table_entries.len() {
+            debug!("Invalid MSI-X table entry index {index}");
+            data.copy_from_slice(&[0xff; 8][..data.len()]);
+            return;
+        }
+
         match data.len() {
             4 => {
                 let value = match modulo_offset {
@@ -259,6 +265,11 @@ impl MsixConfig {
 
         let index: usize = (offset / MSIX_TABLE_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_TABLE_ENTRIES_MODULO;
+
+        if index >= self.table_entries.len() {
+            debug!("Invalid MSI-X table entry index {index}");
+            return;
+        }
 
         // Store the value of the entry before modification
         let old_entry = self.table_entries[index].clone();
@@ -350,6 +361,12 @@ impl MsixConfig {
 
         let index: usize = (offset / MSIX_PBA_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_PBA_ENTRIES_MODULO;
+
+        if index >= self.pba_entries.len() {
+            debug!("Invalid MSI-X PBA entry index {index}");
+            data.copy_from_slice(&[0xff; 8][..data.len()]);
+            return;
+        }
 
         match data.len() {
             4 => {


### PR DESCRIPTION
The index is derived from the access offset, so it is controlled by the guest. Check it before accessing internal data structures.

Since Rust enforces strict bound check even in release builds, the VMM process will crash if the guest misbehaves. There is no security issue since the guest can only DoS itself.