### PR TITLE
feat: allow selective VFIO BAR mapping

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -8803,7 +8803,76 @@ mod windows {
 #[cfg(target_arch = "x86_64")]
 mod vfio {
     use crate::*;
+
     const NVIDIA_VFIO_DEVICE: &str = "/sys/bus/pci/devices/0002:00:01.0";
+    const IORESOURCE_MEM: u64 = 0x0000_0200;
+
+    fn nvidia_vfio_device_ready() -> bool {
+        if !std::path::Path::new(NVIDIA_VFIO_DEVICE).exists() {
+            println!("SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} not found");
+            return false;
+        }
+
+        let driver_path = format!("{NVIDIA_VFIO_DEVICE}/driver");
+        if let Ok(driver) = std::fs::read_link(&driver_path) {
+            let driver_name = driver.file_name().unwrap_or_default().to_string_lossy();
+            if driver_name != "vfio-pci" {
+                println!(
+                    "SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} bound to {driver_name}, not vfio-pci"
+                );
+                return false;
+            }
+        } else {
+            println!("SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} not bound to any driver");
+            return false;
+        }
+
+        true
+    }
+
+    fn first_nvidia_memory_bar() -> Option<u8> {
+        let resource_path = format!("{NVIDIA_VFIO_DEVICE}/resource");
+        let resource = match std::fs::read_to_string(&resource_path) {
+            Ok(resource) => resource,
+            Err(e) => {
+                println!("SKIPPED: failed to read {resource_path}: {e}");
+                return None;
+            }
+        };
+
+        for (index, line) in resource.lines().take(6).enumerate() {
+            let mut fields = line.split_whitespace();
+            let Some(start) = fields.next() else {
+                continue;
+            };
+            let Some(end) = fields.next() else {
+                continue;
+            };
+            let Some(flags) = fields.next() else {
+                continue;
+            };
+
+            let parse_hex = |value: &str| u64::from_str_radix(value.trim_start_matches("0x"), 16);
+            let Ok(start) = parse_hex(start) else {
+                continue;
+            };
+            let Ok(end) = parse_hex(end) else {
+                continue;
+            };
+            let Ok(flags) = parse_hex(flags) else {
+                continue;
+            };
+
+            if flags & IORESOURCE_MEM == 0 || end < start || (start == 0 && end == 0) {
+                continue;
+            }
+
+            return Some(index as u8);
+        }
+
+        println!("SKIPPED: no non-empty memory BAR found for {NVIDIA_VFIO_DEVICE}");
+        None
+    }
 
     fn platform_cfg(iommufd: bool) -> String {
         if iommufd {
@@ -9038,25 +9107,66 @@ mod vfio {
         test_nvidia_card_iommu_address_width_common(true);
     }
 
-    fn test_nvidia_guest_numa_generic_initiator_common(iommufd: bool) {
-        // Skip test if VFIO device is not available or not ready
-        if !std::path::Path::new(NVIDIA_VFIO_DEVICE).exists() {
-            println!("SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} not found");
+    fn test_nvidia_card_x_exclude_mmap_bars_common(iommufd: bool) {
+        if !nvidia_vfio_device_ready() {
             return;
         }
 
-        // Check if device is bound to vfio-pci driver
-        let driver_path = format!("{NVIDIA_VFIO_DEVICE}/driver");
-        if let Ok(driver) = std::fs::read_link(&driver_path) {
-            let driver_name = driver.file_name().unwrap_or_default().to_string_lossy();
-            if driver_name != "vfio-pci" {
-                println!(
-                    "SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} bound to {driver_name}, not vfio-pci"
-                );
-                return;
-            }
-        } else {
-            println!("SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} not bound to any driver");
+        let Some(bar) = first_nvidia_memory_bar() else {
+            return;
+        };
+
+        let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+
+        let mut child = GuestCommand::new(&guest)
+            .args(["--cpus", "boot=4"])
+            .args(["--memory", "size=1G"])
+            .args(["--kernel", fw_path(FwType::RustHypervisorFirmware).as_str()])
+            .args(["--platform", &platform_cfg(iommufd)])
+            .args([
+                "--device",
+                format!("path={NVIDIA_VFIO_DEVICE},x_exclude_mmap_bars=[{bar}]").as_str(),
+            ])
+            .default_disks()
+            .default_net()
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = std::panic::catch_unwind(|| {
+            guest.wait_vm_boot().unwrap();
+            assert!(wait_until(Duration::from_secs(10), || guest.check_nvidia_gpu()));
+        });
+
+        let _ = child.kill();
+        let output = child.wait_with_output().unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            stderr.contains("Skipping VFIO BAR mmap"),
+            "Expected x_exclude_mmap_bars log in stderr: {stderr}"
+        );
+        assert!(
+            stderr.contains(format!("BAR {bar}").as_str()),
+            "Expected skipped BAR index in stderr: {stderr}"
+        );
+
+        handle_child_output(r, &output);
+    }
+
+    #[test]
+    fn test_nvidia_card_x_exclude_mmap_bars() {
+        test_nvidia_card_x_exclude_mmap_bars_common(false);
+    }
+
+    #[test]
+    fn test_iommufd_nvidia_card_x_exclude_mmap_bars() {
+        test_nvidia_card_x_exclude_mmap_bars_common(true);
+    }
+
+    fn test_nvidia_guest_numa_generic_initiator_common(iommufd: bool) {
+        if !nvidia_vfio_device_ready() {
             return;
         }
 

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -10652,7 +10652,90 @@ mod windows {
 #[cfg(target_arch = "x86_64")]
 mod vfio {
     use crate::*;
+
     const NVIDIA_VFIO_DEVICE: &str = "/sys/bus/pci/devices/0002:00:01.0";
+    const IORESOURCE_MEM: u64 = 0x0000_0200;
+    const IORESOURCE_PREFETCH: u64 = 0x0000_2000;
+
+    fn nvidia_vfio_device_ready() -> bool {
+        if !std::path::Path::new(NVIDIA_VFIO_DEVICE).exists() {
+            println!("SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} not found");
+            return false;
+        }
+
+        let driver_path = format!("{NVIDIA_VFIO_DEVICE}/driver");
+        if let Ok(driver) = std::fs::read_link(&driver_path) {
+            let driver_name = driver.file_name().unwrap_or_default().to_string_lossy();
+            if driver_name != "vfio-pci" {
+                println!(
+                    "SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} bound to {driver_name}, not vfio-pci"
+                );
+                return false;
+            }
+        } else {
+            println!("SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} not bound to any driver");
+            return false;
+        }
+
+        true
+    }
+
+    fn largest_nvidia_prefetchable_memory_bar() -> Option<u8> {
+        let resource_path = format!("{NVIDIA_VFIO_DEVICE}/resource");
+        let resource = match std::fs::read_to_string(&resource_path) {
+            Ok(resource) => resource,
+            Err(e) => {
+                println!("SKIPPED: failed to read {resource_path}: {e}");
+                return None;
+            }
+        };
+
+        let mut selected_bar = None;
+        let mut selected_size = 0;
+        for (index, line) in resource.lines().take(6).enumerate() {
+            let mut fields = line.split_whitespace();
+            let Some(start) = fields.next() else {
+                continue;
+            };
+            let Some(end) = fields.next() else {
+                continue;
+            };
+            let Some(flags) = fields.next() else {
+                continue;
+            };
+
+            let parse_hex = |value: &str| u64::from_str_radix(value.trim_start_matches("0x"), 16);
+            let Ok(start) = parse_hex(start) else {
+                continue;
+            };
+            let Ok(end) = parse_hex(end) else {
+                continue;
+            };
+            let Ok(flags) = parse_hex(flags) else {
+                continue;
+            };
+
+            if flags & IORESOURCE_MEM == 0 || end < start || (start == 0 && end == 0) {
+                continue;
+            }
+            if flags & IORESOURCE_PREFETCH == 0 {
+                continue;
+            }
+
+            let size = end - start + 1;
+            if size > selected_size {
+                selected_bar = Some(index as u8);
+                selected_size = size;
+            }
+        }
+
+        if selected_bar.is_none() {
+            println!(
+                "SKIPPED: no non-empty prefetchable memory BAR found for {NVIDIA_VFIO_DEVICE}"
+            );
+        }
+        selected_bar
+    }
 
     fn platform_cfg(iommufd: bool) -> String {
         if iommufd {
@@ -10887,25 +10970,66 @@ mod vfio {
         test_nvidia_card_iommu_address_width_common(true);
     }
 
-    fn test_nvidia_guest_numa_generic_initiator_common(iommufd: bool) {
-        // Skip test if VFIO device is not available or not ready
-        if !std::path::Path::new(NVIDIA_VFIO_DEVICE).exists() {
-            println!("SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} not found");
+    fn test_nvidia_card_x_exclude_mmap_bars_common(iommufd: bool) {
+        if !nvidia_vfio_device_ready() {
             return;
         }
 
-        // Check if device is bound to vfio-pci driver
-        let driver_path = format!("{NVIDIA_VFIO_DEVICE}/driver");
-        if let Ok(driver) = std::fs::read_link(&driver_path) {
-            let driver_name = driver.file_name().unwrap_or_default().to_string_lossy();
-            if driver_name != "vfio-pci" {
-                println!(
-                    "SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} bound to {driver_name}, not vfio-pci"
-                );
-                return;
-            }
-        } else {
-            println!("SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} not bound to any driver");
+        let Some(bar) = largest_nvidia_prefetchable_memory_bar() else {
+            return;
+        };
+
+        let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+
+        let mut child = GuestCommand::new(&guest)
+            .args(["--cpus", "boot=4"])
+            .args(["--memory", "size=1G"])
+            .args(["--kernel", fw_path(FwType::RustHypervisorFirmware).as_str()])
+            .args(["--platform", &platform_cfg(iommufd)])
+            .args([
+                "--device",
+                format!("path={NVIDIA_VFIO_DEVICE},x_exclude_mmap_bars=[{bar}]").as_str(),
+            ])
+            .default_disks()
+            .default_net()
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = std::panic::catch_unwind(|| {
+            guest.wait_vm_boot().unwrap();
+            assert!(wait_until(Duration::from_secs(10), || guest.check_nvidia_gpu()));
+        });
+
+        let _ = child.kill();
+        let output = child.wait_with_output().unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            stderr.contains("Skipping VFIO BAR mmap"),
+            "Expected x_exclude_mmap_bars log in stderr: {stderr}"
+        );
+        assert!(
+            stderr.contains(format!("BAR {bar}").as_str()),
+            "Expected skipped BAR index in stderr: {stderr}"
+        );
+
+        handle_child_output(r, &output);
+    }
+
+    #[test]
+    fn test_nvidia_card_x_exclude_mmap_bars() {
+        test_nvidia_card_x_exclude_mmap_bars_common(false);
+    }
+
+    #[test]
+    fn test_iommufd_nvidia_card_x_exclude_mmap_bars() {
+        test_nvidia_card_x_exclude_mmap_bars_common(true);
+    }
+
+    fn test_nvidia_guest_numa_generic_initiator_common(iommufd: bool) {
+        if !nvidia_vfio_device_ready() {
             return;
         }
 

--- a/docs/vfio.md
+++ b/docs/vfio.md
@@ -159,6 +159,17 @@ nvidia-smi topo -p2p r
  GPU7	OK	OK	OK	OK	OK	OK	OK	X	
 ```
 
+Some VFIO devices expose BARs that should not be mmapped by the VMM even when
+the kernel reports them as mappable. The `x_exclude_mmap_bars` config argument can
+be used to skip mmap for specific BAR indices.
+
+BAR indices must be between 0 and 5 inclusive. The following example disables
+mmap for BAR 2 of the assigned device:
+
+```
+--device path=/sys/bus/pci/devices/0000:01:00.0/,x_exclude_mmap_bars=[2]
+```
+
 Some VFIO devices have a 32-bit mmio BAR. When using many such devices, it is
 possible to exhaust the 32-bit mmio space available on a PCI segment. The
 following example demonstrates an example device with a 16 MiB 32-bit mmio BAR.

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -501,6 +501,13 @@ pub(crate) struct VfioCommon {
     pub(crate) vfio_wrapper: Arc<dyn Vfio>,
     pub(crate) patches: HashMap<usize, ConfigPatch>,
     x_nv_gpudirect_clique: Option<u8>,
+    x_exclude_mmap_bars: Vec<u8>,
+}
+
+#[derive(Default)]
+pub(crate) struct VfioCommonConfig {
+    pub(crate) x_nv_gpudirect_clique: Option<u8>,
+    pub(crate) x_exclude_mmap_bars: Vec<u8>,
 }
 
 impl VfioCommon {
@@ -511,7 +518,7 @@ impl VfioCommon {
         subclass: &dyn PciSubclass,
         bdf: PciBdf,
         snapshot: Option<&Snapshot>,
-        x_nv_gpudirect_clique: Option<u8>,
+        config: VfioCommonConfig,
     ) -> Result<Self, VfioPciError> {
         let pci_configuration_state = vm_migration::state_from_id(snapshot, PCI_CONFIGURATION_ID)
             .map_err(|e| {
@@ -546,7 +553,8 @@ impl VfioCommon {
             legacy_interrupt_group,
             vfio_wrapper,
             patches: HashMap::new(),
-            x_nv_gpudirect_clique,
+            x_nv_gpudirect_clique: config.x_nv_gpudirect_clique,
+            x_exclude_mmap_bars: config.x_exclude_mmap_bars,
         };
 
         let state: Option<VfioCommonState> = snapshot
@@ -1499,6 +1507,7 @@ impl VfioPciDevice {
         memory_slot_allocator: MemorySlotAllocator,
         snapshot: Option<&Snapshot>,
         x_nv_gpudirect_clique: Option<u8>,
+        x_exclude_mmap_bars: Vec<u8>,
         device_path: PathBuf,
     ) -> Result<Self, VfioPciError> {
         let device = Arc::new(device);
@@ -1513,7 +1522,10 @@ impl VfioPciDevice {
             &PciVfioSubclass::VfioSubclass,
             bdf,
             vm_migration::snapshot_from_id(snapshot, VFIO_COMMON_ID),
-            x_nv_gpudirect_clique,
+            VfioCommonConfig {
+                x_nv_gpudirect_clique,
+                x_exclude_mmap_bars,
+            },
         )?;
 
         let vfio_pci_device = VfioPciDevice {
@@ -1649,6 +1661,21 @@ impl VfioPciDevice {
         // SAFETY: fd is guaranteed valid
         let fd = unsafe { BorrowedFd::borrow_raw(fd) };
         for region in self.common.mmio_regions.iter_mut() {
+            if self
+                .common
+                .x_exclude_mmap_bars
+                .contains(&(region.index as u8))
+            {
+                info!(
+                    "Skipping VFIO BAR mmap for device {} at {} BAR {} (size = 0x{:x})",
+                    self.bdf,
+                    self.device_path.display(),
+                    region.index,
+                    region.length
+                );
+                continue;
+            }
+
             let region_flags = self.device.get_region_flags(region.index);
             if region_flags & VFIO_REGION_INFO_FLAG_MMAP != 0 {
                 let mut prot = 0;

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -501,6 +501,13 @@ pub(crate) struct VfioCommon {
     pub(crate) vfio_wrapper: Arc<dyn Vfio>,
     pub(crate) patches: HashMap<usize, ConfigPatch>,
     x_nv_gpudirect_clique: Option<u8>,
+    x_exclude_mmap_bars: Vec<u8>,
+}
+
+#[derive(Default)]
+pub(crate) struct VfioCommonConfig {
+    pub(crate) x_nv_gpudirect_clique: Option<u8>,
+    pub(crate) x_exclude_mmap_bars: Vec<u8>,
 }
 
 impl VfioCommon {
@@ -511,7 +518,7 @@ impl VfioCommon {
         subclass: &dyn PciSubclass,
         bdf: PciBdf,
         snapshot: Option<&Snapshot>,
-        x_nv_gpudirect_clique: Option<u8>,
+        config: VfioCommonConfig,
     ) -> Result<Self, VfioPciError> {
         let pci_configuration_state = vm_migration::state_from_id(snapshot, PCI_CONFIGURATION_ID)
             .map_err(|e| {
@@ -546,7 +553,8 @@ impl VfioCommon {
             legacy_interrupt_group,
             vfio_wrapper,
             patches: HashMap::new(),
-            x_nv_gpudirect_clique,
+            x_nv_gpudirect_clique: config.x_nv_gpudirect_clique,
+            x_exclude_mmap_bars: config.x_exclude_mmap_bars,
         };
 
         let state: Option<VfioCommonState> = snapshot
@@ -1499,6 +1507,7 @@ impl VfioPciDevice {
         memory_slot_allocator: MemorySlotAllocator,
         snapshot: Option<&Snapshot>,
         x_nv_gpudirect_clique: Option<u8>,
+        x_exclude_mmap_bars: Vec<u8>,
         device_path: PathBuf,
     ) -> Result<Self, VfioPciError> {
         let device = Arc::new(device);
@@ -1513,7 +1522,10 @@ impl VfioPciDevice {
             &PciVfioSubclass::VfioSubclass,
             bdf,
             vm_migration::snapshot_from_id(snapshot, VFIO_COMMON_ID),
-            x_nv_gpudirect_clique,
+            VfioCommonConfig {
+                x_nv_gpudirect_clique,
+                x_exclude_mmap_bars,
+            },
         )?;
 
         let vfio_pci_device = VfioPciDevice {
@@ -1649,6 +1661,21 @@ impl VfioPciDevice {
         // SAFETY: fd is guaranteed valid
         let fd = unsafe { BorrowedFd::borrow_raw(fd) };
         for region in self.common.mmio_regions.iter_mut() {
+            if self
+                .common
+                .x_exclude_mmap_bars
+                .contains(&(region.index as u8))
+            {
+                info!(
+                    "Skipping VFIO BAR mmap and P2P DMA mapping for device {} at {} BAR {} (size = 0x{:x})",
+                    self.bdf,
+                    self.device_path.display(),
+                    region.index,
+                    region.length
+                );
+                continue;
+            }
+
             let region_flags = self.device.get_region_flags(region.index);
             if region_flags & VFIO_REGION_INFO_FLAG_MMAP != 0 {
                 let mut prot = 0;

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -26,7 +26,9 @@ use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottabl
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::mmap::MmapRegion;
-use crate::vfio::{UserMemoryRegion, VFIO_COMMON_ID, Vfio, VfioCommon, VfioError};
+use crate::vfio::{
+    UserMemoryRegion, VFIO_COMMON_ID, Vfio, VfioCommon, VfioCommonConfig, VfioError,
+};
 use crate::{
     BarReprogrammingParams, PciBarConfiguration, PciBdf, PciDevice, PciDeviceError, PciSubclass,
     VfioPciError,
@@ -101,7 +103,7 @@ impl VfioUserPciDevice {
             &PciVfioUserSubclass::VfioUserSubclass,
             bdf,
             vm_migration::snapshot_from_id(snapshot, VFIO_COMMON_ID),
-            None,
+            VfioCommonConfig::default(),
         )
         .map_err(VfioUserPciDeviceError::CreateVfioCommon)?;
 

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1219,6 +1219,11 @@ components:
         x_nv_gpudirect_clique:
           type: integer
           format: int8
+        x_exclude_mmap_bars:
+          type: array
+          items:
+            type: integer
+            format: int8
     TpmConfig:
       required:
         - socket

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1223,6 +1223,11 @@ components:
         x_nv_gpudirect_clique:
           type: integer
           format: int8
+        x_exclude_mmap_bars:
+          type: array
+          items:
+            type: integer
+            format: int64
 
     UserDeviceConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -144,6 +144,9 @@ pub enum Error {
     /// Missing path from device,
     #[error("Error parsing --device: path missing")]
     ParseDevicePathMissing,
+    /// Invalid excluded-mmap BAR from device
+    #[error("Error parsing --device: invalid excluded-mmap BAR index {0}")]
+    ParseDeviceExcludeMmapBarInvalid(u64),
     /// Failed parsing vsock parameters
     #[error("Error parsing --vsock")]
     ParseVsock(#[source] OptionParserError),
@@ -307,6 +310,9 @@ pub enum ValidationError {
     /// Invalid PCI segment aperture weight
     #[error("Invalid PCI segment aperture weight: {0}")]
     InvalidPciSegmentApertureWeight(u32),
+    /// Invalid VFIO excluded-mmap BAR index
+    #[error("Invalid VFIO excluded-mmap BAR index: {0}")]
+    InvalidDeviceExcludeMmapBar(u8),
     /// Invalid IOMMU address width in bits
     #[error(
         "IOMMU address width in bits ({0}) should be less than or equal to {MAX_IOMMU_ADDRESS_WIDTH_BITS}"
@@ -2221,14 +2227,17 @@ impl DebugConsoleConfig {
 impl DeviceConfig {
     pub const SYNTAX: &'static str = "Direct device assignment parameters \
     \"path=<device_path>,iommu=on|off,id=<device_id>,\
-    pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
+    pci_segment=<segment_id>,pci_device_id=<pci_slot>,\
+    x_nv_gpudirect_clique=<clique_id>,\
+    x_exclude_mmap_bars=[<bar>...]\"";
 
     pub fn parse(device: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser
             .add("path")
             .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU)
-            .add("x_nv_gpudirect_clique");
+            .add("x_nv_gpudirect_clique")
+            .add("x_exclude_mmap_bars");
         parser.parse(device).map_err(Error::ParseDevice)?;
 
         let pci_common = PciDeviceCommonConfig::parse(device)?;
@@ -2239,10 +2248,23 @@ impl DeviceConfig {
         let x_nv_gpudirect_clique = parser
             .convert::<u8>("x_nv_gpudirect_clique")
             .map_err(Error::ParseDevice)?;
+        let IntegerList(raw_x_exclude_mmap_bars) = parser
+            .convert::<IntegerList>("x_exclude_mmap_bars")
+            .map_err(Error::ParseDevice)?
+            .unwrap_or(IntegerList(Vec::new()));
+        let mut x_exclude_mmap_bars = Vec::with_capacity(raw_x_exclude_mmap_bars.len());
+        for bar in raw_x_exclude_mmap_bars {
+            // PCI devices have six standard BARs indexed 0..=5.
+            if bar > 5 {
+                return Err(Error::ParseDeviceExcludeMmapBarInvalid(bar));
+            }
+            x_exclude_mmap_bars.push(bar as u8);
+        }
         Ok(DeviceConfig {
             pci_common,
             path,
             x_nv_gpudirect_clique,
+            x_exclude_mmap_bars,
         })
     }
 
@@ -2253,6 +2275,13 @@ impl DeviceConfig {
             let vfio_p2p_dma = vm_config.platform.as_ref().is_none_or(|p| p.vfio_p2p_dma);
             if !vfio_p2p_dma {
                 return Err(ValidationError::GpuDirectCliqueRequiresP2pDma);
+            }
+        }
+
+        // PCI devices expose six BARs, so only BAR indices 0 through 5 are valid here.
+        for bar in &self.x_exclude_mmap_bars {
+            if *bar > 5 {
+                return Err(ValidationError::InvalidDeviceExcludeMmapBar(*bar));
             }
         }
 
@@ -4380,6 +4409,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             pci_common: PciDeviceCommonConfig::default(),
             path: PathBuf::from("/path/to/device"),
             x_nv_gpudirect_clique: None,
+            x_exclude_mmap_bars: Vec::new(),
         }
     }
 
@@ -4415,6 +4445,26 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             }
         );
 
+        assert_eq!(
+            DeviceConfig::parse("path=/path/to/device,x_exclude_mmap_bars=[2]")?,
+            DeviceConfig {
+                x_exclude_mmap_bars: vec![2],
+                ..device_fixture()
+            }
+        );
+
+        assert_eq!(
+            DeviceConfig::parse("path=/path/to/device,x_exclude_mmap_bars=[0,2,5]")?,
+            DeviceConfig {
+                x_exclude_mmap_bars: vec![0, 2, 5],
+                ..device_fixture()
+            }
+        );
+
+        assert!(matches!(
+            DeviceConfig::parse("path=/path/to/device,x_exclude_mmap_bars=[6]").unwrap_err(),
+            Error::ParseDeviceExcludeMmapBarInvalid(6)
+        ));
         Ok(())
     }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -310,6 +310,9 @@ pub enum ValidationError {
     /// Invalid PCI segment aperture weight
     #[error("Invalid PCI segment aperture weight: {0}")]
     InvalidPciSegmentApertureWeight(u32),
+    /// Invalid VFIO excluded-mmap BAR index
+    #[error("Invalid VFIO excluded-mmap BAR index: {0}")]
+    InvalidDeviceExcludeMmapBar(u64),
     /// Invalid IOMMU address width in bits
     #[error(
         "IOMMU address width in bits ({0}) should be less than or equal to {MAX_IOMMU_ADDRESS_WIDTH_BITS}"
@@ -2237,14 +2240,17 @@ impl DebugConsoleConfig {
 impl DeviceConfig {
     pub const SYNTAX: &'static str = "Direct device assignment parameters \
     \"path=<device_path>,iommu=on|off,id=<device_id>,\
-    pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
+    pci_segment=<segment_id>,pci_device_id=<pci_slot>,\
+    x_nv_gpudirect_clique=<clique_id>,\
+    x_exclude_mmap_bars=[<bar>...]\"";
 
     pub fn parse(device: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser
             .add("path")
             .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU)
-            .add("x_nv_gpudirect_clique");
+            .add("x_nv_gpudirect_clique")
+            .add("x_exclude_mmap_bars");
         parser.parse(device).map_err(Error::ParseDevice)?;
 
         let pci_common = PciDeviceCommonConfig::parse(device)?;
@@ -2255,10 +2261,16 @@ impl DeviceConfig {
         let x_nv_gpudirect_clique = parser
             .convert::<u8>("x_nv_gpudirect_clique")
             .map_err(Error::ParseDevice)?;
+        let x_exclude_mmap_bars = parser
+            .convert::<IntegerList>("x_exclude_mmap_bars")
+            .map_err(Error::ParseDevice)?
+            .map(|bars| bars.0)
+            .unwrap_or_default();
         Ok(DeviceConfig {
             pci_common,
             path,
             x_nv_gpudirect_clique,
+            x_exclude_mmap_bars,
         })
     }
 
@@ -2269,6 +2281,13 @@ impl DeviceConfig {
             let vfio_p2p_dma = vm_config.platform.as_ref().is_none_or(|p| p.vfio_p2p_dma);
             if !vfio_p2p_dma {
                 return Err(ValidationError::GpuDirectCliqueRequiresP2pDma);
+            }
+        }
+
+        // PCI devices expose six BARs, so only BAR indices 0 through 5 are valid here.
+        for bar in &self.x_exclude_mmap_bars {
+            if *bar > 5 {
+                return Err(ValidationError::InvalidDeviceExcludeMmapBar(*bar));
             }
         }
 
@@ -4427,6 +4446,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             pci_common: PciDeviceCommonConfig::default(),
             path: PathBuf::from("/path/to/device"),
             x_nv_gpudirect_clique: None,
+            x_exclude_mmap_bars: Vec::new(),
         }
     }
 
@@ -4462,6 +4482,29 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             }
         );
 
+        assert_eq!(
+            DeviceConfig::parse("path=/path/to/device,x_exclude_mmap_bars=[2]")?,
+            DeviceConfig {
+                x_exclude_mmap_bars: vec![2],
+                ..device_fixture()
+            }
+        );
+
+        assert_eq!(
+            DeviceConfig::parse("path=/path/to/device,x_exclude_mmap_bars=[0,2,5]")?,
+            DeviceConfig {
+                x_exclude_mmap_bars: vec![0, 2, 5],
+                ..device_fixture()
+            }
+        );
+
+        assert_eq!(
+            DeviceConfig::parse("path=/path/to/device,x_exclude_mmap_bars=[6]")?,
+            DeviceConfig {
+                x_exclude_mmap_bars: vec![6],
+                ..device_fixture()
+            }
+        );
         Ok(())
     }
 
@@ -5849,6 +5892,17 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             ..device_fixture()
         }]);
         still_valid_config.validate().unwrap();
+
+        // x_exclude_mmap_bars only accepts PCI BAR indices 0 through 5
+        let mut invalid_config = valid_config.clone();
+        invalid_config.devices = Some(vec![DeviceConfig {
+            x_exclude_mmap_bars: vec![6],
+            ..device_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::InvalidDeviceExcludeMmapBar(6))
+        );
 
         let mut still_valid_config = valid_config.clone();
         // SAFETY: Safe as the file was just opened

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4061,6 +4061,7 @@ impl DeviceManager {
             memory_manager.lock().unwrap().memory_slot_allocator(),
             vm_migration::snapshot_from_id(self.snapshot.as_ref(), vfio_name.as_str()),
             device_cfg.x_nv_gpudirect_clique,
+            device_cfg.x_exclude_mmap_bars.clone(),
             device_cfg.path.clone(),
         )
         .map_err(DeviceManagerError::VfioPciCreate)?;

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3899,6 +3899,11 @@ impl DeviceManager {
             memory_manager.lock().unwrap().memory_slot_allocator(),
             vm_migration::snapshot_from_id(self.snapshot.as_ref(), vfio_name.as_str()),
             device_cfg.x_nv_gpudirect_clique,
+            device_cfg
+                .x_exclude_mmap_bars
+                .iter()
+                .map(|bar| *bar as u8)
+                .collect(),
             device_cfg.path.clone(),
         )
         .map_err(DeviceManagerError::VfioPciCreate)?;

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -614,6 +614,8 @@ pub struct DeviceConfig {
     pub path: PathBuf,
     #[serde(default)]
     pub x_nv_gpudirect_clique: Option<u8>,
+    #[serde(default)]
+    pub x_exclude_mmap_bars: Vec<u8>,
 }
 
 impl ApplyLandlock for DeviceConfig {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -614,6 +614,8 @@ pub struct DeviceConfig {
     pub path: PathBuf,
     #[serde(default)]
     pub x_nv_gpudirect_clique: Option<u8>,
+    #[serde(default)]
+    pub x_exclude_mmap_bars: Vec<u64>,
 }
 
 impl ApplyLandlock for DeviceConfig {


### PR DESCRIPTION
## Purpose

On older host kernels, mmaping a very large VFIO BAR can add noticeable boot and hotplug latency because of host-side BAR mmap overhead and page-table growth. This option allows selected BARs to stay trap-and-emulate instead of being mmapped into the guest when that tradeoff is preferable.

For the original GPU use case, the large VRAM BAR was the main target: keeping that BAR out of the mmap path improved attach time while leaving smaller BARs available to be mmapped normally.

## Summary
- add `x_exclude_mmap_bars` to VFIO device configuration so specific BARs can stay trap-and-emulate instead of being mmapped into the guest
- thread the new setting through the API/config/device-manager path and skip BAR mmap in `VfioPciDevice::map_mmio_regions()` for the selected BAR indices
- document the new option and add VFIO integration coverage for the NVIDIA passthrough test path