### PR TITLE
build: disable vfio-ioctls default features on workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ mshv-bindings = { git = "https://github.com/rust-vmm/mshv", tag = "v0.3.0" }
 mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", tag = "v0.3.0" }
 seccompiler = "0.4.0"
 vfio-bindings = { git = "https://github.com/rust-vmm/vfio", branch = "main" }
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main" }
+vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
 vfio_user = { git = "https://github.com/rust-vmm/vfio-user", branch = "main" }
 vhost = "0.12.0"
 virtio-bindings = "0.2.2"


### PR DESCRIPTION
See the following discussion: https://github.com/rust-lang/cargo/issues/12162#issuecomment-2020763765