### PR TITLE
Fix Resolve Snapshot Restore Failure with virtiofsd

### DIFF
--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -315,6 +315,9 @@ impl VhostUserHandle {
         self.vu
             .get_features()
             .map_err(Error::VhostUserGetFeatures)?;
+        self.vu
+            .get_protocol_features()
+            .map_err(Error::VhostUserGetProtocolFeatures)?;
 
         if acked_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits() != 0 {
             if let Some(acked_protocol_features) =


### PR DESCRIPTION
Fix issue described in #6931

The root cause of the Cloud Hypervisor hang is a failure to negotiate the REPLY_ACK protocol feature with virtiofsd during VM snapshot restore. As a result, the VM hangs [here](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/dd7318e8390843d06d2a678ea2c674f11a60be65/virtio-devices/src/vhost_user/vu_common_ctrl.rs#L163), indefinitely waiting for an ACK reply.

To clarify: the request itself completes successfully, but on the virtiofsd side, the ACK reply is [intentionally skipped](https://github.com/rust-vmm/vhost/blob/888165bd8b0ab593ccc8498169f152d4a2a50b1f/vhost/src/vhost_user/backend_req_handler.rs#L983) because reply_ack_enabled is false. Despite the fact that req.is_need_reply is true (indicating an ACK is expected), the protocol feature negotiation was incomplete.

The missing piece is that, before negotiating virtiofsd protocol features, both [GET_FEATURES](https://github.com/rust-vmm/vhost/blob/888165bd8b0ab593ccc8498169f152d4a2a50b1f/vhost/src/vhost_user/backend_req_handler.rs#L450) and [GET_PROTOCOL_FEATURES](https://github.com/rust-vmm/vhost/blob/888165bd8b0ab593ccc8498169f152d4a2a50b1f/vhost/src/vhost_user/backend_req_handler.rs#L523) must be called, as these initialize required state on the virtiofsd side.

In our code, we already called [GET_FEATURES](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/6d85fb5af4e56a60d55fc56a426ab943c1482acd/virtio-devices/src/vhost_user/vu_common_ctrl.rs#L317) before negotiating protocol features. However, we missed a corresponding call to GET_PROTOCOL_FEATURES.

You might wonder why this worked when starting a VM normally (i.e., without restoring from a snapshot). My assumption is that, in that case, we follow [this](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/dd7318e8390843d06d2a678ea2c674f11a60be65/virtio-devices/src/vhost_user/vu_common_ctrl.rs#L128) code path, where GET_PROTOCOL_FEATURES is triggered just before protocol feature negotiation.

This fix allows the VM to be successfully restored from a snapshot:
```
cloud-hypervisor: 5.028427s: <vmm> INFO:vmm/src/cpu.rs:1241 -- Starting vCPUs: desired = 1, allocated = 1, present = 0, paused = true
cloud-hypervisor: 5.028631s: <vmm> INFO:vmm/src/cpu.rs:1011 -- Starting vCPU: cpu_id = 0
```

However, I’m still encountering a kernel panic when resuming the VM:
```
cloud-hypervisor: 38.646376s: <vmm> INFO:vmm/src/api/mod.rs:1220 -- API request event: VmResume
cloud-hypervisor: 38.646505s: <vmm> INFO:virtio-devices/src/device.rs:335 -- Resuming virtio-fs
cloud-hypervisor: 38.647966s: <vmm> INFO:virtio-devices/src/device.rs:335 -- Resuming virtio-console
cloud-hypervisor: 38.648150s: <vmm> INFO:virtio-devices/src/device.rs:335 -- Resuming virtio-rng
cloud-hypervisor: 38.648312s: <vmm> INFO:virtio-devices/src/device.rs:335 -- Resuming virtio-net
[   20.020053] Hangcheck: hangcheck value past margin!
[   20.041587] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000007
[   20.042535] Kernel Offset: disabled
[   20.043427] ---[ end Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000007 ]---
```

I’d love to contribute a fix for this as well, but for now I’m not sure what’s causing it, happy to hear any thoughts or suggestions!

Thanks!:)