### PR TITLE
misc: Replace anyhow with thiserror in TPM module.

### DIFF
--- a/devices/src/tpm.rs
+++ b/devices/src/tpm.rs
@@ -18,12 +18,12 @@ use vm_device::BusDevice;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Emulator doesn't implement min required capabilities")]
-    CheckCaps(#[source] anyhow::Error),
-    #[error("Failed to initialize tpm")]
-    Init(#[source] anyhow::Error),
+    #[error("Emulator doesn't implement min required capabilities: {0}")]
+    CheckCaps(String),
+    #[error("Failed to initialize tpm: {0}")]
+    Init(String),
 }
-type Result<T> = anyhow::Result<T, Error>;
+type Result<T> = std::result::Result<T, Error>;
 
 #[allow(dead_code)]
 enum LocStateFields {
@@ -220,8 +220,8 @@ pub struct Tpm {
 
 impl Tpm {
     pub fn new(path: String) -> Result<Self> {
-        let emulator = Emulator::new(path)
-            .map_err(|e| Error::Init(anyhow!("Failed while initializing tpm Emulator: {e:?}")))?;
+        let emulator =
+            Emulator::new(path).map_err(|e| Error::Init(format!("Failed to init tpm: {e:?}")))?;
         let mut tpm = Tpm {
             emulator,
             regs: [0; TPM_CRB_R_MAX],
@@ -329,11 +329,9 @@ impl Tpm {
 
         self.backend_buff_size = cmp::min(cur_buff_size, TPM_CRB_BUFFER_MAX);
 
-        if let Err(e) = self.emulator.startup_tpm(self.backend_buff_size) {
-            return Err(Error::Init(anyhow!(
-                "Failed while running Startup TPM. Error: {e:?}"
-            )));
-        }
+        self.emulator
+            .startup_tpm(self.backend_buff_size)
+            .map_err(|e| Error::Init(format!("Failed while running Startup TPM. Error: {e:?}")))?;
         Ok(())
     }
 }

--- a/tpm/src/emulator.rs
+++ b/tpm/src/emulator.rs
@@ -45,23 +45,23 @@ pub fn is_selftest(input: &[u8]) -> bool {
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Could not initialize emulator's backend")]
-    InitializeEmulator(#[source] anyhow::Error),
-    #[error("Failed to create data fd to pass to swtpm")]
-    PrepareDataFd(#[source] anyhow::Error),
-    #[error("Failed to run Control Cmd")]
-    RunControlCmd(#[source] anyhow::Error),
-    #[error("Emulator doesn't implement min required capabilities")]
-    CheckCaps(#[source] anyhow::Error),
-    #[error("Emulator failed to deliver request")]
-    DeliverRequest(#[source] anyhow::Error),
-    #[error("Emulator failed to send/receive msg on data fd")]
-    SendReceive(#[source] anyhow::Error),
-    #[error("Incorrect response to Self Test")]
-    SelfTest(#[source] anyhow::Error),
+    #[error("Could not initialize emulator's backend: {0}")]
+    InitializeEmulator(String),
+    #[error("Failed to create data fd to pass to swtpm: {0}")]
+    PrepareDataFd(String),
+    #[error("Failed to run Control Cmd: {0}")]
+    RunControlCmd(String),
+    #[error("Emulator doesn't implement min required capabilities: {0}")]
+    CheckCaps(String),
+    #[error("Emulator failed to deliver request: {0}")]
+    DeliverRequest(String),
+    #[error("Emulator failed to send/receive msg on data fd: {0}")]
+    SendReceive(String),
+    #[error("Incorrect response to Self Test: {0}")]
+    SelfTest(String),
 }
 
-type Result<T> = anyhow::Result<T, Error>;
+type Result<T> = std::result::Result<T, Error>;
 
 pub struct BackendCmd<'a> {
     // This buffer is used for both input and output.
@@ -87,14 +87,14 @@ impl Emulator {
     ///
     pub fn new(path: String) -> Result<Self> {
         if !Path::new(&path).exists() {
-            return Err(Error::InitializeEmulator(anyhow!(
+            return Err(Error::InitializeEmulator(format!(
                 "The input TPM Socket path: {path:?} does not exist"
             )));
         }
         let mut socket = SocketDev::new();
-        socket.init(path).map_err(|e| {
-            Error::InitializeEmulator(anyhow!("Failed while initializing tpm emulator: {e:?}"))
-        })?;
+        socket
+            .init(path)
+            .map_err(|e| Error::InitializeEmulator(format!("{e:?}")))?;
 
         let mut emulator = Self {
             caps: 0,
@@ -108,15 +108,15 @@ impl Emulator {
 
         emulator.probe_caps()?;
         if !emulator.check_caps() {
-            return Err(Error::InitializeEmulator(anyhow!(
-                "Required capabilities not supported by tpm backend"
-            )));
+            return Err(Error::InitializeEmulator(
+                "Required capabilities not supported by tpm backend".to_string(),
+            ));
         }
 
         if !emulator.get_established_flag() {
-            return Err(Error::InitializeEmulator(anyhow!(
-                "TPM not in established state"
-            )));
+            return Err(Error::InitializeEmulator(
+                "TPM not in established state".to_string(),
+            ));
         }
 
         Ok(emulator)
@@ -133,7 +133,7 @@ impl Emulator {
         unsafe {
             let ret = libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr());
             if ret == -1 {
-                return Err(Error::PrepareDataFd(anyhow!(
+                return Err(Error::PrepareDataFd(format!(
                     "Failed to prepare data fd for tpm emulator. Error Code {:?}",
                     std::io::Error::last_os_error()
                 )));
@@ -159,7 +159,7 @@ impl Emulator {
                 std::mem::size_of::<net_gen::iff::timeval>() as u32,
             );
             if ret == -1 {
-                return Err(Error::PrepareDataFd(anyhow!(
+                return Err(Error::PrepareDataFd(format!(
                     "Failed to set receive timeout on data fd socket. Error Code {:?}",
                     std::io::Error::last_os_error()
                 )));
@@ -231,20 +231,20 @@ impl Emulator {
         debug!("full Control request {buf:02X?}");
 
         let written = self.control_socket.write(&buf).map_err(|e| {
-            Error::RunControlCmd(anyhow!(
+            Error::RunControlCmd(format!(
                 "Failed while running {cmd:02X?} Control Cmd. Error: {e:?}"
             ))
         })?;
 
         if written < buf.len() {
-            return Err(Error::RunControlCmd(anyhow!(
+            return Err(Error::RunControlCmd(format!(
                 "Truncated write while running {cmd:02X?} Control Cmd",
             )));
         }
 
         // The largest response is 16 bytes so far.
         if msg_len_out > 16 {
-            return Err(Error::RunControlCmd(anyhow!(
+            return Err(Error::RunControlCmd(format!(
                 "Response size is too large for Cmd {cmd:02X?}, max 16 wanted {msg_len_out}"
             )));
         }
@@ -253,7 +253,7 @@ impl Emulator {
 
         // Every Control Cmd gets at least a result code in response. Read it
         let read_size = self.control_socket.read(&mut output).map_err(|e| {
-            Error::RunControlCmd(anyhow!(
+            Error::RunControlCmd(format!(
                 "Failed while reading response for Control Cmd: {cmd:02X?}. Error: {e:?}"
             ))
         })?;
@@ -261,7 +261,7 @@ impl Emulator {
         if msg_len_out != 0 {
             msg.update_ptm_with_response(&output[0..read_size])
                 .map_err(|e| {
-                    Error::RunControlCmd(anyhow!(
+                    Error::RunControlCmd(format!(
                         "Failed while converting response of Control Cmd: {cmd:02X?} to PTM. Error: {e:?}"
                     ))
                 })?;
@@ -271,7 +271,7 @@ impl Emulator {
         }
 
         if msg.get_result_code() != TPM_SUCCESS {
-            return Err(Error::RunControlCmd(anyhow!(
+            return Err(Error::RunControlCmd(format!(
                 "Control Cmd returned error code : {:?}",
                 msg.get_result_code()
             )));
@@ -333,7 +333,7 @@ impl Emulator {
         unsafe {
             let ret = libc::sendmsg(self.data_fd, &msghdr, 0);
             if ret == -1 {
-                return Err(Error::SendReceive(anyhow!(
+                return Err(Error::SendReceive(format!(
                     "Failed to send tpm command over Data FD. Error Code {:?}",
                     std::io::Error::last_os_error()
                 )));
@@ -352,7 +352,7 @@ impl Emulator {
                 &mut len as *mut socklen_t,
             );
             if ret == -1 {
-                return Err(Error::SendReceive(anyhow!(
+                return Err(Error::SendReceive(format!(
                     "Failed to receive response for tpm command over Data FD. Error Code {:?}",
                     std::io::Error::last_os_error()
                 )));
@@ -365,7 +365,7 @@ impl Emulator {
         );
 
         if isselftest && output_len < 10 {
-            return Err(Error::SelfTest(anyhow!(
+            return Err(Error::SelfTest(format!(
                 "Self test response should have 10 bytes. Only {output_len:?} returned"
             )));
         }
@@ -378,9 +378,9 @@ impl Emulator {
 
         // Check if emulator implements Cancel Cmd
         if (self.caps & PTM_CAP_CANCEL_TPM_CMD) != PTM_CAP_CANCEL_TPM_CMD {
-            return Err(Error::CheckCaps(anyhow!(
-                "Emulator does not implement 'Cancel Command' Capability"
-            )));
+            return Err(Error::CheckCaps(
+                "Emulator does not implement 'Cancel Command' Capability".to_string(),
+            ));
         }
         self.run_control_cmd(
             Commands::CmdCancelTpmCmd,

--- a/tpm/src/lib.rs
+++ b/tpm/src/lib.rs
@@ -46,10 +46,10 @@ pub enum Commands {
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Failed converting buf to PTM ")]
-    ConvertToPtm(#[source] anyhow::Error),
+    #[error("Failed converting buf to PTM: {0}")]
+    ConvertToPtm(String),
 }
-type Result<T> = anyhow::Result<T, Error>;
+type Result<T> = std::result::Result<T, Error>;
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum MemberType {
@@ -99,7 +99,7 @@ impl Ptm for PtmResult {
         let expected_len = 4;
         let len = buf.len();
         if len != expected_len {
-            return Err(Error::ConvertToPtm(anyhow!(
+            return Err(Error::ConvertToPtm(format!(
                 "PtmRes buffer is of incorrect length. Got {len} expected {expected_len}."
             )));
         }
@@ -136,7 +136,7 @@ impl Ptm for PtmCap {
         let expected_len = 8;
         let len = buf.len();
         if len != expected_len {
-            return Err(Error::ConvertToPtm(anyhow!(
+            return Err(Error::ConvertToPtm(format!(
                 "Response for GetCapability cmd is of incorrect length. Got {len} expected {expected_len}."
             )));
         }
@@ -197,7 +197,7 @@ impl Ptm for PtmEst {
         let expected_len = 8;
         let len = buf.len();
         if len != expected_len {
-            return Err(Error::ConvertToPtm(anyhow!(
+            return Err(Error::ConvertToPtm(format!(
                 "Response for GetTpmEstablished cmd is of incorrect length. Got {len} expected {expected_len}."
             )));
         }
@@ -259,7 +259,7 @@ impl Ptm for PtmInit {
         let expected_len = 4;
         let len = buf.len();
         if len != expected_len {
-            return Err(Error::ConvertToPtm(anyhow!(
+            return Err(Error::ConvertToPtm(format!(
                 "Response for Init cmd is of incorrect length. Got {len} expected {expected_len}."
             )));
         }
@@ -348,7 +348,7 @@ impl Ptm for PtmSetBufferSize {
         let expected_len = 16;
         let len = buf.len();
         if len != expected_len {
-            return Err(Error::ConvertToPtm(anyhow!(
+            return Err(Error::ConvertToPtm(format!(
                 "Response for CmdSetBufferSize cmd is of incorrect length. Got {len} expected {expected_len}."
             )));
         }

--- a/tpm/src/socket.rs
+++ b/tpm/src/socket.rs
@@ -7,20 +7,21 @@ use std::io::Read;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 
-use anyhow::anyhow;
+use std::io;
+
 use thiserror::Error;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Cannot connect to tpm Socket")]
-    ConnectToSocket(#[source] anyhow::Error),
-    #[error("Failed to read from socket")]
-    ReadFromSocket(#[source] anyhow::Error),
-    #[error("Failed to write to socket")]
-    WriteToSocket(#[source] anyhow::Error),
+    ConnectToSocket(#[source] io::Error),
+    #[error("Failed to read from socket: {0}")]
+    ReadFromSocket(String),
+    #[error("Failed to write to socket: {0}")]
+    WriteToSocket(String),
 }
-type Result<T> = anyhow::Result<T, Error>;
+type Result<T> = std::result::Result<T, Error>;
 
 #[derive(PartialEq)]
 enum SocketDevState {
@@ -65,9 +66,7 @@ impl SocketDev {
     pub fn connect(&mut self, socket_path: &str) -> Result<()> {
         self.state = SocketDevState::Connecting;
 
-        let s = UnixStream::connect(socket_path).map_err(|e| {
-            Error::ConnectToSocket(anyhow!("Failed to connect to tpm Socket. Error: {e:?}"))
-        })?;
+        let s = UnixStream::connect(socket_path).map_err(Error::ConnectToSocket)?;
         self.control_fd = s.as_raw_fd();
         self.stream = Some(s);
         self.state = SocketDevState::Connected;
@@ -91,18 +90,16 @@ impl SocketDev {
             .as_ref()
             .unwrap()
             .send_with_fd(buf, write_fd)
-            .map_err(|e| {
-                Error::WriteToSocket(anyhow!("Failed to write to Socket. Error: {e:?}"))
-            })?;
+            .map_err(|e| Error::WriteToSocket(format!("Failed to write to Socket. Error: {e:?}")))?;
 
         Ok(size)
     }
 
     pub fn write(&mut self, buf: &[u8]) -> Result<usize> {
         if self.stream.is_none() {
-            return Err(Error::WriteToSocket(anyhow!(
-                "Stream for tpm socket was not initialized"
-            )));
+            return Err(Error::WriteToSocket(
+                "Stream for tpm socket was not initialized".to_string(),
+            ));
         }
 
         if matches!(self.state, SocketDevState::Connected) {
@@ -115,22 +112,22 @@ impl SocketDev {
             }
             Ok(ret)
         } else {
-            Err(Error::WriteToSocket(anyhow!(
-                "TPM Socket was not in Connected State"
-            )))
+            Err(Error::WriteToSocket(
+                "TPM Socket was not in Connected State".to_string(),
+            ))
         }
     }
 
     pub fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         if self.stream.is_none() {
-            return Err(Error::ReadFromSocket(anyhow!(
-                "Stream for tpm socket was not initialized"
-            )));
+            return Err(Error::ReadFromSocket(
+                "Stream for tpm socket was not initialized".to_string(),
+            ));
         }
         let mut socket = self.stream.as_ref().unwrap();
-        let size: usize = socket.read(buf).map_err(|e| {
-            Error::ReadFromSocket(anyhow!("Failed to read from socket. Error Code {e:?}"))
-        })?;
+        let size: usize = socket
+            .read(buf)
+            .map_err(|e| Error::ReadFromSocket(format!("Failed to read from socket. Error Code {e:?}")))?;
         Ok(size)
     }
 }


### PR DESCRIPTION
misc: Replace anyhow with thiserror in TPM module.

This commit refactors the error handling across the codebase to replace use of anyhow:Error with strongly typed error enums.

See: cloud-hypervisor#7432

Signed-Off-by: Shubham Chakrawar schakrawar@crusoe.ai