### PR TITLE
Stabilize CI with retries and improve VFIO tests 

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -8274,6 +8274,9 @@ mod vfio {
 
             assert!(guest.get_total_memory().unwrap_or_default() > 3_840_000);
 
+            // Verify the VFIO device works before memory hotplug
+            guest.check_nvidia_gpu();
+
             guest.enable_memory_hotplug();
 
             // Add RAM to the VM
@@ -8447,6 +8450,9 @@ mod vfio {
                     .unwrap()
                     .contains("input address: 42 bits")
             );
+
+            // Check the VFIO device works after boot
+            guest.check_nvidia_gpu();
         });
 
         let _ = child.kill();

--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -31,12 +31,12 @@ export RUST_BACKTRACE=1
 export RUSTFLAGS="$RUSTFLAGS"
 
 # Run VFIO tests using legacy vfio interface with container/group
-time cargo nextest run --no-tests=pass --test-threads=1 "vfio::test_nvidia" -- ${test_binary_args[*]}
+time cargo nextest run --retries 3 --no-tests=pass --test-threads=1 "vfio::test_nvidia" -- ${test_binary_args[*]}
 RES=$?
 
 # Run VFIO tests using vfio cdev interface backed by iommufd
 if [ $RES -eq 0 ]; then
-    time cargo nextest run --no-tests=pass --test-threads=1 "vfio::test_iommufd" -- ${test_binary_args[*]}
+    time cargo nextest run --retries 3 --no-tests=pass --test-threads=1 "vfio::test_iommufd" -- ${test_binary_args[*]}
     RES=$?
 fi
 

--- a/scripts/run_integration_tests_windows_aarch64.sh
+++ b/scripts/run_integration_tests_windows_aarch64.sh
@@ -44,7 +44,7 @@ cargo build --all --release --target "$BUILD_TARGET"
 
 # Only run with 1 thread to avoid tests interfering with one another because
 # Windows has a static IP configured
-time cargo nextest run --no-tests=pass "windows::$test_filter" --target "$BUILD_TARGET" -- ${test_binary_args[*]}
+time cargo nextest run --retries 3 --no-tests=pass "windows::$test_filter" --target "$BUILD_TARGET" -- ${test_binary_args[*]}
 RES=$?
 
 dmsetup remove_all -f

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -48,7 +48,7 @@ export RUSTFLAGS="$RUSTFLAGS"
 
 # Only run with 1 thread to avoid tests interfering with one another because
 # Windows has a static IP configured
-time cargo nextest run --no-tests=pass $test_features "windows::$test_filter" --target "$BUILD_TARGET" -- ${test_binary_args[*]}
+time cargo nextest run --retries 3 --no-tests=pass $test_features "windows::$test_filter" --target "$BUILD_TARGET" -- ${test_binary_args[*]}
 RES=$?
 
 dmsetup remove_all -f

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1316,11 +1316,18 @@ impl Guest {
 
     #[cfg(target_arch = "x86_64")]
     pub fn check_nvidia_gpu(&self) {
-        assert!(
-            self.ssh_command("nvidia-smi")
-                .unwrap()
-                .contains("NVIDIA L40S")
-        );
+        let output = self.ssh_command("nvidia-smi").unwrap();
+        if !output.contains("NVIDIA L40S") {
+            let dmesg = self
+                .ssh_command("sudo dmesg")
+                .unwrap_or_else(|e| format!("Failed to get dmesg: {e:?}"));
+            eprintln!(
+                "\n\n==== Guest dmesg (nvidia-smi check failed) ====\n\n\
+                 {dmesg}\n\
+                 \n==== End guest dmesg ====\n\n"
+            );
+            panic!("nvidia-smi output did not contain 'NVIDIA L40S': {output}");
+        }
     }
 
     pub fn reboot_linux(&self, current_reboot_count: u32) {


### PR DESCRIPTION
Few integration tests from the windows and the vfio pipeline are flaky and causing merge queue failures. Adding retires to stablize CI pipelines. 

Also few improvements have been made to improve vfio tests.

See: #7994, #7998