### PR TITLE
Encrypt live migration data using TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -180,7 +180,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -238,7 +238,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -269,6 +269,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "backtrace"
@@ -458,6 +480,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,8 +648,14 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -699,7 +736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -782,6 +819,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1717,7 +1760,7 @@ dependencies = [
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1879,6 +1922,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,7 +1957,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2088,6 +2180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,7 +2206,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2118,7 +2216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2252,7 +2350,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2266,6 +2364,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf8parse"
@@ -2502,6 +2606,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "itertools",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror",
@@ -2729,12 +2834,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2870,7 +3048,7 @@ dependencies = [
  "tracing",
  "uds_windows",
  "uuid",
- "windows-sys",
+ "windows-sys 0.61.2",
  "winnow 0.7.15",
  "zbus_macros",
  "zbus_names",
@@ -2922,6 +3100,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -240,7 +240,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -271,6 +271,28 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "backtrace"
@@ -482,6 +504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,8 +698,14 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -749,7 +786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -838,6 +875,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1784,7 +1827,7 @@ dependencies = [
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2018,6 +2061,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,7 +2096,44 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2250,6 +2344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,7 +2370,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2280,7 +2380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2420,7 +2520,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2440,6 +2540,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf8parse"
@@ -2677,6 +2783,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "itertools",
+ "log",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror",
@@ -2909,12 +3017,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -3047,7 +3228,7 @@ dependencies = [
  "tracing",
  "uds_windows",
  "uuid",
- "windows-sys",
+ "windows-sys 0.61.2",
  "winnow",
  "zbus_macros",
  "zbus_names",
@@ -3099,6 +3280,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,11 @@ flume = "0.12.0"
 itertools = "0.14.0"
 libc = "0.2.184"
 log = "0.4.29"
+rustls = { version = "0.23.38", default-features = false, features = [
+  "aws-lc-rs",
+  "std",
+  "tls12",
+] }
 signal-hook = "0.4.4"
 thiserror = "2.0.18"
 uuid = { version = "1.23.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ itertools = "0.14.0"
 jiff = { version = "0.2", default-features = false, features = ["std"] }
 libc = "0.2.186"
 log = "0.4.30"
+rustls = { version = "0.23.40", features = ["ring"] }
 sha2 = "0.11.0"
 signal-hook = "0.4.4"
 thiserror = "2.0.18"

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -71,6 +71,8 @@ enum Error {
     ReadingFile(#[source] std::io::Error),
     #[error("Invalid disk size")]
     InvalidDiskSize(#[source] ByteSizedParseError),
+    #[error("Error parsing receive migration configuration")]
+    ReceiveMigrationConfig(#[from] vmm::api::VmReceiveMigrationConfigError),
     #[error("Error parsing send migration configuration")]
     SendMigrationConfig(#[from] vmm::api::VmSendMigrationConfigError),
 }
@@ -534,7 +536,7 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                     .unwrap()
                     .get_one::<String>("receive_migration_config")
                     .unwrap(),
-            );
+            )?;
             simple_api_command(
                 socket,
                 "PUT",
@@ -753,7 +755,7 @@ fn dbus_api_do_command(matches: &ArgMatches, proxy: &DBusApi1ProxyBlocking<'_>) 
                     .unwrap()
                     .get_one::<String>("receive_migration_config")
                     .unwrap(),
-            );
+            )?;
             proxy.api_vm_receive_migration(&receive_migration_data)
         }
         Some("create") => {
@@ -941,12 +943,10 @@ fn coredump_config(destination_url: &str) -> String {
     serde_json::to_string(&coredump_config).unwrap()
 }
 
-fn receive_migration_data(url: &str) -> String {
-    let receive_migration_data = vmm::api::VmReceiveMigrationData {
-        receiver_url: url.to_owned(),
-    };
-
-    serde_json::to_string(&receive_migration_data).unwrap()
+fn receive_migration_data(config: &str) -> Result<String, Error> {
+    let receive_migration_data =
+        vmm::api::VmReceiveMigrationData::parse(config).map_err(Error::ReceiveMigrationConfig)?;
+    Ok(serde_json::to_string(&receive_migration_data).unwrap())
 }
 
 fn send_migration_data(config: &str) -> Result<String, Error> {
@@ -1069,7 +1069,7 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
             .arg(
                 Arg::new("receive_migration_config")
                     .index(1)
-                    .help("<receiver_url>"),
+                    .help(vmm::api::VmReceiveMigrationData::SYNTAX),
             ),
         Command::new("remove-device")
             .about("Remove VFIO and PCI device")

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -1136,7 +1136,7 @@ pub(crate) fn start_live_migration(
         .args([
             &format!("--api-socket={dest_api_socket}"),
             "receive-migration",
-            &format! {"unix:{migration_socket}"},
+            &format!("receiver_url=unix:{migration_socket}"),
         ])
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6740,7 +6740,7 @@ mod common_parallel {
             .args([
                 &format!("--api-socket={dest_api_socket}"),
                 "receive-migration",
-                &format!("tcp:0.0.0.0:{migration_port}"),
+                &format!("receiver_url=tcp:0.0.0.0:{migration_port}"),
             ])
             .stdin(Stdio::null())
             .stderr(Stdio::piped())
@@ -7077,7 +7077,7 @@ mod common_parallel {
                 .args([
                     &format!("--api-socket={dest_api_socket}"),
                     "receive-migration",
-                    &format!("tcp:0.0.0.0:{migration_port}"),
+                    &format!("receiver_url=tcp:0.0.0.0:{migration_port}"),
                 ])
                 .stdin(Stdio::null())
                 .stderr(Stdio::piped())

--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -191,6 +191,159 @@ the destination host and continue running there. The source VM instance
 will terminate normally. All ongoing processes and connections within
 the VM should remain intact after the migration.
 
+#### Encryption
+
+TCP migration can be protected with TLS by passing `tls_dir=<path>` to
+both `receive-migration` and `send-migration`.
+
+The destination host needs a directory containing:
+
+- `ca-cert.pem`: the CA certificate used to verify source certificates
+- `server-cert.pem`: the certificate presented by the destination
+- `server-key.pem`: the private key for `server-cert.pem`
+
+The source host needs a directory containing:
+
+- `ca-cert.pem`: the CA certificate used to verify the destination
+  certificate
+- `client-cert.pem`: the certificate presented by the source
+- `client-key.pem`: the private key for `client-cert.pem`
+
+Protect the private key files with file mode `0600` to reduce the risk
+of accidental disclosure:
+
+```console
+$ chmod 600 server-key.pem client-key.pem
+```
+
+Current TCP migration uses mutual TLS (mTLS) authentication. The source
+verifies the destination certificate against `ca-cert.pem` and presents
+`client-cert.pem` and `client-key.pem`. The destination presents
+`server-cert.pem` and `server-key.pem`, and only accepts client
+certificates that chain to `ca-cert.pem`.
+
+Example receiver command:
+
+```console
+dst $ ch-remote --api-socket=/tmp/api receive-migration receiver_url=tcp:0.0.0.0:{port},tls_dir=/path/to/dst-tls
+```
+
+Example sender command:
+
+```console
+src $ ch-remote --api-socket=/tmp/api send-migration destination_url=tcp:{dst}:{port},tls_dir=/path/to/src-tls
+```
+
+TLS encryption is only supported with `tcp:<host>:<port>` migration
+URLs, not with local UNIX-socket migration.
+
+The commands below describe how to create the encryption material necessary
+to perform a same-host TCP migration with TLS.
+
+##### Setup the Certificate Authority
+
+First, set up the CA with a private key and a self-signed certificate.
+
+```console
+$ certtool --generate-privkey \
+           --outfile ca-key.pem
+```
+
+To generate the certificate, provide at least your organization name in a template file, for example `ca.info`:
+
+```text
+cn = Name of your organization
+ca
+cert_signing_key
+```
+
+Then you can create the certificate:
+
+```console
+$ certtool --generate-self-signed \
+           --load-privkey ca-key.pem \
+           --template ca.info \
+           --outfile ca-cert.pem
+```
+
+##### Issuing host certificates
+
+Generate a private key and a certificate for each side. Cloud Hypervisor enforces mTLS, thus you also need a key for the migration sender.
+
+The certificates also require template data. You can use separate templates for sender and receiver, but this example uses a single template, `hosts.info`:
+
+```text
+organization = Name of your organization
+cn = localhost
+tls_www_server
+tls_www_client
+signing_key
+dns_name = localhost
+ip_address = 127.0.0.1
+```
+
+Then you can create the necessary files for the client (migration sender):
+
+```console
+$ certtool --generate-privkey \
+           --outfile client-key.pem
+
+$ certtool --generate-certificate \
+           --load-ca-certificate ca-cert.pem \
+           --load-ca-privkey ca-key.pem \
+           --load-privkey client-key.pem \
+           --template hosts.info \
+           --outfile client-cert.pem
+```
+
+And the necessary files for the server (migration receiver):
+
+```console
+$ certtool --generate-privkey \
+           --outfile server-key.pem
+
+$ certtool --generate-certificate \
+           --load-ca-certificate ca-cert.pem \
+           --load-ca-privkey ca-key.pem \
+           --load-privkey server-key.pem \
+           --template hosts.info \
+           --outfile server-cert.pem
+```
+
+For a same-host test, place these files in a single directory and use that directory as `tls_dir` for both commands.
+
+##### Performing the Migration
+
+On the receiver side, we prepare an empty VM:
+
+```console
+dst $ cloud-hypervisor --api-socket /tmp/api-rcv
+```
+
+In a different terminal, prepare to receive the migration:
+
+```console
+dst $ ch-remote --api-socket=/tmp/api-rcv receive-migration receiver_url=tcp:0.0.0.0:9000,tls_dir=/path/to/certificates
+```
+
+On the sender side, we start a VM:
+
+```console
+src $ cloud-hypervisor \
+        --serial tty --console off \
+        --cpus boot=2 --memory size=4G \
+        --kernel /var/images/linux \
+        --initramfs /var/images/initrd \
+        --cmdline "console=ttyS0" \
+        --api-socket /tmp/api-src
+```
+
+After a few seconds the VM should be up and you can interact with it. Then trigger the migration:
+
+```console
+src $ ch-remote --api-socket=/tmp/api-src send-migration destination_url=tcp:localhost:9000,tls_dir=/path/to/certificates
+```
+
 #### Migration Parameters
 
 Cloud Hypervisor supports additional parameters to control the

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -8,6 +8,8 @@ version = "0.1.0"
 [dependencies]
 anyhow = { workspace = true }
 itertools = { workspace = true }
+log = { workspace = true }
+rustls = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 [dependencies]
 anyhow = { workspace = true }
 itertools = { workspace = true }
+rustls = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -16,6 +16,7 @@ use crate::protocol::MemoryRangeTable;
 mod bitpos_iterator;
 mod context;
 pub mod protocol;
+pub mod tls;
 
 #[derive(Error, Debug)]
 pub enum UffdError {
@@ -92,6 +93,9 @@ pub enum MigratableError {
 
     #[error("Failed to release a disk lock")]
     UnlockError(#[source] anyhow::Error),
+
+    #[error("TLS error")]
+    Tls(#[from] tls::TlsError),
 }
 
 /// A Pausable component can be paused and resumed.

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -19,6 +19,7 @@ use crate::protocol::MemoryRangeTable;
 mod bitpos_iterator;
 mod context;
 pub mod protocol;
+pub mod tls;
 
 #[derive(Error, Debug)]
 pub enum UffdError {
@@ -102,6 +103,9 @@ pub enum MigratableError {
 
     #[error("Lifecycle operation skipped for disconnected component {0}")]
     DeviceDisconnected(String),
+
+    #[error("Error setting up a TLS-encrypted connection")]
+    Tls(#[source] tls::TlsError),
 }
 
 /// A Pausable component can be paused and resumed.

--- a/vm-migration/src/tls.rs
+++ b/vm-migration/src/tls.rs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::io::{self, Read, Write};
 use std::net::TcpStream;
+use std::os::fd::{AsFd, BorrowedFd};
 use std::path::Path;
 use std::result;
 use std::sync::Arc;
@@ -14,6 +16,8 @@ use rustls::{
     ClientConfig, ClientConnection, RootCertStore, ServerConfig, ServerConnection, StreamOwned,
 };
 use thiserror::Error;
+use vm_memory::bitmap::BitmapSlice;
+use vm_memory::{ReadVolatile, VolatileMemoryError, VolatileSlice, WriteVolatile};
 
 use crate::MigratableError;
 
@@ -46,9 +50,17 @@ enum TlsStreamParticipant {
 /// Server/Client-agnostic TLS stream.
 pub struct TlsStream {
     stream: TlsStreamParticipant,
+    /// We have to implement [`ReadVolatile`] and [`WriteVolatile`] for
+    /// [`TlsStream`]. We use this buffer to avoid allocating a new buffer for
+    /// every volatile read or write.
+    buf: Vec<u8>,
 }
 
 impl TlsStream {
+    /// The maximum size of [`TlsStream::buf`]. This keeps the reusable buffer
+    /// from growing without bound.
+    const CHUNK_SIZE: usize = 64 << 10;
+
     /// Creates a client [`TlsStream`]. Encrypts and decrypts data sent through
     /// this stream using the CA certificate from `ca-cert.pem` in the given
     /// directory. The given hostname must match a subject name in the server
@@ -89,6 +101,7 @@ impl TlsStream {
 
         Ok(Self {
             stream: TlsStreamParticipant::Client(tls),
+            buf: Vec::new(),
         })
     }
 
@@ -116,7 +129,117 @@ impl TlsStream {
 
         Ok(Self {
             stream: TlsStreamParticipant::Server(tls),
+            buf: Vec::new(),
         })
+    }
+}
+
+impl Read for TlsStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match &mut self.stream {
+            TlsStreamParticipant::Client(s) => Read::read(s, buf),
+            TlsStreamParticipant::Server(s) => Read::read(s, buf),
+        }
+    }
+}
+
+impl Write for TlsStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match &mut self.stream {
+            TlsStreamParticipant::Client(s) => Write::write(s, buf),
+            TlsStreamParticipant::Server(s) => Write::write(s, buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match &mut self.stream {
+            TlsStreamParticipant::Client(s) => Write::flush(s),
+            TlsStreamParticipant::Server(s) => Write::flush(s),
+        }
+    }
+}
+
+// Reading from or writing to these FDs would break the connection, because
+// those reads or writes wouldn't go through rustls. But the FD is necessary to
+// listen for incoming connections.
+impl AsFd for TlsStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        match &self.stream {
+            TlsStreamParticipant::Client(s) => s.get_ref().as_fd(),
+            TlsStreamParticipant::Server(s) => s.get_ref().as_fd(),
+        }
+    }
+}
+
+impl ReadVolatile for TlsStream {
+    fn read_volatile<B: BitmapSlice>(
+        &mut self,
+        vs: &mut VolatileSlice<B>,
+    ) -> result::Result<usize, VolatileMemoryError> {
+        let len = vs.len().min(Self::CHUNK_SIZE);
+
+        if len == 0 {
+            return Ok(0);
+        }
+
+        if self.buf.len() < len {
+            self.buf.resize(len, 0);
+        }
+
+        let n = {
+            let (stream, buf) = (&mut self.stream, &mut self.buf[..len]);
+
+            match stream {
+                TlsStreamParticipant::Client(s) => Read::read(s, buf),
+                TlsStreamParticipant::Server(s) => Read::read(s, buf),
+            }
+            .map_err(VolatileMemoryError::IOError)?
+        };
+
+        if n == 0 {
+            return Ok(0);
+        }
+
+        vs.copy_from(&self.buf[..n]);
+        self.buf.clear();
+        Ok(n)
+    }
+}
+
+impl WriteVolatile for TlsStream {
+    fn write_volatile<B: BitmapSlice>(
+        &mut self,
+        vs: &VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError> {
+        let len = vs.len().min(Self::CHUNK_SIZE);
+
+        if len == 0 {
+            return Ok(0);
+        }
+
+        if self.buf.len() < len {
+            self.buf.resize(len, 0);
+        }
+
+        let buf = &mut self.buf[..len];
+        let n = vs.copy_to(&mut buf[..len]);
+
+        if n == 0 {
+            return Ok(0);
+        }
+
+        let n = {
+            let stream = &mut self.stream;
+
+            match stream {
+                TlsStreamParticipant::Client(s) => Write::write(s, buf),
+                TlsStreamParticipant::Server(s) => Write::write(s, buf),
+            }
+            .map_err(VolatileMemoryError::IOError)?
+        };
+
+        self.buf.clear();
+        Ok(n)
     }
 }
 

--- a/vm-migration/src/tls.rs
+++ b/vm-migration/src/tls.rs
@@ -9,8 +9,10 @@ use std::result;
 use std::sync::Arc;
 
 use rustls::pki_types::pem::PemObject;
-use rustls::pki_types::{CertificateDer, InvalidDnsNameError, ServerName};
-use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
+use rustls::pki_types::{CertificateDer, InvalidDnsNameError, PrivateKeyDer, ServerName};
+use rustls::{
+    ClientConfig, ClientConnection, RootCertStore, ServerConfig, ServerConnection, StreamOwned,
+};
 use thiserror::Error;
 
 use crate::MigratableError;
@@ -38,6 +40,7 @@ pub enum TlsError {
 #[derive(Debug)]
 enum TlsStreamParticipant {
     Client(StreamOwned<ClientConnection, TcpStream>),
+    Server(StreamOwned<ServerConnection, TcpStream>),
 }
 
 /// Server/Client-agnostic TLS stream.
@@ -87,5 +90,58 @@ impl TlsStream {
         Ok(Self {
             stream: TlsStreamParticipant::Client(tls),
         })
+    }
+
+    /// Creates a server [`TlsStream`]. Encrypts and decrypts data sent through
+    /// this stream using the certificates and key from the provided
+    /// [`TlsServerConfig`].
+    pub fn new_server(
+        socket: TcpStream,
+        config: &TlsServerConfig,
+    ) -> result::Result<Self, MigratableError> {
+        let conn = ServerConnection::new(config.config.clone()).map_err(TlsError::RustlsError)?;
+
+        let mut tls = StreamOwned::new(conn, socket);
+        while tls.conn.is_handshaking() {
+            let (rd, wr) = tls
+                .conn
+                .complete_io(&mut tls.sock)
+                .map_err(TlsError::RustlsIoError)?;
+            if rd == 0 && wr == 0 {
+                Err(TlsError::HandshakeError(
+                    "EOF during TLS handshake".to_string(),
+                ))?;
+            }
+        }
+
+        Ok(Self {
+            stream: TlsStreamParticipant::Server(tls),
+        })
+    }
+}
+
+/// Carries a server-TLS-config. Intended to be turned into a [`TlsStream`]
+/// when paired with a [`TcpStream`].
+#[derive(Debug)]
+pub struct TlsServerConfig {
+    config: Arc<ServerConfig>,
+}
+
+impl TlsServerConfig {
+    /// Creates a [`TlsServerConfig`] from the certificate chain in
+    /// `server-cert.pem` and the private key in `server-key.pem`.
+    pub fn new(cert_dir: &Path) -> result::Result<Self, MigratableError> {
+        let certs = CertificateDer::pem_file_iter(cert_dir.join("server-cert.pem"))
+            .map_err(TlsError::RustlsPemError)?
+            .map(|cert| cert.map_err(TlsError::RustlsPemError))
+            .collect::<Result<Vec<CertificateDer<'_>>, TlsError>>()?;
+        let key = PrivateKeyDer::from_pem_file(cert_dir.join("server-key.pem"))
+            .map_err(TlsError::RustlsPemError)?;
+        let config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .map_err(TlsError::RustlsError)?;
+        let config = Arc::new(config);
+        Ok(Self { config })
     }
 }

--- a/vm-migration/src/tls.rs
+++ b/vm-migration/src/tls.rs
@@ -1,0 +1,91 @@
+// Copyright © 2025 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::net::TcpStream;
+use std::path::Path;
+use std::result;
+use std::sync::Arc;
+
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, InvalidDnsNameError, ServerName};
+use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
+use thiserror::Error;
+
+use crate::MigratableError;
+
+#[derive(Error, Debug)]
+pub enum TlsError {
+    #[error("The provided hostname could not be parsed")]
+    InvalidDnsName(#[source] InvalidDnsNameError),
+
+    #[error("Rustls protocol error")]
+    RustlsError(#[from] rustls::Error),
+
+    #[error("Rustls protocol IO error")]
+    RustlsIoError(#[from] std::io::Error),
+
+    #[error("Error during TLS handshake: {0}")]
+    HandshakeError(String),
+
+    #[error("Error handling PEM file")]
+    RustlsPemError(#[from] rustls::pki_types::pem::Error),
+}
+
+// TLS connections have a server (listens for a connection) and a client (
+// initiates a connection).
+#[derive(Debug)]
+enum TlsStreamParticipant {
+    Client(StreamOwned<ClientConnection, TcpStream>),
+}
+
+/// Server/Client-agnostic TLS stream.
+pub struct TlsStream {
+    stream: TlsStreamParticipant,
+}
+
+impl TlsStream {
+    /// Creates a client [`TlsStream`]. Encrypts and decrypts data sent through
+    /// this stream using the CA certificate from `ca-cert.pem` in the given
+    /// directory. The given hostname must match a subject name in the server
+    /// certificate presented during the TLS handshake.
+    pub fn new_client(
+        socket: TcpStream,
+        cert_dir: &Path,
+        hostname: &str,
+    ) -> result::Result<Self, MigratableError> {
+        let mut root_store = RootCertStore::empty();
+        root_store.add_parsable_certificates(
+            CertificateDer::pem_file_iter(cert_dir.join("ca-cert.pem"))
+                .map_err(TlsError::RustlsPemError)?
+                .map(|cert| cert.map_err(TlsError::RustlsPemError))
+                .collect::<Result<Vec<CertificateDer<'_>>, TlsError>>()?,
+        );
+        let config = ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+        let config = Arc::new(config);
+        let server_name =
+            ServerName::try_from(hostname.to_string()).map_err(TlsError::InvalidDnsName)?;
+        let conn = ClientConnection::new(config.clone(), server_name.clone())
+            .map_err(TlsError::RustlsError)?;
+
+        let mut tls = StreamOwned::new(conn, socket);
+        while tls.conn.is_handshaking() {
+            let (rd, wr) = tls
+                .conn
+                .complete_io(&mut tls.sock)
+                .map_err(TlsError::RustlsIoError)?;
+            if rd == 0 && wr == 0 {
+                Err(TlsError::HandshakeError(
+                    "EOF during TLS handshake".to_string(),
+                ))?;
+            }
+        }
+
+        Ok(Self {
+            stream: TlsStreamParticipant::Client(tls),
+        })
+    }
+}

--- a/vm-migration/src/tls.rs
+++ b/vm-migration/src/tls.rs
@@ -245,7 +245,7 @@ impl WriteVolatile for TlsStream {
 
 /// Carries a server-TLS-config. Intended to be turned into a [`TlsStream`]
 /// when paired with a [`TcpStream`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TlsServerConfig {
     config: Arc<ServerConfig>,
 }

--- a/vm-migration/src/tls.rs
+++ b/vm-migration/src/tls.rs
@@ -273,7 +273,7 @@ impl WriteVolatile for TlsStream {
 
 /// Carries a TLS server configuration. Intended to be turned into a [`TlsStream`]
 /// when paired with a [`TcpStream`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TlsServerConfig {
     /// This config is shared between all server connections.
     config: Arc<ServerConfig>,

--- a/vm-migration/src/tls.rs
+++ b/vm-migration/src/tls.rs
@@ -18,10 +18,11 @@
 //! other migration streams. All data must pass through rustls; direct I/O on the
 //! underlying socket would bypass TLS processing and break the connection.
 
+use std::fs::{self, File};
 use std::io::{self, BufRead, Read, Write};
 use std::net::TcpStream;
 use std::os::fd::{AsFd, BorrowedFd};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::result;
 use std::sync::Arc;
 
@@ -43,6 +44,130 @@ const CLIENT_CERT_FILE: &str = "client-cert.pem";
 const CLIENT_KEY_FILE: &str = "client-key.pem";
 const SERVER_CERT_FILE: &str = "server-cert.pem";
 const SERVER_KEY_FILE: &str = "server-key.pem";
+
+/// Identifies which side of live migration uses a TLS certificate directory.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TlsEndpoint {
+    Client,
+    Server,
+}
+
+impl TlsEndpoint {
+    fn required_files(self) -> [&'static str; 3] {
+        match self {
+            Self::Client => [CA_CERT_FILE, CLIENT_CERT_FILE, CLIENT_KEY_FILE],
+            Self::Server => [CA_CERT_FILE, SERVER_CERT_FILE, SERVER_KEY_FILE],
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Client => "migration client",
+            Self::Server => "migration server",
+        }
+    }
+}
+
+/// Validation errors for a migration TLS certificate directory.
+#[derive(Error, Debug)]
+pub enum TlsConfigError {
+    #[error("TLS directory does not exist or is inaccessible: {path}: {source}")]
+    DirectoryMetadata {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
+    #[error("TLS directory must point to a directory: {path}")]
+    NotADirectory { path: PathBuf },
+
+    #[error("Missing required TLS file for {endpoint}: {path}")]
+    MissingFile {
+        endpoint: &'static str,
+        path: PathBuf,
+    },
+
+    #[error("Required TLS path for {endpoint} must be a regular file: {path}")]
+    NotAFile {
+        endpoint: &'static str,
+        path: PathBuf,
+    },
+
+    #[error("Required TLS file for {endpoint} is not readable: {path}: {source}")]
+    FileRead {
+        endpoint: &'static str,
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
+    #[error("Failed to inspect required TLS file for {endpoint}: {path}: {source}")]
+    FileMetadata {
+        endpoint: &'static str,
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+}
+
+/// Validates that a TLS directory contains all files required by the endpoint.
+///
+/// Each required file must exist, be a regular file, and be readable by the
+/// current Cloud Hypervisor process.
+pub fn validate_tls_dir(
+    cert_dir: &Path,
+    endpoint: TlsEndpoint,
+) -> result::Result<(), TlsConfigError> {
+    let metadata = fs::metadata(cert_dir).map_err(|source| TlsConfigError::DirectoryMetadata {
+        path: cert_dir.to_path_buf(),
+        source,
+    })?;
+
+    if !metadata.is_dir() {
+        return Err(TlsConfigError::NotADirectory {
+            path: cert_dir.to_path_buf(),
+        });
+    }
+
+    for file_name in endpoint.required_files() {
+        let path = cert_dir.join(file_name);
+        let endpoint_name = endpoint.as_str();
+
+        let metadata = match fs::metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(source) if source.kind() == io::ErrorKind::NotFound => {
+                return Err(TlsConfigError::MissingFile {
+                    endpoint: endpoint_name,
+                    path,
+                });
+            }
+            Err(source) => {
+                return Err(TlsConfigError::FileMetadata {
+                    endpoint: endpoint_name,
+                    path,
+                    source,
+                });
+            }
+        };
+
+        if !metadata.is_file() {
+            return Err(TlsConfigError::NotAFile {
+                endpoint: endpoint_name,
+                path,
+            });
+        }
+
+        if let Err(source) = File::open(&path) {
+            return Err(TlsConfigError::FileRead {
+                endpoint: endpoint_name,
+                path,
+                source,
+            });
+        }
+    }
+
+    Ok(())
+}
 
 /// Errors that can occur when establishing a TLS-encrypted migration channel.
 #[derive(Error, Debug)]
@@ -347,4 +472,93 @@ fn load_private_key(key_path: &Path) -> result::Result<PrivateKeyDer<'static>, M
     PrivateKeyDer::from_pem_file(key_path)
         .map_err(TlsError::RustlsPemError)
         .map_err(MigratableError::Tls)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{fs, process};
+
+    use super::*;
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "cloud-hypervisor-{name}-{}-{unique}",
+                process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self { path }
+        }
+
+        fn add_file(&self, file_name: &str) {
+            fs::write(self.path.join(file_name), b"test").unwrap();
+        }
+
+        fn add_client_files(&self) {
+            self.add_file(CA_CERT_FILE);
+            self.add_file(CLIENT_CERT_FILE);
+            self.add_file(CLIENT_KEY_FILE);
+        }
+
+        fn add_server_files(&self) {
+            self.add_file(CA_CERT_FILE);
+            self.add_file(SERVER_CERT_FILE);
+            self.add_file(SERVER_KEY_FILE);
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn validate_tls_dir_accepts_complete_client_directory() {
+        let dir = TestDir::new("tls-client");
+        dir.add_client_files();
+
+        validate_tls_dir(&dir.path, TlsEndpoint::Client).unwrap();
+    }
+
+    #[test]
+    fn validate_tls_dir_accepts_complete_server_directory() {
+        let dir = TestDir::new("tls-server");
+        dir.add_server_files();
+
+        validate_tls_dir(&dir.path, TlsEndpoint::Server).unwrap();
+    }
+
+    #[test]
+    fn validate_tls_dir_rejects_missing_role_specific_file() {
+        let dir = TestDir::new("tls-missing-client-key");
+        dir.add_file(CA_CERT_FILE);
+        dir.add_file(CLIENT_CERT_FILE);
+
+        let err = validate_tls_dir(&dir.path, TlsEndpoint::Client).unwrap_err();
+        let err = err.to_string();
+        assert!(err.contains(CLIENT_KEY_FILE), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_tls_dir_rejects_non_file_entry() {
+        let dir = TestDir::new("tls-non-file");
+        dir.add_file(CA_CERT_FILE);
+        dir.add_file(CLIENT_KEY_FILE);
+        fs::create_dir(dir.path.join(CLIENT_CERT_FILE)).unwrap();
+
+        let err = validate_tls_dir(&dir.path, TlsEndpoint::Client).unwrap_err();
+        let err = err.to_string();
+        assert!(err.contains(CLIENT_CERT_FILE), "unexpected error: {err}");
+    }
 }

--- a/vm-migration/src/tls.rs
+++ b/vm-migration/src/tls.rs
@@ -26,8 +26,10 @@ use std::sync::Arc;
 use log::warn;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, InvalidDnsNameError, PrivateKeyDer, ServerName};
-use rustls::server::VerifierBuilderError;
-use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
+use rustls::server::{VerifierBuilderError, WebPkiClientVerifier};
+use rustls::{
+    ClientConfig, ClientConnection, RootCertStore, ServerConfig, ServerConnection, StreamOwned,
+};
 use thiserror::Error;
 
 use crate::MigratableError;
@@ -35,6 +37,8 @@ use crate::MigratableError;
 const CA_CERT_FILE: &str = "ca-cert.pem";
 const CLIENT_CERT_FILE: &str = "client-cert.pem";
 const CLIENT_KEY_FILE: &str = "client-key.pem";
+const SERVER_CERT_FILE: &str = "server-cert.pem";
+const SERVER_KEY_FILE: &str = "server-key.pem";
 
 /// Errors that can occur when establishing a TLS-encrypted migration channel.
 #[derive(Error, Debug)]
@@ -67,6 +71,7 @@ pub enum TlsError {
 #[derive(Debug)]
 enum TlsStreamParticipant {
     Client(StreamOwned<ClientConnection, TcpStream>),
+    Server(StreamOwned<ServerConnection, TcpStream>),
 }
 
 /// Server/Client-agnostic TLS stream.
@@ -121,6 +126,72 @@ impl TlsStream {
         Ok(Self {
             stream: TlsStreamParticipant::Client(tls),
         })
+    }
+
+    /// Creates a server [`TlsStream`]. Encrypts and decrypts data sent through
+    /// this stream using the certificates and key from the provided
+    /// [`TlsServerConfig`].
+    pub fn new_server(
+        socket: TcpStream,
+        config: &TlsServerConfig,
+    ) -> result::Result<Self, MigratableError> {
+        let conn = ServerConnection::new(config.config.clone())
+            .map_err(TlsError::RustlsError)
+            .map_err(MigratableError::Tls)?;
+
+        let mut tls = StreamOwned::new(conn, socket);
+        while tls.conn.is_handshaking() {
+            let (rd, wr) = tls
+                .conn
+                .complete_io(&mut tls.sock)
+                .map_err(TlsError::RustlsIoError)
+                .map_err(MigratableError::Tls)?;
+            // No handshake progress on a connection that should be handshaking, we treat
+            // that as a failure.
+            if rd == 0 && wr == 0 {
+                return Err(MigratableError::Tls(TlsError::HandshakeError));
+            }
+        }
+
+        Ok(Self {
+            stream: TlsStreamParticipant::Server(tls),
+        })
+    }
+}
+
+/// Carries a TLS server configuration. Intended to be turned into a [`TlsStream`]
+/// when paired with a [`TcpStream`].
+#[derive(Debug)]
+pub struct TlsServerConfig {
+    /// This config is shared between all server connections.
+    config: Arc<ServerConfig>,
+}
+
+impl TlsServerConfig {
+    /// Creates a [`TlsServerConfig`] from the certificate chain in
+    /// `server-cert.pem`, the private key in `server-key.pem`, and the client
+    /// trust anchors in `ca-cert.pem`.
+    ///
+    /// Client certificates presented during the TLS handshake must chain to a CA in
+    /// `ca-cert.pem`.
+    pub fn new(cert_dir: &Path) -> result::Result<Self, MigratableError> {
+        let server_certs = load_cert_chain(&cert_dir.join(SERVER_CERT_FILE))?;
+        let server_key = load_private_key(&cert_dir.join(SERVER_KEY_FILE))?;
+        // Trust anchors used to verify client certificates for mTLS.
+        let client_roots = Arc::new(load_root_store(&cert_dir.join(CA_CERT_FILE))?);
+
+        let client_verifier = WebPkiClientVerifier::builder(client_roots)
+            .build()
+            .map_err(TlsError::RustlsVerifierBuilderError)
+            .map_err(MigratableError::Tls)?;
+
+        let config = ServerConfig::builder()
+            .with_client_cert_verifier(client_verifier)
+            .with_single_cert(server_certs, server_key)
+            .map_err(TlsError::RustlsError)
+            .map_err(MigratableError::Tls)?;
+        let config = Arc::new(config);
+        Ok(Self { config })
     }
 }
 

--- a/vm-migration/src/tls.rs
+++ b/vm-migration/src/tls.rs
@@ -1,0 +1,167 @@
+// Copyright © 2026 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! TLS support for migration streams over TCP.
+//!
+//! This module wraps `rustls` to provide a blocking [`TlsStream`] for migration
+//! traffic. [`TlsStream::new_client`] authenticates the server against
+//! `ca-cert.pem` and the expected hostname, and presents `client-cert.pem` and
+//! `client-key.pem` for mutual TLS (mTLS) authentication. [`TlsServerConfig`] loads
+//! `server-cert.pem` and `server-key.pem`, trusts client certificates issued by
+//! the CA in `ca-cert.pem`, and [`TlsStream::new_server`] uses that
+//! configuration to establish the server side of the connection.
+//!
+//! [`TlsStream`] implements [`Read`], [`Write`], [`ReadVolatile`],
+//! [`WriteVolatile`], and [`AsFd`] so it can be used by the transport layer like
+//! other migration streams. All data must pass through rustls; direct I/O on the
+//! underlying socket would bypass TLS processing and break the connection.
+
+use std::net::TcpStream;
+use std::path::Path;
+use std::result;
+use std::sync::Arc;
+
+use log::warn;
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, InvalidDnsNameError, PrivateKeyDer, ServerName};
+use rustls::server::VerifierBuilderError;
+use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
+use thiserror::Error;
+
+use crate::MigratableError;
+
+const CA_CERT_FILE: &str = "ca-cert.pem";
+const CLIENT_CERT_FILE: &str = "client-cert.pem";
+const CLIENT_KEY_FILE: &str = "client-key.pem";
+
+/// Errors that can occur when establishing a TLS-encrypted migration channel.
+#[derive(Error, Debug)]
+pub enum TlsError {
+    #[error("The provided hostname could not be parsed")]
+    InvalidDnsName(#[source] InvalidDnsNameError),
+
+    #[error("Rustls protocol error")]
+    RustlsError(#[from] rustls::Error),
+
+    #[error("Rustls verifier configuration error")]
+    RustlsVerifierBuilderError(#[source] VerifierBuilderError),
+
+    #[error("Rustls protocol IO error")]
+    RustlsIoError(#[from] std::io::Error),
+
+    #[error("TLS handshake stalled: no read/write progress while handshake is still in progress")]
+    HandshakeError,
+
+    #[error("Error handling PEM file")]
+    RustlsPemError(#[from] rustls::pki_types::pem::Error),
+}
+
+/// Wraps the concrete rustls stream for either side (server or client) of the
+/// TLS connection.
+///
+/// [`TlsStream`] uses this enum to store a [`StreamOwned`] with either a
+/// [`ClientConnection`] or [`ServerConnection`] while exposing a single
+/// transport-agnostic API.
+#[derive(Debug)]
+enum TlsStreamParticipant {
+    Client(StreamOwned<ClientConnection, TcpStream>),
+}
+
+/// Server/Client-agnostic TLS stream.
+pub struct TlsStream {
+    stream: TlsStreamParticipant,
+}
+
+impl TlsStream {
+    /// Creates a client [`TlsStream`].
+    ///
+    /// The client verifies the server certificate against `ca-cert.pem` and the
+    /// provided `hostname`, and presents the certificate chain in
+    /// `client-cert.pem` together with the private key in `client-key.pem` for
+    /// mutual TLS authentication.
+    pub fn new_client(
+        socket: TcpStream,
+        cert_dir: &Path,
+        hostname: &str,
+    ) -> result::Result<Self, MigratableError> {
+        let root_store = load_root_store(&cert_dir.join(CA_CERT_FILE))?;
+        let client_certs = load_cert_chain(&cert_dir.join(CLIENT_CERT_FILE))?;
+        let client_key = load_private_key(&cert_dir.join(CLIENT_KEY_FILE))?;
+
+        let config = ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_client_auth_cert(client_certs, client_key)
+            .map_err(TlsError::RustlsError)
+            .map_err(MigratableError::Tls)?;
+        let config = Arc::new(config);
+
+        let server_name = ServerName::try_from(hostname.to_string())
+            .map_err(TlsError::InvalidDnsName)
+            .map_err(MigratableError::Tls)?;
+        let conn = ClientConnection::new(config, server_name)
+            .map_err(TlsError::RustlsError)
+            .map_err(MigratableError::Tls)?;
+
+        let mut tls = StreamOwned::new(conn, socket);
+        while tls.conn.is_handshaking() {
+            let (rd, wr) = tls
+                .conn
+                .complete_io(&mut tls.sock)
+                .map_err(TlsError::RustlsIoError)
+                .map_err(MigratableError::Tls)?;
+            // No handshake progress on a connection that should be handshaking, we treat
+            // that as a failure.
+            if rd == 0 && wr == 0 {
+                return Err(MigratableError::Tls(TlsError::HandshakeError));
+            }
+        }
+
+        Ok(Self {
+            stream: TlsStreamParticipant::Client(tls),
+        })
+    }
+}
+
+/// Loads trusted CA certificates into a root store, i.e. the set of trust anchors
+/// used to verify the peer's certificate chain.
+fn load_root_store(cert_path: &Path) -> result::Result<RootCertStore, MigratableError> {
+    let mut root_store = RootCertStore::empty();
+    let (_, ignored) = root_store.add_parsable_certificates(
+        CertificateDer::pem_file_iter(cert_path)
+            .map_err(TlsError::RustlsPemError)
+            .map_err(MigratableError::Tls)?
+            .map(|cert| cert.map_err(TlsError::RustlsPemError))
+            .collect::<Result<Vec<CertificateDer<'static>>, TlsError>>()
+            .map_err(MigratableError::Tls)?,
+    );
+
+    if ignored > 0 {
+        warn!(
+            "Ignored {ignored} certificate(s) while loading TLS CA file {}",
+            cert_path.display()
+        );
+    }
+
+    Ok(root_store)
+}
+
+/// Loads a certificate chain to present during the TLS handshake.
+fn load_cert_chain(
+    cert_path: &Path,
+) -> result::Result<Vec<CertificateDer<'static>>, MigratableError> {
+    CertificateDer::pem_file_iter(cert_path)
+        .map_err(TlsError::RustlsPemError)
+        .map_err(MigratableError::Tls)?
+        .map(|cert| cert.map_err(TlsError::RustlsPemError))
+        .collect::<Result<Vec<CertificateDer<'static>>, TlsError>>()
+        .map_err(MigratableError::Tls)
+}
+
+/// Loads the private key that proves ownership of the presented certificate chain.
+fn load_private_key(key_path: &Path) -> result::Result<PrivateKeyDer<'static>, MigratableError> {
+    PrivateKeyDer::from_pem_file(key_path)
+        .map_err(TlsError::RustlsPemError)
+        .map_err(MigratableError::Tls)
+}

--- a/vm-migration/src/tls.rs
+++ b/vm-migration/src/tls.rs
@@ -18,7 +18,9 @@
 //! other migration streams. All data must pass through rustls; direct I/O on the
 //! underlying socket would bypass TLS processing and break the connection.
 
+use std::io::{self, BufRead, Read, Write};
 use std::net::TcpStream;
+use std::os::fd::{AsFd, BorrowedFd};
 use std::path::Path;
 use std::result;
 use std::sync::Arc;
@@ -31,6 +33,8 @@ use rustls::{
     ClientConfig, ClientConnection, RootCertStore, ServerConfig, ServerConnection, StreamOwned,
 };
 use thiserror::Error;
+use vm_memory::bitmap::BitmapSlice;
+use vm_memory::{ReadVolatile, VolatileMemoryError, VolatileSlice, WriteVolatile};
 
 use crate::MigratableError;
 
@@ -77,9 +81,16 @@ enum TlsStreamParticipant {
 /// Server/Client-agnostic TLS stream.
 pub struct TlsStream {
     stream: TlsStreamParticipant,
+    // `rustls` only accepts plaintext writes as regular byte slices, so
+    // `WriteVolatile` needs a staging buffer to copy out of guest memory.
+    write_buf: Vec<u8>,
 }
 
 impl TlsStream {
+    /// The maximum size of [`TlsStream::write_buf`]. This keeps the reusable buffer
+    /// from growing without bound.
+    const BUF_SIZE: usize = 64 /* KiB */ << 10;
+
     /// Creates a client [`TlsStream`].
     ///
     /// The client verifies the server certificate against `ca-cert.pem` and the
@@ -125,6 +136,7 @@ impl TlsStream {
 
         Ok(Self {
             stream: TlsStreamParticipant::Client(tls),
+            write_buf: Vec::new(),
         })
     }
 
@@ -155,7 +167,107 @@ impl TlsStream {
 
         Ok(Self {
             stream: TlsStreamParticipant::Server(tls),
+            write_buf: Vec::new(),
         })
+    }
+}
+
+impl Read for TlsStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match &mut self.stream {
+            TlsStreamParticipant::Client(s) => Read::read(s, buf),
+            TlsStreamParticipant::Server(s) => Read::read(s, buf),
+        }
+    }
+}
+
+impl Write for TlsStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match &mut self.stream {
+            TlsStreamParticipant::Client(s) => Write::write(s, buf),
+            TlsStreamParticipant::Server(s) => Write::write(s, buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match &mut self.stream {
+            TlsStreamParticipant::Client(s) => Write::flush(s),
+            TlsStreamParticipant::Server(s) => Write::flush(s),
+        }
+    }
+}
+
+// Reading from or writing to these FDs would break the connection, because
+// those reads or writes wouldn't go through rustls. But the FD is necessary to
+// listen for incoming connections.
+impl AsFd for TlsStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        match &self.stream {
+            TlsStreamParticipant::Client(s) => s.get_ref().as_fd(),
+            TlsStreamParticipant::Server(s) => s.get_ref().as_fd(),
+        }
+    }
+}
+
+impl ReadVolatile for TlsStream {
+    fn read_volatile<B: BitmapSlice>(
+        &mut self,
+        vs: &mut VolatileSlice<B>,
+    ) -> result::Result<usize, VolatileMemoryError> {
+        if vs.is_empty() {
+            return Ok(0);
+        }
+
+        let chunk = match &mut self.stream {
+            TlsStreamParticipant::Client(s) => BufRead::fill_buf(s),
+            TlsStreamParticipant::Server(s) => BufRead::fill_buf(s),
+        }
+        .map_err(VolatileMemoryError::IOError)?;
+
+        let n = chunk.len().min(vs.len());
+        if n == 0 {
+            return Ok(0);
+        }
+
+        vs.copy_from(&chunk[..n]);
+
+        match &mut self.stream {
+            TlsStreamParticipant::Client(s) => BufRead::consume(s, n),
+            TlsStreamParticipant::Server(s) => BufRead::consume(s, n),
+        }
+        Ok(n)
+    }
+}
+
+impl WriteVolatile for TlsStream {
+    fn write_volatile<B: BitmapSlice>(
+        &mut self,
+        vs: &VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError> {
+        let len = vs.len().min(Self::BUF_SIZE);
+
+        if len == 0 {
+            return Ok(0);
+        }
+
+        if self.write_buf.len() < len {
+            self.write_buf.resize(len, 0);
+        }
+
+        let buf = &mut self.write_buf[..len];
+        let n = vs.copy_to(buf);
+
+        if n == 0 {
+            return Ok(0);
+        }
+
+        let n = match &mut self.stream {
+            TlsStreamParticipant::Client(s) => Write::write(s, &buf[..n]),
+            TlsStreamParticipant::Server(s) => Write::write(s, &buf[..n]),
+        }
+        .map_err(VolatileMemoryError::IOError)?;
+
+        Ok(n)
     }
 }
 

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -267,9 +267,22 @@ pub struct VmCoredumpData {
 }
 
 #[derive(Clone, Deserialize, Serialize, Default, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct VmReceiveMigrationData {
     /// URL for the reception of migration state
     pub receiver_url: String,
+    /// Directory containing the TLS server certificate (server-cert.pem) and TLS server key (server-key.pem).
+    #[serde(default)]
+    pub tls_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Error)]
+pub enum VmReceiveMigrationConfigError {
+    #[error("Error parsing receive migration parameters")]
+    ParseError(#[source] OptionParserError),
+
+    #[error("Error validating receive migration parameters")]
+    ValidationError(String),
 }
 
 fn validate_tcp_migration_address(address: &str) -> Result<(), String> {
@@ -309,6 +322,90 @@ fn validate_tcp_migration_address(address: &str) -> Result<(), String> {
 
         port.parse::<u16>()
             .map_err(|_| format!("invalid TCP port: {port}"))?;
+
+        Ok(())
+    }
+}
+
+impl VmReceiveMigrationData {
+    pub const SYNTAX: &'static str = "VM receive migration parameters \
+        \"<receiver_url>\" or \"receiver_url=<url>[,tls_dir=<path>]\"";
+
+    pub fn parse(migration: &str) -> Result<Self, VmReceiveMigrationConfigError> {
+        let uses_key_value_syntax = migration.split(',').any(
+            |part| matches!(part, p if p.starts_with("receiver_url=") || p.starts_with("tls_dir=")),
+        );
+
+        if !uses_key_value_syntax {
+            let data = Self {
+                receiver_url: migration.to_owned(),
+                tls_dir: None,
+            };
+
+            data.validate()?;
+
+            return Ok(data);
+        }
+
+        let mut parser = OptionParser::new();
+        parser.add("receiver_url").add("tls_dir");
+        parser
+            .parse(migration)
+            .map_err(VmReceiveMigrationConfigError::ParseError)?;
+
+        let receiver_url = parser.get("receiver_url").ok_or_else(|| {
+            VmReceiveMigrationConfigError::ParseError(OptionParserError::InvalidSyntax(
+                "receiver_url is required".to_string(),
+            ))
+        })?;
+        let tls_dir = parser
+            .convert::<String>("tls_dir")
+            .map_err(VmReceiveMigrationConfigError::ParseError)?
+            .map(|path| PathBuf::from(&path));
+
+        let data = Self {
+            receiver_url,
+            tls_dir,
+        };
+
+        data.validate()?;
+
+        Ok(data)
+    }
+
+    pub fn validate(&self) -> Result<(), VmReceiveMigrationConfigError> {
+        if let Some(addr) = self.receiver_url.strip_prefix("tcp:") {
+            validate_tcp_migration_address(addr).map_err(|e| {
+                VmReceiveMigrationConfigError::ValidationError(format!(
+                    "receiver_url must use tcp:<host>:<port> or unix:<path>: {e}."
+                ))
+            })?;
+        } else if self
+            .receiver_url
+            .strip_prefix("unix:")
+            .is_some_and(|path| !path.is_empty())
+        {
+            if self.tls_dir.is_some() {
+                return Err(VmReceiveMigrationConfigError::ValidationError(
+                    "UNIX sockets and TLS encryption cannot be used at the same time.".to_string(),
+                ));
+            }
+        } else {
+            return Err(VmReceiveMigrationConfigError::ValidationError(
+                "receiver_url must use tcp:<host>:<port> or unix:<path>.".to_string(),
+            ));
+        }
+
+        // The TLS implementation checks for all necessary files. Here we only
+        // check whether the path exists and points to a directory.
+        if let Some(tls_dir) = &self.tls_dir
+            && !tls_dir.is_dir()
+        {
+            return Err(VmReceiveMigrationConfigError::ValidationError(format!(
+                "tls_dir must point to a directory. Path: {}",
+                tls_dir.display()
+            )));
+        }
 
         Ok(())
     }
@@ -1827,6 +1924,46 @@ impl ApiAction for VmNmi {
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+
+    #[test]
+    fn test_vm_receive_migration_data_parse() {
+        let data = VmReceiveMigrationData::parse("tcp:192.168.1.1:8080").unwrap();
+        assert_eq!(
+            data,
+            VmReceiveMigrationData {
+                receiver_url: "tcp:192.168.1.1:8080".to_string(),
+                tls_dir: None,
+            }
+        );
+
+        let data = VmReceiveMigrationData::parse("tcp:[2001:db8::1]:8080").unwrap();
+        assert_eq!(data.receiver_url, "tcp:[2001:db8::1]:8080");
+
+        let data = VmReceiveMigrationData::parse("tcp:destination.example:8080").unwrap();
+        assert_eq!(data.receiver_url, "tcp:destination.example:8080");
+
+        let data = VmReceiveMigrationData::parse("unix:/tmp/ch=migrate.sock").unwrap();
+        assert_eq!(data.receiver_url, "unix:/tmp/ch=migrate.sock");
+
+        let tls_dir = std::env::temp_dir();
+        let data = VmReceiveMigrationData::parse(&format!(
+            "receiver_url=tcp:192.168.1.1:8080,tls_dir={}",
+            tls_dir.display()
+        ))
+        .unwrap();
+        assert_eq!(
+            data,
+            VmReceiveMigrationData {
+                receiver_url: "tcp:192.168.1.1:8080".to_string(),
+                tls_dir: Some(tls_dir),
+            }
+        );
+
+        VmReceiveMigrationData::parse("receiver_url=file:///tmp/migration").unwrap_err();
+        VmReceiveMigrationData::parse("tcp:192.168.1.1").unwrap_err();
+        VmReceiveMigrationData::parse("tcp:[2001:db8::1]").unwrap_err();
+        VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,tls_dir=/tmp").unwrap_err();
+    }
 
     #[test]
     fn test_vm_send_migration_data_parse() {

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -35,6 +35,7 @@ pub mod http;
 
 use std::io;
 use std::num::{NonZeroU32, NonZeroU64};
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::mpsc::{RecvError, SendError, Sender, channel};
 use std::time::Duration;
@@ -372,13 +373,17 @@ pub struct VmSendMigrationData {
     /// Must be between 1 and `MAX_MIGRATION_CONNECTIONS` inclusive.
     #[serde(default = "VmSendMigrationData::default_connections")]
     pub connections: NonZeroU32,
+    /// Path to the directory containing the TLS root CA certificate (ca-cert.pem)
+    #[serde(default)]
+    pub tls_dir: Option<PathBuf>,
 }
 
 impl VmSendMigrationData {
     pub const SYNTAX: &'static str = "VM send migration parameters \
         \"destination_url=<url>[,local=on|off,\
         downtime_ms=<milliseconds>,timeout_s=<seconds>,\
-        timeout_strategy=cancel|ignore,connections=<amount>]\"";
+        timeout_strategy=cancel|ignore,connections=<amount>,\
+        tls_dir=<path>]\"";
 
     // Same as QEMU.
     pub const DEFAULT_DOWNTIME: Duration = Duration::from_millis(300);
@@ -406,7 +411,8 @@ impl VmSendMigrationData {
             .add("downtime_ms")
             .add("timeout_s")
             .add("timeout_strategy")
-            .add("connections");
+            .add("connections")
+            .add("tls_dir");
         parser
             .parse(migration)
             .map_err(VmSendMigrationConfigError::ParseError)?;
@@ -458,6 +464,10 @@ impl VmSendMigrationData {
             })?,
             None => Self::default_connections(),
         };
+        let tls_dir = parser
+            .convert::<String>("tls_dir")
+            .map_err(VmSendMigrationConfigError::ParseError)?
+            .map(|path| PathBuf::from(&path));
 
         let data = Self {
             destination_url,
@@ -466,6 +476,7 @@ impl VmSendMigrationData {
             timeout_s,
             timeout_strategy,
             connections,
+            tls_dir,
         };
 
         data.validate()?;
@@ -499,6 +510,11 @@ impl VmSendMigrationData {
                         .to_string(),
                 ));
             }
+            if self.tls_dir.is_some() {
+                return Err(VmSendMigrationConfigError::ValidationError(
+                    "UNIX sockets and TLS encryption cannot be used at the same time.".to_string(),
+                ));
+            }
         } else {
             return Err(VmSendMigrationConfigError::ValidationError(
                 "destination_url must use tcp:<host>:<port> or unix:<path>.".to_string(),
@@ -524,6 +540,17 @@ impl VmSendMigrationData {
                         .to_string(),
                 ));
             }
+        }
+
+        // The TLS implementation checks for all necessary files. Here we only
+        // check whether the path exists and points to a directory.
+        if let Some(tls_dir) = &self.tls_dir
+            && !tls_dir.is_dir()
+        {
+            return Err(VmSendMigrationConfigError::ValidationError(format!(
+                "tls_dir must point to a directory. Path: {}",
+                tls_dir.display()
+            )));
         }
 
         Ok(())
@@ -1891,12 +1918,14 @@ mod unit_tests {
                 timeout_s: VmSendMigrationData::default_timeout_s(),
                 timeout_strategy: Default::default(),
                 connections: VmSendMigrationData::default_connections(),
+                tls_dir: None,
             }
         );
 
         // Happy path, fully specified
+        let tls_dir = std::env::temp_dir();
         let data =
-            VmSendMigrationData::parse("destination_url=tcp:192.168.1.1:8080,downtime_ms=150,timeout_s=900,timeout_strategy=ignore,connections=4")
+            VmSendMigrationData::parse(&format!("destination_url=tcp:192.168.1.1:8080,downtime_ms=150,timeout_s=900,timeout_strategy=ignore,connections=4,tls_dir={}", tls_dir.display()))
                 .unwrap();
         assert_eq!(
             data,
@@ -1907,6 +1936,7 @@ mod unit_tests {
                 timeout_s: NonZeroU64::new(900).unwrap(),
                 timeout_strategy: TimeoutStrategy::Ignore,
                 connections: NonZeroU32::new(4).unwrap(),
+                tls_dir: Some(tls_dir),
             }
         );
     }

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -271,6 +271,48 @@ pub struct VmReceiveMigrationData {
     pub receiver_url: String,
 }
 
+fn validate_tcp_migration_address(address: &str) -> Result<(), String> {
+    if let Some(rest) = address.strip_prefix('[') {
+        let (host, port) = rest
+            .split_once(']')
+            .ok_or_else(|| "missing closing ']' for bracketed IPv6 address".to_string())?;
+
+        if host.is_empty() {
+            return Err("host must not be empty".to_string());
+        }
+
+        let port = port
+            .strip_prefix(':')
+            .ok_or_else(|| "missing port separator after bracketed host".to_string())?;
+
+        if port.is_empty() {
+            return Err("port must not be empty".to_string());
+        }
+
+        port.parse::<u16>()
+            .map_err(|_| format!("invalid TCP port: {port}"))?;
+
+        Ok(())
+    } else {
+        let (host, port) = address
+            .rsplit_once(':')
+            .ok_or_else(|| "missing TCP port".to_string())?;
+
+        if host.is_empty() {
+            return Err("host must not be empty".to_string());
+        }
+
+        if port.is_empty() {
+            return Err("port must not be empty".to_string());
+        }
+
+        port.parse::<u16>()
+            .map_err(|_| format!("invalid TCP port: {port}"))?;
+
+        Ok(())
+    }
+}
+
 #[derive(Copy, Clone, Default, Deserialize, Serialize, Debug, PartialEq, Eq)]
 /// The migration timeout strategy.
 ///
@@ -440,26 +482,27 @@ impl VmSendMigrationData {
     }
 
     pub fn validate(&self) -> Result<(), VmSendMigrationConfigError> {
-        match self.destination_url.as_str() {
-            url if url
-                .strip_prefix("tcp:")
-                .is_some_and(|addr| !addr.is_empty()) => {}
-            url if url
-                .strip_prefix("unix:")
-                .is_some_and(|path| !path.is_empty()) =>
-            {
-                if self.connections.get() > 1 {
-                    return Err(VmSendMigrationConfigError::ValidationError(
-                        "UNIX sockets and connections option cannot be used at the same time."
-                            .to_string(),
-                    ));
-                }
-            }
-            _ => {
+        if let Some(addr) = self.destination_url.strip_prefix("tcp:") {
+            validate_tcp_migration_address(addr).map_err(|e| {
+                VmSendMigrationConfigError::ValidationError(format!(
+                    "destination_url must use tcp:<host>:<port> or unix:<path>: {e}."
+                ))
+            })?;
+        } else if self
+            .destination_url
+            .strip_prefix("unix:")
+            .is_some_and(|path| !path.is_empty())
+        {
+            if self.connections.get() > 1 {
                 return Err(VmSendMigrationConfigError::ValidationError(
-                    "destination_url must use tcp:<host>:<port> or unix:<path>.".to_string(),
+                    "UNIX sockets and connections option cannot be used at the same time."
+                        .to_string(),
                 ));
             }
+        } else {
+            return Err(VmSendMigrationConfigError::ValidationError(
+                "destination_url must use tcp:<host>:<port> or unix:<path>.".to_string(),
+            ));
         }
 
         if self.connections.get() > MAX_MIGRATION_CONNECTIONS {
@@ -1781,6 +1824,14 @@ mod unit_tests {
         assert_eq!(data.timeout_strategy, TimeoutStrategy::default());
         assert_eq!(data.connections, VmSendMigrationData::default_connections());
 
+        let data = VmSendMigrationData::parse("destination_url=tcp:[2001:db8::1]:8080")
+            .expect("IPv6 migration string should parse");
+        assert_eq!(data.destination_url, "tcp:[2001:db8::1]:8080");
+
+        let data = VmSendMigrationData::parse("destination_url=tcp:destination.example:8080")
+            .expect("hostname migration string should parse");
+        assert_eq!(data.destination_url, "tcp:destination.example:8080");
+
         // Missing destination_url is an error
         VmSendMigrationData::parse("local=on,downtime_ms=200").unwrap_err();
 
@@ -1817,6 +1868,8 @@ mod unit_tests {
 
         // Invalid destination URL scheme is rejected
         VmSendMigrationData::parse("destination_url=file:///tmp/migration").unwrap_err();
+        VmSendMigrationData::parse("destination_url=tcp:192.168.1.1").unwrap_err();
+        VmSendMigrationData::parse("destination_url=tcp:[2001:db8::1]").unwrap_err();
 
         // Local migration requires a UNIX socket destination
         VmSendMigrationData::parse("destination_url=tcp:192.168.1.1:8080,local=yes").unwrap_err();

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -35,6 +35,7 @@ pub mod http;
 
 use std::io;
 use std::num::{NonZeroU32, NonZeroU64};
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::mpsc::{RecvError, SendError, Sender, channel};
 use std::time::Duration;
@@ -338,13 +339,17 @@ pub struct VmSendMigrationData {
     /// Must be between 1 and `MAX_MIGRATION_CONNECTIONS` inclusive.
     #[serde(default = "VmSendMigrationData::default_connections")]
     pub connections: NonZeroU32,
+    /// Path to the directory containing the TLS root CA certificate (ca-cert.pem), the TLS client certificate (client-cert.pem), and TLS client key (client-key.pem).
+    #[serde(default)]
+    pub tls_dir: Option<PathBuf>,
 }
 
 impl VmSendMigrationData {
     pub const SYNTAX: &'static str = "VM send migration parameters \
         \"destination_url=<url>[,local=on|off,\
         downtime_ms=<milliseconds>,timeout_s=<seconds>,\
-        timeout_strategy=cancel|ignore,connections=<amount>]\"";
+        timeout_strategy=cancel|ignore,connections=<amount>,\
+        tls_dir=<path>]\"";
 
     // Same as QEMU.
     pub const DEFAULT_DOWNTIME: Duration = Duration::from_millis(300);
@@ -372,7 +377,8 @@ impl VmSendMigrationData {
             .add("downtime_ms")
             .add("timeout_s")
             .add("timeout_strategy")
-            .add("connections");
+            .add("connections")
+            .add("tls_dir");
         parser
             .parse(migration)
             .map_err(VmSendMigrationConfigError::ParseError)?;
@@ -424,6 +430,10 @@ impl VmSendMigrationData {
             })?,
             None => Self::default_connections(),
         };
+        let tls_dir = parser
+            .convert::<String>("tls_dir")
+            .map_err(VmSendMigrationConfigError::ParseError)?
+            .map(|path| PathBuf::from(&path));
 
         let data = Self {
             destination_url,
@@ -432,6 +442,7 @@ impl VmSendMigrationData {
             timeout_s,
             timeout_strategy,
             connections,
+            tls_dir,
         };
 
         data.validate()?;
@@ -460,6 +471,11 @@ impl VmSendMigrationData {
                 return Err(VmSendMigrationConfigError::ValidationError(
                     "UNIX sockets and connections option cannot be used at the same time."
                         .to_string(),
+                ));
+            }
+            if self.tls_dir.is_some() {
+                return Err(VmSendMigrationConfigError::ValidationError(
+                    "UNIX sockets and TLS encryption cannot be used at the same time.".to_string(),
                 ));
             }
         } else {
@@ -1862,12 +1878,14 @@ mod unit_tests {
                 timeout_s: VmSendMigrationData::default_timeout_s(),
                 timeout_strategy: Default::default(),
                 connections: VmSendMigrationData::default_connections(),
+                tls_dir: None,
             }
         );
 
         // Happy path, fully specified
+        let tls_dir = std::env::temp_dir();
         let data =
-            VmSendMigrationData::parse("destination_url=tcp:192.168.1.1:8080,downtime_ms=150,timeout_s=900,timeout_strategy=ignore,connections=4")
+            VmSendMigrationData::parse(&format!("destination_url=tcp:192.168.1.1:8080,downtime_ms=150,timeout_s=900,timeout_strategy=ignore,connections=4,tls_dir={}", tls_dir.display()))
                 .unwrap();
         assert_eq!(
             data,
@@ -1878,6 +1896,7 @@ mod unit_tests {
                 timeout_s: NonZeroU64::new(900).unwrap(),
                 timeout_strategy: TimeoutStrategy::Ignore,
                 connections: NonZeroU32::new(4).unwrap(),
+                tls_dir: Some(tls_dir),
             }
         );
     }

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -53,7 +53,9 @@ pub use self::http::{start_http_fd_thread, start_http_path_thread};
 use crate::Error as VmmError;
 use crate::config::RestoreConfig;
 use crate::device_tree::DeviceTree;
-use crate::migration_transport::MAX_MIGRATION_CONNECTIONS;
+use crate::migration_transport::{
+    MAX_MIGRATION_CONNECTIONS, TcpAddressParseError, tcp_address_to_server_name,
+};
 use crate::vm::{Error as VmError, VmState};
 use crate::vm_config::{
     DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, NetConfig, PmemConfig,
@@ -301,6 +303,11 @@ pub enum VmSendMigrationConfigError {
     #[error("Error parsing send migration parameters")]
     ParseError(#[source] OptionParserError),
 
+    #[error(
+        "Error validating send migration parameters: destination_url must use tcp:<host>:<port> or unix:<path>."
+    )]
+    InvalidDestinationUrl(#[source] TcpAddressParseError),
+
     #[error("Error validating send migration parameters")]
     ValidationError(String),
 }
@@ -441,26 +448,24 @@ impl VmSendMigrationData {
     }
 
     pub fn validate(&self) -> Result<(), VmSendMigrationConfigError> {
-        match self.destination_url.as_str() {
-            url if url
-                .strip_prefix("tcp:")
-                .is_some_and(|addr| !addr.is_empty()) => {}
-            url if url
-                .strip_prefix("unix:")
-                .is_some_and(|path| !path.is_empty()) =>
-            {
-                if self.connections.get() > 1 {
-                    return Err(VmSendMigrationConfigError::ValidationError(
-                        "UNIX sockets and connections option cannot be used at the same time."
-                            .to_string(),
-                    ));
-                }
-            }
-            _ => {
+        if let Some(addr) = self.destination_url.strip_prefix("tcp:") {
+            tcp_address_to_server_name(addr)
+                .map_err(VmSendMigrationConfigError::InvalidDestinationUrl)?;
+        } else if self
+            .destination_url
+            .strip_prefix("unix:")
+            .is_some_and(|path| !path.is_empty())
+        {
+            if self.connections.get() > 1 {
                 return Err(VmSendMigrationConfigError::ValidationError(
-                    "destination_url must use tcp:<host>:<port> or unix:<path>.".to_string(),
+                    "UNIX sockets and connections option cannot be used at the same time."
+                        .to_string(),
                 ));
             }
+        } else {
+            return Err(VmSendMigrationConfigError::ValidationError(
+                "destination_url must use tcp:<host>:<port> or unix:<path>.".to_string(),
+            ));
         }
 
         if self.connections.get() > MAX_MIGRATION_CONNECTIONS {
@@ -1782,6 +1787,14 @@ mod unit_tests {
         assert_eq!(data.timeout_strategy, TimeoutStrategy::default());
         assert_eq!(data.connections, VmSendMigrationData::default_connections());
 
+        let data = VmSendMigrationData::parse("destination_url=tcp:[2001:db8::1]:8080")
+            .expect("IPv6 migration string should parse");
+        assert_eq!(data.destination_url, "tcp:[2001:db8::1]:8080");
+
+        let data = VmSendMigrationData::parse("destination_url=tcp:destination.example:8080")
+            .expect("hostname migration string should parse");
+        assert_eq!(data.destination_url, "tcp:destination.example:8080");
+
         // Missing destination_url is an error
         VmSendMigrationData::parse("local=on,downtime_ms=200").unwrap_err();
 
@@ -1818,6 +1831,16 @@ mod unit_tests {
 
         // Invalid destination URL scheme is rejected
         VmSendMigrationData::parse("destination_url=file:///tmp/migration").unwrap_err();
+        assert!(matches!(
+            VmSendMigrationData::parse("destination_url=tcp:192.168.1.1").unwrap_err(),
+            VmSendMigrationConfigError::InvalidDestinationUrl(TcpAddressParseError::MissingPort)
+        ));
+        assert!(matches!(
+            VmSendMigrationData::parse("destination_url=tcp:[2001:db8::1]").unwrap_err(),
+            VmSendMigrationConfigError::InvalidDestinationUrl(
+                TcpAddressParseError::MissingPortSeparatorAfterBracketedHost
+            )
+        ));
 
         // Local migration requires a UNIX socket destination
         VmSendMigrationData::parse("destination_url=tcp:192.168.1.1:8080,local=yes").unwrap_err();

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -46,6 +46,7 @@ use option_parser::{OptionParser, OptionParserError, Toggle};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vm_migration::MigratableError;
+use vm_migration::tls::{TlsEndpoint, validate_tls_dir};
 use vmm_sys_util::eventfd::EventFd;
 
 #[cfg(feature = "dbus_api")]
@@ -342,6 +343,14 @@ impl VmReceiveMigrationData {
             ));
         }
 
+        if let Some(tls_dir) = &self.tls_dir {
+            validate_tls_dir(tls_dir, TlsEndpoint::Server).map_err(|e| {
+                VmReceiveMigrationConfigError::ValidationError(format!(
+                    "invalid TLS configuration for receive-migration: {e}"
+                ))
+            })?;
+        }
+
         Ok(())
     }
 }
@@ -574,6 +583,14 @@ impl VmSendMigrationData {
                         .to_string(),
                 ));
             }
+        }
+
+        if let Some(tls_dir) = &self.tls_dir {
+            validate_tls_dir(tls_dir, TlsEndpoint::Client).map_err(|e| {
+                VmSendMigrationConfigError::ValidationError(format!(
+                    "invalid TLS configuration for send-migration: {e}"
+                ))
+            })?;
         }
 
         Ok(())
@@ -1849,7 +1866,52 @@ impl ApiAction for VmNmi {
 
 #[cfg(test)]
 mod unit_tests {
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{fs, process};
+
     use super::*;
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "cloud-hypervisor-api-{name}-{}-{unique}",
+                process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self { path }
+        }
+
+        fn add_file(&self, file_name: &str) {
+            fs::write(self.path.join(file_name), b"test").unwrap();
+        }
+
+        fn add_receive_tls_files(&self) {
+            self.add_file("ca-cert.pem");
+            self.add_file("server-cert.pem");
+            self.add_file("server-key.pem");
+        }
+
+        fn add_send_tls_files(&self) {
+            self.add_file("ca-cert.pem");
+            self.add_file("client-cert.pem");
+            self.add_file("client-key.pem");
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
 
     #[test]
     fn test_vm_receive_migration_data_parse() {
@@ -1872,19 +1934,28 @@ mod unit_tests {
         let data = VmReceiveMigrationData::parse("receiver_url=unix:/tmp/ch=migrate.sock").unwrap();
         assert_eq!(data.receiver_url, "unix:/tmp/ch=migrate.sock");
 
-        let tls_dir = std::env::temp_dir();
+        let tls_dir = TestDir::new("receive-tls");
+        tls_dir.add_receive_tls_files();
+        let tls_dir_path = tls_dir.path.clone();
         let data = VmReceiveMigrationData::parse(&format!(
             "receiver_url=tcp:192.168.1.1:8080,tls_dir={}",
-            tls_dir.display()
+            tls_dir_path.display()
         ))
         .unwrap();
         assert_eq!(
             data,
             VmReceiveMigrationData {
                 receiver_url: "tcp:192.168.1.1:8080".to_string(),
-                tls_dir: Some(tls_dir),
+                tls_dir: Some(tls_dir_path),
             }
         );
+
+        let tls_dir = TestDir::new("receive-empty-tls");
+        VmReceiveMigrationData::parse(&format!(
+            "receiver_url=tcp:192.168.1.1:8080,tls_dir={}",
+            tls_dir.path.display()
+        ))
+        .unwrap_err();
 
         VmReceiveMigrationData::parse("receiver_url=file:///tmp/migration").unwrap_err();
         VmReceiveMigrationData::parse("receiver_url=tcp:192.168.1.1").unwrap_err();
@@ -1995,9 +2066,11 @@ mod unit_tests {
         );
 
         // Happy path, fully specified
-        let tls_dir = std::env::temp_dir();
+        let tls_dir = TestDir::new("send-tls");
+        tls_dir.add_send_tls_files();
+        let tls_dir_path = tls_dir.path.clone();
         let data =
-            VmSendMigrationData::parse(&format!("destination_url=tcp:192.168.1.1:8080,downtime_ms=150,timeout_s=900,timeout_strategy=ignore,connections=4,tls_dir={}", tls_dir.display()))
+            VmSendMigrationData::parse(&format!("destination_url=tcp:192.168.1.1:8080,downtime_ms=150,timeout_s=900,timeout_strategy=ignore,connections=4,tls_dir={}", tls_dir_path.display()))
                 .unwrap();
         assert_eq!(
             data,
@@ -2008,7 +2081,7 @@ mod unit_tests {
                 timeout_s: NonZeroU64::new(900).unwrap(),
                 timeout_strategy: TimeoutStrategy::Ignore,
                 connections: NonZeroU32::new(4).unwrap(),
-                tls_dir: Some(tls_dir),
+                tls_dir: Some(tls_dir_path),
             }
         );
     }

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -270,9 +270,80 @@ pub struct VmCoredumpData {
 }
 
 #[derive(Clone, Deserialize, Serialize, Default, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct VmReceiveMigrationData {
     /// URL for the reception of migration state
     pub receiver_url: String,
+    /// Directory containing the TLS server certificate (server-cert.pem), the TLS server key (server-key.pem), and the client TLS root CA certificate (ca-cert.pem).
+    #[serde(default)]
+    pub tls_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Error)]
+pub enum VmReceiveMigrationConfigError {
+    #[error("Error parsing receive migration parameters")]
+    ParseError(#[source] OptionParserError),
+
+    #[error("Error validating receive migration parameters")]
+    ValidationError(String),
+}
+
+impl VmReceiveMigrationData {
+    pub const SYNTAX: &'static str = "VM receive migration parameters \
+        \"<receiver_url>\" or \"receiver_url=<url>[,tls_dir=<path>]\"";
+
+    pub fn parse(migration: &str) -> Result<Self, VmReceiveMigrationConfigError> {
+        let mut parser = OptionParser::new();
+        parser.add("receiver_url").add("tls_dir");
+        parser
+            .parse(migration)
+            .map_err(VmReceiveMigrationConfigError::ParseError)?;
+
+        let receiver_url = parser.get("receiver_url").ok_or_else(|| {
+            VmReceiveMigrationConfigError::ParseError(OptionParserError::InvalidSyntax(
+                "receiver_url is required".to_string(),
+            ))
+        })?;
+        let tls_dir = parser
+            .convert::<String>("tls_dir")
+            .map_err(VmReceiveMigrationConfigError::ParseError)?
+            .map(|path| PathBuf::from(&path));
+
+        let data = Self {
+            receiver_url,
+            tls_dir,
+        };
+
+        data.validate()?;
+
+        Ok(data)
+    }
+
+    pub fn validate(&self) -> Result<(), VmReceiveMigrationConfigError> {
+        if let Some(addr) = self.receiver_url.strip_prefix("tcp:") {
+            tcp_address_to_server_name(addr).map_err(|e| {
+                VmReceiveMigrationConfigError::ValidationError(format!(
+                    "receiver_url must use tcp:<host>:<port> or unix:<path>: {e}."
+                ))
+            })?;
+        } else if self
+            .receiver_url
+            .strip_prefix("unix:")
+            .is_some_and(|path| !path.is_empty())
+        {
+            if self.tls_dir.is_some() {
+                return Err(VmReceiveMigrationConfigError::ValidationError(
+                    "UNIX sockets and TLS encryption cannot be used at the same time.".to_string(),
+                ));
+            }
+        } else {
+            return Err(VmReceiveMigrationConfigError::ValidationError(
+                "receiver_url must use tcp:<host>:<port> or unix:<path>.".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Copy, Clone, Default, Deserialize, Serialize, Debug, PartialEq, Eq)]
@@ -1779,6 +1850,47 @@ impl ApiAction for VmNmi {
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+
+    #[test]
+    fn test_vm_receive_migration_data_parse() {
+        let data = VmReceiveMigrationData::parse("receiver_url=tcp:192.168.1.1:8080").unwrap();
+        assert_eq!(
+            data,
+            VmReceiveMigrationData {
+                receiver_url: "tcp:192.168.1.1:8080".to_string(),
+                tls_dir: None,
+            }
+        );
+
+        let data = VmReceiveMigrationData::parse("receiver_url=tcp:[2001:db8::1]:8080").unwrap();
+        assert_eq!(data.receiver_url, "tcp:[2001:db8::1]:8080");
+
+        let data =
+            VmReceiveMigrationData::parse("receiver_url=tcp:destination.example:8080").unwrap();
+        assert_eq!(data.receiver_url, "tcp:destination.example:8080");
+
+        let data = VmReceiveMigrationData::parse("receiver_url=unix:/tmp/ch=migrate.sock").unwrap();
+        assert_eq!(data.receiver_url, "unix:/tmp/ch=migrate.sock");
+
+        let tls_dir = std::env::temp_dir();
+        let data = VmReceiveMigrationData::parse(&format!(
+            "receiver_url=tcp:192.168.1.1:8080,tls_dir={}",
+            tls_dir.display()
+        ))
+        .unwrap();
+        assert_eq!(
+            data,
+            VmReceiveMigrationData {
+                receiver_url: "tcp:192.168.1.1:8080".to_string(),
+                tls_dir: Some(tls_dir),
+            }
+        );
+
+        VmReceiveMigrationData::parse("receiver_url=file:///tmp/migration").unwrap_err();
+        VmReceiveMigrationData::parse("receiver_url=tcp:192.168.1.1").unwrap_err();
+        VmReceiveMigrationData::parse("receiver_url=tcp:[2001:db8::1]").unwrap_err();
+        VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,tls_dir=/tmp").unwrap_err();
+    }
 
     #[test]
     fn test_vm_send_migration_data_parse() {

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1421,6 +1421,11 @@ components:
             The number of parallel TCP connections to use for migration.
             Must be between 1 and 128. Multiple connections are not supported
             with local UNIX-socket migration.
+        tls_dir:
+          type: string
+          description: >
+            Directory containing the TLS root CA certificate (ca-cert.pem).
+            TLS is only supported with tcp:<host>:<port> destination URLs.
 
     VmAddUserDevice:
       required:

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1374,6 +1374,12 @@ components:
       properties:
         receiver_url:
           type: string
+        tls_dir:
+          type: string
+          description: >
+            Directory containing the TLS server certificate (server-cert.pem)
+            and TLS server key (server-key.pem). TLS is only supported with
+            tcp:<host>:<port> receiver URLs.
 
     TimeoutStrategy:
       type: string

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1506,6 +1506,12 @@ components:
       properties:
         receiver_url:
           type: string
+        tls_dir:
+          type: string
+          description: >
+            Directory containing the TLS server certificate (server-cert.pem), the TLS
+            server key (server-key.pem), and the client TLS root CA certificate (ca-cert.pem).
+            TLS is only supported with tcp:<host>:<port> receiver URLs.
 
     TimeoutStrategy:
       type: string

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1553,6 +1553,12 @@ components:
             The number of parallel TCP connections to use for migration.
             Must be between 1 and 128. Multiple connections are not supported
             with local UNIX-socket migration.
+        tls_dir:
+          type: string
+          description: >
+            Directory containing the TLS root CA certificate (ca-cert.pem), the TLS client
+            certificate (client-cert.pem), and TLS client key (client-key.pem).
+            TLS is only supported with tcp:<host>:<port> destination URLs.
 
     VmAddUserDevice:
       required:

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1171,7 +1171,7 @@ impl Vmm {
                 MigratableError::MigrateReceive(anyhow!("Failed restoring the Vm: {e}"))
             })?;
 
-            Ok(vm)
+            Ok::<Vm, MigratableError>(vm)
         })?;
 
         self.vm = Some(vm);

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1385,8 +1385,10 @@ impl Vmm {
         let mut ctx = OngoingMigrationContext::new();
 
         // Set up the socket connection
-        let mut socket =
-            migration_transport::send_migration_socket(&send_data_migration.destination_url)?;
+        let mut socket = migration_transport::send_migration_socket(
+            &send_data_migration.destination_url,
+            send_data_migration.tls_dir.as_deref(),
+        )?;
 
         // Start the migration
         migration_transport::send_request_expect_ok(
@@ -1463,6 +1465,7 @@ impl Vmm {
             let mut mem_send = migration_transport::SendAdditionalConnections::new(
                 &send_data_migration.destination_url,
                 send_data_migration.connections,
+                send_data_migration.tls_dir.as_deref(),
                 &vm.guest_memory(),
             )?;
 
@@ -2478,13 +2481,21 @@ impl RequestHandler for Vmm {
         &mut self,
         receive_data_migration: VmReceiveMigrationData,
     ) -> result::Result<(), MigratableError> {
+        receive_data_migration
+            .validate()
+            .context("Invalid receive migration configuration")
+            .map_err(MigratableError::MigrateReceive)?;
+
         info!(
-            "Receiving migration: receiver_url = {}",
-            receive_data_migration.receiver_url
+            "Receiving migration: receiver_url={},tls={}",
+            receive_data_migration.receiver_url,
+            receive_data_migration.tls_dir.is_some()
         );
 
-        let mut listener =
-            migration_transport::receive_migration_listener(&receive_data_migration.receiver_url)?;
+        let mut listener = migration_transport::receive_migration_listener(
+            &receive_data_migration.receiver_url,
+            receive_data_migration.tls_dir.as_deref(),
+        )?;
         // Accept the connection and get the socket
         let mut socket = listener.accept()?;
 
@@ -2540,9 +2551,10 @@ impl RequestHandler for Vmm {
             .map_err(MigratableError::MigrateSend)?;
 
         info!(
-            "Sending migration: destination_url={},local={},downtime={}ms,timeout={}s,timeout_strategy={:?}",
+            "Sending migration: destination_url={},local={},tls={},downtime={}ms,timeout={}s,timeout_strategy={:?}",
             send_data_migration.destination_url,
             send_data_migration.local,
+            send_data_migration.tls_dir.is_some(),
             send_data_migration.downtime().as_millis(),
             send_data_migration.timeout().as_secs(),
             send_data_migration.timeout_strategy

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1430,9 +1430,9 @@ impl Vmm {
                     // Proceed with sending memory file descriptors over UNIX socket
                     vm.send_memory_fds(unix_socket)?;
                 }
-                SocketStream::Tcp(_tcp_socket) => {
+                _ => {
                     return Err(MigratableError::MigrateSend(anyhow!(
-                        "--local option is not supported with TCP sockets",
+                        "--local option is only supported with UNIX sockets",
                     )));
                 }
             }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1466,9 +1466,9 @@ impl Vmm {
                     // Proceed with sending memory file descriptors over UNIX socket
                     vm.send_memory_fds(unix_socket)?;
                 }
-                SocketStream::Tcp(_tcp_socket) => {
+                _ => {
                     return Err(MigratableError::MigrateSend(anyhow!(
-                        "--local option is not supported with TCP sockets",
+                        "--local option is only supported with UNIX sockets",
                     )));
                 }
             }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1411,8 +1411,10 @@ impl Vmm {
         let mut ctx = OngoingMigrationContext::new();
 
         // Set up the socket connection
-        let mut socket =
-            migration_transport::send_migration_socket(&send_data_migration.destination_url)?;
+        let mut socket = migration_transport::send_migration_socket(
+            &send_data_migration.destination_url,
+            send_data_migration.tls_dir.as_deref(),
+        )?;
 
         // Start the migration
         migration_transport::send_request_expect_ok(
@@ -1501,6 +1503,7 @@ impl Vmm {
             let mut mem_send = migration_transport::SendAdditionalConnections::new(
                 &send_data_migration.destination_url,
                 send_data_migration.connections,
+                send_data_migration.tls_dir.as_deref(),
                 &vm.guest_memory(),
             )?;
 
@@ -2531,13 +2534,21 @@ impl RequestHandler for Vmm {
         &mut self,
         receive_data_migration: VmReceiveMigrationData,
     ) -> result::Result<(), MigratableError> {
+        receive_data_migration
+            .validate()
+            .context("Invalid receive migration configuration")
+            .map_err(MigratableError::MigrateReceive)?;
+
         info!(
-            "Receiving migration: receiver_url = {}",
-            receive_data_migration.receiver_url
+            "Receiving migration: receiver_url={},tls={}",
+            receive_data_migration.receiver_url,
+            receive_data_migration.tls_dir.is_some()
         );
 
-        let mut listener =
-            migration_transport::receive_migration_listener(&receive_data_migration.receiver_url)?;
+        let mut listener = migration_transport::receive_migration_listener(
+            &receive_data_migration.receiver_url,
+            receive_data_migration.tls_dir.as_deref(),
+        )?;
 
         event!("vm", "migration-receive-ready");
 
@@ -2596,9 +2607,10 @@ impl RequestHandler for Vmm {
             .map_err(MigratableError::MigrateSend)?;
 
         info!(
-            "Sending migration: destination_url={},local={},downtime={}ms,timeout={}s,timeout_strategy={:?}",
+            "Sending migration: destination_url={},local={},tls={},downtime={}ms,timeout={}s,timeout_strategy={:?}",
             send_data_migration.destination_url,
             send_data_migration.local,
+            send_data_migration.tls_dir.is_some(),
             send_data_migration.downtime().as_millis(),
             send_data_migration.timeout().as_secs(),
             send_data_migration.timeout_strategy

--- a/vmm/src/migration_transport.rs
+++ b/vmm/src/migration_transport.rs
@@ -26,6 +26,7 @@ use vm_memory::{
     VolatileSlice, WriteVolatile,
 };
 use vm_migration::protocol::{Command, MemoryRangeTable, Request, Response};
+use vm_migration::tls::TlsStream;
 use vm_migration::{MigratableError, Snapshot};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -107,6 +108,7 @@ impl AsFd for ReceiveListener {
 pub(crate) enum SocketStream {
     Unix(UnixStream),
     Tcp(TcpStream),
+    Tls(Box<TlsStream>),
 }
 
 impl Read for SocketStream {
@@ -114,6 +116,7 @@ impl Read for SocketStream {
         match self {
             SocketStream::Unix(stream) => stream.read(buf),
             SocketStream::Tcp(stream) => stream.read(buf),
+            SocketStream::Tls(stream) => stream.read(buf),
         }
     }
 }
@@ -123,6 +126,7 @@ impl Write for SocketStream {
         match self {
             SocketStream::Unix(stream) => stream.write(buf),
             SocketStream::Tcp(stream) => stream.write(buf),
+            SocketStream::Tls(stream) => stream.write(buf),
         }
     }
 
@@ -130,6 +134,7 @@ impl Write for SocketStream {
         match self {
             SocketStream::Unix(stream) => stream.flush(),
             SocketStream::Tcp(stream) => stream.flush(),
+            SocketStream::Tls(stream) => stream.flush(),
         }
     }
 }
@@ -139,6 +144,7 @@ impl AsFd for SocketStream {
         match self {
             SocketStream::Unix(s) => s.as_fd(),
             SocketStream::Tcp(s) => s.as_fd(),
+            SocketStream::Tls(s) => s.as_fd(),
         }
     }
 }
@@ -151,6 +157,7 @@ impl ReadVolatile for SocketStream {
         match self {
             SocketStream::Unix(s) => s.read_volatile(buf),
             SocketStream::Tcp(s) => s.read_volatile(buf),
+            SocketStream::Tls(s) => s.read_volatile(buf),
         }
     }
 }
@@ -163,6 +170,7 @@ impl WriteVolatile for SocketStream {
         match self {
             SocketStream::Unix(s) => s.write_volatile(buf),
             SocketStream::Tcp(s) => s.write_volatile(buf),
+            SocketStream::Tls(s) => s.write_volatile(buf),
         }
     }
 }

--- a/vmm/src/migration_transport.rs
+++ b/vmm/src/migration_transport.rs
@@ -9,7 +9,7 @@ use std::num::NonZeroU32;
 use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::result::Result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender, SyncSender, TrySendError, channel, sync_channel};
@@ -507,6 +507,7 @@ impl SendAdditionalConnections {
     pub(crate) fn new(
         destination: &str,
         connections: NonZeroU32,
+        tls_dir: Option<&Path>,
         guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
     ) -> Result<Self, MigratableError> {
         let mut threads = Vec::new();
@@ -533,7 +534,7 @@ impl SendAdditionalConnections {
         // the memory chunks to the workers, but does not send memory anymore. Thus in
         // this case we create one additional thread for each connection.
         for n in 0..configured_connections {
-            let mut socket = send_migration_socket(destination)?;
+            let mut socket = send_migration_socket(destination, tls_dir)?;
             let guest_memory = guest_memory.clone();
             let message_rx = message_rx.clone();
             let worker_error = worker_error.clone();
@@ -779,9 +780,40 @@ fn socket_url_to_path(url: &str) -> Result<PathBuf, anyhow::Error> {
         .map(|s| s.into())
 }
 
+/// Extract the server name from a TCP address. This function assumes that
+/// `tcp:` has already been stripped.
+fn tcp_address_to_server_name(address: &str) -> Result<&str, anyhow::Error> {
+    if let Some(rest) = address.strip_prefix('[') {
+        let (host, port) = rest
+            .split_once(']')
+            .ok_or_else(|| anyhow!("Could not extract host from TCP address: {address}"))?;
+
+        if host.is_empty() || !port.starts_with(':') || port.len() == 1 {
+            return Err(anyhow!(
+                "Could not extract host from TCP address: {address}"
+            ));
+        }
+
+        Ok(host)
+    } else {
+        let (host, port) = address
+            .rsplit_once(':')
+            .ok_or_else(|| anyhow!("Could not extract host from TCP address: {address}"))?;
+
+        if host.is_empty() || port.is_empty() {
+            return Err(anyhow!(
+                "Could not extract host from TCP address: {address}"
+            ));
+        }
+
+        Ok(host)
+    }
+}
+
 /// Connect to a migration endpoint and return the established stream.
 pub(crate) fn send_migration_socket(
     destination_url: &str,
+    tls_dir: Option<&Path>,
 ) -> Result<SocketStream, MigratableError> {
     if let Some(address) = destination_url.strip_prefix("tcp:") {
         info!("Connecting to TCP socket at {address}");
@@ -790,7 +822,18 @@ pub(crate) fn send_migration_socket(
             MigratableError::MigrateSend(anyhow!("Error connecting to TCP socket: {e}"))
         })?;
 
-        Ok(SocketStream::Tcp(socket))
+        if let Some(tls_dir) = tls_dir {
+            let server_name = tcp_address_to_server_name(address)
+                .context("Error extracting TLS server name from destination URL")
+                .map_err(MigratableError::MigrateSend)?;
+            TlsStream::new_client(socket, tls_dir, server_name)
+                .map(Box::new)
+                .map(SocketStream::Tls)
+                .context("Error creating TLS migration stream")
+                .map_err(MigratableError::MigrateSend)
+        } else {
+            Ok(SocketStream::Tcp(socket))
+        }
     } else {
         let path = socket_url_to_path(destination_url).map_err(MigratableError::MigrateSend)?;
         info!("Connecting to UNIX socket at {path:?}");
@@ -806,12 +849,21 @@ pub(crate) fn send_migration_socket(
 /// Bind a migration listener for the receiver side.
 pub(crate) fn receive_migration_listener(
     receiver_url: &str,
+    tls_dir: Option<&Path>,
 ) -> Result<ReceiveListener, MigratableError> {
     if let Some(address) = receiver_url.strip_prefix("tcp:") {
-        TcpListener::bind(address)
-            .map(ReceiveListener::Tcp)
+        let listener = TcpListener::bind(address)
             .context("Error binding to TCP socket")
-            .map_err(MigratableError::MigrateReceive)
+            .map_err(MigratableError::MigrateReceive)?;
+
+        if let Some(tls_dir) = tls_dir {
+            let config = TlsServerConfig::new(tls_dir)
+                .context("Error creating TLS server config")
+                .map_err(MigratableError::MigrateReceive)?;
+            Ok(ReceiveListener::Tls(listener, config))
+        } else {
+            Ok(ReceiveListener::Tcp(listener))
+        }
     } else {
         let path = socket_url_to_path(receiver_url).map_err(MigratableError::MigrateReceive)?;
         UnixListener::bind(&path)
@@ -971,4 +1023,33 @@ pub(crate) fn receive_memory_ranges(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tcp_address_to_server_name;
+
+    #[test]
+    fn test_tcp_address_to_server_name() {
+        assert_eq!(
+            tcp_address_to_server_name("example.com:1234").unwrap(),
+            "example.com"
+        );
+        assert_eq!(
+            tcp_address_to_server_name("192.0.2.1:1234").unwrap(),
+            "192.0.2.1"
+        );
+        assert_eq!(
+            tcp_address_to_server_name("[2001:db8::1]:1234").unwrap(),
+            "2001:db8::1"
+        );
+    }
+
+    #[test]
+    fn test_tcp_address_to_server_name_rejects_invalid_addresses() {
+        tcp_address_to_server_name("example.com").unwrap_err();
+        tcp_address_to_server_name(":1234").unwrap_err();
+        tcp_address_to_server_name("[2001:db8::1]").unwrap_err();
+        tcp_address_to_server_name("[2001:db8::1]1234").unwrap_err();
+    }
 }

--- a/vmm/src/migration_transport.rs
+++ b/vmm/src/migration_transport.rs
@@ -153,16 +153,6 @@ impl ReadVolatile for SocketStream {
             SocketStream::Tcp(s) => s.read_volatile(buf),
         }
     }
-
-    fn read_exact_volatile<B: BitmapSlice>(
-        &mut self,
-        buf: &mut VolatileSlice<B>,
-    ) -> Result<(), VolatileMemoryError> {
-        match self {
-            SocketStream::Unix(s) => s.read_exact_volatile(buf),
-            SocketStream::Tcp(s) => s.read_exact_volatile(buf),
-        }
-    }
 }
 
 impl WriteVolatile for SocketStream {
@@ -173,16 +163,6 @@ impl WriteVolatile for SocketStream {
         match self {
             SocketStream::Unix(s) => s.write_volatile(buf),
             SocketStream::Tcp(s) => s.write_volatile(buf),
-        }
-    }
-
-    fn write_all_volatile<B: BitmapSlice>(
-        &mut self,
-        buf: &VolatileSlice<B>,
-    ) -> Result<(), VolatileMemoryError> {
-        match self {
-            SocketStream::Unix(s) => s.write_all_volatile(buf),
-            SocketStream::Tcp(s) => s.write_all_volatile(buf),
         }
     }
 }

--- a/vmm/src/migration_transport.rs
+++ b/vmm/src/migration_transport.rs
@@ -26,7 +26,7 @@ use vm_memory::{
     VolatileSlice, WriteVolatile,
 };
 use vm_migration::protocol::{Command, MemoryRangeTable, Request, Response};
-use vm_migration::tls::TlsStream;
+use vm_migration::tls::{TlsServerConfig, TlsStream};
 use vm_migration::{MigratableError, Snapshot};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -42,6 +42,7 @@ pub(crate) const MAX_MIGRATION_CONNECTIONS: u32 = 128;
 pub(crate) enum ReceiveListener {
     Tcp(TcpListener),
     Unix(UnixListener),
+    Tls(TcpListener, TlsServerConfig),
 }
 
 impl ReceiveListener {
@@ -57,6 +58,15 @@ impl ReceiveListener {
                 .accept()
                 .map(|(socket, _)| SocketStream::Unix(socket))
                 .context("Failed to accept Unix migration connection")
+                .map_err(MigratableError::MigrateReceive),
+            ReceiveListener::Tls(listener, config) => listener
+                .accept()
+                .map(|(socket, _)| TlsStream::new_server(socket, config))
+                .context("Failed to accept TCP connection")
+                .map_err(MigratableError::MigrateReceive)?
+                .map(Box::new)
+                .map(SocketStream::Tls)
+                .context("Failed to accept TLS migration connection")
                 .map_err(MigratableError::MigrateReceive),
         }
     }
@@ -91,6 +101,11 @@ impl ReceiveListener {
                 .map(ReceiveListener::Unix)
                 .context("Failed to clone Unix listener")
                 .map_err(MigratableError::MigrateReceive),
+            ReceiveListener::Tls(listener, config) => listener
+                .try_clone()
+                .map(|listener| ReceiveListener::Tls(listener, config.clone()))
+                .context("Failed to clone Unix listener")
+                .map_err(MigratableError::MigrateReceive),
         }
     }
 }
@@ -100,6 +115,7 @@ impl AsFd for ReceiveListener {
         match self {
             ReceiveListener::Tcp(listener) => listener.as_fd(),
             ReceiveListener::Unix(listener) => listener.as_fd(),
+            ReceiveListener::Tls(listener, _) => listener.as_fd(),
         }
     }
 }

--- a/vmm/src/migration_transport.rs
+++ b/vmm/src/migration_transport.rs
@@ -7,7 +7,7 @@ use std::io::{self, ErrorKind, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::num::NonZeroU32;
 use std::os::fd::{AsFd, BorrowedFd};
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::result::Result;
@@ -130,15 +130,6 @@ impl Write for SocketStream {
         match self {
             SocketStream::Unix(stream) => stream.flush(),
             SocketStream::Tcp(stream) => stream.flush(),
-        }
-    }
-}
-
-impl AsRawFd for SocketStream {
-    fn as_raw_fd(&self) -> RawFd {
-        match self {
-            SocketStream::Unix(s) => s.as_raw_fd(),
-            SocketStream::Tcp(s) => s.as_raw_fd(),
         }
     }
 }

--- a/vmm/src/migration_transport.rs
+++ b/vmm/src/migration_transport.rs
@@ -26,7 +26,7 @@ use vm_memory::{
     VolatileSlice, WriteVolatile,
 };
 use vm_migration::protocol::{Command, MemoryRangeTable, Request, Response};
-use vm_migration::tls::TlsStream;
+use vm_migration::tls::{TlsServerConfig, TlsStream};
 use vm_migration::{MigratableError, Snapshot};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -42,6 +42,7 @@ pub(crate) const MAX_MIGRATION_CONNECTIONS: u32 = 128;
 pub(crate) enum ReceiveListener {
     Tcp(TcpListener),
     Unix(UnixListener),
+    Tls(TcpListener, TlsServerConfig),
 }
 
 impl ReceiveListener {
@@ -58,6 +59,18 @@ impl ReceiveListener {
                 .map(|(socket, _)| SocketStream::Unix(socket))
                 .context("Failed to accept Unix migration connection")
                 .map_err(MigratableError::MigrateReceive),
+            ReceiveListener::Tls(listener, config) => {
+                let (socket, _) = listener
+                    .accept()
+                    .context("Failed to accept TCP connection")
+                    .map_err(MigratableError::MigrateReceive)?;
+
+                TlsStream::new_server(socket, config)
+                    .map(Box::new)
+                    .map(SocketStream::Tls)
+                    .context("Failed to accept TLS migration connection")
+                    .map_err(MigratableError::MigrateReceive)
+            }
         }
     }
 
@@ -91,6 +104,11 @@ impl ReceiveListener {
                 .map(ReceiveListener::Unix)
                 .context("Failed to clone Unix listener")
                 .map_err(MigratableError::MigrateReceive),
+            ReceiveListener::Tls(listener, config) => listener
+                .try_clone()
+                .map(|listener| ReceiveListener::Tls(listener, config.clone()))
+                .context("Failed to clone TLS listener")
+                .map_err(MigratableError::MigrateReceive),
         }
     }
 }
@@ -100,6 +118,7 @@ impl AsFd for ReceiveListener {
         match self {
             ReceiveListener::Tcp(listener) => listener.as_fd(),
             ReceiveListener::Unix(listener) => listener.as_fd(),
+            ReceiveListener::Tls(listener, _) => listener.as_fd(),
         }
     }
 }

--- a/vmm/src/migration_transport.rs
+++ b/vmm/src/migration_transport.rs
@@ -9,7 +9,7 @@ use std::num::{NonZeroU32, ParseIntError};
 use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::result::Result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender, SyncSender, TrySendError, channel, sync_channel};
@@ -511,6 +511,7 @@ impl SendAdditionalConnections {
     pub(crate) fn new(
         destination: &str,
         connections: NonZeroU32,
+        tls_dir: Option<&Path>,
         guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
     ) -> Result<Self, MigratableError> {
         let mut threads = Vec::new();
@@ -537,7 +538,7 @@ impl SendAdditionalConnections {
         // the memory chunks to the workers, but does not send memory anymore. Thus in
         // this case we create one additional thread for each connection.
         for n in 0..configured_connections {
-            let mut socket = send_migration_socket(destination)?;
+            let mut socket = send_migration_socket(destination, tls_dir)?;
             let guest_memory = guest_memory.clone();
             let message_rx = message_rx.clone();
             let worker_error = worker_error.clone();
@@ -852,6 +853,7 @@ pub fn tcp_address_to_server_name(address: &str) -> Result<&str, TcpAddressParse
 /// Connect to a migration endpoint and return the established stream.
 pub(crate) fn send_migration_socket(
     destination_url: &str,
+    tls_dir: Option<&Path>,
 ) -> Result<SocketStream, MigratableError> {
     if let Some(address) = destination_url.strip_prefix("tcp:") {
         info!("Connecting to TCP socket at {address}");
@@ -860,7 +862,19 @@ pub(crate) fn send_migration_socket(
             MigratableError::MigrateSend(anyhow!("Error connecting to TCP socket: {e}"))
         })?;
 
-        Ok(SocketStream::Tcp(socket))
+        if let Some(tls_dir) = tls_dir {
+            // The address should have been validated by the API using this exact function.
+            // Any error here has to be treated as a programming error.
+            let server_name = tcp_address_to_server_name(address)
+                .expect("TCP address should have been validated by the API");
+            TlsStream::new_client(socket, tls_dir, server_name)
+                .map(Box::new)
+                .map(SocketStream::Tls)
+                .context("Error creating TLS migration stream")
+                .map_err(MigratableError::MigrateSend)
+        } else {
+            Ok(SocketStream::Tcp(socket))
+        }
     } else {
         let path = socket_url_to_path(destination_url).map_err(MigratableError::MigrateSend)?;
         info!("Connecting to UNIX socket at {path:?}");
@@ -876,12 +890,21 @@ pub(crate) fn send_migration_socket(
 /// Bind a migration listener for the receiver side.
 pub(crate) fn receive_migration_listener(
     receiver_url: &str,
+    tls_dir: Option<&Path>,
 ) -> Result<ReceiveListener, MigratableError> {
     if let Some(address) = receiver_url.strip_prefix("tcp:") {
-        TcpListener::bind(address)
-            .map(ReceiveListener::Tcp)
+        let listener = TcpListener::bind(address)
             .context("Error binding to TCP socket")
-            .map_err(MigratableError::MigrateReceive)
+            .map_err(MigratableError::MigrateReceive)?;
+
+        if let Some(tls_dir) = tls_dir {
+            let config = TlsServerConfig::new(tls_dir)
+                .context("Error creating TLS server config")
+                .map_err(MigratableError::MigrateReceive)?;
+            Ok(ReceiveListener::Tls(listener, config))
+        } else {
+            Ok(ReceiveListener::Tcp(listener))
+        }
     } else {
         let path = socket_url_to_path(receiver_url).map_err(MigratableError::MigrateReceive)?;
         UnixListener::bind(&path)

--- a/vmm/src/migration_transport.rs
+++ b/vmm/src/migration_transport.rs
@@ -5,7 +5,7 @@
 
 use std::io::{self, ErrorKind, Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, ParseIntError};
 use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
@@ -20,6 +20,7 @@ use std::time::Duration;
 use anyhow::{Context, anyhow};
 use log::{debug, error, info, warn};
 use serde_json;
+use thiserror::Error;
 use vm_memory::bitmap::BitmapSlice;
 use vm_memory::{
     Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, ReadVolatile, VolatileMemoryError,
@@ -782,6 +783,72 @@ fn socket_url_to_path(url: &str) -> Result<PathBuf, anyhow::Error> {
         .map(|s| s.into())
 }
 
+/// Errors that can occur when parsing a TCP address.
+#[derive(Debug, Error)]
+pub enum TcpAddressParseError {
+    #[error("Missing closing ']' for bracketed IPv6 address")]
+    MissingIpv6ClosingBracket,
+
+    #[error("Missing port separator after bracketed host")]
+    MissingPortSeparatorAfterBracketedHost,
+
+    #[error("Missing TCP port")]
+    MissingPort,
+
+    #[error("Host must not be empty")]
+    EmptyHost,
+
+    #[error("Port must not be empty")]
+    EmptyPort,
+
+    #[error("Invalid TCP port: {port}")]
+    InvalidPort {
+        port: String,
+        #[source]
+        source: ParseIntError,
+    },
+}
+
+/// Extract the server name from a TCP address. This function assumes that
+/// `tcp:` has already been stripped.
+///
+/// The expected format is `<host>:<port>` for hostnames and IPv4 addresses, or
+/// `[<ipv6-address>]:<port>` for IPv6 addresses. The host and port must both be
+/// present, and the port must parse as a `u16`.
+pub fn tcp_address_to_server_name(address: &str) -> Result<&str, TcpAddressParseError> {
+    let (host, port) = if let Some(rest) = address.strip_prefix('[') {
+        let (host, rest) = rest
+            .split_once(']')
+            .ok_or(TcpAddressParseError::MissingIpv6ClosingBracket)?;
+
+        let port = rest
+            .strip_prefix(':')
+            .ok_or(TcpAddressParseError::MissingPortSeparatorAfterBracketedHost)?;
+
+        (host, port)
+    } else {
+        address
+            .rsplit_once(':')
+            .ok_or(TcpAddressParseError::MissingPort)?
+    };
+
+    if host.is_empty() {
+        return Err(TcpAddressParseError::EmptyHost);
+    }
+
+    if port.is_empty() {
+        return Err(TcpAddressParseError::EmptyPort);
+    }
+
+    port.parse::<u16>()
+        .map_err(|source| TcpAddressParseError::InvalidPort {
+            port: port.to_owned(),
+            source,
+        })?;
+
+    Ok(host)
+}
+
 /// Connect to a migration endpoint and return the established stream.
 pub(crate) fn send_migration_socket(
     destination_url: &str,
@@ -974,4 +1041,79 @@ pub(crate) fn receive_memory_ranges(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tcp_address_to_server_name;
+
+    #[test]
+    fn test_tcp_address_to_server_name() {
+        assert_eq!(
+            tcp_address_to_server_name("example.com:1234").unwrap(),
+            "example.com"
+        );
+        assert_eq!(
+            tcp_address_to_server_name("192.0.2.1:1234").unwrap(),
+            "192.0.2.1"
+        );
+        assert_eq!(
+            tcp_address_to_server_name("[2001:db8::1]:1234").unwrap(),
+            "2001:db8::1"
+        );
+    }
+
+    #[test]
+    fn test_tcp_address_to_server_name_rejects_invalid_addresses() {
+        assert_eq!(
+            tcp_address_to_server_name("192.168.1.1")
+                .unwrap_err()
+                .to_string(),
+            "Missing TCP port"
+        );
+        assert_eq!(
+            tcp_address_to_server_name(":8080").unwrap_err().to_string(),
+            "Host must not be empty"
+        );
+        assert_eq!(
+            tcp_address_to_server_name("host:").unwrap_err().to_string(),
+            "Port must not be empty"
+        );
+        assert_eq!(
+            tcp_address_to_server_name("host:not-a-port")
+                .unwrap_err()
+                .to_string(),
+            "Invalid TCP port: not-a-port"
+        );
+        assert_eq!(
+            tcp_address_to_server_name("[2001:db8::1")
+                .unwrap_err()
+                .to_string(),
+            "Missing closing ']' for bracketed IPv6 address"
+        );
+        assert_eq!(
+            tcp_address_to_server_name("[]:8080")
+                .unwrap_err()
+                .to_string(),
+            "Host must not be empty"
+        );
+        assert_eq!(
+            tcp_address_to_server_name("[2001:db8::1]")
+                .unwrap_err()
+                .to_string(),
+            "Missing port separator after bracketed host"
+        );
+        assert_eq!(
+            tcp_address_to_server_name("[2001:db8::1]:")
+                .unwrap_err()
+                .to_string(),
+            "Port must not be empty"
+        );
+        assert_eq!(
+            tcp_address_to_server_name("[2001:db8::1]:99999")
+                .unwrap_err()
+                .to_string(),
+            "Invalid TCP port: 99999"
+        );
+    }
 }


### PR DESCRIPTION
This PR adds the option to encrypt live migration data using TLS (mTLS - mutual TLS).

The API is similar to what [Qemu](https://www.qemu.org/docs/master/system/tls.html) does: The user has to provide a path to a directory that contains the necessary certificates or keys. If any files are missing, Cloud Hypervisor will complain. The names of the files are hard coded: the TLS client (the side that does `send-migration`) expects a `ca-cert.pem` file, while the TLS server expects a `server-cert.pem` and a `server-key.pem`.