### PR TITLE
update mshv crates to the latest release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,9 +1257,9 @@ checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
 name = "mshv-bindings"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4aa8157010f69f380a86a0ba087167b0a01e2e3f2bcca5b576bd26a9206dc8"
+checksum = "577073a0abbf515d17bfe96ca2ce49c44a68454d4179e95ce1244e858a9ebd4e"
 dependencies = [
  "libc",
  "num_enum",
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bdc151fdc265efbb20f6c74e235dcdbce9a54e695655ac88b4db7385b26319"
+checksum = "4bfcb8dfbdc1be2350d929291e88bd872dacdbeb50944ff36a7ede1de1fd3258"
 dependencies = [
  "libc",
  "mshv-bindings",
@@ -2253,7 +2253,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#bdbb1cd486484faa23db48c82d51484e2ee43692"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#0d6929d5242c9467c41dd41a53babd90ace7c555"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -2261,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#bdbb1cd486484faa23db48c82d51484e2ee43692"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#0d6929d5242c9467c41dd41a53babd90ace7c555"
 dependencies = [
  "byteorder",
  "kvm-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ acpi_tables = { git = "https://github.com/rust-vmm/acpi_tables", branch = "main"
 kvm-bindings = "0.10.0"
 kvm-ioctls = "0.19.1"
 linux-loader = "0.13.0"
-mshv-bindings = "0.3.5"
-mshv-ioctls = "0.3.5"
+mshv-bindings = "0.4.0"
+mshv-ioctls = "0.4.0"
 seccompiler = "0.5.0"
 vfio-bindings = { git = "https://github.com/rust-vmm/vfio", branch = "main" }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ libc = "0.2.155"
 libfuzzer-sys = "0.4.7"
 linux-loader = { version = "0.13.0", features = ["bzimage", "elf", "pe"] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
-mshv-bindings = "0.3.2"
+mshv-bindings = "0.4.0"
 net_util = { path = "../net_util" }
 once_cell = "1.19.0"
 seccompiler = "0.5.0"

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -506,11 +506,11 @@ impl hypervisor::Hypervisor for MshvHypervisor {
     ///
     fn get_host_ipa_limit(&self) -> i32 {
         let host_ipa = self.mshv.get_host_partition_property(
-            hv_partition_property_code_HV_PARTITION_PROPERTY_PHYSICAL_ADDRESS_WIDTH as u64,
+            hv_partition_property_code_HV_PARTITION_PROPERTY_PHYSICAL_ADDRESS_WIDTH,
         );
 
         match host_ipa {
-            Ok(ipa) => ipa,
+            Ok(ipa) => ipa.try_into().unwrap(),
             Err(e) => {
                 panic!("Failed to get host IPA limit: {:?}", e);
             }

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -262,7 +262,7 @@ impl MshvHypervisor {
     ///
     /// Retrieve the list of MSRs supported by MSHV.
     ///
-    fn get_msr_list(&self) -> hypervisor::Result<MsrList> {
+    fn get_msr_list(&self) -> hypervisor::Result<Vec<u32>> {
         self.mshv
             .get_msr_index_list()
             .map_err(|e| hypervisor::HypervisorError::GetMsrList(e.into()))
@@ -347,15 +347,13 @@ impl MshvHypervisor {
         #[cfg(target_arch = "x86_64")]
         {
             let msr_list = self.get_msr_list()?;
-            let num_msrs = msr_list.as_fam_struct_ref().nmsrs as usize;
             let mut msrs: Vec<MsrEntry> = vec![
                 MsrEntry {
                     ..Default::default()
                 };
-                num_msrs
+                msr_list.len()
             ];
-            let indices = msr_list.as_slice();
-            for (pos, index) in indices.iter().enumerate() {
+            for (pos, index) in msr_list.iter().enumerate() {
                 msrs[pos].index = *index;
             }
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -3188,7 +3188,7 @@ As part of our general effort to offload paravirtualized I/O to external
 processes, we added support for
 [vhost-user-net](https://access.redhat.com/solutions/3394851) backends. This
 enables `cloud-hypervisor` users to plug a `vhost-user` based networking device
-(e.g. [DPDK](https://dpdk.org)) into the VMM as their virtio network backend.
+(e.g. [DPDK](https://www.dpdk.org)) into the VMM as their virtio network backend.
 
 ### Minimal hardware-reduced ACPI
 


### PR DESCRIPTION
Latest mshv crates contains some IOCTL changes that
enhances VM creation and configures the features in correct
way. Also adds some features that improves register access.