### PR TITLE
vmm: migration: add user-configurable downtime and timeout

### DIFF
--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -16,7 +16,9 @@ use api_client::{
     Error as ApiClientError, simple_api_command, simple_api_command_with_fds,
     simple_api_full_command,
 };
-use clap::{Arg, ArgAction, ArgMatches, Command};
+#[cfg(feature = "dbus_api")]
+use clap::ArgAction;
+use clap::{Arg, ArgMatches, Command};
 use log::error;
 use option_parser::{ByteSized, ByteSizedParseError};
 use thiserror::Error;
@@ -69,6 +71,8 @@ enum Error {
     ReadingFile(#[source] std::io::Error),
     #[error("Invalid disk size")]
     InvalidDiskSize(#[source] ByteSizedParseError),
+    #[error("Error parsing send migration configuration")]
+    SendMigrationConfig(#[from] vmm::api::VmSendMigrationParseError),
 }
 
 enum TargetApi<'a> {
@@ -519,11 +523,7 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                     .unwrap()
                     .get_one::<String>("send_migration_config")
                     .unwrap(),
-                matches
-                    .subcommand_matches("send-migration")
-                    .unwrap()
-                    .get_flag("send_migration_local"),
-            );
+            )?;
             simple_api_command(socket, "PUT", "send-migration", Some(&send_migration_data))
                 .map_err(Error::HttpApiClient)
         }
