### PR TITLE
Add 404 response to vm.info in the OpenAPI spec

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -40,6 +40,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VmInfo"
+        404:
+          description: The VM instance has not been created yet.
 
   /vm.counters:
     get:


### PR DESCRIPTION
This PR updates the OpenAPI specification by adding a documented 404 response for the vm.info endpoint.