### PR TITLE
devices: Add fw_cfg device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,7 @@ dependencies = [
  "vm-memory",
  "vm-migration",
  "vmm-sys-util",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitfield"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5acf59e2452f0c4b968b15ce4b9468f57b45f7733b919d68b19fcc39264bfb8"
+
+[[package]]
 name = "bitfield-struct"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +570,7 @@ dependencies = [
  "acpi_tables",
  "anyhow",
  "arch",
+ "bitfield",
  "bitflags 2.9.0",
  "byteorder",
  "event_monitor",
@@ -1712,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -2043,9 +2050,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.38.34",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -216,7 +216,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 0.38.34",
  "tracing",
 ]
 
@@ -243,7 +243,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 0.38.34",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -569,6 +569,7 @@ dependencies = [
  "event_monitor",
  "hypervisor",
  "libc",
+ "linux-loader",
  "log",
  "num_enum",
  "pci",
@@ -698,12 +699,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1140,9 +1141,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libredox"
@@ -1194,6 +1195,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "lock_api"
@@ -1671,7 +1678,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.34",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -1849,8 +1856,21 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2034,14 +2054,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.3",
  "windows-sys 0.59.0",
 ]
 
@@ -2051,7 +2071,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ wait-timeout = "0.2.0"
 dbus_api = ["vmm/dbus_api", "zbus"]
 default = ["io_uring", "kvm"]
 dhat-heap = ["dhat", "vmm/dhat-heap"]       # For heap profiling
+fw_cfg = ["vmm/fw_cfg"]
 guest_debug = ["vmm/guest_debug"]
 igvm = ["mshv", "vmm/igvm"]
 io_uring = ["vmm/io_uring"]

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -13,6 +13,7 @@ byteorder = "1.5.0"
 event_monitor = { path = "../event_monitor" }
 hypervisor = { path = "../hypervisor" }
 libc = "0.2.167"
+linux-loader = { workspace = true, features = ["bzimage", "elf", "pe"] }
 log = "0.4.22"
 num_enum = "0.7.2"
 pci = { path = "../pci" }

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -9,6 +9,7 @@ acpi_tables = { workspace = true }
 anyhow = "1.0.94"
 arch = { path = "../arch" }
 bitflags = "2.9.0"
+bitfield = "0.16.1"
 byteorder = "1.5.0"
 event_monitor = { path = "../event_monitor" }
 hypervisor = { path = "../hypervisor" }

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -28,6 +28,7 @@ vm-memory = { workspace = true, features = [
 ] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { workspace = true }
+zerocopy = { version = "0.8.24", features = ["alloc", "derive"] }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]
 arch = { path = "../arch" }

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -16,14 +16,16 @@
 /// We implement the functionality necessary to use Oak's Stage0 Firmware
 /// (This includes most of the functionality, besides adding additional
 /// items to the fw_cfg device for the firmware).
+use linux_loader::bootparam::boot_params;
 use std::{
     fs::File,
     io::Result,
-    mem::size_of_val,
+    mem::{size_of, size_of_val},
     os::unix::fs::FileExt,
     sync::{Arc, Barrier},
 };
 use vm_device::BusDevice;
+use vm_memory::ByteValued;
 use vmm_sys_util::sock_ctrl_msg::IntoIovec;
 use zerocopy::{IntoBytes, FromBytes};
 
@@ -171,6 +173,37 @@ impl FwCfg {
         Ok(())
     }
 
