### PR TITLE
devices: Add fw_cfg device

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,9 @@ jobs:
       - name: Build (default features + pvmemcontrol)
         run: cargo rustc --locked --bin cloud-hypervisor --features "pvmemcontrol" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 
+      - name: Build (default features + fw_cfg)
+        run: cargo rustc --locked --bin cloud-hypervisor --features "fw_cfg" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+
       - name: Build (mshv)
         run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv"  -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
 

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -111,7 +111,12 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           args: --locked --all --all-targets --tests --examples --features "tracing" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
-
+      - name: Clippy (default features + fw_cfg)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
+          command: clippy
+          args: --target=${{ matrix.target }} --locked --all --all-targets --tests --examples --features "fw_cfg" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
       - name: Clippy (sev_snp)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: houseabsolute/actions-rust-cross@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ dependencies = [
  "event_monitor",
  "hypervisor",
  "libc",
+ "linux-loader",
  "log",
  "num_enum",
  "pci",
@@ -1143,8 +1144,7 @@ dependencies = [
 [[package]]
 name = "linux-loader"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870c3814345f050991f99869417779f6062542bcf4ed81db7a1b926ad1306638"
+source = "git+https://github.com/rust-vmm/linux-loader?branch=main#d5f39c09d59c8f50d5313b78ce4de511b12d1848"
 dependencies = [
  "vm-memory",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,7 @@ dependencies = [
  "acpi_tables",
  "anyhow",
  "arch",
+ "bitfield-struct",
  "bitflags 2.9.0",
  "byteorder",
  "event_monitor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "vm-memory",
  "vm-migration",
  "vmm-sys-util",
+ "zerocopy 0.8.26",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,8 @@ members = [
 acpi_tables = { git = "https://github.com/rust-vmm/acpi_tables", branch = "main" }
 kvm-bindings = "0.12.0"
 kvm-ioctls = "0.22.0"
-linux-loader = "0.13.0"
+# TODO: update to 0.13.1+
+linux-loader = { git = "https://github.com/rust-vmm/linux-loader", branch = "main" }
 mshv-bindings = "0.5.2"
 mshv-ioctls = "0.5.2"
 seccompiler = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ wait-timeout = { workspace = true }
 dbus_api = ["vmm/dbus_api", "zbus"]
 default = ["io_uring", "kvm"]
 dhat-heap = ["dhat", "vmm/dhat-heap"]       # For heap profiling
+fw_cfg = ["vmm/fw_cfg"]
 guest_debug = ["vmm/guest_debug"]
 igvm = ["mshv", "vmm/igvm"]
 io_uring = ["vmm/io_uring"]

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 
 [features]
 default = []
+fw_cfg = []
 kvm = ["hypervisor/kvm"]
 sev_snp = []
 tdx = []

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -850,6 +850,21 @@ fn create_gpio_node<T: DeviceInfoForFdt + Clone + Debug>(
     Ok(())
 }
 
+// https://www.kernel.org/doc/Documentation/devicetree/bindings/arm/fw-cfg.txt
+#[cfg(feature = "fw_cfg")]
+fn create_fw_cfg_node<T: DeviceInfoForFdt + Clone + Debug>(
+    fdt: &mut FdtWriter,
+    dev_info: &T,
+) -> FdtWriterResult<()> {
+    // FwCfg node
+    let fw_cfg_node = fdt.begin_node(&format!("fw-cfg@{:x}", dev_info.addr()))?;
+    fdt.property("compatible", b"qemu,fw-cfg-mmio\0")?;
+    fdt.property_array_u64("reg", &[dev_info.addr(), dev_info.length()])?;
+    fdt.end_node(fw_cfg_node)?;
+
+    Ok(())
+}
+
 fn create_devices_node<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::BuildHasher>(
     fdt: &mut FdtWriter,
     dev_info: &HashMap<(DeviceType, String), T, S>,
@@ -865,6 +880,8 @@ fn create_devices_node<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::Buil
             DeviceType::Virtio(_) => {
                 ordered_virtio_device.push(info);
             }
+            #[cfg(feature = "fw_cfg")]
+            DeviceType::FwCfg => create_fw_cfg_node(fdt, info)?,
         }
     }
 

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -155,6 +155,9 @@ pub enum DeviceType {
     /// Device Type: GPIO.
     #[cfg(target_arch = "aarch64")]
     Gpio,
+    /// Device Type: fw_cfg.
+    #[cfg(feature = "fw_cfg")]
+    FwCfg,
 }
 
 /// Default (smallest) memory page size for the supported architectures.

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -28,11 +28,16 @@ vm-memory = { workspace = true, features = [
 ] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { workspace = true }
+zerocopy = { version = "0.8.26", features = [
+  "alloc",
+  "derive",
+], optional = true }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]
 arch = { path = "../arch" }
 
 [features]
 default = []
+fw_cfg = ["zerocopy"]
 kvm = ["arch/kvm"]
 pvmemcontrol = []

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -13,6 +13,11 @@ byteorder = { workspace = true }
 event_monitor = { path = "../event_monitor" }
 hypervisor = { path = "../hypervisor" }
 libc = { workspace = true }
+linux-loader = { workspace = true, features = [
+  "bzimage",
+  "elf",
+  "pe",
+], optional = true }
 log = { workspace = true }
 num_enum = "0.7.2"
 pci = { path = "../pci" }
@@ -38,6 +43,6 @@ arch = { path = "../arch" }
 
 [features]
 default = []
-fw_cfg = ["zerocopy"]
+fw_cfg = ["linux-loader", "zerocopy"]
 kvm = ["arch/kvm"]
 pvmemcontrol = []

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 acpi_tables = { workspace = true }
 anyhow = { workspace = true }
 arch = { path = "../arch" }
+bitfield-struct = { version = "0.10.1", optional = true }
 bitflags = { workspace = true }
 byteorder = { workspace = true }
 event_monitor = { path = "../event_monitor" }
@@ -43,6 +44,6 @@ arch = { path = "../arch" }
 
 [features]
 default = []
-fw_cfg = ["linux-loader", "zerocopy"]
+fw_cfg = ["bitfield-struct", "linux-loader", "zerocopy"]
 kvm = ["arch/kvm"]
 pvmemcontrol = []

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -44,6 +44,6 @@ arch = { path = "../arch" }
 
 [features]
 default = []
-fw_cfg = ["bitfield-struct", "linux-loader", "zerocopy"]
+fw_cfg = ["arch/fw_cfg", "bitfield-struct", "linux-loader", "zerocopy"]
 kvm = ["arch/kvm"]
 pvmemcontrol = []

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -433,6 +433,34 @@ impl FwCfg {
         }
     }
 
+    pub fn populate_fw_cfg(
+        &mut self,
+        mem_size: Option<usize>,
+        kernel: Option<File>,
+        initramfs: Option<File>,
+        cmdline: Option<std::ffi::CString>,
+        fw_cfg_item_list: Option<Vec<FwCfgItem>>,
+    ) -> Result<()> {
+        if let Some(mem_size) = mem_size {
+            self.add_e820(mem_size)?
+        }
+        if let Some(kernel) = kernel {
+            self.add_kernel_data(&kernel)?;
+        }
+        if let Some(cmdline) = cmdline {
+            self.add_kernel_cmdline(cmdline);
+        }
+        if let Some(initramfs) = initramfs {
+            self.add_initramfs_data(&initramfs)?
+        }
+        if let Some(fw_cfg_item_list) = fw_cfg_item_list {
+            for item in fw_cfg_item_list {
+                self.add_item(item)?;
+            }
+        }
+        Ok(())
+    }
+
     pub fn add_e820(&mut self, mem_size: usize) -> Result<()> {
         #[cfg(target_arch = "x86_64")]
         let mut mem_regions = vec![

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -13,7 +13,7 @@
 /// only firmware must implement mechanism to interact with this fw_cfg device
 use std::{
     fs::File,
-    io::Result,
+    io::{ErrorKind, Read, Result, Seek, SeekFrom},
     mem::offset_of,
     os::unix::fs::FileExt,
     sync::{Arc, Barrier},
@@ -30,16 +30,18 @@ use arch::layout::{
     MEM_32BIT_RESERVED_START, PCI_MMCONFIG_SIZE, PCI_MMCONFIG_START, RAM_64BIT_START,
 };
 use arch::RegionType;
+use bitfield_struct::bitfield;
 #[cfg(target_arch = "x86_64")]
 use linux_loader::bootparam::boot_params;
 #[cfg(target_arch = "aarch64")]
 use linux_loader::loader::pe::arm64_image_header as boot_params;
 use vm_device::BusDevice;
-use vm_memory::ByteValued;
-#[cfg(target_arch = "x86_64")]
-use vm_memory::GuestAddress;
+use vm_memory::bitmap::AtomicBitmap;
+use vm_memory::{
+    ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap,
+};
 use vmm_sys_util::sock_ctrl_msg::IntoIovec;
-use zerocopy::{FromBytes, Immutable, IntoBytes};
+use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes};
 
 #[cfg(target_arch = "x86_64")]
 // https://github.com/project-oak/oak/tree/main/stage0_bin#memory-layout
@@ -114,6 +116,34 @@ pub enum FwCfgContent {
     U32(u32),
 }
 
+struct FwCfgContentAccess<'a> {
+    content: &'a FwCfgContent,
+    offset: u32,
+}
+
+impl Read for FwCfgContentAccess<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        match self.content {
+            FwCfgContent::File(offset, f) => {
+                Seek::seek(&mut (&*f), SeekFrom::Start(offset + self.offset as u64))?;
+                Read::read(&mut (&*f), buf)
+            }
+            FwCfgContent::Bytes(b) => match b.get(self.offset as usize..) {
+                Some(mut s) => s.read(buf),
+                None => Err(ErrorKind::UnexpectedEof)?,
+            },
+            FwCfgContent::Slice(b) => match b.get(self.offset as usize..) {
+                Some(mut s) => s.read(buf),
+                None => Err(ErrorKind::UnexpectedEof)?,
+            },
+            FwCfgContent::U32(n) => match n.to_le_bytes().get(self.offset as usize..) {
+                Some(mut s) => s.read(buf),
+                None => Err(ErrorKind::UnexpectedEof)?,
+            },
+        }
+    }
+}
+
 impl Default for FwCfgContent {
     fn default() -> Self {
         FwCfgContent::Slice(&[])
@@ -130,6 +160,12 @@ impl FwCfgContent {
         };
         u32::try_from(ret).map_err(|_| std::io::ErrorKind::InvalidInput.into())
     }
+    fn access(&self, offset: u32) -> FwCfgContentAccess<'_> {
+        FwCfgContentAccess {
+            content: self,
+            offset,
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -139,12 +175,45 @@ pub struct FwCfgItem {
 }
 
 /// https://www.qemu.org/docs/master/specs/fw_cfg.html
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct FwCfg {
     selector: u16,
     data_offset: u32,
+    dma_address: u64,
     items: Vec<FwCfgItem>,                           // 0x20 and above
     known_items: [FwCfgContent; FW_CFG_KNOWN_ITEMS], // 0x0 to 0x19
+    memory: GuestMemoryAtomic<GuestMemoryMmap<AtomicBitmap>>,
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes)]
+struct FwCfgDmaAccess {
+    control_be: u32,
+    length_be: u32,
+    address_be: u64,
+}
+
+// https://github.com/torvalds/linux/blob/master/include/uapi/linux/qemu_fw_cfg.h#L67
+#[bitfield(u32)]
+struct AccessControl {
+    // FW_CFG_DMA_CTL_ERROR = 0x01
+    error: bool,
+    // FW_CFG_DMA_CTL_READ = 0x02
+    read: bool,
+    #[bits(1)]
+    _unused2: u8,
+    // FW_CFG_DMA_CTL_SKIP = 0x04
+    skip: bool,
+    #[bits(3)]
+    _unused3: u8,
+    // FW_CFG_DMA_CTL_ERROR = 0x08
+    select: bool,
+    #[bits(7)]
+    _unused4: u8,
+    // FW_CFG_DMA_CTL_WRITE = 0x10
+    write: bool,
+    #[bits(16)]
+    _unused: u32,
 }
 
 #[repr(C)]
@@ -344,7 +413,7 @@ fn create_acpi_loader(acpi_table: AcpiTable) -> [FwCfgItem; 3] {
 }
 
 impl FwCfg {
-    pub fn new() -> FwCfg {
+    pub fn new(memory: GuestMemoryAtomic<GuestMemoryMmap<AtomicBitmap>>) -> FwCfg {
         const DEFAULT_ITEM: FwCfgContent = FwCfgContent::Slice(&[]);
         let mut known_items = [DEFAULT_ITEM; FW_CFG_KNOWN_ITEMS];
         known_items[FW_CFG_SIGNATURE as usize] = FwCfgContent::Slice(&FW_CFG_DMA_SIGNATURE);
@@ -355,8 +424,10 @@ impl FwCfg {
         FwCfg {
             selector: 0,
             data_offset: 0,
+            dma_address: 0,
             items: vec![],
             known_items,
+            memory,
         }
     }
 
@@ -446,6 +517,87 @@ impl FwCfg {
         self.items.push(item);
         self.update_count();
         Ok(())
+    }
+
+    fn dma_read_content(
+        &self,
+        content: &FwCfgContent,
+        offset: u32,
+        len: u32,
+        address: u64,
+    ) -> Result<u32> {
+        let content_size = content.size()?.saturating_sub(offset);
+        let op_size = std::cmp::min(content_size, len);
+        let mut access = content.access(offset);
+        let mut buf = vec![0u8; op_size as usize];
+        access.read_exact(buf.as_mut_bytes())?;
+        let r = self
+            .memory
+            .memory()
+            .write(buf.as_bytes(), GuestAddress(address));
+        match r {
+            Err(e) => {
+                error!("fw_cfg: dma read error: {e:x?}");
+                Err(ErrorKind::InvalidInput.into())
+            }
+            Ok(size) => Ok(size as u32),
+        }
+    }
+
+    fn dma_read(&mut self, selector: u16, len: u32, address: u64) -> Result<()> {
+        let op_size = if let Some(content) = self.known_items.get(selector as usize) {
+            self.dma_read_content(content, self.data_offset, len, address)
+        } else if let Some(item) = self.items.get((selector - FW_CFG_FILE_FIRST) as usize) {
+            self.dma_read_content(&item.content, self.data_offset, len, address)
+        } else {
+            error!("fw_cfg: selector {selector:#x} does not exist.");
+            Err(ErrorKind::NotFound.into())
+        }?;
+        self.data_offset += op_size;
+        Ok(())
+    }
+
+    fn do_dma(&mut self) {
+        let dma_address = self.dma_address;
+        let mut access = FwCfgDmaAccess::new_zeroed();
+        let dma_access = match self
+            .memory
+            .memory()
+            .read(access.as_mut_bytes(), GuestAddress(dma_address))
+        {
+            Ok(_) => access,
+            Err(e) => {
+                error!("fw_cfg: invalid address of dma access {dma_address:#x}: {e:?}");
+                return;
+            }
+        };
+        let control = AccessControl(u32::from_be(dma_access.control_be));
+        if control.select() {
+            self.selector = control.select() as u16;
+        }
+        let len = u32::from_be(dma_access.length_be);
+        let addr = u64::from_be(dma_access.address_be);
+        let ret = if control.read() {
+            self.dma_read(self.selector, len, addr)
+        } else if control.write() {
+            Err(ErrorKind::InvalidInput.into())
+        } else if control.skip() {
+            self.data_offset += len;
+            Ok(())
+        } else {
+            Err(ErrorKind::InvalidData.into())
+        };
+        let mut access_resp = AccessControl(0);
+        if let Err(e) = ret {
+            error!("fw_cfg: dma operation {dma_access:x?}: {e:x?}");
+            access_resp.set_error(true);
+        }
+        if let Err(e) = self.memory.memory().write(
+            &access_resp.0.to_be_bytes(),
+            GuestAddress(dma_address + core::mem::offset_of!(FwCfgDmaAccess, control_be) as u64),
+        ) {
+            error!("fw_cfg: finishing dma: {e:?}")
+        }
     }
 
     pub fn add_kernel_data(&mut self, file: &File) -> Result<()> {
@@ -560,10 +712,14 @@ impl BusDevice for FwCfg {
             }
             (PORT_FW_CFG_DATA, _) => _ = self.read_data(data, size as u32),
             (PORT_FW_CFG_DMA_HI, 4) => {
-                unimplemented!()
+                let addr = self.dma_address;
+                let addr_hi = (addr >> 32) as u32;
+                data.copy_from_slice(&addr_hi.to_be_bytes());
             }
             (PORT_FW_CFG_DMA_LO, 4) => {
-                unimplemented!()
+                let addr = self.dma_address;
+                let addr_lo = (addr & 0xffff_ffff) as u32;
+                data.copy_from_slice(&addr_lo.to_be_bytes());
             }
             _ => {
                 debug!("fw_cfg: read from unknown port {port:#x}: {size:#x} bytes and offset {offset:#x}.");
@@ -587,10 +743,19 @@ impl BusDevice for FwCfg {
             }
             (PORT_FW_CFG_DATA, 1) => error!("fw_cfg: data register is read-only."),
             (PORT_FW_CFG_DMA_HI, 4) => {
-                unimplemented!()
+                let mut buf = [0u8; 4];
+                buf[..size].copy_from_slice(&data[..size]);
+                let val = u32::from_be_bytes(buf);
+                self.dma_address &= 0xffff_ffff;
+                self.dma_address |= (val as u64) << 32;
             }
             (PORT_FW_CFG_DMA_LO, 4) => {
-                unimplemented!()
+                let mut buf = [0u8; 4];
+                buf[..size].copy_from_slice(&data[..size]);
+                let val = u32::from_be_bytes(buf);
+                self.dma_address &= !0xffff_ffff;
+                self.dma_address |= val as u64;
+                self.do_dma();
             }
             _ => debug!(
                 "fw_cfg: write to unknown port {port:#x}: {size:#x} bytes and offset {offset:#x} ."
@@ -617,10 +782,18 @@ mod tests {
     const DATA_OFFSET: u64 = 1;
     #[cfg(target_arch = "aarch64")]
     const DATA_OFFSET: u64 = 0;
+    #[cfg(target_arch = "x86_64")]
+    const DMA_OFFSET: u64 = 4;
+    #[cfg(target_arch = "aarch64")]
+    const DMA_OFFSET: u64 = 16;
 
     #[test]
     fn test_signature() {
-        let mut fw_cfg = FwCfg::new();
+        let gm = GuestMemoryAtomic::new(
+            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), RAM_64BIT_START.0 as usize)]).unwrap(),
+        );
+
+        let mut fw_cfg = FwCfg::new(gm);
 
         let mut data = vec![0u8];
 
@@ -637,7 +810,11 @@ mod tests {
     }
     #[test]
     fn test_kernel_cmdline() {
-        let mut fw_cfg = FwCfg::new();
+        let gm = GuestMemoryAtomic::new(
+            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), RAM_64BIT_START.0 as usize)]).unwrap(),
+        );
+
+        let mut fw_cfg = FwCfg::new(gm);
 
         let cmdline = *b"cmdline\0";
 
@@ -659,7 +836,11 @@ mod tests {
 
     #[test]
     fn test_initram_fs() {
-        let mut fw_cfg = FwCfg::new();
+        let gm = GuestMemoryAtomic::new(
+            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), RAM_64BIT_START.0 as usize)]).unwrap(),
+        );
+
+        let mut fw_cfg = FwCfg::new(gm);
 
         let temp = TempFile::new().unwrap();
         let mut temp_file = temp.as_file();
@@ -681,5 +862,61 @@ mod tests {
                 return;
             }
         }
+    }
+
+    #[test]
+    fn test_dma() {
+        let code = [
+            0xba, 0xf8, 0x03, 0x00, 0xd8, 0x04, b'0', 0xee, 0xb0, b'\n', 0xee, 0xf4,
+        ];
+
+        let content = FwCfgContent::Bytes(code.to_vec());
+
+        let mem_size = 0x1000;
+        let load_addr = GuestAddress(0x1000);
+        let mem: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&[(load_addr, mem_size)]).unwrap();
+
+        // Note: In firmware we would just allocate FwCfgDmaAccess struct
+        // and use address of struct (&) as dma address
+        let mut access_control = AccessControl(0);
+        // bit 1 = read access
+        access_control.set_read(true);
+        // length of data to access
+        let length_be = (code.len() as u32).to_be();
+        // guest address for data
+        let code_address = 0x1900_u64;
+        let address_be = code_address.to_be();
+        let mut access = FwCfgDmaAccess {
+            control_be: access_control.0.to_be(), // bit(1) = read bit
+            length_be,
+            address_be,
+        };
+        // access address is where to put the code
+        let access_address = GuestAddress(load_addr.0);
+        let address_bytes = access_address.0.to_be_bytes();
+        let dma_lo: [u8; 4] = address_bytes[0..4].try_into().unwrap();
+        let dma_hi: [u8; 4] = address_bytes[4..8].try_into().unwrap();
+
+        // writing the FwCfgDmaAccess to mem (this would just be self.dma_access.as_ref() in guest)
+        let _ = mem.write(access.as_mut_bytes(), access_address);
+        let mem_m = GuestMemoryAtomic::new(mem.clone());
+        let mut fw_cfg = FwCfg::new(mem_m);
+        let cfg_item = FwCfgItem {
+            name: "code".to_string(),
+            content,
+        };
+        let _ = fw_cfg.add_item(cfg_item);
+
+        let mut data = [0u8; 12];
+
+        let _ = mem.read(&mut data, GuestAddress(code_address));
+        assert_ne!(data, code);
+
+        fw_cfg.write(0, SELECTOR_OFFSET, &[FW_CFG_FILE_FIRST as u8, 0]);
+        fw_cfg.write(0, DMA_OFFSET, &dma_lo);
+        fw_cfg.write(0, DMA_OFFSET + 4, &dma_hi);
+        let _ = mem.read(&mut data, GuestAddress(code_address));
+        assert_eq!(data, code);
     }
 }

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -1,0 +1,309 @@
+// Copyright 2025 Google LLC.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// Cloud Hypervisor implementation of Qemu's fw_cfg spec
+/// https://www.qemu.org/docs/master/specs/fw_cfg.html
+/// Linux kernel fw_cfg driver header
+/// https://github.com/torvalds/linux/blob/master/include/uapi/linux/qemu_fw_cfg.h
+/// Uploading files to the guest via fw_cfg is supported for all kernels 4.6+ w/ CONFIG_FW_CFG_SYSFS enabled
+/// https://cateee.net/lkddb/web-lkddb/FW_CFG_SYSFS.html
+/// No kernel requirement if above functionality is not required,
+/// only firmware must implement mechanism to interact with this fw_cfg device
+use std::{
+    fs::File,
+    io::Result,
+    mem::size_of_val,
+    os::unix::fs::FileExt,
+    sync::{Arc, Barrier},
+};
+
+use vm_device::BusDevice;
+use vmm_sys_util::sock_ctrl_msg::IntoIovec;
+use zerocopy::{FromBytes, IntoBytes};
+
+#[cfg(target_arch = "x86_64")]
+const PORT_FW_CFG_SELECTOR: u64 = 0x510;
+#[cfg(target_arch = "x86_64")]
+const PORT_FW_CFG_DATA: u64 = 0x511;
+#[cfg(target_arch = "x86_64")]
+const PORT_FW_CFG_DMA_HI: u64 = 0x514;
+#[cfg(target_arch = "x86_64")]
+const PORT_FW_CFG_DMA_LO: u64 = 0x518;
+#[cfg(target_arch = "x86_64")]
+pub const PORT_FW_CFG_BASE: u64 = 0x510;
+#[cfg(target_arch = "x86_64")]
+pub const PORT_FW_CFG_WIDTH: u64 = 0xc;
+#[cfg(target_arch = "aarch64")]
+const PORT_FW_CFG_SELECTOR: u64 = 0x9030008;
+#[cfg(target_arch = "aarch64")]
+const PORT_FW_CFG_DATA: u64 = 0x9030000;
+#[cfg(target_arch = "aarch64")]
+const PORT_FW_CFG_DMA_HI: u64 = 0x9030010;
+#[cfg(target_arch = "aarch64")]
+const PORT_FW_CFG_DMA_LO: u64 = 0x9030014;
+#[cfg(target_arch = "aarch64")]
+pub const PORT_FW_CFG_BASE: u64 = 0x9030000;
+#[cfg(target_arch = "aarch64")]
+pub const PORT_FW_CFG_WIDTH: u64 = 0x10;
+
+const FW_CFG_SIGNATURE: u16 = 0x00;
+const FW_CFG_ID: u16 = 0x01;
+const FW_CFG_FILE_DIR: u16 = 0x19;
+const FW_CFG_KNOWN_ITEMS: usize = 0x20;
+
+pub const FW_CFG_FILE_FIRST: u16 = 0x20;
+pub const FW_CFG_DMA_SIGNATURE: [u8; 8] = *b"QEMU CFG";
+// Reserved (must be enabled)
+const FW_CFG_F_RESERVED: u8 = 1 << 0;
+// DMA Toggle Bit (enabled by default)
+const FW_CFG_F_DMA: u8 = 1 << 1;
+pub const FW_CFG_FEATURE: [u8; 4] = [FW_CFG_F_RESERVED | FW_CFG_F_DMA, 0, 0, 0];
+
+#[derive(Debug)]
+pub enum FwCfgContent {
+    Bytes(Vec<u8>),
+    Slice(&'static [u8]),
+    File(u64, File),
+    U32(u32),
+}
+
+impl Default for FwCfgContent {
+    fn default() -> Self {
+        FwCfgContent::Slice(&[])
+    }
+}
+
+impl FwCfgContent {
+    fn size(&self) -> Result<u32> {
+        let ret = match self {
+            FwCfgContent::Bytes(v) => v.len(),
+            FwCfgContent::File(offset, f) => (f.metadata()?.len() - offset) as usize,
+            FwCfgContent::Slice(s) => s.len(),
+            FwCfgContent::U32(n) => size_of_val(n),
+        };
+        u32::try_from(ret).map_err(|_| std::io::ErrorKind::InvalidInput.into())
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct FwCfgItem {
+    pub name: String,
+    pub content: FwCfgContent,
+}
+
+/// https://www.qemu.org/docs/master/specs/fw_cfg.html
+#[derive(Debug, Default)]
+pub struct FwCfg {
+    selector: u16,
+    data_offset: u32,
+    items: Vec<FwCfgItem>,                           // 0x20 and above
+    known_items: [FwCfgContent; FW_CFG_KNOWN_ITEMS], // 0x0 to 0x19
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes)]
+struct FwCfgFilesHeader {
+    count_be: u32,
+}
+
+pub const FILE_NAME_SIZE: usize = 56;
+
+pub fn create_file_name(name: &str) -> [u8; FILE_NAME_SIZE] {
+    let mut c_name = [0u8; FILE_NAME_SIZE];
+    let c_len = std::cmp::min(FILE_NAME_SIZE - 1, name.len());
+    c_name[0..c_len].copy_from_slice(&name.as_bytes()[0..c_len]);
+    c_name
+}
+
+#[allow(dead_code)]
+#[repr(C, packed)]
+#[derive(Debug, IntoBytes, FromBytes, Clone, Copy)]
+struct BootE820Entry {
+    addr: u64,
+    size: u64,
+    type_: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes)]
+struct FwCfgFile {
+    size_be: u32,
+    select_be: u16,
+    _reserved: u16,
+    name: [u8; FILE_NAME_SIZE],
+}
+
+impl FwCfg {
+    pub fn new() -> FwCfg {
+        const DEFAULT_ITEM: FwCfgContent = FwCfgContent::Slice(&[]);
+        let mut known_items = [DEFAULT_ITEM; FW_CFG_KNOWN_ITEMS];
+        known_items[FW_CFG_SIGNATURE as usize] = FwCfgContent::Slice(&FW_CFG_DMA_SIGNATURE);
+        known_items[FW_CFG_ID as usize] = FwCfgContent::Slice(&FW_CFG_FEATURE);
+        let file_buf = Vec::from(FwCfgFilesHeader { count_be: 0 }.as_mut_bytes());
+        known_items[FW_CFG_FILE_DIR as usize] = FwCfgContent::Bytes(file_buf);
+
+        FwCfg {
+            selector: 0,
+            data_offset: 0,
+            items: vec![],
+            known_items,
+        }
+    }
+
+    fn file_dir_mut(&mut self) -> &mut Vec<u8> {
+        let FwCfgContent::Bytes(file_buf) = &mut self.known_items[FW_CFG_FILE_DIR as usize] else {
+            unreachable!("fw_cfg: selector {FW_CFG_FILE_DIR:#x} should be FwCfgContent::Byte!")
+        };
+        file_buf
+    }
+
+    fn update_count(&mut self) {
+        let mut header = FwCfgFilesHeader {
+            count_be: (self.items.len() as u32).to_be(),
+        };
+        self.file_dir_mut()[0..4].copy_from_slice(header.as_mut_bytes());
+    }
+
+    pub fn add_item(&mut self, item: FwCfgItem) -> Result<()> {
+        let index = self.items.len();
+        let c_name = create_file_name(&item.name);
+        let size = item.content.size()?;
+        let mut cfg_file = FwCfgFile {
+            size_be: size.to_be(),
+            select_be: (FW_CFG_FILE_FIRST + index as u16).to_be(),
+            _reserved: 0,
+            name: c_name,
+        };
+        self.file_dir_mut()
+            .extend_from_slice(cfg_file.as_mut_bytes());
+        self.items.push(item);
+        self.update_count();
+        Ok(())
+    }
+
+    fn read_content(content: &FwCfgContent, offset: u32, data: &mut [u8], size: u32) -> Option<u8> {
+        let start = offset as usize;
+        let end = start + size as usize;
+        match content {
+            FwCfgContent::Bytes(b) => {
+                if b.len() >= size as usize {
+                    data.copy_from_slice(&b[start..end]);
+                }
+            }
+            FwCfgContent::Slice(s) => {
+                if s.len() >= size as usize {
+                    data.copy_from_slice(&s[start..end]);
+                }
+            }
+            FwCfgContent::File(o, f) => {
+                f.read_exact_at(data, o + offset as u64).ok()?;
+            }
+            FwCfgContent::U32(n) => {
+                let bytes = n.to_le_bytes();
+                data.copy_from_slice(&bytes[start..end]);
+            }
+        };
+        Some(size as u8)
+    }
+
+    fn read_data(&mut self, data: &mut [u8], size: u32) -> u8 {
+        let ret = if let Some(content) = self.known_items.get(self.selector as usize) {
+            Self::read_content(content, self.data_offset, data, size)
+        } else if let Some(item) = self.items.get((self.selector - FW_CFG_FILE_FIRST) as usize) {
+            Self::read_content(&item.content, self.data_offset, data, size)
+        } else {
+            error!("fw_cfg: selector {:#x} does not exist.", self.selector);
+            None
+        };
+        if let Some(val) = ret {
+            self.data_offset += size;
+            val
+        } else {
+            0
+        }
+    }
+}
+
+impl BusDevice for FwCfg {
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
+        let port = offset + PORT_FW_CFG_BASE;
+        let size = data.len();
+        match (port, size) {
+            (PORT_FW_CFG_SELECTOR, _) => {
+                error!("fw_cfg: selector register is write-only.");
+            }
+            (PORT_FW_CFG_DATA, _) => _ = self.read_data(data, size as u32),
+            (PORT_FW_CFG_DMA_HI, 4) => {
+                unimplemented!()
+            }
+            (PORT_FW_CFG_DMA_LO, 4) => {
+                unimplemented!()
+            }
+            _ => {
+                debug!("fw_cfg: read from unknown port {port:#x}: {size:#x} bytes and offset {offset:#x}.");
+            }
+        };
+    }
+
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        let port = offset + PORT_FW_CFG_BASE;
+        let size = data.size();
+        match (port, size) {
+            (PORT_FW_CFG_SELECTOR, 2) => {
+                let mut buf = [0u8; 2];
+                buf[..size].copy_from_slice(&data[..size]);
+                #[cfg(target_arch = "x86_64")]
+                let val = u16::from_le_bytes(buf);
+                #[cfg(target_arch = "aarch64")]
+                let val = u16::from_be_bytes(buf);
+                self.selector = val;
+                self.data_offset = 0;
+            }
+            (PORT_FW_CFG_DATA, 1) => error!("fw_cfg: data register is read-only."),
+            (PORT_FW_CFG_DMA_HI, 4) => {
+                unimplemented!()
+            }
+            (PORT_FW_CFG_DMA_LO, 4) => {
+                unimplemented!()
+            }
+            _ => debug!(
+                "fw_cfg: write to unknown port {port:#x}: {size:#x} bytes and offset {offset:#x} ."
+            ),
+        };
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_arch = "x86_64")]
+    const SELECTOR_OFFSET: u64 = 0;
+    #[cfg(target_arch = "aarch64")]
+    const SELECTOR_OFFSET: u64 = 8;
+    #[cfg(target_arch = "x86_64")]
+    const DATA_OFFSET: u64 = 1;
+    #[cfg(target_arch = "aarch64")]
+    const DATA_OFFSET: u64 = 0;
+
+    #[test]
+    fn test_signature() {
+        let mut fw_cfg = FwCfg::new();
+
+        let mut data = vec![0u8];
+
+        let mut sig_iter = FW_CFG_DMA_SIGNATURE.into_iter();
+        fw_cfg.write(0, SELECTOR_OFFSET, &[FW_CFG_SIGNATURE as u8, 0]);
+        loop {
+            if let Some(char) = sig_iter.next() {
+                fw_cfg.read(0, DATA_OFFSET, &mut data);
+                assert_eq!(data[0], char);
+            } else {
+                return;
+            }
+        }
+    }
+}

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -91,6 +91,8 @@ const FW_CFG_KNOWN_ITEMS: usize = 0x20;
 
 pub const FW_CFG_FILE_FIRST: u16 = 0x20;
 pub const FW_CFG_DMA_SIGNATURE: [u8; 8] = *b"QEMU CFG";
