### PR TITLE
vmm: tighten landlock rule for PmemConfig

### DIFF
--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -486,7 +486,8 @@ pub struct PmemConfig {
 
 impl ApplyLandlock for PmemConfig {
     fn apply_landlock(&self, landlock: &mut Landlock) -> LandlockResult<()> {
-        landlock.add_rule_with_access(self.file.to_path_buf(), "rw")?;
+        let access = if self.discard_writes { "r" } else { "rw" };
+        landlock.add_rule_with_access(self.file.to_path_buf(), access)?;
         Ok(())
     }
 }


### PR DESCRIPTION
when discard_writes is true, only grant read access in landlock