### PR TITLE
hypervisor: Enable MSHV compilation on ARM64

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -56,6 +56,20 @@ jobs:
           command: clippy
           args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
+      - name: Clippy (mshv)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
+          command: clippy
+          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "mshv" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+
+      - name: Clippy (mshv + kvm)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
+          command: clippy
+          args: --target=${{ matrix.target }} --locked --all --all-targets --no-default-features --tests --examples --features "mshv,kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+
       - name: Clippy (default features)
         uses: actions-rs/cargo@v1
         with:

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -36,7 +36,7 @@ pub mod arch;
 pub mod kvm;
 
 /// Microsoft Hypervisor implementation module
-#[cfg(all(feature = "mshv", target_arch = "x86_64"))]
+#[cfg(feature = "mshv")]
 pub mod mshv;
 
 /// Hypervisor related module
@@ -148,7 +148,7 @@ pub const USER_MEMORY_REGION_ADJUSTABLE: u32 = 1 << 4;
 pub enum MpState {
     #[cfg(feature = "kvm")]
     Kvm(kvm_bindings::kvm_mp_state),
-    #[cfg(all(feature = "mshv", target_arch = "x86_64"))]
+    #[cfg(feature = "mshv")]
     Mshv, /* MSHV does not support MpState yet */
 }
 

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -528,6 +528,7 @@ unsafe impl Send for Ghcb {}
 unsafe impl Sync for Ghcb {}
 
 /// Vcpu struct for Microsoft Hypervisor
+#[allow(dead_code)]
 pub struct MshvVcpu {
     fd: VcpuFd,
     vp_index: u8,
@@ -1283,7 +1284,7 @@ impl cpu::Vcpu for MshvVcpu {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn init_pmu(&self, irq: u32) -> cpu::Result<()> {
+    fn init_pmu(&self, _irq: u32) -> cpu::Result<()> {
         unimplemented!()
     }
 
@@ -1293,12 +1294,12 @@ impl cpu::Vcpu for MshvVcpu {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn setup_regs(&self, cpu_id: u8, boot_ip: u64, fdt_start: u64) -> cpu::Result<()> {
+    fn setup_regs(&self, _cpu_id: u8, _boot_ip: u64, _fdt_start: u64) -> cpu::Result<()> {
         unimplemented!()
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn get_sys_reg(&self, sys_reg: u32) -> cpu::Result<u64> {
+    fn get_sys_reg(&self, _sys_reg: u32) -> cpu::Result<u64> {
         unimplemented!()
     }
 
@@ -1444,7 +1445,7 @@ impl cpu::Vcpu for MshvVcpu {
     ///
     /// Set CPU state for aarch64 guest.
     ///
-    fn set_state(&self, state: &CpuState) -> cpu::Result<()> {
+    fn set_state(&self, _state: &CpuState) -> cpu::Result<()> {
         unimplemented!()
     }
 
@@ -2170,7 +2171,7 @@ impl vm::Vm for MshvVm {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn create_vgic(&self, config: VgicConfig) -> vm::Result<Arc<Mutex<dyn Vgic>>> {
+    fn create_vgic(&self, _config: VgicConfig) -> vm::Result<Arc<Mutex<dyn Vgic>>> {
         unimplemented!()
     }
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -2934,14 +2934,18 @@ mod tests {
 #[cfg(target_arch = "aarch64")]
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "kvm")]
     use std::mem;
 
     use arch::aarch64::regs;
     use arch::layout;
+    #[cfg(feature = "kvm")]
     use hypervisor::kvm::aarch64::is_system_register;
+    #[cfg(feature = "kvm")]
     use hypervisor::kvm::kvm_bindings::{
         user_pt_regs, KVM_REG_ARM64, KVM_REG_ARM64_SYSREG, KVM_REG_ARM_CORE, KVM_REG_SIZE_U64,
     };
+    #[cfg(feature = "kvm")]
     use hypervisor::{arm64_core_reg_id, offset_of};
 
     #[test]
@@ -2975,6 +2979,7 @@ mod tests {
         assert_eq!(vcpu.get_sys_reg(regs::MPIDR_EL1).unwrap(), 0x80000000);
     }
 
+    #[cfg(feature = "kvm")]
     #[test]
     fn test_is_system_register() {
         let offset = offset_of!(user_pt_regs, pc);


### PR DESCRIPTION
With these changes we can now compile cloud-hypervisor for MSHV on ARM64. There are still some follow up changes required that would be required to launch a guest on MSHV ARM64 which would be published in the upcoming PRs.