### PR TITLE
ci: dco: rename misleading job title

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -3,7 +3,7 @@ on: [pull_request, merge_group]
 
 jobs:
   check:
-    name: DCO Check ("Signed-Off-By")
+    name: DCO Check ("Signed-off-by")
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
"Signed-off-by" is the only variant that is accepted. So we should remove the inconsistency to prevent:

- user forgets this at all
- CI complains
- user adds "Signed-Off-By"
- CI still complains because of the wrong format

