### PR TITLE
pci: vfio: Update MMIO region IOMMU mappings with BAR reprogramming

### DIFF
--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -18,6 +18,8 @@ use crate::{MsixConfig, PciInterruptPin};
 // The number of 32bit registers in the config space, 4096 bytes.
 const NUM_CONFIGURATION_REGISTERS: usize = 1024;
 
+pub(crate) const COMMAND_REG: usize = 1;
+pub(crate) const COMMAND_REG_MEMORY_SPACE_MASK: u32 = 0x0000_0002;
 const STATUS_REG: usize = 1;
 const STATUS_REG_CAPABILITIES_USED_MASK: u32 = 0x0010_0000;
 const BAR0_REG: usize = 4;

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1697,8 +1697,13 @@ impl VfioPciDevice {
                     if let Err(e) = self
                         .container
                         .vfio_dma_unmap(user_memory_region.start, user_memory_region.size)
+                        .map_err(|e| VfioPciError::DmaUnmap(e, self.device_path.clone(), self.bdf))
                     {
-                        error!("Could not unmap mmio region from vfio container: {}", e);
+                        error!(
+                            "Could not unmap mmio region from vfio container: \
+                            iova 0x{:x}, size 0x{:x}: {}, ",
+                            user_memory_region.start, user_memory_region.size, e
+                        );
                     }
                 }
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -760,6 +760,7 @@ fn create_vcpu_ioctl_seccomp_rule(
     let mut rules = or![
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_DEVICE_SET_IRQS)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_GROUP_UNSET_CONTAINER)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, VFIO_IOMMU_MAP_DMA)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_IOMMU_UNMAP_DMA)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VHOST_VDPA_SET_STATUS)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VHOST_VDPA_GET_CONFIG)?],


### PR DESCRIPTION
To support PCIe P2P between VFIO devices, we populate IOMMU mappings for
the non-emulated MMIO regions of all VFIO devices via
`VFIO_IOMMU_MAP_DMA` (https://github.com/cloud-hypervisor/cloud-hypervisor/commit/f0c1f8d079d90d2390b2c01a88d81cd00dd08209), but the patch did not properly update
the IOMMU mappings with BAR reprogramming.

Fixes: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7027