### PR TITLE
pci: Handle dword MSI-X control writes

### DIFF
--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -158,6 +158,10 @@ impl VfioMsix {
         // Update "Message Control" word
         if offset == 2 && data.len() == 2 {
             self.bar.set_msg_ctl(LittleEndian::read_u16(data));
+        } else if offset == 0 && data.len() == 4 {
+            // Some guests update MSI-X control through the dword config write path.
+            self.bar
+                .set_msg_ctl((LittleEndian::read_u32(data) >> 16) as u16);
         }
 
         let new_enabled = self.bar.enabled();


### PR DESCRIPTION
## Summary
- Fix VFIO MSI-X config handling when the guest updates the MSI-X capability through a 32-bit write at offset `0` instead of only a 16-bit write at offset `2`.
- Keep the cached MSI-X message control state in sync with what the guest programmed so enable/disable transitions are applied correctly.
- This is important for passthrough GPUs, where MSI-X interrupts are used during NVIDIA Fabric Manager registration. If the guest enables MSI-X through the dword write path and the cached state is not updated, interrupt delivery can remain stale and GPU initialization or fabric registration can fail.