### PR TITLE
virtio-devices: Improve VIRTIO_F_ACCESS_PLATFORM handling

### DIFF
--- a/fuzz/fuzz_targets/balloon.rs
+++ b/fuzz/fuzz_targets/balloon.rs
@@ -49,6 +49,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
         BALLOON_SIZE,
         true,
         true,
+        false,
         SeccompAction::Allow,
         EventFd::new(EFD_NONBLOCK).unwrap(),
         None,

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -34,14 +34,15 @@ use vm_memory::{
     GuestMemoryError, GuestMemoryRegion,
 };
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
+use vm_virtio::{AccessPlatform, Translatable};
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::seccomp_filters::Thread;
 use crate::thread_helper::spawn_virtio_thread;
 use crate::{
     ActivateResult, EPOLL_HELPER_EVENT_LAST, EpollHelper, EpollHelperError, EpollHelperHandler,
-    GuestMemoryMmap, VIRTIO_F_VERSION_1, VirtioCommon, VirtioDevice, VirtioDeviceType,
-    VirtioInterrupt, VirtioInterruptType,
+    GuestMemoryMmap, VIRTIO_F_ACCESS_PLATFORM, VIRTIO_F_VERSION_1, VirtioCommon, VirtioDevice,
+    VirtioDeviceType, VirtioInterrupt, VirtioInterruptType,
 };
 
 const QUEUE_SIZE: u16 = 128;
