### PR TITLE
Add support for cross-host live migration over TCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,9 +2402,9 @@ source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#ef5bd734f5f66fb0772
 
 [[package]]
 name = "vm-memory"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2919f87420b6998a131eb7c78843890295e91a3f8f786ccc925c8d387b75121"
+checksum = "f1720e7240cdc739f935456eb77f370d7e9b2a3909204da1e2b47bef1137a013"
 dependencies = [
  "arc-swap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,5 +117,5 @@ vhost-user-backend = { git = "https://github.com/rust-vmm/vhost", rev = "d983ae0
 virtio-bindings = "0.2.4"
 virtio-queue = "0.14.0"
 vm-fdt = { git = "https://github.com/rust-vmm/vm-fdt", branch = "main" }
-vm-memory = "0.16.0"
+vm-memory = "0.16.1"
 vmm-sys-util = "0.12.1"

--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -1,7 +1,7 @@
 # Live Migration
 
-This document gives two examples of how to use the live migration
-support in Cloud Hypervisor:
+This document gives examples of how to use the live migration support
+in Cloud Hypervisor:
 
 1. local migration - migrating a VM from one Cloud Hypervisor instance to another on the same machine;
 1. remote migration - migrating a VM between two machines;
@@ -50,14 +50,11 @@ In this example, we will migrate a VM from one machine (`src`) to
 another (`dst`) across the network. To keep it simple, we will use a
 minimal VM setup without storage.
 
-Because Cloud Hypervisor does not natively support migrating via TCP
-connections, we will tunnel traffic through `socat`.
-
 ### Preparation
 
 Make sure that `src` and `dst` can reach each other via the
 network. You should be able to ping each machine. Also each machine
-should have an open TCP port. For this example we assume port 6000.
+should have an open TCP port.
 
 You will need a kernel and initramfs for a minimal Linux system. For
 this example, we will use the Debian netboot image.
@@ -75,7 +72,11 @@ src $ curl $DEBIAN/initrd.gz > /var/images/initrd
 
 Repeat the above steps on the destination host.
 
-### Starting the Receiver VM
+### Unix Socket Migration
+
+If Unix socket is selected for migration, we can tunnel traffic through "socat".
+
+#### Starting the Receiver VM
 
 On the receiver side, we prepare an empty VM:
 
@@ -92,10 +93,10 @@ dst $ ch-remote --api-socket=/tmp/api receive-migration unix:/tmp/sock
 In yet another terminal, forward TCP connections to the Unix domain socket:
 
 ```console
-dst $ socat TCP-LISTEN:6000,reuseaddr UNIX-CLIENT:/tmp/sock
+dst $ socat TCP-LISTEN:{port},reuseaddr UNIX-CLIENT:/tmp/sock
 ```
 
-### Starting the Sender VM
+#### Starting the Sender VM
 
 Let's start the VM on the source machine:
 
@@ -111,13 +112,15 @@ src $ cloud-hypervisor \
 
 After a few seconds the VM should be up and you can interact with it.
 
-### Performing the Migration
+#### Performing the Migration
 
 First, we start `socat`:
 
 ```console
-src $ socat UNIX-LISTEN:/tmp/sock,reuseaddr TCP:dst:6000
+src $ socat UNIX-LISTEN:/tmp/sock,reuseaddr TCP:{dst}:{port}
 ```
+
+> Replace {dst}:{port} with the actual IP address and port of your destination host.
 
 Then we kick-off the migration itself:
 
@@ -127,3 +130,53 @@ src $ ch-remote --api-socket=/tmp/api send-migration unix:/tmp/sock
 
 When the above commands completed, the VM should be successfully
 migrated to the destination machine without interrupting the workload.
+
+### TCP Socket Migration
+
+If TCP socket is selected for migration, we need to consider migrating
+in a trusted network.
+
+#### Starting the Receiver VM
+
+On the receiver side, we prepare an empty VM:
+
+```console
+dst $ cloud-hypervisor --api-socket /tmp/api
+```
+
+In a different terminal, prepare to receive the migration:
+
+```console
+dst $ ch-remote --api-socket=/tmp/api receive-migration tcp:0.0.0.0:{port}
+```
+
+#### Starting the Sender VM
+
+Let's start the VM on the source machine:
+
+```console
+src $ cloud-hypervisor \
+        --serial tty --console off \
+        --cpus boot=2 --memory size=4G \
+        --kernel /var/images/linux \
+        --initramfs /var/images/initrd \
+        --cmdline "console=ttyS0" \
+        --api-socket /tmp/api
+```
+
+After a few seconds the VM should be up and you can interact with it.
+
+#### Performing the Migration
+
+Initiate the Migration over TCP:
+
+```console
+src $ ch-remote --api-socket=/tmp/api send-migration  tcp:{dst}:{port}
+```
+
+> Replace {dst}:{port} with the actual IP address and port of your destination host.
+
+After completing the above commands, the source VM will be migrated to
+the destination host and continue running there. The source VM instance
+will terminate normally. All ongoing processes and connections within
+the VM should remain intact after the migration.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,12 +12,14 @@ extern crate test_infra;
 
 use std::collections::HashMap;
 use std::io::{BufRead, Read, Seek, Write};
+use std::net::TcpListener;
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::string::String;
 use std::sync::mpsc::Receiver;
 use std::sync::{mpsc, Mutex};
+use std::time::Duration;
 use std::{fs, io, thread};
 
 use net_util::MacAddr;
@@ -10295,6 +10297,220 @@ mod live_migration {
         handle_child_output(r, &dest_output);
     }
 
+    // Function to get an available port
+    fn get_available_port() -> u16 {
+        TcpListener::bind("127.0.0.1:0")
+            .expect("Failed to bind to address")
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    fn start_live_migration_tcp(src_api_socket: &str, dest_api_socket: &str) -> bool {
+        // Get an available TCP port
+        let migration_port = get_available_port();
+        let host_ip = "127.0.0.1";
+
+        // Start the 'receive-migration' command on the destination
+        let mut receive_migration = Command::new(clh_command("ch-remote"))
+            .args([
+                &format!("--api-socket={}", dest_api_socket),
+                "receive-migration",
+                &format!("tcp:0.0.0.0:{}", migration_port),
+            ])
+            .stdin(Stdio::null())
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        // Give the destination some time to start listening
+        thread::sleep(Duration::from_secs(1));
+
+        // Start the 'send-migration' command on the source
+        let mut send_migration = Command::new(clh_command("ch-remote"))
+            .args([
+                &format!("--api-socket={}", src_api_socket),
+                "send-migration",
+                &format!("tcp:{}:{}", host_ip, migration_port),
+            ])
+            .stdin(Stdio::null())
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        // Check if the 'send-migration' command executed successfully
+        let send_success = if let Some(status) = send_migration
+            .wait_timeout(Duration::from_secs(60))
+            .unwrap()
+        {
+            status.success()
+        } else {
+            false
+        };
+
+        if !send_success {
+            let _ = send_migration.kill();
+            let output = send_migration.wait_with_output().unwrap();
+            eprintln!(
+                "\n\n==== Start 'send_migration' output ====\n\n---stdout---\n{}\n\n---stderr---\n{}\n\n==== End 'send_migration' output ====\n\n",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        // Check if the 'receive-migration' command executed successfully
+        let receive_success = if let Some(status) = receive_migration
+            .wait_timeout(Duration::from_secs(60))
+            .unwrap()
+        {
+            status.success()
+        } else {
+            false
+        };
+
+        if !receive_success {
+            let _ = receive_migration.kill();
+            let output = receive_migration.wait_with_output().unwrap();
+            eprintln!(
+                "\n\n==== Start 'receive_migration' output ====\n\n---stdout---\n{}\n\n---stderr---\n{}\n\n==== End 'receive_migration' output ====\n\n",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        send_success && receive_success
+    }
+
+    fn _test_live_migration_tcp() {
+        let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(focal));
+        let kernel_path = direct_kernel_boot_path();
+        let console_text = String::from("On a branch floating down river a cricket, singing.");
+        let net_id = "net123";
+        let net_params = format!(
+            "id={},tap=,mac={},ip={},mask=255.255.255.0",
+            net_id, guest.network.guest_mac, guest.network.host_ip
+        );
+        let memory_param: &[&str] = &["--memory", "size=4G,shared=on"];
+        let boot_vcpus = 2;
+        let max_vcpus = 4;
+        let pmem_temp_file = TempFile::new().unwrap();
+        pmem_temp_file.as_file().set_len(128 << 20).unwrap();
+        std::process::Command::new("mkfs.ext4")
+            .arg(pmem_temp_file.as_path())
+            .output()
+            .expect("Expect creating disk image to succeed");
+        let pmem_path = String::from("/dev/pmem0");
+
+        // Start the source VM
+        let src_vm_path = clh_command("cloud-hypervisor");
+        let src_api_socket = temp_api_path(&guest.tmp_dir);
+        let mut src_vm_cmd = GuestCommand::new_with_binary_path(&guest, &src_vm_path);
+        src_vm_cmd
+            .args([
+                "--cpus",
+                format!("boot={},max={}", boot_vcpus, max_vcpus).as_str(),
+            ])
+            .args(memory_param)
+            .args(["--kernel", kernel_path.to_str().unwrap()])
+            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_disks()
+            .args(["--net", net_params.as_str()])
+            .args(["--api-socket", &src_api_socket])
+            .args([
+                "--pmem",
+                format!(
+                    "file={},discard_writes=on",
+                    pmem_temp_file.as_path().to_str().unwrap(),
+                )
+                .as_str(),
+            ])
+            .capture_output();
+        let mut src_child = src_vm_cmd.spawn().unwrap();
+
+        // Start the destination VM
+        let mut dest_api_socket = temp_api_path(&guest.tmp_dir);
+        dest_api_socket.push_str(".dest");
+        let mut dest_child = GuestCommand::new(&guest)
+            .args(["--api-socket", &dest_api_socket])
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = std::panic::catch_unwind(|| {
+            guest.wait_vm_boot(None).unwrap();
+            // Ensure the source VM is running normally
+            assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
+            assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+            guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
+
+            // On x86_64 architecture, remove and re-add the virtio-net device
+            #[cfg(target_arch = "x86_64")]
+            {
+                assert!(remote_command(
+                    &src_api_socket,
+                    "remove-device",
+                    Some(net_id),
+                ));
+                thread::sleep(Duration::new(10, 0));
+                // Re-add the virtio-net device
+                assert!(remote_command(
+                    &src_api_socket,
+                    "add-net",
+                    Some(net_params.as_str()),
+                ));
+                thread::sleep(Duration::new(10, 0));
+            }
+            // Start TCP live migration
+            assert!(
+                start_live_migration_tcp(&src_api_socket, &dest_api_socket),
+                "Unsuccessful command: 'send-migration' or 'receive-migration'."
+            );
+        });
+
+        // Check and report any errors that occurred during live migration
+        if r.is_err() {
+            print_and_panic(
+                src_child,
+                dest_child,
+                None,
+                "Error occurred during live-migration",
+            );
+        }
+
+        // Check the source vm has been terminated successful (give it '3s' to settle)
+        thread::sleep(std::time::Duration::new(3, 0));
+        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
+            print_and_panic(
+                src_child,
+                dest_child,
+                None,
+                "Source VM was not terminated successfully.",
+            );
+        };
+
+        // After live migration, ensure the destination VM is running normally
+        let r = std::panic::catch_unwind(|| {
+            // Perform the same checks to ensure the VM has migrated correctly
+            assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
+            assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+            guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
+        });
+
+        // Clean up the destination VM and ensure it terminates properly
+        let _ = dest_child.kill();
+        let dest_output = dest_child.wait_with_output().unwrap();
+        handle_child_output(r, &dest_output);
+
+        // Check if the expected `console_text` is present in the destination VM's output
+        let r = std::panic::catch_unwind(|| {
+            assert!(String::from_utf8_lossy(&dest_output.stdout).contains(&console_text));
+        });
+        handle_child_output(r, &dest_output);
+    }
+
     mod live_migration_parallel {
         use super::*;
         #[test]
@@ -10305,6 +10521,11 @@ mod live_migration {
         #[test]
         fn test_live_migration_local() {
             _test_live_migration(false, true)
+        }
+
+        #[test]
+        fn test_live_migration_tcp() {
+            _test_live_migration_tcp();
         }
 
         #[test]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -11,6 +11,7 @@ extern crate log;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{stdout, Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::panic::AssertUnwindSafe;
@@ -36,8 +37,8 @@ use serde::{Deserialize, Serialize};
 use signal_hook::iterator::{Handle, Signals};
 use thiserror::Error;
 use tracer::trace_scoped;
-use vm_memory::bitmap::AtomicBitmap;
-use vm_memory::{ReadVolatile, WriteVolatile};
+use vm_memory::bitmap::{AtomicBitmap, BitmapSlice};
+use vm_memory::{ReadVolatile, VolatileMemoryError, VolatileSlice, WriteVolatile};
 use vm_migration::protocol::*;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
@@ -231,6 +232,89 @@ impl From<u64> for EpollDispatch {
             3 => ActivateVirtioDevices,
             4 => Debug,
             _ => Unknown,
+        }
+    }
+}
+
+enum SocketStream {
+    Unix(UnixStream),
+    Tcp(TcpStream),
+}
+
+impl Read for SocketStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            SocketStream::Unix(stream) => stream.read(buf),
+            SocketStream::Tcp(stream) => stream.read(buf),
+        }
+    }
+}
+
+impl Write for SocketStream {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            SocketStream::Unix(stream) => stream.write(buf),
+            SocketStream::Tcp(stream) => stream.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            SocketStream::Unix(stream) => stream.flush(),
+            SocketStream::Tcp(stream) => stream.flush(),
+        }
+    }
+}
+
+impl AsRawFd for SocketStream {
+    fn as_raw_fd(&self) -> RawFd {
+        match self {
+            SocketStream::Unix(s) => s.as_raw_fd(),
+            SocketStream::Tcp(s) => s.as_raw_fd(),
+        }
+    }
+}
+
+impl ReadVolatile for SocketStream {
+    fn read_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &mut VolatileSlice<B>,
+    ) -> std::result::Result<usize, VolatileMemoryError> {
+        match self {
+            SocketStream::Unix(s) => s.read_volatile(buf),
+            SocketStream::Tcp(s) => s.read_volatile(buf),
+        }
+    }
+
+    fn read_exact_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &mut VolatileSlice<B>,
+    ) -> std::result::Result<(), VolatileMemoryError> {
+        match self {
+            SocketStream::Unix(s) => s.read_exact_volatile(buf),
+            SocketStream::Tcp(s) => s.read_exact_volatile(buf),
+        }
+    }
+}
+
+impl WriteVolatile for SocketStream {
+    fn write_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> std::result::Result<usize, VolatileMemoryError> {
+        match self {
+            SocketStream::Unix(s) => s.write_volatile(buf),
+            SocketStream::Tcp(s) => s.write_volatile(buf),
+        }
+    }
+
+    fn write_all_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> std::result::Result<(), VolatileMemoryError> {
+        match self {
+            SocketStream::Unix(s) => s.write_all_volatile(buf),
+            SocketStream::Tcp(s) => s.write_all_volatile(buf),
         }
     }
 }
