### PR TITLE
Support more formats for block performance metrics

### DIFF
--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -712,8 +712,6 @@ fn main() {
     // Run performance tests sequentially and report results (in both readable/json format)
     let mut metrics_report: MetricsReport = Default::default();
 
-    init_tests();
-
     let overrides = Arc::new(PerformanceTestOverrides {
         test_iterations: cmd_arguments
             .get_one::<String>("iterations")
@@ -726,6 +724,8 @@ fn main() {
             .transpose()
             .unwrap_or_default(),
     });
+
+    init_tests();
 
     for test in test_list.iter() {
         if test_filter.is_empty() || test_filter.iter().any(|&s| test.name.contains(s)) {


### PR DESCRIPTION
I'm exploring ideas to rework block layer traits in my copious free time. I don't want to accidentally introduce performance regression, so I wrote this series to assist me.

I don't think anyone is asking badly for this, so there is no rush to merge it. If people don't find this useful, I can keep it locally.

Example:

` ./scripts/dev_cli.sh tests --metrics -- --test-filter block_ -- --image-format qcow2`