### PR TITLE
vmm: allow net devices without ip and mask

### DIFF
--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -36,7 +36,7 @@ struct OptionParserValue {
     requires_value: bool,
 }
 
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub enum OptionParserError {
     #[error("unknown option: {0}")]
     UnknownOption(String),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1340,20 +1340,6 @@ mod unit_tests {
                 vec![
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--net",
-                    "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,tap=tap0,ip=1.2.3.4",
-                ],
-                r#"{
-                    "payload": {"kernel": "/path/to/kernel"},
-                    "net": [
-                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "tap": "tap0", "ip": "1.2.3.4"}
-                    ]
-                }"#,
-                true,
-            ),
-            (
-                vec![
-                    "cloud-hypervisor", "--kernel", "/path/to/kernel",
-                    "--net",
                     "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,tap=tap0,ip=1.2.3.4,mask=5.6.7.8",
                 ],
                 r#"{

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2904,8 +2904,8 @@ impl DeviceManager {
                     virtio_devices::Net::new(
                         id.clone(),
                         Some(tap_if_name),
-                        Some(net_cfg.ip),
-                        Some(net_cfg.mask),
+                        net_cfg.ip,
+                        net_cfg.mask,
                         Some(net_cfg.mac),
                         &mut net_cfg.host_mac,
                         net_cfg.mtu,
@@ -2955,8 +2955,8 @@ impl DeviceManager {
                     virtio_devices::Net::new(
                         id.clone(),
                         None,
-                        Some(net_cfg.ip),
-                        Some(net_cfg.mask),
+                        net_cfg.ip,
+                        net_cfg.mask,
                         Some(net_cfg.mac),
                         &mut net_cfg.host_mac,
                         net_cfg.mtu,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 #[cfg(feature = "fw_cfg")]
 use std::str::FromStr;
@@ -303,10 +303,8 @@ pub fn default_diskconfig_queue_size() -> u16 {
 pub struct NetConfig {
     #[serde(default = "default_netconfig_tap")]
     pub tap: Option<String>,
-    #[serde(default = "default_netconfig_ip")]
-    pub ip: IpAddr,
-    #[serde(default = "default_netconfig_mask")]
-    pub mask: IpAddr,
+    pub ip: Option<IpAddr>,
+    pub mask: Option<IpAddr>,
     #[serde(default = "default_netconfig_mac")]
     pub mac: MacAddr,
     #[serde(default)]
@@ -350,20 +348,6 @@ pub fn default_netconfig_true() -> bool {
 
 pub fn default_netconfig_tap() -> Option<String> {
     None
-}
-
-pub fn default_netconfig_ip() -> IpAddr {
-    warn!(
-        "Deprecation warning: No IP address provided. A default IP address is assigned. This behavior will be deprecated soon."
-    );
-    IpAddr::V4(Ipv4Addr::new(192, 168, 249, 1))
-}
-
-pub fn default_netconfig_mask() -> IpAddr {
-    warn!(
-        "Deprecation warning: No network mask provided. A default network mask is assigned. This behavior will be deprecated soon."
-    );
-    IpAddr::V4(Ipv4Addr::new(255, 255, 255, 0))
 }
 
 pub fn default_netconfig_mac() -> MacAddr {


### PR DESCRIPTION
This change enables easier integration with third-party tools by removing the requirement for a dummy IP address when configuring tap devices. The modification applies to both CLI and API interactions.

Previously, cloud-hypervisor would automatically set a default static IP address (192.168.249.1) if none was provided.

This could lead to:

* multiple devices without explicit IP configurations would end up with the same default IP
* unnecessary inclusion of this IP in firewall rules
* the IP address could clash with host networking and routing

Removes warnings introduced in #7179.
Closes issue #7083.

Supersedes #7076