### PR TITLE
seccomp: allow sendto for vfio_user devices

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -810,6 +810,7 @@ fn vcpu_thread_rules(
         (libc::SYS_rt_sigreturn, vec![]),
         (libc::SYS_sched_yield, vec![]),
         (libc::SYS_sendmsg, vec![]),
+        (libc::SYS_sendto, vec![]),
         (libc::SYS_shutdown, vec![]),
         (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_tgkill, vec![]),


### PR DESCRIPTION
As of rust 1.90, writes to unix sockets use the `sendto` syscall. This affects the vcpu threads when `vfio_user` devices are accessed.

See also #7477 and #7454.