### PR TITLE
Fix memory region api

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -602,9 +602,8 @@ impl vm::Vm for KvmVm {
             .map_err(|e| vm::HypervisorVmError::SetGsiRouting(e.into()))
     }
 
-    ///
+    /// # Safety
     /// Creates a memory region structure that can be used with {create/remove}_user_memory_region
-    ///
     unsafe fn make_user_memory_region(
         &self,
         slot: u32,

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -602,8 +602,13 @@ impl vm::Vm for KvmVm {
             .map_err(|e| vm::HypervisorVmError::SetGsiRouting(e.into()))
     }
 
-    /// # Safety
     /// Creates a memory region structure that can be used with {create/remove}_user_memory_region
+    ///
+    /// # Safety
+    ///         
+    /// The caller must guarantee the validity of the following parameters:
+    /// slot, guest_phys_addr, memory_size, userspace_addr.
+    ///
     unsafe fn make_user_memory_region(
         &self,
         slot: u32,

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -605,7 +605,7 @@ impl vm::Vm for KvmVm {
     ///
     /// Creates a memory region structure that can be used with {create/remove}_user_memory_region
     ///
-    fn make_user_memory_region(
+    unsafe fn make_user_memory_region(
         &self,
         slot: u32,
         guest_phys_addr: u64,

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -120,11 +120,11 @@ pub fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
 ///
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct UserMemoryRegion {
-    pub slot: u32,
-    pub guest_phys_addr: u64,
-    pub memory_size: u64,
-    pub userspace_addr: u64,
-    pub flags: u32,
+    slot: u32,
+    guest_phys_addr: u64,
+    memory_size: u64,
+    userspace_addr: u64,
+    flags: u32,
 }
 
 ///

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1769,7 +1769,7 @@ impl vm::Vm for MshvVm {
         Ok(())
     }
 
-    fn make_user_memory_region(
+    unsafe fn make_user_memory_region(
         &self,
         _slot: u32,
         guest_phys_addr: u64,

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1769,6 +1769,8 @@ impl vm::Vm for MshvVm {
         Ok(())
     }
 
+    /// # Safety
+    /// Creates a memory region structure that can be used with {create/remove}_user_memory_region
     unsafe fn make_user_memory_region(
         &self,
         _slot: u32,

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1769,8 +1769,13 @@ impl vm::Vm for MshvVm {
         Ok(())
     }
 
-    /// # Safety
     /// Creates a memory region structure that can be used with {create/remove}_user_memory_region
+    ///
+    /// # Safety
+    ///         
+    /// The caller must guarantee the validity of the following parameters:
+    /// slot, guest_phys_addr, memory_size, userspace_addr.
+    ///
     unsafe fn make_user_memory_region(
         &self,
         _slot: u32,

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -316,6 +316,7 @@ pub trait Vm: Send + Sync + Any {
     fn make_routing_entry(&self, gsi: u32, config: &InterruptSourceConfig) -> IrqRoutingEntry;
     /// Sets the GSI routing table entries, overwriting any previously set
     fn set_gsi_routing(&self, entries: &[IrqRoutingEntry]) -> Result<()>;
+    /// # Safety
     /// Creates a memory region structure that can be used with {create/remove}_user_memory_region
     unsafe fn make_user_memory_region(
         &self,

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -316,8 +316,13 @@ pub trait Vm: Send + Sync + Any {
     fn make_routing_entry(&self, gsi: u32, config: &InterruptSourceConfig) -> IrqRoutingEntry;
     /// Sets the GSI routing table entries, overwriting any previously set
     fn set_gsi_routing(&self, entries: &[IrqRoutingEntry]) -> Result<()>;
-    /// # Safety
     /// Creates a memory region structure that can be used with {create/remove}_user_memory_region
+    ///
+    /// # Safety
+    ///         
+    /// The caller must guarantee the validity of the following parameters:
+    /// slot, guest_phys_addr, memory_size, userspace_addr.
+    ///
     unsafe fn make_user_memory_region(
         &self,
         slot: u32,

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -317,7 +317,7 @@ pub trait Vm: Send + Sync + Any {
     /// Sets the GSI routing table entries, overwriting any previously set
     fn set_gsi_routing(&self, entries: &[IrqRoutingEntry]) -> Result<()>;
     /// Creates a memory region structure that can be used with {create/remove}_user_memory_region
-    fn make_user_memory_region(
+    unsafe fn make_user_memory_region(
         &self,
         slot: u32,
         guest_phys_addr: u64,

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1641,14 +1641,14 @@ impl VfioPciDevice {
 
                     region.user_memory_regions.push(user_memory_region);
 
-                    let mem_region = self.vm.make_user_memory_region(
+                    let mem_region = unsafe {self.vm.make_user_memory_region(
                         user_memory_region.slot,
                         user_memory_region.start,
                         user_memory_region.size,
                         user_memory_region.host_addr,
                         false,
                         false,
-                    );
+                    )};
 
                     self.vm
                         .create_user_memory_region(mem_region)
@@ -1684,14 +1684,14 @@ impl VfioPciDevice {
                 }
 
                 // Remove region
-                let r = self.vm.make_user_memory_region(
+                let r = unsafe {self.vm.make_user_memory_region(
                     user_memory_region.slot,
                     user_memory_region.start,
                     user_memory_region.size,
                     user_memory_region.host_addr,
                     false,
                     false,
-                );
+                )};
 
                 if let Err(e) = self.vm.remove_user_memory_region(r) {
                     error!("Could not remove the userspace memory region: {}", e);
@@ -1855,14 +1855,14 @@ impl PciDevice for VfioPciDevice {
 
                 for user_memory_region in region.user_memory_regions.iter_mut() {
                     // Remove old region
-                    let old_mem_region = self.vm.make_user_memory_region(
+                    let old_mem_region = unsafe {self.vm.make_user_memory_region(
                         user_memory_region.slot,
                         user_memory_region.start,
                         user_memory_region.size,
                         user_memory_region.host_addr,
                         false,
                         false,
-                    );
+                    )};
 
                     self.vm
                         .remove_user_memory_region(old_mem_region)
@@ -1876,14 +1876,14 @@ impl PciDevice for VfioPciDevice {
                     }
 
                     // Insert new region
-                    let new_mem_region = self.vm.make_user_memory_region(
+                    let new_mem_region = unsafe {self.vm.make_user_memory_region(
                         user_memory_region.slot,
                         user_memory_region.start,
                         user_memory_region.size,
                         user_memory_region.host_addr,
                         false,
                         false,
-                    );
+                    )};
 
                     self.vm
                         .create_user_memory_region(new_mem_region)

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1641,14 +1641,18 @@ impl VfioPciDevice {
 
                     region.user_memory_regions.push(user_memory_region);
 
-                    let mem_region = unsafe {self.vm.make_user_memory_region(
-                        user_memory_region.slot,
-                        user_memory_region.start,
-                        user_memory_region.size,
-                        user_memory_region.host_addr,
-                        false,
-                        false,
-                    )};
+                    // SAFETY: make_user_memory_region called with valid params:
+                    // slot, guest_phys_addr, memory_size, userspace_addr
+                    let mem_region = unsafe {
+                        self.vm.make_user_memory_region(
+                            user_memory_region.slot,
+                            user_memory_region.start,
+                            user_memory_region.size,
+                            user_memory_region.host_addr,
+                            false,
+                            false,
+                        )
+                    };
 
                     self.vm
                         .create_user_memory_region(mem_region)
@@ -1684,14 +1688,18 @@ impl VfioPciDevice {
                 }
 
                 // Remove region
-                let r = unsafe {self.vm.make_user_memory_region(
-                    user_memory_region.slot,
-                    user_memory_region.start,
-                    user_memory_region.size,
-                    user_memory_region.host_addr,
-                    false,
-                    false,
-                )};
+                // SAFETY: make_user_memory_region called with valid params:
+                // slot, guest_phys_addr, memory_size, userspace_addr
+                let r = unsafe {
+                    self.vm.make_user_memory_region(
+                        user_memory_region.slot,
+                        user_memory_region.start,
+                        user_memory_region.size,
+                        user_memory_region.host_addr,
+                        false,
+                        false,
+                    )
+                };
 
                 if let Err(e) = self.vm.remove_user_memory_region(r) {
                     error!("Could not remove the userspace memory region: {}", e);
@@ -1855,14 +1863,18 @@ impl PciDevice for VfioPciDevice {
 
                 for user_memory_region in region.user_memory_regions.iter_mut() {
                     // Remove old region
-                    let old_mem_region = unsafe {self.vm.make_user_memory_region(
-                        user_memory_region.slot,
-                        user_memory_region.start,
-                        user_memory_region.size,
-                        user_memory_region.host_addr,
-                        false,
-                        false,
-                    )};
+                    // SAFETY: make_user_memory_region called with valid params:
+                    // slot, guest_phys_addr, memory_size, userspace_addr
+                    let old_mem_region = unsafe {
+                        self.vm.make_user_memory_region(
+                            user_memory_region.slot,
+                            user_memory_region.start,
+                            user_memory_region.size,
+                            user_memory_region.host_addr,
+                            false,
+                            false,
+                        )
+                    };
 
                     self.vm
                         .remove_user_memory_region(old_mem_region)
@@ -1876,14 +1888,18 @@ impl PciDevice for VfioPciDevice {
                     }
 
                     // Insert new region
-                    let new_mem_region = unsafe {self.vm.make_user_memory_region(
-                        user_memory_region.slot,
-                        user_memory_region.start,
-                        user_memory_region.size,
-                        user_memory_region.host_addr,
-                        false,
-                        false,
-                    )};
+                    // SAFETY: make_user_memory_region called with valid params:
+                    // slot, guest_phys_addr, memory_size, userspace_addr
+                    let new_mem_region = unsafe {
+                        self.vm.make_user_memory_region(
+                            user_memory_region.slot,
+                            user_memory_region.start,
+                            user_memory_region.size,
+                            user_memory_region.host_addr,
+                            false,
+                            false,
+                        )
+                    };
 
                     self.vm
                         .create_user_memory_region(new_mem_region)

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -182,14 +182,14 @@ impl VfioUserPciDevice {
 
                     mmio_region.user_memory_regions.push(user_memory_region);
 
-                    let mem_region = self.vm.make_user_memory_region(
+                    let mem_region = unsafe {self.vm.make_user_memory_region(
                         user_memory_region.slot,
                         user_memory_region.start,
                         user_memory_region.size,
                         user_memory_region.host_addr,
                         false,
                         false,
-                    );
+                    )};
 
                     self.vm
                         .create_user_memory_region(mem_region)
@@ -205,14 +205,14 @@ impl VfioUserPciDevice {
         for mmio_region in self.common.mmio_regions.iter() {
             for user_memory_region in mmio_region.user_memory_regions.iter() {
                 // Remove region
-                let r = self.vm.make_user_memory_region(
+                let r = unsafe { self.vm.make_user_memory_region(
                     user_memory_region.slot,
                     user_memory_region.start,
                     user_memory_region.size,
                     user_memory_region.host_addr,
                     false,
                     false,
-                );
+                )};
 
                 if let Err(e) = self.vm.remove_user_memory_region(r) {
                     error!("Could not remove the userspace memory region: {}", e);
@@ -458,14 +458,14 @@ impl PciDevice for VfioUserPciDevice {
 
                 for user_memory_region in mmio_region.user_memory_regions.iter_mut() {
                     // Remove old region
-                    let old_region = self.vm.make_user_memory_region(
+                    let old_region = unsafe {self.vm.make_user_memory_region(
                         user_memory_region.slot,
                         user_memory_region.start,
                         user_memory_region.size,
                         user_memory_region.host_addr,
                         false,
                         false,
-                    );
+                    )};
 
                     self.vm
                         .remove_user_memory_region(old_region)
@@ -479,14 +479,14 @@ impl PciDevice for VfioUserPciDevice {
                     }
 
                     // Insert new region
-                    let new_region = self.vm.make_user_memory_region(
+                    let new_region = unsafe { self.vm.make_user_memory_region(
                         user_memory_region.slot,
                         user_memory_region.start,
                         user_memory_region.size,
                         user_memory_region.host_addr,
                         false,
                         false,
-                    );
+                    )};
 
                     self.vm
                         .create_user_memory_region(new_region)

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -182,14 +182,18 @@ impl VfioUserPciDevice {
 
                     mmio_region.user_memory_regions.push(user_memory_region);
 
-                    let mem_region = unsafe {self.vm.make_user_memory_region(
-                        user_memory_region.slot,
-                        user_memory_region.start,
-                        user_memory_region.size,
-                        user_memory_region.host_addr,
-                        false,
-                        false,
-                    )};
+                    // SAFETY: make_user_memory_region called with valid params:
+                    // slot, guest_phys_addr, memory_size, userspace_addr
+                    let mem_region = unsafe {
+                        self.vm.make_user_memory_region(
+                            user_memory_region.slot,
+                            user_memory_region.start,
+                            user_memory_region.size,
+                            user_memory_region.host_addr,
+                            false,
+                            false,
+                        )
+                    };
 
                     self.vm
                         .create_user_memory_region(mem_region)
@@ -205,14 +209,18 @@ impl VfioUserPciDevice {
         for mmio_region in self.common.mmio_regions.iter() {
             for user_memory_region in mmio_region.user_memory_regions.iter() {
                 // Remove region
-                let r = unsafe { self.vm.make_user_memory_region(
-                    user_memory_region.slot,
-                    user_memory_region.start,
-                    user_memory_region.size,
-                    user_memory_region.host_addr,
-                    false,
-                    false,
-                )};
+                // SAFETY: make_user_memory_region called with valid params:
+                // slot, guest_phys_addr, memory_size, userspace_addr
+                let r = unsafe {
+                    self.vm.make_user_memory_region(
+                        user_memory_region.slot,
+                        user_memory_region.start,
+                        user_memory_region.size,
+                        user_memory_region.host_addr,
+                        false,
+                        false,
+                    )
+                };
 
                 if let Err(e) = self.vm.remove_user_memory_region(r) {
                     error!("Could not remove the userspace memory region: {}", e);
@@ -458,14 +466,18 @@ impl PciDevice for VfioUserPciDevice {
 
                 for user_memory_region in mmio_region.user_memory_regions.iter_mut() {
                     // Remove old region
-                    let old_region = unsafe {self.vm.make_user_memory_region(
-                        user_memory_region.slot,
-                        user_memory_region.start,
-                        user_memory_region.size,
-                        user_memory_region.host_addr,
-                        false,
-                        false,
-                    )};
+                    // SAFETY: make_user_memory_region called with valid params:
+                    // slot, guest_phys_addr, memory_size, userspace_addr
+                    let old_region = unsafe {
+                        self.vm.make_user_memory_region(
+                            user_memory_region.slot,
+                            user_memory_region.start,
+                            user_memory_region.size,
+                            user_memory_region.host_addr,
+                            false,
+                            false,
+                        )
+                    };
 
                     self.vm
                         .remove_user_memory_region(old_region)
@@ -479,14 +491,18 @@ impl PciDevice for VfioUserPciDevice {
                     }
 
                     // Insert new region
-                    let new_region = unsafe { self.vm.make_user_memory_region(
-                        user_memory_region.slot,
-                        user_memory_region.start,
-                        user_memory_region.size,
-                        user_memory_region.host_addr,
-                        false,
-                        false,
-                    )};
+                    // SAFETY: make_user_memory_region called with valid params:
+                    // slot, guest_phys_addr, memory_size, userspace_addr
+                    let new_region = unsafe {
+                        self.vm.make_user_memory_region(
+                            user_memory_region.slot,
+                            user_memory_region.start,
+                            user_memory_region.size,
+                            user_memory_region.host_addr,
+                            false,
+                            false,
+                        )
+                    };
 
                     self.vm
                         .create_user_memory_region(new_region)

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -686,14 +686,14 @@ impl DeviceRelocation for AddressManager {
                 let mut virtio_dev = virtio_dev.lock().unwrap();
                 if let Some(mut shm_regions) = virtio_dev.get_shm_regions() {
                     if shm_regions.addr.raw_value() == old_base {
-                        let mem_region = self.vm.make_user_memory_region(
+                        let mem_region = unsafe {self.vm.make_user_memory_region(
                             shm_regions.mem_slot,
                             old_base,
                             shm_regions.len,
                             shm_regions.host_addr,
                             false,
                             false,
-                        );
+                        )};
 
                         self.vm.remove_user_memory_region(mem_region).map_err(|e| {
                             io::Error::new(
@@ -703,14 +703,14 @@ impl DeviceRelocation for AddressManager {
                         })?;
 
                         // Create new mapping by inserting new region to KVM.
-                        let mem_region = self.vm.make_user_memory_region(
+                        let mem_region = unsafe {self.vm.make_user_memory_region(
                             shm_regions.mem_slot,
                             new_base,
                             shm_regions.len,
                             shm_regions.host_addr,
                             false,
                             false,
-                        );
+                        )};
 
                         self.vm.create_user_memory_region(mem_region).map_err(|e| {
                             io::Error::new(

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -686,14 +686,18 @@ impl DeviceRelocation for AddressManager {
                 let mut virtio_dev = virtio_dev.lock().unwrap();
                 if let Some(mut shm_regions) = virtio_dev.get_shm_regions() {
                     if shm_regions.addr.raw_value() == old_base {
-                        let mem_region = unsafe {self.vm.make_user_memory_region(
-                            shm_regions.mem_slot,
-                            old_base,
-                            shm_regions.len,
-                            shm_regions.host_addr,
-                            false,
-                            false,
-                        )};
+                        // SAFETY: make_user_memory_region called with valid params:
+                        // slot, guest_phys_addr, memory_size, userspace_addr
+                        let mem_region = unsafe {
+                            self.vm.make_user_memory_region(
+                                shm_regions.mem_slot,
+                                old_base,
+                                shm_regions.len,
+                                shm_regions.host_addr,
+                                false,
+                                false,
+                            )
+                        };
 
                         self.vm.remove_user_memory_region(mem_region).map_err(|e| {
                             io::Error::new(
@@ -703,14 +707,18 @@ impl DeviceRelocation for AddressManager {
                         })?;
 
                         // Create new mapping by inserting new region to KVM.
-                        let mem_region = unsafe {self.vm.make_user_memory_region(
-                            shm_regions.mem_slot,
-                            new_base,
-                            shm_regions.len,
-                            shm_regions.host_addr,
-                            false,
-                            false,
-                        )};
+                        // SAFETY: make_user_memory_region called with valid params:
+                        // slot, guest_phys_addr, memory_size, userspace_addr
+                        let mem_region = unsafe {
+                            self.vm.make_user_memory_region(
+                                shm_regions.mem_slot,
+                                new_base,
+                                shm_regions.len,
+                                shm_regions.host_addr,
+                                false,
+                                false,
+                            )
+                        };
 
                         self.vm.create_user_memory_region(mem_region).map_err(|e| {
                             io::Error::new(

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1740,14 +1740,14 @@ impl MemoryManager {
         log_dirty: bool,
     ) -> Result<u32, Error> {
         let slot = self.allocate_memory_slot();
-        let mem_region = self.vm.make_user_memory_region(
+        let mem_region = unsafe {self.vm.make_user_memory_region(
             slot,
             guest_phys_addr,
             memory_size,
             userspace_addr,
             readonly,
             log_dirty,
-        );
+        )};
 
         info!(
             "Creating userspace mapping: {:x} -> {:x} {:x}, slot {}",
@@ -1813,14 +1813,14 @@ impl MemoryManager {
         mergeable: bool,
         slot: u32,
     ) -> Result<(), Error> {
-        let mem_region = self.vm.make_user_memory_region(
+        let mem_region = unsafe {self.vm.make_user_memory_region(
             slot,
             guest_phys_addr,
             memory_size,
             userspace_addr,
             false, /* readonly -- don't care */
             false, /* log dirty */
-        );
+        )};
 
         self.vm
             .remove_user_memory_region(mem_region)

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -958,14 +958,19 @@ impl MemoryManager {
             arch::layout::UEFI_START,
         )
         .unwrap();
-        let uefi_mem_region = self.vm.make_user_memory_region(
-            uefi_mem_slot,
-            uefi_region.start_addr().raw_value(),
-            uefi_region.len(),
-            uefi_region.as_ptr() as u64,
-            false,
-            false,
-        );
+
+        // SAFETY: make_user_memory_region called with valid params:
+        // slot, guest_phys_addr, memory_size, userspace_addr
+        let uefi_mem_region = unsafe {
+            self.vm.make_user_memory_region(
+                uefi_mem_slot,
+                uefi_region.start_addr().raw_value(),
+                uefi_region.len(),
+                uefi_region.as_ptr() as u64,
+                false,
+                false,
+            )
+        };
         self.vm
             .create_user_memory_region(uefi_mem_region)
             .map_err(Error::CreateUefiFlash)?;
@@ -1740,14 +1745,19 @@ impl MemoryManager {
         log_dirty: bool,
     ) -> Result<u32, Error> {
         let slot = self.allocate_memory_slot();
-        let mem_region = unsafe {self.vm.make_user_memory_region(
-            slot,
-            guest_phys_addr,
-            memory_size,
-            userspace_addr,
-            readonly,
-            log_dirty,
-        )};
+
+        // SAFETY: make_user_memory_region called with valid params:
+        // slot, guest_phys_addr, memory_size, userspace_addr
+        let mem_region = unsafe {
+            self.vm.make_user_memory_region(
+                slot,
+                guest_phys_addr,
+                memory_size,
+                userspace_addr,
+                readonly,
+                log_dirty,
+            )
+        };
 
         info!(
             "Creating userspace mapping: {:x} -> {:x} {:x}, slot {}",
@@ -1813,14 +1823,18 @@ impl MemoryManager {
         mergeable: bool,
         slot: u32,
     ) -> Result<(), Error> {
-        let mem_region = unsafe {self.vm.make_user_memory_region(
-            slot,
-            guest_phys_addr,
-            memory_size,
-            userspace_addr,
-            false, /* readonly -- don't care */
-            false, /* log dirty */
-        )};
+        // SAFETY: make_user_memory_region called with valid params:
+        // slot, guest_phys_addr, memory_size, userspace_addr
+        let mem_region = unsafe {
+            self.vm.make_user_memory_region(
+                slot,
+                guest_phys_addr,
+                memory_size,
+                userspace_addr,
+                false, /* readonly -- don't care */
+                false, /* log dirty */
+            )
+        };
 
         self.vm
             .remove_user_memory_region(mem_region)

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3213,14 +3213,14 @@ pub fn test_vm() {
     let vm = hv.create_vm().expect("new VM creation failed");
 
     for (index, region) in mem.iter().enumerate() {
-        let mem_region = vm.make_user_memory_region(
+        let mem_region = unsafe {vm.make_user_memory_region(
             index as u32,
             region.start_addr().raw_value(),
             region.len(),
             region.as_ptr() as u64,
             false,
             false,
-        );
+        )};
 
         vm.create_user_memory_region(mem_region)
             .expect("Cannot configure guest memory");

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3213,14 +3213,18 @@ pub fn test_vm() {
     let vm = hv.create_vm().expect("new VM creation failed");
 
     for (index, region) in mem.iter().enumerate() {
-        let mem_region = unsafe {vm.make_user_memory_region(
-            index as u32,
-            region.start_addr().raw_value(),
-            region.len(),
-            region.as_ptr() as u64,
-            false,
-            false,
-        )};
+        // SAFETY: make_user_memory_region called with valid params:
+        // slot, guest_phys_addr, memory_size, userspace_addr
+        let mem_region = unsafe {
+            vm.make_user_memory_region(
+                index as u32,
+                region.start_addr().raw_value(),
+                region.len(),
+                region.as_ptr() as u64,
+                false,
+                false,
+            )
+        };
 
         vm.create_user_memory_region(mem_region)
             .expect("Cannot configure guest memory");


### PR DESCRIPTION
Fix #6547

Make private fields of ```UserMemoryRegin```.
Mark ```make_user_memory_region``` as ```unsafe```, add relevant comments