### PR TITLE
vmm: support migration of paused VMs

### DIFF
--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -1070,6 +1070,7 @@ pub(crate) fn start_live_migration(
     src_api_socket: &str,
     dest_api_socket: &str,
     local: bool,
+    paused: bool,
 ) -> bool {
     // Start to receive migration from the destination VM
     let mut receive_migration = Command::new(clh_command("ch-remote"))
@@ -1084,8 +1085,17 @@ pub(crate) fn start_live_migration(
         .unwrap();
     // Give it '1s' to make sure the 'migration_socket' file is properly created
     thread::sleep(std::time::Duration::new(1, 0));
-    // Start to send migration from the source VM
 
+    if paused {
+        // Test the migration of a paused VM.
+        let cmd_success = remote_command(src_api_socket, "pause", None);
+        if !cmd_success {
+            let _ = receive_migration.kill();
+            eprintln!("Failed to pause the source VM before live migration");
+        }
+    }
+
+    // Start to send migration from the source VM
     let args = [
         format!("--api-socket={}", &src_api_socket),
         "send-migration".to_string(),
@@ -1145,6 +1155,28 @@ pub(crate) fn start_live_migration(
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+    } else if paused {
+        // for a paused VM, we should make sure the destinations VM state is still 'Paused' after
+        // migration.
+        let dest_state = vm_state(dest_api_socket);
+        if dest_state != "Paused" {
+            eprintln!(
+                "\n\n==== Start 'destination VM state' output ==== \
+                \n\nExpected destination VM state: Paused\nActual destination VM state: {dest_state} \
+                \n\n==== End 'destination VM state' output ====\n\n"
+            );
+            return false;
+        }
+        // Resume the paused VM to make sure it still works after migration
+        let cmd_success = remote_command(dest_api_socket, "resume", None);
+        if !cmd_success {
+            eprintln!(
+                "\n\n==== Start 'destination VM state' output ==== \
+                \n\nFailed to resume the destination VM after live migration \
+                \n\n==== End 'destination VM state' output ====\n\n"
+            );
+            return false;
+        }
     }
 
     send_success && receive_success

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6119,7 +6119,7 @@ mod common_parallel {
     //    live migration;
     // Note: This test does not use vsock as we can't create two identical vsock on the same host.
     #[cfg(not(feature = "mshv"))]
-    fn _test_live_migration(upgrade_test: bool, local: bool) {
+    fn _test_live_migration(upgrade_test: bool, local: bool, paused: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
@@ -6228,7 +6228,13 @@ mod common_parallel {
             );
 
             assert!(
-                start_live_migration(&migration_socket, &src_api_socket, &dest_api_socket, local),
+                start_live_migration(
+                    &migration_socket,
+                    &src_api_socket,
+                    &dest_api_socket,
+                    local,
+                    paused
+                ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );
         });
@@ -6403,7 +6409,13 @@ mod common_parallel {
             );
 
             assert!(
-                start_live_migration(&migration_socket, &src_api_socket, &dest_api_socket, local),
+                start_live_migration(
+                    &migration_socket,
+                    &src_api_socket,
+                    &dest_api_socket,
+                    local,
+                    false
+                ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );
         });
@@ -6563,7 +6575,13 @@ mod common_parallel {
             );
 
             assert!(
-                start_live_migration(&migration_socket, &src_api_socket, &dest_api_socket, true),
+                start_live_migration(
+                    &migration_socket,
+                    &src_api_socket,
+                    &dest_api_socket,
+                    true,
+                    false
+                ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );
         });
@@ -6995,13 +7013,25 @@ mod common_parallel {
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_live_migration_basic() {
-        _test_live_migration(false, false);
+        _test_live_migration(false, false, false);
     }
 
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_live_migration_local() {
-        _test_live_migration(false, true);
+        _test_live_migration(false, true, false);
+    }
+
+    #[test]
+    #[cfg(not(feature = "mshv"))]
+    fn test_live_migration_basic_paused() {
+        _test_live_migration(false, false, true);
+    }
+
+    #[test]
+    #[cfg(not(feature = "mshv"))]
+    fn test_live_migration_local_paused() {
+        _test_live_migration(false, true, true);
     }
 
     #[test]
@@ -7040,16 +7070,18 @@ mod common_parallel {
         _test_live_migration_watchdog(false, true);
     }
 
+    // TODO: Add test of live upgrade paused vm after cloud-hypervisor-static
+    // version is updated.
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_live_upgrade_basic() {
-        _test_live_migration(true, false);
+        _test_live_migration(true, false, false);
     }
 
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_live_upgrade_local() {
-        _test_live_migration(true, true);
+        _test_live_migration(true, true, false);
     }
 
     #[test]
@@ -7177,7 +7209,13 @@ mod common_parallel {
             let _ = std::fs::remove_file(&virtiofsd_socket_path);
 
             assert!(
-                start_live_migration(&migration_socket, &src_api_socket, &dest_api_socket, local),
+                start_live_migration(
+                    &migration_socket,
+                    &src_api_socket,
+                    &dest_api_socket,
+                    local,
+                    false
+                ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );
         });
@@ -7511,7 +7549,13 @@ mod ivshmem {
             );
 
             assert!(
-                start_live_migration(&migration_socket, &src_api_socket, &dest_api_socket, local),
+                start_live_migration(
+                    &migration_socket,
+                    &src_api_socket,
+                    &dest_api_socket,
+                    local,
+                    false
+                ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );
         });
@@ -8987,7 +9031,13 @@ mod common_sequential {
             );
 
             assert!(
-                start_live_migration(&migration_socket, &src_api_socket, &dest_api_socket, local),
+                start_live_migration(
+                    &migration_socket,
+                    &src_api_socket,
+                    &dest_api_socket,
+                    local,
+                    false
+                ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );
         });
@@ -9208,7 +9258,13 @@ mod common_sequential {
             );
 
             assert!(
-                start_live_migration(&migration_socket, &src_api_socket, &dest_api_socket, local),
+                start_live_migration(
+                    &migration_socket,
+                    &src_api_socket,
+                    &dest_api_socket,
+                    local,
+                    false
+                ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );
         });
@@ -9336,7 +9392,13 @@ mod common_sequential {
             );
 
             assert!(
-                start_live_migration(&migration_socket, &src_api_socket, &dest_api_socket, local),
+                start_live_migration(
+                    &migration_socket,
+                    &src_api_socket,
+                    &dest_api_socket,
+                    local,
+                    false
+                ),
                 "Unsuccessful command: 'send-migration' or 'receive-migration'."
             );
         });

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -103,6 +103,7 @@ use crate::bitpos_iterator::BitposIteratorExt;
 ///     Configured --> Configured: Memory
 ///     Configured --> StateReceived: State
 ///     StateReceived --> Completed: Complete
