### PR TITLE
vm-migration: improve downtime observability

### DIFF
--- a/vm-migration/src/context.rs
+++ b/vm-migration/src/context.rs
@@ -54,13 +54,13 @@ pub struct MemoryMigrationContext {
     /// This includes the transmission, all logging, and update of any metrics.
     ///
     /// This is only `None` for iteration 0.
-    iteration_duration: Option<Duration>,
+    pub iteration_duration: Option<Duration>,
     /// Begin of the current transfer.
     transfer_begin: Instant,
     /// Duration of the current transfer.
     ///
     /// This is only `None` for iteration 0.
-    transfer_duration: Option<Duration>,
+    pub transfer_duration: Option<Duration>,
 }
 
 impl MemoryMigrationContext {
@@ -178,6 +178,22 @@ impl MemoryMigrationContext {
             bytes as f64 / duration.as_secs_f64()
         }
     }
+
+    /// Calculates the overhead of an iteration.
+    ///
+    /// This is the additional time next to the transfer time and includes
+    /// fetching and parsing the dirty log, for example.
+    fn iteration_overhead(&self) -> Duration {
+        self.iteration_duration
+            .and_then(|iter| {
+                self.transfer_duration.map(|tr| {
+                    // This is guaranteed by update_metrics_after_transfer()
+                    assert!(iter >= tr);
+                    iter - tr
+                })
+            })
+            .unwrap_or_default()
+    }
 }
 
 impl Default for MemoryMigrationContext {
@@ -207,16 +223,7 @@ impl Display for MemoryMigrationContext {
 
         // Transfer duration and iteration overhead
         let transfer_s = self.transfer_duration.map_or(0.0, |d| d.as_secs_f64());
-        let iteration_overhead_ms = self
-            .iteration_duration
-            .and_then(|iter| {
-                self.transfer_duration.map(|tr| {
-                    // This is guaranteed by update_metrics_after_transfer()
-                    assert!(iter >= tr);
-                    (iter - tr).as_millis()
-                })
-            })
-            .unwrap_or(0);
+        let iteration_overhead_ms = self.iteration_overhead().as_millis();
 
         let est_downtime_ms = self.estimated_downtime.map_or(0, |d| d.as_millis());
 

--- a/vm-migration/src/context.rs
+++ b/vm-migration/src/context.rs
@@ -3,13 +3,212 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-//! Module for [`MemoryMigrationContext`].
+//! Module for context and metrics of migrations.
+//!
+//! Main exports:
+//! - [`OngoingMigrationContext`]
+//! - [`CompletedMigrationContext`]
+//! - [`MemoryMigrationContext`]
 
 use std::fmt;
-use std::fmt::Display;
+use std::fmt::{Display, Formatter};
 use std::time::{Duration, Instant};
 
+use thiserror::Error;
+
 use crate::protocol::MemoryRangeTable;
+
+/// Metrics of the VM downtime during a migration.
+///
+/// By downtime, we mean the time between the VM pause() and the corresponding
+/// resume() on the destination. This downtime covers the time when the vCPUs
+/// didn't execute a single instruction. The network downtime might be longer
+/// and is not covered by this type.
+///
+/// This metric is only relevant for the migration of running VMs.
+#[derive(Debug, PartialEq)]
+pub struct DowntimeContext {
+    /// The effective downtime Cloud Hypervisor observed (from the migration sender).
+    ///
+    /// This is roughly the sum of all the other durations.
+    pub effective_downtime: Duration,
+    /// The time of the final memory iteration.
+    pub final_memory_iteration_dur: Duration,
+    /// The time needed to aggregate the final VM state (i.e., snapshotting it).
+    pub state_dur: Duration,
+    /// The time needed to send the final VM state including deserializing it on
+    /// the destination
+    pub send_state_dur: Duration,
+    /// The time of the completion request. This includes resuming the VM (if it
+    /// was running before the migration).
+    pub complete_dur: Duration,
+}
+
+impl Display for DowntimeContext {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            // Caution: This format is specifically crafted for the VMM log
+            "{}ms (final_iter:{}ms state:{}ms send_state:{}ms complete:{}ms)",
+            self.effective_downtime.as_millis(),
+            self.final_memory_iteration_dur.as_millis(),
+            self.state_dur.as_millis(),
+            self.send_state_dur.as_millis(),
+            self.complete_dur.as_millis()
+        )
+    }
+}
+
+/// The internal metrics of a completed migration.
+///
+/// The properties of this type help to investigate timings of the migration,
+/// with specific focus on the VM downtime.
+///
+/// This type is static once it was created and should not change.
+#[derive(Debug, PartialEq)]
+pub struct CompletedMigrationContext {
+    /// Total duration of the migration.
+    pub migration_dur: Duration,
+    pub downtime_ctx: DowntimeContext,
+    /// The finalized context of the memory migration.
+    pub memory_ctx: MemoryMigrationContext,
+}
+
+impl CompletedMigrationContext {
+    fn new(
+        migration_dur: Duration,
+        effective_downtime: Duration,
+        state_dur: Duration,
+        send_state_dur: Duration,
+        complete_dur: Duration,
+        memory_ctx: MemoryMigrationContext,
+    ) -> Self {
+        Self {
+            migration_dur,
+            downtime_ctx: DowntimeContext {
+                effective_downtime,
+                final_memory_iteration_dur: memory_ctx.iteration_duration.unwrap_or_default(),
+                state_dur,
+                send_state_dur,
+                complete_dur,
+            },
+            memory_ctx,
+        }
+    }
+}
+
+/// Error returned when the migration context is advanced in an invalid order.
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum MigrationContextError {
+    /// The memory migration context was not finalized before transition.
+    #[error("memory migration context should be finalized before pausing the VM")]
+    MemoryContextNotFinalized,
+    /// The transition to `VmPaused` was attempted from an invalid state.
+    #[error("memory migration should only advance from the Begin state")]
+    InvalidVmPausedTransition,
+    /// Finalization was attempted before memory migration completed.
+    #[error("migration should only finalize after memory migration completed")]
+    InvalidFinalizeTransition,
+}
+
+/// Holds context and metrics about the current ongoing migration.
+///
+/// This is a state-machine to properly reflect the intermediate states and
+/// their properties. This machine does not have a `Completed` variant in favor
+/// of [`CompletedMigrationContext`], which is easier to work with.
+#[derive(Debug, PartialEq)]
+pub enum OngoingMigrationContext {
+    /// Migration started.
+    Begin {
+        /// Begin of the migration.
+        migration_begin: Instant,
+    },
+    /// VM memory fully transferred to the destination and the VM is paused.
+    VmPaused {
+        /// Begin of the migration.
+        migration_begin: Instant,
+        /// Downtime begin of the migration.
+        downtime_begin: Instant,
+        /// The finalized context of the memory migration.
+        finalized_memory_ctx: MemoryMigrationContext,
+    },
+}
+
+impl OngoingMigrationContext {
+    /// Creates a new context.
+    pub fn new() -> Self {
+        Self::Begin {
+            migration_begin: Instant::now(),
+        }
+    }
+
+    /// Marks the memory migration as completed and records when downtime
+    /// started. The VM is now in paused state.
+    pub fn set_vm_paused(
+        &mut self,
+        downtime_begin: Instant,
+        finalized_memory_ctx: MemoryMigrationContext,
+    ) -> Result<(), MigrationContextError> {
+        if finalized_memory_ctx.migration_duration.is_none() {
+            return Err(MigrationContextError::MemoryContextNotFinalized);
+        }
+        let migration_begin = match self {
+            Self::Begin { migration_begin } => *migration_begin,
+            _ => return Err(MigrationContextError::InvalidVmPausedTransition),
+        };
+        *self = Self::VmPaused {
+            migration_begin,
+            downtime_begin,
+            finalized_memory_ctx,
+        };
+        Ok(())
+    }
+
+    /// Finalizes the metrics and returns a [`CompletedMigrationContext`].
+    ///
+    /// This should be called right after the completed migration was
+    /// acknowledged by the receiver. From now on, the metrics are considered
+    /// finalized and should not be modified. They can be stored for further
+    /// analysis.
+    ///
+    /// # Arguments
+    /// - `state_dur`: The time needed to aggregate the final VM state (i.e.,
+    ///   snapshotting it).
+    /// - `send_state_dur`:  The time needed to send the final VM state
+    ///   including deserializing it on the destination.
+    /// - `complete_dur`: The time of the completion request. This includes
+    ///   resuming the VM (if it was running before the migration).
+    pub fn finalize(
+        self,
+        state_dur: Duration,
+        send_state_dur: Duration,
+        complete_dur: Duration,
+    ) -> Result<CompletedMigrationContext, MigrationContextError> {
+        let (migration_begin, downtime_begin, finalized_memory_ctx) = match self {
+            Self::VmPaused {
+                migration_begin,
+                downtime_begin,
+                finalized_memory_ctx,
+            } => (migration_begin, downtime_begin, finalized_memory_ctx),
+            _ => return Err(MigrationContextError::InvalidFinalizeTransition),
+        };
+
+        Ok(CompletedMigrationContext::new(
+            migration_begin.elapsed(),
+            downtime_begin.elapsed(),
+            state_dur,
+            send_state_dur,
+            complete_dur,
+            finalized_memory_ctx,
+        ))
+    }
+}
+
+impl Default for OngoingMigrationContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Internal metrics for the precopy migration phase.
 ///
