### PR TITLE
pci: expand sub-page VFIO BAR mmap to page size

### DIFF
--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -21,7 +21,8 @@ use thiserror::Error;
 use vfio_bindings::bindings::vfio::*;
 use vfio_ioctls::{VfioDevice, VfioIrq, VfioOps, VfioRegionInfoCap, VfioRegionSparseMmapArea};
 use vm_allocator::page_size::{
-    align_page_size_down, align_page_size_up, is_4k_aligned, is_4k_multiple, is_page_size_aligned,
+    align_page_size_down, align_page_size_up, get_page_size, is_4k_aligned, is_4k_multiple,
+    is_page_size_aligned,
 };
 use vm_allocator::{AddressAllocator, MemorySlotAllocator, SystemAllocator};
 use vm_device::dma_mapping::ExternalDmaMapping;
@@ -1686,9 +1687,40 @@ impl VfioPciDevice {
                     self.common.interrupt.msix.as_ref(),
                 )?;
 
+                let page_size = get_page_size();
                 for area in sparse_areas.iter() {
+                    // KVM_SET_USER_MEMORY_REGION requires memory_size to be a
+                    // multiple of the host page size. On aarch64 with 64K pages
+                    // a device BAR can be smaller than a page (e.g. 16K NVMe
+                    // BAR).
+                    //
+                    // The kernel only sets VFIO_REGION_INFO_FLAG_MMAP on sub-page
+                    // BARs after verifying the physical BAR start is page-aligned
+                    // and reserving the rest of the page. Expansion is only safe
+                    // at offset 0 where the kernel reservation applies.
+                    //
+                    // fixup_msix_region() ensures MSI-X relocation at >= page_size
+                    // offset, so the expanded mmap cannot overlap the trap region.
+                    let mmap_len = if area.size < page_size {
+                        if area.offset != 0 {
+                            error!(
+                                "BAR {}: sub-page sparse area at non-zero offset 0x{:x} \
+                                 cannot be safely expanded to page size",
+                                region.index, area.offset,
+                            );
+                            return Err(VfioPciError::MmapArea);
+                        }
+                        info!(
+                            "BAR {}: expanding sub-page sparse area mmap from 0x{:x} to \
+                             page size 0x{:x}",
+                            region.index, area.size, page_size,
+                        );
+                        page_size
+                    } else {
+                        area.size
+                    };
                     let mapping = match MmapRegion::mmap(
-                        area.size,
+                        mmap_len,
                         prot,
                         fd,
                         mmap_offset,
@@ -1699,7 +1731,7 @@ impl VfioPciDevice {
                             error!(
                                 "Could not mmap sparse area (offset = 0x{:x}, size = 0x{:x}): {}",
                                 mmap_offset,
-                                area.size,
+                                mmap_len,
                                 std::io::Error::last_os_error()
                             );
                             return Err(VfioPciError::MmapArea);


### PR DESCRIPTION
On aarch64 with 64K host pages, VFIO passthrough of devices with sub-page BARs (e.g. 16K NVMe BAR0) crashes with EINVAL from KVM_SET_USER_MEMORY_REGION, which requires memory_size to be a multiple of the host page size.

Expand the mmap to page size instead of rejecting it, matching QEMU's approach. The kernel's vfio_pci_probe_mmaps() already verifies that sub-page BARs are page-aligned and reserves the remainder of the page, so this is safe.

The expanded mmap region will not overlap with the relocated MSI-X trap region because `fixup_msix_region()` ensures MSI-X relocation at >= page_size offset.

 **Validation**

 **Host**: aarch64, 64K pages (kernel 6.11), VFIO passthrough.
 **Device Under Test**

  Intel NVMe DC SSD [3DNAND, Sentinel Rock Controller] — 16K BAR0 with MSI-X in the same BAR.
```
  0006:01:00.0 Non-Volatile memory controller: Intel Corporation NVMe DC SSD
    Region 0: Memory at 630040010000 (64-bit, non-prefetchable) [size=16K]
    Capabilities: [50] MSI-X: Enable- Count=136 Masked-
            Vector table: BAR=0 offset=00002000
            PBA: BAR=0 offset=00003000
```

Launch
```
sudo /home/saravanand/cloud-hypervisor/target/aarch64-unknown-linux-musl/release/cloud-hypervisor \
    --cpus boot=4 \
    --memory size=0 \
    --memory-zone id=mem0,size=1G id=mem1,size=1G \
    --numa \
        guest_numa_id=0,cpus=[0-1],distances=[1@20,2@15],memory_zones=mem0 \
        guest_numa_id=1,cpus=[2-3],distances=[0@20,2@25],memory_zones=mem1 \
        guest_numa_id=2,device_id=nvme0,distances=[0@15,1@25] \
    --firmware /home/saravanand/test-generic-initiator/CLOUDHV_EFI.fd \
    --disk path=/home/saravanand/test-generic-initiator/ubuntu-24.04-server-cloudimg-arm64.raw \
           path=/home/saravanand/test-generic-initiator/seed.img \
    --device id=nvme0,path=/sys/bus/pci/devices/0006:01:00.0 \
    --net "tap=,mac=,ip=192.168.249.1,mask=255.255.255.0" \
    --serial tty \
    --console off
```

  **Functional**

  - Guest enumerates NVMe controller and creates block device (/dev/nvme0n1)
  - Guest lspci shows doubled virtual BAR (128K) with MSI-X relocated to upper half
  - dmesg confirms 4/0/0 default/read/poll queues — full NVMe operation

  Performance (fio 4K random read, io_uring, iodepth=64, numjobs=4, 60s, 3 runs)
  ```
ubuntu@ubuntu:~$ sudo fio \
      --name=randread \
      --ioengine=io_uring \
      --direct=1 \
      --bs=4k \
      --iodepth=64 \
      --numjobs=4 \
      --rw=randread \
      --size=1G \
      --runtime=60 \
      --time_based \
      --filename=/dev/nvme0n1 \
      --group_reporting
  ```
  Median IOPS: **747,589** — no regression from baseline Pre-#7904
  
  
  