### PR TITLE
ci: dump kernel logs in MSHV workflow

### DIFF
--- a/.github/workflows/mshv-infra.yaml
+++ b/.github/workflows/mshv-infra.yaml
@@ -34,6 +34,12 @@ on:
       USERNAME:
         required: true
     outputs:
+      RG_NAME:
+        description: 'Resource group of the VM'
+        value: ${{ jobs.infra-setup.outputs.RG_NAME }}
+      VM_NAME:
+        description: 'Name of the VM'
+        value: ${{ jobs.infra-setup.outputs.VM_NAME }}
       PRIVATE_IP:
         description: 'Private IP of the VM'
         value: ${{ jobs.infra-setup.outputs.PRIVATE_IP }}
@@ -46,6 +52,8 @@ jobs:
     runs-on: mshv
     continue-on-error: true
     outputs:
+      RG_NAME: ${{ steps.rg-setup.outputs.RG_NAME }}
+      VM_NAME: ${{ steps.vm-setup.outputs.VM_NAME }}
       PRIVATE_IP: ${{ steps.get-vm-ip.outputs.PRIVATE_IP }}
     steps:
       - name: Install & login to AZ CLI
@@ -112,6 +120,7 @@ jobs:
           # Create the resource group
           echo "Creating resource group in location: ${LOCATION}"
           az group create --name ${RG} --location ${LOCATION}
+          echo "RG_NAME=${RG}" >> $GITHUB_OUTPUT
           echo "Resource group created successfully."
 
       - name: Generate SSH Key
@@ -173,6 +182,9 @@ jobs:
             --security-type Standard \
             --output json
 
+          az vm boot-diagnostics enable --name ${VM_NAME} --resource-group ${RG}
+
+          echo "VM_NAME=${VM_NAME}" >> $GITHUB_OUTPUT
           echo "VM creation process completed successfully."
 
       - name: Get VM Private IP

--- a/.github/workflows/mshv-integration.yaml
+++ b/.github/workflows/mshv-integration.yaml
@@ -79,6 +79,28 @@ jobs:
             sudo ./scripts/dev_cli.sh tests --hypervisor mshv --integration
           EOF
 
+      - name: Dump dmesg
+        if: always()
+        continue-on-error: true
+        env:
+          KEY: azure_key_${{ github.run_id }}
+          PRIVATE_IP: ${{ needs.infra-setup.outputs.PRIVATE_IP }}
+          USERNAME: ${{ secrets.MSHV_USERNAME }}
+        run: |
+          ssh -i ~/.ssh/${KEY} -o StrictHostKeyChecking=no ${USERNAME}@${PRIVATE_IP} << EOF
+            sudo dmesg
+          EOF
+
+      - name: Dump serial console logs
+        if: always()
+        continue-on-error: true
+        env:
+          RG_NAME: ${{ needs.infra-setup.outputs.RG_NAME }}
+          VM_NAME: ${{ needs.infra-setup.outputs.VM_NAME }}
+        run: |
+          set -e
+          az vm boot-diagnostics get-boot-log --name "${VM_NAME}" --resource-group "${RG_NAME}" | jq -r
+
   cleanup:
     name: Cleanup
     needs: run-tests


### PR DESCRIPTION
Dump kernel logs after running the tests in the MSHV workflow to help debug failures.

In addition to getting the kernel logs using `dmesg` also use AzCli to retrieve the serial console logs. If the VM is hung or panicked, the workflow would be unable to SSH into it and execute `dmesg`. In this case the serial console logs would be helpful.