### PR TITLE
Enhance ACPI PPTT with cache topology information

### DIFF
--- a/arch/src/aarch64/cache.rs
+++ b/arch/src/aarch64/cache.rs
@@ -1,0 +1,125 @@
+// Copyright 2020 Arm Limited (or its affiliates). All rights reserved.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+use std::fs;
+use std::path::Path;
+
+#[derive(Copy, Clone)]
+pub enum CacheLevel {
+    /// L1 data cache
+    L1D = 0,
+    /// L1 instruction cache
+    L1I = 1,
+    /// L2 cache
+    L2 = 2,
+    /// L3 cache
+    L3 = 3,
+}
+
+/// NOTE: cache size file directory example,
+/// "/sys/devices/system/cpu/cpu0/cache/index0/size".
+pub fn get_cache_size(cache_level: CacheLevel) -> u32 {
+    let mut file_directory: String = "/sys/devices/system/cpu/cpu0/cache".to_string();
+    match cache_level {
+        CacheLevel::L1D => file_directory += "/index0/size",
+        CacheLevel::L1I => file_directory += "/index1/size",
+        CacheLevel::L2 => file_directory += "/index2/size",
+        CacheLevel::L3 => file_directory += "/index3/size",
+    }
+
+    let file_path = Path::new(&file_directory);
+    if file_path.exists() {
+        let src = fs::read_to_string(file_directory).expect("File not exists or file corrupted.");
+        // The content of the file is as simple as a size, like: "32K"
+        let src = src.trim();
+        let src_digits: u32 = src[0..src.len() - 1].parse().unwrap();
+        let src_unit = &src[src.len() - 1..];
+
+        src_digits
+            * match src_unit {
+                "K" => 1024,
+                "M" => 1024u32.pow(2),
+                "G" => 1024u32.pow(3),
+                _ => 1,
+            }
+    } else {
+        0
+    }
+}
+
+/// NOTE: coherency_line_size file directory example,
+/// "/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size".
+pub fn get_cache_coherency_line_size(cache_level: CacheLevel) -> u32 {
+    let mut file_directory: String = "/sys/devices/system/cpu/cpu0/cache".to_string();
+    match cache_level {
+        CacheLevel::L1D => file_directory += "/index0/coherency_line_size",
+        CacheLevel::L1I => file_directory += "/index1/coherency_line_size",
+        CacheLevel::L2 => file_directory += "/index2/coherency_line_size",
+        CacheLevel::L3 => file_directory += "/index3/coherency_line_size",
+    }
+
+    let file_path = Path::new(&file_directory);
+    if file_path.exists() {
+        let src = fs::read_to_string(file_directory).expect("File not exists or file corrupted.");
+        src.trim().parse::<u32>().unwrap()
+    } else {
+        0
+    }
+}
+
+/// NOTE: number_of_sets file directory example,
+/// "/sys/devices/system/cpu/cpu0/cache/index0/number_of_sets".
+pub fn get_cache_number_of_sets(cache_level: CacheLevel) -> u32 {
+    let mut file_directory: String = "/sys/devices/system/cpu/cpu0/cache".to_string();
+    match cache_level {
+        CacheLevel::L1D => file_directory += "/index0/number_of_sets",
+        CacheLevel::L1I => file_directory += "/index1/number_of_sets",
+        CacheLevel::L2 => file_directory += "/index2/number_of_sets",
+        CacheLevel::L3 => file_directory += "/index3/number_of_sets",
+    }
+
+    let file_path = Path::new(&file_directory);
+    if file_path.exists() {
+        let src = fs::read_to_string(file_directory).expect("File not exists or file corrupted.");
+        src.trim().parse::<u32>().unwrap()
+    } else {
+        0
+    }
+}
+
+/// NOTE: shared_cpu_list file directory example,
+/// "/sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list".
+pub fn get_cache_shared(cache_level: CacheLevel) -> bool {
+    let mut file_directory: String = "/sys/devices/system/cpu/cpu0/cache".to_string();
+    let mut result = true;
+
+    match cache_level {
+        CacheLevel::L1D | CacheLevel::L1I => result = false,
+        CacheLevel::L2 => file_directory += "/index2/shared_cpu_list",
+        CacheLevel::L3 => file_directory += "/index3/shared_cpu_list",
+    }
+
+    if !result {
+        return false;
+    }
+
+    let file_path = Path::new(&file_directory);
+    if file_path.exists() {
+        let src = fs::read_to_string(file_directory).expect("File not exists or file corrupted.");
+        let src = src.trim();
+        if src.is_empty() {
+            result = false;
+        } else {
+            result = src.contains('-') || src.contains(',');
+        }
+    } else {
+        result = false;
+    }
+
+    result
+}

