### PR TITLE
build: Bump mshv crates from 0.5.0 to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,9 +1257,9 @@ checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
 name = "mshv-bindings"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7ebac759cce39aee9b81e19c8182a811161e4439a54ae47bc604e3b6a26ca7"
+checksum = "909de5fd4a5a3347a6c62872f6816e6279efd8615a753f10a3bc4daaef8a72ef"
 dependencies = [
  "libc",
  "num_enum",
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d0777bea77576c91f7d6a6fed2e188433b3f102a38fb2b5aba259e9690e896"
+checksum = "8c7d94972588d562bd349b916de6a43f2ee268e6e9c91cfb5b30549ed4ea2751"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ acpi_tables = { git = "https://github.com/rust-vmm/acpi_tables", branch = "main"
 kvm-bindings = "0.10.0"
 kvm-ioctls = "0.19.1"
 linux-loader = "0.13.0"
-mshv-bindings = "0.5.0"
-mshv-ioctls = "0.5.0"
+mshv-bindings = "0.5.1"
+mshv-ioctls = "0.5.1"
 seccompiler = "0.5.0"
 vfio-bindings = { git = "https://github.com/rust-vmm/vfio", branch = "main" }
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }


### PR DESCRIPTION
This release has critical bug fixes IOCTL changes. No API changes.