### PR TITLE
disks: use advisory locks for disk image files

### DIFF
--- a/block/src/async_io.rs
+++ b/block/src/async_io.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
+use std::os::fd::RawFd;
+
 use thiserror::Error;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -25,6 +27,12 @@ pub trait DiskFile: Send {
     fn topology(&mut self) -> DiskTopology {
         DiskTopology::default()
     }
+    /// Returns the file descriptor of the underlying disk image file.
+    // Impl Note:
+    // This must be `RawFd` instead of `BorrowedFd` or `&File`, as some
+    // implementations wrap the file in an `Arc<Mutex<T>>`, which makes it
+    // impossible to return a reference.
+    fn fd(&mut self) -> RawFd;
 }
 
 #[derive(Error, Debug)]

--- a/block/src/fcntl.rs
+++ b/block/src/fcntl.rs
@@ -1,0 +1,183 @@
+// Copyright © 2025 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Helpers for advisory file locking.
+//!
+//! Under the hood, the implementation uses OFD locks for the entire file,
+//! as described in [[0]]. The advantage over `F_SETLKW` (currently used by
+//! Rust std: `File::try_lock()`) is that only the very last `close()` on a
+//! file descriptor releases the lock. This prevents mistakes and unexpected
+//! behavior.
+//!
+//! [0]: <https://apenwarr.ca/log/20101213>.
+
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
+use std::io;
+use std::os::fd::{AsRawFd, RawFd};
+
+/// Errors that can happen when working with file locks.
+#[derive(Debug)]
+pub enum LockError {
+    /// The file is already locked.
+    ///
+    /// A call to [`get_lock_state`] can help to identify the reason.
+    AlreadyLocked,
+    /// IO error.
+    Io(io::Error),
+}
+
+impl Display for LockError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LockError::AlreadyLocked => f.write_str("The file is already locked"),
+            LockError::Io(e) => {
+                write!(f, "{e}")
+            }
+        }
+    }
+}
+
+impl Error for LockError {}
+
+/// Commands for use with [`fcntl`].
+#[allow(non_camel_case_types)]
+enum FcntlArg<'a> {
+    /// Set an OFD lock from the given lock description.
+    F_OFD_SETLK(&'a libc::flock),
+    /// Get the first OFD lock for the given lock description.
+    F_OFD_GETLK(&'a mut libc::flock),
+}
+
+/// Wrapper for [`libc::fcntl`] that properly sets the function arguments.
+fn fcntl(fd: RawFd, arg: FcntlArg) -> libc::c_int {
+    // SAFETY: We use a valid FD.
+    unsafe {
+        match arg {
+            FcntlArg::F_OFD_SETLK(flock) => libc::fcntl(fd, libc::F_OFD_SETLK, flock),
+            FcntlArg::F_OFD_GETLK(flock) => libc::fcntl(fd, libc::F_OFD_GETLK, flock),
+        }
+    }
+}
+
+/// Describes the type of lock you want to set.
+#[derive(Clone, Copy, Debug)]
+pub enum LockType {
+    /// Clear a lock.
+    Unlock,
+    /// Set a write lock (exclusive).
+    Write,
+    /// Set a read lock (shared).
+    Read,
+}
+
+impl LockType {
+    pub const fn to_libc_val(self) -> libc::c_int {
+        match self {
+            Self::Unlock => libc::F_UNLCK as libc::c_int,
+            Self::Write => libc::F_WRLCK as libc::c_int,
+            Self::Read => libc::F_RDLCK as libc::c_int,
+        }
+    }
+}
+
+/// Describes the current state of a lock.
+#[derive(Debug)]
+pub enum LockState {
+    /// No lock set.
+    Unlocked,
+    /// Locked for reading (non-exclusive).
+    SharedRead,
+    /// Locked for writing (exclusive mode).
+    ExclusiveWrite,
+}
+
+impl LockState {
+    fn new(value: libc::c_int) -> Self {
+        const F_UNLCK: libc::c_int = libc::F_UNLCK as libc::c_int;
+        const F_WRLCK: libc::c_int = libc::F_WRLCK as libc::c_int;
+        const F_RDLCK: libc::c_int = libc::F_RDLCK as libc::c_int;
+        match value {
+            F_UNLCK => Self::Unlocked,
+            F_WRLCK => Self::ExclusiveWrite,
+            F_RDLCK => Self::SharedRead,
+            // This is so unlikely that we want to avoid the complexity of
+            // coping with this error case. Can only fail if either Linux
+            // is broken or memory is messed up.
+            other => panic!("Unexpected lock state: {other}"),
+        }
+    }
+}
+
+/// Returns a [`struct@libc::flock`] structure for the whole file.
+const fn get_flock(lock_type: LockType) -> libc::flock {
+    libc::flock {
+        l_type: lock_type.to_libc_val() as libc::c_short,
+        l_whence: libc::SEEK_SET as libc::c_short,
+        l_start: 0,
+        l_len: 0, /* EOF */
+        l_pid: 0, /* filled by callee */
+    }
+}
+
+/// Tries to acquire a lock using [`fcntl`] with respect to the given
+/// parameters.
+///
+/// Please note that `fcntl()` OFD locks are **advisory locks**, which do not
+/// prevent to `open()` a file if a lock is already placed.
+///
+/// # Parameters
+/// - `file`: The file to acquire a lock for [`LockType`]. The file's state will
+///   be logically mutated, but not technically.
+/// - `lock_type`: The [`LockType`]
+pub fn try_acquire_lock<Fd: AsRawFd>(file: Fd, lock_type: LockType) -> Result<(), LockError> {
+    let flock = get_flock(lock_type);
+
+    let res = fcntl(file.as_raw_fd(), FcntlArg::F_OFD_SETLK(&flock));
+    match res {
+        0 => Ok(()),
+        -1 => {
+            let io_error = io::Error::last_os_error();
+            let errno = io_error.raw_os_error().unwrap();
+            match errno {
+                // See man page for error code:
+                // <https://man7.org/linux/man-pages/man2/fcntl.2.html>
+                libc::EAGAIN | libc::EACCES => Err(LockError::AlreadyLocked),
+                _ => Err(LockError::Io(io_error)),
+            }
+        }
+        val => panic!("Unexpected return value from fcntl(): {val}"),
+    }
+}
+
+/// Clears a lock.
+///
+/// # Parameters
+/// - `file`: The file to clear all locks for [`LockType`].
+pub fn clear_lock<Fd: AsRawFd>(file: Fd) -> Result<(), LockError> {
+    try_acquire_lock(file, LockType::Unlock)
+}
+
+/// Returns the current lock state using [`fcntl`] with respect to the given
+/// parameters.
+///
+/// # Parameters
+/// - `file`: The file for which to get the lock state.
+pub fn get_lock_state<Fd: AsRawFd>(file: Fd) -> Result<LockState, LockError> {
+    let mut flock = get_flock(LockType::Write);
+    let res = fcntl(file.as_raw_fd(), FcntlArg::F_OFD_GETLK(&mut flock));
+    match res {
+        0 => {
+            let state = flock.l_type as libc::c_int;
+            let state = LockState::new(state);
+            Ok(state)
+        }
+        -1 => {
+            let io_error = io::Error::last_os_error();
+            Err(LockError::Io(io_error))
+        }
+        val => panic!("Unexpected return value from fcntl(): {val}"),
+    }
+}

--- a/block/src/fixed_vhd_async.rs
+++ b/block/src/fixed_vhd_async.rs
@@ -33,6 +33,10 @@ impl DiskFile for FixedVhdDiskAsync {
                 .map_err(DiskFileError::NewAsyncIo)?,
         ) as Box<dyn AsyncIo>)
     }
