### PR TITLE
scripts: Upgrade virtiofsd to 1.13.3

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -13,7 +13,7 @@ build_virtiofsd() {
     VIRTIOFSD_DIR="$WORKLOADS_DIR/virtiofsd_build"
     VIRTIOFSD_REPO="https://gitlab.com/virtio-fs/virtiofsd.git"
 
-    checkout_repo "$VIRTIOFSD_DIR" "$VIRTIOFSD_REPO" v1.8.0 "97ea7908fe7f9bc59916671a771bdcfaf4044b45"
+    checkout_repo "$VIRTIOFSD_DIR" "$VIRTIOFSD_REPO" v1.13.3 "bbf82173682a3e48083771a0a23331e5c23b4924"
 
     if [ ! -f "$VIRTIOFSD_DIR/.built" ]; then
         pushd "$VIRTIOFSD_DIR" || exit

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -156,7 +156,7 @@ if [ ! -f "$VIRTIOFSD" ]; then
     pushd "$WORKLOADS_DIR" || exit
     git clone "https://gitlab.com/virtio-fs/virtiofsd.git" $VIRTIOFSD_DIR
     pushd $VIRTIOFSD_DIR || exit
-    git checkout v1.8.0
+    git checkout v1.13.3
     time cargo build --release
     cp target/release/virtiofsd "$VIRTIOFSD" || exit 1
     popd || exit


### PR DESCRIPTION
Testing generic vhost-user devices will require virtiofsd to support the --tag option, which v1.8.0 does not support.