### PR TITLE
vmm: device_manager: reject duplicate socket in add_user_device

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -657,6 +657,10 @@ pub enum DeviceManagerError {
     #[error("Invalid identifier: {0}")]
     InvalidIdentifier(String),
 
+    /// vfio-user socket path already in use by another user device.
+    #[error("vfio-user socket path already in use: {0:?}")]
+    UserDeviceSocketInUse(std::path::PathBuf),
+
     /// Error activating virtio device
     #[error("Error activating virtio device")]
     VirtioActivate(#[source] ActivateError),
@@ -4706,6 +4710,17 @@ impl DeviceManager {
         device_cfg: &mut UserDeviceConfig,
     ) -> DeviceManagerResult<PciDeviceInfo> {
         self.validate_identifier(&device_cfg.pci_common.id)?;
+
+        // Reject duplicate socket up-front: libvfio-user servers accept a
+        // single client, so a second Client::new() on the same socket blocks
+        // indefinitely in the handshake recvmsg() and hangs the VMM thread.
+        if let Some(existing) = &self.config.lock().unwrap().user_devices
+            && existing.iter().any(|d| d.socket == device_cfg.socket)
+        {
+            return Err(DeviceManagerError::UserDeviceSocketInUse(
+                device_cfg.socket.clone(),
+            ));
+        }
 
         let (bdf, device_name) = self.add_vfio_user_device(device_cfg)?;
 


### PR DESCRIPTION
## Summary

Calling `vm.add-user-device` with a socket path already in use hangs the VMM
thread indefinitely inside `vfio_user::Client::new()`, freezing the entire
HTTP API while the VM keeps running on its vcpu threads. Reject the request
up-front when another user_device already has the same socket path.

## Repro

1. Start CH, `vm.create`, `vm.add-user-device` with socket `/path/cntrl`, `vm.boot`
2. Call `vm.add-user-device` with the **same** socket again
3. Second call hangs forever; any subsequent `vm.info` / `vmm.ping` also hangs
4. `/proc/<ch-pid>/task/<vmm-tid>/stack` shows `unix_stream_recvmsg` blocked

## Test plan

- [x] Second `vm.add-user-device` with same socket now returns HTTP 500 in ~6ms with `"vfio-user socket path already in use"`
- [x] `vm.info` remains responsive after the rejected second add
- [x] First add with fresh socket still works; Linux guest boots normally