### PR TITLE
main: add `.action(ArgAction::Append)` to all `.num_args(1..)`

### DIFF
--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -246,11 +246,13 @@ fn get_cli_options_sorted(
             .long("device")
             .help(DeviceConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("disk")
             .long("disk")
             .help(DiskConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("event-monitor")
             .long("event-monitor")
@@ -266,6 +268,7 @@ fn get_cli_options_sorted(
             .long("fs")
             .help(FsConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         #[cfg(feature = "fw_cfg")]
         Arg::new("fw-cfg-config")
@@ -283,6 +286,7 @@ fn get_cli_options_sorted(
             .long("generic-vhost-user")
             .help(GenericVhostUserConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         #[cfg(feature = "igvm")]
         Arg::new("igvm")
@@ -328,6 +332,7 @@ fn get_cli_options_sorted(
             .long("landlock-rules")
             .help(LandlockConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("log-file")
             .long("log-file")
@@ -360,21 +365,25 @@ fn get_cli_options_sorted(
                      prefault=on|off\"",
             )
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("net")
             .long("net")
             .help(NetConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("numa")
             .long("numa")
             .help(NumaConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("pci-segment")
             .long("pci-segment")
             .help(PciSegmentConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("platform")
             .long("platform")
@@ -387,6 +396,7 @@ fn get_cli_options_sorted(
             .long("pmem")
             .help(PmemConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         #[cfg(feature = "pvmemcontrol")]
         Arg::new("pvmemcontrol")
@@ -405,6 +415,7 @@ fn get_cli_options_sorted(
             .long("rate-limit-group")
             .help(RateLimiterGroupConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("restore")
             .long("restore")
@@ -437,6 +448,7 @@ fn get_cli_options_sorted(
             .long("user-device")
             .help(UserDeviceConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("v")
             .short('v')
@@ -447,6 +459,7 @@ fn get_cli_options_sorted(
             .long("vdpa")
             .help(VdpaConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("version")
             .short('V')


### PR DESCRIPTION
With `.num_args(1..)`, multiple values can be specified for a CLI option, but the option cannot be specified more than once. In my experience, it’s more common to specify flags with a single argument multiple times to specify multiple arguments. One might thus expect to call `cloud-hypervisor` with e.g. `--disk path=foo --disk path==bar`.

With this PR, both `--disk path=foo path=bar path=baz` and `--disk path=foo -disk path=bar path=baz` (note: combinations as well) are allowed.