### PR TITLE
build: update mshv-bindings/ioctls to 0.6.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,9 +1353,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mshv-bindings"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94fc3871dd23738188e5bc76a1d1a5930ebcaf9308c560a7274aa62b1770594"
+checksum = "83303108160c2b7a7bdd25000ee679384e19471386d23e501ed832574c9229ef"
 dependencies = [
  "libc",
  "num_enum",
@@ -1367,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1339723fe3a26baf4041459de20ad923e89d312c3bb25dbf9f60738c22a47f5e"
+checksum = "1db4449ac7012237b133da366f5b32ce4af1f8caf770486e5a9d54f7f6b73c4c"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ iommufd-ioctls = "0.1.0"
 kvm-bindings = "0.14.0"
 kvm-ioctls = "0.24.0"
 linux-loader = "0.13.2"
-mshv-bindings = "0.6.8"
-mshv-ioctls = "0.6.8"
+mshv-bindings = "0.6.9"
+mshv-ioctls = "0.6.9"
 seccompiler = "0.5.0"
 vfio-bindings = { version = "0.6.2", default-features = false }
 vfio-ioctls = { version = "0.6.0", default-features = false }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2.185"
 libfuzzer-sys = "0.4.12"
 linux-loader = { version = "0.13.2", features = ["bzimage", "elf", "pe"] }
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
-mshv-bindings = "0.6.8"
+mshv-bindings = "0.6.9"
 net_util = { path = "../net_util" }
 seccompiler = "0.5.0"
 virtio-devices = { path = "../virtio-devices" }


### PR DESCRIPTION
Update mshv-bindings and mshv-ioctls from 0.6.8 to 0.6.9 in workspace Cargo.toml and fuzz/Cargo.toml.