### PR TITLE
misc: remove once_cell; superseded by std::*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,6 @@ dependencies = [
  "libc",
  "log",
  "net_util",
- "once_cell",
  "option_parser",
  "seccompiler",
  "serde_json",
@@ -686,7 +685,6 @@ version = "0.1.0"
 dependencies = [
  "flume",
  "libc",
- "once_cell",
  "serde",
  "serde_json",
 ]
@@ -1256,7 +1254,6 @@ dependencies = [
  "libc",
  "log",
  "net_gen",
- "once_cell",
  "pnet",
  "pnet_datalink",
  "rate_limiter",
@@ -2028,7 +2025,6 @@ dependencies = [
  "dirs",
  "epoll",
  "libc",
- "once_cell",
  "serde",
  "serde_json",
  "ssh2",
@@ -2119,7 +2115,6 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "log",
- "once_cell",
  "serde",
  "serde_json",
 ]
@@ -2457,7 +2452,6 @@ dependencies = [
  "micro_http",
  "mshv-bindings",
  "net_util",
- "once_cell",
  "option_parser",
  "pci",
  "range_map_vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ zbus = { version = "5.7.1", optional = true }
 [dev-dependencies]
 dirs = "6.0.0"
 net_util = { path = "net_util" }
-once_cell = "1.20.2"
 serde_json = { workspace = true }
 test_infra = { path = "test_infra" }
 wait-timeout = "0.2.0"

--- a/event_monitor/Cargo.toml
+++ b/event_monitor/Cargo.toml
@@ -7,6 +7,5 @@ version = "0.1.0"
 [dependencies]
 flume = "0.11.1"
 libc = "0.2.167"
-once_cell = "1.20.2"
 serde = { version = "1.0.208", features = ["derive", "rc"] }
 serde_json = { workspace = true }

--- a/event_monitor/src/lib.rs
+++ b/event_monitor/src/lib.rs
@@ -8,13 +8,12 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io;
 use std::os::unix::io::AsRawFd;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
-use once_cell::sync::OnceCell;
 use serde::Serialize;
 
-static MONITOR: OnceCell<MonitorHandle> = OnceCell::new();
+static MONITOR: OnceLock<MonitorHandle> = OnceLock::new();
 
 #[derive(Serialize)]
 struct Event<'a> {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -217,7 +217,6 @@ dependencies = [
  "micro_http",
  "mshv-bindings",
  "net_util",
- "once_cell",
  "seccompiler",
  "virtio-devices",
  "virtio-queue",
@@ -362,7 +361,6 @@ version = "0.1.0"
 dependencies = [
  "flume",
  "libc",
- "once_cell",
  "serde",
  "serde_json",
 ]
@@ -1089,7 +1087,6 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "log",
- "once_cell",
  "serde",
  "serde_json",
 ]
@@ -1316,7 +1313,6 @@ dependencies = [
  "log",
  "micro_http",
  "net_util",
- "once_cell",
  "option_parser",
  "pci",
  "rate_limiter",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,7 +26,6 @@ linux-loader = { version = "0.13.0", features = ["bzimage", "elf", "pe"] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 mshv-bindings = "0.5.0"
 net_util = { path = "../net_util" }
-once_cell = "1.19.0"
 seccompiler = "0.5.0"
 virtio-devices = { path = "../virtio-devices" }
 virtio-queue = "0.14.0"

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -6,11 +6,11 @@
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver};
+use std::sync::LazyLock;
 use std::thread;
 
 use libfuzzer_sys::{fuzz_target, Corpus};
 use micro_http::Request;
-use once_cell::sync::Lazy;
 use vm_migration::MigratableError;
 use vmm::api::http::*;
 use vmm::api::{
@@ -24,8 +24,8 @@ use vmm::{EpollContext, EpollDispatch};
 use vmm_sys_util::eventfd::EventFd;
 
 // Need to be ordered for test case reproducibility
-static ROUTES: Lazy<Vec<&Box<dyn EndpointHandler + Sync + Send>>> =
-    Lazy::new(|| HTTP_ROUTES.routes.values().collect());
+static ROUTES: LazyLock<Vec<&Box<dyn EndpointHandler + Sync + Send>>> =
+    LazyLock::new(|| HTTP_ROUTES.routes.values().collect());
 
 fuzz_target!(|bytes: &[u8]| -> Corpus {
     if bytes.len() < 2 {

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -24,7 +24,6 @@ vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { workspace = true }
 
 [dev-dependencies]
-once_cell = "1.20.2"
 pnet = "0.35.0"
 pnet_datalink = "0.35.0"
 serde_json = { workspace = true }

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -506,11 +506,10 @@ impl AsRawFd for Tap {
 #[cfg(test)]
 mod tests {
     use std::net::Ipv4Addr;
-    use std::sync::{mpsc, Mutex};
+    use std::sync::{mpsc, LazyLock, Mutex};
     use std::time::Duration;
     use std::{str, thread};
 
-    use once_cell::sync::Lazy;
     use pnet::packet::ethernet::{EtherTypes, EthernetPacket, MutableEthernetPacket};
     use pnet::packet::ip::IpNextHeaderProtocols;
     use pnet::packet::ipv4::{Ipv4Packet, MutableIpv4Packet};
@@ -525,13 +524,14 @@ mod tests {
     static DATA_STRING: &str = "test for tap";
     static SUBNET_MASK: &str = "255.255.255.0";
 
-    // We needed to have a mutex as a global variable, so we used once_cell for testing. The main
+    // We needed to have a mutex as a global variable, so we use a once cell for testing. The main
     // potential problem, caused by tests being run in parallel by cargo, is creating different
     // TAPs and trying to associate the same address, so we hide the IP address &str behind this
     // mutex, more as a convention to remember to lock it at the very beginning of each function
     // susceptible to this issue. Another variant is to use a different IP address per function,
     // but we must remember to pick an unique one each time.
-    static TAP_IP_LOCK: Lazy<Mutex<&'static str>> = Lazy::new(|| Mutex::new("192.168.241.1"));
+    static TAP_IP_LOCK: LazyLock<Mutex<&'static str>> =
+        LazyLock::new(|| Mutex::new("192.168.241.1"));
 
     // Describes the outcomes we are currently interested in when parsing a packet (we use
     // an UDP packet for testing).

--- a/test_infra/Cargo.toml
+++ b/test_infra/Cargo.toml
@@ -8,7 +8,6 @@ version = "0.1.0"
 dirs = "6.0.0"
 epoll = "4.3.3"
 libc = "0.2.167"
-once_cell = "1.20.2"
 serde = { version = "1.0.208", features = ["derive", "rc"] }
 serde_json = { workspace = true }
 ssh2 = { version = "0.9.4", features = ["vendored-openssl"] }

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -14,11 +14,10 @@ use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::path::Path;
 use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::str::FromStr;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 use std::{env, fmt, fs, io, thread};
 
-use once_cell::sync::Lazy;
 use serde_json::Value;
 use ssh2::Session;
 use thiserror::Error;
@@ -842,7 +841,7 @@ pub fn kill_child(child: &mut Child) {
 
 pub const PIPE_SIZE: i32 = 32 << 20;
 
-static NEXT_VM_ID: Lazy<Mutex<u8>> = Lazy::new(|| Mutex::new(1));
+static NEXT_VM_ID: LazyLock<Mutex<u8>> = LazyLock::new(|| Mutex::new(1));
 
 pub struct Guest {
     pub tmp_dir: TempDir,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7981,11 +7981,11 @@ mod common_sequential {
 }
 
 mod windows {
-    use once_cell::sync::Lazy;
+    use std::sync::LazyLock;
 
     use crate::*;
 
-    static NEXT_DISK_ID: Lazy<Mutex<u8>> = Lazy::new(|| Mutex::new(1));
+    static NEXT_DISK_ID: LazyLock<Mutex<u8>> = LazyLock::new(|| Mutex::new(1));
 
     struct WindowsGuest {
         guest: Guest,

--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 [dependencies]
 libc = "0.2.167"
 log = "0.4.22"
-once_cell = "1.20.2"
 serde = { version = "1.0.208", features = ["derive", "rc"] }
 serde_json = { workspace = true }
 

--- a/tracer/src/tracer.rs
+++ b/tracer/src/tracer.rs
@@ -5,6 +5,7 @@
 
 #![allow(static_mut_refs)]
 
+use std::cell::OnceCell;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
@@ -12,7 +13,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use once_cell::unsync::OnceCell;
 use serde::Serialize;
 
 #[derive(Debug)]

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -56,7 +56,6 @@ mshv-bindings = { workspace = true, features = [
   "with-serde",
 ], optional = true }
 net_util = { path = "../net_util" }
-once_cell = "1.20.2"
 option_parser = { path = "../option_parser" }
 pci = { path = "../pci" }
 range_map_vec = { version = "0.2.0", optional = true }

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -11,13 +11,13 @@ use std::os::unix::net::UnixListener;
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::mpsc::Sender;
+use std::sync::LazyLock;
 use std::thread;
 
 use hypervisor::HypervisorType;
 use micro_http::{
     Body, HttpServer, MediaType, Method, Request, Response, ServerError, StatusCode, Version,
 };
-use once_cell::sync::Lazy;
 use seccompiler::{apply_filter, SeccompAction};
 use serde_json::Error as SerdeError;
 use thiserror::Error;
@@ -173,7 +173,7 @@ macro_rules! endpoint {
 }
 
 /// HTTP_ROUTES contain all the cloud-hypervisor HTTP routes.
-pub static HTTP_ROUTES: Lazy<HttpRoutes> = Lazy::new(|| {
+pub static HTTP_ROUTES: LazyLock<HttpRoutes> = LazyLock::new(|| {
     let mut r = HttpRoutes {
         routes: BTreeMap::new(),
     };


### PR DESCRIPTION
We now have types in the Rust standard library.
Dropping the dependency.

