### PR TITLE
vmm/memory_manager: use MmapRegion::bitmap() directly

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -2765,7 +2765,7 @@ impl Migratable for MemoryManager {
         })?;
 
         for r in self.guest_memory.memory().iter() {
-            r.bitmap().reset();
+            (**r).bitmap().reset();
         }
 
         Ok(())
@@ -2792,7 +2792,7 @@ impl Migratable for MemoryManager {
                 Some(region) => {
                     assert!(region.start_addr().raw_value() == r.gpa);
                     assert!(region.len() == r.size);
-                    region.bitmap().get_and_reset()
+                    (**region).bitmap().get_and_reset()
                 }
                 None => {
                     return Err(MigratableError::MigrateSend(anyhow!(


### PR DESCRIPTION
For use in QEMU, I would like GuestMemoryRegion to return a BitmapSlice instead of a &Bitmap ([rust-vmm/vm-memory#324](https://github.com/rust-vmm/vm-memory/pull/324)).  This adds some flexibility that QEMU needs in order to support a single global dirty bitmap that is sliced by the various GuestMemoryRegions.

However, this removes access to the methods of AtomicBitmap, and in particular reset() and get_and_reset().  Fortunately, cloud-hypervisor always uses GuestMemoryMmap, and therefore `region` is known to be a &GuestRegionMmap.  Dereferencing it returns the MmapRegion to which the bitmap is attached, thus calling MmapRegion::bitmap(); this has the same effect as `<GuestRegionMmap as GuestRegion>::bitmap()`, and works both with or without https://github.com/rust-vmm/vm-memory/pull/324.