### PR TITLE
misc: Appease clippy

### DIFF
--- a/block/src/qcow/qcow_raw_file.rs
+++ b/block/src/qcow/qcow_raw_file.rs
@@ -24,7 +24,7 @@ impl QcowRawFile {
     /// Creates a `QcowRawFile` from the given `File`, `None` is returned if `cluster_size` is not
     /// a power of two.
     pub fn from(file: RawFile, cluster_size: u64) -> Option<Self> {
-        if cluster_size.count_ones() != 1 {
+        if !cluster_size.is_power_of_two() {
             return None;
         }
         Some(QcowRawFile {

--- a/block/src/qcow/raw_file.rs
+++ b/block/src/qcow/raw_file.rs
@@ -74,7 +74,7 @@ impl RawFile {
 
     fn round_up(&self, offset: u64) -> u64 {
         let align: u64 = self.alignment.try_into().unwrap();
-        ((offset + align - 1) / align) * align
+        offset.div_ceil(align) * align
     }
 
     fn round_down(&self, offset: u64) -> u64 {

--- a/block/src/vhdx/mod.rs
+++ b/block/src/vhdx/mod.rs
@@ -17,12 +17,6 @@ use crate::vhdx::vhdx_io::VhdxIoError;
 use crate::vhdx::vhdx_metadata::{DiskSpec, VhdxMetadataError};
 use crate::BlockBackend;
 
-macro_rules! div_round_up {
-    ($n:expr,$d:expr) => {
-        ($n + $d - 1) / $d
-    };
-}
-
 mod vhdx_bat;
 mod vhdx_header;
 mod vhdx_io;
@@ -105,8 +99,7 @@ impl Read for Vhdx {
     /// Wrapper function to satisfy Read trait implementation for VHDx disk.
     /// Convert the offset to sector index and buffer length to sector count.
     fn read(&mut self, buf: &mut [u8]) -> std::result::Result<usize, std::io::Error> {
-        let sector_count =
-            div_round_up!(buf.len() as u64, self.disk_spec.logical_sector_size as u64);
+        let sector_count = (buf.len() as u64).div_ceil(self.disk_spec.logical_sector_size as u64);
         let sector_index = self.current_offset / self.disk_spec.logical_sector_size as u64;
 
         vhdx_io::read(
@@ -136,8 +129,7 @@ impl Write for Vhdx {
     /// Wrapper function to satisfy Write trait implementation for VHDx disk.
     /// Convert the offset to sector index and buffer length to sector count.
     fn write(&mut self, buf: &[u8]) -> std::result::Result<usize, std::io::Error> {
-        let sector_count =
-            div_round_up!(buf.len() as u64, self.disk_spec.logical_sector_size as u64);
+        let sector_count = (buf.len() as u64).div_ceil(self.disk_spec.logical_sector_size as u64);
         let sector_index = self.current_offset / self.disk_spec.logical_sector_size as u64;
 
         if self.first_write {

--- a/block/src/vhdx/vhdx_bat.rs
+++ b/block/src/vhdx/vhdx_bat.rs
@@ -78,7 +78,7 @@ impl BatEntry {
 
     // Calculate the number of entries in the BAT
     fn calculate_entries(block_size: u32, virtual_disk_size: u64, chunk_ratio: u64) -> u64 {
-        let data_blocks_count = div_round_up!(virtual_disk_size, block_size as u64);
+        let data_blocks_count = virtual_disk_size.div_ceil(block_size as u64);
         data_blocks_count + (data_blocks_count - 1) / chunk_ratio
     }
 

--- a/block/src/vhdx/vhdx_io.rs
+++ b/block/src/vhdx/vhdx_io.rs
@@ -36,7 +36,7 @@ pub type Result<T> = std::result::Result<T, VhdxIoError>;
 
 macro_rules! align {
     ($n:expr, $align:expr) => {{
-        (($n + $align - 1) / $align) * $align
+        $n.div_ceil($align) * $align
     }};
 }
 

--- a/fuzz/fuzz_targets/balloon.rs
+++ b/fuzz/fuzz_targets/balloon.rs
@@ -120,7 +120,7 @@ impl VirtioInterrupt for NoopVirtioInterrupt {
 
 macro_rules! align {
     ($n:expr, $align:expr) => {{
-        (($n + $align - 1) / $align) * $align
+        $n.div_ceil($align) * $align
     }};
 }
 

--- a/fuzz/fuzz_targets/console.rs
+++ b/fuzz/fuzz_targets/console.rs
@@ -21,7 +21,7 @@ type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 
 macro_rules! align {
     ($n:expr, $align:expr) => {{
-        (($n + $align - 1) / $align) * $align
+        $n.div_ceil($align) * $align
     }};
 }
 

--- a/fuzz/fuzz_targets/iommu.rs
+++ b/fuzz/fuzz_targets/iommu.rs
@@ -19,7 +19,7 @@ type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 
 macro_rules! align {
     ($n:expr, $align:expr) => {{
-        (($n + $align - 1) / $align) * $align
+        $n.div_ceil($align) * $align
     }};
 }
 

--- a/fuzz/fuzz_targets/mem.rs
+++ b/fuzz/fuzz_targets/mem.rs
@@ -20,7 +20,7 @@ type GuestRegionMmap = vm_memory::GuestRegionMmap<AtomicBitmap>;
 
 macro_rules! align {
     ($n:expr, $align:expr) => {{
-        (($n + $align - 1) / $align) * $align
+        $n.div_ceil($align) * $align
     }};
 }
 

--- a/fuzz/fuzz_targets/net.rs
+++ b/fuzz/fuzz_targets/net.rs
@@ -22,7 +22,7 @@ type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 
 macro_rules! align {
     ($n:expr, $align:expr) => {{
-        (($n + $align - 1) / $align) * $align
+        $n.div_ceil($align) * $align
     }};
 }
 

--- a/fuzz/fuzz_targets/rng.rs
+++ b/fuzz/fuzz_targets/rng.rs
@@ -19,7 +19,7 @@ type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 
 macro_rules! align {
     ($n:expr, $align:expr) => {{
-        (($n + $align - 1) / $align) * $align
+        $n.div_ceil($align) * $align
     }};
 }
 

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -90,7 +90,7 @@ pub fn new() -> std::result::Result<Arc<dyn Hypervisor>, HypervisorError> {
 
 // Returns a `Vec<T>` with a size in bytes at least as large as `size_in_bytes`.
 fn vec_with_size_in_bytes<T: Default>(size_in_bytes: usize) -> Vec<T> {
-    let rounded_size = (size_in_bytes + size_of::<T>() - 1) / size_of::<T>();
+    let rounded_size = size_in_bytes.div_ceil(size_of::<T>());
     let mut v = Vec::with_capacity(rounded_size);
     v.resize_with(rounded_size, T::default);
     v

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -320,7 +320,7 @@ impl IovecBuffer {
 
 struct IovecBufferBorrowed<'a>(&'a mut Vec<libc::iovec>);
 
-impl<'a> std::ops::Deref for IovecBufferBorrowed<'a> {
+impl std::ops::Deref for IovecBufferBorrowed<'_> {
     type Target = Vec<libc::iovec>;
 
     fn deref(&self) -> &Self::Target {
@@ -328,7 +328,7 @@ impl<'a> std::ops::Deref for IovecBufferBorrowed<'a> {
     }
 }
 
-impl<'a> std::ops::DerefMut for IovecBufferBorrowed<'a> {
+impl std::ops::DerefMut for IovecBufferBorrowed<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
     }

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -124,7 +124,7 @@ impl Tap {
             // Open calls are safe because we give a constant null-terminated
             // string and verify the result.
             libc::open(
-                b"/dev/net/tun\0".as_ptr() as *const c_char,
+                c"/dev/net/tun".as_ptr() as *const c_char,
                 flags.unwrap_or(libc::O_RDWR | libc::O_NONBLOCK | libc::O_CLOEXEC),
             )
         };

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -734,7 +734,7 @@ impl PciConfiguration {
             return Err(Error::BarInUse(bar_idx));
         }
 
-        if config.size.count_ones() != 1 {
+        if !config.size.is_power_of_two() {
             return Err(Error::BarSizeInvalid(config.size));
         }
 
@@ -806,7 +806,7 @@ impl PciConfiguration {
             return Err(Error::RomBarInUse(bar_idx));
         }
 
-        if config.size.count_ones() != 1 {
+        if !config.size.is_power_of_two() {
             return Err(Error::RomBarSizeInvalid(config.size));
         }
 

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -62,7 +62,7 @@ pub struct PciBdf(u32);
 
 struct PciBdfVisitor;
 
-impl<'de> Visitor<'de> for PciBdfVisitor {
+impl Visitor<'_> for PciBdfVisitor {
     type Value = PciBdf;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/rate_limiter/src/group.rs
+++ b/rate_limiter/src/group.rs
@@ -309,12 +309,12 @@ pub(crate) mod tests {
     use crate::{TokenBucket, TokenType, REFILL_TIMER_INTERVAL_MS};
 
     impl RateLimiterGroupHandle {
-        pub fn bandwidth(&self) -> Option<TokenBucket> {
+        fn bandwidth(&self) -> Option<TokenBucket> {
             let guard = self.inner.rate_limiter.inner.lock().unwrap();
             guard.bandwidth.clone()
         }
 
-        pub fn ops(&self) -> Option<TokenBucket> {
+        fn ops(&self) -> Option<TokenBucket> {
             let guard = self.inner.rate_limiter.inner.lock().unwrap();
             guard.ops.clone()
         }

--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -544,7 +544,8 @@ pub(crate) mod tests {
         }
 
         // After a restore, we cannot be certain that the last_update field has the same value.
-        pub fn partial_eq(&self, other: &TokenBucket) -> bool {
+        #[allow(dead_code)]
+        fn partial_eq(&self, other: &TokenBucket) -> bool {
             (other.capacity() == self.capacity())
                 && (other.one_time_burst() == self.one_time_burst())
                 && (other.refill_time_ms() == self.refill_time_ms())
@@ -553,12 +554,12 @@ pub(crate) mod tests {
     }
 
     impl RateLimiter {
-        pub fn bandwidth(&self) -> Option<TokenBucket> {
+        fn bandwidth(&self) -> Option<TokenBucket> {
             let guard = self.inner.lock().unwrap();
             guard.bandwidth.clone()
         }
 
-        pub fn ops(&self) -> Option<TokenBucket> {
+        fn ops(&self) -> Option<TokenBucket> {
             let guard = self.inner.lock().unwrap();
             guard.ops.clone()
         }

--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -258,7 +258,7 @@ impl<'a> DBusApi1ProxyBlocking<'a> {
     }
 }
 
-impl<'a> TargetApi<'a> {
+impl TargetApi<'_> {
     fn do_command(&mut self, matches: &ArgMatches) -> ApiResult {
         match self {
             Self::HttpApi(api_socket, _) => rest_api_do_command(matches, api_socket),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8216,7 +8216,7 @@ mod windows {
             .output()
             .expect("ps command failed")
             .stdout;
-        return String::from_utf8_lossy(&out).matches("vcpu").count() as u8;
+        String::from_utf8_lossy(&out).matches("vcpu").count() as u8
     }
 
     fn netdev_ctrl_threads_count(pid: u32) -> u8 {

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -349,7 +349,7 @@ mod tests {
         pub guest_evvq: GuestQ<'a>,
     }
 
-    impl<'a> EpollHandlerContext<'a> {
+    impl EpollHandlerContext<'_> {
         pub fn signal_txq_event(&mut self) {
             self.handler.queue_evts[1].write(1).unwrap();
             let events = epoll::Events::EPOLLIN;

--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -178,7 +178,7 @@ pub mod testing {
         // We try to make sure things are aligned properly :-s
         pub fn new(start: GuestAddress, mem: &'a GuestMemoryMmap, qsize: u16) -> Self {
             // power of 2?
-            assert!(qsize > 0 && qsize & (qsize - 1) == 0);
+            assert!(qsize.is_power_of_two());
 
             let mut dtable = Vec::with_capacity(qsize as usize);
 

--- a/vmm/src/coredump.rs
+++ b/vmm/src/coredump.rs
@@ -50,13 +50,6 @@ pub trait GuestDebuggable: vm_migration::Pausable {
     }
 }
 
-#[macro_export]
-macro_rules! div_round_up {
-    ($n:expr,$d:expr) => {
-        ($n + $d - 1) / $d
-    };
-}
-
 #[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct X86_64UserRegs {
@@ -314,7 +307,7 @@ pub trait Elf64Writable {
     }
 
     fn elf_note_size(&self, hdr_size: u32, name_size: u32, desc_size: u32) -> u32 {
-        (div_round_up!(hdr_size, 4) + div_round_up!(name_size, 4) + div_round_up!(desc_size, 4)) * 4
+        (hdr_size.div_ceil(4) + name_size.div_ceil(4) + desc_size.div_ceil(4)) * 4
     }
 
     fn get_note_size(&self, desc_type: NoteDescType, nr_cpus: u32) -> u32 {

--- a/vmm/src/device_tree.rs
+++ b/vmm/src/device_tree.rs
@@ -145,7 +145,7 @@ impl<'a> Iterator for BftIter<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for BftIter<'a> {
+impl DoubleEndedIterator for BftIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.nodes.pop()
     }

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1088,9 +1088,9 @@ impl MemoryManager {
                         } else {
                             // Alignment must be "natural" i.e. same as size of block
                             let start_addr = GuestAddress(
-                                (start_of_device_area.0 + virtio_devices::VIRTIO_MEM_ALIGN_SIZE
-                                    - 1)
-                                    / virtio_devices::VIRTIO_MEM_ALIGN_SIZE
+                                start_of_device_area
+                                    .0
+                                    .div_ceil(virtio_devices::VIRTIO_MEM_ALIGN_SIZE)
                                     * virtio_devices::VIRTIO_MEM_ALIGN_SIZE,
                             );
 


### PR DESCRIPTION
This PR addresses some clippy warnings appeared since `1.83.0-beta.1`:

- Replace div_round_up operation with div_ceil
- Remove manual implementation of is_power_of_two
- Use c"" to construct nul-terminated string
- Elide needless lifetimes
- Remove redundant return statement
- Remove redundant pub keyword of helper functions

But leaves two problem unsolved:

1. The new clippy wants a `.wait()` in places we try to spawn a child thread, while we did manually take care of these threads but it fails to understand.
2. In `tracing` module, we are trying to create shared reference to mutable static, which is discouraged