### PR TITLE
net_util: increase tap send buffer to 4MB for high-throughput workloads

### DIFF
--- a/net_util/src/open_tap.rs
+++ b/net_util/src/open_tap.rs
@@ -33,6 +33,8 @@ pub enum Error {
     TapSetVnetHdrSize(#[source] TapError),
     #[error("Setting MTU failed")]
     TapSetMtu(#[source] TapError),
+    #[error("Setting send buffer size failed")]
+    TapSetSndbuf(#[source] TapError),
     #[error("Enabling tap interface failed")]
     TapEnable(#[source] TapError),
 }
@@ -102,6 +104,9 @@ fn open_tap_rx_q_0(
     tap.set_vnet_hdr_size(vnet_hdr_len() as i32)
         .map_err(Error::TapSetVnetHdrSize)?;
 
+    tap.set_sndbuf(Tap::SNDBUF_SIZE)
+        .map_err(Error::TapSetSndbuf)?;
+
     Ok(tap)
 }
 
@@ -140,6 +145,9 @@ pub fn open_tap(
 
             tap.set_vnet_hdr_size(vnet_hdr_len() as i32)
                 .map_err(Error::TapSetVnetHdrSize)?;
+
+            tap.set_sndbuf(Tap::SNDBUF_SIZE)
+                .map_err(Error::TapSetSndbuf)?;
         }
         taps.push(tap);
     }

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -13,6 +13,7 @@ use std::os::raw::*;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 use libc::{__c_anonymous_ifr_ifru, ifreq};
+use log::warn;
 use thiserror::Error;
 use vmm_sys_util::ioctl::{ioctl_with_mut_ref, ioctl_with_ref, ioctl_with_val};
 
@@ -290,6 +291,9 @@ impl Tap {
         let tap = Tap { tap_file, if_name };
         let vnet_hdr_size = vnet_hdr_len() as i32;
         tap.set_vnet_hdr_size(vnet_hdr_size)?;
+        if let Err(e) = tap.set_sndbuf(Self::SNDBUF_SIZE) {
+            warn!("Failed to set tap send buffer size: {e}");
+        }
 
         Ok(tap)
     }
@@ -487,6 +491,16 @@ impl Tap {
     pub fn set_vnet_hdr_size(&self, size: c_int) -> Result<()> {
         // SAFETY: ioctl is safe. Called with a valid tap fd, and we check the return.
         unsafe { Self::ioctl_with_ref(&self.tap_file, libc::TUNSETVNETHDRSZ as c_ulong, &size) }
+    }
+
+    /// Tap send buffer size (4MB). The kernel default is ~212KB which limits
+    /// throughput on high-bandwidth workloads.
+    pub const SNDBUF_SIZE: c_int = 4 * 1024 * 1024;
+
+    /// Set the tap send buffer size.
+    pub fn set_sndbuf(&self, size: c_int) -> Result<()> {
+        // SAFETY: ioctl is safe. Called with a valid tap fd, and we check the return.
+        unsafe { Self::ioctl_with_ref(&self.tap_file, libc::TUNSETSNDBUF as c_ulong, &size) }
     }
 
     fn get_ifreq(&self) -> libc::ifreq {


### PR DESCRIPTION
## Summary

Increase the tap send buffer from the kernel default (~212KB) to 4MB via
`TUNSETSNDBUF`. The default is too small for 10 Gbps+ workloads and causes
packet drops under burst traffic.

## Motivation

In production testing at Cloudflare with 4-vCPU VMs on 25 Gbps NICs, we
observed the tap send buffer saturating under burst TX traffic. At 10 Gbps
with 64KB frames (TSO), the 212KB default buffer holds ~3 frames before
dropping. Increasing to 4MB gives ~62 frames of headroom, eliminating
drops during transient bursts without significant memory overhead (4MB per
tap fd, so 16MB for a 4-queue-pair setup).

This is a common tuning applied by high-throughput VMMs. Firecracker
applies a similar tuning to its tap devices.

## Changes

- `net_util/src/tap.rs`: Add `Tap::set_sndbuf()` method wrapping the
  `TUNSETSNDBUF` ioctl.
- `net_util/src/open_tap.rs`: Call `set_sndbuf(4MB)` on all tap fds
  during creation (both primary q0 and secondary multi-queue taps).

## Testing

Builds on existing tap creation path. The `TUNSETSNDBUF` ioctl is
supported on all Linux kernels with TUN/TAP (2.6.27+).

Signed-off-by: Keith Adler <kadler@cloudflare.com>