### PR TITLE
 vm-migration: Optimize downtime by moving stop_dirty_log()

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1209,9 +1209,6 @@ impl Vmm {
 
             // Send last batch of dirty pages
             Self::vm_maybe_send_dirty_pages(vm, &mut socket)?;
-
-            // Stop logging dirty pages
-            vm.stop_dirty_log()?;
         }
         // Capture snapshot and send it
         let vm_snapshot = vm.snapshot()?;
@@ -1230,6 +1227,11 @@ impl Vmm {
             &mut socket,
             MigratableError::MigrateSend(anyhow!("Error completing migration")),
         )?;
+
+        // Stop logging dirty pages
+        if !send_data_migration.local {
+            vm.stop_dirty_log()?;
+        }
 
         info!("Migration complete");
 


### PR DESCRIPTION
The larger the VM memory, the greater the memory pressure, and the greater the stop_dirty_log() overhead. For example, in the case of a 32c64g virtual machine with memory compression, stop_dirty_log() takes 36ms. Moving stop_dirty_log() outside the downtime period can reduce downtime.