### PR TITLE
seccomp: avoid hardcoding ioctl numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,6 +2489,7 @@ dependencies = [
  "uuid",
  "vfio-ioctls",
  "vfio_user",
+ "vhost",
  "virtio-bindings",
  "virtio-devices",
  "vm-allocator",

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use libc::{FIONBIO, TIOCGWINSZ, TUNSETOFFLOAD};
 use seccompiler::SeccompCmpOp::Eq;
 use seccompiler::{
     BpfProgram, Error, SeccompAction, SeccompCmpArgLen as ArgLen, SeccompCondition as Cond,
@@ -46,16 +47,9 @@ macro_rules! or {
     ($($x:expr),*) => (vec![$($x),*])
 }
 
-// See include/uapi/asm-generic/ioctls.h in the kernel code.
-const TIOCGWINSZ: u64 = 0x5413;
-const FIONBIO: u64 = 0x5421;
-
 // See include/uapi/linux/vfio.h in the kernel code.
 const VFIO_IOMMU_MAP_DMA: u64 = 0x3b71;
 const VFIO_IOMMU_UNMAP_DMA: u64 = 0x3b72;
-
-// See include/uapi/linux/if_tun.h in the kernel code.
-const TUNSETOFFLOAD: u64 = 0x4004_54d0;
 
 #[cfg(feature = "sev_snp")]
 fn mshv_sev_snp_ioctl_seccomp_rule() -> SeccompRule {
@@ -75,7 +69,7 @@ fn create_mshv_sev_snp_ioctl_seccomp_rule() -> Vec<SeccompRule> {
 
 fn create_virtio_console_ioctl_seccomp_rule() -> Vec<SeccompRule> {
     or![
-        and![Cond::new(1, ArgLen::Dword, Eq, TIOCGWINSZ).unwrap()],
+        and![Cond::new(1, ArgLen::Dword, Eq, TIOCGWINSZ as _).unwrap()],
         #[cfg(feature = "sev_snp")]
         mshv_sev_snp_ioctl_seccomp_rule(),
     ]
@@ -157,7 +151,7 @@ fn virtio_net_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
 
 fn create_virtio_net_ctl_ioctl_seccomp_rule() -> Vec<SeccompRule> {
     or![
-        and![Cond::new(1, ArgLen::Dword, Eq, TUNSETOFFLOAD).unwrap()],
+        and![Cond::new(1, ArgLen::Dword, Eq, TUNSETOFFLOAD as _).unwrap()],
         #[cfg(feature = "sev_snp")]
         mshv_sev_snp_ioctl_seccomp_rule(),
     ]
@@ -231,7 +225,7 @@ fn virtio_vhost_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
 
 fn create_vsock_ioctl_seccomp_rule() -> Vec<SeccompRule> {
     or![
-        and![Cond::new(1, ArgLen::Dword, Eq, FIONBIO,).unwrap()],
+        and![Cond::new(1, ArgLen::Dword, Eq, FIONBIO as _).unwrap()],
         #[cfg(feature = "sev_snp")]
         mshv_sev_snp_ioctl_seccomp_rule(),
     ]

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -78,6 +78,7 @@ tracer = { path = "../tracer" }
 uuid = { workspace = true }
 vfio-ioctls = { workspace = true, default-features = false }
 vfio_user = { workspace = true }
+vhost = { workspace = true }
 virtio-bindings = { workspace = true }
 virtio-devices = { path = "../virtio-devices" }
 vm-allocator = { path = "../vm-allocator" }


### PR DESCRIPTION
These can differ between platforms, so it's better to use centralized definitions of them.  We can't currently do this for the KVM and VFIO ioctls, because the corresponding crates don't publicly expose the ioctl numbers.