### PR TITLE
Serial Manager fixes

### DIFF
--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -294,7 +294,7 @@ impl SerialManager {
                             }
                         };
 
-                        if matches!(in_file, ConsoleOutput::Socket(_)) && num_events == 0 {
+                        if matches!(in_file, ConsoleOutput::Pty(_)) && num_events == 0 {
                             // This very specific case happens when the serial is connected
                             // to a PTY. We know EPOLLHUP is always present when there's nothing
                             // connected at the other end of the PTY. That's why getting no event


### PR DESCRIPTION
Fix the initial flush when PTY serial type is used.
Fix FD leak while using socket backend for serial device