### PR TITLE
tests: extend timeout for CVM tests

### DIFF
--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -76,7 +76,7 @@ pub struct GuestNetworkConfig {
 pub const DEFAULT_TCP_LISTENER_MESSAGE: &str = "booted";
 pub const DEFAULT_TCP_LISTENER_PORT: u16 = 8000;
 pub const DEFAULT_TCP_LISTENER_TIMEOUT: u32 = 120;
-pub const DEFAULT_CVM_TCP_LISTENER_TIMEOUT: u32 = 120;
+pub const DEFAULT_CVM_TCP_LISTENER_TIMEOUT: u32 = 140;
 
 #[derive(Error, Debug)]
 pub enum WaitForBootError {


### PR DESCRIPTION
Confidential VMs require additional time during boot to load the IGVM image, complete page measurements, and perform Reverse Map Table (RMP) validation. In addition, PSP latency can further delay the boot process. Extend the test timeout to accommodate these additional initialization steps.