### PR TITLE
vmm: api: Expose the nested option in API description

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -703,6 +703,9 @@ components:
           default: false
         max_phys_bits:
           type: integer
+        nested:
+          type: boolean
+          default: true
         affinity:
           type: array
           items:


### PR DESCRIPTION
Please consider backporting this to v50.