### PR TITLE
misc: make MSRV workspace-wide for cloud-hypervisor dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,14 @@ members = [
   "vmm",
 ]
 package.edition = "2024"
+# Minimum buildable version:
+# Keep in sync with version in .github/workflows/build.yaml
+# Policy on MSRV (see #4318):
+# Can only be bumped if satisfying any of the following:
+# a.) A dependency requires it,
+# b.) If we want to use a new feature and that MSRV is at least 6 months old,
+# c.) There is a security issue that is addressed by the toolchain update.
+package.rust-version = "1.89.0"
 resolver = "3"
 
 [workspace.dependencies]

--- a/api_client/Cargo.toml
+++ b/api_client/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["The Cloud Hypervisor Authors"]
 edition.workspace = true
 license = "Apache-2.0"
 name = "api_client"
+rust-version.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Chromium OS Authors"]
 edition.workspace = true
 name = "arch"
+rust-version.workspace = true
 version = "0.1.0"
 
 [features]

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Chromium OS Authors", "The Cloud Hypervisor Authors"]
 edition.workspace = true
 name = "block"
+rust-version.workspace = true
 version = "0.1.0"
 
 [features]

--- a/cloud-hypervisor/Cargo.toml
+++ b/cloud-hypervisor/Cargo.toml
@@ -7,15 +7,8 @@ edition = "2024"
 homepage = "https://github.com/cloud-hypervisor/cloud-hypervisor"
 license = "Apache-2.0 AND BSD-3-Clause"
 name = "cloud-hypervisor"
+rust-version.workspace = true
 version = "51.0.0"
-# Minimum buildable version:
-# Keep in sync with version in .github/workflows/build.yaml
-# Policy on MSRV (see #4318):
-# Can only be bumped if satisfying any of the following:
-# a.) A dependency requires it,
-# b.) If we want to use a new feature and that MSRV is at least 6 months old,
-# c.) There is a security issue that is addressed by the toolchain update.
-rust-version = "1.89.0"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Chromium OS Authors"]
 edition.workspace = true
 name = "devices"
+rust-version.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/event_monitor/Cargo.toml
+++ b/event_monitor/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Cloud Hypervisor Authors"]
 edition.workspace = true
 name = "event_monitor"
+rust-version.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Microsoft Authors"]
 edition.workspace = true
 license = "Apache-2.0 OR BSD-3-Clause"
 name = "hypervisor"
+rust-version.workspace = true
 version = "0.1.0"
 
 [features]

--- a/net_gen/Cargo.toml
+++ b/net_gen/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["The Chromium OS Authors"]
 edition = "2021"
 #edition.workspace = true
 name = "net_gen"
+rust-version.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Chromium OS Authors"]
 edition.workspace = true
 name = "net_util"
+rust-version.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/option_parser/Cargo.toml
+++ b/option_parser/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Cloud Hypervisor Authors"]
 edition.workspace = true
 name = "option_parser"
+rust-version.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["Samuel Ortiz <sameo@linux.intel.com>"]
 edition.workspace = true
 name = "pci"
+rust-version.workspace = true
 version = "0.1.0"
 
 [features]

--- a/rate_limiter/Cargo.toml
+++ b/rate_limiter/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 edition.workspace = true
 name = "rate_limiter"
+rust-version.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/serial_buffer/Cargo.toml
+++ b/serial_buffer/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Cloud Hypervisor Authors"]
 edition.workspace = true
 name = "serial_buffer"
+rust-version.workspace = true
 version = "0.1.0"
 
 [lints]

--- a/test_infra/Cargo.toml
+++ b/test_infra/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Cloud Hypervisor Authors"]
 edition.workspace = true
 name = "test_infra"
+rust-version.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/tpm/Cargo.toml
+++ b/tpm/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Microsoft Authors"]
 edition = "2021"
 license = "Apache-2.0"
 name = "tpm"
+rust-version.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Cloud Hypervisor Authors"]
 edition.workspace = true
 name = "tracer"
+rust-version.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Cloud Hypervisor Authors"]
 edition.workspace = true
 name = "virtio-devices"
+rust-version.workspace = true
 version = "0.1.0"
 
 [features]

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Chromium OS Authors"]
 edition.workspace = true
 name = "vm-allocator"
+rust-version.workspace = true
 version = "0.1.0"
 
 [features]

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Cloud Hypervisor Authors"]
 edition.workspace = true
 name = "vm-device"
+rust-version.workspace = true
 version = "0.1.0"
 
 [features]

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Cloud Hypervisor Authors"]
 edition.workspace = true
 name = "vm-migration"
+rust-version.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Cloud Hypervisor Authors"]
 edition.workspace = true
 name = "vm-virtio"
+rust-version.workspace = true
 version = "0.1.0"
 
 [features]

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Cloud Hypervisor Authors"]
 edition.workspace = true
 name = "vmm"
+rust-version.workspace = true
 version = "0.1.0"
 
 [features]


### PR DESCRIPTION
Moves the MSRV requirement to the workspace and expands it to all cloud-hypervisor dependencies and dev-dependencies. This improves discoverability for new contributors working on crates other than the cloud-hypervisor itself and creates consistency regarding the MSRV of cloud-hypervisor dependencies.
Functionally, this doesn't change anything for dependencies of the cloud-hypervisor crate as the MSRV requirement is already enforced by CI when building the cloud-hypervisor with the MSRV versioned compiler.

## Open questions

Should the MSRV be applied to all crates in the workspace irrespective of whether they are a dependency of cloud-hypervisor?