### PR TITLE
Properly account for bytes read and written in VHDX IO code

### DIFF
--- a/block/src/vhdx/vhdx_io.rs
+++ b/block/src/vhdx/vhdx_io.rs
@@ -133,7 +133,7 @@ pub fn read(
             };
             sector_count -= sector.free_sectors;
             sector_index += sector.free_sectors;
-            read_count = sector.free_bytes as usize;
+            read_count += sector.free_bytes as usize;
         };
     }
     Ok(read_count)
@@ -219,7 +219,7 @@ pub fn write(
             };
             sector_count -= sector.free_sectors;
             sector_index += sector.free_sectors;
-            write_count = sector.free_bytes as usize;
+            write_count += sector.free_bytes as usize;
         };
     }
     Ok(write_count)


### PR DESCRIPTION
This potentially fixes #6897. I'm running tests overnight to see if I still get the occasional failures.