@@ -246,6 +445,75 @@ impl Display for MemoryMigrationContext {
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+
+    /// Tests for [`CompletedMigrationContext`] and [`OngoingMigrationContext`].
+    mod migration_ctx_tests {
+        use super::*;
+
+        #[test]
+        fn memory_migrated_and_vm_paused_records_transition() {
+            let mut ctx = OngoingMigrationContext::new();
+            let downtime_begin = Instant::now();
+
+            let mut memory_ctx = MemoryMigrationContext::new();
+            memory_ctx.finalize();
+
+            ctx.set_vm_paused(downtime_begin, memory_ctx)
+                .expect("migration context should transition to VmPaused after memory migration");
+
+            assert!(matches!(
+                ctx,
+                OngoingMigrationContext::VmPaused {
+                    downtime_begin: recorded_downtime_begin,
+                    ..
+                } if recorded_downtime_begin == downtime_begin
+            ));
+        }
+
+        #[test]
+        fn finalize_returns_completed_context() {
+            let mut ctx = OngoingMigrationContext::new();
+            let downtime_begin = Instant::now() - Duration::from_millis(10);
+
+            let mut memory_ctx = MemoryMigrationContext::new();
+            memory_ctx.finalize();
+
+            ctx.set_vm_paused(downtime_begin, memory_ctx)
+                .expect("migration context should transition to VmPaused after memory migration");
+
+            let completed = ctx
+                .finalize(
+                    Duration::from_millis(1),
+                    Duration::from_millis(2),
+                    Duration::from_millis(3),
+                )
+                .expect("migration context should finalize after memory migration completed");
+
+            assert_eq!(completed.downtime_ctx.state_dur, Duration::from_millis(1));
+            assert_eq!(
+                completed.downtime_ctx.send_state_dur,
+                Duration::from_millis(2)
+            );
+            assert_eq!(
+                completed.downtime_ctx.complete_dur,
+                Duration::from_millis(3)
+            );
+            assert!(completed.downtime_ctx.effective_downtime >= Duration::from_millis(10));
+            assert!(completed.migration_dur > Duration::ZERO);
+            assert!(completed.memory_ctx.migration_duration.is_some());
+        }
+
+        #[test]
+        fn finalize_errors_before_memory_migration_completed() {
+            let err = OngoingMigrationContext::new()
+                .finalize(Duration::ZERO, Duration::ZERO, Duration::ZERO)
+                .unwrap_err();
+
+            assert_eq!(err, MigrationContextError::InvalidFinalizeTransition);
+        }
+    }
+
+    /// Tests for [`MemoryMigrationContext`].
     mod memory_migration_ctx_tests {
         use std::time::{Duration, Instant};
 

--- a/vm-migration/src/context.rs
+++ b/vm-migration/src/context.rs
@@ -238,169 +238,172 @@ impl Display for MemoryMigrationContext {
 
 #[cfg(test)]
 mod unit_tests {
-    use std::time::{Duration, Instant};
-
     use super::*;
-    use crate::protocol::MemoryRange;
+    mod memory_migration_ctx_tests {
+        use std::time::{Duration, Instant};
 
-    fn make_table(bytes: u64) -> MemoryRangeTable {
-        let mut table = MemoryRangeTable::default();
-        if bytes > 0 {
-            table.push(MemoryRange {
-                gpa: 0,
-                length: bytes,
-            });
+        use super::*;
+        use crate::protocol::MemoryRange;
+
+        fn make_table(bytes: u64) -> MemoryRangeTable {
+            let mut table = MemoryRangeTable::default();
+            if bytes > 0 {
+                table.push(MemoryRange {
+                    gpa: 0,
+                    length: bytes,
+                });
+            }
+            table
         }
-        table
-    }
 
-    /// A controlled migration scenario with fixed timing offsets.
-    ///
-    /// ```text
-    /// migration_begin
-    ///   + 1.0s -> iteration_begin
-    ///   + 1.1s -> transfer_begin
-    ///   + 2.0s -> transfer ends   (transfer_duration = 0.9s)
-    ///   + 2.1s -> iteration ends  (iteration_duration = 1.1s, overhead = 0.2s)
-    /// ```
-    struct Scenario {
-        migration_begin: Instant,
-        iteration_begin: Instant,
-        transfer_begin: Instant,
-        transfer_duration: Duration,
-    }
+        /// A controlled migration scenario with fixed timing offsets.
+        ///
+        /// ```text
+        /// migration_begin
+        ///   + 1.0s -> iteration_begin
+        ///   + 1.1s -> transfer_begin
+        ///   + 2.0s -> transfer ends   (transfer_duration = 0.9s)
+        ///   + 2.1s -> iteration ends  (iteration_duration = 1.1s, overhead = 0.2s)
+        /// ```
+        struct Scenario {
+            migration_begin: Instant,
+            iteration_begin: Instant,
+            transfer_begin: Instant,
+            transfer_duration: Duration,
+        }
 
-    impl Scenario {
-        /// We use a fixed point in the past so all offsets are in the past too,
-        /// meaning elapsed() calls in the code under test will be >= our durations.
-        const FIXPOINT_PAST: Duration = Duration::from_secs(10);
+        impl Scenario {
+            /// We use a fixed point in the past so all offsets are in the past too,
+            /// meaning elapsed() calls in the code under test will be >= our durations.
+            const FIXPOINT_PAST: Duration = Duration::from_secs(10);
 
-        fn new() -> Self {
-            // Use a fixed point in the past so all offsets are in the past too,
-            // meaning elapsed() calls in the code under test will be >= our durations.
-            let migration_begin = Instant::now() - Self::FIXPOINT_PAST;
-            Self {
-                migration_begin,
-                iteration_begin: migration_begin + Duration::from_millis(1000),
-                transfer_begin: migration_begin + Duration::from_millis(1100),
-                transfer_duration: Duration::from_millis(900),
+            fn new() -> Self {
+                // Use a fixed point in the past so all offsets are in the past too,
+                // meaning elapsed() calls in the code under test will be >= our durations.
+                let migration_begin = Instant::now() - Self::FIXPOINT_PAST;
+                Self {
+                    migration_begin,
+                    iteration_begin: migration_begin + Duration::from_millis(1000),
+                    transfer_begin: migration_begin + Duration::from_millis(1100),
+                    transfer_duration: Duration::from_millis(900),
+                }
+            }
+
+            fn make_ctx(&self) -> MemoryMigrationContext {
+                let mut ctx = MemoryMigrationContext::new();
+                // Override migration_begin with our controlled value.
+                ctx.migration_begin = self.migration_begin;
+                ctx
             }
         }
 
-        fn make_ctx(&self) -> MemoryMigrationContext {
-            let mut ctx = MemoryMigrationContext::new();
-            // Override migration_begin with our controlled value.
-            ctx.migration_begin = self.migration_begin;
-            ctx
+        #[test]
+        fn before_transfer_updates_begin_and_bytes() {
+            let s = Scenario::new();
+            let mut ctx = s.make_ctx();
+
+            ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(4096));
+
+            assert_eq!(ctx.iteration_begin, s.iteration_begin);
+            assert_eq!(ctx.current_iteration_total_bytes, 4096);
         }
-    }
 
-    #[test]
-    fn before_transfer_updates_begin_and_bytes() {
-        let s = Scenario::new();
-        let mut ctx = s.make_ctx();
+        #[test]
+        fn before_transfer_estimated_downtime() {
+            let s = Scenario::new();
+            let mut ctx = s.make_ctx();
 
-        ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(4096));
+            // Empty table -> zero downtime regardless of bandwidth
+            ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(0));
+            assert_eq!(ctx.estimated_downtime, Some(Duration::ZERO));
 
-        assert_eq!(ctx.iteration_begin, s.iteration_begin);
-        assert_eq!(ctx.current_iteration_total_bytes, 4096);
-    }
+            // No bandwidth yet -> None
+            ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(1024));
+            assert_eq!(ctx.estimated_downtime, None);
 
-    #[test]
-    fn before_transfer_estimated_downtime() {
-        let s = Scenario::new();
-        let mut ctx = s.make_ctx();
+            // 1024 B/s, 1024 bytes -> 1s
+            ctx.bandwidth_bytes_per_second = 1024.0;
+            ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(1024));
+            assert_eq!(ctx.estimated_downtime, Some(Duration::from_secs(1)));
+        }
 
-        // Empty table -> zero downtime regardless of bandwidth
-        ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(0));
-        assert_eq!(ctx.estimated_downtime, Some(Duration::ZERO));
+        #[test]
+        fn after_transfer_updates_timing_and_bandwidth() {
+            let s = Scenario::new();
+            let mut ctx = s.make_ctx();
 
-        // No bandwidth yet -> None
-        ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(1024));
-        assert_eq!(ctx.estimated_downtime, None);
+            ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(1024));
+            ctx.update_metrics_after_transfer(s.transfer_begin, s.transfer_duration);
 
-        // 1024 B/s, 1024 bytes -> 1s
-        ctx.bandwidth_bytes_per_second = 1024.0;
-        ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(1024));
-        assert_eq!(ctx.estimated_downtime, Some(Duration::from_secs(1)));
-    }
+            assert_eq!(ctx.transfer_begin, s.transfer_begin);
+            assert_eq!(ctx.transfer_duration, Some(s.transfer_duration));
+            // 1024 bytes / 0.9s
+            assert_eq!(ctx.bandwidth_bytes_per_second, 1024.0 / 0.9);
+            // iteration_duration = time from iteration_begin until now (>= transfer_duration)
+            assert!(ctx.iteration_duration.unwrap() >= s.transfer_duration);
+            // Zero transfer_duration -> bandwidth is 0.0, no division by zero
+            ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(1024));
+            ctx.update_metrics_after_transfer(s.transfer_begin, Duration::ZERO);
+            assert_eq!(ctx.bandwidth_bytes_per_second, 0.0);
 
