### PR TITLE
build: Revert "build: Bump vfio-ioctls from `a51a474` to `bfbe1bd`"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
  "thiserror",
  "uuid",
  "vm-fdt",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -334,7 +334,7 @@ dependencies = [
  "uuid",
  "virtio-bindings",
  "virtio-queue",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -443,7 +443,7 @@ dependencies = [
  "thiserror",
  "tpm",
  "tracer",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vmm",
  "vmm-sys-util",
  "wait-timeout",
@@ -579,7 +579,7 @@ dependencies = [
  "tpm",
  "vm-allocator",
  "vm-device",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -976,7 +976,7 @@ dependencies = [
  "serde_with",
  "thiserror",
  "vfio-ioctls",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1171,7 +1171,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d379d0089d0fbf4161c35a4fdfd76125923f1a93632c49195f5372b4c0b1472"
 dependencies = [
- "vm-memory 0.15.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -1299,7 +1299,7 @@ dependencies = [
  "thiserror",
  "virtio-bindings",
  "virtio-queue",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vm-virtio",
  "vmm-sys-util",
 ]
@@ -1506,7 +1506,7 @@ dependencies = [
  "vfio_user",
  "vm-allocator",
  "vm-device",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vm-migration",
  "vmm-sys-util",
 ]
@@ -2217,7 +2217,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#bfbe1bda73a68acd183fd5d15463a6d14edd81da"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#a51a4746b0d317bfc21fa49d40f9287f3b8137fd"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -2225,7 +2225,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#bfbe1bda73a68acd183fd5d15463a6d14edd81da"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#a51a4746b0d317bfc21fa49d40f9287f3b8137fd"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -2236,7 +2236,7 @@ dependencies = [
  "mshv-ioctls",
  "thiserror",
  "vfio-bindings",
- "vm-memory 0.16.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -2253,7 +2253,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "vfio-bindings",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -2266,7 +2266,7 @@ dependencies = [
  "bitflags 2.6.0",
  "libc",
  "uuid",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -2281,7 +2281,7 @@ dependencies = [
  "vhost",
  "virtio-bindings",
  "virtio-queue",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -2300,7 +2300,7 @@ dependencies = [
  "vhost-user-backend",
  "virtio-bindings",
  "virtio-queue",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -2318,7 +2318,7 @@ dependencies = [
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -2356,7 +2356,7 @@ dependencies = [
  "virtio-queue",
  "vm-allocator",
  "vm-device",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
@@ -2370,7 +2370,7 @@ checksum = "ffb1761348d3b5e82131379b9373435b48dc8333100bff3f1cdf9cc541a0ad83"
 dependencies = [
  "log",
  "virtio-bindings",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -2380,7 +2380,7 @@ version = "0.1.0"
 dependencies = [
  "arch",
  "libc",
- "vm-memory 0.15.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -2392,7 +2392,7 @@ dependencies = [
  "serde",
  "thiserror",
  "vfio-ioctls",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -2414,17 +2414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vm-memory"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2919f87420b6998a131eb7c78843890295e91a3f8f786ccc925c8d387b75121"
-dependencies = [
- "libc",
- "thiserror",
- "winapi",
-]
-
-[[package]]
 name = "vm-migration"
 version = "0.1.0"
 dependencies = [
@@ -2432,7 +2421,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "vm-memory 0.15.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -2441,7 +2430,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "virtio-queue",
- "vm-memory 0.15.0",
+ "vm-memory",
 ]
 
 [[package]]
@@ -2495,7 +2484,7 @@ dependencies = [
  "virtio-queue",
  "vm-allocator",
  "vm-device",
- "vm-memory 0.15.0",
+ "vm-memory",
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",


### PR DESCRIPTION
This reverts commit b264aebcde66c766e3d6b72b64d6f41a15008486.

Pulls in new vm-memory so should be done as part of a global bump of
Rust-VMM crates.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
