### PR TITLE
pci: Adding the pci device address for map errors.

### DIFF
--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -16,7 +16,7 @@ mod msix;
 mod vfio;
 mod vfio_user;
 
-use std::fmt::{self, Display};
+use std::fmt::{self, Debug, Display};
 use std::num::ParseIntError;
 use std::str::FromStr;
 
@@ -149,6 +149,19 @@ impl From<PciBdf> for u16 {
 impl From<&PciBdf> for u16 {
     fn from(bdf: &PciBdf) -> Self {
         (bdf.0 & 0xffff) as u16
+    }
+}
+
+impl Debug for PciBdf {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:04x}:{:02x}:{:02x}.{:01x}",
+            self.segment(),
+            self.bus(),
+            self.device(),
+            self.function()
+        )
     }
 }
 

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -48,10 +48,10 @@ pub(crate) const VFIO_COMMON_ID: &str = "vfio_common";
 pub enum VfioPciError {
     #[error("Failed to create user memory region: {0}")]
     CreateUserMemoryRegion(#[source] HypervisorVmError),
-    #[error("Failed to DMA map: {0}")]
-    DmaMap(#[source] vfio_ioctls::VfioError),
-    #[error("Failed to DMA unmap: {0}")]
-    DmaUnmap(#[source] vfio_ioctls::VfioError),
+    #[error("Failed to DMA map: {0} for device {1}")]
+    DmaMap(#[source] vfio_ioctls::VfioError, PciBdf),
+    #[error("Failed to DMA unmap: {0} for device {1}")]
+    DmaUnmap(#[source] vfio_ioctls::VfioError, PciBdf),
     #[error("Failed to enable INTx: {0}")]
     EnableIntx(#[source] VfioError),
     #[error("Failed to enable MSI: {0}")]
@@ -1410,6 +1410,7 @@ pub struct VfioPciDevice {
     common: VfioCommon,
     iommu_attached: bool,
     memory_slot_allocator: MemorySlotAllocator,
+    bdf: PciBdf,
 }
 
 impl VfioPciDevice {
@@ -1451,6 +1452,7 @@ impl VfioPciDevice {
             common,
             iommu_attached,
             memory_slot_allocator,
+            bdf,
         };
 
         Ok(vfio_pci_device)
@@ -1656,7 +1658,7 @@ impl VfioPciDevice {
                                 user_memory_region.size,
                                 user_memory_region.host_addr,
                             )
-                            .map_err(VfioPciError::DmaMap)?;
+                            .map_err(|e| VfioPciError::DmaMap(e, self.bdf))?;
                     }
                 }
             }
@@ -1717,7 +1719,7 @@ impl VfioPciDevice {
         if !self.iommu_attached {
             self.container
                 .vfio_dma_map(iova, size, user_addr)
-                .map_err(VfioPciError::DmaMap)?;
+                .map_err(|e| VfioPciError::DmaMap(e, self.bdf))?;
         }
 
         Ok(())
@@ -1727,7 +1729,7 @@ impl VfioPciDevice {
         if !self.iommu_attached {
             self.container
                 .vfio_dma_unmap(iova, size)
-                .map_err(VfioPciError::DmaUnmap)?;
+                .map_err(|e| VfioPciError::DmaUnmap(e, self.bdf))?;
         }
 
         Ok(())


### PR DESCRIPTION
This PR adds the PCI device address information to the error message where the mapping and unmapping of the mmio_regions fails. The identified issues stemmed from GPUs sometime losing their PCI state occasionally. This patch helps identify the device that is failing to allow more targeted recovery for the device, as opposed to having to reboot the entire host. The pci device id has to be propagated back in an error message to allow the recovery process, and could not be just handled by the additional error logging here.

I could not find an easy way to find the pci device bdf id. This patch addresses that. If there is a better way to find this information, then please let me know.