### PR TITLE
vmm: fix rebooting with landlock and pty console

### DIFF
--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -553,6 +553,10 @@ pub fn default_consoleconfig_file() -> Option<PathBuf> {
 
 impl ApplyLandlock for ConsoleConfig {
     fn apply_landlock(&self, landlock: &mut Landlock) -> LandlockResult<()> {
+        if self.mode == ConsoleOutputMode::Pty {
+            landlock.add_rule_with_access(Path::new("/dev/pts"), "rw")?;
+            landlock.add_rule_with_access(Path::new("/dev/ptmx"), "rw")?;
+        }
         if let Some(file) = &self.file {
             landlock.add_rule_with_access(file, "rw")?;
         }
@@ -586,6 +590,10 @@ impl Default for DebugConsoleConfig {
 #[cfg(target_arch = "x86_64")]
 impl ApplyLandlock for DebugConsoleConfig {
     fn apply_landlock(&self, landlock: &mut Landlock) -> LandlockResult<()> {
+        if self.mode == ConsoleOutputMode::Pty {
+            landlock.add_rule_with_access(Path::new("/dev/pts"), "rw")?;
+            landlock.add_rule_with_access(Path::new("/dev/ptmx"), "rw")?;
+        }
         if let Some(file) = &self.file {
             landlock.add_rule_with_access(file, "rw")?;
         }


### PR DESCRIPTION
When landlock support was added, creation of file descriptors was moved out into a function called `pre_create_console_devices`, with the idea being that this could be run before Landlock rules are applied and access to all the necessary paths are dropped.

This idea didn't take reboots into account, though.  When a VM is rebooted, `pre_create_console_devices` is called again, but now the Landlock rules have been applied, so they need to allow access to all those paths anyway.

I imagine the way this was intended to work was that file descriptors would be preserved across reboot, but that's not currently the case, and it's not a trivial change to make because they get dropped when the VM is destroyed.  Longer term it would be ideal if Cloud Hypervisor's implementation was more focused on file descriptors than paths[1], and if created VMs only took references to file descriptors, so they were easily preserved across reboots.

Fixes: b3e5738b4 ("vmm: Introduce ApplyLandlock trait")
Closes: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7547
Link: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7704 [1]