### PR TITLE
virtio-devices: vhost-user: Fix IO safety violation on shutdown

### DIFF
--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -375,11 +375,6 @@ impl VhostUserCommon {
     }
 
     pub fn shutdown(&mut self) {
-        if let Some(vu) = &self.vu {
-            // SAFETY: trivially safe
-            let _ = unsafe { libc::close(vu.lock().unwrap().socket_handle().as_raw_fd()) };
-        }
-
         // Remove socket path if needed
         if self.server {
             let _ = std::fs::remove_file(&self.socket_path);


### PR DESCRIPTION
File descriptor double close happens in the debug build when running a virtual machine with a vhost block or fs device.

Remove the manual libc::close() call on the vhost-user socket handle in shutdown(). The file descriptor will be properly closed when it is dropped. Manually closing it causes a double-close, triggering "fatal runtime error: IO Safety violation: owned file descriptor already closed" when the owned handle is later dropped or replaced.