### PR TITLE
scripts: fix warning in test util

### DIFF
--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -212,7 +212,7 @@ mount_and_exec() {
     local COMMAND_STATUS=0
 
     # Cleanup function to unmount and detach loop device
-    # shellcheck disable=SC2317
+    # shellcheck disable=SC2317,SC2329
     cleanup() {
         if [ -n "$MOUNT_DIR" ]; then
             echo "Cleanup: Unmounting $MOUNT_DIR..." >&2


### PR DESCRIPTION
CI reports:
In scripts/test-util.sh line 216:
    cleanup() {
    ^-- SC2329 (info): This function is never invoked. Check usage (or ignored if invoked indirectly).

The shellcheck can't trace calling in trap, so we need add hint to make it happy.