### PR TITLE
block: qcow: Add missing flush in write_refcount_block

### DIFF
--- a/block/src/qcow/qcow_raw_file.rs
+++ b/block/src/qcow/qcow_raw_file.rs
@@ -102,6 +102,7 @@ impl QcowRawFile {
         for count in table {
             buffer.write_u16::<BigEndian>(*count)?;
         }
+        buffer.flush()?;
         Ok(())
     }
 


### PR DESCRIPTION
The BufWriter must be flushed explicitly to handle errors properly. Without explicit flush, errors during the implicit drop flush are ignored.

This is the same issue fixed for write_pointer_table in commit 85556951a.