### PR TITLE
kvm/aarch64: fix vCPU snapshot/restore on ARM9 hosts

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -460,6 +460,18 @@ pub trait Vcpu: Send + Sync {
     #[cfg(target_arch = "aarch64")]
     fn vcpu_finalize(&self, feature: i32) -> Result<()>;
     ///
+    /// Restore the subset of vCPU state that must be written *before*
+    /// `KVM_ARM_VCPU_FINALIZE`. On KVM this covers the
+    /// `KVM_REG_ARM64_SVE_VLS` pseudo-register, which selects the SVE
+    /// vector length and becomes immutable once the vcpu is finalized.
+    /// The default implementation is a no-op, which is correct for
+    /// hypervisors that do not require pre-finalize register writes.
+    ///
+    #[cfg(target_arch = "aarch64")]
+    fn restore_pre_finalize(&self, _state: &CpuState) -> Result<()> {
+        Ok(())
+    }
+    ///
     /// Gets the features that have been finalized for a given CPU.
     ///
     #[cfg(target_arch = "aarch64")]

--- a/hypervisor/src/kvm/aarch64/mod.rs
+++ b/hypervisor/src/kvm/aarch64/mod.rs
@@ -12,7 +12,8 @@ pub mod gic;
 
 use kvm_bindings::{
     KVM_REG_ARM_COPROC_MASK, KVM_REG_ARM_CORE, KVM_REG_SIZE_MASK, KVM_REG_SIZE_U32,
-    KVM_REG_SIZE_U64, kvm_mp_state, kvm_one_reg, kvm_regs,
+    KVM_REG_SIZE_U64, KVM_REG_SIZE_U128, KVM_REG_SIZE_U256, KVM_REG_SIZE_U512, KVM_REG_SIZE_U1024,
+    KVM_REG_SIZE_U2048, kvm_mp_state, kvm_one_reg, kvm_regs,
 };
 pub use kvm_ioctls::{Cap, Kvm};
 use serde::{Deserialize, Serialize};
@@ -64,19 +65,60 @@ macro_rules! arm64_core_reg_id {
 /// # Arguments
 ///
 /// * `regid` - The index of the register we are checking.
+/// Classifies a register id from `KVM_GET_REG_LIST` as a "system register"
+/// for the purposes of snapshot/restore, i.e. a register that fits in a
+/// single `u64` and is saved/restored via `VcpuKvmState::sys_regs`.
+///
+/// Core registers (aarch64 `KVM_REG_ARM_CORE`) are handled separately, and
+/// so are SVE registers wider than 64 bits; see [`is_wide_register`].
+///
+/// Panics on register sizes we do not recognise at all, so that a future
+/// kernel introducing a new register size is loud rather than silently
+/// dropped from the snapshot.
 pub fn is_system_register(regid: u64) -> bool {
     if (regid & KVM_REG_ARM_COPROC_MASK as u64) == KVM_REG_ARM_CORE as u64 {
         return false;
     }
 
-    // System registers fetched through the generic KVM_GET_REG_LIST path are
-    // always U32 or U64. Other register sizes (e.g. the U2048-sized SVE Z
-    // registers, the U256-sized SVE P registers, the U512-sized SVE VLS
-    // pseudo-register, etc.) are not "system registers" for the purposes of
-    // our save/restore machinery; treat them as non-system so they are
-    // filtered out of the system-register list rather than causing a panic.
     let size = regid & KVM_REG_SIZE_MASK;
-    size == KVM_REG_SIZE_U32 || size == KVM_REG_SIZE_U64
+    match size {
+        KVM_REG_SIZE_U32 | KVM_REG_SIZE_U64 => true,
+        KVM_REG_SIZE_U128 | KVM_REG_SIZE_U256 | KVM_REG_SIZE_U512 | KVM_REG_SIZE_U1024
+        | KVM_REG_SIZE_U2048 => false,
+        _ => panic!("Unexpected register size {size:#x} for register id {regid:#x}"),
+    }
+}
+
+/// Classifies a register id as a "wide register" for snapshot/restore, i.e.
+/// a register whose value does not fit in a single `u64` and must be saved
+/// via `VcpuKvmState::wide_regs`.
+///
+/// This covers SVE-introduced register sizes (U128 through U2048). Core
+/// registers and U32/U64 system registers return `false` here.
+pub fn is_wide_register(regid: u64) -> bool {
+    if (regid & KVM_REG_ARM_COPROC_MASK as u64) == KVM_REG_ARM_CORE as u64 {
+        return false;
+    }
+
+    let size = regid & KVM_REG_SIZE_MASK;
+    matches!(
+        size,
+        KVM_REG_SIZE_U128
+            | KVM_REG_SIZE_U256
+            | KVM_REG_SIZE_U512
+            | KVM_REG_SIZE_U1024
+            | KVM_REG_SIZE_U2048
+    )
+}
+
+/// Returns the size in bytes encoded in a KVM register id.
+///
+/// The KVM register id encodes its size in bits 52..55:
+///   0 -> U8, 1 -> U16, 2 -> U32, 3 -> U64, 4 -> U128, 5 -> U256,
+///   6 -> U512, 7 -> U1024, 8 -> U2048.
+pub fn reg_size_from_id(regid: u64) -> usize {
+    let shift = (regid & KVM_REG_SIZE_MASK) >> 52;
+    1usize << shift
 }
 
 pub fn check_required_kvm_extensions(kvm: &Kvm) -> KvmResult<()> {
@@ -100,9 +142,29 @@ pub fn check_required_kvm_extensions(kvm: &Kvm) -> KvmResult<()> {
     Ok(())
 }
 
+/// A KVM register whose value is wider than 64 bits.
+///
+/// `kvm_one_reg` carries its value in a single `u64`, so it cannot represent
+/// registers whose `KVM_REG_SIZE_*` is U128 or larger. That set includes the
+/// SVE Z registers (U2048), the SVE P registers and FFR (U256), and the SVE
+/// VLS pseudo-register (U512). We serialise their raw bytes so they can be
+/// round-tripped across snapshot/restore.
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct WideReg {
+    pub id: u64,
+    pub data: Vec<u8>,
+}
+
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct VcpuKvmState {
     pub mp_state: kvm_mp_state,
     pub core_regs: kvm_regs,
     pub sys_regs: Vec<kvm_one_reg>,
+    /// Registers wider than 64 bits (e.g. SVE Z/P/FFR/VLS).
+    ///
+    /// `#[serde(default)]` keeps snapshots taken before SVE state was
+    /// preserved deserialisable: the field simply defaults to an empty vec
+    /// when the key is absent.
+    #[serde(default)]
+    pub wide_regs: Vec<WideReg>,
 }

--- a/hypervisor/src/kvm/aarch64/mod.rs
+++ b/hypervisor/src/kvm/aarch64/mod.rs
@@ -69,14 +69,14 @@ pub fn is_system_register(regid: u64) -> bool {
         return false;
     }
 
+    // System registers fetched through the generic KVM_GET_REG_LIST path are
+    // always U32 or U64. Other register sizes (e.g. the U2048-sized SVE Z
+    // registers, the U256-sized SVE P registers, the U512-sized SVE VLS
+    // pseudo-register, etc.) are not "system registers" for the purposes of
+    // our save/restore machinery; treat them as non-system so they are
+    // filtered out of the system-register list rather than causing a panic.
     let size = regid & KVM_REG_SIZE_MASK;
-
-    assert!(
-        !(size != KVM_REG_SIZE_U32 && size != KVM_REG_SIZE_U64),
-        "Unexpected register size for system register {size}"
-    );
-
-    true
+    size == KVM_REG_SIZE_U32 || size == KVM_REG_SIZE_U64
 }
 
 pub fn check_required_kvm_extensions(kvm: &Kvm) -> KvmResult<()> {

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -113,10 +113,11 @@ pub use kvm_bindings::{
 };
 #[cfg(target_arch = "aarch64")]
 use kvm_bindings::{
-    KVM_GUESTDBG_USE_HW, KVM_NR_SPSR, KVM_REG_ARM_CORE, KVM_REG_ARM64, KVM_REG_ARM64_SYSREG,
-    KVM_REG_ARM64_SYSREG_CRM_MASK, KVM_REG_ARM64_SYSREG_CRN_MASK, KVM_REG_ARM64_SYSREG_OP0_MASK,
-    KVM_REG_ARM64_SYSREG_OP1_MASK, KVM_REG_ARM64_SYSREG_OP2_MASK, KVM_REG_SIZE_U32,
-    KVM_REG_SIZE_U64, KVM_REG_SIZE_U128, kvm_regs, user_pt_regs,
+    KVM_GUESTDBG_USE_HW, KVM_NR_SPSR, KVM_REG_ARM_CORE, KVM_REG_ARM64, KVM_REG_ARM64_SVE,
+    KVM_REG_ARM64_SVE_ZREG_BASE, KVM_REG_ARM64_SYSREG, KVM_REG_ARM64_SYSREG_CRM_MASK,
+    KVM_REG_ARM64_SYSREG_CRN_MASK, KVM_REG_ARM64_SYSREG_OP0_MASK, KVM_REG_ARM64_SYSREG_OP1_MASK,
+    KVM_REG_ARM64_SYSREG_OP2_MASK, KVM_REG_SIZE_U32, KVM_REG_SIZE_U64, KVM_REG_SIZE_U128,
+    KVM_REG_SIZE_U2048, kvm_regs, user_pt_regs,
 };
 #[cfg(target_arch = "riscv64")]
 use kvm_bindings::{KVM_REG_RISCV_CORE, kvm_riscv_core};
@@ -1704,6 +1705,21 @@ pub struct KvmVcpu {
     vm_fd: Arc<VmFd>,
 }
 
+// Compute the KVM register ID for SVE Z register `n` (slice 0).
+// Per arch/arm64/include/uapi/asm/kvm.h:
+//   KVM_REG_ARM64_SVE_ZREG(n, i) = KVM_REG_ARM64 | KVM_REG_ARM64_SVE |
+//                                  KVM_REG_ARM64_SVE_ZREG_BASE |
+//                                  KVM_REG_SIZE_U2048 | ((n & 0x1f) << 5) |
+//                                  (i & 0x1f)
+#[cfg(target_arch = "aarch64")]
+fn sve_zreg_id(n: u32) -> u64 {
+    KVM_REG_ARM64 as u64
+        | u64::from(KVM_REG_ARM64_SVE)
+        | u64::from(KVM_REG_ARM64_SVE_ZREG_BASE)
+        | KVM_REG_SIZE_U2048
+        | (u64::from(n & 0x1f) << 5)
+}
+
 /// Implementation of Vcpu trait for KVM
 ///
 /// # Examples
@@ -1820,12 +1836,29 @@ impl cpu::Vcpu for KvmVcpu {
 
         // Now moving on to floating point registers which are stored in the user_fpsimd_state in the kernel:
         // https://elixir.bootlin.com/linux/v4.9.62/source/arch/arm64/include/uapi/asm/kvm.h#L53
+        //
+        // NOTE: When the vcpu is configured with SVE, the kernel refuses to
+        // access the FPSIMD V-registers via KVM_REG_ARM_CORE (returns -EINVAL)
+        // and requires using KVM_REG_ARM64_SVE_ZREG instead. The vregs alias
+        // the low 128 bits of the SVE Z registers, so on EINVAL fall back to
+        // reading the low 128 bits of the corresponding SVE Z register.
         let mut off = offset_of!(kvm_regs, fp_regs.vregs);
         for i in 0..32 {
             let mut bytes = [0_u8; 16];
-            self.fd
+            match self
+                .fd
                 .get_one_reg(arm64_core_reg_id!(KVM_REG_SIZE_U128, off), &mut bytes)
-                .map_err(|e| cpu::HypervisorCpuError::GetAarchCoreRegister(e.into()))?;
+            {
+                Ok(_) => {}
+                Err(e) if e.errno() == libc::EINVAL => {
+                    let mut sve_buf = vec![0u8; 256];
+                    self.fd
+                        .get_one_reg(sve_zreg_id(i as u32), &mut sve_buf)
+                        .map_err(|e| cpu::HypervisorCpuError::GetAarchCoreRegister(e.into()))?;
+                    bytes.copy_from_slice(&sve_buf[..16]);
+                }
+                Err(e) => return Err(cpu::HypervisorCpuError::GetAarchCoreRegister(e.into())),
+            }
             state.fp_regs.vregs[i] = u128::from_le_bytes(bytes);
             off += mem::size_of::<u128>();
         }
@@ -1998,14 +2031,27 @@ impl cpu::Vcpu for KvmVcpu {
             off += std::mem::size_of::<u64>();
         }
 
+        // See the matching comment in get_regs(): on SVE-enabled vcpus, the
+        // kernel rejects KVM_REG_ARM_CORE access to fp_regs.vregs with
+        // -EINVAL. Fall back to writing the low 128 bits of the corresponding
+        // SVE Z register (leaving the upper bits zero).
         let mut off = offset_of!(kvm_regs, fp_regs.vregs);
         for i in 0..32 {
-            self.fd
-                .set_one_reg(
-                    arm64_core_reg_id!(KVM_REG_SIZE_U128, off),
-                    &kvm_regs_state.fp_regs.vregs[i].to_le_bytes(),
-                )
-                .map_err(|e| cpu::HypervisorCpuError::SetAarchCoreRegister(e.into()))?;
+            let res = self.fd.set_one_reg(
+                arm64_core_reg_id!(KVM_REG_SIZE_U128, off),
+                &kvm_regs_state.fp_regs.vregs[i].to_le_bytes(),
+            );
+            match res {
+                Ok(_) => {}
+                Err(e) if e.errno() == libc::EINVAL => {
+                    let mut sve_buf = vec![0u8; 256];
+                    sve_buf[..16].copy_from_slice(&kvm_regs_state.fp_regs.vregs[i].to_le_bytes());
+                    self.fd
+                        .set_one_reg(sve_zreg_id(i as u32), &sve_buf)
+                        .map_err(|e| cpu::HypervisorCpuError::SetAarchCoreRegister(e.into()))?;
+                }
+                Err(e) => return Err(cpu::HypervisorCpuError::SetAarchCoreRegister(e.into())),
+            }
             off += mem::size_of::<u128>();
         }
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -42,7 +42,10 @@ use vmm_sys_util::eventfd::EventFd;
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::gic::KvmGicV3Its;
 #[cfg(target_arch = "aarch64")]
-pub use crate::aarch64::{VcpuKvmState, check_required_kvm_extensions, is_system_register};
+pub use crate::aarch64::{
+    VcpuKvmState, WideReg, check_required_kvm_extensions, is_system_register, is_wide_register,
+    reg_size_from_id,
+};
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::gic::{Vgic, VgicConfig};
 #[cfg(target_arch = "riscv64")]
@@ -117,7 +120,7 @@ use kvm_bindings::{
     KVM_REG_ARM64_SVE_ZREG_BASE, KVM_REG_ARM64_SYSREG, KVM_REG_ARM64_SYSREG_CRM_MASK,
     KVM_REG_ARM64_SYSREG_CRN_MASK, KVM_REG_ARM64_SYSREG_OP0_MASK, KVM_REG_ARM64_SYSREG_OP1_MASK,
     KVM_REG_ARM64_SYSREG_OP2_MASK, KVM_REG_SIZE_U32, KVM_REG_SIZE_U64, KVM_REG_SIZE_U128,
-    KVM_REG_SIZE_U2048, kvm_regs, user_pt_regs,
+    KVM_REG_SIZE_U512, KVM_REG_SIZE_U2048, kvm_regs, user_pt_regs,
 };
 #[cfg(target_arch = "riscv64")]
 use kvm_bindings::{KVM_REG_RISCV_CORE, kvm_riscv_core};
@@ -1720,6 +1723,12 @@ fn sve_zreg_id(n: u32) -> u64 {
         | (u64::from(n & 0x1f) << 5)
 }
 
+// KVM_REG_ARM64_SVE_VLS pseudo-register id, per arch/arm64/include/uapi/asm/kvm.h:
+//   KVM_REG_ARM64_SVE_VLS = KVM_REG_ARM64 | KVM_REG_ARM64_SVE | KVM_REG_SIZE_U512 | 0xffff
+#[cfg(target_arch = "aarch64")]
+const KVM_REG_ARM64_SVE_VLS: u64 =
+    KVM_REG_ARM64 as u64 | (KVM_REG_ARM64_SVE as u64) | KVM_REG_SIZE_U512 | 0xffff;
+
 /// Implementation of Vcpu trait for KVM
 ///
 /// # Examples
@@ -2643,6 +2652,19 @@ impl cpu::Vcpu for KvmVcpu {
             .map_err(|e| cpu::HypervisorCpuError::VcpuFinalize(e.into()))
     }
 
+    #[cfg(target_arch = "aarch64")]
+    fn restore_pre_finalize(&self, state: &CpuState) -> cpu::Result<()> {
+        let state: VcpuKvmState = state.clone().into();
+        for reg in &state.wide_regs {
+            if reg.id == KVM_REG_ARM64_SVE_VLS {
+                self.fd
+                    .set_one_reg(reg.id, &reg.data)
+                    .map_err(|e| cpu::HypervisorCpuError::SetSysRegister(e.into()))?;
+            }
+        }
+        Ok(())
+    }
+
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     ///
     /// Gets a list of the guest registers that are supported for the
@@ -2922,39 +2944,46 @@ impl cpu::Vcpu for KvmVcpu {
         // Get core registers
         state.core_regs = self.get_regs()?.into();
 
-        // Get systerm register
-        // Call KVM_GET_REG_LIST to get all registers available to the guest.
-        // For ArmV8 there are around 500 registers.
-        let mut sys_regs: Vec<kvm_bindings::kvm_one_reg> = Vec::new();
+        // Call KVM_GET_REG_LIST to enumerate every register the guest has.
+        // For ArmV8 there are typically ~450 registers; SVE adds ~50 more
+        // (32 Z + 16 P + FFR + VLS), so 500 is a safe default here.
         let mut reg_list = kvm_bindings::RegList::new(500).unwrap();
         self.fd
             .get_reg_list(&mut reg_list)
             .map_err(|e| cpu::HypervisorCpuError::GetRegList(e.into()))?;
 
-        // At this point reg_list should contain: core registers and system
-        // registers.
-        // The register list contains the number of registers and their ids. We
-        // will be needing to call KVM_GET_ONE_REG on each id in order to save
-        // all of them. We carve out from the list  the core registers which are
-        // represented in the kernel by kvm_regs structure and for which we can
-        // calculate the id based on the offset in the structure.
-        reg_list.retain(|regid| is_system_register(*regid));
-
-        // Now, for the rest of the registers left in the previously fetched
-        // register list, we are simply calling KVM_GET_ONE_REG.
-        let indices = reg_list.as_slice();
-        for index in indices.iter() {
-            let mut bytes = [0_u8; 8];
-            self.fd
-                .get_one_reg(*index, &mut bytes)
-                .map_err(|e| cpu::HypervisorCpuError::GetSysRegister(e.into()))?;
-            sys_regs.push(kvm_bindings::kvm_one_reg {
-                id: *index,
-                addr: u64::from_le_bytes(bytes),
-            });
+        // Split the register list into three buckets:
+        //   - core registers: already captured via get_regs() above.
+        //   - wide registers (SVE Z/P/FFR/VLS): saved into `wide_regs` as
+        //     raw bytes since their values do not fit in a u64.
+        //   - "system" registers (U32/U64): saved into `sys_regs`.
+        let mut sys_regs: Vec<kvm_bindings::kvm_one_reg> = Vec::new();
+        let mut wide_regs: Vec<WideReg> = Vec::new();
+        for regid in reg_list.as_slice().iter().copied() {
+            if is_wide_register(regid) {
+                let size = reg_size_from_id(regid);
+                let mut buf = vec![0u8; size];
+                self.fd
+                    .get_one_reg(regid, &mut buf)
+                    .map_err(|e| cpu::HypervisorCpuError::GetSysRegister(e.into()))?;
+                wide_regs.push(WideReg {
+                    id: regid,
+                    data: buf,
+                });
+            } else if is_system_register(regid) {
+                let mut bytes = [0_u8; 8];
+                self.fd
+                    .get_one_reg(regid, &mut bytes)
+                    .map_err(|e| cpu::HypervisorCpuError::GetSysRegister(e.into()))?;
+                sys_regs.push(kvm_bindings::kvm_one_reg {
+                    id: regid,
+                    addr: u64::from_le_bytes(bytes),
+                });
+            }
         }
 
         state.sys_regs = sys_regs;
+        state.wide_regs = wide_regs;
 
         Ok(state.into())
     }
@@ -3120,9 +3149,28 @@ impl cpu::Vcpu for KvmVcpu {
     ///
     /// Restore the previously saved AArch64 CPU state
     ///
+    /// Register-write ordering:
+    ///  1. `wide_regs` (SVE Z/P/FFR, but not VLS; that one must be restored
+    ///     before `KVM_ARM_VCPU_FINALIZE` and is handled by
+    ///     `restore_pre_finalize`). Writing the full-width Z registers first
+    ///     means the subsequent `set_regs()` vreg fallback will overwrite
+    ///     only the low 128 bits of each Z with identical data, leaving the
+    ///     upper bits intact.
+    ///  2. Core registers (including the vreg fallback to SVE Z low-128).
+    ///  3. U32/U64 system registers.
+    ///  4. `mp_state`.
+    ///
     #[cfg(target_arch = "aarch64")]
     fn set_state(&self, state: &CpuState) -> cpu::Result<()> {
         let state: VcpuKvmState = state.clone().into();
+        for reg in &state.wide_regs {
+            if reg.id == KVM_REG_ARM64_SVE_VLS {
+                continue;
+            }
+            self.fd
+                .set_one_reg(reg.id, &reg.data)
+                .map_err(|e| cpu::HypervisorCpuError::SetSysRegister(e.into()))?;
+        }
         // Set core registers
         self.set_regs(&state.core_regs.into())?;
         // Set system registers

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -553,7 +553,7 @@ impl Vcpu {
     ) -> Result<()> {
         #[cfg(target_arch = "aarch64")]
         {
-            self.init(vm)?;
+            self.init(vm, None)?;
             self.mpidr = arch::configure_vcpu(self.vcpu.as_ref(), self.id, boot_setup)
                 .map_err(Error::VcpuConfiguration)?;
         }
@@ -605,8 +605,12 @@ impl Vcpu {
     }
 
     /// Initializes an aarch64 specific vcpu for booting Linux.
+    ///
+    /// When `restore_state` is `Some(_)`, this performs the SVE-aware restore
+    /// sequence, writing any pre-finalize registers between
+    /// `KVM_ARM_VCPU_INIT` and `KVM_ARM_VCPU_FINALIZE(SVE)`.
     #[cfg(target_arch = "aarch64")]
-    pub fn init(&self, vm: &dyn hypervisor::Vm) -> Result<()> {
+    pub fn init(&self, vm: &dyn hypervisor::Vm, restore_state: Option<&CpuState>) -> Result<()> {
         use std::arch::is_aarch64_feature_detected;
         #[allow(clippy::nonminimal_bool)]
         let sve_supported =
@@ -622,6 +626,12 @@ impl Vcpu {
             .map_err(Error::VcpuSetProcessorFeatures)?;
 
         self.vcpu.vcpu_init(&kvi).map_err(Error::VcpuArmInit)?;
+
+        if let Some(state) = restore_state {
+            self.vcpu
+                .restore_pre_finalize(state)
+                .map_err(Error::VcpuArmInit)?;
+        }
 
         if sve_supported {
             let finalized_features = self.vcpu.vcpu_get_finalized_features();
@@ -984,13 +994,15 @@ impl CpuManager {
         )?;
 
         if let Some(snapshot) = snapshot {
-            // AArch64 vCPUs should be initialized after created.
-            #[cfg(target_arch = "aarch64")]
-            vcpu.init(self.vm.as_ref())?;
-
             let state: CpuState = snapshot.to_state().map_err(|e| {
                 Error::VcpuCreate(anyhow!("Could not get vCPU state from snapshot {e:?}"))
             })?;
+
+            // AArch64 restore has to interleave pre-finalize register writes
+            // between KVM_ARM_VCPU_INIT and KVM_ARM_VCPU_FINALIZE.
+            #[cfg(target_arch = "aarch64")]
+            vcpu.init(self.vm.as_ref(), Some(&state))?;
+
             vcpu.vcpu
                 .set_state(&state)
                 .map_err(|e| Error::VcpuCreate(anyhow!("Could not set the vCPU state {e:?}")))?;


### PR DESCRIPTION
Fixes #8057

## Summary

- preserve aarch64 SVE snapshot state by saving wide KVM registers (Z/P/FFR/VLS) separately from the existing U32/U64 system-register list
- keep FPSIMD vreg save/restore working on SVE-enabled vCPUs by falling back from `KVM_REG_ARM_CORE` to `KVM_REG_ARM64_SVE_ZREG` when KVM rejects the core-register path
- restore the `KVM_REG_ARM64_SVE_VLS` pseudo-register before `KVM_ARM_VCPU_FINALIZE`, which is required because KVM makes the selected vector length immutable after finalize

## Root cause

On SVE-enabled aarch64 vCPUs, the snapshot/restore path was missing three SVE-specific KVM behaviors:

1. `fp_regs.vregs[]` is no longer accessible through `KVM_REG_ARM_CORE` once SVE is enabled. KVM returns `-EINVAL` and requires reading/writing the corresponding `KVM_REG_ARM64_SVE_ZREG(n, 0)` register instead. That made the first FPSIMD register access in `get_regs()` fail and aborted snapshotting.
2. `KVM_GET_REG_LIST` enumerates the full SVE register set. Those registers are wider than `u64` (`Z=U2048`, `P/FFR=U256`, `VLS=U512`), so they do not fit in `kvm_one_reg`. The old code treated only U32/U64 entries as snapshot-able system registers, which either panicked while classifying the register list or dropped the SVE state entirely.
3. `KVM_REG_ARM64_SVE_VLS` must be written after `KVM_ARM_VCPU_INIT` but before `KVM_ARM_VCPU_FINALIZE(SVE)`. Restoring it in the normal post-finalize register path is too late: KVM rejects the write once finalize has happened.

## Fix

`hypervisor/src/kvm/aarch64/mod.rs`

- classify KVM register ids into U32/U64 system registers and wide SVE registers instead of assuming every non-core register fits in `u64`
- add `WideReg` plus `wide_regs` to `VcpuKvmState`, with `#[serde(default)]` so older snapshots remain deserializable
- add a helper to derive the byte width encoded in a KVM register id so wide SVE registers can be serialized as raw bytes

`hypervisor/src/kvm/mod.rs`

- in the aarch64 `get_regs()` / `set_regs()` paths, fall back to `KVM_REG_ARM64_SVE_ZREG(i, 0)` on `EINVAL` when KVM refuses direct `fp_regs.vregs[i]` access; only the low 128 bits are copied because that is the FPSIMD-visible portion
- capture wide registers returned by `KVM_GET_REG_LIST` into `wide_regs` and restore them before the existing core/system-register restore sequence
- treat `KVM_REG_ARM64_SVE_VLS` specially and restore it in a pre-finalize step instead of in the normal `set_state()` path

`hypervisor/src/cpu.rs` and `vmm/src/cpu.rs`

- add a `restore_pre_finalize()` hook to the vCPU trait
- on the aarch64 restore path, call that hook between `KVM_ARM_VCPU_INIT` and `KVM_ARM_VCPU_FINALIZE(SVE)` so `KVM_REG_ARM64_SVE_VLS` is restored in the only window where KVM accepts it

Non-SVE vCPUs keep the existing behavior: the direct core-register path succeeds, there are no wide SVE registers to serialize, and the pre-finalize hook is effectively a no-op.