-    #[test]
-    fn after_transfer_updates_timing_and_bandwidth() {
-        let s = Scenario::new();
-        let mut ctx = s.make_ctx();
+            // Check finalize() sets migration duration
+            assert_eq!(ctx.migration_duration, None);
+            ctx.finalize();
+            assert!(matches!(ctx.migration_duration, Some(d) if d >= Scenario::FIXPOINT_PAST));
+        }
 
-        ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(1024));
-        ctx.update_metrics_after_transfer(s.transfer_begin, s.transfer_duration);
+        #[test]
+        fn two_iterations_accumulate_bytes_and_feed_downtime_estimate() {
+            let s = Scenario::new();
+            let mut ctx = s.make_ctx();
 
-        assert_eq!(ctx.transfer_begin, s.transfer_begin);
-        assert_eq!(ctx.transfer_duration, Some(s.transfer_duration));
-        // 1024 bytes / 0.9s
-        assert_eq!(ctx.bandwidth_bytes_per_second, 1024.0 / 0.9);
-        // iteration_duration = time from iteration_begin until now (>= transfer_duration)
-        assert!(ctx.iteration_duration.unwrap() >= s.transfer_duration);
-        // Zero transfer_duration -> bandwidth is 0.0, no division by zero
-        ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(1024));
-        ctx.update_metrics_after_transfer(s.transfer_begin, Duration::ZERO);
-        assert_eq!(ctx.bandwidth_bytes_per_second, 0.0);
+            // Iteration 0: no bandwidth yet -> downtime is None
+            ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(1024));
+            assert_eq!(ctx.estimated_downtime, None);
+            ctx.update_metrics_after_transfer(s.transfer_begin, s.transfer_duration);
+            assert_eq!(ctx.total_sent_bytes, 1024);
 
