### PR TITLE
hypervisor: Introduce RISC-V architecture

### DIFF
--- a/.github/workflows/preview-riscv64.yaml
+++ b/.github/workflows/preview-riscv64.yaml
@@ -1,0 +1,30 @@
+name: Cloud Hypervisor RISC-V 64-bit Preview
+on: [pull_request, merge_group]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Cargo
+    runs-on: riscv64-qemu-host
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        run: /opt/scripts/exec-in-qemu.sh rustup default 1.77.0
+
+      - name: Build hypervisor Module (kvm)
+        run: /opt/scripts/exec-in-qemu.sh cargo rustc --locked -p hypervisor --no-default-features --features "kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+
+      - name: Clippy hypervisor Module (kvm)
+        run: /opt/scripts/exec-in-qemu.sh cargo clippy --locked -p hypervisor --no-default-features --features "kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+
+      - name: Test hypervisor Module (kvm)
+        run: /opt/scripts/exec-in-qemu.sh cargo test --locked -p hypervisor --no-default-features --features "kvm"
+
+      - name: Check no files were modified
+        run: test -z "$(git status --porcelain)"

--- a/hypervisor/src/arch/mod.rs
+++ b/hypervisor/src/arch/mod.rs
@@ -21,3 +21,6 @@ pub mod x86;
 
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64;
+
+#[cfg(target_arch = "riscv64")]
+pub mod riscv64;

--- a/hypervisor/src/arch/riscv64/aia.rs
+++ b/hypervisor/src/arch/riscv64/aia.rs
@@ -1,0 +1,65 @@
+// Copyright © 2024 Institute of Software, CAS. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::any::Any;
+use std::result;
+
+use thiserror::Error;
+
+use crate::{AiaState, HypervisorDeviceError, HypervisorVmError};
+
+/// Errors thrown while setting up the VAIA.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Error while calling KVM ioctl for setting up the global interrupt controller.
+    #[error("Failed creating AIA device: {0}")]
+    CreateAia(HypervisorVmError),
+    /// Error while setting device attributes for the AIA.
+    #[error("Failed setting device attributes for the AIA: {0}")]
+    SetDeviceAttribute(HypervisorDeviceError),
+    /// Error while getting device attributes for the AIA.
+    #[error("Failed getting device attributes for the AIA: {0}")]
+    GetDeviceAttribute(HypervisorDeviceError),
+}
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Debug)]
+pub struct VaiaConfig {
+    pub vcpu_count: u64,
+    pub aplic_addr: u64,
+    pub aplic_size: u64,
+    pub imsic_addr: u64,
+    pub imsic_size: u64,
+    pub nr_irqs: u32,
+}
+
+/// Hypervisor agnostic interface for a virtualized AIA
+pub trait Vaia: Send + Sync {
+    /// Returns the compatibility property of APLIC
+    fn aplic_compatibility(&self) -> &str;
+
+    /// Returns an array with APLIC device properties
+    fn aplic_properties(&self) -> [u64; 4];
+
+    /// Returns the compatibility property of IMSIC
+    fn imsic_compatibility(&self) -> &str;
+
+    /// Returns an array with IMSIC device properties
+    fn imsic_properties(&self) -> [u64; 4];
+
+    /// Returns the number of vCPUs this AIA handles
+    fn vcpu_count(&self) -> u64;
+
+    /// Returns whether the AIA device is MSI compatible or not
+    fn msi_compatible(&self) -> bool;
+
+    /// Downcast the trait object to its concrete type.
+    fn as_any_concrete_mut(&mut self) -> &mut dyn Any;
+
+    /// Save the state of AiaImsics.
+    fn state(&self) -> Result<AiaState>;
+
+    /// Restore the state of AiaImsics.
+    fn set_state(&mut self, state: &AiaState) -> Result<()>;
+}

