### PR TITLE
vmm: restore KVM clock before resuming vCPUs

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3111,7 +3111,8 @@ impl Pausable for Vm {
             .valid_transition(new_state)
             .map_err(|e| MigratableError::Resume(anyhow!("Invalid transition: {e:?}")))?;
 
-        self.cpu_manager.lock().unwrap().resume()?;
+        // Restore KVM clock BEFORE vCPUs start running, so they see correct
+        // TSC/kvmclock from the first instruction after resume.
         #[cfg(target_arch = "x86_64")]
         {
             if let Some(clock) = &self.saved_clock {
@@ -3128,6 +3129,7 @@ impl Pausable for Vm {
         }
 
         self.device_manager.lock().unwrap().resume()?;
+        self.cpu_manager.lock().unwrap().resume()?;
 
         // And we're back to the Running state.
         self.state = new_state;


### PR DESCRIPTION
The resume() method previously started vCPUs before calling KVM_SET_CLOCK, causing guests to execute with stale clock parameters. This is particularly problematic for Windows/Hyper-V guests where the TSC reference page contains outdated scale/offset values, leading to ~4 minute hangs after vm.restore.

Reorder resume() to: set_clock → device_manager.resume → cpu_manager.resume. This matches the inverse of pause() which correctly saves the clock before pausing vCPUs.

close #7930 