@@ -919,14 +1003,72 @@ impl Vmm {
             .map(|s| s.into())
     }
 
+    fn send_migration_socket(
+        destination_url: &str,
+    ) -> std::result::Result<SocketStream, MigratableError> {
+        if let Some(address) = destination_url.strip_prefix("tcp:") {
+            info!("Connecting to TCP socket at {}", address);
+
+            let socket = TcpStream::connect(address).map_err(|e| {
+                MigratableError::MigrateSend(anyhow!("Error connecting to TCP socket: {}", e))
+            })?;
+
+            Ok(SocketStream::Tcp(socket))
+        } else {
+            let path = Vmm::socket_url_to_path(destination_url)?;
+            info!("Connecting to UNIX socket at {:?}", path);
+
+            let socket = UnixStream::connect(&path).map_err(|e| {
+                MigratableError::MigrateSend(anyhow!("Error connecting to UNIX socket: {}", e))
+            })?;
+
+            Ok(SocketStream::Unix(socket))
+        }
+    }
+
+    fn receive_migration_socket(
+        receiver_url: &str,
+    ) -> std::result::Result<SocketStream, MigratableError> {
+        if let Some(address) = receiver_url.strip_prefix("tcp:") {
+            let listener = TcpListener::bind(address).map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!("Error binding to TCP socket: {}", e))
+            })?;
+
+            let (socket, _addr) = listener.accept().map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!(
+                    "Error accepting connection on TCP socket: {}",
+                    e
+                ))
+            })?;
+
+            Ok(SocketStream::Tcp(socket))
+        } else {
+            let path = Vmm::socket_url_to_path(receiver_url)?;
+            let listener = UnixListener::bind(&path).map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!("Error binding to UNIX socket: {}", e))
+            })?;
+
+            let (socket, _addr) = listener.accept().map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!(
+                    "Error accepting connection on UNIX socket: {}",
+                    e
+                ))
+            })?;
+
+            // Remove the UNIX socket file after accepting the connection
+            std::fs::remove_file(&path).map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!("Error removing UNIX socket file: {}", e))
+            })?;
+
+            Ok(SocketStream::Unix(socket))
+        }
+    }
+
     // Returns true if there were dirty pages to send
