### PR TITLE
hypervisor: mshv: implement extended guest requests with empty certs

### DIFF
--- a/hypervisor/src/mshv/snp_constants.rs
+++ b/hypervisor/src/mshv/snp_constants.rs
@@ -20,5 +20,6 @@ pub const ECDSA_SIG_Y_COMPONENT_END: usize =
 // These constants are derived from GHCB spec Sect. 2.6 Table 3 GHCB Layout
 // Link: https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56421.pdf
 pub const GHCB_RAX_OFFSET: u64 = 0x01F8;
+pub const GHCB_RBX_OFFSET: u64 = 0x0318;
 pub const GHCB_SW_EXITINFO1_OFFSET: u64 = 0x398;
 pub const GHCB_SW_EXITINFO2_OFFSET: u64 = 0x3A0;


### PR DESCRIPTION
Previously we didn't handle extended guest requests at all and always returned an error. This lead to issues with some guests that expected extended requests to succeed. Instead, handle extended requests like normal requests and write zeros to the extended area to signal to the guest that we don't want to supply any additional certificate data.