### PR TITLE
Add support for CPU profiles part 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "log",
  "proptest",
  "serde",
+ "serde_json",
  "thiserror",
  "uuid",
  "vm-fdt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "libc",
  "linux-loader",
  "log",
+ "proptest",
  "serde",
  "thiserror",
  "uuid",
@@ -286,6 +287,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitfield-struct"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,7 +410,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -778,6 +794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,7 +964,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1736,6 +1758,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +1795,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,13 +1842,42 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1800,6 +1885,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "range_map_vec"
@@ -1908,6 +2002,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2128,7 +2234,7 @@ dependencies = [
  "dirs",
  "epoll",
  "libc",
- "rand",
+ "rand 0.10.0",
  "serde_json",
  "ssh2",
  "thiserror",
@@ -2256,6 +2362,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,7 +2393,7 @@ checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "rand",
+ "rand 0.10.0",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "log",
  "proptest",
  "serde",
+ "serde_json",
  "thiserror",
  "uuid",
  "vm-fdt",
@@ -1796,15 +1797,15 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1842,9 +1843,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "libc",
  "linux-loader",
  "log",
+ "proptest",
  "serde",
  "thiserror",
  "uuid",
@@ -286,6 +287,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitfield-struct"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,7 +420,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -815,6 +831,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,7 +1001,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1785,6 +1807,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,6 +1844,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,13 +1891,42 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1849,6 +1934,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "range_map_vec"
@@ -1957,6 +2051,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2188,7 +2294,7 @@ dependencies = [
  "dirs",
  "epoll",
  "libc",
- "rand",
+ "rand 0.10.1",
  "serde_json",
  "ssh2",
  "thiserror",
@@ -2322,6 +2428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2347,7 +2459,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "rand",
+ "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -27,6 +27,7 @@ vmm-sys-util = { workspace = true, features = ["with-serde"] }
 
 [dev-dependencies]
 proptest = "1.0.0"
+serde_json = { workspace = true }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]
 fdt_parser = { version = "0.1.5", package = "fdt" }

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -25,6 +25,9 @@ uuid = { workspace = true }
 vm-memory = { workspace = true, features = ["backend-bitmap", "backend-mmap"] }
 vmm-sys-util = { workspace = true, features = ["with-serde"] }
 
+[dev-dependencies]
+proptest = "1.0.0"
+
 [target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]
 fdt_parser = { version = "0.1.5", package = "fdt" }
 vm-fdt = { workspace = true }

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -9,9 +9,11 @@
 //! Supported platforms: x86_64, aarch64, riscv64.
 
 use std::collections::BTreeMap;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::{fmt, result};
 
+use serde::de::IntoDeserializer;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -52,6 +54,32 @@ pub enum Error {
 
 /// Type for returning public functions outcome.
 pub type Result<T> = result::Result<T, Error>;
+
+// If the target_arch is x86_64 we import CpuProfile from the x86_64 module, otherwise we
+// declare it here with only "host" as a selectable CPU profile. This trick is useful to prevent
+// excessive conditional compilation throughout the codebase.
+#[cfg(not(target_arch = "x86_64"))]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+/// A [`CpuProfile`] is a mechanism for ensuring live migration compatibility
+/// between host's with potentially different CPU models.
+pub enum CpuProfile {
+    #[default]
+    Host,
+}
+
+// Note that this trait impl is architecture agnostic and may thus reside here.
+impl FromStr for CpuProfile {
+    type Err = serde::de::value::Error;
+    fn from_str(s: &str) -> result::Result<Self, Self::Err> {
+        // Should accept both plain strings, and strings surrounded by `"`.
+        let normalized = s
+            .strip_prefix('"')
+            .unwrap_or(s)
+            .strip_suffix('"')
+            .unwrap_or(s);
+        Self::deserialize(normalized.into_deserializer())
+    }
+}
 
 /// Type for memory region types.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -100,8 +128,9 @@ pub mod x86_64;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
     _NSIG, CpuidConfig, CpuidFeatureEntry, EntryPoint, arch_memory_regions, configure_system,
-    configure_vcpu, generate_common_cpuid, generate_ram_ranges, get_host_cpu_phys_bits,
-    initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START, regs,
+    configure_vcpu, cpu_profile::CpuProfile, generate_common_cpuid, generate_ram_ranges,
+    get_host_cpu_phys_bits, initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE,
+    layout::CMDLINE_START, regs,
 };
 
 /// Safe wrapper for `sysconf(_SC_PAGESIZE)`.

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -9,9 +9,11 @@
 //! Supported platforms: x86_64, aarch64, riscv64.
 
 use std::collections::BTreeMap;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::{fmt, result};
 
+use serde::de::IntoDeserializer;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -52,6 +54,26 @@ pub enum Error {
 
 /// Type for returning public functions outcome.
 pub type Result<T> = result::Result<T, Error>;
+
+// If the target_arch is x86_64 we import CpuProfile from the x86_64 module, otherwise we
+// declare it here with only "host" as a selectable CPU profile. This trick is useful to prevent
+// excessive conditional compilation throughout the codebase.
+#[cfg(not(target_arch = "x86_64"))]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+/// A [`CpuProfile`] is a mechanism for ensuring live migration compatibility
+/// between host's with potentially different CPU models.
+pub enum CpuProfile {
+    #[default]
+    Host,
+}
+
+// Note that this trait impl is architecture agnostic and may thus reside here.
+impl FromStr for CpuProfile {
+    type Err = serde::de::value::Error;
+    fn from_str(s: &str) -> result::Result<Self, Self::Err> {
+        Self::deserialize(s.into_deserializer())
+    }
+}
 
 /// Type for memory region types.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -100,8 +122,9 @@ pub mod x86_64;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
     _NSIG, CpuidConfig, CpuidFeatureEntry, EntryPoint, arch_memory_regions, configure_system,
-    configure_vcpu, generate_common_cpuid, generate_ram_ranges, get_host_cpu_phys_bits,
-    initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START, regs,
+    configure_vcpu, cpu_profile::CpuProfile, generate_common_cpuid, generate_ram_ranges,
+    get_host_cpu_phys_bits, initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE,
+    layout::CMDLINE_START, regs,
 };
 
 /// Safe wrapper for `sysconf(_SC_PAGESIZE)`.

--- a/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
+++ b/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
@@ -9,8 +9,11 @@
 use std::io::Write;
 use std::ops::RangeInclusive;
 
+use hypervisor::arch::x86::CpuIdEntry;
+use log::error;
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::x86_64::{CpuidReg, deserialize_u32_hex, serialize_u32_hex};
 
@@ -98,6 +101,133 @@ impl Serialize for CpuidOutputRegisterAdjustments {
         serialize_field("replacements", self.replacements)?;
         serialize_field("mask", self.mask)?;
         s.end()
+    }
+}
+
+// NOTE: We prefer to directly log more precise information with regards to which entries are missing
+// over constructing a more complicated error type.
+#[derive(Debug, Error)]
+#[error("Required CPUID entries not found")]
+pub struct MissingCpuidEntriesError;
+
+impl CpuidOutputRegisterAdjustments {
+    fn adjust(self, cpuid_output_register: &mut u32) {
+        let temp_register_copy = *cpuid_output_register;
+        let replacements_area_masked_in_temp_copy = temp_register_copy & self.mask;
+        *cpuid_output_register = replacements_area_masked_in_temp_copy | self.replacements;
+    }
+
+    /// Adjust `cpuid` according to the given `adjustments`.
+    ///
+    /// An error is returned if an entry cannot be found for an adjustment describing non-zero replacements.
+    pub(super) fn adjust_cpuid_entries(
+        mut cpuid: Vec<CpuIdEntry>,
+        adjustments: &[(Parameters, Self)],
+    ) -> Result<Vec<CpuIdEntry>, MissingCpuidEntriesError> {
+        for entry in &mut cpuid {
+            for (reg, reg_value) in [
+                (CpuidReg::EAX, &mut entry.eax),
+                (CpuidReg::EBX, &mut entry.ebx),
+                (CpuidReg::ECX, &mut entry.ecx),
+                (CpuidReg::EDX, &mut entry.edx),
+            ] {
+                // Get the adjustment corresponding to the entry's function/leaf and index/sub-leaf for each of the register. If no such
+                // adjustment is found we use the trivial adjustment (leading to the register being zeroed out entirely).
+                let adjustment = adjustments
+                    .iter()
+                    .find_map(|(param, adjustment)| {
+                        ((param.leaf == entry.function)
+                            & param.sub_leaf.contains(&entry.index)
+                            & (param.register == reg))
+                            .then_some(*adjustment)
+                    })
+                    .unwrap_or(CpuidOutputRegisterAdjustments {
+                        mask: 0,
+                        replacements: 0,
+                    });
+                adjustment.adjust(reg_value);
+            }
+        }
+
+        Self::expected_entries_found(&cpuid, adjustments).map(|_| cpuid)
+    }
+
+    /// Check that we found every value that was supposed to be replaced with something else than 0
+    ///
+    /// IMPORTANT: This function assumes that the given `cpuid` has already been adjusted with the
+    /// provided `adjustments`.
+    fn expected_entries_found(
+        cpuid: &[CpuIdEntry],
+        adjustments: &[(Parameters, Self)],
+    ) -> Result<(), MissingCpuidEntriesError> {
+        let mut missing_entry = false;
+
+        // Invalid state components can be ignored. The next few lines obtain the relevant entries to
+        // check for this.
+        let eax_0xd_0 = cpuid
+            .iter()
+            .find(|entry| (entry.function == 0xd) && (entry.index == 0))
+            .map_or(0, |entry| entry.eax);
+        let ecx_0xd_1 = cpuid
+            .iter()
+            .find(|entry| (entry.function == 0xd) && (entry.index == 1))
+            .map_or(0, |entry| entry.ecx);
+
+        let edx_0xd_0 = cpuid
+            .iter()
+            .find(|entry| (entry.function == 0xd) && (entry.index == 0))
+            .map_or(0, |entry| entry.edx);
+        let edx_0xd_1 = cpuid
+            .iter()
+            .find(|entry| (entry.function == 0xd) && (entry.index == 1))
+            .map_or(0, |entry| entry.edx);
+
+        for (param, adjustment) in adjustments {
+            if adjustment.replacements == 0 {
+                continue;
+            }
+            let sub_start = *param.sub_leaf.start();
+            let sub_end = *param.sub_leaf.end();
+
+            let can_skip_lo = if (param.leaf == 0xd) && (2..32).contains(&sub_start) {
+                let start = sub_start;
+                let end = std::cmp::min(sub_end, 31);
+                let mask = (start..=end).fold(0, |acc, next| acc | (1 << next));
+                ((mask & eax_0xd_0) == 0) & ((mask & ecx_0xd_1) == 0)
+            } else {
+                false
+            };
+
+            let can_skip_hi = if (param.leaf == 0xd) && (32..64).contains(&sub_end) {
+                let start = std::cmp::max(32, sub_start);
+                let end = sub_end;
+                let mask = (start..=end)
+                    .map(|val| val - 32)
+                    .fold(0, |acc, next| acc | (1 << next));
+                ((mask & edx_0xd_0) == 0) & ((mask & edx_0xd_1) == 0)
+            } else {
+                false
+            };
+
+            if can_skip_lo && can_skip_hi {
+                // This means that all state components referred to by the specified sub-leaf range are not valid
+                // and may be skipped.
+                continue;
+            }
+            if !cpuid.iter().any(|entry| {
+                (entry.function == param.leaf) && (param.sub_leaf.contains(&entry.index))
+            }) {
+                error!(
+                    "cannot adjust CPU profile. No entry found matching the required parameters: {param:?}"
+                );
+                missing_entry = true;
+            }
+        }
+        if missing_entry {
+            Err(MissingCpuidEntriesError)
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
+++ b/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
@@ -231,6 +231,13 @@ impl CpuidOutputRegisterAdjustments {
     }
 }
 
+/// Data describing CPUID adjustments related to a CPU Profile.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CpuIdProfileData {
+    /// Adjustments necessary to become compatible with the desired target.
+    pub adjustments: Vec<(Parameters, CpuidOutputRegisterAdjustments)>,
+}
+
 #[cfg(test)]
 mod unit_tests {
     use proptest::prelude::*;

--- a/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
+++ b/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
@@ -6,8 +6,10 @@
 //! This module contains types associated with adjusting CPUID entries according
 //! to a selected CPU profile.
 
+use std::io::Write;
 use std::ops::RangeInclusive;
 
+use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 
 use crate::x86_64::{CpuidReg, deserialize_u32_hex, serialize_u32_hex};
@@ -63,4 +65,81 @@ fn deserialize_range_hex<'de, D: serde::Deserializer<'de>>(
     let ProvisionalRangeInclusive { start, end } =
         ProvisionalRangeInclusive::deserialize(deserializer)?;
     Ok(start..=end)
+}
+
+/// Used for adjusting an entire cpuid output register (EAX, EBX, ECX or EDX)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub struct CpuidOutputRegisterAdjustments {
+    #[serde(deserialize_with = "deserialize_u32_hex")]
+    pub replacements: u32,
+    /// Used to zero out the area `replacements` occupy. This mask is not necessarily !replacements, as replacements may pack values of different types (i.e. it is wrong to think of it as a bitset conceptually speaking).
+    #[serde(deserialize_with = "deserialize_u32_hex")]
+    pub mask: u32,
+}
+
+/*
+We want to serialize the values as 10 bytes, starting with 0x,
+regardless of the value. This makes it easier for humans to compare different serialized values.
+*/
+impl Serialize for CpuidOutputRegisterAdjustments {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("CpuidOutputRegisterAdjustments", 2)?;
+        let mut serialize_field = |key, value| {
+            // two bytes for "0x" prefix and eight for the hex encoded number
+            let mut buffer = [0_u8; 10];
+            write!(&mut buffer[..], "{value:#010x}").expect("This write should be infallible");
+            let str = core::str::from_utf8(&buffer[..])
+                .expect("the buffer should be filled with valid UTF-8 bytes");
+            s.serialize_field(key, str)
+        };
+        serialize_field("replacements", self.replacements)?;
+        serialize_field("mask", self.mask)?;
+        s.end()
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use proptest::prelude::*;
+
+    use super::CpuidOutputRegisterAdjustments;
+
+    // Check that serializing and then deserializing `CpuidOutputResiterAdjustments` results in the same value we started with.
+    //
+    // Also check that the serialized numeric values satisfy our expectations: They are 10-byte hex encoded strings
+    proptest! {
+        #[test]
+        fn cpuid_output_register_adjustments_serialization_works(replacements in any::<u32>(), mask in any::<u32>()) {
+            // Randomly generate these values. Several of the generated values will not represent anything that may be
+            // produced in practice, but (de-)serialization does not take such domain knowledge into account (if that changes
+            // then this test will need to be updated).
+            let adjustments = CpuidOutputRegisterAdjustments {
+                replacements,
+                mask
+            };
+            let serialized = serde_json::to_string(&adjustments).unwrap();
+            let deserialized: CpuidOutputRegisterAdjustments = serde_json::from_str(&serialized).unwrap();
+            prop_assert_eq!(&deserialized, &adjustments);
+            let json = serde_json::to_value(adjustments).unwrap();
+            let replacements_str = json.get("replacements").unwrap().as_str().unwrap();
+            let mask_str = json.get("mask").unwrap().as_str().unwrap();
+            let check_str_invariants = |value: &str| {
+                prop_assert!(value.starts_with("0x"));
+                prop_assert_eq!(value.len(),10);
+                prop_assert!(value.as_bytes().iter().all(|byte| byte.is_ascii()));
+                let is_hex_digit = |byte: &u8| -> bool {
+                    byte.is_ascii_digit() | (*byte == b'a') | (*byte == b'b') | (*byte == b'c') | (*byte == b'd') | (*byte == b'e') | (*byte == b'f')
+                };
+                prop_assert!(
+                    value.as_bytes()[2..].iter().all(is_hex_digit)
+                );
+                Ok(())
+            };
+            check_str_invariants(replacements_str)?;
+            check_str_invariants(mask_str)?;
+        }
+    }
 }

--- a/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
+++ b/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
@@ -1,0 +1,66 @@
+// Copyright © 2026 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! This module contains types associated with adjusting CPUID entries according
+//! to a selected CPU profile.
+
+use std::ops::RangeInclusive;
+
+use serde::{Deserialize, Serialize};
+
+use crate::x86_64::{CpuidReg, deserialize_u32_hex, serialize_u32_hex};
+
+/// Parameters for inspecting CPUID definitions.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CpuidParameters {
+    /// The leaf (EAX) parameter used with the CPUID instruction
+    #[serde(
+        serialize_with = "serialize_u32_hex",
+        deserialize_with = "deserialize_u32_hex"
+    )]
+    pub leaf: u32,
+    /// The sub-leaf (ECX) parameter used with the CPUID instruction
+    #[serde(
+        serialize_with = "serialize_range_hex",
+        deserialize_with = "deserialize_range_hex"
+    )]
+    pub sub_leaf: RangeInclusive<u32>,
+    /// The register we are interested in inspecting which gets filled by the CPUID instruction
+    pub register: CpuidReg,
+}
+
+// Only used for (de-)serialization
+#[derive(Debug, Serialize, Deserialize)]
+struct ProvisionalRangeInclusive {
+    #[serde(
+        serialize_with = "serialize_u32_hex",
+        deserialize_with = "deserialize_u32_hex"
+    )]
+    start: u32,
+    #[serde(
+        serialize_with = "serialize_u32_hex",
+        deserialize_with = "deserialize_u32_hex"
+    )]
+    end: u32,
+}
+
+fn serialize_range_hex<S: serde::Serializer>(
+    input: &RangeInclusive<u32>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let provisional = ProvisionalRangeInclusive {
+        start: *input.start(),
+        end: *input.end(),
+    };
+    provisional.serialize(serializer)
+}
+
+fn deserialize_range_hex<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<RangeInclusive<u32>, D::Error> {
+    let ProvisionalRangeInclusive { start, end } =
+        ProvisionalRangeInclusive::deserialize(deserializer)?;
+    Ok(start..=end)
+}

