### PR TITLE
vdpa: fix RX failure after device reset by always using base 0

### DIFF
--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -217,7 +217,7 @@ impl Vdpa {
 
     fn activate_vdpa(
         &mut self,
-        mem: &GuestMemoryMmap,
+        _mem: &GuestMemoryMmap,
         virtio_interrupt: &dyn VirtioInterrupt,
         queues: &[(usize, Queue, EventFd)],
     ) -> Result<()> {
@@ -269,13 +269,7 @@ impl Vdpa {
             self.vhost
                 .as_ref()
                 .unwrap()
-                .set_vring_base(
-                    *queue_index,
-                    queue
-                        .avail_idx(mem, Ordering::Acquire)
-                        .map_err(Error::GetAvailableIndex)?
-                        .0,
-                )
+                .set_vring_base(*queue_index, 0)
                 .map_err(Error::SetVringBase)?;
 
             if let Some(eventfd) =


### PR DESCRIPTION
## Summary

After a vDPA device reset (e.g. triggered by Windows netkvm driver
reinstalling), `activate_vdpa()` read `avail_idx` from guest memory to
pass as the vring base. However, guest memory still contained the stale
value from the previous session. For a 256-entry ring this meant
`base=256`, causing the hardware to think all RX buffers were consumed —
RX stopped completely while TX continued to work.

QEMU handles this by tracking `last_avail_idx` internally (reset to 0 in
`virtio_reset()`) rather than reading from guest memory.

**Fix**: always pass `base=0` to `set_vring_base()`. After reset both the
guest driver and vhost backend restart from 0.

## Test plan

- [x] Tested with mlx5_vdpa (ConnectX-6 Dx) + Windows Server 2025 (netkvm)
- [x] Before fix: `RX=0 bytes` after 3rd driver activation, ping 100% loss
- [x] After fix: full bidirectional connectivity — `ping 10.123.123.4` Reply <1ms, `ping 1.1.1.1` Reply 3ms (via SRv6 + SNAT)
- [x] Verified `set_vring_base` values via logging: 1st=0, 2nd=16, 3rd=256 (stale) → fixed to always 0