### PR TITLE
replace `as <pointer>` casts with safer alternatives

### DIFF
--- a/arch/src/x86_64/mptable.rs
+++ b/arch/src/x86_64/mptable.rs
@@ -101,8 +101,9 @@ const CPU_FEATURE_APIC: u32 = 0x200;
 const CPU_FEATURE_FPU: u32 = 0x001;
 
 fn compute_checksum<T: Copy + ByteValued>(v: &T) -> u8 {
+    let v: *const T = v;
     // SAFETY: we are only reading the bytes within the size of the `T` reference `v`.
-    let v_slice = unsafe { slice::from_raw_parts(v as *const T as *const u8, mem::size_of::<T>()) };
+    let v_slice = unsafe { slice::from_raw_parts(v.cast(), mem::size_of::<T>()) };
     let mut checksum: u8 = 0;
     for i in v_slice.iter() {
         checksum = checksum.wrapping_add(*i);

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -49,8 +49,9 @@ const PCI_SUPPORTED: u64 = 1 << 7;
 const IS_VIRTUAL_MACHINE: u8 = 1 << 4;
 
 fn compute_checksum<T: Copy>(v: &T) -> u8 {
+    let v: *const T = v;
     // SAFETY: we are only reading the bytes within the size of the `T` reference `v`.
-    let v_slice = unsafe { slice::from_raw_parts(v as *const T as *const u8, mem::size_of::<T>()) };
+    let v_slice = unsafe { slice::from_raw_parts(v.cast(), mem::size_of::<T>()) };
     let mut checksum: u8 = 0;
     for i in v_slice.iter() {
         checksum = checksum.wrapping_add(*i);

--- a/arch/src/x86_64/tdx/mod.rs
+++ b/arch/src/x86_64/tdx/mod.rs
@@ -163,7 +163,7 @@ pub fn parse_tdvf_sections(file: &mut File) -> Result<(Vec<TdvfSection>, bool), 
     // SAFETY: we read exactly the size of the descriptor header
     file.read_exact(unsafe {
         std::slice::from_raw_parts_mut(
-            &mut descriptor as *mut _ as *mut u8,
+            (&raw mut descriptor).cast(),
             std::mem::size_of::<TdvfDescriptor>(),
         )
     })
@@ -190,7 +190,7 @@ pub fn parse_tdvf_sections(file: &mut File) -> Result<(Vec<TdvfSection>, bool), 
     // SAFETY: we read exactly the advertised sections
     file.read_exact(unsafe {
         std::slice::from_raw_parts_mut(
-            sections.as_mut_ptr() as *mut u8,
+            sections.as_mut_ptr().cast(),
             descriptor.num_sections as usize * std::mem::size_of::<TdvfSection>(),
         )
     })

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -931,8 +931,7 @@ mod unit_tests {
         unsafe { ptr::write_bytes(buf, 0xAB, alignment) };
 
         // SAFETY: buf is aligned and sized for O_DIRECT; fd is valid.
-        let written =
-            unsafe { libc::pwrite(f.as_raw_fd(), buf as *const libc::c_void, alignment, 0) };
+        let written = unsafe { libc::pwrite(f.as_raw_fd(), buf.cast(), alignment, 0) };
         assert_eq!(
             written as usize,
             alignment,
@@ -943,7 +942,7 @@ mod unit_tests {
         // SAFETY: buf is valid for `alignment` bytes.
         unsafe { ptr::write_bytes(buf, 0x00, alignment) };
         // SAFETY: buf is aligned and sized for O_DIRECT; fd is valid.
-        let read = unsafe { libc::pread(f.as_raw_fd(), buf as *mut libc::c_void, alignment, 0) };
+        let read = unsafe { libc::pread(f.as_raw_fd(), buf.cast(), alignment, 0) };
         assert_eq!(
             read as usize,
             alignment,

--- a/block/src/qcow/raw_file.rs
+++ b/block/src/qcow/raw_file.rs
@@ -15,7 +15,6 @@ use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::slice;
 
-use libc::c_void;
 use vmm_sys_util::file_traits::FileSync;
 use vmm_sys_util::seek_hole::SeekHole;
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
@@ -39,14 +38,7 @@ fn is_valid_alignment(fd: RawFd, alignment: usize) -> bool {
     assert!(!ptr.is_null());
 
     // SAFETY: FFI call
-    let ret = unsafe {
-        ::libc::pread(
-            fd,
-            ptr as *mut c_void,
-            alignment,
-            alignment.try_into().unwrap(),
-        )
-    };
+    let ret = unsafe { ::libc::pread(fd, ptr.cast(), alignment, alignment.try_into().unwrap()) };
 
     // SAFETY: ptr was allocated by alloc_zeroed with layout
     unsafe { dealloc(ptr, layout) };
@@ -187,7 +179,7 @@ impl Read for RawFile {
             let ret = unsafe {
                 ::libc::pread64(
                     self.file.as_raw_fd(),
-                    tmp_buf.as_mut_ptr() as *mut c_void,
+                    tmp_buf.as_mut_ptr().cast(),
                     tmp_buf.len(),
                     rounded_pos.try_into().unwrap(),
                 )
@@ -267,7 +259,7 @@ impl Write for RawFile {
             let ret = unsafe {
                 ::libc::pread64(
                     self.file.as_raw_fd(),
-                    tmp_buf.as_mut_ptr() as *mut c_void,
+                    tmp_buf.as_mut_ptr().cast(),
                     tmp_buf.len(),
                     rounded_pos.try_into().unwrap(),
                 )
@@ -286,7 +278,7 @@ impl Write for RawFile {
             let ret = unsafe {
                 ::libc::pwrite64(
                     self.file.as_raw_fd(),
-                    tmp_buf.as_ptr() as *const c_void,
+                    tmp_buf.as_ptr().cast(),
                     tmp_buf.len(),
                     rounded_pos.try_into().unwrap(),
                 )

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -597,7 +597,7 @@ mod unit_tests {
             let mut val = 0u64;
             // SAFETY: reading 8 bytes from a valid eventfd.
             unsafe {
-                libc::read(fd, &mut val as *mut u64 as *mut libc::c_void, 8);
+                libc::read(fd, (&raw mut val).cast(), 8);
             }
         }
     }
@@ -605,7 +605,7 @@ mod unit_tests {
     fn async_write(disk: &QcowDisk, offset: u64, data: &[u8]) {
         let mut async_io = disk.create_async_io(1).unwrap();
         let iovec = libc::iovec {
-            iov_base: data.as_ptr() as *mut libc::c_void,
+            iov_base: data.as_ptr().cast::<libc::c_void>().cast_mut(),
             iov_len: data.len(),
         };
         async_io
@@ -624,7 +624,7 @@ mod unit_tests {
         let mut async_io = disk.create_async_io(1).unwrap();
         let mut buf = vec![0xFFu8; len];
         let iovec = libc::iovec {
-            iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+            iov_base: buf.as_mut_ptr().cast(),
             iov_len: buf.len(),
         };
         async_io
@@ -755,11 +755,11 @@ mod unit_tests {
         let offset_b: u64 = 65536;
 
         let iov_a = libc::iovec {
-            iov_base: write_a.as_ptr() as *mut libc::c_void,
+            iov_base: write_a.as_ptr().cast::<libc::c_void>().cast_mut(),
             iov_len: write_a.len(),
         };
         let iov_b = libc::iovec {
-            iov_base: write_b.as_ptr() as *mut libc::c_void,
+            iov_base: write_b.as_ptr().cast::<libc::c_void>().cast_mut(),
             iov_len: write_b.len(),
         };
 
@@ -793,11 +793,11 @@ mod unit_tests {
         let mut read_a = vec![0u8; 4096];
         let mut read_b = vec![0u8; 4096];
         let riov_a = libc::iovec {
-            iov_base: read_a.as_mut_ptr() as *mut libc::c_void,
+            iov_base: read_a.as_mut_ptr().cast(),
             iov_len: read_a.len(),
         };
         let riov_b = libc::iovec {
-            iov_base: read_b.as_mut_ptr() as *mut libc::c_void,
+            iov_base: read_b.as_mut_ptr().cast(),
             iov_len: read_b.len(),
         };
 
@@ -1068,7 +1068,7 @@ mod unit_tests {
                     let mut async_io = disk.create_async_io(1).unwrap();
                     let mut buf = vec![0xFFu8; cluster_size];
                     let iovec = libc::iovec {
-                        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+                        iov_base: buf.as_mut_ptr().cast(),
                         iov_len: buf.len(),
                     };
                     async_io.read_vectored(0, &[iovec], 1).unwrap();

--- a/block/src/qcow_common.rs
+++ b/block/src/qcow_common.rs
@@ -30,7 +30,7 @@ pub fn pread_exact(fd: RawFd, buf: &mut [u8], offset: u64) -> io::Result<()> {
         let ret = unsafe {
             libc::pread64(
                 fd,
-                buf[total..].as_mut_ptr() as *mut libc::c_void,
+                buf[total..].as_mut_ptr().cast(),
                 buf.len() - total,
                 (offset + total as u64) as libc::off_t,
             )
@@ -81,7 +81,7 @@ pub fn pwrite_all(fd: RawFd, buf: &[u8], offset: u64) -> io::Result<()> {
         let ret = unsafe {
             libc::pwrite64(
                 fd,
-                buf[total..].as_ptr() as *const libc::c_void,
+                buf[total..].as_ptr().cast(),
                 buf.len() - total,
                 (offset + total as u64) as libc::off_t,
             )
@@ -211,7 +211,7 @@ pub unsafe fn scatter_to_iovecs(iovecs: &[libc::iovec], start: usize, data: &[u8
         let count = min(available, remaining.len());
         // SAFETY: iov_base is valid for iov_len bytes per caller contract.
         unsafe {
-            let dst = (iov.iov_base as *mut u8).add(iov_start);
+            let dst = iov.iov_base.cast::<u8>().add(iov_start);
             ptr::copy_nonoverlapping(remaining.as_ptr(), dst, count);
         }
         remaining = &remaining[count..];
@@ -240,7 +240,7 @@ pub unsafe fn zero_fill_iovecs(iovecs: &[libc::iovec], start: usize, len: usize)
         let count = min(available, remaining);
         // SAFETY: iov_base is valid for iov_len bytes per caller contract.
         unsafe {
-            let dst = (iov.iov_base as *mut u8).add(iov_start);
+            let dst = iov.iov_base.cast::<u8>().add(iov_start);
             ptr::write_bytes(dst, 0, count);
         }
         remaining -= count;
@@ -270,7 +270,7 @@ pub unsafe fn gather_from_iovecs_into(iovecs: &[libc::iovec], start: usize, dst:
         let count = min(available, len - written);
         // SAFETY: iov_base is valid for iov_len bytes per caller contract.
         unsafe {
-            let src = (iov.iov_base as *const u8).add(iov_start);
+            let src = iov.iov_base.cast::<u8>().add(iov_start);
             ptr::copy_nonoverlapping(src, dst.as_mut_ptr().add(written), count);
         }
         written += count;

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -353,7 +353,7 @@ mod unit_tests {
         let mut async_io = disk.create_async_io(1).unwrap();
         let mut buf = vec![0xFFu8; len];
         let iovec = libc::iovec {
-            iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+            iov_base: buf.as_mut_ptr().cast(),
             iov_len: buf.len(),
         };
         async_io
@@ -368,7 +368,7 @@ mod unit_tests {
     fn async_write(disk: &QcowDisk, offset: u64, data: &[u8]) {
         let mut async_io = disk.create_async_io(1).unwrap();
         let iovec = libc::iovec {
-            iov_base: data.as_ptr() as *mut libc::c_void,
+            iov_base: data.as_ptr().cast::<libc::c_void>().cast_mut(),
             iov_len: data.len(),
         };
         async_io
@@ -1550,15 +1550,15 @@ mod unit_tests {
         let c = vec![0xCCu8; 16 * 1024];
         let iovecs_w = [
             libc::iovec {
-                iov_base: a.as_ptr() as *mut libc::c_void,
+                iov_base: a.as_ptr().cast::<libc::c_void>().cast_mut(),
                 iov_len: a.len(),
             },
             libc::iovec {
-                iov_base: b.as_ptr() as *mut libc::c_void,
+                iov_base: b.as_ptr().cast::<libc::c_void>().cast_mut(),
                 iov_len: b.len(),
             },
             libc::iovec {
-                iov_base: c.as_ptr() as *mut libc::c_void,
+                iov_base: c.as_ptr().cast::<libc::c_void>().cast_mut(),
                 iov_len: c.len(),
             },
         ];
@@ -1578,15 +1578,15 @@ mod unit_tests {
         let mut r3 = vec![0u8; 8 * 1024];
         let iovecs_r = [
             libc::iovec {
-                iov_base: r1.as_mut_ptr() as *mut libc::c_void,
+                iov_base: r1.as_mut_ptr().cast(),
                 iov_len: r1.len(),
             },
             libc::iovec {
-                iov_base: r2.as_mut_ptr() as *mut libc::c_void,
+                iov_base: r2.as_mut_ptr().cast(),
                 iov_len: r2.len(),
             },
             libc::iovec {
-                iov_base: r3.as_mut_ptr() as *mut libc::c_void,
+                iov_base: r3.as_mut_ptr().cast(),
                 iov_len: r3.len(),
             },
         ];

--- a/block/src/request.rs
+++ b/block/src/request.rs
@@ -291,7 +291,7 @@ impl Request {
                 .get_slice(data_addr, data_len)
                 .map_err(ExecuteError::GetHostAddress)?;
             assert!(origin_ptr.len() >= data_len);
-            let origin_ptr = origin_ptr.ptr_guard();
+            let origin_ptr = origin_ptr.ptr_guard_mut();
 
             // O_DIRECT requires buffer addresses to be aligned to the
             // backend device's logical block size. In case it's not properly
@@ -299,7 +299,7 @@ impl Request {
             // alignment, and a copy from/to the origin buffer is performed,
             // depending on the type of operation.
             let iov_base = if (origin_ptr.as_ptr() as u64).is_multiple_of(alignment) {
-                origin_ptr.as_ptr() as *mut libc::c_void
+                origin_ptr.as_ptr().cast()
             } else {
                 let layout = Layout::from_size_align(data_len, alignment as usize).unwrap();
                 // SAFETY: layout has non-zero size
@@ -327,7 +327,7 @@ impl Request {
                     layout,
                 });
 
-                aligned_ptr as *mut libc::c_void
+                aligned_ptr.cast()
             };
 
             let iovec = libc::iovec {

--- a/block/src/vhdx/vhdx_header.rs
+++ b/block/src/vhdx/vhdx_header.rs
@@ -135,7 +135,7 @@ impl Header {
             .map_err(VhdxHeaderError::ReadHeader)?;
 
         // SAFETY: buffer is of correct size and has been successfully filled.
-        let header = unsafe { *(buffer.as_ptr() as *mut Header) };
+        let header: Header = unsafe { *(buffer.as_ptr().cast()) };
         if header.signature != HEADER_SIGN {
             return Err(VhdxHeaderError::InvalidHeaderSign);
         }
@@ -151,9 +151,8 @@ impl Header {
     /// Converts the header structure into a buffer
     fn write_to_buffer(&self, buffer: &mut [u8; HEADER_SIZE as usize]) {
         // SAFETY: self is a valid header.
-        let reference = unsafe {
-            std::slice::from_raw_parts(self as *const Header as *const u8, HEADER_SIZE as usize)
-        };
+        let reference =
+            unsafe { std::slice::from_raw_parts((&raw const *self).cast(), HEADER_SIZE as usize) };
         *buffer = reference.try_into().unwrap();
     }
 
@@ -222,7 +221,7 @@ impl RegionTableHeader {
             .map_err(VhdxHeaderError::ReadRegionTableHeader)?;
 
         // SAFETY: buffer is of correct size and has been successfully filled.
-        let region_table_header = unsafe { *(buffer.as_ptr() as *mut RegionTableHeader) };
+        let region_table_header: RegionTableHeader = unsafe { *(buffer.as_ptr().cast()) };
         if region_table_header.signature != REGION_SIGN {
             return Err(VhdxHeaderError::InvalidRegionSign);
         }
@@ -340,7 +339,7 @@ impl RegionTableEntry {
     pub fn new(buffer: &[u8]) -> Result<RegionTableEntry> {
         assert!(buffer.len() == std::mem::size_of::<RegionTableEntry>());
         // SAFETY: the assertion above makes sure the buffer size is correct.
-        let mut region_table_entry = unsafe { *(buffer.as_ptr() as *mut RegionTableEntry) };
+        let mut region_table_entry: RegionTableEntry = unsafe { *(buffer.as_ptr().cast()) };
 
         let uuid = crate::vhdx::uuid_from_guid(buffer);
         region_table_entry.guid = uuid;

--- a/block/src/vhdx/vhdx_metadata.rs
+++ b/block/src/vhdx/vhdx_metadata.rs
@@ -280,7 +280,7 @@ impl MetadataTableHeader {
     pub fn new(buffer: &[u8]) -> Result<MetadataTableHeader> {
         assert!(buffer.len() == std::mem::size_of::<MetadataTableHeader>());
         // SAFETY: the assertion above makes sure the buffer size is correct.
-        let metadata_table_header = unsafe { *(buffer.as_ptr() as *mut MetadataTableHeader) };
+        let metadata_table_header: MetadataTableHeader = unsafe { *(buffer.as_ptr().cast()) };
 
         if metadata_table_header.signature != METADATA_SIGN {
             return Err(VhdxMetadataError::InvalidMetadataSign);
@@ -313,7 +313,7 @@ impl MetadataTableEntry {
     fn new(buffer: &[u8]) -> Result<MetadataTableEntry> {
         assert!(buffer.len() == std::mem::size_of::<MetadataTableEntry>());
         // SAFETY: the assertion above makes sure the buffer size is correct.
-        let mut metadata_table_entry = unsafe { *(buffer.as_ptr() as *mut MetadataTableEntry) };
+        let mut metadata_table_entry: MetadataTableEntry = unsafe { *(buffer.as_ptr().cast()) };
 
         let uuid = crate::vhdx::uuid_from_guid(buffer);
         metadata_table_entry.item_id = uuid;

--- a/devices/src/legacy/cmos.rs
+++ b/devices/src/legacy/cmos.rs
@@ -122,13 +122,13 @@ impl BusDevice for Cmos {
                 // the tm and timespec struct because it contains only plain data.
                 let update_in_progress = unsafe {
                     let mut timespec: timespec = mem::zeroed();
-                    clock_gettime(CLOCK_REALTIME, &mut timespec as *mut _);
+                    clock_gettime(CLOCK_REALTIME, &raw mut timespec);
 
                     // https://github.com/rust-lang/libc/issues/1848
                     #[cfg_attr(target_env = "musl", allow(deprecated))]
                     let now: time_t = timespec.tv_sec;
                     let mut tm: tm = mem::zeroed();
-                    gmtime_r(&now, &mut tm as *mut _);
+                    gmtime_r(&now, &raw mut tm);
 
                     // The following lines of code are safe but depend on tm being in scope.
                     seconds = tm.tm_sec;

--- a/devices/src/pvmemcontrol.rs
+++ b/devices/src/pvmemcontrol.rs
@@ -443,7 +443,7 @@ impl PvmemcontrolBusDevice {
             )));
         };
         assert!(slice.len() >= range_len);
-        let res = f(slice.ptr_guard_mut().as_ptr() as _, slice.len());
+        let res = f(slice.ptr_guard_mut().as_ptr().cast(), slice.len());
         if res != 0 {
             return Err(Error::LibcFail(io::Error::last_os_error()));
         }

--- a/hypervisor/src/kvm/aarch64/gic/dist_regs.rs
+++ b/hypervisor/src/kvm/aarch64/gic/dist_regs.rs
@@ -82,7 +82,7 @@ fn dist_attr_set(gic: &DeviceFd, offset: u32, val: u32) -> Result<()> {
     let gic_dist_attr = kvm_device_attr {
         group: KVM_DEV_ARM_VGIC_GRP_DIST_REGS,
         attr: offset as u64,
-        addr: &val as *const u32 as u64,
+        addr: &raw const val as u64,
         flags: 0,
     };
 
@@ -99,7 +99,7 @@ fn dist_attr_get(gic: &DeviceFd, offset: u32) -> Result<u32> {
     let mut gic_dist_attr = kvm_device_attr {
         group: KVM_DEV_ARM_VGIC_GRP_DIST_REGS,
         attr: offset as u64,
-        addr: &mut val as *mut u32 as u64,
+        addr: &raw mut val as u64,
         flags: 0,
     };
 
@@ -127,7 +127,7 @@ fn get_interrupts_num(gic: &DeviceFd) -> Result<u32> {
     let mut nr_irqs_attr = kvm_device_attr {
         group: KVM_DEV_ARM_VGIC_GRP_NR_IRQS,
         attr: 0,
-        addr: &mut num_irq as *mut u32 as u64,
+        addr: &raw mut num_irq as u64,
         flags: 0,
     };
     // SAFETY: nr_irqs_attr.addr is safe to write to.

--- a/hypervisor/src/kvm/aarch64/gic/icc_regs.rs
+++ b/hypervisor/src/kvm/aarch64/gic/icc_regs.rs
@@ -85,7 +85,7 @@ fn icc_attr_set(gic: &DeviceFd, offset: u64, typer: u64, val: u32) -> Result<()>
     let gic_icc_attr = kvm_device_attr {
         group: KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS,
         attr: ((typer & KVM_DEV_ARM_VGIC_V3_MPIDR_MASK) | offset), // this needs the mpidr
-        addr: &val as *const u32 as u64,
+        addr: &raw const val as u64,
         flags: 0,
     };
 
@@ -102,7 +102,7 @@ fn icc_attr_get(gic: &DeviceFd, offset: u64, typer: u64) -> Result<u32> {
     let mut gic_icc_attr = kvm_device_attr {
         group: KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS,
         attr: ((typer & KVM_DEV_ARM_VGIC_V3_MPIDR_MASK) | offset), // this needs the mpidr
-        addr: &mut val as *mut u32 as u64,
+        addr: &raw mut val as u64,
         flags: 0,
     };
 

--- a/hypervisor/src/kvm/aarch64/gic/mod.rs
+++ b/hypervisor/src/kvm/aarch64/gic/mod.rs
@@ -30,7 +30,7 @@ fn gicv3_its_attr_set(its_device: &DeviceFd, group: u32, attr: u32, val: u64) ->
     let gicv3_its_attr = kvm_bindings::kvm_device_attr {
         group,
         attr: attr as u64,
-        addr: &val as *const u64 as u64,
+        addr: &raw const val as u64,
         flags: 0,
     };
 
@@ -45,7 +45,7 @@ fn gicv3_its_attr_get(its_device: &DeviceFd, group: u32, attr: u32) -> Result<u6
     let mut gicv3_its_attr = kvm_bindings::kvm_device_attr {
         group,
         attr: attr as u64,
-        addr: &mut val as *mut u64 as u64,
+        addr: &raw mut val as u64,
         flags: 0,
     };
 
@@ -159,7 +159,7 @@ impl KvmGicV3Its {
             &self.device,
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
             u64::from(kvm_bindings::KVM_VGIC_V3_ADDR_TYPE_DIST),
-            &self.dist_addr as *const u64 as u64,
+            &raw const self.dist_addr as u64,
             0,
         )?;
 
@@ -168,7 +168,7 @@ impl KvmGicV3Its {
             &self.device,
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
             u64::from(kvm_bindings::KVM_VGIC_V3_ADDR_TYPE_REDIST),
-            &self.redists_addr as *const u64 as u64,
+            &raw const self.redists_addr as u64,
             0,
         )?;
 
@@ -190,7 +190,7 @@ impl KvmGicV3Its {
             &its_fd,
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_ADDR,
             u64::from(kvm_bindings::KVM_VGIC_ITS_ADDR_TYPE),
-            &self.msi_addr as *const u64 as u64,
+            &raw const self.msi_addr as u64,
             0,
         )?;
 
@@ -207,7 +207,7 @@ impl KvmGicV3Its {
         /* We need to tell the kernel how many irqs to support with this vgic.
          * See the `layout` module for details.
          */
-        let nr_irqs_ptr = &nr_irqs as *const u32;
+        let nr_irqs_ptr = &raw const nr_irqs;
         Self::set_device_attribute(
             &self.device,
             kvm_bindings::KVM_DEV_ARM_VGIC_GRP_NR_IRQS,

--- a/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
+++ b/hypervisor/src/kvm/aarch64/gic/redist_regs.rs
@@ -100,7 +100,7 @@ fn redist_attr_set(gic: &DeviceFd, offset: u32, typer: u64, val: u32) -> Result<
     let gic_redist_attr = kvm_device_attr {
         group: KVM_DEV_ARM_VGIC_GRP_REDIST_REGS,
         attr: (typer & KVM_DEV_ARM_VGIC_V3_MPIDR_MASK) | (offset as u64), // this needs the mpidr
-        addr: &val as *const u32 as u64,
+        addr: &raw const val as u64,
         flags: 0,
     };
 
@@ -117,7 +117,7 @@ fn redist_attr_get(gic: &DeviceFd, offset: u32, typer: u64) -> Result<u32> {
     let mut gic_redist_attr = kvm_device_attr {
         group: KVM_DEV_ARM_VGIC_GRP_REDIST_REGS,
         attr: (typer & KVM_DEV_ARM_VGIC_V3_MPIDR_MASK) | (offset as u64), // this needs the mpidr
-        addr: &mut val as *mut u32 as u64,
+        addr: &raw mut val as u64,
         flags: 0,
     };
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -121,7 +121,7 @@ use kvm_bindings::{
 #[cfg(target_arch = "riscv64")]
 use kvm_bindings::{KVM_REG_RISCV_CORE, kvm_riscv_core};
 #[cfg(feature = "tdx")]
-use kvm_bindings::{KVM_X86_SW_PROTECTED_VM, KVMIO, kvm_run__bindgen_ty_1};
+use kvm_bindings::{KVM_X86_SW_PROTECTED_VM, KVMIO};
 #[cfg(target_arch = "x86_64")]
 use kvm_bindings::{Xsave as xsave2, kvm_xsave2};
 pub use kvm_ioctls::{self, Cap, Kvm, VcpuExit};
@@ -1331,7 +1331,7 @@ impl vm::Vm for KvmVm {
             &self.fd.as_raw_fd(),
             TdxCommand::InitVm,
             0,
-            &data as *const _ as *const _,
+            (&raw const data).cast(),
         )
         .map_err(vm::HypervisorVmError::InitializeTdx)
     }
@@ -1379,7 +1379,7 @@ impl vm::Vm for KvmVm {
             &self.fd.as_raw_fd(),
             TdxCommand::InitMemRegion,
             u32::from(measure),
-            &data as *const _ as *const _,
+            (&raw const data).cast(),
         )
         .map_err(vm::HypervisorVmError::InitMemRegionTdx)
     }
@@ -1417,7 +1417,7 @@ fn tdx_command(
         ioctl_with_val(
             fd,
             KVM_MEMORY_ENCRYPT_OP(),
-            &cmd as *const TdxIoctlCmd as std::os::raw::c_ulong,
+            &raw const cmd as std::os::raw::c_ulong,
         )
     };
 
@@ -1677,7 +1677,7 @@ impl hypervisor::Hypervisor for KvmHypervisor {
             &self.kvm.as_raw_fd(),
             TdxCommand::Capabilities,
             0,
-            &data as *const _ as *const _,
+            (&raw const data).cast(),
         )
         .map_err(|e| hypervisor::HypervisorError::TdxCapabilities(e.into()))?;
 
@@ -3155,8 +3155,7 @@ impl cpu::Vcpu for KvmVcpu {
         let kvm_run = self.fd.get_kvm_run();
         // SAFETY: accessing a union field in a valid structure
         let tdx_vmcall = unsafe {
-            &mut (*((&mut kvm_run.__bindgen_anon_1) as *mut kvm_run__bindgen_ty_1
-                as *mut KvmTdxExit))
+            &mut (*((&raw mut kvm_run.__bindgen_anon_1).cast::<KvmTdxExit>()))
                 .u
                 .vmcall
         };
@@ -3184,8 +3183,7 @@ impl cpu::Vcpu for KvmVcpu {
         let kvm_run = self.fd.get_kvm_run();
         // SAFETY: accessing a union field in a valid structure
         let tdx_vmcall = unsafe {
-            &mut (*((&mut kvm_run.__bindgen_anon_1) as *mut kvm_run__bindgen_ty_1
-                as *mut KvmTdxExit))
+            &mut (*((&raw mut kvm_run.__bindgen_anon_1).cast::<KvmTdxExit>()))
                 .u
                 .vmcall
         };
@@ -3243,7 +3241,7 @@ impl cpu::Vcpu for KvmVcpu {
         let cpu_attr_irq = kvm_bindings::kvm_device_attr {
             group: kvm_bindings::KVM_ARM_VCPU_PMU_V3_CTRL,
             attr: u64::from(kvm_bindings::KVM_ARM_VCPU_PMU_V3_IRQ),
-            addr: &irq as *const u32 as u64,
+            addr: &raw const irq as u64,
             flags: 0,
         };
         self.fd

--- a/hypervisor/src/kvm/riscv64/aia.rs
+++ b/hypervisor/src/kvm/riscv64/aia.rs
@@ -45,7 +45,7 @@ impl KvmAiaImsics {
             &self.device,
             kvm_bindings::KVM_DEV_RISCV_AIA_GRP_CONFIG,
             u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_CONFIG_MODE),
-            &mut aia_mode as *mut u32 as u64,
+            &raw mut aia_mode as u64,
             0,
         )?;
 
@@ -56,7 +56,7 @@ impl KvmAiaImsics {
             &self.device,
             kvm_bindings::KVM_DEV_RISCV_AIA_GRP_CONFIG,
             u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_CONFIG_SRCS),
-            &nr_irqs as *const u32 as u64,
+            &raw const nr_irqs as u64,
             0,
         )?;
 
@@ -66,7 +66,7 @@ impl KvmAiaImsics {
             &self.device,
             kvm_bindings::KVM_DEV_RISCV_AIA_GRP_CONFIG,
             u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_CONFIG_IDS),
-            &mut aia_nr_ids as *mut u32 as u64,
+            &raw mut aia_nr_ids as u64,
             0,
         )?;
 
@@ -79,7 +79,7 @@ impl KvmAiaImsics {
             &self.device,
             kvm_bindings::KVM_DEV_RISCV_AIA_GRP_CONFIG,
             u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_CONFIG_HART_BITS),
-            &hart_bits as *const u32 as u64,
+            &raw const hart_bits as u64,
             0,
         )?;
 
@@ -90,7 +90,7 @@ impl KvmAiaImsics {
             &self.device,
             kvm_bindings::KVM_DEV_RISCV_AIA_GRP_ADDR,
             u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_ADDR_APLIC),
-            &self.aplic_addr as *const u64 as u64,
+            &raw const self.aplic_addr as u64,
             0,
         )?;
 
@@ -107,7 +107,7 @@ impl KvmAiaImsics {
                 &self.device,
                 kvm_bindings::KVM_DEV_RISCV_AIA_GRP_ADDR,
                 riscv_imsic_attr_of(cpu_index),
-                &cpu_imsic_addr as *const u64 as u64,
+                &raw const cpu_imsic_addr as u64,
                 0,
             )?;
         }

--- a/hypervisor/src/kvm/x86_64/sev.rs
+++ b/hypervisor/src/kvm/x86_64/sev.rs
@@ -207,7 +207,7 @@ impl SevFd {
         };
         let mut sev_cmd = kvm_sev_cmd {
             id: KVM_SEV_INIT2,
-            data: &mut init as *mut KvmSevInit as _,
+            data: &raw mut init as u64,
             sev_fd: self.fd.as_raw_fd() as _,
             ..Default::default()
         };
@@ -221,7 +221,7 @@ impl SevFd {
         };
         let mut sev_cmd = kvm_sev_cmd {
             id: KVM_SEV_SNP_LAUNCH_START,
-            data: &mut start as *mut KvmSevSnpLaunchStart as _,
+            data: &raw mut start as u64,
             sev_fd: self.fd.as_raw_fd() as _,
             ..Default::default()
         };
@@ -247,7 +247,7 @@ impl SevFd {
         };
         let mut sev_cmd = kvm_sev_cmd {
             id: KVM_SEV_SNP_LAUNCH_UPDATE,
-            data: &mut update as *mut KvmSevSnpLaunchUpdate as _,
+            data: &raw mut update as u64,
             sev_fd: self.fd.as_raw_fd() as _,
             ..Default::default()
         };
@@ -276,7 +276,7 @@ impl SevFd {
         };
         let mut sev_cmd = kvm_sev_cmd {
             id: KVM_SEV_SNP_LAUNCH_FINISH,
-            data: &mut finish as *mut KvmSevSnpLaunchFinish as _,
+            data: &raw mut finish as u64,
             sev_fd: self.fd.as_raw_fd() as _,
             ..Default::default()
         };

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1961,7 +1961,7 @@ impl vm::Vm for MshvVm {
                 // Return error
                 return Err(vm::HypervisorVmError::MmapToRoot);
             }
-            Some(Ghcb(addr as *mut svm_ghcb_base))
+            Some(Ghcb(addr.cast()))
         } else {
             None
         };

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -81,7 +81,7 @@ impl TxVirtio {
                     assert!(buf.len() >= desc.len() as usize);
                     let buf = buf.ptr_guard_mut();
                     let iovec = libc::iovec {
-                        iov_base: buf.as_ptr() as *mut libc::c_void,
+                        iov_base: buf.as_ptr().cast(),
                         iov_len: desc.len() as libc::size_t,
                     };
                     iovecs.push(iovec);
@@ -238,7 +238,7 @@ impl RxVirtio {
                     assert!(buf.len() >= desc.len() as usize);
                     let buf = buf.ptr_guard_mut();
                     let iovec = libc::iovec {
-                        iov_base: buf.as_ptr() as *mut libc::c_void,
+                        iov_base: buf.as_ptr().cast(),
                         iov_len: desc.len() as libc::size_t,
                     };
                     iovecs.push(iovec);

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -169,7 +169,7 @@ impl Tap {
             // Open calls are safe because we give a constant null-terminated
             // string and verify the result.
             libc::open(
-                c"/dev/net/tun".as_ptr() as *const c_char,
+                c"/dev/net/tun".as_ptr().cast(),
                 flags.unwrap_or(libc::O_RDWR | libc::O_NONBLOCK | libc::O_CLOEXEC),
             )
         };

--- a/pci/src/mmap.rs
+++ b/pci/src/mmap.rs
@@ -26,7 +26,7 @@ pub struct MmapRegion {
 impl Drop for MmapRegion {
     fn drop(&mut self) {
         // SAFETY: guaranteed by type validity invariant
-        unsafe { assert_eq!(libc::munmap(self.addr as *mut _, self.len), 0) }
+        unsafe { assert_eq!(libc::munmap(self.addr.cast(), self.len), 0) }
     }
 }
 // SAFETY: the caller is responsible for avoiding data races
@@ -82,7 +82,7 @@ in both isize and libc::size_t";
         if addr == libc::MAP_FAILED {
             Err(Error::last_os_error())
         } else {
-            let addr = addr as _;
+            let addr = addr.cast();
             Ok(Self { addr, len })
         }
     }

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -32,12 +32,12 @@ pub fn micro_bench_aio_drain(control: &PerformanceTestControl) -> f64 {
         .create_async_io(num_ops as u32)
         .expect("failed to create AIO context");
 
-    let buf = vec![0xA5u8; BLOCK_SIZE as usize];
+    let mut buf = vec![0xA5u8; BLOCK_SIZE as usize];
 
     // Submit all writes.
     for i in 0..num_ops {
         let iovec = libc::iovec {
-            iov_base: buf.as_ptr() as *mut _,
+            iov_base: buf.as_mut_ptr().cast(),
             iov_len: buf.len(),
         };
         aio.write_vectored((i as u64 * BLOCK_SIZE) as libc::off_t, &[iovec], i as u64)
@@ -378,7 +378,7 @@ pub fn micro_bench_qcow_batch_read(control: &PerformanceTestControl) -> f64 {
             BatchRequest {
                 offset: (i as u64 * QCOW_CLUSTER_SIZE) as libc::off_t,
                 iovecs: vec![libc::iovec {
-                    iov_base: slice.as_mut_ptr() as *mut libc::c_void,
+                    iov_base: slice.as_mut_ptr().cast(),
                     iov_len: QCOW_CLUSTER_SIZE as usize,
                 }]
                 .into(),
@@ -565,15 +565,16 @@ pub fn micro_bench_qcow_batch_write(control: &PerformanceTestControl) -> f64 {
         .create_async_io(num_ops as u32)
         .expect("create_async_io failed");
 
-    let buf = vec![0xA5u8; num_ops * QCOW_CLUSTER_SIZE as usize];
+    let mut buf = vec![0xA5u8; num_ops * QCOW_CLUSTER_SIZE as usize];
 
     let batch: Vec<BatchRequest> = (0..num_ops)
         .map(|i| {
-            let slice = &buf[i * QCOW_CLUSTER_SIZE as usize..(i + 1) * QCOW_CLUSTER_SIZE as usize];
+            let slice =
+                &mut buf[i * QCOW_CLUSTER_SIZE as usize..(i + 1) * QCOW_CLUSTER_SIZE as usize];
             BatchRequest {
                 offset: (i as u64 * QCOW_CLUSTER_SIZE) as libc::off_t,
                 iovecs: vec![libc::iovec {
-                    iov_base: slice.as_ptr() as *mut libc::c_void,
+                    iov_base: slice.as_mut_ptr().cast(),
                     iov_len: QCOW_CLUSTER_SIZE as usize,
                 }]
                 .into(),

--- a/performance-metrics/src/util.rs
+++ b/performance-metrics/src/util.rs
@@ -84,7 +84,7 @@ pub fn drain_completions(async_io: &mut dyn AsyncIo, count: usize) {
 /// Build an iovec suitable for a read into `buf`.
 pub fn read_iovec(buf: &mut [u8]) -> libc::iovec {
     libc::iovec {
-        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_base: buf.as_mut_ptr().cast(),
         iov_len: buf.len(),
     }
 }
@@ -92,7 +92,7 @@ pub fn read_iovec(buf: &mut [u8]) -> libc::iovec {
 /// Build an iovec suitable for a write from `buf`.
 pub fn write_iovec(buf: &[u8]) -> libc::iovec {
     libc::iovec {
-        iov_base: buf.as_ptr() as *mut libc::c_void,
+        iov_base: buf.as_ptr().cast::<libc::c_void>().cast_mut(),
         iov_len: buf.len(),
     }
 }

--- a/tpm/src/emulator.rs
+++ b/tpm/src/emulator.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::{mem, ptr};
 
 use anyhow::anyhow;
-use libc::{c_void, sockaddr_storage, socklen_t};
+use libc::{sockaddr_storage, socklen_t};
 use log::{debug, error};
 use thiserror::Error;
 
@@ -158,7 +158,7 @@ impl Emulator {
                 fds[0],
                 libc::SOL_SOCKET,
                 libc::SO_RCVTIMEO,
-                &tv as *const _ as *const libc::c_void,
+                (&raw const tv).cast(),
                 std::mem::size_of::<libc::timeval>() as u32,
             );
             if ret == -1 {
@@ -318,8 +318,8 @@ impl Emulator {
             cmd.buffer, cmd.input_len
         );
 
-        let data_vecs = [libc::iovec {
-            iov_base: cmd.buffer.as_ptr() as *mut libc::c_void,
+        let mut data_vecs = [libc::iovec {
+            iov_base: cmd.buffer.as_mut_ptr().cast(),
             iov_len: cmd.input_len,
         }; 1];
 
@@ -327,7 +327,7 @@ impl Emulator {
         let mut msghdr: libc::msghdr = unsafe { mem::zeroed() };
         msghdr.msg_name = ptr::null_mut();
         msghdr.msg_namelen = 0;
-        msghdr.msg_iov = data_vecs.as_ptr() as *mut libc::iovec;
+        msghdr.msg_iov = data_vecs.as_mut_ptr().cast();
         msghdr.msg_iovlen = data_vecs.len() as _;
         msghdr.msg_control = ptr::null_mut();
         msghdr.msg_controllen = 0;
@@ -348,11 +348,11 @@ impl Emulator {
         unsafe {
             let ret = libc::recvfrom(
                 self.data_fd,
-                cmd.buffer.as_mut_ptr() as *mut c_void,
+                cmd.buffer.as_mut_ptr().cast(),
                 cmd.buffer.len(),
                 0,
-                &mut addr as *mut libc::sockaddr_storage as *mut libc::sockaddr,
-                &mut len as *mut socklen_t,
+                (&raw mut addr).cast(),
+                &raw mut len,
             );
             if ret == -1 {
                 return Err(Error::SendReceive(anyhow!(

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -185,7 +185,7 @@ impl BalloonEpollHandler {
         let res =
             // SAFETY: FFI call with valid arguments, guaranteed by VolatileSlice
             unsafe {
-                libc::madvise(slice.ptr_guard_mut().as_ptr() as *mut libc::c_void,
+                libc::madvise(slice.ptr_guard_mut().as_ptr().cast(),
                 range_len as libc::size_t, advice) };
         if res != 0 {
             return Err(Error::MadviseFail(io::Error::last_os_error()));

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -605,13 +605,10 @@ Setting device status to 'NEEDS_RESET' and stopping processing queues until rese
 
         // Schedule the thread to run on the expected CPU set
         if let Some(cpuset) = cpuset.as_ref() {
+            let cpuset: *const libc::cpu_set_t = cpuset;
             // SAFETY: FFI call with correct arguments
             let ret = unsafe {
-                libc::sched_setaffinity(
-                    0,
-                    std::mem::size_of::<libc::cpu_set_t>(),
-                    cpuset as *const libc::cpu_set_t,
-                )
+                libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), cpuset)
             };
 
             if ret != 0 {
@@ -1070,7 +1067,7 @@ impl VirtioDevice for Block {
     fn write_config(&mut self, offset: u64, data: &[u8]) {
         // The "writeback" field is the only mutable field
         let writeback_offset =
-            (&self.config.writeback as *const _ as u64) - (&self.config as *const _ as u64);
+            (&raw const self.config.writeback as u64) - (&raw const self.config as u64);
         if offset != writeback_offset || data.len() != std::mem::size_of_val(&self.config.writeback)
         {
             error!(

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -1081,7 +1081,7 @@ impl VirtioDevice for Iommu {
     fn write_config(&mut self, offset: u64, data: &[u8]) {
         // The "bypass" field is the only mutable field
         let bypass_offset =
-            (&self.config.bypass as *const _ as u64) - (&self.config as *const _ as u64);
+            (&raw const self.config.bypass as u64) - (&raw const self.config as u64);
         if offset != bypass_offset || data.len() != std::mem::size_of_val(&self.config.bypass) {
             error!(
                 "Attempt to write to read-only field: offset {:x} length {}",

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -480,7 +480,7 @@ impl MemEpollHandler {
             // alone is not past the end.
             let res = unsafe {
                 libc::madvise(
-                    self.region.as_ptr().offset(offset as isize) as *mut libc::c_void,
+                    self.region.as_ptr().offset(offset as isize).cast(),
                     size as libc::size_t,
                     libc::MADV_DONTNEED,
                 )

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -233,7 +233,7 @@ impl VirtioDevice for Blk {
     fn write_config(&mut self, offset: u64, data: &[u8]) {
         // The "writeback" field is the only mutable field
         let writeback_offset =
-            (&self.config.writeback as *const _ as u64) - (&self.config as *const _ as u64);
+            (&raw const self.config.writeback as u64) - (&raw const self.config as u64);
         if offset != writeback_offset || data.len() != std::mem::size_of_val(&self.config.writeback)
         {
             error!(

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -687,7 +687,7 @@ impl VhostUserHandle {
             // SAFETY: region is of size len
             let bitmap: &[u64] = unsafe {
                 // Cast the pointer to u64
-                let ptr = region.as_ptr() as *const u64;
+                let ptr = region.as_ptr().cast();
                 std::slice::from_raw_parts(ptr, len)
             };
             Ok(MemoryRangeTable::from_dirty_bitmap(

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -396,7 +396,7 @@ impl VsockPacket {
             PacketBuffer::Borrowed { ptr, len } => {
                 // SAFETY: bound checks have already been performed when creating the packet
                 // from the virtq descriptor.
-                Some(unsafe { std::slice::from_raw_parts(*ptr as *const u8, *len) })
+                Some(unsafe { std::slice::from_raw_parts((*ptr).cast(), *len) })
             }
         }
     }

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -444,7 +444,7 @@ impl MemoryRangeTable {
     pub fn write_to(&self, fd: &mut dyn Write) -> Result<(), MigratableError> {
         // SAFETY: the slice is constructed with the correct arguments
         fd.write_all(unsafe {
-            std::slice::from_raw_parts(self.data.as_ptr() as *const u8, self.length() as usize)
+            std::slice::from_raw_parts(self.data.as_ptr().cast(), self.length() as usize)
         })
         .map_err(MigratableError::MigrateSocket)
     }

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -1278,7 +1278,7 @@ mod tests {
         // safe to read. Casting to `u8` satisfies alignment requirements.
         let bytes = unsafe {
             std::slice::from_raw_parts(
-                &gi as *const GenericInitiatorAffinity as *const u8,
+                (&raw const gi).cast::<u8>(),
                 std::mem::size_of::<GenericInitiatorAffinity>(),
             )
         };

--- a/vmm/src/console_devices.rs
+++ b/vmm/src/console_devices.rs
@@ -87,7 +87,7 @@ fn modify_mode<F: FnOnce(&mut termios)>(
     // and we check the return result.
     let mut termios: termios = unsafe { zeroed() };
     // SAFETY: see above
-    let ret = unsafe { tcgetattr(fd, &mut termios as *mut _) };
+    let ret = unsafe { tcgetattr(fd, &raw mut termios) };
     if ret < 0 {
         return vmm_sys_util::errno::errno_result();
     }
@@ -98,7 +98,7 @@ fn modify_mode<F: FnOnce(&mut termios)>(
     f(&mut termios);
     // SAFETY: Safe because the syscall will only read the extent of termios and we check
     // the return result.
-    let ret = unsafe { tcsetattr(fd, TCSANOW, &termios as *const _) };
+    let ret = unsafe { tcsetattr(fd, TCSANOW, &raw const termios) };
     if ret < 0 {
         return vmm_sys_util::errno::errno_result();
     }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -303,7 +303,7 @@ fn core_scheduling_cookie() -> u64 {
             PR_SCHED_CORE_GET,
             0,
             PR_SCHED_CORE_SCOPE_THREAD,
-            &mut cookie as *mut u64,
+            &raw mut cookie,
         )
     };
     if ret == -1 {
@@ -1187,12 +1187,13 @@ impl CpuManager {
                 .spawn(move || {
                     // Schedule the thread to run on the expected CPU set
                     if let Some(cpuset) = cpuset.as_ref() {
+                        let cpuset: *const libc::cpu_set_t = cpuset;
                         // SAFETY: FFI call with correct arguments
                         let ret = unsafe {
                             libc::sched_setaffinity(
                                 0,
                                 std::mem::size_of::<libc::cpu_set_t>(),
-                                cpuset as *const libc::cpu_set_t,
+                                cpuset,
                             )
                         };
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4902,7 +4902,7 @@ impl DeviceManager {
                         .remove_userspace_mapping(
                             mapping.addr.raw_value(),
                             mapping.mapping.size(),
-                            mapping.mapping.as_ptr() as _,
+                            mapping.mapping.as_ptr().cast(),
                             mapping.mergeable,
                             mapping.mem_slot,
                         )

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1188,7 +1188,7 @@ impl MemoryManager {
             let n = unsafe {
                 libc::read(
                     uffd_raw_fd,
-                    &mut msg as *mut uffd::UffdMsg as *mut libc::c_void,
+                    (&raw mut msg).cast(),
                     std::mem::size_of::<uffd::UffdMsg>(),
                 )
             };
@@ -1824,7 +1824,7 @@ impl MemoryManager {
         let res = unsafe {
             libc::syscall(
                 libc::SYS_mbind,
-                addr as *mut libc::c_void,
+                addr.cast::<libc::c_void>(),
                 len,
                 mode,
                 nodemask.as_ptr(),
@@ -2002,7 +2002,7 @@ impl MemoryManager {
                         // SAFETY: FFI call with correct arguments
                         let ret = unsafe {
                             let addr = r.as_ptr().add(offset);
-                            libc::madvise(addr as _, pages * page_size, libc::MADV_POPULATE_WRITE)
+                            libc::madvise(addr.cast(), pages * page_size, libc::MADV_POPULATE_WRITE)
                         };
                         if ret != 0 {
                             let e = io::Error::last_os_error();
@@ -2021,7 +2021,7 @@ impl MemoryManager {
 
         if thp && !hugepages {
             // SAFETY: FFI call with correct arguments
-            let ret = unsafe { libc::madvise(region.as_ptr() as _, size, libc::MADV_HUGEPAGE) };
+            let ret = unsafe { libc::madvise(region.as_ptr().cast(), size, libc::MADV_HUGEPAGE) };
             if ret != 0 {
                 let e = io::Error::last_os_error();
                 warn!("Failed to mark pages as THP eligible: {e}");
@@ -2319,7 +2319,7 @@ impl MemoryManager {
         // mmap succeeded.
         let ret = unsafe {
             libc::madvise(
-                userspace_addr as *mut libc::c_void,
+                userspace_addr.cast(),
                 memory_size as libc::size_t,
                 libc::MADV_DONTDUMP,
             )
@@ -2335,7 +2335,7 @@ impl MemoryManager {
             // mmap succeeded.
             let ret = unsafe {
                 libc::madvise(
-                    userspace_addr as *mut libc::c_void,
+                    userspace_addr.cast(),
                     memory_size as libc::size_t,
                     libc::MADV_MERGEABLE,
                 )
@@ -2400,7 +2400,7 @@ impl MemoryManager {
             // previously advised.
             let ret = unsafe {
                 libc::madvise(
-                    userspace_addr as *mut libc::c_void,
+                    userspace_addr.cast(),
                     memory_size as libc::size_t,
                     libc::MADV_UNMERGEABLE,
                 )

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -4069,7 +4069,7 @@ pub fn test_vm() {
                 index as u32,
                 region.start_addr().raw_value(),
                 region.len().try_into().unwrap(),
-                region.as_ptr() as _,
+                region.as_ptr().cast(),
                 false,
                 false,
             )


### PR DESCRIPTION
With `cast()`, the compiler prevents mutability changes when casting pointers. This prevents accidental mutability changes and with that undefined behavior, especially in refactors.

`&raw [const, mut]` are only strictly necessary if there may not be an intermediate reference (due to a struct being unaligned or uninitialized for example), but make the code more robust for refactors.

Most of the changes are to make the code more robust, the changes in `vmm/src/igvm/igvm_loader.rs` fix UB.