### PR TITLE
devices: Add fw_cfg device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
  "vm-memory",
  "vm-migration",
  "vmm-sys-util",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitfield"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5acf59e2452f0c4b968b15ce4b9468f57b45f7733b919d68b19fcc39264bfb8"
+
+[[package]]
 name = "bitfield-struct"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +573,7 @@ dependencies = [
  "acpi_tables",
  "anyhow",
  "arch",
+ "bitfield",
  "bitflags 2.9.0",
  "byteorder",
  "event_monitor",
@@ -1718,9 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -2055,9 +2062,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.38.34",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -216,7 +216,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 0.38.34",
  "tracing",
 ]
 
@@ -243,7 +243,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 0.38.34",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -572,6 +572,7 @@ dependencies = [
  "event_monitor",
  "hypervisor",
  "libc",
+ "linux-loader",
  "log",
  "num_enum",
  "pci",
@@ -701,12 +702,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1143,9 +1144,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libredox"
@@ -1197,6 +1198,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "lock_api"
@@ -1677,7 +1684,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.34",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -1855,8 +1862,21 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2046,14 +2066,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.3",
  "windows-sys 0.59.0",
 ]
 
@@ -2063,7 +2083,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ wait-timeout = "0.2.0"
 dbus_api = ["vmm/dbus_api", "zbus"]
 default = ["io_uring", "kvm"]
 dhat-heap = ["dhat", "vmm/dhat-heap"]       # For heap profiling
+fw_cfg = ["vmm/fw_cfg"]
 guest_debug = ["vmm/guest_debug"]
 igvm = ["mshv", "vmm/igvm"]
 io_uring = ["vmm/io_uring"]

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -13,6 +13,7 @@ byteorder = "1.5.0"
 event_monitor = { path = "../event_monitor" }
 hypervisor = { path = "../hypervisor" }
 libc = "0.2.167"
+linux-loader = { workspace = true, features = ["bzimage", "elf", "pe"] }
 log = "0.4.22"
 num_enum = "0.7.2"
 pci = { path = "../pci" }

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -28,6 +28,7 @@ vm-memory = { workspace = true, features = [
 ] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { workspace = true }
+zerocopy = { version = "0.8.24", features = ["alloc", "derive"] }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]
 arch = { path = "../arch" }

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 acpi_tables = { workspace = true }
 anyhow = "1.0.94"
 arch = { path = "../arch" }
+bitfield = "0.16.1"
 bitflags = "2.9.0"
 byteorder = "1.5.0"
 event_monitor = { path = "../event_monitor" }

--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -3,18 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#[cfg(not(target_arch = "riscv64"))]
+use std::mem::{offset_of, size_of};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Instant;
 
+#[cfg(not(target_arch = "riscv64"))]
+use acpi_tables::rsdp::Rsdp;
 use acpi_tables::{aml, Aml, AmlSink};
 use vm_device::interrupt::InterruptSourceGroup;
 use vm_device::BusDevice;
 use vm_memory::GuestAddress;
 use vmm_sys_util::eventfd::EventFd;
+#[cfg(not(target_arch = "riscv64"))]
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use super::AcpiNotificationFlags;
+#[cfg(not(target_arch = "riscv64"))]
+use crate::legacy::fw_cfg::{create_file_name, FwCfgContent, FwCfgItem, FILE_NAME_SIZE};
 
 pub const GED_DEVICE_ACPI_SIZE: usize = 0x1;
 
@@ -253,4 +261,205 @@ impl BusDevice for AcpiPmTimerDevice {
 
         data.copy_from_slice(&counter.to_le_bytes());
     }
