### PR TITLE
vmm: hypervisor: Add a new interface to setup GICR for vcpus

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -590,7 +590,13 @@ pub trait Vcpu: Send + Sync {
     fn set_sev_control_register(&self, _reg: u64) -> Result<()> {
         unimplemented!()
     }
-
+    ///
+    /// Sets the value of GIC redistributor address
+    ///
+    #[cfg(target_arch = "aarch64")]
+    fn set_gic_redistributor_addr(&self, _gicr_base_addr: u64) -> Result<()> {
+        Ok(())
+    }
     #[cfg(target_arch = "x86_64")]
     ///
     /// Trigger NMI interrupt

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1603,6 +1603,24 @@ impl cpu::Vcpu for MshvVcpu {
             .request_virtual_interrupt(&cfg)
             .map_err(|e| cpu::HypervisorCpuError::Nmi(e.into()))
     }
+    ///
+    /// Set the GICR base address for the vcpu.
+    ///
+    #[cfg(target_arch = "aarch64")]
+    fn set_gic_redistributor_addr(&self, gicr_base_addr: u64) -> cpu::Result<()> {
+        debug!(
+            "Setting GICR base address to: {:#x}, for vp_index: {:?}",
+            gicr_base_addr, self.vp_index
+        );
+        let arr_reg_name_value = [(
+            hv_register_name_HV_ARM64_REGISTER_GICR_BASE_GPA,
+            gicr_base_addr,
+        )];
+        set_registers_64!(self.fd, arr_reg_name_value)
+            .map_err(|e| cpu::HypervisorCpuError::SetRegister(e.into()))?;
+
+        Ok(())
+    }
 }
 
 impl MshvVcpu {


### PR DESCRIPTION
For MSHV arm64 guest, there is an in-hypervisor GICv2M emulation and for that to work, it needs to be enlightened with the base address of GIC redistributor exposed to guest via FDT.