### PR TITLE
hypervisor: mshv: implement get_guest_debug_hw_bps

### DIFF
--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -386,6 +386,10 @@ impl hypervisor::Hypervisor for MshvHypervisor {
         // but the ioctl API is limited to u8
         256
     }
+
+    fn get_guest_debug_hw_bps(&self) -> usize {
+        0
+    }
 }
 
 /// Vcpu struct for Microsoft Hypervisor


### PR DESCRIPTION
Implement get_guest_debug_hw_bps() for mshv and simply return 0 for now. This unblocks the usage of the crashdump feature with mshv. If left unimplemented, Cloud Hypervisor built with mshv and guest_debug features crashes immediately upon start due to the unimplemented!() macro.