-        // Check finalize() sets migration duration
-        assert_eq!(ctx.migration_duration, None);
-        ctx.finalize();
-        assert!(matches!(ctx.migration_duration, Some(d) if d >= Scenario::FIXPOINT_PAST));
-    }
+            // Iteration 1: bandwidth now known -> downtime is Some
+            ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(2048));
+            assert!(ctx.estimated_downtime.is_some());
+            ctx.update_metrics_after_transfer(s.transfer_begin, s.transfer_duration);
+            assert_eq!(ctx.total_sent_bytes, 1024 + 2048);
 
-    #[test]
-    fn two_iterations_accumulate_bytes_and_feed_downtime_estimate() {
-        let s = Scenario::new();
-        let mut ctx = s.make_ctx();
+            // Check finalize() sets migration duration
+            assert_eq!(ctx.migration_duration, None);
+            ctx.finalize();
+            assert!(matches!(ctx.migration_duration, Some(d) if d >= Scenario::FIXPOINT_PAST));
+        }
 
-        // Iteration 0: no bandwidth yet -> downtime is None
-        ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(1024));
-        assert_eq!(ctx.estimated_downtime, None);
-        ctx.update_metrics_after_transfer(s.transfer_begin, s.transfer_duration);
-        assert_eq!(ctx.total_sent_bytes, 1024);
+        #[test]
+        /// The display format is specifically crafted to be very insightful in logs.
+        /// Therefore, we have a dedicated test for that format.
+        fn display_format() {
+            let s = Scenario::new();
+            let mut ctx = s.make_ctx();
 
-        // Iteration 1: bandwidth now known -> downtime is Some
-        ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(2048));
-        assert!(ctx.estimated_downtime.is_some());
-        ctx.update_metrics_after_transfer(s.transfer_begin, s.transfer_duration);
-        assert_eq!(ctx.total_sent_bytes, 1024 + 2048);
+            // Iteration 0: 1 MiB in 1s
+            ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(1024 * 1024));
+            ctx.update_metrics_after_transfer(s.transfer_begin, Duration::from_secs(1));
+            ctx.iteration += 1;
 
