### PR TITLE
ci: Extend typos to accept MSIS

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -11,6 +11,7 @@ CLASSE = "CLASSE"
 Dake = "Dake"
 EXTINT = "EXTINT"
 INOUT = "INOUT"
+MSIS = "MSIS" # MSIs (Message Signaled Interrupt)
 SME = "SME" # Secure Memory Encryption
 THR = "THR" # Transmitter Holding Register
 TRANSLATER = "TRANSLATER"


### PR DESCRIPTION
Previous RISC-V ACPI related change introduced MSIS which will be rejected by typo check, let's extend the typos to accept it.