### PR TITLE
Add more resiliency to disk image format handling

### DIFF
--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -30,12 +30,13 @@ pub mod vhdx_sync;
 
 use std::alloc::{Layout, alloc_zeroed, dealloc};
 use std::collections::VecDeque;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::fs::File;
 use std::io::{self, IoSlice, IoSliceMut, Read, Seek, SeekFrom, Write};
 use std::os::linux::fs::MetadataExt;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
+use std::str::FromStr;
 use std::time::Instant;
 use std::{cmp, result};
 
@@ -1005,12 +1006,44 @@ pub trait AsyncAdaptor {
     }
 }
 
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum ImageType {
     FixedVhd,
     Qcow2,
     Raw,
     Vhdx,
+    #[default]
+    Unknown,
+}
+
+impl fmt::Display for ImageType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ImageType::FixedVhd => write!(f, "vhd"),
+            ImageType::Qcow2 => write!(f, "qcow2"),
+            ImageType::Raw => write!(f, "raw"),
+            ImageType::Vhdx => write!(f, "vhdx"),
+            ImageType::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+pub enum ImageTypeParseError {
+    InvalidValue(String),
+}
+
+impl FromStr for ImageType {
+    type Err = ImageTypeParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "vhd" => Ok(ImageType::FixedVhd),
+            "qcow2" => Ok(ImageType::Qcow2),
+            "raw" => Ok(ImageType::Raw),
+            "vhdx" => Ok(ImageType::Vhdx),
+            _ => Err(ImageTypeParseError::InvalidValue(s.to_string())),
+        }
+    }
 }
 
 const QCOW_MAGIC: u32 = 0x5146_49fb;

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -1199,14 +1199,14 @@ mod unit_tests {
                     "--kernel",
                     "/path/to/kernel",
                     "--disk",
-                    "path=/path/to/disk/1",
+                    "path=/path/to/disk/1,image_type=raw",
                     "path=/path/to/disk/2",
                 ],
                 r#"{
                     "payload": {"kernel": "/path/to/kernel"},
                     "disks": [
-                        {"path": "/path/to/disk/1"},
-                        {"path": "/path/to/disk/2"}
+                        {"path": "/path/to/disk/1", "image_type": "Raw"},
+                        {"path": "/path/to/disk/2", "image_type": "Unknown"}
                     ]
                 }"#,
                 true,
@@ -1217,8 +1217,8 @@ mod unit_tests {
                     "--kernel",
                     "/path/to/kernel",
                     "--disk",
-                    "path=/path/to/disk/1",
-                    "path=/path/to/disk/2",
+                    "path=/path/to/disk/1,image_type=raw",
+                    "path=/path/to/disk/2,image_type=qcow2",
                 ],
                 r#"{
                     "payload": {"kernel": "/path/to/kernel"},