--- a/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
+++ b/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
@@ -1,0 +1,66 @@
+// Copyright © 2025 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! This module contains types associated with adjusting CPUID entries according
+//! to a selected CPU profile.
+
+use std::ops::RangeInclusive;
+
+use serde::{Deserialize, Serialize};
+
+use crate::x86_64::{CpuidReg, deserialize_u32_hex, serialize_u32_hex};
+
+/// Parameters for inspecting CPUID definitions.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Parameters {
+    // The leaf (EAX) parameter used with the CPUID instruction
+    #[serde(
+        serialize_with = "serialize_u32_hex",
+        deserialize_with = "deserialize_u32_hex"
+    )]
+    pub leaf: u32,
+    // The sub-leaf (ECX) parameter used with the CPUID instruction
+    #[serde(
+        serialize_with = "serialize_range_hex",
+        deserialize_with = "deserialize_range_hex"
+    )]
+    pub sub_leaf: RangeInclusive<u32>,
+    // The register we are interested in inspecting which gets filled by the CPUID instruction
+    pub register: CpuidReg,
+}
+
+// Only used for (de-)serialization
+#[derive(Debug, Serialize, Deserialize)]
+struct ProvisionalRangeInclusive {
+    #[serde(
+        serialize_with = "serialize_u32_hex",
+        deserialize_with = "deserialize_u32_hex"
+    )]
+    start: u32,
+    #[serde(
+        serialize_with = "serialize_u32_hex",
+        deserialize_with = "deserialize_u32_hex"
+    )]
+    end: u32,
+}
+
+fn serialize_range_hex<S: serde::Serializer>(
+    input: &RangeInclusive<u32>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let provisional = ProvisionalRangeInclusive {
+        start: *input.start(),
+        end: *input.end(),
+    };
+    provisional.serialize(serializer)
+}
+
+fn deserialize_range_hex<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<RangeInclusive<u32>, D::Error> {
+    let ProvisionalRangeInclusive { start, end } =
+        ProvisionalRangeInclusive::deserialize(deserializer)?;
+    Ok(start..=end)
+}

--- a/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
+++ b/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
@@ -181,3 +181,10 @@ impl CpuidOutputRegisterAdjustments {
         }
     }
 }
+
+/// Data describing CPUID adjustments related to a CPU Profile.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CpuidProfileData {
+    /// Adjustments necessary to become compatible with the desired target.
+    pub adjustments: Vec<(CpuidParameters, CpuidOutputRegisterAdjustments)>,
+}

--- a/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
+++ b/arch/src/x86_64/cpu_profile/cpuid_adjustments.rs
@@ -8,7 +8,10 @@
 
 use std::ops::RangeInclusive;
 
+use hypervisor::arch::x86::CpuIdEntry;
+use log::error;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::x86_64::{CpuidReg, deserialize_u32_hex, serialize_u32_hex};
 
@@ -63,4 +66,118 @@ fn deserialize_range_hex<'de, D: serde::Deserializer<'de>>(
     let ProvisionalRangeInclusive { start, end } =
         ProvisionalRangeInclusive::deserialize(deserializer)?;
     Ok(start..=end)
+}
+
+/// Used for adjusting an entire cpuid output register (EAX, EBX, ECX or EDX).
+///
+/// Instances of this struct typically adjust CPUID according to the following
+/// formula: `cpuid_reg_value = (self.mask & cpuid_reg_value) | self.replacements`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CpuidOutputRegisterAdjustments {
+    /// Packs values to be placed into the given CPUID output register.
+    #[serde(
+        serialize_with = "serialize_u32_hex",
+        deserialize_with = "deserialize_u32_hex"
+    )]
+    pub replacements: u32,
+    /// Used to zero out the area `replacements` occupy. This mask is not necessarily !replacements, as replacements
+    /// may pack values of different types that occupy varying ranges of bits.
+    ///
+    /// Bit ranges within a CPUID output register that are **not** supposed to be replaced/overwritten should be set in
+    /// this mask.
+    #[serde(
+        serialize_with = "serialize_u32_hex",
+        deserialize_with = "deserialize_u32_hex"
+    )]
+    pub mask: u32,
+}
+
+/// Error type indicating that expected CPUID entries could not be found.
+///
+/// This type does not record which entries could not be found as we do not
+/// expect this to be actionable at runtime. Instead we encourage logging such
+/// violations when and where they are detected.
+#[derive(Debug, Error)]
+#[error("Required CPUID entries not found")]
+pub struct MissingCpuidEntriesError;
+
+impl CpuidOutputRegisterAdjustments {
+    /// Adjust the given `cpuid_output_register` by retaining and replacing values according to `self`.
+    fn adjust(self, cpuid_output_register: &mut u32) {
+        *cpuid_output_register &= self.mask;
+        *cpuid_output_register |= self.replacements;
+    }
+
+    /// Adjust `cpuid` according to the given `adjustments`.
+    ///
+    /// The returned vector of cpuid entries covers the same CPUID (sub-) leaves as the given `cpuid` input,
+    /// but values without matching [`CpuidParameters`] are zeroed out.
+    ///
+    /// # Errors
+    ///
+    /// An error is returned if an entry cannot be found for an adjustment describing non-zero replacements.
+    pub(super) fn adjust_cpuid_entries(
+        mut cpuid: Vec<CpuIdEntry>,
+        adjustments: &[(CpuidParameters, Self)],
+    ) -> Result<Vec<CpuIdEntry>, MissingCpuidEntriesError> {
+        for entry in &mut cpuid {
+            for (reg, reg_value) in [
+                (CpuidReg::EAX, &mut entry.eax),
+                (CpuidReg::EBX, &mut entry.ebx),
+                (CpuidReg::ECX, &mut entry.ecx),
+                (CpuidReg::EDX, &mut entry.edx),
+            ] {
+                // Lookup the adjustment corresponding to the entry's function/leaf and index/sub-leaf for each of the register.
+                let register_adjustments: Option<CpuidOutputRegisterAdjustments> =
+                    adjustments.iter().find_map(|(param, adjustment)| {
+                        ((param.leaf == entry.function)
+                            && param.sub_leaf.contains(&entry.index)
+                            && (param.register == reg))
+                            .then_some(*adjustment)
+                    });
+
+                match register_adjustments {
+                    Some(adjustment) => adjustment.adjust(reg_value),
+                    None => {
+                        // No matching cpuid parameters were found. We thus set the value of the register to 0.
+                        *reg_value = 0;
+                    }
+                }
+            }
+        }
+
+        Self::expected_entries_found(&cpuid, adjustments)?;
+        Ok(cpuid)
+    }
+
+    /// Check that we found every value that was supposed to be replaced with something else than 0
+    ///
+    /// IMPORTANT: This function assumes that the given `cpuid` has already been adjusted with the
+    /// provided `adjustments`.
+    fn expected_entries_found(
+        cpuid: &[CpuIdEntry],
+        adjustments: &[(CpuidParameters, Self)],
+    ) -> Result<(), MissingCpuidEntriesError> {
+        let mut missing_entry = false;
+
+        for (param, adjustment) in adjustments {
+            if adjustment.replacements == 0 {
+                continue;
+            }
+
+            if !cpuid.iter().any(|entry| {
+                (entry.function == param.leaf) && (param.sub_leaf.contains(&entry.index))
+            }) {
+                error!(
+                    "cannot adjust CPU profile. No entry found matching the required parameters: {param:?}"
+                );
+                missing_entry = true;
+            }
+        }
+        if missing_entry {
+            Err(MissingCpuidEntriesError)
+        } else {
+            Ok(())
+        }
+    }
 }

