### PR TITLE
vmm: fix dma map after removing vfio device

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3740,6 +3740,10 @@ impl DeviceManager {
             vfio_container
         };
 
+        if !self.has_vfio_device() {
+            needs_dma_mapping = true;
+        }
+
         let vfio_device = VfioDevice::new(&device_cfg.path, Arc::clone(&vfio_container))
             .map_err(DeviceManagerError::VfioCreate)?;
 
@@ -4942,6 +4946,18 @@ impl DeviceManager {
     #[cfg(not(target_arch = "riscv64"))]
     pub(crate) fn acpi_platform_addresses(&self) -> &AcpiPlatformAddresses {
         &self.acpi_platform_addresses
+    }
+
+    fn has_vfio_device(&self) -> bool {
+        let device_tree = self.device_tree.lock().unwrap();
+        for pci_device_node in device_tree.pci_devices() {
+            let pci_device_handle = pci_device_node.pci_device_handle.as_ref().unwrap();
+            if matches!(pci_device_handle, PciDeviceHandle::Vfio(_)) {
+                return true;
+            }
+        }
+
+        false
     }
 }
 


### PR DESCRIPTION
Now cloud hypervisor do vfio dma map when first vfio container. However, vfio device will call Drop when remove all vfio device and vfio driver in kernel will unpin and unmap all guest pages. After this if new vfio device is added dma will fail because cloud hypervisor will not do vfio dma map again.

This patch adds a function to judge if vfio device exists, if all vfio device have been dropped we will do vfio dma map again.

Fixes: #7328