### PR TITLE
misc: Replace anyhow with thiserror in TPM module

### DIFF
--- a/tpm/src/lib.rs
+++ b/tpm/src/lib.rs
@@ -9,7 +9,6 @@ extern crate log;
 pub mod emulator;
 pub mod socket;
 
-use anyhow::anyhow;
 use thiserror::Error;
 
 pub const TPM_CRB_BUFFER_MAX: usize = 3968; // 0x1_000 - 0x80
@@ -46,10 +45,10 @@ pub enum Commands {
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Failed converting buf to PTM ")]
-    ConvertToPtm(#[source] anyhow::Error),
+    #[error("Failed converting buf to PTM: {0}")]
+    ConvertToPtm(String),
 }
-type Result<T> = anyhow::Result<T, Error>;
+type Result<T> = std::result::Result<T, Error>;
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum MemberType {
@@ -99,7 +98,7 @@ impl Ptm for PtmResult {
         let expected_len = 4;
         let len = buf.len();
         if len != expected_len {
-            return Err(Error::ConvertToPtm(anyhow!(
+            return Err(Error::ConvertToPtm(format!(
                 "PtmRes buffer is of incorrect length. Got {len} expected {expected_len}."
             )));
         }
@@ -136,7 +135,7 @@ impl Ptm for PtmCap {
         let expected_len = 8;
         let len = buf.len();
         if len != expected_len {
-            return Err(Error::ConvertToPtm(anyhow!(
+            return Err(Error::ConvertToPtm(format!(
                 "Response for GetCapability cmd is of incorrect length. Got {len} expected {expected_len}."
             )));
         }
@@ -197,7 +196,7 @@ impl Ptm for PtmEst {
         let expected_len = 8;
         let len = buf.len();
         if len != expected_len {
-            return Err(Error::ConvertToPtm(anyhow!(
+            return Err(Error::ConvertToPtm(format!(
                 "Response for GetTpmEstablished cmd is of incorrect length. Got {len} expected {expected_len}."
             )));
         }
@@ -259,7 +258,7 @@ impl Ptm for PtmInit {
         let expected_len = 4;
         let len = buf.len();
         if len != expected_len {
-            return Err(Error::ConvertToPtm(anyhow!(
+            return Err(Error::ConvertToPtm(format!(
                 "Response for Init cmd is of incorrect length. Got {len} expected {expected_len}."
             )));
         }
@@ -348,7 +347,7 @@ impl Ptm for PtmSetBufferSize {
         let expected_len = 16;
         let len = buf.len();
         if len != expected_len {
-            return Err(Error::ConvertToPtm(anyhow!(
+            return Err(Error::ConvertToPtm(format!(
                 "Response for CmdSetBufferSize cmd is of incorrect length. Got {len} expected {expected_len}."
             )));
         }

--- a/tpm/src/socket.rs
+++ b/tpm/src/socket.rs
@@ -3,24 +3,24 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::io;
 use std::io::Read;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 
-use anyhow::anyhow;
 use thiserror::Error;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Cannot connect to tpm Socket")]
-    ConnectToSocket(#[source] anyhow::Error),
-    #[error("Failed to read from socket")]
-    ReadFromSocket(#[source] anyhow::Error),
-    #[error("Failed to write to socket")]
-    WriteToSocket(#[source] anyhow::Error),
+    ConnectToSocket(#[source] io::Error),
+    #[error("Failed to read from socket: {0}")]
+    ReadFromSocket(String),
+    #[error("Failed to write to socket: {0}")]
+    WriteToSocket(String),
 }
-type Result<T> = anyhow::Result<T, Error>;
+type Result<T> = std::result::Result<T, Error>;
 
 #[derive(PartialEq)]
 enum SocketDevState {
@@ -65,9 +65,7 @@ impl SocketDev {
     pub fn connect(&mut self, socket_path: &str) -> Result<()> {
         self.state = SocketDevState::Connecting;
 
-        let s = UnixStream::connect(socket_path).map_err(|e| {
-            Error::ConnectToSocket(anyhow!("Failed to connect to tpm Socket. Error: {e:?}"))
-        })?;
+        let s = UnixStream::connect(socket_path).map_err(Error::ConnectToSocket)?;
         self.control_fd = s.as_raw_fd();
         self.stream = Some(s);
         self.state = SocketDevState::Connected;
@@ -92,7 +90,7 @@ impl SocketDev {
             .unwrap()
             .send_with_fd(buf, write_fd)
             .map_err(|e| {
-                Error::WriteToSocket(anyhow!("Failed to write to Socket. Error: {e:?}"))
+                Error::WriteToSocket(format!("Failed to write to Socket. Error: {e:?}"))
             })?;
 
         Ok(size)
@@ -100,9 +98,9 @@ impl SocketDev {
 
     pub fn write(&mut self, buf: &[u8]) -> Result<usize> {
         if self.stream.is_none() {
-            return Err(Error::WriteToSocket(anyhow!(
-                "Stream for tpm socket was not initialized"
-            )));
+            return Err(Error::WriteToSocket(
+                "Stream for tpm socket was not initialized".to_string(),
+            ));
         }
 
         if matches!(self.state, SocketDevState::Connected) {
@@ -115,21 +113,21 @@ impl SocketDev {
             }
             Ok(ret)
         } else {
-            Err(Error::WriteToSocket(anyhow!(
-                "TPM Socket was not in Connected State"
-            )))
+            Err(Error::WriteToSocket(
+                "TPM Socket was not in Connected State".to_string(),
+            ))
         }
     }
 
     pub fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         if self.stream.is_none() {
-            return Err(Error::ReadFromSocket(anyhow!(
-                "Stream for tpm socket was not initialized"
-            )));
+            return Err(Error::ReadFromSocket(
+                "Stream for tpm socket was not initialized".to_string(),
+            ));
         }
         let mut socket = self.stream.as_ref().unwrap();
         let size: usize = socket.read(buf).map_err(|e| {
-            Error::ReadFromSocket(anyhow!("Failed to read from socket. Error Code {e:?}"))
+            Error::ReadFromSocket(format!("Failed to read from socket. Error Code {e:?}"))
         })?;
         Ok(size)
     }


### PR DESCRIPTION
misc: Replace anyhow with explicit error types in TPM module.

This commit refactors the error handling in tpm module to replace use of anyhow:Error with strongly typed error enums.
See: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7432

Signed-Off-by: Shubham Chakrawar [schakrawar@crusoe.ai](mailto:schakrawar@crusoe.ai)