### PR TITLE
pci: clamp sparse mmap holes to physical BAR

### DIFF
--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1564,13 +1564,33 @@ impl VfioPciDevice {
                             let (offset, size) = msix.cap.table_range();
                             let offset = align_page_size_down(offset);
                             let size = align_page_size_up(size);
-                            inter_ranges.insert(offset, size);
+                            // MSI-X mmap region safety: when a device has a non page
+                            // aligned MSI-X offset, fixup_msix_region() relocates MSI-X
+                            // to the upper half of an enlarged virtual BAR, causing the
+                            // offsets in msix.cap to exceed the physical BAR size. This
+                            // check skips carving a hole, preventing invalid offsets from
+                            // reaching the mmap path. With no holes,
+                            // generate_sparse_areas() returns a single sparse region
+                            // covering the entire physical BAR. The relocated MSI-X in
+                            // the virtual BAR remains trapped because its upper half has
+                            // no mmap backing. Exposing the physical MSI-X region through
+                            // mmap is safe when the kernel advertises
+                            // VFIO_REGION_INFO_CAP_MSIX_MAPPABLE. When MSI-X offsets are
+                            // already page aligned, fixup_msix_region() does not relocate
+                            // and this check is satisfied, so a hole is carved at the
+                            // intended offset as before.
+                            if offset < region_size {
+                                inter_ranges.insert(offset, size);
+                            }
                         }
                         if region_index == msix.cap.pba_bir() {
                             let (offset, size) = msix.cap.pba_range();
                             let offset = align_page_size_down(offset);
                             let size = align_page_size_up(size);
-                            inter_ranges.insert(offset, size);
+                            // See MSI-X mmap safety comment above.
+                            if offset < region_size {
+                                inter_ranges.insert(offset, size);
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Summary

  - Guard `inter_ranges.insert()` with `offset < region_size`
    check in `generate_sparse_areas()` so relocated MSI-X
    offsets beyond the physical BAR are skipped
  - Full physical BAR is mmapped as a single region
  - MSI-X trap preserved at relocated offset in virtual BAR

  ## Test

  KIOXIA CD8P NVMe SSD (MSI-X at 0x5200, PBA at 0xd600) passed through via VFIO.
  ```
   21:00.0 Non-Volatile memory controller: KIOXIA Corporation NVMe SSD Controller CD8P EDSFF (rev 01) 
   ...
   Region 0: Memory at c6710000 (64-bit, non-prefetchable) [size=64K]
   Expansion ROM at c6700000 [disabled] [size=64K]
   ...
   Capabilities: [b0] MSI-X: Enable- Count=129 Masked-
          Vector table: BAR=0 offset=00005200
          PBA: BAR=0 offset=0000d600
   ...
   Kernel driver in use: vfio-pci
   ...
  ```
  Launch
  ```
    ./cloud-hypervisor.fixup_msix \
          --firmware ./CLOUDHV.fd \
          --disk path=noble-server-cloudimg-amd64-custom-20260327-0.raw path=./ubuntu-cloudinit.img \
          --cpus boot=4 \
          --memory size=1024M \
          --net "tap=,mac=,ip=,mask=" \
          --device path=/sys/bus/pci/devices/0000\:21\:00.0/ \
          --serial tty \
          --console off
  ```

  Guest lspci confirms BAR doubled and MSI-X relocated:
  ```
  Region 0: Memory at 100100000 (64-bit, non-prefetchable) [size=128K]
  Expansion ROM at c0100000 [disabled] [size=64K]
   ...
  Capabilities: [b0] MSI-X: Enable+ Count=129 Masked-
          Vector table: BAR=0 offset=00010000
          PBA: BAR=0 offset=00018400
  ...
  Kernel driver in use: nvme
  ```

  Guest `dmesg` confirmed NVMe fully operational:
  ```
  nvme nvme0: pci function 0000:00:05.0
  nvme nvme0: 4/0/0 default/read/poll queues
 ```


Fixes: #7898

Signed-off-by: Saravanan D <saravanand@crusoe.ai>