### PR TITLE
misc: Fix clippy - operator precedence can trip the unwary

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -747,12 +747,12 @@ pub fn generate_common_cpuid(
                 // These features are not supported by TDX
                 #[cfg(feature = "tdx")]
                 if config.tdx {
-                    entry.eax &= !(1 << KVM_FEATURE_CLOCKSOURCE_BIT
-                        | 1 << KVM_FEATURE_CLOCKSOURCE2_BIT
-                        | 1 << KVM_FEATURE_CLOCKSOURCE_STABLE_BIT
-                        | 1 << KVM_FEATURE_ASYNC_PF_BIT
-                        | 1 << KVM_FEATURE_ASYNC_PF_VMEXIT_BIT
-                        | 1 << KVM_FEATURE_STEAL_TIME_BIT)
+                    entry.eax &= !((1 << KVM_FEATURE_CLOCKSOURCE_BIT)
+                        | (1 << KVM_FEATURE_CLOCKSOURCE2_BIT)
+                        | (1 << KVM_FEATURE_CLOCKSOURCE_STABLE_BIT)
+                        | (1 << KVM_FEATURE_ASYNC_PF_BIT)
+                        | (1 << KVM_FEATURE_ASYNC_PF_VMEXIT_BIT)
+                        | (1 << KVM_FEATURE_STEAL_TIME_BIT))
                 }
             }
             _ => {}


### PR DESCRIPTION
Reported by 1.85.0-stable (4d91de4e4 2025-02-17), fix accordingly.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>
