### PR TITLE
performance-metrics: fix overly broad process cleanup

### DIFF
--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -1297,8 +1297,9 @@ fn run_test_with_timeout(
 }
 
 fn cleanup_stale_processes() {
-    for proc in &["cloud-hypervisor", "iperf3", "ethr"] {
-        let _ = Command::new("pkill").args(["-9", "-f", proc]).status();
+    // "cloud-hyperviso" - process name truncated to 15 chars by the kernel
+    for proc in &["cloud-hyperviso", "iperf3", "ethr"] {
+        let _ = Command::new("pkill").args(["-9", proc]).status();
     }
     thread::sleep(Duration::from_secs(2));
 }


### PR DESCRIPTION
Drop the -f flag from the process termination command in cleanup_stale_processes() so it matches by process name only, not the full command line. This prevents terminating unrelated processes whose arguments happen to contain target strings (e.g., the test runner invoked with --report-file /cloud-hypervisor/report.json).

Use the truncated name 'cloud-hyperviso' because Linux limits process names to 15 characters.