### PR TITLE
block: Only advertise write zeroes when supported

### DIFF
--- a/block/src/async_io.rs
+++ b/block/src/async_io.rs
@@ -86,6 +86,14 @@ pub trait DiskFile: Send {
         false
     }
 
+    /// Indicates support for WRITE_ZEROES requests.
+    ///
+    /// Backends can override this when write zeroes support differs from the
+    /// broader sparse/discard capability.
+    fn supports_write_zeroes(&self) -> bool {
+        self.supports_sparse_operations()
+    }
+
     /// Indicates support for zero flag optimization in WRITE_ZEROES. Override
     /// to return true when supported.
     fn supports_zero_flag(&self) -> bool {

--- a/block/src/disk_file.rs
+++ b/block/src/disk_file.rs
@@ -75,6 +75,11 @@ pub trait SparseCapable: Send + Debug {
         false
     }
 
+    /// Indicates support for WRITE_ZEROES requests.
+    fn supports_write_zeroes(&self) -> bool {
+        self.supports_sparse_operations()
+    }
+
     /// Indicates support for a metadata level zero flag optimization in
     /// virtio `VIRTIO_BLK_T_WRITE_ZEROES` requests. When true, the format
     /// can mark regions as reading zeros via a metadata bit rather than
@@ -198,6 +203,13 @@ impl DiskBackend {
         match self {
             Self::Legacy(d) => d.supports_sparse_operations(),
             Self::Next(d) => d.supports_sparse_operations(),
+        }
+    }
+
+    pub fn supports_write_zeroes(&self) -> bool {
+        match self {
+            Self::Legacy(d) => d.supports_write_zeroes(),
+            Self::Next(d) => d.supports_write_zeroes(),
         }
     }
 

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -43,7 +43,7 @@ use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::str::FromStr;
 use std::time::Instant;
-use std::{cmp, mem, result};
+use std::{cmp, fs, mem, result};
 
 #[cfg(feature = "io_uring")]
 use io_uring::{IoUring, Probe, opcode};
@@ -898,6 +898,46 @@ pub fn probe_sparse_support(file: &File) -> bool {
     }
 }
 
