### PR TITLE
pci: be more robust when parsing PCI capabilities

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -11,6 +11,9 @@ exclude = [
 
     # GitHub user smibarber referenced in `CREDITS.md` no longer exist
     '^https://github.com/smibarber',
+
+    # OSDev has added bot protection and accesses my result in 403 Forbidden.
+    '^https://wiki.osdev.org',
 ]
 
 max_retries = 3

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -804,7 +804,7 @@ impl VfioCommon {
         Ok(())
     }
 
-    pub(crate) fn parse_msix_capabilities(&mut self, cap: u8) -> MsixCap {
+    fn parse_msix_capabilities(&mut self, cap: u8) -> MsixCap {
         let msg_ctl = self.vfio_wrapper.read_config_word((cap + 2).into());
 
         let table = self.vfio_wrapper.read_config_dword((cap + 4).into());
@@ -818,7 +818,7 @@ impl VfioCommon {
         }
     }
 
-    pub(crate) fn initialize_msix(
+    fn initialize_msix(
         &mut self,
         msix_cap: MsixCap,
         cap_offset: u32,
@@ -849,16 +849,11 @@ impl VfioCommon {
         });
     }
 
-    pub(crate) fn parse_msi_capabilities(&mut self, cap: u8) -> u16 {
+    fn parse_msi_capabilities(&mut self, cap: u8) -> u16 {
         self.vfio_wrapper.read_config_word((cap + 2).into())
     }
 
-    pub(crate) fn initialize_msi(
-        &mut self,
-        msg_ctl: u16,
-        cap_offset: u32,
-        state: Option<MsiConfigState>,
-    ) {
+    fn initialize_msi(&mut self, msg_ctl: u16, cap_offset: u32, state: Option<MsiConfigState>) {
         let interrupt_source_group = self
             .msi_interrupt_manager
             .create_group(MsiIrqGroupConfig {
@@ -877,12 +872,12 @@ impl VfioCommon {
     }
 
     /// Returns true, if the device claims to have a PCI capability list.
-    pub(crate) fn has_capabilities(&self) -> bool {
+    fn has_capabilities(&self) -> bool {
         let status = self.vfio_wrapper.read_config_word(PCI_CONFIG_STATUS_OFFSET);
         status & PCI_CONFIG_STATUS_CAPABILITIES_LIST != 0
     }
 
-    pub(crate) fn get_msix_cap_idx(&self) -> Option<usize> {
+    fn get_msix_cap_idx(&self) -> Option<usize> {
         if !self.has_capabilities() {
             return None;
         }
@@ -912,7 +907,7 @@ impl VfioCommon {
         None
     }
 
-    pub(crate) fn parse_capabilities(&mut self, bdf: PciBdf) {
+    fn parse_capabilities(&mut self, bdf: PciBdf) {
         if !self.has_capabilities() {
             return;
         }
@@ -1122,7 +1117,7 @@ impl VfioCommon {
         }
     }
 
-    pub(crate) fn initialize_legacy_interrupt(&mut self) -> Result<(), VfioPciError> {
+    fn initialize_legacy_interrupt(&mut self) -> Result<(), VfioPciError> {
         if let Some(irq_info) = self.vfio_wrapper.get_irq_info(VFIO_PCI_INTX_IRQ_INDEX) {
             if irq_info.count == 0 {
                 // A count of 0 means the INTx IRQ is not supported, therefore
@@ -1143,11 +1138,7 @@ impl VfioCommon {
         Ok(())
     }
 
-    pub(crate) fn update_msi_capabilities(
-        &mut self,
-        offset: u64,
-        data: &[u8],
-    ) -> Result<(), VfioPciError> {
+    fn update_msi_capabilities(&mut self, offset: u64, data: &[u8]) -> Result<(), VfioPciError> {
         match self.interrupt.update_msi(offset, data) {
             Some(InterruptUpdateAction::EnableMsi) => {
                 // Disable INTx before we can enable MSI
@@ -1165,11 +1156,7 @@ impl VfioCommon {
         Ok(())
     }
 
-    pub(crate) fn update_msix_capabilities(
-        &mut self,
-        offset: u64,
-        data: &[u8],
-    ) -> Result<(), VfioPciError> {
+    fn update_msix_capabilities(&mut self, offset: u64, data: &[u8]) -> Result<(), VfioPciError> {
         match self.interrupt.update_msix(offset, data) {
             Some(InterruptUpdateAction::EnableMsix) => {
                 // Disable INTx before we can enable MSI-X
@@ -1187,7 +1174,7 @@ impl VfioCommon {
         Ok(())
     }
 
-    pub(crate) fn find_region(&self, addr: u64) -> Option<MmioRegion> {
+    fn find_region(&self, addr: u64) -> Option<MmioRegion> {
         for region in self.mmio_regions.iter() {
             if addr >= region.start.raw_value()
                 && addr < region.start.unchecked_add(region.length).raw_value()

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -889,14 +889,16 @@ impl VfioCommon {
 
         let mut cap_next = self
             .vfio_wrapper
-            .read_config_byte(PCI_CONFIG_CAPABILITY_OFFSET);
+            .read_config_byte(PCI_CONFIG_CAPABILITY_OFFSET)
+            & PCI_CONFIG_CAPABILITY_PTR_MASK;
 
         while cap_next != 0 {
             let cap_id = self.vfio_wrapper.read_config_byte(cap_next.into());
             if PciCapabilityId::from(cap_id) == PciCapabilityId::MsiX {
                 return Some(cap_next as usize);
             } else {
-                cap_next = self.vfio_wrapper.read_config_byte((cap_next + 1).into());
+                cap_next = self.vfio_wrapper.read_config_byte((cap_next + 1).into())
+                    & PCI_CONFIG_CAPABILITY_PTR_MASK;
             }
         }
 
@@ -910,7 +912,8 @@ impl VfioCommon {
 
         let mut cap_iter = self
             .vfio_wrapper
-            .read_config_byte(PCI_CONFIG_CAPABILITY_OFFSET);
+            .read_config_byte(PCI_CONFIG_CAPABILITY_OFFSET)
+            & PCI_CONFIG_CAPABILITY_PTR_MASK;
 
         let mut pci_express_cap_found = false;
         let mut power_management_cap_found = false;
@@ -945,7 +948,8 @@ impl VfioCommon {
                 _ => {}
             };
 
-            let cap_next = self.vfio_wrapper.read_config_byte((cap_iter + 1).into());
+            let cap_next = self.vfio_wrapper.read_config_byte((cap_iter + 1).into())
+                & PCI_CONFIG_CAPABILITY_PTR_MASK;
             if cap_next == 0 {
                 break;
             }
@@ -1799,6 +1803,8 @@ const PCI_CONFIG_STATUS_CAPABILITIES_LIST: u16 = 1 << 4;
 const PCI_CONFIG_BAR_OFFSET: u32 = 0x10;
 // Capability register offset in the PCI config space.
 const PCI_CONFIG_CAPABILITY_OFFSET: u32 = 0x34;
+// The valid bits for the capabilities pointer.
+const PCI_CONFIG_CAPABILITY_PTR_MASK: u8 = !0b11;
 // Extended capabilities register offset in the PCI config space.
 const PCI_CONFIG_EXTENDED_CAPABILITY_OFFSET: u32 = 0x100;
 // IO BAR when first BAR bit is 1.


### PR DESCRIPTION
When devices don't implement a capabilities list or just return 0xFF for the capabilities pointer sad things happen. It typically boils down to receiving 0xFF from the capabilities register. In debug builds, this will then crash the VMM, because `cap_iter + 1` overflows:

```
thread 'vmm' panicked at pci/src/vfio.rs:934:63:
attempt to add with overflow
```

Fix by:

- checking whether the device claims to have a capability list,
- terminate the checking loop if the capability points to itself.

A very broken (malicious) device might still send this code into an endless loop, but I assume this is not part of the threat model and we don't want to overcomplicate this code.

It would be nice to implement a small iterator for the capability list, so we don't have to duplicate the logic (and quirks handling). If this is interesting, please say so. :)

While I was here, I also changed the capability pointer handling to follow the PCI spec and mask out the lowest two bits. See PCI Local Bus Specification 3.0 Chapter 6.7 "Capabilities List".