### PR TITLE
block: Use logical block size for alignment

### DIFF
--- a/block/src/async_io.rs
+++ b/block/src/async_io.rs
@@ -8,7 +8,7 @@ use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use thiserror::Error;
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::{BatchRequest, DiskTopology};
+use crate::{BatchRequest, DiskTopology, SECTOR_SIZE};
 
 #[derive(Error, Debug)]
 pub enum DiskFileError {
@@ -144,5 +144,8 @@ pub trait AsyncIo: Send {
     }
     fn submit_batch_requests(&mut self, _batch_request: &[BatchRequest]) -> AsyncIoResult<()> {
         Ok(())
+    }
+    fn alignment(&self) -> u64 {
+        SECTOR_SIZE
     }
 }


### PR DESCRIPTION
    block: Use logical block size for alignment
    
    O_DIRECT requires buffer addresses to be aligned to the backend
    device's logical block size. The existing bounce buffer logic in
    execute_async() hardcodes SECTOR_SIZE (512) for the alignment check
    and bounce buffer allocation. This is insufficient for devices with
    a 4096-byte logical block size, where misaligned buffers cause
    -EINVAL from the host kernel.
    
    Add an alignment() method to the AsyncIo trait that returns the
    backend's logical block size, defaulting to SECTOR_SIZE. The three
    raw I/O backends (io_uring, AIO, synchronous) probe the device
    topology via DiskTopology::probe() at creation time and return the
    actual logical block size. All image format backends would simply
    use the default value of 512 bytes since their underlying are
    not block devices.
    
    execute_async() now queries disk_image.alignment() instead of using
    the hardcoded SECTOR_SIZE
    
    Fixes: #7720
    
    Signed-off-by: Saravanan D <saravanand@crusoe.ai>