### PR TITLE
hypervisor, vmm: Remove inner Mutex protecting VcpuFd

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -66,7 +66,7 @@ pub struct EntryPoint {
 
 /// Configure the specified VCPU, and return its MPIDR.
 pub fn configure_vcpu(
-    vcpu: &Arc<dyn hypervisor::Vcpu>,
+    vcpu: &dyn hypervisor::Vcpu,
     id: u32,
     boot_setup: Option<(EntryPoint, &GuestMemoryAtomic<GuestMemoryMmap>)>,
 ) -> super::Result<u64> {

--- a/arch/src/riscv64/mod.rs
+++ b/arch/src/riscv64/mod.rs
@@ -63,7 +63,7 @@ pub struct EntryPoint {
 
 /// Configure the specified VCPU, and return its MPIDR.
 pub fn configure_vcpu(
-    vcpu: &Arc<dyn hypervisor::Vcpu>,
+    vcpu: &dyn hypervisor::Vcpu,
     id: u32,
     boot_setup: Option<(EntryPoint, &GuestMemoryAtomic<GuestMemoryMmap>)>,
 ) -> super::Result<()> {

--- a/arch/src/x86_64/interrupts.rs
+++ b/arch/src/x86_64/interrupts.rs
@@ -6,7 +6,6 @@
 // found in the LICENSE-BSD-3-Clause file.
 
 use std::result;
-use std::sync::Arc;
 
 pub type Result<T> = result::Result<T, hypervisor::HypervisorCpuError>;
 
@@ -24,7 +23,7 @@ pub fn set_apic_delivery_mode(reg: u32, mode: u32) -> u32 {
 ///
 /// # Arguments
 /// * `vcpu` - The VCPU object to configure.
-pub fn set_lint(vcpu: &Arc<dyn hypervisor::Vcpu>) -> Result<()> {
+pub fn set_lint(vcpu: &dyn hypervisor::Vcpu) -> Result<()> {
     let mut klapic = vcpu.get_lapic()?;
 
     let lvt_lint0 = klapic.get_klapic_reg(APIC_LVT0);

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -775,7 +775,7 @@ pub fn generate_common_cpuid(
 }
 
 pub fn configure_vcpu(
-    vcpu: &Arc<dyn hypervisor::Vcpu>,
+    vcpu: &dyn hypervisor::Vcpu,
     id: u32,
     boot_setup: Option<(EntryPoint, &GuestMemoryAtomic<GuestMemoryMmap>)>,
     cpuid: Vec<CpuIdEntry>,

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -6,7 +6,6 @@
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
-use std::sync::Arc;
 use std::{mem, result};
 
 use hypervisor::arch::x86::gdt::{gdt_entry, segment_from_gdt};
@@ -67,7 +66,7 @@ pub type Result<T> = result::Result<T, Error>;
 /// # Arguments
 ///
 /// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
-pub fn setup_fpu(vcpu: &Arc<dyn hypervisor::Vcpu>) -> Result<()> {
+pub fn setup_fpu(vcpu: &dyn hypervisor::Vcpu) -> Result<()> {
     let fpu: FpuState = FpuState {
         fcw: 0x37f,
         mxcsr: 0x1f80,
@@ -82,7 +81,7 @@ pub fn setup_fpu(vcpu: &Arc<dyn hypervisor::Vcpu>) -> Result<()> {
 /// # Arguments
 ///
 /// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
-pub fn setup_msrs(vcpu: &Arc<dyn hypervisor::Vcpu>) -> Result<()> {
+pub fn setup_msrs(vcpu: &dyn hypervisor::Vcpu) -> Result<()> {
     vcpu.set_msrs(&vcpu.boot_msr_entries())
         .map_err(Error::SetModelSpecificRegisters)?;
 
@@ -95,7 +94,7 @@ pub fn setup_msrs(vcpu: &Arc<dyn hypervisor::Vcpu>) -> Result<()> {
 ///
 /// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
 /// * `entry_point` - Description of the boot entry to set up.
-pub fn setup_regs(vcpu: &Arc<dyn hypervisor::Vcpu>, entry_point: EntryPoint) -> Result<()> {
+pub fn setup_regs(vcpu: &dyn hypervisor::Vcpu, entry_point: EntryPoint) -> Result<()> {
     let mut regs = vcpu.create_standard_regs();
     match entry_point.setup_header {
         None => {
@@ -121,7 +120,7 @@ pub fn setup_regs(vcpu: &Arc<dyn hypervisor::Vcpu>, entry_point: EntryPoint) -> 
 /// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
 pub fn setup_sregs(
     mem: &GuestMemoryMmap,
-    vcpu: &Arc<dyn hypervisor::Vcpu>,
+    vcpu: &dyn hypervisor::Vcpu,
     enable_x2_apic_mode: bool,
 ) -> Result<()> {
     let mut sregs: SpecialRegisters = vcpu.get_sregs().map_err(Error::GetStatusRegisters)?;

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -526,7 +526,7 @@ pub trait Vcpu: Send + Sync {
     ///
     /// Triggers the running of the current virtual CPU returning an exit reason.
     ///
-    fn run(&self) -> std::result::Result<VmExit, HypervisorCpuError>;
+    fn run(&mut self) -> std::result::Result<VmExit, HypervisorCpuError>;
     #[cfg(target_arch = "x86_64")]
     ///
     /// Translate guest virtual address to guest physical address
@@ -542,7 +542,7 @@ pub trait Vcpu: Send + Sync {
     ///
     /// Set the "immediate_exit" state
     ///
-    fn set_immediate_exit(&self, _exit: bool) {}
+    fn set_immediate_exit(&mut self, _exit: bool) {}
     #[cfg(feature = "tdx")]
     ///
     /// Returns the details about TDX exit reason

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -604,7 +604,7 @@ impl cpu::Vcpu for MshvVcpu {
     }
 
     #[allow(non_upper_case_globals)]
-    fn run(&self) -> std::result::Result<cpu::VmExit, cpu::HypervisorCpuError> {
+    fn run(&mut self) -> std::result::Result<cpu::VmExit, cpu::HypervisorCpuError> {
         match self.fd.run() {
             Ok(x) => match x.header.message_type {
                 hv_message_type_HVMSG_X64_HALT => {
@@ -1821,7 +1821,7 @@ impl vm::Vm for MshvVm {
         &self,
         id: u32,
         vm_ops: Option<Arc<dyn VmOps>>,
-    ) -> vm::Result<Arc<dyn cpu::Vcpu>> {
+    ) -> vm::Result<Box<dyn cpu::Vcpu>> {
         let id: u8 = id.try_into().unwrap();
         let vcpu_fd = self
             .fd
@@ -1869,7 +1869,7 @@ impl vm::Vm for MshvVm {
             #[cfg(feature = "sev_snp")]
             host_access_pages: ArcSwap::new(self.host_access_pages.load().clone()),
         };
-        Ok(Arc::new(vcpu))
+        Ok(Box::new(vcpu))
     }
 
     #[cfg(target_arch = "x86_64")]

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -316,7 +316,7 @@ pub trait Vm: Send + Sync + Any {
     /// Unregister an event that will, when signaled, trigger the `gsi` IRQ.
     fn unregister_irqfd(&self, fd: &EventFd, gsi: u32) -> Result<()>;
     /// Creates a new KVM vCPU file descriptor and maps the memory corresponding
-    fn create_vcpu(&self, id: u32, vm_ops: Option<Arc<dyn VmOps>>) -> Result<Arc<dyn Vcpu>>;
+    fn create_vcpu(&self, id: u32, vm_ops: Option<Arc<dyn VmOps>>) -> Result<Box<dyn Vcpu>>;
     #[cfg(target_arch = "aarch64")]
     fn create_vgic(&self, config: VgicConfig) -> Result<Arc<Mutex<dyn Vgic>>>;
     #[cfg(target_arch = "riscv64")]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3548,7 +3548,7 @@ pub fn test_vm() {
     mem.write_slice(&code, load_addr)
         .expect("Writing code to memory failed");
 
-    let vcpu = vm.create_vcpu(0, None).expect("new Vcpu failed");
+    let mut vcpu = vm.create_vcpu(0, None).expect("new Vcpu failed");
 
     let mut vcpu_sregs = vcpu.get_sregs().expect("get sregs failed");
     vcpu_sregs.cs.base = 0;


### PR DESCRIPTION
This was added in 7be69edf5179e948b892693f6c88cba9626a0795 to deal with
changes to the KVM bindings that made run() and set_immediate_exit()
take &mut self. Instead adopt a Box<> value in Vcpu allowing the removal
of this internal Mutex.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>


