### PR TITLE
Add an unreachable arm to get/set_x86_64_reg

### DIFF
--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -225,6 +225,8 @@ macro_rules! set_x86_64_reg {
                         StandardRegisters::Kvm(s) => s.$reg_name = val,
                         #[cfg(any(feature = "mshv", feature = "mshv_emulator"))]
                         StandardRegisters::Mshv(s) => s.$reg_name = val,
+                        #[allow(unreachable_patterns)]
+                        _ => { let _ = val; unreachable!("no x86_64 register backend available") },
                     }
                 }
             }
@@ -243,6 +245,8 @@ macro_rules! get_x86_64_reg {
                         StandardRegisters::Kvm(s) => s.$reg_name,
                         #[cfg(any(feature = "mshv", feature = "mshv_emulator"))]
                         StandardRegisters::Mshv(s) => s.$reg_name,
+                        #[allow(unreachable_patterns)]
+                        _ => unreachable!("no x86_64 register backend available"),
                     }
                 }
             }


### PR DESCRIPTION
This is useful when neither kvm nor mshv is defined.

This fixies `cargo test -p arch`, and by extension, any crate's tests which (transitively) depend on the `arch` crate.