### PR TITLE
block: vhd: Unify FixedVhdDiskSync and FixedVhdDiskAsync into FixedVhdDisk

### DIFF
--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -18,9 +18,7 @@ use log::info;
 
 use crate::disk_file::AsyncFullDiskFile;
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
-#[cfg(feature = "io_uring")]
-use crate::fixed_vhd_async::FixedVhdDiskAsync;
-use crate::fixed_vhd_sync::FixedVhdDiskSync;
+use crate::fixed_vhd_disk::FixedVhdDisk;
 #[cfg(feature = "io_uring")]
 use crate::qcow_async::QcowDiskAsync;
 use crate::qcow_sync::QcowDiskSync;
@@ -132,7 +130,7 @@ fn open_fixed_vhd(
         if io_uring_supported() {
             info!("Opening fixed VHD disk file with io_uring backend");
             return Ok(Box::new(
-                FixedVhdDiskAsync::new(file).map_err(|e| e.with_path(options.path))?,
+                FixedVhdDisk::new(file, true).map_err(|e| e.with_path(options.path))?,
             ));
         }
         info!("io_uring runtime probe failed for fixed VHD, using synchronous backend");
@@ -140,7 +138,7 @@ fn open_fixed_vhd(
 
     info!("Opening fixed VHD disk file with synchronous backend");
     Ok(Box::new(
-        FixedVhdDiskSync::new(file).map_err(|e| e.with_path(options.path))?,
+        FixedVhdDisk::new(file, false).map_err(|e| e.with_path(options.path))?,
     ))
 }
 

--- a/block/src/fixed_vhd_async.rs
+++ b/block/src/fixed_vhd_async.rs
@@ -2,86 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs::File;
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::RawFd;
 
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFileError};
-use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
-use crate::fixed_vhd::FixedVhd;
+use crate::BatchRequest;
+use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
+use crate::error::BlockResult;
 use crate::raw_async::RawFileAsync;
-use crate::{BatchRequest, BlockBackend, disk_file};
-
-#[derive(Debug)]
-pub struct FixedVhdDiskAsync(FixedVhd);
-
-impl FixedVhdDiskAsync {
-    pub fn new(file: File) -> BlockResult<Self> {
-        Ok(Self(
-            FixedVhd::new(file).map_err(|e| BlockError::from(e).with_op(ErrorOp::Open))?,
-        ))
-    }
-}
-
-impl disk_file::DiskSize for FixedVhdDiskAsync {
-    fn logical_size(&self) -> BlockResult<u64> {
-        self.0
-            .logical_size()
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, e))
-    }
-}
-
-impl disk_file::PhysicalSize for FixedVhdDiskAsync {
-    fn physical_size(&self) -> BlockResult<u64> {
-        self.0.physical_size().map_err(|e| match e {
-            crate::Error::GetFileMetadata(io) => {
-                BlockError::new(BlockErrorKind::Io, crate::Error::GetFileMetadata(io))
-            }
-            _ => unreachable!("unexpected error from FixedVhd::physical_size(): {e}"),
-        })
-    }
-}
-
-impl disk_file::DiskFd for FixedVhdDiskAsync {
-    fn fd(&self) -> BorrowedDiskFd<'_> {
-        BorrowedDiskFd::new(self.0.as_raw_fd())
-    }
-}
-
-impl disk_file::Geometry for FixedVhdDiskAsync {}
-
-impl disk_file::SparseCapable for FixedVhdDiskAsync {}
-
-impl disk_file::Resizable for FixedVhdDiskAsync {
-    fn resize(&mut self, _size: u64) -> BlockResult<()> {
-        Err(BlockError::new(
-            BlockErrorKind::UnsupportedFeature,
-            DiskFileError::ResizeError(std::io::Error::other("resize not supported for fixed VHD")),
-        )
-        .with_op(ErrorOp::Resize))
-    }
-}
-
-impl disk_file::DiskFile for FixedVhdDiskAsync {}
-
-impl disk_file::AsyncDiskFile for FixedVhdDiskAsync {
-    fn try_clone(&self) -> BlockResult<Box<dyn disk_file::AsyncDiskFile>> {
-        Ok(Box::new(FixedVhdDiskAsync(self.0.clone())))
-    }
-
-    fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
-        let size = self
-            .0
-            .logical_size()
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
-        Ok(Box::new(FixedVhdAsync::new(
-            self.0.as_raw_fd(),
-            ring_depth,
-            size,
-        )?))
-    }
-}
 
 pub struct FixedVhdAsync {
     raw_file_async: RawFileAsync,

--- a/block/src/fixed_vhd_disk.rs
+++ b/block/src/fixed_vhd_disk.rs
@@ -115,3 +115,51 @@ impl disk_file::AsyncDiskFile for FixedVhdDisk {
         ))
     }
 }
