### PR TITLE
devices: gracefully close preserved FDs on hot device remove

### DIFF
--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -926,6 +926,10 @@ pub struct VmConfig {
     // VmConfig instance, such as FDs for creating TAP devices.
     // Preserved FDs will stay open as long as the holding VmConfig instance is
     // valid, and will be closed when the holding VmConfig instance is destroyed.
+    //
+    // This is populated as devices are added at runtime. Removing them again
+    // causes the FDs to be closed early. This allows management software to
+    // gracefully clean up resources (e.g., libvirt closes tap devices).
     #[serde(skip)]
     pub preserved_fds: Option<Vec<i32>>,
     #[serde(default)]


### PR DESCRIPTION
For a graceful resource management of externally provided FDs in Cloud
Hypervisor, corresponding FDs need to be closed on a device removal.
This is the case for virtio-net devices using external FDs, for example.

With the fix introduced in this commit, we allow management software to
properly clean up resources, e.g., libvirt can clean up tap devices.

PS: CHV uses "added" and "removed", which has the same meaning as
hot device attach/hotplug and hot device detach/unplug.


---
Part of #7291.