### PR TITLE
block: raw: Unify raw disk wrappers into RawDisk

### DIFF
--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -16,6 +16,8 @@ use std::{fmt, fs};
 
 use log::info;
 
+#[cfg(feature = "io_uring")]
+use crate::block_io_uring_is_supported;
 use crate::disk_file::AsyncFullDiskFile;
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
 #[cfg(feature = "io_uring")]
@@ -24,14 +26,11 @@ use crate::fixed_vhd_sync::FixedVhdDiskSync;
 #[cfg(feature = "io_uring")]
 use crate::qcow_async::QcowDiskAsync;
 use crate::qcow_sync::QcowDiskSync;
-use crate::raw_async_aio::RawFileDiskAio;
-use crate::raw_sync::RawFileDiskSync;
+use crate::raw_disk::{RawBackend, RawDisk};
 use crate::vhdx_sync::VhdxDiskSync;
 use crate::{
     ImageType, block_aio_is_supported, detect_image_type, open_disk_image, preallocate_disk,
 };
-#[cfg(feature = "io_uring")]
-use crate::{block_io_uring_is_supported, raw_async::RawFileDisk};
 
 /// Options for opening a disk image via [`open_disk`].
 pub struct DiskOpenOptions<'a> {
@@ -156,7 +155,7 @@ fn open_raw(
     if !options.disable_io_uring {
         if io_uring_supported() {
             info!("Opening RAW disk file with io_uring backend");
-            return Ok(Box::new(RawFileDisk::new(file)));
+            return Ok(Box::new(RawDisk::new(file, RawBackend::IoUring)));
         }
         info!("io_uring runtime probe failed for RAW, trying next backend");
     }
@@ -164,13 +163,13 @@ fn open_raw(
     if !options.disable_aio {
         if aio_supported() {
             info!("Opening RAW disk file with AIO backend");
-            return Ok(Box::new(RawFileDiskAio::new(file)));
+            return Ok(Box::new(RawDisk::new(file, RawBackend::Aio)));
         }
         info!("AIO runtime probe failed for RAW, using synchronous backend");
     }
 
     info!("Opening RAW disk file with synchronous backend");
-    Ok(Box::new(RawFileDiskSync::new(file)))
+    Ok(Box::new(RawDisk::new(file, RawBackend::Sync)))
 }
 
 fn open_qcow2(

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -24,15 +24,12 @@ pub mod qcow_async;
 pub(crate) mod qcow_common;
 pub mod qcow_sync;
 #[cfg(feature = "io_uring")]
-/// Async primitives based on `io-uring`
-///
-/// Enabled with the `"io_uring"` feature
-pub mod raw_async;
-pub mod raw_async_aio;
+pub(crate) mod raw_async;
+pub(crate) mod raw_async_aio;
 #[cfg(test)]
 mod raw_async_io_tests;
 pub mod raw_disk;
-pub mod raw_sync;
+pub(crate) mod raw_sync;
 mod request;
 pub mod vhd;
 pub mod vhdx;

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -31,6 +31,7 @@ pub mod raw_async;
 pub mod raw_async_aio;
 #[cfg(test)]
 mod raw_async_io_tests;
+pub mod raw_disk;
 pub mod raw_sync;
 mod request;
 pub mod vhd;

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -2,118 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::fs::File;
-use std::io::{self, Error};
-use std::os::unix::fs::FileTypeExt;
+use std::io::Error;
 use std::os::unix::io::{AsRawFd, RawFd};
 
 use io_uring::{IoUring, opcode, types};
 use libc::{FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE, FALLOC_FL_ZERO_RANGE};
-use log::warn;
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFileError};
+use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
-use crate::{
-    BatchRequest, DiskTopology, RequestType, SECTOR_SIZE, disk_file, probe_sparse_support,
-    query_device_size,
-};
-
-#[derive(Debug)]
-pub struct RawFileDisk {
-    file: File,
-}
-
-impl RawFileDisk {
-    pub fn new(file: File) -> Self {
-        RawFileDisk { file }
-    }
-}
-
-impl disk_file::DiskSize for RawFileDisk {
-    fn logical_size(&self) -> BlockResult<u64> {
-        query_device_size(&self.file)
-            .map(|(logical_size, _)| logical_size)
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::Size(e)))
-    }
-}
-
-impl disk_file::PhysicalSize for RawFileDisk {
-    fn physical_size(&self) -> BlockResult<u64> {
-        query_device_size(&self.file)
-            .map(|(_, physical_size)| physical_size)
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::Size(e)))
-    }
-}
-
-impl disk_file::DiskFd for RawFileDisk {
-    fn fd(&self) -> BorrowedDiskFd<'_> {
-        BorrowedDiskFd::new(self.file.as_raw_fd())
-    }
-}
-
-impl disk_file::Geometry for RawFileDisk {
-    fn topology(&self) -> DiskTopology {
-        DiskTopology::probe(&self.file).unwrap_or_else(|_| {
-            warn!("Unable to get device topology. Using default topology");
-            DiskTopology::default()
-        })
-    }
-}
-
-impl disk_file::SparseCapable for RawFileDisk {
-    fn supports_sparse_operations(&self) -> bool {
-        probe_sparse_support(&self.file)
-    }
-}
-
-impl disk_file::Resizable for RawFileDisk {
-    fn resize(&mut self, size: u64) -> BlockResult<()> {
-        let fd_metadata = self
-            .file
-            .metadata()
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::ResizeError(e)))?;
-
-        if fd_metadata.file_type().is_block_device() {
-            // Block devices cannot be resized via ftruncate - they are resized
-            // externally (LVM, losetup -c, etc.). Verify the size matches.
-            let (actual_size, _) = query_device_size(&self.file)
-                .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::ResizeError(e)))?;
-            if actual_size != size {
-                return Err(BlockError::new(
-                    BlockErrorKind::Io,
-                    DiskFileError::ResizeError(io::Error::other(format!(
-                        "Block device size {actual_size} does not match requested size {size}"
-                    ))),
-                ));
-            }
-            Ok(())
-        } else {
-            self.file
-                .set_len(size)
-                .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::ResizeError(e)))
-        }
-    }
-}
-
-impl disk_file::DiskFile for RawFileDisk {}
-
-impl disk_file::AsyncDiskFile for RawFileDisk {
-    fn try_clone(&self) -> BlockResult<Box<dyn disk_file::AsyncDiskFile>> {
-        let file = self
-            .file
-            .try_clone()
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::Clone(e)))?;
-        Ok(Box::new(RawFileDisk { file }))
-    }
-
-    fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
-        let mut raw = RawFileAsync::new(self.file.as_raw_fd(), ring_depth)?;
-        raw.alignment =
-            DiskTopology::probe(&self.file).map_or(SECTOR_SIZE, |t| t.logical_block_size);
-        Ok(Box::new(raw) as Box<dyn AsyncIo>)
-    }
-}
+use crate::{BatchRequest, RequestType, SECTOR_SIZE};
 
 pub struct RawFileAsync {
     fd: RawFd,

--- a/block/src/raw_async_aio.rs
+++ b/block/src/raw_async_aio.rs
@@ -6,92 +6,15 @@
 //
 
 use std::collections::VecDeque;
-use std::fs::File;
 use std::os::unix::io::{AsRawFd, RawFd};
 
 use libc::{FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE, FALLOC_FL_ZERO_RANGE};
-use log::warn;
 use vmm_sys_util::aio;
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFileError};
+use crate::SECTOR_SIZE;
+use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
-use crate::{DiskTopology, SECTOR_SIZE, disk_file, probe_sparse_support, query_device_size};
-
-#[derive(Debug)]
-pub struct RawFileDiskAio {
-    file: File,
-}
-
-impl RawFileDiskAio {
-    pub fn new(file: File) -> Self {
-        RawFileDiskAio { file }
-    }
-}
-
-impl disk_file::DiskSize for RawFileDiskAio {
-    fn logical_size(&self) -> BlockResult<u64> {
-        query_device_size(&self.file)
-            .map(|(logical_size, _)| logical_size)
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::Size(e)))
-    }
-}
-
-impl disk_file::PhysicalSize for RawFileDiskAio {
-    fn physical_size(&self) -> BlockResult<u64> {
-        query_device_size(&self.file)
-            .map(|(_, physical_size)| physical_size)
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::Size(e)))
-    }
-}
-
-impl disk_file::DiskFd for RawFileDiskAio {
-    fn fd(&self) -> BorrowedDiskFd<'_> {
-        BorrowedDiskFd::new(self.file.as_raw_fd())
-    }
-}
-
-impl disk_file::Geometry for RawFileDiskAio {
-    fn topology(&self) -> DiskTopology {
-        DiskTopology::probe(&self.file).unwrap_or_else(|_| {
-            warn!("Unable to get device topology. Using default topology");
-            DiskTopology::default()
-        })
-    }
-}
-
-impl disk_file::SparseCapable for RawFileDiskAio {
-    fn supports_sparse_operations(&self) -> bool {
-        probe_sparse_support(&self.file)
-    }
-}
-
-impl disk_file::Resizable for RawFileDiskAio {
-    fn resize(&mut self, size: u64) -> BlockResult<()> {
-        self.file
-            .set_len(size)
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::ResizeError(e)))
-    }
-}
-
-impl disk_file::DiskFile for RawFileDiskAio {}
-
-impl disk_file::AsyncDiskFile for RawFileDiskAio {
-    fn try_clone(&self) -> BlockResult<Box<dyn disk_file::AsyncDiskFile>> {
-        let file = self
-            .file
-            .try_clone()
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::Clone(e)))?;
-        Ok(Box::new(RawFileDiskAio { file }))
-    }
-
-    fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
-        let mut raw = RawFileAsyncAio::new(self.file.as_raw_fd(), ring_depth)?;
-        raw.alignment =
-            DiskTopology::probe(&self.file).map_or(SECTOR_SIZE, |t| t.logical_block_size);
-        Ok(Box::new(raw) as Box<dyn AsyncIo>)
-    }
-}
 
 pub struct RawFileAsyncAio {
     fd: RawFd,

--- a/block/src/raw_disk.rs
+++ b/block/src/raw_disk.rs
@@ -213,4 +213,31 @@ mod unit_tests {
         let disk = RawDisk::new(file, RawBackend::IoUring);
         assert_io_uring_backend(&disk);
     }
+
+    fn assert_try_clone(disk: &RawDisk, expect_backend: RawBackend) {
+        let cloned = disk.try_clone().unwrap();
+        assert_async_io_from_dyn(cloned.as_ref(), expect_backend);
+    }
+
+    #[test]
+    fn try_clone_preserves_sync_backend() {
+        let file = make_raw_file();
+        let disk = RawDisk::new(file, RawBackend::Sync);
+        assert_try_clone(&disk, RawBackend::Sync);
+    }
+
+    #[test]
+    fn try_clone_preserves_aio_backend() {
+        let file = make_raw_file();
+        let disk = RawDisk::new(file, RawBackend::Aio);
+        assert_try_clone(&disk, RawBackend::Aio);
+    }
+
+    #[cfg(feature = "io_uring")]
+    #[test]
+    fn try_clone_preserves_io_uring_backend() {
+        let file = make_raw_file();
+        let disk = RawDisk::new(file, RawBackend::IoUring);
+        assert_try_clone(&disk, RawBackend::IoUring);
+    }
 }

