### PR TITLE
vmm: fix rsdp_addr assertion for TDX

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2516,7 +2516,7 @@ impl Vm {
 
         #[cfg(not(target_arch = "riscv64"))]
         {
-            #[cfg(not(feature = "sev_snp"))]
+            #[cfg(not(any(feature = "sev_snp", feature = "tdx")))]
             assert!(rsdp_addr.is_some());
             // Configure shared state based on loaded kernel
             if let Some(rsdp_adr) = rsdp_addr {


### PR DESCRIPTION
TDX builds its own ACPI tables in `create_acpi_tables_tdx` so it will return None in the standard `create_acpi_tables` function and the assertion for `rsdp_addr` will fail.