### PR TITLE
Fix extended topology enumeration leaf

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -1411,6 +1411,7 @@ fn update_cpuid_topology(
         u32::from(dies_per_package * cores_per_die * threads_per_core),
     );
     CpuidPatch::set_cpuid_reg(cpuid, 0xb, Some(1), CpuidReg::ECX, 2 << 8);
+    CpuidPatch::set_cpuid_reg(cpuid, 0xb, Some(1), CpuidReg::EDX, x2apic_id);
 
     // CPU Topology leaf 0x1f
     CpuidPatch::set_cpuid_reg(cpuid, 0x1f, Some(0), CpuidReg::EAX, thread_width);


### PR DESCRIPTION
When booting a Linux guest in SMP configuration, the following kernel warning can be observed:

`[Firmware Bug]: CPUID leaf 0xb subleaf 1 APIC ID mismatch 1 != 0`

The reason is that we announce the presence of the extended topology leaf, but fail to announce the x2apic ID in EDX.

I found this issue because I am currently working on x86_64 support for >255 vCPUs where this fix is absolutely needed in order to convince Linux to boot the additional processors above 255.