### PR TITLE
block: qcow: Move QCOW2 compressed cluster decompression out of the metadata lock

### DIFF
--- a/block/src/qcow/backing.rs
+++ b/block/src/qcow/backing.rs
@@ -11,9 +11,10 @@ use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
 use std::sync::Arc;
 
 use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
+use crate::qcow::decoder::Decoder;
 use crate::qcow::metadata::{BackingRead, ClusterReadMapping, QcowMetadata};
 use crate::qcow::{BackingFile, BackingKind, Error as QcowError};
-use crate::qcow_common::pread_exact;
+use crate::qcow_common::{decompress_cluster, pread_alloc, pread_exact};
 
 /// Raw backing file using pread64 on a duplicated fd.
 pub(crate) struct RawBacking {
@@ -52,6 +53,8 @@ pub(crate) struct Qcow2Backing {
     pub(crate) metadata: Arc<QcowMetadata>,
     pub(crate) data_fd: OwnedFd,
     pub(crate) backing_file: Option<Arc<dyn BackingRead>>,
+    pub(crate) cluster_size: u64,
+    pub(crate) decoder: Arc<dyn Decoder>,
 }
 
 // SAFETY: All reads go through QcowMetadata which uses RwLock
@@ -104,10 +107,22 @@ impl Qcow2Backing {
                     )?;
                     buf_offset += length as usize;
                 }
