### PR TITLE
Fix riscv aia

### DIFF
--- a/hypervisor/src/kvm/riscv64/aia.rs
+++ b/hypervisor/src/kvm/riscv64/aia.rs
@@ -99,7 +99,7 @@ impl KvmAiaImsics {
         let riscv_imsic_addr_of = |cpu_index: u32| -> u64 {
             self.imsic_addr + (cpu_index * kvm_bindings::KVM_DEV_RISCV_IMSIC_SIZE) as u64
         };
-        let riscv_imsic_attr_of = |cpu_index: u32| -> u64 { cpu_index as u64 };
+        let riscv_imsic_attr_of = |cpu_index: u32| -> u64 { cpu_index as u64 + 1 };
 
         // Setting up RISC-V IMSICs
         for cpu_index in 0..self.vcpu_count {

--- a/hypervisor/src/kvm/riscv64/aia.rs
+++ b/hypervisor/src/kvm/riscv64/aia.rs
@@ -268,6 +268,7 @@ mod tests {
     fn test_create_aia() {
         let hv = crate::new().unwrap();
         let vm = hv.create_vm().unwrap();
+        let _vcpu = vm.create_vcpu(0, None).unwrap();
 
         assert!(KvmAiaImsics::new(&*vm, create_test_vaia_config()).is_ok());
     }


### PR DESCRIPTION
- hypervisor: Fix AIA IMSIC attr calculation
  The IMSIC attr of RISC-V AIA is wrongly configured to start from 0, which
  would error out with `os error 22` (invalid argument).

  ```console
  Error booting VM: VmBoot(DeviceManager(CreateInterruptController(CreateAia(CreateVaia(Vaia error 
  SetDeviceAttribute(SetDeviceAttribute(Invalid argument (os error 22))))))))
  ```

  `riscv_imsic_attr_of` should shift `cpu_index` by 1 here to produce
  correct IMSIC attr.
- hypervisor: Create vcpu before initialize AIA
  Create a corresponding `vcpu` in `test_create_aia`  to capture wrongly
  configured RISC-V IMSIC attr.
