### PR TITLE
vmm: allow to call fcntl in debug

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -270,6 +270,8 @@ fn virtio_thread_common() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_rt_sigreturn, vec![]),
         (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_write, vec![]),
+        #[cfg(debug_assertions)]
+        (libc::SYS_fcntl, vec![]),
     ]
 }
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -488,6 +488,8 @@ fn signal_handler_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, Backend
         (libc::SYS_sendto, vec![]),
         (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_write, vec![]),
+        #[cfg(debug_assertions)]
+        (libc::SYS_fcntl, vec![]),
     ])
 }
 
@@ -520,6 +522,8 @@ fn pty_foreground_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, Backend
         (libc::SYS_setsid, vec![]),
         (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_write, vec![]),
+        #[cfg(debug_assertions)]
+        (libc::SYS_fcntl, vec![]),
     ])
 }
 
@@ -802,6 +806,8 @@ fn vcpu_thread_rules(
         (libc::SYS_unlinkat, vec![]),
         (libc::SYS_write, vec![]),
         (libc::SYS_writev, vec![]),
+        #[cfg(debug_assertions)]
+        (libc::SYS_fcntl, vec![]),
     ])
 }
 


### PR DESCRIPTION
This fixes a issue of running vm compiled in debug with Rust 1.80.0 or later, where this check was introduced.

Fix: #6694 