### PR TITLE
api_client: fix clippy

### DIFF
--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -188,8 +188,8 @@ pub fn simple_api_full_command_with_fds<T: Read + Write + ScmSocket>(
         request_fds,
     )?;
 
-    if response.is_some() {
-        println!("{}", response.unwrap());
+    if let Some(response) = response {
+        println!("{response}");
     }
 
     Ok(())


### PR DESCRIPTION
Upcoming (still nightly) versions of clippy have a new lint.