### PR TITLE
docs: Update docs to reflect program functioning

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -56,13 +56,6 @@ or a fd with `--api-socket fd=...`.
 
 ```
 $ ./target/debug/cloud-hypervisor --api-socket path=/tmp/cloud-hypervisor.sock
-Cloud Hypervisor Guest
-    API server: /tmp/cloud-hypervisor.sock
-    vCPUs: 1
-    Memory: 512 MB
-    Kernel: None
-    Kernel cmdline:
-    Disk(s): None
 ```
 
 #### REST API Endpoints
@@ -121,13 +114,6 @@ the REST API available at `/tmp/cloud-hypervisor.sock`:
 
 ```
 $ ./target/debug/cloud-hypervisor --api-socket /tmp/cloud-hypervisor.sock
-Cloud Hypervisor Guest
-    API server: /tmp/cloud-hypervisor.sock
-    vCPUs: 1
-    Memory: 512 MB
-    Kernel: None
-    Kernel cmdline:
-    Disk(s): None
 ```
 
 ##### Create a Virtual Machine


### PR DESCRIPTION
The API documentation tells users to expect
a message when Cloud Hypervisor is launched,
this message was removed in commit 13724db

This change updates the documentation to reflect
how the program actually functions, which is to
say no message.

partial fixes issue #7449 
https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7449#issuecomment-3474902151
https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7449#issuecomment-3474902151