### PR TITLE
build: Update seccompiler to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,8 +1853,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "seccompiler"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345a3e4dddf721a478089d4697b83c6c0a8f5bf16086f6c13397e4534eb6e2e5"
+source = "git+https://github.com/TimePrinciple/seccompiler?branch=update-to-6.12#5aae7bfc496bd39c92dc51599c1863f959e7d30d"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ kvm-ioctls = "0.19.1"
 linux-loader = "0.13.0"
 mshv-bindings = "0.3.2"
 mshv-ioctls = "0.3.2"
-seccompiler = "0.4.0"
+seccompiler = { git = "https://github.com/TimePrinciple/seccompiler", branch = "update-to-6.12" }
 vfio-bindings = { git = "https://github.com/rust-vmm/vfio", branch = "main" }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
 vfio_user = { git = "https://github.com/rust-vmm/vfio-user", branch = "main" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,7 +26,7 @@ micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch
 mshv-bindings = "0.3.2"
 net_util = { path = "../net_util" }
 once_cell = "1.19.0"
-seccompiler = "0.4.0"
+seccompiler = { git = "https://github.com/TimePrinciple/seccompiler", branch = "update-to-6.12" }
 virtio-devices = { path = "../virtio-devices" }
 virtio-queue = "0.14.0"
 vm-device = { path = "../vm-device" }


### PR DESCRIPTION
Update `secompiler` to capture RISC-V architecture support and v6.12 kernel support (since `syscall_tables` were generated from v6.12 kernel source).