### PR TITLE
arch: Introduce RISC-V architecture

### DIFF
--- a/.github/workflows/preview-riscv64.yaml
+++ b/.github/workflows/preview-riscv64.yaml
@@ -8,6 +8,13 @@ jobs:
   build:
     name: Cargo
     runs-on: riscv64-qemu-host
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - hypervisor
+          - arch
+
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
@@ -17,14 +24,14 @@ jobs:
       - name: Install Rust toolchain
         run: /opt/scripts/exec-in-qemu.sh rustup default 1.77.0
 
-      - name: Build hypervisor Module (kvm)
-        run: /opt/scripts/exec-in-qemu.sh cargo rustc --locked -p hypervisor --no-default-features --features "kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+      - name: Build ${{ matrix.module }} Module (kvm)
+        run: /opt/scripts/exec-in-qemu.sh cargo rustc --locked -p ${{ matrix.module }} --no-default-features --features "kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
-      - name: Clippy hypervisor Module (kvm)
-        run: /opt/scripts/exec-in-qemu.sh cargo clippy --locked -p hypervisor --no-default-features --features "kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+      - name: Clippy ${{ matrix.module }} Module (kvm)
+        run: /opt/scripts/exec-in-qemu.sh cargo clippy --locked -p ${{ matrix.module }} --no-default-features --features "kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
-      - name: Test hypervisor Module (kvm)
-        run: /opt/scripts/exec-in-qemu.sh cargo test --locked -p hypervisor --no-default-features --features "kvm"
+      - name: Test ${{ matrix.module }} Module (kvm)
+        run: /opt/scripts/exec-in-qemu.sh cargo test --locked -p ${{ matrix.module }} --no-default-features --features "kvm"
 
       - name: Check no files were modified
         run: test -z "$(git status --porcelain)"

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -24,6 +24,6 @@ vm-memory = { workspace = true, features = ["backend-bitmap", "backend-mmap"] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { workspace = true, features = ["with-serde"] }
 
-[target.'cfg(target_arch = "aarch64")'.dependencies]
+[target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]
 fdt_parser = { version = "0.1.5", package = "fdt" }
 vm-fdt = { workspace = true }

--- a/arch/src/riscv64/fdt.rs
+++ b/arch/src/riscv64/fdt.rs
@@ -1,0 +1,484 @@
+// Copyright © 2024 Institute of Software, CAS. All rights reserved.
+// Copyright 2020 Arm Limited (or its affiliates). All rights reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+use std::{cmp, result, str};
+
+use byteorder::{BigEndian, ByteOrder};
+use hypervisor::arch::riscv64::aia::Vaia;
+use thiserror::Error;
+use vm_fdt::{FdtWriter, FdtWriterResult};
+use vm_memory::{Address, Bytes, GuestMemory, GuestMemoryError, GuestMemoryRegion};
+
+use super::super::{DeviceType, GuestMemoryMmap, InitramfsConfig};
+use super::layout::{
+    IRQ_BASE, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START, MEM_PCI_IO_SIZE, MEM_PCI_IO_START,
+    PCI_HIGH_BASE, PCI_MMIO_CONFIG_SIZE_PER_SEGMENT,
+};
+use crate::PciSpaceInfo;
+
+const AIA_APLIC_PHANDLE: u32 = 1;
+const AIA_IMSIC_PHANDLE: u32 = 2;
+const CPU_INTC_BASE_PHANDLE: u32 = 3;
+const CPU_BASE_PHANDLE: u32 = 256 + CPU_INTC_BASE_PHANDLE;
+// Read the documentation specified when appending the root node to the FDT.
+const ADDRESS_CELLS: u32 = 0x2;
+const SIZE_CELLS: u32 = 0x2;
+
+// From https://elixir.bootlin.com/linux/v6.10/source/include/dt-bindings/interrupt-controller/irq.h#L14
+const _IRQ_TYPE_EDGE_RISING: u32 = 1;
+const IRQ_TYPE_LEVEL_HI: u32 = 4;
+
+const S_MODE_EXT_IRQ: u32 = 9;
+
+/// Trait for devices to be added to the Flattened Device Tree.
+pub trait DeviceInfoForFdt {
+    /// Returns the address where this device will be loaded.
+    fn addr(&self) -> u64;
+    /// Returns the associated interrupt for this device.
+    fn irq(&self) -> u32;
+    /// Returns the amount of memory that needs to be reserved for this device.
+    fn length(&self) -> u64;
+}
+
+/// Errors thrown while configuring the Flattened Device Tree for riscv64.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Failure in writing FDT in memory.
+    #[error("Failure in writing FDT in memory: {0}")]
+    WriteFdtToMemory(GuestMemoryError),
+}
+type Result<T> = result::Result<T, Error>;
+
+/// Creates the flattened device tree for this riscv64 VM.
+#[allow(clippy::too_many_arguments)]
+pub fn create_fdt<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHasher>(
+    guest_mem: &GuestMemoryMmap,
+    cmdline: &str,
+    num_vcpu: u32,
+    device_info: &HashMap<(DeviceType, String), T, S>,
+    aia_device: &Arc<Mutex<dyn Vaia>>,
+    initrd: &Option<InitramfsConfig>,
+    pci_space_info: &[PciSpaceInfo],
+) -> FdtWriterResult<Vec<u8>> {
+    // Allocate stuff necessary for the holding the blob.
+    let mut fdt = FdtWriter::new()?;
+
+    // For an explanation why these nodes were introduced in the blob take a look at
+    // https://github.com/devicetree-org/devicetree-specification/releases/tag/v0.4
+    // In chapter 3.
+
+    // Header or the root node as per above mentioned documentation.
+    let root_node = fdt.begin_node("")?;
+    fdt.property_string("compatible", "linux,dummy-virt")?;
+    // For info on #address-cells and size-cells resort to Table 3.1 Root Node
+    // Properties
+    fdt.property_u32("#address-cells", ADDRESS_CELLS)?;
+    fdt.property_u32("#size-cells", SIZE_CELLS)?;
+    create_cpu_nodes(&mut fdt, num_vcpu)?;
+    create_memory_node(&mut fdt, guest_mem)?;
+    create_chosen_node(&mut fdt, cmdline, initrd)?;
+    create_aia_node(&mut fdt, aia_device)?;
+    create_devices_node(&mut fdt, device_info)?;
+    create_pci_nodes(&mut fdt, pci_space_info)?;
+
+    // End Header node.
+    fdt.end_node(root_node)?;
+
+    let fdt_final = fdt.finish()?;
+
+    Ok(fdt_final)
+}
+
+pub fn write_fdt_to_memory(fdt_final: Vec<u8>, guest_mem: &GuestMemoryMmap) -> Result<()> {
+    // Write FDT to memory.
+    guest_mem
+        .write_slice(fdt_final.as_slice(), super::layout::FDT_START)
+        .map_err(Error::WriteFdtToMemory)?;
+    Ok(())
+}
+
+// Following are the auxiliary function for creating the different nodes that we append to our FDT.
+fn create_cpu_nodes(fdt: &mut FdtWriter, num_cpus: u32) -> FdtWriterResult<()> {
+    // See https://elixir.bootlin.com/linux/v6.10/source/Documentation/devicetree/bindings/riscv/cpus.yaml
+    let cpus = fdt.begin_node("cpus")?;
+    // As per documentation, on RISC-V 64-bit systems value should be set to 1.
+    fdt.property_u32("#address-cells", 0x01)?;
+    fdt.property_u32("#size-cells", 0x0)?;
+    // TODO: Retrieve CPU frequency from cpu timer regs
+    let timebase_frequency: u32 = 0x989680;
+    fdt.property_u32("timebase-frequency", timebase_frequency)?;
+
+    for cpu_index in 0..num_cpus {
+        let cpu = fdt.begin_node(&format!("cpu@{:x}", cpu_index))?;
+        fdt.property_string("device_type", "cpu")?;
+        fdt.property_string("compatible", "riscv")?;
+        fdt.property_string("mmu-type", "sv48")?;
+        fdt.property_string("riscv,isa", "rv64imafdc_smaia_ssaia")?;
+        fdt.property_string("status", "okay")?;
+        fdt.property_u32("reg", cpu_index)?;
+        fdt.property_u32("phandle", CPU_BASE_PHANDLE + cpu_index)?;
+
+        // interrupt controller node
+        let intc_node = fdt.begin_node("interrupt-controller")?;
+        fdt.property_string("compatible", "riscv,cpu-intc")?;
+        fdt.property_u32("#interrupt-cells", 1u32)?;
+        fdt.property_null("#interrupt-controller")?;
+        fdt.property_u32("phandle", CPU_INTC_BASE_PHANDLE + cpu_index)?;
+        fdt.end_node(intc_node)?;
+
+        fdt.end_node(cpu)?;
+    }
+
+    fdt.end_node(cpus)?;
+
+    Ok(())
+}
+
+fn create_memory_node(fdt: &mut FdtWriter, guest_mem: &GuestMemoryMmap) -> FdtWriterResult<()> {
+    // Note: memory regions from "GuestMemory" are sorted and non-zero sized.
+    let ram_regions = {
+        let mut ram_regions = Vec::new();
+        let mut current_start = guest_mem
+            .iter()
+            .next()
+            .map(GuestMemoryRegion::start_addr)
+            .expect("GuestMemory must have one memory region at least")
+            .raw_value();
+        let mut current_end = current_start;
+
+        for (start, size) in guest_mem
+            .iter()
+            .map(|m| (m.start_addr().raw_value(), m.len()))
+        {
+            if current_end == start {
+                // This zone is continuous with the previous one.
+                current_end += size;
+            } else {
+                ram_regions.push((current_start, current_end));
+
+                current_start = start;
+                current_end = start + size;
+            }
+        }
+
+        ram_regions.push((current_start, current_end));
+
+        ram_regions
+    };
+
+    let mut mem_reg_property = Vec::new();
+    for region in ram_regions {
+        let mem_size = region.1 - region.0;
+        mem_reg_property.push(region.0);
+        mem_reg_property.push(mem_size);
+    }
+
+    let ram_start = super::layout::RAM_START.raw_value();
+    let memory_node_name = format!("memory@{:x}", ram_start);
+    let memory_node = fdt.begin_node(&memory_node_name)?;
+    fdt.property_string("device_type", "memory")?;
+    fdt.property_array_u64("reg", &mem_reg_property)?;
+    fdt.end_node(memory_node)?;
+
+    Ok(())
+}
+
+fn create_chosen_node(
+    fdt: &mut FdtWriter,
+    cmdline: &str,
+    initrd: &Option<InitramfsConfig>,
+) -> FdtWriterResult<()> {
+    let chosen_node = fdt.begin_node("chosen")?;
+    fdt.property_string("bootargs", cmdline)?;
+
+    if let Some(initrd_config) = initrd {
+        let initrd_start = initrd_config.address.raw_value();
+        let initrd_end = initrd_config.address.raw_value() + initrd_config.size as u64;
+        fdt.property_u64("linux,initrd-start", initrd_start)?;
+        fdt.property_u64("linux,initrd-end", initrd_end)?;
+    }
+
+    fdt.end_node(chosen_node)?;
+
+    Ok(())
+}
+
+fn create_aia_node(fdt: &mut FdtWriter, aia_device: &Arc<Mutex<dyn Vaia>>) -> FdtWriterResult<()> {
+    // IMSIC
+    if aia_device.lock().unwrap().msi_compatible() {
+        use super::layout::IMSIC_START;
+        let imsic_name = format!("imsics@{:x}", IMSIC_START.0);
+        let imsic_node = fdt.begin_node(&imsic_name)?;
+
+        fdt.property_string(
+            "compatible",
+            aia_device.lock().unwrap().imsic_compatibility(),
+        )?;
+        let imsic_reg_prop = aia_device.lock().unwrap().imsic_properties();
+        fdt.property_array_u32("reg", &imsic_reg_prop)?;
+        fdt.property_u32("#interrupt-cells", 0u32)?;
+        fdt.property_null("interrupt-controller")?;
+        fdt.property_null("msi-controller")?;
+        // TODO complete num-ids
+        fdt.property_u32("riscv,num-ids", 2047u32)?;
+        fdt.property_u32("phandle", AIA_IMSIC_PHANDLE)?;
+
+        let mut irq_cells = Vec::new();
+        let num_cpus = aia_device.lock().unwrap().vcpu_count();
+        for i in 0..num_cpus {
+            irq_cells.push(CPU_INTC_BASE_PHANDLE + i);
+            irq_cells.push(S_MODE_EXT_IRQ);
+        }
+        fdt.property_array_u32("interrupts-extended", &irq_cells)?;
+
+        fdt.end_node(imsic_node)?;
+    }
+
+    // APLIC
+    use super::layout::APLIC_START;
+    let aplic_name = format!("aplic@{:x}", APLIC_START.0);
+    let aplic_node = fdt.begin_node(&aplic_name)?;
+
+    fdt.property_string(
+        "compatible",
+        aia_device.lock().unwrap().aplic_compatibility(),
+    )?;
+    let reg_cells = aia_device.lock().unwrap().aplic_properties();
+    fdt.property_array_u32("reg", &reg_cells)?;
+    fdt.property_u32("#interrupt-cells", 2u32)?;
+    fdt.property_null("interrupt-controller")?;
+    // TODO complete num-srcs
+    fdt.property_u32("riscv,num-sources", 96u32)?;
+    fdt.property_u32("phandle", AIA_APLIC_PHANDLE)?;
+    fdt.property_u32("msi-parent", AIA_IMSIC_PHANDLE)?;
+
+    fdt.end_node(aplic_node)?;
+
+    Ok(())
+}
+
+fn create_serial_node<T: DeviceInfoForFdt + Clone + Debug>(
+    fdt: &mut FdtWriter,
+    dev_info: &T,
+) -> FdtWriterResult<()> {
+    let serial_reg_prop = [dev_info.addr(), dev_info.length()];
+    let irq = [dev_info.irq() - IRQ_BASE, IRQ_TYPE_LEVEL_HI];
+
+    let serial_node = fdt.begin_node(&format!("serial@{:x}", dev_info.addr()))?;
+    fdt.property_string("compatible", "ns16550a")?;
+    fdt.property_array_u64("reg", &serial_reg_prop)?;
+    fdt.property_u32("clock-frequency", 3686400)?;
+    fdt.property_u32("interrupt-parent", AIA_APLIC_PHANDLE)?;
+    fdt.property_array_u32("interrupts", &irq)?;
+    fdt.end_node(serial_node)?;
+
+    Ok(())
+}
+
+fn create_devices_node<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHasher>(
+    fdt: &mut FdtWriter,
+    dev_info: &HashMap<(DeviceType, String), T, S>,
+) -> FdtWriterResult<()> {
+    for ((device_type, _device_id), info) in dev_info {
+        match device_type {
+            DeviceType::Serial => create_serial_node(fdt, info)?,
+            DeviceType::Virtio(_) => unreachable!(),
+        }
+    }
+
+    Ok(())
+}
+
+fn create_pci_nodes(fdt: &mut FdtWriter, pci_device_info: &[PciSpaceInfo]) -> FdtWriterResult<()> {
+    // Add node for PCIe controller.
+    // See Documentation/devicetree/bindings/pci/host-generic-pci.txt in the kernel
+    // and https://elinux.org/Device_Tree_Usage.
+    // In multiple PCI segments setup, each PCI segment needs a PCI node.
+    for pci_device_info_elem in pci_device_info.iter() {
+        // EDK2 requires the PCIe high space above 4G address.
+        // The actual space in CLH follows the RAM. If the RAM space is small, the PCIe high space
+        // could fall below 4G.
+        // Here we cut off PCI device space below 8G in FDT to workaround the EDK2 check.
+        // But the address written in ACPI is not impacted.
+        let (pci_device_base_64bit, pci_device_size_64bit) =
+            if pci_device_info_elem.pci_device_space_start < PCI_HIGH_BASE.raw_value() {
+                (
+                    PCI_HIGH_BASE.raw_value(),
+                    pci_device_info_elem.pci_device_space_size
+                        - (PCI_HIGH_BASE.raw_value() - pci_device_info_elem.pci_device_space_start),
+                )
+            } else {
+                (
+                    pci_device_info_elem.pci_device_space_start,
+                    pci_device_info_elem.pci_device_space_size,
+                )
+            };
+        // There is no specific requirement of the 32bit MMIO range, and
+        // therefore at least we can make these ranges 4K aligned.
+        let pci_device_size_32bit: u64 =
+            MEM_32BIT_DEVICES_SIZE / ((1 << 12) * pci_device_info.len() as u64) * (1 << 12);
+        let pci_device_base_32bit: u64 = MEM_32BIT_DEVICES_START.0
+            + pci_device_size_32bit * pci_device_info_elem.pci_segment_id as u64;
+
+        let ranges = [
+            // io addresses. Since AArch64 will not use IO address,
+            // we can set the same IO address range for every segment.
+            0x1000000,
+            0_u32,
+            0_u32,
+            (MEM_PCI_IO_START.0 >> 32) as u32,
+            MEM_PCI_IO_START.0 as u32,
+            (MEM_PCI_IO_SIZE >> 32) as u32,
+            MEM_PCI_IO_SIZE as u32,
+            // mmio addresses
+            0x2000000,                            // (ss = 10: 32-bit memory space)
+            (pci_device_base_32bit >> 32) as u32, // PCI address
+            pci_device_base_32bit as u32,
+            (pci_device_base_32bit >> 32) as u32, // CPU address
+            pci_device_base_32bit as u32,
+            (pci_device_size_32bit >> 32) as u32, // size
+            pci_device_size_32bit as u32,
+            // device addresses
+            0x3000000,                            // (ss = 11: 64-bit memory space)
+            (pci_device_base_64bit >> 32) as u32, // PCI address
+            pci_device_base_64bit as u32,
+            (pci_device_base_64bit >> 32) as u32, // CPU address
+            pci_device_base_64bit as u32,
+            (pci_device_size_64bit >> 32) as u32, // size
+            pci_device_size_64bit as u32,
+        ];
+        let bus_range = [0, 0]; // Only bus 0
+        let reg = [
+            pci_device_info_elem.mmio_config_address,
+            PCI_MMIO_CONFIG_SIZE_PER_SEGMENT,
+        ];
+        // See kernel document Documentation/devicetree/bindings/pci/pci-msi.txt
+        let msi_map = [
+            // rid-base: A single cell describing the first RID matched by the entry.
+            0x0,
+            // msi-controller: A single phandle to an MSI controller.
+            AIA_IMSIC_PHANDLE,
+            // msi-base: An msi-specifier describing the msi-specifier produced for the
+            // first RID matched by the entry.
+            (pci_device_info_elem.pci_segment_id as u32) << 8,
+            // length: A single cell describing how many consecutive RIDs are matched
+            // following the rid-base.
+            0x100,
+        ];
+
+        let pci_node_name = format!("pci@{:x}", pci_device_info_elem.mmio_config_address);
+        let pci_node = fdt.begin_node(&pci_node_name)?;
+
+        fdt.property_string("compatible", "pci-host-ecam-generic")?;
+        fdt.property_string("device_type", "pci")?;
+        fdt.property_array_u32("ranges", &ranges)?;
+        fdt.property_array_u32("bus-range", &bus_range)?;
+        fdt.property_u32(
+            "linux,pci-domain",
+            pci_device_info_elem.pci_segment_id as u32,
+        )?;
+        fdt.property_u32("#address-cells", 3)?;
+        fdt.property_u32("#size-cells", 2)?;
+        fdt.property_array_u64("reg", &reg)?;
+        fdt.property_u32("#interrupt-cells", 1)?;
+        fdt.property_null("interrupt-map")?;
+        fdt.property_null("interrupt-map-mask")?;
+        fdt.property_null("dma-coherent")?;
+        fdt.property_array_u32("msi-map", &msi_map)?;
+        fdt.property_u32("msi-parent", AIA_IMSIC_PHANDLE)?;
+
+        fdt.end_node(pci_node)?;
+    }
+
+    Ok(())
+}
+
+// Parse the DTB binary and print for debugging
+pub fn print_fdt(dtb: &[u8]) {
+    match fdt_parser::Fdt::new(dtb) {
+        Ok(fdt) => {
+            if let Some(root) = fdt.find_node("/") {
+                debug!("Printing the FDT:");
+                print_node(root, 0);
+            } else {
+                debug!("Failed to find root node in FDT for debugging.");
+            }
+        }
+        Err(_) => debug!("Failed to parse FDT for debugging."),
+    }
+}
+
+fn print_node(node: fdt_parser::node::FdtNode<'_, '_>, n_spaces: usize) {
+    debug!("{:indent$}{}/", "", node.name, indent = n_spaces);
+    for property in node.properties() {
+        let name = property.name;
+
+        // If the property is 'compatible', its value requires special handling.
+        // The u8 array could contain multiple null-terminated strings.
+        // We copy the original array and simply replace all 'null' characters with spaces.
+        let value = if name == "compatible" {
+            let mut compatible = vec![0u8; 256];
+            let handled_value = property
+                .value
+                .iter()
+                .map(|&c| if c == 0 { b' ' } else { c })
+                .collect::<Vec<_>>();
+            let len = cmp::min(255, handled_value.len());
+            compatible[..len].copy_from_slice(&handled_value[..len]);
+            compatible[..(len + 1)].to_vec()
+        } else {
+            property.value.to_vec()
+        };
+        let value = &value;
+
+        // Now the value can be either:
+        //   - A null-terminated C string, or
+        //   - Binary data
+        // We follow a very simple logic to present the value:
+        //   - At first, try to convert it to CStr and print,
+        //   - If failed, print it as u32 array.
+        let value_result = match CStr::from_bytes_with_nul(value) {
+            Ok(value_cstr) => match value_cstr.to_str() {
+                Ok(value_str) => Some(value_str),
+                Err(_e) => None,
+            },
+            Err(_e) => None,
+        };
+
+        if let Some(value_str) = value_result {
+            debug!(
+                "{:indent$}{} : {:#?}",
+                "",
+                name,
+                value_str,
+                indent = (n_spaces + 2)
+            );
+        } else {
+            let mut array = Vec::with_capacity(256);
+            array.resize(value.len() / 4, 0u32);
+            BigEndian::read_u32_into(value, &mut array);
+            debug!(
+                "{:indent$}{} : {:X?}",
+                "",
+                name,
+                array,
+                indent = (n_spaces + 2)
+            );
+        };
+    }
+
+    // Print children nodes if there is any
+    for child in node.children() {
+        print_node(child, n_spaces + 2);
+    }
+}

