### PR TITLE
build: Use released vfio & vhost crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,16 +2277,18 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vfio-bindings"
-version = "0.6.1"
-source = "git+https://github.com/rust-vmm/vfio?rev=df861a878168ad71602d8a1945bd3b7acbd22693#df861a878168ad71602d8a1945bd3b7acbd22693"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "188dac3057a0cbc94470085204c84b82ff7ec5dac629a514323cd133d1f9abe0"
 dependencies = [
  "vmm-sys-util",
 ]
 
 [[package]]
 name = "vfio-ioctls"
-version = "0.5.2"
-source = "git+https://github.com/rust-vmm/vfio?rev=df861a878168ad71602d8a1945bd3b7acbd22693#df861a878168ad71602d8a1945bd3b7acbd22693"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c80c6d52f8e592e31a8f7eb45e882a9617aa61ec2479981a175e9f0a79f2434e"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -2303,8 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "vfio_user"
-version = "0.1.2"
-source = "git+https://github.com/rust-vmm/vfio?rev=df861a878168ad71602d8a1945bd3b7acbd22693#df861a878168ad71602d8a1945bd3b7acbd22693"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731c2582dd43f4f174ab47b4c933a1a9bb872d9d1b7f54c5867e12dbc1491b75"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -2320,8 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.15.0"
-source = "git+https://github.com/rust-vmm/vhost?rev=c9b80a1c93bac7820e4aee4269aa904568937035#c9b80a1c93bac7820e4aee4269aa904568937035"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee90657203a8644e9a0860a0db6a7887d8ef0c7bc09fc22dfa4ae75df65bac86"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -2332,8 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.21.0"
-source = "git+https://github.com/rust-vmm/vhost?rev=c9b80a1c93bac7820e4aee4269aa904568937035#c9b80a1c93bac7820e4aee4269aa904568937035"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5925983d8fb537752ad3e26604c0a17abfa5de77cb6773a096c8a959c9eca0f"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,11 +59,11 @@ linux-loader = "0.13.2"
 mshv-bindings = "0.6.7"
 mshv-ioctls = "0.6.7"
 seccompiler = "0.5.0"
-vfio-bindings = { git = "https://github.com/rust-vmm/vfio", rev = "df861a878168ad71602d8a1945bd3b7acbd22693", default-features = false }
-vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", rev = "df861a878168ad71602d8a1945bd3b7acbd22693", default-features = false }
-vfio_user = { git = "https://github.com/rust-vmm/vfio", rev = "df861a878168ad71602d8a1945bd3b7acbd22693", default-features = false }
-vhost = { git = "https://github.com/rust-vmm/vhost", rev = "c9b80a1c93bac7820e4aee4269aa904568937035", default-features = false }
-vhost-user-backend = { git = "https://github.com/rust-vmm/vhost", rev = "c9b80a1c93bac7820e4aee4269aa904568937035", default-features = false }
+vfio-bindings = { version = "0.6.2", default-features = false }
+vfio-ioctls = { version = "0.5.3", default-features = false }
+vfio_user = { version = "0.1.3", default-features = false }
+vhost = { version = "0.16.0", default-features = false }
+vhost-user-backend = { version = "0.22.0", default-features = false }
 virtio-bindings = "0.2.6"
 virtio-queue = "0.17.0"
 vm-fdt = "0.3.0"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1273,16 +1273,18 @@ dependencies = [
 
 [[package]]
 name = "vfio-bindings"
-version = "0.6.1"
-source = "git+https://github.com/rust-vmm/vfio?rev=df861a878168ad71602d8a1945bd3b7acbd22693#df861a878168ad71602d8a1945bd3b7acbd22693"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "188dac3057a0cbc94470085204c84b82ff7ec5dac629a514323cd133d1f9abe0"
 dependencies = [
  "vmm-sys-util",
 ]
 
 [[package]]
 name = "vfio-ioctls"
-version = "0.5.2"
-source = "git+https://github.com/rust-vmm/vfio?rev=df861a878168ad71602d8a1945bd3b7acbd22693#df861a878168ad71602d8a1945bd3b7acbd22693"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c80c6d52f8e592e31a8f7eb45e882a9617aa61ec2479981a175e9f0a79f2434e"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -1297,8 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "vfio_user"
-version = "0.1.2"
-source = "git+https://github.com/rust-vmm/vfio?rev=df861a878168ad71602d8a1945bd3b7acbd22693#df861a878168ad71602d8a1945bd3b7acbd22693"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731c2582dd43f4f174ab47b4c933a1a9bb872d9d1b7f54c5867e12dbc1491b75"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -1314,8 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.15.0"
-source = "git+https://github.com/rust-vmm/vhost?rev=c9b80a1c93bac7820e4aee4269aa904568937035#c9b80a1c93bac7820e4aee4269aa904568937035"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee90657203a8644e9a0860a0db6a7887d8ef0c7bc09fc22dfa4ae75df65bac86"
 dependencies = [
  "bitflags 2.11.0",
  "libc",


### PR DESCRIPTION
Replace the git dependencies with newly released versions

Signed-off-by: Rob Bradford <rbradford@meta.com>