+    pub fn add_kernel_data(&mut self, file: &File) -> Result<()> {
+        let mut buffer = vec![0u8; size_of::<boot_params>()];
+        file.read_exact_at(&mut buffer, 0)?;
+        let bp = boot_params::from_mut_slice(&mut buffer).unwrap();
+        if bp.hdr.setup_sects == 0 {
+            bp.hdr.setup_sects = 4;
+        }
+        bp.hdr.type_of_loader = 0xff;
+        let kernel_start = (bp.hdr.setup_sects as usize + 1) * 512;
+        self.known_items[FW_CFG_SETUP_SIZE as usize] = FwCfgContent::U32(buffer.len() as u32);
+        self.known_items[FW_CFG_SETUP_DATA as usize] = FwCfgContent::Bytes(buffer);
+        self.known_items[FW_CFG_KERNEL_SIZE as usize] =
+            FwCfgContent::U32(file.metadata()?.len() as u32 - kernel_start as u32);
+        self.known_items[FW_CFG_KERNEL_DATA as usize] =
+            FwCfgContent::File(kernel_start as u64, file.try_clone()?);
+        Ok(())
+    }
+
+    pub fn add_kernel_cmdline(&mut self, s: std::ffi::CString) {
+        let bytes = s.into_bytes_with_nul();
+        self.known_items[FW_CFG_CMDLINE_SIZE as usize] = FwCfgContent::U32(bytes.len() as u32);
+        self.known_items[FW_CFG_CMDLINE_DATA as usize] = FwCfgContent::Bytes(bytes);
+    }
+
+    pub fn add_initramfs_data(&mut self, file: &File) -> Result<()> {
+        let initramfs_size = file.metadata()?.len();
+        self.known_items[FW_CFG_INITRD_SIZE as usize] = FwCfgContent::U32(initramfs_size as _);
+        self.known_items[FW_CFG_INITRD_DATA as usize] = FwCfgContent::File(0, file.try_clone()?);
+        Ok(())
+    }
+
     fn read_content(content: &FwCfgContent, offset: u32) -> Option<u8> {
         match content {
             FwCfgContent::Bytes(b) => b.get(offset as usize).copied(),
@@ -257,6 +290,10 @@ impl BusDevice for FwCfg {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::CString;
+    use std::io::Write;
+    use vmm_sys_util::tempfile::TempFile;
+
     use super::*;
 
     #[test]
@@ -269,6 +306,53 @@ mod tests {
         fw_cfg.write(0, 0, &[FW_CFG_SIGNATURE as u8, 0]);
         loop {
             if let Some(char) = sig_iter.next() {
+                fw_cfg.read(0, 1, &mut data);
+                assert_eq!(data[0], char);
+            } else {
+                return;
+            }
+        }
+    }
+    #[test]
+    fn test_kernel_cmdline() {
+        let mut fw_cfg = FwCfg::new();
+
+        let cmdline = *b"cmdline\0";
+
+        fw_cfg.add_kernel_cmdline(CString::from_vec_with_nul(cmdline.to_vec()).unwrap());
+
+        let mut data = vec![0u8];
+
+        let mut cmdline_iter = cmdline.into_iter();
+        fw_cfg.write(0, 0, &[FW_CFG_CMDLINE_DATA as u8, 0]);
+        loop {
+            if let Some(char) = cmdline_iter.next() {
+                fw_cfg.read(0, 1, &mut data);
+                assert_eq!(data[0], char);
+            } else {
+                return;
+            }
+        }
+    }
+
+    #[test]
+    fn test_initram_fs() {
+        let mut fw_cfg = FwCfg::new();
+
+        let temp = TempFile::new().unwrap();
+        let mut temp_file = temp.as_file();
+
+        let initram_content = b"this is the initramfs";
+        let written = temp_file.write(initram_content);
+        assert_eq!(written.unwrap(), 21);
+        let _ = fw_cfg.add_initramfs_data(temp_file);
+
+        let mut data = vec![0u8];
+
+        let mut initram_iter = (*initram_content).into_iter();
+        fw_cfg.write(0, 0, &[FW_CFG_INITRD_DATA as u8, 0]);
+        loop {
+            if let Some(char) = initram_iter.next() {
                 fw_cfg.read(0, 1, &mut data);
                 assert_eq!(data[0], char);
             } else {

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -1,0 +1,279 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// NOTE: This is not a full implementation of the qemu fw_cfg spec.
+/// We implement the functionality necessary to use Oak's Stage0 Firmware
+/// (This includes most of the functionality, besides adding additional
+/// items to the fw_cfg device for the firmware).
+use std::{
+    fs::File,
+    io::Result,
+    mem::size_of_val,
+    os::unix::fs::FileExt,
+    sync::{Arc, Barrier},
+};
+use vm_device::BusDevice;
+use vmm_sys_util::sock_ctrl_msg::IntoIovec;
+use zerocopy::{IntoBytes, FromBytes};
+
+pub const PORT_FW_CFG_SELECTOR: u16 = 0x510;
+pub const PORT_FW_CFG_DATA: u16 = 0x511;
+pub const PORT_FW_CFG_DMA_HI: u16 = 0x514;
+pub const PORT_FW_CFG_DMA_LO: u16 = 0x518;
+
+pub const FW_CFG_SIGNATURE: u16 = 0x00;
+pub const FW_CFG_ID: u16 = 0x01;
+pub const FW_CFG_KERNEL_SIZE: u16 = 0x08;
+pub const FW_CFG_INITRD_SIZE: u16 = 0x0b;
+pub const FW_CFG_KERNEL_DATA: u16 = 0x11;
+pub const FW_CFG_INITRD_DATA: u16 = 0x12;
+pub const FW_CFG_CMDLINE_SIZE: u16 = 0x14;
+pub const FW_CFG_CMDLINE_DATA: u16 = 0x15;
+pub const FW_CFG_SETUP_SIZE: u16 = 0x17;
+pub const FW_CFG_SETUP_DATA: u16 = 0x18;
+pub const FW_CFG_FILE_DIR: u16 = 0x19;
+pub const FW_CFG_KNOWN_ITEMS: usize = 0x20;
+
+pub const FW_CFG_FILE_FIRST: u16 = 0x20;
+pub const FW_CFG_DMA_SIGNATURE: [u8; 8] = *b"QEMU CFG";
+// bit 1 must always be enabled, bit 2 enables DMA
+pub const FW_CFG_FEATURE: [u8; 4] = [0b11, 0, 0, 0];
+
+#[derive(Debug)]
+pub enum FwCfgContent {
+    Bytes(Vec<u8>),
+    Slice(&'static [u8]),
+    File(u64, File),
+    U32(u32),
+}
+
+impl Default for FwCfgContent {
+    fn default() -> Self {
+        FwCfgContent::Slice(&[])
+    }
+}
+
+impl FwCfgContent {
+    fn size(&self) -> Result<u32> {
+        let ret = match self {
+            FwCfgContent::Bytes(v) => v.len(),
+            FwCfgContent::File(offset, f) => (f.metadata()?.len() - offset) as usize,
+            FwCfgContent::Slice(s) => s.len(),
+            FwCfgContent::U32(n) => size_of_val(n),
+        };
+        u32::try_from(ret).map_err(|_| std::io::ErrorKind::InvalidInput.into())
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct FwCfgItem {
+    pub name: String,
+    pub content: FwCfgContent,
+}
+
+/// https://www.qemu.org/docs/master/specs/fw_cfg.html
+pub struct FwCfg {
+    selector: u16,
+    data_offset: u32,
+    items: Vec<FwCfgItem>,                           // 0x20 and above
+    known_items: [FwCfgContent; FW_CFG_KNOWN_ITEMS], // 0x0 to 0x19
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes)]
+struct FwCfgFilesHeader {
+    count_be: u32,
+}
+
+pub const FILE_NAME_SIZE: usize = 56;
+
+pub fn create_file_name(name: &str) -> [u8; FILE_NAME_SIZE] {
+    let mut c_name = [0u8; FILE_NAME_SIZE];
+    let c_len = std::cmp::min(FILE_NAME_SIZE - 1, name.len());
+    c_name[0..c_len].copy_from_slice(&name.as_bytes()[0..c_len]);
+    c_name
+}
+
+#[allow(dead_code)]
+#[repr(C, packed)]
+#[derive(Debug, IntoBytes, FromBytes, Clone, Copy)]
+pub struct BootE820Entry {
+    pub addr: u64,
+    pub size: u64,
+    pub type_: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes)]
+struct FwCfgFile {
+    size_be: u32,
+    select_be: u16,
+    _reserved: u16,
+    name: [u8; FILE_NAME_SIZE],
+}
+
+impl FwCfg {
+    pub fn new() -> FwCfg {
+        const DEFAULT_ITEM: FwCfgContent = FwCfgContent::Slice(&[]);
+        let mut known_items = [DEFAULT_ITEM; FW_CFG_KNOWN_ITEMS];
+        known_items[FW_CFG_SIGNATURE as usize] = FwCfgContent::Slice(&FW_CFG_DMA_SIGNATURE);
+        known_items[FW_CFG_ID as usize] = FwCfgContent::Slice(&FW_CFG_FEATURE);
+        let file_buf = Vec::from(FwCfgFilesHeader { count_be: 0 }.as_mut_bytes());
+        known_items[FW_CFG_FILE_DIR as usize] = FwCfgContent::Bytes(file_buf);
+
+        FwCfg {
+            selector: 0,
+            data_offset: 0,
+            items: vec![],
+            known_items,
+        }
+    }
+
+    fn get_file_dir_mut(&mut self) -> &mut Vec<u8> {
+        let FwCfgContent::Bytes(file_buf) = &mut self.known_items[FW_CFG_FILE_DIR as usize] else {
+            unreachable!("fw_cfg: selector {FW_CFG_FILE_DIR:#x} should be FwCfgContent::Byte!")
+        };
+        file_buf
+    }
+
+    fn update_count(&mut self) {
+        let mut header = FwCfgFilesHeader {
+            count_be: (self.items.len() as u32).to_be(),
+        };
+        self.get_file_dir_mut()[0..4].copy_from_slice(header.as_mut_bytes());
+    }
+
+    pub fn add_item(&mut self, item: FwCfgItem) -> Result<()> {
+        let index = self.items.len();
+        let c_name = create_file_name(&item.name);
+        let size = item.content.size()?;
+        let mut cfg_file = FwCfgFile {
+            size_be: size.to_be(),
+            select_be: (FW_CFG_FILE_FIRST + index as u16).to_be(),
+            _reserved: 0,
+            name: c_name,
+        };
+        self.get_file_dir_mut()
+            .extend_from_slice(cfg_file.as_mut_bytes());
+        self.items.push(item);
+        self.update_count();
+        Ok(())
+    }
+
+    fn read_content(content: &FwCfgContent, offset: u32) -> Option<u8> {
+        match content {
+            FwCfgContent::Bytes(b) => b.get(offset as usize).copied(),
+            FwCfgContent::Slice(s) => s.get(offset as usize).copied(),
+            FwCfgContent::File(o, f) => {
+                let mut buf = [0u8];
+                match f.read_exact_at(&mut buf, o + offset as u64) {
+                    Ok(_) => Some(buf[0]),
+                    Err(e) => {
+                        error!("fw_cfg: reading {f:?}: {e:?}");
+                        None
+                    }
+                }
+            }
+            FwCfgContent::U32(n) => n.to_le_bytes().get(offset as usize).copied(),
+        }
+    }
+
+    fn read_data(&mut self) -> u8 {
+        let ret = if let Some(content) = self.known_items.get(self.selector as usize) {
+            Self::read_content(content, self.data_offset)
+        } else if let Some(item) = self.items.get((self.selector - FW_CFG_FILE_FIRST) as usize) {
+            Self::read_content(&item.content, self.data_offset)
+        } else {
+            error!("fw_cfg: selector {:#x} does not exist.", self.selector);
+            None
+        };
+        if let Some(val) = ret {
+            self.data_offset += 1;
+            val
+        } else {
+            0
+        }
+    }
+}
+
+impl BusDevice for FwCfg {
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
+        let port = offset as u16 + PORT_FW_CFG_SELECTOR;
+        let size = data.len();
+        match (port, size) {
+            (PORT_FW_CFG_SELECTOR, _) => {
+                error!("fw_cfg: selector register is write-only.");
+            }
+            (PORT_FW_CFG_DATA, 1) => data[0] = self.read_data(),
+            (PORT_FW_CFG_DMA_HI, 4) => {
+                unimplemented!()
+            }
+            (PORT_FW_CFG_DMA_LO, 4) => {
+                unimplemented!()
+            }
+            _ => {
+                error!("fw_cfg: read unknown port {port:#x} with size {size}.");
+            }
+        };
+    }
+
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        let port = offset as u16 + PORT_FW_CFG_SELECTOR;
+        let size = data.size();
+        match (port, size) {
+            (PORT_FW_CFG_SELECTOR, 2) => {
+                let mut buf = [0u8; 2];
+                buf[..size].copy_from_slice(&data[..size]);
+                let val = u16::from_le_bytes(buf);
+                self.selector = val;
+                self.data_offset = 0;
+            }
+            (PORT_FW_CFG_DATA, 1) => error!("fw_cfg: data register is read-only."),
+            (PORT_FW_CFG_DMA_HI, 4) => {
+                unimplemented!()
+            }
+            (PORT_FW_CFG_DMA_LO, 4) => {
+                unimplemented!()
+            }
+            _ => error!(
+                "fw_cfg: write 0x{offset:0width$x} to unknown port {port:#x}.",
+                width = 2 * size,
+            ),
+        };
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_signature() {
+        let mut fw_cfg = FwCfg::new();
+
+        let mut data = vec![0u8];
+
+        let mut sig_iter = FW_CFG_DMA_SIGNATURE.into_iter();
+        fw_cfg.write(0, 0, &[FW_CFG_SIGNATURE as u8, 0]);
+        loop {
+            if let Some(char) = sig_iter.next() {
+                fw_cfg.read(0, 1, &mut data);
+                assert_eq!(data[0], char);
+            } else {
+                return;
+            }
+        }
+    }
+}

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -16,6 +16,13 @@
 /// We implement the functionality necessary to use Oak's Stage0 Firmware
 /// (This includes most of the functionality, besides adding additional
 /// items to the fw_cfg device for the firmware).
+use arch::{
+    layout::{
+        EBDA_START, HIGH_RAM_START, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START,
+        MEM_32BIT_RESERVED_START, PCI_MMCONFIG_SIZE, PCI_MMCONFIG_START, RAM_64BIT_START,
+    },
+    RegionType,
+};
 use linux_loader::bootparam::boot_params;
 use std::{
     fs::File,
@@ -25,9 +32,14 @@ use std::{
     sync::{Arc, Barrier},
 };
 use vm_device::BusDevice;
-use vm_memory::ByteValued;
+use vm_memory::{ByteValued, GuestAddress};
 use vmm_sys_util::sock_ctrl_msg::IntoIovec;
 use zerocopy::{IntoBytes, FromBytes};
+
+const STAGE0_START_ADDRESS: GuestAddress = GuestAddress(0xffe0_0000);
+const STAGE0_SIZE: usize = 0x20_0000;
+const E820_RAM: u32 = 1;
+const E820_RESERVED: u32 = 2;
 
 pub const PORT_FW_CFG_SELECTOR: u16 = 0x510;
 pub const PORT_FW_CFG_DATA: u16 = 0x511;
@@ -140,6 +152,61 @@ impl FwCfg {
             items: vec![],
             known_items,
         }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn add_e820(&mut self, mem_size: usize) -> Result<()> {
+        let mut mem_regions = vec![
+            (GuestAddress(0), EBDA_START.0 as usize, RegionType::Ram),
+            (
+                MEM_32BIT_DEVICES_START,
+                MEM_32BIT_DEVICES_SIZE as usize,
+                RegionType::Reserved,
+            ),
+            (
+                PCI_MMCONFIG_START,
+                PCI_MMCONFIG_SIZE as usize,
+                RegionType::Reserved,
+            ),
+            (STAGE0_START_ADDRESS, STAGE0_SIZE, RegionType::Reserved),
+        ];
+        if mem_size < MEM_32BIT_DEVICES_START.0 as usize {
+            mem_regions.push((
+                HIGH_RAM_START,
+                mem_size - HIGH_RAM_START.0 as usize,
+                RegionType::Ram,
+            ));
+        } else {
+            mem_regions.push((
+                HIGH_RAM_START,
+                MEM_32BIT_RESERVED_START.0 as usize - HIGH_RAM_START.0 as usize,
+                RegionType::Ram,
+            ));
+            mem_regions.push((
+                RAM_64BIT_START,
+                mem_size - (MEM_32BIT_DEVICES_START.0 as usize),
+                RegionType::Ram,
+            ));
+        }
+        let mut bytes = vec![];
+        for (addr, size, region) in mem_regions.iter() {
+            let type_ = match region {
+                RegionType::Ram => E820_RAM,
+                RegionType::Reserved => E820_RESERVED,
+                RegionType::SubRegion => continue,
+            };
+            let mut entry = BootE820Entry {
+                addr: addr.0,
+                size: *size as u64,
+                type_,
+            };
+            bytes.extend_from_slice(entry.as_mut_bytes());
+        }
+        let item = FwCfgItem {
+            name: "etc/e820".to_owned(),
+            content: FwCfgContent::Bytes(bytes),
+        };
+        self.add_item(item)
     }
 
     fn get_file_dir_mut(&mut self) -> &mut Vec<u8> {

--- a/devices/src/legacy/mod.rs
+++ b/devices/src/legacy/mod.rs
@@ -8,6 +8,7 @@
 mod cmos;
 #[cfg(target_arch = "x86_64")]
 mod debug_port;
+pub mod fw_cfg;
 #[cfg(target_arch = "x86_64")]
 mod fwdebug;
 #[cfg(target_arch = "aarch64")]
@@ -24,6 +25,7 @@ pub use self::cmos::Cmos;
 pub use self::debug_port::DebugPort;
 #[cfg(target_arch = "x86_64")]
 pub use self::fwdebug::FwDebugDevice;
+pub use self::fw_cfg::FwCfg;
 #[cfg(target_arch = "aarch64")]
 pub use self::gpio_pl061::Error as GpioDeviceError;
 #[cfg(target_arch = "aarch64")]

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 dbus_api = ["blocking", "futures", "zbus"]
 default = []
 dhat-heap = ["dhat"] # For heap profiling
+fw_cfg = []
 guest_debug = ["gdbstub", "gdbstub_arch", "kvm"]
 igvm = ["dep:igvm", "hex", "igvm_defs", "mshv-bindings", "range_map_vec"]
 io_uring = ["block/io_uring"]

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -16,6 +16,8 @@ use arch::aarch64::DeviceInfoForFdt;
 use arch::DeviceType;
 use arch::NumaNodes;
 use bitflags::bitflags;
+#[cfg(feature = "fw_cfg")]
+use devices::acpi::AcpiTable;
 use pci::PciBdf;
 use tracer::trace_scoped;
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryRegion};
@@ -192,6 +194,8 @@ pub fn create_dsdt_table(
     dsdt
 }
 
+pub const FACP_DSDT_OFFSET: usize = 140;
+
 fn create_facp_table(dsdt_offset: GuestAddress, device_manager: &Arc<Mutex<DeviceManager>>) -> Sdt {
     trace_scoped!("create_facp_table");
 
@@ -241,7 +245,7 @@ fn create_facp_table(dsdt_offset: GuestAddress, device_manager: &Arc<Mutex<Devic
     // FADT minor version
     facp.write(131, 3u8);
     // X_DSDT
-    facp.write(140, dsdt_offset.0);
+    facp.write(FACP_DSDT_OFFSET, dsdt_offset.0);
     // Hypervisor Vendor Identity
     facp.write_bytes(268, b"CLOUDHYP");
 
@@ -836,6 +840,103 @@ pub fn create_acpi_tables(
         xsdt_offset.0 + xsdt.len() as u64 - rsdp_offset.0
     );
     rsdp_offset
+}
+
+#[cfg(feature = "fw_cfg")]
+pub fn create_acpi_tables_for_fw_cfg(
+    device_manager: &Arc<Mutex<DeviceManager>>,
+    cpu_manager: &Arc<Mutex<CpuManager>>,
+    memory_manager: &Arc<Mutex<MemoryManager>>,
+) -> GuestAddress {
+    trace_scoped!("create_acpi_tables");
+
+    // To create AcpiTable
+    let mut table_bytes: Vec<u8> = vec![];
+    let mut pointers: Vec<usize> = vec![];
+    let mut checksums: Vec<(usize, usize)> = vec![];
+    let mut tables: Vec<u64> = Vec::new();
+
+    let xsdt_offset = GuestAddress(0);
+    let xsdt_size = if device_manager
+        .lock()
+        .unwrap()
+        .iommu_attached_devices()
+        .is_some()
+    {
+        0x44
+    } else {
+        0x3c
+    };
+
+    // DSDT
+    let dsdt = create_dsdt_table(device_manager, cpu_manager, memory_manager);
+    let dsdt_offset = xsdt_offset.checked_add(xsdt_size).unwrap();
+    table_bytes.extend_from_slice(dsdt.as_slice());
+
+    // FACP aka FADT
+    let facp = create_facp_table(dsdt_offset, device_manager);
+    let facp_offset = dsdt_offset.checked_add(dsdt.len() as u64).unwrap();
+    let pointer_facp_to_dsdt = facp_offset.0 as usize + FACP_DSDT_OFFSET;
+    pointers.push(pointer_facp_to_dsdt);
+    table_bytes.extend_from_slice(facp.as_slice());
+    checksums.push((facp_offset.0 as usize, facp.len()));
+    tables.push(facp_offset.0);
+
+    // MADT
+    let madt = cpu_manager.lock().unwrap().create_madt();
+    let madt_offset = facp_offset.checked_add(facp.len() as u64).unwrap();
+    tables.push(madt_offset.0);
+    let mut prev_tbl_len = madt.len() as u64;
+    let mut prev_tbl_off = madt_offset;
+    table_bytes.extend_from_slice(madt.as_slice());
+
+    // MCFG
+    let mcfg = create_mcfg_table(device_manager.lock().unwrap().pci_segments());
+    let mcfg_offset = prev_tbl_off.checked_add(prev_tbl_len).unwrap();
+    tables.push(mcfg_offset.0);
+    prev_tbl_len = mcfg.len() as u64;
+    prev_tbl_off = mcfg_offset;
+    table_bytes.extend_from_slice(mcfg.as_slice());
+
+    // VIOT
+    if let Some((iommu_bdf, devices_bdf)) = device_manager.lock().unwrap().iommu_attached_devices()
+    {
+        let viot = create_viot_table(iommu_bdf, devices_bdf);
+
+        let viot_offset = prev_tbl_off.checked_add(prev_tbl_len).unwrap();
+        tables.push(viot_offset.0);
+        table_bytes.extend_from_slice(viot.as_slice());
+    }
+    // XSDT
+    let mut xsdt = Sdt::new(*b"XSDT", 36, 1, *b"CLOUDH", *b"CHXSDT  ", 1);
+    for table in tables {
+        pointers.push(xsdt.len());
+        xsdt.append(table);
+    }
+    xsdt.update_checksum();
+    info!("xsdt len: {:x}", xsdt.len());
+    checksums.push((xsdt_offset.0 as usize, xsdt.len()));
+    let bytes = [xsdt.as_slice(), &table_bytes].concat();
+
+    // RSDP
+    let rsdp = Rsdp::new(*b"CLOUDH", xsdt_offset.0);
+
+    let acpi = AcpiTable {
+        rsdp,
+        tables: bytes,
+        table_checksums: checksums,
+        table_pointers: pointers,
+    };
+    info!("created acpi table, now add to fw_cfg");
+    let _ = device_manager
+        .lock()
+        .unwrap()
+        .fw_cfg()
+        .expect("fw_cfg must be present")
+        .lock()
+        .unwrap()
+        .add_acpi(acpi);
+    xsdt_offset
 }
 
 #[cfg(feature = "tdx")]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1750,7 +1750,9 @@ impl DeviceManager {
 
             #[cfg(feature = "fw_cfg")]
             {
-                let fw_cfg = Arc::new(Mutex::new(devices::legacy::FwCfg::new()));
+                let fw_cfg = Arc::new(Mutex::new(devices::legacy::FwCfg::new(
+                    self.memory_manager.lock().as_ref().unwrap().guest_memory(),
+                )));
 
                 self.bus_devices
                     .push(Arc::clone(&fw_cfg) as Arc<dyn BusDeviceSync>);

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -53,6 +53,8 @@ use devices::gic;
 use devices::interrupt_controller::InterruptController;
 #[cfg(target_arch = "x86_64")]
 use devices::ioapic;
+#[cfg(feature = "fw_cfg")]
+use devices::legacy::FwCfg;
 #[cfg(target_arch = "aarch64")]
 use devices::legacy::Pl011;
 #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
@@ -938,6 +940,9 @@ pub struct DeviceManager {
     rate_limit_groups: HashMap<String, Arc<RateLimiterGroup>>,
 
     mmio_regions: Arc<Mutex<Vec<MmioRegion>>>,
+
+    #[cfg(feature = "fw_cfg")]
+    fw_cfg: Option<Arc<Mutex<FwCfg>>>,
 }
 
 fn create_mmio_allocators(
@@ -1201,6 +1206,8 @@ impl DeviceManager {
             snapshot,
             rate_limit_groups,
             mmio_regions: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(feature = "fw_cfg")]
+            fw_cfg: None,
         };
 
         let device_manager = Arc::new(Mutex::new(device_manager));
@@ -1740,6 +1747,23 @@ impl DeviceManager {
                 + 1;
             let mem_below_4g = std::cmp::min(arch::layout::MEM_32BIT_RESERVED_START.0, mem_size);
             let mem_above_4g = mem_size.saturating_sub(arch::layout::RAM_64BIT_START.0);
+
+            #[cfg(feature = "fw_cfg")]
+            {
+                let fw_cfg = Arc::new(Mutex::new(devices::legacy::FwCfg::new()));
+
+                self.bus_devices
+                    .push(Arc::clone(&fw_cfg) as Arc<dyn BusDeviceSync>);
+
+                self.fw_cfg = Some(fw_cfg.clone());
+
+                info!("allocating address space for fw_cfg");
+
+                self.address_manager
+                    .io_bus
+                    .insert(fw_cfg, 0x510, 0x10)
+                    .map_err(DeviceManagerError::BusError)?;
+            }
 
             let cmos = Arc::new(Mutex::new(devices::legacy::Cmos::new(
                 mem_below_4g,
@@ -3992,6 +4016,11 @@ impl DeviceManager {
 
     pub fn mmio_bus(&self) -> &Arc<Bus> {
         &self.address_manager.mmio_bus
+    }
+
+    #[cfg(feature = "fw_cfg")]
+    pub fn fw_cfg(&self) -> Option<&Arc<Mutex<FwCfg>>> {
+        self.fw_cfg.as_ref()
     }
 
     pub fn allocator(&self) -> &Arc<Mutex<SystemAllocator>> {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -661,6 +661,15 @@ impl Vm {
 
         #[cfg(feature = "fw_cfg")]
         {
+            let _ = device_manager
+                .lock()
+                .unwrap()
+                .fw_cfg()
+                .expect("fw_cfg device must be present")
+                .lock()
+                .unwrap()
+                .add_e820(config.lock().unwrap().memory.size as usize);
+
             let kernel = config
                 .lock()
                 .unwrap()

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -68,6 +68,8 @@ use vm_migration::{
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
+#[cfg(feature = "fw_cfg")]
+use crate::acpi::create_acpi_tables_for_fw_cfg;
 use crate::config::{add_to_config, ValidationError};
 use crate::console_devices::{ConsoleDeviceError, ConsoleInfo};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
@@ -2254,6 +2256,13 @@ impl Vm {
             VmState::Running
         };
         current_state.valid_transition(new_state)?;
+
+        #[cfg(feature = "fw_cfg")]
+        let _ = create_acpi_tables_for_fw_cfg(
+            &self.device_manager,
+            &self.cpu_manager,
+            &self.memory_manager,
+        );
 
         // Do earlier to parallelise with loading kernel
         #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
We are working with the project [Oak](https://github.com/project-oak/oak) team to enable running [Oak Containers](https://github.com/project-oak/oak/tree/main/oak_containers) on cloud hypervisor. These containers are SEV-SNP enlightened and can be used alongside with the rest of the oak suite for attestation and measurement of the cvm. 

Here is the functionality we are adding to CHV.
1. Implmenting the sev-snp APIs previously defined (sev_snp_init, import_isolated_pages, complete_isolated_import). 
2. Expanded the igvm loader to support booting KVM + SEV-SNP enabled VMs. (Note that we can also use the igvm loader to boot VMs with standard cloud images with/without sev-snp enabled as seen here (https://github.com/AlexOrozco1256/chv-demo)
3. Added a fw_cfg device with DMA enabled. Oak's [Stage0](https://github.com/project-oak/oak/tree/main/stage0_bin) firmware uses fw_cfg for loading various parameters into the VM. 

Additional design/implementation details can be found here: https://tinyurl.com/chv-kvm-sev-snp

See: #6653