### PR TITLE
fix deadlock between CpuManager:.pause() and MMIO-Write to ACPI CPU Hotplug Controller

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -1941,7 +1941,7 @@ mod common_parallel {
             .args([
                 "--cmdline",
                 DIRECT_KERNEL_BOOT_CMDLINE
-                    .replace("console=hvc0 ", console_str)
+                    .replace("console=hvc0", console_str)
                     .as_str(),
             ])
             .default_disks()
@@ -1997,7 +1997,7 @@ mod common_parallel {
             .args([
                 "--cmdline",
                 DIRECT_KERNEL_BOOT_CMDLINE
-                    .replace("console=hvc0 ", console_str)
+                    .replace("console=hvc0", console_str)
                     .as_str(),
             ])
             .default_disks()
@@ -2055,7 +2055,7 @@ mod common_parallel {
             .args([
                 "--cmdline",
                 DIRECT_KERNEL_BOOT_CMDLINE
-                    .replace("console=hvc0 ", console_str)
+                    .replace("console=hvc0", console_str)
                     .as_str(),
             ])
             .default_disks()
@@ -2613,7 +2613,7 @@ mod common_parallel {
             .args([
                 "--cmdline",
                 DIRECT_KERNEL_BOOT_CMDLINE
-                    .replace("console=hvc0 ", console_str)
+                    .replace("console=hvc0", console_str)
                     .as_str(),
             ])
             .args(["--serial", "tty"])
@@ -5621,7 +5621,7 @@ mod common_parallel {
             .args([
                 "--cmdline",
                 DIRECT_KERNEL_BOOT_CMDLINE
-                    .replace("console=hvc0 ", tty_str)
+                    .replace("console=hvc0", tty_str)
                     .as_str(),
             ])
             .capture_output()

--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -147,6 +147,9 @@ impl Bus {
         None
     }
 
+    /// Inserts a bus device into the bus.
+    ///
+    /// The bus will only hold a weak reference to the object.
     #[allow(clippy::needless_pass_by_value)]
     pub fn insert(&self, device: Arc<dyn BusDeviceSync>, base: u64, len: u64) -> Result<()> {
         if len == 0 {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -682,8 +682,8 @@ pub struct CpuManager {
     reset_evt: EventFd,
     #[cfg(feature = "guest_debug")]
     vm_debug_evt: EventFd,
+    // Shared with AcpiCpuHotplugController
     vcpu_states: Arc<Mutex<Vec<VcpuState>>>,
-    selected_cpu: u32,
     vcpus: Vec<Arc<Mutex<Vcpu>>>,
     seccomp_action: SeccompAction,
     vm_ops: Arc<dyn VmOps>,
@@ -698,14 +698,6 @@ pub struct CpuManager {
     // State of the core scheduling group leader election (VM mode).
     core_scheduling_group_leader: Arc<AtomicI32>,
 }
-
-const CPU_ENABLE_FLAG: usize = 0;
-const CPU_INSERTING_FLAG: usize = 1;
-const CPU_REMOVING_FLAG: usize = 2;
-const CPU_EJECT_FLAG: usize = 3;
-
-const CPU_STATUS_OFFSET: u64 = 4;
-const CPU_SELECTION_OFFSET: u64 = 0;
 
 /// State of the core scheduling group leader election for VM-wide cookie
 /// sharing.
@@ -734,85 +726,6 @@ impl TryFrom<i32> for CoreSchedulingLeader {
             -2 => Ok(Self::Error),
             _ => Err(()),
         }
-    }
-}
-
-impl BusDevice for CpuManager {
-    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
-        // The Linux kernel, quite reasonably, doesn't zero the memory it gives us.
-        data.fill(0);
-        let vcpu_states = self.vcpu_states.lock().unwrap();
-
-        match offset {
-            CPU_SELECTION_OFFSET => {
-                assert!(data.len() >= core::mem::size_of::<u32>());
-                data[0..core::mem::size_of::<u32>()]
-                    .copy_from_slice(&self.selected_cpu.to_le_bytes());
-            }
-            CPU_STATUS_OFFSET => {
-                if self.selected_cpu < self.max_vcpus() {
-                    let state = &vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
-                    if state.active() {
-                        data[0] |= 1 << CPU_ENABLE_FLAG;
-                    }
-                    if state.inserting {
-                        data[0] |= 1 << CPU_INSERTING_FLAG;
-                    }
-                    if state.removing {
-                        data[0] |= 1 << CPU_REMOVING_FLAG;
-                    }
-                } else {
-                    warn!("Out of range vCPU id: {}", self.selected_cpu);
-                }
-            }
-            _ => {
-                warn!("Unexpected offset for accessing CPU manager device: {offset:#}");
-            }
-        }
-    }
-
-    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
-        match offset {
-            CPU_SELECTION_OFFSET => {
-                assert!(data.len() >= core::mem::size_of::<u32>());
-                self.selected_cpu =
-                    u32::from_le_bytes(data[0..core::mem::size_of::<u32>()].try_into().unwrap());
-            }
-            CPU_STATUS_OFFSET => {
-                if self.selected_cpu < self.max_vcpus() {
-                    let eject = {
-                        // This structure is not shared with the vCPU thread, therefore, holding the
-                        // lock for the entire function doesn't cause any deadlock.
-                        let mut vcpu_states = self.vcpu_states.lock().unwrap();
-                        let state = &mut vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
-
-                        if (data[0] & (1 << CPU_INSERTING_FLAG) == 1 << CPU_INSERTING_FLAG)
-                            && state.inserting
-                        {
-                            state.inserting = false;
-                        }
-
-                        if (data[0] & (1 << CPU_REMOVING_FLAG) == 1 << CPU_REMOVING_FLAG)
-                            && state.removing
-                        {
-                            state.removing = false;
-                        }
-
-                        data[0] & (1 << CPU_EJECT_FLAG) == 1 << CPU_EJECT_FLAG
-                    };
-
-                    if eject && let Err(e) = self.remove_vcpu(self.selected_cpu) {
-                        error!("Error removing vCPU: {e:?}");
-                    }
-                } else {
-                    warn!("Out of range vCPU id: {}", self.selected_cpu);
-                }
-            }
-            _ => {
-                warn!("Unexpected offset for accessing CPU manager device: {offset:#}");
-            }
-        }
-        None
     }
 }
 
@@ -965,7 +878,6 @@ impl CpuManager {
             reset_evt,
             #[cfg(feature = "guest_debug")]
             vm_debug_evt,
-            selected_cpu: 0,
             vcpus: Vec::with_capacity(max_vcpus),
             seccomp_action,
             vm_ops,
@@ -1541,23 +1453,6 @@ impl CpuManager {
             }
         }
         false
-    }
-
-    fn remove_vcpu(&mut self, cpu_id: u32) -> Result<()> {
-        info!("Removing vCPU: cpu_id = {cpu_id}");
-        let mut vcpu_states = self.vcpu_states.lock().unwrap();
-        let state = &mut vcpu_states[usize::try_from(cpu_id).unwrap()];
-        state.kill.store(true, Ordering::SeqCst);
-        state.signal_thread();
-        state.wait_until_signal_acknowledged()?;
-        state.join_thread()?;
-        state.handle = None;
-
-        // Once the thread has exited, clear the "kill" so that it can reused
-        state.kill.store(false, Ordering::SeqCst);
-        state.pending_removal.store(false, Ordering::SeqCst);
-
-        Ok(())
     }
 
     pub fn create_boot_vcpus(
@@ -3200,6 +3095,132 @@ impl CpuElf64Writable for CpuManager {
         }
 
         Ok(())
+    }
+}
+
+/// MMIO-accessible controller for handling ACPI hotplug and unplug events.
+///
+/// Shares state about the vCPUs with the [`CpuManager`].
+pub struct AcpiCpuHotplugController {
+    /// The currently selected CPU by the guest.
+    selected_cpu: u32,
+    /// Shared vCPU state with [`CpuManager`].
+    vcpu_states: Arc<Mutex<Vec<VcpuState>>>,
+    /// Maximum number of vCPUS of the VM.
+    max_vcpus: u32,
+}
+
+impl AcpiCpuHotplugController {
+    const CPU_ENABLE_FLAG: usize = 0;
+    const CPU_INSERTING_FLAG: usize = 1;
+    const CPU_REMOVING_FLAG: usize = 2;
+    const CPU_EJECT_FLAG: usize = 3;
+
+    const CPU_SELECTION_OFFSET: u64 = 0;
+    const CPU_STATUS_OFFSET: u64 = 4;
+
+    /// Creates a new [`AcpiCpuHotplugController`].
+    pub fn new(cpu_manager: &CpuManager) -> AcpiCpuHotplugController {
+        Self {
+            max_vcpus: cpu_manager.config.max_vcpus,
+            selected_cpu: 0,
+            vcpu_states: cpu_manager.vcpu_states.clone(),
+        }
+    }
+
+    /// Removes a vCPU from the guest.
+    ///
+    /// The corresponding vCPU thread will be gracefully stopped and joined.
+    fn remove_vcpu(cpu_id: u32, state: &mut VcpuState) -> Result<()> {
+        info!("Removing vCPU: cpu_id = {cpu_id}");
+        state.kill.store(true, Ordering::SeqCst);
+        state.signal_thread();
+        state.wait_until_signal_acknowledged()?;
+        state.join_thread()?;
+        state.handle = None;
+
+        // Once the thread has exited, clear the "kill" so that it can reused
+        state.kill.store(false, Ordering::SeqCst);
+        state.pending_removal.store(false, Ordering::SeqCst);
+
+        Ok(())
+    }
+}
+
+impl BusDevice for AcpiCpuHotplugController {
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
+        // The Linux kernel, quite reasonably, doesn't zero the memory it gives us.
+        data.fill(0);
+        let vcpu_states = self.vcpu_states.lock().unwrap();
+
+        match offset {
+            Self::CPU_SELECTION_OFFSET => {
+                assert!(data.len() >= core::mem::size_of::<u32>());
+                data[0..core::mem::size_of::<u32>()]
+                    .copy_from_slice(&self.selected_cpu.to_le_bytes());
+            }
+            Self::CPU_STATUS_OFFSET => {
+                if self.selected_cpu < self.max_vcpus {
+                    let state = &vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
+                    if state.active() {
+                        data[0] |= 1 << Self::CPU_ENABLE_FLAG;
+                    }
+                    if state.inserting {
+                        data[0] |= 1 << Self::CPU_INSERTING_FLAG;
+                    }
+                    if state.removing {
+                        data[0] |= 1 << Self::CPU_REMOVING_FLAG;
+                    }
+                } else {
+                    warn!("Out of range vCPU id: {}", self.selected_cpu);
+                }
+            }
+            _ => {
+                warn!("Unexpected offset for accessing CPU manager device: {offset:#}");
+            }
+        }
+    }
+
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        match offset {
+            Self::CPU_SELECTION_OFFSET => {
+                assert!(data.len() >= core::mem::size_of::<u32>());
+                self.selected_cpu =
+                    u32::from_le_bytes(data[0..core::mem::size_of::<u32>()].try_into().unwrap());
+            }
+            Self::CPU_STATUS_OFFSET => {
+                if self.selected_cpu < self.max_vcpus {
+                    // This structure is not shared with the vCPU thread, therefore, holding the
+                    // lock for the entire function doesn't cause any deadlock.
+                    let mut vcpu_states = self.vcpu_states.lock().unwrap();
+                    let state = &mut vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
+                    // The ACPI code writes back a 1 to acknowledge the insertion
+                    if (data[0] & (1 << Self::CPU_INSERTING_FLAG) == 1 << Self::CPU_INSERTING_FLAG)
+                        && state.inserting
+                    {
+                        state.inserting = false;
+                    }
+                    // Ditto for removal
+                    if (data[0] & (1 << Self::CPU_REMOVING_FLAG) == 1 << Self::CPU_REMOVING_FLAG)
+                        && state.removing
+                    {
+                        state.removing = false;
+                    }
+                    // Trigger removal of vCPU:
+                    if data[0] & (1 << Self::CPU_EJECT_FLAG) == 1 << Self::CPU_EJECT_FLAG
+                        && let Err(e) = Self::remove_vcpu(self.selected_cpu, state)
+                    {
+                        error!("Error removing vCPU: {e:?}");
+                    }
+                } else {
+                    warn!("Out of range vCPU id: {}", self.selected_cpu);
+                }
+            }
+            _ => {
+                warn!("Unexpected offset for accessing CPU manager device: {offset:#}");
+            }
+        }
+        None
     }
 }
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -682,7 +682,7 @@ pub struct CpuManager {
     reset_evt: EventFd,
     #[cfg(feature = "guest_debug")]
     vm_debug_evt: EventFd,
-    vcpu_states: Vec<VcpuState>,
+    vcpu_states: Arc<Mutex<Vec<VcpuState>>>,
     selected_cpu: u32,
     vcpus: Vec<Arc<Mutex<Vcpu>>>,
     seccomp_action: SeccompAction,
@@ -741,6 +741,7 @@ impl BusDevice for CpuManager {
     fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         // The Linux kernel, quite reasonably, doesn't zero the memory it gives us.
         data.fill(0);
+        let vcpu_states = self.vcpu_states.lock().unwrap();
 
         match offset {
             CPU_SELECTION_OFFSET => {
@@ -750,7 +751,7 @@ impl BusDevice for CpuManager {
             }
             CPU_STATUS_OFFSET => {
                 if self.selected_cpu < self.max_vcpus() {
-                    let state = &self.vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
+                    let state = &vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
                     if state.active() {
                         data[0] |= 1 << CPU_ENABLE_FLAG;
                     }
@@ -779,23 +780,28 @@ impl BusDevice for CpuManager {
             }
             CPU_STATUS_OFFSET => {
                 if self.selected_cpu < self.max_vcpus() {
-                    let state = &mut self.vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
-                    // The ACPI code writes back a 1 to acknowledge the insertion
-                    if (data[0] & (1 << CPU_INSERTING_FLAG) == 1 << CPU_INSERTING_FLAG)
-                        && state.inserting
-                    {
-                        state.inserting = false;
-                    }
-                    // Ditto for removal
-                    if (data[0] & (1 << CPU_REMOVING_FLAG) == 1 << CPU_REMOVING_FLAG)
-                        && state.removing
-                    {
-                        state.removing = false;
-                    }
-                    // Trigger removal of vCPU
-                    if data[0] & (1 << CPU_EJECT_FLAG) == 1 << CPU_EJECT_FLAG
-                        && let Err(e) = self.remove_vcpu(self.selected_cpu)
-                    {
+                    let eject = {
+                        // This structure is not shared with the vCPU thread, therefore, holding the
+                        // lock for the entire function doesn't cause any deadlock.
+                        let mut vcpu_states = self.vcpu_states.lock().unwrap();
+                        let state = &mut vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
+
+                        if (data[0] & (1 << CPU_INSERTING_FLAG) == 1 << CPU_INSERTING_FLAG)
+                            && state.inserting
+                        {
+                            state.inserting = false;
+                        }
+
+                        if (data[0] & (1 << CPU_REMOVING_FLAG) == 1 << CPU_REMOVING_FLAG)
+                            && state.removing
+                        {
+                            state.removing = false;
+                        }
+
+                        data[0] & (1 << CPU_EJECT_FLAG) == 1 << CPU_EJECT_FLAG
+                    };
+
+                    if eject && let Err(e) = self.remove_vcpu(self.selected_cpu) {
                         error!("Error removing vCPU: {e:?}");
                     }
                 } else {
@@ -907,6 +913,7 @@ impl CpuManager {
         let max_vcpus = usize::try_from(config.max_vcpus).unwrap();
         let mut vcpu_states = Vec::with_capacity(max_vcpus);
         vcpu_states.resize_with(max_vcpus, VcpuState::default);
+        let vcpu_states = Arc::new(Mutex::new(vcpu_states));
         let hypervisor_type = hypervisor.hypervisor_type();
         #[cfg(target_arch = "x86_64")]
         let cpu_vendor = hypervisor.get_cpu_vendor();
@@ -1176,14 +1183,14 @@ impl CpuManager {
         let vcpus_pause_signalled = self.vcpus_pause_signalled.clone();
         let vcpus_kick_signalled = self.vcpus_kick_signalled.clone();
 
-        let vcpu_kill = self.vcpu_states[usize::try_from(vcpu_id).unwrap()]
-            .kill
-            .clone();
-        let vcpu_run_interrupted = self.vcpu_states[usize::try_from(vcpu_id).unwrap()]
+        let mut vcpu_states = self.vcpu_states.lock().unwrap();
+
+        let vcpu_kill = vcpu_states[usize::try_from(vcpu_id).unwrap()].kill.clone();
+        let vcpu_run_interrupted = vcpu_states[usize::try_from(vcpu_id).unwrap()]
             .vcpu_run_interrupted
             .clone();
         let panic_vcpu_run_interrupted = vcpu_run_interrupted.clone();
-        let vcpu_paused = self.vcpu_states[usize::try_from(vcpu_id).unwrap()]
+        let vcpu_paused = vcpu_states[usize::try_from(vcpu_id).unwrap()]
             .paused
             .clone();
 
@@ -1470,8 +1477,8 @@ impl CpuManager {
 
         // On hot plug calls into this function entry_point is None. It is for
         // those hotplug CPU additions that we need to set the inserting flag.
-        self.vcpu_states[usize::try_from(vcpu_id).unwrap()].handle = handle;
-        self.vcpu_states[usize::try_from(vcpu_id).unwrap()].inserting = inserting;
+        vcpu_states[usize::try_from(vcpu_id).unwrap()].handle = handle;
+        vcpu_states[usize::try_from(vcpu_id).unwrap()].inserting = inserting;
 
         Ok(())
     }
@@ -1515,17 +1522,20 @@ impl CpuManager {
     }
 
     fn mark_vcpus_for_removal(&mut self, desired_vcpus: u32) {
+        let mut vcpu_states = self.vcpu_states.lock().unwrap();
+        let present_vcpus = Self::active_vcpus(&vcpu_states);
+
         // Mark vCPUs for removal, actual removal happens on ejection
-        for cpu_id in desired_vcpus..self.present_vcpus() {
-            self.vcpu_states[usize::try_from(cpu_id).unwrap()].removing = true;
-            self.vcpu_states[usize::try_from(cpu_id).unwrap()]
+        for cpu_id in desired_vcpus..present_vcpus {
+            vcpu_states[usize::try_from(cpu_id).unwrap()].removing = true;
+            vcpu_states[usize::try_from(cpu_id).unwrap()]
                 .pending_removal
                 .store(true, Ordering::SeqCst);
         }
     }
 
     pub fn check_pending_removed_vcpu(&mut self) -> bool {
-        for state in self.vcpu_states.iter() {
+        for state in self.vcpu_states.lock().unwrap().iter() {
             if state.active() && state.pending_removal.load(Ordering::SeqCst) {
                 return true;
             }
@@ -1535,7 +1545,8 @@ impl CpuManager {
 
     fn remove_vcpu(&mut self, cpu_id: u32) -> Result<()> {
         info!("Removing vCPU: cpu_id = {cpu_id}");
-        let state = &mut self.vcpu_states[usize::try_from(cpu_id).unwrap()];
+        let mut vcpu_states = self.vcpu_states.lock().unwrap();
+        let state = &mut vcpu_states[usize::try_from(cpu_id).unwrap()];
         state.kill.store(true, Ordering::SeqCst);
         state.signal_thread();
         state.wait_until_signal_acknowledged()?;
@@ -1631,12 +1642,15 @@ impl CpuManager {
     /// For the vCPU threads this will interrupt the KVM_RUN ioctl() allowing
     /// the loop to check the shared state booleans.
     fn signal_vcpus(&mut self) -> Result<()> {
+        // Holding the lock for the whole operation is correct:
+        let vcpu_states = self.vcpu_states.lock().unwrap();
+
         // Splitting this into two loops reduced the time to pause many vCPUs
         // massively. Example: 254 vCPUs. >254ms -> ~4ms.
-        for state in self.vcpu_states.iter() {
+        for state in vcpu_states.iter() {
             state.signal_thread();
         }
-        for state in self.vcpu_states.iter() {
+        for state in vcpu_states.iter() {
             state.wait_until_signal_acknowledged()?;
         }
 
@@ -1651,14 +1665,14 @@ impl CpuManager {
         self.vcpus_pause_signalled.store(false, Ordering::SeqCst);
 
         // Unpark all the VCPU threads.
-        for state in self.vcpu_states.iter() {
+        for state in self.vcpu_states.lock().unwrap().iter() {
             state.unpark_thread();
         }
 
         self.signal_vcpus()?;
 
         // Wait for all the threads to finish. This removes the state from the vector.
-        for mut state in self.vcpu_states.drain(..) {
+        for mut state in self.vcpu_states.lock().unwrap().drain(..) {
             state.join_thread()?;
         }
 
@@ -1691,8 +1705,15 @@ impl CpuManager {
         self.cpuid.clone()
     }
 
+    /// Locks the vCPU states and calls [`Self::active_vcpus`].
     fn present_vcpus(&self) -> u32 {
-        self.vcpu_states
+        let lock = self.vcpu_states.lock().unwrap();
+        Self::active_vcpus(&lock)
+    }
+
+    /// Counts the number of active vCPUs (running vCPU threads).
+    fn active_vcpus(vcpu_states: &[VcpuState]) -> u32 {
+        vcpu_states
             .iter()
             .fold(0, |acc, state| acc + state.active() as u32)
     }
@@ -2651,7 +2672,7 @@ impl Pausable for CpuManager {
 
         // The vCPU thread will change its paused state before parking, wait here for each
         // activated vCPU change their state to ensure they have parked.
-        for state in self.vcpu_states.iter() {
+        for state in self.vcpu_states.lock().unwrap().iter() {
             if state.active() {
                 // wait for vCPU to update state
                 while !state.paused.load(Ordering::SeqCst) {
@@ -2669,16 +2690,18 @@ impl Pausable for CpuManager {
         // their run vCPU loop.
         self.vcpus_pause_signalled.store(false, Ordering::SeqCst);
 
+        let vcpu_states = self.vcpu_states.lock().unwrap();
+
         // Unpark all the vCPU threads.
         // Step 1/2: signal each thread
         {
-            for state in self.vcpu_states.iter() {
+            for state in vcpu_states.iter() {
                 state.unpark_thread();
             }
         }
         // Step 2/2: wait for state ACK
         {
-            for state in self.vcpu_states.iter() {
+            for state in vcpu_states.iter() {
                 // wait for vCPU to update state
                 while state.paused.load(Ordering::SeqCst) {
                     // To avoid a priority inversion with the vCPU thread

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -729,13 +729,17 @@ impl TryFrom<i32> for CoreSchedulingLeader {
     }
 }
 
+/// Management structure for a vCPU (thread).
 #[derive(Default)]
 struct VcpuState {
     inserting: bool,
     removing: bool,
     pending_removal: Arc<AtomicBool>,
+    /// Handle to the vCPU thread.
     handle: Option<thread::JoinHandle<()>>,
+    /// Instructs the thread to exit the run-vCPU loop.
     kill: Arc<AtomicBool>,
+    /// Used to ACK interruption from the run vCPU loop to the CPU Manager.
     vcpu_run_interrupted: Arc<AtomicBool>,
     /// Used to ACK state changes from the run vCPU loop to the CPU Manager.
     paused: Arc<AtomicBool>,
@@ -750,6 +754,13 @@ impl VcpuState {
     ///
     /// Please call [`Self::wait_until_signal_acknowledged`] afterward to block
     /// until the vCPU thread has acknowledged the signal.
+    ///
+    /// If the thread is in KVM_RUN (or MSHV_RUN_VP or equivalent), this kicks
+    /// the thread out of kernel space. If the thread is in user-space, the
+    /// thread will just handle the event eventually. If the thread is in
+    /// user-space but about to enter kernel-space, the user-space signal
+    /// handler will make sure that the next kernel entry of the given
+    /// vCPU thread immediately exits to handle the event in user-space.
     fn signal_thread(&self) {
         if let Some(handle) = self.handle.as_ref() {
             // SAFETY: FFI call with correct arguments
@@ -1532,10 +1543,10 @@ impl CpuManager {
         }
     }
 
-    /// Signal to the spawned threads (vCPUs and console signal handler).
+    /// Signals all vCPU threads and waits for them to ACK the interruption.
     ///
-    /// For the vCPU threads this will interrupt the KVM_RUN ioctl() allowing
-    /// the loop to check the shared state booleans.
+    /// Calls [`VcpuState::signal_thread`] and
+    /// [`VcpuState::wait_until_signal_acknowledged`] for each vCPU.
     fn signal_vcpus(&mut self) -> Result<()> {
         // Holding the lock for the whole operation is correct:
         let vcpu_states = self.vcpu_states.lock().unwrap();

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -124,7 +124,7 @@ use vm_virtio::{AccessPlatform, VirtioDeviceType};
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::console_devices::{ConsoleDeviceError, ConsoleInfo, ConsoleTransport};
-use crate::cpu::{CPU_MANAGER_ACPI_SIZE, CpuManager};
+use crate::cpu::{AcpiCpuHotplugController, CPU_MANAGER_ACPI_SIZE, CpuManager};
 use crate::device_tree::{DeviceNode, DeviceTree};
 use crate::interrupt::{LegacyUserspaceInterruptManager, MsiInterruptManager};
 use crate::memory_manager::{Error as MemoryManagerError, MEMORY_MANAGER_ACPI_SIZE, MemoryManager};
@@ -1026,6 +1026,10 @@ pub struct DeviceManager {
     // CPU Manager
     cpu_manager: Arc<Mutex<CpuManager>>,
 
+    /// Owned version needed to keep the bus device alive (the bus only holds
+    /// a weak reference).
+    _acpi_cpu_hotplug_controller: Arc<Mutex<AcpiCpuHotplugController>>,
+
     // The virtio devices on the system
     virtio_devices: Vec<MetaVirtioDevice>,
 
@@ -1324,6 +1328,10 @@ impl DeviceManager {
             )?);
         }
 
+        let acpi_cpu_hotplug_controller =
+            AcpiCpuHotplugController::new(&cpu_manager.lock().unwrap());
+        let acpi_cpu_hotplug_controller = Arc::new(Mutex::new(acpi_cpu_hotplug_controller));
+
         if dynamic {
             let acpi_address = address_manager
                 .allocator
@@ -1335,7 +1343,7 @@ impl DeviceManager {
             address_manager
                 .mmio_bus
                 .insert(
-                    cpu_manager.clone(),
+                    acpi_cpu_hotplug_controller.clone(),
                     acpi_address.0,
                     CPU_MANAGER_ACPI_SIZE as u64,
                 )
@@ -1429,6 +1437,7 @@ impl DeviceManager {
             fw_cfg: None,
             #[cfg(feature = "ivshmem")]
             ivshmem_device: None,
+            _acpi_cpu_hotplug_controller: acpi_cpu_hotplug_controller,
         };
 
         let device_manager = Arc::new(Mutex::new(device_manager));


### PR DESCRIPTION
TL;DR: Very rare deadlock that can be easily fixed with a clearer design: Splitting `AcpiCpuHotplugController` from `CpuManager`

The same bug exists for the Device Manager (which implements the `AcpiPciHotplugController`), but splitting that is a larger chunk of work.

More info in the commit messages!