### PR TITLE
build: Use workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,20 +29,20 @@ inherits = "release"
 strip = false
 
 [dependencies]
-anyhow = "1.0.94"
+anyhow = { workspace = true }
 api_client = { path = "api_client" }
-clap = { version = "4.5.13", features = ["string"] }
-dhat = { version = "0.3.3", optional = true }
+clap = { workspace = true, features = ["string"] }
+dhat = { workspace = true, optional = true }
 env_logger = { workspace = true }
-epoll = "4.3.3"
+epoll = { workspace = true }
 event_monitor = { path = "event_monitor" }
 hypervisor = { path = "hypervisor" }
-libc = "0.2.167"
-log = { version = "0.4.22", features = ["std"] }
+libc = { workspace = true }
+log = { workspace = true, features = ["std"] }
 option_parser = { path = "option_parser" }
 seccompiler = { workspace = true }
 serde_json = { workspace = true }
-signal-hook = "0.3.18"
+signal-hook = { workspace = true }
 thiserror = { workspace = true }
 tpm = { path = "tpm" }
 tracer = { path = "tracer" }
@@ -52,11 +52,11 @@ vmm-sys-util = { workspace = true }
 zbus = { version = "5.7.1", optional = true }
 
 [dev-dependencies]
-dirs = "6.0.0"
+dirs = { workspace = true }
 net_util = { path = "net_util" }
 serde_json = { workspace = true }
 test_infra = { path = "test_infra" }
-wait-timeout = "0.2.0"
+wait-timeout = { workspace = true }
 
 # Please adjust `vmm::feature_list()` accordingly when changing the
 # feature list below
@@ -127,10 +127,25 @@ igvm = { git = "https://github.com/microsoft/igvm", branch = "main" }
 igvm_defs = { git = "https://github.com/microsoft/igvm", branch = "main" }
 
 # serde crates
+serde = "1.0.208"
 serde_json = "1.0.120"
+serde_with = { version = "3.14.0", default-features = false }
 
 # other crates
+anyhow = "1.0.94"
+bitflags = "2.9.0"
+byteorder = "1.5.0"
+cfg-if = "1.0.0"
+clap = "4.5.13"
+dhat = "0.3.3"
+dirs = "6.0.0"
 env_logger = "0.11.8"
+epoll = "4.3.3"
+flume = "0.11.1"
+libc = "0.2.167"
+log = "0.4.22"
+signal-hook = "0.3.18"
 thiserror = "2.0.12"
 uuid = { version = "1.17.0" }
+wait-timeout = "0.2.0"
 zerocopy = { version = "0.8.26", default-features = false }

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -11,13 +11,13 @@ sev_snp = []
 tdx = []
 
 [dependencies]
-anyhow = "1.0.94"
-byteorder = "1.5.0"
+anyhow = { workspace = true }
+byteorder = { workspace = true }
 hypervisor = { path = "../hypervisor" }
-libc = "0.2.167"
+libc = { workspace = true }
 linux-loader = { workspace = true, features = ["bzimage", "elf", "pe"] }
-log = "0.4.22"
-serde = { version = "1.0.208", features = ["derive", "rc"] }
+log = { workspace = true }
+serde = { workspace = true, features = ["derive", "rc"] }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 vm-memory = { workspace = true, features = ["backend-bitmap", "backend-mmap"] }

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -9,13 +9,13 @@ default = []
 io_uring = ["dep:io-uring"]
 
 [dependencies]
-byteorder = "1.5.0"
+byteorder = { workspace = true }
 crc-any = "2.5.0"
 io-uring = { version = "0.6.4", optional = true }
-libc = "0.2.167"
-log = "0.4.22"
+libc = { workspace = true }
+log = { workspace = true }
 remain = "0.2.15"
