### PR TITLE
Optimize CPU state update after emulation

### DIFF
--- a/hypervisor/src/arch/x86/emulator/mod.rs
+++ b/hypervisor/src/arch/x86/emulator/mod.rs
@@ -711,7 +711,7 @@ mod mock_vmm {
             insn: &[u8],
             num_insn: Option<usize>,
         ) -> MockResult {
-            let mut state = self
+            let state = self
                 .cpu_state(cpu_id)
                 .map_err(EmulationError::PlatformEmulationError)?;
             let ip = state.ip();

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -733,7 +733,7 @@ impl cpu::Vcpu for MshvVcpu {
 
                     // Set CPU state back.
                     context
-                        .set_cpu_state(self.vp_index as usize, new_state)
+                        .update_cpu_state(self.vp_index as usize, old_state, new_state)
                         .map_err(|e| cpu::HypervisorCpuError::RunVcpu(e.into()))?;
 
                     Ok(cpu::VmExit::Ignore)


### PR DESCRIPTION
Instead of setting the CPU state after emulation (which unconditionally sets both standard and special registers), introduce and use a new function, which updates only the standard registers unconditionally (IP has changed anyway), while special registers are updated only if changed (which usually don't).

This approach saves a system call and a hypercall on every emulation: a small, but an optimization.