+}
+
+pub const COMMAND_ALLOCATE: u32 = 0x1;
+pub const COMMAND_ADD_POINTER: u32 = 0x2;
+pub const COMMAND_ADD_CHECKSUM: u32 = 0x3;
+
+pub const ALLOC_ZONE_HIGH: u8 = 0x1;
+pub const ALLOC_ZONE_FSEG: u8 = 0x2;
+
+pub const FW_CFG_FILENAME_TABLE_LOADER: &str = "etc/table-loader";
+pub const FW_CFG_FILENAME_RSDP: &str = "acpi/rsdp";
+pub const FW_CFG_FILENAME_ACPI_TABLES: &str = "acpi/tables";
+
+pub const SIGNATURE: [u8; 4] = *b"XSDT";
+pub const COMPILER_ID: [u8; 4] = *b"RVAT";
+
+#[cfg(not(target_arch = "riscv64"))]
+#[repr(C, align(4))]
+#[derive(Debug, IntoBytes, Immutable)]
+pub struct Allocate {
+    command: u32,
+    file: [u8; FILE_NAME_SIZE],
+    align: u32,
+    zone: u8,
+    _pad: [u8; 63],
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+#[repr(C, align(4))]
+#[derive(Debug, IntoBytes, Immutable)]
+pub struct AddPointer {
+    command: u32,
+    dst: [u8; FILE_NAME_SIZE],
+    src: [u8; FILE_NAME_SIZE],
+    offset: u32,
+    size: u8,
+    _pad: [u8; 7],
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+#[repr(C, align(4))]
+#[derive(Debug, IntoBytes, Immutable)]
+pub struct AddChecksum {
+    command: u32,
+    file: [u8; FILE_NAME_SIZE],
+    offset: u32,
+    start: u32,
+    len: u32,
+    _pad: [u8; 56],
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+fn create_intra_pointer(name: &str, offset: usize, size: u8) -> AddPointer {
+    AddPointer {
+        command: COMMAND_ADD_POINTER,
+        dst: create_file_name(name),
+        src: create_file_name(name),
+        offset: offset as u32,
+        size,
+        _pad: [0; 7],
+    }
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+fn create_acpi_table_checksum(offset: usize, len: usize) -> AddChecksum {
+    AddChecksum {
+        command: COMMAND_ADD_CHECKSUM,
+        file: create_file_name(FW_CFG_FILENAME_ACPI_TABLES),
+        offset: (offset + offset_of!(AcpiTableHeader, checksum)) as u32,
+        start: offset as u32,
+        len: len as u32,
+        _pad: [0; 56],
+    }
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+#[inline]
+pub fn wrapping_sum<'a, T>(data: T) -> u8
+where
+    T: IntoIterator<Item = &'a u8>,
+{
+    data.into_iter().fold(0u8, |accu, e| accu.wrapping_add(*e))
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+#[repr(C, align(4))]
+#[derive(Debug, Clone, Default, FromBytes, IntoBytes)]
+pub struct AcpiTableHeader {
+    pub signature: [u8; 4],
+    pub length: u32,
+    pub revision: u8,
+    pub checksum: u8,
+    pub oem_id: [u8; 6],
+    pub oem_table_id: [u8; 8],
+    pub oem_revision: u32,
+    pub asl_compiler_id: [u8; 4],
+    pub asl_compiler_revision: u32,
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+pub struct AcpiTable {
+    pub rsdp: Rsdp,
+    pub tables: Vec<u8>,
+    pub table_pointers: Vec<usize>,
+    pub table_checksums: Vec<(usize, usize)>,
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+impl AcpiTable {
+    pub fn rsdp(&self) -> &Rsdp {
+        &self.rsdp
+    }
+
+    pub fn tables(&self) -> &[u8] {
+        &self.tables
+    }
+
+    pub fn pointers(&self) -> &[usize] {
+        &self.table_pointers
+    }
+
+    pub fn checksums(&self) -> &[(usize, usize)] {
+        &self.table_checksums
+    }
+
+    pub fn take(self) -> (Rsdp, Vec<u8>) {
+        (self.rsdp, self.tables)
+    }
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+pub fn create_acpi_loader(acpi_table: AcpiTable) -> [FwCfgItem; 3] {
+    let mut table_loader_bytes: Vec<u8> = Vec::new();
+    let allocate_rsdp = Allocate {
+        command: COMMAND_ALLOCATE,
+        file: create_file_name(FW_CFG_FILENAME_RSDP),
+        align: 4,
+        zone: ALLOC_ZONE_FSEG,
+        _pad: [0; 63],
+    };
+    table_loader_bytes.extend(allocate_rsdp.as_bytes());
+
+    let allocate_tables = Allocate {
+        command: COMMAND_ALLOCATE,
+        file: create_file_name(FW_CFG_FILENAME_ACPI_TABLES),
+        align: 4,
+        zone: ALLOC_ZONE_HIGH,
+        _pad: [0; 63],
+    };
+    table_loader_bytes.extend(allocate_tables.as_bytes());
+
+    for pointer_offset in acpi_table.pointers().iter() {
+        let pointer = create_intra_pointer(FW_CFG_FILENAME_ACPI_TABLES, *pointer_offset, 8);
+        table_loader_bytes.extend(pointer.as_bytes());
+    }
+    for (offset, len) in acpi_table.checksums().iter() {
+        let checksum = create_acpi_table_checksum(*offset, *len);
+        table_loader_bytes.extend(checksum.as_bytes());
+    }
+    let pointer_rsdp_to_xsdt = AddPointer {
+        command: COMMAND_ADD_POINTER,
+        dst: create_file_name(FW_CFG_FILENAME_RSDP),
+        src: create_file_name(FW_CFG_FILENAME_ACPI_TABLES),
+        offset: offset_of!(Rsdp, xsdt_addr) as u32,
+        size: 8,
+        _pad: [0; 7],
+    };
+    table_loader_bytes.extend(pointer_rsdp_to_xsdt.as_bytes());
+    let checksum_rsdp = AddChecksum {
+        command: COMMAND_ADD_CHECKSUM,
+        file: create_file_name(FW_CFG_FILENAME_RSDP),
+        offset: offset_of!(Rsdp, checksum) as u32,
+        start: 0,
+        len: offset_of!(Rsdp, length) as u32,
+        _pad: [0; 56],
+    };
+    let checksum_rsdp_ext = AddChecksum {
+        command: COMMAND_ADD_CHECKSUM,
+        file: create_file_name(FW_CFG_FILENAME_RSDP),
+        offset: offset_of!(Rsdp, extended_checksum) as u32,
+        start: 0,
+        len: size_of::<Rsdp>() as u32,
+        _pad: [0; 56],
+    };
+    table_loader_bytes.extend(checksum_rsdp.as_bytes());
+    table_loader_bytes.extend(checksum_rsdp_ext.as_bytes());
+
+    let table_loader = FwCfgItem {
+        name: FW_CFG_FILENAME_TABLE_LOADER.to_owned(),
+        content: FwCfgContent::Bytes(table_loader_bytes),
+    };
+    let (rsdp, tables) = acpi_table.take();
+    let acpi_rsdp = FwCfgItem {
+        name: FW_CFG_FILENAME_RSDP.to_owned(),
+        content: FwCfgContent::Bytes(rsdp.as_bytes().to_owned()),
+    };
+    let apci_tables = FwCfgItem {
+        name: FW_CFG_FILENAME_ACPI_TABLES.to_owned(),
+        content: FwCfgContent::Bytes(tables),
+    };
+    [table_loader, acpi_rsdp, apci_tables]
 }

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -1,0 +1,307 @@
+// Copyright 2025 Google LLC.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// NOTE: This is not a full implementation of the qemu fw_cfg spec.
+/// We implement the functionality necessary to use Oak's Stage0 Firmware
+/// (This includes most of the functionality, besides adding additional
+/// items to the fw_cfg device for the firmware).
+use std::{
+    fs::File,
+    io::Result,
+    mem::size_of_val,
+    os::unix::fs::FileExt,
+    sync::{Arc, Barrier},
+};
+
+use vm_device::BusDevice;
+use vmm_sys_util::sock_ctrl_msg::IntoIovec;
+use zerocopy::{FromBytes, IntoBytes};
+
+#[cfg(target_arch = "x86_64")]
+pub const PORT_FW_CFG_SELECTOR: u64 = 0x510;
+#[cfg(target_arch = "x86_64")]
+pub const PORT_FW_CFG_DATA: u64 = 0x511;
+#[cfg(target_arch = "x86_64")]
+pub const PORT_FW_CFG_DMA_HI: u64 = 0x514;
+#[cfg(target_arch = "x86_64")]
+pub const PORT_FW_CFG_DMA_LO: u64 = 0x518;
+#[cfg(target_arch = "x86_64")]
+pub const PORT_FW_CFG_BASE: u64 = 0x510;
+#[cfg(target_arch = "x86_64")]
+pub const PORT_FW_CFG_WIDTH: u64 = 0xc;
+#[cfg(target_arch = "aarch64")]
+pub const PORT_FW_CFG_SELECTOR: u64 = 0x9020008;
+#[cfg(target_arch = "aarch64")]
+pub const PORT_FW_CFG_DATA: u64 = 0x9020000;
+#[cfg(target_arch = "aarch64")]
+pub const PORT_FW_CFG_DMA_HI: u64 = 0x9020010;
+#[cfg(target_arch = "aarch64")]
+pub const PORT_FW_CFG_DMA_LO: u64 = 0x9020014;
+#[cfg(target_arch = "aarch64")]
+pub const PORT_FW_CFG_BASE: u64 = 0x9020000;
+#[cfg(target_arch = "aarch64")]
+pub const PORT_FW_CFG_WIDTH: u64 = 0x10;
+
+pub const FW_CFG_SIGNATURE: u16 = 0x00;
+pub const FW_CFG_ID: u16 = 0x01;
+pub const FW_CFG_KERNEL_SIZE: u16 = 0x08;
+pub const FW_CFG_INITRD_SIZE: u16 = 0x0b;
+pub const FW_CFG_KERNEL_DATA: u16 = 0x11;
+pub const FW_CFG_INITRD_DATA: u16 = 0x12;
+pub const FW_CFG_CMDLINE_SIZE: u16 = 0x14;
+pub const FW_CFG_CMDLINE_DATA: u16 = 0x15;
+pub const FW_CFG_SETUP_SIZE: u16 = 0x17;
+pub const FW_CFG_SETUP_DATA: u16 = 0x18;
+pub const FW_CFG_FILE_DIR: u16 = 0x19;
+pub const FW_CFG_KNOWN_ITEMS: usize = 0x20;
+
+pub const FW_CFG_FILE_FIRST: u16 = 0x20;
+pub const FW_CFG_DMA_SIGNATURE: [u8; 8] = *b"QEMU CFG";
+// bit 1 must always be enabled, bit 2 enables DMA
+pub const FW_CFG_FEATURE: [u8; 4] = [0b11, 0, 0, 0];
+
+#[derive(Debug)]
+pub enum FwCfgContent {
+    Bytes(Vec<u8>),
+    Slice(&'static [u8]),
+    File(u64, File),
+    U32(u32),
+}
+
+impl Default for FwCfgContent {
+    fn default() -> Self {
+        FwCfgContent::Slice(&[])
+    }
+}
+
+impl FwCfgContent {
+    fn size(&self) -> Result<u32> {
+        let ret = match self {
+            FwCfgContent::Bytes(v) => v.len(),
+            FwCfgContent::File(offset, f) => (f.metadata()?.len() - offset) as usize,
+            FwCfgContent::Slice(s) => s.len(),
+            FwCfgContent::U32(n) => size_of_val(n),
+        };
+        u32::try_from(ret).map_err(|_| std::io::ErrorKind::InvalidInput.into())
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct FwCfgItem {
+    pub name: String,
+    pub content: FwCfgContent,
+}
+
+/// https://www.qemu.org/docs/master/specs/fw_cfg.html
+pub struct FwCfg {
+    selector: u16,
+    data_offset: u32,
+    items: Vec<FwCfgItem>,                           // 0x20 and above
+    known_items: [FwCfgContent; FW_CFG_KNOWN_ITEMS], // 0x0 to 0x19
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes)]
+struct FwCfgFilesHeader {
+    count_be: u32,
+}
+
+pub const FILE_NAME_SIZE: usize = 56;
+
+pub fn create_file_name(name: &str) -> [u8; FILE_NAME_SIZE] {
+    let mut c_name = [0u8; FILE_NAME_SIZE];
+    let c_len = std::cmp::min(FILE_NAME_SIZE - 1, name.len());
+    c_name[0..c_len].copy_from_slice(&name.as_bytes()[0..c_len]);
+    c_name
+}
+
+#[allow(dead_code)]
+#[repr(C, packed)]
+#[derive(Debug, IntoBytes, FromBytes, Clone, Copy)]
+pub struct BootE820Entry {
+    pub addr: u64,
+    pub size: u64,
+    pub type_: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes)]
+struct FwCfgFile {
+    size_be: u32,
+    select_be: u16,
+    _reserved: u16,
+    name: [u8; FILE_NAME_SIZE],
+}
+
+impl FwCfg {
+    pub fn new() -> FwCfg {
+        const DEFAULT_ITEM: FwCfgContent = FwCfgContent::Slice(&[]);
+        let mut known_items = [DEFAULT_ITEM; FW_CFG_KNOWN_ITEMS];
+        known_items[FW_CFG_SIGNATURE as usize] = FwCfgContent::Slice(&FW_CFG_DMA_SIGNATURE);
+        known_items[FW_CFG_ID as usize] = FwCfgContent::Slice(&FW_CFG_FEATURE);
+        let file_buf = Vec::from(FwCfgFilesHeader { count_be: 0 }.as_mut_bytes());
+        known_items[FW_CFG_FILE_DIR as usize] = FwCfgContent::Bytes(file_buf);
+
+        FwCfg {
+            selector: 0,
+            data_offset: 0,
+            items: vec![],
+            known_items,
+        }
+    }
+
+    fn get_file_dir_mut(&mut self) -> &mut Vec<u8> {
+        let FwCfgContent::Bytes(file_buf) = &mut self.known_items[FW_CFG_FILE_DIR as usize] else {
+            unreachable!("fw_cfg: selector {FW_CFG_FILE_DIR:#x} should be FwCfgContent::Byte!")
+        };
+        file_buf
+    }
+
+    fn update_count(&mut self) {
+        let mut header = FwCfgFilesHeader {
+            count_be: (self.items.len() as u32).to_be(),
+        };
+        self.get_file_dir_mut()[0..4].copy_from_slice(header.as_mut_bytes());
+    }
+
+    pub fn add_item(&mut self, item: FwCfgItem) -> Result<()> {
+        let index = self.items.len();
+        let c_name = create_file_name(&item.name);
+        let size = item.content.size()?;
+        let mut cfg_file = FwCfgFile {
+            size_be: size.to_be(),
+            select_be: (FW_CFG_FILE_FIRST + index as u16).to_be(),
+            _reserved: 0,
+            name: c_name,
+        };
+        self.get_file_dir_mut()
+            .extend_from_slice(cfg_file.as_mut_bytes());
+        self.items.push(item);
+        self.update_count();
+        Ok(())
+    }
+
+    fn read_content(content: &FwCfgContent, offset: u32, data: &mut [u8], size: u32) -> Option<u8> {
+        let start = offset as usize;
+        let end = start + size as usize;
+        match content {
+            FwCfgContent::Bytes(b) => {
+                if b.len() >= size as usize {
+                    data.copy_from_slice(&b[start..end]);
+                }
+            }
+            FwCfgContent::Slice(s) => {
+                if s.len() >= size as usize {
+                    data.copy_from_slice(&s[start..end]);
+                }
+            }
+            FwCfgContent::File(o, f) => {
+                f.read_exact_at(data, o + offset as u64).ok()?;
+            }
+            FwCfgContent::U32(n) => {
+                let bytes = n.to_le_bytes();
+                data.copy_from_slice(&bytes[start..end]);
+            }
+        };
+        Some(size as u8)
+    }
+
+    fn read_data(&mut self, data: &mut [u8], size: u32) -> u8 {
+        let ret = if let Some(content) = self.known_items.get(self.selector as usize) {
+            Self::read_content(content, self.data_offset, data, size)
+        } else if let Some(item) = self.items.get((self.selector - FW_CFG_FILE_FIRST) as usize) {
+            Self::read_content(&item.content, self.data_offset, data, size)
+        } else {
+            error!("fw_cfg: selector {:#x} does not exist.", self.selector);
+            None
+        };
+        if let Some(val) = ret {
+            self.data_offset += size;
+            val
+        } else {
+            0
+        }
+    }
+}
+
+impl BusDevice for FwCfg {
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
+        let port = offset + PORT_FW_CFG_BASE;
+        let size = data.len();
+        match (port, size) {
+            (PORT_FW_CFG_SELECTOR, _) => {
+                error!("fw_cfg: selector register is write-only.");
+            }
+            (PORT_FW_CFG_DATA, _) => _ = self.read_data(data, size as u32),
+            (PORT_FW_CFG_DMA_HI, 4) => {
+                unimplemented!()
+            }
+            (PORT_FW_CFG_DMA_LO, 4) => {
+                unimplemented!()
+            }
+            _ => {
+                error!("fw_cfg: read unknown port {port:#x} with size {size}.");
+            }
+        };
+    }
+
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        let port = offset + PORT_FW_CFG_BASE;
+        let size = data.size();
+        match (port, size) {
+            (PORT_FW_CFG_SELECTOR, 2) => {
+                let mut buf = [0u8; 2];
+                buf[..size].copy_from_slice(&data[..size]);
+                let val = u16::from_le_bytes(buf);
+                self.selector = val;
+                self.data_offset = 0;
+            }
+            (PORT_FW_CFG_DATA, 1) => error!("fw_cfg: data register is read-only."),
+            (PORT_FW_CFG_DMA_HI, 4) => {
+                unimplemented!()
+            }
+            (PORT_FW_CFG_DMA_LO, 4) => {
+                unimplemented!()
+            }
+            _ => error!(
+                "fw_cfg: write 0x{offset:0width$x} to unknown port {port:#x}.",
+                width = 2 * size,
+            ),
+        };
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_arch = "x86_64")]
+    const SELECTOR_OFFSET: u64 = 0;
+    #[cfg(target_arch = "aarch64")]
+    const SELECTOR_OFFSET: u64 = 8;
+    #[cfg(target_arch = "x86_64")]
+    const DATA_OFFSET: u64 = 1;
+    #[cfg(target_arch = "aarch64")]
+    const DATA_OFFSET: u64 = 0;
+
+    #[test]
+    fn test_signature() {
+        let mut fw_cfg = FwCfg::new();
+
+        let mut data = vec![0u8];
+
+        let mut sig_iter = FW_CFG_DMA_SIGNATURE.into_iter();
+        fw_cfg.write(0, SELECTOR_OFFSET, &[FW_CFG_SIGNATURE as u8, 0]);
+        loop {
+            if let Some(char) = sig_iter.next() {
+                fw_cfg.read(0, DATA_OFFSET, &mut data);
+                assert_eq!(data[0], char);
+            } else {
+                return;
+            }
+        }
+    }
+}

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -9,7 +9,7 @@
 /// items to the fw_cfg device for the firmware).
 use std::{
     fs::File,
-    io::Result,
+    io::{ErrorKind, Read, Result, Seek, SeekFrom},
     mem::{size_of, size_of_val},
     os::unix::fs::FileExt,
     sync::{Arc, Barrier},
@@ -25,14 +25,16 @@ use arch::layout::{
     MEM_32BIT_RESERVED_START, PCI_MMCONFIG_SIZE, PCI_MMCONFIG_START, RAM_64BIT_START,
 };
 use arch::RegionType;
+use bitfield::bitfield;
 #[cfg(target_arch = "x86_64")]
 use linux_loader::bootparam::boot_params;
 use vm_device::BusDevice;
-use vm_memory::ByteValued;
-#[cfg(target_arch = "x86_64")]
-use vm_memory::GuestAddress;
+use vm_memory::bitmap::AtomicBitmap;
+use vm_memory::{
+    ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap,
+};
 use vmm_sys_util::sock_ctrl_msg::IntoIovec;
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::{FromBytes, FromZeros, IntoBytes};
 
 use crate::acpi::{create_acpi_loader, AcpiTable};
 #[cfg(target_arch = "aarch64")]
@@ -113,6 +115,34 @@ pub enum FwCfgContent {
     U32(u32),
 }
 
+struct FwCfgContentAccess<'a> {
+    content: &'a FwCfgContent,
+    offset: u32,
+}
+
+impl Read for FwCfgContentAccess<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        match self.content {
+            FwCfgContent::File(offset, f) => {
+                Seek::seek(&mut (&*f), SeekFrom::Start(offset + self.offset as u64))?;
+                Read::read(&mut (&*f), buf)
+            }
+            FwCfgContent::Bytes(b) => match b.get(self.offset as usize..) {
+                Some(mut s) => s.read(buf),
+                None => Err(ErrorKind::UnexpectedEof)?,
+            },
+            FwCfgContent::Slice(b) => match b.get(self.offset as usize..) {
+                Some(mut s) => s.read(buf),
+                None => Err(ErrorKind::UnexpectedEof)?,
+            },
+            FwCfgContent::U32(n) => match n.to_le_bytes().get(self.offset as usize..) {
+                Some(mut s) => s.read(buf),
+                None => Err(ErrorKind::UnexpectedEof)?,
+            },
+        }
+    }
+}
+
 impl Default for FwCfgContent {
     fn default() -> Self {
         FwCfgContent::Slice(&[])
@@ -129,6 +159,12 @@ impl FwCfgContent {
         };
         u32::try_from(ret).map_err(|_| std::io::ErrorKind::InvalidInput.into())
     }
+    fn access(&self, offset: u32) -> FwCfgContentAccess {
+        FwCfgContentAccess {
+            content: self,
+            offset,
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -141,8 +177,29 @@ pub struct FwCfgItem {
 pub struct FwCfg {
     selector: u16,
     data_offset: u32,
+    dma_address: u64,
     items: Vec<FwCfgItem>,                           // 0x20 and above
     known_items: [FwCfgContent; FW_CFG_KNOWN_ITEMS], // 0x0 to 0x19
+    memory: GuestMemoryAtomic<GuestMemoryMmap<AtomicBitmap>>,
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes)]
+struct FwCfgDmaAccess {
+    control_be: u32,
+    length_be: u32,
+    address_be: u64,
+}
+
+bitfield! {
+    struct AccessControl(u32);
+    impl Debug;
+    error, set_error: 0;
+    read, _: 1;
+    skip, _: 2;
+    select, _ : 3;
+    write, _ :4;
+    selector, _: 31, 16;
 }
 
 #[repr(C)]
@@ -179,7 +236,7 @@ struct FwCfgFile {
 }
 
 impl FwCfg {
-    pub fn new() -> FwCfg {
+    pub fn new(memory: GuestMemoryAtomic<GuestMemoryMmap<AtomicBitmap>>) -> FwCfg {
         const DEFAULT_ITEM: FwCfgContent = FwCfgContent::Slice(&[]);
         let mut known_items = [DEFAULT_ITEM; FW_CFG_KNOWN_ITEMS];
         known_items[FW_CFG_SIGNATURE as usize] = FwCfgContent::Slice(&FW_CFG_DMA_SIGNATURE);
@@ -190,8 +247,10 @@ impl FwCfg {
         FwCfg {
             selector: 0,
             data_offset: 0,
+            dma_address: 0,
             items: vec![],
             known_items,
+            memory,
         }
     }
 
@@ -281,6 +340,91 @@ impl FwCfg {
         self.items.push(item);
         self.update_count();
         Ok(())
+    }
+
+    fn dma_read_content(
+        &self,
+        content: &FwCfgContent,
+        offset: u32,
+        len: u32,
+        address: u64,
+    ) -> Result<u32> {
+        let content_size = content.size()?.saturating_sub(offset);
+        let op_size = std::cmp::min(content_size, len);
+        let mut access = content.access(offset);
+        let mut buf = vec![0u8; op_size as usize];
+        access.read_exact(buf.as_mut_bytes())?;
+        let r = self
+            .memory
+            .memory()
+            .write(buf.as_bytes(), GuestAddress(address));
+        match r {
+            Err(e) => {
+                error!("fw_cfg: dma read error: {e:x?}");
+                Err(ErrorKind::InvalidInput.into())
+            }
+            Ok(size) => Ok(size as u32),
+        }
+    }
+
+    fn dma_read(&mut self, selector: u16, len: u32, address: u64) -> Result<()> {
+        let op_size = if let Some(content) = self.known_items.get(selector as usize) {
+            self.dma_read_content(content, self.data_offset, len, address)
+        } else if let Some(item) = self.items.get((selector - FW_CFG_FILE_FIRST) as usize) {
+            self.dma_read_content(&item.content, self.data_offset, len, address)
+        } else {
+            error!("fw_cfg: selector {selector:#x} does not exist.");
+            Err(ErrorKind::NotFound.into())
+        }?;
+        self.data_offset += op_size;
+        Ok(())
+    }
+
+    fn dma_write(&self, _selector: u16, _len: u32, _address: u64) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn do_dma(&mut self) {
+        let dma_address = self.dma_address;
+        let mut access = FwCfgDmaAccess::new_zeroed();
+        let dma_access = match self
+            .memory
+            .memory()
+            .read(access.as_mut_bytes(), GuestAddress(dma_address))
+        {
+            Ok(_) => access,
+            Err(e) => {
+                error!("fw_cfg: invalid address of dma access {dma_address:#x}: {e:?}");
+                return;
+            }
+        };
+        let control = AccessControl(u32::from_be(dma_access.control_be));
+        if control.select() {
+            self.selector = control.select() as u16;
+        }
+        let len = u32::from_be(dma_access.length_be);
+        let addr = u64::from_be(dma_access.address_be);
+        let ret = if control.read() {
+            self.dma_read(self.selector, len, addr)
+        } else if control.write() {
+            self.dma_write(self.selector, len, addr)
+        } else if control.skip() {
+            self.data_offset += len;
+            Ok(())
+        } else {
+            Err(ErrorKind::InvalidData.into())
+        };
+        let mut access_resp = AccessControl(0);
+        if let Err(e) = ret {
+            error!("fw_cfg: dma operation {dma_access:x?}: {e:x?}");
+            access_resp.set_error(true);
+        }
+        if let Err(e) = self.memory.memory().write(
+            &access_resp.0.to_be_bytes(),
+            GuestAddress(dma_address + core::mem::offset_of!(FwCfgDmaAccess, control_be) as u64),
+        ) {
+            error!("fw_cfg: finishing dma: {e:?}")
+        }
     }
 
     pub fn add_kernel_data(&mut self, file: &File) -> Result<()> {
@@ -380,10 +524,14 @@ impl BusDevice for FwCfg {
             }
             (PORT_FW_CFG_DATA, _) => _ = self.read_data(data, size as u32),
             (PORT_FW_CFG_DMA_HI, 4) => {
-                unimplemented!()
+                let addr = self.dma_address;
+                let addr_hi = (addr >> 32) as u32;
+                data.copy_from_slice(&addr_hi.to_be_bytes());
             }
             (PORT_FW_CFG_DMA_LO, 4) => {
-                unimplemented!()
+                let addr = self.dma_address;
+                let addr_lo = (addr & 0xffff_ffff) as u32;
+                data.copy_from_slice(&addr_lo.to_be_bytes());
             }
             _ => {
                 error!("fw_cfg: read unknown port {port:#x} with size {size}.");
@@ -404,10 +552,19 @@ impl BusDevice for FwCfg {
             }
             (PORT_FW_CFG_DATA, 1) => error!("fw_cfg: data register is read-only."),
             (PORT_FW_CFG_DMA_HI, 4) => {
-                unimplemented!()
+                let mut buf = [0u8; 4];
+                buf[..size].copy_from_slice(&data[..size]);
+                let val = u32::from_be_bytes(buf);
+                self.dma_address &= 0xffff_ffff;
+                self.dma_address |= (val as u64) << 32;
             }
             (PORT_FW_CFG_DMA_LO, 4) => {
-                unimplemented!()
+                let mut buf = [0u8; 4];
+                buf[..size].copy_from_slice(&data[..size]);
+                let val = u32::from_be_bytes(buf);
+                self.dma_address &= !0xffff_ffff;
+                self.dma_address |= val as u64;
+                self.do_dma();
             }
             _ => error!(
                 "fw_cfg: write 0x{offset:0width$x} to unknown port {port:#x}.",
@@ -435,10 +592,18 @@ mod tests {
     const DATA_OFFSET: u64 = 1;
     #[cfg(target_arch = "aarch64")]
     const DATA_OFFSET: u64 = 0;
+    #[cfg(target_arch = "x86_64")]
+    const DMA_OFFSET: u64 = 4;
+    #[cfg(target_arch = "aarch64")]
+    const DMA_OFFSET: u64 = 16;
 
     #[test]
     fn test_signature() {
-        let mut fw_cfg = FwCfg::new();
+        let gm = GuestMemoryAtomic::new(
+            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), RAM_64BIT_START.0 as usize)]).unwrap(),
+        );
+
+        let mut fw_cfg = FwCfg::new(gm);
 
         let mut data = vec![0u8];
 
@@ -455,7 +620,11 @@ mod tests {
     }
     #[test]
     fn test_kernel_cmdline() {
-        let mut fw_cfg = FwCfg::new();
+        let gm = GuestMemoryAtomic::new(
+            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), RAM_64BIT_START.0 as usize)]).unwrap(),
+        );
+
+        let mut fw_cfg = FwCfg::new(gm);
 
         let cmdline = *b"cmdline\0";
 
@@ -477,7 +646,11 @@ mod tests {
 
     #[test]
     fn test_initram_fs() {
-        let mut fw_cfg = FwCfg::new();
+        let gm = GuestMemoryAtomic::new(
+            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), RAM_64BIT_START.0 as usize)]).unwrap(),
+        );
+
+        let mut fw_cfg = FwCfg::new(gm);
 
         let temp = TempFile::new().unwrap();
         let mut temp_file = temp.as_file();
@@ -499,5 +672,62 @@ mod tests {
                 return;
             }
         }
+    }
+
+    #[test]
+    fn test_dma() {
+        use bitfield::BitMut;
+        let code = [
+            0xba, 0xf8, 0x03, 0x00, 0xd8, 0x04, b'0', 0xee, 0xb0, b'\n', 0xee, 0xf4,
+        ];
+
+        let content = FwCfgContent::Bytes(code.to_vec());
+
+        let mem_size = 0x1000;
+        let load_addr = GuestAddress(0x1000);
+        let mem: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&[(load_addr, mem_size)]).unwrap();
+
+        // Note: In firmware we would just allocate FwCfgDmaAccess struct
+        // and use address of struct (&) as dma address
+        let mut access_control = AccessControl(0);
+        // bit 1 = read access
+        access_control.set_bit(1, true);
+        // length of data to access
+        let length_be = (code.len() as u32).to_be();
+        // guest address for data
+        let code_address = 0x1900_u64;
+        let address_be = code_address.to_be();
+        let mut access = FwCfgDmaAccess {
+            control_be: access_control.0.to_be(), // bit(1) = read bit
+            length_be,
+            address_be,
+        };
+        // access address is where to put the code
+        let access_address = GuestAddress(load_addr.0);
+        let address_bytes = access_address.0.to_be_bytes();
+        let dma_lo: [u8; 4] = address_bytes[0..4].try_into().unwrap();
+        let dma_hi: [u8; 4] = address_bytes[4..8].try_into().unwrap();
+
+        // writing the FwCfgDmaAccess to mem (this would just be self.dma_access.as_ref() in guest)
+        let _ = mem.write(access.as_mut_bytes(), access_address);
+        let mem_m = GuestMemoryAtomic::new(mem.clone());
+        let mut fw_cfg = FwCfg::new(mem_m);
+        let cfg_item = FwCfgItem {
+            name: "code".to_string(),
+            content,
+        };
+        let _ = fw_cfg.add_item(cfg_item);
+
+        let mut data = [0u8; 12];
+
+        let _ = mem.read(&mut data, GuestAddress(code_address));
+        assert_ne!(data, code);
+
+        fw_cfg.write(0, SELECTOR_OFFSET, &[FW_CFG_FILE_FIRST as u8, 0]);
+        fw_cfg.write(0, DMA_OFFSET, &dma_lo);
+        fw_cfg.write(0, DMA_OFFSET + 4, &dma_hi);
+        let _ = mem.read(&mut data, GuestAddress(code_address));
+        assert_eq!(data, code);
     }
 }

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -15,10 +15,22 @@ use std::{
     sync::{Arc, Barrier},
 };
 
+#[cfg(target_arch = "aarch64")]
+use arch::aarch64::layout::{
+    MEM_32BIT_DEVICES_START, MEM_32BIT_RESERVED_START, RAM_64BIT_START, RAM_START as HIGH_RAM_START,
+};
+#[cfg(target_arch = "x86_64")]
+use arch::layout::{
+    EBDA_START, HIGH_RAM_START, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START,
+    MEM_32BIT_RESERVED_START, PCI_MMCONFIG_SIZE, PCI_MMCONFIG_START, RAM_64BIT_START,
+};
+use arch::RegionType;
 #[cfg(target_arch = "x86_64")]
 use linux_loader::bootparam::boot_params;
 use vm_device::BusDevice;
 use vm_memory::ByteValued;
+#[cfg(target_arch = "x86_64")]
+use vm_memory::GuestAddress;
 use vmm_sys_util::sock_ctrl_msg::IntoIovec;
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -41,6 +53,13 @@ struct boot_params {
 }
 #[cfg(target_arch = "aarch64")]
 unsafe impl ByteValued for boot_params {}
+
+#[cfg(target_arch = "x86_64")]
+const STAGE0_START_ADDRESS: GuestAddress = GuestAddress(0xffe0_0000);
+#[cfg(target_arch = "x86_64")]
+const STAGE0_SIZE: usize = 0x20_0000;
+const E820_RAM: u32 = 1;
+const E820_RESERVED: u32 = 2;
 
 #[cfg(target_arch = "x86_64")]
 pub const PORT_FW_CFG_SELECTOR: u64 = 0x510;
@@ -173,6 +192,63 @@ impl FwCfg {
             items: vec![],
             known_items,
         }
+    }
+
+    pub fn add_e820(&mut self, mem_size: usize) -> Result<()> {
+        #[cfg(target_arch = "x86_64")]
+        let mut mem_regions = vec![
+            (GuestAddress(0), EBDA_START.0 as usize, RegionType::Ram),
+            (
+                MEM_32BIT_DEVICES_START,
+                MEM_32BIT_DEVICES_SIZE as usize,
+                RegionType::Reserved,
+            ),
+            (
+                PCI_MMCONFIG_START,
+                PCI_MMCONFIG_SIZE as usize,
+                RegionType::Reserved,
+            ),
+            (STAGE0_START_ADDRESS, STAGE0_SIZE, RegionType::Reserved),
+        ];
+        #[cfg(target_arch = "aarch64")]
+        let mut mem_regions = arch::aarch64::arch_memory_regions();
+        if mem_size < MEM_32BIT_DEVICES_START.0 as usize {
+            mem_regions.push((
+                HIGH_RAM_START,
+                mem_size - HIGH_RAM_START.0 as usize,
+                RegionType::Ram,
+            ));
+        } else {
+            mem_regions.push((
+                HIGH_RAM_START,
+                MEM_32BIT_RESERVED_START.0 as usize - HIGH_RAM_START.0 as usize,
+                RegionType::Ram,
+            ));
+            mem_regions.push((
+                RAM_64BIT_START,
+                mem_size - (MEM_32BIT_DEVICES_START.0 as usize),
+                RegionType::Ram,
+            ));
+        }
+        let mut bytes = vec![];
+        for (addr, size, region) in mem_regions.iter() {
+            let type_ = match region {
+                RegionType::Ram => E820_RAM,
+                RegionType::Reserved => E820_RESERVED,
+                RegionType::SubRegion => continue,
+            };
+            let mut entry = BootE820Entry {
+                addr: addr.0,
+                size: *size as u64,
+                type_,
+            };
+            bytes.extend_from_slice(entry.as_mut_bytes());
+        }
+        let item = FwCfgItem {
+            name: "etc/e820".to_owned(),
+            content: FwCfgContent::Bytes(bytes),
+        };
+        self.add_item(item)
     }
 
     fn get_file_dir_mut(&mut self) -> &mut Vec<u8> {

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -104,6 +104,8 @@ pub const FW_CFG_KNOWN_ITEMS: usize = 0x20;
 
 pub const FW_CFG_FILE_FIRST: u16 = 0x20;
 pub const FW_CFG_DMA_SIGNATURE: [u8; 8] = *b"QEMU CFG";
+// https://github.com/torvalds/linux/blob/master/include/uapi/linux/qemu_fw_cfg.h
+pub const FW_CFG_ACPI_ID: &str = "QEMU0002";
 // bit 1 must always be enabled, bit 2 enables DMA
 pub const FW_CFG_FEATURE: [u8; 4] = [0b11, 0, 0, 0];
 

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -37,11 +37,12 @@ use vmm_sys_util::sock_ctrl_msg::IntoIovec;
 use zerocopy::{FromBytes, FromZeros, IntoBytes};
 
 use crate::acpi::{create_acpi_loader, AcpiTable};
+// TODO: make arm64_image_header public in linux loader crate
+// https://github.com/rust-vmm/linux-loader/blob/main/src/loader/pe/mod.rs#L78
 #[cfg(target_arch = "aarch64")]
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone, Default)]
-// TODO: make arm64_image_header public in linux loader crate
-// https://github.com/rust-vmm/linux-loader/blob/main/src/loader/pe/mod.rs#L78
+
 struct boot_params {
     code0: u32,
     code1: u32,
@@ -54,6 +55,7 @@ struct boot_params {
     magic: u32,
     res5: u32,
 }
+// SAFETY: boot_params is only data, reading it from data is a safe initialization.
 #[cfg(target_arch = "aarch64")]
 unsafe impl ByteValued for boot_params {}
 

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -10,14 +10,37 @@
 use std::{
     fs::File,
     io::Result,
-    mem::size_of_val,
+    mem::{size_of, size_of_val},
     os::unix::fs::FileExt,
     sync::{Arc, Barrier},
 };
 
+#[cfg(target_arch = "x86_64")]
+use linux_loader::bootparam::boot_params;
 use vm_device::BusDevice;
+use vm_memory::ByteValued;
 use vmm_sys_util::sock_ctrl_msg::IntoIovec;
 use zerocopy::{FromBytes, IntoBytes};
+
+#[cfg(target_arch = "aarch64")]
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone, Default)]
+// TODO: make arm64_image_header public in linux loader crate
+// https://github.com/rust-vmm/linux-loader/blob/main/src/loader/pe/mod.rs#L78
+struct boot_params {
+    code0: u32,
+    code1: u32,
+    text_offset: u64,
+    image_size: u64,
+    flags: u64,
+    res2: u64,
+    res3: u64,
+    res4: u64,
+    magic: u32,
+    res5: u32,
+}
+#[cfg(target_arch = "aarch64")]
+unsafe impl ByteValued for boot_params {}
 
 #[cfg(target_arch = "x86_64")]
 pub const PORT_FW_CFG_SELECTOR: u64 = 0x510;
