### PR TITLE
build: add missing dependency features

### DIFF
--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -6,8 +6,8 @@ version = "0.1.0"
 
 [features]
 default = []
-kvm = ["vfio-ioctls/kvm"]
-mshv = ["vfio-ioctls/mshv"]
+kvm = ["hypervisor/kvm", "vfio-ioctls/kvm"]
+mshv = ["hypervisor/mshv", "vfio-ioctls/mshv"]
 
 [dependencies]
 anyhow = "1.0.94"

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -6,6 +6,8 @@ version = "0.1.0"
 
 [features]
 default = []
+kvm = ["pci/kvm"]
+mshv = ["pci/mshv"]
 sev_snp = ["mshv-ioctls"]
 
 [dependencies]

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -16,9 +16,16 @@ kvm = [
   "hypervisor/kvm",
   "pci/kvm",
   "vfio-ioctls/kvm",
+  "virtio-devices/kvm",
   "vm-device/kvm",
 ]
-mshv = ["hypervisor/mshv", "pci/mshv", "vfio-ioctls/mshv", "vm-device/mshv"]
+mshv = [
+  "hypervisor/mshv",
+  "pci/mshv",
+  "vfio-ioctls/mshv",
+  "virtio-devices/mshv",
+  "vm-device/mshv",
+]
 pvmemcontrol = ["devices/pvmemcontrol"]
 sev_snp = ["arch/sev_snp", "hypervisor/sev_snp", "virtio-devices/sev_snp"]
 tdx = ["arch/tdx", "hypervisor/tdx"]


### PR DESCRIPTION
This makes it possible to run cargo test just for the virtio-devices crate (as long as either KVM or MSHV is specified).