### PR TITLE
virtio-devices: Fix seccomp rules for SevSnp guest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,6 +2368,7 @@ dependencies = [
  "event_monitor",
  "libc",
  "log",
+ "mshv-ioctls",
  "net_gen",
  "net_util",
  "pci",

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 
 [features]
 default = []
-sev_snp = []
+sev_snp = ["mshv-ioctls"]
 
 [dependencies]
 anyhow = "1.0.86"
@@ -17,6 +17,7 @@ epoll = "4.3.3"
 event_monitor = { path = "../event_monitor" }
 libc = "0.2.155"
 log = "0.4.22"
+mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", tag = "v0.2.0", optional = true }
 net_gen = { path = "../net_gen" }
 net_util = { path = "../net_util" }
 pci = { path = "../pci" }


### PR DESCRIPTION
With commit 1e967697c ("vmm: pass AccessPlatform implementation for SEV-SNP guest"), we started performing one additional ioctl to gain access to the guest memory before accessing those regions inside virtio-device emulation code path. This additional ioctl is not part of the current seccomp filter, which is causing the SevSnp guest to crash in this scenario with seccomp violation.

Fixes: 1e967697c ("vmm: pass AccessPlatform implementation for SEV-SNP guest")