### PR TITLE
block: qcow: Fix O_DIRECT EINVAL in async io_uring read path

### DIFF
--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -6,7 +6,7 @@
 
 //! QCOW2 async disk backend.
 
-use std::cmp::min;
+use std::cmp::{max, min};
 use std::collections::VecDeque;
 use std::fs::File;
 use std::io::Error;
@@ -30,7 +30,7 @@ use crate::qcow_common::{
     AlignedBuf, aligned_pread, aligned_pwrite, gather_from_iovecs_into, pread_exact, pwrite_all,
     scatter_to_iovecs, zero_fill_iovecs,
 };
-use crate::{BatchRequest, RequestType, disk_file};
+use crate::{BatchRequest, RequestType, SECTOR_SIZE, disk_file};
 
 /// Device level handle for a QCOW2 image.
 ///
@@ -175,6 +175,8 @@ pub struct QcowAsync {
     sparse: bool,
     /// O_DIRECT alignment requirement (0 = no alignment needed).
     alignment: usize,
+    /// I/O alignment for the AsyncIo trait (at least SECTOR_SIZE).
+    io_alignment: u64,
     io_uring: IoUring,
     eventfd: EventFd,
     completion_list: VecDeque<(u64, i32)>,
@@ -189,6 +191,7 @@ impl QcowAsync {
         ring_depth: u32,
     ) -> io::Result<Self> {
         let alignment = data_file.file().alignment();
+        let io_alignment = max(alignment as u64, SECTOR_SIZE);
         let io_uring = IoUring::new(ring_depth)?;
         let eventfd = EventFd::new(libc::EFD_NONBLOCK)?;
         io_uring.submitter().register_eventfd(eventfd.as_raw_fd())?;
@@ -199,6 +202,7 @@ impl QcowAsync {
             backing_file,
             sparse,
             alignment,
+            io_alignment,
             io_uring,
             eventfd,
             completion_list: VecDeque::new(),
@@ -367,6 +371,10 @@ impl AsyncIo for QcowAsync {
         true
     }
 
+    fn alignment(&self) -> u64 {
+        self.io_alignment
+    }
+
     fn submit_batch_requests(&mut self, batch_request: &[BatchRequest]) -> AsyncIoResult<()> {
         let (submitter, mut sq, _) = self.io_uring.split();
         let mut needs_submit = false;
@@ -464,7 +472,15 @@ impl QcowAsync {
             .map_clusters_for_read(address, total_len, has_backing)
             .map_err(AsyncIoError::ReadVectored)?;
 
-        if mappings.len() == 1
+        // The fast path returns a host offset so the caller can submit a
+        // single io_uring readv with the original iovecs.  This only works
+        // without O_DIRECT because it requires I/O
+        // size and file offset to be multiples of the device sector size.
+        // Guest requests can be smaller (e.g. 512 byte UEFI reads on a
+        // 4096 byte sector device), so O_DIRECT reads fall through to the
+        // alignment aware synchronous path instead.
+        if alignment == 0
+            && mappings.len() == 1
             && let ClusterReadMapping::Allocated {
                 offset: host_offset,
                 length,

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -1032,4 +1032,25 @@ mod unit_tests {
         let async_io = disk.new_async_io(1).unwrap();
         assert!(async_io.alignment() >= SECTOR_SIZE);
     }
+
+    #[test]
+    fn test_qcow_async_sub_sector_read_with_direct_io() {
+        let temp_file = TempFile::new().unwrap();
+        let disk = match try_create_direct_io_disk(&temp_file, 100 * 1024 * 1024) {
+            Some(d) => d,
+            None => {
+                eprintln!("skipping: O_DIRECT not supported on this filesystem");
+                return;
+            }
+        };
+
+        let pattern = vec![0xAB; 65536];
+        async_write(&disk, 0, &pattern);
+
+        let buf = async_read(&disk, 0, 512);
+        assert!(
+            buf.iter().all(|&b| b == 0xAB),
+            "sub-sector O_DIRECT read should return written data"
+        );
+    }
 }

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -630,7 +630,7 @@ mod unit_tests {
     use super::*;
     use crate::disk_file::AsyncDiskFile;
     use crate::qcow::{QcowFile, RawFile};
-    use crate::{BatchRequest, RequestType};
+    use crate::{BatchRequest, RequestType, SECTOR_SIZE};
 
     fn create_disk_with_data(
         file_size: u64,
@@ -994,5 +994,19 @@ mod unit_tests {
                 "cluster {i} mismatch"
             );
         }
+    }
+
+    #[test]
+    fn test_qcow_async_alignment_without_direct_io() {
+        let file_size = 100 * 1024 * 1024;
+        let temp_file = TempFile::new().unwrap();
+        {
+            let raw_file = RawFile::new(temp_file.as_file().try_clone().unwrap(), false);
+            QcowFile::new(raw_file, 3, file_size, true).unwrap();
+        }
+        let disk = QcowDiskAsync::new(temp_file.as_file().try_clone().unwrap(), false, false, true)
+            .unwrap();
+        let async_io = disk.new_async_io(1).unwrap();
+        assert_eq!(async_io.alignment(), SECTOR_SIZE);
     }
 }

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -1053,4 +1053,22 @@ mod unit_tests {
             "sub-sector O_DIRECT read should return written data"
         );
     }
+
+    #[test]
+    fn test_qcow_async_direct_io_write_read_roundtrip() {
+        let temp_file = TempFile::new().unwrap();
+        let disk = match try_create_direct_io_disk(&temp_file, 100 * 1024 * 1024) {
+            Some(d) => d,
+            None => {
+                eprintln!("skipping: O_DIRECT not supported on this filesystem");
+                return;
+            }
+        };
+
+        let pattern: Vec<u8> = (0..128 * 1024).map(|i| (i % 251) as u8).collect();
+        async_write(&disk, 0, &pattern);
+
+        let buf = async_read(&disk, 0, pattern.len());
+        assert_eq!(buf, pattern, "O_DIRECT roundtrip should match");
+    }
 }

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -1009,4 +1009,27 @@ mod unit_tests {
         let async_io = disk.new_async_io(1).unwrap();
         assert_eq!(async_io.alignment(), SECTOR_SIZE);
     }
+
+    /// Returns None if O_DIRECT is not supported (e.g. tmpfs).
+    fn try_create_direct_io_disk(temp_file: &TempFile, file_size: u64) -> Option<QcowDiskAsync> {
+        {
+            let raw_file = RawFile::new(temp_file.as_file().try_clone().unwrap(), false);
+            QcowFile::new(raw_file, 3, file_size, true).unwrap();
+        }
+        QcowDiskAsync::new(temp_file.as_file().try_clone().unwrap(), true, false, true).ok()
+    }
+
+    #[test]
+    fn test_qcow_async_alignment_with_direct_io() {
+        let temp_file = TempFile::new().unwrap();
+        let disk = match try_create_direct_io_disk(&temp_file, 100 * 1024 * 1024) {
+            Some(d) => d,
+            None => {
+                eprintln!("skipping: O_DIRECT not supported on this filesystem");
+                return;
+            }
+        };
+        let async_io = disk.new_async_io(1).unwrap();
+        assert!(async_io.alignment() >= SECTOR_SIZE);
+    }
 }

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -1309,6 +1309,96 @@ mod common_parallel {
                 .expect("Failed to read back data after discard stress");
         });
     }
