### PR TITLE
virtio-devices: block: add helpful error message when writing sector 0 without image_type=raw

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -182,6 +182,9 @@ impl BlockEpollHandler {
             // For virtio spec compliance
             // "A device MUST set the status byte to VIRTIO_BLK_S_IOERR for a write request
             // if the VIRTIO_BLK_F_RO feature if offered, and MUST NOT write any data."
+            warn!(
+                "Rejecting block request {request_type:?}: device is read-only (VIRTIO_BLK_F_RO negotiated)"
+            );
             return Err(ExecuteError::ReadOnly);
         }
 


### PR DESCRIPTION
Unfortunately, my colleague Paul (@pkr4711) tried to install Windows from the Windows installer (via network + VNC) in a Cloud Hypervisor VM and it failed during the installation step. Turns out our recent hardening (https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7728/changes/6ecdf90e22adeecbaf1ce311b1abd358a4788d48) caused the issue :)

I've added a descriptive and helpful warn message.