### PR TITLE
hypervisor: mshv: Make changes to dirty bit atomic

### DIFF
--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1714,8 +1714,8 @@ impl MshvVcpu {
             // SAFETY: access raw pointer to reg page, access union fields
             unsafe {
                 (*vp_reg_page).__bindgen_anon_1.__bindgen_anon_1.rip = info.header.rip + insn_len;
-                (*vp_reg_page).dirty |= 1 << HV_X64_REGISTER_CLASS_IP;
-                (*vp_reg_page).dirty |= 1 << HV_X64_REGISTER_CLASS_GENERAL;
+                (*vp_reg_page).dirty |=
+                    1 << HV_X64_REGISTER_CLASS_IP | 1 << HV_X64_REGISTER_CLASS_GENERAL;
             }
         } else {
             let arr_reg_name_value = [


### PR DESCRIPTION
There are chances that it can race with fast interrupt injection
feature. Since both of them are using the same register page to provide
the functionality. Thus, make the changes atomic to make sure that both
IP and RAX registers are update by the hypervisor simultaneously.

Fixes: 59e11f1b0b (hypervisor: mshv: fix advance_rip_update_rax() helper)
Fixes: f67484a714 (hypervisor: mshv: advance_rip_rax after port handle)