### PR TITLE
tests: consolidate test config into nextest profiles

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,38 @@
 [profile.default]
 # Don't let one individual test run for more than 10 minutes
 slow-timeout = { period = "60s", terminate-after = 10 }
+
+[profile.integration]
+fail-fast = false
+retries = 3
+
+[profile.common_tests]
+inherits = "integration"
+default-filter = 'test(common_parallel::) | test(common_sequential::) | test(aarch64_acpi::)'
+junit.path = "/root/workloads/junit/common.xml"
+
+[[profile.common_tests.overrides]]
+filter = 'test(common_sequential::)'
+# use up all the available test threads for each of the sequential tests
+# i.e. no other test can be running while a sequential test is running.
+threads-required = 'num-test-threads'
+
+[profile.dbus]
+inherits = "integration"
+default-filter = 'test(dbus_api::)'
+junit.path = "/root/workloads/junit/dbus.xml"
+
+[profile.fw_cfg]
+inherits = "integration"
+default-filter = 'test(fw_cfg::)'
+junit.path = "/root/workloads/junit/fw_cfg.xml"
+
+[profile.ivshmem]
+inherits = "integration"
+default-filter = 'test(ivshmem::)'
+junit.path = "/root/workloads/junit/ivshmem.xml"
+
+[profile.common_cvm]
+inherits = "integration"
+default-filter = 'test(common_cvm::)'
+junit.path = "/root/workloads/junit/cvm.xml"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,49 @@
 [profile.default]
 # Don't let one individual test run for more than 10 minutes
 slow-timeout = { period = "60s", terminate-after = 10 }
+
+[profile.integration]
+fail-fast = false
+retries = 3
+
+[profile.common_tests]
+inherits = "integration"
+default-filter = 'test(common_parallel::) | test(common_sequential::) | test(aarch64_acpi::)'
+junit.path = "/root/workloads/junit/common.xml"
+
+[[profile.common_tests.overrides]]
+filter = 'test(common_sequential::)'
+# use up all the available test threads for each of the sequential tests
+# i.e. no other test can be running while a sequential test is running.
+threads-required = 'num-test-threads'
+
+[profile.live_migration]
+inherits = "integration"
+default-filter = 'test(live_migration_parallel::) | test(live_migration_sequential::)'
+junit.path = "/root/workloads/junit/live_migration.xml"
+
+[[profile.live_migration.overrides]]
+filter = 'test(live_migration_sequential::)'
+# use up all the available test threads for each of the sequential tests
+# i.e. no other test can be running while a sequential test is running.
+threads-required = 'num-test-threads'
+
+[profile.dbus]
+inherits = "integration"
+default-filter = 'test(dbus_api::)'
+junit.path = "/root/workloads/junit/dbus.xml"
+
+[profile.fw_cfg]
+inherits = "integration"
+default-filter = 'test(fw_cfg::)'
+junit.path = "/root/workloads/junit/fw_cfg.xml"
+
+[profile.ivshmem]
+inherits = "integration"
+default-filter = 'test(ivshmem::)'
+junit.path = "/root/workloads/junit/ivshmem.xml"
+
+[profile.common_cvm]
+inherits = "integration"
+default-filter = 'test(common_cvm::)'
+junit.path = "/root/workloads/junit/cvm.xml"

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -41,7 +41,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=raw,value=20251114-0
+            type=raw,value=20260417-0
             type=sha
 
       - name: Build and push

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -41,7 +41,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=raw,value=20251114-0
+            type=raw,value=20260517-0
             type=sha
 
       - name: Build and push

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -112,7 +112,7 @@ RUN export ARCH="$(uname -m)" \
             $RUST_TOOLCHAIN-x86_64-unknown-linux-musl; fi \
     && if [ "$TARGETARCH" = "amd64" ]; then rustup component add rustfmt; fi \
     && if [ "$TARGETARCH" = "amd64" ]; then rustup component add clippy; fi \
-    && cargo install cargo-nextest --locked \
+    && cargo install cargo-nextest --locked --version 0.9.128 \
     && rm -rf "$CARGO_HOME/registry" \
     && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \
     && rm -rf "$CARGO_HOME/git" \

--- a/scripts/common-aarch64.sh
+++ b/scripts/common-aarch64.sh
@@ -3,6 +3,7 @@
 WORKLOADS_DIR="$HOME/workloads"
 
 mkdir -p "$WORKLOADS_DIR"
