### PR TITLE
Quality of Life Improvement: enable `cargo test --workspace`: via `#[cfg(chv_testenv)]`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,29 @@ License](https://opensource.org/licenses/Apache-2.0).
 ## Coding Style
 
 We follow the [Rust Style](https://github.com/rust-lang/rust/tree/HEAD/src/doc/style-guide/src)
-convention and enforce it through the Continuous Integration (CI) process calling into `rustfmt`
-for each submitted Pull Request (PR).
+convention and enforce it through the Continuous Integration (CI) process calling into `rustfmt`,
+`clippy`, and other well-known code quality tool of the ecosystem for each submitted Pull Request (PR).
 
 ## Basic Checks
+
+```sh
+# We currently rely on nightly-only formatting features
+cargo +nightly fmt --all
+cargo check --all --all-targets --tests 
+cargo clippy --all --all-targets --tests
+# Please note that this will not execute integration tests.
+cargo test --all --all-targets --tests
+```
+
+### \[Optional\] Run Integration Tests
+
+_Caution: These tests are taking a long time to complete (40+ mins) and need special setup._
+
+```sh
+ bash ./scripts/dev_cli.sh tests --integration -- --test-filter '<optionally filter test by name pattern>' 
+```
+
+### Setup Commit Hook
 
 Please consider creating the following hook as `.git/hooks/pre-commit` in order
 to ensure basic correctness of your code. You can extend this further if you
@@ -26,7 +45,7 @@ have specific features that you regularly develop against.
 ```sh
 #!/bin/sh
 
-cargo fmt -- --check || exit 1
+cargo +nightly fmt -- --check || exit 1
 cargo check --locked --all --all-targets --tests || exit 1
 cargo clippy --locked --all --all-targets --tests -- -D warnings || exit 1
 ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,3 +162,7 @@ zerocopy = { version = "0.8.27", default-features = false }
 # https://rust-lang.github.io/rust-clippy/master/index.html
 assertions_on_result_states = "deny"
 undocumented_unsafe_blocks = "deny"
+
+[workspace.lints.rust]
+# `level = warn` is irrelevant here but mandatory for rustc/cargo
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(devcli_testenv)'] }

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -192,7 +192,7 @@ pub fn get_host_cpu_phys_bits(hypervisor: &dyn hypervisor::Hypervisor) -> u8 {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     #[test]

--- a/arch/src/riscv64/mod.rs
+++ b/arch/src/riscv64/mod.rs
@@ -218,7 +218,7 @@ pub fn get_host_cpu_phys_bits(_hypervisor: &dyn hypervisor::Hypervisor) -> u8 {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     #[test]

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -1428,7 +1428,7 @@ fn update_cpuid_topology(
     }
 }
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use linux_loader::loader::bootparam::boot_e820_entry;
 
     use super::*;

--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -297,7 +297,7 @@ pub fn setup_mptable(
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use vm_memory::bitmap::BitmapSlice;
     use vm_memory::{GuestUsize, VolatileMemoryError, VolatileSlice, WriteVolatile};
 

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -196,7 +196,7 @@ pub fn configure_segments_and_sregs(
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use vm_memory::GuestAddress;
 
     use super::*;

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -272,7 +272,7 @@ pub fn setup_smbios(
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     #[test]

--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -519,7 +519,7 @@ impl TdHob {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     #[test]

--- a/block/src/qcow/mod.rs
+++ b/block/src/qcow/mod.rs
@@ -1815,7 +1815,7 @@ pub fn detect_image_type(file: &mut RawFile) -> Result<ImageType> {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use std::fs::File;
     use std::path::Path;
 

--- a/block/src/qcow/vec_cache.rs
+++ b/block/src/qcow/vec_cache.rs
@@ -135,7 +135,7 @@ impl<T: Cacheable> CacheMap<T> {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     struct NumCache(());

--- a/block/src/vhd.rs
+++ b/block/src/vhd.rs
@@ -117,7 +117,7 @@ pub fn is_fixed_vhd(f: &mut File) -> std::io::Result<bool> {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use std::fs::File;
     use std::io::{Seek, SeekFrom, Write};
 

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -798,7 +798,7 @@ impl BusDevice for FwCfg {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use std::ffi::CString;
     use std::io::Write;
 

--- a/devices/src/legacy/gpio_pl061.rs
+++ b/devices/src/legacy/gpio_pl061.rs
@@ -323,7 +323,7 @@ impl Transportable for Gpio {}
 impl Migratable for Gpio {}
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use vm_device::interrupt::{InterruptIndex, InterruptSourceConfig};
     use vmm_sys_util::eventfd::EventFd;
 

--- a/devices/src/legacy/rtc_pl031.rs
+++ b/devices/src/legacy/rtc_pl031.rs
@@ -216,7 +216,7 @@ impl BusDevice for Rtc {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
     use crate::{
         read_be_u16, read_be_u32, read_le_i32, read_le_u16, read_le_u64, write_be_u16,

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -340,7 +340,7 @@ impl Transportable for Serial {}
 impl Migratable for Serial {}
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use std::sync::Mutex;
 
     use vm_device::interrupt::{InterruptIndex, InterruptSourceConfig};

--- a/devices/src/legacy/uart_pl011.rs
+++ b/devices/src/legacy/uart_pl011.rs
@@ -453,7 +453,7 @@ impl Transportable for Pl011 {}
 impl Migratable for Pl011 {}
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use std::sync::Mutex;
 
     use vm_device::interrupt::{InterruptIndex, InterruptSourceConfig};

--- a/devices/src/tpm.rs
+++ b/devices/src/tpm.rs
@@ -531,7 +531,7 @@ impl BusDevice for Tpm {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     #[test]

--- a/fuzz/fuzz_targets/vsock.rs
+++ b/fuzz/fuzz_targets/vsock.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use libfuzzer_sys::{fuzz_target, Corpus};
 use seccompiler::SeccompAction;
-use virtio_devices::vsock::tests::TestBackend;
+use virtio_devices::vsock::unit_tests::TestBackend;
 use virtio_devices::{VirtioDevice, VirtioInterrupt, VirtioInterruptType};
 use virtio_queue::{Queue, QueueT};
 use vm_memory::bitmap::AtomicBitmap;

--- a/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/cmp.rs
@@ -208,7 +208,7 @@ impl<T: CpuStateManager> InstructionHandler<T> for Cmp_rm64_imm8 {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
     use crate::arch::x86::emulator::mock_vmm::*;
 

--- a/hypervisor/src/arch/x86/emulator/instructions/mov.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/mov.rs
@@ -268,7 +268,7 @@ impl<T: CpuStateManager> InstructionHandler<T> for Mov_RAX_moffs64 {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
     use crate::arch::x86::emulator::mock_vmm::*;
 

--- a/hypervisor/src/arch/x86/emulator/instructions/movs.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/movs.rs
@@ -104,7 +104,7 @@ impl<T: CpuStateManager> InstructionHandler<T> for Movsb_m8_m8 {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
     use crate::arch::x86::emulator::mock_vmm::*;
 

--- a/hypervisor/src/arch/x86/emulator/instructions/or.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/or.rs
@@ -49,7 +49,7 @@ impl<T: CpuStateManager> InstructionHandler<T> for Or_rm8_r8 {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
     use crate::arch::x86::emulator::mock_vmm::*;
 

--- a/hypervisor/src/arch/x86/emulator/instructions/stos.rs
+++ b/hypervisor/src/arch/x86/emulator/instructions/stos.rs
@@ -90,7 +90,7 @@ impl<T: CpuStateManager> InstructionHandler<T> for Stosb_m8_AL {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
     use crate::arch::x86::emulator::mock_vmm::*;
 

--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -786,7 +786,7 @@ mod mock_vmm {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
     use crate::arch::x86::emulator::mock_vmm::*;
 

--- a/hypervisor/src/arch/x86/gdt.rs
+++ b/hypervisor/src/arch/x86/gdt.rs
@@ -114,7 +114,7 @@ pub fn segment_from_gdt(entry: u64, table_index: u8) -> SegmentRegister {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     #[test]

--- a/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -481,7 +481,7 @@ impl Vgic for KvmGicV3Its {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use crate::HypervisorVmConfig;
     use crate::aarch64::gic::{
         get_dist_regs, get_icc_regs, get_redist_regs, set_dist_regs, set_icc_regs, set_redist_regs,

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -2937,7 +2937,7 @@ impl KvmVcpu {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     #[test]
     #[cfg(target_arch = "riscv64")]
     fn test_get_and_set_regs() {

--- a/hypervisor/src/kvm/riscv64/aia.rs
+++ b/hypervisor/src/kvm/riscv64/aia.rs
@@ -250,7 +250,7 @@ impl Vaia for KvmAiaImsics {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use crate::HypervisorVmConfig;
     use crate::arch::riscv64::aia::VaiaConfig;
     use crate::kvm::KvmAiaImsics;

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -189,7 +189,7 @@ pub fn virtio_features_to_tap_offload(features: u64) -> c_uint {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     #[test]

--- a/net_util/src/mac.rs
+++ b/net_util/src/mac.rs
@@ -139,7 +139,7 @@ impl FromStr for MacAddr {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     #[test]

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -549,6 +549,7 @@ impl AsRawFd for Tap {
 }
 
 #[cfg(test)]
+#[cfg(devcli_testenv)] // we need special permissions in the ENV to create Tap devices
 mod tests {
     use std::net::Ipv4Addr;
     use std::sync::{LazyLock, Mutex, mpsc};

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -550,7 +550,7 @@ impl AsRawFd for Tap {
 
 #[cfg(test)]
 #[cfg(devcli_testenv)] // we need special permissions in the ENV to create Tap devices
-mod tests {
+mod unit_tests {
     use std::net::Ipv4Addr;
     use std::sync::{LazyLock, Mutex, mpsc};
     use std::time::Duration;

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -638,13 +638,6 @@ mod unit_tests {
         }
     }
 
-    fn tap_name_to_string(tap: &Tap) -> String {
-        let null_pos = tap.if_name.iter().position(|x| *x == 0).unwrap();
-        str::from_utf8(&tap.if_name[..null_pos])
-            .unwrap()
-            .to_string()
-    }
-
     // Given a buffer of appropriate size, this fills in the relevant fields based on the
     // provided information. Payload refers to the UDP payload.
     fn pnet_build_packet(buf: &mut [u8], dst_mac: MacAddr, payload: &[u8]) {
@@ -785,7 +778,7 @@ mod unit_tests {
         tap.enable().unwrap();
 
         // Send a packet to the interface. We expect to be able to receive it on the associated fd.
-        pnet_send_packet(tap_name_to_string(&tap));
+        pnet_send_packet(tap.if_name_as_str().to_owned());
 
         let mut buf = [0u8; 4096];
 
@@ -843,7 +836,7 @@ mod unit_tests {
         tap.set_ip_addr(ip_addr, Some(netmask)).unwrap();
         tap.enable().unwrap();
 
-        let (mac, _, mut rx) = pnet_get_mac_tx_rx(tap_name_to_string(&tap));
+        let (mac, _, mut rx) = pnet_get_mac_tx_rx(tap.if_name_as_str().to_owned());
 
         let payload = DATA_STRING.as_bytes();
 

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -442,7 +442,7 @@ impl Parseable for StringList {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     #[test]

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -1180,7 +1180,7 @@ impl PciBarConfiguration {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use vm_memory::ByteValued;
 
     use super::*;

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -553,7 +553,7 @@ pub fn performance_restore_latency(control: &PerformanceTestControl) -> f64 {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     #[test]

--- a/rate_limiter/src/group.rs
+++ b/rate_limiter/src/group.rs
@@ -297,7 +297,7 @@ impl Drop for RateLimiterGroup {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+pub(crate) mod unit_tests {
     use std::os::fd::AsRawFd;
     use std::thread;
     use std::time::Duration;

--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -522,7 +522,7 @@ impl Default for RateLimiter {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+pub(crate) mod unit_tests {
     use std::{fmt, thread};
 
     use super::*;

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -47,6 +47,9 @@ CARGO_GIT_REGISTRY_DIR="${CLH_BUILD_DIR}/cargo_git_registry"
 # Full path to the cargo target dir on the host.
 CARGO_TARGET_DIR="${CLH_BUILD_DIR}/cargo_target"
 
+# Let tests know that the special environment is set up.
+RUSTFLAGS="${RUSTFLAGS} --cfg devcli_testenv"
+
 # Send a decorated message to stdout, followed by a new line
 #
 say() {

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -191,7 +191,9 @@ if [ $RES -ne 0 ]; then
     exit 1
 fi
 
+# Common configuration for every test run
 export RUST_BACKTRACE=1
+export RUSTFLAGS="$RUSTFLAGS"
 
 cargo build --features mshv --all --release --target "$BUILD_TARGET"
 

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -83,7 +83,10 @@ PAGE_NUM=$((12288 * 1024 / HUGEPAGESIZE))
 echo "$PAGE_NUM" | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
+# Common configuration for every test run
 export RUST_BACKTRACE=1
+export RUSTFLAGS="$RUSTFLAGS"
+
 time cargo nextest run $test_features --retries 3 --no-fail-fast --test-threads=$(($(nproc) / 4)) "live_migration_parallel::$test_filter" -- ${test_binary_args[*]}
 
 RES=$?

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -55,7 +55,10 @@ fi
 
 cargo build --features mshv --all --release --target "$BUILD_TARGET"
 
+# Common configuration for every test run
 export RUST_BACKTRACE=1
+export RUSTFLAGS="$RUSTFLAGS"
+
 time cargo nextest run $test_features --test-threads=1 "rate_limiter::$test_filter" -- ${test_binary_args[*]}
 RES=$?
 

--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -26,7 +26,10 @@ fi
 
 cargo build --features mshv --all --release --target "$BUILD_TARGET"
 
+# Common configuration for every test run
 export RUST_BACKTRACE=1
+export RUSTFLAGS="$RUSTFLAGS"
+
 time cargo nextest run --test-threads=1 "vfio::test_nvidia" -- ${test_binary_args[*]}
 RES=$?
 

--- a/scripts/run_integration_tests_windows_aarch64.sh
+++ b/scripts/run_integration_tests_windows_aarch64.sh
@@ -36,7 +36,9 @@ dmsetup mknodes
 dmsetup create windows-snapshot-base --table "0 $img_blk_size snapshot-origin /dev/mapper/windows-base"
 dmsetup mknodes
 
+# Common configuration for every test run
 export RUST_BACKTRACE=1
+export RUSTFLAGS="$RUSTFLAGS"
 
 cargo build --all --release --target "$BUILD_TARGET"
 

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -41,7 +41,9 @@ dmsetup mknodes
 
 cargo build --features mshv --all --release --target "$BUILD_TARGET"
 
+# Common configuration for every test run
 export RUST_BACKTRACE=1
+export RUSTFLAGS="$RUSTFLAGS"
 
 # Only run with 1 thread to avoid tests interfering with one another because
 # Windows has a static IP configured

--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -1205,7 +1205,7 @@ fn main() {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use std::cmp::Ordering;
 
     use super::*;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+#![cfg(devcli_testenv)]
 #![allow(clippy::undocumented_unsafe_blocks)]
 // When enabling the `mshv` feature, we skip quite some tests and
 // hence have known dead-code. This annotation silences dead-code

--- a/tpm/src/lib.rs
+++ b/tpm/src/lib.rs
@@ -381,7 +381,7 @@ impl Ptm for PtmSetBufferSize {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
     #[test]
     fn test_ptmresult() -> Result<()> {

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -392,7 +392,7 @@ impl Snapshottable for VirtioPciCommonConfig {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use vm_memory::GuestMemoryAtomic;
     use vmm_sys_util::eventfd::EventFd;
 

--- a/virtio-devices/src/vsock/csm/connection.rs
+++ b/virtio-devices/src/vsock/csm/connection.rs
@@ -670,14 +670,14 @@ where
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use std::io::{Error as IoError, Result as IoResult};
 
     use libc::EFD_NONBLOCK;
     use virtio_queue::QueueOwnedT;
     use vmm_sys_util::eventfd::EventFd;
 
-    use super::super::super::tests::TestContext;
+    use super::super::super::unit_tests::TestContext;
     use super::super::defs as csm_defs;
     use super::*;
 

--- a/virtio-devices/src/vsock/csm/txbuf.rs
+++ b/virtio-devices/src/vsock/csm/txbuf.rs
@@ -142,7 +142,7 @@ impl TxBuf {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use std::io::{Error as IoError, ErrorKind, Result as IoResult};
 
     use super::*;

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -514,10 +514,10 @@ impl<B> Transportable for Vsock<B> where B: VsockBackend + Sync + 'static {}
 impl<B> Migratable for Vsock<B> where B: VsockBackend + Sync + 'static {}
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use libc::EFD_NONBLOCK;
 
-    use super::super::tests::{NoopVirtioInterrupt, TestContext};
+    use super::super::unit_tests::{NoopVirtioInterrupt, TestContext};
     use super::super::*;
     use super::*;
     use crate::ActivateError;

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -161,7 +161,7 @@ pub trait VsockChannel {
 pub trait VsockBackend: VsockChannel + VsockEpollListener + Send {}
 
 #[cfg(any(test, fuzzing))]
-pub mod tests {
+pub mod unit_tests {
     use std::os::unix::io::AsRawFd;
     use std::path::PathBuf;
     use std::sync::{Arc, RwLock};

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -418,13 +418,13 @@ impl VsockPacket {
 
 #[cfg(test)]
 #[allow(clippy::undocumented_unsafe_blocks)]
-mod tests {
+mod unit_tests {
     use virtio_bindings::virtio_ring::VRING_DESC_F_WRITE;
     use virtio_queue::QueueOwnedT;
     use vm_memory::GuestAddress;
     use vm_virtio::queue::testing::VirtqDesc as GuestQDesc;
 
-    use super::super::tests::TestContext;
+    use super::super::unit_tests::TestContext;
     use super::*;
     use crate::GuestMemoryMmap;
     use crate::vsock::defs::MAX_PKT_BUF_SIZE;

--- a/virtio-devices/src/vsock/unix/muxer.rs
+++ b/virtio-devices/src/vsock/unix/muxer.rs
@@ -867,7 +867,7 @@ impl VsockMuxer {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use std::cmp::min;
     use std::io::Write;
     use std::path::{Path, PathBuf};
@@ -875,7 +875,7 @@ mod tests {
     use virtio_queue::QueueOwnedT;
 
     use super::super::super::csm::defs as csm_defs;
-    use super::super::super::tests::TestContext as VsockTestContext;
+    use super::super::super::unit_tests::TestContext as VsockTestContext;
     use super::*;
 
     impl PartiallyReadCommand {

--- a/vm-allocator/src/address.rs
+++ b/vm-allocator/src/address.rs
@@ -215,7 +215,7 @@ impl AddressAllocator {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     #[test]

--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -259,7 +259,7 @@ impl Bus {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     struct DummyDevice;

--- a/vm-migration/src/bitpos_iterator.rs
+++ b/vm-migration/src/bitpos_iterator.rs
@@ -74,7 +74,7 @@ pub trait BitposIteratorExt: Iterator<Item = u64> + Sized {
 impl<I: Iterator<Item = u64> + Sized> BitposIteratorExt for I {}
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     fn bitpos_check(inp: &[u64], out: &[u64]) {

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -320,7 +320,7 @@ impl MemoryRangeTable {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use crate::protocol::{MemoryRange, MemoryRangeTable};
 
     #[test]

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -3170,7 +3170,7 @@ impl Drop for VmConfig {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use std::fs::File;
     use std::os::unix::io::AsRawFd;
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -2992,7 +2992,7 @@ impl CpuElf64Writable for CpuManager {
 
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use arch::layout::{BOOT_STACK_POINTER, ZERO_PAGE_START};
     use arch::x86_64::interrupts::*;
     use arch::x86_64::regs::*;
@@ -3140,7 +3140,7 @@ mod tests {
 
 #[cfg(target_arch = "aarch64")]
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     #[cfg(feature = "kvm")]
     use std::{mem, mem::offset_of};
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -5496,7 +5496,7 @@ impl Drop for DeviceManager {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     #[test]

--- a/vmm/src/device_tree.rs
+++ b/vmm/src/device_tree.rs
@@ -152,7 +152,7 @@ impl DoubleEndedIterator for BftIter<'_> {
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::{DeviceNode, DeviceTree};
 
     #[test]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2401,7 +2401,8 @@ mod unit_tests {
             },
             console: ConsoleConfig {
                 file: None,
-                mode: ConsoleOutputMode::Tty,
+                // Caution: Don't use `Tty` to not mess with users terminal
+                mode: ConsoleOutputMode::Off,
                 iommu: false,
                 socket: None,
             },

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3167,7 +3167,7 @@ impl GuestDebuggable for Vm {
 
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
 
     fn test_vm_state_transitions(state: VmState) {
@@ -3443,7 +3443,7 @@ mod tests {
 
 #[cfg(target_arch = "aarch64")]
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use arch::aarch64::fdt::create_fdt;
     use arch::aarch64::layout;
     use arch::{DeviceType, MmioDeviceInfo};


### PR DESCRIPTION
TL;DR: Massive quality of life improvement for devs

Please review this **commit-by-commit**.

Cloud Hypervisor uses the Cargo test framework for multiple tests:

- normal unit tests
- unit tests requiring special environment (the Tap device tests)
- integration tests requiring a special environment

This prevented the execution of `cargo test --workspace`, which results
in a very poor developer experience. Although `./scripts/run_unittests.sh`
exists, there are valid reasons why people can not or even don't want to
use them.

By adding a new `chv_testenv` rustc config, we can conditionally only
activate tests when the `./scripts/` magic runs them.
