### PR TITLE
build: Bump vfio-ioctls to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2286,9 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "vfio-ioctls"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80c6d52f8e592e31a8f7eb45e882a9617aa61ec2479981a175e9f0a79f2434e"
+checksum = "d4b1d98dff7f0d219278e406323e7eda4d426447bd203c7828189baf0d8c07b7"
 dependencies = [
  "byteorder",
  "kvm-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ mshv-bindings = "0.6.7"
 mshv-ioctls = "0.6.7"
 seccompiler = "0.5.0"
 vfio-bindings = { version = "0.6.2", default-features = false }
-vfio-ioctls = { version = "0.5.3", default-features = false }
+vfio-ioctls = { version = "0.6.0", default-features = false }
 vfio_user = { version = "0.1.3", default-features = false }
 vhost = { version = "0.16.0", default-features = false }
 vhost-user-backend = { version = "0.22.0", default-features = false }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1282,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "vfio-ioctls"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80c6d52f8e592e31a8f7eb45e882a9617aa61ec2479981a175e9f0a79f2434e"
+checksum = "d4b1d98dff7f0d219278e406323e7eda4d426447bd203c7828189baf0d8c07b7"
 dependencies = [
  "byteorder",
  "kvm-bindings",


### PR DESCRIPTION
This version is identical but with a new version number as the old
version is yanked due to a semver break.

Signed-off-by: Rob Bradford <rbradford@meta.com>
