### PR TITLE
vmm: Enable RISC-V ACPI support

### DIFF
--- a/arch/src/riscv64/layout.rs
+++ b/arch/src/riscv64/layout.rs
@@ -98,7 +98,12 @@ pub const CMDLINE_MAX_SIZE: usize = 1024;
 pub const FDT_START: GuestAddress = RAM_START;
 pub const FDT_MAX_SIZE: u64 = 0x1_0000;
 
-/// Kernel start after FDT
+/// Put ACPI table above dtb
+pub const ACPI_START: GuestAddress = GuestAddress(RAM_START.0 + FDT_MAX_SIZE);
+pub const ACPI_MAX_SIZE: u64 = 0x20_0000;
+pub const RSDP_POINTER: GuestAddress = ACPI_START;
+
+/// Kernel start after FDT and ACPI
 pub const KERNEL_START: GuestAddress = GuestAddress(RAM_START.0 + FDT_MAX_SIZE);
 
 /// Pci high memory base

--- a/arch/src/riscv64/mod.rs
+++ b/arch/src/riscv64/mod.rs
@@ -22,6 +22,11 @@ use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryAtomic};
 pub use self::fdt::DeviceInfoForFdt;
 use crate::{DeviceType, GuestMemoryMmap, PciSpaceInfo, RegionType};
 
+pub const CLOUDHV_IRQCHIP_NUM_MSIS: u16 = 255;
+pub const CLOUDHV_IRQCHIP_NUM_SOURCES: u8 = 96;
+pub const CLOUDHV_IRQCHIP_NUM_PRIO_BITS: u8 = 3;
+pub const CLOUDHV_IRQCHIP_MAX_GUESTS_BITS: u8 = 3;
+pub const CLOUDHV_IRQCHIP_MAX_GUESTS: u8 = (1 << CLOUDHV_IRQCHIP_MAX_GUESTS_BITS) - 1;
 pub const _NSIG: i32 = 65;
 
 /// Errors thrown while configuring riscv64 system.

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -44,6 +44,10 @@ pub const ACPI_APIC_GIC_MSI_FRAME: u8 = 13;
 pub const ACPI_APIC_GENERIC_REDISTRIBUTOR: u8 = 14;
 #[cfg(target_arch = "aarch64")]
 pub const ACPI_APIC_GENERIC_TRANSLATOR: u8 = 15;
+#[cfg(target_arch = "riscv64")]
+pub const ACPI_RISC_V_IMSIC: u8 = 0x19;
+#[cfg(target_arch = "riscv64")]
+pub const ACPI_RISC_V_APLIC: u8 = 0x1A;
 
 #[allow(dead_code)]
 #[repr(C, packed)]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -67,7 +67,6 @@ use crate::vm_config::{
     VmConfig, VsockConfig,
 };
 
-#[cfg(not(target_arch = "riscv64"))]
 mod acpi;
 pub mod api;
 mod clone3;


### PR DESCRIPTION
Add necessary definitions, RISC-V ACPI tables and entries to enable ACPI feature.