### PR TITLE
block: Followup improvements to segment validation

### DIFF
--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -110,8 +110,8 @@ pub enum Error {
     RawFileError(#[source] std::io::Error),
     #[error("The requested operation does not support multiple descriptors")]
     TooManyDescriptors,
-    #[error("Request contains too many segments")]
-    TooManySegments,
+    #[error("Request contains too many segments ({0}, max {MAX_DISCARD_WRITE_ZEROES_SEG})")]
+    TooManySegments(u32),
     #[error("Failure in vhdx")]
     VhdxError(#[source] VhdxError),
 }
@@ -602,7 +602,9 @@ impl Request {
                     return Err(ExecuteError::BadRequest(Error::DescriptorLengthTooSmall));
                 }
                 if data_len > DISCARD_WZ_MAX_PAYLOAD {
-                    return Err(ExecuteError::BadRequest(Error::TooManySegments));
+                    return Err(ExecuteError::BadRequest(Error::TooManySegments(
+                        data_len.div_ceil(DISCARD_WZ_SEG_SIZE),
+                    )));
                 }
 
                 let mut discard_sector = [0u8; 8];
@@ -651,7 +653,9 @@ impl Request {
                     return Err(ExecuteError::BadRequest(Error::DescriptorLengthTooSmall));
                 }
                 if data_len > DISCARD_WZ_MAX_PAYLOAD {
-                    return Err(ExecuteError::BadRequest(Error::TooManySegments));
+                    return Err(ExecuteError::BadRequest(Error::TooManySegments(
+                        data_len.div_ceil(DISCARD_WZ_SEG_SIZE),
+                    )));
                 }
 
                 let mut wz_sector = [0u8; 8];


### PR DESCRIPTION
Followup to #7874, addressing review feedback from @phip1611.

- Add `DISCARD_WZ_MAX_PAYLOAD` constant to avoid repeating the `DISCARD_WZ_SEG_SIZE * MAX_DISCARD_WRITE_ZEROES_SEG` product
- Include actual segment count in `TooManySegments` error for easier debugging