+mkdir -p "$WORKLOADS_DIR/junit"
 
 build_edk2() {
     EDK2_BUILD_DIR="$WORKLOADS_DIR/edk2_build"

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -9,7 +9,7 @@ CLI_NAME="Cloud Hypervisor"
 CTR_IMAGE_TAG="ghcr.io/cloud-hypervisor/cloud-hypervisor"
 
 # Needs to match explicit version in docker-image.yaml workflow
-CTR_IMAGE_VERSION="20251114-0"
+CTR_IMAGE_VERSION="20260417-0"
 : "${CTR_IMAGE:=${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}}"
 
 DOCKER_RUNTIME="docker"

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -9,7 +9,7 @@ CLI_NAME="Cloud Hypervisor"
 CTR_IMAGE_TAG="ghcr.io/cloud-hypervisor/cloud-hypervisor"
 
 # Needs to match explicit version in docker-image.yaml workflow
-CTR_IMAGE_VERSION="20251114-0"
+CTR_IMAGE_VERSION="20260517-0"
 : "${CTR_IMAGE:=${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}}"
 
 DOCKER_RUNTIME="docker"

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -248,36 +248,12 @@ echo "$PAGE_NUM" | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
 # Run all direct kernel boot (Device Tree) test cases in mod `parallel`
-time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "common_parallel::$test_filter" -- ${test_binary_args[*]}
+time cargo nextest run $test_features --profile common_tests --no-tests=pass --test-threads=$(($(nproc) / 4)) "$test_filter" -- ${test_binary_args[*]}
 RES=$?
-
-# Run some tests in sequence since the result could be affected by other tests
-# running in parallel.
-if [ $RES -eq 0 ]; then
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "common_sequential::$test_filter" -- ${test_binary_args[*]}
-    RES=$?
-else
-    exit $RES
-fi
-
-# Run all ACPI test cases
-if [ $RES -eq 0 ]; then
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "aarch64_acpi::$test_filter" -- ${test_binary_args[*]}
-    RES=$?
-else
-    exit $RES
-fi
 
 # Run all test cases related to live migration
 if [ $RES -eq 0 ]; then
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "live_migration_parallel::$test_filter" -- ${test_binary_args[*]}
-    RES=$?
-else
-    exit $RES
-fi
-
-if [ $RES -eq 0 ]; then
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "live_migration_sequential::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --profile live_migration --no-tests=pass --test-threads=$(($(nproc) / 4)) "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 else
     exit $RES
@@ -288,7 +264,7 @@ if [ $RES -eq 0 ]; then
     cargo build --features "dbus_api" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
     # integration tests now do not reply on build feature "dbus_api"
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "dbus_api::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --profile dbus --no-tests=pass --test-threads=$(($(nproc) / 4)) "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 
@@ -296,14 +272,14 @@ fi
 if [ $RES -eq 0 ]; then
     cargo build --features "fw_cfg" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "fw_cfg::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --profile fw_cfg --no-tests=pass --test-threads=$(($(nproc) / 4)) "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 
 if [ $RES -eq 0 ]; then
     cargo build --features "ivshmem" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "ivshmem::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --profile ivshmem --no-tests=pass --test-threads=$(($(nproc) / 4)) "$test_filter" -- ${test_binary_args[*]}
 
     RES=$?
 fi

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -243,24 +243,13 @@ if ! [[ "${PARALLEL_INTEGRATION_TESTS_NUM:-}" =~ ^[1-9][0-9]*$ ]]; then
     PARALLEL_INTEGRATION_TESTS_NUM="${TEST_THREADS_DEFAULT}"
 fi
 echo "nproc:$(nproc), parallel_integration_tests:${PARALLEL_INTEGRATION_TESTS_NUM}"
-# Run all direct kernel boot (Device Tree) test cases in mod `parallel`
-time cargo nextest run -p cloud-hypervisor $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads="${PARALLEL_INTEGRATION_TESTS_NUM}" "common_parallel::$test_filter" -- ${test_binary_args[*]}
+# Run all direct kernel boot (Device Tree) test cases in mod `parallel`,
+# `sequential`, and ACPI cases. The `common_tests` profile filter covers
+# all three sets, and the per-mod `threads-required = 'num-test-threads'`
+# override on `common_sequential` enforces serial scheduling within the run.
+time cargo nextest run -p cloud-hypervisor $test_features --profile common_tests --no-tests=pass --test-threads="${PARALLEL_INTEGRATION_TESTS_NUM}" "$test_filter" -- ${test_binary_args[*]}
 RES=$?
-
-# Run some tests in sequence since the result could be affected by other tests
-# running in parallel.
-if [ $RES -eq 0 ]; then
-    time cargo nextest run -p cloud-hypervisor $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "common_sequential::$test_filter" -- ${test_binary_args[*]}
-    RES=$?
-else
-    exit $RES
-fi
-
-# Run all ACPI test cases
-if [ $RES -eq 0 ]; then
-    time cargo nextest run -p cloud-hypervisor $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "aarch64_acpi::$test_filter" -- ${test_binary_args[*]}
-    RES=$?
-else
+if [ $RES -ne 0 ]; then
     exit $RES
 fi
 
@@ -269,7 +258,7 @@ if [ $RES -eq 0 ]; then
     cargo build --features "mshv,dbus_api" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
     # integration tests now do not reply on build feature "dbus_api"
-    time cargo nextest run -p cloud-hypervisor $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "dbus_api::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run -p cloud-hypervisor $test_features --profile dbus --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 
@@ -277,14 +266,14 @@ fi
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,fw_cfg" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
-    time cargo nextest run -p cloud-hypervisor $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "fw_cfg::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run -p cloud-hypervisor $test_features --profile fw_cfg --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,ivshmem" --all --release --target "$BUILD_TARGET"
     export RUST_BACKTRACE=1
-    time cargo nextest run -p cloud-hypervisor $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "ivshmem::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run -p cloud-hypervisor $test_features --profile ivshmem --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "$test_filter" -- ${test_binary_args[*]}
 
     RES=$?
 fi

--- a/scripts/run_integration_tests_cvm.sh
+++ b/scripts/run_integration_tests_cvm.sh
@@ -8,6 +8,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/test-util.sh"
 
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
+mkdir -p "$WORKLOADS_DIR/junit"
 
 process_common_args "$@"
 
@@ -27,7 +28,7 @@ popd || exit
 cargo build --features $build_features --all --release --target "$BUILD_TARGET"
 
 export RUST_BACKTRACE=1
-time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "common_cvm::$test_filter" -- ${test_binary_args[*]}
+time cargo nextest run $test_features --profile common_cvm --no-tests=pass --test-threads=$(($(nproc) / 4)) "$test_filter" -- ${test_binary_args[*]}
 RES=$?
 
 exit $RES

--- a/scripts/run_integration_tests_cvm.sh
+++ b/scripts/run_integration_tests_cvm.sh
@@ -8,6 +8,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/test-util.sh"
 
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
+mkdir -p "$WORKLOADS_DIR/junit"
 
 process_common_args "$@"
 
@@ -27,7 +28,7 @@ popd || exit
 cargo build --features $build_features --all --release --target "$BUILD_TARGET"
 
 export RUST_BACKTRACE=1
-time cargo nextest run -p cloud-hypervisor $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "common_cvm::$test_filter" -- ${test_binary_args[*]}
+time cargo nextest run -p cloud-hypervisor $test_features --profile common_cvm --no-tests=pass --test-threads=$(($(nproc) / 4)) "$test_filter" -- ${test_binary_args[*]}
 RES=$?
 
 exit $RES

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -8,6 +8,7 @@ source "$(dirname "$0")"/test-util.sh
 
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
+mkdir -p "$WORKLOADS_DIR/junit"
 
 process_common_args "$@"
 
@@ -87,16 +88,7 @@ sudo chmod a+rwX /dev/hugepages
 export RUST_BACKTRACE=1
 export RUSTFLAGS="$RUSTFLAGS"
 
-time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "live_migration_parallel::$test_filter" -- ${test_binary_args[*]}
+time cargo nextest run $test_features --profile live_migration --no-tests=pass --test-threads=$(($(nproc) / 4)) "$test_filter" -- ${test_binary_args[*]}
 
 RES=$?
-
-# Run some tests in sequence since the result could be affected by other tests
-# running in parallel.
-if [ $RES -eq 0 ]; then
-    export RUST_BACKTRACE=1
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "live_migration_sequential::$test_filter" -- ${test_binary_args[*]}
-    RES=$?
-fi
-
 exit $RES

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -8,6 +8,7 @@ source "$(dirname "$0")"/test-util.sh
 
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
+mkdir -p "$WORKLOADS_DIR/junit"
 
 process_common_args "$@"
 
@@ -189,34 +190,27 @@ ulimit -n 4096
 export RUST_BACKTRACE=1
 export RUSTFLAGS="$RUSTFLAGS"
 
-time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "common_parallel::$test_filter" -- ${test_binary_args[*]}
+time cargo nextest run $test_features --profile common_tests --no-tests=pass --test-threads=$(($(nproc) / 4)) "$test_filter" -- ${test_binary_args[*]}
 RES=$?
-
-# Run some tests in sequence since the result could be affected by other tests
-# running in parallel.
-if [ $RES -eq 0 ]; then
-    cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "common_sequential::$test_filter" -- ${test_binary_args[*]}
-    RES=$?
-fi
 
 # Run tests on dbus_api
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,dbus_api" --all --release --target "$BUILD_TARGET"
     # integration tests now do not reply on build feature "dbus_api"
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "dbus_api::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --profile dbus --no-tests=pass --test-threads=$(($(nproc) / 4)) "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 
 # Run tests on fw_cfg
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,fw_cfg" --all --release --target "$BUILD_TARGET"
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "fw_cfg::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --profile fw_cfg --no-tests=pass --test-threads=$(($(nproc) / 4)) "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,ivshmem" --all --release --target "$BUILD_TARGET"
-    time cargo nextest run $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=$(($(nproc) / 4)) "ivshmem::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run $test_features --profile ivshmem --no-tests=pass --test-threads=$(($(nproc) / 4)) "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -8,6 +8,7 @@ source "$(dirname "$0")"/test-util.sh
 
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
+mkdir -p "$WORKLOADS_DIR/junit"
 
 process_common_args "$@"
 
@@ -225,34 +226,27 @@ if ! [[ "${PARALLEL_INTEGRATION_TESTS_NUM:-}" =~ ^[1-9][0-9]*$ ]]; then
     PARALLEL_INTEGRATION_TESTS_NUM="${TEST_THREADS_DEFAULT}"
 fi
 echo "nproc:$(nproc), parallel_integration_tests:${PARALLEL_INTEGRATION_TESTS_NUM}"
-time cargo nextest run -p cloud-hypervisor $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads="${PARALLEL_INTEGRATION_TESTS_NUM}" "common_parallel::$test_filter" -- ${test_binary_args[*]}
+time cargo nextest run -p cloud-hypervisor $test_features --profile common_tests --no-tests=pass --test-threads="${PARALLEL_INTEGRATION_TESTS_NUM}" "$test_filter" -- ${test_binary_args[*]}
 RES=$?
-
-# Run some tests in sequence since the result could be affected by other tests
-# running in parallel.
-if [ $RES -eq 0 ]; then
-    cargo nextest run -p cloud-hypervisor $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads=1 "common_sequential::$test_filter" -- ${test_binary_args[*]}
-    RES=$?
-fi
 
 # Run tests on dbus_api
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,dbus_api" --all --release --target "$BUILD_TARGET"
     # integration tests now do not reply on build feature "dbus_api"
-    time cargo nextest run -p cloud-hypervisor $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "dbus_api::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run -p cloud-hypervisor $test_features --profile dbus --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 
 # Run tests on fw_cfg
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,fw_cfg" --all --release --target "$BUILD_TARGET"
-    time cargo nextest run -p cloud-hypervisor $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "fw_cfg::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run -p cloud-hypervisor $test_features --profile fw_cfg --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,ivshmem" --all --release --target "$BUILD_TARGET"
-    time cargo nextest run -p cloud-hypervisor $test_features --retries 3 --no-fail-fast --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "ivshmem::$test_filter" -- ${test_binary_args[*]}
+    time cargo nextest run -p cloud-hypervisor $test_features --profile ivshmem --no-tests=pass --test-threads="$TEST_THREADS_DEFAULT" "$test_filter" -- ${test_binary_args[*]}
     RES=$?
 fi
 


### PR DESCRIPTION
Centralize test configuration (filters, retries, fail-fast, sequential/parallel scheduling) into nextest profiles, replacing scattered flags across shell scripts. This simplifies the scripts and provides a single source of truth for test behavior.

Enable JUnit XML output per profile, giving CI systems structured test results for better reporting.

Not all test invocations are converted to profiles yet. Just the ones that are repeated across scripts.