--- a/arch/src/x86_64/cpu_profile/mod.rs
+++ b/arch/src/x86_64/cpu_profile/mod.rs
@@ -3,6 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use hypervisor::CpuVendor;
+use hypervisor::arch::x86::CpuIdEntry;
+
+use crate::x86_64::CpuidReg;
+use crate::x86_64::cpu_profile::cpuid_adjustments::{
+    CpuIdProfileData, CpuidOutputRegisterAdjustments, MissingCpuidEntriesError,
+};
+
 pub mod cpuid_adjustments;
 
 /*
@@ -14,4 +22,73 @@ NOTE: This is a temporary stub that will be replaced in a follow up PR.
 pub enum CpuProfile {
     #[default]
     Host,
+}
+
+impl CpuProfile {
+    /// Adjust `cpuid` to the chosen CPU profile.
+    ///
+    /// This method does **not** perform any compatibility checks beyond
+    /// ensuring that all expected (sub) leaves required by the CPU profile are present.
+    ///
+    /// The caller is responsible for ensuring compatibility of `cpuid` by the time it is
+    /// utilized.
+    ///
+    /// If Intel AMX is not desired, then passing `amx:=false` will permit missing (sub)-leaves
+    /// that are **purely AMX related**.
+    pub(in crate::x86_64) fn adjust_cpuid(
+        &self,
+        cpuid: Vec<CpuIdEntry>,
+        amx: bool,
+        cpu_vendor: CpuVendor,
+    ) -> Result<Vec<CpuIdEntry>, MissingCpuidEntriesError> {
+        let Some(CpuIdProfileData { mut adjustments }) = self.cpuid_data() else {
+            return Ok(cpuid);
+        };
+
+        if (!amx) && matches!(cpu_vendor, CpuVendor::Intel) {
+            // In this case we invalidate tile state components and zero out all other purely AMX related leaves
+            // in order to maximize our chances of finding all required (sub) leaves.
+            for adj in adjustments.iter_mut() {
+                if adj.0.sub_leaf.start() != adj.0.sub_leaf.end() {
+                    continue;
+                }
+                let sub_leaf = *adj.0.sub_leaf.start();
+                let leaf = adj.0.leaf;
+                if (leaf == 0xd) && (sub_leaf == 0) && (adj.0.register == CpuidReg::EAX) {
+                    adj.1.replacements &= !((1 << 17) | (1 << 18));
+                }
+
+                if (leaf == 0xd) && (sub_leaf == 1) && (adj.0.register == CpuidReg::ECX) {
+                    adj.1.replacements &= !((1 << 17) | (1 << 18));
+                }
+
+                if (leaf == 0xd) && ((sub_leaf == 17) | (sub_leaf == 18)) {
+                    adj.1.replacements = 0;
+                }
+
+                // Tile Information (purely AMX related).
+                if leaf == 0x1d {
+                    adj.1.replacements = 0;
+                }
+
+                // TMUL information (purely AMX related)
+                if leaf == 0x1e {
+                    adj.1.replacements = 0;
+                }
+            }
+        }
+
+        CpuidOutputRegisterAdjustments::adjust_cpuid_entries(cpuid, &adjustments)
+    }
+
+    /// Obtain CPUID adjustment data related to the CPU profile.
+    ///
+    /// This function is mainly a stub at this point, but will be
+    /// meaningful once we add some actual CPU profiles in the near
+    /// future.
+    fn cpuid_data(&self) -> Option<CpuIdProfileData> {
+        match self {
+            CpuProfile::Host => None,
+        }
+    }
 }

--- a/arch/src/x86_64/cpu_profile/mod.rs
+++ b/arch/src/x86_64/cpu_profile/mod.rs
@@ -1,0 +1,6 @@
+// Copyright © 2026 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+pub mod cpuid_adjustments;

--- a/arch/src/x86_64/cpu_profile/mod.rs
+++ b/arch/src/x86_64/cpu_profile/mod.rs
@@ -1,0 +1,6 @@
+// Copyright © 2025 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+pub mod cpuid_adjustments;

--- a/arch/src/x86_64/cpu_profile/mod.rs
+++ b/arch/src/x86_64/cpu_profile/mod.rs
@@ -4,3 +4,14 @@
 //
 
 pub mod cpuid_adjustments;
+
+/*
+NOTE: This is a temporary stub that will be replaced in a follow up PR.
+*/
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+/// A [`CpuProfile`] is a mechanism for ensuring live migration compatibility
+/// between host's with potentially different CPU models.
+pub enum CpuProfile {
+    #[default]
+    Host,
+}

--- a/arch/src/x86_64/cpu_profile/mod.rs
+++ b/arch/src/x86_64/cpu_profile/mod.rs
@@ -3,6 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use hypervisor::CpuVendor;
+use hypervisor::arch::x86::CpuIdEntry;
+
+use crate::x86_64::cpu_profile::cpuid_adjustments::{
+    CpuidOutputRegisterAdjustments, CpuidProfileData, MissingCpuidEntriesError,
+};
+use crate::x86_64::{AMX_TILECFG_BIT, AMX_TILEDATA_BIT, CpuidReg};
+
+/// Mask indicating availability of the AMX TILECFG state component
+const TILECFG_MASK: u32 = 1_u32 << AMX_TILECFG_BIT;
+/// Mask indicating availability of the AMX TILEDATA state component
+const TILEDATA_MASK: u32 = 1_u32 << AMX_TILEDATA_BIT;
+
 pub mod cpuid_adjustments;
 
 // TODO: Auto generate the CpuProfile enum with a build script once we introduce user facing CPU profiles.
