### PR TITLE
docs: refine coding standards in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,30 @@ license of those projects.
 New code should be under the [Apache v2
 License](https://opensource.org/licenses/Apache-2.0).
 
-## Coding Style
+## Coding Style & Code Comments
 
-We follow the [Rust Style](https://github.com/rust-lang/rust/tree/HEAD/src/doc/style-guide/src)
-convention and enforce it through the Continuous Integration (CI) process calling into `rustfmt`,
-`clippy`, and other well-known code quality tool of the ecosystem for each submitted Pull Request (PR).
+We use the [Rust Style] guide and enforce formatting and linting in CI,
+including `rustfmt`, `clippy`, and other common Rust quality checks, for every
+pull request. We adapt to best practices, new lints and new tooling as the
+ecosystem evolves.
+
+Code should **speak for itself** (for example, by using descriptive identifiers)
+and be **easy to read and maintain**. Beyond the conventions and tooling
+described above, contributors have _some_ room to apply their own style and
+preferred structure. Maintainers may still suggest refactorings where they
+believe readability, consistency, or maintainability can be improved.
+
+For new code, add documentation and comments where they **provide additional value**:
+
+* **Rustdoc** explains the API to its users.
+* **Inline comments** explain the code the reader, especially *why* it is
+  written that way.
+* **Commit messages** explain the broader context of a change (for more
+  information on commit messages, see below).
+
+Comments should be concise and add additional context or information to the code.
+
+[Rust Style]: https://github.com/rust-lang/rust/tree/HEAD/src/doc/style-guide/src
 
 ## Basic Checks
 


### PR DESCRIPTION
TL;DR: Add note about how we expect code comments/documentation

This updates the coding standards as discussed [0]. The general guideline is to write down as little process as possible and leave room for pragmatic exceptions, maintainer and contributor preferences while still striving for excellent code quality.

\[0\]: https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7990#issuecomment-4245571054

PS: This is the outcome of the internal review at @cyberus-technology. As you might expect, it is difficult to find a phrasing that meets everyone’s needs and expectations while also striking the right balance between specificity and flexibility.