### PR TITLE
block: Rename AsyncDiskFile::new_async_io to create_async_io

### DIFF
--- a/block/src/async_io.rs
+++ b/block/src/async_io.rs
@@ -72,7 +72,7 @@ pub trait DiskFile: Send {
     fn logical_size(&mut self) -> DiskFileResult<u64>;
     /// Returns the physical size of the underlying file.
     fn physical_size(&mut self) -> DiskFileResult<u64>;
-    fn new_async_io(&self, ring_depth: u32) -> DiskFileResult<Box<dyn AsyncIo>>;
+    fn create_async_io(&self, ring_depth: u32) -> DiskFileResult<Box<dyn AsyncIo>>;
     fn topology(&mut self) -> DiskTopology {
         DiskTopology::default()
     }

--- a/block/src/disk_file.rs
+++ b/block/src/disk_file.rs
@@ -24,7 +24,7 @@
 //!         /                                     \
 //! FullDiskFile:                           AsyncDiskFile:
 //!   DiskFile + PhysicalSize +               DiskFile + Unpin
-//!   DiskFd + SparseCapable +               try_clone, new_async_io
+//!   DiskFd + SparseCapable +               try_clone, create_async_io
 //!   Resizable
 //!         \                                     /
 //!          AsyncFullDiskFile: FullDiskFile + AsyncDiskFile
@@ -139,7 +139,7 @@ pub trait AsyncDiskFile: DiskFile + Unpin {
     ///   Callers typically pass the virtio queue size. Must be greater
     ///   than zero. Backends that do not use an async ring (e.g. sync
     ///   fallback implementations) may ignore this value.
-    fn new_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>>;
+    fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>>;
 }
 
 /// Full capability async disk file trait.
@@ -215,12 +215,12 @@ impl DiskBackend {
         }
     }
 
-    pub fn new_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+    pub fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
         match self {
             Self::Legacy(d) => d
-                .new_async_io(ring_depth)
+                .create_async_io(ring_depth)
                 .map_err(|e| BlockError::new(BlockErrorKind::Io, io::Error::other(e))),
-            Self::Next(d) => d.new_async_io(ring_depth),
+            Self::Next(d) => d.create_async_io(ring_depth),
         }
     }
 

--- a/block/src/fixed_vhd_async.rs
+++ b/block/src/fixed_vhd_async.rs
@@ -70,7 +70,7 @@ impl disk_file::AsyncDiskFile for FixedVhdDiskAsync {
         Ok(Box::new(FixedVhdDiskAsync(self.0.clone())))
     }
 
-    fn new_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+    fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
         let size = self
             .0
             .logical_size()

--- a/block/src/fixed_vhd_sync.rs
+++ b/block/src/fixed_vhd_sync.rs
@@ -70,7 +70,7 @@ impl disk_file::AsyncDiskFile for FixedVhdDiskSync {
         Ok(Box::new(FixedVhdDiskSync(self.0.clone())))
     }
 
-    fn new_async_io(&self, _ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+    fn create_async_io(&self, _ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
         let size = self
             .0
             .logical_size()

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -146,7 +146,7 @@ impl disk_file::AsyncDiskFile for QcowDiskAsync {
         }))
     }
 