+
+#[cfg(test)]
+mod unit_tests {
+    use std::fs::File;
+    use std::io::{Seek, SeekFrom, Write};
+
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+    use crate::disk_file::DiskSize;
+
+    /// Minimal fixed VHD footer (disk type = 2, current_size = 0x11223344).
+    fn fixed_vhd_footer() -> &'static [u8] {
+        &[
+            0x63, 0x6f, 0x6e, 0x65, 0x63, 0x74, 0x69, 0x78, // cookie
+            0x00, 0x00, 0x00, 0x02, // features
+            0x00, 0x01, 0x00, 0x00, // file format version
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // data offset
+            0x27, 0xa6, 0xa6, 0x5d, // time stamp
+            0x71, 0x65, 0x6d, 0x75, // creator application
+            0x00, 0x05, 0x00, 0x03, // creator version
+            0x57, 0x69, 0x32, 0x6b, // creator host os
+            0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33, 0x44, // original size
+            0x00, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33, 0x44, // current size
+            0x11, 0xe0, 0x10, 0x3f, // disk geometry
+            0x00, 0x00, 0x00, 0x02, // disk type
+            0x00, 0x00, 0x00, 0x00, // checksum
+            0x98, 0x7b, 0xb1, 0xcd, 0x84, 0x14, 0x41, 0xfc, // unique id
+            0xa4, 0xab, 0xd0, 0x69, 0x45, 0x2b, 0xf2, 0x23, 0x00, // saved state
+        ]
+    }
+
+    fn make_vhd_file() -> File {
+        let mut file: File = TempFile::new().unwrap().into_file();
+        let data_size: u64 = 0x1122_3344;
+        file.set_len(data_size + 0x200).unwrap();
+        file.seek(SeekFrom::Start(data_size)).unwrap();
+        file.write_all(fixed_vhd_footer()).unwrap();
+        file
+    }
+
+    #[test]
+    fn new_sync_returns_correct_size() {
+        let file = make_vhd_file();
+        let disk = FixedVhdDisk::new(file, false).unwrap();
+        assert_eq!(disk.logical_size().unwrap(), 0x1122_3344);
+    }
+}

--- a/block/src/fixed_vhd_disk.rs
+++ b/block/src/fixed_vhd_disk.rs
@@ -124,7 +124,8 @@ mod unit_tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
-    use crate::disk_file::DiskSize;
+    use crate::async_io::AsyncIo;
+    use crate::disk_file::{AsyncDiskFile, DiskSize};
 
     /// Minimal fixed VHD footer (disk type = 2, current_size = 0x11223344).
     fn fixed_vhd_footer() -> &'static [u8] {
@@ -161,5 +162,29 @@ mod unit_tests {
         let file = make_vhd_file();
         let disk = FixedVhdDisk::new(file, false).unwrap();
         assert_eq!(disk.logical_size().unwrap(), 0x1122_3344);
+    }
+
+    fn assert_async_io_from_dyn(disk: &dyn AsyncDiskFile, expect_batch: bool) {
+        let io: Box<dyn AsyncIo> = disk.create_async_io(128).unwrap();
+        assert_eq!(io.batch_requests_enabled(), expect_batch);
+    }
+
+    fn assert_async_io(disk: &FixedVhdDisk, expect_batch: bool) {
+        assert_async_io_from_dyn(disk, expect_batch);
+    }
+
+    #[test]
+    fn sync_backend_disables_batch_requests() {
+        let file = make_vhd_file();
+        let disk = FixedVhdDisk::new(file, false).unwrap();
+        assert_async_io(&disk, false);
+    }
+
+    #[cfg(feature = "io_uring")]
+    #[test]
+    fn io_uring_backend_enables_batch_requests() {
+        let file = make_vhd_file();
+        let disk = FixedVhdDisk::new(file, true).unwrap();
+        assert_async_io(&disk, true);
     }
 }