--- a/hypervisor/src/arch/riscv64/mod.rs
+++ b/hypervisor/src/arch/riscv64/mod.rs
@@ -1,0 +1,5 @@
+// Copyright © 2024 Institute of Software, CAS. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod aia;

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -216,6 +216,16 @@ pub enum HypervisorCpuError {
     #[error("Failed to set aarch64 core register: {0}")]
     SetAarchCoreRegister(#[source] anyhow::Error),
     ///
+    /// Getting RISC-V 64-bit core register error
+    ///
+    #[error("Failed to get riscv64 core register: {0}")]
+    GetRiscvCoreRegister(#[source] anyhow::Error),
+    ///
+    /// Setting RISC-V 64-bit core register error
+    ///
+    #[error("Failed to set riscv64 core register: {0}")]
+    SetRiscvCoreRegister(#[source] anyhow::Error),
+    ///
     /// Getting registers list error
     ///
     #[error("Failed to retrieve list of registers: {0}")]
@@ -230,6 +240,16 @@ pub enum HypervisorCpuError {
     ///
     #[error("Failed to set system register: {0}")]
     SetSysRegister(#[source] anyhow::Error),
+    ///
+    /// Getting RISC-V 64-bit non-core register error
+    ///
+    #[error("Failed to get non-core register: {0}")]
+    GetNonCoreRegister(#[source] anyhow::Error),
+    ///
+    /// Setting RISC-V 64-bit non-core register error
+    ///
+    #[error("Failed to set non-core register: {0}")]
+    SetNonCoreRegister(#[source] anyhow::Error),
     ///
     /// GVA translation error
     ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -65,6 +65,9 @@ use crate::{
 // aarch64 dependencies
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64;
+// riscv64 dependencies
+#[cfg(target_arch = "riscv64")]
+pub mod riscv64;
 #[cfg(target_arch = "aarch64")]
 use std::mem;
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1260,7 +1260,14 @@ impl cpu::Vcpu for KvmVcpu {
     /// Returns StandardRegisters with default value set
     ///
     fn create_standard_regs(&self) -> StandardRegisters {
-        kvm_bindings::kvm_regs::default().into()
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        {
+            kvm_bindings::kvm_regs::default().into()
+        }
+        #[cfg(target_arch = "riscv64")]
+        {
+            kvm_bindings::kvm_riscv_core::default().into()
+        }
     }
     #[cfg(target_arch = "x86_64")]
     ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -3398,3 +3398,58 @@ impl KvmVcpu {
             .map_err(|e| cpu::HypervisorCpuError::SetVcpuEvents(e.into()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg(target_arch = "riscv64")]
+    fn test_get_and_set_regs() {
+        use super::*;
+
+        let kvm = KvmHypervisor::new().unwrap();
+        let hypervisor = Arc::new(kvm);
+        let vm = hypervisor.create_vm().expect("new VM fd creation failed");
+        let vcpu0 = vm.create_vcpu(0, None).unwrap();
+
+        let core_regs = StandardRegisters::from(kvm_riscv_core {
+            regs: user_regs_struct {
+                pc: 0x00,
+                ra: 0x01,
+                sp: 0x02,
+                gp: 0x03,
+                tp: 0x04,
+                t0: 0x05,
+                t1: 0x06,
+                t2: 0x07,
+                s0: 0x08,
+                s1: 0x09,
+                a0: 0x0a,
+                a1: 0x0b,
+                a2: 0x0c,
+                a3: 0x0d,
+                a4: 0x0e,
+                a5: 0x0f,
+                a6: 0x10,
+                a7: 0x11,
+                s2: 0x12,
+                s3: 0x13,
+                s4: 0x14,
+                s5: 0x15,
+                s6: 0x16,
+                s7: 0x17,
+                s8: 0x18,
+                s9: 0x19,
+                s10: 0x1a,
+                s11: 0x1b,
+                t3: 0x1c,
+                t4: 0x1d,
+                t5: 0x1e,
+                t6: 0x1f,
+            },
+            mode: 0x00,
+        });
+
+        vcpu0.set_regs(&core_regs).unwrap();
+        assert_eq!(vcpu0.get_regs().unwrap(), core_regs);
+    }
+}

--- a/hypervisor/src/kvm/riscv64/aia.rs
+++ b/hypervisor/src/kvm/riscv64/aia.rs
@@ -1,0 +1,273 @@
+// Copyright © 2024 Institute of Software, CAS. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::any::Any;
+
+use kvm_ioctls::DeviceFd;
+use serde::{Deserialize, Serialize};
+
+use crate::arch::riscv64::aia::{Error, Result, Vaia, VaiaConfig};
+use crate::device::HypervisorDeviceError;
+use crate::kvm::KvmVm;
+use crate::Vm;
+
+pub struct KvmAiaImsics {
+    /// The KVM device for the Aia
+    device: DeviceFd,
+
+    /// AIA APLIC address
+    aplic_addr: u64,
+
+    /// AIA APLIC size
+    aplic_size: u64,
+
+    /// AIA IMSIC address
+    imsic_addr: u64,
+
+    /// AIA IMSIC size
+    imsic_size: u64,
+
+    /// Number of CPUs handled by the device
+    vcpu_count: u64,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct AiaImsicsState {}
+
+impl KvmAiaImsics {
+    /// Device trees specific constants
+
+    fn version() -> u32 {
+        kvm_bindings::kvm_device_type_KVM_DEV_TYPE_RISCV_AIA
+    }
+
+    /// Setup the device-specific attributes
+    fn init_device_attributes(&mut self, nr_irqs: u32) -> Result<()> {
+        // AIA part attributes
+        // Getting the working mode of RISC-V AIA, defaults to EMUL, passible
+        // variants are EMUL, HW_ACCL, AUTO
+        let mut aia_mode = kvm_bindings::KVM_DEV_RISCV_AIA_MODE_EMUL;
+        Self::get_device_attribute(
+            &self.device,
+            kvm_bindings::KVM_DEV_RISCV_AIA_GRP_CONFIG,
+            u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_CONFIG_MODE),
+            &mut aia_mode as *mut u32 as u64,
+            0,
+        )?;
+
+        // Report AIA MODE
+
+        // Setting up the number of wired interrupt sources
+        Self::set_device_attribute(
+            &self.device,
+            kvm_bindings::KVM_DEV_RISCV_AIA_GRP_CONFIG,
+            u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_CONFIG_SRCS),
+            &nr_irqs as *const u32 as u64,
+            0,
+        )?;
+
+        // Getting the number of ids
+        let mut aia_nr_ids: u32 = 0;
+        Self::get_device_attribute(
+            &self.device,
+            kvm_bindings::KVM_DEV_RISCV_AIA_GRP_CONFIG,
+            u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_CONFIG_IDS),
+            &mut aia_nr_ids as *mut u32 as u64,
+            0,
+        )?;
+
+        // Report NR_IDS
+
+        // Setting up hart_bits
+        let max_hart_index = self.vcpu_count - 1;
+        let hart_bits = std::cmp::max(64 - max_hart_index.leading_zeros(), 1);
+        Self::set_device_attribute(
+            &self.device,
+            kvm_bindings::KVM_DEV_RISCV_AIA_GRP_CONFIG,
+            u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_CONFIG_HART_BITS),
+            &hart_bits as *const u32 as u64,
+            0,
+        )?;
+
+        // Designate addresses of APLIC and IMSICS
+
+        // Setting up RISC-V APLIC
+        Self::set_device_attribute(
+            &self.device,
+            kvm_bindings::KVM_DEV_RISCV_AIA_GRP_ADDR,
+            u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_ADDR_APLIC),
+            &self.aplic_addr as *const u64 as u64,
+            0,
+        )?;
+
+        // Helpers to calculate address and attribute of IMSIC of each vCPU
+        let riscv_imsic_addr_of =
+            |cpu_index: u64| -> u64 { self.imsic_addr + cpu_index * self.imsic_size };
+        let riscv_imsic_attr_of = |cpu_index: u64| -> u64 { cpu_index };
+
+        // Setting up RISC-V IMSICs
+        for cpu_index in 0..self.vcpu_count {
+            let cpu_imsic_addr = riscv_imsic_addr_of(cpu_index);
+            Self::set_device_attribute(
+                &self.device,
+                kvm_bindings::KVM_DEV_RISCV_AIA_GRP_ADDR,
+                riscv_imsic_attr_of(cpu_index),
+                &cpu_imsic_addr as *const u64 as u64,
+                0,
+            )?;
+        }
+
+        // Finalizing the AIA device
+        Self::set_device_attribute(
+            &self.device,
+            kvm_bindings::KVM_DEV_RISCV_AIA_GRP_CTRL,
+            u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_CTRL_INIT),
+            0,
+            0,
+        )
+    }
+
+    /// Create a KVM Vaia device
+    fn create_device(vm: &KvmVm) -> Result<DeviceFd> {
+        let mut aia_device = kvm_bindings::kvm_create_device {
+            type_: Self::version(),
+            fd: 0,
+            flags: 0,
+        };
+
+        let device_fd = vm
+            .create_device(&mut aia_device)
+            .map_err(Error::CreateAia)?;
+
+        // We know for sure this is a KVM fd
+        Ok(device_fd.to_kvm().unwrap())
+    }
+
+    /// Get an AIA device attribute
+    fn get_device_attribute(
+        device: &DeviceFd,
+        group: u32,
+        attr: u64,
+        addr: u64,
+        flags: u32,
+    ) -> Result<()> {
+        let mut attr = kvm_bindings::kvm_device_attr {
+            flags,
+            group,
+            attr,
+            addr,
+        };
+        // SAFETY: attr.addr is safe to write to.
+        unsafe {
+            device.get_device_attr(&mut attr).map_err(|e| {
+                Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
+            })
+        }
+    }
+
+    /// Set an AIA device attribute
+    fn set_device_attribute(
+        device: &DeviceFd,
+        group: u32,
+        attr: u64,
+        addr: u64,
+        flags: u32,
+    ) -> Result<()> {
+        let attr = kvm_bindings::kvm_device_attr {
+            flags,
+            group,
+            attr,
+            addr,
+        };
+        device.set_device_attr(&attr).map_err(|e| {
+            Error::SetDeviceAttribute(HypervisorDeviceError::SetDeviceAttribute(e.into()))
+        })
+    }
+
+    /// Method to initialize the AIA device
+    pub fn new(vm: &dyn Vm, config: VaiaConfig) -> Result<KvmAiaImsics> {
+        // This is inside KVM module
+        let vm = vm.as_any().downcast_ref::<KvmVm>().expect("Wrong VM type?");
+
+        let vaia = Self::create_device(vm)?;
+
+        let mut aia_device = KvmAiaImsics {
+            device: vaia,
+            vcpu_count: config.vcpu_count,
+            aplic_addr: config.aplic_addr,
+            aplic_size: config.aplic_size,
+            imsic_addr: config.imsic_addr,
+            imsic_size: config.imsic_size,
+        };
+
+        aia_device.init_device_attributes(config.nr_irqs)?;
+
+        Ok(aia_device)
+    }
+}
+
+impl Vaia for KvmAiaImsics {
+    fn aplic_compatibility(&self) -> &str {
+        "riscv,aplic"
+    }
+
+    fn aplic_properties(&self) -> [u64; 4] {
+        [0, self.aplic_addr, 0, self.aplic_size]
+    }
+
+    fn imsic_compatibility(&self) -> &str {
+        "riscv,imsics"
+    }
+
+    fn imsic_properties(&self) -> [u64; 4] {
+        [0, self.imsic_addr, 0, self.imsic_size * self.vcpu_count]
+    }
+
+    fn vcpu_count(&self) -> u64 {
+        self.vcpu_count
+    }
+
+    fn msi_compatible(&self) -> bool {
+        true
+    }
+
+    fn as_any_concrete_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    /// Save the state of AIA.
+    fn state(&self) -> Result<AiaImsicsState> {
+        unimplemented!()
+    }
+
+    /// Restore the state of AIA_IMSICs.
+    fn set_state(&mut self, _state: &AiaImsicsState) -> Result<()> {
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::arch::riscv64::aia::VaiaConfig;
+    use crate::kvm::KvmAiaImsics;
+
+    fn create_test_vaia_config() -> VaiaConfig {
+        VaiaConfig {
+            vcpu_count: 1,
+            aplic_addr: 0xd000000,
+            aplic_size: 0x4000,
+            imsic_addr: 0x2800000,
+            imsic_size: 0x1000,
+            nr_irqs: 256,
+        }
+    }
+
+    #[test]
+    fn test_create_aia() {
+        let hv = crate::new().unwrap();
+        let vm = hv.create_vm().unwrap();
+
+        assert!(KvmAiaImsics::new(&*vm, create_test_vaia_config()).is_ok());
+    }
+}

--- a/hypervisor/src/kvm/riscv64/mod.rs
+++ b/hypervisor/src/kvm/riscv64/mod.rs
@@ -1,0 +1,161 @@
+// Copyright © 2024 Institute of Software, CAS. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use kvm_bindings::{
+    kvm_mp_state, kvm_one_reg, kvm_riscv_core, KVM_REG_RISCV_CORE, KVM_REG_RISCV_TYPE_MASK,
+    KVM_REG_SIZE_MASK, KVM_REG_SIZE_U64,
+};
+pub use kvm_bindings::{kvm_one_reg as Register, RegList};
+pub use kvm_ioctls::{Cap, Kvm};
+use serde::{Deserialize, Serialize};
+
+use crate::kvm::{KvmError, KvmResult};
+
+// This macro gets the offset of a structure (i.e `str`) member (i.e `field`) without having
+// an instance of that structure.
+#[macro_export]
+macro_rules! _offset_of {
+    ($str:ty, $field:ident) => {{
+        let tmp: std::mem::MaybeUninit<$str> = std::mem::MaybeUninit::uninit();
+        let base = tmp.as_ptr();
+
+        // Avoid warnings when nesting `unsafe` blocks.
+        #[allow(unused_unsafe)]
+        // SAFETY: The pointer is valid and aligned, just not initialised. Using `addr_of` ensures
+        // that we don't actually read from `base` (which would be UB) nor create an intermediate
+        // reference.
+        let member = unsafe { core::ptr::addr_of!((*base).$field) } as *const u8;
+
+        // Avoid warnings when nesting `unsafe` blocks.
+        #[allow(unused_unsafe)]
+        // SAFETY: The two pointers are within the same allocated object `tmp`. All requirements
+        // from offset_from are upheld.
+        unsafe {
+            member.offset_from(base as *const u8) as usize
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! offset_of {
+    ($reg_struct:ty, $field:ident) => {
+        $crate::_offset_of!($reg_struct, $field)
+    };
+    ($outer_reg_struct:ty, $outer_field:ident, $($inner_reg_struct:ty, $inner_field:ident), +) => {
+        $crate::_offset_of!($outer_reg_struct, $outer_field) + offset_of!($($inner_reg_struct, $inner_field), +)
+    };
+}
+
+// Following are macros that help with getting the ID of a riscv64 register, including config registers, core registers and timer registers.
+// The register of core registers are wrapped in the `user_regs_struct` structure. See:
+// https://elixir.bootlin.com/linux/v6.10/source/arch/riscv/include/uapi/asm/kvm.h#L62
+
+// Get the ID of a register
+#[macro_export]
+macro_rules! riscv64_reg_id {
+    ($reg_type: tt, $offset: tt) => {
+        // The core registers of an riscv64 machine are represented
+        // in kernel by the `kvm_riscv_core` structure:
+        //
+        // struct kvm_riscv_core {
+        //     struct user_regs_struct regs;
+        //     unsigned long mode;
+        // };
+        //
+        // struct user_regs_struct {
+        //     unsigned long pc;
+        //     unsigned long ra;
+        //     unsigned long sp;
+        //     unsigned long gp;
+        //     unsigned long tp;
+        //     unsigned long t0;
+        //     unsigned long t1;
+        //     unsigned long t2;
+        //     unsigned long s0;
+        //     unsigned long s1;
+        //     unsigned long a0;
+        //     unsigned long a1;
+        //     unsigned long a2;
+        //     unsigned long a3;
+        //     unsigned long a4;
+        //     unsigned long a5;
+        //     unsigned long a6;
+        //     unsigned long a7;
+        //     unsigned long s2;
+        //     unsigned long s3;
+        //     unsigned long s4;
+        //     unsigned long s5;
+        //     unsigned long s6;
+        //     unsigned long s7;
+        //     unsigned long s8;
+        //     unsigned long s9;
+        //     unsigned long s10;
+        //     unsigned long s11;
+        //     unsigned long t3;
+        //     unsigned long t4;
+        //     unsigned long t5;
+        //     unsigned long t6;
+        // };
+        // The id of a core register can be obtained like this: offset = id &
+        // ~(KVM_REG_ARCH_MASK | KVM_REG_SIZE_MASK | KVM_REG_RISCV_CORE). Thus,
+        // id = KVM_REG_RISCV | KVM_REG_SIZE_U64 | KVM_REG_RISCV_CORE | offset
+        //
+        // To generalize, the id of a register can be obtained by:
+        // id = KVM_REG_RISCV | KVM_REG_SIZE_U64 |
+        //      KVM_REG_RISCV_CORE/KVM_REG_RISCV_CONFIG/KVM_REG_RISCV_TIMER |
+        //      offset
+        kvm_bindings::KVM_REG_RISCV as u64
+            | u64::from($reg_type)
+            | u64::from(kvm_bindings::KVM_REG_SIZE_U64)
+            | (($offset / std::mem::size_of::<u64>()) as u64)
+    };
+}
+
+/// Specifies whether a particular register is a core register or not.
+///
+/// # Arguments
+///
+/// * `regid` - The index of the register we are checking.
+pub fn is_non_core_register(regid: u64) -> bool {
+    if (regid & KVM_REG_RISCV_TYPE_MASK as u64) == KVM_REG_RISCV_CORE as u64 {
+        return false;
+    }
+
+    let size = regid & KVM_REG_SIZE_MASK;
+
+    assert!(
+        size == KVM_REG_SIZE_U64,
+        "Unexpected register size for system register {size}"
+    );
+
+    true
+}
+
+pub fn check_required_kvm_extensions(kvm: &Kvm) -> KvmResult<()> {
+    macro_rules! check_extension {
+        ($cap:expr) => {
+            if !kvm.check_extension($cap) {
+                return Err(KvmError::CapabilityMissing($cap));
+            }
+        };
+    }
+
+    // SetGuestDebug is required but some kernels have it implemented without the capability flag.
+    check_extension!(Cap::ImmediateExit);
+    check_extension!(Cap::Ioeventfd);
+    check_extension!(Cap::Irqchip);
+    check_extension!(Cap::Irqfd);
+    check_extension!(Cap::IrqRouting);
+    check_extension!(Cap::MpState);
+    check_extension!(Cap::OneReg);
+    check_extension!(Cap::UserMemory);
+    Ok(())
+}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct VcpuKvmState {
+    pub mp_state: kvm_mp_state,
+    pub core_regs: kvm_riscv_core,
+    pub non_core_regs: Vec<kvm_one_reg>,
+}

--- a/hypervisor/src/kvm/riscv64/mod.rs
+++ b/hypervisor/src/kvm/riscv64/mod.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod aia;
+
 use kvm_bindings::{
     kvm_mp_state, kvm_one_reg, kvm_riscv_core, KVM_REG_RISCV_CORE, KVM_REG_RISCV_TYPE_MASK,
     KVM_REG_SIZE_MASK, KVM_REG_SIZE_U64,

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright © 2024 Institute of Software, CAS. All rights reserved.
+//
 // Copyright © 2019 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
@@ -16,6 +18,7 @@
 //!
 //! - x86_64
 //! - arm64
+//! - riscv64 (experimental)
 //!
 
 #[macro_use]
@@ -57,6 +60,8 @@ pub use cpu::{HypervisorCpuError, Vcpu, VmExit};
 pub use device::HypervisorDeviceError;
 #[cfg(all(feature = "kvm", target_arch = "aarch64"))]
 pub use kvm::{aarch64, GicState};
+#[cfg(all(feature = "kvm", target_arch = "riscv64"))]
+pub use kvm::{riscv64, AiaState};
 pub use vm::{
     DataMatch, HypervisorVmError, InterruptSourceConfig, LegacyIrqSourceConfig, MsiIrqSourceConfig,
     Vm, VmOps,
@@ -193,8 +198,10 @@ pub enum IrqRoutingEntry {
 
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum StandardRegisters {
-    #[cfg(feature = "kvm")]
+    #[cfg(all(feature = "kvm", not(target_arch = "riscv64")))]
     Kvm(kvm_bindings::kvm_regs),
+    #[cfg(all(feature = "kvm", target_arch = "riscv64"))]
+    Kvm(kvm_bindings::kvm_riscv_core),
     #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
     Mshv(mshv_bindings::StandardRegisters),
 }
@@ -314,3 +321,125 @@ get_aarch64_reg!(regs, [u64; 31usize]);
 get_aarch64_reg!(sp, u64);
 get_aarch64_reg!(pc, u64);
 get_aarch64_reg!(pstate, u64);
+
+macro_rules! set_riscv64_reg {
+    (mode) => {
+        #[cfg(target_arch = "riscv64")]
+        impl StandardRegisters {
+            pub fn set_mode(&mut self, val: u64) {
+                match self {
+                    #[cfg(feature = "kvm")]
+                    StandardRegisters::Kvm(s) => s.mode = val,
+                }
+            }
+        }
+    };
+    ($reg_name:ident) => {
+        concat_idents!(method_name = "set_", $reg_name {
+            #[cfg(target_arch = "riscv64")]
+            impl StandardRegisters {
+                pub fn method_name(&mut self, val: u64) {
+                    match self {
+                        #[cfg(feature = "kvm")]
+                        StandardRegisters::Kvm(s) => s.regs.$reg_name = val,
+                    }
+                }
+            }
+        });
+    }
+}
+
+macro_rules! get_riscv64_reg {
+    (mode) => {
+        #[cfg(target_arch = "riscv64")]
+        impl StandardRegisters {
+            pub fn get_mode(&self) -> u64 {
+                match self {
+                    #[cfg(feature = "kvm")]
+                    StandardRegisters::Kvm(s) => s.mode,
+                }
+            }
+        }
+    };
+    ($reg_name:ident) => {
+        concat_idents!(method_name = "get_", $reg_name {
+            #[cfg(target_arch = "riscv64")]
+            impl StandardRegisters {
+                pub fn method_name(&self) -> u64 {
+                    match self {
+                        #[cfg(feature = "kvm")]
+                        StandardRegisters::Kvm(s) => s.regs.$reg_name,
+                    }
+                }
+            }
+        });
+    }
+}
+
+set_riscv64_reg!(pc);
+set_riscv64_reg!(ra);
+set_riscv64_reg!(sp);
+set_riscv64_reg!(gp);
+set_riscv64_reg!(tp);
+set_riscv64_reg!(t0);
+set_riscv64_reg!(t1);
+set_riscv64_reg!(t2);
+set_riscv64_reg!(s0);
+set_riscv64_reg!(s1);
+set_riscv64_reg!(a0);
+set_riscv64_reg!(a1);
+set_riscv64_reg!(a2);
+set_riscv64_reg!(a3);
+set_riscv64_reg!(a4);
+set_riscv64_reg!(a5);
+set_riscv64_reg!(a6);
+set_riscv64_reg!(a7);
+set_riscv64_reg!(s2);
+set_riscv64_reg!(s3);
+set_riscv64_reg!(s4);
+set_riscv64_reg!(s5);
+set_riscv64_reg!(s6);
+set_riscv64_reg!(s7);
+set_riscv64_reg!(s8);
+set_riscv64_reg!(s9);
+set_riscv64_reg!(s10);
+set_riscv64_reg!(s11);
+set_riscv64_reg!(t3);
+set_riscv64_reg!(t4);
+set_riscv64_reg!(t5);
+set_riscv64_reg!(t6);
+set_riscv64_reg!(mode);
+
+get_riscv64_reg!(pc);
+get_riscv64_reg!(ra);
+get_riscv64_reg!(sp);
+get_riscv64_reg!(gp);
+get_riscv64_reg!(tp);
+get_riscv64_reg!(t0);
+get_riscv64_reg!(t1);
+get_riscv64_reg!(t2);
+get_riscv64_reg!(s0);
+get_riscv64_reg!(s1);
+get_riscv64_reg!(a0);
+get_riscv64_reg!(a1);
+get_riscv64_reg!(a2);
+get_riscv64_reg!(a3);
+get_riscv64_reg!(a4);
+get_riscv64_reg!(a5);
+get_riscv64_reg!(a6);
+get_riscv64_reg!(a7);
+get_riscv64_reg!(s2);
+get_riscv64_reg!(s3);
+get_riscv64_reg!(s4);
+get_riscv64_reg!(s5);
+get_riscv64_reg!(s6);
+get_riscv64_reg!(s7);
+get_riscv64_reg!(s8);
+get_riscv64_reg!(s9);
+get_riscv64_reg!(s10);
+get_riscv64_reg!(s11);
+get_riscv64_reg!(t3);
+get_riscv64_reg!(t4);
+get_riscv64_reg!(t5);
+get_riscv64_reg!(t6);
+get_riscv64_reg!(mode);


### PR DESCRIPTION
- Introduce definitions, traits relate to RISC-V AIA (Advanced Interrupt
Architecutre) construction.
- Integrate `aia` module into `riscv64` module, and enable `riscv64`
module if target architecture is RISC-V 64-bit.
- Implement macros to calculate register ID on riscv64, definition of
RISC-V `VcpuKvmState`.
- Implement definition required to work with KVM in-kernel AIA device,
construction procedure of AIA.
- Add error variants specific to RISC-V architecture.
- Incorporates riscv64 register interaction and AIA creation to kvm
module. Complete `Vcpu` trait on RISC-V platform.
- Add RISC-V specific Vcpu trait. Disable `set_guest_debug` on RISC-V
platform.
- Introduce RISC-V specific Vm traits and error variant, disable
`create_irq_chip` on RISC-V platform.
- Introduce cpu, vm, kvm, arch module RISC-V platform support. Add macro
definitions to implement methods interacting with RISC-V registers.
- Complement `create_standard_regs` implementation on RISC-V platform to
work with `From` trait of `kvm_riscv_core`.
- Integrate machine provided by @ISRC-CAS to run build, clippy and
unit-test on hypervisor module.
- Add unit-test to make sure get_regs and set_regs on riscv64 architecture
work as expected, effectively avoiding typos in register names.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>