@@ -183,6 +206,43 @@ impl FwCfg {
         Ok(())
     }
 
+    pub fn add_kernel_data(&mut self, file: &File) -> Result<()> {
+        let mut buffer = vec![0u8; size_of::<boot_params>()];
+        file.read_exact_at(&mut buffer, 0)?;
+        let bp = boot_params::from_mut_slice(&mut buffer).unwrap();
+        #[cfg(target_arch = "x86_64")]
+        {
+            if bp.hdr.setup_sects == 0 {
+                bp.hdr.setup_sects = 4;
+            }
+            bp.hdr.type_of_loader = 0xff;
+        }
+        #[cfg(target_arch = "aarch64")]
+        let kernel_start = bp.text_offset;
+        #[cfg(target_arch = "x86_64")]
+        let kernel_start = (bp.hdr.setup_sects as usize + 1) * 512;
+        self.known_items[FW_CFG_SETUP_SIZE as usize] = FwCfgContent::U32(buffer.len() as u32);
+        self.known_items[FW_CFG_SETUP_DATA as usize] = FwCfgContent::Bytes(buffer);
+        self.known_items[FW_CFG_KERNEL_SIZE as usize] =
+            FwCfgContent::U32(file.metadata()?.len() as u32 - kernel_start as u32);
+        self.known_items[FW_CFG_KERNEL_DATA as usize] =
+            FwCfgContent::File(kernel_start as u64, file.try_clone()?);
+        Ok(())
+    }
+
+    pub fn add_kernel_cmdline(&mut self, s: std::ffi::CString) {
+        let bytes = s.into_bytes_with_nul();
+        self.known_items[FW_CFG_CMDLINE_SIZE as usize] = FwCfgContent::U32(bytes.len() as u32);
+        self.known_items[FW_CFG_CMDLINE_DATA as usize] = FwCfgContent::Bytes(bytes);
+    }
+
+    pub fn add_initramfs_data(&mut self, file: &File) -> Result<()> {
+        let initramfs_size = file.metadata()?.len();
+        self.known_items[FW_CFG_INITRD_SIZE as usize] = FwCfgContent::U32(initramfs_size as _);
+        self.known_items[FW_CFG_INITRD_DATA as usize] = FwCfgContent::File(0, file.try_clone()?);
+        Ok(())
+    }
+
     fn read_content(content: &FwCfgContent, offset: u32, data: &mut [u8], size: u32) -> Option<u8> {
         let start = offset as usize;
         let end = start + size as usize;
@@ -276,6 +336,11 @@ impl BusDevice for FwCfg {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::CString;
+    use std::io::Write;
+
+    use vmm_sys_util::tempfile::TempFile;
+
     use super::*;
 
     #[cfg(target_arch = "x86_64")]
@@ -297,6 +362,53 @@ mod tests {
         fw_cfg.write(0, SELECTOR_OFFSET, &[FW_CFG_SIGNATURE as u8, 0]);
         loop {
             if let Some(char) = sig_iter.next() {
+                fw_cfg.read(0, DATA_OFFSET, &mut data);
+                assert_eq!(data[0], char);
+            } else {
+                return;
+            }
+        }
+    }
+    #[test]
+    fn test_kernel_cmdline() {
+        let mut fw_cfg = FwCfg::new();
+
+        let cmdline = *b"cmdline\0";
+
+        fw_cfg.add_kernel_cmdline(CString::from_vec_with_nul(cmdline.to_vec()).unwrap());
+
+        let mut data = vec![0u8];
+
+        let mut cmdline_iter = cmdline.into_iter();
+        fw_cfg.write(0, SELECTOR_OFFSET, &[FW_CFG_CMDLINE_DATA as u8, 0]);
+        loop {
+            if let Some(char) = cmdline_iter.next() {
+                fw_cfg.read(0, DATA_OFFSET, &mut data);
+                assert_eq!(data[0], char);
+            } else {
+                return;
+            }
+        }
+    }
+
+    #[test]
+    fn test_initram_fs() {
+        let mut fw_cfg = FwCfg::new();
+
+        let temp = TempFile::new().unwrap();
+        let mut temp_file = temp.as_file();
+
+        let initram_content = b"this is the initramfs";
+        let written = temp_file.write(initram_content);
+        assert_eq!(written.unwrap(), 21);
+        let _ = fw_cfg.add_initramfs_data(temp_file);
+
+        let mut data = vec![0u8];
+
+        let mut initram_iter = (*initram_content).into_iter();
+        fw_cfg.write(0, SELECTOR_OFFSET, &[FW_CFG_INITRD_DATA as u8, 0]);
+        loop {
+            if let Some(char) = initram_iter.next() {
                 fw_cfg.read(0, DATA_OFFSET, &mut data);
                 assert_eq!(data[0], char);
             } else {

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -34,6 +34,7 @@ use vm_memory::GuestAddress;
 use vmm_sys_util::sock_ctrl_msg::IntoIovec;
 use zerocopy::{FromBytes, IntoBytes};
 
+use crate::acpi::{create_acpi_loader, AcpiTable};
 #[cfg(target_arch = "aarch64")]
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone, Default)]
@@ -310,6 +311,13 @@ impl FwCfg {
         let bytes = s.into_bytes_with_nul();
         self.known_items[FW_CFG_CMDLINE_SIZE as usize] = FwCfgContent::U32(bytes.len() as u32);
         self.known_items[FW_CFG_CMDLINE_DATA as usize] = FwCfgContent::Bytes(bytes);
+    }
+
+    pub fn add_acpi(&mut self, acpi_table: AcpiTable) -> Result<()> {
+        let [table_loader, acpi_rsdp, apci_tables] = create_acpi_loader(acpi_table);
+        self.add_item(table_loader)?;
+        self.add_item(acpi_rsdp)?;
+        self.add_item(apci_tables)
     }
 
     pub fn add_initramfs_data(&mut self, file: &File) -> Result<()> {

--- a/devices/src/legacy/mod.rs
+++ b/devices/src/legacy/mod.rs
@@ -8,6 +8,8 @@
 mod cmos;
 #[cfg(target_arch = "x86_64")]
 mod debug_port;
+#[cfg(not(target_arch = "riscv64"))]
+pub mod fw_cfg;
 #[cfg(target_arch = "x86_64")]
 mod fwdebug;
 #[cfg(target_arch = "aarch64")]
@@ -22,6 +24,8 @@ mod uart_pl011;
 pub use self::cmos::Cmos;
 #[cfg(target_arch = "x86_64")]
 pub use self::debug_port::DebugPort;
+#[cfg(not(target_arch = "riscv64"))]
+pub use self::fw_cfg::FwCfg;
 #[cfg(target_arch = "x86_64")]
 pub use self::fwdebug::FwDebugDevice;
 #[cfg(target_arch = "aarch64")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,8 @@ use vmm::api::ApiAction;
 use vmm::config::{RestoreConfig, VmParams};
 use vmm::landlock::{Landlock, LandlockError};
 use vmm::vm_config;
+#[cfg(feature = "fw_cfg")]
+use vmm::vm_config::FwCfgItem;
 #[cfg(target_arch = "x86_64")]
 use vmm::vm_config::SgxEpcConfig;
 use vmm::vm_config::{
@@ -261,6 +263,12 @@ fn get_cli_options_sorted(
             .help("Path to firmware that is loaded in an architectural specific way")
             .num_args(1)
             .group("vm-payload"),
+        #[cfg(feature = "fw_cfg")]
+        Arg::new("fw_cfg")
+            .long("fw_cfg")
+            .help(FwCfgItem::SYNTAX)
+            .num_args(1..)
+            .group("vm-config"),
         Arg::new("fs")
             .long("fs")
             .help(FsConfig::SYNTAX)
@@ -1019,6 +1027,8 @@ mod unit_tests {
             preserved_fds: None,
             landlock_enable: false,
             landlock_rules: None,
+            #[cfg(feature = "fw_cfg")]
+            fw_cfg: None,
         };
 
         assert_eq!(expected_vm_config, result_vm_config);

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 dbus_api = ["blocking", "futures", "zbus"]
 default = []
 dhat-heap = ["dhat"] # For heap profiling
+fw_cfg = []
 guest_debug = ["gdbstub", "gdbstub_arch", "kvm"]
 igvm = ["dep:igvm", "hex", "igvm_defs", "mshv-bindings", "range_map_vec"]
 io_uring = ["block/io_uring"]

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -16,6 +16,8 @@ use arch::aarch64::DeviceInfoForFdt;
 use arch::DeviceType;
 use arch::NumaNodes;
 use bitflags::bitflags;
+#[cfg(feature = "fw_cfg")]
+use devices::acpi::AcpiTable;
 use pci::PciBdf;
 use tracer::trace_scoped;
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryRegion};
@@ -192,6 +194,8 @@ pub fn create_dsdt_table(
     dsdt
 }
 
+pub const FACP_DSDT_OFFSET: usize = 140;
+
 fn create_facp_table(dsdt_offset: GuestAddress, device_manager: &Arc<Mutex<DeviceManager>>) -> Sdt {
     trace_scoped!("create_facp_table");
 
@@ -241,7 +245,7 @@ fn create_facp_table(dsdt_offset: GuestAddress, device_manager: &Arc<Mutex<Devic
     // FADT minor version
     facp.write(131, 3u8);
     // X_DSDT
-    facp.write(140, dsdt_offset.0);
+    facp.write(FACP_DSDT_OFFSET, dsdt_offset.0);
     // Hypervisor Vendor Identity
     facp.write_bytes(268, b"CLOUDHYP");
 
@@ -836,6 +840,202 @@ pub fn create_acpi_tables(
         xsdt_offset.0 + xsdt.len() as u64 - rsdp_offset.0
     );
     rsdp_offset
+}
+
+#[cfg(feature = "fw_cfg")]
+pub fn create_acpi_tables_for_fw_cfg(
+    device_manager: &Arc<Mutex<DeviceManager>>,
+    cpu_manager: &Arc<Mutex<CpuManager>>,
+    memory_manager: &Arc<Mutex<MemoryManager>>,
+    numa_nodes: &NumaNodes,
+    tpm_enabled: bool,
+) {
+    trace_scoped!("create_acpi_tables");
+
+    // To create AcpiTable
+    let mut table_bytes: Vec<u8> = vec![];
+    let mut pointers: Vec<usize> = vec![];
+    let mut checksums: Vec<(usize, usize)> = vec![];
+    let mut tables: Vec<u64> = Vec::new();
+
+    // DSDT
+    let dsdt = create_dsdt_table(device_manager, cpu_manager, memory_manager);
+    let dsdt_offset = GuestAddress(0);
+    table_bytes.extend_from_slice(dsdt.as_slice());
+
+    // FACP aka FADT
+    let facp = create_facp_table(dsdt_offset, device_manager);
+    let facp_offset = dsdt_offset.checked_add(dsdt.len() as u64).unwrap();
+    let pointer_facp_to_dsdt = facp_offset.0 as usize + FACP_DSDT_OFFSET;
+    pointers.push(pointer_facp_to_dsdt);
+    table_bytes.extend_from_slice(facp.as_slice());
+    checksums.push((facp_offset.0 as usize, facp.len()));
+    tables.push(facp_offset.0);
+
+    // MADT
+    let madt = cpu_manager.lock().unwrap().create_madt();
+    let madt_offset = facp_offset.checked_add(facp.len() as u64).unwrap();
+    tables.push(madt_offset.0);
+    let mut prev_tbl_len = madt.len() as u64;
+    let mut prev_tbl_off = madt_offset;
+    table_bytes.extend_from_slice(madt.as_slice());
+
+    // PPTT
+    #[cfg(target_arch = "aarch64")]
+    {
+        let pptt = cpu_manager.lock().unwrap().create_pptt();
+        let pptt_offset = prev_tbl_off.checked_add(prev_tbl_len).unwrap();
+        tables.push(pptt_offset.0);
+        prev_tbl_len = pptt.len() as u64;
+        prev_tbl_off = pptt_offset;
+        table_bytes.extend_from_slice(pptt.as_slice());
+    }
+
+    // GTDT
+    #[cfg(target_arch = "aarch64")]
+    {
+        let gtdt = create_gtdt_table();
+        let gtdt_offset = prev_tbl_off.checked_add(prev_tbl_len).unwrap();
+        tables.push(gtdt_offset.0);
+        prev_tbl_len = gtdt.len() as u64;
+        prev_tbl_off = gtdt_offset;
+        table_bytes.extend_from_slice(gtdt.as_slice());
+    }
+
+    // MCFG
+    let mcfg = create_mcfg_table(device_manager.lock().unwrap().pci_segments());
+    let mcfg_offset = prev_tbl_off.checked_add(prev_tbl_len).unwrap();
+    tables.push(mcfg_offset.0);
+    prev_tbl_len = mcfg.len() as u64;
+    prev_tbl_off = mcfg_offset;
+    table_bytes.extend_from_slice(mcfg.as_slice());
+
+    // SPCR and DBG2
+    #[cfg(target_arch = "aarch64")]
+    {
+        let is_serial_on = device_manager
+            .lock()
+            .unwrap()
+            .get_device_info()
+            .clone()
+            .contains_key(&(DeviceType::Serial, DeviceType::Serial.to_string()));
+        let serial_device_addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START.raw_value();
+        let serial_device_irq = if is_serial_on {
+            device_manager
+                .lock()
+                .unwrap()
+                .get_device_info()
+                .clone()
+                .get(&(DeviceType::Serial, DeviceType::Serial.to_string()))
+                .unwrap()
+                .irq()
+        } else {
+            // If serial is turned off, add a fake device with invalid irq.
+            31
+        };
+
+        // SPCR
+        let spcr = create_spcr_table(serial_device_addr, serial_device_irq);
+        let spcr_offset = prev_tbl_off.checked_add(prev_tbl_len).unwrap();
+        tables.push(spcr_offset.0);
+        prev_tbl_len = spcr.len() as u64;
+        prev_tbl_off = spcr_offset;
+        table_bytes.extend_from_slice(spcr.as_slice());
+
+        // DBG2
+        let dbg2 = create_dbg2_table(serial_device_addr);
+        let dbg2_offset = prev_tbl_off.checked_add(prev_tbl_len).unwrap();
+        tables.push(dbg2_offset.0);
+        prev_tbl_len = dbg2.len() as u64;
+        prev_tbl_off = dbg2_offset;
+        table_bytes.extend_from_slice(dbg2.as_slice());
+    }
+
+    if tpm_enabled {
+        // TPM2 Table
+        let tpm2 = create_tpm2_table();
+        let tpm2_offset = prev_tbl_off.checked_add(prev_tbl_len).unwrap();
+        tables.push(tpm2_offset.0);
+
+        prev_tbl_len = tpm2.len() as u64;
+        prev_tbl_off = tpm2_offset;
+        table_bytes.extend_from_slice(tpm2.as_slice());
+    }
+    // SRAT and SLIT
+    // Only created if the NUMA nodes list is not empty.
+    if !numa_nodes.is_empty() {
+        #[cfg(target_arch = "x86_64")]
+        let topology = cpu_manager.lock().unwrap().get_vcpu_topology();
+        // SRAT
+        let srat = create_srat_table(
+            numa_nodes,
+            #[cfg(target_arch = "x86_64")]
+            topology,
+        );
+        let srat_offset = prev_tbl_off.checked_add(prev_tbl_len).unwrap();
+        tables.push(srat_offset.0);
+        table_bytes.extend_from_slice(srat.as_slice());
+
+        // SLIT
+        let slit = create_slit_table(numa_nodes);
+        let slit_offset = srat_offset.checked_add(srat.len() as u64).unwrap();
+        tables.push(slit_offset.0);
+
+        prev_tbl_len = slit.len() as u64;
+        prev_tbl_off = slit_offset;
+        table_bytes.extend_from_slice(slit.as_slice());
+    };
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        let iort = create_iort_table(device_manager.lock().unwrap().pci_segments());
+        let iort_offset = prev_tbl_off.checked_add(prev_tbl_len).unwrap();
+        tables.push(iort_offset.0);
+        prev_tbl_len = iort.len() as u64;
+        prev_tbl_off = iort_offset;
+        table_bytes.extend_from_slice(iort.as_slice());
+    }
+
+    // VIOT
+    if let Some((iommu_bdf, devices_bdf)) = device_manager.lock().unwrap().iommu_attached_devices()
+    {
+        let viot = create_viot_table(iommu_bdf, devices_bdf);
+
+        let viot_offset = prev_tbl_off.checked_add(prev_tbl_len).unwrap();
+        tables.push(viot_offset.0);
+        prev_tbl_len = viot.len() as u64;
+        prev_tbl_off = viot_offset;
+        table_bytes.extend_from_slice(viot.as_slice());
+    }
+    // XSDT
+    let xsdt_offset = prev_tbl_off.checked_add(prev_tbl_len).unwrap();
+    let mut xsdt = Sdt::new(*b"XSDT", 36, 1, *b"CLOUDH", *b"CHXSDT  ", 1);
+    for table in tables {
+        pointers.push(xsdt_offset.0 as usize + xsdt.len());
+        xsdt.append(table);
+    }
+    xsdt.update_checksum();
+    checksums.push((xsdt_offset.0 as usize, xsdt.len()));
+    let bytes = [&table_bytes, xsdt.as_slice()].concat();
+
+    // RSDP
+    let rsdp = Rsdp::new(*b"CLOUDH", xsdt_offset.0);
+
+    let acpi = AcpiTable {
+        rsdp,
+        tables: bytes,
+        table_checksums: checksums,
+        table_pointers: pointers,
+    };
+    info!("created acpi table, now add to fw_cfg");
+    let _ = device_manager
+        .lock()
+        .unwrap()
+        .fw_cfg()
+        .expect("fw_cfg must be present")
+        .lock()
+        .unwrap()
+        .add_acpi(acpi);
 }
 
 #[cfg(feature = "tdx")]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1891,7 +1891,9 @@ impl DeviceManager {
 
             #[cfg(feature = "fw_cfg")]
             {
-                let fw_cfg = Arc::new(Mutex::new(devices::legacy::FwCfg::new()));
+                let fw_cfg = Arc::new(Mutex::new(devices::legacy::FwCfg::new(
+                    self.memory_manager.lock().as_ref().unwrap().guest_memory(),
+                )));
 
                 self.bus_devices
                     .push(Arc::clone(&fw_cfg) as Arc<dyn BusDeviceSync>);
@@ -2036,7 +2038,9 @@ impl DeviceManager {
 
         #[cfg(feature = "fw_cfg")]
         {
-            let fw_cfg = Arc::new(Mutex::new(devices::legacy::FwCfg::new()));
+            let fw_cfg = Arc::new(Mutex::new(devices::legacy::FwCfg::new(
+                self.memory_manager.lock().as_ref().unwrap().guest_memory(),
+            )));
 
             self.fw_cfg = Some(fw_cfg.clone());
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -727,6 +727,15 @@ impl Vm {
 
         #[cfg(all(feature = "fw_cfg", not(target_arch = "riscv64")))]
         {
+            let _ = device_manager
+                .lock()
+                .unwrap()
+                .fw_cfg()
+                .expect("fw_cfg device must be present")
+                .lock()
+                .unwrap()
+                .add_e820(config.lock().unwrap().memory.size as usize);
+
             let kernel = config
                 .lock()
                 .unwrap()

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -70,6 +70,8 @@ use vm_migration::{
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
+#[cfg(all(feature = "fw_cfg", not(target_arch = "riscv64")))]
+use crate::acpi::create_acpi_tables_for_fw_cfg;
 use crate::config::{add_to_config, ValidationError};
 use crate::console_devices::{ConsoleDeviceError, ConsoleInfo};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
@@ -2331,6 +2333,17 @@ impl Vm {
             VmState::Running
         };
         current_state.valid_transition(new_state)?;
+        #[cfg(all(feature = "fw_cfg", not(target_arch = "riscv64")))]
+        {
+            let tpm_enabled = self.config.lock().unwrap().tpm.is_some();
+            create_acpi_tables_for_fw_cfg(
+                &self.device_manager,
+                &self.cpu_manager,
+                &self.memory_manager,
+                &self.numa_nodes,
+                tpm_enabled,
+            );
+        }
 
         // Do earlier to parallelise with loading kernel
         #[cfg(target_arch = "x86_64")]

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -699,6 +699,15 @@ pub struct PayloadConfig {
     pub host_data: Option<String>,
 }
 
+#[cfg(feature = "fw_cfg")]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct FwCfgItem {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub file: Option<PathBuf>,
+}
+
 impl ApplyLandlock for PayloadConfig {
     fn apply_landlock(&self, landlock: &mut Landlock) -> LandlockResult<()> {
         // Payload only needs read access
@@ -819,6 +828,8 @@ pub struct VmConfig {
     #[serde(default)]
     pub landlock_enable: bool,
     pub landlock_rules: Option<Vec<LandlockConfig>>,
+    #[cfg(feature = "fw_cfg")]
+    pub fw_cfg: Option<Vec<FwCfgItem>>,
 }
 
 impl VmConfig {


### PR DESCRIPTION
We are working with the project [Oak](https://github.com/project-oak/oak) team to enable running [Oak Containers](https://github.com/project-oak/oak/tree/main/oak_containers) on cloud hypervisor. These containers are SEV-SNP enlightened and can be used alongside with the rest of the oak suite for attestation and measurement of the cvm. 

Here is the functionality we are adding to CHV.
1. Implmenting the sev-snp APIs previously defined (sev_snp_init, import_isolated_pages, complete_isolated_import). 
2. Expanded the igvm loader to support booting KVM + SEV-SNP enabled VMs. (Note that we can also use the igvm loader to boot VMs with standard cloud images with/without sev-snp enabled as seen here (https://github.com/AlexOrozco1256/chv-demo)
3. Added a fw_cfg device with DMA enabled. Oak's [Stage0](https://github.com/project-oak/oak/tree/main/stage0_bin) firmware uses fw_cfg for loading various parameters into the VM. 

Additional design/implementation details can be found here: https://tinyurl.com/chv-kvm-sev-snp

See: #6653