--- a/block/src/fixed_vhd_disk.rs
+++ b/block/src/fixed_vhd_disk.rs
@@ -125,7 +125,7 @@ mod unit_tests {
 
     use super::*;
     use crate::async_io::AsyncIo;
-    use crate::disk_file::{AsyncDiskFile, DiskSize, Resizable};
+    use crate::disk_file::{AsyncDiskFile, DiskSize, PhysicalSize, Resizable};
 
     /// Minimal fixed VHD footer (disk type = 2, current_size = 0x11223344).
     fn fixed_vhd_footer() -> &'static [u8] {
@@ -210,5 +210,13 @@ mod unit_tests {
         let file = make_vhd_file();
         let mut disk = FixedVhdDisk::new(file, false).unwrap();
         assert!(disk.resize(0x2000_0000).is_err());
+    }
+
+    #[test]
+    fn physical_size_includes_footer() {
+        let file = make_vhd_file();
+        let disk = FixedVhdDisk::new(file, false).unwrap();
+        // Data region (0x1122_3344) + VHD footer (0x200).
+        assert_eq!(disk.physical_size().unwrap(), 0x1122_3344 + 0x200);
     }
 }

--- a/block/src/fixed_vhd_disk.rs
+++ b/block/src/fixed_vhd_disk.rs
@@ -125,7 +125,7 @@ mod unit_tests {
 
     use super::*;
     use crate::async_io::AsyncIo;
-    use crate::disk_file::{AsyncDiskFile, DiskSize};
+    use crate::disk_file::{AsyncDiskFile, DiskSize, Resizable};
 
     /// Minimal fixed VHD footer (disk type = 2, current_size = 0x11223344).
     fn fixed_vhd_footer() -> &'static [u8] {
@@ -203,5 +203,12 @@ mod unit_tests {
         let disk = FixedVhdDisk::new(file, true).unwrap();
         let cloned = disk.try_clone().unwrap();
         assert_async_io_from_dyn(cloned.as_ref(), true);
+    }
+
+    #[test]
+    fn resize_returns_error() {
+        let file = make_vhd_file();
+        let mut disk = FixedVhdDisk::new(file, false).unwrap();
+        assert!(disk.resize(0x2000_0000).is_err());
     }
 }

--- a/block/src/fixed_vhd_disk.rs
+++ b/block/src/fixed_vhd_disk.rs
@@ -187,4 +187,21 @@ mod unit_tests {
         let disk = FixedVhdDisk::new(file, true).unwrap();
         assert_async_io(&disk, true);
     }
+
+    #[test]
+    fn try_clone_preserves_sync_dispatch() {
+        let file = make_vhd_file();
+        let disk = FixedVhdDisk::new(file, false).unwrap();
+        let cloned = disk.try_clone().unwrap();
+        assert_async_io_from_dyn(cloned.as_ref(), false);
+    }
+
+    #[cfg(feature = "io_uring")]
+    #[test]
+    fn try_clone_preserves_io_uring_dispatch() {
+        let file = make_vhd_file();
+        let disk = FixedVhdDisk::new(file, true).unwrap();
+        let cloned = disk.try_clone().unwrap();
+        assert_async_io_from_dyn(cloned.as_ref(), true);
+    }
 }

