### PR TITLE
tests: Fix flaky rate limiter integration tests

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -10295,6 +10295,7 @@ mod rate_limiter {
 
     const NET_RATE_LIMITER_RUNTIME: u32 = 20;
     const BLOCK_RATE_LIMITER_RUNTIME: u32 = 20;
+    const BLOCK_RATE_LIMITER_RAMP_TIME: u32 = 5;
 
     // Check if the 'measured' rate is within the expected 'difference' (in percentage)
     // compared to given 'limit' rate.
@@ -10442,7 +10443,8 @@ mod rate_limiter {
             let fio_command = format!(
                 "sudo fio --filename=/dev/vdc --name=test --output-format=json \
                 --direct=1 --bs=4k --ioengine=io_uring --iodepth=64 \
-                --rw={fio_ops} --runtime={BLOCK_RATE_LIMITER_RUNTIME} --numjobs={num_queues}"
+                --rw={fio_ops} --runtime={BLOCK_RATE_LIMITER_RUNTIME} \
+                --ramp_time={BLOCK_RATE_LIMITER_RAMP_TIME} --numjobs={num_queues}",
             );
             let output = guest.ssh_command(&fio_command).unwrap();
 
@@ -10539,7 +10541,8 @@ mod rate_limiter {
             let mut fio_command = format!(
                 "sudo fio --name=global --output-format=json \
                 --direct=1 --bs=4k --ioengine=io_uring --iodepth=64 \
-                --rw={fio_ops} --runtime={BLOCK_RATE_LIMITER_RUNTIME} --numjobs={num_queues}"
+                --rw={fio_ops} --runtime={BLOCK_RATE_LIMITER_RUNTIME} \
+                --ramp_time={BLOCK_RATE_LIMITER_RAMP_TIME} --numjobs={num_queues}",
             );
 
             // Generate additional argument for each disk:


### PR DESCRIPTION
The rate limiter integration tests fail because the token bucket `cool_down_time` (fixed at 100 ms) interacts badly with the 100 ms `refill_time`. As documented in `docs/io_throttling.md`, the actual rate can drop to `size / (refill_time + cool_down_time)`, which halves throughput when both intervals are equal. The faster the underlying disk, the more `cool_down_time` bottlenecks the observed rate.

This series fixes the flakiness by:

- Increasing the refill time from 100 ms to 1000 ms for all rate limiter tests, and
- Scaling the bucket sizes by 10x to preserve the same target rate
- Setting `one_time_burst=0` to prevent transient overshoot above the upper bound
- Adding a 5s fio ramp time to let block workloads warm up before measurement begins
- Raising the measurement runtime from 10 s to 20 s for steadier results

Test only, no production code change.

Fixes part of #7752.