### PR TITLE
Fix MSHV SEV-SNP CVM boot regressions

### DIFF
--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -23,12 +23,14 @@ use log::info;
 #[cfg(feature = "mshv")]
 use mshv_bindings::*;
 use thiserror::Error;
+#[cfg(all(feature = "kvm", feature = "sev_snp"))]
+use vm_memory::Bytes;
 #[cfg(feature = "sev_snp")]
-use vm_memory::{Bytes, GuestAddress, GuestAddressSpace, GuestMemory};
+use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemory};
 #[cfg(all(feature = "kvm", feature = "sev_snp"))]
 use vm_migration::Snapshottable;
 use zerocopy::IntoBytes;
-#[cfg(feature = "sev_snp")]
+#[cfg(all(feature = "kvm", feature = "sev_snp"))]
 use zerocopy::{FromBytes, FromZeros};
 
 #[cfg(feature = "sev_snp")]
@@ -40,11 +42,11 @@ use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
 
 #[cfg(feature = "sev_snp")]
 const ISOLATED_PAGE_SHIFT: u32 = 12;
-#[cfg(feature = "sev_snp")]
+#[cfg(all(feature = "kvm", feature = "sev_snp"))]
 const SNP_CPUID_LIMIT: u32 = 64;
 // see section 7.1
 // https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56860.pdf
-#[cfg(feature = "sev_snp")]
+#[cfg(all(feature = "kvm", feature = "sev_snp"))]
 #[repr(C)]
 #[derive(Debug, Clone, PartialEq, Eq, IntoBytes, FromBytes)]
 pub struct SnpCpuidFunc {
@@ -59,7 +61,7 @@ pub struct SnpCpuidFunc {
     pub reserved: u64,
 }
 
-#[cfg(feature = "sev_snp")]
+#[cfg(all(feature = "kvm", feature = "sev_snp"))]
 #[repr(C)]
 #[derive(Debug, Clone, FromBytes, IntoBytes)]
 pub struct SnpCpuidInfo {
@@ -656,8 +658,12 @@ pub fn load_igvm(
                 .collect();
             #[cfg(feature = "kvm")]
             let page_type = group[0].page_type;
+            #[cfg(feature = "kvm")]
             let mut new_cp = SnpCpuidInfo::new_zeroed();
-            let _ = guest_memory.read(new_cp.as_mut_bytes(), GuestAddress(group[0].gpa));
+            #[cfg(feature = "kvm")]
+            if hypervisor_type == HypervisorType::Kvm {
+                let _ = guest_memory.read(new_cp.as_mut_bytes(), GuestAddress(group[0].gpa));
+            }
             let import_result = memory_manager
                 .lock()
                 .unwrap()

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -232,8 +232,8 @@ pub fn load_igvm(
             isolated_page_size_4kb: mshv_bindings::hv_isolated_page_size_HV_ISOLATED_PAGE_SIZE_4KB,
             normal: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_NORMAL,
             unmeasured: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_UNMEASURED,
-            cpuid: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_NORMAL,
-            secrets: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_UNMEASURED,
+            cpuid: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_CPUID,
+            secrets: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_SECRETS,
             vmsa: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_VMSA,
         },
         #[cfg(feature = "kvm")]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1547,7 +1547,9 @@ impl Vm {
         // Only reserve bootloader/VMSA regions for KVM + SEV-SNP; other hypervisors
         // (e.g. MSHV) handle this through their own import path.
         #[cfg(all(feature = "kvm", feature = "sev_snp"))]
-        if cpu_manager.lock().unwrap().sev_snp_enabled() {
+        if cpu_manager.lock().unwrap().sev_snp_enabled()
+            && cpu_manager.lock().unwrap().hypervisor_type() == hypervisor::HypervisorType::Kvm
+        {
             Self::reserve_bootloader_regions(&memory_manager)?;
         }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2840,10 +2840,13 @@ impl Vm {
         let rsdp_addr = self.create_acpi_tables();
 
         #[cfg(not(target_arch = "riscv64"))]
-        // Configure shared state based on loaded kernel
-        entry_point
-            .map(|entry_point| self.configure_system(rsdp_addr, entry_point))
-            .transpose()?;
+        // Configure shared state based on loaded kernel.
+        // Skip for SEV-SNP guests where system configuration is provided via IGVM.
+        if rsdp_addr.is_some() {
+            entry_point
+                .map(|entry_point| self.configure_system(rsdp_addr, entry_point))
+                .transpose()?;
+        }
 
         #[cfg(target_arch = "riscv64")]
         self.configure_system().unwrap();


### PR DESCRIPTION
Fix MSHV SEV-SNP CVM boot regressions

## Summary

This PR fixes multiple regressions that broke MSHV SEV-SNP confidential VM (CVM) boot
introduced during recent refactoring and KVM SEV-SNP IGVM loader integration.

The issues were identified via `git bisect` against two breaking commits:
- `7d65187350a1` ("vmm: make RSDP address optional in configure_system")
- `75ed2c9f903f` ("vmm: add KVM SEV-SNP support to IGVM loader")

## Fixes

1. **Skip `configure_system` when `rsdp_addr` is `None`** — For IGVM-based SEV-SNP guests,
   ACPI tables and system configuration are provided by the IGVM file. The refactoring in
   `7d65187350a1` removed the guard that prevented `configure_system` from running when
   `rsdp_addr` is `None`, causing it to overwrite IGVM-provided guest memory layout.

2. **Use correct MSHV page types for CPUID and secrets** — The `PageTypeConfig` for MSHV
   incorrectly mapped `cpuid` to `HV_ISOLATED_PAGE_TYPE_NORMAL` (0) and `secrets` to
   `HV_ISOLATED_PAGE_TYPE_UNMEASURED` (3). The correct values are
   `HV_ISOLATED_PAGE_TYPE_CPUID` (5) and `HV_ISOLATED_PAGE_TYPE_SECRETS` (4).

3. **Gate CPUID page read with runtime hypervisor check** — The `SnpCpuidInfo` allocation
   and `guest_memory.read()` in the isolated page import loop are KVM-only retry logic.
   `#[cfg(feature = "kvm")]` is insufficient when both `mshv` and `kvm` features are
   compiled together; a runtime `HypervisorType::Kvm` check is required.

4. **Gate `reserve_bootloader_regions` on KVM hypervisor type** — This function allocates
   RAM at KVM-specific addresses (0xffc00000, 0xfffffffff000) for stage0/VMSA. On MSHV,
   these spurious mappings cause `HVMSG_UNACCEPTED_GPA` when the guest accesses MMIO
   regions like the IOAPIC at 0xFEC00000.

## Key Insight

`#[cfg(feature = "kvm")]` compile-time guards are **not sufficient** when both `mshv` and
`kvm` features are enabled in the same binary. Runtime `hypervisor_type == HypervisorType::Kvm`
checks are required to properly gate KVM-specific code paths.

## Testing

- Verified CVM boots to login prompt on MSHV with `--features mshv,igvm,sev_snp`
