### PR TITLE
build: Bump mshv crate to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,9 +1243,9 @@ checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
 name = "mshv-bindings"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0cb5031f3243a7459b7c13d960d25420980874eebda816db24ce6077e21d43"
+checksum = "30f83f36cb864d90b62a4576556cef3319603d02f3aca58a87694e1e0694bdda"
 dependencies = [
  "libc",
  "num_enum",
@@ -1257,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89abe853221fa6f14ad4066affb9abda241a03d65622887d5794e1422d0bd75a"
+checksum = "7cd6d081aa1eb9916b8f2ac89a6f22adaaa9b5308c71ff5f14332143dc52aaf6"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,8 +106,8 @@ acpi_tables = { git = "https://github.com/rust-vmm/acpi_tables", branch = "main"
 kvm-bindings = "0.10.0"
 kvm-ioctls = "0.19.1"
 linux-loader = "0.13.0"
-mshv-bindings = "0.3.2"
-mshv-ioctls = "0.3.2"
+mshv-bindings = "0.3.3"
+mshv-ioctls = "0.3.3"
 seccompiler = "0.4.0"
 vfio-bindings = { git = "https://github.com/rust-vmm/vfio", branch = "main" }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1868,7 +1868,7 @@ impl vm::Vm for MshvVm {
 
     fn create_passthrough_device(&self) -> vm::Result<VfioDeviceFd> {
         let mut vfio_dev = mshv_create_device {
-            type_: mshv_device_type_MSHV_DEV_TYPE_VFIO,
+            type_: MSHV_DEV_TYPE_VFIO,
             fd: 0,
             flags: 0,
         };


### PR DESCRIPTION
Move mshv crates from v0.3.2 to v0.3.3