### PR TITLE
ci: get rid of continue-on-error from mshv workflows

### DIFF
--- a/.github/workflows/mshv-infra.yaml
+++ b/.github/workflows/mshv-infra.yaml
@@ -50,7 +50,6 @@ jobs:
   infra-setup:
     name: ${{ inputs.ARCH }} VM Provision
     runs-on: mshv
-    continue-on-error: true
     outputs:
       RG_NAME: ${{ steps.rg-setup.outputs.RG_NAME }}
       VM_NAME: ${{ steps.vm-setup.outputs.VM_NAME }}

--- a/.github/workflows/mshv-integration.yaml
+++ b/.github/workflows/mshv-integration.yaml
@@ -23,7 +23,6 @@ jobs:
     needs: infra-setup
     if: ${{ always() && needs.infra-setup.result == 'success' }}
     runs-on: mshv
-    continue-on-error: true
     steps:
       - name: Run integration tests
         timeout-minutes: 60


### PR DESCRIPTION
Since the mshv integration workflow has been stable for a long time, make the workflows no longer optional.