--- a/block/src/raw_disk.rs
+++ b/block/src/raw_disk.rs
@@ -151,7 +151,7 @@ mod unit_tests {
 
     use super::*;
     use crate::async_io::AsyncIo;
-    use crate::disk_file::{AsyncDiskFile, DiskSize};
+    use crate::disk_file::{AsyncDiskFile, DiskSize, Resizable};
 
     const TEST_SIZE: u64 = 0x1122_3344;
 
@@ -239,5 +239,14 @@ mod unit_tests {
         let file = make_raw_file();
         let disk = RawDisk::new(file, RawBackend::IoUring);
         assert_try_clone(&disk, RawBackend::IoUring);
+    }
+
+    #[test]
+    fn resize_changes_file_size() {
+        let file = make_raw_file();
+        let mut disk = RawDisk::new(file, RawBackend::Aio);
+        let new_size = TEST_SIZE * 2;
+        disk.resize(new_size).unwrap();
+        assert_eq!(disk.logical_size().unwrap(), new_size);
     }
 }

--- a/block/src/raw_disk.rs
+++ b/block/src/raw_disk.rs
@@ -151,7 +151,7 @@ mod unit_tests {
 
     use super::*;
     use crate::async_io::AsyncIo;
-    use crate::disk_file::{AsyncDiskFile, DiskSize, Resizable};
+    use crate::disk_file::{AsyncDiskFile, DiskSize, PhysicalSize, Resizable};
 
     const TEST_SIZE: u64 = 0x1122_3344;
 
@@ -248,5 +248,13 @@ mod unit_tests {
         let new_size = TEST_SIZE * 2;
         disk.resize(new_size).unwrap();
         assert_eq!(disk.logical_size().unwrap(), new_size);
+    }
+
+    #[test]
+    fn physical_size_reports_allocated_blocks() {
+        let file = make_raw_file();
+        let disk = RawDisk::new(file, RawBackend::Aio);
+        // Sparse file: physical size is less than logical size.
+        assert!(disk.physical_size().unwrap() < disk.logical_size().unwrap());
     }
 }

