### PR TITLE
block: Reject write zeroes with unknown flags

### DIFF
--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -679,7 +679,13 @@ impl Request {
 
                 let wz_sector = u64::from_le_bytes(wz_sector);
                 let wz_num_sectors = u32::from_le_bytes(wz_num_sectors);
+
                 let wz_flags = u32::from_le_bytes(wz_flags);
+                // Per virtio spec v1.2 reject write zeroes if any unknown flag is set.
+                if (wz_flags & !VIRTIO_BLK_WRITE_ZEROES_FLAG_UNMAP) != 0 {
+                    warn!("Unsupported flags {wz_flags:#x} in write zeroes request");
+                    return Err(ExecuteError::Unsupported(VIRTIO_BLK_T_WRITE_ZEROES));
+                }
 
                 let wz_offset = wz_sector * SECTOR_SIZE;
                 if wz_offset == 0 && disable_sector0_writes {


### PR DESCRIPTION
The virtio spec v1.2 in 5.2.6.2 requires that the device MUST return VIRTIO_BLK_S_UNSUPP for write zeroes commands if any unknown flag is set.

Add an early check that rejects requests with reserved flag bits set by returning VIRTIO_BLK_S_UNSUPP via the existing ExecuteError::Unsupported variant.