### PR TITLE
misc: make topology a 4-tuple of u16s

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -126,7 +126,7 @@ pub fn configure_system<T: DeviceInfoForFdt + Clone + Debug, S: ::std::hash::Bui
     guest_mem: &GuestMemoryMmap,
     cmdline: &str,
     vcpu_mpidr: Vec<u64>,
-    vcpu_topology: Option<(u8, u8, u8)>,
+    vcpu_topology: Option<(u16, u16, u16, u16)>,
     device_info: &HashMap<(DeviceType, String), T, S>,
     initrd: &Option<super::InitramfsConfig>,
     pci_space_info: &[PciSpaceInfo],

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -136,7 +136,7 @@ pub fn setup_mptable(
     offset: GuestAddress,
     mem: &GuestMemoryMmap,
     num_cpus: u32,
-    topology: Option<(u8, u8, u8)>,
+    topology: Option<(u16, u16, u16, u16)>,
 ) -> Result<()> {
     if num_cpus > 0 {
         let cpu_id_max = num_cpus - 1;

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -285,7 +285,7 @@ fn create_tpm2_table() -> Sdt {
 
 fn create_srat_table(
     numa_nodes: &NumaNodes,
-    #[cfg(target_arch = "x86_64")] topology: Option<(u8, u8, u8)>,
+    #[cfg(target_arch = "x86_64")] topology: Option<(u16, u16, u16, u16)>,
 ) -> Sdt {
     let mut srat = Sdt::new(*b"SRAT", 36, 3, *b"CLOUDH", *b"CHSRAT  ", 1);
     // SRAT reserved 12 bytes

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3582,7 +3582,7 @@ mod tests {
             &mem,
             "console=tty0",
             vec![0],
-            Some((0, 0, 0)),
+            Some((0, 0, 0, 0)),
             &dev_info,
             &gic,
             &None,


### PR DESCRIPTION
This is the second patch in a series intended to let Cloud Hypervisor support more than 255 vCPUs in guest VMs; the first patch/commit is https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7231

At the moment, CPU topology in Cloud Hypervisor is using u8 for components, and somewhat inconsistently:

- struct CpuTopology in vmm/src/vm_config.rs uses four components (threads_per_core, cores_per_die, dies_per_package, packages);

- when passed around as a tuple, it is a 3-tuple of u8, with some inconsistency:

- in get_x2apic_id in arch/src/x86_64/mod.rs  the three u8 are assumed to be (correctly) threads_per_core, cores_per_die, and dies_per_package, but

- in get_vcpu_topology() in vmm/src/cpu.rs the three-tuple is threads_per_core, cores_per_die, and packages (dies_per_package is assumed to always be one? not clear).

So for consistency, a 4-tuple is always passed around.

In addition, the types of the tuple components is changed from u8 to u16, as on x86_64 subcomponents can consume up to 16 bits.

Again, config constraints have not been changed, so this patch is mostly NOOP.