### PR TITLE
Use caching during the page access request for SEV-SNP guest on MSHV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,7 @@ name = "hypervisor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "byteorder",
  "cfg-if",
  "concat-idents",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -13,6 +13,7 @@ tdx = []
 
 [dependencies]
 anyhow = "1.0.94"
+arc-swap = "1.7.1"
 byteorder = "1.5.0"
 cfg-if = "1.0.0"
 concat-idents = "1.1.5"
@@ -33,7 +34,11 @@ serde_with = { version = "3.9.0", default-features = false, features = [
 ] }
 thiserror = "1.0.62"
 vfio-ioctls = { workspace = true, default-features = false }
-vm-memory = { workspace = true, features = ["backend-atomic", "backend-mmap"] }
+vm-memory = { workspace = true, features = [
+  "backend-atomic",
+  "backend-bitmap",
+  "backend-mmap",
+] }
 vmm-sys-util = { workspace = true, features = ["with-serde"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -118,6 +118,17 @@ pub trait Hypervisor: Send + Sync {
     fn create_vm_with_type(&self, _vm_type: u64) -> Result<Arc<dyn Vm>> {
         unreachable!()
     }
+    ///
+    /// Create a Vm of a specific type using the underlying hypervisor, passing memory size
+    /// Return a hypervisor-agnostic Vm trait object
+    ///
+    fn create_vm_with_type_and_memory(
+        &self,
+        _vm_type: u64,
+        #[cfg(feature = "sev_snp")] _mem_size: u64,
+    ) -> Result<Arc<dyn Vm>> {
+        unreachable!()
+    }
     #[cfg(target_arch = "x86_64")]
     ///
     /// Get the supported CpuID

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1076,6 +1076,26 @@ impl hypervisor::Hypervisor for KvmHypervisor {
         HypervisorType::Kvm
     }
 
+    ///
+    /// Create a Vm of a specific type using the underlying hypervisor, passing memory size
+    /// Return a hypervisor-agnostic Vm trait object
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hypervisor::kvm::KvmHypervisor;
+    /// use hypervisor::kvm::KvmVm;
+    /// let hypervisor = KvmHypervisor::new().unwrap();
+    /// let vm = hypervisor.create_vm_with_type_and_memory(0).unwrap();
+    /// ```
+    fn create_vm_with_type_and_memory(
+        &self,
+        vm_type: u64,
+        #[cfg(feature = "sev_snp")] _mem_size: u64,
+    ) -> hypervisor::Result<Arc<dyn vm::Vm>> {
+        self.create_vm_with_type(vm_type)
+    }
+
     /// Create a KVM vm object of a specific VM type and return the object as Vm trait object
     ///
     /// # Examples

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -786,6 +786,8 @@ impl Vmm {
             false,
             #[cfg(feature = "sev_snp")]
             false,
+            #[cfg(feature = "sev_snp")]
+            config.lock().unwrap().memory.total_size(),
         )
         .map_err(|e| {
             MigratableError::MigrateReceive(anyhow!(

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -827,6 +827,8 @@ impl Vm {
             tdx_enabled,
             #[cfg(feature = "sev_snp")]
             sev_snp_enabled,
+            #[cfg(feature = "sev_snp")]
+            vm_config.lock().unwrap().memory.total_size(),
         )?;
 
         let phys_bits = physical_bits(&hypervisor, vm_config.lock().unwrap().cpus.max_phys_bits);
@@ -885,6 +887,7 @@ impl Vm {
         hypervisor: &Arc<dyn hypervisor::Hypervisor>,
         #[cfg(feature = "tdx")] tdx_enabled: bool,
         #[cfg(feature = "sev_snp")] sev_snp_enabled: bool,
+        #[cfg(feature = "sev_snp")] mem_size: u64,
     ) -> Result<Arc<dyn hypervisor::Vm>> {
         hypervisor.check_required_extensions().unwrap();
 
@@ -901,7 +904,7 @@ impl Vm {
                 // Otherwise SEV_SNP_DISABLED: 0
                 // value of sev_snp_enabled is mapped to SEV_SNP_ENABLED for true or SEV_SNP_DISABLED for false
                 let vm = hypervisor
-                    .create_vm_with_type(u64::from(sev_snp_enabled))
+                    .create_vm_with_type_and_memory(u64::from(sev_snp_enabled), mem_size)
                     .unwrap();
             } else {
                 let vm = hypervisor.create_vm().unwrap();


### PR DESCRIPTION
For SEV-SNP VM VMM needs access to pages during IO. VMM requests for access to the page, IO threads can use same page and we don't need to request for access if the request  has already been made early and the guest did not revoke
the access. For this purpose we maintain a bit for each page. Once we have the access to the page we set the bit so that later
we can avoid such request to reduce the number of IOCTLS and hypercalls. With this caching we see performance improvement ranging around 5% or more.
