### PR TITLE
vmm: cleanup &Mutex parameters

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -922,11 +922,9 @@ impl CpuManager {
 
     pub fn configure_vcpu(
         &self,
-        vcpu: &Mutex<Vcpu>,
+        vcpu: &mut Vcpu,
         boot_setup: Option<(EntryPoint, &GuestMemoryAtomic<GuestMemoryMmap>)>,
     ) -> Result<()> {
-        let mut vcpu = vcpu.lock().unwrap();
-
         #[cfg(feature = "sev_snp")]
         if self.sev_snp_enabled {
             if let Some((kernel_entry_point, _)) = boot_setup {
@@ -1406,7 +1404,8 @@ impl CpuManager {
             cmp::Ordering::Greater => {
                 let vcpus = self.create_vcpus(desired_vcpus, None)?;
                 for vcpu in vcpus {
-                    self.configure_vcpu(&vcpu, None)?;
+                    let mut vcpu = vcpu.lock().unwrap();
+                    self.configure_vcpu(&mut vcpu, None)?;
                 }
                 self.activate_vcpus(desired_vcpus, true, None)?;
                 Ok(true)

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1014,7 +1014,8 @@ impl Vmm {
             .unwrap()
             .landlock_enable
         {
-            apply_landlock(self.vm_config.as_ref().unwrap().as_ref()).map_err(|e| {
+            let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
+            apply_landlock(&mut config).map_err(|e| {
                 MigratableError::MigrateReceive(anyhow!("Error applying landlock: {e:?}"))
             })?;
         }
@@ -1486,8 +1487,8 @@ impl Vmm {
             .unwrap()
             .landlock_enable
         {
-            apply_landlock(self.vm_config.as_ref().unwrap().as_ref())
-                .map_err(VmError::ApplyLandlock)?;
+            let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
+            apply_landlock(&mut config).map_err(VmError::ApplyLandlock)?;
         }
 
         // Now we can restore the rest of the VM.
@@ -1606,8 +1607,8 @@ impl Vmm {
     }
 }
 
-fn apply_landlock(vm_config: &Mutex<VmConfig>) -> result::Result<(), LandlockError> {
-    vm_config.lock().unwrap().apply_landlock()?;
+fn apply_landlock(vm_config: &mut VmConfig) -> result::Result<(), LandlockError> {
+    vm_config.apply_landlock()?;
     Ok(())
 }
 
@@ -1628,8 +1629,8 @@ impl RequestHandler for Vmm {
             .as_ref()
             .is_some_and(|config| config.lock().unwrap().landlock_enable)
         {
-            apply_landlock(self.vm_config.as_ref().unwrap().as_ref())
-                .map_err(VmError::ApplyLandlock)?;
+            let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
+            apply_landlock(&mut config).map_err(VmError::ApplyLandlock)?;
         }
         Ok(())
     }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2390,16 +2390,15 @@ impl Vm {
         for vcpu in vcpus {
             let guest_memory = &self.memory_manager.lock().as_ref().unwrap().guest_memory();
             let boot_setup = entry_point.map(|e| (e, guest_memory));
+            let mut vcpu = vcpu.lock().unwrap();
             self.cpu_manager
                 .lock()
                 .unwrap()
-                .configure_vcpu(&vcpu, boot_setup)
+                .configure_vcpu(&mut vcpu, boot_setup)
                 .map_err(Error::CpuManager)?;
 
             #[cfg(target_arch = "aarch64")]
-            vcpu.lock()
-                .unwrap()
-                .set_gic_redistributor_addr(redist_addr[2], redist_addr[3])
+            vcpu.set_gic_redistributor_addr(redist_addr[2], redist_addr[3])
                 .map_err(Error::CpuManager)?;
         }
 


### PR DESCRIPTION
In [0] we refactored some Arc<Mutex<T>> parameters to &Mutex<T>> to satisfy clippy's needless_pass_by_value lint. Nevertheless, this is also not so idiomatic, so as a follow-up, we put the responsibility to lock objects to the caller side (only where this is not strictly needed by the callee).

While on it, I also tried to pass vm_config directly into pre_create_console_devices() which would clean up some code, but then we have interleaving mutable and immutable borrows of the Vmm.

This was my attempt:

```patch
diff --git a/vmm/src/console_devices.rs b/vmm/src/console_devices.rs
index 6e1ef2039..105d005dc 100644
--- a/vmm/src/console_devices.rs
+++ b/vmm/src/console_devices.rs
@@ -24,7 +24,7 @@ use thiserror::Error;

 use crate::Vmm;
 use crate::sigwinch_listener::listen_for_sigwinch_on_tty;
-use crate::vm_config::ConsoleOutputMode;
+use crate::vm_config::{ConsoleOutputMode, VmConfig};

 const TIOCSPTLCK: libc::c_int = 0x4004_5431;
 const TIOCGPTPEER: libc::c_int = 0x5441;
diff --git a/vmm/src/lib.rs b/vmm/src/lib.rs
index 88084cb38..1ef6d7b63 100644
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1002,9 +1002,16 @@ impl Vmm {

         let config = vm_migration_config.vm_config.clone();
         self.vm_config = Some(vm_migration_config.vm_config);
-        self.console_info = Some(pre_create_console_devices(self).map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error creating console devices: {e:?}"))
-        })?);
+        self.console_info = {
+            let mut vmconfig = self.vm_config.as_ref().unwrap().lock().unwrap();
+            Some(
+                pre_create_console_devices(self, &mut *vmconfig).map_err(|e| {
+                    MigratableError::MigrateReceive(anyhow!(
+                        "Error creating console devices: {e:?}"
+                    ))
+                })?,
+            )
+        };

         if self
             .vm_config
@@ -1443,7 +1450,7 @@ impl Vmm {
         self.vm_check_cpuid_compatibility(&vm_config, &vm_snapshot.common_cpuid)
             .map_err(VmError::Restore)?;

-        self.vm_config = Some(Arc::clone(&vm_config));
+        self.vm_config = Some(vm_config);

         // Always re-populate the 'console_info' based on the new 'vm_config'
         self.console_info =
@@ -1613,25 +1620,23 @@ fn apply_landlock(vm_config: &mut VmConfig) -> result::Result<(), LandlockError>
 }

 impl RequestHandler for Vmm {
-    fn vm_create(&mut self, config: Box<VmConfig>) -> result::Result<(), VmError> {
+    fn vm_create(&mut self, mut config: Box<VmConfig>) -> result::Result<(), VmError> {
         // We only store the passed VM config.
         // The VM will be created when being asked to boot it.
         if self.vm_config.is_some() {
             return Err(VmError::VmAlreadyCreated);
         }

-        self.vm_config = Some(Arc::new(Mutex::new(*config)));
-        self.console_info =
-            Some(pre_create_console_devices(self).map_err(VmError::CreateConsoleDevices)?);
+        self.console_info = Some(
+            pre_create_console_devices(self, &mut *config)
+                .map_err(VmError::CreateConsoleDevices)?,
+        );

-        if self
-            .vm_config
-            .as_ref()
-            .is_some_and(|config| config.lock().unwrap().landlock_enable)
-        {
-            let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
+        if config.landlock_enable {
             apply_landlock(&mut *config).map_err(VmError::ApplyLandlock)?;
         }
+
+        self.vm_config = Some(Arc::new(Mutex::new(*config)));
         Ok(())
     }

@@ -1648,8 +1653,11 @@ impl RequestHandler for Vmm {

             // console_info is set to None in vm_shutdown. re-populate here if empty
             if self.console_info.is_none() {
-                self.console_info =
-                    Some(pre_create_console_devices(self).map_err(VmError::CreateConsoleDevices)?);
+                let mut vmconfig = self.vm_config.as_ref().unwrap().lock().unwrap();
+                self.console_info = Some(
+                    pre_create_console_devices(self, &mut *vmconfig)
+                        .map_err(VmError::CreateConsoleDevices)?,
+                );
             }

             // Create a new VM if we don't have one yet.

```

[0] https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7519
