### PR TITLE
performance-metrics: Add QCOW2 backing file performance tests

### DIFF
--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -319,7 +319,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 30] = [
+const TEST_LIST: [PerformanceTest; 32] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -709,6 +709,36 @@ const TEST_LIST: [PerformanceTest; 30] = [
             ..PerformanceTestControl::default()
         },
         unit_adjuster: adjuster::identity,
+    },
+    PerformanceTest {
+        name: "block_qcow2_backing_qcow2_read_MiBps",
+        func_ptr: performance_block_io,
+        control: PerformanceTestControl {
+            num_queues: Some(1),
+            queue_size: Some(128),
+            block_control: Some(BlockControl {
+                fio_ops: FioOps::Read,
+                bandwidth: true,
+                test_file: OVERLAY_WITH_QCOW2_BACKING,
+            }),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::Bps_to_MiBps,
+    },
+    PerformanceTest {
+        name: "block_qcow2_backing_qcow2_random_read_MiBps",
+        func_ptr: performance_block_io,
+        control: PerformanceTestControl {
+            num_queues: Some(1),
+            queue_size: Some(128),
+            block_control: Some(BlockControl {
+                fio_ops: FioOps::RandomRead,
+                bandwidth: true,
+                test_file: OVERLAY_WITH_QCOW2_BACKING,
+            }),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::Bps_to_MiBps,
     },
 ];
 


### PR DESCRIPTION
Add sequential and random read performance tests for QCOW2 overlays with QCOW2 backing files.

This is based on the new BlockControl structure that replaces fio_control tuple and includies the `test_file` parameter. This provides better extensibility and allows to reuse `performance_block_io` function for new tests. Kudos to @likebreath for the refactoring idea.
