### PR TITLE
Log vCPU CPUID entries

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -887,6 +887,10 @@ pub fn configure_vcpu(
         }
     }
 
+    for c in &cpuid {
+        info!("{}", c);
+    }
+
     vcpu.set_cpuid2(&cpuid)
         .map_err(|e| Error::SetSupportedCpusFailed(e.into()))?;
 

--- a/hypervisor/src/arch/x86/mod.rs
+++ b/hypervisor/src/arch/x86/mod.rs
@@ -11,6 +11,8 @@
 // Copyright © 2020, Microsoft Corporation
 //
 
+use core::fmt;
+
 #[cfg(all(feature = "mshv_emulator", target_arch = "x86_64"))]
 pub mod emulator;
 pub mod gdt;
@@ -209,6 +211,22 @@ pub struct CpuIdEntry {
     pub ebx: u32,
     pub ecx: u32,
     pub edx: u32,
+}
+
+impl fmt::Display for CpuIdEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "function = 0x{:08x} \
+             index = 0x{:08x} \
+             eax = 0x{:08x} \
+             ebx = 0x{:08x} \
+             ecx = 0x{:08x} \
+             edx = 0x{:08x} \
+             flags = 0x{:08x}",
+            self.function, self.index, self.eax, self.ebx, self.ecx, self.edx, self.flags
+        )
+    }
 }
 
 pub const CPUID_FLAG_VALID_INDEX: u32 = 1;


### PR DESCRIPTION
- **hypervisor: Implement fmt::Display for CpuIdEntry**
- **arch: x86_64: Log the cpuid per vCPU**
