### PR TITLE
vmm: Consolidate 'load_firmware/kernel' for aarch64 and riscv

### DIFF
--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -97,7 +97,7 @@ pub mod riscv64;
 pub use riscv64::{
     arch_memory_regions, configure_system, configure_vcpu, fdt::DeviceInfoForFdt,
     get_host_cpu_phys_bits, initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE,
-    layout::IRQ_BASE, EntryPoint, _NSIG,
+    layout::IRQ_BASE, uefi, EntryPoint, _NSIG,
 };
 
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
Both functions are defined separately for the two architecture with minor differences.

* `load_firmware()`: call `arch::uefi::load_uefi` which are available on both architecture;
* `load_kernel()`: manually align to `arch::layout::KERNEL_START` 2MB for both architecture (e.g. no-op for `aarch64`);