### PR TITLE
vmm: add compile-time validation for userfaultfd ioctl constants

### DIFF
--- a/vmm/src/userfaultfd.rs
+++ b/vmm/src/userfaultfd.rs
@@ -8,6 +8,18 @@ pub const UFFDIO_REGISTER: u64 = 0xc020_aa00; // _IOWR(0xAA, 0x00, struct uffdio
 pub const UFFDIO_COPY: u64 = 0xc028_aa03; // _IOWR(0xAA, 0x03, struct uffdio_copy)
 pub const UFFDIO_WAKE: u64 = 0x8010_aa02; // _IOR(0xAA, 0x02, struct uffdio_range)
 
+// Validate ioctl encoding against the _IO{R,W,WR}(type, nr, size) formula so
+// transposed direction bits or sizes are caught at compile time.
+const fn ioctl_ioc(dir: u64, typ: u64, nr: u64, size: u64) -> u64 {
+    (dir << 30) | (size << 16) | (typ << 8) | nr
+}
+const IOC_READ: u64 = 2;
+const IOC_READWRITE: u64 = 3;
+const _: () = assert!(UFFDIO_API == ioctl_ioc(IOC_READWRITE, 0xAA, 0x3F, 24));
+const _: () = assert!(UFFDIO_REGISTER == ioctl_ioc(IOC_READWRITE, 0xAA, 0x00, 32));
+const _: () = assert!(UFFDIO_COPY == ioctl_ioc(IOC_READWRITE, 0xAA, 0x03, 40));
+const _: () = assert!(UFFDIO_WAKE == ioctl_ioc(IOC_READ, 0xAA, 0x02, 16));
+
 // Seccomp compares these as Dword (u32); ensure they fit.
 const _: () = assert!(UFFDIO_API <= u32::MAX as u64);
 const _: () = assert!(UFFDIO_REGISTER <= u32::MAX as u64);


### PR DESCRIPTION
Depends on #8016.

Add compile-time ioctl encoding assertions that cross-check each UFFDIO_* constant against the kernel's _IOC(dir, type, nr, size) formula so future edits are validated at build time.