--- a/block/src/fixed_vhd_disk.rs
+++ b/block/src/fixed_vhd_disk.rs
@@ -1,0 +1,117 @@
+// Copyright 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::File;
+use std::io;
+use std::os::unix::io::AsRawFd;
+
+use crate::async_io::{AsyncIo, BorrowedDiskFd, DiskFileError};
+use crate::disk_file::DiskSize;
+use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
+use crate::fixed_vhd::FixedVhd;
+#[cfg(feature = "io_uring")]
+use crate::fixed_vhd_async::FixedVhdAsync;
+use crate::fixed_vhd_sync::FixedVhdSync;
+use crate::{BlockBackend, Error, disk_file};
+
+#[derive(Debug)]
+pub struct FixedVhdDisk {
+    inner: FixedVhd,
+    use_io_uring: bool,
+}
+
+impl FixedVhdDisk {
+    pub fn new(file: File, use_io_uring: bool) -> BlockResult<Self> {
+        #[cfg(not(feature = "io_uring"))]
+        if use_io_uring {
+            return Err(BlockError::new(
+                BlockErrorKind::UnsupportedFeature,
+                DiskFileError::NewAsyncIo(io::Error::other(
+                    "io_uring requested but feature is not enabled",
+                )),
+            ));
+        }
+
+        Ok(Self {
+            inner: FixedVhd::new(file).map_err(|e| BlockError::from(e).with_op(ErrorOp::Open))?,
+            use_io_uring,
+        })
+    }
+}
+
+impl disk_file::DiskSize for FixedVhdDisk {
+    fn logical_size(&self) -> BlockResult<u64> {
+        self.inner
+            .logical_size()
+            .map_err(|e| BlockError::new(BlockErrorKind::Io, e))
+    }
+}
+
+impl disk_file::PhysicalSize for FixedVhdDisk {
+    fn physical_size(&self) -> BlockResult<u64> {
+        self.inner.physical_size().map_err(|e| match e {
+            Error::GetFileMetadata(io) => {
+                BlockError::new(BlockErrorKind::Io, Error::GetFileMetadata(io))
+            }
+            _ => unreachable!("unexpected error from FixedVhd::physical_size(): {e}"),
+        })
+    }
+}
+
+impl disk_file::DiskFd for FixedVhdDisk {
+    fn fd(&self) -> BorrowedDiskFd<'_> {
+        BorrowedDiskFd::new(self.inner.as_raw_fd())
+    }
+}
+
+impl disk_file::Geometry for FixedVhdDisk {}
+
+impl disk_file::SparseCapable for FixedVhdDisk {}
+
+impl disk_file::Resizable for FixedVhdDisk {
+    fn resize(&mut self, _size: u64) -> BlockResult<()> {
+        Err(BlockError::new(
+            BlockErrorKind::UnsupportedFeature,
+            DiskFileError::ResizeError(io::Error::other("resize not supported for fixed VHD")),
+        )
+        .with_op(ErrorOp::Resize))
+    }
+}
+
+impl disk_file::DiskFile for FixedVhdDisk {}
+
+impl disk_file::AsyncDiskFile for FixedVhdDisk {
+    fn try_clone(&self) -> BlockResult<Box<dyn disk_file::AsyncDiskFile>> {
+        Ok(Box::new(FixedVhdDisk {
+            inner: self.inner.clone(),
+            use_io_uring: self.use_io_uring,
+        }))
+    }
+
+    fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+        let size = self.logical_size()?;
+
+        if self.use_io_uring {
+            #[cfg(feature = "io_uring")]
+            {
+                return Ok(Box::new(FixedVhdAsync::new(
+                    self.inner.as_raw_fd(),
+                    ring_depth,
+                    size,
+                )?));
+            }
+
+            #[cfg(not(feature = "io_uring"))]
+            unreachable!("use_io_uring is set but io_uring feature is not enabled");
+        }
+
+        let _ = ring_depth;
+        Ok(Box::new(
+            FixedVhdSync::new(self.inner.as_raw_fd(), size).map_err(|e| {
+                BlockError::new(BlockErrorKind::Io, DiskFileError::NewAsyncIo(e))
+                    .with_op(ErrorOp::Open)
+            })?,
+        ))
+    }
+}

