### PR TITLE
virtio-devices: block: Derive discard alignment from topology

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -833,7 +833,7 @@ impl Block {
                 if avail_features & (1u64 << VIRTIO_BLK_F_DISCARD) != 0 {
                     config.max_discard_sectors = u32::MAX;
                     config.max_discard_seg = 1;
-                    config.discard_sector_alignment = 1;
+                    config.discard_sector_alignment = (logical_block_size / SECTOR_SIZE) as u32;
                 }
 
                 if num_queues > 1 {


### PR DESCRIPTION
Set discard_sector_alignment from the logical block size reported by the backend topology instead of hardcoding it to 1 sector. This gives the guest accurate alignment hints so it can avoid sub block discards that the filesystem might silently ignore.

For example, on a 4K block filesystem the alignment is now 8 sectors (4096/512) instead of 1.

For image formats with their own allocation units (QCOW2 clusters, VHD/VHDX block sizes), the ideal alignment would be derived from the format cluster/block size. This is left for a followup that surfaces allocation granularity through DiskTopology.