### PR TITLE
ci: reduce CI load by refining workflow concurrency groups

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor Build
 on: [pull_request, merge_group]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths: resources/Dockerfile
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor Code Formatting
 on: [pull_request, merge_group]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/fuzz-build.yaml
+++ b/.github/workflows/fuzz-build.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor Cargo Fuzz Build
 on: [pull_request, merge_group]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/integration-arm64.yaml
+++ b/.github/workflows/integration-arm64.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor Tests (ARM64)
 on: [pull_request, merge_group]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/integration-rate-limiter.yaml
+++ b/.github/workflows/integration-rate-limiter.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor Tests (Rate-Limiter)
 on: [merge_group, pull_request]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/integration-vfio.yaml
+++ b/.github/workflows/integration-vfio.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor Tests (VFIO)
 on: [merge_group, pull_request]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/integration-windows.yaml
+++ b/.github/workflows/integration-windows.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor Tests (Windows Guest)
 on: [merge_group, pull_request]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/integration-x86-64.yaml
+++ b/.github/workflows/integration-x86-64.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor Tests (x86-64)
 on: [pull_request, merge_group]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/mshv-infra.yaml
+++ b/.github/workflows/mshv-infra.yaml
@@ -1,5 +1,5 @@
 name: MSHV Infra Setup
-on: 
+on:
   workflow_call:
     inputs:
       ARCH:
@@ -44,7 +44,7 @@ on:
         description: 'Private IP of the VM'
         value: ${{ jobs.infra-setup.outputs.PRIVATE_IP }}
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 jobs:
   infra-setup:

--- a/.github/workflows/package-consistency.yaml
+++ b/.github/workflows/package-consistency.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor Consistency
 on: [pull_request, merge_group]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/preview-riscv64-build.yaml
+++ b/.github/workflows/preview-riscv64-build.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor RISC-V 64-bit kvm build Preview
 on: [pull_request, merge_group]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/preview-riscv64-modules.yaml
+++ b/.github/workflows/preview-riscv64-modules.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor RISC-V 64-bit Preview
 on: [pull_request, merge_group]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor Quality Checks
 on: [pull_request, merge_group]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Cloud Hypervisor Release
 on: [create, merge_group]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 env:
   GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
TL;DR: Would reduce CI pressure by cancelling more "unnecessary" runs 
       but I can't verify without running a merge queue.

A common development pattern is to push a change and then immediately check CI results. Follow-up fix pushes are quite common, which leads to multiple CI runs being queued for the same pull request.

In Cloud Hypervisor, the size and cost of the CI matrix means that several consecutive pushes (for example 3-4 in a short time) put significant pressure on CI runners and noticeably increase feedback latency.

In practice, concurrency handling is especially tricky for the merge queue. From personal experience: If one does not take special care, CI runs triggered by a `merge_group` can cancel each other, as in a merge queue there are two runs for each job by default: one for the normal PR and one for the merge commit. This is easy to run into, also because the available documentation and best practices for this feature are not very good.

At the same time, our workflows do not run on `push` events, but only on `pull_request` and `merge_group`. Because of this, using `${{ github.ref }}` alone as a concurrency key is not very meaningful, and in practice only few runs are actually cancelled for successive PR updates. Therefore, we should improve the usage of this feature.

This change tries to improve the situation by refining the concurrency group key. The goal is to keep cancellation for multiple PR pushes, while at the same time preventing unintended cancellations in the merge queue by separating `merge_group` runs from regular PR runs.

