### PR TITLE
api_client: Add license info to api_client crate

### DIFF
--- a/api_client/Cargo.toml
+++ b/api_client/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Cloud Hypervisor Authors"]
 edition.workspace = true
+license = "Apache-2.0"
 name = "api_client"
 version = "0.1.0"
 


### PR DESCRIPTION
Hi team, in kata-containers we use the `api_client` crate, but it's currently failing our cargo deny check due to missing license, and there aren't any license files within the crate, so I haven't found a good way to work around this.

Alternatively I'd be happy to add the license to the workspace crate and then reference it here, but that seems to clash with the direction of the project in #7525.

For reference, here is the cargo deny output:
```

warning[no-license-field]: license expression was not specified in manifest for crate 'api_client = 0.1.0'
 ├ api_client v0.1.0
   └── ch-config v0.1.0
       └── hypervisor v0.1.0
           ├── (dev) hypervisor v0.1.0 (*)
           ├── resource v0.1.0
           │   ├── common v0.1.0
           │   │   ├── linux_container v0.1.0
           │   │   │   └── runtimes v0.1.0
           │   │   │       ├── runtime-rs v0.1.0
           │   │   │       ├── service v0.1.0
           │   │   │       │   └── shim v0.1.0
           │   │   │       │       └── runtime-rs v0.1.0 (*)
           │   │   │       ├── shim v0.1.0 (*)
           │   │   │       └── shim-ctl v0.1.0
           │   │   ├── runtime-rs v0.1.0 (*)
           │   │   ├── runtimes v0.1.0 (*)
           │   │   ├── service v0.1.0 (*)
           │   │   ├── shim-ctl v0.1.0 (*)
           │   │   ├── virt_container v0.1.0
           │   │   │   └── runtimes v0.1.0 (*)
           │   │   └── wasm_container v0.1.0
           │   │       └── runtimes v0.1.0 (*)
           │   ├── linux_container v0.1.0 (*)
           │   ├── runtimes v0.1.0 (*)
           │   ├── virt_container v0.1.0 (*)
           │   └── wasm_container v0.1.0 (*)
           ├── runtimes v0.1.0 (*)
           └── virt_container v0.1.0 (*)

warning[unlicensed]: a valid license expression could not be retrieved for the crate
  ┌─ git+https://github.com/cloud-hypervisor/cloud-hypervisor?tag=v27.0#api_client@0.1.0-synthesized.toml:2:9
  │
2 │ name = "api_client"
  │         ━━━━━━━━━━
  │
  ├ api_client v0.1.0 (*)

error[unlicensed]: api_client = 0.1.0 is unlicensed
 ├ api_client v0.1.0 (*)
```