### PR TITLE
build: Only run ARM64 CI on merge queue

### DIFF
--- a/.github/workflows/integration-arm64.yaml
+++ b/.github/workflows/integration-arm64.yaml
@@ -8,19 +8,24 @@ jobs:
   build:
     timeout-minutes: 120
     name: Tests (ARM64)
-    runs-on: bookworm-arm64
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'bookworm-arm64' }}
     steps:
       - name: Fix workspace permissions
+        if: ${{ github.event_name != 'pull_request' }}
         run: sudo chown -R runner:runner ${GITHUB_WORKSPACE}
       - name: Code checkout
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Run unit tests (musl)
+        if: ${{ github.event_name != 'pull_request' }}
         run: scripts/dev_cli.sh tests --unit --libc musl
       - name: Load openvswitch module
+        if: ${{ github.event_name != 'pull_request' }}
         run: sudo modprobe openvswitch
       - name: Run integration tests (musl)
+        if: ${{ github.event_name != 'pull_request' }}
         timeout-minutes: 60
         run: scripts/dev_cli.sh tests --integration --libc musl
       - name: Install Azure CLI
@@ -52,3 +57,6 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         timeout-minutes: 30
         run: scripts/dev_cli.sh tests --integration-windows --libc musl
+      - name: Skipping build for PR
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "Skipping build for PR"


### PR DESCRIPTION
Unfortunately with a single ARM64 machine this has now become a
bottleneck for landing PRs. Copy the methodology we use for existing
jobs that we only run on the MQ by creating dummy jobs that run on the
GH hosted runner (ubuntu-latest) allowing the PR to transition into
the MQ by passing the required checks.

Signed-off-by: Rob Bradford <rbradford@meta.com>