+// https://github.com/torvalds/linux/blob/master/include/uapi/linux/qemu_fw_cfg.h
+pub const FW_CFG_ACPI_ID: &str = "QEMU0002";
 // Reserved (must be enabled)
 const FW_CFG_F_RESERVED: u8 = 1 << 0;
 // DMA Toggle Bit (enabled by default)

--- a/devices/src/legacy/mod.rs
+++ b/devices/src/legacy/mod.rs
@@ -8,6 +8,8 @@
 mod cmos;
 #[cfg(target_arch = "x86_64")]
 mod debug_port;
+#[cfg(feature = "fw_cfg")]
+pub mod fw_cfg;
 #[cfg(target_arch = "x86_64")]
 mod fwdebug;
 #[cfg(target_arch = "aarch64")]
@@ -22,6 +24,8 @@ mod uart_pl011;
 pub use self::cmos::Cmos;
 #[cfg(target_arch = "x86_64")]
 pub use self::debug_port::DebugPort;
+#[cfg(feature = "fw_cfg")]
+pub use self::fw_cfg::FwCfg;
 #[cfg(target_arch = "x86_64")]
 pub use self::fwdebug::FwDebugDevice;
 #[cfg(target_arch = "aarch64")]

--- a/docs/fw_cfg.md
+++ b/docs/fw_cfg.md
@@ -1,0 +1,77 @@
+# Firmware Configuration (fw_cfg) Device
+
+The `fw_cfg` device is a QEMU-compatible device that allows the hypervisor to pass configuration and data to the guest operating system. This is particularly useful for firmware to access information like ACPI tables, kernel images, initramfs, kernel command lines, and other arbitrary data blobs.
+
+Cloud Hypervisor implements the `fw_cfg` device with DMA-enabled access.
+
+## Purpose
+
+The `fw_cfg` device serves as a generic information channel between the VMM and the guest. It can be used to:
+
+*   Load the kernel, initramfs, and kernel command line for direct kernel boot with firmware.
+*   Provide ACPI tables to the guest firmware or OS.
+*   Pass custom configuration files or data blobs (e.g., attestation data, SEV-SNP launch secrets) to the guest.
+*   Supply an E820 memory map to the guest.
+
+## Enabling `fw_cfg`
+
+The `fw_cfg` device is enabled via the `fw_cfg` feature flag when building Cloud Hypervisor:
+
+```bash
+cargo build --features fw_cfg
+```
+
+## Guest Kernel Configuration
+
+For the guest Linux kernel to recognize and use the `fw_cfg` device via sysfs, the following kernel configuration option must be enabled:
+
+*   `CONFIG_FW_CFG_SYSFS=y`
+
+This option allows the kernel to expose `fw_cfg` entries under `/sys/firmware/qemu_fw_cfg/by_name/`.
+
+## Command Line Options
+
+The `fw_cfg` device is configured using the `--fw-cfg-config` command-line option.
+
+**Parameters:**
+*   `e820=on|off`: (Default: `on`) Whether to add an E820 memory map entry to `fw_cfg`.
+*   `kernel=on|off`: (Default: `on`) Whether to add the kernel image (specified by `--kernel`) to `fw_cfg`.
+*   `cmdline=on|off`: (Default: `on`) Whether to add the kernel command line (specified by `--cmdline`) to `fw_cfg`.
+*   `initramfs=on|off`: (Default: `on`) Whether to add the initramfs image (specified by `--initramfs`) to `fw_cfg`.
+*   `acpi_table=on|off`: (Default: `on`) Whether to add generated ACPI tables to `fw_cfg`.
+*   `items=[... : ...]`: A list of custom key-value pairs to be exposed via `fw_cfg`.
+    *   `name=<guest_sysfs_path>`: The path under which the item will appear in the guest's sysfs (e.g., `opt/org.example/my-data`).
+    *   `file=<host_file_path>`: The path to the file on the host whose content will be provided to the guest for this item.
+
+**Example Usage:**
+
+1.  **Direct kernel boot with custom `fw_cfg` entries:**
+
+    ```bash
+    cloud-hypervisor \
+        --kernel /path/to/vmlinux \
+        --cmdline "console=hvc0 root=/dev/vda1" \
+        --disk path=/path/to/rootfs.img \
+        --fw-cfg-config initramfs=off,items=[name=opt/org.mycorp/setup_info,file=/tmp/guest_setup.txt] \
+        ...
+    ```
+    In the guest, `/tmp/guest_setup.txt` from the host will be accessible at `/sys/firmware/qemu_fw_cfg/by_name/opt/org.mycorp/setup_info/raw`.
+
+2.  **Disabling `fw_cfg` explicitly:**
+
+    ```bash
+    cloud-hypervisor \
+        --fw-cfg-config disable \
+        ...
+    ```
+
+## Accessing `fw_cfg` Items in the Guest
+
+If `CONFIG_FW_CFG_SYSFS` is enabled in the guest kernel, items added to `fw_cfg` can be accessed via sysfs.
+
+For example, an item added with `name=opt/org.example/my-data` will be available at:
+`/sys/firmware/qemu_fw_cfg/by_name/opt/org.example/my-data/raw`
+
+The `raw` file contains the binary content of the host file provided.
+
+Standard items like kernel, initramfs, cmdline, and ACPI tables also have predefined names (e.g., `etc/kernel`, `etc/cmdline`) if they are enabled to be passed via `fw_cfg`.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -22,7 +22,12 @@ epoll = "4.3.3"
 hypervisor = { path = "../hypervisor", features = ["mshv_emulator"] }
 libc = "0.2.155"
 libfuzzer-sys = "0.4.7"
