### PR TITLE
virtio-devices: block: Use error specific status in sync fallback path

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -340,7 +340,7 @@ Setting device status to 'NEEDS_RESET' and stopping processing queues until rese
                     Ok(_) => VIRTIO_BLK_S_OK,
                     Err(e) => {
                         warn!("Request failed: {request:x?} {e:?}");
-                        VIRTIO_BLK_S_IOERR
+                        e.status() as u32
                     }
                 };
 


### PR DESCRIPTION
The sync fallback path in process_queue_submit() hardcoded VIRTIO_BLK_S_IOERR for all errors. This caused unsupported request errors to report IOERR to the guest instead of the correct VIRTIO_BLK_S_UNSUPP.

Use ExecuteError::status() to return the appropriate status code for each error variant.