### PR TITLE
vmm/api: document and streamline process of externally passed FDs for virtio-net devices

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2198,38 +2198,15 @@ pub struct RestoredNetConfig {
     pub id: String,
     #[serde(default)]
     pub num_fds: usize,
-    // Special (de)serialize handling:
+    // Special deserialize handling:
     // A serialize-deserialize cycle typically happens across processes.
     // Therefore, we don't serialize FDs, and whatever value is here after
     // deserialization is invalid.
     //
     // Valid FDs are transmitted via a different channel (SCM_RIGHTS message)
     // and will be populated into this struct on the destination VMM eventually.
-    #[serde(
-        default,
-        serialize_with = "serialize_restorednetconfig_fds",
-        deserialize_with = "deserialize_restorednetconfig_fds"
-    )]
+    #[serde(default, deserialize_with = "deserialize_restorednetconfig_fds")]
     pub fds: Option<Vec<i32>>,
-}
-
-fn serialize_restorednetconfig_fds<S>(
-    x: &Option<Vec<i32>>,
-    s: S,
-) -> std::result::Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    if let Some(x) = x {
-        // If the live-migration path is used properly, new FDs are passed as
-        // SCM_RIGHTS message. So, we don't get them from the serialized JSON
-        // anyway.
-        debug!("FDs in 'RestoredNetConfig' won't be serialized as they are most likely invalid after deserialization. Serializing them as -1.");
-        let invalid_fds = vec![-1; x.len()];
-        s.serialize_some(&invalid_fds)
-    } else {
-        s.serialize_none()
-    }
 }
 
 fn deserialize_restorednetconfig_fds<'de, D>(

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -326,6 +326,12 @@ pub struct NetConfig {
     pub vhost_mode: VhostMode,
     #[serde(default)]
     pub id: Option<String>,
+    // Special (de)serialize handling:
+    // Therefore, we don't serialize FDs, and whatever value is here after
+    // deserialization is invalid.
+    //
+    // Valid FDs are transmitted via a different channel (SCM_RIGHTS message)
+    // and will be populated into this struct on the destination VMM eventually.
     #[serde(
         default,
         serialize_with = "serialize_netconfig_fds",
@@ -387,9 +393,7 @@ where
     S: serde::Serializer,
 {
     if let Some(x) = x {
-        warn!(
-            "'NetConfig' contains FDs that can't be serialized correctly. Serializing them as invalid FDs."
-        );
+        debug!("FDs in 'NetConfig' won't be serialized as they are most likely invalid after deserialization; using -1.");
         let invalid_fds = vec![-1; x.len()];
         s.serialize_some(&invalid_fds)
     } else {
@@ -403,8 +407,8 @@ where
 {
     let invalid_fds: Option<Vec<i32>> = Option::deserialize(d)?;
     if let Some(invalid_fds) = invalid_fds {
-        warn!(
-            "'NetConfig' contains FDs that can't be deserialized correctly. Deserializing them as invalid FDs."
+        debug!(
+            "FDs in 'NetConfig' won't be deserialized as they are most likely invalid now. Deserializing them as -1."
         );
         Ok(Some(vec![-1; invalid_fds.len()]))
     } else {


### PR DESCRIPTION
Part of #7291 to work towards live-migration with FDs for virtio-net devices.

## About

### Part 1:
Document and streamline the current handling of externally provided FDs for virtio-net devices.

### Part 2:
Regarding the introduced abstraction to attach FDs to config objects.

_This version might be outdated. The most current form is in the commit message!_

The motivation of the new abstraction is to provide a verbose, solid,
and bulletproof solution for an complex domain. The interaction between
- the management layer,
- the passing of file descriptors over UNIX domain sockets via
  SCM_RIGHTS,
- the attachment of configurations to those FDs,
- **and the ability to give
  new developers clear insights into what happens under the hood**

is not trivial. These factors justify encapsulating the complexity
behind a convenient and well-documented abstraction, making the system
both robust in production and approachable for new developers.
  
In addition, it allows us to perform unit testing. Further, We get rid of
existing partial code duplication and inconsistencies.

Finally, while this approach may initially result in more code, every new
handler that accepts FDs benefits from reduced duplication and a correct
implementation by relying on the shared abstraction. This will also enable
future functionality, such as virtio-blk devices backed by FDs which can
then be integrated with ease.

## Hints for Reviewrs

- demystifies the UNIX' SCM_RIGHTS magic to pass file descriptors
- streamlines the code
- simplifies the addition of other handlers to work with FDs
  - e.g. needed in #7150 for live migration