### PR TITLE
block: qcow: Optimize pointer table writes with iterator-based API

### DIFF
--- a/block/src/qcow/refcount.rs
+++ b/block/src/qcow/refcount.rs
@@ -156,11 +156,8 @@ impl RefCount {
     /// Returns true if the table changed since the previous `flush_table()` call.
     pub fn flush_table(&mut self, raw_file: &mut QcowRawFile) -> io::Result<bool> {
         if self.ref_table.dirty() {
-            raw_file.write_pointer_table(
-                self.refcount_table_offset,
-                self.ref_table.get_values(),
-                0,
-            )?;
+            raw_file
+                .write_pointer_table_direct(self.refcount_table_offset, self.ref_table.iter())?;
             self.ref_table.mark_clean();
             Ok(true)
         } else {

--- a/block/src/qcow/vec_cache.rs
+++ b/block/src/qcow/vec_cache.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 use std::collections::hash_map::IterMut;
 use std::io;
-use std::ops::{Index, IndexMut};
+use std::ops::{Deref, Index, IndexMut};
 use std::slice::SliceIndex;
 
 /// Trait that allows for checking if an implementor is dirty. Useful for types that are cached so
@@ -82,6 +82,14 @@ impl<T: 'static + Copy + Default> IndexMut<usize> for VecCache<T> {
     fn index_mut(&mut self, index: usize) -> &mut T {
         self.dirty = true;
         self.vec.index_mut(index)
+    }
+}
+
+impl<T: 'static + Copy + Default> Deref for VecCache<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] {
+        &self.vec
     }
 }
 

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -99,6 +99,7 @@ fn virtio_balloon_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
 fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
     vec![
         (libc::SYS_fallocate, vec![]),
+        (libc::SYS_fcntl, vec![]),
         (libc::SYS_fdatasync, vec![]),
         (libc::SYS_fsync, vec![]),
         (libc::SYS_ftruncate, vec![]),


### PR DESCRIPTION
This patch series refactors QCOW2 pointer table writes to use an iterator-based API, with aim to eliminate temporary allocations and improve code clarity.

The original `write_pointer_table()` API required callers to pass a pre-allocated slice `&[u64]`, forcing the `L1` sync code to collect entries into a temporary `vec<u64>` just to apply OFLAG_COPIED bits. This series refactors the API to accept iterators and callbacks, enabling on-the-fly computation without intermediate allocations.

Changes
- block: qcow: Refactor pointer table writes to use iterators
  - Changes `write_pointer_table()` to accept `Iterator<Item = &T>` + callback
  - Adds `write_pointer_table_direct()` for simple writes without transformation
  - Unifies API across all call sites with lazy evaluation
  - Uses `try_clone()` to create separate file descriptors for `BufWriter`
- block: qcow: Implement Deref for VecCache
  - Enables direct `.iter()` calls on cache objects without explicit get_values()
- seccomp: Allow fcntl in virtio-block thread
  - Adds fcntl syscall support needed by try_clone() used in the refactored code

Performance Impact
- Eliminates allocation for `L1` sync that scales with disk size (~2KB per 100GB with 64KB clusters)
- Removes branching overhead from old `non_zero_flags` parameter
- Enables iterator chaining optimizations (like filtering)
- Maintains `BufWriter` batching
