### PR TITLE
ci: Move metrics and rate-limiter workers

### DIFF
--- a/.github/workflows/integration-metrics.yaml
+++ b/.github/workflows/integration-metrics.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Tests (Metrics)
-    runs-on: garm-jammy-16
+    runs-on: bare-metal-9950x
     env:
       METRICS_PUBLISH_KEY: ${{ secrets.METRICS_PUBLISH_KEY }}
     steps:
@@ -15,15 +15,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Docker
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install ca-certificates curl gnupg
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-          sudo chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-          sudo apt install -y docker-ce docker-ce-cli
       - name: Run metrics tests
         timeout-minutes: 60
         run: scripts/dev_cli.sh tests --metrics -- -- --report-file /root/workloads/metrics.json

--- a/.github/workflows/integration-metrics.yaml
+++ b/.github/workflows/integration-metrics.yaml
@@ -1,8 +1,5 @@
 name: Cloud Hypervisor Tests (Metrics)
-on:
-  push:
-    branches:
-      - main
+on: pull_request
 
 jobs:
   build:
@@ -18,5 +15,3 @@ jobs:
       - name: Run metrics tests
         timeout-minutes: 60
         run: scripts/dev_cli.sh tests --metrics -- -- --report-file /root/workloads/metrics.json
-      - name: Upload metrics report
-        run: 'curl -X PUT https://ch-metrics.azurewebsites.net/api/publishmetrics -H "x-functions-key: $METRICS_PUBLISH_KEY" -T ~/workloads/metrics.json'

--- a/.github/workflows/integration-rate-limiter.yaml
+++ b/.github/workflows/integration-rate-limiter.yaml
@@ -7,19 +7,16 @@ concurrency:
 jobs:
   build:
     name: Tests (Rate-Limiter)
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'bare-metal-9950x' }}
+    runs-on: bare-metal-9950x
     env:
       AUTH_DOWNLOAD_TOKEN: ${{ secrets.AUTH_DOWNLOAD_TOKEN }}
     steps:
       - name: Code checkout
-        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Run rate-limiter integration tests
-        if: ${{ github.event_name != 'pull_request' }}
         timeout-minutes: 20
         run: scripts/dev_cli.sh tests --integration-rate-limiter
       - name: Skipping build for PR
-        if: ${{ github.event_name == 'pull_request' }}
         run: echo "Skipping build for PR"

--- a/.github/workflows/integration-rate-limiter.yaml
+++ b/.github/workflows/integration-rate-limiter.yaml
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   build:
     name: Tests (Rate-Limiter)
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'garm-jammy-16' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'bare-metal-9950x' }}
     env:
       AUTH_DOWNLOAD_TOKEN: ${{ secrets.AUTH_DOWNLOAD_TOKEN }}
     steps:
@@ -16,16 +16,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Docker
-        if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install ca-certificates curl gnupg
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-          sudo chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-          sudo apt install -y docker-ce docker-ce-cli
       - name: Run rate-limiter integration tests
         if: ${{ github.event_name != 'pull_request' }}
         timeout-minutes: 20


### PR DESCRIPTION
We are moving the metrics and rate-limiter workers to a bare-metal
system, so that we can have more consistent results (particularly for
the block device metrics)

Signed-off-by: Bo Chen <bchen@crusoe.ai>