### PR TITLE
build: Provide CH_EXTRA_VERSION

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::env;
 use std::process::Command;
 
 fn main() {
@@ -12,8 +13,16 @@ fn main() {
         if git_out.status.success() {
             if let Ok(git_out_str) = String::from_utf8(git_out.stdout) {
                 version = git_out_str;
+                // Pop the trailing newline.
+                version.pop();
             }
         }
+    }
+
+    // Append CH_EXTRA_VERSION to version if it is set.
+    if let Ok(extra_version) = env::var("CH_EXTRA_VERSION") {
+        println!("cargo:rerun-if-env-changed=CH_EXTRA_VERSION");
+        version.push_str(&format!("-{}", extra_version));
     }
 
     // This println!() has a special behavior, as it will set the environment


### PR DESCRIPTION
Use this to add any extra versioning information to the binary. It is useful when packaging Cloud Hypervisor.