### PR TITLE
block: Validate sector range for DISCARD and WRITE_ZEROES requests

### DIFF
--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -616,6 +616,13 @@ impl Request {
 
                 let discard_num_sectors = u32::from_le_bytes(discard_num_sectors);
 
+                let top = discard_sector
+                    .checked_add(discard_num_sectors as u64)
+                    .ok_or(ExecuteError::BadRequest(Error::InvalidOffset))?;
+                if top > disk_nsectors {
+                    return Err(ExecuteError::BadRequest(Error::InvalidOffset));
+                }
+
                 let discard_offset = discard_sector * SECTOR_SIZE;
                 let discard_length = (discard_num_sectors as u64) * SECTOR_SIZE;
 
@@ -660,6 +667,14 @@ impl Request {
                 if wz_offset == 0 && disable_sector0_writes {
                     return Err(ExecuteError::BadRequest(Error::InvalidOffset));
                 }
+
+                let top = wz_sector
+                    .checked_add(wz_num_sectors as u64)
+                    .ok_or(ExecuteError::BadRequest(Error::InvalidOffset))?;
+                if top > disk_nsectors {
+                    return Err(ExecuteError::BadRequest(Error::InvalidOffset));
+                }
+
                 let wz_length = (wz_num_sectors as u64) * SECTOR_SIZE;
 
                 if wz_flags & VIRTIO_BLK_WRITE_ZEROES_FLAG_UNMAP != 0 {


### PR DESCRIPTION
Add range validation for DISCARD and WRITE_ZEROES, matching the existing check in the read/write path. Per virtio spec section 5.2.6.1, a driver must not submit a request which would cause a read or write beyond capacity. Use checked_add to guard against overflow, then compare against disk_nsectors.

Without this, requests beyond device capacity pass through to the host punch_hole/write_zeroes calls, relying on backend specific behavior rather than returning VIRTIO_BLK_S_IOERR consistently.