### PR TITLE
net_util: add io_uring-based TX submission for virtio-net tap devices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ resolver = "3"
 [workspace.dependencies]
 # rust-vmm crates
 acpi_tables = "0.2.0"
+io-uring = "0.7.11"
 iommufd-ioctls = "0.1.0"
 kvm-bindings = "0.14.0"
 kvm-ioctls = "0.24.0"

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 [dependencies]
 epoll = { workspace = true }
 getrandom = "0.4.2"
+io-uring = { workspace = true, optional = true }
 libc = { workspace = true }
 log = { workspace = true }
 rate_limiter = { path = "../rate_limiter" }
@@ -22,6 +23,9 @@ vm-memory = { workspace = true, features = [
 ] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { workspace = true }
+
+[features]
+io_uring = ["dep:io-uring"]
 
 [dev-dependencies]
 pnet = "0.35.0"

--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -7,6 +7,8 @@
 
 mod ctrl_queue;
 mod mac;
+#[cfg(feature = "io_uring")]
+pub mod net_io_uring;
 mod open_tap;
 mod queue_pair;
 mod tap;

--- a/net_util/src/net_io_uring.rs
+++ b/net_util/src/net_io_uring.rs
@@ -1,0 +1,132 @@
+// Copyright 2026 Cloudflare, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// io_uring-based TX path for virtio-net tap devices. Batches multiple
+// writev operations into a single io_uring submission, reducing per-packet
+// syscall overhead compared to the synchronous writev() path.
+
+use std::os::unix::io::AsRawFd;
+
+use io_uring::{IoUring, opcode, types};
+use log::warn;
+use vmm_sys_util::eventfd::EventFd;
+
+use crate::Tap;
+
+/// io_uring-accelerated TX submission. Collects packets from the virtio TX
+/// queue and submits them as batched Writev SQEs to the tap fd.
+pub struct NetTxIoUring {
+    ring: IoUring,
+    tap_fd: i32,
+    /// EventFd signalled when CQEs are ready.
+    completion_eventfd: EventFd,
+    /// Number of in-flight SQEs awaiting completion.
+    inflight: u32,
+}
+
+impl NetTxIoUring {
+    /// Create a new io_uring TX handler for the given tap device.
+    /// `ring_depth` controls the SQ/CQ size (typically the virtio queue size).
+    pub fn new(tap: &Tap, ring_depth: u32) -> std::io::Result<Self> {
+        let ring = IoUring::new(ring_depth)?;
+        let completion_eventfd = EventFd::new(libc::EFD_NONBLOCK)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+        ring.submitter()
+            .register_eventfd(completion_eventfd.as_raw_fd())?;
+
+        Ok(NetTxIoUring {
+            ring,
+            tap_fd: tap.as_raw_fd(),
+            completion_eventfd,
+            inflight: 0,
+        })
+    }
+
+    /// Returns the eventfd that fires when CQEs are ready. Register this
+    /// in the epoll loop alongside the existing queue/tap events.
+    pub fn completion_notifier(&self) -> &EventFd {
+        &self.completion_eventfd
+    }
+
+    /// Submit a batch of TX packets via io_uring Writev. Each entry in
+    /// `iovec_batches` is one packet (a slice of iovecs gathered from the
+    /// virtio descriptor chain). Returns the number of SQEs submitted.
+    ///
+    /// # Safety
+    /// The iovec pointers must remain valid until the corresponding CQEs
+    /// are harvested. The caller must ensure guest memory is pinned.
+    pub unsafe fn submit_tx_batch(
+        &mut self,
+        iovec_batches: &[(u64, *const libc::iovec, u32)], // (user_data, iovecs_ptr, iovecs_len)
+    ) -> std::io::Result<u32> {
+        let (submitter, mut sq, _) = self.ring.split();
+        let mut pushed = 0u32;
+
+        for &(user_data, iovecs_ptr, iovecs_len) in iovec_batches {
+            let entry = opcode::Writev::new(types::Fd(self.tap_fd), iovecs_ptr, iovecs_len)
+                .build()
+                .user_data(user_data);
+
+            if unsafe { sq.push(&entry) }.is_err() {
+                // SQ is full, submit what we have and retry.
+                sq.sync();
+                submitter.submit()?;
+                self.inflight += pushed;
+                pushed = 0;
+
+                if unsafe { sq.push(&entry) }.is_err() {
+                    warn!("io_uring SQ still full after submit, dropping packet");
+                    break;
+                }
+            }
+            pushed += 1;
+        }
+
+        if pushed > 0 {
+            sq.sync();
+            submitter.submit()?;
+            self.inflight += pushed;
+        }
+
+        Ok(pushed)
+    }
+
+    /// Harvest completed TX operations. Returns an iterator of
+    /// (user_data, result) pairs. Positive result = bytes written,
+    /// negative result = negated errno.
+    pub fn harvest_completions(&mut self) -> Vec<(u64, i32)> {
+        let mut results = Vec::new();
+        let cq = self.ring.completion();
+        for entry in cq {
+            results.push((entry.user_data(), entry.result()));
+            self.inflight = self.inflight.saturating_sub(1);
+        }
+        // Drain the eventfd to avoid spurious epoll wakeups.
+        let _ = self.completion_eventfd.read();
+        results
+    }
+
+    /// Number of SQEs currently in flight.
+    pub fn inflight_count(&self) -> u32 {
+        self.inflight
+    }
+}
+
+/// Check if the kernel supports io_uring with the opcodes we need for
+/// networking (Writev). Returns false on kernels < 5.6 or when io_uring
+/// is disabled via seccomp.
+pub fn net_io_uring_is_supported() -> bool {
+    let ring = match IoUring::new(2) {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+
+    let mut probe = io_uring::Probe::new();
+    if ring.submitter().register_probe(&mut probe).is_err() {
+        return false;
+    }
+
+    probe.is_supported(opcode::Writev::CODE)
+}


### PR DESCRIPTION
## Summary

Add `NetTxIoUring`, an io_uring-accelerated TX path for tap devices that
batches multiple writev operations into a single `io_uring_enter()` call.

## Motivation

The current virtio-net TX path calls `libc::writev()` per packet - one
syscall per frame. At high packet rates (1M+ pps) and line rates
(10 Gbps+), the per-packet syscall overhead becomes the bottleneck.

Cloud Hypervisor already uses io_uring for block devices
(`block/src/raw_async.rs`) with the drain-then-batch-submit pattern.
This PR brings the same approach to networking.

With io_uring:
1. Drain the entire virtio TX queue
2. Push all packets as `Writev` SQEs
3. Submit in one `io_uring_enter()` call
4. Harvest CQEs via eventfd in the epoll loop

This reduces the number of syscalls from N (one per packet) to 1 (one
per batch), which is the same optimization that makes the block io_uring
path faster than synchronous I/O.

## Changes

- `net_util/src/net_io_uring.rs` (new): `NetTxIoUring` struct with:
  - `new()` - creates ring bound to tap fd with eventfd for CQ notification
  - `submit_tx_batch()` - pushes Writev SQEs and submits in one call
  - `harvest_completions()` - drains CQEs
  - `completion_notifier()` - eventfd for epoll integration
  - `net_io_uring_is_supported()` - runtime capability probe
- `net_util/src/lib.rs`: register module behind `io_uring` feature
- `net_util/Cargo.toml`: add `io-uring` optional dependency and feature

## Status

This PR provides the building blocks. Integration into the net device's
epoll handler (`virtio-devices/src/net.rs`) to use `NetTxIoUring` instead
of synchronous `writev()` will follow in a subsequent PR, gated behind
the same `io_uring` feature flag.

## Testing

Builds clean on Linux: `cargo build -p net_util --features io_uring`

Signed-off-by: Keith Adler <kadler@cloudflare.com>