### PR TITLE
block: qcow: Fix QCOW2 + O_DIRECT writes failing with EINVAL

### DIFF
--- a/block/src/qcow/raw_file.rs
+++ b/block/src/qcow/raw_file.rs
@@ -125,6 +125,10 @@ impl RawFile {
         self.direct_io
     }
 
+    pub fn alignment(&self) -> usize {
+        self.alignment
+    }
+
     /// Returns true if the file was opened with write access.
     pub fn is_writable(&self) -> bool {
         // SAFETY: fcntl with F_GETFL is safe and doesn't modify the file descriptor

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -27,7 +27,8 @@ use crate::qcow::metadata::{
 use crate::qcow::qcow_raw_file::QcowRawFile;
 use crate::qcow::{MAX_NESTING_DEPTH, RawFile, parse_qcow};
 use crate::qcow_common::{
-    gather_from_iovecs, pread_exact, pwrite_all, scatter_to_iovecs, zero_fill_iovecs,
+    AlignedBuf, aligned_pread, aligned_pwrite, gather_from_iovecs_into, pread_exact, pwrite_all,
+    scatter_to_iovecs, zero_fill_iovecs,
 };
 use crate::{BatchRequest, RequestType, disk_file};
 
@@ -172,6 +173,8 @@ pub struct QcowAsync {
     data_file: QcowRawFile,
     backing_file: Option<Arc<dyn BackingRead>>,
     sparse: bool,
+    /// O_DIRECT alignment requirement (0 = no alignment needed).
+    alignment: usize,
     io_uring: IoUring,
     eventfd: EventFd,
     completion_list: VecDeque<(u64, i32)>,
@@ -185,6 +188,7 @@ impl QcowAsync {
         sparse: bool,
         ring_depth: u32,
     ) -> io::Result<Self> {
+        let alignment = data_file.file().alignment();
         let io_uring = IoUring::new(ring_depth)?;
         let eventfd = EventFd::new(libc::EFD_NONBLOCK)?;
         io_uring.submitter().register_eventfd(eventfd.as_raw_fd())?;
@@ -194,6 +198,7 @@ impl QcowAsync {
             data_file,
             backing_file,
             sparse,
+            alignment,
             io_uring,
             eventfd,
             completion_list: VecDeque::new(),
@@ -241,6 +246,7 @@ impl AsyncIo for QcowAsync {
             offset as u64,
             iovecs,
             total_len,
+            self.alignment,
         )? {
             let fd = self.data_file.as_raw_fd();
             let (submitter, mut sq, _) = self.io_uring.split();
@@ -285,6 +291,7 @@ impl AsyncIo for QcowAsync {
             &self.metadata,
             &self.data_file,
             &self.backing_file,
+            self.alignment,
         )?;
 
         let total_len: usize = iovecs.iter().map(|v| v.iov_len).sum();
@@ -377,6 +384,7 @@ impl AsyncIo for QcowAsync {
                         req.offset as u64,
                         &req.iovecs,
                         total_len,
+                        self.alignment,
                     )? {
                         let fd = self.data_file.as_raw_fd();
                         // SAFETY: fd is valid and iovecs point to valid guest memory.
@@ -408,6 +416,7 @@ impl AsyncIo for QcowAsync {
                         &self.metadata,
                         &self.data_file,
                         &self.backing_file,
+                        self.alignment,
                     )?;
                     sync_completions.push((req.user_data, total_len as i32));
                 }
@@ -448,6 +457,7 @@ impl QcowAsync {
         address: u64,
         iovecs: &[libc::iovec],
         total_len: usize,
+        alignment: usize,
     ) -> AsyncIoResult<Option<u64>> {
         let has_backing = backing_file.is_some();
         let mappings = metadata
@@ -464,7 +474,7 @@ impl QcowAsync {
             return Ok(Some(*host_offset));
         }
 
-        Self::scatter_read_sync(mappings, iovecs, data_file, backing_file)?;
+        Self::scatter_read_sync(mappings, iovecs, data_file, backing_file, alignment)?;
         Ok(None)
     }
 
@@ -474,6 +484,7 @@ impl QcowAsync {
         iovecs: &[libc::iovec],
         data_file: &QcowRawFile,
         backing_file: &Option<Arc<dyn BackingRead>>,
+        alignment: usize,
     ) -> AsyncIoResult<()> {
         let mut buf_offset = 0usize;
         for mapping in mappings {
@@ -489,12 +500,27 @@ impl QcowAsync {
                     offset: host_offset,
                     length,
                 } => {
-                    let mut buf = vec![0u8; length as usize];
-                    pread_exact(data_file.as_raw_fd(), &mut buf, host_offset)
+                    let len = length as usize;
+                    if alignment > 0 {
+                        let mut abuf =
+                            AlignedBuf::new(len, alignment).map_err(AsyncIoError::ReadVectored)?;
+                        aligned_pread(
+                            data_file.as_raw_fd(),
+                            abuf.as_mut_slice(len),
+                            host_offset,
+                            alignment,
+                        )
                         .map_err(AsyncIoError::ReadVectored)?;
-                    // SAFETY: iovecs point to valid guest memory buffers.
-                    unsafe { scatter_to_iovecs(iovecs, buf_offset, &buf) };
-                    buf_offset += length as usize;
+                        // SAFETY: iovecs point to valid guest memory buffers.
+                        unsafe { scatter_to_iovecs(iovecs, buf_offset, abuf.as_slice(len)) };
+                    } else {
+                        let mut buf = vec![0u8; len];
+                        pread_exact(data_file.as_raw_fd(), &mut buf, host_offset)
+                            .map_err(AsyncIoError::ReadVectored)?;
+                        // SAFETY: iovecs point to valid guest memory buffers.
+                        unsafe { scatter_to_iovecs(iovecs, buf_offset, &buf) };
+                    }
+                    buf_offset += len;
                 }
                 ClusterReadMapping::Compressed { data } => {
                     let len = data.len();
@@ -528,6 +554,7 @@ impl QcowAsync {
         metadata: &QcowMetadata,
         data_file: &QcowRawFile,
         backing_file: &Option<Arc<dyn BackingRead>>,
+        alignment: usize,
     ) -> AsyncIoResult<()> {
         let total_len: usize = iovecs.iter().map(|v| v.iov_len).sum();
         let cluster_size = metadata.cluster_size();
@@ -561,10 +588,31 @@ impl QcowAsync {
                 ClusterWriteMapping::Allocated {
                     offset: host_offset,
                 } => {
-                    // SAFETY: iovecs point to valid guest memory buffers.
-                    let buf = unsafe { gather_from_iovecs(iovecs, buf_offset, count) };
-                    pwrite_all(data_file.as_raw_fd(), &buf, host_offset)
+                    if alignment > 0 {
+                        // O_DIRECT, gather directly into aligned buffer.
+                        let mut abuf = AlignedBuf::new(count, alignment)
+                            .map_err(AsyncIoError::WriteVectored)?;
+                        // SAFETY: iovecs point to valid guest memory buffers
+                        unsafe {
+                            gather_from_iovecs_into(iovecs, buf_offset, abuf.as_mut_slice(count));
+                        }
+                        aligned_pwrite(
+                            data_file.as_raw_fd(),
+                            abuf.as_slice(count),
+                            host_offset,
+                            alignment,
+                        )
                         .map_err(AsyncIoError::WriteVectored)?;
+                    } else {
+                        // No O_DIRECT, plain buffer is fine.
+                        let mut buf = vec![0u8; count];
+                        // SAFETY: iovecs point to valid guest memory buffers.
+                        unsafe {
+                            gather_from_iovecs_into(iovecs, buf_offset, &mut buf);
+                        }
+                        pwrite_all(data_file.as_raw_fd(), &buf, host_offset)
+                            .map_err(AsyncIoError::WriteVectored)?;
+                    }
                 }
             }
             buf_offset += count;

--- a/block/src/qcow_common.rs
+++ b/block/src/qcow_common.rs
@@ -9,6 +9,7 @@
 //! Position-independent I/O (`pread_exact`, `pwrite_all`) and iovec
 //! scatter/gather helpers used by both `qcow_sync` and `qcow_async`.
 
+use std::alloc::{Layout, alloc_zeroed, dealloc};
 use std::cmp::min;
 use std::os::fd::RawFd;
 use std::{io, ptr, slice};
@@ -65,6 +66,98 @@ pub fn pwrite_all(fd: RawFd, buf: &[u8], offset: u64) -> io::Result<()> {
         total += ret as usize;
     }
     Ok(())
+}
+
+/// RAII wrapper for an aligned heap buffer required by O_DIRECT.
+pub struct AlignedBuf {
+    ptr: *mut u8,
+    layout: Layout,
+}
+
+impl AlignedBuf {
+    pub fn new(size: usize, alignment: usize) -> io::Result<Self> {
+        let size = size.max(1).next_multiple_of(alignment);
+        let layout = Layout::from_size_align(size, alignment)
+            .map_err(|e| io::Error::other(format!("invalid aligned layout: {e}")))?;
+        // SAFETY: layout has non-zero size.
+        let ptr = unsafe { alloc_zeroed(layout) };
+        if ptr.is_null() {
+            return Err(io::Error::new(
+                io::ErrorKind::OutOfMemory,
+                "aligned allocation failed",
+            ));
+        }
+        Ok(AlignedBuf { ptr, layout })
+    }
+
+    pub fn as_mut_slice(&mut self, len: usize) -> &mut [u8] {
+        let len = len.min(self.layout.size());
+        // SAFETY: ptr is valid for layout.size() bytes; len <= layout.size().
+        unsafe { slice::from_raw_parts_mut(self.ptr, len) }
+    }
+
+    pub fn as_slice(&self, len: usize) -> &[u8] {
+        let len = len.min(self.layout.size());
+        // SAFETY: ptr is valid for layout.size() bytes; len <= layout.size().
+        unsafe { slice::from_raw_parts(self.ptr, len) }
+    }
+
+    #[cfg(test)]
+    pub fn layout(&self) -> &Layout {
+        &self.layout
+    }
+
+    #[cfg(test)]
+    pub fn ptr(&self) -> *const u8 {
+        self.ptr
+    }
+}
+
+impl Drop for AlignedBuf {
+    fn drop(&mut self) {
+        // SAFETY: ptr was allocated by alloc_zeroed with self.layout.
+        unsafe { dealloc(self.ptr, self.layout) };
+    }
+}
+
+/// Read into `buf` via an aligned bounce buffer when O_DIRECT requires it.
+pub fn aligned_pread(fd: RawFd, buf: &mut [u8], offset: u64, alignment: usize) -> io::Result<()> {
+    if alignment == 0
+        || ((buf.as_ptr() as usize).is_multiple_of(alignment)
+            && buf.len().is_multiple_of(alignment)
+            && (offset as usize).is_multiple_of(alignment))
+    {
+        return pread_exact(fd, buf, offset);
+    }
+
+    let aligned_offset = offset & !(alignment as u64 - 1);
+    let head = (offset - aligned_offset) as usize;
+    let aligned_len = (head + buf.len()).next_multiple_of(alignment);
+    let mut bounce = AlignedBuf::new(aligned_len, alignment)?;
+    pread_exact(fd, bounce.as_mut_slice(aligned_len), aligned_offset)?;
+    buf.copy_from_slice(&bounce.as_slice(aligned_len)[head..head + buf.len()]);
+    Ok(())
+}
+
+/// Write `buf` via an aligned bounce buffer when O_DIRECT requires it.
+pub fn aligned_pwrite(fd: RawFd, buf: &[u8], offset: u64, alignment: usize) -> io::Result<()> {
+    if alignment == 0
+        || ((buf.as_ptr() as usize).is_multiple_of(alignment)
+            && buf.len().is_multiple_of(alignment)
+            && (offset as usize).is_multiple_of(alignment))
+    {
+        return pwrite_all(fd, buf, offset);
+    }
+
+    let aligned_offset = offset & !(alignment as u64 - 1);
+    let head = (offset - aligned_offset) as usize;
+    let aligned_len = (head + buf.len()).next_multiple_of(alignment);
+    let mut bounce = AlignedBuf::new(aligned_len, alignment)?;
+
+    // Read-modify-write: read the existing aligned region, overlay our data.
+    pread_exact(fd, bounce.as_mut_slice(aligned_len), aligned_offset)?;
+    bounce.as_mut_slice(aligned_len)[head..head + buf.len()].copy_from_slice(buf);
+    pwrite_all(fd, bounce.as_slice(aligned_len), aligned_offset)
 }
 
 // -- iovec helper functions --
@@ -129,33 +222,43 @@ pub unsafe fn zero_fill_iovecs(iovecs: &[libc::iovec], start: usize, len: usize)
     }
 }
 
-/// Gather bytes from iovecs starting at the given byte offset into a Vec.
+/// Gather bytes from iovecs starting at the given byte offset into `dst`.
 ///
 /// # Safety
 /// Caller must ensure iovecs point to valid, readable memory of sufficient size.
-pub unsafe fn gather_from_iovecs(iovecs: &[libc::iovec], start: usize, len: usize) -> Vec<u8> {
-    let mut result = Vec::with_capacity(len);
-    let mut remaining = len;
+pub unsafe fn gather_from_iovecs_into(iovecs: &[libc::iovec], start: usize, dst: &mut [u8]) {
+    let len = dst.len();
+    let mut written = 0usize;
     let mut pos = 0usize;
     for iov in iovecs {
         let iov_end = pos + iov.iov_len;
-        if iov_end <= start || remaining == 0 {
+        if iov_end <= start || written == len {
             pos = iov_end;
             continue;
         }
         let iov_start = start.saturating_sub(pos);
         let available = iov.iov_len - iov_start;
-        let count = min(available, remaining);
+        let count = min(available, len - written);
         // SAFETY: iov_base is valid for iov_len bytes per caller contract.
         unsafe {
             let src = (iov.iov_base as *const u8).add(iov_start);
-            result.extend_from_slice(slice::from_raw_parts(src, count));
+            ptr::copy_nonoverlapping(src, dst.as_mut_ptr().add(written), count);
         }
-        remaining -= count;
-        if remaining == 0 {
+        written += count;
+        if written == len {
             break;
         }
         pos = iov_end;
     }
+}
+
+/// Gather bytes from iovecs starting at the given byte offset into a Vec.
+///
+/// # Safety
+/// Caller must ensure iovecs point to valid, readable memory of sufficient size.
+pub unsafe fn gather_from_iovecs(iovecs: &[libc::iovec], start: usize, len: usize) -> Vec<u8> {
+    let mut result = vec![0u8; len];
+    // SAFETY: caller guarantees iovecs are valid; result has len bytes.
+    unsafe { gather_from_iovecs_into(iovecs, start, &mut result) };
     result
 }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -419,6 +419,7 @@ impl AsyncIo for QcowSync {
 #[cfg(test)]
 mod unit_tests {
     use std::io::{Seek, SeekFrom, Write};
+    use std::os::fd::RawFd;
     use std::thread;
 
     use vmm_sys_util::tempfile::TempFile;
@@ -1718,5 +1719,37 @@ mod unit_tests {
     #[test]
     fn test_multi_iovec_read_write_direct_io() {
         test_multi_iovec_read_write_impl(true);
+    }
+
+    // -- Low level aligned I/O function tests --
+    //
+    // Test aligned_pread and aligned_pwrite directly with controlled
+    // alignment values on a plain temp file.
+
+    /// Create a temp file filled with a repeating pattern of the given size.
+    /// Returns the TempFile (must be kept alive) and the raw fd.
+    fn create_pattern_file(size: usize) -> (TempFile, RawFd) {
+        let tf = TempFile::new().unwrap();
+        let pattern: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+        tf.as_file().write_all(&pattern).unwrap();
+        tf.as_file().sync_all().unwrap();
+        let fd = tf.as_file().as_raw_fd();
+        (tf, fd)
+    }
+
+    #[test]
+    fn test_aligned_pread_pass_through() {
+        // When buffer address, length, and offset are all aligned,
+        // aligned_pread should take the fast path (no bounce buffer).
+        let size = 4096usize;
+        let (_tf, fd) = create_pattern_file(size);
+        let alignment = 512;
+
+        // Use AlignedBuf to guarantee buffer address alignment.
+        let mut abuf = AlignedBuf::new(size, alignment).unwrap();
+        aligned_pread(fd, abuf.as_mut_slice(size), 0, alignment).unwrap();
+
+        let expected: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+        assert_eq!(abuf.as_slice(size), &expected[..]);
     }
 }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -1884,4 +1884,23 @@ mod unit_tests {
         let after: Vec<u8> = (after_start..file_size).map(|i| (i % 251) as u8).collect();
         assert_eq!(&whole[after_start..], &after[..]);
     }
+
+    #[test]
+    fn test_aligned_buf_allocation_and_access() {
+        for alignment in [512, 4096] {
+            let size = 1024usize;
+            let mut abuf = AlignedBuf::new(size, alignment).unwrap();
+            let aligned_size = size.next_multiple_of(alignment);
+
+            assert!(
+                (abuf.ptr() as usize).is_multiple_of(alignment),
+                "ptr not aligned to {alignment}"
+            );
+            assert!(abuf.as_slice(aligned_size).iter().all(|&b| b == 0));
+
+            let pattern: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+            abuf.as_mut_slice(size).copy_from_slice(&pattern);
+            assert_eq!(abuf.as_slice(size), &pattern[..]);
+        }
+    }
 }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -1752,4 +1752,21 @@ mod unit_tests {
         let expected: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
         assert_eq!(abuf.as_slice(size), &expected[..]);
     }
+
+    #[test]
+    fn test_aligned_pread_bounce_unaligned_buffer() {
+        // Force a misaligned buffer so aligned_pread must take the
+        // bounce path. A plain vec![0u8; 4096] is often page-aligned
+        // by the allocator, which would skip the bounce entirely.
+        let size = 4096usize;
+        let (_tf, fd) = create_pattern_file(size);
+        let alignment = 512;
+
+        let mut backing = vec![0u8; size + 1];
+        let buf = &mut backing[1..size + 1];
+        aligned_pread(fd, buf, 0, alignment).unwrap();
+
+        let expected: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+        assert_eq!(buf, &expected[..]);
+    }
 }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -1856,4 +1856,32 @@ mod unit_tests {
         let after: Vec<u8> = (after_start..file_size).map(|i| (i % 251) as u8).collect();
         assert_eq!(&whole[after_start..], &after[..]);
     }
+
+    #[test]
+    fn test_aligned_pread_pwrite_4096_alignment() {
+        // Exercise aligned I/O with 4096 byte alignment.
+        let file_size = 16384usize;
+        let (_tf, fd) = create_pattern_file(file_size);
+        let alignment = 4096;
+
+        // Write 4096 bytes at offset 4096 via unaligned Vec<u8>.
+        let offset = 4096u64;
+        let len = 4096usize;
+        let data: Vec<u8> = (0..len).map(|i| ((i + 1) % 239) as u8).collect();
+        aligned_pwrite(fd, &data, offset, alignment).unwrap();
+
+        // Read back the written region via unaligned Vec<u8>.
+        let mut buf = vec![0u8; len];
+        aligned_pread(fd, &mut buf, offset, alignment).unwrap();
+        assert_eq!(buf, data);
+
+        // Verify untouched regions.
+        let mut whole = vec![0u8; file_size];
+        pread_exact(fd, &mut whole, 0).unwrap();
+        let before: Vec<u8> = (0..offset as usize).map(|i| (i % 251) as u8).collect();
+        assert_eq!(&whole[..offset as usize], &before[..]);
+        let after_start = offset as usize + len;
+        let after: Vec<u8> = (after_start..file_size).map(|i| (i % 251) as u8).collect();
+        assert_eq!(&whole[after_start..], &after[..]);
+    }
 }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -1825,4 +1825,35 @@ mod unit_tests {
         pread_exact(fd, &mut readback, 0).unwrap();
         assert_eq!(readback, data);
     }
+
+    #[test]
+    fn test_aligned_pwrite_unaligned_offset() {
+        // Write at an offset that is not a multiple of alignment.
+        // aligned_pwrite should do read-modify-write and preserve
+        // surrounding data.
+        let file_size = 8192usize;
+        let (_tf, fd) = create_pattern_file(file_size);
+        let alignment = 512;
+
+        let offset = 100u64;
+        let len = 200usize;
+        let data: Vec<u8> = (0..len).map(|i| ((i + 1) % 239) as u8).collect();
+        aligned_pwrite(fd, &data, offset, alignment).unwrap();
+
+        // Read entire file and verify the written region plus untouched areas.
+        let mut whole = vec![0u8; file_size];
+        pread_exact(fd, &mut whole, 0).unwrap();
+
+        // Before the write region: original pattern.
+        let before: Vec<u8> = (0..offset as usize).map(|i| (i % 251) as u8).collect();
+        assert_eq!(&whole[..offset as usize], &before[..]);
+
+        // The written region.
+        assert_eq!(&whole[offset as usize..offset as usize + len], &data[..]);
+
+        // After the write region: original pattern.
+        let after_start = offset as usize + len;
+        let after: Vec<u8> = (after_start..file_size).map(|i| (i % 251) as u8).collect();
+        assert_eq!(&whole[after_start..], &after[..]);
+    }
 }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -1636,4 +1636,87 @@ mod unit_tests {
             "size should be unchanged after failed resize"
         );
     }
+
+    fn test_multi_iovec_read_write_impl(direct_io: bool) {
+        // Exercise scatter/gather with multiple iovecs per operation.
+        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &[], 0, true, direct_io);
+
+        // Write: 3 iovecs with distinct patterns
+        let a = vec![0xAAu8; 16 * 1024];
+        let b = vec![0xBBu8; 32 * 1024];
+        let c = vec![0xCCu8; 16 * 1024];
+        let iovecs_w = [
+            libc::iovec {
+                iov_base: a.as_ptr() as *mut libc::c_void,
+                iov_len: a.len(),
+            },
+            libc::iovec {
+                iov_base: b.as_ptr() as *mut libc::c_void,
+                iov_len: b.len(),
+            },
+            libc::iovec {
+                iov_base: c.as_ptr() as *mut libc::c_void,
+                iov_len: c.len(),
+            },
+        ];
+        let total = a.len() + b.len() + c.len();
+
+        let mut aio = disk.new_async_io(1).unwrap();
+        aio.write_vectored(0, &iovecs_w, 1).unwrap();
+        let (ud, res) = aio.next_completed_request().unwrap();
+        assert_eq!(ud, 1);
+        assert_eq!(res as usize, total);
+        aio.fsync(Some(2)).unwrap();
+        drop(aio);
+
+        // Read back into 3 iovecs of different sizes
+        let mut r1 = vec![0u8; 8 * 1024];
+        let mut r2 = vec![0u8; 48 * 1024];
+        let mut r3 = vec![0u8; 8 * 1024];
+        let iovecs_r = [
+            libc::iovec {
+                iov_base: r1.as_mut_ptr() as *mut libc::c_void,
+                iov_len: r1.len(),
+            },
+            libc::iovec {
+                iov_base: r2.as_mut_ptr() as *mut libc::c_void,
+                iov_len: r2.len(),
+            },
+            libc::iovec {
+                iov_base: r3.as_mut_ptr() as *mut libc::c_void,
+                iov_len: r3.len(),
+            },
+        ];
+
+        let mut aio = disk.new_async_io(1).unwrap();
+        aio.read_vectored(0, &iovecs_r, 10).unwrap();
+        let (ud, res) = aio.next_completed_request().unwrap();
+        assert_eq!(ud, 10);
+        assert_eq!(res as usize, total);
+        drop(aio);
+
+        // Reassemble the read buffers into a flat vec
+        let mut got = Vec::with_capacity(total);
+        got.extend_from_slice(&r1);
+        got.extend_from_slice(&r2);
+        got.extend_from_slice(&r3);
+
+        // Build expected from the write buffers
+        let mut expected = Vec::with_capacity(total);
+        expected.extend_from_slice(&a);
+        expected.extend_from_slice(&b);
+        expected.extend_from_slice(&c);
+
+        assert_eq!(got, expected, "Multi iovec read should match written data");
+    }
+
+    #[test]
+    fn test_multi_iovec_read_write() {
+        test_multi_iovec_read_write_impl(false);
+    }
+
+    #[test]
+    fn test_multi_iovec_read_write_direct_io() {
+        test_multi_iovec_read_write_impl(true);
+    }
 }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -1807,4 +1807,22 @@ mod unit_tests {
         pread_exact(fd, &mut readback, 0).unwrap();
         assert_eq!(readback, data);
     }
+
+    #[test]
+    fn test_aligned_pwrite_bounce_unaligned_buffer() {
+        // Force a misaligned buffer so aligned_pwrite must take the
+        // bounce path. A plain vec![0u8; 4096] is often page-aligned
+        // by the allocator, which would skip the bounce entirely.
+        let size = 4096usize;
+        let (_tf, fd) = create_pattern_file(size);
+        let alignment = 512;
+
+        let backing: Vec<u8> = (0..size + 1).map(|i| ((i + 1) % 251) as u8).collect();
+        let data = &backing[1..size + 1];
+        aligned_pwrite(fd, data, 0, alignment).unwrap();
+
+        let mut readback = vec![0u8; size];
+        pread_exact(fd, &mut readback, 0).unwrap();
+        assert_eq!(readback, data);
+    }
 }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -1903,4 +1903,13 @@ mod unit_tests {
             assert_eq!(abuf.as_slice(size), &pattern[..]);
         }
     }
+
+    #[test]
+    fn test_aligned_buf_size_rounds_up() {
+        let abuf = AlignedBuf::new(1, 512).unwrap();
+        assert_eq!(abuf.layout().size(), 512);
+
+        let abuf = AlignedBuf::new(513, 512).unwrap();
+        assert_eq!(abuf.layout().size(), 1024);
+    }
 }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -1769,4 +1769,24 @@ mod unit_tests {
         let expected: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
         assert_eq!(buf, &expected[..]);
     }
+
+    #[test]
+    fn test_aligned_pread_unaligned_offset() {
+        // Read at an offset that is not a multiple of alignment.
+        // aligned_pread should round down the offset, read an aligned
+        // region, then copy the correct slice into the caller buffer.
+        let file_size = 8192usize;
+        let (_tf, fd) = create_pattern_file(file_size);
+        let alignment = 512;
+
+        let offset = 100u64;
+        let len = 200usize;
+        let mut buf = vec![0u8; len];
+        aligned_pread(fd, &mut buf, offset, alignment).unwrap();
+
+        let expected: Vec<u8> = (offset as usize..offset as usize + len)
+            .map(|i| (i % 251) as u8)
+            .collect();
+        assert_eq!(buf, expected);
+    }
 }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -1789,4 +1789,22 @@ mod unit_tests {
             .collect();
         assert_eq!(buf, expected);
     }
+
+    #[test]
+    fn test_aligned_pwrite_pass_through() {
+        // When buffer address, length, and offset are all aligned,
+        // aligned_pwrite should take the fast path.
+        let size = 4096usize;
+        let (_tf, fd) = create_pattern_file(size);
+        let alignment = 512;
+
+        let data: Vec<u8> = (0..size).map(|i| ((i + 1) % 251) as u8).collect();
+        let mut abuf = AlignedBuf::new(size, alignment).unwrap();
+        abuf.as_mut_slice(size).copy_from_slice(&data);
+        aligned_pwrite(fd, abuf.as_slice(size), 0, alignment).unwrap();
+
+        let mut readback = vec![0u8; size];
+        pread_exact(fd, &mut readback, 0).unwrap();
+        assert_eq!(readback, data);
+    }
 }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -432,6 +432,7 @@ mod unit_tests {
         data: &[u8],
         offset: u64,
         sparse: bool,
+        direct_io: bool,
     ) -> (TempFile, QcowDiskSync) {
         let temp_file = TempFile::new().unwrap();
         {
@@ -443,7 +444,7 @@ mod unit_tests {
         }
         let disk = QcowDiskSync::new(
             temp_file.as_file().try_clone().unwrap(),
-            false,
+            direct_io,
             false,
             sparse,
         )
@@ -485,7 +486,7 @@ mod unit_tests {
     fn test_qcow_async_punch_hole_completion() {
         let data = vec![0xDD; 128 * 1024];
         let offset = 0u64;
-        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true);
+        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true, false);
 
         let mut async_io = disk.new_async_io(1).unwrap();
         async_io.punch_hole(offset, data.len() as u64, 100).unwrap();
@@ -505,7 +506,7 @@ mod unit_tests {
     fn test_qcow_async_write_zeroes_completion() {
         let data = vec![0xEE; 256 * 1024];
         let offset = 64 * 1024u64;
-        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true);
+        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true, false);
 
         let mut async_io = disk.new_async_io(1).unwrap();
         async_io
@@ -526,7 +527,7 @@ mod unit_tests {
     #[test]
     fn test_qcow_async_multiple_operations() {
         let data = vec![0xFF; 64 * 1024];
-        let (_temp, _) = create_disk_with_data(100 * 1024 * 1024, &[], 0, true);
+        let (_temp, _) = create_disk_with_data(100 * 1024 * 1024, &[], 0, true, false);
 
         // Write data at multiple offsets via QcowFile first, then punch
         {
@@ -567,7 +568,7 @@ mod unit_tests {
         // Verify that after punch_hole, a second async_io sees zeros.
         let data = vec![0xAB; 128 * 1024];
         let offset = 0u64;
-        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true);
+        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true, false);
 
         let mut async_io1 = disk.new_async_io(1).unwrap();
         async_io1
@@ -591,7 +592,7 @@ mod unit_tests {
         // Simulates the real usage pattern of write data, punch hole, then read back.
         let data = vec![0xCD; 64 * 1024]; // one cluster
         let offset = 1024 * 1024u64; // 1MB offset
-        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true);
+        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true, false);
 
         // Punch hole to simulate DISCARD
         let mut async_io1 = disk.new_async_io(1).unwrap();
@@ -609,9 +610,8 @@ mod unit_tests {
         );
     }
 
-    #[test]
-    fn test_qcow_async_read_write_roundtrip() {
-        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &[], 0, true);
+    fn test_qcow_async_read_write_roundtrip_impl(direct_io: bool) {
+        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &[], 0, true, direct_io);
 
         let data = vec![0x42u8; 64 * 1024];
         let offset = 0u64;
@@ -630,9 +630,18 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_qcow_async_read_unallocated() {
+    fn test_qcow_async_read_write_roundtrip() {
+        test_qcow_async_read_write_roundtrip_impl(false);
+    }
+
+    #[test]
+    fn test_qcow_async_read_write_roundtrip_direct_io() {
+        test_qcow_async_read_write_roundtrip_impl(true);
+    }
+
+    fn test_qcow_async_read_unallocated_impl(direct_io: bool) {
         // Reading from an unallocated region should return zeros.
-        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &[], 0, true);
+        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &[], 0, true, direct_io);
         let read_buf = async_read(&disk, 0, 64 * 1024);
         assert!(
             read_buf.iter().all(|&b| b == 0),
@@ -641,8 +650,17 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_qcow_async_cross_cluster_read_write() {
-        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &[], 0, true);
+    fn test_qcow_async_read_unallocated() {
+        test_qcow_async_read_unallocated_impl(false);
+    }
+
+    #[test]
+    fn test_qcow_async_read_unallocated_direct_io() {
+        test_qcow_async_read_unallocated_impl(true);
+    }
+
+    fn test_qcow_async_cross_cluster_read_write_impl(direct_io: bool) {
+        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &[], 0, true, direct_io);
 
         // Default cluster size is 64KB. Write 96KB starting at 32KB to cross the boundary.
         let data: Vec<u8> = (0..96 * 1024).map(|i| (i % 251) as u8).collect();
@@ -662,7 +680,16 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_backing_file_read() {
+    fn test_qcow_async_cross_cluster_read_write() {
+        test_qcow_async_cross_cluster_read_write_impl(false);
+    }
+
+    #[test]
+    fn test_qcow_async_cross_cluster_read_write_direct_io() {
+        test_qcow_async_cross_cluster_read_write_impl(true);
+    }
+
+    fn test_backing_file_read_impl(direct_io: bool) {
         let backing_temp = TempFile::new().unwrap();
         let cluster_size = 1u64 << 16;
         let file_size = cluster_size * 4;
@@ -683,7 +710,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, false, true, true).unwrap();
+        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
 
         // Read first cluster - should come from backing file
         let buf = async_read(&disk, 0, cluster_size as usize);
@@ -719,7 +746,16 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_backing_file_read_qcow2_backing() {
+    fn test_backing_file_read() {
+        test_backing_file_read_impl(false);
+    }
+
+    #[test]
+    fn test_backing_file_read_direct_io() {
+        test_backing_file_read_impl(true);
+    }
+
+    fn test_backing_file_read_qcow2_backing_impl(direct_io: bool) {
         let backing_temp = TempFile::new().unwrap();
         let cluster_size = 1u64 << 16;
         let file_size = cluster_size * 4;
@@ -745,7 +781,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, false, true, true).unwrap();
+        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
 
         // Read first cluster - should come from QCOW2 backing
         let buf = async_read(&disk, 0, cluster_size as usize);
@@ -786,14 +822,23 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_multi_queue_concurrent_reads() {
+    fn test_backing_file_read_qcow2_backing() {
+        test_backing_file_read_qcow2_backing_impl(false);
+    }
+
+    #[test]
+    fn test_backing_file_read_qcow2_backing_direct_io() {
+        test_backing_file_read_qcow2_backing_impl(true);
+    }
+
+    fn test_multi_queue_concurrent_reads_impl(direct_io: bool) {
         // Verify that multiple queues (threads) can read simultaneously.
         // This exercises the RwLock + pread64 design: concurrent L2 cache hits
         // proceed in parallel and data reads are position independent.
         let cluster_size = 1u64 << 16;
         let file_size = cluster_size * 16;
         let pattern: Vec<u8> = (0..file_size as usize).map(|i| (i % 251) as u8).collect();
-        let (_temp, disk) = create_disk_with_data(file_size, &pattern, 0, true);
+        let (_temp, disk) = create_disk_with_data(file_size, &pattern, 0, true, direct_io);
         let disk = Arc::new(disk);
 
         let threads: Vec<_> = (0..8)
@@ -822,7 +867,16 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_multi_queue_concurrent_reads_qcow2_backing() {
+    fn test_multi_queue_concurrent_reads() {
+        test_multi_queue_concurrent_reads_impl(false);
+    }
+
+    #[test]
+    fn test_multi_queue_concurrent_reads_direct_io() {
+        test_multi_queue_concurrent_reads_impl(true);
+    }
+
+    fn test_multi_queue_concurrent_reads_qcow2_backing_impl(direct_io: bool) {
         // Same as above but reads go through a Qcow2Backing,
         // exercising concurrent metadata resolution + pread64 in the backing.
         let backing_temp = TempFile::new().unwrap();
@@ -850,7 +904,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = Arc::new(QcowDiskSync::new(file, false, true, true).unwrap());
+        let disk = Arc::new(QcowDiskSync::new(file, direct_io, true, true).unwrap());
 
         let threads: Vec<_> = (0..8)
             .map(|t| {
@@ -877,7 +931,16 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_three_layer_backing_chain() {
+    fn test_multi_queue_concurrent_reads_qcow2_backing() {
+        test_multi_queue_concurrent_reads_qcow2_backing_impl(false);
+    }
+
+    #[test]
+    fn test_multi_queue_concurrent_reads_qcow2_backing_direct_io() {
+        test_multi_queue_concurrent_reads_qcow2_backing_impl(true);
+    }
+
+    fn test_three_layer_backing_chain_impl(direct_io: bool) {
         // raw base -> qcow2 mid -> qcow2 overlay
         // Tests recursive shared_backing_from() with nested backing.
         let cluster_size = 1u64 << 16;
@@ -924,7 +987,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, false, true, true).unwrap();
+        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
 
         // Cluster 0: mid wrote 0xBB
         let buf = async_read(&disk, 0, cluster_size as usize);
@@ -960,7 +1023,16 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_backing_cow_preserves_all_unwritten_clusters() {
+    fn test_three_layer_backing_chain() {
+        test_three_layer_backing_chain_impl(false);
+    }
+
+    #[test]
+    fn test_three_layer_backing_chain_direct_io() {
+        test_three_layer_backing_chain_impl(true);
+    }
+
+    fn test_backing_cow_preserves_all_unwritten_clusters_impl(direct_io: bool) {
         // Write to specific clusters in the overlay, verify all others still
         // read from the qcow2 backing correctly.
         let cluster_size = 1u64 << 16;
@@ -990,7 +1062,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, false, true, true).unwrap();
+        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
 
         let written = vec![0xFFu8; cluster_size as usize];
         for &idx in &[0u64, 3, 7] {
@@ -1025,7 +1097,16 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_qcow2_backing_read_beyond_virtual_size() {
+    fn test_backing_cow_preserves_all_unwritten_clusters() {
+        test_backing_cow_preserves_all_unwritten_clusters_impl(false);
+    }
+
+    #[test]
+    fn test_backing_cow_preserves_all_unwritten_clusters_direct_io() {
+        test_backing_cow_preserves_all_unwritten_clusters_impl(true);
+    }
+
+    fn test_qcow2_backing_read_beyond_virtual_size_impl(direct_io: bool) {
         // Read starting past the backing file virtual_size should return zeros.
         let cluster_size = 1u64 << 16;
         let backing_size = cluster_size * 2;
@@ -1053,7 +1134,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, false, true, true).unwrap();
+        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
 
         // Read cluster 2 (past backing virtual_size) - should be zeros
         let buf = async_read(&disk, backing_size, cluster_size as usize);
@@ -1064,7 +1145,16 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_qcow2_backing_read_spanning_virtual_size() {
+    fn test_qcow2_backing_read_beyond_virtual_size() {
+        test_qcow2_backing_read_beyond_virtual_size_impl(false);
+    }
+
+    #[test]
+    fn test_qcow2_backing_read_beyond_virtual_size_direct_io() {
+        test_qcow2_backing_read_beyond_virtual_size_impl(true);
+    }
+
+    fn test_qcow2_backing_read_spanning_virtual_size_impl(direct_io: bool) {
         // Read that starts within backing bounds but extends past virtual_size.
         // First part should have backing data, remainder should be zeros.
         let cluster_size = 1u64 << 16;
@@ -1094,7 +1184,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, false, true, true).unwrap();
+        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
 
         // Read 2 clusters starting at cluster 1 (spans backing boundary)
         let read_len = cluster_size as usize * 2;
@@ -1114,7 +1204,16 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_raw_backing_read_beyond_virtual_size() {
+    fn test_qcow2_backing_read_spanning_virtual_size() {
+        test_qcow2_backing_read_spanning_virtual_size_impl(false);
+    }
+
+    #[test]
+    fn test_qcow2_backing_read_spanning_virtual_size_direct_io() {
+        test_qcow2_backing_read_spanning_virtual_size_impl(true);
+    }
+
+    fn test_raw_backing_read_beyond_virtual_size_impl(direct_io: bool) {
         // Read past raw backing file virtual_size should return zeros.
         let cluster_size = 1u64 << 16;
         let backing_size = cluster_size * 2;
@@ -1138,7 +1237,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, false, true, true).unwrap();
+        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
 
         // Read cluster 2 (past backing size) - should be zeros
         let buf = async_read(&disk, backing_size, cluster_size as usize);
@@ -1161,7 +1260,16 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_qcow2_backing_cross_cluster_read() {
+    fn test_raw_backing_read_beyond_virtual_size() {
+        test_raw_backing_read_beyond_virtual_size_impl(false);
+    }
+
+    #[test]
+    fn test_raw_backing_read_beyond_virtual_size_direct_io() {
+        test_raw_backing_read_beyond_virtual_size_impl(true);
+    }
+
+    fn test_qcow2_backing_cross_cluster_read_impl(direct_io: bool) {
         // Read spanning a cluster boundary through qcow2 backing.
         // Exercises the read_clusters loop in Qcow2Backing.
         let cluster_size = 1u64 << 16;
@@ -1190,7 +1298,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, false, true, true).unwrap();
+        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
 
         // Read spanning clusters 1-2 boundary: 512 bytes before + 512 after
         let mid = cluster_size - 512;
@@ -1214,7 +1322,16 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_punch_hole_with_backing_fallthrough() {
+    fn test_qcow2_backing_cross_cluster_read() {
+        test_qcow2_backing_cross_cluster_read_impl(false);
+    }
+
+    #[test]
+    fn test_qcow2_backing_cross_cluster_read_direct_io() {
+        test_qcow2_backing_cross_cluster_read_impl(true);
+    }
+
+    fn test_punch_hole_with_backing_fallthrough_impl(direct_io: bool) {
         // Write to overlay, then punch hole. After punch, the cluster should
         // fall through to backing data (not zeros).
         let cluster_size = 1u64 << 16;
@@ -1238,7 +1355,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, false, true, true).unwrap();
+        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
 
         let written = vec![0xFFu8; cluster_size as usize];
         async_write(&disk, 0, &written);
@@ -1277,10 +1394,19 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_rewrite_allocated_cluster() {
+    fn test_punch_hole_with_backing_fallthrough() {
+        test_punch_hole_with_backing_fallthrough_impl(false);
+    }
+
+    #[test]
+    fn test_punch_hole_with_backing_fallthrough_direct_io() {
+        test_punch_hole_with_backing_fallthrough_impl(true);
+    }
+
+    fn test_rewrite_allocated_cluster_impl(direct_io: bool) {
         // Write to a cluster, then overwrite it. The second write should hit
         // the already allocated path in map_write (no new cluster allocation).
-        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &[], 0, true);
+        let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &[], 0, true, direct_io);
         let cluster_size = 1u64 << 16;
 
         let data1 = vec![0xAAu8; cluster_size as usize];
@@ -1306,7 +1432,16 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_partial_cluster_write_with_backing_cow() {
+    fn test_rewrite_allocated_cluster() {
+        test_rewrite_allocated_cluster_impl(false);
+    }
+
+    #[test]
+    fn test_rewrite_allocated_cluster_direct_io() {
+        test_rewrite_allocated_cluster_impl(true);
+    }
+
+    fn test_partial_cluster_write_with_backing_cow_impl(direct_io: bool) {
         // Partial cluster write to an overlay with a backing file triggers COW.
         // The unwritten part of the cluster must be copied from backing.
         let cluster_size = 1u64 << 16;
@@ -1330,7 +1465,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, false, true, true).unwrap();
+        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
 
         // Write 4KB at offset 4KB within cluster 0 (partial cluster)
         let write_offset = 4096u64;
@@ -1367,6 +1502,16 @@ mod unit_tests {
     }
 
     #[test]
+    fn test_partial_cluster_write_with_backing_cow() {
+        test_partial_cluster_write_with_backing_cow_impl(false);
+    }
+
+    #[test]
+    fn test_partial_cluster_write_with_backing_cow_direct_io() {
+        test_partial_cluster_write_with_backing_cow_impl(true);
+    }
+
+    #[test]
     fn test_partial_cluster_deallocate() {
         // Punch hole on a partial cluster range. The deallocate_bytes path
         // should produce WriteZeroes actions for partial clusters.
@@ -1376,7 +1521,7 @@ mod unit_tests {
         let data: Vec<u8> = (0..2 * cluster_size as usize)
             .map(|i| (i % 251) as u8)
             .collect();
-        let (_temp, disk) = create_disk_with_data(file_size, &data, 0, true);
+        let (_temp, disk) = create_disk_with_data(file_size, &data, 0, true, false);
 
         // Punch a partial range: last 4KB of cluster 0 + first 4KB of cluster 1
         let punch_offset = cluster_size - 4096;
@@ -1420,7 +1565,7 @@ mod unit_tests {
         let cluster_size = 1u64 << 16;
         let initial_size = cluster_size * 4;
         let data = vec![0xAA; cluster_size as usize];
-        let (_temp, mut disk) = create_disk_with_data(initial_size, &data, 0, true);
+        let (_temp, mut disk) = create_disk_with_data(initial_size, &data, 0, true, false);
 
         assert_eq!(disk.logical_size().unwrap(), initial_size);
 

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -22,7 +22,8 @@ use crate::qcow::metadata::{
 use crate::qcow::qcow_raw_file::QcowRawFile;
 use crate::qcow::{MAX_NESTING_DEPTH, RawFile, parse_qcow};
 use crate::qcow_common::{
-    gather_from_iovecs, pread_exact, pwrite_all, scatter_to_iovecs, zero_fill_iovecs,
+    AlignedBuf, aligned_pread, aligned_pwrite, gather_from_iovecs, gather_from_iovecs_into,
+    pread_exact, pwrite_all, scatter_to_iovecs, zero_fill_iovecs,
 };
 
 pub struct QcowDiskSync {
@@ -153,6 +154,8 @@ pub struct QcowSync {
     /// See the backing_file field on QcowDiskSync.
     backing_file: Option<Arc<dyn BackingRead>>,
     sparse: bool,
+    /// O_DIRECT alignment requirement (0 = no alignment needed).
+    alignment: usize,
     eventfd: EventFd,
     completion_list: VecDeque<(u64, i32)>,
 }
@@ -164,11 +167,13 @@ impl QcowSync {
         backing_file: Option<Arc<dyn BackingRead>>,
         sparse: bool,
     ) -> Self {
+        let alignment = data_file.file().alignment();
         QcowSync {
             metadata,
             data_file,
             backing_file,
             sparse,
+            alignment,
             eventfd: EventFd::new(libc::EFD_NONBLOCK)
                 .expect("Failed creating EventFd for QcowSync"),
             completion_list: VecDeque::new(),
@@ -208,12 +213,29 @@ impl AsyncIo for QcowSync {
                     offset: host_offset,
                     length,
                 } => {
-                    let mut buf = vec![0u8; length as usize];
-                    pread_exact(self.data_file.as_raw_fd(), &mut buf, host_offset)
+                    let len = length as usize;
+                    if self.alignment > 0 {
+                        // O_DIRECT, aligned buffer avoids bounce copy.
+                        let mut abuf = AlignedBuf::new(len, self.alignment)
+                            .map_err(AsyncIoError::ReadVectored)?;
+                        aligned_pread(
+                            self.data_file.as_raw_fd(),
+                            abuf.as_mut_slice(len),
+                            host_offset,
+                            self.alignment,
+                        )
                         .map_err(AsyncIoError::ReadVectored)?;
-                    // SAFETY: iovecs point to valid guest memory buffers
-                    unsafe { scatter_to_iovecs(iovecs, buf_offset, &buf) };
-                    buf_offset += length as usize;
+                        // SAFETY: iovecs point to valid guest memory buffers
+                        unsafe { scatter_to_iovecs(iovecs, buf_offset, abuf.as_slice(len)) };
+                    } else {
+                        // No O_DIRECT, plain buffer is fine.
+                        let mut buf = vec![0u8; len];
+                        pread_exact(self.data_file.as_raw_fd(), &mut buf, host_offset)
+                            .map_err(AsyncIoError::ReadVectored)?;
+                        // SAFETY: iovecs point to valid guest memory buffers
+                        unsafe { scatter_to_iovecs(iovecs, buf_offset, &buf) };
+                    }
+                    buf_offset += len;
                 }
                 ClusterReadMapping::Compressed { data } => {
                     let len = data.len();
@@ -287,10 +309,28 @@ impl AsyncIo for QcowSync {
                 ClusterWriteMapping::Allocated {
                     offset: host_offset,
                 } => {
-                    // SAFETY: iovecs point to valid guest memory buffers
-                    let buf = unsafe { gather_from_iovecs(iovecs, buf_offset, count) };
-                    pwrite_all(self.data_file.as_raw_fd(), &buf, host_offset)
+                    if self.alignment > 0 {
+                        // O_DIRECT, gather directly into aligned buffer.
+                        let mut abuf = AlignedBuf::new(count, self.alignment)
+                            .map_err(AsyncIoError::WriteVectored)?;
+                        // SAFETY: iovecs point to valid guest memory buffers
+                        unsafe {
+                            gather_from_iovecs_into(iovecs, buf_offset, abuf.as_mut_slice(count));
+                        }
+                        aligned_pwrite(
+                            self.data_file.as_raw_fd(),
+                            abuf.as_slice(count),
+                            host_offset,
+                            self.alignment,
+                        )
                         .map_err(AsyncIoError::WriteVectored)?;
+                    } else {
+                        // No O_DIRECT, plain buffer is fine.
+                        // SAFETY: iovecs point to valid guest memory buffers
+                        let buf = unsafe { gather_from_iovecs(iovecs, buf_offset, count) };
+                        pwrite_all(self.data_file.as_raw_fd(), &buf, host_offset)
+                            .map_err(AsyncIoError::WriteVectored)?;
+                    }
                 }
             }
             buf_offset += count;

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -8337,6 +8337,73 @@ mod windows {
 
         handle_child_output(r, &output);
     }
+
+    #[test]
+    fn test_windows_guest_qcow2_backing_direct() {
+        let windows_guest = WindowsGuest::new();
+
+        let qcow2_path = windows_guest.guest().disk_config.qcow2_disk().unwrap();
+
+        let mut child = GuestCommand::new(windows_guest.guest())
+            .args(["--cpus", "boot=2,kvm_hyperv=on"])
+            .args(["--memory", "size=4G"])
+            .args(["--kernel", edk2_path().to_str().unwrap()])
+            .args(["--serial", "tty"])
+            .args(["--console", "off"])
+            .args([
+                "--disk",
+                format!("path={qcow2_path},image_type=qcow2,backing_files=on,direct=on").as_str(),
+            ])
+            .default_net()
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let fd = child.stdout.as_ref().unwrap().as_raw_fd();
+        let pipesize = unsafe { libc::fcntl(fd, libc::F_SETPIPE_SZ, PIPE_SIZE) };
+        let fd = child.stderr.as_ref().unwrap().as_raw_fd();
+        let pipesize1 = unsafe { libc::fcntl(fd, libc::F_SETPIPE_SZ, PIPE_SIZE) };
+
+        assert!(pipesize >= PIPE_SIZE && pipesize1 >= PIPE_SIZE);
+
+        let mut child_dnsmasq = windows_guest.run_dnsmasq();
+
+        let r = std::panic::catch_unwind(|| {
+            windows_guest.wait_for_boot().unwrap();
+
+            // Write and read back files through qcow2 + direct I/O.
+            for i in 0..5 {
+                let fname = format!("c:\\test-dio-{i}.bin");
+                let fname2 = format!("c:\\test-dio-{i}-copy.bin");
+                let size = (i + 1) * 4 * 1024 * 1024;
+                windows_guest.ssh_cmd(&format!(
+                    "powershell -Command \"\
+                    $r = New-Object byte[] {size}; \
+                    (New-Object Random {i}).NextBytes($r); \
+                    [IO.File]::WriteAllBytes('{fname}', $r)\""
+                ));
+                let hash_write = windows_guest.ssh_cmd(&format!(
+                    "powershell -Command \"(Get-FileHash '{fname}' -Algorithm SHA256).Hash\""
+                ));
+                windows_guest.ssh_cmd(&format!("copy {fname} {fname2}"));
+                let hash_read = windows_guest.ssh_cmd(&format!(
+                    "powershell -Command \"(Get-FileHash '{fname2}' -Algorithm SHA256).Hash\""
+                ));
+                assert_eq!(hash_write.trim(), hash_read.trim());
+            }
+
+            windows_guest.shutdown();
+        });
+
+        let _ = child.wait_timeout(std::time::Duration::from_secs(60));
+        let _ = child.kill();
+        let output = child.wait_with_output().unwrap();
+
+        let _ = child_dnsmasq.kill();
+        let _ = child_dnsmasq.wait();
+
+        handle_child_output(r, &output);
+    }
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -226,6 +226,9 @@ pub trait DiskConfig {
     fn prepare_files(&mut self, tmp_dir: &TempDir, network: &GuestNetworkConfig);
     fn prepare_cloudinit(&self, tmp_dir: &TempDir, network: &GuestNetworkConfig) -> String;
     fn disk(&self, disk_type: DiskType) -> Option<String>;
+    fn qcow2_disk(&self) -> Option<String> {
+        None
+    }
 }
 
 #[derive(Clone)]
@@ -248,6 +251,7 @@ impl UbuntuDiskConfig {
 pub struct WindowsDiskConfig {
     image_name: String,
     osdisk_path: String,
+    osdisk_qcow2_path: String,
     loopback_device: String,
     windows_snapshot_cow: String,
     windows_snapshot: String,
@@ -258,6 +262,7 @@ impl WindowsDiskConfig {
         WindowsDiskConfig {
             image_name,
             osdisk_path: String::new(),
+            osdisk_qcow2_path: String::new(),
             loopback_device: String::new(),
             windows_snapshot_cow: String::new(),
             windows_snapshot: String::new(),
@@ -286,6 +291,10 @@ impl Drop for WindowsDiskConfig {
             .args(["-d", self.loopback_device.as_str()])
             .output()
             .expect("Expect removing loopback device to succeed");
+
+        if !self.osdisk_qcow2_path.is_empty() {
+            let _ = fs::remove_file(&self.osdisk_qcow2_path);
+        }
     }
 }
 
@@ -451,7 +460,7 @@ impl DiskConfig for WindowsDiskConfig {
         let mut osdisk_path = workload_path;
         osdisk_path.push(&self.image_name);
 
-        let osdisk_blk_size = fs::metadata(osdisk_path)
+        let osdisk_blk_size = fs::metadata(&osdisk_path)
             .expect("Expect retrieving Windows image metadata")
             .len()
             >> 9;
@@ -530,6 +539,27 @@ impl DiskConfig for WindowsDiskConfig {
         self.osdisk_path = format!("/dev/mapper/{windows_snapshot}");
         self.windows_snapshot_cow = windows_snapshot_cow;
         self.windows_snapshot = windows_snapshot;
+
+        // Create a qcow2 overlay backed by the raw image.
+        let mut workload_path = dirs::home_dir().unwrap();
+        workload_path.push("workloads");
+        let qcow2_name = format!("windows-qcow2-{}.qcow2", random_extension.to_str().unwrap());
+        let qcow2_path = workload_path.join(&qcow2_name);
+        let output = Command::new("qemu-img")
+            .args([
+                "create",
+                "-f",
+                "qcow2",
+                "-b",
+                osdisk_path.to_str().unwrap(),
+                "-F",
+                "raw",
+                qcow2_path.to_str().unwrap(),
+            ])
+            .output()
+            .expect("Expect creating qcow2 overlay to succeed");
+        assert!(output.status.success(), "qemu-img create failed");
+        self.osdisk_qcow2_path = qcow2_path.to_str().unwrap().to_string();
     }
 
     fn disk(&self, disk_type: DiskType) -> Option<String> {
@@ -537,6 +567,10 @@ impl DiskConfig for WindowsDiskConfig {
             DiskType::OperatingSystem => Some(self.osdisk_path.clone()),
             DiskType::CloudInit => None,
         }
+    }
+
+    fn qcow2_disk(&self) -> Option<String> {
+        Some(self.osdisk_qcow2_path.clone())
     }
 }
 


### PR DESCRIPTION
When a guest issues unaligned writes through a QCOW2 disk with `direct=on`, the `pwrite` syscall fails with EINVAL. O_DIRECT requires buffer address, offset, and length to be aligned to the device logical block size. Windows guests trigger this regularly.

`RawFile` probes the device alignment at open time when `direct_io` is enabled. `QcowSync` uses that value to route I/O through `aligned_pread` and `aligned_pwrite`. These functions allocate properly aligned buffers when needed and pass through with no extra allocation when everything is already aligned.

Based on @CMGS patch from #8007.

#### Tests

Existing QCOW2 tests are extended to run with and without `direct_io`. Additional tests exercise `aligned_pread` and `aligned_pwrite` with aligned and unaligned buffers, offsets, and both 512 and 4096 byte alignment.

The Windows test infrastructure now prepares a QCOW2 overlay backed by the raw Windows image for each test run, exposed through `DiskConfig::qcow2_disk()` and cleaned up on drop.

`test_windows_guest_qcow2_backing_direct` boots a Windows guest from that overlay with `direct=on`, writes, reads and copies randomly filled files of various sizes.

Fixes: #8007