### PR TITLE
virtio-devices: Do not close an unowned FD

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -12440,6 +12440,7 @@ mod live_migration {
         }
 
         #[test]
+        #[ignore = "See #5532 and #7689"]
         #[cfg(target_arch = "x86_64")]
         #[cfg(not(feature = "mshv"))]
         fn test_live_migration_ovs_dpdk_local() {

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -375,15 +375,13 @@ impl VhostUserCommon {
     }
 
     pub fn shutdown(&mut self) {
-        if let Some(vu) = &self.vu {
-            // SAFETY: trivially safe
-            let _ = unsafe { libc::close(vu.lock().unwrap().socket_handle().as_raw_fd()) };
-        }
-
         // Remove socket path if needed
         if self.server {
             let _ = std::fs::remove_file(&self.socket_path);
         }
+
+        // Drop the vhost-user handle
+        self.vu = None;
     }
 
     pub fn add_memory_region(


### PR DESCRIPTION
Instead of closing a file descriptor that belongs to the vhost-user frontend, drop the vu_common_ctrl::VhostUserHandle and the vhost::vhost_user::Frontend it contains.  This causes the destructor to drop the file descriptor.