### PR TITLE
misc: add __pycache__ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /rpm/SOURCES
 /.vscode
 /vendor
+__pycache__


### PR DESCRIPTION
Running `gitlint` locally produces a `__pycache__` directory in `scripts/gitlint/rules/`. It makes sense to exclude this directory.

