### PR TITLE
vmm: remove duplicate vm config parameter

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -612,7 +612,6 @@ impl Vm {
             #[cfg(not(target_arch = "riscv64"))]
             timestamp,
             snapshot,
-            &config,
         )?;
 
         // Perform hypervisor-specific initialization
@@ -798,10 +797,9 @@ impl Vm {
         boot_id_list: BTreeSet<String>,
         #[cfg(not(target_arch = "riscv64"))] timestamp: Instant,
         snapshot: Option<&Snapshot>,
-        _vm_config: &Arc<Mutex<VmConfig>>,
     ) -> Result<Arc<Mutex<DeviceManager>>> {
         #[cfg(feature = "tdx")]
-        let dynamic = !_vm_config.lock().unwrap().is_tdx_enabled();
+        let dynamic = !config.lock().unwrap().is_tdx_enabled();
         #[cfg(not(feature = "tdx"))]
         let dynamic = true;
 


### PR DESCRIPTION
Vm::create_device_manager accepted both config and _vm_config, but both represented the same VM configuration source. Remove _vm_config from the function signature and from its call site, and use config for the TDX dynamic check.

This is a cleanup-only refactor with no intended functional change.