-        // Check finalize() sets migration duration
-        assert_eq!(ctx.migration_duration, None);
-        ctx.finalize();
-        assert!(matches!(ctx.migration_duration, Some(d) if d >= Scenario::FIXPOINT_PAST));
-    }
+            // Iteration 1: 512 KiB in 1s; fix migration_duration for deterministic elapsed/avg_bw
+            ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(512 * 1024));
+            ctx.update_metrics_after_transfer(s.transfer_begin, Duration::from_secs(1));
 
-    #[test]
-    /// The display format is specifically crafted to be very insightful in logs.
-    /// Therefore, we have a dedicated test for that format.
-    fn display_format() {
-        let s = Scenario::new();
-        let mut ctx = s.make_ctx();
+            ctx.migration_duration = Some(Duration::from_secs(2));
+            let out = ctx.to_string();
 
-        // Iteration 0: 1 MiB in 1s
-        ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(1024 * 1024));
-        ctx.update_metrics_after_transfer(s.transfer_begin, Duration::from_secs(1));
-        ctx.iteration += 1;
+            assert_eq!(
+                out,
+                "iter=1 curr=1MiB total=2MiB bw=0.50MiB/s transfer=1.00s overhead=8000ms est_downtime=500ms elapsed=2.00s avg_bw=0.15MiB/s"
+            );
 
-        // Iteration 1: 512 KiB in 1s; fix migration_duration for deterministic elapsed/avg_bw
-        ctx.update_metrics_before_transfer(s.iteration_begin, &make_table(512 * 1024));
-        ctx.update_metrics_after_transfer(s.transfer_begin, Duration::from_secs(1));
-
-        ctx.migration_duration = Some(Duration::from_secs(2));
-        let out = ctx.to_string();
-
-        assert_eq!(
-            out,
-            "iter=1 curr=1MiB total=2MiB bw=0.50MiB/s transfer=1.00s overhead=8000ms est_downtime=500ms elapsed=2.00s avg_bw=0.15MiB/s"
-        );
-
-        // Should change elapsed() time!
-        // Since this is at least 10s, we never face timing issues in CI!
-        ctx.finalize();
-        let out2 = ctx.to_string();
-        assert_ne!(out2, out, "elapsed time should have changed! is={out2}");
+            // Should change elapsed() time!
+            // Since this is at least 10s, we never face timing issues in CI!
+            ctx.finalize();
+            let out2 = ctx.to_string();
+            assert_ne!(out2, out, "elapsed time should have changed! is={out2}");
+        }
     }
 }

--- a/vm-migration/src/context.rs
+++ b/vm-migration/src/context.rs
@@ -286,6 +286,15 @@ impl MemoryMigrationContext {
         }
     }
 
+    /// Returns an empty finalized block.
+    ///
+    /// This can be used if no memory was transferred (e.g., local migration).
+    pub fn empty_finalized() -> Self {
+        let mut this = Self::new();
+        this.finalize();
+        this
+    }
+
     /// Updates the metrics right before the transfer over the wire.
     ///
     /// Supposed to be called once per precopy memory iteration.

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -4,7 +4,10 @@
 //
 
 use anyhow::anyhow;
