### PR TITLE
IGVM: Add support for booting non-SNP guests via native x86-64 VP context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,8 @@ dependencies = [
  "byteorder",
  "fdt",
  "hypervisor",
+ "igvm",
+ "igvm_defs",
  "libc",
  "linux-loader",
  "log",

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 [features]
 default = []
 fw_cfg = []
+igvm = ["dep:igvm", "igvm_defs"]
 kvm = ["hypervisor/kvm"]
 sev_snp = []
 tdx = []
@@ -16,6 +17,8 @@ tdx = []
 anyhow = { workspace = true }
 byteorder = { workspace = true }
 hypervisor = { path = "../hypervisor" }
+igvm = { workspace = true, optional = true }
+igvm_defs = { workspace = true, optional = true }
 libc = { workspace = true }
 linux-loader = { workspace = true, features = ["bzimage", "elf", "pe"] }
 log = { workspace = true }

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -123,3 +123,14 @@ pub const APIC_START: GuestAddress = GuestAddress(0xfee0_0000);
 
 // ** 64-bit RAM start (start: 4GiB, length: varies) **
 pub const RAM_64BIT_START: GuestAddress = GuestAddress(0x1_0000_0000);
+
+/// Linux boot_params e820 table offset (offset of e820_table within struct boot_params).
+pub const BOOT_E820_TABLE_OFFSET: u64 = 0x2d0;
+/// Linux boot_params e820 entry count offset (offset of e820_entries within struct boot_params).
+pub const BOOT_E820_ENTRIES_OFFSET: u64 = 0x1e8;
+/// Linux boot_params ACPI RSDP address offset.
+pub const BOOT_ACPI_RSDP_OFFSET: u64 = 0x70;
+/// Linux boot_params max e820 entries.
+pub const BOOT_MAX_E820_ENTRIES: usize = 128;
+/// E820 memory type: usable RAM.
+pub const E820_TYPE_RAM: u32 = 1;

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -819,6 +819,7 @@ pub fn configure_vcpu(
     cpu_vendor: CpuVendor,
     topology: (u16, u16, u16, u16),
     nested: bool,
+    #[cfg(feature = "igvm")] igvm_vp_context: Option<&igvm_defs::IgvmNativeVpContextX64>,
 ) -> super::Result<()> {
     let x2apic_id = get_x2apic_id(id, Some(topology));
 
@@ -891,6 +892,15 @@ pub fn configure_vcpu(
     }
 
     regs::setup_msrs(vcpu).map_err(Error::MsrsConfiguration)?;
+
+    #[cfg(feature = "igvm")]
+    if let Some(ctx) = igvm_vp_context {
+        regs::setup_fpu(vcpu).map_err(Error::FpuConfiguration)?;
+        regs::setup_regs_from_igvm_native_context(vcpu, ctx).map_err(Error::RegsConfiguration)?;
+        interrupts::set_lint(vcpu).map_err(|e| Error::LocalIntConfiguration(e.into()))?;
+        return Ok(());
+    }
+
     if let Some((kernel_entry_point, guest_memory)) = boot_setup {
         regs::setup_regs(vcpu, kernel_entry_point).map_err(Error::RegsConfiguration)?;
         regs::setup_fpu(vcpu).map_err(Error::FpuConfiguration)?;

--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -10,6 +10,8 @@ use std::{mem, result};
 
 use hypervisor::arch::x86::gdt::{gdt_entry, segment_from_gdt};
 use hypervisor::arch::x86::regs::CR0_PE;
+#[cfg(feature = "igvm")]
+use hypervisor::arch::x86::{DescriptorTable, SegmentRegister};
 use hypervisor::arch::x86::{FpuState, SpecialRegisters};
 use thiserror::Error;
 use vm_memory::{Address, Bytes, GuestMemory, GuestMemoryError};
@@ -193,6 +195,116 @@ pub fn configure_segments_and_sregs(
     }
 
     Ok(())
+}
+
+/// Convert IGVM segment attributes (VMX access rights format) to a SegmentRegister.
+///
+/// IGVM attribute format:
+///   Bits 3:0  = Type
+///   Bit  4    = S (descriptor type: 0=system, 1=code/data)
+///   Bits 6:5  = DPL
+///   Bit  7    = Present
+///   Bits 11:8 = Reserved (must be zero)
+///   Bit  12   = AVL
+///   Bit  13   = L (long mode)
+///   Bit  14   = D/B (default operation size)
+///   Bit  15   = G (granularity)
+#[cfg(feature = "igvm")]
+fn segment_from_igvm_attributes(
+    selector: u16,
+    attributes: u16,
+    base: u64,
+    limit: u32,
+) -> SegmentRegister {
+    SegmentRegister {
+        base,
+        limit,
+        selector,
+        type_: (attributes & 0xf) as u8,
+        s: ((attributes >> 4) & 1) as u8,
+        dpl: ((attributes >> 5) & 3) as u8,
+        present: ((attributes >> 7) & 1) as u8,
+        avl: ((attributes >> 12) & 1) as u8,
+        l: ((attributes >> 13) & 1) as u8,
+        db: ((attributes >> 14) & 1) as u8,
+        g: ((attributes >> 15) & 1) as u8,
+        unusable: 0,
+    }
+}
+
+/// Configure vCPU registers from an IGVM native VP context.
+///
+/// This sets the standard registers (GPRs + RIP + RFLAGS) and special registers
+/// (segments, CRs, EFER, GDT, IDT) from the IGVM context. Unlike `setup_sregs`,
+/// this does NOT write GDT/IDT to guest memory — the IGVM file already placed them.
+#[cfg(feature = "igvm")]
+pub fn setup_regs_from_igvm_native_context(
+    vcpu: &dyn hypervisor::Vcpu,
+    ctx: &igvm_defs::IgvmNativeVpContextX64,
+) -> Result<()> {
+    // Set standard registers (GPRs + RIP + RFLAGS)
+    let mut regs = vcpu.create_standard_regs();
+    regs.set_rip(ctx.rip);
+    regs.set_rflags(ctx.rflags);
+    regs.set_rax(ctx.rax);
+    regs.set_rbx(ctx.rbx);
+    regs.set_rcx(ctx.rcx);
+    regs.set_rdx(ctx.rdx);
+    regs.set_rsi(ctx.rsi);
+    regs.set_rdi(ctx.rdi);
+    regs.set_rsp(ctx.rsp);
+    regs.set_rbp(ctx.rbp);
+    regs.set_r8(ctx.r8);
+    regs.set_r9(ctx.r9);
+    regs.set_r10(ctx.r10);
+    regs.set_r11(ctx.r11);
+    regs.set_r12(ctx.r12);
+    regs.set_r13(ctx.r13);
+    regs.set_r14(ctx.r14);
+    regs.set_r15(ctx.r15);
+    vcpu.set_regs(&regs).map_err(Error::SetBaseRegisters)?;
+
+    // Set special registers (segments, CRs, EFER, GDT, IDT)
+    let mut sregs: SpecialRegisters = vcpu.get_sregs().map_err(Error::GetStatusRegisters)?;
+
+    sregs.cr0 = ctx.cr0;
+    sregs.cr3 = ctx.cr3;
+    sregs.cr4 = ctx.cr4;
+    sregs.efer = ctx.efer;
+
+    sregs.gdt = DescriptorTable {
+        base: ctx.gdtr_base,
+        limit: ctx.gdtr_limit,
+    };
+    sregs.idt = DescriptorTable {
+        base: ctx.idtr_base,
+        limit: ctx.idtr_limit,
+    };
+
+    sregs.cs = segment_from_igvm_attributes(
+        ctx.code_selector,
+        ctx.code_attributes,
+        ctx.code_base as u64,
+        ctx.code_limit,
+    );
+
+    let data_seg = segment_from_igvm_attributes(
+        ctx.data_selector,
+        ctx.data_attributes,
+        ctx.data_base as u64,
+        ctx.data_limit,
+    );
+    sregs.ds = data_seg;
+    sregs.es = data_seg;
+    sregs.fs = data_seg;
+    sregs.ss = data_seg;
+
+    // GS uses data segment attributes but with its own base
+    let mut gs_seg = data_seg;
+    gs_seg.base = ctx.gs_base;
+    sregs.gs = gs_seg;
+
+    vcpu.set_sregs(&sregs).map_err(Error::SetStatusRegisters)
 }
 
 #[cfg(test)]

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1088,6 +1088,7 @@ impl CpuManager {
             #[cfg(feature = "igvm")]
             self.igvm_vp_context.as_ref().and_then(|ctx| match ctx {
                 crate::igvm::IgvmVpContext::X64Native(native) => Some(native.as_ref()),
+                #[allow(unreachable_patterns)]
                 _ => None,
             }),
         )?;
@@ -2251,6 +2252,7 @@ impl CpuManager {
     }
 
     #[cfg(feature = "igvm")]
+    #[allow(dead_code)]
     pub(crate) fn get_cpuid_leaf(
         &self,
         cpu_id: u8,

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -681,6 +681,8 @@ pub struct CpuManager {
     sev_snp_enabled: bool,
     // State of the core scheduling group leader election (VM mode).
     core_scheduling_group_leader: Arc<AtomicI32>,
+    #[cfg(feature = "igvm")]
+    igvm_vp_context: Option<crate::igvm::IgvmVpContext>,
 }
 
 const CPU_ENABLE_FLAG: usize = 0;
@@ -956,6 +958,8 @@ impl CpuManager {
             core_scheduling_group_leader: Arc::new(AtomicI32::new(
                 CoreSchedulingLeader::Initial as i32,
             )),
+            #[cfg(feature = "igvm")]
+            igvm_vp_context: None,
         })))
     }
 
