### PR TITLE
performance-metrics: Track spawned processes per test and kill by process group

### DIFF
--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -17,7 +17,7 @@ use std::{env, fmt, thread};
 use clap::{Arg, ArgAction, Command as ClapCommand};
 use performance_tests::*;
 use serde::{Deserialize, Serialize};
-use test_infra::FioOps;
+use test_infra::{FioOps, ProcessRegistry};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -1719,45 +1719,44 @@ fn run_test_with_timeout(
     let test_iterations = overrides.test_iterations;
     let test_timeout = overrides.test_timeout;
     let overrides = overrides.clone();
-    thread::spawn(move || {
-        println!(
-            "Test '{}' running .. (control: {}, overrides: {})",
-            test.name, test.control, overrides
-        );
+    thread::Builder::new()
+        .name(test.name.into())
+        .spawn(move || {
+            println!(
+                "Test '{}' running .. (control: {}, overrides: {})",
+                test.name, test.control, overrides
+            );
 
-        let output = match std::panic::catch_unwind(|| test.run(&overrides)) {
-            Ok(test_result) => {
-                println!(
-                    "Test '{}' .. ok: mean = {}, std_dev = {}",
-                    test_result.name, test_result.mean, test_result.std_dev
-                );
-                Ok(test_result)
-            }
-            Err(_) => Err(Error::TestFailed),
-        };
+            let output = match std::panic::catch_unwind(|| test.run(&overrides)) {
+                Ok(test_result) => {
+                    println!(
+                        "Test '{}' .. ok: mean = {}, std_dev = {}",
+                        test_result.name, test_result.mean, test_result.std_dev
+                    );
+                    Ok(test_result)
+                }
+                Err(_) => Err(Error::TestFailed),
+            };
 
-        let _ = sender.send(output);
-    });
+            let _ = sender.send(output);
+        })
+        .unwrap();
 
     let test_timeout = test.calc_timeout(&test_iterations, &test_timeout);
-    receiver
+    let result = receiver
         .recv_timeout(Duration::from_secs(test_timeout))
         .map_err(|_| {
             eprintln!(
                 "[Error] Test '{}' time-out after {} seconds",
                 test.name, test_timeout
             );
-            cleanup_stale_processes();
             Error::TestTimeout
-        })?
-}
+        })
+        .and_then(|r| r);
 
