### PR TITLE
ci: improve gitlint

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,6 +1,7 @@
 [general]
-extra-path=scripts/gitlint/rules.py
+extra-path=scripts/gitlint/rules
 regex-style-search=true
+ignore=body-max-line-length
 
 [ignore-by-author-name]
 regex=dependabot
@@ -10,11 +11,3 @@ ignore=all
 [title-max-length]
 line-length=72
 
-# default 80
-[body-max-line-length]
-line-length=72
-
-# Allow developers to add long links to useful resources
-[ignore-by-body]
-regex=^https?:\/\/
-ignore=body-max-line-length

--- a/scripts/gitlint/rules/BodyMaxLineLengthEx.py
+++ b/scripts/gitlint/rules/BodyMaxLineLengthEx.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from gitlint.rules import LineRule, RuleViolation, CommitMessageBody
+import re
+
+
+class BodyMaxLineLengthEx(LineRule):
+    """A rule to enforce a line limit of 72 characters, except for valid cases."""
+
+    # A rule MUST have a human friendly name
+    name = "body-max-line-length-ex"
+
+    # A rule MUST have a *unique* id.
+    # We recommend starting with UL (for User-defined Line-rule)
+    id = "UL-ll"
+
+    # A line-rule MUST have a target (not required for CommitRules).
+    target = CommitMessageBody
+
+    max_len = 72
+
+    # Updated property as the commit messages is validated line by line.
+    inside_open_codeblock = False
+
+    def validate(self, line, commit):
+        # Pattern allowing:
+        # - [0]: https://foobar
+        # - [0] https://foobar
+        # - https://foobar
+        link_regex = re.compile(r"^((\[[0-9]+\]:?\s?)?https?:\/\/).*$")
+
+        is_codeblock_marker = line.startswith("```")
+
+        inside_open_codeblock_ = self.inside_open_codeblock
+        if is_codeblock_marker:
+            self.inside_open_codeblock = not self.inside_open_codeblock
+
+        if len(line) > self.max_len:
+            is_link = link_regex.match(line)
+
+            if inside_open_codeblock_:
+                return
+
+            if is_link:
+                return
+
+            return [
+                RuleViolation(self.id, f"Line '{line}' exceeds limit of {self.max_len}")
+            ]

--- a/scripts/gitlint/rules/TitleStartsWithComponent.py
+++ b/scripts/gitlint/rules/TitleStartsWithComponent.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 from gitlint.rules import LineRule, RuleViolation, CommitMessageTitle
 import re
 


### PR DESCRIPTION
Follow-up of 5aa1540c5dc33d61020a08dd2818c0f5fd08575f (#6989) but way more mature.
It is not perfect but better than what we have.

Allowed to exceed the 72 wide limit are now:

1. links in the following three common patterns:

https://example.com/very-long-links/very-long-links/very-long-links/very-long-links/very-long-links/very-long-links/very-long-links
[0] https://example.com/very-long-links/very-long-links/very-long-links/very-long-links/very-long-links/very-long-links/very-long-links
[0]:
https://example.com/very-long-links/very-long-links/very-long-links/very-long-links/very-long-links/very-long-links/very-long-links

2. code blocks

```
let x = "very_long_very_long_very_long_very_long_very_long_very_long_very_long_very_long_very_long_very_long_"
```


On-behalf-of: SAP philipp.schuster@sap.com