### PR TITLE
pci: Save deferred BAR reprogramming state

### DIFF
--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -422,6 +422,9 @@ pub struct PciConfigurationState {
     rom_bar_used: bool,
     last_capability: Option<(usize, usize)>,
     msix_cap_reg_idx: Option<usize>,
+    // Preserve deferred BAR moves across snapshot and restore.
+    #[serde(default)]
+    pending_bar_reprogram: Vec<BarReprogrammingParams>,
 }
 
 /// Contains the configuration space of a PCI node.
@@ -557,6 +560,7 @@ impl PciConfiguration {
             rom_bar_used,
             last_capability,
             msix_cap_reg_idx,
+            pending_bar_reprogram,
         ) = if let Some(state) = state {
             (
                 state.registers.try_into().unwrap(),
@@ -567,6 +571,7 @@ impl PciConfiguration {
                 state.rom_bar_used,
                 state.last_capability,
                 state.msix_cap_reg_idx,
+                state.pending_bar_reprogram,
             )
         } else {
             let mut registers = [0u32; NUM_CONFIGURATION_REGISTERS];
@@ -606,6 +611,7 @@ impl PciConfiguration {
                 false,
                 None,
                 None,
+                Vec::new(),
             )
         };
 
@@ -619,7 +625,7 @@ impl PciConfiguration {
             last_capability,
             msix_cap_reg_idx,
             msix_config,
-            pending_bar_reprogram: Vec::new(),
+            pending_bar_reprogram,
         }
     }
 
@@ -633,6 +639,7 @@ impl PciConfiguration {
             rom_bar_used: self.rom_bar_used,
             last_capability: self.last_capability,
             msix_cap_reg_idx: self.msix_cap_reg_idx,
+            pending_bar_reprogram: self.pending_bar_reprogram.clone(),
         }
     }
 

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -8,6 +8,7 @@ use std::any::Any;
 use std::sync::{Arc, Barrier, Mutex};
 use std::{io, result};
 
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vm_allocator::{AddressAllocator, SystemAllocator};
 use vm_device::Resource;
@@ -35,7 +36,7 @@ pub enum Error {
 }
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct BarReprogrammingParams {
     pub old_base: u64,
     pub new_base: u64,


### PR DESCRIPTION
This PR serializes and restores `pending_bar_reprogram` so pending BAR updates survive snapshot and restore.

OVMF can reprogram PCI BARs while memory space decoding is disabled. Cloud Hypervisor defers the corresponding BAR move in `pending_bar_reprogram` until memory space is enabled again via the PCI command register.

That deferred state is not part of `PciConfigurationState`. If a snapshot is taken in that window, the restored guest sees the updated BAR values in PCI config space, but the VMM-side BAR mapping is still stale.

We observed this during early boot while snapshotting mid-firmware (EDK2). In the firmware debug log, OVMF assigns BARs at `0xc0000000`, `0x100000000`, and `0x100080000`. After restore, cloud-hypervisor logs repeated guest MMIO accesses to those same addresses as unregistered, for example:

```text
Guest MMIO write to unregistered address 0x100080014
Guest MMIO write to unregistered address 0x100080000
Guest MMIO read to unregistered address 0x100080004
Guest MMIO write to unregistered address 0x100000000
Guest MMIO read to unregistered address 0x100000004
...
 ```
 
The firmware continues into Boot Device Selection, still detects the mass-storage device, but can no longer boot from it:
```text
PciHostBridge driver failed to set EFI_MEMORY_UC to MMIO aperture - Out of Resources.
...
Found Mass Storage device: PciRoot(0x0)/Pci(0x3,0x0)
...
[Bds] Unable to boot!
BdsDxe: No bootable option or device was found.
```

We have implemented this fix in our fork at https://github.com/cyberus-technology/cloud-hypervisor/pull/135.