### PR TITLE
github: Introduce cool down periods for non-rust-vmm crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,11 @@ updates:
     interval: weekly
   allow:
     - dependency-type: all
+  cooldown:
+    default-days: 7
+    semver-major-days: 14
+    semver-minor-days: 7
+    semver-patch-days: 3
   ignore:
     - dependency-name: "acpi_tables"
     - dependency-name: "kvm-bindings"


### PR DESCRIPTION
This gives the community more time to react to possible security chain compromises.

We have high confidence that rust-vmm crates are trusted, and the community is fully capable of spotting any issues. There is no need to delay that group.

Ref: https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/

Feel free to suggest different length of time.