### PR TITLE
block: Batch drain AIO completions in next_completed_request

### DIFF
--- a/block/src/raw_async_aio.rs
+++ b/block/src/raw_async_aio.rs
@@ -172,18 +172,16 @@ impl AsyncIo for RawFileAsyncAio {
     }
 
     fn next_completed_request(&mut self) -> Option<(u64, i32)> {
-        // Drain synchronous completions first (from punch_hole/write_zeroes).
-        if let Some(completed) = self.completion_list.pop_front() {
-            return Some(completed);
+        if self.completion_list.is_empty() {
+            // Drain pending AIO completions batched into the same queue.
+            let mut events = [aio::IoEvent::default(); 32];
+            let rc = self.ctx.get_events(0, &mut events, None).unwrap();
+            for event in &events[..rc] {
+                self.completion_list
+                    .push_back((event.data, event.res as i32));
+            }
         }
-
-        let mut events: [aio::IoEvent; 1] = [aio::IoEvent::default()];
-        let rc = self.ctx.get_events(0, &mut events, None).unwrap();
-        if rc == 0 {
-            None
-        } else {
-            Some((events[0].data, events[0].res as i32))
-        }
+        self.completion_list.pop_front()
     }
 
     fn punch_hole(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {


### PR DESCRIPTION
Collect up to 32 completions per `io_getevents` call instead of one at a time, buffering them in the existing `VecDeque`. At the default queue depth of 128, this reduces syscalls from 128 to 4 per drain cycle.

The batch size of 32 matches QEMU `DEFAULT_MAX_BATCH`. The stack cost is 1 KB per call (32 x 32 byte `IoEvent`).

### Micro benchmark results

| Test | Before | After (batch=32) | Speedup |
|------|--------|-----------------|---------|
| drain_128 | 61.8 us | 8.2 us | ~8x |
| drain_256 | 160.1 us | 12.6 us | ~13x |