--- a/block/src/raw_disk.rs
+++ b/block/src/raw_disk.rs
@@ -18,7 +18,7 @@ use crate::raw_sync::RawFileSync;
 use crate::{DiskTopology, disk_file, probe_sparse_support, query_device_size};
 
 /// Selects which async I/O backend a `RawDisk` uses.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum RawBackend {
     /// Blocking I/O where the caller waits for completion.
     Sync,
@@ -150,7 +150,8 @@ mod unit_tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
-    use crate::disk_file::DiskSize;
+    use crate::async_io::AsyncIo;
+    use crate::disk_file::{AsyncDiskFile, DiskSize};
 
     const TEST_SIZE: u64 = 0x1122_3344;
 
@@ -165,5 +166,51 @@ mod unit_tests {
         let file = make_raw_file();
         let disk = RawDisk::new(file, RawBackend::Sync);
         assert_eq!(disk.logical_size().unwrap(), TEST_SIZE);
+    }
+
+    fn assert_async_io_from_dyn(disk: &dyn AsyncDiskFile, expect_backend: RawBackend) {
+        let io: Box<dyn AsyncIo> = disk.create_async_io(128).unwrap();
+        assert_eq!(
+            io.batch_requests_enabled(),
+            expect_backend == RawBackend::IoUring
+        );
+    }
+
+    fn assert_sync_backend(disk: &RawDisk) {
+        assert_eq!(disk.backend, RawBackend::Sync);
+        assert_async_io_from_dyn(disk, RawBackend::Sync);
+    }
+
+    fn assert_aio_backend(disk: &RawDisk) {
+        assert_eq!(disk.backend, RawBackend::Aio);
+        assert_async_io_from_dyn(disk, RawBackend::Aio);
+    }
+
+    #[cfg(feature = "io_uring")]
+    fn assert_io_uring_backend(disk: &RawDisk) {
+        assert_eq!(disk.backend, RawBackend::IoUring);
+        assert_async_io_from_dyn(disk, RawBackend::IoUring);
+    }
+
+    #[test]
+    fn sync_backend_disables_batch_requests() {
+        let file = make_raw_file();
+        let disk = RawDisk::new(file, RawBackend::Sync);
+        assert_sync_backend(&disk);
+    }
+
+    #[test]
+    fn aio_backend_disables_batch_requests() {
+        let file = make_raw_file();
+        let disk = RawDisk::new(file, RawBackend::Aio);
+        assert_aio_backend(&disk);
+    }
+
+    #[cfg(feature = "io_uring")]
+    #[test]
+    fn io_uring_backend_enables_batch_requests() {
+        let file = make_raw_file();
+        let disk = RawDisk::new(file, RawBackend::IoUring);
+        assert_io_uring_backend(&disk);
     }
 }

