### PR TITLE
scripts: deduplicate docker args and support custom kernel

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,403 @@
+# Testing
+
+- [Testing](#testing)
+  - [Overview](#overview)
+  - [Prerequisites](#prerequisites)
+  - [The dev\_cli.sh entry point](#the-dev_clish-entry-point)
+    - [Global flags](#global-flags)
+    - [Building](#building)
+    - [Running tests](#running-tests)
+    - [Argument passthrough](#argument-passthrough)
+    - [Custom kernel and firmware](#custom-kernel-and-firmware)
+  - [Unit tests](#unit-tests)
+  - [Integration tests](#integration-tests)
+    - [x86\_64](#x86_64)
+    - [ARM64](#arm64)
+    - [VFIO](#vfio)
+    - [Windows guests](#windows-guests)
+    - [Rate limiter](#rate-limiter)
+    - [Confidential VMs](#confidential-vms)
+  - [Performance metrics](#performance-metrics)
+  - [Code coverage](#code-coverage)
+  - [CI workflows](#ci-workflows)
+
+## Overview
+
+All Cloud Hypervisor builds and tests run inside a Docker container to
+provide a reproducible environment. The main entry point is
+`scripts/dev_cli.sh`, which manages the container lifecycle and
+forwards arguments to the appropriate test scripts.
+
+The container image is published at
+`ghcr.io/cloud-hypervisor/cloud-hypervisor` and is automatically
+pulled on first use. A local build of the container can be triggered
+with `scripts/dev_cli.sh build-container` or by passing the `--local`
+flag.
+
+Test workloads (guest images, kernels, firmware) are stored on the host
+under `$HOME/workloads` and bind-mounted into the container at
+`/root/workloads`. Most test scripts download missing workloads
+automatically on first run.
+
+## Prerequisites
+
+A working Docker (or Podman) installation and access to `/dev/kvm`
+(or `/dev/mshv` for Microsoft Hypervisor tests) are required. The
+host must be running Linux on x86_64 or aarch64.
+
+```shell
+# Verify KVM is available
+ls -l /dev/kvm
+```
+
+The container image bundles all build dependencies. No Rust toolchain
+is needed on the host.
+
+## The dev_cli.sh entry point
+
+```
+scripts/dev_cli.sh [flags] <command> [<command args>]
+```
+
+### Global flags
+
+| Flag      | Description                                      |
+|-----------|--------------------------------------------------|
+| `--local` | Build and use a local container image instead of pulling from the registry. |
+
+### Building
+
+```shell
+scripts/dev_cli.sh build [--debug|--release] [--libc musl|gnu] \
+    [--hypervisor kvm|mshv] [--features <features>] \
+    [--volumes /host:/ctr#...] [-- <cargo args>]
+```
+
+| Flag           | Default | Description                              |
+|----------------|---------|------------------------------------------|
+| `--debug`      | yes     | Build debug binaries.                    |
+| `--release`    |         | Build release binaries.                  |
+| `--libc`       | `gnu`   | C library to link against (`musl`/`gnu`).|
+| `--hypervisor` | `kvm`   | Hypervisor backend (`kvm`/`mshv`).       |
+| `--features`   |         | Additional cargo features.               |
+| `--volumes`    |         | Extra host volumes (`/a:/a#/b:/b`).      |
+| `--runtime`    | `docker`| Container runtime (`docker`/`podman`).   |
+
+Arguments after `--` are forwarded directly to `cargo build`.
+
+### Running tests
+
+```shell
+scripts/dev_cli.sh tests [<test type>] [--libc musl|gnu] \
+    [--hypervisor kvm|mshv] [--volumes /host:/ctr#...] \
+    [-- <script args> [-- <binary args>]]
+```
+
+**Test type flags:**
+
+| Flag                           | Description                                |
+|--------------------------------|--------------------------------------------|
+| `--unit`                       | Run unit tests.                            |
+| `--integration`                | Run integration tests (includes live migration). |
+| `--integration-vfio`           | Run VFIO integration tests.                |
+| `--integration-windows`        | Run Windows guest integration tests.       |
+| `--integration-rate-limiter`   | Run rate limiter integration tests.        |
+| `--integration-cvm`            | Run confidential VM integration tests.     |
+| `--metrics`                    | Generate performance metrics.              |
+| `--coverage`                   | Generate code coverage.                    |
+| `--all`                        | Run both unit and integration tests.       |
+
+**Configuration flags:**
+
+| Flag           | Default | Description                              |
+|----------------|---------|------------------------------------------|
+| `--libc`       | `gnu`   | C library to link against (`musl`/`gnu`).|
+| `--hypervisor` | `kvm`   | Hypervisor backend (`kvm`/`mshv`).       |
+| `--volumes`    |         | Extra host volumes (`/a:/a#/b:/b`).      |
+
+### Argument passthrough
+
+The `--` separator creates layers of argument forwarding:
+
+```
+dev_cli.sh tests <flags> -- <script args> -- <binary args>
+```
+
+1. Everything before the first `--` is consumed by `dev_cli.sh`.
+2. Everything between the first and second `--` is forwarded to the
+   test script (e.g., `run_integration_tests_x86_64.sh`).
+3. Everything after the second `--` is forwarded to the test binary
+   itself (e.g., `performance-metrics`).
+
+The test scripts accept the following common arguments via
+`process_common_args()` in `scripts/test-util.sh`:
+
+| Argument              | Description                                  |
+|-----------------------|----------------------------------------------|
+| `--hypervisor kvm\|mshv` | Select hypervisor (also passed by dev_cli.sh). |
+| `--test-filter <name>`| Run only tests matching the filter.           |
+| `--test-exclude <name>`| Exclude tests matching the pattern.          |
+| `--build-guest-kernel`| Build the guest kernel from source instead of downloading a prebuilt binary. |
+
+**Example — run a single integration test:**
+
+```shell
+scripts/dev_cli.sh tests --integration \
+    -- --test-filter test_boot_from_virtio_pmem
+```
+
+**Example — run metrics excluding micro-benchmarks:**
+
+```shell
+scripts/dev_cli.sh tests --metrics \
+    -- --test-exclude micro_ \
+    -- --report-file /root/workloads/metrics.json
+```
+
+### Custom kernel and firmware
+
+The following environment variables allow overriding the default guest
+kernel or firmware binaries. Each variable is independent; set any
+combination without affecting the others.
+
+| Variable             | Description                                |
+|----------------------|--------------------------------------------|
+| `CH_CUSTOM_KERNEL`   | Path to a custom `vmlinux` (x86_64) or `Image` (aarch64) kernel binary. |
+| `CH_CUSTOM_FIRMWARE` | Path to a custom `hypervisor-fw` firmware binary. |
+| `CH_CUSTOM_OVMF`    | Path to a custom OVMF binary (`CLOUDHV.fd` on x86_64, `CLOUDHV_EFI.fd` on aarch64). |
+
+The paths refer to locations on the **host**. Before launching the
+Docker container, `dev_cli.sh` copies the referenced files into
+`$HOME/workloads` at the default names the test scripts expect
+(e.g., `vmlinux-x86_64`, `hypervisor-fw`, `CLOUDHV.fd`). Because
+the workloads directory is bind-mounted into the container, the
+existing download-if-missing guards inside the test scripts
+automatically skip the network fetch.
+
+```shell
+# Use a custom kernel for integration tests
+CH_CUSTOM_KERNEL=/path/to/vmlinux \
+    scripts/dev_cli.sh tests --integration
+
+# Override all three
+CH_CUSTOM_KERNEL=/path/to/vmlinux \
+CH_CUSTOM_FIRMWARE=/path/to/hypervisor-fw \
+CH_CUSTOM_OVMF=/path/to/CLOUDHV.fd \
+    scripts/dev_cli.sh tests --integration
+```
+
+## Unit tests
+
+```shell
+scripts/dev_cli.sh tests --unit [--libc musl|gnu] [--hypervisor kvm|mshv]
+```
+
+Unit tests run `cargo test` on the entire workspace in release mode:
+
+```
+cargo test --lib --bins --target <target> --release --workspace
+cargo test --doc --target <target> --release --workspace
+```
+
+The container is _not_ fully privileged. It receives `--device
+/dev/kvm` (or `/dev/mshv`), `--device /dev/net/tun`, and `--cap-add
+net_admin` so that tests requiring a hypervisor device or TAP
+interfaces can run.
+
+When the hypervisor is `mshv`, the feature flag `--features mshv` is
+passed to cargo. On x86_64 with KVM, the `tdx` feature is additionally
+enabled if needed (MSHV does not support TDX).
+
+## Integration tests
+
+All integration test containers run with `--privileged` and full
+access to `/dev`. Workloads are bind-mounted from the host.
+
+Test scripts use `cargo nextest run` with the `--release` profile.
+Tests are grouped by module name filter (e.g., `common_parallel`,
+`common_sequential`). Most groups support automatic retries (default
+3). The nextest configuration in `.config/nextest.toml` sets a
+slow-timeout of 60 seconds per period with automatic termination
+after 10 periods (i.e., any single test running longer than 10
+minutes is terminated).
+
+The Rust test modules are defined in `cloud-hypervisor/tests/integration.rs`:
+
+| Module               | Description                                        |
+|----------------------|----------------------------------------------------|
+| `common_parallel`    | Main tests run in parallel, including live migration. |
+| `common_sequential`  | Tests requiring serial execution (snapshot/restore, OVS-DPDK live migration). |
+| `dbus_api`           | D-Bus API tests (requires `dbus_api` feature).     |
+| `fw_cfg`             | Firmware configuration tests (requires `fw_cfg` feature). |
+| `ivshmem`            | Inter-VM shared memory tests (requires `ivshmem` feature). |
+| `aarch64_acpi`       | ARM64 ACPI-specific tests.                         |
+| `windows`            | Windows guest tests.                               |
+| `vfio`               | VFIO passthrough tests (x86_64 only).              |
+| `rate_limiter`       | Network/block rate limiting tests.                 |
+
+Confidential VM tests are in a separate file
+(`cloud-hypervisor/tests/integration_cvm.rs`) under the `common_cvm`
+module.
+
+### x86_64
+
+```shell
+scripts/dev_cli.sh tests --integration [--libc musl|gnu]
+```
+
+Runs `scripts/run_integration_tests_x86_64.sh`. The script
+automatically downloads and prepares all required workloads:
+
+- **Kernel:** `vmlinux-x86_64` (prebuilt or built from source with
+  `--build-guest-kernel`).
+- **Firmware:** `hypervisor-fw` (rust-hypervisor-firmware).
+- **OVMF:** `CLOUDHV.fd`.
+- **Guest images:** Ubuntu Focal and Jammy cloud images in multiple
+  formats (raw, qcow2, compressed, backing-file variants).
+- **Alpine:** Minirootfs and initramfs for lightweight boot tests.
+- **virtiofsd:** Built from source for virtio-fs tests.
+
+**System tuning applied inside the container:**
+
+- KSM (Kernel Same-page Merging) is enabled.
+- 2 MiB hugepages are allocated for DPDK/VDPA tests.
+- The open file descriptor limit is raised to 4096.
+
+**Test groups executed:** `common_parallel`, `common_sequential`,
+`dbus_api`, `fw_cfg`, `ivshmem`.
+
+The `dbus_api`, `fw_cfg`, and `ivshmem` groups are each built with
+their respective cargo feature enabled before running.
+
+Live migration tests (`test_live_migration_*`, `test_live_upgrade_*`)
+run as part of the `common_parallel` and `common_sequential` groups.
+
+### ARM64
+
+```shell
+scripts/dev_cli.sh tests --integration --libc musl
+```
+
+Runs `scripts/run_integration_tests_aarch64.sh`. The workload setup
+mirrors x86_64 with aarch64-specific images:
+
+- **Kernel:** `Image-arm64`.
+- **OVMF:** `CLOUDHV_EFI.fd`.
+- **Guest images:** Focal and Jammy aarch64 cloud images.
+
+**Test groups executed:** `common_parallel`, `common_sequential`,
+`aarch64_acpi`, `dbus_api`, `fw_cfg`, `ivshmem`.
+
+### VFIO
+
+```shell
+scripts/dev_cli.sh tests --integration-vfio
+```
+
+Runs `scripts/run_integration_tests_vfio.sh`. Requires dedicated
+hardware with an Nvidia GPU (Tesla T4) for VFIO passthrough testing.
+
+**Test groups executed (single-threaded):**
+
+| Group               | Description                               |
+|----------------------|-------------------------------------------|
+| `vfio::test_nvidia`  | Legacy VFIO with container/group interface.|
+| `vfio::test_iommufd` | VFIO with cdev interface via iommufd.      |
+
+### Windows guests
+
+```shell
+scripts/dev_cli.sh tests --integration-windows [--libc musl|gnu]
+```
+
+Runs the architecture-appropriate script:
+- x86_64: `scripts/run_integration_tests_windows_x86_64.sh`
+- aarch64: `scripts/run_integration_tests_windows_aarch64.sh`
+
+Both scripts require a pre-downloaded Windows guest image in the
+workloads directory. Device mapper snapshots are created to allow
+concurrent test runs without corrupting the base image.
+
+**Workloads:**
+
+| Architecture | Image                                        | Firmware         |
+|--------------|----------------------------------------------|------------------|
+| x86_64       | `windows-server-2025-amd64-1.raw`            | `CLOUDHV.fd`     |
+| aarch64      | `windows-11-iot-enterprise-aarch64.raw`       | `CLOUDHV_EFI.fd` |
+
+**Test group:** `windows` (single-threaded, retries 3).
+
+### Rate limiter
+
+```shell
+scripts/dev_cli.sh tests --integration-rate-limiter
+```
+
+Runs `scripts/run_integration_tests_rate_limiter.sh`. Downloads Jammy
+guest images and a prebuilt kernel.
+
+**Test group:** `rate_limiter` (single-threaded, no retries).
+
+### Confidential VMs
+
+```shell
+scripts/dev_cli.sh tests --integration-cvm [--hypervisor mshv]
+```
+
+Runs `scripts/run_integration_tests_cvm.sh`. Builds with `--features
+mshv,igvm,sev_snp` and requires IGVM files to be present at
+`/usr/share/cloud-hypervisor/cvm` on the host.
+
+**Test group:** `common_cvm` (`nproc / 4` threads, retries 3).
+
+## Performance metrics
+
+```shell
+scripts/dev_cli.sh tests --metrics [-- <script args> [-- <binary args>]]
+```
+
+Runs `scripts/run_metrics.sh`, which builds and executes the
+`performance-metrics` binary. The binary produces a JSON report with
+boot time, throughput, and latency measurements.
+
+Useful arguments:
+
+```shell
+# Exclude micro-benchmarks and write results to a file
+scripts/dev_cli.sh tests --metrics \
+    -- --test-exclude micro_ \
+    -- --report-file /root/workloads/metrics.json
+```
+
+## Code coverage
+
+```shell
+scripts/dev_cli.sh tests --coverage
+```
+
+Runs `scripts/run_coverage.sh`, which instruments the build with
+LLVM source-based code coverage, executes the test suite via
+`dbus-run-session`, and produces either an LCOV or HTML report. See
+[coverage.md](coverage.md) for details on collecting and viewing
+coverage data.
+
+## CI workflows
+
+The following GitHub Actions workflows exercise the test
+infrastructure on every pull request or merge-group event:
+
+| Workflow                        | Tests run                                           |
+|---------------------------------|-----------------------------------------------------|
+| `build.yaml`                    | Cargo build with multiple feature/toolchain combos. |
+| `quality.yaml`                  | Clippy (stable + beta), bisectability check.        |
+| `integration-x86-64.yaml`       | `--unit` + `--integration` (gnu, musl).             |
+| `integration-arm64.yaml`        | `--unit` + `--integration` + `--integration-windows` (musl). |
+| `integration-vfio.yaml`         | `--integration-vfio`.                               |
+| `integration-windows.yaml`      | `--integration-windows` (gnu, musl).                |
+| `integration-rate-limiter.yaml` | `--integration-rate-limiter`.                        |
+| `mshv-integration.yaml`         | `--hypervisor mshv --integration` on Azure VM.      |
+| `integration-metrics.yaml`      | `--metrics` (runs on push to `main` only).          |
+
+Most integration workflows run tests only on `merge_group` events.
+The `integration-x86-64.yaml` workflow also runs on `pull_request`
+events (limited to the `garm-jammy` + `gnu` combination).

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -500,6 +500,37 @@ cmd_tests() {
             ./scripts/run_unit_tests.sh "$@" || fix_dir_perms $? || exit $?
     fi
 
+    # Copy custom kernel/firmware into the workloads directory on the
+    # host so they are visible inside the container at the default
+    # paths.  Each variable is independent; only set vars are copied.
+    if [ -n "$CH_CUSTOM_KERNEL" ]; then
+        say "Copying custom kernel from $CH_CUSTOM_KERNEL"
+        if [ "$(uname -m)" = "aarch64" ]; then
+            cp "$CH_CUSTOM_KERNEL" "$CLH_INTEGRATION_WORKLOADS/Image-arm64"
+        else
+            cp "$CH_CUSTOM_KERNEL" "$CLH_INTEGRATION_WORKLOADS/vmlinux-x86_64"
+        fi
+    fi
+    if [ -n "$CH_CUSTOM_BZIMAGE" ]; then
+        say "Copying custom bzImage from $CH_CUSTOM_BZIMAGE"
+        if [ "$(uname -m)" = "x86_64" ]; then
+            cp "$CH_CUSTOM_BZIMAGE" "$CLH_INTEGRATION_WORKLOADS/bzImage-x86_64"
+        fi
+    fi
+
+    if [ -n "$CH_CUSTOM_FIRMWARE" ]; then
+        say "Copying custom firmware from $CH_CUSTOM_FIRMWARE"
+        cp "$CH_CUSTOM_FIRMWARE" "$CLH_INTEGRATION_WORKLOADS/hypervisor-fw"
+    fi
+    if [ -n "$CH_CUSTOM_OVMF" ]; then
+        say "Copying custom OVMF from $CH_CUSTOM_OVMF"
+        if [ "$(uname -m)" = "aarch64" ]; then
+            cp "$CH_CUSTOM_OVMF" "$CLH_INTEGRATION_WORKLOADS/CLOUDHV_EFI.fd"
+        else
+            cp "$CH_CUSTOM_OVMF" "$CLH_INTEGRATION_WORKLOADS/CLOUDHV.fd"
+        fi
+    fi
+
     # Extend common_args with integration-specific runtime settings.
     common_args+=(
         --privileged
@@ -514,6 +545,10 @@ cmd_tests() {
     common_env_args+=(
         --env USER="root"
         --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN"
+        --env CH_CUSTOM_KERNEL="$CH_CUSTOM_KERNEL"
+        --env CH_CUSTOM_BZIMAGE="$CH_CUSTOM_BZIMAGE"
+        --env CH_CUSTOM_FIRMWARE="$CH_CUSTOM_FIRMWARE"
+        --env CH_CUSTOM_OVMF="$CH_CUSTOM_OVMF"
     )
 
     if [ "$integration" = true ]; then

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -470,18 +470,23 @@ cmd_tests() {
         rustflags="$rustflags -C link-args=-Wl,-Bstatic -C link-args=-lc"
     fi
 
+    # Common base runtime args shared by all test container runs.
+    common_args=(
+        --name "$CLH_CTR_NAME"
+        --workdir "$CTR_CLH_ROOT_DIR"
+        --rm
+        --security-opt seccomp=unconfined
+        --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR"
+        ${exported_volumes:+$exported_volumes}
+    )
+
     if [[ "$unit" = true ]]; then
         say "Running unit tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
-            --name "$CLH_CTR_NAME" \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
+            "${common_args[@]}" \
             --device $exported_device \
             --device /dev/net/tun \
             --cap-add net_admin \
-            --security-opt seccomp=unconfined \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
             --env BUILD_TARGET="$target" \
             --env RUSTFLAGS="$rustflags" \
             --env TARGET_CC="$target_cc" \
@@ -490,21 +495,20 @@ cmd_tests() {
             ./scripts/run_unit_tests.sh "$@" || fix_dir_perms $? || exit $?
     fi
 
+    # Extend common_args with integration-specific runtime settings.
+    common_args+=(
+        --privileged
+        --ipc=host
+        --net="$CTR_CLH_NET"
+        "--mount" "type=tmpfs,destination=/tmp"
+        --volume /dev:/dev
+        --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS"
+    )
+
     if [ "$integration" = true ]; then
         say "Running integration tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
-            --name "$CLH_CTR_NAME" \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+            "${common_args[@]}" \
             --env USER="root" \
             --env BUILD_TARGET="$target" \
             --env RUSTFLAGS="$rustflags" \
@@ -522,19 +526,8 @@ cmd_tests() {
         copy_igvm_files "$SRC_IGVM_FILES_PATH" "$DEST_IGVM_FILES_PATH"
         say "Running CVM integration tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
-            --name "$CLH_CTR_NAME" \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
+            "${common_args[@]}" \
             --volume "$DEST_IGVM_FILES_PATH:$CTR_IGVM_FILES_PATH" \
-            ${exported_volumes:+"$exported_volumes"} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
             --env USER="root" \
             --env BUILD_TARGET="$target" \
             --env RUSTFLAGS="$rustflags" \
@@ -548,18 +541,7 @@ cmd_tests() {
     if [ "$integration_vfio" = true ]; then
         say "Running VFIO integration tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
-            --name "$CLH_CTR_NAME" \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+            "${common_args[@]}" \
             --env USER="root" \
             --env BUILD_TARGET="$target" \
             --env RUSTFLAGS="$rustflags" \
@@ -572,18 +554,7 @@ cmd_tests() {
     if [ "$integration_windows" = true ]; then
         say "Running Windows integration tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
-            --name "$CLH_CTR_NAME" \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+            "${common_args[@]}" \
             --env USER="root" \
             --env BUILD_TARGET="$target" \
             --env RUSTFLAGS="$rustflags" \
@@ -596,18 +567,7 @@ cmd_tests() {
     if [ "$integration_rate_limiter" = true ]; then
         say "Running 'rate limiter' integration tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
-            --name "$CLH_CTR_NAME" \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+            "${common_args[@]}" \
             --env USER="root" \
             --env BUILD_TARGET="$target" \
             --env RUSTFLAGS="$rustflags" \
@@ -620,18 +580,7 @@ cmd_tests() {
     if [ "$metrics" = true ]; then
         say "Generating performance metrics for $target..."
         run_container "$DOCKER_RUNTIME" run \
-            --name "$CLH_CTR_NAME" \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+            "${common_args[@]}" \
             --env USER="root" \
             --env BUILD_TARGET="$target" \
             --env RUSTFLAGS="$rustflags" \
@@ -645,18 +594,7 @@ cmd_tests() {
     if [ "$coverage" = true ]; then
         say "Generating code coverage information for $target..."
         run_container "$DOCKER_RUNTIME" run \
-            --name "$CLH_CTR_NAME" \
-            --workdir "$CTR_CLH_ROOT_DIR" \
-            --rm \
-            --privileged \
-            --security-opt seccomp=unconfined \
-            --ipc=host \
-            --net="$CTR_CLH_NET" \
-            --mount type=tmpfs,destination=/tmp \
-            --volume /dev:/dev \
-            --volume "$CLH_ROOT_DIR:$CTR_CLH_ROOT_DIR" \
-            ${exported_volumes:+$exported_volumes} \
-            --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS" \
+            "${common_args[@]}" \
             --env USER="root" \
             --env BUILD_TARGET="$target" \
             --env RUSTFLAGS="$rustflags" \

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -480,6 +480,13 @@ cmd_tests() {
         ${exported_volumes:+$exported_volumes}
     )
 
+    # Common base environment variables shared by all test container runs.
+    common_env_args=(
+        --env BUILD_TARGET="$target"
+        --env RUSTFLAGS="$rustflags"
+        --env TARGET_CC="$target_cc"
+    )
+
     if [[ "$unit" = true ]]; then
         say "Running unit tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
@@ -487,9 +494,7 @@ cmd_tests() {
             --device $exported_device \
             --device /dev/net/tun \
             --cap-add net_admin \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
+            "${common_env_args[@]}" \
             --env LLVM_PROFILE_FILE="$LLVM_PROFILE_FILE" \
             "$CTR_IMAGE" \
             ./scripts/run_unit_tests.sh "$@" || fix_dir_perms $? || exit $?
@@ -505,16 +510,18 @@ cmd_tests() {
         --volume "$CLH_INTEGRATION_WORKLOADS:$CTR_CLH_INTEGRATION_WORKLOADS"
     )
 
+    # Extend common_env_args with integration-specific settings.
+    common_env_args+=(
+        --env USER="root"
+        --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN"
+    )
+
     if [ "$integration" = true ]; then
         say "Running integration tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
             "${common_args[@]}" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
+            "${common_env_args[@]}" \
             --env PARALLEL_INTEGRATION_TESTS_NUM="${PARALLEL_INTEGRATION_TESTS_NUM:-}" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
             --env LLVM_PROFILE_FILE="$LLVM_PROFILE_FILE" \
             --env MIGRATABLE_VERSION="$MIGRATABLE_VERSION" \
             "$CTR_IMAGE" \
@@ -528,11 +535,7 @@ cmd_tests() {
         run_container "$DOCKER_RUNTIME" run \
             "${common_args[@]}" \
             --volume "$DEST_IGVM_FILES_PATH:$CTR_IGVM_FILES_PATH" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
+            "${common_env_args[@]}" \
             --env LLVM_PROFILE_FILE="$LLVM_PROFILE_FILE" \
             "$CTR_IMAGE" \
             ./scripts/run_integration_tests_cvm.sh "$@" || fix_dir_perms $? || exit $?
@@ -542,11 +545,7 @@ cmd_tests() {
         say "Running VFIO integration tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
             "${common_args[@]}" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
+            "${common_env_args[@]}" \
             "$CTR_IMAGE" \
             ./scripts/run_integration_tests_vfio.sh "$@" || fix_dir_perms $? || exit $?
     fi
@@ -555,11 +554,7 @@ cmd_tests() {
         say "Running Windows integration tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
             "${common_args[@]}" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
+            "${common_env_args[@]}" \
             "$CTR_IMAGE" \
             ./scripts/run_integration_tests_windows_"$(uname -m)".sh "$@" || fix_dir_perms $? || exit $?
     fi
@@ -568,11 +563,7 @@ cmd_tests() {
         say "Running 'rate limiter' integration tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
             "${common_args[@]}" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
+            "${common_env_args[@]}" \
             "$CTR_IMAGE" \
             ./scripts/run_integration_tests_rate_limiter.sh "$@" || fix_dir_perms $? || exit $?
     fi
@@ -581,12 +572,8 @@ cmd_tests() {
         say "Generating performance metrics for $target..."
         run_container "$DOCKER_RUNTIME" run \
             "${common_args[@]}" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
+            "${common_env_args[@]}" \
             --env RUST_BACKTRACE="${RUST_BACKTRACE}" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
             "$CTR_IMAGE" \
             ./scripts/run_metrics.sh "$@" || fix_dir_perms $? || exit $?
     fi
@@ -595,11 +582,7 @@ cmd_tests() {
         say "Generating code coverage information for $target..."
         run_container "$DOCKER_RUNTIME" run \
             "${common_args[@]}" \
-            --env USER="root" \
-            --env BUILD_TARGET="$target" \
-            --env RUSTFLAGS="$rustflags" \
-            --env TARGET_CC="$target_cc" \
-            --env AUTH_DOWNLOAD_TOKEN="$AUTH_DOWNLOAD_TOKEN" \
+            "${common_env_args[@]}" \
             "$CTR_IMAGE" \
             dbus-run-session ./scripts/run_coverage.sh "$@" || fix_dir_perms $? || exit $?
     fi

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -141,9 +141,17 @@ update_workloads() {
 
     pushd "$WORKLOADS_DIR" || exit
 
-    if ! sha1sum sha1sums-aarch64-common --check; then
-        echo "sha1sum validation of images failed, remove invalid images to fix the issue."
-        exit 1
+    # Skip checksum verification for custom-provided workloads
+    if [ -n "$CH_CUSTOM_OVMF" ]; then
+        if ! grep -v "CLOUDHV_EFI.fd" sha1sums-aarch64-common | sha1sum --check; then
+            echo "sha1sum validation of images failed, remove invalid images to fix the issue."
+            exit 1
+        fi
+    else
+        if ! sha1sum sha1sums-aarch64-common --check; then
+            echo "sha1sum validation of images failed, remove invalid images to fix the issue."
+            exit 1
+        fi
     fi
     popd || exit
 

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -137,7 +137,9 @@ update_workloads() {
     fi
 
     # Download aarch64 ovmf
-    download_aarch64_ovmf
+    if [ ! -f "$WORKLOADS_DIR/CLOUDHV_EFI.fd" ]; then
+        download_aarch64_ovmf
+    fi
 
     pushd "$WORKLOADS_DIR" || exit
 

--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -16,7 +16,9 @@ process_common_args "$@"
 
 WORKLOADS_DIR="$HOME/workloads"
 
-download_hypervisor_fw
+if [ ! -f "$WORKLOADS_DIR/hypervisor-fw" ]; then
+    download_hypervisor_fw
+fi
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then

--- a/scripts/run_integration_tests_windows_aarch64.sh
+++ b/scripts/run_integration_tests_windows_aarch64.sh
@@ -20,7 +20,9 @@ WIN_IMAGE_FILE="$WORKLOADS_DIR/$WIN_IMAGE_BASENAME"
 
 # Download aarch64 OVMF
 OVMF_FW="$WORKLOADS_DIR/CLOUDHV_EFI.fd"
-download_aarch64_ovmf
+if [ ! -f "$OVMF_FW" ]; then
+    download_aarch64_ovmf
+fi
 
 # Check if the images are present
 if [[ ! -f ${WIN_IMAGE_FILE} || ! -f ${OVMF_FW} ]]; then

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -16,9 +16,12 @@ fi
 WIN_IMAGE_FILE="/root/workloads/windows-server-2025-amd64-1.raw"
 
 WORKLOADS_DIR="/root/workloads"
+OVMF_FW="$WORKLOADS_DIR/CLOUDHV.fd"
 
 # Download amd64 ovmf
-download_amd64_ovmf
+if [ ! -f "$OVMF_FW" ]; then
+    download_amd64_ovmf
+fi
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -116,9 +116,21 @@ if [ ! -f "$ALPINE_INITRAMFS_IMAGE" ]; then
 fi
 
 pushd "$WORKLOADS_DIR" || exit
-if ! sha1sum sha1sums-x86_64 sha1sums-x86_64-common --check; then
-    echo "sha1sum validation of images failed, remove invalid images to fix the issue."
-    exit 1
+# Skip checksum verification for custom-provided workloads
+sha1_exclude=""
+[ -n "$CH_CUSTOM_FIRMWARE" ] && sha1_exclude="${sha1_exclude}|hypervisor-fw"
+[ -n "$CH_CUSTOM_OVMF" ] && sha1_exclude="${sha1_exclude}|CLOUDHV\\.fd"
+sha1_exclude="${sha1_exclude#|}"
+if [ -n "$sha1_exclude" ]; then
+    if ! cat sha1sums-x86_64 sha1sums-x86_64-common | grep -Ev "$sha1_exclude" | sha1sum --check; then
+        echo "sha1sum validation of images failed, remove invalid images to fix the issue."
+        exit 1
+    fi
+else
+    if ! sha1sum sha1sums-x86_64 sha1sums-x86_64-common --check; then
+        echo "sha1sum validation of images failed, remove invalid images to fix the issue."
+        exit 1
+    fi
 fi
 popd || exit
 

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -187,15 +187,32 @@ download_linux() {
 }
 
 prepare_linux() {
+    if [ "$build_kernel" = true ] && [ -n "$CH_CUSTOM_KERNEL" ]; then
+        echo "ERROR: --build-guest-kernel and CH_CUSTOM_KERNEL are mutually exclusive"
+        exit 1
+    fi
+
+    if [ "$(uname -m)" = "x86_64" ]; then
+        if { [ -n "$CH_CUSTOM_KERNEL" ] && [ -z "$CH_CUSTOM_BZIMAGE" ]; } ||
+            { [ -z "$CH_CUSTOM_KERNEL" ] && [ -n "$CH_CUSTOM_BZIMAGE" ]; }; then
+            echo "ERROR: On x86_64, both CH_CUSTOM_KERNEL and CH_CUSTOM_BZIMAGE must be provided"
+            exit 1
+        fi
+    fi
+
     if [ "$(uname -m)" = "aarch64" ]; then
         KERNEL_FILE="$WORKLOADS_DIR/Image-arm64"
-    else
+        if [[ -f "$KERNEL_FILE" ]]; then
+            echo "Kernel already present at $KERNEL_FILE, skipping"
+            return
+        fi
+    elif [ "$(uname -m)" = "x86_64" ]; then
         KERNEL_FILE="$WORKLOADS_DIR/vmlinux-x86_64"
         BZIMAGE_FILE="$WORKLOADS_DIR/bzImage-x86_64"
-    fi
-    if [[ -f "$KERNEL_FILE" && -f "$BZIMAGE_FILE" ]]; then
-        echo "Kernel already present at $KERNEL_FILE, skipping"
-        return
+        if [[ -f "$KERNEL_FILE" ]] && [[ -f "$BZIMAGE_FILE" ]]; then
+            echo "Kernel already present at $KERNEL_FILE and bzImage at $BZIMAGE_FILE, skipping"
+            return
+        fi
     fi
 
     if [ "$build_kernel" = true ]; then

--- a/scripts/test-util.sh
+++ b/scripts/test-util.sh
@@ -187,6 +187,17 @@ download_linux() {
 }
 
 prepare_linux() {
+    if [ "$(uname -m)" = "aarch64" ]; then
+        KERNEL_FILE="$WORKLOADS_DIR/Image-arm64"
+    else
+        KERNEL_FILE="$WORKLOADS_DIR/vmlinux-x86_64"
+        BZIMAGE_FILE="$WORKLOADS_DIR/bzImage-x86_64"
+    fi
+    if [[ -f "$KERNEL_FILE" && -f "$BZIMAGE_FILE" ]]; then
+        echo "Kernel already present at $KERNEL_FILE, skipping"
+        return
+    fi
+
     if [ "$build_kernel" = true ]; then
         echo "Building kernel from source"
         build_custom_linux


### PR DESCRIPTION
Motivation: At MSFT we do run integration tests internally and with our supported internal guest Kernel what we release for our customers. It's often necessary to have support from the script to accept custom built kernel.

## Summary

Deduplicate container arguments in `dev_cli.sh` and add support for
providing custom kernel, firmware, and OVMF binaries when running
integration tests. This allows developers to inject their own builds
without modifying scripts or waiting for unnecessary downloads.

## Changes

### Deduplicate container arguments (patches 1-2)

Extract `common_args` and `common_env_args` bash arrays so runtime
flags and environment variables shared across unit and integration
test containers are defined once instead of repeated in every block.

### Custom workload support (patches 3-5)

Introduce three independent environment variables:

| Variable             | Description                                                        |
|----------------------|--------------------------------------------------------------------|
| `CH_CUSTOM_KERNEL`   | Path to a custom `vmlinux` (x86_64) or `Image` (aarch64) binary   |
| `CH_CUSTOM_FIRMWARE` | Path to a custom `hypervisor-fw` firmware binary                   |
| `CH_CUSTOM_OVMF`    | Path to a custom OVMF binary (`CLOUDHV.fd` / `CLOUDHV_EFI.fd`)    |

- `dev_cli.sh` copies custom files into `$HOME/workloads/` at the
  default paths before launching the Docker container.
- File-existence guards in container scripts prevent re-downloading
  workloads that are already present.
- `sha1sum` verification filters out custom-provided firmware files
  so user-supplied binaries are not rejected.

### Documentation (patch 6)

Add `docs/testing.md` covering the `dev_cli.sh` interface, all test
types, custom kernel/firmware overrides, performance metrics, code
coverage, and the CI workflow matrix.

## Usage

```bash
# Custom kernel only
CH_CUSTOM_KERNEL=/path/to/vmlinux dev_cli.sh tests --integration

# All three overrides
CH_CUSTOM_KERNEL=/path/to/vmlinux \
CH_CUSTOM_FIRMWARE=/path/to/hypervisor-fw \
CH_CUSTOM_OVMF=/path/to/CLOUDHV.fd \
  dev_cli.sh tests --integration