### PR TITLE
vmm: call notify_guest_clock_paused for Hyper-V guests

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -2637,16 +2637,16 @@ impl Pausable for CpuManager {
         self.signal_vcpus()
             .map_err(|e| MigratableError::Pause(anyhow!("Error signalling vCPUs: {e}")))?;
 
+        // Notify all guests (including Hyper-V / Windows) that the clock was
+        // paused.  KVM_KVMCLOCK_CTRL updates internal KVM state that affects
+        // both pvclock (Linux) and the Hyper-V TSC reference page, so it must
+        // be called unconditionally.
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         for vcpu in self.vcpus.iter() {
             let vcpu = vcpu.lock().unwrap();
-            if !self.config.kvm_hyperv {
-                vcpu.vcpu.notify_guest_clock_paused().map_err(|e| {
-                    MigratableError::Pause(anyhow!(
-                        "Could not notify guest it has been paused {e:?}"
-                    ))
-                })?;
-            }
+            vcpu.vcpu.notify_guest_clock_paused().map_err(|e| {
+                MigratableError::Pause(anyhow!("Could not notify guest it has been paused {e:?}"))
+            })?;
         }
 
         // The vCPU thread will change its paused state before parking, wait here for each


### PR DESCRIPTION
Previously, KVM_KVMCLOCK_CTRL was skipped when kvm_hyperv=on because Windows does not use pvclock directly. However, KVM internally uses pvclock data structures as the basis for computing the Hyper-V Reference TSC page parameters. Not calling KVM_KVMCLOCK_CTRL means there is no mechanism to signal time discontinuity to Windows guests after pause/resume, contributing to multi-minute hangs.

Remove the kvm_hyperv guard so all guests receive the clock-paused notification.

close #7931 