### PR TITLE
vmm: fix memory slot over KVM_USER_MEM_SLOTS

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3422,6 +3422,7 @@ impl DeviceManager {
             };
 
         let memory_manager = self.memory_manager.clone();
+        let memory_manager2 = self.memory_manager.clone();
 
         let vfio_pci_device = VfioPciDevice::new(
             vfio_name.clone(),
@@ -3433,6 +3434,7 @@ impl DeviceManager {
             device_cfg.iommu,
             pci_device_bdf,
             Arc::new(move || memory_manager.lock().unwrap().allocate_memory_slot()),
+            Arc::new(move |x| memory_manager2.lock().unwrap().free_memory_slot(x)),
             vm_migration::snapshot_from_id(self.snapshot.as_ref(), vfio_name.as_str()),
             device_cfg.x_nv_gpudirect_clique,
         )


### PR DESCRIPTION
When adding vfio passthrough devices cloud hypervisor allocate a new memory slot in map_mmio_regions. As we +1 each time as new memory slot, it will fail as the memory slot over KVM_USER_MEM_SLOTS in kernel when calling KVM_SET_USER_MEMORY_REGION ioctl.

This patch introduces a vector to save the memory slots allocated, and return the minimal available memory slot to caller to fix this issue.