@@ -160,6 +161,7 @@ struct BalloonEpollHandler {
     kill_evt: EventFd,
     pause_evt: EventFd,
     pbp: Option<PartiallyBalloonedPage>,
+    access_platform: Option<Arc<dyn AccessPlatform>>,
 }
 
 impl BalloonEpollHandler {
@@ -277,7 +279,12 @@ impl BalloonEpollHandler {
 
             let mut offset = 0u64;
             while offset < desc.len() as u64 {
-                let addr = desc.addr().checked_add(offset).unwrap();
+                let addr = desc
+                    .addr()
+                    .checked_add(offset)
+                    .unwrap()
+                    .translate_gva(self.access_platform.as_deref(), data_chunk_size)
+                    .map_err(|e| Error::GuestMemory(GuestMemoryError::IOError(e)))?;
                 let pfn: u32 = desc_chain
                     .memory()
                     .read_obj(addr)
@@ -324,7 +331,11 @@ impl BalloonEpollHandler {
             let mut descs_len = 0;
             while let Some(desc) = desc_chain.next() {
                 descs_len += desc.len();
-                Self::release_memory_range(desc_chain.memory(), desc.addr(), desc.len() as usize)?;
+                let addr = desc
+                    .addr()
+                    .translate_gva(self.access_platform.as_deref(), desc.len() as usize)
+                    .map_err(|e| Error::GuestMemory(GuestMemoryError::IOError(e)))?;
+                Self::release_memory_range(desc_chain.memory(), addr, desc.len() as usize)?;
             }
 
             self.queues[queue_index]
@@ -437,11 +448,13 @@ pub struct Balloon {
 
 impl Balloon {
     // Create a new virtio-balloon.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         size: u64,
         deflate_on_oom: bool,
         free_page_reporting: bool,
+        access_platform_enabled: bool,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
         state: Option<BalloonState>,
@@ -463,6 +476,9 @@ impl Balloon {
             }
             if free_page_reporting {
                 avail_features |= 1u64 << VIRTIO_BALLOON_F_REPORTING;
+            }
+            if access_platform_enabled {
+                avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
             }
 
             let config = VirtioBalloonConfig {
@@ -628,6 +644,7 @@ impl VirtioDevice for Balloon {
             kill_evt,
             pause_evt,
             pbp: None,
+            access_platform: self.common.access_platform(),
         };
 
         let paused = self.common.paused.clone();
@@ -646,6 +663,14 @@ impl VirtioDevice for Balloon {
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())
+    }
+
+    fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {
+        self.common.set_access_platform(access_platform);
+    }
+
+    fn access_platform(&self) -> Option<Arc<dyn AccessPlatform>> {
+        self.common.access_platform()
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -1140,7 +1140,7 @@ impl VirtioDevice for Block {
                     .map(|r| r.new_handle())
                     .transpose()
                     .unwrap(),
-                access_platform: self.common.access_platform.clone(),
+                access_platform: self.common.access_platform(),
                 host_cpus: self.queue_affinity.get(&queue_idx).cloned(),
                 acked_features: self.common.acked_features,
                 disable_sector0_writes: self.disable_sector0_writes,

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -734,7 +734,7 @@ impl Block {
         mut disk_image: DiskBackend,
         disk_path: PathBuf,
         read_only: bool,
-        iommu: bool,
+        access_platform_enabled: bool,
         num_queues: usize,
         queue_size: u16,
         serial: Option<String>,
@@ -793,7 +793,7 @@ impl Block {
                     warn!("sparse=on requested but backend does not support sparse operations");
                 }
 
-                if iommu {
+                if access_platform_enabled {
                     avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
                 }
 

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -1223,6 +1223,10 @@ impl VirtioDevice for Block {
     fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {
         self.common.set_access_platform(access_platform);
     }
+
+    fn access_platform(&self) -> Option<Arc<dyn AccessPlatform>> {
+        self.common.access_platform()
+    }
 }
 
 impl Pausable for Block {

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -751,7 +751,7 @@ impl VirtioDevice for Console {
             self.resize_pipe.as_ref().map(|p| p.try_clone().unwrap()),
             kill_evt,
             pause_evt,
-            self.common.access_platform.clone(),
+            self.common.access_platform(),
         );
 
         let paused = self.common.paused.clone();

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -782,6 +782,10 @@ impl VirtioDevice for Console {
     fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {
         self.common.set_access_platform(access_platform);
     }
+
+    fn access_platform(&self) -> Option<Arc<dyn AccessPlatform>> {
+        self.common.access_platform()
+    }
 }
 
 impl Pausable for Console {

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -602,7 +602,7 @@ impl Console {
         id: String,
         endpoint: Endpoint,
         resize_pipe: Option<File>,
-        iommu: bool,
+        access_platform_enabled: bool,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
         state: Option<ConsoleState>,
@@ -619,7 +619,7 @@ impl Console {
             )
         } else {
             let mut avail_features = (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_CONSOLE_F_SIZE);
-            if iommu {
+            if access_platform_enabled {
                 avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
             }
 

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -16,6 +16,7 @@ use std::thread;
 use anyhow::anyhow;
 use libc::EFD_NONBLOCK;
 use log::{error, info, warn};
+use virtio_bindings::virtio_config::VIRTIO_F_ACCESS_PLATFORM;
 use virtio_queue::Queue;
 use vm_device::UserspaceMapping;
 use vm_memory::{GuestAddress, GuestMemoryAtomic};
@@ -331,6 +332,15 @@ impl VirtioCommon {
         // Indirect descriptors feature is not supported when the device
         // requires the addresses held by the descriptors to be translated.
         self.avail_features &= !(1 << VIRTIO_F_RING_INDIRECT_DESC);
+    }
+
+    /// Returns the access platform only if the feature has been acked.
+    pub fn access_platform(&self) -> Option<Arc<dyn AccessPlatform>> {
+        if self.feature_acked(VIRTIO_F_ACCESS_PLATFORM as u64) {
+            self.access_platform.clone()
+        } else {
+            None
+        }
     }
 }
 

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -188,6 +188,12 @@ pub trait VirtioDevice: Send {
     /// Set the access platform trait to let the device perform address
     /// translations if needed.
     fn set_access_platform(&mut self, _access_platform: Arc<dyn AccessPlatform>) {}
+
+    /// Returns the access platform only if VIRTIO_F_ACCESS_PLATFORM was
+    /// negotiated with the guest.
+    fn access_platform(&self) -> Option<Arc<dyn AccessPlatform>> {
+        None
+    }
 }
 
 /// Trait to define address translation for devices managed by virtio-iommu

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -468,7 +468,7 @@ impl Net {
         id: String,
         taps: Vec<Tap>,
         guest_mac: Option<MacAddr>,
-        iommu: bool,
+        access_platform_enabled: bool,
         num_queues: usize,
         queue_size: u16,
         seccomp_action: SeccompAction,
@@ -499,7 +499,7 @@ impl Net {
                 | (1 << VIRTIO_RING_F_EVENT_IDX)
                 | (1 << VIRTIO_F_VERSION_1);
 
-            if iommu {
+            if access_platform_enabled {
                 avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
             }
 
@@ -587,7 +587,7 @@ impl Net {
         guest_mac: Option<MacAddr>,
         host_mac: &mut Option<MacAddr>,
         mtu: Option<u16>,
-        iommu: bool,
+        access_platform_enabled: bool,
         num_queues: usize,
         queue_size: u16,
         seccomp_action: SeccompAction,
@@ -613,7 +613,7 @@ impl Net {
             id,
             taps,
             guest_mac,
-            iommu,
+            access_platform_enabled,
             num_queues,
             queue_size,
             seccomp_action,
@@ -632,7 +632,7 @@ impl Net {
         fds: &[RawFd],
         guest_mac: Option<MacAddr>,
         mtu: Option<u16>,
-        iommu: bool,
+        access_platform_enabled: bool,
         queue_size: u16,
         seccomp_action: SeccompAction,
         rate_limiter_config: Option<RateLimiterConfig>,
@@ -666,7 +666,7 @@ impl Net {
             id,
             taps,
             guest_mac,
-            iommu,
+            access_platform_enabled,
             num_queue_pairs * 2,
             queue_size,
             seccomp_action,

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -900,6 +900,10 @@ impl VirtioDevice for Net {
     fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {
         self.common.set_access_platform(access_platform);
     }
+
+    fn access_platform(&self) -> Option<Arc<dyn AccessPlatform>> {
+        self.common.access_platform()
+    }
 }
 
 impl Pausable for Net {

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -765,7 +765,7 @@ impl VirtioDevice for Net {
                 ctrl_q: CtrlQueue::new(self.taps.clone()),
                 queue: ctrl_queue,
                 queue_evt: ctrl_queue_evt,
-                access_platform: self.common.access_platform.clone(),
+                access_platform: self.common.access_platform(),
                 queue_index: ctrl_queue_index as u16,
                 interrupt_cb: interrupt_cb.clone(),
             };
@@ -837,7 +837,7 @@ impl VirtioDevice for Net {
                     rx_desc_avail: false,
                     rx_rate_limiter,
                     tx_rate_limiter,
-                    access_platform: self.common.access_platform.clone(),
+                    access_platform: self.common.access_platform(),
                 },
                 mem: mem.clone(),
                 queue_index_base: (i * 2) as u16,

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -441,6 +441,10 @@ impl VirtioDevice for Pmem {
     fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {
         self.common.set_access_platform(access_platform);
     }
+
+    fn access_platform(&self) -> Option<Arc<dyn AccessPlatform>> {
+        self.common.access_platform()
+    }
 }
 
 impl Pausable for Pmem {

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -404,7 +404,7 @@ impl VirtioDevice for Pmem {
                 queue_evt,
                 kill_evt,
                 pause_evt,
-                access_platform: self.common.access_platform.clone(),
+                access_platform: self.common.access_platform(),
             };
 
             let paused = self.common.paused.clone();

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -287,7 +287,7 @@ impl Pmem {
         disk: File,
         addr: GuestAddress,
         mapping: UserspaceMapping,
-        iommu: bool,
+        access_platform_enabled: bool,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
         state: Option<PmemState>,
@@ -308,7 +308,7 @@ impl Pmem {
 
             let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;
 
-            if iommu {
+            if access_platform_enabled {
                 avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
             }
             (avail_features, 0, config, false)

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -169,7 +169,7 @@ impl Rng {
     pub fn new(
         id: String,
         path: &str,
-        iommu: bool,
+        access_platform_enabled: bool,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
         state: Option<RngState>,
@@ -182,7 +182,7 @@ impl Rng {
         } else {
             let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;
 
-            if iommu {
+            if access_platform_enabled {
                 avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
             }
 

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -273,7 +273,7 @@ impl VirtioDevice for Rng {
                 queue_evt,
                 kill_evt,
                 pause_evt,
-                access_platform: self.common.access_platform.clone(),
+                access_platform: self.common.access_platform(),
             };
 
             let paused = self.common.paused.clone();

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -305,6 +305,10 @@ impl VirtioDevice for Rng {
     fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {
         self.common.set_access_platform(access_platform);
     }
+
+    fn access_platform(&self) -> Option<Arc<dyn AccessPlatform>> {
+        self.common.access_platform()
+    }
 }
 
 impl Pausable for Rng {

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -14,7 +14,6 @@ use log::{debug, error, warn};
 use serde::{Deserialize, Serialize};
 use virtio_queue::{Queue, QueueT};
 use vm_migration::{MigratableError, Pausable, Snapshot, Snapshottable};
-use vm_virtio::AccessPlatform;
 
 use super::pci_device::VIRTQ_MSI_NO_VECTOR;
 use crate::VirtioDevice;
@@ -125,7 +124,7 @@ pub fn get_vring_size(t: VringType, queue_size: u16) -> u64 {
 ///    le64 queue_avail;               // 0x28 // read-write
 ///    le64 queue_used;                // 0x30 // read-write
 pub struct VirtioPciCommonConfig {
-    pub access_platform: Option<Arc<dyn AccessPlatform>>,
+    pub device: Arc<Mutex<dyn VirtioDevice>>,
     pub driver_status: Arc<AtomicU8>,
     pub config_generation: u8,
     pub device_feature_select: u32,
@@ -136,12 +135,9 @@ pub struct VirtioPciCommonConfig {
 }
 
 impl VirtioPciCommonConfig {
-    pub fn new(
-        state: VirtioPciCommonConfigState,
-        access_platform: Option<Arc<dyn AccessPlatform>>,
-    ) -> Self {
+    pub fn new(state: VirtioPciCommonConfigState, device: Arc<Mutex<dyn VirtioDevice>>) -> Self {
         VirtioPciCommonConfig {
-            access_platform,
+            device,
             driver_status: Arc::new(AtomicU8::new(state.driver_status)),
             config_generation: state.config_generation,
             device_feature_select: state.device_feature_select,
@@ -164,13 +160,7 @@ impl VirtioPciCommonConfig {
         }
     }
 
-    pub fn read(
-        &mut self,
-        offset: u64,
-        data: &mut [u8],
-        queues: &[Queue],
-        device: Arc<Mutex<dyn VirtioDevice>>,
-    ) {
+    pub fn read(&mut self, offset: u64, data: &mut [u8], queues: &[Queue]) {
         assert!(data.len() <= 8);
 
         match data.len() {
@@ -183,7 +173,7 @@ impl VirtioPciCommonConfig {
                 LittleEndian::write_u16(data, v);
             }
             4 => {
-                let v = self.read_common_config_dword(offset, device);
+                let v = self.read_common_config_dword(offset);
                 LittleEndian::write_u32(data, v);
             }
             8 => {
@@ -194,26 +184,14 @@ impl VirtioPciCommonConfig {
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn write(
-        &mut self,
-        offset: u64,
-        data: &[u8],
-        queues: &mut [Queue],
-        device: Arc<Mutex<dyn VirtioDevice>>,
-    ) {
+    pub fn write(&mut self, offset: u64, data: &[u8], queues: &mut [Queue]) {
         assert!(data.len() <= 8);
 
         match data.len() {
             1 => self.write_common_config_byte(offset, data[0]),
             2 => self.write_common_config_word(offset, LittleEndian::read_u16(data), queues),
             4 => {
-                self.write_common_config_dword(
-                    offset,
-                    LittleEndian::read_u32(data),
-                    queues,
-                    device,
-                );
+                self.write_common_config_dword(offset, LittleEndian::read_u32(data), queues);
             }
             8 => self.write_common_config_qword(offset, LittleEndian::read_u64(data), queues),
             _ => error!("invalid data length for virtio write: len {}", data.len()),
@@ -285,8 +263,12 @@ impl VirtioPciCommonConfig {
             0x1c => self.with_queue_mut(queues, |q| {
                 let ready = value == 1;
                 q.set_ready(ready);
-                // Translate address of descriptor table and vrings.
-                if ready && let Some(access_platform) = &self.access_platform {
+                let access_platform = if ready {
+                    self.device.lock().unwrap().access_platform()
+                } else {
+                    None
+                };
+                if let Some(access_platform) = access_platform {
                     let desc_table = match access_platform
                         .translate_gva(q.desc_table(), get_vring_size(VringType::Desc, q.size()))
                     {
@@ -337,15 +319,12 @@ impl VirtioPciCommonConfig {
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)]
-    fn read_common_config_dword(&self, offset: u64, device: Arc<Mutex<dyn VirtioDevice>>) -> u32 {
+    fn read_common_config_dword(&self, offset: u64) -> u32 {
         debug!("read_common_config_dword: offset 0x{offset:x}");
         match offset {
             0x00 => self.device_feature_select,
             0x04 => {
-                let locked_device = device.lock().unwrap();
-                // Only 64 bits of features (2 pages) are defined for now, so limit
-                // device_feature_select to avoid shifting by 64 or more bits.
+                let locked_device = self.device.lock().unwrap();
                 if self.device_feature_select < 2 {
                     (locked_device.features() >> (self.device_feature_select * 32)) as u32
                 } else {
@@ -360,14 +339,7 @@ impl VirtioPciCommonConfig {
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)]
-    fn write_common_config_dword(
-        &mut self,
-        offset: u64,
-        value: u32,
-        queues: &mut [Queue],
-        device: Arc<Mutex<dyn VirtioDevice>>,
-    ) {
+    fn write_common_config_dword(&mut self, offset: u64, value: u32, queues: &mut [Queue]) {
         debug!("write_common_config_dword: offset 0x{offset:x}");
 
         match offset {
@@ -375,7 +347,7 @@ impl VirtioPciCommonConfig {
             0x08 => self.driver_feature_select = value,
             0x0c => {
                 if self.driver_feature_select < 2 {
-                    let mut locked_device = device.lock().unwrap();
+                    let mut locked_device = self.device.lock().unwrap();
                     locked_device
                         .ack_features(u64::from(value) << (self.driver_feature_select * 32));
                 }
@@ -472,8 +444,9 @@ mod unit_tests {
 
     #[test]
     fn write_base_regs() {
+        let dev: Arc<Mutex<dyn VirtioDevice>> = Arc::new(Mutex::new(DummyDevice(0)));
         let mut regs = VirtioPciCommonConfig {
-            access_platform: None,
+            device: dev.clone(),
             driver_status: Arc::new(AtomicU8::new(0xaa)),
             config_generation: 0x55,
             device_feature_select: 0x0,
@@ -483,72 +456,69 @@ mod unit_tests {
             msix_queues: Arc::new(Mutex::new(vec![0; 3])),
         };
 
-        let dev = Arc::new(Mutex::new(DummyDevice(0)));
         let mut queues = Vec::new();
 
         // Can set all bits of driver_status.
-        regs.write(0x14, &[0x55], &mut queues, dev.clone());
+        regs.write(0x14, &[0x55], &mut queues);
         let mut read_back = vec![0x00];
-        regs.read(0x14, &mut read_back, &queues, dev.clone());
+        regs.read(0x14, &mut read_back, &queues);
         assert_eq!(read_back[0], 0x55);
 
         // The config generation register is read only.
-        regs.write(0x15, &[0xaa], &mut queues, dev.clone());
+        regs.write(0x15, &[0xaa], &mut queues);
         let mut read_back = vec![0x00];
-        regs.read(0x15, &mut read_back, &queues, dev.clone());
+        regs.read(0x15, &mut read_back, &queues);
         assert_eq!(read_back[0], 0x55);
 
         // Device features is read-only and passed through from the device.
-        regs.write(0x04, &[0, 0, 0, 0], &mut queues, dev.clone());
+        regs.write(0x04, &[0, 0, 0, 0], &mut queues);
         let mut read_back = vec![0, 0, 0, 0];
-        regs.read(0x04, &mut read_back, &queues, dev.clone());
+        regs.read(0x04, &mut read_back, &queues);
         assert_eq!(LittleEndian::read_u32(&read_back), DUMMY_FEATURES as u32);
 
         // Feature select registers are read/write.
-        regs.write(0x00, &[1, 2, 3, 4], &mut queues, dev.clone());
+        regs.write(0x00, &[1, 2, 3, 4], &mut queues);
         let mut read_back = vec![0, 0, 0, 0];
-        regs.read(0x00, &mut read_back, &queues, dev.clone());
+        regs.read(0x00, &mut read_back, &queues);
         assert_eq!(LittleEndian::read_u32(&read_back), 0x0403_0201);
-        regs.write(0x08, &[1, 2, 3, 4], &mut queues, dev.clone());
+        regs.write(0x08, &[1, 2, 3, 4], &mut queues);
         let mut read_back = vec![0, 0, 0, 0];
-        regs.read(0x08, &mut read_back, &queues, dev.clone());
+        regs.read(0x08, &mut read_back, &queues);
         assert_eq!(LittleEndian::read_u32(&read_back), 0x0403_0201);
 
         // 'queue_select' can be read and written.
-        regs.write(0x16, &[0xaa, 0x55], &mut queues, dev.clone());
+        regs.write(0x16, &[0xaa, 0x55], &mut queues);
         let mut read_back = vec![0x00, 0x00];
-        regs.read(0x16, &mut read_back, &queues, dev);
+        regs.read(0x16, &mut read_back, &queues);
         assert_eq!(read_back[0], 0xaa);
         assert_eq!(read_back[1], 0x55);
     }
 
     #[test]
     fn oob_queue_select_does_not_panic() {
-        // Regression test: reading/writing queue_msix_vector (offset 0x1a)
-        // with an out-of-bounds queue_select must not panic.
+        let dev: Arc<Mutex<dyn VirtioDevice>> = Arc::new(Mutex::new(DummyDevice(0)));
         let mut regs = VirtioPciCommonConfig {
-            access_platform: None,
+            device: dev.clone(),
             driver_status: Arc::new(AtomicU8::new(0)),
             config_generation: 0,
             device_feature_select: 0,
             driver_feature_select: 0,
             queue_select: 0,
             msix_config: Arc::new(AtomicU16::new(0)),
-            msix_queues: Arc::new(Mutex::new(vec![0; 1])), // only 1 queue
+            msix_queues: Arc::new(Mutex::new(vec![0; 1])),
         };
 
-        let dev = Arc::new(Mutex::new(DummyDevice(0)));
         let mut queues = vec![Queue::new(256).unwrap()];
 
         // Set queue_select to an out-of-bounds value.
-        regs.write(0x16, &[0xFF, 0xFF], &mut queues, dev.clone());
+        regs.write(0x16, &[0xFF, 0xFF], &mut queues);
 
         // Read queue_msix_vector — must not panic, should return VIRTQ_MSI_NO_VECTOR.
         let mut read_back = vec![0x00, 0x00];
-        regs.read(0x1a, &mut read_back, &queues, dev.clone());
+        regs.read(0x1a, &mut read_back, &queues);
         assert_eq!(LittleEndian::read_u16(&read_back), VIRTQ_MSI_NO_VECTOR);
 
         // Write queue_msix_vector — must not panic.
-        regs.write(0x1a, &[0xAB, 0xCD], &mut queues, dev);
+        regs.write(0x1a, &[0xAB, 0xCD], &mut queues);
     }
 }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -404,7 +404,7 @@ impl VirtioPciDevice {
         memory: GuestMemoryAtomic<GuestMemoryMmap>,
         device: Arc<Mutex<dyn VirtioDevice>>,
         msix_num: u16,
-        access_platform: Option<Arc<dyn AccessPlatform>>,
+        access_platform: Option<&Arc<dyn AccessPlatform>>,
         interrupt_manager: &dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>,
         pci_device_bdf: u32,
         activate_evt: EventFd,
@@ -422,7 +422,7 @@ impl VirtioPciDevice {
         }
         let num_queues = locked_device.queue_max_sizes().len();
 
-        if let Some(access_platform) = &access_platform {
+        if let Some(access_platform) = access_platform {
             locked_device.set_access_platform(access_platform.clone());
         }
 
@@ -518,7 +518,7 @@ impl VirtioPciDevice {
             })?;
 
         let common_config = if let Some(common_config_state) = common_config_state {
-            VirtioPciCommonConfig::new(common_config_state, access_platform)
+            VirtioPciCommonConfig::new(common_config_state, device.clone())
         } else {
             VirtioPciCommonConfig::new(
                 VirtioPciCommonConfigState {
@@ -530,7 +530,7 @@ impl VirtioPciDevice {
                     msix_config: VIRTQ_MSI_NO_VECTOR,
                     msix_queues: vec![VIRTQ_MSI_NO_VECTOR; num_queues],
                 },
-                access_platform,
+                device.clone(),
             )
         };
 
@@ -1139,12 +1139,10 @@ impl PciDevice for VirtioPciDevice {
 
     fn read_bar(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         match offset {
-            o if o < COMMON_CONFIG_BAR_OFFSET + COMMON_CONFIG_SIZE => self.common_config.read(
-                o - COMMON_CONFIG_BAR_OFFSET,
-                data,
-                &self.queues,
-                self.device.clone(),
-            ),
+            o if o < COMMON_CONFIG_BAR_OFFSET + COMMON_CONFIG_SIZE => {
+                self.common_config
+                    .read(o - COMMON_CONFIG_BAR_OFFSET, data, &self.queues);
+            }
             o if (ISR_CONFIG_BAR_OFFSET..ISR_CONFIG_BAR_OFFSET + ISR_CONFIG_SIZE).contains(&o) => {
                 if let Some(v) = data.get_mut(0) {
                     // Reading this register resets it to 0.
@@ -1185,12 +1183,10 @@ impl PciDevice for VirtioPciDevice {
     fn write_bar(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         let initial_ready = self.is_driver_ready();
         match offset {
-            o if o < COMMON_CONFIG_BAR_OFFSET + COMMON_CONFIG_SIZE => self.common_config.write(
-                o - COMMON_CONFIG_BAR_OFFSET,
-                data,
-                &mut self.queues,
-                self.device.clone(),
-            ),
+            o if o < COMMON_CONFIG_BAR_OFFSET + COMMON_CONFIG_SIZE => {
+                self.common_config
+                    .write(o - COMMON_CONFIG_BAR_OFFSET, data, &mut self.queues);
+            }
             o if (ISR_CONFIG_BAR_OFFSET..ISR_CONFIG_BAR_OFFSET + ISR_CONFIG_SIZE).contains(&o) => {
                 if let Some(v) = data.first() {
                     self.interrupt_status

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -251,21 +251,21 @@ impl Vdpa {
                 desc_table_addr: queue
                     .desc_table()
                     .translate_gpa(
-                        self.common.access_platform.as_deref(),
+                        self.common.access_platform().as_deref(),
                         queue_size as usize * std::mem::size_of::<RawDescriptor>(),
                     )
                     .map_err(Error::TranslateAddress)?,
                 used_ring_addr: queue
                     .used_ring()
                     .translate_gpa(
-                        self.common.access_platform.as_deref(),
+                        self.common.access_platform().as_deref(),
                         4 + queue_size as usize * 8,
                     )
                     .map_err(Error::TranslateAddress)?,
                 avail_ring_addr: queue
                     .avail_ring()
                     .translate_gpa(
-                        self.common.access_platform.as_deref(),
+                        self.common.access_platform().as_deref(),
                         4 + queue_size as usize * 2,
                     )
                     .map_err(Error::TranslateAddress)?,

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -465,6 +465,10 @@ impl VirtioDevice for Vdpa {
     fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {
         self.common.set_access_platform(access_platform);
     }
+
+    fn access_platform(&self) -> Option<Arc<dyn AccessPlatform>> {
+        self.common.access_platform()
+    }
 }
 
 impl Pausable for Vdpa {

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -45,7 +45,7 @@ pub struct Blk {
     guest_memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     seccomp_action: SeccompAction,
     exit_evt: EventFd,
-    iommu: bool,
+    access_platform_enabled: bool,
 }
 
 impl Blk {
@@ -55,7 +55,7 @@ impl Blk {
         vu_cfg: VhostUserConfig,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
-        iommu: bool,
+        access_platform_enabled: bool,
         state: Option<State>,
     ) -> Result<Blk> {
         let num_queues = vu_cfg.num_queues;
@@ -191,7 +191,7 @@ impl Blk {
             guest_memory: None,
             seccomp_action,
             exit_evt,
-            iommu,
+            access_platform_enabled,
         })
     }
 
@@ -217,7 +217,7 @@ impl VirtioDevice for Blk {
 
     fn features(&self) -> u64 {
         let mut features = self.vu_common.virtio_common.avail_features;
-        if self.iommu {
+        if self.access_platform_enabled {
             features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
         }
         features

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -68,7 +68,7 @@ pub struct Fs {
     seccomp_action: SeccompAction,
     guest_memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     exit_evt: EventFd,
-    iommu: bool,
+    access_platform_enabled: bool,
 }
 
 impl Fs {
@@ -83,7 +83,7 @@ impl Fs {
         cache: Option<(VirtioSharedMemoryList, MmapRegion)>,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
-        iommu: bool,
+        access_platform_enabled: bool,
         state: Option<State>,
     ) -> Result<Fs> {
         // Calculate the actual number of queues needed.
@@ -200,7 +200,7 @@ impl Fs {
             seccomp_action,
             guest_memory: None,
             exit_evt,
-            iommu,
+            access_platform_enabled,
         })
     }
 
@@ -226,7 +226,7 @@ impl VirtioDevice for Fs {
 
     fn features(&self) -> u64 {
         let mut features = self.vu_common.virtio_common.avail_features;
-        if self.iommu {
+        if self.access_platform_enabled {
             features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
         }
         features

--- a/virtio-devices/src/vhost_user/generic_vhost_user.rs
+++ b/virtio-devices/src/vhost_user/generic_vhost_user.rs
@@ -42,7 +42,7 @@ pub struct GenericVhostUser {
     seccomp_action: SeccompAction,
     guest_memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     exit_evt: EventFd,
-    iommu: bool,
+    access_platform_enabled: bool,
     cfg_warning: AtomicBool,
 }
 
@@ -57,7 +57,7 @@ impl GenericVhostUser {
         cache: Option<(VirtioSharedMemoryList, MmapRegion)>,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
-        iommu: bool,
+        access_platform_enabled: bool,
         state: Option<State>,
     ) -> Result<GenericVhostUser> {
         // Calculate the actual number of queues needed.
@@ -159,7 +159,7 @@ since the backend only supports {backend_num_queues}\n",
             seccomp_action,
             guest_memory: None,
             exit_evt,
-            iommu,
+            access_platform_enabled,
             cfg_warning: AtomicBool::new(false),
         })
     }
@@ -201,7 +201,7 @@ impl VirtioDevice for GenericVhostUser {
 
     fn features(&self) -> u64 {
         let mut features = self.vu_common.virtio_common.avail_features;
-        if self.iommu {
+        if self.access_platform_enabled {
             features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
         }
         features

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -48,7 +48,7 @@ pub struct Net {
     ctrl_queue_epoll_thread: Option<thread::JoinHandle<()>>,
     seccomp_action: SeccompAction,
     exit_evt: EventFd,
-    iommu: bool,
+    access_platform_enabled: bool,
 }
 
 impl Net {
@@ -62,7 +62,7 @@ impl Net {
         server: bool,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
-        iommu: bool,
+        access_platform_enabled: bool,
         state: Option<State>,
         offload_tso: bool,
         offload_ufo: bool,
@@ -220,7 +220,7 @@ impl Net {
             ctrl_queue_epoll_thread: None,
             seccomp_action,
             exit_evt,
-            iommu,
+            access_platform_enabled,
         })
     }
 
@@ -252,7 +252,7 @@ impl VirtioDevice for Net {
 
     fn features(&self) -> u64 {
         let mut features = self.vu_common.virtio_common.avail_features;
-        if self.iommu {
+        if self.access_platform_enabled {
             features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
         }
         features

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -339,7 +339,7 @@ where
         cid: u32,
         path: PathBuf,
         mut backend: B,
-        iommu: bool,
+        access_platform_enabled: bool,
         seccomp_action: SeccompAction,
         exit_evt: EventFd,
         state: Option<VsockState>,
@@ -353,7 +353,7 @@ where
         } else {
             let mut avail_features = (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_F_IN_ORDER);
 
-            if iommu {
+            if access_platform_enabled {
                 avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
             }
             (avail_features, 0, false)

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -466,7 +466,7 @@ where
             pause_evt,
             interrupt_cb,
             backend: self.backend.clone(),
-            access_platform: self.common.access_platform.clone(),
+            access_platform: self.common.access_platform(),
         };
 
         let paused = self.common.paused.clone();

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -501,6 +501,10 @@ where
     fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {
         self.common.set_access_platform(access_platform);
     }
+
+    fn access_platform(&self) -> Option<Arc<dyn AccessPlatform>> {
+        self.common.access_platform()
+    }
 }
 
 impl<B> Pausable for Vsock<B>

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1126,8 +1126,8 @@ pub struct DeviceManager {
     // pvpanic device
     pvpanic_device: Option<Arc<Mutex<devices::PvPanicDevice>>>,
 
-    // Flag to force setting the iommu on virtio devices
-    force_iommu: bool,
+    // Force VIRTIO_F_ACCESS_PLATFORM on all virtio devices (e.g. for TDX/SEV-SNP)
+    force_access_platform: bool,
 
     // io_uring availability if detected
     io_uring_supported: Option<bool>,
@@ -1215,7 +1215,7 @@ impl DeviceManager {
         seccomp_action: SeccompAction,
         numa_nodes: NumaNodes,
         activate_evt: &EventFd,
-        force_iommu: bool,
+        force_access_platform: bool,
         boot_id_list: BTreeSet<String>,
         #[cfg(not(target_arch = "riscv64"))] timestamp: Instant,
         snapshot: Option<&Snapshot>,
@@ -1429,7 +1429,7 @@ impl DeviceManager {
             #[cfg(feature = "pvmemcontrol")]
             pvmemcontrol_devices: None,
             pvpanic_device: None,
-            force_iommu,
+            force_access_platform,
             io_uring_supported: None,
             aio_supported: None,
             boot_id_list,
@@ -2434,7 +2434,7 @@ impl DeviceManager {
             self.console_resize_pipe
                 .as_ref()
                 .map(|p| p.try_clone().unwrap()),
-            self.force_iommu | console_config.iommu,
+            self.force_access_platform | console_config.iommu,
             self.seccomp_action.clone(),
             self.exit_evt
                 .try_clone()
@@ -2697,7 +2697,7 @@ impl DeviceManager {
                     self.exit_evt
                         .try_clone()
                         .map_err(DeviceManagerError::EventFd)?,
-                    self.force_iommu,
+                    self.force_access_platform,
                     state_from_id(self.snapshot.as_ref(), id.as_str())
                         .map_err(DeviceManagerError::RestoreGetState)?,
                 ) {
@@ -2924,7 +2924,7 @@ impl DeviceManager {
                     .ok_or(DeviceManagerError::NoDiskPath)?
                     .clone(),
                 disk_cfg.readonly,
-                self.force_iommu | disk_cfg.pci_common.iommu,
+                self.force_access_platform | disk_cfg.pci_common.iommu,
                 disk_cfg.num_queues,
                 disk_cfg.queue_size,
                 disk_cfg.serial.clone(),
@@ -3026,7 +3026,7 @@ impl DeviceManager {
                     self.exit_evt
                         .try_clone()
                         .map_err(DeviceManagerError::EventFd)?,
-                    self.force_iommu,
+                    self.force_access_platform,
                     state_from_id(self.snapshot.as_ref(), id.as_str())
                         .map_err(DeviceManagerError::RestoreGetState)?,
                     net_cfg.offload_tso,
@@ -3057,7 +3057,7 @@ impl DeviceManager {
                         Some(net_cfg.mac),
                         &mut net_cfg.host_mac,
                         net_cfg.mtu,
-                        self.force_iommu | net_cfg.pci_common.iommu,
+                        self.force_access_platform | net_cfg.pci_common.iommu,
                         net_cfg.num_queues,
                         net_cfg.queue_size,
                         self.seccomp_action.clone(),
@@ -3078,7 +3078,7 @@ impl DeviceManager {
                     fds,
                     Some(net_cfg.mac),
                     net_cfg.mtu,
-                    self.force_iommu | net_cfg.pci_common.iommu,
+                    self.force_access_platform | net_cfg.pci_common.iommu,
                     net_cfg.queue_size,
                     self.seccomp_action.clone(),
                     net_cfg.rate_limiter_config,
@@ -3108,7 +3108,7 @@ impl DeviceManager {
                         Some(net_cfg.mac),
                         &mut net_cfg.host_mac,
                         net_cfg.mtu,
-                        self.force_iommu | net_cfg.pci_common.iommu,
+                        self.force_access_platform | net_cfg.pci_common.iommu,
                         net_cfg.num_queues,
                         net_cfg.queue_size,
                         self.seccomp_action.clone(),
@@ -3171,7 +3171,7 @@ impl DeviceManager {
                 virtio_devices::Rng::new(
                     id.clone(),
                     rng_path,
-                    self.force_iommu | rng_config.iommu,
+                    self.force_access_platform | rng_config.iommu,
                     self.seccomp_action.clone(),
                     self.exit_evt
                         .try_clone()
@@ -3233,7 +3233,7 @@ impl DeviceManager {
                     self.exit_evt
                         .try_clone()
                         .map_err(DeviceManagerError::EventFd)?,
-                    self.force_iommu,
+                    self.force_access_platform,
                     state_from_id(self.snapshot.as_ref(), id.as_str())
                         .map_err(DeviceManagerError::RestoreGetState)?,
                 )
@@ -3299,7 +3299,7 @@ impl DeviceManager {
                     self.exit_evt
                         .try_clone()
                         .map_err(DeviceManagerError::EventFd)?,
-                    self.force_iommu,
+                    self.force_access_platform,
                     state_from_id(self.snapshot.as_ref(), id.as_str())
                         .map_err(DeviceManagerError::RestoreGetState)?,
                 )
@@ -3478,7 +3478,7 @@ impl DeviceManager {
                 file,
                 GuestAddress(region_base),
                 mapping,
-                self.force_iommu | pmem_cfg.pci_common.iommu,
+                self.force_access_platform | pmem_cfg.pci_common.iommu,
                 self.seccomp_action.clone(),
                 self.exit_evt
                     .try_clone()
@@ -3549,7 +3549,7 @@ impl DeviceManager {
                 vsock_cfg.cid,
                 vsock_cfg.socket.clone(),
                 backend,
-                self.force_iommu | vsock_cfg.pci_common.iommu,
+                self.force_access_platform | vsock_cfg.pci_common.iommu,
                 self.seccomp_action.clone(),
                 self.exit_evt
                     .try_clone()

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4392,7 +4392,7 @@ impl DeviceManager {
                 memory,
                 virtio_device,
                 msix_num,
-                access_platform,
+                access_platform.as_ref(),
                 self.msi_interrupt_manager.as_ref(),
                 pci_device_bdf.into(),
                 self.activate_evt

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3698,6 +3698,7 @@ impl DeviceManager {
                     balloon_config.size,
                     balloon_config.deflate_on_oom,
                     balloon_config.free_page_reporting,
+                    self.force_access_platform,
                     self.seccomp_action.clone(),
                     self.exit_evt
                         .try_clone()

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -567,8 +567,8 @@ impl Vm {
         let numa_nodes =
             Self::create_numa_nodes(config.lock().unwrap().numa.as_deref(), &memory_manager)?;
 
-        // Determine if IOMMU should be forced based on confidential computing features
-        let force_iommu = Self::should_force_iommu(&config);
+        // Determine if VIRTIO_F_ACCESS_PLATFORM should be forced (e.g. for TDX/SEV-SNP)
+        let force_access_platform = Self::should_force_access_platform(&config);
 
         let stop_on_boot = Self::should_stop_on_boot(&config);
 
@@ -615,7 +615,7 @@ impl Vm {
             seccomp_action.clone(),
             numa_nodes.clone(),
             &activate_evt,
-            force_iommu,
+            force_access_platform,
             boot_id_list,
             #[cfg(not(target_arch = "riscv64"))]
             timestamp,
@@ -694,8 +694,9 @@ impl Vm {
         })
     }
 
-    /// Determine if IOMMU should be forced based on confidential computing features.
-    fn should_force_iommu(_config: &Arc<Mutex<VmConfig>>) -> bool {
+    /// Determine if VIRTIO_F_ACCESS_PLATFORM should be forced based on
+    /// confidential computing features.
+    fn should_force_access_platform(_config: &Arc<Mutex<VmConfig>>) -> bool {
         #[cfg(feature = "tdx")]
         if _config.lock().unwrap().is_tdx_enabled() {
             return true;
@@ -802,7 +803,7 @@ impl Vm {
         seccomp_action: SeccompAction,
         numa_nodes: NumaNodes,
         activate_evt: &EventFd,
-        force_iommu: bool,
+        force_access_platform: bool,
         boot_id_list: BTreeSet<String>,
         #[cfg(not(target_arch = "riscv64"))] timestamp: Instant,
         snapshot: Option<&Snapshot>,
@@ -825,7 +826,7 @@ impl Vm {
             seccomp_action,
             numa_nodes,
             activate_evt,
-            force_iommu,
+            force_access_platform,
             boot_id_list,
             #[cfg(not(target_arch = "riscv64"))]
             timestamp,


### PR DESCRIPTION
I set out to implemeent VIRTIO_F_ACCESS_PLATFORM for balloon but found that we
needed some bug fixes for spec compliance and that lead to the refactoring :-)

- **virtio-devices: Add feature acked gated accessor for AccessPlatform**
- **virtio-devices: Use new VirtioCommon::access_platform() accessor**
- **virtio-devices: Add VirtioDevice::access_platform()**
- **virtio-devices: Implement VirtioDevice::access_platform()**
- **virtio-devices: Add a VirtioDevice reference to VirtioPciCommonConfig**
- **virtio-devices: Rename control parameter for VIRTIO_F_ACCESS_PLATFORM**
- **vmm: Rename force_iommu to force_access_platform**
- **virtio-devices: balloon: Enable use with confidential VMs**
