### PR TITLE
[RFC] ci: Skip heavy workflows for documentation-only changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-docs-only:
+    uses: ./.github/workflows/check-docs-only.yaml
+
   build:
+    needs: [check-docs-only]
     name: Build
     runs-on: ubuntu-latest
     strategy:
@@ -20,61 +24,83 @@ jobs:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
     steps:
+      - name: Skip build for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping build for documentation-only changes"
+
       - name: Code checkout
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install musl-gcc
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: sudo apt install -y musl-tools
 
       - name: Install Rust toolchain (${{ matrix.rust }})
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
 
       - name: Build (default features)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --bin cloud-hypervisor
 
       - name: Build (kvm)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --bin cloud-hypervisor --no-default-features --features "kvm"
 
       - name: Build (default features + tdx)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --bin cloud-hypervisor --features "tdx"
 
       - name: Build (default features + dbus_api)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --bin cloud-hypervisor --features "dbus_api"
 
       - name: Build (default features + guest_debug)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --bin cloud-hypervisor --features "guest_debug"
 
       - name: Build (default features + pvmemcontrol)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --bin cloud-hypervisor --features "pvmemcontrol"
 
       - name: Build (default features + fw_cfg)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --bin cloud-hypervisor --features "fw_cfg"
 
       - name: Build (default features + ivshmem)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --bin cloud-hypervisor --features "ivshmem"
 
       - name: Build (mshv)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --bin cloud-hypervisor --no-default-features --features "mshv"
 
       - name: Build (sev_snp)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --bin cloud-hypervisor --no-default-features --features "sev_snp"
 
       - name: Build (kvm + igvm + sev_snp + fw_cfg)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --bin cloud-hypervisor --no-default-features --features "kvm,igvm,sev_snp,fw_cfg"
 
       - name: Build (igvm)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --bin cloud-hypervisor --no-default-features --features "igvm"
 
       - name: Build (mshv + kvm)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --bin cloud-hypervisor --no-default-features --features "mshv,kvm"
 
       - name: Release Build (default features)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo build --locked --all --release --target=${{ matrix.target }}
 
       - name: Check build did not modify any files
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: test -z "$(git status --porcelain)"

--- a/.github/workflows/check-docs-only.yaml
+++ b/.github/workflows/check-docs-only.yaml
@@ -1,0 +1,38 @@
+name: Check documentation only
+on:
+  workflow_call:
+    outputs:
+      docs-only:
+        description: "true if only documentation files were changed"
+        value: ${{ jobs.check.outputs.docs-only }}
+
+jobs:
+  check:
+    name: Check for doc-only changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.check.outputs.docs-only }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Documentation file patterns (centralized here — edit only this file)
+          DOC_PATTERN='^(docs/|[^/]*\.md$|\.github/ISSUE_TEMPLATE/|LICENSES/|CODEOWNERS$)'
+
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_target" ]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            NON_DOC_COUNT=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+              --paginate --jq '.[].filename' | grep -cvE "$DOC_PATTERN" || true)
+          else
+            echo "docs-only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${NON_DOC_COUNT:-0}" -eq 0 ]; then
+            echo "docs-only=true" >> "$GITHUB_OUTPUT"
+            echo "Only documentation files changed — skippable"
+          else
+            echo "docs-only=false" >> "$GITHUB_OUTPUT"
+            echo "Non-documentation files changed — CI required"
+          fi

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -5,7 +5,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-docs-only:
+    uses: ./.github/workflows/check-docs-only.yaml
+
   build:
+    needs: [check-docs-only]
     name: Code Formatting
     runs-on: ubuntu-latest
     strategy:
@@ -18,15 +22,23 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
+      - name: Skip formatting for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping formatting for documentation-only changes"
+
       - name: Code checkout
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: actions/checkout@v6
       - name: Install Rust toolchain (${{ matrix.rust }})
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: dtolnay/rust-toolchain@stable
         with:
             toolchain: ${{ matrix.rust }}
             target: ${{ matrix.target }}
             components: rustfmt
       - name: Formatting (rustfmt)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo fmt --all -- --check
       - name: Formatting (fuzz) (rustfmt)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo fmt --all --manifest-path fuzz/Cargo.toml -- --check

