### PR TITLE
misc: fix spellcheck CI step (caused by typos v1.43)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -21,5 +21,8 @@ liness = "liness"
 outout = "outout"
 
 [default.extend-identifiers]
+consts = "consts"
 fo = "fo"
 fpr = "fpr"
+# Public Linux API
+msg_controllen = "msg_controllen"


### PR DESCRIPTION
Unfortunately, was merged #7654 although the CI was failing. I fixed this here. I suggest marking this CI step as required @rbradford @likebreath .


Ping @scholzp for #7631 