### PR TITLE
build: Enable the vfio CI worker

### DIFF
--- a/.github/workflows/integration-vfio.yaml
+++ b/.github/workflows/integration-vfio.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fix workspace permissions
         if: ${{ github.event_name != 'pull_request' }}
-        run: sudo chown -R runner:runner ${GITHUB_WORKSPACE}
+        run: sudo chown -R github-runner:github-runner ${GITHUB_WORKSPACE}
       - name: Code checkout
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/checkout@v6


### PR DESCRIPTION
This reverts commit https://github.com/cloud-hypervisor/cloud-hypervisor/commit/8aaf3734aadbf550ad7df06328f5c7964fc38220.

Fixes: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7751

Signed-off-by: Saravanan D <saravanand@crusoe.ai>
Signed-off-by: Bo Chen <bchen@crusoe.ai>