### PR TITLE
block: Add back UUID crate's `v4` feature

### DIFF
--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -18,7 +18,7 @@ remain = "0.2.15"
 serde = { version = "1.0.208", features = ["derive"] }
 smallvec = "1.13.2"
 thiserror = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 virtio-bindings = { workspace = true, features = ["virtio-v5_0_0"] }
 virtio-queue = { workspace = true }
 vm-memory = { workspace = true, features = [


### PR DESCRIPTION
That feature was dropped when consolidating the UUID dependency because somehow building the whole project worked. The CI system was happy.

However, building the block crate alone is broken. The vhdx code uses Uuid::new_v4, which requires `v4` to be enabled.

Add the feature back.