### PR TITLE
vmm: fix console resizing

### DIFF
--- a/vmm/src/console_devices.rs
+++ b/vmm/src/console_devices.rs
@@ -183,14 +183,14 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
             console_info.console_main_fd = Some(main_fd.into_raw_fd());
             set_raw_mode(&sub_fd.as_raw_fd(), vmm.original_termios_opt.clone())?;
             vmconfig.console.file = Some(path.clone());
-            vmm.console_resize_pipe = Some(
+            vmm.console_resize_pipe = Some(Arc::new(
                 listen_for_sigwinch_on_tty(
                     sub_fd,
                     &vmm.seccomp_action,
                     vmm.hypervisor.hypervisor_type(),
                 )
                 .map_err(ConsoleDeviceError::StartSigwinchListener)?,
-            );
+            ));
         }
         ConsoleOutputMode::Tty => {
             // Duplicating the file descriptors like this is needed as otherwise
@@ -206,14 +206,14 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
 
             // SAFETY: FFI call. Trivially safe.
             if unsafe { libc::isatty(stdout.as_raw_fd()) } == 1 {
-                vmm.console_resize_pipe = Some(
+                vmm.console_resize_pipe = Some(Arc::new(
                     listen_for_sigwinch_on_tty(
                         stdout.try_clone().unwrap(),
                         &vmm.seccomp_action,
                         vmm.hypervisor.hypervisor_type(),
                     )
                     .map_err(ConsoleDeviceError::StartSigwinchListener)?,
-                );
+                ));
             }
 
             // Make sure stdout is in raw mode, if it's a terminal.
@@ -255,14 +255,14 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
 
             // SAFETY: FFI call. Trivially safe.
             if unsafe { libc::isatty(stdout.as_raw_fd()) } == 1 {
-                vmm.console_resize_pipe = Some(
+                vmm.console_resize_pipe = Some(Arc::new(
                     listen_for_sigwinch_on_tty(
                         stdout.try_clone().unwrap(),
                         &vmm.seccomp_action,
                         vmm.hypervisor.hypervisor_type(),
                     )
                     .map_err(ConsoleDeviceError::StartSigwinchListener)?,
-                );
+                ));
             }
 
             // Make sure stdout is in raw mode, if it's a terminal.

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -493,7 +493,7 @@ impl Vm {
         activate_evt: EventFd,
         timestamp: Instant,
         console_info: Option<ConsoleInfo>,
-        console_resize_pipe: Option<File>,
+        console_resize_pipe: Option<Arc<File>>,
         original_termios: Arc<Mutex<Option<termios>>>,
         snapshot: Option<Snapshot>,
     ) -> Result<Self> {
@@ -801,7 +801,7 @@ impl Vm {
         hypervisor: Arc<dyn hypervisor::Hypervisor>,
         activate_evt: EventFd,
         console_info: Option<ConsoleInfo>,
-        console_resize_pipe: Option<File>,
+        console_resize_pipe: Option<Arc<File>>,
         original_termios: Arc<Mutex<Option<termios>>>,
         snapshot: Option<Snapshot>,
         source_url: Option<&str>,


### PR DESCRIPTION
`DeviceManager::add_virtio_console_device` used to create the console resize pipe and assign it to `self.console_resize_pipe`, but when this was changed to use console_info, that was deleted without replacement. This meant that, even though the console resize pipe was created by `pre_create_console_devices`, the `DeviceManager` never found out about it, so console resize didn't work (at least for pty consoles).

To fix this, the console resize pipe needs to be passed to the `Vm` initializer, which is already supported, it was just previously not used for new VMs.

Since `DeviceManager` already stores the console resize pipe in an `Arc`, and `Vmm` also needs a copy of it, the sensible thing to do is change `DeviceManager::new` to take `Arc`, and then we don't need to dup the file descriptor, which could fail.

Fixes: 52eebaf6 ("vmm: refactor DeviceManager to use console_info")