### PR TITLE
treewide: streamline #[source] and Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,6 +1435,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "option_parser"
 version = "0.1.0"
+dependencies = [
+ "thiserror 2.0.6",
+]
 
 [[package]]
 name = "ordered-stream"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,6 +2353,7 @@ dependencies = [
  "log",
  "net_util",
  "option_parser",
+ "thiserror 2.0.6",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,6 +2333,7 @@ dependencies = [
  "libc",
  "log",
  "option_parser",
+ "thiserror 2.0.6",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",

--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -12,15 +12,15 @@ use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Error writing to or reading from HTTP socket: {0}")]
-    Socket(std::io::Error),
+    Socket(#[source] std::io::Error),
     #[error("Error sending file descriptors: {0}")]
-    SocketSendFds(vmm_sys_util::errno::Error),
+    SocketSendFds(#[source] vmm_sys_util::errno::Error),
     #[error("Error parsing HTTP status code: {0}")]
-    StatusCodeParsing(std::num::ParseIntError),
+    StatusCodeParsing(#[source] std::num::ParseIntError),
     #[error("HTTP output is missing protocol statement")]
     MissingProtocol,
     #[error("Error parsing HTTP Content-Length field: {0}")]
-    ContentLengthParsing(std::num::ParseIntError),
+    ContentLengthParsing(#[source] std::num::ParseIntError),
     #[error("Server responded with an error: {0:?}: {1:?}")]
     ServerResponse(StatusCode, Option<String>),
 }

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -82,7 +82,7 @@ pub trait DeviceInfoForFdt {
 pub enum Error {
     /// Failure in writing FDT in memory.
     #[error("Failure in writing FDT in memory: {0}")]
-    WriteFdtToMemory(GuestMemoryError),
+    WriteFdtToMemory(#[source] GuestMemoryError),
 }
 type Result<T> = result::Result<T, Error>;
 

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -33,7 +33,7 @@ pub enum Error {
 
     /// Failed to write FDT to memory.
     #[error("Failed to write FDT to memory: {0}")]
-    WriteFdtToMemory(fdt::Error),
+    WriteFdtToMemory(#[source] fdt::Error),
 
     /// Failed to create a GIC.
     #[error("Failed to create a GIC")]
@@ -45,11 +45,11 @@ pub enum Error {
 
     /// Error configuring the general purpose registers
     #[error("Error configuring the general purpose registers: {0}")]
-    RegsConfiguration(hypervisor::HypervisorCpuError),
+    RegsConfiguration(#[source] hypervisor::HypervisorCpuError),
 
     /// Error configuring the MPIDR register
     #[error("Error configuring the MPIDR register: {0}")]
-    VcpuRegMpidr(hypervisor::HypervisorCpuError),
+    VcpuRegMpidr(#[source] hypervisor::HypervisorCpuError),
 
     /// Error initializing PMU for vcpu
     #[error("Error initializing PMU for vcpu")]

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -28,14 +28,14 @@ type GuestRegionMmap = vm_memory::GuestRegionMmap<vm_memory::bitmap::AtomicBitma
 #[derive(Debug, Error)]
 pub enum Error {
     #[cfg(target_arch = "x86_64")]
-    #[error("Platform specific error (x86_64): {0:?}")]
-    PlatformSpecific(x86_64::Error),
+    #[error("Platform specific error (x86_64): {0}")]
+    PlatformSpecific(#[source] x86_64::Error),
     #[cfg(target_arch = "aarch64")]
     #[error("Platform specific error (aarch64): {0:?}")]
-    PlatformSpecific(aarch64::Error),
+    PlatformSpecific(#[source] aarch64::Error),
     #[cfg(target_arch = "riscv64")]
     #[error("Platform specific error (riscv64): {0:?}")]
-    PlatformSpecific(riscv64::Error),
+    PlatformSpecific(#[source] riscv64::Error),
     #[error("The memory map table extends past the end of guest memory")]
     MemmapTablePastRamEnd,
     #[error("Error writing memory map table to guest memory")]

--- a/arch/src/riscv64/fdt.rs
+++ b/arch/src/riscv64/fdt.rs
@@ -55,7 +55,7 @@ pub trait DeviceInfoForFdt {
 pub enum Error {
     /// Failure in writing FDT in memory.
     #[error("Failure in writing FDT in memory: {0}")]
-    WriteFdtToMemory(GuestMemoryError),
+    WriteFdtToMemory(#[source] GuestMemoryError),
 }
 type Result<T> = result::Result<T, Error>;
 

--- a/arch/src/riscv64/mod.rs
+++ b/arch/src/riscv64/mod.rs
@@ -31,7 +31,7 @@ pub enum Error {
 
     /// Failed to write FDT to memory.
     #[error("Failed to write FDT to memory: {0}")]
-    WriteFdtToMemory(fdt::Error),
+    WriteFdtToMemory(#[source] fdt::Error),
 
     /// Failed to create a AIA.
     #[error("Failed to create a AIA")]
@@ -43,7 +43,7 @@ pub enum Error {
 
     /// Error configuring the general purpose registers
     #[error("Error configuring the general purpose registers: {0}")]
-    RegsConfiguration(hypervisor::HypervisorCpuError),
+    RegsConfiguration(#[source] hypervisor::HypervisorCpuError),
 }
 
 impl From<Error> for super::Error {

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -133,35 +133,35 @@ pub struct CpuidConfig {
 pub enum Error {
     /// Error writing MP table to memory.
     #[error("Error writing MP table to memory: {0}")]
-    MpTableSetup(mptable::Error),
+    MpTableSetup(#[source] mptable::Error),
 
     /// Error configuring the general purpose registers
     #[error("Error configuring the general purpose registers: {0}")]
-    RegsConfiguration(regs::Error),
+    RegsConfiguration(#[source] regs::Error),
 
     /// Error configuring the special registers
     #[error("Error configuring the special registers: {0}")]
-    SregsConfiguration(regs::Error),
+    SregsConfiguration(#[source] regs::Error),
 
     /// Error configuring the floating point related registers
     #[error("Error configuring the floating point related registers: {0}")]
-    FpuConfiguration(regs::Error),
+    FpuConfiguration(#[source] regs::Error),
 
     /// Error configuring the MSR registers
     #[error("Error configuring the MSR registers: {0}")]
-    MsrsConfiguration(regs::Error),
+    MsrsConfiguration(#[source] regs::Error),
 
     /// Failed to set supported CPUs.
     #[error("Failed to set supported CPUs: {0}")]
-    SetSupportedCpusFailed(anyhow::Error),
+    SetSupportedCpusFailed(#[source] anyhow::Error),
 
     /// Cannot set the local interruption due to bad configuration.
     #[error("Cannot set the local interruption due to bad configuration: {0}")]
-    LocalIntConfiguration(anyhow::Error),
+    LocalIntConfiguration(#[source] anyhow::Error),
 
     /// Error setting up SMBIOS table
     #[error("Error setting up SMBIOS table: {0}")]
-    SmbiosSetup(smbios::Error),
+    SmbiosSetup(#[source] smbios::Error),
 
     /// Could not find any SGX EPC section
     #[error("Could not find any SGX EPC section")]
@@ -177,15 +177,15 @@ pub enum Error {
 
     /// Error getting supported CPUID through the hypervisor (kvm/mshv) API
     #[error("Error getting supported CPUID through the hypervisor API: {0}")]
-    CpuidGetSupported(HypervisorError),
+    CpuidGetSupported(#[source] HypervisorError),
 
     /// Error populating CPUID with KVM HyperV emulation details
     #[error("Error populating CPUID with KVM HyperV emulation details: {0}")]
-    CpuidKvmHyperV(vmm_sys_util::fam::Error),
+    CpuidKvmHyperV(#[source] vmm_sys_util::fam::Error),
 
     /// Error populating CPUID with CPU identification
     #[error("Error populating CPUID with CPU identification: {0}")]
-    CpuidIdentification(vmm_sys_util::fam::Error),
+    CpuidIdentification(#[source] vmm_sys_util::fam::Error),
 
     /// Error checking CPUID compatibility
     #[error("Error checking CPUID compatibility")]
@@ -193,11 +193,11 @@ pub enum Error {
 
     // Error writing EBDA address
     #[error("Error writing EBDA address: {0}")]
-    EbdaSetup(vm_memory::GuestMemoryError),
+    EbdaSetup(#[source] vm_memory::GuestMemoryError),
 
     // Error getting CPU TSC frequency
     #[error("Error getting CPU TSC frequency: {0}")]
-    GetTscFrequency(HypervisorCpuError),
+    GetTscFrequency(#[source] HypervisorCpuError),
 
     /// Error retrieving TDX capabilities through the hypervisor (kvm/mshv) API
     #[cfg(feature = "tdx")]

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -66,25 +66,25 @@ pub enum Error {
     TooManyCpus,
     /// Failure to write the MP floating pointer.
     #[error("Failure to write the MP floating pointer: {0}")]
-    WriteMpfIntel(GuestMemoryError),
+    WriteMpfIntel(#[source] GuestMemoryError),
     /// Failure to write MP CPU entry.
     #[error("Failure to write MP CPU entry: {0}")]
-    WriteMpcCpu(GuestMemoryError),
+    WriteMpcCpu(#[source] GuestMemoryError),
     /// Failure to write MP ioapic entry.
     #[error("Failure to write MP ioapic entry: {0}")]
-    WriteMpcIoapic(GuestMemoryError),
+    WriteMpcIoapic(#[source] GuestMemoryError),
     /// Failure to write MP bus entry.
     #[error("Failure to write MP bus entry: {0}")]
-    WriteMpcBus(GuestMemoryError),
+    WriteMpcBus(#[source] GuestMemoryError),
     /// Failure to write MP interrupt source entry.
     #[error("Failure to write MP interrupt source entry: {0}")]
-    WriteMpcIntsrc(GuestMemoryError),
+    WriteMpcIntsrc(#[source] GuestMemoryError),
     /// Failure to write MP local interrupt source entry.
     #[error("Failure to write MP local interrupt source entry: {0}")]
-    WriteMpcLintsrc(GuestMemoryError),
+    WriteMpcLintsrc(#[source] GuestMemoryError),
     /// Failure to write MP table header.
     #[error("Failure to write MP table header: {0}")]
-    WriteMpcTable(GuestMemoryError),
+    WriteMpcTable(#[source] GuestMemoryError),
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -24,40 +24,40 @@ use crate::{EntryPoint, GuestMemoryMmap};
 pub enum Error {
     /// Failed to get SREGs for this CPU.
     #[error("Failed to get SREGs for this CPU: {0}")]
-    GetStatusRegisters(hypervisor::HypervisorCpuError),
+    GetStatusRegisters(#[source] hypervisor::HypervisorCpuError),
     /// Failed to set base registers for this CPU.
     #[error("Failed to set base registers for this CPU: {0}")]
-    SetBaseRegisters(hypervisor::HypervisorCpuError),
+    SetBaseRegisters(#[source] hypervisor::HypervisorCpuError),
     /// Failed to configure the FPU.
     #[error("Failed to configure the FPU: {0}")]
-    SetFpuRegisters(hypervisor::HypervisorCpuError),
+    SetFpuRegisters(#[source] hypervisor::HypervisorCpuError),
     /// Setting up MSRs failed.
     #[error("Setting up MSRs failed: {0}")]
-    SetModelSpecificRegisters(hypervisor::HypervisorCpuError),
+    SetModelSpecificRegisters(#[source] hypervisor::HypervisorCpuError),
     /// Failed to set SREGs for this CPU.
     #[error("Failed to set SREGs for this CPU: {0}")]
-    SetStatusRegisters(hypervisor::HypervisorCpuError),
+    SetStatusRegisters(#[source] hypervisor::HypervisorCpuError),
     /// Checking the GDT address failed.
     #[error("Checking the GDT address failed")]
     CheckGdtAddr,
     /// Writing the GDT to RAM failed.
     #[error("Writing the GDT to RAM failed: {0}")]
-    WriteGdt(GuestMemoryError),
+    WriteGdt(#[source] GuestMemoryError),
     /// Writing the IDT to RAM failed.
     #[error("Writing the IDT to RAM failed: {0}")]
-    WriteIdt(GuestMemoryError),
+    WriteIdt(#[source] GuestMemoryError),
     /// Writing PDPTE to RAM failed.
     #[error("Writing PDPTE to RAM failed: {0}")]
-    WritePdpteAddress(GuestMemoryError),
+    WritePdpteAddress(#[source] GuestMemoryError),
     /// Writing PDE to RAM failed.
     #[error("Writing PDE to RAM failed: {0}")]
-    WritePdeAddress(GuestMemoryError),
+    WritePdeAddress(#[source] GuestMemoryError),
     /// Writing PML4 to RAM failed.
     #[error("Writing PML4 to RAM failed: {0}")]
-    WritePml4Address(GuestMemoryError),
+    WritePml4Address(#[source] GuestMemoryError),
     /// Writing PML5 to RAM failed.
     #[error("Writing PML5 to RAM failed: {0}")]
-    WritePml5Address(GuestMemoryError),
+    WritePml5Address(#[source] GuestMemoryError),
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -34,7 +34,7 @@ pub enum Error {
     WriteData,
     /// Failure to parse uuid, uuid format may be error
     #[error("Failure to parse uuid: {0}")]
-    ParseUuid(uuid::Error),
+    ParseUuid(#[source] uuid::Error),
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -68,9 +68,9 @@ pub const SECTOR_SIZE: u64 = 0x01 << SECTOR_SHIFT;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Guest gave us bad memory addresses")]
-    GuestMemory(GuestMemoryError),
+    GuestMemory(#[source] GuestMemoryError),
     #[error("Guest gave us offsets that would have overflowed a usize")]
-    CheckedOffset(GuestAddress, usize),
+    CheckedOffset(GuestAddress, usize /* sector offset */),
     #[error("Guest gave us a write only descriptor that protocol says to read from")]
     UnexpectedWriteOnlyDescriptor,
     #[error("Guest gave us a read only descriptor that protocol says to write to")]
@@ -80,21 +80,21 @@ pub enum Error {
     #[error("Guest gave us a descriptor that was too short to use")]
     DescriptorLengthTooSmall,
     #[error("Failed to detect image type: {0}")]
-    DetectImageType(std::io::Error),
+    DetectImageType(#[source] std::io::Error),
     #[error("Failure in fixed vhd: {0}")]
-    FixedVhdError(std::io::Error),
+    FixedVhdError(#[source] std::io::Error),
     #[error("Getting a block's metadata fails for any reason")]
     GetFileMetadata,
     #[error("The requested operation would cause a seek beyond disk end")]
     InvalidOffset,
     #[error("Failure in qcow: {0}")]
-    QcowError(qcow::Error),
+    QcowError(#[source] qcow::Error),
     #[error("Failure in raw file: {0}")]
-    RawFileError(std::io::Error),
+    RawFileError(#[source] std::io::Error),
     #[error("The requested operation does not support multiple descriptors")]
     TooManyDescriptors,
     #[error("Failure in vhdx: {0}")]
-    VhdxError(VhdxError),
+    VhdxError(#[source] VhdxError),
 }
 
 fn build_device_id(disk_path: &Path) -> result::Result<String, Error> {
@@ -132,33 +132,33 @@ pub fn build_serial(disk_path: &Path) -> Vec<u8> {
 #[derive(Error, Debug)]
 pub enum ExecuteError {
     #[error("Bad request: {0}")]
-    BadRequest(Error),
+    BadRequest(#[source] Error),
     #[error("Failed to flush: {0}")]
-    Flush(io::Error),
+    Flush(#[source] io::Error),
     #[error("Failed to read: {0}")]
-    Read(GuestMemoryError),
+    Read(#[source] GuestMemoryError),
     #[error("Failed to read_exact: {0}")]
-    ReadExact(io::Error),
+    ReadExact(#[source] io::Error),
     #[error("Failed to seek: {0}")]
-    Seek(io::Error),
+    Seek(#[source] io::Error),
     #[error("Failed to write: {0}")]
-    Write(GuestMemoryError),
+    Write(#[source] GuestMemoryError),
     #[error("Failed to write_all: {0}")]
-    WriteAll(io::Error),
+    WriteAll(#[source] io::Error),
     #[error("Unsupported request: {0}")]
     Unsupported(u32),
     #[error("Failed to submit io uring: {0}")]
-    SubmitIoUring(io::Error),
+    SubmitIoUring(#[source] io::Error),
     #[error("Failed to get guest address: {0}")]
-    GetHostAddress(GuestMemoryError),
+    GetHostAddress(#[source] GuestMemoryError),
     #[error("Failed to async read: {0}")]
-    AsyncRead(AsyncIoError),
+    AsyncRead(#[source] AsyncIoError),
     #[error("Failed to async write: {0}")]
-    AsyncWrite(AsyncIoError),
+    AsyncWrite(#[source] AsyncIoError),
     #[error("failed to async flush: {0}")]
-    AsyncFlush(AsyncIoError),
+    AsyncFlush(#[source] AsyncIoError),
     #[error("Failed allocating a temporary buffer: {0}")]
-    TemporaryBufferAllocation(io::Error),
+    TemporaryBufferAllocation(#[source] io::Error),
 }
 
 impl ExecuteError {

--- a/block/src/qcow/mod.rs
+++ b/block/src/qcow/mod.rs
@@ -37,23 +37,23 @@ const MAX_NESTING_DEPTH: u32 = 10;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Backing file io error: {0}")]
-    BackingFileIo(io::Error),
+    BackingFileIo(#[source] io::Error),
     #[error("Backing file open error: {0}")]
-    BackingFileOpen(Box<Error>),
+    BackingFileOpen(#[source] Box<Error>),
     #[error("Backing file name is too long: {0} bytes over")]
     BackingFileTooLong(usize),
     #[error("Compressed blocks not supported")]
     CompressedBlocksNotSupported,
     #[error("Failed to evict cache: {0}")]
-    EvictingCache(io::Error),
+    EvictingCache(#[source] io::Error),
     #[error("File larger than max of {MAX_QCOW_FILE_SIZE}: {0}")]
     FileTooBig(u64),
     #[error("Failed to get file size: {0}")]
-    GettingFileSize(io::Error),
+    GettingFileSize(#[source] io::Error),
     #[error("Failed to get refcount: {0}")]
-    GettingRefcount(refcount::Error),
+    GettingRefcount(#[source] refcount::Error),
     #[error("Failed to parse filename: {0}")]
-    InvalidBackingFileName(str::Utf8Error),
+    InvalidBackingFileName(#[source] str::Utf8Error),
     #[error("Invalid cluster index")]
     InvalidClusterIndex,
     #[error("Invalid cluster size")]
@@ -81,29 +81,29 @@ pub enum Error {
     #[error("Not enough space for refcounts")]
     NotEnoughSpaceForRefcounts,
     #[error("Failed to open file {0}")]
-    OpeningFile(io::Error),
+    OpeningFile(#[source] io::Error),
     #[error("Failed to read data: {0}")]
-    ReadingData(io::Error),
+    ReadingData(#[source] io::Error),
     #[error("Failed to read header: {0}")]
-    ReadingHeader(io::Error),
+    ReadingHeader(#[source] io::Error),
     #[error("Failed to read pointers: {0}")]
-    ReadingPointers(io::Error),
+    ReadingPointers(#[source] io::Error),
     #[error("Failed to read ref count block: {0}")]
-    ReadingRefCountBlock(refcount::Error),
+    ReadingRefCountBlock(#[source] refcount::Error),
     #[error("Failed to read ref counts: {0}")]
-    ReadingRefCounts(io::Error),
+    ReadingRefCounts(#[source] io::Error),
     #[error("Failed to rebuild ref counts: {0}")]
-    RebuildingRefCounts(io::Error),
+    RebuildingRefCounts(#[source] io::Error),
     #[error("Refcount table offset past file end")]
     RefcountTableOffEnd,
     #[error("Too many clusters specified for refcount")]
     RefcountTableTooLarge,
     #[error("Failed to seek file: {0}")]
-    SeekingFile(io::Error),
+    SeekingFile(#[source] io::Error),
     #[error("Failed to set file size: {0}")]
-    SettingFileSize(io::Error),
+    SettingFileSize(#[source] io::Error),
     #[error("Failed to set refcount refcount: {0}")]
-    SettingRefcountRefcount(io::Error),
+    SettingRefcountRefcount(#[source] io::Error),
     #[error("Size too small for number of clusters")]
     SizeTooSmallForNumberOfClusters,
     #[error("L1 entry table too large: {0}")]
@@ -115,9 +115,9 @@ pub enum Error {
     #[error("Unsupported version: {0}")]
     UnsupportedVersion(u32),
     #[error("Failed to write data: {0}")]
-    WritingData(io::Error),
+    WritingData(#[source] io::Error),
     #[error("Failed to write header: {0}")]
-    WritingHeader(io::Error),
+    WritingHeader(#[source] io::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/block/src/qcow/refcount.rs
+++ b/block/src/qcow/refcount.rs
@@ -16,7 +16,7 @@ use crate::qcow::vec_cache::{CacheMap, Cacheable, VecCache};
 pub enum Error {
     /// `EvictingCache` - Error writing a refblock from the cache to disk.
     #[error("Failed to write a refblock from the cache to disk: {0}")]
-    EvictingRefCounts(io::Error),
+    EvictingRefCounts(#[source] io::Error),
     /// `InvalidIndex` - Address requested isn't within the range of the disk.
     #[error("Address requested is not within the range of the disk")]
     InvalidIndex,
@@ -28,7 +28,7 @@ pub enum Error {
     NeedNewCluster,
     /// `ReadingRefCounts` - Error reading the file into the refcount cache.
     #[error("Failed to read the file into the refcount cache: {0}")]
-    ReadingRefCounts(io::Error),
+    ReadingRefCounts(#[source] io::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/block/src/vhdx/mod.rs
+++ b/block/src/vhdx/mod.rs
@@ -26,19 +26,19 @@ mod vhdx_metadata;
 #[sorted]
 #[derive(Error, Debug)]
 pub enum VhdxError {
-    #[error("Not a VHDx file {0}")]
+    #[error("Not a VHDx file: {0}")]
     NotVhdx(#[source] VhdxHeaderError),
-    #[error("Failed to parse VHDx header {0}")]
+    #[error("Failed to parse VHDx header: {0}")]
     ParseVhdxHeader(#[source] VhdxHeaderError),
-    #[error("Failed to parse VHDx metadata {0}")]
+    #[error("Failed to parse VHDx metadata: {0}")]
     ParseVhdxMetadata(#[source] VhdxMetadataError),
-    #[error("Failed to parse VHDx region entries {0}")]
+    #[error("Failed to parse VHDx region entries: {0}")]
     ParseVhdxRegionEntry(#[source] VhdxHeaderError),
-    #[error("Failed reading metadata {0}")]
+    #[error("Failed reading metadata: {0}")]
     ReadBatEntry(#[source] VhdxBatError),
-    #[error("Failed reading sector from disk {0}")]
+    #[error("Failed reading sector from disk: {0}")]
     ReadFailed(#[source] VhdxIoError),
-    #[error("Failed writing to sector on disk {0}")]
+    #[error("Failed writing to sector on disk: {0}")]
     WriteFailed(#[source] VhdxIoError),
 }
 

--- a/block/src/vhdx/vhdx_bat.rs
+++ b/block/src/vhdx/vhdx_bat.rs
@@ -33,9 +33,9 @@ pub enum VhdxBatError {
     InvalidBatEntry,
     #[error("Invalid BAT entry count")]
     InvalidEntryCount,
-    #[error("Failed to read BAT entry {0}")]
+    #[error("Failed to read BAT entry: {0}")]
     ReadBat(#[source] io::Error),
-    #[error("Failed to write BAT entry {0}")]
+    #[error("Failed to write BAT entry: {0}")]
     WriteBat(#[source] io::Error),
 }
 

--- a/devices/src/interrupt_controller.rs
+++ b/devices/src/interrupt_controller.rs
@@ -18,22 +18,22 @@ pub enum Error {
     InvalidDeliveryMode,
     /// Failed creating the interrupt source group.
     #[error("Failed creating the interrupt source group: {0}")]
-    CreateInterruptSourceGroup(io::Error),
+    CreateInterruptSourceGroup(#[source] io::Error),
     /// Failed triggering the interrupt.
     #[error("Failed triggering the interrupt: {0}")]
-    TriggerInterrupt(io::Error),
+    TriggerInterrupt(#[source] io::Error),
     /// Failed masking the interrupt.
     #[error("Failed masking the interrupt: {0}")]
-    MaskInterrupt(io::Error),
+    MaskInterrupt(#[source] io::Error),
     /// Failed unmasking the interrupt.
     #[error("Failed unmasking the interrupt: {0}")]
-    UnmaskInterrupt(io::Error),
+    UnmaskInterrupt(#[source] io::Error),
     /// Failed updating the interrupt.
     #[error("Failed updating the interrupt: {0}")]
-    UpdateInterrupt(io::Error),
+    UpdateInterrupt(#[source] io::Error),
     /// Failed enabling the interrupt.
     #[error("Failed enabling the interrupt: {0}")]
-    EnableInterrupt(io::Error),
+    EnableInterrupt(#[source] io::Error),
     #[cfg(target_arch = "aarch64")]
     /// Failed creating GIC device.
     #[error("Failed creating GIC device: {0}")]

--- a/devices/src/legacy/gpio_pl061.rs
+++ b/devices/src/legacy/gpio_pl061.rs
@@ -46,7 +46,7 @@ pub enum Error {
     #[error("GPIO interrupt disabled by guest driver.")]
     GpioInterruptDisabled,
     #[error("Could not trigger GPIO interrupt: {0}.")]
-    GpioInterruptFailure(io::Error),
+    GpioInterruptFailure(#[source] io::Error),
     #[error("Invalid GPIO Input key triggered: {0}.")]
     GpioTriggerKeyFailure(u32),
 }

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -46,7 +46,7 @@ pub enum Error {
     #[error("Bad Write Offset: {0}")]
     BadWriteOffset(u64),
     #[error("Failed to trigger interrupt: {0}")]
-    InterruptFailure(io::Error),
+    InterruptFailure(#[source] io::Error),
 }
 
 type Result<T> = result::Result<T, Error>;

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -54,11 +54,11 @@ pub enum Error {
     #[error("pl011: DMA not implemented.")]
     DmaNotImplemented,
     #[error("Failed to trigger interrupt: {0}")]
-    InterruptFailure(io::Error),
+    InterruptFailure(#[source] io::Error),
     #[error("Failed to write: {0}")]
-    WriteAllFailure(io::Error),
+    WriteAllFailure(#[source] io::Error),
     #[error("Failed to flush: {0}")]
-    FlushFailure(io::Error),
+    FlushFailure(#[source] io::Error),
 }
 
 type Result<T> = result::Result<T, Error>;

--- a/hypervisor/src/arch/aarch64/gic.rs
+++ b/hypervisor/src/arch/aarch64/gic.rs
@@ -17,13 +17,13 @@ use crate::{CpuState, HypervisorDeviceError, HypervisorVmError};
 pub enum Error {
     /// Error while calling KVM ioctl for setting up the global interrupt controller.
     #[error("Failed creating GIC device: {0}")]
-    CreateGic(HypervisorVmError),
+    CreateGic(#[source] HypervisorVmError),
     /// Error while setting device attributes for the GIC.
     #[error("Failed setting device attributes for the GIC: {0}")]
-    SetDeviceAttribute(HypervisorDeviceError),
+    SetDeviceAttribute(#[source] HypervisorDeviceError),
     /// Error while getting device attributes for the GIC.
     #[error("Failed getting device attributes for the GIC: {0}")]
-    GetDeviceAttribute(HypervisorDeviceError),
+    GetDeviceAttribute(#[source] HypervisorDeviceError),
 }
 pub type Result<T> = result::Result<T, Error>;
 

--- a/hypervisor/src/arch/emulator/mod.rs
+++ b/hypervisor/src/arch/emulator/mod.rs
@@ -82,13 +82,13 @@ pub enum EmulationError<T: Debug> {
     WrongNumberOperands(#[source] anyhow::Error),
 
     #[error("Instruction Exception: {0}")]
-    InstructionException(Exception<T>),
+    InstructionException(#[source] Exception<T>),
 
     #[error("Instruction fetching error: {0}")]
     InstructionFetchingError(#[source] anyhow::Error),
 
     #[error("Platform emulation error: {0}")]
-    PlatformEmulationError(PlatformError),
+    PlatformEmulationError(#[source] PlatformError),
 
     #[error(transparent)]
     EmulationError(#[from] anyhow::Error),

--- a/hypervisor/src/arch/riscv64/aia.rs
+++ b/hypervisor/src/arch/riscv64/aia.rs
@@ -14,13 +14,13 @@ use crate::{AiaState, HypervisorDeviceError, HypervisorVmError};
 pub enum Error {
     /// Error while calling KVM ioctl for setting up the global interrupt controller.
     #[error("Failed creating AIA device: {0}")]
-    CreateAia(HypervisorVmError),
+    CreateAia(#[source] HypervisorVmError),
     /// Error while setting device attributes for the AIA.
     #[error("Failed setting device attributes for the AIA: {0}")]
-    SetDeviceAttribute(HypervisorDeviceError),
+    SetDeviceAttribute(#[source] HypervisorDeviceError),
     /// Error while getting device attributes for the AIA.
     #[error("Failed getting device attributes for the AIA: {0}")]
-    GetDeviceAttribute(HypervisorDeviceError),
+    GetDeviceAttribute(#[source] HypervisorDeviceError),
 }
 pub type Result<T> = result::Result<T, Error>;
 

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -67,22 +67,22 @@ pub enum HypervisorError {
     ///
     /// Checking extensions failed
     ///
-    #[error("Checking extensions:{0}")]
+    #[error("Checking extensions: {0}")]
     CheckExtensions(#[source] anyhow::Error),
     ///
     /// Failed to retrieve TDX capabilities
     ///
-    #[error("Failed to retrieve TDX capabilities:{0}")]
+    #[error("Failed to retrieve TDX capabilities: {0}")]
     TdxCapabilities(#[source] anyhow::Error),
     ///
     /// Failed to set partition property
     ///
-    #[error("Failed to set partition property:{0}")]
+    #[error("Failed to set partition property: {0}")]
     SetPartitionProperty(#[source] anyhow::Error),
     ///
     /// Running on an unsupported CPU
     ///
-    #[error("Unsupported CPU:{0}")]
+    #[error("Unsupported CPU: {0}")]
     UnsupportedCpu(#[source] anyhow::Error),
     ///
     /// Launching a VM with unsupported VM Type

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -41,7 +41,7 @@ pub use tap::{Error as TapError, Tap};
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Failed to create a socket: {0}")]
-    CreateSocket(IoError),
+    CreateSocket(#[source] IoError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/net_util/src/open_tap.rs
+++ b/net_util/src/open_tap.rs
@@ -13,27 +13,27 @@ use super::{vnet_hdr_len, MacAddr, Tap, TapError};
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Failed to convert an hexadecimal string into an integer: {0}")]
-    ConvertHexStringToInt(std::num::ParseIntError),
+    ConvertHexStringToInt(#[source] std::num::ParseIntError),
     #[error("Error related to the multiqueue support (no support TAP side)")]
     MultiQueueNoTapSupport,
     #[error("Error related to the multiqueue support (no support device side)")]
     MultiQueueNoDeviceSupport,
     #[error("Failed to read the TAP flags from sysfs: {0}")]
-    ReadSysfsTunFlags(io::Error),
+    ReadSysfsTunFlags(#[source] io::Error),
     #[error("Open tap device failed: {0}")]
-    TapOpen(TapError),
+    TapOpen(#[source] TapError),
     #[error("Setting tap IP and/or netmask failed: {0}")]
-    TapSetIpNetmask(TapError),
+    TapSetIpNetmask(#[source] TapError),
     #[error("Setting MAC address failed: {0}")]
-    TapSetMac(TapError),
+    TapSetMac(#[source] TapError),
     #[error("Getting MAC address failed: {0}")]
-    TapGetMac(TapError),
+    TapGetMac(#[source] TapError),
     #[error("Setting vnet header size failed: {0}")]
-    TapSetVnetHdrSize(TapError),
+    TapSetVnetHdrSize(#[source] TapError),
     #[error("Setting MTU failed: {0}")]
-    TapSetMtu(TapError),
+    TapSetMtu(#[source] TapError),
     #[error("Enabling tap interface failed: {0}")]
-    TapEnable(TapError),
+    TapEnable(#[source] TapError),
 }
 
 type Result<T> = std::result::Result<T, Error>;

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -354,27 +354,27 @@ pub enum NetQueuePairError {
     #[error("No memory configured")]
     NoMemoryConfigured,
     #[error("Error registering listener: {0}")]
-    RegisterListener(io::Error),
+    RegisterListener(#[source] io::Error),
     #[error("Error unregistering listener: {0}")]
-    UnregisterListener(io::Error),
+    UnregisterListener(#[source] io::Error),
     #[error("Error writing to the TAP device: {0}")]
-    WriteTap(io::Error),
+    WriteTap(#[source] io::Error),
     #[error("Error reading from the TAP device: {0}")]
-    ReadTap(io::Error),
+    ReadTap(#[source] io::Error),
     #[error("Error related to guest memory: {0}")]
-    GuestMemory(vm_memory::GuestMemoryError),
+    GuestMemory(#[source] vm_memory::GuestMemoryError),
     #[error("Returned an error while iterating through the queue: {0}")]
-    QueueIteratorFailed(virtio_queue::Error),
+    QueueIteratorFailed(#[source] virtio_queue::Error),
     #[error("Descriptor chain is too short")]
     DescriptorChainTooShort,
     #[error("Descriptor chain does not contain valid descriptors")]
     DescriptorChainInvalid,
     #[error("Failed to determine if queue needed notification: {0}")]
-    QueueNeedsNotification(virtio_queue::Error),
+    QueueNeedsNotification(#[source] virtio_queue::Error),
     #[error("Failed to enable notification on the queue: {0}")]
-    QueueEnableNotification(virtio_queue::Error),
+    QueueEnableNotification(#[source] virtio_queue::Error),
     #[error("Failed to add used index to the queue: {0}")]
-    QueueAddUsed(virtio_queue::Error),
+    QueueAddUsed(#[source] virtio_queue::Error),
     #[error("Descriptor with invalid virtio-net header")]
     DescriptorInvalidHeader,
     #[error("Invalid virtio-net header")]

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -23,21 +23,21 @@ use crate::mac::MAC_ADDR_LEN;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Couldn't open /dev/net/tun: {0}")]
-    OpenTun(IoError),
+    OpenTun(#[source] IoError),
     #[error("Unable to configure tap interface: {0}")]
-    ConfigureTap(IoError),
+    ConfigureTap(#[source] IoError),
     #[error("Unable to retrieve features: {0}")]
-    GetFeatures(IoError),
+    GetFeatures(#[source] IoError),
     #[error("Missing multiqueue support in the kernel")]
     MultiQueueKernelSupport,
     #[error("ioctl ({0}) failed: {1}")]
-    IoctlError(c_ulong, IoError),
+    IoctlError(c_ulong, #[source] IoError),
     #[error("Failed to create a socket: {0}")]
-    NetUtil(NetUtilError),
+    NetUtil(#[source] NetUtilError),
     #[error("Invalid interface name")]
     InvalidIfname,
     #[error("Error parsing MAC data: {0}")]
-    MacParsing(IoError),
+    MacParsing(#[source] IoError),
     #[error("Invalid netmask")]
     InvalidNetmask,
 }

--- a/option_parser/Cargo.toml
+++ b/option_parser/Cargo.toml
@@ -3,3 +3,6 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2021"
 name = "option_parser"
 version = "0.1.0"
+
+[dependencies]
+thiserror = "2.0.6"

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -4,9 +4,10 @@
 //
 
 use std::collections::HashMap;
-use std::fmt;
 use std::num::ParseIntError;
 use std::str::FromStr;
+
+use thiserror::Error;
 
 #[derive(Default)]
 pub struct OptionParser {
@@ -18,25 +19,16 @@ struct OptionParserValue {
     requires_value: bool,
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum OptionParserError {
+    #[error("unknown option: {0}")]
     UnknownOption(String),
+    #[error("unknown option: {0}")]
     InvalidSyntax(String),
-    Conversion(String, String),
+    #[error("unable to convert {1} for {0}")]
+    Conversion(String /* field */, String /* value */),
+    #[error("invalid value: {0}")]
     InvalidValue(String),
-}
-
-impl fmt::Display for OptionParserError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            OptionParserError::UnknownOption(s) => write!(f, "unknown option: {s}"),
-            OptionParserError::InvalidSyntax(s) => write!(f, "invalid syntax:{s}"),
-            OptionParserError::Conversion(field, value) => {
-                write!(f, "unable to convert {value} for {field}")
-            }
-            OptionParserError::InvalidValue(s) => write!(f, "invalid value: {s}"),
-        }
-    }
 }
 type OptionParserResult<T> = std::result::Result<T, OptionParserError>;
 

--- a/pci/src/msi.rs
+++ b/pci/src/msi.rs
@@ -40,9 +40,9 @@ pub fn msi_num_enabled_vectors(msg_ctl: u16) -> usize {
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Failed enabling the interrupt route: {0}")]
-    EnableInterruptRoute(io::Error),
+    EnableInterruptRoute(#[source] io::Error),
     #[error("Failed updating the interrupt route: {0}")]
-    UpdateInterruptRoute(io::Error),
+    UpdateInterruptRoute(#[source] io::Error),
 }
 
 pub const MSI_CONFIG_ID: &str = "msi_config";

--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -8,6 +8,7 @@ use std::{io, result};
 
 use byteorder::{ByteOrder, LittleEndian};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use vm_device::interrupt::{
     InterruptIndex, InterruptSourceConfig, InterruptSourceGroup, MsiIrqSourceConfig,
 };
@@ -27,12 +28,14 @@ const MSIX_ENABLE_MASK: u16 = (1 << MSIX_ENABLE_BIT) as u16;
 pub const MSIX_TABLE_ENTRY_SIZE: usize = 16;
 pub const MSIX_CONFIG_ID: &str = "msix_config";
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// Failed enabling the interrupt route.
-    EnableInterruptRoute(io::Error),
+    #[error("Failed enabling the interrupt route: {0}")]
+    EnableInterruptRoute(#[source] io::Error),
     /// Failed updating the interrupt route.
-    UpdateInterruptRoute(io::Error),
+    #[error("Failed updating the interrupt route: {0}")]
+    UpdateInterruptRoute(#[source] io::Error),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,23 +52,23 @@ enum Error {
     #[error("Failed to start the VMM thread: {0}")]
     StartVmmThread(#[source] vmm::Error),
     #[error("Error parsing config: {0}")]
-    ParsingConfig(vmm::config::Error),
+    ParsingConfig(#[source] vmm::config::Error),
     #[error("Error creating VM: {0:?}")]
-    VmCreate(vmm::api::ApiError),
+    VmCreate(#[source] vmm::api::ApiError),
     #[error("Error booting VM: {0:?}")]
-    VmBoot(vmm::api::ApiError),
+    VmBoot(#[source] vmm::api::ApiError),
     #[error("Error restoring VM: {0:?}")]
-    VmRestore(vmm::api::ApiError),
+    VmRestore(#[source] vmm::api::ApiError),
     #[error("Error parsing restore: {0}")]
-    ParsingRestore(vmm::config::Error),
+    ParsingRestore(#[source] vmm::config::Error),
     #[error("Failed to join on VMM thread: {0:?}")]
     ThreadJoin(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
     #[error("VMM thread exited with error: {0}")]
     VmmThread(#[source] vmm::Error),
     #[error("Error parsing --api-socket: {0}")]
-    ParsingApiSocket(std::num::ParseIntError),
+    ParsingApiSocket(#[source] std::num::ParseIntError),
     #[error("Error parsing --event-monitor: {0}")]
-    ParsingEventMonitor(option_parser::OptionParserError),
+    ParsingEventMonitor(#[source] option_parser::OptionParserError),
     #[cfg(feature = "dbus_api")]
     #[error("`--dbus-object-path` option isn't provided")]
     MissingDBusObjectPath,
@@ -78,7 +78,7 @@ enum Error {
     #[error("Error parsing --event-monitor: path or fd required")]
     BareEventMonitor,
     #[error("Error doing event monitor I/O: {0}")]
-    EventMonitorIo(std::io::Error),
+    EventMonitorIo(#[source] std::io::Error),
     #[error("Event monitor thread failed: {0}")]
     EventMonitorThread(#[source] vmm::Error),
     #[cfg(feature = "guest_debug")]
@@ -102,13 +102,13 @@ enum Error {
 #[derive(Error, Debug)]
 enum FdTableError {
     #[error("Failed to create event fd: {0}")]
-    CreateEventFd(std::io::Error),
+    CreateEventFd(#[source] std::io::Error),
     #[error("Failed to obtain file limit: {0}")]
-    GetRLimit(std::io::Error),
+    GetRLimit(#[source] std::io::Error),
     #[error("Error calling fcntl with F_GETFD: {0}")]
-    GetFd(std::io::Error),
+    GetFd(#[source] std::io::Error),
     #[error("Failed to duplicate file handle: {0}")]
-    Dup2(std::io::Error),
+    Dup2(#[source] std::io::Error),
 }
 
 struct Logger {

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,14 +83,14 @@ enum Error {
     EventMonitorThread(#[source] vmm::Error),
     #[cfg(feature = "guest_debug")]
     #[error("Error parsing --gdb: {0}")]
-    ParsingGdb(option_parser::OptionParserError),
+    ParsingGdb(#[source] option_parser::OptionParserError),
     #[cfg(feature = "guest_debug")]
     #[error("Error parsing --gdb: path required")]
     BareGdb,
     #[error("Error creating log file: {0}")]
-    LogFileCreation(std::io::Error),
+    LogFileCreation(#[source] std::io::Error),
     #[error("Error setting up logger: {0}")]
-    LoggerSetup(log::SetLoggerError),
+    LoggerSetup(#[source] log::SetLoggerError),
     #[error("Failed to gracefully shutdown http api: {0}")]
     HttpApiShutdown(#[source] vmm::Error),
     #[error("Failed to create Landlock object: {0}")]

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -13,6 +13,7 @@ epoll = "4.3.3"
 libc = "0.2.167"
 log = "0.4.22"
 option_parser = { path = "../option_parser" }
+thiserror = "2.0.6"
 vhost = { workspace = true, features = ["vhost-user-backend"] }
 vhost-user-backend = { workspace = true }
 virtio-bindings = { workspace = true }

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -13,6 +13,7 @@ libc = "0.2.167"
 log = "0.4.22"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
+thiserror = "2.0.6"
 vhost = { workspace = true, features = ["vhost-user-backend"] }
 vhost-user-backend = { workspace = true }
 virtio-bindings = { workspace = true }

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -65,27 +65,27 @@ const VIRTIO_BALLOON_F_REPORTING: u64 = 5;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Guest gave us bad memory addresses.: {0}")]
-    GuestMemory(GuestMemoryError),
+    GuestMemory(#[source] GuestMemoryError),
     #[error("Guest gave us a write only descriptor that protocol says to read from")]
     UnexpectedWriteOnlyDescriptor,
     #[error("Guest sent us invalid request")]
     InvalidRequest,
     #[error("Fallocate fail.: {0}")]
-    FallocateFail(std::io::Error),
+    FallocateFail(#[source] std::io::Error),
     #[error("Madvise fail.: {0}")]
-    MadviseFail(std::io::Error),
+    MadviseFail(#[source] std::io::Error),
     #[error("Failed to EventFd write.: {0}")]
-    EventFdWriteFail(std::io::Error),
+    EventFdWriteFail(#[source] std::io::Error),
     #[error("Invalid queue index: {0}")]
     InvalidQueueIndex(usize),
     #[error("Fail tp signal: {0}")]
-    FailedSignal(io::Error),
+    FailedSignal(#[source] io::Error),
     #[error("Descriptor chain is too short")]
     DescriptorChainTooShort,
     #[error("Failed adding used index: {0}")]
-    QueueAddUsed(virtio_queue::Error),
+    QueueAddUsed(#[source] virtio_queue::Error),
     #[error("Failed creating an iterator over the queue: {0}")]
-    QueueIterator(virtio_queue::Error),
+    QueueIterator(#[source] virtio_queue::Error),
 }
 
 // Got from include/uapi/linux/virtio_balloon.h

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -62,25 +62,25 @@ pub const MINIMUM_BLOCK_QUEUE_SIZE: u16 = 2;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Failed to parse the request: {0}")]
-    RequestParsing(block::Error),
+    RequestParsing(#[source] block::Error),
     #[error("Failed to execute the request: {0}")]
-    RequestExecuting(block::ExecuteError),
+    RequestExecuting(#[source] block::ExecuteError),
     #[error("Failed to complete the request: {0}")]
-    RequestCompleting(block::Error),
+    RequestCompleting(#[source] block::Error),
     #[error("Missing the expected entry in the list of requests")]
     MissingEntryRequestList,
     #[error("The asynchronous request returned with failure")]
     AsyncRequestFailure,
     #[error("Failed synchronizing the file: {0}")]
-    Fsync(AsyncIoError),
+    Fsync(#[source] AsyncIoError),
     #[error("Failed adding used index: {0}")]
-    QueueAddUsed(virtio_queue::Error),
+    QueueAddUsed(#[source] virtio_queue::Error),
     #[error("Failed creating an iterator over the queue: {0}")]
-    QueueIterator(virtio_queue::Error),
+    QueueIterator(#[source] virtio_queue::Error),
     #[error("Failed to update request status: {0}")]
-    RequestStatus(GuestMemoryError),
+    RequestStatus(#[source] GuestMemoryError),
     #[error("Failed to enable notification: {0}")]
-    QueueEnableNotification(virtio_queue::Error),
+    QueueEnableNotification(#[source] virtio_queue::Error),
     #[error("Failed to get {lock_type:?} lock for disk image {path}: {error}")]
     LockDiskImage {
         /// The underlying error.

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -52,15 +52,15 @@ enum Error {
     #[error("Descriptor chain too short")]
     DescriptorChainTooShort,
     #[error("Failed to read from guest memory: {0}")]
-    GuestMemoryRead(vm_memory::guest_memory::Error),
+    GuestMemoryRead(#[source] vm_memory::guest_memory::Error),
     #[error("Failed to write to guest memory: {0}")]
-    GuestMemoryWrite(vm_memory::guest_memory::Error),
+    GuestMemoryWrite(#[source] vm_memory::guest_memory::Error),
     #[error("Failed to write_all output: {0}")]
-    OutputWriteAll(io::Error),
+    OutputWriteAll(#[source] io::Error),
     #[error("Failed to flush output: {0}")]
-    OutputFlush(io::Error),
+    OutputFlush(#[source] io::Error),
     #[error("Failed to add used index: {0}")]
-    QueueAddUsed(virtio_queue::Error),
+    QueueAddUsed(#[source] virtio_queue::Error),
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]

--- a/virtio-devices/src/epoll_helper.rs
+++ b/virtio-devices/src/epoll_helper.rs
@@ -25,19 +25,19 @@ pub struct EpollHelper {
 #[derive(Error, Debug)]
 pub enum EpollHelperError {
     #[error("Failed to create Fd: {0}")]
-    CreateFd(std::io::Error),
+    CreateFd(#[source] std::io::Error),
     #[error("Failed to epoll_ctl: {0}")]
-    Ctl(std::io::Error),
+    Ctl(#[source] std::io::Error),
     #[error("IO error: {0}")]
-    IoError(std::io::Error),
+    IoError(#[source] std::io::Error),
     #[error("Failed to epoll_wait: {0}")]
-    Wait(std::io::Error),
+    Wait(#[source] std::io::Error),
     #[error("Failed to get virtio-queue index: {0}")]
-    QueueRingIndex(virtio_queue::Error),
+    QueueRingIndex(#[source] virtio_queue::Error),
     #[error("Failed to handle virtio device events: {0}")]
-    HandleEvent(anyhow::Error),
+    HandleEvent(#[source] anyhow::Error),
     #[error("Failed to handle timeout: {0}")]
-    HandleTimeout(anyhow::Error),
+    HandleTimeout(#[source] anyhow::Error),
 }
 
 pub const EPOLL_HELPER_EVENT_PAUSE: u16 = 0;

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -293,7 +293,7 @@ unsafe impl ByteValued for VirtioIommuFault {}
 #[derive(Error, Debug)]
 enum Error {
     #[error("Guest gave us bad memory addresses: {0}")]
-    GuestMemory(GuestMemoryError),
+    GuestMemory(#[source] GuestMemoryError),
     #[error("Guest gave us a write only descriptor that protocol says to read from")]
     UnexpectedWriteOnlyDescriptor,
     #[error("Guest gave us a read only descriptor that protocol says to write to")]
@@ -323,11 +323,11 @@ enum Error {
     #[error("Guest sent us invalid PROBE request")]
     InvalidProbeRequest,
     #[error("Failed to performing external mapping: {0}")]
-    ExternalMapping(io::Error),
+    ExternalMapping(#[source] io::Error),
     #[error("Failed to performing external unmapping: {0}")]
-    ExternalUnmapping(io::Error),
+    ExternalUnmapping(#[source] io::Error),
     #[error("Failed adding used index: {0}")]
-    QueueAddUsed(virtio_queue::Error),
+    QueueAddUsed(#[source] virtio_queue::Error),
 }
 
 struct Request {}

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -88,19 +88,19 @@ pub enum ActivateError {
     #[error("Failed to activate virtio device")]
     BadActivate,
     #[error("Failed to clone exit event fd: {0}")]
-    CloneExitEventFd(std::io::Error),
+    CloneExitEventFd(#[source] std::io::Error),
     #[error("Failed to spawn thread: {0}")]
-    ThreadSpawn(std::io::Error),
+    ThreadSpawn(#[source] std::io::Error),
     #[error("Failed to setup vhost-user-fs daemon: {0}")]
-    VhostUserFsSetup(vhost_user::Error),
+    VhostUserFsSetup(#[source] vhost_user::Error),
     #[error("Failed to setup vhost-user daemon: {0}")]
-    VhostUserSetup(vhost_user::Error),
+    VhostUserSetup(#[source] vhost_user::Error),
     #[error("Failed to create seccomp filter: {0}")]
-    CreateSeccompFilter(seccompiler::Error),
+    CreateSeccompFilter(#[source] seccompiler::Error),
     #[error("Failed to create rate limiter: {0}")]
-    CreateRateLimiter(std::io::Error),
+    CreateRateLimiter(#[source] std::io::Error),
     #[error("Failed to activate the vDPA device: {0}")]
-    ActivateVdpa(vdpa::Error),
+    ActivateVdpa(#[source] vdpa::Error),
 }
 
 pub type ActivateResult = std::result::Result<(), ActivateError>;
@@ -110,21 +110,21 @@ pub type DeviceEventT = u16;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Failed to single used queue: {0}")]
-    FailedSignalingUsedQueue(io::Error),
+    FailedSignalingUsedQueue(#[source] io::Error),
     #[error("I/O Error: {0}")]
-    IoError(io::Error),
+    IoError(#[source] io::Error),
     #[error("Failed to update memory vhost-user: {0}")]
-    VhostUserUpdateMemory(vhost_user::Error),
+    VhostUserUpdateMemory(#[source] vhost_user::Error),
     #[error("Failed to add memory region vhost-user: {0}")]
-    VhostUserAddMemoryRegion(vhost_user::Error),
+    VhostUserAddMemoryRegion(#[source] vhost_user::Error),
     #[error("Failed to set shared memory region")]
     SetShmRegionsNotSupported,
     #[error("Failed to process net queue: {0}")]
-    NetQueuePair(::net_util::NetQueuePairError),
+    NetQueuePair(#[source] ::net_util::NetQueuePairError),
     #[error("Failed to : {0}")]
-    QueueAddUsed(virtio_queue::Error),
+    QueueAddUsed(#[source] virtio_queue::Error),
     #[error("Failed to : {0}")]
-    QueueIterator(virtio_queue::Error),
+    QueueIterator(#[source] virtio_queue::Error),
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -102,7 +102,7 @@ const VIRTIO_MEM_F_ACPI_PXM: u8 = 0;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Guest gave us bad memory addresses: {0}")]
-    GuestMemory(GuestMemoryError),
+    GuestMemory(#[source] GuestMemoryError),
     #[error("Guest gave us a write only descriptor that protocol says to read from")]
     UnexpectedWriteOnlyDescriptor,
     #[error("Guest gave us a read only descriptor that protocol says to write to")]
@@ -114,23 +114,23 @@ pub enum Error {
     #[error("Guest sent us invalid request")]
     InvalidRequest,
     #[error("Failed to EventFd write: {0}")]
-    EventFdWriteFail(std::io::Error),
+    EventFdWriteFail(#[source] std::io::Error),
     #[error("Failed to EventFd try_clone: {0}")]
-    EventFdTryCloneFail(std::io::Error),
+    EventFdTryCloneFail(#[source] std::io::Error),
     #[error("Failed to MpscRecv: {0}")]
-    MpscRecvFail(mpsc::RecvError),
+    MpscRecvFail(#[source] mpsc::RecvError),
     #[error("Resize invalid argument: {0}")]
-    ResizeError(anyhow::Error),
+    ResizeError(#[source] anyhow::Error),
     #[error("Fail to resize trigger: {0}")]
-    ResizeTriggerFail(DeviceError),
+    ResizeTriggerFail(#[source] DeviceError),
     #[error("Invalid configuration: {0}")]
-    ValidateError(anyhow::Error),
+    ValidateError(#[source] anyhow::Error),
     #[error("Failed discarding memory range: {0}")]
-    DiscardMemoryRange(std::io::Error),
+    DiscardMemoryRange(#[source] std::io::Error),
     #[error("Failed DMA mapping: {0}")]
-    DmaMap(std::io::Error),
+    DmaMap(#[source] std::io::Error),
     #[error("Failed DMA unmapping: {0}")]
-    DmaUnmap(std::io::Error),
+    DmaUnmap(#[source] std::io::Error),
     #[error("Invalid DMA mapping handler")]
     InvalidDmaMappingHandler,
     #[error("Not activated by the guest")]
@@ -138,7 +138,7 @@ pub enum Error {
     #[error("Unknown request type: {0}")]
     UnknownRequestType(u16),
     #[error("Failed adding used index: {0}")]
-    QueueAddUsed(virtio_queue::Error),
+    QueueAddUsed(#[source] virtio_queue::Error),
 }
 
 #[repr(C)]

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -154,11 +154,11 @@ pub const TX_RATE_LIMITER_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 6;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Failed to open taps: {0}")]
-    OpenTap(OpenTapError),
+    OpenTap(#[source] OpenTapError),
     #[error("Using existing tap: {0}")]
-    TapError(TapError),
+    TapError(#[source] TapError),
     #[error("Error calling dup() on tap fd: {0}")]
-    DuplicateTapFd(std::io::Error),
+    DuplicateTapFd(#[source] std::io::Error),
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -76,7 +76,7 @@ unsafe impl ByteValued for VirtioPmemResp {}
 #[derive(Error, Debug)]
 enum Error {
     #[error("Bad guest memory addresses: {0}")]
-    GuestMemory(GuestMemoryError),
+    GuestMemory(#[source] GuestMemoryError),
     #[error("Unexpected write-only descriptor")]
     UnexpectedWriteOnlyDescriptor,
     #[error("Unexpected read-only descriptor")]
@@ -88,7 +88,7 @@ enum Error {
     #[error("Invalid request")]
     InvalidRequest,
     #[error("Failed adding used index: {0}")]
-    QueueAddUsed(virtio_queue::Error),
+    QueueAddUsed(#[source] virtio_queue::Error),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -42,9 +42,9 @@ enum Error {
     #[error("Invalid descriptor")]
     InvalidDescriptor,
     #[error("Failed to write to guest memory: {0}")]
-    GuestMemoryWrite(vm_memory::guest_memory::Error),
+    GuestMemoryWrite(#[source] vm_memory::guest_memory::Error),
     #[error("Failed adding used index: {0}")]
-    QueueAddUsed(virtio_queue::Error),
+    QueueAddUsed(#[source] virtio_queue::Error),
 }
 
 struct RngEpollHandler {

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -32,59 +32,59 @@ use crate::{
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Failed to create vhost-vdpa: {0}")]
-    CreateVhostVdpa(vhost::Error),
+    CreateVhostVdpa(#[source] vhost::Error),
     #[error("Failed to map DMA range: {0}")]
-    DmaMap(vhost::Error),
+    DmaMap(#[source] vhost::Error),
     #[error("Failed to unmap DMA range: {0}")]
-    DmaUnmap(vhost::Error),
+    DmaUnmap(#[source] vhost::Error),
     #[error("Failed to get address range")]
     GetAddressRange,
     #[error("Failed to get the available index from the virtio queue: {0}")]
-    GetAvailableIndex(virtio_queue::Error),
+    GetAvailableIndex(#[source] virtio_queue::Error),
     #[error("Get virtio configuration size: {0}")]
-    GetConfigSize(vhost::Error),
+    GetConfigSize(#[source] vhost::Error),
     #[error("Get virtio device identifier: {0}")]
-    GetDeviceId(vhost::Error),
+    GetDeviceId(#[source] vhost::Error),
     #[error("Failed to get backend specific features: {0}")]
-    GetBackendFeatures(vhost::Error),
+    GetBackendFeatures(#[source] vhost::Error),
     #[error("Failed to get virtio features: {0}")]
-    GetFeatures(vhost::Error),
+    GetFeatures(#[source] vhost::Error),
     #[error("Failed to get the IOVA range: {0}")]
-    GetIovaRange(vhost::Error),
+    GetIovaRange(#[source] vhost::Error),
     #[error("Failed to get queue size: {0}")]
-    GetVringNum(vhost::Error),
+    GetVringNum(#[source] vhost::Error),
     #[error("Invalid IOVA range: {0}-{1}")]
     InvalidIovaRange(u64, u64),
     #[error("Missing VIRTIO_F_ACCESS_PLATFORM feature")]
     MissingAccessPlatformVirtioFeature,
     #[error("Failed to reset owner: {0}")]
-    ResetOwner(vhost::Error),
+    ResetOwner(#[source] vhost::Error),
     #[error("Failed to set backend specific features: {0}")]
-    SetBackendFeatures(vhost::Error),
+    SetBackendFeatures(#[source] vhost::Error),
     #[error("Failed to set backend configuration: {0}")]
-    SetConfig(vhost::Error),
+    SetConfig(#[source] vhost::Error),
     #[error("Failed to set eventfd notifying about a configuration change: {0}")]
-    SetConfigCall(vhost::Error),
+    SetConfigCall(#[source] vhost::Error),
     #[error("Failed to set virtio features: {0}")]
-    SetFeatures(vhost::Error),
+    SetFeatures(#[source] vhost::Error),
     #[error("Failed to set memory table: {0}")]
-    SetMemTable(vhost::Error),
+    SetMemTable(#[source] vhost::Error),
     #[error("Failed to set owner: {0}")]
-    SetOwner(vhost::Error),
+    SetOwner(#[source] vhost::Error),
     #[error("Failed to set virtio status: {0}")]
-    SetStatus(vhost::Error),
+    SetStatus(#[source] vhost::Error),
     #[error("Failed to set vring address: {0}")]
-    SetVringAddr(vhost::Error),
+    SetVringAddr(#[source] vhost::Error),
     #[error("Failed to set vring base: {0}")]
-    SetVringBase(vhost::Error),
+    SetVringBase(#[source] vhost::Error),
     #[error("Failed to set vring eventfd when buffer are used: {0}")]
-    SetVringCall(vhost::Error),
+    SetVringCall(#[source] vhost::Error),
     #[error("Failed to enable/disable vring: {0}")]
-    SetVringEnable(vhost::Error),
+    SetVringEnable(#[source] vhost::Error),
     #[error("Failed to set vring eventfd when new descriptors are available: {0}")]
-    SetVringKick(vhost::Error),
+    SetVringKick(#[source] vhost::Error),
     #[error("Failed to set vring size: {0}")]
-    SetVringNum(vhost::Error),
+    SetVringNum(#[source] vhost::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -43,85 +43,85 @@ pub use self::vu_common_ctrl::VhostUserConfig;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Failed accepting connection: {0}")]
-    AcceptConnection(io::Error),
+    AcceptConnection(#[source] io::Error),
     #[error("Invalid available address")]
     AvailAddress,
     #[error("Queue number  is not correct")]
     BadQueueNum,
     #[error("Failed binding vhost-user socket: {0}")]
-    BindSocket(io::Error),
+    BindSocket(#[source] io::Error),
     #[error("Creating kill eventfd failed: {0}")]
-    CreateKillEventFd(io::Error),
+    CreateKillEventFd(#[source] io::Error),
     #[error("Cloning kill eventfd failed: {0}")]
-    CloneKillEventFd(io::Error),
+    CloneKillEventFd(#[source] io::Error),
     #[error("Invalid descriptor table address")]
     DescriptorTableAddress,
     #[error("Signal used queue failed: {0}")]
-    FailedSignalingUsedQueue(io::Error),
+    FailedSignalingUsedQueue(#[source] io::Error),
     #[error("Failed to read vhost eventfd: {0}")]
-    MemoryRegions(MmapError),
+    MemoryRegions(#[source] MmapError),
     #[error("Failed removing socket path: {0}")]
-    RemoveSocketPath(io::Error),
+    RemoveSocketPath(#[source] io::Error),
     #[error("Failed to create frontend: {0}")]
-    VhostUserCreateFrontend(VhostError),
+    VhostUserCreateFrontend(#[source] VhostError),
     #[error("Failed to open vhost device: {0}")]
-    VhostUserOpen(VhostError),
+    VhostUserOpen(#[source] VhostError),
     #[error("Connection to socket failed")]
     VhostUserConnect,
     #[error("Get features failed: {0}")]
-    VhostUserGetFeatures(VhostError),
+    VhostUserGetFeatures(#[source] VhostError),
     #[error("Get queue max number failed: {0}")]
-    VhostUserGetQueueMaxNum(VhostError),
+    VhostUserGetQueueMaxNum(#[source] VhostError),
     #[error("Get protocol features failed: {0}")]
-    VhostUserGetProtocolFeatures(VhostError),
+    VhostUserGetProtocolFeatures(#[source] VhostError),
     #[error("Get vring base failed: {0}")]
-    VhostUserGetVringBase(VhostError),
+    VhostUserGetVringBase(#[source] VhostError),
     #[error("Vhost-user Backend not support vhost-user protocol")]
     VhostUserProtocolNotSupport,
     #[error("Set owner failed: {0}")]
-    VhostUserSetOwner(VhostError),
+    VhostUserSetOwner(#[source] VhostError),
     #[error("Reset owner failed: {0}")]
-    VhostUserResetOwner(VhostError),
+    VhostUserResetOwner(#[source] VhostError),
     #[error("Set features failed: {0}")]
-    VhostUserSetFeatures(VhostError),
+    VhostUserSetFeatures(#[source] VhostError),
     #[error("Set protocol features failed: {0}")]
-    VhostUserSetProtocolFeatures(VhostError),
+    VhostUserSetProtocolFeatures(#[source] VhostError),
     #[error("Set mem table failed: {0}")]
-    VhostUserSetMemTable(VhostError),
+    VhostUserSetMemTable(#[source] VhostError),
     #[error("Set vring num failed: {0}")]
-    VhostUserSetVringNum(VhostError),
+    VhostUserSetVringNum(#[source] VhostError),
     #[error("Set vring addr failed: {0}")]
-    VhostUserSetVringAddr(VhostError),
+    VhostUserSetVringAddr(#[source] VhostError),
     #[error("Set vring base failed: {0}")]
-    VhostUserSetVringBase(VhostError),
+    VhostUserSetVringBase(#[source] VhostError),
     #[error("Set vring call failed: {0}")]
-    VhostUserSetVringCall(VhostError),
+    VhostUserSetVringCall(#[source] VhostError),
     #[error("Set vring kick failed: {0}")]
-    VhostUserSetVringKick(VhostError),
+    VhostUserSetVringKick(#[source] VhostError),
     #[error("Set vring enable failed: {0}")]
-    VhostUserSetVringEnable(VhostError),
+    VhostUserSetVringEnable(#[source] VhostError),
     #[error("Failed to create vhost eventfd: {0}")]
-    VhostIrqCreate(io::Error),
+    VhostIrqCreate(#[source] io::Error),
     #[error("Failed to read vhost eventfd: {0}")]
-    VhostIrqRead(io::Error),
+    VhostIrqRead(#[source] io::Error),
     #[error("Failed to read vhost eventfd: {0}")]
-    VhostUserMemoryRegion(MmapError),
+    VhostUserMemoryRegion(#[source] MmapError),
     #[error("Failed to create the frontend request handler from backend: {0}")]
-    FrontendReqHandlerCreation(vhost::vhost_user::Error),
+    FrontendReqHandlerCreation(#[source] vhost::vhost_user::Error),
     #[error("Set backend request fd failed: {0}")]
-    VhostUserSetBackendRequestFd(vhost::Error),
+    VhostUserSetBackendRequestFd(#[source] vhost::Error),
     #[error("Add memory region failed: {0}")]
-    VhostUserAddMemReg(VhostError),
+    VhostUserAddMemReg(#[source] VhostError),
     #[error("Failed getting the configuration: {0}")]
-    VhostUserGetConfig(VhostError),
+    VhostUserGetConfig(#[source] VhostError),
     #[error("Failed setting the configuration: {0}")]
-    VhostUserSetConfig(VhostError),
+    VhostUserSetConfig(#[source] VhostError),
     #[error("Failed getting inflight shm log: {0}")]
-    VhostUserGetInflight(VhostError),
+    VhostUserGetInflight(#[source] VhostError),
     #[error("Failed setting inflight shm log: {0}")]
-    VhostUserSetInflight(VhostError),
+    VhostUserSetInflight(#[source] VhostError),
     #[error("Failed setting the log base: {0}")]
-    VhostUserSetLogBase(VhostError),
+    VhostUserSetLogBase(#[source] VhostError),
     #[error("Invalid used address")]
     UsedAddress,
     #[error("Invalid features provided from vhost-user backend")]
@@ -131,17 +131,17 @@ pub enum Error {
     #[error("Missing IrqFd")]
     MissingIrqFd,
     #[error("Failed getting the available index: {0}")]
-    GetAvailableIndex(QueueError),
+    GetAvailableIndex(#[source] QueueError),
     #[error("Migration is not supported by this vhost-user device")]
     MigrationNotSupported,
     #[error("Failed creating memfd: {0}")]
-    MemfdCreate(io::Error),
+    MemfdCreate(#[source] io::Error),
     #[error("Failed truncating the file size to the expected size: {0}")]
-    SetFileSize(io::Error),
+    SetFileSize(#[source] io::Error),
     #[error("Failed to set the seals on the file: {0}")]
-    SetSeals(io::Error),
+    SetSeals(#[source] io::Error),
     #[error("Failed creating new mmap region: {0}")]
-    NewMmapRegion(MmapRegionError),
+    NewMmapRegion(#[source] MmapRegionError),
     #[error("Could not find the shm log region")]
     MissingShmLogRegion,
 }

--- a/virtio-devices/src/vsock/csm/mod.rs
+++ b/virtio-devices/src/vsock/csm/mod.rs
@@ -33,10 +33,10 @@ pub enum Error {
     TxBufFull,
     /// An I/O error occurred, when attempting to flush the connection TX buffer.
     #[error("Error flushing TX buffer: {0}")]
-    TxBufFlush(std::io::Error),
+    TxBufFlush(#[source] std::io::Error),
     /// An I/O error occurred, when attempting to write data to the host-side stream.
     #[error("Error writing to host side stream: {0}")]
-    StreamWrite(std::io::Error),
+    StreamWrite(#[source] std::io::Error),
 }
 
 type Result<T> = std::result::Result<T, Error>;

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -49,15 +49,15 @@ const WATCHDOG_TIMEOUT: u64 = WATCHDOG_TIMER_INTERVAL as u64 + 5;
 #[derive(Error, Debug)]
 enum Error {
     #[error("Error programming timer fd: {0}")]
-    TimerfdSetup(io::Error),
+    TimerfdSetup(#[source] io::Error),
     #[error("Descriptor chain too short")]
     DescriptorChainTooShort,
     #[error("Failed adding used index: {0}")]
-    QueueAddUsed(virtio_queue::Error),
+    QueueAddUsed(#[source] virtio_queue::Error),
     #[error("Invalid descriptor")]
     InvalidDescriptor,
     #[error("Failed to write to guest memory: {0}")]
-    GuestMemoryWrite(vm_memory::guest_memory::Error),
+    GuestMemoryWrite(#[source] vm_memory::guest_memory::Error),
 }
 
 struct WatchdogEpollHandler {

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -40,6 +40,7 @@ use std::sync::mpsc::{channel, RecvError, SendError, Sender};
 
 use micro_http::Body;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use vm_migration::MigratableError;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -56,10 +57,10 @@ use crate::vm_config::{
 use crate::Error as VmmError;
 
 /// API errors are sent back from the VMM API server through the ApiResponse.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ApiError {
     /// Cannot write to EventFd.
-    EventFdWrite(io::Error),
+    EventFdWrite(#[source] io::Error),
 
     /// API request send error
     RequestSend(SendError<ApiRequest>),

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -41,81 +41,81 @@ pub enum Error {
     /// Missing restore source_url parameter.
     ParseRestoreSourceUrlMissing,
     /// Error parsing CPU options
-    ParseCpus(OptionParserError),
+    ParseCpus(#[source] OptionParserError),
     /// Invalid CPU features
     InvalidCpuFeatures(String),
     /// Error parsing memory options
-    ParseMemory(OptionParserError),
+    ParseMemory(#[source] OptionParserError),
     /// Error parsing memory zone options
-    ParseMemoryZone(OptionParserError),
+    ParseMemoryZone(#[source] OptionParserError),
     /// Missing 'id' from memory zone
     ParseMemoryZoneIdMissing,
     /// Error parsing rate-limiter group options
-    ParseRateLimiterGroup(OptionParserError),
+    ParseRateLimiterGroup(#[source] OptionParserError),
     /// Error parsing disk options
-    ParseDisk(OptionParserError),
+    ParseDisk(#[source] OptionParserError),
     /// Error parsing network options
-    ParseNetwork(OptionParserError),
+    ParseNetwork(#[source] OptionParserError),
     /// Error parsing RNG options
-    ParseRng(OptionParserError),
+    ParseRng(#[source] OptionParserError),
     /// Error parsing balloon options
-    ParseBalloon(OptionParserError),
+    ParseBalloon(#[source] OptionParserError),
     /// Error parsing filesystem parameters
-    ParseFileSystem(OptionParserError),
+    ParseFileSystem(#[source] OptionParserError),
     /// Error parsing persistent memory parameters
-    ParsePersistentMemory(OptionParserError),
+    ParsePersistentMemory(#[source] OptionParserError),
     /// Failed parsing console
-    ParseConsole(OptionParserError),
+    ParseConsole(#[source] OptionParserError),
     #[cfg(target_arch = "x86_64")]
     /// Failed parsing debug-console
-    ParseDebugConsole(OptionParserError),
+    ParseDebugConsole(#[source] OptionParserError),
     /// No mode given for console
     ParseConsoleInvalidModeGiven,
     /// Failed parsing device parameters
-    ParseDevice(OptionParserError),
+    ParseDevice(#[source] OptionParserError),
     /// Missing path from device,
     ParseDevicePathMissing,
     /// Failed parsing vsock parameters
-    ParseVsock(OptionParserError),
+    ParseVsock(#[source] OptionParserError),
     /// Failed parsing restore parameters
-    ParseRestore(OptionParserError),
+    ParseRestore(#[source] OptionParserError),
     /// Failed parsing SGX EPC parameters
     #[cfg(target_arch = "x86_64")]
-    ParseSgxEpc(OptionParserError),
+    ParseSgxEpc(#[source] OptionParserError),
     /// Missing 'id' from SGX EPC section
     #[cfg(target_arch = "x86_64")]
     ParseSgxEpcIdMissing,
     /// Failed parsing NUMA parameters
-    ParseNuma(OptionParserError),
+    ParseNuma(#[source] OptionParserError),
     /// Failed validating configuration
-    Validation(ValidationError),
+    Validation(#[source] ValidationError),
     #[cfg(feature = "sev_snp")]
     /// Failed parsing SEV-SNP config
-    ParseSevSnp(OptionParserError),
+    ParseSevSnp(#[source] OptionParserError),
     #[cfg(feature = "tdx")]
     /// Failed parsing TDX config
-    ParseTdx(OptionParserError),
+    ParseTdx(#[source] OptionParserError),
     #[cfg(feature = "tdx")]
     /// No TDX firmware
     FirmwarePathMissing,
     /// Failed parsing userspace device
-    ParseUserDevice(OptionParserError),
+    ParseUserDevice(#[source] OptionParserError),
     /// Missing socket for userspace device
     ParseUserDeviceSocketMissing,
     /// Error parsing pci segment options
-    ParsePciSegment(OptionParserError),
+    ParsePciSegment(#[source] OptionParserError),
     /// Failed parsing platform parameters
-    ParsePlatform(OptionParserError),
+    ParsePlatform(#[source] OptionParserError),
     /// Failed parsing vDPA device
-    ParseVdpa(OptionParserError),
+    ParseVdpa(#[source] OptionParserError),
     /// Missing path for vDPA device
     ParseVdpaPathMissing,
     /// Failed parsing TPM device
-    ParseTpm(OptionParserError),
+    ParseTpm(#[source] OptionParserError),
     /// Missing path for TPM device
     ParseTpmPathMissing,
     /// Error parsing Landlock rules
-    ParseLandlockRules(OptionParserError),
+    ParseLandlockRules(#[source] OptionParserError),
     /// Missing fields in Landlock rules
     ParseLandlockMissingFields,
 }

--- a/vmm/src/coredump.rs
+++ b/vmm/src/coredump.rs
@@ -9,6 +9,7 @@ use std::io::Write;
 #[cfg(target_arch = "x86_64")]
 use hypervisor::arch::x86::{DescriptorTable, SegmentRegister};
 use linux_loader::elf;
+use thiserror::Error;
 use vm_memory::ByteValued;
 
 #[derive(Clone)]
@@ -33,12 +34,16 @@ pub struct DumpState {
     pub file: Option<File>,
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum GuestDebuggableError {
-    Coredump(anyhow::Error),
-    CoredumpFile(std::io::Error),
-    Pause(vm_migration::MigratableError),
-    Resume(vm_migration::MigratableError),
+    #[error("coredump: {0}")]
+    Coredump(#[source] anyhow::Error),
+    #[error("coredump file: {0}")]
+    CoredumpFile(#[source] std::io::Error),
+    #[error("Failed to pause: {0}")]
+    Pause(#[source] vm_migration::MigratableError),
+    #[error("Failed to resume: {0}")]
+    Resume(#[source] vm_migration::MigratableError),
 }
 
 pub trait GuestDebuggable: vm_migration::Pausable {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -204,7 +204,7 @@ pub enum Error {
 
     #[cfg(target_arch = "x86_64")]
     #[error("Failed to inject NMI")]
-    NmiError(hypervisor::HypervisorCpuError),
+    NmiError(#[source] hypervisor::HypervisorCpuError),
 }
 pub type Result<T> = result::Result<T, Error>;
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -145,15 +145,15 @@ pub enum Error {
 
     /// Cannot handle the VM STDIN stream
     #[error("Error handling VM stdin: {0:?}")]
-    Stdin(VmError),
+    Stdin(#[source] VmError),
 
     /// Cannot handle the VM pty stream
     #[error("Error handling VM pty: {0:?}")]
-    Pty(VmError),
+    Pty(#[source] VmError),
 
     /// Cannot reboot the VM
     #[error("Error rebooting VM: {0:?}")]
-    VmReboot(VmError),
+    VmReboot(#[source] VmError),
 
     /// Cannot create VMM thread
     #[error("Error spawning VMM thread {0:?}")]
@@ -161,22 +161,23 @@ pub enum Error {
 
     /// Cannot shut the VMM down
     #[error("Error shutting down VMM: {0:?}")]
-    VmmShutdown(VmError),
+    VmmShutdown(#[source] VmError),
 
     /// Cannot create seccomp filter
     #[error("Error creating seccomp filter: {0}")]
-    CreateSeccompFilter(seccompiler::Error),
+    CreateSeccompFilter(#[source] seccompiler::Error),
 
     /// Cannot apply seccomp filter
     #[error("Error applying seccomp filter: {0}")]
-    ApplySeccompFilter(seccompiler::Error),
+    ApplySeccompFilter(#[source] seccompiler::Error),
 
     /// Error activating virtio devices
     #[error("Error activating virtio devices: {0:?}")]
-    ActivateVirtioDevices(VmError),
+    ActivateVirtioDevices(#[source] VmError),
 
     /// Error creating API server
     #[error("Error creating API server {0:?}")]
+    // TODO #[source]  once the type implements Error
     CreateApiServer(micro_http::ServerError),
 
     /// Error binding API server socket
@@ -185,7 +186,7 @@ pub enum Error {
 
     #[cfg(feature = "guest_debug")]
     #[error("Failed to start the GDB thread: {0}")]
-    GdbThreadSpawn(io::Error),
+    GdbThreadSpawn(#[source] io::Error),
 
     /// GDB request receive error
     #[cfg(feature = "guest_debug")]
@@ -205,11 +206,11 @@ pub enum Error {
 
     /// Cannot create Landlock object
     #[error("Error creating landlock object: {0}")]
-    CreateLandlock(LandlockError),
+    CreateLandlock(#[source] LandlockError),
 
     /// Cannot apply landlock based sandboxing
     #[error("Error applying landlock: {0}")]
-    ApplyLandlock(LandlockError),
+    ApplyLandlock(#[source] LandlockError),
 }
 pub type Result<T> = result::Result<T, Error>;
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -142,10 +142,10 @@ pub enum Error {
     PoisonedState,
 
     #[error("Error from device manager: {0:?}")]
-    DeviceManager(DeviceManagerError),
+    DeviceManager(#[source] DeviceManagerError),
 
     #[error("Error initializing VM: {0:?}")]
-    InitializeVm(hypervisor::HypervisorVmError),
+    InitializeVm(#[source] hypervisor::HypervisorVmError),
 
     #[error("No device with id {0:?} to remove")]
     NoDeviceToRemove(String),
@@ -196,7 +196,7 @@ pub enum Error {
     Resume(#[source] MigratableError),
 
     #[error("Memory manager error: {0:?}")]
-    MemoryManager(MemoryManagerError),
+    MemoryManager(#[source] MemoryManagerError),
 
     #[error("Eventfd write error: {0}")]
     EventfdError(#[source] std::io::Error),
@@ -235,16 +235,16 @@ pub enum Error {
     ResizeZone,
 
     #[error("Cannot activate virtio devices: {0:?}")]
-    ActivateVirtioDevices(DeviceManagerError),
+    ActivateVirtioDevices(#[source] DeviceManagerError),
 
     #[error("Error triggering power button: {0:?}")]
-    PowerButton(DeviceManagerError),
+    PowerButton(#[source] DeviceManagerError),
 
     #[error("Kernel lacks PVH header")]
     KernelMissingPvhHeader,
 
     #[error("Failed to allocate firmware RAM: {0:?}")]
-    AllocateFirmwareMemory(MemoryManagerError),
+    AllocateFirmwareMemory(#[source] MemoryManagerError),
 
     #[error("Error manipulating firmware file: {0}")]
     FirmwareFile(#[source] std::io::Error),
@@ -304,7 +304,7 @@ pub enum Error {
     Debug(DebuggableError),
 
     #[error("Error spawning kernel loading thread")]
-    KernelLoadThreadSpawn(std::io::Error),
+    KernelLoadThreadSpawn(#[source] std::io::Error),
 
     #[error("Error joining kernel loading thread")]
     KernelLoadThreadJoin(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
@@ -314,7 +314,7 @@ pub enum Error {
 
     #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
     #[error("Error coredumping VM: {0:?}")]
-    Coredump(GuestDebuggableError),
+    Coredump(#[source] GuestDebuggableError),
 
     #[cfg(feature = "igvm")]
     #[error("Cannot open igvm file: {0}")]
@@ -331,10 +331,10 @@ pub enum Error {
     ResumeVm(#[source] hypervisor::HypervisorVmError),
 
     #[error("Error creating console devices")]
-    CreateConsoleDevices(ConsoleDeviceError),
+    CreateConsoleDevices(#[source] ConsoleDeviceError),
 
     #[error("Error locking disk images: Another instance likely holds a lock")]
-    LockingError(DeviceManagerError),
+    LockingError(#[source] DeviceManagerError),
 }
 pub type Result<T> = result::Result<T, Error>;
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -114,7 +114,7 @@ pub enum Error {
 
     #[cfg(target_arch = "aarch64")]
     #[error("Cannot load the UEFI binary in memory: {0:?}")]
-    UefiLoad(arch::aarch64::uefi::Error),
+    UefiLoad(#[source] arch::aarch64::uefi::Error),
 
     #[error("Cannot load the initramfs into memory")]
     InitramfsLoad,
@@ -136,7 +136,7 @@ pub enum Error {
 
     #[cfg(target_arch = "aarch64")]
     #[error("Cannot enable interrupt controller: {0:?}")]
-    EnableInterruptController(interrupt_controller::Error),
+    EnableInterruptController(#[source] interrupt_controller::Error),
 
     #[error("VM state is poisoned")]
     PoisonedState,
@@ -277,7 +277,7 @@ pub enum Error {
 
     #[cfg(feature = "tdx")]
     #[error("Error allocating TDVF memory: {0:?}")]
-    AllocatingTdvfMemory(crate::memory_manager::Error),
+    AllocatingTdvfMemory(#[source] crate::memory_manager::Error),
 
     #[cfg(feature = "tdx")]
     #[error("Error enabling TDX VM: {0}")]
@@ -301,7 +301,7 @@ pub enum Error {
 
     #[cfg(feature = "guest_debug")]
     #[error("Error debugging VM: {0:?}")]
-    Debug(DebuggableError),
+    Debug(#[source] DebuggableError),
 
     #[error("Error spawning kernel loading thread")]
     KernelLoadThreadSpawn(#[source] std::io::Error),


### PR DESCRIPTION
Follow-up of #7061 and split-out from #7066. 

This MR implements `std::error::Error` via the `thiserror::Error` derive macro for all error types where this wasn't done yet. Also `#[source]` is set properly everywhere. This will allow #7066 eventually.

This still follows the "current" style for errors that `Display::fmt()` includes any suberror like this `": {0}"` 

# Steps to Undraft
- [x] merge and rebase onto #7061