### PR TITLE
tests: Introduce a way to skip tests via dev_cli.sh

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -248,13 +248,13 @@ echo "$PAGE_NUM" | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 # Run all direct kernel boot (Device Tree) test cases in mod `parallel`
-time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "common_parallel::$test_filter" -- ${test_binary_args[*]}
+time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "common_parallel::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
 RES=$?
 
 # Run some tests in sequence since the result could be affected by other tests
 # running in parallel.
 if [ $RES -eq 0 ]; then
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "common_sequential::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "common_sequential::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
     RES=$?
 else
     exit $RES
@@ -262,7 +262,7 @@ fi
 
 # Run all ACPI test cases
 if [ $RES -eq 0 ]; then
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "aarch64_acpi::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "aarch64_acpi::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
     RES=$?
 else
     exit $RES
@@ -270,14 +270,14 @@ fi
 
 # Run all test cases related to live migration
 if [ $RES -eq 0 ]; then
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "live_migration_parallel::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "live_migration_parallel::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
     RES=$?
 else
     exit $RES
 fi
 
 if [ $RES -eq 0 ]; then
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "live_migration_sequential::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "live_migration_sequential::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
     RES=$?
 else
     exit $RES
@@ -288,7 +288,7 @@ if [ $RES -eq 0 ]; then
     cargo build --features "dbus_api" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
     # integration tests now do not reply on build feature "dbus_api"
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "dbus_api::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "dbus_api::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
     RES=$?
 fi
 
@@ -296,15 +296,14 @@ fi
 if [ $RES -eq 0 ]; then
     cargo build --features "fw_cfg" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "fw_cfg::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "fw_cfg::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
     RES=$?
 fi
 
 if [ $RES -eq 0 ]; then
     cargo build --features "ivshmem" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "ivshmem::$test_filter" -- ${test_binary_args[*]}
-
+    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "ivshmem::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
     RES=$?
 fi
 

--- a/scripts/run_integration_tests_cvm.sh
+++ b/scripts/run_integration_tests_cvm.sh
@@ -27,7 +27,7 @@ popd || exit
 cargo build --features $build_features --all --release --target "$BUILD_TARGET"
 
 export RUST_BACKTRACE=1
-cargo nextest run $test_features "common_cvm::$test_filter" -- ${test_binary_args[*]}
+cargo nextest run $test_features "common_cvm::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
 RES=$?
 
 exit $RES

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -87,7 +87,7 @@ sudo chmod a+rwX /dev/hugepages
 export RUST_BACKTRACE=1
 export RUSTFLAGS="$RUSTFLAGS"
 
-time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "live_migration_parallel::$test_filter" -- ${test_binary_args[*]}
+time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "live_migration_parallel::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
 
 RES=$?
 
@@ -95,7 +95,7 @@ RES=$?
 # running in parallel.
 if [ $RES -eq 0 ]; then
     export RUST_BACKTRACE=1
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "live_migration_sequential::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "live_migration_sequential::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
     RES=$?
 fi
 

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -59,7 +59,7 @@ cargo build --features mshv --all --release --target "$BUILD_TARGET"
 export RUST_BACKTRACE=1
 export RUSTFLAGS="$RUSTFLAGS"
 
-time cargo nextest run --no-tests=pass $test_features --test-threads=1 "rate_limiter::$test_filter" -- ${test_binary_args[*]}
+time cargo nextest run --no-tests=pass $test_features --test-threads=1 "rate_limiter::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
 RES=$?
 
 exit $RES

--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -30,7 +30,7 @@ cargo build --features mshv --all --release --target "$BUILD_TARGET"
 export RUST_BACKTRACE=1
 export RUSTFLAGS="$RUSTFLAGS"
 
-time cargo nextest run --no-tests=pass --test-threads=1 "vfio::test_nvidia" -- ${test_binary_args[*]}
+time cargo nextest run --no-tests=pass --test-threads=1 "vfio::test_nvidia" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
 RES=$?
 
 exit $RES

