### PR TITLE
Don't allow resizing VM to 0 vCPUs

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -157,6 +157,9 @@ pub enum Error {
     #[error("Error adding CpuManager to MMIO bus: {0}")]
     BusError(#[source] vm_device::BusError),
 
+    #[error("Requested zero vCPUs")]
+    DesiredVCpuCountIsZero,
+
     #[error("Requested vCPUs exceed maximum")]
     DesiredVCpuCountExceedsMax,
 
@@ -1318,6 +1321,10 @@ impl CpuManager {
 
         if !self.dynamic {
             return Ok(false);
+        }
+
+        if desired_vcpus < 1 {
+            return Err(Error::DesiredVCpuCountIsZero);
         }
 
         if self.check_pending_removed_vcpu() {


### PR DESCRIPTION
No sane guest OS will allow hotplugging all cpus.
However, the REST API currently allows specifying `ch-remote resize --cpus 0`, contrary to what is [specified](https://raw.githubusercontent.com/cloud-hypervisor/cloud-hypervisor/master/vmm/src/api/openapi/cloud-hypervisor.yaml).

On Linux, we can then observe the following error in the kernel log:

`processor cpu0: Offline failed.`

Subsequent resize commands via ch-remote will then fail with `VcpuPendingRemovedVcpu` because the removal of cpu0 was never successful.

Fix this by disallowing resizing to zero vCPUs.