@@ -13,4 +26,855 @@ pub mod cpuid_adjustments;
 pub enum CpuProfile {
     #[default]
     Host,
+}
+
+impl CpuProfile {
+    /// Adjust `cpuid` to the chosen CPU profile.
+    ///
+    /// The CPUID data obtained from the hypervisor is thus downgraded to the selected profile.
+    ///
+    /// This method does **not** perform any compatibility checks beyond
+    /// ensuring that all expected (sub) leaves required by the CPU profile are present.
+    ///
+    /// The caller is responsible for ensuring compatibility of `cpuid` by the time it is
+    /// utilized.
+    ///
+    /// If Intel AMX is not desired, then passing `amx = false` will permit missing (sub)-leaves
+    /// that are **purely AMX related**.
+    ///
+    /// The Host profile guarantees that `cpuid` is returned without any modifications.
+    pub(in crate::x86_64) fn adjust_cpuid(
+        &self,
+        cpuid: Vec<CpuIdEntry>,
+        amx: bool,
+        cpu_vendor: CpuVendor,
+    ) -> Result<Vec<CpuIdEntry>, MissingCpuidEntriesError> {
+        let Some(cpuid_profile_data) = self.cpuid_data() else {
+            return Ok(cpuid);
+        };
+        adjust_cpuid(cpuid_profile_data, cpuid, amx, cpu_vendor)
+    }
+
+    /// Obtain CPUID adjustment data related to the CPU profile.
+    fn cpuid_data(&self) -> Option<CpuidProfileData> {
+        // TODO: Auto generate this through a build script once
+        // we introduce actual CPU profiles.
+        match self {
+            CpuProfile::Host => None,
+        }
+    }
+}
+
+/// See [`CpuProfile::adjust_cpuid`](CpuProfile::adjust_cpuid)
+fn adjust_cpuid(
+    CpuidProfileData { mut adjustments }: CpuidProfileData,
+    cpuid: Vec<CpuIdEntry>,
+    amx: bool,
+    cpu_vendor: CpuVendor,
+) -> Result<Vec<CpuIdEntry>, MissingCpuidEntriesError> {
+    if (!amx) && matches!(cpu_vendor, CpuVendor::Intel) {
+        let amx_tilecfg_leaf = u32::from(AMX_TILECFG_BIT);
+        let amx_tiledata_leaf = u32::from(AMX_TILEDATA_BIT);
+
+        // In this case we invalidate tile state components and zero out all other purely AMX related leaves
+        // in order to maximize our chances of finding all required (sub) leaves.
+        for adj in adjustments.iter_mut() {
+            if adj.0.sub_leaf.start() != adj.0.sub_leaf.end() {
+                continue;
+            }
+            let sub_leaf = *adj.0.sub_leaf.start();
+            let leaf = adj.0.leaf;
+            if (leaf == 0xd) && (sub_leaf == 0) && (adj.0.register == CpuidReg::EAX) {
+                adj.1.mask &= !(TILECFG_MASK | TILEDATA_MASK);
+                adj.1.replacements &= !(TILECFG_MASK | TILEDATA_MASK);
+            }
+
+            if (leaf == 0xd) && (sub_leaf == 1) && (adj.0.register == CpuidReg::ECX) {
+                adj.1.mask &= !(TILECFG_MASK | TILEDATA_MASK);
+                adj.1.replacements &= !(TILECFG_MASK | TILEDATA_MASK);
+            }
+
+            if (leaf == 0xd) && ((sub_leaf == amx_tilecfg_leaf) || (sub_leaf == amx_tiledata_leaf))
+            {
+                adj.1.mask = 0;
+                adj.1.replacements = 0;
+            }
+
+            // Tile Information (purely AMX related).
+            if leaf == 0x1d {
+                adj.1.mask = 0;
+                adj.1.replacements = 0;
+            }
+
+            // TMUL information (purely AMX related)
+            if leaf == 0x1e {
+                adj.1.mask = 0;
+                adj.1.replacements = 0;
+            }
+        }
+    }
+
+    CpuidOutputRegisterAdjustments::adjust_cpuid_entries(cpuid, &adjustments)
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use proptest::prelude::*;
+
+    use super::{CpuIdEntry, CpuVendor, CpuidProfileData, CpuidReg, adjust_cpuid};
+    use crate::x86_64::cpu_profile::cpuid_adjustments::{
+        CpuidOutputRegisterAdjustments, CpuidParameters,
+    };
+    use crate::x86_64::cpu_profile::{TILECFG_MASK, TILEDATA_MASK};
+
+    // Note that the tests for adjust_cpuid within this module tend to use much simpler inputs
+    // than what it will be called with at runtime within Cloud hypervisor. We do this here in order
+    // to keep each test focused on the behavioral aspect under test.
+
+    /// Helper function that returns adjustments tied to purely AMX related leaves.
+    fn amx_related_adjustments() -> Vec<(CpuidParameters, CpuidOutputRegisterAdjustments)> {
+        let amx_adjustments_json = r#"
+            [
+                [
+                  {
+                    "leaf": "0xd",
+                    "sub_leaf": {
+                      "start": "0x11",
+                      "end": "0x11"
+                    },
+                    "register": "EAX"
+                  },
+                  {
+                    "replacements": "0x40",
+                    "mask": "0x0"
+                  }
+                ],
+                [
+                  {
+                    "leaf": "0xd",
+                    "sub_leaf": {
+                      "start": "0x11",
+                      "end": "0x11"
+                    },
+                    "register": "EBX"
+                  },
+                  {
+                    "replacements": "0xac0",
+                    "mask": "0x0"
+                  }
+                ],
+                [
+                  {
+                    "leaf": "0xd",
+                    "sub_leaf": {
+                      "start": "0x11",
+                      "end": "0x11"
+                    },
+                    "register": "ECX"
+                  },
+                  {
+                    "replacements": "0x2",
+                    "mask": "0x0"
+                  }
+                ],
+                [
+                  {
+                    "leaf": "0xd",
+                    "sub_leaf": {
+                      "start": "0x12",
+                      "end": "0x12"
+                    },
+                    "register": "EAX"
+                  },
+                  {
+                    "replacements": "0x2000",
+                    "mask": "0x0"
+                  }
+                ],
+                [
+                  {
+                    "leaf": "0xd",
+                    "sub_leaf": {
+                      "start": "0x12",
+                      "end": "0x12"
+                    },
+                    "register": "EBX"
+                  },
+                  {
+                    "replacements": "0xb00",
+                    "mask": "0x0"
+                  }
+                ],
+                [
+                  {
+                    "leaf": "0xd",
+                    "sub_leaf": {
+                      "start": "0x12",
+                      "end": "0x12"
+                    },
+                    "register": "ECX"
+                  },
+                  {
+                    "replacements": "0x6",
+                    "mask": "0x0"
+                  }
+                ],
+                [
+                  {
+                    "leaf": "0x1d",
+                    "sub_leaf": {
+                      "start": "0x0",
+                      "end": "0x0"
+                    },
+                    "register": "EAX"
+                  },
+                  {
+                    "replacements": "0x1",
+                    "mask": "0x0"
+                  }
+                ],
+                [
+                  {
+                    "leaf": "0x1d",
+                    "sub_leaf": {
+                      "start": "0x1",
+                      "end": "0x1"
+                    },
+                    "register": "EAX"
+                  },
+                  {
+                    "replacements": "0x4002000",
+                    "mask": "0x0"
+                  }
+                ],
+                [
+                  {
+                    "leaf": "0x1d",
+                    "sub_leaf": {
+                      "start": "0x1",
+                      "end": "0x1"
+                    },
+                    "register": "EBX"
+                  },
+                  {
+                    "replacements": "0x80040",
+                    "mask": "0x0"
+                  }
+                ],
+                [
+                  {
+                    "leaf": "0x1d",
+                    "sub_leaf": {
+                      "start": "0x1",
+                      "end": "0x1"
+                    },
+                    "register": "ECX"
+                  },
+                  {
+                    "replacements": "0x10",
+                    "mask": "0x0"
+                  }
+                ],
+                [
+                  {
+                    "leaf": "0x1e",
+                    "sub_leaf": {
+                      "start": "0x0",
+                      "end": "0x0"
+                    },
+                    "register": "EAX"
+                  },
+                  {
+                    "replacements": "0x0",
+                    "mask": "0x0"
+                  }
+                ],
+                [
+                  {
+                    "leaf": "0x1e",
+                    "sub_leaf": {
+                      "start": "0x0",
+                      "end": "0x0"
+                    },
+                    "register": "EBX"
+                  },
+                  {
+                    "replacements": "0x4010",
+                    "mask": "0x0"
+                  }
+                ]
+            ]"#;
+        serde_json::from_str(amx_adjustments_json).unwrap()
+    }
+
+    // Randonly generate three CPUID entries and construct some simple adjustments which we apply
+    // through the `adjust_cpuid` function and assert that our expectations are met.
+    proptest! {
+        #[test]
+        fn adjust_cpuid_simple_adjustments(
+            leaf0 in any::<u32>(),
+            leaf1 in any::<u32>(),
+            leaf2 in any::<u32>(),
+            a in any::<u32>(),
+            b in any::<u32>(),
+            c in any::<u32>(),
+            d in any::<u32>(),
+        ) {
+            // Ensure that we have distinct leaves in this test
+            let mut leaves = [leaf0, leaf1, leaf2];
+            leaves.sort_unstable();
+            for (l, i) in leaves.iter_mut().zip([0, 1, 2]) {
+                *l = l.wrapping_add(i);
+            }
+
+            let [leaf0, leaf1, leaf2] = leaves;
+
+            // The following leaves have some special handling that we test in later
+            // more specialized tests. In this simple test we want to avoid them.
+            let leaves_with_special_handling = { [0xd, 0x1d, 0x1e] };
+
+            let transform_leaf = |leaf: u32| {
+                if leaves_with_special_handling.contains(&leaf) {
+                    // Ensures that we get a leaf different from any of the leaves that have special handling
+                    leaf | 0x1000
+                } else {
+                    leaf
+                }
+            };
+
+            let leaf0 = transform_leaf(leaf0);
+
+            let leaf1 = transform_leaf(leaf1);
+
+            let leaf2 = transform_leaf(leaf2);
+
+            // The leaves should still be distinct
+            assert!(leaf0 != leaf1);
+            assert!(leaf0 != leaf2);
+            assert!(leaf1 != leaf2);
+            // We have now setup leaves to be used in this test
+
+            // Let's now construct some simple adjustments
+
+            // mask retaining bits 0,1,2 and 3
+            let first_four_bits_mask = 15;
+
+            // Retain the first four bits of the register and overwrite the remaining bits with the value "42"
+            let adjustment_u = CpuidOutputRegisterAdjustments {
+                mask: first_four_bits_mask,
+                replacements: 42 << 4,
+            };
+
+            let assert_adjustment_u = |new_value: u32, old_value: u32| {
+                assert_eq!(new_value & first_four_bits_mask, (old_value & first_four_bits_mask));
+                // Recall that we placed the value 42 into bits 31:4
+                assert_eq!(new_value >> 4, 42);
+            };
+
+            // Set bits 0 and 28 and zero out the rest
+            let adjustment_v = CpuidOutputRegisterAdjustments {
+                replacements: 1 | (1 << 28),
+                mask: 0
+            };
+
+            let assert_adjustment_v = |new_value: u32| {
+                assert_eq!(new_value, 1 | (1 << 28));
+            };
+
+            // Make adjustment_u apply to EAX of leaf0 and EBX of leaf1.
+            //
+            // Make adjustment_v apply to EDX of leaf0 and ECX of leaf1.
+            //
+            // We do not specify any adjustment for leaf2.
+            let cpuid_profile_data = CpuidProfileData {
+                adjustments: vec![
+                    (
+                        CpuidParameters {
+                            leaf: leaf0,
+                            sub_leaf: 0..=0,
+                            register: CpuidReg::EAX,
+                        },
+                        adjustment_u,
+                    ),
+                    (
+                        CpuidParameters {
+                            leaf: leaf0,
+                            sub_leaf: 0..=0,
+                            register: CpuidReg::EDX,
+                        },
+                        adjustment_v,
+                    ),
+                    (
+                        CpuidParameters {
+                            leaf: leaf1,
+                            sub_leaf: 0..=0,
+                            register: CpuidReg::EBX,
+                        },
+                        adjustment_u,
+                    ),
+                    (
+                        CpuidParameters {
+                            leaf: leaf1,
+                            sub_leaf: 0..=0,
+                            register: CpuidReg::ECX,
+                        },
+                        adjustment_v,
+                    ),
+                ],
+            };
+
+            // Construct cpuid entries consisting of leaves leaf0, leaf1 and leaf2.
+            // The registers eax, ebx, ecx, edx are populated with the randomly generated values `a`, `b`, `c` and `d`
+            // and we do not consider sub-leaves in this test.
+            let cpuid = vec![
+                CpuIdEntry {
+                    function: leaf0,
+                    index: 0,
+                    flags: 0,
+                    eax: a,
+                    ebx: b,
+                    ecx: c,
+                    edx: d,
+                },
+                CpuIdEntry {
+                    function: leaf1,
+                    index: 0,
+                    flags: 0,
+                    eax: a,
+                    ebx: b,
+                    ecx: c,
+                    edx: d,
+                },
+                CpuIdEntry {
+                    function: leaf2,
+                    index: 0,
+                    flags: 0,
+                    eax: a,
+                    ebx: b,
+                    ecx: c,
+                    edx: d,
+                },
+            ];
+
+            // Check that the output of `adjust_cpuid` contains the same CPUID leaves as the
+            // `cpuid` vector we started with.
+            let expected_num_entries = cpuid.len();
+            let mut found_entry_count = 0;
+
+            let adjusted_cpuid =
+                adjust_cpuid(cpuid_profile_data, cpuid, false, CpuVendor::Intel).unwrap();
+
+            // Iterate through our adjusted entries and assert that our expectations are met.
+            for entry in adjusted_cpuid {
+                let CpuIdEntry {
+                    function,
+                    index,
+                    flags,
+                    eax,
+                    ebx,
+                    ecx,
+                    edx,
+                } = entry;
+                if function == leaf0 {
+                    found_entry_count += 1;
+
+                    assert_adjustment_u(eax, a);
+                    assert_adjustment_v(edx);
+
+                    // ebx and ecx should be zeroed out
+                    assert_eq!(ebx, 0);
+                    assert_eq!(ecx, 0);
+                }
+                if function == leaf1 {
+                    found_entry_count += 1;
+                    assert_adjustment_u(ebx, b);
+                    assert_adjustment_v(ecx);
+
+                    // eax and edx should be zeroed out
+                    assert_eq!(eax, 0);
+                    assert_eq!(edx, 0);
+                }
+
+                if function == leaf2 {
+                    found_entry_count += 1;
+
+                    // All registers should be zeroed out
+                    assert_eq!(eax, ebx);
+                    assert_eq!(ebx, ecx);
+                    assert_eq!(ecx, edx);
+                    assert_eq!(edx, 0);
+                }
+
+                // Index and flags should not be altered. Since these were both
+                // always 0 for all leaves in the original `cpuid` that should
+                // remain the case.
+                assert_eq!(index, 0);
+                assert_eq!(flags, 0);
+            }
+
+            assert_eq!(expected_num_entries, found_entry_count);
+        }
+    }
+
+    // Check that adjust_cpuid follows the prescribed adjustments on
+    // specified subleaf ranges
+    #[test]
+    fn adjust_cpuid_works_with_subleaf_ranges() {
+        // As in the real runtime case the Topology enumeration leaves should not be altered
+        // by CPU profiles. In this test we thus define adjustment's that do not alter non-reserved
+        // bits for the 0x1f leaf and its sub-leaves.
+        let adjustments_json = r#"
+        [
+            [
+              {
+                "leaf": "0x1f",
+                "sub_leaf": {
+                  "start": "0x0",
+                  "end": "0xffffffff"
+                },
+                "register": "EAX"
+              },
+              {
+                "replacements": "0x0",
+                "mask": "0x1f"
+              }
+            ],
+            [
+              {
+                "leaf": "0x1f",
+                "sub_leaf": {
+                  "start": "0x0",
+                  "end": "0xffffffff"
+                },
+                "register": "EBX"
+              },
+              {
+                "replacements": "0x0",
+                "mask": "0xffff"
+              }
+            ],
+            [
+              {
+                "leaf": "0x1f",
+                "sub_leaf": {
+                  "start": "0x0",
+                  "end": "0xffffffff"
+                },
+                "register": "ECX"
+              },
+              {
+                "replacements": "0x0",
+                "mask": "0xffff"
+              }
+            ],
+            [
+              {
+                "leaf": "0x1f",
+                "sub_leaf": {
+                  "start": "0x0",
+                  "end": "0xffffffff"
+                },
+                "register": "EDX"
+              },
+              {
+                "replacements": "0x0",
+                "mask": "0xffffffff"
+              }
+            ]
+        ]"#;
+        let cpuid_profile_data = CpuidProfileData {
+            adjustments: serde_json::from_str(adjustments_json).unwrap(),
+        };
+
+        let cpuid = vec![
+            CpuIdEntry {
+                function: 0x1f,
+                index: 0,
+                flags: 1,
+                eax: 0x00000001,
+                ebx: 0x00000002,
+                ecx: 0x00000100,
+                edx: 0x00000000,
+            },
+            CpuIdEntry {
+                function: 0x1f,
+                index: 1,
+                flags: 1,
+                eax: 0x00000004,
+                ebx: 0x00000008,
+                ecx: 0x00000201,
+                edx: 0x00000006,
+            },
+        ];
+
+        let adjusted_cpuid =
+            adjust_cpuid(cpuid_profile_data, cpuid.clone(), false, CpuVendor::Intel).unwrap();
+
+        // Check that cpuid was indeed not altered
+        for entry in cpuid {
+            let adjusted_entry = adjusted_cpuid
+                .iter()
+                .find(|e| (e.function == entry.function) && (e.index == entry.index))
+                .unwrap();
+            assert_eq!(entry.eax, adjusted_entry.eax);
+            assert_eq!(entry.ebx, adjusted_entry.ebx);
+            assert_eq!(entry.ecx, adjusted_entry.ecx);
+            assert_eq!(entry.edx, adjusted_entry.edx);
+        }
+    }
+
+    #[test]
+    fn adjust_cpuid_fails_on_missing_entries() {
+        let cpuid = vec![CpuIdEntry {
+            function: 0x0,
+            index: 0x0,
+            eax: 0x20,
+            ebx: 0x756e6547,
+            ecx: 0x6c65746e,
+            edx: 0x49656e69,
+            flags: 0,
+        }];
+
+        let cpuid_profile_data = CpuidProfileData {
+            adjustments: vec![(
+                CpuidParameters {
+                    leaf: 0x1,
+                    sub_leaf: 0x0..=0x0,
+                    register: CpuidReg::EAX,
+                },
+                CpuidOutputRegisterAdjustments {
+                    replacements: 0x000806f8,
+                    mask: 0,
+                },
+            )],
+        };
+        let _ =
+            adjust_cpuid(cpuid_profile_data, cpuid.clone(), false, CpuVendor::Intel).unwrap_err();
+
+        // Also check this for a purely AMX related leaves which has special handling
+        let _ = adjust_cpuid(
+            CpuidProfileData {
+                adjustments: amx_related_adjustments(),
+            },
+            cpuid,
+            true,
+            CpuVendor::Intel,
+        )
+        .unwrap_err();
+    }
+
+    // Check that if `amx = false` then AMX related leaves are zeroed out
+    #[test]
+    fn adjust_cpuid_no_amx_zeros_amx_leaves() {
+        // Not AMX related
+        let leaf_zero = CpuIdEntry {
+            function: 0x0,
+            index: 0x0,
+            eax: 0x20,
+            ebx: 0x756e6547,
+            ecx: 0x6c65746e,
+            edx: 0x49656e69,
+            flags: 0,
+        };
+
+        let cpuid = vec![
+            leaf_zero,
+            // State components base leaf extracted from granite rapids the AMX related state component bits are set
+            CpuIdEntry {
+                function: 0xd,
+                index: 0x0,
+                flags: 1,
+                eax: 0x000602e7,
+                ebx: 0x00002b00,
+                ecx: 0x00002b00,
+                edx: 0x00000000,
+            },
+            // TILECFG state
+            CpuIdEntry {
+                function: 0xd,
+                index: 0x11,
+                flags: 1,
+                eax: 0x00000040,
+                ebx: 0x00000ac0,
+                ecx: 0x00000002,
+                edx: 0x00000000,
+            },
+            // TILEDATA state
+            CpuIdEntry {
+                function: 0xd,
+                index: 0x12,
+                flags: 1,
+                eax: 0x00002000,
+                ebx: 0x00000b00,
+                ecx: 0x00000006,
+                edx: 0x00000000,
+            },
+            // Tile information base leaf
+            CpuIdEntry {
+                function: 0x1d,
+                index: 0x0,
+                flags: 1,
+                eax: 0x00000001,
+                ebx: 0x00000000,
+                ecx: 0x00000000,
+                edx: 0x00000000,
+            },
+            // Tile Palette 1
+            CpuIdEntry {
+                function: 0x1d,
+                index: 0x1,
+                flags: 1,
+                eax: 0x04002000,
+                ebx: 0x00080040,
+                ecx: 0x00000010,
+                edx: 0x00000000,
+            },
+            // TMUL information base leaf
+            CpuIdEntry {
+                function: 0x1e,
+                index: 0x0,
+                flags: 1,
+                eax: 0x00000000,
+                ebx: 0x00004010,
+                ecx: 0x00000000,
+                edx: 0x00000000,
+            },
+        ];
+
+        let adjustments: Vec<(CpuidParameters, CpuidOutputRegisterAdjustments)> =
+            amx_related_adjustments()
+                .into_iter()
+                // leave leaf 0 untouched
+                .chain([
+                    (
+                        CpuidParameters {
+                            leaf: 0x0,
+                            sub_leaf: 0x0..=0x0,
+                            register: CpuidReg::EAX,
+                        },
+                        CpuidOutputRegisterAdjustments {
+                            replacements: 0,
+                            mask: u32::MAX,
+                        },
+                    ),
+                    (
+                        CpuidParameters {
+                            leaf: 0x0,
+                            sub_leaf: 0x0..=0x0,
+                            register: CpuidReg::EBX,
+                        },
+                        CpuidOutputRegisterAdjustments {
+                            replacements: 0,
+                            mask: u32::MAX,
+                        },
+                    ),
+                    (
+                        CpuidParameters {
+                            leaf: 0x0,
+                            sub_leaf: 0x0..=0x0,
+                            register: CpuidReg::ECX,
+                        },
+                        CpuidOutputRegisterAdjustments {
+                            replacements: 0,
+                            mask: u32::MAX,
+                        },
+                    ),
+                    (
+                        CpuidParameters {
+                            leaf: 0x0,
+                            sub_leaf: 0x0..=0x0,
+                            register: CpuidReg::EDX,
+                        },
+                        CpuidOutputRegisterAdjustments {
+                            replacements: 0,
+                            mask: u32::MAX,
+                        },
+                    ),
+                ])
+                // Keep EAX of leaf 0xd so we see that the AMX-related state component bits get unset, regardless of what
+                // the adjustment says
+                .chain([(
+                    CpuidParameters {
+                        leaf: 0xd,
+                        sub_leaf: 0x0..=0x0,
+                        register: CpuidReg::EAX,
+                    },
+                    CpuidOutputRegisterAdjustments {
+                        mask: u32::MAX,
+                        replacements: 0,
+                    },
+                )])
+                .collect();
+
+        let adjusted_cpuid = adjust_cpuid(
+            CpuidProfileData { adjustments },
+            cpuid.clone(),
+            false,
+            CpuVendor::Intel,
+        )
+        .unwrap();
+
+        // Check that leaf zero is left untouched as expected
+        {
+            let adjusted_leaf_zero = adjusted_cpuid
+                .iter()
+                .find(|entry| entry.function == 0x0)
+                .unwrap();
+            assert_eq!(adjusted_leaf_zero.eax, leaf_zero.eax);
+            assert_eq!(adjusted_leaf_zero.ebx, leaf_zero.ebx);
+            assert_eq!(adjusted_leaf_zero.ecx, leaf_zero.ecx);
+            assert_eq!(adjusted_leaf_zero.edx, leaf_zero.edx);
+        }
+
+        // Check that the TILECFG and TILEDATA state bits are now zeroed ut
+        {
+            let state_cmp_base_leaf = adjusted_cpuid
+                .iter()
+                .find(|entry| (entry.function == 0xd) && (entry.index == 0x0))
+                .unwrap();
+            // EAX should not have been zeroed out in its entirety
+            assert!(state_cmp_base_leaf.eax != 0);
+            // The TILECFG state bit should be unset
+            assert_eq!(state_cmp_base_leaf.eax & TILECFG_MASK, 0);
+            // The TILEDATA state bit should be unset
+            assert_eq!(state_cmp_base_leaf.eax & TILEDATA_MASK, 0);
+        }
+
+        // Since all remaining entries we placed in `cpuid` are purely AMX related we now
+        // expect them to be zeroed out
+        for entry in adjusted_cpuid {
+            if entry.function == 0 || (entry.function == 0xd && entry.index == 0x0) {
+                continue;
+            }
+            assert_eq!(entry.eax, 0);
+            assert_eq!(entry.ebx, 0);
+            assert_eq!(entry.ecx, 0);
+            assert_eq!(entry.edx, 0);
+        }
+    }
+
+    // Check that if `amx = false` then missing purely AMX related leaves
+    // do not lead to failure
+    #[test]
+    fn adjust_cpuid_no_amx_missing_amx_leaves_accepted() {
+        let cpuid = vec![CpuIdEntry {
+            function: 0x0,
+            index: 0x0,
+            eax: 0x20,
+            ebx: 0x756e6547,
+            ecx: 0x6c65746e,
+            edx: 0x49656e69,
+            flags: 0,
+        }];
+
+        let _ = adjust_cpuid(
+            CpuidProfileData {
+                adjustments: amx_related_adjustments(),
+            },
+            cpuid,
+            false,
+            CpuVendor::Intel,
+        )
+        .unwrap();
+    }
 }

