### PR TITLE
vmm: Add support for explicit PCI device IDs

### DIFF
--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -976,7 +976,7 @@ pub(crate) fn _test_virtio_fs(
 
         if hotplug {
             // Add fs to the VM
-            let (cmd_success, cmd_output) =
+            let (cmd_success, cmd_output, _) =
                 remote_command_w_output(&api_socket, add_arg, Some(&fs_params));
             assert!(cmd_success);
 
@@ -1065,7 +1065,7 @@ pub(crate) fn _test_virtio_fs(
             );
 
             // Add back and check it works
-            let (cmd_success, cmd_output) =
+            let (cmd_success, cmd_output, _) =
                 remote_command_w_output(&api_socket, add_arg, Some(&fs_params));
             assert!(cmd_success);
             if let Some(pci_segment) = pci_segment {
@@ -1207,7 +1207,7 @@ pub(crate) fn _test_virtio_vsock(guest: &Guest, hotplug: bool) {
         guest.wait_vm_boot().unwrap();
 
         if hotplug {
-            let (cmd_success, cmd_output) = remote_command_w_output(
+            let (cmd_success, cmd_output, _) = remote_command_w_output(
                 &api_socket,
                 "add-vsock",
                 Some(format!("cid=3,socket={socket},id=test0").as_str()),
@@ -2673,7 +2673,7 @@ pub(crate) fn _test_disk_hotplug(guest: &Guest, landlock_enabled: bool) {
         );
 
         // Now let's add the extra disk.
-        let (cmd_success, cmd_output) = remote_command_w_output(
+        let (cmd_success, cmd_output, _) = remote_command_w_output(
             &api_socket,
             "add-disk",
             Some(
@@ -2722,7 +2722,7 @@ pub(crate) fn _test_disk_hotplug(guest: &Guest, landlock_enabled: bool) {
         );
 
         // And add it back to validate unplug did work correctly.
-        let (cmd_success, cmd_output) = remote_command_w_output(
+        let (cmd_success, cmd_output, _) = remote_command_w_output(
             &api_socket,
             "add-disk",
             Some(
@@ -2901,7 +2901,7 @@ pub(crate) fn _test_net_hotplug(
 
     let r = std::panic::catch_unwind(|| {
         // Add network
-        let (cmd_success, cmd_output) = remote_command_w_output(
+        let (cmd_success, cmd_output, _) = remote_command_w_output(
             &api_socket,
             "add-net",
             Some(
@@ -2964,7 +2964,7 @@ pub(crate) fn _test_net_hotplug(
         thread::sleep(std::time::Duration::new(5, 0));
 
         // Add network
-        let (cmd_success, cmd_output) = remote_command_w_output(
+        let (cmd_success, cmd_output, _) = remote_command_w_output(
             &api_socket,
             "add-net",
             Some(
@@ -3353,7 +3353,7 @@ pub(crate) fn _test_macvtap(
         // call to ch-remote from failing.
         thread::sleep(std::time::Duration::new(10, 0));
         // Hotplug the virtio-net device
-        let (cmd_success, cmd_output) =
+        let (cmd_success, cmd_output, _) =
             remote_command_w_output(&api_socket, "add-net", Some(&net_params));
         assert!(cmd_success);
         #[cfg(target_arch = "x86_64")]
@@ -3448,7 +3448,7 @@ pub(crate) fn _test_vdpa_block(guest: &Guest) {
 
         // Hotplug an extra vDPA block device behind the vIOMMU
         // Add a new vDPA device to the VM
-        let (cmd_success, cmd_output) = remote_command_w_output(
+        let (cmd_success, cmd_output, _) = remote_command_w_output(
             &api_socket,
             "add-vdpa",
             Some("id=myvdpa0,path=/dev/vhost-vdpa-1,num_queues=1,pci_segment=1,iommu=on"),

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -688,7 +688,7 @@ pub struct Counters {
 
 pub(crate) fn get_counters(api_socket: &str) -> Counters {
     // Get counters
-    let (cmd_success, cmd_output) = remote_command_w_output(api_socket, "counters", None);
+    let (cmd_success, cmd_output, _) = remote_command_w_output(api_socket, "counters", None);
     assert!(cmd_success);
 
     let counters: HashMap<&str, HashMap<&str, u64>> =
@@ -738,7 +738,7 @@ pub(super) fn pty_read(mut pty: std::fs::File) -> Receiver<String> {
 }
 
 pub(crate) fn get_pty_path(api_socket: &str, pty_type: &str) -> PathBuf {
-    let (cmd_success, cmd_output) = remote_command_w_output(api_socket, "info", None);
+    let (cmd_success, cmd_output, _) = remote_command_w_output(api_socket, "info", None);
     assert!(cmd_success);
     let info: serde_json::Value = serde_json::from_slice(&cmd_output).unwrap_or_default();
     assert_eq!("Pty", info["config"][pty_type]["mode"]);
@@ -786,7 +786,7 @@ pub(crate) fn cleanup_vfio_network_interfaces() {
 }
 
 pub(crate) fn balloon_size(api_socket: &str) -> u64 {
-    let (cmd_success, cmd_output) = remote_command_w_output(api_socket, "info", None);
+    let (cmd_success, cmd_output, _) = remote_command_w_output(api_socket, "info", None);
     assert!(cmd_success);
 
     let info: serde_json::Value = serde_json::from_slice(&cmd_output).unwrap_or_default();
@@ -802,7 +802,7 @@ pub(crate) fn balloon_size(api_socket: &str) -> u64 {
 }
 
 pub(crate) fn vm_state(api_socket: &str) -> String {
-    let (cmd_success, cmd_output) = remote_command_w_output(api_socket, "info", None);
+    let (cmd_success, cmd_output, _) = remote_command_w_output(api_socket, "info", None);
     assert!(cmd_success);
 
     let info: serde_json::Value = serde_json::from_slice(&cmd_output).unwrap_or_default();

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -1033,3 +1033,29 @@ pub(crate) fn make_guest_panic(guest: &Guest) {
     // Trigger guest a panic
     guest.ssh_command("screen -dmS reboot sh -c \"sleep 5; echo s | tee /proc/sysrq-trigger; echo c | sudo tee /proc/sysrq-trigger\"").unwrap();
 }
+
+/// Extracts a BDF from a CHV returned response
+pub(crate) fn bdf_from_hotplug_response(
+    s: &str,
+) -> (
+    u16, /* Segment ID */
+    u8,  /* Bus ID */
+    u8,  /* Device ID */
+    u8,  /* Function ID */
+) {
+    let json: serde_json::Value = serde_json::from_str(s).expect("should be valid JSON");
+    let bdf_str = json["bdf"]
+        .as_str()
+        .expect("should contain string key `bdf`");
+
+    // BDF format: "SSSS:BB:DD.F"
+    let parts: Vec<&str> = bdf_str.split(&[':', '.'][..]).collect();
+    assert_eq!(parts.len(), 4, "unexpected BDF format: {bdf_str}");
+
+    let segment_id = u16::from_str_radix(parts[0], 16).unwrap();
+    let bus_id = u8::from_str_radix(parts[1], 16).unwrap();
+    let device_id = u8::from_str_radix(parts[2], 16).unwrap();
+    let function_id = u8::from_str_radix(parts[3], 16).unwrap();
+
+    (segment_id, bus_id, device_id, function_id)
+}

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -5696,6 +5696,144 @@ mod common_parallel {
 
         handle_child_output(r, &output);
     }
+
+    #[test]
+    fn test_pci_device_id() {
+        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+
+        #[cfg(target_arch = "x86_64")]
+        let kernel_path = direct_kernel_boot_path();
+        #[cfg(target_arch = "aarch64")]
+        let kernel_path = edk2_path();
+
+        let api_socket = temp_api_path(&guest.tmp_dir);
+
+        // Boot without network
+        let mut cmd = GuestCommand::new(&guest);
+
+        cmd.args(["--api-socket", &api_socket])
+            .default_cpus()
+            .default_memory()
+            .args(["--kernel", kernel_path.to_str().unwrap()])
+            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_net()
+            .default_disks()
+            .capture_output();
+
+        let mut child = cmd.spawn().unwrap();
+
+        guest.wait_vm_boot().unwrap();
+
+        // Add a network device with non-static device id request
+        let r = std::panic::catch_unwind(|| {
+            let (cmd_success, cmd_stdout, _) = remote_command_w_output(
+                &api_socket,
+                "add-net",
+                Some(
+                    format!(
+                        "id=test0,tap=,mac={},ip={},mask=255.255.255.128",
+                        guest.network.guest_mac1, guest.network.host_ip1,
+                    )
+                    .as_str(),
+                ),
+            );
+            assert!(cmd_success);
+            // We now know the first free device ID on the bus
+            let output = String::from_utf8(cmd_stdout).expect("should work");
+            let (_, _, first_free_device_id, _) = bdf_from_hotplug_response(output.as_str());
+            assert_ne!(first_free_device_id, 0);
+
+            // We expect a match from grep
+            let _ = String::from(
+                guest
+                    .ssh_command(&format!(
+                        "lspci -n | grep \"00:{first_free_device_id:02x}.0\""
+                    ))
+                    .unwrap()
+                    .trim(),
+            );
+            // Calculate the succeeding device ID
+            let device_id_to_allocate = first_free_device_id + 1;
+            // We expect the succeeding device ID to be free
+            assert!(matches!(
+                guest.ssh_command(&format!(
+                    "lspci -n | grep \"00:{device_id_to_allocate:02x}.0\""
+                )),
+                Err(SshCommandError::NonZeroExitStatus(1))
+            ));
+
+            // Add a device to the next device slot explicitly
+            let (cmd_success, cmd_stdout, _) = remote_command_w_output(
+                &api_socket,
+                "add-net",
+                Some(
+                    format!(
+                        "id=test1337,tap=,mac={},ip={},mask=255.255.255.128,pci_device_id={}",
+                        guest.network.guest_mac1, guest.network.host_ip1, device_id_to_allocate,
+                    )
+                    .as_str(),
+                ),
+            );
+            assert!(cmd_success);
+            // Retrieve what BDF we actually reserved and assert it's equal to that we wanted to reserve
+            let output = String::from_utf8(cmd_stdout).expect("should work");
+            let (_, _, allocated_device_id, _) = bdf_from_hotplug_response(output.as_str());
+            assert_eq!(device_id_to_allocate, allocated_device_id);
+            // Check that the device ID is really in use
+            let _ = String::from(
+                guest
+                    .ssh_command(&format!(
+                        "lspci -n | grep \"00:{allocated_device_id:02x}.0\""
+                    ))
+                    .unwrap()
+                    .trim(),
+            );
+            // Remove the first device to create a hole
+            let cmd_success = remote_command(&api_socket, "remove-device", Some("test0"));
+            assert!(cmd_success);
+            thread::sleep(std::time::Duration::new(5, 0));
+            // We left a hole in the used PCI IDs. The guest sees no device on the respective ID
+            assert!(matches!(
+                guest.ssh_command(&format!(
+                    "lspci -n | grep \"00:{first_free_device_id:02x}.0\""
+                )),
+                Err(SshCommandError::NonZeroExitStatus(1))
+            ));
+            // Reuse the device ID hole by dynamically coalescing with the first free ID
+            let (cmd_success, cmd_stdout, _) = remote_command_w_output(
+                &api_socket,
+                "add-net",
+                Some(
+                    format!(
+                        "id=test0,tap=,mac={},ip={},mask=255.255.255.128",
+                        guest.network.guest_mac1, guest.network.host_ip1,
+                    )
+                    .as_str(),
+                ),
+            );
+            assert!(cmd_success);
+            // Check that CHV reports that we added the same device to the same ID
+            let output = String::from_utf8(cmd_stdout).expect("should work");
+            let (_, _, allocated_device_id, _) = bdf_from_hotplug_response(output.as_str());
+            assert_eq!(first_free_device_id, allocated_device_id);
+
+            // Check that guest sees the same device again at the same BDF
+            let _ = String::from(
+                guest
+                    .ssh_command(&format!(
+                        "lspci -n | grep \"00:{allocated_device_id:02x}.0\""
+                    ))
+                    .unwrap()
+                    .trim(),
+            );
+        });
+
+        kill_child(&mut child);
+        let output = child.wait_with_output().unwrap();
+
+        handle_child_output(r, &output);
+    }
 }
 
 mod dbus_api {

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -5834,6 +5834,84 @@ mod common_parallel {
 
         handle_child_output(r, &output);
     }
+
+    #[test]
+    // Test that adding a duplicate PCI device ID fails
+    fn test_duplicate_pci_device_id() {
+        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+
+        #[cfg(target_arch = "x86_64")]
+        let kernel_path = direct_kernel_boot_path();
+        #[cfg(target_arch = "aarch64")]
+        let kernel_path = edk2_path();
+
+        let api_socket = temp_api_path(&guest.tmp_dir);
+
+        // Boot without network
+        let mut cmd = GuestCommand::new(&guest);
+
+        cmd.args(["--api-socket", &api_socket])
+            .default_cpus()
+            .default_memory()
+            .args(["--kernel", kernel_path.to_str().unwrap()])
+            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_net()
+            .default_disks()
+            .capture_output();
+
+        let mut child = cmd.spawn().unwrap();
+
+        guest.wait_vm_boot().unwrap();
+
+        // Add a network device with non-static device ID request
+        let r = std::panic::catch_unwind(|| {
+            let (cmd_success, cmd_stdout, _) = remote_command_w_output(
+                &api_socket,
+                "add-net",
+                Some(
+                    format!(
+                        "id=test0,tap=,mac={},ip={},mask=255.255.255.128",
+                        guest.network.guest_mac1, guest.network.host_ip1,
+                    )
+                    .as_str(),
+                ),
+            );
+            assert!(cmd_success);
+
+            // We now know the first free device ID on the bus
+            let output = String::from_utf8(cmd_stdout).expect("should work");
+            let (_, _, first_free_device_id, _) = bdf_from_hotplug_response(output.as_str());
+            assert_ne!(first_free_device_id, 0);
+
+            let (cmd_success, _, cmd_stderr) = remote_command_w_output(
+                &api_socket,
+                "add-net",
+                Some(
+                    format!(
+                        "id=test1337,tap=,mac={},ip={},mask=255.255.255.128,pci_device_id={first_free_device_id}",
+                        guest.network.guest_mac1, guest.network.host_ip1,
+                    )
+                    .as_str(),
+                ),
+            );
+            // Check for fail; Allocating the same device ID for two devices is disallowed
+            assert!(!cmd_success);
+            // Check that the error message contains the expected error
+            let std_err_str = String::from_utf8(cmd_stderr).unwrap();
+            assert!(
+                std_err_str.contains(&format!(
+                    "Valid PCI device identifier but already used: {first_free_device_id}"
+                )),
+                "Command return was: {std_err_str}"
+            );
+        });
+
+        kill_child(&mut child);
+        let output = child.wait_with_output().unwrap();
+
+        handle_child_output(r, &output);
+    }
 }
 
 mod dbus_api {

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -5744,22 +5744,26 @@ mod common_parallel {
             let (_, _, first_free_device_id, _) = bdf_from_hotplug_response(output.as_str());
             assert_ne!(first_free_device_id, 0);
 
-            // We expect a match from grep
-            let _ = String::from(
-                guest
-                    .ssh_command(&format!(
-                        "lspci -n | grep \"00:{first_free_device_id:02x}.0\""
-                    ))
-                    .unwrap()
-                    .trim(),
-            );
+            // Wait for the hotplugged device to appear in the guest
+            assert!(wait_until(Duration::from_secs(10), || {
+                ssh_command_ip_with_auth(
+                    &format!("lspci -n | grep \"00:{first_free_device_id:02x}.0\""),
+                    &default_guest_auth(),
+                    &guest.network.guest_ip0,
+                    Some(Duration::from_secs(1)),
+                )
+                .is_ok()
+            }));
             // Calculate the succeeding device ID
             let device_id_to_allocate = first_free_device_id + 1;
-            // We expect the succeeding device ID to be free
+            // We expect the succeeding device ID to be free (single attempt, no retries)
             assert!(matches!(
-                guest.ssh_command(&format!(
-                    "lspci -n | grep \"00:{device_id_to_allocate:02x}.0\""
-                )),
+                ssh_command_ip_with_auth(
+                    &format!("lspci -n | grep \"00:{device_id_to_allocate:02x}.0\""),
+                    &default_guest_auth(),
+                    &guest.network.guest_ip0,
+                    Some(Duration::from_secs(1)),
+                ),
                 Err(SshCommandError::NonZeroExitStatus(1))
             ));
 
@@ -5780,26 +5784,31 @@ mod common_parallel {
             let output = String::from_utf8(cmd_stdout).expect("should work");
             let (_, _, allocated_device_id, _) = bdf_from_hotplug_response(output.as_str());
             assert_eq!(device_id_to_allocate, allocated_device_id);
-            // Check that the device ID is really in use
-            let _ = String::from(
-                guest
-                    .ssh_command(&format!(
-                        "lspci -n | grep \"00:{allocated_device_id:02x}.0\""
-                    ))
-                    .unwrap()
-                    .trim(),
-            );
+            // Wait for the hotplugged device to appear in the guest
+            assert!(wait_until(Duration::from_secs(10), || {
+                ssh_command_ip_with_auth(
+                    &format!("lspci -n | grep \"00:{allocated_device_id:02x}.0\""),
+                    &default_guest_auth(),
+                    &guest.network.guest_ip0,
+                    Some(Duration::from_secs(1)),
+                )
+                .is_ok()
+            }));
             // Remove the first device to create a hole
             let cmd_success = remote_command(&api_socket, "remove-device", Some("test0"));
             assert!(cmd_success);
-            thread::sleep(std::time::Duration::new(5, 0));
-            // We left a hole in the used PCI IDs. The guest sees no device on the respective ID
-            assert!(matches!(
-                guest.ssh_command(&format!(
-                    "lspci -n | grep \"00:{first_free_device_id:02x}.0\""
-                )),
-                Err(SshCommandError::NonZeroExitStatus(1))
-            ));
+            // Wait for the device to disappear from the guest
+            assert!(wait_until(Duration::from_secs(10), || {
+                matches!(
+                    ssh_command_ip_with_auth(
+                        &format!("lspci -n | grep \"00:{first_free_device_id:02x}.0\""),
+                        &default_guest_auth(),
+                        &guest.network.guest_ip0,
+                        Some(Duration::from_secs(1)),
+                    ),
+                    Err(SshCommandError::NonZeroExitStatus(1))
+                )
+            }));
             // Reuse the device ID hole by dynamically coalescing with the first free ID
             let (cmd_success, cmd_stdout, _) = remote_command_w_output(
                 &api_socket,
@@ -5818,15 +5827,16 @@ mod common_parallel {
             let (_, _, allocated_device_id, _) = bdf_from_hotplug_response(output.as_str());
             assert_eq!(first_free_device_id, allocated_device_id);
 
-            // Check that guest sees the same device again at the same BDF
-            let _ = String::from(
-                guest
-                    .ssh_command(&format!(
-                        "lspci -n | grep \"00:{allocated_device_id:02x}.0\""
-                    ))
-                    .unwrap()
-                    .trim(),
-            );
+            // Wait for the re-added device to appear in the guest
+            assert!(wait_until(Duration::from_secs(10), || {
+                ssh_command_ip_with_auth(
+                    &format!("lspci -n | grep \"00:{allocated_device_id:02x}.0\""),
+                    &default_guest_auth(),
+                    &guest.network.guest_ip0,
+                    Some(Duration::from_secs(1)),
+                )
+                .is_ok()
+            }));
         });
 
         kill_child(&mut child);

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -375,7 +375,7 @@ mod common_parallel {
         guest.wait_vm_boot().unwrap();
 
         let r = std::panic::catch_unwind(|| {
-            let (cmd_success, cmd_output) = remote_command_w_output(
+            let (cmd_success, cmd_output, _) = remote_command_w_output(
                 &api_socket,
                 "add-disk",
                 Some(
@@ -2979,7 +2979,7 @@ mod common_parallel {
             guest.wait_vm_boot().unwrap();
 
             // Add the disk to the VM
-            let (cmd_success, cmd_output) = remote_command_w_output(
+            let (cmd_success, cmd_output, _) = remote_command_w_output(
                 &api_socket,
                 "add-disk",
                 Some("path=/tmp/resize.img,id=test0"),
@@ -3094,7 +3094,7 @@ mod common_parallel {
             guest.wait_vm_boot().unwrap();
 
             // Add the QCOW2 disk to the VM
-            let (cmd_success, cmd_output) = remote_command_w_output(
+            let (cmd_success, cmd_output, _) = remote_command_w_output(
                 &api_socket,
                 "add-disk",
                 Some(&format!(
@@ -4904,7 +4904,7 @@ mod common_parallel {
 
             let pmem_temp_file = TempFile::new().unwrap();
             pmem_temp_file.as_file().set_len(128 << 20).unwrap();
-            let (cmd_success, cmd_output) = remote_command_w_output(
+            let (cmd_success, cmd_output, _) = remote_command_w_output(
                 &api_socket,
                 "add-pmem",
                 Some(&format!(
@@ -5402,7 +5402,7 @@ mod common_parallel {
             guest.wait_vm_boot().unwrap();
 
             // Hotplug the SPDK-NVMe device to the VM
-            let (cmd_success, cmd_output) = remote_command_w_output(
+            let (cmd_success, cmd_output, _) = remote_command_w_output(
                 &api_socket,
                 "add-user-device",
                 Some(&format!(
@@ -7979,7 +7979,7 @@ mod windows {
             assert_eq!(netdev_ctrl_threads_count(child.id()), netdev_num);
 
             // Hotplug network device
-            let (cmd_success, cmd_output) = remote_command_w_output(
+            let (cmd_success, cmd_output, _) = remote_command_w_output(
                 &api_socket,
                 "add-net",
                 Some(windows_guest.guest().default_net_string().as_str()),
@@ -8063,7 +8063,7 @@ mod windows {
             assert_eq!(disk_ctrl_threads_count(child.id()), disk_num);
 
             // Hotplug disk device
-            let (cmd_success, cmd_output) = remote_command_w_output(
+            let (cmd_success, cmd_output, _) = remote_command_w_output(
                 &api_socket,
                 "add-disk",
                 Some(format!("path={disk},readonly=off").as_str()),
@@ -8101,7 +8101,7 @@ mod windows {
             assert_eq!(disk_ctrl_threads_count(child.id()), disk_num);
 
             // Remount and check the file exists with the expected contents
-            let (cmd_success, _cmd_output) = remote_command_w_output(
+            let (cmd_success, _cmd_output, _) = remote_command_w_output(
                 &api_socket,
                 "add-disk",
                 Some(format!("path={disk},readonly=off").as_str()),
@@ -8192,7 +8192,7 @@ mod windows {
                 let expected_ctrl_threads = disk_ctrl_threads_count(child.id()) + 1;
 
                 // Hotplug disk device
-                let (cmd_success, cmd_output) = remote_command_w_output(
+                let (cmd_success, cmd_output, _) = remote_command_w_output(
                     &api_socket,
                     "add-disk",
                     Some(format!("path={disk},readonly=off").as_str()),
@@ -8245,7 +8245,7 @@ mod windows {
             // Remount
             for it in &disk_test_data {
                 let disk = it[1].as_str();
-                let (cmd_success, _cmd_output) = remote_command_w_output(
+                let (cmd_success, _cmd_output, _) = remote_command_w_output(
                     &api_socket,
                     "add-disk",
                     Some(format!("path={disk},readonly=off").as_str()),
@@ -8511,7 +8511,7 @@ mod vfio {
             guest.wait_vm_boot().unwrap();
 
             // Hotplug the card to the VM
-            let (cmd_success, cmd_output) = remote_command_w_output(
+            let (cmd_success, cmd_output, _) = remote_command_w_output(
                 &api_socket,
                 "add-device",
                 Some(format!("id=vfio0,path={NVIDIA_VFIO_DEVICE}").as_str()),

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -5912,6 +5912,86 @@ mod common_parallel {
 
         handle_child_output(r, &output);
     }
+
+    #[test]
+    // Test that requesting an invalid device ID fails.
+    fn test_invalid_pci_device_id() {
+        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+
+        #[cfg(target_arch = "x86_64")]
+        let kernel_path = direct_kernel_boot_path();
+        #[cfg(target_arch = "aarch64")]
+        let kernel_path = edk2_path();
+
+        let api_socket = temp_api_path(&guest.tmp_dir);
+
+        // Boot without network
+        let mut cmd = GuestCommand::new(&guest);
+
+        cmd.args(["--api-socket", &api_socket])
+            .default_cpus()
+            .default_memory()
+            .args(["--kernel", kernel_path.to_str().unwrap()])
+            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_net()
+            .default_disks()
+            .capture_output();
+
+        let mut child = cmd.spawn().unwrap();
+
+        guest.wait_vm_boot().unwrap();
+
+        let r = std::panic::catch_unwind(|| {
+            // Invalid API call because the PCI device ID is out of range
+            let (cmd_success, _, cmd_stderr) = remote_command_w_output(
+                &api_socket,
+                "add-net",
+                Some(
+                    format!(
+                        "id=test0,tap=,mac={},ip={},mask=255.255.255.128,pci_device_id=188",
+                        guest.network.guest_mac1, guest.network.host_ip1,
+                    )
+                    .as_str(),
+                ),
+            );
+            // Check for fail
+            assert!(!cmd_success);
+            // Check that the error message contains the expected error
+            let std_err_str = String::from_utf8(cmd_stderr).unwrap();
+            assert!(
+                std_err_str
+                    .contains("Given PCI device ID (188) is out of the supported range of 0..32"),
+                "Command return was: {std_err_str}",
+            );
+
+            // Use the reserved device ID 0 (root device)
+            let (cmd_success, _, cmd_stderr) = remote_command_w_output(
+                &api_socket,
+                "add-net",
+                Some(
+                    format!(
+                        "id=test0,tap=,mac={},ip={},mask=255.255.255.128,pci_device_id=0",
+                        guest.network.guest_mac1, guest.network.host_ip1,
+                    )
+                    .as_str(),
+                ),
+            );
+            // Check for fail
+            assert!(!cmd_success);
+            // Check that the error message contains the expected error
+            let std_err_str = String::from_utf8(cmd_stderr).unwrap();
+            assert!(
+                std_err_str.contains("Given PCI device ID (0) is reserved"),
+                "Command return was: {std_err_str}"
+            );
+        });
+
+        kill_child(&mut child);
+        let output = child.wait_with_output().unwrap();
+
+        handle_child_output(r, &output);
+    }
 }
 
 mod dbus_api {

--- a/docs/device_model.md
+++ b/docs/device_model.md
@@ -90,8 +90,9 @@ feature is enabled by default.
 
 For all virtio devices listed below, only `virtio-pci` transport layer is
 supported. Cloud Hypervisor supports multiple PCI segments, and users can
-append `,pci_segment=<PCI_segment_number>` to the device flag in the Cloud
-Hypervisor command line to assign devices to a specific PCI segment.
+append `,pci_segment=<PCI_segment_number>` or `,pci_device_id=<PCI_device_ID>` to
+the device flag in the Cloud Hypervisor command line to assign devices to a specific
+PCI segment or into a specific device slot.
 
 ### virtio-block
 

--- a/docs/vdpa.md
+++ b/docs/vdpa.md
@@ -32,11 +32,12 @@ struct VdpaConfig {
     iommu: bool,
     id: Option<String>,
     pci_segment: u16,
+    pci_device_id: Option<u8>
 }
 ```
 
 ```
---vdpa <vdpa>	vDPA device "path=<device_path>,num_queues=<number_of_queues>,iommu=on|off,id=<device_id>,pci_segment=<segment_id>"
+--vdpa <vdpa>	vDPA device "path=<device_path>,num_queues=<number_of_queues>,iommu=on|off,id=<device_id>,pci_segment=<segment_id>,pci_device_id=<pci_slot>"
 ```
 
 ### `path`
@@ -96,6 +97,21 @@ _Example_
 --vdpa path=/dev/vhost-vdpa-0,pci_segment=1
 ```
 
+### `pci_device_id`
+
+PCI device ID to assign to the vDPA device on its PCI bus.
+
+This parameter is optional. If not specified, a device ID is automatically
+allocated.
+
+Value is an unsigned integer in the range 1-31.
+
+_Example_
+
+```
+--vdpa path=/dev/vhost-vdpa-0,pci_device_id=5
+```
+
 ## Example with vDPA block simulator
 
 The vDPA framework provides a simulator with both `virtio-block` and
@@ -146,10 +162,10 @@ The `virtio-block` device backed by the vDPA simulator can be found as
 ```
 cloud@cloud:~$ lsblk
 NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
-nullb0  252:0    0  250G  0 disk 
-vda     254:0    0  2.2G  0 disk 
+nullb0  252:0    0  250G  0 disk
+vda     254:0    0  2.2G  0 disk
 ├─vda1  254:1    0  2.1G  0 part /
-├─vda14 254:14   0    4M  0 part 
+├─vda14 254:14   0    4M  0 part
 └─vda15 254:15   0  106M  0 part /boot/efi
 vdb     254:16   0  128M  0 disk
 ```

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -114,21 +114,28 @@ impl PciDevice for PciRoot {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DeviceIdState {
+    Free,
+    Reserved,
+    Allocated,
+}
+
 pub struct PciBus {
     /// Devices attached to this bus.
     /// Device 0 is host bridge.
     devices: HashMap<u8, Arc<Mutex<dyn PciDevice>>>,
     device_reloc: Arc<dyn DeviceRelocation>,
-    device_ids: [bool; NUM_DEVICE_IDS as usize],
+    device_ids: [DeviceIdState; NUM_DEVICE_IDS as usize],
 }
 
 impl PciBus {
     pub fn new(pci_root: PciRoot, device_reloc: Arc<dyn DeviceRelocation>) -> Self {
         let mut devices: HashMap<u8, Arc<Mutex<dyn PciDevice>>> = HashMap::new();
-        let mut device_ids = [false; NUM_DEVICE_IDS as usize];
+        let mut device_ids = [DeviceIdState::Free; NUM_DEVICE_IDS as usize];
 
         devices.insert(PCI_ROOT_DEVICE_ID, Arc::new(Mutex::new(pci_root)));
-        device_ids[PCI_ROOT_DEVICE_ID as usize] = true;
+        device_ids[PCI_ROOT_DEVICE_ID as usize] = DeviceIdState::Allocated;
 
         PciBus {
             devices,
@@ -172,6 +179,31 @@ impl PciBus {
         Ok(())
     }
 
+    /// Reserves a PCI device ID on the bus, marking it as in-use so
+    /// that automatic allocation will not use it.
+    ///
+    /// - `id`: Preferred ID to reserve on the bus.
+    ///
+    /// ## Errors
+    ///
+    /// * Returns [`PciRootError::AlreadyInUsePciDeviceSlot`] if the
+    ///   slot is already reserved or allocated.
+    /// * Returns [`PciRootError::InvalidPciDeviceSlot`] if the slot
+    ///   exceeds [`NUM_DEVICE_IDS`].
+    pub fn reserve_device_id(&mut self, id: u8) -> Result<u8> {
+        let idx = id as usize;
+        if idx < NUM_DEVICE_IDS as usize {
+            if self.device_ids[idx] == DeviceIdState::Free {
+                self.device_ids[idx] = DeviceIdState::Reserved;
+                Ok(id)
+            } else {
+                Err(PciRootError::AlreadyInUsePciDeviceSlot(idx))
+            }
+        } else {
+            Err(PciRootError::InvalidPciDeviceSlot(idx))
+        }
+    }
+
     /// Allocates a PCI device ID on the bus.
     ///
     /// - `id`: ID to allocate on the bus. If [`None`], the next free
@@ -179,6 +211,7 @@ impl PciBus {
     ///   allocated
     ///
     /// ## Errors
+    ///
     /// * Returns [`PciRootError::AlreadyInUsePciDeviceSlot`] in case
     ///   the ID requested is already allocated.
     /// * Returns [`PciRootError::InvalidPciDeviceSlot`] in case the
@@ -190,10 +223,10 @@ impl PciBus {
     pub fn allocate_device_id(&mut self, id: Option<u8>) -> Result<u8> {
         if let Some(idx) = id.map(|i| i as usize) {
             if idx < NUM_DEVICE_IDS as usize {
-                if self.device_ids[idx] {
+                if self.device_ids[idx] == DeviceIdState::Allocated {
                     Err(PciRootError::AlreadyInUsePciDeviceSlot(idx))
                 } else {
-                    self.device_ids[idx] = true;
+                    self.device_ids[idx] = DeviceIdState::Allocated;
                     Ok(idx as u8)
                 }
             } else {
@@ -201,8 +234,8 @@ impl PciBus {
             }
         } else {
             for (idx, device_id) in self.device_ids.iter_mut().enumerate() {
-                if !(*device_id) {
-                    *device_id = true;
+                if *device_id == DeviceIdState::Free {
+                    *device_id = DeviceIdState::Allocated;
                     return Ok(idx as u8);
                 }
             }
@@ -210,22 +243,9 @@ impl PciBus {
         }
     }
 
-    pub fn get_device_id(&mut self, id: usize) -> Result<()> {
-        if id < NUM_DEVICE_IDS as usize {
-            if self.device_ids[id] {
-                Err(PciRootError::AlreadyInUsePciDeviceSlot(id))
-            } else {
-                self.device_ids[id] = true;
-                Ok(())
-            }
-        } else {
-            Err(PciRootError::InvalidPciDeviceSlot(id))
-        }
-    }
-
     pub fn put_device_id(&mut self, id: usize) -> Result<()> {
         if id < NUM_DEVICE_IDS as usize {
-            self.device_ids[id] = false;
+            self.device_ids[id] = DeviceIdState::Free;
             Ok(())
         } else {
             Err(PciRootError::InvalidPciDeviceSlot(id))
@@ -577,14 +597,13 @@ mod unit_tests {
     }
 
     #[test]
-    // Test that gaps resulting from explicit allocations are filled by implicit ones,
-    // beginning with the first free slot
+    // Test that reserved IDs are skipped by automatic allocation
     fn allocate_device_id_fills_gaps() -> Result<(), Box<dyn Error>> {
         // The first address is occupied by the root
         let mut bus = setup_bus();
-        assert_eq!(0x01_u8, bus.allocate_device_id(Some(0x01))?);
-        assert_eq!(0x03_u8, bus.allocate_device_id(Some(0x03))?);
-        assert_eq!(0x06_u8, bus.allocate_device_id(Some(0x06))?);
+        bus.reserve_device_id(0x01)?;
+        bus.reserve_device_id(0x03)?;
+        bus.reserve_device_id(0x06)?;
         assert_eq!(0x02_u8, bus.allocate_device_id(None)?);
         assert_eq!(0x04_u8, bus.allocate_device_id(None)?);
         assert_eq!(0x05_u8, bus.allocate_device_id(None)?);
@@ -593,16 +612,25 @@ mod unit_tests {
     }
 
     #[test]
-    // Test that requesting the same ID twice fails
-    fn allocate_device_id_request_id_twice_fails() -> Result<(), Box<dyn Error>> {
+    // Test that reserving the same ID twice fails
+    fn reserve_device_id_twice_fails() -> Result<(), Box<dyn Error>> {
         let mut bus = setup_bus();
         let max_id = NUM_DEVICE_IDS - 1;
-        bus.allocate_device_id(Some(max_id))?;
-        let result = bus.allocate_device_id(Some(max_id));
+        bus.reserve_device_id(max_id)?;
+        let result = bus.reserve_device_id(max_id);
         assert!(matches!(
             result,
             Err(PciRootError::AlreadyInUsePciDeviceSlot(x)) if x == usize::from(max_id),
         ));
+        Ok(())
+    }
+
+    #[test]
+    // Test that allocating a previously reserved ID succeeds (idempotent)
+    fn allocate_device_id_after_reserve() -> Result<(), Box<dyn Error>> {
+        let mut bus = setup_bus();
+        bus.reserve_device_id(0x10)?;
+        assert_eq!(0x10_u8, bus.allocate_device_id(Some(0x10))?);
         Ok(())
     }
 

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -47,10 +47,10 @@ pub enum PciRootError {
     #[error("Could not find an available device slot on the PCI bus")]
     NoPciDeviceSlotAvailable,
     /// Invalid PCI device identifier provided.
-    #[error("Invalid PCI device identifier provided")]
+    #[error("Invalid PCI device identifier provided: {0}")]
     InvalidPciDeviceSlot(usize),
     /// Valid PCI device identifier but already used.
-    #[error("Valid PCI device identifier but already used")]
+    #[error("Valid PCI device identifier but already used: {0}")]
     AlreadyInUsePciDeviceSlot(usize),
 }
 pub type Result<T> = std::result::Result<T, PciRootError>;
@@ -172,15 +172,42 @@ impl PciBus {
         Ok(())
     }
 
-    pub fn next_device_id(&mut self) -> Result<u32> {
-        for (idx, device_id) in self.device_ids.iter_mut().enumerate() {
-            if !(*device_id) {
-                *device_id = true;
-                return Ok(idx as u32);
+    /// Allocates a PCI device ID on the bus.
+    ///
+    /// - `id`: ID to allocate on the bus. If [`None`], the next free
+    ///   device ID on the bus is allocated, else the ID given is
+    ///   allocated
+    ///
+    /// ## Errors
+    /// * Returns [`PciRootError::AlreadyInUsePciDeviceSlot`] in case
+    ///   the ID requested is already allocated.
+    /// * Returns [`PciRootError::InvalidPciDeviceSlot`] in case the
+    ///   requested ID exceeds the maximum number of devices allowed per
+    ///   bus (see [`NUM_DEVICE_IDS`]).
+    /// * If `id` is [`None`]: Returns
+    ///   [`PciRootError::NoPciDeviceSlotAvailable`] if no free device
+    ///   slot is available on the bus.
+    pub fn allocate_device_id(&mut self, id: Option<u8>) -> Result<u8> {
+        if let Some(idx) = id.map(|i| i as usize) {
+            if idx < NUM_DEVICE_IDS as usize {
+                if self.device_ids[idx] {
+                    Err(PciRootError::AlreadyInUsePciDeviceSlot(idx))
+                } else {
+                    self.device_ids[idx] = true;
+                    Ok(idx as u8)
+                }
+            } else {
+                Err(PciRootError::InvalidPciDeviceSlot(idx))
             }
+        } else {
+            for (idx, device_id) in self.device_ids.iter_mut().enumerate() {
+                if !(*device_id) {
+                    *device_id = true;
+                    return Ok(idx as u8);
+                }
+            }
+            Err(PciRootError::NoPciDeviceSlotAvailable)
         }
-
-        Err(PciRootError::NoPciDeviceSlotAvailable)
     }
 
     pub fn get_device_id(&mut self, id: usize) -> Result<()> {
@@ -495,4 +522,115 @@ fn parse_io_config_address(config_address: u32) -> (usize, usize, usize, usize) 
         shift_and_mask(config_address, FUNCTION_NUMBER_OFFSET, FUNCTION_NUMBER_MASK),
         shift_and_mask(config_address, REGISTER_NUMBER_OFFSET, REGISTER_NUMBER_MASK),
     )
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::error::Error;
+    use std::result::Result;
+
+    use super::*;
+
+    #[derive(Debug)]
+    /// Helper struct that mocks the implementation of DeviceRelocation
+    struct MockDeviceRelocation;
+
+    impl DeviceRelocation for MockDeviceRelocation {
+        fn move_bar(
+            &self,
+            _old_base: u64,
+            _new_base: u64,
+            _len: u64,
+            _pci_dev: &mut dyn PciDevice,
+            _region_type: PciBarRegionType,
+        ) -> Result<(), std::io::Error> {
+            Ok(())
+        }
+    }
+
+    fn setup_bus() -> PciBus {
+        let pci_root = PciRoot::new(None);
+        let mock_device_reloc = Arc::new(MockDeviceRelocation {});
+        PciBus::new(pci_root, mock_device_reloc)
+    }
+
+    #[test]
+    // Test to acquire all IDs that can be acquired
+    fn allocate_device_id_next_free() {
+        // The first address is occupied by the root
+        let mut bus = setup_bus();
+        for expected_id in 1..NUM_DEVICE_IDS {
+            assert_eq!(expected_id, bus.allocate_device_id(None).unwrap());
+        }
+    }
+
+    #[test]
+    // Test that requesting specific ID work
+    fn allocate_device_id_request_id() -> Result<(), Box<dyn Error>> {
+        // The first address is occupied by the root
+        let mut bus = setup_bus();
+        let max_id = NUM_DEVICE_IDS - 1;
+        assert_eq!(0x01_u8, bus.allocate_device_id(Some(0x01))?);
+        assert_eq!(0x10_u8, bus.allocate_device_id(Some(0x10))?);
+        assert_eq!(max_id, bus.allocate_device_id(Some(max_id))?);
+        Ok(())
+    }
+
+    #[test]
+    // Test that gaps resulting from explicit allocations are filled by implicit ones,
+    // beginning with the first free slot
+    fn allocate_device_id_fills_gaps() -> Result<(), Box<dyn Error>> {
+        // The first address is occupied by the root
+        let mut bus = setup_bus();
+        assert_eq!(0x01_u8, bus.allocate_device_id(Some(0x01))?);
+        assert_eq!(0x03_u8, bus.allocate_device_id(Some(0x03))?);
+        assert_eq!(0x06_u8, bus.allocate_device_id(Some(0x06))?);
+        assert_eq!(0x02_u8, bus.allocate_device_id(None)?);
+        assert_eq!(0x04_u8, bus.allocate_device_id(None)?);
+        assert_eq!(0x05_u8, bus.allocate_device_id(None)?);
+        assert_eq!(0x07_u8, bus.allocate_device_id(None)?);
+        Ok(())
+    }
+
+    #[test]
+    // Test that requesting the same ID twice fails
+    fn allocate_device_id_request_id_twice_fails() -> Result<(), Box<dyn Error>> {
+        let mut bus = setup_bus();
+        let max_id = NUM_DEVICE_IDS - 1;
+        bus.allocate_device_id(Some(max_id))?;
+        let result = bus.allocate_device_id(Some(max_id));
+        assert!(matches!(
+            result,
+            Err(PciRootError::AlreadyInUsePciDeviceSlot(x)) if x == usize::from(max_id),
+        ));
+        Ok(())
+    }
+
+    #[test]
+    // Test to request an invalid ID
+    fn allocate_device_id_request_invalid_id_fails() -> Result<(), Box<dyn Error>> {
+        let mut bus = setup_bus();
+        let max_id = NUM_DEVICE_IDS + 1;
+        let result = bus.allocate_device_id(Some(max_id));
+        assert!(matches!(
+            result,
+            Err(PciRootError::InvalidPciDeviceSlot(x)) if x == usize::from(max_id),
+        ));
+        Ok(())
+    }
+
+    #[test]
+    // Test to acquire an ID when all IDs were already acquired
+    fn allocate_device_id_none_left() {
+        // The first address is occupied by the root
+        let mut bus = setup_bus();
+        for expected_id in 1..NUM_DEVICE_IDS {
+            assert_eq!(expected_id, bus.allocate_device_id(None).unwrap());
+        }
+        let result = bus.allocate_device_id(None);
+        assert!(matches!(
+            result,
+            Err(PciRootError::NoPciDeviceSlotAvailable),
+        ));
+    }
 }

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -20,9 +20,13 @@ use crate::configuration::{
 };
 use crate::device::{BarReprogrammingParams, DeviceRelocation, Error as PciDeviceError, PciDevice};
 
+/// Denotes the PCI device ID of a bus' root bridge device.
+pub const PCI_ROOT_DEVICE_ID: u8 = 0;
+/// Denotes the maximum number of PCI devices allowed on a bus. 32 per PCI spec.
+pub const NUM_DEVICE_IDS: u8 = 32;
+
 const VENDOR_ID_INTEL: u16 = 0x8086;
 const DEVICE_ID_INTEL_VIRT_PCIE_HOST: u16 = 0x0d57;
-const NUM_DEVICE_IDS: usize = 32;
 
 /// Errors for device manager.
 #[derive(Error, Debug)]
@@ -113,18 +117,18 @@ impl PciDevice for PciRoot {
 pub struct PciBus {
     /// Devices attached to this bus.
     /// Device 0 is host bridge.
-    devices: HashMap<u32, Arc<Mutex<dyn PciDevice>>>,
+    devices: HashMap<u8, Arc<Mutex<dyn PciDevice>>>,
     device_reloc: Arc<dyn DeviceRelocation>,
-    device_ids: Vec<bool>,
+    device_ids: [bool; NUM_DEVICE_IDS as usize],
 }
 
 impl PciBus {
     pub fn new(pci_root: PciRoot, device_reloc: Arc<dyn DeviceRelocation>) -> Self {
-        let mut devices: HashMap<u32, Arc<Mutex<dyn PciDevice>>> = HashMap::new();
-        let mut device_ids: Vec<bool> = vec![false; NUM_DEVICE_IDS];
+        let mut devices: HashMap<u8, Arc<Mutex<dyn PciDevice>>> = HashMap::new();
+        let mut device_ids = [false; NUM_DEVICE_IDS as usize];
 
-        devices.insert(0, Arc::new(Mutex::new(pci_root)));
-        device_ids[0] = true;
+        devices.insert(PCI_ROOT_DEVICE_ID, Arc::new(Mutex::new(pci_root)));
+        device_ids[PCI_ROOT_DEVICE_ID as usize] = true;
 
         PciBus {
             devices,
@@ -158,7 +162,7 @@ impl PciBus {
         Ok(())
     }
 
-    pub fn add_device(&mut self, device_id: u32, device: Arc<Mutex<dyn PciDevice>>) -> Result<()> {
+    pub fn add_device(&mut self, device_id: u8, device: Arc<Mutex<dyn PciDevice>>) -> Result<()> {
         self.devices.insert(device_id, device);
         Ok(())
     }
@@ -180,7 +184,7 @@ impl PciBus {
     }
 
     pub fn get_device_id(&mut self, id: usize) -> Result<()> {
-        if id < NUM_DEVICE_IDS {
+        if id < NUM_DEVICE_IDS as usize {
             if self.device_ids[id] {
                 Err(PciRootError::AlreadyInUsePciDeviceSlot(id))
             } else {
@@ -193,7 +197,7 @@ impl PciBus {
     }
 
     pub fn put_device_id(&mut self, id: usize) -> Result<()> {
-        if id < NUM_DEVICE_IDS {
+        if id < NUM_DEVICE_IDS as usize {
             self.device_ids[id] = false;
             Ok(())
         } else {
@@ -240,7 +244,7 @@ impl PciConfigIo {
             .lock()
             .unwrap()
             .devices
-            .get(&(device as u32))
+            .get(&(device as u8))
             .map_or(0xffff_ffff, |d| {
                 d.lock().unwrap().read_config_register(register)
             })
@@ -265,7 +269,7 @@ impl PciConfigIo {
         }
 
         let pci_bus = self.pci_bus.as_ref().lock().unwrap();
-        if let Some(d) = pci_bus.devices.get(&(device as u32)) {
+        if let Some(d) = pci_bus.devices.get(&(device as u8)) {
             let mut device = d.lock().unwrap();
 
             // Update the register value
@@ -376,7 +380,7 @@ impl PciConfigMmio {
             .lock()
             .unwrap()
             .devices
-            .get(&(device as u32))
+            .get(&(device as u8))
             .map_or(0xffff_ffff, |d| {
                 d.lock().unwrap().read_config_register(register)
             })
@@ -395,7 +399,7 @@ impl PciConfigMmio {
         }
 
         let pci_bus = self.pci_bus.lock().unwrap();
-        if let Some(d) = pci_bus.devices.get(&(device as u32)) {
+        if let Some(d) = pci_bus.devices.get(&(device as u8)) {
             let mut device = d.lock().unwrap();
 
             // Update the register value

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -243,12 +243,19 @@ impl PciBus {
         }
     }
 
-    pub fn put_device_id(&mut self, id: usize) -> Result<()> {
-        if id < NUM_DEVICE_IDS as usize {
-            self.device_ids[id] = DeviceIdState::Free;
+    /// Frees a PCI device ID on the bus.
+    ///
+    /// - `id`: ID to free on the bus.
+    ///
+    /// ## Errors
+    /// * Returns [`PciRootError::InvalidPciDeviceSlot`] if the slot
+    ///   exceeds [`NUM_DEVICE_IDS`].
+    pub fn free_device_id(&mut self, id: u8) -> Result<()> {
+        if id < NUM_DEVICE_IDS {
+            self.device_ids[id as usize] = DeviceIdState::Free;
             Ok(())
         } else {
-            Err(PciRootError::InvalidPciDeviceSlot(id))
+            Err(PciRootError::InvalidPciDeviceSlot(id as usize))
         }
     }
 }

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -21,7 +21,9 @@ use std::str::FromStr;
 
 use serde::de::Visitor;
 
-pub use self::bus::{PciBus, PciConfigIo, PciConfigMmio, PciRoot, PciRootError};
+pub use self::bus::{
+    NUM_DEVICE_IDS, PCI_ROOT_DEVICE_ID, PciBus, PciConfigIo, PciConfigMmio, PciRoot, PciRootError,
+};
 pub use self::configuration::{
     PCI_CONFIGURATION_ID, PciBarConfiguration, PciBarPrefetchable, PciBarRegionType, PciCapability,
     PciCapabilityId, PciClassCode, PciConfiguration, PciExpressCapabilityId, PciHeaderType,

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -702,7 +702,7 @@ pub enum WaitForSshError {
     },
 }
 
-fn default_guest_auth() -> PasswordAuth {
+pub fn default_guest_auth() -> PasswordAuth {
     PasswordAuth {
         username: String::from("cloud"),
         password: String::from("cloud123"),

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1970,7 +1970,7 @@ pub fn remote_command_w_output(
     api_socket: &str,
     command: &str,
     arg: Option<&str>,
-) -> (bool, Vec<u8>) {
+) -> (bool, Vec<u8> /* stdout */, Vec<u8> /* stderr */) {
     let mut cmd = Command::new(clh_command("ch-remote"));
     cmd.args([&format!("--api-socket={api_socket}"), command]);
 
@@ -1980,7 +1980,7 @@ pub fn remote_command_w_output(
 
     let output = cmd.output().expect("Failed to launch ch-remote");
 
-    (output.status.success(), output.stdout)
+    (output.status.success(), output.stdout, output.stderr)
 }
 
 pub fn parse_iperf3_output(output: &[u8], sender: bool, bandwidth: bool) -> Result<f64, Error> {

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -984,6 +984,9 @@ components:
         pci_segment:
           type: integer
           format: int16
+        pci_device_id:
+          type: integer
+          format: uint8
         id:
           type: string
         serial:
@@ -1046,6 +1049,9 @@ components:
         pci_segment:
           type: integer
           format: int16
+        pci_device_id:
+          type: integer
+          format: uint8
         rate_limiter_config:
           $ref: "#/components/schemas/RateLimiterConfig"
         offload_tso:
@@ -1107,6 +1113,9 @@ components:
         pci_segment:
           type: integer
           format: int16
+        pci_device_id:
+          type: integer
+          format: uint8
         id:
           type: string
 
@@ -1127,6 +1136,9 @@ components:
         pci_segment:
           type: integer
           format: int16
+        pci_device_id:
+          type: integer
+          format: uint8
         virtio_id:
           type: uint32
 
@@ -1149,6 +1161,9 @@ components:
         pci_segment:
           type: integer
           format: int16
+        pci_device_id:
+          type: integer
+          format: uint8
         id:
           type: string
 
@@ -1196,6 +1211,9 @@ components:
         pci_segment:
           type: integer
           format: int16
+        pci_device_id:
+          type: integer
+          format: uint8
         id:
           type: string
         x_nv_gpudirect_clique:
@@ -1226,6 +1244,9 @@ components:
         pci_segment:
           type: integer
           format: int16
+        pci_device_id:
+          type: integer
+          format: uint8
         id:
           type: string
 
@@ -1249,6 +1270,9 @@ components:
         pci_segment:
           type: integer
           format: int16
+        pci_device_id:
+          type: integer
+          format: uint8
         id:
           type: string
 
@@ -1429,6 +1453,12 @@ components:
       properties:
         socket:
           type: string
+        pci_segment:
+          type: integer
+          format: int16
+        pci_device_id:
+          type: integer
+          format: uint8
 
     LandlockConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1195,8 +1195,8 @@ impl RateLimiterGroupConfig {
 }
 
 impl PciDeviceCommonConfig {
-    const OPTIONS: &[&str] = &["id", "pci_segment"];
-    const OPTIONS_IOMMU: &[&str] = &["id", "iommu", "pci_segment"];
+    const OPTIONS: &[&str] = &["id", "pci_segment", "pci_device_id"];
+    const OPTIONS_IOMMU: &[&str] = &["id", "iommu", "pci_segment", "pci_device_id"];
 
     pub fn parse(input: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -1217,11 +1217,15 @@ impl PciDeviceCommonConfig {
             .convert("pci_segment")
             .map_err(Error::ParsePciDeviceCommonConfig)?
             .unwrap_or_default();
+        let pci_device_id = parser
+            .convert::<u8>("pci_device_id")
+            .map_err(Error::ParsePciDeviceCommonConfig)?;
 
         Ok(Self {
             id,
             iommu,
             pci_segment,
+            pci_device_id,
         })
     }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -17,6 +17,7 @@ use log::{debug, warn};
 use option_parser::{
     ByteSized, IntegerList, OptionParser, OptionParserError, StringList, Toggle, Tuple,
 };
+use pci::NUM_DEVICE_IDS;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use virtio_bindings::virtio_blk::VIRTIO_BLK_ID_BYTES;
@@ -402,6 +403,13 @@ pub enum ValidationError {
     /// Invalid NUMA Configuration
     #[error("NUMA Configuration is invalid")]
     InvalidNumaConfig(String),
+    /// The supplied PCI ID was greater then the max. supported number
+    /// of devices per Bus
+    #[error("Given PCI device ID ({0}) is out of the supported range of 0..{NUM_DEVICE_IDS}")]
+    InvalidPciDeviceId(u8),
+    /// The supplied PCI ID is reserved
+    #[error("Given PCI device ID ({0}) is reserved")]
+    ReservedPciDeviceId(u8),
 }
 
 type ValidationResult<T> = std::result::Result<T, ValidationError>;
@@ -412,6 +420,21 @@ pub fn add_to_config<T>(items: &mut Option<Vec<T>>, item: T) {
     } else {
         *items = Some(vec![item]);
     }
+}
+
+/// Check that the PCI device supplied is neither out of range nor does
+/// it use any reserved device ID.
+fn validate_pci_device_id(device_id: u8) -> ValidationResult<()> {
+    if device_id >= pci::NUM_DEVICE_IDS {
+        // Check the given ID is not out of range
+        return Err(ValidationError::InvalidPciDeviceId(device_id));
+    } else if device_id == pci::PCI_ROOT_DEVICE_ID {
+        // Check the ID isn't any reserved one. Currently, only the device ID
+        // for the root device is reserved.
+        return Err(ValidationError::ReservedPciDeviceId(device_id));
+    }
+
+    Ok(())
 }
 
 pub type Result<T> = result::Result<T, Error>;
@@ -1241,6 +1264,10 @@ impl PciDeviceCommonConfig {
             {
                 return Err(ValidationError::OnIommuSegment(self.pci_segment));
             }
+        }
+
+        if let Some(device_id) = self.pci_device_id {
+            validate_pci_device_id(device_id)?;
         }
 
         Ok(())
@@ -5643,7 +5670,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         }]);
         still_valid_config.validate().unwrap();
 
-        let mut still_valid_config = valid_config;
+        let mut still_valid_config = valid_config.clone();
         // SAFETY: Safe as the file was just opened
         let fd1 = unsafe { libc::dup(File::open("/dev/null").unwrap().as_raw_fd()) };
         // SAFETY: Safe as the file was just opened
@@ -5653,6 +5680,45 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             still_valid_config.add_preserved_fds(vec![fd1, fd2]);
         }
         let _still_valid_config = still_valid_config.clone();
+
+        // Valid BDF test
+        let mut still_valid_config = valid_config.clone();
+        still_valid_config.disks = Some(vec![DiskConfig {
+            pci_common: PciDeviceCommonConfig {
+                pci_device_id: Some(8),
+                ..Default::default()
+            },
+            ..disk_fixture()
+        }]);
+        still_valid_config.validate().unwrap();
+        // Invalid BDF - Same ID as Root device
+        let mut invalid_config = valid_config.clone();
+        invalid_config.disks = Some(vec![DiskConfig {
+            pci_common: PciDeviceCommonConfig {
+                pci_device_id: Some(pci::PCI_ROOT_DEVICE_ID),
+                ..Default::default()
+            },
+            ..disk_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::ReservedPciDeviceId(
+                pci::PCI_ROOT_DEVICE_ID
+            ))
+        );
+        // Invalid BDF - Out of range
+        let mut invalid_config = valid_config.clone();
+        invalid_config.disks = Some(vec![DiskConfig {
+            pci_common: PciDeviceCommonConfig {
+                pci_device_id: Some(pci::NUM_DEVICE_IDS + 1),
+                ..Default::default()
+            },
+            ..disk_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::InvalidPciDeviceId(pci::NUM_DEVICE_IDS + 1))
+        );
     }
     #[test]
     fn test_landlock_parsing() -> Result<()> {

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1254,7 +1254,8 @@ impl DiskConfig {
          vhost_user=on|off,socket=<vhost_user_socket_path>,\
          bw_size=<bytes>,bw_one_time_burst=<bytes>,bw_refill_time=<ms>,\
          ops_size=<io_ops>,ops_one_time_burst=<io_ops>,ops_refill_time=<ms>,\
-         id=<device_id>,pci_segment=<segment_id>,rate_limit_group=<group_id>,\
+         id=<device_id>,pci_segment=<segment_id>,pci_device_id=<pci_slot>,\
+         rate_limit_group=<group_id>,\
          queue_affinity=<list_of_queue_indices_with_their_associated_cpuset>,\
          serial=<serial_number>,backing_files=on|off,sparse=on|off,\
          image_type=<raw,qcow2,vhd,vhdx>,lock_granularity=byte-range|full";
@@ -1496,7 +1497,8 @@ impl NetConfig {
     num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,id=<device_id>,\
     vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>,vhost_mode=client|server,\
     bw_size=<bytes>,bw_one_time_burst=<bytes>,bw_refill_time=<ms>,\
-    ops_size=<io_ops>,ops_one_time_burst=<io_ops>,ops_refill_time=<ms>,pci_segment=<segment_id>,\
+    ops_size=<io_ops>,ops_one_time_burst=<io_ops>,ops_refill_time=<ms>,\
+    pci_segment=<segment_id>,pci_device_id=<pci_slot>,\
     offload_tso=on|off,offload_ufo=on|off,offload_csum=on|off\"";
 
     pub fn parse(net: &str) -> Result<Self> {
@@ -1767,7 +1769,7 @@ impl GenericVhostUserConfig {
     \"virtio_id=<ID number for virtio device type (FS, block, net, etc) or symbolic name>,\
     socket=<socket_path>,\
     queue_sizes=<list of queue sizes>,\
-    id=<device_id>,pci_segment=<segment_id>\"";
+    id=<device_id>,pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
 
     pub fn parse(vhost_user: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -1891,7 +1893,8 @@ impl GenericVhostUserConfig {
 impl FsConfig {
     pub const SYNTAX: &'static str = "virtio-fs parameters \
     \"tag=<tag_name>,socket=<socket_path>,num_queues=<number_of_queues>,\
-    queue_size=<size_of_each_queue>,id=<device_id>,pci_segment=<segment_id>\"";
+    queue_size=<size_of_each_queue>,id=<device_id>,\
+    pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
 
     pub fn parse(fs: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -2044,7 +2047,8 @@ impl FwCfgItem {
 impl PmemConfig {
     pub const SYNTAX: &'static str = "Persistent memory parameters \
     \"file=<backing_file_path>,size=<persistent_memory_size>,iommu=on|off,\
-    discard_writes=on|off,id=<device_id>,pci_segment=<segment_id>\"";
+    discard_writes=on|off,id=<device_id>,\
+    pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
 
     pub fn parse(pmem: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -2188,7 +2192,9 @@ impl DebugConsoleConfig {
 }
 
 impl DeviceConfig {
-    pub const SYNTAX: &'static str = "Direct device assignment parameters \"path=<device_path>,iommu=on|off,id=<device_id>,pci_segment=<segment_id>\"";
+    pub const SYNTAX: &'static str = "Direct device assignment parameters \
+    \"path=<device_path>,iommu=on|off,id=<device_id>,\
+    pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
 
     pub fn parse(device: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -2228,8 +2234,8 @@ impl DeviceConfig {
 }
 
 impl UserDeviceConfig {
-    pub const SYNTAX: &'static str =
-        "Userspace device socket=<socket_path>,id=<device_id>,pci_segment=<segment_id>\"";
+    pub const SYNTAX: &'static str = "Userspace device socket=<socket_path>,id=<device_id>,\
+        pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
 
     pub fn parse(user_device: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -2257,7 +2263,7 @@ impl UserDeviceConfig {
 impl VdpaConfig {
     pub const SYNTAX: &'static str = "vDPA device \
         \"path=<device_path>,num_queues=<number_of_queues>,iommu=on|off,\
-        id=<device_id>,pci_segment=<segment_id>\"";
+        id=<device_id>,pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
 
     pub fn parse(vdpa: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -2291,7 +2297,8 @@ impl VdpaConfig {
 
 impl VsockConfig {
     pub const SYNTAX: &'static str = "Virtio VSOCK parameters \
-        \"cid=<context_id>,socket=<socket_path>,iommu=on|off,id=<device_id>,pci_segment=<segment_id>\"";
+        \"cid=<context_id>,socket=<socket_path>,iommu=on|off,id=<device_id>,\
+        pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
 
     pub fn parse(vsock: &str) -> Result<Self> {
         let mut parser = OptionParser::new();

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -500,9 +500,9 @@ pub enum DeviceManagerError {
     #[error("Could not reserve the PCI device ID")]
     ReservePciDeviceId(#[source] pci::PciRootError),
 
-    /// Could not give the PCI device ID back.
-    #[error("Could not give the PCI device ID back")]
-    PutPciDeviceId(#[source] pci::PciRootError),
+    /// Could not free the PCI device ID.
+    #[error("Could not free PCI device ID")]
+    FreePciDeviceId(#[source] pci::PciRootError),
 
     /// No disk path was specified when one was expected
     #[error("No disk path was specified when one was expected")]
@@ -4877,8 +4877,8 @@ impl DeviceManager {
             .pci_bus
             .lock()
             .unwrap()
-            .put_device_id(device_id as usize)
-            .map_err(DeviceManagerError::PutPciDeviceId)?;
+            .free_device_id(device_id)
+            .map_err(DeviceManagerError::FreePciDeviceId)?;
 
         let (pci_device_handle, id) = {
             // Remove the device from the device tree along with its children.

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1693,6 +1693,10 @@ impl DeviceManager {
 
         let mut iommu_attached_devices = Vec::new();
         {
+            // Reserve all explicit PCI device IDs before any device creation
+            // so that they won't be picked for dynamic allocation.
+            self.reserve_explicit_device_ids()?;
+
             for handle in self.virtio_devices.clone() {
                 let mapping: Option<Arc<IommuMapping>> = if handle.pci_common.iommu {
                     self.iommu_mapping.clone()
@@ -4528,6 +4532,37 @@ impl DeviceManager {
         self.device_tree.lock().unwrap().insert(id, node);
 
         Ok(Some(ivshmem_device))
+    }
+
+    fn reserve_explicit_device_ids(&self) -> DeviceManagerResult<()> {
+        for handle in &self.virtio_devices {
+            if let Some(device_id) = handle.pci_common.pci_device_id {
+                self.pci_segments[handle.pci_common.pci_segment as usize]
+                    .reserve_device_id(device_id)?;
+            }
+        }
+
+        let config = self.config.lock().unwrap();
+
+        if let Some(devices) = &config.devices {
+            for device_cfg in devices {
+                if let Some(device_id) = device_cfg.pci_common.pci_device_id {
+                    self.pci_segments[device_cfg.pci_common.pci_segment as usize]
+                        .reserve_device_id(device_id)?;
+                }
+            }
+        }
+
+        if let Some(user_devices) = &config.user_devices {
+            for device_cfg in user_devices {
+                if let Some(device_id) = device_cfg.pci_common.pci_device_id {
+                    self.pci_segments[device_cfg.pci_common.pci_segment as usize]
+                        .reserve_device_id(device_id)?;
+                }
+            }
+        }
+
+        Ok(())
     }
 
     fn pci_resources(

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -498,7 +498,7 @@ pub enum DeviceManagerError {
 
     /// Could not reserve the PCI device ID.
     #[error("Could not reserve the PCI device ID")]
-    GetPciDeviceId(#[source] pci::PciRootError),
+    ReservePciDeviceId(#[source] pci::PciRootError),
 
     /// Could not give the PCI device ID back.
     #[error("Could not give the PCI device ID back")]
@@ -4546,8 +4546,8 @@ impl DeviceManager {
                 .pci_bus
                 .lock()
                 .unwrap()
-                .get_device_id(pci_device_bdf.device() as usize)
-                .map_err(DeviceManagerError::GetPciDeviceId)?;
+                .allocate_device_id(Some(pci_device_bdf.device()))
+                .map_err(DeviceManagerError::AllocatePciDeviceId)?;
 
             (pci_segment_id, pci_device_bdf, resources)
         } else {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1707,6 +1707,7 @@ impl DeviceManager {
                     &id,
                     handle.pci_common.pci_segment,
                     handle.dma_handler,
+                    handle.pci_common.pci_device_id,
                 )?;
 
                 // Track device BDF for Generic Initiator support
@@ -1738,7 +1739,8 @@ impl DeviceManager {
             }
 
             if let Some(iommu_device) = iommu_device {
-                let dev_id = self.add_virtio_pci_device(iommu_device, &None, &iommu_id, 0, None)?;
+                let dev_id =
+                    self.add_virtio_pci_device(iommu_device, &None, &iommu_id, 0, None, None)?;
                 self.iommu_attached_devices = Some((dev_id, iommu_attached_devices));
             }
         }
@@ -3652,7 +3654,7 @@ impl DeviceManager {
         let pci_segment_id = 0x0_u16;
 
         let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&id, pci_segment_id)?;
+            self.pci_resources(&id, pci_segment_id, None)?;
 
         info!("Creating pvmemcontrol device: id = {id}");
         let (pvmemcontrol_pci_device, pvmemcontrol_bus_device) =
@@ -3918,8 +3920,11 @@ impl DeviceManager {
             id
         };
 
-        let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&vfio_name, device_cfg.pci_common.pci_segment)?;
+        let (pci_segment_id, pci_device_bdf, resources) = self.pci_resources(
+            &vfio_name,
+            device_cfg.pci_common.pci_segment,
+            device_cfg.pci_common.pci_device_id,
+        )?;
 
         let mut needs_dma_mapping = false;
 
@@ -4180,8 +4185,11 @@ impl DeviceManager {
             id
         };
 
-        let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&vfio_user_name, device_cfg.pci_common.pci_segment)?;
+        let (pci_segment_id, pci_device_bdf, resources) = self.pci_resources(
+            &vfio_user_name,
+            device_cfg.pci_common.pci_segment,
+            device_cfg.pci_common.pci_device_id,
+        )?;
 
         let legacy_interrupt_group =
             if let Some(legacy_interrupt_manager) = &self.legacy_interrupt_manager {
@@ -4297,6 +4305,7 @@ impl DeviceManager {
         virtio_device_id: &str,
         pci_segment_id: u16,
         dma_handler: Option<Arc<dyn ExternalDmaMapping>>,
+        pci_device_id: Option<u8>,
     ) -> DeviceManagerResult<PciBdf> {
         let id = format!("{VIRTIO_PCI_DEVICE_NAME_PREFIX}-{virtio_device_id}");
 
@@ -4305,7 +4314,7 @@ impl DeviceManager {
         node.children = vec![virtio_device_id.to_string()];
 
         let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&id, pci_segment_id)?;
+            self.pci_resources(&id, pci_segment_id, pci_device_id)?;
 
         // Update the existing virtio node by setting the parent.
         if let Some(node) = self.device_tree.lock().unwrap().get_mut(virtio_device_id) {
@@ -4442,7 +4451,7 @@ impl DeviceManager {
         info!("Creating pvpanic device {id}");
 
         let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&id, pci_segment_id)?;
+            self.pci_resources(&id, pci_segment_id, None)?;
 
         let snapshot = snapshot_from_id(self.snapshot.as_ref(), id.as_str());
 
@@ -4480,7 +4489,7 @@ impl DeviceManager {
         info!("Creating ivshmem device {id}");
 
         let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&id, pci_segment_id)?;
+            self.pci_resources(&id, pci_segment_id, None)?;
         let snapshot = snapshot_from_id(self.snapshot.as_ref(), id.as_str());
 
         let ivshmem_ops = Arc::new(Mutex::new(IvshmemHandler {
@@ -4525,6 +4534,7 @@ impl DeviceManager {
         &self,
         id: &str,
         pci_segment_id: u16,
+        pci_device_id: Option<u8>,
     ) -> DeviceManagerResult<(u16, PciBdf, Option<Vec<Resource>>)> {
         // Look for the id in the device tree. If it can be found, that means
         // the device is being restored, otherwise it's created from scratch.
@@ -4552,7 +4562,7 @@ impl DeviceManager {
             (pci_segment_id, pci_device_bdf, resources)
         } else {
             let pci_device_bdf =
-                self.pci_segments[pci_segment_id as usize].allocate_device_id(None)?;
+                self.pci_segments[pci_segment_id as usize].allocate_device_id(pci_device_id)?;
 
             (pci_segment_id, pci_device_bdf, None)
         })
@@ -5060,6 +5070,7 @@ impl DeviceManager {
             &id,
             handle.pci_common.pci_segment,
             handle.dma_handler,
+            handle.pci_common.pci_device_id,
         )?;
 
         // Update the PCIU bitmap

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -494,7 +494,7 @@ pub enum DeviceManagerError {
 
     /// Failed to find an available PCI device ID.
     #[error("Failed to find an available PCI device ID")]
-    NextPciDeviceId(#[source] pci::PciRootError),
+    AllocatePciDeviceId(#[source] pci::PciRootError),
 
     /// Could not reserve the PCI device ID.
     #[error("Could not reserve the PCI device ID")]
@@ -4551,7 +4551,8 @@ impl DeviceManager {
 
             (pci_segment_id, pci_device_bdf, resources)
         } else {
-            let pci_device_bdf = self.pci_segments[pci_segment_id as usize].next_device_bdf()?;
+            let pci_device_bdf =
+                self.pci_segments[pci_segment_id as usize].allocate_device_id(None)?;
 
             (pci_segment_id, pci_device_bdf, None)
         })

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4121,7 +4121,7 @@ impl DeviceManager {
             .unwrap();
 
         pci_bus
-            .add_device(bdf.device() as u32, pci_device)
+            .add_device(bdf.device(), pci_device)
             .map_err(DeviceManagerError::AddPciDevice)?;
 
         self.bus_devices.push(Arc::clone(&bus_device));

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -105,7 +105,7 @@ impl PciSegment {
         };
 
         info!(
-            "Adding PCI segment: id={}, PCI MMIO config address: 0x{:x}, mem32 area [0x{:x}-0x{:x}, mem64 area [0x{:x}-0x{:x}",
+            "Adding PCI segment: id={}, PCI MMIO config address: 0x{:x}, mem32 area [0x{:x}-0x{:x}], mem64 area [0x{:x}-0x{:x}]",
             segment.id,
             segment.mmio_config_address,
             segment.start_of_mem32_area,

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -209,6 +209,65 @@ impl PciSegment {
 
         Ok(())
     }
+
+    #[cfg(test)]
+    /// Creates a PciSegment without the need for an [`AddressManager`]
+    /// for testing purpose.
+    ///
+    /// An [`AddressManager`] would otherwise be required to create
+    /// [`PciBus`] instances. Instead, we use any struct that implements
+    /// [`DeviceRelocation`] to instantiate a [`PciBus`].
+    pub(crate) fn new_without_address_manager(
+        id: u16,
+        numa_node: u32,
+        mem32_allocator: Arc<Mutex<AddressAllocator>>,
+        mem64_allocator: Arc<Mutex<AddressAllocator>>,
+        pci_irq_slots: &[u8; 32],
+        device_reloc: &Arc<dyn DeviceRelocation>,
+    ) -> DeviceManagerResult<Self> {
+        let pci_root = PciRoot::new(None);
+        let pci_bus = Arc::new(Mutex::new(PciBus::new(pci_root, device_reloc.clone())));
+
+        let pci_config_mmio = Arc::new(Mutex::new(PciConfigMmio::new(Arc::clone(&pci_bus))));
+        let mmio_config_address =
+            layout::PCI_MMCONFIG_START.0 + layout::PCI_MMIO_CONFIG_SIZE_PER_SEGMENT * id as u64;
+
+        let start_of_mem32_area = mem32_allocator.lock().unwrap().base().0;
+        let end_of_mem32_area = mem32_allocator.lock().unwrap().end().0;
+
+        let start_of_mem64_area = mem64_allocator.lock().unwrap().base().0;
+        let end_of_mem64_area = mem64_allocator.lock().unwrap().end().0;
+
+        let segment = PciSegment {
+            id,
+            pci_bus,
+            pci_config_mmio,
+            mmio_config_address,
+            proximity_domain: numa_node,
+            pci_devices_up: 0,
+            pci_devices_down: 0,
+            #[cfg(target_arch = "x86_64")]
+            pci_config_io: None,
+            mem32_allocator,
+            mem64_allocator,
+            start_of_mem32_area,
+            end_of_mem32_area,
+            start_of_mem64_area,
+            end_of_mem64_area,
+            pci_irq_slots: *pci_irq_slots,
+        };
+
+        info!(
+            "Adding PCI segment: id={}, PCI MMIO config address: 0x{:x}, mem32 area [0x{:x}-0x{:x}], mem64 area [0x{:x}-0x{:x}]",
+            segment.id,
+            segment.mmio_config_address,
+            segment.start_of_mem32_area,
+            segment.end_of_mem32_area,
+            segment.start_of_mem64_area,
+            segment.end_of_mem64_area
+        );
+        Ok(segment)
+    }
 }
 
 struct PciDevSlot {
@@ -479,5 +538,103 @@ impl Aml for PciSegment {
             pci_dsdt_inner_data,
         )
         .to_aml_bytes(sink);
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::result::Result;
+
+    use vm_memory::GuestAddress;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct MockDeviceRelocation;
+    impl DeviceRelocation for MockDeviceRelocation {
+        fn move_bar(
+            &self,
+            _old_base: u64,
+            _new_base: u64,
+            _len: u64,
+            _pci_dev: &mut dyn pci::PciDevice,
+            _region_type: pci::PciBarRegionType,
+        ) -> Result<(), std::io::Error> {
+            Ok(())
+        }
+    }
+
+    fn setup() -> PciSegment {
+        let guest_addr = 0_u64;
+        let guest_size = 0x1000_usize;
+        let allocator_1 = Arc::new(Mutex::new(
+            AddressAllocator::new(GuestAddress(guest_addr), guest_size as u64).unwrap(),
+        ));
+        let allocator_2 = Arc::new(Mutex::new(
+            AddressAllocator::new(GuestAddress(guest_addr), guest_size as u64).unwrap(),
+        ));
+        let mock_device_reloc: Arc<dyn DeviceRelocation> = Arc::new(MockDeviceRelocation {});
+        let arr = [0_u8; 32];
+
+        PciSegment::new_without_address_manager(
+            0,
+            0,
+            allocator_1,
+            allocator_2,
+            &arr,
+            &mock_device_reloc,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    // Test the default device ID for a segment with an empty bus (except for the root device).
+    fn allocate_device_id_default() {
+        // The first address is occupied by the root
+        let segment = setup();
+        let bdf = segment.allocate_device_id(None).unwrap();
+        assert_eq!(bdf.segment(), segment.id);
+        assert_eq!(bdf.bus(), 0);
+        assert_eq!(bdf.device(), 1);
+        assert_eq!(bdf.function(), 0);
+    }
+
+    #[test]
+    // Test to acquire a specific device ID
+    fn allocate_device_id_fixed_device_id() {
+        // The first address is occupied by the root
+        let expect_device_id = 0x10_u8;
+        let segment = setup();
+        let bdf = segment.allocate_device_id(Some(expect_device_id)).unwrap();
+        assert_eq!(bdf.segment(), segment.id);
+        assert_eq!(bdf.bus(), 0);
+        assert_eq!(bdf.device(), expect_device_id);
+        assert_eq!(bdf.function(), 0);
+    }
+
+    #[test]
+    // Test to acquire a device ID that is invalid, one that is already taken
+    // and one being greater than the number of allowed devices per bus.
+    fn allocate_device_id_invalid_device_id() {
+        // The first address is occupied by the root
+        let already_taken_device_id = 0x0_u8;
+        let overflow_device_id = 0xff_u8;
+        let segment = setup();
+        let bdf_res = segment.allocate_device_id(Some(already_taken_device_id));
+        assert!(matches!(
+            bdf_res,
+            Err(DeviceManagerError::GetPciDeviceId(e)) if matches!(
+                e,
+                pci::PciRootError::AlreadyInUsePciDeviceSlot(0x0)
+            )
+        ));
+        let bdf_res = segment.allocate_device_id(Some(overflow_device_id));
+        assert!(matches!(
+            bdf_res,
+            Err(DeviceManagerError::AllocatePciDeviceId(e)) if matches!(
+                e,
+                pci::PciRootError::InvalidPciDeviceSlot(0xff)
+            )
+        ));
     }
 }

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -164,6 +164,17 @@ impl PciSegment {
         )
     }
 
+    /// Reserves a device ID on this PCI segment, marking it as in-use
+    /// so that automatic allocation will not use it.
+    pub(crate) fn reserve_device_id(&self, device_id: u8) -> DeviceManagerResult<()> {
+        self.pci_bus
+            .lock()
+            .unwrap()
+            .reserve_device_id(device_id)
+            .map_err(DeviceManagerError::ReservePciDeviceId)?;
+        Ok(())
+    }
+
     /// Allocates a device's ID on this PCI segment.
     ///
     /// - `device_id`: Device ID to request for allocation
@@ -613,17 +624,17 @@ mod unit_tests {
     }
 
     #[test]
-    // Test to acquire a device ID that is invalid, one that is already taken
-    // and one being greater than the number of allowed devices per bus.
+    // Test that reserving an already taken device ID fails and that
+    // allocating an out-of-range device ID fails.
     fn allocate_device_id_invalid_device_id() {
         // The first address is occupied by the root
         let already_taken_device_id = 0x0_u8;
         let overflow_device_id = 0xff_u8;
         let segment = setup();
-        let bdf_res = segment.allocate_device_id(Some(already_taken_device_id));
+        let bdf_res = segment.reserve_device_id(already_taken_device_id);
         assert!(matches!(
             bdf_res,
-            Err(DeviceManagerError::GetPciDeviceId(e)) if matches!(
+            Err(DeviceManagerError::ReservePciDeviceId(e)) if matches!(
                 e,
                 pci::PciRootError::AlreadyInUsePciDeviceSlot(0x0)
             )

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -164,15 +164,22 @@ impl PciSegment {
         )
     }
 
-    pub(crate) fn next_device_bdf(&self) -> DeviceManagerResult<PciBdf> {
+    /// Allocates a device's ID on this PCI segment.
+    ///
+    /// - `device_id`: Device ID to request for allocation
+    ///
+    /// ## Errors
+    /// * [`DeviceManagerError::AllocatePciDeviceId`] if device ID
+    ///   allocation on the bus fails.
+    pub(crate) fn allocate_device_id(&self, device_id: Option<u8>) -> DeviceManagerResult<PciBdf> {
         Ok(PciBdf::new(
             self.id,
             0,
             self.pci_bus
                 .lock()
                 .unwrap()
-                .next_device_id()
-                .map_err(DeviceManagerError::NextPciDeviceId)? as u8,
+                .allocate_device_id(device_id)
+                .map_err(DeviceManagerError::AllocatePciDeviceId)?,
             0,
         ))
     }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -281,6 +281,8 @@ pub struct PciDeviceCommonConfig {
     pub iommu: bool,
     #[serde(default)]
     pub pci_segment: u16,
+    #[serde(default)]
+    pub pci_device_id: Option<u8>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]


### PR DESCRIPTION
Based on the work in #7631 but adjusted to correctly handle clashes between
device types (not just within virtio devices). Building on the refactoring from
#7962

- **pci: Refactor bus.rs to better fit a PCI bus's semantics**
- **vmm: Allow for device ID allocation on a segment**
- **vmm: Fix segment log message formatting**
- **vmm: Add tests for `allocate_device_id` in `PciSegment`**
- **pci: Add support for reserving but not allocating slots**
- **vmm: Use the PciBus::allocate_device_id on restore path**
- **vmm: config: Add pci_device_id to PciDeviceCommonConfig**
- **vmm: openapi: Add pci_device_id to the required device entries**
- **vmm: config: Add pci_device_id to SYNTAX for supported devices**
- **docs: Update the relevant documentation**
- **vmm: Validate PCI device ID**
- **vmm: Propagate PCI device ID from the config**
- **vmm: device_manager: Reserve explicitly used PCI device IDs**
- **tests: Return stderr when executing commands**
- **tests: Add an integration test to verify PCI device allocations**
- **tests: Add an integration test to check duplicate PCI device IDs**
- **tests: Add an integration test for PCI device ID allocation errors**
