### PR TITLE
vsock: Fix vsock connection failure after restore

### DIFF
--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -516,7 +516,10 @@ where
     }
 
     fn snapshot(&mut self) -> std::result::Result<Snapshot, MigratableError> {
-        Snapshot::new_from_state(&self.state())
+        let mut snapshot = Snapshot::new_from_state(&self.state())?;
+        let mut backend = self.backend.write().unwrap();
+        snapshot.add_snapshot(backend.id(), backend.snapshot()?);
+        Ok(snapshot)
     }
 }
 impl<B> Transportable for Vsock<B> where B: VsockBackend + Sync + 'static {}


### PR DESCRIPTION
virtio-devices: Fix vsock connection failure after restore

We take a snapshot when the vsock connection is not disconnected. After 
restoring, this connection will use a local port, which the vsock 
backend is not aware of. The new connection will fail to establish if a 
local port is assigned to this used port for the new connection at this 
time.
This patch saves the local ports to snapshot and we can get the 
usage of local ports before snapshot.

Fix: #7263

Signed-off-by: Songqian Li <sionli@tencent.com>