### PR TITLE
misc: Replace `map_or` on false with `is_some_and`

### DIFF
--- a/net_util/src/open_tap.rs
+++ b/net_util/src/open_tap.rs
@@ -75,9 +75,7 @@ pub fn open_tap(
     let mut ifname: String = String::new();
     let vnet_hdr_size = vnet_hdr_len() as i32;
     // Check if the given interface exists before we create it.
-    let tap_existed = if_name.map_or(false, |n| {
-        Path::new(&format!("/sys/class/net/{n}")).exists()
-    });
+    let tap_existed = if_name.is_some_and(|n| Path::new(&format!("/sys/class/net/{n}")).exists());
 
     // In case the tap interface already exists, check if the number of
     // queues is appropriate. The tap might not support multiqueue while

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -468,7 +468,7 @@ impl NetQueuePair {
         let rate_limit_reached = self
             .rx_rate_limiter
             .as_ref()
-            .map_or(false, |r| r.is_blocked());
+            .is_some_and(|r| r.is_blocked());
 
         // Stop listening on the `RX_TAP_EVENT` when:
         // 1) there is no available describes, or

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9401,7 +9401,7 @@ mod live_migration {
 
         // Check the source vm has been terminated successful (give it '3s' to settle)
         thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().map_or(false, |s| s.success()) {
+        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
             print_and_panic(
                 src_child,
                 dest_child,
@@ -9575,7 +9575,7 @@ mod live_migration {
 
         // Check the source vm has been terminated successful (give it '3s' to settle)
         thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().map_or(false, |s| s.success()) {
+        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
             print_and_panic(
                 src_child,
                 dest_child,
@@ -9793,7 +9793,7 @@ mod live_migration {
 
         // Check the source vm has been terminated successful (give it '3s' to settle)
         thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().map_or(false, |s| s.success()) {
+        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
             print_and_panic(
                 src_child,
                 dest_child,
@@ -10009,7 +10009,7 @@ mod live_migration {
 
         // Check the source vm has been terminated successful (give it '3s' to settle)
         thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().map_or(false, |s| s.success()) {
+        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
             print_and_panic(
                 src_child,
                 dest_child,
@@ -10119,7 +10119,7 @@ mod live_migration {
 
         // Check the source vm has been terminated successful (give it '3s' to settle)
         thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().map_or(false, |s| s.success()) {
+        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
             print_and_panic(
                 src_child,
                 dest_child,
@@ -10266,7 +10266,7 @@ mod live_migration {
 
         // Check the source vm has been terminated successful (give it '3s' to settle)
         thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().map_or(false, |s| s.success()) {
+        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
             print_and_panic(
                 src_child,
                 dest_child,

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -489,8 +489,7 @@ impl EpollHelperHandler for BlockEpollHandler {
                     EpollHelperError::HandleEvent(anyhow!("Failed to get queue event: {:?}", e))
                 })?;
 
-                let rate_limit_reached =
-                    self.rate_limiter.as_ref().map_or(false, |r| r.is_blocked());
+                let rate_limit_reached = self.rate_limiter.as_ref().is_some_and(|r| r.is_blocked());
 
                 // Process the queue only when the rate limit is not reached
                 if !rate_limit_reached {
@@ -509,8 +508,7 @@ impl EpollHelperHandler for BlockEpollHandler {
                     ))
                 })?;
 
-                let rate_limit_reached =
-                    self.rate_limiter.as_ref().map_or(false, |r| r.is_blocked());
+                let rate_limit_reached = self.rate_limiter.as_ref().is_some_and(|r| r.is_blocked());
 
                 // Process the queue only when the rate limit is not reached
                 if !rate_limit_reached {

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -201,7 +201,7 @@ impl NetEpollHandler {
             .net
             .rx_rate_limiter
             .as_ref()
-            .map_or(false, |r| r.is_blocked());
+            .is_some_and(|r| r.is_blocked());
 
         // Start to listen on RX_TAP_EVENT only when the rate limit is not reached
         if !self.net.rx_tap_listening && !rate_limit_reached {
@@ -238,7 +238,7 @@ impl NetEpollHandler {
             .net
             .tx_rate_limiter
             .as_ref()
-            .map_or(false, |r| r.is_blocked());
+            .is_some_and(|r| r.is_blocked());
 
         if !rate_limit_reached {
             self.process_tx()?;


### PR DESCRIPTION
Replace `map_or()` on false condition with `is_some_and` to provide
better readability, as suggestted by v1.84.0-beta.1 `cargo clippy`.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>