### PR TITLE
Support live disk resizing for RAW images

### DIFF
--- a/block/src/async_io.rs
+++ b/block/src/async_io.rs
@@ -18,6 +18,12 @@ pub enum DiskFileError {
     /// Failed creating a new AsyncIo.
     #[error("Failed creating a new AsyncIo")]
     NewAsyncIo(#[source] std::io::Error),
+    /// Unsupported operation.
+    #[error("Unsupported operation")]
+    Unsupported,
+    /// Resize failed
+    #[error("Resize failed")]
+    ResizeError(#[source] std::io::Error),
 }
 
 pub type DiskFileResult<T> = std::result::Result<T, DiskFileError>;
@@ -68,6 +74,10 @@ pub trait DiskFile: Send {
     fn topology(&mut self) -> DiskTopology {
         DiskTopology::default()
     }
+    fn resize(&mut self, _size: u64) -> DiskFileResult<()> {
+        Err(DiskFileError::Unsupported)
+    }
+
     /// Returns the file descriptor of the underlying disk image file.
     ///
     /// The file descriptor is supposed to be used for `fcntl()` calls but no

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -55,6 +55,10 @@ impl DiskFile for RawFileDisk {
         }
     }
 
+    fn resize(&mut self, size: u64) -> DiskFileResult<()> {
+        self.file.set_len(size).map_err(DiskFileError::ResizeError)
+    }
+
     fn fd(&mut self) -> BorrowedDiskFd<'_> {
         BorrowedDiskFd::new(self.file.as_raw_fd())
     }

--- a/docs/api.md
+++ b/docs/api.md
@@ -86,6 +86,7 @@ The Cloud Hypervisor API exposes the following actions through its endpoints:
 | Restore the VM from a snapshot     | `/vm.restore`           | `/schemas/RestoreConfig`        | N/A                      | The VM is created but not booted                       |
 | Add/remove CPUs to/from the VM     | `/vm.resize`            | `/schemas/VmResize`             | N/A                      | The VM is booted                                       |
 | Add/remove memory from the VM      | `/vm.resize`            | `/schemas/VmResize`             | N/A                      | The VM is booted                                       |
+| Resize a disk attached to the VM   | `/vm.resize-disk`       | `/schemas/VmResizeDisk`         | N/A                      | The VM is created                                      |
 | Add/remove memory from a zone      | `/vm.resize-zone`       | `/schemas/VmResizeZone`         | N/A                      | The VM is booted                                       |
 | Dump the VM information            | `/vm.info`              | N/A                             | `/schemas/VmInfo`        | The VM is created                                      |
 | Add VFIO PCI device to the VM      | `/vm.add-device`        | `/schemas/VmAddDevice`          | `/schemas/PciDeviceInfo` | The VM is booted                                       |

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -108,6 +108,10 @@ impl RequestHandler for StubApiRequestHandler {
         Ok(())
     }
 
+    fn vm_resize_disk(&mut self, _: String, _: u64) -> Result<(), VmError> {
+        Ok(())
+    }
+
     #[cfg(target_arch = "x86_64")]
     fn vm_coredump(&mut self, _: &str) -> Result<(), VmError> {
         Ok(())

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -47,8 +47,8 @@ use crate::api::http::{EndpointHandler, HttpError, error_response};
 use crate::api::{
     AddDisk, ApiAction, ApiError, ApiRequest, NetConfig, VmAddDevice, VmAddFs, VmAddNet, VmAddPmem,
     VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot, VmConfig, VmCounters, VmDelete, VmNmi, VmPause,
-    VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeZone, VmRestore,
-    VmResume, VmSendMigration, VmShutdown, VmSnapshot,
+    VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeDisk,
+    VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
 use crate::config::RestoreConfig;
 use crate::cpu::Error as CpuError;
@@ -424,6 +424,7 @@ vm_action_put_handler_body!(VmAddVdpa);
 vm_action_put_handler_body!(VmAddVsock);
 vm_action_put_handler_body!(VmAddUserDevice);
 vm_action_put_handler_body!(VmRemoveDevice);
+vm_action_put_handler_body!(VmResizeDisk);
 vm_action_put_handler_body!(VmResizeZone);
 vm_action_put_handler_body!(VmSnapshot);
 vm_action_put_handler_body!(VmReceiveMigration);

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -30,7 +30,7 @@ use crate::api::VmCoredump;
 use crate::api::{
     AddDisk, ApiError, ApiRequest, VmAddDevice, VmAddFs, VmAddNet, VmAddPmem, VmAddUserDevice,
     VmAddVdpa, VmAddVsock, VmBoot, VmCounters, VmDelete, VmNmi, VmPause, VmPowerButton, VmReboot,
-    VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeZone, VmRestore, VmResume,
+    VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeDisk, VmResizeZone, VmRestore, VmResume,
     VmSendMigration, VmShutdown, VmSnapshot,
 };
 use crate::landlock::Landlock;
@@ -250,6 +250,10 @@ pub static HTTP_ROUTES: LazyLock<HttpRoutes> = LazyLock::new(|| {
     r.routes.insert(
         endpoint!("/vm.resize"),
         Box::new(VmActionHandler::new(&VmResize)),
+    );
+    r.routes.insert(
+        endpoint!("/vm.resize-disk"),
+        Box::new(VmActionHandler::new(&VmResizeDisk)),
     );
     r.routes.insert(
         endpoint!("/vm.resize-zone"),

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -315,6 +315,8 @@ pub trait RequestHandler {
 
     fn vm_resize_zone(&mut self, id: String, desired_ram: u64) -> Result<(), VmError>;
 
+    fn vm_resize_disk(&mut self, id: String, desired_size: u64) -> Result<(), VmError>;
+
     fn vm_add_device(&mut self, device_cfg: DeviceConfig) -> Result<Option<Vec<u8>>, VmError>;
 
     fn vm_add_user_device(

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -163,6 +163,22 @@ paths:
         429:
           description: The VM instance could not be resized because a cpu removal is still pending.
 
+  /vm.resize-disk:
+    put:
+      summary: Resize a disk
+      requestBody:
+        description: Resizes a disk attached to the VM
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VmResizeDisk"
+        required: true
+      responses:
+        204:
+          description: The disk was successfully resized.
+        500:
+          description: The disk could not be resized.
+
   /vm.resize-zone:
     put:
       summary: Resize a memory zone
@@ -1200,6 +1216,17 @@ components:
           format: int64
         desired_balloon:
           description: desired balloon size in bytes
+          type: integer
+          format: int64
+
+    VmResizeDisk:
+      type: object
+      properties:
+        id:
+          description: disk identifier
+          type: string
+        desired_size:
+          description: desired disk size in bytes
           type: integer
           format: int64
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1962,6 +1962,16 @@ impl RequestHandler for Vmm {
         }
     }
 
+    fn vm_resize_disk(&mut self, id: String, desired_size: u64) -> result::Result<(), VmError> {
+        self.vm_config.as_ref().ok_or(VmError::VmNotCreated)?;
+
+        if let Some(ref mut vm) = self.vm {
+            return vm.resize_disk(&id, desired_size);
+        }
+
+        Err(VmError::ResizeDisk)
+    }
+
     fn vm_resize_zone(&mut self, id: String, desired_ram: u64) -> result::Result<(), VmError> {
         self.vm_config.as_ref().ok_or(VmError::VmNotCreated)?;
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -246,6 +246,9 @@ pub enum Error {
     #[error("Failed resizing a memory zone")]
     ResizeZone,
 
+    #[error("Failed resizing a disk image")]
+    ResizeDisk,
+
     #[error("Cannot activate virtio devices")]
     ActivateVirtioDevices(#[source] DeviceManagerError),
 
@@ -1702,6 +1705,16 @@ impl Vm {
         }
 
         event!("vm", "resized");
+
+        Ok(())
+    }
+
+    pub fn resize_disk(&mut self, id: &str, desired_size: u64) -> Result<()> {
+        self.device_manager
+            .lock()
+            .unwrap()
+            .resize_disk(id, desired_size)
+            .map_err(Error::DeviceManager)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

This pull request introduces live disk resizing support for RAW images. This enhancement enables dynamic adjustment of disks while the guest is running. This is part of our [cloud-hypervisor openstack enablement](https://github.com/cyberus-technology/openstack-nova/tree/gardenlinux).

## Testing
- [x] Ran our [libvirt test suite](https://github.com/cyberus-technology/libvirt-tests).
- [x] Add integration test


