### PR TITLE
vmm: fix landlock on aarch64

### DIFF
--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -955,6 +955,11 @@ impl VmConfig {
     pub(crate) fn apply_landlock(&self) -> LandlockResult<()> {
         let mut landlock = Landlock::new()?;
 
+        #[cfg(target_arch = "aarch64")]
+        {
+            landlock.add_rule_with_access(Path::new("/sys/devices/system/cpu/cpu0/cache"), "r")?;
+        }
+
         if let Some(mem_zones) = &self.memory.zones {
             for zone in mem_zones.iter() {
                 zone.apply_landlock(&mut landlock)?;


### PR DESCRIPTION
arch::aarch64::fdt::create_cpu_nodes will always look at this if it exists.  (If it doesn't exist, this is a no-op —
add_rule_with_access() won't add rules for paths that don't exist.)

Fixes: b3e5738b4 ("vmm: Introduce ApplyLandlock trait")