### PR TITLE
build: Centralize igvm crates to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ members = [
 ]
 
 [workspace.dependencies]
+# rust-vmm crates
 acpi_tables = { git = "https://github.com/rust-vmm/acpi_tables", branch = "main" }
 kvm-bindings = "0.10.0"
 kvm-ioctls = "0.19.1"
@@ -119,3 +120,7 @@ virtio-queue = "0.14.0"
 vm-fdt = { git = "https://github.com/rust-vmm/vm-fdt", branch = "main" }
 vm-memory = "0.16.1"
 vmm-sys-util = "0.12.1"
+
+# igvm crates
+igvm = "0.3.4"
+igvm_defs = "0.3.1"

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -18,8 +18,8 @@ arc-swap = "1.7.1"
 byteorder = "1.5.0"
 cfg-if = "1.0.0"
 concat-idents = "1.1.5"
-igvm = { version = "0.3.4", optional = true }
-igvm_defs = { version = "0.3.1", optional = true }
+igvm = { workspace = true, optional = true }
+igvm_defs = { workspace = true, optional = true }
 kvm-bindings = { workspace = true, optional = true, features = ["serde"] }
 kvm-ioctls = { workspace = true, optional = true }
 libc = "0.2.167"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -44,8 +44,8 @@ gdbstub = { version = "0.7.1", optional = true }
 gdbstub_arch = { version = "0.3.0", optional = true }
 hex = { version = "0.4.3", optional = true }
 hypervisor = { path = "../hypervisor" }
-igvm = { version = "0.3.4", optional = true }
-igvm_defs = { version = "0.3.1", optional = true }
+igvm = { workspace = true, optional = true }
+igvm_defs = { workspace = true, optional = true }
 landlock = "0.4.0"
 libc = "0.2.167"
 linux-loader = { workspace = true, features = ["bzimage", "elf", "pe"] }


### PR DESCRIPTION
`igvm` crates are referenced by multiple components, centralize them to workspace to better manage those crates.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>