### PR TITLE
ci: Run pull_request_target workflows with no permisisons

### DIFF
--- a/.github/workflows/mshv-integration.yaml
+++ b/.github/workflows/mshv-integration.yaml
@@ -1,5 +1,6 @@
 name: Cloud Hypervisor Tests (MSHV) (x86_64)
 on: [pull_request_target, merge_group]
+permissions: {}
 
 jobs:
   infra-setup:


### PR DESCRIPTION
The MSHV tests need access to secrets so that they can run workloads in Azure.  It does not need privileged access to GitHub.  Ensure its GITHUB_TOKEN has no permissions.

This is complementary to #7780: instead of hardening the actions themselves, it eliminates the main reason they need to be hardened.