--- a/.github/workflows/fuzz-build.yaml
+++ b/.github/workflows/fuzz-build.yaml
@@ -5,7 +5,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-docs-only:
+    uses: ./.github/workflows/check-docs-only.yaml
+
   build:
+    needs: [check-docs-only]
     name: Cargo Fuzz Build
     runs-on: ubuntu-latest
     strategy:
@@ -17,16 +21,25 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
+      - name: Skip fuzz build for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping fuzz build for documentation-only changes"
+
       - name: Code checkout
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: actions/checkout@v6
       - name: Install Rust toolchain (${{ matrix.rust }})
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: dtolnay/rust-toolchain@stable
         with:
             toolchain: ${{ matrix.rust }}
             target: ${{ matrix.target }}
       - name: Install Cargo fuzz
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo install cargo-fuzz
       - name: Fuzz Build
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo fuzz build
       - name: Fuzz Check
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: cargo fuzz check

--- a/.github/workflows/integration-arm64.yaml
+++ b/.github/workflows/integration-arm64.yaml
@@ -5,7 +5,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-docs-only:
+    uses: ./.github/workflows/check-docs-only.yaml
+
   build:
+    needs: [check-docs-only]
     timeout-minutes: 120
     env:
       # Our runner has 80 cores (nproc).
@@ -15,26 +19,30 @@ jobs:
     name: Tests (ARM64)
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'bookworm-arm64' }}
     steps:
+      - name: Skip tests for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping tests for documentation-only changes"
+
       - name: Fix workspace permissions
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         run: sudo chown -R runner:runner ${GITHUB_WORKSPACE}
       - name: Code checkout
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Run unit tests (musl)
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         run: scripts/dev_cli.sh tests --unit --libc musl
       - name: Load openvswitch module
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         run: sudo modprobe openvswitch
       - name: Run integration tests (musl)
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         timeout-minutes: 60
         run: scripts/dev_cli.sh tests --integration --libc musl
       - name: Install Azure CLI
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         run: |
           set -eufo pipefail
           sudo apt install -y ca-certificates curl apt-transport-https lsb-release gnupg
@@ -43,7 +51,7 @@ jobs:
           sudo apt update
           sudo apt install -y azure-cli
       - name: Download Windows image
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         shell: bash
         run: |
           set -eufo pipefail
@@ -61,9 +69,9 @@ jobs:
           az storage blob download --container-name private-images --file "$IMG_GZ_PATH" --name "$IMG_GZ_BLOB_NAME" --connection-string "${{ secrets.CH_PRIVATE_IMAGES }}"
           gzip -d "$IMG_GZ_PATH"
       - name: Run Windows guest integration tests
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         timeout-minutes: 30
         run: scripts/dev_cli.sh tests --integration-windows --libc musl
       - name: Skipping build for PR
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name == 'pull_request' }}
         run: echo "Skipping build for PR"

--- a/.github/workflows/integration-rate-limiter.yaml
+++ b/.github/workflows/integration-rate-limiter.yaml
@@ -5,21 +5,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-docs-only:
+    uses: ./.github/workflows/check-docs-only.yaml
+
   build:
+    needs: [check-docs-only]
     name: Tests (Rate-Limiter)
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'bare-metal-9950x' }}
     env:
       AUTH_DOWNLOAD_TOKEN: ${{ secrets.AUTH_DOWNLOAD_TOKEN }}
     steps:
+      - name: Skip tests for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping tests for documentation-only changes"
+
       - name: Code checkout
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Run rate-limiter integration tests
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         timeout-minutes: 20
         run: scripts/dev_cli.sh tests --integration-rate-limiter
       - name: Skipping build for PR
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name == 'pull_request' }}
         run: echo "Skipping build for PR"

