### PR TITLE
vmm: Refactor common PCI based device configuration

### DIFF
--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -73,7 +73,7 @@ pub enum OptionParserError {
     #[error("unknown option: {0}")]
     UnknownOption(String),
     /// The input string has invalid syntax (unbalanced quotes/brackets, missing `=`).
-    #[error("unknown option: {0}")]
+    #[error("invalid syntax: {0}")]
     InvalidSyntax(String),
     /// A value could not be converted to the requested type.
     #[error("unable to convert {1} for {0}")]

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -647,4 +647,234 @@ mod unit_tests {
     fn check_dequote() {
         assert_eq!(dequote("a\u{3b2}\"a\"\"\""), "a\u{3b2}a\"");
     }
+
+    #[test]
+    fn test_empty_input() {
+        let mut parser = OptionParser::new();
+        parser.add("foo");
+        parser.parse("").unwrap();
+        parser.parse("   ").unwrap();
+        assert!(!parser.is_set("foo"));
+    }
+
+    #[test]
+    fn test_parse_subset_ignores_unknown() {
+        let mut parser = OptionParser::new();
+        parser.add("known");
+        parser.parse_subset("known=val,unknown=other").unwrap();
+        assert_eq!(parser.get("known"), Some("val".to_owned()));
+        assert!(!parser.is_set("unknown"));
+    }
+
+    #[test]
+    fn test_add_all() {
+        let mut parser = OptionParser::new();
+        parser.add_all(&["a", "b", "c"]);
+        parser.parse("a=1,b=2,c=3").unwrap();
+        assert_eq!(parser.get("a"), Some("1".to_owned()));
+        assert_eq!(parser.get("b"), Some("2".to_owned()));
+        assert_eq!(parser.get("c"), Some("3".to_owned()));
+    }
+
+    #[test]
+    fn test_add_valueless() {
+        let mut parser = OptionParser::new();
+        parser.add_valueless("readonly");
+        parser.add("path");
+        parser.parse("path=/dev/sda,readonly").unwrap();
+        assert!(parser.is_set("readonly"));
+        assert_eq!(parser.get("readonly"), None);
+        assert_eq!(parser.get("path"), Some("/dev/sda".to_owned()));
+    }
+
+    #[test]
+    fn test_convert_integer() {
+        let mut parser = OptionParser::new();
+        parser.add("count");
+        parser.parse("count=42").unwrap();
+        assert_eq!(parser.convert::<u64>("count").unwrap(), Some(42));
+        assert_eq!(parser.convert::<u32>("count").unwrap(), Some(42));
+    }
+
+    #[test]
+    fn test_convert_unset_returns_none() {
+        let mut parser = OptionParser::new();
+        parser.add("count");
+        assert_eq!(parser.convert::<u64>("count").unwrap(), None);
+    }
+
+    #[test]
+    fn test_convert_invalid_returns_error() {
+        let mut parser = OptionParser::new();
+        parser.add("count");
+        parser.parse("count=notanumber").unwrap();
+        parser.convert::<u64>("count").unwrap_err();
+    }
+
+    #[test]
+    fn test_toggle() {
+        for (input, expected) in [
+            ("on", true),
+            ("off", false),
+            ("true", true),
+            ("false", false),
+            ("ON", true),
+            ("OFF", false),
+            ("True", true),
+            ("False", false),
+        ] {
+            let mut parser = OptionParser::new();
+            parser.add("flag");
+            parser.parse(&format!("flag={input}")).unwrap();
+            let toggle = parser.convert::<Toggle>("flag").unwrap().unwrap();
+            assert_eq!(toggle.0, expected, "Toggle({input}) should be {expected}");
+        }
+    }
+
+    #[test]
+    fn test_toggle_invalid() {
+        let mut parser = OptionParser::new();
+        parser.add("flag");
+        parser.parse("flag=maybe").unwrap();
+        assert!(parser.convert::<Toggle>("flag").is_err());
+    }
+
+    #[test]
+    fn test_byte_sized() {
+        let cases = [
+            ("1024", 1024u64),
+            ("1K", 1024),
+            ("2M", 2 * 1024 * 1024),
+            ("4G", 4 * 1024 * 1024 * 1024),
+            ("0K", 0),
+        ];
+        for (input, expected) in cases {
+            let mut parser = OptionParser::new();
+            parser.add("size");
+            parser.parse(&format!("size={input}")).unwrap();
+            let bs = parser.convert::<ByteSized>("size").unwrap().unwrap();
+            assert_eq!(bs.0, expected, "ByteSized({input}) should be {expected}");
+        }
+    }
+
+    #[test]
+    fn test_byte_sized_invalid() {
+        assert!("xyzK".parse::<ByteSized>().is_err());
+        assert!("".parse::<ByteSized>().is_err());
+    }
+
+    #[test]
+    fn test_integer_list_single_values() {
+        let list = IntegerList::from_str("[1,3,5]").unwrap();
+        assert_eq!(list.0, vec![1, 3, 5]);
+    }
+
+    #[test]
+    fn test_integer_list_ranges() {
+        let list = IntegerList::from_str("[0,2-4,7]").unwrap();
+        assert_eq!(list.0, vec![0, 2, 3, 4, 7]);
+    }
+
+    #[test]
+    fn test_integer_list_invalid_range() {
+        assert!(IntegerList::from_str("[5-3]").is_err());
+        assert!(IntegerList::from_str("[5-5]").is_err());
+    }
+
+    #[test]
+    fn test_integer_list_too_many_dashes() {
+        assert!(IntegerList::from_str("[1-2-3]").is_err());
+    }
+
+    #[test]
+    fn test_integer_list_display() {
+        let list = IntegerList(vec![1, 2, 3]);
+        assert_eq!(format!("{list}"), "[1,2,3]");
+
+        let empty = IntegerList(vec![]);
+        assert_eq!(format!("{empty}"), "[]");
+
+        let single = IntegerList(vec![42]);
+        assert_eq!(format!("{single}"), "[42]");
+    }
+
+    #[test]
+    fn test_string_list() {
+        let list = StringList::from_str("[foo,bar,baz]").unwrap();
+        assert_eq!(list.0, vec!["foo", "bar", "baz"]);
+    }
+
+    #[test]
+    fn test_string_list_no_brackets() {
+        let list = StringList::from_str("foo,bar").unwrap();
+        assert_eq!(list.0, vec!["foo", "bar"]);
+    }
+
+    #[test]
+    fn test_tuple_single_pair() {
+        let t = Tuple::<String, u64>::from_str("[foo@42]").unwrap();
+        assert_eq!(t, Tuple(vec![("foo".to_owned(), 42)]));
+    }
+
+    #[test]
+    fn test_tuple_multiple_pairs() {
+        let t = Tuple::<String, Vec<u64>>::from_str("[a@[1,2],b@[3,4]]").unwrap();
+        assert_eq!(
+            t,
+            Tuple(vec![
+                ("a".to_owned(), vec![1, 2]),
+                ("b".to_owned(), vec![3, 4]),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_tuple_missing_at_separator() {
+        Tuple::<String, u64>::from_str("[foo42]").unwrap_err();
+    }
+
+    #[test]
+    fn test_tuple_missing_brackets() {
+        Tuple::<String, u64>::from_str("foo@42").unwrap_err();
+    }
+
+    #[test]
+    fn test_split_commas_unbalanced_bracket() {
+        split_commas("[a,b").unwrap_err();
+        split_commas("a]").unwrap_err();
+    }
+
+    #[test]
+    fn test_split_commas_unbalanced_quote() {
+        split_commas("\"abc").unwrap_err();
+    }
+
+    #[test]
+    fn test_quoted_value_with_commas() {
+        let mut parser = OptionParser::new();
+        parser.add("cmd");
+        parser.parse("cmd=\"a,b,c\"").unwrap();
+        assert_eq!(parser.get("cmd"), Some("a,b,c".to_owned()));
+    }
+
+    #[test]
+    #[should_panic(expected = "forbidden character")]
+    fn test_add_option_with_equals() {
+        let mut parser = OptionParser::new();
+        parser.add("bad=name");
+    }
+
+    #[test]
+    #[should_panic(expected = "forbidden character")]
+    fn test_add_option_with_comma() {
+        let mut parser = OptionParser::new();
+        parser.add("bad,name");
+    }
+
+    #[test]
+    #[should_panic(expected = "forbidden character")]
+    fn test_add_option_with_bracket() {
+        let mut parser = OptionParser::new();
+        parser.add("bad[name");
+    }
 }

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -93,7 +93,7 @@ impl OptionParser {
         }
     }
 
-    pub fn parse(&mut self, input: &str) -> OptionParserResult<()> {
+    fn parse_inner(&mut self, input: &str, ignore_unknown: bool) -> OptionParserResult<()> {
         if input.trim().is_empty() {
             return Ok(());
         }
@@ -101,7 +101,11 @@ impl OptionParser {
         for option in split_commas(input)?.iter() {
             let parts: Vec<&str> = option.splitn(2, '=').collect();
             match self.options.get_mut(parts[0]) {
-                None => return Err(OptionParserError::UnknownOption(parts[0].to_owned())),
+                None => {
+                    if !ignore_unknown {
+                        return Err(OptionParserError::UnknownOption(parts[0].to_owned()));
+                    }
+                }
                 Some(value) => {
                     if value.requires_value {
                         if parts.len() != 2 {
@@ -116,6 +120,14 @@ impl OptionParser {
         }
 
         Ok(())
+    }
+
+    pub fn parse(&mut self, input: &str) -> OptionParserResult<()> {
+        self.parse_inner(input, false)
+    }
+
+    pub fn parse_subset(&mut self, input: &str) -> OptionParserResult<()> {
+        self.parse_inner(input, true)
     }
 
     pub fn add(&mut self, option: &str) -> &mut Self {

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -148,6 +148,14 @@ impl OptionParser {
         self
     }
 
+    pub fn add_all(&mut self, options: &[&str]) -> &mut Self {
+        for option in options {
+            self.add(option);
+        }
+
+        self
+    }
+
     pub fn add_valueless(&mut self, option: &str) -> &mut Self {
         self.options.insert(
             option.to_owned(),

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -3,6 +3,29 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+//! A parser for comma-separated `key=value` option strings.
+//!
+//! This crate provides [`OptionParser`], which parses strings of the form
+//! `"key1=value1,key2=value2,..."` into a set of named options that can then
+//! be retrieved and converted to various types.
+//!
+//! Values may be quoted with `"` to embed commas and other special characters,
+//! and brackets `[` `]` are tracked so that list-valued options like
+//! `topology=[1,2,3]` are not split at inner commas.
+//!
+//! # Example
+//!
+//! ```
+//! use option_parser::OptionParser;
+//!
+//! let mut parser = OptionParser::new();
+//! parser.add("size").add("mergeable");
+//! parser.parse("size=128M,mergeable=on").unwrap();
+//!
+//! assert_eq!(parser.get("size"), Some("128M".to_owned()));
+//! assert_eq!(parser.get("mergeable"), Some("on".to_owned()));
+//! ```
+
 use std::collections::HashMap;
 use std::fmt::{Display, Write};
 use std::num::ParseIntError;
@@ -27,6 +50,12 @@ mod private_trait {
 }
 use private_trait::Parseable;
 
+/// A parser for comma-separated `key=value` option strings.
+///
+/// Options must be registered with [`add`](Self::add) or
+/// [`add_valueless`](Self::add_valueless) before parsing. After calling
+/// [`parse`](Self::parse), values can be retrieved with [`get`](Self::get)
+/// or converted to a specific type with [`convert`](Self::convert).
 #[derive(Default)]
 pub struct OptionParser {
     options: HashMap<String, OptionParserValue>,
@@ -37,14 +66,19 @@ struct OptionParserValue {
     requires_value: bool,
 }
 
+/// Errors returned when parsing or converting options.
 #[derive(Debug, Error)]
 pub enum OptionParserError {
+    /// An option name was not previously registered with [`OptionParser::add`].
     #[error("unknown option: {0}")]
     UnknownOption(String),
+    /// The input string has invalid syntax (unbalanced quotes/brackets, missing `=`).
     #[error("unknown option: {0}")]
     InvalidSyntax(String),
+    /// A value could not be converted to the requested type.
     #[error("unable to convert {1} for {0}")]
     Conversion(String /* field */, String /* value */),
+    /// A value was syntactically valid but semantically wrong.
     #[error("invalid value: {0}")]
     InvalidValue(String),
 }
@@ -87,6 +121,7 @@ fn split_commas(s: &str) -> OptionParserResult<Vec<String>> {
 }
 
 impl OptionParser {
+    /// Creates an empty `OptionParser` with no registered options.
     pub fn new() -> Self {
         Self {
             options: HashMap::new(),
@@ -122,14 +157,30 @@ impl OptionParser {
         Ok(())
     }
 
+    /// Parses a comma-separated `key=value` string, updating registered options.
+    ///
+    /// Returns an error if the input contains an unknown option name, has
+    /// unbalanced quotes or brackets, or a value-requiring option lacks `=`.
     pub fn parse(&mut self, input: &str) -> OptionParserResult<()> {
         self.parse_inner(input, false)
     }
 
+    /// Like [`parse`](Self::parse), but silently ignores unknown option names.
+    ///
+    /// This is useful when multiple parsers share the same input string and
+    /// each only cares about a subset of the options.
     pub fn parse_subset(&mut self, input: &str) -> OptionParserResult<()> {
         self.parse_inner(input, true)
     }
 
+    /// Registers a named option that requires a value (i.e. `key=value`).
+    ///
+    /// Option names must not contain `"`, `[`, `]`, `=`, or `,`.
+    /// Returns `&mut Self` for chaining.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the option name contains a forbidden character.
     pub fn add(&mut self, option: &str) -> &mut Self {
         // Check that option=value has balanced
         // quotes and brackets iff value does.
@@ -148,6 +199,9 @@ impl OptionParser {
         self
     }
 
+    /// Registers multiple value-requiring options at once.
+    ///
+    /// Equivalent to calling [`add`](Self::add) for each element in the slice.
     pub fn add_all(&mut self, options: &[&str]) -> &mut Self {
         for option in options {
             self.add(option);
@@ -156,6 +210,10 @@ impl OptionParser {
         self
     }
 
+    /// Registers a flag-style option that does not take a value.
+    ///
+    /// When this option appears in the input string (without `=`), it is
+    /// marked as set. Use [`is_set`](Self::is_set) to query it.
     pub fn add_valueless(&mut self, option: &str) -> &mut Self {
         self.options.insert(
             option.to_owned(),
@@ -168,6 +226,10 @@ impl OptionParser {
         self
     }
 
+    /// Returns the raw string value of an option, or `None` if the option was
+    /// not set or if its value is an empty string (e.g. `key=`).
+    ///
+    /// Surrounding double-quotes in the value are removed.
     pub fn get(&self, option: &str) -> Option<String> {
         self.options
             .get(option)
@@ -181,6 +243,9 @@ impl OptionParser {
             })
     }
 
+    /// Returns `true` if the option was present in the parsed input.
+    ///
+    /// This works for both value-requiring and valueless options.
     pub fn is_set(&self, option: &str) -> bool {
         self.options
             .get(option)
@@ -188,6 +253,14 @@ impl OptionParser {
             .is_some()
     }
 
+    /// Retrieves and converts an option value to type `T`.
+    ///
+    /// Returns `Ok(None)` if the option was not set or its value is empty.
+    /// Returns `Err` if the value cannot be converted to `T`.
+    ///
+    /// `T` can be any type that implements `FromStr` (e.g. `u32`, `String`),
+    /// or one of this crate's types such as [`Toggle`], [`IntegerList`],
+    /// [`Tuple`], or [`StringList`].
     pub fn convert<T: Parseable>(&self, option: &str) -> OptionParserResult<Option<T>> {
         match self.options.get(option).and_then(|v| v.value.as_ref()) {
             None => Ok(None),
@@ -204,6 +277,9 @@ impl OptionParser {
     }
 }
 
+/// A boolean-like value that accepts `"on"`, `"true"`, `"off"`, `"false"`, or `""`.
+///
+/// An empty string is treated as `false`.
 pub struct Toggle(pub bool);
 
 #[derive(Error, Debug)]
@@ -227,6 +303,10 @@ impl Parseable for Toggle {
     }
 }
 
+/// A byte size parsed from a human-readable string with optional `K`, `M`, or `G` suffix.
+///
+/// The suffix is binary (1K = 1024, 1M = 1048576, 1G = 1073741824).
+/// A bare integer is treated as bytes.
 pub struct ByteSized(pub u64);
 
 #[derive(Error, Debug)]
@@ -259,6 +339,9 @@ impl FromStr for ByteSized {
     }
 }
 
+/// A list of integers parsed from a bracket-enclosed, comma-separated string.
+///
+/// Ranges are supported with `-`: `"[0,2-4,6]"` produces `[0, 2, 3, 4, 6]`.
 pub struct IntegerList(pub Vec<u64>);
 
 impl Display for IntegerList {
@@ -324,7 +407,11 @@ impl Parseable for IntegerList {
     }
 }
 
+/// Types that can appear as the second element of a [`Tuple`] pair.
+///
+/// Implemented for `u64`, `Vec<u8>`, `Vec<u64>`, and `Vec<usize>`.
 pub trait TupleValue {
+    /// Parses the value portion of a `key@value` tuple element.
     fn parse_value(input: &str) -> Result<Self, TupleError>
     where
         Self: Sized;
@@ -366,6 +453,10 @@ impl TupleValue for Vec<usize> {
     }
 }
 
+/// A list of `key@value` pairs parsed from a bracket-enclosed string.
+///
+/// The format is `[key1@value1,key2@value2,...]` where `@` separates each
+/// pair's elements. `S` is the key type and `T` is the value type.
 #[derive(PartialEq, Eq, Debug)]
 pub struct Tuple<S, T>(pub Vec<(S, T)>);
 
@@ -421,6 +512,9 @@ impl<S: Parseable, T: TupleValue> Parseable for Tuple<S, T> {
     }
 }
 
+/// A list of strings parsed from a bracket-enclosed, comma-separated string.
+///
+/// The format is `[str1,str2,...]`. Brackets are optional.
 #[derive(Default)]
 pub struct StringList(pub Vec<String>);
 

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -588,10 +588,12 @@ mod unit_tests {
 
         assert_eq!(split_commas("\"\"").unwrap(), vec!["\"\""]);
         parser.parse("size=128M,hanging_param").unwrap_err();
-        parser
-            .parse("size=128M,too_many_equals=foo=bar")
-            .unwrap_err();
         parser.parse("size=128M,file=/dev/shm").unwrap_err();
+
+        // Equals signs within a value are fine (splitn(2, '=') keeps them)
+        parser.add("extra");
+        parser.parse("extra=foo=bar").unwrap();
+        assert_eq!(parser.get("extra"), Some("foo=bar".to_owned()));
 
         parser.parse("size=128M").unwrap();
         assert_eq!(parser.get("size"), Some("128M".to_owned()));

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -122,7 +122,7 @@ mod fds_helper {
 
         impl ConfigWithFDs for NetConfig {
             fn id(&self) -> Option<&str> {
-                self.id.as_deref()
+                self.pci_common.id.as_deref()
             }
 
             fn fds_from_http_body(&self) -> Option<&[RawFd]> {

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1861,11 +1861,7 @@ impl GenericVhostUserConfig {
             }
             _ => {}
         }
-        let id = parser.get("id");
-        let pci_segment = parser
-            .convert("pci_segment")
-            .map_err(Error::ParseGenericVhostUser)?
-            .unwrap_or_default();
+        let pci_common = PciDeviceCommonConfig::parse(vhost_user)?;
         let mut converted_queue_sizes: Vec<u16> = Vec::new();
         for (offset, &queue_size) in queue_sizes.iter().enumerate() {
             match queue_size.try_into() {
@@ -1879,30 +1875,19 @@ impl GenericVhostUserConfig {
         }
 
         Ok(GenericVhostUserConfig {
+            pci_common,
             socket: socket.into(),
             device_type,
-            id,
-            pci_segment,
             queue_sizes: converted_queue_sizes,
         })
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
-        if let Some(platform_config) = vm_config.platform.as_ref() {
-            if self.pci_segment >= platform_config.num_pci_segments {
-                return Err(ValidationError::InvalidPciSegment(self.pci_segment));
-            }
-
-            if let Some(iommu_segments) = platform_config.iommu_segments.as_ref()
-                && iommu_segments.contains(&self.pci_segment)
-            {
-                return Err(ValidationError::IommuNotSupportedOnSegment(
-                    self.pci_segment,
-                ));
-            }
+        if self.pci_common.iommu {
+            return Err(ValidationError::IommuNotSupported);
         }
 
-        Ok(())
+        self.pci_common.validate(vm_config)
     }
 }
 
@@ -3054,7 +3039,7 @@ impl VmConfig {
             for generic_vhost_user_device in generic_vhost_user_devices {
                 generic_vhost_user_device.validate(self)?;
 
-                Self::validate_identifier(&mut id_list, &generic_vhost_user_device.id)?;
+                Self::validate_identifier(&mut id_list, &generic_vhost_user_device.pci_common.id)?;
             }
         }
 
@@ -3521,7 +3506,8 @@ impl VmConfig {
         // Remove if generic vhost-user device
         if let Some(generic_vhost_user) = self.generic_vhost_user.as_mut() {
             let len = generic_vhost_user.len();
-            generic_vhost_user.retain(|dev| dev.id.as_ref().map(|id| id.as_ref()) != Some(id));
+            generic_vhost_user
+                .retain(|dev| dev.pci_common.id.as_ref().map(|id| id.as_ref()) != Some(id));
             removed |= generic_vhost_user.len() != len;
         }
 
@@ -4292,10 +4278,13 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             assert_eq!(
                 config.unwrap(),
                 GenericVhostUserConfig {
+                    pci_common: PciDeviceCommonConfig {
+                        id: Some(id.to_owned()),
+                        pci_segment: u16::try_from(pci_segment).unwrap(),
+                        ..Default::default()
+                    },
                     socket: socket.into(),
-                    id: Some(id.to_owned()),
                     device_type: u32::try_from(virtio_id).unwrap(),
-                    pci_segment: u16::try_from(pci_segment).unwrap(),
                     queue_sizes: queue_sizes
                         .0
                         .iter()

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1226,6 +1226,23 @@ impl PciDeviceCommonConfig {
             pci_segment,
         })
     }
+
+    pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
+        if let Some(platform_config) = vm_config.platform.as_ref() {
+            if self.pci_segment >= platform_config.num_pci_segments {
+                return Err(ValidationError::InvalidPciSegment(self.pci_segment));
+            }
+
+            if let Some(iommu_segments) = platform_config.iommu_segments.as_ref()
+                && iommu_segments.contains(&self.pci_segment)
+                && !self.iommu
+            {
+                return Err(ValidationError::OnIommuSegment(self.pci_segment));
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl DiskConfig {

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2061,52 +2061,28 @@ impl PmemConfig {
             .add("pci_segment");
         parser.parse(pmem).map_err(Error::ParsePersistentMemory)?;
 
+        let pci_common = PciDeviceCommonConfig::parse(pmem)?;
         let file = PathBuf::from(parser.get("file").ok_or(Error::ParsePmemFileMissing)?);
         let size = parser
             .convert::<ByteSized>("size")
             .map_err(Error::ParsePersistentMemory)?
             .map(|v| v.0);
-        let iommu = parser
-            .convert::<Toggle>("iommu")
-            .map_err(Error::ParsePersistentMemory)?
-            .unwrap_or(Toggle(false))
-            .0;
         let discard_writes = parser
             .convert::<Toggle>("discard_writes")
             .map_err(Error::ParsePersistentMemory)?
             .unwrap_or(Toggle(false))
             .0;
-        let id = parser.get("id");
-        let pci_segment = parser
-            .convert("pci_segment")
-            .map_err(Error::ParsePersistentMemory)?
-            .unwrap_or_default();
 
         Ok(PmemConfig {
+            pci_common,
             file,
             size,
-            iommu,
             discard_writes,
-            id,
-            pci_segment,
         })
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
-        if let Some(platform_config) = vm_config.platform.as_ref() {
-            if self.pci_segment >= platform_config.num_pci_segments {
-                return Err(ValidationError::InvalidPciSegment(self.pci_segment));
-            }
-
-            if let Some(iommu_segments) = platform_config.iommu_segments.as_ref()
-                && iommu_segments.contains(&self.pci_segment)
-                && !self.iommu
-            {
-                return Err(ValidationError::OnIommuSegment(self.pci_segment));
-            }
-        }
-
-        Ok(())
+        self.pci_common.validate(vm_config)
     }
 }
 
@@ -3046,9 +3022,9 @@ impl VmConfig {
         if let Some(pmems) = &self.pmem {
             for pmem in pmems {
                 pmem.validate(self)?;
-                self.iommu |= pmem.iommu;
+                self.iommu |= pmem.pci_common.iommu;
 
-                Self::validate_identifier(&mut id_list, &pmem.id)?;
+                Self::validate_identifier(&mut id_list, &pmem.pci_common.id)?;
             }
         }
 
@@ -3521,7 +3497,7 @@ impl VmConfig {
         // Remove if pmem device
         if let Some(pmem) = self.pmem.as_mut() {
             let len = pmem.len();
-            pmem.retain(|dev| dev.id.as_ref().map(|id| id.as_ref()) != Some(id));
+            pmem.retain(|dev| dev.pci_common.id.as_ref().map(|id| id.as_ref()) != Some(id));
             removed |= pmem.len() != len;
         }
 
@@ -4345,12 +4321,10 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
 
     fn pmem_fixture() -> PmemConfig {
         PmemConfig {
+            pci_common: PciDeviceCommonConfig::default(),
             file: PathBuf::from("/tmp/pmem"),
             size: Some(128 << 20),
-            iommu: false,
             discard_writes: false,
-            id: None,
-            pci_segment: 0,
         }
     }
 
@@ -4366,15 +4340,21 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         assert_eq!(
             PmemConfig::parse("file=/tmp/pmem,size=128M,id=mypmem0")?,
             PmemConfig {
-                id: Some("mypmem0".to_owned()),
+                pci_common: PciDeviceCommonConfig {
+                    id: Some("mypmem0".to_owned()),
+                    ..Default::default()
+                },
                 ..pmem_fixture()
             }
         );
         assert_eq!(
             PmemConfig::parse("file=/tmp/pmem,size=128M,iommu=on,discard_writes=on")?,
             PmemConfig {
+                pci_common: PciDeviceCommonConfig {
+                    iommu: true,
+                    ..Default::default()
+                },
                 discard_writes: true,
-                iommu: true,
                 ..pmem_fixture()
             }
         );
@@ -5313,8 +5293,11 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..platform_fixture()
         });
         still_valid_config.pmem = Some(vec![PmemConfig {
-            iommu: true,
-            pci_segment: 1,
+            pci_common: PciDeviceCommonConfig {
+                iommu: true,
+                pci_segment: 1,
+                ..Default::default()
+            },
             ..pmem_fixture()
         }]);
         still_valid_config.validate().unwrap();
@@ -5388,8 +5371,10 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..platform_fixture()
         });
         invalid_config.pmem = Some(vec![PmemConfig {
-            iommu: false,
-            pci_segment: 1,
+            pci_common: PciDeviceCommonConfig {
+                pci_segment: 1,
+                ..Default::default()
+            },
             ..pmem_fixture()
         }]);
         assert_eq!(

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2277,6 +2277,7 @@ impl VdpaConfig {
             .add("pci_segment");
         parser.parse(vdpa).map_err(Error::ParseVdpa)?;
 
+        let pci_common = PciDeviceCommonConfig::parse(vdpa)?;
         let path = parser
             .get("path")
             .map(PathBuf::from)
@@ -2285,41 +2286,16 @@ impl VdpaConfig {
             .convert("num_queues")
             .map_err(Error::ParseVdpa)?
             .unwrap_or_else(default_vdpaconfig_num_queues);
-        let iommu = parser
-            .convert::<Toggle>("iommu")
-            .map_err(Error::ParseVdpa)?
-            .unwrap_or(Toggle(false))
-            .0;
-        let id = parser.get("id");
-        let pci_segment = parser
-            .convert("pci_segment")
-            .map_err(Error::ParseVdpa)?
-            .unwrap_or_default();
 
         Ok(VdpaConfig {
+            pci_common,
             path,
             num_queues,
-            iommu,
-            id,
-            pci_segment,
         })
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
-        if let Some(platform_config) = vm_config.platform.as_ref() {
-            if self.pci_segment >= platform_config.num_pci_segments {
-                return Err(ValidationError::InvalidPciSegment(self.pci_segment));
-            }
-
-            if let Some(iommu_segments) = platform_config.iommu_segments.as_ref()
-                && iommu_segments.contains(&self.pci_segment)
-                && !self.iommu
-            {
-                return Err(ValidationError::OnIommuSegment(self.pci_segment));
-            }
-        }
-
-        Ok(())
+        self.pci_common.validate(vm_config)
     }
 }
 
@@ -3041,9 +3017,9 @@ impl VmConfig {
         if let Some(vdpa_devices) = &self.vdpa {
             for vdpa_device in vdpa_devices {
                 vdpa_device.validate(self)?;
-                self.iommu |= vdpa_device.iommu;
+                self.iommu |= vdpa_device.pci_common.iommu;
 
-                Self::validate_identifier(&mut id_list, &vdpa_device.id)?;
+                Self::validate_identifier(&mut id_list, &vdpa_device.pci_common.id)?;
             }
         }
 
@@ -3464,7 +3440,7 @@ impl VmConfig {
         // Remove if vDPA device
         if let Some(vdpa) = self.vdpa.as_mut() {
             let len = vdpa.len();
-            vdpa.retain(|dev| dev.id.as_ref().map(|id| id.as_ref()) != Some(id));
+            vdpa.retain(|dev| dev.pci_common.id.as_ref().map(|id| id.as_ref()) != Some(id));
             removed |= vdpa.len() != len;
         }
 
@@ -4446,11 +4422,9 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
 
     fn vdpa_fixture() -> VdpaConfig {
         VdpaConfig {
+            pci_common: PciDeviceCommonConfig::default(),
             path: PathBuf::from("/dev/vhost-vdpa"),
             num_queues: 1,
-            iommu: false,
-            id: None,
-            pci_segment: 0,
         }
     }
 
@@ -4462,8 +4436,11 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         assert_eq!(
             VdpaConfig::parse("path=/dev/vhost-vdpa,num_queues=2,id=my_vdpa")?,
             VdpaConfig {
+                pci_common: PciDeviceCommonConfig {
+                    id: Some("my_vdpa".to_owned()),
+                    ..Default::default()
+                },
                 num_queues: 2,
-                id: Some("my_vdpa".to_owned()),
                 ..vdpa_fixture()
             }
         );
@@ -5408,7 +5385,10 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..platform_fixture()
         });
         invalid_config.vdpa = Some(vec![VdpaConfig {
-            pci_segment: 1,
+            pci_common: PciDeviceCommonConfig {
+                pci_segment: 1,
+                ..Default::default()
+            },
             ..vdpa_fixture()
         }]);
         assert_eq!(

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -320,11 +320,6 @@ pub enum ValidationError {
     /// GPUDirect clique requires P2P DMA
     #[error("Device with x_nv_gpudirect_clique requires vfio_p2p_dma=on")]
     GpuDirectCliqueRequiresP2pDma,
-    // On a IOMMU segment but IOMMU not supported
-    #[error(
-        "Device is on an IOMMU PCI segment ({0}) but does not support being placed behind IOMMU"
-    )]
-    IommuNotSupportedOnSegment(u16),
     // Identifier is not unique
     #[error("Identifier {0} is not unique")]
     IdentifierNotUnique(String),

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2313,49 +2313,25 @@ impl VsockConfig {
             .add("pci_segment");
         parser.parse(vsock).map_err(Error::ParseVsock)?;
 
+        let pci_common = PciDeviceCommonConfig::parse(vsock)?;
         let socket = parser
             .get("socket")
             .map(PathBuf::from)
             .ok_or(Error::ParseVsockSockMissing)?;
-        let iommu = parser
-            .convert::<Toggle>("iommu")
-            .map_err(Error::ParseVsock)?
-            .unwrap_or(Toggle(false))
-            .0;
         let cid = parser
             .convert("cid")
             .map_err(Error::ParseVsock)?
             .ok_or(Error::ParseVsockCidMissing)?;
-        let id = parser.get("id");
-        let pci_segment = parser
-            .convert("pci_segment")
-            .map_err(Error::ParseVsock)?
-            .unwrap_or_default();
 
         Ok(VsockConfig {
+            pci_common,
             cid,
             socket,
-            iommu,
-            id,
-            pci_segment,
         })
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
-        if let Some(platform_config) = vm_config.platform.as_ref() {
-            if self.pci_segment >= platform_config.num_pci_segments {
-                return Err(ValidationError::InvalidPciSegment(self.pci_segment));
-            }
-
-            if let Some(iommu_segments) = platform_config.iommu_segments.as_ref()
-                && iommu_segments.contains(&self.pci_segment)
-                && !self.iommu
-            {
-                return Err(ValidationError::OnIommuSegment(self.pci_segment));
-            }
-        }
-
-        Ok(())
+        self.pci_common.validate(vm_config)
     }
 }
 
@@ -3064,9 +3040,9 @@ impl VmConfig {
 
         if let Some(vsock) = &self.vsock {
             vsock.validate(self)?;
-            self.iommu |= vsock.iommu;
+            self.iommu |= vsock.pci_common.iommu;
 
-            Self::validate_identifier(&mut id_list, &vsock.id)?;
+            Self::validate_identifier(&mut id_list, &vsock.pci_common.id)?;
         }
 
         let num_pci_segments = match &self.platform {
@@ -3446,7 +3422,7 @@ impl VmConfig {
 
         // Remove if vsock device
         if let Some(vsock) = self.vsock.as_ref()
-            && vsock.id.as_ref().map(|id| id.as_ref()) == Some(id)
+            && vsock.pci_common.id.as_ref().map(|id| id.as_ref()) == Some(id)
         {
             self.vsock = None;
             removed = true;
@@ -4467,21 +4443,20 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         assert_eq!(
             VsockConfig::parse("socket=/tmp/sock,cid=3")?,
             VsockConfig {
+                pci_common: PciDeviceCommonConfig::default(),
                 cid: 3,
                 socket: PathBuf::from("/tmp/sock"),
-                iommu: false,
-                id: None,
-                pci_segment: 0,
             }
         );
         assert_eq!(
             VsockConfig::parse("socket=/tmp/sock,cid=3,iommu=on")?,
             VsockConfig {
+                pci_common: PciDeviceCommonConfig {
+                    iommu: true,
+                    ..Default::default()
+                },
                 cid: 3,
                 socket: PathBuf::from("/tmp/sock"),
-                iommu: true,
-                id: None,
-                pci_segment: 0,
             }
         );
         Ok(())
@@ -5264,11 +5239,13 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..platform_fixture()
         });
         still_valid_config.vsock = Some(VsockConfig {
+            pci_common: PciDeviceCommonConfig {
+                iommu: true,
+                pci_segment: 1,
+                ..Default::default()
+            },
             cid: 3,
             socket: PathBuf::new(),
-            id: None,
-            iommu: true,
-            pci_segment: 1,
         });
         still_valid_config.validate().unwrap();
 
@@ -5350,11 +5327,12 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..platform_fixture()
         });
         invalid_config.vsock = Some(VsockConfig {
+            pci_common: PciDeviceCommonConfig {
+                pci_segment: 1,
+                ..Default::default()
+            },
             cid: 3,
             socket: PathBuf::new(),
-            id: None,
-            iommu: false,
-            pci_segment: 1,
         });
         assert_eq!(
             invalid_config.validate(),

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -209,6 +209,8 @@ pub enum Error {
     /// Failed Parsing FwCfgItem config
     #[error("Error parsing --fw-cfg-config items")]
     ParseFwCfgItem(#[source] OptionParserError),
+    #[error("Error parsing common PCI device config")]
+    ParsePciDeviceCommonConfig(#[source] OptionParserError),
 }
 
 #[derive(Debug, PartialEq, Eq, Error)]
@@ -1194,6 +1196,35 @@ impl RateLimiterGroupConfig {
         }
 
         Ok(())
+    }
+}
+
+impl PciDeviceCommonConfig {
+    pub fn parse(input: &str) -> Result<Self> {
+        let mut parser = OptionParser::new();
+
+        parser.add("id").add("iommu").add("pci_segment");
+
+        parser
+            .parse_subset(input)
+            .map_err(Error::ParsePciDeviceCommonConfig)?;
+
+        let id = parser.get("id");
+        let iommu = parser
+            .convert::<Toggle>("iommu")
+            .map_err(Error::ParsePciDeviceCommonConfig)?
+            .unwrap_or(Toggle(false))
+            .0;
+        let pci_segment = parser
+            .convert("pci_segment")
+            .map_err(Error::ParsePciDeviceCommonConfig)?
+            .unwrap_or_default();
+
+        Ok(Self {
+            id,
+            iommu,
+            pci_segment,
+        })
     }
 }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1937,20 +1937,14 @@ impl FsConfig {
             .map_err(Error::ParseFileSystem)?
             .unwrap_or_else(default_fsconfig_num_queues);
 
-        let id = parser.get("id");
-
-        let pci_segment = parser
-            .convert("pci_segment")
-            .map_err(Error::ParseFileSystem)?
-            .unwrap_or_default();
+        let pci_common = PciDeviceCommonConfig::parse(fs)?;
 
         Ok(FsConfig {
+            pci_common,
             tag,
             socket,
             num_queues,
             queue_size,
-            id,
-            pci_segment,
         })
     }
 
@@ -1962,21 +1956,11 @@ impl FsConfig {
             ));
         }
 
-        if let Some(platform_config) = vm_config.platform.as_ref() {
-            if self.pci_segment >= platform_config.num_pci_segments {
-                return Err(ValidationError::InvalidPciSegment(self.pci_segment));
-            }
-
-            if let Some(iommu_segments) = platform_config.iommu_segments.as_ref()
-                && iommu_segments.contains(&self.pci_segment)
-            {
-                return Err(ValidationError::IommuNotSupportedOnSegment(
-                    self.pci_segment,
-                ));
-            }
+        if self.pci_common.iommu {
+            return Err(ValidationError::IommuNotSupported);
         }
 
-        Ok(())
+        self.pci_common.validate(vm_config)
     }
 }
 
@@ -3059,7 +3043,7 @@ impl VmConfig {
             for fs in fses {
                 fs.validate(self)?;
 
-                Self::validate_identifier(&mut id_list, &fs.id)?;
+                Self::validate_identifier(&mut id_list, &fs.pci_common.id)?;
             }
         }
 
@@ -3530,7 +3514,7 @@ impl VmConfig {
         // Remove if fs device
         if let Some(fs) = self.fs.as_mut() {
             let len = fs.len();
-            fs.retain(|dev| dev.id.as_ref().map(|id| id.as_ref()) != Some(id));
+            fs.retain(|dev| dev.pci_common.id.as_ref().map(|id| id.as_ref()) != Some(id));
             removed |= fs.len() != len;
         }
 
@@ -4256,12 +4240,11 @@ mod unit_tests {
 
     fn fs_fixture() -> FsConfig {
         FsConfig {
+            pci_common: PciDeviceCommonConfig::default(),
             socket: PathBuf::from("/tmp/sock"),
             tag: "mytag".to_owned(),
             num_queues: 1,
             queue_size: 1024,
-            id: None,
-            pci_segment: 0,
         }
     }
 
@@ -5471,7 +5454,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         }]);
         assert_eq!(
             invalid_config.validate(),
-            Err(ValidationError::IommuNotSupportedOnSegment(1))
+            Err(ValidationError::OnIommuSegment(1))
         );
 
         let mut invalid_config = valid_config.clone();
@@ -5495,12 +5478,15 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..platform_fixture()
         });
         invalid_config.fs = Some(vec![FsConfig {
-            pci_segment: 1,
+            pci_common: PciDeviceCommonConfig {
+                pci_segment: 1,
+                ..Default::default()
+            },
             ..fs_fixture()
         }]);
         assert_eq!(
             invalid_config.validate(),
-            Err(ValidationError::IommuNotSupportedOnSegment(1))
+            Err(ValidationError::OnIommuSegment(1))
         );
 
         let mut invalid_config = valid_config.clone();

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2206,45 +2206,23 @@ impl DeviceConfig {
             .add("x_nv_gpudirect_clique");
         parser.parse(device).map_err(Error::ParseDevice)?;
 
+        let pci_common = PciDeviceCommonConfig::parse(device)?;
         let path = parser
             .get("path")
             .map(PathBuf::from)
             .ok_or(Error::ParseDevicePathMissing)?;
-        let iommu = parser
-            .convert::<Toggle>("iommu")
-            .map_err(Error::ParseDevice)?
-            .unwrap_or(Toggle(false))
-            .0;
-        let id = parser.get("id");
-        let pci_segment = parser
-            .convert::<u16>("pci_segment")
-            .map_err(Error::ParseDevice)?
-            .unwrap_or_default();
         let x_nv_gpudirect_clique = parser
             .convert::<u8>("x_nv_gpudirect_clique")
             .map_err(Error::ParseDevice)?;
         Ok(DeviceConfig {
+            pci_common,
             path,
-            iommu,
-            id,
-            pci_segment,
             x_nv_gpudirect_clique,
         })
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
-        if let Some(platform_config) = vm_config.platform.as_ref() {
-            if self.pci_segment >= platform_config.num_pci_segments {
-                return Err(ValidationError::InvalidPciSegment(self.pci_segment));
-            }
-
-            if let Some(iommu_segments) = platform_config.iommu_segments.as_ref()
-                && iommu_segments.contains(&self.pci_segment)
-                && !self.iommu
-            {
-                return Err(ValidationError::OnIommuSegment(self.pci_segment));
-            }
-        }
+        self.pci_common.validate(vm_config)?;
 
         if self.x_nv_gpudirect_clique.is_some() {
             let vfio_p2p_dma = vm_config.platform.as_ref().is_none_or(|p| p.vfio_p2p_dma);
@@ -3120,9 +3098,9 @@ impl VmConfig {
                 }
 
                 device.validate(self)?;
-                self.iommu |= device.iommu;
+                self.iommu |= device.pci_common.iommu;
 
-                Self::validate_identifier(&mut id_list, &device.id)?;
+                Self::validate_identifier(&mut id_list, &device.pci_common.id)?;
             }
         }
 
@@ -3454,7 +3432,7 @@ impl VmConfig {
         // Remove if VFIO device
         if let Some(devices) = self.devices.as_mut() {
             let len = devices.len();
-            devices.retain(|dev| dev.id.as_ref().map(|id| id.as_ref()) != Some(id));
+            devices.retain(|dev| dev.pci_common.id.as_ref().map(|id| id.as_ref()) != Some(id));
             removed |= devices.len() != len;
         }
 
@@ -4443,10 +4421,8 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
 
     fn device_fixture() -> DeviceConfig {
         DeviceConfig {
+            pci_common: PciDeviceCommonConfig::default(),
             path: PathBuf::from("/path/to/device"),
-            id: None,
-            iommu: false,
-            pci_segment: 0,
             x_nv_gpudirect_clique: None,
         }
     }
@@ -4463,7 +4439,10 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         assert_eq!(
             DeviceConfig::parse("path=/path/to/device,iommu=on")?,
             DeviceConfig {
-                iommu: true,
+                pci_common: PciDeviceCommonConfig {
+                    iommu: true,
+                    ..Default::default()
+                },
                 ..device_fixture()
             }
         );
@@ -4471,8 +4450,11 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         assert_eq!(
             DeviceConfig::parse("path=/path/to/device,iommu=on,id=mydevice0")?,
             DeviceConfig {
-                id: Some("mydevice0".to_owned()),
-                iommu: true,
+                pci_common: PciDeviceCommonConfig {
+                    id: Some("mydevice0".to_owned()),
+                    iommu: true,
+                    ..Default::default()
+                },
                 ..device_fixture()
             }
         );
@@ -5308,8 +5290,11 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..platform_fixture()
         });
         still_valid_config.devices = Some(vec![DeviceConfig {
-            iommu: true,
-            pci_segment: 1,
+            pci_common: PciDeviceCommonConfig {
+                iommu: true,
+                pci_segment: 1,
+                ..Default::default()
+            },
             ..device_fixture()
         }]);
         still_valid_config.validate().unwrap();
@@ -5389,8 +5374,10 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..platform_fixture()
         });
         invalid_config.devices = Some(vec![DeviceConfig {
-            iommu: false,
-            pci_segment: 1,
+            pci_common: PciDeviceCommonConfig {
+                pci_segment: 1,
+                ..Default::default()
+            },
             ..device_fixture()
         }]);
         assert_eq!(

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1299,11 +1299,6 @@ impl DiskConfig {
             .map_err(Error::ParseDisk)?
             .unwrap_or(Toggle(false))
             .0;
-        let iommu = parser
-            .convert::<Toggle>("iommu")
-            .map_err(Error::ParseDisk)?
-            .unwrap_or(Toggle(false))
-            .0;
         let queue_size = parser
             .convert("queue_size")
             .map_err(Error::ParseDisk)?
@@ -1318,7 +1313,6 @@ impl DiskConfig {
             .unwrap_or(Toggle(false))
             .0;
         let vhost_socket = parser.get("socket");
-        let id = parser.get("id");
         let disable_io_uring = parser
             .convert::<Toggle>("_disable_io_uring")
             .map_err(Error::ParseDisk)?
@@ -1329,10 +1323,6 @@ impl DiskConfig {
             .map_err(Error::ParseDisk)?
             .unwrap_or(Toggle(false))
             .0;
-        let pci_segment = parser
-            .convert("pci_segment")
-            .map_err(Error::ParseDisk)?
-            .unwrap_or_default();
         let rate_limit_group = parser.get("rate_limit_group");
         let bw_size = parser
             .convert("bw_size")
@@ -1423,21 +1413,21 @@ impl DiskConfig {
             .unwrap_or_else(|| Toggle(default_diskconfig_sparse()))
             .0;
 
+        let pci_common = PciDeviceCommonConfig::parse(disk)?;
+
         Ok(DiskConfig {
+            pci_common,
             path,
             readonly,
             direct,
-            iommu,
             num_queues,
             queue_size,
             vhost_user,
             vhost_socket,
             rate_limit_group,
             rate_limiter_config,
-            id,
             disable_io_uring,
             disable_aio,
-            pci_segment,
             serial,
             queue_affinity,
             backing_files,
@@ -1448,6 +1438,8 @@ impl DiskConfig {
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
+        self.pci_common.validate(vm_config)?;
+
         if self.num_queues > vm_config.cpus.boot_vcpus as usize {
             return Err(ValidationError::TooManyQueues(
                 self.num_queues,
@@ -1459,21 +1451,8 @@ impl DiskConfig {
             return Err(ValidationError::InvalidQueueSize(self.queue_size));
         }
 
-        if self.vhost_user && self.iommu {
+        if self.vhost_user && self.pci_common.iommu {
             return Err(ValidationError::IommuNotSupported);
-        }
-
-        if let Some(platform_config) = vm_config.platform.as_ref() {
-            if self.pci_segment >= platform_config.num_pci_segments {
-                return Err(ValidationError::InvalidPciSegment(self.pci_segment));
-            }
-
-            if let Some(iommu_segments) = platform_config.iommu_segments.as_ref()
-                && iommu_segments.contains(&self.pci_segment)
-                && !self.iommu
-            {
-                return Err(ValidationError::OnIommuSegment(self.pci_segment));
-            }
         }
 
         if self.rate_limiter_config.is_some() && self.rate_limit_group.is_some() {
@@ -3075,9 +3054,9 @@ impl VmConfig {
                 }
 
                 disk.validate(self)?;
-                self.iommu |= disk.iommu;
+                self.iommu |= disk.pci_common.iommu;
 
-                Self::validate_identifier(&mut id_list, &disk.id)?;
+                Self::validate_identifier(&mut id_list, &disk.pci_common.id)?;
             }
         }
 
@@ -3564,7 +3543,7 @@ impl VmConfig {
         // Remove if disk device
         if let Some(disks) = self.disks.as_mut() {
             let len = disks.len();
-            disks.retain(|dev| dev.id.as_ref().map(|id| id.as_ref()) != Some(id));
+            disks.retain(|dev| dev.pci_common.id.as_ref().map(|id| id.as_ref()) != Some(id));
             removed |= disks.len() != len;
         }
 
@@ -4025,20 +4004,18 @@ mod unit_tests {
 
     fn disk_fixture() -> DiskConfig {
         DiskConfig {
+            pci_common: PciDeviceCommonConfig::default(),
             path: Some(PathBuf::from("/path/to_file")),
             readonly: false,
             direct: false,
-            iommu: false,
             num_queues: 1,
             queue_size: 128,
             vhost_user: false,
             vhost_socket: None,
-            id: None,
             disable_io_uring: false,
             disable_aio: false,
             rate_limit_group: None,
             rate_limiter_config: None,
-            pci_segment: 0,
             serial: None,
             queue_affinity: None,
             backing_files: false,
@@ -4057,7 +4034,10 @@ mod unit_tests {
         assert_eq!(
             DiskConfig::parse("path=/path/to_file,id=mydisk0")?,
             DiskConfig {
-                id: Some("mydisk0".to_owned()),
+                pci_common: PciDeviceCommonConfig {
+                    id: Some("mydisk0".to_owned()),
+                    ..Default::default()
+                },
                 ..disk_fixture()
             }
         );
@@ -4074,14 +4054,20 @@ mod unit_tests {
         assert_eq!(
             DiskConfig::parse("path=/path/to_file,iommu=on")?,
             DiskConfig {
-                iommu: true,
+                pci_common: PciDeviceCommonConfig {
+                    iommu: true,
+                    ..Default::default()
+                },
                 ..disk_fixture()
             }
         );
         assert_eq!(
             DiskConfig::parse("path=/path/to_file,iommu=on,queue_size=256")?,
             DiskConfig {
-                iommu: true,
+                pci_common: PciDeviceCommonConfig {
+                    iommu: true,
+                    ..Default::default()
+                },
                 queue_size: 256,
                 ..disk_fixture()
             }
@@ -4089,7 +4075,10 @@ mod unit_tests {
         assert_eq!(
             DiskConfig::parse("path=/path/to_file,iommu=on,queue_size=256,num_queues=4")?,
             DiskConfig {
-                iommu: true,
+                pci_common: PciDeviceCommonConfig {
+                    iommu: true,
+                    ..Default::default()
+                },
                 queue_size: 256,
                 num_queues: 4,
                 ..disk_fixture()
@@ -5326,8 +5315,11 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..platform_fixture()
         });
         still_valid_config.disks = Some(vec![DiskConfig {
-            iommu: true,
-            pci_segment: 1,
+            pci_common: PciDeviceCommonConfig {
+                iommu: true,
+                pci_segment: 1,
+                ..Default::default()
+            },
             ..disk_fixture()
         }]);
         still_valid_config.validate().unwrap();
@@ -5388,8 +5380,11 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..platform_fixture()
         });
         invalid_config.disks = Some(vec![DiskConfig {
-            iommu: false,
-            pci_segment: 1,
+            pci_common: PciDeviceCommonConfig {
+                iommu: false,
+                pci_segment: 1,
+                ..Default::default()
+            },
             ..disk_fixture()
         }]);
         assert_eq!(

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1195,10 +1195,13 @@ impl RateLimiterGroupConfig {
 }
 
 impl PciDeviceCommonConfig {
+    const OPTIONS: &[&str] = &["id", "pci_segment"];
+    const OPTIONS_IOMMU: &[&str] = &["id", "iommu", "pci_segment"];
+
     pub fn parse(input: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
 
-        parser.add("id").add("iommu").add("pci_segment");
+        parser.add_all(Self::OPTIONS_IOMMU);
 
         parser
             .parse_subset(input)
@@ -1258,7 +1261,6 @@ impl DiskConfig {
             .add("path")
             .add("readonly")
             .add("direct")
-            .add("iommu")
             .add("queue_size")
             .add("num_queues")
             .add("vhost_user")
@@ -1269,17 +1271,16 @@ impl DiskConfig {
             .add("ops_size")
             .add("ops_one_time_burst")
             .add("ops_refill_time")
-            .add("id")
             .add("_disable_io_uring")
             .add("_disable_aio")
-            .add("pci_segment")
             .add("serial")
             .add("rate_limit_group")
             .add("queue_affinity")
             .add("backing_files")
             .add("sparse")
             .add("image_type")
-            .add("lock_granularity");
+            .add("lock_granularity")
+            .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU);
 
         parser.parse(disk).map_err(Error::ParseDisk)?;
 
@@ -1507,13 +1508,11 @@ impl NetConfig {
             .add("offload_ufo")
             .add("offload_csum")
             .add("mtu")
-            .add("iommu")
             .add("queue_size")
             .add("num_queues")
             .add("vhost_user")
             .add("socket")
             .add("vhost_mode")
-            .add("id")
             .add("fd")
             .add("bw_size")
             .add("bw_one_time_burst")
@@ -1521,7 +1520,7 @@ impl NetConfig {
             .add("ops_size")
             .add("ops_one_time_burst")
             .add("ops_refill_time")
-            .add("pci_segment");
+            .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU);
         parser.parse(net).map_err(Error::ParseNetwork)?;
 
         let tap = parser.get("tap");
@@ -1772,8 +1771,7 @@ impl GenericVhostUserConfig {
             .add("virtio_id")
             .add("queue_sizes")
             .add("socket")
-            .add("id")
-            .add("pci_segment");
+            .add_all(PciDeviceCommonConfig::OPTIONS);
         parser
             .parse(vhost_user)
             .map_err(Error::ParseGenericVhostUser)?;
@@ -1898,8 +1896,7 @@ impl FsConfig {
             .add("queue_size")
             .add("num_queues")
             .add("socket")
-            .add("id")
-            .add("pci_segment");
+            .add_all(PciDeviceCommonConfig::OPTIONS);
         parser.parse(fs).map_err(Error::ParseFileSystem)?;
 
         let tag = parser.get("tag").ok_or(Error::ParseFsTagMissing)?;
@@ -2050,10 +2047,8 @@ impl PmemConfig {
         parser
             .add("size")
             .add("file")
-            .add("iommu")
             .add("discard_writes")
-            .add("id")
-            .add("pci_segment");
+            .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU);
         parser.parse(pmem).map_err(Error::ParsePersistentMemory)?;
 
         let pci_common = PciDeviceCommonConfig::parse(pmem)?;
@@ -2195,9 +2190,7 @@ impl DeviceConfig {
         let mut parser = OptionParser::new();
         parser
             .add("path")
-            .add("id")
-            .add("iommu")
-            .add("pci_segment")
+            .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU)
             .add("x_nv_gpudirect_clique");
         parser.parse(device).map_err(Error::ParseDevice)?;
 
@@ -2236,7 +2229,7 @@ impl UserDeviceConfig {
 
     pub fn parse(user_device: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
-        parser.add("socket").add("id").add("pci_segment");
+        parser.add("socket").add_all(PciDeviceCommonConfig::OPTIONS);
         parser.parse(user_device).map_err(Error::ParseUserDevice)?;
 
         let pci_common = PciDeviceCommonConfig::parse(user_device)?;
@@ -2267,9 +2260,7 @@ impl VdpaConfig {
         parser
             .add("path")
             .add("num_queues")
-            .add("iommu")
-            .add("id")
-            .add("pci_segment");
+            .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU);
         parser.parse(vdpa).map_err(Error::ParseVdpa)?;
 
         let pci_common = PciDeviceCommonConfig::parse(vdpa)?;
@@ -2303,9 +2294,7 @@ impl VsockConfig {
         parser
             .add("socket")
             .add("cid")
-            .add("iommu")
-            .add("id")
-            .add("pci_segment");
+            .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU);
         parser.parse(vsock).map_err(Error::ParseVsock)?;
 
         let pci_common = PciDeviceCommonConfig::parse(vsock)?;

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2244,39 +2244,21 @@ impl UserDeviceConfig {
         parser.add("socket").add("id").add("pci_segment");
         parser.parse(user_device).map_err(Error::ParseUserDevice)?;
 
+        let pci_common = PciDeviceCommonConfig::parse(user_device)?;
         let socket = parser
             .get("socket")
             .map(PathBuf::from)
             .ok_or(Error::ParseUserDeviceSocketMissing)?;
-        let id = parser.get("id");
-        let pci_segment = parser
-            .convert::<u16>("pci_segment")
-            .map_err(Error::ParseUserDevice)?
-            .unwrap_or_default();
 
-        Ok(UserDeviceConfig {
-            socket,
-            id,
-            pci_segment,
-        })
+        Ok(UserDeviceConfig { pci_common, socket })
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
-        if let Some(platform_config) = vm_config.platform.as_ref() {
-            if self.pci_segment >= platform_config.num_pci_segments {
-                return Err(ValidationError::InvalidPciSegment(self.pci_segment));
-            }
-
-            if let Some(iommu_segments) = platform_config.iommu_segments.as_ref()
-                && iommu_segments.contains(&self.pci_segment)
-            {
-                return Err(ValidationError::IommuNotSupportedOnSegment(
-                    self.pci_segment,
-                ));
-            }
+        if self.pci_common.iommu {
+            return Err(ValidationError::IommuNotSupported);
         }
 
-        Ok(())
+        self.pci_common.validate(vm_config)
     }
 }
 
@@ -3052,7 +3034,7 @@ impl VmConfig {
             for user_device in user_devices {
                 user_device.validate(self)?;
 
-                Self::validate_identifier(&mut id_list, &user_device.id)?;
+                Self::validate_identifier(&mut id_list, &user_device.pci_common.id)?;
             }
         }
 
@@ -3439,7 +3421,7 @@ impl VmConfig {
         // Remove if VFIO user device
         if let Some(user_devices) = self.user_devices.as_mut() {
             let len = user_devices.len();
-            user_devices.retain(|dev| dev.id.as_ref().map(|id| id.as_ref()) != Some(id));
+            user_devices.retain(|dev| dev.pci_common.id.as_ref().map(|id| id.as_ref()) != Some(id));
             removed |= user_devices.len() != len;
         }
 
@@ -5409,9 +5391,11 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..platform_fixture()
         });
         invalid_config.user_devices = Some(vec![UserDeviceConfig {
-            pci_segment: 1,
+            pci_common: PciDeviceCommonConfig {
+                pci_segment: 1,
+                ..Default::default()
+            },
             socket: PathBuf::new(),
-            id: None,
         }]);
         assert_eq!(
             invalid_config.validate(),

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1554,11 +1554,6 @@ impl NetConfig {
             .unwrap_or(Toggle(true))
             .0;
         let mtu = parser.convert("mtu").map_err(Error::ParseNetwork)?;
-        let iommu = parser
-            .convert::<Toggle>("iommu")
-            .map_err(Error::ParseNetwork)?
-            .unwrap_or(Toggle(false))
-            .0;
         let queue_size = parser
             .convert("queue_size")
             .map_err(Error::ParseNetwork)?
@@ -1577,15 +1572,10 @@ impl NetConfig {
             .convert("vhost_mode")
             .map_err(Error::ParseNetwork)?
             .unwrap_or_default();
-        let id = parser.get("id");
         let fds = parser
             .convert::<IntegerList>("fd")
             .map_err(Error::ParseNetwork)?
             .map(|v| v.0.iter().map(|e| *e as i32).collect());
-        let pci_segment = parser
-            .convert("pci_segment")
-            .map_err(Error::ParseNetwork)?
-            .unwrap_or_default();
         let bw_size = parser
             .convert("bw_size")
             .map_err(Error::ParseNetwork)?
@@ -1637,23 +1627,23 @@ impl NetConfig {
             None
         };
 
+        let pci_common = PciDeviceCommonConfig::parse(net)?;
+
         let config = NetConfig {
+            pci_common,
             tap,
             ip,
             mask,
             mac,
             host_mac,
             mtu,
-            iommu,
             num_queues,
             queue_size,
             vhost_user,
             vhost_socket,
             vhost_mode,
-            id,
             fds,
             rate_limiter_config,
-            pci_segment,
             offload_tso,
             offload_ufo,
             offload_csum,
@@ -1662,6 +1652,8 @@ impl NetConfig {
     }
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
+        self.pci_common.validate(vm_config)?;
+
         if self.num_queues < 2 {
             return Err(ValidationError::VnetQueueLowerThan2(self.num_queues));
         }
@@ -1689,21 +1681,8 @@ impl NetConfig {
             ));
         }
 
-        if self.vhost_user && self.iommu {
+        if self.vhost_user && self.pci_common.iommu {
             return Err(ValidationError::IommuNotSupported);
-        }
-
-        if let Some(platform_config) = vm_config.platform.as_ref() {
-            if self.pci_segment >= platform_config.num_pci_segments {
-                return Err(ValidationError::InvalidPciSegment(self.pci_segment));
-            }
-
-            if let Some(iommu_segments) = platform_config.iommu_segments.as_ref()
-                && iommu_segments.contains(&self.pci_segment)
-                && !self.iommu
-            {
-                return Err(ValidationError::OnIommuSegment(self.pci_segment));
-            }
         }
 
         if let Some(mtu) = self.mtu
@@ -2778,6 +2757,7 @@ impl RestoreConfig {
         for net_fds in vm_config.net.iter().flatten() {
             if let Some(expected_fds) = &net_fds.fds {
                 let expected_id = net_fds
+                    .pci_common
                     .id
                     .as_ref()
                     .expect("Invalid 'NetConfig' with empty 'id' for VM restore.");
@@ -3066,9 +3046,9 @@ impl VmConfig {
                     return Err(ValidationError::VhostUserRequiresSharedMemory);
                 }
                 net.validate(self)?;
-                self.iommu |= net.iommu;
+                self.iommu |= net.pci_common.iommu;
 
-                Self::validate_identifier(&mut id_list, &net.id)?;
+                Self::validate_identifier(&mut id_list, &net.pci_common.id)?;
             }
         }
 
@@ -3564,7 +3544,7 @@ impl VmConfig {
         // Remove if net device
         if let Some(net) = self.net.as_mut() {
             let len = net.len();
-            net.retain(|dev| dev.id.as_ref().map(|id| id.as_ref()) != Some(id));
+            net.retain(|dev| dev.pci_common.id.as_ref().map(|id| id.as_ref()) != Some(id));
             removed |= net.len() != len;
         }
 
@@ -4148,22 +4128,20 @@ mod unit_tests {
 
     fn net_fixture() -> NetConfig {
         NetConfig {
+            pci_common: PciDeviceCommonConfig::default(),
             tap: None,
             ip: None,
             mask: None,
             mac: MacAddr::parse_str("de:ad:be:ef:12:34").unwrap(),
             host_mac: Some(MacAddr::parse_str("12:34:de:ad:be:ef").unwrap()),
             mtu: None,
-            iommu: false,
             num_queues: 2,
             queue_size: 256,
             vhost_user: false,
             vhost_socket: None,
             vhost_mode: VhostMode::Client,
-            id: None,
             fds: None,
             rate_limiter_config: None,
-            pci_segment: 0,
             offload_tso: true,
             offload_ufo: true,
             offload_csum: true,
@@ -4181,7 +4159,10 @@ mod unit_tests {
         assert_eq!(
             NetConfig::parse("mac=de:ad:be:ef:12:34,host_mac=12:34:de:ad:be:ef,id=mynet0")?,
             NetConfig {
-                id: Some("mynet0".to_owned()),
+                pci_common: PciDeviceCommonConfig {
+                    id: Some("mynet0".to_owned()),
+                    ..Default::default()
+                },
                 ..net_fixture()
             }
         );
@@ -4214,9 +4195,12 @@ mod unit_tests {
                 "mac=de:ad:be:ef:12:34,host_mac=12:34:de:ad:be:ef,num_queues=4,queue_size=1024,iommu=on"
             )?,
             NetConfig {
+                pci_common: PciDeviceCommonConfig {
+                    iommu: true,
+                    ..Default::default()
+                },
                 num_queues: 4,
                 queue_size: 1024,
-                iommu: true,
                 ..net_fixture()
             }
         );
@@ -4840,19 +4824,28 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             preserved_fds: None,
             net: Some(vec![
                 NetConfig {
-                    id: Some("net0".to_owned()),
+                    pci_common: PciDeviceCommonConfig {
+                        id: Some("net0".to_owned()),
+                        ..Default::default()
+                    },
                     num_queues: 2,
                     fds: Some(vec![-1, -1, -1, -1]),
                     ..net_fixture()
                 },
                 NetConfig {
-                    id: Some("net1".to_owned()),
+                    pci_common: PciDeviceCommonConfig {
+                        id: Some("net1".to_owned()),
+                        ..Default::default()
+                    },
                     num_queues: 1,
                     fds: Some(vec![-1, -1]),
                     ..net_fixture()
                 },
                 NetConfig {
-                    id: Some("net2".to_owned()),
+                    pci_common: PciDeviceCommonConfig {
+                        id: Some("net2".to_owned()),
+                        ..Default::default()
+                    },
                     fds: None,
                     ..net_fixture()
                 },
@@ -4947,7 +4940,10 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             resume: false,
         };
         snapshot_vm_config.net = Some(vec![NetConfig {
-            id: Some("net2".to_owned()),
+            pci_common: PciDeviceCommonConfig {
+                id: Some("net2".to_owned()),
+                ..Default::default()
+            },
             fds: None,
             ..net_fixture()
         }]);
@@ -5330,8 +5326,11 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..platform_fixture()
         });
         still_valid_config.net = Some(vec![NetConfig {
-            iommu: true,
-            pci_segment: 1,
+            pci_common: PciDeviceCommonConfig {
+                iommu: true,
+                pci_segment: 1,
+                ..Default::default()
+            },
             ..net_fixture()
         }]);
         still_valid_config.validate().unwrap();
@@ -5398,8 +5397,11 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..platform_fixture()
         });
         invalid_config.net = Some(vec![NetConfig {
-            iommu: false,
-            pci_segment: 1,
+            pci_common: PciDeviceCommonConfig {
+                iommu: false,
+                pci_segment: 1,
+                ..Default::default()
+            },
             ..net_fixture()
         }]);
         assert_eq!(

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3150,11 +3150,11 @@ impl DeviceManager {
         &mut self,
         generic_vhost_user_cfg: &mut GenericVhostUserConfig,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &generic_vhost_user_cfg.id {
+        let id = if let Some(id) = &generic_vhost_user_cfg.pci_common.id {
             id.clone()
         } else {
             let id = self.next_device_name(GENERIC_VHOST_USER_DEVICE_NAME_PREFIX)?;
-            generic_vhost_user_cfg.id = Some(id.clone());
+            generic_vhost_user_cfg.pci_common.id = Some(id.clone());
             id
         };
 
@@ -3191,7 +3191,7 @@ impl DeviceManager {
                     as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
                 iommu: false,
                 id,
-                pci_segment: generic_vhost_user_cfg.pci_segment,
+                pci_segment: generic_vhost_user_cfg.pci_common.pci_segment,
                 dma_handler: None,
             })
         } else {
@@ -5049,7 +5049,7 @@ impl DeviceManager {
         &mut self,
         generic_vhost_user_cfg: &mut GenericVhostUserConfig,
     ) -> DeviceManagerResult<PciDeviceInfo> {
-        self.validate_identifier(&generic_vhost_user_cfg.id)?;
+        self.validate_identifier(&generic_vhost_user_cfg.pci_common.id)?;
 
         let device = self.make_generic_vhost_user_device(generic_vhost_user_cfg)?;
         self.hotplug_virtio_pci_device(device)

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2937,11 +2937,11 @@ impl DeviceManager {
         &mut self,
         net_cfg: &mut NetConfig,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &net_cfg.id {
+        let id = if let Some(id) = &net_cfg.pci_common.id {
             id.clone()
         } else {
             let id = self.next_device_name(NET_DEVICE_NAME_PREFIX)?;
-            net_cfg.id = Some(id.clone());
+            net_cfg.pci_common.id = Some(id.clone());
             id
         };
         info!("Creating virtio-net device: {net_cfg:?}");
@@ -2999,7 +2999,7 @@ impl DeviceManager {
                         Some(net_cfg.mac),
                         &mut net_cfg.host_mac,
                         net_cfg.mtu,
-                        self.force_iommu | net_cfg.iommu,
+                        self.force_iommu | net_cfg.pci_common.iommu,
                         net_cfg.num_queues,
                         net_cfg.queue_size,
                         self.seccomp_action.clone(),
@@ -3020,7 +3020,7 @@ impl DeviceManager {
                     fds,
                     Some(net_cfg.mac),
                     net_cfg.mtu,
-                    self.force_iommu | net_cfg.iommu,
+                    self.force_iommu | net_cfg.pci_common.iommu,
                     net_cfg.queue_size,
                     self.seccomp_action.clone(),
                     net_cfg.rate_limiter_config,
@@ -3050,7 +3050,7 @@ impl DeviceManager {
                         Some(net_cfg.mac),
                         &mut net_cfg.host_mac,
                         net_cfg.mtu,
-                        self.force_iommu | net_cfg.iommu,
+                        self.force_iommu | net_cfg.pci_common.iommu,
                         net_cfg.num_queues,
                         net_cfg.queue_size,
                         self.seccomp_action.clone(),
@@ -3083,9 +3083,9 @@ impl DeviceManager {
 
         Ok(MetaVirtioDevice {
             virtio_device,
-            iommu: net_cfg.iommu,
+            iommu: net_cfg.pci_common.iommu,
             id,
-            pci_segment: net_cfg.pci_segment,
+            pci_segment: net_cfg.pci_common.pci_segment,
             dma_handler: None,
         })
     }
@@ -4737,7 +4737,7 @@ impl DeviceManager {
                     let nets = config.net.as_deref_mut().unwrap();
                     let net_dev_cfg = nets
                         .iter_mut()
-                        .find(|net| net.id.as_deref() == Some(id))
+                        .find(|net| net.pci_common.id.as_deref() == Some(id))
                         // unwrap: the device could not have been removed without an ID
                         .unwrap();
                     let fds = net_dev_cfg.fds.take().unwrap_or(Vec::new());
@@ -5067,9 +5067,9 @@ impl DeviceManager {
     }
 
     pub fn add_net(&mut self, net_cfg: &mut NetConfig) -> DeviceManagerResult<PciDeviceInfo> {
-        self.validate_identifier(&net_cfg.id)?;
+        self.validate_identifier(&net_cfg.pci_common.id)?;
 
-        if net_cfg.iommu && !self.is_iommu_segment(net_cfg.pci_segment) {
+        if net_cfg.pci_common.iommu && !self.is_iommu_segment(net_cfg.pci_common.pci_segment) {
             return Err(DeviceManagerError::InvalidIommuHotplug);
         }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3282,11 +3282,11 @@ impl DeviceManager {
         &mut self,
         pmem_cfg: &mut PmemConfig,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &pmem_cfg.id {
+        let id = if let Some(id) = &pmem_cfg.pci_common.id {
             id.clone()
         } else {
             let id = self.next_device_name(PMEM_DEVICE_NAME_PREFIX)?;
-            pmem_cfg.id = Some(id.clone());
+            pmem_cfg.pci_common.id = Some(id.clone());
             id
         };
 
@@ -3358,7 +3358,7 @@ impl DeviceManager {
         let (region_base, region_size) = if let Some((base, size)) = region_range {
             // The memory needs to be 2MiB aligned in order to support
             // hugepages.
-            self.pci_segments[pmem_cfg.pci_segment as usize]
+            self.pci_segments[pmem_cfg.pci_common.pci_segment as usize]
                 .mem64_allocator
                 .lock()
                 .unwrap()
@@ -3373,7 +3373,7 @@ impl DeviceManager {
         } else {
             // The memory needs to be 2MiB aligned in order to support
             // hugepages.
-            let base = self.pci_segments[pmem_cfg.pci_segment as usize]
+            let base = self.pci_segments[pmem_cfg.pci_common.pci_segment as usize]
                 .mem64_allocator
                 .lock()
                 .unwrap()
@@ -3421,7 +3421,7 @@ impl DeviceManager {
                 file,
                 GuestAddress(region_base),
                 mapping,
-                self.force_iommu | pmem_cfg.iommu,
+                self.force_iommu | pmem_cfg.pci_common.iommu,
                 self.seccomp_action.clone(),
                 self.exit_evt
                     .try_clone()
@@ -3444,9 +3444,9 @@ impl DeviceManager {
         Ok(MetaVirtioDevice {
             virtio_device: Arc::clone(&virtio_pmem_device)
                 as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-            iommu: pmem_cfg.iommu,
+            iommu: pmem_cfg.pci_common.iommu,
             id,
-            pci_segment: pmem_cfg.pci_segment,
+            pci_segment: pmem_cfg.pci_common.pci_segment,
             dma_handler: None,
         })
     }
@@ -5056,9 +5056,9 @@ impl DeviceManager {
     }
 
     pub fn add_pmem(&mut self, pmem_cfg: &mut PmemConfig) -> DeviceManagerResult<PciDeviceInfo> {
-        self.validate_identifier(&pmem_cfg.id)?;
+        self.validate_identifier(&pmem_cfg.pci_common.id)?;
 
-        if pmem_cfg.iommu && !self.is_iommu_segment(pmem_cfg.pci_segment) {
+        if pmem_cfg.pci_common.iommu && !self.is_iommu_segment(pmem_cfg.pci_common.pci_segment) {
             return Err(DeviceManagerError::InvalidIommuHotplug);
         }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3858,16 +3858,16 @@ impl DeviceManager {
         &mut self,
         device_cfg: &mut DeviceConfig,
     ) -> DeviceManagerResult<(PciBdf, String)> {
-        let vfio_name = if let Some(id) = &device_cfg.id {
+        let vfio_name = if let Some(id) = &device_cfg.pci_common.id {
             id.clone()
         } else {
             let id = self.next_device_name(VFIO_DEVICE_NAME_PREFIX)?;
-            device_cfg.id = Some(id.clone());
+            device_cfg.pci_common.id = Some(id.clone());
             id
         };
 
         let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&vfio_name, device_cfg.pci_segment)?;
+            self.pci_resources(&vfio_name, device_cfg.pci_common.pci_segment)?;
 
         let mut needs_dma_mapping = false;
 
@@ -3884,7 +3884,7 @@ impl DeviceManager {
         // container/group. The VFIO cdev and iommufd do not have such a
         // limitation, and this will be revised once we have VFIO cdev and
         // iommufd support.
-        let vfio_ops = if device_cfg.iommu {
+        let vfio_ops = if device_cfg.pci_common.iommu {
             let vfio_ops = self.create_vfio_ops()?;
 
             let vfio_mapping = Arc::new(VfioDmaMapping::new(
@@ -3989,7 +3989,7 @@ impl DeviceManager {
             vfio_ops,
             self.msi_interrupt_manager.clone(),
             legacy_interrupt_group,
-            device_cfg.iommu,
+            device_cfg.pci_common.iommu,
             vfio_p2p_dma,
             pci_device_bdf,
             memory_manager.lock().unwrap().memory_slot_allocator(),
@@ -4104,7 +4104,7 @@ impl DeviceManager {
         if let Some(device_list_cfg) = &mut devices {
             for device_cfg in device_list_cfg.iter_mut() {
                 let (device_id, _) = self.add_passthrough_device(device_cfg)?;
-                if device_cfg.iommu && self.iommu_device.is_some() {
+                if device_cfg.pci_common.iommu && self.iommu_device.is_some() {
                     iommu_attached_device_ids.push(device_id);
                 }
             }
@@ -4630,16 +4630,18 @@ impl DeviceManager {
         &mut self,
         device_cfg: &mut DeviceConfig,
     ) -> DeviceManagerResult<PciDeviceInfo> {
-        self.validate_identifier(&device_cfg.id)?;
+        self.validate_identifier(&device_cfg.pci_common.id)?;
 
-        if device_cfg.iommu && !self.is_iommu_segment(device_cfg.pci_segment) {
+        if device_cfg.pci_common.iommu && !self.is_iommu_segment(device_cfg.pci_common.pci_segment)
+        {
             return Err(DeviceManagerError::InvalidIommuHotplug);
         }
 
         let (bdf, device_name) = self.add_passthrough_device(device_cfg)?;
 
         // Update the PCIU bitmap
-        self.pci_segments[device_cfg.pci_segment as usize].pci_devices_up |= 1 << bdf.device();
+        self.pci_segments[device_cfg.pci_common.pci_segment as usize].pci_devices_up |=
+            1 << bdf.device();
 
         Ok(PciDeviceInfo {
             id: device_name,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3216,11 +3216,11 @@ impl DeviceManager {
         &mut self,
         fs_cfg: &mut FsConfig,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &fs_cfg.id {
+        let id = if let Some(id) = &fs_cfg.pci_common.id {
             id.clone()
         } else {
             let id = self.next_device_name(FS_DEVICE_NAME_PREFIX)?;
-            fs_cfg.id = Some(id.clone());
+            fs_cfg.pci_common.id = Some(id.clone());
             id
         };
 
@@ -3257,7 +3257,7 @@ impl DeviceManager {
                     as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
                 iommu: false,
                 id,
-                pci_segment: fs_cfg.pci_segment,
+                pci_segment: fs_cfg.pci_common.pci_segment,
                 dma_handler: None,
             })
         } else {
@@ -5039,7 +5039,7 @@ impl DeviceManager {
     }
 
     pub fn add_fs(&mut self, fs_cfg: &mut FsConfig) -> DeviceManagerResult<PciDeviceInfo> {
-        self.validate_identifier(&fs_cfg.id)?;
+        self.validate_identifier(&fs_cfg.pci_common.id)?;
 
         let device = self.make_virtio_fs_device(fs_cfg)?;
         self.hotplug_virtio_pci_device(device)

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3469,11 +3469,11 @@ impl DeviceManager {
         &mut self,
         vsock_cfg: &mut VsockConfig,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &vsock_cfg.id {
+        let id = if let Some(id) = &vsock_cfg.pci_common.id {
             id.clone()
         } else {
             let id = self.next_device_name(VSOCK_DEVICE_NAME_PREFIX)?;
-            vsock_cfg.id = Some(id.clone());
+            vsock_cfg.pci_common.id = Some(id.clone());
             id
         };
 
@@ -3493,7 +3493,7 @@ impl DeviceManager {
                 vsock_cfg.cid,
                 vsock_cfg.socket.clone(),
                 backend,
-                self.force_iommu | vsock_cfg.iommu,
+                self.force_iommu | vsock_cfg.pci_common.iommu,
                 self.seccomp_action.clone(),
                 self.exit_evt
                     .try_clone()
@@ -3515,9 +3515,9 @@ impl DeviceManager {
         Ok(MetaVirtioDevice {
             virtio_device: Arc::clone(&vsock_device)
                 as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-            iommu: vsock_cfg.iommu,
+            iommu: vsock_cfg.pci_common.iommu,
             id,
-            pci_segment: vsock_cfg.pci_segment,
+            pci_segment: vsock_cfg.pci_common.pci_segment,
             dma_handler: None,
         })
     }
@@ -5092,9 +5092,9 @@ impl DeviceManager {
     }
 
     pub fn add_vsock(&mut self, vsock_cfg: &mut VsockConfig) -> DeviceManagerResult<PciDeviceInfo> {
-        self.validate_identifier(&vsock_cfg.id)?;
+        self.validate_identifier(&vsock_cfg.pci_common.id)?;
 
-        if vsock_cfg.iommu && !self.is_iommu_segment(vsock_cfg.pci_segment) {
+        if vsock_cfg.pci_common.iommu && !self.is_iommu_segment(vsock_cfg.pci_common.pci_segment) {
             return Err(DeviceManagerError::InvalidIommuHotplug);
         }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2636,11 +2636,11 @@ impl DeviceManager {
         disk_cfg: &mut DiskConfig,
         is_hotplug: bool,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &disk_cfg.id {
+        let id = if let Some(id) = &disk_cfg.pci_common.id {
             id.clone()
         } else {
             let id = self.next_device_name(DISK_DEVICE_NAME_PREFIX)?;
-            disk_cfg.id = Some(id.clone());
+            disk_cfg.pci_common.id = Some(id.clone());
             id
         };
 
@@ -2822,7 +2822,7 @@ impl DeviceManager {
                     let bw = rate_limiter_cfg.bandwidth.unwrap_or_default();
                     let ops = rate_limiter_cfg.ops.unwrap_or_default();
                     let mut rate_limit_group = RateLimiterGroup::new(
-                        disk_cfg.id.as_ref().unwrap(),
+                        disk_cfg.pci_common.id.as_ref().unwrap(),
                         bw.size,
                         bw.one_time_burst.unwrap_or(0),
                         bw.refill_time,
@@ -2865,7 +2865,7 @@ impl DeviceManager {
                     .ok_or(DeviceManagerError::NoDiskPath)?
                     .clone(),
                 disk_cfg.readonly,
-                self.force_iommu | disk_cfg.iommu,
+                self.force_iommu | disk_cfg.pci_common.iommu,
                 disk_cfg.num_queues,
                 disk_cfg.queue_size,
                 disk_cfg.serial.clone(),
@@ -2913,9 +2913,9 @@ impl DeviceManager {
 
         Ok(MetaVirtioDevice {
             virtio_device,
-            iommu: disk_cfg.iommu,
+            iommu: disk_cfg.pci_common.iommu,
             id,
-            pci_segment: disk_cfg.pci_segment,
+            pci_segment: disk_cfg.pci_common.pci_segment,
             dma_handler: None,
         })
     }
@@ -5028,9 +5028,9 @@ impl DeviceManager {
     }
 
     pub fn add_disk(&mut self, disk_cfg: &mut DiskConfig) -> DeviceManagerResult<PciDeviceInfo> {
-        self.validate_identifier(&disk_cfg.id)?;
+        self.validate_identifier(&disk_cfg.pci_common.id)?;
 
-        if disk_cfg.iommu && !self.is_iommu_segment(disk_cfg.pci_segment) {
+        if disk_cfg.pci_common.iommu && !self.is_iommu_segment(disk_cfg.pci_common.pci_segment) {
             return Err(DeviceManagerError::InvalidIommuHotplug);
         }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -132,8 +132,8 @@ use crate::serial_manager::{Error as SerialManagerError, SerialManager};
 use crate::vm_config::IvshmemConfig;
 use crate::vm_config::{
     ConsoleOutputMode, DEFAULT_IOMMU_ADDRESS_WIDTH_BITS, DEFAULT_PCI_SEGMENT_APERTURE_WEIGHT,
-    DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, NetConfig, PmemConfig,
-    UserDeviceConfig, VdpaConfig, VhostMode, VmConfig, VsockConfig,
+    DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, NetConfig, PciDeviceCommonConfig,
+    PmemConfig, UserDeviceConfig, VdpaConfig, VhostMode, VmConfig, VsockConfig,
 };
 use crate::{DEVICE_MANAGER_SNAPSHOT_ID, GuestRegionMmap, PciDeviceInfo, device_node};
 
@@ -926,10 +926,17 @@ pub enum PciDeviceHandle {
 #[derive(Clone)]
 struct MetaVirtioDevice {
     virtio_device: Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-    iommu: bool,
-    id: String,
-    pci_segment: u16,
+    pci_common: PciDeviceCommonConfig,
     dma_handler: Option<Arc<dyn ExternalDmaMapping>>,
+}
+
+impl MetaVirtioDevice {
+    fn id(&self) -> &str {
+        self.pci_common
+            .id
+            .as_deref()
+            .expect("ID should have been assigned before use")
+    }
 }
 
 #[derive(Default)]
@@ -1669,24 +1676,25 @@ impl DeviceManager {
         let mut iommu_attached_devices = Vec::new();
         {
             for handle in self.virtio_devices.clone() {
-                let mapping: Option<Arc<IommuMapping>> = if handle.iommu {
+                let mapping: Option<Arc<IommuMapping>> = if handle.pci_common.iommu {
                     self.iommu_mapping.clone()
                 } else {
                     None
                 };
 
+                let id = handle.id().to_owned();
                 let dev_id = self.add_virtio_pci_device(
                     handle.virtio_device,
                     &mapping,
-                    &handle.id,
-                    handle.pci_segment,
+                    &id,
+                    handle.pci_common.pci_segment,
                     handle.dma_handler,
                 )?;
 
                 // Track device BDF for Generic Initiator support
-                self.device_id_to_bdf.insert(handle.id.clone(), dev_id);
+                self.device_id_to_bdf.insert(id, dev_id);
 
-                if handle.iommu {
+                if handle.pci_common.iommu {
                     iommu_attached_devices.push(dev_id);
                 }
             }
@@ -2417,9 +2425,11 @@ impl DeviceManager {
         self.virtio_devices.push(MetaVirtioDevice {
             virtio_device: Arc::clone(&virtio_console_device)
                 as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-            iommu: console_config.iommu,
-            id: id.clone(),
-            pci_segment: 0,
+            pci_common: PciDeviceCommonConfig {
+                id: Some(id.clone()),
+                iommu: console_config.iommu,
+                ..Default::default()
+            },
             dma_handler: None,
         });
 
@@ -2913,9 +2923,7 @@ impl DeviceManager {
 
         Ok(MetaVirtioDevice {
             virtio_device,
-            iommu: disk_cfg.pci_common.iommu,
-            id,
-            pci_segment: disk_cfg.pci_common.pci_segment,
+            pci_common: disk_cfg.pci_common.clone(),
             dma_handler: None,
         })
     }
@@ -3083,9 +3091,7 @@ impl DeviceManager {
 
         Ok(MetaVirtioDevice {
             virtio_device,
-            iommu: net_cfg.pci_common.iommu,
-            id,
-            pci_segment: net_cfg.pci_common.pci_segment,
+            pci_common: net_cfg.pci_common.clone(),
             dma_handler: None,
         })
     }
@@ -3128,9 +3134,11 @@ impl DeviceManager {
             self.virtio_devices.push(MetaVirtioDevice {
                 virtio_device: Arc::clone(&virtio_rng_device)
                     as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-                iommu: rng_config.iommu,
-                id: id.clone(),
-                pci_segment: 0,
+                pci_common: PciDeviceCommonConfig {
+                    id: Some(id.clone()),
+                    iommu: rng_config.iommu,
+                    ..Default::default()
+                },
                 dma_handler: None,
             });
 
@@ -3189,9 +3197,7 @@ impl DeviceManager {
             Ok(MetaVirtioDevice {
                 virtio_device: Arc::clone(&generic_vhost_user_device)
                     as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-                iommu: false,
-                id,
-                pci_segment: generic_vhost_user_cfg.pci_common.pci_segment,
+                pci_common: generic_vhost_user_cfg.pci_common.clone(),
                 dma_handler: None,
             })
         } else {
@@ -3255,9 +3261,7 @@ impl DeviceManager {
             Ok(MetaVirtioDevice {
                 virtio_device: Arc::clone(&virtio_fs_device)
                     as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-                iommu: false,
-                id,
-                pci_segment: fs_cfg.pci_common.pci_segment,
+                pci_common: fs_cfg.pci_common.clone(),
                 dma_handler: None,
             })
         } else {
@@ -3444,9 +3448,7 @@ impl DeviceManager {
         Ok(MetaVirtioDevice {
             virtio_device: Arc::clone(&virtio_pmem_device)
                 as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-            iommu: pmem_cfg.pci_common.iommu,
-            id,
-            pci_segment: pmem_cfg.pci_common.pci_segment,
+            pci_common: pmem_cfg.pci_common.clone(),
             dma_handler: None,
         })
     }
@@ -3515,9 +3517,7 @@ impl DeviceManager {
         Ok(MetaVirtioDevice {
             virtio_device: Arc::clone(&vsock_device)
                 as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-            iommu: vsock_cfg.pci_common.iommu,
-            id,
-            pci_segment: vsock_cfg.pci_common.pci_segment,
+            pci_common: vsock_cfg.pci_common.clone(),
             dma_handler: None,
         })
     }
@@ -3571,9 +3571,10 @@ impl DeviceManager {
                 self.virtio_devices.push(MetaVirtioDevice {
                     virtio_device: Arc::clone(&virtio_mem_device)
                         as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-                    iommu: false,
-                    id: memory_zone_id.clone(),
-                    pci_segment: 0,
+                    pci_common: PciDeviceCommonConfig {
+                        id: Some(memory_zone_id.clone()),
+                        ..Default::default()
+                    },
                     dma_handler: None,
                 });
 
@@ -3658,9 +3659,10 @@ impl DeviceManager {
             self.virtio_devices.push(MetaVirtioDevice {
                 virtio_device: Arc::clone(&virtio_balloon_device)
                     as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-                iommu: false,
-                id: id.clone(),
-                pci_segment: 0,
+                pci_common: PciDeviceCommonConfig {
+                    id: Some(id.clone()),
+                    ..Default::default()
+                },
                 dma_handler: None,
             });
 
@@ -3697,9 +3699,10 @@ impl DeviceManager {
         self.virtio_devices.push(MetaVirtioDevice {
             virtio_device: Arc::clone(&virtio_watchdog_device)
                 as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-            iommu: false,
-            id: id.clone(),
-            pci_segment: 0,
+            pci_common: PciDeviceCommonConfig {
+                id: Some(id.clone()),
+                ..Default::default()
+            },
             dma_handler: None,
         });
 
@@ -3755,9 +3758,7 @@ impl DeviceManager {
 
         Ok(MetaVirtioDevice {
             virtio_device: vdpa_device as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-            iommu: vdpa_cfg.pci_common.iommu,
-            id,
-            pci_segment: vdpa_cfg.pci_common.pci_segment,
+            pci_common: vdpa_cfg.pci_common.clone(),
             dma_handler: Some(vdpa_mapping),
         })
     }
@@ -4555,7 +4556,7 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::UpdateMemoryForVirtioDevice)?;
 
             if let Some(dma_handler) = &handle.dma_handler
-                && !handle.iommu
+                && !handle.pci_common.iommu
             {
                 let gpa = new_region.start_addr().0;
                 let size = new_region.len();
@@ -4994,24 +4995,26 @@ impl DeviceManager {
         // for instance.
         self.virtio_devices.push(handle.clone());
 
-        let mapping: Option<Arc<IommuMapping>> = if handle.iommu {
+        let mapping: Option<Arc<IommuMapping>> = if handle.pci_common.iommu {
             self.iommu_mapping.clone()
         } else {
             None
         };
 
+        let id = handle.id().to_owned();
         let bdf = self.add_virtio_pci_device(
             handle.virtio_device,
             &mapping,
-            &handle.id,
-            handle.pci_segment,
+            &id,
+            handle.pci_common.pci_segment,
             handle.dma_handler,
         )?;
 
         // Update the PCIU bitmap
-        self.pci_segments[handle.pci_segment as usize].pci_devices_up |= 1 << bdf.device();
+        self.pci_segments[handle.pci_common.pci_segment as usize].pci_devices_up |=
+            1 << bdf.device();
 
-        Ok(PciDeviceInfo { id: handle.id, bdf })
+        Ok(PciDeviceInfo { id, bdf })
     }
 
     fn is_iommu_segment(&self, pci_segment_id: u16) -> bool {
@@ -5108,7 +5111,7 @@ impl DeviceManager {
         for handle in &self.virtio_devices {
             let virtio_device = handle.virtio_device.lock().unwrap();
             if let Some(device_counters) = virtio_device.counters() {
-                counters.insert(handle.id.clone(), device_counters.clone());
+                counters.insert(handle.id().to_owned(), device_counters.clone());
             }
         }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3715,11 +3715,11 @@ impl DeviceManager {
         &mut self,
         vdpa_cfg: &mut VdpaConfig,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &vdpa_cfg.id {
+        let id = if let Some(id) = &vdpa_cfg.pci_common.id {
             id.clone()
         } else {
             let id = self.next_device_name(VDPA_DEVICE_NAME_PREFIX)?;
-            vdpa_cfg.id = Some(id.clone());
+            vdpa_cfg.pci_common.id = Some(id.clone());
             id
         };
 
@@ -3755,9 +3755,9 @@ impl DeviceManager {
 
         Ok(MetaVirtioDevice {
             virtio_device: vdpa_device as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-            iommu: vdpa_cfg.iommu,
+            iommu: vdpa_cfg.pci_common.iommu,
             id,
-            pci_segment: vdpa_cfg.pci_segment,
+            pci_segment: vdpa_cfg.pci_common.pci_segment,
             dma_handler: Some(vdpa_mapping),
         })
     }
@@ -5081,9 +5081,9 @@ impl DeviceManager {
     }
 
     pub fn add_vdpa(&mut self, vdpa_cfg: &mut VdpaConfig) -> DeviceManagerResult<PciDeviceInfo> {
-        self.validate_identifier(&vdpa_cfg.id)?;
+        self.validate_identifier(&vdpa_cfg.pci_common.id)?;
 
-        if vdpa_cfg.iommu && !self.is_iommu_segment(vdpa_cfg.pci_segment) {
+        if vdpa_cfg.pci_common.iommu && !self.is_iommu_segment(vdpa_cfg.pci_common.pci_segment) {
             return Err(DeviceManagerError::InvalidIommuHotplug);
         }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4120,16 +4120,16 @@ impl DeviceManager {
         &mut self,
         device_cfg: &mut UserDeviceConfig,
     ) -> DeviceManagerResult<(PciBdf, String)> {
-        let vfio_user_name = if let Some(id) = &device_cfg.id {
+        let vfio_user_name = if let Some(id) = &device_cfg.pci_common.id {
             id.clone()
         } else {
             let id = self.next_device_name(VFIO_USER_DEVICE_NAME_PREFIX)?;
-            device_cfg.id = Some(id.clone());
+            device_cfg.pci_common.id = Some(id.clone());
             id
         };
 
         let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&vfio_user_name, device_cfg.pci_segment)?;
+            self.pci_resources(&vfio_user_name, device_cfg.pci_common.pci_segment)?;
 
         let legacy_interrupt_group =
             if let Some(legacy_interrupt_manager) = &self.legacy_interrupt_manager {
@@ -4653,12 +4653,13 @@ impl DeviceManager {
         &mut self,
         device_cfg: &mut UserDeviceConfig,
     ) -> DeviceManagerResult<PciDeviceInfo> {
-        self.validate_identifier(&device_cfg.id)?;
+        self.validate_identifier(&device_cfg.pci_common.id)?;
 
         let (bdf, device_name) = self.add_vfio_user_device(device_cfg)?;
 
         // Update the PCIU bitmap
-        self.pci_segments[device_cfg.pci_segment as usize].pci_devices_up |= 1 << bdf.device();
+        self.pci_segments[device_cfg.pci_common.pci_segment as usize].pci_devices_up |=
+            1 << bdf.device();
 
         Ok(PciDeviceInfo {
             id: device_name,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2646,12 +2646,13 @@ impl DeviceManager {
         disk_cfg: &mut DiskConfig,
         is_hotplug: bool,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &disk_cfg.pci_common.id {
-            id.clone()
-        } else {
-            let id = self.next_device_name(DISK_DEVICE_NAME_PREFIX)?;
-            disk_cfg.pci_common.id = Some(id.clone());
-            id
+        let id = match disk_cfg.pci_common.id.as_ref() {
+            Some(id) => id.clone(),
+            None => disk_cfg
+                .pci_common
+                .id
+                .insert(self.next_device_name(DISK_DEVICE_NAME_PREFIX)?)
+                .clone(),
         };
 
         info!("Creating virtio-block device: {disk_cfg:?}");
@@ -2945,12 +2946,13 @@ impl DeviceManager {
         &mut self,
         net_cfg: &mut NetConfig,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &net_cfg.pci_common.id {
-            id.clone()
-        } else {
-            let id = self.next_device_name(NET_DEVICE_NAME_PREFIX)?;
-            net_cfg.pci_common.id = Some(id.clone());
-            id
+        let id = match net_cfg.pci_common.id.as_ref() {
+            Some(id) => id.clone(),
+            None => net_cfg
+                .pci_common
+                .id
+                .insert(self.next_device_name(NET_DEVICE_NAME_PREFIX)?)
+                .clone(),
         };
         info!("Creating virtio-net device: {net_cfg:?}");
 
@@ -3158,12 +3160,13 @@ impl DeviceManager {
         &mut self,
         generic_vhost_user_cfg: &mut GenericVhostUserConfig,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &generic_vhost_user_cfg.pci_common.id {
-            id.clone()
-        } else {
-            let id = self.next_device_name(GENERIC_VHOST_USER_DEVICE_NAME_PREFIX)?;
-            generic_vhost_user_cfg.pci_common.id = Some(id.clone());
-            id
+        let id = match generic_vhost_user_cfg.pci_common.id.as_ref() {
+            Some(id) => id.clone(),
+            None => generic_vhost_user_cfg
+                .pci_common
+                .id
+                .insert(self.next_device_name(GENERIC_VHOST_USER_DEVICE_NAME_PREFIX)?)
+                .clone(),
         };
 
         info!("Creating generic vhost-user device: {generic_vhost_user_cfg:?}");
@@ -3222,12 +3225,13 @@ impl DeviceManager {
         &mut self,
         fs_cfg: &mut FsConfig,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &fs_cfg.pci_common.id {
-            id.clone()
-        } else {
-            let id = self.next_device_name(FS_DEVICE_NAME_PREFIX)?;
-            fs_cfg.pci_common.id = Some(id.clone());
-            id
+        let id = match fs_cfg.pci_common.id.as_ref() {
+            Some(id) => id.clone(),
+            None => fs_cfg
+                .pci_common
+                .id
+                .insert(self.next_device_name(FS_DEVICE_NAME_PREFIX)?)
+                .clone(),
         };
 
         info!("Creating virtio-fs device: {fs_cfg:?}");
@@ -3286,12 +3290,13 @@ impl DeviceManager {
         &mut self,
         pmem_cfg: &mut PmemConfig,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &pmem_cfg.pci_common.id {
-            id.clone()
-        } else {
-            let id = self.next_device_name(PMEM_DEVICE_NAME_PREFIX)?;
-            pmem_cfg.pci_common.id = Some(id.clone());
-            id
+        let id = match pmem_cfg.pci_common.id.as_ref() {
+            Some(id) => id.clone(),
+            None => pmem_cfg
+                .pci_common
+                .id
+                .insert(self.next_device_name(PMEM_DEVICE_NAME_PREFIX)?)
+                .clone(),
         };
 
         info!("Creating virtio-pmem device: {pmem_cfg:?}");
@@ -3471,12 +3476,13 @@ impl DeviceManager {
         &mut self,
         vsock_cfg: &mut VsockConfig,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &vsock_cfg.pci_common.id {
-            id.clone()
-        } else {
-            let id = self.next_device_name(VSOCK_DEVICE_NAME_PREFIX)?;
-            vsock_cfg.pci_common.id = Some(id.clone());
-            id
+        let id = match vsock_cfg.pci_common.id.as_ref() {
+            Some(id) => id.clone(),
+            None => vsock_cfg
+                .pci_common
+                .id
+                .insert(self.next_device_name(VSOCK_DEVICE_NAME_PREFIX)?)
+                .clone(),
         };
 
         info!("Creating virtio-vsock device: {vsock_cfg:?}");
@@ -3718,12 +3724,13 @@ impl DeviceManager {
         &mut self,
         vdpa_cfg: &mut VdpaConfig,
     ) -> DeviceManagerResult<MetaVirtioDevice> {
-        let id = if let Some(id) = &vdpa_cfg.pci_common.id {
-            id.clone()
-        } else {
-            let id = self.next_device_name(VDPA_DEVICE_NAME_PREFIX)?;
-            vdpa_cfg.pci_common.id = Some(id.clone());
-            id
+        let id = match vdpa_cfg.pci_common.id.as_ref() {
+            Some(id) => id.clone(),
+            None => vdpa_cfg
+                .pci_common
+                .id
+                .insert(self.next_device_name(VDPA_DEVICE_NAME_PREFIX)?)
+                .clone(),
         };
 
         info!("Creating vDPA device: {vdpa_cfg:?}");

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1879,7 +1879,9 @@ impl RequestHandler for Vmm {
             for net in restored_nets.iter() {
                 for net_config in vm_net_configs.iter_mut() {
                     // update only if the net dev is backed by FDs
-                    if net_config.id.as_ref() == Some(&net.id) && net_config.fds.is_some() {
+                    if net_config.pci_common.id.as_ref() == Some(&net.id)
+                        && net_config.fds.is_some()
+                    {
                         net_config.fds.clone_from(&net.fds);
                     }
                 }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -667,14 +667,10 @@ impl ApplyLandlock for VdpaConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct VsockConfig {
+    #[serde(flatten)]
+    pub pci_common: PciDeviceCommonConfig,
     pub cid: u32,
     pub socket: PathBuf,
-    #[serde(default)]
-    pub iommu: bool,
-    #[serde(default)]
-    pub id: Option<String>,
-    #[serde(default)]
-    pub pci_segment: u16,
 }
 
 impl ApplyLandlock for VsockConfig {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -350,6 +350,8 @@ pub fn default_diskconfig_sparse() -> bool {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct NetConfig {
+    #[serde(flatten)]
+    pub pci_common: PciDeviceCommonConfig,
     #[serde(default = "default_netconfig_tap")]
     pub tap: Option<String>,
     pub ip: Option<IpAddr>,
@@ -360,8 +362,6 @@ pub struct NetConfig {
     pub host_mac: Option<MacAddr>,
     #[serde(default)]
     pub mtu: Option<u16>,
-    #[serde(default)]
-    pub iommu: bool,
     #[serde(default = "default_netconfig_num_queues")]
     pub num_queues: usize,
     #[serde(default = "default_netconfig_queue_size")]
@@ -371,8 +371,6 @@ pub struct NetConfig {
     pub vhost_socket: Option<String>,
     #[serde(default)]
     pub vhost_mode: VhostMode,
-    #[serde(default)]
-    pub id: Option<String>,
     // Special deserialize handling:
     // Therefore, we don't serialize FDs, and whatever value is here after
     // deserialization is invalid.
@@ -383,8 +381,6 @@ pub struct NetConfig {
     pub fds: Option<Vec<i32>>,
     #[serde(default)]
     pub rate_limiter_config: Option<RateLimiterConfig>,
-    #[serde(default)]
-    pub pci_segment: u16,
     #[serde(default = "default_netconfig_true")]
     pub offload_tso: bool,
     #[serde(default = "default_netconfig_true")]

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -607,13 +607,9 @@ impl ApplyLandlock for DebugConsoleConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DeviceConfig {
+    #[serde(flatten)]
+    pub pci_common: PciDeviceCommonConfig,
     pub path: PathBuf,
-    #[serde(default)]
-    pub iommu: bool,
-    #[serde(default)]
-    pub id: Option<String>,
-    #[serde(default)]
-    pub pci_segment: u16,
     #[serde(default)]
     pub x_nv_gpudirect_clique: Option<u8>,
 }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -471,16 +471,14 @@ pub struct PvmemcontrolConfig {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct FsConfig {
+    #[serde(flatten)]
+    pub pci_common: PciDeviceCommonConfig,
     pub tag: String,
     pub socket: PathBuf,
     #[serde(default = "default_fsconfig_num_queues")]
     pub num_queues: usize,
     #[serde(default = "default_fsconfig_queue_size")]
     pub queue_size: u16,
-    #[serde(default)]
-    pub id: Option<String>,
-    #[serde(default)]
-    pub pci_segment: u16,
 }
 
 pub fn default_fsconfig_num_queues() -> usize {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -498,12 +498,10 @@ impl ApplyLandlock for FsConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GenericVhostUserConfig {
+    #[serde(flatten)]
+    pub pci_common: PciDeviceCommonConfig,
     pub socket: PathBuf,
     pub queue_sizes: Vec<u16>,
-    #[serde(default)]
-    pub id: Option<String>,
-    #[serde(default)]
-    pub pci_segment: u16,
     pub device_type: u32,
 }
 

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -647,15 +647,11 @@ impl ApplyLandlock for UserDeviceConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct VdpaConfig {
+    #[serde(flatten)]
+    pub pci_common: PciDeviceCommonConfig,
     pub path: PathBuf,
     #[serde(default = "default_vdpaconfig_num_queues")]
     pub num_queues: usize,
-    #[serde(default)]
-    pub iommu: bool,
-    #[serde(default)]
-    pub id: Option<String>,
-    #[serde(default)]
-    pub pci_segment: u16,
 }
 
 pub fn default_vdpaconfig_num_queues() -> usize {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -633,11 +633,9 @@ impl ApplyLandlock for DeviceConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct UserDeviceConfig {
+    #[serde(flatten)]
+    pub pci_common: PciDeviceCommonConfig,
     pub socket: PathBuf,
-    #[serde(default)]
-    pub id: Option<String>,
-    #[serde(default)]
-    pub pci_segment: u16,
 }
 
 impl ApplyLandlock for UserDeviceConfig {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -273,6 +273,16 @@ pub struct VirtQueueAffinity {
     pub host_cpus: Vec<usize>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub struct PciDeviceCommonConfig {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "<&bool as std::ops::Not>::not")]
+    pub iommu: bool,
+    #[serde(default)]
+    pub pci_segment: u16,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DiskConfig {
     pub path: Option<PathBuf>,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -514,17 +514,13 @@ impl ApplyLandlock for GenericVhostUserConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct PmemConfig {
+    #[serde(flatten)]
+    pub pci_common: PciDeviceCommonConfig,
     pub file: PathBuf,
     #[serde(default)]
     pub size: Option<u64>,
     #[serde(default)]
-    pub iommu: bool,
-    #[serde(default)]
     pub discard_writes: bool,
-    #[serde(default)]
-    pub id: Option<String>,
-    #[serde(default)]
-    pub pci_segment: u16,
 }
 
 impl ApplyLandlock for PmemConfig {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -285,13 +285,13 @@ pub struct PciDeviceCommonConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DiskConfig {
+    #[serde(flatten)]
+    pub pci_common: PciDeviceCommonConfig,
     pub path: Option<PathBuf>,
     #[serde(default)]
     pub readonly: bool,
     #[serde(default)]
     pub direct: bool,
-    #[serde(default)]
-    pub iommu: bool,
     #[serde(default = "default_diskconfig_num_queues")]
     pub num_queues: usize,
     #[serde(default = "default_diskconfig_queue_size")]
@@ -303,16 +303,12 @@ pub struct DiskConfig {
     pub rate_limit_group: Option<String>,
     #[serde(default)]
     pub rate_limiter_config: Option<RateLimiterConfig>,
-    #[serde(default)]
-    pub id: Option<String>,
     // For testing use only. Not exposed in API.
     #[serde(default)]
     pub disable_io_uring: bool,
     // For testing use only. Not exposed in API.
     #[serde(default)]
     pub disable_aio: bool,
-    #[serde(default)]
-    pub pci_segment: u16,
     #[serde(default)]
     pub serial: Option<String>,
     #[serde(default)]


### PR DESCRIPTION

I noticed that we have a lot of common shared PCI configuration options between
our different config structs. By consolidating into a common struct we can then
use this to reduce code duplication but also make it easier for the work to add a
`pci_device_id` as required in #7631

- **vmm: Introduce a PciDeviceCommonConfig struct**
- **option_parser: Introduce parse_subset() tolerating unknown options**
- **vmm: config: Implement PciDeviceCommonConfig::parse**
- **vmm: Introduce PciDeviceCommonConfig::validate()**
- **vmm: config: Switch DiskConfig to use PciDeviceCommonConfig**
- **vmm: config: Switch NetConfig to use PciDeviceCommonConfig**
- **vmm: config: Switch FsConfig to use PciDeviceCommonConfig**
- **vmm: config: Switch GenericVhostUserConfig to use PciDeviceCommonConfig**
- **vmm: config: Switch PmemConfig to use PciDeviceCommonConfig**
- **vmm: config: Switch DeviceConfig to use PciDeviceCommonConfig**
- **vmm: config: Switch UserDeviceConfig to use PciDeviceCommonConfig**
- **vmm: config: Switch VdpaConfig to use PciDeviceCommonConfig**
- **vmm: config: Switch VsockConfig to use PciDeviceCommonConfig**
- **vmm: config: Remove unused error variant**
- **vmm: device_manager: Reuse PciDeviceCommonConfig in MetaVirtioDevice**
