### PR TITLE
build: fix warnings/errors from latest nightly (1.91)

### DIFF
--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -211,7 +211,7 @@ impl MsixConfig {
     }
 
     pub fn read_table(&self, offset: u64, data: &mut [u8]) {
-        assert!((data.len() == 4 || data.len() == 8));
+        assert!(data.len() == 4 || data.len() == 8);
 
         let index: usize = (offset / MSIX_TABLE_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_TABLE_ENTRIES_MODULO;
@@ -264,7 +264,7 @@ impl MsixConfig {
     }
 
     pub fn write_table(&mut self, offset: u64, data: &[u8]) {
-        assert!((data.len() == 4 || data.len() == 8));
+        assert!(data.len() == 4 || data.len() == 8);
 
         let index: usize = (offset / MSIX_TABLE_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_TABLE_ENTRIES_MODULO;
@@ -360,7 +360,7 @@ impl MsixConfig {
     }
 
     pub fn read_pba(&mut self, offset: u64, data: &mut [u8]) {
-        assert!((data.len() == 4 || data.len() == 8));
+        assert!(data.len() == 4 || data.len() == 8);
 
         let index: usize = (offset / MSIX_PBA_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_PBA_ENTRIES_MODULO;


### PR DESCRIPTION
The underlying problem currently causes unrelated PRs to fail. This commit fixes that.

Pipelines currently red (specifically: the nightly runs, such as `cargo fuzz build`):
- #7255 
  - https://github.com/cloud-hypervisor/cloud-hypervisor/actions/runs/17036558874/job/48290309379?pr=7255
