### PR TITLE
vmm: Print out version at launch

### DIFF
--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -595,6 +595,8 @@ fn start_vmm(cmd_arguments: &ArgMatches) -> Result<Option<String>, Error> {
         }
     }
 
+    info!("{} starting", env!("BUILD_VERSION"));
+
     let hypervisor = hypervisor::new().map_err(Error::CreateHypervisor)?;
 
     #[cfg(feature = "guest_debug")]


### PR DESCRIPTION
It is useful to see this information in the log while debugging issues.