### PR TITLE
virtio-devices: vsock: process pending rx on startup

### DIFF
--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -218,6 +218,13 @@ where
         helper.add_event(self.queue_evts[1].as_raw_fd(), TX_QUEUE_EVENT)?;
         helper.add_event(self.queue_evts[2].as_raw_fd(), EVT_QUEUE_EVENT)?;
         helper.add_event(self.backend.read().unwrap().get_polled_fd(), BACKEND_EVENT)?;
+
+        if self.backend.read().unwrap().has_pending_rx() {
+            self.process_rx().map_err(|e| {
+                EpollHelperError::HandleEvent(anyhow!("Failed to process RX queue on start: {e:?}"))
+            })?;
+        }
+
         helper.run(paused, paused_sync, self)?;
 
         Ok(())


### PR DESCRIPTION
Commit f56c8392ea48b43620be238c6650f3ed15184cb0 (PR #7958) enqueued RST packet on snapshot restore. Sometimes this is not enough, and the packet stays in the queue for a long time.

Process any pending RX on vsock startup.