### PR TITLE
tpm: Use the same log version as other workspace members

### DIFF
--- a/tpm/Cargo.toml
+++ b/tpm/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 [dependencies]
 anyhow = "1.0.94"
 libc = "0.2.167"
-log = "0.4.21"
+log = "0.4.22"
 net_gen = { path = "../net_gen" }
 thiserror = { workspace = true }
 vmm-sys-util = { workspace = true }


### PR DESCRIPTION
The other workspace members in the Cloud-hypervisor workspace currently declare log version 0.4.22, but the tpm crate has an older version. This inconsistency is addressed by this PR which opens the door for declaring log as a workspace dependency.