### PR TITLE
Bump various dependencies to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,9 +1254,9 @@ checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
 name = "mshv-bindings"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f83f36cb864d90b62a4576556cef3319603d02f3aca58a87694e1e0694bdda"
+checksum = "cd4aa8157010f69f380a86a0ba087167b0a01e2e3f2bcca5b576bd26a9206dc8"
 dependencies = [
  "libc",
  "num_enum",
@@ -1268,9 +1268,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd6d081aa1eb9916b8f2ac89a6f22adaaa9b5308c71ff5f14332143dc52aaf6"
+checksum = "f2bdc151fdc265efbb20f6c74e235dcdbce9a54e695655ac88b4db7385b26319"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ acpi_tables = { git = "https://github.com/rust-vmm/acpi_tables", branch = "main"
 kvm-bindings = "0.10.0"
 kvm-ioctls = "0.19.1"
 linux-loader = "0.13.0"
-mshv-bindings = "0.3.3"
-mshv-ioctls = "0.3.3"
+mshv-bindings = "0.3.5"
+mshv-ioctls = "0.3.5"
 seccompiler = "0.5.0"
 vfio-bindings = { git = "https://github.com/rust-vmm/vfio", branch = "main" }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }


### PR DESCRIPTION
- zerocopy from 0.7x to 0.8.x
- mshv crates from 0.3.3 to 0.3.5