-    fn vm_maybe_send_dirty_pages<T>(
+    fn vm_maybe_send_dirty_pages(
         vm: &mut Vm,
-        socket: &mut T,
-    ) -> result::Result<bool, MigratableError>
-    where
-        T: Read + Write + WriteVolatile,
-    {
+        socket: &mut SocketStream,
+    ) -> result::Result<bool, MigratableError> {
         // Send (dirty) memory table
         let table = vm.dirty_log()?;
 
@@ -954,10 +1096,8 @@ impl Vmm {
         >,
         send_data_migration: VmSendMigrationData,
     ) -> result::Result<(), MigratableError> {
-        let path = Self::socket_url_to_path(&send_data_migration.destination_url)?;
-        let mut socket = UnixStream::connect(path).map_err(|e| {
-            MigratableError::MigrateSend(anyhow!("Error connecting to UNIX socket: {}", e))
-        })?;
+        // Set up the socket connection
+        let mut socket = Self::send_migration_socket(&send_data_migration.destination_url)?;
 
         // Start the migration
         Request::start().write_to(&mut socket)?;
@@ -997,7 +1137,17 @@ impl Vmm {
         };
 
         if send_data_migration.local {
-            vm.send_memory_fds(&mut socket)?;
+            match &mut socket {
+                SocketStream::Unix(unix_socket) => {
+                    // Proceed with sending memory file descriptors over UNIX socket
+                    vm.send_memory_fds(unix_socket)?;
+                }
+                SocketStream::Tcp(_tcp_socket) => {
+                    return Err(MigratableError::MigrateSend(anyhow!(
+                        "--local option is not supported with TCP sockets",
+                    )));
+                }
+            }
         }
 
         let vm_migration_config = VmMigrationConfig {
@@ -1958,16 +2108,8 @@ impl RequestHandler for Vmm {
             receive_data_migration.receiver_url
         );
 
-        let path = Self::socket_url_to_path(&receive_data_migration.receiver_url)?;
-        let listener = UnixListener::bind(&path).map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error binding to UNIX socket: {}", e))
-        })?;
-        let (mut socket, _addr) = listener.accept().map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error accepting on UNIX socket: {}", e))
-        })?;
-        std::fs::remove_file(&path).map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error unlinking UNIX socket: {}", e))
-        })?;
+        // Accept the connection and get the socket
+        let mut socket = Vmm::receive_migration_socket(&receive_data_migration.receiver_url)?;
 
         let mut started = false;
         let mut memory_manager: Option<Arc<Mutex<MemoryManager>>> = None;
