### PR TITLE
Fix mis-sorting of command line options

### DIFF
--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -218,22 +218,16 @@ fn get_cli_options_sorted(
             )
             .default_value(default_vcpus)
             .group("vm-config"),
-        #[cfg(target_arch = "x86_64")]
-        Arg::new("debug-console")
-            .long("debug-console")
-            .help("Debug console: off|pty|tty|file=</path/to/a/file>,iobase=<port in hex>")
-            .default_value("off,iobase=0xe9")
-            .group("vm-config"),
-        #[cfg(feature = "dbus_api")]
-        Arg::new("dbus-service-name")
-            .long("dbus-service-name")
-            .help("Well known name of the device")
-            .num_args(1)
-            .group("vmm-config"),
         #[cfg(feature = "dbus_api")]
         Arg::new("dbus-object-path")
             .long("dbus-object-path")
             .help("Object path to serve the dbus interface")
+            .num_args(1)
+            .group("vmm-config"),
+        #[cfg(feature = "dbus_api")]
+        Arg::new("dbus-service-name")
+            .long("dbus-service-name")
+            .help("Well known name of the device")
             .num_args(1)
             .group("vmm-config"),
         #[cfg(feature = "dbus_api")]
@@ -243,6 +237,12 @@ fn get_cli_options_sorted(
             .help("Use the system bus instead of a session bus")
             .num_args(0)
             .group("vmm-config"),
+        #[cfg(target_arch = "x86_64")]
+        Arg::new("debug-console")
+            .long("debug-console")
+            .help("Debug console: off|pty|tty|file=</path/to/a/file>,iobase=<port in hex>")
+            .default_value("off,iobase=0xe9")
+            .group("vm-config"),
         Arg::new("device")
             .long("device")
             .help(DeviceConfig::SYNTAX)


### PR DESCRIPTION
This un-breaks the test suite with the dbus_api feature enabled.