-pub use context::MemoryMigrationContext;
+pub use context::{
+    CompletedMigrationContext, DowntimeContext, MemoryMigrationContext, MigrationContextError,
+    OngoingMigrationContext,
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -115,6 +115,7 @@ pub enum Command {
     Config,
     State,
     Memory,
+    /// Finalizes the migration and resumes the VM on the guest.
     Complete,
     Abandon,
     MemoryFd,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -653,7 +653,10 @@ enum ReceiveMigrationState {
     Configured(ReceiveMigrationConfiguredData),
 
     /// Memory is populated and we received the state. The VM is ready to go.
-    StateReceived,
+    StateReceived {
+        /// The timestamp where the VMM started to receive the final state.
+        state_receive_begin: Instant,
+    },
 
     /// The migration is successful.
     Completed,
@@ -938,18 +941,43 @@ impl Vmm {
                     Ok(Configured(config_data))
                 }
                 Command::State => {
+                    let state_receive_begin = Instant::now();
                     config_data.connections.cleanup()?;
-                    self.vm_receive_state(req, socket, config_data.memory_manager)?;
-                    Ok(StateReceived)
+                    let (recv_state_dur, restore_vm_dur) =
+                        self.vm_receive_state(req, socket, config_data.memory_manager)?;
+                    debug!(
+                        "Migration (incoming): recv_snapshot:{}ms restore:{}ms",
+                        recv_state_dur.as_millis(),
+                        restore_vm_dur.as_millis(),
+                    );
+                    Ok(StateReceived {
+                        state_receive_begin,
+                    })
                 }
                 _ => invalid_command(),
             },
-            StateReceived => match req.command() {
+            StateReceived {
+                state_receive_begin,
+            } => match req.command() {
                 Command::Complete => {
                     // The unwrap is safe, because the state machine makes sure we called
                     // vm_receive_state before, which creates the VM.
                     let vm = self.vm.as_mut().unwrap();
-                    vm.resume()?;
+                    let (_, resume_duration) = measure_ok(|| vm.resume())?;
+                    debug!(
+                        "Migration (incoming): resume:{}ms",
+                        resume_duration.as_millis()
+                    );
+                    // This logs the downtime without the final memory delta, so
+                    // it does not reflect the actual downtime. While we could
+                    // pass along the timestamp from when the VM was paused,
+                    // that would rely on both VM hosts having synchronized
+                    // clocks, which we cannot guarantee. For that reason, this
+                    // is logged as debug! rather than info!.
+                    debug!(
+                        "Migration (incoming): Receiving final state and resuming the VM took {}ms",
+                        state_receive_begin.elapsed().as_millis()
+                    );
                     Ok(Completed)
                 }
                 _ => invalid_command(),
@@ -1046,23 +1074,33 @@ impl Vmm {
         Ok(memory_manager)
     }
 
+    /// Receives the final VM state (devices, vCPUs) and restores the VM.
+    ///
+    /// Measures the time for each step.
     fn vm_receive_state<T>(
         &mut self,
         req: &Request,
         socket: &mut T,
         mm: Arc<Mutex<MemoryManager>>,
-    ) -> std::result::Result<(), MigratableError>
+    ) -> std::result::Result<
+        (
+            Duration, /* state receive + deserialize */
+            Duration, /* restoring */
+        ),
+        MigratableError,
+    >
     where
         T: Read,
     {
-        // Read in state data
-        let mut data: Vec<u8> = Vec::new();
-        data.resize_with(req.length() as usize, Default::default);
-        socket
-            .read_exact(&mut data)
-            .map_err(MigratableError::MigrateSocket)?;
-        let snapshot: Snapshot = serde_json::from_slice(&data).map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error deserialising snapshot: {e}"))
+        let (snapshot, receive_duration): (Snapshot, Duration) = measure_ok(|| {
+            let mut data: Vec<u8> = Vec::new();
+            data.resize_with(req.length() as usize, Default::default);
+            socket
+                .read_exact(&mut data)
+                .map_err(MigratableError::MigrateSocket)?;
+            serde_json::from_slice(&data).map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!("Error deserialising snapshot: {e}"))
+            })
         })?;
 
         let exit_evt = self.exit_evt.try_clone().map_err(|e| {
@@ -1079,38 +1117,44 @@ impl Vmm {
             MigratableError::MigrateReceive(anyhow!("Error cloning activate EventFd: {e}"))
         })?;
 
-        #[cfg(not(target_arch = "riscv64"))]
-        let timestamp = Instant::now();
-        let hypervisor_vm = mm.lock().unwrap().vm.clone();
-        let mut vm = Vm::new_from_memory_manager(
-            self.vm_config.clone().unwrap(),
-            mm,
-            hypervisor_vm,
-            exit_evt,
-            reset_evt,
-            #[cfg(feature = "guest_debug")]
-            debug_evt,
-            &self.seccomp_action,
-            self.hypervisor.clone(),
-            activate_evt,
+        let (vm, restore_duration) = measure_ok(|| {
             #[cfg(not(target_arch = "riscv64"))]
-            timestamp,
-            self.console_info.clone(),
-            self.console_resize_pipe.clone(),
-            Arc::clone(&self.original_termios_opt),
-            Some(&snapshot),
-        )
-        .map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error creating VM from snapshot: {e:?}"))
+            let timestamp = Instant::now();
+            let hypervisor_vm = mm.lock().unwrap().vm.clone();
+
+            let mut vm = Vm::new_from_memory_manager(
+                self.vm_config.clone().unwrap(),
+                mm,
+                hypervisor_vm,
+                exit_evt,
+                reset_evt,
+                #[cfg(feature = "guest_debug")]
+                debug_evt,
+                &self.seccomp_action,
+                self.hypervisor.clone(),
+                activate_evt,
+                #[cfg(not(target_arch = "riscv64"))]
+                timestamp,
+                self.console_info.clone(),
+                self.console_resize_pipe.clone(),
+                Arc::clone(&self.original_termios_opt),
+                Some(&snapshot),
+            )
+            .map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!("Error creating VM from snapshot: {e:?}"))
+            })?;
+
+            // Create VM
+            vm.restore().map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!("Failed restoring the Vm: {e}"))
+            })?;
+
+            Ok(vm)
         })?;
 
