### PR TITLE
api_client: show response body in ServerResponse

### DIFF
--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -20,7 +20,7 @@ pub enum Error {
     MissingProtocol,
     #[error("Error parsing HTTP Content-Length field: {0}")]
     ContentLengthParsing(std::num::ParseIntError),
-    #[error("Server responded with an error: {0:?}")]
+    #[error("Server responded with an error: {0:?}: {1:?}")]
     ServerResponse(StatusCode, Option<String>),
 }
 


### PR DESCRIPTION
Otherwise, you just see output like "Error running command: Server responded with an error: InternalServerError", which isn't very helpful.  The response body used to be include with the message, but was removed when the Error enum was converted to thiserror.

Fixes: 5d0d56f5 ("api_client: Use thiserror for errors")