### PR TITLE
tests: Reduce parallelism on x86-64 testing

### DIFF
--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -178,7 +178,7 @@ ulimit -l unlimited
 ulimit -n 4096
 
 export RUST_BACKTRACE=1
-time cargo test --release --target "$BUILD_TARGET" $test_features "common_parallel::$test_filter" -- ${test_binary_args[*]}
+time cargo test --release --target "$BUILD_TARGET" $test_features "common_parallel::$test_filter" -- ${test_binary_args[*]} --test-threads=$((($(nproc) * 3) / 4))
 RES=$?
 
 # Run some tests in sequence since the result could be affected by other tests


### PR DESCRIPTION
Only use 75% of the available threads - this will reduce dislk and
memory pressure. Reducing the chance of flaky tests.

See: #7405

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
