### PR TITLE
performance-metrics: Add QCOW2 in-process micro benchmarks

### DIFF
--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -5,7 +5,7 @@ name = "performance-metrics"
 version = "0.1.0"
 
 [dependencies]
-block = { path = "../block" }
+block = { path = "../block", features = ["io_uring"] }
 clap = { workspace = true, features = ["wrap_help"] }
 dirs = { workspace = true }
 libc = { workspace = true }

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 72] = [
+const TEST_LIST: [PerformanceTest; 74] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1364,6 +1364,30 @@ const TEST_LIST: [PerformanceTest; 72] = [
     PerformanceTest {
         name: "micro_block_qcow_fsync_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_fsync,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_backing_read_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_backing_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_backing_read_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_backing_read,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 74] = [
+const TEST_LIST: [PerformanceTest; 76] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1388,6 +1388,30 @@ const TEST_LIST: [PerformanceTest; 74] = [
     PerformanceTest {
         name: "micro_block_qcow_backing_read_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_backing_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_cow_write_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_cow_write,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_cow_write_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_cow_write,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 78] = [
+const TEST_LIST: [PerformanceTest; 80] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1436,6 +1436,30 @@ const TEST_LIST: [PerformanceTest; 78] = [
     PerformanceTest {
         name: "micro_block_qcow_compressed_read_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_compressed_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_multi_cluster_read_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_multi_cluster_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_multi_cluster_read_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_multi_cluster_read,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 90] = [
+const TEST_LIST: [PerformanceTest; 92] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1580,6 +1580,30 @@ const TEST_LIST: [PerformanceTest; 90] = [
     PerformanceTest {
         name: "micro_block_qcow_async_multi_cluster_read_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_async_multi_cluster_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_backing_read_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_backing_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_backing_read_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_backing_read,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 96] = [
+const TEST_LIST: [PerformanceTest; 98] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1652,6 +1652,30 @@ const TEST_LIST: [PerformanceTest; 96] = [
     PerformanceTest {
         name: "micro_block_qcow_async_write_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_async_write,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_l2_cache_miss_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_l2_cache_miss,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_l2_cache_miss_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_l2_cache_miss,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 98] = [
+const TEST_LIST: [PerformanceTest; 100] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1676,6 +1676,30 @@ const TEST_LIST: [PerformanceTest; 98] = [
     PerformanceTest {
         name: "micro_block_qcow_async_l2_cache_miss_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_async_l2_cache_miss,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_batch_write_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_batch_write,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_batch_write_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_batch_write,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 88] = [
+const TEST_LIST: [PerformanceTest; 90] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1556,6 +1556,30 @@ const TEST_LIST: [PerformanceTest; 88] = [
     PerformanceTest {
         name: "micro_block_qcow_async_random_read_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_async_random_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_multi_cluster_read_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_multi_cluster_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_multi_cluster_read_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_multi_cluster_read,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 92] = [
+const TEST_LIST: [PerformanceTest; 94] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1604,6 +1604,30 @@ const TEST_LIST: [PerformanceTest; 92] = [
     PerformanceTest {
         name: "micro_block_qcow_async_backing_read_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_async_backing_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_compressed_read_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_compressed_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_compressed_read_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_compressed_read,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 84] = [
+const TEST_LIST: [PerformanceTest; 86] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1508,6 +1508,30 @@ const TEST_LIST: [PerformanceTest; 84] = [
     PerformanceTest {
         name: "micro_block_qcow_async_read_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_async_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_batch_read_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_batch_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_batch_read_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_batch_read,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 68] = [
+const TEST_LIST: [PerformanceTest; 70] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1316,6 +1316,30 @@ const TEST_LIST: [PerformanceTest; 68] = [
     PerformanceTest {
         name: "micro_block_qcow_punch_hole_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_punch_hole,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_fsync_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_fsync,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_fsync_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_fsync,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 64] = [
+const TEST_LIST: [PerformanceTest; 66] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1268,6 +1268,30 @@ const TEST_LIST: [PerformanceTest; 64] = [
     PerformanceTest {
         name: "micro_block_qcow_read_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_write_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_write,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_write_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_write,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 76] = [
+const TEST_LIST: [PerformanceTest; 78] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1412,6 +1412,30 @@ const TEST_LIST: [PerformanceTest; 76] = [
     PerformanceTest {
         name: "micro_block_qcow_cow_write_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_cow_write,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_compressed_read_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_compressed_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_compressed_read_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_compressed_read,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 80] = [
+const TEST_LIST: [PerformanceTest; 82] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1460,6 +1460,30 @@ const TEST_LIST: [PerformanceTest; 80] = [
     PerformanceTest {
         name: "micro_block_qcow_multi_cluster_read_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_multi_cluster_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_l2_cache_miss_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_l2_cache_miss,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_l2_cache_miss_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_l2_cache_miss,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 62] = [
+const TEST_LIST: [PerformanceTest; 64] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1246,6 +1246,30 @@ const TEST_LIST: [PerformanceTest; 62] = [
         func_ptr: micro_bench_block::micro_bench_aio_drain,
         control: PerformanceTestControl {
             test_timeout: 5,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_read_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_read_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
             test_iterations: 20,
             warmup_iterations: 5,
             num_ops: Some(256),

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 82] = [
+const TEST_LIST: [PerformanceTest; 84] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1484,6 +1484,30 @@ const TEST_LIST: [PerformanceTest; 82] = [
     PerformanceTest {
         name: "micro_block_qcow_l2_cache_miss_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_l2_cache_miss,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_read_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_read_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_read,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 70] = [
+const TEST_LIST: [PerformanceTest; 72] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1268,6 +1268,30 @@ const TEST_LIST: [PerformanceTest; 70] = [
     PerformanceTest {
         name: "micro_block_qcow_read_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_random_read_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_random_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_random_read_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_random_read,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 86] = [
+const TEST_LIST: [PerformanceTest; 88] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1532,6 +1532,30 @@ const TEST_LIST: [PerformanceTest; 86] = [
     PerformanceTest {
         name: "micro_block_qcow_batch_read_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_batch_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_random_read_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_random_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_random_read_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_random_read,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 66] = [
+const TEST_LIST: [PerformanceTest; 68] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1292,6 +1292,30 @@ const TEST_LIST: [PerformanceTest; 66] = [
     PerformanceTest {
         name: "micro_block_qcow_write_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_write,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_punch_hole_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_punch_hole,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_punch_hole_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_punch_hole,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -378,7 +378,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 94] = [
+const TEST_LIST: [PerformanceTest; 96] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1628,6 +1628,30 @@ const TEST_LIST: [PerformanceTest; 94] = [
     PerformanceTest {
         name: "micro_block_qcow_async_compressed_read_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_async_compressed_read,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(256),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_write_128_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_write,
+        control: PerformanceTestControl {
+            test_timeout: 10,
+            test_iterations: 20,
+            warmup_iterations: 5,
+            num_ops: Some(128),
+            ..PerformanceTestControl::default()
+        },
+        unit_adjuster: adjuster::s_to_us,
+    },
+    PerformanceTest {
+        name: "micro_block_qcow_async_write_256_us",
+        func_ptr: micro_bench_block::micro_bench_qcow_async_write,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -247,3 +247,27 @@ pub fn micro_bench_qcow_cow_write(control: &PerformanceTestControl) -> f64 {
 
     elapsed
 }
+
+/// Read num_ops clusters from a zlib compressed QCOW2 image.
+///
+/// Every cluster is stored compressed, so each read triggers
+/// decompression.  This isolates the decompression overhead from
+/// the normal allocated-cluster read path.
+///
+/// Returns the total read wall clock time in seconds.
+pub fn micro_bench_qcow_compressed_read(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::compressed_qcow_tempfile(num_ops);
+    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+
+    let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = read_iovec(&mut buf);
+
+    let start = Instant::now();
+    submit_reads(async_io.as_mut(), num_ops, QCOW_CLUSTER_SIZE, &[iovec]);
+    let elapsed = start.elapsed().as_secs_f64();
+
+    drain_completions(async_io.as_mut(), num_ops);
+
+    elapsed
+}

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -106,3 +106,29 @@ pub fn micro_bench_qcow_write(control: &PerformanceTestControl) -> f64 {
 
     elapsed
 }
+
+/// Punch holes for num_ops clusters in a prepopulated qcow2 image through
+/// the QcowSync async_io path and time the total punch_hole wall clock.
+///
+/// This exercises the discard path: deallocate_bytes decrements refcounts,
+/// frees clusters and issues fallocate punch_hole on the host file.
+///
+/// Returns the total punch_hole wall clock time in seconds.
+pub fn micro_bench_qcow_punch_hole(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::qcow_tempfile(num_ops);
+    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+
+    let start = Instant::now();
+    for i in 0..num_ops {
+        async_io
+            .punch_hole(i as u64 * QCOW_CLUSTER_SIZE, QCOW_CLUSTER_SIZE, i as u64)
+            .expect("punch_hole failed");
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+
+    // Drain completions so Drop is clean.
+    drain_completions(async_io.as_mut(), num_ops);
+
+    elapsed
+}

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -456,3 +456,27 @@ pub fn micro_bench_qcow_async_multi_cluster_read(control: &PerformanceTestContro
     drain_async_completions(async_io.as_mut(), num_reads);
     start.elapsed().as_secs_f64()
 }
+
+/// Read num_ops clusters from a QCOW2 overlay backed by a raw file
+/// through the QcowAsync io_uring path.
+///
+/// All reads fall through to the backing file (sync fallback in
+/// QcowAsync since the mapping is not a single allocated cluster).
+///
+/// Returns the total read wall clock time in seconds.
+pub fn micro_bench_qcow_async_backing_read(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_backing, _overlay, disk) = util::qcow_async_overlay_tempfile(num_ops);
+    let mut async_io = disk
+        .new_async_io(num_ops as u32)
+        .expect("new_async_io failed");
+
+    let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = read_iovec(&mut buf);
+
+    let start = Instant::now();
+    submit_reads(async_io.as_mut(), num_ops, QCOW_CLUSTER_SIZE, &[iovec]);
+
+    drain_async_completions(async_io.as_mut(), num_ops);
+    start.elapsed().as_secs_f64()
+}

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -16,8 +16,8 @@ use block::raw_async_aio::RawFileAsyncAio;
 
 use crate::PerformanceTestControl;
 use crate::util::{
-    self, BLOCK_SIZE, QCOW_CLUSTER_SIZE, drain_completions, read_iovec, submit_reads,
-    submit_writes, write_iovec,
+    self, BLOCK_SIZE, QCOW_CLUSTER_SIZE, deterministic_permutation, drain_completions, read_iovec,
+    submit_reads, submit_writes, write_iovec,
 };
 
 /// Submit num_ops AIO writes, wait for them all to land, then time
@@ -76,6 +76,40 @@ pub fn micro_bench_qcow_read(control: &PerformanceTestControl) -> f64 {
     let elapsed = start.elapsed().as_secs_f64();
 
     // Drain completions so Drop is clean.
+    drain_completions(async_io.as_mut(), num_ops);
+
+    elapsed
+}
+
+/// Read num_ops clusters from a prepopulated qcow2 image in random order.
+///
+/// Unlike micro_bench_qcow_read which reads sequentially, this shuffles
+/// the cluster indices to exercise L2 cache miss and eviction behaviour
+/// under random access patterns.
+///
+/// Returns the total read wall clock time in seconds.
+pub fn micro_bench_qcow_random_read(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::qcow_tempfile(num_ops);
+    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+
+    let indices = deterministic_permutation(num_ops);
+
+    let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = read_iovec(&mut buf);
+
+    let start = Instant::now();
+    for (seq, &cluster_idx) in indices.iter().enumerate() {
+        async_io
+            .read_vectored(
+                (cluster_idx as u64 * QCOW_CLUSTER_SIZE) as libc::off_t,
+                &[iovec],
+                seq as u64,
+            )
+            .expect("read_vectored failed");
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+
     drain_completions(async_io.as_mut(), num_ops);
 
     elapsed

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -428,3 +428,31 @@ pub fn micro_bench_qcow_async_random_read(control: &PerformanceTestControl) -> f
     drain_async_completions(async_io.as_mut(), num_ops);
     start.elapsed().as_secs_f64()
 }
+
+/// Issue large multi-cluster reads from a prepopulated QCOW2 image
+/// through the QcowAsync io_uring path.
+///
+/// Each read spans 8 contiguous clusters (512 KiB). With coalesced
+/// mappings, this can hit the io_uring fast path for a single Readv.
+///
+/// Returns the total read wall clock time in seconds.
+pub fn micro_bench_qcow_async_multi_cluster_read(control: &PerformanceTestControl) -> f64 {
+    const CLUSTERS_PER_READ: usize = 8;
+
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::qcow_async_tempfile(num_ops);
+    let mut async_io = disk
+        .new_async_io(num_ops as u32)
+        .expect("new_async_io failed");
+
+    let read_size = CLUSTERS_PER_READ * QCOW_CLUSTER_SIZE as usize;
+    let mut buf = vec![0u8; read_size];
+    let iovec = read_iovec(&mut buf);
+
+    let num_reads = num_ops / CLUSTERS_PER_READ;
+    let start = Instant::now();
+    submit_reads(async_io.as_mut(), num_reads, read_size as u64, &[iovec]);
+
+    drain_async_completions(async_io.as_mut(), num_reads);
+    start.elapsed().as_secs_f64()
+}

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -397,3 +397,34 @@ pub fn micro_bench_qcow_batch_read(control: &PerformanceTestControl) -> f64 {
     drain_async_completions(async_io.as_mut(), num_ops);
     start.elapsed().as_secs_f64()
 }
+
+/// Read num_ops clusters from a prepopulated QCOW2 image in random order
+/// through the QcowAsync io_uring path.
+///
+/// Returns the total read wall clock time in seconds.
+pub fn micro_bench_qcow_async_random_read(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::qcow_async_tempfile(num_ops);
+    let mut async_io = disk
+        .new_async_io(num_ops as u32)
+        .expect("new_async_io failed");
+
+    let indices = deterministic_permutation(num_ops);
+
+    let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = read_iovec(&mut buf);
+
+    let start = Instant::now();
+    for (seq, &cluster_idx) in indices.iter().enumerate() {
+        async_io
+            .read_vectored(
+                (cluster_idx as u64 * QCOW_CLUSTER_SIZE) as libc::off_t,
+                &[iovec],
+                seq as u64,
+            )
+            .expect("read_vectored failed");
+    }
+
+    drain_async_completions(async_io.as_mut(), num_ops);
+    start.elapsed().as_secs_f64()
+}

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -16,8 +16,8 @@ use block::raw_async_aio::RawFileAsyncAio;
 
 use crate::PerformanceTestControl;
 use crate::util::{
-    self, BLOCK_SIZE, QCOW_CLUSTER_SIZE, deterministic_permutation, drain_completions, read_iovec,
-    submit_reads, submit_writes, write_iovec,
+    self, BLOCK_SIZE, L2_ENTRIES_PER_TABLE, QCOW_CLUSTER_SIZE, deterministic_permutation,
+    drain_completions, read_iovec, submit_reads, submit_writes, write_iovec,
 };
 
 /// Submit num_ops AIO writes, wait for them all to land, then time
@@ -298,6 +298,33 @@ pub fn micro_bench_qcow_multi_cluster_read(control: &PerformanceTestControl) -> 
     let elapsed = start.elapsed().as_secs_f64();
 
     drain_completions(async_io.as_mut(), num_reads);
+
+    elapsed
+}
+
+/// Read one cluster from each of num_ops distinct L2 tables in a
+/// sparsely allocated QCOW2 image.
+///
+/// The clusters are spaced L2_ENTRIES_PER_TABLE apart so every read
+/// touches a different L2 table.  With num_ops exceeding the L2 cache
+/// capacity (100 entries), this forces eviction on nearly every read
+/// and measures the cold L2 cache miss overhead.
+///
+/// Returns the total read wall clock time in seconds.
+pub fn micro_bench_qcow_l2_cache_miss(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::sparse_qcow_tempfile(num_ops);
+    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+
+    let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = read_iovec(&mut buf);
+
+    let stride = L2_ENTRIES_PER_TABLE as u64 * QCOW_CLUSTER_SIZE;
+    let start = Instant::now();
+    submit_reads(async_io.as_mut(), num_ops, stride, &[iovec]);
+    let elapsed = start.elapsed().as_secs_f64();
+
+    drain_completions(async_io.as_mut(), num_ops);
 
     elapsed
 }

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -132,3 +132,33 @@ pub fn micro_bench_qcow_punch_hole(control: &PerformanceTestControl) -> f64 {
 
     elapsed
 }
+
+/// Write num_ops clusters into an empty qcow2 image to dirty L2 and
+/// refcount metadata, then time a single fsync that flushes all dirty
+/// tables to disk.
+///
+/// This isolates the metadata flush cost which scales with the number
+/// of dirty L2 table entries and refcount blocks.
+///
+/// Returns the fsync wall clock time in seconds.
+pub fn micro_bench_qcow_fsync(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::empty_qcow_tempfile(num_ops);
+    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+
+    // Write num_ops clusters to dirty L2 and refcount metadata.
+    let buf = vec![0xA5u8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = write_iovec(&buf);
+    submit_writes(async_io.as_mut(), num_ops, QCOW_CLUSTER_SIZE, &[iovec]);
+    // Drain write completions.
+    drain_completions(async_io.as_mut(), num_ops);
+
+    // Time the flush.
+    let start = Instant::now();
+    async_io.fsync(Some(num_ops as u64)).expect("fsync failed");
+    let elapsed = start.elapsed().as_secs_f64();
+
+    drain_completions(async_io.as_mut(), 1);
+
+    elapsed
+}

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -13,6 +13,7 @@ use std::time::Instant;
 use block::async_io::AsyncIo;
 use block::disk_file::AsyncDiskFile;
 use block::raw_async_aio::RawFileAsyncAio;
+use block::{BatchRequest, RequestType};
 
 use crate::PerformanceTestControl;
 use crate::util::{
@@ -350,6 +351,47 @@ pub fn micro_bench_qcow_async_read(control: &PerformanceTestControl) -> f64 {
 
     let start = Instant::now();
     submit_reads(async_io.as_mut(), num_ops, QCOW_CLUSTER_SIZE, &[iovec]);
+
+    // Drain all io_uring completions before stopping the clock.
+    drain_async_completions(async_io.as_mut(), num_ops);
+    start.elapsed().as_secs_f64()
+}
+
+/// Measure QCOW2 batch read submission via io_uring.
+///
+/// Builds a batch of `num_ops` read requests and submits them all at once
+/// through `submit_batch_requests`, which packs multiple SQEs into a single
+/// io_uring submission. Returns the total wall clock time in seconds.
+pub fn micro_bench_qcow_batch_read(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::qcow_async_tempfile(num_ops);
+    let mut async_io = disk
+        .new_async_io(num_ops as u32)
+        .expect("new_async_io failed");
+
+    let mut buf = vec![0u8; num_ops * QCOW_CLUSTER_SIZE as usize];
+
+    let batch: Vec<BatchRequest> = (0..num_ops)
+        .map(|i| {
+            let slice =
+                &mut buf[i * QCOW_CLUSTER_SIZE as usize..(i + 1) * QCOW_CLUSTER_SIZE as usize];
+            BatchRequest {
+                offset: (i as u64 * QCOW_CLUSTER_SIZE) as libc::off_t,
+                iovecs: vec![libc::iovec {
+                    iov_base: slice.as_mut_ptr() as *mut libc::c_void,
+                    iov_len: QCOW_CLUSTER_SIZE as usize,
+                }]
+                .into(),
+                user_data: i as u64,
+                request_type: RequestType::In,
+            }
+        })
+        .collect();
+
+    let start = Instant::now();
+    async_io
+        .submit_batch_requests(&batch)
+        .expect("submit_batch_requests failed");
 
     // Drain all io_uring completions before stopping the clock.
     drain_async_completions(async_io.as_mut(), num_ops);

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -480,3 +480,25 @@ pub fn micro_bench_qcow_async_backing_read(control: &PerformanceTestControl) -> 
     drain_async_completions(async_io.as_mut(), num_ops);
     start.elapsed().as_secs_f64()
 }
+
+/// Compressed clusters take the sync fallback in QcowAsync since they
+/// require decompression. This measures decompression overhead through
+/// the async code path.
+///
+/// Returns the total read wall clock time in seconds.
+pub fn micro_bench_qcow_async_compressed_read(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::compressed_qcow_async_tempfile(num_ops);
+    let mut async_io = disk
+        .new_async_io(num_ops as u32)
+        .expect("new_async_io failed");
+
+    let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = read_iovec(&mut buf);
+
+    let start = Instant::now();
+    submit_reads(async_io.as_mut(), num_ops, QCOW_CLUSTER_SIZE, &[iovec]);
+
+    drain_async_completions(async_io.as_mut(), num_ops);
+    start.elapsed().as_secs_f64()
+}

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -549,3 +549,45 @@ pub fn micro_bench_qcow_async_l2_cache_miss(control: &PerformanceTestControl) ->
     drain_async_completions(async_io.as_mut(), num_ops);
     start.elapsed().as_secs_f64()
 }
+
+/// Measure QCOW2 batch write submission via io_uring.
+///
+/// Builds a batch of num_ops write requests and submits them all at once
+/// through submit_batch_requests. Writes in QcowAsync are synchronous
+/// (COW path), so this measures whether batching reduces per-request
+/// overhead compared to individual write_vectored calls.
+///
+/// Returns the total wall clock time in seconds.
+pub fn micro_bench_qcow_batch_write(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::empty_qcow_async_tempfile(num_ops);
+    let mut async_io = disk
+        .new_async_io(num_ops as u32)
+        .expect("new_async_io failed");
+
+    let buf = vec![0xA5u8; num_ops * QCOW_CLUSTER_SIZE as usize];
+
+    let batch: Vec<BatchRequest> = (0..num_ops)
+        .map(|i| {
+            let slice = &buf[i * QCOW_CLUSTER_SIZE as usize..(i + 1) * QCOW_CLUSTER_SIZE as usize];
+            BatchRequest {
+                offset: (i as u64 * QCOW_CLUSTER_SIZE) as libc::off_t,
+                iovecs: vec![libc::iovec {
+                    iov_base: slice.as_ptr() as *mut libc::c_void,
+                    iov_len: QCOW_CLUSTER_SIZE as usize,
+                }]
+                .into(),
+                user_data: i as u64,
+                request_type: RequestType::Out,
+            }
+        })
+        .collect();
+
+    let start = Instant::now();
+    async_io
+        .submit_batch_requests(&batch)
+        .expect("submit_batch_requests failed");
+
+    drain_async_completions(async_io.as_mut(), num_ops);
+    start.elapsed().as_secs_f64()
+}

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -17,6 +17,7 @@ use block::raw_async_aio::RawFileAsyncAio;
 use crate::PerformanceTestControl;
 use crate::util::{
     self, BLOCK_SIZE, QCOW_CLUSTER_SIZE, drain_completions, read_iovec, submit_reads,
+    submit_writes, write_iovec,
 };
 
 /// Submit num_ops AIO writes, wait for them all to land, then time
@@ -72,6 +73,32 @@ pub fn micro_bench_qcow_read(control: &PerformanceTestControl) -> f64 {
 
     let start = Instant::now();
     submit_reads(async_io.as_mut(), num_ops, QCOW_CLUSTER_SIZE, &[iovec]);
+    let elapsed = start.elapsed().as_secs_f64();
+
+    // Drain completions so Drop is clean.
+    drain_completions(async_io.as_mut(), num_ops);
+
+    elapsed
+}
+
+/// Write num_ops clusters into an empty qcow2 image through the
+/// QcowSync async_io path and time the total write_vectored wall clock.
+///
+/// This exercises the write allocation path: map_cluster_for_write
+/// allocates a new cluster and bumps refcounts, then pwrite_all writes
+/// the data.
+///
+/// Returns the total write wall clock time in seconds.
+pub fn micro_bench_qcow_write(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::empty_qcow_tempfile(num_ops);
+    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+
+    let buf = vec![0xA5u8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = write_iovec(&buf);
+
+    let start = Instant::now();
+    submit_writes(async_io.as_mut(), num_ops, QCOW_CLUSTER_SIZE, &[iovec]);
     let elapsed = start.elapsed().as_secs_f64();
 
     // Drain completions so Drop is clean.

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -11,10 +11,13 @@ use std::os::unix::io::AsRawFd;
 use std::time::Instant;
 
 use block::async_io::AsyncIo;
+use block::disk_file::AsyncDiskFile;
 use block::raw_async_aio::RawFileAsyncAio;
 
 use crate::PerformanceTestControl;
-use crate::util::{self, BLOCK_SIZE};
+use crate::util::{
+    self, BLOCK_SIZE, QCOW_CLUSTER_SIZE, drain_completions, read_iovec, submit_reads,
+};
 
 /// Submit num_ops AIO writes, wait for them all to land, then time
 /// how long it takes to drain every completion via next_completed_request().
@@ -50,4 +53,29 @@ pub fn micro_bench_aio_drain(control: &PerformanceTestControl) -> f64 {
         }
     }
     start.elapsed().as_secs_f64()
+}
+
+/// Read num_ops clusters from a prepopulated qcow2 image through the
+/// QcowSync async_io path and time the total read_vectored wall clock.
+///
+/// This exercises the hot read path: L2 lookup via map_clusters_for_read,
+/// pread64 for allocated data, and iovec scatter.
+///
+/// Returns the total read wall clock time in seconds.
+pub fn micro_bench_qcow_read(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::qcow_tempfile(num_ops);
+    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+
+    let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = read_iovec(&mut buf);
+
+    let start = Instant::now();
+    submit_reads(async_io.as_mut(), num_ops, QCOW_CLUSTER_SIZE, &[iovec]);
+    let elapsed = start.elapsed().as_secs_f64();
+
+    // Drain completions so Drop is clean.
+    drain_completions(async_io.as_mut(), num_ops);
+
+    elapsed
 }

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -502,3 +502,28 @@ pub fn micro_bench_qcow_async_compressed_read(control: &PerformanceTestControl) 
     drain_async_completions(async_io.as_mut(), num_ops);
     start.elapsed().as_secs_f64()
 }
+
+/// Write num_ops clusters into an empty QCOW2 image through the
+/// QcowAsync io_uring path.
+///
+/// Writes in QcowAsync are synchronous (COW metadata allocation must
+/// complete before the host offset is known), so this measures the
+/// write path overhead through the async code path.
+///
+/// Returns the total write wall clock time in seconds.
+pub fn micro_bench_qcow_async_write(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::empty_qcow_async_tempfile(num_ops);
+    let mut async_io = disk
+        .new_async_io(num_ops as u32)
+        .expect("new_async_io failed");
+
+    let buf = vec![0xA5u8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = write_iovec(&buf);
+
+    let start = Instant::now();
+    submit_writes(async_io.as_mut(), num_ops, QCOW_CLUSTER_SIZE, &[iovec]);
+
+    drain_async_completions(async_io.as_mut(), num_ops);
+    start.elapsed().as_secs_f64()
+}

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -17,7 +17,8 @@ use block::raw_async_aio::RawFileAsyncAio;
 use crate::PerformanceTestControl;
 use crate::util::{
     self, BLOCK_SIZE, L2_ENTRIES_PER_TABLE, QCOW_CLUSTER_SIZE, deterministic_permutation,
-    drain_completions, read_iovec, submit_reads, submit_writes, write_iovec,
+    drain_async_completions, drain_completions, read_iovec, submit_reads, submit_writes,
+    write_iovec,
 };
 
 /// Submit num_ops AIO writes, wait for them all to land, then time
@@ -327,4 +328,30 @@ pub fn micro_bench_qcow_l2_cache_miss(control: &PerformanceTestControl) -> f64 {
     drain_completions(async_io.as_mut(), num_ops);
 
     elapsed
+}
+
+/// Read num_ops clusters from a prepopulated qcow2 image through the
+/// QcowAsync io_uring path and time the total wall clock.
+///
+/// Unlike micro_bench_qcow_read which uses QcowDiskSync (blocking),
+/// this uses QcowDiskAsync where single-allocated-cluster reads go
+/// through io_uring for true asynchronous completion.
+///
+/// Returns the total read wall clock time in seconds.
+pub fn micro_bench_qcow_async_read(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::qcow_async_tempfile(num_ops);
+    let mut async_io = disk
+        .new_async_io(num_ops as u32)
+        .expect("new_async_io failed");
+
+    let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = read_iovec(&mut buf);
+
+    let start = Instant::now();
+    submit_reads(async_io.as_mut(), num_ops, QCOW_CLUSTER_SIZE, &[iovec]);
+
+    // Drain all io_uring completions before stopping the clock.
+    drain_async_completions(async_io.as_mut(), num_ops);
+    start.elapsed().as_secs_f64()
 }

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -196,3 +196,28 @@ pub fn micro_bench_qcow_fsync(control: &PerformanceTestControl) -> f64 {
 
     elapsed
 }
+
+/// Read num_ops clusters from a QCOW2 overlay whose data lives entirely
+/// in a raw backing file.
+///
+/// This exercises the backing file read path: L2 lookup finds no
+/// allocated cluster and falls through to the backing file for every
+/// read.
+///
+/// Returns the total read wall clock time in seconds.
+pub fn micro_bench_qcow_backing_read(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_backing, _overlay, disk) = util::qcow_overlay_tempfile(num_ops);
+    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+
+    let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = read_iovec(&mut buf);
+
+    let start = Instant::now();
+    submit_reads(async_io.as_mut(), num_ops, QCOW_CLUSTER_SIZE, &[iovec]);
+    let elapsed = start.elapsed().as_secs_f64();
+
+    drain_completions(async_io.as_mut(), num_ops);
+
+    elapsed
+}

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -271,3 +271,33 @@ pub fn micro_bench_qcow_compressed_read(control: &PerformanceTestControl) -> f64
 
     elapsed
 }
+
+/// Issue large multicluster reads from a prepopulated QCOW2 image.
+///
+/// Each read_vectored call spans `CLUSTERS_PER_READ` contiguous clusters
+/// (8 x 64 KiB = 512 KiB).  This exercises the mapping coalesce path
+/// where multiple L2 entries are merged into fewer host I/O operations.
+/// `num_ops` is the total number of clusters; reads are issued in
+/// chunks of CLUSTERS_PER_READ.
+///
+/// Returns the total read wall clock time in seconds.
+pub fn micro_bench_qcow_multi_cluster_read(control: &PerformanceTestControl) -> f64 {
+    const CLUSTERS_PER_READ: usize = 8;
+
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::qcow_tempfile(num_ops);
+    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+
+    let read_size = CLUSTERS_PER_READ * QCOW_CLUSTER_SIZE as usize;
+    let mut buf = vec![0u8; read_size];
+    let iovec = read_iovec(&mut buf);
+
+    let num_reads = num_ops / CLUSTERS_PER_READ;
+    let start = Instant::now();
+    submit_reads(async_io.as_mut(), num_reads, read_size as u64, &[iovec]);
+    let elapsed = start.elapsed().as_secs_f64();
+
+    drain_completions(async_io.as_mut(), num_reads);
+
+    elapsed
+}

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -221,3 +221,29 @@ pub fn micro_bench_qcow_backing_read(control: &PerformanceTestControl) -> f64 {
 
     elapsed
 }
+
+/// Write num_ops clusters into a QCOW2 overlay backed by a raw file.
+///
+/// Each write triggers copy-on-write: the overlay must allocate a new
+/// cluster, update L2 and refcount tables, then write the data.  This
+/// measures the COW allocation overhead compared to writing into an
+/// empty image (no backing read needed since we overwrite the full
+/// cluster).
+///
+/// Returns the total write wall clock time in seconds.
+pub fn micro_bench_qcow_cow_write(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_backing, _overlay, disk) = util::qcow_overlay_tempfile(num_ops);
+    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+
+    let buf = vec![0xBBu8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = write_iovec(&buf);
+
+    let start = Instant::now();
+    submit_writes(async_io.as_mut(), num_ops, QCOW_CLUSTER_SIZE, &[iovec]);
+    let elapsed = start.elapsed().as_secs_f64();
+
+    drain_completions(async_io.as_mut(), num_ops);
+
+    elapsed
+}

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -527,3 +527,25 @@ pub fn micro_bench_qcow_async_write(control: &PerformanceTestControl) -> f64 {
     drain_async_completions(async_io.as_mut(), num_ops);
     start.elapsed().as_secs_f64()
 }
+
+/// Read one cluster from each of num_ops distinct L2 tables in a sparse
+/// QCOW2 image through the QcowAsync io_uring path.
+///
+/// Returns the total read wall clock time in seconds.
+pub fn micro_bench_qcow_async_l2_cache_miss(control: &PerformanceTestControl) -> f64 {
+    let num_ops = control.num_ops.expect("num_ops required") as usize;
+    let (_tmp, disk) = util::sparse_qcow_async_tempfile(num_ops);
+    let mut async_io = disk
+        .new_async_io(num_ops as u32)
+        .expect("new_async_io failed");
+
+    let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
+    let iovec = read_iovec(&mut buf);
+
+    let stride = L2_ENTRIES_PER_TABLE as u64 * QCOW_CLUSTER_SIZE;
+    let start = Instant::now();
+    submit_reads(async_io.as_mut(), num_ops, stride, &[iovec]);
+
+    drain_async_completions(async_io.as_mut(), num_ops);
+    start.elapsed().as_secs_f64()
+}

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -73,6 +73,15 @@ pub fn drain_completions(async_io: &mut dyn AsyncIo, count: usize) {
     }
 }
 
+/// Submit `count` sequential read_vectored calls at `stride`-byte intervals.
+pub fn submit_reads(async_io: &mut dyn AsyncIo, count: usize, stride: u64, iovec: &[libc::iovec]) {
+    for i in 0..count {
+        async_io
+            .read_vectored((i as u64 * stride) as libc::off_t, iovec, i as u64)
+            .expect("read_vectored failed");
+    }
+}
+
 /// Spin and wait until the given eventfd becomes readable.
 pub fn wait_for_eventfd(notifier: &EventFd) {
     loop {

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -98,6 +98,15 @@ pub fn submit_reads(async_io: &mut dyn AsyncIo, count: usize, stride: u64, iovec
     }
 }
 
+/// Submit `count` sequential write_vectored calls at `stride`-byte intervals.
+pub fn submit_writes(async_io: &mut dyn AsyncIo, count: usize, stride: u64, iovec: &[libc::iovec]) {
+    for i in 0..count {
+        async_io
+            .write_vectored((i as u64 * stride) as libc::off_t, iovec, i as u64)
+            .expect("write_vectored failed");
+    }
+}
+
 /// Create an empty QCOW2 image sized for `num_clusters` clusters.
 /// No data clusters are allocated.
 fn create_empty_qcow_tempfile(num_clusters: usize) -> TempFile {

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -158,6 +158,14 @@ pub fn empty_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDiskSync) {
     (tmp, disk)
 }
 
+/// Empty QCOW2 opened via QcowDiskAsync.
+pub fn empty_qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDiskAsync) {
+    let tmp = create_empty_qcow_tempfile(num_clusters);
+    let disk = QcowDiskAsync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
+        .expect("failed to open qcow2 via QcowDiskAsync");
+    (tmp, disk)
+}
+
 /// Create a QCOW2 overlay backed by a raw file with `num_clusters`
 /// pre-populated clusters.  Returns (backing_tempfile, overlay_tempfile).
 fn create_overlay_tempfiles(num_clusters: usize) -> (TempFile, TempFile) {

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -98,6 +98,24 @@ pub fn submit_reads(async_io: &mut dyn AsyncIo, count: usize, stride: u64, iovec
     }
 }
 
+/// Create an empty QCOW2 image sized for `num_clusters` clusters.
+/// No data clusters are allocated.
+fn create_empty_qcow_tempfile(num_clusters: usize) -> TempFile {
+    let tmp = TempFile::new().expect("failed to create tempfile");
+    let virtual_size = QCOW_CLUSTER_SIZE * num_clusters as u64;
+    let raw = RawFile::new(tmp.as_file().try_clone().unwrap(), false);
+    QcowFile::new(raw, 3, virtual_size, true).expect("failed to create qcow2 file");
+    tmp
+}
+
+/// Empty QCOW2 opened via QcowDiskSync.
+pub fn empty_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDiskSync) {
+    let tmp = create_empty_qcow_tempfile(num_clusters);
+    let disk = QcowDiskSync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
+        .expect("failed to open qcow2 via QcowDiskSync");
+    (tmp, disk)
+}
+
 /// Spin and wait until the given eventfd becomes readable.
 pub fn wait_for_eventfd(notifier: &EventFd) {
     loop {

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -237,6 +237,35 @@ pub fn compressed_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDiskSync)
     (tmp, disk)
 }
 
+/// Number of data clusters covered by a single L2 table (64 KiB cluster,
+/// 8-byte entries -> 8192 entries per L2 table).
+pub const L2_ENTRIES_PER_TABLE: usize = QCOW_CLUSTER_SIZE as usize / 8;
+
+/// Create a sparse QCOW2 image with one allocated cluster per L2 table,
+/// spanning `num_l2_tables` L2 tables.
+fn create_sparse_qcow_tempfile(num_l2_tables: usize) -> TempFile {
+    let virtual_size = QCOW_CLUSTER_SIZE * (num_l2_tables as u64 * L2_ENTRIES_PER_TABLE as u64);
+    let tmp = TempFile::new().expect("failed to create tempfile");
+    let raw = RawFile::new(tmp.as_file().try_clone().unwrap(), false);
+    let mut qcow = QcowFile::new(raw, 3, virtual_size, true).expect("failed to create qcow2 file");
+    let buf = vec![0xA5u8; QCOW_CLUSTER_SIZE as usize];
+    for i in 0..num_l2_tables {
+        let offset = i as u64 * L2_ENTRIES_PER_TABLE as u64 * QCOW_CLUSTER_SIZE;
+        qcow.seek(SeekFrom::Start(offset)).expect("seek failed");
+        qcow.write_all(&buf).expect("write failed");
+    }
+    qcow.flush().expect("flush failed");
+    tmp
+}
+
+/// Sparse QCOW2 opened via QcowDiskSync.
+pub fn sparse_qcow_tempfile(num_l2_tables: usize) -> (TempFile, QcowDiskSync) {
+    let tmp = create_sparse_qcow_tempfile(num_l2_tables);
+    let disk = QcowDiskSync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
+        .expect("failed to open qcow2 via QcowDiskSync");
+    (tmp, disk)
+}
+
 /// Spin and wait until the given eventfd becomes readable.
 pub fn wait_for_eventfd(notifier: &EventFd) {
     loop {

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -128,6 +128,18 @@ pub fn submit_writes(async_io: &mut dyn AsyncIo, count: usize, stride: u64, iove
     }
 }
 
+/// Drain `count` completions from an asynchronous I/O backend that delivers
+/// results via eventfd notification (e.g. io_uring).
+pub fn drain_async_completions(async_io: &mut dyn AsyncIo, count: usize) {
+    let mut drained = 0usize;
+    while drained < count {
+        wait_for_eventfd(async_io.notifier());
+        while async_io.next_completed_request().is_some() {
+            drained += 1;
+        }
+    }
+}
+
 /// Create an empty QCOW2 image sized for `num_clusters` clusters.
 /// No data clusters are allocated.
 fn create_empty_qcow_tempfile(num_clusters: usize) -> TempFile {

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -196,6 +196,14 @@ pub fn qcow_overlay_tempfile(num_clusters: usize) -> (TempFile, TempFile, QcowDi
     (backing, overlay, disk)
 }
 
+/// QCOW2 overlay with raw backing opened via QcowDiskAsync.
+pub fn qcow_async_overlay_tempfile(num_clusters: usize) -> (TempFile, TempFile, QcowDiskAsync) {
+    let (backing, overlay) = create_overlay_tempfiles(num_clusters);
+    let disk = QcowDiskAsync::new(overlay.as_file().try_clone().unwrap(), false, true, true)
+        .expect("failed to open overlay qcow2 via QcowDiskAsync");
+    (backing, overlay, disk)
+}
+
 /// Create a zlib compressed QCOW2 image with `num_clusters` clusters
 /// via `qemu-img convert -c`.
 fn create_compressed_qcow_tempfile(num_clusters: usize) -> TempFile {

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -308,6 +308,14 @@ pub fn sparse_qcow_tempfile(num_l2_tables: usize) -> (TempFile, QcowDiskSync) {
     (tmp, disk)
 }
 
+/// Sparse QCOW2 opened via QcowDiskAsync.
+pub fn sparse_qcow_async_tempfile(num_l2_tables: usize) -> (TempFile, QcowDiskAsync) {
+    let tmp = create_sparse_qcow_tempfile(num_l2_tables);
+    let disk = QcowDiskAsync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
+        .expect("failed to open qcow2 via QcowDiskAsync");
+    (tmp, disk)
+}
+
 /// Spin and wait until the given eventfd becomes readable.
 pub fn wait_for_eventfd(notifier: &EventFd) {
     loop {

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -73,6 +73,22 @@ pub fn drain_completions(async_io: &mut dyn AsyncIo, count: usize) {
     }
 }
 
+/// Build an iovec suitable for a read into `buf`.
+pub fn read_iovec(buf: &mut [u8]) -> libc::iovec {
+    libc::iovec {
+        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    }
+}
+
+/// Build an iovec suitable for a write from `buf`.
+pub fn write_iovec(buf: &[u8]) -> libc::iovec {
+    libc::iovec {
+        iov_base: buf.as_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    }
+}
+
 /// Submit `count` sequential read_vectored calls at `stride`-byte intervals.
 pub fn submit_reads(async_io: &mut dyn AsyncIo, count: usize, stride: u64, iovec: &[libc::iovec]) {
     for i in 0..count {

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -5,11 +5,12 @@
 //! Shared benchmark helpers.
 
 use std::io::{ErrorKind, Seek, SeekFrom, Write};
+use std::os::unix::fs::FileExt;
 use std::thread;
 use std::time::Duration;
 
 use block::async_io::AsyncIo;
-use block::qcow::{QcowFile, RawFile};
+use block::qcow::{BackingFileConfig, ImageType, QcowFile, RawFile};
 use block::qcow_async::QcowDiskAsync;
 use block::qcow_sync::QcowDiskSync;
 use vmm_sys_util::eventfd::EventFd;
@@ -141,6 +142,44 @@ pub fn empty_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDiskSync) {
     let disk = QcowDiskSync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
         .expect("failed to open qcow2 via QcowDiskSync");
     (tmp, disk)
+}
+
+/// Create a QCOW2 overlay backed by a raw file with `num_clusters`
+/// pre-populated clusters.  Returns (backing_tempfile, overlay_tempfile).
+fn create_overlay_tempfiles(num_clusters: usize) -> (TempFile, TempFile) {
+    let virtual_size = QCOW_CLUSTER_SIZE * num_clusters as u64;
+
+    let backing = TempFile::new().expect("failed to create backing tempfile");
+    {
+        let f = backing.as_file();
+        f.set_len(virtual_size).expect("set_len failed");
+        let buf = vec![0xA5u8; QCOW_CLUSTER_SIZE as usize];
+        for i in 0..num_clusters {
+            f.write_at(&buf, i as u64 * QCOW_CLUSTER_SIZE)
+                .expect("write_at failed");
+        }
+    }
+
+    let overlay = TempFile::new().expect("failed to create overlay tempfile");
+    {
+        let raw = RawFile::new(overlay.as_file().try_clone().unwrap(), false);
+        let backing_config = BackingFileConfig {
+            path: backing.as_path().to_str().unwrap().to_string(),
+            format: Some(ImageType::Raw),
+        };
+        QcowFile::new_from_backing(raw, 3, virtual_size, &backing_config, true)
+            .expect("failed to create overlay qcow2");
+    }
+
+    (backing, overlay)
+}
+
+/// QCOW2 overlay with raw backing opened via QcowDiskSync.
+pub fn qcow_overlay_tempfile(num_clusters: usize) -> (TempFile, TempFile, QcowDiskSync) {
+    let (backing, overlay) = create_overlay_tempfiles(num_clusters);
+    let disk = QcowDiskSync::new(overlay.as_file().try_clone().unwrap(), false, true, true)
+        .expect("failed to open overlay qcow2 via QcowDiskSync");
+    (backing, overlay, disk)
 }
 
 /// Spin and wait until the given eventfd becomes readable.

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -4,8 +4,10 @@
 
 //! Shared benchmark helpers.
 
+use std::fs::File;
 use std::io::{ErrorKind, Seek, SeekFrom, Write};
 use std::os::unix::fs::FileExt;
+use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
@@ -180,6 +182,59 @@ pub fn qcow_overlay_tempfile(num_clusters: usize) -> (TempFile, TempFile, QcowDi
     let disk = QcowDiskSync::new(overlay.as_file().try_clone().unwrap(), false, true, true)
         .expect("failed to open overlay qcow2 via QcowDiskSync");
     (backing, overlay, disk)
+}
+
+/// Create a zlib compressed QCOW2 image with `num_clusters` clusters
+/// via `qemu-img convert -c`.
+fn create_compressed_qcow_tempfile(num_clusters: usize) -> TempFile {
+    let virtual_size = QCOW_CLUSTER_SIZE * num_clusters as u64;
+
+    let raw_tmp = TempFile::new().expect("failed to create raw tempfile");
+    {
+        let f = raw_tmp.as_file();
+        f.set_len(virtual_size).expect("set_len failed");
+        let buf = vec![0xA5u8; QCOW_CLUSTER_SIZE as usize];
+        for i in 0..num_clusters {
+            f.write_at(&buf, i as u64 * QCOW_CLUSTER_SIZE)
+                .expect("write_at failed");
+        }
+    }
+
+    let qcow_tmp = TempFile::new().expect("failed to create qcow2 tempfile");
+    let qcow_path = qcow_tmp.as_path().to_str().unwrap().to_string();
+    let raw_path = raw_tmp.as_path().to_str().unwrap().to_string();
+    let status = Command::new("qemu-img")
+        .args([
+            "convert",
+            "-f",
+            "raw",
+            "-O",
+            "qcow2",
+            "-c",
+            "-o",
+            "compression_type=zlib",
+            &raw_path,
+            &qcow_path,
+        ])
+        .status()
+        .expect("failed to run qemu-img");
+    assert!(status.success(), "qemu-img convert failed");
+
+    qcow_tmp
+}
+
+/// Compressed QCOW2 opened via QcowDiskSync.
+pub fn compressed_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDiskSync) {
+    let tmp = create_compressed_qcow_tempfile(num_clusters);
+    let path = tmp.as_path().to_str().unwrap().to_string();
+    let disk = QcowDiskSync::new(
+        File::open(&path).expect("failed to open compressed qcow2"),
+        false,
+        false,
+        true,
+    )
+    .expect("failed to open compressed qcow2 via QcowDiskSync");
+    (tmp, disk)
 }
 
 /// Spin and wait until the given eventfd becomes readable.

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -4,14 +4,18 @@
 
 //! Shared benchmark helpers.
 
-use std::io::ErrorKind;
+use std::io::{ErrorKind, Seek, SeekFrom, Write};
 use std::thread;
 use std::time::Duration;
 
+use block::qcow::{QcowFile, RawFile};
+use block::qcow_async::QcowDiskAsync;
+use block::qcow_sync::QcowDiskSync;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::tempfile::TempFile;
 
 pub const BLOCK_SIZE: u64 = 4096;
+pub const QCOW_CLUSTER_SIZE: u64 = 65536;
 
 /// Create a temporary file pre sized to hold `num_blocks` blocks.
 pub fn sized_tempfile(num_blocks: usize) -> TempFile {
@@ -20,6 +24,45 @@ pub fn sized_tempfile(num_blocks: usize) -> TempFile {
         .set_len(BLOCK_SIZE * num_blocks as u64)
         .expect("failed to set file length");
     tmp
+}
+
+/// Create a QCOW2 image with `num_clusters` allocated clusters and return
+/// the tempfile handle.
+///
+/// Each cluster is default QCOW2 cluster size of 64 KiB. The image is
+/// created via `QcowFile::new` then populated with writes so that the
+/// clusters are actually allocated in the L2 / refcount tables.
+fn create_qcow_tempfile(num_clusters: usize) -> TempFile {
+    let tmp = TempFile::new().expect("failed to create tempfile");
+    let virtual_size = QCOW_CLUSTER_SIZE * num_clusters as u64;
+    let raw = RawFile::new(tmp.as_file().try_clone().unwrap(), false);
+    let mut qcow = QcowFile::new(raw, 3, virtual_size, true).expect("failed to create QCOW2 file");
+    let buf = vec![0xA5u8; QCOW_CLUSTER_SIZE as usize];
+    for i in 0..num_clusters {
+        qcow.seek(SeekFrom::Start(i as u64 * QCOW_CLUSTER_SIZE))
+            .expect("seek failed");
+        qcow.write_all(&buf).expect("write failed");
+    }
+    qcow.flush().expect("flush failed");
+    tmp
+}
+
+/// Create a QCOW2 image with `num_clusters` allocated clusters opened
+/// via `QcowDiskSync` (blocking I/O backend).
+pub fn qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDiskSync) {
+    let tmp = create_qcow_tempfile(num_clusters);
+    let disk = QcowDiskSync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
+        .expect("failed to open QCOW2 via QcowDiskSync");
+    (tmp, disk)
+}
+
+/// Create a QCOW2 image with `num_clusters` allocated clusters opened
+/// via `QcowDiskAsync` (io_uring backend).
+pub fn qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDiskAsync) {
+    let tmp = create_qcow_tempfile(num_clusters);
+    let disk = QcowDiskAsync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
+        .expect("failed to open QCOW2 via QcowDiskAsync");
+    (tmp, disk)
 }
 
 /// Spin and wait until the given eventfd becomes readable.

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -89,6 +89,24 @@ pub fn write_iovec(buf: &[u8]) -> libc::iovec {
     }
 }
 
+/// Build a deterministic pseudo-random permutation of `[0, n)`.
+///
+/// Uses a Fisher-Yates shuffle seeded by `DefaultHasher` so the
+/// permutation is identical across runs.
+pub fn deterministic_permutation(n: usize) -> Vec<usize> {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut indices: Vec<usize> = (0..n).collect();
+    for i in (1..n).rev() {
+        let mut h = DefaultHasher::new();
+        i.hash(&mut h);
+        let j = h.finish() as usize % (i + 1);
+        indices.swap(i, j);
+    }
+    indices
+}
+
 /// Submit `count` sequential read_vectored calls at `stride`-byte intervals.
 pub fn submit_reads(async_io: &mut dyn AsyncIo, count: usize, stride: u64, iovec: &[libc::iovec]) {
     for i in 0..count {

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -8,6 +8,7 @@ use std::io::{ErrorKind, Seek, SeekFrom, Write};
 use std::thread;
 use std::time::Duration;
 
+use block::async_io::AsyncIo;
 use block::qcow::{QcowFile, RawFile};
 use block::qcow_async::QcowDiskAsync;
 use block::qcow_sync::QcowDiskSync;
@@ -63,6 +64,13 @@ pub fn qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDiskAsync) {
     let disk = QcowDiskAsync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
         .expect("failed to open QCOW2 via QcowDiskAsync");
     (tmp, disk)
+}
+
+/// Drain `count` completions from a synchronous async_io backend.
+pub fn drain_completions(async_io: &mut dyn AsyncIo, count: usize) {
+    for _ in 0..count {
+        async_io.next_completed_request();
+    }
 }
 
 /// Spin and wait until the given eventfd becomes readable.

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -257,6 +257,20 @@ pub fn compressed_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDiskSync)
     (tmp, disk)
 }
 
+/// Compressed QCOW2 opened via QcowDiskAsync.
+pub fn compressed_qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDiskAsync) {
+    let tmp = create_compressed_qcow_tempfile(num_clusters);
+    let path = tmp.as_path().to_str().unwrap().to_string();
+    let disk = QcowDiskAsync::new(
+        File::open(&path).expect("failed to open compressed qcow2"),
+        false,
+        false,
+        true,
+    )
+    .expect("failed to open compressed qcow2 via QcowDiskAsync");
+    (tmp, disk)
+}
+
 /// Number of data clusters covered by a single L2 table (64 KiB cluster,
 /// 8-byte entries -> 8192 entries per L2 table).
 pub const L2_ENTRIES_PER_TABLE: usize = QCOW_CLUSTER_SIZE as usize / 8;


### PR DESCRIPTION
Add 20 micro benchmarks that exercise QCOW2 block layer hot paths without booting a VM. Each benchmark creates a throwaway QCOW2 image via tempfile, runs the operation under test through the AsyncIo interface, and reports wall clock time.

The benchmarks cover both the synchronous (QcowDiskSync/pread64) and asynchronous (QcowDiskAsync/io_uring) backends across a range of cluster mapping scenarios:

**QcowDiskSync**
- basic allocated cluster read, write, fsync
- random access with deterministic permutation
- discard via fallocate punch hole
- read through a backing chain
- copy on write into overlay
- zlib compressed cluster read
- multi cluster spanning reads
- cold L2 table cache (one entry per table)

**QcowDiskAsync / io_uring**
- single cluster read and write
- random access, multi cluster, backing chain, compressed reads
- cold L2 cache
- batched read and write submission

Shared helpers are implemented in `util.rs` to avoid the duplication in benchmark bodies.

These benchmarks are intended to support upcoming QCOW2 refactoring and optimization work by providing a fast feedback loop without the overhead of full VM integration tests.

Run with:

`./scripts/dev_cli.sh tests --metrics -- --test-filter micro_block_qcow`