### PR TITLE
Fix bugs in VHDX code

### DIFF
--- a/block/src/vhdx/mod.rs
+++ b/block/src/vhdx/mod.rs
@@ -102,7 +102,7 @@ impl Read for Vhdx {
         let sector_count = (buf.len() as u64).div_ceil(self.disk_spec.logical_sector_size as u64);
         let sector_index = self.current_offset / self.disk_spec.logical_sector_size as u64;
 
-        vhdx_io::read(
+        let result = vhdx_io::read(
             &mut self.file,
             buf,
             &self.disk_spec,
@@ -117,7 +117,11 @@ impl Read for Vhdx {
                     "Failed reading {sector_count} sectors from VHDx at index {sector_index}: {e}"
                 ),
             )
-        })
+        })?;
+
+        self.current_offset += result as u64;
+
+        Ok(result)
     }
 }
 
@@ -142,7 +146,7 @@ impl Write for Vhdx {
             })?;
         }
 
-        vhdx_io::write(
+        let result = vhdx_io::write(
             &mut self.file,
             buf,
             &mut self.disk_spec,
@@ -158,7 +162,11 @@ impl Write for Vhdx {
                     "Failed writing {sector_count} sectors on VHDx at index {sector_index}: {e}"
                 ),
             )
-        })
+        })?;
+
+        self.current_offset += result as u64;
+
+        Ok(result)
     }
 }
 