@@ -1140,6 +1144,11 @@ impl CpuManager {
 
     pub fn vcpus(&self) -> Vec<Arc<Mutex<Vcpu>>> {
         self.vcpus.clone()
+    }
+
+    #[cfg(feature = "igvm")]
+    pub fn set_igvm_vp_context(&mut self, ctx: crate::igvm::IgvmVpContext) {
+        self.igvm_vp_context = Some(ctx);
     }
 
     fn start_vcpu(

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -530,6 +530,9 @@ impl Vcpu {
         #[cfg(target_arch = "x86_64")] kvm_hyperv: bool,
         #[cfg(target_arch = "x86_64")] topology: (u16, u16, u16, u16),
         #[cfg(target_arch = "x86_64")] nested: bool,
+        #[cfg(all(target_arch = "x86_64", feature = "igvm"))] igvm_vp_context: Option<
+            &igvm_defs::IgvmNativeVpContextX64,
+        >,
     ) -> Result<()> {
         #[cfg(target_arch = "aarch64")]
         {
@@ -551,6 +554,8 @@ impl Vcpu {
             self.vendor,
             topology,
             nested,
+            #[cfg(feature = "igvm")]
+            igvm_vp_context,
         )
         .map_err(Error::VcpuConfiguration)?;
 
@@ -1080,6 +1085,11 @@ impl CpuManager {
             self.config.kvm_hyperv,
             topology,
             self.config.nested,
+            #[cfg(feature = "igvm")]
+            self.igvm_vp_context.as_ref().and_then(|ctx| match ctx {
+                crate::igvm::IgvmVpContext::X64Native(native) => Some(native.as_ref()),
+                _ => None,
+            }),
         )?;
 
         #[cfg(target_arch = "aarch64")]

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -330,6 +330,10 @@ pub fn load_igvm(
                 import_parameter(&mut parameter_areas, info, memory_map.as_bytes())?;
             }
             IgvmDirectiveHeader::CommandLine(info) => {
+                debug!(
+                    "CommandLine parameter: area_index={} offset={}, cmdline={:?}",
+                    info.parameter_area_index, info.byte_offset, cmdline
+                );
                 import_parameter(&mut parameter_areas, info, command_line.as_bytes_with_nul())?;
             }
             IgvmDirectiveHeader::RequiredMemory {

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -5,31 +5,34 @@
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::io::{Read, Seek, SeekFrom};
+#[cfg(feature = "sev_snp")]
 use std::mem::size_of;
 use std::sync::{Arc, Mutex};
 
+#[cfg(feature = "sev_snp")]
 use igvm::snp_defs::SevVmsa;
 use igvm::{IgvmDirectiveHeader, IgvmFile, IgvmPlatformHeader, IsolationType};
-#[cfg(feature = "sev_snp")]
-use igvm_defs::{IGVM_VHS_MEMORY_MAP_ENTRY, MemoryMapEntryType};
 use igvm_defs::{
-    IGVM_VHS_PARAMETER, IGVM_VHS_PARAMETER_INSERT, IgvmPageDataType, IgvmPlatformType,
+    IGVM_VHS_MEMORY_MAP_ENTRY, IGVM_VHS_PARAMETER, IGVM_VHS_PARAMETER_INSERT, IgvmPageDataType,
+    IgvmPlatformType, MemoryMapEntryType,
 };
 use log::debug;
 #[cfg(feature = "sev_snp")]
 use log::info;
+#[cfg(feature = "sev_snp")]
 use mshv_bindings::*;
 use thiserror::Error;
 use zerocopy::IntoBytes;
 
-#[cfg(feature = "sev_snp")]
 use crate::GuestMemoryMmap;
 use crate::cpu::CpuManager;
+#[cfg(feature = "sev_snp")]
+use crate::igvm::IgvmVpContext;
 use crate::igvm::loader::Loader;
-use crate::igvm::{
-    BootPageAcceptance, HV_PAGE_SIZE, IgvmLoadedInfo, IgvmVpContext, StartupMemoryType,
-};
-use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
+use crate::igvm::{BootPageAcceptance, HV_PAGE_SIZE, IgvmLoadedInfo, StartupMemoryType};
+#[cfg(feature = "sev_snp")]
+use crate::memory_manager::Error as MemoryManagerError;
+use crate::memory_manager::MemoryManager;
 use vm_memory::{Address, GuestMemory, GuestMemoryRegion};
 
 #[derive(Debug, Error)]
@@ -47,17 +50,22 @@ pub enum Error {
     #[error("parameter too large for parameter area")]
     ParameterTooLarge,
     #[error("Error importing isolated pages")]
+    #[cfg(feature = "sev_snp")]
     ImportIsolatedPages(#[source] hypervisor::HypervisorVmError),
+    #[cfg(feature = "sev_snp")]
     #[error("Error completing importing isolated pages")]
     CompleteIsolatedImport(#[source] hypervisor::HypervisorVmError),
+    #[cfg(feature = "sev_snp")]
     #[error("Error decoding host data")]
     FailedToDecodeHostData(#[source] hex::FromHexError),
+    #[cfg(feature = "sev_snp")]
     #[error("Error allocating address space")]
     MemoryManager(MemoryManagerError),
     #[error("no matching platform type found in igvm file")]
     NoMatchingPlatform,
 }
 
+#[cfg(feature = "sev_snp")]
 #[allow(dead_code)]
 #[derive(Copy, Clone)]
 struct GpaPages {
@@ -74,7 +82,6 @@ enum ParameterAreaState {
     Inserted,
 }
 
-#[cfg(feature = "sev_snp")]
 fn igvm_memmap_from_ram_range(ram_range: (u64, u64)) -> IGVM_VHS_MEMORY_MAP_ENTRY {
     assert!(ram_range.0.is_multiple_of(HV_PAGE_SIZE));
     assert!((ram_range.1 - ram_range.0).is_multiple_of(HV_PAGE_SIZE));
@@ -88,7 +95,6 @@ fn igvm_memmap_from_ram_range(ram_range: (u64, u64)) -> IGVM_VHS_MEMORY_MAP_ENTR
     }
 }
 
-#[cfg(feature = "sev_snp")]
 fn generate_memory_map(
     guest_mem: &GuestMemoryMmap,
 ) -> Result<Vec<IGVM_VHS_MEMORY_MAP_ENTRY>, Error> {
@@ -153,6 +159,7 @@ pub fn load_igvm(
     let command_line = CString::new(cmdline).map_err(Error::InvalidCommandLine)?;
     let mut file_contents = Vec::new();
     let memory = memory_manager.lock().as_ref().unwrap().guest_memory();
+    #[cfg(feature = "sev_snp")]
     let mut gpas: Vec<GpaPages> = Vec::new();
     let proc_count = cpu_manager.lock().unwrap().vcpus().len() as u32;
 
@@ -228,6 +235,7 @@ pub fn load_igvm(
                 let acceptance = match *data_type {
                     IgvmPageDataType::NORMAL => {
                         if flags.unmeasured() {
+                            #[cfg(feature = "sev_snp")]
                             gpas.push(GpaPages {
                                 gpa: *gpa,
                                 page_type: hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_UNMEASURED,
@@ -235,6 +243,7 @@ pub fn load_igvm(
                             });
                             BootPageAcceptance::ExclusiveUnmeasured
                         } else {
+                            #[cfg(feature = "sev_snp")]
                             gpas.push(GpaPages {
                                 gpa: *gpa,
                                 page_type: hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_NORMAL,
@@ -243,6 +252,7 @@ pub fn load_igvm(
                             BootPageAcceptance::Exclusive
                         }
                     }
+                    #[cfg(feature = "sev_snp")]
                     IgvmPageDataType::SECRETS => {
                         gpas.push(GpaPages {
                             gpa: *gpa,
@@ -251,6 +261,7 @@ pub fn load_igvm(
                         });
                         BootPageAcceptance::SecretsPage
                     }
+                    #[cfg(feature = "sev_snp")]
                     IgvmPageDataType::CPUID_DATA => {
                         // SAFETY: CPUID is readonly
                         unsafe {
@@ -362,6 +373,7 @@ pub fn load_igvm(
                     )
                     .map_err(Error::Loader)?;
             }
+            #[cfg(feature = "sev_snp")]
             IgvmDirectiveHeader::SnpVpContext {
                 gpa,
                 compatibility_mask: _,
@@ -389,6 +401,7 @@ pub fn load_igvm(
                     page_size: hv_isolated_page_size_HV_ISOLATED_PAGE_SIZE_4KB,
                 });
             }
+            #[cfg(feature = "sev_snp")]
             IgvmDirectiveHeader::SnpIdBlock {
                 compatibility_mask,
                 author_key_enabled,
@@ -452,6 +465,7 @@ pub fn load_igvm(
                     ParameterAreaState::Inserted => panic!("igvmfile is invalid, multiple insert"),
                 }
                 *area = ParameterAreaState::Inserted;
+                #[cfg(feature = "sev_snp")]
                 gpas.push(GpaPages {
                     gpa: *gpa,
                     page_type: hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_UNMEASURED,

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -26,14 +26,19 @@ use zerocopy::IntoBytes;
 
 use crate::GuestMemoryMmap;
 use crate::cpu::CpuManager;
-#[cfg(feature = "sev_snp")]
-use crate::igvm::IgvmVpContext;
 use crate::igvm::loader::Loader;
-use crate::igvm::{BootPageAcceptance, HV_PAGE_SIZE, IgvmLoadedInfo, StartupMemoryType};
+use crate::igvm::{
+    BootPageAcceptance, HV_PAGE_SIZE, IgvmLoadedInfo, IgvmVpContext, StartupMemoryType,
+};
 #[cfg(feature = "sev_snp")]
 use crate::memory_manager::Error as MemoryManagerError;
 use crate::memory_manager::MemoryManager;
-use vm_memory::{Address, GuestMemory, GuestMemoryRegion};
+// use vm_memory::{Address, GuestMemory, GuestMemoryRegion};
+use arch::layout::{
+    BOOT_ACPI_RSDP_OFFSET, BOOT_E820_ENTRIES_OFFSET, BOOT_E820_TABLE_OFFSET, BOOT_MAX_E820_ENTRIES,
+    E820_TYPE_RAM, RSDP_POINTER,
+};
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryRegion};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -479,6 +484,65 @@ pub fn load_igvm(
                 todo!("Header not supported!!")
             }
         }
+    }
+
+    // Fill in e820 table and RSDP pointer in boot_params.
+    // The IGVM parameter mechanism places the memory map at a separate GPA,
+    // but Linux boot_params needs e820 entries inline at offset 0x2d0.
+    let boot_params_gpa = match &loaded_info.vp_context {
+        Some(IgvmVpContext::X64Native(ctx)) => Some(ctx.rsi),
+        _ => None,
+    };
+
+    if let Some(boot_params_gpa) = boot_params_gpa {
+        let guest_mem = memory_manager.lock().unwrap().boot_guest_memory();
+        // Generate e820 entries from guest memory regions
+        let memory_map = generate_memory_map(&guest_mem)?;
+        let num_entries = std::cmp::min(memory_map.len(), BOOT_MAX_E820_ENTRIES);
+        for (i, entry) in memory_map.iter().take(num_entries).enumerate() {
+            let addr = entry.starting_gpa_page_number * HV_PAGE_SIZE;
+            let size = entry.number_of_pages * HV_PAGE_SIZE;
+            let e820_offset = BOOT_E820_TABLE_OFFSET + (i as u64) * 20;
+
+            guest_mem
+                .write_obj(addr, GuestAddress(boot_params_gpa + e820_offset))
+                .map_err(|_| Error::ParameterTooLarge)?;
+            guest_mem
+                .write_obj(size, GuestAddress(boot_params_gpa + e820_offset + 8))
+                .map_err(|_| Error::ParameterTooLarge)?;
+            guest_mem
+                .write_obj(
+                    E820_TYPE_RAM,
+                    GuestAddress(boot_params_gpa + e820_offset + 16),
+                )
+                .map_err(|_| Error::ParameterTooLarge)?;
+
+            debug!(
+                "e820[{}]: addr=0x{:x} size=0x{:x} type={}",
+                i, addr, size, E820_TYPE_RAM
+            );
+        }
+
+        // Write e820_entries count
+        guest_mem
+            .write_obj(
+                num_entries as u8,
+                GuestAddress(boot_params_gpa + BOOT_E820_ENTRIES_OFFSET),
+            )
+            .map_err(|_| Error::ParameterTooLarge)?;
+
+        debug!(
+            "Wrote {} e820 entries to boot_params @ 0x{:x}",
+            num_entries, boot_params_gpa
+        );
+
+        guest_mem
+            .write_obj(
+                RSDP_POINTER.0,
+                GuestAddress(boot_params_gpa + BOOT_ACPI_RSDP_OFFSET),
+            )
+            .map_err(|_| Error::ParameterTooLarge)?;
+        debug!("Set acpi_rsdp_addr=0x{:x} in boot_params", RSDP_POINTER.0);
     }
 
     #[cfg(feature = "sev_snp")]

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -556,7 +556,7 @@ pub fn load_igvm(
     }
 
     debug!(
-        "Dumping the contents of VMSA page: {:x?}",
+        "Dumping the contents of VP context: {:x?}",
         loaded_info.vp_context
     );
     Ok(loaded_info)

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -338,6 +338,10 @@ pub fn load_igvm(
                 );
                 import_parameter(&mut parameter_areas, info, command_line.as_bytes_with_nul())?;
             }
+            IgvmDirectiveHeader::Madt(info) => {
+                let madt = cpu_manager.lock().unwrap().create_madt();
+                import_parameter(&mut parameter_areas, info, madt.as_slice())?;
+            }
             IgvmDirectiveHeader::RequiredMemory {
                 gpa,
                 compatibility_mask: _,

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -362,6 +362,18 @@ pub fn load_igvm(
                 let madt = cpu_manager.lock().unwrap().create_madt();
                 import_parameter(&mut parameter_areas, info, madt.as_slice())?;
             }
+            IgvmDirectiveHeader::Srat(info) => {
+                debug!("Srat parameter requested but no NUMA config available, importing empty");
+                import_parameter(&mut parameter_areas, info, &[])?;
+            }
+            IgvmDirectiveHeader::Slit(info) => {
+                debug!("Slit parameter requested but no NUMA config available, importing empty");
+                import_parameter(&mut parameter_areas, info, &[])?;
+            }
+            IgvmDirectiveHeader::Pptt(info) => {
+                debug!("Pptt parameter requested, importing empty");
+                import_parameter(&mut parameter_areas, info, &[])?;
+            }
             IgvmDirectiveHeader::RequiredMemory {
                 gpa,
                 compatibility_mask: _,

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -26,7 +26,9 @@ use zerocopy::IntoBytes;
 use crate::GuestMemoryMmap;
 use crate::cpu::CpuManager;
 use crate::igvm::loader::Loader;
-use crate::igvm::{BootPageAcceptance, HV_PAGE_SIZE, IgvmLoadedInfo, StartupMemoryType};
+use crate::igvm::{
+    BootPageAcceptance, HV_PAGE_SIZE, IgvmLoadedInfo, IgvmVpContext, StartupMemoryType,
+};
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 
 #[derive(Debug, Error)]
@@ -361,8 +363,10 @@ pub fn load_igvm(
                 assert_eq!(gpa % HV_PAGE_SIZE, 0);
                 let mut data: [u8; 4096] = [0; 4096];
                 let len = size_of::<SevVmsa>();
-                loaded_info.vmsa_gpa = *gpa;
-                loaded_info.vmsa = **vmsa;
+                loaded_info.vp_context = Some(IgvmVpContext::SevSnp {
+                    vmsa: **vmsa,
+                    vmsa_gpa: *gpa,
+                });
                 // Only supported for index zero
                 if *vp_index == 0 {
                     data[..len].copy_from_slice(vmsa.as_bytes());
@@ -529,6 +533,9 @@ pub fn load_igvm(
         );
     }
 
-    debug!("Dumping the contents of VMSA page: {:x?}", loaded_info.vmsa);
+    debug!(
+        "Dumping the contents of VMSA page: {:x?}",
+        loaded_info.vp_context
+    );
     Ok(loaded_info)
 }

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -445,6 +445,15 @@ pub fn load_igvm(
             } => {
                 todo!("VbsVpContext not supported");
             }
+            IgvmDirectiveHeader::X64NativeVpContext {
+                compatibility_mask: _,
+                vp_index,
+                context,
+            } => {
+                if *vp_index == 0 {
+                    loaded_info.vp_context = Some(IgvmVpContext::X64Native(context.clone()));
+                }
+            }
             IgvmDirectiveHeader::VbsMeasurement { .. } => {
                 todo!("VbsMeasurement not supported")
             }

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -51,6 +51,8 @@ pub enum Error {
     FailedToDecodeHostData(#[source] hex::FromHexError),
     #[error("Error allocating address space")]
     MemoryManager(MemoryManagerError),
+    #[error("no matching platform type found in igvm file")]
+    NoMatchingPlatform,
 }
 
 #[allow(dead_code)]
@@ -159,15 +161,43 @@ pub fn load_igvm(
     file.seek(SeekFrom::Start(0)).map_err(Error::Igvm)?;
     file.read_to_end(&mut file_contents).map_err(Error::Igvm)?;
 
-    let igvm_file = IgvmFile::new_from_binary(&file_contents, Some(IsolationType::Snp))
-        .map_err(Error::InvalidIgvmFile)?;
-
-    let mask = match &igvm_file.platforms()[0] {
-        IgvmPlatformHeader::SupportedPlatform(info) => {
-            debug_assert!(info.platform_type == IgvmPlatformType::SEV_SNP);
-            info.compatibility_mask
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "sev_snp")] {
+            let expected_platform_type: &[IgvmPlatformType] = &[IgvmPlatformType::SEV_SNP];
+        } else {
+            let expected_platform_type: &[IgvmPlatformType] = &[IgvmPlatformType::NATIVE];
         }
-    };
+    }
+
+    // Determine which platform is present in the file so we can use the
+    // correct isolation filter when parsing directives.
+    let igvm_file_unfiltered =
+        IgvmFile::new_from_binary(&file_contents, None).map_err(Error::InvalidIgvmFile)?;
+
+    let (mask, match_isolation_type) = expected_platform_type
+        .iter()
+        .find_map(|expected| {
+            igvm_file_unfiltered
+                .platforms()
+                .iter()
+                .find_map(|platform| match platform {
+                    IgvmPlatformHeader::SupportedPlatform(info)
+                        if info.platform_type == *expected =>
+                    {
+                        let isolation: IsolationType = match info.platform_type {
+                            IgvmPlatformType::SEV_SNP => IsolationType::Snp,
+                            IgvmPlatformType::NATIVE => IsolationType::NotIsolated,
+                            _ => unimplemented!("Unsupported platform type"),
+                        };
+                        Some((info.compatibility_mask, isolation))
+                    }
+                    _ => None,
+                })
+        })
+        .ok_or(Error::NoMatchingPlatform)?;
+
+    let igvm_file = IgvmFile::new_from_binary(&file_contents, Some(match_isolation_type))
+        .map_err(Error::InvalidIgvmFile)?;
 
     let mut loader = Loader::new(memory);
 

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -30,6 +30,7 @@ use crate::igvm::{
     BootPageAcceptance, HV_PAGE_SIZE, IgvmLoadedInfo, IgvmVpContext, StartupMemoryType,
 };
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
+use vm_memory::{Address, GuestMemory, GuestMemoryRegion};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -93,11 +94,14 @@ fn generate_memory_map(
 ) -> Result<Vec<IGVM_VHS_MEMORY_MAP_ENTRY>, Error> {
     let mut memory_map = Vec::new();
 
-    // Get usable physical memory ranges
-    let ram_ranges = arch::generate_ram_ranges(guest_mem).map_err(Error::InvalidGuestMemmap)?;
-
-    for ram_range in ram_ranges {
-        memory_map.push(igvm_memmap_from_ram_range(ram_range));
+    // For IGVM boot, report the full guest memory layout including low memory.
+    // Unlike the e820 map (which skips below 1MiB), the IGVM memory map must
+    // include all usable RAM since the IGVM file may place boot structures
+    // (page tables, GDT, boot params) in low memory.
+    for region in guest_mem.iter() {
+        let start = region.start_addr().raw_value();
+        let size = region.len();
+        memory_map.push(igvm_memmap_from_ram_range((start, start + size)));
     }
 
     Ok(memory_map)

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -318,16 +318,16 @@ pub fn load_igvm(
             IgvmDirectiveHeader::MmioRanges(_info) => {
                 todo!("unsupported IgvmPageDataType");
             }
-            IgvmDirectiveHeader::MemoryMap(_info) => {
-                #[cfg(feature = "sev_snp")]
-                {
-                    let guest_mem = memory_manager.lock().unwrap().boot_guest_memory();
-                    let memory_map = generate_memory_map(&guest_mem)?;
-                    import_parameter(&mut parameter_areas, _info, memory_map.as_bytes())?;
+            IgvmDirectiveHeader::MemoryMap(info) => {
+                let guest_mem = memory_manager.lock().unwrap().boot_guest_memory();
+                let memory_map = generate_memory_map(&guest_mem)?;
+                for entry in &memory_map {
+                    debug!(
+                        "IGVM memory map entry: start=0x{:x} pages={} type={:?}",
+                        entry.starting_gpa_page_number, entry.number_of_pages, entry.entry_type
+                    );
                 }
-
-                #[cfg(not(feature = "sev_snp"))]
-                todo!("Not implemented");
+                import_parameter(&mut parameter_areas, info, memory_map.as_bytes())?;
             }
             IgvmDirectiveHeader::CommandLine(info) => {
                 import_parameter(&mut parameter_areas, info, command_line.as_bytes_with_nul())?;

--- a/vmm/src/igvm/mod.rs
+++ b/vmm/src/igvm/mod.rs
@@ -27,25 +27,36 @@
 
 pub mod igvm_loader;
 mod loader;
-use igvm::snp_defs::SevVmsa;
 use igvm_defs::IGVM_VHS_SNP_ID_BLOCK;
 use zerocopy::FromZeros;
+
+/// VP context extracted from the IGVM file.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum IgvmVpContext {
+    /// SEV-SNP VMSA context (for SNP-isolated guests).
+    #[cfg(feature = "sev_snp")]
+    SevSnp {
+        vmsa: igvm::snp_defs::SevVmsa,
+        vmsa_gpa: u64,
+    },
+}
 
 #[derive(Debug, Clone)]
 pub struct IgvmLoadedInfo {
     pub gpas: Vec<u64>,
-    pub vmsa_gpa: u64,
+    pub vp_context: Option<IgvmVpContext>,
+    #[cfg(feature = "sev_snp")]
     pub snp_id_block: IGVM_VHS_SNP_ID_BLOCK,
-    pub vmsa: SevVmsa,
 }
 
 impl Default for IgvmLoadedInfo {
     fn default() -> Self {
         IgvmLoadedInfo {
             gpas: Vec::new(),
-            vmsa_gpa: 0,
+            vp_context: None,
+            #[cfg(feature = "sev_snp")]
             snp_id_block: IGVM_VHS_SNP_ID_BLOCK::new_zeroed(),
-            vmsa: SevVmsa::new_zeroed(),
         }
     }
 }

--- a/vmm/src/igvm/mod.rs
+++ b/vmm/src/igvm/mod.rs
@@ -34,6 +34,8 @@ use zerocopy::FromZeros;
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub enum IgvmVpContext {
+    /// Native x86-64 VP context (for non-isolated guests).
+    X64Native(Box<igvm_defs::IgvmNativeVpContextX64>),
     /// SEV-SNP VMSA context (for SNP-isolated guests).
     #[cfg(feature = "sev_snp")]
     SevSnp {

--- a/vmm/src/igvm/mod.rs
+++ b/vmm/src/igvm/mod.rs
@@ -27,7 +27,9 @@
 
 pub mod igvm_loader;
 mod loader;
+#[cfg(feature = "sev_snp")]
 use igvm_defs::IGVM_VHS_SNP_ID_BLOCK;
+#[cfg(feature = "sev_snp")]
 use zerocopy::FromZeros;
 
 /// VP context extracted from the IGVM file.

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1455,6 +1455,7 @@ impl Vm {
         igvm: File,
         memory_manager: Arc<Mutex<MemoryManager>>,
         cpu_manager: Arc<Mutex<cpu::CpuManager>>,
+        cmdline: &str,
         #[cfg(feature = "sev_snp")] host_data: &Option<String>,
     ) -> Result<EntryPoint> {
         use crate::igvm::IgvmVpContext;
@@ -1463,7 +1464,7 @@ impl Vm {
             &igvm,
             memory_manager,
             cpu_manager.clone(),
-            "",
+            cmdline,
             #[cfg(feature = "sev_snp")]
             host_data,
         )
@@ -1570,12 +1571,19 @@ impl Vm {
         {
             if let Some(_igvm_file) = &payload.igvm {
                 let igvm = File::open(_igvm_file).map_err(Error::IgvmFile)?;
+                let cmdline = payload.cmdline.as_deref().unwrap_or("");
                 #[cfg(feature = "sev_snp")]
                 if sev_snp_enabled {
-                    return Self::load_igvm(igvm, memory_manager, cpu_manager, &payload.host_data);
+                    return Self::load_igvm(
+                        igvm,
+                        memory_manager,
+                        cpu_manager,
+                        cmdline,
+                        &payload.host_data,
+                    );
                 }
                 #[cfg(not(feature = "sev_snp"))]
-                return Self::load_igvm(igvm, memory_manager, cpu_manager);
+                return Self::load_igvm(igvm, memory_manager, cpu_manager, cmdline);
             }
         }
         match (&payload.firmware, &payload.kernel) {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1491,6 +1491,7 @@ impl Vm {
                     setup_header: None,
                 }
             }
+            #[allow(unreachable_patterns)]
             Some(_) | None => unimplemented!("Unknown vp_context!"),
         };
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1457,6 +1457,8 @@ impl Vm {
         cpu_manager: Arc<Mutex<cpu::CpuManager>>,
         #[cfg(feature = "sev_snp")] host_data: &Option<String>,
     ) -> Result<EntryPoint> {
+        use crate::igvm::IgvmVpContext;
+
         let res = igvm_loader::load_igvm(
             &igvm,
             memory_manager,
@@ -1467,17 +1469,19 @@ impl Vm {
         )
         .map_err(Error::IgvmLoad)?;
 
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "sev_snp")] {
-                let entry_point = if cpu_manager.lock().unwrap().sev_snp_enabled() {
-                    EntryPoint { entry_addr: vm_memory::GuestAddress(res.vmsa_gpa), setup_header: None }
-                } else {
-                    EntryPoint {entry_addr: vm_memory::GuestAddress(res.vmsa.rip), setup_header: None }
-                };
-            } else {
-               let entry_point = EntryPoint { entry_addr: vm_memory::GuestAddress(res.vmsa.rip), setup_header: None };
+        let entry_point = match &res.vp_context {
+            #[cfg(feature = "sev_snp")]
+            Some(IgvmVpContext::SevSnp { vmsa_gpa, .. })
+                if cpu_manager.lock().unwrap().sev_snp_enabled() =>
+            {
+                EntryPoint {
+                    entry_addr: vm_memory::GuestAddress(*vmsa_gpa),
+                    setup_header: None,
+                }
             }
+            Some(_) | None => unimplemented!("Unknown vp_context!"),
         };
+
         Ok(entry_point)
     }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1479,6 +1479,17 @@ impl Vm {
                     setup_header: None,
                 }
             }
+            Some(IgvmVpContext::X64Native(ctx)) => {
+                let entry_addr = vm_memory::GuestAddress(ctx.rip);
+                cpu_manager
+                    .lock()
+                    .unwrap()
+                    .set_igvm_vp_context(IgvmVpContext::X64Native(ctx.clone()));
+                EntryPoint {
+                    entry_addr,
+                    setup_header: None,
+                }
+            }
             Some(_) | None => unimplemented!("Unknown vp_context!"),
         };
 


### PR DESCRIPTION
This series extends Cloud Hypervisor's IGVM loader to support booting non-isolated (non-SNP) guests using the native x86-64 VP context mechanism defined in the IGVM specification. Previously, the IGVM loader was hardcoded to assume SEV-SNP isolation, making it unusable on platforms without AMD SEV-SNP support (e.g., Intel or non-CoCo environments).

I have a guest boot on KVM with IGVM file generated from [igvmgenfile](https://github.com/microsoft/openvmm/tree/main/vm/loader/igvmfilegen) tooling from openvmm repo.

```
./target/debug/cloud-hypervisor --igvm ../../dev/openvmm/output.bin --serial tty --console off --disk path=focal-server-cloudimg-amd64.raw --cmdline "console=ttyS0 root=/dev/vda1 rw" -v -v
```

I have used the following resource and manifest file to generate the IGVM file:

```

❯ cat manifest.json
 {
      "guest_arch": "x64",
      "guest_configs": [
          {
              "guest_svn": 1,
              "max_vtl": 0,
              "isolation_type": "none",
              "image": {
                  "linux": {
                      "use_initrd": false,
                      "command_line": "console=ttyS0",
                      "memory_size": 536870912
                  }
              }
          }
      ]
 }


❯ cat resource.json
{
     "resources": {
         "linux_kernel": "/home/jinankjain/dev/linux/vmlinux"
     }
}
```
