### PR TITLE
tests: exclude test_fw_cfg for mshv

### DIFF
--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -202,7 +202,7 @@ fi
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,fw_cfg" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
-    time cargo test "fw_cfg::$test_filter" --target "$BUILD_TARGET" -- ${test_binary_args[*]}
+    time cargo test $test_features "fw_cfg::$test_filter" --target "$BUILD_TARGET" -- ${test_binary_args[*]}
     RES=$?
 fi
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11687,6 +11687,7 @@ mod fw_cfg {
     use crate::*;
 
     #[test]
+    #[cfg_attr(feature = "mshv", ignore = "See #7434")]
     fn test_fw_cfg() {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));


### PR DESCRIPTION
test_fw_cfg is frequently failing in the CI for MSHV. Exclude it for now. It needs further investigation. See issue #7434 for details.