### PR TITLE
vhost-user-blk: Support zoned devices

### DIFF
--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -608,6 +608,10 @@ pub struct VirtioBlockConfig {
     pub max_write_zeroes_seg: u32,
     pub write_zeroes_may_unmap: u8,
     pub unused1: [u8; 3],
+    pub max_secure_erase_sectors: u32,
+    pub max_secure_erase_seg: u32,
+    pub secure_erase_sector_alignment: u32,
+    pub zoned: VirtioBlockZonedCharacteristics,
 }
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
 #[repr(C, packed)]
@@ -615,6 +619,17 @@ pub struct VirtioBlockGeometry {
     pub cylinders: u16,
     pub heads: u8,
     pub sectors: u8,
+}
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
+#[repr(C, packed)]
+pub struct VirtioBlockZonedCharacteristics {
+    pub zone_sectors: u32,
+    pub max_open_zones: u32,
+    pub max_active_zones: u32,
+    pub max_append_sectors: u32,
+    pub write_granularity: u32,
+    pub model: u8,
+    pub unused2: [u8; 3usize],
 }
 
 // SAFETY: data structure only contain a series of integers

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -16,7 +16,7 @@ use vhost::vhost_user::{FrontendReqHandler, VhostUserFrontend, VhostUserFrontend
 use virtio_bindings::virtio_blk::{
     VIRTIO_BLK_F_BLK_SIZE, VIRTIO_BLK_F_CONFIG_WCE, VIRTIO_BLK_F_DISCARD, VIRTIO_BLK_F_FLUSH,
     VIRTIO_BLK_F_GEOMETRY, VIRTIO_BLK_F_MQ, VIRTIO_BLK_F_RO, VIRTIO_BLK_F_SEG_MAX,
-    VIRTIO_BLK_F_SIZE_MAX, VIRTIO_BLK_F_TOPOLOGY, VIRTIO_BLK_F_WRITE_ZEROES,
+    VIRTIO_BLK_F_SIZE_MAX, VIRTIO_BLK_F_TOPOLOGY, VIRTIO_BLK_F_WRITE_ZEROES, VIRTIO_BLK_F_ZONED,
 };
 use virtio_queue::Queue;
 use vm_memory::{ByteValued, GuestMemoryAtomic};
@@ -108,6 +108,7 @@ impl Blk {
                 | (1 << VIRTIO_BLK_F_CONFIG_WCE)
                 | (1 << VIRTIO_BLK_F_DISCARD)
                 | (1 << VIRTIO_BLK_F_WRITE_ZEROES)
+                | (1 << VIRTIO_BLK_F_ZONED)
                 | DEFAULT_VIRTIO_FEATURES;
 
             if num_queues > 1 {


### PR DESCRIPTION
vhost-user-blk supports [Zoned Storage](https://zonedstorage.io/) by negotiating the `VIRTIO_BLK_F_ZONED` feature. This allows the underlying device to impose an append-only constraint on each zone (an uniform grouping of sectors) to do some optimizations in the way the data is stored.

This change adds cloud-hypervisor support for zoned devices: with this change, vhost-user-blk programs can use this flag and it will be acknowledgeable by the guest kernel. As a side-effect, the `VIRTIO_BLK_F_TOPOLOGY` flag is also fixed by virtue of the `get_config()` call now reading 0x60 bytes instead of only 0x3c, so now the fields that are relevant to both zoned devices and the topology information of the device can be reported to the guest kernel instead of being unset.

Signed-off-by: Luis Héctor Chávez <lhchavez@lhchavez.com>