### PR TITLE
block: Add disk image factory and perform cleanups

### DIFF
--- a/block/src/async_io.rs
+++ b/block/src/async_io.rs
@@ -8,7 +8,7 @@ use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use thiserror::Error;
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::{BatchRequest, DiskTopology, SECTOR_SIZE};
+use crate::{BatchRequest, SECTOR_SIZE};
 
 #[derive(Error, Debug)]
 pub enum DiskFileError {
@@ -30,10 +30,10 @@ pub enum DiskFileError {
 
 pub type DiskFileResult<T> = std::result::Result<T, DiskFileError>;
 
-/// A wrapper for [`RawFd`] capturing the lifetime of a corresponding [`DiskFile`].
+/// A wrapper for [`RawFd`] capturing the lifetime of a corresponding disk file.
 ///
 /// This fulfills the same role as [`BorrowedFd`] but is tailored to the limitations
-/// by some implementations of [`DiskFile`], which wrap the effective [`File`]
+/// by some disk implementations, which wrap the effective [`File`]
 /// in an `Arc<Mutex<T>>`, making the use of [`BorrowedFd`] impossible.
 ///
 /// [`BorrowedFd`]: std::os::fd::BorrowedFd
@@ -56,47 +56,6 @@ impl AsRawFd for BorrowedDiskFd<'_> {
     fn as_raw_fd(&self) -> RawFd {
         self.raw_fd
     }
-}
-
-/// Abstraction over the effective [`File`] backing up a block device,
-/// with support for synchronous and asynchronous I/O.
-///
-/// This allows abstracting over raw image formats as well as structured
-/// image formats.
-pub trait DiskFile: Send {
-    /// Returns the logical disk size a guest will see.
-    ///
-    /// For raw formats, this is equal to [`Self::physical_size`]. For file formats
-    /// that wrap disk images in a container (e.g. QCOW2), this refers to the
-    /// effective size that the guest will see.
-    fn logical_size(&mut self) -> DiskFileResult<u64>;
-    /// Returns the physical size of the underlying file.
-    fn physical_size(&mut self) -> DiskFileResult<u64>;
-    fn create_async_io(&self, ring_depth: u32) -> DiskFileResult<Box<dyn AsyncIo>>;
-    fn topology(&mut self) -> DiskTopology {
-        DiskTopology::default()
-    }
-    fn resize(&mut self, _size: u64) -> DiskFileResult<()> {
-        Err(DiskFileError::Unsupported)
-    }
-
-    /// Indicates support for sparse operations (punch hole, write zeroes, discard).
-    /// Override to return true when supported.
-    fn supports_sparse_operations(&self) -> bool {
-        false
-    }
-
-    /// Indicates support for zero flag optimization in WRITE_ZEROES. Override
-    /// to return true when supported.
-    fn supports_zero_flag(&self) -> bool {
-        false
-    }
-
-    /// Returns the file descriptor of the underlying disk image file.
-    ///
-    /// The file descriptor is supposed to be used for `fcntl()` calls but no
-    /// other operation.
-    fn fd(&mut self) -> BorrowedDiskFd<'_>;
 }
 
 #[derive(Error, Debug)]

--- a/block/src/disk_file.rs
+++ b/block/src/disk_file.rs
@@ -34,10 +34,8 @@
 //! `&mut self`. Errors are returned as [`BlockResult`].
 
 use std::fmt::Debug;
-use std::io;
 
-use crate::async_io::{self, AsyncIo, BorrowedDiskFd};
-use crate::error::{BlockError, BlockErrorKind};
+use crate::async_io::{AsyncIo, BorrowedDiskFd};
 use crate::{BlockResult, DiskTopology};
 
 /// Reported capacity of a disk image.
@@ -158,82 +156,3 @@ pub trait AsyncFullDiskFile: FullDiskFile + AsyncDiskFile {}
 /// Blanket implementation: any type implementing both [`FullDiskFile`]
 /// and [`AsyncDiskFile`] automatically satisfies [`AsyncFullDiskFile`].
 impl<T: FullDiskFile + AsyncDiskFile> AsyncFullDiskFile for T {}
-
-/// A disk backend that dispatches to either the existing [`async_io::DiskFile`]
-/// trait or the next-generation [`AsyncFullDiskFile`] trait.
-pub enum DiskBackend {
-    /// Existing disk file backend (raw, vhd, vhdx, etc.).
-    Legacy(Box<dyn async_io::DiskFile>),
-    /// Next-generation disk file backend (qcow2, and more formats as they migrate).
-    Next(Box<dyn AsyncFullDiskFile>),
-}
-
-impl DiskBackend {
-    pub fn logical_size(&mut self) -> BlockResult<u64> {
-        match self {
-            Self::Legacy(d) => d
-                .logical_size()
-                .map_err(|e| BlockError::new(BlockErrorKind::Io, io::Error::other(e))),
-            Self::Next(d) => d.logical_size(),
-        }
-    }
-
-    pub fn physical_size(&mut self) -> BlockResult<u64> {
-        match self {
-            Self::Legacy(d) => d
-                .physical_size()
-                .map_err(|e| BlockError::new(BlockErrorKind::Io, io::Error::other(e))),
-            Self::Next(d) => d.physical_size(),
-        }
-    }
-
-    pub fn topology(&mut self) -> DiskTopology {
-        match self {
-            Self::Legacy(d) => d.topology(),
-            Self::Next(d) => d.topology(),
-        }
-    }
-
-    pub fn supports_sparse_operations(&self) -> bool {
-        match self {
-            Self::Legacy(d) => d.supports_sparse_operations(),
-            Self::Next(d) => d.supports_sparse_operations(),
-        }
-    }
-
-    pub fn supports_zero_flag(&self) -> bool {
-        match self {
-            Self::Legacy(d) => d.supports_zero_flag(),
-            Self::Next(d) => d.supports_zero_flag(),
-        }
-    }
-
-    pub fn fd(&mut self) -> BorrowedDiskFd<'_> {
-        match self {
-            Self::Legacy(d) => d.fd(),
-            Self::Next(d) => d.fd(),
-        }
-    }
-
-    pub fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
-        match self {
-            Self::Legacy(d) => d
-                .create_async_io(ring_depth)
-                .map_err(|e| BlockError::new(BlockErrorKind::Io, io::Error::other(e))),
-            Self::Next(d) => d.create_async_io(ring_depth),
-        }
-    }
-
-    pub fn resize(&mut self, new_size: u64) -> BlockResult<()> {
-        match self {
-            Self::Legacy(d) => d.resize(new_size).map_err(|e| match e {
-                async_io::DiskFileError::Unsupported => BlockError::new(
-                    BlockErrorKind::UnsupportedFeature,
-                    io::Error::other("resize not supported"),
-                ),
-                _ => BlockError::new(BlockErrorKind::Io, io::Error::other(e)),
-            }),
-            Self::Next(d) => d.resize(new_size),
-        }
-    }
-}

