### PR TITLE
vmm: Add support for loading SMBIOS OEM strings from files

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -207,6 +207,10 @@ pub enum Error {
     /// Failed to configure E820 map for bzImage
     #[error("Failed to configure E820 map for bzImage")]
     E820Configuration,
+
+    /// Error reading OEM string file
+    #[error("Error reading OEM string file: {0}")]
+    OemStringFileRead(String),
 }
 
 pub fn get_x2apic_id(cpu_id: u32, topology: Option<(u8, u8, u8)>) -> u32 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,7 +364,7 @@ fn get_cli_options_sorted(
         Arg::new("platform")
             .long("platform")
             .help(
-                "num_pci_segments=<num_pci_segments>,iommu_segments=<list_of_segments>,iommu_address_width=<bits>,serial_number=<dmi_device_serial_number>,uuid=<dmi_device_uuid>,oem_strings=<list_of_strings>"
+                "num_pci_segments=<num_pci_segments>,iommu_segments=<list_of_segments>,iommu_address_width=<bits>,serial_number=<dmi_device_serial_number>,uuid=<dmi_device_uuid>,oem_strings=<list_of_strings>,oem_string_paths=<list_of_paths>"
             )
             .num_args(1)
             .group("vm-config"),

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -735,6 +735,10 @@ components:
           type: array
           items:
             type: string
+        oem_string_paths:
+          type: array
+          items:
+            type: string
         tdx:
           type: boolean
           default: false

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -683,7 +683,8 @@ impl PlatformConfig {
             .add("iommu_address_width")
             .add("serial_number")
             .add("uuid")
-            .add("oem_strings");
+            .add("oem_strings")
+            .add("oem_string_paths");
         #[cfg(feature = "tdx")]
         parser.add("tdx");
         #[cfg(feature = "sev_snp")]
@@ -710,6 +711,10 @@ impl PlatformConfig {
             .convert::<StringList>("oem_strings")
             .map_err(Error::ParsePlatform)?
             .map(|v| v.0);
+        let oem_string_paths = parser
+            .convert::<StringList>("oem_string_paths")
+            .map_err(Error::ParsePlatform)?
+            .map(|v| v.0);
         #[cfg(feature = "tdx")]
         let tdx = parser
             .convert::<Toggle>("tdx")
@@ -729,6 +734,7 @@ impl PlatformConfig {
             serial_number,
             uuid,
             oem_strings,
+            oem_string_paths,
             #[cfg(feature = "tdx")]
             tdx,
             #[cfg(feature = "sev_snp")]
@@ -3888,6 +3894,7 @@ mod tests {
             serial_number: None,
             uuid: None,
             oem_strings: None,
+            oem_string_paths: None,
             #[cfg(feature = "tdx")]
             tdx: false,
             #[cfg(feature = "sev_snp")]
@@ -4615,6 +4622,28 @@ mod tests {
                 access: "rw".to_string(),
             }
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_platform_config_parsing() -> Result<()> {
+        // Test oem_strings parsing
+        assert_eq!(
+            PlatformConfig::parse("oem_strings=[foo,bar]")?.oem_strings,
+            Some(vec!["foo".to_string(), "bar".to_string()])
+        );
+
+        // Test oem_string_paths parsing
+        assert_eq!(
+            PlatformConfig::parse("oem_string_paths=[/path/1,/path/2]")?.oem_string_paths,
+            Some(vec!["/path/1".to_string(), "/path/2".to_string()])
+        );
+
+        // Test both together
+        let config = PlatformConfig::parse("oem_strings=[foo],oem_string_paths=[/path]")?;
+        assert_eq!(config.oem_strings, Some(vec!["foo".to_string()]));
+        assert_eq!(config.oem_string_paths, Some(vec!["/path".to_string()]));
+
         Ok(())
     }
 }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -107,6 +107,8 @@ pub struct PlatformConfig {
     pub uuid: Option<String>,
     #[serde(default)]
     pub oem_strings: Option<Vec<String>>,
+    #[serde(default)]
+    pub oem_string_paths: Option<Vec<String>>,
     #[cfg(feature = "tdx")]
     #[serde(default)]
     pub tdx: bool,


### PR DESCRIPTION
Introduces a new `oem_string_paths` configuration option that allows
loading SMBIOS OEM strings from files instead of passing them directly
on the command line. This prevents sensitive data exposure in process
lists and logs.

Files specified in oem_string_paths are read and their contents are
used as individual OEM strings. The feature works alongside the existing
oem_strings option, with the final list being a concatenation of both
sources.

Fixes #6951

Signed-off-by: Casey Link <casey@outskirtslabs.com>


---

An example usage would look like: 

`--platform 'oem_string_paths=[/path/to/some/value]'`

Then if that file contained the string `io.systemd.credential:bootstrap_secret=super-secret-value`

Then a systemd enabled guest would be able to

```console
[root@cloud-hypervisor-microvm:~]# systemd-creds --system list
NAME              SECURE SIZE PATH
bootstrap_secret   secure  19B /run/credentials/@system/bootstrap_secret

[root@cloud-hypervisor-microvm:~]# systemd-creds --system cat bootstrap_secret
super-secret-value
```
