### PR TITLE
pci, vmm: vfio: Report device path on host with DMA map/unmap errors

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3431,6 +3431,7 @@ impl DeviceManager {
             memory_manager.lock().unwrap().memory_slot_allocator(),
             vm_migration::snapshot_from_id(self.snapshot.as_ref(), vfio_name.as_str()),
             device_cfg.x_nv_gpudirect_clique,
+            device_cfg.path.clone(),
         )
         .map_err(DeviceManagerError::VfioPciCreate)?;
 


### PR DESCRIPTION
Comparing with BDF information on the guest, reporting the device path of the VFIO device on the host is more useful when it comes to debug DMA map/unmap errors particularly ones caused by failing hardware on the host.