### PR TITLE
logger: improve format of timestamp (quality of life improvement)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,12 +133,14 @@ impl log::Log for Logger {
 
         let now = std::time::Instant::now();
         let duration = now.duration_since(self.start);
+        let duration_s = duration.as_secs_f32();
 
         if record.file().is_some() && record.line().is_some() {
             write!(
                 *(*(self.output.lock().unwrap())),
-                "cloud-hypervisor: {:.6?}: <{}> {}:{}:{} -- {}\r\n",
-                duration,
+                // 10: 6 decimal places + sep => whole seconds in range `0..=999` properly aligned
+                "cloud-hypervisor: {:>10.6?}s: <{}> {}:{}:{} -- {}\r\n",
+                duration_s,
                 std::thread::current().name().unwrap_or("anonymous"),
                 record.level(),
                 record.file().unwrap(),
@@ -148,8 +150,9 @@ impl log::Log for Logger {
         } else {
             write!(
                 *(*(self.output.lock().unwrap())),
-                "cloud-hypervisor: {:.6?}: <{}> {}:{} -- {}\r\n",
-                duration,
+                // 10: 6 decimal places + sep => whole seconds in range `0..=999` properly aligned
+                "cloud-hypervisor: {:>10.6?}s: <{}> {}:{} -- {}\r\n",
+                duration_s,
                 std::thread::current().name().unwrap_or("anonymous"),
                 record.level(),
                 record.target(),


### PR DESCRIPTION
This is a small improvement to the timestamp in the logging format.

# Example (old style)
```
cloud-hypervisor: 858.465660ms: <vcpu0> DEBUG:devices/src/ioapic.rs:154 -- IOAPIC_R @ offset 0x10
cloud-hypervisor: 858.507342ms: <vcpu0> DEBUG:devices/src/ioapic.rs:298 -- IOAPIC_R reg 0x1
cloud-hypervisor: 1.010001s: <vcpu0> DEBUG:devices/src/ioapic.rs:174 -- IOAPIC_W @ offset 0x0
cloud-hypervisor: 1.010067s: <vcpu0> DEBUG:devices/src/ioapic.rs:154 -- IOAPIC_R @ offset 0x10
```

# Example (new style)
```
cloud-hypervisor:   0.731399s: <vcpu0> DEBUG:devices/src/ioapic.rs:174 -- IOAPIC_W @ offset 0x10
cloud-hypervisor:   0.731420s: <vcpu0> DEBUG:devices/src/ioapic.rs:252 -- IOAPIC_W reg 0x2a, val 0x10000
cloud-hypervisor:  17.026073s: <vmm> INFO:vmm/src/api/mod.rs:898 -- API request event: VmInfo
cloud-hypervisor:  17.263210s: <vmm> INFO:vmm/src/api/mod.rs:898 -- API request event: VmInfo
cloud-hypervisor:  17.547915s: <vmm> INFO:vmm/src/api/mod.rs:898 -- API request event: VmInfo
```
