### PR TITLE
README: Add RISC-V support status

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,13 @@ based on the [Rust VMM](https://github.com/rust-vmm) crates.
 
 ### Architectures
 
-Cloud Hypervisor supports the `x86-64` and `AArch64` architectures. There are
-minor differences in functionality between the two architectures
-(see [#1125](https://github.com/cloud-hypervisor/cloud-hypervisor/issues/1125)).
+Cloud Hypervisor supports the `x86-64`, `AArch64` and `riscv64`
+architectures, with functionality varying across these platforms. The
+functionality differences between `x86-64` and `AArch64` are documented
+in [#1125](https://github.com/cloud-hypervisor/cloud-hypervisor/issues/1125).
+The `riscv64` architecture support is experimental and offers limited
+functionality. For more details and instructions, please refer to [riscv
+documentation](docs/riscv.md).
 
 ### Guest OS
 

--- a/docs/riscv.md
+++ b/docs/riscv.md
@@ -1,0 +1,88 @@
+# How to build and test Cloud Hypervisor on riscv64
+
+This document introduces how to build and test Cloud Hypervisor on `riscv64`.
+All instructions here are tested with Ubuntu 24.04.2 as the host OS.
+
+## Hardware requirements
+
+- riscv64 servers (recommended) or development boards equipped with the AIA
+(Advance Interrupt Architecture) interrupt controller.
+
+## Getting started
+
+We create a folder to build and run Cloud Hypervisor at `$HOME/cloud-hypervisor`
+
+```console
+export CLOUDH=$HOME/cloud-hypervisor
+mkdir $CLOUDH
+```
+
+## Prerequisites
+
+You need to install some prerequisite packages to build and test Cloud Hypervisor.
+
+### Tools
+
+```console
+# Install rust tool chain
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+# Install the tools used for building guest kernel, EDK2 and converting guest disk
+sudo apt-get update
+sudo apt-get install git build-essential m4 bison flex uuid-dev qemu-utils
+```
+
+### Building Cloud Hypervisor
+
+```console
+pushd $CLOUDH
+git clone https://github.com/cloud-hypervisor/cloud-hypervisor.git
+cd cloud-hypervisor
+cargo build
+popd
+```
+
+### Disk image
+
+Download the Ubuntu cloud image and convert the image type.
+
+```console
+pushd $CLOUDH
+wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-riscv64.img
+qemu-img convert -p -f qcow2 -O raw jammy-server-cloudimg-riscv64.img jammy-server-cloudimg-riscv64.raw
+popd
+```
+
+## Direct-kernel booting
+
+### Building kernel
+
+```console
+pushd $CLOUDH
+git clone --depth 1 "https://github.com/cloud-hypervisor/linux.git" -b ch-6.12.8
+cd linux
+make ch_defconfig
+make -j `nproc`
+popd
+```
+
+### Booting the guest VM
+
+```console
+pushd $CLOUDH
+sudo $CLOUDH/cloud-hypervisor/target/debug/cloud-hypervisor \
+           --kernel $CLOUDH/linux/arch/riscv64/boot/Image \
+           --disk path=jammy-server-cloudimg-riscv64.raw \
+           --cmdline "console=hvc0 root=/dev/vda rw" \
+           --cpus boot=1 \
+           --memory size=1024M \
+           --seccomp false \
+           --log-file boot.log -vv
+popd
+```
+
+## Known limitations
+
+- Direct kernel boot only
+- `64-bit Linux` guest OS only
+- For more details, see
+  [here](https://github.com/cloud-hypervisor/cloud-hypervisor/issues/6978).


### PR DESCRIPTION
RISC-V experimental support is in place, document it in our README.md.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>
