### PR TITLE
misc: Fix clippy error from beta compiler

### DIFF
--- a/block/src/qcow/mod.rs
+++ b/block/src/qcow/mod.rs
@@ -1625,8 +1625,7 @@ impl FileSync for QcowFile {
 
 impl FileSetLen for QcowFile {
     fn set_len(&self, _len: u64) -> std::io::Result<()> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        Err(std::io::Error::other(
             "set_len() not supported for QcowFile",
         ))
     }

--- a/block/src/vhdx/mod.rs
+++ b/block/src/vhdx/mod.rs
@@ -111,12 +111,9 @@ impl Read for Vhdx {
             sector_count,
         )
         .map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!(
-                    "Failed reading {sector_count} sectors from VHDx at index {sector_index}: {e}"
-                ),
-            )
+            std::io::Error::other(format!(
+                "Failed reading {sector_count} sectors from VHDx at index {sector_index}: {e}"
+            ))
         })?;
 
         self.current_offset = self.current_offset.checked_add(result as u64).unwrap();
@@ -138,12 +135,9 @@ impl Write for Vhdx {
 
         if self.first_write {
             self.first_write = false;
-            self.vhdx_header.update(&mut self.file).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("Failed to update VHDx header: {e}"),
-                )
-            })?;
+            self.vhdx_header
+                .update(&mut self.file)
+                .map_err(|e| std::io::Error::other(format!("Failed to update VHDx header: {e}")))?;
         }
 
         let result = vhdx_io::write(
@@ -156,12 +150,9 @@ impl Write for Vhdx {
             sector_count,
         )
         .map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!(
-                    "Failed writing {sector_count} sectors on VHDx at index {sector_index}: {e}"
-                ),
-            )
+            std::io::Error::other(format!(
+                "Failed writing {sector_count} sectors on VHDx at index {sector_index}: {e}"
+            ))
         })?;
 
         self.current_offset = self.current_offset.checked_add(result as u64).unwrap();

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1813,7 +1813,7 @@ impl vm::Vm for MshvVm {
                     MSHV_VP_MMAP_OFFSET_GHCB as i64 * libc::sysconf(libc::_SC_PAGE_SIZE),
                 )
             };
-            if addr == libc::MAP_FAILED {
+            if std::ptr::eq(addr, libc::MAP_FAILED) {
                 // No point of continuing, without this mmap VMGEXIT will fail anyway
                 // Return error
                 return Err(vm::HypervisorVmError::MmapToRoot);

--- a/net_util/src/mac.rs
+++ b/net_util/src/mac.rs
@@ -25,10 +25,10 @@ impl MacAddr {
     {
         let v: Vec<&str> = s.as_ref().split(':').collect();
         let mut bytes = [0u8; MAC_ADDR_LEN];
-        let common_err = Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("parsing of {} into a MAC address failed", s.as_ref()),
-        ));
+        let common_err = Err(io::Error::other(format!(
+            "parsing of {} into a MAC address failed",
+            s.as_ref()
+        )));
 
         if v.len() != MAC_ADDR_LEN {
             return common_err;
@@ -39,10 +39,11 @@ impl MacAddr {
                 return common_err;
             }
             bytes[i] = u8::from_str_radix(v[i], 16).map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("parsing of {} into a MAC address failed: {}", s.as_ref(), e),
-                )
+                io::Error::other(format!(
+                    "parsing of {} into a MAC address failed: {}",
+                    s.as_ref(),
+                    e
+                ))
             })?;
         }
 
@@ -64,10 +65,11 @@ impl MacAddr {
     #[inline]
     pub fn from_bytes(src: &[u8]) -> Result<MacAddr, io::Error> {
         if src.len() != MAC_ADDR_LEN {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("invalid length of slice: {} vs {}", src.len(), MAC_ADDR_LEN),
-            ));
+            return Err(io::Error::other(format!(
+                "invalid length of slice: {} vs {}",
+                src.len(),
+                MAC_ADDR_LEN
+            )));
         }
         Ok(MacAddr::from_bytes_unchecked(src))
     }

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1613,7 +1613,7 @@ impl VfioPciDevice {
                         )
                     };
 
