### PR TITLE
block: qcow: Unify QCOW2 disk wrappers into QcowDisk

### DIFF
--- a/block/src/factory.rs
+++ b/block/src/factory.rs
@@ -21,9 +21,7 @@ use crate::block_io_uring_is_supported;
 use crate::disk_file::AsyncFullDiskFile;
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
 use crate::fixed_vhd_disk::FixedVhdDisk;
-#[cfg(feature = "io_uring")]
-use crate::qcow_async::QcowDiskAsync;
-use crate::qcow_sync::QcowDiskSync;
+use crate::qcow_disk::QcowDisk;
 use crate::raw_disk::{RawBackend, RawDisk};
 use crate::vhdx_sync::VhdxDiskSync;
 use crate::{
@@ -179,8 +177,14 @@ fn open_qcow2(
         if io_uring_supported() {
             info!("Opening QCOW2 disk file with io_uring backend");
             return Ok(Box::new(
-                QcowDiskAsync::new(file, options.direct, options.backing_files, options.sparse)
-                    .map_err(|e| e.with_path(options.path))?,
+                QcowDisk::new(
+                    file,
+                    options.direct,
+                    options.backing_files,
+                    options.sparse,
+                    true,
+                )
+                .map_err(|e| e.with_path(options.path))?,
             ));
         }
         info!("io_uring runtime probe failed for QCOW2, using synchronous backend");
@@ -188,8 +192,14 @@ fn open_qcow2(
 
     info!("Opening QCOW2 disk file with synchronous backend");
     Ok(Box::new(
-        QcowDiskSync::new(file, options.direct, options.backing_files, options.sparse)
-            .map_err(|e| e.with_path(options.path))?,
+        QcowDisk::new(
+            file,
+            options.direct,
+            options.backing_files,
+            options.sparse,
+            false,
+        )
+        .map_err(|e| e.with_path(options.path))?,
     ))
 }
 

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -23,6 +23,7 @@ pub mod qcow;
 #[cfg(feature = "io_uring")]
 pub mod qcow_async;
 pub(crate) mod qcow_common;
+pub mod qcow_disk;
 pub mod qcow_sync;
 #[cfg(feature = "io_uring")]
 pub(crate) mod raw_async;

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -21,10 +21,10 @@ pub mod fixed_vhd_disk;
 pub mod fixed_vhd_sync;
 pub mod qcow;
 #[cfg(feature = "io_uring")]
-pub mod qcow_async;
+pub(crate) mod qcow_async;
 pub(crate) mod qcow_common;
 pub mod qcow_disk;
-pub mod qcow_sync;
+pub(crate) mod qcow_sync;
 #[cfg(feature = "io_uring")]
 pub(crate) mod raw_async;
 pub(crate) mod raw_async_aio;

--- a/block/src/qcow/mod.rs
+++ b/block/src/qcow/mod.rs
@@ -372,8 +372,7 @@ impl Debug for BackingFile {
 /// Parses and validates a QCOW2 image file, returning the metadata, backing
 /// file and sparse flag.
 ///
-/// This shared constructor is used by both QcowFile for sequential I/O
-/// and QcowDiskSync for lock based parallel I/O.
+/// Used by [`QcowFile`] and [`QcowDisk`] constructors.
 pub(crate) fn parse_qcow(
     mut file: RawFile,
     max_nesting_depth: u32,

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -186,7 +186,7 @@ pub struct QcowAsync {
 }
 
 impl QcowAsync {
-    fn new(
+    pub(crate) fn new(
         metadata: Arc<QcowMetadata>,
         data_file: QcowRawFile,
         backing_file: Option<Arc<dyn BackingRead>>,

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -689,6 +689,7 @@ mod unit_tests {
     use crate::disk_file::AsyncDiskFile;
     use crate::qcow::{QcowFile, RawFile};
     use crate::qcow_common::unit_tests::compress_allocated_clusters;
+    use crate::qcow_disk::QcowDisk;
     use crate::{BatchRequest, RequestType, SECTOR_SIZE};
 
     fn create_disk_with_data(
@@ -696,7 +697,7 @@ mod unit_tests {
         data: &[u8],
         offset: u64,
         sparse: bool,
-    ) -> (TempFile, QcowDiskAsync) {
+    ) -> (TempFile, QcowDisk) {
         let temp_file = TempFile::new().unwrap();
         {
             let raw_file = RawFile::new(temp_file.as_file().try_clone().unwrap(), false);
@@ -705,11 +706,12 @@ mod unit_tests {
             qcow_file.write_all(data).unwrap();
             qcow_file.flush().unwrap();
         }
-        let disk = QcowDiskAsync::new(
+        let disk = QcowDisk::new(
             temp_file.as_file().try_clone().unwrap(),
             false,
             false,
             sparse,
+            true,
         )
         .unwrap();
         (temp_file, disk)
@@ -730,7 +732,7 @@ mod unit_tests {
         }
     }
 
-    fn async_write(disk: &QcowDiskAsync, offset: u64, data: &[u8]) {
+    fn async_write(disk: &QcowDisk, offset: u64, data: &[u8]) {
         let mut async_io = disk.create_async_io(1).unwrap();
         let iovec = libc::iovec {
             iov_base: data.as_ptr() as *mut libc::c_void,
@@ -748,7 +750,7 @@ mod unit_tests {
         );
     }
 
-    fn async_read(disk: &QcowDiskAsync, offset: u64, len: usize) -> Vec<u8> {
+    fn async_read(disk: &QcowDisk, offset: u64, len: usize) -> Vec<u8> {
         let mut async_io = disk.create_async_io(1).unwrap();
         let mut buf = vec![0xFFu8; len];
         let iovec = libc::iovec {
@@ -814,8 +816,14 @@ mod unit_tests {
             let raw_file = RawFile::new(temp_file.as_file().try_clone().unwrap(), false);
             QcowFile::new(raw_file, 3, file_size, true).unwrap();
         }
-        let disk = QcowDiskAsync::new(temp_file.as_file().try_clone().unwrap(), false, false, true)
-            .unwrap();
+        let disk = QcowDisk::new(
+            temp_file.as_file().try_clone().unwrap(),
+            false,
+            false,
+            true,
+            true,
+        )
+        .unwrap();
 
         let pattern: Vec<u8> = (0..128 * 1024).map(|i| (i % 251) as u8).collect();
         let offset = 64 * 1024;
@@ -859,8 +867,14 @@ mod unit_tests {
             let raw_file = RawFile::new(temp_file.as_file().try_clone().unwrap(), false);
             QcowFile::new(raw_file, 3, file_size, true).unwrap();
         }
-        let disk = QcowDiskAsync::new(temp_file.as_file().try_clone().unwrap(), false, false, true)
-            .unwrap();
+        let disk = QcowDisk::new(
+            temp_file.as_file().try_clone().unwrap(),
+            false,
+            false,
+            true,
+            true,
+        )
+        .unwrap();
 
         let mut async_io = disk.create_async_io(8).unwrap();
 
@@ -955,8 +969,14 @@ mod unit_tests {
             let raw_file = RawFile::new(temp_file.as_file().try_clone().unwrap(), false);
             QcowFile::new(raw_file, 3, file_size, true).unwrap();
         }
-        let disk = QcowDiskAsync::new(temp_file.as_file().try_clone().unwrap(), false, false, true)
-            .unwrap();
+        let disk = QcowDisk::new(
+            temp_file.as_file().try_clone().unwrap(),
+            false,
+            false,
+            true,
+            true,
+        )
+        .unwrap();
 
         let buf = async_read(&disk, 0, 128 * 1024);
         assert!(
@@ -974,8 +994,14 @@ mod unit_tests {
             let raw_file = RawFile::new(temp_file.as_file().try_clone().unwrap(), false);
             QcowFile::new(raw_file, 3, file_size, true).unwrap();
         }
-        let disk = QcowDiskAsync::new(temp_file.as_file().try_clone().unwrap(), false, false, true)
-            .unwrap();
+        let disk = QcowDisk::new(
+            temp_file.as_file().try_clone().unwrap(),
+            false,
+            false,
+            true,
+            true,
+        )
+        .unwrap();
 
         // Write 4K into the middle of a cluster.
         let write_offset = 4096u64;
@@ -1063,19 +1089,32 @@ mod unit_tests {
             let raw_file = RawFile::new(temp_file.as_file().try_clone().unwrap(), false);
             QcowFile::new(raw_file, 3, file_size, true).unwrap();
         }
-        let disk = QcowDiskAsync::new(temp_file.as_file().try_clone().unwrap(), false, false, true)
-            .unwrap();
+        let disk = QcowDisk::new(
+            temp_file.as_file().try_clone().unwrap(),
+            false,
+            false,
+            true,
+            true,
+        )
+        .unwrap();
         let async_io = disk.create_async_io(1).unwrap();
         assert_eq!(async_io.alignment(), SECTOR_SIZE);
     }
 
     /// Returns None if O_DIRECT is not supported (e.g. tmpfs).
-    fn try_create_direct_io_disk(temp_file: &TempFile, file_size: u64) -> Option<QcowDiskAsync> {
+    fn try_create_direct_io_disk(temp_file: &TempFile, file_size: u64) -> Option<QcowDisk> {
         {
             let raw_file = RawFile::new(temp_file.as_file().try_clone().unwrap(), false);
             QcowFile::new(raw_file, 3, file_size, true).unwrap();
         }
-        QcowDiskAsync::new(temp_file.as_file().try_clone().unwrap(), true, false, true).ok()
+        QcowDisk::new(
+            temp_file.as_file().try_clone().unwrap(),
+            true,
+            false,
+            true,
+            true,
+        )
+        .ok()
     }
 
     #[test]
@@ -1141,7 +1180,14 @@ mod unit_tests {
         compress_allocated_clusters(&mut temp.as_file().try_clone().unwrap());
 
         let disk = Arc::new(
-            QcowDiskAsync::new(temp.as_file().try_clone().unwrap(), false, false, false).unwrap(),
+            QcowDisk::new(
+                temp.as_file().try_clone().unwrap(),
+                false,
+                false,
+                false,
+                true,
+            )
+            .unwrap(),
         );
 
         let handles: Vec<_> = (0..4)

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -8,157 +8,25 @@
 
 use std::cmp::{max, min};
 use std::collections::VecDeque;
-use std::fs::File;
-use std::io::Error;
-use std::os::fd::{AsFd, AsRawFd};
+use std::io;
+use std::os::unix::io::AsRawFd;
 use std::sync::Arc;
-use std::{fmt, io};
 
 use io_uring::{IoUring, opcode, types};
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
-use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFileError};
-use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
-use crate::qcow::backing::shared_backing_from;
+use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
 use crate::qcow::decoder::Decoder;
 use crate::qcow::metadata::{
     BackingRead, ClusterReadMapping, ClusterWriteMapping, DeallocAction, QcowMetadata,
 };
 use crate::qcow::qcow_raw_file::QcowRawFile;
-use crate::qcow::{MAX_NESTING_DEPTH, RawFile, parse_qcow};
 use crate::qcow_common::{
     AlignedBuf, aligned_pread, aligned_pwrite, decompress_cluster, gather_from_iovecs_into,
     pread_alloc, pread_exact, pwrite_all, scatter_to_iovecs, zero_fill_iovecs,
 };
-use crate::{BatchRequest, RequestType, SECTOR_SIZE, disk_file};
-
-/// Device level handle for a QCOW2 image.
-///
-/// Owns the parsed metadata and backing file chain. One instance is
-/// created per disk and shared across virtio queues.
-pub struct QcowDiskAsync {
-    metadata: Arc<QcowMetadata>,
-    backing_file: Option<Arc<dyn BackingRead>>,
-    sparse: bool,
-    data_raw_file: QcowRawFile,
-}
-
-impl fmt::Debug for QcowDiskAsync {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("QcowDiskAsync")
-            .field("sparse", &self.sparse)
-            .field("has_backing", &self.backing_file.is_some())
-            .finish_non_exhaustive()
-    }
-}
-
-impl QcowDiskAsync {
-    pub fn new(
-        file: File,
-        direct_io: bool,
-        backing_files: bool,
-        sparse: bool,
-    ) -> BlockResult<Self> {
-        let max_nesting_depth = if backing_files { MAX_NESTING_DEPTH } else { 0 };
-        let (inner, backing_file, sparse) =
-            parse_qcow(RawFile::new(file, direct_io), max_nesting_depth, sparse).map_err(|e| {
-                let e = if !backing_files && matches!(e.kind(), BlockErrorKind::Overflow) {
-                    e.with_kind(BlockErrorKind::UnsupportedFeature)
-                } else {
-                    e
-                };
-                e.with_op(ErrorOp::Open)
-            })?;
-        let data_raw_file = inner.raw_file.clone();
-        Ok(QcowDiskAsync {
-            metadata: Arc::new(QcowMetadata::new(inner)),
-            backing_file: backing_file.map(shared_backing_from).transpose()?,
-            sparse,
-            data_raw_file,
-        })
-    }
-}
-
-impl Drop for QcowDiskAsync {
-    fn drop(&mut self) {
-        self.metadata.shutdown();
-    }
-}
-
-impl disk_file::DiskSize for QcowDiskAsync {
-    fn logical_size(&self) -> BlockResult<u64> {
-        Ok(self.metadata.virtual_size())
-    }
-}
-
-impl disk_file::PhysicalSize for QcowDiskAsync {
-    fn physical_size(&self) -> BlockResult<u64> {
-        Ok(self.data_raw_file.physical_size()?)
-    }
-}
-
-impl disk_file::DiskFd for QcowDiskAsync {
-    fn fd(&self) -> BorrowedDiskFd<'_> {
-        BorrowedDiskFd::new(self.data_raw_file.as_fd().as_raw_fd())
-    }
-}
-
-impl disk_file::Geometry for QcowDiskAsync {}
-
-impl disk_file::SparseCapable for QcowDiskAsync {
-    fn supports_sparse_operations(&self) -> bool {
-        true
-    }
-
-    fn supports_zero_flag(&self) -> bool {
-        true
-    }
-}
-
-impl disk_file::Resizable for QcowDiskAsync {
-    fn resize(&mut self, size: u64) -> BlockResult<()> {
-        if self.backing_file.is_some() {
-            return Err(BlockError::new(
-                BlockErrorKind::UnsupportedFeature,
-                DiskFileError::ResizeError(io::Error::other(
-                    "resize not supported with backing file",
-                )),
-            )
-            .with_op(ErrorOp::Resize));
-        }
-        self.metadata.resize(size).map_err(|e| {
-            BlockError::new(BlockErrorKind::Io, DiskFileError::ResizeError(e))
-                .with_op(ErrorOp::Resize)
-        })
-    }
-}
-
-impl disk_file::DiskFile for QcowDiskAsync {}
-
-impl disk_file::AsyncDiskFile for QcowDiskAsync {
-    fn try_clone(&self) -> BlockResult<Box<dyn disk_file::AsyncDiskFile>> {
-        Ok(Box::new(QcowDiskAsync {
-            metadata: Arc::clone(&self.metadata),
-            backing_file: self.backing_file.as_ref().map(Arc::clone),
-            sparse: self.sparse,
-            data_raw_file: self.data_raw_file.clone(),
-        }))
-    }
-
-    fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
-        Ok(Box::new(
-            QcowAsync::new(
-                Arc::clone(&self.metadata),
-                self.data_raw_file.clone(),
-                self.backing_file.as_ref().map(Arc::clone),
-                self.sparse,
-                ring_depth,
-            )
-            .map_err(|e| BlockError::new(BlockErrorKind::Io, DiskFileError::NewAsyncIo(e)))?,
-        ))
-    }
-}
+use crate::{BatchRequest, RequestType, SECTOR_SIZE};
 
 /// Per queue QCOW2 I/O worker using io_uring.
 ///
@@ -271,7 +139,7 @@ impl AsyncIo for QcowAsync {
                         .user_data(user_data),
                 )
                 .map_err(|_| {
-                    AsyncIoError::ReadVectored(Error::other("Submission queue is full"))
+                    AsyncIoError::ReadVectored(io::Error::other("Submission queue is full"))
                 })?;
             };
 
@@ -418,7 +286,9 @@ impl AsyncIo for QcowAsync {
                                 .user_data(req.user_data),
                             )
                             .map_err(|_| {
-                                AsyncIoError::ReadVectored(Error::other("Submission queue is full"))
+                                AsyncIoError::ReadVectored(io::Error::other(
+                                    "Submission queue is full",
+                                ))
                             })?;
                         }
                         needs_submit = true;

--- a/block/src/qcow_disk.rs
+++ b/block/src/qcow_disk.rs
@@ -237,4 +237,21 @@ mod unit_tests {
         let disk = QcowDisk::new(file, false, false, true, true).unwrap();
         assert_async_io(&disk, true);
     }
+
+    #[test]
+    fn try_clone_preserves_sync_dispatch() {
+        let file = make_qcow_file();
+        let disk = QcowDisk::new(file, false, false, true, false).unwrap();
+        let cloned = disk.try_clone().unwrap();
+        assert_async_io_from_dyn(cloned.as_ref(), false);
+    }
+
+    #[cfg(feature = "io_uring")]
+    #[test]
+    fn try_clone_preserves_io_uring_dispatch() {
+        let file = make_qcow_file();
+        let disk = QcowDisk::new(file, false, false, true, true).unwrap();
+        let cloned = disk.try_clone().unwrap();
+        assert_async_io_from_dyn(cloned.as_ref(), true);
+    }
 }

--- a/block/src/qcow_disk.rs
+++ b/block/src/qcow_disk.rs
@@ -193,7 +193,7 @@ mod unit_tests {
 
     use super::*;
     use crate::async_io::AsyncIo;
-    use crate::disk_file::{AsyncDiskFile, DiskSize};
+    use crate::disk_file::{AsyncDiskFile, DiskSize, PhysicalSize};
     use crate::qcow::{QcowFile, RawFile};
 
     const TEST_SIZE: u64 = 0x5566_7788;
@@ -253,5 +253,14 @@ mod unit_tests {
         let disk = QcowDisk::new(file, false, false, true, true).unwrap();
         let cloned = disk.try_clone().unwrap();
         assert_async_io_from_dyn(cloned.as_ref(), true);
+    }
+
+    #[test]
+    fn physical_size_less_than_logical() {
+        // make_qcow_file() writes no guest data, so the file on disk
+        // only contains QCOW2 headers and metadata tables.
+        let file = make_qcow_file();
+        let disk = QcowDisk::new(file, false, false, true, false).unwrap();
+        assert!(disk.physical_size().unwrap() < disk.logical_size().unwrap());
     }
 }

--- a/block/src/qcow_disk.rs
+++ b/block/src/qcow_disk.rs
@@ -192,7 +192,8 @@ mod unit_tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
-    use crate::disk_file::DiskSize;
+    use crate::async_io::AsyncIo;
+    use crate::disk_file::{AsyncDiskFile, DiskSize};
     use crate::qcow::{QcowFile, RawFile};
 
     const TEST_SIZE: u64 = 0x5566_7788;
@@ -211,5 +212,29 @@ mod unit_tests {
         let file = make_qcow_file();
         let disk = QcowDisk::new(file, false, false, true, false).unwrap();
         assert_eq!(disk.logical_size().unwrap(), TEST_SIZE);
+    }
+
+    fn assert_async_io_from_dyn(disk: &dyn AsyncDiskFile, expect_batch: bool) {
+        let io: Box<dyn AsyncIo> = disk.create_async_io(128).unwrap();
+        assert_eq!(io.batch_requests_enabled(), expect_batch);
+    }
+
+    fn assert_async_io(disk: &QcowDisk, expect_batch: bool) {
+        assert_async_io_from_dyn(disk, expect_batch);
+    }
+
+    #[test]
+    fn sync_backend_disables_batch_requests() {
+        let file = make_qcow_file();
+        let disk = QcowDisk::new(file, false, false, true, false).unwrap();
+        assert_async_io(&disk, false);
+    }
+
+    #[cfg(feature = "io_uring")]
+    #[test]
+    fn io_uring_backend_enables_batch_requests() {
+        let file = make_qcow_file();
+        let disk = QcowDisk::new(file, false, false, true, true).unwrap();
+        assert_async_io(&disk, true);
     }
 }

--- a/block/src/qcow_disk.rs
+++ b/block/src/qcow_disk.rs
@@ -186,3 +186,30 @@ impl disk_file::AsyncDiskFile for QcowDisk {
         )))
     }
 }
+
+#[cfg(test)]
+mod unit_tests {
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+    use crate::disk_file::DiskSize;
+    use crate::qcow::{QcowFile, RawFile};
+
+    const TEST_SIZE: u64 = 0x5566_7788;
+
+    fn make_qcow_file() -> File {
+        let temp_file = TempFile::new().unwrap();
+        {
+            let raw = RawFile::new(temp_file.as_file().try_clone().unwrap(), false);
+            QcowFile::new(raw, 3, TEST_SIZE, true).unwrap();
+        }
+        temp_file.into_file()
+    }
+
+    #[test]
+    fn new_sync_returns_correct_size() {
+        let file = make_qcow_file();
+        let disk = QcowDisk::new(file, false, false, true, false).unwrap();
+        assert_eq!(disk.logical_size().unwrap(), TEST_SIZE);
+    }
+}

--- a/block/src/qcow_disk.rs
+++ b/block/src/qcow_disk.rs
@@ -1,0 +1,188 @@
+// Copyright 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::File;
+use std::os::unix::io::AsRawFd;
+use std::sync::Arc;
+use std::{fmt, io};
+
+use crate::async_io::{AsyncIo, BorrowedDiskFd, DiskFileError};
+use crate::disk_file;
+use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
+use crate::qcow::backing::shared_backing_from;
+use crate::qcow::metadata::{BackingRead, QcowMetadata};
+use crate::qcow::qcow_raw_file::QcowRawFile;
+use crate::qcow::{MAX_NESTING_DEPTH, RawFile, parse_qcow};
+#[cfg(feature = "io_uring")]
+use crate::qcow_async::QcowAsync;
+use crate::qcow_sync::QcowSync;
+
+/// Unified DiskFile wrapper for QCOW2 disk images.
+///
+/// Holds the in memory QCOW2 metadata, the data file, and an optional
+/// backing file. The metadata is wrapped in an `Arc` because
+/// [`QcowSync`] and [`QcowAsync`] I/O workers receive a clone when
+/// they are created via [`create_async_io`](DiskFile::create_async_io).
+/// The backing file is likewise shared with workers through an `Arc`.
+///
+/// The `sparse` flag controls whether the image advertises discard
+/// support to the guest. The `use_io_uring` flag selects between the
+/// [`QcowSync`] and [`QcowAsync`] I/O backends. Both are recorded at
+/// construction time and propagated through [`try_clone`](DiskFile::try_clone).
+pub struct QcowDisk {
+    metadata: Arc<QcowMetadata>,
+    backing_file: Option<Arc<dyn BackingRead>>,
+    sparse: bool,
+    data_raw_file: QcowRawFile,
+    use_io_uring: bool,
+}
+
+impl fmt::Debug for QcowDisk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QcowDisk")
+            .field("sparse", &self.sparse)
+            .field("has_backing", &self.backing_file.is_some())
+            .field("use_io_uring", &self.use_io_uring)
+            .finish_non_exhaustive()
+    }
+}
+
+impl QcowDisk {
+    pub fn new(
+        file: File,
+        direct_io: bool,
+        backing_files: bool,
+        sparse: bool,
+        use_io_uring: bool,
+    ) -> BlockResult<Self> {
+        #[cfg(not(feature = "io_uring"))]
+        if use_io_uring {
+            return Err(BlockError::new(
+                BlockErrorKind::UnsupportedFeature,
+                DiskFileError::NewAsyncIo(io::Error::other(
+                    "io_uring requested but feature is not enabled",
+                )),
+            ));
+        }
+
+        let max_nesting_depth = if backing_files { MAX_NESTING_DEPTH } else { 0 };
+        let raw_file = RawFile::new(file, direct_io);
+        let (inner, backing_file, sparse) = parse_qcow(raw_file, max_nesting_depth, sparse)
+            .map_err(|e| {
+                let e = if !backing_files && matches!(e.kind(), BlockErrorKind::Overflow) {
+                    e.with_kind(BlockErrorKind::UnsupportedFeature)
+                } else {
+                    e
+                };
+                e.with_op(ErrorOp::Open)
+            })?;
+        let data_raw_file = inner.raw_file.clone();
+        Ok(QcowDisk {
+            metadata: Arc::new(QcowMetadata::new(inner)),
+            backing_file: backing_file.map(shared_backing_from).transpose()?,
+            sparse,
+            data_raw_file,
+            use_io_uring,
+        })
+    }
+}
+
+impl Drop for QcowDisk {
+    fn drop(&mut self) {
+        self.metadata.shutdown();
+    }
+}
+
+impl disk_file::DiskSize for QcowDisk {
+    fn logical_size(&self) -> BlockResult<u64> {
+        Ok(self.metadata.virtual_size())
+    }
+}
+
+impl disk_file::PhysicalSize for QcowDisk {
+    fn physical_size(&self) -> BlockResult<u64> {
+        Ok(self.data_raw_file.physical_size()?)
+    }
+}
+
+impl disk_file::DiskFd for QcowDisk {
+    fn fd(&self) -> BorrowedDiskFd<'_> {
+        BorrowedDiskFd::new(self.data_raw_file.as_raw_fd())
+    }
+}
+
+impl disk_file::Geometry for QcowDisk {}
+
+impl disk_file::SparseCapable for QcowDisk {
+    fn supports_sparse_operations(&self) -> bool {
+        true
+    }
+
+    fn supports_zero_flag(&self) -> bool {
+        true
+    }
+}
+
+impl disk_file::Resizable for QcowDisk {
+    fn resize(&mut self, size: u64) -> BlockResult<()> {
+        if self.backing_file.is_some() {
+            return Err(BlockError::new(
+                BlockErrorKind::UnsupportedFeature,
+                DiskFileError::ResizeError(io::Error::other(
+                    "resize not supported with backing files",
+                )),
+            )
+            .with_op(ErrorOp::Resize));
+        }
+        self.metadata.resize(size).map_err(|e| {
+            BlockError::new(BlockErrorKind::Io, DiskFileError::ResizeError(e))
+                .with_op(ErrorOp::Resize)
+        })
+    }
+}
+
+impl disk_file::DiskFile for QcowDisk {}
+
+impl disk_file::AsyncDiskFile for QcowDisk {
+    fn try_clone(&self) -> BlockResult<Box<dyn disk_file::AsyncDiskFile>> {
+        Ok(Box::new(QcowDisk {
+            metadata: Arc::clone(&self.metadata),
+            backing_file: self.backing_file.as_ref().map(Arc::clone),
+            sparse: self.sparse,
+            data_raw_file: self.data_raw_file.clone(),
+            use_io_uring: self.use_io_uring,
+        }))
+    }
+
+    fn create_async_io(&self, ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
+        if self.use_io_uring {
+            #[cfg(feature = "io_uring")]
+            {
+                return Ok(Box::new(
+                    QcowAsync::new(
+                        Arc::clone(&self.metadata),
+                        self.data_raw_file.clone(),
+                        self.backing_file.as_ref().map(Arc::clone),
+                        self.sparse,
+                        ring_depth,
+                    )
+                    .map_err(|e| {
+                        BlockError::new(BlockErrorKind::Io, DiskFileError::NewAsyncIo(e))
+                    })?,
+                ));
+            }
+
+            #[cfg(not(feature = "io_uring"))]
+            unreachable!("use_io_uring is set but io_uring feature is not enabled");
+        }
+
+        let _ = ring_depth;
+        Ok(Box::new(QcowSync::new(
+            Arc::clone(&self.metadata),
+            self.data_raw_file.clone(),
+            self.backing_file.as_ref().map(Arc::clone),
+            self.sparse,
+        )))
+    }
+}

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -4,156 +4,28 @@
 
 use std::cmp::min;
 use std::collections::VecDeque;
-use std::fs::File;
-use std::os::fd::{AsFd, AsRawFd};
+use std::os::unix::io::AsRawFd;
 use std::sync::Arc;
-use std::{fmt, io};
 
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
-use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult, BorrowedDiskFd, DiskFileError};
-use crate::disk_file;
-use crate::error::{BlockError, BlockErrorKind, BlockResult, ErrorOp};
-use crate::qcow::backing::shared_backing_from;
+use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
 use crate::qcow::decoder::Decoder;
 use crate::qcow::metadata::{
     BackingRead, ClusterReadMapping, ClusterWriteMapping, DeallocAction, QcowMetadata,
 };
 use crate::qcow::qcow_raw_file::QcowRawFile;
-use crate::qcow::{MAX_NESTING_DEPTH, RawFile, parse_qcow};
 use crate::qcow_common::{
     AlignedBuf, aligned_pread, aligned_pwrite, decompress_cluster, gather_from_iovecs,
     gather_from_iovecs_into, pread_alloc, pread_exact, pwrite_all, scatter_to_iovecs,
     zero_fill_iovecs,
 };
 
-pub struct QcowDiskSync {
-    metadata: Arc<QcowMetadata>,
-    /// Shared across queues, resolved once at construction.
-    backing_file: Option<Arc<dyn BackingRead>>,
-    sparse: bool,
-    data_raw_file: QcowRawFile,
-}
-
-impl fmt::Debug for QcowDiskSync {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("QcowDiskSync")
-            .field("sparse", &self.sparse)
-            .field("has_backing", &self.backing_file.is_some())
-            .finish_non_exhaustive()
-    }
-}
-
-impl QcowDiskSync {
-    pub fn new(
-        file: File,
-        direct_io: bool,
-        backing_files: bool,
-        sparse: bool,
-    ) -> BlockResult<Self> {
-        let max_nesting_depth = if backing_files { MAX_NESTING_DEPTH } else { 0 };
-        let (inner, backing_file, sparse) =
-            parse_qcow(RawFile::new(file, direct_io), max_nesting_depth, sparse).map_err(|e| {
-                let e = if !backing_files && matches!(e.kind(), BlockErrorKind::Overflow) {
-                    e.with_kind(BlockErrorKind::UnsupportedFeature)
-                } else {
-                    e
-                };
-                e.with_op(ErrorOp::Open)
-            })?;
-        let data_raw_file = inner.raw_file.clone();
-        Ok(QcowDiskSync {
-            metadata: Arc::new(QcowMetadata::new(inner)),
-            backing_file: backing_file.map(shared_backing_from).transpose()?,
-            sparse,
-            data_raw_file,
-        })
-    }
-}
-
-impl Drop for QcowDiskSync {
-    fn drop(&mut self) {
-        self.metadata.shutdown();
-    }
-}
-
-impl disk_file::DiskSize for QcowDiskSync {
-    fn logical_size(&self) -> BlockResult<u64> {
-        Ok(self.metadata.virtual_size())
-    }
-}
-
-impl disk_file::PhysicalSize for QcowDiskSync {
-    fn physical_size(&self) -> BlockResult<u64> {
-        Ok(self.data_raw_file.physical_size()?)
-    }
-}
-
-impl disk_file::DiskFd for QcowDiskSync {
-    fn fd(&self) -> BorrowedDiskFd<'_> {
-        BorrowedDiskFd::new(self.data_raw_file.as_fd().as_raw_fd())
-    }
-}
-
-impl disk_file::Geometry for QcowDiskSync {}
-
-impl disk_file::SparseCapable for QcowDiskSync {
-    fn supports_sparse_operations(&self) -> bool {
-        true
-    }
-
-    fn supports_zero_flag(&self) -> bool {
-        true
-    }
-}
-
-impl disk_file::Resizable for QcowDiskSync {
-    fn resize(&mut self, size: u64) -> BlockResult<()> {
-        if self.backing_file.is_some() {
-            return Err(BlockError::new(
-                BlockErrorKind::UnsupportedFeature,
-                DiskFileError::ResizeError(io::Error::other(
-                    "resize not supported with backing file",
-                )),
-            )
-            .with_op(ErrorOp::Resize));
-        }
-        self.metadata.resize(size).map_err(|e| {
-            BlockError::new(BlockErrorKind::Io, DiskFileError::ResizeError(e))
-                .with_op(ErrorOp::Resize)
-        })
-    }
-}
-
-impl disk_file::DiskFile for QcowDiskSync {}
-
-impl disk_file::AsyncDiskFile for QcowDiskSync {
-    fn try_clone(&self) -> BlockResult<Box<dyn disk_file::AsyncDiskFile>> {
-        Ok(Box::new(QcowDiskSync {
-            metadata: Arc::clone(&self.metadata),
-            backing_file: self.backing_file.as_ref().map(Arc::clone),
-            sparse: self.sparse,
-            data_raw_file: self.data_raw_file.clone(),
-        }))
-    }
-
-    // ring_depth is unused - this sync backend performs blocking I/O
-    // instead of submitting to an async ring.
-    fn create_async_io(&self, _ring_depth: u32) -> BlockResult<Box<dyn AsyncIo>> {
-        Ok(Box::new(QcowSync::new(
-            Arc::clone(&self.metadata),
-            self.data_raw_file.clone(),
-            self.backing_file.as_ref().map(Arc::clone),
-            self.sparse,
-        )))
-    }
-}
-
 pub struct QcowSync {
     metadata: Arc<QcowMetadata>,
     data_file: QcowRawFile,
-    /// See the backing_file field on QcowDiskSync.
+    /// See the backing_file field on QcowDisk.
     backing_file: Option<Arc<dyn BackingRead>>,
     sparse: bool,
     /// O_DIRECT alignment requirement (0 = no alignment needed).

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -165,7 +165,7 @@ pub struct QcowSync {
 }
 
 impl QcowSync {
-    fn new(
+    pub(crate) fn new(
         metadata: Arc<QcowMetadata>,
         data_file: QcowRawFile,
         backing_file: Option<Arc<dyn BackingRead>>,

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -449,6 +449,7 @@ mod unit_tests {
     use crate::disk_file::{AsyncDiskFile, DiskSize, Resizable};
     use crate::qcow::{BackingFileConfig, ImageType, QcowFile, RawFile};
     use crate::qcow_common::unit_tests::compress_allocated_clusters;
+    use crate::qcow_disk::QcowDisk;
 
     fn create_disk_with_data(
         file_size: u64,
@@ -456,7 +457,7 @@ mod unit_tests {
         offset: u64,
         sparse: bool,
         direct_io: bool,
-    ) -> (TempFile, QcowDiskSync) {
+    ) -> (TempFile, QcowDisk) {
         let temp_file = TempFile::new().unwrap();
         {
             let raw_file = RawFile::new(temp_file.as_file().try_clone().unwrap(), false);
@@ -465,17 +466,18 @@ mod unit_tests {
             qcow_file.write_all(data).unwrap();
             qcow_file.flush().unwrap();
         }
-        let disk = QcowDiskSync::new(
+        let disk = QcowDisk::new(
             temp_file.as_file().try_clone().unwrap(),
             direct_io,
             false,
             sparse,
+            false,
         )
         .unwrap();
         (temp_file, disk)
     }
 
-    fn async_read(disk: &QcowDiskSync, offset: u64, len: usize) -> Vec<u8> {
+    fn async_read(disk: &QcowDisk, offset: u64, len: usize) -> Vec<u8> {
         let mut async_io = disk.create_async_io(1).unwrap();
         let mut buf = vec![0xFFu8; len];
         let iovec = libc::iovec {
@@ -491,7 +493,7 @@ mod unit_tests {
         buf
     }
 
-    fn async_write(disk: &QcowDiskSync, offset: u64, data: &[u8]) {
+    fn async_write(disk: &QcowDisk, offset: u64, data: &[u8]) {
         let mut async_io = disk.create_async_io(1).unwrap();
         let iovec = libc::iovec {
             iov_base: data.as_ptr() as *mut libc::c_void,
@@ -565,8 +567,14 @@ mod unit_tests {
             qcow_file.flush().unwrap();
         }
 
-        let disk =
-            QcowDiskSync::new(_temp.as_file().try_clone().unwrap(), false, false, true).unwrap();
+        let disk = QcowDisk::new(
+            _temp.as_file().try_clone().unwrap(),
+            false,
+            false,
+            true,
+            false,
+        )
+        .unwrap();
 
         let mut async_io = disk.create_async_io(1).unwrap();
 
@@ -733,7 +741,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
+        let disk = QcowDisk::new(file, direct_io, true, true, false).unwrap();
 
         // Read first cluster - should come from backing file
         let buf = async_read(&disk, 0, cluster_size as usize);
@@ -804,7 +812,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
+        let disk = QcowDisk::new(file, direct_io, true, true, false).unwrap();
 
         // Read first cluster - should come from QCOW2 backing
         let buf = async_read(&disk, 0, cluster_size as usize);
@@ -927,7 +935,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = Arc::new(QcowDiskSync::new(file, direct_io, true, true).unwrap());
+        let disk = Arc::new(QcowDisk::new(file, direct_io, true, true, false).unwrap());
 
         let threads: Vec<_> = (0..8)
             .map(|t| {
@@ -1010,7 +1018,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
+        let disk = QcowDisk::new(file, direct_io, true, true, false).unwrap();
 
         // Cluster 0: mid wrote 0xBB
         let buf = async_read(&disk, 0, cluster_size as usize);
@@ -1085,7 +1093,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
+        let disk = QcowDisk::new(file, direct_io, true, true, false).unwrap();
 
         let written = vec![0xFFu8; cluster_size as usize];
         for &idx in &[0u64, 3, 7] {
@@ -1157,7 +1165,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
+        let disk = QcowDisk::new(file, direct_io, true, true, false).unwrap();
 
         // Read cluster 2 (past backing virtual_size) - should be zeros
         let buf = async_read(&disk, backing_size, cluster_size as usize);
@@ -1207,7 +1215,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
+        let disk = QcowDisk::new(file, direct_io, true, true, false).unwrap();
 
         // Read 2 clusters starting at cluster 1 (spans backing boundary)
         let read_len = cluster_size as usize * 2;
@@ -1260,7 +1268,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
+        let disk = QcowDisk::new(file, direct_io, true, true, false).unwrap();
 
         // Read cluster 2 (past backing size) - should be zeros
         let buf = async_read(&disk, backing_size, cluster_size as usize);
@@ -1321,7 +1329,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
+        let disk = QcowDisk::new(file, direct_io, true, true, false).unwrap();
 
         // Read spanning clusters 1-2 boundary: 512 bytes before + 512 after
         let mid = cluster_size - 512;
@@ -1378,7 +1386,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
+        let disk = QcowDisk::new(file, direct_io, true, true, false).unwrap();
 
         let written = vec![0xFFu8; cluster_size as usize];
         async_write(&disk, 0, &written);
@@ -1488,7 +1496,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let disk = QcowDiskSync::new(file, direct_io, true, true).unwrap();
+        let disk = QcowDisk::new(file, direct_io, true, true, false).unwrap();
 
         // Write 4KB at offset 4KB within cluster 0 (partial cluster)
         let write_offset = 4096u64;
@@ -1648,7 +1656,7 @@ mod unit_tests {
         }
 
         let file = overlay_temp.as_file().try_clone().unwrap();
-        let mut disk = QcowDiskSync::new(file, false, true, true).unwrap();
+        let mut disk = QcowDisk::new(file, false, true, true, false).unwrap();
 
         assert_eq!(disk.logical_size().unwrap(), file_size);
         let result = disk.resize(file_size * 2);
@@ -1944,8 +1952,14 @@ mod unit_tests {
 
         compress_allocated_clusters(&mut temp.as_file().try_clone().unwrap());
 
-        let disk =
-            QcowDiskSync::new(temp.as_file().try_clone().unwrap(), false, false, false).unwrap();
+        let disk = QcowDisk::new(
+            temp.as_file().try_clone().unwrap(),
+            false,
+            false,
+            false,
+            false,
+        )
+        .unwrap();
 
         let buf = async_read(&disk, 0, cluster_size);
         assert_eq!(buf, data);

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -334,8 +334,8 @@ pub fn micro_bench_qcow_l2_cache_miss(control: &PerformanceTestControl) -> f64 {
 /// Read num_ops clusters from a prepopulated qcow2 image through the
 /// QcowAsync io_uring path and time the total wall clock.
 ///
-/// Unlike micro_bench_qcow_read which uses QcowDiskSync (blocking),
-/// this uses QcowDiskAsync where single-allocated-cluster reads go
+/// Unlike micro_bench_qcow_read which uses the synchronous backend,
+/// this uses the io_uring backend where single allocated cluster reads go
 /// through io_uring for true asynchronous completion.
 ///
 /// Returns the total read wall clock time in seconds.

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -13,8 +13,7 @@ use std::time::Duration;
 
 use block::async_io::AsyncIo;
 use block::qcow::{BackingFileConfig, ImageType, QcowFile, RawFile};
-use block::qcow_async::QcowDiskAsync;
-use block::qcow_sync::QcowDiskSync;
+use block::qcow_disk::QcowDisk;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::tempfile::TempFile;
 
@@ -52,20 +51,26 @@ fn create_qcow_tempfile(num_clusters: usize) -> TempFile {
 }
 
 /// Create a QCOW2 image with `num_clusters` allocated clusters opened
-/// via `QcowDiskSync` (blocking I/O backend).
-pub fn qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDiskSync) {
+/// via QcowDisk with synchronous backend.
+pub fn qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
     let tmp = create_qcow_tempfile(num_clusters);
-    let disk = QcowDiskSync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
-        .expect("failed to open QCOW2 via QcowDiskSync");
+    let disk = QcowDisk::new(
+        tmp.as_file().try_clone().unwrap(),
+        false,
+        false,
+        true,
+        false,
+    )
+    .expect("failed to open QCOW2 via QcowDisk");
     (tmp, disk)
 }
 
 /// Create a QCOW2 image with `num_clusters` allocated clusters opened
-/// via `QcowDiskAsync` (io_uring backend).
-pub fn qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDiskAsync) {
+/// via QcowDisk with io_uring backend.
+pub fn qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
     let tmp = create_qcow_tempfile(num_clusters);
-    let disk = QcowDiskAsync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
-        .expect("failed to open QCOW2 via QcowDiskAsync");
+    let disk = QcowDisk::new(tmp.as_file().try_clone().unwrap(), false, false, true, true)
+        .expect("failed to open QCOW2 via QcowDisk");
     (tmp, disk)
 }
 
@@ -150,19 +155,25 @@ fn create_empty_qcow_tempfile(num_clusters: usize) -> TempFile {
     tmp
 }
 
-/// Empty QCOW2 opened via QcowDiskSync.
-pub fn empty_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDiskSync) {
+/// Empty QCOW2 opened via QcowDisk with synchronous backend.
+pub fn empty_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
     let tmp = create_empty_qcow_tempfile(num_clusters);
-    let disk = QcowDiskSync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
-        .expect("failed to open qcow2 via QcowDiskSync");
+    let disk = QcowDisk::new(
+        tmp.as_file().try_clone().unwrap(),
+        false,
+        false,
+        true,
+        false,
+    )
+    .expect("failed to open QCOW2 via QcowDisk");
     (tmp, disk)
 }
 
-/// Empty QCOW2 opened via QcowDiskAsync.
-pub fn empty_qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDiskAsync) {
+/// Empty QCOW2 opened via QcowDisk with io_uring backend.
+pub fn empty_qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
     let tmp = create_empty_qcow_tempfile(num_clusters);
-    let disk = QcowDiskAsync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
-        .expect("failed to open qcow2 via QcowDiskAsync");
+    let disk = QcowDisk::new(tmp.as_file().try_clone().unwrap(), false, false, true, true)
+        .expect("failed to open QCOW2 via QcowDisk");
     (tmp, disk)
 }
 
@@ -196,19 +207,31 @@ fn create_overlay_tempfiles(num_clusters: usize) -> (TempFile, TempFile) {
     (backing, overlay)
 }
 
-/// QCOW2 overlay with raw backing opened via QcowDiskSync.
-pub fn qcow_overlay_tempfile(num_clusters: usize) -> (TempFile, TempFile, QcowDiskSync) {
+/// QCOW2 overlay with raw backing opened via QcowDisk with synchronous backend.
+pub fn qcow_overlay_tempfile(num_clusters: usize) -> (TempFile, TempFile, QcowDisk) {
     let (backing, overlay) = create_overlay_tempfiles(num_clusters);
-    let disk = QcowDiskSync::new(overlay.as_file().try_clone().unwrap(), false, true, true)
-        .expect("failed to open overlay qcow2 via QcowDiskSync");
+    let disk = QcowDisk::new(
+        overlay.as_file().try_clone().unwrap(),
+        false,
+        true,
+        true,
+        false,
+    )
+    .expect("failed to open overlay QCOW2 via QcowDisk");
     (backing, overlay, disk)
 }
 
-/// QCOW2 overlay with raw backing opened via QcowDiskAsync.
-pub fn qcow_async_overlay_tempfile(num_clusters: usize) -> (TempFile, TempFile, QcowDiskAsync) {
+/// QCOW2 overlay with raw backing opened via QcowDisk with io_uring backend.
+pub fn qcow_async_overlay_tempfile(num_clusters: usize) -> (TempFile, TempFile, QcowDisk) {
     let (backing, overlay) = create_overlay_tempfiles(num_clusters);
-    let disk = QcowDiskAsync::new(overlay.as_file().try_clone().unwrap(), false, true, true)
-        .expect("failed to open overlay qcow2 via QcowDiskAsync");
+    let disk = QcowDisk::new(
+        overlay.as_file().try_clone().unwrap(),
+        false,
+        true,
+        true,
+        true,
+    )
+    .expect("failed to open overlay QCOW2 via QcowDisk");
     (backing, overlay, disk)
 }
 
@@ -251,31 +274,33 @@ fn create_compressed_qcow_tempfile(num_clusters: usize) -> TempFile {
     qcow_tmp
 }
 
-/// Compressed QCOW2 opened via QcowDiskSync.
-pub fn compressed_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDiskSync) {
+/// Compressed QCOW2 opened via QcowDisk with synchronous backend.
+pub fn compressed_qcow_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
     let tmp = create_compressed_qcow_tempfile(num_clusters);
     let path = tmp.as_path().to_str().unwrap().to_string();
-    let disk = QcowDiskSync::new(
+    let disk = QcowDisk::new(
         File::open(&path).expect("failed to open compressed qcow2"),
         false,
         false,
         true,
+        false,
     )
-    .expect("failed to open compressed qcow2 via QcowDiskSync");
+    .expect("failed to open compressed QCOW2 via QcowDisk");
     (tmp, disk)
 }
 
-/// Compressed QCOW2 opened via QcowDiskAsync.
-pub fn compressed_qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDiskAsync) {
+/// Compressed QCOW2 opened via QcowDisk with io_uring backend.
+pub fn compressed_qcow_async_tempfile(num_clusters: usize) -> (TempFile, QcowDisk) {
     let tmp = create_compressed_qcow_tempfile(num_clusters);
     let path = tmp.as_path().to_str().unwrap().to_string();
-    let disk = QcowDiskAsync::new(
+    let disk = QcowDisk::new(
         File::open(&path).expect("failed to open compressed qcow2"),
         false,
         false,
         true,
+        true,
     )
-    .expect("failed to open compressed qcow2 via QcowDiskAsync");
+    .expect("failed to open compressed QCOW2 via QcowDisk");
     (tmp, disk)
 }
 
@@ -300,19 +325,25 @@ fn create_sparse_qcow_tempfile(num_l2_tables: usize) -> TempFile {
     tmp
 }
 
-/// Sparse QCOW2 opened via QcowDiskSync.
-pub fn sparse_qcow_tempfile(num_l2_tables: usize) -> (TempFile, QcowDiskSync) {
+/// Sparse QCOW2 opened via QcowDisk with synchronous backend.
+pub fn sparse_qcow_tempfile(num_l2_tables: usize) -> (TempFile, QcowDisk) {
     let tmp = create_sparse_qcow_tempfile(num_l2_tables);
-    let disk = QcowDiskSync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
-        .expect("failed to open qcow2 via QcowDiskSync");
+    let disk = QcowDisk::new(
+        tmp.as_file().try_clone().unwrap(),
+        false,
+        false,
+        true,
+        false,
+    )
+    .expect("failed to open QCOW2 via QcowDisk");
     (tmp, disk)
 }
 
-/// Sparse QCOW2 opened via QcowDiskAsync.
-pub fn sparse_qcow_async_tempfile(num_l2_tables: usize) -> (TempFile, QcowDiskAsync) {
+/// Sparse QCOW2 opened via QcowDisk with io_uring backend.
+pub fn sparse_qcow_async_tempfile(num_l2_tables: usize) -> (TempFile, QcowDisk) {
     let tmp = create_sparse_qcow_tempfile(num_l2_tables);
-    let disk = QcowDiskAsync::new(tmp.as_file().try_clone().unwrap(), false, false, true)
-        .expect("failed to open qcow2 via QcowDiskAsync");
+    let disk = QcowDisk::new(tmp.as_file().try_clone().unwrap(), false, false, true, true)
+        .expect("failed to open QCOW2 via QcowDisk");
     (tmp, disk)
 }
 


### PR DESCRIPTION
Replaces the two monolithic wrapper types `QcowDiskSync` and `QcowDiskAsync` with a single `QcowDisk` that owns the `QcowMetadata`, backing file, and data file, dispatching `create_async_io` to the correct I/O backend based on a `use_io_uring` flag.

The old wrappers duplicated every `DiskFile` trait impl even though only `create_async_io` differed between them. The unified type keeps the metadata/ownership layer in one place and leaves `QcowSync`/`QcowAsync` as pure I/O workers.

A runtime guard in the constructor returns an error when `use_io_uring` is true but the feature is compiled out.

The performance benchmarks and unit tests are updated to use the new type.

Planning and test implementation assisted by Claude Opus 4.6.

Ref: #7877