### PR TITLE
arch: x86_64: lower the cpuid log level

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -888,7 +888,7 @@ pub fn configure_vcpu(
     }
 
     for c in &cpuid {
-        info!("{}", c);
+        debug!("{}", c);
     }
 
     vcpu.set_cpuid2(&cpuid)


### PR DESCRIPTION
There are a little many cpuid logs now. When starting a vm with 64 vcpu, we can get more than four thousand INFO messages:

cat vm1.log |grep 'arch/src/x86_64/mod.rs:891' |wc -l 
4352