### PR TITLE
misc: replace manual `From<T>` for `*Error` with `#[from]`

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -56,12 +56,6 @@ pub enum Error {
     VcpuInitPmu,
 }
 
-impl From<Error> for super::Error {
-    fn from(e: Error) -> super::Error {
-        super::Error::PlatformSpecific(e)
-    }
-}
-
 #[derive(Debug, Copy, Clone)]
 /// Specifies the entry point address where the guest must start
 /// executing code.

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -29,13 +29,13 @@ type GuestRegionMmap = vm_memory::GuestRegionMmap<vm_memory::bitmap::AtomicBitma
 pub enum Error {
     #[cfg(target_arch = "x86_64")]
     #[error("Platform specific error (x86_64): {0}")]
-    PlatformSpecific(#[source] x86_64::Error),
+    PlatformSpecific(#[from] x86_64::Error),
     #[cfg(target_arch = "aarch64")]
     #[error("Platform specific error (aarch64): {0:?}")]
-    PlatformSpecific(#[source] aarch64::Error),
+    PlatformSpecific(#[from] aarch64::Error),
     #[cfg(target_arch = "riscv64")]
     #[error("Platform specific error (riscv64): {0:?}")]
-    PlatformSpecific(#[source] riscv64::Error),
+    PlatformSpecific(#[from] riscv64::Error),
     #[error("The memory map table extends past the end of guest memory")]
     MemmapTablePastRamEnd,
     #[error("Error writing memory map table to guest memory")]

--- a/arch/src/riscv64/mod.rs
+++ b/arch/src/riscv64/mod.rs
@@ -46,12 +46,6 @@ pub enum Error {
     RegsConfiguration(#[source] hypervisor::HypervisorCpuError),
 }
 
-impl From<Error> for super::Error {
-    fn from(e: Error) -> super::Error {
-        super::Error::PlatformSpecific(e)
-    }
-}
-
 #[derive(Debug, Copy, Clone)]
 /// Specifies the entry point address where the guest must start
 /// executing code.

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -209,12 +209,6 @@ pub enum Error {
     E820Configuration,
 }
 
-impl From<Error> for super::Error {
-    fn from(e: Error) -> super::Error {
-        super::Error::PlatformSpecific(e)
-    }
-}
-
 pub fn get_x2apic_id(cpu_id: u32, topology: Option<(u8, u8, u8)>) -> u32 {
     if let Some(t) = topology {
         let thread_mask_width = u8::BITS - (t.0 - 1).leading_zeros();

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -25,15 +25,9 @@ enum Error {
     #[error("boot time could not be parsed")]
     BootTimeParse,
     #[error("infrastructure failure: {0}")]
-    Infra(#[source] InfraError),
+    Infra(#[from] InfraError),
     #[error("restore time could not be parsed")]
     RestoreTimeParse,
-}
-
-impl From<InfraError> for Error {
-    fn from(e: InfraError) -> Self {
-        Self::Infra(e)
-    }
 }
 
 const BLK_IO_TEST_IMG: &str = "/var/tmp/ch-blk-io-test.img";

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -40,7 +40,7 @@ pub enum Error {
     #[error("Failed to parse: {0}")]
     Parsing(#[source] std::num::ParseIntError),
     #[error("ssh command failed: {0}")]
-    SshCommand(#[source] SshCommandError),
+    SshCommand(#[from] SshCommandError),
     #[error("waiting for boot failed: {0}")]
     WaitForBoot(#[source] WaitForBootError),
     #[error("reading log file failed: {0}")]
@@ -55,12 +55,6 @@ pub enum Error {
     Spawn(#[source] std::io::Error),
     #[error("waiting for timeout failed: {0}")]
     WaitTimeout(#[source] WaitTimeoutError),
-}
-
-impl From<SshCommandError> for Error {
-    fn from(e: SshCommandError) -> Self {
-        Self::SshCommand(e)
-    }
 }
 
 pub struct GuestNetworkConfig {

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -44,7 +44,7 @@ pub type HttpApiHandle = (thread::JoinHandle<Result<()>>, EventFd);
 pub enum HttpError {
     /// API request receive error
     #[error("Failed to deserialize JSON: {0}")]
-    SerdeJsonDeserialize(#[source] SerdeError),
+    SerdeJsonDeserialize(#[from] SerdeError),
 
     /// Attempt to access unsupported HTTP method
     #[error("Bad Request")]
@@ -65,12 +65,6 @@ pub enum HttpError {
     /// Error from internal API
     #[error("Error from API: {0}")]
     ApiError(#[source] ApiError),
-}
-
-impl From<serde_json::Error> for HttpError {
-    fn from(e: serde_json::Error) -> Self {
-        HttpError::SerdeJsonDeserialize(e)
-    }
 }
 
 const HTTP_ROOT: &str = "/api/v1";


### PR DESCRIPTION
This is a small simplification we can use since we use `thiserror` anyway. Note that `#[from]` implies `#[source]` [0].

[0]: https://docs.rs/thiserror/2.0.12/thiserror/index.html

