### PR TITLE
vm-allocator: Remove a redundant check for zero

### DIFF
--- a/vm-allocator/src/address.rs
+++ b/vm-allocator/src/address.rs
@@ -174,7 +174,7 @@ impl AddressAllocator {
         }
 
         let alignment = align_size.unwrap_or(4);
-        if !alignment.is_power_of_two() || alignment == 0 {
+        if !alignment.is_power_of_two() {
             return None;
         }
 


### PR DESCRIPTION
alignment.is_power_of_two() already implies alignment != 0.