### PR TITLE
arch: Enable build with `kvm` feature

### DIFF
--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 
 [features]
 default = []
-kvm = []
+kvm = ["hypervisor/kvm"]
 sev_snp = []
 tdx = []
 


### PR DESCRIPTION
Currently `arch` crate cannot be built, by specifying `hypervisor/kvm` to turn on the features required for its dependency - `hypervisor` crate to build. Thus enabling `arch` crate to be built with command:

```sh
cargo build -p arch --features kvm
```