### PR TITLE
block: allow VIRTIO_BLK_T_GET_ID for read-only devices

### DIFF
--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -136,7 +136,7 @@ pub enum ExecuteError {
     Read(#[source] GuestMemoryError),
     #[error("Failed to read_exact")]
     ReadExact(#[source] io::Error),
-    #[error("Can't execute an operation other than `read` on a read-only device")]
+    #[error("Can't execute an operation other than `read` or `get_id` on a read-only device")]
     ReadOnly,
     #[error("Failed to seek")]
     Seek(#[source] io::Error),

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -158,7 +158,9 @@ fn has_feature(features: u64, feature_flag: u64) -> bool {
 
 impl BlockEpollHandler {
     fn check_request(features: u64, request_type: RequestType) -> result::Result<(), ExecuteError> {
-        if has_feature(features, VIRTIO_BLK_F_RO.into()) && request_type != RequestType::In {
+        if has_feature(features, VIRTIO_BLK_F_RO.into())
+            && !(request_type == RequestType::In || request_type == RequestType::GetDeviceId)
+        {
             // For virtio spec compliance
             // "A device MUST set the status byte to VIRTIO_BLK_S_IOERR for a write request
             // if the VIRTIO_BLK_F_RO feature if offered, and MUST NOT write any data."


### PR DESCRIPTION
https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7294 adjusted the checks for read-only requests made to virtio-blk devices and started rejecting VIRTIO_BLK_T_GET_ID requests. These requests do not perform any writes and are needed in order to access device serials from within the guest.