--- a/block/src/raw_disk.rs
+++ b/block/src/raw_disk.rs
@@ -9,8 +9,12 @@ use std::os::unix::io::AsRawFd;
 
 use log::warn;
 
-use crate::async_io::{BorrowedDiskFd, DiskFileError};
+use crate::async_io::{AsyncIo, BorrowedDiskFd, DiskFileError};
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
+#[cfg(feature = "io_uring")]
+use crate::raw_async::RawFileAsync;
+use crate::raw_async_aio::RawFileAsyncAio;
+use crate::raw_sync::RawFileSync;
 use crate::{DiskTopology, disk_file, probe_sparse_support, query_device_size};
 
 /// Selects which async I/O backend a `RawDisk` uses.
@@ -105,6 +109,36 @@ impl disk_file::Resizable for RawDisk {
             self.file
                 .set_len(size)
                 .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::ResizeError(e)))
+        }
+    }
+}
+
+impl disk_file::DiskFile for RawDisk {}
+
+impl disk_file::AsyncDiskFile for RawDisk {
+    fn try_clone(&self) -> BlockResult<Box<dyn disk_file::AsyncDiskFile>> {
+        let file = self
+            .file
+            .try_clone()
+            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::Clone(e)))?;
+        Ok(Box::new(RawDisk {
+            file,
+            backend: self.backend,
+        }))
+    }
+
+    fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+        match self.backend {
+            RawBackend::Sync => Ok(Box::new(RawFileSync::new(self.file.as_raw_fd()))),
+            #[cfg(feature = "io_uring")]
+            RawBackend::IoUring => Ok(Box::new(RawFileAsync::new(
+                self.file.as_raw_fd(),
+                ring_depth,
+            )?)),
+            RawBackend::Aio => Ok(Box::new(RawFileAsyncAio::new(
+                self.file.as_raw_fd(),
+                ring_depth,
+            )?)),
         }
     }
 }

