### PR TITLE
virtio-devices: remove unnecessary parentheses

### DIFF
--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -575,7 +575,7 @@ impl Request {
                         .get_mut(&domain_id)
                         .unwrap()
                         .mappings
-                        .retain(|&x, _| (x < req.virt_start || x > req.virt_end));
+                        .retain(|&x, _| x < req.virt_start || x > req.virt_end);
                 }
                 VIRTIO_IOMMU_T_PROBE => {
                     if desc_size_left != size_of::<VirtioIommuReqProbe>() {


### PR DESCRIPTION
Cargo fuzz build report an warning:

warning: unnecessary parentheses around closure body --> /mnt/dev-store/cloud-hypervisor/russell-islam/cloud-hypervisor/virtio-devices/src/iommu.rs:578:41 |
578 |                         .retain(|&x, _| (x < req.virt_start || x > req.virt_end));
|                                         ^                                      ^
|
= note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
|
578 -                         .retain(|&x, _| (x < req.virt_start || x > req.virt_end));
578 +                         .retain(|&x, _| x < req.virt_start || x > req.virt_end);
|

warning: `virtio-devices` (lib) generated 1 warning (run `cargo fix --lib -p virtio-devices` to apply 1 suggestion)