### PR TITLE
Use repr(C, packed) where necessary

### DIFF
--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -35,7 +35,7 @@ const TABLE_FOOTER_GUID: &str = "96b582de-1fb2-45f7-baea-a366c55a082d";
 const TDVF_METADATA_OFFSET_GUID: &str = "e47a6535-984a-4798-865e-4685a7bf8ec2";
 
 // TDVF_DESCRIPTOR
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default)]
 pub struct TdvfDescriptor {
     signature: [u8; 4],
@@ -45,7 +45,7 @@ pub struct TdvfDescriptor {
 }
 
 // TDVF_SECTION
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Default, Debug)]
 pub struct TdvfSection {
     pub data_offset: u32,
@@ -209,7 +209,7 @@ enum HobType {
     EndOfHobList = 0xffff,
 }
 
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Copy, Clone, Default, Debug)]
 struct HobHeader {
     r#type: HobType,
@@ -217,7 +217,7 @@ struct HobHeader {
     reserved: u32,
 }
 
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Copy, Clone, Default, Debug)]
 struct HobHandoffInfoTable {
     header: HobHeader,
@@ -230,7 +230,7 @@ struct HobHandoffInfoTable {
     efi_end_of_hob_list: u64,
 }
 
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Copy, Clone, Default, Debug)]
 struct EfiGuid {
     data1: u32,
@@ -239,7 +239,7 @@ struct EfiGuid {
     data4: [u8; 8],
 }
 
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Copy, Clone, Default, Debug)]
 struct HobResourceDescriptor {
     header: HobHeader,
@@ -250,7 +250,7 @@ struct HobResourceDescriptor {
     resource_length: u64,
 }
 
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Copy, Clone, Default, Debug)]
 struct HobGuidType {
     header: HobHeader,
@@ -266,14 +266,14 @@ pub enum PayloadImageType {
     RawVmLinux,
 }
 
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Copy, Clone, Default, Debug)]
 pub struct PayloadInfo {
     pub image_type: PayloadImageType,
     pub entry_point: u64,
 }
 
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Copy, Clone, Default, Debug)]
 struct TdPayload {
     guid_type: HobGuidType,

--- a/block/src/vhdx/vhdx_header.rs
+++ b/block/src/vhdx/vhdx_header.rs
@@ -110,7 +110,7 @@ impl FileTypeIdentifier {
     }
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Debug)]
 pub struct Header {
     pub signature: u32,
@@ -203,7 +203,7 @@ impl Header {
     }
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Debug)]
 struct RegionTableHeader {
     pub signature: u32,
@@ -328,7 +328,7 @@ impl RegionInfo {
     }
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Debug)]
 pub struct RegionTableEntry {
     pub guid: Uuid,

--- a/block/src/vhdx/vhdx_metadata.rs
+++ b/block/src/vhdx/vhdx_metadata.rs
@@ -267,7 +267,7 @@ impl DiskSpec {
     }
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, Debug, Clone, Copy)]
 struct MetadataTableHeader {
     signature: u64,
@@ -298,7 +298,7 @@ impl MetadataTableHeader {
     }
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, Debug, Clone, Copy)]
 pub struct MetadataTableEntry {
     item_id: Uuid,

--- a/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
+++ b/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
@@ -221,7 +221,7 @@ pub fn construct_gicr_typers(vcpu_states: &[CpuState]) -> Vec<u64> {
         //calculate affinity
         let mut cpu_affid = mpidr[0].addr & 1095233437695;
         cpu_affid = ((cpu_affid & 0xFF00000000) >> 8) | (cpu_affid & 0xFFFFFF);
-        gicr_typers.push((cpu_affid << 32) | (1 << 24) | (index as u64) << 8 | (last << 4));
+        gicr_typers.push((cpu_affid << 32) | (1 << 24) | ((index as u64) << 8) | (last << 4));
     }
 
     gicr_typers

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -1159,7 +1159,7 @@ mod tests {
 
     use super::*;
 
-    #[repr(packed)]
+    #[repr(C, packed)]
     #[derive(Clone, Copy, Default)]
     #[allow(dead_code)]
     struct TestCap {

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -456,7 +456,7 @@ impl Snapshottable for MsixConfig {
 }
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Default, Serialize, Deserialize)]
 pub struct MsixCap {
     // Message Control Register

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -73,7 +73,7 @@ const VIRTIO_IOMMU_F_BYPASS_CONFIG: u32 = 6;
 const VIRTIO_IOMMU_PAGE_SIZE_MASK: u64 = (2 << 20) | (4 << 10);
 
 #[derive(Copy, Clone, Debug, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(dead_code)]
 struct VirtioIommuRange32 {
     start: u32,
@@ -81,7 +81,7 @@ struct VirtioIommuRange32 {
 }
 
 #[derive(Copy, Clone, Debug, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(dead_code)]
 struct VirtioIommuRange64 {
     start: u64,
@@ -89,7 +89,7 @@ struct VirtioIommuRange64 {
 }
 
 #[derive(Copy, Clone, Debug, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(dead_code)]
 struct VirtioIommuConfig {
     page_size_mask: u64,
@@ -108,7 +108,7 @@ const VIRTIO_IOMMU_T_UNMAP: u8 = 4;
 const VIRTIO_IOMMU_T_PROBE: u8 = 5;
 
 #[derive(Copy, Clone, Debug, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 struct VirtioIommuReqHead {
     type_: u8,
     _reserved: [u8; 3],
@@ -134,7 +134,7 @@ const VIRTIO_IOMMU_S_FAULT: u8 = 7;
 const VIRTIO_IOMMU_S_NOMEM: u8 = 8;
 
 #[derive(Copy, Clone, Debug, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(dead_code)]
 struct VirtioIommuReqTail {
     status: u8,
@@ -143,7 +143,7 @@ struct VirtioIommuReqTail {
 
 /// ATTACH request
 #[derive(Copy, Clone, Debug, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 struct VirtioIommuReqAttach {
     domain: u32,
     endpoint: u32,
@@ -155,7 +155,7 @@ const VIRTIO_IOMMU_ATTACH_F_BYPASS: u32 = 1;
 
 /// DETACH request
 #[derive(Copy, Clone, Debug, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 struct VirtioIommuReqDetach {
     domain: u32,
     endpoint: u32,
@@ -175,7 +175,7 @@ const VIRTIO_IOMMU_MAP_F_MASK: u32 =
 
 /// MAP request
 #[derive(Copy, Clone, Debug, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 struct VirtioIommuReqMap {
     domain: u32,
     virt_start: u64,
@@ -186,7 +186,7 @@ struct VirtioIommuReqMap {
 
 /// UNMAP request
 #[derive(Copy, Clone, Debug, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 struct VirtioIommuReqUnmap {
     domain: u32,
     virt_start: u64,
@@ -203,7 +203,7 @@ const VIRTIO_IOMMU_PROBE_T_MASK: u16 = 0xfff;
 
 /// PROBE request
 #[derive(Copy, Clone, Debug, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(dead_code)]
 struct VirtioIommuReqProbe {
     endpoint: u32,
@@ -211,7 +211,7 @@ struct VirtioIommuReqProbe {
 }
 
 #[derive(Copy, Clone, Debug, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(dead_code)]
 struct VirtioIommuProbeProperty {
     type_: u16,
@@ -224,7 +224,7 @@ const VIRTIO_IOMMU_RESV_MEM_T_RESERVED: u8 = 0;
 const VIRTIO_IOMMU_RESV_MEM_T_MSI: u8 = 1;
 
 #[derive(Copy, Clone, Debug, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(dead_code)]
 struct VirtioIommuProbeResvMem {
     subtype: u8,
@@ -254,7 +254,7 @@ const VIRTIO_IOMMU_FAULT_R_MAPPING: u32 = 2;
 /// Fault reporting through eventq
 #[allow(unused)]
 #[derive(Copy, Clone, Debug, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 struct VirtioIommuFault {
     reason: u8,
     reserved: [u8; 3],

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -60,7 +60,7 @@ enum PciCapabilityType {
 const VIRTIO_PCI_CAP_OFFSET: usize = 2;
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Default)]
 struct VirtioPciCap {
     cap_len: u8,      // Generic PCI field: capability length
@@ -101,7 +101,7 @@ impl VirtioPciCap {
 }
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Default)]
 struct VirtioPciNotifyCap {
     cap: VirtioPciCap,
@@ -145,7 +145,7 @@ impl VirtioPciNotifyCap {
 }
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Default)]
 struct VirtioPciCap64 {
     cap: VirtioPciCap,
@@ -184,7 +184,7 @@ impl VirtioPciCap64 {
 }
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Clone, Copy, Default)]
 struct VirtioPciCfgCap {
     cap: VirtioPciCap,

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -44,7 +44,7 @@ pub const ACPI_APIC_GENERIC_REDISTRIBUTOR: u8 = 14;
 pub const ACPI_APIC_GENERIC_TRANSLATOR: u8 = 15;
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, AsBytes)]
 struct PciRangeEntry {
     pub base_address: u64,
@@ -55,7 +55,7 @@ struct PciRangeEntry {
 }
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, AsBytes)]
 struct MemoryAffinity {
     pub type_: u8,
@@ -72,7 +72,7 @@ struct MemoryAffinity {
 }
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, AsBytes)]
 struct ProcessorLocalX2ApicAffinity {
     pub type_: u8,
@@ -86,7 +86,7 @@ struct ProcessorLocalX2ApicAffinity {
 }
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, AsBytes)]
 struct ProcessorGiccAffinity {
     pub type_: u8,
@@ -146,7 +146,7 @@ impl MemoryAffinity {
 }
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, AsBytes)]
 struct ViotVirtioPciNode {
     pub type_: u8,
@@ -158,7 +158,7 @@ struct ViotVirtioPciNode {
 }
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, AsBytes)]
 struct ViotPciRangeNode {
     pub type_: u8,

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -205,7 +205,7 @@ pub type Result<T> = result::Result<T, Error>;
 
 #[cfg(target_arch = "x86_64")]
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(AsBytes)]
 struct LocalX2Apic {
     pub r#type: u8,
@@ -217,7 +217,7 @@ struct LocalX2Apic {
 }
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, AsBytes)]
 struct Ioapic {
     pub r#type: u8,
@@ -230,7 +230,7 @@ struct Ioapic {
 
 #[cfg(target_arch = "aarch64")]
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(AsBytes)]
 struct GicC {
     pub r#type: u8,
@@ -255,7 +255,7 @@ struct GicC {
 
 #[cfg(target_arch = "aarch64")]
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(AsBytes)]
 struct GicD {
     pub r#type: u8,
@@ -270,7 +270,7 @@ struct GicD {
 
 #[cfg(target_arch = "aarch64")]
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(AsBytes)]
 struct GicR {
     pub r#type: u8,
@@ -282,7 +282,7 @@ struct GicR {
 
 #[cfg(target_arch = "aarch64")]
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(AsBytes)]
 struct GicIts {
     pub r#type: u8,
@@ -295,7 +295,7 @@ struct GicIts {
 
 #[cfg(target_arch = "aarch64")]
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(AsBytes)]
 struct ProcessorHierarchyNode {
     pub r#type: u8,
@@ -308,7 +308,7 @@ struct ProcessorHierarchyNode {
 }
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, AsBytes)]
 struct InterruptSourceOverride {
     pub r#type: u8,


### PR DESCRIPTION
Beta Clippy reports issues with VHDX structures.

Fix all places where `repr` is problematic.