### PR TITLE
misc: switch error output from error! back to stderr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,15 @@ pub fn cli_print_error_chain<'a>(
         &'a (dyn Error + 'static),
     ) -> Option<String>,
 ) {
-    let msg = format!("Error: {component} exited with the following");
+    // Debug info.
+    error!("Fatal error: {top_error:?}");
+
+    eprint!("Error: {component} exited with the following ");
     if top_error.source().is_none() {
-        error!("{msg} error:");
-        error!("  {top_error}");
+        eprintln!("error:");
+        eprintln!("  {top_error}");
     } else {
-        error!("{msg} chain of errors:");
+        eprintln!("chain of errors:");
         std::iter::successors(Some(top_error), |sub_error| {
             // Dereference necessary to mitigate rustc compiler bug.
             // See <https://github.com/rust-lang/rust/issues/141673>
@@ -34,13 +37,10 @@ pub fn cli_print_error_chain<'a>(
         .for_each(|(level, error)| {
             // Special case: handling of HTTP Server responses in ch-remote
             if let Some(message) = display_modifier(level, 2, error) {
-                error!("{message}");
+                eprintln!("{message}");
             } else {
-                error!("  {level}: {error}");
+                eprintln!("  {level}: {error}");
             }
         });
     }
-
-    error!("");
-    error!("Debug Info: {top_error:?}");
 }


### PR DESCRIPTION
Moved discussion from https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7183#issuecomment-3173923366 to this PR.

---

This partially reverts
ed8f347fe62edd33355ad771615296ff8edc8d33 from #7183 and 6277d7d5f20126945904fefdf5fb990bbcce5ae8 from #7201.

# Output how it was merged for v47 (#7066)
```
Error: Cloud Hypervisor exited with the following chain of errors:
 0: Error booting VM
 1: The VM could not boot
 2: Error manipulating firmware file
 3: No such file or directory (os error 2)

Debug Info: VmBoot(VmBoot(FirmwareFile(Os { code: 2, kind: NotFound, message: "No such file or directory" })))
```

# Output after #7183 and #7201
```
cloud-hypervisor: 31.385730ms: <main> ERROR:/home/pschuster/dev/cloud-hypervisor/src/lib.rs:27 -- Error: Cloud Hypervisor exited with the following chain of errors:
cloud-hypervisor: 31.417961ms: <main> ERROR:/home/pschuster/dev/cloud-hypervisor/src/lib.rs:39 --   0: Error booting VM
cloud-hypervisor: 31.448078ms: <main> ERROR:/home/pschuster/dev/cloud-hypervisor/src/lib.rs:39 --   1: The VM could not boot
cloud-hypervisor: 31.486711ms: <main> ERROR:/home/pschuster/dev/cloud-hypervisor/src/lib.rs:39 --   2: Error manipulating firmware file
cloud-hypervisor: 31.513331ms: <main> ERROR:/home/pschuster/dev/cloud-hypervisor/src/lib.rs:39 --   3: No such file or directory (os error 2)
cloud-hypervisor: 31.548037ms: <main> ERROR:/home/pschuster/dev/cloud-hypervisor/src/lib.rs:44 --
cloud-hypervisor: 31.568045ms: <main> ERROR:/home/pschuster/dev/cloud-hypervisor/src/lib.rs:45 -- Debug Info: VmBoot(VmBoot(FirmwareFile(Os { code: 2, kind: NotFound, message: "No such file or directory" })))
```

The "proper logger" has indeed the advantage that messages can be gracefully redirected to log files etc. However, this makes the error message hardly readable.

Therefore, I propose to use error!() only for runtime errors messages
but not a pretty-printed version of those.

