### PR TITLE
treewide: streamline #[source] and Error (follow-up (2/2))

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -6,7 +6,7 @@
 use std::io::Read;
 use std::marker::PhantomData;
 use std::os::unix::net::UnixStream;
-use std::{fmt, process};
+use std::process;
 
 use api_client::{
     simple_api_command, simple_api_command_with_fds, simple_api_full_command,
@@ -14,6 +14,7 @@ use api_client::{
 };
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use option_parser::{ByteSized, ByteSizedParseError};
+use thiserror::Error;
 use vmm::config::RestoreConfig;
 use vmm::vm_config::{
     DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, UserDeviceConfig, VdpaConfig,
@@ -24,50 +25,41 @@ use zbus::{proxy, zvariant::Optional};
 
 type ApiResult = Result<(), Error>;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 enum Error {
-    HttpApiClient(ApiClientError),
+    #[error("http client error: {0}")]
+    HttpApiClient(#[source] ApiClientError),
     #[cfg(feature = "dbus_api")]
-    DBusApiClient(zbus::Error),
-    InvalidCpuCount(std::num::ParseIntError),
-    InvalidMemorySize(ByteSizedParseError),
-    InvalidBalloonSize(ByteSizedParseError),
-    AddDeviceConfig(vmm::config::Error),
-    AddDiskConfig(vmm::config::Error),
-    AddFsConfig(vmm::config::Error),
-    AddPmemConfig(vmm::config::Error),
-    AddNetConfig(vmm::config::Error),
-    AddUserDeviceConfig(vmm::config::Error),
-    AddVdpaConfig(vmm::config::Error),
-    AddVsockConfig(vmm::config::Error),
-    Restore(vmm::config::Error),
-    ReadingStdin(std::io::Error),
-    ReadingFile(std::io::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Error::*;
-        match self {
-            HttpApiClient(e) => e.fmt(f),
-            #[cfg(feature = "dbus_api")]
-            DBusApiClient(e) => write!(f, "Error D-Bus proxy: {e}"),
-            InvalidCpuCount(e) => write!(f, "Error parsing CPU count: {e}"),
-            InvalidMemorySize(e) => write!(f, "Error parsing memory size: {e:?}"),
-            InvalidBalloonSize(e) => write!(f, "Error parsing balloon size: {e:?}"),
-            AddDeviceConfig(e) => write!(f, "Error parsing device syntax: {e}"),
-            AddDiskConfig(e) => write!(f, "Error parsing disk syntax: {e}"),
-            AddFsConfig(e) => write!(f, "Error parsing filesystem syntax: {e}"),
-            AddPmemConfig(e) => write!(f, "Error parsing persistent memory syntax: {e}"),
-            AddNetConfig(e) => write!(f, "Error parsing network syntax: {e}"),
-            AddUserDeviceConfig(e) => write!(f, "Error parsing user device syntax: {e}"),
-            AddVdpaConfig(e) => write!(f, "Error parsing vDPA device syntax: {e}"),
-            AddVsockConfig(e) => write!(f, "Error parsing vsock syntax: {e}"),
-            Restore(e) => write!(f, "Error parsing restore syntax: {e}"),
-            ReadingStdin(e) => write!(f, "Error reading from stdin: {e}"),
-            ReadingFile(e) => write!(f, "Error reading from file: {e}"),
-        }
-    }
+    #[error("dbus api client error: {0}")]
+    DBusApiClient(#[source] zbus::Error),
+    #[error("Error parsing CPU count: {0}")]
+    InvalidCpuCount(#[source] std::num::ParseIntError),
+    #[error("Error parsing memory size: {0}")]
+    InvalidMemorySize(#[source] ByteSizedParseError),
+    #[error("Error parsing balloon size: {0}")]
+    InvalidBalloonSize(#[source] ByteSizedParseError),
+    #[error("Error parsing device syntax: {0}")]
+    AddDeviceConfig(#[source] vmm::config::Error),
+    #[error("Error parsing disk syntax: {0}")]
+    AddDiskConfig(#[source] vmm::config::Error),
+    #[error("Error parsing filesystem syntax: {0}")]
+    AddFsConfig(#[source] vmm::config::Error),
+    #[error("Error parsing persistent memory syntax: {0}")]
+    AddPmemConfig(#[source] vmm::config::Error),
+    #[error("Error parsing network syntax: {0}")]
+    AddNetConfig(#[source] vmm::config::Error),
+    #[error("Error parsing user device syntax: {0}")]
+    AddUserDeviceConfig(#[source] vmm::config::Error),
+    #[error("Error parsing vDPA device syntax: {0}")]
+    AddVdpaConfig(#[source] vmm::config::Error),
+    #[error("Error parsing vsock syntax: {0}")]
+    AddVsockConfig(#[source] vmm::config::Error),
+    #[error("Error parsing restore syntax: {0}")]
+    Restore(#[source] vmm::config::Error),
+    #[error("Error reading from stdin: {0}")]
+    ReadingStdin(#[source] std::io::Error),
+    #[error("Error reading from file: {0}")]
+    ReadingFile(#[source] std::io::Error),
 }
 
 enum TargetApi<'a> {

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -33,8 +33,6 @@
 pub mod dbus;
 pub mod http;
 
-use core::fmt;
-use std::fmt::Display;
 use std::io;
 use std::sync::mpsc::{channel, RecvError, SendError, Sender};
 
@@ -60,154 +58,146 @@ use crate::Error as VmmError;
 #[derive(Error, Debug)]
 pub enum ApiError {
     /// Cannot write to EventFd.
+    #[error("Cannot write to EventFd: {0}")]
     EventFdWrite(#[source] io::Error),
 
     /// API request send error
-    RequestSend(SendError<ApiRequest>),
+    #[error("API request send error: {0}")]
+    RequestSend(#[source] SendError<ApiRequest>),
 
     /// Wrong response payload type
+    #[error("Wrong response payload type")]
     ResponsePayloadType,
 
     /// API response receive error
-    ResponseRecv(RecvError),
+    #[error("API response receive error: {0}")]
+    ResponseRecv(#[source] RecvError),
 
     /// The VM could not boot.
-    VmBoot(VmError),
+    #[error("The VM could not boot: {0}")]
+    VmBoot(#[source] VmError),
 
     /// The VM could not be created.
-    VmCreate(VmError),
+    #[error("The VM could not be created: {0}")]
+    VmCreate(#[source] VmError),
 
     /// The VM could not be deleted.
-    VmDelete(VmError),
+    #[error("The VM could not be deleted: {0}")]
+    VmDelete(#[source] VmError),
 
     /// The VM info is not available.
-    VmInfo(VmError),
+    #[error("The VM info is not available: {0}")]
+    VmInfo(#[source] VmError),
 
     /// The VM could not be paused.
-    VmPause(VmError),
+    #[error("The VM could not be paused: {0}")]
+    VmPause(#[source] VmError),
 
     /// The VM could not resume.
-    VmResume(VmError),
+    #[error("The VM could not resume: {0}")]
+    VmResume(#[source] VmError),
 
     /// The VM is not booted.
+    #[error("The VM is not booted")]
     VmNotBooted,
 
     /// The VM is not created.
+    #[error("The VM is not created")]
     VmNotCreated,
 
     /// The VM could not shutdown.
-    VmShutdown(VmError),
+    #[error("The VM could not shutdown: {0}")]
+    VmShutdown(#[source] VmError),
 
     /// The VM could not reboot.
-    VmReboot(VmError),
+    #[error("The VM could not reboot: {0}")]
+    VmReboot(#[source] VmError),
 
     /// The VM could not be snapshotted.
-    VmSnapshot(VmError),
+    #[error("The VM could not be snapshotted: {0}")]
+    VmSnapshot(#[source] VmError),
 
     /// The VM could not restored.
-    VmRestore(VmError),
+    #[error("The VM could not restored: {0}")]
+    VmRestore(#[source] VmError),
 
     /// The VM could not be coredumped.
-    VmCoredump(VmError),
+    #[error("The VM could not be coredumped: {0}")]
+    VmCoredump(#[source] VmError),
 
     /// The VMM could not shutdown.
-    VmmShutdown(VmError),
+    #[error("The VMM could not shutdown: {0}")]
+    VmmShutdown(#[source] VmError),
 
     /// The VM could not be resized
-    VmResize(VmError),
+    #[error("The VM could not be resized: {0}")]
+    VmResize(#[source] VmError),
 
     /// The memory zone could not be resized.
-    VmResizeZone(VmError),
+    #[error("The memory zone could not be resized: {0}")]
+    VmResizeZone(#[source] VmError),
 
     /// The device could not be added to the VM.
-    VmAddDevice(VmError),
+    #[error("The device could not be added to the VM: {0}")]
+    VmAddDevice(#[source] VmError),
 
     /// The user device could not be added to the VM.
-    VmAddUserDevice(VmError),
+    #[error("The user device could not be added to the VM: {0}")]
+    VmAddUserDevice(#[source] VmError),
 
     /// The device could not be removed from the VM.
-    VmRemoveDevice(VmError),
+    #[error("The device could not be removed from the VM: {0}")]
+    VmRemoveDevice(#[source] VmError),
 
     /// Cannot create seccomp filter
-    CreateSeccompFilter(seccompiler::Error),
+    #[error("Cannot create seccomp filter: {0}")]
+    CreateSeccompFilter(#[source] seccompiler::Error),
 
     /// Cannot apply seccomp filter
-    ApplySeccompFilter(seccompiler::Error),
+    #[error("Cannot apply seccomp filter: {0}")]
+    ApplySeccompFilter(#[source] seccompiler::Error),
 
     /// The disk could not be added to the VM.
-    VmAddDisk(VmError),
+    #[error("The disk could not be added to the VM: {0}")]
+    VmAddDisk(#[source] VmError),
 
     /// The fs could not be added to the VM.
-    VmAddFs(VmError),
+    #[error("The fs could not be added to the VM: {0}")]
+    VmAddFs(#[source] VmError),
 
     /// The pmem device could not be added to the VM.
-    VmAddPmem(VmError),
+    #[error("The pmem device could not be added to the VM: {0}")]
+    VmAddPmem(#[source] VmError),
 
     /// The network device could not be added to the VM.
-    VmAddNet(VmError),
+    #[error("The network device could not be added to the VM: {0}")]
+    VmAddNet(#[source] VmError),
 
     /// The vDPA device could not be added to the VM.
-    VmAddVdpa(VmError),
+    #[error("The vDPA device could not be added to the VM: {0}")]
+    VmAddVdpa(#[source] VmError),
 
     /// The vsock device could not be added to the VM.
-    VmAddVsock(VmError),
+    #[error("The vsock device could not be added to the VM: {0}")]
+    VmAddVsock(#[source] VmError),
 
     /// Error starting migration receiver
-    VmReceiveMigration(MigratableError),
+    #[error("Error starting migration receiver: {0}")]
+    VmReceiveMigration(#[source] MigratableError),
 
     /// Error starting migration sender
-    VmSendMigration(MigratableError),
+    #[error("Error starting migration sender: {0}")]
+    VmSendMigration(#[source] MigratableError),
 
     /// Error triggering power button
-    VmPowerButton(VmError),
+    #[error("Error triggering power button: {0}")]
+    VmPowerButton(#[source] VmError),
 
     /// Error triggering NMI
-    VmNmi(VmError),
+    #[error("Error triggering NMI: {0}")]
+    VmNmi(#[source] VmError),
 }
 pub type ApiResult<T> = Result<T, ApiError>;
-
-impl Display for ApiError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::ApiError::*;
-        match self {
-            EventFdWrite(serde_error) => write!(f, "{serde_error}"),
-            RequestSend(send_error) => write!(f, "{send_error}"),
-            ResponsePayloadType => write!(f, "Wrong response payload type"),
-            ResponseRecv(recv_error) => write!(f, "{recv_error}"),
-            VmBoot(vm_error) => write!(f, "{vm_error}"),
-            VmCreate(vm_error) => write!(f, "{vm_error}"),
-            VmDelete(vm_error) => write!(f, "{vm_error}"),
-            VmInfo(vm_error) => write!(f, "{vm_error}"),
-            VmPause(vm_error) => write!(f, "{vm_error}"),
-            VmResume(vm_error) => write!(f, "{vm_error}"),
-            VmNotBooted => write!(f, "VM is not booted"),
-            VmNotCreated => write!(f, "VM is not created"),
-            VmShutdown(vm_error) => write!(f, "{vm_error}"),
-            VmReboot(vm_error) => write!(f, "{vm_error}"),
-            VmSnapshot(vm_error) => write!(f, "{vm_error}"),
-            VmRestore(vm_error) => write!(f, "{vm_error}"),
-            VmCoredump(vm_error) => write!(f, "{vm_error}"),
-            VmmShutdown(vm_error) => write!(f, "{vm_error}"),
-            VmResize(vm_error) => write!(f, "{vm_error}"),
-            VmResizeZone(vm_error) => write!(f, "{vm_error}"),
-            VmAddDevice(vm_error) => write!(f, "{vm_error}"),
-            VmAddUserDevice(vm_error) => write!(f, "{vm_error}"),
-            VmRemoveDevice(vm_error) => write!(f, "{vm_error}"),
-            CreateSeccompFilter(seccomp_error) => write!(f, "{seccomp_error}"),
-            ApplySeccompFilter(seccomp_error) => write!(f, "{seccomp_error}"),
-            VmAddDisk(vm_error) => write!(f, "{vm_error}"),
-            VmAddFs(vm_error) => write!(f, "{vm_error}"),
-            VmAddPmem(vm_error) => write!(f, "{vm_error}"),
-            VmAddNet(vm_error) => write!(f, "{vm_error}"),
-            VmAddVdpa(vm_error) => write!(f, "{vm_error}"),
-            VmAddVsock(vm_error) => write!(f, "{vm_error}"),
-            VmReceiveMigration(migratable_error) => write!(f, "{migratable_error}"),
-            VmSendMigration(migratable_error) => write!(f, "{migratable_error}"),
-            VmPowerButton(vm_error) => write!(f, "{vm_error}"),
-            VmNmi(vm_error) => write!(f, "{vm_error}"),
-        }
-    }
-}
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct VmInfoResponse {


### PR DESCRIPTION
Split-out of the problematic part of #7085. The commits 
- misc: ch-remote: streamline #[source] and Error impl
- misc: vmm/api: streamline #[source] and Error impl
somehow introduce the problem.

I'm seeking help and guidance; I have no idea how to debug the failing `test_api_http_pause_resume` test efficiently. [Failing Output Example](https://github.com/cloud-hypervisor/cloud-hypervisor/actions/runs/15181465682/job/42691642237?pr=7089)

```
...
Error running ch-remote command: "target/x86_64-unknown-linux-gnu/release/ch-remote" "--api-socket=/tmp/ch4qye1L/cloud-hypervisor.sock" "resume"
stderr: Error opening HTTP socket: Connection refused (os error 111)

thread 'common_parallel::test_api_http_pause_resume' panicked at tests/integration.rs:377:9:
assertion failed: target_api.remote_command("resume", None)
...
```

 Using `bash ./scripts/dev_cli.sh tests --integration -- --test-filter test_api_http_pause_resume -- --show-output`, I could reduce the feedback loop to around six minutes on my machine, which is not very pleasant to work with. Thanks for any help in advance!

## Steps to Undraft
- [ ] Merge and rebase onto #7085
- [ ] Understand and fix bug