### PR TITLE
Bounds check fixes

### DIFF
--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -557,23 +557,34 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioUserDmaMappi
     fn map(&self, iova: u64, gpa: u64, size: u64) -> std::result::Result<(), std::io::Error> {
         let mem = self.memory.memory();
         let guest_addr = GuestAddress(gpa);
-        let region = mem.find_region(guest_addr);
-
-        if let Some(region) = region {
-            let file_offset = region.file_offset().unwrap();
-            let offset = (GuestAddress(gpa).checked_offset_from(region.start_addr())).unwrap()
-                + file_offset.start();
-
-            self.client
-                .lock()
-                .unwrap()
-                .dma_map(offset, iova, size, file_offset.file().as_raw_fd())
-                .map_err(|e| std::io::Error::other(format!("Error mapping region: {e}")))
-        } else {
-            Err(std::io::Error::other(format!(
+        let Some(region) = mem.find_region(guest_addr) else {
+            return Err(std::io::Error::other(format!(
                 "Region not found for 0x{gpa:x}"
-            )))
+            )));
+        };
+
+        // Check that the range fits in the region.
+        let region_offset = guest_addr
+            .checked_offset_from(region.start_addr())
+            .ok_or_else(|| std::io::Error::other(format!("gpa 0x{gpa:x} below region start")))?;
+        let region_remaining = (region.len())
+            .checked_sub(region_offset)
+            .ok_or_else(|| std::io::Error::other(format!("gpa 0x{gpa:x} past region end")))?;
+        if size > region_remaining {
+            return Err(std::io::Error::other(format!(
+                "DMA map (gpa 0x{gpa:x}, size 0x{size:x}) extends past region end"
+            )));
         }
+
+        // Unwrap is safe as we only do vfio with shared mem with a backing file.
+        let file_offset = region.file_offset().unwrap();
+        let offset = region_offset + file_offset.start();
+
+        self.client
+            .lock()
+            .unwrap()
+            .dma_map(offset, iova, size, file_offset.file().as_raw_fd())
+            .map_err(|e| std::io::Error::other(format!("Error mapping region: {e}")))
     }
 
     fn unmap(&self, iova: u64, size: u64) -> std::result::Result<(), std::io::Error> {

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -494,12 +494,25 @@ impl Request {
                         .map(|(&e, _)| e)
                         .collect();
 
+                    let Some(size) = req
+                        .virt_end
+                        .checked_sub(req.virt_start)
+                        .and_then(|delta| delta.checked_add(1))
+                    else {
+                        status = VIRTIO_IOMMU_S_RANGE;
+                        return Err(Error::InvalidMapRequest);
+                    };
+
+                    if req.phys_start > u64::MAX - size || req.virt_start > u64::MAX - size {
+                        status = VIRTIO_IOMMU_S_RANGE;
+                        return Err(Error::InvalidMapRequest);
+                    }
+
                     // For viommu all endpoints receive their own VFIO container, as a result
                     // Each endpoint within the domain needs to be separately mapped, as the
                     // mapping is done on a per-container level, not a per-domain level
                     for endpoint in endpoints {
                         if let Some(ext_map) = ext_mapping.get(&endpoint) {
-                            let size = req.virt_end - req.virt_start + 1;
                             ext_map
                                 .map(req.virt_start, req.phys_start, size)
                                 .map_err(Error::ExternalMapping)?;
@@ -518,7 +531,7 @@ impl Request {
                             req.virt_start,
                             Mapping {
                                 gpa: req.phys_start,
-                                size: req.virt_end - req.virt_start + 1,
+                                size,
                             },
                         );
                 }
@@ -558,10 +571,18 @@ impl Request {
                         .map(|(&e, _)| e)
                         .collect();
 
+                    let Some(size) = req
+                        .virt_end
+                        .checked_sub(virt_start)
+                        .and_then(|d| d.checked_add(1))
+                    else {
+                        status = VIRTIO_IOMMU_S_RANGE;
+                        return Err(Error::InvalidUnmapRequest);
+                    };
+
                     // Trigger external unmapping if necessary.
                     for endpoint in endpoints {
                         if let Some(ext_map) = ext_mapping.get(&endpoint) {
-                            let size = req.virt_end - virt_start + 1;
                             ext_map
                                 .unmap(virt_start, size)
                                 .map_err(Error::ExternalUnmapping)?;

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -807,7 +807,8 @@ impl VirtioPciDevice {
             }
 
             if !queue.is_valid(self.memory.memory().deref()) {
-                error!("Queue {queue_index} is not valid");
+                error!("Queue {queue_index} is not valid; skipping activation");
+                continue;
             }
 
             queues.push((

--- a/virtio-devices/src/vdpa.rs
+++ b/virtio-devices/src/vdpa.rs
@@ -365,7 +365,12 @@ impl Vdpa {
     }
 
     fn dma_unmap(&self, iova: u64, size: u64) -> Result<()> {
-        let iova_last = iova + size - 1;
+        let Some(iova_last) = iova.checked_add(size) else {
+            return Err(Error::InvalidIovaRange(iova, u64::MAX));
+        };
+        let Some(iova_last) = iova_last.checked_sub(1) else {
+            return Err(Error::InvalidIovaRange(0, 0));
+        };
         if iova < self.iova_range.first || iova_last > self.iova_range.last {
             return Err(Error::InvalidIovaRange(iova, iova_last));
         }

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -175,6 +175,9 @@ impl VsockPacket {
         // For small packets, the data may be stored in the same descriptor as the header.
         if !head.has_next() {
             let buf_size: usize = head.len() as usize - VSOCK_PKT_HDR_SIZE;
+            if buf_size < pkt.len() as usize {
+                return Err(VsockError::BufDescTooSmall);
+            }
             let buf_ptr = get_host_address_range(
                 desc_chain.memory(),
                 head.addr()


### PR DESCRIPTION
Patch a few paths guests have to crash Cloud hypervisor. These are self-DoS only so not critical, but it's nice to have clean errors from the VMM instead of panics.