@@ -2035,24 +2177,35 @@ impl RequestHandler for Vmm {
                         continue;
                     }
 
-                    let mut buf = [0u8; 4];
-                    let (_, file) = socket.recv_with_fd(&mut buf).map_err(|e| {
-                        MigratableError::MigrateReceive(anyhow!(
-                            "Error receiving slot from socket: {}",
-                            e
-                        ))
-                    })?;
+                    match &mut socket {
+                        SocketStream::Unix(unix_socket) => {
+                            let mut buf = [0u8; 4];
+                            let (_, file) = unix_socket.recv_with_fd(&mut buf).map_err(|e| {
+                                MigratableError::MigrateReceive(anyhow!(
+                                    "Error receiving slot from socket: {}",
+                                    e
+                                ))
+                            })?;
 
-                    if existing_memory_files.is_none() {
-                        existing_memory_files = Some(HashMap::default())
+                            if existing_memory_files.is_none() {
+                                existing_memory_files = Some(HashMap::default())
+                            }
+
+                            if let Some(ref mut existing_memory_files) = existing_memory_files {
+                                let slot = u32::from_le_bytes(buf);
+                                existing_memory_files.insert(slot, file.unwrap());
+                            }
+
+                            Response::ok().write_to(&mut socket)?;
+                        }
+                        SocketStream::Tcp(_tcp_socket) => {
+                            // For TCP sockets, we cannot transfer file descriptors
+                            warn!(
+                                "MemoryFd command received over TCP socket, which is not supported"
+                            );
+                            Response::error().write_to(&mut socket)?;
+                        }
                     }
-
-                    if let Some(ref mut existing_memory_files) = existing_memory_files {
-                        let slot = u32::from_le_bytes(buf);
-                        existing_memory_files.insert(slot, file.unwrap());
-                    }
-
-                    Response::ok().write_to(&mut socket)?;
                 }
                 Command::Complete => {
                     info!("Complete Command Received");


### PR DESCRIPTION
# Summary

This pull request updates the vm-memory crate from version 0.16.0 to 0.16.1, incorporating the necessary implementations for TcpStream. It introduces TCP-based cross-host live migration support in Cloud Hypervisor, enhancing migration performance and simplifying the process. Additionally, the live migration documentation has been updated to provide instructions for executing cross-host live migrations over TCP connections.

# Changes Made

## `build`: Bump `vm-memory` from `0.16.0` to `0.16.1`

- **Updated** the `vm-memory` crate dependency to version `0.16.1` to include the implementations of `ReadVolatile` and `WriteVolatile` for `TcpStream`, which are necessary for TCP-based live migration.

## `vmm`: Add support for cross-host live migration over TCP

- **Modified** `vm_send_migration` and `vm_receive_migration` functions to support `destination_url` and `receiver_url` starting with `tcp:`, allowing live migration over TCP sockets.
- **Moved** socket connection logic into `vm_send_migration` and `vm_receive_migration`, simplifying the migration functions.
- **Improved** migration efficiency by implementing direct TCP connections between hosts to transmit data.

## `docs`: Add documentation for cross-host TCP live migration

- **Updated** the live migration documentation to include instructions for performing cross-host live migrations over TCP connections.
- **Provided** detailed steps, commands, and considerations for users to perform TCP-based cross-host migrations.

# Test

We conducted tests to compare the performance of the new TCP-based cross-host live migration with the existing Unix socket migration using `socat` for cross-host communication. The key metrics measured were the **Total Migration Time** and **Downtime** experienced during the migration process.

## **Testing Environment**

- **Host Machines**: Both the source and destination hosts are equipped with identical hardware specifications.

- Virtual Machine Under Test:

  - **CPU**: 4 vCPUs
  - **Memory**: 8 GB RAM

- Memory Pressure Application

  - Inside the guest VM, we applied memory pressure using the following command:

    ```bash
    stress -m 4 --vm-bytes 256M
    ```

### Estimating Migration Time and Downtime from Logs

The migration time and downtime were estimated using timestamps from the Cloud Hypervisor logs. The methodology is as follows:

- **Migration Time**: Calculated as the difference between the timestamps when the migration started and when it completed.
  - **Migration Start Time**: The timestamp when the `VmSendMigration` API request is received.
  - **Migration End Time**: The timestamp when the migration is marked as complete (`Migration complete` log entry).
- **Downtime**: Calculated as the difference between the timestamps when the VM is paused for migration and when the migration is complete.
  - **Downtime Start Time**: The timestamp when the VM is paused (`VM has been paused` log entry).
  - **Downtime End Time**: The same as the Migration End Time.

## Log Examples and Calculations

### TCP Migration Example

```
Start Migration: cloud-hypervisor: 12.852263s:  INFO:vmm/src/api/mod.rs:1262 -- API request event: VmSendMigration VmSendMigrationData { destination_url: "tcp:192.168.102.2:6000", local: false }
Start Downtime: cloud-hypervisor: 17.796833s: INFO:vmm/src/vm.rs:2488 -- VM has been paused
End Migration: cloud-hypervisor: 18.226345s:  INFO:vmm/src/lib.rs:1167 -- Migration complete
```

**Calculations:**

- **Migration Time** = Migration End Time - Migration Start Time
  - **Migration Time** = 18.226345s - 12.852263s = **5374.082 ms**
- **Downtime** = Migration End Time - Downtime Start Time
  - **Downtime** = 18.226345s - 17.796833s = **429.512 ms**

## Test Results

### TCP Migration Results

| Test        | **Migration Time (ms)** | **Downtime (ms)** |
| ----------- | ----------------------- | ----------------- |
| 1           | 5374.082                | 429.512           |
| 2           | 5347.307                | 353.986           |
| 3           | 5364.191                | 404.331           |
| **Average** | **5361.860**            | **395.943**       |

### Unix Socket Migration with Socat Results

| Test        | **Migration Time (ms)** | **Downtime (ms)** |
| ----------- | ----------------------- | ----------------- |
| 1           | 11797.579               | 845.931           |
| 2           | 11211.548               | 786.769           |
| 3           | 11689.248               | 790.308           |
| **Average** | **11566.125**           | **807.669**       |

## Analysis

- **Migration Time:**
  - TCP migration shows significantly faster migration times, averaging approximately **5,362 ms**.
  - Unix socket migration with `socat` takes longer, averaging approximately **11,566 ms**.
  - TCP migration reduces the total migration time by about **53%** compared to Unix socket migration.
- **Downtime:**
  - Downtime during TCP migration is shorter, averaging approximately **396 ms**.
  - Downtime during Unix socket migration averages around **808 ms**.
  - TCP migration reduces downtime by about **51%** compared to Unix socket migration.

The implementation of TCP-based cross-host live migration significantly improves migration performance when compared to Unix socket migration using `socat`. By reducing both the total migration time and the downtime by over 50%, this enhancement increases the efficiency and reliability of live migrations in cross-host scenarios.