### PR TITLE
riscv64: Enable firmware booting

### DIFF
--- a/arch/src/riscv64/layout.rs
+++ b/arch/src/riscv64/layout.rs
@@ -44,16 +44,23 @@
 //           |                                                               |
 //           |                            APLICs                             |
 //           |                                                               |
+//    4 MB   +---------------------------------------------------------------+
+//           |                          UEFI flash                           |
 //    0 GB   +---------------------------------------------------------------+
 //
 //
 
 use vm_memory::GuestAddress;
 
+/// 0x0 ~ 0x40_0000 (4 MiB) is reserved to UEFI
+/// UEFI binary size is required less than 3 MiB, reserving 4 MiB is enough.
+pub const UEFI_START: GuestAddress = GuestAddress(0);
+pub const UEFI_SIZE: u64 = 0x040_0000;
+
 /// AIA related devices
 /// See https://elixir.bootlin.com/linux/v6.10/source/arch/riscv/include/uapi/asm/kvm.h
-/// 0x0 ~ 0x0400_0000 (64 MiB) resides APLICs
-pub const APLIC_START: GuestAddress = GuestAddress(0);
+/// 0x40_0000 ~ 0x0400_0000 (64 MiB) resides APLICs
+pub const APLIC_START: GuestAddress = GuestAddress(0x40_0000);
 pub const APLIC_SIZE: u64 = 0x4000;
 
 /// 0x0400_0000 ~ 0x0800_0000 (64 MiB) resides IMSICs

--- a/arch/src/riscv64/mod.rs
+++ b/arch/src/riscv64/mod.rs
@@ -7,6 +7,8 @@
 pub mod fdt;
 /// Layout for this riscv64 system.
 pub mod layout;
+/// Module for loading UEFI binary.
+pub mod uefi;
 
 use std::collections::HashMap;
 use std::fmt::Debug;

--- a/arch/src/riscv64/uefi.rs
+++ b/arch/src/riscv64/uefi.rs
@@ -1,0 +1,50 @@
+// Copyright 2020 Arm Limited (or its affiliates). All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::{Read, Seek, SeekFrom};
+use std::os::fd::AsFd;
+use std::result;
+
+use thiserror::Error;
+use vm_memory::{GuestAddress, GuestMemory};
+
+/// Errors thrown while loading UEFI binary
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Unable to seek to UEFI image start.
+    #[error("Unable to seek to UEFI image start")]
+    SeekUefiStart,
+    /// Unable to seek to UEFI image end.
+    #[error("Unable to seek to UEFI image end")]
+    SeekUefiEnd,
+    /// UEFI image too big.
+    #[error("UEFI image too big")]
+    UefiTooBig,
+    /// Unable to read UEFI image
+    #[error("Unable to read UEFI image")]
+    ReadUefiImage,
+}
+type Result<T> = result::Result<T, Error>;
+
+pub fn load_uefi<F, M: GuestMemory>(
+    guest_mem: &M,
+    guest_addr: GuestAddress,
+    uefi_image: &mut F,
+) -> Result<()>
+where
+    F: Read + Seek + AsFd,
+{
+    let uefi_size = uefi_image
+        .seek(SeekFrom::End(0))
+        .map_err(|_| Error::SeekUefiEnd)? as usize;
+
+    // edk2 image on virtual platform is smaller than 3M
+    if uefi_size > 0x300000 {
+        return Err(Error::UefiTooBig);
+    }
+    uefi_image.rewind().map_err(|_| Error::SeekUefiStart)?;
+    guest_mem
+        .read_exact_volatile_from(guest_addr, &mut uefi_image.as_fd(), uefi_size)
+        .map_err(|_| Error::ReadUefiImage)
+}

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -199,7 +199,7 @@ pub struct MemoryManager {
     guest_ram_mappings: Vec<GuestRamMapping>,
 
     pub acpi_address: Option<GuestAddress>,
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     uefi_flash: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
 }
 
@@ -1274,7 +1274,7 @@ impl MemoryManager {
             arch_mem_regions,
             ram_allocator,
             dynamic,
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
             uefi_flash: None,
             thp: config.thp,
         };
@@ -2192,7 +2192,7 @@ impl MemoryManager {
         self.guest_ram_mappings.len() as u32
     }
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     pub fn uefi_flash(&self) -> GuestMemoryAtomic<GuestMemoryMmap> {
         self.uefi_flash.as_ref().unwrap().clone()
     }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -116,6 +116,10 @@ pub enum Error {
     #[error("Cannot load the UEFI binary in memory")]
     UefiLoad(#[source] arch::aarch64::uefi::Error),
 
+    #[cfg(target_arch = "riscv64")]
+    #[error("Cannot load the UEFI binary in memory")]
+    UefiLoad(#[source] arch::riscv64::uefi::Error),
+
     #[error("Cannot load the initramfs into memory")]
     InitramfsLoad,
 


### PR DESCRIPTION
- arch: riscv: Introduce UEFI related constants
- arch: riscv: Introduce UEFI module
- vmm: Enable uefi_flash field for riscv64
- vmm: Define riscv64 UEFI Error
- vmm: Enable firmware boot for riscv64

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>