+
+    fn fd(&mut self) -> RawFd {
+        self.0.as_raw_fd()
+    }
 }
 
 pub struct FixedVhdAsync {

--- a/block/src/fixed_vhd_async.rs
+++ b/block/src/fixed_vhd_async.rs
@@ -8,7 +8,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::async_io::{
-    AsyncIo, AsyncIoError, AsyncIoResult, DiskFile, DiskFileError, DiskFileResult,
+    AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFile, DiskFileError, DiskFileResult,
 };
 use crate::fixed_vhd::FixedVhd;
 use crate::raw_async::RawFileAsync;
@@ -34,8 +34,8 @@ impl DiskFile for FixedVhdDiskAsync {
         ) as Box<dyn AsyncIo>)
     }
 
-    fn fd(&mut self) -> RawFd {
-        self.0.as_raw_fd()
+    fn fd(&mut self) -> BorrowedDiskFd {
+        BorrowedDiskFd::new(self.0.as_raw_fd())
     }
 }
 

--- a/block/src/fixed_vhd_sync.rs
+++ b/block/src/fixed_vhd_sync.rs
@@ -8,7 +8,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::async_io::{
-    AsyncIo, AsyncIoError, AsyncIoResult, DiskFile, DiskFileError, DiskFileResult,
+    AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFile, DiskFileError, DiskFileResult,
 };
 use crate::fixed_vhd::FixedVhd;
 use crate::raw_sync::RawFileSync;