--- a/arch/src/riscv64/layout.rs
+++ b/arch/src/riscv64/layout.rs
@@ -1,0 +1,105 @@
+// Copyright © 2024 Institute of Software, CAS. All rights reserved.
+// Copyright 2020 Arm Limited (or its affiliates). All rights reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Memory layout of RISC-V 64-bit guest:
+//
+// Physical  +---------------------------------------------------------------+
+// address   |                                                               |
+// end       |                                                               |
+//           ~                   ~                       ~                   ~
+//           |                                                               |
+//           |                    Highmem PCI MMIO space                     |
+//           |                                                               |
+// RAM end   +---------------------------------------------------------------+
+// (dynamic, |                                                               |
+// including |                                                               |
+// hotplug   ~                   ~                       ~                   ~
+// memory)   |                                                               |
+//           |                             DRAM                              |
+//           |                                                               |
+//           |                                                               |
+//           |                                                               |
+//           |                                                               |
+//    1 GB   +---------------------------------------------------------------+
+//           |                                                               |
+//           |                      PCI MMCONFIG space                       |
+//           |                                                               |
+//  768 MB   +---------------------------------------------------------------+
+//           |                                                               |
+//           |                                                               |
+//           |                        PCI MMIO space                         |
+//           |                                                               |
+//  256 MB   +---------------------------------------------------------------|
+//           |                                                               |
+//           |                     Legacy devices space                      |
+//           |                                                               |
+//  128 MB   +---------------------------------------------------------------|
+//           |                                                               |
+//           |                            IMSICs                             |
+//           |                                                               |
+//   64 MB   +---------------------------------------------------------------+
+//           |                                                               |
+//           |                            APLICs                             |
+//           |                                                               |
+//    0 GB   +---------------------------------------------------------------+
+//
+//
+
+use vm_memory::GuestAddress;
+
+/// AIA related devices
+/// See https://elixir.bootlin.com/linux/v6.10/source/arch/riscv/include/uapi/asm/kvm.h
+/// 0x0 ~ 0x0400_0000 (64 MiB) resides APLICs
+pub const APLIC_START: GuestAddress = GuestAddress(0);
+pub const APLIC_SIZE: u64 = 0x4000;
+
+/// 0x0400_0000 ~ 0x0800_0000 (64 MiB) resides IMSICs
+pub const IMSIC_START: GuestAddress = GuestAddress(0x0400_0000);
+pub const IMSIC_SIZE: u64 = 0x1000;
+
+/// Below this address will reside the AIA, above this address will reside the MMIO devices.
+const MAPPED_IO_START: GuestAddress = GuestAddress(0x0800_0000);
+
+/// Space 0x0800_0000 ~ 0x1000_0000 is reserved for legacy devices.
+pub const LEGACY_SERIAL_MAPPED_IO_START: GuestAddress = MAPPED_IO_START;
+
+/// Space 0x0905_0000 ~ 0x0906_0000 is reserved for pcie io address
+pub const MEM_PCI_IO_START: GuestAddress = GuestAddress(0x0905_0000);
+pub const MEM_PCI_IO_SIZE: u64 = 0x1_0000;
+
+/// Starting from 0x1000_0000 (256MiB) to 0x3000_0000 (768MiB) is used for PCIE MMIO
+pub const MEM_32BIT_DEVICES_START: GuestAddress = GuestAddress(0x1000_0000);
+pub const MEM_32BIT_DEVICES_SIZE: u64 = 0x2000_0000;
+
+/// PCI MMCONFIG space (start: after the device space at 768MiB, length: 256MiB)
+pub const PCI_MMCONFIG_START: GuestAddress = GuestAddress(0x3000_0000);
+pub const PCI_MMCONFIG_SIZE: u64 = 256 << 20;
+// One bus with potentially 256 devices (32 slots x 8 functions).
+pub const PCI_MMIO_CONFIG_SIZE_PER_SEGMENT: u64 = 4096 * 256;
+
+/// Start of RAM.
+pub const RAM_START: GuestAddress = GuestAddress(0x4000_0000);
+
+/// Kernel command line maximum size on RISC-V.
+/// See https://elixir.bootlin.com/linux/v6.10/source/arch/riscv/include/uapi/asm/setup.h
+pub const CMDLINE_MAX_SIZE: usize = 1024;
+
+/// FDT is at the beginning of RAM.
+pub const FDT_START: GuestAddress = RAM_START;
+pub const FDT_MAX_SIZE: u64 = 0x1_0000;
+
+/// Kernel start after FDT
+pub const KERNEL_START: GuestAddress = GuestAddress(RAM_START.0 + FDT_MAX_SIZE);
+
+/// Pci high memory base
+pub const PCI_HIGH_BASE: GuestAddress = GuestAddress(0x2_0000_0000);
+
+/// First usable interrupt on riscv64
+pub const IRQ_BASE: u32 = 0;
+
+// As per https://elixir.bootlin.com/linux/v6.10/source/arch/riscv/include/asm/kvm_host.h#L31
+/// Number of supported interrupts
+pub const IRQ_NUM: u32 = 1023;

