### PR TITLE
arm64: Add support for enabling SVE in vm guests

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -159,6 +159,11 @@ pub enum HypervisorCpuError {
     #[error("Failed to init vcpu: {0}")]
     VcpuInit(#[source] anyhow::Error),
     ///
+    /// Vcpu Finalize error
+    ///
+    #[error("Failed to finalize vcpu: {0}")]
+    VcpuFinalize(#[source] anyhow::Error),
+    ///
     /// Setting one reg error
     ///
     #[error("Failed to init vcpu: {0}")]
@@ -417,6 +422,10 @@ pub trait Vcpu: Send + Sync {
     ///
     #[cfg(target_arch = "aarch64")]
     fn vcpu_init(&self, kvi: &VcpuInit) -> Result<()>;
+
+    #[cfg(target_arch = "aarch64")]
+    fn vcpu_finalize(&self, feature: i32) -> Result<()>;
+
     ///
     /// Gets a list of the guest registers that are supported for the
     /// KVM_GET_ONE_REG/KVM_SET_ONE_REG calls.

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1881,6 +1881,15 @@ impl cpu::Vcpu for KvmVcpu {
             .map_err(|e| cpu::HypervisorCpuError::VcpuInit(e.into()))
     }
 
+    #[cfg(target_arch = "aarch64")]
+    fn vcpu_finalize(&self, feature: i32) -> cpu::Result<()> {
+        self.fd
+            .lock()
+            .unwrap()
+            .vcpu_finalize(&feature)
+            .map_err(|e| cpu::HypervisorCpuError::VcpuFinalize(e.into()))
+    }
+
     ///
     /// Gets a list of the guest registers that are supported for the
     /// KVM_GET_ONE_REG/KVM_SET_ONE_REG calls.

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -427,12 +427,14 @@ fn create_vmm_ioctl_seccomp_rule_kvm() -> Result<Vec<SeccompRule>, BackendError>
     const KVM_ARM_PREFERRED_TARGET: u64 = 0x8020_aeaf;
     const KVM_ARM_VCPU_INIT: u64 = 0x4020_aeae;
     const KVM_SET_GUEST_DEBUG: u64 = 0x4208_ae9b;
+    const KVM_ARM_VCPU_FINALIZE: u64 = 0x4004_aec2;
 
     let common_rules = create_vmm_ioctl_seccomp_rule_common(HypervisorType::Kvm)?;
     let mut arch_rules = or![
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_ARM_PREFERRED_TARGET,)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_ARM_VCPU_INIT,)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_GUEST_DEBUG,)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_ARM_VCPU_FINALIZE,)?],
     ];
     arch_rules.extend(common_rules);
 


### PR DESCRIPTION
This change then adds the first --cpus features option sve that when passed will enable SVE usage for guests (needs a 5.2+ kernel) or exits with failure.

Fix: #6678 