### PR TITLE
vmm: fix vsock with landlock

### DIFF
--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -647,7 +647,12 @@ pub struct VsockConfig {
 
 impl ApplyLandlock for VsockConfig {
     fn apply_landlock(&self, landlock: &mut Landlock) -> LandlockResult<()> {
+        if let Some(parent) = self.socket.parent() {
+            landlock.add_rule_with_access(parent, "w")?;
+        }
+
         landlock.add_rule_with_access(&self.socket, "rw")?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
Without write access to the directory the socket will go in, it's not possible to create the socket.

I've tested outgoing connections from the VM, and they don't seem to need read permissions on that directory to connect to a socket on the host.

Fixes: b3e5738b4 ("vmm: Introduce ApplyLandlock trait")