### PR TITLE
main: log VM startup time at process start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,7 @@ dependencies = [
  "epoll",
  "event_monitor",
  "hypervisor",
+ "jiff",
  "libc",
  "log",
  "net_util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ env_logger = "0.11.10"
 epoll = "4.4.0"
 flume = "0.12.0"
 itertools = "0.14.0"
+jiff = { version = "0.2.23", default-features = false, features = ["std"] }
 libc = "0.2.183"
 log = "0.4.29"
 signal-hook = "0.4.3"

--- a/cloud-hypervisor/Cargo.toml
+++ b/cloud-hypervisor/Cargo.toml
@@ -19,6 +19,7 @@ env_logger = { workspace = true }
 epoll = { workspace = true }
 event_monitor = { path = "../event_monitor" }
 hypervisor = { path = "../hypervisor" }
+jiff = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true, features = ["std"] }
 option_parser = { path = "../option_parser" }

--- a/cloud-hypervisor/build.rs
+++ b/cloud-hypervisor/build.rs
@@ -19,8 +19,8 @@ fn main() {
     }
 
     // Append CH_EXTRA_VERSION to version if it is set.
+    println!("cargo:rerun-if-env-changed=CH_EXTRA_VERSION");
     if let Ok(extra_version) = env::var("CH_EXTRA_VERSION") {
-        println!("cargo:rerun-if-env-changed=CH_EXTRA_VERSION");
         version.push_str(&format!("-{extra_version}"));
     }
 

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -606,8 +606,8 @@ fn start_vmm(cmd_arguments: &ArgMatches) -> Result<Option<String>, Error> {
             error!("Error blocking signals: {e}");
         }
     }
-
-    info!("{} starting", env!("BUILD_VERSION"));
+    info!("Starting Cloud Hypervisor {}", env!("BUILD_VERSION"));
+    info!("Startup timestamp: {}", jiff::Timestamp::now());
 
     let hypervisor = hypervisor::new().map_err(Error::CreateHypervisor)?;
 
@@ -896,7 +896,6 @@ fn main() {
         if cmd_arguments.get_count("v") != 0 {
             println!("Enabled features: {:?}", vmm::feature_list());
         }
-
         return;
     }
 


### PR DESCRIPTION
main: log VM startup time at process start

# About and Motivation

In production, the version string tells operators which binary is
running, but it does not tell them when a specific cloud-hypervisor
process actually started.

That distinction matters when correlating logs across libvirt,
OpenStack, journald, and other host-side components for a single VM
launch. A dedicated startup timestamp gives every process instance an
explicit wall-clock anchor in the log stream.

This adds jiff as a runtime dependency for timestamp formatting. It is
already transitively part of the build and does not increase the binary
size therefore.