--- a/arch/src/aarch64/cache.rs
+++ b/arch/src/aarch64/cache.rs
@@ -42,9 +42,9 @@ pub fn get_cache_size(cache_level: CacheLevel) -> u32 {
 
         src_digits
             * match src_unit {
-                "K" => 1024,
-                "M" => 1024u32.pow(2),
-                "G" => 1024u32.pow(3),
+                "K" => 1u32 << 10,
+                "M" => 1u32 << 20,
+                "G" => 1u32 << 30,
                 _ => 1,
             }
     } else {

--- a/arch/src/aarch64/cache.rs
+++ b/arch/src/aarch64/cache.rs
@@ -9,6 +9,8 @@
 use std::fs;
 use std::path::Path;
 
+use log::warn;
+
 #[derive(Copy, Clone)]
 pub enum CacheLevel {
     /// L1 data cache
@@ -122,4 +124,65 @@ pub fn get_cache_shared(cache_level: CacheLevel) -> bool {
     }
 
     result
+}
+
+#[derive(Default, Copy, Clone, Debug)]
+pub struct CacheTopologyInfo {
+    pub l1_d_cache_size: u32,
+    pub l1_d_cache_line_size: u32,
+    pub l1_d_cache_sets: u32,
+
+    pub l1_i_cache_size: u32,
+    pub l1_i_cache_line_size: u32,
+    pub l1_i_cache_sets: u32,
+
+    pub l2_cache_size: u32,
+    pub l2_cache_line_size: u32,
+    pub l2_cache_sets: u32,
+
+    pub l3_cache_size: u32,
+    pub l3_cache_line_size: u32,
+    pub l3_cache_sets: u32,
+
+    pub l2_cache_shared: bool,
+    pub l3_cache_shared: bool,
+}
+
+/// Reads cache topology information from sysfs for cpu0.
+pub fn read_cache_topology() -> Option<CacheTopologyInfo> {
+    let cache_path = Path::new("/sys/devices/system/cpu/cpu0/cache");
+    if !cache_path.exists() {
+        warn!("Cache topology information is not available in sysfs.");
+        return None;
+    }
+
+    let mut info = CacheTopologyInfo {
+        l1_d_cache_size: get_cache_size(CacheLevel::L1D),
+        l1_d_cache_line_size: get_cache_coherency_line_size(CacheLevel::L1D),
+        l1_d_cache_sets: get_cache_number_of_sets(CacheLevel::L1D),
+
+        l1_i_cache_size: get_cache_size(CacheLevel::L1I),
+        l1_i_cache_line_size: get_cache_coherency_line_size(CacheLevel::L1I),
+        l1_i_cache_sets: get_cache_number_of_sets(CacheLevel::L1I),
+
+        l2_cache_size: get_cache_size(CacheLevel::L2),
+        l2_cache_line_size: get_cache_coherency_line_size(CacheLevel::L2),
+        l2_cache_sets: get_cache_number_of_sets(CacheLevel::L2),
+
+        l3_cache_size: get_cache_size(CacheLevel::L3),
+        l3_cache_line_size: get_cache_coherency_line_size(CacheLevel::L3),
+        l3_cache_sets: get_cache_number_of_sets(CacheLevel::L3),
+
+        l2_cache_shared: false,
+        l3_cache_shared: false,
+    };
+
+    if info.l2_cache_size != 0 {
+        info.l2_cache_shared = get_cache_shared(CacheLevel::L2);
+    }
+    if info.l3_cache_size != 0 {
+        info.l3_cache_shared = get_cache_shared(CacheLevel::L3);
+    }
+
+    Some(info)
 }

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -10,7 +10,6 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fmt::Debug;
 use std::hash::BuildHasher;
-use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::{cmp, result, str};
 
@@ -21,16 +20,13 @@ use hypervisor::arch::aarch64::regs::{
     AARCH64_ARCH_TIMER_HYP_IRQ, AARCH64_ARCH_TIMER_PHYS_NONSECURE_IRQ,
     AARCH64_ARCH_TIMER_PHYS_SECURE_IRQ, AARCH64_ARCH_TIMER_VIRT_IRQ, AARCH64_PMU_IRQ,
 };
-use log::{debug, info, warn};
+use log::{debug, info};
 use thiserror::Error;
 use vm_fdt::{FdtWriter, FdtWriterResult};
 use vm_memory::{Address, Bytes, GuestMemory, GuestMemoryError, GuestMemoryRegion};
 
 use super::super::{DeviceType, GuestMemoryMmap, InitramfsConfig};
-use super::cache::{
-    CacheLevel, get_cache_coherency_line_size, get_cache_number_of_sets, get_cache_shared,
-    get_cache_size,
-};
+use super::cache::{CacheTopologyInfo, read_cache_topology};
 use super::layout::{
     GIC_V2M_COMPATIBLE, GICV2M_SPI_BASE, GICV2M_SPI_NUM, IRQ_BASE, MEM_32BIT_DEVICES_SIZE,
     MEM_32BIT_DEVICES_START, MEM_PCI_IO_SIZE, MEM_PCI_IO_START, PCI_HIGH_BASE,
@@ -178,63 +174,24 @@ fn create_cpu_nodes(
         threads_per_core as u32 * cores_per_die as u32 * dies_per_package as u32 * packages as u32;
 
     // Add cache info.
-    // L1 Data Cache Info.
-    let mut l1_d_cache_size: u32 = 0;
-    let mut l1_d_cache_line_size: u32 = 0;
-    let mut l1_d_cache_sets: u32 = 0;
-
-    // L1 Instruction Cache Info.
-    let mut l1_i_cache_size: u32 = 0;
-    let mut l1_i_cache_line_size: u32 = 0;
-    let mut l1_i_cache_sets: u32 = 0;
-
-    // L2 Cache Info.
-    let mut l2_cache_size: u32 = 0;
-    let mut l2_cache_line_size: u32 = 0;
-    let mut l2_cache_sets: u32 = 0;
-
-    // L3 Cache Info.
-    let mut l3_cache_size: u32 = 0;
-    let mut l3_cache_line_size: u32 = 0;
-    let mut l3_cache_sets: u32 = 0;
-
-    // Cache Shared Info.
-    let mut l2_cache_shared: bool = false;
-    let mut l3_cache_shared: bool = false;
-
-    let cache_path = Path::new("/sys/devices/system/cpu/cpu0/cache");
-    let cache_exist: bool = cache_path.exists();
-    if cache_exist {
-        // L1 Data Cache Info.
-        l1_d_cache_size = get_cache_size(CacheLevel::L1D);
-        l1_d_cache_line_size = get_cache_coherency_line_size(CacheLevel::L1D);
-        l1_d_cache_sets = get_cache_number_of_sets(CacheLevel::L1D);
-
-        // L1 Instruction Cache Info.
-        l1_i_cache_size = get_cache_size(CacheLevel::L1I);
-        l1_i_cache_line_size = get_cache_coherency_line_size(CacheLevel::L1I);
-        l1_i_cache_sets = get_cache_number_of_sets(CacheLevel::L1I);
-
-        // L2 Cache Info.
-        l2_cache_size = get_cache_size(CacheLevel::L2);
-        l2_cache_line_size = get_cache_coherency_line_size(CacheLevel::L2);
-        l2_cache_sets = get_cache_number_of_sets(CacheLevel::L2);
-
-        // L3 Cache Info.
-        l3_cache_size = get_cache_size(CacheLevel::L3);
-        l3_cache_line_size = get_cache_coherency_line_size(CacheLevel::L3);
-        l3_cache_sets = get_cache_number_of_sets(CacheLevel::L3);
-
-        // Cache Shared Info.
-        if l2_cache_size != 0 {
-            l2_cache_shared = get_cache_shared(CacheLevel::L2);
-        }
-        if l3_cache_size != 0 {
-            l3_cache_shared = get_cache_shared(CacheLevel::L3);
-        }
-    } else {
-        warn!("cache sysfs system does not exist.");
-    }
+    let cache_info = read_cache_topology();
+    let cache_exist = cache_info.is_some();
+    let CacheTopologyInfo {
+        l1_d_cache_size,
+        l1_d_cache_line_size,
+        l1_d_cache_sets,
+        l1_i_cache_size,
+        l1_i_cache_line_size,
+        l1_i_cache_sets,
+        l2_cache_size,
+        l2_cache_line_size,
+        l2_cache_sets,
+        l3_cache_size,
+        l3_cache_line_size,
+        l3_cache_sets,
+        l2_cache_shared,
+        l3_cache_shared,
+    } = cache_info.unwrap_or_default();
 
     // Arm boot protocol requires a minimal Device Tree
     // https://docs.kernel.org/arch/arm64/booting.html

--- a/arch/src/aarch64/fdt.rs
+++ b/arch/src/aarch64/fdt.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 use std::hash::BuildHasher;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use std::{cmp, fs, result, str};
+use std::{cmp, result, str};
 
 use byteorder::{BigEndian, ByteOrder};
 use fdt_parser::node::FdtNode;
@@ -27,6 +27,10 @@ use vm_fdt::{FdtWriter, FdtWriterResult};
 use vm_memory::{Address, Bytes, GuestMemory, GuestMemoryError, GuestMemoryRegion};
 
 use super::super::{DeviceType, GuestMemoryMmap, InitramfsConfig};
+use super::cache::{
+    CacheLevel, get_cache_coherency_line_size, get_cache_number_of_sets, get_cache_shared,
+    get_cache_size,
+};
 use super::layout::{
     GIC_V2M_COMPATIBLE, GICV2M_SPI_BASE, GICV2M_SPI_NUM, IRQ_BASE, MEM_32BIT_DEVICES_SIZE,
     MEM_32BIT_DEVICES_START, MEM_PCI_IO_SIZE, MEM_PCI_IO_START, PCI_HIGH_BASE,
@@ -89,121 +93,6 @@ pub enum Error {
     WriteFdtToMemory(#[source] GuestMemoryError),
 }
 type Result<T> = result::Result<T, Error>;
-
-#[derive(Copy, Clone)]
-pub enum CacheLevel {
-    /// L1 data cache
-    L1D = 0,
-    /// L1 instruction cache
-    L1I = 1,
-    /// L2 cache
-    L2 = 2,
-    /// L3 cache
-    L3 = 3,
-}
-
-/// NOTE: cache size file directory example,
-/// "/sys/devices/system/cpu/cpu0/cache/index0/size".
-pub fn get_cache_size(cache_level: CacheLevel) -> u32 {
-    let mut file_directory: String = "/sys/devices/system/cpu/cpu0/cache".to_string();
-    match cache_level {
-        CacheLevel::L1D => file_directory += "/index0/size",
-        CacheLevel::L1I => file_directory += "/index1/size",
-        CacheLevel::L2 => file_directory += "/index2/size",
-        CacheLevel::L3 => file_directory += "/index3/size",
-    }
-
-    let file_path = Path::new(&file_directory);
-    if file_path.exists() {
-        let src = fs::read_to_string(file_directory).expect("File not exists or file corrupted.");
-        // The content of the file is as simple as a size, like: "32K"
-        let src = src.trim();
-        let src_digits: u32 = src[0..src.len() - 1].parse().unwrap();
-        let src_unit = &src[src.len() - 1..];
-
-        src_digits
-            * match src_unit {
-                "K" => 1024,
-                "M" => 1024u32.pow(2),
-                "G" => 1024u32.pow(3),
-                _ => 1,
-            }
-    } else {
-        0
-    }
-}
-
-/// NOTE: coherency_line_size file directory example,
-/// "/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size".
-pub fn get_cache_coherency_line_size(cache_level: CacheLevel) -> u32 {
-    let mut file_directory: String = "/sys/devices/system/cpu/cpu0/cache".to_string();
-    match cache_level {
-        CacheLevel::L1D => file_directory += "/index0/coherency_line_size",
-        CacheLevel::L1I => file_directory += "/index1/coherency_line_size",
-        CacheLevel::L2 => file_directory += "/index2/coherency_line_size",
-        CacheLevel::L3 => file_directory += "/index3/coherency_line_size",
-    }
-
-    let file_path = Path::new(&file_directory);
-    if file_path.exists() {
-        let src = fs::read_to_string(file_directory).expect("File not exists or file corrupted.");
-        src.trim().parse::<u32>().unwrap()
-    } else {
-        0
-    }
-}
-
-/// NOTE: number_of_sets file directory example,
-/// "/sys/devices/system/cpu/cpu0/cache/index0/number_of_sets".
-pub fn get_cache_number_of_sets(cache_level: CacheLevel) -> u32 {
-    let mut file_directory: String = "/sys/devices/system/cpu/cpu0/cache".to_string();
-    match cache_level {
-        CacheLevel::L1D => file_directory += "/index0/number_of_sets",
-        CacheLevel::L1I => file_directory += "/index1/number_of_sets",
-        CacheLevel::L2 => file_directory += "/index2/number_of_sets",
-        CacheLevel::L3 => file_directory += "/index3/number_of_sets",
-    }
-
-    let file_path = Path::new(&file_directory);
-    if file_path.exists() {
-        let src = fs::read_to_string(file_directory).expect("File not exists or file corrupted.");
-        src.trim().parse::<u32>().unwrap()
-    } else {
-        0
-    }
-}
-
-/// NOTE: shared_cpu_list file directory example,
-/// "/sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list".
-pub fn get_cache_shared(cache_level: CacheLevel) -> bool {
-    let mut file_directory: String = "/sys/devices/system/cpu/cpu0/cache".to_string();
-    let mut result = true;
-
-    match cache_level {
-        CacheLevel::L1D | CacheLevel::L1I => result = false,
-        CacheLevel::L2 => file_directory += "/index2/shared_cpu_list",
-        CacheLevel::L3 => file_directory += "/index3/shared_cpu_list",
-    }
-
-    if !result {
-        return false;
-    }
-
-    let file_path = Path::new(&file_directory);
-    if file_path.exists() {
-        let src = fs::read_to_string(file_directory).expect("File not exists or file corrupted.");
-        let src = src.trim();
-        if src.is_empty() {
-            result = false;
-        } else {
-            result = src.contains('-') || src.contains(',');
-        }
-    } else {
-        result = false;
-    }
-
-    result
-}
 
 /// Creates the flattened device tree for this aarch64 VM.
 #[expect(clippy::too_many_arguments)]

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -2,6 +2,8 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Module for cache info.
+pub mod cache;
 /// Module for the flattened device tree.
 pub mod fdt;
 /// Layout for this aarch64 system.

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -12456,6 +12456,52 @@ mod aarch64_acpi {
     fn test_virtio_iommu() {
         _test_virtio_iommu(true);
     }
+
+    #[test]
+    fn test_cache_topology() {
+        let jammy = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+
+        vec![Box::new(jammy)].drain(..).for_each(|disk_config| {
+            let guest = Guest::new(disk_config);
+
+            let mut child = GuestCommand::new(&guest)
+                .default_cpus()
+                .default_memory()
+                .args(["--kernel", edk2_path().to_str().unwrap()])
+                .default_disks()
+                .default_net()
+                .args(["--serial", "tty", "--console", "off"])
+                .capture_output()
+                .spawn()
+                .unwrap();
+
+            let r = panic::catch_unwind(|| {
+                guest.wait_vm_boot().unwrap();
+
+                let cache_levels = ["L1d", "L1i", "L2", "L3"];
+                for level in cache_levels {
+                    let host_sz = exec_host_command_output(&format!(
+                        "lscpu -C=NAME,ONE-SIZE | grep \"{level}\" | awk '{{print $2}}'"
+                    ));
+                    let guest_sz = guest
+                        .ssh_command(&format!(
+                            "lscpu -C=NAME,ONE-SIZE | grep \"{level}\" | awk '{{print $2}}'"
+                        ))
+                        .unwrap();
+                    assert_eq!(
+                        String::from_utf8_lossy(&host_sz.stdout).trim(),
+                        guest_sz.trim(),
+                        "Cache size mismatch for {level}"
+                    );
+                }
+            });
+
+            let _ = child.kill();
+            let output = child.wait_with_output().unwrap();
+
+            handle_child_output(r, &output);
+        });
+    }
 }
 
 mod rate_limiter {

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -884,9 +884,12 @@ fn create_acpi_tables_internal(
     {
         let pptt = cpu_manager.create_pptt();
         let pptt_addr = prev_tbl_addr.checked_add(prev_tbl_len).unwrap();
-        tables_bytes.extend_from_slice(pptt.as_slice());
+        let mut pptt_bytes = Vec::new();
+
+        pptt.to_aml_bytes(&mut pptt_bytes);
+        tables_bytes.extend_from_slice(&pptt_bytes);
         xsdt_table_pointers.push(pptt_addr.0);
-        prev_tbl_len = pptt.len() as u64;
+        prev_tbl_len = pptt_bytes.len() as u64;
         prev_tbl_addr = pptt_addr;
     }
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -21,10 +21,12 @@ use std::sync::{Arc, Barrier, Mutex};
 use std::{any, cmp, hint, io, panic, result, thread, time};
 
 #[cfg(target_arch = "aarch64")]
-use acpi_tables::pptt::{PPTT, ProcessorNode};
+use acpi_tables::pptt::{CacheNodeBuilder, CacheType, PPTT, ProcessorNode};
 use acpi_tables::sdt::Sdt;
 use acpi_tables::{Aml, aml};
 use anyhow::anyhow;
+#[cfg(target_arch = "aarch64")]
+use arch::aarch64::cache::{CacheTopologyInfo, read_cache_topology};
 use arch::{EntryPoint, NumaNodes, layout};
 #[cfg(target_arch = "aarch64")]
 use devices::gic::Gic;
@@ -1945,11 +1947,90 @@ impl CpuManager {
             .unwrap_or((1, u16::try_from(self.max_vcpus()).unwrap(), 1, 1));
         let cores_per_package = cores_per_die * dies_per_package;
 
+        // Add cache info.
+        let cache_info = read_cache_topology();
+        let CacheTopologyInfo {
+            l1_d_cache_size,
+            l1_d_cache_line_size,
+            l1_d_cache_sets,
+            l1_i_cache_size,
+            l1_i_cache_line_size,
+            l1_i_cache_sets,
+            l2_cache_size,
+            l2_cache_line_size,
+            l2_cache_sets,
+            l3_cache_size,
+            l3_cache_line_size,
+            l3_cache_sets,
+            ..
+        } = cache_info.unwrap_or_default();
+
         let mut pptt = PPTT::new(*b"CLOUDH", *b"CHPPTT  ", 1);
+
+        let l3_cache_handle = if l3_cache_size != 0 {
+            let l3_cache_node = CacheNodeBuilder::default()
+                .cache_type(CacheType::Unified)
+                .sets(l3_cache_sets)
+                .size(l3_cache_size)
+                .line_size(l3_cache_line_size as u16)
+                .to_node();
+            Some(pptt.add_cache(l3_cache_node))
+        } else {
+            None
+        };
+
+        let l2_cache_handle = if l2_cache_size != 0 {
+            let l2_cache_node = CacheNodeBuilder::default()
+                .cache_type(CacheType::Unified)
+                .sets(l2_cache_sets)
+                .size(l2_cache_size)
+                .line_size(l2_cache_line_size as u16)
+                .to_node();
+            Some(pptt.add_cache(l2_cache_node))
+        } else {
+            None
+        };
+
+        let l1d_cache_handle = if l1_d_cache_size != 0 {
+            let mut l1d_cache_node = CacheNodeBuilder::default()
+                .cache_type(CacheType::Data)
+                .sets(l1_d_cache_sets)
+                .size(l1_d_cache_size)
+                .line_size(l1_d_cache_line_size as u16);
+
+            if let Some(ref l2_cache_handle) = l2_cache_handle {
+                l1d_cache_node = l1d_cache_node.next_level(l2_cache_handle);
+            }
+
+            Some(pptt.add_cache(l1d_cache_node.to_node()))
+        } else {
+            None
+        };
+
+        let l1i_cache_handle = if l1_i_cache_size != 0 {
+            let mut l1i_cache_node = CacheNodeBuilder::default()
+                .cache_type(CacheType::Instruction)
+                .sets(l1_i_cache_sets)
+                .size(l1_i_cache_size)
+                .line_size(l1_i_cache_line_size as u16);
+
+            if let Some(ref l2_cache_handle) = l2_cache_handle {
+                l1i_cache_node = l1i_cache_node.next_level(l2_cache_handle);
+            }
+
+            Some(pptt.add_cache(l1i_cache_node.to_node()))
+        } else {
+            None
+        };
 
         for cluster_idx in 0..packages {
             if cpus < self.config.boot_vcpus as usize {
-                let cluster_hierarchy_node = ProcessorNode::new(None, cluster_idx as u32).valid();
+                let mut cluster_hierarchy_node =
+                    ProcessorNode::new(None, cluster_idx as u32).valid();
+                if let Some(ref l3_cache_handle) = l3_cache_handle {
+                    cluster_hierarchy_node = cluster_hierarchy_node.add_cache(l3_cache_handle);
+                }
+
                 let cluster_handle = pptt.add_processor(cluster_hierarchy_node);
 
                 for core_idx in 0..cores_per_package {
@@ -1959,19 +2040,41 @@ impl CpuManager {
                         let core_handle = pptt.add_processor(core_hierarchy_node);
 
                         for _thread_idx in 0..threads_per_core {
-                            let thread_hierarchy_node =
+                            let mut thread_hierarchy_node =
                                 ProcessorNode::new(Some(&core_handle), uid as u32)
                                     .valid()
                                     .thread()
                                     .leaf();
+
+                            if let Some(ref l1d_cache_handle) = l1d_cache_handle {
+                                thread_hierarchy_node =
+                                    thread_hierarchy_node.add_cache(l1d_cache_handle);
+                            }
+
+                            if let Some(ref l1i_cache_handle) = l1i_cache_handle {
+                                thread_hierarchy_node =
+                                    thread_hierarchy_node.add_cache(l1i_cache_handle);
+                            }
+
                             pptt.add_processor(thread_hierarchy_node);
                             uid += 1;
                         }
                     } else {
-                        let thread_hierarchy_node =
+                        let mut thread_hierarchy_node =
                             ProcessorNode::new(Some(&cluster_handle), uid as u32)
                                 .valid()
                                 .leaf();
+
+                        if let Some(ref l1d_cache_handle) = l1d_cache_handle {
+                            thread_hierarchy_node =
+                                thread_hierarchy_node.add_cache(l1d_cache_handle);
+                        }
+
+                        if let Some(ref l1i_cache_handle) = l1i_cache_handle {
+                            thread_hierarchy_node =
+                                thread_hierarchy_node.add_cache(l1i_cache_handle);
+                        }
+
                         pptt.add_processor(thread_hierarchy_node);
                         uid += 1;
                     }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -20,6 +20,8 @@ use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use std::{any, cmp, hint, io, panic, result, thread, time};
 
+#[cfg(target_arch = "aarch64")]
+use acpi_tables::pptt::{PPTT, ProcessorNode};
 use acpi_tables::sdt::Sdt;
 use acpi_tables::{Aml, aml};
 use anyhow::anyhow;
@@ -413,19 +415,6 @@ struct GicIts {
     pub translation_id: u32,
     pub base_address: u64,
     pub reserved1: u32,
-}
-
-#[cfg(target_arch = "aarch64")]
-#[repr(C, packed)]
-#[derive(IntoBytes, Immutable, FromBytes)]
-struct ProcessorHierarchyNode {
-    pub r#type: u8,
-    pub length: u8,
-    pub reserved: u16,
-    pub flags: u32,
-    pub parent: u32,
-    pub acpi_processor_id: u32,
-    pub num_private_resources: u32,
 }
 
 #[cfg(target_arch = "riscv64")]
@@ -1945,8 +1934,7 @@ impl CpuManager {
     }
 
     #[cfg(target_arch = "aarch64")]
-    pub fn create_pptt(&self) -> Sdt {
-        let pptt_start = 0;
+    pub fn create_pptt(&self) -> PPTT {
         let mut cpus = 0;
         let mut uid = 0;
         // If topology is not specified, the default setting is:
@@ -1957,61 +1945,34 @@ impl CpuManager {
             .unwrap_or((1, u16::try_from(self.max_vcpus()).unwrap(), 1, 1));
         let cores_per_package = cores_per_die * dies_per_package;
 
-        let mut pptt = Sdt::new(*b"PPTT", 36, 2, *b"CLOUDH", *b"CHPPTT  ", 1);
+        let mut pptt = PPTT::new(*b"CLOUDH", *b"CHPPTT  ", 1);
 
         for cluster_idx in 0..packages {
             if cpus < self.config.boot_vcpus as usize {
-                let cluster_offset = pptt.len() - pptt_start;
-                let cluster_hierarchy_node = ProcessorHierarchyNode {
-                    r#type: 0,
-                    length: 20,
-                    reserved: 0,
-                    flags: 0x2,
-                    parent: 0,
-                    acpi_processor_id: cluster_idx as u32,
-                    num_private_resources: 0,
-                };
-                pptt.append(cluster_hierarchy_node);
+                let cluster_hierarchy_node = ProcessorNode::new(None, cluster_idx as u32).valid();
+                let cluster_handle = pptt.add_processor(cluster_hierarchy_node);
 
                 for core_idx in 0..cores_per_package {
-                    let core_offset = pptt.len() - pptt_start;
-
                     if threads_per_core > 1 {
-                        let core_hierarchy_node = ProcessorHierarchyNode {
-                            r#type: 0,
-                            length: 20,
-                            reserved: 0,
-                            flags: 0x2,
-                            parent: cluster_offset as u32,
-                            acpi_processor_id: core_idx as u32,
-                            num_private_resources: 0,
-                        };
-                        pptt.append(core_hierarchy_node);
+                        let core_hierarchy_node =
+                            ProcessorNode::new(Some(&cluster_handle), core_idx as u32).valid();
+                        let core_handle = pptt.add_processor(core_hierarchy_node);
 
                         for _thread_idx in 0..threads_per_core {
-                            let thread_hierarchy_node = ProcessorHierarchyNode {
-                                r#type: 0,
-                                length: 20,
-                                reserved: 0,
-                                flags: 0xE,
-                                parent: core_offset as u32,
-                                acpi_processor_id: uid as u32,
-                                num_private_resources: 0,
-                            };
-                            pptt.append(thread_hierarchy_node);
+                            let thread_hierarchy_node =
+                                ProcessorNode::new(Some(&core_handle), uid as u32)
+                                    .valid()
+                                    .thread()
+                                    .leaf();
+                            pptt.add_processor(thread_hierarchy_node);
                             uid += 1;
                         }
                     } else {
-                        let thread_hierarchy_node = ProcessorHierarchyNode {
-                            r#type: 0,
-                            length: 20,
-                            reserved: 0,
-                            flags: 0xA,
-                            parent: cluster_offset as u32,
-                            acpi_processor_id: uid as u32,
-                            num_private_resources: 0,
-                        };
-                        pptt.append(thread_hierarchy_node);
+                        let thread_hierarchy_node =
+                            ProcessorNode::new(Some(&cluster_handle), uid as u32)
+                                .valid()
+                                .leaf();
+                        pptt.add_processor(thread_hierarchy_node);
                         uid += 1;
                     }
                 }
@@ -2019,7 +1980,6 @@ impl CpuManager {
             }
         }
 
-        pptt.update_checksum();
         pptt
     }
 


### PR DESCRIPTION
Closes #7761

This pull request refactors and enhances the handling of CPU cache topology information for aarch64. It moves cache information utilities into a dedicated module, updates the ACPI PPTT (Processor Properties Topology Table) construction to include detailed cache hierarchy data, and adds an integration test to verify that cache topology is correctly exposed to guests. Additionally, it updates dependencies and improves code organization.

**Aarch64 cache topology refactor and enhancements:**

* Moved cache information functions and the `CacheLevel` enum from `fdt.rs` to a new `arch/src/aarch64/cache.rs` module, and updated imports accordingly for better code organization and reuse.
* Refactored the aarch64 ACPI PPTT table construction in `CpuManager::create_pptt` to use the new cache module, and now populates the PPTT with detailed cache hierarchy (L1d, L1i, L2, L3) information as available from sysfs, using the `acpi_tables` crate's PPTT API.

**Testing and validation:**

* Added an integration test (`test_cache_topology`) to verify that the guest sees the same cache sizes as the host, ensuring the PPTT and cache information are correctly exposed.

**Other improvements:**

* Updated ACPI table generation to use the helpers from the `acpi_tables` crate.