### PR TITLE
misc: Eliminate use of `assert!((...).is_ok())`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,34 +35,34 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: Build (default features)
-        run: cargo rustc --locked --bin cloud-hypervisor -- -D warnings -D clippy::undocumented_unsafe_blocks
+        run: cargo rustc --locked --bin cloud-hypervisor -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Build (kvm)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "kvm"  -- -D warnings -D clippy::undocumented_unsafe_blocks
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "kvm"  -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Build (default features + tdx)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "tdx" -- -D warnings -D clippy::undocumented_unsafe_blocks
+        run: cargo rustc --locked --bin cloud-hypervisor --features "tdx" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Build (default features + dbus_api)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "dbus_api" -- -D warnings -D clippy::undocumented_unsafe_blocks
+        run: cargo rustc --locked --bin cloud-hypervisor --features "dbus_api" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Build (default features + guest_debug)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "guest_debug" -- -D warnings -D clippy::undocumented_unsafe_blocks
+        run: cargo rustc --locked --bin cloud-hypervisor --features "guest_debug" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Build (default features + pvmemcontrol)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "pvmemcontrol" -- -D warnings -D clippy::undocumented_unsafe_blocks
+        run: cargo rustc --locked --bin cloud-hypervisor --features "pvmemcontrol" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Build (mshv)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv"  -- -D warnings -D clippy::undocumented_unsafe_blocks
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv"  -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Build (sev_snp)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "sev_snp"  -- -D warnings -D clippy::undocumented_unsafe_blocks
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "sev_snp"  -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Build (igvm)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "igvm"  -- -D warnings -D clippy::undocumented_unsafe_blocks
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "igvm"  -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Build (mshv + kvm)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv,kvm"  -- -D warnings -D clippy::undocumented_unsafe_blocks
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv,kvm"  -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Release Build (default features)
         run: cargo build --locked --all --release --target=${{ matrix.target }}

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -54,70 +54,70 @@ jobs:
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks
+          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Clippy (default features)
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --target=${{ matrix.target }} --locked --all --all-targets --tests --examples -- -D warnings -D clippy::undocumented_unsafe_blocks
+          args: --target=${{ matrix.target }} --locked --all --all-targets --tests --examples -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Clippy (default features + guest_debug)
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --target=${{ matrix.target }} --locked --all --all-targets --tests --examples --features "guest_debug" -- -D warnings -D clippy::undocumented_unsafe_blocks
+          args: --target=${{ matrix.target }} --locked --all --all-targets --tests --examples --features "guest_debug" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Clippy (default features + pvmemcontrol)
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --target=${{ matrix.target }} --locked --all --all-targets --tests --examples --features "pvmemcontrol" -- -D warnings -D clippy::undocumented_unsafe_blocks
+          args: --target=${{ matrix.target }} --locked --all --all-targets --tests --examples --features "pvmemcontrol" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Clippy (default features + tracing)
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --target=${{ matrix.target }} --locked --all --all-targets --tests --examples --features "tracing" -- -D warnings -D clippy::undocumented_unsafe_blocks
+          args: --target=${{ matrix.target }} --locked --all --all-targets --tests --examples --features "tracing" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Clippy (mshv)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "mshv" -- -D warnings -D clippy::undocumented_unsafe_blocks
+          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "mshv" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Clippy (mshv + kvm)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "mshv,kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks
+          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "mshv,kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Clippy (sev_snp)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "sev_snp" -- -D warnings -D clippy::undocumented_unsafe_blocks
+          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "sev_snp" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Clippy (igvm)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "igvm" -- -D warnings -D clippy::undocumented_unsafe_blocks
+          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "igvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Clippy (kvm + tdx)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "tdx,kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks
+          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "tdx,kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
       - name: Check build did not modify any files
         run: test -z "$(git status --porcelain)"

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -1581,7 +1581,7 @@ mod tests {
             None,
             None,
         );
-        assert!(config_err.is_err());
+        config_err.unwrap_err();
 
         // Now assigning some memory that falls before the 32bit memory hole.
         let arch_mem_regions = arch_memory_regions();
@@ -1686,13 +1686,13 @@ mod tests {
         // Exercise the scenario where the field storing the length of the e820 entry table is
         // is bigger than the allocated memory.
         params.e820_entries = params.e820_table.len() as u8 + 1;
-        assert!(add_e820_entry(
+        add_e820_entry(
             &mut params,
             e820_table[0].addr,
             e820_table[0].size,
-            e820_table[0].type_
+            e820_table[0].type_,
         )
-        .is_err());
+        .unwrap_err();
     }
 
     #[test]

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -336,7 +336,7 @@ mod tests {
         let mem = GuestMemoryMmap::from_ranges(&[(MPTABLE_START, compute_mp_size(num_cpus) - 1)])
             .unwrap();
 
-        assert!(setup_mptable(MPTABLE_START, &mem, num_cpus, None).is_err());
+        setup_mptable(MPTABLE_START, &mem, num_cpus, None).unwrap_err();
     }
 
     #[test]
@@ -433,6 +433,6 @@ mod tests {
             GuestMemoryMmap::from_ranges(&[(MPTABLE_START, compute_mp_size(cpus as u8))]).unwrap();
 
         let result = setup_mptable(MPTABLE_START, &mem, cpus as u8, None);
-        assert!(result.is_err());
+        result.unwrap_err();
     }
 }

--- a/block/src/qcow/mod.rs
+++ b/block/src/qcow/mod.rs
@@ -2051,8 +2051,7 @@ mod tests {
             .expect("Failed to write header to shm.");
         disk_file.rewind().unwrap();
         // The maximum nesting depth is 0, which means backing file is not allowed.
-        let res = QcowFile::from_with_nesting_depth(disk_file, 0);
-        assert!(res.is_ok());
+        QcowFile::from_with_nesting_depth(disk_file, 0).unwrap();
     }
 
     #[test]
@@ -2068,7 +2067,6 @@ mod tests {
         disk_file.rewind().unwrap();
         // The maximum nesting depth is 0, which means backing file is not allowed.
         let res = QcowFile::from_with_nesting_depth(disk_file, 0);
-        assert!(res.is_err());
         assert!(matches!(res.unwrap_err(), Error::MaxNestingDepthExceeded));
     }
 

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -434,7 +434,7 @@ mod tests {
 
         // write 1 to the interrupt event fd, so that read doesn't block in case the event fd
         // counter doesn't change (for 0 it blocks)
-        assert!(intr_evt.write(1).is_ok());
+        intr_evt.write(1).unwrap();
         serial.write(0, IER as u64, &[IER_RECV_BIT]);
         serial.queue_input_bytes(b"abc").unwrap();
 
@@ -471,7 +471,7 @@ mod tests {
 
         // write 1 to the interrupt event fd, so that read doesn't block in case the event fd
         // counter doesn't change (for 0 it blocks)
-        assert!(intr_evt.write(1).is_ok());
+        intr_evt.write(1).unwrap();
         serial.write(0, IER as u64, &[IER_THR_BIT]);
         serial.write(0, DATA as u64, b"a");
 

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -549,7 +549,7 @@ mod tests {
 
         // write 1 to the interrupt event fd, so that read doesn't block in case the event fd
         // counter doesn't change (for 0 it blocks)
-        assert!(intr_evt.write(1).is_ok());
+        intr_evt.write(1).unwrap();
         pl011.queue_input_bytes(b"abc").unwrap();
 
         assert_eq!(intr_evt.read().unwrap(), 2);

--- a/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
@@ -220,7 +220,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0x38, 0xc4]; // cmp ah,al
         let mut vmm = MockVmm::new(ip, vec![(Register::RAX, rax)], None);
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let rflags: u64 = vmm.cpu_state(cpu_id).unwrap().flags() & FLAGS_MASK;
         assert_eq!(0b1000100, rflags);
@@ -234,7 +234,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0x83, 0xf8, 0x64]; // cmp eax,100
         let mut vmm = MockVmm::new(ip, vec![(Register::RAX, rax)], None);
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let rflags: u64 = vmm.cpu_state(cpu_id).unwrap().flags() & FLAGS_MASK;
         assert_eq!(0b100, rflags);
@@ -248,7 +248,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0x83, 0xf8, 0xff]; // cmp eax,-1
         let mut vmm = MockVmm::new(ip, vec![(Register::RAX, rax)], None);
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let rflags: u64 = vmm.cpu_state(cpu_id).unwrap().flags() & FLAGS_MASK;
         assert_eq!(0b101, rflags);
