### PR TITLE
vmm: cli: allow repeating '--net', '--disk', and similar options

### DIFF
--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -246,11 +246,13 @@ fn get_cli_options_sorted(
             .long("device")
             .help(DeviceConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("disk")
             .long("disk")
             .help(DiskConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("event-monitor")
             .long("event-monitor")
@@ -266,6 +268,7 @@ fn get_cli_options_sorted(
             .long("fs")
             .help(FsConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         #[cfg(feature = "fw_cfg")]
         Arg::new("fw-cfg-config")
@@ -283,6 +286,7 @@ fn get_cli_options_sorted(
             .long("generic-vhost-user")
             .help(GenericVhostUserConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         #[cfg(feature = "igvm")]
         Arg::new("igvm")
@@ -360,21 +364,25 @@ fn get_cli_options_sorted(
                      prefault=on|off\"",
             )
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("net")
             .long("net")
             .help(NetConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("numa")
             .long("numa")
             .help(NumaConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("pci-segment")
             .long("pci-segment")
             .help(PciSegmentConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("platform")
             .long("platform")
@@ -387,6 +395,7 @@ fn get_cli_options_sorted(
             .long("pmem")
             .help(PmemConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         #[cfg(feature = "pvmemcontrol")]
         Arg::new("pvmemcontrol")
@@ -405,6 +414,7 @@ fn get_cli_options_sorted(
             .long("rate-limit-group")
             .help(RateLimiterGroupConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("restore")
             .long("restore")
@@ -437,6 +447,7 @@ fn get_cli_options_sorted(
             .long("user-device")
             .help(UserDeviceConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("v")
             .short('v')
@@ -447,6 +458,7 @@ fn get_cli_options_sorted(
             .long("vdpa")
             .help(VdpaConfig::SYNTAX)
             .num_args(1..)
+            .action(ArgAction::Append)
             .group("vm-config"),
         Arg::new("version")
             .short('V')


### PR DESCRIPTION
Several device configuration options accept multiple values but are currently expressed in a single invocation. For example, specifying multiple disks requires:

  --disk path=disk1.raw path=disk2.raw

However, users would typically expect to repeat the option:

  --disk path=disk1.raw --disk path=disk2.raw

This syntax is more natural, improves readability, and aligns better with the CLI conventions used by tools such as QEMU.

Enable this by switching these arguments to `ArgAction::Append`. This allows options that already accept `1..` arguments to also be specified multiple times with their namespace prefix.

The existing syntax continues to work unchanged, so this is purely an extension of the CLI rather than a breaking change.

