### PR TITLE
vmm: pci_segment: use segment id as ACPI _UID

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -489,6 +489,20 @@ mod common_parallel {
                     .unwrap_or_default(),
                 TEST_DISK_NODE
             );
+
+            // Each PNP0A08 host bridge in the DSDT must expose a unique
+            // _UID matching its PCI segment id. Linux surfaces the
+            // evaluated _UID via /sys/bus/acpi/devices/PNP0A08:*/uid.
+            // This test uses firmware boot on aarch64, so ACPI is
+            // available on both supported architectures.
+            let mut uids: Vec<u16> = guest
+                .ssh_command("cat /sys/bus/acpi/devices/PNP0A08:*/uid")
+                .unwrap()
+                .lines()
+                .filter_map(|l| l.trim().parse::<u16>().ok())
+                .collect();
+            uids.sort();
+            assert_eq!(uids, vec![0u16, 1u16]);
         });
 
         kill_child(&mut child);

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -360,7 +360,7 @@ impl Aml for PciSegment {
         pci_dsdt_inner_data.push(&adr);
         let seg = aml::Name::new("_SEG".into(), &self.id);
         pci_dsdt_inner_data.push(&seg);
-        let uid = aml::Name::new("_UID".into(), &aml::ZERO);
+        let uid = aml::Name::new("_UID".into(), &self.id);
         pci_dsdt_inner_data.push(&uid);
         let cca = aml::Name::new("_CCA".into(), &aml::ONE);
         pci_dsdt_inner_data.push(&cca);


### PR DESCRIPTION
## Summary

The ACPI specification requires `_UID` to be unique across devices sharing the same `_HID` (ACPI 6.5 §6.1.12). Currently every `PciSegment` emits `_UID=0` for its `PNP0A08` host bridge, which violates the spec when `num_pci_segments > 1`.

Windows guests detect this during ACPI namespace enumeration and abort boot with **BSOD 0xA5 `ACPI_BIOS_ERROR`**, with the bug check parameters pointing at the `_UID` object of the second `PNP0A08` node. Linux guests are lenient and silently accept the collision, so the issue has gone unnoticed until now.

The fix uses `self.id` as `_UID`, matching what `_SEG` already does on the line immediately above. For single-segment VMs (the default, `id == 0`) this is a no-op at runtime since the only segment's id is 0.

## Prior art

QEMU assigns a unique `_UID` to each PCI host bridge for the same reason (`pcmc->pci_root_uid` on i440fx/q35).

## Test plan

- [x] Single-segment (default) VM still boots on Linux and Windows guests (no-op change)
- [x] `--platform num_pci_segments=2` Windows Server 2025 guest boots without BSOD 0xA5 (previously crashed)
- [x] `iasl -d` on the generated DSDT shows `Name (_UID, 0x00)` on segment 0 and `Name (_UID, 0x01)` on segment 1