### PR TITLE
hypervisor: Enable hyperv synic in KVM when restoring Windows guest

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -519,7 +519,7 @@ pub trait Vcpu: Send + Sync {
     /// Set the vCPU state.
     /// This function is required when restoring the VM
     ///
-    fn set_state(&self, state: &CpuState) -> Result<()>;
+    fn set_state(&self, state: &CpuState, hyperv_guest: bool) -> Result<()>;
     ///
     /// Triggers the running of the current virtual CPU returning an exit reason.
     ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -2569,7 +2569,7 @@ impl cpu::Vcpu for KvmVcpu {
     /// let state = vcpu.state().unwrap();
     /// vcpu.set_state(&state).unwrap();
     /// ```
-    fn set_state(&self, state: &CpuState) -> cpu::Result<()> {
+    fn set_state(&self, state: &CpuState, hyperv_guest: bool) -> cpu::Result<()> {
         let state: VcpuKvmState = state.clone().into();
         self.set_cpuid2(&state.cpuid)?;
         self.set_mp_state(state.mp_state.into())?;
@@ -2585,6 +2585,10 @@ impl cpu::Vcpu for KvmVcpu {
 
         if let Some(freq) = state.tsc_khz {
             self.set_tsc_khz(freq)?;
+        }
+
+        if hyperv_guest {
+            self.enable_hyperv_synic()?;
         }
 
         // Try to set all MSRs previously stored.

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1397,7 +1397,7 @@ impl cpu::Vcpu for MshvVcpu {
     ///
     /// Set CPU state for x86_64 guest.
     ///
-    fn set_state(&self, state: &CpuState) -> cpu::Result<()> {
+    fn set_state(&self, state: &CpuState, _hyperv_guest: bool) -> cpu::Result<()> {
         let mut state: VcpuMshvState = state.clone().into();
         self.set_msrs(&state.msrs)?;
         self.set_vcpu_events(&state.vcpu_events)?;

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -925,7 +925,7 @@ impl CpuManager {
                 Error::VcpuCreate(anyhow!("Could not get vCPU state from snapshot {e:?}"))
             })?;
             vcpu.vcpu
-                .set_state(&state)
+                .set_state(&state, self.config.kvm_hyperv)
                 .map_err(|e| Error::VcpuCreate(anyhow!("Could not set the vCPU state {e:?}")))?;
 
             vcpu.saved_state = Some(state);


### PR DESCRIPTION
This fixes KVM VM abnormal behavior after restoring from a Windows 11 snapshot.

To reproduce the issue:

1. Follow the guide: https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/docs/windows.md
2. Take a snapshot and restore:

```bash
sudo ch-remote --api-socket ./api.sock pause
sudo ch-remote --api-socket ./api.sock snapshot file://$snapshot
sudo ch-remote --api-socket ./api.sock shutdown-vmm

rm -f api.sock
sudo cloud-hypervisor --api-socket ./api.sock \
    --seccomp false \
    --restore source_url=file://$snapshot

sudo ch-remote --api-socket ./api.sock resume
```