### PR TITLE
vmm: Deprecate SGX support

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2893,6 +2893,7 @@ impl VmConfig {
         #[cfg(target_arch = "x86_64")]
         {
             if let Some(sgx_epc_list) = &vm_params.sgx_epc {
+                warn!("SGX support is deprecated and will be removed in a future release.");
                 let mut sgx_epc_config_list = Vec::new();
                 for item in sgx_epc_list.iter() {
                     let sgx_epc_config = SgxEpcConfig::parse(item)?;


### PR DESCRIPTION
This commit adds the warning to deprecate the SGX support with the intention to remove the support from code base in two release cycles.

See: #6960