--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -262,4 +262,24 @@ mod unit_tests {
         let opened = open_disk(&options).unwrap();
         assert_eq!(opened.image_type, ImageType::Raw);
     }
+
+    #[test]
+    fn sync_fallback_when_async_disabled() {
+        let tmp = TempFile::new().unwrap();
+        let size = 1u64 << 20;
+        tmp.as_file().set_len(size).unwrap();
+        let path = tmp.as_path().to_owned();
+        let options = DiskOpenOptions {
+            path: &path,
+            readonly: false,
+            direct: false,
+            sparse: false,
+            backing_files: false,
+            disable_io_uring: true,
+            disable_aio: true,
+        };
+        let opened = open_disk(&options).unwrap();
+        assert_eq!(opened.image_type, ImageType::Raw);
+        assert_eq!(opened.disk.logical_size().unwrap(), size);
+    }
 }

--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -195,3 +195,32 @@ fn open_qcow2(
             .map_err(|e| e.with_path(options.path))?,
     ))
 }
+
+#[cfg(test)]
+mod unit_tests {
+    use std::path::Path;
+
+    use super::*;
+
+    fn default_options(path: &Path) -> DiskOpenOptions<'_> {
+        DiskOpenOptions {
+            path,
+            readonly: false,
+            direct: false,
+            sparse: false,
+            backing_files: false,
+            disable_io_uring: true,
+            disable_aio: true,
+        }
+    }
+
+    #[test]
+    fn nonexistent_path_returns_error() {
+        let path = Path::new("/tmp/no_such_disk_image.raw");
+        let options = default_options(path);
+        match open_disk(&options) {
+            Err(e) => assert_eq!(e.kind(), BlockErrorKind::Io),
+            Ok(_) => panic!("expected error for nonexistent path"),
+        }
+    }
+}

