### PR TITLE
vmm: use gsi bitmap to record the GSI used

### DIFF
--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -29,6 +29,58 @@ impl GsiApic {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
+pub struct GsiBitmap {
+    bits: Vec<u64>,
+    capacity: usize,
+}
+
+impl GsiBitmap {
+    pub fn new(capacity: usize) -> Self {
+        let len = (capacity + 63) / 64;
+        GsiBitmap {
+            bits: vec![0; len],
+            capacity,
+        }
+    }
+
+    pub fn enable(&mut self, pos: usize) {
+        if pos > self.capacity {
+            return;
+        }
+
+        let block = pos / 64;
+        let offset = pos % 64;
+
+        self.bits[block] |= 1 << offset;
+    }
+
+    pub fn disable(&mut self, pos: usize) {
+        if pos > self.capacity {
+            return;
+        }
+
+        let block = pos / 64;
+        let offset = pos % 64;
+
+        self.bits[block] &= !(1 << offset);
+    }
+
+    pub fn get_first_free_gsi(&self) -> Option<u32> {
+        for (idx, &block) in self.bits.iter().enumerate() {
+            if block != u64::MAX {
+                for offset in 0..64 {
+                    if 0 == (block & 1 << offset) {
+                        return Some((idx * 64 + offset) as u32);
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}
+
 /// GsiAllocator
 pub struct GsiAllocator {
     #[cfg(target_arch = "x86_64")]

--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -5,6 +5,10 @@
 #[cfg(target_arch = "x86_64")]
 use std::collections::btree_map::BTreeMap;
 use std::result;
+use std::sync::{Arc, Mutex};
+
+/// According to the value set kernel
+const KVM_MAX_IRQ_ROUTES: usize = 4096;
 
 #[derive(Debug)]
 pub enum Error {
@@ -86,7 +90,7 @@ pub struct GsiAllocator {
     #[cfg(target_arch = "x86_64")]
     apics: BTreeMap<u32, u32>,
     next_irq: u32,
-    next_gsi: u32,
+    gsi_bitmap: Arc<Mutex<GsiBitmap>>,
 }
 
 impl GsiAllocator {
@@ -96,16 +100,12 @@ impl GsiAllocator {
         let mut allocator = GsiAllocator {
             apics: BTreeMap::new(),
             next_irq: 0xffff_ffff,
-            next_gsi: 0,
+            gsi_bitmap: Arc::new(Mutex::new(GsiBitmap::new(KVM_MAX_IRQ_ROUTES))),
         };
 
         for apic in &apics {
             if apic.base < allocator.next_irq {
                 allocator.next_irq = apic.base;
-            }
-
-            if apic.base + apic.irqs > allocator.next_gsi {
-                allocator.next_gsi = apic.base + apic.irqs;
             }
 
             allocator.apics.insert(apic.base, apic.irqs);
@@ -125,9 +125,21 @@ impl GsiAllocator {
 
     /// Allocate a GSI
     pub fn allocate_gsi(&mut self) -> Result<u32> {
-        let gsi = self.next_gsi;
-        self.next_gsi = self.next_gsi.checked_add(1).ok_or(Error::Overflow)?;
+        let mut gsi_bitmap = self.gsi_bitmap.lock().unwrap();
+        let gsi = gsi_bitmap.get_first_free_gsi().ok_or(Error::Overflow)?;
+        gsi_bitmap.enable(gsi as usize);
+
         Ok(gsi)
+    }
+
+    /// Enable gsi bit
+    pub fn enable_gsi_bit(&mut self, gsi: u32) {
+        self.gsi_bitmap.lock().unwrap().enable(gsi as usize);
+    }
+
+    /// Disable gsi bit
+    pub fn disable_gsi_bit(&mut self, gsi: u32) {
+        self.gsi_bitmap.lock().unwrap().disable(gsi as usize);
     }
 
     #[cfg(target_arch = "x86_64")]

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -91,6 +91,16 @@ impl SystemAllocator {
         self.gsi_allocator.allocate_gsi().ok()
     }
 
+    /// Enable GSI bitmap
+    pub fn enable_gsi_bit(&mut self, gsi: u32) {
+        self.gsi_allocator.enable_gsi_bit(gsi);
+    }
+
+    /// Disable GSI bitmap
+    pub fn disable_gsi_bit(&mut self, gsi: u32) {
+        self.gsi_allocator.disable_gsi_bit(gsi);
+    }
+
     /// Reserves a section of `size` bytes of IO address space.
     pub fn allocate_io_addresses(
         &mut self,

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -24,12 +24,15 @@ struct InterruptRoute {
     gsi: u32,
     irq_fd: EventFd,
     registered: AtomicBool,
+    allocator: Arc<Mutex<SystemAllocator>>,
 }
 
 impl InterruptRoute {
-    pub fn new(allocator: &mut SystemAllocator) -> Result<Self> {
+    pub fn new(allocator: Arc<Mutex<SystemAllocator>>) -> Result<Self> {
         let irq_fd = EventFd::new(libc::EFD_NONBLOCK)?;
         let gsi = allocator
+            .lock()
+            .unwrap()
             .allocate_gsi()
             .ok_or_else(|| io::Error::other("Failed allocating new GSI"))?;
 
@@ -37,6 +40,7 @@ impl InterruptRoute {
             gsi,
             irq_fd,
             registered: AtomicBool::new(false),
+            allocator,
         })
     }
 
@@ -49,6 +53,11 @@ impl InterruptRoute {
             self.registered.store(true, Ordering::Release);
         }
 
+        self.allocator
+            .lock()
+            .unwrap()
+            .enable_gsi_bit(self.gsi);
+
         Ok(())
     }
 
@@ -60,6 +69,11 @@ impl InterruptRoute {
             // Update internals to track the irq_fd as "unregistered".
             self.registered.store(false, Ordering::Release);
         }
+
+        self.allocator
+            .lock()
+            .unwrap()
+            .disable_gsi_bit(self.gsi);
 
         Ok(())
     }
@@ -292,11 +306,10 @@ impl InterruptManager for MsiInterruptManager {
     type GroupConfig = MsiIrqGroupConfig;
 
     fn create_group(&self, config: Self::GroupConfig) -> Result<Arc<dyn InterruptSourceGroup>> {
-        let mut allocator = self.allocator.lock().unwrap();
         let mut irq_routes: HashMap<InterruptIndex, InterruptRoute> =
             HashMap::with_capacity(config.count as usize);
         for i in config.base..config.base + config.count {
-            irq_routes.insert(i, InterruptRoute::new(&mut allocator)?);
+            irq_routes.insert(i, InterruptRoute::new(self.allocator.clone())?);
         }
 
         Ok(Arc::new(MsiInterruptGroup::new(


### PR DESCRIPTION
vmm: use gsi bitmap to record the GSI used
    
KVM use KVM_MAX_IRQ_ROUTES(4096) as the max gsi which vm can use.
If we use gsi without restraint, it will eventually exceed that  value and fail.

Add a bitmap to track the gsi enable/disable, so as to maxmize the use the gsi in kvm. 