### PR TITLE
vmm: memory_manager: Fix bound checks for memory hotplug

### DIFF
--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -270,7 +270,7 @@ impl VirtioMemConfig {
         // in the usable region.
         if addr % self.block_size != 0
             || size == 0
-            || (addr < self.addr || addr + size >= self.addr + self.usable_region_size)
+            || (addr < self.addr || addr + size > self.addr + self.usable_region_size)
         {
             return false;
         }

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1675,7 +1675,11 @@ impl MemoryManager {
 
         let start_addr = MemoryManager::start_addr(self.guest_memory.memory().last_addr(), true)?;
 
-        if start_addr.checked_add(size.try_into().unwrap()).unwrap() >= self.end_of_ram_area {
+        if start_addr
+            .checked_add((size - 1).try_into().unwrap())
+            .unwrap()
+            > self.end_of_ram_area
+        {
             return Err(Error::InsufficientHotplugRam);
         }
 


### PR DESCRIPTION
Bound checks for virtio-mem and ACPI memory hotplug are off by one and two, respectively. This prevents users to fully use the reserved memory hotplug size.

For ACPI, if we specific `--memory size=2G,hotplug_size=4G` and run `ch-remote resize --memory 6G`, cloud-hypervisor will report the following error because of the incorrect bound check:

`<vmm> ERROR:vmm/src/lib.rs:1631 -- Error when resizing VM: MemoryManager(InsufficientHotplugRam)`

Similarly, for virtio-mem, cloud-hypervisor will fail the incorrect bound check and abort the resize. The VM will see the following error in dmesg:

`virtio_mem virtio3: unknown error, marking device broken: -22`

This patch has fixed both bound checks and ensure that users can hot add memory up to the reserved hotplug size.

Signed-off-by: Yuhong Zhong yz@cs.columbia.edu