### PR TITLE
scripts: Fix volume argument splitting in dev_cli.sh

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -165,7 +165,7 @@ process_volumes_args() {
         return
     fi
     exported_volumes=""
-    arr_vols=("${arg_vols//#/ }")
+    IFS='#' read -ra arr_vols <<<"$arg_vols"
     for var in "${arr_vols[@]}"; do
         dev=$(echo "$var" | cut -d ':' -f 1)
         if [[ ! -e "$dev" ]]; then


### PR DESCRIPTION
Use IFS-based splitting instead of parameter expansion to correctly separate '#'-delimited volume paths in
process_volumes_args(). The previous approach placed all volumes into a single array element, causing Docker to receive malformed --volume arguments.