### PR TITLE
[WIP] vmm: add more verbosity to network device creation

### DIFF
--- a/net_util/src/open_tap.rs
+++ b/net_util/src/open_tap.rs
@@ -89,6 +89,14 @@ pub fn open_tap(
                 Some(name) => Tap::open_named(name, num_rx_q, flags).map_err(Error::TapOpen)?,
                 None => Tap::new(num_rx_q).map_err(Error::TapOpen)?,
             };
+
+            if if_name.is_none() {
+                log::info!(
+                    "Created tap device: name={}, num_rx_q={num_rx_q}",
+                    std::str::from_utf8(tap.get_if_name()).expect("should be valid utf-8")
+                );
+            }
+
             // Don't overwrite ip configuration of existing interfaces:
             if !tap_existed {
                 if let Some(ip) = ip_addr {

--- a/net_util/src/open_tap.rs
+++ b/net_util/src/open_tap.rs
@@ -114,7 +114,7 @@ pub fn open_tap(
             tap.set_vnet_hdr_size(vnet_hdr_size)
                 .map_err(Error::TapSetVnetHdrSize)?;
 
-            ifname = String::from_utf8(tap.get_if_name()).unwrap();
+            ifname = String::from_utf8(tap.get_if_name().to_vec()).unwrap();
         } else {
             tap = Tap::open_named(ifname.as_str(), num_rx_q, flags).map_err(Error::TapOpen)?;
 

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -471,8 +471,8 @@ impl Tap {
         ifreq
     }
 
-    pub fn get_if_name(&self) -> Vec<u8> {
-        self.if_name.clone()
+    pub fn get_if_name(&self) -> &[u8] {
+        &self.if_name
     }
 
     #[cfg(fuzzing)]

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -122,6 +122,9 @@ fn ipv6_mask_to_prefix(mask: Ipv6Addr) -> Result<u8> {
 }
 
 impl Tap {
+    /// The default naming scheme for Tap devices that are created by Cloud Hypervisor.
+    pub const DEFAULT_NAME_SCHEME: &'static str = "vmtap%d";
+
     unsafe fn ioctl_with_mut_ref<F: AsRawFd, T>(fd: &F, req: c_ulong, arg: &mut T) -> Result<()> {
         let ret = ioctl_with_mut_ref(fd, req, arg);
         if ret < 0 {
@@ -217,7 +220,7 @@ impl Tap {
 
     /// Create a new tap interface.
     pub fn new(num_queue_pairs: usize) -> Result<Tap> {
-        Self::open_named("vmtap%d", num_queue_pairs, None)
+        Self::open_named(Self::DEFAULT_NAME_SCHEME, num_queue_pairs, None)
     }
 
     pub fn from_tap_fd(fd: RawFd, num_queue_pairs: usize) -> Result<Tap> {

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -661,6 +661,24 @@ impl Net {
 
 impl Drop for Net {
     fn drop(&mut self) {
+        // Get a comma-separated list of the interface names of the tap devices
+        // associated with this network device.
+        let ifnames_str = self
+            .taps
+            .iter()
+            .map(|tap| std::str::from_utf8(tap.get_if_name()).expect("should be valid utf-8"))
+            .fold(String::new(), |mut acc, elem| {
+                if !acc.is_empty() {
+                    acc.push(',');
+                }
+                acc.push_str(elem);
+                acc
+            });
+        debug!(
+            "virtio-network device dropped: id={}, ifnames=[{ifnames_str}]",
+            self.id
+        );
+
         if let Some(kill_evt) = self.common.kill_evt.take() {
             // Ignore the result because there is nothing we can do about it.
             let _ = kill_evt.write(1);

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2780,6 +2780,7 @@ impl DeviceManager {
 
         let (virtio_device, migratable_device) = if net_cfg.vhost_user {
             let socket = net_cfg.vhost_socket.as_ref().unwrap().clone();
+            debug!("Creating virtio-net device with vhost-user backend: {socket}");
             let vu_cfg = VhostUserConfig {
                 socket,
                 num_queues: net_cfg.num_queues,
@@ -2822,6 +2823,7 @@ impl DeviceManager {
             let state = state_from_id(self.snapshot.as_ref(), id.as_str())
                 .map_err(DeviceManagerError::RestoreGetState)?;
             let virtio_net = if let Some(ref tap_if_name) = net_cfg.tap {
+                debug!("Creating virtio-net device from Tap device: {tap_if_name}");
                 Arc::new(Mutex::new(
                     virtio_devices::Net::new(
                         id.clone(),
@@ -2847,6 +2849,7 @@ impl DeviceManager {
                     .map_err(DeviceManagerError::CreateVirtioNet)?,
                 ))
             } else if let Some(fds) = &net_cfg.fds {
+                debug!("Creating virtio-net device from network FDs: {fds:?}");
                 let net = virtio_devices::Net::from_tap_fds(
                     id.clone(),
                     fds,
@@ -2873,6 +2876,9 @@ impl DeviceManager {
 
                 Arc::new(Mutex::new(net))
             } else {
+                debug!(
+                    "Creating virtio-net device: no ifname or FDs given, creating new Tap device"
+                );
                 Arc::new(Mutex::new(
                     virtio_devices::Net::new(
                         id.clone(),


### PR DESCRIPTION
There are multiple ways to create virtio-net devices:
- with vhost-user backend
- from provided network FDs
- from provided interface name of Tap device is given
- Tap device is created by CHV (fallback)

To ease debugging of networking in the field, especially in context of
libvirt, state save/resume, and live-migration, these logging helps to
identify what happens behind the scenes in certain corner-cases as well
as (apparently) normal operation.

# Steps to Undraft
- [ ] Finalize what is worth logging.