-    fn new_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+    fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
         Ok(Box::new(
             QcowAsync::new(
                 Arc::clone(&self.metadata),
@@ -731,7 +731,7 @@ mod unit_tests {
     }
 
     fn async_write(disk: &QcowDiskAsync, offset: u64, data: &[u8]) {
-        let mut async_io = disk.new_async_io(1).unwrap();
+        let mut async_io = disk.create_async_io(1).unwrap();
         let iovec = libc::iovec {
             iov_base: data.as_ptr() as *mut libc::c_void,
             iov_len: data.len(),
@@ -749,7 +749,7 @@ mod unit_tests {
     }
 
     fn async_read(disk: &QcowDiskAsync, offset: u64, len: usize) -> Vec<u8> {
-        let mut async_io = disk.new_async_io(1).unwrap();
+        let mut async_io = disk.create_async_io(1).unwrap();
         let mut buf = vec![0xFFu8; len];
         let iovec = libc::iovec {
             iov_base: buf.as_mut_ptr() as *mut libc::c_void,
@@ -770,7 +770,7 @@ mod unit_tests {
         let offset = 0u64;
         let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true);
 
-        let mut async_io = disk.new_async_io(1).unwrap();
+        let mut async_io = disk.create_async_io(1).unwrap();
         async_io.punch_hole(offset, data.len() as u64, 100).unwrap();
         let (user_data, result) = async_io.next_completed_request().unwrap();
         assert_eq!(user_data, 100);
@@ -790,7 +790,7 @@ mod unit_tests {
         let offset = 0u64;
         let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true);
 
-        let mut async_io = disk.new_async_io(1).unwrap();
+        let mut async_io = disk.create_async_io(1).unwrap();
         async_io
             .write_zeroes(offset, data.len() as u64, 200)
             .unwrap();
@@ -862,7 +862,7 @@ mod unit_tests {
         let disk = QcowDiskAsync::new(temp_file.as_file().try_clone().unwrap(), false, false, true)
             .unwrap();
 
-        let mut async_io = disk.new_async_io(8).unwrap();
+        let mut async_io = disk.create_async_io(8).unwrap();
 
         // Prepare write data for two regions.
         let write_a = vec![0xAA; 4096];
@@ -917,7 +917,7 @@ mod unit_tests {
             iov_len: read_b.len(),
         };
 
-        let mut async_io = disk.new_async_io(8).unwrap();
+        let mut async_io = disk.create_async_io(8).unwrap();
         let read_batch = vec![
             BatchRequest {
                 offset: offset_a as libc::off_t,
@@ -1012,7 +1012,7 @@ mod unit_tests {
         let buf = async_read(&disk, offset, data.len());
         assert!(buf.iter().all(|&b| b == 0xAA));
 
-        let mut async_io = disk.new_async_io(1).unwrap();
+        let mut async_io = disk.create_async_io(1).unwrap();
         async_io.punch_hole(offset, data.len() as u64, 10).unwrap();
         let (_, result) = wait_for_completion(async_io.as_mut());
         assert_eq!(result, 0);
@@ -1065,7 +1065,7 @@ mod unit_tests {
         }
         let disk = QcowDiskAsync::new(temp_file.as_file().try_clone().unwrap(), false, false, true)
             .unwrap();
-        let async_io = disk.new_async_io(1).unwrap();
+        let async_io = disk.create_async_io(1).unwrap();
         assert_eq!(async_io.alignment(), SECTOR_SIZE);
     }
 
@@ -1088,7 +1088,7 @@ mod unit_tests {
                 return;
             }
         };
-        let async_io = disk.new_async_io(1).unwrap();
+        let async_io = disk.create_async_io(1).unwrap();
         assert!(async_io.alignment() >= SECTOR_SIZE);
     }
 
@@ -1149,7 +1149,7 @@ mod unit_tests {
                 let disk = Arc::clone(&disk);
                 let expected = data.clone();
                 thread::spawn(move || {
-                    let mut async_io = disk.new_async_io(1).unwrap();
+                    let mut async_io = disk.create_async_io(1).unwrap();
                     let mut buf = vec![0xFFu8; cluster_size];
                     let iovec = libc::iovec {
                         iov_base: buf.as_mut_ptr() as *mut libc::c_void,

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -140,7 +140,7 @@ impl disk_file::AsyncDiskFile for QcowDiskSync {
 
     // ring_depth is unused - this sync backend performs blocking I/O
     // instead of submitting to an async ring.
-    fn new_async_io(&self, _ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+    fn create_async_io(&self, _ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
         Ok(Box::new(QcowSync::new(
             Arc::clone(&self.metadata),
             self.data_raw_file.clone(),
@@ -476,7 +476,7 @@ mod unit_tests {
     }
 
     fn async_read(disk: &QcowDiskSync, offset: u64, len: usize) -> Vec<u8> {
-        let mut async_io = disk.new_async_io(1).unwrap();
+        let mut async_io = disk.create_async_io(1).unwrap();
         let mut buf = vec![0xFFu8; len];
         let iovec = libc::iovec {
             iov_base: buf.as_mut_ptr() as *mut libc::c_void,
@@ -492,7 +492,7 @@ mod unit_tests {
     }
 
     fn async_write(disk: &QcowDiskSync, offset: u64, data: &[u8]) {
-        let mut async_io = disk.new_async_io(1).unwrap();
+        let mut async_io = disk.create_async_io(1).unwrap();
         let iovec = libc::iovec {
             iov_base: data.as_ptr() as *mut libc::c_void,
             iov_len: data.len(),
@@ -511,7 +511,7 @@ mod unit_tests {
         let offset = 0u64;
         let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true, false);
 
-        let mut async_io = disk.new_async_io(1).unwrap();
+        let mut async_io = disk.create_async_io(1).unwrap();
         async_io.punch_hole(offset, data.len() as u64, 100).unwrap();
         let (user_data, result) = async_io.next_completed_request().unwrap();
         assert_eq!(user_data, 100);
@@ -531,7 +531,7 @@ mod unit_tests {
         let offset = 64 * 1024u64;
         let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true, false);
 
-        let mut async_io = disk.new_async_io(1).unwrap();
+        let mut async_io = disk.create_async_io(1).unwrap();
         async_io
             .write_zeroes(offset, data.len() as u64, 200)
             .unwrap();
@@ -568,7 +568,7 @@ mod unit_tests {
         let disk =
             QcowDiskSync::new(_temp.as_file().try_clone().unwrap(), false, false, true).unwrap();
 
-        let mut async_io = disk.new_async_io(1).unwrap();
+        let mut async_io = disk.create_async_io(1).unwrap();
 
         async_io.punch_hole(0, 64 * 1024, 1).unwrap();
         async_io.punch_hole(128 * 1024, 64 * 1024, 2).unwrap();
@@ -593,7 +593,7 @@ mod unit_tests {
         let offset = 0u64;
         let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true, false);
 
-        let mut async_io1 = disk.new_async_io(1).unwrap();
+        let mut async_io1 = disk.create_async_io(1).unwrap();
         async_io1
             .punch_hole(offset, data.len() as u64, 100)
             .unwrap();
@@ -611,14 +611,14 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_qcow_disk_sync_punch_hole_with_new_async_io() {
+    fn test_qcow_disk_sync_punch_hole_with_create_async_io() {
         // Simulates the real usage pattern of write data, punch hole, then read back.
         let data = vec![0xCD; 64 * 1024]; // one cluster
         let offset = 1024 * 1024u64; // 1MB offset
         let (_temp, disk) = create_disk_with_data(100 * 1024 * 1024, &data, offset, true, false);
 
         // Punch hole to simulate DISCARD
-        let mut async_io1 = disk.new_async_io(1).unwrap();
+        let mut async_io1 = disk.create_async_io(1).unwrap();
         async_io1.punch_hole(offset, data.len() as u64, 1).unwrap();
         let (user_data, result) = async_io1.next_completed_request().unwrap();
         assert_eq!(user_data, 1);
@@ -629,7 +629,7 @@ mod unit_tests {
         let read_buf = async_read(&disk, offset, data.len());
         assert!(
             read_buf.iter().all(|&b| b == 0),
-            "After punch_hole via new_async_io, read should return zeros"
+            "After punch_hole via create_async_io, read should return zeros"
         );
     }
 
@@ -641,7 +641,7 @@ mod unit_tests {
 
         async_write(&disk, offset, &data);
 
-        let mut async_io = disk.new_async_io(1).unwrap();
+        let mut async_io = disk.create_async_io(1).unwrap();
         async_io.fsync(Some(10)).unwrap();
         let (ud, res) = async_io.next_completed_request().unwrap();
         assert_eq!(ud, 10);
@@ -691,7 +691,7 @@ mod unit_tests {
 
         async_write(&disk, offset, &data);
 
-        let mut async_io = disk.new_async_io(1).unwrap();
+        let mut async_io = disk.create_async_io(1).unwrap();
         async_io.fsync(Some(99)).unwrap();
         drop(async_io);
 
@@ -825,7 +825,7 @@ mod unit_tests {
         let new_data = vec![0xAB; cluster_size as usize];
         async_write(&disk, 0, &new_data);
         {
-            let mut async_io = disk.new_async_io(1).unwrap();
+            let mut async_io = disk.create_async_io(1).unwrap();
             async_io.fsync(Some(99)).unwrap();
         }
 
@@ -1092,7 +1092,7 @@ mod unit_tests {
             async_write(&disk, idx * cluster_size, &written);
         }
         {
-            let mut async_io = disk.new_async_io(1).unwrap();
+            let mut async_io = disk.create_async_io(1).unwrap();
             async_io.fsync(Some(99)).unwrap();
         }
 
@@ -1383,7 +1383,7 @@ mod unit_tests {
         let written = vec![0xFFu8; cluster_size as usize];
         async_write(&disk, 0, &written);
         {
-            let mut async_io = disk.new_async_io(1).unwrap();
+            let mut async_io = disk.create_async_io(1).unwrap();
             async_io.fsync(Some(99)).unwrap();
         }
 
@@ -1392,7 +1392,7 @@ mod unit_tests {
 
         // Punch hole on cluster 0 - should deallocate and fall through to backing
         {
-            let mut async_io = disk.new_async_io(1).unwrap();
+            let mut async_io = disk.create_async_io(1).unwrap();
             async_io.punch_hole(0, cluster_size, 42).unwrap();
             let (ud, res) = async_io.next_completed_request().unwrap();
             assert_eq!(ud, 42);
@@ -1435,7 +1435,7 @@ mod unit_tests {
         let data1 = vec![0xAAu8; cluster_size as usize];
         async_write(&disk, 0, &data1);
         {
-            let mut aio = disk.new_async_io(1).unwrap();
+            let mut aio = disk.create_async_io(1).unwrap();
             aio.fsync(Some(1)).unwrap();
         }
         let buf = async_read(&disk, 0, cluster_size as usize);
@@ -1444,7 +1444,7 @@ mod unit_tests {
         let data2 = vec![0xBBu8; cluster_size as usize];
         async_write(&disk, 0, &data2);
         {
-            let mut aio = disk.new_async_io(1).unwrap();
+            let mut aio = disk.create_async_io(1).unwrap();
             aio.fsync(Some(2)).unwrap();
         }
         let buf = async_read(&disk, 0, cluster_size as usize);
@@ -1496,7 +1496,7 @@ mod unit_tests {
         let write_data = vec![0xEEu8; write_len];
         async_write(&disk, write_offset, &write_data);
         {
-            let mut aio = disk.new_async_io(1).unwrap();
+            let mut aio = disk.create_async_io(1).unwrap();
             aio.fsync(Some(1)).unwrap();
         }
 
@@ -1550,7 +1550,7 @@ mod unit_tests {
         let punch_offset = cluster_size - 4096;
         let punch_len = 8192u64;
         {
-            let mut aio = disk.new_async_io(1).unwrap();
+            let mut aio = disk.create_async_io(1).unwrap();
             aio.punch_hole(punch_offset, punch_len, 10).unwrap();
             let (ud, res) = aio.next_completed_request().unwrap();
             assert_eq!(ud, 10);
@@ -1614,7 +1614,7 @@ mod unit_tests {
         let new_data = vec![0xBB; cluster_size as usize];
         async_write(&disk, initial_size, &new_data);
         {
-            let mut aio = disk.new_async_io(1).unwrap();
+            let mut aio = disk.create_async_io(1).unwrap();
             aio.fsync(Some(1)).unwrap();
         }
         let buf = async_read(&disk, initial_size, cluster_size as usize);
@@ -1684,7 +1684,7 @@ mod unit_tests {
         ];
         let total = a.len() + b.len() + c.len();
 
-        let mut aio = disk.new_async_io(1).unwrap();
+        let mut aio = disk.create_async_io(1).unwrap();
         aio.write_vectored(0, &iovecs_w, 1).unwrap();
         let (ud, res) = aio.next_completed_request().unwrap();
         assert_eq!(ud, 1);
@@ -1711,7 +1711,7 @@ mod unit_tests {
             },
         ];
 
-        let mut aio = disk.new_async_io(1).unwrap();
+        let mut aio = disk.create_async_io(1).unwrap();
         aio.read_vectored(0, &iovecs_r, 10).unwrap();
         let (ud, res) = aio.next_completed_request().unwrap();
         assert_eq!(ud, 10);

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -107,7 +107,7 @@ impl disk_file::AsyncDiskFile for RawFileDisk {
         Ok(Box::new(RawFileDisk { file }))
     }
 
-    fn new_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+    fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
         let mut raw = RawFileAsync::new(self.file.as_raw_fd(), ring_depth)?;
         raw.alignment =
             DiskTopology::probe(&self.file).map_or(SECTOR_SIZE, |t| t.logical_block_size);

--- a/block/src/raw_async_aio.rs
+++ b/block/src/raw_async_aio.rs
@@ -85,7 +85,7 @@ impl disk_file::AsyncDiskFile for RawFileDiskAio {
         Ok(Box::new(RawFileDiskAio { file }))
     }
 
-    fn new_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+    fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
         let mut raw = RawFileAsyncAio::new(self.file.as_raw_fd(), ring_depth)?;
         raw.alignment =
             DiskTopology::probe(&self.file).map_or(SECTOR_SIZE, |t| t.logical_block_size);

--- a/block/src/raw_sync.rs
+++ b/block/src/raw_sync.rs
@@ -81,7 +81,7 @@ impl disk_file::AsyncDiskFile for RawFileDiskSync {
         Ok(Box::new(RawFileDiskSync { file }))
     }
 
-    fn new_async_io(&self, _ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+    fn create_async_io(&self, _ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
         let mut raw = RawFileSync::new(self.file.as_raw_fd());
         raw.alignment =
             DiskTopology::probe(&self.file).map_or(SECTOR_SIZE, |t| t.logical_block_size);

--- a/block/src/vhdx_sync.rs
+++ b/block/src/vhdx_sync.rs
@@ -95,7 +95,7 @@ impl disk_file::AsyncDiskFile for VhdxDiskSync {
         }))
     }
 
-    fn new_async_io(&self, _ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+    fn create_async_io(&self, _ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
         Ok(Box::new(VhdxSync::new(Arc::clone(&self.vhdx_file))))
     }
 }

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -68,7 +68,7 @@ pub fn micro_bench_aio_drain(control: &PerformanceTestControl) -> f64 {
 pub fn micro_bench_qcow_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_tempfile(num_ops);
-    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+    let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
 
     let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
     let iovec = read_iovec(&mut buf);
@@ -93,7 +93,7 @@ pub fn micro_bench_qcow_read(control: &PerformanceTestControl) -> f64 {
 pub fn micro_bench_qcow_random_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_tempfile(num_ops);
-    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+    let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
 
     let indices = deterministic_permutation(num_ops);
 
@@ -128,7 +128,7 @@ pub fn micro_bench_qcow_random_read(control: &PerformanceTestControl) -> f64 {
 pub fn micro_bench_qcow_write(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::empty_qcow_tempfile(num_ops);
-    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+    let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
 
     let buf = vec![0xA5u8; QCOW_CLUSTER_SIZE as usize];
     let iovec = write_iovec(&buf);
@@ -153,7 +153,7 @@ pub fn micro_bench_qcow_write(control: &PerformanceTestControl) -> f64 {
 pub fn micro_bench_qcow_punch_hole(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_tempfile(num_ops);
-    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+    let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
 
     let start = Instant::now();
     for i in 0..num_ops {
@@ -180,7 +180,7 @@ pub fn micro_bench_qcow_punch_hole(control: &PerformanceTestControl) -> f64 {
 pub fn micro_bench_qcow_fsync(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::empty_qcow_tempfile(num_ops);
-    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+    let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
 
     // Write num_ops clusters to dirty L2 and refcount metadata.
     let buf = vec![0xA5u8; QCOW_CLUSTER_SIZE as usize];
@@ -210,7 +210,7 @@ pub fn micro_bench_qcow_fsync(control: &PerformanceTestControl) -> f64 {
 pub fn micro_bench_qcow_backing_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_backing, _overlay, disk) = util::qcow_overlay_tempfile(num_ops);
-    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+    let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
 
     let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
     let iovec = read_iovec(&mut buf);
@@ -236,7 +236,7 @@ pub fn micro_bench_qcow_backing_read(control: &PerformanceTestControl) -> f64 {
 pub fn micro_bench_qcow_cow_write(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_backing, _overlay, disk) = util::qcow_overlay_tempfile(num_ops);
-    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+    let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
 
     let buf = vec![0xBBu8; QCOW_CLUSTER_SIZE as usize];
     let iovec = write_iovec(&buf);
@@ -260,7 +260,7 @@ pub fn micro_bench_qcow_cow_write(control: &PerformanceTestControl) -> f64 {
 pub fn micro_bench_qcow_compressed_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::compressed_qcow_tempfile(num_ops);
-    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+    let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
 
     let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
     let iovec = read_iovec(&mut buf);
@@ -288,7 +288,7 @@ pub fn micro_bench_qcow_multi_cluster_read(control: &PerformanceTestControl) -> 
 
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_tempfile(num_ops);
-    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+    let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
 
     let read_size = CLUSTERS_PER_READ * QCOW_CLUSTER_SIZE as usize;
     let mut buf = vec![0u8; read_size];
@@ -316,7 +316,7 @@ pub fn micro_bench_qcow_multi_cluster_read(control: &PerformanceTestControl) -> 
 pub fn micro_bench_qcow_l2_cache_miss(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::sparse_qcow_tempfile(num_ops);
-    let mut async_io = disk.new_async_io(1).expect("new_async_io failed");
+    let mut async_io = disk.create_async_io(1).expect("create_async_io failed");
 
     let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
     let iovec = read_iovec(&mut buf);
@@ -343,8 +343,8 @@ pub fn micro_bench_qcow_async_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_async_tempfile(num_ops);
     let mut async_io = disk
-        .new_async_io(num_ops as u32)
-        .expect("new_async_io failed");
+        .create_async_io(num_ops as u32)
+        .expect("create_async_io failed");
 
     let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
     let iovec = read_iovec(&mut buf);
@@ -366,8 +366,8 @@ pub fn micro_bench_qcow_batch_read(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_async_tempfile(num_ops);
     let mut async_io = disk
-        .new_async_io(num_ops as u32)
-        .expect("new_async_io failed");
+        .create_async_io(num_ops as u32)
+        .expect("create_async_io failed");
 
     let mut buf = vec![0u8; num_ops * QCOW_CLUSTER_SIZE as usize];
 
@@ -406,8 +406,8 @@ pub fn micro_bench_qcow_async_random_read(control: &PerformanceTestControl) -> f
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_async_tempfile(num_ops);
     let mut async_io = disk
-        .new_async_io(num_ops as u32)
-        .expect("new_async_io failed");
+        .create_async_io(num_ops as u32)
+        .expect("create_async_io failed");
 
     let indices = deterministic_permutation(num_ops);
 
@@ -442,8 +442,8 @@ pub fn micro_bench_qcow_async_multi_cluster_read(control: &PerformanceTestContro
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::qcow_async_tempfile(num_ops);
     let mut async_io = disk
-        .new_async_io(num_ops as u32)
-        .expect("new_async_io failed");
+        .create_async_io(num_ops as u32)
+        .expect("create_async_io failed");
 
     let read_size = CLUSTERS_PER_READ * QCOW_CLUSTER_SIZE as usize;
     let mut buf = vec![0u8; read_size];
@@ -468,8 +468,8 @@ pub fn micro_bench_qcow_async_backing_read(control: &PerformanceTestControl) -> 
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_backing, _overlay, disk) = util::qcow_async_overlay_tempfile(num_ops);
     let mut async_io = disk
-        .new_async_io(num_ops as u32)
-        .expect("new_async_io failed");
+        .create_async_io(num_ops as u32)
+        .expect("create_async_io failed");
 
     let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
     let iovec = read_iovec(&mut buf);
@@ -490,8 +490,8 @@ pub fn micro_bench_qcow_async_compressed_read(control: &PerformanceTestControl) 
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::compressed_qcow_async_tempfile(num_ops);
     let mut async_io = disk
-        .new_async_io(num_ops as u32)
-        .expect("new_async_io failed");
+        .create_async_io(num_ops as u32)
+        .expect("create_async_io failed");
 
     let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
     let iovec = read_iovec(&mut buf);
@@ -515,8 +515,8 @@ pub fn micro_bench_qcow_async_write(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::empty_qcow_async_tempfile(num_ops);
     let mut async_io = disk
-        .new_async_io(num_ops as u32)
-        .expect("new_async_io failed");
+        .create_async_io(num_ops as u32)
+        .expect("create_async_io failed");
 
     let buf = vec![0xA5u8; QCOW_CLUSTER_SIZE as usize];
     let iovec = write_iovec(&buf);
@@ -536,8 +536,8 @@ pub fn micro_bench_qcow_async_l2_cache_miss(control: &PerformanceTestControl) ->
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::sparse_qcow_async_tempfile(num_ops);
     let mut async_io = disk
-        .new_async_io(num_ops as u32)
-        .expect("new_async_io failed");
+        .create_async_io(num_ops as u32)
+        .expect("create_async_io failed");
 
     let mut buf = vec![0u8; QCOW_CLUSTER_SIZE as usize];
     let iovec = read_iovec(&mut buf);
@@ -562,8 +562,8 @@ pub fn micro_bench_qcow_batch_write(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let (_tmp, disk) = util::empty_qcow_async_tempfile(num_ops);
     let mut async_io = disk
-        .new_async_io(num_ops as u32)
-        .expect("new_async_io failed");
+        .create_async_io(num_ops as u32)
+        .expect("create_async_io failed");
 
     let buf = vec![0xA5u8; num_ops * QCOW_CLUSTER_SIZE as usize];
 

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -1129,7 +1129,7 @@ impl VirtioDevice for Block {
                 mem: mem.clone(),
                 disk_image: self
                     .disk_image
-                    .new_async_io(queue_size as u32)
+                    .create_async_io(queue_size as u32)
                     .map_err(|e| {
                         error!("failed to create new AsyncIo: {e}");
                         ActivateError::BadActivate


### PR DESCRIPTION
The `new_` prefix in Rust conventionally denotes constructors that return `Self` (e.g. `Vec::new()`, `File::new()`). `AsyncDiskFile::new_async_io` does not return `Self`. It is a factory method that constructs and returns a `Box<dyn AsyncIo>` worker bound to the disk file descriptor and metadata. The `create_` prefix communicates this: the caller receives a freshly constructed object of a different type.

This rename touches every format backend in block plus two external callers in virtio-devices and performance-metrics. Every change is a mechanical s/new_async_io/create_async_io/ substitution. No functional change.

Ref: #7877 (task 3.2.8)