### PR TITLE
build: Bump version number of Docker image

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -41,7 +41,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=raw,value=20241022-0
+            type=raw,value=20250111-0
             type=sha
 
       - name: Build and push

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright © 2024 Intel Corporation
+# Copyright © 2025 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -9,7 +9,7 @@ CLI_NAME="Cloud Hypervisor"
 CTR_IMAGE_TAG="ghcr.io/cloud-hypervisor/cloud-hypervisor"
 
 # Needs to match explicit version in docker-image.yaml workflow
-CTR_IMAGE_VERSION="20241022-0"
+CTR_IMAGE_VERSION="20250111-0"
 : "${CTR_IMAGE:=${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}}"
 
 DOCKER_RUNTIME="docker"


### PR DESCRIPTION
No change to the Dockerfile but I observed that the 20251022-0 image was
not available in the repository.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
