### PR TITLE
vmm: remove unused mutex in api

### DIFF
--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -9,7 +9,6 @@ use once_cell::sync::Lazy;
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver};
-use std::sync::{Arc, Mutex};
 use std::thread;
 use vm_migration::MigratableError;
 use vmm::api::{
@@ -81,7 +80,7 @@ fn generate_request(bytes: &[u8]) -> Option<Request> {
 struct StubApiRequestHandler;
 
 impl RequestHandler for StubApiRequestHandler {
-    fn vm_create(&mut self, _: Arc<Mutex<VmConfig>>) -> Result<(), VmError> {
+    fn vm_create(&mut self, _: Box<VmConfig>) -> Result<(), VmError> {
         Ok(())
     }
 
@@ -120,7 +119,7 @@ impl RequestHandler for StubApiRequestHandler {
 
     fn vm_info(&self) -> Result<VmInfoResponse, VmError> {
         Ok(VmInfoResponse {
-            config: Arc::new(Mutex::new(VmConfig {
+            config: Box::new(VmConfig {
                 cpus: CpusConfig {
                     boot_vcpus: 1,
                     max_vcpus: 1,
@@ -194,7 +193,7 @@ impl RequestHandler for StubApiRequestHandler {
                 preserved_fds: None,
                 landlock_enable: false,
                 landlock_rules: None,
-            })),
+            }),
             state: VmState::Running,
             memory_actual_size: 0,
             device_tree: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use signal_hook::consts::SIGSYS;
 use std::fs::File;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::sync::mpsc::channel;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::{env, io};
 use thiserror::Error;
 #[cfg(feature = "dbus_api")]
@@ -787,7 +787,7 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
                 .send(
                     api_evt.try_clone().unwrap(),
                     api_request_sender,
-                    Arc::new(Mutex::new(vm_config)),
+                    Box::new(vm_config),
                 )
                 .map_err(Error::VmCreate)?;
             vmm::api::VmBoot

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -51,7 +51,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::io;
 use std::sync::mpsc::{channel, RecvError, SendError, Sender};
-use std::sync::{Arc, Mutex};
 use vm_migration::MigratableError;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -210,10 +209,10 @@ impl Display for ApiError {
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct VmInfoResponse {
-    pub config: Arc<Mutex<VmConfig>>,
+    pub config: Box<VmConfig>,
     pub state: VmState,
     pub memory_actual_size: u64,
-    pub device_tree: Option<Arc<Mutex<DeviceTree>>>,
+    pub device_tree: Option<DeviceTree>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -287,7 +286,7 @@ pub enum ApiResponsePayload {
 pub type ApiResponse = Result<ApiResponsePayload, ApiError>;
 
 pub trait RequestHandler {
-    fn vm_create(&mut self, config: Arc<Mutex<VmConfig>>) -> Result<(), VmError>;
+    fn vm_create(&mut self, config: Box<VmConfig>) -> Result<(), VmError>;
 
     fn vm_boot(&mut self) -> Result<(), VmError>;
 
@@ -827,7 +826,7 @@ impl ApiAction for VmCounters {
 pub struct VmCreate;
 
 impl ApiAction for VmCreate {
-    type RequestBody = Arc<Mutex<VmConfig>>;
+    type RequestBody = Box<VmConfig>;
     type ResponseBody = ();
 
     fn request(

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1239,11 +1239,11 @@ fn apply_landlock(vm_config: Arc<Mutex<VmConfig>>) -> result::Result<(), Landloc
 }
 
 impl RequestHandler for Vmm {
-    fn vm_create(&mut self, config: Arc<Mutex<VmConfig>>) -> result::Result<(), VmError> {
+    fn vm_create(&mut self, config: Box<VmConfig>) -> result::Result<(), VmError> {
         // We only store the passed VM config.
         // The VM will be created when being asked to boot it.
         if self.vm_config.is_none() {
-            self.vm_config = Some(config);
+            self.vm_config = Some(Arc::new(Mutex::new(*config)));
             self.console_info =
                 Some(pre_create_console_devices(self).map_err(VmError::CreateConsoleDevices)?);
 
@@ -1555,23 +1555,25 @@ impl RequestHandler for Vmm {
 
     fn vm_info(&self) -> result::Result<VmInfoResponse, VmError> {
         match &self.vm_config {
-            Some(config) => {
+            Some(vm_config) => {
                 let state = match &self.vm {
                     Some(vm) => vm.get_state()?,
                     None => VmState::Created,
                 };
+                let config = vm_config.lock().unwrap().clone();
 
-                let config = Arc::clone(config);
-
-                let mut memory_actual_size = config.lock().unwrap().memory.total_size();
+                let mut memory_actual_size = config.memory.total_size();
                 if let Some(vm) = &self.vm {
                     memory_actual_size -= vm.balloon_size();
                 }
 
-                let device_tree = self.vm.as_ref().map(|vm| vm.device_tree());
+                let device_tree = self
+                    .vm
+                    .as_ref()
+                    .map(|vm| vm.device_tree().lock().unwrap().clone());
 
                 Ok(VmInfoResponse {
-                    config,
+                    config: Box::new(config),
                     state,
                     memory_actual_size,
                     device_tree,
@@ -2165,8 +2167,8 @@ mod unit_tests {
         .unwrap()
     }
 
-    fn create_dummy_vm_config() -> Arc<Mutex<VmConfig>> {
-        Arc::new(Mutex::new(VmConfig {
+    fn create_dummy_vm_config() -> Box<VmConfig> {
+        Box::new(VmConfig {
             cpus: CpusConfig {
                 boot_vcpus: 1,
                 max_vcpus: 1,
@@ -2243,7 +2245,7 @@ mod unit_tests {
             preserved_fds: None,
             landlock_enable: false,
             landlock_rules: None,
-        }))
+        })
     }
 
     #[test]


### PR DESCRIPTION
This patch removes locks in VmCreate request and VmInfo response since we needn't use a lock here and should ensure that internal implementation is transparent to the runtime.

Signed-off-by: Songqian Li <sionli@tencent.com>