### PR TITLE
pci: Fix #[cfg(target_arch)] guards for port I/O

### DIFF
--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -134,7 +134,7 @@ impl PciBus {
                     io_bus
                         .insert(dev.clone(), bar.addr(), bar.size())
                         .map_err(PciRootError::PioInsert)?;
-                    #[cfg(target_arch = "aarch64")]
+                    #[cfg(not(target_arch = "x86_64"))]
                     error!("I/O region is not supported");
                 }
                 PciBarRegionType::Memory32BitRegion | PciBarRegionType::Memory64BitRegion => {

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -711,11 +711,11 @@ impl VfioCommon {
 
             let bar_addr = match region_type {
                 PciBarRegionType::IoRegion => {
-                    #[cfg(target_arch = "aarch64")]
+                    #[cfg(not(target_arch = "x86_64"))]
                     unimplemented!();
 
                     // The address needs to be 4 bytes aligned.
-                    #[cfg(not(target_arch = "aarch64"))]
+                    #[cfg(target_arch = "x86_64")]
                     allocator
                         .lock()
                         .unwrap()
@@ -795,7 +795,7 @@ impl VfioCommon {
                 PciBarRegionType::IoRegion => {
                     #[cfg(target_arch = "x86_64")]
                     allocator.free_io_addresses(region.start, region.length);
-                    #[cfg(target_arch = "aarch64")]
+                    #[cfg(not(target_arch = "x86_64"))]
                     error!("I/O region is not supported");
                 }
                 PciBarRegionType::Memory32BitRegion => {


### PR DESCRIPTION
Port I/O is only supported on x86_64 - use inverted conditional logic to
match the other architectures rather than calling them out specifically.
This will be relevant when RISC-V support is added.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