--- a/arch/src/riscv64/mod.rs
+++ b/arch/src/riscv64/mod.rs
@@ -1,0 +1,173 @@
+// Copyright © 2024 Institute of Software, CAS. All rights reserved.
+// Copyright 2020 Arm Limited (or its affiliates). All rights reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module for the flattened device tree.
+pub mod fdt;
+/// Layout for this riscv64 system.
+pub mod layout;
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+
+use hypervisor::arch::riscv64::aia::Vaia;
+use log::{log_enabled, Level};
+use thiserror::Error;
+use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryAtomic};
+
+pub use self::fdt::DeviceInfoForFdt;
+use crate::{DeviceType, GuestMemoryMmap, PciSpaceInfo, RegionType};
+
+pub const _NSIG: i32 = 65;
+
+/// Errors thrown while configuring riscv64 system.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Failed to create a FDT.
+    #[error("Failed to create a FDT")]
+    SetupFdt,
+
+    /// Failed to write FDT to memory.
+    #[error("Failed to write FDT to memory: {0}")]
+    WriteFdtToMemory(fdt::Error),
+
+    /// Failed to create a AIA.
+    #[error("Failed to create a AIA")]
+    SetupAia,
+
+    /// Failed to compute the initramfs address.
+    #[error("Failed to compute the initramfs address")]
+    InitramfsAddress,
+
+    /// Error configuring the general purpose registers
+    #[error("Error configuring the general purpose registers: {0}")]
+    RegsConfiguration(hypervisor::HypervisorCpuError),
+}
+
+impl From<Error> for super::Error {
+    fn from(e: Error) -> super::Error {
+        super::Error::PlatformSpecific(e)
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+/// Specifies the entry point address where the guest must start
+/// executing code.
+pub struct EntryPoint {
+    /// Address in guest memory where the guest must start execution
+    pub entry_addr: GuestAddress,
+}
+
+/// Configure the specified VCPU, and return its MPIDR.
+pub fn configure_vcpu(
+    vcpu: &Arc<dyn hypervisor::Vcpu>,
+    id: u8,
+    boot_setup: Option<(EntryPoint, &GuestMemoryAtomic<GuestMemoryMmap>)>,
+) -> super::Result<()> {
+    if let Some((kernel_entry_point, _guest_memory)) = boot_setup {
+        vcpu.setup_regs(
+            id,
+            kernel_entry_point.entry_addr.raw_value(),
+            layout::FDT_START.raw_value(),
+        )
+        .map_err(Error::RegsConfiguration)?;
+    }
+
+    Ok(())
+}
+
+pub fn arch_memory_regions() -> Vec<(GuestAddress, usize, RegionType)> {
+    vec![
+        // 0 MiB ~ 256 MiB: AIA and legacy devices
+        (
+            GuestAddress(0),
+            layout::MEM_32BIT_DEVICES_START.0 as usize,
+            RegionType::Reserved,
+        ),
+        // 256 MiB ~ 768 MiB: MMIO space
+        (
+            layout::MEM_32BIT_DEVICES_START,
+            layout::MEM_32BIT_DEVICES_SIZE as usize,
+            RegionType::SubRegion,
+        ),
+        // 768 MiB ~ 1 GiB: reserved. The leading 256M for PCIe MMCONFIG space
+        (
+            layout::PCI_MMCONFIG_START,
+            layout::PCI_MMCONFIG_SIZE as usize,
+            RegionType::Reserved,
+        ),
+        // 1GiB ~ inf: RAM
+        (layout::RAM_START, usize::MAX, RegionType::Ram),
+    ]
+}
+
+/// Configures the system and should be called once per vm before starting vcpu threads.
+#[allow(clippy::too_many_arguments)]
+pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHasher>(
+    guest_mem: &GuestMemoryMmap,
+    cmdline: &str,
+    num_vcpu: u32,
+    device_info: &HashMap<(DeviceType, String), T, S>,
+    initrd: &Option<super::InitramfsConfig>,
+    pci_space_info: &[PciSpaceInfo],
+    aia_device: &Arc<Mutex<dyn Vaia>>,
+) -> super::Result<()> {
+    let fdt_final = fdt::create_fdt(
+        guest_mem,
+        cmdline,
+        num_vcpu,
+        device_info,
+        aia_device,
+        initrd,
+        pci_space_info,
+    )
+    .map_err(|_| Error::SetupFdt)?;
+
+    if log_enabled!(Level::Debug) {
+        fdt::print_fdt(&fdt_final);
+    }
+
+    fdt::write_fdt_to_memory(fdt_final, guest_mem).map_err(Error::WriteFdtToMemory)?;
+
+    Ok(())
+}
+
+/// Returns the memory address where the initramfs could be loaded.
+pub fn initramfs_load_addr(
+    guest_mem: &GuestMemoryMmap,
+    initramfs_size: usize,
+) -> super::Result<u64> {
+    let round_to_pagesize = |size| (size + (super::PAGE_SIZE - 1)) & !(super::PAGE_SIZE - 1);
+    match guest_mem
+        .last_addr()
+        .checked_sub(round_to_pagesize(initramfs_size) as u64 - 1)
+    {
+        Some(offset) => {
+            if guest_mem.address_in_range(offset) {
+                Ok(offset.raw_value())
+            } else {
+                Err(super::Error::PlatformSpecific(Error::InitramfsAddress))
+            }
+        }
+        None => Err(super::Error::PlatformSpecific(Error::InitramfsAddress)),
+    }
+}
+
+pub fn get_host_cpu_phys_bits(_hypervisor: &Arc<dyn hypervisor::Hypervisor>) -> u8 {
+    40
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_arch_memory_regions_dram() {
+        let regions = arch_memory_regions();
+        assert_eq!(4, regions.len());
+        assert_eq!(layout::RAM_START, regions[3].0);
+        assert_eq!(RegionType::Ram, regions[3].2);
+    }
+}

--- a/hypervisor/src/arch/riscv64/aia.rs
+++ b/hypervisor/src/arch/riscv64/aia.rs
@@ -26,11 +26,9 @@ pub type Result<T> = result::Result<T, Error>;
 
 #[derive(Debug)]
 pub struct VaiaConfig {
-    pub vcpu_count: u64,
+    pub vcpu_count: u32,
     pub aplic_addr: u64,
-    pub aplic_size: u64,
     pub imsic_addr: u64,
-    pub imsic_size: u64,
     pub nr_irqs: u32,
 }
 
@@ -40,16 +38,16 @@ pub trait Vaia: Send + Sync {
     fn aplic_compatibility(&self) -> &str;
 
     /// Returns an array with APLIC device properties
-    fn aplic_properties(&self) -> [u64; 4];
+    fn aplic_properties(&self) -> [u32; 4];
 
     /// Returns the compatibility property of IMSIC
     fn imsic_compatibility(&self) -> &str;
 
     /// Returns an array with IMSIC device properties
-    fn imsic_properties(&self) -> [u64; 4];
+    fn imsic_properties(&self) -> [u32; 4];
 
     /// Returns the number of vCPUs this AIA handles
-    fn vcpu_count(&self) -> u64;
+    fn vcpu_count(&self) -> u32;
 
     /// Returns whether the AIA device is MSI compatible or not
     fn msi_compatible(&self) -> bool;


### PR DESCRIPTION
- hypervisor: Tune Vaia trait to work with fdt setup
- hypervisor: Set pc and a1 for all vcpu
- arch: Enable fdt_parser and vm-fdt for riscv64
- arch: Introduce RISC-V 64-bit layout
- arch: Introduce fdt setup for riscv64
- arch: Introduce RISC-V architecture
- ci: Enable riscv64 CI of arch module

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>