### PR TITLE
Bump Cloud Hypervisor CI Linux version to v6.16.9

### DIFF
--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -49,7 +49,7 @@ checkout_repo() {
 build_custom_linux() {
     ARCH=$(uname -m)
     LINUX_CUSTOM_DIR="$WORKLOADS_DIR/linux-custom"
-    LINUX_CUSTOM_BRANCH="ch-6.12.8"
+    LINUX_CUSTOM_BRANCH="ch-6.16.9"
     LINUX_CUSTOM_URL="https://github.com/cloud-hypervisor/linux.git"
 
     checkout_repo "$LINUX_CUSTOM_DIR" "$LINUX_CUSTOM_URL" "$LINUX_CUSTOM_BRANCH"
@@ -140,7 +140,7 @@ download_hypervisor_fw() {
 }
 
 download_linux() {
-    KERNEL_TAG="ch-release-v6.12.8-20250613"
+    KERNEL_TAG="ch-release-v6.16.9-20251112"
     if [ -n "$AUTH_DOWNLOAD_TOKEN" ]; then
         echo "Using authenticated download from GitHub"
         KERNEL_URLS=$(curl --silent https://api.github.com/repos/cloud-hypervisor/linux/releases/tags/${KERNEL_TAG} \

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3007,7 +3007,7 @@ mod common_parallel {
             );
             assert_eq!(
                 guest
-                    .ssh_command("ls /sys/kernel/iommu_groups/0/devices")
+                    .ssh_command("ls /sys/kernel/iommu_groups/1/devices")
                     .unwrap()
                     .trim(),
                 "0001:00:01.0"
@@ -7126,7 +7126,7 @@ mod common_parallel {
             );
             assert_eq!(
                 guest
-                    .ssh_command("ls /sys/kernel/iommu_groups/0/devices")
+                    .ssh_command("ls /sys/kernel/iommu_groups/1/devices")
                     .unwrap()
                     .trim(),
                 "0001:00:01.0"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2283,7 +2283,7 @@ fn _test_virtio_iommu(acpi: bool) {
         // contains "0000:00:02.0" which is the first disk.
         //
         // Verify the iommu group of the first disk.
-        let iommu_group = !acpi as i32;
+        let iommu_group = if acpi { 0 } else { 2 };
         assert_eq!(
             guest
                 .ssh_command(format!("ls /sys/kernel/iommu_groups/{iommu_group}/devices").as_str())
@@ -2293,7 +2293,7 @@ fn _test_virtio_iommu(acpi: bool) {
         );
 
         // Verify the iommu group of the second disk.
-        let iommu_group = if acpi { 1 } else { 2 };
+        let iommu_group = if acpi { 1 } else { 3 };
         assert_eq!(
             guest
                 .ssh_command(format!("ls /sys/kernel/iommu_groups/{iommu_group}/devices").as_str())
@@ -2303,7 +2303,7 @@ fn _test_virtio_iommu(acpi: bool) {
         );
 
         // Verify the iommu group of the network card.
-        let iommu_group = if acpi { 2 } else { 3 };
+        let iommu_group = if acpi { 2 } else { 4 };
         assert_eq!(
             guest
                 .ssh_command(format!("ls /sys/kernel/iommu_groups/{iommu_group}/devices").as_str())


### PR DESCRIPTION
- **tests: Update test_iommu_segments check**
- **tests: aarch64: Fix test_virtio_iommu for kernel IOMMU groups change**
- **scripts: Bump Linux version to 6.16.9**
