### PR TITLE
WIP: vmm: refactor FD passing

### DIFF
--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -197,6 +197,7 @@ impl RequestHandler for StubApiRequestHandler {
                 landlock_rules: None,
                 #[cfg(feature = "ivshmem")]
                 ivshmem: None,
+                external_fds: None,
             }),
             state: VmState::Running,
             memory_actual_size: 0,

--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -854,11 +854,12 @@ fn restore_config(config: &str) -> Result<(String, Vec<i32>), Error> {
     let mut restore_config = RestoreConfig::parse(config).map_err(Error::Restore)?;
     // RestoreConfig is modified on purpose to take out the file descriptors.
     // These fds are passed to the server side process via SCM_RIGHTS
-    let fds = match &mut restore_config.net_fds {
-        Some(net_fds) => net_fds
-            .iter_mut()
-            .flat_map(|net| net.fds.take().unwrap_or_default())
-            .collect(),
+    let fds = match &mut restore_config.external_fds {
+        Some(external_fds) => {
+            let mut fds = vec![];
+            core::mem::swap(&mut fds, &mut external_fds.fds);
+            fds
+        }
         None => Vec::new(),
     };
     let restore_config = serde_json::to_string(&restore_config).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1031,6 +1031,7 @@ mod unit_tests {
             landlock_rules: None,
             #[cfg(feature = "ivshmem")]
             ivshmem: None,
+            external_fds: None,
         };
 
         assert_eq!(expected_vm_config, result_vm_config);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8366,8 +8366,9 @@ mod common_sequential {
         )
         .unwrap();
         let restore_params = format!(
-            "source_url=file://{},net_fds=[{}@[{},{}]]",
+            "source_url=file://{},external_ids=[{},{}],external_fds=[{},{}]",
             snapshot_dir,
+            net_id,
             net_id,
             taps[0].as_raw_fd(),
             taps[1].as_raw_fd()

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -35,6 +35,7 @@
 //! [special HTTP library]: https://github.com/firecracker-microvm/micro-http
 
 use std::fs::File;
+use std::os::fd::IntoRawFd;
 use std::sync::mpsc::Sender;
 
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
@@ -42,7 +43,6 @@ use vmm_sys_util::eventfd::EventFd;
 
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::api::VmCoredump;
-use crate::api::http::http_endpoint::fds_helper::{attach_fds_to_cfg, attach_fds_to_cfgs};
 use crate::api::http::{EndpointHandler, HttpError, error_response};
 use crate::api::{
     AddDisk, ApiAction, ApiError, ApiRequest, NetConfig, VmAddDevice, VmAddFs, VmAddNet, VmAddPmem,
@@ -54,206 +54,6 @@ use crate::config::RestoreConfig;
 use crate::cpu::Error as CpuError;
 use crate::vm::Error as VmError;
 
-/// Helper module for attaching externally opened FDs to config objects.
-///
-/// # Difference between [`ConfigWithFDs`] and [`ConfigWithVariableFDs`]
-///
-/// The base trait [`ConfigWithFDs`] type must be implemented by all config
-/// types that want to take ownership of externally provided FDs.
-///
-/// In the case of restore operations, e.g., after a live-migration, config
-/// objects will know the amount of FDs they need. In this case, they must
-/// also implement [`ConfigWithVariableFDs`]. In other scenarios, such as
-/// hot device attach, the base type is sufficient and the type will take
-/// over all available FDs.
-///
-/// In any case, the management software (e.g., libvirt) is responsible for
-/// providing the exact amount of FDs.
-mod fds_helper {
-    use std::fs::File;
-    use std::os::fd::{IntoRawFd, RawFd};
-
-    use crate::api::http::HttpError;
-
-    /// Abstraction over configuration types received via the HTTP API that
-    /// have associated externally opened FDs.
-    pub trait ConfigWithFDs {
-        /// Returns the ID of the device.
-        ///
-        /// Used for logging.
-        fn id(&self) -> Option<&str>;
-
-        /// Returns any FDs provided in the HTTP body.
-        ///
-        /// They will always be invalid and are used for user-facing logging.
-        fn fds_from_http_body(&self) -> Option<&[RawFd]>;
-
-        /// Assigns the provided file descriptors (`fds`) to this configuration
-        /// object.
-        ///
-        /// After calling this method, the configuration will behave as if it
-        /// had originally been created with these FDs. Next, the configuration
-        /// can be used to properly configure the corresponding device.
-        ///
-        /// # Arguments
-        /// - `fds`: Either a non-empty Vector with corresponding FDs or `None`
-        ///   indicating that no valid FDs were supplied.
-        fn set_fds(&mut self, fds: Option<Vec<RawFd>>);
-    }
-
-    /// Extension of [`ConfigWithFDs`] for config objects that know how many
-    /// FDs they want (e.g., a restore configuration that is aware of the
-    /// previous state).
-    pub trait ConfigWithVariableFDs: ConfigWithFDs {
-        /// Returns how many FDs this type wants to have from the pool of
-        /// available FDs.
-        fn expected_num_fds(&self) -> usize;
-    }
-
-    mod config_with_fds_impls {
-        use std::os::fd::RawFd;
-
-        use super::{ConfigWithFDs, ConfigWithVariableFDs};
-        use crate::config::RestoredNetConfig;
-        use crate::vm_config::NetConfig;
-
-        impl ConfigWithFDs for NetConfig {
-            fn id(&self) -> Option<&str> {
-                self.id.as_deref()
-            }
-
-            fn fds_from_http_body(&self) -> Option<&[RawFd]> {
-                self.fds.as_deref()
-            }
-
-            fn set_fds(&mut self, fds: Option<Vec<RawFd>>) {
-                self.fds = fds;
-            }
-        }
-
-        impl ConfigWithFDs for RestoredNetConfig {
-            fn id(&self) -> Option<&str> {
-                Some(self.id.as_str())
-            }
-
-            fn fds_from_http_body(&self) -> Option<&[RawFd]> {
-                self.fds.as_deref()
-            }
-
-            fn set_fds(&mut self, fds: Option<Vec<RawFd>>) {
-                self.fds = fds;
-            }
-        }
-
-        impl ConfigWithVariableFDs for RestoredNetConfig {
-            fn expected_num_fds(&self) -> usize {
-                self.num_fds
-            }
-        }
-    }
-
-    fn attach_fds_to_cfg_inner<T: ConfigWithFDs>(
-        fds: &mut Vec<RawFd>,
-        fds_amount: usize,
-        cfg: &mut T,
-    ) {
-        if cfg.fds_from_http_body().is_some() {
-            // Only FDs transmitted via an SCM_RIGHTS UNIX Domain Socket message
-            // are valid. Any provided over the HTTP API are set to `-1` in our
-            // specialized serializer callbacks.
-            warn!(
-                "FD numbers were present in HTTP request body for device {:?} but will be ignored",
-                cfg.id()
-            );
-
-            // Reset old value in any case; if there are FDs, they are invalid.
-            cfg.set_fds(None);
-        }
-
-        if fds_amount > 0 {
-            let new_fds = fds.drain(..fds_amount).collect::<Vec<_>>();
-            log::debug!(
-                "Attaching network FDs received via UNIX domain socket to device: id={:?}, fds={new_fds:?}",
-                cfg.id()
-            );
-            cfg.set_fds(Some(new_fds));
-        }
-    }
-
-    /// Applies FDs to configs for their corresponding devices, as part of the special
-    /// handling for devices backed by externally provided FDs.
-    ///
-    /// The FDs (via `files`) must be provided in the exact order matching the
-    /// config struct they belong to.
-    ///
-    /// See [module description] for more info.
-    ///
-    /// # Arguments
-    /// - `device_fds`: Ordered list of all FDs from the request.
-    /// - `cfgs`: List of network configurations where each network can have up to `n` FDs.
-    ///
-    /// [module description]: self
-    pub fn attach_fds_to_cfgs<T: ConfigWithVariableFDs>(
-        device_fds: Vec<File>,
-        cfgs: &mut [&mut T],
-    ) -> Result<(), HttpError> {
-        let expected_fds: usize = cfgs.iter().map(|cfg| cfg.expected_num_fds()).sum();
-
-        if device_fds.len() != expected_fds {
-            error!(
-                "Number of expected FDs: {}, received: {}",
-                expected_fds,
-                device_fds.len()
-            );
-            return Err(HttpError::BadRequest);
-        }
-
-        // We are only interested in the raw FDs. After this operation, we are
-        // responsible for manually closing the FDs eventually.
-        let mut fds = device_fds
-            .into_iter()
-            .map(|f| f.into_raw_fd())
-            .collect::<Vec<_>>();
-
-        // For each config: We drain the FDs vector by the amount of FDs the config expects.
-        for cfg in cfgs {
-            attach_fds_to_cfg_inner(&mut fds, cfg.expected_num_fds(), *cfg);
-        }
-
-        // We checked that `fds.len() == expected_fds`; so if we panic here, we
-        // have a hard programming error
-        assert!(fds.is_empty());
-
-        Ok(())
-    }
-
-    /// Applies FDs to the config for the corresponding device, as part of the special
-    /// handling for devices backed by externally provided FDs.
-    ///
-    /// See [module description] for more info.
-    ///
-    /// # Arguments
-    /// - `device_fds`: Ordered list of all FDs from the request.
-    /// - `cfg`: The config object that wants to take ownership of all available FDs.
-    ///
-    /// [module description]: self
-    pub fn attach_fds_to_cfg<T: ConfigWithFDs>(
-        device_fds: Vec<File>,
-        cfg: &mut T,
-    ) -> Result<(), HttpError> {
-        // We are only interested in the raw FDs.
-        let mut fds = device_fds
-            .into_iter()
-            .map(|f| f.into_raw_fd())
-            .collect::<Vec<_>>();
-
-        let len = fds.len();
-        attach_fds_to_cfg_inner(&mut fds, len, cfg);
-
-        Ok(())
-    }
-}
-
 // /api/v1/vm.create handler
 pub struct VmCreate {}
 
@@ -264,6 +64,13 @@ impl EndpointHandler for VmCreate {
         api_notifier: EventFd,
         api_sender: Sender<ApiRequest>,
     ) -> Response {
+        // Need to clone, as files in req.files are closed on drop.
+        let fds: Vec<i32> = req
+            .files
+            .iter()
+            .map(|f| f.try_clone().unwrap().into_raw_fd())
+            .collect();
+
         match req.method() {
             Method::Put => {
                 match &req.body {
@@ -276,21 +83,10 @@ impl EndpointHandler for VmCreate {
                             Err(e) => return error_response(e, StatusCode::BadRequest),
                         };
 
-                        if let Some(ref mut nets) = vm_config.net {
-                            let mut cfgs = nets.iter_mut().collect::<Vec<&mut _>>();
-                            let cfgs = cfgs.as_mut_slice();
-
-                            // For the VmCreate call, we do not accept FDs from the socket currently.
-                            // This call sets all FDs to null while doing the same logging as
-                            // similar code paths.
-                            for cfg in cfgs {
-                                if let Err(e) = attach_fds_to_cfg(vec![], *cfg)
-                                    .map_err(|e| error_response(e, StatusCode::InternalServerError))
-                                {
-                                    return e;
-                                }
-                            }
-                        }
+                        if let Err(e) = vm_config.consume_fds(fds) {
+                            log::error!("Error consuming fds: {e:?}");
+                            return error_response(HttpError::BadRequest, StatusCode::BadRequest);
+                        };
 
                         match crate::api::VmCreate
                             .send(api_notifier, api_sender, vm_config)
@@ -442,7 +238,13 @@ impl PutHandler for VmAddNet {
     ) -> std::result::Result<Option<Body>, HttpError> {
         if let Some(body) = body {
             let mut net_cfg: NetConfig = serde_json::from_slice(body.raw())?;
-            attach_fds_to_cfg(files, &mut net_cfg)?;
+            // Need to clone, as files in req.files are closed on drop.
+            let fds: Vec<i32> = files
+                .iter()
+                .map(|f| f.try_clone().unwrap().into_raw_fd())
+                .collect();
+
+            net_cfg.consume_fds(fds);
 
             self.send(api_notifier, api_sender, net_cfg)
                 .map_err(HttpError::ApiError)
@@ -495,11 +297,14 @@ impl PutHandler for VmRestore {
         if let Some(body) = body {
             let mut restore_cfg: RestoreConfig = serde_json::from_slice(body.raw())?;
 
-            if let Some(cfgs) = restore_cfg.net_fds.as_mut() {
-                let mut cfgs = cfgs.iter_mut().collect::<Vec<&mut _>>();
-                let cfgs = cfgs.as_mut_slice();
-                attach_fds_to_cfgs(files, cfgs)?;
-            }
+            // Need to clone, as files in req.files are closed on drop.
+            let fds: Vec<i32> = files
+                .iter()
+                .map(|f| f.try_clone().unwrap().into_raw_fd())
+                .collect();
+            restore_cfg
+                .consume_fds(fds)
+                .map_err(|_| HttpError::BadRequest)?;
 
             self.send(api_notifier, api_sender, restore_cfg)
                 .map_err(HttpError::ApiError)
@@ -624,117 +429,5 @@ impl EndpointHandler for VmmShutdown {
             }
             _ => error_response(HttpError::BadRequest, StatusCode::BadRequest),
         }
-    }
-}
-
-#[cfg(test)]
-mod external_fds_tests {
-    use super::*;
-    use crate::api::http::http_endpoint::fds_helper::{ConfigWithFDs, ConfigWithVariableFDs};
-
-    struct DummyNewDeviceCfg {
-        http_fds: Option<Vec<i32>>,
-    }
-
-    impl ConfigWithFDs for DummyNewDeviceCfg {
-        fn id(&self) -> Option<&str> {
-            Some("dummy")
-        }
-
-        fn fds_from_http_body(&self) -> Option<&[i32]> {
-            self.http_fds.as_deref()
-        }
-
-        fn set_fds(&mut self, fds: Option<Vec<i32>>) {
-            self.http_fds = fds;
-        }
-    }
-
-    struct DummyRestoreDeviceCfg {
-        http_fds: Option<Vec<i32>>,
-        num_fds: usize,
-    }
-
-    impl ConfigWithFDs for DummyRestoreDeviceCfg {
-        fn id(&self) -> Option<&str> {
-            Some("dummy")
-        }
-
-        fn fds_from_http_body(&self) -> Option<&[i32]> {
-            self.http_fds.as_deref()
-        }
-
-        fn set_fds(&mut self, fds: Option<Vec<i32>>) {
-            self.http_fds = fds;
-        }
-    }
-
-    impl ConfigWithVariableFDs for DummyRestoreDeviceCfg {
-        fn expected_num_fds(&self) -> usize {
-            self.num_fds
-        }
-    }
-
-    #[test]
-    fn test_fds_provided_via_http_api_are_reset() {
-        let mut config = DummyNewDeviceCfg {
-            http_fds: Some(vec![1, 2, 3]),
-        };
-
-        attach_fds_to_cfg(vec![], &mut config).unwrap();
-        assert_eq!(config.http_fds, None);
-    }
-
-    #[test]
-    fn test_new_device_cfg_takes_all_fds() {
-        let path = "/dev/null";
-
-        let new_fds = vec![
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-        ];
-        let mut config = DummyNewDeviceCfg {
-            http_fds: Some(vec![1, 2, 3]),
-        };
-
-        attach_fds_to_cfg(new_fds, &mut config).unwrap();
-        assert_eq!(config.http_fds.unwrap().len(), 3);
-    }
-
-    #[test]
-    fn test_restore_cfgs_take_only_their_fds() {
-        let path = "/dev/null";
-        let new_fds = vec![
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-            File::open(path).unwrap(),
-        ];
-        let mut config1 = DummyRestoreDeviceCfg {
-            http_fds: None,
-            num_fds: 3,
-        };
-        let mut config2 = DummyRestoreDeviceCfg {
-            http_fds: None,
-            num_fds: 1,
-        };
-        let mut config3 = DummyRestoreDeviceCfg {
-            http_fds: None,
-            num_fds: 0,
-        };
-        let mut config4 = DummyRestoreDeviceCfg {
-            http_fds: None,
-            num_fds: 2,
-        };
-        let mut configs = [&mut config1, &mut config2, &mut config3, &mut config4];
-
-        attach_fds_to_cfgs(new_fds, &mut configs).unwrap();
-        assert_eq!(config1.http_fds.unwrap().len(), 3);
-        assert_eq!(config2.http_fds.unwrap().len(), 1);
-        assert!(config3.http_fds.is_none());
-        assert_eq!(config4.http_fds.unwrap().len(), 2);
     }
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -56,6 +56,9 @@ pub enum Error {
     /// Missing restore source_url parameter.
     #[error("Error parsing --restore: source_url missing")]
     ParseRestoreSourceUrlMissing,
+    /// Invalid restore external_fds parameter.
+    #[error("Error parsing --restore: invalid external_fds")]
+    ParseRestoreBadExternalFds(#[source] OptionParserError),
     /// Error parsing CPU options
     #[error("Error parsing --cpus")]
     ParseCpus(#[source] OptionParserError),
@@ -319,9 +322,12 @@ pub enum ValidationError {
     /// Restore expects all net ids that have fds
     #[error("Net id {0} is associated with FDs and is required")]
     RestoreMissingRequiredNetId(String),
-    /// Number of FDs passed during Restore are incorrect to the NetConfig
+    /// Number of FDs passed to the NetConfig during Restore are incorrect
     #[error("Number of Net FDs passed for '{0}' during Restore: {1}. Expected: {2}")]
     RestoreNetFdCountMismatch(String, usize, usize),
+    /// Number of FDs passed during Restore are incorrect
+    #[error("Number of FDs passed during Restore: {0}. Expected: {1}")]
+    RestoreFdCountMismatch(usize, usize),
     /// Path provided in landlock-rules doesn't exist
     #[error("Path {0:?} provided in landlock-rules does not exist")]
     LandlockPathDoesNotExist(PathBuf),
@@ -2201,62 +2207,29 @@ impl NumaConfig {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
-pub struct RestoredNetConfig {
-    pub id: String,
-    #[serde(default)]
-    pub num_fds: usize,
-    // Special deserialize handling:
-    // A serialize-deserialize cycle typically happens across processes.
-    // Therefore, we don't serialize FDs, and whatever value is here after
-    // deserialization is invalid.
-    //
-    // Valid FDs are transmitted via a different channel (SCM_RIGHTS message)
-    // and will be populated into this struct on the destination VMM eventually.
-    #[serde(default, deserialize_with = "deserialize_restorednetconfig_fds")]
-    pub fds: Option<Vec<i32>>,
-}
-
-fn deserialize_restorednetconfig_fds<'de, D>(
-    d: D,
-) -> std::result::Result<Option<Vec<i32>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let invalid_fds: Option<Vec<i32>> = Option::deserialize(d)?;
-    if let Some(invalid_fds) = invalid_fds {
-        // If the live-migration path is used properly, new FDs are passed as
-        // SCM_RIGHTS message. So, we don't get them from the serialized JSON
-        // anyway.
-        debug!(
-            "FDs in 'RestoredNetConfig' won't be deserialized as they are most likely invalid now. Deserializing them as -1."
-        );
-        Ok(Some(vec![-1; invalid_fds.len()]))
-    } else {
-        Ok(None)
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct RestoreConfig {
     pub source_url: PathBuf,
     #[serde(default)]
     pub prefault: bool,
     #[serde(default)]
-    pub net_fds: Option<Vec<RestoredNetConfig>>,
+    pub external_fds: Option<ExternalFdsConfig>,
 }
 
 impl RestoreConfig {
     pub const SYNTAX: &'static str = "Restore from a VM snapshot. \
         \nRestore parameters \"source_url=<source_url>,prefault=on|off,\
-        net_fds=<list_of_net_ids_with_their_associated_fds>\" \
         \n`source_url` should be a valid URL (e.g file:///foo/bar or tcp://192.168.1.10/foo) \
         \n`prefault` brings memory pages in when enabled (disabled by default) \
-        \n`net_fds` is a list of net ids with new file descriptors. \
-        Only net devices backed by FDs directly are needed as input.";
+        \n`external_ids` is a list of net device IDs that will receive FDs; \
+        \n`external_fds` is the list of FDs for the IDs.";
 
     pub fn parse(restore: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
-        parser.add("source_url").add("prefault").add("net_fds");
+        parser
+            .add("source_url")
+            .add("prefault")
+            .add("external_ids")
+            .add("external_fds");
         parser.parse(restore).map_err(Error::ParseRestore)?;
 
         let source_url = parser
@@ -2268,67 +2241,74 @@ impl RestoreConfig {
             .map_err(Error::ParseRestore)?
             .unwrap_or(Toggle(false))
             .0;
-        let net_fds = parser
-            .convert::<Tuple<String, Vec<u64>>>("net_fds")
-            .map_err(Error::ParseRestore)?
-            .map(|v| {
-                v.0.iter()
-                    .map(|(id, fds)| RestoredNetConfig {
-                        id: id.clone(),
-                        num_fds: fds.len(),
-                        fds: Some(fds.iter().map(|e| *e as i32).collect()),
-                    })
-                    .collect()
+
+        let ids = parser
+            .convert::<StringList>("external_ids")
+            .map_err(Error::ParseRestoreBadExternalFds)?
+            .map(|v| v.0.to_vec());
+
+        let fds: Option<Vec<i32>> = parser
+            .convert::<IntegerList>("external_fds")
+            .map_err(Error::ParseNetwork)?
+            .map(|v| v.0.iter().map(|e| *e as i32).collect());
+
+        if ids.is_none() && fds.is_none() {
+            return Ok(RestoreConfig {
+                source_url,
+                prefault,
+                external_fds: None,
             });
+        }
+
+        let Some(ids) = ids else {
+            return Err(Error::ParseRestoreBadExternalFds(
+                OptionParserError::InvalidValue("external_ids".to_owned()),
+            ));
+        };
+
+        let Some(fds) = fds else {
+            return Err(Error::ParseRestoreBadExternalFds(
+                OptionParserError::InvalidValue("external_fds".to_owned()),
+            ));
+        };
+
+        if ids.len() != fds.len() {
+            return Err(Error::ParseRestoreBadExternalFds(
+                OptionParserError::InvalidValue("external ids/fds don't match".to_owned()),
+            ));
+        }
+
+        let external_fds = Some(ExternalFdsConfig { ids, fds });
 
         Ok(RestoreConfig {
             source_url,
             prefault,
-            net_fds,
+            external_fds,
         })
     }
 
-    // Ensure all net devices from 'VmConfig' backed by FDs have a
-    // corresponding 'RestoreNetConfig' with a matched 'id' and expected
-    // number of FDs.
-    pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
-        let mut restored_net_with_fds = HashMap::new();
-        for n in self.net_fds.iter().flatten() {
-            assert_eq!(
-                n.num_fds,
-                n.fds.as_ref().map_or(0, |f| f.len()),
-                "Invalid 'RestoredNetConfig' with conflicted fields."
-            );
-            if restored_net_with_fds.insert(n.id.clone(), n).is_some() {
-                return Err(ValidationError::IdentifierNotUnique(n.id.clone()));
+    pub fn consume_fds(&mut self, fds: Vec<i32>) -> ValidationResult<()> {
+        // Update self.external_fds, if appropriate.
+        let Some(external_fds) = self.external_fds.as_mut() else {
+            if fds.is_empty() {
+                return Ok(());
+            } else {
+                return Err(ValidationError::RestoreFdCountMismatch(0, fds.len()));
             }
+        };
+
+        if external_fds.ids.len() != fds.len() {
+            return Err(ValidationError::RestoreFdCountMismatch(
+                external_fds.ids.len(),
+                fds.len(),
+            ));
         }
 
-        for net_fds in vm_config.net.iter().flatten() {
-            if let Some(expected_fds) = &net_fds.fds {
-                let expected_id = net_fds
-                    .id
-                    .as_ref()
-                    .expect("Invalid 'NetConfig' with empty 'id' for VM restore.");
-                if let Some(r) = restored_net_with_fds.remove(expected_id) {
-                    if r.num_fds != expected_fds.len() {
-                        return Err(ValidationError::RestoreNetFdCountMismatch(
-                            expected_id.clone(),
-                            r.num_fds,
-                            expected_fds.len(),
-                        ));
-                    }
-                } else {
-                    return Err(ValidationError::RestoreMissingRequiredNetId(
-                        expected_id.clone(),
-                    ));
-                }
-            }
+        if fds.is_empty() {
+            return Ok(());
         }
 
-        if !restored_net_with_fds.is_empty() {
-            warn!("Ignoring unused 'net_fds' for VM restore.")
-        }
+        external_fds.fds = fds;
 
         Ok(())
     }
@@ -3024,6 +3004,7 @@ impl VmConfig {
             landlock_rules,
             #[cfg(feature = "ivshmem")]
             ivshmem,
+            external_fds: None,
         };
         config.validate().map_err(Error::Validation)?;
         Ok(config)
@@ -3153,6 +3134,7 @@ impl Clone for VmConfig {
             landlock_rules: self.landlock_rules.clone(),
             #[cfg(feature = "ivshmem")]
             ivshmem: self.ivshmem.clone(),
+            external_fds: self.external_fds.clone(),
             ..*self
         }
     }
@@ -3882,178 +3864,20 @@ mod tests {
             RestoreConfig {
                 source_url: PathBuf::from("/path/to/snapshot"),
                 prefault: false,
-                net_fds: None,
+                external_fds: None,
             }
         );
         assert_eq!(
-            RestoreConfig::parse(
-                "source_url=/path/to/snapshot,prefault=off,net_fds=[net0@[3,4],net1@[5,6,7,8]]"
-            )?,
+            RestoreConfig::parse("source_url=/path/to/snapshot,prefault=off")?,
             RestoreConfig {
                 source_url: PathBuf::from("/path/to/snapshot"),
                 prefault: false,
-                net_fds: Some(vec![
-                    RestoredNetConfig {
-                        id: "net0".to_string(),
-                        num_fds: 2,
-                        fds: Some(vec![3, 4]),
-                    },
-                    RestoredNetConfig {
-                        id: "net1".to_string(),
-                        num_fds: 4,
-                        fds: Some(vec![5, 6, 7, 8]),
-                    }
-                ]),
+                external_fds: None,
             }
         );
         // Parsing should fail as source_url is a required field
         RestoreConfig::parse("prefault=off").unwrap_err();
         Ok(())
-    }
-
-    #[test]
-    fn test_restore_config_validation() {
-        // interested in only VmConfig.net, so set rest to default values
-        let mut snapshot_vm_config = VmConfig {
-            cpus: CpusConfig::default(),
-            memory: MemoryConfig::default(),
-            payload: None,
-            rate_limit_groups: None,
-            disks: None,
-            rng: RngConfig::default(),
-            balloon: None,
-            fs: None,
-            pmem: None,
-            serial: default_serial(),
-            console: default_console(),
-            #[cfg(target_arch = "x86_64")]
-            debug_console: DebugConsoleConfig::default(),
-            devices: None,
-            user_devices: None,
-            vdpa: None,
-            vsock: None,
-            #[cfg(feature = "pvmemcontrol")]
-            pvmemcontrol: None,
-            pvpanic: false,
-            iommu: false,
-            numa: None,
-            watchdog: false,
-            #[cfg(feature = "guest_debug")]
-            gdb: false,
-            pci_segments: None,
-            platform: None,
-            tpm: None,
-            preserved_fds: None,
-            net: Some(vec![
-                NetConfig {
-                    id: Some("net0".to_owned()),
-                    num_queues: 2,
-                    fds: Some(vec![-1, -1, -1, -1]),
-                    ..net_fixture()
-                },
-                NetConfig {
-                    id: Some("net1".to_owned()),
-                    num_queues: 1,
-                    fds: Some(vec![-1, -1]),
-                    ..net_fixture()
-                },
-                NetConfig {
-                    id: Some("net2".to_owned()),
-                    fds: None,
-                    ..net_fixture()
-                },
-            ]),
-            landlock_enable: false,
-            landlock_rules: None,
-            #[cfg(feature = "ivshmem")]
-            ivshmem: None,
-        };
-
-        let valid_config = RestoreConfig {
-            source_url: PathBuf::from("/path/to/snapshot"),
-            prefault: false,
-            net_fds: Some(vec![
-                RestoredNetConfig {
-                    id: "net0".to_string(),
-                    num_fds: 4,
-                    fds: Some(vec![3, 4, 5, 6]),
-                },
-                RestoredNetConfig {
-                    id: "net1".to_string(),
-                    num_fds: 2,
-                    fds: Some(vec![7, 8]),
-                },
-            ]),
-        };
-        valid_config.validate(&snapshot_vm_config).unwrap();
-
-        let mut invalid_config = valid_config.clone();
-        invalid_config.net_fds = Some(vec![RestoredNetConfig {
-            id: "netx".to_string(),
-            num_fds: 4,
-            fds: Some(vec![3, 4, 5, 6]),
-        }]);
-        assert_eq!(
-            invalid_config.validate(&snapshot_vm_config),
-            Err(ValidationError::RestoreMissingRequiredNetId(
-                "net0".to_string()
-            ))
-        );
-
-        invalid_config.net_fds = Some(vec![
-            RestoredNetConfig {
-                id: "net0".to_string(),
-                num_fds: 4,
-                fds: Some(vec![3, 4, 5, 6]),
-            },
-            RestoredNetConfig {
-                id: "net0".to_string(),
-                num_fds: 4,
-                fds: Some(vec![3, 4, 5, 6]),
-            },
-        ]);
-        assert_eq!(
-            invalid_config.validate(&snapshot_vm_config),
-            Err(ValidationError::IdentifierNotUnique("net0".to_string()))
-        );
-
-        invalid_config.net_fds = Some(vec![RestoredNetConfig {
-            id: "net0".to_string(),
-            num_fds: 4,
-            fds: Some(vec![3, 4, 5, 6]),
-        }]);
-        assert_eq!(
-            invalid_config.validate(&snapshot_vm_config),
-            Err(ValidationError::RestoreMissingRequiredNetId(
-                "net1".to_string()
-            ))
-        );
-
-        invalid_config.net_fds = Some(vec![RestoredNetConfig {
-            id: "net0".to_string(),
-            num_fds: 2,
-            fds: Some(vec![3, 4]),
-        }]);
-        assert_eq!(
-            invalid_config.validate(&snapshot_vm_config),
-            Err(ValidationError::RestoreNetFdCountMismatch(
-                "net0".to_string(),
-                2,
-                4
-            ))
-        );
-
-        let another_valid_config = RestoreConfig {
-            source_url: PathBuf::from("/path/to/snapshot"),
-            prefault: false,
-            net_fds: None,
-        };
-        snapshot_vm_config.net = Some(vec![NetConfig {
-            id: Some("net2".to_owned()),
-            fds: None,
-            ..net_fixture()
-        }]);
-        another_valid_config.validate(&snapshot_vm_config).unwrap();
     }
 
     fn platform_fixture() -> PlatformConfig {
@@ -4160,6 +3984,7 @@ mod tests {
             landlock_rules: None,
             #[cfg(feature = "ivshmem")]
             ivshmem: None,
+            external_fds: None,
         };
 
         valid_config.validate().unwrap();

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -63,8 +63,8 @@ use crate::migration::{recv_vm_config, recv_vm_state};
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::vm::{Error as VmError, Vm, VmState};
 use crate::vm_config::{
-    DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, UserDeviceConfig, VdpaConfig,
-    VmConfig, VsockConfig,
+    DeviceConfig, DiskConfig, ExternalFdsConfig, FsConfig, NetConfig, PmemConfig, UserDeviceConfig,
+    VdpaConfig, VmConfig, VsockConfig,
 };
 
 mod acpi;
@@ -1612,22 +1612,14 @@ impl RequestHandler for Vmm {
         let vm_config = Arc::new(Mutex::new(
             recv_vm_config(source_url).map_err(VmError::Restore)?,
         ));
-        restore_cfg
-            .validate(&vm_config.lock().unwrap().clone())
-            .map_err(VmError::ConfigValidation)?;
 
-        // Update VM's net configurations with new fds received for restore operation
-        if let (Some(restored_nets), Some(vm_net_configs)) =
-            (restore_cfg.net_fds, &mut vm_config.lock().unwrap().net)
-        {
-            for net in restored_nets.iter() {
-                for net_config in vm_net_configs.iter_mut() {
-                    // update only if the net dev is backed by FDs
-                    if net_config.id == Some(net.id.clone()) && net_config.fds.is_some() {
-                        net_config.fds.clone_from(&net.fds);
-                    }
-                }
-            }
+        if let Some(external_fds) = restore_cfg.external_fds.clone() {
+            let ExternalFdsConfig { ids, fds } = external_fds;
+            let mut vm_config = vm_config.lock().unwrap();
+            vm_config.external_fds = Some(vm_config::ExternalFdsConfig { ids, fds: vec![] });
+            vm_config
+                .consume_fds(fds)
+                .map_err(|_| VmError::InvalidExternalFds)?;
         }
 
         self.vm_restore(source_url, vm_config, restore_cfg.prefault)
@@ -2431,6 +2423,7 @@ mod unit_tests {
             landlock_rules: None,
             #[cfg(feature = "ivshmem")]
             ivshmem: None,
+            external_fds: None,
         })
     }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -217,6 +217,9 @@ pub enum Error {
     #[error("Cannot restore VM")]
     Restore(#[source] MigratableError),
 
+    #[error("Invalid external FDs")]
+    InvalidExternalFds,
+
     #[error("Cannot send VM snapshot")]
     SnapshotSend(#[source] MigratableError),
 

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -54,6 +54,22 @@ pub fn default_cpuconfig_max_phys_bits() -> u8 {
     DEFAULT_MAX_PHYS_BITS
 }
 
+// Some runtime objects, such as net devices and memory zones, may
+// be provided to Cloud Hypervisor via file descriptors constructed
+// "externally". For example, when a unix domain socket is used to
+// configure/create a new VM via VmCreate HTTP API command, the API
+// client may send file descriptors via SCM_RIGHTS UDS side-channel.
+// `ExternalFdsConfig` will then contain the list of devices (`ids`)
+// that are to receive the FDs; in the API call `ExternalFdsConfig::fds`
+// field will initially be empty, and the API handler will populate
+// it with file descriptors received via the "side channel".
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ExternalFdsConfig {
+    pub ids: Vec<String>,
+    #[serde(default)]
+    pub fds: Vec<i32>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct CpusConfig {
     pub boot_vcpus: u32,
@@ -324,13 +340,7 @@ pub struct NetConfig {
     pub vhost_mode: VhostMode,
     #[serde(default)]
     pub id: Option<String>,
-    // Special deserialize handling:
-    // Therefore, we don't serialize FDs, and whatever value is here after
-    // deserialization is invalid.
-    //
-    // Valid FDs are transmitted via a different channel (SCM_RIGHTS message)
-    // and will be populated into this struct on the destination VMM eventually.
-    #[serde(default, deserialize_with = "deserialize_netconfig_fds")]
+    #[serde(skip)]
     pub fds: Option<Vec<i32>>,
     #[serde(default)]
     pub rate_limiter_config: Option<RateLimiterConfig>,
@@ -342,6 +352,14 @@ pub struct NetConfig {
     pub offload_ufo: bool,
     #[serde(default = "default_netconfig_true")]
     pub offload_csum: bool,
+}
+
+impl NetConfig {
+    pub fn consume_fds(&mut self, fds: Vec<i32>) {
+        if !fds.is_empty() {
+            self.fds = Some(fds);
+        }
+    }
 }
 
 pub fn default_netconfig_true() -> bool {
@@ -366,21 +384,6 @@ pub const DEFAULT_NET_QUEUE_SIZE: u16 = 256;
 
 pub fn default_netconfig_queue_size() -> u16 {
     DEFAULT_NET_QUEUE_SIZE
-}
-
-fn deserialize_netconfig_fds<'de, D>(d: D) -> Result<Option<Vec<i32>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let invalid_fds: Option<Vec<i32>> = Option::deserialize(d)?;
-    if let Some(invalid_fds) = invalid_fds {
-        debug!(
-            "FDs in 'NetConfig' won't be deserialized as they are most likely invalid now. Deserializing them as -1."
-        );
-        Ok(Some(vec![-1; invalid_fds.len()]))
-    } else {
-        Ok(None)
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -695,6 +698,9 @@ pub enum PayloadConfigError {
     /// Specifying a kernel or firmware is not supported when an igvm is provided.
     #[error("Specifying a kernel or firmware is not supported when an igvm is provided")]
     IgvmPlusOtherPayloads,
+    /// The number of received FDs do not match the number of expected FDs.
+    #[error("The number of received FDs do not match the number of expected FDs")]
+    FdCountMismatch,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -950,6 +956,9 @@ pub struct VmConfig {
     pub landlock_rules: Option<Vec<LandlockConfig>>,
     #[cfg(feature = "ivshmem")]
     pub ivshmem: Option<IvshmemConfig>,
+
+    #[serde(default)]
+    pub external_fds: Option<ExternalFdsConfig>,
 }
 
 impl VmConfig {
@@ -1055,5 +1064,46 @@ impl VmConfig {
         } else {
             self.cpus.max_vcpus
         }
+    }
+
+    pub fn consume_fds(&mut self, fds: Vec<i32>) -> Result<(), PayloadConfigError> {
+        // Update self.external_fds, if appropriate.
+        let Some(external_fds) = self.external_fds.as_mut() else {
+            if fds.is_empty() {
+                return Ok(());
+            } else {
+                return Err(PayloadConfigError::FdCountMismatch);
+            }
+        };
+
+        if external_fds.ids.len() != fds.len() {
+            return Err(PayloadConfigError::FdCountMismatch);
+        }
+
+        if fds.is_empty() {
+            return Ok(());
+        }
+
+        external_fds.fds = fds;
+
+        // Consume net fds.
+        let Some(nets) = self.net.as_mut() else {
+            return Ok(());
+        };
+
+        for net in nets {
+            let Some(net_id) = net.id.clone() else {
+                continue;
+            };
+            let mut fds = vec![];
+            for idx in 0..external_fds.ids.len() {
+                if external_fds.ids[idx] == net_id {
+                    fds.push(external_fds.fds[idx]);
+                }
+            }
+            net.consume_fds(fds);
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
As discussed in [PR #7377](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7377), Cloud Hypervisor may potentially accept different types of FDs on VM creation and/or resuming:
- FDs for net devices (currently supported);
- FDs for pmem devices for memory zones (WIP);
- FDs for storage devices, etc.

As FDs are passed as an array of anonymous numbers over UDS sockets, there should be a way to assign them to the devices they belong to.

This PR introduces ExternalFdsConfig in vm_config.rs, which matches, positionally, the list of device IDs/names to the list of FDs.

Signed-off-by: Peter Oskolkov posk@google.com