### PR TITLE
build: Centralize rust-vmm crates to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,15 +39,15 @@ hypervisor = { path = "hypervisor" }
 libc = "0.2.158"
 log = { version = "0.4.22", features = ["std"] }
 option_parser = { path = "option_parser" }
-seccompiler = "0.4.0"
+seccompiler = { workspace = true }
 serde_json = "1.0.120"
 signal-hook = "0.3.17"
 thiserror = "1.0.62"
 tpm = { path = "tpm" }
 tracer = { path = "tracer" }
-vm-memory = "0.15.0"
+vm-memory = { workspace = true }
 vmm = { path = "vmm" }
-vmm-sys-util = "0.12.1"
+vmm-sys-util = { workspace = true }
 zbus = { version = "4.1.2", optional = true }
 
 [dev-dependencies]
@@ -100,3 +100,21 @@ members = [
   "vm-virtio",
   "vmm",
 ]
+
+[workspace.dependencies]
+acpi_tables = { git = "https://github.com/rust-vmm/acpi_tables", branch = "main" }
+kvm-bindings = "0.9.1"
+kvm-ioctls = "0.18.0"
+linux-loader = "0.12.0"
+mshv-bindings = { git = "https://github.com/rust-vmm/mshv", tag = "v0.3.0" }
+mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", tag = "v0.3.0" }
+seccompiler = "0.4.0"
+vfio-bindings = { git = "https://github.com/rust-vmm/vfio", branch = "main" }
+vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main" }
+vfio_user = { git = "https://github.com/rust-vmm/vfio-user", branch = "main" }
+vhost = "0.12.0"
+virtio-bindings = "0.2.2"
+virtio-queue = "0.13.0"
+vm-fdt = { git = "https://github.com/rust-vmm/vm-fdt", branch = "main" }
+vm-memory = "0.15.0"
+vmm-sys-util = "0.12.1"

--- a/api_client/Cargo.toml
+++ b/api_client/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 
 [dependencies]
 thiserror = "1.0.62"
-vmm-sys-util = "0.12.1"
+vmm-sys-util = { workspace = true }

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -15,18 +15,15 @@ anyhow = "1.0.87"
 byteorder = "1.5.0"
 hypervisor = { path = "../hypervisor" }
 libc = "0.2.158"
-linux-loader = { version = "0.12.0", features = ["bzimage", "elf", "pe"] }
+linux-loader = { workspace = true, features = ["bzimage", "elf", "pe"] }
 log = "0.4.22"
 serde = { version = "1.0.208", features = ["derive", "rc"] }
 thiserror = "1.0.62"
 uuid = "1.8.0"
-vm-memory = { version = "0.15.0", features = [
-  "backend-bitmap",
-  "backend-mmap",
-] }
+vm-memory = { workspace = true, features = ["backend-bitmap", "backend-mmap"] }
 vm-migration = { path = "../vm-migration" }
-vmm-sys-util = { version = "0.12.1", features = ["with-serde"] }
+vmm-sys-util = { workspace = true, features = ["with-serde"] }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 fdt_parser = { version = "0.1.5", package = "fdt" }
-vm-fdt = { git = "https://github.com/rust-vmm/vm-fdt", branch = "main" }
+vm-fdt = { workspace = true }

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -19,12 +19,12 @@ serde = { version = "1.0.208", features = ["derive"] }
 smallvec = "1.13.2"
 thiserror = "1.0.62"
 uuid = { version = "1.8.0", features = ["v4"] }
