### PR TITLE
Fix cargo fuzz compiler errors

### DIFF
--- a/block/src/async_io.rs
+++ b/block/src/async_io.rs
@@ -65,7 +65,7 @@ pub trait DiskFile: Send {
     ///
     /// The file descriptor is supposed to be used for `fcntl()` calls but no
     /// other operation.
-    fn fd(&mut self) -> BorrowedDiskFd;
+    fn fd(&mut self) -> BorrowedDiskFd<'_>;
 }
 
 #[derive(Error, Debug)]

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -744,7 +744,7 @@ where
         Ok(())
     }
 
-    fn file(&mut self) -> MutexGuard<F>;
+    fn file(&mut self) -> MutexGuard<'_, F>;
 }
 
 pub enum ImageType {


### PR DESCRIPTION
Cargo fuzz build report an error:
error: lifetime flowing from input to output with different syntax can be confusing
   --> /home/runner/work/cloud-hypervisor/cloud-hypervisor/block/src/lib.rs:747:13
    |
747 |     fn file(&mut self) -> MutexGuard<F>;
    |             ^^^^^^^^^     ------------- the lifetime gets resolved as `'_`
    |             |
    |             this lifetime flows to the output

error: lifetime flowing from input to output with different syntax can be confusing
  --> /home/runner/work/cloud-hypervisor/cloud-hypervisor/block/src/async_io.rs:68:11
   |
68 |     fn fd(&mut self) -> BorrowedDiskFd;
   |           ^^^^^^^^^     -------------- the lifetime gets resolved as `'_`
   |           |
   |           this lifetime flows to the output