### PR TITLE
[WIP] devices: remove preserved fds on device hot detach

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -3140,6 +3140,8 @@ impl VmConfig {
         removed
     }
 
+    /// Prepends the list of FDs to the preserved FDs.
+    ///
     /// # Safety
     /// To use this safely, the caller must guarantee that the input
     /// fds are all valid.
@@ -3149,7 +3151,12 @@ impl VmConfig {
         }
 
         if let Some(preserved_fds) = &self.preserved_fds {
-            fds.append(&mut preserved_fds.clone());
+            for fd in preserved_fds {
+                if fds.contains(fd) {
+                    log::warn!("fd {fd} is already preserved, skipping");
+                }
+                fds.push(*fd);
+            }
         }
 
         self.preserved_fds = Some(fds);

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -956,6 +956,10 @@ pub struct VmConfig {
     // VmConfig instance, such as FDs for creating TAP devices.
     // Preserved FDs will stay open as long as the holding VmConfig instance is
     // valid, and will be closed when the holding VmConfig instance is destroyed.
+    //
+    // This is populated during hot device attach. Hot device detach causes the
+    // FDs to be closed early. This allows management software to gracefully
+    // clean up resources (e.g., libvirt destroys tap devices).
     #[serde(skip)]
     pub preserved_fds: Option<Vec<i32>>,
     #[serde(default)]


### PR DESCRIPTION
Part of #7291 to work towards live-migration with FDs for virtio-net devices.

## About 
This implements the closing of all file descriptors opened externally for a certain device. This allows management software (e.g., libvirt) to properly close tap devices after a hot-remove operation.

Background: virtio-net devices are currently the only devices for that you can pass externally opened FDs. This works via UNIX SCM_RIGHTS messages via the UNIX domain socket between the management software (e.g., libvirt) and Cloud Hypervisor. 

## Steps to Undraft
- [ ] Wait until more of the PRs mentioned in #7291 are merged to reduce maintainer load
