### PR TITLE
vmm: Fix clippy lints on RISC-V

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1702,7 +1702,7 @@ impl CpuManager {
                 n_supervisor_int_id: arch::riscv64::CLOUDHV_IRQCHIP_NUM_MSIS,
                 n_guest_int_id: arch::riscv64::CLOUDHV_IRQCHIP_NUM_MSIS,
                 geust_index_bits: 1,
-                hart_index_bits: hart_index_bits,
+                hart_index_bits,
                 group_index_bits: 1,
                 // IMSIC_MMIO_GROUP_MIN_SHIFT
                 group_index_shift: 24,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1741,7 +1741,7 @@ impl DeviceManager {
     ) -> DeviceManagerResult<Arc<Mutex<dyn InterruptController>>> {
         let interrupt_controller: Arc<Mutex<aia::Aia>> = Arc::new(Mutex::new(
             aia::Aia::new(
-                self.config.lock().unwrap().cpus.boot_vcpus as u32,
+                self.config.lock().unwrap().cpus.boot_vcpus,
                 Arc::clone(&self.msi_interrupt_manager),
                 self.address_manager.vm.clone(),
             )


### PR DESCRIPTION
These caused CI failures in #7129.

No functional change.