### PR TITLE
seccomp: allow sendto for vsock thread

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -239,6 +239,7 @@ fn virtio_vsock_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_connect, vec![]),
         (libc::SYS_ioctl, create_vsock_ioctl_seccomp_rule()),
         (libc::SYS_recvfrom, vec![]),
+        (libc::SYS_sendto, vec![]),
         (libc::SYS_socket, vec![]),
         // If debug_assertions is enabled, closing a file first checks
         // whether the FD is valid with fcntl.


### PR DESCRIPTION
As of rust 1.90, [writes to unix socket streams use send_with_flags](https://github.com/rust-lang/rust/pull/140005/files#diff-acb690c6d5a39051bd53bdb4f11396f804b2bf973d397deb286cef2c0b63871cR657) instead of write, so it uses a sendto syscall instead of write.

I found this when upgrading my machines to a new Nixpkgs which bumped rust from 1.89 to 1.90. Suddenly, all of my VMs were crashlooping due to seccomp violations. `--seccomp log` showed this as the culprit, and with this patch, I'm not seeing any more audit logs.