--- a/scripts/run_integration_tests_windows_aarch64.sh
+++ b/scripts/run_integration_tests_windows_aarch64.sh
@@ -44,7 +44,7 @@ cargo build --all --release --target "$BUILD_TARGET"
 
 # Only run with 1 thread to avoid tests interfering with one another because
 # Windows has a static IP configured
-time cargo nextest run --no-tests=pass "windows::$test_filter" --target "$BUILD_TARGET" -- ${test_binary_args[*]}
+time cargo nextest run --no-tests=pass "windows::$test_filter" --target "$BUILD_TARGET" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
 RES=$?
 
 dmsetup remove_all -f

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -47,7 +47,7 @@ export RUSTFLAGS="$RUSTFLAGS"
 
 # Only run with 1 thread to avoid tests interfering with one another because
 # Windows has a static IP configured
-time cargo nextest run --no-tests=pass $test_features "windows::$test_filter" --target "$BUILD_TARGET" -- ${test_binary_args[*]}
+time cargo nextest run --no-tests=pass $test_features "windows::$test_filter" --target "$BUILD_TARGET" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
 RES=$?
 
 dmsetup remove_all -f

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -189,13 +189,13 @@ ulimit -n 4096
 export RUST_BACKTRACE=1
 export RUSTFLAGS="$RUSTFLAGS"
 
-time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "common_parallel::$test_filter" -- ${test_binary_args[*]}
+time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "common_parallel::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
 RES=$?
 
 # Run some tests in sequence since the result could be affected by other tests
 # running in parallel.
 if [ $RES -eq 0 ]; then
-    cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "common_sequential::$test_filter" -- ${test_binary_args[*]}
+    cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "common_sequential::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
     RES=$?
 fi
 
@@ -203,20 +203,20 @@ fi
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,dbus_api" --all --release --target "$BUILD_TARGET"
     # integration tests now do not reply on build feature "dbus_api"
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "dbus_api::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "dbus_api::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
     RES=$?
 fi
 
 # Run tests on fw_cfg
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,fw_cfg" --all --release --target "$BUILD_TARGET"
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "fw_cfg::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "fw_cfg::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
     RES=$?
 fi
 
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,ivshmem" --all --release --target "$BUILD_TARGET"
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "ivshmem::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "ivshmem::$test_filter" ${skip_filter:+-- $skip_filter }-- ${test_binary_args[*]}
     RES=$?
 fi
 

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -17,5 +17,5 @@ elif [[ $(uname -m) = "x86_64" ]]; then
 fi
 
 export RUST_BACKTRACE=1
-cargo test --lib --bins --target "$BUILD_TARGET" --release --workspace ${cargo_args[@]} || exit 1
-cargo test --doc --target "$BUILD_TARGET" --release --workspace ${cargo_args[@]} || exit 1
+cargo test --lib --bins --target "$BUILD_TARGET" --release --workspace ${cargo_args[@]} ${skip_filter:+-- $skip_filter }|| exit 1
+cargo test --doc --target "$BUILD_TARGET" --release --workspace ${cargo_args[@]} ${skip_filter:+-- $skip_filter }|| exit 1

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -5,6 +5,7 @@ set -x
 
 hypervisor="kvm"
 test_filter=""
+skip_filter=""
 build_kernel=false
 
 # Download from a url with retries
@@ -121,6 +122,10 @@ process_common_args() {
         "--test-filter")
             shift
             test_filter="$1"
+            ;;
+        "--skip")
+            shift
+            skip_filter+=" --skip $1"
             ;;
         "--build-guest-kernel")
             build_kernel=true


### PR DESCRIPTION
It's sometimes more convenient to skip some tests than to specify the list of tests to run. There can be multiple "--skip" options provided.

Example - run integration tests expect common_parallel::test_watchdog and common_parallel::test_multi_cpu to be skipped:

	./scripts/dev_cli.sh tests --integration -- --skip	\
			common_parallel::test_watchdog		\
			common_parallel::test_multi_cpu