### PR TITLE
vmm: remove nested virtualization check for arm64/riscv64

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -717,14 +717,6 @@ impl CpusConfig {
             .map_err(Error::ParseCpus)?
             .is_none_or(|toggle| toggle.0);
 
-        // Nested virtualization is always turned on for aarch64 and riscv64
-        // TODO: revisit this when nested support can be turned of on these architectures
-        #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-        if !nested {
-            return Err(Error::ParseCpus(OptionParserError::InvalidValue(
-                "nested=off is not supported on aarch64 and riscv64 architectures".to_string(),
-            )));
-        }
         let core_scheduling = parser
             .convert("core_scheduling")
             .map_err(Error::ParseCpus)?


### PR DESCRIPTION
Remove the architecture check that prevented nested virtualization control on arm64 and riscv64. This allows nested virtualization to be disabled where supported, particularly when using MSHV.

Note that on arm64 disabling nested virtualization may not fully disable the capability depending on the underlying platform. Use of this functionality is left to the user's discretion.