### PR TITLE
hypervisor: remove invalid url

### DIFF
--- a/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -216,9 +216,7 @@ impl KvmGicV3Its {
             0,
         )?;
 
-        /* Finalize the GIC.
-         * See https://code.woboq.org/linux/linux/virt/kvm/arm/vgic/vgic-kvm-device.c.html#211.
-         */
+        // Finalize the GIC.
         Self::set_device_attribute(
             &self.device,
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_CTRL,


### PR DESCRIPTION
Reference link to set_device_attribut for aarch64
is invalid. Looks like the code browsing does not
have the reference anymore.