### PR TITLE
hypervisor: mshv: stub implementation for save_data_tables()

### DIFF
--- a/hypervisor/src/mshv/aarch64/gic/mod.rs
+++ b/hypervisor/src/mshv/aarch64/gic/mod.rs
@@ -121,6 +121,6 @@ impl Vgic for MshvGicV2M {
     }
 
     fn save_data_tables(&self) -> Result<()> {
-        unimplemented!()
+        Ok(())
     }
 }


### PR DESCRIPTION
Provide a stub implementation for save_data_tables() to unblock pause functionality. Without this, pausing a VM causes Cloud Hypervisor to panic due to the unimplemented!() macro. This unblocks the test_api_http_pause_resume testcase. We don't need to save any state just to pause and resume.