--- a/arch/src/x86_64/cpu_profile/mod.rs
+++ b/arch/src/x86_64/cpu_profile/mod.rs
@@ -4,3 +4,13 @@
 //
 
 pub mod cpuid_adjustments;
+
+// TODO: Auto generate the CpuProfile enum with a build script once we introduce user facing CPU profiles.
+
+/// A [`CpuProfile`] is a mechanism for ensuring live migration compatibility
+/// between hosts with potentially different CPU models.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum CpuProfile {
+    #[default]
+    Host,
+}

--- a/arch/src/x86_64/general_purpose_helper_fns.rs
+++ b/arch/src/x86_64/general_purpose_helper_fns.rs
@@ -1,0 +1,38 @@
+// Copyright © 2025 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! This module contains general purpose helper functions.
+
+use std::io::Write;
+
+use serde::{Deserialize, Deserializer, Serializer};
+
+// Introduce some helper functions to (de)-serialize u32's as hexadecimal
+// strings
+
+/// Serializes the given `input` as a hex string (starting with "0x")
+pub(crate) fn serialize_u32_hex<S: Serializer>(
+    input: &u32,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error> {
+    // two bytes for "0x" prefix and at most eight for the hex encoded number
+    let mut buffer = [0_u8; 10];
+    let mut write_slice = &mut buffer[..];
+    write!(write_slice, "{input:#x}").expect("This write should be infallible");
+    let len = 10 - write_slice.len();
+    let hex_str = core::str::from_utf8(&buffer[..len])
+        .expect("the buffer should be filled with valid UTF-8 bytes");
+    serializer.serialize_str(hex_str)
+}
+
+/// Deserializes a u32 from a hex string representation
+pub(crate) fn deserialize_u32_hex<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> std::result::Result<u32, D::Error> {
+    let hex = <&'de str as Deserialize>::deserialize(deserializer)?;
+    u32::from_str_radix(hex.strip_prefix("0x").unwrap_or(""), 16).map_err(|_| {
+        <D::Error as serde::de::Error>::custom(format!("{hex} is not a hex encoded 32 bit integer"))
+    })
+}

--- a/arch/src/x86_64/helpers.rs
+++ b/arch/src/x86_64/helpers.rs
@@ -1,0 +1,80 @@
+// Copyright © 2026 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use serde::{Deserialize, Deserializer, Serializer};
+
+/// Serializes the given `input` as a hex string (starting with "0x").
+///
+/// As an example if `input:=5` then this function will feed the given
+/// `serializer` the string "0x5".
+pub(crate) fn serialize_u32_hex<S: Serializer>(
+    input: &u32,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error> {
+    serializer.serialize_str(&format!("{input:#x}"))
+}
+
+/// Deserializes a u32 from a hex string representation.
+pub(crate) fn deserialize_u32_hex<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> std::result::Result<u32, D::Error> {
+    let hex: &str = <&str>::deserialize(deserializer)?;
+    u32::from_str_radix(hex.strip_prefix("0x").unwrap_or(""), 16).map_err(|_| {
+        <D::Error as serde::de::Error>::custom(format!("{hex} is not a hex encoded 32 bit integer"))
+    })
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use proptest::prelude::*;
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+
+    #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+    struct TestStruct {
+        #[serde(
+            serialize_with = "serialize_u32_hex",
+            deserialize_with = "deserialize_u32_hex"
+        )]
+        foo: u32,
+        #[serde(
+            serialize_with = "serialize_u32_hex",
+            deserialize_with = "deserialize_u32_hex"
+        )]
+        bar: u32,
+    }
+
+    // Check that our hex serializers satisfy the two following invariants
+    // 1. Serialization followed by deserialization is the identity.
+    // 2. Values of type u32 are serialized to strings starting with "0x" and then
+    // a sub-string where all characters are ascii hex digits (with the letters [a-f] always in lowercase).
+    proptest! {
+        #[test]
+        fn hex_serialization_works(foo in any::<u32>(), bar in any::<u32>()) {
+            let t = TestStruct { foo , bar };
+
+            let t_string = serde_json::to_string(&t).unwrap();
+            let t_deserialized = serde_json::from_str(&t_string).unwrap();
+            prop_assert_eq!(t, t_deserialized);
+
+            let t_json = serde_json::to_value(t).unwrap();
+
+            let check_str_invariants = |value: &str| {
+                prop_assert!(value.starts_with("0x"));
+                prop_assert!(value.as_bytes()[2..].iter().all(u8::is_ascii_hexdigit));
+                prop_assert!(!value.as_bytes()[2..].iter().any(u8::is_ascii_uppercase));
+                Ok(())
+            };
+
+            let foo_str = t_json.get("foo").unwrap().as_str().unwrap();
+            let bar_str = t_json.get("bar").unwrap().as_str().unwrap();
+
+            check_str_invariants(foo_str)?;
+            check_str_invariants(bar_str)?;
+
+        }
+    }
+}

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -508,11 +508,27 @@ impl CpuidFeatureEntry {
         features
     }
 
-    // The function returns `Error` (a.k.a. "incompatible"), when the CPUID features from `src_vm_cpuid`
-    // is not a subset of those of the `dest_vm_cpuid`.
+    /// The function returns `Error` (a.k.a. "incompatible"), when the CPUID features from `src_vm_cpuid`
+    /// is not a subset of those of the `dest_vm_cpuid`.
     pub fn check_cpuid_compatibility(
         src_vm_cpuid: &[CpuIdEntry],
         dest_vm_cpuid: &[CpuIdEntry],
+    ) -> Result<(), Error> {
+        Self::check_cpuid_compatibility_with_descriptions(
+            src_vm_cpuid,
+            "source VM",
+            dest_vm_cpuid,
+            "destination VM",
+        )
+    }
+
+    /// Similar to `check_cpuid_compatibility`, but with the possibility to change
+    /// the description of the source and destination for logging purposes.
+    fn check_cpuid_compatibility_with_descriptions(
+        src_vm_cpuid: &[CpuIdEntry],
+        src_description: &str,
+        dest_vm_cpuid: &[CpuIdEntry],
+        dest_description: &str,
     ) -> Result<(), Error> {
         let feature_entry_list = &Self::checked_feature_entry_list();
         let src_vm_features = Self::get_features_from_cpuid(src_vm_cpuid, feature_entry_list);
@@ -539,7 +555,7 @@ impl CpuidFeatureEntry {
             if !entry_compatible {
                 error!(
                     "Detected incompatible CPUID entry: leaf={:#02x} (subleaf={:#02x}), register='{:?}', \
-                    compatible_check='{:?}', source VM feature='{:#04x}', destination VM feature'{:#04x}'.",
+                    compatible_check='{:?}', {src_description} feature='{:#04x}', {dest_description} feature'{:#04x}'.",
                     entry.function,
                     entry.index,
                     entry.feature_reg,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -9,8 +9,8 @@
 
 // This is currently only utilized by the x86_64 module, but there is nothing x86_64 specific
 // about this.
+pub mod cpu_profile;
 mod general_purpose_helper_fns;
-
 pub mod interrupts;
 pub mod layout;
 pub mod regs;

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -7,6 +7,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
+// This is currently only utilized by the x86_64 module, but there is nothing x86_64 specific
+// about this.
+mod general_purpose_helper_fns;
+
 pub mod interrupts;
 pub mod layout;
 pub mod regs;
@@ -21,6 +25,7 @@ mod smbios;
 use std::arch::x86_64;
 use std::mem;
 
+use general_purpose_helper_fns::{deserialize_u32_hex, serialize_u32_hex};
 use hypervisor::arch::x86::{CPUID_FLAG_VALID_INDEX, CpuIdEntry};
 use hypervisor::{CpuVendor, HypervisorCpuError, HypervisorError};
 use linux_loader::loader::bootparam::{boot_params, setup_header};

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -14,6 +14,7 @@ pub mod regs;
 #[cfg(feature = "tdx")]
 pub mod tdx;
 
+mod helpers;
 mod mpspec;
 mod mptable;
 mod smbios;
@@ -21,6 +22,7 @@ mod smbios;
 use std::arch::x86_64;
 use std::mem;
 
+use helpers::{deserialize_u32_hex, serialize_u32_hex};
 use hypervisor::arch::x86::{CPUID_FLAG_VALID_INDEX, CpuIdEntry};
 use hypervisor::{CpuVendor, HypervisorCpuError, HypervisorError};
 use linux_loader::loader::bootparam::{boot_params, setup_header};

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -7,6 +7,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
+pub mod cpu_profile;
 pub mod interrupts;
 pub mod layout;
 pub mod regs;

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -39,7 +39,7 @@ use vm_memory::{
     GuestMemoryRegion,
 };
 
-use crate::{GuestMemoryMmap, InitramfsConfig, RegionType};
+use crate::{CpuProfile, GuestMemoryMmap, InitramfsConfig, RegionType};
 
 // While modern architectures support more than 255 CPUs via x2APIC,
 // legacy devices such as mptable support at most 254 CPUs.
@@ -98,6 +98,7 @@ pub struct CpuidConfig {
     #[cfg(feature = "tdx")]
     pub tdx: bool,
     pub amx: bool,
+    pub profile: CpuProfile,
 }
 
 #[derive(Debug, Error)]

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -190,7 +190,7 @@ pub fn get_max_x2apic_id(topology: (u16, u16, u16, u16)) -> u32 {
     )
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub enum CpuidReg {
     EAX,
     EBX,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -39,6 +39,7 @@ use vm_memory::{
     GuestMemoryRegion,
 };
 
+use crate::x86_64::cpu_profile::cpuid_adjustments::MissingCpuidEntriesError;
 use crate::{CpuProfile, GuestMemoryMmap, InitramfsConfig, RegionType};
 
 // While modern architectures support more than 255 CPUs via x2APIC,
@@ -150,6 +151,29 @@ pub enum Error {
     /// Error checking CPUID compatibility
     #[error("Error checking CPUID compatibility")]
     CpuidCheckCompatibility,
+
+    /// Error checking if CPUID is compatible with profile
+    #[error(
+        "The selected CPU profile cannot be utilized because the host's CPUID entries are not compatible with the profile"
+    )]
+    CpuProfileCpuidIncompatibility,
+
+    /// Error because TDX cannot be enabled when a custom (non host) CPU profile has been selected
+    #[error("TDX cannot be enabled when a custom CPU profile has been selected")]
+    CpuProfileTdxIncompatibility,
+    #[error(
+        "The selected CPU profile cannot be utilized because a necessary CPUID entry was not found"
+    )]
+    /// Error when trying to apply a CPU profile because a necessary CPUID entry was not found
+    MissingExpectedCpuidEntry(#[source] MissingCpuidEntriesError),
+    /// Error when trying to apply a CPU profile because the host has a CPU from a different vendor
+    #[error(
+        "The selected CPU profile cannot be utilized because the host has a CPU from a different vendor: host_vendor:={cpu_vendor_host:?}, expected_vendor:={cpu_vendor_profile:?}"
+    )]
+    CpuProfileVendorIncompatibility {
+        cpu_vendor_profile: CpuVendor,
+        cpu_vendor_host: CpuVendor,
+    },
 
     // Error writing EBDA address
     #[error("Error writing EBDA address")]
@@ -577,6 +601,15 @@ impl CpuidFeatureEntry {
     }
 }
 
