### PR TITLE
vmm: Make VM information output human-readable

### DIFF
--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -563,7 +563,7 @@ impl EndpointHandler for VmInfo {
             {
                 Ok(info) => {
                     let mut response = Response::new(Version::Http11, StatusCode::OK);
-                    let info_serialized = serde_json::to_string(&info).unwrap();
+                    let info_serialized = serde_json::to_string_pretty(&info).unwrap();
 
                     response.set_body(Body::new(info_serialized));
                     response


### PR DESCRIPTION
The current VM information output is presented ina congested text format. This patch improves the formatting to make the output clearer and easier to read.

Prevous format:
```
{"config":{"cpus":{"boot_vcpus":4,"max_vcpus":4,"topology":null,"kvm_hyperv":false,"max_phys_bits":46,"affinity":null,"features":{"amx":false},"nested":true},"memory":"size":1073741824,"mergeable":false,"hotplug_method":"Acpi","hotplug_size":null,"hotplugged_size":null,"shared":true,"hugepages":false,"hugepage_size":null,"prefault":false,"zones":null,"thp":true},"payload":{"firmware":null,"kernel":"./linux-cloud-hypervisor/arch/x86/boot/bzImage","cmdline":"root=/dev/vda1 console=ttyS0","initramfs":null,"igvm":null,"host_data":null},"rate_limit_groups":null,"disks":[{"path":"focal-server-cloudimg-amd64-ch.raw","readonly":false,"direct":false,"iommu":false,"num_queues":1,"queue_size":128,"vhost_user":false,"vhost_socket":null,"rate_limit_group":null,"rate_limiter_config":null,"id":"_disk0","disable_io_uring":false,"disable_aio":false,"pci_segment":0,"serial":null,"queue_affinity":null}],"net":null,"rng":{"src":"/dev/urandom","iommu":false},"balloon":null,"fs":null,"pmem":null,"serial":{"file":null,"mode":"Tty","iommu":false,"socket":null},"console":{"file":null,"mode":"Off","iommu":false,"socket":null},"debug_console":{"file":null,"mode":"Off","iobase":233},"devices":null,"user_devices":null,"vdpa":null,"vsock":null,"pvpanic":false,"iommu":false,"numa":null,"watchdog":false,"pci_segments":null,"platform":null,"tpm":null,"landlock_enable":false,"landlock_rules":null},"state":"Running","memory_actual_size":1073741824,"device_tree":{"_virtio-pci-_disk0":{"id":"_virtio-pci-_disk0","resources":[{"PciBar":{"index":0,"base":3891789824,"size":524288,"type_":"Mmio32","prefetchable":false}}],"parent":null,"children":["_disk0"],"pci_bdf":"0000:00:01.0"},"_virtio-pci-__rng":{"id":"_virtio-pci-__rng","resources":[{"PciBar":{"index":0,"base":545460322304,"size":524288,"type_":"Mmio64","prefetchable":false}}],"parent":null,"children":["__rng"],"pci_bdf":"0000:00:02.0"},"__rng":{"id":"__rng","resources":[],"parent":"_virtio-pci-__rng","children":[],"pci_bdf":null},"_disk0":{"id":"_disk0","resources":[],"parent":"_virtio-pci-_disk0","children":[],"pci_bdf":null},"__ioapic":{"id":"__ioapic","resources":[],"parent":null,"children":[],"pci_bdf":null},"__serial":{"id":"__serial","resources":[],"parent":null,"children":[],"pci_bdf":null}}}
```
Updated format:
```
{
  "config": {
    "cpus": {
      "boot_vcpus": 4,
      "max_vcpus": 4,
      "topology": null,
      "kvm_hyperv": false,
      "max_phys_bits": 46,
      "affinity": null,
      "features": {
        "amx": false
      },
      "nested": true
    },
    "memory": {
      "size": 1073741824,
      "mergeable": false,
      "hotplug_method": "Acpi",
      "hotplug_size": null,
      "hotplugged_size": null,
      "shared": true,
      "hugepages": false,
      "hugepage_size": null,
      "prefault": false,
      "zones": null,
      "thp": true
    },
    "payload": {
      "firmware": null,
      "kernel": "./linux-cloud-hypervisor/arch/x86/boot/bzImage",
      "cmdline": "root=/dev/vda1 console=ttyS0",
      "initramfs": null,
      "igvm": null,
      "host_data": null
    },
    "rate_limit_groups": null,
    "disks": [
      {
        "path": "focal-server-cloudimg-amd64-ch.raw",
        "readonly": false,
        "direct": false,
        "iommu": false,
        "num_queues": 1,
        "queue_size": 128,
        "vhost_user": false,
        "vhost_socket": null,
        "rate_limit_group": null,
        "rate_limiter_config": null,
        "id": "_disk0",
        "disable_io_uring": false,
        "disable_aio": false,
        "pci_segment": 0,
        "serial": null,
        "queue_affinity": null
      }
    ],
    "net": null,
    "rng": {
      "src": "/dev/urandom",
      "iommu": false
    },
    "balloon": null,
    "fs": null,
    "pmem": null,
    "serial": {
      "file": null,
      "mode": "Tty",
      "iommu": false,
      "socket": null
    },
    "console": {
      "file": null,
      "mode": "Off",
      "iommu": false,
      "socket": null
    },
    "debug_console": {
      "file": null,
      "mode": "Off",
      "iobase": 233
    },
    "devices": null,
    "user_devices": null,
    "vdpa": null,
    "vsock": null,
    "pvpanic": false,
    "iommu": false,
    "numa": null,
    "watchdog": false,
    "pci_segments": null,
    "platform": null,
    "tpm": null,
    "landlock_enable": false,
    "landlock_rules": null
  },
  "state": "Running",
  "memory_actual_size": 1073741824,
  "device_tree": {
    "__serial": {
      "id": "__serial",
      "resources": [],
      "parent": null,
      "children": [],
      "pci_bdf": null
    },
    "_virtio-pci-__rng": {
      "id": "_virtio-pci-__rng",
      "resources": [
        {
          "PciBar": {
            "index": 0,
            "base": 545460322304,
            "size": 524288,
            "type_": "Mmio64",
            "prefetchable": false
          }
        }
      ],
      "parent": null,
      "children": [
        "__rng"
      ],
      "pci_bdf": "0000:00:02.0"
    },
    "__rng": {
      "id": "__rng",
      "resources": [],
      "parent": "_virtio-pci-__rng",
      "children": [],
      "pci_bdf": null
    },
    "_virtio-pci-_disk0": {
      "id": "_virtio-pci-_disk0",
      "resources": [
        {
          "PciBar": {
            "index": 0,
            "base": 3891789824,
            "size": 524288,
            "type_": "Mmio32",
            "prefetchable": false
          }
        }
      ],
      "parent": null,
      "children": [
        "_disk0"
      ],
      "pci_bdf": "0000:00:01.0"
    },
    "__ioapic": {
      "id": "__ioapic",
      "resources": [],
      "parent": null,
      "children": [],
      "pci_bdf": null
    },
    "_disk0": {
      "id": "_disk0",
      "resources": [],
      "parent": "_virtio-pci-_disk0",
      "children": [],
      "pci_bdf": null
    }
  }
}
```
