### PR TITLE
virtio-devices: iommu: AI-aided spec compliance fixes

### DIFF
--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -202,10 +202,23 @@ pub trait VirtioDevice: Send {
 /// On the other side, the implementation itself should be provided by the code
 /// emulating the IOMMU for the guest.
 pub trait DmaRemapping {
-    /// Provide a way to translate GVA address ranges into GPAs.
-    fn translate_gva(&self, id: u32, addr: u64) -> std::result::Result<u64, std::io::Error>;
-    /// Provide a way to translate GPA address ranges into GVAs.
-    fn translate_gpa(&self, id: u32, addr: u64) -> std::result::Result<u64, std::io::Error>;
+    /// Provide a way to translate GVA address ranges into GPAs. The
+    /// implementation must reject translations whose [addr, addr+size)
+    /// span isn't entirely covered by a single mapping.
+    fn translate_gva(
+        &self,
+        id: u32,
+        addr: u64,
+        size: u64,
+    ) -> std::result::Result<u64, std::io::Error>;
+    /// Provide a way to translate GPA address ranges into GVAs. Same
+    /// span requirement as `translate_gva`.
+    fn translate_gpa(
+        &self,
+        id: u32,
+        addr: u64,
+        size: u64,
+    ) -> std::result::Result<u64, std::io::Error>;
 }
 
 /// Structure to handle device state common to all devices

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -1241,7 +1241,9 @@ impl VirtioDevice for Iommu {
             return;
         }
 
-        self.config.bypass = data[0];
+        // virtio spec says ignore bits 1-7 and that the device must
+        // never present a value other than 0 or 1.
+        self.config.bypass = data[0] & 1;
 
         self.update_bypass();
     }

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -388,6 +388,7 @@ impl Request {
         let mut reply: Vec<u8> = Vec::new();
         let mut status = VIRTIO_IOMMU_S_OK;
         let mut hdr_len = 0;
+        let mut unrecognised_type = false;
 
         let result = (|| {
             match req_head.type_ {
@@ -679,12 +680,18 @@ impl Request {
                     hdr_len = PROBE_PROP_SIZE;
                 }
                 _ => {
-                    status = VIRTIO_IOMMU_S_INVAL;
+                    unrecognised_type = true;
                     return Err(Error::InvalidRequest);
                 }
             }
             Ok(())
         })();
+
+        // virtio spec: unrecognised request types must not have the reply
+        // buffer written and must report a used length of zero.
+        if unrecognised_type {
+            return Ok(0);
+        }
 
         let status_desc = desc_chain.next().ok_or(Error::DescriptorChainTooShort)?;
 

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -642,7 +642,10 @@ impl Request {
             return Err(Error::UnexpectedReadOnlyDescriptor);
         }
 
-        if status_desc.len() < hdr_len + size_of::<VirtioIommuReqTail>() as u32 {
+        let reply_len = (hdr_len as usize)
+            .checked_add(size_of::<VirtioIommuReqTail>())
+            .ok_or(Error::BufferLengthTooSmall)?;
+        if (status_desc.len() as usize) < reply_len {
             return Err(Error::BufferLengthTooSmall);
         }
 
@@ -662,7 +665,7 @@ impl Request {
         // Return the error if the result was not Ok().
         result?;
 
-        Ok((hdr_len as usize) + size_of::<VirtioIommuReqTail>())
+        Ok(reply_len)
     }
 }
 

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -121,7 +121,6 @@ const VIRTIO_IOMMU_S_OK: u8 = 0;
 const VIRTIO_IOMMU_S_IOERR: u8 = 1;
 #[allow(unused)]
 const VIRTIO_IOMMU_S_UNSUPP: u8 = 2;
-#[allow(unused)]
 const VIRTIO_IOMMU_S_DEVERR: u8 = 3;
 #[allow(unused)]
 const VIRTIO_IOMMU_S_INVAL: u8 = 4;
@@ -510,32 +509,41 @@ impl Request {
                         return Err(Error::InvalidMapRequest);
                     }
 
+                    let mut mapped: Vec<u32> = Vec::new();
+                    let rollback = |mapped: &[u32]| {
+                        for ep in mapped {
+                            if let Some(pmap) = ext_mapping.get(ep) {
+                                let _ = pmap.unmap(req.virt_start, size);
+                            }
+                        }
+                    };
                     // For viommu all endpoints receive their own VFIO container, as a result
                     // Each endpoint within the domain needs to be separately mapped, as the
                     // mapping is done on a per-container level, not a per-domain level
                     for endpoint in endpoints {
                         if let Some(ext_map) = ext_mapping.get(&endpoint) {
-                            ext_map
-                                .map(req.virt_start, req.phys_start, size)
-                                .map_err(Error::ExternalMapping)?;
+                            if let Err(e) = ext_map.map(req.virt_start, req.phys_start, size) {
+                                rollback(&mapped);
+                                status = VIRTIO_IOMMU_S_DEVERR;
+                                return Err(Error::ExternalMapping(e));
+                            }
+                            mapped.push(endpoint);
                         }
                     }
 
-                    // Add new mapping associated with the domain
-                    mapping
-                        .domains
-                        .write()
-                        .unwrap()
-                        .get_mut(&domain_id)
-                        .unwrap()
-                        .mappings
-                        .insert(
-                            req.virt_start,
-                            Mapping {
-                                gpa: req.phys_start,
-                                size,
-                            },
-                        );
+                    let mut domains = mapping.domains.write().unwrap();
+                    let Some(domain) = domains.get_mut(&domain_id) else {
+                        rollback(&mapped);
+                        status = VIRTIO_IOMMU_S_NOENT;
+                        return Err(Error::InvalidMapRequestMissingDomain);
+                    };
+                    domain.mappings.insert(
+                        req.virt_start,
+                        Mapping {
+                            gpa: req.phys_start,
+                            size,
+                        },
+                    );
                 }
                 VIRTIO_IOMMU_T_UNMAP => {
                     if desc_size_left != size_of::<VirtioIommuReqUnmap>() {
@@ -614,13 +622,12 @@ impl Request {
                         }
                     }
 
-                    // Remove all mappings associated with the domain within the requested range
-                    mapping
-                        .domains
-                        .write()
-                        .unwrap()
-                        .get_mut(&domain_id)
-                        .unwrap()
+                    let mut domains = mapping.domains.write().unwrap();
+                    let Some(domain) = domains.get_mut(&domain_id) else {
+                        status = VIRTIO_IOMMU_S_INVAL;
+                        return Err(Error::InvalidUnmapRequestMissingDomain);
+                    };
+                    domain
                         .mappings
                         .retain(|&x, _| x < req.virt_start || x > req.virt_end);
                 }

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -819,9 +819,32 @@ pub struct IommuMapping {
     bypass: AtomicBool,
 }
 