-fn cleanup_stale_processes() {
-    // "cloud-hyperviso" - process name truncated to 15 chars by the kernel
-    for proc in &["cloud-hyperviso", "iperf3", "ethr"] {
-        let _ = Command::new("pkill").args(["-9", proc]).status();
-    }
-    thread::sleep(Duration::from_secs(2));
+    ProcessRegistry::cleanup(test.name);
+
+    result
 }
 
 fn settle_host() {
@@ -1914,7 +1913,6 @@ fn main() {
                     metrics_report
                         .results
                         .push(PerformanceTestResult::failed(test.name));
-                    cleanup_stale_processes();
                 } else {
                     eprintln!("Aborting test due to error: '{e:?}'");
                     std::process::exit(1);

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2604,3 +2604,26 @@ pub mod aarch64 {
 
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::*;
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    fn is_alive(pid: u32) -> bool {
+        unsafe { libc::kill(pid as i32, 0) == 0 }
+    }
+
+    #[test]
+    fn process_registry_spawn_and_cleanup() {
+        let name = "test_spawn_and_cleanup";
+        let mut cmd = Command::new("sleep");
+        cmd.arg("60");
+        let mut child = ProcessRegistry::spawn(name, &mut cmd).unwrap();
+        let pid = child.id();
+
+        assert!(is_alive(pid));
+        assert!(ProcessRegistry::cleanup(name));
+        let _ = child.wait();
+        assert!(!is_alive(pid));
+    }
+}

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![allow(clippy::undocumented_unsafe_blocks)]
 
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fmt::Display;
 use std::fs::OpenOptions;
@@ -12,9 +13,11 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::net::{TcpListener, TcpStream};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::str::FromStr;
+use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 use std::{env, fmt, fs, io, thread};
 
@@ -24,6 +27,101 @@ use ssh2::Session;
 use thiserror::Error;
 use vmm_sys_util::tempdir::TempDir;
 use wait_timeout::ChildExt;
+
+// ---------------------------------------------------------------------------
+// Process group registry, one group per test.
+//
+// Every child process spawned during a test is placed into a shared
+// process group.  The first child creates the group via setpgid(0, 0)
+// and subsequent children join via setpgid(0, pgid).  A single
+// killpg(pgid, SIGKILL) tears down all processes when the test ends.
+//
+// The registry maps test name to the group PID, protected by a mutex
+// so that concurrent tests each get their own independent group.
+//
+// Any Command::spawn() in test helpers should go through
+// ProcessRegistry::spawn so the child is automatically tracked.
+// ---------------------------------------------------------------------------
+
+static PROCESS_REGISTRY: LazyLock<Mutex<HashMap<String, u32>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub struct ProcessRegistry;
+
+impl ProcessRegistry {
+    /// Spawn `cmd` in the process group for `test_name`.
+    ///
+    /// The first spawn creates a new group (group PID = child PID).
+    /// Subsequent spawns join the existing group.
+    pub fn spawn(test_name: &str, cmd: &mut Command) -> io::Result<Child> {
+        let pgid = {
+            let mut reg = PROCESS_REGISTRY.lock().unwrap();
+            let stored = reg.get(test_name).copied();
+            // If the stored group no longer has any live processes,
+            // discard it so the next child creates a fresh group.
+            if let Some(id) = stored {
+                let probe = unsafe { libc::killpg(id as i32, 0) };
+                if probe == -1 && io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+                    reg.remove(test_name);
+                    None
+                } else {
+                    stored
+                }
+            } else {
+                None
+            }
+        };
+
+        unsafe {
+            cmd.pre_exec(move || {
+                let target = pgid.unwrap_or(0) as libc::pid_t;
+                // Best effort: may fail with EPERM in containers.
+                let _ = libc::setpgid(0, target);
+                Ok(())
+            });
+        }
+
+        let child = cmd.spawn()?;
+
+        if pgid.is_none() {
+            let actual = unsafe { libc::getpgid(child.id() as i32) };
+            if actual == child.id() as i32 {
+                PROCESS_REGISTRY
+                    .lock()
+                    .unwrap()
+                    .insert(test_name.to_string(), child.id());
+            }
+        }
+
+        Ok(child)
+    }
+
+    /// Kill all processes in the group for `test_name` and remove
+    /// the entry.
+    pub fn cleanup(test_name: &str) -> bool {
+        let pgid = PROCESS_REGISTRY.lock().unwrap().remove(test_name);
+
+        if let Some(pgid) = pgid {
+            let ret = unsafe { libc::killpg(pgid as i32, libc::SIGKILL) };
+            if ret == 0 {
+                eprintln!(
+                    "[cleanup] Sent SIGKILL to process group {pgid} \
+                     (test '{test_name}')"
+                );
+                return true;
+            }
+            let err = io::Error::last_os_error();
+            // ESRCH: all processes already exited.
+            if err.raw_os_error() != Some(libc::ESRCH) {
+                eprintln!(
+                    "[cleanup] Failed to kill process group {pgid} \
+                     (test '{test_name}'): {err}"
+                );
+            }
+        }
+        false
+    }
+}
 
 #[derive(Error, Debug)]
 pub enum WaitTimeoutError {
@@ -1046,6 +1144,8 @@ pub struct Guest {
     pub num_cpu: u32,
     pub nested: bool,
     pub mem_size_str: String,
+    /// Test name, set from the current thread name at construction.
+    pub test_name: Option<String>,
 }
 
 // Return the next id that can be used for this guest. This is stored in a
@@ -1118,6 +1218,7 @@ impl Guest {
             num_cpu: 1u32,
             nested: true,
             mem_size_str: "512M".to_string(),
+            test_name: thread::current().name().map(String::from),
         }
     }
 

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2626,4 +2626,30 @@ mod unit_tests {
         let _ = child.wait();
         assert!(!is_alive(pid));
     }
+
+    #[test]
+    fn process_registry_shared_group() {
+        let name = "test_shared_group";
+
+        let mut cmd1 = Command::new("sleep");
+        cmd1.arg("60");
+        let mut child1 = ProcessRegistry::spawn(name, &mut cmd1).unwrap();
+        let pid1 = child1.id();
+
+        let mut cmd2 = Command::new("sleep");
+        cmd2.arg("60");
+        let mut child2 = ProcessRegistry::spawn(name, &mut cmd2).unwrap();
+        let pid2 = child2.id();
+
+        let pgid1 = unsafe { libc::getpgid(pid1 as i32) };
+        let pgid2 = unsafe { libc::getpgid(pid2 as i32) };
+        assert_eq!(pgid1, pgid2);
+        assert_eq!(pgid1, pid1 as i32);
+
+        assert!(ProcessRegistry::cleanup(name));
+        let _ = child1.wait();
+        let _ = child2.wait();
+        assert!(!is_alive(pid1));
+        assert!(!is_alive(pid2));
+    }
 }

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2657,4 +2657,29 @@ mod unit_tests {
     fn process_registry_cleanup_unknown() {
         assert!(!ProcessRegistry::cleanup("nonexistent"));
     }
+
+    #[test]
+    fn process_registry_stale_group_replaced() {
+        let name = "test_stale_group";
+
+        let mut cmd1 = Command::new("sleep");
+        cmd1.arg("0");
+        let mut child1 = ProcessRegistry::spawn(name, &mut cmd1).unwrap();
+        let pid1 = child1.id();
+        let _ = child1.wait();
+
+        // Group is now stale. Next spawn should create a fresh group.
+        let mut cmd2 = Command::new("sleep");
+        cmd2.arg("60");
+        let mut child2 = ProcessRegistry::spawn(name, &mut cmd2).unwrap();
+        let pid2 = child2.id();
+
+        assert_ne!(pid1, pid2);
+        let pgid2 = unsafe { libc::getpgid(pid2 as i32) };
+        assert_eq!(pgid2, pid2 as i32);
+
+        assert!(ProcessRegistry::cleanup(name));
+        let _ = child2.wait();
+        assert!(!is_alive(pid2));
+    }
 }

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2652,4 +2652,9 @@ mod unit_tests {
         assert!(!is_alive(pid1));
         assert!(!is_alive(pid2));
     }
