### PR TITLE
vmm: Fix compilation on aarch64 MSHV

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -166,6 +166,12 @@ fn create_vmm_ioctl_seccomp_rule_common_mshv() -> Result<Vec<SeccompRule>, Backe
             MSHV_INITIALIZE_PARTITION()
         )?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_GUEST_MEMORY())?],
+        and![Cond::new(
+            1,
+            ArgLen::Dword,
+            Eq,
+            MSHV_GET_HOST_PARTITION_PROPERTY()
+        )?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_CREATE_VP())?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_IRQFD())?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_IOEVENTFD())?],
@@ -173,7 +179,9 @@ fn create_vmm_ioctl_seccomp_rule_common_mshv() -> Result<Vec<SeccompRule>, Backe
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_REGISTERS())?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_VP_REGISTERS())?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_RUN_VP())?],
+        #[cfg(target_arch = "x86_64")]
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_GET_VP_STATE())?],
+        #[cfg(target_arch = "x86_64")]
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_SET_VP_STATE())?],
         and![Cond::new(
             1,
@@ -194,6 +202,7 @@ fn create_vmm_ioctl_seccomp_rule_common_mshv() -> Result<Vec<SeccompRule>, Backe
             MSHV_GET_GPAP_ACCESS_BITMAP()
         )?],
         and![Cond::new(1, ArgLen::Dword, Eq, MSHV_VP_TRANSLATE_GVA())?],
+        #[cfg(target_arch = "x86_64")]
         and![Cond::new(
             1,
             ArgLen::Dword,
@@ -453,7 +462,7 @@ fn create_vmm_ioctl_seccomp_rule_kvm() -> Result<Vec<SeccompRule>, BackendError>
     Ok(common_rules)
 }
 
-#[cfg(all(target_arch = "x86_64", feature = "mshv"))]
+#[cfg(feature = "mshv")]
 fn create_vmm_ioctl_seccomp_rule_mshv() -> Result<Vec<SeccompRule>, BackendError> {
     create_vmm_ioctl_seccomp_rule_common(HypervisorType::Mshv)
 }


### PR DESCRIPTION
Certain MSHV ioctls are only available on x86 architecture. Thus, conditionally compile seccomp filter for x86 and in general enable seccomp filters when compiling for MSHV on aarch64.