### PR TITLE
hypervisor: kvm/x86_64: get and set nested guest state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b153a59bb3ca930ff8148655b2ef68c34259a623ae08cf2fb9b570b2e45363"
+checksum = "9a537873e15e8daabb416667e606d9b0abc2a8fb9a45bd5853b888ae0ead82f9"
 dependencies = [
  "serde",
  "vmm-sys-util",
@@ -1084,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b702df98508cb63ad89dd9beb9f6409761b30edca10d48e57941d3f11513a006"
+checksum = "0c8f7370330b4f57981e300fa39b02088f2f2a5c2d0f1f994e8090589619c56d"
 dependencies = [
  "bitflags 2.9.4",
  "kvm-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ package.edition = "2024"
 [workspace.dependencies]
 # rust-vmm crates
 acpi_tables = { git = "https://github.com/rust-vmm/acpi_tables", branch = "main" }
-kvm-bindings = "0.12.0"
-kvm-ioctls = "0.22.0"
+kvm-bindings = "0.12.1"
+kvm-ioctls = "0.22.1"
 # TODO: update to 0.13.1+
 linux-loader = { git = "https://github.com/rust-vmm/linux-loader", branch = "main" }
 mshv-bindings = "0.6.0"

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -334,6 +334,10 @@ pub enum HypervisorCpuError {
     ///
     #[error("Failed to inject NMI")]
     Nmi(#[source] anyhow::Error),
+    #[error("Failed to get nested guest state")]
+    GetNestedState(#[source] anyhow::Error),
+    #[error("Failed to set nested guest state")]
+    SetNestedState(#[source] anyhow::Error),
 }
 
 #[derive(Debug)]

--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -19,6 +19,7 @@ pub use {
     kvm_bindings::kvm_msr_entry, kvm_bindings::kvm_regs, kvm_bindings::kvm_segment,
     kvm_bindings::kvm_sregs, kvm_bindings::kvm_vcpu_events as VcpuEvents,
     kvm_bindings::kvm_xcrs as ExtendedControlRegisters, kvm_bindings::kvm_xsave,
+    kvm_bindings::nested::KvmNestedStateBuffer,
 };
 
 use crate::arch::x86::{
@@ -75,6 +76,9 @@ pub struct VcpuKvmState {
     pub xcrs: ExtendedControlRegisters,
     pub mp_state: MpState,
     pub tsc_khz: Option<u32>,
+    // Option to prevent useless 8K (de)serialization when no nested
+    // state exists.
+    pub nested_state: Option<KvmNestedStateBuffer>,
 }
 
 impl From<SegmentRegister> for kvm_segment {

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -103,6 +103,8 @@ mod kvm {
     pub const KVM_GET_REG_LIST: u64 = 0xc008_aeb0;
     pub const KVM_MEMORY_ENCRYPT_OP: u64 = 0xc008_aeba;
     pub const KVM_NMI: u64 = 0xae9a;
+    pub const KVM_GET_NESTED_STATE: u64 = 3229658814;
+    pub const KVM_SET_NESTED_STATE: u64 = 1082175167;
 }
 
 // MSHV IOCTL code. This is unstable until the kernel code has been declared stable.
@@ -232,6 +234,8 @@ fn create_vmm_ioctl_seccomp_rule_common_kvm() -> Result<Vec<SeccompRule>, Backen
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_USER_MEMORY_REGION,)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_VCPU_EVENTS,)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_NMI)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_GET_NESTED_STATE)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_NESTED_STATE)?],
     ])
 }
 
@@ -697,6 +701,8 @@ fn create_vcpu_ioctl_seccomp_rule_kvm() -> Result<Vec<SeccompRule>, BackendError
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_USER_MEMORY_REGION,)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_RUN,)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_NMI)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_GET_NESTED_STATE)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_NESTED_STATE)?],
     ])
 }
 


### PR DESCRIPTION
Since the functionality of [0] was backported to `kvm-bindings@v0.12.1` and `kvm-ioctls@v0.22.1` [1, 2], we can now save nested KVM state. This way, nesting works across state save/resume and live-migration.

[0] https://github.com/rust-vmm/kvm/pull/322
[1] https://github.com/rust-vmm/kvm/pull/349
[2] https://github.com/rust-vmm/kvm/pull/350


Closes #7160 (makes it obsolete).
