### PR TITLE
block: Allow (and ignore) FLUSH requests on read-only devices

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -169,7 +169,9 @@ fn has_feature(features: u64, feature_flag: u64) -> bool {
 impl BlockEpollHandler {
     fn check_request(features: u64, request_type: RequestType) -> result::Result<(), ExecuteError> {
         if has_feature(features, VIRTIO_BLK_F_RO.into())
-            && !(request_type == RequestType::In || request_type == RequestType::GetDeviceId)
+            && !(request_type == RequestType::In
+                || request_type == RequestType::GetDeviceId
+                || request_type == RequestType::Flush)
         {
             // For virtio spec compliance
             // "A device MUST set the status byte to VIRTIO_BLK_S_IOERR for a write request


### PR DESCRIPTION
OVMF sends FLUSH requests to read-only virtio-block devices.  Refusing these requests prevents OVMF from accessing the EFI System Partition and therefore makes VMs unable to boot.  Accept these requests instead. them.

Ignoring these requests is possible, but inconsistent with fsync(2) which honors them.

Fixes: #7698