+/// Generate the CPUID entries intended for every vCPU.
+///
+/// ## CPU profiles
+///
+/// This function takes the CPU profile given in `config` into account and returns compatible CPUID entries
+/// if possible.
+///
+/// An error is returned when the CPUID entries obtained from the hypervisor do not satisfy the requirements
+/// to apply the selected CPU profile.
 pub fn generate_common_cpuid(
     hypervisor: &dyn hypervisor::Hypervisor,
     config: &CpuidConfig,
@@ -602,6 +635,83 @@ pub fn generate_common_cpuid(
         "Generating guest CPUID for with physical address size: {}",
         config.phys_bits
     );
+
+    // Supported CPUID
+    let mut cpuid = hypervisor
+        .get_supported_cpuid()
+        .map_err(Error::CpuidGetSupported)?;
+
+    let is_non_host_profile = !matches!(config.profile, CpuProfile::Host);
+    #[cfg(feature = "tdx")]
+    if config.tdx {
+        if is_non_host_profile {
+            // TDX is not supported by CPU profiles other than host for the time being.
+            return Err(Into::into(Error::CpuProfileTdxIncompatibility));
+        }
+        common_cpuid_tdx_configuration(&mut cpuid, hypervisor)?;
+    }
+
+    // Copy CPU identification string
+    for i in 0x8000_0002..=0x8000_0004 {
+        cpuid.retain(|c| c.function != i);
+        // SAFETY: call cpuid with valid leaves
+        #[allow(unused_unsafe)]
+        let leaf = unsafe { std::arch::x86_64::__cpuid(i) };
+        cpuid.push(CpuIdEntry {
+            function: i,
+            eax: leaf.eax,
+            ebx: leaf.ebx,
+            ecx: leaf.ecx,
+            edx: leaf.edx,
+            ..Default::default()
+        });
+    }
+
+    let cpuid_profile = if is_non_host_profile {
+        let cpuid_profile = config
+            .profile
+            .adjust_cpuid(cpuid.clone(), config.amx, hypervisor.get_cpu_vendor())
+            .map_err(Error::MissingExpectedCpuidEntry)?;
+
+        required_common_cpuid_updates(
+            cpuid_profile,
+            config,
+            #[cfg(feature = "kvm")]
+            hypervisor.hypervisor_type(),
+        )
+    } else {
+        Vec::new()
+    };
+
+    let cpuid_host = required_common_cpuid_updates(
+        cpuid,
+        config,
+        #[cfg(feature = "kvm")]
+        hypervisor.hypervisor_type(),
+    );
+
+    // If we want to apply a CPU profile we need to check that it remains compatible with `cpuid_host`
+    if is_non_host_profile {
+        CpuidFeatureEntry::check_cpuid_compatibility_with_descriptions(
+            &cpuid_profile,
+            "CPU Profile",
+            &cpuid_host,
+            "Host VM",
+        )
+        .map_err(|_| Error::CpuProfileCpuidIncompatibility)?;
+        Ok(cpuid_profile)
+    } else {
+        Ok(cpuid_host)
+    }
+}
+
+/// Apply updates to common CPUID (not vCPU specific) that are necessary regardless of
+/// the chosen CPU profile.
+fn required_common_cpuid_updates(
+    mut cpuid: Vec<CpuIdEntry>,
+    config: &CpuidConfig,
+    #[cfg(feature = "kvm")] hypervisor_type: hypervisor::HypervisorType,
+) -> Vec<CpuIdEntry> {
     #[allow(unused_mut)]
     let mut cpuid_patches = vec![
         // Patch hypervisor bit
@@ -626,11 +736,9 @@ pub fn generate_common_cpuid(
         },
     ];
 
+    // TODO: Can we not assume that feature = "kvm" => HypervisorType::Kvm?
     #[cfg(feature = "kvm")]
-    if matches!(
-        hypervisor.hypervisor_type(),
-        hypervisor::HypervisorType::Kvm
-    ) {
+    if matches!(hypervisor_type, hypervisor::HypervisorType::Kvm) {
         // Patch tsc deadline timer bit
         cpuid_patches.push(CpuidPatch {
             function: 1,
@@ -643,23 +751,7 @@ pub fn generate_common_cpuid(
         });
     }
 
-    // Supported CPUID
-    let mut cpuid = hypervisor
-        .get_supported_cpuid()
-        .map_err(Error::CpuidGetSupported)?;
-
     CpuidPatch::patch_cpuid(&mut cpuid, &cpuid_patches);
-
-    #[cfg(feature = "tdx")]
-    let tdx_capabilities = if config.tdx {
-        let caps = hypervisor
-            .tdx_capabilities()
-            .map_err(Error::TdxCapabilities)?;
-        info!("TDX capabilities {caps:#?}");
-        Some(caps)
-    } else {
-        None
-    };
 
     // Update some existing CPUID
     for entry in cpuid.as_mut_slice().iter_mut() {
@@ -673,25 +765,6 @@ pub fn generate_common_cpuid(
                 if entry.index == 1 {
                     entry.eax &= !(1 << AMX_FP16);
                     entry.edx &= !(1 << AMX_COMPLEX);
-                }
-            }
-            0xd =>
-            {
-                #[cfg(feature = "tdx")]
-                if let Some(caps) = &tdx_capabilities {
-                    let xcr0_mask: u64 = 0x82ff;
-                    let xss_mask: u64 = !xcr0_mask;
-                    if entry.index == 0 {
-                        entry.eax &= (caps.xfam_fixed0 as u32) & (xcr0_mask as u32);
-                        entry.eax |= (caps.xfam_fixed1 as u32) & (xcr0_mask as u32);
-                        entry.edx &= ((caps.xfam_fixed0 & xcr0_mask) >> 32) as u32;
-                        entry.edx |= ((caps.xfam_fixed1 & xcr0_mask) >> 32) as u32;
-                    } else if entry.index == 1 {
-                        entry.ecx &= (caps.xfam_fixed0 as u32) & (xss_mask as u32);
-                        entry.ecx |= (caps.xfam_fixed1 as u32) & (xss_mask as u32);
-                        entry.edx &= ((caps.xfam_fixed0 & xss_mask) >> 32) as u32;
-                        entry.edx |= ((caps.xfam_fixed1 & xss_mask) >> 32) as u32;
-                    }
                 }
             }
             // Tile Information (purely AMX related).
@@ -765,22 +838,6 @@ pub fn generate_common_cpuid(
         }
     }
 
-    // Copy CPU identification string
-    for i in 0x8000_0002..=0x8000_0004 {
-        cpuid.retain(|c| c.function != i);
-        // SAFETY: call cpuid with valid leaves
-        #[allow(unused_unsafe)]
-        let leaf = unsafe { std::arch::x86_64::__cpuid(i) };
-        cpuid.push(CpuIdEntry {
-            function: i,
-            eax: leaf.eax,
-            ebx: leaf.ebx,
-            ecx: leaf.ecx,
-            edx: leaf.edx,
-            ..Default::default()
-        });
-    }
-
     if config.kvm_hyperv {
         // Remove conflicting entries
         cpuid.retain(|c| c.function != 0x4000_0000);
@@ -828,7 +885,36 @@ pub fn generate_common_cpuid(
         }
     }
 
-    Ok(cpuid)
+    cpuid
+}
+
+#[cfg(feature = "tdx")]
+fn common_cpuid_tdx_configuration(
+    cpuid: &mut [CpuIdEntry],
+    hypervisor: &dyn hypervisor::Hypervisor,
+) -> super::Result<()> {
+    let caps = hypervisor
+        .tdx_capabilities()
+        .map_err(Error::TdxCapabilities)?;
+    info!("TDX capabilities {caps:#?}");
+
+    for entry in cpuid.iter_mut().filter(|entry| entry.function == 0xd) {
+        let xcr0_mask: u64 = 0x82ff;
+        let xss_mask: u64 = !xcr0_mask;
+        if entry.index == 0 {
+            entry.eax &= (caps.xfam_fixed0 as u32) & (xcr0_mask as u32);
+            entry.eax |= (caps.xfam_fixed1 as u32) & (xcr0_mask as u32);
+            entry.edx &= ((caps.xfam_fixed0 & xcr0_mask) >> 32) as u32;
+            entry.edx |= ((caps.xfam_fixed1 & xcr0_mask) >> 32) as u32;
+        } else if entry.index == 1 {
+            entry.ecx &= (caps.xfam_fixed0 as u32) & (xss_mask as u32);
+            entry.ecx |= (caps.xfam_fixed1 as u32) & (xss_mask as u32);
+            entry.edx &= ((caps.xfam_fixed0 & xss_mask) >> 32) as u32;
+            entry.edx |= ((caps.xfam_fixed1 & xss_mask) >> 32) as u32;
+        }
+    }
+
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -509,11 +509,27 @@ impl CpuidFeatureEntry {
         features
     }
 
-    // The function returns `Error` (a.k.a. "incompatible"), when the CPUID features from `src_vm_cpuid`
-    // is not a subset of those of the `dest_vm_cpuid`.
+    /// The function returns `Error` (a.k.a. "incompatible"), when the CPUID features from `src_vm_cpuid`
+    /// is not a subset of those of the `dest_vm_cpuid`.
     pub fn check_cpuid_compatibility(
         src_vm_cpuid: &[CpuIdEntry],
         dest_vm_cpuid: &[CpuIdEntry],
+    ) -> Result<(), Error> {
+        Self::check_cpuid_compatibility_with_descriptions(
+            src_vm_cpuid,
+            "source VM",
+            dest_vm_cpuid,
+            "destination VM",
+        )
+    }
+
+    /// Similar to `check_cpuid_compatibility`, but with the possibility to change
+    /// the description of the source and destination for logging purposes.
+    fn check_cpuid_compatibility_with_descriptions(
+        src_vm_cpuid: &[CpuIdEntry],
+        src_description: &str,
+        dest_vm_cpuid: &[CpuIdEntry],
+        dest_description: &str,
     ) -> Result<(), Error> {
         let feature_entry_list = &Self::checked_feature_entry_list();
         let src_vm_features = Self::get_features_from_cpuid(src_vm_cpuid, feature_entry_list);
@@ -540,7 +556,7 @@ impl CpuidFeatureEntry {
             if !entry_compatible {
                 error!(
                     "Detected incompatible CPUID entry: leaf={:#04x} (subleaf={:#04x}), register='{:?}', \
-                    compatible_check='{:?}', source VM feature='{:#04x}', destination VM feature'{:#04x}'.",
+                    compatible_check='{:?}', {src_description} feature='{:#04x}', {dest_description} feature='{:#04x}'.",
                     entry.function,
                     entry.index,
                     entry.feature_reg,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -37,6 +37,7 @@ use vm_memory::{
     GuestMemoryRegion,
 };
 
+use crate::x86_64::cpu_profile::cpuid_adjustments::MissingCpuidEntriesError;
 use crate::{CpuProfile, GuestMemoryMmap, InitramfsConfig, RegionType};
 
 // While modern architectures support more than 255 CPUs via x2APIC,
@@ -151,6 +152,22 @@ pub enum Error {
     /// Error checking CPUID compatibility
     #[error("Error checking CPUID compatibility")]
     CpuidCheckCompatibility,
+
+    /// Error checking if CPUID is compatible with profile
+    #[error(
+        "The selected CPU profile cannot be utilized because the host's CPUID entries are not compatible with the profile"
+    )]
+    CpuProfileCpuidIncompatibility,
+
+    /// Error because TDX cannot be enabled when a custom (non host) CPU profile has been selected
+    #[error("TDX cannot be enabled when a custom CPU profile has been selected")]
+    CpuProfileTdxIncompatibility,
+
+    /// Error when trying to apply a CPU profile because a necessary CPUID entry was not found
+    #[error(
+        "The selected CPU profile cannot be utilized because a necessary CPUID entry was not found"
+    )]
+    MissingExpectedCpuidEntry(#[source] MissingCpuidEntriesError),
 
     // Error writing EBDA address
     #[error("Error writing EBDA address")]
@@ -578,6 +595,15 @@ impl CpuidFeatureEntry {
     }
 }
 
+/// Generate the CPUID entries intended for every vCPU.
+///
+/// ## CPU profiles
+///
+/// This function takes the CPU profile given in `config` into account and returns compatible CPUID entries
+/// if possible.
+///
+/// An error is returned when the CPUID entries obtained from the hypervisor do not satisfy the requirements
+/// to apply the selected CPU profile.
 pub fn generate_common_cpuid(
     hypervisor: &dyn hypervisor::Hypervisor,
     config: &CpuidConfig,
@@ -603,6 +629,83 @@ pub fn generate_common_cpuid(
         "Generating guest CPUID for with physical address size: {}",
         config.phys_bits
     );
+
+    // Supported CPUID
+    let mut cpuid = hypervisor
+        .get_supported_cpuid()
+        .map_err(Error::CpuidGetSupported)?;
+
+    let is_non_host_profile = !matches!(config.profile, CpuProfile::Host);
+    #[cfg(feature = "tdx")]
+    if config.tdx {
+        if is_non_host_profile {
+            // TDX is not supported by CPU profiles other than host for the time being.
+            return Err(Error::CpuProfileTdxIncompatibility.into());
+        }
+        common_cpuid_tdx_configuration(&mut cpuid, hypervisor)?;
+    }
+
+    // Copy CPU identification string
+    for i in 0x8000_0002..=0x8000_0004 {
+        cpuid.retain(|c| c.function != i);
+        // SAFETY: call cpuid with valid leaves
+        #[allow(unused_unsafe)]
+        let leaf = unsafe { std::arch::x86_64::__cpuid(i) };
+        cpuid.push(CpuIdEntry {
+            function: i,
+            eax: leaf.eax,
+            ebx: leaf.ebx,
+            ecx: leaf.ecx,
+            edx: leaf.edx,
+            ..Default::default()
+        });
+    }
+
+    let cpuid_profile = if is_non_host_profile {
+        let cpuid_profile = config
+            .profile
+            .adjust_cpuid(cpuid.clone(), config.amx, hypervisor.get_cpu_vendor())
+            .map_err(Error::MissingExpectedCpuidEntry)?;
+
+        required_common_cpuid_updates(
+            cpuid_profile,
+            config,
+            #[cfg(feature = "kvm")]
+            hypervisor.hypervisor_type(),
+        )
+    } else {
+        Vec::new()
+    };
+
+    let cpuid_host = required_common_cpuid_updates(
+        cpuid,
+        config,
+        #[cfg(feature = "kvm")]
+        hypervisor.hypervisor_type(),
+    );
+
+    // If we want to apply a CPU profile we need to check that it remains compatible with `cpuid_host`
+    if is_non_host_profile {
+        CpuidFeatureEntry::check_cpuid_compatibility_with_descriptions(
+            &cpuid_profile,
+            "CPU Profile",
+            &cpuid_host,
+            "Host VM",
+        )
+        .map_err(|_| Error::CpuProfileCpuidIncompatibility)?;
+        Ok(cpuid_profile)
+    } else {
+        Ok(cpuid_host)
+    }
+}
+
+/// Apply updates to common CPUID (not vCPU specific) that are necessary regardless of
+/// the chosen CPU profile.
+fn required_common_cpuid_updates(
+    mut cpuid: Vec<CpuIdEntry>,
+    config: &CpuidConfig,
+    #[cfg(feature = "kvm")] hypervisor_type: hypervisor::HypervisorType,
+) -> Vec<CpuIdEntry> {
     #[allow(unused_mut)]
     let mut cpuid_patches = vec![
         // Patch hypervisor bit
@@ -628,10 +731,7 @@ pub fn generate_common_cpuid(
     ];
 
     #[cfg(feature = "kvm")]
-    if matches!(
-        hypervisor.hypervisor_type(),
-        hypervisor::HypervisorType::Kvm
-    ) {
+    if matches!(hypervisor_type, hypervisor::HypervisorType::Kvm) {
         // Patch tsc deadline timer bit
         cpuid_patches.push(CpuidPatch {
             function: 1,
@@ -644,23 +744,7 @@ pub fn generate_common_cpuid(
         });
     }
 
-    // Supported CPUID
-    let mut cpuid = hypervisor
-        .get_supported_cpuid()
-        .map_err(Error::CpuidGetSupported)?;
-
     CpuidPatch::patch_cpuid(&mut cpuid, &cpuid_patches);
-
-    #[cfg(feature = "tdx")]
-    let tdx_capabilities = if config.tdx {
-        let caps = hypervisor
-            .tdx_capabilities()
-            .map_err(Error::TdxCapabilities)?;
-        info!("TDX capabilities {caps:#?}");
-        Some(caps)
-    } else {
-        None
-    };
 
     // Update some existing CPUID
     for entry in cpuid.as_mut_slice().iter_mut() {
@@ -674,25 +758,6 @@ pub fn generate_common_cpuid(
                 if entry.index == 1 {
                     entry.eax &= !(1 << AMX_FP16);
                     entry.edx &= !(1 << AMX_COMPLEX);
-                }
-            }
-            0xd =>
-            {
-                #[cfg(feature = "tdx")]
-                if let Some(caps) = &tdx_capabilities {
-                    let xcr0_mask: u64 = 0x82ff;
-                    let xss_mask: u64 = !xcr0_mask;
-                    if entry.index == 0 {
-                        entry.eax &= (caps.xfam_fixed0 as u32) & (xcr0_mask as u32);
-                        entry.eax |= (caps.xfam_fixed1 as u32) & (xcr0_mask as u32);
-                        entry.edx &= ((caps.xfam_fixed0 & xcr0_mask) >> 32) as u32;
-                        entry.edx |= ((caps.xfam_fixed1 & xcr0_mask) >> 32) as u32;
-                    } else if entry.index == 1 {
-                        entry.ecx &= (caps.xfam_fixed0 as u32) & (xss_mask as u32);
-                        entry.ecx |= (caps.xfam_fixed1 as u32) & (xss_mask as u32);
-                        entry.edx &= ((caps.xfam_fixed0 & xss_mask) >> 32) as u32;
-                        entry.edx |= ((caps.xfam_fixed1 & xss_mask) >> 32) as u32;
-                    }
                 }
             }
             // Tile Information (purely AMX related).
@@ -766,22 +831,6 @@ pub fn generate_common_cpuid(
         }
     }
 
-    // Copy CPU identification string
-    for i in 0x8000_0002..=0x8000_0004 {
-        cpuid.retain(|c| c.function != i);
-        // SAFETY: call cpuid with valid leaves
-        #[allow(unused_unsafe)]
-        let leaf = unsafe { std::arch::x86_64::__cpuid(i) };
-        cpuid.push(CpuIdEntry {
-            function: i,
-            eax: leaf.eax,
-            ebx: leaf.ebx,
-            ecx: leaf.ecx,
-            edx: leaf.edx,
-            ..Default::default()
-        });
-    }
-
     if config.kvm_hyperv {
         // Remove conflicting entries
         cpuid.retain(|c| c.function != 0x4000_0000);
@@ -829,7 +878,36 @@ pub fn generate_common_cpuid(
         }
     }
 
-    Ok(cpuid)
+    cpuid
+}
+
+#[cfg(feature = "tdx")]
+fn common_cpuid_tdx_configuration(
+    cpuid: &mut [CpuIdEntry],
+    hypervisor: &dyn hypervisor::Hypervisor,
+) -> super::Result<()> {
+    let caps = hypervisor
+        .tdx_capabilities()
+        .map_err(Error::TdxCapabilities)?;
+    info!("TDX capabilities {caps:#?}");
+
+    for entry in cpuid.iter_mut().filter(|entry| entry.function == 0xd) {
+        let xcr0_mask: u64 = 0x82ff;
+        let xss_mask: u64 = !xcr0_mask;
+        if entry.index == 0 {
+            entry.eax &= (caps.xfam_fixed0 as u32) & (xcr0_mask as u32);
+            entry.eax |= (caps.xfam_fixed1 as u32) & (xcr0_mask as u32);
+            entry.edx &= ((caps.xfam_fixed0 & xcr0_mask) >> 32) as u32;
+            entry.edx |= ((caps.xfam_fixed1 & xcr0_mask) >> 32) as u32;
+        } else if entry.index == 1 {
+            entry.ecx &= (caps.xfam_fixed0 as u32) & (xss_mask as u32);
+            entry.ecx |= (caps.xfam_fixed1 as u32) & (xss_mask as u32);
+            entry.edx &= ((caps.xfam_fixed0 & xss_mask) >> 32) as u32;
+            entry.edx |= ((caps.xfam_fixed1 & xss_mask) >> 32) as u32;
+        }
+    }
+
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -626,7 +626,7 @@ pub fn generate_common_cpuid(
     }
 
     info!(
-        "Generating guest CPUID for with physical address size: {}",
+        "Generating guest CPUID with physical address size: {}",
         config.phys_bits
     );
 

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -37,7 +37,7 @@ use vm_memory::{
     GuestMemoryRegion,
 };
 
-use crate::{GuestMemoryMmap, InitramfsConfig, RegionType};
+use crate::{CpuProfile, GuestMemoryMmap, InitramfsConfig, RegionType};
 
 // While modern architectures support more than 255 CPUs via x2APIC,
 // legacy devices such as mptable support at most 254 CPUs.
@@ -99,6 +99,7 @@ pub struct CpuidConfig {
     #[cfg(feature = "tdx")]
     pub tdx: bool,
     pub amx: bool,
+    pub profile: CpuProfile,
 }
 
 #[derive(Debug, Error)]

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -58,6 +58,9 @@ const AMX_INT8: u8 = 25; // AMX tile computation on 8-bit integers
 const AMX_FP16: u8 = 21; // AMX tile computation on fp16 numbers
 const AMX_COMPLEX: u8 = 8; // AMX tile computation on complex numbers
 
+const AMX_TILECFG_BIT: u8 = 17; // AMX tile cfg state component bit
+const AMX_TILEDATA_BIT: u8 = 18; // AMX tile data state component bit
+
 // KVM feature bits
 #[cfg(feature = "tdx")]
 const KVM_FEATURE_CLOCKSOURCE_BIT: u8 = 0;

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -1001,6 +1001,7 @@ mod unit_tests {
                 features: CpuFeatures::default(),
                 nested: true,
                 core_scheduling: CoreScheduling::Vm,
+                profile: Default::default(),
             },
             memory: MemoryConfig {
                 size: 536_870_912,

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -985,6 +985,7 @@ mod unit_tests {
                 features: CpuFeatures::default(),
                 nested: true,
                 core_scheduling: CoreScheduling::Vm,
+                profile: Default::default(),
             },
             memory: MemoryConfig {
                 size: 536_870_912,

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -136,6 +136,7 @@ impl RequestHandler for StubApiRequestHandler {
                     max_phys_bits: 46,
                     affinity: None,
                     features: CpuFeatures::default(),
+                    profile: Default::default(),
                     nested: true,
                     core_scheduling: CoreScheduling::default(),
                 },

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -25,7 +25,7 @@ use crate::kvm::{TdxExitDetails, TdxExitStatus};
 use crate::{CpuState, MpState, StandardRegisters};
 
 #[cfg(target_arch = "x86_64")]
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub enum CpuVendor {
     #[default]
     Unknown,

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -27,7 +27,7 @@ use crate::kvm::{TdxExitDetails, TdxExitStatus};
 use crate::{CpuState, MpState, StandardRegisters};
 
 #[cfg(target_arch = "x86_64")]
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub enum CpuVendor {
     #[default]
     Unknown,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -11,6 +11,7 @@ use std::result;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
+use arch::CpuProfile;
 use block::ImageType;
 use clap::ArgMatches;
 use log::{debug, warn};
@@ -662,7 +663,8 @@ impl CpusConfig {
             .add("affinity")
             .add("features")
             .add("nested")
-            .add("core_scheduling");
+            .add("core_scheduling")
+            .add("profile");
         parser.parse(cpus).map_err(Error::ParseCpus)?;
 
         let boot_vcpus: u32 = parser
@@ -694,6 +696,12 @@ impl CpusConfig {
                     })
                     .collect()
             });
+
+        let profile = parser
+            .convert::<CpuProfile>("profile")
+            .map_err(Error::ParseCpus)?
+            .unwrap_or_default();
+
         let features_list = parser
             .convert::<StringList>("features")
             .map_err(Error::ParseCpus)?
@@ -736,6 +744,7 @@ impl CpusConfig {
             features,
             nested,
             core_scheduling,
+            profile,
         })
     }
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -11,6 +11,7 @@ use std::result;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
+use arch::CpuProfile;
 use block::ImageType;
 use clap::ArgMatches;
 use log::{debug, warn};
@@ -697,7 +698,8 @@ impl CpusConfig {
             .add("affinity")
             .add("features")
             .add("nested")
-            .add("core_scheduling");
+            .add("core_scheduling")
+            .add("profile");
         parser.parse(cpus).map_err(Error::ParseCpus)?;
 
         let boot_vcpus: u32 = parser
@@ -729,6 +731,12 @@ impl CpusConfig {
                     })
                     .collect()
             });
+
+        let profile = parser
+            .convert::<CpuProfile>("profile")
+            .map_err(Error::ParseCpus)?
+            .unwrap_or_default();
+
         let features_list = parser
             .convert::<StringList>("features")
             .map_err(Error::ParseCpus)?
@@ -771,6 +779,7 @@ impl CpusConfig {
             features,
             nested,
             core_scheduling,
+            profile,
         })
     }
 }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -991,6 +991,7 @@ impl CpuManager {
                     #[cfg(feature = "tdx")]
                     tdx,
                     amx: self.config.features.amx,
+                    profile: self.config.profile,
                 },
             )
             .map_err(Error::CommonCpuId)?

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -963,6 +963,7 @@ impl CpuManager {
                     #[cfg(feature = "tdx")]
                     tdx,
                     amx: self.config.features.amx,
+                    profile: self.config.profile,
                 },
             )
             .map_err(Error::CommonCpuId)?

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1384,17 +1384,27 @@ impl Vmm {
                 )));
             }
 
