### PR TITLE
Split AcpiPciHotplugController from DeviceManager to prevent potential deadlocks

### DIFF
--- a/scripts/gitlint/rules/BodyMaxLineLengthEx.py
+++ b/scripts/gitlint/rules/BodyMaxLineLengthEx.py
@@ -9,6 +9,7 @@ IGNORE_PREFIXES = [
     # Please sort alphabetically
     " ",
     "Acked-by: ",
+    "Assisted-by: ",
     "Co-authored-by: ",
     "Co-developed-by: ",
     "Debugged-by: ",

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -912,7 +912,7 @@ fn create_acpi_tables_internal(
     }
 
     // MCFG
-    let mcfg = create_mcfg_table(device_manager.pci_segments());
+    let mcfg = create_mcfg_table(&device_manager.pci_segments());
     let mcfg_addr = prev_tbl_addr.checked_add(prev_tbl_len).unwrap();
     tables_bytes.extend_from_slice(mcfg.as_slice());
     xsdt_table_pointers.push(mcfg_addr.0);
@@ -994,7 +994,7 @@ fn create_acpi_tables_internal(
 
     #[cfg(target_arch = "aarch64")]
     {
-        let iort = create_iort_table(device_manager.pci_segments());
+        let iort = create_iort_table(&device_manager.pci_segments());
         let iort_addr = prev_tbl_addr.checked_add(prev_tbl_len).unwrap();
         tables_bytes.extend_from_slice(iort.as_slice());
         xsdt_table_pointers.push(iort_addr.0);
@@ -1003,7 +1003,7 @@ fn create_acpi_tables_internal(
     }
 
     // VIOT
-    if let Some((iommu_bdf, devices_bdf)) = device_manager.iommu_attached_devices() {
+    if let Some((iommu_bdf, devices_bdf)) = device_manager.iommu_attached_devices().as_ref() {
         let viot = create_viot_table(iommu_bdf, devices_bdf);
 
         let viot_addr = prev_tbl_addr.checked_add(prev_tbl_len).unwrap();
@@ -1146,7 +1146,7 @@ pub fn create_acpi_tables_tdx(
     tables.push(cpu_manager.create_madt());
 
     // MCFG
-    tables.push(create_mcfg_table(device_manager.pci_segments()));
+    tables.push(create_mcfg_table(&device_manager.pci_segments()));
 
     // SRAT and SLIT
     // Only created if the NUMA nodes list is not empty.
@@ -1167,7 +1167,7 @@ pub fn create_acpi_tables_tdx(
     }
 
     // VIOT
-    if let Some((iommu_bdf, devices_bdf)) = device_manager.iommu_attached_devices() {
+    if let Some((iommu_bdf, devices_bdf)) = device_manager.iommu_attached_devices().as_ref() {
         tables.push(create_viot_table(iommu_bdf, devices_bdf));
     }
 

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -912,7 +912,7 @@ fn create_acpi_tables_internal(
     }
 
     // MCFG
-    let mcfg = create_mcfg_table(&device_manager.pci_segments());
+    let mcfg = device_manager.with_pci_segments(create_mcfg_table);
     let mcfg_addr = prev_tbl_addr.checked_add(prev_tbl_len).unwrap();
     tables_bytes.extend_from_slice(mcfg.as_slice());
     xsdt_table_pointers.push(mcfg_addr.0);
@@ -994,7 +994,7 @@ fn create_acpi_tables_internal(
 
     #[cfg(target_arch = "aarch64")]
     {
-        let iort = create_iort_table(&device_manager.pci_segments());
+        let iort = device_manager.with_pci_segments(create_iort_table);
         let iort_addr = prev_tbl_addr.checked_add(prev_tbl_len).unwrap();
         tables_bytes.extend_from_slice(iort.as_slice());
         xsdt_table_pointers.push(iort_addr.0);
@@ -1146,7 +1146,7 @@ pub fn create_acpi_tables_tdx(
     tables.push(cpu_manager.create_madt());
 
     // MCFG
-    tables.push(create_mcfg_table(&device_manager.pci_segments()));
+    device_manager.with_pci_segments(create_mcfg_table);
 
     // SRAT and SLIT
     // Only created if the NUMA nodes list is not empty.

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+use std::sync::Arc;
 use std::time::Instant;
 
 use acpi_tables::Aml;
@@ -191,7 +192,7 @@ bitflags! {
 
 impl MemoryAffinity {
     fn from_region(
-        region: &GuestRegionMmap,
+        region: &Arc<GuestRegionMmap>,
         proximity_domain: u32,
         flags: MemAffinityFlags,
     ) -> Self {
@@ -283,34 +284,32 @@ fn create_facp_table(dsdt_offset: GuestAddress, device_manager: &DeviceManager) 
     // Revision 6 of the ACPI FADT table is 276 bytes long
     let mut facp = Sdt::new(*b"FACP", 276, 6, *b"CLOUDH", *b"CHFACP  ", 1);
 
+    if let Some(address) = device_manager.acpi_platform_addresses().reset_reg_address {
+        // RESET_REG
+        facp.write(116, address);
+        // RESET_VALUE
+        facp.write(128, 1u8);
+    }
+
+    if let Some(address) = device_manager
+        .acpi_platform_addresses()
+        .sleep_control_reg_address
     {
-        if let Some(address) = device_manager.acpi_platform_addresses().reset_reg_address {
-            // RESET_REG
-            facp.write(116, address);
-            // RESET_VALUE
-            facp.write(128, 1u8);
-        }
+        // SLEEP_CONTROL_REG
+        facp.write(244, address);
+    }
 
-        if let Some(address) = device_manager
-            .acpi_platform_addresses()
-            .sleep_control_reg_address
-        {
-            // SLEEP_CONTROL_REG
-            facp.write(244, address);
-        }
+    if let Some(address) = device_manager
+        .acpi_platform_addresses()
+        .sleep_status_reg_address
+    {
+        // SLEEP_STATUS_REG
+        facp.write(256, address);
+    }
 
-        if let Some(address) = device_manager
-            .acpi_platform_addresses()
-            .sleep_status_reg_address
-        {
-            // SLEEP_STATUS_REG
-            facp.write(256, address);
-        }
-
-        if let Some(address) = device_manager.acpi_platform_addresses().pm_timer_address {
-            // X_PM_TMR_BLK
-            facp.write(208, address);
-        }
+    if let Some(address) = device_manager.acpi_platform_addresses().pm_timer_address {
+        // X_PM_TMR_BLK
+        facp.write(208, address);
     }
 
     // aarch64 specific fields
@@ -912,7 +911,7 @@ fn create_acpi_tables_internal(
     }
 
     // MCFG
-    let mcfg = create_mcfg_table(&device_manager.pci_segments());
+    let mcfg = device_manager.with_pci_segments(create_mcfg_table);
     let mcfg_addr = prev_tbl_addr.checked_add(prev_tbl_len).unwrap();
     tables_bytes.extend_from_slice(mcfg.as_slice());
     xsdt_table_pointers.push(mcfg_addr.0);
@@ -994,7 +993,7 @@ fn create_acpi_tables_internal(
 
     #[cfg(target_arch = "aarch64")]
     {
-        let iort = create_iort_table(&device_manager.pci_segments());
+        let iort = device_manager.with_pci_segments(create_iort_table);
         let iort_addr = prev_tbl_addr.checked_add(prev_tbl_len).unwrap();
         tables_bytes.extend_from_slice(iort.as_slice());
         xsdt_table_pointers.push(iort_addr.0);
@@ -1003,8 +1002,8 @@ fn create_acpi_tables_internal(
     }
 
     // VIOT
-    if let Some((iommu_bdf, devices_bdf)) = device_manager.iommu_attached_devices().as_ref() {
-        let viot = create_viot_table(iommu_bdf, devices_bdf);
+    if let Some((iommu_bdf, devices_bdf)) = device_manager.iommu_attached_devices() {
+        let viot = create_viot_table(&iommu_bdf, &devices_bdf);
 
         let viot_addr = prev_tbl_addr.checked_add(prev_tbl_len).unwrap();
         tables_bytes.extend_from_slice(viot.as_slice());
@@ -1146,7 +1145,7 @@ pub fn create_acpi_tables_tdx(
     tables.push(cpu_manager.create_madt());
 
     // MCFG
-    tables.push(create_mcfg_table(&device_manager.pci_segments()));
+    tables.push(device_manager.with_pci_segments(create_mcfg_table));
 
     // SRAT and SLIT
     // Only created if the NUMA nodes list is not empty.
@@ -1167,8 +1166,8 @@ pub fn create_acpi_tables_tdx(
     }
 
     // VIOT
-    if let Some((iommu_bdf, devices_bdf)) = device_manager.iommu_attached_devices().as_ref() {
-        tables.push(create_viot_table(iommu_bdf, devices_bdf));
+    if let Some((iommu_bdf, devices_bdf)) = device_manager.iommu_attached_devices() {
+        tables.push(create_viot_table(&iommu_bdf, &devices_bdf));
     }
 
     tables

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -13,7 +13,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::{File, OpenOptions};
 use std::io::{self, IsTerminal, Seek, SeekFrom, stdout};
 use std::num::Wrapping;
-use std::ops::Deref;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 #[cfg(not(target_arch = "riscv64"))]
@@ -894,30 +893,6 @@ struct PciHotplugSharedState {
     iommu_attached_devices: Option<(PciBdf, Vec<PciBdf>)>,
     // Possible handle to the virtio-mem device
     virtio_mem_devices: Vec<Arc<Mutex<virtio_devices::Mem>>>,
-}
-
-pub(crate) struct PciSegmentsGuard<'a> {
-    shared_state: std::sync::MutexGuard<'a, PciHotplugSharedState>,
-}
-
-impl Deref for PciSegmentsGuard<'_> {
-    type Target = [PciSegment];
-
-    fn deref(&self) -> &Self::Target {
-        &self.shared_state.pci_segments
-    }
-}
-
-pub struct IommuAttachedDevicesGuard<'a> {
-    shared_state: std::sync::MutexGuard<'a, PciHotplugSharedState>,
-}
-
-impl Deref for IommuAttachedDevicesGuard<'_> {
-    type Target = Option<(PciBdf, Vec<PciBdf>)>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.shared_state.iommu_attached_devices
-    }
 }
 
 #[derive(Debug)]
@@ -4518,10 +4493,9 @@ impl DeviceManager {
             .map(|ic| ic.clone() as Arc<Mutex<dyn InterruptController>>)
     }
 
-    pub(crate) fn pci_segments(&self) -> PciSegmentsGuard<'_> {
-        PciSegmentsGuard {
-            shared_state: self.shared_state(),
-        }
+    pub(crate) fn with_pci_segments<T>(&self, f: impl FnOnce(&[PciSegment]) -> T) -> T {
+        let shared_state = self.shared_state();
+        f(&shared_state.pci_segments)
     }
 
     // Get the guest PCI BDF for a device ID.
@@ -5206,10 +5180,8 @@ impl DeviceManager {
             .map_err(DeviceManagerError::PowerButtonNotification);
     }
 
-    pub fn iommu_attached_devices(&self) -> IommuAttachedDevicesGuard<'_> {
-        IommuAttachedDevicesGuard {
-            shared_state: self.shared_state(),
-        }
+    pub fn iommu_attached_devices(&self) -> Option<(PciBdf, Vec<PciBdf>)> {
+        self.shared_state().iommu_attached_devices.clone()
     }
 
     fn validate_identifier(&self, id: &Option<String>) -> DeviceManagerResult<()> {
@@ -5364,7 +5336,7 @@ impl Aml for DeviceManager {
         use arch::riscv64::DeviceInfoForFdt;
 
         let mut pci_scan_methods = Vec::new();
-        let pci_segment_count = self.pci_segments().len();
+        let pci_segment_count = self.with_pci_segments(|segments| segments.len());
         for i in 0..pci_segment_count {
             pci_scan_methods.push(aml::MethodCall::new(
                 format!("\\_SB_.PC{i:02X}.PCNT").as_str().into(),
@@ -5435,19 +5407,23 @@ impl Aml for DeviceManager {
         )
         .to_aml_bytes(sink);
 
-        for segment in self.pci_segments().iter() {
-            segment.to_aml_bytes(sink);
-        }
+        self.with_pci_segments(|segments| {
+            for segment in segments {
+                segment.to_aml_bytes(sink);
+            }
+        });
 
         let mut mbrd_memory = Vec::new();
 
-        for segment in self.pci_segments().iter() {
-            mbrd_memory.push(aml::Memory32Fixed::new(
-                true,
-                segment.mmio_config_address as u32,
-                layout::PCI_MMIO_CONFIG_SIZE_PER_SEGMENT as u32,
-            ));
-        }
+        self.with_pci_segments(|segments| {
+            for segment in segments {
+                mbrd_memory.push(aml::Memory32Fixed::new(
+                    true,
+                    segment.mmio_config_address as u32,
+                    layout::PCI_MMIO_CONFIG_SIZE_PER_SEGMENT as u32,
+                ));
+            }
+        });
 
         let mut mbrd_memory_refs = Vec::new();
         for mbrd_memory_ref in &mbrd_memory {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -927,6 +927,23 @@ struct PciHotplugSharedState {
     virtio_mem_devices: Vec<Arc<Mutex<virtio_devices::Mem>>>,
 }
 
+impl PciHotplugSharedState {
+    fn push_bus_device(&mut self, bus_device: Arc<dyn BusDeviceSync>) {
+        self.bus_devices.push(bus_device);
+    }
+
+    fn remove_bus_device(&mut self, bus_device: &Arc<dyn BusDeviceSync>) {
+        self.bus_devices.retain(|dev| !Arc::ptr_eq(dev, bus_device));
+    }
+
+    fn cleanup_vfio_ops(&mut self) {
+        if let Some(1) = self.vfio_ops.as_ref().map(Arc::strong_count) {
+            debug!("Drop VfioOps given no active VFIO devices.");
+            self.vfio_ops = None;
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct PtyPair {
     pub main: File,
@@ -1237,13 +1254,6 @@ impl AcpiPciHotplugController {
         }
     }
 
-    fn cleanup_vfio_ops(shared_state: &mut PciHotplugSharedState) {
-        if let Some(1) = shared_state.vfio_ops.as_ref().map(Arc::strong_count) {
-            debug!("Drop VfioOps given no active VFIO devices.");
-            shared_state.vfio_ops = None;
-        }
-    }
-
     fn eject_device(&mut self, pci_segment_id: u16, device_id: u8) -> DeviceManagerResult<()> {
         info!("Ejecting device_id = {device_id} on segment_id={pci_segment_id}");
 
@@ -1455,10 +1465,8 @@ impl AcpiPciHotplugController {
         }
 
         let mut shared_state = self.shared_state.lock().unwrap();
-        shared_state
-            .bus_devices
-            .retain(|dev| !Arc::ptr_eq(dev, &bus_device));
-        Self::cleanup_vfio_ops(&mut shared_state);
+        shared_state.remove_bus_device(&bus_device);
+        shared_state.cleanup_vfio_ops();
         drop(shared_state);
 
         // At this point, the device has been removed from all the list and
@@ -1481,10 +1489,6 @@ impl AcpiPciHotplugController {
 impl DeviceManager {
     fn shared_state(&self) -> std::sync::MutexGuard<'_, PciHotplugSharedState> {
         self.shared_state.lock().unwrap()
-    }
-
-    fn push_bus_device(&self, bus_device: Arc<dyn BusDeviceSync>) {
-        self.shared_state().bus_devices.push(bus_device);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1842,7 +1846,8 @@ impl DeviceManager {
         #[cfg(not(target_arch = "riscv64"))]
         if let Some(tpm) = self.config.clone().lock().unwrap().tpm.as_ref() {
             let tpm_dev = self.add_tpm_device(&tpm.socket)?;
-            self.push_bus_device(Arc::clone(&tpm_dev) as Arc<dyn BusDeviceSync>);
+            self.shared_state()
+                .push_bus_device(Arc::clone(&tpm_dev) as Arc<dyn BusDeviceSync>);
         }
         self.legacy_interrupt_manager = Some(legacy_interrupt_manager);
 
@@ -1880,7 +1885,8 @@ impl DeviceManager {
 
         self.fw_cfg = Some(fw_cfg.clone());
 
-        self.push_bus_device(Arc::clone(&fw_cfg) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&fw_cfg) as Arc<dyn BusDeviceSync>);
 
         #[cfg(target_arch = "x86_64")]
         self.address_manager
@@ -2062,7 +2068,7 @@ impl DeviceManager {
             })
             .collect();
         for bus_device in pci_config_devices {
-            self.push_bus_device(bus_device);
+            self.shared_state().push_bus_device(bus_device);
         }
 
         Ok(())
@@ -2184,7 +2190,8 @@ impl DeviceManager {
             .insert(interrupt_controller.clone(), IOAPIC_START.0, IOAPIC_SIZE)
             .map_err(DeviceManagerError::BusError)?;
 
-        self.push_bus_device(Arc::clone(&interrupt_controller) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&interrupt_controller) as Arc<dyn BusDeviceSync>);
 
         // Fill the device tree with a new node. In case of restore, we
         // know there is nothing to do, so we can simply override the
@@ -2215,7 +2222,8 @@ impl DeviceManager {
             vcpus_kill_signalled,
         )));
 
-        self.push_bus_device(Arc::clone(&shutdown_device) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&shutdown_device) as Arc<dyn BusDeviceSync>);
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -2277,11 +2285,13 @@ impl DeviceManager {
                 devices::acpi::GED_DEVICE_ACPI_SIZE as u64,
             )
             .map_err(DeviceManagerError::BusError)?;
-        self.push_bus_device(Arc::clone(&ged_device) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&ged_device) as Arc<dyn BusDeviceSync>);
 
         let pm_timer_device = Arc::new(Mutex::new(devices::AcpiPmTimerDevice::new()));
 
-        self.push_bus_device(Arc::clone(&pm_timer_device) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&pm_timer_device) as Arc<dyn BusDeviceSync>);
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -2320,7 +2330,8 @@ impl DeviceManager {
             vcpus_kill_signalled.clone(),
         )));
 
-        self.push_bus_device(Arc::clone(&i8042) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&i8042) as Arc<dyn BusDeviceSync>);
 
         self.address_manager
             .io_bus
@@ -2347,7 +2358,8 @@ impl DeviceManager {
                 Some(vcpus_kill_signalled),
             )));
 
-            self.push_bus_device(Arc::clone(&cmos) as Arc<dyn BusDeviceSync>);
+            self.shared_state()
+                .push_bus_device(Arc::clone(&cmos) as Arc<dyn BusDeviceSync>);
 
             self.address_manager
                 .io_bus
@@ -2356,7 +2368,8 @@ impl DeviceManager {
 
             let fwdebug = Arc::new(Mutex::new(devices::legacy::FwDebugDevice::new()));
 
-            self.push_bus_device(Arc::clone(&fwdebug) as Arc<dyn BusDeviceSync>);
+            self.shared_state()
+                .push_bus_device(Arc::clone(&fwdebug) as Arc<dyn BusDeviceSync>);
 
             self.address_manager
                 .io_bus
@@ -2366,7 +2379,8 @@ impl DeviceManager {
 
         // 0x80 debug port
         let debug_port = Arc::new(Mutex::new(devices::legacy::DebugPort::new(self.timestamp)));
-        self.push_bus_device(Arc::clone(&debug_port) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&debug_port) as Arc<dyn BusDeviceSync>);
         self.address_manager
             .io_bus
             .insert(debug_port, 0x80, 0x1)
@@ -2391,7 +2405,8 @@ impl DeviceManager {
 
         let rtc_device = Arc::new(Mutex::new(devices::legacy::Rtc::new()));
 
-        self.push_bus_device(Arc::clone(&rtc_device) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&rtc_device) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_RTC_MAPPED_IO_START;
 
@@ -2432,7 +2447,8 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.push_bus_device(Arc::clone(&gpio_device) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&gpio_device) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_GPIO_MAPPED_IO_START;
 
@@ -2480,7 +2496,8 @@ impl DeviceManager {
             .iobase
             .map_or(debug_console::DEFAULT_PORT, |port| port as u64);
 
-        self.push_bus_device(Arc::clone(&debug_console) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&debug_console) as Arc<dyn BusDeviceSync>);
 
         self.address_manager
             .allocator
@@ -2530,7 +2547,8 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
 
         self.address_manager
             .allocator
@@ -2586,7 +2604,8 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START;
 
@@ -2648,7 +2667,8 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START;
 
@@ -4438,7 +4458,7 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::AddPciDevice)?;
         }
 
-        shared_state.bus_devices.push(bus_device);
+        shared_state.push_bus_device(bus_device);
 
         let mut new_resources = Vec::new();
         for bar in bars {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -13,6 +13,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::{File, OpenOptions};
 use std::io::{self, IsTerminal, Seek, SeekFrom, stdout};
 use std::num::Wrapping;
+use std::ops::Deref;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 #[cfg(not(target_arch = "riscv64"))]
@@ -874,6 +875,51 @@ struct DeviceManagerState {
     device_id_cnt: Wrapping<usize>,
 }
 
+struct PciHotplugSharedState {
+    pci_segments: Vec<PciSegment>,
+    selected_segment: usize,
+    // List of bus devices
+    // Let the DeviceManager keep strong references to the BusDevice devices.
+    // This allows the IO and MMIO buses to be provided with Weak references,
+    // which prevents cyclic dependencies.
+    bus_devices: Vec<Arc<dyn BusDeviceSync>>,
+    // VFIO operation instance
+    // Only one can be created, therefore it is stored as part of the
+    // DeviceManager to be reused.
+    vfio_ops: Option<Arc<dyn VfioOps>>,
+    // PCI information about devices attached to the paravirtualized IOMMU
+    // It contains the virtual IOMMU PCI BDF along with the list of PCI BDF
+    // representing the devices attached to the virtual IOMMU. This is useful
+    // information for filling the ACPI VIOT table.
+    iommu_attached_devices: Option<(PciBdf, Vec<PciBdf>)>,
+    // Possible handle to the virtio-mem device
+    virtio_mem_devices: Vec<Arc<Mutex<virtio_devices::Mem>>>,
+}
+
+pub(crate) struct PciSegmentsGuard<'a> {
+    shared_state: std::sync::MutexGuard<'a, PciHotplugSharedState>,
+}
+
+impl Deref for PciSegmentsGuard<'_> {
+    type Target = [PciSegment];
+
+    fn deref(&self) -> &Self::Target {
+        &self.shared_state.pci_segments
+    }
+}
+
+pub struct IommuAttachedDevicesGuard<'a> {
+    shared_state: std::sync::MutexGuard<'a, PciHotplugSharedState>,
+}
+
+impl Deref for IommuAttachedDevicesGuard<'_> {
+    type Target = Option<(PciBdf, Vec<PciBdf>)>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.shared_state.iommu_attached_devices
+    }
+}
+
 #[derive(Debug)]
 pub struct PtyPair {
     pub main: File,
@@ -954,9 +1000,6 @@ impl AccessPlatform for SevSnpPageAccessProxy {
 }
 
 pub struct DeviceManager {
-    // Manage address space related to devices
-    address_manager: Arc<AddressManager>,
-
     // Console abstraction
     console: Arc<Console>,
 
@@ -997,22 +1040,19 @@ pub struct DeviceManager {
     /// a weak reference).
     _acpi_cpu_hotplug_controller: Arc<Mutex<AcpiCpuHotplugController>>,
 
+    // Manage address space related to devices
+    address_manager: Arc<AddressManager>,
+
     // The virtio devices on the system
     virtio_devices: Vec<MetaVirtioDevice>,
 
     /// All disks. Needed for locking and unlocking the images.
     block_devices: Vec<Arc<Mutex<Block>>>,
 
-    // List of bus devices
-    // Let the DeviceManager keep strong references to the BusDevice devices.
-    // This allows the IO and MMIO buses to be provided with Weak references,
-    // which prevents cyclic dependencies.
-    bus_devices: Vec<Arc<dyn BusDeviceSync>>,
-
     // Counter to keep track of the consumed device IDs.
     device_id_cnt: Wrapping<usize>,
 
-    pci_segments: Vec<PciSegment>,
+    shared_state: Arc<Mutex<PciHotplugSharedState>>,
 
     #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     // MSI Interrupt Manager
@@ -1025,20 +1065,9 @@ pub struct DeviceManager {
     // Passthrough device handle
     passthrough_device: Option<VfioDeviceFd>,
 
-    // VFIO operation instance
-    // Only one can be created, therefore it is stored as part of the
-    // DeviceManager to be reused.
-    vfio_ops: Option<Arc<dyn VfioOps>>,
-
     // Paravirtualized IOMMU
     iommu_device: Option<Arc<Mutex<virtio_devices::Iommu>>>,
     iommu_mapping: Option<Arc<IommuMapping>>,
-
-    // PCI information about devices attached to the paravirtualized IOMMU
-    // It contains the virtual IOMMU PCI BDF along with the list of PCI BDF
-    // representing the devices attached to the virtual IOMMU. This is useful
-    // information for filling the ACPI VIOT table.
-    iommu_attached_devices: Option<(PciBdf, Vec<PciBdf>)>,
 
     // Tree of devices, representing the dependencies between devices.
     // Useful for introspection, snapshot and restore.
@@ -1070,11 +1099,6 @@ pub struct DeviceManager {
     activate_evt: EventFd,
 
     acpi_address: GuestAddress,
-
-    selected_segment: usize,
-
-    // Possible handle to the virtio-mem device
-    virtio_mem_devices: Vec<Arc<Mutex<virtio_devices::Mem>>>,
 
     #[cfg(target_arch = "aarch64")]
     // GPIO device for AArch64
@@ -1165,6 +1189,14 @@ fn use_64bit_bar_for_virtio_device(
 }
 
 impl DeviceManager {
+    fn shared_state(&self) -> std::sync::MutexGuard<'_, PciHotplugSharedState> {
+        self.shared_state.lock().unwrap()
+    }
+
+    fn push_bus_device(&self, bus_device: Arc<dyn BusDeviceSync>) {
+        self.shared_state().bus_devices.push(bus_device);
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         io_bus: Arc<Bus>,
@@ -1302,6 +1334,15 @@ impl DeviceManager {
             AcpiCpuHotplugController::new(&cpu_manager.lock().unwrap());
         let acpi_cpu_hotplug_controller = Arc::new(Mutex::new(acpi_cpu_hotplug_controller));
 
+        let mmio_regions = Arc::new(Mutex::new(Vec::new()));
+        let shared_state = Arc::new(Mutex::new(PciHotplugSharedState {
+            pci_segments,
+            selected_segment: 0,
+            bus_devices: Vec::new(),
+            vfio_ops: None,
+            iommu_attached_devices: None,
+            virtio_mem_devices: Vec::new(),
+        }));
         if dynamic {
             let acpi_address = address_manager
                 .allocator
@@ -1348,7 +1389,6 @@ impl DeviceManager {
         }
 
         let device_manager = DeviceManager {
-            address_manager: Arc::clone(&address_manager),
             console: Arc::new(Console::default()),
             interrupt_controller: None,
             #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
@@ -1357,18 +1397,16 @@ impl DeviceManager {
             config,
             memory_manager,
             cpu_manager,
+            address_manager: Arc::clone(&address_manager),
             virtio_devices: Vec::new(),
             block_devices: vec![],
-            bus_devices: Vec::new(),
             device_id_cnt,
+            shared_state,
             msi_interrupt_manager,
             legacy_interrupt_manager: None,
             passthrough_device: None,
-            vfio_ops: None,
             iommu_device: None,
             iommu_mapping: None,
-            iommu_attached_devices: None,
-            pci_segments,
             device_tree,
             exit_evt,
             reset_evt,
@@ -1383,11 +1421,9 @@ impl DeviceManager {
                 .try_clone()
                 .map_err(DeviceManagerError::EventFd)?,
             acpi_address,
-            selected_segment: 0,
             serial_manager: None,
             console_resize_pipe: None,
             original_termios_opt: Arc::new(Mutex::new(None)),
-            virtio_mem_devices: Vec::new(),
             #[cfg(target_arch = "aarch64")]
             gpio_device: None,
             #[cfg(feature = "pvmemcontrol")]
@@ -1401,7 +1437,7 @@ impl DeviceManager {
             acpi_platform_addresses: AcpiPlatformAddresses::default(),
             snapshot: snapshot.cloned(),
             rate_limit_groups,
-            mmio_regions: Arc::new(Mutex::new(Vec::new())),
+            mmio_regions,
             #[cfg(feature = "fw_cfg")]
             fw_cfg: None,
             #[cfg(feature = "ivshmem")]
@@ -1502,8 +1538,7 @@ impl DeviceManager {
         #[cfg(not(target_arch = "riscv64"))]
         if let Some(tpm) = self.config.clone().lock().unwrap().tpm.as_ref() {
             let tpm_dev = self.add_tpm_device(&tpm.socket)?;
-            self.bus_devices
-                .push(Arc::clone(&tpm_dev) as Arc<dyn BusDeviceSync>);
+            self.push_bus_device(Arc::clone(&tpm_dev) as Arc<dyn BusDeviceSync>);
         }
         self.legacy_interrupt_manager = Some(legacy_interrupt_manager);
 
@@ -1541,8 +1576,7 @@ impl DeviceManager {
 
         self.fw_cfg = Some(fw_cfg.clone());
 
-        self.bus_devices
-            .push(Arc::clone(&fw_cfg) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&fw_cfg) as Arc<dyn BusDeviceSync>);
 
         #[cfg(target_arch = "x86_64")]
         self.address_manager
@@ -1719,19 +1753,32 @@ impl DeviceManager {
                     None,
                     None,
                 )?;
-                self.iommu_attached_devices = Some((dev_id, iommu_attached_devices));
+                self.shared_state().iommu_attached_devices = Some((dev_id, iommu_attached_devices));
             }
         }
 
-        for segment in &self.pci_segments {
-            #[cfg(target_arch = "x86_64")]
-            if let Some(pci_config_io) = segment.pci_config_io.as_ref() {
-                self.bus_devices
-                    .push(Arc::clone(pci_config_io) as Arc<dyn BusDeviceSync>);
-            }
-
-            self.bus_devices
-                .push(Arc::clone(&segment.pci_config_mmio) as Arc<dyn BusDeviceSync>);
+        let pci_config_devices: Vec<Arc<dyn BusDeviceSync>> = self
+            .shared_state()
+            .pci_segments
+            .iter()
+            .flat_map(|segment| {
+                #[cfg(target_arch = "x86_64")]
+                {
+                    let mut devices =
+                        vec![Arc::clone(&segment.pci_config_mmio) as Arc<dyn BusDeviceSync>];
+                    if let Some(pci_config_io) = segment.pci_config_io.as_ref() {
+                        devices.push(Arc::clone(pci_config_io) as Arc<dyn BusDeviceSync>);
+                    }
+                    devices
+                }
+                #[cfg(not(target_arch = "x86_64"))]
+                {
+                    vec![Arc::clone(&segment.pci_config_mmio) as Arc<dyn BusDeviceSync>]
+                }
+            })
+            .collect();
+        for bus_device in pci_config_devices {
+            self.push_bus_device(bus_device);
         }
 
         Ok(())
@@ -1853,8 +1900,7 @@ impl DeviceManager {
             .insert(interrupt_controller.clone(), IOAPIC_START.0, IOAPIC_SIZE)
             .map_err(DeviceManagerError::BusError)?;
 
-        self.bus_devices
-            .push(Arc::clone(&interrupt_controller) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&interrupt_controller) as Arc<dyn BusDeviceSync>);
 
         // Fill the device tree with a new node. In case of restore, we
         // know there is nothing to do, so we can simply override the
@@ -1885,8 +1931,7 @@ impl DeviceManager {
             vcpus_kill_signalled,
         )));
 
-        self.bus_devices
-            .push(Arc::clone(&shutdown_device) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&shutdown_device) as Arc<dyn BusDeviceSync>);
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -1948,13 +1993,11 @@ impl DeviceManager {
                 devices::acpi::GED_DEVICE_ACPI_SIZE as u64,
             )
             .map_err(DeviceManagerError::BusError)?;
-        self.bus_devices
-            .push(Arc::clone(&ged_device) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&ged_device) as Arc<dyn BusDeviceSync>);
 
         let pm_timer_device = Arc::new(Mutex::new(devices::AcpiPmTimerDevice::new()));
 
-        self.bus_devices
-            .push(Arc::clone(&pm_timer_device) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&pm_timer_device) as Arc<dyn BusDeviceSync>);
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -1993,8 +2036,7 @@ impl DeviceManager {
             vcpus_kill_signalled.clone(),
         )));
 
-        self.bus_devices
-            .push(Arc::clone(&i8042) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&i8042) as Arc<dyn BusDeviceSync>);
 
         self.address_manager
             .io_bus
@@ -2021,8 +2063,7 @@ impl DeviceManager {
                 Some(vcpus_kill_signalled),
             )));
 
-            self.bus_devices
-                .push(Arc::clone(&cmos) as Arc<dyn BusDeviceSync>);
+            self.push_bus_device(Arc::clone(&cmos) as Arc<dyn BusDeviceSync>);
 
             self.address_manager
                 .io_bus
@@ -2031,8 +2072,7 @@ impl DeviceManager {
 
             let fwdebug = Arc::new(Mutex::new(devices::legacy::FwDebugDevice::new()));
 
-            self.bus_devices
-                .push(Arc::clone(&fwdebug) as Arc<dyn BusDeviceSync>);
+            self.push_bus_device(Arc::clone(&fwdebug) as Arc<dyn BusDeviceSync>);
 
             self.address_manager
                 .io_bus
@@ -2042,8 +2082,7 @@ impl DeviceManager {
 
         // 0x80 debug port
         let debug_port = Arc::new(Mutex::new(devices::legacy::DebugPort::new(self.timestamp)));
-        self.bus_devices
-            .push(Arc::clone(&debug_port) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&debug_port) as Arc<dyn BusDeviceSync>);
         self.address_manager
             .io_bus
             .insert(debug_port, 0x80, 0x1)
@@ -2068,8 +2107,7 @@ impl DeviceManager {
 
         let rtc_device = Arc::new(Mutex::new(devices::legacy::Rtc::new()));
 
-        self.bus_devices
-            .push(Arc::clone(&rtc_device) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&rtc_device) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_RTC_MAPPED_IO_START;
 
@@ -2110,8 +2148,7 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.bus_devices
-            .push(Arc::clone(&gpio_device) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&gpio_device) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_GPIO_MAPPED_IO_START;
 
@@ -2159,8 +2196,7 @@ impl DeviceManager {
             .iobase
             .map_or(debug_console::DEFAULT_PORT, |port| port as u64);
 
-        self.bus_devices
-            .push(Arc::clone(&debug_console) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&debug_console) as Arc<dyn BusDeviceSync>);
 
         self.address_manager
             .allocator
@@ -2210,8 +2246,7 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.bus_devices
-            .push(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
 
         self.address_manager
             .allocator
@@ -2267,8 +2302,7 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.bus_devices
-            .push(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START;
 
@@ -2330,8 +2364,7 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.bus_devices
-            .push(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START;
 
@@ -3259,7 +3292,7 @@ impl DeviceManager {
         let (region_base, region_size) = if let Some((base, size)) = region_range {
             // The memory needs to be 2MiB aligned in order to support
             // hugepages.
-            self.pci_segments[pmem_cfg.pci_common.pci_segment as usize]
+            self.shared_state().pci_segments[pmem_cfg.pci_common.pci_segment as usize]
                 .mem64_allocator
                 .lock()
                 .unwrap()
@@ -3274,7 +3307,7 @@ impl DeviceManager {
         } else {
             // The memory needs to be 2MiB aligned in order to support
             // hugepages.
-            let base = self.pci_segments[pmem_cfg.pci_common.pci_segment as usize]
+            let base = self.shared_state().pci_segments[pmem_cfg.pci_common.pci_segment as usize]
                 .mem64_allocator
                 .lock()
                 .unwrap()
@@ -3464,7 +3497,9 @@ impl DeviceManager {
                 // if needed.
                 virtio_mem_zone.set_virtio_device(Arc::clone(&virtio_mem_device));
 
-                self.virtio_mem_devices.push(Arc::clone(&virtio_mem_device));
+                self.shared_state()
+                    .virtio_mem_devices
+                    .push(Arc::clone(&virtio_mem_device));
 
                 self.virtio_devices.push(MetaVirtioDevice {
                     virtio_device: Arc::clone(&virtio_mem_device)
@@ -3807,12 +3842,12 @@ impl DeviceManager {
             }
 
             vfio_ops
-        } else if let Some(vfio_ops) = &self.vfio_ops {
+        } else if let Some(vfio_ops) = &self.shared_state().vfio_ops {
             Arc::clone(vfio_ops)
         } else {
             let vfio_ops = self.create_vfio_ops()?;
             needs_dma_mapping = true;
-            self.vfio_ops = Some(Arc::clone(&vfio_ops));
+            self.shared_state().vfio_ops = Some(Arc::clone(&vfio_ops));
 
             vfio_ops
         };
@@ -3849,7 +3884,8 @@ impl DeviceManager {
                 Arc::clone(&self.mmio_regions),
             ));
 
-            for virtio_mem_device in self.virtio_mem_devices.iter() {
+            let virtio_mem_devices = self.shared_state().virtio_mem_devices.clone();
+            for virtio_mem_device in virtio_mem_devices.iter() {
                 virtio_mem_device
                     .lock()
                     .unwrap()
@@ -3863,12 +3899,14 @@ impl DeviceManager {
 
         let legacy_interrupt_group =
             if let Some(legacy_interrupt_manager) = &self.legacy_interrupt_manager {
+                let irq = {
+                    self.shared_state().pci_segments[pci_segment_id as usize].pci_irq_slots
+                        [pci_device_bdf.device() as usize]
+                };
                 Some(
                     legacy_interrupt_manager
                         .create_group(LegacyIrqGroupConfig {
-                            irq: self.pci_segments[pci_segment_id as usize].pci_irq_slots
-                                [pci_device_bdf.device() as usize]
-                                as InterruptIndex,
+                            irq: irq as InterruptIndex,
                         })
                         .map_err(DeviceManagerError::CreateInterruptGroup)?,
                 )
@@ -3950,16 +3988,17 @@ impl DeviceManager {
         bdf: PciBdf,
         resources: Option<Vec<Resource>>,
     ) -> DeviceManagerResult<Vec<Resource>> {
+        let mut shared_state = self.shared_state();
         let bars = pci_device
             .lock()
             .unwrap()
             .allocate_bars(
                 &mut self.address_manager.allocator.lock().unwrap(),
-                &mut self.pci_segments[segment_id as usize]
+                &mut shared_state.pci_segments[segment_id as usize]
                     .mem32_allocator
                     .lock()
                     .unwrap(),
-                &mut self.pci_segments[segment_id as usize]
+                &mut shared_state.pci_segments[segment_id as usize]
                     .mem64_allocator
                     .lock()
                     .unwrap(),
@@ -3967,25 +4006,27 @@ impl DeviceManager {
             )
             .map_err(DeviceManagerError::AllocateBars)?;
 
-        let mut pci_bus = self.pci_segments[segment_id as usize]
-            .pci_bus
-            .lock()
-            .unwrap();
+        {
+            let mut pci_bus = shared_state.pci_segments[segment_id as usize]
+                .pci_bus
+                .lock()
+                .unwrap();
 
-        pci_bus
-            .add_device(bdf.device(), pci_device)
-            .map_err(DeviceManagerError::AddPciDevice)?;
+            pci_bus
+                .add_device(bdf.device(), pci_device)
+                .map_err(DeviceManagerError::AddPciDevice)?;
 
-        self.bus_devices.push(Arc::clone(&bus_device));
+            pci_bus
+                .register_mapping(
+                    Arc::clone(&bus_device),
+                    self.address_manager.io_bus.as_ref(),
+                    self.address_manager.mmio_bus.as_ref(),
+                    bars.clone(),
+                )
+                .map_err(DeviceManagerError::AddPciDevice)?;
+        }
 
-        pci_bus
-            .register_mapping(
-                bus_device,
-                self.address_manager.io_bus.as_ref(),
-                self.address_manager.mmio_bus.as_ref(),
-                bars.clone(),
-            )
-            .map_err(DeviceManagerError::AddPciDevice)?;
+        shared_state.bus_devices.push(bus_device);
 
         let mut new_resources = Vec::new();
         for bar in bars {
@@ -4040,12 +4081,14 @@ impl DeviceManager {
 
         let legacy_interrupt_group =
             if let Some(legacy_interrupt_manager) = &self.legacy_interrupt_manager {
+                let irq = {
+                    self.shared_state().pci_segments[pci_segment_id as usize].pci_irq_slots
+                        [pci_device_bdf.device() as usize]
+                };
                 Some(
                     legacy_interrupt_manager
                         .create_group(LegacyIrqGroupConfig {
-                            irq: self.pci_segments[pci_segment_id as usize].pci_irq_slots
-                                [pci_device_bdf.device() as usize]
-                                as InterruptIndex,
+                            irq: irq as InterruptIndex,
                         })
                         .map_err(DeviceManagerError::CreateInterruptGroup)?,
                 )
@@ -4074,7 +4117,8 @@ impl DeviceManager {
 
         let memory = self.memory_manager.lock().unwrap().guest_memory();
         let vfio_user_mapping = Arc::new(VfioUserDmaMapping::new(client, Arc::new(memory)));
-        for virtio_mem_device in self.virtio_mem_devices.iter() {
+        let virtio_mem_devices = self.shared_state().virtio_mem_devices.clone();
+        for virtio_mem_device in virtio_mem_devices.iter() {
             virtio_mem_device
                 .lock()
                 .unwrap()
@@ -4214,7 +4258,8 @@ impl DeviceManager {
             } else {
                 // Let every virtio-mem device handle the DMA map/unmap through the
                 // DMA handler provided.
-                for virtio_mem_device in self.virtio_mem_devices.iter() {
+                let virtio_mem_devices = self.shared_state().virtio_mem_devices.clone();
+                for virtio_mem_device in virtio_mem_devices.iter() {
                     virtio_mem_device
                         .lock()
                         .unwrap()
@@ -4379,9 +4424,11 @@ impl DeviceManager {
     }
 
     fn reserve_explicit_device_ids(&self) -> DeviceManagerResult<()> {
+        let shared_state = self.shared_state();
+
         for handle in &self.virtio_devices {
             if let Some(device_id) = handle.pci_common.pci_device_id {
-                self.pci_segments[handle.pci_common.pci_segment as usize]
+                shared_state.pci_segments[handle.pci_common.pci_segment as usize]
                     .reserve_device_id(device_id)?;
             }
         }
@@ -4391,7 +4438,7 @@ impl DeviceManager {
         if let Some(devices) = &config.devices {
             for device_cfg in devices {
                 if let Some(device_id) = device_cfg.pci_common.pci_device_id {
-                    self.pci_segments[device_cfg.pci_common.pci_segment as usize]
+                    shared_state.pci_segments[device_cfg.pci_common.pci_segment as usize]
                         .reserve_device_id(device_id)?;
                 }
             }
@@ -4400,7 +4447,7 @@ impl DeviceManager {
         if let Some(user_devices) = &config.user_devices {
             for device_cfg in user_devices {
                 if let Some(device_id) = device_cfg.pci_common.pci_device_id {
-                    self.pci_segments[device_cfg.pci_common.pci_segment as usize]
+                    shared_state.pci_segments[device_cfg.pci_common.pci_segment as usize]
                         .reserve_device_id(device_id)?;
                 }
             }
@@ -4431,7 +4478,7 @@ impl DeviceManager {
         Ok(if let Some(pci_device_bdf) = pci_device_bdf {
             let pci_segment_id = pci_device_bdf.segment();
 
-            self.pci_segments[pci_segment_id as usize]
+            self.shared_state().pci_segments[pci_segment_id as usize]
                 .pci_bus
                 .lock()
                 .unwrap()
@@ -4440,8 +4487,8 @@ impl DeviceManager {
 
             (pci_segment_id, pci_device_bdf, resources)
         } else {
-            let pci_device_bdf =
-                self.pci_segments[pci_segment_id as usize].allocate_device_id(pci_device_id)?;
+            let pci_device_bdf = self.shared_state().pci_segments[pci_segment_id as usize]
+                .allocate_device_id(pci_device_id)?;
 
             (pci_segment_id, pci_device_bdf, None)
         })
@@ -4471,8 +4518,10 @@ impl DeviceManager {
             .map(|ic| ic.clone() as Arc<Mutex<dyn InterruptController>>)
     }
 
-    pub(crate) fn pci_segments(&self) -> &Vec<PciSegment> {
-        &self.pci_segments
+    pub(crate) fn pci_segments(&self) -> PciSegmentsGuard<'_> {
+        PciSegmentsGuard {
+            shared_state: self.shared_state(),
+        }
     }
 
     // Get the guest PCI BDF for a device ID.
@@ -4508,7 +4557,8 @@ impl DeviceManager {
         }
 
         // Take care of updating the memory for VFIO PCI devices.
-        if let Some(vfio_ops) = &self.vfio_ops {
+        let vfio_ops = self.shared_state().vfio_ops.clone();
+        if let Some(vfio_ops) = vfio_ops {
             // vfio_dma_map is unsound and ought to be marked as unsafe
             #[allow(unused_unsafe)]
             // SAFETY: GuestMemoryMmap guarantees that region points
@@ -4582,8 +4632,8 @@ impl DeviceManager {
         let (bdf, device_name) = self.add_passthrough_device(device_cfg)?;
 
         // Update the PCIU bitmap
-        self.pci_segments[device_cfg.pci_common.pci_segment as usize].pci_devices_up |=
-            1 << bdf.device();
+        self.shared_state().pci_segments[device_cfg.pci_common.pci_segment as usize]
+            .pci_devices_up |= 1 << bdf.device();
 
         Ok(PciDeviceInfo {
             id: device_name,
@@ -4611,8 +4661,8 @@ impl DeviceManager {
         let (bdf, device_name) = self.add_vfio_user_device(device_cfg)?;
 
         // Update the PCIU bitmap
-        self.pci_segments[device_cfg.pci_common.pci_segment as usize].pci_devices_up |=
-            1 << bdf.device();
+        self.shared_state().pci_segments[device_cfg.pci_common.pci_segment as usize]
+            .pci_devices_up |= 1 << bdf.device();
 
         Ok(PciDeviceInfo {
             id: device_name,
@@ -4716,7 +4766,8 @@ impl DeviceManager {
         }
 
         // Update the PCID bitmap
-        self.pci_segments[pci_segment_id as usize].pci_devices_down |= 1 << pci_device_bdf.device();
+        self.shared_state().pci_segments[pci_segment_id as usize].pci_devices_down |=
+            1 << pci_device_bdf.device();
 
         Ok(())
     }
@@ -4726,9 +4777,10 @@ impl DeviceManager {
 
         // Convert the device ID into the corresponding b/d/f.
         let pci_device_bdf = PciBdf::new(pci_segment_id, 0, device_id, 0);
+        let mut shared_state = self.shared_state();
 
         // Give the PCI device ID back to the PCI bus.
-        self.pci_segments[pci_segment_id as usize]
+        shared_state.pci_segments[pci_segment_id as usize]
             .pci_bus
             .lock()
             .unwrap()
@@ -4749,27 +4801,24 @@ impl DeviceManager {
             let pci_device_handle = pci_device_node
                 .pci_device_handle
                 .ok_or(DeviceManagerError::MissingPciDevice)?;
-            if matches!(pci_device_handle, PciDeviceHandle::Virtio(_)) {
-                // The virtio-pci device has a single child
-                if !pci_device_node.children.is_empty() {
-                    assert_eq!(pci_device_node.children.len(), 1);
-                    let child_id = &pci_device_node.children[0];
-                    id.clone_from(child_id);
-                }
+            if matches!(pci_device_handle, PciDeviceHandle::Virtio(_))
+                && !pci_device_node.children.is_empty()
+            {
+                // The virtio-pci device has a single child.
+                assert_eq!(pci_device_node.children.len(), 1);
+                id.clone_from(&pci_device_node.children[0]);
             }
-            for child in pci_device_node.children.iter() {
+            for child in &pci_device_node.children {
                 device_tree.remove(child);
             }
 
             (pci_device_handle, id)
         };
 
-        let mut iommu_attached = false;
-        if let Some((_, iommu_attached_devices)) = &self.iommu_attached_devices
-            && iommu_attached_devices.contains(&pci_device_bdf)
-        {
-            iommu_attached = true;
-        }
+        let iommu_attached = shared_state
+            .iommu_attached_devices
+            .as_ref()
+            .is_some_and(|(_, devices)| devices.contains(&pci_device_bdf));
 
         let (pci_device, bus_device, virtio_device, remove_dma_handler) = match pci_device_handle {
             // VirtioMemMappingSource::Container cleanup is handled by
@@ -4809,10 +4858,8 @@ impl DeviceManager {
                 {
                     for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
                         for region in zone.regions() {
-                            let iova = region.start_addr().0;
-                            let size = region.len();
                             dma_handler
-                                .unmap(iova, size)
+                                .unmap(region.start_addr().0, region.len())
                                 .map_err(DeviceManagerError::VirtioDmaUnmap)?;
                         }
                     }
@@ -4844,7 +4891,7 @@ impl DeviceManager {
         };
 
         if remove_dma_handler {
-            for virtio_mem_device in self.virtio_mem_devices.iter() {
+            for virtio_mem_device in &shared_state.virtio_mem_devices {
                 let source = VirtioMemMappingSource::Device(pci_device_bdf.into());
                 virtio_mem_device
                     .lock()
@@ -4854,25 +4901,24 @@ impl DeviceManager {
             }
         }
 
-        // Free the allocated BARs
+        // Free the allocated BARs.
         pci_device
             .lock()
             .unwrap()
             .free_bars(
                 &mut self.address_manager.allocator.lock().unwrap(),
-                &mut self.pci_segments[pci_segment_id as usize]
+                &mut shared_state.pci_segments[pci_segment_id as usize]
                     .mem32_allocator
                     .lock()
                     .unwrap(),
-                &mut self.pci_segments[pci_segment_id as usize]
+                &mut shared_state.pci_segments[pci_segment_id as usize]
                     .mem64_allocator
                     .lock()
                     .unwrap(),
             )
             .map_err(DeviceManagerError::FreePciBars)?;
 
-        // Remove the device from the PCI bus
-        self.pci_segments[pci_segment_id as usize]
+        shared_state.pci_segments[pci_segment_id as usize]
             .pci_bus
             .lock()
             .unwrap()
@@ -4880,27 +4926,29 @@ impl DeviceManager {
             .map_err(DeviceManagerError::RemoveDeviceFromPciBus)?;
 
         #[cfg(target_arch = "x86_64")]
-        // Remove the device from the IO bus
-        self.io_bus()
+        // Remove the device from the IO bus.
+        self.address_manager
+            .io_bus
             .remove_by_device(bus_device.as_ref())
             .map_err(DeviceManagerError::RemoveDeviceFromIoBus)?;
 
-        // Remove the device from the MMIO bus
-        self.mmio_bus()
+        // Remove the device from the MMIO bus.
+        self.address_manager
+            .mmio_bus
             .remove_by_device(bus_device.as_ref())
             .map_err(DeviceManagerError::RemoveDeviceFromMmioBus)?;
 
         // Remove the device from the list of BusDevice held by the
         // DeviceManager.
-        self.bus_devices
+        shared_state
+            .bus_devices
             .retain(|dev| !Arc::ptr_eq(dev, &bus_device));
 
-        // Shutdown and remove the underlying virtio-device if present
         if let Some(virtio_device) = virtio_device {
             for mapping in virtio_device.lock().unwrap().userspace_mappings() {
                 // SAFETY: userspace_mappings only has valid mappings.
-                // TODO: do not rely on the correctness of all the code in this file
-                // for this to hold.
+                // TODO: do not rely on the correctness of all the code in this
+                // file for this to hold.
                 unsafe {
                     self.memory_manager
                         .lock()
@@ -4917,11 +4965,28 @@ impl DeviceManager {
             }
 
             virtio_device.lock().unwrap().shutdown();
-
+            drop(shared_state);
             self.virtio_devices
                 .retain(|handler| !Arc::ptr_eq(&handler.virtio_device, &virtio_device));
+            self.cleanup_vfio_ops();
+            event!(
+                "vm",
+                "device-removed",
+                "id",
+                &id,
+                "bdf",
+                pci_device_bdf.to_string()
+            );
+            return Ok(());
         }
 
+        drop(shared_state);
+        self.cleanup_vfio_ops();
+
+        // At this point, the device has been removed from all the list and
+        // buses where it was stored. At the end of this function, after
+        // any_device, bus_device and pci_device are released, the actual
+        // device will be dropped.
         event!(
             "vm",
             "device-removed",
@@ -4931,10 +4996,6 @@ impl DeviceManager {
             pci_device_bdf.to_string()
         );
 
-        // At this point, the device has been removed from all the list and
-        // buses where it was stored. At the end of this function, after
-        // any_device, bus_device and pci_device are released, the actual
-        // device will be dropped.
         Ok(())
     }
 
@@ -4965,7 +5026,7 @@ impl DeviceManager {
         )?;
 
         // Update the PCIU bitmap
-        self.pci_segments[handle.pci_common.pci_segment as usize].pci_devices_up |=
+        self.shared_state().pci_segments[handle.pci_common.pci_segment as usize].pci_devices_up |=
             1 << bdf.device();
 
         Ok(PciDeviceInfo { id, bdf })
@@ -5145,8 +5206,10 @@ impl DeviceManager {
             .map_err(DeviceManagerError::PowerButtonNotification);
     }
 
-    pub fn iommu_attached_devices(&self) -> &Option<(PciBdf, Vec<PciBdf>)> {
-        &self.iommu_attached_devices
+    pub fn iommu_attached_devices(&self) -> IommuAttachedDevicesGuard<'_> {
+        IommuAttachedDevicesGuard {
+            shared_state: self.shared_state(),
+        }
     }
 
     fn validate_identifier(&self, id: &Option<String>) -> DeviceManagerResult<()> {
@@ -5168,10 +5231,12 @@ impl DeviceManager {
     }
 
     fn cleanup_vfio_ops(&mut self) {
+        let mut state = self.shared_state();
+
         // Drop the VfioOps instance when "Self" is the only reference
-        if let Some(1) = self.vfio_ops.as_ref().map(Arc::strong_count) {
+        if let Some(1) = state.vfio_ops.as_ref().map(Arc::strong_count) {
             debug!("Drop VfioOps given no active VFIO devices.");
-            self.vfio_ops = None;
+            state.vfio_ops = None;
         }
     }
 }
@@ -5299,7 +5364,8 @@ impl Aml for DeviceManager {
         use arch::riscv64::DeviceInfoForFdt;
 
         let mut pci_scan_methods = Vec::new();
-        for i in 0..self.pci_segments.len() {
+        let pci_segment_count = self.pci_segments().len();
+        for i in 0..pci_segment_count {
             pci_scan_methods.push(aml::MethodCall::new(
                 format!("\\_SB_.PC{i:02X}.PCNT").as_str().into(),
                 vec![],
@@ -5369,13 +5435,13 @@ impl Aml for DeviceManager {
         )
         .to_aml_bytes(sink);
 
-        for segment in &self.pci_segments {
+        for segment in self.pci_segments().iter() {
             segment.to_aml_bytes(sink);
         }
 
         let mut mbrd_memory = Vec::new();
 
-        for segment in &self.pci_segments {
+        for segment in self.pci_segments().iter() {
             mbrd_memory.push(aml::Memory32Fixed::new(
                 true,
                 segment.mmio_config_address as u32,
@@ -5607,26 +5673,28 @@ const PSEG_FIELD_SIZE: usize = 4;
 
 impl BusDevice for DeviceManager {
     fn read(&mut self, base: u64, offset: u64, data: &mut [u8]) {
+        let mut shared_state = self.shared_state();
+        let selected_segment = shared_state.selected_segment;
         match offset {
             PCIU_FIELD_OFFSET => {
                 assert!(data.len() == PCIU_FIELD_SIZE);
                 data.copy_from_slice(
-                    &self.pci_segments[self.selected_segment]
+                    &shared_state.pci_segments[selected_segment]
                         .pci_devices_up
                         .to_le_bytes(),
                 );
                 // Clear the PCIU bitmap
-                self.pci_segments[self.selected_segment].pci_devices_up = 0;
+                shared_state.pci_segments[selected_segment].pci_devices_up = 0;
             }
             PCID_FIELD_OFFSET => {
                 assert!(data.len() == PCID_FIELD_SIZE);
                 data.copy_from_slice(
-                    &self.pci_segments[self.selected_segment]
+                    &shared_state.pci_segments[selected_segment]
                         .pci_devices_down
                         .to_le_bytes(),
                 );
                 // Clear the PCID bitmap
-                self.pci_segments[self.selected_segment].pci_devices_down = 0;
+                shared_state.pci_segments[selected_segment].pci_devices_down = 0;
             }
             B0EJ_FIELD_OFFSET => {
                 assert!(data.len() == B0EJ_FIELD_SIZE);
@@ -5636,7 +5704,7 @@ impl BusDevice for DeviceManager {
             }
             PSEG_FIELD_OFFSET => {
                 assert_eq!(data.len(), PSEG_FIELD_SIZE);
-                data.copy_from_slice(&(self.selected_segment as u32).to_le_bytes());
+                data.copy_from_slice(&(selected_segment as u32).to_le_bytes());
             }
             _ => error!("Accessing unknown location at base 0x{base:x}, offset 0x{offset:x}"),
         }
@@ -5648,16 +5716,16 @@ impl BusDevice for DeviceManager {
         match offset {
             B0EJ_FIELD_OFFSET => {
                 assert!(data.len() == B0EJ_FIELD_SIZE);
+                let selected_segment = self.shared_state().selected_segment as u16;
                 let mut data_array: [u8; 4] = [0, 0, 0, 0];
                 data_array.copy_from_slice(data);
                 let mut slot_bitmap = u32::from_le_bytes(data_array);
 
                 while slot_bitmap > 0 {
                     let slot_id = slot_bitmap.trailing_zeros();
-                    if let Err(e) = self.eject_device(self.selected_segment as u16, slot_id as u8) {
+                    if let Err(e) = self.eject_device(selected_segment, slot_id as u8) {
                         error!("Failed ejecting device {slot_id}: {e:?}");
                     }
-                    self.cleanup_vfio_ops();
                     slot_bitmap &= !(1 << slot_id);
                 }
             }
@@ -5666,15 +5734,16 @@ impl BusDevice for DeviceManager {
                 let mut data_array: [u8; 4] = [0, 0, 0, 0];
                 data_array.copy_from_slice(data);
                 let selected_segment = u32::from_le_bytes(data_array) as usize;
-                if selected_segment >= self.pci_segments.len() {
+                let mut shared_state = self.shared_state();
+                if selected_segment >= shared_state.pci_segments.len() {
                     error!(
                         "Segment selection out of range: {} >= {}",
                         selected_segment,
-                        self.pci_segments.len()
+                        shared_state.pci_segments.len()
                     );
                     return None;
                 }
-                self.selected_segment = selected_segment;
+                shared_state.selected_segment = selected_segment;
             }
             _ => error!("Accessing unknown location at base 0x{base:x}, offset 0x{offset:x}"),
         }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -907,7 +907,7 @@ struct DeviceManagerState {
     device_id_cnt: Wrapping<usize>,
 }
 
-struct DeviceManagerSharedState {
+struct PciHotplugSharedState {
     pci_segments: Vec<PciSegment>,
     // List of bus devices
     // Let the DeviceManager keep strong references to the BusDevice devices.
@@ -1059,7 +1059,7 @@ pub struct DeviceManager {
     // Counter to keep track of the consumed device IDs.
     device_id_cnt: Wrapping<usize>,
 
-    shared_state: Arc<Mutex<DeviceManagerSharedState>>,
+    shared_state: Arc<Mutex<PciHotplugSharedState>>,
 
     #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     // MSI Interrupt Manager
@@ -1163,7 +1163,7 @@ pub struct DeviceManager {
 ///
 /// Shares PCI hotplug state with the [`DeviceManager`].
 pub struct AcpiPciHotplugController {
-    shared_state: Arc<Mutex<DeviceManagerSharedState>>,
+    shared_state: Arc<Mutex<PciHotplugSharedState>>,
     selected_segment: usize,
     address_manager: Arc<AddressManager>,
     memory_manager: Arc<Mutex<MemoryManager>>,
@@ -1211,7 +1211,7 @@ fn create_mmio_allocators(
 
 impl AcpiPciHotplugController {
     fn new(
-        shared_state: Arc<Mutex<DeviceManagerSharedState>>,
+        shared_state: Arc<Mutex<PciHotplugSharedState>>,
         address_manager: Arc<AddressManager>,
         memory_manager: Arc<Mutex<MemoryManager>>,
         device_tree: Arc<Mutex<DeviceTree>>,
@@ -1227,7 +1227,7 @@ impl AcpiPciHotplugController {
         }
     }
 
-    fn cleanup_vfio_ops(shared_state: &mut DeviceManagerSharedState) {
+    fn cleanup_vfio_ops(shared_state: &mut PciHotplugSharedState) {
         if let Some(1) = shared_state.vfio_ops.as_ref().map(Arc::strong_count) {
             debug!("Drop VfioOps given no active VFIO devices.");
             shared_state.vfio_ops = None;
@@ -1450,7 +1450,7 @@ impl AcpiPciHotplugController {
 }
 
 impl DeviceManager {
-    fn shared_state(&self) -> std::sync::MutexGuard<'_, DeviceManagerSharedState> {
+    fn shared_state(&self) -> std::sync::MutexGuard<'_, PciHotplugSharedState> {
         self.shared_state.lock().unwrap()
     }
 
@@ -1596,7 +1596,7 @@ impl DeviceManager {
 
         let device_tree = Arc::clone(&device_tree);
         let mmio_regions = Arc::new(Mutex::new(Vec::new()));
-        let shared_state = Arc::new(Mutex::new(DeviceManagerSharedState {
+        let shared_state = Arc::new(Mutex::new(PciHotplugSharedState {
             pci_segments,
             bus_devices: Vec::new(),
             vfio_ops: None,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -894,6 +894,24 @@ struct PciHotplugSharedState {
     virtio_mem_devices: Vec<Arc<Mutex<virtio_devices::Mem>>>,
 }
 
+impl PciHotplugSharedState {
+    fn push_bus_device(&mut self, bus_device: Arc<dyn BusDeviceSync>) {
+        self.bus_devices.push(bus_device);
+    }
+
+    fn remove_bus_device(&mut self, bus_device: &Arc<dyn BusDeviceSync>) {
+        self.bus_devices.retain(|dev| !Arc::ptr_eq(dev, bus_device));
+    }
+
+    fn cleanup_vfio_ops(&mut self) {
+        // Drop the VfioOps instance when "Self" is the only reference.
+        if let Some(1) = self.vfio_ops.as_ref().map(Arc::strong_count) {
+            debug!("Drop VfioOps given no active VFIO devices.");
+            self.vfio_ops = None;
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct PtyPair {
     pub main: File,
@@ -1197,13 +1215,6 @@ impl AcpiPciHotplugController {
         }
     }
 
-    fn cleanup_vfio_ops(shared_state: &mut PciHotplugSharedState) {
-        if let Some(1) = shared_state.vfio_ops.as_ref().map(Arc::strong_count) {
-            debug!("Drop VfioOps given no active VFIO devices.");
-            shared_state.vfio_ops = None;
-        }
-    }
-
     fn eject_device(
         &mut self,
         pci_segment_id: u16,
@@ -1402,10 +1413,8 @@ impl AcpiPciHotplugController {
         let mut shared_state = self.shared_state.lock().unwrap();
         // Remove the device from the list of BusDevice held by the
         // DeviceManager.
-        shared_state
-            .bus_devices
-            .retain(|dev| !Arc::ptr_eq(dev, &bus_device));
-        Self::cleanup_vfio_ops(&mut shared_state);
+        shared_state.remove_bus_device(&bus_device);
+        shared_state.cleanup_vfio_ops();
         drop(shared_state);
 
         // At this point, the device has been removed from all the list and
@@ -1428,10 +1437,6 @@ impl AcpiPciHotplugController {
 impl DeviceManager {
     fn shared_state(&self) -> std::sync::MutexGuard<'_, PciHotplugSharedState> {
         self.shared_state.lock().unwrap()
-    }
-
-    fn push_bus_device(&self, bus_device: Arc<dyn BusDeviceSync>) {
-        self.shared_state().bus_devices.push(bus_device);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1784,7 +1789,8 @@ impl DeviceManager {
         #[cfg(not(target_arch = "riscv64"))]
         if let Some(tpm) = self.config.clone().lock().unwrap().tpm.as_ref() {
             let tpm_dev = self.add_tpm_device(&tpm.socket)?;
-            self.push_bus_device(Arc::clone(&tpm_dev) as Arc<dyn BusDeviceSync>);
+            self.shared_state()
+                .push_bus_device(Arc::clone(&tpm_dev) as Arc<dyn BusDeviceSync>);
         }
         self.legacy_interrupt_manager = Some(legacy_interrupt_manager);
 
@@ -1822,7 +1828,8 @@ impl DeviceManager {
 
         self.fw_cfg = Some(fw_cfg.clone());
 
-        self.push_bus_device(Arc::clone(&fw_cfg) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&fw_cfg) as Arc<dyn BusDeviceSync>);
 
         #[cfg(target_arch = "x86_64")]
         self.address_manager
@@ -2024,7 +2031,7 @@ impl DeviceManager {
             })
             .collect();
         for bus_device in pci_config_devices {
-            self.push_bus_device(bus_device);
+            self.shared_state().push_bus_device(bus_device);
         }
 
         Ok(())
@@ -2146,7 +2153,8 @@ impl DeviceManager {
             .insert(interrupt_controller.clone(), IOAPIC_START.0, IOAPIC_SIZE)
             .map_err(DeviceManagerError::BusError)?;
 
-        self.push_bus_device(Arc::clone(&interrupt_controller) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&interrupt_controller) as Arc<dyn BusDeviceSync>);
 
         // Fill the device tree with a new node. In case of restore, we
         // know there is nothing to do, so we can simply override the
@@ -2177,7 +2185,8 @@ impl DeviceManager {
             vcpus_kill_signalled,
         )));
 
-        self.push_bus_device(Arc::clone(&shutdown_device) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&shutdown_device) as Arc<dyn BusDeviceSync>);
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -2239,11 +2248,13 @@ impl DeviceManager {
                 devices::acpi::GED_DEVICE_ACPI_SIZE as u64,
             )
             .map_err(DeviceManagerError::BusError)?;
-        self.push_bus_device(Arc::clone(&ged_device) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&ged_device) as Arc<dyn BusDeviceSync>);
 
         let pm_timer_device = Arc::new(Mutex::new(devices::AcpiPmTimerDevice::new()));
 
-        self.push_bus_device(Arc::clone(&pm_timer_device) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&pm_timer_device) as Arc<dyn BusDeviceSync>);
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -2282,7 +2293,8 @@ impl DeviceManager {
             vcpus_kill_signalled.clone(),
         )));
 
-        self.push_bus_device(Arc::clone(&i8042) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&i8042) as Arc<dyn BusDeviceSync>);
 
         self.address_manager
             .io_bus
@@ -2309,7 +2321,8 @@ impl DeviceManager {
                 Some(vcpus_kill_signalled),
             )));
 
-            self.push_bus_device(Arc::clone(&cmos) as Arc<dyn BusDeviceSync>);
+            self.shared_state()
+                .push_bus_device(Arc::clone(&cmos) as Arc<dyn BusDeviceSync>);
 
             self.address_manager
                 .io_bus
@@ -2318,7 +2331,8 @@ impl DeviceManager {
 
             let fwdebug = Arc::new(Mutex::new(devices::legacy::FwDebugDevice::new()));
 
-            self.push_bus_device(Arc::clone(&fwdebug) as Arc<dyn BusDeviceSync>);
+            self.shared_state()
+                .push_bus_device(Arc::clone(&fwdebug) as Arc<dyn BusDeviceSync>);
 
             self.address_manager
                 .io_bus
@@ -2328,7 +2342,8 @@ impl DeviceManager {
 
         // 0x80 debug port
         let debug_port = Arc::new(Mutex::new(devices::legacy::DebugPort::new(self.timestamp)));
-        self.push_bus_device(Arc::clone(&debug_port) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&debug_port) as Arc<dyn BusDeviceSync>);
         self.address_manager
             .io_bus
             .insert(debug_port, 0x80, 0x1)
@@ -2353,7 +2368,8 @@ impl DeviceManager {
 
         let rtc_device = Arc::new(Mutex::new(devices::legacy::Rtc::new()));
 
-        self.push_bus_device(Arc::clone(&rtc_device) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&rtc_device) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_RTC_MAPPED_IO_START;
 
@@ -2394,7 +2410,8 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.push_bus_device(Arc::clone(&gpio_device) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&gpio_device) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_GPIO_MAPPED_IO_START;
 
@@ -2442,7 +2459,8 @@ impl DeviceManager {
             .iobase
             .map_or(debug_console::DEFAULT_PORT, |port| port as u64);
 
-        self.push_bus_device(Arc::clone(&debug_console) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&debug_console) as Arc<dyn BusDeviceSync>);
 
         self.address_manager
             .allocator
@@ -2492,7 +2510,8 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
 
         self.address_manager
             .allocator
@@ -2548,7 +2567,8 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START;
 
@@ -2610,7 +2630,8 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
+        self.shared_state()
+            .push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START;
 
@@ -4272,7 +4293,7 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::AddPciDevice)?;
         }
 
-        shared_state.bus_devices.push(bus_device);
+        shared_state.push_bus_device(bus_device);
 
         let mut new_resources = Vec::new();
         for bar in bars {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -909,7 +909,6 @@ struct DeviceManagerState {
 
 struct DeviceManagerSharedState {
     pci_segments: Vec<PciSegment>,
-    selected_segment: usize,
     // List of bus devices
     // Let the DeviceManager keep strong references to the BusDevice devices.
     // This allows the IO and MMIO buses to be provided with Weak references,
@@ -1165,6 +1164,7 @@ pub struct DeviceManager {
 /// Shares PCI hotplug state with the [`DeviceManager`].
 pub struct AcpiPciHotplugController {
     shared_state: Arc<Mutex<DeviceManagerSharedState>>,
+    selected_segment: usize,
     address_manager: Arc<AddressManager>,
     memory_manager: Arc<Mutex<MemoryManager>>,
     device_tree: Arc<Mutex<DeviceTree>>,
@@ -1219,6 +1219,7 @@ impl AcpiPciHotplugController {
     ) -> Self {
         Self {
             shared_state,
+            selected_segment: 0,
             address_manager,
             memory_manager,
             device_tree,
@@ -1597,7 +1598,6 @@ impl DeviceManager {
         let mmio_regions = Arc::new(Mutex::new(Vec::new()));
         let shared_state = Arc::new(Mutex::new(DeviceManagerSharedState {
             pci_segments,
-            selected_segment: 0,
             bus_devices: Vec::new(),
             vfio_ops: None,
             iommu_attached_devices: None,
@@ -5772,7 +5772,7 @@ const PSEG_FIELD_SIZE: usize = 4;
 impl BusDevice for AcpiPciHotplugController {
     fn read(&mut self, base: u64, offset: u64, data: &mut [u8]) {
         let mut shared_state = self.shared_state.lock().unwrap();
-        let selected_segment = shared_state.selected_segment;
+        let selected_segment = self.selected_segment;
         match offset {
             PCIU_FIELD_OFFSET => {
                 assert!(data.len() == PCIU_FIELD_SIZE);
@@ -5814,7 +5814,7 @@ impl BusDevice for AcpiPciHotplugController {
         match offset {
             B0EJ_FIELD_OFFSET => {
                 assert!(data.len() == B0EJ_FIELD_SIZE);
-                let selected_segment = self.shared_state.lock().unwrap().selected_segment as u16;
+                let selected_segment = self.selected_segment as u16;
                 let mut data_array: [u8; 4] = [0, 0, 0, 0];
                 data_array.copy_from_slice(data);
                 let mut slot_bitmap = u32::from_le_bytes(data_array);
@@ -5832,7 +5832,7 @@ impl BusDevice for AcpiPciHotplugController {
                 let mut data_array: [u8; 4] = [0, 0, 0, 0];
                 data_array.copy_from_slice(data);
                 let selected_segment = u32::from_le_bytes(data_array) as usize;
-                let mut shared_state = self.shared_state.lock().unwrap();
+                let shared_state = self.shared_state.lock().unwrap();
                 if selected_segment >= shared_state.pci_segments.len() {
                     error!(
                         "Segment selection out of range: {} >= {}",
@@ -5841,7 +5841,8 @@ impl BusDevice for AcpiPciHotplugController {
                     );
                     return None;
                 }
-                shared_state.selected_segment = selected_segment;
+                drop(shared_state);
+                self.selected_segment = selected_segment;
             }
             _ => error!("Accessing unknown location at base 0x{base:x}, offset 0x{offset:x}"),
         }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -13,6 +13,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::{File, OpenOptions};
 use std::io::{self, IsTerminal, Seek, SeekFrom, stdout};
 use std::num::Wrapping;
+use std::ops::Deref;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 #[cfg(not(target_arch = "riscv64"))]
@@ -907,6 +908,51 @@ struct DeviceManagerState {
     device_id_cnt: Wrapping<usize>,
 }
 
+struct DeviceManagerSharedState {
+    pci_segments: Vec<PciSegment>,
+    selected_segment: usize,
+    // List of bus devices
+    // Let the DeviceManager keep strong references to the BusDevice devices.
+    // This allows the IO and MMIO buses to be provided with Weak references,
+    // which prevents cyclic dependencies.
+    bus_devices: Vec<Arc<dyn BusDeviceSync>>,
+    // VFIO operation instance
+    // Only one can be created, therefore it is stored as part of the
+    // DeviceManager to be reused.
+    vfio_ops: Option<Arc<dyn VfioOps>>,
+    // PCI information about devices attached to the paravirtualized IOMMU
+    // It contains the virtual IOMMU PCI BDF along with the list of PCI BDF
+    // representing the devices attached to the virtual IOMMU. This is useful
+    // information for filling the ACPI VIOT table.
+    iommu_attached_devices: Option<(PciBdf, Vec<PciBdf>)>,
+    // Possible handle to the virtio-mem device
+    virtio_mem_devices: Vec<Arc<Mutex<virtio_devices::Mem>>>,
+}
+
+pub(crate) struct PciSegmentsGuard<'a> {
+    shared_state: std::sync::MutexGuard<'a, DeviceManagerSharedState>,
+}
+
+impl Deref for PciSegmentsGuard<'_> {
+    type Target = [PciSegment];
+
+    fn deref(&self) -> &Self::Target {
+        &self.shared_state.pci_segments
+    }
+}
+
+pub struct IommuAttachedDevicesGuard<'a> {
+    shared_state: std::sync::MutexGuard<'a, DeviceManagerSharedState>,
+}
+
+impl Deref for IommuAttachedDevicesGuard<'_> {
+    type Target = Option<(PciBdf, Vec<PciBdf>)>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.shared_state.iommu_attached_devices
+    }
+}
+
 #[derive(Debug)]
 pub struct PtyPair {
     pub main: File,
@@ -987,9 +1033,6 @@ impl AccessPlatform for SevSnpPageAccessProxy {
 }
 
 pub struct DeviceManager {
-    // Manage address space related to devices
-    address_manager: Arc<AddressManager>,
-
     // Console abstraction
     console: Arc<Console>,
 
@@ -1030,22 +1073,19 @@ pub struct DeviceManager {
     /// a weak reference).
     _acpi_cpu_hotplug_controller: Arc<Mutex<AcpiCpuHotplugController>>,
 
+    // Manage address space related to devices
+    address_manager: Arc<AddressManager>,
+
     // The virtio devices on the system
     virtio_devices: Vec<MetaVirtioDevice>,
 
     /// All disks. Needed for locking and unlocking the images.
     block_devices: Vec<Arc<Mutex<Block>>>,
 
-    // List of bus devices
-    // Let the DeviceManager keep strong references to the BusDevice devices.
-    // This allows the IO and MMIO buses to be provided with Weak references,
-    // which prevents cyclic dependencies.
-    bus_devices: Vec<Arc<dyn BusDeviceSync>>,
-
     // Counter to keep track of the consumed device IDs.
     device_id_cnt: Wrapping<usize>,
 
-    pci_segments: Vec<PciSegment>,
+    shared_state: Arc<Mutex<DeviceManagerSharedState>>,
 
     #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     // MSI Interrupt Manager
@@ -1058,20 +1098,9 @@ pub struct DeviceManager {
     // Passthrough device handle
     passthrough_device: Option<VfioDeviceFd>,
 
-    // VFIO operation instance
-    // Only one can be created, therefore it is stored as part of the
-    // DeviceManager to be reused.
-    vfio_ops: Option<Arc<dyn VfioOps>>,
-
     // Paravirtualized IOMMU
     iommu_device: Option<Arc<Mutex<virtio_devices::Iommu>>>,
     iommu_mapping: Option<Arc<IommuMapping>>,
-
-    // PCI information about devices attached to the paravirtualized IOMMU
-    // It contains the virtual IOMMU PCI BDF along with the list of PCI BDF
-    // representing the devices attached to the virtual IOMMU. This is useful
-    // information for filling the ACPI VIOT table.
-    iommu_attached_devices: Option<(PciBdf, Vec<PciBdf>)>,
 
     // Tree of devices, representing the dependencies between devices.
     // Useful for introspection, snapshot and restore.
@@ -1102,11 +1131,6 @@ pub struct DeviceManager {
     activate_evt: EventFd,
 
     acpi_address: GuestAddress,
-
-    selected_segment: usize,
-
-    // Possible handle to the virtio-mem device
-    virtio_mem_devices: Vec<Arc<Mutex<virtio_devices::Mem>>>,
 
     #[cfg(target_arch = "aarch64")]
     // GPIO device for AArch64
@@ -1196,6 +1220,14 @@ fn create_mmio_allocators(
 }
 
 impl DeviceManager {
+    fn shared_state(&self) -> std::sync::MutexGuard<'_, DeviceManagerSharedState> {
+        self.shared_state.lock().unwrap()
+    }
+
+    fn push_bus_device(&self, bus_device: Arc<dyn BusDeviceSync>) {
+        self.shared_state().bus_devices.push(bus_device);
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         io_bus: Arc<Bus>,
@@ -1332,6 +1364,15 @@ impl DeviceManager {
             AcpiCpuHotplugController::new(&cpu_manager.lock().unwrap());
         let acpi_cpu_hotplug_controller = Arc::new(Mutex::new(acpi_cpu_hotplug_controller));
 
+        let mmio_regions = Arc::new(Mutex::new(Vec::new()));
+        let shared_state = Arc::new(Mutex::new(DeviceManagerSharedState {
+            pci_segments,
+            selected_segment: 0,
+            bus_devices: Vec::new(),
+            vfio_ops: None,
+            iommu_attached_devices: None,
+            virtio_mem_devices: Vec::new(),
+        }));
         if dynamic {
             let acpi_address = address_manager
                 .allocator
@@ -1378,7 +1419,6 @@ impl DeviceManager {
         }
 
         let device_manager = DeviceManager {
-            address_manager: Arc::clone(&address_manager),
             console: Arc::new(Console::default()),
             interrupt_controller: None,
             #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
@@ -1387,18 +1427,16 @@ impl DeviceManager {
             config,
             memory_manager,
             cpu_manager,
+            address_manager: Arc::clone(&address_manager),
             virtio_devices: Vec::new(),
             block_devices: vec![],
-            bus_devices: Vec::new(),
             device_id_cnt,
+            shared_state,
             msi_interrupt_manager,
             legacy_interrupt_manager: None,
             passthrough_device: None,
-            vfio_ops: None,
             iommu_device: None,
             iommu_mapping: None,
-            iommu_attached_devices: None,
-            pci_segments,
             device_tree,
             exit_evt,
             reset_evt,
@@ -1412,11 +1450,9 @@ impl DeviceManager {
                 .try_clone()
                 .map_err(DeviceManagerError::EventFd)?,
             acpi_address,
-            selected_segment: 0,
             serial_manager: None,
             console_resize_pipe: None,
             original_termios_opt: Arc::new(Mutex::new(None)),
-            virtio_mem_devices: Vec::new(),
             #[cfg(target_arch = "aarch64")]
             gpio_device: None,
             #[cfg(feature = "pvmemcontrol")]
@@ -1432,7 +1468,7 @@ impl DeviceManager {
             acpi_platform_addresses: AcpiPlatformAddresses::default(),
             snapshot: snapshot.cloned(),
             rate_limit_groups,
-            mmio_regions: Arc::new(Mutex::new(Vec::new())),
+            mmio_regions,
             #[cfg(feature = "fw_cfg")]
             fw_cfg: None,
             #[cfg(feature = "ivshmem")]
@@ -1533,8 +1569,7 @@ impl DeviceManager {
         #[cfg(not(target_arch = "riscv64"))]
         if let Some(tpm) = self.config.clone().lock().unwrap().tpm.as_ref() {
             let tpm_dev = self.add_tpm_device(&tpm.socket)?;
-            self.bus_devices
-                .push(Arc::clone(&tpm_dev) as Arc<dyn BusDeviceSync>);
+            self.push_bus_device(Arc::clone(&tpm_dev) as Arc<dyn BusDeviceSync>);
         }
         self.legacy_interrupt_manager = Some(legacy_interrupt_manager);
 
@@ -1572,8 +1607,7 @@ impl DeviceManager {
 
         self.fw_cfg = Some(fw_cfg.clone());
 
-        self.bus_devices
-            .push(Arc::clone(&fw_cfg) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&fw_cfg) as Arc<dyn BusDeviceSync>);
 
         #[cfg(target_arch = "x86_64")]
         self.address_manager
@@ -1736,19 +1770,26 @@ impl DeviceManager {
 
             if let Some(iommu_device) = iommu_device {
                 let dev_id = self.add_virtio_pci_device(iommu_device, &None, &iommu_id, 0, None)?;
-                self.iommu_attached_devices = Some((dev_id, iommu_attached_devices));
+                self.shared_state().iommu_attached_devices = Some((dev_id, iommu_attached_devices));
             }
         }
 
-        for segment in &self.pci_segments {
-            #[cfg(target_arch = "x86_64")]
-            if let Some(pci_config_io) = segment.pci_config_io.as_ref() {
-                self.bus_devices
-                    .push(Arc::clone(pci_config_io) as Arc<dyn BusDeviceSync>);
-            }
-
-            self.bus_devices
-                .push(Arc::clone(&segment.pci_config_mmio) as Arc<dyn BusDeviceSync>);
+        let pci_config_devices: Vec<Arc<dyn BusDeviceSync>> = self
+            .shared_state()
+            .pci_segments
+            .iter()
+            .flat_map(|segment| {
+                let mut devices = Vec::new();
+                #[cfg(target_arch = "x86_64")]
+                if let Some(pci_config_io) = segment.pci_config_io.as_ref() {
+                    devices.push(Arc::clone(pci_config_io) as Arc<dyn BusDeviceSync>);
+                }
+                devices.push(Arc::clone(&segment.pci_config_mmio) as Arc<dyn BusDeviceSync>);
+                devices
+            })
+            .collect();
+        for bus_device in pci_config_devices {
+            self.push_bus_device(bus_device);
         }
 
         Ok(())
@@ -1870,8 +1911,7 @@ impl DeviceManager {
             .insert(interrupt_controller.clone(), IOAPIC_START.0, IOAPIC_SIZE)
             .map_err(DeviceManagerError::BusError)?;
 
-        self.bus_devices
-            .push(Arc::clone(&interrupt_controller) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&interrupt_controller) as Arc<dyn BusDeviceSync>);
 
         // Fill the device tree with a new node. In case of restore, we
         // know there is nothing to do, so we can simply override the
@@ -1902,8 +1942,7 @@ impl DeviceManager {
             vcpus_kill_signalled,
         )));
 
-        self.bus_devices
-            .push(Arc::clone(&shutdown_device) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&shutdown_device) as Arc<dyn BusDeviceSync>);
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -1965,13 +2004,11 @@ impl DeviceManager {
                 devices::acpi::GED_DEVICE_ACPI_SIZE as u64,
             )
             .map_err(DeviceManagerError::BusError)?;
-        self.bus_devices
-            .push(Arc::clone(&ged_device) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&ged_device) as Arc<dyn BusDeviceSync>);
 
         let pm_timer_device = Arc::new(Mutex::new(devices::AcpiPmTimerDevice::new()));
 
-        self.bus_devices
-            .push(Arc::clone(&pm_timer_device) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&pm_timer_device) as Arc<dyn BusDeviceSync>);
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -2010,8 +2047,7 @@ impl DeviceManager {
             vcpus_kill_signalled.clone(),
         )));
 
-        self.bus_devices
-            .push(Arc::clone(&i8042) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&i8042) as Arc<dyn BusDeviceSync>);
 
         self.address_manager
             .io_bus
@@ -2038,8 +2074,7 @@ impl DeviceManager {
                 Some(vcpus_kill_signalled),
             )));
 
-            self.bus_devices
-                .push(Arc::clone(&cmos) as Arc<dyn BusDeviceSync>);
+            self.push_bus_device(Arc::clone(&cmos) as Arc<dyn BusDeviceSync>);
 
             self.address_manager
                 .io_bus
@@ -2048,8 +2083,7 @@ impl DeviceManager {
 
             let fwdebug = Arc::new(Mutex::new(devices::legacy::FwDebugDevice::new()));
 
-            self.bus_devices
-                .push(Arc::clone(&fwdebug) as Arc<dyn BusDeviceSync>);
+            self.push_bus_device(Arc::clone(&fwdebug) as Arc<dyn BusDeviceSync>);
 
             self.address_manager
                 .io_bus
@@ -2059,8 +2093,7 @@ impl DeviceManager {
 
         // 0x80 debug port
         let debug_port = Arc::new(Mutex::new(devices::legacy::DebugPort::new(self.timestamp)));
-        self.bus_devices
-            .push(Arc::clone(&debug_port) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&debug_port) as Arc<dyn BusDeviceSync>);
         self.address_manager
             .io_bus
             .insert(debug_port, 0x80, 0x1)
@@ -2085,8 +2118,7 @@ impl DeviceManager {
 
         let rtc_device = Arc::new(Mutex::new(devices::legacy::Rtc::new()));
 
-        self.bus_devices
-            .push(Arc::clone(&rtc_device) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&rtc_device) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_RTC_MAPPED_IO_START;
 
@@ -2127,8 +2159,7 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.bus_devices
-            .push(Arc::clone(&gpio_device) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&gpio_device) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_GPIO_MAPPED_IO_START;
 
@@ -2176,8 +2207,7 @@ impl DeviceManager {
             .iobase
             .map_or(debug_console::DEFAULT_PORT, |port| port as u64);
 
-        self.bus_devices
-            .push(Arc::clone(&debug_console) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&debug_console) as Arc<dyn BusDeviceSync>);
 
         self.address_manager
             .allocator
@@ -2227,8 +2257,7 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.bus_devices
-            .push(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
 
         self.address_manager
             .allocator
@@ -2284,8 +2313,7 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.bus_devices
-            .push(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START;
 
@@ -2347,8 +2375,7 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::RestoreGetState)?,
         )));
 
-        self.bus_devices
-            .push(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
+        self.push_bus_device(Arc::clone(&serial) as Arc<dyn BusDeviceSync>);
 
         let addr = arch::layout::LEGACY_SERIAL_MAPPED_IO_START;
 
@@ -3408,7 +3435,7 @@ impl DeviceManager {
         let (region_base, region_size) = if let Some((base, size)) = region_range {
             // The memory needs to be 2MiB aligned in order to support
             // hugepages.
-            self.pci_segments[pmem_cfg.pci_common.pci_segment as usize]
+            self.shared_state().pci_segments[pmem_cfg.pci_common.pci_segment as usize]
                 .mem64_allocator
                 .lock()
                 .unwrap()
@@ -3423,7 +3450,7 @@ impl DeviceManager {
         } else {
             // The memory needs to be 2MiB aligned in order to support
             // hugepages.
-            let base = self.pci_segments[pmem_cfg.pci_common.pci_segment as usize]
+            let base = self.shared_state().pci_segments[pmem_cfg.pci_common.pci_segment as usize]
                 .mem64_allocator
                 .lock()
                 .unwrap()
@@ -3613,7 +3640,9 @@ impl DeviceManager {
                 // if needed.
                 virtio_mem_zone.set_virtio_device(Arc::clone(&virtio_mem_device));
 
-                self.virtio_mem_devices.push(Arc::clone(&virtio_mem_device));
+                self.shared_state()
+                    .virtio_mem_devices
+                    .push(Arc::clone(&virtio_mem_device));
 
                 self.virtio_devices.push(MetaVirtioDevice {
                     virtio_device: Arc::clone(&virtio_mem_device)
@@ -3952,12 +3981,12 @@ impl DeviceManager {
             }
 
             vfio_ops
-        } else if let Some(vfio_ops) = &self.vfio_ops {
+        } else if let Some(vfio_ops) = &self.shared_state().vfio_ops {
             Arc::clone(vfio_ops)
         } else {
             let vfio_ops = self.create_vfio_ops()?;
             needs_dma_mapping = true;
-            self.vfio_ops = Some(Arc::clone(&vfio_ops));
+            self.shared_state().vfio_ops = Some(Arc::clone(&vfio_ops));
 
             vfio_ops
         };
@@ -3994,7 +4023,8 @@ impl DeviceManager {
                 Arc::clone(&self.mmio_regions),
             ));
 
-            for virtio_mem_device in self.virtio_mem_devices.iter() {
+            let virtio_mem_devices = self.shared_state().virtio_mem_devices.clone();
+            for virtio_mem_device in virtio_mem_devices.iter() {
                 virtio_mem_device
                     .lock()
                     .unwrap()
@@ -4008,12 +4038,14 @@ impl DeviceManager {
 
         let legacy_interrupt_group =
             if let Some(legacy_interrupt_manager) = &self.legacy_interrupt_manager {
+                let irq = {
+                    self.shared_state().pci_segments[pci_segment_id as usize].pci_irq_slots
+                        [pci_device_bdf.device() as usize]
+                };
                 Some(
                     legacy_interrupt_manager
                         .create_group(LegacyIrqGroupConfig {
-                            irq: self.pci_segments[pci_segment_id as usize].pci_irq_slots
-                                [pci_device_bdf.device() as usize]
-                                as InterruptIndex,
+                            irq: irq as InterruptIndex,
                         })
                         .map_err(DeviceManagerError::CreateInterruptGroup)?,
                 )
@@ -4095,16 +4127,17 @@ impl DeviceManager {
         bdf: PciBdf,
         resources: Option<Vec<Resource>>,
     ) -> DeviceManagerResult<Vec<Resource>> {
+        let mut shared_state = self.shared_state();
         let bars = pci_device
             .lock()
             .unwrap()
             .allocate_bars(
                 &mut self.address_manager.allocator.lock().unwrap(),
-                &mut self.pci_segments[segment_id as usize]
+                &mut shared_state.pci_segments[segment_id as usize]
                     .mem32_allocator
                     .lock()
                     .unwrap(),
-                &mut self.pci_segments[segment_id as usize]
+                &mut shared_state.pci_segments[segment_id as usize]
                     .mem64_allocator
                     .lock()
                     .unwrap(),
@@ -4112,25 +4145,27 @@ impl DeviceManager {
             )
             .map_err(DeviceManagerError::AllocateBars)?;
 
-        let mut pci_bus = self.pci_segments[segment_id as usize]
-            .pci_bus
-            .lock()
-            .unwrap();
+        {
+            let mut pci_bus = shared_state.pci_segments[segment_id as usize]
+                .pci_bus
+                .lock()
+                .unwrap();
 
-        pci_bus
-            .add_device(bdf.device() as u32, pci_device)
-            .map_err(DeviceManagerError::AddPciDevice)?;
+            pci_bus
+                .add_device(bdf.device() as u32, pci_device)
+                .map_err(DeviceManagerError::AddPciDevice)?;
 
-        self.bus_devices.push(Arc::clone(&bus_device));
+            pci_bus
+                .register_mapping(
+                    Arc::clone(&bus_device),
+                    self.address_manager.io_bus.as_ref(),
+                    self.address_manager.mmio_bus.as_ref(),
+                    bars.clone(),
+                )
+                .map_err(DeviceManagerError::AddPciDevice)?;
+        }
 
-        pci_bus
-            .register_mapping(
-                bus_device,
-                self.address_manager.io_bus.as_ref(),
-                self.address_manager.mmio_bus.as_ref(),
-                bars.clone(),
-            )
-            .map_err(DeviceManagerError::AddPciDevice)?;
+        shared_state.bus_devices.push(bus_device);
 
         let mut new_resources = Vec::new();
         for bar in bars {
@@ -4182,12 +4217,14 @@ impl DeviceManager {
 
         let legacy_interrupt_group =
             if let Some(legacy_interrupt_manager) = &self.legacy_interrupt_manager {
+                let irq = {
+                    self.shared_state().pci_segments[pci_segment_id as usize].pci_irq_slots
+                        [pci_device_bdf.device() as usize]
+                };
                 Some(
                     legacy_interrupt_manager
                         .create_group(LegacyIrqGroupConfig {
-                            irq: self.pci_segments[pci_segment_id as usize].pci_irq_slots
-                                [pci_device_bdf.device() as usize]
-                                as InterruptIndex,
+                            irq: irq as InterruptIndex,
                         })
                         .map_err(DeviceManagerError::CreateInterruptGroup)?,
                 )
@@ -4216,7 +4253,8 @@ impl DeviceManager {
 
         let memory = self.memory_manager.lock().unwrap().guest_memory();
         let vfio_user_mapping = Arc::new(VfioUserDmaMapping::new(client, Arc::new(memory)));
-        for virtio_mem_device in self.virtio_mem_devices.iter() {
+        let virtio_mem_devices = self.shared_state().virtio_mem_devices.clone();
+        for virtio_mem_device in virtio_mem_devices.iter() {
             virtio_mem_device
                 .lock()
                 .unwrap()
@@ -4353,7 +4391,8 @@ impl DeviceManager {
             } else {
                 // Let every virtio-mem device handle the DMA map/unmap through the
                 // DMA handler provided.
-                for virtio_mem_device in self.virtio_mem_devices.iter() {
+                let virtio_mem_devices = self.shared_state().virtio_mem_devices.clone();
+                for virtio_mem_device in virtio_mem_devices.iter() {
                     virtio_mem_device
                         .lock()
                         .unwrap()
@@ -4539,7 +4578,7 @@ impl DeviceManager {
         Ok(if let Some(pci_device_bdf) = pci_device_bdf {
             let pci_segment_id = pci_device_bdf.segment();
 
-            self.pci_segments[pci_segment_id as usize]
+            self.shared_state().pci_segments[pci_segment_id as usize]
                 .pci_bus
                 .lock()
                 .unwrap()
@@ -4548,7 +4587,8 @@ impl DeviceManager {
 
             (pci_segment_id, pci_device_bdf, resources)
         } else {
-            let pci_device_bdf = self.pci_segments[pci_segment_id as usize].next_device_bdf()?;
+            let pci_device_bdf =
+                self.shared_state().pci_segments[pci_segment_id as usize].next_device_bdf()?;
 
             (pci_segment_id, pci_device_bdf, None)
         })
@@ -4578,8 +4618,10 @@ impl DeviceManager {
             .map(|ic| ic.clone() as Arc<Mutex<dyn InterruptController>>)
     }
 
-    pub(crate) fn pci_segments(&self) -> &Vec<PciSegment> {
-        &self.pci_segments
+    pub(crate) fn pci_segments(&self) -> PciSegmentsGuard<'_> {
+        PciSegmentsGuard {
+            shared_state: self.shared_state(),
+        }
     }
 
     // Get the guest PCI BDF for a device ID.
@@ -4615,7 +4657,8 @@ impl DeviceManager {
         }
 
         // Take care of updating the memory for VFIO PCI devices.
-        if let Some(vfio_ops) = &self.vfio_ops {
+        let vfio_ops = self.shared_state().vfio_ops.clone();
+        if let Some(vfio_ops) = vfio_ops {
             // vfio_dma_map is unsound and ought to be marked as unsafe
             #[allow(unused_unsafe)]
             // SAFETY: GuestMemoryMmap guarantees that region points
@@ -4689,8 +4732,8 @@ impl DeviceManager {
         let (bdf, device_name) = self.add_passthrough_device(device_cfg)?;
 
         // Update the PCIU bitmap
-        self.pci_segments[device_cfg.pci_common.pci_segment as usize].pci_devices_up |=
-            1 << bdf.device();
+        self.shared_state().pci_segments[device_cfg.pci_common.pci_segment as usize]
+            .pci_devices_up |= 1 << bdf.device();
 
         Ok(PciDeviceInfo {
             id: device_name,
@@ -4707,8 +4750,8 @@ impl DeviceManager {
         let (bdf, device_name) = self.add_vfio_user_device(device_cfg)?;
 
         // Update the PCIU bitmap
-        self.pci_segments[device_cfg.pci_common.pci_segment as usize].pci_devices_up |=
-            1 << bdf.device();
+        self.shared_state().pci_segments[device_cfg.pci_common.pci_segment as usize]
+            .pci_devices_up |= 1 << bdf.device();
 
         Ok(PciDeviceInfo {
             id: device_name,
@@ -4812,7 +4855,8 @@ impl DeviceManager {
         }
 
         // Update the PCID bitmap
-        self.pci_segments[pci_segment_id as usize].pci_devices_down |= 1 << pci_device_bdf.device();
+        self.shared_state().pci_segments[pci_segment_id as usize].pci_devices_down |=
+            1 << pci_device_bdf.device();
 
         Ok(())
     }
@@ -4822,9 +4866,10 @@ impl DeviceManager {
 
         // Convert the device ID into the corresponding b/d/f.
         let pci_device_bdf = PciBdf::new(pci_segment_id, 0, device_id, 0);
+        let mut shared_state = self.shared_state();
 
         // Give the PCI device ID back to the PCI bus.
-        self.pci_segments[pci_segment_id as usize]
+        shared_state.pci_segments[pci_segment_id as usize]
             .pci_bus
             .lock()
             .unwrap()
@@ -4845,27 +4890,24 @@ impl DeviceManager {
             let pci_device_handle = pci_device_node
                 .pci_device_handle
                 .ok_or(DeviceManagerError::MissingPciDevice)?;
-            if matches!(pci_device_handle, PciDeviceHandle::Virtio(_)) {
-                // The virtio-pci device has a single child
-                if !pci_device_node.children.is_empty() {
-                    assert_eq!(pci_device_node.children.len(), 1);
-                    let child_id = &pci_device_node.children[0];
-                    id.clone_from(child_id);
-                }
+            if matches!(pci_device_handle, PciDeviceHandle::Virtio(_))
+                && !pci_device_node.children.is_empty()
+            {
+                // The virtio-pci device has a single child.
+                assert_eq!(pci_device_node.children.len(), 1);
+                id.clone_from(&pci_device_node.children[0]);
             }
-            for child in pci_device_node.children.iter() {
+            for child in &pci_device_node.children {
                 device_tree.remove(child);
             }
 
             (pci_device_handle, id)
         };
 
-        let mut iommu_attached = false;
-        if let Some((_, iommu_attached_devices)) = &self.iommu_attached_devices
-            && iommu_attached_devices.contains(&pci_device_bdf)
-        {
-            iommu_attached = true;
-        }
+        let iommu_attached = shared_state
+            .iommu_attached_devices
+            .as_ref()
+            .is_some_and(|(_, devices)| devices.contains(&pci_device_bdf));
 
         let (pci_device, bus_device, virtio_device, remove_dma_handler) = match pci_device_handle {
             // VirtioMemMappingSource::Container cleanup is handled by
@@ -4905,10 +4947,8 @@ impl DeviceManager {
                 {
                     for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
                         for region in zone.regions() {
-                            let iova = region.start_addr().0;
-                            let size = region.len();
                             dma_handler
-                                .unmap(iova, size)
+                                .unmap(region.start_addr().0, region.len())
                                 .map_err(DeviceManagerError::VirtioDmaUnmap)?;
                         }
                     }
@@ -4940,7 +4980,7 @@ impl DeviceManager {
         };
 
         if remove_dma_handler {
-            for virtio_mem_device in self.virtio_mem_devices.iter() {
+            for virtio_mem_device in &shared_state.virtio_mem_devices {
                 let source = VirtioMemMappingSource::Device(pci_device_bdf.into());
                 virtio_mem_device
                     .lock()
@@ -4950,25 +4990,24 @@ impl DeviceManager {
             }
         }
 
-        // Free the allocated BARs
+        // Free the allocated BARs.
         pci_device
             .lock()
             .unwrap()
             .free_bars(
                 &mut self.address_manager.allocator.lock().unwrap(),
-                &mut self.pci_segments[pci_segment_id as usize]
+                &mut shared_state.pci_segments[pci_segment_id as usize]
                     .mem32_allocator
                     .lock()
                     .unwrap(),
-                &mut self.pci_segments[pci_segment_id as usize]
+                &mut shared_state.pci_segments[pci_segment_id as usize]
                     .mem64_allocator
                     .lock()
                     .unwrap(),
             )
             .map_err(DeviceManagerError::FreePciBars)?;
 
-        // Remove the device from the PCI bus
-        self.pci_segments[pci_segment_id as usize]
+        shared_state.pci_segments[pci_segment_id as usize]
             .pci_bus
             .lock()
             .unwrap()
@@ -4976,27 +5015,29 @@ impl DeviceManager {
             .map_err(DeviceManagerError::RemoveDeviceFromPciBus)?;
 
         #[cfg(target_arch = "x86_64")]
-        // Remove the device from the IO bus
-        self.io_bus()
+        // Remove the device from the IO bus.
+        self.address_manager
+            .io_bus
             .remove_by_device(bus_device.as_ref())
             .map_err(DeviceManagerError::RemoveDeviceFromIoBus)?;
 
-        // Remove the device from the MMIO bus
-        self.mmio_bus()
+        // Remove the device from the MMIO bus.
+        self.address_manager
+            .mmio_bus
             .remove_by_device(bus_device.as_ref())
             .map_err(DeviceManagerError::RemoveDeviceFromMmioBus)?;
 
         // Remove the device from the list of BusDevice held by the
         // DeviceManager.
-        self.bus_devices
+        shared_state
+            .bus_devices
             .retain(|dev| !Arc::ptr_eq(dev, &bus_device));
 
-        // Shutdown and remove the underlying virtio-device if present
         if let Some(virtio_device) = virtio_device {
             for mapping in virtio_device.lock().unwrap().userspace_mappings() {
                 // SAFETY: userspace_mappings only has valid mappings.
-                // TODO: do not rely on the correctness of all the code in this file
-                // for this to hold.
+                // TODO: do not rely on the correctness of all the code in this
+                // file for this to hold.
                 unsafe {
                     self.memory_manager
                         .lock()
@@ -5013,11 +5054,28 @@ impl DeviceManager {
             }
 
             virtio_device.lock().unwrap().shutdown();
-
+            drop(shared_state);
             self.virtio_devices
                 .retain(|handler| !Arc::ptr_eq(&handler.virtio_device, &virtio_device));
+            self.cleanup_vfio_ops();
+            event!(
+                "vm",
+                "device-removed",
+                "id",
+                &id,
+                "bdf",
+                pci_device_bdf.to_string()
+            );
+            return Ok(());
         }
 
+        drop(shared_state);
+        self.cleanup_vfio_ops();
+
+        // At this point, the device has been removed from all the list and
+        // buses where it was stored. At the end of this function, after
+        // any_device, bus_device and pci_device are released, the actual
+        // device will be dropped.
         event!(
             "vm",
             "device-removed",
@@ -5027,10 +5085,6 @@ impl DeviceManager {
             pci_device_bdf.to_string()
         );
 
-        // At this point, the device has been removed from all the list and
-        // buses where it was stored. At the end of this function, after
-        // any_device, bus_device and pci_device are released, the actual
-        // device will be dropped.
         Ok(())
     }
 
@@ -5059,7 +5113,7 @@ impl DeviceManager {
         )?;
 
         // Update the PCIU bitmap
-        self.pci_segments[handle.pci_common.pci_segment as usize].pci_devices_up |=
+        self.shared_state().pci_segments[handle.pci_common.pci_segment as usize].pci_devices_up |=
             1 << bdf.device();
 
         Ok(PciDeviceInfo { id, bdf })
@@ -5239,8 +5293,10 @@ impl DeviceManager {
             .map_err(DeviceManagerError::PowerButtonNotification);
     }
 
-    pub fn iommu_attached_devices(&self) -> &Option<(PciBdf, Vec<PciBdf>)> {
-        &self.iommu_attached_devices
+    pub fn iommu_attached_devices(&self) -> IommuAttachedDevicesGuard<'_> {
+        IommuAttachedDevicesGuard {
+            shared_state: self.shared_state(),
+        }
     }
 
     fn validate_identifier(&self, id: &Option<String>) -> DeviceManagerResult<()> {
@@ -5263,9 +5319,9 @@ impl DeviceManager {
 
     fn cleanup_vfio_ops(&mut self) {
         // Drop the VfioOps instance when "Self" is the only reference
-        if let Some(1) = self.vfio_ops.as_ref().map(Arc::strong_count) {
+        if let Some(1) = self.shared_state().vfio_ops.as_ref().map(Arc::strong_count) {
             debug!("Drop VfioOps given no active VFIO devices.");
-            self.vfio_ops = None;
+            self.shared_state().vfio_ops = None;
         }
     }
 }
@@ -5393,7 +5449,8 @@ impl Aml for DeviceManager {
         use arch::riscv64::DeviceInfoForFdt;
 
         let mut pci_scan_methods = Vec::new();
-        for i in 0..self.pci_segments.len() {
+        let pci_segment_count = self.pci_segments().len();
+        for i in 0..pci_segment_count {
             pci_scan_methods.push(aml::MethodCall::new(
                 format!("\\_SB_.PC{i:02X}.PCNT").as_str().into(),
                 vec![],
@@ -5463,13 +5520,13 @@ impl Aml for DeviceManager {
         )
         .to_aml_bytes(sink);
 
-        for segment in &self.pci_segments {
+        for segment in self.pci_segments().iter() {
             segment.to_aml_bytes(sink);
         }
 
         let mut mbrd_memory = Vec::new();
 
-        for segment in &self.pci_segments {
+        for segment in self.pci_segments().iter() {
             mbrd_memory.push(aml::Memory32Fixed::new(
                 true,
                 segment.mmio_config_address as u32,
@@ -5701,26 +5758,28 @@ const PSEG_FIELD_SIZE: usize = 4;
 
 impl BusDevice for DeviceManager {
     fn read(&mut self, base: u64, offset: u64, data: &mut [u8]) {
+        let mut shared_state = self.shared_state();
+        let selected_segment = shared_state.selected_segment;
         match offset {
             PCIU_FIELD_OFFSET => {
                 assert!(data.len() == PCIU_FIELD_SIZE);
                 data.copy_from_slice(
-                    &self.pci_segments[self.selected_segment]
+                    &shared_state.pci_segments[selected_segment]
                         .pci_devices_up
                         .to_le_bytes(),
                 );
                 // Clear the PCIU bitmap
-                self.pci_segments[self.selected_segment].pci_devices_up = 0;
+                shared_state.pci_segments[selected_segment].pci_devices_up = 0;
             }
             PCID_FIELD_OFFSET => {
                 assert!(data.len() == PCID_FIELD_SIZE);
                 data.copy_from_slice(
-                    &self.pci_segments[self.selected_segment]
+                    &shared_state.pci_segments[selected_segment]
                         .pci_devices_down
                         .to_le_bytes(),
                 );
                 // Clear the PCID bitmap
-                self.pci_segments[self.selected_segment].pci_devices_down = 0;
+                shared_state.pci_segments[selected_segment].pci_devices_down = 0;
             }
             B0EJ_FIELD_OFFSET => {
                 assert!(data.len() == B0EJ_FIELD_SIZE);
@@ -5730,7 +5789,7 @@ impl BusDevice for DeviceManager {
             }
             PSEG_FIELD_OFFSET => {
                 assert_eq!(data.len(), PSEG_FIELD_SIZE);
-                data.copy_from_slice(&(self.selected_segment as u32).to_le_bytes());
+                data.copy_from_slice(&(selected_segment as u32).to_le_bytes());
             }
             _ => error!("Accessing unknown location at base 0x{base:x}, offset 0x{offset:x}"),
         }
@@ -5742,13 +5801,14 @@ impl BusDevice for DeviceManager {
         match offset {
             B0EJ_FIELD_OFFSET => {
                 assert!(data.len() == B0EJ_FIELD_SIZE);
+                let selected_segment = self.shared_state().selected_segment as u16;
                 let mut data_array: [u8; 4] = [0, 0, 0, 0];
                 data_array.copy_from_slice(data);
                 let mut slot_bitmap = u32::from_le_bytes(data_array);
 
                 while slot_bitmap > 0 {
                     let slot_id = slot_bitmap.trailing_zeros();
-                    if let Err(e) = self.eject_device(self.selected_segment as u16, slot_id as u8) {
+                    if let Err(e) = self.eject_device(selected_segment, slot_id as u8) {
                         error!("Failed ejecting device {slot_id}: {e:?}");
                     }
                     self.cleanup_vfio_ops();
@@ -5760,15 +5820,16 @@ impl BusDevice for DeviceManager {
                 let mut data_array: [u8; 4] = [0, 0, 0, 0];
                 data_array.copy_from_slice(data);
                 let selected_segment = u32::from_le_bytes(data_array) as usize;
-                if selected_segment >= self.pci_segments.len() {
+                let mut shared_state = self.shared_state();
+                if selected_segment >= shared_state.pci_segments.len() {
                     error!(
                         "Segment selection out of range: {} >= {}",
                         selected_segment,
-                        self.pci_segments.len()
+                        shared_state.pci_segments.len()
                     );
                     return None;
                 }
-                self.selected_segment = selected_segment;
+                shared_state.selected_segment = selected_segment;
             }
             _ => error!("Accessing unknown location at base 0x{base:x}, offset 0x{offset:x}"),
         }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -876,7 +876,6 @@ struct DeviceManagerState {
 
 struct PciHotplugSharedState {
     pci_segments: Vec<PciSegment>,
-    selected_segment: usize,
     // List of bus devices
     // Let the DeviceManager keep strong references to the BusDevice devices.
     // This allows the IO and MMIO buses to be provided with Weak references,
@@ -1126,6 +1125,8 @@ pub struct DeviceManager {
 /// Shares PCI hotplug state with the [`DeviceManager`].
 pub struct AcpiPciHotplugController {
     shared_state: Arc<Mutex<PciHotplugSharedState>>,
+    /// The currently selected segment by the guest (via MMIO).
+    selected_segment: usize,
     address_manager: Arc<AddressManager>,
     memory_manager: Arc<Mutex<MemoryManager>>,
     device_tree: Arc<Mutex<DeviceTree>>,
@@ -1188,6 +1189,7 @@ impl AcpiPciHotplugController {
     ) -> Self {
         Self {
             shared_state,
+            selected_segment: 0,
             address_manager,
             memory_manager,
             device_tree,
@@ -1570,7 +1572,6 @@ impl DeviceManager {
         let mmio_regions = Arc::new(Mutex::new(Vec::new()));
         let shared_state = Arc::new(Mutex::new(PciHotplugSharedState {
             pci_segments,
-            selected_segment: 0,
             bus_devices: Vec::new(),
             vfio_ops: None,
             iommu_attached_devices: None,
@@ -5704,7 +5705,7 @@ const PSEG_FIELD_SIZE: usize = 4;
 impl BusDevice for AcpiPciHotplugController {
     fn read(&mut self, base: u64, offset: u64, data: &mut [u8]) {
         let mut shared_state = self.shared_state.lock().unwrap();
-        let selected_segment = shared_state.selected_segment;
+        let selected_segment = self.selected_segment;
         match offset {
             PCIU_FIELD_OFFSET => {
                 assert!(data.len() == PCIU_FIELD_SIZE);
@@ -5746,7 +5747,7 @@ impl BusDevice for AcpiPciHotplugController {
         match offset {
             B0EJ_FIELD_OFFSET => {
                 assert!(data.len() == B0EJ_FIELD_SIZE);
-                let selected_segment = self.shared_state.lock().unwrap().selected_segment as u16;
+                let selected_segment = self.selected_segment as u16;
                 let mut data_array: [u8; 4] = [0, 0, 0, 0];
                 data_array.copy_from_slice(data);
                 let mut slot_bitmap = u32::from_le_bytes(data_array);
@@ -5764,7 +5765,7 @@ impl BusDevice for AcpiPciHotplugController {
                 let mut data_array: [u8; 4] = [0, 0, 0, 0];
                 data_array.copy_from_slice(data);
                 let selected_segment = u32::from_le_bytes(data_array) as usize;
-                let mut shared_state = self.shared_state.lock().unwrap();
+                let shared_state = self.shared_state.lock().unwrap();
                 if selected_segment >= shared_state.pci_segments.len() {
                     error!(
                         "Segment selection out of range: {} >= {}",
@@ -5773,7 +5774,8 @@ impl BusDevice for AcpiPciHotplugController {
                     );
                     return None;
                 }
-                shared_state.selected_segment = selected_segment;
+                drop(shared_state);
+                self.selected_segment = selected_segment;
             }
             _ => error!("Accessing unknown location at base 0x{base:x}, offset 0x{offset:x}"),
         }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1154,9 +1154,28 @@ pub struct DeviceManager {
     // ivshmem device
     ivshmem_device: Option<Arc<Mutex<devices::IvshmemDevice>>>,
 
+    /// Shared context for ACPI PCI hot-unplug teardown.
+    _pci_hotplug_backend: Arc<PciHotplugBackend>,
+
     /// Owned version needed to keep the bus device alive (the bus only holds
     /// a weak reference).
     _acpi_pci_hotplug_controller: Arc<Mutex<AcpiPciHotplugController>>,
+}
+
+/// Non-register context needed to tear down PCI devices during ACPI hot-unplug.
+///
+/// Unlike [`PciHotplugSharedState`], this state is not part of the ACPI hotplug
+/// register model. It groups the broader `DeviceManager` internals that the
+/// controller must access when unplugging a device.
+struct PciHotplugBackend {
+    /// Allocators and buses used to free and unregister PCI resources.
+    address_manager: Arc<AddressManager>,
+    /// Guest memory state needed for DMA teardown and userspace unmapping.
+    memory_manager: Arc<Mutex<MemoryManager>>,
+    /// Device topology used to remove unplugged devices and their children.
+    device_tree: Arc<Mutex<DeviceTree>>,
+    /// Tracked MMIO regions for VFIO-backed devices.
+    mmio_regions: Arc<Mutex<Vec<MmioRegion>>>,
 }
 
 /// MMIO-accessible controller for handling ACPI PCI hotplug and unplug events.
@@ -1165,10 +1184,7 @@ pub struct DeviceManager {
 pub struct AcpiPciHotplugController {
     shared_state: Arc<Mutex<PciHotplugSharedState>>,
     selected_segment: usize,
-    address_manager: Arc<AddressManager>,
-    memory_manager: Arc<Mutex<MemoryManager>>,
-    device_tree: Arc<Mutex<DeviceTree>>,
-    mmio_regions: Arc<Mutex<Vec<MmioRegion>>>,
+    backend: Arc<PciHotplugBackend>,
 }
 
 /// Create per-PCI-segment MMIO allocators over the range `[start, end]`.
@@ -1212,18 +1228,12 @@ fn create_mmio_allocators(
 impl AcpiPciHotplugController {
     fn new(
         shared_state: Arc<Mutex<PciHotplugSharedState>>,
-        address_manager: Arc<AddressManager>,
-        memory_manager: Arc<Mutex<MemoryManager>>,
-        device_tree: Arc<Mutex<DeviceTree>>,
-        mmio_regions: Arc<Mutex<Vec<MmioRegion>>>,
+        backend: Arc<PciHotplugBackend>,
     ) -> Self {
         Self {
             shared_state,
             selected_segment: 0,
-            address_manager,
-            memory_manager,
-            device_tree,
-            mmio_regions,
+            backend,
         }
     }
 
@@ -1251,7 +1261,7 @@ impl AcpiPciHotplugController {
 
         let (pci_device_handle, id) = {
             // Remove the device from the device tree along with its children.
-            let mut device_tree = self.device_tree.lock().unwrap();
+            let mut device_tree = self.backend.device_tree.lock().unwrap();
             let pci_device_node = device_tree
                 .remove_node_by_pci_bdf(pci_device_bdf)
                 .ok_or(DeviceManagerError::MissingPciDevice)?;
@@ -1292,7 +1302,7 @@ impl AcpiPciHotplugController {
                 // updates the device's region addresses but not the
                 // DeviceManager's cloned copies.
                 let device_regions = vfio_pci_device.lock().unwrap().mmio_regions().clone();
-                let mut mmio_regions = self.mmio_regions.lock().unwrap();
+                let mut mmio_regions = self.backend.mmio_regions.lock().unwrap();
                 for device_region in &device_regions {
                     mmio_regions.retain(|x| !x.has_matching_slots(device_region));
                 }
@@ -1309,7 +1319,8 @@ impl AcpiPciHotplugController {
                 let bar_addr = dev.config_bar_addr();
                 for (event, addr) in dev.ioeventfds(bar_addr) {
                     let io_addr = IoEventAddress::Mmio(addr);
-                    self.address_manager
+                    self.backend
+                        .address_manager
                         .vm
                         .unregister_ioevent(event, &io_addr)
                         .map_err(|e| DeviceManagerError::UnRegisterIoevent(e.into()))?;
@@ -1318,7 +1329,14 @@ impl AcpiPciHotplugController {
                 if let Some(dma_handler) = dev.dma_handler()
                     && !iommu_attached
                 {
-                    for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
+                    for (_, zone) in self
+                        .backend
+                        .memory_manager
+                        .lock()
+                        .unwrap()
+                        .memory_zones()
+                        .iter()
+                    {
                         for region in zone.regions() {
                             dma_handler
                                 .unmap(region.start_addr().0, region.len())
@@ -1336,7 +1354,14 @@ impl AcpiPciHotplugController {
             }
             PciDeviceHandle::VfioUser(vfio_user_pci_device) => {
                 let mut dev = vfio_user_pci_device.lock().unwrap();
-                for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
+                for (_, zone) in self
+                    .backend
+                    .memory_manager
+                    .lock()
+                    .unwrap()
+                    .memory_zones()
+                    .iter()
+                {
                     for region in zone.regions() {
                         dev.dma_unmap(region)
                             .map_err(DeviceManagerError::VfioUserDmaUnmap)?;
@@ -1368,7 +1393,7 @@ impl AcpiPciHotplugController {
             .lock()
             .unwrap()
             .free_bars(
-                &mut self.address_manager.allocator.lock().unwrap(),
+                &mut self.backend.address_manager.allocator.lock().unwrap(),
                 &mut shared_state.pci_segments[pci_segment_id as usize]
                     .mem32_allocator
                     .lock()
@@ -1389,13 +1414,15 @@ impl AcpiPciHotplugController {
 
         #[cfg(target_arch = "x86_64")]
         // Remove the device from the IO bus.
-        self.address_manager
+        self.backend
+            .address_manager
             .io_bus
             .remove_by_device(bus_device.as_ref())
             .map_err(DeviceManagerError::RemoveDeviceFromIoBus)?;
 
         // Remove the device from the MMIO bus.
-        self.address_manager
+        self.backend
+            .address_manager
             .mmio_bus
             .remove_by_device(bus_device.as_ref())
             .map_err(DeviceManagerError::RemoveDeviceFromMmioBus)?;
@@ -1412,7 +1439,8 @@ impl AcpiPciHotplugController {
                 // TODO: do not rely on the correctness of all the code in this
                 // file for this to hold.
                 unsafe {
-                    self.memory_manager
+                    self.backend
+                        .memory_manager
                         .lock()
                         .unwrap()
                         .remove_userspace_mapping(
@@ -1603,12 +1631,15 @@ impl DeviceManager {
             iommu_attached_devices: None,
             virtio_mem_devices: Vec::new(),
         }));
+        let pci_hotplug_backend = Arc::new(PciHotplugBackend {
+            address_manager: Arc::clone(&address_manager),
+            memory_manager: Arc::clone(&memory_manager),
+            device_tree: Arc::clone(&device_tree),
+            mmio_regions: Arc::clone(&mmio_regions),
+        });
         let acpi_pci_hotplug_controller = Arc::new(Mutex::new(AcpiPciHotplugController::new(
             Arc::clone(&shared_state),
-            Arc::clone(&address_manager),
-            Arc::clone(&memory_manager),
-            Arc::clone(&device_tree),
-            Arc::clone(&mmio_regions),
+            Arc::clone(&pci_hotplug_backend),
         )));
         let acpi_pci_hotplug_bus_device = Arc::clone(&acpi_pci_hotplug_controller);
 
@@ -1712,6 +1743,7 @@ impl DeviceManager {
             fw_cfg: None,
             #[cfg(feature = "ivshmem")]
             ivshmem_device: None,
+            _pci_hotplug_backend: pci_hotplug_backend,
             _acpi_cpu_hotplug_controller: acpi_cpu_hotplug_controller,
             _acpi_pci_hotplug_controller: acpi_pci_hotplug_controller,
         };

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1015,6 +1015,10 @@ pub struct DeviceManager {
     /// a weak reference).
     _acpi_cpu_hotplug_controller: Arc<Mutex<AcpiCpuHotplugController>>,
 
+    /// Owned version needed to keep the bus device alive (the bus only holds
+    /// a weak reference).
+    _acpi_pci_hotplug_controller: Arc<Mutex<AcpiPciHotplugController>>,
+
     // Manage address space related to devices
     address_manager: Arc<AddressManager>,
 
@@ -1117,6 +1121,17 @@ pub struct DeviceManager {
     ivshmem_device: Option<Arc<Mutex<devices::IvshmemDevice>>>,
 }
 
+/// MMIO-accessible controller for handling ACPI PCI hotplug and unplug events.
+///
+/// Shares PCI hotplug state with the [`DeviceManager`].
+pub struct AcpiPciHotplugController {
+    shared_state: Arc<Mutex<PciHotplugSharedState>>,
+    address_manager: Arc<AddressManager>,
+    memory_manager: Arc<Mutex<MemoryManager>>,
+    device_tree: Arc<Mutex<DeviceTree>>,
+    mmio_regions: Arc<Mutex<Vec<MmioRegion>>>,
+}
+
 /// Create per-PCI-segment MMIO allocators over the range `[start, end]`.
 /// Both `start` and `end` are inclusive addresses.
 fn create_mmio_allocators(
@@ -1161,6 +1176,249 @@ fn use_64bit_bar_for_virtio_device(
     is_hotplug: bool,
 ) -> bool {
     pci_segment_id > 0 || device_type != VirtioDeviceType::Block as u32 || is_hotplug
+}
+
+impl AcpiPciHotplugController {
+    fn new(
+        shared_state: Arc<Mutex<PciHotplugSharedState>>,
+        address_manager: Arc<AddressManager>,
+        memory_manager: Arc<Mutex<MemoryManager>>,
+        device_tree: Arc<Mutex<DeviceTree>>,
+        mmio_regions: Arc<Mutex<Vec<MmioRegion>>>,
+    ) -> Self {
+        Self {
+            shared_state,
+            address_manager,
+            memory_manager,
+            device_tree,
+            mmio_regions,
+        }
+    }
+
+    fn cleanup_vfio_ops(shared_state: &mut PciHotplugSharedState) {
+        if let Some(1) = shared_state.vfio_ops.as_ref().map(Arc::strong_count) {
+            debug!("Drop VfioOps given no active VFIO devices.");
+            shared_state.vfio_ops = None;
+        }
+    }
+
+    fn eject_device(
+        &mut self,
+        pci_segment_id: u16,
+        device_id: u8,
+    ) -> DeviceManagerResult<Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>> {
+        info!("Ejecting device_id = {device_id} on segment_id={pci_segment_id}");
+
+        // Convert the device ID into the corresponding b/d/f.
+        let pci_device_bdf = PciBdf::new(pci_segment_id, 0, device_id, 0);
+        let mut shared_state = self.shared_state.lock().unwrap();
+
+        // Give the PCI device ID back to the PCI bus.
+        shared_state.pci_segments[pci_segment_id as usize]
+            .pci_bus
+            .lock()
+            .unwrap()
+            .free_device_id(device_id)
+            .map_err(DeviceManagerError::FreePciDeviceId)?;
+
+        let (pci_device_handle, id) = {
+            // Remove the device from the device tree along with its children.
+            let mut device_tree = self.device_tree.lock().unwrap();
+            let pci_device_node = device_tree
+                .remove_node_by_pci_bdf(pci_device_bdf)
+                .ok_or(DeviceManagerError::MissingPciDevice)?;
+
+            // For VFIO and vfio-user the PCI device id is the id.
+            // For virtio we overwrite it later as we want the id of the
+            // underlying device.
+            let mut id = pci_device_node.id;
+            let pci_device_handle = pci_device_node
+                .pci_device_handle
+                .ok_or(DeviceManagerError::MissingPciDevice)?;
+            if matches!(pci_device_handle, PciDeviceHandle::Virtio(_))
+                && !pci_device_node.children.is_empty()
+            {
+                // The virtio-pci device has a single child.
+                assert_eq!(pci_device_node.children.len(), 1);
+                id.clone_from(&pci_device_node.children[0]);
+            }
+            for child in &pci_device_node.children {
+                device_tree.remove(child);
+            }
+
+            (pci_device_handle, id)
+        };
+
+        let iommu_attached = shared_state
+            .iommu_attached_devices
+            .as_ref()
+            .is_some_and(|(_, devices)| devices.contains(&pci_device_bdf));
+
+        let (pci_device, bus_device, virtio_device, remove_dma_handler) = match pci_device_handle {
+            // VirtioMemMappingSource::Container cleanup is handled by
+            // cleanup_vfio_ops when the last VFIO device is removed.
+            PciDeviceHandle::Vfio(vfio_pci_device) => {
+                // Remove this device's MMIO regions from the DeviceManager's
+                // mmio_regions list. We match on UserMemoryRegion slot numbers
+                // rather than MmioRegion start addresses because move_bar()
+                // updates the device's region addresses but not the
+                // DeviceManager's cloned copies.
+                let device_regions = vfio_pci_device.lock().unwrap().mmio_regions().clone();
+                let mut mmio_regions = self.mmio_regions.lock().unwrap();
+                for device_region in &device_regions {
+                    mmio_regions.retain(|x| !x.has_matching_slots(device_region));
+                }
+
+                (
+                    Arc::clone(&vfio_pci_device) as Arc<Mutex<dyn PciDevice>>,
+                    Arc::clone(&vfio_pci_device) as Arc<dyn BusDeviceSync>,
+                    None as Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>,
+                    false,
+                )
+            }
+            PciDeviceHandle::Virtio(virtio_pci_device) => {
+                let dev = virtio_pci_device.lock().unwrap();
+                let bar_addr = dev.config_bar_addr();
+                for (event, addr) in dev.ioeventfds(bar_addr) {
+                    let io_addr = IoEventAddress::Mmio(addr);
+                    self.address_manager
+                        .vm
+                        .unregister_ioevent(event, &io_addr)
+                        .map_err(|e| DeviceManagerError::UnRegisterIoevent(e.into()))?;
+                }
+
+                if let Some(dma_handler) = dev.dma_handler()
+                    && !iommu_attached
+                {
+                    for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
+                        for region in zone.regions() {
+                            dma_handler
+                                .unmap(region.start_addr().0, region.len())
+                                .map_err(DeviceManagerError::VirtioDmaUnmap)?;
+                        }
+                    }
+                }
+
+                (
+                    Arc::clone(&virtio_pci_device) as Arc<Mutex<dyn PciDevice>>,
+                    Arc::clone(&virtio_pci_device) as Arc<dyn BusDeviceSync>,
+                    Some(dev.virtio_device()),
+                    dev.dma_handler().is_some() && !iommu_attached,
+                )
+            }
+            PciDeviceHandle::VfioUser(vfio_user_pci_device) => {
+                let mut dev = vfio_user_pci_device.lock().unwrap();
+                for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
+                    for region in zone.regions() {
+                        dev.dma_unmap(region)
+                            .map_err(DeviceManagerError::VfioUserDmaUnmap)?;
+                    }
+                }
+
+                (
+                    Arc::clone(&vfio_user_pci_device) as Arc<Mutex<dyn PciDevice>>,
+                    Arc::clone(&vfio_user_pci_device) as Arc<dyn BusDeviceSync>,
+                    None as Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>,
+                    true,
+                )
+            }
+        };
+
+        if remove_dma_handler {
+            for virtio_mem_device in &shared_state.virtio_mem_devices {
+                let source = VirtioMemMappingSource::Device(pci_device_bdf.into());
+                virtio_mem_device
+                    .lock()
+                    .unwrap()
+                    .remove_dma_mapping_handler(&source)
+                    .map_err(DeviceManagerError::RemoveDmaMappingHandlerVirtioMem)?;
+            }
+        }
+
+        // Free the allocated BARs.
+        pci_device
+            .lock()
+            .unwrap()
+            .free_bars(
+                &mut self.address_manager.allocator.lock().unwrap(),
+                &mut shared_state.pci_segments[pci_segment_id as usize]
+                    .mem32_allocator
+                    .lock()
+                    .unwrap(),
+                &mut shared_state.pci_segments[pci_segment_id as usize]
+                    .mem64_allocator
+                    .lock()
+                    .unwrap(),
+            )
+            .map_err(DeviceManagerError::FreePciBars)?;
+
+        shared_state.pci_segments[pci_segment_id as usize]
+            .pci_bus
+            .lock()
+            .unwrap()
+            .remove_by_device(&pci_device)
+            .map_err(DeviceManagerError::RemoveDeviceFromPciBus)?;
+
+        #[cfg(target_arch = "x86_64")]
+        // Remove the device from the IO bus.
+        self.address_manager
+            .io_bus
+            .remove_by_device(bus_device.as_ref())
+            .map_err(DeviceManagerError::RemoveDeviceFromIoBus)?;
+
+        // Remove the device from the MMIO bus.
+        self.address_manager
+            .mmio_bus
+            .remove_by_device(bus_device.as_ref())
+            .map_err(DeviceManagerError::RemoveDeviceFromMmioBus)?;
+
+        // Remove the device from the list of BusDevice held by the
+        // DeviceManager.
+        shared_state
+            .bus_devices
+            .retain(|dev| !Arc::ptr_eq(dev, &bus_device));
+        // Shutdown and remove the underlying virtio-device if present.
+        if let Some(virtio_device) = &virtio_device {
+            for mapping in virtio_device.lock().unwrap().userspace_mappings() {
+                // SAFETY: userspace_mappings only has valid mappings.
+                // TODO: do not rely on the correctness of all the code in this
+                // file for this to hold.
+                unsafe {
+                    self.memory_manager
+                        .lock()
+                        .unwrap()
+                        .remove_userspace_mapping(
+                            mapping.addr.raw_value(),
+                            mapping.mapping.size(),
+                            mapping.mapping.as_ptr() as _,
+                            mapping.mergeable,
+                            mapping.mem_slot,
+                        )
+                        .map_err(DeviceManagerError::MemoryManager)
+                }?;
+            }
+
+            virtio_device.lock().unwrap().shutdown();
+        }
+
+        Self::cleanup_vfio_ops(&mut shared_state);
+        drop(shared_state);
+
+        // At this point, the device has been removed from all the list and
+        // buses where it was stored. At the end of this function, after
+        // any_device, bus_device and pci_device are released, the actual
+        // device will be dropped.
+        event!(
+            "vm",
+            "device-removed",
+            "id",
+            &id,
+            "bdf",
+            pci_device_bdf.to_string()
+        );
+
+        Ok(virtio_device)
+    }
 }
 
 impl DeviceManager {
@@ -1318,6 +1576,15 @@ impl DeviceManager {
             iommu_attached_devices: None,
             virtio_mem_devices: Vec::new(),
         }));
+        let acpi_pci_hotplug_controller = Arc::new(Mutex::new(AcpiPciHotplugController::new(
+            Arc::clone(&shared_state),
+            Arc::clone(&address_manager),
+            Arc::clone(&memory_manager),
+            Arc::clone(&device_tree),
+            Arc::clone(&mmio_regions),
+        )));
+        let acpi_pci_hotplug_bus_device = Arc::clone(&acpi_pci_hotplug_controller);
+
         if dynamic {
             let acpi_address = address_manager
                 .allocator
@@ -1418,6 +1685,7 @@ impl DeviceManager {
             #[cfg(feature = "ivshmem")]
             ivshmem_device: None,
             _acpi_cpu_hotplug_controller: acpi_cpu_hotplug_controller,
+            _acpi_pci_hotplug_controller: acpi_pci_hotplug_controller,
         };
 
         let device_manager = Arc::new(Mutex::new(device_manager));
@@ -1425,7 +1693,7 @@ impl DeviceManager {
         address_manager
             .mmio_bus
             .insert(
-                Arc::clone(&device_manager) as Arc<dyn BusDeviceSync>,
+                acpi_pci_hotplug_bus_device as Arc<dyn BusDeviceSync>,
                 acpi_address.0,
                 DEVICE_MANAGER_ACPI_SIZE as u64,
             )
@@ -4747,228 +5015,24 @@ impl DeviceManager {
     }
 
     pub fn eject_device(&mut self, pci_segment_id: u16, device_id: u8) -> DeviceManagerResult<()> {
-        info!("Ejecting device_id = {device_id} on segment_id={pci_segment_id}");
-
-        // Convert the device ID into the corresponding b/d/f.
-        let pci_device_bdf = PciBdf::new(pci_segment_id, 0, device_id, 0);
-        let mut shared_state = self.shared_state();
-
-        // Give the PCI device ID back to the PCI bus.
-        shared_state.pci_segments[pci_segment_id as usize]
-            .pci_bus
+        // The caller already holds the DeviceManager lock through `&mut self`.
+        // Keep the lock order as DeviceManager -> AcpiPciHotplugController ->
+        // PciHotplugSharedState to match the hot-unplug path and avoid
+        // deadlocks.
+        let virtio_device = self
+            ._acpi_pci_hotplug_controller
             .lock()
             .unwrap()
-            .free_device_id(device_id)
-            .map_err(DeviceManagerError::FreePciDeviceId)?;
-
-        let (pci_device_handle, id) = {
-            // Remove the device from the device tree along with its children.
-            let mut device_tree = self.device_tree.lock().unwrap();
-            let pci_device_node = device_tree
-                .remove_node_by_pci_bdf(pci_device_bdf)
-                .ok_or(DeviceManagerError::MissingPciDevice)?;
-
-            // For VFIO and vfio-user the PCI device id is the id.
-            // For virtio we overwrite it later as we want the id of the
-            // underlying device.
-            let mut id = pci_device_node.id;
-            let pci_device_handle = pci_device_node
-                .pci_device_handle
-                .ok_or(DeviceManagerError::MissingPciDevice)?;
-            if matches!(pci_device_handle, PciDeviceHandle::Virtio(_))
-                && !pci_device_node.children.is_empty()
-            {
-                // The virtio-pci device has a single child.
-                assert_eq!(pci_device_node.children.len(), 1);
-                id.clone_from(&pci_device_node.children[0]);
-            }
-            for child in &pci_device_node.children {
-                device_tree.remove(child);
-            }
-
-            (pci_device_handle, id)
-        };
-
-        let iommu_attached = shared_state
-            .iommu_attached_devices
-            .as_ref()
-            .is_some_and(|(_, devices)| devices.contains(&pci_device_bdf));
-
-        let (pci_device, bus_device, virtio_device, remove_dma_handler) = match pci_device_handle {
-            // VirtioMemMappingSource::Container cleanup is handled by
-            // cleanup_vfio_ops when the last VFIO device is removed.
-            PciDeviceHandle::Vfio(vfio_pci_device) => {
-                // Remove this device's MMIO regions from the DeviceManager's
-                // mmio_regions list. We match on UserMemoryRegion slot numbers
-                // rather than MmioRegion start addresses because move_bar()
-                // updates the device's region addresses but not the
-                // DeviceManager's cloned copies.
-                let device_regions = vfio_pci_device.lock().unwrap().mmio_regions();
-                let mut mmio_regions = self.mmio_regions.lock().unwrap();
-                for device_region in &device_regions {
-                    mmio_regions.retain(|x| !x.has_matching_slots(device_region));
-                }
-
-                (
-                    Arc::clone(&vfio_pci_device) as Arc<Mutex<dyn PciDevice>>,
-                    Arc::clone(&vfio_pci_device) as Arc<dyn BusDeviceSync>,
-                    None as Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>,
-                    false,
-                )
-            }
-            PciDeviceHandle::Virtio(virtio_pci_device) => {
-                let dev = virtio_pci_device.lock().unwrap();
-                let bar_addr = dev.config_bar_addr();
-                for (event, addr) in dev.ioeventfds(bar_addr) {
-                    let io_addr = IoEventAddress::Mmio(addr);
-                    self.address_manager
-                        .vm
-                        .unregister_ioevent(event, &io_addr)
-                        .map_err(|e| DeviceManagerError::UnRegisterIoevent(e.into()))?;
-                }
-
-                if let Some(dma_handler) = dev.dma_handler()
-                    && !iommu_attached
-                {
-                    for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
-                        for region in zone.regions() {
-                            dma_handler
-                                .unmap(region.start_addr().0, region.len())
-                                .map_err(DeviceManagerError::VirtioDmaUnmap)?;
-                        }
-                    }
-                }
-
-                (
-                    Arc::clone(&virtio_pci_device) as Arc<Mutex<dyn PciDevice>>,
-                    Arc::clone(&virtio_pci_device) as Arc<dyn BusDeviceSync>,
-                    Some(dev.virtio_device()),
-                    dev.dma_handler().is_some() && !iommu_attached,
-                )
-            }
-            PciDeviceHandle::VfioUser(vfio_user_pci_device) => {
-                let mut dev = vfio_user_pci_device.lock().unwrap();
-                for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
-                    for region in zone.regions() {
-                        dev.dma_unmap(region)
-                            .map_err(DeviceManagerError::VfioUserDmaUnmap)?;
-                    }
-                }
-
-                (
-                    Arc::clone(&vfio_user_pci_device) as Arc<Mutex<dyn PciDevice>>,
-                    Arc::clone(&vfio_user_pci_device) as Arc<dyn BusDeviceSync>,
-                    None as Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>,
-                    true,
-                )
-            }
-        };
-
-        if remove_dma_handler {
-            for virtio_mem_device in &shared_state.virtio_mem_devices {
-                let source = VirtioMemMappingSource::Device(pci_device_bdf.into());
-                virtio_mem_device
-                    .lock()
-                    .unwrap()
-                    .remove_dma_mapping_handler(&source)
-                    .map_err(DeviceManagerError::RemoveDmaMappingHandlerVirtioMem)?;
-            }
-        }
-
-        // Free the allocated BARs.
-        pci_device
-            .lock()
-            .unwrap()
-            .free_bars(
-                &mut self.address_manager.allocator.lock().unwrap(),
-                &mut shared_state.pci_segments[pci_segment_id as usize]
-                    .mem32_allocator
-                    .lock()
-                    .unwrap(),
-                &mut shared_state.pci_segments[pci_segment_id as usize]
-                    .mem64_allocator
-                    .lock()
-                    .unwrap(),
-            )
-            .map_err(DeviceManagerError::FreePciBars)?;
-
-        shared_state.pci_segments[pci_segment_id as usize]
-            .pci_bus
-            .lock()
-            .unwrap()
-            .remove_by_device(&pci_device)
-            .map_err(DeviceManagerError::RemoveDeviceFromPciBus)?;
-
-        #[cfg(target_arch = "x86_64")]
-        // Remove the device from the IO bus.
-        self.address_manager
-            .io_bus
-            .remove_by_device(bus_device.as_ref())
-            .map_err(DeviceManagerError::RemoveDeviceFromIoBus)?;
-
-        // Remove the device from the MMIO bus.
-        self.address_manager
-            .mmio_bus
-            .remove_by_device(bus_device.as_ref())
-            .map_err(DeviceManagerError::RemoveDeviceFromMmioBus)?;
-
-        // Remove the device from the list of BusDevice held by the
-        // DeviceManager.
-        shared_state
-            .bus_devices
-            .retain(|dev| !Arc::ptr_eq(dev, &bus_device));
+            .eject_device(pci_segment_id, device_id)?;
 
         if let Some(virtio_device) = virtio_device {
-            for mapping in virtio_device.lock().unwrap().userspace_mappings() {
-                // SAFETY: userspace_mappings only has valid mappings.
-                // TODO: do not rely on the correctness of all the code in this
-                // file for this to hold.
-                unsafe {
-                    self.memory_manager
-                        .lock()
-                        .unwrap()
-                        .remove_userspace_mapping(
-                            mapping.addr.raw_value(),
-                            mapping.mapping.size(),
-                            mapping.mapping.as_ptr() as _,
-                            mapping.mergeable,
-                            mapping.mem_slot,
-                        )
-                        .map_err(DeviceManagerError::MemoryManager)
-                }?;
-            }
-
-            virtio_device.lock().unwrap().shutdown();
-            drop(shared_state);
+            // The controller already performed the full virtio teardown,
+            // including userspace unmapping and shutdown. Remove the stale
+            // bookkeeping entry from virtio_devices here because that list
+            // remains owned by DeviceManager rather than shared state.
             self.virtio_devices
                 .retain(|handler| !Arc::ptr_eq(&handler.virtio_device, &virtio_device));
-            self.cleanup_vfio_ops();
-            event!(
-                "vm",
-                "device-removed",
-                "id",
-                &id,
-                "bdf",
-                pci_device_bdf.to_string()
-            );
-            return Ok(());
         }
-
-        drop(shared_state);
-        self.cleanup_vfio_ops();
-
-        // At this point, the device has been removed from all the list and
-        // buses where it was stored. At the end of this function, after
-        // any_device, bus_device and pci_device are released, the actual
-        // device will be dropped.
-        event!(
-            "vm",
-            "device-removed",
-            "id",
-            &id,
-            "bdf",
-            pci_device_bdf.to_string()
-        );
 
         Ok(())
     }
@@ -5200,16 +5264,6 @@ impl DeviceManager {
 
     pub(crate) fn acpi_platform_addresses(&self) -> &AcpiPlatformAddresses {
         &self.acpi_platform_addresses
-    }
-
-    fn cleanup_vfio_ops(&mut self) {
-        let mut state = self.shared_state();
-
-        // Drop the VfioOps instance when "Self" is the only reference
-        if let Some(1) = state.vfio_ops.as_ref().map(Arc::strong_count) {
-            debug!("Drop VfioOps given no active VFIO devices.");
-            state.vfio_ops = None;
-        }
     }
 }
 
@@ -5647,9 +5701,9 @@ const PCID_FIELD_SIZE: usize = 4;
 const B0EJ_FIELD_SIZE: usize = 4;
 const PSEG_FIELD_SIZE: usize = 4;
 
-impl BusDevice for DeviceManager {
+impl BusDevice for AcpiPciHotplugController {
     fn read(&mut self, base: u64, offset: u64, data: &mut [u8]) {
-        let mut shared_state = self.shared_state();
+        let mut shared_state = self.shared_state.lock().unwrap();
         let selected_segment = shared_state.selected_segment;
         match offset {
             PCIU_FIELD_OFFSET => {
@@ -5692,7 +5746,7 @@ impl BusDevice for DeviceManager {
         match offset {
             B0EJ_FIELD_OFFSET => {
                 assert!(data.len() == B0EJ_FIELD_SIZE);
-                let selected_segment = self.shared_state().selected_segment as u16;
+                let selected_segment = self.shared_state.lock().unwrap().selected_segment as u16;
                 let mut data_array: [u8; 4] = [0, 0, 0, 0];
                 data_array.copy_from_slice(data);
                 let mut slot_bitmap = u32::from_le_bytes(data_array);
@@ -5710,7 +5764,7 @@ impl BusDevice for DeviceManager {
                 let mut data_array: [u8; 4] = [0, 0, 0, 0];
                 data_array.copy_from_slice(data);
                 let selected_segment = u32::from_le_bytes(data_array) as usize;
-                let mut shared_state = self.shared_state();
+                let mut shared_state = self.shared_state.lock().unwrap();
                 if selected_segment >= shared_state.pci_segments.len() {
                     error!(
                         "Segment selection out of range: {} >= {}",

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -13,7 +13,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::{File, OpenOptions};
 use std::io::{self, IsTerminal, Seek, SeekFrom, stdout};
 use std::num::Wrapping;
-use std::ops::Deref;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 #[cfg(not(target_arch = "riscv64"))]
@@ -929,30 +928,6 @@ struct DeviceManagerSharedState {
     virtio_mem_devices: Vec<Arc<Mutex<virtio_devices::Mem>>>,
 }
 
-pub(crate) struct PciSegmentsGuard<'a> {
-    shared_state: std::sync::MutexGuard<'a, DeviceManagerSharedState>,
-}
-
-impl Deref for PciSegmentsGuard<'_> {
-    type Target = [PciSegment];
-
-    fn deref(&self) -> &Self::Target {
-        &self.shared_state.pci_segments
-    }
-}
-
-pub struct IommuAttachedDevicesGuard<'a> {
-    shared_state: std::sync::MutexGuard<'a, DeviceManagerSharedState>,
-}
-
-impl Deref for IommuAttachedDevicesGuard<'_> {
-    type Target = Option<(PciBdf, Vec<PciBdf>)>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.shared_state.iommu_attached_devices
-    }
-}
-
 #[derive(Debug)]
 pub struct PtyPair {
     pub main: File,
@@ -1364,6 +1339,7 @@ impl DeviceManager {
             AcpiCpuHotplugController::new(&cpu_manager.lock().unwrap());
         let acpi_cpu_hotplug_controller = Arc::new(Mutex::new(acpi_cpu_hotplug_controller));
 
+        let device_tree = Arc::clone(&device_tree);
         let mmio_regions = Arc::new(Mutex::new(Vec::new()));
         let shared_state = Arc::new(Mutex::new(DeviceManagerSharedState {
             pci_segments,
@@ -4618,10 +4594,9 @@ impl DeviceManager {
             .map(|ic| ic.clone() as Arc<Mutex<dyn InterruptController>>)
     }
 
-    pub(crate) fn pci_segments(&self) -> PciSegmentsGuard<'_> {
-        PciSegmentsGuard {
-            shared_state: self.shared_state(),
-        }
+    pub(crate) fn with_pci_segments<T>(&self, f: impl FnOnce(&[PciSegment]) -> T) -> T {
+        let shared_state = self.shared_state();
+        f(&shared_state.pci_segments)
     }
 
     // Get the guest PCI BDF for a device ID.
@@ -5293,10 +5268,8 @@ impl DeviceManager {
             .map_err(DeviceManagerError::PowerButtonNotification);
     }
 
-    pub fn iommu_attached_devices(&self) -> IommuAttachedDevicesGuard<'_> {
-        IommuAttachedDevicesGuard {
-            shared_state: self.shared_state(),
-        }
+    pub fn iommu_attached_devices(&self) -> Option<(PciBdf, Vec<PciBdf>)> {
+        self.shared_state().iommu_attached_devices.clone()
     }
 
     fn validate_identifier(&self, id: &Option<String>) -> DeviceManagerResult<()> {
@@ -5449,7 +5422,7 @@ impl Aml for DeviceManager {
         use arch::riscv64::DeviceInfoForFdt;
 
         let mut pci_scan_methods = Vec::new();
-        let pci_segment_count = self.pci_segments().len();
+        let pci_segment_count = self.with_pci_segments(|segments| segments.len());
         for i in 0..pci_segment_count {
             pci_scan_methods.push(aml::MethodCall::new(
                 format!("\\_SB_.PC{i:02X}.PCNT").as_str().into(),
@@ -5520,19 +5493,23 @@ impl Aml for DeviceManager {
         )
         .to_aml_bytes(sink);
 
-        for segment in self.pci_segments().iter() {
-            segment.to_aml_bytes(sink);
-        }
+        self.with_pci_segments(|segments| {
+            for segment in segments {
+                segment.to_aml_bytes(sink);
+            }
+        });
 
         let mut mbrd_memory = Vec::new();
 
-        for segment in self.pci_segments().iter() {
-            mbrd_memory.push(aml::Memory32Fixed::new(
-                true,
-                segment.mmio_config_address as u32,
-                layout::PCI_MMIO_CONFIG_SIZE_PER_SEGMENT as u32,
-            ));
-        }
+        self.with_pci_segments(|segments| {
+            for segment in segments {
+                mbrd_memory.push(aml::Memory32Fixed::new(
+                    true,
+                    segment.mmio_config_address as u32,
+                    layout::PCI_MMIO_CONFIG_SIZE_PER_SEGMENT as u32,
+                ));
+            }
+        });
 
         let mut mbrd_memory_refs = Vec::new();
         for mbrd_memory_ref in &mbrd_memory {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1249,11 +1249,24 @@ impl AcpiPciHotplugController {
 
         // Convert the device ID into the corresponding b/d/f.
         let pci_device_bdf = PciBdf::new(pci_segment_id, 0, device_id, 0);
-        let mut shared_state = self.shared_state.lock().unwrap();
+        let (pci_bus, mem32_allocator, mem64_allocator, virtio_mem_devices, iommu_attached) = {
+            let shared_state = self.shared_state.lock().unwrap();
+            let pci_segment = &shared_state.pci_segments[pci_segment_id as usize];
+
+            (
+                Arc::clone(&pci_segment.pci_bus),
+                Arc::clone(&pci_segment.mem32_allocator),
+                Arc::clone(&pci_segment.mem64_allocator),
+                shared_state.virtio_mem_devices.clone(),
+                shared_state
+                    .iommu_attached_devices
+                    .as_ref()
+                    .is_some_and(|(_, devices)| devices.contains(&pci_device_bdf)),
+            )
+        };
 
         // Give the PCI device ID back to the PCI bus.
-        shared_state.pci_segments[pci_segment_id as usize]
-            .pci_bus
+        pci_bus
             .lock()
             .unwrap()
             .put_device_id(device_id as usize)
@@ -1286,11 +1299,6 @@ impl AcpiPciHotplugController {
 
             (pci_device_handle, id)
         };
-
-        let iommu_attached = shared_state
-            .iommu_attached_devices
-            .as_ref()
-            .is_some_and(|(_, devices)| devices.contains(&pci_device_bdf));
 
         let (pci_device, bus_device, virtio_device, remove_dma_handler) = match pci_device_handle {
             // VirtioMemMappingSource::Container cleanup is handled by
@@ -1378,7 +1386,7 @@ impl AcpiPciHotplugController {
         };
 
         if remove_dma_handler {
-            for virtio_mem_device in &shared_state.virtio_mem_devices {
+            for virtio_mem_device in &virtio_mem_devices {
                 let source = VirtioMemMappingSource::Device(pci_device_bdf.into());
                 virtio_mem_device
                     .lock()
@@ -1394,19 +1402,12 @@ impl AcpiPciHotplugController {
             .unwrap()
             .free_bars(
                 &mut self.backend.address_manager.allocator.lock().unwrap(),
-                &mut shared_state.pci_segments[pci_segment_id as usize]
-                    .mem32_allocator
-                    .lock()
-                    .unwrap(),
-                &mut shared_state.pci_segments[pci_segment_id as usize]
-                    .mem64_allocator
-                    .lock()
-                    .unwrap(),
+                &mut mem32_allocator.lock().unwrap(),
+                &mut mem64_allocator.lock().unwrap(),
             )
             .map_err(DeviceManagerError::FreePciBars)?;
 
-        shared_state.pci_segments[pci_segment_id as usize]
-            .pci_bus
+        pci_bus
             .lock()
             .unwrap()
             .remove_by_device(&pci_device)
@@ -1429,10 +1430,6 @@ impl AcpiPciHotplugController {
 
         // Remove the device from the list of BusDevice held by the
         // DeviceManager.
-        shared_state
-            .bus_devices
-            .retain(|dev| !Arc::ptr_eq(dev, &bus_device));
-
         if let Some(virtio_device) = virtio_device {
             for mapping in virtio_device.lock().unwrap().userspace_mappings() {
                 // SAFETY: userspace_mappings only has valid mappings.
@@ -1457,6 +1454,10 @@ impl AcpiPciHotplugController {
             virtio_device.lock().unwrap().shutdown();
         }
 
+        let mut shared_state = self.shared_state.lock().unwrap();
+        shared_state
+            .bus_devices
+            .retain(|dev| !Arc::ptr_eq(dev, &bus_device));
         Self::cleanup_vfio_ops(&mut shared_state);
         drop(shared_state);
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1213,11 +1213,24 @@ impl AcpiPciHotplugController {
 
         // Convert the device ID into the corresponding b/d/f.
         let pci_device_bdf = PciBdf::new(pci_segment_id, 0, device_id, 0);
-        let mut shared_state = self.shared_state.lock().unwrap();
+        let (pci_bus, mem32_allocator, mem64_allocator, virtio_mem_devices, iommu_attached) = {
+            let shared_state = self.shared_state.lock().unwrap();
+            let pci_segment = &shared_state.pci_segments[pci_segment_id as usize];
+
+            (
+                Arc::clone(&pci_segment.pci_bus),
+                Arc::clone(&pci_segment.mem32_allocator),
+                Arc::clone(&pci_segment.mem64_allocator),
+                shared_state.virtio_mem_devices.clone(),
+                shared_state
+                    .iommu_attached_devices
+                    .as_ref()
+                    .is_some_and(|(_, devices)| devices.contains(&pci_device_bdf)),
+            )
+        };
 
         // Give the PCI device ID back to the PCI bus.
-        shared_state.pci_segments[pci_segment_id as usize]
-            .pci_bus
+        pci_bus
             .lock()
             .unwrap()
             .free_device_id(device_id)
@@ -1250,11 +1263,6 @@ impl AcpiPciHotplugController {
 
             (pci_device_handle, id)
         };
-
-        let iommu_attached = shared_state
-            .iommu_attached_devices
-            .as_ref()
-            .is_some_and(|(_, devices)| devices.contains(&pci_device_bdf));
 
         let (pci_device, bus_device, virtio_device, remove_dma_handler) = match pci_device_handle {
             // VirtioMemMappingSource::Container cleanup is handled by
@@ -1327,7 +1335,7 @@ impl AcpiPciHotplugController {
         };
 
         if remove_dma_handler {
-            for virtio_mem_device in &shared_state.virtio_mem_devices {
+            for virtio_mem_device in &virtio_mem_devices {
                 let source = VirtioMemMappingSource::Device(pci_device_bdf.into());
                 virtio_mem_device
                     .lock()
@@ -1343,19 +1351,12 @@ impl AcpiPciHotplugController {
             .unwrap()
             .free_bars(
                 &mut self.address_manager.allocator.lock().unwrap(),
-                &mut shared_state.pci_segments[pci_segment_id as usize]
-                    .mem32_allocator
-                    .lock()
-                    .unwrap(),
-                &mut shared_state.pci_segments[pci_segment_id as usize]
-                    .mem64_allocator
-                    .lock()
-                    .unwrap(),
+                &mut mem32_allocator.lock().unwrap(),
+                &mut mem64_allocator.lock().unwrap(),
             )
             .map_err(DeviceManagerError::FreePciBars)?;
 
-        shared_state.pci_segments[pci_segment_id as usize]
-            .pci_bus
+        pci_bus
             .lock()
             .unwrap()
             .remove_by_device(&pci_device)
@@ -1374,11 +1375,6 @@ impl AcpiPciHotplugController {
             .remove_by_device(bus_device.as_ref())
             .map_err(DeviceManagerError::RemoveDeviceFromMmioBus)?;
 
-        // Remove the device from the list of BusDevice held by the
-        // DeviceManager.
-        shared_state
-            .bus_devices
-            .retain(|dev| !Arc::ptr_eq(dev, &bus_device));
         // Shutdown and remove the underlying virtio-device if present.
         if let Some(virtio_device) = &virtio_device {
             for mapping in virtio_device.lock().unwrap().userspace_mappings() {
@@ -1403,6 +1399,12 @@ impl AcpiPciHotplugController {
             virtio_device.lock().unwrap().shutdown();
         }
 
+        let mut shared_state = self.shared_state.lock().unwrap();
+        // Remove the device from the list of BusDevice held by the
+        // DeviceManager.
+        shared_state
+            .bus_devices
+            .retain(|dev| !Arc::ptr_eq(dev, &bus_device));
         Self::cleanup_vfio_ops(&mut shared_state);
         drop(shared_state);
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1154,6 +1154,21 @@ pub struct DeviceManager {
     #[cfg(feature = "ivshmem")]
     // ivshmem device
     ivshmem_device: Option<Arc<Mutex<devices::IvshmemDevice>>>,
+
+    /// Owned version needed to keep the bus device alive (the bus only holds
+    /// a weak reference).
+    _acpi_pci_hotplug_controller: Arc<Mutex<AcpiPciHotplugController>>,
+}
+
+/// MMIO-accessible controller for handling ACPI PCI hotplug and unplug events.
+///
+/// Shares PCI hotplug state with the [`DeviceManager`].
+pub struct AcpiPciHotplugController {
+    shared_state: Arc<Mutex<DeviceManagerSharedState>>,
+    address_manager: Arc<AddressManager>,
+    memory_manager: Arc<Mutex<MemoryManager>>,
+    device_tree: Arc<Mutex<DeviceTree>>,
+    mmio_regions: Arc<Mutex<Vec<MmioRegion>>>,
 }
 
 /// Create per-PCI-segment MMIO allocators over the range `[start, end]`.
@@ -1192,6 +1207,245 @@ fn create_mmio_allocators(
     }
 
     mmio_allocators
+}
+
+impl AcpiPciHotplugController {
+    fn new(
+        shared_state: Arc<Mutex<DeviceManagerSharedState>>,
+        address_manager: Arc<AddressManager>,
+        memory_manager: Arc<Mutex<MemoryManager>>,
+        device_tree: Arc<Mutex<DeviceTree>>,
+        mmio_regions: Arc<Mutex<Vec<MmioRegion>>>,
+    ) -> Self {
+        Self {
+            shared_state,
+            address_manager,
+            memory_manager,
+            device_tree,
+            mmio_regions,
+        }
+    }
+
+    fn cleanup_vfio_ops(shared_state: &mut DeviceManagerSharedState) {
+        if let Some(1) = shared_state.vfio_ops.as_ref().map(Arc::strong_count) {
+            debug!("Drop VfioOps given no active VFIO devices.");
+            shared_state.vfio_ops = None;
+        }
+    }
+
+    fn eject_device(&mut self, pci_segment_id: u16, device_id: u8) -> DeviceManagerResult<()> {
+        info!("Ejecting device_id = {device_id} on segment_id={pci_segment_id}");
+
+        // Convert the device ID into the corresponding b/d/f.
+        let pci_device_bdf = PciBdf::new(pci_segment_id, 0, device_id, 0);
+        let mut shared_state = self.shared_state.lock().unwrap();
+
+        // Give the PCI device ID back to the PCI bus.
+        shared_state.pci_segments[pci_segment_id as usize]
+            .pci_bus
+            .lock()
+            .unwrap()
+            .put_device_id(device_id as usize)
+            .map_err(DeviceManagerError::PutPciDeviceId)?;
+
+        let (pci_device_handle, id) = {
+            // Remove the device from the device tree along with its children.
+            let mut device_tree = self.device_tree.lock().unwrap();
+            let pci_device_node = device_tree
+                .remove_node_by_pci_bdf(pci_device_bdf)
+                .ok_or(DeviceManagerError::MissingPciDevice)?;
+
+            // For VFIO and vfio-user the PCI device id is the id.
+            // For virtio we overwrite it later as we want the id of the
+            // underlying device.
+            let mut id = pci_device_node.id;
+            let pci_device_handle = pci_device_node
+                .pci_device_handle
+                .ok_or(DeviceManagerError::MissingPciDevice)?;
+            if matches!(pci_device_handle, PciDeviceHandle::Virtio(_))
+                && !pci_device_node.children.is_empty()
+            {
+                // The virtio-pci device has a single child.
+                assert_eq!(pci_device_node.children.len(), 1);
+                id.clone_from(&pci_device_node.children[0]);
+            }
+            for child in &pci_device_node.children {
+                device_tree.remove(child);
+            }
+
+            (pci_device_handle, id)
+        };
+
+        let iommu_attached = shared_state
+            .iommu_attached_devices
+            .as_ref()
+            .is_some_and(|(_, devices)| devices.contains(&pci_device_bdf));
+
+        let (pci_device, bus_device, virtio_device, remove_dma_handler) = match pci_device_handle {
+            // VirtioMemMappingSource::Container cleanup is handled by
+            // cleanup_vfio_ops when the last VFIO device is removed.
+            PciDeviceHandle::Vfio(vfio_pci_device) => {
+                // Remove this device's MMIO regions from the DeviceManager's
+                // mmio_regions list. We match on UserMemoryRegion slot numbers
+                // rather than MmioRegion start addresses because move_bar()
+                // updates the device's region addresses but not the
+                // DeviceManager's cloned copies.
+                let device_regions = vfio_pci_device.lock().unwrap().mmio_regions().clone();
+                let mut mmio_regions = self.mmio_regions.lock().unwrap();
+                for device_region in &device_regions {
+                    mmio_regions.retain(|x| !x.has_matching_slots(device_region));
+                }
+
+                (
+                    Arc::clone(&vfio_pci_device) as Arc<Mutex<dyn PciDevice>>,
+                    Arc::clone(&vfio_pci_device) as Arc<dyn BusDeviceSync>,
+                    None as Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>,
+                    false,
+                )
+            }
+            PciDeviceHandle::Virtio(virtio_pci_device) => {
+                let dev = virtio_pci_device.lock().unwrap();
+                let bar_addr = dev.config_bar_addr();
+                for (event, addr) in dev.ioeventfds(bar_addr) {
+                    let io_addr = IoEventAddress::Mmio(addr);
+                    self.address_manager
+                        .vm
+                        .unregister_ioevent(event, &io_addr)
+                        .map_err(|e| DeviceManagerError::UnRegisterIoevent(e.into()))?;
+                }
+
+                if let Some(dma_handler) = dev.dma_handler()
+                    && !iommu_attached
+                {
+                    for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
+                        for region in zone.regions() {
+                            dma_handler
+                                .unmap(region.start_addr().0, region.len())
+                                .map_err(DeviceManagerError::VirtioDmaUnmap)?;
+                        }
+                    }
+                }
+
+                (
+                    Arc::clone(&virtio_pci_device) as Arc<Mutex<dyn PciDevice>>,
+                    Arc::clone(&virtio_pci_device) as Arc<dyn BusDeviceSync>,
+                    Some(dev.virtio_device()),
+                    dev.dma_handler().is_some() && !iommu_attached,
+                )
+            }
+            PciDeviceHandle::VfioUser(vfio_user_pci_device) => {
+                let mut dev = vfio_user_pci_device.lock().unwrap();
+                for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
+                    for region in zone.regions() {
+                        dev.dma_unmap(region)
+                            .map_err(DeviceManagerError::VfioUserDmaUnmap)?;
+                    }
+                }
+
+                (
+                    Arc::clone(&vfio_user_pci_device) as Arc<Mutex<dyn PciDevice>>,
+                    Arc::clone(&vfio_user_pci_device) as Arc<dyn BusDeviceSync>,
+                    None as Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>,
+                    true,
+                )
+            }
+        };
+
+        if remove_dma_handler {
+            for virtio_mem_device in &shared_state.virtio_mem_devices {
+                let source = VirtioMemMappingSource::Device(pci_device_bdf.into());
+                virtio_mem_device
+                    .lock()
+                    .unwrap()
+                    .remove_dma_mapping_handler(&source)
+                    .map_err(DeviceManagerError::RemoveDmaMappingHandlerVirtioMem)?;
+            }
+        }
+
+        // Free the allocated BARs.
+        pci_device
+            .lock()
+            .unwrap()
+            .free_bars(
+                &mut self.address_manager.allocator.lock().unwrap(),
+                &mut shared_state.pci_segments[pci_segment_id as usize]
+                    .mem32_allocator
+                    .lock()
+                    .unwrap(),
+                &mut shared_state.pci_segments[pci_segment_id as usize]
+                    .mem64_allocator
+                    .lock()
+                    .unwrap(),
+            )
+            .map_err(DeviceManagerError::FreePciBars)?;
+
+        shared_state.pci_segments[pci_segment_id as usize]
+            .pci_bus
+            .lock()
+            .unwrap()
+            .remove_by_device(&pci_device)
+            .map_err(DeviceManagerError::RemoveDeviceFromPciBus)?;
+
+        #[cfg(target_arch = "x86_64")]
+        // Remove the device from the IO bus.
+        self.address_manager
+            .io_bus
+            .remove_by_device(bus_device.as_ref())
+            .map_err(DeviceManagerError::RemoveDeviceFromIoBus)?;
+
+        // Remove the device from the MMIO bus.
+        self.address_manager
+            .mmio_bus
+            .remove_by_device(bus_device.as_ref())
+            .map_err(DeviceManagerError::RemoveDeviceFromMmioBus)?;
+
+        // Remove the device from the list of BusDevice held by the
+        // DeviceManager.
+        shared_state
+            .bus_devices
+            .retain(|dev| !Arc::ptr_eq(dev, &bus_device));
+
+        if let Some(virtio_device) = virtio_device {
+            for mapping in virtio_device.lock().unwrap().userspace_mappings() {
+                // SAFETY: userspace_mappings only has valid mappings.
+                // TODO: do not rely on the correctness of all the code in this
+                // file for this to hold.
+                unsafe {
+                    self.memory_manager
+                        .lock()
+                        .unwrap()
+                        .remove_userspace_mapping(
+                            mapping.addr.raw_value(),
+                            mapping.mapping.size(),
+                            mapping.mapping.as_ptr() as _,
+                            mapping.mergeable,
+                            mapping.mem_slot,
+                        )
+                        .map_err(DeviceManagerError::MemoryManager)
+                }?;
+            }
+
+            virtio_device.lock().unwrap().shutdown();
+        }
+
+        Self::cleanup_vfio_ops(&mut shared_state);
+        drop(shared_state);
+
+        // At this point, the device has been removed from all the list and
+        // buses where it was stored. At the end of this function, after
+        // any_device, bus_device and pci_device are released, the actual
+        // device will be dropped.
+        event!(
+            "vm",
+            "device-removed",
+            "id",
+            &id,
+            "bdf",
+            pci_device_bdf.to_string()
+        );
+
+        Ok(())
+    }
 }
 
 impl DeviceManager {
@@ -1349,6 +1603,15 @@ impl DeviceManager {
             iommu_attached_devices: None,
             virtio_mem_devices: Vec::new(),
         }));
+        let acpi_pci_hotplug_controller = Arc::new(Mutex::new(AcpiPciHotplugController::new(
+            Arc::clone(&shared_state),
+            Arc::clone(&address_manager),
+            Arc::clone(&memory_manager),
+            Arc::clone(&device_tree),
+            Arc::clone(&mmio_regions),
+        )));
+        let acpi_pci_hotplug_bus_device = Arc::clone(&acpi_pci_hotplug_controller);
+
         if dynamic {
             let acpi_address = address_manager
                 .allocator
@@ -1450,6 +1713,7 @@ impl DeviceManager {
             #[cfg(feature = "ivshmem")]
             ivshmem_device: None,
             _acpi_cpu_hotplug_controller: acpi_cpu_hotplug_controller,
+            _acpi_pci_hotplug_controller: acpi_pci_hotplug_controller,
         };
 
         let device_manager = Arc::new(Mutex::new(device_manager));
@@ -1457,7 +1721,7 @@ impl DeviceManager {
         address_manager
             .mmio_bus
             .insert(
-                Arc::clone(&device_manager) as Arc<dyn BusDeviceSync>,
+                acpi_pci_hotplug_bus_device as Arc<dyn BusDeviceSync>,
                 acpi_address.0,
                 DEVICE_MANAGER_ACPI_SIZE as u64,
             )
@@ -4837,230 +5101,10 @@ impl DeviceManager {
     }
 
     pub fn eject_device(&mut self, pci_segment_id: u16, device_id: u8) -> DeviceManagerResult<()> {
-        info!("Ejecting device_id = {device_id} on segment_id={pci_segment_id}");
-
-        // Convert the device ID into the corresponding b/d/f.
-        let pci_device_bdf = PciBdf::new(pci_segment_id, 0, device_id, 0);
-        let mut shared_state = self.shared_state();
-
-        // Give the PCI device ID back to the PCI bus.
-        shared_state.pci_segments[pci_segment_id as usize]
-            .pci_bus
+        self._acpi_pci_hotplug_controller
             .lock()
             .unwrap()
-            .put_device_id(device_id as usize)
-            .map_err(DeviceManagerError::PutPciDeviceId)?;
-
-        let (pci_device_handle, id) = {
-            // Remove the device from the device tree along with its children.
-            let mut device_tree = self.device_tree.lock().unwrap();
-            let pci_device_node = device_tree
-                .remove_node_by_pci_bdf(pci_device_bdf)
-                .ok_or(DeviceManagerError::MissingPciDevice)?;
-
-            // For VFIO and vfio-user the PCI device id is the id.
-            // For virtio we overwrite it later as we want the id of the
-            // underlying device.
-            let mut id = pci_device_node.id;
-            let pci_device_handle = pci_device_node
-                .pci_device_handle
-                .ok_or(DeviceManagerError::MissingPciDevice)?;
-            if matches!(pci_device_handle, PciDeviceHandle::Virtio(_))
-                && !pci_device_node.children.is_empty()
-            {
-                // The virtio-pci device has a single child.
-                assert_eq!(pci_device_node.children.len(), 1);
-                id.clone_from(&pci_device_node.children[0]);
-            }
-            for child in &pci_device_node.children {
-                device_tree.remove(child);
-            }
-
-            (pci_device_handle, id)
-        };
-
-        let iommu_attached = shared_state
-            .iommu_attached_devices
-            .as_ref()
-            .is_some_and(|(_, devices)| devices.contains(&pci_device_bdf));
-
-        let (pci_device, bus_device, virtio_device, remove_dma_handler) = match pci_device_handle {
-            // VirtioMemMappingSource::Container cleanup is handled by
-            // cleanup_vfio_ops when the last VFIO device is removed.
-            PciDeviceHandle::Vfio(vfio_pci_device) => {
-                // Remove this device's MMIO regions from the DeviceManager's
-                // mmio_regions list. We match on UserMemoryRegion slot numbers
-                // rather than MmioRegion start addresses because move_bar()
-                // updates the device's region addresses but not the
-                // DeviceManager's cloned copies.
-                let device_regions = vfio_pci_device.lock().unwrap().mmio_regions().clone();
-                let mut mmio_regions = self.mmio_regions.lock().unwrap();
-                for device_region in &device_regions {
-                    mmio_regions.retain(|x| !x.has_matching_slots(device_region));
-                }
-
-                (
-                    Arc::clone(&vfio_pci_device) as Arc<Mutex<dyn PciDevice>>,
-                    Arc::clone(&vfio_pci_device) as Arc<dyn BusDeviceSync>,
-                    None as Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>,
-                    false,
-                )
-            }
-            PciDeviceHandle::Virtio(virtio_pci_device) => {
-                let dev = virtio_pci_device.lock().unwrap();
-                let bar_addr = dev.config_bar_addr();
-                for (event, addr) in dev.ioeventfds(bar_addr) {
-                    let io_addr = IoEventAddress::Mmio(addr);
-                    self.address_manager
-                        .vm
-                        .unregister_ioevent(event, &io_addr)
-                        .map_err(|e| DeviceManagerError::UnRegisterIoevent(e.into()))?;
-                }
-
-                if let Some(dma_handler) = dev.dma_handler()
-                    && !iommu_attached
-                {
-                    for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
-                        for region in zone.regions() {
-                            dma_handler
-                                .unmap(region.start_addr().0, region.len())
-                                .map_err(DeviceManagerError::VirtioDmaUnmap)?;
-                        }
-                    }
-                }
-
-                (
-                    Arc::clone(&virtio_pci_device) as Arc<Mutex<dyn PciDevice>>,
-                    Arc::clone(&virtio_pci_device) as Arc<dyn BusDeviceSync>,
-                    Some(dev.virtio_device()),
-                    dev.dma_handler().is_some() && !iommu_attached,
-                )
-            }
-            PciDeviceHandle::VfioUser(vfio_user_pci_device) => {
-                let mut dev = vfio_user_pci_device.lock().unwrap();
-                for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
-                    for region in zone.regions() {
-                        dev.dma_unmap(region)
-                            .map_err(DeviceManagerError::VfioUserDmaUnmap)?;
-                    }
-                }
-
-                (
-                    Arc::clone(&vfio_user_pci_device) as Arc<Mutex<dyn PciDevice>>,
-                    Arc::clone(&vfio_user_pci_device) as Arc<dyn BusDeviceSync>,
-                    None as Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>,
-                    true,
-                )
-            }
-        };
-
-        if remove_dma_handler {
-            for virtio_mem_device in &shared_state.virtio_mem_devices {
-                let source = VirtioMemMappingSource::Device(pci_device_bdf.into());
-                virtio_mem_device
-                    .lock()
-                    .unwrap()
-                    .remove_dma_mapping_handler(&source)
-                    .map_err(DeviceManagerError::RemoveDmaMappingHandlerVirtioMem)?;
-            }
-        }
-
-        // Free the allocated BARs.
-        pci_device
-            .lock()
-            .unwrap()
-            .free_bars(
-                &mut self.address_manager.allocator.lock().unwrap(),
-                &mut shared_state.pci_segments[pci_segment_id as usize]
-                    .mem32_allocator
-                    .lock()
-                    .unwrap(),
-                &mut shared_state.pci_segments[pci_segment_id as usize]
-                    .mem64_allocator
-                    .lock()
-                    .unwrap(),
-            )
-            .map_err(DeviceManagerError::FreePciBars)?;
-
-        shared_state.pci_segments[pci_segment_id as usize]
-            .pci_bus
-            .lock()
-            .unwrap()
-            .remove_by_device(&pci_device)
-            .map_err(DeviceManagerError::RemoveDeviceFromPciBus)?;
-
-        #[cfg(target_arch = "x86_64")]
-        // Remove the device from the IO bus.
-        self.address_manager
-            .io_bus
-            .remove_by_device(bus_device.as_ref())
-            .map_err(DeviceManagerError::RemoveDeviceFromIoBus)?;
-
-        // Remove the device from the MMIO bus.
-        self.address_manager
-            .mmio_bus
-            .remove_by_device(bus_device.as_ref())
-            .map_err(DeviceManagerError::RemoveDeviceFromMmioBus)?;
-
-        // Remove the device from the list of BusDevice held by the
-        // DeviceManager.
-        shared_state
-            .bus_devices
-            .retain(|dev| !Arc::ptr_eq(dev, &bus_device));
-
-        if let Some(virtio_device) = virtio_device {
-            for mapping in virtio_device.lock().unwrap().userspace_mappings() {
-                // SAFETY: userspace_mappings only has valid mappings.
-                // TODO: do not rely on the correctness of all the code in this
-                // file for this to hold.
-                unsafe {
-                    self.memory_manager
-                        .lock()
-                        .unwrap()
-                        .remove_userspace_mapping(
-                            mapping.addr.raw_value(),
-                            mapping.mapping.size(),
-                            mapping.mapping.as_ptr() as _,
-                            mapping.mergeable,
-                            mapping.mem_slot,
-                        )
-                        .map_err(DeviceManagerError::MemoryManager)
-                }?;
-            }
-
-            virtio_device.lock().unwrap().shutdown();
-            drop(shared_state);
-            self.virtio_devices
-                .retain(|handler| !Arc::ptr_eq(&handler.virtio_device, &virtio_device));
-            self.cleanup_vfio_ops();
-            event!(
-                "vm",
-                "device-removed",
-                "id",
-                &id,
-                "bdf",
-                pci_device_bdf.to_string()
-            );
-            return Ok(());
-        }
-
-        drop(shared_state);
-        self.cleanup_vfio_ops();
-
-        // At this point, the device has been removed from all the list and
-        // buses where it was stored. At the end of this function, after
-        // any_device, bus_device and pci_device are released, the actual
-        // device will be dropped.
-        event!(
-            "vm",
-            "device-removed",
-            "id",
-            &id,
-            "bdf",
-            pci_device_bdf.to_string()
-        );
-
-        Ok(())
+            .eject_device(pci_segment_id, device_id)
     }
 
     fn hotplug_virtio_pci_device(
@@ -5288,14 +5332,6 @@ impl DeviceManager {
 
     pub(crate) fn acpi_platform_addresses(&self) -> &AcpiPlatformAddresses {
         &self.acpi_platform_addresses
-    }
-
-    fn cleanup_vfio_ops(&mut self) {
-        // Drop the VfioOps instance when "Self" is the only reference
-        if let Some(1) = self.shared_state().vfio_ops.as_ref().map(Arc::strong_count) {
-            debug!("Drop VfioOps given no active VFIO devices.");
-            self.shared_state().vfio_ops = None;
-        }
     }
 }
 
@@ -5733,9 +5769,9 @@ const PCID_FIELD_SIZE: usize = 4;
 const B0EJ_FIELD_SIZE: usize = 4;
 const PSEG_FIELD_SIZE: usize = 4;
 
-impl BusDevice for DeviceManager {
+impl BusDevice for AcpiPciHotplugController {
     fn read(&mut self, base: u64, offset: u64, data: &mut [u8]) {
-        let mut shared_state = self.shared_state();
+        let mut shared_state = self.shared_state.lock().unwrap();
         let selected_segment = shared_state.selected_segment;
         match offset {
             PCIU_FIELD_OFFSET => {
@@ -5778,7 +5814,7 @@ impl BusDevice for DeviceManager {
         match offset {
             B0EJ_FIELD_OFFSET => {
                 assert!(data.len() == B0EJ_FIELD_SIZE);
-                let selected_segment = self.shared_state().selected_segment as u16;
+                let selected_segment = self.shared_state.lock().unwrap().selected_segment as u16;
                 let mut data_array: [u8; 4] = [0, 0, 0, 0];
                 data_array.copy_from_slice(data);
                 let mut slot_bitmap = u32::from_le_bytes(data_array);
@@ -5788,7 +5824,6 @@ impl BusDevice for DeviceManager {
                     if let Err(e) = self.eject_device(selected_segment, slot_id as u8) {
                         error!("Failed ejecting device {slot_id}: {e:?}");
                     }
-                    self.cleanup_vfio_ops();
                     slot_bitmap &= !(1 << slot_id);
                 }
             }
@@ -5797,7 +5832,7 @@ impl BusDevice for DeviceManager {
                 let mut data_array: [u8; 4] = [0, 0, 0, 0];
                 data_array.copy_from_slice(data);
                 let selected_segment = u32::from_le_bytes(data_array) as usize;
-                let mut shared_state = self.shared_state();
+                let mut shared_state = self.shared_state.lock().unwrap();
                 if selected_segment >= shared_state.pci_segments.len() {
                     error!(
                         "Segment selection out of range: {} >= {}",

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1723,25 +1723,28 @@ impl Vm {
             .get_device_info()
             .clone();
 
-        for pci_segment in self.device_manager.lock().unwrap().pci_segments().iter() {
-            let pci_space = PciSpaceInfo {
-                pci_segment_id: pci_segment.id,
-                mmio_config_address: pci_segment.mmio_config_address,
-                pci_device_space_start: pci_segment.start_of_mem64_area,
-                pci_device_space_size: pci_segment.end_of_mem64_area
-                    - pci_segment.start_of_mem64_area
-                    + 1,
-            };
-            pci_space_info.push(pci_space);
-        }
+        self.device_manager
+            .lock()
+            .unwrap()
+            .with_pci_segments(|segments| {
+                for pci_segment in segments {
+                    pci_space_info.push(PciSpaceInfo {
+                        pci_segment_id: pci_segment.id,
+                        mmio_config_address: pci_segment.mmio_config_address,
+                        pci_device_space_start: pci_segment.start_of_mem64_area,
+                        pci_device_space_size: pci_segment.end_of_mem64_area
+                            - pci_segment.start_of_mem64_area
+                            + 1,
+                    });
+                }
+            });
 
         let virtio_iommu_bdf = self
             .device_manager
             .lock()
             .unwrap()
             .iommu_attached_devices()
-            .as_ref()
-            .map(|(v, _)| *v);
+            .map(|(v, _)| v);
 
         let vgic = self
             .device_manager
@@ -1809,17 +1812,21 @@ impl Vm {
             .get_device_info()
             .clone();
 
-        for pci_segment in self.device_manager.lock().unwrap().pci_segments().iter() {
-            let pci_space = PciSpaceInfo {
-                pci_segment_id: pci_segment.id,
-                mmio_config_address: pci_segment.mmio_config_address,
-                pci_device_space_start: pci_segment.start_of_mem64_area,
-                pci_device_space_size: pci_segment.end_of_mem64_area
-                    - pci_segment.start_of_mem64_area
-                    + 1,
-            };
-            pci_space_info.push(pci_space);
-        }
+        self.device_manager
+            .lock()
+            .unwrap()
+            .with_pci_segments(|segments| {
+                for pci_segment in segments {
+                    pci_space_info.push(PciSpaceInfo {
+                        pci_segment_id: pci_segment.id,
+                        mmio_config_address: pci_segment.mmio_config_address,
+                        pci_device_space_start: pci_segment.start_of_mem64_area,
+                        pci_device_space_size: pci_segment.end_of_mem64_area
+                            - pci_segment.start_of_mem64_area
+                            + 1,
+                    });
+                }
+            });
 
         // TODO: IOMMU for riscv64 is not yet support in kernel.
 
@@ -2508,11 +2515,14 @@ impl Vm {
         .map_err(Error::PopulateHob)?;
 
         // Loop over the ACPI tables and copy them to the HOB.
+        let device_manager = self.device_manager.lock().unwrap();
+        let cpu_manager = self.cpu_manager.lock().unwrap();
+        let memory_manager = self.memory_manager.lock().unwrap();
 
         for acpi_table in crate::acpi::create_acpi_tables_tdx(
-            &self.device_manager.lock().unwrap(),
-            &self.cpu_manager.lock().unwrap(),
-            &self.memory_manager.lock().unwrap(),
+            &device_manager,
+            &cpu_manager,
+            &memory_manager,
             &self.numa_nodes,
         ) {
             hob.add_acpi_table(&mem, acpi_table.as_slice())
@@ -2568,13 +2578,16 @@ impl Vm {
         if self.config.lock().unwrap().is_tdx_enabled() {
             return None;
         }
-        let mem = self.memory_manager.lock().unwrap().guest_memory().memory();
+        let memory_manager = self.memory_manager.lock().unwrap();
+        let mem = memory_manager.guest_memory().memory();
+        let device_manager = self.device_manager.lock().unwrap();
+        let cpu_manager = self.cpu_manager.lock().unwrap();
         let tpm_enabled = self.config.lock().unwrap().tpm.is_some();
         let rsdp_addr = crate::acpi::create_acpi_tables(
             &mem,
-            &self.device_manager.lock().unwrap(),
-            &self.cpu_manager.lock().unwrap(),
-            &self.memory_manager.lock().unwrap(),
+            &device_manager,
+            &cpu_manager,
+            &memory_manager,
             &self.numa_nodes,
             tpm_enabled,
         );
@@ -2637,11 +2650,14 @@ impl Vm {
                 Self::populate_fw_cfg(&fw_cfg_config, &self.device_manager, &self.config)?;
 
                 if fw_cfg_config.acpi_tables {
+                    let device_manager = self.device_manager.lock().unwrap();
+                    let cpu_manager = self.cpu_manager.lock().unwrap();
+                    let memory_manager = self.memory_manager.lock().unwrap();
                     let tpm_enabled = self.config.lock().unwrap().tpm.is_some();
                     crate::acpi::create_acpi_tables_for_fw_cfg(
-                        &self.device_manager.lock().unwrap(),
-                        &self.cpu_manager.lock().unwrap(),
-                        &self.memory_manager.lock().unwrap(),
+                        &device_manager,
+                        &cpu_manager,
+                        &memory_manager,
                         &self.numa_nodes,
                         tpm_enabled,
                     )?;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1826,25 +1826,28 @@ impl Vm {
             .get_device_info()
             .clone();
 
-        for pci_segment in self.device_manager.lock().unwrap().pci_segments().iter() {
-            let pci_space = PciSpaceInfo {
-                pci_segment_id: pci_segment.id,
-                mmio_config_address: pci_segment.mmio_config_address,
-                pci_device_space_start: pci_segment.start_of_mem64_area,
-                pci_device_space_size: pci_segment.end_of_mem64_area
-                    - pci_segment.start_of_mem64_area
-                    + 1,
-            };
-            pci_space_info.push(pci_space);
-        }
+        self.device_manager
+            .lock()
+            .unwrap()
+            .with_pci_segments(|segments| {
+                for pci_segment in segments {
+                    pci_space_info.push(PciSpaceInfo {
+                        pci_segment_id: pci_segment.id,
+                        mmio_config_address: pci_segment.mmio_config_address,
+                        pci_device_space_start: pci_segment.start_of_mem64_area,
+                        pci_device_space_size: pci_segment.end_of_mem64_area
+                            - pci_segment.start_of_mem64_area
+                            + 1,
+                    });
+                }
+            });
 
         let virtio_iommu_bdf = self
             .device_manager
             .lock()
             .unwrap()
             .iommu_attached_devices()
-            .as_ref()
-            .map(|(v, _)| *v);
+            .map(|(v, _)| v);
 
         let vgic = self
             .device_manager
@@ -1912,17 +1915,21 @@ impl Vm {
             .get_device_info()
             .clone();
 
-        for pci_segment in self.device_manager.lock().unwrap().pci_segments().iter() {
-            let pci_space = PciSpaceInfo {
-                pci_segment_id: pci_segment.id,
-                mmio_config_address: pci_segment.mmio_config_address,
-                pci_device_space_start: pci_segment.start_of_mem64_area,
-                pci_device_space_size: pci_segment.end_of_mem64_area
-                    - pci_segment.start_of_mem64_area
-                    + 1,
-            };
-            pci_space_info.push(pci_space);
-        }
+        self.device_manager
+            .lock()
+            .unwrap()
+            .with_pci_segments(|segments| {
+                for pci_segment in segments {
+                    pci_space_info.push(PciSpaceInfo {
+                        pci_segment_id: pci_segment.id,
+                        mmio_config_address: pci_segment.mmio_config_address,
+                        pci_device_space_start: pci_segment.start_of_mem64_area,
+                        pci_device_space_size: pci_segment.end_of_mem64_area
+                            - pci_segment.start_of_mem64_area
+                            + 1,
+                    });
+                }
+            });
 
         // TODO: IOMMU for riscv64 is not yet support in kernel.
 
@@ -2611,11 +2618,14 @@ impl Vm {
         .map_err(Error::PopulateHob)?;
 
         // Loop over the ACPI tables and copy them to the HOB.
+        let device_manager = self.device_manager.lock().unwrap();
+        let cpu_manager = self.cpu_manager.lock().unwrap();
+        let memory_manager = self.memory_manager.lock().unwrap();
 
         for acpi_table in crate::acpi::create_acpi_tables_tdx(
-            &self.device_manager.lock().unwrap(),
-            &self.cpu_manager.lock().unwrap(),
-            &self.memory_manager.lock().unwrap(),
+            &device_manager,
+            &cpu_manager,
+            &memory_manager,
             &self.numa_nodes,
         ) {
             hob.add_acpi_table(&mem, acpi_table.as_slice())
@@ -2671,13 +2681,16 @@ impl Vm {
         if self.config.lock().unwrap().is_tdx_enabled() {
             return None;
         }
-        let mem = self.memory_manager.lock().unwrap().guest_memory().memory();
+        let memory_manager = self.memory_manager.lock().unwrap();
+        let mem = memory_manager.guest_memory().memory();
+        let device_manager = self.device_manager.lock().unwrap();
+        let cpu_manager = self.cpu_manager.lock().unwrap();
         let tpm_enabled = self.config.lock().unwrap().tpm.is_some();
         let rsdp_addr = crate::acpi::create_acpi_tables(
             &mem,
-            &self.device_manager.lock().unwrap(),
-            &self.cpu_manager.lock().unwrap(),
-            &self.memory_manager.lock().unwrap(),
+            &device_manager,
+            &cpu_manager,
+            &memory_manager,
             &self.numa_nodes,
             tpm_enabled,
         );
@@ -2740,11 +2753,14 @@ impl Vm {
                 Self::populate_fw_cfg(&fw_cfg_config, &self.device_manager, &self.config)?;
 
                 if fw_cfg_config.acpi_tables {
+                    let device_manager = self.device_manager.lock().unwrap();
+                    let cpu_manager = self.cpu_manager.lock().unwrap();
+                    let memory_manager = self.memory_manager.lock().unwrap();
                     let tpm_enabled = self.config.lock().unwrap().tpm.is_some();
                     crate::acpi::create_acpi_tables_for_fw_cfg(
-                        &self.device_manager.lock().unwrap(),
-                        &self.cpu_manager.lock().unwrap(),
-                        &self.memory_manager.lock().unwrap(),
+                        &device_manager,
+                        &cpu_manager,
+                        &memory_manager,
                         &self.numa_nodes,
                         tpm_enabled,
                     )?;


### PR DESCRIPTION
Fixes #8028 by doing the same as #7990 but for DeviceManager instead of CpuManager.

This splits struct `DeviceManager` into `DeviceManager` and `AcpiPciHotplugController`, nicely preventing any race condition (and hopefully doesn't introduce any new one 🫣).

This PR was created with the help of Codex/GPT-5.4. It helped with all the mechanical changes. However, I had to touch the majority of changes manually over time as LLM produced garbage in many cases.

### Steps to Undraft

- [ ] test this in our internal pipeline Cyberus Technology pipeline
- [ ] finish internal discussions regarding this PR