+
+    #[test]
+    fn test_virtio_block_qcow2_uefi_direct_io() {
+        // Regression test for #8007.
+        // Place the QCOW2 OS image on a 4096 byte sector filesystem so
+        // O_DIRECT forces 4096 byte alignment on all I/O buffers.
+        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME_QCOW2.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+        let kernel_path = edk2_path();
+
+        let mut workloads_path = dirs::home_dir().unwrap();
+        workloads_path.push("workloads");
+        let img_dir = TempDir::new_in(workloads_path.as_path()).unwrap();
+        let fs_img_path = img_dir.as_path().join("fs_4ksec.img");
+
+        assert!(
+            exec_host_command_output(&format!("truncate -s 4G {}", fs_img_path.to_str().unwrap()))
+                .status
+                .success(),
+            "truncate failed"
+        );
+
+        let loop_dev_path = create_loop_device(fs_img_path.to_str().unwrap(), 4096, 5);
+
+        assert!(
+            exec_host_command_output(&format!("mkfs.ext4 -q {loop_dev_path}"))
+                .status
+                .success(),
+            "mkfs.ext4 failed"
+        );
+
+        let mnt_dir = img_dir.as_path().join("mnt");
+        fs::create_dir_all(&mnt_dir).unwrap();
+        assert!(
+            exec_host_command_output(&format!(
+                "mount {} {}",
+                &loop_dev_path,
+                mnt_dir.to_str().unwrap()
+            ))
+            .status
+            .success(),
+            "mount failed"
+        );
+
+        let src_qcow2 = guest.disk_config.disk(DiskType::OperatingSystem).unwrap();
+        let dest_qcow2 = mnt_dir.join("os.qcow2");
+        assert!(
+            exec_host_command_output(&format!(
+                "cp {} {}",
+                &src_qcow2,
+                dest_qcow2.to_str().unwrap()
+            ))
+            .status
+            .success(),
+            "cp failed"
+        );
+
+        let mut child = GuestCommand::new(&guest)
+            .default_cpus()
+            .default_memory()
+            .args(["--kernel", kernel_path.to_str().unwrap()])
+            .args([
+                "--disk",
+                &format!(
+                    "path={},direct=on,image_type=qcow2",
+                    dest_qcow2.to_str().unwrap()
+                ),
+                &format!(
+                    "path={}",
+                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
+                ),
+            ])
+            .default_net()
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = std::panic::catch_unwind(|| {
+            guest.wait_vm_boot().unwrap();
+        });
+
+        kill_child(&mut child);
+        let output = child.wait_with_output().unwrap();
+
+        let _ = exec_host_command_output(&format!("umount {}", mnt_dir.to_str().unwrap()));
+        let _ = exec_host_command_output(&format!("losetup -d {loop_dev_path}"));
+
+        handle_child_output(r, &output);
+    }
+
     #[test]
     fn test_virtio_block_qcow2_dirty_bit_unclean_shutdown() {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME_QCOW2.to_string());

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -3529,12 +3529,7 @@ mod common_parallel {
             "truncate failed"
         );
 
