### PR TITLE
performance-metrics: Add CVM support to performance test harness

### DIFF
--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -294,6 +294,7 @@ impl PerformanceTest {
             if let Some(test_timeout) = overrides.test_timeout {
                 control.test_timeout = test_timeout;
             }
+            control.vm_type = overrides.vm_type;
             control
         };
 

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -282,15 +282,17 @@ impl PerformanceTest {
             );
         }
 
+        let effective_control = {
+            let mut control = self.control.clone();
+            if let Some(test_timeout) = overrides.test_timeout {
+                control.test_timeout = test_timeout;
+            }
+            control
+        };
+
         // Run warmup iterations if configured (results discarded)
         for _ in 0..self.control.warmup_iterations {
-            if let Some(test_timeout) = overrides.test_timeout {
-                let mut control: PerformanceTestControl = self.control.clone();
-                control.test_timeout = test_timeout;
-                let _ = (self.func_ptr)(&control);
-            } else {
-                let _ = (self.func_ptr)(&self.control);
-            }
+            let _ = (self.func_ptr)(&effective_control);
         }
 
         let mut metrics = Vec::new();
@@ -298,14 +300,7 @@ impl PerformanceTest {
             .test_iterations
             .unwrap_or(self.control.test_iterations)
         {
-            // update the timeout in control if passed explicitly and run testcase with it
-            if let Some(test_timeout) = overrides.test_timeout {
-                let mut control: PerformanceTestControl = self.control.clone();
-                control.test_timeout = test_timeout;
-                metrics.push((self.func_ptr)(&control));
-            } else {
-                metrics.push((self.func_ptr)(&self.control));
-            }
+            metrics.push((self.func_ptr)(&effective_control));
         }
 
         let mean = (self.unit_adjuster)(mean(&metrics).unwrap());

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -178,6 +178,7 @@ pub struct PerformanceTestOverrides {
     test_iterations: Option<u32>,
     test_timeout: Option<u32>,
     test_image_format: Option<ImageFormat>,
+    vm_type: GuestVmType,
 }
 
 impl fmt::Display for PerformanceTestOverrides {
@@ -192,6 +193,8 @@ impl fmt::Display for PerformanceTestOverrides {
         if let Some(test_image_format) = self.test_image_format {
             write!(f, "test_image_format = {test_image_format}")?;
         }
+
+        write!(f, "vm_type = {}", self.vm_type)?;
 
         Ok(())
     }
@@ -1887,6 +1890,7 @@ fn main() {
             .map(|s| s.parse())
             .transpose()
             .unwrap_or_default(),
+        vm_type: GuestVmType::Regular,
     });
 
     // Skip heavy VM level init/cleanup when only micro benchmarks are selected.

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -1907,6 +1907,14 @@ fn main() {
             .unwrap_or_default(),
     });
 
+    #[cfg(target_arch = "aarch64")]
+    {
+        if overrides.vm_type == GuestVmType::Confidential {
+            eprintln!("Confidential VM is currently not supported on Arm64");
+            std::process::exit(1);
+        }
+    }
+
     // Skip heavy VM level init/cleanup when only micro benchmarks are selected.
     let needs_vm_tests = tests_to_run.iter().any(|t| !t.name.starts_with("micro_"));
 

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -183,20 +183,20 @@ pub struct PerformanceTestOverrides {
 
 impl fmt::Display for PerformanceTestOverrides {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(test_iterations) = self.test_iterations {
-            write!(f, "test_iterations = {test_iterations}, ")?;
-        }
-        if let Some(test_timeout) = self.test_timeout {
-            write!(f, "test_timeout = {test_timeout}")?;
-        }
-
-        if let Some(test_image_format) = self.test_image_format {
-            write!(f, "test_image_format = {test_image_format}")?;
-        }
-
-        write!(f, "vm_type = {}", self.vm_type)?;
-
-        Ok(())
+        write!(
+            f,
+            "{}{}{}vm_type = {}",
+            self.test_iterations
+                .map(|v| format!("test_iterations = {v}, "))
+                .unwrap_or_default(),
+            self.test_timeout
+                .map(|v| format!("test_timeout = {v}, "))
+                .unwrap_or_default(),
+            self.test_image_format
+                .map(|v| format!("test_image_format = {v}, "))
+                .unwrap_or_default(),
+            self.vm_type
+        )
     }
 }
 
