### PR TITLE
ci: gitlint now ignores long lines from links

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -13,3 +13,8 @@ line-length=72
 # default 80
 [body-max-line-length]
 line-length=72
+
+# Allow developers to add long links to useful resources
+[ignore-by-body]
+regex=^https?:\/\/
+ignore=body-max-line-length


### PR DESCRIPTION

This is a split-out from #6974 to separate discussions.

The change helps to prevent annoying CI failures when one adds useful resources into
a commit message, such as [0].

One can test this locally using: `gitlint --commits HEAD~1..HEAD`

[0]
https://example.com/?lorem-ipsum-lorem-ipsum-lorem-ipsum-lorem-ipsum-lorem-ipsum-lorem-ipsum-lorem-ipsum-lorem-ipsum-lorem-ipsum-lorem-ipsum-lorem-ipsum-lorem-ipsum-lorem-ipsum-lorem-ipsum