-linux-loader = { version = "0.13.0", features = ["bzimage", "elf", "pe"] }
+# TODO: update to 0.13.1+
+linux-loader = { git = "https://github.com/rust-vmm/linux-loader", branch = "main", features = [
+  "bzimage",
+  "elf",
+  "pe",
+] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 mshv-bindings = "0.5.2"
 net_util = { path = "../net_util" }

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -250,4 +250,12 @@ if [ $RES -eq 0 ]; then
     RES=$?
 fi
 
+# Run tests on fw_cfg
+if [ $RES -eq 0 ]; then
+    cargo build --features "fw_cfg" --all --release --target "$BUILD_TARGET"
+    export RUST_BACKTRACE=1
+    time cargo test "fw_cfg::$test_filter" --target "$BUILD_TARGET" -- ${test_binary_args[*]}
+    RES=$?
+fi
+
 exit $RES

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -198,4 +198,12 @@ if [ $RES -eq 0 ]; then
     RES=$?
 fi
 
+# Run tests on fw_cfg
+if [ $RES -eq 0 ]; then
+    cargo build --features "mshv,fw_cfg" --all --release --target "$BUILD_TARGET"
+    export RUST_BACKTRACE=1
+    time cargo test "fw_cfg::$test_filter" --target "$BUILD_TARGET" -- ${test_binary_args[*]}
+    RES=$?
+fi
+
 exit $RES

--- a/src/main.rs
+++ b/src/main.rs
@@ -853,6 +853,8 @@ fn main() {
     compile_error!("Feature 'tdx' and 'sev_snp' are mutually exclusive.");
     #[cfg(all(feature = "sev_snp", not(target_arch = "x86_64")))]
     compile_error!("Feature 'sev_snp' needs target 'x86_64'");
+    #[cfg(all(feature = "fw_cfg", target_arch = "riscv64"))]
+    compile_error!("Feature 'fw_cfg' needs targets 'x86_64' or 'aarch64'");
 
     #[cfg(feature = "dhat-heap")]
     let _profiler = dhat::Profiler::new_heap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ use vmm::api::ApiAction;
 use vmm::config::{RestoreConfig, VmParams};
 use vmm::landlock::{Landlock, LandlockError};
 use vmm::vm_config;
+#[cfg(feature = "fw_cfg")]
+use vmm::vm_config::FwCfgConfig;
 #[cfg(target_arch = "x86_64")]
 use vmm::vm_config::SgxEpcConfig;
 use vmm::vm_config::{
@@ -269,6 +271,12 @@ fn get_cli_options_sorted(
             .help(FsConfig::SYNTAX)
             .num_args(1..)
             .group("vm-config"),
+        #[cfg(feature = "fw_cfg")]
+        Arg::new("fw-cfg-config")
+            .long("fw-cfg-config")
+            .help(FwCfgConfig::SYNTAX)
+            .num_args(1)
+            .group("vm-payload"),
         #[cfg(feature = "guest_debug")]
         Arg::new("gdb")
             .long("gdb")
@@ -979,6 +987,8 @@ mod unit_tests {
                 igvm: None,
                 #[cfg(feature = "sev_snp")]
                 host_data: None,
+                #[cfg(feature = "fw_cfg")]
+                fw_cfg_config: None,
             }),
             rate_limit_groups: None,
             disks: None,

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 dbus_api = ["blocking", "futures", "zbus"]
 default = []
 dhat-heap = ["dhat"] # For heap profiling
+fw_cfg = ["devices/fw_cfg"]
 guest_debug = ["gdbstub", "gdbstub_arch", "kvm"]
 igvm = ["dep:igvm", "hex", "igvm_defs", "mshv-bindings", "range_map_vec"]
 io_uring = ["block/io_uring"]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1477,7 +1477,9 @@ impl DeviceManager {
 
     #[cfg(feature = "fw_cfg")]
     pub fn create_fw_cfg_device(&mut self) -> Result<(), DeviceManagerError> {
-        let fw_cfg = Arc::new(Mutex::new(devices::legacy::FwCfg::new()));
+        let fw_cfg = Arc::new(Mutex::new(devices::legacy::FwCfg::new(
+            self.memory_manager.lock().as_ref().unwrap().guest_memory(),
+        )));
 
         self.fw_cfg = Some(fw_cfg.clone());
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -405,6 +405,8 @@ pub fn feature_list() -> Vec<String> {
         "dbus_api".to_string(),
         #[cfg(feature = "dhat-heap")]
         "dhat-heap".to_string(),
+        #[cfg(feature = "fw_cfg")]
+        "fw_cfg".to_string(),
         #[cfg(feature = "guest_debug")]
         "guest_debug".to_string(),
         #[cfg(feature = "igvm")]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2391,6 +2391,8 @@ mod unit_tests {
                 igvm: None,
                 #[cfg(feature = "sev_snp")]
                 host_data: None,
+                #[cfg(feature = "fw_cfg")]
+                fw_cfg_config: None,
             }),
             rate_limit_groups: None,
             disks: None,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -716,6 +716,13 @@ impl Vm {
             vm.sev_snp_init().map_err(Error::InitializeSevSnpVm)?;
         }
 
+        #[cfg(feature = "fw_cfg")]
+        device_manager
+            .lock()
+            .unwrap()
+            .create_fw_cfg_device()
+            .map_err(Error::DeviceManager)?;
+
         #[cfg(feature = "tdx")]
         let kernel = config
             .lock()

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -351,6 +351,10 @@ pub enum Error {
     #[cfg(feature = "fw_cfg")]
     #[error("Error creating e820 map")]
     CreatingE820Map(#[source] io::Error),
+
+    #[cfg(feature = "fw_cfg")]
+    #[error("Error creating acpi tables")]
+    CreatingAcpiTables(#[source] io::Error),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -2348,10 +2352,21 @@ impl Vm {
         } else {
             VmState::Running
         };
+
         current_state.valid_transition(new_state)?;
 
         #[cfg(feature = "fw_cfg")]
-        Self::populate_fw_cfg(&self.device_manager, &self.config)?;
+        {
+            Self::populate_fw_cfg(&self.device_manager, &self.config)?;
+            let tpm_enabled = self.config.lock().unwrap().tpm.is_some();
+            crate::acpi::create_acpi_tables_for_fw_cfg(
+                &self.device_manager,
+                &self.cpu_manager,
+                &self.memory_manager,
+                &self.numa_nodes,
+                tpm_enabled,
+            )?
+        }
 
         // Do earlier to parallelise with loading kernel
         #[cfg(target_arch = "x86_64")]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -347,6 +347,10 @@ pub enum Error {
     #[cfg(feature = "fw_cfg")]
     #[error("Fw Cfg missing kernel cmdline")]
     MissingFwCfgCmdline,
+
+    #[cfg(feature = "fw_cfg")]
+    #[error("Error creating e820 map")]
+    CreatingE820Map(#[source] io::Error),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -797,6 +801,15 @@ impl Vm {
         device_manager: &Arc<Mutex<DeviceManager>>,
         config: &Arc<Mutex<VmConfig>>,
     ) -> Result<()> {
+        device_manager
+            .lock()
+            .unwrap()
+            .fw_cfg()
+            .expect("fw_cfg device must be present")
+            .lock()
+            .unwrap()
+            .add_e820(config.lock().unwrap().memory.size as usize)
+            .map_err(Error::CreatingE820Map)?;
         let kernel = config
             .lock()
             .unwrap()

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -34,6 +34,8 @@ use arch::PciSpaceInfo;
 use arch::{get_host_cpu_phys_bits, EntryPoint, NumaNode, NumaNodes};
 #[cfg(target_arch = "aarch64")]
 use devices::interrupt_controller;
+#[cfg(feature = "fw_cfg")]
+use devices::legacy::fw_cfg::FwCfgItem;
 use devices::AcpiNotificationFlags;
 #[cfg(all(target_arch = "aarch64", feature = "guest_debug"))]
 use gdbstub_arch::aarch64::reg::AArch64CoreRegs as CoreRegs;
@@ -91,6 +93,8 @@ use crate::migration::get_vm_snapshot;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::migration::url_to_file;
 use crate::migration::{url_to_path, SNAPSHOT_CONFIG_FILE, SNAPSHOT_STATE_FILE};
+#[cfg(feature = "fw_cfg")]
+use crate::vm_config::FwCfgConfig;
 use crate::vm_config::{
     DeviceConfig, DiskConfig, FsConfig, HotplugMethod, NetConfig, NumaConfig, PayloadConfig,
     PmemConfig, UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
@@ -355,6 +359,18 @@ pub enum Error {
     #[cfg(feature = "fw_cfg")]
     #[error("Error creating acpi tables")]
     CreatingAcpiTables(#[source] io::Error),
+
+    #[cfg(feature = "fw_cfg")]
+    #[error("Error adding fw_cfg item")]
+    AddingFwCfgItem(#[source] io::Error),
+
+    #[cfg(feature = "fw_cfg")]
+    #[error("Error populating fw_cfg")]
+    ErrorPopulatingFwCfg(#[source] io::Error),
+
+    #[cfg(feature = "fw_cfg")]
+    #[error("Error using fw_cfg while disabled")]
+    FwCfgDisabled,
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -737,11 +753,22 @@ impl Vm {
         }
 
         #[cfg(feature = "fw_cfg")]
-        device_manager
-            .lock()
-            .unwrap()
-            .create_fw_cfg_device()
-            .map_err(Error::DeviceManager)?;
+        {
+            let fw_cfg_config = config
+                .lock()
+                .unwrap()
+                .payload
+                .as_ref()
+                .map(|p| p.fw_cfg_config.is_some())
+                .unwrap_or(false);
+            if fw_cfg_config {
+                device_manager
+                    .lock()
+                    .unwrap()
+                    .create_fw_cfg_device()
+                    .map_err(Error::DeviceManager)?;
+            }
+        }
 
         #[cfg(feature = "tdx")]
         let kernel = config
@@ -802,76 +829,85 @@ impl Vm {
 
     #[cfg(feature = "fw_cfg")]
     fn populate_fw_cfg(
+        fw_cfg_config: &FwCfgConfig,
         device_manager: &Arc<Mutex<DeviceManager>>,
         config: &Arc<Mutex<VmConfig>>,
     ) -> Result<()> {
-        device_manager
-            .lock()
-            .unwrap()
-            .fw_cfg()
-            .expect("fw_cfg device must be present")
-            .lock()
-            .unwrap()
-            .add_e820(config.lock().unwrap().memory.size as usize)
-            .map_err(Error::CreatingE820Map)?;
-        let kernel = config
-            .lock()
-            .unwrap()
-            .payload
-            .as_ref()
-            .map(|p| p.kernel.as_ref().map(File::open))
-            .unwrap_or_default()
-            .transpose()
-            .map_err(Error::MissingFwCfgKernelFile)?;
-        if let Some(kernel_file) = kernel {
-            device_manager
-                .lock()
-                .unwrap()
-                .fw_cfg()
-                .expect("fw_cfg device must be present")
-                .lock()
-                .unwrap()
-                .add_kernel_data(&kernel_file)
-                .map_err(Error::MissingFwCfgKernelFile)?
+        let mut e820_option: Option<usize> = None;
+        if fw_cfg_config.e820 {
+            e820_option = Some(config.lock().unwrap().memory.size as usize);
         }
-        let cmdline = Vm::generate_cmdline(
-            config.lock().unwrap().payload.as_ref().unwrap(),
-            #[cfg(target_arch = "aarch64")]
-            device_manager,
-        )
-        .map_err(|_| Error::MissingFwCfgCmdline)?
-        .as_cstring()
-        .map_err(|_| Error::MissingFwCfgCmdline)?;
-        device_manager
-            .lock()
-            .unwrap()
-            .fw_cfg()
-            .expect("fw_cfg device must be present")
-            .lock()
-            .unwrap()
-            .add_kernel_cmdline(cmdline);
-        let initramfs = config
-            .lock()
-            .unwrap()
-            .payload
-            .as_ref()
-            .map(|p| p.initramfs.as_ref().map(File::open))
-            .unwrap_or_default()
-            .transpose()
-            .map_err(Error::MissingFwCfgInitramfs)?;
-        // We measure the initramfs when running Oak Containers in SNP mode (initramfs = Stage1)
-        // o/w use Stage0 to launch cloud disk images
-        if let Some(initramfs_file) = initramfs {
-            device_manager
+        let mut kernel_option: Option<File> = None;
+        if fw_cfg_config.kernel {
+            let kernel = config
                 .lock()
                 .unwrap()
-                .fw_cfg()
-                .expect("fw_cfg device must be present")
+                .payload
+                .as_ref()
+                .map(|p| p.kernel.as_ref().map(File::open))
+                .unwrap_or_default()
+                .transpose()
+                .map_err(Error::MissingFwCfgKernelFile)?;
+            kernel_option = kernel;
+        }
+        let mut cmdline_option: Option<std::ffi::CString> = None;
+        if fw_cfg_config.cmdline {
+            let cmdline = Vm::generate_cmdline(
+                config.lock().unwrap().payload.as_ref().unwrap(),
+                #[cfg(target_arch = "aarch64")]
+                device_manager,
+            )
+            .map_err(|_| Error::MissingFwCfgCmdline)?
+            .as_cstring()
+            .map_err(|_| Error::MissingFwCfgCmdline)?;
+            cmdline_option = Some(cmdline);
+        }
+        let mut initramfs_option: Option<File> = None;
+        if fw_cfg_config.initramfs {
+            let initramfs = config
                 .lock()
                 .unwrap()
-                .add_initramfs_data(&initramfs_file)
+                .payload
+                .as_ref()
+                .map(|p| p.initramfs.as_ref().map(File::open))
+                .unwrap_or_default()
+                .transpose()
                 .map_err(Error::MissingFwCfgInitramfs)?;
+            // We measure the initramfs when running Oak Containers in SNP mode (initramfs = Stage1)
+            // o/w use Stage0 to launch cloud disk images
+            initramfs_option = initramfs;
         }
+        let mut fw_cfg_item_list_option: Option<Vec<FwCfgItem>> = None;
+        if let Some(fw_cfg_files) = &fw_cfg_config.items {
+            let mut fw_cfg_item_list = vec![];
+            for fw_cfg_file in fw_cfg_files.item_list.clone() {
+                fw_cfg_item_list.push(FwCfgItem {
+                    name: fw_cfg_file.name,
+                    content: devices::legacy::fw_cfg::FwCfgContent::File(
+                        0,
+                        File::open(fw_cfg_file.file).map_err(Error::AddingFwCfgItem)?,
+                    ),
+                });
+            }
+            fw_cfg_item_list_option = Some(fw_cfg_item_list);
+        }
+
+        let device_manager_binding = device_manager.lock().unwrap();
+        let Some(fw_cfg) = device_manager_binding.fw_cfg() else {
+            return Err(Error::FwCfgDisabled);
+        };
+
+        fw_cfg
+            .lock()
+            .unwrap()
+            .populate_fw_cfg(
+                e820_option,
+                kernel_option,
+                initramfs_option,
+                cmdline_option,
+                fw_cfg_item_list_option,
+            )
+            .map_err(Error::ErrorPopulatingFwCfg)?;
         Ok(())
     }
 
@@ -2357,15 +2393,37 @@ impl Vm {
 
         #[cfg(feature = "fw_cfg")]
         {
-            Self::populate_fw_cfg(&self.device_manager, &self.config)?;
-            let tpm_enabled = self.config.lock().unwrap().tpm.is_some();
-            crate::acpi::create_acpi_tables_for_fw_cfg(
-                &self.device_manager,
-                &self.cpu_manager,
-                &self.memory_manager,
-                &self.numa_nodes,
-                tpm_enabled,
-            )?
+            let fw_cfg_enabled = self
+                .config
+                .lock()
+                .unwrap()
+                .payload
+                .as_ref()
+                .map(|p| p.fw_cfg_config.is_some())
+                .unwrap_or(false);
+            if fw_cfg_enabled {
+                let fw_cfg_config = self
+                    .config
+                    .lock()
+                    .unwrap()
+                    .payload
+                    .as_ref()
+                    .map(|p| p.fw_cfg_config.clone())
+                    .unwrap_or_default()
+                    .ok_or(Error::VmMissingConfig)?;
+                Self::populate_fw_cfg(&fw_cfg_config, &self.device_manager, &self.config)?;
+
+                if fw_cfg_config.acpi_tables {
+                    let tpm_enabled = self.config.lock().unwrap().tpm.is_some();
+                    crate::acpi::create_acpi_tables_for_fw_cfg(
+                        &self.device_manager,
+                        &self.cpu_manager,
+                        &self.memory_manager,
+                        &self.numa_nodes,
+                        tpm_enabled,
+                    )?
+                }
+            }
         }
 
         // Do earlier to parallelise with loading kernel


### PR DESCRIPTION
We are working with the project [Oak](https://github.com/project-oak/oak) team to enable running [Oak Containers](https://github.com/project-oak/oak/tree/main/oak_containers) on cloud hypervisor. These containers are SEV-SNP enlightened and can be used alongside with the rest of the oak suite for attestation and measurement of the cvm. 

Here is the functionality we are adding to CHV.
1. Implmenting the sev-snp APIs previously defined (sev_snp_init, import_isolated_pages, complete_isolated_import). 
2. Expanded the igvm loader to support booting KVM + SEV-SNP enabled VMs. (Note that we can also use the igvm loader to boot VMs with standard cloud images with/without sev-snp enabled as seen here (https://github.com/AlexOrozco1256/chv-demo)
3. Added a fw_cfg device with DMA enabled. Oak's [Stage0](https://github.com/project-oak/oak/tree/main/stage0_bin) firmware uses fw_cfg for loading various parameters into the VM. 

Additional design/implementation details can be found here: https://tinyurl.com/chv-kvm-sev-snp

See: #6653