--- a/.github/workflows/integration-vfio.yaml
+++ b/.github/workflows/integration-vfio.yaml
@@ -5,29 +5,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-docs-only:
+    uses: ./.github/workflows/check-docs-only.yaml
+
   build:
+    needs: [check-docs-only]
     name: Tests (VFIO)
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'vfio-nvidia' }}
     env:
       AUTH_DOWNLOAD_TOKEN: ${{ secrets.AUTH_DOWNLOAD_TOKEN }}
     steps:
+      - name: Skip tests for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping tests for documentation-only changes"
+
       - name: Fix workspace permissions
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         run: sudo chown -R github-runner:github-runner "${GITHUB_WORKSPACE}"
       - name: Code checkout
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Run VFIO integration tests
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         timeout-minutes: 15
         run: scripts/dev_cli.sh tests --integration-vfio
       # Most tests are failing with musl see #6790
       # - name: Run VFIO integration tests for musl
-      #   if: ${{ github.event_name != 'pull_request' }}
+      #   if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
       #   timeout-minutes: 15
       #   run: scripts/dev_cli.sh tests --integration-vfio --libc musl
       - name: Skipping build for PR
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name == 'pull_request' }}
         run: echo "Skipping build for PR"

--- a/.github/workflows/integration-windows.yaml
+++ b/.github/workflows/integration-windows.yaml
@@ -5,17 +5,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-docs-only:
+    uses: ./.github/workflows/check-docs-only.yaml
+
   build:
+    needs: [check-docs-only]
     name: Tests (Windows Guest)
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'garm-jammy-16' }}
     steps:
+      - name: Skip tests for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping tests for documentation-only changes"
+
       - name: Code checkout
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install Docker
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         run: |
           set -eufo pipefail
           sudo apt-get update
@@ -26,7 +34,7 @@ jobs:
           sudo apt-get update
           sudo apt install -y docker-ce docker-ce-cli
       - name: Install Azure CLI
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         run: |
           set -eufo pipefail
           sudo apt install -y ca-certificates curl apt-transport-https lsb-release gnupg
@@ -35,19 +43,19 @@ jobs:
           sudo apt update
           sudo apt install -y azure-cli
       - name: Download Windows image
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         run: |
           set -eufo pipefail
           mkdir $HOME/workloads
           az storage blob download --container-name private-images --file "$HOME/workloads/windows-server-2025-amd64-1.raw" --name windows-server-2025-amd64-1.raw --connection-string "${{ secrets.CH_PRIVATE_IMAGES }}"
       - name: Run Windows guest integration tests
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         timeout-minutes: 15
         run: scripts/dev_cli.sh tests --integration-windows
       - name: Run Windows guest integration tests for musl
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name != 'pull_request' }}
         timeout-minutes: 15
         run: scripts/dev_cli.sh tests --integration-windows --libc musl
       - name: Skipping build for PR
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name == 'pull_request' }}
         run: echo "Skipping build for PR"

--- a/.github/workflows/integration-x86-64.yaml
+++ b/.github/workflows/integration-x86-64.yaml
@@ -5,7 +5,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-docs-only:
+    uses: ./.github/workflows/check-docs-only.yaml
+
   build:
+    needs: [check-docs-only]
     timeout-minutes: 80
     env:
       # Our runner has 16 cores (nproc).