@@ -263,7 +263,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0x48, 0x39, 0xd8, 0x00, 0xc3]; // cmp rax,rbx + two bytes garbage
         let mut vmm = MockVmm::new(ip, vec![(Register::RAX, rax), (Register::RBX, rbx)], None);
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let rflags: u64 = vmm.cpu_state(cpu_id).unwrap().flags() & FLAGS_MASK;
         assert_eq!(0b100, rflags);
@@ -290,7 +290,7 @@ mod tests {
                 vec![(Register::RAX, rax), (Register::RBX, rbx)],
                 None,
             );
-            assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+            vmm.emulate_first_insn(0, &insn).unwrap();
 
             let rflags: u64 = vmm.cpu_state(0).unwrap().flags() & FLAGS_MASK;
             assert_eq!(d.2, rflags);
@@ -318,7 +318,7 @@ mod tests {
                 vec![(Register::RAX, rax), (Register::RBX, rbx)],
                 None,
             );
-            assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+            vmm.emulate_first_insn(0, &insn).unwrap();
 
             let rflags: u64 = vmm.cpu_state(0).unwrap().flags() & FLAGS_MASK;
             assert_eq!(d.2, rflags);

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -280,7 +280,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0x48, 0x89, 0xd8];
         let mut vmm = MockVmm::new(ip, vec![(Register::RBX, rbx)], None);
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let rax: u64 = vmm
             .cpu_state(cpu_id)
@@ -298,7 +298,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0x48, 0xb8, 0x44, 0x33, 0x22, 0x11, 0x44, 0x33, 0x22, 0x11];
         let mut vmm = MockVmm::new(ip, vec![], None);
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let rax: u64 = vmm
             .cpu_state(cpu_id)
@@ -318,7 +318,7 @@ mod tests {
         let memory: [u8; 8] = target_rax.to_le_bytes();
         let insn = [0x48, 0x8b, 0x04, 0x00];
         let mut vmm = MockVmm::new(ip, vec![(Register::RAX, rax)], Some((rax + rax, &memory)));
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         rax = vmm
             .cpu_state(cpu_id)
@@ -336,7 +336,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0xb0, 0x11];
         let mut vmm = MockVmm::new(ip, vec![], None);
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let al = vmm
             .cpu_state(cpu_id)
@@ -354,7 +354,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0xb8, 0x11, 0x00, 0x00, 0x00];
         let mut vmm = MockVmm::new(ip, vec![], None);
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let eax = vmm
             .cpu_state(cpu_id)
@@ -372,7 +372,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0x48, 0xc7, 0xc0, 0x44, 0x33, 0x22, 0x11];
         let mut vmm = MockVmm::new(ip, vec![], None);
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let rax: u64 = vmm
             .cpu_state(cpu_id)
@@ -395,7 +395,7 @@ mod tests {
             vec![(Register::RAX, rax), (Register::DH, dh.into())],
             None,
         );
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let mut memory: [u8; 1] = [0; 1];
         vmm.read_memory(rax, &mut memory).unwrap();
@@ -416,7 +416,7 @@ mod tests {
             vec![(Register::RAX, rax), (Register::ESI, esi.into())],
             None,
         );
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let mut memory: [u8; 4] = [0; 4];
         vmm.read_memory(rax, &mut memory).unwrap();
@@ -438,7 +438,7 @@ mod tests {
             vec![(Register::RAX, rax), (Register::EDI, edi.into())],
             None,
         );
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let mut memory: [u8; 4] = [0; 4];
         vmm.read_memory(rax + displacement, &mut memory).unwrap();
@@ -461,7 +461,7 @@ mod tests {
             vec![(Register::RAX, rax)],
             Some((rax + displacement, &memory)),
         );
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let new_eax = vmm
             .cpu_state(cpu_id)
@@ -486,7 +486,7 @@ mod tests {
             vec![(Register::RAX, rax)],
             Some((rax + displacement, &memory)),
         );
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let new_al = vmm
             .cpu_state(cpu_id)
@@ -511,7 +511,7 @@ mod tests {
             0x48, 0x8b, 0x58, 0x10, // mov rbx, qword ptr [rax+10h]
         ];
         let mut vmm = MockVmm::new(ip, vec![], Some((rax + displacement, &memory)));
-        assert!(vmm.emulate_insn(cpu_id, &insn, Some(2)).is_ok());
+        vmm.emulate_insn(cpu_id, &insn, Some(2)).unwrap();
 
         let rbx: u64 = vmm
             .cpu_state(cpu_id)
