### PR TITLE
DeviceManagerError: Implement Error including all Variants

### DIFF
--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -10,6 +10,7 @@ use std::ops::DerefMut;
 use std::sync::{Arc, Barrier, Mutex};
 
 use byteorder::{ByteOrder, LittleEndian};
+use thiserror::Error;
 use vm_device::{Bus, BusDevice, BusDeviceSync};
 
 use crate::configuration::{
@@ -23,21 +24,28 @@ const DEVICE_ID_INTEL_VIRT_PCIE_HOST: u16 = 0x0d57;
 const NUM_DEVICE_IDS: usize = 32;
 
 /// Errors for device manager.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum PciRootError {
     /// Could not allocate device address space for the device.
-    AllocateDeviceAddrs(PciDeviceError),
+    #[error("Could not allocate device address space for the device: {0}")]
+    AllocateDeviceAddrs(#[source] PciDeviceError),
     /// Could not allocate an IRQ number.
+    #[error("Could not allocate an IRQ number")]
     AllocateIrq,
     /// Could not add a device to the port io bus.
-    PioInsert(vm_device::BusError),
+    #[error("Could not add a device to the port io bus: {0}")]
+    PioInsert(#[source] vm_device::BusError),
     /// Could not add a device to the mmio bus.
-    MmioInsert(vm_device::BusError),
+    #[error("Could not add a device to the mmio bus: {0}")]
+    MmioInsert(#[source] vm_device::BusError),
     /// Could not find an available device slot on the PCI bus.
+    #[error("Could not find an available device slot on the PCI bus")]
     NoPciDeviceSlotAvailable,
     /// Invalid PCI device identifier provided.
+    #[error("Invalid PCI device identifier provided")]
     InvalidPciDeviceSlot(usize),
     /// Valid PCI device identifier but already used.
+    #[error("Valid PCI device identifier but already used")]
     AlreadyInUsePciDeviceSlot(usize),
 }
 pub type Result<T> = std::result::Result<T, PciRootError>;

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -4,11 +4,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::fmt::{self, Display};
 use std::sync::{Arc, Mutex};
 
 use byteorder::{ByteOrder, LittleEndian};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use vm_device::PciBarType;
 use vm_migration::{MigratableError, Pausable, Snapshot, Snapshottable};
 
@@ -493,59 +493,44 @@ pub struct PciBarConfiguration {
     prefetchable: PciBarPrefetchable,
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
+    #[error("address {0} size {1} too big")]
     BarAddressInvalid(u64, u64),
+    #[error("bar {0} already used")]
     BarInUse(usize),
+    #[error("64bit bar {0} already used (requires two regs)")]
     BarInUse64(usize),
+    #[error("bar {0} invalid, max {max}", max = NUM_BAR_REGS - 1)]
     BarInvalid(usize),
+    #[error("64bitbar {0} invalid, requires two regs, max {max}", max = NUM_BAR_REGS - 1)]
     BarInvalid64(usize),
+    #[error("bar address {0} not a power of two")]
     BarSizeInvalid(u64),
+    #[error("empty capabilities are invalid")]
     CapabilityEmpty,
+    #[error("Invalid capability length {0}")]
     CapabilityLengthInvalid(usize),
+    #[error("capability of size {0} doesn't fit")]
     CapabilitySpaceFull(usize),
+    #[error("failed to decode 32 bits BAR size")]
     Decode32BarSize,
+    #[error("failed to decode 64 bits BAR size")]
     Decode64BarSize,
+    #[error("failed to encode 32 bits BAR size")]
     Encode32BarSize,
+    #[error("failed to encode 64 bits BAR size")]
     Encode64BarSize,
+    #[error("address {0} size {1} too big")]
     RomBarAddressInvalid(u64, u64),
+    #[error("rom bar {0} already used")]
     RomBarInUse(usize),
+    #[error("rom bar {0} invalid, max {max}", max = NUM_BAR_REGS - 1)]
     RomBarInvalid(usize),
+    #[error("rom bar address {0} not a power of two")]
     RomBarSizeInvalid(u64),
 }
 pub type Result<T> = std::result::Result<T, Error>;
-
-impl std::error::Error for Error {}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-        match self {
-            BarAddressInvalid(a, s) => write!(f, "address {a} size {s} too big"),
-            BarInUse(b) => write!(f, "bar {b} already used"),
-            BarInUse64(b) => write!(f, "64bit bar {b} already used(requires two regs)"),
-            BarInvalid(b) => write!(f, "bar {} invalid, max {}", b, NUM_BAR_REGS - 1),
-            BarInvalid64(b) => write!(
-                f,
-                "64bitbar {} invalid, requires two regs, max {}",
-                b,
-                NUM_BAR_REGS - 1
-            ),
-            BarSizeInvalid(s) => write!(f, "bar address {s} not a power of two"),
-            CapabilityEmpty => write!(f, "empty capabilities are invalid"),
-            CapabilityLengthInvalid(l) => write!(f, "Invalid capability length {l}"),
-            CapabilitySpaceFull(s) => write!(f, "capability of size {s} doesn't fit"),
-            Decode32BarSize => write!(f, "failed to decode 32 bits BAR size"),
-            Decode64BarSize => write!(f, "failed to decode 64 bits BAR size"),
-            Encode32BarSize => write!(f, "failed to encode 32 bits BAR size"),
-            Encode64BarSize => write!(f, "failed to encode 64 bits BAR size"),
-            RomBarAddressInvalid(a, s) => write!(f, "address {a} size {s} too big"),
-            RomBarInUse(b) => write!(f, "rom bar {b} already used"),
-            RomBarInvalid(b) => write!(f, "rom bar {} invalid, max {}", b, NUM_BAR_REGS - 1),
-            RomBarSizeInvalid(s) => write!(f, "rom bar address {s} not a power of two"),
-        }
-    }
-}
 
 impl PciConfiguration {
     #[allow(clippy::too_many_arguments)]

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -7,6 +7,7 @@
 use std::any::Any;
 use std::sync::{Arc, Barrier, Mutex};
 use std::{io, result};
+
 use thiserror::Error;
 use vm_allocator::{AddressAllocator, SystemAllocator};
 use vm_device::Resource;

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -5,48 +5,34 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::any::Any;
-use std::fmt::{self, Display};
 use std::sync::{Arc, Barrier, Mutex};
 use std::{io, result};
-
+use thiserror::Error;
 use vm_allocator::{AddressAllocator, SystemAllocator};
 use vm_device::Resource;
 
 use crate::configuration::{self, PciBarRegionType};
 use crate::PciBarConfiguration;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// Setup of the device capabilities failed.
-    CapabilitiesSetup(configuration::Error),
+    #[error("Setup of the device capabilities failed: {0}")]
+    CapabilitiesSetup(#[source] configuration::Error),
     /// Allocating space for an IO BAR failed.
+    #[error("Allocating space for an IO BAR failed")]
     IoAllocationFailed(u64),
     /// Registering an IO BAR failed.
-    IoRegistrationFailed(u64, configuration::Error),
+    #[error("Registering an IO BAR failed: {0}")]
+    IoRegistrationFailed(u64, #[source] configuration::Error),
     /// Expected resource not found.
+    #[error("Expected resource not found")]
     MissingResource,
     /// Invalid resource.
+    #[error("Invalid resource: {0:?}")]
     InvalidResource(Resource),
 }
 pub type Result<T> = std::result::Result<T, Error>;
-
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-
-        match self {
-            CapabilitiesSetup(e) => write!(f, "failed to add capability {e}"),
-            IoAllocationFailed(size) => {
-                write!(f, "failed to allocate space for an IO BAR, size={size}")
-            }
-            IoRegistrationFailed(addr, e) => {
-                write!(f, "failed to register an IO BAR, addr={addr} err={e}")
-            }
-            MissingResource => write!(f, "failed to find expected resource"),
-            InvalidResource(r) => write!(f, "invalid resource {r:?}"),
-        }
-    }
-}
 
 #[derive(Clone, Copy, Debug)]
 pub struct BarReprogrammingParams {

--- a/virtio-devices/src/vsock/unix/mod.rs
+++ b/virtio-devices/src/vsock/unix/mod.rs
@@ -13,6 +13,7 @@ mod muxer;
 mod muxer_killq;
 mod muxer_rxq;
 
+use thiserror::Error;
 pub use muxer::VsockMuxer as VsockUnixBackend;
 pub use Error as VsockUnixError;
 
@@ -27,29 +28,40 @@ mod defs {
     pub const MUXER_KILLQ_SIZE: usize = 128;
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// Error converting from UTF-8
-    ConvertFromUtf8(std::str::Utf8Error),
+    #[error("Error converting from UTF-8: {0}")]
+    ConvertFromUtf8(#[source] std::str::Utf8Error),
     /// Error registering a new epoll-listening FD.
-    EpollAdd(std::io::Error),
+    #[error("Error registering a new epoll-listening FD: {0}")]
+    EpollAdd(#[source] std::io::Error),
     /// Error creating an epoll FD.
-    EpollFdCreate(std::io::Error),
+    #[error("Error creating an epoll FD: {0}")]
+    EpollFdCreate(#[source] std::io::Error),
     /// The host made an invalid vsock port connection request.
+    #[error("The host made an invalid vsock port connection request")]
     InvalidPortRequest,
     /// Error parsing integer.
-    ParseInteger(std::num::ParseIntError),
+    #[error("Error parsing integer: {0}")]
+    ParseInteger(#[source] std::num::ParseIntError),
     /// Error reading stream port.
-    ReadStreamPort(Box<Error>),
+    #[error("Error reading stream port: {0}")]
+    ReadStreamPort(#[source] Box<Error>),
     /// Error accepting a new connection from the host-side Unix socket.
-    UnixAccept(std::io::Error),
+    #[error("Error accepting a new connection from the host-side Unix socket: {0}")]
+    UnixAccept(#[source] std::io::Error),
     /// Error binding to the host-side Unix socket.
-    UnixBind(std::io::Error),
+    #[error("Error binding to the host-side Unix socket: {0}")]
+    UnixBind(#[source] std::io::Error),
     /// Error connecting to a host-side Unix socket.
-    UnixConnect(std::io::Error),
+    #[error("Error connecting to a host-side Unix socket: {0}")]
+    UnixConnect(#[source] std::io::Error),
     /// Error reading from host-side Unix socket.
-    UnixRead(std::io::Error),
+    #[error("Error reading from host-side Unix socket: {0}")]
+    UnixRead(#[source] std::io::Error),
     /// Muxer connection limit reached.
+    #[error("Muxer connection limit reached")]
     TooManyConnections,
 }
 

--- a/virtio-devices/src/vsock/unix/mod.rs
+++ b/virtio-devices/src/vsock/unix/mod.rs
@@ -13,8 +13,8 @@ mod muxer;
 mod muxer_killq;
 mod muxer_rxq;
 
-use thiserror::Error;
 pub use muxer::VsockMuxer as VsockUnixBackend;
+use thiserror::Error;
 pub use Error as VsockUnixError;
 
 mod defs {

--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -10,7 +10,9 @@
 use std::cmp::Ordering;
 use std::collections::btree_map::BTreeMap;
 use std::sync::{Arc, Barrier, Mutex, RwLock, Weak};
-use std::{convert, error, fmt, io, result};
+use std::{convert, io, result};
+
+use thiserror::Error;
 
 /// Trait for devices that respond to reads or writes in an arbitrary address space.
 ///
@@ -51,25 +53,20 @@ impl<B: BusDevice> BusDeviceSync for Mutex<B> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// The insertion failed because the new device overlapped with an old device.
+    #[error("The insertion failed because the new device overlapped with an old device")]
     Overlap,
     /// Failed to operate on zero sized range.
+    #[error("Failed to operate on zero sized range")]
     ZeroSizedRange,
     /// Failed to find address range.
+    #[error("Failed to find address range")]
     MissingAddressRange,
 }
 
 pub type Result<T> = result::Result<T, Error>;
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "bus_error: {self:?}")
-    }
-}
-
-impl error::Error for Error {}
 
 impl convert::From<Error> for io::Error {
     fn from(e: Error) -> Self {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -265,11 +265,11 @@ pub enum DeviceManagerError {
 
     /// Cannot allocate PCI BARs
     #[error("Cannot allocate PCI BARs: {0}")]
-    AllocateBars(pci::PciDeviceError),
+    AllocateBars(#[source] pci::PciDeviceError),
 
     /// Could not free the BARs associated with a PCI device.
     #[error("Could not free the BARs associated with a PCI device: {0}")]
-    FreePciBars(pci::PciDeviceError),
+    FreePciBars(#[source] pci::PciDeviceError),
 
     /// Cannot register ioevent.
     #[error("Cannot register ioevent: {0}")]
@@ -285,7 +285,7 @@ pub enum DeviceManagerError {
 
     /// Cannot add PCI device
     #[error("Cannot add PCI device")]
-    AddPciDevice(pci::PciRootError),
+    AddPciDevice(#[source] pci::PciRootError),
 
     /// Cannot open persistent memory file
     #[error("Cannot open persistent memory file")]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -382,7 +382,7 @@ pub enum DeviceManagerError {
 
     /// Error from a memory manager operation
     #[error("Error from a memory manager operation")]
-    MemoryManager(MemoryManagerError),
+    MemoryManager(#[source] MemoryManagerError),
 
     /// Failed to create new interrupt source group.
     #[error("Failed to create new interrupt source group")]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -215,7 +215,7 @@ pub enum DeviceManagerError {
     CreateVsockConvertPath,
 
     /// Cannot create virtio-vsock backend
-    #[error("Cannot create virtio-vsock backend")]
+    #[error("Cannot create virtio-vsock backend: {0}")]
     CreateVsockBackend(#[source] virtio_devices::vsock::VsockUnixError),
 
     /// Cannot create virtio-iommu device
@@ -280,19 +280,19 @@ pub enum DeviceManagerError {
     UnRegisterIoevent(#[source] anyhow::Error),
 
     /// Cannot create virtio device
-    #[error("Cannot create virtio device")]
+    #[error("Cannot create virtio device: {0}")]
     VirtioDevice(#[source] virtio_devices::transport::VirtioPciDeviceError),
 
     /// Cannot add PCI device
-    #[error("Cannot add PCI device")]
+    #[error("Cannot add PCI device: {0}")]
     AddPciDevice(#[source] pci::PciRootError),
 
     /// Cannot open persistent memory file
-    #[error("Cannot open persistent memory file")]
+    #[error("Cannot open persistent memory file: {0}")]
     PmemFileOpen(#[source] io::Error),
 
     /// Cannot set persistent memory file size
-    #[error("Cannot set persistent memory file size")]
+    #[error("Cannot set persistent memory file size: {0}")]
     PmemFileSetLen(#[source] io::Error),
 
     /// Cannot find a memory range for persistent memory
@@ -304,68 +304,68 @@ pub enum DeviceManagerError {
     FsRangeAllocation,
 
     /// Error creating serial output file
-    #[error("Error creating serial output file")]
+    #[error("Error creating serial output file: {0}")]
     SerialOutputFileOpen(#[source] io::Error),
 
     /// Error creating debug-console output file
     #[cfg(target_arch = "x86_64")]
-    #[error("Error creating debug-console output file")]
+    #[error("Error creating debug-console output file: {0}")]
     DebugconOutputFileOpen(#[source] io::Error),
 
     /// Error creating console output file
-    #[error("Error creating console output file")]
+    #[error("Error creating console output file: {0}")]
     ConsoleOutputFileOpen(#[source] io::Error),
 
     /// Error creating serial pty
-    #[error("Error creating serial pty")]
+    #[error("Error creating serial pty: {0}")]
     SerialPtyOpen(#[source] io::Error),
 
     /// Error creating console pty
-    #[error("Error creating console pty")]
+    #[error("Error creating console pty: {0}")]
     ConsolePtyOpen(#[source] io::Error),
 
     /// Error creating debugcon pty
-    #[error("Error creating console pty")]
+    #[error("Error creating console pty: {0}")]
     DebugconPtyOpen(#[source] io::Error),
 
     /// Error setting pty raw mode
-    #[error("Error setting pty raw mode")]
+    #[error("Error setting pty raw mode: {0}")]
     SetPtyRaw(#[source] ConsoleDeviceError),
 
     /// Error getting pty peer
-    #[error("Error getting pty peer")]
+    #[error("Error getting pty peer: {0}")]
     GetPtyPeer(#[source] vmm_sys_util::errno::Error),
 
     /// Cannot create a VFIO device
-    #[error("Cannot create a VFIO device")]
+    #[error("Cannot create a VFIO device: {0}")]
     VfioCreate(#[source] vfio_ioctls::VfioError),
 
     /// Cannot create a VFIO PCI device
-    #[error("Cannot create a VFIO PCI device")]
+    #[error("Cannot create a VFIO PCI device: {0}")]
     VfioPciCreate(#[source] pci::VfioPciError),
 
     /// Failed to map VFIO MMIO region.
-    #[error("Failed to map VFIO MMIO region")]
+    #[error("Failed to map VFIO MMIO region: {0}")]
     VfioMapRegion(#[source] pci::VfioPciError),
 
     /// Failed to DMA map VFIO device.
-    #[error("Failed to DMA map VFIO device")]
+    #[error("Failed to DMA map VFIO device: {0}")]
     VfioDmaMap(#[source] vfio_ioctls::VfioError),
 
     /// Failed to DMA unmap VFIO device.
-    #[error("Failed to DMA unmap VFIO device")]
+    #[error("Failed to DMA unmap VFIO device: {0}")]
     VfioDmaUnmap(#[source] pci::VfioPciError),
 
     /// Failed to create the passthrough device.
-    #[error("Failed to create the passthrough device")]
+    #[error("Failed to create the passthrough device: {0}")]
     CreatePassthroughDevice(#[source] anyhow::Error),
 
     /// Failed to memory map.
-    #[error("Failed to memory map")]
+    #[error("Failed to memory map: {0}")]
     Mmap(#[source] io::Error),
 
     /// Cannot add legacy device to Bus.
-    #[error("Cannot add legacy device to Bus")]
+    #[error("Cannot add legacy device to Bus: {0}")]
     BusError(#[source] vm_device::BusError),
 
     /// Failed to allocate IO port
@@ -377,27 +377,27 @@ pub enum DeviceManagerError {
     AllocateMmioAddress,
 
     /// Failed to make hotplug notification
-    #[error("Failed to make hotplug notification")]
+    #[error("Failed to make hotplug notification: {0}")]
     HotPlugNotification(#[source] io::Error),
 
     /// Error from a memory manager operation
-    #[error("Error from a memory manager operation")]
+    #[error("Error from a memory manager operation: {0}")]
     MemoryManager(#[source] MemoryManagerError),
 
     /// Failed to create new interrupt source group.
-    #[error("Failed to create new interrupt source group")]
+    #[error("Failed to create new interrupt source group: {0}")]
     CreateInterruptGroup(#[source] io::Error),
 
     /// Failed to update interrupt source group.
-    #[error("Failed to update interrupt source group")]
+    #[error("Failed to update interrupt source group: {0}")]
     UpdateInterruptGroup(#[source] io::Error),
 
     /// Failed to create interrupt controller.
-    #[error("Failed to create interrupt controller")]
+    #[error("Failed to create interrupt controller: {0}")]
     CreateInterruptController(#[source] interrupt_controller::Error),
 
     /// Failed to create a new MmapRegion instance.
-    #[error("Failed to create a new MmapRegion instance")]
+    #[error("Failed to create a new MmapRegion instance: {0}")]
     NewMmapRegion(#[source] vm_memory::mmap::MmapRegionError),
 
     /// Failed to clone a File.
@@ -405,15 +405,15 @@ pub enum DeviceManagerError {
     CloneFile(#[source] io::Error),
 
     /// Failed to create socket file
-    #[error("Failed to create socket file")]
+    #[error("Failed to create socket file: {0}")]
     CreateSocketFile(#[source] io::Error),
 
     /// Failed to spawn the network backend
-    #[error("Failed to spawn the network backend")]
+    #[error("Failed to spawn the network backend: {0}")]
     SpawnNetBackend(#[source] io::Error),
 
     /// Failed to spawn the block backend
-    #[error("Failed to spawn the block backend")]
+    #[error("Failed to spawn the block backend: {0}")]
     SpawnBlockBackend(#[source] io::Error),
 
     /// Missing PCI bus.
@@ -429,15 +429,15 @@ pub enum DeviceManagerError {
     MissingPciDevice,
 
     /// Failed to remove a PCI device from the PCI bus.
-    #[error("Failed to remove a PCI device from the PCI bus")]
-    RemoveDeviceFromPciBus(pci::PciRootError),
+    #[error("Failed to remove a PCI device from the PCI bus: {0}")]
+    RemoveDeviceFromPciBus(#[source] pci::PciRootError),
 
     /// Failed to remove a bus device from the IO bus.
-    #[error("Failed to remove a bus device from the IO bus")]
+    #[error("Failed to remove a bus device from the IO bus: {0}")]
     RemoveDeviceFromIoBus(#[source] vm_device::BusError),
 
     /// Failed to remove a bus device from the MMIO bus.
-    #[error("Failed to remove a bus device from the MMIO bus")]
+    #[error("Failed to remove a bus device from the MMIO bus: {0}")]
     RemoveDeviceFromMmioBus(#[source] vm_device::BusError),
 
     /// Failed to find the device corresponding to a specific PCI b/d/f.
@@ -445,7 +445,7 @@ pub enum DeviceManagerError {
     UnknownPciBdf(u32),
 
     /// Not allowed to remove this type of device from the VM.
-    #[error("Not allowed to remove this type of device from the VM")]
+    #[error("Not allowed to remove this type of device from the VM: {0}")]
     RemovalNotAllowed(vm_virtio::VirtioDeviceType),
 
     /// Failed to find device corresponding to the given identifier.
@@ -453,35 +453,35 @@ pub enum DeviceManagerError {
     UnknownDeviceId(String),
 
     /// Failed to find an available PCI device ID.
-    #[error("Failed to find an available PCI device ID")]
-    NextPciDeviceId(pci::PciRootError),
+    #[error("Failed to find an available PCI device ID: {0}")]
+    NextPciDeviceId(#[source] pci::PciRootError),
 
     /// Could not reserve the PCI device ID.
-    #[error("Could not reserve the PCI device ID")]
-    GetPciDeviceId(pci::PciRootError),
+    #[error("Could not reserve the PCI device ID: {0}")]
+    GetPciDeviceId(#[source] pci::PciRootError),
 
     /// Could not give the PCI device ID back.
-    #[error("Could not give the PCI device ID back")]
-    PutPciDeviceId(pci::PciRootError),
+    #[error("Could not give the PCI device ID back: {0}")]
+    PutPciDeviceId(#[source] pci::PciRootError),
 
     /// No disk path was specified when one was expected
     #[error("No disk path was specified when one was expected")]
     NoDiskPath,
 
     /// Failed to update guest memory for virtio device.
-    #[error("Failed to update guest memory for virtio device")]
+    #[error("Failed to update guest memory for virtio device: {0}")]
     UpdateMemoryForVirtioDevice(#[source] virtio_devices::Error),
 
     /// Cannot create virtio-mem device
-    #[error("Cannot create virtio-mem device")]
-    CreateVirtioMem(io::Error),
+    #[error("Cannot create virtio-mem device: {0}")]
+    CreateVirtioMem(#[source] io::Error),
 
     /// Cannot find a memory range for virtio-mem memory
     #[error("Cannot find a memory range for virtio-mem memory")]
     VirtioMemRangeAllocation,
 
     /// Failed to update guest memory for VFIO PCI device.
-    #[error("Failed to update guest memory for VFIO PCI device")]
+    #[error("Failed to update guest memory for VFIO PCI device: {0}")]
     UpdateMemoryForVfioPciDevice(#[source] vfio_ioctls::VfioError),
 
     /// Trying to use a directory for pmem but no size specified
@@ -517,7 +517,7 @@ pub enum DeviceManagerError {
     NoSocketOptionSupportForConsoleDevice,
 
     /// Failed to resize virtio-balloon
-    #[error("Failed to resize virtio-balloon")]
+    #[error("Failed to resize virtio-balloon: {0}")]
     VirtioBalloonResize(#[source] virtio_devices::balloon::Error),
 
     /// Missing virtio-balloon, can't proceed as expected.
@@ -529,76 +529,76 @@ pub enum DeviceManagerError {
     MissingVirtualIommu,
 
     /// Failed to do power button notification
-    #[error("Failed to do power button notification")]
+    #[error("Failed to do power button notification: {0}")]
     PowerButtonNotification(#[source] io::Error),
 
     /// Failed to do AArch64 GPIO power button notification
     #[cfg(target_arch = "aarch64")]
-    #[error("Failed to do AArch64 GPIO power button notification")]
-    AArch64PowerButtonNotification(devices::legacy::GpioDeviceError),
+    #[error("Failed to do AArch64 GPIO power button notification: {0}")]
+    AArch64PowerButtonNotification(#[source] devices::legacy::GpioDeviceError),
 
     /// Failed to set O_DIRECT flag to file descriptor
     #[error("Failed to set O_DIRECT flag to file descriptor")]
     SetDirectIo,
 
     /// Failed to create FixedVhdDiskAsync
-    #[error("Failed to create FixedVhdDiskAsync")]
+    #[error("Failed to create FixedVhdDiskAsync: {0}")]
     CreateFixedVhdDiskAsync(#[source] io::Error),
 
     /// Failed to create FixedVhdDiskSync
-    #[error("Failed to create FixedVhdDiskSync")]
+    #[error("Failed to create FixedVhdDiskSync: {0}")]
     CreateFixedVhdDiskSync(#[source] io::Error),
 
     /// Failed to create QcowDiskSync
-    #[error("Failed to create QcowDiskSync")]
+    #[error("Failed to create QcowDiskSync: {0}")]
     CreateQcowDiskSync(#[source] qcow::Error),
 
     /// Failed to create FixedVhdxDiskSync
-    #[error("Failed to create FixedVhdxDiskSync")]
+    #[error("Failed to create FixedVhdxDiskSync: {0}")]
     CreateFixedVhdxDiskSync(#[source] vhdx::VhdxError),
 
     /// Failed to add DMA mapping handler to virtio-mem device.
-    #[error("Failed to add DMA mapping handler to virtio-mem device")]
+    #[error("Failed to add DMA mapping handler to virtio-mem device: {0}")]
     AddDmaMappingHandlerVirtioMem(#[source] virtio_devices::mem::Error),
 
     /// Failed to remove DMA mapping handler from virtio-mem device.
-    #[error("Failed to remove DMA mapping handler from virtio-mem device")]
+    #[error("Failed to remove DMA mapping handler from virtio-mem device: {0}")]
     RemoveDmaMappingHandlerVirtioMem(#[source] virtio_devices::mem::Error),
 
     /// Failed to create vfio-user client
-    #[error("Failed to create vfio-user client")]
+    #[error("Failed to create vfio-user client: {0}")]
     VfioUserCreateClient(#[source] vfio_user::Error),
 
     /// Failed to create VFIO user device
-    #[error("Failed to create VFIO user device")]
+    #[error("Failed to create VFIO user device: {0}")]
     VfioUserCreate(#[source] VfioUserPciDeviceError),
 
     /// Failed to map region from VFIO user device into guest
-    #[error("Failed to map region from VFIO user device into guest")]
+    #[error("Failed to map region from VFIO user device into guest: {0}")]
     VfioUserMapRegion(#[source] VfioUserPciDeviceError),
 
     /// Failed to DMA map VFIO user device.
-    #[error("Failed to DMA map VFIO user device")]
+    #[error("Failed to DMA map VFIO user device: {0}")]
     VfioUserDmaMap(#[source] VfioUserPciDeviceError),
 
     /// Failed to DMA unmap VFIO user device.
-    #[error("Failed to DMA unmap VFIO user device")]
+    #[error("Failed to DMA unmap VFIO user device: {0}")]
     VfioUserDmaUnmap(#[source] VfioUserPciDeviceError),
 
     /// Failed to update memory mappings for VFIO user device
-    #[error("Failed to update memory mappings for VFIO user device")]
+    #[error("Failed to update memory mappings for VFIO user device: {0}")]
     UpdateMemoryForVfioUserPciDevice(#[source] VfioUserPciDeviceError),
 
     /// Cannot duplicate file descriptor
-    #[error("Cannot duplicate file descriptor")]
+    #[error("Cannot duplicate file descriptor: {0}")]
     DupFd(#[source] vmm_sys_util::errno::Error),
 
     /// Failed to DMA map virtio device.
-    #[error("Failed to DMA map virtio device")]
+    #[error("Failed to DMA map virtio device: {0}")]
     VirtioDmaMap(#[source] std::io::Error),
 
     /// Failed to DMA unmap virtio device.
-    #[error("Failed to DMA unmap virtio device")]
+    #[error("Failed to DMA unmap virtio device: {0}")]
     VirtioDmaUnmap(#[source] std::io::Error),
 
     /// Cannot hotplug device behind vIOMMU
@@ -606,31 +606,31 @@ pub enum DeviceManagerError {
     InvalidIommuHotplug,
 
     /// Invalid identifier as it is not unique.
-    #[error("Invalid identifier as it is not unique")]
+    #[error("Invalid identifier as it is not unique: {0}")]
     IdentifierNotUnique(String),
 
     /// Invalid identifier
-    #[error("Invalid identifier")]
+    #[error("Invalid identifier: {0}")]
     InvalidIdentifier(String),
 
     /// Error activating virtio device
-    #[error("Error activating virtio device")]
+    #[error("Error activating virtio device: {0}")]
     VirtioActivate(#[source] ActivateError),
 
     /// Failed retrieving device state from snapshot
-    #[error("Failed retrieving device state from snapshot")]
+    #[error("Failed retrieving device state from snapshot: {0}")]
     RestoreGetState(#[source] MigratableError),
 
     /// Cannot create a PvPanic device
-    #[error("Cannot create a PvPanic device")]
+    #[error("Cannot create a PvPanic device: {0}")]
     PvPanicCreate(#[source] devices::pvpanic::PvPanicError),
 
     /// Cannot create a RateLimiterGroup
-    #[error("Cannot create a RateLimiterGroup")]
+    #[error("Cannot create a RateLimiterGroup: {0}")]
     RateLimiterGroupCreate(#[source] rate_limiter::group::Error),
 
     /// Cannot start sigwinch listener
-    #[error("Cannot start sigwinch listener")]
+    #[error("Cannot start sigwinch listener: {0}")]
     StartSigwinchListener(#[source] std::io::Error),
 
     // Invalid console info

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -216,7 +216,7 @@ pub enum DeviceManagerError {
 
     /// Cannot create virtio-vsock backend
     #[error("Cannot create virtio-vsock backend")]
-    CreateVsockBackend(virtio_devices::vsock::VsockUnixError),
+    CreateVsockBackend(#[source] virtio_devices::vsock::VsockUnixError),
 
     /// Cannot create virtio-iommu device
     #[error("Cannot create virtio-iommu device: {0}")]


### PR DESCRIPTION
**EDIT**: This is a prerequisite for #7066. To have smaller PRs, this is a split-out.

The DeviceManagerError type is among the types missing the `Error` trait so
far. To streamline the code and to simplify usage on higher levels of this
error type, this type now implements Display and Error.

As not all variant values are Error yet, `#[source]` is not everywhere where
it could be. This is done in the next commits.

The high level goal is: Enable future work to improve the error output of
cloud hypervisor.

