### PR TITLE
Fix V2 extended topology enumeration APIC ID reporting

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -1347,6 +1347,7 @@ fn update_cpuid_topology(
         u32::from(threads_per_core),
     );
     CpuidPatch::set_cpuid_reg(cpuid, 0x1f, Some(0), CpuidReg::ECX, 1 << 8);
+    CpuidPatch::set_cpuid_reg(cpuid, 0x1f, Some(0), CpuidReg::EDX, x2apic_id);
 
     CpuidPatch::set_cpuid_reg(cpuid, 0x1f, Some(1), CpuidReg::EAX, core_width);
     CpuidPatch::set_cpuid_reg(
@@ -1357,6 +1358,7 @@ fn update_cpuid_topology(
         u32::from(cores_per_die * threads_per_core),
     );
     CpuidPatch::set_cpuid_reg(cpuid, 0x1f, Some(1), CpuidReg::ECX, 2 << 8);
+    CpuidPatch::set_cpuid_reg(cpuid, 0x1f, Some(1), CpuidReg::EDX, x2apic_id);
 
     CpuidPatch::set_cpuid_reg(cpuid, 0x1f, Some(2), CpuidReg::EAX, die_width);
     CpuidPatch::set_cpuid_reg(
@@ -1367,6 +1369,7 @@ fn update_cpuid_topology(
         u32::from(dies_per_package * cores_per_die * threads_per_core),
     );
     CpuidPatch::set_cpuid_reg(cpuid, 0x1f, Some(2), CpuidReg::ECX, 5 << 8);
+    CpuidPatch::set_cpuid_reg(cpuid, 0x1f, Some(2), CpuidReg::EDX, x2apic_id);
 
     if matches!(cpu_vendor, CpuVendor::AMD) {
         CpuidPatch::set_cpuid_reg(


### PR DESCRIPTION
When booting a Linux guest in SMP configuration, on sapphire rapids and granite rapids the following kernel warning can be observed:

```
[Firmware Bug]: CPUID leaf 0x1f subleaf 1 APIC ID mismatch 1 != 0
[Firmware Bug]: CPUID leaf 0x1f subleaf 2 APIC ID mismatch 1 != 0
```

The reason is that we announce the presence of the extended topology leaf, but fail to announce the x2apic ID in EDX for each sub-leaf.

We already fixed this for leaf 0xb, sub-leaf zero in https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7087, but forgot to do the same for leaf 0x1f and its sub-leafs.

The documentation for this cpuid leaf states the following for EDX: It is always valid and does not vary with the sub-leaf index in ECX