### PR TITLE
vmm: seccomp: Use rseq syscall constant

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -638,12 +638,7 @@ fn vmm_thread_rules(
         (libc::SYS_recvfrom, vec![]),
         (libc::SYS_recvmsg, vec![]),
         (libc::SYS_restart_syscall, vec![]),
-        // musl is missing this constant
-        // (libc::SYS_rseq, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (334, vec![]),
-        #[cfg(target_arch = "aarch64")]
-        (293, vec![]),
+        (libc::SYS_rseq, vec![]),
         (libc::SYS_rt_sigaction, vec![]),
         (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_rt_sigreturn, vec![]),
@@ -888,12 +883,7 @@ fn dbus_api_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError>
         (libc::SYS_munmap, vec![]),
         (libc::SYS_prctl, vec![]),
         (libc::SYS_recvmsg, vec![]),
-        // musl is missing this constant
-        // (libc::SYS_rseq, vec![]),
-        #[cfg(target_arch = "x86_64")]
-        (334, vec![]),
-        #[cfg(target_arch = "aarch64")]
-        (293, vec![]),
+        (libc::SYS_rseq, vec![]),
         (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_sched_getaffinity, vec![]),
         (libc::SYS_sched_yield, vec![]),


### PR DESCRIPTION
Formerly these syscall's had to be specified by number as the constants
were missing in musl.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
