### PR TITLE
hypervisor: Extend interrupt handling for legacy IRQ

### DIFF
--- a/hypervisor/src/mshv/aarch64/gic/mod.rs
+++ b/hypervisor/src/mshv/aarch64/gic/mod.rs
@@ -32,6 +32,8 @@ pub struct MshvGicV2M {
     pub vcpu_count: u64,
 }
 
+pub const BASE_SPI_IRQ: u32 = 32;
+
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct MshvGicV2MState {}
 


### PR DESCRIPTION
On x86 MSHV guests only used to support MSI based interrupts via IOAPIC but ARM64 guests uses legacy interrupt for its functioning. Thus, extend the logic to create routing entry to support legacy interrupts for ARM64 guests on MSHV.