### PR TITLE
 vmm: config: Add DiskConfig check for device serial length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2472,6 +2472,7 @@ dependencies = [
  "uuid",
  "vfio-ioctls",
  "vfio_user",
+ "virtio-bindings",
  "virtio-devices",
  "virtio-queue",
  "vm-allocator",

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -71,6 +71,7 @@ tracer = { path = "../tracer" }
 uuid = "1.12.1"
 vfio-ioctls = { workspace = true, default-features = false }
 vfio_user = { workspace = true }
+virtio-bindings = { workspace = true }
 virtio-devices = { path = "../virtio-devices" }
 virtio-queue = { workspace = true }
 vm-allocator = { path = "../vm-allocator" }


### PR DESCRIPTION
When starting a VM with a disk serial specified, for example:

```
--disk path=focal-server-cloudimg-amd64-custom.raw,serial=aabbccfjdlsdkjfkldsjlkfjdsklfjdslkjflsdk
```
The VM fails to boot and the following log is observed:
```
cloud-hypervisor: 1.041609s: <_disk0_q0> ERROR:virtio-devices/src/thread_helper.rs:53 -- Error running worker: HandleEvent(Failed to process queue (submit): RequestExecuting(BadRequest(InvalidOffset)))
```
This patch adds support for checking and truncating disk custom serial to avoid VM startup failures.