-virtio-bindings = { version = "0.2.2", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.13.0"
-vm-memory = { version = "0.15.0", features = [
+virtio-bindings = { workspace = true, features = ["virtio-v5_0_0"] }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true, features = [
   "backend-atomic",
   "backend-bitmap",
   "backend-mmap",
 ] }
 vm-virtio = { path = "../vm-virtio" }
-vmm-sys-util = "0.12.1"
+vmm-sys-util = { workspace = true }

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -5,7 +5,7 @@ name = "devices"
 version = "0.1.0"
 
 [dependencies]
-acpi_tables = { git = "https://github.com/rust-vmm/acpi_tables", branch = "main" }
+acpi_tables = { workspace = true }
 anyhow = "1.0.87"
 arch = { path = "../arch" }
 bitflags = "2.6.0"
@@ -21,13 +21,13 @@ thiserror = "1.0.62"
 tpm = { path = "../tpm" }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.15.0", features = [
+vm-memory = { workspace = true, features = [
   "backend-atomic",
   "backend-bitmap",
   "backend-mmap",
 ] }
 vm-migration = { path = "../vm-migration" }
-vmm-sys-util = "0.12.1"
+vmm-sys-util = { workspace = true }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 arch = { path = "../arch" }

--- a/fuzz/fuzz_targets/console.rs
+++ b/fuzz/fuzz_targets/console.rs
@@ -66,7 +66,7 @@ fuzz_target!(|bytes| {
             memfd_create(&std::ffi::CString::new("fuzz_console_output").unwrap()).unwrap(),
         )
     };
-    let endpoint = virtio_devices::Endpoint::FilePair(output, pipe_rx);
+    let endpoint = virtio_devices::Endpoint::FilePair(Arc::new(output), Arc::new(pipe_rx));
 
     let (mut console, _) = virtio_devices::Console::new(
         "fuzzer_console".to_owned(),

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -18,26 +18,23 @@ cfg-if = "1.0.0"
 concat-idents = "1.1.5"
 igvm = { version = "0.3.3", optional = true }
 igvm_defs = { version = "0.3.1", optional = true }
-kvm-bindings = { version = "0.9.1", optional = true, features = ["serde"] }
-kvm-ioctls = { version = "0.18.0", optional = true }
+kvm-bindings = { workspace = true, optional = true, features = ["serde"] }
+kvm-ioctls = { workspace = true, optional = true }
 libc = "0.2.158"
 log = "0.4.22"
-mshv-bindings = { git = "https://github.com/rust-vmm/mshv", tag = "v0.3.0", features = [
+mshv-bindings = { workspace = true, features = [
   "fam-wrappers",
   "with-serde",
 ], optional = true }
-mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", tag = "v0.3.0", optional = true }
+mshv-ioctls = { workspace = true, optional = true }
 serde = { version = "1.0.208", features = ["derive", "rc"] }
 serde_with = { version = "3.9.0", default-features = false, features = [
   "macros",
 ] }
 thiserror = "1.0.62"
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vm-memory = { version = "0.15.0", features = [
-  "backend-atomic",
-  "backend-mmap",
-] }
-vmm-sys-util = { version = "0.12.1", features = ["with-serde"] }
+vfio-ioctls = { workspace = true, default-features = false }
+vm-memory = { workspace = true, features = ["backend-atomic", "backend-mmap"] }
+vmm-sys-util = { workspace = true, features = ["with-serde"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.iced-x86]
 default-features = false

--- a/net_gen/Cargo.toml
+++ b/net_gen/Cargo.toml
@@ -5,4 +5,4 @@ name = "net_gen"
 version = "0.1.0"
 
 [dependencies]
-vmm-sys-util = "0.12.1"
+vmm-sys-util = { workspace = true }

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -13,15 +13,15 @@ net_gen = { path = "../net_gen" }
 rate_limiter = { path = "../rate_limiter" }
 serde = { version = "1.0.208", features = ["derive"] }
 thiserror = "1.0.62"
-virtio-bindings = "0.2.2"
-virtio-queue = "0.13.0"
-vm-memory = { version = "0.15.0", features = [
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true, features = [
   "backend-atomic",
   "backend-bitmap",
   "backend-mmap",
 ] }
 vm-virtio = { path = "../vm-virtio" }
-vmm-sys-util = "0.12.1"
+vmm-sys-util = { workspace = true }
 
 [dev-dependencies]
 once_cell = "1.19.0"

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -17,17 +17,15 @@ libc = "0.2.158"
 log = "0.4.22"
 serde = { version = "1.0.208", features = ["derive"] }
 thiserror = "1.0.62"
-vfio-bindings = { git = "https://github.com/rust-vmm/vfio", branch = "main", features = [
-  "fam-wrappers",
-] }
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vfio_user = { git = "https://github.com/rust-vmm/vfio-user", branch = "main" }
+vfio-bindings = { workspace = true, features = ["fam-wrappers"] }
+vfio-ioctls = { workspace = true, default-features = false }
+vfio_user = { workspace = true }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.15.0", features = [
+vm-memory = { workspace = true, features = [
   "backend-atomic",
   "backend-bitmap",
   "backend-mmap",
 ] }
 vm-migration = { path = "../vm-migration" }
-vmm-sys-util = "0.12.1"
+vmm-sys-util = { workspace = true }

--- a/rate_limiter/Cargo.toml
+++ b/rate_limiter/Cargo.toml
@@ -8,4 +8,4 @@ epoll = "4.3.3"
 libc = "0.2.158"
 log = "0.4.22"
 thiserror = "1.0.62"
-vmm-sys-util = "0.12.1"
+vmm-sys-util = { workspace = true }

--- a/test_infra/Cargo.toml
+++ b/test_infra/Cargo.toml
@@ -12,5 +12,5 @@ once_cell = "1.19.0"
 serde = { version = "1.0.208", features = ["derive", "rc"] }
 serde_json = "1.0.120"
 ssh2 = { version = "0.9.4", features = ["vendored-openssl"] }
-vmm-sys-util = "0.12.1"
+vmm-sys-util = { workspace = true }
 wait-timeout = "0.2.0"

--- a/tpm/Cargo.toml
+++ b/tpm/Cargo.toml
@@ -12,4 +12,4 @@ libc = "0.2.153"
 log = "0.4.21"
 net_gen = { path = "../net_gen" }
 thiserror = "1.0.58"
-vmm-sys-util = "0.12.1"
+vmm-sys-util = { workspace = true }

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -13,9 +13,9 @@ epoll = "4.3.3"
 libc = "0.2.158"
 log = "0.4.22"
 option_parser = { path = "../option_parser" }
-vhost = { version = "0.12.0", features = ["vhost-user-backend"] }
+vhost = { workspace = true, features = ["vhost-user-backend"] }
 vhost-user-backend = "0.16.0"
-virtio-bindings = "0.2.2"
-virtio-queue = "0.13.0"
-vm-memory = "0.15.0"
-vmm-sys-util = "0.12.1"
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -13,8 +13,8 @@ libc = "0.2.158"
 log = "0.4.22"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
-vhost = { version = "0.12.0", features = ["vhost-user-backend"] }
+vhost = { workspace = true, features = ["vhost-user-backend"] }
 vhost-user-backend = "0.16.0"
-virtio-bindings = "0.2.2"
-vm-memory = "0.15.0"
-vmm-sys-util = "0.12.1"
+virtio-bindings = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -17,12 +17,12 @@ epoll = "4.3.3"
 event_monitor = { path = "../event_monitor" }
 libc = "0.2.158"
 log = "0.4.22"
-mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", tag = "v0.3.0", optional = true }
+mshv-ioctls = { workspace = true, optional = true }
 net_gen = { path = "../net_gen" }
 net_util = { path = "../net_util" }
 pci = { path = "../pci" }
 rate_limiter = { path = "../rate_limiter" }
-seccompiler = "0.4.0"
+seccompiler = { workspace = true }
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.120"
 serde_with = { version = "3.9.0", default-features = false, features = [
@@ -30,21 +30,21 @@ serde_with = { version = "3.9.0", default-features = false, features = [
 ] }
 serial_buffer = { path = "../serial_buffer" }
 thiserror = "1.0.62"
-vhost = { version = "0.12.0", features = [
+vhost = { workspace = true, features = [
   "vhost-kern",
   "vhost-user-backend",
   "vhost-user-frontend",
   "vhost-vdpa",
 ] }
-virtio-bindings = { version = "0.2.2", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.13.0"
+virtio-bindings = { workspace = true, features = ["virtio-v5_0_0"] }
+virtio-queue = { workspace = true }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.15.0", features = [
+vm-memory = { workspace = true, features = [
   "backend-atomic",
   "backend-bitmap",
   "backend-mmap",
 ] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
-vmm-sys-util = "0.12.1"
+vmm-sys-util = { workspace = true }

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 libc = "0.2.158"
-vm-memory = "0.15.0"
+vm-memory = { workspace = true }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 arch = { path = "../arch" }

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -14,6 +14,6 @@ anyhow = "1.0.87"
 hypervisor = { path = "../hypervisor" }
 serde = { version = "1.0.208", features = ["derive", "rc"] }
 thiserror = "1.0.62"
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vm-memory = { version = "0.15.0", features = ["backend-mmap"] }
-vmm-sys-util = "0.12.1"
+vfio-ioctls = { workspace = true, default-features = false }
+vm-memory = { workspace = true, features = ["backend-mmap"] }
+vmm-sys-util = { workspace = true }

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -9,7 +9,4 @@ anyhow = "1.0.87"
 serde = { version = "1.0.208", features = ["derive", "rc"] }
 serde_json = "1.0.120"
 thiserror = "1.0.62"
-vm-memory = { version = "0.15.0", features = [
-  "backend-atomic",
-  "backend-mmap",
-] }
+vm-memory = { workspace = true, features = ["backend-atomic", "backend-mmap"] }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -9,8 +9,8 @@ default = []
 
 [dependencies]
 log = "0.4.22"
-virtio-queue = "0.13.0"
-vm-memory = { version = "0.15.0", features = [
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true, features = [
   "backend-atomic",
   "backend-bitmap",
   "backend-mmap",

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -25,7 +25,7 @@ tdx = ["arch/tdx", "hypervisor/tdx"]
 tracing = ["tracer/tracing"]
 
 [dependencies]
-acpi_tables = { git = "https://github.com/rust-vmm/acpi_tables", branch = "main" }
+acpi_tables = { workspace = true }
 anyhow = "1.0.87"
 arc-swap = "1.7.1"
 arch = { path = "../arch" }
@@ -48,10 +48,10 @@ igvm = { version = "0.3.3", optional = true }
 igvm_defs = { version = "0.3.1", optional = true }
 landlock = "0.4.0"
 libc = "0.2.158"
-linux-loader = { version = "0.12.0", features = ["bzimage", "elf", "pe"] }
+linux-loader = { workspace = true, features = ["bzimage", "elf", "pe"] }
 log = "0.4.22"
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
-mshv-bindings = { git = "https://github.com/rust-vmm/mshv", tag = "v0.3.0", features = [
+mshv-bindings = { workspace = true, features = [
   "fam-wrappers",
   "with-serde",
 ], optional = true }
@@ -61,7 +61,7 @@ option_parser = { path = "../option_parser" }
 pci = { path = "../pci" }
 range_map_vec = { version = "0.2.0", optional = true }
 rate_limiter = { path = "../rate_limiter" }
-seccompiler = "0.4.0"
+seccompiler = { workspace = true }
 serde = { version = "1.0.208", features = ["derive", "rc"] }
 serde_json = "1.0.120"
 serial_buffer = { path = "../serial_buffer" }
@@ -69,19 +69,19 @@ signal-hook = "0.3.17"
 thiserror = "1.0.62"
 tracer = { path = "../tracer" }
 uuid = "1.8.0"
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
-vfio_user = { git = "https://github.com/rust-vmm/vfio-user", branch = "main" }
+vfio-ioctls = { workspace = true, default-features = false }
+vfio_user = { workspace = true }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.13.0"
+virtio-queue = { workspace = true }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
-vm-memory = { version = "0.15.0", features = [
+vm-memory = { workspace = true, features = [
   "backend-atomic",
   "backend-bitmap",
   "backend-mmap",
 ] }
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
-vmm-sys-util = { version = "0.12.1", features = ["with-serde"] }
+vmm-sys-util = { workspace = true, features = ["with-serde"] }
 zbus = { version = "4.1.2", optional = true }
 zerocopy = { version = "0.7.35", features = ["alloc", "derive"] }


### PR DESCRIPTION
- Modify `Cargo.toml` in each member crate to follow the dependencies
specified in root `Cargo.toml` file.
- The construction of `FilePair` in `virtio_devices` component has changed
in 287887c, wrapping the parameters with `Arc` to fix fuzz build.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>