### PR TITLE
ci: Switch to Windows Server 2025 for AMD64

### DIFF
--- a/.github/workflows/integration-windows.yaml
+++ b/.github/workflows/integration-windows.yaml
@@ -39,7 +39,7 @@ jobs:
         run: |
           set -eufo pipefail
           mkdir $HOME/workloads
-          az storage blob download --container-name private-images --file "$HOME/workloads/windows-server-2022-amd64-2.raw" --name windows-server-2022-amd64-2.raw --connection-string "${{ secrets.CH_PRIVATE_IMAGES }}"
+          az storage blob download --container-name private-images --file "$HOME/workloads/windows-server-2025-amd64-1.raw" --name windows-server-2025-amd64-1.raw --connection-string "${{ secrets.CH_PRIVATE_IMAGES }}"
       - name: Run Windows guest integration tests
         if: ${{ github.event_name != 'pull_request' }}
         timeout-minutes: 15

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -13,7 +13,7 @@ test_features=""
 if [ "$hypervisor" = "mshv" ]; then
     test_features="--features mshv"
 fi
-WIN_IMAGE_FILE="/root/workloads/windows-server-2022-amd64-2.raw"
+WIN_IMAGE_FILE="/root/workloads/windows-server-2025-amd64-1.raw"
 
 WORKLOADS_DIR="/root/workloads"
 

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2412,7 +2412,7 @@ pub mod x86_64 {
         "jammy-server-cloudimg-amd64-custom-20241017-0-backing-uncompressed.qcow2";
     pub const JAMMY_IMAGE_NAME_QCOW2_BACKING_RAW_FILE: &str =
         "jammy-server-cloudimg-amd64-custom-20241017-0-backing-raw.qcow2";
-    pub const WINDOWS_IMAGE_NAME: &str = "windows-server-2022-amd64-2.raw";
+    pub const WINDOWS_IMAGE_NAME: &str = "windows-server-2025-amd64-1.raw";
     pub const OVMF_NAME: &str = "CLOUDHV.fd";
     pub const GREP_SERIAL_IRQ_CMD: &str = "grep -c 'IO-APIC.*ttyS0' /proc/interrupts || true";
 }


### PR DESCRIPTION
The updated image is configured in a same way as the previously used 2022.

SAC, SSH, and RDP are configured.

All Windows updates to the curent date are installed.

Includes latest stable virtio-win 0.1.285 drivers.