--- a/block/src/raw_disk.rs
+++ b/block/src/raw_disk.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::fs::File;
+use std::io;
+use std::os::unix::fs::FileTypeExt;
 use std::os::unix::io::AsRawFd;
 
 use log::warn;
@@ -75,5 +77,34 @@ impl disk_file::Geometry for RawDisk {
 impl disk_file::SparseCapable for RawDisk {
     fn supports_sparse_operations(&self) -> bool {
         probe_sparse_support(&self.file)
+    }
+}
+
+impl disk_file::Resizable for RawDisk {
+    fn resize(&mut self, size: u64) -> BlockResult<()> {
+        let fd_metadata = self
+            .file
+            .metadata()
+            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::ResizeError(e)))?;
+
+        if fd_metadata.file_type().is_block_device() {
+            // Block devices cannot be resized via ftruncate; they are resized
+            // externally (LVM, losetup, etc.). Verify the size matches.
+            let (actual_size, _) = query_device_size(&self.file)
+                .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::ResizeError(e)))?;
+            if actual_size != size {
+                return Err(BlockError::new(
+                    BlockErrorKind::Io,
+                    DiskFileError::ResizeError(io::Error::other(format!(
+                        "Block device size {actual_size} does not match requested size {size}"
+                    ))),
+                ));
+            }
+            Ok(())
+        } else {
+            self.file
+                .set_len(size)
+                .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::ResizeError(e)))
+        }
     }
 }

--- a/block/src/raw_disk.rs
+++ b/block/src/raw_disk.rs
@@ -142,3 +142,28 @@ impl disk_file::AsyncDiskFile for RawDisk {
         }
     }
 }
+
+#[cfg(test)]
+mod unit_tests {
+    use std::fs::File;
+
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+    use crate::disk_file::DiskSize;
+
+    const TEST_SIZE: u64 = 0x1122_3344;
+
+    fn make_raw_file() -> File {
+        let file: File = TempFile::new().unwrap().into_file();
+        file.set_len(TEST_SIZE).unwrap();
+        file
+    }
+
+    #[test]
+    fn new_sync_returns_correct_size() {
+        let file = make_raw_file();
+        let disk = RawDisk::new(file, RawBackend::Sync);
+        assert_eq!(disk.logical_size().unwrap(), TEST_SIZE);
+    }
+}

