### PR TITLE
vmm: clear VFIO MMIO regions in DeviceManager::drop

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4958,7 +4958,7 @@ impl DeviceManager {
                 // rather than MmioRegion start addresses because move_bar()
                 // updates the device's region addresses but not the
                 // DeviceManager's cloned copies.
-                let device_regions = vfio_pci_device.lock().unwrap().mmio_regions().clone();
+                let device_regions = vfio_pci_device.lock().unwrap().mmio_regions();
                 let mut mmio_regions = self.mmio_regions.lock().unwrap();
                 for device_region in &device_regions {
                     mmio_regions.retain(|x| !x.has_matching_slots(device_region));
@@ -5865,6 +5865,11 @@ impl BusDevice for DeviceManager {
 
 impl Drop for DeviceManager {
     fn drop(&mut self) {
+        // Explicitly clear the regions owned by this device to ensure
+        // that they are dropped and unmapped before the container is cleared.
+        // See eject_device() for the device hot-unplug equivalent.
+        self.mmio_regions.lock().unwrap().clear();
+
         // Wake up the DeviceManager threads (mainly virtio device workers),
         // to avoid deadlock on waiting for paused/parked worker threads.
         if let Err(e) = self.resume() {


### PR DESCRIPTION
DeviceManager and VfioPciDevice both hold Arc<MmapRegion> for each VFIO BAR mmap window. During VM shutdown, VfioPciDevice drops after DeviceManager::Drop::drop (via device_tree field drop). Without clearing DeviceManager's clones first, VfioPciDevice::unmap_mmio_regions decrements the Arc but does not reach zero, munmap never fires, the VFIO device file VMAs survive, and VFIO_GROUP_UNSET_CONTAINER returns EBUSY.

## Sequence
VM Shutdown ..> Declaration order ..>  DeviceManager drop ..> Declaration order ..> device_tree drop ..> VfioPciDevice drop ..> VfioDevice drop ..> Close device fd ..> VFIO_GROUP_UNSET_CONTAINER ioctl -> EBUSY (Host) because device file VMA(s) survive.

## Fix
* Clear DeviceManager's mmio_regions in Drop::drop so VfioPciDevice is the sole Arc owner at drop time and ensure VFIO_GROUP_UNSET_CONTAINER ioctl success.

* Remove redundant .clone() on the mmio_regions() return value in the eject_device() hot-unplug path.


## Test
**Launch** :
```
sudo ./cloud-hypervisor \
--api-socket /home/saravanand/ch-run/ch.sock \
--firmware ./CLOUDHV.fd \
--cpus boot=1 \
--memory size=4G,shared=on \
--disk path=./noble-server-cloudimg-amd64-custom-20260327-0.raw,image_type=raw \
--disk path=./ubuntu-cloudinit.img,image_type=raw \
--device path=/sys/bus/pci/devices/0000:42:00.2 \
--seccomp=false \
--serial tty \
--console off 
```

`sudo poweroff` from within the VM

**Before** :
```
[  OK  ] Finished systemd-poweroff.service - System Power Off.
[  OK  ] Reached target poweroff.target - System Power Off.
[   27.176043] reboot: Power down
cloud-hypervisor:  30.639574s: <vmm> ERROR:/home/saravanand/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/vfio-ioctls-0.6.0/src/vfio_device.rs:384 -- Could not unbind VFIO group: 94
```

**After**:
```
[  OK  ] Finished systemd-poweroff.service - System Power Off.
[  OK  ] Reached target poweroff.target - System Power Off.
[   23.337708] reboot: Power down
saravanand@txdr-iah13b-r406-prod-hv-04:~$
```