### PR TITLE
Allow clock_gettime() on the http api thread

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -825,6 +825,7 @@ fn http_api_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError>
     Ok(vec![
         (libc::SYS_accept4, vec![]),
         (libc::SYS_brk, vec![]),
+        (libc::SYS_clock_gettime, vec![]),
         (libc::SYS_close, vec![]),
         (libc::SYS_dup, vec![]),
         (libc::SYS_epoll_create1, vec![]),


### PR DESCRIPTION
Similar to https://github.com/cloud-hypervisor/cloud-hypervisor/pull/2094 the http api thread is lacking the clock_gettime system call in its seccomp filters.

As soon as we execute on a platform where gettime results in a syscall, the thread crashes.