### PR TITLE
hypervisor: Avoid leaking KVM GIC state into common GIC state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,6 +984,7 @@ dependencies = [
  "mshv-bindings",
  "mshv-ioctls",
  "serde",
+ "serde_json",
  "serde_with",
  "thiserror 2.0.6",
  "vfio-ioctls",

--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -9,8 +9,8 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::anyhow;
 use arch::layout;
-use hypervisor::arch::aarch64::gic::{Vgic, VgicConfig};
-use hypervisor::{CpuState, GicState};
+use hypervisor::arch::aarch64::gic::{GicState, Vgic, VgicConfig};
+use hypervisor::CpuState;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, InterruptSourceConfig, InterruptSourceGroup,
     LegacyIrqSourceConfig, MsiIrqGroupConfig,

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -30,6 +30,7 @@ mshv-bindings = { workspace = true, features = [
 ], optional = true }
 mshv-ioctls = { workspace = true, optional = true }
 serde = { version = "1.0.208", features = ["derive", "rc"] }
+serde_json = "1.0.120"
 serde_with = { version = "3.9.0", default-features = false, features = [
   "macros",
 ] }

--- a/hypervisor/src/arch/aarch64/gic.rs
+++ b/hypervisor/src/arch/aarch64/gic.rs
@@ -5,9 +5,12 @@
 use std::any::Any;
 use std::result;
 
+use serde::de::Error as SerdeError;
+use serde::{Deserialize, Serialize};
+use serde_json;
 use thiserror::Error;
 
-use crate::{CpuState, GicState, HypervisorDeviceError, HypervisorVmError};
+use crate::{CpuState, HypervisorDeviceError, HypervisorVmError};
 
 /// Errors thrown while setting up the VGIC.
 #[derive(Debug, Error)]
@@ -36,6 +39,50 @@ pub struct VgicConfig {
     pub nr_irqs: u32,
 }
 
+#[derive(Clone, Serialize)]
+pub enum GicState {
+    #[cfg(feature = "kvm")]
+    Kvm(crate::kvm::aarch64::gic::Gicv3ItsState),
+}
+
+impl<'de> Deserialize<'de> for GicState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // GicStateDefaultDeserialize is a helper enum that mirrors GicState but also derives the Deserialize trait.
+        // This enables backward-compatible deserialization of GicState, facilitating live-upgrade scenarios.
+        #[derive(Deserialize)]
+        pub enum GicStateDefaultDeserialize {
+            #[cfg(feature = "kvm")]
+            Kvm(crate::kvm::aarch64::gic::Gicv3ItsState),
+        }
+
+        const {
+            assert!(
+                std::mem::size_of::<GicStateDefaultDeserialize>()
+                    == std::mem::size_of::<GicState>()
+            )
+        };
+
+        let value: serde_json::Value = Deserialize::deserialize(deserializer)?;
+
+        #[cfg(feature = "kvm")]
+        if let Ok(gicv3_its_state) =
+            crate::kvm::aarch64::gic::Gicv3ItsState::deserialize(value.clone())
+        {
+            return Ok(GicState::Kvm(gicv3_its_state));
+        }
+
+        if let Ok(gic_state_de) = GicStateDefaultDeserialize::deserialize(value.clone()) {
+            return match gic_state_de {
+                #[cfg(feature = "kvm")]
+                GicStateDefaultDeserialize::Kvm(state) => Ok(GicState::Kvm(state)),
+            };
+        }
+        Err(SerdeError::custom("Failed to deserialize GicState"))
+    }
+}
 /// Hypervisor agnostic interface for a virtualized GIC
 pub trait Vgic: Send + Sync {
     /// Returns the fdt compatibility property of the device

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -29,9 +29,7 @@ use vmm_sys_util::eventfd::EventFd;
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::gic::KvmGicV3Its;
 #[cfg(target_arch = "aarch64")]
-pub use crate::aarch64::{
-    check_required_kvm_extensions, gic::Gicv3ItsState as GicState, is_system_register, VcpuKvmState,
-};
+pub use crate::aarch64::{check_required_kvm_extensions, is_system_register, VcpuKvmState};
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::gic::{Vgic, VgicConfig};
 #[cfg(target_arch = "riscv64")]

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -59,7 +59,7 @@ pub use cpu::CpuVendor;
 pub use cpu::{HypervisorCpuError, Vcpu, VmExit};
 pub use device::HypervisorDeviceError;
 #[cfg(all(feature = "kvm", target_arch = "aarch64"))]
-pub use kvm::{aarch64, GicState};
+pub use kvm::aarch64;
 #[cfg(all(feature = "kvm", target_arch = "riscv64"))]
 pub use kvm::{riscv64, AiaState};
 pub use vm::{


### PR DESCRIPTION
KVM supports GICv3-ITS emulation and the current GicState is modelled around the KVM implementation. We should refactor this to accomodate other hypervisor requirements. For example, MSHV only support GICv2M emulation for guests for delivering MSI interrupts instead of GICv3-ITS.