### PR TITLE
Pass the newly created console resizer pipe during vm reboot

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1490,11 +1490,10 @@ impl RequestHandler for Vmm {
         event!("vm", "rebooting");
 
         // First we stop the current VM
-        let (config, console_resize_pipe) = if let Some(mut vm) = self.vm.take() {
+        let config = if let Some(mut vm) = self.vm.take() {
             let config = vm.get_config();
-            let console_resize_pipe = vm.console_resize_pipe();
             vm.shutdown()?;
-            (config, console_resize_pipe)
+            config
         } else {
             return Err(VmError::VmNotCreated);
         };
@@ -1536,7 +1535,7 @@ impl RequestHandler for Vmm {
             self.hypervisor.clone(),
             activate_evt,
             self.console_info.clone(),
-            console_resize_pipe,
+            self.console_resize_pipe.as_ref().map(Arc::clone),
             Arc::clone(&self.original_termios_opt),
             None,
             None,


### PR DESCRIPTION
For a VM with virt-console enabled, when a reboot is requested, the console devices are closed during the shutdown path. As part of this the sigwinch listener process and the console resizer pipe could be closed. For the new incarnation of the VM, fresh set of console devices are setup and a new console resizer pipe is created. The new VM should be setup to use the newly created console devices including the console resizer pipe.

Reading from the older console resizer pipe results in unexpected eof error and terminates the cloud hypervisor process.

cloud-hypervisor: 182.581732s: <__console> ERROR:virtio-devices/src/thread_helper.rs:55 -- Error running worker: HandleEvent(Failed to get resize event: Error { kind: UnexpectedEof, message: "failed to fill whole buffer" })