### PR TITLE
build: Bump rust-vmm crates

### DIFF
--- a/.github/workflows/package-consistency.yaml
+++ b/.github/workflows/package-consistency.yaml
@@ -22,5 +22,11 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Check Rust VMM Package Consistency
+      - name: Check Rust VMM Package Consistency of root Workspace
         run: python3 scripts/package-consistency-check.py github.com/rust-vmm
+
+      - name: Check Rust VMM Package Consistency of fuzz Workspace
+        run: |
+          pushd fuzz
+          python3 ../scripts/package-consistency-check.py github.com/rust-vmm
+          popd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ name = "acpi_tables"
 version = "0.1.0"
 source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#e268627630839bd22f1c13e7e81ec70c7e9b73d6"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1009,7 +1009,7 @@ dependencies = [
  "range_map_vec",
  "thiserror",
  "tracing",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1021,7 +1021,7 @@ dependencies = [
  "bitfield-struct",
  "open-enum",
  "static_assertions",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1085,20 +1085,20 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efe3f1a4437bffe000e6297a593b98184213cd27486776c335f95ab53d48e3a"
+checksum = "fa4933174d0cc4b77b958578cd45784071cc5ae212c2d78fbd755aaaa6dfa71a"
 dependencies = [
  "serde",
  "vmm-sys-util",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c2176b91f68903b54ac8c6185bada7d607ca6110998976ff15c032f88a7d39"
+checksum = "337d1afa126368bbd6a5c328048f71a69a737e9afe7e436b392a8f8d770c9171"
 dependencies = [
  "bitflags 2.6.0",
  "kvm-bindings",
@@ -1167,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d379d0089d0fbf4161c35a4fdfd76125923f1a93632c49195f5372b4c0b1472"
+checksum = "870c3814345f050991f99869417779f6062542bcf4ed81db7a1b926ad1306638"
 dependencies = [
  "vm-memory",
 ]
@@ -1243,21 +1243,23 @@ checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
 name = "mshv-bindings"
-version = "0.3.0"
-source = "git+https://github.com/rust-vmm/mshv?tag=v0.3.0#fda05380ea4c68b807996299d5ffb2854ca6d01d"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576504619272a742fa7b75e69c9cd92520df5b4b66181c55e0d3eeb10d8341f8"
 dependencies = [
  "libc",
  "num_enum",
  "serde",
  "serde_derive",
  "vmm-sys-util",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.3.0"
-source = "git+https://github.com/rust-vmm/mshv?tag=v0.3.0#fda05380ea4c68b807996299d5ffb2854ca6d01d"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccd62dfa7e0448b49700744f4d23e28ed7a49e83087ba6d7c06c4ee18b8821c"
 dependencies = [
  "libc",
  "mshv-bindings",
@@ -1665,7 +1667,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2217,7 +2219,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#a51a4746b0d317bfc21fa49d40f9287f3b8137fd"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#b135b8305c2cc8ec333e0cf77a780445cc98dcee"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -2225,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#a51a4746b0d317bfc21fa49d40f9287f3b8137fd"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#b135b8305c2cc8ec333e0cf77a780445cc98dcee"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -2243,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "vfio_user"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio-user?branch=main#bf7d7e851b604d8414a7960fb9137b59fc42421d"
+source = "git+https://github.com/rust-vmm/vfio-user?branch=main#3febcdd3fa2531623865663ca1721e1962ed9979"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -2259,9 +2261,8 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1c4c6c9f79fbe3150d9a403008ca416d34c489897effdda28b646f09900aad"
+version = "0.12.1"
+source = "git+https://github.com/rust-vmm/vhost?rev=d983ae0#d983ae07f78663b7d24059667376992460b571a2"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
@@ -2272,9 +2273,8 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73768c8584e0be5ed8feb063785910cabe3f1af6661a5953fd3247fa611ddfaf"
+version = "0.16.1"
+source = "git+https://github.com/rust-vmm/vhost?rev=d983ae0#d983ae07f78663b7d24059667376992460b571a2"
 dependencies = [
  "libc",
  "log",
@@ -2324,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-bindings"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d0df4f5ad79b1dc81b5913ac737e24a84dcd5100f36ed953a1faec18aba241"
+checksum = "1711e61c00f8cb450bd15368152a1e37a12ef195008ddc7d0f4812f9e2b30a68"
 
 [[package]]
 name = "virtio-devices"
@@ -2364,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1761348d3b5e82131379b9373435b48dc8333100bff3f1cdf9cc541a0ad83"
+checksum = "872e2f3fbd70a7e6f01689720cce3d5c2c5efe52b484dd07b674246ada0e9a8d"
 dependencies = [
  "log",
  "virtio-bindings",
@@ -2403,9 +2403,9 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#ef5bd734f5f66fb0772
 
 [[package]]
 name = "vm-memory"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a320fc11792e063174402ff444aa3c80363cbf1e31c47b5ef74124406c334ce6"
+checksum = "e2919f87420b6998a131eb7c78843890295e91a3f8f786ccc925c8d387b75121"
 dependencies = [
  "arc-swap",
  "libc",
@@ -2489,7 +2489,7 @@ dependencies = [
  "vm-virtio",
  "vmm-sys-util",
  "zbus",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2815,7 +2815,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a4e33e6dce36f2adba29746927f8e848ba70989fdb61c772773bbdda8b5d6a7"
+dependencies = [
+ "zerocopy-derive 0.8.8",
 ]
 
 [[package]]
@@ -2823,6 +2832,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd137b4cc21bde6ecce3bbbb3350130872cda0be2c6888874279ea76e17d4c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,19 +103,19 @@ members = [
 
 [workspace.dependencies]
 acpi_tables = { git = "https://github.com/rust-vmm/acpi_tables", branch = "main" }
-kvm-bindings = "0.9.1"
-kvm-ioctls = "0.18.0"
-linux-loader = "0.12.0"
-mshv-bindings = { git = "https://github.com/rust-vmm/mshv", tag = "v0.3.0" }
-mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", tag = "v0.3.0" }
+kvm-bindings = "0.10.0"
+kvm-ioctls = "0.19.0"
+linux-loader = "0.13.0"
+mshv-bindings = "0.3.1"
+mshv-ioctls = "0.3.1"
 seccompiler = "0.4.0"
 vfio-bindings = { git = "https://github.com/rust-vmm/vfio", branch = "main" }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
 vfio_user = { git = "https://github.com/rust-vmm/vfio-user", branch = "main" }
-vhost = "0.12.0"
-vhost-user-backend = "0.16.0"
-virtio-bindings = "0.2.2"
-virtio-queue = "0.13.0"
+vhost = { git = "https://github.com/rust-vmm/vhost", rev = "d983ae0" }
+vhost-user-backend = { git = "https://github.com/rust-vmm/vhost", rev = "d983ae0" }
+virtio-bindings = "0.2.4"
+virtio-queue = "0.14.0"
 vm-fdt = { git = "https://github.com/rust-vmm/vm-fdt", branch = "main" }
-vm-memory = "0.15.0"
+vm-memory = "0.16.0"
 vmm-sys-util = "0.12.1"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acpi_tables"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#ca1a473fe73cdd8eb49c1449faad7aaac06f32c2"
+source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#849d5950196f66dd10f2b2606d8fe8c7cb39ec24"
 dependencies = [
  "zerocopy",
 ]
@@ -361,9 +361,9 @@ checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -500,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efe3f1a4437bffe000e6297a593b98184213cd27486776c335f95ab53d48e3a"
+checksum = "fa4933174d0cc4b77b958578cd45784071cc5ae212c2d78fbd755aaaa6dfa71a"
 dependencies = [
  "serde",
  "vmm-sys-util",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c2176b91f68903b54ac8c6185bada7d607ca6110998976ff15c032f88a7d39"
+checksum = "337d1afa126368bbd6a5c328048f71a69a737e9afe7e436b392a8f8d770c9171"
 dependencies = [
  "bitflags 2.6.0",
  "kvm-bindings",
@@ -551,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d379d0089d0fbf4161c35a4fdfd76125923f1a93632c49195f5372b4c0b1472"
+checksum = "870c3814345f050991f99869417779f6062542bcf4ed81db7a1b926ad1306638"
 dependencies = [
  "vm-memory",
 ]
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "option_parser"
@@ -1020,7 +1020,7 @@ dependencies = [
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#a51a4746b0d317bfc21fa49d40f9287f3b8137fd"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#b135b8305c2cc8ec333e0cf77a780445cc98dcee"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -1028,7 +1028,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#a51a4746b0d317bfc21fa49d40f9287f3b8137fd"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#b135b8305c2cc8ec333e0cf77a780445cc98dcee"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -1044,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "vfio_user"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio-user?branch=main#bf7d7e851b604d8414a7960fb9137b59fc42421d"
+source = "git+https://github.com/rust-vmm/vfio-user?branch=main#3febcdd3fa2531623865663ca1721e1962ed9979"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -1060,9 +1060,8 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1c4c6c9f79fbe3150d9a403008ca416d34c489897effdda28b646f09900aad"
+version = "0.12.1"
+source = "git+https://github.com/rust-vmm/vhost?rev=d983ae0#d983ae07f78663b7d24059667376992460b571a2"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
@@ -1073,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-bindings"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d0df4f5ad79b1dc81b5913ac737e24a84dcd5100f36ed953a1faec18aba241"
+checksum = "1711e61c00f8cb450bd15368152a1e37a12ef195008ddc7d0f4812f9e2b30a68"
 
 [[package]]
 name = "virtio-devices"
@@ -1112,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1761348d3b5e82131379b9373435b48dc8333100bff3f1cdf9cc541a0ad83"
+checksum = "872e2f3fbd70a7e6f01689720cce3d5c2c5efe52b484dd07b674246ada0e9a8d"
 dependencies = [
  "log",
  "virtio-bindings",
@@ -1147,13 +1146,13 @@ dependencies = [
 [[package]]
 name = "vm-fdt"
 version = "0.3.0"
-source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#982fb8d9c8cd7f53520d7e304b39ff307fa3a641"
+source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#ef5bd734f5f66fb07722d766981adbc915f0d941"
 
 [[package]]
 name = "vm-memory"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a320fc11792e063174402ff444aa3c80363cbf1e31c47b5ef74124406c334ce6"
+checksum = "e2919f87420b6998a131eb7c78843890295e91a3f8f786ccc925c8d387b75121"
 dependencies = [
  "arc-swap",
  "libc",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,15 +18,15 @@ devices = { path = "../devices" }
 epoll = "4.3.3"
 libc = "0.2.155"
 libfuzzer-sys = "0.4.7"
-linux-loader = { version = "0.12.0", features = ["bzimage", "elf", "pe"] }
+linux-loader = { version = "0.13.0", features = ["bzimage", "elf", "pe"] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 net_util = { path = "../net_util" }
 once_cell = "1.19.0"
 seccompiler = "0.4.0"
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.13.0"
+virtio-queue = "0.14.0"
 vm-device = { path = "../vm-device" }
-vm-memory = "0.15.0"
+vm-memory = "0.16.0"
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm = { path = "../vmm", features = ["guest_debug"] }

--- a/hypervisor/src/kvm/aarch64/gic/dist_regs.rs
+++ b/hypervisor/src/kvm/aarch64/gic/dist_regs.rs
@@ -103,9 +103,8 @@ fn dist_attr_get(gic: &DeviceFd, offset: u32) -> Result<u32> {
         flags: 0,
     };
 
-    // get_device_attr should be marked as unsafe, and will be in future.
     // SAFETY: gic_dist_attr.addr is safe to write to.
-    gic.get_device_attr(&mut gic_dist_attr).map_err(|e| {
+    unsafe { gic.get_device_attr(&mut gic_dist_attr) }.map_err(|e| {
         Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
     })?;
 
@@ -131,9 +130,8 @@ fn get_interrupts_num(gic: &DeviceFd) -> Result<u32> {
         addr: &mut num_irq as *mut u32 as u64,
         flags: 0,
     };
-    // get_device_attr should be marked as unsafe, and will be in future.
     // SAFETY: nr_irqs_attr.addr is safe to write to.
-    gic.get_device_attr(&mut nr_irqs_attr).map_err(|e| {
+    unsafe { gic.get_device_attr(&mut nr_irqs_attr) }.map_err(|e| {
         Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
     })?;
     Ok(num_irq)

--- a/hypervisor/src/kvm/aarch64/gic/icc_regs.rs
+++ b/hypervisor/src/kvm/aarch64/gic/icc_regs.rs
@@ -105,9 +105,8 @@ fn icc_attr_get(gic: &DeviceFd, offset: u64, typer: u64) -> Result<u32> {
         flags: 0,
     };
 
-    // get_device_attr should be marked as unsafe, and will be in future.
     // SAFETY: gic_icc_attr.addr is safe to write to.
-    gic.get_device_attr(&mut gic_icc_attr).map_err(|e| {
+    unsafe { gic.get_device_attr(&mut gic_icc_attr) }.map_err(|e| {
         Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
     })?;
 

--- a/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -49,13 +49,10 @@ fn gicv3_its_attr_get(its_device: &DeviceFd, group: u32, attr: u32) -> Result<u6
         flags: 0,
     };
 
-    // get_device_attr should be marked as unsafe, and will be in future.
     // SAFETY: gicv3_its_attr.addr is safe to write to.
-    its_device
-        .get_device_attr(&mut gicv3_its_attr)
-        .map_err(|e| {
-            Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
-        })?;
+    unsafe { its_device.get_device_attr(&mut gicv3_its_attr) }.map_err(|e| {
+        Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
+    })?;
 
     Ok(val)
 }

--- a/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
+++ b/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
@@ -121,9 +121,8 @@ fn redist_attr_get(gic: &DeviceFd, offset: u32, typer: u64) -> Result<u32> {
         flags: 0,
     };
 
-    // get_device_attr should be marked as unsafe, and will be in future.
     // SAFETY: gic_redist_attr.addr is safe to write to.
-    gic.get_device_attr(&mut gic_redist_attr).map_err(|e| {
+    unsafe { gic.get_device_attr(&mut gic_redist_attr) }.map_err(|e| {
         Error::GetDeviceAttribute(HypervisorDeviceError::GetDeviceAttribute(e.into()))
     })?;
 


### PR DESCRIPTION
- Bump kvm-bindings from 0.9.1 to 0.10.0
- Bump kvm-ioctls from 0.18.0 to 0.19.0
- Bump vm-memory from 0.15.0 to 0.16.0
- Bump linux-loader from 0.12.0 to 0.13.0
- Bump virtio-bindings from 0.2.1 to 0.2.4
- Bump virtio-queue from 0.13.0 to 0.14.0
- Pin mshv-bindings to 0.3.1
- Pin mshv-ioctls to 0.3.1
- Pin vhost to rev "d983ae0"
- Pin vhost-user-backend to rev "d983ae0"

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>