### PR TITLE
build: use latest 0.6.8 mshv crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,9 +1336,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mshv-bindings"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbfd4f32d185152003679339751839da77c17e18fa8882a11051a236f841426"
+checksum = "a94fc3871dd23738188e5bc76a1d1a5930ebcaf9308c560a7274aa62b1770594"
 dependencies = [
  "libc",
  "num_enum",
@@ -1350,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f035616abe1e4cbc026a1a8094ff8d3900f5063fe6608309098bc745926fdfd8"
+checksum = "1339723fe3a26baf4041459de20ad923e89d312c3bb25dbf9f60738c22a47f5e"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,8 @@ acpi_tables = "0.2.0"
 kvm-bindings = "0.14.0"
 kvm-ioctls = "0.24.0"
 linux-loader = "0.13.2"
-mshv-bindings = "0.6.7"
-mshv-ioctls = "0.6.7"
+mshv-bindings = "0.6.8"
+mshv-ioctls = "0.6.8"
 seccompiler = "0.5.0"
 vfio-bindings = { version = "0.6.2", default-features = false }
 vfio-ioctls = { version = "0.6.0", default-features = false }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-bindings"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbfd4f32d185152003679339751839da77c17e18fa8882a11051a236f841426"
+checksum = "a94fc3871dd23738188e5bc76a1d1a5930ebcaf9308c560a7274aa62b1770594"
 dependencies = [
  "libc",
  "num_enum",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2.183"
 libfuzzer-sys = "0.4.12"
 linux-loader = { version = "0.13.2", features = ["bzimage", "elf", "pe"] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
-mshv-bindings = "0.6.7"
+mshv-bindings = "0.6.8"
 net_util = { path = "../net_util" }
 seccompiler = "0.5.0"
 virtio-devices = { path = "../virtio-devices" }


### PR DESCRIPTION
Use mshv-{ioctls, bindings) with the latest versions that fixes a bug on interrupt vector.