### PR TITLE
block: Improves guest signaling for lower virtblk end-to-end latency

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -607,17 +607,14 @@ impl EpollHelperHandler for BlockEpollHandler {
                     ))
                 })?;
 
+                self.try_signal_used_queue()?;
+
                 let rate_limit_reached = self.rate_limiter.as_ref().is_some_and(|r| r.is_blocked());
 
                 // Process the queue only when the rate limit is not reached
                 if !rate_limit_reached {
-                    self.process_queue_submit().map_err(|e| {
-                        EpollHelperError::HandleEvent(anyhow!(
-                            "Failed to process queue (submit): {e:?}"
-                        ))
-                    })?;
+                    self.process_queue_submit_and_signal()?;
                 }
-                self.try_signal_used_queue()?;
             }
             RATE_LIMITER_EVENT => {
                 if let Some(rate_limiter) = &mut self.rate_limiter {


### PR DESCRIPTION
Signal the guest before processing queue submissions to enable earlier guest side completion event handling, reducing end-to-end latency for block device operations.

FIO benchmarks show up to 7.4% bandwidth improvement at 16 iodepth and 4k block size with NVMe devices.

## test stats
before the change: bw=2209MiB/s lat=112.62us
after the change: bw=2373MiB/s lat=104.92us

## Test details
fio command: fio --name=direct_aio_randwrite --ioengine=libaio --iodepth=16 --rw=randwrite --bs=4k --direct=1 --size=4G --numjobs=4 --runtime=240 --group_reporting --time_based --filename=/dev/vdb

cloud-hypervisor setup:
```
numactl --cpubind=0 {clh-path} \
        --memory size=40G,shared=on \
        --kernel {linux 6.1.103} \
        --disk path={boot-disk-path} path={nvme-disk-path},direct=on,num_queues=4,queue_affinity=[0@8,1@9,2@10,3@11] \
        --cmdline "nokaslr earlyprintk=ttyS0 console=hvc0 root=/dev/vda1 rw" \
        --cpus boot=4,affinity=[0@4,1@5,2@6,3@7] \
        --serial tty  \
        --api-socket /tmp/ch-socket \
        --device path=/sys/bus/pci/devices/$dev1 \
        --net "tap=tap1"
```

machine info
```
#lscpu
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
CPU(s):              192
On-line CPU(s) list: 0-191
Thread(s) per core:  2
Core(s) per socket:  24
Socket(s):           4
NUMA node(s):        8
Vendor ID:           HygonGenuine
BIOS Vendor ID:      Chengdu Hygon
CPU family:          24
Model:               4
Model name:          Hygon C86-4G (OPN:7470)
BIOS Model name:     Hygon C86-4G (OPN:7470)
Stepping:            1
CPU MHz:             2999.320
BogoMIPS:            5200.03
Virtualization:      AMD-V
L1d cache:           32K
L1i cache:           32K
L2 cache:            512K
L3 cache:            16384K
NUMA node0 CPU(s):   0-11,96-107
NUMA node1 CPU(s):   12-23,108-119
NUMA node2 CPU(s):   24-35,120-131
NUMA node3 CPU(s):   36-47,132-143
NUMA node4 CPU(s):   48-59,144-155
NUMA node5 CPU(s):   60-71,156-167
NUMA node6 CPU(s):   72-83,168-179
NUMA node7 CPU(s):   84-95,180-191
Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid amd_dcm aperfmperf pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb hw_pstate ssbd ibrs ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 xsaves clzero irperf xsaveerptr arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif umip overflow_recov succor smca sme sev sev_es
```
