### PR TITLE
fuzz: explicitly keep or reject fuzzer corpus

### DIFF
--- a/fuzz/fuzz_targets/block.rs
+++ b/fuzz/fuzz_targets/block.rs
@@ -17,7 +17,7 @@ use std::{ffi, io};
 
 use block::async_io::DiskFile;
 use block::raw_sync::RawFileDiskSync;
-use libfuzzer_sys::fuzz_target;
+use libfuzzer_sys::{fuzz_target, Corpus};
 use seccompiler::SeccompAction;
 use virtio_devices::{Block, VirtioDevice, VirtioInterrupt, VirtioInterruptType};
 use virtio_queue::{Queue, QueueT};
@@ -40,9 +40,9 @@ const AVAIL_RING_SIZE: u64 = 6_u64 + 2 * QUEUE_SIZE as u64;
 // Guest physical address for used ring (requires to 4-bytes aligned)
 const USED_RING_ADDR: u64 = (AVAIL_RING_ADDR + AVAIL_RING_SIZE + 3) & !3_u64;
 
-fuzz_target!(|bytes| {
+fuzz_target!(|bytes: &[u8]| -> Corpus {
     if bytes.len() < QUEUE_DATA_SIZE || bytes.len() > (QUEUE_DATA_SIZE + MEM_SIZE) {
-        return;
+        return Corpus::Reject;
     }
 
     let queue_data = &bytes[..QUEUE_DATA_SIZE];
@@ -76,7 +76,7 @@ fuzz_target!(|bytes| {
     // Setup the guest memory with the input bytes
     let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), MEM_SIZE)]).unwrap();
     if mem.write_slice(mem_bytes, GuestAddress(0 as u64)).is_err() {
-        return;
+        return Corpus::Reject;
     }
     let guest_memory = GuestMemoryAtomic::new(mem);
 
@@ -96,6 +96,8 @@ fuzz_target!(|bytes| {
 
     // Wait for the events to finish and block device worker thread to return
     block.wait_for_epoll_threads();
+
+    Corpus::Keep
 });
 
 fn memfd_create(name: &ffi::CStr, flags: u32) -> Result<RawFd, io::Error> {

--- a/fuzz/fuzz_targets/cmos.rs
+++ b/fuzz/fuzz_targets/cmos.rs
@@ -5,14 +5,14 @@
 #![no_main]
 use devices::legacy::Cmos;
 use libc::EFD_NONBLOCK;
-use libfuzzer_sys::fuzz_target;
+use libfuzzer_sys::{fuzz_target, Corpus};
 use vm_device::BusDevice;
 use vmm_sys_util::eventfd::EventFd;
 
-fuzz_target!(|bytes| {
+fuzz_target!(|bytes: &[u8]| -> Corpus {
     // Need at least 16 bytes for the test
     if bytes.len() < 16 {
-        return;
+        return Corpus::Reject;
     }
 
     let mut below_4g = [0u8; 8];
@@ -46,4 +46,6 @@ fuzz_target!(|bytes| {
             cmos.write(0, offset, &data);
         }
     }
+
+    Corpus::Keep
 });

--- a/fuzz/fuzz_targets/linux_loader_cmdline.rs
+++ b/fuzz/fuzz_targets/linux_loader_cmdline.rs
@@ -8,7 +8,7 @@
 
 #![no_main]
 
-use libfuzzer_sys::fuzz_target;
+use libfuzzer_sys::{fuzz_target, Corpus};
 use vm_memory::bitmap::AtomicBitmap;
 use vm_memory::GuestAddress;
 
@@ -18,7 +18,7 @@ const MEM_SIZE: usize = 256 * 1024 * 1024;
 // From 'arch::x86_64::layout::CMDLINE_START'
 const CMDLINE_START: GuestAddress = GuestAddress(0x20000);
 
-fuzz_target!(|bytes| {
+fuzz_target!(|bytes: &[u8]| -> Corpus {
     let payload_config = vmm::vm_config::PayloadConfig {
         firmware: None,
         kernel: None,
@@ -29,9 +29,11 @@ fuzz_target!(|bytes| {
     };
     let kernel_cmdline = match vmm::vm::Vm::generate_cmdline(&payload_config) {
         Ok(cmdline) => cmdline,
-        _ => return,
+        _ => return Corpus::Reject,
     };
     let guest_memory = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), MEM_SIZE)]).unwrap();
 
     linux_loader::loader::load_cmdline(&guest_memory, CMDLINE_START, &kernel_cmdline).ok();
+
+    Corpus::Keep
 });

--- a/fuzz/fuzz_targets/mem.rs
+++ b/fuzz/fuzz_targets/mem.rs
@@ -7,7 +7,7 @@
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::sync::{Arc, Mutex};
 
-use libfuzzer_sys::fuzz_target;
+use libfuzzer_sys::{fuzz_target, Corpus};
 use seccompiler::SeccompAction;
 use virtio_devices::{BlocksState, Mem, VirtioDevice, VirtioInterrupt, VirtioInterruptType};
 use virtio_queue::{Queue, QueueT};
@@ -57,11 +57,11 @@ const USED_RING_ADDR: u64 = align!(AVAIL_RING_ADDR + AVAIL_RING_SIZE, USED_RING_
 // Virtio-queue size in bytes
 const QUEUE_BYTES_SIZE: usize = (USED_RING_ADDR + USED_RING_SIZE - DESC_TABLE_ADDR) as usize;
 
-fuzz_target!(|bytes| {
+fuzz_target!(|bytes: &[u8]| -> Corpus {
     if bytes.len() < VIRTIO_MEM_DATA_SIZE + QUEUE_DATA_SIZE + QUEUE_BYTES_SIZE
         || bytes.len() > (VIRTIO_MEM_DATA_SIZE + QUEUE_DATA_SIZE + QUEUE_BYTES_SIZE + MEM_SIZE)
     {
-        return;
+        return Corpus::Reject;
     }
 
     let virtio_mem_data = &bytes[..VIRTIO_MEM_DATA_SIZE];
@@ -86,7 +86,7 @@ fuzz_target!(|bytes| {
         .write_slice(queue_bytes, GuestAddress(DESC_TABLE_ADDR))
         .is_err()
     {
-        return;
+        return Corpus::Reject;
     }
     // Add the memory region for the virtio-mem device
     let mem = mem.insert_region(virtio_mem_region).unwrap();
@@ -94,7 +94,7 @@ fuzz_target!(|bytes| {
         .write_slice(mem_bytes, GuestAddress(VIRTIO_MEM_REGION_ADDRESS))
         .is_err()
     {
-        return;
+        return Corpus::Reject;
     }
     let guest_memory = GuestMemoryAtomic::new(mem);
 
@@ -114,6 +114,8 @@ fuzz_target!(|bytes| {
 
     // Wait for the events to finish and virtio-mem device worker thread to return
     virtio_mem.wait_for_epoll_threads();
+
+    return Corpus::Keep;
 });
 
 pub struct NoopVirtioInterrupt {}

--- a/fuzz/fuzz_targets/qcow.rs
+++ b/fuzz/fuzz_targets/qcow.rs
@@ -12,14 +12,14 @@ use std::mem::size_of;
 use std::os::unix::io::{FromRawFd, RawFd};
 
 use block::qcow::{QcowFile, RawFile};
-use libfuzzer_sys::fuzz_target;
+use libfuzzer_sys::{fuzz_target, Corpus};
 
 // Take the first 64 bits of data as an address and the next 64 bits as data to
 // store there. The rest of the data is used as a qcow image.
-fuzz_target!(|bytes| {
+fuzz_target!(|bytes: &[u8]| -> Corpus {
     if bytes.len() < 16 {
         // Need an address and data, each are 8 bytes.
-        return;
+        return Corpus::Reject;
     }
     let mut disk_image = Cursor::new(bytes);
     let addr = read_u64(&mut disk_image);
@@ -33,6 +33,8 @@ fuzz_target!(|bytes| {
             let _ = qcow.write_all(&value.to_le_bytes());
         }
     }
+
+    Corpus::Keep
 });
 
 fn read_u64<T: Read>(readable: &mut T) -> u64 {

--- a/fuzz/fuzz_targets/rng.rs
+++ b/fuzz/fuzz_targets/rng.rs
@@ -7,7 +7,7 @@
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::sync::Arc;
 
-use libfuzzer_sys::fuzz_target;
+use libfuzzer_sys::{fuzz_target, Corpus};
 use seccompiler::SeccompAction;
 use virtio_devices::{VirtioDevice, VirtioInterrupt, VirtioInterruptType};
 use virtio_queue::{Queue, QueueT};
@@ -52,11 +52,11 @@ const USED_RING_ADDR: u64 = align!(AVAIL_RING_ADDR + AVAIL_RING_SIZE, USED_RING_
 // Virtio-queue size in bytes
 const QUEUE_BYTES_SIZE: usize = (USED_RING_ADDR + USED_RING_SIZE - DESC_TABLE_ADDR) as usize;
 
-fuzz_target!(|bytes| {
+fuzz_target!(|bytes: &[u8]| -> Corpus {
     if bytes.len() < (QUEUE_DATA_SIZE + QUEUE_BYTES_SIZE)
         || bytes.len() > (QUEUE_DATA_SIZE + QUEUE_BYTES_SIZE + MEM_SIZE)
     {
-        return;
+        return Corpus::Reject;
     }
 
     let mut rng = virtio_devices::Rng::new(
@@ -86,10 +86,10 @@ fuzz_target!(|bytes| {
         .write_slice(queue_bytes, GuestAddress(DESC_TABLE_ADDR))
         .is_err()
     {
-        return;
+        return Corpus::Reject;
     }
     if mem.write_slice(mem_bytes, GuestAddress(0 as u64)).is_err() {
-        return;
+        return Corpus::Reject;
     }
     let guest_memory = GuestMemoryAtomic::new(mem);
 
@@ -108,6 +108,8 @@ fuzz_target!(|bytes| {
 
     // Wait for the events to finish and rng device worker thread to return
     rng.wait_for_epoll_threads();
+
+    Corpus::Keep
 });
 
 pub struct NoopVirtioInterrupt {}

--- a/fuzz/fuzz_targets/watchdog.rs
+++ b/fuzz/fuzz_targets/watchdog.rs
@@ -7,7 +7,7 @@
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::sync::Arc;
 
-use libfuzzer_sys::fuzz_target;
+use libfuzzer_sys::{fuzz_target, Corpus};
 use seccompiler::SeccompAction;
 use virtio_devices::{VirtioDevice, VirtioInterrupt, VirtioInterruptType};
 use virtio_queue::{Queue, QueueT};
@@ -30,9 +30,9 @@ const AVAIL_RING_SIZE: u64 = 6_u64 + 2 * QUEUE_SIZE as u64;
 // Guest physical address for used ring (requires to 4-bytes aligned)
 const USED_RING_ADDR: u64 = (AVAIL_RING_ADDR + AVAIL_RING_SIZE + 3) & !3_u64;
 
-fuzz_target!(|bytes| {
+fuzz_target!(|bytes: &[u8]| -> Corpus {
     if bytes.len() < QUEUE_DATA_SIZE || bytes.len() > (QUEUE_DATA_SIZE + MEM_SIZE) {
-        return;
+        return Corpus::Reject;
     }
 
     let mut watchdog = virtio_devices::Watchdog::new(
@@ -53,7 +53,7 @@ fuzz_target!(|bytes| {
     // Setup the guest memory with the input bytes
     let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), MEM_SIZE)]).unwrap();
     if mem.write_slice(mem_bytes, GuestAddress(0 as u64)).is_err() {
-        return;
+        return Corpus::Reject;
     }
     let guest_memory = GuestMemoryAtomic::new(mem);
 
@@ -73,6 +73,8 @@ fuzz_target!(|bytes| {
 
     // Wait for the events to finish and watchdog device worker thread to return
     watchdog.wait_for_epoll_threads();
+
+    Corpus::Keep
 });
 
 pub struct NoopVirtioInterrupt {}


### PR DESCRIPTION
When the main fuzzer function returns (), it is equivalent to returning Corpus::Keep.

In some of the return paths, we want to reject the input so that the libfuzzer won't spend more time mutating them.

The should make fuzzing more efficient. No functional change intended.