### PR TITLE
hypervisor: aarch64: Remove redefinition of StandardRegisters

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -9,14 +9,13 @@
 //
 
 #[cfg(target_arch = "aarch64")]
-use crate::aarch64::{RegList, StandardRegisters, VcpuInit};
+use crate::aarch64::{RegList, VcpuInit};
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::{CpuIdEntry, FpuState, LapicState, MsrEntry, SpecialRegisters};
 #[cfg(feature = "tdx")]
 use crate::kvm::{TdxExitDetails, TdxExitStatus};
 use crate::CpuState;
 use crate::MpState;
-#[cfg(target_arch = "x86_64")]
 use crate::StandardRegisters;
 use thiserror::Error;
 use vm_memory::GuestAddress;

--- a/hypervisor/src/kvm/aarch64/mod.rs
+++ b/hypervisor/src/kvm/aarch64/mod.rs
@@ -15,9 +15,7 @@ use kvm_bindings::{
     kvm_mp_state, kvm_one_reg, kvm_regs, KVM_REG_ARM_COPROC_MASK, KVM_REG_ARM_CORE,
     KVM_REG_SIZE_MASK, KVM_REG_SIZE_U32, KVM_REG_SIZE_U64,
 };
-pub use kvm_bindings::{
-    kvm_one_reg as Register, kvm_regs as StandardRegisters, kvm_vcpu_init as VcpuInit, RegList,
-};
+pub use kvm_bindings::{kvm_one_reg as Register, kvm_vcpu_init as VcpuInit, RegList};
 use serde::{Deserialize, Serialize};
 pub use {kvm_ioctls::Cap, kvm_ioctls::Kvm};
 

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -270,3 +270,45 @@ get_x86_64_reg!(r14);
 get_x86_64_reg!(r15);
 get_x86_64_reg!(rip);
 get_x86_64_reg!(rflags);
+
+macro_rules! set_aarch64_reg {
+    ($reg_name:ident, $type:ty) => {
+        concat_idents!(method_name = "set_", $reg_name {
+            #[cfg(target_arch = "aarch64")]
+            impl StandardRegisters {
+                pub fn method_name(&mut self, val: $type) {
+                    match self {
+                        #[cfg(feature = "kvm")]
+                        StandardRegisters::Kvm(s) => s.regs.$reg_name = val,
+                    }
+                }
+            }
+        });
+    }
+}
+
+macro_rules! get_aarch64_reg {
+    ($reg_name:ident, $type:ty) => {
+        concat_idents!(method_name = "get_", $reg_name {
+            #[cfg(target_arch = "aarch64")]
+            impl StandardRegisters {
+                pub fn method_name(&self) -> $type {
+                    match self {
+                        #[cfg(feature = "kvm")]
+                        StandardRegisters::Kvm(s) => s.regs.$reg_name,
+                    }
+                }
+            }
+        });
+    }
+}
+
+set_aarch64_reg!(regs, [u64; 31usize]);
+set_aarch64_reg!(sp, u64);
+set_aarch64_reg!(pc, u64);
+set_aarch64_reg!(pstate, u64);
+
+get_aarch64_reg!(regs, [u64; 31usize]);
+get_aarch64_reg!(sp, u64);
+get_aarch64_reg!(pc, u64);
+get_aarch64_reg!(pstate, u64);


### PR DESCRIPTION
This is along the lines of #6629, in the previous PR the major focus was on x86. This PR tries to do the same thing but for ARM64 side of the world. Basically remove the redefinition of StandaradRegisters and define a union structure which entails all possible hypervisor implementations.