### PR TITLE
tests: Relax rate limit check for group rate limiter

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10750,7 +10750,7 @@ mod rate_limiter {
             } else {
                 parse_fio_output_iops(&output, &fio_ops, num_queues * num_disks).unwrap()
             };
-            assert!(check_rate_limit(measured_rate, limit_rate, 0.1));
+            assert!(check_rate_limit(measured_rate, limit_rate, 0.2));
         });
 
         let _ = child.kill();


### PR DESCRIPTION
The rate-limiter worker now is running on Azure VMs whose performance are more prone to be fluctuate, particularly on block performances. This commit relaxes the limit check for group rate limiter tests to make them less flaky.