### PR TITLE
ci: Update reference kernel to 'v6.12.8-20250613'

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -137,7 +137,7 @@ update_workloads() {
     mkdir -p "$FOCAL_OS_RAW_IMAGE_UPDATE_KERNEL_ROOT_DIR"
     # Mount the 'raw' image, replace the compressed kernel file and umount the working folder
     guestmount -a "$WORKLOADS_DIR/$FOCAL_OS_RAW_IMAGE_UPDATE_KERNEL_NAME" -m /dev/sda1 "$FOCAL_OS_RAW_IMAGE_UPDATE_KERNEL_ROOT_DIR" || exit 1
-    cp "$WORKLOADS_DIR"/Image.gz "$FOCAL_OS_RAW_IMAGE_UPDATE_KERNEL_ROOT_DIR"/boot/vmlinuz
+    cp "$WORKLOADS_DIR"/Image-arm64.gz "$FOCAL_OS_RAW_IMAGE_UPDATE_KERNEL_ROOT_DIR"/boot/vmlinuz
     guestunmount "$FOCAL_OS_RAW_IMAGE_UPDATE_KERNEL_ROOT_DIR"
 
     # Build virtiofsd

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -54,7 +54,7 @@ chmod +x $CH_RELEASE_NAME
 popd || exit
 
 # Build custom kernel based on virtio-pmem and virtio-fs upstream patches
-VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
+VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux-x86_64"
 if [ ! -f "$VMLINUX_IMAGE" ]; then
     # Prepare linux image (build from source or download pre-built)
     prepare_linux

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -100,7 +100,7 @@ fi
 popd || exit
 
 # Build custom kernel based on virtio-pmem and virtio-fs upstream patches
-VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
+VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux-x86_64"
 if [ ! -f "$VMLINUX_IMAGE" ]; then
     # Prepare linux image (build from source or download pre-built)
     prepare_linux

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -x
+
 hypervisor="kvm"
 test_filter=""
 build_kernel=false
@@ -56,11 +58,11 @@ build_custom_linux() {
     make ch_defconfig
     make -j "$(nproc)"
     if [ "${ARCH}" == "x86_64" ]; then
-        cp vmlinux "$WORKLOADS_DIR/" || exit 1
-        cp arch/x86/boot/bzImage "$WORKLOADS_DIR/" || exit 1
+        cp vmlinux "$WORKLOADS_DIR/vmlinux-x86_64" || exit 1
+        cp arch/x86/boot/bzImage "$WORKLOADS_DIR/bzImage-x86_64" || exit 1
     elif [ "${ARCH}" == "aarch64" ]; then
-        cp arch/arm64/boot/Image "$WORKLOADS_DIR/" || exit 1
-        cp arch/arm64/boot/Image.gz "$WORKLOADS_DIR/" || exit 1
+        cp arch/arm64/boot/Image "$WORKLOADS_DIR/Image-arm64" || exit 1
+        cp arch/arm64/boot/Image.gz "$WORKLOADS_DIR/Image-arm64.gz" || exit 1
     fi
     popd || exit
 }
@@ -138,7 +140,7 @@ download_hypervisor_fw() {
 }
 
 download_linux() {
-    KERNEL_TAG="ch-release-v6.12.8-20250114"
+    KERNEL_TAG="ch-release-v6.12.8-20250613"
     if [ -n "$AUTH_DOWNLOAD_TOKEN" ]; then
         echo "Using authenticated download from GitHub"
         KERNEL_URLS=$(curl --silent https://api.github.com/repos/cloud-hypervisor/linux/releases/tags/${KERNEL_TAG} \

--- a/test_data/cloud-init/ubuntu/ci/user-data
+++ b/test_data/cloud-init/ubuntu/ci/user-data
@@ -47,7 +47,7 @@ write_files:
         # 1G ram requires 512 pages
         echo 512 | sudo tee /proc/sys/vm/nr_hugepages
         sudo chmod a+rwX /dev/hugepages
-        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules root=/dev/vda1 VFIOTAG" --disk path=/mnt/focal-server-cloudimg-amd64-custom-20210609-0.raw path=/mnt/cloudinit.img --cpus boot=1 --memory size=512M,hotplug_size=1G,hugepages=on --device path=/sys/bus/pci/devices/0000:00:05.0/ path=/sys/bus/pci/devices/0000:00:07.0/ path=/sys/bus/pci/devices/0000:00:08.0/ --api-socket=/tmp/ch_api.sock
+        /mnt/cloud-hypervisor --kernel /mnt/vmlinux-x86_64 --cmdline "console=hvc0 reboot=k panic=1 nomodules root=/dev/vda1 VFIOTAG" --disk path=/mnt/focal-server-cloudimg-amd64-custom-20210609-0.raw path=/mnt/cloudinit.img --cpus boot=1 --memory size=512M,hotplug_size=1G,hugepages=on --device path=/sys/bus/pci/devices/0000:00:05.0/ path=/sys/bus/pci/devices/0000:00:07.0/ path=/sys/bus/pci/devices/0000:00:08.0/ --api-socket=/tmp/ch_api.sock
 
   -
     path: /etc/systemd/system/notify-booted.service

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -533,9 +533,9 @@ fn direct_kernel_boot_path() -> PathBuf {
 
     let mut kernel_path = workload_path;
     #[cfg(target_arch = "x86_64")]
-    kernel_path.push("vmlinux");
+    kernel_path.push("vmlinux-x86_64");
     #[cfg(target_arch = "aarch64")]
-    kernel_path.push("Image");
+    kernel_path.push("Image-arm64");
 
     kernel_path
 }
@@ -3180,7 +3180,7 @@ mod common_parallel {
         let mut kernel_path = direct_kernel_boot_path();
         // Replace the default kernel with the bzImage.
         kernel_path.pop();
-        kernel_path.push("bzImage");
+        kernel_path.push("bzImage-x86_64");
 
         let mut child = GuestCommand::new(&guest)
             .args(["--cpus", "boot=1"])
@@ -6045,7 +6045,7 @@ mod common_parallel {
         #[cfg(target_arch = "x86_64")]
         {
             let mut pvh_kernel_path = workload_path.clone();
-            pvh_kernel_path.push("vmlinux");
+            pvh_kernel_path.push("vmlinux-x86_64");
             kernels.push(pvh_kernel_path);
         }
 


### PR DESCRIPTION
This bump also includes another release 'ch-release-v6.12.8-20250422' which
changed the naming convention of the released kernel binaries [1]. As a result,
few changes are made to our integration tests and test scripts.

[1] https://github.com/cloud-hypervisor/linux/releases/tag/ch-release-v6.12.8-20250422