### PR TITLE
block: qcow2: Flush the buffer explicitly when writing pointer table

### DIFF
--- a/block/src/qcow/qcow_raw_file.rs
+++ b/block/src/qcow/qcow_raw_file.rs
@@ -80,6 +80,7 @@ impl QcowRawFile {
             };
             buffer.write_u64::<BigEndian>(val)?;
         }
+        buffer.flush()?;
         Ok(())
     }
 


### PR DESCRIPTION
Previously the code relies on the implicit flush when BufWriter is dropped. That's not safe.

Per BufWriter's document:

```
It is critical to call flush before BufWriter<W> is dropped. Though
dropping will attempt to flush the contents of the buffer, any errors
that happen in the process of dropping will be ignored. Calling flush
ensures that the buffer is empty and thus dropping will not even attempt
file operations.
```