### PR TITLE
docs: update outdated MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,57 @@
 # Maintainers
 
-- Sebastien Boeuf - @sboeuf
-- Robert Bradford - @rbradford
-- Bo Chen - @likebreath
-- Samuel Ortiz - @sameo
-- Wei Liu - @liuw
-- Michael Zhao - @michael2012z
+- **Main Maintainers**
+  - Bo Chen - @likebreath
+  - Robert Bradford - @rbradford
+- **Co-Maintainers**
+  - Alyssa Ross - @alyssais
+  - Jinank Jain - @jinankjain
+  - Muminul Islam Russell - @russell-islam
+  - Philipp Schuster - @phip1611
+  - Ruoqing He - @RuoqingHe
+  - Sebastien Boeuf - @sboeuf
+  - Wei Liu - @liuw
+  - Yi Wang - @up2wing
+
+All (co-)maintainers generally have a comprehensive view of the project and 
+contribute to the project in a wide variety of ways. Some of them have a 
+specific focus on a particular component or subsystem, which is described in 
+the following sections.
+
+## Domain Experts
+
+The list below highlights key components alongside the people who focus on 
+them most. It is neither exhaustive nor fine-grained — many contributors work
+across multiple areas.
+
+### Hypervisor Backends
+
+- **KVM**
+  - @alyssais
+  - @likebreath
+  - @phip1611
+  - @rbradford
+- **MSHV**
+  - @jinankjain
+  - @liuw
+  - @russell-islam
+  - @up2wing
+
+### Architectures
+
+- **ARM**: Shared responsibility across all maintainers
+- **x86_64**: Shared responsibility across all maintainers
+- **RISC-V**
+  - @RuoqingHe
+
+### Features & Subsystems
+
+- **Hardware-enforced VM isolation and attestation (SEV-SNP, IGVM, Confidential VMs)**
+  - @jinankjain
+  - @russell-islam
+- **Migration**
+  - @phip1611
+  - @likebreath
+- **VFIO & vhost-user**
+  - @alyssais
+


### PR DESCRIPTION
TL;DR: The MAINTAINERS.md file is heavily outdated.

I've updated MAINTAINERS.md from the (co-)maintainers I regularly see working on CHV and from the information available at https://github.com/orgs/cloud-hypervisor/teams.

I also removed two maintainers (@sameo and @michael2012z) as they are not in https://github.com/orgs/cloud-hypervisor/teams respectively inactive for many years (latter case).

Further, I think it is helpful to list domain experts for a few selected areas. I'm very open and welcome everyone to join the discussion how this can be handled in a fair and inclusive way, helpful for everyone.


### Other tasks
- [ ] I think https://github.com/orgs/cloud-hypervisor/teams needs some major cleanup. There are many teams and I think most of them are not needed anymore or don't fulfill the intended purpose?