### PR TITLE
virtio-devices: Fix some spec compliance issues

### DIFF
--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -174,12 +174,10 @@ impl CtrlQueue {
                         .map_err(|e| Error::GuestMemory(GuestMemoryError::IOError(e)))?,
                 )
                 .map_err(Error::GuestMemory)?;
-            // Per virtio spec 2.6.8, used_len is the number of bytes written
-            // to device-writable descriptors. Only the status byte is written.
-            let len = status_desc.len();
-
+            // Per the virtio spec the used length is bytes the device wrote
+            // to device-writable descriptors; here just the 1-byte ack.
             queue
-                .add_used(desc_chain.memory(), desc_chain.head_index(), len)
+                .add_used(desc_chain.memory(), desc_chain.head_index(), 1)
                 .map_err(Error::QueueAddUsed)?;
 
             if !queue

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -97,7 +97,7 @@ impl TxVirtio {
                 next_desc = desc_chain.next();
             }
 
-            let len = if iovecs.is_empty() {
+            let bytes_sent = if iovecs.is_empty() {
                 0
             } else {
                 // SAFETY: FFI call with correct arguments
@@ -129,7 +129,7 @@ impl TxVirtio {
                 self.counter_bytes += Wrapping(result as u64 - vnet_hdr_len() as u64);
                 self.counter_frames += Wrapping(1);
 
-                result as u32
+                result as u64
             };
 
             // For the sake of simplicity (similar to the RX rate limiting), we always
@@ -137,11 +137,14 @@ impl TxVirtio {
             // limit, and simply stop processing oncoming `avail_desc` if any.
             if let Some(rate_limiter) = rate_limiter {
                 rate_limit_reached = !rate_limiter.consume(1, TokenType::Ops)
-                    || !rate_limiter.consume(len as u64, TokenType::Bytes);
+                    || !rate_limiter.consume(bytes_sent, TokenType::Bytes);
             }
 
+            // TX descriptors are device-readable only; the device wrote
+            // nothing back to guest memory, so per the virtio spec the used
+            // length is 0.
             queue
-                .add_used(desc_chain.memory(), desc_chain.head_index(), len)
+                .add_used(desc_chain.memory(), desc_chain.head_index(), 0)
                 .map_err(NetQueuePairError::QueueAddUsed)?;
 
             if !queue

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -20,7 +20,7 @@ use std::time::Instant;
 use std::{convert, io, process, result};
 
 use block::qcow::{self, ImageType, QcowFile};
-use block::{Request, VirtioBlockConfig, build_serial};
+use block::{Request, RequestType, VirtioBlockConfig, build_serial};
 use libc::EFD_NONBLOCK;
 use log::{debug, error, info, warn};
 use option_parser::{OptionParser, OptionParserError, Toggle};
@@ -128,36 +128,33 @@ impl VhostUserBlkThread {
             .pop_descriptor_chain(self.mem.memory())
         {
             debug!("got an element in the queue");
-            let len;
-            match Request::parse(&mut desc_chain, None) {
+            let len = match Request::parse(&mut desc_chain, None) {
                 Ok(mut request) => {
                     debug!("element is a valid request");
                     request.set_writeback(self.writeback.load(Ordering::Acquire));
-                    let status = match request.execute(
+                    let (status, len) = match request.execute(
                         &mut self.disk_image.lock().unwrap().deref_mut(),
                         self.disk_nsectors,
                         desc_chain.memory(),
                         &self.serial,
                     ) {
-                        Ok(l) => {
-                            len = l;
-                            VIRTIO_BLK_S_OK as u8
+                        Ok(_) if request.request_type == RequestType::GetDeviceId => {
+                            (VIRTIO_BLK_S_OK as u8, self.serial.len() as u32 + 1)
                         }
-                        Err(e) => {
-                            len = 1;
-                            e.status()
-                        }
+                        Ok(l) => (VIRTIO_BLK_S_OK as u8, l + 1),
+                        Err(e) => (e.status(), 1),
                     };
                     desc_chain
                         .memory()
                         .write_obj(status, request.status_addr)
                         .unwrap();
+                    len
                 }
                 Err(err) => {
                     error!("failed to parse available descriptor chain: {err:?}");
-                    len = 0;
+                    0
                 }
-            }
+            };
 
             vring
                 .get_queue_mut()

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -268,7 +268,7 @@ Setting device status to 'NEEDS_RESET' and stopping processing queues until rese
                 // If no asynchronous operation has been submitted, we can
                 // simply return the used descriptor.
                 queue
-                    .add_used(desc_chain.memory(), desc_chain.head_index(), 0)
+                    .add_used(desc_chain.memory(), desc_chain.head_index(), 1)
                     .map_err(Error::QueueAddUsed)?;
                 queue
                     .enable_notification(self.mem.memory().deref())
@@ -349,10 +349,17 @@ Setting device status to 'NEEDS_RESET' and stopping processing queues until rese
                     .write_obj(status as u8, request.status_addr)
                     .map_err(Error::RequestStatus)?;
 
+                let len = if status == VIRTIO_BLK_S_OK
+                    && request.request_type == RequestType::GetDeviceId
+                {
+                    self.serial.len() as u32 + 1
+                } else {
+                    1
+                };
                 // If no asynchronous operation has been submitted, we can
                 // simply return the used descriptor.
                 queue
-                    .add_used(desc_chain.memory(), desc_chain.head_index(), 0)
+                    .add_used(desc_chain.memory(), desc_chain.head_index(), len)
                     .map_err(Error::QueueAddUsed)?;
                 queue
                     .enable_notification(self.mem.memory().deref())
@@ -373,7 +380,7 @@ Setting device status to 'NEEDS_RESET' and stopping processing queues until rese
                     mem.write_obj(VIRTIO_BLK_S_IOERR as u8, request.status_addr)
                         .map_err(Error::RequestStatus)?;
                     queue
-                        .add_used(mem.deref(), desc_index, 0)
+                        .add_used(mem.deref(), desc_index, 1)
                         .map_err(Error::QueueAddUsed)?;
                     queue
                         .enable_notification(mem.deref())
@@ -528,14 +535,19 @@ Setting device status to 'NEEDS_RESET' and stopping processing queues until rese
                     .write_latency_avg
                     .store(write_avg, Ordering::Relaxed);
 
-                (VIRTIO_BLK_S_OK as u8, result as u32)
+                let len = if request.request_type == RequestType::In {
+                    result as u32 + 1
+                } else {
+                    1
+                };
+                (VIRTIO_BLK_S_OK as u8, len)
             } else {
                 warn!(
                     "Request failed: {:x?} {:?}",
                     request,
                     io::Error::from_raw_os_error(-result)
                 );
-                (VIRTIO_BLK_S_IOERR as u8, 0)
+                (VIRTIO_BLK_S_IOERR as u8, 1)
             };
 
             mem.write_obj(status, request.status_addr)

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -293,7 +293,7 @@ impl Request {
         if desc.is_write_only() {
             return Err(Error::UnexpectedWriteOnlyDescriptor);
         }
-        if desc.len() as usize != size_of::<VirtioMemReq>() {
+        if (desc.len() as usize) < size_of::<VirtioMemReq>() {
             return Err(Error::InvalidRequest);
         }
         let req: VirtioMemReq = desc_chain

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -115,7 +115,7 @@ impl Request {
             return Err(Error::UnexpectedWriteOnlyDescriptor);
         }
 
-        if desc.len() as usize != size_of::<VirtioPmemReq>() {
+        if (desc.len() as usize) < size_of::<VirtioPmemReq>() {
             return Err(Error::InvalidRequest);
         }
 

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -191,7 +191,17 @@ impl PmemEpollHandler {
                 Ok(ref req) => {
                     // Currently, there is only one virtio-pmem request, FLUSH.
                     error!("Invalid virtio request type {:?}", req.type_);
-                    0
+                    // The virtio spec requires a status response even on error.
+                    let resp = VirtioPmemResp {
+                        ret: VIRTIO_PMEM_RESP_TYPE_EIO,
+                    };
+                    match desc_chain.memory().write_obj(resp, req.status_addr) {
+                        Ok(()) => size_of::<VirtioPmemResp>() as u32,
+                        Err(e) => {
+                            error!("Bad guest memory address: {e}");
+                            0
+                        }
+                    }
                 }
                 Err(e) => {
                     error!("Failed to parse available descriptor chain: {e:?}");

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -12,7 +12,7 @@ use std::{io, result};
 
 use anyhow::anyhow;
 use event_monitor::event;
-use log::{error, info};
+use log::{error, info, warn};
 use seccompiler::SeccompAction;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -39,12 +39,6 @@ const QUEUE_AVAIL_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 1;
 
 #[derive(Error, Debug)]
 enum Error {
-    #[error("Descriptor chain too short")]
-    DescriptorChainTooShort,
-    #[error("Invalid descriptor")]
-    InvalidDescriptor,
-    #[error("Failed to write to guest memory")]
-    GuestMemoryWrite(#[source] vm_memory::guest_memory::Error),
     #[error("Failed adding used index")]
     QueueAddUsed(#[source] virtio_queue::Error),
 }
@@ -66,29 +60,50 @@ impl RngEpollHandler {
 
         let mut used_descs = false;
         while let Some(mut desc_chain) = queue.pop_descriptor_chain(self.mem.memory()) {
-            let desc = desc_chain.next().ok_or(Error::DescriptorChainTooShort)?;
-
-            // The descriptor must be write-only and non-zero length
-            if !(desc.is_write_only() && desc.len() > 0) {
-                return Err(Error::InvalidDescriptor);
-            }
-
-            // Fill the read with data from the random device on the host.
-            let len = desc_chain
-                .memory()
-                .read_volatile_from(
-                    desc.addr()
-                        .translate_gva(self.access_platform.as_deref(), desc.len() as usize)
-                        .map_err(|e| {
-                            Error::GuestMemoryWrite(vm_memory::GuestMemoryError::IOError(e))
-                        })?,
+            // virtio-rng has no status byte; on any error along the chain
+            // report a used length of 0 to indicate failure.
+            let mut total_len: usize = 0;
+            while let Some(desc) = desc_chain.next() {
+                if !desc.is_write_only() || desc.len() == 0 {
+                    warn!(
+                        "Skipping descriptor with write_only={} len={}",
+                        desc.is_write_only(),
+                        desc.len()
+                    );
+                    total_len = 0;
+                    break;
+                }
+                let addr = match desc
+                    .addr()
+                    .translate_gva(self.access_platform.as_deref(), desc.len() as usize)
+                {
+                    Ok(a) => a,
+                    Err(e) => {
+                        warn!("Failed to translate descriptor address: {e}");
+                        total_len = 0;
+                        break;
+                    }
+                };
+                match desc_chain.memory().read_volatile_from(
+                    addr,
                     &mut self.random_file,
                     desc.len() as usize,
-                )
-                .map_err(Error::GuestMemoryWrite)?;
+                ) {
+                    Ok(written) => total_len += written,
+                    Err(e) => {
+                        warn!("Failed to read entropy into descriptor: {e}");
+                        total_len = 0;
+                        break;
+                    }
+                }
+            }
 
             queue
-                .add_used(desc_chain.memory(), desc_chain.head_index(), len as u32)
+                .add_used(
+                    desc_chain.memory(),
+                    desc_chain.head_index(),
+                    total_len as u32,
+                )
                 .map_err(Error::QueueAddUsed)?;
             used_descs = true;
         }


### PR DESCRIPTION
Fix some basic spec compliance issues. :

* Tolerating multiple writable descriptors (some devices already did this)
* Ensuring the correct number of bytes reported via `add_used()`
* Supporting descriptors larger than our version of the struct.

I used Claude to compare the virtio spec with our implementation. There was a lot of issues; these are fixes for all those related to reporting wrong bytes written with `.add_used()` and incorrect descriptor chain expectations (multiple writable, too strict.)

- **virtio-devices: net: Report correct used length on TX and ctrl**
- **virtio-devices: mem: Relax descriptor size check**
- **virtio-devices: pmem: Relax descriptor size check**
- **virtio-devices: pmem: Always write status response on error**
- **virtio-devices: rng: Fill the entire descriptor chain**
- **vhost_user_block: Correctly report number of used bytes**
- **virtio-devices: block: Correctly report number of bytes written**

