### PR TITLE
ci: prevent cross-PR CI cancellation for mshv workflows

### DIFF
--- a/.github/workflows/mshv-infra.yaml
+++ b/.github/workflows/mshv-infra.yaml
@@ -38,7 +38,7 @@ on:
         description: 'Private IP of the VM'
         value: ${{ jobs.infra-setup.outputs.PRIVATE_IP }}
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   infra-setup:


### PR DESCRIPTION
The existing concurrency configuration causes workflow runs for one Pull Request to cancel in-progress runs for another Pull Request. When the workflow is triggered by the `pull_request_target` event, **github.ref is always set to the base branch**, regardless of which branch raised the PR. This causes every new pull request to share the same concurrency key and thus cancel the running CI of any other open pull request.

This commit updates the `concurrency.group` to use `github.event.pull_request.number` for unique isolation when running on PR, falling back to `github.ref` for non-PR push (e.g., merge group).