@@ -34,8 +34,8 @@ impl DiskFile for FixedVhdDiskSync {
         ) as Box<dyn AsyncIo>)
     }
 
-    fn fd(&mut self) -> RawFd {
-        self.0.as_raw_fd()
+    fn fd(&mut self) -> BorrowedDiskFd {
+        BorrowedDiskFd::new(self.0.as_raw_fd())
     }
 }
 

--- a/block/src/fixed_vhd_sync.rs
+++ b/block/src/fixed_vhd_sync.rs
@@ -33,6 +33,10 @@ impl DiskFile for FixedVhdDiskSync {
                 .map_err(DiskFileError::NewAsyncIo)?,
         ) as Box<dyn AsyncIo>)
     }
+
+    fn fd(&mut self) -> RawFd {
+        self.0.as_raw_fd()
+    }
 }
 
 pub struct FixedVhdSync {

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -12,6 +12,7 @@
 extern crate log;
 
 pub mod async_io;
+pub mod fcntl;
 pub mod fixed_vhd;
 #[cfg(feature = "io_uring")]
 /// Enabled with the `"io_uring"` feature

--- a/block/src/qcow/mod.rs
+++ b/block/src/qcow/mod.rs
@@ -13,6 +13,7 @@ use std::cmp::{max, min};
 use std::fs::OpenOptions;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
+use std::os::fd::{AsRawFd, RawFd};
 use std::str;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
@@ -1513,6 +1514,12 @@ impl QcowFile {
             self.raw_file.file_mut().sync_data()?;
         }
         Ok(())
+    }
+}
+
+impl AsRawFd for QcowFile {
+    fn as_raw_fd(&self) -> RawFd {
+        self.raw_file.as_raw_fd()
     }
 }
 

--- a/block/src/qcow/qcow_raw_file.rs
+++ b/block/src/qcow/qcow_raw_file.rs
@@ -6,6 +6,7 @@
 
 use std::io::{self, BufWriter, Seek, SeekFrom, Write};
 use std::mem::size_of;
+use std::os::fd::{AsRawFd, RawFd};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use vmm_sys_util::write_zeroes::WriteZeroes;
@@ -157,5 +158,11 @@ impl Clone for QcowRawFile {
             cluster_size: self.cluster_size,
             cluster_mask: self.cluster_mask,
         }
+    }
+}
+
+impl AsRawFd for QcowRawFile {
+    fn as_raw_fd(&self) -> RawFd {
+        self.file.as_raw_fd()
     }
 }

--- a/block/src/qcow/raw_file.rs
+++ b/block/src/qcow/raw_file.rs
@@ -369,3 +369,9 @@ impl Clone for RawFile {
         }
     }
 }
+
+impl AsRawFd for RawFile {
+    fn as_raw_fd(&self) -> RawFd {
+        self.file.as_raw_fd()
+    }
+}

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -5,12 +5,14 @@
 use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{Seek, SeekFrom};
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::AsRawFd;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::async_io::{AsyncIo, AsyncIoResult, DiskFile, DiskFileError, DiskFileResult};
+use crate::async_io::{
+    AsyncIo, AsyncIoResult, BorrowedDiskFd, DiskFile, DiskFileError, DiskFileResult,
+};
 use crate::qcow::{QcowFile, RawFile, Result as QcowResult};
 use crate::AsyncAdaptor;
 
@@ -37,9 +39,9 @@ impl DiskFile for QcowDiskSync {
         Ok(Box::new(QcowSync::new(self.qcow_file.clone())) as Box<dyn AsyncIo>)
     }
 
-    fn fd(&mut self) -> RawFd {
+    fn fd(&mut self) -> BorrowedDiskFd {
         let lock = self.qcow_file.lock().unwrap();
-        lock.as_raw_fd()
+        BorrowedDiskFd::new(lock.as_raw_fd())
     }
 }
 

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -5,6 +5,7 @@
 use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{Seek, SeekFrom};
+use std::os::fd::{AsRawFd, RawFd};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use vmm_sys_util::eventfd::EventFd;
@@ -34,6 +35,11 @@ impl DiskFile for QcowDiskSync {
 
     fn new_async_io(&self, _ring_depth: u32) -> DiskFileResult<Box<dyn AsyncIo>> {
         Ok(Box::new(QcowSync::new(self.qcow_file.clone())) as Box<dyn AsyncIo>)
+    }
+
+    fn fd(&mut self) -> RawFd {
+        let lock = self.qcow_file.lock().unwrap();
+        lock.as_raw_fd()
     }
 }
 

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -46,6 +46,10 @@ impl DiskFile for RawFileDisk {
             DiskTopology::default()
         }
     }
