### PR TITLE
build: Use binary kernel artifacts

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -154,8 +154,8 @@ update_workloads() {
     fi
     popd || exit
 
-    # Build custom kernel for guest VMs
-    build_custom_linux
+    # Download prebuild linux binaries
+    download_linux
 
     # Update the kernel in the cloud image for some tests that requires recent kernel version
     FOCAL_OS_RAW_IMAGE_UPDATE_KERNEL_NAME="focal-server-cloudimg-arm64-custom-20210929-0-update-kernel.raw"

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -56,7 +56,8 @@ popd || exit
 # Build custom kernel based on virtio-pmem and virtio-fs upstream patches
 VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
 if [ ! -f "$VMLINUX_IMAGE" ]; then
-    build_custom_linux
+    # Download prebuild linux binaries
+    download_linux
 fi
 
 CFLAGS=""

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -44,7 +44,8 @@ if ! grep focal sha1sums-x86_64 | sha1sum --check; then
 fi
 popd || exit
 
-build_custom_linux
+# Download prebuild linux binaries
+download_linux
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -102,7 +102,8 @@ popd || exit
 # Build custom kernel based on virtio-pmem and virtio-fs upstream patches
 VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
 if [ ! -f "$VMLINUX_IMAGE" ]; then
-    build_custom_linux
+    # Download prebuild linux binaries
+    download_linux
 fi
 
 VIRTIOFSD="$WORKLOADS_DIR/virtiofsd"

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -80,8 +80,8 @@ if [ "${TEST_ARCH}" == "aarch64" ]; then
     guestunmount "$FOCAL_OS_RAW_IMAGE_UPDATE_TOOL_ROOT_DIR"
 fi
 
-# Build custom kernel based on virtio-pmem and virtio-fs upstream patches
-build_custom_linux
+# Download prebuild linux binaries
+download_linux
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "${TEST_ARCH}-unknown-linux-musl" ]]; then


### PR DESCRIPTION
The Linux kernel fork repository for Cloud Hypervisor now produces
prebuilt x86-64 and aarch64 binaries. Speed up the CI by using those
binaries.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
