### PR TITLE
pci: vfio: Update IOMMU mappings of MMIO regions with BAR reprogram

### DIFF
--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1893,6 +1893,23 @@ impl PciDevice for VfioPciDevice {
                 region.start = GuestAddress(new_base);
 
                 for user_memory_region in region.user_memory_regions.iter_mut() {
+                    // Unmap the old MMIO region from vfio container
+                    if !self.iommu_attached {
+                        if let Err(e) = self
+                            .container
+                            .vfio_dma_unmap(user_memory_region.start, user_memory_region.size)
+                            .map_err(|e| {
+                                VfioPciError::DmaUnmap(e, self.device_path.clone(), self.bdf)
+                            })
+                        {
+                            error!(
+                                "Could not unmap mmio region from vfio container: \
+                                iova 0x{:x}, size 0x{:x}: {}, ",
+                                user_memory_region.start, user_memory_region.size, e
+                            );
+                        }
+                    }
+
                     // Remove old region
                     let old_mem_region = self.vm.make_user_memory_region(
                         user_memory_region.slot,
@@ -1927,6 +1944,26 @@ impl PciDevice for VfioPciDevice {
                     self.vm
                         .create_user_memory_region(new_mem_region)
                         .map_err(io::Error::other)?;
+
+                    // Map the moved mmio region to vfio container
+                    if !self.iommu_attached {
+                        self.container
+                            .vfio_dma_map(
+                                user_memory_region.start,
+                                user_memory_region.size,
+                                user_memory_region.host_addr,
+                            )
+                            .map_err(|e| {
+                                VfioPciError::DmaMap(e, self.device_path.clone(), self.bdf)
+                            })
+                            .map_err(|e| {
+                                io::Error::other(format!(
+                                    "Could not map mmio region to vfio container: \
+                                    iova 0x{:x}, size 0x{:x}: {}, ",
+                                    user_memory_region.start, user_memory_region.size, e
+                                ))
+                            })?;
+                    }
                 }
             }
         }

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1718,8 +1718,13 @@ impl VfioPciDevice {
                     if let Err(e) = self
                         .container
                         .vfio_dma_unmap(user_memory_region.start, user_memory_region.size)
+                        .map_err(|e| VfioPciError::DmaUnmap(e, self.device_path.clone(), self.bdf))
                     {
-                        error!("Could not unmap mmio region from vfio container: {}", e);
+                        error!(
+                            "Could not unmap mmio region from vfio container: \
+                            iova 0x{:x}, size 0x{:x}: {}, ",
+                            user_memory_region.start, user_memory_region.size, e
+                        );
                     }
                 }
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -760,6 +760,7 @@ fn create_vcpu_ioctl_seccomp_rule(
     let mut rules = or![
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_DEVICE_SET_IRQS)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_GROUP_UNSET_CONTAINER)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, VFIO_IOMMU_MAP_DMA)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_IOMMU_UNMAP_DMA)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VHOST_VDPA_SET_STATUS)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VHOST_VDPA_GET_CONFIG)?],


### PR DESCRIPTION
Note: this PR depends on #7057 and #7063

To support PCIe P2P between VFIO devices, we populate IOMMU mappings for
the non-emulated MMIO regions of all VFIO devices via
`VFIO_IOMMU_MAP_DMA` (https://github.com/cloud-hypervisor/cloud-hypervisor/commit/f0c1f8d079d90d2390b2c01a88d81cd00dd08209), but the patch did not properly update
the IOMMU mappings with BAR reprogramming.

Fixes: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7027