### PR TITLE
arch: move GICv2M SPI base to leave room for legacy IRQs

### DIFF
--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -25,8 +25,9 @@ use vm_memory::{Address, Bytes, GuestMemory, GuestMemoryError, GuestMemoryRegion
 
 use super::super::{DeviceType, GuestMemoryMmap, InitramfsConfig};
 use super::layout::{
-    GIC_V2M_COMPATIBLE, IRQ_BASE, MEM_32BIT_DEVICES_SIZE, MEM_32BIT_DEVICES_START, MEM_PCI_IO_SIZE,
-    MEM_PCI_IO_START, PCI_HIGH_BASE, PCI_MMIO_CONFIG_SIZE_PER_SEGMENT, SPI_BASE, SPI_NUM,
+    GIC_V2M_COMPATIBLE, GICV2M_SPI_BASE, GICV2M_SPI_NUM, IRQ_BASE, MEM_32BIT_DEVICES_SIZE,
+    MEM_32BIT_DEVICES_START, MEM_PCI_IO_SIZE, MEM_PCI_IO_START, PCI_HIGH_BASE,
+    PCI_MMIO_CONFIG_SIZE_PER_SEGMENT,
 };
 use crate::{NumaNodes, PciSpaceInfo};
 
@@ -666,8 +667,8 @@ fn create_gic_node(fdt: &mut FdtWriter, gic_device: &Arc<Mutex<dyn Vgic>>) -> Fd
         fdt.property_array_u64("reg", &msi_reg_prop)?;
 
         if msi_compatibility == GIC_V2M_COMPATIBLE {
-            fdt.property_u32("arm,msi-base-spi", SPI_BASE)?;
-            fdt.property_u32("arm,msi-num-spis", SPI_NUM)?;
+            fdt.property_u32("arm,msi-base-spi", GICV2M_SPI_BASE)?;
+            fdt.property_u32("arm,msi-num-spis", GICV2M_SPI_NUM)?;
         }
 
         fdt.end_node(msic_node)?;

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -139,11 +139,11 @@ pub const IRQ_BASE: u32 = 32;
 /// Number of supported interrupts
 pub const IRQ_NUM: u32 = 256;
 
-/// Base SPI interrupt number
-pub const SPI_BASE: u32 = 32;
+/// Base SPI interrupt number for the GICv2M MSI frame
+pub const GICV2M_SPI_BASE: u32 = 128;
 
-/// Total number of SPIs
-pub const SPI_NUM: u32 = 64;
+/// Total number of SPIs for the GICv2M MSI frame
+pub const GICV2M_SPI_NUM: u32 = 64;
 
 /// GICv2M compatible string
 pub const GIC_V2M_COMPATIBLE: &str = "arm,gic-v2m-frame";

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1578,7 +1578,7 @@ impl CpuManager {
 
         #[cfg(target_arch = "aarch64")]
         {
-            use arch::layout::{GIC_V2M_COMPATIBLE, SPI_BASE, SPI_NUM};
+            use arch::layout::{GIC_V2M_COMPATIBLE, GICV2M_SPI_BASE, GICV2M_SPI_NUM};
 
             /* Notes:
              * Ignore Local Interrupt Controller Address at byte offset 36 of MADT table.
@@ -1654,8 +1654,8 @@ impl CpuManager {
                     msi_frame_id: 0,
                     base_address: vgic_config.msi_addr,
                     flags: 1,
-                    spi_count: SPI_NUM as u16,
-                    spi_base: SPI_BASE as u16,
+                    spi_count: GICV2M_SPI_NUM as u16,
+                    spi_base: GICV2M_SPI_BASE as u16,
                 };
                 madt.append(gic_msi_frame);
             } else {


### PR DESCRIPTION
Move the GICv2M MSI frame SPI base from 32 to 128 to avoid conflicts with platform device interrupts.

While at it, rename the constants to make it explicit that they are associated with the GICv2m MSI Frame.

Only MSHV uses GICv2m. So, this change only affects MSHV.