### PR TITLE
build: Increase ARM64 CI build timeouts

### DIFF
--- a/.github/workflows/integration-arm64.yaml
+++ b/.github/workflows/integration-arm64.yaml
@@ -6,7 +6,7 @@ concurrency:
 
 jobs:
   build:
-    timeout-minutes: 60
+    timeout-minutes: 120
     name: Tests (ARM64)
     runs-on: bookworm-arm64
     steps:
@@ -21,7 +21,7 @@ jobs:
       - name: Load openvswitch module
         run: sudo modprobe openvswitch
       - name: Run integration tests (musl)
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: scripts/dev_cli.sh tests --integration --libc musl
       - name: Install Azure CLI
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
The builds are flaking due to reaching the timeouts.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