--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -251,4 +251,15 @@ mod unit_tests {
         let opened = open_disk(&options).unwrap();
         assert_eq!(opened.image_type, ImageType::Qcow2);
     }
+
+    #[test]
+    fn open_readonly() {
+        let tmp = TempFile::new().unwrap();
+        tmp.as_file().set_len(1 << 20).unwrap();
+        let path = tmp.as_path().to_owned();
+        let mut options = default_options(&path);
+        options.readonly = true;
+        let opened = open_disk(&options).unwrap();
+        assert_eq!(opened.image_type, ImageType::Raw);
+    }
 }

--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -198,11 +198,13 @@ fn open_qcow2(
 
 #[cfg(test)]
 mod unit_tests {
+    use std::io::Write;
     use std::path::Path;
 
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
+    use crate::qcow::{QcowFile, RawFile};
 
     fn default_options(path: &Path) -> DiskOpenOptions<'_> {
         DiskOpenOptions {
@@ -234,5 +236,19 @@ mod unit_tests {
         let options = default_options(&path);
         let opened = open_disk(&options).unwrap();
         assert_eq!(opened.image_type, ImageType::Raw);
+    }
+
+    #[test]
+    fn detect_qcow2_image() {
+        let tmp = TempFile::new().unwrap();
+        {
+            let raw = RawFile::new(tmp.as_file().try_clone().unwrap(), false);
+            let mut qcow = QcowFile::new(raw, 3, 100 * 1024 * 1024, true).unwrap();
+            qcow.flush().unwrap();
+        }
+        let path = tmp.as_path().to_owned();
+        let options = default_options(&path);
+        let opened = open_disk(&options).unwrap();
+        assert_eq!(opened.image_type, ImageType::Qcow2);
     }
 }

--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -1,0 +1,197 @@
+// Copyright 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Disk image factory.
+//!
+//! [`open_disk`] is the single entry point for opening a disk image.
+//! It opens the file, detects the image format, probes async I/O
+//! support, and constructs the appropriate backend. Callers receive
+//! a trait object that is ready for use by virtio queue workers.
+
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+use std::sync::OnceLock;
+use std::{fmt, fs};
+
+use log::info;
+
+use crate::disk_file::AsyncFullDiskFile;
+use crate::error::{BlockError, BlockErrorKind, BlockResult};
+#[cfg(feature = "io_uring")]
+use crate::fixed_vhd_async::FixedVhdDiskAsync;
+use crate::fixed_vhd_sync::FixedVhdDiskSync;
+#[cfg(feature = "io_uring")]
+use crate::qcow_async::QcowDiskAsync;
+use crate::qcow_sync::QcowDiskSync;
+use crate::raw_async_aio::RawFileDiskAio;
+use crate::raw_sync::RawFileDiskSync;
+use crate::vhdx_sync::VhdxDiskSync;
+use crate::{
+    ImageType, block_aio_is_supported, detect_image_type, open_disk_image, preallocate_disk,
+};
+#[cfg(feature = "io_uring")]
+use crate::{block_io_uring_is_supported, raw_async::RawFileDisk};
+
+/// Options for opening a disk image via [`open_disk`].
+pub struct DiskOpenOptions<'a> {
+    pub path: &'a Path,
+    pub readonly: bool,
+    pub direct: bool,
+    pub sparse: bool,
+    pub backing_files: bool,
+    pub disable_io_uring: bool,
+    pub disable_aio: bool,
+}
+
+/// Result of [`open_disk`], carrying the detected image type alongside
+/// the constructed backend.
+pub struct OpenedDisk {
+    pub image_type: ImageType,
+    pub disk: Box<dyn AsyncFullDiskFile>,
+}
+
+impl fmt::Debug for OpenedDisk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpenedDisk")
+            .field("image_type", &self.image_type)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Returns true when io_uring is supported on the running kernel.
+///
+/// The result is cached so the probe runs at most once per process.
+#[cfg(feature = "io_uring")]
+fn io_uring_supported() -> bool {
+    static SUPPORTED: OnceLock<bool> = OnceLock::new();
+    *SUPPORTED.get_or_init(block_io_uring_is_supported)
+}
+
+/// Returns true when Linux AIO is supported on the running kernel.
+///
+/// The result is cached so the probe runs at most once per process.
+fn aio_supported() -> bool {
+    static SUPPORTED: OnceLock<bool> = OnceLock::new();
+    *SUPPORTED.get_or_init(block_aio_is_supported)
+}
+
+/// Open a disk image and construct the appropriate async backend.
+///
+/// - Opens the file with the requested access mode and flags.
+/// - Detects the image format from the file header.
+/// - Probes io_uring and Linux AIO support on the running kernel.
+/// - Constructs the most capable backend available for the detected
+///   format, preferring io_uring over AIO over synchronous fallback.
+///
+/// The returned [`OpenedDisk`] exposes the detected [`ImageType`] so
+/// callers can perform post construction validation (e.g. type mismatch
+/// checks, configuration warnings).
+pub fn open_disk(options: &DiskOpenOptions<'_>) -> BlockResult<OpenedDisk> {
+    let mut fs_options = fs::OpenOptions::new();
+    fs_options.read(true);
+    fs_options.write(!options.readonly);
+    if options.direct {
+        fs_options.custom_flags(libc::O_DIRECT);
+    }
+
+    let mut file = open_disk_image(options.path, &fs_options)?;
+    let image_type = detect_image_type(&mut file)?;
+
+    let disk: Box<dyn AsyncFullDiskFile> = match image_type {
+        ImageType::FixedVhd => open_fixed_vhd(file, options)?,
+        ImageType::Raw => open_raw(file, options)?,
+        ImageType::Qcow2 => open_qcow2(file, options)?,
+        ImageType::Vhdx => open_vhdx(file, options)?,
+        ImageType::Unknown => {
+            return Err(
+                BlockError::from_kind(BlockErrorKind::UnsupportedFeature).with_path(options.path)
+            );
+        }
+    };
+
+    Ok(OpenedDisk { image_type, disk })
+}
+
+fn open_vhdx(
+    file: fs::File,
+    options: &DiskOpenOptions<'_>,
+) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
+    info!("Opening VHDX disk file with synchronous backend");
+    Ok(Box::new(
+        VhdxDiskSync::new(file).map_err(|e| e.with_path(options.path))?,
+    ))
+}
+
+fn open_fixed_vhd(
+    file: fs::File,
+    options: &DiskOpenOptions<'_>,
+) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
+    #[cfg(feature = "io_uring")]
+    if !options.disable_io_uring {
+        if io_uring_supported() {
+            info!("Opening fixed VHD disk file with io_uring backend");
+            return Ok(Box::new(
+                FixedVhdDiskAsync::new(file).map_err(|e| e.with_path(options.path))?,
+            ));
+        }
+        info!("io_uring runtime probe failed for fixed VHD, using synchronous backend");
+    }
+
+    info!("Opening fixed VHD disk file with synchronous backend");
+    Ok(Box::new(
+        FixedVhdDiskSync::new(file).map_err(|e| e.with_path(options.path))?,
+    ))
+}
+
+fn open_raw(
+    file: fs::File,
+    options: &DiskOpenOptions<'_>,
+) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
+    if !options.readonly && !options.sparse {
+        preallocate_disk(&file, options.path);
+    }
+
+    #[cfg(feature = "io_uring")]
+    if !options.disable_io_uring {
+        if io_uring_supported() {
+            info!("Opening RAW disk file with io_uring backend");
+            return Ok(Box::new(RawFileDisk::new(file)));
+        }
+        info!("io_uring runtime probe failed for RAW, trying next backend");
+    }
+
+    if !options.disable_aio {
+        if aio_supported() {
+            info!("Opening RAW disk file with AIO backend");
+            return Ok(Box::new(RawFileDiskAio::new(file)));
+        }
+        info!("AIO runtime probe failed for RAW, using synchronous backend");
+    }
+
+    info!("Opening RAW disk file with synchronous backend");
+    Ok(Box::new(RawFileDiskSync::new(file)))
+}
+
+fn open_qcow2(
+    file: fs::File,
+    options: &DiskOpenOptions<'_>,
+) -> BlockResult<Box<dyn AsyncFullDiskFile>> {
+    #[cfg(feature = "io_uring")]
+    if !options.disable_io_uring {
+        if io_uring_supported() {
+            info!("Opening QCOW2 disk file with io_uring backend");
+            return Ok(Box::new(
+                QcowDiskAsync::new(file, options.direct, options.backing_files, options.sparse)
+                    .map_err(|e| e.with_path(options.path))?,
+            ));
+        }
+        info!("io_uring runtime probe failed for QCOW2, using synchronous backend");
+    }
+
+    info!("Opening QCOW2 disk file with synchronous backend");
+    Ok(Box::new(
+        QcowDiskSync::new(file, options.direct, options.backing_files, options.sparse)
+            .map_err(|e| e.with_path(options.path))?,
+    ))
+}