-                    if host_addr == libc::MAP_FAILED {
+                    if std::ptr::eq(host_addr, libc::MAP_FAILED) {
                         error!(
                             "Could not mmap sparse area (offset = 0x{:x}, size = 0x{:x}): {}",
                             area.offset,

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -476,7 +476,7 @@ impl PciDevice for VfioUserPciDevice {
 
                     self.vm
                         .remove_user_memory_region(old_region)
-                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                        .map_err(std::io::Error::other)?;
 
                     // Update the user memory region with the correct start address.
                     if new_base > old_base {
@@ -497,7 +497,7 @@ impl PciDevice for VfioUserPciDevice {
 
                     self.vm
                         .create_user_memory_region(new_region)
-                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                        .map_err(std::io::Error::other)?;
                 }
                 info!("Moved bar 0x{:x} -> 0x{:x}", old_base, new_base);
             }
@@ -582,17 +582,11 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioUserDmaMappi
                 .lock()
                 .unwrap()
                 .dma_map(offset, iova, size, file_offset.file().as_raw_fd())
-                .map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("Error mapping region: {e}"),
-                    )
-                })
+                .map_err(|e| std::io::Error::other(format!("Error mapping region: {e}")))
         } else {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Region not found for 0x{gpa:x}"),
-            ))
+            Err(std::io::Error::other(format!(
+                "Region not found for 0x{gpa:x}"
+            )))
         }
     }
 
@@ -601,11 +595,6 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioUserDmaMappi
             .lock()
             .unwrap()
             .dma_unmap(iova, size)
-            .map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("Error unmapping region: {e}"),
-                )
-            })
+            .map_err(|e| std::io::Error::other(format!("Error unmapping region: {e}")))
     }
 }

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -169,7 +169,7 @@ impl VfioUserPciDevice {
                         )
                     };
 
