### PR TITLE
vmm: openapi: Remove `path` as required for `DiskConfig`

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -885,8 +885,6 @@ components:
             type: integer
 
     DiskConfig:
-      required:
-        - path
       type: object
       properties:
         path:


### PR DESCRIPTION
This aligns with our CLI syntax. The correctness of `DiskConfig` will be ensured via `VmConfig::validate()`, e.g. `path` and `socket` are mutually exclusive.

Fixes: #7016