+// Inclusive end of `[addr, addr+size)`. Returns None for zero size or
+// overflow so range checks cannot be bypassed.
+fn inclusive_end(addr: u64, size: u64) -> Option<u64> {
+    if size == 0 {
+        return None;
+    }
+    addr.checked_add(size - 1)
+}
+
+fn span_end(addr: u64, size: u64) -> std::result::Result<u64, io::Error> {
+    inclusive_end(addr, size).ok_or_else(|| {
+        io::Error::other(format!(
+            "translate span overflow or zero size: addr 0x{addr:x} size 0x{size:x}"
+        ))
+    })
+}
+
 impl DmaRemapping for IommuMapping {
-    fn translate_gva(&self, id: u32, addr: u64) -> std::result::Result<u64, std::io::Error> {
-        debug!("Translate GVA addr 0x{addr:x}");
+    fn translate_gva(
+        &self,
+        id: u32,
+        addr: u64,
+        size: u64,
+    ) -> std::result::Result<u64, std::io::Error> {
+        debug!("Translate GVA addr 0x{addr:x} size 0x{size:x}");
+        let end = span_end(addr, size)?;
         if let Some(domain_id) = self.endpoints.read().unwrap().get(&id) {
             if let Some(domain) = self.domains.read().unwrap().get(domain_id) {
                 // Directly return identity mapping in case the domain is in
@@ -831,7 +854,10 @@ impl DmaRemapping for IommuMapping {
                 }
 
                 for (&key, &value) in domain.mappings.iter() {
-                    if addr >= key && addr < key + value.size {
+                    if let Some(mapping_end) = inclusive_end(key, value.size)
+                        && addr >= key
+                        && end <= mapping_end
+                    {
                         let new_addr = addr - key + value.gpa;
                         debug!("Into GPA addr 0x{new_addr:x}");
                         return Ok(new_addr);
@@ -843,12 +869,18 @@ impl DmaRemapping for IommuMapping {
         }
 
         Err(io::Error::other(format!(
-            "failed to translate GVA addr 0x{addr:x}"
+            "failed to translate GVA addr 0x{addr:x} size 0x{size:x}"
         )))
     }
 
-    fn translate_gpa(&self, id: u32, addr: u64) -> std::result::Result<u64, std::io::Error> {
-        debug!("Translate GPA addr 0x{addr:x}");
+    fn translate_gpa(
+        &self,
+        id: u32,
+        addr: u64,
+        size: u64,
+    ) -> std::result::Result<u64, std::io::Error> {
+        debug!("Translate GPA addr 0x{addr:x} size 0x{size:x}");
+        let end = span_end(addr, size)?;
         if let Some(domain_id) = self.endpoints.read().unwrap().get(&id) {
             if let Some(domain) = self.domains.read().unwrap().get(domain_id) {
                 // Directly return identity mapping in case the domain is in
@@ -858,7 +890,10 @@ impl DmaRemapping for IommuMapping {
                 }
 
                 for (&key, &value) in domain.mappings.iter() {
-                    if addr >= value.gpa && addr < value.gpa + value.size {
+                    if let Some(mapping_gpa_end) = inclusive_end(value.gpa, value.size)
+                        && addr >= value.gpa
+                        && end <= mapping_gpa_end
+                    {
                         let new_addr = addr - value.gpa + key;
                         debug!("Into GVA addr 0x{new_addr:x}");
                         return Ok(new_addr);
@@ -870,7 +905,7 @@ impl DmaRemapping for IommuMapping {
         }
 
         Err(io::Error::other(format!(
-            "failed to translate GPA addr 0x{addr:x}"
+            "failed to translate GPA addr 0x{addr:x} size 0x{size:x}"
         )))
     }
 }
@@ -888,11 +923,11 @@ impl AccessPlatformMapping {
 }
 
 impl AccessPlatform for AccessPlatformMapping {
-    fn translate_gva(&self, base: u64, _size: u64) -> std::result::Result<u64, std::io::Error> {
-        self.mapping.translate_gva(self.id, base)
+    fn translate_gva(&self, base: u64, size: u64) -> std::result::Result<u64, std::io::Error> {
+        self.mapping.translate_gva(self.id, base, size)
     }
-    fn translate_gpa(&self, base: u64, _size: u64) -> std::result::Result<u64, std::io::Error> {
-        self.mapping.translate_gpa(self.id, base)
+    fn translate_gpa(&self, base: u64, size: u64) -> std::result::Result<u64, std::io::Error> {
+        self.mapping.translate_gpa(self.id, base, size)
     }
 }
 

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -347,6 +347,7 @@ impl Request {
         mapping: &Arc<IommuMapping>,
         ext_mapping: &BTreeMap<u32, Arc<dyn ExternalDmaMapping>>,
         msi_iova_space: (u64, u64),
+        input_range: Option<(u64, u64)>,
     ) -> result::Result<usize, Error> {
         let desc = desc_chain
             .next()
@@ -490,6 +491,13 @@ impl Request {
                         return Err(Error::InvalidMapRequest);
                     }
 
+                    if let Some((lo, hi)) = input_range
+                        && (req.virt_start < lo || req.virt_end > hi)
+                    {
+                        status = VIRTIO_IOMMU_S_RANGE;
+                        return Err(Error::InvalidMapRequest);
+                    }
+
                     // Copy the value to use it as a proper reference.
                     let domain_id = req.domain;
 
@@ -610,6 +618,13 @@ impl Request {
                         .read_obj(req_addr as GuestAddress)
                         .map_err(Error::GuestMemory)?;
                     debug!("Unmap request 0x{req:x?}");
+
+                    if let Some((lo, hi)) = input_range
+                        && (req.virt_start < lo || req.virt_end > hi)
+                    {
+                        status = VIRTIO_IOMMU_S_RANGE;
+                        return Err(Error::InvalidUnmapRequest);
+                    }
 
                     // Copy the value to use it as a proper reference.
                     let domain_id = req.domain;
@@ -808,6 +823,7 @@ struct IommuEpollHandler {
     mapping: Arc<IommuMapping>,
     ext_mapping: Arc<Mutex<BTreeMap<u32, Arc<dyn ExternalDmaMapping>>>>,
     msi_iova_space: (u64, u64),
+    input_range: Option<(u64, u64)>,
 }
 
 impl IommuEpollHandler {
@@ -820,6 +836,7 @@ impl IommuEpollHandler {
                 &self.mapping,
                 &self.ext_mapping.lock().unwrap(),
                 self.msi_iova_space,
+                self.input_range,
             )?;
 
             self.request_queue
@@ -1032,6 +1049,7 @@ pub struct Iommu {
     seccomp_action: SeccompAction,
     exit_evt: EventFd,
     msi_iova_space: (u64, u64),
+    input_range: Option<(u64, u64)>,
 }
 
 type EndpointsState = Vec<(u32, u32)>;
@@ -1091,13 +1109,14 @@ impl Iommu {
             ..Default::default()
         };
 
-        if address_width_bits < 64 {
+        let input_range = if address_width_bits < 64 {
             avail_features |= 1u64 << VIRTIO_IOMMU_F_INPUT_RANGE;
-            config.input_range = VirtioIommuRange64 {
-                start: 0,
-                end: (1u64 << address_width_bits) - 1,
-            }
-        }
+            let end = (1u64 << address_width_bits) - 1;
+            config.input_range = VirtioIommuRange64 { start: 0, end };
+            Some((0, end))
+        } else {
+            None
+        };
 
         let mapping = Arc::new(IommuMapping {
             endpoints: Arc::new(RwLock::new(endpoints)),
@@ -1124,6 +1143,7 @@ impl Iommu {
                 seccomp_action,
                 exit_evt,
                 msi_iova_space,
+                input_range,
             },
             mapping,
         ))
@@ -1251,6 +1271,7 @@ impl VirtioDevice for Iommu {
             mapping: self.mapping.clone(),
             ext_mapping: self.ext_mapping.clone(),
             msi_iova_space: self.msi_iova_space,
+            input_range: self.input_range,
         };
 
         let paused = self.common.paused.clone();

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -621,7 +621,7 @@ impl Request {
                             return Err(Error::InvalidUnmapRequestBypassDomain);
                         }
                     } else {
-                        status = VIRTIO_IOMMU_S_INVAL;
+                        status = VIRTIO_IOMMU_S_NOENT;
                         return Err(Error::InvalidUnmapRequestMissingDomain);
                     }
 
@@ -641,7 +641,7 @@ impl Request {
                     {
                         let domains = mapping.domains.read().unwrap();
                         let Some(domain) = domains.get(&domain_id) else {
-                            status = VIRTIO_IOMMU_S_INVAL;
+                            status = VIRTIO_IOMMU_S_NOENT;
                             return Err(Error::InvalidUnmapRequestMissingDomain);
                         };
                         for (&start, m) in domain.mappings.iter() {
@@ -678,7 +678,7 @@ impl Request {
 
                     let mut domains = mapping.domains.write().unwrap();
                     let Some(domain) = domains.get_mut(&domain_id) else {
-                        status = VIRTIO_IOMMU_S_INVAL;
+                        status = VIRTIO_IOMMU_S_NOENT;
                         return Err(Error::InvalidUnmapRequestMissingDomain);
                     };
                     domain

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -77,6 +77,10 @@ const VIRTIO_IOMMU_PAGE_GRANULE: u64 = 1u64 << VIRTIO_IOMMU_PAGE_SIZE_MASK.trail
 // ~64 MiB at ~64 bytes/entry, well above any legitimate workload.
 const MAX_MAPPINGS_PER_DOMAIN: usize = 1 << 20;
 
+// Bound the per-device domain count so a guest cannot grow the
+// domain map indefinitely with ATTACH-only requests.
+const MAX_DOMAINS: usize = 1 << 16;
+
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(C, packed)]
 #[allow(dead_code)]
@@ -321,6 +325,8 @@ enum Error {
     InvalidUnmapRequestPartialOverlap,
     #[error("Per-domain mapping count cap exceeded")]
     MappingCountExceeded,
+    #[error("Per-device domain count cap exceeded: current:{0}, max:{MAX_DOMAINS}")]
+    DomainCountExceeded(usize),
     #[error("Guest sent us invalid PROBE request")]
     InvalidProbeRequest,
     #[error("Failed to performing external mapping")]
@@ -419,6 +425,17 @@ impl Request {
                         return Err(Error::InvalidAttachRequest);
                     }
 
+                    // Refuse before mutating any state so a failed ATTACH
+                    // does not leave a phantom endpoint pointing at a
+                    // domain that was never created.
+                    {
+                        let domains = mapping.domains.read().unwrap();
+                        if !domains.contains_key(&domain_id) && domains.len() >= MAX_DOMAINS {
+                            status = VIRTIO_IOMMU_S_NOMEM;
+                            return Err(Error::DomainCountExceeded(domains.len()));
+                        }
+                    }
+
                     let mut old_domain_id = domain_id;
                     if let Some(&id) = mapping.endpoints.read().unwrap().get(&endpoint) {
                         old_domain_id = id;
@@ -449,6 +466,18 @@ impl Request {
 
                     // Add new domain with no mapping if the entry didn't exist yet
                     let mut domains = mapping.domains.write().unwrap();
+                    if !domains.contains_key(&domain_id) && domains.len() >= MAX_DOMAINS {
+                        // Defensive re-check under write lock. Single-threaded
+                        // today, but keeps the invariant if processing ever
+                        // becomes concurrent. Drop the domains write lock
+                        // before taking the endpoints write lock so we never
+                        // hold both simultaneously.
+                        let count = domains.len();
+                        drop(domains);
+                        mapping.endpoints.write().unwrap().remove(&endpoint);
+                        status = VIRTIO_IOMMU_S_NOMEM;
+                        return Err(Error::DomainCountExceeded(count));
+                    }
                     let domain = Domain {
                         mappings: BTreeMap::new(),
                         bypass,

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -150,7 +150,7 @@ struct VirtioIommuReqAttach {
     domain: u32,
     endpoint: u32,
     flags: u32,
-    _reserved: [u8; 4],
+    reserved: [u8; 4],
 }
 
 const VIRTIO_IOMMU_ATTACH_F_BYPASS: u32 = 1;
@@ -404,11 +404,25 @@ impl Request {
                         .map_err(Error::GuestMemory)?;
                     debug!("Attach request 0x{req:x?}");
 
+                    if req.reserved.iter().any(|&b| b != 0)
+                        || (req.flags & !VIRTIO_IOMMU_ATTACH_F_BYPASS) != 0
+                    {
+                        status = VIRTIO_IOMMU_S_INVAL;
+                        return Err(Error::InvalidAttachRequest);
+                    }
+
                     // Copy the value to use it as a proper reference.
                     let domain_id = req.domain;
                     let endpoint = req.endpoint;
                     let bypass =
                         (req.flags & VIRTIO_IOMMU_ATTACH_F_BYPASS) == VIRTIO_IOMMU_ATTACH_F_BYPASS;
+
+                    if let Some(d) = mapping.domains.read().unwrap().get(&domain_id)
+                        && d.bypass != bypass
+                    {
+                        status = VIRTIO_IOMMU_S_INVAL;
+                        return Err(Error::InvalidAttachRequest);
+                    }
 
                     let mut old_domain_id = domain_id;
                     if let Some(&id) = mapping.endpoints.read().unwrap().get(&endpoint) {

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -72,6 +72,7 @@ const VIRTIO_IOMMU_F_BYPASS_CONFIG: u32 = 6;
 
 // Support 2MiB and 4KiB page sizes.
 const VIRTIO_IOMMU_PAGE_SIZE_MASK: u64 = (2 << 20) | (4 << 10);
+const VIRTIO_IOMMU_PAGE_GRANULE: u64 = 1u64 << VIRTIO_IOMMU_PAGE_SIZE_MASK.trailing_zeros();
 
 // ~64 MiB at ~64 bytes/entry, well above any legitimate workload.
 const MAX_MAPPINGS_PER_DOMAIN: usize = 1 << 20;
@@ -125,11 +126,8 @@ const VIRTIO_IOMMU_S_IOERR: u8 = 1;
 #[allow(unused)]
 const VIRTIO_IOMMU_S_UNSUPP: u8 = 2;
 const VIRTIO_IOMMU_S_DEVERR: u8 = 3;
-#[allow(unused)]
 const VIRTIO_IOMMU_S_INVAL: u8 = 4;
-#[allow(unused)]
 const VIRTIO_IOMMU_S_RANGE: u8 = 5;
-#[allow(unused)]
 const VIRTIO_IOMMU_S_NOENT: u8 = 6;
 #[allow(unused)]
 const VIRTIO_IOMMU_S_FAULT: u8 = 7;
@@ -165,13 +163,9 @@ struct VirtioIommuReqDetach {
 }
 
 /// Virtio IOMMU request MAP flags
-#[allow(unused)]
 const VIRTIO_IOMMU_MAP_F_READ: u32 = 1;
-#[allow(unused)]
 const VIRTIO_IOMMU_MAP_F_WRITE: u32 = 1 << 1;
-#[allow(unused)]
 const VIRTIO_IOMMU_MAP_F_MMIO: u32 = 1 << 2;
-#[allow(unused)]
 const VIRTIO_IOMMU_MAP_F_MASK: u32 =
     VIRTIO_IOMMU_MAP_F_READ | VIRTIO_IOMMU_MAP_F_WRITE | VIRTIO_IOMMU_MAP_F_MMIO;
 
@@ -183,7 +177,7 @@ struct VirtioIommuReqMap {
     virt_start: u64,
     virt_end: u64,
     phys_start: u64,
-    _flags: u32,
+    flags: u32,
 }
 
 /// UNMAP request
@@ -491,6 +485,11 @@ impl Request {
                         .map_err(Error::GuestMemory)?;
                     debug!("Map request 0x{req:x?}");
 
+                    if (req.flags & !VIRTIO_IOMMU_MAP_F_MASK) != 0 {
+                        status = VIRTIO_IOMMU_S_INVAL;
+                        return Err(Error::InvalidMapRequest);
+                    }
+
                     // Copy the value to use it as a proper reference.
                     let domain_id = req.domain;
 
@@ -500,7 +499,7 @@ impl Request {
                             return Err(Error::InvalidMapRequestBypassDomain);
                         }
                     } else {
-                        status = VIRTIO_IOMMU_S_INVAL;
+                        status = VIRTIO_IOMMU_S_NOENT;
                         return Err(Error::InvalidMapRequestMissingDomain);
                     }
 
@@ -525,6 +524,27 @@ impl Request {
 
                     if req.phys_start > u64::MAX - size || req.virt_start > u64::MAX - size {
                         status = VIRTIO_IOMMU_S_RANGE;
+                        return Err(Error::InvalidMapRequest);
+                    }
+
+                    let mask = VIRTIO_IOMMU_PAGE_GRANULE - 1;
+                    if (req.virt_start & mask) != 0
+                        || (req.phys_start & mask) != 0
+                        || (size & mask) != 0
+                    {
+                        status = VIRTIO_IOMMU_S_RANGE;
+                        return Err(Error::InvalidMapRequest);
+                    }
+
+                    // Going forward MAP rejects overlap, so within a domain
+                    // mappings are disjoint and the rightmost mapping with
+                    // start <= virt_end is the only candidate to overlap.
+                    if let Some(d) = mapping.domains.read().unwrap().get(&domain_id)
+                        && let Some((&start, m)) = d.mappings.range(..=req.virt_end).next_back()
+                        && let Some(end) = inclusive_end(start, m.size)
+                        && end >= req.virt_start
+                    {
+                        status = VIRTIO_IOMMU_S_INVAL;
                         return Err(Error::InvalidMapRequest);
                     }
 

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -322,6 +322,8 @@ enum Error {
     InvalidUnmapRequestBypassDomain,
     #[error("Invalid to unmap because the domain is missing")]
     InvalidUnmapRequestMissingDomain,
+    #[error("UNMAP range partially overlaps an existing mapping")]
+    InvalidUnmapRequestPartialOverlap,
     #[error("Guest sent us invalid PROBE request")]
     InvalidProbeRequest,
     #[error("Failed to performing external mapping")]
@@ -561,6 +563,38 @@ impl Request {
                         return Err(Error::InvalidUnmapRequestMissingDomain);
                     }
 
+                    let Some(size) = req
+                        .virt_end
+                        .checked_sub(virt_start)
+                        .and_then(|d| d.checked_add(1))
+                    else {
+                        status = VIRTIO_IOMMU_S_RANGE;
+                        return Err(Error::InvalidUnmapRequest);
+                    };
+
+                    // An UNMAP that would split an existing mapping must be
+                    // rejected with VIRTIO_IOMMU_S_RANGE without removing
+                    // anything. Inspect bookkeeping before touching VFIO so
+                    // a rejection cannot leave VFIO out of sync.
+                    {
+                        let domains = mapping.domains.read().unwrap();
+                        let Some(domain) = domains.get(&domain_id) else {
+                            status = VIRTIO_IOMMU_S_INVAL;
+                            return Err(Error::InvalidUnmapRequestMissingDomain);
+                        };
+                        for (&start, m) in domain.mappings.iter() {
+                            let Some(end) = inclusive_end(start, m.size) else {
+                                continue;
+                            };
+                            let overlaps = start <= req.virt_end && end >= req.virt_start;
+                            let split = start < req.virt_start || end > req.virt_end;
+                            if overlaps && split {
+                                status = VIRTIO_IOMMU_S_RANGE;
+                                return Err(Error::InvalidUnmapRequestPartialOverlap);
+                            }
+                        }
+                    }
+
                     // Find the list of endpoints attached to the given domain.
                     let endpoints: Vec<u32> = mapping
                         .endpoints
@@ -570,15 +604,6 @@ impl Request {
                         .filter(|&(_, &d)| d == domain_id)
                         .map(|(&e, _)| e)
                         .collect();
-
-                    let Some(size) = req
-                        .virt_end
-                        .checked_sub(virt_start)
-                        .and_then(|d| d.checked_add(1))
-                    else {
-                        status = VIRTIO_IOMMU_S_RANGE;
-                        return Err(Error::InvalidUnmapRequest);
-                    };
 
                     // Trigger external unmapping if necessary.
                     for endpoint in endpoints {

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -73,6 +73,9 @@ const VIRTIO_IOMMU_F_BYPASS_CONFIG: u32 = 6;
 // Support 2MiB and 4KiB page sizes.
 const VIRTIO_IOMMU_PAGE_SIZE_MASK: u64 = (2 << 20) | (4 << 10);
 
+// ~64 MiB at ~64 bytes/entry, well above any legitimate workload.
+const MAX_MAPPINGS_PER_DOMAIN: usize = 1 << 20;
+
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(C, packed)]
 #[allow(dead_code)]
@@ -130,7 +133,6 @@ const VIRTIO_IOMMU_S_RANGE: u8 = 5;
 const VIRTIO_IOMMU_S_NOENT: u8 = 6;
 #[allow(unused)]
 const VIRTIO_IOMMU_S_FAULT: u8 = 7;
-#[allow(unused)]
 const VIRTIO_IOMMU_S_NOMEM: u8 = 8;
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -323,6 +325,8 @@ enum Error {
     InvalidUnmapRequestMissingDomain,
     #[error("UNMAP range partially overlaps an existing mapping")]
     InvalidUnmapRequestPartialOverlap,
+    #[error("Per-domain mapping count cap exceeded")]
+    MappingCountExceeded,
     #[error("Guest sent us invalid PROBE request")]
     InvalidProbeRequest,
     #[error("Failed to performing external mapping")]
@@ -509,6 +513,16 @@ impl Request {
                         return Err(Error::InvalidMapRequest);
                     }
 
+                    {
+                        let domains = mapping.domains.read().unwrap();
+                        if let Some(d) = domains.get(&domain_id)
+                            && d.mappings.len() >= MAX_MAPPINGS_PER_DOMAIN
+                        {
+                            status = VIRTIO_IOMMU_S_NOMEM;
+                            return Err(Error::MappingCountExceeded);
+                        }
+                    }
+
                     let mut mapped: Vec<u32> = Vec::new();
                     let rollback = |mapped: &[u32]| {
                         for ep in mapped {
@@ -537,6 +551,11 @@ impl Request {
                         status = VIRTIO_IOMMU_S_NOENT;
                         return Err(Error::InvalidMapRequestMissingDomain);
                     };
+                    if domain.mappings.len() >= MAX_MAPPINGS_PER_DOMAIN {
+                        rollback(&mapped);
+                        status = VIRTIO_IOMMU_S_NOMEM;
+                        return Err(Error::MappingCountExceeded);
+                    }
                     domain.mappings.insert(
                         req.virt_start,
                         Mapping {


### PR DESCRIPTION
The virtio-iommu device hasn't had much love for while. Using Claude I asked it
verify the implementation against the virtio specification and identify and fix
gaps. 

- **virtio-devices: iommu: Validate guest MAP/UNMAP ranges**
- **virtio-devices: iommu: Use checked add for reply length**
- **virtio-devices: iommu: Pass size to translate_gva/translate_gpa**
- **virtio-devices: iommu: Reject UNMAP that partially overlaps a mapping**
- **virtio-devices: iommu: Roll back partial MAP and fix DETACH panic**
- **virtio-devices: iommu: Cap mappings per domain**
- **virtio-devices: iommu: Drop unrecognised requests without writing reply**
- **virtio-devices: iommu: Validate ATTACH reserved field and flags**
- **virtio-devices: iommu: Tighten MAP request validation**
- **virtio-devices: iommu: Return NOENT for UNMAP on unknown domain**
- **virtio-devices: iommu: Enforce input_range on MAP requests**
- **virtio-devices: iommu: Clamp bypass config field to 0 or 1**
- **virtio-devices: iommu: Cap number of domains per device**