--- a/block/src/fixed_vhd_sync.rs
+++ b/block/src/fixed_vhd_sync.rs
@@ -2,87 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs::File;
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::RawFd;
 
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFileError};
-use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
-use crate::fixed_vhd::FixedVhd;
+use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
 use crate::raw_sync::RawFileSync;
-use crate::{BlockBackend, disk_file};
-
-#[derive(Debug)]
-pub struct FixedVhdDiskSync(FixedVhd);
-
-impl FixedVhdDiskSync {
-    pub fn new(file: File) -> BlockResult<Self> {
-        Ok(Self(
-            FixedVhd::new(file).map_err(|e| BlockError::from(e).with_op(ErrorOp::Open))?,
-        ))
-    }
-}
-
-impl disk_file::DiskSize for FixedVhdDiskSync {
-    fn logical_size(&self) -> BlockResult<u64> {
-        self.0
-            .logical_size()
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, e))
-    }
-}
-
-impl disk_file::PhysicalSize for FixedVhdDiskSync {
-    fn physical_size(&self) -> BlockResult<u64> {
-        self.0.physical_size().map_err(|e| match e {
-            crate::Error::GetFileMetadata(io) => {
-                BlockError::new(BlockErrorKind::Io, crate::Error::GetFileMetadata(io))
-            }
-            _ => unreachable!("unexpected error from FixedVhd::physical_size(): {e}"),
-        })
-    }
-}
-
-impl disk_file::DiskFd for FixedVhdDiskSync {
-    fn fd(&self) -> BorrowedDiskFd<'_> {
-        BorrowedDiskFd::new(self.0.as_raw_fd())
-    }
-}
-
-impl disk_file::Geometry for FixedVhdDiskSync {}
-
-impl disk_file::SparseCapable for FixedVhdDiskSync {}
-
-impl disk_file::Resizable for FixedVhdDiskSync {
-    fn resize(&mut self, _size: u64) -> BlockResult<()> {
-        Err(BlockError::new(
-            BlockErrorKind::UnsupportedFeature,
-            DiskFileError::ResizeError(std::io::Error::other("resize not supported for fixed VHD")),
-        )
-        .with_op(ErrorOp::Resize))
-    }
-}
-
-impl disk_file::DiskFile for FixedVhdDiskSync {}
-
-impl disk_file::AsyncDiskFile for FixedVhdDiskSync {
-    fn try_clone(&self) -> BlockResult<Box<dyn disk_file::AsyncDiskFile>> {
-        Ok(Box::new(FixedVhdDiskSync(self.0.clone())))
-    }
-
-    fn create_async_io(&self, _ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
-        let size = self
-            .0
-            .logical_size()
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
-        Ok(Box::new(
-            FixedVhdSync::new(self.0.as_raw_fd(), size).map_err(|e| {
-                BlockError::new(BlockErrorKind::Io, DiskFileError::NewAsyncIo(e))
-                    .with_op(ErrorOp::Open)
-            })?,
-        ))
-    }
-}
 
 pub struct FixedVhdSync {
     raw_file_sync: RawFileSync,

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -17,6 +17,7 @@ pub mod fixed_vhd;
 #[cfg(feature = "io_uring")]
 /// Enabled with the `"io_uring"` feature
 pub mod fixed_vhd_async;
+pub mod fixed_vhd_disk;
 pub mod fixed_vhd_sync;
 pub mod qcow;
 #[cfg(feature = "io_uring")]


### PR DESCRIPTION
Replaces the two monolithic wrapper types `FixedVhdDiskSync` and `FixedVhdDiskAsync` with a single `FixedVhdDisk` that owns the `FixedVhd` and dispatches `create_async_io` to the correct I/O backend based on a `use_io_uring` flag.

The old wrappers duplicated every `DiskFile` trait impl even though only `create_async_io` differed between them. The unified type keeps the metadata/ownership layer in one place and leaves `FixedVhdSync`/`FixedVhdAsync` as pure I/O workers that receive a raw fd and size at construction time.

Planning and test implementation assisted by Claude Opus 4.6.

Ref: #7877 (task 3.2.5)