### PR TITLE
pci: vfio-user: Fix sparse mappings

### DIFF
--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -163,12 +163,16 @@ impl VfioUserPciDevice {
                 let file_offset = file_offset.as_ref().unwrap();
 
                 for s in mmaps.iter() {
+                    // The fd is a per-area fd where the mapping starts at
+                    // offset 0. This is different from VFIO as it uses a
+                    // single device fd where sparse_area.offset locates data
+                    // within that fd.
                     let mapping = match MmapRegion::mmap(
                         s.size,
                         prot,
                         file_offset.file().as_fd(),
                         file_offset.start(),
-                        s.offset,
+                        0,
                     ) {
                         Ok(mapping) => Arc::new(mapping),
                         Err(e) => {


### PR DESCRIPTION
When a sparse mmap area was defined with an offset different from 0, it led the mapping not to work as expected. That's because the mapping was performed by incorrectly applying the sparse area offset into the memory mapping. And that's because each sparse area is provided with a separate file descriptor, meaning there's no need for any offset.