### PR TITLE
vmm: api: Fix image_type in OpenAPI definition

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -948,7 +948,8 @@ components:
           type: boolean
           default: true
         image_type:
-          type: enum ["FixedVhd", "Qcow2", "Raw", "Vhdx"]
+          type: string
+          enum: [FixedVhd, Qcow2, Raw, Vhdx, Unknown]
 
 
     NetConfig:


### PR DESCRIPTION
It is reported OpenAPI tool handles this snippet wrong.


        image_type:
          type: enum ["FixedVhd", "Qcow2", "Raw", "Vhdx"]
 
The code generator tool doesn’t complain, generates code that uses a hypothetical enum type, but then it doesn’t define that enum:
 
```
# github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/cloud-hypervisor/client
../../virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go:35:21: undefined: EnumFixedVhdQcow2RawVhdx
../../virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go:600:37: undefined: EnumFixedVhdQcow2RawVhdx
../../virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go:602:11: undefined: EnumFixedVhdQcow2RawVhdx
../../virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go:610:41: undefined: EnumFixedVhdQcow2RawVhdx
../../virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go:627:37: undefined: EnumFixedVhdQcow2RawVhdx
```

Change the definition to follow how other enums are define. The example we use is the state field under VmInfo.

We should backport this to v50 and v51.