### PR TITLE
vmm: openapi: Sync DiskConfig OpenAPI spec

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -941,6 +941,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/VirtQueueAffinity"
+        backing_files:
+          type: boolean
+          default: false
+        sparse:
+          type: boolean
+          default: true
 
     NetConfig:
       type: object


### PR DESCRIPTION
Add backing_files and sparse fields to the REST API.