@@ -538,7 +538,7 @@ mod tests {
 
         let mut vmm = MockVmm::new(ip, vec![], Some((rax + displacement, &memory)));
         // Only run the first instruction.
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         assert_eq!(ip + 7, vmm.cpu_state(cpu_id).unwrap().ip());
 
@@ -569,7 +569,7 @@ mod tests {
 
         let mut vmm = MockVmm::new(ip, vec![], Some((rax + displacement, &memory)));
         // Run the 2 first instructions.
-        assert!(vmm.emulate_insn(cpu_id, &insn, Some(2)).is_ok());
+        vmm.emulate_insn(cpu_id, &insn, Some(2)).unwrap();
 
         assert_eq!(ip + 7 + 4, vmm.cpu_state(cpu_id).unwrap().ip());
 
@@ -597,7 +597,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0x0f, 0xb6, 0xc3];
         let mut vmm = MockVmm::new(ip, vec![(Register::BX, bx as u64)], None);
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let eax: u64 = vmm
             .cpu_state(cpu_id)
@@ -615,7 +615,7 @@ mod tests {
         let cpu_id = 0;
         let insn = [0x0f, 0xb6, 0xc7];
         let mut vmm = MockVmm::new(ip, vec![(Register::BX, bx as u64)], None);
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let eax: u64 = vmm
             .cpu_state(cpu_id)
@@ -635,7 +635,7 @@ mod tests {
         let insn = [0x0f, 0xb7, 0x03];
         let memory: [u8; 1] = value.to_le_bytes();
         let mut vmm = MockVmm::new(ip, vec![(Register::RBX, rbx)], Some((rbx, &memory)));
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let eax: u64 = vmm
             .cpu_state(cpu_id)
@@ -680,7 +680,7 @@ mod tests {
 
             let memory: [u8; 8] = mem_value.to_le_bytes();
             let mut vmm = MockVmm::new(ip, vec![], Some((mem_addr, &memory)));
-            assert!(vmm.emulate_first_insn(cpu_id, &instruction_bytes).is_ok());
+            vmm.emulate_first_insn(cpu_id, &instruction_bytes).unwrap();
 
             let ax: u64 = vmm.cpu_state(cpu_id).unwrap().read_reg(register).unwrap();
 
@@ -737,7 +737,7 @@ mod tests {
             ]);
 
             let mut vmm = MockVmm::new(ip, vec![(Register::RAX, ax)], None);
-            assert!(vmm.emulate_first_insn(cpu_id, &instruction_bytes).is_ok());
+            vmm.emulate_first_insn(cpu_id, &instruction_bytes).unwrap();
 
             match register {
                 Register::AX => {

--- a/hypervisor/src/arch/x86/emulator/instructions/movs.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/movs.rs
@@ -131,7 +131,7 @@ mod tests {
 
         let mut vmm = MockVmm::new(ip, regs, Some((0, &memory)));
 
-        assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+        vmm.emulate_first_insn(0, &insn).unwrap();
 
         vmm.read_memory(0x10, &mut data).unwrap();
         assert_eq!(0xaabbccdd12345678, <u64>::from_le_bytes(data));
@@ -159,7 +159,7 @@ mod tests {
 
         let mut vmm = MockVmm::new(ip, regs, Some((0, &memory)));
 
-        assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+        vmm.emulate_first_insn(0, &insn).unwrap();
 
         vmm.read_memory(0xc, &mut data).unwrap();
         assert_eq!(0x12345678, <u32>::from_le_bytes(data));
@@ -184,7 +184,7 @@ mod tests {
 
         let mut vmm = MockVmm::new(ip, regs, Some((0, &memory)));
 
-        assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+        vmm.emulate_first_insn(0, &insn).unwrap();
 
         vmm.read_memory(0x8, &mut data).unwrap();
         assert_eq!(0x12345678, <u32>::from_le_bytes(data));
@@ -212,7 +212,7 @@ mod tests {
 
         let mut vmm = MockVmm::new(ip, regs, Some((0, &memory)));
 
-        assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+        vmm.emulate_first_insn(0, &insn).unwrap();
 
         vmm.read_memory(0xc, &mut data).unwrap();
         assert_eq!(0x5678, <u16>::from_le_bytes(data));
@@ -243,7 +243,7 @@ mod tests {
 
         let mut vmm = MockVmm::new(ip, regs, Some((0, &memory)));
 
-        assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+        vmm.emulate_first_insn(0, &insn).unwrap();
 
         vmm.read_memory(0x8, &mut data).unwrap();
         assert_eq!(0x5678, <u16>::from_le_bytes(data));
@@ -269,7 +269,7 @@ mod tests {
 
         let mut vmm = MockVmm::new(ip, regs, Some((0, &memory)));
 
-        assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+        vmm.emulate_first_insn(0, &insn).unwrap();
 
         vmm.read_memory(0x8, &mut data).unwrap();
         assert_eq!(0x78, data[0]);
@@ -299,7 +299,7 @@ mod tests {
 
         let mut vmm = MockVmm::new(ip, regs, Some((0, &memory)));
 
-        assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+        vmm.emulate_first_insn(0, &insn).unwrap();
 
         vmm.read_memory(0x8, &mut data).unwrap();
         assert_eq!(0x78, data[0]);

--- a/hypervisor/src/arch/x86/emulator/instructions/or.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/or.rs
@@ -69,7 +69,7 @@ mod tests {
             Some((0, &memory)),
         );
 
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_ok());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap();
 
         let mut out: [u8; 1] = [0; 1];
 

--- a/hypervisor/src/arch/x86/emulator/instructions/stos.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/stos.rs
@@ -112,7 +112,7 @@ mod tests {
 
         let mut vmm = MockVmm::new(ip, regs, Some((0, &memory)));
 
-        assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+        vmm.emulate_first_insn(0, &insn).unwrap();
 
         vmm.read_memory(0, &mut data).unwrap();
         assert_eq!(0x12ffffff, <u32>::from_le_bytes(data));
@@ -134,7 +134,7 @@ mod tests {
 
         let mut vmm = MockVmm::new(ip, regs, Some((0, &memory)));
 
-        assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+        vmm.emulate_first_insn(0, &insn).unwrap();
 
         vmm.read_memory(0x0, &mut data).unwrap();
         assert_eq!(0x12aabb78, <u32>::from_le_bytes(data));
@@ -162,7 +162,7 @@ mod tests {
 
         let mut vmm = MockVmm::new(ip, regs, Some((0, &memory)));
 
-        assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+        vmm.emulate_first_insn(0, &insn).unwrap();
 
         vmm.read_memory(0x0, &mut data).unwrap();
         assert_eq!(0xaabb5678, <u32>::from_le_bytes(data));
@@ -195,7 +195,7 @@ mod tests {
         state.set_flags(state.flags() | DF);
         vmm.set_cpu_state(0, state).unwrap();
 
-        assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+        vmm.emulate_first_insn(0, &insn).unwrap();
 
         vmm.read_memory(0x0, &mut data).unwrap();
         assert_eq!(0x12345678, <u32>::from_le_bytes(data));
@@ -224,7 +224,7 @@ mod tests {
 
         let mut vmm = MockVmm::new(ip, regs, Some((0, &memory)));
 
-        assert!(vmm.emulate_first_insn(0, &insn).is_ok());
+        vmm.emulate_first_insn(0, &insn).unwrap();
 
         vmm.read_memory(0x0, &mut data).unwrap();
         assert_eq!(0x11223344aabbccdd, <u64>::from_le_bytes(data));

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -809,7 +809,7 @@ mod tests {
         ];
 
         let mut vmm = MockVmm::new(ip, vec![], Some((ip, &memory)));
-        assert!(vmm.emulate_insn(cpu_id, &[], Some(2)).is_ok());
+        vmm.emulate_insn(cpu_id, &[], Some(2)).unwrap();
 
         let rax: u64 = vmm
             .cpu_state(cpu_id)
@@ -847,7 +847,7 @@ mod tests {
         ];
 
         let mut vmm = MockVmm::new(ip, vec![], Some((ip, &memory)));
-        assert!(vmm.emulate_insn(cpu_id, &[], None).is_err());
+        vmm.emulate_insn(cpu_id, &[], None).unwrap_err();
     }
 
     #[test]
@@ -875,7 +875,7 @@ mod tests {
         ];
 
         let mut vmm = MockVmm::new(ip, vec![], Some((ip, &memory)));
-        assert!(vmm.emulate_insn(cpu_id, &insn, Some(2)).is_ok());
+        vmm.emulate_insn(cpu_id, &insn, Some(2)).unwrap();
 
         let rax: u64 = vmm
             .cpu_state(cpu_id)
@@ -910,7 +910,7 @@ mod tests {
         ];
 
         let mut vmm = MockVmm::new(ip, vec![], Some((ip, &memory)));
-        assert!(vmm.emulate_insn(cpu_id, &insn, Some(2)).is_ok());
+        vmm.emulate_insn(cpu_id, &insn, Some(2)).unwrap();
 
         let rbx: u64 = vmm
             .cpu_state(cpu_id)
@@ -945,7 +945,7 @@ mod tests {
         ];
 
         let mut vmm = MockVmm::new(ip, vec![], Some((ip, &memory)));
-        assert!(vmm.emulate_insn(cpu_id, &insn, Some(1)).is_ok());
+        vmm.emulate_insn(cpu_id, &insn, Some(1)).unwrap();
 
         let new_ip: u64 = vmm.cpu_state(cpu_id).unwrap().ip();
         assert_eq!(new_ip, ip + 0x7 /* length of mov rax,0x1000 */);
@@ -986,6 +986,6 @@ mod tests {
         ];
 
         let mut vmm = MockVmm::new(ip, vec![], Some((ip, &memory)));
-        assert!(vmm.emulate_first_insn(cpu_id, &insn).is_err());
+        vmm.emulate_first_insn(cpu_id, &insn).unwrap_err();
     }
 }

--- a/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -491,7 +491,7 @@ mod tests {
         let hv = crate::new().unwrap();
         let vm = hv.create_vm().unwrap();
 
-        assert!(KvmGicV3Its::new(&*vm, create_test_vgic_config()).is_ok());
+        KvmGicV3Its::new(&*vm, create_test_vgic_config()).unwrap();
     }
 
     #[test]
@@ -501,13 +501,10 @@ mod tests {
         let _ = vm.create_vcpu(0, None).unwrap();
         let gic = KvmGicV3Its::new(&*vm, create_test_vgic_config()).expect("Cannot create gic");
 
-        let res = get_dist_regs(&gic.device);
-        assert!(res.is_ok());
-        let state = res.unwrap();
+        let state = get_dist_regs(&gic.device).unwrap();
         assert_eq!(state.len(), 568);
 
-        let res = set_dist_regs(&gic.device, &state);
-        assert!(res.is_ok());
+        set_dist_regs(&gic.device, &state).unwrap();
     }
 
     #[test]
@@ -518,13 +515,11 @@ mod tests {
         let gic = KvmGicV3Its::new(&*vm, create_test_vgic_config()).expect("Cannot create gic");
 
         let gicr_typer = vec![123];
-        let res = get_redist_regs(&gic.device, &gicr_typer);
-        assert!(res.is_ok());
-        let state = res.unwrap();
+        let state = get_redist_regs(&gic.device, &gicr_typer).unwrap();
         println!("{}", state.len());
         assert!(state.len() == 24);
 
-        assert!(set_redist_regs(&gic.device, &gicr_typer, &state).is_ok());
+        set_redist_regs(&gic.device, &gicr_typer, &state).unwrap();
     }
 
     #[test]
@@ -535,13 +530,11 @@ mod tests {
         let gic = KvmGicV3Its::new(&*vm, create_test_vgic_config()).expect("Cannot create gic");
 
         let gicr_typer = vec![123];
-        let res = get_icc_regs(&gic.device, &gicr_typer);
-        assert!(res.is_ok());
-        let state = res.unwrap();
+        let state = get_icc_regs(&gic.device, &gicr_typer).unwrap();
         println!("{}", state.len());
         assert!(state.len() == 9);
 
-        assert!(set_icc_regs(&gic.device, &gicr_typer, &state).is_ok());
+        set_icc_regs(&gic.device, &gicr_typer, &state).unwrap();
     }
 
     #[test]
@@ -553,6 +546,6 @@ mod tests {
             .create_vgic(create_test_vgic_config())
             .expect("Cannot create gic");
 
-        assert!(gic.lock().unwrap().save_data_tables().is_ok());
+        gic.lock().unwrap().save_data_tables().unwrap();
     }
 }

--- a/net_util/src/mac.rs
+++ b/net_util/src/mac.rs
@@ -146,16 +146,16 @@ mod tests {
     #[test]
     fn test_mac_addr() {
         // too long
-        assert!(MacAddr::parse_str("aa:aa:aa:aa:aa:aa:aa").is_err());
+        MacAddr::parse_str("aa:aa:aa:aa:aa:aa:aa").unwrap_err();
 
         // invalid hex
-        assert!(MacAddr::parse_str("aa:aa:aa:aa:aa:ax").is_err());
+        MacAddr::parse_str("aa:aa:aa:aa:aa:ax").unwrap_err();
 
         // single digit mac address component should be invalid
-        assert!(MacAddr::parse_str("aa:aa:aa:aa:aa:b").is_err());
+        MacAddr::parse_str("aa:aa:aa:aa:aa:b").unwrap_err();
 
         // components with more than two digits should also be invalid
-        assert!(MacAddr::parse_str("aa:aa:aa:aa:aa:bbb").is_err());
+        MacAddr::parse_str("aa:aa:aa:aa:aa:bbb").unwrap_err();
 
         let mac = MacAddr::parse_str("12:34:56:78:9a:BC").unwrap();
 
@@ -171,12 +171,12 @@ mod tests {
         let src2 = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
         let src3 = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
 
-        assert!(MacAddr::from_bytes(&src1[..]).is_err());
+        MacAddr::from_bytes(&src1[..]).unwrap_err();
 
         let x = MacAddr::from_bytes(&src2[..]).unwrap();
         assert_eq!(x.to_string(), String::from("01:02:03:04:05:06"));
 
-        assert!(MacAddr::from_bytes(&src3[..]).is_err());
+        MacAddr::from_bytes(&src3[..]).unwrap_err();
     }
 
     #[test]

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -605,10 +605,8 @@ mod tests {
         let ip_addr: net::Ipv4Addr = (*tap_ip_guard).parse().unwrap();
         let netmask: net::Ipv4Addr = SUBNET_MASK.parse().unwrap();
 
-        let ret = tap.set_ip_addr(ip_addr);
-        assert!(ret.is_ok());
-        let ret = tap.set_netmask(netmask);
-        assert!(ret.is_ok());
+        tap.set_ip_addr(ip_addr).unwrap();
+        tap.set_netmask(netmask).unwrap();
     }
 
     #[test]
@@ -626,8 +624,7 @@ mod tests {
         let _tap_ip_guard = TAP_IP_LOCK.lock().unwrap();
 
         let tap = Tap::new(1).unwrap();
-        let ret = tap.enable();
-        assert!(ret.is_ok());
+        tap.enable().unwrap();
     }
 
     #[test]
@@ -657,10 +654,7 @@ mod tests {
         // In theory, this could actually loop forever if something keeps sending data through the
         // tap interface, but it's highly unlikely.
         while found_packet_sz.is_none() {
-            let result = tap.read(&mut buf);
-            assert!(result.is_ok());
-
-            let size = result.unwrap();
+            let size = tap.read(&mut buf).unwrap();
 
             // We skip the first 10 bytes because the IFF_VNET_HDR flag is set when the interface
             // is created, and the legacy header is 10 bytes long without a certain flag which
@@ -719,8 +713,8 @@ mod tests {
         // leave the vnet hdr as is
         pnet_build_packet(&mut buf[10..], mac, payload);
 
-        assert!(tap.write(&buf[..]).is_ok());
-        assert!(tap.flush().is_ok());
+        tap.write_all(&buf).unwrap();
+        tap.flush().unwrap();
 
         let (channel_tx, channel_rx) = mpsc::channel();
 

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -381,42 +381,44 @@ mod tests {
             .add("topology")
             .add("cmdline");
 
-        assert!(parser.parse("size=128M,hanging_param").is_err());
-        assert!(parser.parse("size=128M,too_many_equals=foo=bar").is_err());
-        assert!(parser.parse("size=128M,file=/dev/shm").is_err());
+        parser.parse("size=128M,hanging_param").unwrap_err();
+        parser
+            .parse("size=128M,too_many_equals=foo=bar")
+            .unwrap_err();
+        parser.parse("size=128M,file=/dev/shm").unwrap_err();
 
-        assert!(parser.parse("size=128M").is_ok());
+        parser.parse("size=128M").unwrap();
         assert_eq!(parser.get("size"), Some("128M".to_owned()));
         assert!(!parser.is_set("mergeable"));
         assert!(parser.is_set("size"));
 
-        assert!(parser.parse("size=128M,mergeable=on").is_ok());
+        parser.parse("size=128M,mergeable=on").unwrap();
         assert_eq!(parser.get("size"), Some("128M".to_owned()));
         assert_eq!(parser.get("mergeable"), Some("on".to_owned()));
 
-        assert!(parser
+        parser
             .parse("size=128M,mergeable=on,topology=[1,2]")
-            .is_ok());
+            .unwrap();
         assert_eq!(parser.get("size"), Some("128M".to_owned()));
         assert_eq!(parser.get("mergeable"), Some("on".to_owned()));
         assert_eq!(parser.get("topology"), Some("[1,2]".to_owned()));
 
-        assert!(parser
+        parser
             .parse("size=128M,mergeable=on,topology=[[1,2],[3,4]]")
-            .is_ok());
+            .unwrap();
         assert_eq!(parser.get("size"), Some("128M".to_owned()));
         assert_eq!(parser.get("mergeable"), Some("on".to_owned()));
         assert_eq!(parser.get("topology"), Some("[[1,2],[3,4]]".to_owned()));
 
-        assert!(parser.parse("topology=[").is_err());
-        assert!(parser.parse("topology=[[[]]]]").is_err());
+        parser.parse("topology=[").unwrap_err();
+        parser.parse("topology=[[[]]]]").unwrap_err();
 
-        assert!(parser.parse("cmdline=\"console=ttyS0,9600n8\"").is_ok());
+        parser.parse("cmdline=\"console=ttyS0,9600n8\"").unwrap();
         assert_eq!(
             parser.get("cmdline"),
             Some("console=ttyS0,9600n8".to_owned())
         );
-        assert!(parser.parse("cmdline=\"").is_err());
-        assert!(parser.parse("cmdline=\"\"\"").is_err());
+        parser.parse("cmdline=\"").unwrap_err();
+        parser.parse("cmdline=\"\"\"").unwrap_err();
     }
 }

--- a/rate_limiter/src/group.rs
+++ b/rate_limiter/src/group.rs
@@ -388,7 +388,7 @@ pub(crate) mod tests {
         // wait the other half of the timer period
         thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
         // the timer_fd should have an event on it by now
-        assert!(h.event_handler().is_ok());
+        h.event_handler().unwrap();
         // limiter should now be unblocked
         assert!(!h.is_blocked());
         // try and succeed on another 100 bytes this time
@@ -424,7 +424,7 @@ pub(crate) mod tests {
         // wait the other half of the timer period
         thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
         // the timer_fd should have an event on it by now
-        assert!(h.event_handler().is_ok());
+        h.event_handler().unwrap();
         // limiter should now be unblocked
         assert!(!h.is_blocked());
         // try and succeed on another 100 ops this time
@@ -461,7 +461,7 @@ pub(crate) mod tests {
         // wait the other half of the timer period
         thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
         // the timer_fd should have an event on it by now
-        assert!(h.event_handler().is_ok());
+        h.event_handler().unwrap();
         // limiter should now be unblocked
         assert!(!h.is_blocked());
         // try and succeed on another 100 ops this time
@@ -491,7 +491,7 @@ pub(crate) mod tests {
         // after 1.5x the replenish time has passed, the rate limiter
         // is available again
         thread::sleep(Duration::from_millis(500));
-        assert!(h.event_handler().is_ok());
+        h.event_handler().unwrap();
         assert!(!h.is_blocked());
 
         // reset the rate limiter
@@ -525,7 +525,7 @@ pub(crate) mod tests {
         // after waiting out the full duration, rate limiter should be
         // available again
         thread::sleep(Duration::from_millis(200));
-        assert!(h.event_handler().is_ok());
+        h.event_handler().unwrap();
         assert!(!h.is_blocked());
         assert!(h.consume(100, TokenType::Bytes));
     }

--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -666,7 +666,7 @@ pub(crate) mod tests {
         assert!(l.consume(u64::MAX, TokenType::Ops));
         assert!(l.consume(u64::MAX, TokenType::Bytes));
         // calling the handler without there having been an event should error
-        assert!(l.event_handler().is_err());
+        l.event_handler().unwrap_err();
         assert_eq!(
             format!("{:?}", l.event_handler().err().unwrap()),
             "SpuriousRateLimiterEvent(\
@@ -737,7 +737,7 @@ pub(crate) mod tests {
         // wait the other half of the timer period
         thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
         // the timer_fd should have an event on it by now
-        assert!(l.event_handler().is_ok());
+        l.event_handler().unwrap();
         // limiter should now be unblocked
         assert!(!l.is_blocked());
         // try and succeed on another 100 bytes this time
@@ -770,7 +770,7 @@ pub(crate) mod tests {
         // wait the other half of the timer period
         thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
         // the timer_fd should have an event on it by now
-        assert!(l.event_handler().is_ok());
+        l.event_handler().unwrap();
         // limiter should now be unblocked
         assert!(!l.is_blocked());
         // try and succeed on another 100 ops this time
@@ -804,7 +804,7 @@ pub(crate) mod tests {
         // wait the other half of the timer period
         thread::sleep(Duration::from_millis(REFILL_TIMER_INTERVAL_MS / 2));
         // the timer_fd should have an event on it by now
-        assert!(l.event_handler().is_ok());
+        l.event_handler().unwrap();
         // limiter should now be unblocked
         assert!(!l.is_blocked());
         // try and succeed on another 100 ops this time
@@ -825,13 +825,13 @@ pub(crate) mod tests {
         // check that even after a whole second passes, the rate limiter
         // is still blocked
         thread::sleep(Duration::from_millis(1000));
-        assert!(l.event_handler().is_err());
+        l.event_handler().unwrap_err();
         assert!(l.is_blocked());
 
         // after 1.5x the replenish time has passed, the rate limiter
         // is available again
         thread::sleep(Duration::from_millis(500));
-        assert!(l.event_handler().is_ok());
+        l.event_handler().unwrap();
         assert!(!l.is_blocked());
 
         // reset the rate limiter
@@ -845,27 +845,27 @@ pub(crate) mod tests {
         // check that after more than the minimum refill time,
         // the rate limiter is still blocked
         thread::sleep(Duration::from_millis(200));
-        assert!(l.event_handler().is_err());
+        l.event_handler().unwrap_err();
         assert!(l.is_blocked());
 
         // try to consume some tokens, which should fail as the timer
         // is still active
         assert!(!l.consume(100, TokenType::Bytes));
-        assert!(l.event_handler().is_err());
+        l.event_handler().unwrap_err();
         assert!(l.is_blocked());
 
         // check that after the minimum refill time, the timer was not
         // overwritten and the rate limiter is still blocked from the
         // borrowing we performed earlier
         thread::sleep(Duration::from_millis(100));
-        assert!(l.event_handler().is_err());
+        l.event_handler().unwrap_err();
         assert!(l.is_blocked());
         assert!(!l.consume(100, TokenType::Bytes));
 
         // after waiting out the full duration, rate limiter should be
         // available again
         thread::sleep(Duration::from_millis(200));
-        assert!(l.event_handler().is_ok());
+        l.event_handler().unwrap();
         assert!(!l.is_blocked());
         assert!(l.consume(100, TokenType::Bytes));
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -362,13 +362,13 @@ fn _test_api_pause_resume(target_api: TargetApi, guest: Guest) {
         thread::sleep(std::time::Duration::new(2, 0));
 
         // SSH into the VM should fail
-        assert!(ssh_command_ip(
+        ssh_command_ip(
             "grep -c processor /proc/cpuinfo",
             &guest.network.guest_ip,
             2,
-            5
+            5,
         )
-        .is_err());
+        .unwrap_err();
 
         // Resume the VM
         assert!(target_api.remote_command("resume", None));
@@ -6580,7 +6580,7 @@ mod common_parallel {
             thread::sleep(std::time::Duration::new(5, 0));
 
             // Check the connection fails this time
-            assert!(guest2.ssh_command("nc -vz 172.100.0.1 12345").is_err());
+            guest2.ssh_command("nc -vz 172.100.0.1 12345").unwrap_err();
 
             // Add the OVS port back
             assert!(exec_host_command_status("ovs-vsctl add-port ovsbr0 vhost-user1 -- set Interface vhost-user1 type=dpdkvhostuserclient options:vhost-server-path=/tmp/dpdkvhostclient1").success());

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -628,7 +628,7 @@ mod tests {
             let ctx = test_ctx.create_epoll_handler_context();
 
             let _queue: Queue = Queue::new(256).unwrap();
-            assert!(ctx.handler.signal_used_queue(0).is_ok());
+            ctx.handler.signal_used_queue(0).unwrap();
         }
     }
 
@@ -711,10 +711,9 @@ mod tests {
             let mut epoll_helper =
                 EpollHelper::new(&ctx.handler.kill_evt, &ctx.handler.pause_evt).unwrap();
 
-            assert!(
-                ctx.handler.handle_event(&mut epoll_helper, &event).is_err(),
-                "handle_event() should have failed"
-            );
+            ctx.handler
+                .handle_event(&mut epoll_helper, &event)
+                .expect_err("handle_event() should have failed");
         }
     }
 
@@ -764,7 +763,7 @@ mod tests {
             ctx.guest_rxvq.dtable[0].len.set(0);
 
             // The chain should've been processed, without employing the backend.
-            assert!(ctx.handler.process_rx().is_ok());
+            ctx.handler.process_rx().unwrap();
             assert_eq!(ctx.guest_rxvq.used.idx.get(), 1);
             assert_eq!(ctx.handler.backend.read().unwrap().rx_ok_cnt, 0);
         }
@@ -781,10 +780,9 @@ mod tests {
                 EpollHelper::new(&ctx.handler.kill_evt, &ctx.handler.pause_evt).unwrap();
 
             assert_eq!(ctx.guest_rxvq.used.idx.get(), 0);
-            assert!(
-                ctx.handler.handle_event(&mut epoll_helper, &event).is_err(),
-                "handle_event() should have failed"
-            );
+            ctx.handler
+                .handle_event(&mut epoll_helper, &event)
+                .expect_err("handle_event() should have failed");
         }
     }
 
@@ -802,10 +800,10 @@ mod tests {
                 EpollHelper::new(&ctx.handler.kill_evt, &ctx.handler.pause_evt).unwrap();
 
             assert_eq!(ctx.guest_evvq.used.idx.get(), 0);
-            assert!(
-                ctx.handler.handle_event(&mut epoll_helper, &event).is_err(),
-                "handle_event() should have failed"
-            );
+
+            ctx.handler
+                .handle_event(&mut epoll_helper, &event)
+                .expect_err("handle_event() should have failed");
         }
     }
 
@@ -824,7 +822,7 @@ mod tests {
             let event = epoll::Event::new(events, BACKEND_EVENT as u64);
             let mut epoll_helper =
                 EpollHelper::new(&ctx.handler.kill_evt, &ctx.handler.pause_evt).unwrap();
-            assert!(ctx.handler.handle_event(&mut epoll_helper, &event).is_ok());
+            ctx.handler.handle_event(&mut epoll_helper, &event).unwrap();
 
             // The backend should've received this event.
             assert_eq!(
@@ -850,7 +848,7 @@ mod tests {
             let event = epoll::Event::new(events, BACKEND_EVENT as u64);
             let mut epoll_helper =
                 EpollHelper::new(&ctx.handler.kill_evt, &ctx.handler.pause_evt).unwrap();
-            assert!(ctx.handler.handle_event(&mut epoll_helper, &event).is_ok());
+            ctx.handler.handle_event(&mut epoll_helper, &event).unwrap();
 
             // The backend should've received this event.
             assert_eq!(
@@ -874,9 +872,8 @@ mod tests {
         let mut epoll_helper =
             EpollHelper::new(&ctx.handler.kill_evt, &ctx.handler.pause_evt).unwrap();
 
-        assert!(
-            ctx.handler.handle_event(&mut epoll_helper, &event).is_err(),
-            "handle_event() should have failed"
-        );
+        ctx.handler
+            .handle_event(&mut epoll_helper, &event)
+            .expect_err("handle_event() should have failed");
     }
 }

--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -288,21 +288,20 @@ mod tests {
     fn bus_insert() {
         let bus = Bus::new();
         let dummy = Arc::new(DummyDevice);
-        assert!(bus.insert(dummy.clone(), 0x10, 0).is_err());
-        assert!(bus.insert(dummy.clone(), 0x10, 0x10).is_ok());
+        bus.insert(dummy.clone(), 0x10, 0).unwrap_err();
+        bus.insert(dummy.clone(), 0x10, 0x10).unwrap();
 
         let result = bus.insert(dummy.clone(), 0x0f, 0x10);
-        assert!(result.is_err());
         assert_eq!(format!("{result:?}"), "Err(Overlap)");
 
-        assert!(bus.insert(dummy.clone(), 0x10, 0x10).is_err());
-        assert!(bus.insert(dummy.clone(), 0x10, 0x15).is_err());
-        assert!(bus.insert(dummy.clone(), 0x12, 0x15).is_err());
-        assert!(bus.insert(dummy.clone(), 0x12, 0x01).is_err());
-        assert!(bus.insert(dummy.clone(), 0x0, 0x20).is_err());
-        assert!(bus.insert(dummy.clone(), 0x20, 0x05).is_ok());
-        assert!(bus.insert(dummy.clone(), 0x25, 0x05).is_ok());
-        assert!(bus.insert(dummy, 0x0, 0x10).is_ok());
+        bus.insert(dummy.clone(), 0x10, 0x10).unwrap_err();
+        bus.insert(dummy.clone(), 0x10, 0x15).unwrap_err();
+        bus.insert(dummy.clone(), 0x12, 0x15).unwrap_err();
+        bus.insert(dummy.clone(), 0x12, 0x01).unwrap_err();
+        bus.insert(dummy.clone(), 0x0, 0x20).unwrap_err();
+        bus.insert(dummy.clone(), 0x20, 0x05).unwrap();
+        bus.insert(dummy.clone(), 0x25, 0x05).unwrap();
+        bus.insert(dummy, 0x0, 0x10).unwrap();
     }
 
     #[test]
@@ -310,17 +309,17 @@ mod tests {
     fn bus_read_write() {
         let bus = Bus::new();
         let dummy = Arc::new(DummyDevice);
-        assert!(bus.insert(dummy.clone(), 0x10, 0x10).is_ok());
-        assert!(bus.read(0x10, &mut [0, 0, 0, 0]).is_ok());
-        assert!(bus.write(0x10, &[0, 0, 0, 0]).is_ok());
-        assert!(bus.read(0x11, &mut [0, 0, 0, 0]).is_ok());
-        assert!(bus.write(0x11, &[0, 0, 0, 0]).is_ok());
-        assert!(bus.read(0x16, &mut [0, 0, 0, 0]).is_ok());
-        assert!(bus.write(0x16, &[0, 0, 0, 0]).is_ok());
-        assert!(bus.read(0x20, &mut [0, 0, 0, 0]).is_err());
-        assert!(bus.write(0x20, &[0, 0, 0, 0]).is_err());
-        assert!(bus.read(0x06, &mut [0, 0, 0, 0]).is_err());
-        assert!(bus.write(0x06, &[0, 0, 0, 0]).is_err());
+        bus.insert(dummy.clone(), 0x10, 0x10).unwrap();
+        bus.read(0x10, &mut [0, 0, 0, 0]).unwrap();
+        bus.write(0x10, &[0, 0, 0, 0]).unwrap();
+        bus.read(0x11, &mut [0, 0, 0, 0]).unwrap();
+        bus.write(0x11, &[0, 0, 0, 0]).unwrap();
+        bus.read(0x16, &mut [0, 0, 0, 0]).unwrap();
+        bus.write(0x16, &[0, 0, 0, 0]).unwrap();
+        bus.read(0x20, &mut [0, 0, 0, 0]).unwrap_err();
+        bus.write(0x20, &[0, 0, 0, 0]).unwrap_err();
+        bus.read(0x06, &mut [0, 0, 0, 0]).unwrap_err();
+        bus.write(0x06, &[0, 0, 0, 0]).unwrap_err();
     }
 
     #[test]
@@ -328,15 +327,15 @@ mod tests {
     fn bus_read_write_values() {
         let bus = Bus::new();
         let dummy = Arc::new(ConstantDevice);
-        assert!(bus.insert(dummy.clone(), 0x10, 0x10).is_ok());
+        bus.insert(dummy.clone(), 0x10, 0x10).unwrap();
 
         let mut values = [0, 1, 2, 3];
-        assert!(bus.read(0x10, &mut values).is_ok());
+        bus.read(0x10, &mut values).unwrap();
         assert_eq!(values, [0, 1, 2, 3]);
-        assert!(bus.write(0x10, &values).is_ok());
-        assert!(bus.read(0x15, &mut values).is_ok());
+        bus.write(0x10, &values).unwrap();
+        bus.read(0x15, &mut values).unwrap();
         assert_eq!(values, [5, 6, 7, 8]);
-        assert!(bus.write(0x15, &values).is_ok());
+        bus.write(0x15, &values).unwrap();
     }
 
     #[test]
@@ -354,9 +353,9 @@ mod tests {
         let bus = Bus::new();
         let mut data = [1, 2, 3, 4];
         let device = Arc::new(DummyDevice);
-        assert!(bus.insert(device.clone(), 0x10, 0x10).is_ok());
-        assert!(bus.write(0x10, &data).is_ok());
-        assert!(bus.read(0x10, &mut data).is_ok());
+        bus.insert(device.clone(), 0x10, 0x10).unwrap();
+        bus.write(0x10, &data).unwrap();
+        bus.read(0x10, &mut data).unwrap();
         assert_eq!(data, [1, 2, 3, 4]);
     }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -3148,8 +3148,8 @@ mod tests {
             }
         );
 
-        assert!(CpusConfig::parse("boot=8,topology=2:2:1").is_err());
-        assert!(CpusConfig::parse("boot=8,topology=2:2:1:x").is_err());
+        CpusConfig::parse("boot=8,topology=2:2:1").unwrap_err();
+        CpusConfig::parse("boot=8,topology=2:2:1:x").unwrap_err();
         assert_eq!(
             CpusConfig::parse("boot=1,kvm_hyperv=on")?,
             CpusConfig {
@@ -3560,9 +3560,9 @@ mod tests {
     #[test]
     fn test_parse_fs() -> Result<()> {
         // "tag" and "socket" must be supplied
-        assert!(FsConfig::parse("").is_err());
-        assert!(FsConfig::parse("tag=mytag").is_err());
-        assert!(FsConfig::parse("socket=/tmp/sock").is_err());
+        FsConfig::parse("").unwrap_err();
+        FsConfig::parse("tag=mytag").unwrap_err();
+        FsConfig::parse("socket=/tmp/sock").unwrap_err();
         assert_eq!(FsConfig::parse("tag=mytag,socket=/tmp/sock")?, fs_fixture());
         assert_eq!(
             FsConfig::parse("tag=mytag,socket=/tmp/sock,num_queues=4,queue_size=1024")?,
@@ -3590,8 +3590,8 @@ mod tests {
     #[test]
     fn test_pmem_parsing() -> Result<()> {
         // Must always give a file and size
-        assert!(PmemConfig::parse("").is_err());
-        assert!(PmemConfig::parse("size=128M").is_err());
+        PmemConfig::parse("").unwrap_err();
+        PmemConfig::parse("size=128M").unwrap_err();
         assert_eq!(
             PmemConfig::parse("file=/tmp/pmem,size=128M")?,
             pmem_fixture()
@@ -3617,8 +3617,8 @@ mod tests {
 
     #[test]
     fn test_console_parsing() -> Result<()> {
-        assert!(ConsoleConfig::parse("").is_err());
-        assert!(ConsoleConfig::parse("badmode").is_err());
+        ConsoleConfig::parse("").unwrap_err();
+        ConsoleConfig::parse("badmode").unwrap_err();
         assert_eq!(
             ConsoleConfig::parse("off")?,
             ConsoleConfig {
@@ -3707,7 +3707,7 @@ mod tests {
     #[test]
     fn test_device_parsing() -> Result<()> {
         // Device must have a path provided
-        assert!(DeviceConfig::parse("").is_err());
+        DeviceConfig::parse("").unwrap_err();
         assert_eq!(
             DeviceConfig::parse("path=/path/to/device")?,
             device_fixture()
@@ -3746,7 +3746,7 @@ mod tests {
     #[test]
     fn test_vdpa_parsing() -> Result<()> {
         // path is required
-        assert!(VdpaConfig::parse("").is_err());
+        VdpaConfig::parse("").unwrap_err();
         assert_eq!(VdpaConfig::parse("path=/dev/vhost-vdpa")?, vdpa_fixture());
         assert_eq!(
             VdpaConfig::parse("path=/dev/vhost-vdpa,num_queues=2,id=my_vdpa")?,
@@ -3762,7 +3762,7 @@ mod tests {
     #[test]
     fn test_tpm_parsing() -> Result<()> {
         // path is required
-        assert!(TpmConfig::parse("").is_err());
+        TpmConfig::parse("").unwrap_err();
         assert_eq!(
             TpmConfig::parse("socket=/var/run/tpm.sock")?,
             TpmConfig {
@@ -3775,7 +3775,7 @@ mod tests {
     #[test]
     fn test_vsock_parsing() -> Result<()> {
         // socket and cid is required
-        assert!(VsockConfig::parse("").is_err());
+        VsockConfig::parse("").unwrap_err();
         assert_eq!(
             VsockConfig::parse("socket=/tmp/sock,cid=3")?,
             VsockConfig {
@@ -3831,7 +3831,7 @@ mod tests {
             }
         );
         // Parsing should fail as source_url is a required field
-        assert!(RestoreConfig::parse("prefault=off").is_err());
+        RestoreConfig::parse("prefault=off").unwrap_err();
         Ok(())
     }
 
@@ -3909,7 +3909,7 @@ mod tests {
                 },
             ]),
         };
-        assert!(valid_config.validate(&snapshot_vm_config).is_ok());
+        valid_config.validate(&snapshot_vm_config).unwrap();
 
         let mut invalid_config = valid_config.clone();
         invalid_config.net_fds = Some(vec![RestoredNetConfig {
@@ -3977,7 +3977,7 @@ mod tests {
             fds: None,
             ..net_fixture()
         }]);
-        assert!(another_valid_config.validate(&snapshot_vm_config).is_ok());
+        another_valid_config.validate(&snapshot_vm_config).unwrap();
     }
 
     fn platform_fixture() -> PlatformConfig {
@@ -4085,12 +4085,12 @@ mod tests {
             landlock_rules: None,
         };
 
-        assert!(valid_config.validate().is_ok());
+        valid_config.validate().unwrap();
 
         let mut invalid_config = valid_config.clone();
         invalid_config.serial.mode = ConsoleOutputMode::Tty;
         invalid_config.console.mode = ConsoleOutputMode::Tty;
-        assert!(valid_config.validate().is_ok());
+        valid_config.validate().unwrap();
 
         let mut invalid_config = valid_config.clone();
         invalid_config.payload = None;
@@ -4172,7 +4172,7 @@ mod tests {
             ..disk_fixture()
         }]);
         still_valid_config.memory.shared = true;
-        assert!(still_valid_config.validate().is_ok());
+        still_valid_config.validate().unwrap();
 
         let mut invalid_config = valid_config.clone();
         invalid_config.net = Some(vec![NetConfig {
@@ -4191,7 +4191,7 @@ mod tests {
             ..net_fixture()
         }]);
         still_valid_config.memory.shared = true;
-        assert!(still_valid_config.validate().is_ok());
+        still_valid_config.validate().unwrap();
 
         let mut invalid_config = valid_config.clone();
         invalid_config.net = Some(vec![NetConfig {
@@ -4222,16 +4222,16 @@ mod tests {
 
         let mut still_valid_config = valid_config.clone();
         still_valid_config.memory.shared = true;
-        assert!(still_valid_config.validate().is_ok());
+        still_valid_config.validate().unwrap();
 
         let mut still_valid_config = valid_config.clone();
         still_valid_config.memory.hugepages = true;
-        assert!(still_valid_config.validate().is_ok());
+        still_valid_config.validate().unwrap();
 
         let mut still_valid_config = valid_config.clone();
         still_valid_config.memory.hugepages = true;
         still_valid_config.memory.hugepage_size = Some(2 << 20);
-        assert!(still_valid_config.validate().is_ok());
+        still_valid_config.validate().unwrap();
 
         let mut invalid_config = valid_config.clone();
         invalid_config.memory.hugepages = false;
@@ -4251,7 +4251,7 @@ mod tests {
 
         let mut still_valid_config = valid_config.clone();
         still_valid_config.platform = Some(platform_fixture());
-        assert!(still_valid_config.validate().is_ok());
+        still_valid_config.validate().unwrap();
 
         let mut invalid_config = valid_config.clone();
         invalid_config.platform = Some(PlatformConfig {
@@ -4270,7 +4270,7 @@ mod tests {
             iommu_segments: Some(vec![1, 2, 3]),
             ..platform_fixture()
         });
-        assert!(still_valid_config.validate().is_ok());
+        still_valid_config.validate().unwrap();
 
         let mut invalid_config = valid_config.clone();
         invalid_config.platform = Some(PlatformConfig {
@@ -4292,7 +4292,7 @@ mod tests {
             pci_segment: 1,
             ..disk_fixture()
         }]);
-        assert!(still_valid_config.validate().is_ok());
+        still_valid_config.validate().unwrap();
 
         let mut still_valid_config = valid_config.clone();
         still_valid_config.platform = Some(PlatformConfig {
@@ -4304,7 +4304,7 @@ mod tests {
             pci_segment: 1,
             ..net_fixture()
         }]);
-        assert!(still_valid_config.validate().is_ok());
+        still_valid_config.validate().unwrap();
 
         let mut still_valid_config = valid_config.clone();
         still_valid_config.platform = Some(PlatformConfig {
@@ -4316,7 +4316,7 @@ mod tests {
             pci_segment: 1,
             ..pmem_fixture()
         }]);
-        assert!(still_valid_config.validate().is_ok());
+        still_valid_config.validate().unwrap();
 
         let mut still_valid_config = valid_config.clone();
         still_valid_config.platform = Some(PlatformConfig {
@@ -4328,7 +4328,7 @@ mod tests {
             pci_segment: 1,
             ..device_fixture()
         }]);
-        assert!(still_valid_config.validate().is_ok());
+        still_valid_config.validate().unwrap();
 
         let mut still_valid_config = valid_config.clone();
         still_valid_config.platform = Some(PlatformConfig {
@@ -4342,7 +4342,7 @@ mod tests {
             iommu: true,
             pci_segment: 1,
         });
-        assert!(still_valid_config.validate().is_ok());
+        still_valid_config.validate().unwrap();
 
         let mut invalid_config = valid_config.clone();
         invalid_config.platform = Some(PlatformConfig {
@@ -4568,7 +4568,7 @@ mod tests {
                 ..device_fixture()
             },
         ]);
-        assert!(still_valid_config.validate().is_ok());
+        still_valid_config.validate().unwrap();
 
         let mut invalid_config = valid_config.clone();
         invalid_config.devices = Some(vec![
@@ -4581,7 +4581,7 @@ mod tests {
                 ..device_fixture()
             },
         ]);
-        assert!(invalid_config.validate().is_err());
+        invalid_config.validate().unwrap_err();
         #[cfg(feature = "sev_snp")]
         {
             // Payload with empty host data
@@ -4596,7 +4596,7 @@ mod tests {
                 #[cfg(feature = "sev_snp")]
                 host_data: Some("".to_string()),
             });
-            assert!(config_with_no_host_data.validate().is_err());
+            config_with_no_host_data.validate().unwrap_err();
 
             // Payload with no host data provided
             let mut valid_config_with_no_host_data = valid_config.clone();
@@ -4610,7 +4610,7 @@ mod tests {
                 #[cfg(feature = "sev_snp")]
                 host_data: None,
             });
-            assert!(valid_config_with_no_host_data.validate().is_ok());
+            valid_config_with_no_host_data.validate().unwrap();
 
             // Payload with invalid host data length i.e less than 64
             let mut config_with_invalid_host_data = valid_config.clone();
@@ -4626,7 +4626,7 @@ mod tests {
                     "243eb7dc1a21129caa91dcbb794922b933baecb5823a377eb43118867328".to_string(),
                 ),
             });
-            assert!(config_with_invalid_host_data.validate().is_err());
+            config_with_invalid_host_data.validate().unwrap_err();
         }
 
         let mut still_valid_config = valid_config;
@@ -4643,10 +4643,10 @@ mod tests {
     #[test]
     fn test_landlock_parsing() -> Result<()> {
         // should not be empty
-        assert!(LandlockConfig::parse("").is_err());
+        LandlockConfig::parse("").unwrap_err();
         // access should not be empty
-        assert!(LandlockConfig::parse("path=/dir/path1").is_err());
-        assert!(LandlockConfig::parse("path=/dir/path1,access=rwr").is_err());
+        LandlockConfig::parse("path=/dir/path1").unwrap_err();
+        LandlockConfig::parse("path=/dir/path1,access=rwr").unwrap_err();
         assert_eq!(
             LandlockConfig::parse("path=/dir/path1,access=rw")?,
             LandlockConfig {

--- a/vmm/src/landlock.rs
+++ b/vmm/src/landlock.rs
@@ -36,6 +36,7 @@ pub enum LandlockError {
 // https://docs.rs/landlock/latest/landlock/enum.ABI.html for more info on ABI
 static ABI: ABI = ABI::V3;
 
+#[derive(Debug)]
 pub(crate) struct LandlockAccess {
     access: BitFlags<AccessFs>,
 }
@@ -150,5 +151,5 @@ fn test_try_from_access() {
     let landlock_access = LandlockAccess::try_from("w").unwrap();
     assert!(landlock_access.access == write_access);
 
-    assert!(LandlockAccess::try_from("").is_err());
+    LandlockAccess::try_from("").unwrap_err();
 }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2280,9 +2280,7 @@ mod unit_tests {
             .devices
             .is_none());
 
-        let result = vmm.vm_add_device(device_config.clone());
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        assert!(vmm.vm_add_device(device_config.clone()).unwrap().is_none());
         assert_eq!(
             vmm.vm_config
                 .as_ref()
@@ -2329,9 +2327,10 @@ mod unit_tests {
             .user_devices
             .is_none());
 
-        let result = vmm.vm_add_user_device(user_device_config.clone());
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        assert!(vmm
+            .vm_add_user_device(user_device_config.clone())
+            .unwrap()
+            .is_none());
         assert_eq!(
             vmm.vm_config
                 .as_ref()
@@ -2377,9 +2376,7 @@ mod unit_tests {
             .disks
             .is_none());
 
-        let result = vmm.vm_add_disk(disk_config.clone());
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        assert!(vmm.vm_add_disk(disk_config.clone()).unwrap().is_none());
         assert_eq!(
             vmm.vm_config
                 .as_ref()
@@ -2418,9 +2415,7 @@ mod unit_tests {
         let _ = vmm.vm_create(create_dummy_vm_config());
         assert!(vmm.vm_config.as_ref().unwrap().lock().unwrap().fs.is_none());
 
-        let result = vmm.vm_add_fs(fs_config.clone());
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        assert!(vmm.vm_add_fs(fs_config.clone()).unwrap().is_none());
         assert_eq!(
             vmm.vm_config
                 .as_ref()
@@ -2466,9 +2461,7 @@ mod unit_tests {
             .pmem
             .is_none());
 
-        let result = vmm.vm_add_pmem(pmem_config.clone());
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        assert!(vmm.vm_add_pmem(pmem_config.clone()).unwrap().is_none());
         assert_eq!(
             vmm.vm_config
                 .as_ref()
@@ -2517,9 +2510,7 @@ mod unit_tests {
             .net
             .is_none());
 
-        let result = vmm.vm_add_net(net_config.clone());
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        assert!(vmm.vm_add_net(net_config.clone()).unwrap().is_none());
         assert_eq!(
             vmm.vm_config
                 .as_ref()
@@ -2565,9 +2556,7 @@ mod unit_tests {
             .vdpa
             .is_none());
 
-        let result = vmm.vm_add_vdpa(vdpa_config.clone());
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        assert!(vmm.vm_add_vdpa(vdpa_config.clone()).unwrap().is_none());
         assert_eq!(
             vmm.vm_config
                 .as_ref()
@@ -2613,9 +2602,7 @@ mod unit_tests {
             .vsock
             .is_none());
 
-        let result = vmm.vm_add_vsock(vsock_config.clone());
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        assert!(vmm.vm_add_vsock(vsock_config.clone()).unwrap().is_none());
         assert_eq!(
             vmm.vm_config
                 .as_ref()

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2850,43 +2850,43 @@ mod tests {
         match state {
             VmState::Created => {
                 // Check the transitions from Created
-                assert!(state.valid_transition(VmState::Created).is_err());
-                assert!(state.valid_transition(VmState::Running).is_ok());
-                assert!(state.valid_transition(VmState::Shutdown).is_ok());
-                assert!(state.valid_transition(VmState::Paused).is_ok());
-                assert!(state.valid_transition(VmState::BreakPoint).is_ok());
+                state.valid_transition(VmState::Created).unwrap_err();
+                state.valid_transition(VmState::Running).unwrap();
+                state.valid_transition(VmState::Shutdown).unwrap();
+                state.valid_transition(VmState::Paused).unwrap();
+                state.valid_transition(VmState::BreakPoint).unwrap();
             }
             VmState::Running => {
                 // Check the transitions from Running
-                assert!(state.valid_transition(VmState::Created).is_err());
-                assert!(state.valid_transition(VmState::Running).is_err());
-                assert!(state.valid_transition(VmState::Shutdown).is_ok());
-                assert!(state.valid_transition(VmState::Paused).is_ok());
-                assert!(state.valid_transition(VmState::BreakPoint).is_ok());
+                state.valid_transition(VmState::Created).unwrap_err();
+                state.valid_transition(VmState::Running).unwrap_err();
+                state.valid_transition(VmState::Shutdown).unwrap();
+                state.valid_transition(VmState::Paused).unwrap();
+                state.valid_transition(VmState::BreakPoint).unwrap();
             }
             VmState::Shutdown => {
                 // Check the transitions from Shutdown
-                assert!(state.valid_transition(VmState::Created).is_err());
-                assert!(state.valid_transition(VmState::Running).is_ok());
-                assert!(state.valid_transition(VmState::Shutdown).is_err());
-                assert!(state.valid_transition(VmState::Paused).is_err());
-                assert!(state.valid_transition(VmState::BreakPoint).is_err());
+                state.valid_transition(VmState::Created).unwrap_err();
+                state.valid_transition(VmState::Running).unwrap();
+                state.valid_transition(VmState::Shutdown).unwrap_err();
+                state.valid_transition(VmState::Paused).unwrap_err();
+                state.valid_transition(VmState::BreakPoint).unwrap_err();
             }
             VmState::Paused => {
                 // Check the transitions from Paused
-                assert!(state.valid_transition(VmState::Created).is_err());
-                assert!(state.valid_transition(VmState::Running).is_ok());
-                assert!(state.valid_transition(VmState::Shutdown).is_ok());
-                assert!(state.valid_transition(VmState::Paused).is_err());
-                assert!(state.valid_transition(VmState::BreakPoint).is_err());
+                state.valid_transition(VmState::Created).unwrap_err();
+                state.valid_transition(VmState::Running).unwrap();
+                state.valid_transition(VmState::Shutdown).unwrap();
+                state.valid_transition(VmState::Paused).unwrap_err();
+                state.valid_transition(VmState::BreakPoint).unwrap_err();
             }
             VmState::BreakPoint => {
                 // Check the transitions from Breakpoint
-                assert!(state.valid_transition(VmState::Created).is_ok());
-                assert!(state.valid_transition(VmState::Running).is_ok());
-                assert!(state.valid_transition(VmState::Shutdown).is_err());
-                assert!(state.valid_transition(VmState::Paused).is_err());
-                assert!(state.valid_transition(VmState::BreakPoint).is_err());
+                state.valid_transition(VmState::Created).unwrap();
+                state.valid_transition(VmState::Running).unwrap();
+                state.valid_transition(VmState::Shutdown).unwrap_err();
+                state.valid_transition(VmState::Paused).unwrap_err();
+                state.valid_transition(VmState::BreakPoint).unwrap_err();
             }
         }
     }
@@ -3169,7 +3169,7 @@ mod tests {
         let gic = vm
             .create_vgic(Gic::create_default_config(1))
             .expect("Cannot create gic");
-        assert!(create_fdt(
+        create_fdt(
             &mem,
             "console=tty0",
             vec![0],
@@ -3182,7 +3182,7 @@ mod tests {
             None,
             true,
         )
-        .is_ok())
+        .unwrap();
     }
 }
 


### PR DESCRIPTION
Inspired by @roypat.

Asserting on .is_ok()/.is_err() leads to hard to debug failures (as if
the test fails, it will only say "assertion failed: false". We replace
these with `.unwrap()`, which also prints the exact error variant that
was unexpectedly encountered (we can to this these days thanks to
efforts to implement Display and Debug for our error types). If the
assert!((...).is_ok()) was followed by an .unwrap() anyway, we just drop
the assert.

Enable clippy::assertions_on_result_states lint for `build.yaml` and `quality.yaml`.