@@ -1280,8 +1280,8 @@ mod unit_tests {
                 r#"{
                     "payload": {"kernel": "/path/to/kernel"},
                     "disks": [
-                        {"path": "/path/to/disk/1", "rate_limit_group": "group0"},
-                        {"path": "/path/to/disk/2", "rate_limit_group": "group0"}
+                        {"path": "/path/to/disk/1", "rate_limit_group": "group0", "image_type": "Unknown"},
+                        {"path": "/path/to/disk/2", "rate_limit_group": "group0", "image_type": "Unknown"}
                     ],
                     "rate_limit_groups": [
                         {"id": "group0", "rate_limiter_config": {"bandwidth": {"size": 1000, "one_time_burst": 0, "refill_time": 100}}}

--- a/fuzz/fuzz_targets/block.rs
+++ b/fuzz/fuzz_targets/block.rs
@@ -68,6 +68,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
         None,
         queue_affinity,
         true,
+        false,
     )
     .unwrap();
 

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -224,9 +224,9 @@ impl VhostUserBlkBackend {
         let image_type = qcow::detect_image_type(&mut raw_img).unwrap();
         let image = match image_type {
             ImageType::Raw => Arc::new(Mutex::new(raw_img)) as Arc<Mutex<dyn DiskFile>>,
-            ImageType::Qcow2 => {
-                Arc::new(Mutex::new(QcowFile::from(raw_img).unwrap())) as Arc<Mutex<dyn DiskFile>>
-            }
+            ImageType::Qcow2 => Arc::new(Mutex::new(
+                QcowFile::from_with_nesting_depth(raw_img, 0, true).unwrap(),
+            )) as Arc<Mutex<dyn DiskFile>>,
         };
 
         let nsectors = (image.lock().unwrap().seek(SeekFrom::End(0)).unwrap()) / SECTOR_SIZE;

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -160,6 +160,7 @@ struct BlockEpollHandler {
     access_platform: Option<Arc<dyn AccessPlatform>>,
     host_cpus: Option<Vec<usize>>,
     acked_features: u64,
+    disable_sector0_writes: bool,
 }
 
 fn has_feature(features: u64, feature_flag: u64) -> bool {
@@ -167,8 +168,13 @@ fn has_feature(features: u64, feature_flag: u64) -> bool {
 }
 
 impl BlockEpollHandler {
-    fn check_request(features: u64, request_type: RequestType) -> result::Result<(), ExecuteError> {
-        if has_feature(features, VIRTIO_BLK_F_RO.into())
+    fn check_request(
+        features: u64,
+        request: &Request,
+        disable_sector0_writes: bool,
+    ) -> result::Result<(), ExecuteError> {
+        let request_type = request.request_type;
+        if (has_feature(features, VIRTIO_BLK_F_RO.into()))
             && !(request_type == RequestType::In
                 || request_type == RequestType::GetDeviceId
                 || request_type == RequestType::Flush)
@@ -178,6 +184,11 @@ impl BlockEpollHandler {
             // if the VIRTIO_BLK_F_RO feature if offered, and MUST NOT write any data."
             return Err(ExecuteError::ReadOnly);
         }
+
+        if request_type == RequestType::Out && disable_sector0_writes && request.sector == 0 {
+            return Err(ExecuteError::ReadOnly);
+        }
+
         Ok(())
     }
 
@@ -193,7 +204,10 @@ impl BlockEpollHandler {
             // For virtio spec compliance
             // "A device MUST set the status byte to VIRTIO_BLK_S_IOERR for a write request
             // if the VIRTIO_BLK_F_RO feature if offered, and MUST NOT write any data."
-            if let Err(e) = Self::check_request(self.acked_features, request.request_type) {
+            // Also, if sector 0 writes are disabled, treat writes to sector 0 as read-only as well.
+            if let Err(e) =
+                Self::check_request(self.acked_features, &request, self.disable_sector0_writes)
+            {
                 warn!("Request check failed: {request:x?} {e:?}");
                 desc_chain
                     .memory()
@@ -646,6 +660,7 @@ pub struct Block {
     exit_evt: EventFd,
     serial: Vec<u8>,
     queue_affinity: BTreeMap<u16, Vec<usize>>,
+    disable_sector0_writes: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -675,6 +690,7 @@ impl Block {
         state: Option<BlockState>,
         queue_affinity: BTreeMap<u16, Vec<usize>>,
         sparse: bool,
+        disable_sector0_writes: bool,
     ) -> io::Result<Self> {
         let (disk_nsectors, avail_features, acked_features, config, paused) =
             if let Some(state) = state {
@@ -789,6 +805,7 @@ impl Block {
             exit_evt,
             serial,
             queue_affinity,
+            disable_sector0_writes,
         })
     }
 
@@ -1040,6 +1057,7 @@ impl VirtioDevice for Block {
                 access_platform: self.common.access_platform.clone(),
                 host_cpus: self.queue_affinity.get(&queue_idx).cloned(),
                 acked_features: self.common.acked_features,
+                disable_sector0_writes: self.disable_sector0_writes,
             };
 
             let paused = self.common.paused.clone();

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -263,6 +263,7 @@ impl BlockEpollHandler {
                 self.disk_nsectors.load(Ordering::SeqCst),
                 self.disk_image.as_mut(),
                 &self.serial,
+                self.disable_sector0_writes,
                 desc_chain.head_index() as u64,
             );
 

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -947,6 +947,9 @@ components:
         sparse:
           type: boolean
           default: true
+        image_type:
+          type: enum ["FixedVhd", "Qcow2", "Raw", "Vhdx"]
+
 
     NetConfig:
       type: object

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use std::result;
 use std::str::FromStr;
 
+use block::ImageType;
 use clap::ArgMatches;
 use log::{debug, warn};
 use option_parser::{
@@ -1096,7 +1097,8 @@ impl DiskConfig {
          ops_size=<io_ops>,ops_one_time_burst=<io_ops>,ops_refill_time=<ms>,\
          id=<device_id>,pci_segment=<segment_id>,rate_limit_group=<group_id>,\
          queue_affinity=<list_of_queue_indices_with_their_associated_cpuset>,\
-         serial=<serial_number>,backing_files=on|off,sparse=on|off";
+         serial=<serial_number>,backing_files=on|off,sparse=on|off,\
+         image_type=<raw,qcow2,vhd,vhdx>";
 
     pub fn parse(disk: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -1123,7 +1125,9 @@ impl DiskConfig {
             .add("rate_limit_group")
             .add("queue_affinity")
             .add("backing_files")
-            .add("sparse");
+            .add("sparse")
+            .add("image_type");
+
         parser.parse(disk).map_err(Error::ParseDisk)?;
 
         let path = parser.get("path").map(PathBuf::from);
@@ -1208,11 +1212,21 @@ impl DiskConfig {
                     })
                     .collect()
             });
+
         let backing_files = parser
             .convert::<Toggle>("backing_files")
             .map_err(Error::ParseDisk)?
             .unwrap_or(Toggle(false))
             .0;
+
+        let image_type = if vhost_socket.is_none() {
+            parser
+                .convert::<ImageType>("image_type")
+                .map_err(Error::ParseDisk)?
+                .unwrap_or(ImageType::Unknown)
+        } else {
+            ImageType::Unknown
+        };
 
         let bw_tb_config = if bw_size != 0 && bw_refill_time != 0 {
             Some(TokenBucketConfig {
@@ -1265,6 +1279,7 @@ impl DiskConfig {
             queue_affinity,
             backing_files,
             sparse,
+            image_type,
         })
     }
 
@@ -3516,6 +3531,7 @@ mod unit_tests {
             queue_affinity: None,
             backing_files: false,
             sparse: true,
+            image_type: ImageType::Unknown,
         }
     }
 
@@ -3538,6 +3554,7 @@ mod unit_tests {
                 path: None,
                 vhost_socket: Some(String::from("/tmp/sock")),
                 vhost_user: true,
+                image_type: ImageType::Unknown,
                 ..disk_fixture()
             }
         );

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2677,13 +2677,18 @@ impl DeviceManager {
 
             let detected_image_type =
                 detect_image_type(&mut file).map_err(DeviceManagerError::DetectImageType)?;
+            let mut disable_sector0_writes = false;
+
             if disk_cfg.image_type == ImageType::Unknown {
                 warn!(
                     "No image_type specified - detected as {detected_image_type}. \
                     Configuration updated to persist type across reboots and migrations."
                 );
 
-                if detected_image_type != ImageType::Raw {
+                if detected_image_type == ImageType::Raw {
+                    warn!("Autodetected raw image type. Disabling sector 0 writes.");
+                    disable_sector0_writes = true;
+                } else {
                     warn!(
                         "Non-raw image type detected. In the future it will be necessary \
                         to specify image_type for non-raw files."
@@ -2850,6 +2855,7 @@ impl DeviceManager {
                     .map_err(DeviceManagerError::RestoreGetState)?,
                 queue_affinity,
                 disk_cfg.sparse,
+                disable_sector0_writes,
             )
             .map_err(DeviceManagerError::CreateVirtioBlock)?;
 

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{fs, result};
 
+use block::ImageType;
 use log::{debug, warn};
 use net_util::MacAddr;
 use serde::{Deserialize, Serialize};
@@ -288,6 +289,8 @@ pub struct DiskConfig {
     pub backing_files: bool,
     #[serde(default = "default_diskconfig_sparse")]
     pub sparse: bool,
+    #[serde(default)]
+    pub image_type: ImageType,
 }
 
 impl ApplyLandlock for DiskConfig {


### PR DESCRIPTION
- **vmm: Improve resiliency of image type handling**
- **vmm, virtio-devices: Deny zero sector writes for autodetected raw images**
- **vhost_user_blk: Disable use of backing files in test implementation**
- **virtio-devices, block: Reject sector 0 discard/"write zeroes" requests**
