### PR TITLE
virtio-devices: signal activated queue eventfds on resume

### DIFF
--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -384,6 +384,15 @@ impl Pausable for VirtioCommon {
             })?;
         }
 
+        // Also trigger interrupts into the guest to wake up the driver to avoid a "livelock"
+        if let Some(interrupt_cb) = &self.interrupt_cb {
+            for i in 0..self.queue_evts.len() {
+                interrupt_cb
+                    .trigger(crate::VirtioInterruptType::Queue(i as u16))
+                    .ok();
+            }
+        }
+
         Ok(())
     }
 }

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -254,20 +254,15 @@ impl VirtioCommon {
             return Err(ActivateError::BadActivate);
         }
 
-        // Do not retain virtio-net queue eventfds here. Signaling them on
-        // resume would break its `driver_awake` workaround.
-        self.queue_evts = match VirtioDeviceType::from(self.device_type) {
-            VirtioDeviceType::Net => Vec::new(),
-            _ => queues
-                .iter()
-                .map(|(_, _, queue_evt)| {
-                    queue_evt.try_clone().map_err(|e| {
-                        error!("failed cloning queue EventFd: {e}");
-                        ActivateError::BadActivate
-                    })
+        self.queue_evts = queues
+            .iter()
+            .map(|(_, _, queue_evt)| {
+                queue_evt.try_clone().map_err(|e| {
+                    error!("failed cloning queue EventFd: {e}");
+                    ActivateError::BadActivate
                 })
-                .collect::<Result<Vec<_>, _>>()?,
-        };
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         let kill_evt = EventFd::new(EFD_NONBLOCK).map_err(|e| {
             error!("failed creating kill EventFd: {e}");

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
 
+use anyhow::anyhow;
 use libc::EFD_NONBLOCK;
 use log::{error, info, warn};
 use virtio_queue::Queue;
@@ -215,6 +216,7 @@ pub struct VirtioCommon {
     pub paused_sync: Option<Arc<Barrier>>,
     pub epoll_threads: Option<Vec<thread::JoinHandle<()>>>,
     pub queue_sizes: Vec<u16>,
+    pub queue_evts: Vec<EventFd>,
     pub device_type: u32,
     pub min_queues: u16,
     pub access_platform: Option<Arc<dyn AccessPlatform>>,
@@ -252,6 +254,21 @@ impl VirtioCommon {
             return Err(ActivateError::BadActivate);
         }
 
+        // Do not retain virtio-net queue eventfds here. Signaling them on
+        // resume would break its `driver_awake` workaround.
+        self.queue_evts = match VirtioDeviceType::from(self.device_type) {
+            VirtioDeviceType::Net => Vec::new(),
+            _ => queues
+                .iter()
+                .map(|(_, _, queue_evt)| {
+                    queue_evt.try_clone().map_err(|e| {
+                        error!("failed cloning queue EventFd: {e}");
+                        ActivateError::BadActivate
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        };
+
         let kill_evt = EventFd::new(EFD_NONBLOCK).map_err(|e| {
             error!("failed creating kill EventFd: {e}");
             ActivateError::BadActivate
@@ -272,6 +289,8 @@ impl VirtioCommon {
     }
 
     pub fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
+        self.queue_evts.clear();
+
         // We first must resume the virtio thread if it was paused.
         if self.pause_evt.take().is_some() {
             self.resume().ok()?;
@@ -353,6 +372,16 @@ impl Pausable for VirtioCommon {
             for t in epoll_threads.iter() {
                 t.thread().unpark();
             }
+        }
+
+        // Signal each activated queue eventfd so workers process restored queues
+        // that may already contain pending requests.
+        for queue_evt in &self.queue_evts {
+            queue_evt.write(1).map_err(|e| {
+                MigratableError::Resume(anyhow!(
+                    "Could not notify restored virtio worker on resume: {e}"
+                ))
+            })?;
         }
 
         Ok(())

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -174,11 +174,6 @@ struct NetEpollHandler {
     queue_index_base: u16,
     queue_pair: (Queue, Queue),
     queue_evt_pair: (EventFd, EventFd),
-    // Always generate interrupts until the driver has signalled to the device.
-    // This mitigates a problem with interrupts from tap events being "lost" upon
-    // a restore as the vCPU thread isn't ready to handle the interrupt. This causes
-    // issues when combined with VIRTIO_RING_F_EVENT_IDX interrupt suppression.
-    driver_awake: bool,
     device_status: Arc<AtomicU8>,
 }
 
@@ -260,7 +255,7 @@ Setting device status to 'NEEDS_RESET' and stopping processing queues until rese
             return Ok(());
         }
 
-        if res.map_err(DeviceError::NetQueuePair)? || !self.driver_awake {
+        if res.map_err(DeviceError::NetQueuePair)? {
             self.signal_used_queue(self.queue_index_base + 1)?;
             debug!("Signalling TX queue");
         } else {
@@ -296,7 +291,7 @@ Setting device status to 'NEEDS_RESET' and stopping processing queues until rese
             return Ok(());
         }
 
-        if res.map_err(DeviceError::NetQueuePair)? || !self.driver_awake {
+        if res.map_err(DeviceError::NetQueuePair)? {
             self.signal_used_queue(self.queue_index_base)?;
             debug!("Signalling RX queue");
         } else {
@@ -361,7 +356,6 @@ impl EpollHelperHandler for NetEpollHandler {
         let ev_type = event.data as u16;
         match ev_type {
             RX_QUEUE_EVENT => {
-                self.driver_awake = true;
                 self.handle_rx_event().map_err(|e| {
                     EpollHelperError::HandleEvent(anyhow!("Error processing RX queue: {e:?}"))
                 })?;
@@ -371,7 +365,6 @@ impl EpollHelperHandler for NetEpollHandler {
                 if let Err(e) = queue_evt.read() {
                     error!("Failed to get tx queue event: {e:?}");
                 }
-                self.driver_awake = true;
                 self.handle_tx_event().map_err(|e| {
                     EpollHelperError::HandleEvent(anyhow!("Error processing TX queue: {e:?}"))
                 })?;
@@ -428,8 +421,6 @@ impl EpollHelperHandler for NetEpollHandler {
                             "Error from 'rate_limiter.event_handler()': {e:?}"
                         ))
                     })?;
-
-                    self.driver_awake = true;
                     self.process_tx().map_err(|e| {
                         EpollHelperError::HandleEvent(anyhow!("Error processing TX queue: {e:?}"))
                     })?;
@@ -855,7 +846,6 @@ impl VirtioDevice for Net {
                 interrupt_cb: interrupt_cb.clone(),
                 kill_evt,
                 pause_evt,
-                driver_awake: false,
                 device_status: self.device_status.clone(),
             };
 


### PR DESCRIPTION
This PR fixes a deadlock, we found and fixed in our fork in https://github.com/cyberus-technology/cloud-hypervisor/pull/138.
It is [part](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7944) of a [series](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7945) of fixes for boot failures and deadlocks observed by our [integration test](https://github.com/cyberus-technology/libvirt-tests) `test_save_restore_during_boot`.

It might contribute to stabilize CI as per https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7994. 
I don't have the Windows image used by CI, and I was unable to run the Windows integration tests locally yet.

Could you @weltling @russell-islam help me verify if this fixes the CI flakiness problem?

--- 

We observed a guest hang when doing snapshot/restore during early boot (mid-firmware).
This is a very time-sensitive bug: we reproduce it by creating a snapshot with a random sleep offset between 2 - 5 seconds after the VM is created and rerunning this test dozens of times.

I was able to reproduce this bug upstream as well.

With temporary probing logs in EDK2 and Cloud Hypervisor, we traced the failure to the virtio-blk restore path: the guest had already placed a request into the virtqueue before the snapshot, but after restore the worker waited for a new kick that never came.

### Symptom

In failing runs, the guest got stuck in firmware while waiting for virtio-blk progress. With temporary EDK2 probing, the last visible firmware progress was in the blk flush path:
 ```text
  FatVolumeFlushCache: calling FlushBlocks
  VirtioBlkFlushBlocks: WriteCaching=1
  VirtioBlk: flush request start
```
At the same time, temporary Cloud Hypervisor probing showed that the restored virtio-blk queue already contained pending work, but the worker still went to sleep waiting for a fresh queue event.
 
### Cause
The problem appears when work was already pending in a virtqueue at snapshot time. 
The sequence is:

1. The guest places a request into the virtqueue.
2. The guest notifies the device.
3. The snapshot captures the queue contents.
4. Restore recreates the host-side eventfds.
5. The worker waits for a new queue eventfd signal.
6. The guest does not notify again because it already did so before the snapshot.

The queue state is preserved because it lives in guest memory and is part of the snapshot. 
The host-side wakeup is different: it is not durable snapshot state. This can leave a restored queue non-empty while the guest is still waiting for completion.

In our case that stalled firmware block I/O and prevented boot from making further progress.

### Fix

This change handles that case in the shared virtio resume path.

For activated virtio devices, Cloud Hypervisor now retains the queue eventfds needed to re-signal restored queues once on resume. This lets the existing worker logic re-check queues that may already contain pending descriptors after restore, instead of waiting indefinitely for a queue eventfd signal that may never arrive.

Virtio-net remains excluded from this common path. Its queue eventfds are not retained for resume-time signaling, so its existing driver_awake workaround remains unchanged.