### PR TITLE
vmm: add info! message on graceful shutdown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::{env, io};
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches, Command};
 use event_monitor::event;
 use libc::EFD_NONBLOCK;
-use log::{LevelFilter, error, warn};
+use log::{LevelFilter, error, info, warn};
 use option_parser::OptionParser;
 use seccompiler::SeccompAction;
 use signal_hook::consts::SIGSYS;
@@ -891,6 +891,7 @@ fn main() {
     let exit_code = match start_vmm(cmd_arguments) {
         Ok(path) => {
             path.map(|s| std::fs::remove_file(s).ok());
+            info!("Cloud Hypervisor exited successfully");
             0
         }
         Err(top_error) => {


### PR DESCRIPTION
This message makes it easier to confirm a successful shutdown when scanning logs during development as well as in production. If the message is missing and the last log entry is not an error, the most likely cause is a livelock (e.g. contention on a lock) introduced while developing new Cloud Hypervisor features.
