### PR TITLE
net_util: increase tap send buffer to 4MB for high-throughput workloads

### DIFF
--- a/net_util/src/open_tap.rs
+++ b/net_util/src/open_tap.rs
@@ -33,6 +33,8 @@ pub enum Error {
     TapSetVnetHdrSize(#[source] TapError),
     #[error("Setting MTU failed")]
     TapSetMtu(#[source] TapError),
+    #[error("Setting send buffer size failed")]
+    TapSetSndbuf(#[source] TapError),
     #[error("Enabling tap interface failed")]
     TapEnable(#[source] TapError),
 }
@@ -102,6 +104,9 @@ fn open_tap_rx_q_0(
     tap.set_vnet_hdr_size(vnet_hdr_len() as i32)
         .map_err(Error::TapSetVnetHdrSize)?;
 
+    tap.set_sndbuf(Tap::SNDBUF_SIZE)
+        .map_err(Error::TapSetSndbuf)?;
+
     Ok(tap)
 }
 
@@ -140,6 +145,9 @@ pub fn open_tap(
 
             tap.set_vnet_hdr_size(vnet_hdr_len() as i32)
                 .map_err(Error::TapSetVnetHdrSize)?;
+
+            tap.set_sndbuf(Tap::SNDBUF_SIZE)
+                .map_err(Error::TapSetSndbuf)?;
         }
         taps.push(tap);
     }

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -489,6 +489,16 @@ impl Tap {
         unsafe { Self::ioctl_with_ref(&self.tap_file, libc::TUNSETVNETHDRSZ as c_ulong, &size) }
     }
 
+    /// Tap send buffer size (4MB). The kernel default is ~212KB which limits
+    /// throughput on high-bandwidth workloads.
+    pub const SNDBUF_SIZE: c_int = 4 * 1024 * 1024;
+
+    /// Set the tap send buffer size.
+    pub fn set_sndbuf(&self, size: c_int) -> Result<()> {
+        // SAFETY: ioctl is safe. Called with a valid tap fd, and we check the return.
+        unsafe { Self::ioctl_with_ref(&self.tap_file, libc::TUNSETSNDBUF as c_ulong, &size) }
+    }
+
     fn get_ifreq(&self) -> libc::ifreq {
         let mut ifreq: libc::ifreq = libc::ifreq {
             ifr_name: [0; libc::IFNAMSIZ],

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -9,7 +9,7 @@ use libc::{
     BLKIOMIN, BLKIOOPT, BLKPBSZGET, BLKSSZGET, FIOCLEX, FIONBIO, SIOCGIFFLAGS, SIOCGIFHWADDR,
     SIOCGIFINDEX, SIOCGIFMTU, SIOCSIFADDR, SIOCSIFFLAGS, SIOCSIFHWADDR, SIOCSIFMTU, SIOCSIFNETMASK,
     TCGETS, TCGETS2, TCSETS, TCSETS2, TIOCGPGRP, TIOCGPTPEER, TIOCGWINSZ, TIOCSCTTY, TIOCSPGRP,
-    TIOCSPTLCK, TUNGETFEATURES, TUNGETIFF, TUNSETIFF, TUNSETOFFLOAD, TUNSETVNETHDRSZ,
+    TIOCSPTLCK, TUNGETFEATURES, TUNGETIFF, TUNSETIFF, TUNSETOFFLOAD, TUNSETSNDBUF, TUNSETVNETHDRSZ,
 };
 use seccompiler::SeccompCmpOp::Eq;
 use seccompiler::{
@@ -345,6 +345,7 @@ fn create_vmm_ioctl_seccomp_rule_common(
         and![Cond::new(1, ArgLen::Dword, Eq, TUNGETIFF as _)?],
         and![Cond::new(1, ArgLen::Dword, Eq, TUNSETIFF as _)?],
         and![Cond::new(1, ArgLen::Dword, Eq, TUNSETOFFLOAD as _)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, TUNSETSNDBUF as _)?],
         and![Cond::new(1, ArgLen::Dword, Eq, TUNSETVNETHDRSZ as _)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_GET_API_VERSION)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_CHECK_EXTENSION)?],


### PR DESCRIPTION
Reopen of #8036. Original closed 4/27 as abandoned, but the cargo-fmt fix that @rbradford requested at 21:28 UTC on 4/16 was pushed at 22:25 UTC the same day - the PR sat for 11 days unreviewed before being closed. Rebased onto current main, no functional changes since the last push.

The kernel default tap send buffer is ~212KB. On Cloudflare edge metals running real-time UDP workloads (eero, Discord audio/video) that fills in microseconds and causes packet drops on burst traffic. CC-7372 traces a 2.3 vs 10 Gbps regression that lines up with the difference between this and the larger buffer Firecracker gets through vhost-net.

## Changes

- `net_util/src/tap.rs`: `Tap::SNDBUF_SIZE` constant (4 MB) and `Tap::set_sndbuf()` method wrapping `TUNSETSNDBUF`. `from_tap_fd` (user-supplied fd) calls it best-effort with a warn-only on failure; new taps via `Tap::new` and the regular open path error hard so misconfiguration is loud.
- `net_util/src/open_tap.rs`: applies `Tap::SNDBUF_SIZE` on the q0 tap and on each multi-queue tap in `open_tap()`, both with hard errors via the new `Error::TapSetSndbuf`.

## Notes

- Kernel-side ceiling is `/proc/sys/net/core/wmem_max`. If that is below 4 MB the ioctl returns the kernel cap silently; production hosts have wmem_max well above 4 MB so this is just a guard for under-tuned dev VMs.
- This is the conservative half of the networking work: a single sysctl-equivalent knob, no new backend, no security surface change. Pairs with the upstream design discussion that's coming for vhost-net / AF_XDP / vhost-user.

Refs: #8036
Refs: #5162

Signed-off-by: Keith Adler <kadler@cloudflare.com>