### PR TITLE
ci: update MSHV workflow & job names

### DIFF
--- a/.github/workflows/mshv-integration.yaml
+++ b/.github/workflows/mshv-integration.yaml
@@ -1,4 +1,4 @@
-name: MSHV Integration Tests
+name: Cloud Hypervisor Tests (MSHV) (x86_64)
 on: [pull_request_target, merge_group]
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
       USERNAME: ${{ secrets.MSHV_USERNAME }}
 
   run-tests:
-    name: Integration Tests
+    name: Integration Tests (x86_64)
     needs: infra-setup
     if: ${{ always() && needs.infra-setup.result == 'success' }}
     runs-on: mshv


### PR DESCRIPTION
Rename the MSHV CI workflow to better align with the existing naming scheme and also make the arch explicit.