-                ClusterReadMapping::Compressed { data } => {
-                    let len = data.len();
-                    buf[buf_offset..buf_offset + len].copy_from_slice(&data);
-                    buf_offset += len;
+                ClusterReadMapping::Compressed {
+                    host_offset,
+                    compressed_size,
+                    cluster_offset,
+                    length,
+                } => {
+                    let compressed =
+                        pread_alloc(self.data_fd.as_raw_fd(), host_offset, compressed_size)?;
+                    let decompressed = decompress_cluster(
+                        &compressed,
+                        self.cluster_size as usize,
+                        &*self.decoder,
+                    )?;
+                    buf[buf_offset..buf_offset + length]
+                        .copy_from_slice(&decompressed[cluster_offset..cluster_offset + length]);
+                    buf_offset += length;
                 }
                 ClusterReadMapping::Backing {
                     offset: backing_offset,
@@ -152,8 +167,11 @@ pub fn shared_backing_from(bf: BackingFile) -> BlockResult<Arc<dyn BackingRead>>
         }
         BackingKind::Qcow { inner, backing } => {
             let data_fd = dup_fd(inner.raw_file.as_fd())?;
+            let metadata = Arc::new(QcowMetadata::new(*inner));
             Ok(Arc::new(Qcow2Backing {
-                metadata: Arc::new(QcowMetadata::new(*inner)),
+                cluster_size: metadata.cluster_size(),
+                decoder: metadata.decoder(),
+                metadata,
                 data_fd,
                 backing_file: backing.map(|bf| shared_backing_from(*bf)).transpose()?,
             }))

--- a/block/src/qcow/decoder.rs
+++ b/block/src/qcow/decoder.rs
@@ -19,7 +19,7 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Generic trait for decoding zlib/zstd formats
-pub trait Decoder {
+pub trait Decoder: Send + Sync {
     fn decode(&self, input: &[u8], output: &mut [u8]) -> Result<usize>;
 }
 

--- a/block/src/qcow/metadata.rs
+++ b/block/src/qcow/metadata.rs
@@ -333,11 +333,6 @@ impl QcowMetadata {
     pub fn cluster_size(&self) -> u64 {
         self.inner.read().unwrap().raw_file.cluster_size()
     }
-
-    /// Returns the intra cluster byte offset for a given guest address.
-    pub fn cluster_offset(&self, address: u64) -> u64 {
-        self.inner.read().unwrap().raw_file.cluster_offset(address)
-    }
 }
 
 impl QcowState {

--- a/block/src/qcow/metadata.rs
+++ b/block/src/qcow/metadata.rs
@@ -19,10 +19,11 @@
 use std::cmp::min;
 use std::io::{self, Seek};
 use std::mem;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 use libc::{EINVAL, EIO};
 
+use super::decoder::Decoder;
 use super::qcow_raw_file::QcowRawFile;
 use super::refcount::RefCount;
 use super::util::{
@@ -51,13 +52,16 @@ pub enum ClusterReadMapping {
     /// bounded by cluster boundary and guest request.
     Allocated { offset: u64, length: u64 },
 
-    /// The cluster is compressed. The decompressed data is returned inline
-    /// because decompression is a CPU only operation that was done under the
-    /// write lock to access the raw compressed bytes from disk.
-    ///
-    /// The data field contains exactly the bytes the guest requested, already
-    /// sliced from the decompressed cluster.
-    Compressed { data: Vec<u8> },
+    /// The cluster is compressed. The host file offset and compressed byte
+    /// count are extracted from the L2 entry under the read lock. The caller
+    /// reads the compressed data with pread on its own fd, decompresses
+    /// into a cluster sized buffer, then slices the requested range.
+    Compressed {
+        host_offset: u64,
+        compressed_size: usize,
+        cluster_offset: usize,
+        length: usize,
+    },
 
     /// The cluster is not allocated in this layer but may exist in a backing
     /// file. The caller should delegate to the backing file at the given
@@ -112,6 +116,7 @@ pub enum DeallocAction {
 /// write lock, so contention stays low and queues scale.
 pub struct QcowMetadata {
     inner: RwLock<QcowState>,
+    decoder: Arc<dyn Decoder>,
 }
 
 /// The actual metadata state, accessible only through the RwLock.
@@ -132,6 +137,7 @@ pub(crate) struct QcowState {
 impl QcowMetadata {
     pub(crate) fn new(inner: QcowState) -> Self {
         QcowMetadata {
+            decoder: Arc::from(inner.header.get_decoder()),
             inner: RwLock::new(inner),
         }
     }
@@ -333,6 +339,11 @@ impl QcowMetadata {
     pub fn cluster_size(&self) -> u64 {
         self.inner.read().unwrap().raw_file.cluster_size()
     }
+
+    /// Returns the shared decoder matching the image compression type.
+    pub fn decoder(&self) -> Arc<dyn Decoder> {
+        Arc::clone(&self.decoder)
+    }
 }
 
 impl QcowState {
@@ -373,10 +384,19 @@ impl QcowState {
         let l2_index = self.l2_table_index(address) as usize;
         let l2_entry = l2_table[l2_index];
 
-        // Compressed entries require disk I/O for decompression - can't do
-        // that under a read lock. Fall through to the write lock path.
+        // Compressed entries: extract layout from L2 entry under read lock.
+        // The caller reads and decompresses on its own fd without holding
+        // the metadata lock.
         if l2_entry_is_compressed(l2_entry) {
-            return Ok(None);
+            let (host_offset, compressed_size) =
+                l2_entry_compressed_cluster_layout(l2_entry, self.header.cluster_bits);
+            let cluster_offset = self.raw_file.cluster_offset(address) as usize;
+            return Ok(Some(ClusterReadMapping::Compressed {
+                host_offset,
+                compressed_size,
+                cluster_offset,
+                length: count,
+            }));
         }
 
         if l2_entry_is_empty(l2_entry) {
@@ -439,17 +459,14 @@ impl QcowState {
         if l2_entry_is_empty(l2_entry) {
             Ok(self.unallocated_read_mapping(address, count, has_backing_file))
         } else if l2_entry_is_compressed(l2_entry) {
-            // Under write lock we can do I/O for decompression
-            let decompressed = self.decompress_l2_cluster(l2_entry)?;
-            let start = self.raw_file.cluster_offset(address) as usize;
-            let end = start
-                .checked_add(count)
-                .ok_or_else(|| io::Error::from_raw_os_error(EINVAL))?;
-            if end > decompressed.len() {
-                return Err(io::Error::from_raw_os_error(EINVAL));
-            }
+            let (host_offset, compressed_size) =
+                l2_entry_compressed_cluster_layout(l2_entry, self.header.cluster_bits);
+            let cluster_offset = self.raw_file.cluster_offset(address) as usize;
             Ok(ClusterReadMapping::Compressed {
-                data: decompressed[start..end].to_vec(),
+                host_offset,
+                compressed_size,
+                cluster_offset,
+                length: count,
             })
         } else if l2_entry_is_zero(l2_entry) {
             // Match original QcowFile::file_read semantics where zero flagged

--- a/block/src/qcow/mod.rs
+++ b/block/src/qcow/mod.rs
@@ -57,6 +57,7 @@ use crate::qcow::qcow_raw_file::{BeUint, QcowRawFile};
 pub use crate::qcow::raw_file::RawFile;
 use crate::qcow::refcount::RefCount;
 use crate::qcow::vec_cache::{CacheMap, Cacheable, VecCache};
+use crate::qcow_common::decompress_cluster;
 
 #[sorted]
 #[derive(Debug, Error)]
@@ -322,8 +323,26 @@ impl BackingFile {
                                 .file_mut()
                                 .read_exact(&mut buf[pos..pos + length as usize])?;
                         }
-                        ClusterReadMapping::Compressed { data } => {
-                            buf[pos..pos + data.len()].copy_from_slice(&data);
+                        ClusterReadMapping::Compressed {
+                            host_offset,
+                            compressed_size,
+                            cluster_offset,
+                            length,
+                        } => {
+                            let mut compressed = vec![0u8; compressed_size];
+                            inner
+                                .raw_file
+                                .file_mut()
+                                .seek(SeekFrom::Start(host_offset))?;
+                            inner.raw_file.file_mut().read_exact(&mut compressed)?;
+                            let decompressed = decompress_cluster(
+                                &compressed,
+                                cluster_size as usize,
+                                &*inner.header.get_decoder(),
+                            )?;
+                            buf[pos..pos + length].copy_from_slice(
+                                &decompressed[cluster_offset..cluster_offset + length],
+                            );
                         }
                         ClusterReadMapping::Backing {
                             offset: backing_off,

--- a/block/src/qcow/mod.rs
+++ b/block/src/qcow/mod.rs
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 pub(crate) mod backing;
-mod decoder;
+pub(crate) mod decoder;
 mod header;
 pub(crate) mod metadata;
 pub(crate) mod qcow_raw_file;

--- a/block/src/qcow/mod.rs
+++ b/block/src/qcow/mod.rs
@@ -2353,6 +2353,7 @@ mod unit_tests {
 
     use super::util::{COMPRESSED_FLAG, ZERO_FLAG};
     use super::*;
+    use crate::qcow_common::unit_tests::compress_allocated_clusters;
 
     fn valid_header_v3() -> Vec<u8> {
         vec![
@@ -4589,5 +4590,28 @@ mod unit_tests {
             let qcow = QcowFile::from(disk_file.try_clone().unwrap()).unwrap();
             assert_eq!(qcow.header.version, 2);
         });
+    }
+
+    #[test]
+    fn test_compressed_read() {
+        let cluster_size = 65536usize;
+        let data: Vec<u8> = (0..=255).cycle().take(cluster_size).collect();
+        let temp = TempFile::new().unwrap();
+        {
+            let raw_file = RawFile::new(temp.as_file().try_clone().unwrap(), false);
+            let mut qcow = QcowFile::new(raw_file, 3, 100 * 1024 * 1024, false).unwrap();
+            qcow.seek(SeekFrom::Start(0)).unwrap();
+            qcow.write_all(&data).unwrap();
+            qcow.flush().unwrap();
+        }
+
+        compress_allocated_clusters(&mut temp.as_file().try_clone().unwrap());
+
+        let raw_file = RawFile::new(temp.as_file().try_clone().unwrap(), false);
+        let mut qcow = QcowFile::from(raw_file).unwrap();
+        qcow.seek(SeekFrom::Start(0)).unwrap();
+        let mut buf = vec![0u8; cluster_size];
+        qcow.read_exact(&mut buf).unwrap();
+        assert_eq!(buf, data);
     }
 }

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -177,6 +177,7 @@ pub struct QcowAsync {
     alignment: usize,
     /// I/O alignment for the AsyncIo trait (at least SECTOR_SIZE).
     io_alignment: u64,
+    cluster_size: u64,
     io_uring: IoUring,
     eventfd: EventFd,
     completion_list: VecDeque<(u64, i32)>,
@@ -197,6 +198,7 @@ impl QcowAsync {
         io_uring.submitter().register_eventfd(eventfd.as_raw_fd())?;
 
         Ok(QcowAsync {
+            cluster_size: metadata.cluster_size(),
             metadata,
             data_file,
             backing_file,
@@ -296,6 +298,7 @@ impl AsyncIo for QcowAsync {
             &self.data_file,
             &self.backing_file,
             self.alignment,
+            self.cluster_size,
         )?;
 
         let total_len: usize = iovecs.iter().map(|v| v.iov_len).sum();
@@ -325,7 +328,7 @@ impl AsyncIo for QcowAsync {
 
     fn punch_hole(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {
         let virtual_size = self.metadata.virtual_size();
-        let cluster_size = self.metadata.cluster_size();
+        let cluster_size = self.cluster_size;
 
         let result = self
             .metadata
@@ -425,6 +428,7 @@ impl AsyncIo for QcowAsync {
                         &self.data_file,
                         &self.backing_file,
                         self.alignment,
+                        self.cluster_size,
                     )?;
                     sync_completions.push((req.user_data, total_len as i32));
                 }
@@ -571,14 +575,14 @@ impl QcowAsync {
         data_file: &QcowRawFile,
         backing_file: &Option<Arc<dyn BackingRead>>,
         alignment: usize,
+        cluster_size: u64,
     ) -> AsyncIoResult<()> {
         let total_len: usize = iovecs.iter().map(|v| v.iov_len).sum();
-        let cluster_size = metadata.cluster_size();
         let mut buf_offset = 0usize;
 
         while buf_offset < total_len {
             let curr_addr = address + buf_offset as u64;
-            let intra_offset = metadata.cluster_offset(curr_addr);
+            let intra_offset = curr_addr & (cluster_size - 1);
             let remaining_in_cluster = (cluster_size - intra_offset) as usize;
             let count = min(total_len - buf_offset, remaining_in_cluster);
 

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -680,12 +680,15 @@ impl QcowAsync {
 #[cfg(test)]
 mod unit_tests {
     use std::io::{Seek, SeekFrom, Write};
+    use std::sync::Arc;
+    use std::thread;
 
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
     use crate::disk_file::AsyncDiskFile;
     use crate::qcow::{QcowFile, RawFile};
+    use crate::qcow_common::unit_tests::compress_allocated_clusters;
     use crate::{BatchRequest, RequestType, SECTOR_SIZE};
 
     fn create_disk_with_data(
@@ -1126,5 +1129,42 @@ mod unit_tests {
 
         let buf = async_read(&disk, 0, pattern.len());
         assert_eq!(buf, pattern, "O_DIRECT roundtrip should match");
+    }
+
+    #[test]
+    fn test_compressed_read_multi_queue() {
+        let cluster_size = 65536usize;
+        let data: Vec<u8> = (0..=255).cycle().take(cluster_size).collect();
+        let (temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, 0, false);
+        drop(disk);
+
+        compress_allocated_clusters(&mut temp.as_file().try_clone().unwrap());
+
+        let disk = Arc::new(
+            QcowDiskAsync::new(temp.as_file().try_clone().unwrap(), false, false, false).unwrap(),
+        );
+
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let disk = Arc::clone(&disk);
+                let expected = data.clone();
+                thread::spawn(move || {
+                    let mut async_io = disk.new_async_io(1).unwrap();
+                    let mut buf = vec![0xFFu8; cluster_size];
+                    let iovec = libc::iovec {
+                        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+                        iov_len: buf.len(),
+                    };
+                    async_io.read_vectored(0, &[iovec], 1).unwrap();
+                    let (_, result) = wait_for_completion(async_io.as_mut());
+                    assert_eq!(result as usize, cluster_size);
+                    assert_eq!(buf, expected);
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
     }
 }

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -21,14 +21,15 @@ use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFileError};
 use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
 use crate::qcow::backing::shared_backing_from;
+use crate::qcow::decoder::Decoder;
 use crate::qcow::metadata::{
     BackingRead, ClusterReadMapping, ClusterWriteMapping, DeallocAction, QcowMetadata,
 };
 use crate::qcow::qcow_raw_file::QcowRawFile;
 use crate::qcow::{MAX_NESTING_DEPTH, RawFile, parse_qcow};
 use crate::qcow_common::{
-    AlignedBuf, aligned_pread, aligned_pwrite, gather_from_iovecs_into, pread_exact, pwrite_all,
-    scatter_to_iovecs, zero_fill_iovecs,
+    AlignedBuf, aligned_pread, aligned_pwrite, decompress_cluster, gather_from_iovecs_into,
+    pread_alloc, pread_exact, pwrite_all, scatter_to_iovecs, zero_fill_iovecs,
 };
 use crate::{BatchRequest, RequestType, SECTOR_SIZE, disk_file};
 
@@ -178,6 +179,7 @@ pub struct QcowAsync {
     /// I/O alignment for the AsyncIo trait (at least SECTOR_SIZE).
     io_alignment: u64,
     cluster_size: u64,
+    decoder: Arc<dyn Decoder>,
     io_uring: IoUring,
     eventfd: EventFd,
     completion_list: VecDeque<(u64, i32)>,
@@ -199,6 +201,7 @@ impl QcowAsync {
 
         Ok(QcowAsync {
             cluster_size: metadata.cluster_size(),
+            decoder: metadata.decoder(),
             metadata,
             data_file,
             backing_file,
@@ -253,6 +256,8 @@ impl AsyncIo for QcowAsync {
             iovecs,
             total_len,
             self.alignment,
+            self.cluster_size,
+            &*self.decoder,
         )? {
             let fd = self.data_file.as_raw_fd();
             let (submitter, mut sq, _) = self.io_uring.split();
@@ -396,6 +401,8 @@ impl AsyncIo for QcowAsync {
                         &req.iovecs,
                         total_len,
                         self.alignment,
+                        self.cluster_size,
+                        &*self.decoder,
                     )? {
                         let fd = self.data_file.as_raw_fd();
                         // SAFETY: fd is valid and iovecs point to valid guest memory.
@@ -462,6 +469,7 @@ impl QcowAsync {
     /// Returns `Some(host_offset)` if the entire read falls within a single
     /// allocated cluster (fast path). Otherwise handles the read
     /// synchronously via `scatter_read_sync` and returns `None`.
+    #[allow(clippy::too_many_arguments)]
     fn resolve_read(
         metadata: &QcowMetadata,
         data_file: &QcowRawFile,
@@ -470,6 +478,8 @@ impl QcowAsync {
         iovecs: &[libc::iovec],
         total_len: usize,
         alignment: usize,
+        cluster_size: u64,
+        decoder: &dyn Decoder,
     ) -> AsyncIoResult<Option<u64>> {
         let has_backing = backing_file.is_some();
         let mappings = metadata
@@ -494,7 +504,15 @@ impl QcowAsync {
             return Ok(Some(*host_offset));
         }
 
-        Self::scatter_read_sync(mappings, iovecs, data_file, backing_file, alignment)?;
+        Self::scatter_read_sync(
+            mappings,
+            iovecs,
+            data_file,
+            backing_file,
+            alignment,
+            cluster_size,
+            decoder,
+        )?;
         Ok(None)
     }
 
@@ -505,6 +523,8 @@ impl QcowAsync {
         data_file: &QcowRawFile,
         backing_file: &Option<Arc<dyn BackingRead>>,
         alignment: usize,
+        cluster_size: u64,
+        decoder: &dyn Decoder,
     ) -> AsyncIoResult<()> {
         let mut buf_offset = 0usize;
         for mapping in mappings {
@@ -542,11 +562,27 @@ impl QcowAsync {
                     }
                     buf_offset += len;
                 }
-                ClusterReadMapping::Compressed { data } => {
-                    let len = data.len();
+                ClusterReadMapping::Compressed {
+                    host_offset,
+                    compressed_size,
+                    cluster_offset,
+                    length,
+                } => {
+                    let compressed =
+                        pread_alloc(data_file.as_raw_fd(), host_offset, compressed_size)
+                            .map_err(AsyncIoError::ReadVectored)?;
+                    let decompressed =
+                        decompress_cluster(&compressed, cluster_size as usize, decoder)
+                            .map_err(AsyncIoError::ReadVectored)?;
                     // SAFETY: iovecs point to valid guest memory buffers.
-                    unsafe { scatter_to_iovecs(iovecs, buf_offset, &data) };
-                    buf_offset += len;
+                    unsafe {
+                        scatter_to_iovecs(
+                            iovecs,
+                            buf_offset,
+                            &decompressed[cluster_offset..cluster_offset + length],
+                        );
+                    }
+                    buf_offset += length;
                 }
                 ClusterReadMapping::Backing {
                     offset: backing_offset,

--- a/block/src/qcow_common.rs
+++ b/block/src/qcow_common.rs
@@ -296,10 +296,15 @@ pub unsafe fn gather_from_iovecs(iovecs: &[libc::iovec], start: usize, len: usiz
 pub(crate) mod unit_tests {
     use std::fs::File;
     use std::io::{Read, Seek, SeekFrom, Write};
+    use std::os::unix::fs::FileExt;
+    use std::os::unix::io::AsRawFd;
 
     use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-    use flate2::write::DeflateEncoder;
     use flate2::Compression;
+    use flate2::write::DeflateEncoder;
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::pread_alloc;
 
     const COMPRESSED_FLAG: u64 = 1 << 62;
     const CLUSTER_USED_FLAG: u64 = 1 << 63;
@@ -400,5 +405,21 @@ pub(crate) mod unit_tests {
         }
 
         file.flush().unwrap();
+    }
+
+    #[test]
+    fn test_pread_alloc() {
+        let temp = TempFile::new().unwrap();
+        let file = temp.as_file();
+        let data: Vec<u8> = (0..=255).cycle().take(4096).collect();
+        file.write_all_at(&data, 0).unwrap();
+
+        let buf = pread_alloc(file.as_raw_fd(), 0, 4096).unwrap();
+        assert_eq!(buf, data);
+
+        let buf = pread_alloc(file.as_raw_fd(), 100, 200).unwrap();
+        assert_eq!(buf, &data[100..300]);
+
+        pread_alloc(file.as_raw_fd(), 4000, 200).unwrap_err();
     }
 }

--- a/block/src/qcow_common.rs
+++ b/block/src/qcow_common.rs
@@ -291,3 +291,114 @@ pub unsafe fn gather_from_iovecs(iovecs: &[libc::iovec], start: usize, len: usiz
     unsafe { gather_from_iovecs_into(iovecs, start, &mut result) };
     result
 }
+
+#[cfg(test)]
+pub(crate) mod unit_tests {
+    use std::fs::File;
+    use std::io::{Read, Seek, SeekFrom, Write};
+
+    use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+    use flate2::write::DeflateEncoder;
+    use flate2::Compression;
+
+    const COMPRESSED_FLAG: u64 = 1 << 62;
+    const CLUSTER_USED_FLAG: u64 = 1 << 63;
+    const COMPRESSED_SECTOR_SIZE: u64 = 512;
+
+    const HEADER_CLUSTER_BITS_OFFSET: u64 = 20;
+    const HEADER_L1_SIZE_OFFSET: u64 = 36;
+    const HEADER_L1_TABLE_OFFSET: u64 = 40;
+
+    const L1_L2_ADDR_MASK: u64 = 0x00ff_ffff_ffff_fe00;
+
+    fn make_compressed_l2_entry(host_offset: u64, compressed_len: usize, cluster_bits: u32) -> u64 {
+        let compressed_size_shift = 62 - (cluster_bits - 8);
+        let intra_sector_offset = host_offset & (COMPRESSED_SECTOR_SIZE - 1);
+        let total_bytes = compressed_len as u64 + intra_sector_offset;
+        let nsectors = total_bytes.div_ceil(COMPRESSED_SECTOR_SIZE);
+        let addr_part = host_offset & ((1 << compressed_size_shift) - 1);
+        let size_part = (nsectors - 1) << compressed_size_shift;
+        COMPRESSED_FLAG | size_part | addr_part
+    }
+
+    /// Compress every allocated cluster in a QCOW2 image file in place.
+    ///
+    /// Walks L1 -> L2 tables, compresses each standard cluster with raw
+    /// deflate, appends the compressed payload at the end of the file,
+    /// and rewrites the L2 entry with the compressed layout.
+    pub fn compress_allocated_clusters(file: &mut File) {
+        file.seek(SeekFrom::Start(HEADER_CLUSTER_BITS_OFFSET))
+            .unwrap();
+        let cluster_bits = file.read_u32::<BigEndian>().unwrap();
+        let cluster_size = 1u64 << cluster_bits;
+
+        file.seek(SeekFrom::Start(HEADER_L1_SIZE_OFFSET)).unwrap();
+        let l1_size = file.read_u32::<BigEndian>().unwrap();
+
+        file.seek(SeekFrom::Start(HEADER_L1_TABLE_OFFSET)).unwrap();
+        let l1_table_offset = file.read_u64::<BigEndian>().unwrap();
+
+        let entries_per_l2 = cluster_size / 8;
+
+        let mut append_offset = file.seek(SeekFrom::End(0)).unwrap();
+        append_offset = (append_offset + 511) & !511;
+
+        for l1_idx in 0..l1_size as u64 {
+            let l1_entry_offset = l1_table_offset + l1_idx * 8;
+            file.seek(SeekFrom::Start(l1_entry_offset)).unwrap();
+            let l1_entry = file.read_u64::<BigEndian>().unwrap();
+
+            let l2_table_addr = l1_entry & L1_L2_ADDR_MASK;
+            if l2_table_addr == 0 {
+                continue;
+            }
+
+            for l2_idx in 0..entries_per_l2 {
+                let l2_entry_offset = l2_table_addr + l2_idx * 8;
+                file.seek(SeekFrom::Start(l2_entry_offset)).unwrap();
+                let l2_entry = file.read_u64::<BigEndian>().unwrap();
+
+                if l2_entry & CLUSTER_USED_FLAG == 0 || l2_entry & COMPRESSED_FLAG != 0 {
+                    continue;
+                }
+
+                let host_cluster_addr = l2_entry & L1_L2_ADDR_MASK;
+                if host_cluster_addr == 0 {
+                    continue;
+                }
+
+                let mut cluster_data = vec![0u8; cluster_size as usize];
+                file.seek(SeekFrom::Start(host_cluster_addr)).unwrap();
+                file.read_exact(&mut cluster_data).unwrap();
+
+                let mut encoder = DeflateEncoder::new(Vec::new(), Compression::default());
+                encoder.write_all(&cluster_data).unwrap();
+                let compressed = encoder.finish().unwrap();
+
+                file.seek(SeekFrom::Start(append_offset)).unwrap();
+                file.write_all(&compressed).unwrap();
+
+                // The L2 entry encodes the compressed size in units of
+                // 512 byte sectors. The reader decodes the sector count
+                // back and computes: nsectors * 512 - (addr & 511).
+                // Because addr is 512 aligned, this yields nsectors * 512
+                // which rounds up to the next sector boundary. The file
+                // must contain enough bytes for that rounded up pread.
+                let padded_len = (compressed.len() + 511) & !511;
+                if padded_len > compressed.len() {
+                    let padding = vec![0u8; padded_len - compressed.len()];
+                    file.write_all(&padding).unwrap();
+                }
+
+                let new_entry =
+                    make_compressed_l2_entry(append_offset, compressed.len(), cluster_bits);
+                file.seek(SeekFrom::Start(l2_entry_offset)).unwrap();
+                file.write_u64::<BigEndian>(new_entry).unwrap();
+
+                append_offset += padded_len as u64;
+            }
+        }
+
+        file.flush().unwrap();
+    }
+}

--- a/block/src/qcow_common.rs
+++ b/block/src/qcow_common.rs
@@ -304,7 +304,8 @@ pub(crate) mod unit_tests {
     use flate2::write::DeflateEncoder;
     use vmm_sys_util::tempfile::TempFile;
 
-    use super::pread_alloc;
+    use super::{decompress_cluster, pread_alloc};
+    use crate::qcow::decoder::ZlibDecoder;
 
     const COMPRESSED_FLAG: u64 = 1 << 62;
     const CLUSTER_USED_FLAG: u64 = 1 << 63;
@@ -421,5 +422,18 @@ pub(crate) mod unit_tests {
         assert_eq!(buf, &data[100..300]);
 
         pread_alloc(file.as_raw_fd(), 4000, 200).unwrap_err();
+    }
+
+    #[test]
+    fn test_decompress_cluster() {
+        let cluster_size = 65536;
+        let original: Vec<u8> = (0..=255).cycle().take(cluster_size).collect();
+
+        let mut encoder = DeflateEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&original).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let result = decompress_cluster(&compressed, cluster_size, &ZlibDecoder {}).unwrap();
+        assert_eq!(result, original);
     }
 }

--- a/block/src/qcow_common.rs
+++ b/block/src/qcow_common.rs
@@ -14,6 +14,8 @@ use std::cmp::min;
 use std::os::fd::RawFd;
 use std::{io, ptr, slice};
 
+use crate::qcow::decoder::Decoder;
+
 // -- Position independent I/O helpers --
 //
 // Duplicated file descriptors share the kernel file description and thus the
@@ -42,6 +44,33 @@ pub fn pread_exact(fd: RawFd, buf: &mut [u8], offset: u64) -> io::Result<()> {
         total += ret as usize;
     }
     Ok(())
+}
+
+/// Allocate a buffer and pread exactly `len` bytes at `offset`.
+pub fn pread_alloc(fd: RawFd, offset: u64, len: usize) -> io::Result<Vec<u8>> {
+    let mut buf = vec![0u8; len];
+    pread_exact(fd, &mut buf, offset)?;
+    Ok(buf)
+}
+
+/// Decompress a full QCOW2 cluster from compressed data.
+///
+/// Returns a `cluster_size` byte buffer with the decompressed cluster
+/// content. Fails if the decoder does not produce exactly `cluster_size`
+/// bytes.
+pub fn decompress_cluster(
+    compressed: &[u8],
+    cluster_size: usize,
+    decoder: &dyn Decoder,
+) -> io::Result<Vec<u8>> {
+    let mut decompressed = vec![0u8; cluster_size];
+    let n = decoder
+        .decode(compressed, &mut decompressed)
+        .map_err(|_| io::Error::from_raw_os_error(libc::EIO))?;
+    if n != cluster_size {
+        return Err(io::Error::from_raw_os_error(libc::EIO));
+    }
+    Ok(decompressed)
 }
 
 /// Write all bytes to fd at offset, looping on short writes.

--- a/block/src/qcow_common.rs
+++ b/block/src/qcow_common.rs
@@ -436,4 +436,11 @@ pub(crate) mod unit_tests {
         let result = decompress_cluster(&compressed, cluster_size, &ZlibDecoder {}).unwrap();
         assert_eq!(result, original);
     }
+
+    #[test]
+    fn test_decompress_cluster_corrupt_input() {
+        let corrupt = vec![0xffu8; 64];
+        let err = decompress_cluster(&corrupt, 65536, &ZlibDecoder {}).unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(libc::EIO));
+    }
 }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -448,6 +448,7 @@ mod unit_tests {
     use super::*;
     use crate::disk_file::{AsyncDiskFile, DiskSize, Resizable};
     use crate::qcow::{BackingFileConfig, ImageType, QcowFile, RawFile};
+    use crate::qcow_common::unit_tests::compress_allocated_clusters;
 
     fn create_disk_with_data(
         file_size: u64,
@@ -1932,5 +1933,21 @@ mod unit_tests {
 
         let abuf = AlignedBuf::new(513, 512).unwrap();
         assert_eq!(abuf.layout().size(), 1024);
+    }
+
+    #[test]
+    fn test_compressed_read() {
+        let cluster_size = 65536usize;
+        let data: Vec<u8> = (0..=255).cycle().take(cluster_size).collect();
+        let (temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, 0, false, false);
+        drop(disk);
+
+        compress_allocated_clusters(&mut temp.as_file().try_clone().unwrap());
+
+        let disk =
+            QcowDiskSync::new(temp.as_file().try_clone().unwrap(), false, false, false).unwrap();
+
+        let buf = async_read(&disk, 0, cluster_size);
+        assert_eq!(buf, data);
     }
 }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -156,6 +156,7 @@ pub struct QcowSync {
     sparse: bool,
     /// O_DIRECT alignment requirement (0 = no alignment needed).
     alignment: usize,
+    cluster_size: u64,
     eventfd: EventFd,
     completion_list: VecDeque<(u64, i32)>,
 }
@@ -169,6 +170,7 @@ impl QcowSync {
     ) -> Self {
         let alignment = data_file.file().alignment();
         QcowSync {
+            cluster_size: metadata.cluster_size(),
             metadata,
             data_file,
             backing_file,
@@ -278,9 +280,8 @@ impl AsyncIo for QcowSync {
 
         while buf_offset < total_len {
             let curr_addr = address + buf_offset as u64;
-            let cluster_size = self.metadata.cluster_size();
-            let intra_offset = self.metadata.cluster_offset(curr_addr);
-            let remaining_in_cluster = (cluster_size - intra_offset) as usize;
+            let intra_offset = curr_addr & (self.cluster_size - 1);
+            let remaining_in_cluster = (self.cluster_size - intra_offset) as usize;
             let count = min(total_len - buf_offset, remaining_in_cluster);
 
             // Read backing data for COW if this is a partial cluster
@@ -288,10 +289,10 @@ impl AsyncIo for QcowSync {
             let backing_data = if let Some(backing) = self
                 .backing_file
                 .as_ref()
-                .filter(|_| intra_offset != 0 || count < cluster_size as usize)
+                .filter(|_| intra_offset != 0 || count < self.cluster_size as usize)
             {
                 let cluster_begin = curr_addr - intra_offset;
-                let mut data = vec![0u8; cluster_size as usize];
+                let mut data = vec![0u8; self.cluster_size as usize];
                 backing
                     .read_at(cluster_begin, &mut data)
                     .map_err(AsyncIoError::WriteVectored)?;
@@ -357,7 +358,7 @@ impl AsyncIo for QcowSync {
 
     fn punch_hole(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {
         let virtual_size = self.metadata.virtual_size();
-        let cluster_size = self.metadata.cluster_size();
+        let cluster_size = self.cluster_size;
 
         let result = self
             .metadata

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -16,14 +16,16 @@ use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, Disk
 use crate::disk_file;
 use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
 use crate::qcow::backing::shared_backing_from;
+use crate::qcow::decoder::Decoder;
 use crate::qcow::metadata::{
     BackingRead, ClusterReadMapping, ClusterWriteMapping, DeallocAction, QcowMetadata,
 };
 use crate::qcow::qcow_raw_file::QcowRawFile;
 use crate::qcow::{MAX_NESTING_DEPTH, RawFile, parse_qcow};
 use crate::qcow_common::{
-    AlignedBuf, aligned_pread, aligned_pwrite, gather_from_iovecs, gather_from_iovecs_into,
-    pread_exact, pwrite_all, scatter_to_iovecs, zero_fill_iovecs,
+    AlignedBuf, aligned_pread, aligned_pwrite, decompress_cluster, gather_from_iovecs,
+    gather_from_iovecs_into, pread_alloc, pread_exact, pwrite_all, scatter_to_iovecs,
+    zero_fill_iovecs,
 };
 
 pub struct QcowDiskSync {
@@ -157,6 +159,7 @@ pub struct QcowSync {
     /// O_DIRECT alignment requirement (0 = no alignment needed).
     alignment: usize,
     cluster_size: u64,
+    decoder: Arc<dyn Decoder>,
     eventfd: EventFd,
     completion_list: VecDeque<(u64, i32)>,
 }
@@ -171,6 +174,7 @@ impl QcowSync {
         let alignment = data_file.file().alignment();
         QcowSync {
             cluster_size: metadata.cluster_size(),
+            decoder: metadata.decoder(),
             metadata,
             data_file,
             backing_file,
@@ -239,11 +243,27 @@ impl AsyncIo for QcowSync {
                     }
                     buf_offset += len;
                 }
-                ClusterReadMapping::Compressed { data } => {
-                    let len = data.len();
+                ClusterReadMapping::Compressed {
+                    host_offset,
+                    compressed_size,
+                    cluster_offset,
+                    length,
+                } => {
+                    let compressed =
+                        pread_alloc(self.data_file.as_raw_fd(), host_offset, compressed_size)
+                            .map_err(AsyncIoError::ReadVectored)?;
+                    let decompressed =
+                        decompress_cluster(&compressed, self.cluster_size as usize, &*self.decoder)
+                            .map_err(AsyncIoError::ReadVectored)?;
                     // SAFETY: iovecs point to valid guest memory buffers
-                    unsafe { scatter_to_iovecs(iovecs, buf_offset, &data) };
-                    buf_offset += len;
+                    unsafe {
+                        scatter_to_iovecs(
+                            iovecs,
+                            buf_offset,
+                            &decompressed[cluster_offset..cluster_offset + length],
+                        );
+                    }
+                    buf_offset += length;
                 }
                 ClusterReadMapping::Backing {
                     offset: backing_offset,


### PR DESCRIPTION
Previously the read lock was held during L2 lookup, pread, and decompression. Now only the layout (host offset, compressed size) is extracted under the lock. Each queue performs pread and decompression on its own fd and a shared `Arc<dyn Decoder>`.

Helpers `pread_alloc` and `decompress_cluster` are shared across all backends. cluster_size is cached per queue to avoid repeated metadata access for the bitmask computation.

Tests use a new `compress_allocated_clusters` helper that converts standard QCOW2 clusters to compressed format at the binary level. Coverage includes `pread_alloc`, `decompress_cluster`, and end to end compressed reads through `QcowDiskSync`, `QcowDiskAsync` using concurrent queues, and `QcowFile`.

Benchmark results (us, lower is better):

| Benchmark                              | Before | After | Change |
|----------------------------------------|--------|-------|--------|
| compressed_read_128                    |   1406 |  1204 |   +14% |
| compressed_read_256                    |   3029 |  2448 |   +19% |
| async_compressed_read_128              |   1546 |  1214 |   +21% |
| async_compressed_read_256              |   2964 |  2411 |   +19% |
| multi_cluster_read_128                 |   1412 |  1200 |   +15% |
| multi_cluster_read_256                 |   2972 |  2478 |   +17% |
| async_backing_read_128                 |   1381 |  1157 |   +16% |
| async_read_256                         |   2506 |  2151 |   +14% |
| async_random_read_256                  |   2306 |  2105 |    +9% |
| async_multi_cluster_read_256           |   2663 |  2426 |    +9% |
| async_l2_cache_miss_128                |   2139 |  1963 |    +8% |
| async_l2_cache_miss_256                |   4481 |  4039 |   +10% |
| batch_write_128                        |   2614 |  2163 |   +17% |
| batch_write_256                        |   4672 |  4300 |    +8% |

The `cluster_size` caching benefits all read paths, not just compressed.

No regressions observed. Write path results are within noise.