### PR TITLE
vmm: handle malformed balloon actual from guest

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2061,7 +2061,7 @@ impl RequestHandler for Vmm {
 
                 let mut memory_actual_size = config.memory.total_size();
                 if let Some(vm) = &self.vm {
-                    memory_actual_size -= vm.balloon_size();
+                    memory_actual_size = memory_actual_size.saturating_sub(vm.balloon_size());
                 }
 
                 let device_tree = self


### PR DESCRIPTION
The actual size of the balloon is taken directly from the guest. A misbehaving guest can set it to an arbitrary value and cause underflow on the next vm.info call. Use a saturation_sub instead to avoid a panic in a debug build or a crazy number in a release build.