### PR TITLE
hypervisor: mshv: fix advance_rip_update_rax() helper

### DIFF
--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1711,10 +1711,11 @@ impl MshvVcpu {
         if let Some(reg_page) = self.fd.get_vp_reg_page() {
             let vp_reg_page = reg_page.0;
             set_gp_regs_field_ptr!(vp_reg_page, rax, ret_rax);
-            // SAFETY: access union fields
+            // SAFETY: access raw pointer to reg page, access union fields
             unsafe {
                 (*vp_reg_page).__bindgen_anon_1.__bindgen_anon_1.rip = info.header.rip + insn_len;
                 (*vp_reg_page).dirty |= 1 << HV_X64_REGISTER_CLASS_IP;
+                (*vp_reg_page).dirty |= 1 << HV_X64_REGISTER_CLASS_GENERAL;
             }
         } else {
             let arr_reg_name_value = [


### PR DESCRIPTION
The dirty bit for the GP registers must be set for the hypervisor to update them.