-        // Create VM
-        vm.restore().map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Failed restoring the Vm: {e}"))
-        })?;
         self.vm = Some(vm);
 
-        Ok(())
+        Ok((receive_duration, restore_duration))
     }
 
     /// Performs the initial memory transmission (iteration zero) plus a

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -40,8 +40,8 @@ use vm_memory::GuestMemoryAtomic;
 use vm_memory::bitmap::AtomicBitmap;
 use vm_migration::protocol::*;
 use vm_migration::{
-    MemoryMigrationContext, Migratable, MigratableError, Pausable, Snapshot, Snapshottable,
-    Transportable,
+    MemoryMigrationContext, Migratable, MigratableError, OngoingMigrationContext, Pausable,
+    Snapshot, Snapshottable, Transportable,
 };
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::unblock_signal;
@@ -1260,23 +1260,30 @@ impl Vmm {
     /// - initial memory - VM is running
     /// - multiple memory delta transmissions - VM is running
     /// - final memory iteration - VM is paused
+    ///
+    /// Stores the [finalized] [`MemoryMigrationContext`] in the provided
+    /// [`OngoingMigrationContext`].
+    ///
+    /// [finalized]: MemoryMigrationContext::finalize
     fn do_memory_migration(
         vm: &mut Vm,
         socket: &mut SocketStream,
         send_data_migration: &VmSendMigrationData,
         mem_send: &mut SendAdditionalConnections,
+        ctx: &mut OngoingMigrationContext,
     ) -> result::Result<(), MigratableError> {
-        let mut ctx = MemoryMigrationContext::new();
+        let mut mem_ctx = MemoryMigrationContext::new();
 
         vm.start_dirty_log()?;
         let remaining = Self::do_memory_iterations(
             vm,
             socket,
-            &mut ctx,
+            &mut mem_ctx,
             // We bind send_data_migration to the callback
             |ctx| Self::is_precopy_converged(ctx, send_data_migration),
             mem_send,
         )?;
+        let downtime_begin = Instant::now();
         vm.pause()?;
 
         // Send last batch of dirty pages: final iteration
@@ -1286,26 +1293,31 @@ impl Vmm {
             let mut final_table = vm.dirty_log()?;
             final_table.extend(remaining);
 
-            ctx.update_metrics_before_transfer(iteration_begin, &final_table);
+            mem_ctx.update_metrics_before_transfer(iteration_begin, &final_table);
             let transfer_begin = Instant::now();
             mem_send.send_memory(final_table, socket)?;
             let transfer_duration = transfer_begin.elapsed();
-            ctx.update_metrics_after_transfer(transfer_begin, transfer_duration);
-            ctx.iteration += 1;
+            mem_ctx.update_metrics_after_transfer(transfer_begin, transfer_duration);
+            mem_ctx.iteration += 1;
         }
-        ctx.finalize();
-
-        info!("Precopy complete: {ctx}");
+        mem_ctx.finalize();
+        info!("Precopy complete: {mem_ctx}");
+        ctx.set_vm_paused(downtime_begin, mem_ctx)
+            .expect("migration context should transition to VmPaused after memory migration");
 
         Ok(())
     }
 
+    /// Performs a migration including all its phases.
     fn send_migration(
         vm: &mut Vm,
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         hypervisor: &dyn hypervisor::Hypervisor,
         send_data_migration: &VmSendMigrationData,
     ) -> result::Result<(), MigratableError> {
+        // State machine that is updated with more context as we progress.
+        let mut ctx = OngoingMigrationContext::new();
+
         // Set up the socket connection
         let mut socket =
             migration_transport::send_migration_socket(&send_data_migration.destination_url)?;
@@ -1373,7 +1385,14 @@ impl Vmm {
 
         if send_data_migration.local {
             // Now pause VM
+            let downtime_begin = Instant::now();
             vm.pause()?;
+            ctx.set_vm_paused(
+                downtime_begin,
+                // No memory was transferred
+                MemoryMigrationContext::empty_finalized(),
+            )
+            .expect("migration context should transition to VmPaused for local migration");
         } else {
             let mut mem_send = migration_transport::SendAdditionalConnections::new(
                 &send_data_migration.destination_url,
@@ -1381,14 +1400,20 @@ impl Vmm {
                 &vm.guest_memory(),
             )?;
 
-            Self::do_memory_migration(vm, &mut socket, send_data_migration, &mut mem_send)
-                .inspect_err(|_| {
-                    // Calling cleanup multiple times is fine, thus here we just make sure
-                    // that it is called.
-                    if let Err(e) = mem_send.cleanup() {
-                        warn!("Error cleaning up migration connections: {e}");
-                    }
-                })?;
+            Self::do_memory_migration(
+                vm,
+                &mut socket,
+                send_data_migration,
+                &mut mem_send,
+                &mut ctx,
+            )
+            .inspect_err(|_| {
+                // Calling cleanup multiple times is fine, thus here we just make sure
+                // that it is called.
+                if let Err(e) = mem_send.cleanup() {
+                    warn!("Error cleaning up migration connections: {e}");
+                }
+            })?;
 
             mem_send.cleanup()?;
         }
@@ -1399,22 +1424,38 @@ impl Vmm {
             .map_err(|e| MigratableError::UnlockError(anyhow!("{e}")))?;
 
         // Capture snapshot and send it
-        let vm_snapshot = vm.snapshot()?;
-        migration_transport::send_state(&mut socket, &vm_snapshot)?;
-        // Complete the migration
-        // At this step, the receiving VMM will acquire disk locks again.
-        migration_transport::send_request_expect_ok(
-            &mut socket,
-            Request::complete(),
-            MigratableError::MigrateSend(anyhow!("Error completing migration")),
-        )?;
+        let (vm_snapshot, snapshot_duration) = measure_ok(|| vm.snapshot())?;
+        let (_, send_snapshot_duration) =
+            measure_ok(|| migration_transport::send_state(&mut socket, &vm_snapshot))?;
+
+        // Complete the migration.
+        // When this returns, we know the VM was resumed (if it was running
+        // before the migration) and that the receiving VMM acquired disk
+        // locks again.
+        let (_, complete_duration) = measure_ok(|| {
+            migration_transport::send_request_expect_ok(
+                &mut socket,
+                Request::complete(),
+                MigratableError::MigrateSend(anyhow!("Error completing migration")),
+            )
+        })?;
+
+        let ctx = ctx
+            .finalize(snapshot_duration, send_snapshot_duration, complete_duration)
+            .expect("migration context should finalize after memory migration completed");
+
+        info!(
+            "Migration completed after {:.1}s with a downtime of {}ms (goal was {}ms)",
+            ctx.migration_dur.as_secs_f32(),
+            ctx.downtime_ctx.effective_downtime.as_millis(),
+            send_data_migration.downtime().as_millis()
+        );
+        debug!("Downtime breakdown: {}", ctx.downtime_ctx);
 
         // Stop logging dirty pages
         if !send_data_migration.local {
             vm.stop_dirty_log()?;
         }
-
-        info!("Migration complete");
 
         // Let every Migratable object know about the migration being complete
         vm.complete_migration()

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -563,6 +563,17 @@ pub fn start_vmm_thread(
     })
 }
 
+/// Measures the time of the callback, in case it returns `Ok`.
+fn measure_ok<T, E, F>(f: F) -> result::Result<(T, Duration), E>
+where
+    F: FnOnce() -> result::Result<T, E>,
+{
+    let begin = Instant::now();
+    let value = f()?;
+    let duration = begin.elapsed();
+    Ok((value, duration))
+}
+
 #[derive(Clone, Deserialize, Serialize)]
 struct VmMigrationConfig {
     vm_config: Arc<Mutex<VmConfig>>,


### PR DESCRIPTION
This PR touches a few areas described in #7111:

- it further prepares live migration statistics (queryable via a dedicated API endpoint)
  - here, we just gather more data, that we eventually might export
- **log the actual downtime of the VM** (on the source side)
- log the expensive tasks during the downtime (break down downtime in its components)
  - this helps in the analysis of the downtime in further refactorings and developments

Please review this **commit-by-commit**.

### New Log Messages

I performed a local TCP migration of a small VM with a workload.

**New log messages on sender**:

```
cloud-hypervisor:   7.703402s: <vmm> INFO:vmm/src/lib.rs:1494 -- Migration completed after 2.2s with a downtime of 298ms (goal was 300ms)
cloud-hypervisor:   7.703453s: <vmm> DEBUG:vmm/src/lib.rs:1500 -- Downtime breakdown: 298ms (final_iter:269ms state:7ms send_state:19ms complete:1ms)
```

**New log messages on destination**:

```
cloud-hypervisor:   7.283424s: <vmm> DEBUG:vmm/src/lib.rs:948 -- Migration (incoming): recv_snapshot:3ms restore:10ms
cloud-hypervisor:   7.284824s: <vmm> DEBUG:vmm/src/lib.rs:967 -- Migration (incoming): resume:1ms
cloud-hypervisor:   7.284842s: <vmm> DEBUG:vmm/src/lib.rs:977 -- Migration (incoming): Receiving final state and resuming the VM took 15ms
```

### Learnings

For very small downtimes, we might have to optimize the snapshot path. Future work.