-        let loop_dev = exec_host_command_output(&format!(
-            "losetup --find --show --sector-size 4096 {}",
-            fs_img_path.to_str().unwrap()
-        ));
-        assert!(loop_dev.status.success(), "losetup failed");
-        let loop_dev_path = String::from_utf8_lossy(&loop_dev.stdout).trim().to_string();
+        let loop_dev_path = create_loop_device(fs_img_path.to_str().unwrap(), 4096, 5);
 
         assert!(
             exec_host_command_output(&format!("mkfs.ext4 -q {loop_dev_path}"))


### PR DESCRIPTION
Fixes `EINVAL` errors when booting UEFI guests from QCOW2 images with `direct=on` on devices where O_DIRECT requires alignment larger than 512 bytes.

`QcowAsync::resolve_read()` has a fast path that submits guest iovecs directly to io_uring. When O_DIRECT is active on a device with 4096 byte sectors, guest reads smaller than the sector size (for example, 512 byte UEFI firmware reads) are rejected by the kernel because the I/O length is not a multiple of the required alignment.

The `AsyncIo::alignment()` trait method was also not overridden, so `execute_async()` in the virtio block layer used the default 512, which is not enough to correctly bounce misaligned guest memory pointers on 4K sector devices.

### Fix:

- Override `AsyncIo::alignment()` on `QcowAsync` to report the actual device alignment (`max(file_alignment, SECTOR_SIZE)`), so that `execute_async()` correctly handles pointer alignment.
- Guard the io_uring fast path in `resolve_read()` with an alignment check. When O_DIRECT is active, reads are routed through `scatter_read_sync()` which uses `AlignedBuf` and `aligned_pread` to satisfy all three O_DIRECT constraints (buffer address, offset, and length alignment).

### Tests:

- Four unit tests covering alignment reporting and O_DIRECT read/write correctness
- One integration test that boots a UEFI Linux guest from a QCOW2 image with `direct=on`

Ref #8007.

See #8050 for a broader discussion on centralizing alignment handling across all block backends.