### PR TITLE
vmm: remove lock for VmState

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1875,7 +1875,7 @@ impl RequestHandler for Vmm {
         match &self.vm_config {
             Some(vm_config) => {
                 let state = match &self.vm {
-                    Some(vm) => vm.get_state()?,
+                    Some(vm) => vm.get_state(),
                     None => VmState::Created,
                 };
                 let config = vm_config.lock().unwrap().clone();
@@ -2347,7 +2347,7 @@ impl RequestHandler for Vmm {
                     return e;
                 }
 
-                if vm.get_state().unwrap() == VmState::Paused
+                if vm.get_state() == VmState::Paused
                     && let Err(e) = vm.resume()
                 {
                     return e;


### PR DESCRIPTION
vmm: remove lock for VmState

The lock doesn't make any sense. There is no shared ownership. All
accesses are already synchronized by accesses on a higher level.
