### PR TITLE
Add VFIO device passthrough support with vfio cdev and iommufd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "iommufd-bindings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7de3a04f6fd55f171a6682852f7aa360bb848a85e0c610513349e006b3c139"
+
+[[package]]
+name = "iommufd-ioctls"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eabd3414d9c4e716c9a198fbfac484625f088c075605372daf037edfe336e18"
+dependencies = [
+ "iommufd-bindings",
+ "thiserror",
+ "vmm-sys-util",
+]
+
+[[package]]
 name = "ipnetwork"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,6 +2308,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b1d98dff7f0d219278e406323e7eda4d426447bd203c7828189baf0d8c07b7"
 dependencies = [
  "byteorder",
+ "iommufd-bindings",
+ "iommufd-ioctls",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
@@ -2521,6 +2540,7 @@ dependencies = [
  "hypervisor",
  "igvm",
  "igvm_defs",
+ "iommufd-ioctls",
  "landlock",
  "libc",
  "linux-loader",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ resolver = "3"
 [workspace.dependencies]
 # rust-vmm crates
 acpi_tables = "0.2.0"
+iommufd-ioctls = "0.1.0"
 kvm-bindings = "0.14.0"
 kvm-ioctls = "0.24.0"
 linux-loader = "0.13.2"

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -33,8 +33,8 @@ use vmm::vm_config::FwCfgConfig;
 use vmm::vm_config::IvshmemConfig;
 use vmm::vm_config::{
     BalloonConfig, DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, LandlockConfig,
-    NetConfig, NumaConfig, PciSegmentConfig, PmemConfig, RateLimiterGroupConfig, TpmConfig,
-    UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
+    NetConfig, NumaConfig, PciSegmentConfig, PlatformConfig, PmemConfig, RateLimiterGroupConfig,
+    TpmConfig, UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
 };
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::block_signal;
@@ -388,7 +388,7 @@ fn get_cli_options_sorted(
         Arg::new("platform")
             .long("platform")
             .help(
-                "num_pci_segments=<num_pci_segments>,iommu_segments=<list_of_segments>,iommu_address_width=<bits>,serial_number=<dmi_device_serial_number>,uuid=<dmi_device_uuid>,oem_strings=<list_of_strings>"
+                PlatformConfig::syntax()
             )
             .num_args(1)
             .group("vm-config"),

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -8240,7 +8240,15 @@ mod vfio {
     use crate::*;
     const NVIDIA_VFIO_DEVICE: &str = "/sys/bus/pci/devices/0002:00:01.0";
 
-    fn test_nvidia_card_memory_hotplug(hotplug_method: &str) {
+    fn platform_cfg(iommufd: bool) -> String {
+        if iommufd {
+            "iommufd=on,vfio_p2p_dma=off".to_string()
+        } else {
+            "iommufd=off".to_string()
+        }
+    }
+
+    fn test_nvidia_card_memory_hotplug(hotplug_method: &str, iommufd: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
@@ -8252,6 +8260,7 @@ mod vfio {
                 format!("size=4G,hotplug_size=4G,hotplug_method={hotplug_method}").as_str(),
             ])
             .args(["--kernel", fw_path(FwType::RustHypervisorFirmware).as_str()])
+            .args(["--platform", &platform_cfg(iommufd)])
             .args(["--device", format!("path={NVIDIA_VFIO_DEVICE}").as_str()])
             .args(["--api-socket", &api_socket])
             .default_disks()
@@ -8285,16 +8294,25 @@ mod vfio {
 
     #[test]
     fn test_nvidia_card_memory_hotplug_acpi() {
-        test_nvidia_card_memory_hotplug("acpi");
+        test_nvidia_card_memory_hotplug("acpi", false);
     }
 
     #[test]
     fn test_nvidia_card_memory_hotplug_virtio_mem() {
-        test_nvidia_card_memory_hotplug("virtio-mem");
+        test_nvidia_card_memory_hotplug("virtio-mem", false);
     }
 
     #[test]
-    fn test_nvidia_card_pci_hotplug() {
+    fn test_iommufd_nvidia_card_memory_hotplug_acpi() {
+        test_nvidia_card_memory_hotplug("acpi", true);
+    }
+
+    #[test]
+    fn test_iommufd_nvidia_card_memory_hotplug_virtio_mem() {
+        test_nvidia_card_memory_hotplug("virtio-mem", true);
+    }
+
+    fn test_nvidia_card_pci_hotplug_common(iommufd: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
@@ -8303,6 +8321,7 @@ mod vfio {
             .args(["--cpus", "boot=4"])
             .args(["--memory", "size=4G"])
             .args(["--kernel", fw_path(FwType::RustHypervisorFirmware).as_str()])
+            .args(["--platform", &platform_cfg(iommufd)])
             .args(["--api-socket", &api_socket])
             .default_disks()
             .default_net()
@@ -8338,7 +8357,16 @@ mod vfio {
     }
 
     #[test]
-    fn test_nvidia_card_reboot() {
+    fn test_nvidia_card_pci_hotplug() {
+        test_nvidia_card_pci_hotplug_common(false);
+    }
+
+    #[test]
+    fn test_iommufd_nvidia_card_pci_hotplug() {
+        test_nvidia_card_pci_hotplug_common(true);
+    }
+
+    fn test_nvidia_card_reboot_common(iommufd: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
@@ -8346,6 +8374,7 @@ mod vfio {
         let mut child = GuestCommand::new(&guest)
             .args(["--cpus", "boot=4"])
             .args(["--memory", "size=4G"])
+            .args(["--platform", &platform_cfg(iommufd)])
             .args(["--kernel", fw_path(FwType::RustHypervisorFirmware).as_str()])
             .args([
                 "--device",
@@ -8377,20 +8406,31 @@ mod vfio {
     }
 
     #[test]
-    fn test_nvidia_card_iommu_address_width() {
+    fn test_nvidia_card_reboot() {
+        test_nvidia_card_reboot_common(false);
+    }
+
+    #[test]
+    fn test_iommufd_nvidia_card_reboot() {
+        test_nvidia_card_reboot_common(true);
+    }
+
+    fn test_nvidia_card_iommu_address_width_common(iommufd: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let api_socket = temp_api_path(&guest.tmp_dir);
+
+        let platform = format!(
+            "num_pci_segments=2,iommu_segments=1,iommu_address_width=42,{}",
+            platform_cfg(iommufd)
+        );
 
         let mut child = GuestCommand::new(&guest)
             .args(["--cpus", "boot=4"])
             .args(["--memory", "size=4G"])
             .args(["--kernel", fw_path(FwType::RustHypervisorFirmware).as_str()])
             .args(["--device", format!("path={NVIDIA_VFIO_DEVICE}").as_str()])
-            .args([
-                "--platform",
-                "num_pci_segments=2,iommu_segments=1,iommu_address_width=42",
-            ])
+            .args(["--platform", &platform])
             .args(["--api-socket", &api_socket])
             .default_disks()
             .default_net()
@@ -8416,7 +8456,16 @@ mod vfio {
     }
 
     #[test]
-    fn test_nvidia_guest_numa_generic_initiator() {
+    fn test_nvidia_card_iommu_address_width() {
+        test_nvidia_card_iommu_address_width_common(false);
+    }
+
+    #[test]
+    fn test_iommufd_nvidia_card_iommu_address_width() {
+        test_nvidia_card_iommu_address_width_common(true);
+    }
+
+    fn test_nvidia_guest_numa_generic_initiator_common(iommufd: bool) {
         // Skip test if VFIO device is not available or not ready
         if !std::path::Path::new(NVIDIA_VFIO_DEVICE).exists() {
             println!("SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} not found");
@@ -8453,6 +8502,7 @@ mod vfio {
                 "guest_numa_id=1,cpus=[2-3],distances=[0@20,2@30],memory_zones=mem1",
                 "guest_numa_id=2,device_id=vfio0,distances=[0@25,1@30]",
             ])
+            .args(["--platform", &platform_cfg(iommufd)])
             .args([
                 "--device",
                 &format!("id=vfio0,path={NVIDIA_VFIO_DEVICE},iommu=on"),
@@ -8524,6 +8574,16 @@ mod vfio {
         let output = child.wait_with_output().unwrap();
 
         handle_child_output(r, &output);
+    }
+
+    #[test]
+    fn test_nvidia_guest_numa_generic_initiator() {
+        test_nvidia_guest_numa_generic_initiator_common(false);
+    }
+
+    #[test]
+    fn test_iommufd_nvidia_guest_numa_generic_initiator() {
+        test_nvidia_guest_numa_generic_initiator_common(true);
     }
 }
 

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -1471,6 +1471,9 @@ pub struct VfioPciDevice {
     vfio_ops: Arc<dyn VfioOps>,
     common: VfioCommon,
     iommu_attached: bool,
+    // Whether to map VFIO device MMIO BARs into the host IOMMU address space.
+    // Required for peer-to-peer DMA between VFIO devices.
+    p2p_dma: bool,
     memory_slot_allocator: MemorySlotAllocator,
     bdf: PciBdf,
     device_path: PathBuf,
@@ -1487,6 +1490,7 @@ impl VfioPciDevice {
         msi_interrupt_manager: Arc<dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>>,
         legacy_interrupt_group: Option<Arc<dyn InterruptSourceGroup>>,
         iommu_attached: bool,
+        p2p_dma: bool,
         bdf: PciBdf,
         memory_slot_allocator: MemorySlotAllocator,
         snapshot: Option<&Snapshot>,
@@ -1515,6 +1519,7 @@ impl VfioPciDevice {
             vfio_ops,
             common,
             iommu_attached,
+            p2p_dma,
             memory_slot_allocator,
             bdf,
             device_path,
@@ -1719,7 +1724,9 @@ impl VfioPciDevice {
                     }
                     .map_err(VfioPciError::CreateUserMemoryRegion)?;
 
-                    if !self.iommu_attached {
+                    // Map the MMIO BAR into the host IOMMU address space via VfioOps
+                    // Only needed if p2p_dma is enabled.
+                    if !self.iommu_attached && self.p2p_dma {
                         // vfio_dma_map should be unsafe but isn't.
                         #[allow(unused_unsafe)]
                         // SAFETY: MmapRegion invariants guarantee that
@@ -1749,7 +1756,9 @@ impl VfioPciDevice {
                 let len = user_memory_region.mapping.len();
                 let host_addr = user_memory_region.mapping.addr();
                 // Unmap MMIO region from the host IOMMU address space via VfioOps
+                // Only needed if p2p_dma is enabled.
                 if !self.iommu_attached
+                    && self.p2p_dma
                     && let Err(e) = self
                         .vfio_ops
                         .vfio_dma_unmap(user_memory_region.start, len)
@@ -1907,7 +1916,9 @@ impl PciDevice for VfioPciDevice {
                     let len = user_memory_region.mapping.len();
                     let host_addr = user_memory_region.mapping.addr();
                     // Unmap the old MMIO region from the host IOMMU address space via VfioOps
+                    // Only needed if p2p_dma is enabled.
                     if !self.iommu_attached
+                        && self.p2p_dma
                         && let Err(e) = self
                             .vfio_ops
                             .vfio_dma_unmap(user_memory_region.start, len)
@@ -1961,7 +1972,8 @@ iova 0x{:x}, size 0x{:x}: {}, ",
                     .map_err(io::Error::other)?;
 
                     // Map the moved MMIO region into the host IOMMU address space via VfioOps
-                    if !self.iommu_attached {
+                    // Only needed if p2p_dma is enabled.
+                    if !self.iommu_attached && self.p2p_dma {
                         // vfio_dma_map is unsound and ought to be marked as unsafe
                         #[allow(unused_unsafe)]
                         // SAFETY: MmapRegion invariants guarantee that

--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -30,7 +30,14 @@ cargo build --features mshv --all --release --target "$BUILD_TARGET"
 export RUST_BACKTRACE=1
 export RUSTFLAGS="$RUSTFLAGS"
 
+# Run VFIO tests using legacy vfio interface with container/group
 time cargo nextest run --no-tests=pass --test-threads=1 "vfio::test_nvidia" -- ${test_binary_args[*]}
 RES=$?
+
+# Run VFIO tests using vfio cdev interface backed by iommufd
+if [ $RES -eq 0 ]; then
+    time cargo nextest run --no-tests=pass --test-threads=1 "vfio::test_iommufd" -- ${test_binary_args[*]}
+    RES=$?
+fi
 
 exit $RES

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -53,6 +53,10 @@ macro_rules! or {
 const VFIO_IOMMU_MAP_DMA: u64 = 0x3b71;
 const VFIO_IOMMU_UNMAP_DMA: u64 = 0x3b72;
 
+// See include/uapi/linux/iommufd.h in the kernel code.
+const IOMMU_IOAS_MAP: u64 = 0x3b85;
+const IOMMU_IOAS_UNMAP: u64 = 0x3b86;
+
 #[cfg(feature = "sev_snp")]
 fn mshv_sev_snp_ioctl_seccomp_rule() -> SeccompRule {
     and![
@@ -83,6 +87,8 @@ fn create_virtio_iommu_ioctl_seccomp_rule() -> Vec<SeccompRule> {
     or![
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_IOMMU_MAP_DMA).unwrap()],
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_IOMMU_UNMAP_DMA).unwrap()],
+        and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_MAP).unwrap()],
+        and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_UNMAP).unwrap()],
     ]
 }
 
@@ -90,6 +96,8 @@ fn create_virtio_mem_ioctl_seccomp_rule() -> Vec<SeccompRule> {
     or![
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_IOMMU_MAP_DMA).unwrap()],
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_IOMMU_UNMAP_DMA).unwrap()],
+        and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_MAP).unwrap()],
+        and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_UNMAP).unwrap()],
     ]
 }
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -17,8 +17,10 @@ ivshmem = ["devices/ivshmem"]
 kvm = [
   "arch/kvm",
   "hypervisor/kvm",
+  "iommufd-ioctls",
   "pci/kvm",
   "vfio-ioctls/kvm",
+  "vfio-ioctls/vfio_cdev",
   "virtio-devices/kvm",
   "vm-device/kvm",
 ]
@@ -55,6 +57,7 @@ hex = { version = "0.4.3", optional = true }
 hypervisor = { path = "../hypervisor" }
 igvm = { workspace = true, optional = true }
 igvm_defs = { workspace = true, optional = true }
+iommufd-ioctls = { workspace = true, optional = true }
 landlock = "0.4.4"
 libc = { workspace = true }
 linux-loader = { workspace = true, features = ["bzimage", "elf", "pe"] }

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -794,6 +794,9 @@ components:
         sev_snp:
           type: boolean
           default: false
+        iommufd:
+          type: boolean
+          default: false
 
     MemoryZoneConfig:
       required:

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -797,6 +797,9 @@ components:
         iommufd:
           type: boolean
           default: false
+        vfio_p2p_dma:
+          type: boolean
+          default: true
 
     MemoryZoneConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::result;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use block::ImageType;
 use clap::ArgMatches;
@@ -798,6 +799,30 @@ impl PciSegmentConfig {
 }
 
 impl PlatformConfig {
+    pub fn syntax() -> &'static str {
+        static SYNTAX: LazyLock<String> = LazyLock::new(|| {
+            let mut syntax = "Platform configuration parameters \
+            \"num_pci_segments=<num_pci_segments>,iommu_segments=<list_of_segments>,\
+            iommu_address_width=<bits>,serial_number=<dmi_device_serial_number>,\
+            uuid=<dmi_device_uuid>,oem_strings=<list_of_strings>"
+                .to_string();
+
+            if cfg!(feature = "tdx") {
+                syntax.push_str(",tdx=on|off");
+            }
+
+            if cfg!(feature = "sev_snp") {
+                syntax.push_str(",sev_snp=on|off");
+            }
+
+            syntax.push('"');
+
+            syntax
+        });
+
+        &SYNTAX
+    }
+
     pub fn parse(platform: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -804,7 +804,7 @@ impl PlatformConfig {
             let mut syntax = "Platform configuration parameters \
             \"num_pci_segments=<num_pci_segments>,iommu_segments=<list_of_segments>,\
             iommu_address_width=<bits>,serial_number=<dmi_device_serial_number>,\
-            uuid=<dmi_device_uuid>,oem_strings=<list_of_strings>"
+            uuid=<dmi_device_uuid>,oem_strings=<list_of_strings>,iommufd=on|off"
                 .to_string();
 
             if cfg!(feature = "tdx") {
@@ -831,7 +831,8 @@ impl PlatformConfig {
             .add("iommu_address_width")
             .add("serial_number")
             .add("uuid")
-            .add("oem_strings");
+            .add("oem_strings")
+            .add("iommufd");
         #[cfg(feature = "tdx")]
         parser.add("tdx");
         #[cfg(feature = "sev_snp")]
@@ -858,6 +859,11 @@ impl PlatformConfig {
             .convert::<StringList>("oem_strings")
             .map_err(Error::ParsePlatform)?
             .map(|v| v.0);
+        let iommufd = parser
+            .convert::<Toggle>("iommufd")
+            .map_err(Error::ParsePlatform)?
+            .unwrap_or(Toggle(false))
+            .0;
         #[cfg(feature = "tdx")]
         let tdx = parser
             .convert::<Toggle>("tdx")
@@ -877,6 +883,7 @@ impl PlatformConfig {
             serial_number,
             uuid,
             oem_strings,
+            iommufd,
             #[cfg(feature = "tdx")]
             tdx,
             #[cfg(feature = "sev_snp")]
@@ -4824,6 +4831,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             serial_number: None,
             uuid: None,
             oem_strings: None,
+            iommufd: false,
             #[cfg(feature = "tdx")]
             tdx: false,
             #[cfg(feature = "sev_snp")]

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -315,6 +315,9 @@ pub enum ValidationError {
     /// On a IOMMU segment but not behind IOMMU
     #[error("Device is on an IOMMU PCI segment ({0}) but not placed behind IOMMU")]
     OnIommuSegment(u16),
+    /// GPUDirect clique requires P2P DMA
+    #[error("Device with x_nv_gpudirect_clique requires vfio_p2p_dma=on")]
+    GpuDirectCliqueRequiresP2pDma,
     // On a IOMMU segment but IOMMU not supported
     #[error(
         "Device is on an IOMMU PCI segment ({0}) but does not support being placed behind IOMMU"
@@ -804,7 +807,8 @@ impl PlatformConfig {
             let mut syntax = "Platform configuration parameters \
             \"num_pci_segments=<num_pci_segments>,iommu_segments=<list_of_segments>,\
             iommu_address_width=<bits>,serial_number=<dmi_device_serial_number>,\
-            uuid=<dmi_device_uuid>,oem_strings=<list_of_strings>,iommufd=on|off"
+            uuid=<dmi_device_uuid>,oem_strings=<list_of_strings>,iommufd=on|off,\
+            vfio_p2p_dma=on|off"
                 .to_string();
 
             if cfg!(feature = "tdx") {
@@ -832,7 +836,8 @@ impl PlatformConfig {
             .add("serial_number")
             .add("uuid")
             .add("oem_strings")
-            .add("iommufd");
+            .add("iommufd")
+            .add("vfio_p2p_dma");
         #[cfg(feature = "tdx")]
         parser.add("tdx");
         #[cfg(feature = "sev_snp")]
@@ -864,6 +869,11 @@ impl PlatformConfig {
             .map_err(Error::ParsePlatform)?
             .unwrap_or(Toggle(false))
             .0;
+        let vfio_p2p_dma = parser
+            .convert::<Toggle>("vfio_p2p_dma")
+            .map_err(Error::ParsePlatform)?
+            .unwrap_or(Toggle(true))
+            .0;
         #[cfg(feature = "tdx")]
         let tdx = parser
             .convert::<Toggle>("tdx")
@@ -884,6 +894,7 @@ impl PlatformConfig {
             uuid,
             oem_strings,
             iommufd,
+            vfio_p2p_dma,
             #[cfg(feature = "tdx")]
             tdx,
             #[cfg(feature = "sev_snp")]
@@ -2274,6 +2285,13 @@ impl DeviceConfig {
                 && !self.iommu
             {
                 return Err(ValidationError::OnIommuSegment(self.pci_segment));
+            }
+        }
+
+        if self.x_nv_gpudirect_clique.is_some() {
+            let vfio_p2p_dma = vm_config.platform.as_ref().is_none_or(|p| p.vfio_p2p_dma);
+            if !vfio_p2p_dma {
+                return Err(ValidationError::GpuDirectCliqueRequiresP2pDma);
             }
         }
 
@@ -4832,6 +4850,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             uuid: None,
             oem_strings: None,
             iommufd: false,
+            vfio_p2p_dma: default_platformconfig_vfio_p2p_dma(),
             #[cfg(feature = "tdx")]
             tdx: false,
             #[cfg(feature = "sev_snp")]
@@ -5571,6 +5590,41 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             });
             config_with_invalid_host_data.validate().unwrap_err();
         }
+
+        // x_nv_gpudirect_clique with vfio_p2p_dma=off should fail
+        let mut invalid_config = valid_config.clone();
+        invalid_config.platform = Some(PlatformConfig {
+            vfio_p2p_dma: false,
+            ..platform_fixture()
+        });
+        invalid_config.devices = Some(vec![DeviceConfig {
+            x_nv_gpudirect_clique: Some(0),
+            ..device_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::GpuDirectCliqueRequiresP2pDma)
+        );
+
+        // x_nv_gpudirect_clique with vfio_p2p_dma=on should pass
+        let mut still_valid_config = valid_config.clone();
+        still_valid_config.platform = Some(PlatformConfig {
+            vfio_p2p_dma: true,
+            ..platform_fixture()
+        });
+        still_valid_config.devices = Some(vec![DeviceConfig {
+            x_nv_gpudirect_clique: Some(0),
+            ..device_fixture()
+        }]);
+        still_valid_config.validate().unwrap();
+
+        // x_nv_gpudirect_clique with no platform config (default p2p_dma=on) should pass
+        let mut still_valid_config = valid_config.clone();
+        still_valid_config.devices = Some(vec![DeviceConfig {
+            x_nv_gpudirect_clique: Some(0),
+            ..device_fixture()
+        }]);
+        still_valid_config.validate().unwrap();
 
         let mut still_valid_config = valid_config;
         // SAFETY: Safe as the file was just opened

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3963,6 +3963,14 @@ impl DeviceManager {
 
         let memory_manager = self.memory_manager.clone();
 
+        let vfio_p2p_dma = self
+            .config
+            .lock()
+            .unwrap()
+            .platform
+            .as_ref()
+            .is_none_or(|p| p.vfio_p2p_dma);
+
         let vfio_pci_device = VfioPciDevice::new(
             vfio_name.clone(),
             self.address_manager.vm.clone(),
@@ -3971,6 +3979,7 @@ impl DeviceManager {
             self.msi_interrupt_manager.clone(),
             legacy_interrupt_group,
             device_cfg.iommu,
+            vfio_p2p_dma,
             pci_device_bdf,
             memory_manager.lock().unwrap().memory_slot_allocator(),
             vm_migration::snapshot_from_id(self.snapshot.as_ref(), vfio_name.as_str()),

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -76,6 +76,8 @@ use event_monitor::event;
 use hypervisor::IoEventAddress;
 #[cfg(target_arch = "aarch64")]
 use hypervisor::arch::aarch64::regs::AARCH64_PMU_IRQ;
+#[cfg(feature = "kvm")]
+use iommufd_ioctls::IommuFd;
 use libc::{
     MAP_NORESERVE, MAP_PRIVATE, MAP_SHARED, O_TMPFILE, PROT_READ, PROT_WRITE, TCSANOW, tcsetattr,
     termios,
@@ -90,6 +92,8 @@ use seccompiler::SeccompAction;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracer::trace_scoped;
+#[cfg(feature = "kvm")]
+use vfio_ioctls::VfioIommufd;
 use vfio_ioctls::{VfioContainer, VfioDevice, VfioDeviceFd, VfioOps};
 use virtio_devices::transport::{VirtioPciDevice, VirtioPciDeviceActivator, VirtioTransport};
 use virtio_devices::vhost_user::VhostUserConfig;
@@ -360,6 +364,15 @@ pub enum DeviceManagerError {
     /// Error getting pty peer
     #[error("Error getting pty peer")]
     GetPtyPeer(#[source] vmm_sys_util::errno::Error),
+
+    /// Cannot create iommufd
+    #[cfg(feature = "kvm")]
+    #[error("Cannot create iommufd")]
+    IommufdCreate(#[source] iommufd_ioctls::IommufdError),
+
+    /// iommufd is not supported
+    #[error("iommufd is not supported without the kvm feature")]
+    IommufdNotSupported,
 
     /// Cannot create a VFIO device
     #[error("Cannot create a VFIO device")]
@@ -3803,9 +3816,31 @@ impl DeviceManager {
             .try_clone()
             .map_err(DeviceManagerError::VfioCreate)?;
 
-        Ok(Arc::new(
-            VfioContainer::new(Some(Arc::new(dup))).map_err(DeviceManagerError::VfioCreate)?,
-        ))
+        let iommufd = self
+            .config
+            .lock()
+            .unwrap()
+            .platform
+            .as_ref()
+            .is_some_and(|p| p.iommufd);
+
+        if iommufd {
+            #[cfg(feature = "kvm")]
+            {
+                info!("Using vfio cdev mode with iommufd.");
+                let iommufd = IommuFd::new().map_err(DeviceManagerError::IommufdCreate)?;
+                let vfio_iommufd = VfioIommufd::new(Arc::new(iommufd), None, Some(Arc::new(dup)))
+                    .map_err(DeviceManagerError::VfioCreate)?;
+                Ok(Arc::new(vfio_iommufd))
+            }
+            #[cfg(not(feature = "kvm"))]
+            Err(DeviceManagerError::IommufdNotSupported)
+        } else {
+            info!("Using vfio legacy mode with vfio container/group.");
+            Ok(Arc::new(
+                VfioContainer::new(Some(Arc::new(dup))).map_err(DeviceManagerError::VfioCreate)?,
+            ))
+        }
     }
 
     fn add_vfio_device(

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -110,6 +110,18 @@ mod kvm {
     pub const KVM_SET_NESTED_STATE: u64 = 1082175167;
 }
 
+mod iommufd {
+    // See include/uapi/linux/iommufd.h in the kernel code.
+    pub const IOMMU_IOAS_ALLOC: u64 = 0x3b81;
+    pub const IOMMU_IOAS_MAP: u64 = 0x3b85;
+    pub const IOMMU_IOAS_UNMAP: u64 = 0x3b86;
+
+    // See include/uapi/linux/vfio.h in the kernel code.
+    pub const VFIO_DEVICE_BIND_IOMMUFD: u64 = 0x3b76;
+    pub const VFIO_DEVICE_ATTACH_IOMMUFD_PT: u64 = 0x3b77;
+    pub const VFIO_DEVICE_DETACH_IOMMUFD_PT: u64 = 0x3b78;
+}
+
 // Block device ioctls (not exported by libc)
 const BLKDISCARD: u64 = 0x1277; // _IO(0x12, 119)
 const BLKZEROOUT: u64 = 0x127f; // _IO(0x12, 127)
@@ -247,6 +259,28 @@ fn create_vmm_ioctl_seccomp_rule_common_kvm() -> Result<Vec<SeccompRule>, Backen
     ])
 }
 
+fn create_vmm_ioctl_seccomp_rule_iommufd() -> Result<Vec<SeccompRule>, BackendError> {
+    use iommufd::*;
+    Ok(or![
+        and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_ALLOC)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_MAP)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_UNMAP)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, VFIO_DEVICE_BIND_IOMMUFD)?],
+        and![Cond::new(
+            1,
+            ArgLen::Dword,
+            Eq,
+            VFIO_DEVICE_ATTACH_IOMMUFD_PT
+        )?],
+        and![Cond::new(
+            1,
+            ArgLen::Dword,
+            Eq,
+            VFIO_DEVICE_DETACH_IOMMUFD_PT
+        )?],
+    ])
+}
+
 fn create_vmm_ioctl_seccomp_rule_hypervisor(
     hypervisor_type: HypervisorType,
 ) -> Result<Vec<SeccompRule>, BackendError> {
@@ -373,8 +407,10 @@ fn create_vmm_ioctl_seccomp_rule_common(
     ];
 
     let hypervisor_rules = create_vmm_ioctl_seccomp_rule_hypervisor(hypervisor_type)?;
-
     common_rules.extend(hypervisor_rules);
+
+    let iommufd_rules = create_vmm_ioctl_seccomp_rule_iommufd()?;
+    common_rules.extend(iommufd_rules);
 
     Ok(common_rules)
 }
@@ -764,6 +800,20 @@ fn create_vcpu_ioctl_seccomp_rule_hypervisor(
     }
 }
 
+fn create_vcpu_ioctl_seccomp_rule_iommufd() -> Result<Vec<SeccompRule>, BackendError> {
+    use iommufd::*;
+    Ok(or![
+        and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_MAP)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_UNMAP)?],
+        and![Cond::new(
+            1,
+            ArgLen::Dword,
+            Eq,
+            VFIO_DEVICE_DETACH_IOMMUFD_PT
+        )?],
+    ])
+}
+
 fn create_vcpu_ioctl_seccomp_rule(
     hypervisor_type: HypervisorType,
 ) -> Result<Vec<SeccompRule>, BackendError> {
@@ -784,8 +834,10 @@ fn create_vcpu_ioctl_seccomp_rule(
     ];
 
     let hypervisor_rules = create_vcpu_ioctl_seccomp_rule_hypervisor(hypervisor_type)?;
-
     rules.extend(hypervisor_rules);
+
+    let iommufd_rules = create_vcpu_ioctl_seccomp_rule_iommufd()?;
+    rules.extend(iommufd_rules);
 
     Ok(rules)
 }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -113,6 +113,10 @@ pub fn default_platformconfig_iommu_address_width_bits() -> u8 {
     DEFAULT_IOMMU_ADDRESS_WIDTH_BITS
 }
 
+pub fn default_platformconfig_vfio_p2p_dma() -> bool {
+    true
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct PlatformConfig {
     #[serde(default = "default_platformconfig_num_pci_segments")]
@@ -135,6 +139,8 @@ pub struct PlatformConfig {
     pub sev_snp: bool,
     #[serde(default)]
     pub iommufd: bool,
+    #[serde(default = "default_platformconfig_vfio_p2p_dma")]
+    pub vfio_p2p_dma: bool,
 }
 
 pub const DEFAULT_PCI_SEGMENT_APERTURE_WEIGHT: u32 = 1;

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -133,6 +133,8 @@ pub struct PlatformConfig {
     #[cfg(feature = "sev_snp")]
     #[serde(default)]
     pub sev_snp: bool,
+    #[serde(default)]
+    pub iommufd: bool,
 }
 
 pub const DEFAULT_PCI_SEGMENT_APERTURE_WEIGHT: u32 = 1;


### PR DESCRIPTION
### Background

Since Linux kernel v6.6, the VFIO subsystem has been extended to support a new device access model - VFIO cdev . Together with the "new" IOMMUFD subsystem, advanced features from modern hardware can be fully exposed and utilized in the guest, achieving fully accelerated iommu in the guest.

More details: https://github.com/rust-vmm/vfio/issues/92

Fixes: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/6892

### Summary

- Add `--platform iommufd=on|off` to use vfio cdev with iommufd instead of the legacy vfio container/group interface (default: `off`)
- Add `--platform vfio_p2p_dma=on|off` to control MMIO BAR DMA mapping into the host IOMMU address space (default: `on`); set to `off` on stock kernels with `iommufd=on` to avoid `-EFAULT` from `IOMMU_IOAS_MAP` on `VM_PFNMAP` pages
- Add seccomp rules for iommufd and vfio cdev ioctls
- Add parameterized iommufd integration tests

### Tests

- [x] VFIO runner (Ubuntu 24.04.3 stock kernel v6.8): existing legacy tests and new `test_iommufd_*` tests pass with `iommufd=on,vfio_p2p_dma=off`
- [x] GH200 system (NVIDIA kernel with [PFNMAP workaround](https://github.com/NVIDIA/NV-Kernels/commit/d5c249583491a530fbedb3ff00621067d5d3ff66)): NVMe and GPU passthrough with `iommufd=on,vfio_p2p_dma=on`