### PR TITLE
arch/x86_64: fix cpuid leaf 0x1 EBX bits 23-16

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -1303,9 +1303,10 @@ fn update_cpuid_topology(
     let die_width = u16::BITS - (dies_per_package - 1).leading_zeros() + core_width;
 
     // The very old way: a flat number of logical CPUs per package: CPUID.1H:EBX[23:16] bits.
+    let core_count = dies_per_package as u32 * cores_per_die as u32 * threads_per_core as u32;
     let mut cpu_ebx = CpuidPatch::get_cpuid_reg(cpuid, 0x1, None, CpuidReg::EBX).unwrap_or(0);
-    cpu_ebx |= ((dies_per_package as u32) * (cores_per_die as u32) * (threads_per_core as u32))
-        & (0xff << 16);
+    cpu_ebx &= !(0xff << 16);
+    cpu_ebx |= (core_count & 0xff) << 16;
     CpuidPatch::set_cpuid_reg(cpuid, 0x1, None, CpuidReg::EBX, cpu_ebx);
 
     let mut cpu_edx = CpuidPatch::get_cpuid_reg(cpuid, 0x1, None, CpuidReg::EDX).unwrap_or(0);


### PR DESCRIPTION
Commit 5ec47d488366 was intended to patch ebx bits 23-16 in cpuid leaf 0x1, but it was not working as expected, as in rust, operator << has a stronger precedence than & [1]. Later commit b6667f948ed2 fixed the operator precedence clippy warning, but did not fix the actual issue. As a result, the current code is not changing ebx,

```
cpu_ebx |= ((dies_per_package as u32) * (cores_per_die as u32) * (threads_per_core as u32))
    & (0xff << 16);
```

Since the total number of logical processors is generally less than 65536, the right hand side of the expression is 0 in most cases.

[1] https://doc.rust-lang.org/reference/expressions.html#expression-precedence

Fixes: 5ec47d488366 ("arch: x86_64: enable HTT flag")