+
+    fn fd(&mut self) -> RawFd {
+        self.file.as_raw_fd()
+    }
 }
 
 pub struct RawFileAsync {

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -10,7 +10,7 @@ use io_uring::{opcode, types, IoUring};
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::async_io::{
-    AsyncIo, AsyncIoError, AsyncIoResult, DiskFile, DiskFileError, DiskFileResult,
+    AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFile, DiskFileError, DiskFileResult,
 };
 use crate::DiskTopology;
 
@@ -47,8 +47,8 @@ impl DiskFile for RawFileDisk {
         }
     }
 
-    fn fd(&mut self) -> RawFd {
-        self.file.as_raw_fd()
+    fn fd(&mut self) -> BorrowedDiskFd {
+        BorrowedDiskFd::new(self.file.as_raw_fd())
     }
 }
 

--- a/block/src/raw_async_aio.rs
+++ b/block/src/raw_async_aio.rs
@@ -49,6 +49,10 @@ impl DiskFile for RawFileDiskAio {
             DiskTopology::default()
         }
     }
+
+    fn fd(&mut self) -> RawFd {
+        self.file.as_raw_fd()
+    }
 }
 
 pub struct RawFileAsyncAio {

--- a/block/src/raw_async_aio.rs
+++ b/block/src/raw_async_aio.rs
@@ -13,7 +13,7 @@ use vmm_sys_util::aio;
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::async_io::{
-    AsyncIo, AsyncIoError, AsyncIoResult, DiskFile, DiskFileError, DiskFileResult,
+    AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFile, DiskFileError, DiskFileResult,
 };
 use crate::DiskTopology;
 
@@ -50,8 +50,8 @@ impl DiskFile for RawFileDiskAio {
         }
     }
 
-    fn fd(&mut self) -> RawFd {
-        self.file.as_raw_fd()
+    fn fd(&mut self) -> BorrowedDiskFd {
+        BorrowedDiskFd::new(self.file.as_raw_fd())
     }
 }
 

--- a/block/src/raw_sync.rs
+++ b/block/src/raw_sync.rs
@@ -10,7 +10,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::async_io::{
-    AsyncIo, AsyncIoError, AsyncIoResult, DiskFile, DiskFileError, DiskFileResult,
+    AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFile, DiskFileError, DiskFileResult,
 };
 use crate::DiskTopology;
 
@@ -44,8 +44,8 @@ impl DiskFile for RawFileDiskSync {
         }
     }
 
-    fn fd(&mut self) -> RawFd {
-        self.file.as_raw_fd()
+    fn fd(&mut self) -> BorrowedDiskFd {
+        BorrowedDiskFd::new(self.file.as_raw_fd())
     }
 }
 

--- a/block/src/raw_sync.rs
+++ b/block/src/raw_sync.rs
@@ -43,6 +43,10 @@ impl DiskFile for RawFileDiskSync {
             DiskTopology::default()
         }
     }
+
+    fn fd(&mut self) -> RawFd {
+        self.file.as_raw_fd()
+    }
 }
 
 pub struct RawFileSync {

--- a/block/src/vhdx/mod.rs
+++ b/block/src/vhdx/mod.rs
@@ -5,6 +5,7 @@
 use std::collections::btree_map::BTreeMap;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
+use std::os::fd::{AsRawFd, RawFd};
 
 use byteorder::{BigEndian, ByteOrder};
 use remain::sorted;
@@ -219,6 +220,12 @@ impl Clone for Vhdx {
             current_offset: self.current_offset,
             first_write: self.first_write,
         }
+    }
+}
+
+impl AsRawFd for Vhdx {
+    fn as_raw_fd(&self) -> RawFd {
+        self.file.as_raw_fd()
     }
 }
 

--- a/block/src/vhdx_sync.rs
+++ b/block/src/vhdx_sync.rs
@@ -4,12 +4,14 @@
 
 use std::collections::VecDeque;
 use std::fs::File;
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::AsRawFd;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::async_io::{AsyncIo, AsyncIoResult, DiskFile, DiskFileError, DiskFileResult};
+use crate::async_io::{
+    AsyncIo, AsyncIoResult, BorrowedDiskFd, DiskFile, DiskFileError, DiskFileResult,
+};
 use crate::vhdx::{Result as VhdxResult, Vhdx};
 use crate::AsyncAdaptor;
 
@@ -37,9 +39,9 @@ impl DiskFile for VhdxDiskSync {
         )
     }
 
