### PR TITLE
hypervisor: Don't create temporary vector for boot MSRs

### DIFF
--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -82,7 +82,7 @@ pub fn setup_fpu(vcpu: &dyn hypervisor::Vcpu) -> Result<()> {
 ///
 /// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
 pub fn setup_msrs(vcpu: &dyn hypervisor::Vcpu) -> Result<()> {
-    vcpu.set_msrs(&vcpu.boot_msr_entries())
+    vcpu.set_msrs(vcpu.boot_msr_entries())
         .map_err(Error::SetModelSpecificRegisters)?;
 
     Ok(())

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -558,7 +558,7 @@ pub trait Vcpu: Send + Sync {
     ///
     /// Return the list of initial MSR entries for a VCPU
     ///
-    fn boot_msr_entries(&self) -> Vec<MsrEntry>;
+    fn boot_msr_entries(&self) -> &'static [MsrEntry];
 
     #[cfg(target_arch = "x86_64")]
     ///

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -2732,10 +2732,10 @@ impl cpu::Vcpu for KvmVcpu {
     ///
     /// Return the list of initial MSR entries for a VCPU
     ///
-    fn boot_msr_entries(&self) -> Vec<MsrEntry> {
+    fn boot_msr_entries(&self) -> &'static [MsrEntry] {
         use crate::arch::x86::{MTRR_ENABLE, MTRR_MEM_TYPE_WB, msr_index};
 
-        [
+        &[
             msr!(msr_index::MSR_IA32_SYSENTER_CS),
             msr!(msr_index::MSR_IA32_SYSENTER_ESP),
             msr!(msr_index::MSR_IA32_SYSENTER_EIP),
@@ -2751,7 +2751,6 @@ impl cpu::Vcpu for KvmVcpu {
             ),
             msr_data!(msr_index::MSR_MTRRdefType, MTRR_ENABLE | MTRR_MEM_TYPE_WB),
         ]
-        .to_vec()
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1441,10 +1441,10 @@ impl cpu::Vcpu for MshvVcpu {
     ///
     /// Return the list of initial MSR entries for a VCPU
     ///
-    fn boot_msr_entries(&self) -> Vec<MsrEntry> {
+    fn boot_msr_entries(&self) -> &'static [MsrEntry] {
         use crate::arch::x86::{MTRR_ENABLE, MTRR_MEM_TYPE_WB, msr_index};
 
-        [
+        &[
             msr!(msr_index::MSR_IA32_SYSENTER_CS),
             msr!(msr_index::MSR_IA32_SYSENTER_ESP),
             msr!(msr_index::MSR_IA32_SYSENTER_EIP),
@@ -1455,7 +1455,6 @@ impl cpu::Vcpu for MshvVcpu {
             msr!(msr_index::MSR_SYSCALL_MASK),
             msr_data!(msr_index::MSR_MTRRdefType, MTRR_ENABLE | MTRR_MEM_TYPE_WB),
         ]
-        .to_vec()
     }
 
     ///

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -3087,7 +3087,7 @@ mod unit_tests {
         // tenth one (i.e the one with index msr_index::MSR_IA32_MISC_ENABLE has the data we
         // expect.
         let entry_vec = vcpu.boot_msr_entries();
-        assert_eq!(entry_vec.as_slice()[9], msrs.as_slice()[0]);
+        assert_eq!(entry_vec[9], msrs.as_slice()[0]);
     }
 
     #[test]


### PR DESCRIPTION
The MSRs are constant at boot time so rather than creating a vector in
the boot_msr_entries() method instead reaturn a reference to static MSR
array data.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