+
+    #[test]
+    fn process_registry_cleanup_unknown() {
+        assert!(!ProcessRegistry::cleanup("nonexistent"));
+    }
 }

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -1904,15 +1904,16 @@ impl<'a> GuestCommand<'a> {
         }
 
         if self.capture_output {
+            self.command.stderr(Stdio::piped()).stdout(Stdio::piped());
+
             // The caller should call .wait() on the returned child
             #[allow(unknown_lints)]
             #[allow(clippy::zombie_processes)]
-            let child = self
-                .command
-                .stderr(Stdio::piped())
-                .stdout(Stdio::piped())
-                .spawn()
-                .unwrap();
+            let child = if let Some(name) = &self.guest.test_name {
+                ProcessRegistry::spawn(name, &mut self.command)?
+            } else {
+                self.command.spawn().unwrap()
+            };
 
             let fd = child.stdout.as_ref().unwrap().as_raw_fd();
             let pipesize = unsafe { libc::fcntl(fd, libc::F_SETPIPE_SZ, PIPE_SIZE) };
@@ -1936,7 +1937,11 @@ impl<'a> GuestCommand<'a> {
             // The caller should call .wait() on the returned child
             #[allow(unknown_lints)]
             #[allow(clippy::zombie_processes)]
-            self.command.spawn()
+            if let Some(name) = &self.guest.test_name {
+                ProcessRegistry::spawn(name, &mut self.command)
+            } else {
+                self.command.spawn()
+            }
         }
     }
 
@@ -2326,11 +2331,12 @@ pub fn measure_virtio_net_throughput(
         if !bandwidth {
             cmd.args(["-u", "-b", "1T"]);
         }
-        let client = cmd
-            .stderr(Stdio::piped())
-            .stdout(Stdio::piped())
-            .spawn()
-            .map_err(Error::Spawn)?;
+        cmd.stderr(Stdio::piped()).stdout(Stdio::piped());
+        let client = if let Some(name) = &guest.test_name {
+            ProcessRegistry::spawn(name, &mut cmd).map_err(Error::Spawn)?
+        } else {
+            cmd.spawn().map_err(Error::Spawn)?
+        };
 
         clients.push(client);
     }
@@ -2425,8 +2431,9 @@ pub fn measure_virtio_net_latency(guest: &Guest, test_timeout: u32) -> Result<Ve
         .to_str()
         .unwrap()
         .to_string();
-    let mut c = Command::new(ethr_path)
-        .args([
+    let mut c = {
+        let mut cmd = Command::new(ethr_path);
+        cmd.args([
             "-c",
             &guest.network.guest_ip0,
             "-t",
@@ -2437,9 +2444,13 @@ pub fn measure_virtio_net_latency(guest: &Guest, test_timeout: u32) -> Result<Ve
             &format!("{test_timeout}s"),
         ])
         .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .map_err(Error::Spawn)?;
+        .stdout(Stdio::piped());
+        if let Some(name) = &guest.test_name {
+            ProcessRegistry::spawn(name, &mut cmd).map_err(Error::Spawn)?
+        } else {
+            cmd.spawn().map_err(Error::Spawn)?
+        }
+    };
 
     if let Err(e) = child_wait_timeout(&mut c, test_timeout as u64 + 5).map_err(Error::WaitTimeout)
     {


### PR DESCRIPTION
The performance metrics tool used `pkill -9` to clean up stale processes by name. This is fragile because it kills processes globally, can hit unrelated processes, and only runs on the error path.

This PR replaces that with a global `ProcessRegistry` using POSIX process groups. Each test gets its own group. The first child creates it via `setpgid(0, 0)`, subsequent children join via `setpgid(0, pgid)`. A single `killpg(pgid, SIGKILL)` tears down everything when the test ends.

`Guest.test_name` is set automatically from the current thread name. The `#[test]` harness names threads after the test function, so integration tests also get process group tracking through `GuestCommand::spawn()` without any changes to test code.

The microbench tests do not currently spawn external processes, but if they do in the future, they will need to go through `ProcessRegistry::spawn()` to be tracked.

`ProcessRegistry::cleanup()` is called unconditionally after every performance test, covering both success and failure paths. The old `cleanup_stale_processes()` is removed.

Fixes #8045