-    fn fd(&mut self) -> RawFd {
+    fn fd(&mut self) -> BorrowedDiskFd {
         let lock = self.vhdx_file.lock().unwrap();
-        lock.as_raw_fd()
+        BorrowedDiskFd::new(lock.as_raw_fd())
     }
 }
 

--- a/block/src/vhdx_sync.rs
+++ b/block/src/vhdx_sync.rs
@@ -4,6 +4,7 @@
 
 use std::collections::VecDeque;
 use std::fs::File;
+use std::os::fd::{AsRawFd, RawFd};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use vmm_sys_util::eventfd::EventFd;
@@ -34,6 +35,11 @@ impl DiskFile for VhdxDiskSync {
             Box::new(VhdxSync::new(self.vhdx_file.clone()).map_err(DiskFileError::NewAsyncIo)?)
                 as Box<dyn AsyncIo>,
         )
+    }
+
+    fn fd(&mut self) -> RawFd {
+        let lock = self.vhdx_file.lock().unwrap();
+        lock.as_raw_fd()
     }
 }
 

--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -418,7 +418,7 @@ impl InterruptController for Ioapic {
         self.interrupt_source_group
             .trigger(irq as InterruptIndex)
             .map_err(Error::TriggerInterrupt)?;
-        debug!("Interrupt {irq} successfully delivered");
+        trace!("Interrupt {irq} successfully delivered");
 
         // If trigger mode is level sensitive, set the Remote IRR bit.
         // It will be cleared when the EOI is received.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4445,7 +4445,7 @@ mod common_parallel {
                 )
                 .as_str(),
                 format!("path={}", vfio_disk_path.to_str().unwrap()).as_str(),
-                format!("path={},iommu=on", blk_file_path.to_str().unwrap()).as_str(),
+                format!("path={},iommu=on,readonly=true", blk_file_path.to_str().unwrap()).as_str(),
             ])
             .args([
                 "--cmdline",
@@ -5193,7 +5193,13 @@ mod common_parallel {
             assert!(!remote_command(
                 &api_socket,
                 "add-disk",
-                Some(format!("path={},id=test0", blk_file_path.to_str().unwrap()).as_str()),
+                Some(
+                    format!(
+                        "path={},id=test0,readonly=true",
+                        blk_file_path.to_str().unwrap()
+                    )
+                    .as_str()
+                ),
             ));
         });
 
@@ -5255,7 +5261,13 @@ mod common_parallel {
             let (cmd_success, cmd_output) = remote_command_w_output(
                 &api_socket,
                 "add-disk",
-                Some(format!("path={},id=test0", blk_file_path.to_str().unwrap()).as_str()),
+                Some(
+                    format!(
+                        "path={},id=test0,readonly=true",
+                        blk_file_path.to_str().unwrap()
+                    )
+                    .as_str(),
+                ),
             );
             assert!(cmd_success);
             assert!(String::from_utf8_lossy(&cmd_output)
@@ -5296,7 +5308,13 @@ mod common_parallel {
             let (cmd_success, cmd_output) = remote_command_w_output(
                 &api_socket,
                 "add-disk",
-                Some(format!("path={},id=test0", blk_file_path.to_str().unwrap()).as_str()),
+                Some(
+                    format!(
+                        "path={},id=test0,readonly=true",
+                        blk_file_path.to_str().unwrap()
+                    )
+                    .as_str(),
+                ),
             );
             assert!(cmd_success);
             assert!(String::from_utf8_lossy(&cmd_output)

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -48,6 +48,9 @@ pub enum MigratableError {
 
     #[error("Failed to complete migration for migratable component: {0}")]
     CompleteMigration(#[source] anyhow::Error),
+
+    #[error("Failed to release a disk lock before the migration: {0}")]
+    UnlockError(#[source] anyhow::Error),
 }
 
 /// A Pausable component can be paused and resumed.

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2460,7 +2460,7 @@ impl DeviceManager {
                     }
                 }
                 ImageType::Qcow2 => {
-                    info!("Using synchronous QCOW disk file");
+                    info!("Using synchronous QCOW2 disk file");
                     Box::new(
                         QcowDiskSync::new(file, disk_cfg.direct)
                             .map_err(DeviceManagerError::CreateQcowDiskSync)?,


### PR DESCRIPTION
## About

Add advisory file locks for disk images, aligning the behavior with QEMU. Please check out the **commit messages for more details**.

</details>

## Hints for Reviewers

Please review this **commit-by-commit**.

## Steps to Undraft
- [x] basic functionality
- [x] add command line option to make this configurable ([context](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/6974#issuecomment-2715096569))
- [x] solution for live migration