### PR TITLE
vmm: support PCI I/O regions on all architectures

### DIFF
--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -125,19 +125,16 @@ impl PciBus {
     pub fn register_mapping(
         &self,
         dev: Arc<dyn BusDeviceSync>,
-        #[cfg(target_arch = "x86_64")] io_bus: &Bus,
+        io_bus: &Bus,
         mmio_bus: &Bus,
         bars: Vec<PciBarConfiguration>,
     ) -> Result<()> {
         for bar in bars {
             match bar.region_type() {
                 PciBarRegionType::IoRegion => {
-                    #[cfg(target_arch = "x86_64")]
                     io_bus
                         .insert(dev.clone(), bar.addr(), bar.size())
                         .map_err(PciRootError::PioInsert)?;
-                    #[cfg(not(target_arch = "x86_64"))]
-                    error!("I/O region is not supported");
                 }
                 PciBarRegionType::Memory32BitRegion | PciBarRegionType::Memory64BitRegion => {
                     mmio_bus

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -713,11 +713,7 @@ impl VfioCommon {
 
             let bar_addr = match region_type {
                 PciBarRegionType::IoRegion => {
-                    #[cfg(not(target_arch = "x86_64"))]
-                    unimplemented!();
-
                     // The address needs to be 4 bytes aligned.
-                    #[cfg(target_arch = "x86_64")]
                     allocator
                         .lock()
                         .unwrap()
@@ -795,10 +791,7 @@ impl VfioCommon {
         for region in self.mmio_regions.iter() {
             match region.type_ {
                 PciBarRegionType::IoRegion => {
-                    #[cfg(target_arch = "x86_64")]
                     allocator.free_io_addresses(region.start, region.length);
-                    #[cfg(not(target_arch = "x86_64"))]
-                    error!("I/O region is not supported");
                 }
                 PciBarRegionType::Memory32BitRegion => {
                     mmio32_allocator.free(region.start, region.length);

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -26,8 +26,8 @@ use crate::page_size::get_page_size;
 /// # use vm_allocator::SystemAllocator;
 /// # use vm_memory::{Address, GuestAddress, GuestUsize};
 ///   let mut allocator = SystemAllocator::new(
-///           #[cfg(target_arch = "x86_64")] GuestAddress(0x1000),
-///           #[cfg(target_arch = "x86_64")] 0x10000,
+///           GuestAddress(0x1000),
+///           0x10000,
 ///           GuestAddress(0x10000000), 0x10000000,
 ///           #[cfg(target_arch = "x86_64")] vec![GsiApic::new(5, 19)]).unwrap();
 ///   #[cfg(target_arch = "x86_64")]
@@ -46,7 +46,6 @@ use crate::page_size::get_page_size;
 ///
 /// ```
 pub struct SystemAllocator {
-    #[cfg(target_arch = "x86_64")]
     io_address_space: AddressAllocator,
     platform_mmio_address_space: AddressAllocator,
     gsi_allocator: GsiAllocator,
@@ -63,14 +62,13 @@ impl SystemAllocator {
     /// * `apics` - (X86) Vector of APIC's.
     ///
     pub fn new(
-        #[cfg(target_arch = "x86_64")] io_base: GuestAddress,
-        #[cfg(target_arch = "x86_64")] io_size: GuestUsize,
+        io_base: GuestAddress,
+        io_size: GuestUsize,
         platform_mmio_base: GuestAddress,
         platform_mmio_size: GuestUsize,
         #[cfg(target_arch = "x86_64")] apics: Vec<GsiApic>,
     ) -> Option<Self> {
         Some(SystemAllocator {
-            #[cfg(target_arch = "x86_64")]
             io_address_space: AddressAllocator::new(io_base, io_size)?,
             platform_mmio_address_space: AddressAllocator::new(
                 platform_mmio_base,
@@ -93,7 +91,6 @@ impl SystemAllocator {
         self.gsi_allocator.allocate_gsi().ok()
     }
 
-    #[cfg(target_arch = "x86_64")]
     /// Reserves a section of `size` bytes of IO address space.
     pub fn allocate_io_addresses(
         &mut self,
@@ -119,7 +116,6 @@ impl SystemAllocator {
         )
     }
 
-    #[cfg(target_arch = "x86_64")]
     /// Free an IO address range.
     /// We can only free a range if it matches exactly an already allocated range.
     pub fn free_io_addresses(&mut self, address: GuestAddress, size: GuestUsize) {

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1159,14 +1159,8 @@ impl MemoryManager {
 
         let allocator = Arc::new(Mutex::new(
             SystemAllocator::new(
-                #[cfg(target_arch = "x86_64")]
-                {
-                    GuestAddress(0)
-                },
-                #[cfg(target_arch = "x86_64")]
-                {
-                    1 << 16
-                },
+                GuestAddress(0),
+                1 << 16,
                 start_of_platform_device_area,
                 PLATFORM_DEVICE_AREA_SIZE,
                 #[cfg(target_arch = "x86_64")]

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1157,7 +1157,6 @@ impl MemoryManager {
 
         let guest_memory = GuestMemoryAtomic::new(guest_memory);
 
-        // Both MMIO and PIO address spaces start at address 0.
         let allocator = Arc::new(Mutex::new(
             SystemAllocator::new(
                 #[cfg(target_arch = "x86_64")]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -531,7 +531,6 @@ impl Vm {
         let stop_on_boot = false;
 
         let memory = memory_manager.lock().unwrap().guest_memory();
-        #[cfg(target_arch = "x86_64")]
         let io_bus = Arc::new(Bus::new());
         let mmio_bus = Arc::new(Bus::new());
 
@@ -622,7 +621,6 @@ impl Vm {
         let dynamic = true;
 
         let device_manager = DeviceManager::new(
-            #[cfg(target_arch = "x86_64")]
             io_bus,
             mmio_bus,
             vm.clone(),


### PR DESCRIPTION
While non-Intel CPU architectures don't have a special concept of IO address space, support for PCI I/O regions is still needed to be able to handle PCI devices that use them.

With this change, I'm able to pass through an e1000e device from QEMU to a cloud-hypervisor VM on aarch64 and use it in the cloud-hypervisor guest. Previously, it would hit the `unimplemented!()`.

---

I'd appreciate some checking here, as while this does fix a problem, I've been learning about PCI as I've gone.  In particular:

- Is starting at address 0 in the MMIO space okay on other architectures?
- When I try to pass through a virtio-net device instead of e1000e, the guest kernel ends up stuck in rtnl_lock.  I'm not sure what's going wrong there (or if it's a Cloud Hypervisor problem, or a problem with something else).