-serde = { version = "1.0.208", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 smallvec = "1.13.2"
 thiserror = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -6,17 +6,17 @@ version = "0.1.0"
 
 [dependencies]
 acpi_tables = { workspace = true }
-anyhow = "1.0.94"
+anyhow = { workspace = true }
 arch = { path = "../arch" }
-bitflags = "2.9.0"
-byteorder = "1.5.0"
+bitflags = { workspace = true }
+byteorder = { workspace = true }
 event_monitor = { path = "../event_monitor" }
 hypervisor = { path = "../hypervisor" }
-libc = "0.2.167"
-log = "0.4.22"
+libc = { workspace = true }
+log = { workspace = true }
 num_enum = "0.7.2"
 pci = { path = "../pci" }
-serde = { version = "1.0.208", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tpm = { path = "../tpm" }
 vm-allocator = { path = "../vm-allocator" }

--- a/event_monitor/Cargo.toml
+++ b/event_monitor/Cargo.toml
@@ -5,7 +5,7 @@ name = "event_monitor"
 version = "0.1.0"
 
 [dependencies]
-flume = "0.11.1"
-libc = "0.2.167"
-serde = { version = "1.0.208", features = ["derive", "rc"] }
+flume = { workspace = true }
+libc = { workspace = true }
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -13,27 +13,27 @@ sev_snp = ["igvm", "igvm_defs"]
 tdx = []
 
 [dependencies]
-anyhow = "1.0.94"
+anyhow = { workspace = true }
 arc-swap = "1.7.1"
 bitfield-struct = "0.10.1"
-byteorder = "1.5.0"
-cfg-if = "1.0.0"
+byteorder = { workspace = true }
+cfg-if = { workspace = true }
 concat-idents = "1.1.5"
 igvm = { workspace = true, optional = true }
 igvm_defs = { workspace = true, optional = true }
 kvm-bindings = { workspace = true, optional = true, features = ["serde"] }
 kvm-ioctls = { workspace = true, optional = true }
-libc = "0.2.167"
-log = "0.4.22"
+libc = { workspace = true }
+log = { workspace = true }
 mshv-bindings = { workspace = true, features = [
   "fam-wrappers",
   "with-serde",
 ], optional = true }
 mshv-ioctls = { workspace = true, optional = true }
 open-enum = "0.5.2"
-serde = { version = "1.0.208", features = ["derive", "rc"] }
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
-serde_with = { version = "3.14.0", default-features = false, features = [
+serde_with = { workspace = true, default-features = false, features = [
   "macros",
 ] }
 thiserror = { workspace = true }

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -5,13 +5,13 @@ name = "net_util"
 version = "0.1.0"
 
 [dependencies]
-epoll = "4.3.3"
+epoll = { workspace = true }
 getrandom = "0.3.3"
-libc = "0.2.167"
-log = "0.4.22"
+libc = { workspace = true }
+log = { workspace = true }
 net_gen = { path = "../net_gen" }
 rate_limiter = { path = "../rate_limiter" }
-serde = { version = "1.0.208", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 virtio-bindings = { workspace = true }
 virtio-queue = { workspace = true }

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -10,12 +10,12 @@ kvm = ["hypervisor/kvm", "vfio-ioctls/kvm"]
 mshv = ["hypervisor/mshv", "vfio-ioctls/mshv"]
 
 [dependencies]
-anyhow = "1.0.94"
-byteorder = "1.5.0"
+anyhow = { workspace = true }
+byteorder = { workspace = true }
 hypervisor = { path = "../hypervisor" }
-libc = "0.2.167"
-log = "0.4.22"
-serde = { version = "1.0.208", features = ["derive"] }
+libc = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 vfio-bindings = { workspace = true, features = ["fam-wrappers"] }
 vfio-ioctls = { workspace = true, default-features = false }

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -6,9 +6,9 @@ name = "performance-metrics"
 version = "0.1.0"
 
 [dependencies]
-clap = { version = "4.5.13", features = ["wrap_help"] }
-dirs = "6.0.0"
-serde = { version = "1.0.208", features = ["derive", "rc"] }
+clap = { workspace = true, features = ["wrap_help"] }
+dirs = { workspace = true }
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 test_infra = { path = "../test_infra" }
 thiserror = { workspace = true }

--- a/rate_limiter/Cargo.toml
+++ b/rate_limiter/Cargo.toml
@@ -4,8 +4,8 @@ name = "rate_limiter"
 version = "0.1.0"
 
 [dependencies]
-epoll = "4.3.3"
-libc = "0.2.167"
-log = "0.4.22"
+epoll = { workspace = true }
+libc = { workspace = true }
+log = { workspace = true }
 thiserror = { workspace = true }
 vmm-sys-util = { workspace = true }

--- a/test_infra/Cargo.toml
+++ b/test_infra/Cargo.toml
@@ -5,11 +5,11 @@ name = "test_infra"
 version = "0.1.0"
 
 [dependencies]
-dirs = "6.0.0"
-epoll = "4.3.3"
-libc = "0.2.167"
+dirs = { workspace = true }
+epoll = { workspace = true }
+libc = { workspace = true }
 serde_json = { workspace = true }
 ssh2 = { version = "0.9.4", features = ["vendored-openssl"] }
 thiserror = { workspace = true }
 vmm-sys-util = { workspace = true }
-wait-timeout = "0.2.0"
+wait-timeout = { workspace = true }

--- a/tpm/Cargo.toml
+++ b/tpm/Cargo.toml
@@ -6,9 +6,9 @@ name = "tpm"
 version = "0.1.0"
 
 [dependencies]
-anyhow = "1.0.94"
-libc = "0.2.167"
-log = "0.4.22"
+anyhow = { workspace = true }
+libc = { workspace = true }
+log = { workspace = true }
 net_gen = { path = "../net_gen" }
 thiserror = { workspace = true }
 vmm-sys-util = { workspace = true }

--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -5,9 +5,9 @@ name = "tracer"
 version = "0.1.0"
 
 [dependencies]
-libc = "0.2.167"
-log = "0.4.22"
-serde = { version = "1.0.208", features = ["derive", "rc"] }
+libc = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 
 [features]

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -7,10 +7,10 @@ version = "0.1.0"
 
 [dependencies]
 block = { path = "../block" }
-clap = { version = "4.5.13", features = ["cargo", "wrap_help"] }
+clap = { workspace = true, features = ["cargo", "wrap_help"] }
 env_logger = { workspace = true }
-libc = "0.2.167"
-log = "0.4.22"
+libc = { workspace = true }
+log = { workspace = true }
 option_parser = { path = "../option_parser" }
 thiserror = { workspace = true }
 vhost = { workspace = true, features = ["vhost-user-backend"] }

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -6,11 +6,11 @@ name = "vhost_user_net"
 version = "0.1.0"
 
 [dependencies]
-clap = { version = "4.5.13", features = ["cargo", "wrap_help"] }
+clap = { workspace = true, features = ["cargo", "wrap_help"] }
 env_logger = { workspace = true }
-epoll = "4.3.3"
-libc = "0.2.167"
-log = "0.4.22"
+epoll = { workspace = true }
+libc = { workspace = true }
+log = { workspace = true }
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
 thiserror = { workspace = true }

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -11,20 +11,20 @@ mshv = ["pci/mshv"]
 sev_snp = ["mshv-ioctls"]
 
 [dependencies]
-anyhow = "1.0.94"
+anyhow = { workspace = true }
 block = { path = "../block" }
-byteorder = "1.5.0"
-epoll = "4.3.3"
+byteorder = { workspace = true }
+epoll = { workspace = true }
 event_monitor = { path = "../event_monitor" }
-libc = "0.2.167"
-log = "0.4.22"
+libc = { workspace = true }
+log = { workspace = true }
 mshv-ioctls = { workspace = true, optional = true }
 net_util = { path = "../net_util" }
 pci = { path = "../pci" }
 rate_limiter = { path = "../rate_limiter" }
 seccompiler = { workspace = true }
-serde = { version = "1.0.208", features = ["derive"] }
-serde_with = { version = "3.14.0", default-features = false, features = [
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true, default-features = false, features = [
   "macros",
 ] }
 serial_buffer = { path = "../serial_buffer" }

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 kvm = ["arch/kvm"]
 
 [dependencies]
-libc = "0.2.167"
+libc = { workspace = true }
 vm-memory = { workspace = true }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -11,7 +11,7 @@ mshv = ["vfio-ioctls/mshv"]
 
 [dependencies]
 hypervisor = { path = "../hypervisor" }
-serde = { version = "1.0.208", features = ["derive", "rc"] }
+serde = { workspace = true, features = ["derive", "rc"] }
 thiserror = { workspace = true }
 vfio-ioctls = { workspace = true, default-features = false }
 vmm-sys-util = { workspace = true }

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -5,8 +5,8 @@ name = "vm-migration"
 version = "0.1.0"
 
 [dependencies]
-anyhow = "1.0.94"
-serde = { version = "1.0.208", features = ["derive", "rc"] }
+anyhow = { workspace = true }
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 vm-memory = { workspace = true, features = ["backend-atomic", "backend-mmap"] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -33,18 +33,18 @@ tracing = ["tracer/tracing"]
 
 [dependencies]
 acpi_tables = { workspace = true }
-anyhow = "1.0.94"
+anyhow = { workspace = true }
 arch = { path = "../arch" }
-bitflags = "2.9.0"
+bitflags = { workspace = true }
 block = { path = "../block" }
 blocking = { version = "1.6.1", optional = true }
-cfg-if = "1.0.0"
-clap = "4.5.13"
+cfg-if = { workspace = true }
+clap = { workspace = true }
 devices = { path = "../devices" }
-dhat = { version = "0.3.3", optional = true }
-epoll = "4.3.3"
+dhat = { workspace = true, optional = true }
+epoll = { workspace = true }
 event_monitor = { path = "../event_monitor" }
-flume = "0.11.1"
+flume = { workspace = true }
 futures = { version = "0.3.31", optional = true }
 gdbstub = { version = "0.7.6", optional = true }
 gdbstub_arch = { version = "0.3.0", optional = true }
@@ -53,9 +53,9 @@ hypervisor = { path = "../hypervisor" }
 igvm = { workspace = true, optional = true }
 igvm_defs = { workspace = true, optional = true }
 landlock = "0.4.0"
-libc = "0.2.167"
+libc = { workspace = true }
 linux-loader = { workspace = true, features = ["bzimage", "elf", "pe"] }
-log = "0.4.22"
+log = { workspace = true }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 mshv-bindings = { workspace = true, features = [
   "fam-wrappers",
@@ -67,10 +67,10 @@ pci = { path = "../pci" }
 range_map_vec = { version = "0.2.0", optional = true }
 rate_limiter = { path = "../rate_limiter" }
 seccompiler = { workspace = true }
-serde = { version = "1.0.208", features = ["derive", "rc"] }
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 serial_buffer = { path = "../serial_buffer" }
-signal-hook = "0.3.18"
+signal-hook = { workspace = true }
 thiserror = { workspace = true }
 tracer = { path = "../tracer" }
 uuid = { workspace = true }


### PR DESCRIPTION
Many of the workspace members in the Cloud-hypervisor workspace share common dependencies. Making these workspace dependencies reduces duplication and improves maintainability.
