### PR TITLE
vmm: Drop 'vfio container' when no active vfio devices

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4942,6 +4942,18 @@ impl DeviceManager {
     pub(crate) fn acpi_platform_addresses(&self) -> &AcpiPlatformAddresses {
         &self.acpi_platform_addresses
     }
+
+    fn cleanup_vfio_container(&mut self) {
+        // Drop the 'vfio container' instance when "Self" is the only reference
+        if let Some(1) = self
+            .vfio_container
+            .as_ref()
+            .map(|container| Arc::strong_count(container))
+        {
+            info!("Drop 'vfio container' given no active 'vfio devices'.");
+            self.vfio_container = None;
+        }
+    }
 }
 
 #[cfg(feature = "ivshmem")]
@@ -5425,6 +5437,7 @@ impl BusDevice for DeviceManager {
                     if let Err(e) = self.eject_device(self.selected_segment as u16, slot_id as u8) {
                         error!("Failed ejecting device {}: {:?}", slot_id, e);
                     }
+                    self.cleanup_vfio_container();
                     slot_bitmap &= !(1 << slot_id);
                 }
             }


### PR DESCRIPTION
This provides clearer life-cycle management of resources around vfio, and aligns better with the kernel behavior as reported below with vfio legacy mode (with vfio container/group).

Fixes: #7328