### PR TITLE
tracer: Allow shared reference to mutable static

### DIFF
--- a/tracer/src/tracer.rs
+++ b/tracer/src/tracer.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#![allow(static_mut_refs)]
+
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;


### PR DESCRIPTION
This PR is raised to resolve clippy warning appeared since `1.83.0-beta.1` in `tracer` module:

```
error: creating a shared reference to mutable static is discouraged
   --> tracer/src/tracer.rs:111:59
    |
111 |         timestamp: Instant::now().duration_since(unsafe { TRACER.get().unwrap().start }),
    |                                                           ^^^^^^^^^^^^ shared reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `-D static-mut-refs` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(static_mut_refs)]`
```

Allowing shared reference to mutable static.