### PR TITLE
misc: Partially fix clippy warnings

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -1109,10 +1109,7 @@ fn print_node(node: fdt_parser::node::FdtNode<'_, '_>, n_spaces: usize) {
         //   - At first, try to convert it to CStr and print,
         //   - If failed, print it as u32 array.
         let value_result = match CStr::from_bytes_with_nul(value) {
-            Ok(value_cstr) => match value_cstr.to_str() {
-                Ok(value_str) => Some(value_str),
-                Err(_e) => None,
-            },
+            Ok(value_cstr) => value_cstr.to_str().ok(),
             Err(_e) => None,
         };
 

--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -299,7 +299,7 @@ pub struct TdHob {
 }
 
 fn align_hob(v: u64) -> u64 {
-    (v + 7) / 8 * 8
+    v.div_ceil(8) * 8
 }
 
 impl TdHob {

--- a/block/src/qcow/mod.rs
+++ b/block/src/qcow/mod.rs
@@ -502,7 +502,7 @@ impl QcowFile {
         if refcount_bits != 16 {
             return Err(Error::UnsupportedRefcountOrder);
         }
-        let refcount_bytes = (refcount_bits + 7) / 8;
+        let refcount_bytes = refcount_bits.div_ceil(8);
 
         // Need at least one refcount cluster
         if header.refcount_table_clusters == 0 {

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1552,7 +1552,7 @@ impl VfioPciDevice {
     /// # Arguments
     ///
     /// * `vm` - The VM object. It is used to set the VFIO MMIO regions
-    ///          as user memory regions.
+    ///   as user memory regions.
     /// * `mem_slot` - The closure to return a memory slot.
     pub fn map_mmio_regions(&mut self) -> Result<(), VfioPciError> {
         let fd = self.device.as_raw_fd();

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -108,7 +108,7 @@ struct PartiallyBalloonedPage {
 impl PartiallyBalloonedPage {
     fn new() -> Self {
         let page_size = get_page_size();
-        let len = ((page_size >> VIRTIO_BALLOON_PFN_SHIFT) + 63) / 64;
+        let len = (page_size >> VIRTIO_BALLOON_PFN_SHIFT).div_ceil(64);
         // Initial each padding bit as 1 in bitmap.
         let mut bitmap = vec![0_u64; len as usize];
         let pad_num = len * 64 - (page_size >> VIRTIO_BALLOON_PFN_SHIFT);
@@ -134,7 +134,7 @@ impl PartiallyBalloonedPage {
     }
 
     fn reset(&mut self) {
-        let len = ((self.page_size >> VIRTIO_BALLOON_PFN_SHIFT) + 63) / 64;
+        let len = (self.page_size >> VIRTIO_BALLOON_PFN_SHIFT).div_ceil(64);
         self.addr = 0;
         self.bitmap = vec![0; len as usize];
         let pad_num = len * 64 - (self.page_size >> VIRTIO_BALLOON_PFN_SHIFT);

--- a/virtio-devices/src/vsock/csm/connection.rs
+++ b/virtio-devices/src/vsock/csm/connection.rs
@@ -146,9 +146,9 @@ where
     /// Returns:
     /// - `Ok(())`: the packet has been successfully filled in and is ready for delivery;
     /// - `Err(VsockError::NoData)`: there was no data available with which to fill in the
-    ///    packet;
+    ///   packet;
     /// - `Err(VsockError::PktBufMissing)`: the packet would've been filled in with data, but
-    ///    it is missing the data buffer.
+    ///   it is missing the data buffer.
     ///
     fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> VsockResult<()> {
         // Perform some generic initialization that is the same for any packet operation (e.g.

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -191,7 +191,7 @@ pub trait Transportable: Pausable + Snapshottable {
     ///
     /// * `snapshot` - The migratable component snapshot to send.
     /// * `destination_url` - The destination URL to send the snapshot to. This
-    ///                       could be an HTTP endpoint, a TCP address or a local file.
+    ///   could be an HTTP endpoint, a TCP address or a local file.
     fn send(
         &self,
         _snapshot: &Snapshot,
@@ -205,7 +205,7 @@ pub trait Transportable: Pausable + Snapshottable {
     /// # Arguments
     ///
     /// * `source_url` - The source URL to fetch the snapshot from. This could be an HTTP
-    ///                  endpoint, a TCP address or a local file.
+    ///   endpoint, a TCP address or a local file.
     fn recv(&self, _source_url: &str) -> std::result::Result<Snapshot, MigratableError> {
         Ok(Snapshot::default())
     }


### PR DESCRIPTION
Partially fix clippy warnings reported by 1.86.0-beta.1 (f0cb41030 2025-02-17):

misc: Fix clippy - doc list item overindented
misc: Fix clippy - manually reimplementing div_ceil
misc: Fix clippy - manual implementation of ok

The rest is in #6953, which requires additional fix after bumping MSRV.

Signed-off-by: Ruoqing He [heruoqing@iscas.ac.cn](mailto:heruoqing@iscas.ac.cn)