### PR TITLE
block: fix short read and short write in AsyncAdaptor

### DIFF
--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -668,9 +668,11 @@ where
             file.seek(SeekFrom::Start(offset as u64))
                 .map_err(AsyncIoError::ReadVectored)?;
 
-            // Read vectored
-            file.read_vectored(slices.as_mut_slice())
-                .map_err(AsyncIoError::ReadVectored)?
+            let mut r = 0;
+            for b in slices.iter_mut() {
+                r += file.read(b).map_err(AsyncIoError::ReadVectored)?;
+            }
+            r
         };
 
         completion_list.push_back((user_data, result as i32));
@@ -703,9 +705,11 @@ where
             file.seek(SeekFrom::Start(offset as u64))
                 .map_err(AsyncIoError::WriteVectored)?;
 
-            // Write vectored
-            file.write_vectored(slices.as_slice())
-                .map_err(AsyncIoError::WriteVectored)?
+            let mut r = 0;
+            for b in slices.iter() {
+                r += file.write(b).map_err(AsyncIoError::WriteVectored)?;
+            }
+            r
         };
 
         completion_list.push_back((user_data, result as i32));


### PR DESCRIPTION
The original code relied on the default `read_vectored` or `write_vectored` implementations from the standard library.

The default implementation of those functions only uses the first non-empty buffer. That's not correct when there are more than one buffers.

Fixes: #6876

This should be backported.