### PR TITLE
vmm: acpi: Generate IORT table according to spec revision E.b

### DIFF
--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -582,7 +582,12 @@ fn create_iort_table(pci_segments: &[PciSegment]) -> Sdt {
         // 1 (bus) x 32 (devices) x 8 (functions) = 256
         // Note: Currently only 1 bus is supported in a segment.
         iort.write(mapping_offset + 4, (255_u32).to_le());
-        // The lowest value in the output range
+        // Output base maps to ITS device IDs which must match the
+        // device ID encoding used in KVM MSI routing setup, which
+        // shares the same limitation - only 1 bus per segment and
+        // up to 256 segments.
+        // See: https://github.com/cloud-hypervisor/cloud-hypervisor/commit/c9374d87ac453d49185aa7b734df089444166484
+        assert!(segment.id < 256, "Up to 256 PCI segments are supported.");
         iort.write(mapping_offset + 8, ((256 * segment.id) as u32).to_le());
         // id_mapping_array_output_reference should be
         // the ITS group node (the first node) if no SMMU


### PR DESCRIPTION
The current IORT table implementation is based on IORT Spec revision E.b
[1], as evidenced by:
* The PCI root complex node revision being set to `3`
* The code being updated in late 2021 [2] when revision E.b was the
  latest version

This patch ensures the IORT table is properly generated according to
this specification revision, fixing three issues:

1. The IORT table revision should be `3` rather than `2` (see Table 2 in
   the spec [1])

2. The GIC ITS group node revision should be `1` rather than `0`
   (see Table 12 in the spec [1])

3. The "Memory access properties" and "ATS Attribute" fields of the PCI
   root complex node  was set incorrectly - specifically the MAF (Memory
   Access Flags) including CPM and DACS bits (see Tables 14, 15, and 17
   in the spec [1])

[1] https://developer.arm.com/documentation/den0049/eb/?lang=en
[2] https://github.com/cloud-hypervisor/cloud-hypervisor/pull/3356