--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -200,6 +200,8 @@ fn open_qcow2(
 mod unit_tests {
     use std::path::Path;
 
+    use vmm_sys_util::tempfile::TempFile;
+
     use super::*;
 
     fn default_options(path: &Path) -> DiskOpenOptions<'_> {
@@ -222,5 +224,15 @@ mod unit_tests {
             Err(e) => assert_eq!(e.kind(), BlockErrorKind::Io),
             Ok(_) => panic!("expected error for nonexistent path"),
         }
+    }
+
+    #[test]
+    fn detect_raw_image() {
+        let tmp = TempFile::new().unwrap();
+        tmp.as_file().set_len(1 << 20).unwrap();
+        let path = tmp.as_path().to_owned();
+        let options = default_options(&path);
+        let opened = open_disk(&options).unwrap();
+        assert_eq!(opened.image_type, ImageType::Raw);
     }
 }

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod async_io;
 pub mod disk_file;
 pub mod error;
+pub mod factory;
 pub mod fcntl;
 pub mod fixed_vhd;
 #[cfg(feature = "io_uring")]

--- a/fuzz/fuzz_targets/block.rs
+++ b/fuzz/fuzz_targets/block.rs
@@ -15,7 +15,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::{ffi, io};
 
-use block::disk_file::DiskBackend;
 use block::fcntl::LockGranularityChoice;
 use block::raw_sync::RawFileDiskSync;
 use libfuzzer_sys::{fuzz_target, Corpus};