--- a/block/src/raw_disk.rs
+++ b/block/src/raw_disk.rs
@@ -1,0 +1,79 @@
+// Copyright 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+use std::fs::File;
+use std::os::unix::io::AsRawFd;
+
+use log::warn;
+
+use crate::async_io::{BorrowedDiskFd, DiskFileError};
+use crate::error::{BlockError, BlockErrorKind, BlockResult};
+use crate::{DiskTopology, disk_file, probe_sparse_support, query_device_size};
+
+/// Selects which async I/O backend a `RawDisk` uses.
+#[derive(Clone, Copy, Debug)]
+pub enum RawBackend {
+    /// Blocking I/O where the caller waits for completion.
+    Sync,
+    /// Modern asynchronous I/O using shared submission and completion
+    /// rings for lower overhead operation dispatch and completion handling.
+    #[cfg(feature = "io_uring")]
+    IoUring,
+    /// Legacy asynchronous I/O where requests are handed to the kernel
+    /// and completions are collected later.
+    Aio,
+}
+
+/// Unified DiskFile wrapper for raw disk images.
+///
+/// Owns the underlying file and delegates async I/O creation to the
+/// backend selected at construction time via [`RawBackend`].
+#[derive(Debug)]
+pub struct RawDisk {
+    file: File,
+    backend: RawBackend,
+}
+
+impl RawDisk {
+    pub fn new(file: File, backend: RawBackend) -> Self {
+        Self { file, backend }
+    }
+}
+
+impl disk_file::DiskSize for RawDisk {
+    fn logical_size(&self) -> BlockResult<u64> {
+        query_device_size(&self.file)
+            .map(|(logical_size, _)| logical_size)
+            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::Size(e)))
+    }
+}
+
+impl disk_file::PhysicalSize for RawDisk {
+    fn physical_size(&self) -> BlockResult<u64> {
+        query_device_size(&self.file)
+            .map(|(_, physical_size)| physical_size)
+            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::Size(e)))
+    }
+}
+
+impl disk_file::DiskFd for RawDisk {
+    fn fd(&self) -> BorrowedDiskFd<'_> {
+        BorrowedDiskFd::new(self.file.as_raw_fd())
+    }
+}
+
+impl disk_file::Geometry for RawDisk {
+    fn topology(&self) -> DiskTopology {
+        DiskTopology::probe(&self.file).unwrap_or_else(|_| {
+            warn!("Unable to get device topology. Using default topology");
+            DiskTopology::default()
+        })
+    }
+}
+
+impl disk_file::SparseCapable for RawDisk {
+    fn supports_sparse_operations(&self) -> bool {
+        probe_sparse_support(&self.file)
+    }
+}

--- a/block/src/raw_sync.rs
+++ b/block/src/raw_sync.rs
@@ -3,91 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use std::collections::VecDeque;
-use std::fs::File;
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::RawFd;
 
 use libc::{FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE, FALLOC_FL_ZERO_RANGE};
