### PR TITLE
virtio-devices: iommu: allow limiting maximum address width in bits

### DIFF
--- a/fuzz/fuzz_targets/iommu.rs
+++ b/fuzz/fuzz_targets/iommu.rs
@@ -66,6 +66,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
         SeccompAction::Allow,
         EventFd::new(EFD_NONBLOCK).unwrap(),
         ((MEM_SIZE - IOVA_SPACE_SIZE) as u64, (MEM_SIZE - 1) as u64),
+        64,
         None,
     )
     .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ fn create_app(default_vcpus: String, default_memory: String, default_rng: String
         .arg(
             Arg::new("platform")
                 .long("platform")
-                .help("num_pci_segments=<num_pci_segments>,iommu_segments=<list_of_segments>,serial_number=<dmi_device_serial_number>,uuid=<dmi_device_uuid>,oem_strings=<list_of_strings>")
+                .help("num_pci_segments=<num_pci_segments>,iommu_segments=<list_of_segments>,iommu_address_width=<bits>,serial_number=<dmi_device_serial_number>,uuid=<dmi_device_uuid>,oem_strings=<list_of_strings>")
                 .num_args(1)
                 .group("vm-config"),
         )

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -718,6 +718,9 @@ components:
           items:
             type: integer
             format: int16
+        iommu_address_width:
+          type: integer
+          format: uint8
         serial_number:
           type: string
         uuid:

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -88,12 +88,19 @@ pub fn default_platformconfig_num_pci_segments() -> u16 {
     DEFAULT_NUM_PCI_SEGMENTS
 }
 
+pub const DEFAULT_IOMMU_ADDRESS_WIDTH_BITS: u8 = 64;
+pub fn default_platformconfig_iommu_address_width_bits() -> u8 {
+    DEFAULT_IOMMU_ADDRESS_WIDTH_BITS
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct PlatformConfig {
     #[serde(default = "default_platformconfig_num_pci_segments")]
     pub num_pci_segments: u16,
     #[serde(default)]
     pub iommu_segments: Option<Vec<u16>>,
+    #[serde(default = "default_platformconfig_iommu_address_width_bits")]
+    pub iommu_address_width_bits: u8,
     #[serde(default)]
     pub serial_number: Option<String>,
     #[serde(default)]


### PR DESCRIPTION
Currently, Cloud Hypervisor does not set a VIRTIO_IOMMU_F_INPUT_RANGE feature bit for the VirtIO IOMMU device, which, [according to spec](https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html#x1-5420006), means that the guest may use the whole 64-bit address space is for IOMMU purposes:

>If the feature is not offered, virtual mappings span over the whole 64-bit address space (start = 0, end = 0xffffffff ffffffff)

As far as I am aware, there are currently no host platforms on the market capable of addressing the whole 64-bit address space.

For example, I am currently working with a host platform that reports 39-bit address space for IOMMU purposes:

```
DMAR: Host address width 39
```

When running a VFIO pass-through guest on such a platform, NVIDIA driver in guest gets DMA mapping failures when working with large data, and this results in Cloud Hypervisor exiting with the following error:

```
cloud-hypervisor: 1501.220535s: <__iommu> ERROR:virtio-devices/src/thread_helper.rs:53 -- Error running worker: HandleEvent(Failed to process request queue : ExternalMapping(Custom { kind: Other, error: "failed to map memory for VFIO container, iova 0x7fff00000000, gpa 0x24ce25000, size 0x1000: IommuDmaMap(Error(22))" }))
```

Passing `--platform iommu_address_width=39` to Cloud Hypervisor built with this change fixes this.