### PR TITLE
virtio-devices: PCI device reset/interrupt improvements

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -5393,9 +5393,20 @@ mod common_parallel {
         kill_child(&mut child2);
 
         let output = child1.wait_with_output().unwrap();
-        child2.wait().unwrap();
+        let output2 = child2.wait_with_output().unwrap();
 
         cleanup_ovs_dpdk();
+
+        if r.is_err() {
+            eprintln!(
+                "\n\n==== Start restored VM stdout ====\n\n{}\n\n==== End restored VM stdout ====",
+                String::from_utf8_lossy(&output2.stdout)
+            );
+            eprintln!(
+                "\n\n==== Start restored VM stderr ====\n\n{}\n\n==== End restored VM stderr ====",
+                String::from_utf8_lossy(&output2.stderr)
+            );
+        }
 
         handle_child_output(r, &output);
     }

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -458,7 +458,6 @@ pub struct Balloon {
     config: VirtioBalloonConfig,
     seccomp_action: SeccompAction,
     exit_evt: EventFd,
-    interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
 }
 
 impl Balloon {
@@ -523,20 +522,15 @@ impl Balloon {
             config,
             seccomp_action,
             exit_evt,
-            interrupt_cb: None,
         })
     }
 
     pub fn resize(&mut self, size: u64) -> Result<(), Error> {
         self.config.num_pages = (size >> VIRTIO_BALLOON_PFN_SHIFT) as u32;
 
-        if let Some(interrupt_cb) = &self.interrupt_cb {
-            interrupt_cb
-                .trigger(VirtioInterruptType::Config)
-                .map_err(Error::FailedSignal)
-        } else {
-            Ok(())
-        }
+        self.common
+            .trigger_interrupt(VirtioInterruptType::Config)
+            .map_err(Error::FailedSignal)
     }
 
     // Get the actual size of the virtio-balloon.
@@ -647,8 +641,6 @@ impl VirtioDevice for Balloon {
                 None
             };
 
