### PR TITLE
virtio-devices: Fix multi-vCPU activation race condition

### DIFF
--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -809,7 +809,9 @@ impl VirtioPciDevice {
     }
 
     fn needs_activation(&self) -> bool {
-        !self.device_activated.load(Ordering::SeqCst) && self.is_driver_ready()
+        !self.device_activated.load(Ordering::SeqCst)
+            && self.is_driver_ready()
+            && self.virtio_interrupt.is_some()
     }
 
     pub fn dma_handler(&self) -> Option<&dyn ExternalDmaMapping> {


### PR DESCRIPTION
Fix a race condition where multiple vCPUs writing to virtio PCI config space could trigger needs_activation() simultaneously. The first vCPU calls prepare_activator() which takes virtio_interrupt, then the second vCPU calls prepare_activator() again, finding virtio_interrupt already taken, causing a panic on unwrap() during activation.

Check virtio_interrupt.is_some() to prevent duplicate activation.