### PR TITLE
ci: Escape $ in heredoc in MSHV workflow script

### DIFF
--- a/.github/workflows/mshv-integration.yaml
+++ b/.github/workflows/mshv-integration.yaml
@@ -67,12 +67,12 @@ jobs:
 
             echo "Setting permissions..."
             for i in 0 1 2; do
-              dev="/dev/vhost-vdpa-$i"
-              if [ -e "$dev" ]; then
-                sudo chown $USER:$USER "$dev"
-                sudo chmod 660 "$dev"
+              dev="/dev/vhost-vdpa-\$i"
+              if [ -e "\$dev" ]; then
+                sudo chown \$USER:\$USER "\$dev"
+                sudo chmod 660 "\$dev"
               else
-                echo "Warning: Device $dev not found"
+                echo "Warning: Device \$dev not found"
               fi
             done
 


### PR DESCRIPTION
This is a preexisting bug in the MSHV integration tests, but previously it only caused a warning.  With commit 903938fe5ee7 ("ci: Properly escape $ in heredoc") it becomes an error.

Fixes: 903938fe5ee7 ("ci: Properly escape $ in heredoc")
Fixes: #7996 