-        self.interrupt_cb = Some(interrupt_cb.clone());
-
         let mut handler = BalloonEpollHandler {
             mem,
             queues: virtqueues,
@@ -688,10 +680,9 @@ impl VirtioDevice for Balloon {
         self.common.access_platform()
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        let result = self.common.reset();
+    fn reset(&mut self) {
+        self.common.reset();
         event!("virtio-device", "reset", "id", &self.id);
-        result
     }
 }
 

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -1025,13 +1025,9 @@ impl Block {
 
         self.common.resume().map_err(Error::ResumeVcpus)?;
 
-        if let Some(interrupt_cb) = self.common.interrupt_cb.as_ref() {
-            interrupt_cb
-                .trigger(VirtioInterruptType::Config)
-                .map_err(Error::ConfigChange)
-        } else {
-            Ok(())
-        }
+        self.common
+            .trigger_interrupt(VirtioInterruptType::Config)
+            .map_err(Error::ConfigChange)
     }
 
     #[cfg(fuzzing)]
@@ -1178,11 +1174,10 @@ impl VirtioDevice for Block {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        let result = self.common.reset();
+    fn reset(&mut self) {
+        self.common.reset();
         self.set_writeback_mode(true);
         event!("virtio-device", "reset", "id", &self.id);
-        result
     }
 
     fn counters(&self) -> Option<HashMap<&'static str, Wrapping<u64>>> {

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -773,10 +773,9 @@ impl VirtioDevice for Console {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        let result = self.common.reset();
+    fn reset(&mut self) {
+        self.common.reset();
         event!("virtio-device", "reset", "id", &self.id);
-        result
     }
 
     fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -123,11 +123,8 @@ pub trait VirtioDevice: Send {
     /// Activates this device for real usage.
     fn activate(&mut self, context: ActivationContext) -> ActivateResult;
 
-    /// Optionally deactivates this device and returns ownership of the guest memory map, interrupt
-    /// event, and queue events.
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        None
-    }
+    /// Optionally deactivates this device.
+    fn reset(&mut self) {}
 
     /// Returns the list of shared memory regions required by the device.
     fn get_shm_regions(&self) -> Option<VirtioSharedMemoryList> {
@@ -290,7 +287,7 @@ impl VirtioCommon {
         Ok(())
     }
 
-    pub fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
+    pub fn reset(&mut self) {
         self.queue_evts.clear();
 
         // Resume the virtio thread if it was paused. Reset must always
@@ -315,8 +312,16 @@ impl VirtioCommon {
             }
         }
 
-        // Return the interrupt
-        Some(self.interrupt_cb.take().unwrap())
+        // Drop the interrupt callback clone
+        self.interrupt_cb = None;
+    }
+
+    pub fn trigger_interrupt(&self, int_type: VirtioInterruptType) -> std::io::Result<()> {
+        if let Some(interrupt_cb) = &self.interrupt_cb {
+            interrupt_cb.trigger(int_type)
+        } else {
+            Ok(())
+        }
     }
 
     // Wait for the worker thread to finish and return
@@ -406,12 +411,9 @@ impl Pausable for VirtioCommon {
         }
 
         // Also trigger interrupts into the guest to wake up the driver to avoid a "livelock"
-        if let Some(interrupt_cb) = &self.interrupt_cb {
-            for i in 0..self.queue_evts.len() {
-                interrupt_cb
-                    .trigger(crate::VirtioInterruptType::Queue(i as u16))
-                    .ok();
-            }
+        for i in 0..self.queue_evts.len() {
+            self.trigger_interrupt(crate::VirtioInterruptType::Queue(i as u16))
+                .ok();
         }
 
         Ok(())

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -293,9 +293,13 @@ impl VirtioCommon {
     pub fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.queue_evts.clear();
 
-        // We first must resume the virtio thread if it was paused.
-        if self.pause_evt.take().is_some() {
-            self.resume().ok()?;
+        // Resume the virtio thread if it was paused. Reset must always
+        // converge to fresh state, so a resume failure is logged but doesn't
+        // skip the rest of the teardown.
+        if self.pause_evt.take().is_some()
+            && let Err(e) = self.resume()
+        {
+            error!("Failed to resume paused device during reset: {e:?}");
         }
 
         if let Some(kill_evt) = self.kill_evt.take() {

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -1120,10 +1120,9 @@ impl VirtioDevice for Iommu {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        let result = self.common.reset();
+    fn reset(&mut self) {
+        self.common.reset();
         event!("virtio-device", "reset", "id", &self.id);
-        result
     }
 }
 

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -737,7 +737,6 @@ pub struct Mem {
     dma_mapping_handlers: Arc<Mutex<BTreeMap<VirtioMemMappingSource, Arc<dyn ExternalDmaMapping>>>>,
     blocks_state: Arc<Mutex<BlocksState>>,
     exit_evt: EventFd,
-    interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
 }
 
 impl Mem {
@@ -830,7 +829,6 @@ impl Mem {
             dma_mapping_handlers: Arc::new(Mutex::new(BTreeMap::new())),
             blocks_state,
             exit_evt,
-            interrupt_cb: None,
         })
     }
 
@@ -844,15 +842,11 @@ impl Mem {
             Error::ResizeError(anyhow!("Failed to update virtio configuration: {e:?}"))
         })?;
 
-        if let Some(interrupt_cb) = self.interrupt_cb.as_ref() {
-            interrupt_cb
-                .trigger(VirtioInterruptType::Config)
-                .map_err(|e| {
-                    Error::ResizeError(anyhow!("Failed to signal the guest about resize: {e:?}"))
-                })
-        } else {
-            Ok(())
-        }
+        self.common
+            .trigger_interrupt(VirtioInterruptType::Config)
+            .map_err(|e| {
+                Error::ResizeError(anyhow!("Failed to signal the guest about resize: {e:?}"))
+            })
     }
 
     pub fn add_dma_mapping_handler(
@@ -966,8 +960,6 @@ impl VirtioDevice for Mem {
 
         let (_, queue, queue_evt) = queues.remove(0);
 
-        self.interrupt_cb = Some(interrupt_cb.clone());
-
         let mut handler = MemEpollHandler {
             mem,
             region: self.region.clone(),
@@ -1016,10 +1008,9 @@ impl VirtioDevice for Mem {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        let result = self.common.reset();
+    fn reset(&mut self) {
+        self.common.reset();
         event!("virtio-device", "reset", "id", &self.id);
-        result
     }
 }
 

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -868,10 +868,9 @@ impl VirtioDevice for Net {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        let result = self.common.reset();
+    fn reset(&mut self) {
+        self.common.reset();
         event!("virtio-device", "reset", "id", &self.id);
-        result
     }
 
     fn counters(&self) -> Option<HashMap<&'static str, Wrapping<u64>>> {

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -438,10 +438,9 @@ impl VirtioDevice for Pmem {
         Err(ActivateError::BadActivate)
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        let result = self.common.reset();
+    fn reset(&mut self) {
+        self.common.reset();
         event!("virtio-device", "reset", "id", &self.id);
-        result
     }
 
     fn userspace_mappings(&self) -> Vec<UserspaceMapping> {

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -311,10 +311,9 @@ impl VirtioDevice for Rng {
         Err(ActivateError::BadActivate)
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        let result = self.common.reset();
+    fn reset(&mut self) {
+        self.common.reset();
         event!("virtio-device", "reset", "id", &self.id);
-        result
     }
 
     fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -160,6 +160,19 @@ impl VirtioPciCommonConfig {
         }
     }
 
+    /// Returns the common configuration to its power-on state. Per the virtio
+    /// spec a device reset must restore the values that a fresh driver would
+    /// observe.
+    pub fn reset(&mut self) {
+        self.driver_status.store(0, Ordering::Release);
+        self.device_feature_select = 0;
+        self.driver_feature_select = 0;
+        self.queue_select = 0;
+        self.msix_config
+            .store(VIRTQ_MSI_NO_VECTOR, Ordering::Release);
+        self.msix_queues.lock().unwrap().fill(VIRTQ_MSI_NO_VECTOR);
+    }
+
     pub fn read(&mut self, offset: u64, data: &mut [u8], queues: &[Queue]) {
         assert!(data.len() <= 8);
 
@@ -520,5 +533,39 @@ mod unit_tests {
 
         // Write queue_msix_vector — must not panic.
         regs.write(0x1a, &[0xAB, 0xCD], &mut queues);
+    }
+
+    #[test]
+    fn reset_returns_initial_state() {
+        let dev: Arc<Mutex<dyn VirtioDevice>> = Arc::new(Mutex::new(DummyDevice(0)));
+        let mut regs = VirtioPciCommonConfig {
+            device: dev,
+            driver_status: Arc::new(AtomicU8::new(0x55)),
+            config_generation: 0xab,
+            device_feature_select: 1,
+            driver_feature_select: 1,
+            queue_select: 7,
+            msix_config: Arc::new(AtomicU16::new(3)),
+            msix_queues: Arc::new(Mutex::new(vec![1, 2, 3])),
+        };
+
+        regs.reset();
+
+        assert_eq!(regs.driver_status.load(Ordering::Acquire), 0);
+        assert_eq!(regs.config_generation, 0xab); // unchanged across reset
+        assert_eq!(regs.device_feature_select, 0);
+        assert_eq!(regs.driver_feature_select, 0);
+        assert_eq!(regs.queue_select, 0);
+        assert_eq!(
+            regs.msix_config.load(Ordering::Acquire),
+            VIRTQ_MSI_NO_VECTOR
+        );
+        assert!(
+            regs.msix_queues
+                .lock()
+                .unwrap()
+                .iter()
+                .all(|v| *v == VIRTQ_MSI_NO_VECTOR)
+        );
     }
 }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -300,7 +300,7 @@ pub struct VirtioPciDeviceState {
 }
 
 pub struct VirtioPciDeviceActivator {
-    interrupt: Option<Arc<dyn VirtioInterrupt>>,
+    interrupt: Arc<dyn VirtioInterrupt>,
     memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     device: Arc<Mutex<dyn VirtioDevice>>,
     device_activated: Arc<AtomicBool>,
@@ -315,7 +315,7 @@ impl VirtioPciDeviceActivator {
         let mut locked_device = self.device.lock().unwrap();
         locked_device.activate(crate::device::ActivationContext {
             mem: self.memory.take().unwrap(),
-            interrupt_cb: self.interrupt.take().unwrap(),
+            interrupt_cb: self.interrupt,
             queues: self.queues.take().unwrap(),
             device_status: self.status,
         })?;
@@ -822,7 +822,7 @@ impl VirtioPciDevice {
         }
 
         VirtioPciDeviceActivator {
-            interrupt: self.virtio_interrupt.take(),
+            interrupt: self.virtio_interrupt.as_ref().unwrap().clone(),
             memory: Some(self.memory.clone()),
             device: self.device.clone(),
             queues: Some(queues),
@@ -1250,10 +1250,7 @@ impl PciDevice for VirtioPciDevice {
         if self.is_driver_init() {
             if self.device_activated.swap(false, Ordering::SeqCst) {
                 let mut device = self.device.lock().unwrap();
-                if let Some(virtio_interrupt) = device.reset() {
-                    // Upon reset the device returns its interrupt EventFD
-                    self.virtio_interrupt = Some(virtio_interrupt);
-                }
+                device.reset();
             }
 
             // Reset queue readiness and the common configuration

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1245,24 +1245,20 @@ impl PciDevice for VirtioPciDevice {
             return Some(barrier);
         }
 
-        // Device has been reset by the driver
-        if self.device_activated.load(Ordering::SeqCst) && self.is_driver_init() {
-            let mut device = self.device.lock().unwrap();
-            if let Some(virtio_interrupt) = device.reset() {
-                // Upon reset the device returns its interrupt EventFD
-                self.virtio_interrupt = Some(virtio_interrupt);
-                self.device_activated.store(false, Ordering::SeqCst);
-
-                // Reset queue readiness (changes queue_enable), queue sizes
-                // and selected_queue as per spec for reset
-                self.queues.iter_mut().for_each(Queue::reset);
-                self.common_config.queue_select = 0;
-            } else {
-                error!("Attempt to reset device when not implemented in underlying device");
-                self.common_config
-                    .driver_status
-                    .store(crate::DEVICE_FAILED as u8, Ordering::SeqCst);
+        // The driver requested a reset by writing 0 to device_status. Per the
+        // virtio spec this is permitted at any point in initialisation.
+        if self.is_driver_init() {
+            if self.device_activated.swap(false, Ordering::SeqCst) {
+                let mut device = self.device.lock().unwrap();
+                if let Some(virtio_interrupt) = device.reset() {
+                    // Upon reset the device returns its interrupt EventFD
+                    self.virtio_interrupt = Some(virtio_interrupt);
+                }
             }
+
+            // Reset queue readiness and the common configuration
+            self.queues.iter_mut().for_each(Queue::reset);
+            self.common_config.reset();
         }
 
         None

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -403,7 +403,6 @@ impl VirtioPciDevice {
         id: String,
         memory: GuestMemoryAtomic<GuestMemoryMmap>,
         device: Arc<Mutex<dyn VirtioDevice>>,
-        msix_num: u16,
         access_platform: Option<&Arc<dyn AccessPlatform>>,
         interrupt_manager: &dyn InterruptManager<GroupConfig = MsiIrqGroupConfig>,
         pci_device_bdf: u32,
@@ -433,6 +432,11 @@ impl VirtioPciDevice {
             .collect();
 
         let pci_device_id = VIRTIO_PCI_DEVICE_ID_BASE + locked_device.device_type() as u16;
+
+        // Allows support for one MSI-X vector per interrupt needed by the device.
+        // It also adds 1 as we need to take into account the dedicated vector to notify
+        // about a virtio config change.
+        let msix_num = (locked_device.queue_max_sizes().len() + 1) as u16;
 
         let interrupt_source_group: MaybeMutInterruptSourceGroup = {
             let config = MsiIrqGroupConfig {

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -348,7 +348,7 @@ pub struct VirtioPciDevice {
     common_config: VirtioPciCommonConfig,
 
     // MSI-X config
-    msix_config: Option<Arc<Mutex<MsixConfig>>>,
+    msix_config: Arc<Mutex<MsixConfig>>,
 
     // Number of MSI-X vectors
     msix_num: u16,
@@ -596,7 +596,7 @@ impl VirtioPciDevice {
             id,
             configuration,
             common_config,
-            msix_config: Some(msix_config),
+            msix_config,
             msix_num,
             device,
             device_activated: Arc::new(AtomicBool::new(device_activated)),
@@ -615,14 +615,12 @@ impl VirtioPciDevice {
             pending_activations,
         };
 
-        if let Some(msix_config) = &virtio_pci_device.msix_config {
-            virtio_pci_device.virtio_interrupt = Some(Arc::new(VirtioInterruptMsix::new(
-                msix_config.clone(),
-                virtio_pci_device.common_config.msix_config.clone(),
-                virtio_pci_device.common_config.msix_queues.clone(),
-                virtio_pci_device.interrupt_source_group.clone(),
-            )));
-        }
+        virtio_pci_device.virtio_interrupt = Some(Arc::new(VirtioInterruptMsix::new(
+            virtio_pci_device.msix_config.clone(),
+            virtio_pci_device.common_config.msix_config.clone(),
+            virtio_pci_device.common_config.msix_queues.clone(),
+            virtio_pci_device.interrupt_source_group.clone(),
+        )));
 
         // In case of a restore, we can activate the device, as we know at
         // this point the virtqueues are in the right state and the device is
@@ -739,18 +737,16 @@ impl VirtioPciDevice {
             + VIRTIO_PCI_CAP_OFFSET;
         self.cap_pci_cfg_info.cap = configuration_cap;
 
-        if self.msix_config.is_some() {
-            let msix_cap = MsixCap::new(
-                settings_bar,
-                self.msix_num,
-                MSIX_TABLE_BAR_OFFSET as u32,
-                settings_bar,
-                MSIX_PBA_BAR_OFFSET as u32,
-            );
-            self.configuration
-                .add_capability(&msix_cap)
-                .map_err(PciDeviceError::CapabilitiesSetup)?;
-        }
+        let msix_cap = MsixCap::new(
+            settings_bar,
+            self.msix_num,
+            MSIX_TABLE_BAR_OFFSET as u32,
+            settings_bar,
+            MSIX_PBA_BAR_OFFSET as u32,
+        );
+        self.configuration
+            .add_capability(&msix_cap)
+            .map_err(PciDeviceError::CapabilitiesSetup)?;
 
         self.settings_bar = settings_bar;
         Ok(())
@@ -1163,20 +1159,16 @@ impl PciDevice for VirtioPciDevice {
                 // Handled with ioeventfds.
             }
             o if (MSIX_TABLE_BAR_OFFSET..MSIX_TABLE_BAR_OFFSET + MSIX_TABLE_SIZE).contains(&o) => {
-                if let Some(msix_config) = &self.msix_config {
-                    msix_config
-                        .lock()
-                        .unwrap()
-                        .read_table(o - MSIX_TABLE_BAR_OFFSET, data);
-                }
+                self.msix_config
+                    .lock()
+                    .unwrap()
+                    .read_table(o - MSIX_TABLE_BAR_OFFSET, data);
             }
             o if (MSIX_PBA_BAR_OFFSET..MSIX_PBA_BAR_OFFSET + MSIX_PBA_SIZE).contains(&o) => {
-                if let Some(msix_config) = &self.msix_config {
-                    msix_config
-                        .lock()
-                        .unwrap()
-                        .read_pba(o - MSIX_PBA_BAR_OFFSET, data);
-                }
+                self.msix_config
+                    .lock()
+                    .unwrap()
+                    .read_pba(o - MSIX_PBA_BAR_OFFSET, data);
             }
             _ => (),
         }
@@ -1215,20 +1207,16 @@ impl PciDevice for VirtioPciDevice {
                 error!("Unexpected write to notification BAR: offset = 0x{o:x}");
             }
             o if (MSIX_TABLE_BAR_OFFSET..MSIX_TABLE_BAR_OFFSET + MSIX_TABLE_SIZE).contains(&o) => {
-                if let Some(msix_config) = &self.msix_config {
-                    msix_config
-                        .lock()
-                        .unwrap()
-                        .write_table(o - MSIX_TABLE_BAR_OFFSET, data);
-                }
+                self.msix_config
+                    .lock()
+                    .unwrap()
+                    .write_table(o - MSIX_TABLE_BAR_OFFSET, data);
             }
             o if (MSIX_PBA_BAR_OFFSET..MSIX_PBA_BAR_OFFSET + MSIX_PBA_SIZE).contains(&o) => {
-                if let Some(msix_config) = &self.msix_config {
-                    msix_config
-                        .lock()
-                        .unwrap()
-                        .write_pba(o - MSIX_PBA_BAR_OFFSET, data);
-                }
+                self.msix_config
+                    .lock()
+                    .unwrap()
+                    .write_pba(o - MSIX_PBA_BAR_OFFSET, data);
             }
             _ => (),
         }
@@ -1309,8 +1297,8 @@ impl Snapshottable for VirtioPciDevice {
             .add_snapshot(self.common_config.id(), self.common_config.snapshot()?);
 
         // Snapshot MSI-X
-        if let Some(msix_config) = &self.msix_config {
-            let mut msix_config = msix_config.lock().unwrap();
+        {
+            let mut msix_config = self.msix_config.lock().unwrap();
             virtio_pci_dev_snapshot.add_snapshot(msix_config.id(), msix_config.snapshot()?);
         }
 

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -465,7 +465,7 @@ impl VirtioPciDevice {
                 ))
             })?;
 
-        let (msix_config, msix_config_clone) = if msix_num > 0 {
+        let (msix_config, msix_config_clone) = {
             let interrupt_source_group: MaybeMutInterruptSourceGroup =
                 interrupt_source_group.clone();
             let msix_config = Arc::new(Mutex::new(
@@ -473,9 +473,7 @@ impl VirtioPciDevice {
                     .unwrap(),
             ));
             let msix_config_clone = msix_config.clone();
-            (Some(msix_config), Some(msix_config_clone))
-        } else {
-            (None, None)
+            (msix_config, msix_config_clone)
         };
 
         let (class, subclass) = match VirtioDeviceType::from(locked_device.device_type()) {
@@ -510,7 +508,7 @@ impl VirtioPciDevice {
             PciHeaderType::Device,
             VIRTIO_PCI_VENDOR_ID,
             pci_device_id,
-            msix_config_clone,
+            Some(msix_config_clone),
             pci_configuration_state,
         );
 
@@ -598,7 +596,7 @@ impl VirtioPciDevice {
             id,
             configuration,
             common_config,
-            msix_config,
+            msix_config: Some(msix_config),
             msix_num,
             device,
             device_activated: Arc::new(AtomicBool::new(device_activated)),

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -359,8 +359,7 @@ pub struct VirtioPciDevice {
 
     // PCI interrupts.
     interrupt_status: Arc<AtomicUsize>,
-    virtio_interrupt: Option<Arc<dyn VirtioInterrupt>>,
-    interrupt_source_group: MaybeMutInterruptSourceGroup,
+    virtio_interrupt: Arc<dyn VirtioInterrupt>,
 
     // virtio queues
     queues: Vec<Queue>,
@@ -592,6 +591,13 @@ impl VirtioPciDevice {
         // prevents from a subtle deadlock.
         std::mem::drop(locked_device);
 
+        let virtio_interrupt = Arc::new(VirtioInterruptMsix::new(
+            msix_config.clone(),
+            common_config.msix_config.clone(),
+            common_config.msix_queues.clone(),
+            interrupt_source_group.clone(),
+        ));
+
         let mut virtio_pci_device = VirtioPciDevice {
             id,
             configuration,
@@ -601,26 +607,18 @@ impl VirtioPciDevice {
             device,
             device_activated: Arc::new(AtomicBool::new(device_activated)),
             interrupt_status: Arc::new(AtomicUsize::new(interrupt_status)),
-            virtio_interrupt: None,
+            virtio_interrupt,
             queues,
             queue_evts,
             memory,
             settings_bar: 0,
             use_64bit_bar,
-            interrupt_source_group: interrupt_source_group.clone(),
             cap_pci_cfg_info,
             bar_regions: vec![],
             activate_evt,
             dma_handler,
             pending_activations,
         };
-
-        virtio_pci_device.virtio_interrupt = Some(Arc::new(VirtioInterruptMsix::new(
-            virtio_pci_device.msix_config.clone(),
-            virtio_pci_device.common_config.msix_config.clone(),
-            virtio_pci_device.common_config.msix_queues.clone(),
-            virtio_pci_device.interrupt_source_group.clone(),
-        )));
 
         // In case of a restore, we can activate the device, as we know at
         // this point the virtqueues are in the right state and the device is
@@ -820,7 +818,7 @@ impl VirtioPciDevice {
         }
 
         VirtioPciDeviceActivator {
-            interrupt: self.virtio_interrupt.as_ref().unwrap().clone(),
+            interrupt: self.virtio_interrupt.clone(),
             memory: Some(self.memory.clone()),
             device: self.device.clone(),
             queues: Some(queues),

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -451,9 +451,10 @@ impl VirtioDevice for Vdpa {
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
+        // Backend reset failures are logged but don't skip local cleanup:
+        // reset must converge to fresh state regardless of backend state.
         if let Err(e) = self.reset_vdpa() {
             error!("Failed to reset vhost-vdpa: {e:?}");
-            return None;
         }
 
         event!("vdpa", "reset", "id", &self.id);

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -443,14 +443,13 @@ impl VirtioDevice for Vdpa {
         self.activate_vdpa(&mem.memory(), virtio_interrupt.as_ref(), &queues)
             .map_err(ActivateError::ActivateVdpa)?;
 
-        // Store the virtio interrupt handler as we need to return it on reset
         self.common.interrupt_cb = Some(virtio_interrupt);
 
         event!("vdpa", "activated", "id", &self.id);
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
+    fn reset(&mut self) {
         // Backend reset failures are logged but don't skip local cleanup:
         // reset must converge to fresh state regardless of backend state.
         if let Err(e) = self.reset_vdpa() {
@@ -459,8 +458,8 @@ impl VirtioDevice for Vdpa {
 
         event!("vdpa", "reset", "id", &self.id);
 
-        // Return the virtio interrupt handler
-        self.common.interrupt_cb.take()
+        // Drop the interrupt callback clone
+        self.common.interrupt_cb = None;
     }
 
     fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -6,7 +6,6 @@ use std::sync::{Arc, Barrier, Mutex};
 use std::{mem, result};
 
 use block::VirtioBlockConfig;
-use event_monitor::event;
 use log::{error, info};
 use seccompiler::SeccompAction;
 use vhost::vhost_user::message::{
@@ -309,30 +308,7 @@ impl VirtioDevice for Blk {
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        // We first must resume the virtio thread if it was paused.
-        if self.vu_common.virtio_common.pause_evt.take().is_some() {
-            self.vu_common.virtio_common.resume().ok()?;
-        }
-
-        if let Some(vu) = &self.vu_common.vu
-            && let Err(e) = vu.lock().unwrap().reset_vhost_user()
-        {
-            error!(
-                "Failed to reset vhost-user daemon for socket {}: {e:?}",
-                self.vu_common.socket_path
-            );
-            return None;
-        }
-
-        if let Some(kill_evt) = self.vu_common.virtio_common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-
-        event!("virtio-device", "reset", "id", &self.id);
-
-        // Return the interrupt
-        Some(self.vu_common.virtio_common.interrupt_cb.take().unwrap())
+        self.vu_common.reset(&self.id)
     }
 
     fn shutdown(&mut self) {

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -28,7 +28,7 @@ use super::{DEFAULT_VIRTIO_FEATURES, Error, Result};
 use crate::seccomp_filters::Thread;
 use crate::thread_helper::spawn_virtio_thread;
 use crate::vhost_user::{VhostUserCommon, VhostUserState};
-use crate::{GuestMemoryMmap, GuestRegionMmap, VIRTIO_F_ACCESS_PLATFORM, VirtioInterrupt};
+use crate::{GuestMemoryMmap, GuestRegionMmap, VIRTIO_F_ACCESS_PLATFORM};
 
 const DEFAULT_QUEUE_NUMBER: usize = 1;
 
@@ -307,8 +307,8 @@ impl VirtioDevice for Blk {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.vu_common.reset(&self.id)
+    fn reset(&mut self) {
+        self.vu_common.reset(&self.id);
     }
 
     fn shutdown(&mut self) {

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -286,30 +286,7 @@ impl VirtioDevice for Fs {
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        // We first must resume the virtio thread if it was paused.
-        if self.vu_common.virtio_common.pause_evt.take().is_some() {
-            self.vu_common.virtio_common.resume().ok()?;
-        }
-
-        if let Some(vu) = &self.vu_common.vu
-            && let Err(e) = vu.lock().unwrap().reset_vhost_user()
-        {
-            error!(
-                "Failed to reset vhost-user daemon for socket {}: {e:?}",
-                self.vu_common.socket_path
-            );
-            return None;
-        }
-
-        if let Some(kill_evt) = self.vu_common.virtio_common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-
-        event!("virtio-device", "reset", "id", &self.id);
-
-        // Return the interrupt
-        Some(self.vu_common.virtio_common.interrupt_cb.take().unwrap())
+        self.vu_common.reset(&self.id)
     }
 
     fn shutdown(&mut self) {

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -25,7 +25,7 @@ use crate::thread_helper::spawn_virtio_thread;
 use crate::vhost_user::{VhostUserCommon, VhostUserState};
 use crate::{
     ActivateResult, GuestMemoryMmap, GuestRegionMmap, MmapRegion, VIRTIO_F_ACCESS_PLATFORM,
-    VirtioCommon, VirtioDevice, VirtioDeviceType, VirtioInterrupt, VirtioSharedMemoryList,
+    VirtioCommon, VirtioDevice, VirtioDeviceType, VirtioSharedMemoryList,
 };
 
 const NUM_QUEUE_OFFSET: usize = 1;
@@ -285,8 +285,8 @@ impl VirtioDevice for Fs {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.vu_common.reset(&self.id)
+    fn reset(&mut self) {
+        self.vu_common.reset(&self.id);
     }
 
     fn shutdown(&mut self) {

--- a/virtio-devices/src/vhost_user/generic_vhost_user.rs
+++ b/virtio-devices/src/vhost_user/generic_vhost_user.rs
@@ -309,30 +309,7 @@ impl VirtioDevice for GenericVhostUser {
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        // We first must resume the virtio thread if it was paused.
-        if self.vu_common.virtio_common.pause_evt.take().is_some() {
-            self.vu_common.virtio_common.resume().ok()?;
-        }
-
-        if let Some(vu) = &self.vu_common.vu
-            && let Err(e) = vu.lock().unwrap().reset_vhost_user()
-        {
-            error!(
-                "Failed to reset vhost-user daemon for socket {}: {e:?}",
-                self.vu_common.socket_path
-            );
-            return None;
-        }
-
-        if let Some(kill_evt) = self.vu_common.virtio_common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-
-        event!("virtio-device", "reset", "id", &self.id);
-
-        // Return the interrupt
-        Some(self.vu_common.virtio_common.interrupt_cb.take().unwrap())
+        self.vu_common.reset(&self.id)
     }
 
     fn shutdown(&mut self) {

--- a/virtio-devices/src/vhost_user/generic_vhost_user.rs
+++ b/virtio-devices/src/vhost_user/generic_vhost_user.rs
@@ -26,7 +26,7 @@ use crate::thread_helper::spawn_virtio_thread;
 use crate::vhost_user::{VhostUserCommon, VhostUserState};
 use crate::{
     ActivateResult, GuestMemoryMmap, GuestRegionMmap, MmapRegion, VIRTIO_F_ACCESS_PLATFORM,
-    VirtioCommon, VirtioDevice, VirtioInterrupt, VirtioSharedMemoryList,
+    VirtioCommon, VirtioDevice, VirtioSharedMemoryList,
 };
 
 pub type State = VhostUserState<()>;
@@ -308,8 +308,8 @@ impl VirtioDevice for GenericVhostUser {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.vu_common.reset(&self.id)
+    fn reset(&mut self) {
+        self.vu_common.reset(&self.id);
     }
 
     fn shutdown(&mut self) {

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -347,7 +347,6 @@ pub struct VhostUserCommon {
     pub vu_num_queues: usize,
     pub migration_started: bool,
     pub server: bool,
-    pub interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
     pub vring_bases: Option<Vec<u64>>,
     pub epoll_thread: Option<thread::JoinHandle<()>>,
 }
@@ -395,8 +394,6 @@ impl VhostUserCommon {
             )
             .map_err(ActivateError::VhostUserSetup)?;
 
-        self.interrupt_cb = Some(interrupt_cb.clone());
-
         Ok(VhostUserEpollHandler {
             vu: vu.clone(),
             mem,
@@ -428,7 +425,7 @@ impl VhostUserCommon {
         Ok(())
     }
 
-    pub fn reset(&mut self, id: &str) -> Option<Arc<dyn VirtioInterrupt>> {
+    pub fn reset(&mut self, id: &str) {
         // Resume the virtio thread if it was paused. Reset must always
         // converge to fresh state, so backend resume / reset failures are
         // logged but don't skip the rest of the teardown.
@@ -454,8 +451,8 @@ impl VhostUserCommon {
 
         event!("virtio-device", "reset", "id", id);
 
-        // Return the interrupt
-        Some(self.virtio_common.interrupt_cb.take().unwrap())
+        // Drop the interrupt callback clone
+        self.virtio_common.interrupt_cb = None;
     }
 
     pub fn shutdown(&mut self) {
@@ -525,12 +522,10 @@ impl VhostUserCommon {
                 MigratableError::Resume(anyhow!("Error resuming vhost-user backend: {e:?}"))
             })?;
         }
-        if let Some(interrupt_cb) = &self.interrupt_cb {
-            for i in 0..self.vu_num_queues {
-                interrupt_cb
-                    .trigger(crate::VirtioInterruptType::Queue(i as u16))
-                    .ok();
-            }
+        for i in 0..self.vu_num_queues {
+            self.virtio_common
+                .trigger_interrupt(crate::VirtioInterruptType::Queue(i as u16))
+                .ok();
         }
         Ok(())
     }

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, Barrier, Mutex};
 use std::{io, thread};
 
 use anyhow::anyhow;
+use event_monitor::event;
 use log::error;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -21,7 +22,7 @@ use vm_memory::guest_memory::Error as MmapError;
 use vm_memory::mmap::MmapRegionError;
 use vm_memory::{Address, GuestAddressSpace, GuestMemory, GuestMemoryAtomic};
 use vm_migration::protocol::MemoryRangeTable;
-use vm_migration::{MigratableError, Snapshot};
+use vm_migration::{MigratableError, Pausable, Snapshot};
 use vmm_sys_util::eventfd::EventFd;
 use vu_common_ctrl::VhostUserHandle;
 
@@ -425,6 +426,33 @@ impl VhostUserCommon {
         self.vu = Some(Arc::new(Mutex::new(vu)));
 
         Ok(())
+    }
+
+    pub fn reset(&mut self, id: &str) -> Option<Arc<dyn VirtioInterrupt>> {
+        // We first must resume the virtio thread if it was paused.
+        if self.virtio_common.pause_evt.take().is_some() {
+            self.virtio_common.resume().ok()?;
+        }
+
+        if let Some(vu) = &self.vu
+            && let Err(e) = vu.lock().unwrap().reset_vhost_user()
+        {
+            error!(
+                "Failed to reset vhost-user daemon for socket {}: {e:?}",
+                self.socket_path
+            );
+            return None;
+        }
+
+        if let Some(kill_evt) = self.virtio_common.kill_evt.take() {
+            // Ignore the result because there is nothing we can do about it.
+            let _ = kill_evt.write(1);
+        }
+
+        event!("virtio-device", "reset", "id", id);
+
+        // Return the interrupt
+        Some(self.virtio_common.interrupt_cb.take().unwrap())
     }
 
     pub fn shutdown(&mut self) {

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -429,9 +429,13 @@ impl VhostUserCommon {
     }
 
     pub fn reset(&mut self, id: &str) -> Option<Arc<dyn VirtioInterrupt>> {
-        // We first must resume the virtio thread if it was paused.
-        if self.virtio_common.pause_evt.take().is_some() {
-            self.virtio_common.resume().ok()?;
+        // Resume the virtio thread if it was paused. Reset must always
+        // converge to fresh state, so backend resume / reset failures are
+        // logged but don't skip the rest of the teardown.
+        if self.virtio_common.pause_evt.take().is_some()
+            && let Err(e) = self.virtio_common.resume()
+        {
+            error!("Failed to resume paused device during reset: {e:?}");
         }
 
         if let Some(vu) = &self.vu
@@ -441,7 +445,6 @@ impl VhostUserCommon {
                 "Failed to reset vhost-user daemon for socket {}: {e:?}",
                 self.socket_path
             );
-            return None;
         }
 
         if let Some(kill_evt) = self.virtio_common.kill_evt.take() {

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier, Mutex};
 use std::{result, thread};
 
-use event_monitor::event;
 use log::{error, info};
 use net_util::{CtrlQueue, MacAddr, VirtioNetConfig, build_net_config_space};
 use seccompiler::SeccompAction;
@@ -366,30 +365,7 @@ impl VirtioDevice for Net {
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        // We first must resume the virtio thread if it was paused.
-        if self.vu_common.virtio_common.pause_evt.take().is_some() {
-            self.vu_common.virtio_common.resume().ok()?;
-        }
-
-        if let Some(vu) = &self.vu_common.vu
-            && let Err(e) = vu.lock().unwrap().reset_vhost_user()
-        {
-            error!(
-                "Failed to reset vhost-user daemon for socket {}: {e:?}",
-                self.vu_common.socket_path
-            );
-            return None;
-        }
-
-        if let Some(kill_evt) = self.vu_common.virtio_common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-
-        event!("virtio-device", "reset", "id", &self.id);
-
-        // Return the interrupt
-        Some(self.vu_common.virtio_common.interrupt_cb.take().unwrap())
+        self.vu_common.reset(&self.id)
     }
 
     fn shutdown(&mut self) {

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -29,7 +29,7 @@ use crate::vhost_user::vu_common_ctrl::{VhostUserConfig, VhostUserHandle};
 use crate::vhost_user::{DEFAULT_VIRTIO_FEATURES, Error, Result, VhostUserCommon, VhostUserState};
 use crate::{
     ActivateResult, GuestMemoryMmap, GuestRegionMmap, NetCtrlEpollHandler,
-    VIRTIO_F_ACCESS_PLATFORM, VirtioCommon, VirtioDevice, VirtioDeviceType, VirtioInterrupt,
+    VIRTIO_F_ACCESS_PLATFORM, VirtioCommon, VirtioDevice, VirtioDeviceType,
 };
 
 const DEFAULT_QUEUE_NUMBER: usize = 2;
@@ -364,8 +364,8 @@ impl VirtioDevice for Net {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.vu_common.reset(&self.id)
+    fn reset(&mut self) {
+        self.vu_common.reset(&self.id);
     }
 
     fn shutdown(&mut self) {

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -488,10 +488,9 @@ where
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        let result = self.common.reset();
+    fn reset(&mut self) {
+        self.common.reset();
         event!("virtio-device", "reset", "id", &self.id);
-        result
     }
 
     fn shutdown(&mut self) {

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -379,10 +379,9 @@ impl VirtioDevice for Watchdog {
         Ok(())
     }
 
-    fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        let result = self.common.reset();
+    fn reset(&mut self) {
+        self.common.reset();
         event!("virtio-device", "reset", "id", &self.id);
-        result
     }
 }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4172,11 +4172,6 @@ impl DeviceManager {
             return Err(DeviceManagerError::MissingNode);
         }
 
-        // Allows support for one MSI-X vector per interrupt needed by the device.
-        // It also adds 1 as we need to take into account the dedicated vector to notify
-        // about a virtio config change.
-        let msix_num = (virtio_device.lock().unwrap().queue_max_sizes().len() + 1) as u16;
-
         // Create the AccessPlatform trait from the implementation IommuMapping.
         // This will provide address translation for any virtio device sitting
         // behind a vIOMMU.
@@ -4245,7 +4240,6 @@ impl DeviceManager {
                 id.clone(),
                 memory,
                 virtio_device,
-                msix_num,
                 access_platform.as_ref(),
                 self.msi_interrupt_manager.as_ref(),
                 pci_device_bdf.into(),


### PR DESCRIPTION
Improve the reset handling for virtio-pci devices since according to the spec reset must always succeed in leaving the device in a fresh state (at least from a virtio perspective). Whilst implementing this I discovered that we could also simplify the way we handled resets by removing the need to move the interrupt to/from the device.
