### PR TITLE
Delete unused shared memory region code

### DIFF
--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -107,19 +107,6 @@ pub trait VirtioDevice: Send {
         None
     }
 
-    /// Returns the list of shared memory regions required by the device.
-    fn get_shm_regions(&self) -> Option<VirtioSharedMemoryList> {
-        None
-    }
-
-    /// Updates the list of shared memory regions required by the device.
-    fn set_shm_regions(
-        &mut self,
-        _shm_regions: VirtioSharedMemoryList,
-    ) -> std::result::Result<(), Error> {
-        std::unimplemented!()
-    }
-
     /// Some devices may need to do some explicit shutdown work. This method
     /// may be implemented to do this. The VMM should call shutdown() on
     /// every device as part of shutting down the VM. Acting on the device

--- a/virtio-devices/src/vhost_user/generic_vhost_user.rs
+++ b/virtio-devices/src/vhost_user/generic_vhost_user.rs
@@ -15,7 +15,6 @@ use vhost::vhost_user::message::{
 };
 use vhost::vhost_user::{FrontendReqHandler, VhostUserFrontend, VhostUserFrontendReqHandler};
 use virtio_queue::Queue;
-use vm_device::UserspaceMapping;
 use vm_memory::GuestMemoryAtomic;
 use vm_migration::protocol::MemoryRangeTable;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