--- a/block/src/vhdx/vhdx_header.rs
+++ b/block/src/vhdx/vhdx_header.rs
@@ -457,12 +457,10 @@ impl VhdxHeader {
 /// corresponding field is made zero. After the calculation, the existing checksum
 /// is put back to the buffer.
 pub fn calculate_checksum(buffer: &mut [u8], csum_offset: usize) -> Result<u32> {
-    // Read the checksum into a mutable slice
-    let csum_buf = &mut buffer[csum_offset..csum_offset + 4];
-    // Convert the checksum chunk into a u32 integer
-    let orig_csum = LittleEndian::read_u32(csum_buf);
+    // Read the original checksum from the buffer
+    let orig_csum = LittleEndian::read_u32(&buffer[csum_offset..csum_offset + 4]);
     // Zero the checksum in the buffer
-    LittleEndian::write_u32(csum_buf, 0);
+    LittleEndian::write_u32(&mut buffer[csum_offset..csum_offset + 4], 0);
     // Calculate the checksum on the resulting buffer
     let mut crc = crc_any::CRC::crc32c();
     crc.digest(&buffer);

--- a/block/src/vhdx/vhdx_header.rs
+++ b/block/src/vhdx/vhdx_header.rs
@@ -142,7 +142,7 @@ impl Header {
             return Err(VhdxHeaderError::InvalidHeaderSign);
         }
 
-        let new_checksum = calculate_checksum(&mut buffer, size_of::<u32>())?;
+        let new_checksum = calculate_checksum(&mut buffer, size_of::<u32>());
         if header.checksum != new_checksum {
             return Err(VhdxHeaderError::InvalidChecksum(String::from("Header")));
         }
@@ -231,7 +231,7 @@ impl RegionTableHeader {
             return Err(VhdxHeaderError::InvalidRegionSign);
         }
 
-        let new_checksum = calculate_checksum(&mut buffer, size_of::<u32>())?;
+        let new_checksum = calculate_checksum(&mut buffer, size_of::<u32>());
         if region_table_header.checksum != new_checksum {
             return Err(VhdxHeaderError::InvalidChecksum(String::from("Region")));
         }
@@ -456,7 +456,7 @@ impl VhdxHeader {
 /// Therefore, before calculating, the existing checksum is retrieved and the
 /// corresponding field is made zero. After the calculation, the existing checksum
 /// is put back to the buffer.
-pub fn calculate_checksum(buffer: &mut [u8], csum_offset: usize) -> Result<u32> {
+fn calculate_checksum(buffer: &mut [u8], csum_offset: usize) -> u32 {
     // Read the original checksum from the buffer
     let orig_csum = LittleEndian::read_u32(&buffer[csum_offset..csum_offset + 4]);
     // Zero the checksum in the buffer
@@ -469,5 +469,5 @@ pub fn calculate_checksum(buffer: &mut [u8], csum_offset: usize) -> Result<u32> 
     // Put back the original checksum in the buffer
     LittleEndian::write_u32(&mut buffer[csum_offset..csum_offset + 4], orig_csum);
 
-    Ok(new_csum)
+    new_csum
 }

--- a/block/src/vhdx/vhdx_header.rs
+++ b/block/src/vhdx/vhdx_header.rs
@@ -192,9 +192,7 @@ impl Header {
         };
 
         new_header.get_header_as_buffer(&mut buffer);
-        let mut crc = crc_any::CRC::crc32c();
-        crc.digest(&buffer);
-        new_header.checksum = crc.get_crc() as u32;
+        new_header.checksum = calculate_checksum(&mut buffer, size_of::<u32>());
         new_header.get_header_as_buffer(&mut buffer);
 
         f.seek(SeekFrom::Start(start))

--- a/block/src/vhdx/vhdx_header.rs
+++ b/block/src/vhdx/vhdx_header.rs
@@ -160,7 +160,7 @@ impl Header {
     }
 
     /// Creates and returns new updated header from the provided current header
-    pub fn update_header(
+    fn update_header(
         f: &mut File,
         current_header: &Header,
         change_data_guid: bool,

--- a/block/src/vhdx/vhdx_header.rs
+++ b/block/src/vhdx/vhdx_header.rs
@@ -151,7 +151,7 @@ impl Header {
     }
 
     /// Converts the header structure into a buffer
-    fn get_header_as_buffer(&self, buffer: &mut [u8; HEADER_SIZE as usize]) {
+    fn write_to_buffer(&self, buffer: &mut [u8; HEADER_SIZE as usize]) {
         // SAFETY: self is a valid header.
         let reference = unsafe {
             std::slice::from_raw_parts(self as *const Header as *const u8, HEADER_SIZE as usize)
@@ -191,9 +191,9 @@ impl Header {
             log_offset: current_header.log_offset,
         };
 
-        new_header.get_header_as_buffer(&mut buffer);
+        new_header.write_to_buffer(&mut buffer);
         new_header.checksum = calculate_checksum(&mut buffer, size_of::<u32>());
-        new_header.get_header_as_buffer(&mut buffer);
+        new_header.write_to_buffer(&mut buffer);
 
         f.seek(SeekFrom::Start(start))
             .map_err(VhdxHeaderError::SeekHeader)?;

--- a/block/src/vhdx/vhdx_header.rs
+++ b/block/src/vhdx/vhdx_header.rs
@@ -371,22 +371,10 @@ pub struct VhdxHeader {
 impl VhdxHeader {
     /// Creates a VhdxHeader from a reference to a file
     pub fn new(f: &mut File) -> Result<VhdxHeader> {
-        let _file_type_identifier: FileTypeIdentifier = FileTypeIdentifier::new(f)?;
-        let header_1 = Header::new(f, HEADER_1_START);
-        let header_2 = Header::new(f, HEADER_2_START);
-
-        let mut file_write_guid: u128 = 0;
-        let metadata = f.metadata().map_err(VhdxHeaderError::ReadMetadata)?;
-        if !metadata.permissions().readonly() {
-            file_write_guid = Uuid::new_v4().as_u128();
-        }
-
-        let (header_1, header_2) =
-            VhdxHeader::update_headers(f, header_1, header_2, file_write_guid)?;
         Ok(VhdxHeader {
-            _file_type_identifier,
-            header_1,
-            header_2,
+            _file_type_identifier: FileTypeIdentifier::new(f)?,
+            header_1: Header::new(f, HEADER_1_START)?,
+            header_2: Header::new(f, HEADER_2_START)?,
             region_table_1: RegionTableHeader::new(f, REGION_TABLE_1_START)?,
             _region_table_2: RegionTableHeader::new(f, REGION_TABLE_2_START)?,
         })


### PR DESCRIPTION
There are several issues I discovered while trying to debug the SEG_MAX feature on VHDX.

1. Cloud Hypervisor cannot open a VHDX image in read-only mode.
2. Cloud Hypervisor corrupts the VHDX image after it is used once.
3. VHDX code cannot handle multiple segments.

All are fixed in this series.

I used QEMU as a reference. The image still works with QEMU after it's used by CH.