### PR TITLE
vmm: ch-remote: Rest API to dump VM config

### DIFF
--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -108,6 +108,10 @@ impl RequestHandler for StubApiRequestHandler {
         Ok(())
     }
 
+    fn vm_dump_config(&mut self, _: &str) -> Result<(), VmError> {
+        Ok(())
+    }
+
     fn vm_resize_disk(&mut self, _: String, _: u64) -> Result<(), VmError> {
         Ok(())
     }

--- a/vmm/src/api/dbus/mod.rs
+++ b/vmm/src/api/dbus/mod.rs
@@ -23,9 +23,9 @@ use super::{ApiAction, ApiRequest};
 use crate::api::VmCoredump;
 use crate::api::{
     AddDisk, Body, VmAddDevice, VmAddFs, VmAddNet, VmAddPmem, VmAddUserDevice, VmAddVdpa,
-    VmAddVsock, VmBoot, VmCounters, VmCreate, VmDelete, VmInfo, VmPause, VmPowerButton, VmReboot,
-    VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeZone, VmRestore, VmResume,
-    VmSendMigration, VmShutdown, VmSnapshot, VmmPing, VmmShutdown,
+    VmAddVsock, VmBoot, VmConfigDump, VmCounters, VmCreate, VmDelete, VmInfo, VmPause,
+    VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeZone, VmRestore,
+    VmResume, VmSendMigration, VmShutdown, VmSnapshot, VmmPing, VmmShutdown,
 };
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::{Error as VmmError, NetConfig, Result as VmmResult, VmConfig};
@@ -302,6 +302,12 @@ impl DBusApi {
             .map(|_| ())
     }
 
+    async fn vm_dump_config(&self, dump_vm_config: String) -> Result<()> {
+        let dump_vm_config = serde_json::from_str(&dump_vm_config).map_err(api_error)?;
+        self.vm_action(&VmConfigDump, dump_vm_config)
+            .await
+            .map(|_| ())
+    }
     // implementation of this function is provided by the `#[zbus(signal)]` macro call
     #[zbus(signal)]
     async fn event(

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -46,9 +46,9 @@ use crate::api::http::http_endpoint::fds_helper::{attach_fds_to_cfg, attach_fds_
 use crate::api::http::{EndpointHandler, HttpError, error_response};
 use crate::api::{
     AddDisk, ApiAction, ApiError, ApiRequest, NetConfig, VmAddDevice, VmAddFs, VmAddNet, VmAddPmem,
-    VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot, VmConfig, VmCounters, VmDelete, VmNmi, VmPause,
-    VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeDisk,
-    VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
+    VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot, VmConfig, VmConfigDump, VmCounters, VmDelete,
+    VmNmi, VmPause, VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize,
+    VmResizeDisk, VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
 use crate::config::RestoreConfig;
 use crate::cpu::Error as CpuError;
@@ -427,6 +427,7 @@ vm_action_put_handler_body!(VmRemoveDevice);
 vm_action_put_handler_body!(VmResizeDisk);
 vm_action_put_handler_body!(VmResizeZone);
 vm_action_put_handler_body!(VmSnapshot);
+vm_action_put_handler_body!(VmConfigDump);
 vm_action_put_handler_body!(VmReceiveMigration);
 vm_action_put_handler_body!(VmSendMigration);
 

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -29,9 +29,9 @@ use self::http_endpoint::{VmActionHandler, VmCreate, VmInfo, VmmPing, VmmShutdow
 use crate::api::VmCoredump;
 use crate::api::{
     AddDisk, ApiError, ApiRequest, VmAddDevice, VmAddFs, VmAddNet, VmAddPmem, VmAddUserDevice,
-    VmAddVdpa, VmAddVsock, VmBoot, VmCounters, VmDelete, VmNmi, VmPause, VmPowerButton, VmReboot,
-    VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeDisk, VmResizeZone, VmRestore, VmResume,
-    VmSendMigration, VmShutdown, VmSnapshot,
+    VmAddVdpa, VmAddVsock, VmBoot, VmConfigDump, VmCounters, VmDelete, VmNmi, VmPause,
+    VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeDisk,
+    VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
 use crate::landlock::Landlock;
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
@@ -278,6 +278,10 @@ pub static HTTP_ROUTES: LazyLock<HttpRoutes> = LazyLock::new(|| {
     r.routes.insert(
         endpoint!("/vm.snapshot"),
         Box::new(VmActionHandler::new(&VmSnapshot)),
+    );
+    r.routes.insert(
+        endpoint!("/vm.dump-vm-config"),
+        Box::new(VmActionHandler::new(&VmConfigDump)),
     );
     #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
     r.routes.insert(

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1729,6 +1729,14 @@ impl RequestHandler for Vmm {
         }
     }
 
+    fn vm_dump_config(&mut self, destination_url: &str) -> result::Result<(), VmError> {
+        if let Some(ref mut vm) = self.vm {
+            vm.vm_dump_config(destination_url)
+        } else {
+            Err(VmError::VmNotRunning)
+        }
+    }
+
     fn vm_restore(&mut self, restore_cfg: RestoreConfig) -> result::Result<(), VmError> {
         if self.vm.is_some() || self.vm_config.is_some() {
             return Err(VmError::VmAlreadyCreated);


### PR DESCRIPTION
For live upgrade from version n to n+1, customer might want to tweak the VM config for their workload needs. This patch adds a Rest API to dump the source VM config as a JSON file. User can modify the config and provide the modified config file during live upgrade.

Related issue:
https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7592