@@ -20,13 +24,17 @@ jobs:
     name: Tests (x86-64)
     runs-on: ${{ github.event_name == 'pull_request' && !(matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') && 'ubuntu-latest' || format('{0}-16', matrix.runner) }}
     steps:
+      - name: Skip tests for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping tests for documentation-only changes"
+
       - name: Code checkout
-        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && (github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu')) }}
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install Docker
-        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && (github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu')) }}
         run: |
           set -eufo pipefail
           sudo apt-get update
@@ -37,22 +45,22 @@ jobs:
           sudo apt-get update
           sudo apt install -y docker-ce docker-ce-cli
       - name: Prepare for VDPA
-        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && (github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu')) }}
         run: scripts/prepare_vdpa.sh
       - name: Run unit tests
-        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && (github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu')) }}
         run: scripts/dev_cli.sh tests --unit --libc ${{ matrix.libc }}
       - name: Load openvswitch module
-        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && (github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu')) }}
         run: sudo modprobe openvswitch
       - name: Run integration tests
-        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && (github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu')) }}
         timeout-minutes: 60
         run: scripts/dev_cli.sh tests --integration --libc ${{ matrix.libc }}
       - name: Run live-migration integration tests
-        if: ${{ github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && (github.event_name != 'pull_request' || (matrix.runner == 'garm-jammy' && matrix.libc == 'gnu')) }}
         timeout-minutes: 20
         run: scripts/dev_cli.sh tests --integration-live-migration --libc ${{ matrix.libc }}
       - name: Skipping build for PR
-        if: ${{ github.event_name == 'pull_request' && matrix.runner != 'garm-jammy' && matrix.libc != 'gnu' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name == 'pull_request' && !(matrix.runner == 'garm-jammy' && matrix.libc == 'gnu') }}
         run: echo "Skipping build for PR"

--- a/.github/workflows/mshv-infra.yaml
+++ b/.github/workflows/mshv-infra.yaml
@@ -18,6 +18,11 @@ on:
         description: 'Resource Group Name'
         required: true
         type: string
+      skip:
+        description: 'Skip infra setup and report success'
+        required: false
+        default: false
+        type: boolean
       VM_SKU:
         description: 'VM SKU'
         required: true
@@ -49,13 +54,18 @@ concurrency:
 jobs:
   infra-setup:
     name: ${{ inputs.ARCH }} VM Provision
-    runs-on: mshv
+    runs-on: ${{ inputs.skip && 'ubuntu-latest' || 'mshv' }}
     outputs:
       RG_NAME: ${{ steps.rg-setup.outputs.RG_NAME }}
       VM_NAME: ${{ steps.vm-setup.outputs.VM_NAME }}
       PRIVATE_IP: ${{ steps.get-vm-ip.outputs.PRIVATE_IP }}
     steps:
+      - name: Skip infra setup for documentation-only changes
+        if: ${{ inputs.skip }}
+        run: echo "Skipping infra setup for documentation-only changes"
+
       - name: Install & login to AZ CLI
+        if: ${{ !inputs.skip }}
         env:
           MI_CLIENT_ID: ${{ secrets.MI_CLIENT_ID }}
         run: |
@@ -72,6 +82,7 @@ jobs:
 
       - name: Get Location
         id: get-location
+        if: ${{ !inputs.skip }}
         env:
           SKU: ${{ inputs.VM_SKU }}
           STORAGE_ACCOUNT_PATHS: ${{ secrets.STORAGE_ACCOUNT_PATHS }}
@@ -107,6 +118,7 @@ jobs:
 
       - name: Create Resource Group
         id: rg-setup
+        if: ${{ !inputs.skip }}
         env:
           LOCATION: ${{ steps.get-location.outputs.location }}
           RG: ${{ inputs.RG }}
@@ -122,6 +134,7 @@ jobs:
 
       - name: Generate SSH Key
         id: generate-ssh-key
+        if: ${{ !inputs.skip }}
         env:
           KEY: ${{ inputs.KEY }}
         run: |
@@ -132,6 +145,7 @@ jobs:
 
       - name: Create VM
         id: vm-setup
+        if: ${{ !inputs.skip }}
         env:
           KEY: ${{ inputs.KEY }}
           LOCATION: ${{ steps.get-location.outputs.location }}
@@ -186,6 +200,7 @@ jobs:
 
       - name: Get VM Private IP
         id: get-vm-ip
+        if: ${{ !inputs.skip }}
         env:
           RG: ${{ inputs.RG }}
           VM_NAME: ${{ inputs.ARCH }}_${{ steps.get-location.outputs.location }}_${{ github.run_id }}
@@ -201,6 +216,7 @@ jobs:
           echo "PRIVATE_IP=$PRIVATE_IP" >> "$GITHUB_OUTPUT"
 
       - name: Wait for SSH availability
+        if: ${{ !inputs.skip }}
         env:
           KEY: ${{ inputs.KEY }}
           PRIVATE_IP: ${{ steps.get-vm-ip.outputs.PRIVATE_IP }}
@@ -211,6 +227,7 @@ jobs:
           echo "VM is accessible!"
 
       - name: Remove Old Host Key
+        if: ${{ !inputs.skip }}
         env:
           PRIVATE_IP: ${{ steps.get-vm-ip.outputs.PRIVATE_IP }}
         run: |
@@ -219,6 +236,7 @@ jobs:
           ssh-keygen -R "$PRIVATE_IP"
 
       - name: SSH into VM and Install Dependencies
+        if: ${{ !inputs.skip }}
         env:
           KEY: ${{ inputs.KEY }}
           PRIVATE_IP: ${{ steps.get-vm-ip.outputs.PRIVATE_IP }}

--- a/.github/workflows/mshv-integration.yaml
+++ b/.github/workflows/mshv-integration.yaml
@@ -3,7 +3,11 @@ on: [pull_request_target, merge_group]
 permissions: {}
 
 jobs:
+  check-docs-only:
+    uses: ./.github/workflows/check-docs-only.yaml
+
   infra-setup:
+    needs: [check-docs-only]
     name: MSHV Infra Setup (x86_64)
     uses: ./.github/workflows/mshv-infra.yaml
     with:
@@ -11,6 +15,7 @@ jobs:
       KEY: azure_key_${{ github.run_id }}
       OS_DISK_SIZE: 512
       RG: MSHV-INTEGRATION-${{ github.run_id }}
+      skip: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
       VM_SKU: Standard_D16s_v5
     secrets:
       MI_CLIENT_ID: ${{ secrets.MSHV_MI_CLIENT_ID }}
@@ -21,11 +26,16 @@ jobs:
 
   run-tests:
     name: Integration Tests (x86_64)
-    needs: infra-setup
+    needs: [check-docs-only, infra-setup]
     if: ${{ always() && needs.infra-setup.result == 'success' }}
-    runs-on: mshv
+    runs-on: ${{ needs.check-docs-only.outputs.docs-only == 'true' && 'ubuntu-latest' || 'mshv' }}
     steps:
+      - name: Skip integration tests for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping integration tests for documentation-only changes"
+
       - name: Run integration tests
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         timeout-minutes: 60
         env:
           KEY: azure_key_${{ github.run_id }}
@@ -80,7 +90,7 @@ jobs:
           EOF
 
       - name: Dump dmesg
-        if: always()
+        if: ${{ always() && needs.check-docs-only.outputs.docs-only != 'true' }}
         continue-on-error: true
         env:
           KEY: azure_key_${{ github.run_id }}
@@ -90,7 +100,7 @@ jobs:
           ssh -i ~/.ssh/"${KEY}" -o StrictHostKeyChecking=no -- "${USERNAME}@${PRIVATE_IP}" sudo dmesg
 
       - name: Dump serial console logs
-        if: always()
+        if: ${{ always() && needs.check-docs-only.outputs.docs-only != 'true' }}
         continue-on-error: true
         env:
           RG_NAME: ${{ needs.infra-setup.outputs.RG_NAME }}
@@ -101,11 +111,16 @@ jobs:
 
   cleanup:
     name: Cleanup
-    needs: run-tests
+    needs: [check-docs-only, run-tests]
     if: always()
-    runs-on: mshv
+    runs-on: ${{ needs.check-docs-only.outputs.docs-only == 'true' && 'ubuntu-latest' || 'mshv' }}
     steps:
+      - name: Skip cleanup for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping cleanup for documentation-only changes"
+
       - name: Delete RG
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         env:
           RG: MSHV-INTEGRATION-${{ github.run_id }}
         run: |
@@ -117,6 +132,7 @@ jobs:
           echo "Cleanup process completed."
 
       - name: Delete SSH Key
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         env:
           KEY: azure_key_${{ github.run_id }}
         run: |

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -2,13 +2,24 @@ name: Cloud Hypervisor OpenAPI Validation
 on: [pull_request, merge_group]
 
 jobs:
+  check-docs-only:
+    uses: ./.github/workflows/check-docs-only.yaml
+
   Validate:
+    needs: [check-docs-only]
     runs-on: ubuntu-latest
     container: openapitools/openapi-generator-cli
     steps:
-    - uses: actions/checkout@v6
-    - name: Validate OpenAPI
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        /usr/local/bin/docker-entrypoint.sh validate -i vmm/src/api/openapi/cloud-hypervisor.yaml
+      - name: Skip OpenAPI validation for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping OpenAPI validation for documentation-only changes"
+
+      - uses: actions/checkout@v6
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
+
+      - name: Validate OpenAPI
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          /usr/local/bin/docker-entrypoint.sh validate -i vmm/src/api/openapi/cloud-hypervisor.yaml

--- a/.github/workflows/package-consistency.yaml
+++ b/.github/workflows/package-consistency.yaml
@@ -5,27 +5,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-docs-only:
+    uses: ./.github/workflows/check-docs-only.yaml
+
   build:
+    needs: [check-docs-only]
     name: Rust VMM Consistency Check
     runs-on: ubuntu-latest
     steps:
+      - name: Skip consistency checks for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping consistency checks for documentation-only changes"
+
       - name: Code checkout
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install dependencies
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: sudo apt install -y python3
 
       - name: Install Rust toolchain stable
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
 
       - name: Check Rust VMM Package Consistency of root Workspace
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: python3 scripts/package-consistency-check.py github.com/rust-vmm
 
       - name: Check Rust VMM Package Consistency of fuzz Workspace
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: |
           set -eufo pipefail
           pushd fuzz

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -5,7 +5,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-docs-only:
+    uses: ./.github/workflows/check-docs-only.yaml
+
   build:
+    needs: [check-docs-only]
     name: Quality (clippy)
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
@@ -28,12 +32,18 @@ jobs:
             experimental: false
 
     steps:
+      - name: Skip clippy for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping clippy for documentation-only changes"
+
       - name: Code checkout
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install Rust toolchain (${{ matrix.rust }})
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
@@ -42,7 +52,7 @@ jobs:
           components: clippy
 
       - name: Bisectability Check (default features)
-        if: ${{ github.event_name == 'pull_request' && matrix.target == 'x86_64-unknown-linux-gnu' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && github.event_name == 'pull_request' && matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: |
           set -eufo pipefail
           commits=$(git rev-list origin/${{ github.base_ref }}..${{ github.sha }})
@@ -50,6 +60,7 @@ jobs:
           git checkout ${{ github.sha }}
 
       - name: Clippy (kvm)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: clippy
@@ -58,6 +69,7 @@ jobs:
           args: --locked --all --all-targets --no-default-features --tests --examples --features "kvm" -- -D warnings
 
       - name: Clippy (mshv)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: clippy
@@ -66,6 +78,7 @@ jobs:
           args: --locked --all --all-targets --no-default-features --tests --examples --features "mshv" -- -D warnings
 
       - name: Clippy (mshv + kvm)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: clippy
@@ -74,6 +87,7 @@ jobs:
           args: --locked --all --all-targets --no-default-features --tests --examples --features "mshv,kvm" -- -D warnings
 
       - name: Clippy (default features)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: clippy
@@ -82,6 +96,7 @@ jobs:
           args: --locked --all --all-targets --tests --examples -- -D warnings
 
       - name: Clippy (default features + guest_debug)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: clippy
@@ -90,6 +105,7 @@ jobs:
           args: --locked --all --all-targets --tests --examples --features "guest_debug" -- -D warnings
 
       - name: Clippy (default features + pvmemcontrol)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: clippy
@@ -98,6 +114,7 @@ jobs:
           args: --locked --all --all-targets --tests --examples --features "pvmemcontrol" -- -D warnings
 
       - name: Clippy (default features + tracing)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: clippy
@@ -105,6 +122,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --locked --all --all-targets --tests --examples --features "tracing" -- -D warnings
       - name: Clippy (default features + fw_cfg)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
@@ -112,6 +130,7 @@ jobs:
           args: --target=${{ matrix.target }} --locked --all --all-targets --tests --examples --features "fw_cfg" -- -D warnings
 
       - name: Clippy (default features + ivshmem)
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: clippy
@@ -120,7 +139,7 @@ jobs:
           args: --locked --all --all-targets --tests --examples --features "ivshmem" -- -D warnings
 
       - name: Clippy (sev_snp)
-        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: clippy
@@ -129,7 +148,7 @@ jobs:
           args: --locked --all --all-targets --no-default-features --tests --examples --features "sev_snp" -- -D warnings
 
       - name: Clippy (igvm)
-        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: clippy
@@ -138,7 +157,7 @@ jobs:
           args: --locked --all --all-targets --no-default-features --tests --examples --features "igvm" -- -D warnings
 
       - name: Clippy (kvm + tdx)
-        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: clippy
@@ -147,7 +166,7 @@ jobs:
           args: --locked --all --all-targets --no-default-features --tests --examples --features "tdx,kvm" -- -D warnings
 
       - name: Clippy (kvm + igvm + sev_snp + fw_cfg)
-        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: clippy
@@ -157,7 +176,7 @@ jobs:
           args: --locked --all --all-targets --no-default-features --tests --examples --features "kvm,igvm,sev_snp,fw_cfg" -- -D warnings
 
       - name: Clippy (default features + sev_snp + igvm + fw_cfg)
-        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' && matrix.target == 'x86_64-unknown-linux-gnu' }}
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: clippy
@@ -167,6 +186,7 @@ jobs:
           args: --locked --all --all-targets --tests --examples --features "sev_snp,igvm,fw_cfg" -- -D warnings
 
       - name: Check build did not modify any files
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
         run: test -z "$(git status --porcelain)"
 
   typos:

--- a/.github/workflows/shlint.yaml
+++ b/.github/workflows/shlint.yaml
@@ -7,14 +7,25 @@ on:
       - main
 
 jobs:
+  check-docs-only:
+    uses: ./.github/workflows/check-docs-only.yaml
+
   sh-checker:
+    needs: [check-docs-only]
     name: Check shell scripts
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-    - name: Run the shell script checkers
-      uses: luizm/action-sh-checker@master
-      env:
-        SHFMT_OPTS: -i 4 -d
-        SHELLCHECK_OPTS: -x --source-path scripts
+      - name: Skip shell checks for documentation-only changes
+        if: ${{ needs.check-docs-only.outputs.docs-only == 'true' }}
+        run: echo "Skipping shell checks for documentation-only changes"
+
+      - name: Checkout repository
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
+        uses: actions/checkout@v6
+
+      - name: Run the shell script checkers
+        if: ${{ needs.check-docs-only.outputs.docs-only != 'true' }}
+        uses: luizm/action-sh-checker@master
+        env:
+          SHFMT_OPTS: -i 4 -d
+          SHELLCHECK_OPTS: -x --source-path scripts


### PR DESCRIPTION
Add a centralized reusable workflow (check-docs-only.yaml) that determines if a PR only touches documentation files. The doc file patterns are defined in one place:
  - docs/**
  - *.md (root-level)
  - .github/ISSUE_TEMPLATE/**
  - LICENSES/**
  - CODEOWNERS

13 workflows now call check-docs-only and conditionally skip their jobs when only documentation files changed. To update the patterns, edit only check-docs-only.yaml.

Workflows that always run:
- Gitlint (commit message checks)
- DCO (sign-off validation)
- Lychee (link checking)
- REUSE (license compliance)

Workflows already path-filtered (unchanged):
- Audit, Hadolint, Docker-image, Taplo

Assisted-by: OpenAI:ChatGPT-5.4