### PR TITLE
vmm: add PCIe root port topology for VFIO passthrough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,6 +2471,7 @@ name = "vm-device"
 version = "0.1.0"
 dependencies = [
  "hypervisor",
+ "log",
  "serde",
  "thiserror",
  "vfio-ioctls",

--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -88,8 +88,9 @@ pub const MEM_32BIT_DEVICES_SIZE: u64 = 0x2000_0000;
 /// PCI MMCONFIG space (start: after the device space at 1 GiB, length: 256MiB)
 pub const PCI_MMCONFIG_START: GuestAddress = GuestAddress(0x3000_0000);
 pub const PCI_MMCONFIG_SIZE: u64 = 256 << 20;
-// One bus with potentially 256 devices (32 slots x 8 functions).
-pub const PCI_MMIO_CONFIG_SIZE_PER_SEGMENT: u64 = 4096 * 256;
+pub const PCI_BUSES_PER_SEGMENT: u64 = 32;
+// One segment exposes bus 0 plus a secondary bus for each hotplug root port.
+pub const PCI_MMIO_CONFIG_SIZE_PER_SEGMENT: u64 = 4096 * 256 * PCI_BUSES_PER_SEGMENT;
 
 /// Start of RAM.
 pub const RAM_START: GuestAddress = GuestAddress(0x4000_0000);

--- a/arch/src/riscv64/layout.rs
+++ b/arch/src/riscv64/layout.rs
@@ -84,8 +84,9 @@ pub const MEM_32BIT_DEVICES_SIZE: u64 = 0x2000_0000;
 /// PCI MMCONFIG space (start: after the device space at 768MiB, length: 256MiB)
 pub const PCI_MMCONFIG_START: GuestAddress = GuestAddress(0x3000_0000);
 pub const PCI_MMCONFIG_SIZE: u64 = 256 << 20;
-// One bus with potentially 256 devices (32 slots x 8 functions).
-pub const PCI_MMIO_CONFIG_SIZE_PER_SEGMENT: u64 = 4096 * 256;
+pub const PCI_BUSES_PER_SEGMENT: u64 = 32;
+// One segment exposes bus 0 plus a secondary bus for each hotplug root port.
+pub const PCI_MMIO_CONFIG_SIZE_PER_SEGMENT: u64 = 4096 * 256 * PCI_BUSES_PER_SEGMENT;
 
 /// Start of RAM.
 pub const RAM_START: GuestAddress = GuestAddress(0x4000_0000);

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -96,8 +96,9 @@ pub const MEM_32BIT_DEVICES_SIZE: u64 = 640 << 20;
 pub const PCI_MMCONFIG_START: GuestAddress =
     GuestAddress(MEM_32BIT_DEVICES_START.0 + MEM_32BIT_DEVICES_SIZE);
 pub const PCI_MMCONFIG_SIZE: u64 = 256 << 20;
-// One bus with potentially 256 devices (32 slots x 8 functions).
-pub const PCI_MMIO_CONFIG_SIZE_PER_SEGMENT: u64 = 4096 * 256;
+pub const PCI_BUSES_PER_SEGMENT: u64 = 32;
+// One segment exposes bus 0 plus a secondary bus for each hotplug root port.
+pub const PCI_MMIO_CONFIG_SIZE_PER_SEGMENT: u64 = 4096 * 256 * PCI_BUSES_PER_SEGMENT;
 
 // TSS is 3 pages after the PCI MMCONFIG space
 pub const KVM_TSS_START: GuestAddress = GuestAddress(PCI_MMCONFIG_START.0 + PCI_MMCONFIG_SIZE);

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -8803,7 +8803,76 @@ mod windows {
 #[cfg(target_arch = "x86_64")]
 mod vfio {
     use crate::*;
+
     const NVIDIA_VFIO_DEVICE: &str = "/sys/bus/pci/devices/0002:00:01.0";
+    const IORESOURCE_MEM: u64 = 0x0000_0200;
+
+    fn nvidia_vfio_device_ready() -> bool {
+        if !std::path::Path::new(NVIDIA_VFIO_DEVICE).exists() {
+            println!("SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} not found");
+            return false;
+        }
+
+        let driver_path = format!("{NVIDIA_VFIO_DEVICE}/driver");
+        if let Ok(driver) = std::fs::read_link(&driver_path) {
+            let driver_name = driver.file_name().unwrap_or_default().to_string_lossy();
+            if driver_name != "vfio-pci" {
+                println!(
+                    "SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} bound to {driver_name}, not vfio-pci"
+                );
+                return false;
+            }
+        } else {
+            println!("SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} not bound to any driver");
+            return false;
+        }
+
+        true
+    }
+
+    fn first_nvidia_memory_bar() -> Option<u8> {
+        let resource_path = format!("{NVIDIA_VFIO_DEVICE}/resource");
+        let resource = match std::fs::read_to_string(&resource_path) {
+            Ok(resource) => resource,
+            Err(e) => {
+                println!("SKIPPED: failed to read {resource_path}: {e}");
+                return None;
+            }
+        };
+
+        for (index, line) in resource.lines().take(6).enumerate() {
+            let mut fields = line.split_whitespace();
+            let Some(start) = fields.next() else {
+                continue;
+            };
+            let Some(end) = fields.next() else {
+                continue;
+            };
+            let Some(flags) = fields.next() else {
+                continue;
+            };
+
+            let parse_hex = |value: &str| u64::from_str_radix(value.trim_start_matches("0x"), 16);
+            let Ok(start) = parse_hex(start) else {
+                continue;
+            };
+            let Ok(end) = parse_hex(end) else {
+                continue;
+            };
+            let Ok(flags) = parse_hex(flags) else {
+                continue;
+            };
+
+            if flags & IORESOURCE_MEM == 0 || end < start || (start == 0 && end == 0) {
+                continue;
+            }
+
+            return Some(index as u8);
+        }
+
+        println!("SKIPPED: no non-empty memory BAR found for {NVIDIA_VFIO_DEVICE}");
+        None
+    }
 
     fn platform_cfg(iommufd: bool) -> String {
         if iommufd {
@@ -9038,25 +9107,66 @@ mod vfio {
         test_nvidia_card_iommu_address_width_common(true);
     }
 
-    fn test_nvidia_guest_numa_generic_initiator_common(iommufd: bool) {
-        // Skip test if VFIO device is not available or not ready
-        if !std::path::Path::new(NVIDIA_VFIO_DEVICE).exists() {
-            println!("SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} not found");
+    fn test_nvidia_card_x_exclude_mmap_bars_common(iommufd: bool) {
+        if !nvidia_vfio_device_ready() {
             return;
         }
 
-        // Check if device is bound to vfio-pci driver
-        let driver_path = format!("{NVIDIA_VFIO_DEVICE}/driver");
-        if let Ok(driver) = std::fs::read_link(&driver_path) {
-            let driver_name = driver.file_name().unwrap_or_default().to_string_lossy();
-            if driver_name != "vfio-pci" {
-                println!(
-                    "SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} bound to {driver_name}, not vfio-pci"
-                );
-                return;
-            }
-        } else {
-            println!("SKIPPED: VFIO device {NVIDIA_VFIO_DEVICE} not bound to any driver");
+        let Some(bar) = first_nvidia_memory_bar() else {
+            return;
+        };
+
+        let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+
+        let mut child = GuestCommand::new(&guest)
+            .args(["--cpus", "boot=4"])
+            .args(["--memory", "size=1G"])
+            .args(["--kernel", fw_path(FwType::RustHypervisorFirmware).as_str()])
+            .args(["--platform", &platform_cfg(iommufd)])
+            .args([
+                "--device",
+                format!("path={NVIDIA_VFIO_DEVICE},x_exclude_mmap_bars=[{bar}]").as_str(),
+            ])
+            .default_disks()
+            .default_net()
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = std::panic::catch_unwind(|| {
+            guest.wait_vm_boot().unwrap();
+            assert!(wait_until(Duration::from_secs(10), || guest.check_nvidia_gpu()));
+        });
+
+        let _ = child.kill();
+        let output = child.wait_with_output().unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            stderr.contains("Skipping VFIO BAR mmap"),
+            "Expected x_exclude_mmap_bars log in stderr: {stderr}"
+        );
+        assert!(
+            stderr.contains(format!("BAR {bar}").as_str()),
+            "Expected skipped BAR index in stderr: {stderr}"
+        );
+
+        handle_child_output(r, &output);
+    }
+
+    #[test]
+    fn test_nvidia_card_x_exclude_mmap_bars() {
+        test_nvidia_card_x_exclude_mmap_bars_common(false);
+    }
+
+    #[test]
+    fn test_iommufd_nvidia_card_x_exclude_mmap_bars() {
+        test_nvidia_card_x_exclude_mmap_bars_common(true);
+    }
+
+    fn test_nvidia_guest_numa_generic_initiator_common(iommufd: bool) {
+        if !nvidia_vfio_device_ready() {
             return;
         }
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -72,6 +72,12 @@ $ cd cloud-hypervisor
 $ ./scripts/dev_cli.sh build --release
 ```
 
+On Apple Silicon hosts, use `--arch x86_64` to build the x86_64 Linux binary:
+
+```shell
+$ ./scripts/dev_cli.sh build --release --arch x86_64
+```
+
 With `dev_cli.sh`, one can also run the Cloud Hypervisor CI locally. This can be
 very convenient for debugging CI errors without having to fully rely on the
 Cloud Hypervisor CI infrastructure.

--- a/docs/vfio.md
+++ b/docs/vfio.md
@@ -159,6 +159,17 @@ nvidia-smi topo -p2p r
  GPU7	OK	OK	OK	OK	OK	OK	OK	X	
 ```
 
+Some VFIO devices expose BARs that should not be mmapped by the VMM even when
+the kernel reports them as mappable. The `x_exclude_mmap_bars` config argument can
+be used to skip mmap for specific BAR indices.
+
+BAR indices must be between 0 and 5 inclusive. The following example disables
+mmap for BAR 2 of the assigned device:
+
+```
+--device path=/sys/bus/pci/devices/0000:01:00.0/,x_exclude_mmap_bars=[2]
+```
+
 Some VFIO devices have a 32-bit mmio BAR. When using many such devices, it is
 possible to exhaust the 32-bit mmio space available on a PCI segment. The
 following example demonstrates an example device with a 16 MiB 32-bit mmio BAR.

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -123,8 +123,11 @@ enum DeviceIdState {
 
 pub struct PciBus {
     /// Devices attached to this bus.
-    /// Device 0 is host bridge.
+    /// Device 0 is host bridge (only on the root bus).
     devices: HashMap<u8, Arc<Mutex<dyn PciDevice>>>,
+    /// Secondary PCI buses behind PCI-to-PCI bridges on this bus,
+    /// keyed by secondary bus number.
+    secondary_buses: HashMap<u8, Arc<Mutex<PciBus>>>,
     device_reloc: Arc<dyn DeviceRelocation>,
     device_ids: [DeviceIdState; NUM_DEVICE_IDS as usize],
 }
@@ -139,8 +142,20 @@ impl PciBus {
 
         PciBus {
             devices,
+            secondary_buses: HashMap::new(),
             device_reloc,
             device_ids,
+        }
+    }
+
+    /// Create an empty [`PciBus`] with no root bridge. Used as the
+    /// secondary bus hanging off a PCIe root port.
+    pub fn new_empty(device_reloc: Arc<dyn DeviceRelocation>) -> Self {
+        PciBus {
+            devices: HashMap::new(),
+            secondary_buses: HashMap::new(),
+            device_reloc,
+            device_ids: [DeviceIdState::Free; NUM_DEVICE_IDS as usize],
         }
     }
 
@@ -172,6 +187,14 @@ impl PciBus {
     pub fn add_device(&mut self, device_id: u8, device: Arc<Mutex<dyn PciDevice>>) -> Result<()> {
         self.devices.insert(device_id, device);
         Ok(())
+    }
+
+    pub fn add_secondary_bus(&mut self, bus_num: u8, bus: Arc<Mutex<PciBus>>) {
+        self.secondary_buses.insert(bus_num, bus);
+    }
+
+    pub fn remove_secondary_bus(&mut self, bus_num: u8) {
+        self.secondary_buses.remove(&bus_num);
     }
 
     pub fn remove_by_device(&mut self, device: &Arc<Mutex<dyn PciDevice>>) -> Result<()> {
@@ -258,6 +281,98 @@ impl PciBus {
             Err(PciRootError::InvalidPciDeviceSlot(id as usize))
         }
     }
+
+    fn read_config_register_for_device(&self, device: usize, register: usize) -> u32 {
+        self.devices.get(&(device as u8)).map_or(0xffff_ffff, |d| {
+            d.lock().unwrap().read_config_register(register)
+        })
+    }
+
+    fn write_config_register_for_device(
+        &self,
+        device: usize,
+        register: usize,
+        offset: u64,
+        data: &[u8],
+    ) -> Option<Arc<Barrier>> {
+        let d = self.devices.get(&(device as u8))?;
+
+        let mut device = d.lock().unwrap();
+
+        let (bar_reprogram, ret) = device.write_config_register(register, offset, data);
+
+        for params in &bar_reprogram {
+            if let Err(e) = self.device_reloc.move_bar(
+                params.old_base,
+                params.new_base,
+                params.len,
+                device.deref_mut(),
+                params.region_type,
+            ) {
+                warn!(
+                    "Failed moving device BAR: {}: 0x{:x}->0x{:x}(0x{:x}), keeping old BAR",
+                    e, params.old_base, params.new_base, params.len
+                );
+                // Rollback: the config register was already updated to
+                // new_base by detect_bar_reprogramming(). Restore it by
+                // writing back the old address so device state stays
+                // consistent with the MMIO bus mapping.
+                device.restore_bar_addr(params);
+            }
+        }
+
+        ret
+    }
+
+    pub fn config_space_read(
+        &self,
+        bus: usize,
+        device: usize,
+        function: usize,
+        register: usize,
+    ) -> u32 {
+        if function > 0 {
+            return 0xffff_ffff;
+        }
+
+        if bus == 0 {
+            return self.read_config_register_for_device(device, register);
+        }
+
+        self.secondary_buses
+            .get(&(bus as u8))
+            .map_or(0xffff_ffff, |pci_bus| {
+                pci_bus
+                    .lock()
+                    .unwrap()
+                    .read_config_register_for_device(device, register)
+            })
+    }
+
+    pub fn config_space_write(
+        &self,
+        bus: usize,
+        device: usize,
+        function: usize,
+        register: usize,
+        offset: u64,
+        data: &[u8],
+    ) -> Option<Arc<Barrier>> {
+        if function > 0 {
+            return None;
+        }
+
+        if bus == 0 {
+            return self.write_config_register_for_device(device, register, offset, data);
+        }
+
+        self.secondary_buses.get(&(bus as u8)).and_then(|pci_bus| {
+            pci_bus
+                .lock()
+                .unwrap()
+                .write_config_register_for_device(device, register, offset, data)
+        })
+    }
 }
 
 pub struct PciConfigIo {
@@ -283,25 +398,11 @@ impl PciConfigIo {
         let (bus, device, function, register) =
             parse_io_config_address(self.config_address & !0x8000_0000);
 
-        // Only support one bus.
-        if bus != 0 {
-            return 0xffff_ffff;
-        }
-
-        // Don't support multi-function devices.
-        if function > 0 {
-            return 0xffff_ffff;
-        }
-
         self.pci_bus
             .as_ref()
             .lock()
             .unwrap()
-            .devices
-            .get(&(device as u8))
-            .map_or(0xffff_ffff, |d| {
-                d.lock().unwrap().read_config_register(register)
-            })
+            .config_space_read(bus, device, function, register)
     }
 
     pub fn config_space_write(&mut self, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
@@ -314,46 +415,14 @@ impl PciConfigIo {
             return None;
         }
 
-        let (bus, device, _function, register) =
+        let (bus, device, function, register) =
             parse_io_config_address(self.config_address & !0x8000_0000);
 
-        // Only support one bus.
-        if bus != 0 {
-            return None;
-        }
-
-        let pci_bus = self.pci_bus.as_ref().lock().unwrap();
-        if let Some(d) = pci_bus.devices.get(&(device as u8)) {
-            let mut device = d.lock().unwrap();
-
-            // Update the register value
-            let (bar_reprogram, ret) = device.write_config_register(register, offset, data);
-
-            // Move the device's BAR if needed
-            for params in &bar_reprogram {
-                if let Err(e) = pci_bus.device_reloc.move_bar(
-                    params.old_base,
-                    params.new_base,
-                    params.len,
-                    device.deref_mut(),
-                    params.region_type,
-                ) {
-                    warn!(
-                        "Failed moving device BAR: {}: 0x{:x}->0x{:x}(0x{:x}), keeping old BAR",
-                        e, params.old_base, params.new_base, params.len
-                    );
-                    // Rollback: the config register was already updated to
-                    // new_base by detect_bar_reprogramming(). Restore it by
-                    // writing back the old address so device state stays
-                    // consistent with the MMIO bus mapping.
-                    device.restore_bar_addr(params);
-                }
-            }
-
-            ret
-        } else {
-            None
-        }
+        self.pci_bus
+            .as_ref()
+            .lock()
+            .unwrap()
+            .config_space_write(bus, device, function, register, offset, data)
     }
 
     fn set_config_address(&mut self, offset: u64, data: &[u8]) {
@@ -423,21 +492,12 @@ impl PciConfigMmio {
     }
 
     fn config_space_read(&self, config_address: u32) -> u32 {
-        let (bus, device, _function, register) = parse_mmio_config_address(config_address);
-
-        // Only support one bus.
-        if bus != 0 {
-            return 0xffff_ffff;
-        }
+        let (bus, device, function, register) = parse_mmio_config_address(config_address);
 
         self.pci_bus
             .lock()
             .unwrap()
-            .devices
-            .get(&(device as u8))
-            .map_or(0xffff_ffff, |d| {
-                d.lock().unwrap().read_config_register(register)
-            })
+            .config_space_read(bus, device, function, register)
     }
 
     fn config_space_write(&mut self, config_address: u32, offset: u64, data: &[u8]) {
@@ -445,37 +505,13 @@ impl PciConfigMmio {
             return;
         }
 
-        let (bus, device, _function, register) = parse_mmio_config_address(config_address);
+        let (bus, device, function, register) = parse_mmio_config_address(config_address);
 
-        // Only support one bus.
-        if bus != 0 {
-            return;
-        }
-
-        let pci_bus = self.pci_bus.lock().unwrap();
-        if let Some(d) = pci_bus.devices.get(&(device as u8)) {
-            let mut device = d.lock().unwrap();
-
-            // Update the register value
-            let (bar_reprogram, _) = device.write_config_register(register, offset, data);
-
-            // Move the device's BAR if needed
-            for params in &bar_reprogram {
-                if let Err(e) = pci_bus.device_reloc.move_bar(
-                    params.old_base,
-                    params.new_base,
-                    params.len,
-                    device.deref_mut(),
-                    params.region_type,
-                ) {
-                    warn!(
-                        "Failed moving device BAR: {}: 0x{:x}->0x{:x}(0x{:x}), keeping old BAR",
-                        e, params.old_base, params.new_base, params.len
-                    );
-                    device.restore_bar_addr(params);
-                }
-            }
-        }
+        let _ = self
+            .pci_bus
+            .lock()
+            .unwrap()
+            .config_space_write(bus, device, function, register, offset, data);
     }
 }
 

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -32,6 +32,7 @@ const ROM_BAR_ADDR_MASK: u32 = 0xffff_f800;
 const MSI_CAPABILITY_REGISTER_MASK: u32 = 0x0071_0000;
 const MSIX_CAPABILITY_REGISTER_MASK: u32 = 0xc000_0000;
 const NUM_BAR_REGS: usize = 6;
+const NUM_BRIDGE_BAR_REGS: usize = 2;
 const CAPABILITY_LIST_HEAD_OFFSET: usize = 0x34;
 const FIRST_CAPABILITY_OFFSET: usize = 0x40;
 const CAPABILITY_MAX_OFFSET: usize = 192;
@@ -41,10 +42,14 @@ const INTERRUPT_LINE_PIN_REG: usize = 15;
 pub const PCI_CONFIGURATION_ID: &str = "pci_configuration";
 
 /// Represents the types of PCI headers allowed in the configuration registers.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PciHeaderType {
     Device,
     Bridge,
+}
+
+fn default_pci_header_type() -> PciHeaderType {
+    PciHeaderType::Device
 }
 
 /// Classes of PCI nodes.
@@ -417,6 +422,8 @@ pub struct PciConfigurationState {
     registers: Vec<u32>,
     writable_bits: Vec<u32>,
     bars: Vec<PciBar>,
+    #[serde(default = "default_pci_header_type")]
+    header_type: PciHeaderType,
     rom_bar_addr: u32,
     rom_bar_size: u32,
     rom_bar_used: bool,
@@ -435,6 +442,7 @@ pub struct PciConfiguration {
     registers: [u32; NUM_CONFIGURATION_REGISTERS],
     writable_bits: [u32; NUM_CONFIGURATION_REGISTERS], // writable bits for each register.
     bars: [PciBar; NUM_BAR_REGS],
+    header_type: PciHeaderType,
     rom_bar_addr: u32,
     rom_bar_size: u32,
     rom_bar_used: bool,
@@ -555,6 +563,7 @@ impl PciConfiguration {
             registers,
             writable_bits,
             bars,
+            header_type,
             rom_bar_addr,
             rom_bar_size,
             rom_bar_used,
@@ -566,6 +575,7 @@ impl PciConfiguration {
                 state.registers.try_into().unwrap(),
                 state.writable_bits.try_into().unwrap(),
                 state.bars.try_into().unwrap(),
+                state.header_type,
                 state.rom_bar_addr,
                 state.rom_bar_size,
                 state.rom_bar_used,
@@ -593,19 +603,27 @@ impl PciConfiguration {
                 PciHeaderType::Device => {
                     registers[3] = 0x0000_0000; // Header type 0 (device)
                     writable_bits[15] = 0x0000_00ff; // Interrupt line (r/w)
+                    registers[11] =
+                        (u32::from(subsystem_id) << 16) | u32::from(subsystem_vendor_id);
                 }
                 PciHeaderType::Bridge => {
                     registers[3] = 0x0001_0000; // Header type 1 (bridge)
-                    writable_bits[9] = 0xfff0_fff0; // Memory base and limit
+                    writable_bits[6] = 0x00ff_ff00; // Secondary and subordinate bus numbers
+                    writable_bits[7] = 0x0000_f0f0; // I/O base and limit
+                    writable_bits[8] = 0xfff0_fff0; // Memory base and limit
+                    writable_bits[9] = 0xfff1_fff1; // Prefetchable memory base and limit
+                    writable_bits[10] = 0xffff_ffff; // Prefetchable memory base upper 32 bits
+                    writable_bits[11] = 0xffff_ffff; // Prefetchable memory limit upper 32 bits
+                    writable_bits[12] = 0x0000_ffff; // I/O base and limit upper 16 bits
                     writable_bits[15] = 0xffff_00ff; // Bridge control (r/w), interrupt line (r/w)
                 }
             }
-            registers[11] = (u32::from(subsystem_id) << 16) | u32::from(subsystem_vendor_id);
 
             (
                 registers,
                 writable_bits,
                 [PciBar::default(); NUM_BAR_REGS],
+                header_type,
                 0,
                 0,
                 false,
@@ -619,6 +637,7 @@ impl PciConfiguration {
             registers,
             writable_bits,
             bars,
+            header_type,
             rom_bar_addr,
             rom_bar_size,
             rom_bar_used,
@@ -634,6 +653,7 @@ impl PciConfiguration {
             registers: self.registers.to_vec(),
             writable_bits: self.writable_bits.to_vec(),
             bars: self.bars.to_vec(),
+            header_type: self.header_type,
             rom_bar_addr: self.rom_bar_addr,
             rom_bar_size: self.rom_bar_size,
             rom_bar_used: self.rom_bar_used,
@@ -648,17 +668,24 @@ impl PciConfiguration {
         *(self.registers.get(reg_idx).unwrap_or(&0xffff_ffff))
     }
 
+    fn num_bars(&self) -> usize {
+        match self.header_type {
+            PciHeaderType::Device => NUM_BAR_REGS,
+            PciHeaderType::Bridge => NUM_BRIDGE_BAR_REGS,
+        }
+    }
+
     /// Writes a 32bit register to `reg_idx` in the register map.
     pub fn write_reg(&mut self, reg_idx: usize, value: u32) {
         let mut mask = self.writable_bits[reg_idx];
 
-        if (BAR0_REG..BAR0_REG + NUM_BAR_REGS).contains(&reg_idx) {
+        if (BAR0_REG..BAR0_REG + self.num_bars()).contains(&reg_idx) {
             // Handle very specific case where the BAR is being written with
             // all 1's to retrieve the BAR size during next BAR reading.
             if value == 0xffff_ffff {
                 mask &= self.bars[reg_idx - 4].size;
             }
-        } else if reg_idx == ROM_BAR_REG {
+        } else if reg_idx == ROM_BAR_REG && self.header_type == PciHeaderType::Device {
             // Handle very specific case where the BAR is being written with
             // all 1's on bits 31-11 to retrieve the BAR size during next BAR
             // reading.
@@ -735,7 +762,7 @@ impl PciConfiguration {
             return Err(Error::BarSizeInvalid(config.size));
         }
 
-        if bar_idx >= NUM_BAR_REGS {
+        if bar_idx >= self.num_bars() {
             return Err(Error::BarInvalid(bar_idx));
         }
 
@@ -981,7 +1008,7 @@ impl PciConfiguration {
         let value = LittleEndian::read_u32(data);
 
         let mask = self.writable_bits[reg_idx];
-        if (BAR0_REG..BAR0_REG + NUM_BAR_REGS).contains(&reg_idx) {
+        if (BAR0_REG..BAR0_REG + self.num_bars()).contains(&reg_idx) {
             // Ignore the case where the BAR size is being asked for.
             if value == 0xffff_ffff {
                 return None;
@@ -1054,7 +1081,10 @@ impl PciConfiguration {
                     region_type,
                 });
             }
-        } else if reg_idx == ROM_BAR_REG && (value & mask) != (self.rom_bar_addr & mask) {
+        } else if self.header_type == PciHeaderType::Device
+            && reg_idx == ROM_BAR_REG
+            && (value & mask) != (self.rom_bar_addr & mask)
+        {
             // Ignore the case where the BAR size is being asked for.
             if value & ROM_BAR_ADDR_MASK == ROM_BAR_ADDR_MASK {
                 return None;
@@ -1342,5 +1372,115 @@ mod unit_tests {
         assert_eq!(class_code, 0x04);
         assert_eq!(subclass, 0x01);
         assert_eq!(prog_if, 0x5a);
+    }
+
+    #[test]
+    fn bridge_register_write_is_not_treated_as_bar_reprogramming() {
+        let mut cfg = PciConfiguration::new(
+            0x1234,
+            0x5678,
+            0x1,
+            PciClassCode::BridgeDevice,
+            &PciBridgeSubclass::PciToPciBridge,
+            None,
+            PciHeaderType::Bridge,
+            0,
+            0,
+            None,
+            None,
+        );
+
+        assert!(
+            cfg.write_config_register(8, 0, &u32::MAX.to_le_bytes())
+                .is_empty()
+        );
+        assert_eq!(cfg.read_reg(8), 0xfff0_fff0);
+        assert_eq!(cfg.pending_bar_reprogram.len(), 0);
+    }
+
+    #[test]
+    fn bridge_configuration_only_allows_two_bars() {
+        let mut cfg = PciConfiguration::new(
+            0x1234,
+            0x5678,
+            0x1,
+            PciClassCode::BridgeDevice,
+            &PciBridgeSubclass::PciToPciBridge,
+            None,
+            PciHeaderType::Bridge,
+            0,
+            0,
+            None,
+            None,
+        );
+
+        let err = cfg
+            .add_pci_bar(&PciBarConfiguration::new(
+                2,
+                0x1000,
+                PciBarRegionType::Memory32BitRegion,
+                PciBarPrefetchable::NotPrefetchable,
+            ))
+            .unwrap_err();
+
+        assert!(matches!(err, Error::BarInvalid(2)));
+    }
+
+    #[test]
+    fn bridge_register_twelve_is_not_treated_as_rom_bar() {
+        let mut cfg = PciConfiguration::new(
+            0x1234,
+            0x5678,
+            0x1,
+            PciClassCode::BridgeDevice,
+            &PciBridgeSubclass::PciToPciBridge,
+            None,
+            PciHeaderType::Bridge,
+            0,
+            0,
+            None,
+            None,
+        );
+
+        assert!(
+            cfg.write_config_register(12, 0, &0x00ff_00ff_u32.to_le_bytes())
+                .is_empty()
+        );
+        assert_eq!(cfg.read_reg(12), 0x0000_00ff);
+        assert_eq!(cfg.pending_bar_reprogram.len(), 0);
+    }
+
+    #[test]
+    fn bridge_configuration_state_preserves_header_type() {
+        let cfg = PciConfiguration::new(
+            0x1234,
+            0x5678,
+            0x1,
+            PciClassCode::BridgeDevice,
+            &PciBridgeSubclass::PciToPciBridge,
+            None,
+            PciHeaderType::Bridge,
+            0,
+            0,
+            None,
+            None,
+        );
+
+        let restored = PciConfiguration::new(
+            0,
+            0,
+            0,
+            PciClassCode::TooOld,
+            &PciBridgeSubclass::PciToPciBridge,
+            None,
+            PciHeaderType::Device,
+            0,
+            0,
+            None,
+            Some(cfg.state()),
+        );
+
+        assert_eq!(restored.header_type, PciHeaderType::Bridge);
+        assert_eq!(restored.num_bars(), NUM_BRIDGE_BAR_REGS);
     }
 }

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -12,6 +12,7 @@ mod device;
 mod mmap;
 mod msi;
 mod msix;
+mod root_port;
 mod vfio;
 mod vfio_user;
 
@@ -38,6 +39,7 @@ pub use self::msix::{
     MSIX_CONFIG_ID, MSIX_TABLE_ENTRY_SIZE, MaybeMutInterruptSourceGroup, MsixCap, MsixConfig,
     MsixTableEntry,
 };
+pub use self::root_port::PcieRootPort;
 pub use self::vfio::{MmioRegion, VfioDmaMapping, VfioPciDevice, VfioPciError};
 pub use self::vfio_user::{VfioUserDmaMapping, VfioUserPciDevice, VfioUserPciDeviceError};
 

--- a/pci/src/root_port.rs
+++ b/pci/src/root_port.rs
@@ -1,0 +1,332 @@
+// Copyright 2026 Prime Intellect, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::any::Any;
+use std::sync::{Arc, Barrier};
+
+use vm_device::{BusDevice, PciBarType, Resource};
+use vm_memory::ByteValued;
+
+use crate::configuration::{
+    PciBridgeSubclass, PciCapability, PciCapabilityId, PciClassCode, PciConfiguration,
+    PciHeaderType,
+};
+use crate::device::{BarReprogrammingParams, Error as PciDeviceError, PciDevice};
+
+const VENDOR_ID_INTEL: u16 = 0x8086;
+const DEVICE_ID_INTEL_VIRT_PCIE_ROOT_PORT: u16 = 0x0d58;
+const BRIDGE_BUS_NUMBERS_REG: usize = 6;
+const IO_BASE_LIMIT_REG: usize = 7;
+const MEMORY_BASE_LIMIT_REG: usize = 8;
+const PREFETCHABLE_MEMORY_BASE_LIMIT_REG: usize = 9;
+const PREFETCHABLE_MEMORY_BASE_UPPER_REG: usize = 10;
+const PREFETCHABLE_MEMORY_LIMIT_UPPER_REG: usize = 11;
+const IO_BASE_LIMIT_UPPER_REG: usize = 12;
+
+const IO_WINDOW_ALIGNMENT: u64 = 0x1_000;
+const MEMORY_WINDOW_ALIGNMENT: u64 = 0x10_0000;
+const PCIE_ROOT_PORT_TYPE: u16 = 0x4;
+const PCIE_CAPABILITY_VERSION: u16 = 0x2;
+const PCIE_LINK_SPEED_16_0_GT_PER_S: u16 = 0x4;
+const PCIE_LINK_WIDTH_X16: u16 = 0x10;
+const PCIE_SUPPORTED_LINK_SPEEDS: u32 = 0x1e;
+
+#[derive(Copy, Clone)]
+struct Window {
+    base: u64,
+    limit: u64,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy, Default)]
+struct PcieRootPortCapability {
+    pcie_capabilities: u16,
+    device_capabilities: u32,
+    device_control: u16,
+    device_status: u16,
+    link_capabilities: u32,
+    link_control: u16,
+    link_status: u16,
+    slot_capabilities: u32,
+    slot_control: u16,
+    slot_status: u16,
+    root_control: u16,
+    root_capabilities: u16,
+    root_status: u32,
+    device_capabilities_2: u32,
+    device_control_2: u16,
+    link_capabilities_2: u32,
+    link_control_2: u16,
+    link_status_2: u16,
+}
+
+// SAFETY: All members are integer fields and any bit pattern is valid.
+unsafe impl ByteValued for PcieRootPortCapability {}
+
+impl PcieRootPortCapability {
+    fn new() -> Self {
+        let link_speed = u32::from(PCIE_LINK_SPEED_16_0_GT_PER_S);
+        let link_width = u32::from(PCIE_LINK_WIDTH_X16) << 4;
+
+        Self {
+            pcie_capabilities: PCIE_CAPABILITY_VERSION | (PCIE_ROOT_PORT_TYPE << 4),
+            device_capabilities: 0,
+            device_control: 0,
+            device_status: 0,
+            link_capabilities: link_speed | link_width,
+            link_control: 0,
+            link_status: PCIE_LINK_SPEED_16_0_GT_PER_S | (PCIE_LINK_WIDTH_X16 << 4),
+            slot_capabilities: 0,
+            slot_control: 0,
+            slot_status: 0,
+            root_control: 0,
+            root_capabilities: 0,
+            root_status: 0,
+            device_capabilities_2: 0,
+            device_control_2: 0,
+            link_capabilities_2: PCIE_SUPPORTED_LINK_SPEEDS,
+            link_control_2: 0,
+            link_status_2: 0,
+        }
+    }
+}
+
+impl PciCapability for PcieRootPortCapability {
+    fn bytes(&self) -> &[u8] {
+        self.as_slice()
+    }
+
+    fn id(&self) -> PciCapabilityId {
+        PciCapabilityId::PciExpress
+    }
+}
+
+pub struct PcieRootPort {
+    id: String,
+    config: PciConfiguration,
+    secondary_bus_number: u8,
+}
+
+impl PcieRootPort {
+    pub fn new(id: String, secondary_bus_number: u8) -> Result<Self, PciDeviceError> {
+        let mut config = PciConfiguration::new(
+            VENDOR_ID_INTEL,
+            DEVICE_ID_INTEL_VIRT_PCIE_ROOT_PORT,
+            0,
+            PciClassCode::BridgeDevice,
+            &PciBridgeSubclass::PciToPciBridge,
+            None,
+            PciHeaderType::Bridge,
+            0,
+            0,
+            None,
+            None,
+        );
+
+        config
+            .add_capability(&PcieRootPortCapability::new())
+            .map_err(PciDeviceError::CapabilitiesSetup)?;
+
+        config.write_reg(
+            BRIDGE_BUS_NUMBERS_REG,
+            (u32::from(secondary_bus_number) << 8) | (u32::from(secondary_bus_number) << 16),
+        );
+
+        // Keep all downstream apertures closed until a child device is added.
+        Self::set_io_window_registers(&mut config, None);
+        Self::set_memory_window_registers(&mut config, None);
+        Self::set_prefetchable_memory_window_registers(&mut config, None);
+
+        Ok(Self {
+            id,
+            config,
+            secondary_bus_number,
+        })
+    }
+
+    pub fn secondary_bus_number(&self) -> u8 {
+        self.secondary_bus_number
+    }
+
+    pub fn configure_windows(&mut self, resources: &[Resource]) {
+        let mut io_window = None;
+        let mut memory_window = None;
+        let mut prefetchable_memory_window = None;
+
+        for resource in resources {
+            let Resource::PciBar {
+                base,
+                size,
+                type_,
+                prefetchable,
+                ..
+            } = resource
+            else {
+                continue;
+            };
+
+            let Some(limit) = base.checked_add(size.saturating_sub(1)) else {
+                continue;
+            };
+
+            match type_ {
+                PciBarType::Io => Self::extend_window(&mut io_window, *base, limit),
+                PciBarType::Mmio32 | PciBarType::Mmio64 if *prefetchable => {
+                    Self::extend_window(&mut prefetchable_memory_window, *base, limit);
+                }
+                PciBarType::Mmio32 | PciBarType::Mmio64 => {
+                    Self::extend_window(&mut memory_window, *base, limit);
+                }
+            }
+        }
+
+        Self::set_io_window_registers(&mut self.config, io_window);
+        Self::set_memory_window_registers(&mut self.config, memory_window);
+        Self::set_prefetchable_memory_window_registers(
+            &mut self.config,
+            prefetchable_memory_window,
+        );
+    }
+
+    fn extend_window(window: &mut Option<Window>, base: u64, limit: u64) {
+        match window {
+            Some(existing) => {
+                existing.base = existing.base.min(base);
+                existing.limit = existing.limit.max(limit);
+            }
+            None => {
+                *window = Some(Window { base, limit });
+            }
+        }
+    }
+
+    fn align_down(value: u64, alignment: u64) -> u64 {
+        value & !(alignment - 1)
+    }
+
+    fn align_up(value: u64, alignment: u64) -> u64 {
+        value.saturating_add(alignment - 1) & !(alignment - 1)
+    }
+
+    fn set_io_window_registers(config: &mut PciConfiguration, window: Option<Window>) {
+        let (low, upper) = if let Some(window) = window {
+            let base = Self::align_down(window.base, IO_WINDOW_ALIGNMENT);
+            let limit = Self::align_up(window.limit.saturating_add(1), IO_WINDOW_ALIGNMENT)
+                .saturating_sub(1);
+
+            (
+                (((limit >> 8) as u32) & 0x0000_f000) | (((base >> 8) as u32) & 0x0000_00f0),
+                (((limit >> 16) as u32) & 0xffff_0000) | (((base >> 16) as u32) & 0x0000_ffff),
+            )
+        } else {
+            (0x0000_00f0, 0x0000_ffff)
+        };
+
+        config.write_reg(IO_BASE_LIMIT_REG, low);
+        config.write_reg(IO_BASE_LIMIT_UPPER_REG, upper);
+    }
+
+    fn set_memory_window_registers(config: &mut PciConfiguration, window: Option<Window>) {
+        let value = if let Some(window) = window {
+            let base = Self::align_down(window.base, MEMORY_WINDOW_ALIGNMENT);
+            let limit = Self::align_up(window.limit.saturating_add(1), MEMORY_WINDOW_ALIGNMENT)
+                .saturating_sub(1);
+
+            ((((limit >> 16) as u32) & 0x0000_fff0) << 16) | (((base >> 16) as u32) & 0x0000_fff0)
+        } else {
+            0x0000_fff0
+        };
+
+        config.write_reg(MEMORY_BASE_LIMIT_REG, value);
+    }
+
+    fn set_prefetchable_memory_window_registers(
+        config: &mut PciConfiguration,
+        window: Option<Window>,
+    ) {
+        let (low, upper_base, upper_limit) = if let Some(window) = window {
+            let base = Self::align_down(window.base, MEMORY_WINDOW_ALIGNMENT);
+            let limit = Self::align_up(window.limit.saturating_add(1), MEMORY_WINDOW_ALIGNMENT)
+                .saturating_sub(1);
+
+            (
+                (((((limit >> 16) as u32) & 0x0000_fff0) | 0x1) << 16)
+                    | ((((base >> 16) as u32) & 0x0000_fff0) | 0x1),
+                (base >> 32) as u32,
+                (limit >> 32) as u32,
+            )
+        } else {
+            (0x0001_fff1, 0, 0)
+        };
+
+        config.write_reg(PREFETCHABLE_MEMORY_BASE_LIMIT_REG, low);
+        config.write_reg(PREFETCHABLE_MEMORY_BASE_UPPER_REG, upper_base);
+        config.write_reg(PREFETCHABLE_MEMORY_LIMIT_UPPER_REG, upper_limit);
+    }
+}
+
+impl BusDevice for PcieRootPort {}
+
+impl PciDevice for PcieRootPort {
+    fn write_config_register(
+        &mut self,
+        reg_idx: usize,
+        offset: u64,
+        data: &[u8],
+    ) -> (Vec<BarReprogrammingParams>, Option<Arc<Barrier>>) {
+        (
+            self.config.write_config_register(reg_idx, offset, data),
+            None,
+        )
+    }
+
+    fn read_config_register(&mut self, reg_idx: usize) -> u32 {
+        self.config.read_reg(reg_idx)
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn id(&self) -> Option<String> {
+        Some(self.id.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CAPABILITY_LIST_HEAD_REG: usize = 0x34 / 4;
+
+    #[test]
+    fn root_port_exposes_pcie_capability() {
+        let mut root_port = PcieRootPort::new("rp0".to_string(), 1).unwrap();
+
+        let cap_offset = (root_port.read_config_register(CAPABILITY_LIST_HEAD_REG) & 0xff) as usize;
+        assert_eq!(cap_offset, 0x40);
+
+        let capability_header = root_port.read_config_register(cap_offset / 4);
+        assert_eq!(capability_header & 0xff, PciCapabilityId::PciExpress as u32);
+        assert_eq!(
+            (capability_header >> 16) & 0xf,
+            PCIE_CAPABILITY_VERSION as u32
+        );
+        assert_eq!((capability_header >> 20) & 0xf, PCIE_ROOT_PORT_TYPE as u32);
+
+        let link_capabilities = root_port.read_config_register((cap_offset + 0x0c) / 4);
+        let link_status = root_port.read_config_register((cap_offset + 0x10) / 4) >> 16;
+
+        assert_eq!(
+            link_capabilities & 0xf,
+            u32::from(PCIE_LINK_SPEED_16_0_GT_PER_S)
+        );
+        assert_eq!(
+            (link_capabilities >> 4) & 0x3f,
+            u32::from(PCIE_LINK_WIDTH_X16)
+        );
+        assert_eq!(link_status & 0xf, u32::from(PCIE_LINK_SPEED_16_0_GT_PER_S));
+        assert_eq!((link_status >> 4) & 0x3f, u32::from(PCIE_LINK_WIDTH_X16));
+    }
+}

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -766,7 +766,7 @@ impl VfioCommon {
                         .allocate(restored_bar_addr, region_size, Some(region_size))
                         .ok_or(PciDeviceError::IoAllocationFailed(region_size))?
                 }
-                PciBarRegionType::Memory64BitRegion => {
+                PciBarRegionType::Memory64BitRegion if bool::from(prefetchable) => {
                     // We need do some fixup to keep MMIO RW region and msix cap region page size
                     // aligned.
                     region_size = self.fixup_msix_region(bar_id, region_size);
@@ -780,6 +780,15 @@ impl VfioCommon {
                                 region_size,
                             )),
                         )
+                        .ok_or(PciDeviceError::IoAllocationFailed(region_size))?
+                }
+                PciBarRegionType::Memory64BitRegion => {
+                    // Some devices expose 64-bit BARs that are still non-prefetchable.
+                    // Those must live behind the bridge's normal 32-bit memory window,
+                    // so keep them in the 32-bit PCI MMIO aperture.
+                    region_size = self.fixup_msix_region(bar_id, region_size);
+                    mmio32_allocator
+                        .allocate(restored_bar_addr, region_size, Some(region_size))
                         .ok_or(PciDeviceError::IoAllocationFailed(region_size))?
                 }
             };

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -501,6 +501,13 @@ pub(crate) struct VfioCommon {
     pub(crate) vfio_wrapper: Arc<dyn Vfio>,
     pub(crate) patches: HashMap<usize, ConfigPatch>,
     x_nv_gpudirect_clique: Option<u8>,
+    x_exclude_mmap_bars: Vec<u8>,
+}
+
+#[derive(Default)]
+pub(crate) struct VfioCommonConfig {
+    pub(crate) x_nv_gpudirect_clique: Option<u8>,
+    pub(crate) x_exclude_mmap_bars: Vec<u8>,
 }
 
 impl VfioCommon {
@@ -511,7 +518,7 @@ impl VfioCommon {
         subclass: &dyn PciSubclass,
         bdf: PciBdf,
         snapshot: Option<&Snapshot>,
-        x_nv_gpudirect_clique: Option<u8>,
+        config: VfioCommonConfig,
     ) -> Result<Self, VfioPciError> {
         let pci_configuration_state = vm_migration::state_from_id(snapshot, PCI_CONFIGURATION_ID)
             .map_err(|e| {
@@ -546,7 +553,8 @@ impl VfioCommon {
             legacy_interrupt_group,
             vfio_wrapper,
             patches: HashMap::new(),
-            x_nv_gpudirect_clique,
+            x_nv_gpudirect_clique: config.x_nv_gpudirect_clique,
+            x_exclude_mmap_bars: config.x_exclude_mmap_bars,
         };
 
         let state: Option<VfioCommonState> = snapshot
@@ -1499,6 +1507,7 @@ impl VfioPciDevice {
         memory_slot_allocator: MemorySlotAllocator,
         snapshot: Option<&Snapshot>,
         x_nv_gpudirect_clique: Option<u8>,
+        x_exclude_mmap_bars: Vec<u8>,
         device_path: PathBuf,
     ) -> Result<Self, VfioPciError> {
         let device = Arc::new(device);
@@ -1513,7 +1522,10 @@ impl VfioPciDevice {
             &PciVfioSubclass::VfioSubclass,
             bdf,
             vm_migration::snapshot_from_id(snapshot, VFIO_COMMON_ID),
-            x_nv_gpudirect_clique,
+            VfioCommonConfig {
+                x_nv_gpudirect_clique,
+                x_exclude_mmap_bars,
+            },
         )?;
 
         let vfio_pci_device = VfioPciDevice {
@@ -1649,6 +1661,21 @@ impl VfioPciDevice {
         // SAFETY: fd is guaranteed valid
         let fd = unsafe { BorrowedFd::borrow_raw(fd) };
         for region in self.common.mmio_regions.iter_mut() {
+            if self
+                .common
+                .x_exclude_mmap_bars
+                .contains(&(region.index as u8))
+            {
+                info!(
+                    "Skipping VFIO BAR mmap for device {} at {} BAR {} (size = 0x{:x})",
+                    self.bdf,
+                    self.device_path.display(),
+                    region.index,
+                    region.length
+                );
+                continue;
+            }
+
             let region_flags = self.device.get_region_flags(region.index);
             if region_flags & VFIO_REGION_INFO_FLAG_MMAP != 0 {
                 let mut prot = 0;

--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -26,7 +26,9 @@ use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottabl
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::mmap::MmapRegion;
-use crate::vfio::{UserMemoryRegion, VFIO_COMMON_ID, Vfio, VfioCommon, VfioError};
+use crate::vfio::{
+    UserMemoryRegion, VFIO_COMMON_ID, Vfio, VfioCommon, VfioCommonConfig, VfioError,
+};
 use crate::{
     BarReprogrammingParams, PciBarConfiguration, PciBdf, PciDevice, PciDeviceError, PciSubclass,
     VfioPciError,
@@ -101,7 +103,7 @@ impl VfioUserPciDevice {
             &PciVfioUserSubclass::VfioUserSubclass,
             bdf,
             vm_migration::snapshot_from_id(snapshot, VFIO_COMMON_ID),
-            None,
+            VfioCommonConfig::default(),
         )
         .map_err(VfioUserPciDeviceError::CreateVfioCommon)?;
 

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -12,6 +12,8 @@ CTR_IMAGE_TAG="ghcr.io/cloud-hypervisor/cloud-hypervisor"
 CTR_IMAGE_VERSION="20251114-0"
 : "${CTR_IMAGE:=${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}}"
 
+TARGET_CONTAINER_ARCH=""
+
 DOCKER_RUNTIME="docker"
 
 # Host paths
@@ -56,85 +58,85 @@ RUSTFLAGS="${RUSTFLAGS} --cfg devcli_testenv"
 # Send a decorated message to stdout, followed by a new line
 #
 say() {
-    [ -t 1 ] && [ -n "$TERM" ] &&
-        echo "$(tput setaf 2)[$CLI_NAME]$(tput sgr0) $*" ||
-        echo "[$CLI_NAME] $*"
+	[ -t 1 ] && [ -n "$TERM" ] &&
+		echo "$(tput setaf 2)[$CLI_NAME]$(tput sgr0) $*" ||
+		echo "[$CLI_NAME] $*"
 }
 
 # Send a decorated message to stdout, without a trailing new line
 #
 say_noln() {
-    [ -t 1 ] && [ -n "$TERM" ] &&
-        echo -n "$(tput setaf 2)[$CLI_NAME]$(tput sgr0) $*" ||
-        echo "[$CLI_NAME] $*"
+	[ -t 1 ] && [ -n "$TERM" ] &&
+		echo -n "$(tput setaf 2)[$CLI_NAME]$(tput sgr0) $*" ||
+		echo "[$CLI_NAME] $*"
 }
 
 # Send a text message to stderr
 #
 say_err() {
-    [ -t 2 ] && [ -n "$TERM" ] &&
-        echo "$(tput setaf 1)[$CLI_NAME] $*$(tput sgr0)" 1>&2 ||
-        echo "[$CLI_NAME] $*" 1>&2
+	[ -t 2 ] && [ -n "$TERM" ] &&
+		echo "$(tput setaf 1)[$CLI_NAME] $*$(tput sgr0)" 1>&2 ||
+		echo "[$CLI_NAME] $*" 1>&2
 }
 
 # Send a warning-highlighted text to stdout
 say_warn() {
-    [ -t 1 ] && [ -n "$TERM" ] &&
-        echo "$(tput setaf 3)[$CLI_NAME] $*$(tput sgr0)" ||
-        echo "[$CLI_NAME] $*"
+	[ -t 1 ] && [ -n "$TERM" ] &&
+		echo "$(tput setaf 3)[$CLI_NAME] $*$(tput sgr0)" ||
+		echo "[$CLI_NAME] $*"
 }
 
 # Exit with an error message and (optional) code
 # Usage: die [-c <error code>] <error message>
 #
 die() {
-    code=1
-    [[ "$1" = "-c" ]] && {
-        code="$2"
-        shift 2
-    }
-    say_err "$@"
-    exit "$code"
+	code=1
+	[[ "$1" = "-c" ]] && {
+		code="$2"
+		shift 2
+	}
+	say_err "$@"
+	exit "$code"
 }
 
 # Exit with an error message if the last exit code is not 0
 #
 ok_or_die() {
-    code=$?
-    [[ $code -eq 0 ]] || die -c $code "$@"
+	code=$?
+	[[ $code -eq 0 ]] || die -c $code "$@"
 }
 
 # Make sure the build/ dirs are available. Exit if we can't create them.
 # Upon returning from this call, the caller can be certain the build/ dirs exist.
 #
 ensure_build_dir() {
-    for dir in "$CLH_BUILD_DIR" \
-        "$CLH_INTEGRATION_WORKLOADS" \
-        "$CLH_CTR_BUILD_DIR" \
-        "$CARGO_TARGET_DIR" \
-        "$CARGO_REGISTRY_DIR" \
-        "$CARGO_GIT_REGISTRY_DIR"; do
-        mkdir -p "$dir" || die "Error: cannot create dir $dir"
-        [ -x "$dir" ] && [ -w "$dir" ] ||
-            {
-                say "Wrong permissions for $dir. Attempting to fix them ..."
-                chmod +x+w "$dir"
-            } ||
-            die "Error: wrong permissions for $dir. Should be +x+w"
-    done
+	for dir in "$CLH_BUILD_DIR" \
+		"$CLH_INTEGRATION_WORKLOADS" \
+		"$CLH_CTR_BUILD_DIR" \
+		"$CARGO_TARGET_DIR" \
+		"$CARGO_REGISTRY_DIR" \
+		"$CARGO_GIT_REGISTRY_DIR"; do
+		mkdir -p "$dir" || die "Error: cannot create dir $dir"
+		[ -x "$dir" ] && [ -w "$dir" ] ||
+			{
+				say "Wrong permissions for $dir. Attempting to fix them ..."
+				chmod +x+w "$dir"
+			} ||
+			die "Error: wrong permissions for $dir. Should be +x+w"
+	done
 }
 
 # Make sure we're using the latest dev container, by just pulling it.
 ensure_latest_ctr() {
-    if [ "$CTR_IMAGE_VERSION" = "local" ]; then
-        build_container
-    else
-        if ! $DOCKER_RUNTIME pull "$CTR_IMAGE"; then
-            build_container
-        fi
+	if [ "$CTR_IMAGE_VERSION" = "local" ]; then
+		build_container
+	else
+		if ! $DOCKER_RUNTIME pull "$CTR_IMAGE"; then
+			build_container
+		fi
 
-        ok_or_die "Error pulling/building container image. Aborting."
-    fi
+		ok_or_die "Error pulling/building container image. Aborting."
+	fi
 }
 
 # Fix main directory permissions after a container ran as root.
@@ -143,37 +145,70 @@ ensure_latest_ctr() {
 # current user.
 #
 fix_dir_perms() {
-    # Yes, running Docker to get elevated privileges, just to chown some files
-    # is a dirty hack.
-    $DOCKER_RUNTIME run \
-        --workdir "$CTR_CLH_ROOT_DIR" \
-        --rm \
-        --volume /dev:/dev \
-        --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-        ${exported_volumes:+$exported_volumes} \
-        "$CTR_IMAGE" \
-        chown -R "$(id -u):$(id -g)" "$CTR_CLH_ROOT_DIR"
+	# Yes, running Docker to get elevated privileges, just to chown some files
+	# is a dirty hack.
+	$DOCKER_RUNTIME run \
+		--workdir "$CTR_CLH_ROOT_DIR" \
+		--rm \
+		--volume /dev:/dev \
+		--volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+		${exported_volumes:+$exported_volumes} \
+		"$CTR_IMAGE" \
+		chown -R "$(id -u):$(id -g)" "$CTR_CLH_ROOT_DIR"
 
-    return "$1"
+	return "$1"
 }
 # Process exported volumes argument, separate the volumes and make docker compatible
 # Sample input: --volumes /a:/a#/b:/b
 # Sample output: --volume /a:/a --volume /b:/b
 #
 process_volumes_args() {
-    if [ -z "$arg_vols" ]; then
-        return
-    fi
-    exported_volumes=""
-    IFS='#' read -ra arr_vols <<<"$arg_vols"
-    for var in "${arr_vols[@]}"; do
-        dev=$(echo "$var" | cut -d ':' -f 1)
-        if [[ ! -e "$dev" ]]; then
-            echo "The volume $dev does not exist."
-            exit 1
-        fi
-        exported_volumes="$exported_volumes --volume $var"
-    done
+	if [ -z "$arg_vols" ]; then
+		return
+	fi
+	exported_volumes=""
+	IFS='#' read -ra arr_vols <<<"$arg_vols"
+	for var in "${arr_vols[@]}"; do
+		dev=$(echo "$var" | cut -d ':' -f 1)
+		if [[ ! -e "$dev" ]]; then
+			echo "The volume $dev does not exist."
+			exit 1
+		fi
+		exported_volumes="$exported_volumes --volume $var"
+	done
+}
+
+normalize_rust_arch() {
+	case "$1" in
+	"x86_64" | "amd64")
+		echo "x86_64"
+		;;
+	"aarch64" | "arm64")
+		echo "aarch64"
+		;;
+	*)
+		die "Invalid arch: $1. Valid options are \"x86_64\" and \"aarch64\"."
+		;;
+	esac
+}
+
+docker_platform_arch() {
+	case "$(normalize_rust_arch "$1")" in
+	"x86_64")
+		echo "amd64"
+		;;
+	"aarch64")
+		echo "arm64"
+		;;
+	esac
+}
+
+host_rust_arch() {
+	normalize_rust_arch "$(uname -m)"
+}
+
+build_target_triple() {
+	echo "$(normalize_rust_arch "$1")-unknown-linux-$2"
 }
 
 # Copy IGVM files to the workloads directory
@@ -181,592 +216,601 @@ process_volumes_args() {
 #   $1 - source path
 #   $2 - destination path
 copy_igvm_files() {
-    src=$1
-    dest=$2
+	src=$1
+	dest=$2
 
-    if [ -d "$src" ]; then
-        say "Copying IGVM files from $src to $dest"
-        cp "$src"/* "$dest"
-    else
-        say_err "IGVM File path '$src' not found on host"
-        exit 1
-    fi
+	if [ -d "$src" ]; then
+		say "Copying IGVM files from $src to $dest"
+		cp "$src"/* "$dest"
+	else
+		say_err "IGVM File path '$src' not found on host"
+		exit 1
+	fi
 }
 
 cmd_help() {
-    echo ""
-    echo "Cloud Hypervisor $(basename "$0")"
-    echo "Usage: $(basename "$0") [flags] <command> [<command args>]"
-    echo ""
-    echo "Available flags":
-    echo ""
-    echo "    --local        Set the container image version being used to \"local\"."
-    echo ""
-    echo "Available commands:"
-    echo ""
-    echo "    build [--debug|--release] [--libc musl|gnu] [-- [<cargo args>]]"
-    echo "        Build the Cloud Hypervisor binaries."
-    echo "        --debug               Build the debug binaries. This is the default."
-    echo "        --release             Build the release binaries."
-    echo "        --libc                Select the C library Cloud Hypervisor will be built against. Default is gnu"
-    echo "        --volumes             Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
-    echo "        --hypervisor          Underlying hypervisor. Options kvm, mshv"
-    echo ""
-    echo "    tests [<test type (see below)>] [--libc musl|gnu] [-- [<test scripts args>] [-- [<test binary args>]]] "
-    echo "        Run the Cloud Hypervisor tests."
-    echo "        --unit                       Run the unit tests."
-    echo "        --integration                Run the integration tests."
-    echo "        --integration-vfio           Run the VFIO integration tests."
-    echo "        --integration-windows        Run the Windows guest integration tests."
-    echo "        --integration-live-migration Run the live-migration integration tests."
-    echo "        --integration-rate-limiter   Run the rate-limiter integration tests."
-    echo "        --integration-cvm            Run the Confidential VM integration tests."
-    echo "        --libc                       Select the C library Cloud Hypervisor will be built against. Default is gnu"
-    echo "        --metrics                    Generate performance metrics"
-    echo "        --coverage                   Generate code coverage information"
-    echo "        --volumes                    Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
-    echo "        --hypervisor                 Underlying hypervisor. Options kvm, mshv"
-    echo "        --all                        Run all tests."
-    echo ""
-    echo "    build-container [--type]"
-    echo "        Build the Cloud Hypervisor container."
-    echo ""
-    echo "    clean [<cargo args>]]"
-    echo "        Remove the Cloud Hypervisor artifacts."
-    echo ""
-    echo "    shell"
-    echo "        Run the development container into an interactive, privileged BASH shell."
-    echo "        --volumes             Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
-    echo ""
-    echo "    help"
-    echo "        Display this help message."
-    echo ""
+	echo ""
+	echo "Cloud Hypervisor $(basename "$0")"
+	echo "Usage: $(basename "$0") [flags] <command> [<command args>]"
+	echo ""
+	echo "Available flags":
+	echo ""
+	echo "    --local        Set the container image version being used to \"local\"."
+	echo ""
+	echo "Available commands:"
+	echo ""
+	echo "    build [--debug|--release] [--arch x86_64|aarch64] [--libc musl|gnu] [-- [<cargo args>]]"
+	echo "        Build the Cloud Hypervisor binaries."
+	echo "        --debug               Build the debug binaries. This is the default."
+	echo "        --release             Build the release binaries."
+	echo "        --arch                Target architecture. Defaults to the host architecture."
+	echo "        --libc                Select the C library Cloud Hypervisor will be built against. Default is gnu"
+	echo "        --volumes             Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
+	echo "        --hypervisor          Underlying hypervisor. Options kvm, mshv"
+	echo ""
+	echo "    tests [<test type (see below)>] [--libc musl|gnu] [-- [<test scripts args>] [-- [<test binary args>]]] "
+	echo "        Run the Cloud Hypervisor tests."
+	echo "        --unit                       Run the unit tests."
+	echo "        --integration                Run the integration tests."
+	echo "        --integration-vfio           Run the VFIO integration tests."
+	echo "        --integration-windows        Run the Windows guest integration tests."
+	echo "        --integration-live-migration Run the live-migration integration tests."
+	echo "        --integration-rate-limiter   Run the rate-limiter integration tests."
+	echo "        --integration-cvm            Run the Confidential VM integration tests."
+	echo "        --libc                       Select the C library Cloud Hypervisor will be built against. Default is gnu"
+	echo "        --metrics                    Generate performance metrics"
+	echo "        --coverage                   Generate code coverage information"
+	echo "        --volumes                    Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
+	echo "        --hypervisor                 Underlying hypervisor. Options kvm, mshv"
+	echo "        --all                        Run all tests."
+	echo ""
+	echo "    build-container [--type]"
+	echo "        Build the Cloud Hypervisor container."
+	echo ""
+	echo "    clean [<cargo args>]]"
+	echo "        Remove the Cloud Hypervisor artifacts."
+	echo ""
+	echo "    shell"
+	echo "        Run the development container into an interactive, privileged BASH shell."
+	echo "        --volumes             Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
+	echo ""
+	echo "    help"
+	echo "        Display this help message."
+	echo ""
 }
 
 cmd_build() {
-    build="debug"
-    libc="gnu"
-    hypervisor="kvm"
-    features_build=()
-    exported_device="/dev/kvm"
-    while [ $# -gt 0 ]; do
-        case "$1" in
-        "-h" | "--help") {
-            cmd_help
-            exit 1
-        } ;;
-        "--debug") { build="debug"; } ;;
-        "--release") { build="release"; } ;;
-        "--runtime")
-            shift
-            DOCKER_RUNTIME="$1"
-            export DOCKER_RUNTIME
-            ;;
-        "--libc")
-            shift
-            [[ "$1" =~ ^(musl|gnu)$ ]] ||
-                die "Invalid libc: $1. Valid options are \"musl\" and \"gnu\"."
-            libc="$1"
-            ;;
-        "--volumes")
-            shift
-            arg_vols="$1"
-            ;;
-        "--hypervisor")
-            shift
-            hypervisor="$1"
-            ;;
-        "--features")
-            shift
-            features_build=(--features "$1")
-            ;;
-        "--") {
-            shift
-            break
-        } ;;
-        *)
-            die "Unknown build argument: $1. Please use --help for help."
-            ;;
-        esac
-        shift
-    done
+	build="debug"
+	libc="gnu"
+	hypervisor="kvm"
+	arch="$(host_rust_arch)"
+	features_build=()
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		"-h" | "--help") {
+			cmd_help
+			exit 1
+		} ;;
+		"--debug") { build="debug"; } ;;
+		"--release") { build="release"; } ;;
+		"--arch")
+			shift
+			arch="$(normalize_rust_arch "$1")"
+			;;
+		"--runtime")
+			shift
+			DOCKER_RUNTIME="$1"
+			export DOCKER_RUNTIME
+			;;
+		"--libc")
+			shift
+			[[ "$1" =~ ^(musl|gnu)$ ]] ||
+				die "Invalid libc: $1. Valid options are \"musl\" and \"gnu\"."
+			libc="$1"
+			;;
+		"--volumes")
+			shift
+			arg_vols="$1"
+			;;
+		"--hypervisor")
+			shift
+			hypervisor="$1"
+			;;
+		"--features")
+			shift
+			features_build=(--features "$1")
+			;;
+		"--") {
+			shift
+			break
+		} ;;
+		*)
+			die "Unknown build argument: $1. Please use --help for help."
+			;;
+		esac
+		shift
+	done
 
-    ensure_build_dir
-    ensure_latest_ctr
+	TARGET_CONTAINER_ARCH="$arch"
 
-    process_volumes_args
-    if [[ ! ("$hypervisor" = "kvm" || "$hypervisor" = "mshv") ]]; then
-        die "Hypervisor value must be kvm or mshv"
-    fi
-    if [[ "$hypervisor" = "mshv" ]]; then
-        exported_device="/dev/mshv"
-    fi
-    target="$(uname -m)-unknown-linux-${libc}"
+	ensure_build_dir
+	ensure_latest_ctr
 
-    cargo_args=("$@")
-    [ $build = "release" ] && cargo_args+=("--release")
-    cargo_args+=(--target "$target")
+	process_volumes_args
+	if [[ ! ("$hypervisor" = "kvm" || "$hypervisor" = "mshv") ]]; then
+		die "Hypervisor value must be kvm or mshv"
+	fi
+	target="$(build_target_triple "$arch" "$libc")"
+	platform_arch="$(docker_platform_arch "$arch")"
 
-    # shellcheck disable=SC2153
-    rustflags="$RUSTFLAGS"
-    target_cc=""
-    if [ "$(uname -m)" = "aarch64" ] && [ "$libc" = "musl" ]; then
-        rustflags="$rustflags -C link-args=-Wl,-Bstatic -C link-args=-lc"
-    fi
+	cargo_args=("$@")
+	[ $build = "release" ] && cargo_args+=("--release")
+	cargo_args+=(--target "$target")
 
-    $DOCKER_RUNTIME run \
-        --user "$(id -u):$(id -g)" \
-        --workdir "$CTR_CLH_ROOT_DIR" \
-        --rm \
-        --volume $exported_device \
-        --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-        ${exported_volumes:+$exported_volumes} \
-        --env RUSTFLAGS="$rustflags" \
-        --env TARGET_CC="$target_cc" \
-        "$CTR_IMAGE" \
-        cargo build --all "${features_build[@]}" \
-        --target-dir "$CTR_CLH_CARGO_TARGET" \
-        "${cargo_args[@]}" && say "Binaries placed under $CLH_CARGO_TARGET/$target/$build"
+	# shellcheck disable=SC2153
+	rustflags="$RUSTFLAGS"
+	target_cc=""
+	if [ "$arch" = "aarch64" ] && [ "$libc" = "musl" ]; then
+		rustflags="$rustflags -C link-args=-Wl,-Bstatic -C link-args=-lc"
+	fi
+
+	$DOCKER_RUNTIME run \
+		--platform "linux/$platform_arch" \
+		--user "$(id -u):$(id -g)" \
+		--workdir "$CTR_CLH_ROOT_DIR" \
+		--rm \
+		--volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+		${exported_volumes:+$exported_volumes} \
+		--env RUSTFLAGS="$rustflags" \
+		--env TARGET_CC="$target_cc" \
+		"$CTR_IMAGE" \
+		cargo build --all "${features_build[@]}" \
+		--target-dir "$CTR_CLH_CARGO_TARGET" \
+		"${cargo_args[@]}" && say "Binaries placed under $CLH_CARGO_TARGET/$target/$build"
 }
 
 cmd_clean() {
-    cargo_args=("$@")
+	cargo_args=("$@")
 
-    ensure_build_dir
-    ensure_latest_ctr
+	ensure_build_dir
+	ensure_latest_ctr
 
-    $DOCKER_RUNTIME run \
-        --user "$(id -u):$(id -g)" \
-        --workdir "$CTR_CLH_ROOT_DIR" \
-        --rm \
-        --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-        ${exported_volumes:+$exported_volumes} \
-        "$CTR_IMAGE" \
-        cargo clean \
-        --target-dir "$CTR_CLH_CARGO_TARGET" \
-        "${cargo_args[@]}"
+	$DOCKER_RUNTIME run \
+		--user "$(id -u):$(id -g)" \
+		--workdir "$CTR_CLH_ROOT_DIR" \
+		--rm \
+		--volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+		${exported_volumes:+$exported_volumes} \
+		"$CTR_IMAGE" \
+		cargo clean \
+		--target-dir "$CTR_CLH_CARGO_TARGET" \
+		"${cargo_args[@]}"
 }
 
 cmd_tests() {
-    unit=false
-    integration=false
-    integration_vfio=false
-    integration_windows=false
-    integration_live_migration=false
-    integration_rate_limiter=false
-    integration_cvm=false
-    metrics=false
-    coverage=false
-    libc="gnu"
-    arg_vols=""
-    hypervisor="kvm"
-    exported_device="/dev/kvm"
-    while [ $# -gt 0 ]; do
-        case "$1" in
-        "-h" | "--help") {
-            cmd_help
-            exit 1
-        } ;;
-        "--unit") { unit=true; } ;;
-        "--integration") { integration=true; } ;;
-        "--integration-vfio") { integration_vfio=true; } ;;
-        "--integration-windows") { integration_windows=true; } ;;
-        "--integration-live-migration") { integration_live_migration=true; } ;;
-        "--integration-rate-limiter") { integration_rate_limiter=true; } ;;
-        "--integration-cvm") { integration_cvm=true; } ;;
-        "--metrics") { metrics=true; } ;;
-        "--coverage") { coverage=true; } ;;
-        "--libc")
-            shift
-            [[ "$1" =~ ^(musl|gnu)$ ]] ||
-                die "Invalid libc: $1. Valid options are \"musl\" and \"gnu\"."
-            libc="$1"
-            ;;
-        "--volumes")
-            shift
-            arg_vols="$1"
-            ;;
-        "--hypervisor")
-            shift
-            hypervisor="$1"
-            ;;
-        "--all") {
-            unit=true
-            integration=true
-        } ;;
-        "--") {
-            shift
-            break
-        } ;;
-        *)
-            die "Unknown tests argument: $1. Please use --help for help."
-            ;;
-        esac
-        shift
-    done
-    if [[ ! ("$hypervisor" = "kvm" || "$hypervisor" = "mshv") ]]; then
-        die "Hypervisor value must be kvm or mshv"
-    fi
+	unit=false
+	integration=false
+	integration_vfio=false
+	integration_windows=false
+	integration_live_migration=false
+	integration_rate_limiter=false
+	integration_cvm=false
+	metrics=false
+	coverage=false
+	libc="gnu"
+	arg_vols=""
+	hypervisor="kvm"
+	exported_device="/dev/kvm"
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		"-h" | "--help") {
+			cmd_help
+			exit 1
+		} ;;
+		"--unit") { unit=true; } ;;
+		"--integration") { integration=true; } ;;
+		"--integration-vfio") { integration_vfio=true; } ;;
+		"--integration-windows") { integration_windows=true; } ;;
+		"--integration-live-migration") { integration_live_migration=true; } ;;
+		"--integration-rate-limiter") { integration_rate_limiter=true; } ;;
+		"--integration-cvm") { integration_cvm=true; } ;;
+		"--metrics") { metrics=true; } ;;
+		"--coverage") { coverage=true; } ;;
+		"--libc")
+			shift
+			[[ "$1" =~ ^(musl|gnu)$ ]] ||
+				die "Invalid libc: $1. Valid options are \"musl\" and \"gnu\"."
+			libc="$1"
+			;;
+		"--volumes")
+			shift
+			arg_vols="$1"
+			;;
+		"--hypervisor")
+			shift
+			hypervisor="$1"
+			;;
+		"--all") {
+			unit=true
+			integration=true
+		} ;;
+		"--") {
+			shift
+			break
+		} ;;
+		*)
+			die "Unknown tests argument: $1. Please use --help for help."
+			;;
+		esac
+		shift
+	done
+	if [[ ! ("$hypervisor" = "kvm" || "$hypervisor" = "mshv") ]]; then
+		die "Hypervisor value must be kvm or mshv"
+	fi
 
-    if [[ "$hypervisor" = "mshv" ]]; then
-        exported_device="/dev/mshv"
-    fi
+	if [[ "$hypervisor" = "mshv" ]]; then
+		exported_device="/dev/mshv"
+	fi
 
-    if [ ! -e "${exported_device}" ]; then
-        die "${exported_device} does not exist on the system"
-    fi
+	if [ ! -e "${exported_device}" ]; then
+		die "${exported_device} does not exist on the system"
+	fi
 
-    set -- '--hypervisor' "$hypervisor" "$@"
+	set -- '--hypervisor' "$hypervisor" "$@"
 
-    ensure_build_dir
-    ensure_latest_ctr
+	ensure_build_dir
+	ensure_latest_ctr
 
-    process_volumes_args
-    target="$(uname -m)-unknown-linux-${libc}"
+	process_volumes_args
+	host_arch="$(host_rust_arch)"
+	target="$(build_target_triple "$host_arch" "$libc")"
 
-    rustflags="$RUSTFLAGS"
-    target_cc=""
-    if [ "$(uname -m)" = "aarch64" ] && [ "$libc" = "musl" ]; then
-        rustflags="$rustflags -C link-args=-Wl,-Bstatic -C link-args=-lc"
-    fi
+	rustflags="$RUSTFLAGS"
+	target_cc=""
+	if [ "$host_arch" = "aarch64" ] && [ "$libc" = "musl" ]; then
+		rustflags="$rustflags -C link-args=-Wl,-Bstatic -C link-args=-lc"
+	fi
 
-    if [[ "$unit" = true ]]; then
-        say "Running unit tests for $target..."
-        $DOCKER_RUNTIME run \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --device $exported_device \
-            --device /dev/net/tun \
-            --cap-add net_admin \
-            --security-opt seccomp=unconfined \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env LLVM_PROFILE_FILE="$LLVM_PROFILE_FILE" \
-            "$CTR_IMAGE" \
-            ./scripts/run_unit_tests.sh "$@" || fix_dir_perms $? || exit $?
-    fi
+	if [[ "$unit" = true ]]; then
+		say "Running unit tests for $target..."
+		$DOCKER_RUNTIME run \
+			--workdir "$CTR_CLH_ROOT_DIR" \
+			--rm \
+			--device $exported_device \
+			--device /dev/net/tun \
+			--cap-add net_admin \
+			--security-opt seccomp=unconfined \
+			--volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+			${exported_volumes:+$exported_volumes} \
+			--env BUILD_TARGET="$target" \
+			--env RUSTFLAGS="$rustflags" \
+			--env TARGET_CC="$target_cc" \
+			--env LLVM_PROFILE_FILE="$LLVM_PROFILE_FILE" \
+			"$CTR_IMAGE" \
+			./scripts/run_unit_tests.sh "$@" || fix_dir_perms $? || exit $?
+	fi
 
-    if [ "$integration" = true ]; then
-        say "Running integration tests for $target..."
-        $DOCKER_RUNTIME run \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
-            --env LLVM_PROFILE_FILE="$LLVM_PROFILE_FILE" \
-            "$CTR_IMAGE" \
-            dbus-run-session ./scripts/run_integration_tests_"$(uname -m)".sh "$@" || fix_dir_perms $? || exit $?
-    fi
+	if [ "$integration" = true ]; then
+		say "Running integration tests for $target..."
+		$DOCKER_RUNTIME run \
+			--workdir "$CTR_CLH_ROOT_DIR" \
+			--rm \
+			--privileged \
+			--security-opt seccomp=unconfined \
+			--ipc=host \
+			--net="$CTR_CLH_NET" \
+			--mount type=tmpfs,destination=/tmp \
+			--volume /dev:/dev \
+			--volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+			${exported_volumes:+$exported_volumes} \
+			--volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+			--env USER="root" \
+			--env BUILD_TARGET="$target" \
+			--env RUSTFLAGS="$rustflags" \
+			--env TARGET_CC="$target_cc" \
+			--env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
+			--env LLVM_PROFILE_FILE="$LLVM_PROFILE_FILE" \
+			"$CTR_IMAGE" \
+			dbus-run-session ./scripts/run_integration_tests_"$host_arch".sh "$@" || fix_dir_perms $? || exit $?
+	fi
 
-    if [ "$integration_cvm" = true ]; then
-        mkdir -p "$DEST_IGVM_FILES_PATH"
-        copy_igvm_files "$SRC_IGVM_FILES_PATH" "$DEST_IGVM_FILES_PATH"
-        say "Running CVM integration tests for $target..."
-        $DOCKER_RUNTIME run \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            --volume "$DEST_IGVM_FILES_PATH:$CTR_IGVM_FILES_PATH" \
-            ${exported_volumes:+"$exported_volumes"} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
-            --env LLVM_PROFILE_FILE="$LLVM_PROFILE_FILE" \
-            "$CTR_IMAGE" \
-            ./scripts/run_integration_tests_cvm.sh "$@" || fix_dir_perms $? || exit $?
-    fi
+	if [ "$integration_cvm" = true ]; then
+		mkdir -p "$DEST_IGVM_FILES_PATH"
+		copy_igvm_files "$SRC_IGVM_FILES_PATH" "$DEST_IGVM_FILES_PATH"
+		say "Running CVM integration tests for $target..."
+		$DOCKER_RUNTIME run \
+			--workdir "$CTR_CLH_ROOT_DIR" \
+			--rm \
+			--privileged \
+			--security-opt seccomp=unconfined \
+			--ipc=host \
+			--net="$CTR_CLH_NET" \
+			--mount type=tmpfs,destination=/tmp \
+			--volume /dev:/dev \
+			--volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+			--volume "$DEST_IGVM_FILES_PATH:$CTR_IGVM_FILES_PATH" \
+			${exported_volumes:+"$exported_volumes"} \
+			--volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+			--env USER="root" \
+			--env BUILD_TARGET="$target" \
+			--env RUSTFLAGS="$rustflags" \
+			--env TARGET_CC="$target_cc" \
+			--env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
+			--env LLVM_PROFILE_FILE="$LLVM_PROFILE_FILE" \
+			"$CTR_IMAGE" \
+			./scripts/run_integration_tests_cvm.sh "$@" || fix_dir_perms $? || exit $?
+	fi
 
-    if [ "$integration_vfio" = true ]; then
-        say "Running VFIO integration tests for $target..."
-        $DOCKER_RUNTIME run \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
-            "$CTR_IMAGE" \
-            ./scripts/run_integration_tests_vfio.sh "$@" || fix_dir_perms $? || exit $?
-    fi
+	if [ "$integration_vfio" = true ]; then
+		say "Running VFIO integration tests for $target..."
+		$DOCKER_RUNTIME run \
+			--workdir "$CTR_CLH_ROOT_DIR" \
+			--rm \
+			--privileged \
+			--security-opt seccomp=unconfined \
+			--ipc=host \
+			--net="$CTR_CLH_NET" \
+			--mount type=tmpfs,destination=/tmp \
+			--volume /dev:/dev \
+			--volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+			${exported_volumes:+$exported_volumes} \
+			--volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+			--env USER="root" \
+			--env BUILD_TARGET="$target" \
+			--env RUSTFLAGS="$rustflags" \
+			--env TARGET_CC="$target_cc" \
+			--env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
+			"$CTR_IMAGE" \
+			./scripts/run_integration_tests_vfio.sh "$@" || fix_dir_perms $? || exit $?
+	fi
 
-    if [ "$integration_windows" = true ]; then
-        say "Running Windows integration tests for $target..."
-        $DOCKER_RUNTIME run \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
-            "$CTR_IMAGE" \
-            ./scripts/run_integration_tests_windows_"$(uname -m)".sh "$@" || fix_dir_perms $? || exit $?
-    fi
+	if [ "$integration_windows" = true ]; then
+		say "Running Windows integration tests for $target..."
+		$DOCKER_RUNTIME run \
+			--workdir "$CTR_CLH_ROOT_DIR" \
+			--rm \
+			--privileged \
+			--security-opt seccomp=unconfined \
+			--ipc=host \
+			--net="$CTR_CLH_NET" \
+			--mount type=tmpfs,destination=/tmp \
+			--volume /dev:/dev \
+			--volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+			${exported_volumes:+$exported_volumes} \
+			--volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+			--env USER="root" \
+			--env BUILD_TARGET="$target" \
+			--env RUSTFLAGS="$rustflags" \
+			--env TARGET_CC="$target_cc" \
+			--env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
+			"$CTR_IMAGE" \
+			./scripts/run_integration_tests_windows_"$host_arch".sh "$@" || fix_dir_perms $? || exit $?
+	fi
 
-    if [ "$integration_live_migration" = true ]; then
-        say "Running 'live migration' integration tests for $target..."
-        $DOCKER_RUNTIME run \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
-            --env LLVM_PROFILE_FILE="$LLVM_PROFILE_FILE" \
-            --env MIGRATABLE_VERSION="$MIGRATABLE_VERSION" \
-            "$CTR_IMAGE" \
-            ./scripts/run_integration_tests_live_migration.sh "$@" || fix_dir_perms $? || exit $?
-    fi
+	if [ "$integration_live_migration" = true ]; then
+		say "Running 'live migration' integration tests for $target..."
+		$DOCKER_RUNTIME run \
+			--workdir "$CTR_CLH_ROOT_DIR" \
+			--rm \
+			--privileged \
+			--security-opt seccomp=unconfined \
+			--ipc=host \
+			--net="$CTR_CLH_NET" \
+			--mount type=tmpfs,destination=/tmp \
+			--volume /dev:/dev \
+			--volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+			${exported_volumes:+$exported_volumes} \
+			--volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+			--env USER="root" \
+			--env BUILD_TARGET="$target" \
+			--env RUSTFLAGS="$rustflags" \
+			--env TARGET_CC="$target_cc" \
+			--env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
+			--env LLVM_PROFILE_FILE="$LLVM_PROFILE_FILE" \
+			--env MIGRATABLE_VERSION="$MIGRATABLE_VERSION" \
+			"$CTR_IMAGE" \
+			./scripts/run_integration_tests_live_migration.sh "$@" || fix_dir_perms $? || exit $?
+	fi
 
-    if [ "$integration_rate_limiter" = true ]; then
-        say "Running 'rate limiter' integration tests for $target..."
-        $DOCKER_RUNTIME run \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
-            "$CTR_IMAGE" \
-            ./scripts/run_integration_tests_rate_limiter.sh "$@" || fix_dir_perms $? || exit $?
-    fi
+	if [ "$integration_rate_limiter" = true ]; then
+		say "Running 'rate limiter' integration tests for $target..."
+		$DOCKER_RUNTIME run \
+			--workdir "$CTR_CLH_ROOT_DIR" \
+			--rm \
+			--privileged \
+			--security-opt seccomp=unconfined \
+			--ipc=host \
+			--net="$CTR_CLH_NET" \
+			--mount type=tmpfs,destination=/tmp \
+			--volume /dev:/dev \
+			--volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+			${exported_volumes:+$exported_volumes} \
+			--volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+			--env USER="root" \
+			--env BUILD_TARGET="$target" \
+			--env RUSTFLAGS="$rustflags" \
+			--env TARGET_CC="$target_cc" \
+			--env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
+			"$CTR_IMAGE" \
+			./scripts/run_integration_tests_rate_limiter.sh "$@" || fix_dir_perms $? || exit $?
+	fi
 
-    if [ "$metrics" = true ]; then
-        say "Generating performance metrics for $target..."
-        $DOCKER_RUNTIME run \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env RUST_BACKTRACE="${RUST_BACKTRACE}" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
-            "$CTR_IMAGE" \
-            ./scripts/run_metrics.sh "$@" || fix_dir_perms $? || exit $?
-    fi
+	if [ "$metrics" = true ]; then
+		say "Generating performance metrics for $target..."
+		$DOCKER_RUNTIME run \
+			--workdir "$CTR_CLH_ROOT_DIR" \
+			--rm \
+			--privileged \
+			--security-opt seccomp=unconfined \
+			--ipc=host \
+			--net="$CTR_CLH_NET" \
+			--mount type=tmpfs,destination=/tmp \
+			--volume /dev:/dev \
+			--volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+			${exported_volumes:+$exported_volumes} \
+			--volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+			--env USER="root" \
+			--env BUILD_TARGET="$target" \
+			--env RUSTFLAGS="$rustflags" \
+			--env TARGET_CC="$target_cc" \
+			--env RUST_BACKTRACE="${RUST_BACKTRACE}" \
+			--env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
+			"$CTR_IMAGE" \
+			./scripts/run_metrics.sh "$@" || fix_dir_perms $? || exit $?
+	fi
 
-    if [ "$coverage" = true ]; then
-        say "Generating code coverage information for $target..."
-        $DOCKER_RUNTIME run \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
-            "$CTR_IMAGE" \
-            dbus-run-session ./scripts/run_coverage.sh "$@" || fix_dir_perms $? || exit $?
-    fi
+	if [ "$coverage" = true ]; then
+		say "Generating code coverage information for $target..."
+		$DOCKER_RUNTIME run \
+			--workdir "$CTR_CLH_ROOT_DIR" \
+			--rm \
+			--privileged \
+			--security-opt seccomp=unconfined \
+			--ipc=host \
+			--net="$CTR_CLH_NET" \
+			--mount type=tmpfs,destination=/tmp \
+			--volume /dev:/dev \
+			--volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+			${exported_volumes:+$exported_volumes} \
+			--volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+			--env USER="root" \
+			--env BUILD_TARGET="$target" \
+			--env RUSTFLAGS="$rustflags" \
+			--env TARGET_CC="$target_cc" \
+			--env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
+			"$CTR_IMAGE" \
+			dbus-run-session ./scripts/run_coverage.sh "$@" || fix_dir_perms $? || exit $?
+	fi
 
-    fix_dir_perms $?
+	fix_dir_perms $?
 }
 
 build_container() {
-    ensure_build_dir
+	ensure_build_dir
 
-    BUILD_DIR=/tmp/cloud-hypervisor/container/
+	BUILD_DIR=/tmp/cloud-hypervisor/container/
 
-    mkdir -p $BUILD_DIR
-    cp "$CLH_DOCKERFILE" $BUILD_DIR
+	mkdir -p $BUILD_DIR
+	cp "$CLH_DOCKERFILE" $BUILD_DIR
 
-    [ "$(uname -m)" = "aarch64" ] && TARGETARCH="arm64"
-    [ "$(uname -m)" = "x86_64" ] && TARGETARCH="amd64"
+	if [ -n "$TARGET_CONTAINER_ARCH" ]; then
+		TARGETARCH="$(docker_platform_arch "$TARGET_CONTAINER_ARCH")"
+	else
+		TARGETARCH="$(docker_platform_arch "$(host_rust_arch)")"
+	fi
 
-    $DOCKER_RUNTIME build \
-        --target dev \
-        -t "$CTR_IMAGE" \
-        -f $BUILD_DIR/Dockerfile \
-        --build-arg TARGETARCH="$TARGETARCH" \
-        $BUILD_DIR
+	$DOCKER_RUNTIME build \
+		--target dev \
+		-t "$CTR_IMAGE" \
+		-f $BUILD_DIR/Dockerfile \
+		--build-arg TARGETARCH="$TARGETARCH" \
+		$BUILD_DIR
 }
 
 cmd_build-container() {
-    while [ $# -gt 0 ]; do
-        case "$1" in
-        "-h" | "--help") {
-            cmd_help
-            exit 1
-        } ;;
-        "--") {
-            shift
-            break
-        } ;;
-        *)
-            die "Unknown build-container argument: $1. Please use --help for help."
-            ;;
-        esac
-        shift
-    done
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		"-h" | "--help") {
+			cmd_help
+			exit 1
+		} ;;
+		"--") {
+			shift
+			break
+		} ;;
+		*)
+			die "Unknown build-container argument: $1. Please use --help for help."
+			;;
+		esac
+		shift
+	done
 
-    build_container
+	build_container
 }
 
 cmd_shell() {
-    while [ $# -gt 0 ]; do
-        case "$1" in
-        "-h" | "--help") {
-            cmd_help
-            exit 1
-        } ;;
-        "--volumes")
-            shift
-            arg_vols="$1"
-            ;;
-        "--") {
-            shift
-            break
-        } ;;
-        *) ;;
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		"-h" | "--help") {
+			cmd_help
+			exit 1
+		} ;;
+		"--volumes")
+			shift
+			arg_vols="$1"
+			;;
+		"--") {
+			shift
+			break
+		} ;;
+		*) ;;
 
-        esac
-        shift
-    done
-    ensure_build_dir
-    ensure_latest_ctr
-    process_volumes_args
+		esac
+		shift
+	done
+	ensure_build_dir
+	ensure_latest_ctr
+	process_volumes_args
 
-    # Remaining args after -- are passed as a command to bash -c.
-    # With no args, an interactive shell is started.
-    tty_args="-ti"
-    shell_args=()
-    if [ $# -gt 0 ]; then
-        tty_args=""
-        shell_args+=("-c" "$*")
-    else
-        say_warn "Starting a privileged shell prompt as root ..."
-        say_warn "WARNING: Your $CLH_ROOT_DIR folder will be bind-mounted in the container under $CTR_CLH_ROOT_DIR"
-    fi
+	# Remaining args after -- are passed as a command to bash -c.
+	# With no args, an interactive shell is started.
+	tty_args="-ti"
+	shell_args=()
+	if [ $# -gt 0 ]; then
+		tty_args=""
+		shell_args+=("-c" "$*")
+	else
+		say_warn "Starting a privileged shell prompt as root ..."
+		say_warn "WARNING: Your $CLH_ROOT_DIR folder will be bind-mounted in the container under $CTR_CLH_ROOT_DIR"
+	fi
 
-    $DOCKER_RUNTIME run \
-        $tty_args \
-        --workdir "$CTR_CLH_ROOT_DIR" \
-        --rm \
-        --privileged \
-        --security-opt seccomp=unconfined \
-        --ipc=host \
-        --net="$CTR_CLH_NET" \
-        --tmpfs /tmp:exec \
-        --volume /dev:/dev \
-        --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-        ${exported_volumes:+$exported_volumes} \
-        --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
-        --env USER="root" \
-        --entrypoint bash \
-        "$CTR_IMAGE" \
-        "${shell_args[@]}"
+	$DOCKER_RUNTIME run \
+		$tty_args \
+		--workdir "$CTR_CLH_ROOT_DIR" \
+		--rm \
+		--privileged \
+		--security-opt seccomp=unconfined \
+		--ipc=host \
+		--net="$CTR_CLH_NET" \
+		--tmpfs /tmp:exec \
+		--volume /dev:/dev \
+		--volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+		${exported_volumes:+$exported_volumes} \
+		--volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+		--env USER="root" \
+		--entrypoint bash \
+		"$CTR_IMAGE" \
+		"${shell_args[@]}"
 
-    fix_dir_perms $?
+	fix_dir_perms $?
 }
 
 if [ $# = 0 ]; then
-    cmd_help
-    say_err "Please specify command to run!"
-    exit 1
+	cmd_help
+	say_err "Please specify command to run!"
+	exit 1
 fi
 
 # Parse main command line args.
 #
 while [ $# -gt 0 ]; do
-    case "$1" in
-    -h | --help) {
-        cmd_help
-        exit 1
-    } ;;
-    --local) {
-        CTR_IMAGE_VERSION="local"
-        CTR_IMAGE="${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}"
-    } ;;
-    -*)
-        die "Unknown arg: $1. Please use \`$0 help\` for help."
-        ;;
-    *)
-        break
-        ;;
-    esac
-    shift
+	case "$1" in
+	-h | --help) {
+		cmd_help
+		exit 1
+	} ;;
+	--local) {
+		CTR_IMAGE_VERSION="local"
+		CTR_IMAGE="${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}"
+	} ;;
+	-*)
+		die "Unknown arg: $1. Please use \`$0 help\` for help."
+		;;
+	*)
+		break
+		;;
+	esac
+	shift
 done
 
 # $1 is now a command name. Check if it is a valid command and, if so,

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -12,6 +12,7 @@ mshv = ["vfio-ioctls/mshv"]
 
 [dependencies]
 hypervisor = { path = "../hypervisor" }
+log = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 thiserror = { workspace = true }
 vfio-ioctls = { workspace = true, default-features = false }

--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -12,6 +12,7 @@ use std::collections::btree_map::BTreeMap;
 use std::sync::{Arc, Barrier, Mutex, RwLock, Weak};
 use std::{convert, io, result};
 
+use log::error;
 use thiserror::Error;
 
 /// Trait for devices that respond to reads or writes in an arbitrary address space.
@@ -164,6 +165,17 @@ impl Bus {
             .iter()
             .any(|(range, _dev)| range.overlaps(base, len))
         {
+            for (range, _dev) in self.devices.read().unwrap().iter() {
+                if range.overlaps(base, len) {
+                    error!(
+                        "Bus insert overlap: requested [0x{:x}-0x{:x}] conflicts with existing [0x{:x}-0x{:x}]",
+                        base,
+                        base + len - 1,
+                        range.base,
+                        range.base + range.len - 1
+                    );
+                }
+            }
             return Err(Error::Overlap);
         }
 

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1219,6 +1219,11 @@ components:
         x_nv_gpudirect_clique:
           type: integer
           format: int8
+        x_exclude_mmap_bars:
+          type: array
+          items:
+            type: integer
+            format: int8
     TpmConfig:
       required:
         - socket

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1224,6 +1224,9 @@ components:
           items:
             type: integer
             format: int8
+        root_port:
+          type: boolean
+          default: false
     TpmConfig:
       required:
         - socket

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -144,6 +144,9 @@ pub enum Error {
     /// Missing path from device,
     #[error("Error parsing --device: path missing")]
     ParseDevicePathMissing,
+    /// Invalid excluded-mmap BAR from device
+    #[error("Error parsing --device: invalid excluded-mmap BAR index {0}")]
+    ParseDeviceExcludeMmapBarInvalid(u64),
     /// Failed parsing vsock parameters
     #[error("Error parsing --vsock")]
     ParseVsock(#[source] OptionParserError),
@@ -307,6 +310,9 @@ pub enum ValidationError {
     /// Invalid PCI segment aperture weight
     #[error("Invalid PCI segment aperture weight: {0}")]
     InvalidPciSegmentApertureWeight(u32),
+    /// Invalid VFIO excluded-mmap BAR index
+    #[error("Invalid VFIO excluded-mmap BAR index: {0}")]
+    InvalidDeviceExcludeMmapBar(u8),
     /// Invalid IOMMU address width in bits
     #[error(
         "IOMMU address width in bits ({0}) should be less than or equal to {MAX_IOMMU_ADDRESS_WIDTH_BITS}"
@@ -2221,14 +2227,17 @@ impl DebugConsoleConfig {
 impl DeviceConfig {
     pub const SYNTAX: &'static str = "Direct device assignment parameters \
     \"path=<device_path>,iommu=on|off,id=<device_id>,\
-    pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
+    pci_segment=<segment_id>,pci_device_id=<pci_slot>,\
+    x_nv_gpudirect_clique=<clique_id>,\
+    x_exclude_mmap_bars=[<bar>...]\"";
 
     pub fn parse(device: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser
             .add("path")
             .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU)
-            .add("x_nv_gpudirect_clique");
+            .add("x_nv_gpudirect_clique")
+            .add("x_exclude_mmap_bars");
         parser.parse(device).map_err(Error::ParseDevice)?;
 
         let pci_common = PciDeviceCommonConfig::parse(device)?;
@@ -2239,10 +2248,23 @@ impl DeviceConfig {
         let x_nv_gpudirect_clique = parser
             .convert::<u8>("x_nv_gpudirect_clique")
             .map_err(Error::ParseDevice)?;
+        let IntegerList(raw_x_exclude_mmap_bars) = parser
+            .convert::<IntegerList>("x_exclude_mmap_bars")
+            .map_err(Error::ParseDevice)?
+            .unwrap_or(IntegerList(Vec::new()));
+        let mut x_exclude_mmap_bars = Vec::with_capacity(raw_x_exclude_mmap_bars.len());
+        for bar in raw_x_exclude_mmap_bars {
+            // PCI devices have six standard BARs indexed 0..=5.
+            if bar > 5 {
+                return Err(Error::ParseDeviceExcludeMmapBarInvalid(bar));
+            }
+            x_exclude_mmap_bars.push(bar as u8);
+        }
         Ok(DeviceConfig {
             pci_common,
             path,
             x_nv_gpudirect_clique,
+            x_exclude_mmap_bars,
         })
     }
 
@@ -2253,6 +2275,13 @@ impl DeviceConfig {
             let vfio_p2p_dma = vm_config.platform.as_ref().is_none_or(|p| p.vfio_p2p_dma);
             if !vfio_p2p_dma {
                 return Err(ValidationError::GpuDirectCliqueRequiresP2pDma);
+            }
+        }
+
+        // PCI devices expose six BARs, so only BAR indices 0 through 5 are valid here.
+        for bar in &self.x_exclude_mmap_bars {
+            if *bar > 5 {
+                return Err(ValidationError::InvalidDeviceExcludeMmapBar(*bar));
             }
         }
 
@@ -4380,6 +4409,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             pci_common: PciDeviceCommonConfig::default(),
             path: PathBuf::from("/path/to/device"),
             x_nv_gpudirect_clique: None,
+            x_exclude_mmap_bars: Vec::new(),
         }
     }
 
@@ -4415,6 +4445,26 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             }
         );
 
+        assert_eq!(
+            DeviceConfig::parse("path=/path/to/device,x_exclude_mmap_bars=[2]")?,
+            DeviceConfig {
+                x_exclude_mmap_bars: vec![2],
+                ..device_fixture()
+            }
+        );
+
+        assert_eq!(
+            DeviceConfig::parse("path=/path/to/device,x_exclude_mmap_bars=[0,2,5]")?,
+            DeviceConfig {
+                x_exclude_mmap_bars: vec![0, 2, 5],
+                ..device_fixture()
+            }
+        );
+
+        assert!(matches!(
+            DeviceConfig::parse("path=/path/to/device,x_exclude_mmap_bars=[6]").unwrap_err(),
+            Error::ParseDeviceExcludeMmapBarInvalid(6)
+        ));
         Ok(())
     }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -26,10 +26,13 @@ use virtio_devices::block::MINIMUM_BLOCK_QUEUE_SIZE;
 use virtio_devices::vhost_user::VIRTIO_FS_TAG_LEN;
 use virtio_devices::{RateLimiterConfig, TokenBucketConfig};
 
+use arch::layout;
+
 use crate::landlock::LandlockAccess;
 use crate::vm_config::*;
 
-const MAX_NUM_PCI_SEGMENTS: u16 = 96;
+const MAX_NUM_PCI_SEGMENTS: u16 =
+    (layout::PCI_MMCONFIG_SIZE / layout::PCI_MMIO_CONFIG_SIZE_PER_SEGMENT) as u16;
 const MAX_IOMMU_ADDRESS_WIDTH_BITS: u8 = 64;
 
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
@@ -2229,7 +2232,7 @@ impl DeviceConfig {
     \"path=<device_path>,iommu=on|off,id=<device_id>,\
     pci_segment=<segment_id>,pci_device_id=<pci_slot>,\
     x_nv_gpudirect_clique=<clique_id>,\
-    x_exclude_mmap_bars=[<bar>...]\"";
+    x_exclude_mmap_bars=[<bar>...],root_port=on|off\"";
 
     pub fn parse(device: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -2237,7 +2240,8 @@ impl DeviceConfig {
             .add("path")
             .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU)
             .add("x_nv_gpudirect_clique")
-            .add("x_exclude_mmap_bars");
+            .add("x_exclude_mmap_bars")
+            .add("root_port");
         parser.parse(device).map_err(Error::ParseDevice)?;
 
         let pci_common = PciDeviceCommonConfig::parse(device)?;
@@ -2260,11 +2264,17 @@ impl DeviceConfig {
             }
             x_exclude_mmap_bars.push(bar as u8);
         }
+        let root_port = parser
+            .convert::<Toggle>("root_port")
+            .map_err(Error::ParseDevice)?
+            .unwrap_or(Toggle(false))
+            .0;
         Ok(DeviceConfig {
             pci_common,
             path,
             x_nv_gpudirect_clique,
             x_exclude_mmap_bars,
+            root_port,
         })
     }
 
@@ -4410,6 +4420,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             path: PathBuf::from("/path/to/device"),
             x_nv_gpudirect_clique: None,
             x_exclude_mmap_bars: Vec::new(),
+            root_port: false,
         }
     }
 
@@ -4465,6 +4476,14 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             DeviceConfig::parse("path=/path/to/device,x_exclude_mmap_bars=[6]").unwrap_err(),
             Error::ParseDeviceExcludeMmapBarInvalid(6)
         ));
+
+        assert_eq!(
+            DeviceConfig::parse("path=/path/to/device,root_port=on")?,
+            DeviceConfig {
+                root_port: true,
+                ..device_fixture()
+            }
+        );
         Ok(())
     }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4942,7 +4942,7 @@ impl DeviceManager {
                 // rather than MmioRegion start addresses because move_bar()
                 // updates the device's region addresses but not the
                 // DeviceManager's cloned copies.
-                let device_regions = vfio_pci_device.lock().unwrap().mmio_regions().clone();
+                let device_regions = vfio_pci_device.lock().unwrap().mmio_regions();
                 let mut mmio_regions = self.mmio_regions.lock().unwrap();
                 for device_region in &device_regions {
                     mmio_regions.retain(|x| !x.has_matching_slots(device_region));
@@ -5848,6 +5848,11 @@ impl BusDevice for DeviceManager {
 
 impl Drop for DeviceManager {
     fn drop(&mut self) {
+        // Explicitly clear the regions owned by this device to ensure
+        // that they are dropped and unmapped before the container is cleared.
+        // See eject_device() for the device hot-unplug equivalent.
+        self.mmio_regions.lock().unwrap().clear();
+
         // Wake up the DeviceManager threads (mainly virtio device workers),
         // to avoid deadlock on waiting for paused/parked worker threads.
         if let Err(e) = self.resume() {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -86,8 +86,8 @@ use libc::{
 };
 use log::{debug, error, info, warn};
 use pci::{
-    DeviceRelocation, MmioRegion, PciBarRegionType, PciBdf, PciDevice, VfioDmaMapping,
-    VfioPciDevice, VfioUserDmaMapping, VfioUserPciDevice, VfioUserPciDeviceError,
+    DeviceRelocation, MmioRegion, PciBarRegionType, PciBdf, PciBus, PciDevice, PcieRootPort,
+    VfioDmaMapping, VfioPciDevice, VfioUserDmaMapping, VfioUserPciDevice, VfioUserPciDeviceError,
 };
 use rate_limiter::group::RateLimiterGroup;
 use seccompiler::SeccompAction;
@@ -383,6 +383,10 @@ pub enum DeviceManagerError {
     /// Cannot create a VFIO PCI device
     #[error("Cannot create a VFIO PCI device")]
     VfioPciCreate(#[source] pci::VfioPciError),
+
+    /// Cannot create a synthetic PCIe root port
+    #[error("Cannot create a synthetic PCIe root port")]
+    CreatePcieRootPort(#[source] pci::PciDeviceError),
 
     /// Failed to map VFIO MMIO region.
     #[error("Failed to map VFIO MMIO region")]
@@ -750,6 +754,7 @@ pub(crate) struct AddressManager {
     device_tree: Arc<Mutex<DeviceTree>>,
     pci_mmio32_allocators: Vec<Arc<Mutex<AddressAllocator>>>,
     pci_mmio64_allocators: Vec<Arc<Mutex<AddressAllocator>>>,
+    resource_transaction: Mutex<()>,
 }
 
 impl DeviceRelocation for AddressManager {
@@ -761,6 +766,8 @@ impl DeviceRelocation for AddressManager {
         pci_dev: &mut dyn PciDevice,
         region_type: PciBarRegionType,
     ) -> std::result::Result<(), std::io::Error> {
+        let _resource_transaction_guard = self.resource_transaction.lock().unwrap();
+
         match region_type {
             PciBarRegionType::IoRegion => {
                 let mut sys_allocator = self.allocator.lock().unwrap();
@@ -776,27 +783,32 @@ impl DeviceRelocation for AddressManager {
                     .map_err(io::Error::other)?;
             }
             PciBarRegionType::Memory32BitRegion | PciBarRegionType::Memory64BitRegion => {
-                let pci_mmio_allocators = if region_type == PciBarRegionType::Memory32BitRegion {
-                    &self.pci_mmio32_allocators
-                } else {
-                    &self.pci_mmio64_allocators
-                };
-
                 // Find the specific allocator that this BAR was allocated from and use it for a new one
-                for pci_mmio_allocator_mutex in pci_mmio_allocators {
+                let mut allocator_found = false;
+                for pci_mmio_allocator_mutex in self
+                    .pci_mmio32_allocators
+                    .iter()
+                    .chain(self.pci_mmio64_allocators.iter())
+                {
                     let mut pci_mmio_allocator = pci_mmio_allocator_mutex.lock().unwrap();
 
-                    if old_base >= pci_mmio_allocator.base().0
-                        && old_base <= pci_mmio_allocator.end().0
+                    if old_base < pci_mmio_allocator.base().0
+                        || old_base > pci_mmio_allocator.end().0
                     {
-                        pci_mmio_allocator.free(GuestAddress(old_base), len as GuestUsize);
-
-                        pci_mmio_allocator
-                            .allocate(Some(GuestAddress(new_base)), len as GuestUsize, Some(len))
-                            .ok_or_else(|| io::Error::other("failed allocating new MMIO range"))?;
-
-                        break;
+                        continue;
                     }
+
+                    pci_mmio_allocator.free(GuestAddress(old_base), len as GuestUsize);
+
+                    pci_mmio_allocator
+                        .allocate(Some(GuestAddress(new_base)), len as GuestUsize, Some(len))
+                        .ok_or_else(|| io::Error::other("failed allocating new MMIO range"))?;
+                    allocator_found = true;
+                    break;
+                }
+
+                if !allocator_found {
+                    return Err(io::Error::other("failed locating existing MMIO allocator"));
                 }
 
                 // Update MMIO bus
@@ -927,8 +939,16 @@ impl Clone for PtyPair {
 }
 
 #[derive(Clone)]
+pub struct VfioRootPortDeviceHandle {
+    pub vfio_device: Arc<Mutex<VfioPciDevice>>,
+    pub root_port: Arc<Mutex<PcieRootPort>>,
+    pub secondary_bus: Arc<Mutex<PciBus>>,
+}
+
+#[derive(Clone)]
 pub enum PciDeviceHandle {
     Vfio(Arc<Mutex<VfioPciDevice>>),
+    VfioRootPort(VfioRootPortDeviceHandle),
     Virtio(Arc<Mutex<VirtioPciDevice>>),
     VfioUser(Arc<Mutex<VfioUserPciDevice>>),
 }
@@ -1201,6 +1221,87 @@ fn create_mmio_allocators(
 }
 
 impl DeviceManager {
+    fn rollback_pci_device_from_bus(
+        &mut self,
+        segment_id: u16,
+        pci_bus: &Arc<Mutex<PciBus>>,
+        pci_device: &Arc<Mutex<dyn PciDevice>>,
+        bus_device: &Arc<dyn BusDeviceSync>,
+    ) {
+        let _ = pci_device.lock().unwrap().free_bars(
+            &mut self.address_manager.allocator.lock().unwrap(),
+            &mut self.pci_segments[segment_id as usize]
+                .mem32_allocator
+                .lock()
+                .unwrap(),
+            &mut self.pci_segments[segment_id as usize]
+                .mem64_allocator
+                .lock()
+                .unwrap(),
+        );
+
+        let _ = pci_bus.lock().unwrap().remove_by_device(pci_device);
+        #[cfg(target_arch = "x86_64")]
+        let _ = self.io_bus().remove_by_device(bus_device.as_ref());
+        let _ = self.mmio_bus().remove_by_device(bus_device.as_ref());
+
+        self.bus_devices.retain(|dev| !Arc::ptr_eq(dev, bus_device));
+    }
+
+    fn cleanup_root_port_attachment(
+        &mut self,
+        segment_id: u16,
+        root_port: &Arc<Mutex<PcieRootPort>>,
+    ) {
+        let secondary_bus_number = root_port.lock().unwrap().secondary_bus_number();
+        let root_port_pci_device = Arc::clone(root_port) as Arc<Mutex<dyn PciDevice>>;
+        let root_port_bus_device = Arc::clone(root_port) as Arc<dyn BusDeviceSync>;
+
+        let _ = self.pci_segments[segment_id as usize]
+            .pci_bus
+            .lock()
+            .unwrap()
+            .remove_by_device(&root_port_pci_device);
+
+        self.pci_segments[segment_id as usize]
+            .pci_bus
+            .lock()
+            .unwrap()
+            .remove_secondary_bus(secondary_bus_number);
+
+        self.bus_devices
+            .retain(|dev| !Arc::ptr_eq(dev, &root_port_bus_device));
+    }
+
+    fn cleanup_pending_root_port_attachment(
+        &mut self,
+        segment_id: u16,
+        root_port_bdf: PciBdf,
+        root_port: &Arc<Mutex<PcieRootPort>>,
+        secondary_bus: &Arc<Mutex<PciBus>>,
+        vfio_pci_device: Option<&Arc<Mutex<VfioPciDevice>>>,
+    ) {
+        if let Some(vfio_pci_device) = vfio_pci_device {
+            let child_pci_device = Arc::clone(vfio_pci_device) as Arc<Mutex<dyn PciDevice>>;
+            let child_bus_device = Arc::clone(vfio_pci_device) as Arc<dyn BusDeviceSync>;
+
+            self.rollback_pci_device_from_bus(
+                segment_id,
+                secondary_bus,
+                &child_pci_device,
+                &child_bus_device,
+            );
+        }
+
+        self.cleanup_root_port_attachment(segment_id, root_port);
+
+        let _ = self.pci_segments[segment_id as usize]
+            .pci_bus
+            .lock()
+            .unwrap()
+            .free_device_id(root_port_bdf.device());
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         io_bus: Arc<Bus>,
@@ -1289,6 +1390,7 @@ impl DeviceManager {
             device_tree: Arc::clone(&device_tree),
             pci_mmio32_allocators,
             pci_mmio64_allocators,
+            resource_transaction: Mutex::new(()),
         });
 
         // First we create the MSI interrupt manager, the legacy one is created
@@ -3674,9 +3776,11 @@ impl DeviceManager {
         let pvmemcontrol_pci_device = Arc::new(Mutex::new(pvmemcontrol_pci_device));
         let pvmemcontrol_bus_device = Arc::new(pvmemcontrol_bus_device);
 
+        let bus_device: Arc<dyn BusDeviceSync> = pvmemcontrol_bus_device.clone();
+        let pci_device: Arc<Mutex<dyn PciDevice>> = pvmemcontrol_pci_device.clone();
         let new_resources = self.add_pci_device(
-            pvmemcontrol_bus_device.clone(),
-            pvmemcontrol_pci_device.clone(),
+            &bus_device,
+            &pci_device,
             pci_segment_id,
             pci_device_bdf,
             resources,
@@ -3865,7 +3969,7 @@ impl DeviceManager {
     fn add_passthrough_device(
         &mut self,
         device_cfg: &mut DeviceConfig,
-    ) -> DeviceManagerResult<(PciBdf, String)> {
+    ) -> DeviceManagerResult<(PciBdf, PciBdf, String)> {
         // If the passthrough device has not been created yet, it is created
         // here and stored in the DeviceManager structure for future needs.
         if self.passthrough_device.is_none() {
@@ -3920,7 +4024,7 @@ impl DeviceManager {
     fn add_vfio_device(
         &mut self,
         device_cfg: &mut DeviceConfig,
-    ) -> DeviceManagerResult<(PciBdf, String)> {
+    ) -> DeviceManagerResult<(PciBdf, PciBdf, String)> {
         let vfio_name = if let Some(id) = &device_cfg.pci_common.id {
             id.clone()
         } else {
@@ -3929,11 +4033,47 @@ impl DeviceManager {
             id
         };
 
-        let (pci_segment_id, pci_device_bdf, resources) = self.pci_resources(
-            &vfio_name,
-            device_cfg.pci_common.pci_segment,
-            device_cfg.pci_common.pci_device_id,
-        )?;
+        let (pci_segment_id, hotplug_bdf, pci_device_bdf, resources, root_port, secondary_bus) =
+            if device_cfg.root_port {
+                let root_port_bdf = self.pci_segments
+                    [device_cfg.pci_common.pci_segment as usize]
+                    .allocate_device_id(device_cfg.pci_common.pci_device_id)?;
+                let secondary_bus_num = self.pci_segments
+                    [device_cfg.pci_common.pci_segment as usize]
+                    .allocate_secondary_bus()?;
+                let secondary_bus = Arc::new(Mutex::new(PciBus::new_empty(Arc::clone(
+                    &self.address_manager,
+                )
+                    as Arc<dyn DeviceRelocation>)));
+                let root_port = Arc::new(Mutex::new(
+                    PcieRootPort::new(format!("{vfio_name}-root-port"), secondary_bus_num)
+                        .map_err(DeviceManagerError::CreatePcieRootPort)?,
+                ));
+
+                (
+                    device_cfg.pci_common.pci_segment,
+                    root_port_bdf,
+                    PciBdf::new(device_cfg.pci_common.pci_segment, secondary_bus_num, 0, 0),
+                    None,
+                    Some(root_port),
+                    Some(secondary_bus),
+                )
+            } else {
+                let (pci_segment_id, pci_device_bdf, resources) = self.pci_resources(
+                    &vfio_name,
+                    device_cfg.pci_common.pci_segment,
+                    device_cfg.pci_common.pci_device_id,
+                )?;
+
+                (
+                    pci_segment_id,
+                    pci_device_bdf,
+                    pci_device_bdf,
+                    resources,
+                    None,
+                    None,
+                )
+            };
 
         let mut needs_dma_mapping = false;
 
@@ -4067,20 +4207,97 @@ impl DeviceManager {
         .map_err(DeviceManagerError::VfioPciCreate)?;
 
         let vfio_pci_device = Arc::new(Mutex::new(vfio_pci_device));
+        let mut attached_vfio_pci_device = None;
 
-        let new_resources = self.add_pci_device(
-            vfio_pci_device.clone(),
-            vfio_pci_device.clone(),
-            pci_segment_id,
-            pci_device_bdf,
-            resources,
-        )?;
+        let new_resources = if let Some(secondary_bus) = &secondary_bus {
+            let vfio_bus_device: Arc<dyn BusDeviceSync> = vfio_pci_device.clone();
+            let vfio_pci_device_dyn: Arc<Mutex<dyn PciDevice>> = vfio_pci_device.clone();
+            match self.add_pci_device_to_bus(
+                secondary_bus,
+                &vfio_bus_device,
+                &vfio_pci_device_dyn,
+                pci_segment_id,
+                pci_device_bdf,
+                resources,
+            ) {
+                Ok(resources) => {
+                    attached_vfio_pci_device = Some(vfio_pci_device.clone());
+                    resources
+                }
+                Err(err) => {
+                    if let Some(root_port) = &root_port {
+                        self.cleanup_pending_root_port_attachment(
+                            device_cfg.pci_common.pci_segment,
+                            hotplug_bdf,
+                            root_port,
+                            secondary_bus,
+                            None,
+                        );
+                    }
+                    return Err(err);
+                }
+            }
+        } else {
+            let bus_device: Arc<dyn BusDeviceSync> = vfio_pci_device.clone();
+            let pci_device: Arc<Mutex<dyn PciDevice>> = vfio_pci_device.clone();
+            self.add_pci_device(
+                &bus_device,
+                &pci_device,
+                pci_segment_id,
+                pci_device_bdf,
+                resources,
+            )?
+        };
 
-        vfio_pci_device
-            .lock()
-            .unwrap()
-            .map_mmio_regions()
-            .map_err(DeviceManagerError::VfioMapRegion)?;
+        if let Some(root_port) = &root_port {
+            root_port.lock().unwrap().configure_windows(&new_resources);
+
+            let secondary_bus = secondary_bus.as_ref().unwrap();
+            let secondary_bus_number = root_port.lock().unwrap().secondary_bus_number();
+
+            self.pci_segments[device_cfg.pci_common.pci_segment as usize]
+                .pci_bus
+                .lock()
+                .unwrap()
+                .add_secondary_bus(secondary_bus_number, Arc::clone(secondary_bus));
+
+            let segment_pci_bus = Arc::clone(
+                &self.pci_segments[device_cfg.pci_common.pci_segment as usize].pci_bus,
+            );
+            let root_port_bus_device: Arc<dyn BusDeviceSync> = root_port.clone();
+            let root_port_pci_device: Arc<Mutex<dyn PciDevice>> = root_port.clone();
+            if let Err(err) = self.add_pci_device_to_bus(
+                &segment_pci_bus,
+                &root_port_bus_device,
+                &root_port_pci_device,
+                device_cfg.pci_common.pci_segment,
+                hotplug_bdf,
+                None,
+            ) {
+                self.cleanup_pending_root_port_attachment(
+                    device_cfg.pci_common.pci_segment,
+                    hotplug_bdf,
+                    root_port,
+                    secondary_bus,
+                    attached_vfio_pci_device.as_ref(),
+                );
+                return Err(err);
+            }
+        }
+
+        if let Err(err) = vfio_pci_device.lock().unwrap().map_mmio_regions() {
+            if let (Some(root_port), Some(secondary_bus)) = (&root_port, &secondary_bus) {
+                self.cleanup_pending_root_port_attachment(
+                    device_cfg.pci_common.pci_segment,
+                    hotplug_bdf,
+                    root_port,
+                    secondary_bus,
+                    attached_vfio_pci_device.as_ref(),
+                );
+            }
+
+            return Err(DeviceManagerError::VfioMapRegion(err));
+        }
 
         for mmio_region in vfio_pci_device.lock().unwrap().mmio_regions() {
             self.mmio_regions.lock().unwrap().push(mmio_region);
@@ -4090,8 +4307,18 @@ impl DeviceManager {
 
         // Update the device tree with correct resource information.
         node.resources = new_resources;
-        node.pci_bdf = Some(pci_device_bdf);
-        node.pci_device_handle = Some(PciDeviceHandle::Vfio(vfio_pci_device));
+        node.pci_bdf = Some(hotplug_bdf);
+        node.pci_device_handle = Some(
+            if let (Some(root_port), Some(secondary_bus)) = (root_port, secondary_bus) {
+                PciDeviceHandle::VfioRootPort(VfioRootPortDeviceHandle {
+                    vfio_device: vfio_pci_device,
+                    root_port,
+                    secondary_bus,
+                })
+            } else {
+                PciDeviceHandle::Vfio(vfio_pci_device)
+            },
+        );
 
         self.device_tree
             .lock()
@@ -4102,17 +4329,21 @@ impl DeviceManager {
         self.device_id_to_bdf
             .insert(vfio_name.clone(), pci_device_bdf);
 
-        Ok((pci_device_bdf, vfio_name))
+        Ok((pci_device_bdf, hotplug_bdf, vfio_name))
     }
 
-    fn add_pci_device(
+    fn add_pci_device_to_bus(
         &mut self,
-        bus_device: Arc<dyn BusDeviceSync>,
-        pci_device: Arc<Mutex<dyn PciDevice>>,
+        pci_bus: &Arc<Mutex<PciBus>>,
+        bus_device: &Arc<dyn BusDeviceSync>,
+        pci_device: &Arc<Mutex<dyn PciDevice>>,
         segment_id: u16,
         bdf: PciBdf,
         resources: Option<Vec<Resource>>,
     ) -> DeviceManagerResult<Vec<Resource>> {
+        let mut pci_bus = pci_bus.lock().unwrap();
+        let _resource_transaction_guard = self.address_manager.resource_transaction.lock().unwrap();
+
         let bars = pci_device
             .lock()
             .unwrap()
@@ -4130,25 +4361,72 @@ impl DeviceManager {
             )
             .map_err(DeviceManagerError::AllocateBars)?;
 
-        let mut pci_bus = self.pci_segments[segment_id as usize]
-            .pci_bus
-            .lock()
-            .unwrap();
+        let bar_descriptions: Vec<String> = bars
+            .iter()
+            .map(|bar| {
+                format!(
+                    "bar{}@0x{:x}/0x{:x}:{:?}:prefetch={}",
+                    bar.idx(),
+                    bar.addr(),
+                    bar.size(),
+                    bar.region_type(),
+                    bool::from(bar.prefetchable())
+                )
+            })
+            .collect();
 
-        pci_bus
-            .add_device(bdf.device(), pci_device)
-            .map_err(DeviceManagerError::AddPciDevice)?;
+        if let Err(err) = pci_bus.add_device(bdf.device(), Arc::clone(pci_device)) {
+            drop(pci_bus);
+            let _ = pci_device.lock().unwrap().free_bars(
+                &mut self.address_manager.allocator.lock().unwrap(),
+                &mut self.pci_segments[segment_id as usize]
+                    .mem32_allocator
+                    .lock()
+                    .unwrap(),
+                &mut self.pci_segments[segment_id as usize]
+                    .mem64_allocator
+                    .lock()
+                    .unwrap(),
+            );
+            return Err(DeviceManagerError::AddPciDevice(err));
+        }
 
-        self.bus_devices.push(Arc::clone(&bus_device));
+        self.bus_devices.push(Arc::clone(bus_device));
 
-        pci_bus
-            .register_mapping(
-                bus_device,
-                self.address_manager.io_bus.as_ref(),
-                self.address_manager.mmio_bus.as_ref(),
-                bars.clone(),
-            )
-            .map_err(DeviceManagerError::AddPciDevice)?;
+        if let Err(err) = pci_bus.register_mapping(
+            Arc::clone(bus_device),
+            self.address_manager.io_bus.as_ref(),
+            self.address_manager.mmio_bus.as_ref(),
+            bars.clone(),
+        ) {
+            error!(
+                "Failed to register PCI BAR mappings for {}:{} with [{}]: {}",
+                segment_id,
+                bdf,
+                bar_descriptions.join(", "),
+                err
+            );
+
+            let _ = pci_bus.remove_by_device(pci_device);
+            drop(pci_bus);
+
+            self.bus_devices
+                .retain(|dev| !Arc::ptr_eq(dev, bus_device));
+
+            let _ = pci_device.lock().unwrap().free_bars(
+                &mut self.address_manager.allocator.lock().unwrap(),
+                &mut self.pci_segments[segment_id as usize]
+                    .mem32_allocator
+                    .lock()
+                    .unwrap(),
+                &mut self.pci_segments[segment_id as usize]
+                    .mem64_allocator
+                    .lock()
+                    .unwrap(),
+            );
+
+            return Err(DeviceManagerError::AddPciDevice(err));
+        }
 
         let mut new_resources = Vec::new();
         for bar in bars {
@@ -4164,13 +4442,32 @@ impl DeviceManager {
         Ok(new_resources)
     }
 
+    fn add_pci_device(
+        &mut self,
+        bus_device: &Arc<dyn BusDeviceSync>,
+        pci_device: &Arc<Mutex<dyn PciDevice>>,
+        segment_id: u16,
+        bdf: PciBdf,
+        resources: Option<Vec<Resource>>,
+    ) -> DeviceManagerResult<Vec<Resource>> {
+        let pci_bus = Arc::clone(&self.pci_segments[segment_id as usize].pci_bus);
+        self.add_pci_device_to_bus(
+            &pci_bus,
+            bus_device,
+            pci_device,
+            segment_id,
+            bdf,
+            resources,
+        )
+    }
+
     fn add_vfio_devices(&mut self) -> DeviceManagerResult<Vec<PciBdf>> {
         let mut iommu_attached_device_ids = Vec::new();
         let mut devices = self.config.lock().unwrap().devices.take();
 
         if let Some(device_list_cfg) = &mut devices {
             for device_cfg in device_list_cfg.iter_mut() {
-                let (device_id, _) = self.add_passthrough_device(device_cfg)?;
+                let (device_id, _, _) = self.add_passthrough_device(device_cfg)?;
                 if device_cfg.pci_common.iommu && self.iommu_device.is_some() {
                     iommu_attached_device_ids.push(device_id);
                 }
@@ -4258,9 +4555,11 @@ impl DeviceManager {
 
         let vfio_user_pci_device = Arc::new(Mutex::new(vfio_user_pci_device));
 
+        let bus_device: Arc<dyn BusDeviceSync> = vfio_user_pci_device.clone();
+        let pci_device: Arc<Mutex<dyn PciDevice>> = vfio_user_pci_device.clone();
         let new_resources = self.add_pci_device(
-            vfio_user_pci_device.clone(),
-            vfio_user_pci_device.clone(),
+            &bus_device,
+            &pci_device,
             pci_segment_id,
             pci_device_bdf,
             resources,
@@ -4425,9 +4724,11 @@ impl DeviceManager {
             .map_err(DeviceManagerError::VirtioDevice)?,
         ));
 
+        let bus_device: Arc<dyn BusDeviceSync> = virtio_pci_device.clone();
+        let pci_device: Arc<Mutex<dyn PciDevice>> = virtio_pci_device.clone();
         let new_resources = self.add_pci_device(
-            virtio_pci_device.clone(),
-            virtio_pci_device.clone(),
+            &bus_device,
+            &pci_device,
             pci_segment_id,
             pci_device_bdf,
             resources,
@@ -4470,9 +4771,11 @@ impl DeviceManager {
 
         let pvpanic_device = Arc::new(Mutex::new(pvpanic_device));
 
+        let bus_device: Arc<dyn BusDeviceSync> = pvpanic_device.clone();
+        let pci_device: Arc<Mutex<dyn PciDevice>> = pvpanic_device.clone();
         let new_resources = self.add_pci_device(
-            pvpanic_device.clone(),
-            pvpanic_device.clone(),
+            &bus_device,
+            &pci_device,
             pci_segment_id,
             pci_device_bdf,
             resources,
@@ -4515,9 +4818,11 @@ impl DeviceManager {
             )
             .map_err(DeviceManagerError::IvshmemCreate)?,
         ));
+        let bus_device: Arc<dyn BusDeviceSync> = ivshmem_device.clone();
+        let pci_device: Arc<Mutex<dyn PciDevice>> = ivshmem_device.clone();
         let new_resources = self.add_pci_device(
-            ivshmem_device.clone(),
-            ivshmem_device.clone(),
+            &bus_device,
+            &pci_device,
             pci_segment_id,
             pci_device_bdf,
             resources,
@@ -4741,11 +5046,13 @@ impl DeviceManager {
             return Err(DeviceManagerError::InvalidIommuHotplug);
         }
 
-        let (bdf, device_name) = self.add_passthrough_device(device_cfg)?;
+        let (bdf, hotplug_bdf, device_name) = self.add_passthrough_device(device_cfg)?;
 
-        // Update the PCIU bitmap
+        // Update the PCIU bitmap. For root-port hotplug, notify on the
+        // root port's slot (hotplug_bdf) rather than the device's own BDF
+        // on the secondary bus. In the non-root-port case these are equal.
         self.pci_segments[device_cfg.pci_common.pci_segment as usize].pci_devices_up |=
-            1 << bdf.device();
+            1 << hotplug_bdf.device();
 
         Ok(PciDeviceInfo {
             id: device_name,
@@ -4933,77 +5240,104 @@ impl DeviceManager {
             iommu_attached = true;
         }
 
-        let (pci_device, bus_device, virtio_device, remove_dma_handler) = match pci_device_handle {
-            // VirtioMemMappingSource::Container cleanup is handled by
-            // cleanup_vfio_ops when the last VFIO device is removed.
-            PciDeviceHandle::Vfio(vfio_pci_device) => {
-                // Remove this device's MMIO regions from the DeviceManager's
-                // mmio_regions list. We match on UserMemoryRegion slot numbers
-                // rather than MmioRegion start addresses because move_bar()
-                // updates the device's region addresses but not the
-                // DeviceManager's cloned copies.
-                let device_regions = vfio_pci_device.lock().unwrap().mmio_regions();
-                let mut mmio_regions = self.mmio_regions.lock().unwrap();
-                for device_region in &device_regions {
-                    mmio_regions.retain(|x| !x.has_matching_slots(device_region));
-                }
+        let (pci_device, bus_device, virtio_device, remove_dma_handler, pci_bus, root_port_handle) =
+            match pci_device_handle {
+                // VirtioMemMappingSource::Container cleanup is handled by
+                // cleanup_vfio_ops when the last VFIO device is removed.
+                PciDeviceHandle::Vfio(vfio_pci_device) => {
+                    // Remove this device's MMIO regions from the DeviceManager's
+                    // mmio_regions list. We match on UserMemoryRegion slot numbers
+                    // rather than MmioRegion start addresses because move_bar()
+                    // updates the device's region addresses but not the
+                    // DeviceManager's cloned copies.
+                    let device_regions = vfio_pci_device.lock().unwrap().mmio_regions();
+                    let mut mmio_regions = self.mmio_regions.lock().unwrap();
+                    for device_region in &device_regions {
+                        mmio_regions.retain(|x| !x.has_matching_slots(device_region));
+                    }
 
-                (
-                    Arc::clone(&vfio_pci_device) as Arc<Mutex<dyn PciDevice>>,
-                    Arc::clone(&vfio_pci_device) as Arc<dyn BusDeviceSync>,
-                    None as Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>,
-                    false,
-                )
-            }
-            PciDeviceHandle::Virtio(virtio_pci_device) => {
-                let dev = virtio_pci_device.lock().unwrap();
-                let bar_addr = dev.config_bar_addr();
-                for (event, addr) in dev.ioeventfds(bar_addr) {
-                    let io_addr = IoEventAddress::Mmio(addr);
-                    self.address_manager
-                        .vm
-                        .unregister_ioevent(event, &io_addr)
-                        .map_err(|e| DeviceManagerError::UnRegisterIoevent(e.into()))?;
+                    (
+                        Arc::clone(&vfio_pci_device) as Arc<Mutex<dyn PciDevice>>,
+                        Arc::clone(&vfio_pci_device) as Arc<dyn BusDeviceSync>,
+                        None as Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>,
+                        false,
+                        Arc::clone(&self.pci_segments[pci_segment_id as usize].pci_bus),
+                        None,
+                    )
                 }
+                PciDeviceHandle::VfioRootPort(root_port_handle) => {
+                    let device_regions = root_port_handle
+                        .vfio_device
+                        .lock()
+                        .unwrap()
+                        .mmio_regions();
+                    let mut mmio_regions = self.mmio_regions.lock().unwrap();
+                    for device_region in &device_regions {
+                        mmio_regions.retain(|x| !x.has_matching_slots(device_region));
+                    }
 
-                if let Some(dma_handler) = dev.dma_handler()
-                    && !iommu_attached
-                {
-                    for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
-                        for region in zone.regions() {
-                            let iova = region.start_addr().0;
-                            let size = region.len();
-                            dma_handler
-                                .unmap(iova, size)
-                                .map_err(DeviceManagerError::VirtioDmaUnmap)?;
+                    (
+                        Arc::clone(&root_port_handle.vfio_device) as Arc<Mutex<dyn PciDevice>>,
+                        Arc::clone(&root_port_handle.vfio_device) as Arc<dyn BusDeviceSync>,
+                        None as Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>,
+                        false,
+                        Arc::clone(&root_port_handle.secondary_bus),
+                        Some(root_port_handle),
+                    )
+                }
+                PciDeviceHandle::Virtio(virtio_pci_device) => {
+                    let dev = virtio_pci_device.lock().unwrap();
+                    let bar_addr = dev.config_bar_addr();
+                    for (event, addr) in dev.ioeventfds(bar_addr) {
+                        let io_addr = IoEventAddress::Mmio(addr);
+                        self.address_manager
+                            .vm
+                            .unregister_ioevent(event, &io_addr)
+                            .map_err(|e| DeviceManagerError::UnRegisterIoevent(e.into()))?;
+                    }
+
+                    if let Some(dma_handler) = dev.dma_handler()
+                        && !iommu_attached
+                    {
+                        for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
+                            for region in zone.regions() {
+                                let iova = region.start_addr().0;
+                                let size = region.len();
+                                dma_handler
+                                    .unmap(iova, size)
+                                    .map_err(DeviceManagerError::VirtioDmaUnmap)?;
+                            }
                         }
                     }
-                }
 
-                (
-                    Arc::clone(&virtio_pci_device) as Arc<Mutex<dyn PciDevice>>,
-                    Arc::clone(&virtio_pci_device) as Arc<dyn BusDeviceSync>,
-                    Some(dev.virtio_device()),
-                    dev.dma_handler().is_some() && !iommu_attached,
-                )
-            }
-            PciDeviceHandle::VfioUser(vfio_user_pci_device) => {
-                let mut dev = vfio_user_pci_device.lock().unwrap();
-                for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
-                    for region in zone.regions() {
-                        dev.dma_unmap(region)
-                            .map_err(DeviceManagerError::VfioUserDmaUnmap)?;
+                    (
+                        Arc::clone(&virtio_pci_device) as Arc<Mutex<dyn PciDevice>>,
+                        Arc::clone(&virtio_pci_device) as Arc<dyn BusDeviceSync>,
+                        Some(dev.virtio_device()),
+                        dev.dma_handler().is_some() && !iommu_attached,
+                        Arc::clone(&self.pci_segments[pci_segment_id as usize].pci_bus),
+                        None,
+                    )
+                }
+                PciDeviceHandle::VfioUser(vfio_user_pci_device) => {
+                    let mut dev = vfio_user_pci_device.lock().unwrap();
+                    for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
+                        for region in zone.regions() {
+                            dev.dma_unmap(region)
+                                .map_err(DeviceManagerError::VfioUserDmaUnmap)?;
+                        }
                     }
-                }
 
-                (
-                    Arc::clone(&vfio_user_pci_device) as Arc<Mutex<dyn PciDevice>>,
-                    Arc::clone(&vfio_user_pci_device) as Arc<dyn BusDeviceSync>,
-                    None as Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>,
-                    true,
-                )
-            }
-        };
+                    (
+                        Arc::clone(&vfio_user_pci_device) as Arc<Mutex<dyn PciDevice>>,
+                        Arc::clone(&vfio_user_pci_device) as Arc<dyn BusDeviceSync>,
+                        None as Option<Arc<Mutex<dyn virtio_devices::VirtioDevice>>>,
+                        true,
+                        Arc::clone(&self.pci_segments[pci_segment_id as usize].pci_bus),
+                        None,
+                    )
+                }
+            };
 
         if remove_dma_handler {
             for virtio_mem_device in self.virtio_mem_devices.iter() {
@@ -5034,12 +5368,39 @@ impl DeviceManager {
             .map_err(DeviceManagerError::FreePciBars)?;
 
         // Remove the device from the PCI bus
-        self.pci_segments[pci_segment_id as usize]
-            .pci_bus
+        pci_bus
             .lock()
             .unwrap()
             .remove_by_device(&pci_device)
             .map_err(DeviceManagerError::RemoveDeviceFromPciBus)?;
+
+        if let Some(root_port_handle) = root_port_handle {
+            let secondary_bus_number = root_port_handle
+                .root_port
+                .lock()
+                .unwrap()
+                .secondary_bus_number();
+            let root_port_pci_device =
+                Arc::clone(&root_port_handle.root_port) as Arc<Mutex<dyn PciDevice>>;
+            let root_port_bus_device =
+                Arc::clone(&root_port_handle.root_port) as Arc<dyn BusDeviceSync>;
+
+            self.pci_segments[pci_segment_id as usize]
+                .pci_bus
+                .lock()
+                .unwrap()
+                .remove_by_device(&root_port_pci_device)
+                .map_err(DeviceManagerError::RemoveDeviceFromPciBus)?;
+
+            self.pci_segments[pci_segment_id as usize]
+                .pci_bus
+                .lock()
+                .unwrap()
+                .remove_secondary_bus(secondary_bus_number);
+
+            self.bus_devices
+                .retain(|dev| !Arc::ptr_eq(dev, &root_port_bus_device));
+        }
 
         #[cfg(target_arch = "x86_64")]
         // Remove the device from the IO bus

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4061,6 +4061,7 @@ impl DeviceManager {
             memory_manager.lock().unwrap().memory_slot_allocator(),
             vm_migration::snapshot_from_id(self.snapshot.as_ref(), vfio_name.as_str()),
             device_cfg.x_nv_gpudirect_clique,
+            device_cfg.x_exclude_mmap_bars.clone(),
             device_cfg.path.clone(),
         )
         .map_err(DeviceManagerError::VfioPciCreate)?;

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -49,6 +49,7 @@ pub(crate) struct PciSegment {
 
     pub(crate) mem32_allocator: Arc<Mutex<AddressAllocator>>,
     pub(crate) mem64_allocator: Arc<Mutex<AddressAllocator>>,
+    pub(crate) next_secondary_bus: u8,
 }
 
 impl PciSegment {
@@ -102,6 +103,7 @@ impl PciSegment {
             start_of_mem64_area,
             end_of_mem64_area,
             pci_irq_slots: *pci_irq_slots,
+            next_secondary_bus: 1,
         };
 
         info!(
@@ -195,6 +197,16 @@ impl PciSegment {
         ))
     }
 
+    pub(crate) fn allocate_secondary_bus(&mut self) -> DeviceManagerResult<u8> {
+        if u64::from(self.next_secondary_bus) >= layout::PCI_BUSES_PER_SEGMENT {
+            return Err(DeviceManagerError::NoPciBus);
+        }
+
+        let bus = self.next_secondary_bus;
+        self.next_secondary_bus += 1;
+        Ok(bus)
+    }
+
     pub fn reserve_legacy_interrupts_for_pci_devices(
         address_manager: &Arc<AddressManager>,
         pci_irq_slots: &mut [u8; 32],
@@ -266,6 +278,7 @@ impl PciSegment {
             start_of_mem64_area,
             end_of_mem64_area,
             pci_irq_slots: *pci_irq_slots,
+            next_secondary_bus: 1,
         };
 
         info!(
@@ -457,7 +470,10 @@ impl Aml for PciSegment {
             aml::Name::new(
                 "_CRS".into(),
                 &aml::ResourceTemplate::new(vec![
-                    &aml::AddressSpace::new_bus_number(0x0u16, 0x0u16),
+                    &aml::AddressSpace::new_bus_number(
+                        0x0u16,
+                        (layout::PCI_BUSES_PER_SEGMENT - 1) as u16,
+                    ),
                     #[cfg(target_arch = "x86_64")]
                     &aml::IO::new(0xcf8, 0xcf8, 1, 0x8),
                     &aml::Memory32Fixed::new(
@@ -489,7 +505,10 @@ impl Aml for PciSegment {
             aml::Name::new(
                 "_CRS".into(),
                 &aml::ResourceTemplate::new(vec![
-                    &aml::AddressSpace::new_bus_number(0x0u16, 0x0u16),
+                    &aml::AddressSpace::new_bus_number(
+                        0x0u16,
+                        (layout::PCI_BUSES_PER_SEGMENT - 1) as u16,
+                    ),
                     &aml::Memory32Fixed::new(
                         true,
                         self.mmio_config_address as u32,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -616,6 +616,8 @@ pub struct DeviceConfig {
     pub x_nv_gpudirect_clique: Option<u8>,
     #[serde(default)]
     pub x_exclude_mmap_bars: Vec<u8>,
+    #[serde(default)]
+    pub root_port: bool,
 }
 
 impl ApplyLandlock for DeviceConfig {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -614,6 +614,8 @@ pub struct DeviceConfig {
     pub path: PathBuf,
     #[serde(default)]
     pub x_nv_gpudirect_clique: Option<u8>,
+    #[serde(default)]
+    pub x_exclude_mmap_bars: Vec<u8>,
 }
 
 impl ApplyLandlock for DeviceConfig {


### PR DESCRIPTION
This PR adds optional PCIe root-port topology for VFIO passthrough devices. The goal is to make assigned GPUs show up behind PCIe root ports and secondary buses, matching the topology that NVLink-aware drivers and tooling expect when discovering peer GPUs.

Without this, passthrough devices are attached directly to the PCI root bus. That works for basic assignment, but it does not give the guest enough PCIe hierarchy to model GPU-to-GPU relationships correctly. With `root_port=on`, each VFIO device can be placed behind a synthetic PCIe root port, so the guest sees a downstream device on its own bus while hotplug still happens through the root-port slot.

Main pieces:

- Add a `PcieRootPort` device with PCIe capability support.
- Track and expose secondary PCI buses per segment.
- Wire `root_port=on` through config parsing, OpenAPI, VFIO device creation, hotplug, and hot-unplug.
- Update ACPI bus resources so guests can discover downstream buses.
- Make PCI resource registration and rollback safer when attaching devices through root ports.
- Add supporting tests and cleanup around VFIO MMIO region lifetime and bus mapping diagnostics.

In practice, this lets guests discover the assigned GPUs in a topology that allows NVLink to initialize correctly.