### PR TITLE
ci: Make package-ecosystem combination unique

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,6 @@ updates:
       rust-vmm:
         patterns:
           - "*"
-  target-branch: main
 - package-ecosystem: cargo
   directories:
     - "/"


### PR DESCRIPTION
"Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'cargo' has overlapping directories for target branch 'main'."

Drop `target-branch` in rust-vmm group to make those two unique.