### PR TITLE
vmm, hypervisor: Add support for embedding kernel hashes to a CVM's launch digest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +529,15 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "darling"
@@ -597,6 +621,17 @@ dependencies = [
  "serde",
  "serde_json",
  "thousands",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
 ]
 
 [[package]]
@@ -993,6 +1028,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hypervisor"
 version = "0.1.0"
 dependencies = [
@@ -1009,6 +1053,7 @@ dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
+ "linux-loader",
  "log",
  "mshv-bindings",
  "mshv-ioctls",
@@ -1016,7 +1061,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sha2",
  "thiserror",
+ "uuid",
  "vfio-ioctls",
  "vm-memory",
  "vmm-sys-util",
@@ -2011,6 +2058,17 @@ name = "serial_buffer"
 version = "0.1.0"
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,6 +2301,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uds_windows"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,6 +1062,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
+ "tempfile",
  "thiserror",
  "uuid",
  "vfio-ioctls",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -25,6 +25,7 @@ igvm_defs = { workspace = true, optional = true }
 kvm-bindings = { workspace = true, optional = true, features = ["serde"] }
 kvm-ioctls = { workspace = true, optional = true }
 libc = { workspace = true }
+linux-loader = { workspace = true, features = ["bzimage"] }
 log = { workspace = true }
 mshv-bindings = { workspace = true, features = [
   "fam-wrappers",
@@ -37,7 +38,9 @@ serde_json = { workspace = true }
 serde_with = { workspace = true, default-features = false, features = [
   "macros",
 ] }
+sha2 = "0.11.0"
 thiserror = { workspace = true }
+uuid = { workspace = true }
 vfio-ioctls = { workspace = true, default-features = false }
 vm-memory = { workspace = true, features = [
   "backend-atomic",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -67,6 +67,7 @@ version = "1.21.0"
 
 [dev-dependencies]
 env_logger = { workspace = true }
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -32,7 +32,7 @@ use crate::arch::x86::{
 use crate::kvm::{Cap, Kvm, KvmError, KvmResult};
 
 #[cfg(feature = "sev_snp")]
-pub(crate) mod sev;
+pub mod sev;
 
 ///
 /// Check KVM extension for Linux

--- a/hypervisor/src/kvm/x86_64/sev.rs
+++ b/hypervisor/src/kvm/x86_64/sev.rs
@@ -117,7 +117,7 @@ impl MeasuredBootInfo {
         // https://github.com/virtee/sev-snp-measure/blob/main/sevsnpmeasure/sev_hashes.py#L71-L74
         let cmdline_digest: [u8; 32] = Sha256::digest(self.cmdline.as_bytes_with_nul()).into();
 
-        // If no initrd is provided, we will simply hash over an empty buffer, mimicing
+        // If no initrd is provided, we will simply hash over an empty buffer, mimicking
         // QEMU's behavior: https://gitlab.com/qemu-project/qemu/-/blob/master/target/i386/sev.c#L2387
         let initrd_digest: [u8; 32] = if let Some(initramfs) = &self.initramfs {
             let mut initramfs = initramfs.try_clone().map_err(Self::measured_boot_io)?;

--- a/hypervisor/src/kvm/x86_64/sev.rs
+++ b/hypervisor/src/kvm/x86_64/sev.rs
@@ -3,16 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::fs::OpenOptions;
+use core::mem::size_of;
+
+use std::ffi::CString;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Cursor, Read, Seek, SeekFrom};
+
 use std::os::fd::{AsRawFd, OwnedFd};
-use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::fs::{FileExt, OpenOptionsExt};
 use std::path::Path;
 
 use igvm_defs::SnpPolicy;
 use kvm_bindings::kvm_sev_cmd;
 use kvm_ioctls::VmFd;
+use linux_loader::bootparam::boot_params;
 use log::{debug, error, info};
+use sha2::{Digest, Sha256};
+use uuid::{Uuid, uuid};
+use vm_memory::ByteValued;
 use vmm_sys_util::errno;
+use zerocopy::{Immutable, IntoBytes};
 
 pub(crate) type Result<T> = std::result::Result<T, errno::Error>;
 
@@ -31,6 +41,158 @@ pub const GPA_METADATA_SHIFT_OFFSET: u32 = 12;
 
 // SNP in VMSA - linux/arch/x86/include/asm/svm.h
 const SVM_SEV_FEAT_SNP_ACTIVE: u64 = 1 << 0;
+
+// https://github.com/tianocore/edk2/blob/f98662c5e35b6ab60f46ee4350fa0e6eab0497cf/OvmfPkg/Include/Fdf/MemFd.fdf.inc#L89-L93
+pub const SEV_HASH_BLOCK_ADDRESS: u64 = 0x10c00;
+pub const SEV_HASH_BLOCK_SIZE: usize = 0x400;
+const SHA256_HASH_SIZE: usize = 32;
+
+// Measured hashes table definitions. These match the definitions found in
+// QEMU's implementation: https://gitlab.com/qemu-project/qemu/-/blob/master/target/i386/sev.c#L68
+#[repr(C, packed)]
+#[derive(IntoBytes, Immutable)]
+struct SevHashTableEntry {
+    pub guid: [u8; 16],
+    pub len: u16,
+    pub hash: [u8; SHA256_HASH_SIZE],
+}
+
+#[repr(C, packed)]
+#[derive(IntoBytes, Immutable)]
+struct SevHashTable {
+    pub guid: [u8; 16],
+    pub len: u16,
+    pub cmdline: SevHashTableEntry,
+    pub initrd: SevHashTableEntry,
+    pub kernel: SevHashTableEntry,
+}
+
+const SEV_HASH_TABLE_PADDING: usize =
+    size_of::<SevHashTable>().next_multiple_of(16) - size_of::<SevHashTable>();
+
+#[derive(IntoBytes, Immutable)]
+pub struct PaddedSevHashTable {
+    #[allow(dead_code)]
+    hash_table: SevHashTable,
+    #[allow(dead_code)]
+    padding: [u8; SEV_HASH_TABLE_PADDING],
+}
+
+// These GUIDs are defined in both EDK2 and QEMU:
+// https://github.com/tianocore/edk2/blob/master/OvmfPkg/AmdSev/BlobVerifierLibSevHashes/BlobVerifierSevHashes.c#L36-L43
+// https://gitlab.com/qemu-project/qemu/-/blob/master/target/i386/sev.c#L2344-2360
+const SEV_HASH_TABLE_GUID: Uuid = uuid!("9438d606-4f22-4cc9-b479-a793d411fd21");
+const SEV_KERNEL_HASH_GUID: Uuid = uuid!("4de79437-abd2-427f-b835-d5b172d2045b");
+const SEV_INITRD_HASH_GUID: Uuid = uuid!("44baf731-3a2f-4bd7-9af1-41e29169781d");
+const SEV_CMDLINE_HASH_GUID: Uuid = uuid!("97d02dd8-bd20-4c94-aa78-e7714d36ab2a");
+
+pub struct MeasuredBootInfo {
+    pub kernel: File,
+    // QEMU also makes initrd optional in the hash table
+    pub initramfs: Option<File>,
+    pub cmdline: CString,
+}
+
+impl MeasuredBootInfo {
+    fn measured_boot_io(err: io::Error) -> errno::Error {
+        errno::Error::new(err.raw_os_error().unwrap_or(libc::EINVAL))
+    }
+
+    fn sha256_reader<R: Read>(mut reader: R) -> Result<[u8; 32]> {
+        let mut hasher = Sha256::new();
+        let mut chunk = [0u8; 8192];
+        loop {
+            let bytes_read = reader.read(&mut chunk).map_err(Self::measured_boot_io)?;
+            if bytes_read == 0 {
+                break;
+            }
+            hasher.update(&chunk[..bytes_read]);
+        }
+
+        Ok(hasher.finalize().into())
+    }
+
+    pub fn build_hash_block(&self) -> Result<[u8; SEV_HASH_BLOCK_SIZE]> {
+        // Current tooling appends a NUL byte at the end of cmdlines:
+        // https://github.com/virtee/sev-snp-measure/blob/main/sevsnpmeasure/sev_hashes.py#L71-L74
+        let cmdline_digest: [u8; 32] = Sha256::digest(self.cmdline.as_bytes_with_nul()).into();
+
+        // If no initrd is provided, we will simply hash over an empty buffer, mimicing
+        // QEMU's behavior: https://gitlab.com/qemu-project/qemu/-/blob/master/target/i386/sev.c#L2387
+        let initrd_digest: [u8; 32] = if let Some(initramfs) = &self.initramfs {
+            let mut initramfs = initramfs.try_clone().map_err(Self::measured_boot_io)?;
+            initramfs
+                .seek(SeekFrom::Start(0))
+                .map_err(Self::measured_boot_io)?;
+            Self::sha256_reader(initramfs)?
+        } else {
+            Self::sha256_reader(Cursor::new([]))?
+        };
+
+        // The kernel components are split up into a setup section and the actual kernel data,
+        // so split them up to avoid double counting, assuming this is a bzImage Linux kernel
+        let mut setup_header = vec![0u8; size_of::<boot_params>()];
+        self.kernel
+            .read_exact_at(&mut setup_header, 0)
+            .map_err(Self::measured_boot_io)?;
+
+        let kernel_start = {
+            // Matches QEMU's way of finding the kernel start/setup start
+            // https://gitlab.com/qemu-project/qemu/-/blob/master/hw/i386/x86-common.c#L903
+            let bp = boot_params::from_mut_slice(&mut setup_header).unwrap();
+            let setup_sects = if bp.hdr.setup_sects == 0 {
+                4
+            } else {
+                bp.hdr.setup_sects
+            };
+            (u64::from(setup_sects) + 1) * 512
+        };
+        let setup_len = kernel_start as usize;
+        let mut setup_data = vec![0u8; setup_len];
+        if setup_len <= setup_header.len() {
+            setup_data.copy_from_slice(&setup_header[..setup_len]);
+        } else {
+            self.kernel
+                .read_exact_at(&mut setup_data, 0)
+                .map_err(Self::measured_boot_io)?;
+            setup_data[..setup_header.len()].copy_from_slice(&setup_header);
+        }
+
+        let mut kernel = self.kernel.try_clone().map_err(Self::measured_boot_io)?;
+        kernel
+            .seek(SeekFrom::Start(kernel_start))
+            .map_err(Self::measured_boot_io)?;
+        let kernel_digest = Self::sha256_reader(Cursor::new(setup_data).chain(kernel))?;
+
+        let table = PaddedSevHashTable {
+            hash_table: SevHashTable {
+                guid: SEV_HASH_TABLE_GUID.to_bytes_le(),
+                len: size_of::<SevHashTable>() as u16,
+                cmdline: SevHashTableEntry {
+                    guid: SEV_CMDLINE_HASH_GUID.to_bytes_le(),
+                    len: size_of::<SevHashTableEntry>() as u16,
+                    hash: cmdline_digest,
+                },
+                initrd: SevHashTableEntry {
+                    guid: SEV_INITRD_HASH_GUID.to_bytes_le(),
+                    len: size_of::<SevHashTableEntry>() as u16,
+                    hash: initrd_digest,
+                },
+                kernel: SevHashTableEntry {
+                    guid: SEV_KERNEL_HASH_GUID.to_bytes_le(),
+                    len: size_of::<SevHashTableEntry>() as u16,
+                    hash: kernel_digest,
+                },
+            },
+            padding: [0; SEV_HASH_TABLE_PADDING],
+        };
+
+        let mut hash_block = [0u8; SEV_HASH_BLOCK_SIZE];
+        // The remainder of the page is zeroed to ensure measurements are reliably calculated
+        hash_block[..size_of::<PaddedSevHashTable>()].copy_from_slice(table.as_bytes());
+        Ok(hash_block)
+    }
+}
 
 fn sev_op(vm: &VmFd, sev_cmd: &mut kvm_sev_cmd, name: &str) -> Result<()> {
     let ret = vm.encrypt_op_sev(sev_cmd);

--- a/hypervisor/src/kvm/x86_64/sev.rs
+++ b/hypervisor/src/kvm/x86_64/sev.rs
@@ -360,3 +360,156 @@ impl SevFd {
         sev_op(vm, &mut sev_cmd, "KVM_SEV_SNP_LAUNCH_FINISH")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn make_tempfile(data: &[u8]) -> File {
+        let mut f = tempfile::tempfile().unwrap();
+        f.write_all(data).unwrap();
+        f
+    }
+
+    fn make_fake_kernel(setup_sects: u8, kernel_payload: &[u8]) -> File {
+        // Refer to the Linux documentation for the format of a bzImage
+        // https://github.com/torvalds/linux/blob/2e68039281932e6dc37718a1ea7cbb8e2cda42e6/Documentation/arch/x86/boot.rst#memory-layout
+        let effective_sects = if setup_sects == 0 { 4 } else { setup_sects };
+        let setup_len = (usize::from(effective_sects) + 1) * 512;
+        let header_size = size_of::<boot_params>();
+        let file_len = std::cmp::max(setup_len, header_size) + kernel_payload.len();
+
+        let mut buf = vec![0u8; file_len];
+        let bp = boot_params::from_mut_slice(&mut buf[..header_size]).unwrap();
+        bp.hdr.setup_sects = setup_sects;
+        // Place kernel payload right after the setup region, matching bzImage layout
+        buf[setup_len..setup_len + kernel_payload.len()].copy_from_slice(kernel_payload);
+
+        make_tempfile(&buf)
+    }
+
+    #[test]
+    fn hash_block_deterministic() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(1, b"KERNEL_DATA"),
+            initramfs: None,
+            cmdline: CString::new("console=ttyS0").unwrap(),
+        };
+        let block1 = info.build_hash_block().unwrap();
+        let block2 = info.build_hash_block().unwrap();
+        assert_eq!(block1, block2);
+    }
+
+    #[test]
+    fn hash_block_cmdline_includes_nul() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(1, b"K"),
+            initramfs: None,
+            cmdline: CString::new("test").unwrap(),
+        };
+        let block = info.build_hash_block().unwrap();
+        let expected: [u8; 32] = Sha256::digest(b"test\0").into();
+        // cmdline entry starts after table guid (16) + table len (2)
+        // entry hash is at: entry guid (16) + entry len (2) = 18 bytes into entry
+        // Then need to skip over the table entry's guid and len
+        let cmdline_hash_offset = 2 * (size_of::<[u8; 16]>() + size_of::<u16>());
+        assert_eq!(
+            &block[cmdline_hash_offset..cmdline_hash_offset + 32],
+            &expected
+        );
+    }
+
+    #[test]
+    fn hash_block_no_initrd_hashes_empty() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(1, b"K"),
+            initramfs: None,
+            cmdline: CString::new("").unwrap(),
+        };
+        let block = info.build_hash_block().unwrap();
+        let expected: [u8; 32] = Sha256::digest([]).into();
+
+        // Skip over the cmdline table entry
+        let initrd_hash_offset =
+            2 * (size_of::<[u8; 16]>() + size_of::<u16>()) + size_of::<SevHashTableEntry>();
+        assert_eq!(
+            &block[initrd_hash_offset..initrd_hash_offset + 32],
+            &expected
+        );
+    }
+
+    #[test]
+    fn hash_block_with_initrd() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(1, b"K"),
+            initramfs: Some(make_tempfile(b"INITRD_CONTENTS")),
+            cmdline: CString::new("").unwrap(),
+        };
+        let block = info.build_hash_block().unwrap();
+        let expected: [u8; 32] = Sha256::digest(b"INITRD_CONTENTS").into();
+        let initrd_hash_offset =
+            2 * (size_of::<[u8; 16]>() + size_of::<u16>()) + size_of::<SevHashTableEntry>();
+        assert_eq!(
+            &block[initrd_hash_offset..initrd_hash_offset + 32],
+            &expected
+        );
+    }
+
+    #[test]
+    fn hash_block_setup_sects_zero_defaults_to_four() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(0, b"PAYLOAD"),
+            initramfs: None,
+            cmdline: CString::new("root=/dev/sda").unwrap(),
+        };
+        info.build_hash_block().unwrap();
+    }
+
+    #[test]
+    fn hash_block_guid_placement() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(1, b"K"),
+            initramfs: None,
+            cmdline: CString::new("x").unwrap(),
+        };
+        let block = info.build_hash_block().unwrap();
+        assert_eq!(&block[0..16], SEV_HASH_TABLE_GUID.to_bytes_le());
+        assert_eq!(&block[18..34], SEV_CMDLINE_HASH_GUID.to_bytes_le());
+        let initrd_guid_offset =
+            size_of::<[u8; 16]>() + size_of::<u16>() + size_of::<SevHashTableEntry>();
+        assert_eq!(
+            &block[initrd_guid_offset..initrd_guid_offset + 16],
+            SEV_INITRD_HASH_GUID.to_bytes_le()
+        );
+        let kernel_guid_offset = initrd_guid_offset + size_of::<SevHashTableEntry>();
+        assert_eq!(
+            &block[kernel_guid_offset..kernel_guid_offset + 16],
+            SEV_KERNEL_HASH_GUID.to_bytes_le()
+        );
+    }
+
+    #[test]
+    fn hash_block_struct_sizes() {
+        // Use the sizes explicitly to ensure we don't mess up the layout
+        assert_eq!(size_of::<SevHashTableEntry>(), 16 + 2 + 32);
+        assert_eq!(
+            size_of::<SevHashTable>(),
+            16 + 2 + 3 * size_of::<SevHashTableEntry>()
+        );
+        assert_eq!(size_of::<PaddedSevHashTable>() % 16, 0);
+        assert!(size_of::<PaddedSevHashTable>() <= SEV_HASH_BLOCK_SIZE);
+    }
+
+    #[test]
+    fn hash_block_remainder_is_zeroed() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(1, b"K"),
+            initramfs: None,
+            cmdline: CString::new("").unwrap(),
+        };
+        let block = info.build_hash_block().unwrap();
+        let table_end = size_of::<PaddedSevHashTable>();
+        assert!(block[table_end..].iter().all(|&b| b == 0));
+    }
+}

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -651,6 +651,10 @@ pub fn load_igvm(
                 let area = parameter_areas
                     .get_mut(parameter_area_index)
                     .expect("igvmfile should be valid");
+                let page_count = match area {
+                    ParameterAreaState::Allocated { max_size, .. } => *max_size / HV_PAGE_SIZE,
+                    ParameterAreaState::Inserted => panic!("igvmfile is invalid, multiple insert"),
+                };
                 match area {
                     ParameterAreaState::Allocated { data, max_size } => {
                         #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
@@ -681,11 +685,13 @@ pub fn load_igvm(
                     ParameterAreaState::Inserted => panic!("igvmfile is invalid, multiple insert"),
                 }
                 *area = ParameterAreaState::Inserted;
-                gpas.push(GpaPages {
-                    gpa: *gpa,
-                    page_type: page_types.unmeasured,
-                    page_size: page_types.isolated_page_size_4kb,
-                });
+                for page_index in 0..page_count {
+                    gpas.push(GpaPages {
+                        gpa: *gpa + page_index * HV_PAGE_SIZE,
+                        page_type: page_types.unmeasured,
+                        page_size: page_types.isolated_page_size_4kb,
+                    });
+                }
             }
             IgvmDirectiveHeader::ErrorRange { .. } => {
                 todo!("Error Range not supported")
@@ -730,14 +736,12 @@ pub fn load_igvm(
 
         let mut now = Instant::now();
 
-        // Sort the gpas to group them by the page type
-        gpas.sort_by_key(|a| a.gpa);
-
         let gpas_grouped = gpas
             .iter()
             .fold(Vec::<Vec<GpaPages>>::new(), |mut acc, gpa| {
                 if let Some(last_vec) = acc.last_mut()
                     && last_vec[0].page_type == gpa.page_type
+                    && last_vec[0].page_size == gpa.page_size
                 {
                     last_vec.push(*gpa);
                     return acc;
@@ -746,8 +750,9 @@ pub fn load_igvm(
                 acc
             });
 
-        // Import the pages as a group(by page type) of PFNs to reduce the
-        // hypercall.
+        // Preserve the original IGVM import order for SNP launch updates.
+        // The launch digest is order-sensitive, so only coalesce adjacent pages
+        // that already share the same page type and size.
         for group in gpas_grouped.iter() {
             info!(
                 "Importing {} page{}",

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -38,7 +38,7 @@ use crate::igvm::loader::Loader;
 use crate::igvm::{BootPageAcceptance, HV_PAGE_SIZE, IgvmLoadedInfo, StartupMemoryType};
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 
-#[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+#[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
 use hypervisor::kvm::x86_64::sev::{MeasuredBootInfo, SEV_HASH_BLOCK_ADDRESS, SEV_HASH_BLOCK_SIZE};
 
 #[cfg(feature = "sev_snp")]
@@ -97,10 +97,10 @@ pub enum Error {
     MissingIgvm,
     #[error("Error applying VMSA to vCPU registers: {0}")]
     SetVmsa(#[source] crate::cpu::Error),
-    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
     #[error("Error building SEV-SNP measured boot hash block")]
     MeasuredBoot(#[source] vmm_sys_util::errno::Error),
-    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
     #[error(
         "igvmfile inserts unmeasured parameter area [0x{region_start:x}, 0x{region_end:x}) over SEV-SNP kernel hashes region [0x{hash_start:x}, 0x{hash_end:x})"
     )]
@@ -242,7 +242,7 @@ pub fn load_igvm(
     memory_manager: Arc<Mutex<MemoryManager>>,
     cpu_manager: Arc<Mutex<CpuManager>>,
     cmdline: &str,
-    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))] measured_boot: Option<
+    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))] measured_boot: Option<
         MeasuredBootInfo,
     >,
     #[cfg(feature = "sev_snp")] host_data: &Option<String>,
@@ -297,7 +297,7 @@ pub fn load_igvm(
     let mut loader = Loader::new(memory);
 
     let mut parameter_areas: HashMap<u32, ParameterAreaState> = HashMap::new();
-    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
     let measured_boot_hash_block = measured_boot
         .as_ref()
         .map(|measured_boot| {
@@ -306,11 +306,11 @@ pub fn load_igvm(
                 .map_err(Error::MeasuredBoot)
         })
         .transpose()?;
-    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
     let measured_boot_hash_page_base = SEV_HASH_BLOCK_ADDRESS / HV_PAGE_SIZE;
-    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
     let measured_boot_hash_offset = (SEV_HASH_BLOCK_ADDRESS % HV_PAGE_SIZE) as usize;
-    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
     let mut measured_boot_hash_block_inserted = measured_boot_hash_block.is_none();
 
     for header in igvm_file.directives() {
@@ -339,10 +339,10 @@ pub fn load_igvm(
                             });
                             BootPageAcceptance::ExclusiveUnmeasured
                         } else {
-                            #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+                            #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
                             let has_measured_boot_table = measured_boot_hash_block.is_some()
                                 && gpa / HV_PAGE_SIZE == measured_boot_hash_page_base;
-                            #[cfg(not(all(feature = "sev_snp", target_arch = "x86_64")))]
+                            #[cfg(not(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64")))]
                             let has_measured_boot_table = false;
                             let page_type = if data.is_empty() && !has_measured_boot_table {
                                 page_types.zero
@@ -465,7 +465,7 @@ pub fn load_igvm(
                         .map_err(Error::Loader)?;
                     imported_page = true;
                 }
-                #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+                #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
                 if !imported_page
                     && measured_boot_hash_block.is_some()
                     && gpa / HV_PAGE_SIZE == measured_boot_hash_page_base
@@ -657,7 +657,7 @@ pub fn load_igvm(
                 };
                 match area {
                     ParameterAreaState::Allocated { data, max_size } => {
-                        #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+                        #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
                         if measured_boot_hash_block.is_some() {
                             let region_end = *gpa + *max_size;
                             let hash_end = SEV_HASH_BLOCK_ADDRESS + SEV_HASH_BLOCK_SIZE as u64;
@@ -702,7 +702,7 @@ pub fn load_igvm(
         }
     }
 
-    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
     if let Some(hash_block) = measured_boot_hash_block.as_ref()
         && !measured_boot_hash_block_inserted
     {

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -118,6 +118,8 @@ const KVM_SNP_PAGE_TYPE_NORMAL: u32 = 1;
 #[cfg(feature = "kvm")]
 const KVM_SNP_PAGE_TYPE_VMSA: u32 = 2;
 #[cfg(feature = "kvm")]
+const KVM_SNP_PAGE_TYPE_ZERO: u32 = 3;
+#[cfg(feature = "kvm")]
 const KVM_SNP_PAGE_TYPE_UNMEASURED: u32 = 4;
 #[cfg(feature = "kvm")]
 const KVM_SNP_PAGE_TYPE_SECRETS: u32 = 5;
@@ -128,6 +130,7 @@ const KVM_SNP_PAGE_TYPE_CPUID: u32 = 6;
 struct PageTypeConfig {
     isolated_page_size_4kb: u32,
     normal: u32,
+    zero: u32,
     unmeasured: u32,
     cpuid: u32,
     secrets: u32,
@@ -250,6 +253,7 @@ pub fn load_igvm(
         HypervisorType::Mshv => PageTypeConfig {
             isolated_page_size_4kb: mshv_bindings::hv_isolated_page_size_HV_ISOLATED_PAGE_SIZE_4KB,
             normal: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_NORMAL,
+            zero: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_NORMAL,
             unmeasured: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_UNMEASURED,
             cpuid: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_NORMAL,
             secrets: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_UNMEASURED,
@@ -259,6 +263,7 @@ pub fn load_igvm(
         HypervisorType::Kvm => PageTypeConfig {
             isolated_page_size_4kb: HV_PAGE_SIZE as u32,
             normal: KVM_SNP_PAGE_TYPE_NORMAL,
+            zero: KVM_SNP_PAGE_TYPE_ZERO,
             unmeasured: KVM_SNP_PAGE_TYPE_UNMEASURED,
             cpuid: KVM_SNP_PAGE_TYPE_CPUID,
             secrets: KVM_SNP_PAGE_TYPE_SECRETS,
@@ -334,9 +339,19 @@ pub fn load_igvm(
                             });
                             BootPageAcceptance::ExclusiveUnmeasured
                         } else {
+                            #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+                            let has_measured_boot_table = measured_boot_hash_block.is_some()
+                                && gpa / HV_PAGE_SIZE == measured_boot_hash_page_base;
+                            #[cfg(not(all(feature = "sev_snp", target_arch = "x86_64")))]
+                            let has_measured_boot_table = false;
+                            let page_type = if data.is_empty() && !has_measured_boot_table {
+                                page_types.zero
+                            } else {
+                                page_types.normal
+                            };
                             gpas.push(GpaPages {
                                 gpa: *gpa,
-                                page_type: page_types.normal,
+                                page_type,
                                 page_size: page_types.isolated_page_size_4kb,
                             });
                             BootPageAcceptance::Exclusive

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -242,9 +242,8 @@ pub fn load_igvm(
     memory_manager: Arc<Mutex<MemoryManager>>,
     cpu_manager: Arc<Mutex<CpuManager>>,
     cmdline: &str,
-    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))] measured_boot: Option<
-        MeasuredBootInfo,
-    >,
+    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+    measured_boot: Option<MeasuredBootInfo>,
     #[cfg(feature = "sev_snp")] host_data: &Option<String>,
 ) -> Result<Box<IgvmLoadedInfo>, Error> {
     let hypervisor_type = cpu_manager.lock().unwrap().hypervisor_type();
@@ -339,10 +338,18 @@ pub fn load_igvm(
                             });
                             BootPageAcceptance::ExclusiveUnmeasured
                         } else {
-                            #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+                            #[cfg(all(
+                                feature = "sev_snp",
+                                feature = "fw_cfg",
+                                target_arch = "x86_64"
+                            ))]
                             let has_measured_boot_table = measured_boot_hash_block.is_some()
                                 && gpa / HV_PAGE_SIZE == measured_boot_hash_page_base;
-                            #[cfg(not(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64")))]
+                            #[cfg(not(all(
+                                feature = "sev_snp",
+                                feature = "fw_cfg",
+                                target_arch = "x86_64"
+                            )))]
                             let has_measured_boot_table = false;
                             let page_type = if data.is_empty() && !has_measured_boot_table {
                                 page_types.zero
@@ -657,7 +664,11 @@ pub fn load_igvm(
                 };
                 match area {
                     ParameterAreaState::Allocated { data, max_size } => {
-                        #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+                        #[cfg(all(
+                            feature = "sev_snp",
+                            feature = "fw_cfg",
+                            target_arch = "x86_64"
+                        ))]
                         if measured_boot_hash_block.is_some() {
                             let region_end = *gpa + *max_size;
                             let hash_end = SEV_HASH_BLOCK_ADDRESS + SEV_HASH_BLOCK_SIZE as u64;

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -38,7 +38,12 @@ use crate::igvm::loader::Loader;
 use crate::igvm::{BootPageAcceptance, HV_PAGE_SIZE, IgvmLoadedInfo, StartupMemoryType};
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 
-#[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+#[cfg(all(
+    feature = "kvm",
+    feature = "sev_snp",
+    feature = "fw_cfg",
+    target_arch = "x86_64"
+))]
 use hypervisor::kvm::x86_64::sev::{MeasuredBootInfo, SEV_HASH_BLOCK_ADDRESS, SEV_HASH_BLOCK_SIZE};
 
 #[cfg(feature = "sev_snp")]
@@ -97,10 +102,20 @@ pub enum Error {
     MissingIgvm,
     #[error("Error applying VMSA to vCPU registers: {0}")]
     SetVmsa(#[source] crate::cpu::Error),
-    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
     #[error("Error building SEV-SNP measured boot hash block")]
     MeasuredBoot(#[source] vmm_sys_util::errno::Error),
-    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
     #[error(
         "igvmfile inserts unmeasured parameter area [0x{region_start:x}, 0x{region_end:x}) over SEV-SNP kernel hashes region [0x{hash_start:x}, 0x{hash_end:x})"
     )]
@@ -242,7 +257,12 @@ pub fn load_igvm(
     memory_manager: Arc<Mutex<MemoryManager>>,
     cpu_manager: Arc<Mutex<CpuManager>>,
     cmdline: &str,
-    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
     measured_boot: Option<MeasuredBootInfo>,
     #[cfg(feature = "sev_snp")] host_data: &Option<String>,
 ) -> Result<Box<IgvmLoadedInfo>, Error> {
@@ -296,7 +316,12 @@ pub fn load_igvm(
     let mut loader = Loader::new(memory);
 
     let mut parameter_areas: HashMap<u32, ParameterAreaState> = HashMap::new();
-    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
     let measured_boot_hash_block = measured_boot
         .as_ref()
         .map(|measured_boot| {
@@ -305,11 +330,26 @@ pub fn load_igvm(
                 .map_err(Error::MeasuredBoot)
         })
         .transpose()?;
-    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
     let measured_boot_hash_page_base = SEV_HASH_BLOCK_ADDRESS / HV_PAGE_SIZE;
-    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
     let measured_boot_hash_offset = (SEV_HASH_BLOCK_ADDRESS % HV_PAGE_SIZE) as usize;
-    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
     let mut measured_boot_hash_block_inserted = measured_boot_hash_block.is_none();
 
     for header in igvm_file.directives() {
@@ -339,6 +379,7 @@ pub fn load_igvm(
                             BootPageAcceptance::ExclusiveUnmeasured
                         } else {
                             #[cfg(all(
+                                feature = "kvm",
                                 feature = "sev_snp",
                                 feature = "fw_cfg",
                                 target_arch = "x86_64"
@@ -346,6 +387,7 @@ pub fn load_igvm(
                             let has_measured_boot_table = measured_boot_hash_block.is_some()
                                 && gpa / HV_PAGE_SIZE == measured_boot_hash_page_base;
                             #[cfg(not(all(
+                                feature = "kvm",
                                 feature = "sev_snp",
                                 feature = "fw_cfg",
                                 target_arch = "x86_64"
@@ -472,7 +514,12 @@ pub fn load_igvm(
                         .map_err(Error::Loader)?;
                     imported_page = true;
                 }
-                #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+                #[cfg(all(
+                    feature = "kvm",
+                    feature = "sev_snp",
+                    feature = "fw_cfg",
+                    target_arch = "x86_64"
+                ))]
                 if !imported_page
                     && measured_boot_hash_block.is_some()
                     && gpa / HV_PAGE_SIZE == measured_boot_hash_page_base
@@ -665,6 +712,7 @@ pub fn load_igvm(
                 match area {
                     ParameterAreaState::Allocated { data, max_size } => {
                         #[cfg(all(
+                            feature = "kvm",
                             feature = "sev_snp",
                             feature = "fw_cfg",
                             target_arch = "x86_64"
@@ -713,7 +761,12 @@ pub fn load_igvm(
         }
     }
 
-    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
     if let Some(hash_block) = measured_boot_hash_block.as_ref()
         && !measured_boot_hash_block_inserted
     {

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -38,6 +38,9 @@ use crate::igvm::loader::Loader;
 use crate::igvm::{BootPageAcceptance, HV_PAGE_SIZE, IgvmLoadedInfo, StartupMemoryType};
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 
+#[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+use hypervisor::kvm::x86_64::sev::{MeasuredBootInfo, SEV_HASH_BLOCK_ADDRESS, SEV_HASH_BLOCK_SIZE};
+
 #[cfg(feature = "sev_snp")]
 const ISOLATED_PAGE_SHIFT: u32 = 12;
 #[cfg(feature = "sev_snp")]
@@ -94,6 +97,19 @@ pub enum Error {
     MissingIgvm,
     #[error("Error applying VMSA to vCPU registers: {0}")]
     SetVmsa(#[source] crate::cpu::Error),
+    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[error("Error building SEV-SNP measured boot hash block")]
+    MeasuredBoot(#[source] vmm_sys_util::errno::Error),
+    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    #[error(
+        "igvmfile inserts unmeasured parameter area [0x{region_start:x}, 0x{region_end:x}) over SEV-SNP kernel hashes region [0x{hash_start:x}, 0x{hash_end:x})"
+    )]
+    MeasuredBootHashOverlap {
+        region_start: u64,
+        region_end: u64,
+        hash_start: u64,
+        hash_end: u64,
+    },
 }
 
 // KVM SNP page types — linux/arch/x86/include/uapi/asm/sev-guest.h
@@ -223,6 +239,9 @@ pub fn load_igvm(
     memory_manager: Arc<Mutex<MemoryManager>>,
     cpu_manager: Arc<Mutex<CpuManager>>,
     cmdline: &str,
+    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))] measured_boot: Option<
+        MeasuredBootInfo,
+    >,
     #[cfg(feature = "sev_snp")] host_data: &Option<String>,
 ) -> Result<Box<IgvmLoadedInfo>, Error> {
     let hypervisor_type = cpu_manager.lock().unwrap().hypervisor_type();
@@ -273,6 +292,21 @@ pub fn load_igvm(
     let mut loader = Loader::new(memory);
 
     let mut parameter_areas: HashMap<u32, ParameterAreaState> = HashMap::new();
+    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    let measured_boot_hash_block = measured_boot
+        .as_ref()
+        .map(|measured_boot| {
+            measured_boot
+                .build_hash_block()
+                .map_err(Error::MeasuredBoot)
+        })
+        .transpose()?;
+    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    let measured_boot_hash_page_base = SEV_HASH_BLOCK_ADDRESS / HV_PAGE_SIZE;
+    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    let measured_boot_hash_offset = (SEV_HASH_BLOCK_ADDRESS % HV_PAGE_SIZE) as usize;
+    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    let mut measured_boot_hash_block_inserted = measured_boot_hash_block.is_none();
 
     for header in igvm_file.directives() {
         debug_assert!(header.compatibility_mask().unwrap_or(mask) & mask == mask);
@@ -414,6 +448,32 @@ pub fn load_igvm(
                     loader
                         .import_pages(gpa / HV_PAGE_SIZE, 1, acceptance, new_cp.as_mut_bytes())
                         .map_err(Error::Loader)?;
+                    imported_page = true;
+                }
+                #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+                if !imported_page
+                    && measured_boot_hash_block.is_some()
+                    && gpa / HV_PAGE_SIZE == measured_boot_hash_page_base
+                {
+                    let mut page = if data.is_empty() {
+                        vec![0; HV_PAGE_SIZE as usize]
+                    } else {
+                        let mut page = data.clone();
+                        page.resize(HV_PAGE_SIZE as usize, 0);
+                        page
+                    };
+                    // If a data page from the bootloader contains this range,
+                    // we need to ensure that the measured boot table is injected
+                    // prior to importing the pages
+                    page[measured_boot_hash_offset
+                        ..measured_boot_hash_offset + SEV_HASH_BLOCK_SIZE]
+                        .copy_from_slice(
+                            &measured_boot_hash_block.as_ref().unwrap()[..SEV_HASH_BLOCK_SIZE],
+                        );
+                    loader
+                        .import_pages(gpa / HV_PAGE_SIZE, 1, acceptance, &page)
+                        .map_err(Error::Loader)?;
+                    measured_boot_hash_block_inserted = true;
                     imported_page = true;
                 }
                 if !imported_page {
@@ -577,14 +637,32 @@ pub fn load_igvm(
                     .get_mut(parameter_area_index)
                     .expect("igvmfile should be valid");
                 match area {
-                    ParameterAreaState::Allocated { data, max_size } => loader
-                        .import_pages(
-                            gpa / HV_PAGE_SIZE,
-                            *max_size / HV_PAGE_SIZE,
-                            BootPageAcceptance::ExclusiveUnmeasured,
-                            data,
-                        )
-                        .map_err(Error::Loader)?,
+                    ParameterAreaState::Allocated { data, max_size } => {
+                        #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+                        if measured_boot_hash_block.is_some() {
+                            let region_end = *gpa + *max_size;
+                            let hash_end = SEV_HASH_BLOCK_ADDRESS + SEV_HASH_BLOCK_SIZE as u64;
+                            if *gpa <= SEV_HASH_BLOCK_ADDRESS && hash_end <= region_end {
+                                // In the case of parameter being inserted where the kernel hashes table lies,
+                                // we should reject the igvmfile since it would interfere with the launch digest
+                                return Err(Error::MeasuredBootHashOverlap {
+                                    region_start: *gpa,
+                                    region_end,
+                                    hash_start: SEV_HASH_BLOCK_ADDRESS,
+                                    hash_end,
+                                });
+                            }
+                        }
+
+                        loader
+                            .import_pages(
+                                gpa / HV_PAGE_SIZE,
+                                *max_size / HV_PAGE_SIZE,
+                                BootPageAcceptance::ExclusiveUnmeasured,
+                                data,
+                            )
+                            .map_err(Error::Loader)?
+                    }
                     ParameterAreaState::Inserted => panic!("igvmfile is invalid, multiple insert"),
                 }
                 *area = ParameterAreaState::Inserted;
@@ -601,6 +679,29 @@ pub fn load_igvm(
                 todo!("Header not supported!!")
             }
         }
+    }
+
+    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    if let Some(hash_block) = measured_boot_hash_block.as_ref()
+        && !measured_boot_hash_block_inserted
+    {
+        // Fallback to adding kernel hashes after importing if the page data wasn't found previously
+        let mut page = vec![0u8; HV_PAGE_SIZE as usize];
+        page[measured_boot_hash_offset..measured_boot_hash_offset + SEV_HASH_BLOCK_SIZE]
+            .copy_from_slice(&hash_block[..SEV_HASH_BLOCK_SIZE]);
+        loader
+            .import_pages(
+                measured_boot_hash_page_base,
+                1,
+                BootPageAcceptance::Exclusive,
+                &page,
+            )
+            .map_err(Error::Loader)?;
+        gpas.push(GpaPages {
+            gpa: measured_boot_hash_page_base * HV_PAGE_SIZE,
+            page_type: page_types.normal,
+            page_size: page_types.isolated_page_size_4kb,
+        });
     }
 
     #[cfg(feature = "sev_snp")]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -115,6 +115,8 @@ use crate::{
     CPU_MANAGER_SNAPSHOT_ID, DEVICE_MANAGER_SNAPSHOT_ID, GuestMemoryMmap,
     MEMORY_MANAGER_SNAPSHOT_ID, PciDeviceInfo, cpu,
 };
+#[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+use hypervisor::kvm::x86_64::sev::MeasuredBootInfo;
 
 /// Errors associated with VM management
 #[derive(Debug, Error)]
@@ -1542,6 +1544,9 @@ impl Vm {
         igvm_file: IgvmFile,
         memory_manager: Arc<Mutex<MemoryManager>>,
         cpu_manager: Arc<Mutex<cpu::CpuManager>>,
+        #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))] measured_boot: Option<
+            MeasuredBootInfo,
+        >,
         #[cfg(feature = "sev_snp")] host_data: &Option<String>,
     ) -> Result<EntryPoint> {
         // Only reserve bootloader/VMSA regions for KVM + SEV-SNP; other hypervisors
@@ -1556,6 +1561,8 @@ impl Vm {
             memory_manager,
             cpu_manager.clone(),
             "",
+            #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+            measured_boot,
             #[cfg(feature = "sev_snp")]
             host_data,
         )
@@ -1650,10 +1657,57 @@ impl Vm {
             if payload.igvm.is_some() {
                 let igvm_file =
                     igvm_file.ok_or(Error::IgvmLoad(igvm_loader::Error::MissingIgvm))?;
+                #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+                let measured_boot = if payload
+                    .fw_cfg_config
+                    .as_ref()
+                    .is_some_and(|cfg| cfg.kernel && cfg.cmdline)
+                    && payload.kernel.is_some()
+                    && payload.cmdline.is_some()
+                {
+                    let kernel =
+                        File::open(payload.kernel.as_ref().unwrap()).map_err(Error::KernelFile)?;
+                    let initramfs = if payload
+                        .fw_cfg_config
+                        .as_ref()
+                        .is_some_and(|cfg| cfg.initramfs)
+                    {
+                        payload
+                            .initramfs
+                            .as_ref()
+                            .map(File::open)
+                            .transpose()
+                            .map_err(Error::InitramfsFile)?
+                    } else {
+                        None
+                    };
+
+                    let cmdline = if payload
+                        .fw_cfg_config
+                        .as_ref()
+                        .is_some_and(|cfg| cfg.cmdline)
+                    {
+                        Self::generate_cmdline(payload)?
+                            .as_cstring()
+                            .map_err(Error::CmdLineCreate)?
+                    } else {
+                        std::ffi::CString::default()
+                    };
+
+                    Some(MeasuredBootInfo {
+                        kernel,
+                        initramfs,
+                        cmdline,
+                    })
+                } else {
+                    None
+                };
                 return Self::load_igvm(
                     igvm_file,
                     memory_manager,
                     cpu_manager,
+                    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+                    measured_boot,
                     #[cfg(feature = "sev_snp")]
                     &payload.host_data,
                 );

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -115,7 +115,7 @@ use crate::{
     CPU_MANAGER_SNAPSHOT_ID, DEVICE_MANAGER_SNAPSHOT_ID, GuestMemoryMmap,
     MEMORY_MANAGER_SNAPSHOT_ID, PciDeviceInfo, cpu,
 };
-#[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+#[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
 use hypervisor::kvm::x86_64::sev::MeasuredBootInfo;
 
 /// Errors associated with VM management
@@ -1544,7 +1544,7 @@ impl Vm {
         igvm_file: IgvmFile,
         memory_manager: Arc<Mutex<MemoryManager>>,
         cpu_manager: Arc<Mutex<cpu::CpuManager>>,
-        #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))] measured_boot: Option<
+        #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))] measured_boot: Option<
             MeasuredBootInfo,
         >,
         #[cfg(feature = "sev_snp")] host_data: &Option<String>,
@@ -1561,7 +1561,7 @@ impl Vm {
             memory_manager,
             cpu_manager.clone(),
             "",
-            #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+            #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
             measured_boot,
             #[cfg(feature = "sev_snp")]
             host_data,
@@ -1657,7 +1657,7 @@ impl Vm {
             if payload.igvm.is_some() {
                 let igvm_file =
                     igvm_file.ok_or(Error::IgvmLoad(igvm_loader::Error::MissingIgvm))?;
-                #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+                #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
                 let measured_boot = if payload
                     .fw_cfg_config
                     .as_ref()
@@ -1706,7 +1706,7 @@ impl Vm {
                     igvm_file,
                     memory_manager,
                     cpu_manager,
-                    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+                    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
                     measured_boot,
                     #[cfg(feature = "sev_snp")]
                     &payload.host_data,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -115,7 +115,12 @@ use crate::{
     CPU_MANAGER_SNAPSHOT_ID, DEVICE_MANAGER_SNAPSHOT_ID, GuestMemoryMmap,
     MEMORY_MANAGER_SNAPSHOT_ID, PciDeviceInfo, cpu,
 };
-#[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+#[cfg(all(
+    feature = "kvm",
+    feature = "sev_snp",
+    feature = "fw_cfg",
+    target_arch = "x86_64"
+))]
 use hypervisor::kvm::x86_64::sev::MeasuredBootInfo;
 
 /// Errors associated with VM management
@@ -1544,9 +1549,13 @@ impl Vm {
         igvm_file: IgvmFile,
         memory_manager: Arc<Mutex<MemoryManager>>,
         cpu_manager: Arc<Mutex<cpu::CpuManager>>,
-        #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))] measured_boot: Option<
-            MeasuredBootInfo,
-        >,
+        #[cfg(all(
+            feature = "kvm",
+            feature = "sev_snp",
+            feature = "fw_cfg",
+            target_arch = "x86_64"
+        ))]
+        measured_boot: Option<MeasuredBootInfo>,
         #[cfg(feature = "sev_snp")] host_data: &Option<String>,
     ) -> Result<EntryPoint> {
         // Only reserve bootloader/VMSA regions for KVM + SEV-SNP; other hypervisors
@@ -1561,7 +1570,12 @@ impl Vm {
             memory_manager,
             cpu_manager.clone(),
             "",
-            #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+            #[cfg(all(
+                feature = "kvm",
+                feature = "sev_snp",
+                feature = "fw_cfg",
+                target_arch = "x86_64"
+            ))]
             measured_boot,
             #[cfg(feature = "sev_snp")]
             host_data,
@@ -1657,7 +1671,12 @@ impl Vm {
             if payload.igvm.is_some() {
                 let igvm_file =
                     igvm_file.ok_or(Error::IgvmLoad(igvm_loader::Error::MissingIgvm))?;
-                #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+                #[cfg(all(
+                    feature = "kvm",
+                    feature = "sev_snp",
+                    feature = "fw_cfg",
+                    target_arch = "x86_64"
+                ))]
                 let measured_boot = if payload
                     .fw_cfg_config
                     .as_ref()
@@ -1706,7 +1725,12 @@ impl Vm {
                     igvm_file,
                     memory_manager,
                     cpu_manager,
-                    #[cfg(all(feature = "sev_snp", feature = "fw_cfg", target_arch = "x86_64"))]
+                    #[cfg(all(
+                        feature = "kvm",
+                        feature = "sev_snp",
+                        feature = "fw_cfg",
+                        target_arch = "x86_64"
+                    ))]
                     measured_boot,
                     #[cfg(feature = "sev_snp")]
                     &payload.host_data,


### PR DESCRIPTION
# Context

I am adding kernel hash support for SEV-SNP in Cloud Hypervisor. The idea behind this is to embed an extra page of data containing a table detailing the `kernel`, `initrd`, and `kernel cmdline` so that these are part of the launch digest, ensuring that all of these components are embedded as part of the TCB. Prior to this, a launch digest only represented the contents of the OVMF binary and the other existing VMSA data.

This is an existing concept from QEMU and OVMF, see this [documentation](https://www.qemu.org/docs/master/system/i386/amd-memory-encryption.html#calculating-expected-guest-launch-measurement). I'm simply porting this over to enable support here .

The idea is that this is a GUID table that resembles a struct like:
```
  0x10c00  +-------------------------------------------------------------+
           | PaddedSevHashTable (0x0b0 = 176 bytes)                      |
           |                                                             |
           |  SevHashTable (0x0a8 = 168 bytes)                           |
           |  0x000  table.guid   [16]  SEV_HASH_TABLE_GUID              |
           |  0x010  table.len    [ 2]  0x00a8                           |
           |                                                             |
           |  0x012  cmdline entry (0x32 = 50 bytes)                     |
           |         - guid     [16]  SEV_CMDLINE_HASH_GUID              |
           |         - len      [ 2]  0x0032                             |
           |         - hash     [32]  sha256(cmdline + trailing NUL)     |
           |                                                             |
           |  0x044  initrd entry  (0x32 = 50 bytes)                     |
           |         - guid     [16]  SEV_INITRD_HASH_GUID               |
           |         - len      [ 2]  0x0032                             |
           |         - hash     [32]  sha256(initrd) or sha256(empty)    |
           |                                                             |
           |  0x076  kernel entry  (0x32 = 50 bytes)                     |
           |         - guid     [16]  SEV_KERNEL_HASH_GUID               |
           |         - len      [ 2]  0x0032                             |
           |         - hash     [32]  sha256(setup_data || kernel_body)  |
           |                                                             |
           |  0x0aa  padding [8]  zeroes to align table to 16 bytes      |
  0x10cb0  +-------------------------------------------------------------+
           | remaining hash block bytes                                  |
           | zero-filled: 0x350 bytes (848)                              |
  0x11000  +-------------------------------------------------------------+
```
When this table is added in to the launch digest via `SNP_LAUNCH_UPDATE`, we can then enforce via the bootloader that we are launching the correct initrd, kernel, and kernel cmdline (see my changes in https://github.com/project-oak/oak/pull/5073). Tying this together, we get a Launch Digest which represents the bootloader, initrd, kernel, kernel hashes, and VMSA (+ any other fields).

# Test Plan

Tested this on an SEV-SNP capable AMD Bergamo host.
I generated `buildigvm` using the PRs I've added in [7](https://gitlab.com/qemu-project/buildigvm/-/merge_requests/7), [8](https://gitlab.com/qemu-project/buildigvm/-/merge_requests/8), and [9](https://gitlab.com/qemu-project/buildigvm/-/merge_requests/9). This makes the `buildigvm` tooling deterministic and matches the behavior of `sev-snp-measure`.
```
$ ./buildigvm sev-snp --firmware stage0_bin --output stage0.igvm --cpucount 4 --vcpu-sig 0x800f12 
```
Launch parameters:
```
$ ./cloud-hypervisor --platform sev_snp=on --igvm stage0.igvm --kernel /cvm/launch/cvm_vmlinuz --cpus boot=4 --memory size=4G,shared=on --disk path=./rootfs.qcow2,image_type=qcow2 --serial tty --console off --initramfs /cvm/launch/layer_no_integrity.cpio.gz --fw-cfg-config kernel=on,cmdline=on,initramfs=on --cmdline "console=ttyS0 root=/dev/vda1 rw rw_overlay_size=1024"
```

When using `snpguest`, I get the following measurement from the CVM:
```
Measurement:                  
7d eb f2 63 da be b4 3d 10 4a a3 88 b7 8c 0d e3 
cc d3 bb 13 62 67 53 c9 50 4c 1d 0f f9 79 7f 05 
53 ed e3 db f7 69 78 0d a1 4f 23 f1 07 64 76 f6
```

Using the `sev-snp-measure` tool from [VirTEE](https://github.com/virtee/sev-snp-measure), I get this:
```
$ ./sev-snp-measure.par --vcpus 4 --vcpu-type EPYC-v4 --ovmf /tmp/stage0_bin --kernel /cvm/launch/cvm_vmlinuz --initrd /cvm/launch/layer_no_integrity.cpio.gz --append "console=ttyS0 root=/dev/vda1 rw rw_overlay_size=1024" --mode snp
7debf263dabeb43d104aa388b78c0de3ccd3bb13626753c9504c1d0ff9797f0553ede3dbf769780da14f23f1076476f6
```

So, at least with this original set of changes we have a consistent measurement with existing tooling (IGVM measurement tooling pending conversation with SVSM folks).