### PR TITLE
docs: fix gdb path option name

### DIFF
--- a/docs/gdb.md
+++ b/docs/gdb.md
@@ -8,7 +8,7 @@ To enable debugging with GDB, build with the `guest_debug` feature enabled:
 cargo build --features guest_debug
 ```
 
-To use the `--gdb` option, specify the Unix Domain Socket with `--path` that Cloud Hypervisor will use to communicate with the host's GDB:
+To use the `--gdb` option, specify the Unix Domain Socket with `path` that Cloud Hypervisor will use to communicate with the host's GDB:
 
 ```bash
 ./cloud-hypervisor \


### PR DESCRIPTION
Fixes: fa22cb0be ("docs: update command line options to use clap")