### PR TITLE
vmm: Support user configurable mrconfigid as a command line argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "cfg-if",
  "concat-idents",
  "env_logger",
+ "hex",
  "iced-x86",
  "igvm",
  "igvm_defs",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -21,6 +21,7 @@ cfg-if = "1.0.0"
 concat-idents = "1.1.5"
 igvm = { workspace = true, optional = true }
 igvm_defs = { workspace = true, optional = true }
+hex = "0.4"
 kvm-bindings = { workspace = true, optional = true, features = ["serde"] }
 kvm-ioctls = { workspace = true, optional = true }
 libc = "0.2.167"

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -381,7 +381,12 @@ pub trait Vm: Send + Sync + Any {
     }
     #[cfg(feature = "tdx")]
     /// Initialize TDX on this VM
-    fn tdx_init(&self, _cpuid: &[CpuIdEntry], _max_vcpus: u32) -> Result<()> {
+    fn tdx_init(
+        &self,
+        _cpuid: &[CpuIdEntry],
+        _max_vcpus: u32,
+        _mrconfigid: &Option<String>,
+    ) -> Result<()> {
         unimplemented!()
     }
     #[cfg(feature = "tdx")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -343,6 +343,12 @@ fn get_cli_options_sorted(
             )
             .num_args(1..)
             .group("vm-config"),
+        #[cfg(feature = "tdx")]
+        Arg::new("mrconfigid")
+            .long("mrconfigid")
+            .help("Host specific data to TDX guest")
+            .num_args(1)
+            .group("vm-config"),
         Arg::new("net")
             .long("net")
             .help(NetConfig::SYNTAX)
@@ -974,6 +980,8 @@ mod unit_tests {
                 igvm: None,
                 #[cfg(feature = "sev_snp")]
                 host_data: None,
+                #[cfg(feature = "tdx")]
+                mrconfigid: None,
             }),
             rate_limit_groups: None,
             disks: None,

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -554,6 +554,8 @@ components:
           type: string
         host_data:
           type: string
+        mrconfigid:
+          type: string
       description: Payloads to boot in guest
 
     VmConfig:

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2388,6 +2388,8 @@ mod unit_tests {
                 igvm: None,
                 #[cfg(feature = "sev_snp")]
                 host_data: None,
+                #[cfg(feature = "tdx")]
+                mrconfigid: None,
             }),
             rate_limit_groups: None,
             disks: None,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -545,6 +545,18 @@ impl Vm {
             mmio_bus: mmio_bus.clone(),
         });
 
+        #[cfg(feature = "tdx")]
+        let mrconfigid =
+            config
+                .lock()
+                .unwrap()
+                .payload
+                .clone()
+                .map(|payload| match payload.mrconfigid {
+                    Some(id) => id.to_string(),
+                    None => "".to_string(),
+                });
+
         let cpus_config = { &config.lock().unwrap().cpus.clone() };
         let cpu_manager = cpu::CpuManager::new(
             cpus_config,
@@ -582,7 +594,7 @@ impl Vm {
         if tdx_enabled {
             let cpuid = cpu_manager.lock().unwrap().common_cpuid();
             let max_vcpus = cpu_manager.lock().unwrap().max_vcpus() as u32;
-            vm.tdx_init(&cpuid, max_vcpus)
+            vm.tdx_init(&cpuid, max_vcpus, &mrconfigid)
                 .map_err(Error::InitializeTdxVm)?;
         }
 

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -697,6 +697,9 @@ pub struct PayloadConfig {
     #[cfg(feature = "sev_snp")]
     #[serde(default)]
     pub host_data: Option<String>,
+    #[cfg(feature = "tdx")]
+    #[serde(default)]
+    pub mrconfigid: Option<String>,
 }
 
 impl ApplyLandlock for PayloadConfig {


### PR DESCRIPTION
MRCONFIGID is a parameter that allows users to specify or assign a sha384 hash value. This value is used to describe or represent the configuration information of a Trusted Domain (TD). It's embedded within the TD report and serves as a key measurement for verifying the TD's integrity and trustworthiness and can be provided for TDX attestation.

This patch instroduces a user configurable MRCONFIGID and allows user to specify value via property mrconfigid with fixed base64 format.

During guest launch, mrconfigid is provided via the hypervisor. This data is securely passed during isolated import completion and then incorporated by the firmware into all guest attestation reports.