### PR TITLE
vmm: Add core scheduling support for vCPU threads

### DIFF
--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -214,7 +214,7 @@ fn get_cli_options_sorted(
                     kvm_hyperv=on|off,max_phys_bits=<maximum_number_of_physical_bits>,\
                     affinity=<list_of_vcpus_with_their_associated_cpuset>,\
                     features=<list_of_features_to_enable>,\
-                    nested=on|off",
+                    nested=on|off,core_scheduling=vm|vcpu|off",
             )
             .default_value(default_vcpus)
             .group("vm-config"),
@@ -911,8 +911,8 @@ mod unit_tests {
     #[cfg(target_arch = "x86_64")]
     use vmm::vm_config::DebugConsoleConfig;
     use vmm::vm_config::{
-        ConsoleConfig, ConsoleOutputMode, CpuFeatures, CpusConfig, HotplugMethod, MemoryConfig,
-        PayloadConfig, RngConfig, VmConfig,
+        ConsoleConfig, ConsoleOutputMode, CoreScheduling, CpuFeatures, CpusConfig, HotplugMethod,
+        MemoryConfig, PayloadConfig, RngConfig, VmConfig,
     };
 
     use crate::test_util::assert_args_sorted;
@@ -963,6 +963,7 @@ mod unit_tests {
                 affinity: None,
                 features: CpuFeatures::default(),
                 nested: true,
+                core_scheduling: CoreScheduling::Vm,
             },
             memory: MemoryConfig {
                 size: 536_870_912,

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -137,6 +137,7 @@ impl RequestHandler for StubApiRequestHandler {
                     affinity: None,
                     features: CpuFeatures::default(),
                     nested: true,
+                    core_scheduling: CoreScheduling::default(),
                 },
                 memory: MemoryConfig {
                     size: 536_870_912,

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -712,6 +712,10 @@ components:
             $ref: "#/components/schemas/CpuAffinity"
         features:
           $ref: "#/components/schemas/CpuFeatures"
+        core_scheduling:
+          type: string
+          enum: ["Vm", "Vcpu", "Off"]
+          default: "Vm"
 
     PciSegmentConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -559,6 +559,23 @@ impl FromStr for HotplugMethod {
     }
 }
 
+pub enum ParseCoreSchedulingError {
+    InvalidValue(String),
+}
+
+impl FromStr for CoreScheduling {
+    type Err = ParseCoreSchedulingError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "vm" => Ok(CoreScheduling::Vm),
+            "vcpu" => Ok(CoreScheduling::Vcpu),
+            "off" => Ok(CoreScheduling::Off),
+            _ => Err(ParseCoreSchedulingError::InvalidValue(s.to_owned())),
+        }
+    }
+}
+
 pub enum CpuTopologyParseError {
     InvalidValue(String),
 }
@@ -603,7 +620,8 @@ impl CpusConfig {
             .add("max_phys_bits")
             .add("affinity")
             .add("features")
-            .add("nested");
+            .add("nested")
+            .add("core_scheduling");
         parser.parse(cpus).map_err(Error::ParseCpus)?;
 
         let boot_vcpus: u32 = parser
@@ -670,6 +688,11 @@ impl CpusConfig {
                 "nested=off is not supported on aarch64 and riscv64 architectures".to_string(),
             )));
         }
+        let core_scheduling = parser
+            .convert("core_scheduling")
+            .map_err(Error::ParseCpus)?
+            .unwrap_or(CoreScheduling::Vm);
+
         Ok(CpusConfig {
             boot_vcpus,
             max_vcpus,
@@ -679,6 +702,7 @@ impl CpusConfig {
             affinity,
             features,
             nested,
+            core_scheduling,
         })
     }
 }
@@ -3370,6 +3394,42 @@ mod unit_tests {
                 ..Default::default()
             },
         );
