### PR TITLE
virtio-devices: remove incorrect comment

### DIFF
--- a/virtio-devices/src/vhost_user/generic_vhost_user.rs
+++ b/virtio-devices/src/vhost_user/generic_vhost_user.rs
@@ -121,7 +121,7 @@ since the backend only supports {backend_num_queues}\n",
                     );
                     return Err(Error::BadQueueNum);
                 }
-                // Create virtio-vhost-user device configuration.
+
                 (
                     acked_features,
                     // If part of the available features that have been acked, the


### PR DESCRIPTION
This device is not called virtio-vhost-user; that's something else.

I don't think the comment really clarifies anything anyway, so just remove it.

Fixes: 8c618ff5e ("virtio-devices: generic-vhost-user: implement device")