-                    if host_addr == libc::MAP_FAILED {
+                    if std::ptr::eq(host_addr, libc::MAP_FAILED) {
                         error!(
                             "Could not mmap regions, error:{}",
                             std::io::Error::last_os_error()

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1328,8 +1328,7 @@ impl<'a> GuestCommand<'a> {
             if pipesize >= PIPE_SIZE && pipesize1 >= PIPE_SIZE {
                 Ok(child)
             } else {
-                Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
+                Err(std::io::Error::other(
                     format!(
                         "resizing pipe w/ 'fnctl' failed: stdout pipesize {pipesize}, stderr pipesize {pipesize1}"
                     ),

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -83,7 +83,7 @@ impl error::Error for Error {}
 
 impl convert::From<Error> for io::Error {
     fn from(e: Error) -> Self {
-        io::Error::new(io::ErrorKind::Other, e)
+        io::Error::other(e)
     }
 }
 

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -69,7 +69,7 @@ impl std::error::Error for Error {}
 
 impl std::convert::From<Error> for std::io::Error {
     fn from(e: Error) -> Self {
-        std::io::Error::new(io::ErrorKind::Other, e)
+        std::io::Error::other(e)
     }
 }
 

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -608,12 +608,9 @@ impl Block {
                     true,
                 )
             } else {
-                let disk_size = disk_image.size().map_err(|e| {
-                    io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("Failed getting disk size: {e}"),
-                    )
-                })?;
+                let disk_size = disk_image
+                    .size()
+                    .map_err(|e| io::Error::other(format!("Failed getting disk size: {e}")))?;
                 if disk_size % SECTOR_SIZE != 0 {
                     warn!(
                         "Disk size {} is not a multiple of sector size {}; \

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -822,10 +822,9 @@ impl DmaRemapping for IommuMapping {
             return Ok(addr);
         }
 
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("failed to translate GVA addr 0x{addr:x}"),
-        ))
+        Err(io::Error::other(format!(
+            "failed to translate GVA addr 0x{addr:x}"
+        )))
     }
 
     fn translate_gpa(&self, id: u32, addr: u64) -> std::result::Result<u64, std::io::Error> {
@@ -850,10 +849,9 @@ impl DmaRemapping for IommuMapping {
             return Ok(addr);
         }
 
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("failed to translate GPA addr 0x{addr:x}"),
-        ))
+        Err(io::Error::other(format!(
+            "failed to translate GPA addr 0x{addr:x}"
+        )))
     }
 }
 

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -723,10 +723,9 @@ impl Mem {
         let region_len = region.len();
 
         if region_len != region_len / VIRTIO_MEM_ALIGN_SIZE * VIRTIO_MEM_ALIGN_SIZE {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("Virtio-mem size is not aligned with {VIRTIO_MEM_ALIGN_SIZE}"),
-            ));
+            return Err(io::Error::other(format!(
+                "Virtio-mem size is not aligned with {VIRTIO_MEM_ALIGN_SIZE}"
+            )));
         }
 
         let (avail_features, acked_features, config, paused) = if let Some(state) = state {
@@ -753,12 +752,9 @@ impl Mem {
 
             if initial_size != 0 {
                 config.resize(initial_size).map_err(|e| {
-                    io::Error::new(
-                        io::ErrorKind::Other,
-                        format!(
-                            "Failed to resize virtio-mem configuration to {initial_size}: {e:?}"
-                        ),
-                    )
+                    io::Error::other(format!(
+                        "Failed to resize virtio-mem configuration to {initial_size}: {e:?}"
+                    ))
                 })?;
             }
 
@@ -770,10 +766,7 @@ impl Mem {
             // Make sure the virtio-mem configuration complies with the
             // specification.
             config.validate().map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("Invalid virtio-mem configuration: {e:?}"),
-                )
+                io::Error::other(format!("Invalid virtio-mem configuration: {e:?}"))
             })?;
 
             (avail_features, 0, config, false)

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -541,13 +541,10 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VdpaDmaMapping<M
         let user_addr = if mem.check_range(guest_addr, size as usize) {
             mem.get_host_address(guest_addr).unwrap() as *const u8
         } else {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!(
-                    "failed to convert guest address 0x{gpa:x} into \
+            return Err(io::Error::other(format!(
+                "failed to convert guest address 0x{gpa:x} into \
                      host user virtual address"
-                ),
-            ));
+            )));
         };
 
         debug!(
@@ -559,13 +556,10 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VdpaDmaMapping<M
             .unwrap()
             .dma_map(iova, size, user_addr, false)
             .map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!(
-                        "failed to map memory for vDPA device, \
+                io::Error::other(format!(
+                    "failed to map memory for vDPA device, \
                          iova 0x{iova:x}, gpa 0x{gpa:x}, size 0x{size:x}: {e:?}"
-                    ),
-                )
+                ))
             })
     }
 
@@ -576,13 +570,10 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VdpaDmaMapping<M
             .unwrap()
             .dma_unmap(iova, size)
             .map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!(
-                        "failed to unmap memory for vDPA device, \
+                io::Error::other(format!(
+                    "failed to unmap memory for vDPA device, \
                      iova 0x{iova:x}, size 0x{size:x}: {e:?}"
-                    ),
-                )
+                ))
             })
     }
 }

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -215,10 +215,9 @@ impl<S: VhostUserFrontendReqHandler> VhostUserEpollHandler<S> {
             true,
         )
         .map_err(|e| {
-            EpollHelperError::IoError(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("failed connecting vhost-user backend {e:?}"),
-            ))
+            EpollHelperError::IoError(std::io::Error::other(format!(
+                "failed connecting vhost-user backend {e:?}"
+            )))
         })?;
 
         // Initialize the backend
