### PR TITLE
vmm: api: Expose SEV-SNP and igvm related options

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -548,6 +548,10 @@ components:
           type: string
         initramfs:
           type: string
+        igvm:
+          type: string
+        host_data:
+          type: string
       description: Payloads to boot in guest
 
     VmConfig:
@@ -730,6 +734,9 @@ components:
           items:
             type: string
         tdx:
+          type: boolean
+          default: false
+        sev_snp:
           type: boolean
           default: false
 


### PR DESCRIPTION
This involves the platform and VM config, that can be reused by Kata. 