### PR TITLE
vmm: support loading SMBIOS OEM strings from files

### DIFF
--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -833,6 +833,7 @@ impl PlatformConfig {
             .add("serial_number")
             .add("uuid")
             .add("oem_strings")
+            .add("oem_string_files")
             .add("iommufd")
             .add("vfio_p2p_dma");
         #[cfg(feature = "tdx")]
@@ -859,6 +860,10 @@ impl PlatformConfig {
         let uuid = parser.convert("uuid").map_err(Error::ParsePlatform)?;
         let oem_strings = parser
             .convert::<StringList>("oem_strings")
+            .map_err(Error::ParsePlatform)?
+            .map(|v| v.0);
+        let oem_string_files = parser
+            .convert::<StringList>("oem_string_files")
             .map_err(Error::ParsePlatform)?
             .map(|v| v.0);
         let iommufd = parser
@@ -890,6 +895,7 @@ impl PlatformConfig {
             serial_number,
             uuid,
             oem_strings,
+            oem_string_files,
             iommufd,
             vfio_p2p_dma,
             #[cfg(feature = "tdx")]
@@ -4822,6 +4828,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             serial_number: None,
             uuid: None,
             oem_strings: None,
+            oem_string_files: None,
             iommufd: false,
             vfio_p2p_dma: default_platformconfig_vfio_p2p_dma(),
             #[cfg(feature = "tdx")]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -333,6 +333,9 @@ pub enum Error {
     #[error("Cannot load the igvm into memory")]
     IgvmLoad(#[source] igvm_loader::Error),
 
+    #[error("Error reading OEM string file")]
+    PlatformOemStringFile(#[source] std::io::Error),
+
     #[error("Error injecting NMI")]
     ErrorNmi,
 
@@ -1672,13 +1675,24 @@ impl Vm {
             .as_ref()
             .and_then(|p| p.uuid.clone());
 
-        let oem_strings = self
-            .config
-            .lock()
-            .unwrap()
-            .platform
-            .as_ref()
-            .and_then(|p| p.oem_strings.clone());
+        let config_lock = self.config.lock().unwrap();
+        let platform = config_lock.platform.as_ref();
+        let mut oem_strings = platform.and_then(|p| p.oem_strings.clone());
+
+        // Resolve oem_string_files: read file contents and merge into oem_strings.
+        if let Some(files) = platform.and_then(|p| p.oem_string_files.as_ref()) {
+            let strings = oem_strings.get_or_insert_with(Vec::new);
+            for path in files {
+                let content = std::fs::read_to_string(path).map_err(|e| {
+                    Error::PlatformOemStringFile(std::io::Error::new(
+                        e.kind(),
+                        format!("{path}: {e}"),
+                    ))
+                })?;
+                strings.push(content.trim_end().to_string());
+            }
+        }
+        drop(config_lock);
 
         let oem_strings = oem_strings
             .as_deref()

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -131,6 +131,8 @@ pub struct PlatformConfig {
     pub uuid: Option<String>,
     #[serde(default)]
     pub oem_strings: Option<Vec<String>>,
+    #[serde(default)]
+    pub oem_string_files: Option<Vec<String>>,
     #[cfg(feature = "tdx")]
     #[serde(default)]
     pub tdx: bool,


### PR DESCRIPTION
## Summary

Add `oem_string_files` option to load SMBIOS OEM strings from files
instead of passing them on the command line. Prevents secrets from
appearing in process listings and log files.

Closes #6951

## Changes

- `vmm/src/vm_config.rs`: Add `oem_string_files: Option<Vec<String>>` to `PlatformConfig`.
- `vmm/src/config.rs`: Parse `oem_string_files`, read each file, trim trailing whitespace, append to `oem_strings` vec. Update test fixture.

## Usage

```
cloud-hypervisor --platform oem_string_files=[/path/to/secret]
```

Both `oem_strings` (inline) and `oem_string_files` (from files) can be used together. File contents are trimmed of trailing whitespace.

Tested: builds clean on Linux (cargo build --release).

Signed-off-by: Keith Adler <kadler@cloudflare.com>