### PR TITLE
event_monitor: Send events to info! level logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,7 @@ version = "0.1.0"
 dependencies = [
  "flume",
  "libc",
+ "log",
  "serde",
  "serde_json",
 ]

--- a/event_monitor/Cargo.toml
+++ b/event_monitor/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 [dependencies]
 flume = { workspace = true }
 libc = { workspace = true }
+log = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 


### PR DESCRIPTION
The resulting output looks like:

Event: source = virtio-device event = activated id = _disk0

See: #7484

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
