### PR TITLE
vmm: api/migration: support virtio-net backed by external FDs

### DIFF
--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -904,6 +904,9 @@ fn coredump_config(destination_url: &str) -> String {
 fn receive_migration_data(url: &str) -> String {
     let receive_migration_data = vmm::api::VmReceiveMigrationData {
         receiver_url: url.to_owned(),
+        // Only FDs transmitted via an SCM_RIGHTS UNIX Domain Socket message
+        // are valid. Would be omitted by Cloud Hypervisor anyway.
+        net_fds: vec![],
     };
 
     serde_json::to_string(&receive_migration_data).unwrap()

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -10945,6 +10945,10 @@ mod vfio {
 }
 
 mod live_migration {
+    use core::fmt::Write;
+
+    use vmm::config::RestoredNetConfig;
+
     use crate::*;
 
     pub fn start_live_migration(
@@ -12117,10 +12121,29 @@ mod live_migration {
             .port()
     }
 
-    fn start_live_migration_tcp(src_api_socket: &str, dest_api_socket: &str) -> bool {
+    fn start_live_migration_tcp(
+        src_api_socket: &str,
+        dest_api_socket: &str,
+        new_net_fds: &[RestoredNetConfig],
+    ) -> bool {
         // Get an available TCP port
         let migration_port = get_available_port();
         let host_ip = "127.0.0.1";
+
+        let mut receive_migration_config_str = String::new();
+        if !new_net_fds.is_empty() {
+            receive_migration_config_str.push_str("[");
+            for cfg in new_net_fds {
+                write!(&mut receive_migration_config_str, "{}", cfg.id).unwrap();
+                receive_migration_config_str.push_str("@");
+                receive_migration_config_str.push_str("[");
+                for fd in cfg.fds.iter().flatten() {
+                    write!(&mut receive_migration_config_str, "{fd},").unwrap();
+                }
+                receive_migration_config_str.push_str("]");
+            }
+            receive_migration_config_str.push_str("]");
+        }
 
         // Start the 'receive-migration' command on the destination
         let mut receive_migration = Command::new(clh_command("ch-remote"))
@@ -12128,6 +12151,7 @@ mod live_migration {
                 &format!("--api-socket={dest_api_socket}"),
                 "receive-migration",
                 &format!("tcp:0.0.0.0:{migration_port}"),
+                &format!("--config {receive_migration_config_str}"),
             ])
             .stdin(Stdio::null())
             .stderr(Stdio::piped())
@@ -12276,7 +12300,180 @@ mod live_migration {
             }
             // Start TCP live migration
             assert!(
-                start_live_migration_tcp(&src_api_socket, &dest_api_socket),
+                start_live_migration_tcp(&src_api_socket, &dest_api_socket, &[]),
+                "Unsuccessful command: 'send-migration' or 'receive-migration'."
+            );
+        });
+
+        // Check and report any errors that occurred during live migration
+        if r.is_err() {
+            print_and_panic(
+                src_child,
+                dest_child,
+                None,
+                "Error occurred during live-migration",
+            );
+        }
+
+        // Check the source vm has been terminated successful (give it '3s' to settle)
+        thread::sleep(std::time::Duration::new(3, 0));
+        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
+            print_and_panic(
+                src_child,
+                dest_child,
+                None,
+                "Source VM was not terminated successfully.",
+            );
+        }
+
+        // After live migration, ensure the destination VM is running normally
+        let r = std::panic::catch_unwind(|| {
+            // Perform the same checks to ensure the VM has migrated correctly
+            assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
+            assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+            guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
+        });
+
+        // Clean up the destination VM and ensure it terminates properly
+        let _ = dest_child.kill();
+        let dest_output = dest_child.wait_with_output().unwrap();
+        handle_child_output(r, &dest_output);
+
+        // Check if the expected `console_text` is present in the destination VM's output
+        let r = std::panic::catch_unwind(|| {
+            assert!(String::from_utf8_lossy(&dest_output.stdout).contains(&console_text));
+        });
+        handle_child_output(r, &dest_output);
+    }
+
+    /// Tests live-migration via TCP and with virtio-net devices backed by external FDs.
+    fn _test_live_migration_tcp_and_external_fds() {
+        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+        let net_id = "net123";
+        let num_queue_pairs: usize = 2;
+        // use a name that does not conflict with tap dev created from other tests
+        let tap_name = "chtap42";
+        use std::str::FromStr;
+        let taps = net_util::open_tap(
+            Some(tap_name),
+            Some(std::net::IpAddr::V4(
+                std::net::Ipv4Addr::from_str(&guest.network.host_ip0).unwrap(),
+            )),
+            None,
+            &mut None,
+            None,
+            num_queue_pairs,
+            Some(libc::O_RDWR | libc::O_NONBLOCK),
+        )
+        .unwrap();
+
+        let kernel_path = direct_kernel_boot_path();
+        let console_text = String::from("On a branch floating down river a cricket, singing.");
+        let net_params = format!(
+            "id={},fd=[{},{}],mac={},ip={},mask=255.255.255.128,num_queues={}",
+            net_id,
+            taps[0].as_raw_fd(),
+            taps[1].as_raw_fd(),
+            guest.network.guest_mac0,
+            guest.network.host_ip0,
+            num_queue_pairs * 2,
+        );
+        let memory_param: &[&str] = &["--memory", "size=4G,shared=on"];
+        let boot_vcpus = 2;
+        let max_vcpus = 4;
+        let pmem_temp_file = TempFile::new().unwrap();
+        pmem_temp_file.as_file().set_len(128 << 20).unwrap();
+        std::process::Command::new("mkfs.ext4")
+            .arg(pmem_temp_file.as_path())
+            .output()
+            .expect("Expect creating disk image to succeed");
+        let pmem_path = String::from("/dev/pmem0");
+
+        // Start the source VM
+        let src_vm_path = clh_command("cloud-hypervisor");
+        let src_api_socket = temp_api_path(&guest.tmp_dir);
+        let mut src_vm_cmd = GuestCommand::new_with_binary_path(&guest, &src_vm_path);
+        src_vm_cmd
+            .args([
+                "--cpus",
+                format!("boot={boot_vcpus},max={max_vcpus}").as_str(),
+            ])
+            .args(memory_param)
+            .args(["--kernel", kernel_path.to_str().unwrap()])
+            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_disks()
+            .args(["--net", net_params.as_str()])
+            .args(["--api-socket", &src_api_socket])
+            .args([
+                "--pmem",
+                format!(
+                    "file={},discard_writes=on",
+                    pmem_temp_file.as_path().to_str().unwrap(),
+                )
+                .as_str(),
+            ])
+            .capture_output();
+        let mut src_child = src_vm_cmd.spawn().unwrap();
+
+        // Start the destination VM
+        let mut dest_api_socket = temp_api_path(&guest.tmp_dir);
+        dest_api_socket.push_str(".dest");
+        let mut dest_child = GuestCommand::new(&guest)
+            .args(["--api-socket", &dest_api_socket])
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let new_taps = net_util::open_tap(
+            Some(tap_name),
+            Some(std::net::IpAddr::V4(
+                std::net::Ipv4Addr::from_str(&guest.network.host_ip0).unwrap(),
+            )),
+            None,
+            &mut None,
+            None,
+            num_queue_pairs,
+            Some(libc::O_RDWR | libc::O_NONBLOCK),
+        )
+        .unwrap();
+
+        let r = std::panic::catch_unwind(|| {
+            guest.wait_vm_boot().unwrap();
+            // Ensure the source VM is running normally
+            assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
+            assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+            guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
+
+            // On x86_64 architecture, remove and re-add the virtio-net device
+            // to increase test coverage
+            #[cfg(target_arch = "x86_64")]
+            {
+                assert!(remote_command(
+                    &src_api_socket,
+                    "remove-device",
+                    Some(net_id),
+                ));
+                thread::sleep(Duration::new(10, 0));
+                // Re-add the virtio-net device
+                assert!(remote_command(
+                    &src_api_socket,
+                    "add-net",
+                    Some(net_params.as_str()),
+                ));
+                thread::sleep(Duration::new(10, 0));
+            }
+            // Start TCP live migration
+            assert!(
+                start_live_migration_tcp(
+                    &src_api_socket,
+                    &dest_api_socket,
+                    &[RestoredNetConfig {
+                        id: net_id.to_string(),
+                        num_fds: 2,
+                        fds: Some(vec![new_taps[0].as_raw_fd(), new_taps[1].as_raw_fd(),])
+                    }]
+                ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );
         });
@@ -12337,6 +12534,11 @@ mod live_migration {
         #[test]
         fn test_live_migration_tcp() {
             _test_live_migration_tcp();
+        }
+
+        #[test]
+        fn test_live_migration_tcp_and_external_fds() {
+            _test_live_migration_tcp_and_external_fds();
         }
 
         #[test]

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -47,8 +47,8 @@ use crate::api::http::{EndpointHandler, HttpError, error_response};
 use crate::api::{
     AddDisk, ApiAction, ApiError, ApiRequest, NetConfig, VmAddDevice, VmAddFs, VmAddNet, VmAddPmem,
     VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot, VmConfig, VmCounters, VmDelete, VmNmi, VmPause,
-    VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeDisk,
-    VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
+    VmPowerButton, VmReboot, VmReceiveMigration, VmReceiveMigrationData, VmRemoveDevice, VmResize,
+    VmResizeDisk, VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
 use crate::config::RestoreConfig;
 use crate::cpu::Error as CpuError;
@@ -427,7 +427,6 @@ vm_action_put_handler_body!(VmRemoveDevice);
 vm_action_put_handler_body!(VmResizeDisk);
 vm_action_put_handler_body!(VmResizeZone);
 vm_action_put_handler_body!(VmSnapshot);
-vm_action_put_handler_body!(VmReceiveMigration);
 vm_action_put_handler_body!(VmSendMigration);
 
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
@@ -456,6 +455,34 @@ impl PutHandler for VmAddNet {
 }
 
 impl GetHandler for VmAddNet {}
+
+// Special handling for externally provided FDs.
+// See module description for more info.
+impl PutHandler for VmReceiveMigration {
+    fn handle_request(
+        &'static self,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+        body: &Option<Body>,
+        files: Vec<File>,
+    ) -> std::result::Result<Option<Body>, HttpError> {
+        if let Some(body) = body {
+            let mut net_cfg: VmReceiveMigrationData = serde_json::from_slice(body.raw())?;
+            if !net_cfg.net_fds.is_empty() {
+                let mut cfgs = net_cfg.net_fds.iter_mut().collect::<Vec<&mut _>>();
+                let cfgs = cfgs.as_mut_slice();
+                attach_fds_to_cfgs(files, cfgs)?;
+            }
+
+            self.send(api_notifier, api_sender, net_cfg)
+                .map_err(HttpError::ApiError)
+        } else {
+            Err(HttpError::BadRequest)
+        }
+    }
+}
+
+impl GetHandler for VmReceiveMigration {}
 
 impl PutHandler for VmResize {
     fn handle_request(

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -47,7 +47,7 @@ use vmm_sys_util::eventfd::EventFd;
 pub use self::dbus::start_dbus_thread;
 pub use self::http::{start_http_fd_thread, start_http_path_thread};
 use crate::Error as VmmError;
-use crate::config::RestoreConfig;
+use crate::config::{RestoreConfig, RestoredNetConfig};
 use crate::device_tree::DeviceTree;
 use crate::vm::{Error as VmError, VmState};
 use crate::vm_config::{
@@ -260,6 +260,8 @@ pub struct VmCoredumpData {
 pub struct VmReceiveMigrationData {
     /// URL for the reception of migration state
     pub receiver_url: String,
+    /// Map with new network FDs on the new host.
+    pub net_fds: Vec<RestoredNetConfig>,
 }
 
 #[derive(Clone, Deserialize, Serialize, Default, Debug)]

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1267,6 +1267,8 @@ components:
           type: string
         prefault:
           type: boolean
+        net_fds:
+          $ref: '#/components/schemas/RestoredNetConfig'
 
     ReceiveMigrationData:
       required:
@@ -1275,6 +1277,8 @@ components:
       properties:
         receiver_url:
           type: string
+        net_fds:
+          $ref: '#/components/schemas/RestoredNetConfig'
 
     SendMigrationData:
       required:
@@ -1304,3 +1308,21 @@ components:
           type: string
         access:
           type: string
+
+    RestoredNetConfig:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        num_fds:
+          type: integer
+          format: int64
+        fds:
+          type: array
+          nullable: true
+          default: null
+          items:
+            type: integer
+            format: int32


### PR DESCRIPTION
vmm: api/migration: support virtio-net backed by external FDs

Devices (e.g., virtio-net) from external FDs are a popular choice by
management software, as for example libvirt can open and configure tap
devices and pass them to Cloud Hypervisor. Cloud Hypervisor can
therefore remain unpriviledged as it doesn't need to create or configure
tap devices.

So far, we do not have support for these devices in context of live
migration. For first-class live-migration support, this commit series
is introducing the necessary changes to Cloud Hypervisor and ch-remote.

FDs in the VM config are just numbers. We need external knowledge about
"FD number <--> semantic" mappings. Management software, such as
libvirt, has this knowledge.

On the receiving side, the management software must open the appropriate
number of FDs for the given tap devices and pass them to Cloud
Hypervisor via a UNIX domain socket via an SCM_RIGHTS message.

The HTTP REST-API JSON-Payload only holds the number of FDs and
cloud-hypervisor will then associate all FDs with the correct device.
This must happen before the VM continues running after the migration.

This change marks the initial adoption of the `ReceiveMigrationData`
structure as the canonical vehicle for configuration updates during
migration, establishing a clear and more extensible API contract going
forward.

These changes are only the bare minimum to ensure first-class live
migration support. They only cover host/VMM config updates but nothing
guest visible.

While the external FD handling in Cloud Hypervisor requires a broader
refactor, this change neither blocks nor constrains that effort.
Instead, it serves as a focused follow-up to [0], ensuring that
live migration remains a first-class concern as the external FD
infrastructure evolves.

[0] https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7281
[1] https://github.com/cyberus-technology/libvirt/commits/gardenlinux/

On-behalf-of: SAP philipp.schuster@sap.com
Signed-off-by: Philipp Schuster <philipp.schuster@cyberus-technology.de>
## Steps to Merge

- [x] Basic functionality
- [x] First Review Round
- [x] ch-remote support
- [x] Cyberus internal test suite
- [ ] Cloud Hypervisor integration test
  - [x] Basic infrastructure
  - [ ] Actually make it work

## Testing

I've ran this through our [libvirt testing](https://github.com/cyberus-technology/libvirt-tests/blob/2ff795dc72bf004758c0324fab9b2287682d71ed/tests/testscript.py#L581) pipeline and it worked.