@@ -743,11 +743,7 @@ fn dbus_api_do_command(matches: &ArgMatches, proxy: &DBusApi1ProxyBlocking<'_>) 
                     .unwrap()
                     .get_one::<String>("send_migration_config")
                     .unwrap(),
-                matches
-                    .subcommand_matches("send-migration")
-                    .unwrap()
-                    .get_flag("send_migration_local"),
-            );
+            )?;
             proxy.api_vm_send_migration(&send_migration_data)
         }
         Some("receive-migration") => {
@@ -953,13 +949,11 @@ fn receive_migration_data(url: &str) -> String {
     serde_json::to_string(&receive_migration_data).unwrap()
 }
 
-fn send_migration_data(url: &str, local: bool) -> String {
-    let send_migration_data = vmm::api::VmSendMigrationData {
-        destination_url: url.to_owned(),
-        local,
-    };
-
-    serde_json::to_string(&send_migration_data).unwrap()
+fn send_migration_data(config: &str) -> Result<String, Error> {
+    let send_migration_data =
+        vmm::api::VmSendMigrationData::parse(config).map_err(Error::SendMigrationConfig)?;
+    let send_migration_config = serde_json::to_string(&send_migration_data).unwrap();
+    Ok(send_migration_config)
 }
 
 fn create_data(path: &str) -> Result<String, Error> {
@@ -1141,13 +1135,7 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
             .arg(
                 Arg::new("send_migration_config")
                     .index(1)
-                    .help("<destination_url>"),
-            )
-            .arg(
-                Arg::new("send_migration_local")
-                    .long("local")
-                    .num_args(0)
-                    .action(ArgAction::SetTrue),
+                    .help(vmm::api::VmSendMigrationData::SYNTAX),
             ),
         Command::new("shutdown").about("Shutdown the VM"),
         Command::new("shutdown-vmm").about("Shutdown the VMM"),

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -9891,16 +9891,15 @@ mod live_migration {
         thread::sleep(std::time::Duration::new(1, 0));
         // Start to send migration from the source VM
 
-        let mut args = [
+        let args = [
             format!("--api-socket={}", &src_api_socket),
             "send-migration".to_string(),
-            format! {"unix:{migration_socket}"},
+            format!(
+                "destination_url=unix:{migration_socket},local={}",
+                if local { "on" } else { "off" }
+            ),
         ]
         .to_vec();
-
-        if local {
-            args.insert(2, "--local".to_string());
-        }
 
         let mut send_migration = Command::new(clh_command("ch-remote"))
             .args(&args)
@@ -11066,7 +11065,7 @@ mod live_migration {
             .args([
                 &format!("--api-socket={src_api_socket}"),
                 "send-migration",
-                &format!("tcp:{host_ip}:{migration_port}"),
+                &format!("destination_url=tcp:{host_ip}:{migration_port}"),
             ])
             .stdin(Stdio::null())
             .stderr(Stdio::piped())

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -10026,9 +10026,9 @@ mod live_migration {
         );
 
         let memory_param: &[&str] = if local {
-            &["--memory", "size=4G,shared=on"]
+            &["--memory", "size=1500M,shared=on"]
         } else {
-            &["--memory", "size=4G"]
+            &["--memory", "size=1500M"]
         };
 
         let boot_vcpus = 2;
@@ -10084,7 +10084,7 @@ mod live_migration {
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
 
             // Check the guest RAM
-            assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+            assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
 
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
@@ -10151,7 +10151,7 @@ mod live_migration {
         let r = std::panic::catch_unwind(|| {
             // Perform same checks to validate VM has been properly migrated
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
-            assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+            assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
 
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
         });
@@ -10616,9 +10616,9 @@ mod live_migration {
         );
 
         let memory_param: &[&str] = if local {
-            &["--memory", "size=4G,shared=on"]
+            &["--memory", "size=1500M,shared=on"]
         } else {
-            &["--memory", "size=4G"]
+            &["--memory", "size=1500M"]
         };
 
         let boot_vcpus = 2;
@@ -10674,7 +10674,7 @@ mod live_migration {
             // Check the number of vCPUs
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
             // Check the guest RAM
-            assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+            assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
             // Check the guest virtio-devices, e.g. block, rng, console, and net
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
             // x86_64: Following what's done in the `test_snapshot_restore`, we need
@@ -10759,7 +10759,7 @@ mod live_migration {
         let r = std::panic::catch_unwind(|| {
             // Perform same checks to validate VM has been properly migrated
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
-            assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+            assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
 
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
 
@@ -10934,7 +10934,7 @@ mod live_migration {
                 "--cpus",
                 format!("boot={boot_vcpus},max={max_vcpus}").as_str(),
             ])
-            .args(["--memory", "size=4G,shared=on"])
+            .args(["--memory", "size=1500M,shared=on"])
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .default_disks()
@@ -10966,7 +10966,7 @@ mod live_migration {
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
 
             // Check the guest RAM
-            assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+            assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
 
             // Check Landlock is enabled by hot-plugging a disk.
             assert!(!remote_command(
@@ -11016,7 +11016,7 @@ mod live_migration {
         let r = std::panic::catch_unwind(|| {
             // Perform same checks to validate VM has been properly migrated
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
-            assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+            assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
         });
 
         // Check Landlock is enabled on destination VM by hot-plugging a disk.
@@ -11128,7 +11128,7 @@ mod live_migration {
             "id={},tap=,mac={},ip={},mask=255.255.255.128",
             net_id, guest.network.guest_mac0, guest.network.host_ip0
         );
-        let memory_param: &[&str] = &["--memory", "size=4G,shared=on"];
+        let memory_param: &[&str] = &["--memory", "size=1500M,shared=on"];
         let boot_vcpus = 2;
         let max_vcpus = 4;
         let pmem_temp_file = TempFile::new().unwrap();
@@ -11178,7 +11178,7 @@ mod live_migration {
             guest.wait_vm_boot().unwrap();
             // Ensure the source VM is running normally
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
-            assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+            assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
 
             // On x86_64 architecture, remove and re-add the virtio-net device
@@ -11230,7 +11230,7 @@ mod live_migration {
         let r = std::panic::catch_unwind(|| {
             // Perform the same checks to ensure the VM has migrated correctly
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
-            assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
+            assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
         });
 
@@ -11255,7 +11255,7 @@ mod live_migration {
             "id={},tap=,mac={},ip={},mask=255.255.255.128",
             net_id, guest.network.guest_mac0, guest.network.host_ip0
         );
-        let memory_param: &[&str] = &["--memory", "size=2G,shared=on"];
+        let memory_param: &[&str] = &["--memory", "size=1500M,shared=on"];
         let boot_vcpus = 2;
 
         let src_vm_path = clh_command("cloud-hypervisor");
@@ -11284,12 +11284,11 @@ mod live_migration {
             guest.wait_vm_boot().unwrap();
 
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
-            assert!(guest.get_total_memory().unwrap_or_default() > 2_000_000);
 
             // Start a memory stressor in the background to keep pages dirty,
             // ensuring the precopy loop cannot converge within the 1s timeout.
             guest
-                .ssh_command("nohup stress --vm 1 --vm-bytes 1G --vm-keep &>/dev/null &")
+                .ssh_command("nohup stress --vm 2 --vm-bytes 200M --vm-keep &>/dev/null &")
                 .unwrap();
             // Give stress a moment to actually start dirtying memory
             thread::sleep(Duration::from_secs(3));
@@ -11367,7 +11366,6 @@ mod live_migration {
 
                     // Confirm the source VM is still responsive over SSH
                     assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
-                    assert!(guest.get_total_memory().unwrap_or_default() >= 2_000_000);
                 }
                 TimeoutStrategy::Ignore => {
                     // With Ignore strategy the send must succeed despite the timeout
@@ -11392,7 +11390,6 @@ mod live_migration {
 
                     // Confirm the VM is still responsive over SSH on the new host
                     assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
-                    assert!(guest.get_total_memory().unwrap_or_default() >= 2_000_000);
                 }
             }
         }));

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -9868,6 +9868,8 @@ mod vfio {
 }
 
 mod live_migration {
+    use vmm::api::TimeoutStrategy;
+
     use crate::*;
 
     pub fn start_live_migration(
@@ -11244,7 +11246,168 @@ mod live_migration {
         handle_child_output(r, &dest_output);
     }
 
+    fn _test_live_migration_tcp_timeout(timeout_strategy: TimeoutStrategy) {
+        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+        let kernel_path = direct_kernel_boot_path();
+        let net_id = "net1337";
+        let net_params = format!(
+            "id={},tap=,mac={},ip={},mask=255.255.255.128",
+            net_id, guest.network.guest_mac0, guest.network.host_ip0
+        );
+        let memory_param: &[&str] = &["--memory", "size=2G,shared=on"];
+        let boot_vcpus = 2;
+
+        let src_vm_path = clh_command("cloud-hypervisor");
+        let src_api_socket = temp_api_path(&guest.tmp_dir);
+        let mut src_vm_cmd = GuestCommand::new_with_binary_path(&guest, &src_vm_path);
+        src_vm_cmd
+            .args(["--cpus", format!("boot={boot_vcpus}").as_str()])
+            .args(memory_param)
+            .args(["--kernel", kernel_path.to_str().unwrap()])
+            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_disks()
+            .args(["--net", net_params.as_str()])
+            .args(["--api-socket", &src_api_socket])
+            .capture_output();
+        let mut src_child = src_vm_cmd.spawn().unwrap();
+
+        let mut dest_api_socket = temp_api_path(&guest.tmp_dir);
+        dest_api_socket.push_str(".dest");
+        let mut dest_child = GuestCommand::new(&guest)
+            .args(["--api-socket", &dest_api_socket])
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            guest.wait_vm_boot().unwrap();
+
+            assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
+            assert!(guest.get_total_memory().unwrap_or_default() > 2_000_000);
+
+            // Start a memory stressor in the background to keep pages dirty,
+            // ensuring the precopy loop cannot converge within the 1s timeout.
+            guest
+                .ssh_command("nohup stress --vm 1 --vm-bytes 1G --vm-keep &>/dev/null &")
+                .unwrap();
+            // Give stress a moment to actually start dirtying memory
+            thread::sleep(Duration::from_secs(3));
+
+            let migration_port = get_available_port();
+            let host_ip = "127.0.0.1";
+
+            let mut receive_migration = Command::new(clh_command("ch-remote"))
+                .args([
+                    &format!("--api-socket={dest_api_socket}"),
+                    "receive-migration",
+                    &format!("tcp:0.0.0.0:{migration_port}"),
+                ])
+                .stdin(Stdio::null())
+                .stderr(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .unwrap();
+
+            thread::sleep(Duration::from_secs(1));
+
+            // Use a tight downtime budget (50ms) combined with a 1s timeout so the
+            // migration cannot converge regardless of strategy.
+            let mut send_migration = Command::new(clh_command("ch-remote"))
+                .args([
+                    &format!("--api-socket={src_api_socket}"),
+                    "send-migration",
+                    &format!(
+                        "destination_url=tcp:{host_ip}:{migration_port},downtime_ms=50,timeout_s=1,timeout_strategy={timeout_strategy:?}"
+                    ),
+                ])
+                .stdin(Stdio::null())
+                .stderr(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .unwrap();
+
+            let send_status = send_migration
+                .wait_timeout(Duration::from_secs(60))
+                .unwrap();
+            let receive_status = receive_migration
+                .wait_timeout(Duration::from_secs(60))
+                .unwrap();
+
+            // Clean up receive-migration regardless of its outcome
+            if receive_status.is_none() {
+                let _ = receive_migration.kill();
+            }
+
+            // Kill the stressor now that migration has completed or aborted,
+            // to reduce system load during post-migration checks.
+            let _ = guest.ssh_command("pkill -f 'stress --vm'");
+
+            match timeout_strategy {
+                TimeoutStrategy::Cancel => {
+                    // With cancel strategy the send must fail and the source VM
+                    // must keep running.
+                    let send_failed = match send_status {
+                        Some(status) => !status.success(),
+                        None => {
+                            let _ = send_migration.kill();
+                            false
+                        }
+                    };
+                    assert!(
+                        send_failed,
+                        "send-migration should have failed due to 1s timeout with cancel strategy"
+                    );
+
+                    thread::sleep(Duration::from_secs(2));
+                    assert!(
+                        src_child.try_wait().unwrap().is_none(),
+                        "Source VM should still be running after a cancelled migration"
+                    );
+
+                    // Confirm the source VM is still responsive over SSH
+                    assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
+                    assert!(guest.get_total_memory().unwrap_or_default() >= 2_000_000);
+                }
+                TimeoutStrategy::Ignore => {
+                    // With Ignore strategy the send must succeed despite the timeout
+                    // being reached, and the source VM must have terminated.
+                    let send_succeeded = match send_status {
+                        Some(status) => status.success(),
+                        None => {
+                            let _ = send_migration.kill();
+                            false
+                        }
+                    };
+                    assert!(
+                        send_succeeded,
+                        "send-migration should have succeeded with timeout_strategy=ignore"
+                    );
+
+                    thread::sleep(Duration::from_secs(3));
+                    assert!(
+                        src_child.try_wait().unwrap().is_some(),
+                        "Source VM should have terminated after a forced migration"
+                    );
+
+                    // Confirm the VM is still responsive over SSH on the new host
+                    assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
+                    assert!(guest.get_total_memory().unwrap_or_default() >= 2_000_000);
+                }
+            }
+        }));
+
+        let _ = src_child.kill();
+        let src_output = src_child.wait_with_output().unwrap();
+        let _ = dest_child.kill();
+        let _dest_output = dest_child.wait_with_output().unwrap();
+
+        handle_child_output(r, &src_output);
+    }
+
     mod live_migration_parallel {
+        use vmm::api::TimeoutStrategy;
+
         use super::*;
         #[test]
         fn test_live_migration_basic() {
@@ -11259,6 +11422,16 @@ mod live_migration {
         #[test]
         fn test_live_migration_tcp() {
             _test_live_migration_tcp();
+        }
+
+        #[test]
+        fn test_live_migration_tcp_timeout_cancel() {
+            _test_live_migration_tcp_timeout(TimeoutStrategy::Cancel);
+        }
+
+        #[test]
+        fn test_live_migration_tcp_timeout_ignore() {
+            _test_live_migration_tcp_timeout(TimeoutStrategy::Ignore);
         }
 
         #[test]

--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -3,8 +3,9 @@
 This document gives examples of how to use the live migration support
 in Cloud Hypervisor:
 
-1. local migration - migrating a VM from one Cloud Hypervisor instance to another on the same machine;
-1. remote migration - migrating a VM between two machines;
+1. **Local Migration**: Migrating a VM from one Cloud Hypervisor instance to another on the same machine; also called
+  UNIX socket migration.
+1. **Remote Migration** (TCP Migration): migrating a VM between two TCP/IP hosts.
 
 > :warning: These examples place sockets in /tmp. This is done for
 > simplicity and should not be done in production.
@@ -28,7 +29,8 @@ Launch the destination VM from the same directory (on the host machine):
 $ target/release/cloud-hypervisor --api-socket=/tmp/api2
 ```
 
-Get ready for receiving migration for the destination VM (on the host machine):
+Get ready for receiving migration for the destination VM (on the host
+machine):
 
 ```console
 $ target/release/ch-remote --api-socket=/tmp/api2 receive-migration unix:/tmp/sock
@@ -37,14 +39,16 @@ $ target/release/ch-remote --api-socket=/tmp/api2 receive-migration unix:/tmp/so
 Start to send migration for the source VM (on the host machine):
 
 ```console
-$ target/release/ch-remote --api-socket=/tmp/api1 send-migration --local unix:/tmp/sock
+$ target/release/ch-remote --api-socket=/tmp/api1 send-migration destination_url=unix:/tmp/sock,local=true
 ```
 
 When the above commands completed, the source VM should be successfully
 migrated to the destination VM. Now the destination VM is running while
 the source VM is terminated gracefully.
 
-## Remote Migration
+## Remote Migration (TCP Migration)
+
+_Hint: For developing purposes, same-host TCP migrations are also supported._
 
 In this example, we will migrate a VM from one machine (`src`) to
 another (`dst`) across the network. To keep it simple, we will use a
@@ -171,7 +175,13 @@ After a few seconds the VM should be up and you can interact with it.
 Initiate the Migration over TCP:
 
 ```console
-src $ ch-remote --api-socket=/tmp/api send-migration  tcp:{dst}:{port}
+src $ ch-remote --api-socket=/tmp/api send-migration destination_url=tcp:{dst}:{port}
+```
+
+With migration parameters:
+
+```console
+src $ ch-remote --api-socket=/tmp/api send-migration destination_url=tcp:{dst}:{port},downtime_ms=200,timeout_s=3600,timeout_strategy=cancel
 ```
 
 > Replace {dst}:{port} with the actual IP address and port of your destination host.
@@ -180,3 +190,20 @@ After completing the above commands, the source VM will be migrated to
 the destination host and continue running there. The source VM instance
 will terminate normally. All ongoing processes and connections within
 the VM should remain intact after the migration.
+
+#### Migration Parameters
+
+Cloud Hypervisor supports additional parameters to control the
+migration process. Via the API or `ch-remote`, you may specify:
+
+- `downtime_ms <milliseconds>`: \
+  The maximum downtime the migration aims for, in milliseconds.
+  Defaults to `300ms`.
+- `timeout_s <seconds>`: \
+  The timeout for the migration (maximum total duration), in seconds.
+  Defaults to `3600s` (one hour).
+- `timeout_strategy <strategy>` (`[cancel, ignore]`): \
+  The strategy to apply when the migration timeout is reached.
+  Cancel will abort the migration and keep the VM running on the source.
+  Ignore will proceed with the migration regardless of the downtime requirement.
+  Defaults to `cancel`.

--- a/vm-migration/src/context.rs
+++ b/vm-migration/src/context.rs
@@ -40,9 +40,9 @@ pub struct MemoryMigrationContext {
     ///
     /// Please note that this ignores any additional migration overhead and
     /// only looks at the memory transfer itself.
-    estimated_downtime: Option<Duration>,
+    pub estimated_downtime: Option<Duration>,
     /// Begin of the memory migration.
-    migration_begin: Instant,
+    pub migration_begin: Instant,
     /// Duration of the memory migration.
     ///
     /// This is only `None` until the last iteration is finished.

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -34,7 +34,10 @@ pub mod dbus;
 pub mod http;
 
 use std::io;
+use std::num::NonZeroU64;
+use std::str::FromStr;
 use std::sync::mpsc::{RecvError, SendError, Sender, channel};
+use std::time::Duration;
 
 use log::info;
 use micro_http::Body;
@@ -267,27 +270,83 @@ pub struct VmReceiveMigrationData {
     pub receiver_url: String,
 }
 
+#[derive(Copy, Clone, Default, Deserialize, Serialize, Debug, PartialEq, Eq)]
+/// The migration timeout strategy.
+///
+/// This strategy describes the behavior of the migration when the target
+/// downtime can't be reached in the given timeout.
+pub enum TimeoutStrategy {
+    #[default]
+    /// Cancel the migration and keep the VM running on the source.
+    Cancel,
+    /// Ignore the timeout and migrate anyway.
+    Ignore,
+}
+
+impl FromStr for TimeoutStrategy {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "cancel" => Ok(TimeoutStrategy::Cancel),
+            "ignore" => Ok(TimeoutStrategy::Ignore),
+            _ => Err(format!("Invalid timeout strategy: {s}")),
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 #[error("Error parsing send migration parameters")]
 pub struct VmSendMigrationParseError(#[source] OptionParserError);
 
 /// Configuration for an outgoing migration.
 #[derive(Clone, Deserialize, Serialize, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct VmSendMigrationData {
     /// URL to migrate the VM to
     pub destination_url: String,
     /// Send memory across socket without copying
     #[serde(default)]
     pub local: bool,
+    /// The maximum downtime the migration aims for.
+    ///
+    /// Usually, on the order of a few hundred milliseconds.
+    #[serde(default = "VmSendMigrationData::default_downtime_ms")]
+    downtime_ms: NonZeroU64,
+    /// The timeout for the migration, i.e., the maximum duration.
+    #[serde(default = "VmSendMigrationData::default_timeout_s")]
+    timeout_s: NonZeroU64,
+    /// The timeout strategy for the migration.
+    #[serde(default)]
+    pub timeout_strategy: TimeoutStrategy,
 }
 
 impl VmSendMigrationData {
     pub const SYNTAX: &'static str = "VM send migration parameters \
-        \"destination_url=<url>[,local=on|off]\"";
+        \"destination_url=<url>[,local=on|off,\
+        downtime_ms=<milliseconds>,timeout_s=<seconds>,\
+        timeout_strategy=cancel|ignore]\"";
+
+    // Same as QEMU.
+    pub const DEFAULT_DOWNTIME: Duration = Duration::from_millis(300);
+    pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60 * 60 /* one hour */);
+
+    fn default_downtime_ms() -> NonZeroU64 {
+        let ms_u64 = u64::try_from(Self::DEFAULT_DOWNTIME.as_millis()).unwrap();
+        NonZeroU64::new(ms_u64).unwrap()
+    }
+
+    fn default_timeout_s() -> NonZeroU64 {
+        NonZeroU64::new(Self::DEFAULT_TIMEOUT.as_secs()).unwrap()
+    }
 
     pub fn parse(migration: &str) -> Result<Self, VmSendMigrationParseError> {
         let mut parser = OptionParser::new();
-        parser.add("destination_url").add("local");
+        parser
+            .add("destination_url")
+            .add("local")
+            .add("downtime_ms")
+            .add("timeout_s")
+            .add("timeout_strategy");
         parser.parse(migration).map_err(VmSendMigrationParseError)?;
 
         let destination_url = parser.get("destination_url").ok_or_else(|| {
@@ -300,11 +359,48 @@ impl VmSendMigrationData {
             .map_err(VmSendMigrationParseError)?
             .unwrap_or(Toggle(false))
             .0;
+        let downtime_ms = match parser
+            .convert::<u64>("downtime_ms")
+            .map_err(VmSendMigrationParseError)?
+        {
+            Some(v) => NonZeroU64::new(v).ok_or_else(|| {
+                VmSendMigrationParseError(OptionParserError::InvalidValue(
+                    "downtime_ms must be non-zero".to_string(),
+                ))
+            })?,
+            None => Self::default_downtime_ms(),
+        };
+        let timeout_s = match parser
+            .convert::<u64>("timeout_s")
+            .map_err(VmSendMigrationParseError)?
+        {
+            Some(v) => NonZeroU64::new(v).ok_or_else(|| {
+                VmSendMigrationParseError(OptionParserError::InvalidValue(
+                    "timeout_s must be non-zero".to_string(),
+                ))
+            })?,
+            None => Self::default_timeout_s(),
+        };
+        let timeout_strategy = parser
+            .convert("timeout_strategy")
+            .map_err(VmSendMigrationParseError)?
+            .unwrap_or_default();
 
         Ok(Self {
             destination_url,
             local,
+            downtime_ms,
+            timeout_s,
+            timeout_strategy,
         })
+    }
+
+    pub fn downtime(&self) -> Duration {
+        Duration::from_millis(self.downtime_ms.get())
+    }
+
+    pub fn timeout(&self) -> Duration {
+        Duration::from_secs(self.timeout_s.get())
     }
 }
 
@@ -1582,15 +1678,76 @@ mod unit_tests {
     #[test]
     fn test_vm_send_migration_data_parse() {
         // Fully specified
-        let data = VmSendMigrationData::parse("destination_url=tcp://192.168.1.1:8080,local=on")
-            .expect("valid migration string should parse");
+        let data = VmSendMigrationData::parse(
+            "destination_url=tcp://192.168.1.1:8080,local=on,downtime_ms=200,timeout_s=3600,timeout_strategy=cancel"
+        ).expect("valid migration string should parse");
         assert_eq!(data.destination_url, "tcp://192.168.1.1:8080");
         assert!(data.local);
+        assert_eq!(data.downtime_ms.get(), 200);
+        assert_eq!(data.timeout_s.get(), 3600);
+        assert_eq!(data.timeout_strategy, TimeoutStrategy::Cancel);
+
+        // Defaults applied when optional fields are omitted
+        let data = VmSendMigrationData::parse("destination_url=tcp://192.168.1.1:8080")
+            .expect("minimal migration string should parse");
+        assert_eq!(data.destination_url, "tcp://192.168.1.1:8080");
+        assert!(!data.local);
+        assert_eq!(data.downtime_ms, VmSendMigrationData::default_downtime_ms());
+        assert_eq!(data.timeout_s, VmSendMigrationData::default_timeout_s());
+        assert_eq!(data.timeout_strategy, TimeoutStrategy::default());
+
+        // Missing destination_url is an error
+        VmSendMigrationData::parse("local=on,downtime_ms=200").unwrap_err();
+
+        // Zero downtime_ms is rejected
+        let _data =
+            VmSendMigrationData::parse("destination_url=tcp://192.168.1.1:8080,downtime_ms=0")
+                .expect_err("zero downtime_ms should be rejected");
+
+        // Zero timeout_s is rejected
+        let _data = VmSendMigrationData::parse("destination_url=unix:/tmp/sock,timeout_s=0")
+            .expect_err("zero timeout_s should be rejected");
 
         // Unknown option is an error
         VmSendMigrationData::parse("destination_url=unix:/tmp/sock,unknown_field=foo").unwrap_err();
 
         // Invalid toggle value is an error
         VmSendMigrationData::parse("destination_url=unix:/tmp/sock,local=yes").unwrap_err();
+
+        // Timeout strategy
+        let _data = VmSendMigrationData::parse(
+            "destination_url=tcp://192.168.1.1:8080,timeout_strategy=invalid",
+        )
+        .expect_err("zero downtime_ms should be rejected");
+
+        // Happy path with some defaults
+        let data =
+            VmSendMigrationData::parse("destination_url=tcp://192.168.1.1:8080,downtime_ms=150")
+                .unwrap();
+        assert_eq!(
+            data,
+            VmSendMigrationData {
+                destination_url: "tcp://192.168.1.1:8080".to_string(),
+                local: false,
+                downtime_ms: NonZeroU64::new(150).unwrap(),
+                timeout_s: VmSendMigrationData::default_timeout_s(),
+                timeout_strategy: Default::default(),
+            }
+        );
+
+        // Happy path, fully specified
+        let data =
+            VmSendMigrationData::parse("destination_url=tcp://192.168.1.1:8080,downtime_ms=150,timeout_s=900,timeout_strategy=ignore")
+                .unwrap();
+        assert_eq!(
+            data,
+            VmSendMigrationData {
+                destination_url: "tcp://192.168.1.1:8080".to_string(),
+                local: false,
+                downtime_ms: NonZeroU64::new(150).unwrap(),
+                timeout_s: NonZeroU64::new(900).unwrap(),
+                timeout_strategy: TimeoutStrategy::Ignore,
+            }
+        );
     }
 }

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -38,6 +38,7 @@ use std::sync::mpsc::{RecvError, SendError, Sender, channel};
 
 use log::info;
 use micro_http::Body;
+use option_parser::{OptionParser, OptionParserError, Toggle};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vm_migration::MigratableError;
@@ -266,13 +267,45 @@ pub struct VmReceiveMigrationData {
     pub receiver_url: String,
 }
 
-#[derive(Clone, Deserialize, Serialize, Default, Debug)]
+#[derive(Debug, Error)]
+#[error("Error parsing send migration parameters")]
+pub struct VmSendMigrationParseError(#[source] OptionParserError);
+
+/// Configuration for an outgoing migration.
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct VmSendMigrationData {
     /// URL to migrate the VM to
     pub destination_url: String,
     /// Send memory across socket without copying
     #[serde(default)]
     pub local: bool,
+}
+
+impl VmSendMigrationData {
+    pub const SYNTAX: &'static str = "VM send migration parameters \
+        \"destination_url=<url>[,local=on|off]\"";
+
+    pub fn parse(migration: &str) -> Result<Self, VmSendMigrationParseError> {
+        let mut parser = OptionParser::new();
+        parser.add("destination_url").add("local");
+        parser.parse(migration).map_err(VmSendMigrationParseError)?;
+
+        let destination_url = parser.get("destination_url").ok_or_else(|| {
+            VmSendMigrationParseError(OptionParserError::InvalidSyntax(
+                "destination_url is required".to_string(),
+            ))
+        })?;
+        let local = parser
+            .convert::<Toggle>("local")
+            .map_err(VmSendMigrationParseError)?
+            .unwrap_or(Toggle(false))
+            .0;
+
+        Ok(Self {
+            destination_url,
+            local,
+        })
+    }
 }
 
 pub enum ApiResponsePayload {
@@ -1539,5 +1572,25 @@ impl ApiAction for VmNmi {
         data: Self::RequestBody,
     ) -> ApiResult<Self::ResponseBody> {
         get_response_body(self, api_evt, api_sender, data)
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn test_vm_send_migration_data_parse() {
+        // Fully specified
+        let data = VmSendMigrationData::parse("destination_url=tcp://192.168.1.1:8080,local=on")
+            .expect("valid migration string should parse");
+        assert_eq!(data.destination_url, "tcp://192.168.1.1:8080");
+        assert!(data.local);
+
+        // Unknown option is an error
+        VmSendMigrationData::parse("destination_url=unix:/tmp/sock,unknown_field=foo").unwrap_err();
+
+        // Invalid toggle value is an error
+        VmSendMigrationData::parse("destination_url=unix:/tmp/sock,local=yes").unwrap_err();
     }
 }

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1369,6 +1369,15 @@ components:
         receiver_url:
           type: string
 
+    TimeoutStrategy:
+      type: string
+      enum: ["Cancel", "Ignore"]
+      default: "Cancel"
+      description: >
+        The strategy to apply when the migration timeout is reached.
+        Cancel will abort the migration and keep the VM running on the source.
+        Ignore will proceed with the migration regardless of the downtime requirement.
+
     SendMigrationData:
       required:
         - destination_url
@@ -1378,6 +1387,24 @@ components:
           type: string
         local:
           type: boolean
+        downtime_ms:
+          type: integer
+          format: int64
+          minimum: 1
+          default: 300
+          description: >
+            The maximum downtime the migration aims for, in milliseconds.
+            Defaults to 300ms.
+        timeout_s:
+          type: integer
+          format: int64
+          minimum: 1
+          default: 3600
+          description: >
+            The timeout for the migration (maximum total duration), in seconds.
+            Defaults to 3600s (one hour).
+        timeout_strategy:
+          $ref: "#/components/schemas/TimeoutStrategy"
 
     VmAddUserDevice:
       required:

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -13,6 +13,7 @@ use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, RecvError, SendError, Sender};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 #[cfg(not(target_arch = "riscv64"))]
 use std::time::Instant;
 use std::{io, result, thread};
@@ -48,8 +49,8 @@ use vmm_sys_util::signal::unblock_signal;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
 use crate::api::{
-    ApiRequest, ApiResponse, RequestHandler, VmInfoResponse, VmReceiveMigrationData,
-    VmSendMigrationData, VmmPingResponse,
+    ApiRequest, ApiResponse, RequestHandler, TimeoutStrategy, VmInfoResponse,
+    VmReceiveMigrationData, VmSendMigrationData, VmmPingResponse,
 };
 use crate::config::{MemoryRestoreMode, RestoreConfig, add_to_config};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
@@ -1258,7 +1259,7 @@ impl Vmm {
         vm: &mut Vm,
         socket: &mut SocketStream,
         ctx: &mut MemoryMigrationContext,
-        is_converged: impl Fn(&MemoryMigrationContext) -> bool,
+        is_converged: impl Fn(&MemoryMigrationContext) -> result::Result<bool, MigratableError>,
     ) -> result::Result<MemoryRangeTable /* remaining */, MigratableError> {
         loop {
             let iteration_begin = Instant::now();
@@ -1271,7 +1272,7 @@ impl Vmm {
             };
 
             ctx.update_metrics_before_transfer(iteration_begin, &iteration_table);
-            if is_converged(ctx) {
+            if is_converged(ctx)? {
                 debug!("Precopy converged: {ctx}");
                 break Ok(iteration_table);
             }
@@ -1299,6 +1300,95 @@ impl Vmm {
         }
     }
 
+    /// Checks whether the precopy memory migration has converged and it is safe
+    /// to proceed to the final (paused) memory iteration.
+    ///
+    /// Once this returns, the VM is expected to stop as soon as possible.
+    ///
+    /// Convergence is reached when any of the following criteria is met:
+    ///
+    /// 1. **No dirty pages remain** – the current iteration would transfer zero
+    ///    bytes.
+    /// 2. **Downtime budget is met** – the estimated downtime for the final
+    ///    (paused) iteration is within the caller-specified
+    ///    [`VmSendMigrationData::downtime`] budget.
+    /// 3. **Timeout** – the precopy phase has been running for at least
+    ///    [`VmSendMigrationData::timeout`]. The outcome depends on
+    ///    [`VmSendMigrationData::timeout_strategy`]:
+    ///    - [`TimeoutStrategy::Cancel`] – returns
+    ///    - [`TimeoutStrategy::Ignore`] – the migration completes despite not
+    ///      meeting the downtime budget.
+    ///      [`MigratableError::MigrateSend`] so the caller can abort the
+    ///      migration cleanly.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(true)` – convergence criterion met; the caller should stop precopy
+    ///   iterations.
+    /// * `Ok(false)` – not yet converged; the caller should run another
+    ///   dirty-page iteration.
+    /// * `Err(_)` – the timeout was reached and [`TimeoutStrategy::Cancel`]
+    ///   is in effect.
+    fn is_precopy_converged(
+        ctx: &MemoryMigrationContext,
+        send_data_migration: &VmSendMigrationData,
+    ) -> result::Result<bool, MigratableError> {
+        if ctx.current_iteration_total_bytes == 0 {
+            debug!("Precopy: No more memory to transfer");
+            return Ok(true);
+        }
+
+        // We currently ignore the time required to transfer the final
+        // VM state (device state and vCPUs) and the time needed on the
+        // receiver to create the VM and initialize its data structures
+        // before execution can resume.
+        //
+        // Manual testing showed that migrating an idle VM on a modern
+        // AMD CPU (CHV release build) adds ~5 ms of overhead when
+        // scaling from 1 to 200 vCPUs. Given this small cost, we
+        // deliberately avoid additional heuristics to estimate the
+        // downtime more precisely - for now. Instead, we approximate
+        // the downtime just by the transfer time of the final memory
+        // delta.
+        if let Some(memory_downtime) = ctx.estimated_downtime
+            && memory_downtime <= send_data_migration.downtime()
+        {
+            debug!(
+                "Precopy: Target downtime can be met: {}ms <= {}ms",
+                memory_downtime.as_millis(),
+                send_data_migration.downtime().as_millis()
+            );
+            return Ok(true);
+        }
+
+        // We check the beginning of the precopy migration and not the overall migration, and
+        // this is fine: precopy takes the longest and the earlier steps are negligible.
+        if ctx.migration_begin.elapsed() >= send_data_migration.timeout() {
+            return match send_data_migration.timeout_strategy {
+                TimeoutStrategy::Cancel => {
+                    let msg = format!(
+                        "Precopy: Timeout reached: {}s: migration didn't converge in time",
+                        send_data_migration.timeout().as_secs()
+                    );
+                    Err(MigratableError::MigrateSend(anyhow!("{msg}")))
+                }
+                TimeoutStrategy::Ignore => {
+                    info!(
+                        "Precopy: Pausing VM, ignoring target downtime ({}ms) due to timeout ({}s): Estimated downtime: {}ms",
+                        send_data_migration.downtime().as_millis(),
+                        send_data_migration.timeout().as_secs(),
+                        ctx.estimated_downtime
+                            .unwrap_or(Duration::from_secs(0))
+                            .as_millis()
+                    );
+                    Ok(true)
+                }
+            };
+        }
+
+        Ok(false)
+    }
+
     /// Performs the memory migration including multiple iterations.
     ///
     /// This includes:
@@ -1308,19 +1398,18 @@ impl Vmm {
     fn do_memory_migration(
         vm: &mut Vm,
         socket: &mut SocketStream,
-        // Used in next commit
-        _send_data_migration: &VmSendMigrationData,
+        send_data_migration: &VmSendMigrationData,
     ) -> result::Result<(), MigratableError> {
-        const MAX_ITERATIONS: usize = 5;
-
         let mut ctx = MemoryMigrationContext::new();
-        let is_converged = |ctx: &MemoryMigrationContext| {
-            // TODO: Add check for configurable downtime and max migration time #7111
-            ctx.iteration >= MAX_ITERATIONS || ctx.current_iteration_total_bytes == 0
-        };
 
         vm.start_dirty_log()?;
-        let remaining = Self::do_memory_iterations(vm, socket, &mut ctx, is_converged)?;
+        let remaining = Self::do_memory_iterations(
+            vm,
+            socket,
+            &mut ctx,
+            // We bind send_data_migration to the callback
+            |ctx| Self::is_precopy_converged(ctx, send_data_migration),
+        )?;
         vm.pause()?;
 
         // Send last batch of dirty pages: final iteration

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1308,6 +1308,8 @@ impl Vmm {
     fn do_memory_migration(
         vm: &mut Vm,
         socket: &mut SocketStream,
+        // Used in next commit
+        _send_data_migration: &VmSendMigrationData,
     ) -> result::Result<(), MigratableError> {
         const MAX_ITERATIONS: usize = 5;
 
@@ -1424,7 +1426,7 @@ impl Vmm {
             // Now pause VM
             vm.pause()?;
         } else {
-            Self::do_memory_migration(vm, &mut socket)?;
+            Self::do_memory_migration(vm, &mut socket, send_data_migration)?;
         }
 
         // We release the locks early to enable locking them on the destination host.
@@ -2438,8 +2440,12 @@ impl RequestHandler for Vmm {
         send_data_migration: VmSendMigrationData,
     ) -> result::Result<(), MigratableError> {
         info!(
-            "Sending migration: destination_url = {}, local = {}",
-            send_data_migration.destination_url, send_data_migration.local
+            "Sending migration: destination_url={},local={},downtime={}ms,timeout={}s,timeout_strategy={:?}",
+            send_data_migration.destination_url,
+            send_data_migration.local,
+            send_data_migration.downtime().as_millis(),
+            send_data_migration.timeout().as_secs(),
+            send_data_migration.timeout_strategy
         );
 
         if !self


### PR DESCRIPTION
Follow-up of #7799.

This patch adds user-controllable convergence parameters to Cloud Hypervisor's
live migration, replacing the previous hard-coded 5-iteration precopy cap with a
principled, metrics-driven approach.

### What's new

Three new fields are added to `VmSendMigrationData` (API + `ch-remote`):

- `downtime_ms`: maximum acceptable VM downtime (default: 300 ms, matching QEMU)
- `timeout_s`: overall migration time limit (default: 3600 s)
- `timeout_strategy`: action on timeout: `cancel` (abort, keep VM live on source)
  or `force` (proceed despite unmet downtime budget)

The precopy loop now evaluates convergence in order:
- no dirty pages remain
- estimated downtime is within budget
- timeout elapsed:

On timeout, the chosen strategy is applied cleanly, with `cancel` propagating a `MigratableError` up the call stack.

### Breaking change

The `ch-remote send-migration` CLI drops the `--local` flag in favour of a
unified option string, consistent with other `ch-remote` subcommands:
```sh
ch-remote --api-socket=/tmp/api send-migration \
  destination_url=tcp:host:port,downtime_ms=200,timeout_s=3600,timeout_strategy=cancel
```

### Testing

Two new integration tests cover the timeout path under memory pressure
(`stress --vm`), verifying that `cancel` leaves the source VM responsive and
`force` terminates it after a successful forced migration. A specific downtime
test is omitted due to host-load sensitivity; manual testing confirmed
correctness.

Docs and OpenAPI spec updated accordingly.


---

These changes are inspired by [0] but differ significantly in details.

[0] https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7033