@@ -236,10 +235,9 @@ impl<S: VhostUserFrontendReqHandler> VhostUserEpollHandler<S> {
                 self.inflight.as_mut(),
             )
             .map_err(|e| {
-                EpollHelperError::IoError(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("failed reconnecting vhost-user backend: {e:?}"),
-                ))
+                EpollHelperError::IoError(std::io::Error::other(format!(
+                    "failed reconnecting vhost-user backend: {e:?}"
+                )))
             })?;
 
         helper.add_event_custom(

--- a/vm-allocator/src/address.rs
+++ b/vm-allocator/src/address.rs
@@ -148,7 +148,7 @@ impl AddressAllocator {
             if let Some(size_delta) =
                 address.checked_sub(self.align_address(prev_end_address, alignment).raw_value())
             {
-                let adjust = if alignment > 1 { alignment - 1 } else { 0 };
+                let adjust = alignment.saturating_sub(1);
                 if size_delta.raw_value() >= req_size {
                     return Some(
                         self.align_address(address.unchecked_sub(req_size + adjust), alignment),

--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -73,7 +73,7 @@ impl error::Error for Error {}
 
 impl convert::From<Error> for io::Error {
     fn from(e: Error) -> Self {
-        io::Error::new(io::ErrorKind::Other, e)
+        io::Error::other(e)
     }
 }
 

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -31,7 +31,7 @@ impl InterruptRoute {
         let irq_fd = EventFd::new(libc::EFD_NONBLOCK)?;
         let gsi = allocator
             .allocate_gsi()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Failed allocating new GSI"))?;
+            .ok_or_else(|| io::Error::other("Failed allocating new GSI"))?;
 
         Ok(InterruptRoute {
             gsi,
@@ -42,12 +42,8 @@ impl InterruptRoute {
 
     pub fn enable(&self, vm: &Arc<dyn hypervisor::Vm>) -> Result<()> {
         if !self.registered.load(Ordering::Acquire) {
-            vm.register_irqfd(&self.irq_fd, self.gsi).map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("Failed registering irq_fd: {e}"),
-                )
-            })?;
+            vm.register_irqfd(&self.irq_fd, self.gsi)
+                .map_err(|e| io::Error::other(format!("Failed registering irq_fd: {e}")))?;
 
             // Update internals to track the irq_fd as "registered".
             self.registered.store(true, Ordering::Release);
@@ -58,12 +54,8 @@ impl InterruptRoute {
 
     pub fn disable(&self, vm: &Arc<dyn hypervisor::Vm>) -> Result<()> {
         if self.registered.load(Ordering::Acquire) {
-            vm.unregister_irqfd(&self.irq_fd, self.gsi).map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("Failed unregistering irq_fd: {e}"),
-                )
-            })?;
+            vm.unregister_irqfd(&self.irq_fd, self.gsi)
+                .map_err(|e| io::Error::other(format!("Failed unregistering irq_fd: {e}")))?;
 
             // Update internals to track the irq_fd as "unregistered".
             self.registered.store(false, Ordering::Release);
@@ -107,12 +99,9 @@ impl MsiInterruptGroup {
             entry_vec.push(entry.route);
         }
 
-        self.vm.set_gsi_routing(&entry_vec).map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("Failed setting GSI routing: {e}"),
-            )
-        })
+        self.vm
+            .set_gsi_routing(&entry_vec)
+            .map_err(|e| io::Error::other(format!("Failed setting GSI routing: {e}")))
     }
 }
 
@@ -152,10 +141,9 @@ impl InterruptSourceGroup for MsiInterruptGroup {
             return route.trigger();
         }
 
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("trigger: Invalid interrupt index {index}"),
-        ))
+        Err(io::Error::other(format!(
+            "trigger: Invalid interrupt index {index}"
+        )))
     }
 
     fn notifier(&self, index: InterruptIndex) -> Option<EventFd> {
@@ -203,10 +191,9 @@ impl InterruptSourceGroup for MsiInterruptGroup {
             return Ok(());
         }
 
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("update: Invalid interrupt index {index}"),
-        ))
+        Err(io::Error::other(format!(
+            "update: Invalid interrupt index {index}"
+        )))
     }
 
     fn set_gsi(&self) -> Result<()> {
@@ -232,12 +219,7 @@ impl InterruptSourceGroup for LegacyUserspaceInterruptGroup {
             .lock()
             .unwrap()
             .service_irq(self.irq as usize)
-            .map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("failed to inject IRQ #{}: {:?}", self.irq, e),
-                )
-            })
+            .map_err(|e| io::Error::other(format!("failed to inject IRQ #{}: {:?}", self.irq, e)))
     }
 
     fn update(


### PR DESCRIPTION
Rust has a new way of constructing other error and clippy complains if we are still using the older way to construct error message. Thus, migrate to the new approach suggested by the clippy.