@@ -1837,6 +1837,16 @@ fn main() {
                 )
                 .num_args(1),
         )
+        .arg(
+            Arg::new("vm-type")
+                .long("vm-type")
+                .help(
+                    "Set the VM type: 'regular' (default) or 'confidential' (CVM).",
+                )
+                .num_args(1)
+                .value_parser(["regular","confidential"])
+                .default_value("regular"),
+        )
         .get_matches();
 
     // It seems that the tool (ethr) used for testing the virtio-net latency
@@ -1891,7 +1901,10 @@ fn main() {
             .map(|s| s.parse())
             .transpose()
             .unwrap_or_default(),
-        vm_type: GuestVmType::Regular,
+        vm_type: cmd_arguments
+            .get_one::<String>("vm-type")
+            .map(|s| s.parse().unwrap_or_default())
+            .unwrap_or_default(),
     });
 
     // Skip heavy VM level init/cleanup when only micro benchmarks are selected.

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -17,7 +17,7 @@ use std::{env, fmt, thread};
 use clap::{Arg, ArgAction, Command as ClapCommand};
 use performance_tests::*;
 use serde::{Deserialize, Serialize};
-use test_infra::{FioOps, ProcessRegistry};
+use test_infra::{FioOps, GuestVmType, ProcessRegistry};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -215,6 +215,7 @@ pub struct PerformanceTestControl {
     block_control: Option<BlockControl>,
     num_boot_vcpus: Option<u8>,
     num_ops: Option<u32>, // Workload size for micro benchmarks
+    vm_type: GuestVmType,
 }
 
 impl fmt::Display for PerformanceTestControl {
@@ -243,6 +244,8 @@ impl fmt::Display for PerformanceTestControl {
             output = format!("{output}, num_ops = {o}");
         }
 
+        output = format!("{output}, vm_type = {}", self.vm_type);
+
         write!(f, "{output}")
     }
 }
@@ -259,6 +262,7 @@ impl PerformanceTestControl {
             block_control: None,
             num_boot_vcpus: Some(1),
             num_ops: None,
+            vm_type: GuestVmType::Regular,
         }
     }
 }

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -147,8 +147,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
     let mut child = GuestCommand::new(&guest)
         .args(["--cpus", &format!("boot={num_queues}")])
         .args(["--memory", "size=4G"])
-        .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
-        .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+        .default_kernel_cmdline()
         .default_disks()
         .args(["--net", net_params.as_str()])
         .capture_output()
@@ -188,8 +187,7 @@ pub fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
     let mut child = GuestCommand::new(&guest)
         .args(["--cpus", &format!("boot={num_queues}")])
         .args(["--memory", "size=4G"])
-        .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
-        .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+        .default_kernel_cmdline()
         .default_disks()
         .args(["--net", net_params.as_str()])
         .capture_output()
@@ -333,8 +331,7 @@ pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
                 &format!("boot={}", control.num_boot_vcpus.unwrap_or(1)),
             ])
             .args(["--memory", "size=1G"])
-            .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
-            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_kernel_cmdline()
             .args(["--console", "off"])
             .default_disks();
 
@@ -421,8 +418,7 @@ pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
     let mut child = GuestCommand::new(&guest)
         .args(["--cpus", &format!("boot={num_queues}")])
         .args(["--memory", "size=4G"])
