### PR TITLE
vm-allocator: Introduce RISC-V architecture

### DIFF
--- a/.github/workflows/preview-riscv64.yaml
+++ b/.github/workflows/preview-riscv64.yaml
@@ -14,6 +14,7 @@ jobs:
         module:
           - hypervisor
           - arch
+          - vm-allocator
 
     steps:
       - name: Code checkout

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -8,5 +8,5 @@ version = "0.1.0"
 libc = "0.2.167"
 vm-memory = { workspace = true }
 
-[target.'cfg(target_arch = "aarch64")'.dependencies]
+[target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]
 arch = { path = "../arch" }

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -4,6 +4,10 @@ edition = "2021"
 name = "vm-allocator"
 version = "0.1.0"
 
+[features]
+default = []
+kvm = ["arch/kvm"]
+
 [dependencies]
 libc = "0.2.167"
 vm-memory = { workspace = true }

--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -62,7 +62,7 @@ impl GsiAllocator {
         allocator
     }
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     /// New GSI allocator
     pub fn new() -> Self {
         GsiAllocator {
@@ -97,7 +97,7 @@ impl GsiAllocator {
         Ok(irq)
     }
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     /// Allocate an IRQ
     pub fn allocate_irq(&mut self) -> Result<u32> {
         let irq = self.next_irq;
@@ -106,7 +106,7 @@ impl GsiAllocator {
     }
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 impl Default for GsiAllocator {
     fn default() -> Self {
         GsiAllocator::new()

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -22,7 +22,7 @@ use crate::page_size::get_page_size;
 /// ```
 /// # #[cfg(target_arch = "x86_64")]
 /// # use vm_allocator::{GsiApic, SystemAllocator};
-/// # #[cfg(target_arch = "aarch64")]
+/// # #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 /// # use vm_allocator::SystemAllocator;
 /// # use vm_memory::{Address, GuestAddress, GuestUsize};
 ///   let mut allocator = SystemAllocator::new(
@@ -34,10 +34,14 @@ use crate::page_size::get_page_size;
 ///   assert_eq!(allocator.allocate_irq(), Some(5));
 ///   #[cfg(target_arch = "aarch64")]
 ///   assert_eq!(allocator.allocate_irq(), Some(32));
+///   #[cfg(target_arch = "riscv64")]
+///   assert_eq!(allocator.allocate_irq(), Some(0));
 ///   #[cfg(target_arch = "x86_64")]
 ///   assert_eq!(allocator.allocate_irq(), Some(6));
 ///   #[cfg(target_arch = "aarch64")]
 ///   assert_eq!(allocator.allocate_irq(), Some(33));
+///   #[cfg(target_arch = "riscv64")]
+///   assert_eq!(allocator.allocate_irq(), Some(1));
 ///   assert_eq!(allocator.allocate_platform_mmio_addresses(None, 0x1000, Some(0x1000)), Some(GuestAddress(0x1fff_f000)));
 ///
 /// ```
@@ -74,7 +78,7 @@ impl SystemAllocator {
             )?,
             #[cfg(target_arch = "x86_64")]
             gsi_allocator: GsiAllocator::new(apics),
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
             gsi_allocator: GsiAllocator::new(),
         })
     }


### PR DESCRIPTION
- vm-allocator: Enable arch module for riscv64
- vm-allocator: Enable build with kvm feature
- vm-allocator: Introduce RISC-V architecture
- ci: Enable riscv64 CI of vm-allocator module

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>