### PR TITLE
vmm: hypervisor: simplify VM creation API

### DIFF
--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 
 use thiserror::Error;
 
-use crate::HypervisorType;
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86::CpuIdEntry;
 #[cfg(target_arch = "x86_64")]
@@ -21,6 +20,7 @@ use crate::cpu::CpuVendor;
 #[cfg(feature = "tdx")]
 use crate::kvm::TdxCapabilities;
 use crate::vm::Vm;
+use crate::{HypervisorType, HypervisorVmConfig};
 
 #[derive(Error, Debug)]
 pub enum HypervisorError {
@@ -110,25 +110,7 @@ pub trait Hypervisor: Send + Sync {
     /// Create a Vm using the underlying hypervisor
     /// Return a hypervisor-agnostic Vm trait object
     ///
-    fn create_vm(&self) -> Result<Arc<dyn Vm>>;
-    ///
-    /// Create a Vm of a specific type using the underlying hypervisor
-    /// Return a hypervisor-agnostic Vm trait object
-    ///
-    fn create_vm_with_type(&self, _vm_type: u64) -> Result<Arc<dyn Vm>> {
-        unreachable!()
-    }
-    ///
-    /// Create a Vm of a specific type using the underlying hypervisor, passing memory size
-    /// Return a hypervisor-agnostic Vm trait object
-    ///
-    fn create_vm_with_type_and_memory(
-        &self,
-        _vm_type: u64,
-        #[cfg(feature = "sev_snp")] _mem_size: u64,
-    ) -> Result<Arc<dyn Vm>> {
-        unreachable!()
-    }
+    fn create_vm(&self, config: HypervisorVmConfig) -> Result<Arc<dyn Vm>>;
     #[cfg(target_arch = "x86_64")]
     ///
     /// Get the supported CpuID

--- a/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -482,6 +482,7 @@ impl Vgic for KvmGicV3Its {
 
 #[cfg(test)]
 mod tests {
+    use crate::HypervisorVmConfig;
     use crate::aarch64::gic::{
         get_dist_regs, get_icc_regs, get_redist_regs, set_dist_regs, set_icc_regs, set_redist_regs,
     };
@@ -506,7 +507,7 @@ mod tests {
     #[test]
     fn test_create_gic() {
         let hv = crate::new().unwrap();
-        let vm = hv.create_vm().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
 
         KvmGicV3Its::new(&*vm, create_test_vgic_config()).unwrap();
     }
@@ -514,7 +515,7 @@ mod tests {
     #[test]
     fn test_get_set_dist_regs() {
         let hv = crate::new().unwrap();
-        let vm = hv.create_vm().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
         let _ = vm.create_vcpu(0, None).unwrap();
         let gic = KvmGicV3Its::new(&*vm, create_test_vgic_config()).expect("Cannot create gic");
 
@@ -527,7 +528,7 @@ mod tests {
     #[test]
     fn test_get_set_redist_regs() {
         let hv = crate::new().unwrap();
-        let vm = hv.create_vm().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
         let _ = vm.create_vcpu(0, None).unwrap();
         let gic = KvmGicV3Its::new(&*vm, create_test_vgic_config()).expect("Cannot create gic");
 
@@ -542,7 +543,7 @@ mod tests {
     #[test]
     fn test_get_set_icc_regs() {
         let hv = crate::new().unwrap();
-        let vm = hv.create_vm().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
         let _ = vm.create_vcpu(0, None).unwrap();
         let gic = KvmGicV3Its::new(&*vm, create_test_vgic_config()).expect("Cannot create gic");
 
@@ -557,7 +558,7 @@ mod tests {
     #[test]
     fn test_save_data_tables() {
         let hv = crate::new().unwrap();
-        let vm = hv.create_vm().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
         let _ = vm.create_vcpu(0, None).unwrap();
         let gic = vm
             .create_vgic(create_test_vgic_config())

--- a/hypervisor/src/kvm/riscv64/aia.rs
+++ b/hypervisor/src/kvm/riscv64/aia.rs
@@ -251,6 +251,7 @@ impl Vaia for KvmAiaImsics {
 
 #[cfg(test)]
 mod tests {
+    use crate::HypervisorVmConfig;
     use crate::arch::riscv64::aia::VaiaConfig;
     use crate::kvm::KvmAiaImsics;
 
@@ -266,7 +267,7 @@ mod tests {
     #[test]
     fn test_create_aia() {
         let hv = crate::new().unwrap();
-        let vm = hv.create_vm().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
         let _vcpu = vm.create_vcpu(0, None).unwrap();
 
         assert!(KvmAiaImsics::new(&*vm, create_test_vaia_config()).is_ok());

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -188,6 +188,16 @@ impl ClockData {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct HypervisorVmConfig {
+    #[cfg(feature = "tdx")]
+    pub tdx_enabled: bool,
+    #[cfg(feature = "sev_snp")]
+    pub sev_snp_enabled: bool,
+    #[cfg(feature = "sev_snp")]
+    pub mem_size: u64,
+}
+
 #[derive(Copy, Clone)]
 pub enum IrqRoutingEntry {
     #[cfg(feature = "kvm")]

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -2861,14 +2861,16 @@ mod tests {
     use arch::layout::{BOOT_STACK_POINTER, ZERO_PAGE_START};
     use arch::x86_64::interrupts::*;
     use arch::x86_64::regs::*;
-    use hypervisor::StandardRegisters;
     use hypervisor::arch::x86::{FpuState, LapicState};
+    use hypervisor::{HypervisorVmConfig, StandardRegisters};
     use linux_loader::loader::bootparam::setup_header;
 
     #[test]
     fn test_setlint() {
         let hv = hypervisor::new().unwrap();
-        let vm = hv.create_vm().expect("new VM fd creation failed");
+        let vm = hv
+            .create_vm(HypervisorVmConfig::default())
+            .expect("new VM fd creation failed");
         hv.check_required_extensions().unwrap();
         // Calling get_lapic will fail if there is no irqchip before hand.
         vm.create_irq_chip().unwrap();
@@ -2894,7 +2896,9 @@ mod tests {
     #[test]
     fn test_setup_fpu() {
         let hv = hypervisor::new().unwrap();
-        let vm = hv.create_vm().expect("new VM fd creation failed");
+        let vm = hv
+            .create_vm(HypervisorVmConfig::default())
+            .expect("new VM fd creation failed");
         let vcpu = vm.create_vcpu(0, None).unwrap();
         setup_fpu(&vcpu).unwrap();
 
@@ -2918,7 +2922,9 @@ mod tests {
         use hypervisor::arch::x86::{MsrEntry, msr_index};
 
         let hv = hypervisor::new().unwrap();
-        let vm = hv.create_vm().expect("new VM fd creation failed");
+        let vm = hv
+            .create_vm(HypervisorVmConfig::default())
+            .expect("new VM fd creation failed");
         let vcpu = vm.create_vcpu(0, None).unwrap();
         setup_msrs(&vcpu).unwrap();
 
@@ -2944,7 +2950,9 @@ mod tests {
     #[test]
     fn test_setup_regs_for_pvh() {
         let hv = hypervisor::new().unwrap();
-        let vm = hv.create_vm().expect("new VM fd creation failed");
+        let vm = hv
+            .create_vm(HypervisorVmConfig::default())
+            .expect("new VM fd creation failed");
         let vcpu = vm.create_vcpu(0, None).unwrap();
 
         let mut expected_regs: StandardRegisters = vcpu.create_standard_regs();
@@ -2968,7 +2976,9 @@ mod tests {
     #[test]
     fn test_setup_regs_for_bzimage() {
         let hv = hypervisor::new().unwrap();
-        let vm = hv.create_vm().expect("new VM fd creation failed");
+        let vm = hv
+            .create_vm(HypervisorVmConfig::default())
+            .expect("new VM fd creation failed");
         let vcpu = vm.create_vcpu(0, None).unwrap();
 
         let mut expected_regs: StandardRegisters = vcpu.create_standard_regs();
@@ -3000,7 +3010,6 @@ mod tests {
     use std::{mem, mem::offset_of};
 
     use arch::layout;
-    use hypervisor::HypervisorCpuError;
     use hypervisor::arch::aarch64::regs::MPIDR_EL1;
     #[cfg(feature = "kvm")]
     use hypervisor::arm64_core_reg_id;
@@ -3010,11 +3019,12 @@ mod tests {
     use hypervisor::kvm::kvm_bindings::{
         KVM_REG_ARM_CORE, KVM_REG_ARM64, KVM_REG_ARM64_SYSREG, KVM_REG_SIZE_U64, user_pt_regs,
     };
+    use hypervisor::{HypervisorCpuError, HypervisorVmConfig};
 
     #[test]
     fn test_setup_regs() {
         let hv = hypervisor::new().unwrap();
-        let vm = hv.create_vm().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
         let vcpu = vm.create_vcpu(0, None).unwrap();
 
         // Must fail when vcpu is not initialized yet.
@@ -3030,7 +3040,7 @@ mod tests {
     #[test]
     fn test_read_mpidr() {
         let hv = hypervisor::new().unwrap();
-        let vm = hv.create_vm().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
         let vcpu = vm.create_vcpu(0, None).unwrap();
         let mut kvi = vcpu.create_vcpu_init();
         vm.get_preferred_target(&mut kvi).unwrap();
@@ -3055,7 +3065,7 @@ mod tests {
     #[test]
     fn test_save_restore_core_regs() {
         let hv = hypervisor::new().unwrap();
-        let vm = hv.create_vm().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
         let vcpu = vm.create_vcpu(0, None).unwrap();
         let mut kvi = vcpu.create_vcpu_init();
         vm.get_preferred_target(&mut kvi).unwrap();
@@ -3105,7 +3115,7 @@ mod tests {
     #[test]
     fn test_get_set_mpstate() {
         let hv = hypervisor::new().unwrap();
-        let vm = hv.create_vm().unwrap();
+        let vm = hv.create_vm(HypervisorVmConfig::default()).unwrap();
         let vcpu = vm.create_vcpu(0, None).unwrap();
         let mut kvi = vcpu.create_vcpu_init();
         vm.get_preferred_target(&mut kvi).unwrap();


### PR DESCRIPTION
For MSHV customers don't want to make everything default during partition creation. For example nested support, some synthetic features could be controlled from CLI through platform argument. create_vm API getting messy after adding more flags. This patch introduces common data struct to be passed from vmm crate to hypervisor crate during partition creation.