### PR TITLE
vmm: Remove dead QcowDeviceCreate error variant

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -267,10 +267,6 @@ pub enum DeviceManagerError {
     #[error("Failed to parse disk image format")]
     DetectImageType(#[source] io::Error),
 
-    /// Cannot open qcow disk path
-    #[error("Cannot open qcow disk path")]
-    QcowDeviceCreate(#[source] qcow::Error),
-
     /// Cannot create serial manager
     #[error("Cannot create serial manager")]
     CreateSerialManager(#[source] SerialManagerError),


### PR DESCRIPTION
The variant has been unused since commit 12e20effd which replaced direct QcowFile creation with QcowDiskSync.