+
+        // Test core_scheduling parsing
+        assert_eq!(
+            CpusConfig::parse("boot=1,core_scheduling=vm")?,
+            CpusConfig {
+                boot_vcpus: 1,
+                max_vcpus: 1,
+                core_scheduling: CoreScheduling::Vm,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            CpusConfig::parse("boot=1,core_scheduling=vcpu")?,
+            CpusConfig {
+                boot_vcpus: 1,
+                max_vcpus: 1,
+                core_scheduling: CoreScheduling::Vcpu,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            CpusConfig::parse("boot=1,core_scheduling=off")?,
+            CpusConfig {
+                boot_vcpus: 1,
+                max_vcpus: 1,
+                core_scheduling: CoreScheduling::Off,
+                ..Default::default()
+            }
+        );
+        // Default (no core_scheduling specified) should be Vm
+        assert_eq!(
+            CpusConfig::parse("boot=1")?.core_scheduling,
+            CoreScheduling::Vm
+        );
+        // Invalid value should error
+        CpusConfig::parse("boot=1,core_scheduling=invalid").unwrap_err();
 
         Ok(())
     }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2378,8 +2378,8 @@ mod unit_tests {
     #[cfg(target_arch = "x86_64")]
     use crate::vm_config::DebugConsoleConfig;
     use crate::vm_config::{
-        ConsoleConfig, ConsoleOutputMode, CpuFeatures, CpusConfig, HotplugMethod, MemoryConfig,
-        PayloadConfig, RngConfig,
+        ConsoleConfig, ConsoleOutputMode, CoreScheduling, CpuFeatures, CpusConfig, HotplugMethod,
+        MemoryConfig, PayloadConfig, RngConfig,
     };
 
     fn create_dummy_vmm() -> Vmm {
@@ -2408,6 +2408,7 @@ mod unit_tests {
                 affinity: None,
                 features: CpuFeatures::default(),
                 nested: true,
+                core_scheduling: CoreScheduling::default(),
             },
             memory: MemoryConfig {
                 size: 536_870_912,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -39,6 +39,14 @@ pub struct CpuFeatures {
     pub amx: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub enum CoreScheduling {
+    #[default]
+    Vm, // All vCPUs have the same cookie so can share a core
+    Vcpu, // Each vCPU has a unique cookie so can't share a core
+    Off,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct CpuTopology {
     pub threads_per_core: u16,
@@ -72,6 +80,8 @@ pub struct CpusConfig {
     pub features: CpuFeatures,
     #[serde(default = "default_cpusconfig_nested")]
     pub nested: bool,
+    #[serde(default)]
+    pub core_scheduling: CoreScheduling,
 }
 
 pub const DEFAULT_VCPUS: u32 = 1;
@@ -87,6 +97,7 @@ impl Default for CpusConfig {
             affinity: None,
             features: CpuFeatures::default(),
             nested: true,
+            core_scheduling: CoreScheduling::default(),
         }
     }
 }


### PR DESCRIPTION
Add a core_scheduling option to --cpus with three modes of operation.
This feature takes advantage of a kernel feature that restricts scheduling
of processes on the SMT threads on the same core. This is useful for
mitigating certain classes of side-channel attacks and has better
performance that disabling SMT on the CPU.

- vm (default): All vCPU threads share one core scheduling cookie.
  They may be co-scheduled on SMT siblings while host threads are
  excluded - this has minimal performance impact and can even
  potentially improve performance from co-location.
- vcpu: Each vCPU gets a unique cookie preventing any two vCPUs from
  sharing SMT siblings. This has the strongest isolation but at some
  compromise of performance.
- off: No core scheduling applied (old behaviour).

In VM mode the cookie is created on the calling thread before spawning
vCPU threads so they inherit the same cookie. In vCPU mode each vCPU
thread the cookie is created when the thread starts.

EINVAL from prctl is silently ignored so this works transparently on
kernels older than 5.14 that lack PR_SCHED_CORE.

Full details of this kernel feature can be found at:
https://docs.kernel.org/admin-guide/hw-vuln/core-scheduling.html

This implementation was inspired by crosvm's implementation - in
particular the enable_core_scheduling() function.

Signed-off-by: Rob Bradford <rbradford@meta.com>
