### PR TITLE
block: Consolidate boundary error conversions

### DIFF
--- a/block/src/fixed_vhd_async.rs
+++ b/block/src/fixed_vhd_async.rs
@@ -26,7 +26,9 @@ impl FixedVhdDiskAsync {
 
 impl disk_file::DiskSize for FixedVhdDiskAsync {
     fn logical_size(&self) -> BlockResult<u64> {
-        Ok(self.0.logical_size().unwrap())
+        self.0
+            .logical_size()
+            .map_err(|e| BlockError::new(BlockErrorKind::Io, e))
     }
 }
 
@@ -69,13 +71,12 @@ impl disk_file::AsyncDiskFile for FixedVhdDiskAsync {
     }
 
     fn new_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+        let size = self
+            .0
+            .logical_size()
+            .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
         Ok(Box::new(
-            FixedVhdAsync::new(
-                self.0.as_raw_fd(),
-                ring_depth,
-                self.0.logical_size().unwrap(),
-            )
-            .map_err(|e| {
+            FixedVhdAsync::new(self.0.as_raw_fd(), ring_depth, size).map_err(|e| {
                 BlockError::new(BlockErrorKind::Io, DiskFileError::NewAsyncIo(e))
                     .with_op(ErrorOp::Open)
             })?,

--- a/block/src/fixed_vhd_async.rs
+++ b/block/src/fixed_vhd_async.rs
@@ -36,7 +36,7 @@ impl disk_file::PhysicalSize for FixedVhdDiskAsync {
             crate::Error::GetFileMetadata(io) => {
                 BlockError::new(BlockErrorKind::Io, crate::Error::GetFileMetadata(io))
             }
-            _ => BlockError::new(BlockErrorKind::Io, e),
+            _ => unreachable!("unexpected error from FixedVhd::physical_size(): {e}"),
         })
     }
 }

--- a/block/src/fixed_vhd_async.rs
+++ b/block/src/fixed_vhd_async.rs
@@ -75,12 +75,11 @@ impl disk_file::AsyncDiskFile for FixedVhdDiskAsync {
             .0
             .logical_size()
             .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
-        Ok(Box::new(
-            FixedVhdAsync::new(self.0.as_raw_fd(), ring_depth, size).map_err(|e| {
-                BlockError::new(BlockErrorKind::Io, DiskFileError::NewAsyncIo(e))
-                    .with_op(ErrorOp::Open)
-            })?,
-        ))
+        Ok(Box::new(FixedVhdAsync::new(
+            self.0.as_raw_fd(),
+            ring_depth,
+            size,
+        )?))
     }
 }
 
@@ -90,7 +89,7 @@ pub struct FixedVhdAsync {
 }
 
 impl FixedVhdAsync {
-    pub fn new(fd: RawFd, ring_depth: u32, size: u64) -> std::io::Result<Self> {
+    pub fn new(fd: RawFd, ring_depth: u32, size: u64) -> BlockResult<Self> {
         let raw_file_async = RawFileAsync::new(fd, ring_depth)?;
 
         Ok(FixedVhdAsync {

--- a/block/src/fixed_vhd_sync.rs
+++ b/block/src/fixed_vhd_sync.rs
@@ -36,7 +36,7 @@ impl disk_file::PhysicalSize for FixedVhdDiskSync {
             crate::Error::GetFileMetadata(io) => {
                 BlockError::new(BlockErrorKind::Io, crate::Error::GetFileMetadata(io))
             }
-            _ => BlockError::new(BlockErrorKind::Io, e),
+            _ => unreachable!("unexpected error from FixedVhd::physical_size(): {e}"),
         })
     }
 }

--- a/block/src/fixed_vhd_sync.rs
+++ b/block/src/fixed_vhd_sync.rs
@@ -26,7 +26,9 @@ impl FixedVhdDiskSync {
 
 impl disk_file::DiskSize for FixedVhdDiskSync {
     fn logical_size(&self) -> BlockResult<u64> {
-        Ok(self.0.logical_size().unwrap())
+        self.0
+            .logical_size()
+            .map_err(|e| BlockError::new(BlockErrorKind::Io, e))
     }
 }
 
@@ -69,8 +71,12 @@ impl disk_file::AsyncDiskFile for FixedVhdDiskSync {
     }
 
     fn new_async_io(&self, _ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+        let size = self
+            .0
+            .logical_size()
+            .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
         Ok(Box::new(
-            FixedVhdSync::new(self.0.as_raw_fd(), self.0.logical_size().unwrap()).map_err(|e| {
+            FixedVhdSync::new(self.0.as_raw_fd(), size).map_err(|e| {
                 BlockError::new(BlockErrorKind::Io, DiskFileError::NewAsyncIo(e))
                     .with_op(ErrorOp::Open)
             })?,

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -108,8 +108,7 @@ impl disk_file::AsyncDiskFile for RawFileDisk {
     }
 
     fn new_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
-        let mut raw = RawFileAsync::new(self.file.as_raw_fd(), ring_depth)
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::NewAsyncIo(e)))?;
+        let mut raw = RawFileAsync::new(self.file.as_raw_fd(), ring_depth)?;
         raw.alignment =
             DiskTopology::probe(&self.file).map_or(SECTOR_SIZE, |t| t.logical_block_size);
         Ok(Box::new(raw) as Box<dyn AsyncIo>)
@@ -124,13 +123,18 @@ pub struct RawFileAsync {
 }
 
 impl RawFileAsync {
-    pub fn new(fd: RawFd, ring_depth: u32) -> std::io::Result<Self> {
-        let io_uring = IoUring::new(ring_depth)?;
-        let eventfd = EventFd::new(libc::EFD_NONBLOCK)?;
+    pub fn new(fd: RawFd, ring_depth: u32) -> BlockResult<Self> {
+        let io_uring =
+            IoUring::new(ring_depth).map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
+        let eventfd =
+            EventFd::new(libc::EFD_NONBLOCK).map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
 
         // Register the io_uring eventfd that will notify when something in
         // the completion queue is ready.
-        io_uring.submitter().register_eventfd(eventfd.as_raw_fd())?;
+        io_uring
+            .submitter()
+            .register_eventfd(eventfd.as_raw_fd())
+            .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
 
         Ok(RawFileAsync {
             fd,

--- a/block/src/vhdx_sync.rs
+++ b/block/src/vhdx_sync.rs
@@ -53,7 +53,7 @@ impl disk_file::PhysicalSize for VhdxDiskSync {
                 Error::GetFileMetadata(io) => {
                     BlockError::new(BlockErrorKind::Io, Error::GetFileMetadata(io))
                 }
-                _ => BlockError::new(BlockErrorKind::Io, e),
+                _ => unreachable!("unexpected error from Vhdx::physical_size(): {e}"),
             })
     }
 }

--- a/block/src/vhdx_sync.rs
+++ b/block/src/vhdx_sync.rs
@@ -11,7 +11,7 @@ use vmm_sys_util::eventfd::EventFd;
 
 use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFileError};
 use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
-use crate::vhdx::Vhdx;
+use crate::vhdx::{Vhdx, VhdxError};
 use crate::{AsyncAdaptor, BlockBackend, Error, disk_file};
 
 #[derive(Debug)]
@@ -31,7 +31,15 @@ impl VhdxDiskSync {
     pub fn new(f: File) -> BlockResult<Self> {
         Ok(VhdxDiskSync {
             vhdx_file: Arc::new(Mutex::new(Vhdx::new(f).map_err(|e| {
-                BlockError::new(BlockErrorKind::Io, e).with_op(ErrorOp::Open)
+                let kind = match &e {
+                    VhdxError::NotVhdx(_)
+                    | VhdxError::ParseVhdxHeader(_)
+                    | VhdxError::ParseVhdxMetadata(_)
+                    | VhdxError::ParseVhdxRegionEntry(_) => BlockErrorKind::InvalidFormat,
+                    VhdxError::ReadBatEntry(_) => BlockErrorKind::CorruptImage,
+                    VhdxError::ReadFailed(_) | VhdxError::WriteFailed(_) => BlockErrorKind::Io,
+                };
+                BlockError::new(kind, e).with_op(ErrorOp::Open)
             })?)),
         })
     }


### PR DESCRIPTION
Task 3.1.7 from #7877.

- Replace catch-all error arms with `unreachable!()` in VHD and VHDX `physical_size()` boundaries
- Propagate `logical_size()` errors in VHD instead of `.unwrap()`
- Classify `VhdxError` variants explicitly in `VhdxDiskSync::new()` (parse errors to `InvalidFormat`, `ReadBatEntry` to `CorruptImage`)
- Align `RawFileAsync::new()` and `FixedVhdAsync::new()` return type to `BlockResult`

`DiskBackend` legacy catch-alls are dead code, to be removed with 3.3.5 "Remove DiskBackend and async_io::DiskFile impls".