-            let amx = vm_config.lock().unwrap().cpus.features.amx;
-            let phys_bits =
-                vm::physical_bits(hypervisor, vm_config.lock().unwrap().cpus.max_phys_bits);
+            let (amx, phys_bits, profile, kvm_hyperv) = {
+                let guard = vm_config.lock().unwrap();
+                let amx = guard.cpus.features.amx;
+                let max_phys_bits = guard.cpus.max_phys_bits;
+                let profile = guard.cpus.profile;
+                let kvm_hyperv = guard.cpus.kvm_hyperv;
+                // Drop lock before function call
+                core::mem::drop(guard);
+                let phys_bits = vm::physical_bits(hypervisor, max_phys_bits);
+                (amx, phys_bits, profile, kvm_hyperv)
+            };
+
             arch::generate_common_cpuid(
                 hypervisor,
                 &arch::CpuidConfig {
                     phys_bits,
-                    kvm_hyperv: vm_config.lock().unwrap().cpus.kvm_hyperv,
+                    kvm_hyperv,
                     #[cfg(feature = "tdx")]
                     tdx: false,
                     amx,
+                    profile,
                 },
             )
             .map_err(|e| {
@@ -1533,6 +1543,7 @@ impl Vmm {
                     #[cfg(feature = "tdx")]
                     tdx: false,
                     amx: vm_config.cpus.features.amx,
+                    profile: vm_config.cpus.profile,
                 },
             )
             .map_err(|e| {
@@ -2576,6 +2587,8 @@ const DEVICE_MANAGER_SNAPSHOT_ID: &str = "device-manager";
 mod unit_tests {
     use std::path::PathBuf;
 
+    use arch::CpuProfile;
+
     use super::*;
     #[cfg(target_arch = "x86_64")]
     use crate::vm_config::DebugConsoleConfig;
@@ -2611,6 +2624,7 @@ mod unit_tests {
                 features: CpuFeatures::default(),
                 nested: true,
                 core_scheduling: CoreScheduling::default(),
+                profile: CpuProfile::default(),
             },
             memory: MemoryConfig {
                 size: 536_870_912,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1533,8 +1533,17 @@ impl Vmm {
         let dest_cpuid = &{
             let vm_config = &src_vm_config.lock().unwrap();
 
+            if vm_config.cpus.features.amx {
+                // Need to enable AMX tile state components before generating common cpuid
+                // as this affects what Hypervisor::get_supported_cpuid returns.
+                self.hypervisor
+                    .enable_amx_state_components()
+                    .map_err(|e| MigratableError::MigrateReceive(e.into()))?;
+            }
+
             let phys_bits =
                 vm::physical_bits(self.hypervisor.as_ref(), vm_config.cpus.max_phys_bits);
+
             arch::generate_common_cpuid(
                 self.hypervisor.as_ref(),
                 &arch::CpuidConfig {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1584,8 +1584,17 @@ impl Vmm {
         let dest_cpuid = &{
             let vm_config = &src_vm_config.lock().unwrap();
 
+            if vm_config.cpus.features.amx {
+                // Need to enable AMX tile state components before generating common cpuid
+                // as this affects what Hypervisor::get_supported_cpuid returns.
+                self.hypervisor
+                    .enable_amx_state_components()
+                    .map_err(|e| MigratableError::MigrateReceive(e.into()))?;
+            }
+
             let phys_bits =
                 vm::physical_bits(self.hypervisor.as_ref(), vm_config.cpus.max_phys_bits);
+
             arch::generate_common_cpuid(
                 self.hypervisor.as_ref(),
                 &arch::CpuidConfig {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1428,17 +1428,27 @@ impl Vmm {
                 )));
             }
 
-            let amx = vm_config.lock().unwrap().cpus.features.amx;
-            let phys_bits =
-                vm::physical_bits(hypervisor, vm_config.lock().unwrap().cpus.max_phys_bits);
+            let (amx, max_phys_bits, profile, kvm_hyperv) = {
+                let guard = vm_config.lock().unwrap();
+                (
+                    guard.cpus.features.amx,
+                    guard.cpus.max_phys_bits,
+                    guard.cpus.profile,
+                    guard.cpus.kvm_hyperv,
+                )
+            };
+
+            let phys_bits = vm::physical_bits(hypervisor, max_phys_bits);
+
             arch::generate_common_cpuid(
                 hypervisor,
                 &arch::CpuidConfig {
                     phys_bits,
-                    kvm_hyperv: vm_config.lock().unwrap().cpus.kvm_hyperv,
+                    kvm_hyperv,
                     #[cfg(feature = "tdx")]
                     tdx: false,
                     amx,
+                    profile,
                 },
             )
             .map_err(|e| {
@@ -1584,6 +1594,7 @@ impl Vmm {
                     #[cfg(feature = "tdx")]
                     tdx: false,
                     amx: vm_config.cpus.features.amx,
+                    profile: vm_config.cpus.profile,
                 },
             )
             .map_err(|e| {
@@ -2653,6 +2664,8 @@ const DEVICE_MANAGER_SNAPSHOT_ID: &str = "device-manager";
 mod unit_tests {
     use std::path::PathBuf;
 
+    use arch::CpuProfile;
+
     use super::*;
     #[cfg(target_arch = "x86_64")]
     use crate::vm_config::DebugConsoleConfig;
@@ -2690,6 +2703,7 @@ mod unit_tests {
                 features: CpuFeatures::default(),
                 nested: true,
                 core_scheduling: CoreScheduling::default(),
+                profile: CpuProfile::default(),
             },
             memory: MemoryConfig {
                 size: 536_870_912,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3137,19 +3137,22 @@ impl Snapshottable for Vm {
 
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         let common_cpuid = {
-            let amx = self.config.lock().unwrap().cpus.features.amx;
-            let phys_bits = physical_bits(
-                self.hypervisor.as_ref(),
-                self.config.lock().unwrap().cpus.max_phys_bits,
-            );
+            let guard = self.config.lock().unwrap();
+            let amx = guard.cpus.features.amx;
+            let phys_bits = physical_bits(self.hypervisor.as_ref(), guard.cpus.max_phys_bits);
+            let kvm_hyperv = guard.cpus.kvm_hyperv;
+            let profile = guard.cpus.profile;
+            // Drop the guard before function call
+            core::mem::drop(guard);
             arch::generate_common_cpuid(
                 self.hypervisor.as_ref(),
                 &arch::CpuidConfig {
                     phys_bits,
-                    kvm_hyperv: self.config.lock().unwrap().cpus.kvm_hyperv,
+                    kvm_hyperv,
                     #[cfg(feature = "tdx")]
                     tdx: false,
                     amx,
+                    profile,
                 },
             )
             .map_err(|e| {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3359,19 +3359,28 @@ impl Snapshottable for Vm {
 
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         let common_cpuid = {
-            let amx = self.config.lock().unwrap().cpus.features.amx;
-            let phys_bits = physical_bits(
-                self.hypervisor.as_ref(),
-                self.config.lock().unwrap().cpus.max_phys_bits,
-            );
+            let (amx, max_phys_bits, kvm_hyperv, profile) = {
+                let guard = self.config.lock().unwrap();
+                let VmConfig { cpus, .. } = &*guard;
+                (
+                    cpus.features.amx,
+                    cpus.max_phys_bits,
+                    cpus.kvm_hyperv,
+                    cpus.profile,
+                )
+            };
+
+            let phys_bits = physical_bits(self.hypervisor.as_ref(), max_phys_bits);
+
             arch::generate_common_cpuid(
                 self.hypervisor.as_ref(),
                 &arch::CpuidConfig {
                     phys_bits,
-                    kvm_hyperv: self.config.lock().unwrap().cpus.kvm_hyperv,
+                    kvm_hyperv,
                     #[cfg(feature = "tdx")]
                     tdx: false,
                     amx,
+                    profile,
                 },
             )
             .map_err(|e| {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{fs, result};
 
+use arch::CpuProfile;
 use block::ImageType;
 pub use block::fcntl::LockGranularityChoice;
 use log::{debug, warn};
@@ -83,6 +84,8 @@ pub struct CpusConfig {
     pub nested: bool,
     #[serde(default)]
     pub core_scheduling: CoreScheduling,
+    #[serde(default)]
+    pub profile: CpuProfile,
 }
 
 pub const DEFAULT_VCPUS: u32 = 1;
@@ -99,6 +102,7 @@ impl Default for CpusConfig {
             features: CpuFeatures::default(),
             nested: true,
             core_scheduling: CoreScheduling::default(),
+            profile: CpuProfile::default(),
         }
     }
 }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{fs, result};
 
+use arch::CpuProfile;
 use block::ImageType;
 pub use block::fcntl::LockGranularityChoice;
 use log::{debug, warn};
@@ -84,6 +85,9 @@ pub struct CpusConfig {
     pub nested: bool,
     #[serde(default)]
     pub core_scheduling: CoreScheduling,
+    // Defaults to "Host" if no profile is given.
+    #[serde(default)]
+    pub profile: CpuProfile,
 }
 
 pub const DEFAULT_VCPUS: u32 = 1;
@@ -100,6 +104,7 @@ impl Default for CpusConfig {
             features: CpuFeatures::default(),
             nested: true,
             core_scheduling: CoreScheduling::default(),
+            profile: CpuProfile::default(),
         }
     }
 }


### PR DESCRIPTION
This is the first PR in a series adding support for x86_64 CPU profiles to Cloud hypervisor which is requested in https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7068.

We chose to split the full implementation into a series of smaller PRs at the request of @likebreath (See https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7068#issuecomment-4079252520).

The x86_64 CPU profile feature in its entirety is currently tracked in https://github.com/cloud-hypervisor/cloud-hypervisor/issues/7068#issuecomment-4251037508, but you may also want to read the "full implementation overview" section below to get the big picture of what the complete implementation will look like.

Reviewers unfamiliar with CPU profiles/templates/models may want to jump directly to the "Motivation and background" section in this description first.

# What this PR does

This PR does **not add any user facing functionality** to Cloud hypervisor. All it does is introduce data structures and logic for adjusting CPUID entries in accordance with a (at this point) hypothetical CPU profile.

The logic introduced here is (mostly) oblivious to the CPU manufacturer (as long as it is an x86_64 CPU) and also hypervisor agnostic.

# Our working prototype

We have a full implementation for Intel CPUs on our [fork](https://github.com/cyberus-technology/cloud-hypervisor).
 
## Generating a new CPU profile
See our [docs](https://github.com/cyberus-technology/cloud-hypervisor/blob/gardenlinux/docs/cpu_profile_generation.md) for instructions on how to generate a new CPU profile for your own Intel CPU(s)

## Experimenting with existing CPU profiles
 You can also test running cloud hypervisor with one of our pre-generated profiles: Intel Sapphire Rapids or Intel Skylake; Simply add `,profile=sapphire-rapids` or `,profile=skylake` to the `--cpus <cpu option>` argument when bringing up the VM.

## How we have tested our implementation

We have performed a range of tests on deployments of various sizes including:
- Live migration from an Intel Granite Rapids to an Intel Sapphire Rapids processor where the Sapphire Rapids CPU profile is being utilized. We ensured that the migration was successful while the guest was executing a workload involving the intel AMX feature (available on both processors).
- CPU profile restricted VMs boot with several images (CirrOS, Ubuntu, Windows Server, NixOS) and also with direct kernel boot.
- Checks that MSRs not permitted by CPU profiles are not available to the guest.
- A plethora of successful live migrations on our customer's clusters. 

# Full implementation overview

At a high level our implementation consists of:

1. A tool for generating a CPU profile for the hardware and hypervisor the tool is executed on. The output of the tool are JSON files describing required CPUID and MSR adjustments.
2. A build script that traverses all pre-generated CPU profile JSON files, then bakes their compressed versions into the Cloud hypervisor binary at build time and also generates a `CpuProfile` enum with a variant per CPU profile together with logic for extracting the compressed JSON files.
3. Cloud hypervisor is adapted to decompress and deserialize the aforementioned CPUID and MSR adjustment descriptions and sets CPUID and MSR values visible to the guest accordingly.
4. We perform compatibility checks at runtime to determine whether the chosen CPU profile can be applied given the hardware and hypervisor the VM is running on. If these checks fail a hard error is returned and the VM will not start.

We plan to bring all of this functionality to Cloud hypervisor through several PRs:
1. Plumbing for enabling Cloud hypervisor to adjust CPUID entries according to a CPU profile (this PR).
2. Plumbing for enabling Cloud hypervisor to adjust MSR entries according to a CPU profile.
3. The CPU profile generation tool limited to CPUID adjustments on Intel CPUs with the KVM hypervisor.
4. Extending the CPU profile generation tool to also consider MSRs on Intel CPUs with the KVM hypervior.
5. Introducing the build script that generates Rust code based on the CPU profile JSON files in the tree.
6. Including some CPU profiles generated by our tool (Intel Sapphire Rapids and possibly also Intel Granite Rapids and Intel Skylake). This could be split into more PRs.
8. Adding support for AMD CPUs. Note that we have yet to do this on our fork, but we want to get it done in the not too distant future. This step may of course also possibly be split into more PRs.

## The CPU profile generation tool in more detail

Our CPU profile generation tool is aware of pretty much all (Intel) CPUID (sub) leaves and MSRs as well as CPUID and MSR entries tied to KVM.

It uses these hard coded lists together with our specified policies when the tool is executed to select, or prevent CPU features to become part of the generated CPU profile.

We will do our best to make the tool automatically warn or error when it encounters CPUID leaves and/or MSRs it is not aware of as this is a good sign that the tool needs to be updated.

If/when individual reserved CPUID and/or MSR bits within a CPUID or MSR register become specified, then one may also want to update the CPU profile generation tool to take this into account. If this is forgotten then we primarily expect this to just lead to new profiles having a slightly reduced set of supported features. This is something we can fix upon detection by re-generating the profile (with a "v2" suffix for backward compatibility reasons).

## Additional binary size per new CPU profile

Our experiments show that with compression each new CPU profile adds between 3 and 4 KB to the Cloud hypervisor binary. Without compression the pretty printed JSON files sum up to about 50 - 60 KB per CPU profile.

Further optimizations to binary size are definitely possible, but we consider 3 - 4 KB per CPU profile good enough for the time being.

# Motivation and background

Recall that software is usually developed to run on a variety of processors with various features. In order for the software to dynamically discover which hardware features may be utilized one typically uses the CPUID instruction to query the CPU for information, or in some often more low-level cases one uses so called MSRs (model specific registers) to obtain relevant processor specific information.

In the context of live migration this can of course lead to a time of check to time of use bug if the guest obtains processor information through CPUID or MSRs from the migration source and then ends up making decisions based on these findings on the migration destination that may have a different processor that might not support the same instructions as the migration source.

To mitigate this problem Cloud hypervisor performs CPUID checks (MSR checks are done by KVM, but it is debatable whether these are sufficient) at the beginning of a live migration. If the CPUID entries reported by the destination's hypervisor are not compatible with those of the source VM then the migration is aborted.

Such compatibility checks, although important, are thus also somewhat limiting in clusters with hosts/nodes running on different processors. There is no way to perform a live migration from a host with a say Intel Granite Rapids processor to a destination with a Intel Sapphire Rapids processor, even if the guest is not utilizing any functionality outside of the capabilities of the Intel Sapphire Rapids machine.

The aforementioned checks also prevent migrations from older hardware to newer in some cases where the older hardware supports deprecated CPU features (such as for example Intel MPX).

There are also certain CPU features that are unlikely to ever give accurate results in the context of live migration such as performance counters and debugging capabilities. We do not want guests making decisions based on these capabilities during live migration, even when all CPUs involved are identical!

Luckily hypervisors are capable of manipulating what guests see when executing the CPUID instruction or reading MSRs. This is a fact that we can and will use to our advantage. A CPU profile is thus a recipe for adjusting CPUID (sub) leaves and MSRs to hide certain CPU features from guests. One can then vastly increase the number of nodes/hosts in a cluster a booted VM with an applied CPU profile may live migrate to at some point in the future!

# FAQ

## What about other ISAs

We focus on `x86_64` for the time being. Other architectures such as ARM and RISC-V will only have the Host CPU profile for the foreseeable future, unless someone steps up and wants to tackle either of them already now.

Due to the vastly different nature of these architectures we expect there to be relatively little overlap with our work here in the context of x86_64 CPUs.

## What about live migration between Intel and AMD CPUs?

It might work with an extremely limited minimal profile, but I don't think that would be suitable for workloads intended to be used in production.

The intended use-cases are thus Intel <-> Intel and AMD <-> AMD live migrations.



