### PR TITLE
ci: fix jq usage in mshv-infra.yaml

### DIFF
--- a/.github/workflows/mshv-infra.yaml
+++ b/.github/workflows/mshv-infra.yaml
@@ -94,7 +94,7 @@ jobs:
             fi
 
             remaining=$(az vm list-usage --location "$location" --query "[?name.value=='$family'] | [0]" -o json |
-                        jq '.limit + 0 - .currentValue >= $ARGS.positional[0]' --jsonargs "$vcpu")
+                        jq '(.limit | tonumber) - (.currentValue | tonumber) >= ($ARGS.positional[0] | tonumber)' --jsonargs "$vcpu")
             if [[ "$remaining" = true ]]; then
               echo "Sufficient quota found in $location"
               echo "location=$location" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Workflow runs fail in the "Get Location" step with:

jq: error (at <stdin>:9): string ("100") and number (0) cannot be added

Use tonumber to explicitly convert string to number instead of the "+ 0" trick.

Tested locally with the exact same `az` command. I was able to repro the original issue and verified it gets fixed with this change.

Closes: #7996 