### PR TITLE
build: Centralize vhost-user-backend to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ vfio-bindings = { git = "https://github.com/rust-vmm/vfio", branch = "main" }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
 vfio_user = { git = "https://github.com/rust-vmm/vfio-user", branch = "main" }
 vhost = "0.12.0"
+vhost-user-backend = "0.16.0"
 virtio-bindings = "0.2.2"
 virtio-queue = "0.13.0"
 vm-fdt = { git = "https://github.com/rust-vmm/vm-fdt", branch = "main" }

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -14,7 +14,7 @@ libc = "0.2.158"
 log = "0.4.22"
 option_parser = { path = "../option_parser" }
 vhost = { workspace = true, features = ["vhost-user-backend"] }
-vhost-user-backend = "0.16.0"
+vhost-user-backend = { workspace = true }
 virtio-bindings = { workspace = true }
 virtio-queue = { workspace = true }
 vm-memory = { workspace = true }

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4.22"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
 vhost = { workspace = true, features = ["vhost-user-backend"] }
-vhost-user-backend = "0.16.0"
+vhost-user-backend = { workspace = true }
 virtio-bindings = { workspace = true }
 vm-memory = { workspace = true }
 vmm-sys-util = { workspace = true }


### PR DESCRIPTION
`vhost-user-backend` is left behind in #6764, move it to root workspace.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>