@@ -27,8 +26,8 @@ use crate::seccomp_filters::Thread;
 use crate::thread_helper::spawn_virtio_thread;
 use crate::vhost_user::VhostUserCommon;
 use crate::{
-    ActivateResult, GuestMemoryMmap, GuestRegionMmap, MmapRegion, VIRTIO_F_IOMMU_PLATFORM,
-    VirtioCommon, VirtioDevice, VirtioInterrupt, VirtioSharedMemoryList,
+    ActivateResult, GuestMemoryMmap, GuestRegionMmap, VIRTIO_F_IOMMU_PLATFORM, VirtioCommon,
+    VirtioDevice, VirtioInterrupt,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -46,9 +45,6 @@ pub struct GenericVhostUser {
     common: VirtioCommon,
     vu_common: VhostUserCommon,
     id: String,
-    // Hold ownership of the memory that is allocated for the device
-    // which will be automatically dropped when the device is dropped
-    cache: Option<(VirtioSharedMemoryList, MmapRegion)>,
     seccomp_action: SeccompAction,
     guest_memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     epoll_thread: Option<thread::JoinHandle<()>>,
@@ -65,7 +61,6 @@ impl GenericVhostUser {
         path: &str,
         request_queue_sizes: Vec<u16>,
         device_type: u32,
-        cache: Option<(VirtioSharedMemoryList, MmapRegion)>,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
         iommu: bool,
@@ -155,7 +150,6 @@ since the backend only supports {backend_num_queues}\n",
                 ..Default::default()
             },
             id,
-            cache,
             seccomp_action,
             guest_memory: None,
             epoll_thread: None,
@@ -347,41 +341,11 @@ impl VirtioDevice for GenericVhostUser {
         self.vu_common.shutdown();
     }
 
-    fn get_shm_regions(&self) -> Option<VirtioSharedMemoryList> {
-        self.cache.as_ref().map(|cache| cache.0.clone())
-    }
-
-    fn set_shm_regions(
-        &mut self,
-        shm_regions: VirtioSharedMemoryList,
-    ) -> std::result::Result<(), crate::Error> {
-        if let Some(cache) = self.cache.as_mut() {
-            cache.0 = shm_regions;
-            Ok(())
-        } else {
-            Err(crate::Error::SetShmRegionsNotSupported)
-        }
-    }
-
     fn add_memory_region(
         &mut self,
         region: &Arc<GuestRegionMmap>,
     ) -> std::result::Result<(), crate::Error> {
         self.vu_common.add_memory_region(&self.guest_memory, region)
-    }
-
-    fn userspace_mappings(&self) -> Vec<UserspaceMapping> {
-        let mut mappings = Vec::new();
-        if let Some(cache) = self.cache.as_ref() {
-            mappings.push(UserspaceMapping {
-                mem_slot: cache.0.mem_slot,
-                addr: cache.0.addr,
-                mapping: cache.0.mapping.clone(),
-                mergeable: false,
-            });
-        }
-
-        mappings
     }
 }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -103,9 +103,11 @@ use vm_device::interrupt::{
 };
 use vm_device::{Bus, BusDevice, BusDeviceSync, Resource, UserspaceMapping};
 #[cfg(feature = "ivshmem")]
+use vm_memory::VolatileMemory;
+#[cfg(feature = "ivshmem")]
 use vm_memory::bitmap::AtomicBitmap;
 use vm_memory::guest_memory::FileOffset;
-use vm_memory::{Address, GuestAddress, GuestMemoryRegion, GuestUsize, MmapRegion, VolatileMemory};
+use vm_memory::{Address, GuestAddress, GuestMemoryRegion, GuestUsize, MmapRegion};
 #[cfg(target_arch = "x86_64")]
 use vm_memory::{GuestAddressSpace, GuestMemory};
 use vm_migration::protocol::MemoryRangeTable;
@@ -826,53 +828,6 @@ impl DeviceRelocation for AddressManager {
                         .map_err(|e| {
                             io::Error::other(format!("failed to register ioevent: {e:?}"))
                         })?;
-                }
-            } else {
-                let virtio_dev = virtio_pci_dev.virtio_device();
-                let mut virtio_dev = virtio_dev.lock().unwrap();
-                if let Some(mut shm_regions) = virtio_dev.get_shm_regions()
-                    && shm_regions.addr.raw_value() == old_base
-                {
-                    // SAFETY: guaranteed by MmapRegion invariants
-                    unsafe {
-                        // Remove old mapping
-                        self.vm
-                            .remove_user_memory_region(
-                                shm_regions.mem_slot,
-                                old_base,
-                                shm_regions.mapping.len(),
-                                shm_regions.mapping.as_ptr(),
-                                false,
-                                false,
-                            )
-                            .map_err(|e| {
-                                io::Error::other(format!(
-                                    "failed to remove user memory region: {e:?}"
-                                ))
-                            })?;
-
-                        // Create new mapping by inserting new region to KVM.
-                        self.vm
-                            .create_user_memory_region(
-                                shm_regions.mem_slot,
-                                new_base,
-                                shm_regions.mapping.len(),
-                                shm_regions.mapping.as_ptr(),
-                                false,
-                                false,
-                            )
-                            .map_err(|e| {
-                                io::Error::other(format!(
-                                    "failed to create user memory regions: {e:?}"
-                                ))
-                            })?;
-                    }
-
-                    // Update shared memory regions to reflect the new mapping.
-                    shm_regions.addr = GuestAddress(new_base);
-                    virtio_dev.set_shm_regions(shm_regions).map_err(|e| {
-                        io::Error::other(format!("failed to update shared memory regions: {e:?}"))
-                    })?;
                 }
             }
         }
@@ -3144,7 +3099,6 @@ impl DeviceManager {
                     generic_vhost_user_socket,
                     generic_vhost_user_cfg.queue_sizes.clone(),
                     generic_vhost_user_cfg.device_type,
-                    None,
                     self.seccomp_action.clone(),
                     self.exit_evt
                         .try_clone()
@@ -3211,7 +3165,6 @@ impl DeviceManager {
                     &fs_cfg.tag,
                     fs_cfg.num_queues,
                     fs_cfg.queue_size,
-                    None,
                     self.seccomp_action.clone(),
                     self.exit_evt
                         .try_clone()


### PR DESCRIPTION
No virtio device ever offered shared memory regions.

That this code is unreachable is honestly quite surprising, and I want to make sure I didn’t make any mistake here.  Nevertheless, it appears that it is in fact unreachable!

I don’t expect this to actually be merged.  For one, both @alyssais’s virtio-GPU device and the virtio-device-backend device I am working on (#7695) will rely on this.  I do wonder how this code was included in the first place, though!