### PR TITLE
fuzz: build x86emul by default

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.0.0"
 cargo-fuzz = true
 
 [features]
+default = ["mshv_emulator"]
 igvm = []
 mshv_emulator = ["hypervisor/mshv_emulator"]
 pvmemcontrol = []


### PR DESCRIPTION
I have a PR to add the two new fuzzers to oss-fuzz https://github.com/google/oss-fuzz/pull/12935.

The strange thing is that one of the builds fails because x86emul is not built.

My theory right now is that `--features mshv_emulator` is not honoured by oss-fuzz, hence this PR.