-use log::warn;
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFileError};
-use crate::error::{BlockError, BlockErrorKind, BlockResult};
-use crate::{DiskTopology, SECTOR_SIZE, disk_file, probe_sparse_support, query_device_size};
-
-#[derive(Debug)]
-pub struct RawFileDiskSync {
-    file: File,
-}
-
-impl RawFileDiskSync {
-    pub fn new(file: File) -> Self {
-        RawFileDiskSync { file }
-    }
-}
-
-impl disk_file::DiskSize for RawFileDiskSync {
-    fn logical_size(&self) -> BlockResult<u64> {
-        query_device_size(&self.file)
-            .map(|(logical_size, _)| logical_size)
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::Size(e)))
-    }
-}
-
-impl disk_file::PhysicalSize for RawFileDiskSync {
-    fn physical_size(&self) -> BlockResult<u64> {
-        query_device_size(&self.file)
-            .map(|(_, physical_size)| physical_size)
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::Size(e)))
-    }
-}
-
-impl disk_file::DiskFd for RawFileDiskSync {
-    fn fd(&self) -> BorrowedDiskFd<'_> {
-        BorrowedDiskFd::new(self.file.as_raw_fd())
-    }
-}
-
-impl disk_file::Geometry for RawFileDiskSync {
-    fn topology(&self) -> DiskTopology {
-        DiskTopology::probe(&self.file).unwrap_or_else(|_| {
-            warn!("Unable to get device topology. Using default topology");
-            DiskTopology::default()
-        })
-    }
-}
-
-impl disk_file::SparseCapable for RawFileDiskSync {
-    fn supports_sparse_operations(&self) -> bool {
-        probe_sparse_support(&self.file)
-    }
-}
-
-impl disk_file::Resizable for RawFileDiskSync {
-    fn resize(&mut self, size: u64) -> BlockResult<()> {
-        self.file
-            .set_len(size)
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::ResizeError(e)))
-    }
-}
-
-impl disk_file::DiskFile for RawFileDiskSync {}
-
-impl disk_file::AsyncDiskFile for RawFileDiskSync {
-    fn try_clone(&self) -> BlockResult<Box<dyn disk_file::AsyncDiskFile>> {
-        let file = self
-            .file
-            .try_clone()
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::Clone(e)))?;
-        Ok(Box::new(RawFileDiskSync { file }))
-    }
-
-    fn create_async_io(&self, _ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
-        let mut raw = RawFileSync::new(self.file.as_raw_fd());
-        raw.alignment =
-            DiskTopology::probe(&self.file).map_or(SECTOR_SIZE, |t| t.logical_block_size);
-        Ok(Box::new(raw) as Box<dyn AsyncIo>)
-    }
-}
+use crate::SECTOR_SIZE;
+use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
 
 pub struct RawFileSync {
     fd: RawFd,

--- a/fuzz/fuzz_targets/block.rs
+++ b/fuzz/fuzz_targets/block.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::{ffi, io};
 
 use block::fcntl::LockGranularityChoice;
-use block::raw_sync::RawFileDiskSync;
+use block::raw_disk::{RawBackend, RawDisk};
 use libfuzzer_sys::{fuzz_target, Corpus};
 use seccompiler::SeccompAction;
 use virtio_devices::{Block, VirtioDevice, VirtioInterrupt, VirtioInterruptType};
@@ -54,7 +54,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
     let queue_affinity = BTreeMap::new();
     let mut block = Block::new(
         "tmp".to_owned(),
-        Box::new(RawFileDiskSync::new(disk_file)),
+        Box::new(RawDisk::new(disk_file, RawBackend::Sync)),
         PathBuf::from(""),
         false,
         false,

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -7,12 +7,10 @@
 //! These run without booting a VM and measure hot path operations
 //! (e.g. AIO completion draining) at the syscall level.
 
-use std::os::unix::io::AsRawFd;
 use std::time::Instant;
 
-use block::async_io::AsyncIo;
 use block::disk_file::AsyncDiskFile;
-use block::raw_async_aio::RawFileAsyncAio;
+use block::raw_disk::{RawBackend, RawDisk};
 use block::{BatchRequest, RequestType};
 
 use crate::PerformanceTestControl;
@@ -29,8 +27,10 @@ use crate::util::{
 pub fn micro_bench_aio_drain(control: &PerformanceTestControl) -> f64 {
     let num_ops = control.num_ops.expect("num_ops required") as usize;
     let tmp = util::sized_tempfile(num_ops);
-    let fd = tmp.as_file().as_raw_fd();
-    let mut aio = RawFileAsyncAio::new(fd, num_ops as u32).expect("failed to create AIO context");
+    let disk = RawDisk::new(tmp.as_file().try_clone().unwrap(), RawBackend::Aio);
+    let mut aio = disk
+        .create_async_io(num_ops as u32)
+        .expect("failed to create AIO context");
 
     let buf = vec![0xA5u8; BLOCK_SIZE as usize];
 


### PR DESCRIPTION
Replaces the three monolithic wrapper types `RawFileDiskSync`, `RawFileDiskAsync`, and `RawFileDiskAsyncAio` with a single `RawDisk` that owns the `File` and dispatches `create_async_io` to the correct I/O backend based on a `RawBackend` enum.

The old wrappers duplicated every `DiskFile` trait impl even though only `create_async_io` differed between them. The unified type keeps the metadata/ownership layer in one place and leaves `RawFileSync`/`RawFileAsync`/`RawFileAsyncAio` as pure I/O workers that receive a raw fd at construction time.

The `IoUring` variant is behind `#[cfg(feature = "io_uring")]`, so the compiler prevents constructing it when the feature is off. No runtime guard is needed (unlike `FixedVhdDisk` in #8085 which takes a `bool` flag).

The unified `Resizable` impl uses the block device aware resize from the former io_uring variant, which is a superset of the sync/AIO versions. All backends now correctly handle block devices (verify size instead of ftruncate) and regular files (set_len). The sync and AIO versions previously only had `set_len`, which would fail silently on block devices.

Renaming the I/O workers (e.g. `RawFileSync` to `RawSync`) is outstanding and will be part of the next stage of refactoring.

Planning and test implementation assisted by Claude Opus 4.6.

Ref: #7877 (task 3.2.1)