### PR TITLE
pci: vfio: Implement migration v2 for snapshot and restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitfield-struct"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,6 +1611,7 @@ name = "pci"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "byteorder",
  "hypervisor",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,7 +1611,7 @@ dependencies = [
  "log",
  "serde",
  "thiserror",
- "vfio-bindings",
+ "vfio-bindings 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vfio-ioctls",
  "vfio_user",
  "vm-allocator",
@@ -2363,10 +2363,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "vfio-bindings"
+version = "0.6.2"
+source = "git+https://github.com/saravan2/vfio.git?branch=vfio-ioctls#68097e9d4a8841c29d2652d667fdb71c785197dd"
+
+[[package]]
 name = "vfio-ioctls"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b1d98dff7f0d219278e406323e7eda4d426447bd203c7828189baf0d8c07b7"
+source = "git+https://github.com/saravan2/vfio.git?branch=vfio-ioctls#68097e9d4a8841c29d2652d667fdb71c785197dd"
 dependencies = [
  "byteorder",
  "iommufd-bindings",
@@ -2378,7 +2382,7 @@ dependencies = [
  "mshv-bindings",
  "mshv-ioctls",
  "thiserror",
- "vfio-bindings",
+ "vfio-bindings 0.6.2 (git+https://github.com/saravan2/vfio.git?branch=vfio-ioctls)",
  "vm-memory",
  "vmm-sys-util",
 ]
@@ -2396,7 +2400,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "thiserror",
- "vfio-bindings",
+ "vfio-bindings 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory",
  "vmm-sys-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ serde_with = { version = "3.18.0", default-features = false }
 
 # other crates
 anyhow = "1.0.102"
+base64 = "0.22.1"
 bitflags = "2.11.1"
 byteorder = "1.5.0"
 cfg-if = "1.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,3 +128,6 @@ unnecessary_semicolon = "deny"
 [workspace.lints.rust]
 # `level = warn` is irrelevant here but mandatory for rustc/cargo
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(devcli_testenv)'] }
+
+[patch.crates-io]
+vfio-ioctls = { git = "https://github.com/saravan2/vfio.git", branch = "vfio-ioctls" }

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -139,6 +139,26 @@ In the example above, the net device with id `net1` will be backed by FDs '23'
 and '24', and the net device with id `net2` will be backed by FDs '25' and '26'
 from the restored VM.
 
+## VFIO devices
+
+Snapshot and restore work with VFIO devices, with two modes depending on
+whether the device advertises the kernel VFIO migration v2 protocol:
+
+- **Migratable VFIO devices** (e.g. `mlx5_vfio_pci`):
+  Cloud Hypervisor captures the opaque device state through STOP_COPY during
+  snapshot and replays it through RESUMING during restore. The guest observes
+  the device in the same operational state after restore as before snapshot.
+  Requires Linux 5.18 or newer on the host.
+- **Non migratable VFIO devices** (e.g. generic `vfio_pci`): snapshot and
+  restore still succeed, but device internal state is not captured. Only the
+  PCI configuration and interrupt routing that Cloud Hypervisor owns are
+  preserved. Device behavior after restore depends on whether the device
+  driver inside the guest can recover without explicit reconfiguration.
+
+See [`vfio.md`](vfio.md) for details on requirements and behavior.
+
 ## Limitations
 
-VFIO devices is out of scope.
+Snapshot and restore of VMs with VFIO devices is supported as described above.
+Live Migration support for VFIO devices (including DMA dirty page tracking and
+VMM orchestration) is tracked as a follow up.

--- a/docs/vfio.md
+++ b/docs/vfio.md
@@ -194,3 +194,57 @@ mmio address space is available for use by devices on PCI segment 1.
 --pci-segment pci_segment=0,mmio32_aperture_weight=2
 --pci-segment pci_segment=1,mmio32_aperture_weight=1
 ```
+
+## Snapshot and Restore of VFIO Devices
+
+Cloud Hypervisor supports snapshotting and restoring VFIO devices that advertise
+the kernel VFIO migration v2 protocol. This covers same host snapshot to disk
+and restore from disk. Cross host live migration of VFIO devices is a separate
+effort not covered by this section.
+
+### Requirements
+
+- **Kernel.** Linux 5.18 or newer for the migration v2 ioctls. 6.0 or newer is
+  recommended for the broadest set of state transitions.
+- **Driver.** The device must be bound to a VFIO variant driver that implements
+  migration v2, for example `mlx5_vfio_pci` on Mellanox NICs. The generic
+  `vfio_pci` driver does not implement migration and is treated as non
+  migratable.
+
+### Behavior
+
+At device creation time, Cloud Hypervisor probes the VFIO device for migration
+support via `VFIO_DEVICE_FEATURE_MIGRATION`. The device is classified into one
+of two modes for the lifetime of the guest.
+
+- **Migratable.** The device supports migration v2 with at least STOP_COPY.
+  Cloud Hypervisor drives the full state machine on snapshot and restore.
+  Pausing the guest transitions the device to STOP, snapshot walks
+  STOP_COPY, captures the opaque device state, and returns the device to
+  STOP. On restore, the saved device blob is written through RESUMING in
+  a single transition; the kernel handles the intermediate STOP arc
+  internally. After the blob loads, Cloud Hypervisor pushes the saved
+  PCI_COMMAND to the device and rearms MSI or MSI-X eventfds, because
+  the kernel's view of those is not restored by in memory state replay
+  alone. The device is left in RESUMING and `resume()` drives it to
+  RUNNING when the guest is resumed. This matches QEMU's
+  `vfio_pci_load_config()` behavior.
+- **Non migratable.** The device does not advertise migration v2. Snapshot
+  and restore still work, but the device state that is internal to the
+  hardware is not preserved. Only Cloud Hypervisor side state such as PCI
+  configuration and interrupt routing is captured. This matches the
+  pre existing behavior.
+
+The classification is logged at device init, for example:
+
+```
+INFO  vfio: VFIO device 0000:01:00.0 supports migration v2 (flags=0x7, ...)
+```
+
+Non migratable devices log at debug level.
+
+### Limitations
+
+The current snapshot format stores the blob as base64 inside the snapshot
+JSON. Very large blobs may benefit from a binary transport path in the
+future.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "acpi_tables"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad581b2b0fa02638f3df6ff3f852ebc30dc7cfe531e9745d1ca4c0f283a6dbe"
+checksum = "ce821f856a3eb1d033287f2dcfcdf94276d7895dd5bdd8ca45ae17e7d33d4dd9"
 dependencies = [
  "zerocopy",
 ]
@@ -112,6 +112,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitfield-struct"
@@ -777,7 +783,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 [[package]]
 name = "micro_http"
 version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/micro-http?branch=main#5c2254d6cf4f32a668d0d8e57ba20bebad9d4fba"
+source = "git+https://github.com/firecracker-microvm/micro-http?branch=main#876f3feccc30e09225f2c77bf95a6b2d46a9259e"
 dependencies = [
  "libc",
  "vmm-sys-util",
@@ -906,13 +912,14 @@ name = "pci"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "byteorder",
  "hypervisor",
  "libc",
  "log",
  "serde",
  "thiserror",
- "vfio-bindings",
+ "vfio-bindings 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vfio-ioctls",
  "vfio_user",
  "vm-allocator",
@@ -1287,10 +1294,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "vfio-bindings"
+version = "0.6.2"
+source = "git+https://github.com/saravan2/vfio.git?branch=vfio-ioctls#68097e9d4a8841c29d2652d667fdb71c785197dd"
+
+[[package]]
 name = "vfio-ioctls"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b1d98dff7f0d219278e406323e7eda4d426447bd203c7828189baf0d8c07b7"
+source = "git+https://github.com/saravan2/vfio.git?branch=vfio-ioctls#68097e9d4a8841c29d2652d667fdb71c785197dd"
 dependencies = [
  "byteorder",
  "iommufd-bindings",
@@ -1300,7 +1311,7 @@ dependencies = [
  "libc",
  "log",
  "thiserror",
- "vfio-bindings",
+ "vfio-bindings 0.6.2 (git+https://github.com/saravan2/vfio.git?branch=vfio-ioctls)",
  "vm-memory",
  "vmm-sys-util",
 ]
@@ -1318,7 +1329,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "thiserror",
- "vfio-bindings",
+ "vfio-bindings 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory",
  "vmm-sys-util",
 ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -41,6 +41,9 @@ vmm-sys-util = "0.15.0"
 [workspace]
 members = ["."]
 
+[patch.crates-io]
+vfio-ioctls = { git = "https://github.com/saravan2/vfio.git", branch = "vfio-ioctls" }
+
 [[bin]]
 doc = false
 name = "balloon"

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -12,6 +12,7 @@ mshv = ["hypervisor/mshv", "vfio-ioctls/mshv"]
 
 [dependencies]
 anyhow = { workspace = true }
+base64 = { workspace = true }
 byteorder = { workspace = true }
 hypervisor = { path = "../hypervisor" }
 libc = { workspace = true }

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -88,6 +88,8 @@ pub enum VfioPciError {
     RetrievePciConfigurationState(#[source] anyhow::Error),
     #[error("Failed to retrieve VfioCommonState")]
     RetrieveVfioCommonState(#[source] anyhow::Error),
+    #[error("Failed to restore VFIO migration state")]
+    RestoreMigration(#[source] anyhow::Error),
 }
 
 #[derive(Copy, Clone)]
@@ -495,6 +497,10 @@ pub(crate) trait Vfio: Send + Sync {
     fn read_migration_data_to_end(&self) -> Result<Vec<u8>, VfioError> {
         Err(VfioError::NoMigrationSupport)
     }
+
+    fn write_migration_data(&self, _data: &[u8]) -> Result<(), VfioError> {
+        Err(VfioError::NoMigrationSupport)
+    }
 }
 
 struct VfioDeviceWrapper {
@@ -553,6 +559,12 @@ impl Vfio for VfioDeviceWrapper {
     fn read_migration_data_to_end(&self) -> Result<Vec<u8>, VfioError> {
         self.device
             .read_migration_data_to_end()
+            .map_err(VfioError::KernelVfio)
+    }
+
+    fn write_migration_data(&self, data: &[u8]) -> Result<(), VfioError> {
+        self.device
+            .write_migration_data(data)
             .map_err(VfioError::KernelVfio)
     }
 }
@@ -684,6 +696,48 @@ impl VfioCommon {
 
         if let Some(state) = state.as_ref() {
             vfio_common.set_state(state, msi_state, msix_state)?;
+
+            if vfio_common.migration_flags.is_some() {
+                let mig: Option<VfioMigrationData> =
+                    vm_migration::state_from_id(snapshot, VFIO_MIGRATION_ID).map_err(|e| {
+                        VfioPciError::RestoreMigration(anyhow!(
+                            "Failed to get VfioMigrationData from Snapshot: {e}"
+                        ))
+                    })?;
+
+                if let Some(mig) = mig {
+                    let blob = BASE64_STANDARD.decode(mig.blob.as_bytes()).map_err(|e| {
+                        VfioPciError::RestoreMigration(anyhow!(
+                            "Failed to base64-decode migration blob: {e}"
+                        ))
+                    })?;
+                    vfio_common
+                        .load_migration_data(&blob)
+                        .map_err(|e| VfioPciError::RestoreMigration(anyhow!("{e}")))?;
+                }
+            }
+
+            // Push PCI_COMMAND to the device as set_state() does not.
+            let cmd = (vfio_common
+                .configuration
+                .read_reg(crate::configuration::COMMAND_REG)
+                & 0xFFFF) as u16;
+            vfio_common.vfio_wrapper.write_config(
+                (crate::configuration::COMMAND_REG * PCI_CONFIG_REGISTER_SIZE) as u32,
+                &cmd.to_le_bytes(),
+            );
+
+            // Rearm VFIO_DEVICE_SET_IRQS as set_state() only restores
+            // in-memory MSI/MSI-X state, not the kernel eventfds.
+            if let Some(msi) = &vfio_common.interrupt.msi
+                && msi.cfg.enabled()
+            {
+                vfio_common.enable_msi()?;
+            } else if let Some(msix) = &vfio_common.interrupt.msix
+                && msix.bar.enabled()
+            {
+                vfio_common.enable_msix()?;
+            }
         } else {
             vfio_common.parse_capabilities(bdf);
             vfio_common.initialize_legacy_interrupt()?;
@@ -897,14 +951,19 @@ impl VfioCommon {
                 .set_region_type(region_type)
                 .set_prefetchable(prefetchable);
 
-            if bar_id == VFIO_PCI_ROM_REGION_INDEX {
-                self.configuration
-                    .add_pci_rom_bar(&bar, flags & 0x1)
-                    .map_err(|e| PciDeviceError::IoRegistrationFailed(bar_addr.raw_value(), e))?;
-            } else {
-                self.configuration
-                    .add_pci_bar(&bar)
-                    .map_err(|e| PciDeviceError::IoRegistrationFailed(bar_addr.raw_value(), e))?;
+            // Skip on restore as BARs come from the saved PciConfiguration state.
+            if resources.is_none() {
+                if bar_id == VFIO_PCI_ROM_REGION_INDEX {
+                    self.configuration
+                        .add_pci_rom_bar(&bar, flags & 0x1)
+                        .map_err(|e| {
+                            PciDeviceError::IoRegistrationFailed(bar_addr.raw_value(), e)
+                        })?;
+                } else {
+                    self.configuration.add_pci_bar(&bar).map_err(|e| {
+                        PciDeviceError::IoRegistrationFailed(bar_addr.raw_value(), e)
+                    })?;
+                }
             }
 
             bars.push(bar);
@@ -1586,6 +1645,24 @@ impl VfioCommon {
             self.transition_migration_state(VfioMigrationState::Stop)
                 .map_err(MigratableError::Snapshot)?;
             Ok(data)
+        })();
+
+        if result.is_err() {
+            let _ = self.transition_migration_state(VfioMigrationState::Stop);
+        }
+        result
+    }
+
+    pub(crate) fn load_migration_data(&self, data: &[u8]) -> Result<(), MigratableError> {
+        // Leave the device in RESUMING and resume() drives it back to RUNNING.
+        let result = (|| -> Result<(), MigratableError> {
+            self.transition_migration_state(VfioMigrationState::Resuming)
+                .map_err(MigratableError::Restore)?;
+
+            self.vfio_wrapper.write_migration_data(data).map_err(|e| {
+                MigratableError::Restore(anyhow!("VFIO migration data write failed: {e}"))
+            })?;
+            Ok(())
         })();
 
         if result.is_err() {

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -2439,3 +2439,237 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioDmaMapping<M
             })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    // Trait default behavior and state enum round trip.
+
+    #[test]
+    fn vfio_migration_state_round_trips() {
+        for state in [
+            VfioMigrationState::Error,
+            VfioMigrationState::Stop,
+            VfioMigrationState::Running,
+            VfioMigrationState::StopCopy,
+            VfioMigrationState::Resuming,
+            VfioMigrationState::RunningP2P,
+            VfioMigrationState::PreCopy,
+            VfioMigrationState::PreCopyP2P,
+        ] {
+            let raw = state as u32;
+            assert_eq!(VfioMigrationState::try_from(raw).unwrap(), state);
+        }
+    }
+
+    #[test]
+    fn vfio_migration_state_invalid_errors() {
+        match VfioMigrationState::try_from(999_u32) {
+            Err(VfioError::InvalidMigrationState(999)) => {}
+            other => panic!("expected InvalidMigrationState(999), got {other:?}"),
+        }
+    }
+
+    struct DefaultVfio;
+    impl Vfio for DefaultVfio {}
+
+    #[test]
+    fn default_query_migration_support_returns_none() {
+        assert!(matches!(DefaultVfio.query_migration_support(), Ok(None)));
+    }
+
+    #[test]
+    fn default_set_migration_state_errors() {
+        assert!(matches!(
+            DefaultVfio.set_migration_state(VfioMigrationState::Stop),
+            Err(VfioError::NoMigrationSupport)
+        ));
+    }
+
+    // Save and load state machine flows, driven through a mock Vfio wrapper
+    // that records state transitions and stores the migration data in memory.
+
+    #[derive(Default)]
+    struct MockVfioState {
+        transitions: Vec<VfioMigrationState>,
+        save_blob: Vec<u8>,
+        loaded: Vec<u8>,
+        fail_at: Option<VfioMigrationState>,
+    }
+
+    struct MockVfio {
+        state: Mutex<MockVfioState>,
+    }
+
+    impl MockVfio {
+        fn for_save(blob: Vec<u8>) -> Arc<Self> {
+            Arc::new(Self {
+                state: Mutex::new(MockVfioState {
+                    save_blob: blob,
+                    ..Default::default()
+                }),
+            })
+        }
+
+        fn for_load() -> Arc<Self> {
+            Arc::new(Self {
+                state: Mutex::new(MockVfioState::default()),
+            })
+        }
+
+        fn failing_at(target: VfioMigrationState) -> Arc<Self> {
+            Arc::new(Self {
+                state: Mutex::new(MockVfioState {
+                    fail_at: Some(target),
+                    ..Default::default()
+                }),
+            })
+        }
+
+        fn transitions(&self) -> Vec<VfioMigrationState> {
+            self.state.lock().unwrap().transitions.clone()
+        }
+
+        fn loaded(&self) -> Vec<u8> {
+            self.state.lock().unwrap().loaded.clone()
+        }
+    }
+
+    impl Vfio for MockVfio {
+        fn set_migration_state(&self, state: VfioMigrationState) -> Result<(), VfioError> {
+            let mut s = self.state.lock().unwrap();
+            s.transitions.push(state);
+            if s.fail_at == Some(state) {
+                return Err(VfioError::NoMigrationSupport);
+            }
+            Ok(())
+        }
+
+        fn read_migration_data_to_end(&self) -> Result<Vec<u8>, VfioError> {
+            Ok(self.state.lock().unwrap().save_blob.clone())
+        }
+
+        fn write_migration_data(&self, data: &[u8]) -> Result<(), VfioError> {
+            self.state.lock().unwrap().loaded.extend_from_slice(data);
+            Ok(())
+        }
+
+        fn region_write(&self, _index: u32, _offset: u64, _data: &[u8]) {}
+    }
+
+    struct MockMsiInterruptManager;
+    impl InterruptManager for MockMsiInterruptManager {
+        type GroupConfig = MsiIrqGroupConfig;
+        fn create_group(
+            &self,
+            _: MsiIrqGroupConfig,
+        ) -> std::io::Result<Arc<dyn InterruptSourceGroup>> {
+            unimplemented!("not exercised by the migration-helper tests")
+        }
+        fn destroy_group(&self, _: Arc<dyn InterruptSourceGroup>) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn test_vfio_common(vfio_wrapper: Arc<dyn Vfio>, migration_flags: Option<u64>) -> VfioCommon {
+        let configuration = PciConfiguration::new(
+            0,
+            0,
+            0,
+            PciClassCode::Other,
+            &PciVfioSubclass::VfioSubclass,
+            None,
+            PciHeaderType::Device,
+            0,
+            0,
+            None,
+            None,
+        );
+        VfioCommon {
+            configuration,
+            mmio_regions: Vec::new(),
+            interrupt: Interrupt {
+                intx: None,
+                msi: None,
+                msix: None,
+            },
+            msi_interrupt_manager: Arc::new(MockMsiInterruptManager),
+            legacy_interrupt_group: None,
+            vfio_wrapper,
+            patches: HashMap::new(),
+            x_nv_gpudirect_clique: None,
+            x_exclude_mmap_bars: Vec::new(),
+            migration_flags,
+        }
+    }
+
+    #[test]
+    fn save_migration_data_happy_path() {
+        let blob = b"hello migration".to_vec();
+        let mock = MockVfio::for_save(blob.clone());
+        let common = test_vfio_common(mock.clone(), Some(1));
+        let got = common.save_migration_data().unwrap();
+        assert_eq!(got, blob);
+        assert_eq!(
+            mock.transitions(),
+            vec![VfioMigrationState::StopCopy, VfioMigrationState::Stop]
+        );
+    }
+
+    #[test]
+    fn save_migration_data_recovers_on_failure() {
+        let mock = MockVfio::failing_at(VfioMigrationState::StopCopy);
+        let common = test_vfio_common(mock.clone(), Some(1));
+        let err = common.save_migration_data().unwrap_err();
+        assert!(matches!(err, MigratableError::Snapshot(_)));
+        assert_eq!(
+            mock.transitions(),
+            vec![VfioMigrationState::StopCopy, VfioMigrationState::Stop]
+        );
+    }
+
+    #[test]
+    fn load_migration_data_happy_path() {
+        let blob = b"restore me".to_vec();
+        let mock = MockVfio::for_load();
+        let common = test_vfio_common(mock.clone(), Some(1));
+        common.load_migration_data(&blob).unwrap();
+        assert_eq!(mock.loaded(), blob);
+        // Device is left in RESUMING so resume() can drive it to RUNNING.
+        assert_eq!(mock.transitions(), vec![VfioMigrationState::Resuming]);
+    }
+
+    #[test]
+    fn load_migration_data_recovers_on_failure() {
+        let mock = MockVfio::failing_at(VfioMigrationState::Resuming);
+        let common = test_vfio_common(mock.clone(), Some(1));
+        let err = common.load_migration_data(b"ignored").unwrap_err();
+        assert!(matches!(err, MigratableError::Restore(_)));
+        assert_eq!(
+            mock.transitions(),
+            vec![VfioMigrationState::Resuming, VfioMigrationState::Stop]
+        );
+    }
+
+    // A guest write to a non BAR, non MSI config register must mirror into
+    // the PciConfiguration shadow so a later snapshot() picks up the live
+    // value.
+    #[test]
+    fn write_config_register_mirrors_non_bar_into_shadow() {
+        let mock = MockVfio::for_load();
+        let mut common = test_vfio_common(mock, Some(1));
+
+        // PCI_COMMAND is reg index 1. Write the 16 bit command word only.
+        let cmd: u16 = 0x0406;
+        common.write_config_register(crate::configuration::COMMAND_REG, 0, &cmd.to_le_bytes());
+
+        let got = common
+            .configuration
+            .read_reg(crate::configuration::COMMAND_REG)
+            & 0xFFFF;
+        assert_eq!(got as u16, cmd);
+    }
+}

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -15,7 +15,7 @@ use anyhow::anyhow;
 use byteorder::{ByteOrder, LittleEndian};
 use hypervisor::HypervisorVmError;
 use libc::{_SC_PAGESIZE, sysconf};
-use log::{error, info};
+use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vfio_bindings::bindings::vfio::*;
@@ -436,6 +436,10 @@ pub(crate) trait Vfio: Send + Sync {
     fn unmask_irq(&self, _irq_index: u32) -> Result<(), VfioError> {
         unimplemented!()
     }
+
+    fn query_migration_support(&self) -> Result<Option<u64>, VfioError> {
+        Ok(None)
+    }
 }
 
 struct VfioDeviceWrapper {
@@ -478,6 +482,12 @@ impl Vfio for VfioDeviceWrapper {
             .unmask_irq(irq_index)
             .map_err(VfioError::KernelVfio)
     }
+
+    fn query_migration_support(&self) -> Result<Option<u64>, VfioError> {
+        self.device
+            .query_migration_support()
+            .map_err(VfioError::KernelVfio)
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -502,6 +512,8 @@ pub(crate) struct VfioCommon {
     pub(crate) patches: HashMap<usize, ConfigPatch>,
     x_nv_gpudirect_clique: Option<u8>,
     x_exclude_mmap_bars: Vec<u8>,
+    #[allow(dead_code)]
+    pub(crate) migration_flags: Option<u64>,
 }
 
 #[derive(Default)]
@@ -541,6 +553,27 @@ impl VfioCommon {
             pci_configuration_state,
         );
 
+        let migration_flags = match vfio_wrapper.query_migration_support() {
+            Ok(Some(flags)) => {
+                info!(
+                    "VFIO device {bdf} supports migration v2 (flags=0x{flags:x}, \
+                     STOP_COPY={}, P2P={}, PRE_COPY={})",
+                    flags & VFIO_MIGRATION_STOP_COPY as u64 != 0,
+                    flags & VFIO_MIGRATION_P2P as u64 != 0,
+                    flags & VFIO_MIGRATION_PRE_COPY as u64 != 0,
+                );
+                Some(flags)
+            }
+            Ok(None) => {
+                debug!("VFIO device {bdf} does not support migration v2");
+                None
+            }
+            Err(e) => {
+                warn!("VFIO device {bdf} migration probe failed, treating as non-migratable: {e}");
+                None
+            }
+        };
+
         let mut vfio_common = VfioCommon {
             mmio_regions: Vec::new(),
             configuration,
@@ -555,6 +588,7 @@ impl VfioCommon {
             patches: HashMap::new(),
             x_nv_gpudirect_clique: config.x_nv_gpudirect_clique,
             x_exclude_mmap_bars: config.x_exclude_mmap_bars,
+            migration_flags,
         };
 
         let state: Option<VfioCommonState> = snapshot

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -12,13 +12,24 @@ use std::path::PathBuf;
 use std::sync::{Arc, Barrier, Mutex};
 
 use anyhow::anyhow;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use byteorder::{ByteOrder, LittleEndian};
 use hypervisor::HypervisorVmError;
 use libc::{_SC_PAGESIZE, sysconf};
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use vfio_bindings::bindings::vfio::*;
+use vfio_bindings::bindings::vfio::{
+    vfio_device_mig_state_VFIO_DEVICE_STATE_ERROR as VFIO_DEV_STATE_ERROR,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_PRE_COPY as VFIO_DEV_STATE_PRE_COPY,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_PRE_COPY_P2P as VFIO_DEV_STATE_PRE_COPY_P2P,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_RESUMING as VFIO_DEV_STATE_RESUMING,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_RUNNING as VFIO_DEV_STATE_RUNNING,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_RUNNING_P2P as VFIO_DEV_STATE_RUNNING_P2P,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_STOP as VFIO_DEV_STATE_STOP,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_STOP_COPY as VFIO_DEV_STATE_STOP_COPY, *,
+};
 use vfio_ioctls::{VfioDevice, VfioIrq, VfioOps, VfioRegionInfoCap, VfioRegionSparseMmapArea};
 use vm_allocator::page_size::{
     align_page_size_down, align_page_size_up, get_page_size, is_4k_aligned, is_4k_multiple,
@@ -45,6 +56,7 @@ use crate::{
 };
 
 pub(crate) const VFIO_COMMON_ID: &str = "vfio_common";
+pub(crate) const VFIO_MIGRATION_ID: &str = "vfio_migration";
 
 #[derive(Debug, Error)]
 pub enum VfioPciError {
@@ -363,6 +375,41 @@ pub enum VfioError {
     KernelVfio(#[source] vfio_ioctls::VfioError),
     #[error("VFIO user error")]
     VfioUser(#[source] vfio_user::Error),
+    #[error("VFIO device does not support migration")]
+    NoMigrationSupport,
+    #[error("VFIO device reported unknown migration state {0}")]
+    InvalidMigrationState(u32),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub(crate) enum VfioMigrationState {
+    Error = VFIO_DEV_STATE_ERROR,
+    Stop = VFIO_DEV_STATE_STOP,
+    Running = VFIO_DEV_STATE_RUNNING,
+    StopCopy = VFIO_DEV_STATE_STOP_COPY,
+    Resuming = VFIO_DEV_STATE_RESUMING,
+    RunningP2P = VFIO_DEV_STATE_RUNNING_P2P,
+    PreCopy = VFIO_DEV_STATE_PRE_COPY,
+    PreCopyP2P = VFIO_DEV_STATE_PRE_COPY_P2P,
+}
+
+impl TryFrom<u32> for VfioMigrationState {
+    type Error = VfioError;
+
+    fn try_from(value: u32) -> Result<Self, VfioError> {
+        match value {
+            VFIO_DEV_STATE_ERROR => Ok(Self::Error),
+            VFIO_DEV_STATE_STOP => Ok(Self::Stop),
+            VFIO_DEV_STATE_RUNNING => Ok(Self::Running),
+            VFIO_DEV_STATE_STOP_COPY => Ok(Self::StopCopy),
+            VFIO_DEV_STATE_RESUMING => Ok(Self::Resuming),
+            VFIO_DEV_STATE_RUNNING_P2P => Ok(Self::RunningP2P),
+            VFIO_DEV_STATE_PRE_COPY => Ok(Self::PreCopy),
+            VFIO_DEV_STATE_PRE_COPY_P2P => Ok(Self::PreCopyP2P),
+            other => Err(VfioError::InvalidMigrationState(other)),
+        }
+    }
 }
 
 pub(crate) trait Vfio: Send + Sync {
@@ -440,6 +487,14 @@ pub(crate) trait Vfio: Send + Sync {
     fn query_migration_support(&self) -> Result<Option<u64>, VfioError> {
         Ok(None)
     }
+
+    fn set_migration_state(&self, _state: VfioMigrationState) -> Result<(), VfioError> {
+        Err(VfioError::NoMigrationSupport)
+    }
+
+    fn read_migration_data_to_end(&self) -> Result<Vec<u8>, VfioError> {
+        Err(VfioError::NoMigrationSupport)
+    }
 }
 
 struct VfioDeviceWrapper {
@@ -488,6 +543,18 @@ impl Vfio for VfioDeviceWrapper {
             .query_migration_support()
             .map_err(VfioError::KernelVfio)
     }
+
+    fn set_migration_state(&self, state: VfioMigrationState) -> Result<(), VfioError> {
+        self.device
+            .set_migration_state(state as u32)
+            .map_err(VfioError::KernelVfio)
+    }
+
+    fn read_migration_data_to_end(&self) -> Result<Vec<u8>, VfioError> {
+        self.device
+            .read_migration_data_to_end()
+            .map_err(VfioError::KernelVfio)
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -495,6 +562,11 @@ struct VfioCommonState {
     intx_state: Option<IntxState>,
     msi_state: Option<MsiState>,
     msix_state: Option<MsixState>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct VfioMigrationData {
+    blob: String,
 }
 
 pub(crate) struct ConfigPatch {
@@ -512,7 +584,6 @@ pub(crate) struct VfioCommon {
     pub(crate) patches: HashMap<usize, ConfigPatch>,
     x_nv_gpudirect_clique: Option<u8>,
     x_exclude_mmap_bars: Vec<u8>,
-    #[allow(dead_code)]
     pub(crate) migration_flags: Option<u64>,
 }
 
@@ -1363,6 +1434,20 @@ impl VfioCommon {
         // to the device region to update the MSI Enable bit.
         self.vfio_wrapper.write_config((reg + offset) as u32, data);
 
+        // Mirror into the shadow so snapshot() captures PCI_COMMAND.
+        // Avoid write_config_register as it drains pending_bar_reprogram.
+        let byte_offset = reg_idx * PCI_CONFIG_REGISTER_SIZE + offset as usize;
+        match data.len() {
+            1 => self.configuration.write_byte(byte_offset, data[0]),
+            2 => self
+                .configuration
+                .write_word(byte_offset, u16::from(data[0]) | (u16::from(data[1]) << 8)),
+            4 => self
+                .configuration
+                .write_reg(reg_idx, LittleEndian::read_u32(data)),
+            _ => {}
+        }
+
         // Return pending BAR repgrogramming if MSE bit is set
         let mut ret_param = self.configuration.pending_bar_reprogram();
         if !ret_param.is_empty() {
@@ -1475,6 +1560,39 @@ impl VfioCommon {
 
         Ok(())
     }
+
+    pub(crate) fn transition_migration_state(
+        &self,
+        target: VfioMigrationState,
+    ) -> anyhow::Result<()> {
+        debug!("VFIO migration transition -> {target:?}");
+        self.vfio_wrapper
+            .set_migration_state(target)
+            .map_err(|e| anyhow!("VFIO set_migration_state({target:?}) failed: {e}"))
+    }
+
+    pub(crate) fn save_migration_data(&self) -> Result<Vec<u8>, MigratableError> {
+        let result = (|| -> Result<Vec<u8>, MigratableError> {
+            self.transition_migration_state(VfioMigrationState::StopCopy)
+                .map_err(MigratableError::Snapshot)?;
+
+            let data = self
+                .vfio_wrapper
+                .read_migration_data_to_end()
+                .map_err(|e| {
+                    MigratableError::Snapshot(anyhow!("VFIO migration data read failed: {e}"))
+                })?;
+
+            self.transition_migration_state(VfioMigrationState::Stop)
+                .map_err(MigratableError::Snapshot)?;
+            Ok(data)
+        })();
+
+        if result.is_err() {
+            let _ = self.transition_migration_state(VfioMigrationState::Stop);
+        }
+        result
+    }
 }
 
 impl Pausable for VfioCommon {}
@@ -1498,6 +1616,17 @@ impl Snapshottable for VfioCommon {
         // Snapshot MSI-X
         if let Some(msix) = &mut self.interrupt.msix {
             vfio_common_snapshot.add_snapshot(msix.bar.id(), msix.bar.snapshot()?);
+        }
+
+        if self.migration_flags.is_some() {
+            let data = self.save_migration_data()?;
+            let mig = VfioMigrationData {
+                blob: BASE64_STANDARD.encode(&data),
+            };
+            vfio_common_snapshot.add_snapshot(
+                VFIO_MIGRATION_ID.to_string(),
+                Snapshot::new_from_state(&mig)?,
+            );
         }
 
         Ok(vfio_common_snapshot)
@@ -2108,7 +2237,25 @@ iova 0x{:x}, size 0x{:x}: {}, ",
     }
 }
 
-impl Pausable for VfioPciDevice {}
+impl Pausable for VfioPciDevice {
+    fn pause(&mut self) -> std::result::Result<(), MigratableError> {
+        if self.common.migration_flags.is_some() {
+            self.common
+                .transition_migration_state(VfioMigrationState::Stop)
+                .map_err(MigratableError::Pause)?;
+        }
+        Ok(())
+    }
+
+    fn resume(&mut self) -> std::result::Result<(), MigratableError> {
+        if self.common.migration_flags.is_some() {
+            self.common
+                .transition_migration_state(VfioMigrationState::Running)
+                .map_err(MigratableError::Resume)?;
+        }
+        Ok(())
+    }
+}
 
 impl Snapshottable for VfioPciDevice {
     fn id(&self) -> String {


### PR DESCRIPTION
## Summary

 Adds VFIO v2 migration protocol support for same host snapshot and restore of migratable VFIO devices, for example ConnectX VFs bound to `mlx5_vfio_pci`. Non migratable devices retain their existing snapshot behavior. Live migration with VFIO Devices, DMA dirty page tracking, and precopy iteration are follow up work and are not in this PR.
 
 ### VFIO Migration v2 State Transitions

  | Phase | Action | Device State Transition |
  |---|---|---|
  | Save | `pause()` | RUNNING → STOP |
  | Save | `snapshot()` requests data | STOP → STOP_COPY |
  | Save | `snapshot()` drains `data_fd` (device blob) | no transition |
  | Save | `snapshot()` finalizes | STOP_COPY → STOP |
  | Restore | `load_migration_data()` requests `data_fd` | RUNNING → RESUMING (*) |
  | Restore | `load_migration_data()` writes device blob | no transition |
  | Restore | post load fixups (PCI_COMMAND, rearm MSI or MSI-X) | no transition |
  | Resume | `resume()` after save (optional) | STOP → RUNNING |
  | Resume | `resume()` after restore (mandatory) | RESUMING → RUNNING (*) |

(*) Each arrow (→) is one `VFIO_DEVICE_FEATURE_SET_MIG_DEVICE_STATE` ioctl.
Non adjacent transitions such as `RUNNING → RESUMING, RESUMING → RUNNING` has to pass through `STOP` as per the protocol, and the host kernel walks that intermediate `STOP` state internally via the variant driver (`mlx5_vfio_pci`), therefore in this implementation Cloud-Hypervisor avoids enforcing `STOP` in the restore, resume phases. Referred QEMU's VFIO Migration ioctl sequence for this PR.

 ## Dependency

Blocked on `rust-vmm/vfio` [PR #140](https://github.com/rust-vmm/vfio/pull/140) landing and a new `vfio-ioctls`  crates.io release. The first commit routes the dependency through a fork of `rust-vmm/vfio` in the interim period and will be reverted once `rust-vmm/vfio` [PR #140](https://github.com/rust-vmm/vfio/pull/140) gets merged.

## Test
* cargo test -p pci --lib vfio::tests
* Snapshot and Restore validated on a Mellanox ConnectX 7 VF (`mlx5_vfio_pci`, firmware 28.43.1014)



