### PR TITLE
scripts: use arch OVMF downloads and bump fw tag

### DIFF
--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -136,6 +136,9 @@ update_workloads() {
         popd || exit
     fi
 
+    # Download aarch64 ovmf
+    download_aarch64_ovmf
+
     pushd "$WORKLOADS_DIR" || exit
 
     if ! sha1sum sha1sums-aarch64-common --check; then
@@ -202,9 +205,6 @@ update_workloads() {
         echo "foo" >"$SHARED_DIR/file1"
         echo "bar" >"$SHARED_DIR/file3" || exit 1
     fi
-
-    # Checkout and build EDK2
-    build_edk2
 }
 
 process_common_args "$@"

--- a/scripts/run_integration_tests_windows_aarch64.sh
+++ b/scripts/run_integration_tests_windows_aarch64.sh
@@ -18,9 +18,9 @@ fi
 WIN_IMAGE_BASENAME="windows-11-iot-enterprise-aarch64.raw"
 WIN_IMAGE_FILE="$WORKLOADS_DIR/$WIN_IMAGE_BASENAME"
 
-# Checkout and build EDK2
+# Download aarch64 OVMF
 OVMF_FW="$WORKLOADS_DIR/CLOUDHV_EFI.fd"
-build_edk2
+download_aarch64_ovmf
 
 # Check if the images are present
 if [[ ! -f ${WIN_IMAGE_FILE} || ! -f ${OVMF_FW} ]]; then

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -17,7 +17,8 @@ WIN_IMAGE_FILE="/root/workloads/windows-server-2022-amd64-2.raw"
 
 WORKLOADS_DIR="/root/workloads"
 
-download_ovmf
+# Download amd64 ovmf
+download_amd64_ovmf
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -25,7 +25,7 @@ if [ ! -f "$WORKLOADS_DIR/hypervisor-fw" ]; then
 fi
 
 if [ ! -f "$WORKLOADS_DIR/CLOUDHV.fd" ]; then
-    download_ovmf
+    download_amd64_ovmf
 fi
 
 download_x86_guest_images

--- a/scripts/sha1sums-aarch64-common
+++ b/scripts/sha1sums-aarch64-common
@@ -3,3 +3,4 @@ e4addb6e212a298144f9eb0eb6e36019d013f0e7  alpine-minirootfs-aarch64.tar.gz
 9953b31bb1923cdd8d91b1b7cc9ad3a9be1e0a59  focal-server-cloudimg-arm64-custom-20210929-0.raw
 7118f4d4cad18c8357bc2ad9824a50f9a82a860a  jammy-server-cloudimg-arm64-custom-20220329-0.qcow2
 1f2b71be43b8f748f01306c4454e5c921343faa4  jammy-server-cloudimg-arm64-custom-20220329-0.raw
+ce3656987f9e4238ef8afbd65fca219460c1f767  CLOUDHV_EFI.fd

--- a/scripts/sha1sums-x86_64
+++ b/scripts/sha1sums-x86_64
@@ -1,3 +1,3 @@
 d4a44acc6014d5f83dea1c625c43d677a95fa75f alpine-minirootfs-x86_64.tar.gz
 540ac358429305d7aa94e15363665d1c9d845982 hypervisor-fw
-cf89e3e052c8ef0b6192abee6128eef943393307 CLOUDHV.fd
+fb2e6834cc482c80a45766f6dcf12474f4fcb74e CLOUDHV.fd

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -198,10 +198,20 @@ prepare_linux() {
     fi
 }
 
-download_ovmf() {
-    OVMF_FW_TAG="ch-13b4963ec4"
+download_amd64_ovmf() {
+    OVMF_FW_TAG="ch-1e1b96f126"
     OVMF_FW_URL="https://github.com/cloud-hypervisor/edk2/releases/download/$OVMF_FW_TAG/CLOUDHV.fd"
     OVMF_FW="$WORKLOADS_DIR/CLOUDHV.fd"
+    pushd "$WORKLOADS_DIR" || exit
+    rm -f "$OVMF_FW"
+    download_with_retries $OVMF_FW_URL || exit 1
+    popd || exit
+}
+
+download_aarch64_ovmf() {
+    OVMF_FW_TAG="ch-1e1b96f126"
+    OVMF_FW_URL="https://github.com/cloud-hypervisor/edk2/releases/download/$OVMF_FW_TAG/CLOUDHV_EFI.fd"
+    OVMF_FW="$WORKLOADS_DIR/CLOUDHV_EFI.fd"
     pushd "$WORKLOADS_DIR" || exit
     rm -f "$OVMF_FW"
     download_with_retries $OVMF_FW_URL || exit 1


### PR DESCRIPTION
* Rename download_ovmf to download_amd64_ovmf and add a separate
download_aarch64_ovmf for CLOUDHV_EFI.fd

* Replace build_edk2 with download_aarch64_ovmf in aarch64 scripts

* Update OVMF firmware tag to ch-1e1b96f126

* Update CLOUDHV.fd sha1sum in sha1sums-x86_64

* Add CLOUDHV_EFI.fd sha1sum in sha1sums-aarch64-common

Fixes: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7622

### Validation
arm64 Integration Test
https://github.com/cloud-hypervisor/cloud-hypervisor/actions/runs/24222849244
amd64 Integration Test
https://github.com/cloud-hypervisor/cloud-hypervisor/actions/runs/24222849230
MSHV Integration Test
https://github.com/cloud-hypervisor/cloud-hypervisor/actions/runs/24222849227
Quality Check
https://github.com/cloud-hypervisor/cloud-hypervisor/actions/runs/24222849238

