### PR TITLE
Fix broken link and introduce `lychee` to look after links

### DIFF
--- a/.github/workflows/lychee.yaml
+++ b/.github/workflows/lychee.yaml
@@ -1,0 +1,16 @@
+name: Link Check (lychee)
+on:
+  pull_request
+
+jobs:
+  link_check:
+    name: Link Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v4
+
+      - name: Link Availability Check
+        uses: lycheeverse/lychee-action@master
+        with:
+          args: --verbose --config .lychee.toml .

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,14 @@
+verbose = "info"
+
+exclude = [
+    # Availability of links below should be manually verified.
+    # Page for intel SGX support, returns 403 while querying.
+    '^https://www.intel.com/content/www/us/en/developer/tools/software-guard-extensions/linux-overview.html',
+    # Page for intel TDX support, returns 403 while querying.
+    '^https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.html',
+    # Page for TPM, returns 403 while querying.
+    '^https://trustedcomputinggroup.org/wp-content/uploads/PC-Client-Specific-Platform-TPM-Profile-for-TPM-2p0-v1p05p_r14_pub.pdf',
+
+    # GitHub user smibarber referenced in `CREDITS.md` no longer exist
+    '^https://github.com/smibarber',
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ License](https://opensource.org/licenses/Apache-2.0).
 
 ## Coding Style
 
-We follow the [Rust Style](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md)
+We follow the [Rust Style](https://github.com/rust-lang/rust/tree/HEAD/src/doc/style-guide/src)
 convention and enforce it through the Continuous Integration (CI) process calling into `rustfmt`
 for each submitted Pull Request (PR).
 
@@ -36,7 +36,7 @@ commit you make.
 
 ## Certificate of Origin
 
-In order to get a clear contribution chain of trust we use the [signed-off-by language](https://01.org/community/signed-process)
+In order to get a clear contribution chain of trust we use the [signed-off-by language](https://web.archive.org/web/20230406041855/https://01.org/community/signed-process)
 used by the Linux kernel project.
 
 ## Patch format
@@ -79,12 +79,12 @@ you want to merge your changes to `cloud-hypervisor`:
 
 1. Fork the [cloud-hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor) project
    into your github organization.
-2. Within your fork, create a branch for your contribution.
-3. [Create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
+1. Within your fork, create a branch for your contribution.
+1. [Create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
    against the main branch of the Cloud Hypervisor repository.
-4. To update your pull request amend existing commits whenever applicable and
+1. To update your pull request amend existing commits whenever applicable and
    then push the new changes to your pull request branch.
-5. Once the pull request is approved it can be integrated.
+1. Once the pull request is approved it can be integrated.
 
 ## Issue tracking
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ As of 2023-01-03, the following cloud images are supported:
 
 - [Ubuntu Focal](https://cloud-images.ubuntu.com/focal/current/) (focal-server-cloudimg-{amd64,arm64}.img)
 - [Ubuntu Jammy](https://cloud-images.ubuntu.com/jammy/current/) (jammy-server-cloudimg-{amd64,arm64}.img )
-- [Fedora 36](https://fedora.mirrorservice.org/fedora/linux/releases/36/Cloud/) ([Fedora-Cloud-Base-36-1.5.x86_64.raw.xz](https://fedora.mirrorservice.org/fedora/linux/releases/36/Cloud/x86_64/images/) / [Fedora-Cloud-Base-36-1.5.aarch64.raw.xz](https://fedora.mirrorservice.org/fedora/linux/releases/36/Cloud/aarch64/images/))
+- [Fedora 36](https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/36/Cloud/) ([Fedora-Cloud-Base-36-1.5.x86_64.raw.xz](https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/36/Cloud/x86_64/images/) / [Fedora-Cloud-Base-36-1.5.aarch64.raw.xz](https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/36/Cloud/aarch64/images/))
 
 Direct kernel boot to userspace should work with a rootfs from most
 distributions although you may need to enable exotic filesystem types in the

--- a/docs/amd_sev_snp.md
+++ b/docs/amd_sev_snp.md
@@ -1,6 +1,7 @@
 # AMD SEV-SNP
 
 ### WARNING
+
 This feature is only currently supported on MSHV.
 
 AMD Secure Encrypted Virtualization & Secure Nested Paging (SEV-SNP) is an AMD
@@ -9,8 +10,8 @@ malicious hypervisor-based attacks like data replay, memory-remapping and more
 in order to create an isolated execution environment. Here are some useful
 links:
 
-* [SNP Homepage] (https://www.amd.com/en/processors/amd-secure-encrypted-virtualization)
-more information about SEV-SNP technical aspects, design and specification.
+- [SNP Homepage](https://www.amd.com/content/dam/amd/en/documents/epyc-business-docs/solution-briefs/amd-secure-encrypted-virtualization-solution-brief.pdf):
+  more information about SEV-SNP technical aspects, design and specification.
 
 ## Cloud Hypervisor support
 

--- a/docs/debug-port.md
+++ b/docs/debug-port.md
@@ -1,8 +1,9 @@
 # `cloud-hypervisor` debug IO ports
 
 When running x86 guests, `cloud-hypervisor` provides different kinds of debug ports:
-- [`0x80` debug port](https://www.intel.com/content/www/us/en/support/articles/000005500/boards-and-kits.html) 
-- Debug console (by default at `0xe9`). 
+
+- [`0x80` debug port](https://web.archive.org/web/20211028033025/https://www.intel.com/content/www/us/en/support/articles/000005500/boards-and-kits.html)
+- Debug console (by default at `0xe9`).
 - Firmware debug port at `0x402`.
 
 All of them can be used to trace user-defined guest events and all of them can
@@ -25,13 +26,13 @@ for debugging specific components of the guest software stack. When logging a
 write of one of those codes to the debug port, `cloud-hypervisor` adds a
 pre-defined string to the logs.
 
-| Code Range       | Component   | Log string   |
-| ---------------- | ----------- | ------------ |
-| `0x00` to `0x1f` | Firmware    | `Firmware`   |
-| `0x20` to `0x3f` | Bootloader  | `Bootloader` |
-| `0x40` to `0x5f` | Kernel      | `Kernel`     |
-| `0x60` to `0x7f` | Userspace   | `Userspace`  |
-| `0x80` to `0xff` | Custom      | `Custom`     |
+| Code Range       | Component  | Log string   |
+| ---------------- | ---------- | ------------ |
+| `0x00` to `0x1f` | Firmware   | `Firmware`   |
+| `0x20` to `0x3f` | Bootloader | `Bootloader` |
+| `0x40` to `0x5f` | Kernel     | `Kernel`     |
+| `0x60` to `0x7f` | Userspace  | `Userspace`  |
+| `0x80` to `0xff` | Custom     | `Custom`     |
 
 One typical use case is guest boot time measurement and tracing. By writing
 different values to the debug I/O port at different boot process steps, the
@@ -71,8 +72,8 @@ cloud-hypervisor: 403.499628ms: DEBUG:vmm/src/vm.rs:510 -- [Debug I/O port: Firm
 
 ### Debug console port
 
-The debug console is inspired by QEMU and Bochs, which have a similar feature. 
-By default, the I/O port `0xe9` is used. This port can be configured like a 
+The debug console is inspired by QEMU and Bochs, which have a similar feature.
+By default, the I/O port `0xe9` is used. This port can be configured like a
 console. Thus, it can print to a tty, a file, or a pty, for example.
 
 ### Firmware debug port
@@ -83,7 +84,7 @@ it. The firmware debug port only prints to stdout.
 ## When do I need these ports?
 
 The ports are on the one hand interesting for firmware or kernel developers, as
-they provide an easy way to print debug information from within a guest. 
+they provide an easy way to print debug information from within a guest.
 Furthermore, you can patch "normal" software to measure certain events, such as
 the boot time of a guest.
 
@@ -91,6 +92,6 @@ the boot time of a guest.
 
 The `0x80` debug port and the port of the firmware debug device are always
 available. The debug console must be activated via the command line, but
-provides more configuration options. 
+provides more configuration options.
 
-You can use different ports for different aspect of your logging messages. 
+You can use different ports for different aspect of your logging messages.

--- a/docs/intel_sgx.md
+++ b/docs/intel_sgx.md
@@ -8,11 +8,12 @@ the host kernel. The required Linux and KVM changes can be found in the
 [KVM SGX Tree](https://github.com/intel/kvm-sgx).
 
 Utilizing SGX in the guest requires a kernel/OS with SGX support, e.g. a kernel
-built using the [SGX Linux Development Tree](https://git.kernel.org/pub/scm/linux/kernel/git/jarkko/linux-sgx.git)
+since release 5.11, see
+[here](https://www.intel.com/content/www/us/en/developer/tools/software-guard-extensions/linux-overview.html)
 or the [KVM SGX Tree](https://github.com/intel/kvm-sgx). Running KVM SGX as the
 guest kernel allows nested virtualization of SGX.
 
-For more information about SGX, please refer to the [SGX Homepage](https://software.intel.com/sgx).
+For more information about SGX, please refer to the [SGX Homepage](https://www.intel.com/content/www/us/en/developer/tools/software-guard-extensions/linux-overview.html).
 
 For more information about SGX SDK and how to test SGX, please refer to the
 following [instructions](https://github.com/intel/linux-sgx).

--- a/docs/intel_tdx.md
+++ b/docs/intel_tdx.md
@@ -4,21 +4,21 @@ Intel® Trust Domain Extensions (Intel® TDX) is an Intel technology designed to
 isolate virtual machines from the VMM, hypervisor and any other software on the
 host platform. Here are some useful links:
 
-* [TDX Homepage](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-trust-domain-extensions.html):
-more information about TDX technical aspects, design and specification
+- [TDX Homepage](https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.html):
+  more information about TDX technical aspects, design and specification
 
-* [KVM TDX tree](https://github.com/intel/tdx/tree/kvm): the required
+- [KVM TDX tree](https://github.com/intel/tdx/tree/kvm): the required
   Linux kernel changes for the host side
 
-* [Guest TDX tree](https://github.com/intel/tdx/tree/guest): the Linux
+- [Guest TDX tree](https://github.com/intel/tdx/tree/guest): the Linux
   kernel changes for the guest side
 
-* [EDK2 project](https://github.com/tianocore/edk2): the TDVF firmware
+- [EDK2 project](https://github.com/tianocore/edk2): the TDVF firmware
 
-* [Confidential Containers project](https://github.com/confidential-containers/td-shim):
+- [Confidential Containers project](https://github.com/confidential-containers/td-shim):
   the TDShim firmware
 
-* [TDX Tools](https://github.com/intel/tdx-tools): a collection of tools
+- [TDX Linux](https://github.com/intel/tdx-linux): a collection of tools
   and scripts to setup TDX environment for testing purpose (such as
   installing required packages on the host, creating guest images, and
   building the custom Linux kernel for TDX host and guest)
@@ -27,17 +27,13 @@ more information about TDX technical aspects, design and specification
 
 It is required to use a machine with TDX enabled in hardware and
 with the host OS compiled from the [KVM TDX tree](https://github.com/intel/tdx/tree/kvm).
-The host environment can also be setup with the [TDX Tools](https://github.com/intel/tdx-tools).
+The host environment can also be setup with the [TDX Linux](https://github.com/intel/tdx-linux).
 
 Cloud Hypervisor can run TDX VM (Trust Domain) by loading a TD firmware ([TDVF](https://github.com/tianocore/edk2)),
 which will then load the guest kernel from the image. The image must be custom
 as it must include a kernel built from the [Guest TDX tree](https://github.com/intel/tdx/tree/guest).
 Cloud Hypervisor can also boot a TDX VM with direct kernel boot using [TDshim](https://github.com/confidential-containers/td-shim).
-The custom Linux kernel for the guest can be built with the [TDX Tools](https://github.com/intel/tdx-tools).
-
-> **Note**
-> The latest version of custom host and guest kernel being tested is
-> from [TDX Tools - 2023ww01](https://github.com/intel/tdx-tools/commits/2023ww01).
+The custom Linux kernel for the guest can be built with the [TDX Linux](https://github.com/intel/tdx-linux).
 
 ### TDVF
 
@@ -110,6 +106,7 @@ direct kernel boot, which is useful for containers use cases.
 
 To build TDShim from source, it is required to install `Rust`, `NASM`,
 and `LLVM` first. The TDshim can be build as follows:
+
 ```bash
 git clone https://github.com/confidential-containers/td-shim
 cd td-shim
@@ -126,13 +123,14 @@ cargo image --release
 
 If debug logs from the TDShim is needed, here are the alternative
 commands:
+
 ```bash
 cargo image
 ```
 
 And run a TDX VM by providing the firmware previously built, along with a guest
 kernel built from the [Guest TDX tree](https://github.com/intel/tdx/tree/guest)
-or the [TDX Tools](https://github.com/intel/tdx-tools).
+or the [TDX Linux](https://github.com/intel/tdx-linux).
 The appropriate kernel boot options must be provided through the `--cmdline`
 option as well.
 

--- a/docs/io_throttling.md
+++ b/docs/io_throttling.md
@@ -1,7 +1,7 @@
 # I/O Throttling
 
 Cloud Hypervisor now supports I/O throttling on virtio-block and virtio-net
-devices. This support is based on the [`rate-limiter` module](https://github.com/firecracker-microvm/firecracker/tree/master/src/rate_limiter)
+devices. This support is based on the [`rate-limiter` module](https://github.com/firecracker-microvm/firecracker/tree/7a1231b141e958d15d5b2c079dd5e0880528b4b0/src/rate_limiter)
 from Firecracker. This document explains the user interface of this
 feature, and highlights some internal implementations that can help users
 better understand the expected behavior of I/O throttling in practice.
@@ -44,10 +44,12 @@ generally advisable to keep `bw/ops_refill_time` larger than `100 ms`
 expectation ("refill-rate").
 
 ## Rate Limit Groups
+
 It is possible to throttle the aggregate bandwidth or operations
 of multiple virtio-blk devices using a `rate_limit_group`. virtio-blk devices may be
 dynamically added and removed from a `rate_limit_group`. The following example
 demonstrates how to throttle the aggregate bandwidth of two disks to 10 MiB/s.
+
 ```
 --disk path=disk0.raw,rate_limit_group=group0 \
        path=disk1.raw,rate_limit_group=group0 \

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -2,8 +2,8 @@
 
 The target audience of this document is both:
 
-* Developers who want to understand what log level to use and when,
-* Users who want to debug issues with running their workloads in Cloud Hypervisor
+- Developers who want to understand what log level to use and when,
+- Users who want to debug issues with running their workloads in Cloud Hypervisor
 
 ## Control
 
@@ -28,7 +28,6 @@ A serious problem has occurred but the execution of the VM can continue although
 A typical example of where this level of message should be generated is during an API call request that cannot be fulfilled.
 
 The user should investigate the meaning of this warning and take steps to ensure the correct functionality.
-
 
 ### `info!()`
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -362,9 +362,9 @@
 
 # v44.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v44.0. The following user visible changes have been made:
+This release has been tracked in [v44.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v44.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Configurable `virtio-iommu` Address Width
 
@@ -405,9 +405,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v43.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v43.0. The following user visible changes have been made:
+This release has been tracked in [v43.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v43.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Live Migration over TCP Connections
 
@@ -447,9 +447,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v42.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v42.0. The following user visible changes have been made:
+This release has been tracked in [v42.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v42.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### SVE/SVE2 Support on AArch64
 
@@ -496,9 +496,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v41.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v41.0. The following user visible changes have been made:
+This release has been tracked in [v41.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v41.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Experimental "Pvmemcontrol" Support
 
@@ -555,9 +555,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v40.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v40.0. The following user visible changes have been made:
+This release has been tracked in [v40.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v40.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Support for Restoring File Descriptor Backed Network Devices
 
@@ -606,9 +606,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v39.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v39.0. The following user visible changes have been made:
+This release has been tracked in [v39.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v39.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Variable Sizing of PCI Apertures for Segments
 
@@ -677,9 +677,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v38.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v38.0. The following user visible changes have been made:
+This release has been tracked in [v38.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v38.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Group Rate Limiter on Block Devices
 
@@ -747,9 +747,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v37.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v37.0. The following user visible changes have been made:
+This release has been tracked in [v37.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v37.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Long Term Support (LTS) Release
 
@@ -809,9 +809,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v36.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v36.0. The following user visible changes have been made:
+This release has been tracked in [v36.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v36.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Command Line Changes
 
@@ -884,9 +884,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v35.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v35.0. The following user visible changes have been made:
+This release has been tracked in [v35.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v35.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### `virtio-vsock` Support for Linux Guest Kernel v6.3+
 
@@ -937,9 +937,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v34.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v34.0. The following user visible changes have been made:
+This release has been tracked in [v34.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v34.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Paravirtualised Panic Device Support
 
@@ -997,9 +997,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v33.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v33.0. The following user visible changes have been made:
+This release has been tracked in [v33.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v33.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### D-Bus based API
 
@@ -1041,9 +1041,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v32.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v32.0. The following user visible changes have been made:
+This release has been tracked in [v32.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v32.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Increased PCI Segment Limit
 
@@ -1094,9 +1094,9 @@ This is a bug fix release. The following issues have been addressed:
 
 # v31.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v31.0. The following user visible changes have been made:
+This release has been tracked in [v31.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v31.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Update to Latest `acpi_tables`
 
@@ -1160,9 +1160,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v30.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v30.0. The following user visible changes have been made:
+This release has been tracked in [v30.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v30.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Command Line Changes for Reduced Binary Size
 
@@ -1233,9 +1233,9 @@ This is a bug fix release. The following issues have been addressed:
 
 # v29.0
 
-This release has been tracked in our [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v29.0. The following user visible changes have been made:
+This release has been tracked in [v29.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v29.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Release Binary Supports Both MSHV and KVM
 
@@ -1330,9 +1330,9 @@ addresses an infinite loop issue ([details](https://github.com/rust-vmm/linux-lo
 
 # v28.0
 
-This release has been tracked in our new [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v28.0.
+This release has been tracked in [v28.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v28.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Community Engagement (Reminder)
 
@@ -1406,9 +1406,9 @@ Many thanks to everyone who has contributed to our release:
 
 # v27.0
 
-This release has been tracked in our new [roadmap
-project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
-v27.0.
+This release has been tracked in [v27.0
+group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v27.0%22)
+of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).
 
 ### Community Engagement
 
@@ -1497,9 +1497,6 @@ Many thanks to everyone who has contributed to our release:
 
 # v26.0
 
-This release has been tracked through the [v26.0
-project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/30).
-
 ### SMBIOS Improvements via `--platform`
 
 `--platform` and the appropriate API structure has gained support for supplying
@@ -1563,9 +1560,6 @@ Many thanks to everyone who has contributed to our release:
 
 # v25.0
 
-This release has been tracked through the [v25.0
-project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/29).
-
 ### `ch-remote` Improvements
 
 The `ch-remote` command has gained support for creating the VM from a JSON
@@ -1608,9 +1602,6 @@ Many thanks to everyone who has contributed to our release:
 * Yi Wang <wang.yi59@zte.com.cn>
 
 # v24.0
-
-This release has been tracked through the [v24.0
-project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/28).
 
 ### Bypass Mode for `virtio-iommu`
 
@@ -1697,9 +1688,6 @@ This is a bug fix release. The following issues have been addressed:
 
 # v23.0
 
-This release has been tracked through the [v23.0
-project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/27).
-
 ### vDPA Support
 
 A vDPA device has a datapath that complies with the virtio specification but
@@ -1767,9 +1755,6 @@ This is a bug fix release. The following issues have been addressed:
 * Fix `virtio-net` control queue (#3829)
 
 # v22.0
-
-This release has been tracked through the [v22.0
-project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/25).
 
 ### GDB Debug Stub Support
 
@@ -1851,9 +1836,6 @@ Many thanks to everyone who has contributed to our release:
 
 # v21.0
 
-This release has been tracked through the [v21.0
-project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/24).
-
 ### Efficient Local Live Migration (for Live Upgrade)
 
 In order to support fast live upgrade of the VMM an optimised path has been
@@ -1916,9 +1898,6 @@ This is a bug fix release. The following issues have been addressed:
 
 # v20.0
 
-This release has been tracked through the [v20.0
-project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/23).
-
 ### Multiple PCI segments support
 
 Cloud Hypervisor is no longer limited to 31 PCI devices. For both `x86_64` and
@@ -1973,9 +1952,6 @@ Many thanks to everyone who has contributed to our release:
 * Ziye Yang <ziye.yang@intel.com>
 
 # v19.0
-
-This release has been tracked through the [v19.0
-project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/22).
 
 ### Improved PTY handling for serial and `virtio-console`
 
@@ -2036,9 +2012,6 @@ Many thanks to everyone who has contributed to our release:
 * Yu Li <liyu.yukiteru@bytedance.com>
 
 # v18.0
-
-This release has been tracked through the [v18.0
-project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/21).
 
 ### Experimental User Device (`vfio-user`) support
 
@@ -2110,9 +2083,6 @@ Many thanks to everyone who has contributed to our release:
 
 # v17.0
 
-This release has been tracked through the [v17.0
-project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/20).
-
 ### ARM64 NUMA support using ACPI
 
 The support for ACPI on ARM64 has been enhanced to include support for
@@ -2168,8 +2138,6 @@ Many thanks to everyone who has contributed to our release:
 
 # v16.0
 
-This release has been tracked through the [v16.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/19).
-
 ### Improved live migration support
 
 The live migration support inside Cloud Hypervisor has been improved with the addition of the tracking of dirty pages written by the VMM to complement the tracking of dirty pages made by the guest itself. Further the internal state of the VMM now is versioned which allows the safe migration of VMs from one version of the VMM to a newer one. However further testing is required so this should be done with care. See the [live migration documentation](docs/live_migration.md) for more details.
@@ -2216,8 +2184,6 @@ Many thanks to everyone who has contributed to our release including some new fa
 * Yi Wang <wang.yi59@zte.com.cn>
 
 # v15.0
-
-This release has been tracked through the [v15.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/18).
 
 Highlights for `cloud-hypervisor` version v15.0 include:
 
@@ -2308,8 +2274,6 @@ in this release:
 
 # v0.14.0
 
-This release has been tracked through the [0.14.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/17).
-
 Highlights for `cloud-hypervisor` version 0.14.0 include:
 
 ### Structured event monitoring
@@ -2380,8 +2344,6 @@ some new faces.
 
 # v0.13.0
 
-This release has been tracked through the [0.13.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/16).
-
 Highlights for `cloud-hypervisor` version 0.13.0 include:
 
 ### Wider VFIO device support
@@ -2442,8 +2404,6 @@ some new faces.
 
 # v0.12.0
 
-This release has been tracked through the [0.12.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/15).
-
 Highlights for `cloud-hypervisor` version 0.12.0 include:
 
 ### ARM64 enhancements
@@ -2482,8 +2442,6 @@ Many thanks to everyone who has contributed to our 0.12.0 release:
 * Wei Liu <liuwe@microsoft.com>
 
 # v0.11.0
-
-This release has been tracked through the [0.11.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/14).
 
 Highlights for `cloud-hypervisor` version 0.11.0 include:
 
@@ -2585,8 +2543,6 @@ Many thanks to everyone who has contributed to our 0.11.0 release including some
 
 # v0.10.0
 
-This release has been tracked through the [0.10.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/13).
-
 Highlights for `cloud-hypervisor` version 0.10.0 include:
 
 ### `virtio-block` Support for Multiple Descriptors
@@ -2630,8 +2586,6 @@ Many thanks to everyone who has contributed to our 0.10.0 release including some
 * Wei Liu <liuwe@microsoft.com>
 
 # v0.9.0
-
-This release has been tracked through the [0.9.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/12).
 
 Highlights for `cloud-hypervisor` version 0.9.0 include:
 
@@ -2713,8 +2667,6 @@ Many thanks to everyone who has contributed to our 0.9.0 release including some 
 
 
 # v0.8.0
-
-This release has been tracked through the [0.8.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/10).
 
 Highlights for `cloud-hypervisor` version 0.8.0 include:
 
@@ -2803,8 +2755,6 @@ Many thanks to everyone who has contributed to our 0.8.0 release including some 
 * Sergio Lopez <slp@redhat.com>
 
 # v0.7.0
-
-This release has been tracked through the [0.7.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/7).
 
 Highlights for `cloud-hypervisor` version 0.7.0 include:
 
@@ -2903,8 +2853,6 @@ Many thanks to everyone who has contributed to our 0.7.0 release including some 
 
 # v0.6.0
 
-This release has been tracked through the [0.6.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/7).
-
 Highlights for `cloud-hypervisor` version 0.6.0 include:
 
 ### Directly Assigned Devices Hotplug
@@ -2981,8 +2929,6 @@ This is a bugfix release branched off v0.5.0. It contains the following fixes:
 
 # v0.5.0
 
-This release has been tracked through the [0.5.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/6).
-
 Highlights for `cloud-hypervisor` version 0.5.0 include:
 
 ### Virtual Machine Dynamic Resizing
@@ -3041,8 +2987,6 @@ Many thanks to everyone that contributed to the 0.5.0 release:
 * Yang Zhong <yang.zhong@intel.com>
 
 # v0.4.0
-
-This release has been tracked through the [0.4.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/4).
 
 Highlights for `cloud-hypervisor` version 0.4.0 include:
 
@@ -3121,8 +3065,6 @@ Many thanks to everyone that contributed to the 0.4.0 release:
 
 # v0.3.0
 
-This release has been tracked through the [0.3.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/3).
-
 Highlights for `cloud-hypervisor` version 0.3.0 include:
 
 ### Block device offloading
@@ -3190,8 +3132,6 @@ support guests with large amount of memory (more than 64GB).
 
 # v0.2.0
 
-This release has been tracked through the [0.2.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/2).
-
 Highlights for `cloud-hypervisor` version 0.2.0 include:
 
 ### Network device offloading
@@ -3243,8 +3183,6 @@ improvements, we are now able to boot Ubuntu bionic images. We added those to
 our CI pipeline.
 
 # v0.1.0
-
-This release has been tracked through the [0.1.0 project](https://github.com/cloud-hypervisor/cloud-hypervisor/projects/1).
 
 Highlights for `cloud-hypervisor` version 0.1.0 include:
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -3216,7 +3216,7 @@ enabled by default.
 
 Based on the Firecracker idea of using a dedicated I/O port to measure guest
 boot times, we added support for logging guest events through the
-[0x80](https://www.intel.com/content/www/us/en/support/articles/000005500/boards-and-kits.html)
+[0x80](https://web.archive.org/web/20211028033025/https://www.intel.com/content/www/us/en/support/articles/000005500/boards-and-kits.html)
 PC debug port. This allows, among other things, for granular guest boot time
 measurements. See our [debug port documentation](docs/debug-port.md) for more
 details.

--- a/release-notes.md
+++ b/release-notes.md
@@ -1190,7 +1190,7 @@ heap profiling using `dhat` gated by the `dhat-heap` feature.
 
 The documentation on Intel TDX is expanded with details of the building
 and using [TD-Shim](https://github.com/confidential-containers/td-shim),
-references to [TDX Tools](https://github.com/intel/tdx-tools), and
+references to [TDX Linux](https://github.com/intel/tdx-linux), and
 version information of guest/host kernel/TDVF/TDShim being tested. Also,
 a new 'heap profiling' documentation is added with improvements on the
 existing 'profiling' documentation.

--- a/release-notes.md
+++ b/release-notes.md
@@ -2735,7 +2735,7 @@ a VM using passthrough (VFIO) devices. Issues with SMP have also been observed
 
 Included in this release is experimental support for running on ARM64.
 Currently only `virtio-mmio` devices and a serial port are supported. Full
-details can be found in the [ARM64 documentation](docs/arm64.md).
+details can be found in the [ARM64 documentation](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/8ab15b9a984a448006f97b1211498c1bb583de3b/docs/arm64.md).
 
 ### Support for Using 5-level Paging in Guests
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -2533,7 +2533,7 @@ resources.
 
 The default logging level was changed to include warnings which should make it
 easier to see potential issues. New [logging
-documentation](docs/logging) was also added.
+documentation](docs/logging.md) was also added.
 
 ### New `--balloon` Parameter Added
 


### PR DESCRIPTION
- docs: Fix broken link in amd_sev_snp.md
- docs: Fix link to docs/logging.md
- docs: Fix broken link to docs/arm64.md
- docs: Fix broken link in io_throttling.md
- docs: Update outdated intel_tdx.md
- docs: Update outdated intel_sgx.md
- docs: Fix broken link to intel 0x80 debug port
- docs: Fix broken link in CONTRIBUTING.md
- docs: Fix broken to fedora 36 artifacts
- misc: Update link in release-note.md
- ci: Introduce lychee to check links

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>