### PR TITLE
virtio-devices: pci_common_config: Remove warning for feature pages > 2

### DIFF
--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -330,11 +330,6 @@ impl VirtioPciCommonConfig {
                     let mut locked_device = device.lock().unwrap();
                     locked_device
                         .ack_features(u64::from(value) << (self.driver_feature_select * 32));
-                } else {
-                    warn!(
-                        "invalid ack_features (page {}, value 0x{:x})",
-                        self.driver_feature_select, value
-                    );
                 }
             }
             0x20 => self.with_queue_mut(queues, |q| q.set_desc_table_address(Some(value), None)),


### PR DESCRIPTION
The virtio spec defines the feature bit range and 4 x 32-bit pages.
However no features are currently defined with bits > 63. However Linux
has now started acking features in those higher pages. Since this is
harmless (we drop the acks to those feature pages) and quietly return 0
for available features in those higher pages this warning can be
removed.

Fixes: #7414

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
