### PR TITLE
vmm, ch-remote: add env_logger, replace eprintln! with error! for consistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,7 @@ dependencies = [
  "clap",
  "dhat",
  "dirs",
+ "env_logger",
  "epoll",
  "event_monitor",
  "hypervisor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,14 +621,14 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.3"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime",
+ "jiff",
  "log",
 ]
 
@@ -901,12 +901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hypervisor"
 version = "0.1.0"
 dependencies = [
@@ -1029,6 +1023,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -1624,6 +1642,21 @@ dependencies = [
  "rustix 0.38.44",
  "tracing",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ igvm_defs = { git = "https://github.com/microsoft/igvm", branch = "main" }
 serde_json = "1.0.120"
 
 # other crates
+env_logger = "0.11.8"
 thiserror = "2.0.12"
 uuid = { version = "1.17.0" }
 zerocopy = { version = "0.8.26", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ anyhow = "1.0.94"
 api_client = { path = "api_client" }
 clap = { version = "4.5.13", features = ["string"] }
 dhat = { version = "0.3.3", optional = true }
+env_logger = { workspace = true }
 epoll = "4.3.3"
 event_monitor = { path = "event_monitor" }
 hypervisor = { path = "hypervisor" }

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -62,4 +62,4 @@ optional = true
 version = "1.21.0"
 
 [dev-dependencies]
-env_logger = "0.11.3"
+env_logger = { workspace = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 
 use std::error::Error;
 
+use log::error;
+
 /// Prints a chain of errors to the user in a consistent manner.
 /// The user will see a clear chain of errors, followed by debug output
 /// for opening issues.
@@ -19,10 +21,10 @@ pub fn cli_print_error_chain<'a>(
 ) {
     eprint!("Error: {component} exited with the following ");
     if top_error.source().is_none() {
-        eprintln!("error:");
-        eprintln!("  {top_error}");
+        error!("error:");
+        error!("  {top_error}");
     } else {
-        eprintln!("chain of errors:");
+        error!("chain of errors:");
         std::iter::successors(Some(top_error), |sub_error| {
             // Dereference necessary to mitigate rustc compiler bug.
             // See <https://github.com/rust-lang/rust/issues/141673>
@@ -32,13 +34,13 @@ pub fn cli_print_error_chain<'a>(
         .for_each(|(level, error)| {
             // Special case: handling of HTTP Server responses in ch-remote
             if let Some(message) = display_modifier(level, 2, error) {
-                eprintln!("{message}");
+                error!("{message}");
             } else {
-                eprintln!("  {level}: {error}");
+                error!("  {level}: {error}");
             }
         });
     }
 
-    eprintln!();
-    eprintln!("Debug Info: {top_error:?}");
+    error!("");
+    error!("Debug Info: {top_error:?}");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::{env, io};
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches, Command};
 use event_monitor::event;
 use libc::EFD_NONBLOCK;
-use log::{warn, LevelFilter};
+use log::{error, warn, LevelFilter};
 use option_parser::OptionParser;
 use seccompiler::SeccompAction;
 use signal_hook::consts::SIGSYS;
@@ -561,7 +561,7 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
                 signal_hook::low_level::emulate_default_handler(SIGSYS).unwrap();
             })
         }
-        .map_err(|e| eprintln!("Error adding SIGSYS signal handler: {e}"))
+        .map_err(|e| error!("Error adding SIGSYS signal handler: {e}"))
         .ok();
     }
 
@@ -575,13 +575,13 @@ fn start_vmm(cmd_arguments: ArgMatches) -> Result<Option<String>, Error> {
     // dedicated signal handling thread we'll start in a bit.
     for sig in &vmm::vm::Vm::HANDLED_SIGNALS {
         if let Err(e) = block_signal(*sig) {
-            eprintln!("Error blocking signals: {e}");
+            error!("Error blocking signals: {e}");
         }
     }
 
     for sig in &vmm::Vmm::HANDLED_SIGNALS {
         if let Err(e) = block_signal(*sig) {
-            eprintln!("Error blocking signals: {e}");
+            error!("Error blocking signals: {e}");
         }
     }
 

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 [dependencies]
 block = { path = "../block" }
 clap = { version = "4.5.13", features = ["cargo", "wrap_help"] }
-env_logger = "0.11.3"
+env_logger = { workspace = true }
 epoll = "4.3.3"
 libc = "0.2.167"
 log = "0.4.22"

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 clap = { version = "4.5.13", features = ["cargo", "wrap_help"] }
-env_logger = "0.11.3"
+env_logger = { workspace = true }
 epoll = "4.3.3"
 libc = "0.2.167"
 log = "0.4.22"

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -348,7 +348,7 @@ pub fn start_net_backend(backend_command: &str) {
     let backend_config = match VhostUserNetBackendConfig::parse(backend_command) {
         Ok(config) => config,
         Err(e) => {
-            eprintln!("Failed parsing parameters {e:?}");
+            error!("Failed parsing parameters {e:?}");
             process::exit(1);
         }
     };


### PR DESCRIPTION
In https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7179#issuecomment-3044911791 we discovered that `ch-remote` does not print any log lines generated via `log::level!`.
This PR aims to add `env_logger` to log them.

Furthermore, replace `eprintln!` with `log::error!` as they would be used alongside each other.
When using `env_logger`, messages printed "in between" with `eprintln!` lack proper formatting/colors.
This is currently only relevant in `ch-remote` + `cli_print_error_chain`.

Note that replaced messages now end up in `cloud-hypervisor`'s logfile when configured, rather than stderr.