### PR TITLE
vfio: enable msix vector according to guest

### DIFF
--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -15,7 +15,7 @@ use vm_device::interrupt::{
 use vm_memory::ByteValued;
 use vm_migration::{MigratableError, Pausable, Snapshot, Snapshottable};
 
-use crate::{PciCapability, PciCapabilityId};
+use crate::{PciBdf, PciCapability, PciCapabilityId};
 
 const MAX_MSIX_VECTORS_PER_DEVICE: u16 = 2048;
 const MSIX_TABLE_ENTRIES_MODULO: u64 = 16;
@@ -78,6 +78,7 @@ pub struct MsixConfig {
     interrupt_source_group: Arc<dyn InterruptSourceGroup>,
     masked: bool,
     enabled: bool,
+    pub vector_num: u32,
 }
 
 impl MsixConfig {
@@ -141,6 +142,7 @@ impl MsixConfig {
             interrupt_source_group,
             masked,
             enabled,
+            vector_num: 0,
         })
     }
 
@@ -329,6 +331,14 @@ impl MsixConfig {
                 data: table_entry.msg_data,
                 devid: self.devid,
             };
+
+            self.vector_num += 1;
+            debug!(
+                "devid {} index {} vector_num {}",
+                PciBdf::from(self.devid),
+                index,
+                self.vector_num
+            );
 
             if let Err(e) = self.interrupt_source_group.update(
                 index as InterruptIndex,


### PR DESCRIPTION
Now we enable msix vectos according to msix entry tables, which will cause kvm request vfio-msix interrupts as many as length of msix entry tables which are not needed actually by guest.

The actual vectors are enabled by setting msg ctl when writing mmio, we can update msix vector at that moment.

Fix: #7079 