@@ -55,7 +54,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
     let queue_affinity = BTreeMap::new();
     let mut block = Block::new(
         "tmp".to_owned(),
-        DiskBackend::Next(Box::new(RawFileDiskSync::new(disk_file))),
+        Box::new(RawFileDiskSync::new(disk_file)),
         PathBuf::from(""),
         false,
         false,

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -20,7 +20,7 @@ use std::{io, result};
 
 use anyhow::anyhow;
 use block::async_io::{AsyncIo, AsyncIoError};
-use block::disk_file::DiskBackend;
+use block::disk_file::AsyncFullDiskFile;
 use block::error::BlockError;
 use block::fcntl::{LockError, LockGranularity, LockGranularityChoice, LockType, get_lock_state};
 use block::{
@@ -713,7 +713,7 @@ impl EpollHelperHandler for BlockEpollHandler {
 pub struct Block {
     common: VirtioCommon,
     id: String,
-    disk_image: DiskBackend,
+    disk_image: Box<dyn AsyncFullDiskFile>,
     disk_path: PathBuf,
     disk_nsectors: Arc<AtomicU64>,
     config: VirtioBlockConfig,
@@ -743,7 +743,7 @@ impl Block {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: String,
-        mut disk_image: DiskBackend,
+        disk_image: Box<dyn AsyncFullDiskFile>,
         disk_path: PathBuf,
         read_only: bool,
         access_platform_enabled: bool,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -32,21 +32,10 @@ use arch::layout::{APIC_START, IOAPIC_SIZE, IOAPIC_START};
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use arch::{DeviceType, MmioDeviceInfo};
 use arch::{NumaNodes, layout};
+use block::ImageType;
 use block::disk_file::DiskBackend;
 use block::error::BlockError;
-use block::fixed_vhd_sync::FixedVhdDiskSync;
-#[cfg(feature = "io_uring")]
-use block::qcow_async::QcowDiskAsync;
-use block::qcow_sync::QcowDiskSync;
-use block::raw_async_aio::RawFileDiskAio;
-use block::raw_sync::RawFileDiskSync;
-use block::vhdx_sync::VhdxDiskSync;
-use block::{
-    ImageType, block_aio_is_supported, block_io_uring_is_supported, detect_image_type,
-    open_disk_image, preallocate_disk,
-};
-#[cfg(feature = "io_uring")]
-use block::{fixed_vhd_async::FixedVhdDiskAsync, raw_async::RawFileDisk};
+use block::factory::{DiskOpenOptions, open_disk};
 #[cfg(target_arch = "riscv64")]
 use devices::aia;
 #[cfg(target_arch = "x86_64")]
@@ -269,10 +258,6 @@ pub enum DeviceManagerError {
     /// Cannot create virtio-watchdog device
     #[error("Cannot create virtio-watchdog device")]
     CreateVirtioWatchdog(#[source] io::Error),
-
-    /// Failed to parse disk image format
-    #[error("Failed to parse disk image format")]
-    DetectImageType(#[source] BlockError),
 
     /// Cannot create serial manager
     #[error("Cannot create serial manager")]
@@ -580,27 +565,6 @@ pub enum DeviceManagerError {
     /// Failed to set O_DIRECT flag to file descriptor
     #[error("Failed to set O_DIRECT flag to file descriptor")]
     SetDirectIo,
-
-    /// Failed to create FixedVhdDiskAsync
-    #[error("Failed to create FixedVhdDiskAsync")]
-    CreateFixedVhdDiskAsync(#[source] BlockError),
-
-    /// Failed to create FixedVhdDiskSync
-    #[error("Failed to create FixedVhdDiskSync")]
-    CreateFixedVhdDiskSync(#[source] BlockError),
-
-    /// Failed to create QcowDiskSync
-    #[error("Failed to create QcowDiskSync")]
-    CreateQcowDiskSync(#[source] BlockError),
-
-    /// Failed to create QcowDiskAsync
-    #[error("Failed to create QcowDiskAsync")]
-    CreateQcowDiskAsync(#[source] BlockError),
-
-    /// Failed to create FixedVhdxDiskSync
-    #[error("Failed to create FixedVhdxDiskSync")]
-    CreateFixedVhdxDiskSync(#[source] BlockError),
-
     /// Failed to add DMA mapping handler to virtio-mem device.
     #[error("Failed to add DMA mapping handler to virtio-mem device")]
     AddDmaMappingHandlerVirtioMem(#[source] virtio_devices::mem::Error),
@@ -1128,13 +1092,6 @@ pub struct DeviceManager {
 
     // Force VIRTIO_F_ACCESS_PLATFORM on all virtio devices (e.g. for TDX/SEV-SNP)
     force_access_platform: bool,
-
-    // io_uring availability if detected
-    io_uring_supported: Option<bool>,
-
-    // aio availability if detected
-    aio_supported: Option<bool>,
-
     // List of unique identifiers provided at boot through the configuration.
     boot_id_list: BTreeSet<String>,
 
@@ -1438,8 +1395,6 @@ impl DeviceManager {
             pvmemcontrol_devices: None,
             pvpanic_device: None,
             force_access_platform,
-            io_uring_supported: None,
-            aio_supported: None,
             boot_id_list,
             #[cfg(not(target_arch = "riscv64"))]
             timestamp,
@@ -2652,29 +2607,6 @@ impl DeviceManager {
 
         Ok(())
     }
-
-    // Cache whether aio is supported to avoid checking for very block device
-    fn aio_is_supported(&mut self) -> bool {
-        if let Some(supported) = self.aio_supported {
-            return supported;
-        }
-
-        let supported = block_aio_is_supported();
-        self.aio_supported = Some(supported);
-        supported
-    }
-
-    // Cache whether io_uring is supported to avoid probing for very block device
-    fn io_uring_is_supported(&mut self) -> bool {
-        if let Some(supported) = self.io_uring_supported {
-            return supported;
-        }
-
-        let supported = block_io_uring_is_supported();
-        self.io_uring_supported = Some(supported);
-        supported
-    }
-
     /// Creates a [`MetaVirtioDevice`] from the provided [`DiskConfig`].
     ///
     /// Depending on the config, this is a [`vhost_user::Blk`] device or a [`virtio_devices::Block`]
@@ -2735,22 +2667,23 @@ impl DeviceManager {
                 vhost_user_block as Arc<Mutex<dyn Migratable>>,
             )
         } else {
-            let mut options = OpenOptions::new();
-            options.read(true);
-            options.write(!disk_cfg.readonly);
-            if disk_cfg.direct {
-                options.custom_flags(libc::O_DIRECT);
-            }
-            // Open block device path
             let disk_path = disk_cfg
                 .path
                 .as_ref()
                 .ok_or(DeviceManagerError::NoDiskPath)?;
-            let mut file: File =
-                open_disk_image(disk_path, &options).map_err(DeviceManagerError::Disk)?;
 
-            let detected_image_type =
-                detect_image_type(&mut file).map_err(DeviceManagerError::DetectImageType)?;
+            let opened = open_disk(&DiskOpenOptions {
+                path: disk_path,
+                readonly: disk_cfg.readonly,
+                direct: disk_cfg.direct,
+                sparse: disk_cfg.sparse,
+                backing_files: disk_cfg.backing_files,
+                disable_io_uring: disk_cfg.disable_io_uring,
+                disable_aio: disk_cfg.disable_aio,
+            })
+            .map_err(DeviceManagerError::Disk)?;
+
+            let detected_image_type = opened.image_type;
             let mut disable_sector0_writes = false;
 
             if disk_cfg.image_type == ImageType::Unknown {
@@ -2786,115 +2719,7 @@ impl DeviceManager {
                 warn!("Enabling backing_files option only applies for QCOW2 files");
             }
 
-            let image = match disk_cfg.image_type {
-                ImageType::FixedVhd => {
-                    // Use asynchronous backend relying on io_uring if the
-                    // syscalls are supported.
-                    if cfg!(feature = "io_uring")
-                        && !disk_cfg.disable_io_uring
-                        && self.io_uring_is_supported()
-                    {
-                        info!("Using asynchronous fixed VHD disk file (io_uring)");
-
-                        #[cfg(not(feature = "io_uring"))]
-                        unreachable!("Checked in if statement above");
-                        #[cfg(feature = "io_uring")]
-                        {
-                            DiskBackend::Next(Box::new(
-                                FixedVhdDiskAsync::new(file)
-                                    .map_err(DeviceManagerError::CreateFixedVhdDiskAsync)?,
-                            ))
-                        }
-                    } else {
-                        info!("Using synchronous fixed VHD disk file");
-                        DiskBackend::Next(Box::new(
-                            FixedVhdDiskSync::new(file)
-                                .map_err(DeviceManagerError::CreateFixedVhdDiskSync)?,
-                        ))
-                    }
-                }
-                ImageType::Raw => {
-                    // For non-sparse RAW disks, preallocate disk space
-                    if !disk_cfg.readonly
-                        && !disk_cfg.sparse
-                        && let Some(path) = &disk_cfg.path
-                    {
-                        preallocate_disk(&file, path);
-                    }
-
-                    // Use asynchronous backend relying on io_uring if the
-                    // syscalls are supported.
-                    if cfg!(feature = "io_uring")
-                        && !disk_cfg.disable_io_uring
-                        && self.io_uring_is_supported()
-                    {
-                        info!("Using asynchronous RAW disk file (io_uring)");
-
-                        #[cfg(not(feature = "io_uring"))]
-                        unreachable!("Checked in if statement above");
-                        #[cfg(feature = "io_uring")]
-                        {
-                            DiskBackend::Next(Box::new(RawFileDisk::new(file)))
-                        }
-                    } else if !disk_cfg.disable_aio && self.aio_is_supported() {
-                        info!("Using asynchronous RAW disk file (aio)");
-                        DiskBackend::Next(Box::new(RawFileDiskAio::new(file)))
-                    } else {
-                        info!("Using synchronous RAW disk file");
-                        DiskBackend::Next(Box::new(RawFileDiskSync::new(file)))
-                    }
-                }
-                ImageType::Qcow2 => {
-                    if cfg!(feature = "io_uring")
-                        && !disk_cfg.disable_io_uring
-                        && self.io_uring_is_supported()
-                    {
-                        info!("Using asynchronous QCOW2 disk file (io_uring)");
-
-                        #[cfg(not(feature = "io_uring"))]
-                        unreachable!("Checked in if statement above");
-                        #[cfg(feature = "io_uring")]
-                        {
-                            DiskBackend::Next(Box::new(
-                                QcowDiskAsync::new(
-                                    file,
-                                    disk_cfg.direct,
-                                    disk_cfg.backing_files,
-                                    disk_cfg.sparse,
-                                )
-                                .map_err(|e| match &disk_cfg.path {
-                                    Some(p) => e.with_path(p),
-                                    None => e,
-                                })
-                                .map_err(DeviceManagerError::CreateQcowDiskAsync)?,
-                            ))
-                        }
-                    } else {
-                        info!("Using synchronous QCOW2 disk file");
-                        DiskBackend::Next(Box::new(
-                            QcowDiskSync::new(
-                                file,
-                                disk_cfg.direct,
-                                disk_cfg.backing_files,
-                                disk_cfg.sparse,
-                            )
-                            .map_err(|e| match &disk_cfg.path {
-                                Some(p) => e.with_path(p),
-                                None => e,
-                            })
-                            .map_err(DeviceManagerError::CreateQcowDiskSync)?,
-                        ))
-                    }
-                }
-                ImageType::Vhdx => {
-                    info!("Using synchronous VHDX disk file");
-                    DiskBackend::Next(Box::new(
-                        VhdxDiskSync::new(file)
-                            .map_err(DeviceManagerError::CreateFixedVhdxDiskSync)?,
-                    ))
-                }
-                ImageType::Unknown => unreachable!(),
-            };
+            let image = DiskBackend::Next(opened.disk);
 
             let rate_limit_group =
                 if let Some(rate_limiter_cfg) = disk_cfg.rate_limiter_config.as_ref() {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -33,7 +33,6 @@ use arch::layout::{APIC_START, IOAPIC_SIZE, IOAPIC_START};
 use arch::{DeviceType, MmioDeviceInfo};
 use arch::{NumaNodes, layout};
 use block::ImageType;
-use block::disk_file::DiskBackend;
 use block::error::BlockError;
 use block::factory::{DiskOpenOptions, open_disk};
 #[cfg(target_arch = "riscv64")]
@@ -2719,8 +2718,6 @@ impl DeviceManager {
                 warn!("Enabling backing_files option only applies for QCOW2 files");
             }
 
-            let image = DiskBackend::Next(opened.disk);
-
             let rate_limit_group =
                 if let Some(rate_limiter_cfg) = disk_cfg.rate_limiter_config.as_ref() {
                     // Create an anonymous RateLimiterGroup that is dropped when the Disk
@@ -2764,7 +2761,7 @@ impl DeviceManager {
 
             let mut virtio_block = virtio_devices::Block::new(
                 id.clone(),
-                image,
+                opened.disk,
                 disk_cfg
                     .path
                     .as_ref()


### PR DESCRIPTION
This series introduces the block factory, removes the scaffolding `DiskBackend` enum, and deletes the now obsolete `async_io::DiskFile` trait.. The `block::factory::open_disk` centralises disk image opening, format detection, and async/sync backend selection. Wire vmm to use the factory, then remove the `DiskBackend` dispatch enum and the unused `async_io::DiskFile` trait.

- Add block/src/factory.rs with `DiskOpenOptions`, `OpenedDisk`, and `open_disk`. Format detection uses magic bytes. Backend selection prefers io_uring, falls back to AIO, then sync.
- Replace the manual match block in device_manager.rs with a single `open_disk` call. Remove per format error variants. `BlockError` surfaces via the existing `Disk` variant.
- Delete the `DiskBackend` enum from disk_file.rs. `virtio_devices::Block` takes `Box<dyn AsyncFullDiskFile>` directly.
- Delete the `async_io::DiskFile` trait as zero implementations remain. `DiskFileError`, `AsyncIo`, and related types stay in async_io.rs.

Factory unit tests: nonexistent path, RAW detection, QCOW2 detection, readonly open, sync fallback when async is disabled.

Covers refactoring section 3.3 from #7877.