### PR TITLE
virtio-devices: vdpa: Defer suspend to pause for cross-host live migration

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -25,6 +25,10 @@ use vhost::vhost_kern::vhost_binding::{
     VHOST_VDPA_SET_STATUS, VHOST_VDPA_SET_VRING_ENABLE, VHOST_VDPA_SUSPEND,
 };
 
+// VHOST_VDPA_RESUME is not yet exported by the vhost crate (v0.14.0).
+// _IO(VHOST_VIRTIO=0xAF, 0x7E) = (0xAF << 8) | 0x7E = 0xAF7E
+const VHOST_VDPA_RESUME_NR: u64 = 0xAF7E;
+
 #[derive(Copy, Clone)]
 pub enum Thread {
     HttpApi,
@@ -362,6 +366,7 @@ fn create_vmm_ioctl_seccomp_rule_common(
             VHOST_VDPA_GET_CONFIG_SIZE()
         )?],
         and![Cond::new(1, ArgLen::Dword, Eq, VHOST_VDPA_SUSPEND())?],
+        and![Cond::new(1, ArgLen::Dword, Eq, VHOST_VDPA_RESUME_NR)?],
     ];
 
     let hypervisor_rules = create_vmm_ioctl_seccomp_rule_hypervisor(hypervisor_type)?;


### PR DESCRIPTION
## Summary

This series improves vDPA cross-host live migration by deferring device suspension from `start_migration()` to the `pause()` phase, enabling conservative dirty page tracking, and adding `VHOST_VDPA_RESUME` support for migration failure recovery.

- **Defer suspend to pause**: Move `VHOST_VDPA_SUSPEND` from migration start to the pause phase, allowing the device to operate at full speed during pre-copy. This reduces network downtime from the entire pre-copy duration to ~100-500ms (stop-and-copy only).
- **Conservative dirty page collection**: After suspension, walk the frozen virtqueue descriptor rings and mark as dirty all pages the device could have written (used rings, descriptor tables, device-writable buffers). Also adds indirect descriptor support and improved diagnostics.
- **Migration failure recovery**: Implement `VHOST_VDPA_RESUME` ioctl support to unsuspend devices if migration fails, preventing permanent device suspension and TX timeouts.

Fixes #7738

## Test plan

- [x] Verify vDPA cross-host live migration completes successfully with deferred suspend
- [x] Verify dirty page tracking marks correct pages after device suspension
- [ ] Verify `VHOST_VDPA_RESUME` properly recovers device on migration failure
- [ ] Verify no regression in non-vDPA migration paths
