### PR TITLE
tests: Avoid repeatedly downloading files from GitHub

### DIFF
--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -20,9 +20,13 @@ fi
 
 cp scripts/sha1sums-x86_64 "$WORKLOADS_DIR"
 
-download_hypervisor_fw
+if [ ! -f "$WORKLOADS_DIR/hypervisor-fw" ]; then
+    download_hypervisor_fw
+fi
 
-download_ovmf
+if [ ! -f "$WORKLOADS_DIR/CLOUDHV.fd" ]; then
+    download_ovmf
+fi
 
 FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210609-0.qcow2"
 FOCAL_OS_IMAGE_URL="https://ch-images.azureedge.net/$FOCAL_OS_IMAGE_NAME"

--- a/scripts/sha1sums-x86_64
+++ b/scripts/sha1sums-x86_64
@@ -3,3 +3,5 @@ f1eccdc5e1b515dbad294426ab081b47ebfb97c0 focal-server-cloudimg-amd64-custom-2021
 7f5a8358243a96adf61f5c20139b29f308f2c0e3 focal-server-cloudimg-amd64-custom-20210609-0.raw
 5f10738920efb74f0bf854cadcd1b1fd544e49c8 jammy-server-cloudimg-amd64-custom-20241017-0.qcow2
 c1dfbe7abde400e675844568dbe9d3914222f6de jammy-server-cloudimg-amd64-custom-20241017-0.raw
+540ac358429305d7aa94e15363665d1c9d845982 hypervisor-fw
+4e96fd0914a44005d40707b2b0c7e829e4086bd5 CLOUDHV.fd


### PR DESCRIPTION
Running one or two tests in a tight loop can cause the download functions to quickly hit GitHub's API rate limit. That causes the test script to fail for no apparent reason.