-        .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
-        .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+        .default_kernel_cmdline()
         .args([
             "--disk",
             format!(
@@ -552,8 +548,7 @@ pub fn performance_restore_latency(control: &PerformanceTestControl) -> f64 {
                 &format!("boot={}", control.num_boot_vcpus.unwrap_or(1)),
             ])
             .args(["--memory", "size=256M"])
-            .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
-            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_kernel_cmdline()
             .args(["--console", "off"])
             .default_disks()
             .set_print_cmd(false)

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -135,7 +135,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
     let (rx, bandwidth) = control.net_control.unwrap();
 
     let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-    let guest = performance_test_new_guest(Box::new(focal), GuestVmType::Regular);
+    let guest = performance_test_new_guest(Box::new(focal), control.vm_type);
 
     let num_queues = control.num_queues.unwrap();
     let queue_size = control.queue_size.unwrap();
@@ -176,7 +176,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
 
 pub fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
     let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-    let guest = performance_test_new_guest(Box::new(focal), GuestVmType::Regular);
+    let guest = performance_test_new_guest(Box::new(focal), control.vm_type);
 
     let num_queues = control.num_queues.unwrap();
     let queue_size = control.queue_size.unwrap();
@@ -324,7 +324,7 @@ fn measure_boot_time(cmd: &mut GuestCommand, test_timeout: u32) -> Result<f64, E
 pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-        let guest = performance_test_new_guest(Box::new(focal), GuestVmType::Regular);
+        let guest = performance_test_new_guest(Box::new(focal), control.vm_type);
         let mut cmd = GuestCommand::new(&guest);
 
         let c = cmd
@@ -352,7 +352,7 @@ pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
 pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-        let guest = performance_test_new_guest(Box::new(focal), GuestVmType::Regular);
+        let guest = performance_test_new_guest(Box::new(focal), control.vm_type);
         let mut cmd = GuestCommand::new(&guest);
         let c = cmd
             .args([
@@ -393,7 +393,7 @@ pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
     let test_file = block_control.test_file;
 
     let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-    let guest = performance_test_new_guest(Box::new(focal), GuestVmType::Regular);
+    let guest = performance_test_new_guest(Box::new(focal), control.vm_type);
     let api_socket = guest
         .tmp_dir
         .as_path()
@@ -535,7 +535,7 @@ fn measure_restore_time(
 pub fn performance_restore_latency(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-        let guest = performance_test_new_guest(Box::new(focal), GuestVmType::Regular);
+        let guest = performance_test_new_guest(Box::new(focal), control.vm_type);
         let api_socket_source = String::from(
             guest
                 .tmp_dir

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -120,8 +120,14 @@ pub fn cleanup_tests() {
 // private network. The default constructor "Guest::new()" does not work
 // well, as we can easily create more than 256 VMs from repeating various
 // performance tests dozens times in a single run.
-fn performance_test_new_guest(disk_config: Box<dyn DiskConfig>) -> Guest {
-    Guest::new_from_ip_range(disk_config, "172.19", 0)
+fn performance_test_new_guest(disk_config: Box<dyn DiskConfig>, vm_type: GuestVmType) -> Guest {
+    let mut guest = Guest::new_from_ip_range(disk_config, "172.19", 0);
+    if vm_type == GuestVmType::Confidential {
+        guest.vm_type = GuestVmType::Confidential;
+        guest.boot_timeout = DEFAULT_CVM_TCP_LISTENER_TIMEOUT;
+        guest.nested = false;
+    }
+    guest
 }
 
 pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
@@ -129,7 +135,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
     let (rx, bandwidth) = control.net_control.unwrap();
 
     let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-    let guest = performance_test_new_guest(Box::new(focal));
+    let guest = performance_test_new_guest(Box::new(focal), GuestVmType::Regular);
 
     let num_queues = control.num_queues.unwrap();
     let queue_size = control.queue_size.unwrap();
@@ -170,7 +176,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
 
 pub fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
     let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-    let guest = performance_test_new_guest(Box::new(focal));
+    let guest = performance_test_new_guest(Box::new(focal), GuestVmType::Regular);
 
     let num_queues = control.num_queues.unwrap();
     let queue_size = control.queue_size.unwrap();
@@ -318,7 +324,7 @@ fn measure_boot_time(cmd: &mut GuestCommand, test_timeout: u32) -> Result<f64, E
 pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-        let guest = performance_test_new_guest(Box::new(focal));
+        let guest = performance_test_new_guest(Box::new(focal), GuestVmType::Regular);
         let mut cmd = GuestCommand::new(&guest);
 
         let c = cmd
@@ -346,7 +352,7 @@ pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
 pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-        let guest = performance_test_new_guest(Box::new(focal));
+        let guest = performance_test_new_guest(Box::new(focal), GuestVmType::Regular);
         let mut cmd = GuestCommand::new(&guest);
         let c = cmd
             .args([
@@ -387,7 +393,7 @@ pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
     let test_file = block_control.test_file;
 
     let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-    let guest = performance_test_new_guest(Box::new(focal));
+    let guest = performance_test_new_guest(Box::new(focal), GuestVmType::Regular);
     let api_socket = guest
         .tmp_dir
         .as_path()
@@ -529,7 +535,7 @@ fn measure_restore_time(
 pub fn performance_restore_latency(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-        let guest = performance_test_new_guest(Box::new(focal));
+        let guest = performance_test_new_guest(Box::new(focal), GuestVmType::Regular);
         let api_socket_source = String::from(
             guest
                 .tmp_dir

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2493,6 +2493,18 @@ pub enum GuestVmType {
     Confidential,
 }
 
+impl FromStr for GuestVmType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "regular" => Ok(GuestVmType::Regular),
+            "confidential" => Ok(GuestVmType::Confidential),
+            _ => Err(()),
+        }
+    }
+}
+
 // Get the direct igvm boot file path based on the console type
 fn direct_igvm_boot_path(console: Option<&str>) -> Option<PathBuf> {
     // get the default hvc0 igvm file if console string is not passed

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2487,8 +2487,9 @@ pub fn extract_bar_address(output: &str, device_desc: &str, bar_index: usize) ->
     None
 }
 
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Clone, Copy, Default)]
 pub enum GuestVmType {
+    #[default]
     Regular,
     Confidential,
 }

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 use std::ffi::OsStr;
-use std::fmt::Display;
+use std::fmt::{Display, Formatter};
 use std::fs::OpenOptions;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::net::{TcpListener, TcpStream};
@@ -2501,6 +2501,15 @@ impl FromStr for GuestVmType {
             "regular" => Ok(GuestVmType::Regular),
             "confidential" => Ok(GuestVmType::Confidential),
             _ => Err(()),
+        }
+    }
+}
+
+impl Display for GuestVmType {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            GuestVmType::Regular => write!(f, "regular"),
+            GuestVmType::Confidential => write!(f, "confidential"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Add Confidential VM (CVM) support to the performance-metrics test
harness, allowing all existing performance benchmarks to run against
CVM guests via a new `--vm-type` CLI argument.

Example: `--vm-type confidential`

## Changes

### test_infra
- Implement `FromStr` and `Display` traits for `GuestVmType` to
  enable CLI parsing and formatted output.

### performance-metrics
- Refactor `run()` to consolidate override application into a single
  `effective_control` variable, removing duplicated timeout override
  logic from warmup and measurement iterations.
- Add `vm_type` field to `PerformanceTestControl` (default: Regular)
  and `PerformanceTestOverrides`.
- Update `performance_test_new_guest()` to accept a `GuestVmType`
  parameter. When set to Confidential, configure CVM-specific
  settings: `vm_type`, `boot_timeout`, and nested virtualization
  disabled.
- Replace all hardcoded `GuestVmType::Regular` with `control.vm_type`
  across all performance test functions: `net_throughput`,
  `net_latency`, `boot_time`, `boot_time_pmem`, `block_io`, and
  `restore_latency`.
- Add `--vm-type` CLI argument with `regular` (default) and
  `confidential` options.
- Add early error exit on AArch64 when CVM mode is selected, since
  CVM (SEV-SNP/TDX) is x86_64-only.
- Replace explicit `--kernel` and `--cmdline` arguments with the
  `default_kernel_cmdline()` helper in `net_throughput`,
  `net_latency`, and `block_io` for consistency.

## Files Changed

- `test_infra/src/lib.rs`
- `performance-metrics/src/main.rs`
- `performance-metrics/src/performance_tests.rs`