### PR TITLE
ci: Enable retry for Link Check

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -12,3 +12,7 @@ exclude = [
     # GitHub user smibarber referenced in `CREDITS.md` no longer exist
     '^https://github.com/smibarber',
 ]
+
+max_retries = 3
+
+retry_wait_time = 5


### PR DESCRIPTION
Link check is likely to fail due to connectivity reasons, retry three times before it fails.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>