+///     StateReceived --> Completed: CompletePaused
 /// ```
 ///
 /// [live-migration protocol]: super::protocol
@@ -115,10 +116,14 @@ pub enum Command {
     Config,
     State,
     Memory,
-    /// Finalizes the migration and resumes the VM on the guest.
+    /// Finalizes the migration and resumes the VM on the destination.
+    /// Sent when the source VM was running at migration time.
     Complete,
     Abandon,
     MemoryFd,
+    /// Finalizes the migration without resuming the VM on the destination.
+    /// Sent when the source VM was paused at migration time.
+    CompletePaused,
 }
 
 #[repr(C)]
@@ -161,8 +166,14 @@ impl Request {
         Self::new(Command::MemoryFd, length)
     }
 
+    /// Finalizes the migration and resumes the VM on the destination.
     pub fn complete() -> Self {
         Self::new(Command::Complete, 0)
+    }
+
+    /// Finalizes the migration without resuming the VM on the destination.
+    pub fn complete_paused() -> Self {
+        Self::new(Command::CompletePaused, 0)
     }
 
     pub fn abandon() -> Self {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -986,6 +986,10 @@ impl Vmm {
             StateReceived {
                 state_receive_begin,
             } => match req.command() {
+                Command::CompletePaused => {
+                    debug!("Migration (incoming): Receiving final state of a paused VM");
+                    Ok(Completed)
+                }
                 Command::Complete => {
                     // The unwrap is safe, because the state machine makes sure we called
                     // vm_receive_state before, which creates the VM.
@@ -1361,7 +1365,9 @@ impl Vmm {
             mem_send,
         )?;
         let downtime_begin = Instant::now();
-        vm.pause()?;
+        if vm.get_state() != VmState::Paused {
+            vm.pause()?;
+        }
 
         // Send last batch of dirty pages: final iteration
         {
@@ -1391,6 +1397,7 @@ impl Vmm {
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         hypervisor: &dyn hypervisor::Hypervisor,
         send_data_migration: &VmSendMigrationData,
+        initial_vm_state: VmState,
     ) -> result::Result<(), MigratableError> {
         // State machine that is updated with more context as we progress.
         let mut ctx = OngoingMigrationContext::new();
@@ -1461,9 +1468,11 @@ impl Vmm {
         vm.start_migration()?;
 
         if send_data_migration.local {
-            // Now pause VM
+            // Now pause VM (skip if already paused, e.g. migrating a paused VM)
             let downtime_begin = Instant::now();
-            vm.pause()?;
+            if vm.get_state() != VmState::Paused {
+                vm.pause()?;
+            }
             ctx.set_vm_paused(
                 downtime_begin,
                 // No memory was transferred
@@ -1509,10 +1518,15 @@ impl Vmm {
         // When this returns, we know the VM was resumed (if it was running
         // before the migration) and that the receiving VMM acquired disk
         // locks again.
+        let complete_req = if initial_vm_state == VmState::Running {
+            Request::complete()
+        } else {
+            Request::complete_paused()
+        };
         let (_, complete_duration) = measure_ok(|| {
             migration_transport::send_request_expect_ok(
                 &mut socket,
-                Request::complete(),
+                complete_req,
                 MigratableError::MigrateSend(anyhow!("Error completing migration")),
             )
         })?;
@@ -2578,13 +2592,10 @@ impl RequestHandler for Vmm {
             .as_mut()
             .ok_or_else(|| MigratableError::MigrateSend(anyhow!("VM is not running")))?;
 
-        // Only running VMs can be migrated: Future work can fix this to allow
-        // also the migration of paused VMs while preserving the state in success
-        // and error case. See #7815.
-        if vm.get_state() != VmState::Running {
+        let initial_vm_state = vm.get_state();
+        if initial_vm_state != VmState::Running && initial_vm_state != VmState::Paused {
             return Err(MigratableError::MigrateSend(anyhow!(
-                "VM is not in running state: {:?}",
-                vm.get_state()
+                "VM is not running or paused: {initial_vm_state:?}"
             )));
         }
 
@@ -2594,6 +2605,7 @@ impl RequestHandler for Vmm {
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             self.hypervisor.as_ref(),
             &send_data_migration,
+            initial_vm_state,
         )
         .map_err(|migration_err| {
             error!("Migration failed: {migration_err:?}");
@@ -2606,7 +2618,10 @@ impl RequestHandler for Vmm {
                 return e;
             }
 
-            if vm.get_state() == VmState::Paused
+            // Only resume if the VM was originally running; a VM that was already
+            // paused before migration should remain paused after failure.
+            if initial_vm_state == VmState::Running
+                && vm.get_state() == VmState::Paused
                 && let Err(e) = vm.resume()
             {
                 return e;


### PR DESCRIPTION
This extends migration to support paused VMs, preserving the paused state on the destination.

Changes:
- Add CompletePaused protocol command that finalizes migration without resuming the VM on the destination
- Skip the pause step during migration if the VM is already paused
- On migration failure, only restore the running state if the VM was originally running (not paused)

Closes #7815.