### PR TITLE
pci: Keep detect_bar_reprogramming internal to PciConfiguration

### DIFF
--- a/devices/src/pvmemcontrol.rs
+++ b/devices/src/pvmemcontrol.rs
@@ -698,10 +698,12 @@ impl PciDevice for PvmemcontrolPciDevice {
         reg_idx: usize,
         offset: u64,
         data: &[u8],
-    ) -> Option<Arc<Barrier>> {
-        self.configuration
-            .write_config_register(reg_idx, offset, data);
-        None
+    ) -> (Option<BarReprogrammingParams>, Option<Arc<Barrier>>) {
+        (
+            self.configuration
+                .write_config_register(reg_idx, offset, data),
+            None,
+        )
     }
 
     fn read_config_register(&mut self, reg_idx: usize) -> u32 {
@@ -714,14 +716,6 @@ impl PciDevice for PvmemcontrolPciDevice {
 
     fn id(&self) -> Option<String> {
         Some(self.id.clone())
-    }
-
-    fn detect_bar_reprogramming(
-        &mut self,
-        reg_idx: usize,
-        data: &[u8],
-    ) -> Option<BarReprogrammingParams> {
-        self.configuration.detect_bar_reprogramming(reg_idx, data)
     }
 
     fn allocate_bars(

--- a/devices/src/pvpanic.rs
+++ b/devices/src/pvpanic.rs
@@ -88,7 +88,11 @@ impl PvPanicDevice {
         );
 
         let command: [u8; 2] = [0x03, 0x01];
-        configuration.write_config_register(1, 0, &command);
+        let bar_reprogram = configuration.write_config_register(1, 0, &command);
+        assert!(
+            bar_reprogram.is_none(),
+            "No bar reprogrammig is expected from writing to the COMMAND register"
+        );
 
         let state: Option<PvPanicDeviceState> = snapshot
             .as_ref()
@@ -156,22 +160,16 @@ impl PciDevice for PvPanicDevice {
         reg_idx: usize,
         offset: u64,
         data: &[u8],
-    ) -> Option<Arc<Barrier>> {
-        self.configuration
-            .write_config_register(reg_idx, offset, data);
-        None
+    ) -> (Option<BarReprogrammingParams>, Option<Arc<Barrier>>) {
+        (
+            self.configuration
+                .write_config_register(reg_idx, offset, data),
+            None,
+        )
     }
 
     fn read_config_register(&mut self, reg_idx: usize) -> u32 {
         self.configuration.read_reg(reg_idx)
-    }
-
-    fn detect_bar_reprogramming(
-        &mut self,
-        reg_idx: usize,
-        data: &[u8],
-    ) -> Option<BarReprogrammingParams> {
-        self.configuration.detect_bar_reprogramming(reg_idx, data)
     }
 
     fn allocate_bars(

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -907,9 +907,14 @@ impl PciConfiguration {
         (next + 3) & !3
     }
 
-    pub fn write_config_register(&mut self, reg_idx: usize, offset: u64, data: &[u8]) {
+    pub fn write_config_register(
+        &mut self,
+        reg_idx: usize,
+        offset: u64,
+        data: &[u8],
+    ) -> Option<BarReprogrammingParams> {
         if offset as usize + data.len() > 4 {
-            return;
+            return None;
         }
 
         // Handle potential write to MSI-X message control register
@@ -938,13 +943,15 @@ impl PciConfiguration {
             4 => self.write_reg(reg_idx, LittleEndian::read_u32(data)),
             _ => (),
         }
+
+        self.detect_bar_reprogramming(reg_idx, data)
     }
 
     pub fn read_config_register(&self, reg_idx: usize) -> u32 {
         self.read_reg(reg_idx)
     }
 
-    pub fn detect_bar_reprogramming(
+    fn detect_bar_reprogramming(
         &mut self,
         reg_idx: usize,
         data: &[u8],

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -988,7 +988,7 @@ impl PciConfiguration {
 
                 info!(
                     "Detected BAR reprogramming: (BAR {}) 0x{:x}->0x{:x}",
-                    reg_idx, self.registers[reg_idx], value
+                    bar_idx, self.bars[bar_idx].addr, value
                 );
                 let old_base = u64::from(self.bars[bar_idx].addr & mask);
                 let new_base = u64::from(value & mask);
@@ -1014,7 +1014,7 @@ impl PciConfiguration {
             {
                 info!(
                     "Detected BAR reprogramming: (BAR {}) 0x{:x}->0x{:x}",
-                    reg_idx, self.registers[reg_idx], value
+                    bar_idx, self.bars[bar_idx].addr, value
                 );
                 let old_base = (u64::from(self.bars[bar_idx].addr & mask) << 32)
                     | u64::from(self.bars[bar_idx - 1].addr & self.writable_bits[reg_idx - 1]);
@@ -1043,8 +1043,8 @@ impl PciConfiguration {
             }
 
             info!(
-                "Detected ROM BAR reprogramming: (BAR {}) 0x{:x}->0x{:x}",
-                reg_idx, self.registers[reg_idx], value
+                "Detected ROM BAR reprogramming: (Expansion ROM BAR) 0x{:x}->0x{:x}",
+                self.rom_bar_addr, value
             );
             let old_base = u64::from(self.rom_bar_addr & mask);
             let new_base = u64::from(value & mask);

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -87,18 +87,10 @@ pub trait PciDevice: Send {
         reg_idx: usize,
         offset: u64,
         data: &[u8],
-    ) -> Option<Arc<Barrier>>;
+    ) -> (Option<BarReprogrammingParams>, Option<Arc<Barrier>>);
     /// Gets a register from the configuration space.
     /// * `reg_idx` - The index of the config register to read.
     fn read_config_register(&mut self, reg_idx: usize) -> u32;
-    /// Detects if a BAR is being reprogrammed.
-    fn detect_bar_reprogramming(
-        &mut self,
-        _reg_idx: usize,
-        _data: &[u8],
-    ) -> Option<BarReprogrammingParams> {
-        None
-    }
     /// Reads from a BAR region mapped into the device.
     /// * `addr` - The guest address inside the BAR.
     /// * `data` - Filled with the data from `addr`.

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -426,22 +426,12 @@ impl PciDevice for VfioUserPciDevice {
         self
     }
 
-    fn detect_bar_reprogramming(
-        &mut self,
-        reg_idx: usize,
-        data: &[u8],
-    ) -> Option<BarReprogrammingParams> {
-        self.common
-            .configuration
-            .detect_bar_reprogramming(reg_idx, data)
-    }
-
     fn write_config_register(
         &mut self,
         reg_idx: usize,
         offset: u64,
         data: &[u8],
-    ) -> Option<Arc<Barrier>> {
+    ) -> (Option<BarReprogrammingParams>, Option<Arc<Barrier>>) {
         self.common.write_config_register(reg_idx, offset, data)
     }
 


### PR DESCRIPTION
A BAR reprogramming of a PCI device will only happen when the (guest)
kernel write to its PCI config space, e.g. the detection of bar
reprogramming (`detect_bar_repgraomming()`) can be embedded to the PCI
config space write (`write_config_register()`). It simplifies APIs
exposed by the `struct PciConfiguration` and `trait PciDevice`. It also
prepares for easier handling of pending bar reprogramming when the MSE
bit of the COMMAND register is not enabled at the time of changing BAR
registers.

See: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7027#issuecomment-2853642959
