### PR TITLE
hypervisor: enable x2apic API in kvm on x86_64

### DIFF
--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -126,6 +126,11 @@ pub enum HypervisorVmError {
     #[error("Failed to enable split Irq")]
     EnableSplitIrq(#[source] anyhow::Error),
     ///
+    /// Enable x2apic API error
+    ///
+    #[error("Failed to enable x2apic API")]
+    EnableX2ApicApi(#[source] anyhow::Error),
+    ///
     /// Enable SGX attribute error
     ///
     #[error("Failed to enable SGX attribute")]
@@ -439,6 +444,11 @@ pub trait Vm: Send + Sync + Any {
     #[cfg(feature = "sev_snp")]
     fn gain_page_access(&self, _gpa: u64, _size: u32) -> Result<()> {
         Ok(())
+    }
+
+    #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+    fn enable_x2apic_api(&self) -> Result<()> {
+        unimplemented!("x2Apic is only supported on KVM/Linux hosts")
     }
 }
 


### PR DESCRIPTION
Also tweak extended interrupt handlings, as needed.

Most credit should go to Neel Natu, who figured out the magic bits needed to make things work and provided detailed comments.

This patch is still NOOP, as VM config allows only up to 254 vCPUs on x86_64.

Note: changes in this and related previous patches/PRs have only been tested on Linux hosts running on Intel x86_64 hardware.

Signed-off-by: Barret Rhoden <brho@google.com>
Signed-off-by: Neel Natu <neelnatu@google.com>
Signed-off-by: Ofir Weisse <oweisse@google.com>
Signed-off-by: Peter Oskolkov <posk@google.com>