+/// Probe whether the file/device supports WRITE_ZEROES requests.
+pub fn probe_write_zeroes_support(file: &File) -> bool {
+    let fd = file.as_raw_fd();
+
+    let device = match stat_device(fd) {
+        Ok(device) => device,
+        Err(err) => {
+            warn!("Failed to stat file descriptor for write zeroes probe: {err}");
+            return false;
+        }
+    };
+
+    if device.is_block {
+        probe_block_device_write_zeroes_support(device.rdev, Path::new("/sys"))
+    } else {
+        probe_sparse_support(file)
+    }
+}
+
+struct StatDevice {
+    is_block: bool,
+    rdev: libc::dev_t,
+}
+
+fn stat_device(fd: libc::c_int) -> io::Result<StatDevice> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: FFI call with valid fd and buffer
+    let ret = unsafe { libc::fstat(fd, stat.as_mut_ptr()) };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // SAFETY: stat result is valid at this point
+    let stat = unsafe { stat.assume_init() };
+    Ok(StatDevice {
+        is_block: stat.st_mode & S_IFMT == S_IFBLK,
+        rdev: stat.st_rdev,
+    })
+}
+
 /// Probe sparse support for a regular file using fallocate().
 fn probe_file_sparse_support(fd: libc::c_int) -> bool {
     // SAFETY: FFI call with valid fd
@@ -954,6 +994,37 @@ fn probe_file_sparse_support(fd: libc::c_int) -> bool {
 fn probe_block_device_sparse_support(_fd: libc::c_int) -> bool {
     info!("Block device: assuming sparse support");
     true
+}
+
+fn probe_block_device_write_zeroes_support(rdev: libc::dev_t, sysfs_root: &Path) -> bool {
+    let major = libc::major(rdev);
+    let minor = libc::minor(rdev);
+    let queue_limit_path = sysfs_root
+        .join("dev/block")
+        .join(format!("{major}:{minor}"))
+        .join("queue/write_zeroes_max_bytes");
+
+    let value = match fs::read_to_string(&queue_limit_path) {
+        Ok(value) => value,
+        Err(err) => {
+            info!("Block device write zeroes probe could not read {queue_limit_path:?}: {err}");
+            return false;
+        }
+    };
+
+    let limit = match value.trim().parse::<u64>() {
+        Ok(limit) => limit,
+        Err(err) => {
+            warn!("Block device write zeroes probe could not parse {queue_limit_path:?}: {err}");
+            return false;
+        }
+    };
+
+    let supported = limit > 0;
+    info!(
+        "Block device write zeroes probe: path={queue_limit_path:?}, write_zeroes_max_bytes={limit} => {supported}"
+    );
+    supported
 }
 
 /// Preallocate disk space for a disk image file.
@@ -1379,11 +1450,12 @@ impl DiskTopology {
 #[cfg(test)]
 mod unit_tests {
     use std::alloc::{Layout, alloc_zeroed, dealloc};
-    use std::fs::OpenOptions;
+    use std::fs::{OpenOptions, create_dir_all, write};
     use std::io::Write;
     use std::os::unix::fs::OpenOptionsExt;
     use std::{ptr, slice};
 
+    use vmm_sys_util::tempdir::TempDir;
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
@@ -1563,5 +1635,60 @@ mod unit_tests {
         let f = std::fs::File::open("/dev/zero").unwrap();
         let err = query_device_size(&f).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn test_probe_block_device_write_zeroes_support_from_sysfs_positive_limit() {
+        let sysfs_root = TempDir::new().unwrap();
+        let dev = libc::makedev(43, 7);
+        let queue_dir = sysfs_root.as_path().join("dev/block/43:7/queue");
+        create_dir_all(&queue_dir).unwrap();
+        write(queue_dir.join("write_zeroes_max_bytes"), "4096\n").unwrap();
+
+        assert!(probe_block_device_write_zeroes_support(
+            dev,
+            sysfs_root.as_path()
+        ));
+    }
+
+    #[test]
+    fn test_probe_block_device_write_zeroes_support_from_sysfs_zero_limit() {
+        let sysfs_root = TempDir::new().unwrap();
+        let dev = libc::makedev(43, 8);
+        let queue_dir = sysfs_root.as_path().join("dev/block/43:8/queue");
+        create_dir_all(&queue_dir).unwrap();
+        write(queue_dir.join("write_zeroes_max_bytes"), "0\n").unwrap();
+
+        assert!(!probe_block_device_write_zeroes_support(
+            dev,
+            sysfs_root.as_path()
+        ));
+    }
+
+    #[test]
+    fn test_probe_block_device_write_zeroes_support_from_sysfs_missing_file() {
+        let sysfs_root = TempDir::new().unwrap();
+        let dev = libc::makedev(43, 9);
+        let queue_dir = sysfs_root.as_path().join("dev/block/43:9/queue");
+        create_dir_all(&queue_dir).unwrap();
+
+        assert!(!probe_block_device_write_zeroes_support(
+            dev,
+            sysfs_root.as_path()
+        ));
+    }
+
+    #[test]
+    fn test_probe_block_device_write_zeroes_support_from_sysfs_invalid_value() {
+        let sysfs_root = TempDir::new().unwrap();
+        let dev = libc::makedev(43, 10);
+        let queue_dir = sysfs_root.as_path().join("dev/block/43:10/queue");
+        create_dir_all(&queue_dir).unwrap();
+        write(queue_dir.join("write_zeroes_max_bytes"), "wat\n").unwrap();
+
+        assert!(!probe_block_device_write_zeroes_support(
+            dev,
+            sysfs_root.as_path()
+        ));
     }
 }

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -15,7 +15,7 @@ use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, Disk
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
 use crate::{
     BatchRequest, DiskTopology, RequestType, SECTOR_SIZE, disk_file, probe_sparse_support,
-    query_device_size,
+    probe_write_zeroes_support, query_device_size,
 };
 
 #[derive(Debug)]
@@ -63,6 +63,10 @@ impl disk_file::Geometry for RawFileDisk {
 impl disk_file::SparseCapable for RawFileDisk {
     fn supports_sparse_operations(&self) -> bool {
         probe_sparse_support(&self.file)
+    }
+
+    fn supports_write_zeroes(&self) -> bool {
+        probe_write_zeroes_support(&self.file)
     }
 }
 

--- a/block/src/raw_async_aio.rs
+++ b/block/src/raw_async_aio.rs
@@ -16,7 +16,10 @@ use vmm_sys_util::eventfd::EventFd;
 
 use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFileError};
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
-use crate::{DiskTopology, SECTOR_SIZE, disk_file, probe_sparse_support, query_device_size};
+use crate::{
+    DiskTopology, SECTOR_SIZE, disk_file, probe_sparse_support, probe_write_zeroes_support,
+    query_device_size,
+};
 
 #[derive(Debug)]
 pub struct RawFileDiskAio {
@@ -63,6 +66,10 @@ impl disk_file::Geometry for RawFileDiskAio {
 impl disk_file::SparseCapable for RawFileDiskAio {
     fn supports_sparse_operations(&self) -> bool {
         probe_sparse_support(&self.file)
+    }
+
+    fn supports_write_zeroes(&self) -> bool {
+        probe_write_zeroes_support(&self.file)
     }
 }
 

--- a/block/src/raw_sync.rs
+++ b/block/src/raw_sync.rs
@@ -12,7 +12,10 @@ use vmm_sys_util::eventfd::EventFd;
 
 use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFileError};
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
-use crate::{DiskTopology, SECTOR_SIZE, disk_file, probe_sparse_support, query_device_size};
+use crate::{
+    DiskTopology, SECTOR_SIZE, disk_file, probe_sparse_support, probe_write_zeroes_support,
+    query_device_size,
+};
 
 #[derive(Debug)]
 pub struct RawFileDiskSync {
@@ -59,6 +62,10 @@ impl disk_file::Geometry for RawFileDiskSync {
 impl disk_file::SparseCapable for RawFileDiskSync {
     fn supports_sparse_operations(&self) -> bool {
         probe_sparse_support(&self.file)
+    }
+
+    fn supports_write_zeroes(&self) -> bool {
+        probe_write_zeroes_support(&self.file)
     }
 }
 

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -778,13 +778,14 @@ impl Block {
                     | (1u64 << VIRTIO_RING_F_INDIRECT_DESC);
 
                 // When backend supports sparse operations:
-                // - Always advertise WRITE_ZEROES (safe for all drivers)
-                // - Advertise DISCARD only when sparse=true, since DISCARD
-                //   deallocates space via punch_hole and should require
-                //   explicit user opt in.
+                // - Advertise WRITE_ZEROES only when the host backend can execute it
+                // - Advertise DISCARD only when sparse=true, since it deallocates
+                //   space and should remain an explicit user opt-in
                 let mut discard_supported = false;
-                if disk_image.supports_sparse_operations() {
+                if disk_image.supports_write_zeroes() {
                     avail_features |= 1u64 << VIRTIO_BLK_F_WRITE_ZEROES;
+                }
+                if disk_image.supports_sparse_operations() {
                     if sparse {
                         avail_features |= 1u64 << VIRTIO_BLK_F_DISCARD;
                         discard_supported = true;


### PR DESCRIPTION
Some backends can support sparse or discard operations without supporting `WRITE_ZEROES`. Advertising `VIRTIO_BLK_F_WRITE_ZEROES` in that case lets the guest issue requests that the host backend cannot reliably satisfy. This keeps the advertised virtio block capabilities aligned with what the backend can actually do.

## Summary
- advertise `VIRTIO_BLK_F_WRITE_ZEROES` only when the backend can actually service write-zeroes requests
- add a dedicated block-device probe based on `/sys/dev/block/.../queue/write_zeroes_max_bytes`
- keep `VIRTIO_BLK_F_DISCARD` tied to `sparse=on`