### PR TITLE
vmm: allow http-server to use sendto

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -859,6 +859,7 @@ fn http_api_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError>
         (libc::SYS_recvfrom, vec![]),
         (libc::SYS_recvmsg, vec![]),
         (libc::SYS_sched_yield, vec![]),
+        (libc::SYS_sendto, vec![]),
         (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_write, vec![]),
         (libc::SYS_rt_sigprocmask, vec![]),


### PR DESCRIPTION
Fixes: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7449