### PR TITLE
tpm: Use the same libc crate version as other workspace members

### DIFF
--- a/tpm/Cargo.toml
+++ b/tpm/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1.0.94"
-libc = "0.2.153"
+libc = "0.2.167"
 log = "0.4.21"
 net_gen = { path = "../net_gen" }
 thiserror = { workspace = true }


### PR DESCRIPTION
The other workspace members in the Cloud-hypervisor workspace currently declare libc crate version 0.2.167, but the tpm crate has an older version. This inconsistency is addressed by this PR which opens the door for declaring libc as a workspace dependency.
