### PR TITLE
Add user_devices to OpenAPI spec

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -647,6 +647,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DeviceConfig"
+        user_devices:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserDeviceConfig'
         vdpa:
           type: array
           items:
@@ -1219,6 +1223,23 @@ components:
         x_nv_gpudirect_clique:
           type: integer
           format: int8
+
+    UserDeviceConfig:
+      required:
+        - socket
+      type: object
+      properties:
+        socket:
+          type: string
+        id:
+          type: string
+        pci_segment:
+          type: integer
+          format: int16
+        pci_device_id:
+          type: integer
+          format: uint8
+
     TpmConfig:
       required:
         - socket


### PR DESCRIPTION
The hypervisor returns user_devices in its response, but this field was missing from the OpenAPI spec. Adding it to keep the spec in sync with the actual API behavior.