### PR TITLE
pci: vfio: make DMA mapping errors non-fatal

### DIFF
--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1662,8 +1662,12 @@ impl VfioPciDevice {
                                 user_memory_region.host_addr,
                             )
                             .map_err(|e| {
-                                VfioPciError::DmaMap(e, self.device_path.clone(), self.bdf)
-                            })?;
+                                error!(
+                                    "{}: p2p operation between pass-through devices may not work",
+                                    VfioPciError::DmaMap(e, self.device_path.clone(), self.bdf)
+                                );
+                            })
+                            .unwrap_or_default();
                     }
                 }
             }


### PR DESCRIPTION
We saw a regression with a VFIO integration test based on cloud-hypervisor nested in QEMU with a virtual XHCI controller, when the DMA mapping failed. The DMA mapping for p2p operation is not strictly mandatory for a working single device pass through.

The root cause of the mapping failure is that the default QEMU iommu only exposes a 39 bit address space, and the MMIO region for the virtual device BAR0 is allocated outside this range. The test was fixed by explicitly providing a full-size IOMMU for the QEMU invocation (`aw_bits=48`), but arguably the current handling is not optimal. Cloud-hypervisor should respect platform iommu limitations when allocating the BAR in the first place.

For now, just emit a loud error message, which corresponds to the expected unmap error message.

Fixes: f0c1f8d07 ("pci: vfio: VFIO_IOMMU_MAP_DMA mmio regions")

Note: the current "fail hard" behavior may be desirable to spot misconfigurations early.