### PR TITLE
Don't rely on specific IOMMU grouping behavior in some tests

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -2128,7 +2128,7 @@ fn vm_state(api_socket: &str) -> String {
 // The last interesting part of this test is that it exercises the network
 // interface attached to the virtual IOMMU since this is the one used to
 // send all commands through SSH.
-fn _test_virtio_iommu(acpi: bool) {
+fn _test_virtio_iommu(_acpi: bool /* not needed on x86_64 */) {
     // Virtio-iommu support is ready in recent kernel (v5.14). But the kernel in
     // Focal image is still old.
     // So if ACPI is enabled on AArch64, we use a modified Focal image in which
@@ -2143,7 +2143,7 @@ fn _test_virtio_iommu(acpi: bool) {
     #[cfg(target_arch = "x86_64")]
     let kernel_path = direct_kernel_boot_path();
     #[cfg(target_arch = "aarch64")]
-    let kernel_path = if acpi {
+    let kernel_path = if _acpi {
         edk2_path()
     } else {
         direct_kernel_boot_path()
@@ -2187,39 +2187,29 @@ fn _test_virtio_iommu(acpi: bool) {
         // All devices on the PCI bus will be attached to the virtual IOMMU, except the
         // virtio-iommu device itself. So these devices will all be added to IOMMU groups,
         // and appear under folder '/sys/kernel/iommu_groups/'.
-        // The result is, in the case of FDT, IOMMU group '0' contains "0000:00:01.0"
-        // which is the console. The first disk "0000:00:02.0" is in group '1'.
-        // While on ACPI, console device is not attached to IOMMU. So the IOMMU group '0'
-        // contains "0000:00:02.0" which is the first disk.
         //
-        // Verify the iommu group of the first disk.
-        let iommu_group = if acpi { 0 } else { 2 };
-        assert_eq!(
+        // Verify the first disk is in an iommu group.
+        assert!(
             guest
-                .ssh_command(format!("ls /sys/kernel/iommu_groups/{iommu_group}/devices").as_str())
+                .ssh_command("ls /sys/kernel/iommu_groups/*/devices")
                 .unwrap()
-                .trim(),
-            "0000:00:02.0"
+                .contains("0000:00:02.0")
         );
 
-        // Verify the iommu group of the second disk.
-        let iommu_group = if acpi { 1 } else { 3 };
-        assert_eq!(
+        // Verify the second disk is in an iommu group.
+        assert!(
             guest
-                .ssh_command(format!("ls /sys/kernel/iommu_groups/{iommu_group}/devices").as_str())
+                .ssh_command("ls /sys/kernel/iommu_groups/*/devices")
                 .unwrap()
-                .trim(),
-            "0000:00:03.0"
+                .contains("0000:00:03.0")
         );
 
-        // Verify the iommu group of the network card.
-        let iommu_group = if acpi { 2 } else { 4 };
-        assert_eq!(
+        // Verify the network card is in an iommu group.
+        assert!(
             guest
-                .ssh_command(format!("ls /sys/kernel/iommu_groups/{iommu_group}/devices").as_str())
+                .ssh_command("ls /sys/kernel/iommu_groups/*/devices")
                 .unwrap()
-                .trim(),
-            "0000:00:04.0"
+                .contains("0000:00:04.0")
         );
     });
 


### PR DESCRIPTION
Linux kernel's behavior changes overtime. The grouping can be different across different versions and different architectures.

We only cares about the exact SBDF exists somewhere. It doesn't matter which group it is under.

Change the checks so that test cases are no longer tied to the grouping behavior of a particular kernel.