### PR TITLE
vmm: config: Fix missing comma in NetConfig help text

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1414,7 +1414,7 @@ impl NetConfig {
     num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,id=<device_id>,\
     vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>,vhost_mode=client|server,\
     bw_size=<bytes>,bw_one_time_burst=<bytes>,bw_refill_time=<ms>,\
-    ops_size=<io_ops>,ops_one_time_burst=<io_ops>,ops_refill_time=<ms>,pci_segment=<segment_id>\
+    ops_size=<io_ops>,ops_one_time_burst=<io_ops>,ops_refill_time=<ms>,pci_segment=<segment_id>,\
     offload_tso=on|off,offload_ufo=on|off,offload_csum=on|off\"";
 
     pub fn parse(net: &str) -> Result<Self> {


### PR DESCRIPTION
The SYNTAX help string for --net was missing a comma between pci_segment and offload_tso parameters, making the help output show them as a single run-on token.