### PR TITLE
build: bump mshv crates to 0.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,9 +1272,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mshv-bindings"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f415da68542aca92b33f55ac3e93031dc30a2941952b99679258f7e0527353"
+checksum = "7752a74e9b4f95f20c5eec69ee7cf25aee5da6d87d18574254b44f22940151fb"
 dependencies = [
  "libc",
  "num_enum",
@@ -1286,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52a2a02c4107e08f46ba9dfc4e0f4461dffd44fbeca3e5631b4a047d15376c9"
+checksum = "77e058608d09f2f8b106b06e6c58a09aa44915dd6a36cd4142d3a7d32e59c1fb"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ acpi_tables = { git = "https://github.com/rust-vmm/acpi_tables", branch = "main"
 kvm-bindings = "0.12.1"
 kvm-ioctls = "0.22.1"
 linux-loader = "0.13.1"
-mshv-bindings = "0.6.5"
-mshv-ioctls = "0.6.5"
+mshv-bindings = "0.6.6"
+mshv-ioctls = "0.6.6"
 seccompiler = "0.5.0"
 vfio-bindings = { version = "0.6.0", default-features = false }
 vfio-ioctls = { version = "0.5.1", default-features = false }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2.180"
 libfuzzer-sys = "0.4.10"
 linux-loader = { version = "0.13.1", features = ["bzimage", "elf", "pe"] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
-mshv-bindings = "0.6.5"
+mshv-bindings = "0.6.6"
 net_util = { path = "../net_util" }
 seccompiler = "0.5.0"
 virtio-devices = { path = "../virtio-devices" }


### PR DESCRIPTION
Consume the latest mshv crates.

Refer to https://github.com/rust-vmm/mshv/pull/294 for the changelog.