### PR TITLE
treewide: streamline #[source] and Error (follow-up (1/2))

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,6 +2068,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ssh2",
+ "thiserror 2.0.6",
  "vmm-sys-util",
  "wait-timeout",
 ]

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -202,7 +202,7 @@ pub enum Error {
     /// Error retrieving TDX capabilities through the hypervisor (kvm/mshv) API
     #[cfg(feature = "tdx")]
     #[error("Error retrieving TDX capabilities through the hypervisor API: {0}")]
-    TdxCapabilities(HypervisorError),
+    TdxCapabilities(#[source] HypervisorError),
 
     /// Failed to configure E820 map for bzImage
     #[error("Failed to configure E820 map for bzImage")]

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -60,7 +60,7 @@ pub enum Error {
     AddressOverflow,
     /// Failure while zeroing out the memory for the MP table.
     #[error("Failure while zeroing out the memory for the MP table: {0}")]
-    Clear(GuestMemoryError),
+    Clear(#[source] GuestMemoryError),
     /// Number of CPUs exceeds the maximum supported CPUs
     #[error("Number of CPUs exceeds the maximum supported CPUs")]
     TooManyCpus,

--- a/block/src/fcntl.rs
+++ b/block/src/fcntl.rs
@@ -13,34 +13,24 @@
 //!
 //! [0]: <https://apenwarr.ca/log/20101213>.
 
-use std::error::Error;
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::Debug;
 use std::io;
 use std::os::fd::{AsRawFd, RawFd};
 
+use thiserror::Error;
+
 /// Errors that can happen when working with file locks.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum LockError {
     /// The file is already locked.
     ///
     /// A call to [`get_lock_state`] can help to identify the reason.
+    #[error("The file is already locked")]
     AlreadyLocked,
     /// IO error.
-    Io(io::Error),
+    #[error("The lock state could not be checked or set: {0}")]
+    Io(#[source] io::Error),
 }
-
-impl Display for LockError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LockError::AlreadyLocked => f.write_str("The file is already locked"),
-            LockError::Io(e) => {
-                write!(f, "{e}")
-            }
-        }
-    }
-}
-
-impl Error for LockError {}
 
 /// Commands for use with [`fcntl`].
 #[allow(non_camel_case_types)]

--- a/devices/src/interrupt_controller.rs
+++ b/devices/src/interrupt_controller.rs
@@ -37,19 +37,19 @@ pub enum Error {
     #[cfg(target_arch = "aarch64")]
     /// Failed creating GIC device.
     #[error("Failed creating GIC device: {0}")]
-    CreateGic(hypervisor::HypervisorVmError),
+    CreateGic(#[source] hypervisor::HypervisorVmError),
     #[cfg(target_arch = "aarch64")]
     /// Failed restoring GIC device.
     #[error("Failed restoring GIC device: {0}")]
-    RestoreGic(hypervisor::arch::aarch64::gic::Error),
+    RestoreGic(#[source] hypervisor::arch::aarch64::gic::Error),
     #[cfg(target_arch = "riscv64")]
     /// Failed creating AIA device.
     #[error("Failed creating AIA device: {0}")]
-    CreateAia(hypervisor::HypervisorVmError),
+    CreateAia(#[source] hypervisor::HypervisorVmError),
     #[cfg(target_arch = "riscv64")]
     /// Failed restoring AIA device.
     #[error("Failed restoring AIA device: {0}")]
-    RestoreAia(hypervisor::arch::riscv64::aia::Error),
+    RestoreAia(#[source] hypervisor::arch::riscv64::aia::Error),
 }
 
 type Result<T> = result::Result<T, Error>;

--- a/devices/src/legacy/gpio_pl061.rs
+++ b/devices/src/legacy/gpio_pl061.rs
@@ -43,11 +43,11 @@ const N_GPIOS: u32 = 8;
 pub enum Error {
     #[error("Bad Write Offset: {0}")]
     BadWriteOffset(u64),
-    #[error("GPIO interrupt disabled by guest driver.")]
+    #[error("GPIO interrupt disabled by guest driver")]
     GpioInterruptDisabled,
-    #[error("Could not trigger GPIO interrupt: {0}.")]
+    #[error("Could not trigger GPIO interrupt: {0}")]
     GpioInterruptFailure(#[source] io::Error),
-    #[error("Invalid GPIO Input key triggered: {0}.")]
+    #[error("Invalid GPIO Input key triggered: {0}")]
     GpioTriggerKeyFailure(u32),
 }
 

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -51,7 +51,7 @@ const AMBA_ID_HIGH: u64 = 0x401;
 pub enum Error {
     #[error("pl011_write: Bad Write Offset: {0}")]
     BadWriteOffset(u64),
-    #[error("pl011: DMA not implemented.")]
+    #[error("pl011: DMA not implemented")]
     DmaNotImplemented,
     #[error("Failed to trigger interrupt: {0}")]
     InterruptFailure(#[source] io::Error),

--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -5,6 +5,7 @@
 use std::sync::Arc;
 
 use libc::c_uint;
+use thiserror::Error;
 use virtio_bindings::virtio_net::{
     VIRTIO_NET_CTRL_GUEST_OFFLOADS, VIRTIO_NET_CTRL_GUEST_OFFLOADS_SET, VIRTIO_NET_CTRL_MQ,
     VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MAX, VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MIN,
@@ -18,22 +19,29 @@ use vm_virtio::{AccessPlatform, Translatable};
 
 use crate::{GuestMemoryMmap, Tap};
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// Read queue failed.
-    GuestMemory(GuestMemoryError),
+    #[error("Read queue failed")]
+    GuestMemory(#[source] GuestMemoryError),
     /// No control header descriptor
+    #[error("No control header descriptor")]
     NoControlHeaderDescriptor,
     /// Missing the data descriptor in the chain.
+    #[error("Missing the data descriptor in the chain")]
     NoDataDescriptor,
     /// No status descriptor
+    #[error("No status descriptor")]
     NoStatusDescriptor,
     /// Failed adding used index
-    QueueAddUsed(virtio_queue::Error),
+    #[error("Failed adding used index")]
+    QueueAddUsed(#[source] virtio_queue::Error),
     /// Failed creating an iterator over the queue
-    QueueIterator(virtio_queue::Error),
+    #[error("Failed creating an iterator over the queue")]
+    QueueIterator(#[source] virtio_queue::Error),
     /// Failed enabling notification for the queue
-    QueueEnableNotification(virtio_queue::Error),
+    #[error("Failed enabling notification for the queue")]
+    QueueEnableNotification(#[source] virtio_queue::Error),
 }
 
 type Result<T> = std::result::Result<T, Error>;

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -155,7 +155,9 @@ impl OptionParser {
 
 pub struct Toggle(pub bool);
 
+#[derive(Error, Debug)]
 pub enum ToggleParseError {
+    #[error("invalid value: {0}")]
     InvalidValue(String),
 }
 
@@ -176,8 +178,9 @@ impl FromStr for Toggle {
 
 pub struct ByteSized(pub u64);
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ByteSizedParseError {
+    #[error("invalid value: {0}")]
     InvalidValue(String),
 }
 
@@ -207,7 +210,9 @@ impl FromStr for ByteSized {
 
 pub struct IntegerList(pub Vec<u64>);
 
+#[derive(Error, Debug)]
 pub enum IntegerListParseError {
+    #[error("invalid value: {0}")]
     InvalidValue(String),
 }
 
@@ -297,11 +302,16 @@ impl TupleValue for Vec<usize> {
 
 pub struct Tuple<S, T>(pub Vec<(S, T)>);
 
+#[derive(Error, Debug)]
 pub enum TupleError {
+    #[error("invalid value: {0}")]
     InvalidValue(String),
-    SplitOutsideBrackets(OptionParserError),
-    InvalidIntegerList(IntegerListParseError),
-    InvalidInteger(ParseIntError),
+    #[error("split outside brackets: {0}")]
+    SplitOutsideBrackets(#[source] OptionParserError),
+    #[error("invalid integer list: {0}")]
+    InvalidIntegerList(#[source] IntegerListParseError),
+    #[error("invalid integer: {0}")]
+    InvalidInteger(#[source] ParseIntError),
 }
 
 impl<S: FromStr, T: TupleValue> FromStr for Tuple<S, T> {
@@ -339,7 +349,9 @@ impl<S: FromStr, T: TupleValue> FromStr for Tuple<S, T> {
 #[derive(Default)]
 pub struct StringList(pub Vec<String>);
 
+#[derive(Error, Debug)]
 pub enum StringListParseError {
+    #[error("invalid value: {0}")]
     InvalidValue(String),
 }
 

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use std::{fs, thread};
 
 use test_infra::{Error as InfraError, *};
+use thiserror::Error;
 
 use crate::{mean, PerformanceTestControl};
 
@@ -19,10 +20,13 @@ pub const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-custom-20210609-
 pub const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-arm64-custom-20210929-0-update-tool.raw";
 
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Error, Debug)]
 enum Error {
+    #[error("boot time could not be parsed")]
     BootTimeParse,
-    Infra(InfraError),
+    #[error("infrastructure failure: {0}")]
+    Infra(#[source] InfraError),
+    #[error("restore time could not be parsed")]
     RestoreTimeParse,
 }
 

--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -52,18 +52,21 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use thiserror::Error;
 use vmm_sys_util::timerfd::TimerFd;
 
 /// Module for group rate limiting.
 pub mod group;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 /// Describes the errors that may occur while handling rate limiter events.
 pub enum Error {
     /// The event handler was called spuriously.
+    #[error("Event handler was called spuriously: {0}")]
     SpuriousRateLimiterEvent(&'static str),
     /// The event handler encounters while TimerFd::wait()
-    TimerFdWaitError(std::io::Error),
+    #[error("Failed to wait for the timer: {0}")]
+    TimerFdWaitError(#[source] std::io::Error),
 }
 
 // Interval at which the refill timer will run when limiter is at capacity.

--- a/test_infra/Cargo.toml
+++ b/test_infra/Cargo.toml
@@ -12,5 +12,6 @@ once_cell = "1.20.2"
 serde = { version = "1.0.208", features = ["derive", "rc"] }
 serde_json = { workspace = true }
 ssh2 = { version = "0.9.4", features = ["vendored-openssl"] }
+thiserror = "2.0.6"
 vmm-sys-util = { workspace = true }
 wait-timeout = "0.2.0"


### PR DESCRIPTION
While working on #7066, I've noticed that I've missed more Error types in the code that would benefit from streamlining them. So, this is a follow-up of #7069 basically doing the same.

I've used some tooling to analyze the code base, but it seems that I've finally caught all missing pieces!

I'd like to add that I think this is well invested time, as
- future refactoring of error types can be done much more streamlined (no more manual Display and Error implementations, but `thiserror` for everything)
- error chains (cause chains) can be nicely printed
- whatever crate out there something nice with the `std::error::Error` trait, Cloud Hypervisor will be prepared

I was able to locate all missing pieces using this Python script (happily generated by ChatGPT):

```python
import os
import re

# Matches a tuple enum variant with one inner type ending in 'Error'
variant_pattern = re.compile(r'^\s*(\w+)\s*\(\s*([A-Za-z0-9_:]+Error)\s*\)\s*,?\s*$')

for root, _, files in os.walk("."):
    for f in files:
        if not f.endswith(".rs"):
            continue
        path = os.path.join(root, f)
        with open(path, "r", encoding="utf-8") as file:
            lines = file.readlines()

        for i, line in enumerate(lines):
            match = variant_pattern.match(line)
            if match:
                # Look back for #[source]
                has_source = False
                for j in range(i - 1, -1, -1):
                    prev = lines[j].strip()
                    if not prev or prev.startswith("//"):
                        continue
                    if "#[source]" in prev:
                        has_source = True
                    break

                if not has_source:
                    print(f"{path}:{i+1}: {line.strip()}")

```