### PR TITLE
vmm: allow nested=off on aarch64 with mshv

### DIFF
--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -58,6 +58,8 @@ enum Error {
     StartVmmThread(#[source] vmm::Error),
     #[error("Error parsing config")]
     ParsingConfig(#[source] vmm::config::Error),
+    #[error("Error validating VM config")]
+    ValidatingConfig(#[source] vmm::config::ValidationError),
     #[error("Error creating VM")]
     VmCreate(#[source] vmm::api::ApiError),
     #[error("Error booting VM")]
@@ -597,7 +599,7 @@ fn start_vmm(cmd_arguments: &ArgMatches) -> Result<Option<String>, Error> {
     info!("{} starting", env!("BUILD_VERSION"));
 
     let hypervisor = hypervisor::new().map_err(Error::CreateHypervisor)?;
-
+    let hv_type = hypervisor.hypervisor_type();
     #[cfg(feature = "guest_debug")]
     let gdb_socket_path = if let Some(gdb_config) = cmd_arguments.get_one::<String>("gdb") {
         let mut parser = OptionParser::new();
@@ -731,7 +733,9 @@ fn start_vmm(cmd_arguments: &ArgMatches) -> Result<Option<String>, Error> {
         if payload_present {
             let vm_params = VmParams::from_arg_matches(cmd_arguments);
             let vm_config = VmConfig::parse(vm_params).map_err(Error::ParsingConfig)?;
-
+            vm_config
+                .validate_nested(hv_type)
+                .map_err(Error::ValidatingConfig)?;
             // Create and boot the VM based off the VM config we just built.
             let sender = api_request_sender.clone();
             vmm::api::VmCreate

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -64,7 +64,7 @@ pub use vm::{
 
 pub use crate::hypervisor::{Hypervisor, HypervisorError};
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum HypervisorType {
     #[cfg(feature = "kvm")]
     Kvm,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -12,6 +12,8 @@ use std::str::FromStr;
 
 use block::ImageType;
 use clap::ArgMatches;
+#[allow(unused_imports)]
+use hypervisor::HypervisorType;
 use log::{debug, warn};
 use option_parser::{
     ByteSized, IntegerList, OptionParser, OptionParserError, StringList, Toggle, Tuple,
@@ -398,6 +400,8 @@ pub enum ValidationError {
     /// Invalid NUMA Configuration
     #[error("NUMA Configuration is invalid")]
     InvalidNumaConfig(String),
+    #[error("Nested virtualization is always turned on with KVM on AArch64")]
+    NestedIsAlwaysOnAarch64WithKvm(String),
 }
 
 type ValidationResult<T> = std::result::Result<T, ValidationError>;
@@ -717,14 +721,6 @@ impl CpusConfig {
             .map_err(Error::ParseCpus)?
             .is_none_or(|toggle| toggle.0);
 
-        // Nested virtualization is always turned on for aarch64 and riscv64
-        // TODO: revisit this when nested support can be turned of on these architectures
-        #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-        if !nested {
-            return Err(Error::ParseCpus(OptionParserError::InvalidValue(
-                "nested=off is not supported on aarch64 and riscv64 architectures".to_string(),
-            )));
-        }
         let core_scheduling = parser
             .convert("core_scheduling")
             .map_err(Error::ParseCpus)?
@@ -2799,6 +2795,33 @@ impl VmConfig {
         } else {
             false
         }
+    }
+
+    pub fn validate_nested(&self, _hv_type: HypervisorType) -> ValidationResult<()> {
+        // Nested virtualization is always turned on for aarch64 and riscv64 on KVM
+        // On MSHV nested not supported on aarch64, it is allowed to be turned off.
+        // TODO: revisit this when nested support can be turned off on these architectures
+        #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+        {
+            cfg_if::cfg_if! {
+                if #[cfg(all(feature = "kvm", feature = "mshv"))] {
+                    // Both features enabled: check runtime hypervisor type
+                    let is_kvm = _hv_type == HypervisorType::Kvm;
+                } else if #[cfg(feature = "kvm")] {
+                    // Only KVM enabled
+                    let is_kvm = true;
+                } else {
+                    // Only MSHV or neither enabled
+                    let is_kvm = false;
+                }
+            };
+            if is_kvm && !self.cpus.nested {
+                return Err(ValidationError::NestedIsAlwaysOnAarch64WithKvm(
+                    "Nested virtualization must be enabled on AArch64 with KVM".to_string(),
+                ));
+            }
+        }
+        Ok(())
     }
 
     // Also enables virtio-iommu if the config needs it


### PR DESCRIPTION
Gate the forced nested virtualization check behind non-MSHV builds for aarch64 and riscv64. Keep rejecting nested=off on KVM for these architectures.

Update comments to reflect MSHV behavior and current limitation.