### PR TITLE
KVM SEV-SNP kernel hashes and ID block support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +529,15 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "darling"
@@ -597,6 +621,17 @@ dependencies = [
  "serde",
  "serde_json",
  "thousands",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
 ]
 
 [[package]]
@@ -991,6 +1026,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hypervisor"
@@ -2011,6 +2055,17 @@ name = "serial_buffer"
 version = "0.1.0"
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,6 +2298,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uds_windows"
@@ -2556,6 +2617,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_buffer",
+ "sha2",
  "signal-hook",
  "thiserror",
  "tracer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,6 +2619,7 @@ dependencies = [
  "serial_buffer",
  "sha2",
  "signal-hook",
+ "tempfile",
  "thiserror",
  "tracer",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ flume = "0.12.0"
 itertools = "0.14.0"
 libc = "0.2.186"
 log = "0.4.29"
+sha2 = "0.11.0"
 signal-hook = "0.4.4"
 thiserror = "2.0.18"
 uuid = { version = "1.23.1" }

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -441,12 +441,17 @@ impl FwCfg {
         initramfs: Option<File>,
         cmdline: Option<std::ffi::CString>,
         fw_cfg_item_list: Option<Vec<FwCfgItem>>,
+        #[cfg(target_arch = "x86_64")] kvm_sev_snp_enabled: bool,
     ) -> Result<()> {
         if let Some(mem_size) = mem_size {
             self.add_e820(mem_size)?;
         }
         if let Some(kernel) = kernel {
-            self.add_kernel_data(&kernel)?;
+            self.add_kernel_data(
+                &kernel,
+                #[cfg(target_arch = "x86_64")]
+                kvm_sev_snp_enabled,
+            )?;
         }
         if let Some(cmdline) = cmdline {
             self.add_kernel_cmdline(cmdline);
@@ -631,24 +636,37 @@ impl FwCfg {
         }
     }
 
-    pub fn add_kernel_data(&mut self, file: &File) -> Result<()> {
+    pub fn add_kernel_data(
+        &mut self,
+        file: &File,
+        #[cfg(target_arch = "x86_64")] kvm_sev_snp_enabled: bool,
+    ) -> Result<()> {
         let mut buffer = vec![0u8; size_of::<boot_params>()];
         file.read_exact_at(&mut buffer, 0)?;
         let bp = boot_params::from_mut_slice(&mut buffer).unwrap();
         #[cfg(target_arch = "x86_64")]
         {
-            // must set to 4 for backwards compatibility
-            // https://docs.kernel.org/arch/x86/boot.html#the-real-mode-kernel-header
-            if bp.hdr.setup_sects == 0 {
-                bp.hdr.setup_sects = 4;
+            // For SEV-SNP guests on KVM, don't modify the kernel header so the
+            // bytes sent via fw_cfg match what the VMM hashes for the launch digest.
+            // The guest firmware handles these fields itself.
+            if !kvm_sev_snp_enabled {
+                if bp.hdr.setup_sects == 0 {
+                    bp.hdr.setup_sects = 4;
+                }
+                bp.hdr.type_of_loader = 0xff;
             }
-            // wildcard boot loader type
-            bp.hdr.type_of_loader = 0xff;
         }
         #[cfg(target_arch = "aarch64")]
         let kernel_start = bp.text_offset;
         #[cfg(target_arch = "x86_64")]
-        let kernel_start = (bp.hdr.setup_sects as usize + 1) * 512;
+        let kernel_start = {
+            let sects = if bp.hdr.setup_sects == 0 {
+                4
+            } else {
+                bp.hdr.setup_sects
+            };
+            (sects as usize + 1) * 512
+        };
 
         #[cfg(target_arch = "x86_64")]
         if kernel_start <= buffer.len() {

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -563,6 +563,8 @@ pub struct KvmVm {
     msrs: Vec<MsrEntry>,
     #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
     sev_fd: Option<x86_64::sev::SevFd>,
+    #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
+    snp_guest_policy: std::sync::OnceLock<u64>,
     dirty_log_slots: RwLock<HashMap<u32, KvmDirtyLogSlot>>,
     guest_memfds: Option<RwLock<HashMap<u32, OwnedFd>>>,
 }
@@ -689,7 +691,11 @@ impl vm::Vm for KvmVm {
             .as_ref()
             .unwrap()
             .launch_start(&self.fd, guest_policy)
-            .map_err(|e| vm::HypervisorVmError::InitializeSevSnp(e.into()))
+            .map_err(|e| vm::HypervisorVmError::InitializeSevSnp(e.into()))?;
+        self.snp_guest_policy
+            .set(guest_policy.into_bits())
+            .expect("sev_snp_init called more than once");
+        Ok(())
     }
 
     #[cfg(all(feature = "sev_snp", target_arch = "x86_64"))]
@@ -736,15 +742,22 @@ impl vm::Vm for KvmVm {
         snp_id_block: igvm_defs::IGVM_VHS_SNP_ID_BLOCK,
         host_data: [u8; 32],
         id_block_enabled: u8,
+        auth_key_enabled: u8,
     ) -> vm::Result<()> {
+        let guest_policy = *self
+            .snp_guest_policy
+            .get()
+            .expect("complete_isolated_import called before sev_snp_init");
         self.sev_fd
             .as_ref()
             .unwrap()
             .launch_finish(
                 &self.fd,
+                &snp_id_block,
                 host_data,
                 id_block_enabled,
-                snp_id_block.author_key_enabled,
+                auth_key_enabled,
+                guest_policy,
             )
             .map_err(|e| vm::HypervisorVmError::CompleteIsolatedImport(e.into()))
     }
@@ -1606,6 +1619,8 @@ impl hypervisor::Hypervisor for KvmHypervisor {
                 dirty_log_slots: RwLock::new(HashMap::new()),
                 #[cfg(feature = "sev_snp")]
                 sev_fd,
+                #[cfg(feature = "sev_snp")]
+                snp_guest_policy: std::sync::OnceLock::new(),
                 guest_memfds,
             }))
         }

--- a/hypervisor/src/kvm/x86_64/sev.rs
+++ b/hypervisor/src/kvm/x86_64/sev.rs
@@ -8,11 +8,12 @@ use std::os::fd::{AsRawFd, OwnedFd};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 
-use igvm_defs::SnpPolicy;
+use igvm_defs::{IGVM_VHS_SNP_ID_BLOCK, SnpPolicy};
 use kvm_bindings::kvm_sev_cmd;
 use kvm_ioctls::VmFd;
 use log::{debug, error, info};
 use vmm_sys_util::errno;
+use zerocopy::{FromZeros, Immutable, IntoBytes};
 
 pub(crate) type Result<T> = std::result::Result<T, errno::Error>;
 
@@ -96,6 +97,88 @@ pub(crate) struct KvmSevSnpLaunchFinish {
     pub pad1: [u64; 4],
 }
 
+// See AMD Spec Section 8.18 — Structure of the ID Block
+// https://docs.amd.com/v/u/en-US/56860_PUB_1.58_SEV_SNP
+#[repr(C)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable)]
+pub(crate) struct KvmSevSnpIdBlock {
+    pub ld: [u8; 48],
+    pub family_id: [u8; 16],
+    pub image_id: [u8; 16],
+    pub version: u32,
+    pub guest_svn: u32,
+    pub policy: u64,
+}
+
+// See AMD Spec Section 8.18 — Layout of the ID Authentication Information Structure
+// https://docs.amd.com/v/u/en-US/56860_PUB_1.58_SEV_SNP
+#[repr(C)]
+#[derive(Clone, FromZeros, IntoBytes, Immutable)]
+pub(crate) struct KvmSevSnpIdAuth {
+    pub id_key_alg: u32,
+    pub auth_key_algo: u32,
+    pub reserved: [u8; 56],
+    pub id_block_sig: [u8; 512],
+    pub id_key: [u8; 1028],
+    pub reserved2: [u8; 60],
+    pub id_key_sig: [u8; 512],
+    pub author_key: [u8; 1028],
+    pub reserved3: [u8; 892],
+}
+
+// Must be 1
+// AMD SEV-SNP Firmware ABI, Section 8.18 — Structure of the ID Block
+// https://docs.amd.com/v/u/en-US/56860_PUB_1.58_SEV_SNP
+const IGVM_SEV_ID_BLOCK_VERSION: u32 = 1;
+
+fn build_id_block(snp_id_block: &IGVM_VHS_SNP_ID_BLOCK, guest_policy: u64) -> KvmSevSnpIdBlock {
+    KvmSevSnpIdBlock {
+        ld: snp_id_block.ld,
+        family_id: snp_id_block.family_id,
+        image_id: snp_id_block.image_id,
+        version: IGVM_SEV_ID_BLOCK_VERSION,
+        guest_svn: snp_id_block.guest_svn,
+        policy: guest_policy,
+    }
+}
+
+// SEV-SNP Firmware ABI Spec Chapter 10: Format for an ECDSA P-384 Public Key
+// https://docs.amd.com/v/u/en-US/56860_PUB_1.58_SEV_SNP
+fn serialize_public_key(curve: u32, qx: &[u8; 72], qy: &[u8; 72]) -> [u8; 1028] {
+    let mut key = [0u8; 0x404];
+    key[..0x004].copy_from_slice(&curve.to_le_bytes());
+    key[0x004..0x04C].copy_from_slice(qx);
+    key[0x04C..0x094].copy_from_slice(qy);
+    key
+}
+
+fn build_id_auth(snp_id_block: &IGVM_VHS_SNP_ID_BLOCK) -> KvmSevSnpIdAuth {
+    let mut id_auth = KvmSevSnpIdAuth::new_zeroed();
+
+    id_auth.id_key_alg = snp_id_block.id_key_algorithm;
+    id_auth.auth_key_algo = snp_id_block.author_key_algorithm;
+
+    let sig = snp_id_block.id_key_signature.as_bytes();
+    id_auth.id_block_sig[..sig.len()].copy_from_slice(sig);
+
+    id_auth.id_key = serialize_public_key(
+        snp_id_block.id_public_key.curve,
+        &snp_id_block.id_public_key.qx,
+        &snp_id_block.id_public_key.qy,
+    );
+
+    let sig = snp_id_block.author_key_signature.as_bytes();
+    id_auth.id_key_sig[..sig.len()].copy_from_slice(sig);
+
+    id_auth.author_key = serialize_public_key(
+        snp_id_block.author_public_key.curve,
+        &snp_id_block.author_public_key.qx,
+        &snp_id_block.author_public_key.qy,
+    );
+
+    id_auth
+}
+
 impl SevFd {
     pub(crate) fn new(sev_path: impl AsRef<Path>) -> Result<Self> {
         let file = OpenOptions::new()
@@ -132,9 +215,6 @@ impl SevFd {
     }
 
     pub(crate) fn launch_start(&self, vm: &VmFd, guest_policy: SnpPolicy) -> Result<()> {
-        // See AMD Spec Section 4.3 - Guest Policy
-        // Bit 17 is reserved and has to be one.
-        // https://docs.amd.com/v/u/en-US/56860_PUB_1.58_SEV_SNP
         let mut start: KvmSevSnpLaunchStart = KvmSevSnpLaunchStart {
             policy: guest_policy.into_bits(),
             ..Default::default()
@@ -177,14 +257,21 @@ impl SevFd {
     pub(crate) fn launch_finish(
         &self,
         vm: &VmFd,
+        snp_id_block: &IGVM_VHS_SNP_ID_BLOCK,
         host_data: [u8; 32],
         id_block_en: u8,
         auth_key_en: u8,
+        guest_policy: u64,
     ) -> Result<()> {
+        let id_block = build_id_block(snp_id_block, guest_policy);
+        let id_auth = build_id_auth(snp_id_block);
+
         let mut finish = KvmSevSnpLaunchFinish {
-            host_data,
+            id_block_uaddr: id_block.as_bytes().as_ptr() as u64,
+            id_auth_uaddr: id_auth.as_bytes().as_ptr() as u64,
             id_block_en,
             auth_key_en,
+            host_data,
             ..Default::default()
         };
         let mut sev_cmd = kvm_sev_cmd {
@@ -194,7 +281,108 @@ impl SevFd {
             ..Default::default()
         };
         let flags = finish.flags;
-        debug!("Calling KVM_SEV_SNP_LAUNCH_FINISH, flags: {flags}");
+        debug!(
+            "KVM_SEV_SNP_LAUNCH_FINISH: id_block_en={id_block_en}, auth_key_en={auth_key_en}, policy={guest_policy:#x}, flags={flags}"
+        );
         sev_op(vm, &mut sev_cmd, "KVM_SEV_SNP_LAUNCH_FINISH")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::mem::size_of;
+
+    use super::*;
+
+    fn make_test_igvm_id_block() -> IGVM_VHS_SNP_ID_BLOCK {
+        let mut block = IGVM_VHS_SNP_ID_BLOCK::new_zeroed();
+        block.ld[0] = 0xAA;
+        block.ld[47] = 0xBB;
+        block.family_id[0] = 0x01;
+        block.image_id[0] = 0x02;
+        block.version = 42;
+        block.guest_svn = 7;
+        block.id_key_algorithm = 1;
+        block.author_key_algorithm = 1;
+        block.id_key_signature.r_comp[0] = 0x10;
+        block.id_key_signature.s_comp[0] = 0x20;
+        block.id_public_key.curve = 2;
+        block.id_public_key.qx[0] = 0x30;
+        block.id_public_key.qy[0] = 0x40;
+        block.author_key_signature.r_comp[0] = 0x50;
+        block.author_key_signature.s_comp[0] = 0x60;
+        block.author_public_key.curve = 2;
+        block.author_public_key.qx[0] = 0x70;
+        block.author_public_key.qy[0] = 0x80;
+        block
+    }
+
+    #[test]
+    fn id_block_struct_sizes() {
+        assert_eq!(size_of::<KvmSevSnpIdBlock>(), 96);
+        assert_eq!(size_of::<KvmSevSnpIdAuth>(), 4096);
+    }
+
+    #[test]
+    fn build_id_block_maps_fields_correctly() {
+        let igvm = make_test_igvm_id_block();
+        let policy = 0x30000u64;
+        let id_block = build_id_block(&igvm, policy);
+
+        assert_eq!(id_block.ld, igvm.ld);
+        assert_eq!(id_block.family_id, igvm.family_id);
+        assert_eq!(id_block.image_id, igvm.image_id);
+        assert_eq!(id_block.version, IGVM_SEV_ID_BLOCK_VERSION);
+        assert_eq!(id_block.guest_svn, igvm.guest_svn);
+        assert_eq!(id_block.policy, policy);
+    }
+
+    #[test]
+    fn build_id_block_policy_at_offset_88() {
+        let igvm = IGVM_VHS_SNP_ID_BLOCK::new_zeroed();
+        let policy = 0xDEAD_BEEF_CAFE_BABEu64;
+        let id_block = build_id_block(&igvm, policy);
+        let bytes = id_block.as_bytes();
+        assert_eq!(&bytes[88..96], &policy.to_le_bytes());
+    }
+
+    #[test]
+    fn build_id_auth_maps_signatures_correctly() {
+        let igvm = make_test_igvm_id_block();
+        let id_auth = build_id_auth(&igvm);
+
+        assert_eq!(id_auth.id_key_alg, igvm.id_key_algorithm);
+        assert_eq!(id_auth.auth_key_algo, igvm.author_key_algorithm);
+
+        assert_eq!(id_auth.id_block_sig[0], 0x10);
+        assert_eq!(id_auth.id_block_sig[72], 0x20);
+        assert!(id_auth.id_block_sig[144..].iter().all(|&b| b == 0));
+
+        assert_eq!(id_auth.id_key_sig[0], 0x50);
+        assert_eq!(id_auth.id_key_sig[72], 0x60);
+        assert!(id_auth.id_key_sig[144..].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn build_id_auth_serializes_public_keys() {
+        let igvm = make_test_igvm_id_block();
+        let id_auth = build_id_auth(&igvm);
+
+        assert_eq!(&id_auth.id_key[..4], &2u32.to_le_bytes());
+        assert_eq!(id_auth.id_key[4], 0x30);
+        assert_eq!(id_auth.id_key[76], 0x40);
+        assert!(id_auth.id_key[148..].iter().all(|&b| b == 0));
+
+        assert_eq!(&id_auth.author_key[..4], &2u32.to_le_bytes());
+        assert_eq!(id_auth.author_key[4], 0x70);
+        assert_eq!(id_auth.author_key[76], 0x80);
+        assert!(id_auth.author_key[148..].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn build_id_auth_zeroed_input() {
+        let igvm = IGVM_VHS_SNP_ID_BLOCK::new_zeroed();
+        let id_auth = build_id_auth(&igvm);
+        assert!(id_auth.as_bytes().iter().all(|&b| b == 0));
     }
 }

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -2318,6 +2318,7 @@ impl vm::Vm for MshvVm {
         snp_id_block: IGVM_VHS_SNP_ID_BLOCK,
         host_data: [u8; 32],
         id_block_enabled: u8,
+        auth_key_enabled: u8,
     ) -> vm::Result<()> {
         let mut auth_info = hv_snp_id_auth_info {
             id_key_algorithm: snp_id_block.id_key_algorithm,
@@ -2351,7 +2352,7 @@ impl vm::Vm for MshvVm {
                     id_auth_info: auth_info,
                     host_data,
                     id_block_enabled,
-                    author_key_enabled: 0,
+                    author_key_enabled: auth_key_enabled,
                 },
             },
         };

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -440,6 +440,7 @@ pub trait Vm: Send + Sync + Any {
         _snp_id_block: IGVM_VHS_SNP_ID_BLOCK,
         _host_data: [u8; 32],
         _id_block_enabled: u8,
+        _auth_key_enabled: u8,
     ) -> Result<()> {
         unimplemented!()
     }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -81,6 +81,7 @@ seccompiler = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 serial_buffer = { path = "../serial_buffer" }
+sha2 = { workspace = true }
 signal-hook = { workspace = true }
 thiserror = { workspace = true }
 tracer = { path = "../tracer" }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -104,5 +104,8 @@ vmm-sys-util = { workspace = true, features = ["with-serde"] }
 zbus = { version = "5.14.0", optional = true }
 zerocopy = { workspace = true, features = ["alloc", "derive"] }
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -697,6 +697,11 @@ pub fn load_igvm(
                 let area = parameter_areas
                     .get_mut(parameter_area_index)
                     .expect("igvmfile should be valid");
+                #[cfg(feature = "kvm")]
+                let page_count = match area {
+                    ParameterAreaState::Allocated { max_size, .. } => *max_size / HV_PAGE_SIZE,
+                    ParameterAreaState::Inserted => panic!("igvmfile is invalid, multiple insert"),
+                };
                 match area {
                     ParameterAreaState::Allocated { data, max_size } => {
                         #[cfg(all(
@@ -732,11 +737,25 @@ pub fn load_igvm(
                     ParameterAreaState::Inserted => panic!("igvmfile is invalid, multiple insert"),
                 }
                 *area = ParameterAreaState::Inserted;
-                gpas.push(GpaPages {
-                    gpa: *gpa,
-                    page_type: page_types.unmeasured,
-                    page_size: page_types.isolated_page_size_4kb,
-                });
+                match hypervisor_type {
+                    #[cfg(feature = "kvm")]
+                    HypervisorType::Kvm => {
+                        for page_index in 0..page_count {
+                            gpas.push(GpaPages {
+                                gpa: *gpa + page_index * HV_PAGE_SIZE,
+                                page_type: page_types.unmeasured,
+                                page_size: page_types.isolated_page_size_4kb,
+                            });
+                        }
+                    }
+                    _ => {
+                        gpas.push(GpaPages {
+                            gpa: *gpa,
+                            page_type: page_types.unmeasured,
+                            page_size: page_types.isolated_page_size_4kb,
+                        });
+                    }
+                }
             }
             IgvmDirectiveHeader::ErrorRange { .. } => {
                 todo!("Error Range not supported")
@@ -786,14 +805,24 @@ pub fn load_igvm(
 
         let mut now = Instant::now();
 
-        // Sort the gpas to group them by the page type
-        gpas.sort_by_key(|a| a.gpa);
+        // KVM: preserve original IGVM ordering — the SNP launch digest is order-sensitive.
+        // MSHV: sort by GPA to group pages by type for fewer hypercalls.
+        match hypervisor_type {
+            #[cfg(feature = "kvm")]
+            HypervisorType::Kvm => {}
+            _ => gpas.sort_by_key(|a| a.gpa),
+        }
 
         let gpas_grouped = gpas
             .iter()
             .fold(Vec::<Vec<GpaPages>>::new(), |mut acc, gpa| {
                 if let Some(last_vec) = acc.last_mut()
                     && last_vec[0].page_type == gpa.page_type
+                    && match hypervisor_type {
+                        #[cfg(feature = "kvm")]
+                        HypervisorType::Kvm => last_vec[0].page_size == gpa.page_size,
+                        _ => true,
+                    }
                 {
                     last_vec.push(*gpa);
                     return acc;
@@ -802,8 +831,7 @@ pub fn load_igvm(
                 acc
             });
 
-        // Import the pages as a group(by page type) of PFNs to reduce the
-        // hypercall.
+        // Import pages as groups of PFNs to reduce hypercalls.
         for group in gpas_grouped.iter() {
             info!(
                 "Importing {} page{}",

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -134,6 +134,8 @@ const KVM_SNP_PAGE_TYPE_NORMAL: u32 = 1;
 #[cfg(feature = "kvm")]
 const KVM_SNP_PAGE_TYPE_VMSA: u32 = 2;
 #[cfg(feature = "kvm")]
+const KVM_SNP_PAGE_TYPE_ZERO: u32 = 3;
+#[cfg(feature = "kvm")]
 const KVM_SNP_PAGE_TYPE_UNMEASURED: u32 = 4;
 #[cfg(feature = "kvm")]
 const KVM_SNP_PAGE_TYPE_SECRETS: u32 = 5;
@@ -144,6 +146,8 @@ const KVM_SNP_PAGE_TYPE_CPUID: u32 = 6;
 struct PageTypeConfig {
     isolated_page_size_4kb: u32,
     normal: u32,
+    #[allow(dead_code)]
+    zero: u32,
     unmeasured: u32,
     cpuid: u32,
     secrets: u32,
@@ -270,6 +274,7 @@ pub fn load_igvm(
         HypervisorType::Mshv => PageTypeConfig {
             isolated_page_size_4kb: mshv_bindings::hv_isolated_page_size_HV_ISOLATED_PAGE_SIZE_4KB,
             normal: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_NORMAL,
+            zero: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_ZERO,
             unmeasured: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_UNMEASURED,
             cpuid: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_CPUID,
             secrets: mshv_bindings::hv_isolated_page_type_HV_ISOLATED_PAGE_TYPE_SECRETS,
@@ -279,6 +284,7 @@ pub fn load_igvm(
         HypervisorType::Kvm => PageTypeConfig {
             isolated_page_size_4kb: HV_PAGE_SIZE as u32,
             normal: KVM_SNP_PAGE_TYPE_NORMAL,
+            zero: KVM_SNP_PAGE_TYPE_ZERO,
             unmeasured: KVM_SNP_PAGE_TYPE_UNMEASURED,
             cpuid: KVM_SNP_PAGE_TYPE_CPUID,
             secrets: KVM_SNP_PAGE_TYPE_SECRETS,
@@ -378,9 +384,14 @@ pub fn load_igvm(
                             });
                             BootPageAcceptance::ExclusiveUnmeasured
                         } else {
+                            let page_type = match hypervisor_type {
+                                #[cfg(feature = "kvm")]
+                                HypervisorType::Kvm if data.is_empty() => page_types.zero,
+                                _ => page_types.normal,
+                            };
                             gpas.push(GpaPages {
                                 gpa: *gpa,
-                                page_type: page_types.normal,
+                                page_type,
                                 page_size: page_types.isolated_page_size_4kb,
                             });
                             BootPageAcceptance::Exclusive
@@ -521,6 +532,10 @@ pub fn load_igvm(
                         .map_err(Error::Loader)?;
                     measured_boot_hash_block_inserted = true;
                     imported_page = true;
+                    if let Some(last) = gpas.last_mut() {
+                        debug_assert_eq!(last.gpa, *gpa);
+                        last.page_type = page_types.normal;
+                    }
                 }
                 if !imported_page {
                     loader

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -39,6 +39,13 @@ use crate::cpu::CpuManager;
 use crate::igvm::loader::Loader;
 use crate::igvm::{BootPageAcceptance, HV_PAGE_SIZE, IgvmLoadedInfo, StartupMemoryType};
 use crate::memory_manager::{Error as MemoryManagerError, MemoryManager};
+#[cfg(all(
+    feature = "kvm",
+    feature = "sev_snp",
+    feature = "fw_cfg",
+    target_arch = "x86_64"
+))]
+use crate::sev::{MeasuredBootInfo, SEV_HASH_BLOCK_ADDRESS, SEV_HASH_BLOCK_SIZE};
 
 #[cfg(feature = "sev_snp")]
 const ISOLATED_PAGE_SHIFT: u32 = 12;
@@ -96,6 +103,29 @@ pub enum Error {
     MissingIgvm,
     #[error("Error applying VMSA to vCPU registers: {0}")]
     SetVmsa(#[source] crate::cpu::Error),
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
+    #[error("Error building SEV-SNP measured boot hash block")]
+    MeasuredBoot(#[source] vmm_sys_util::errno::Error),
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
+    #[error(
+        "igvmfile inserts unmeasured parameter area [0x{region_start:x}, 0x{region_end:x}) over SEV-SNP kernel hashes region [0x{hash_start:x}, 0x{hash_end:x})"
+    )]
+    MeasuredBootHashOverlap {
+        region_start: u64,
+        region_end: u64,
+        hash_start: u64,
+        hash_end: u64,
+    },
 }
 
 // KVM SNP page types — linux/arch/x86/include/uapi/asm/sev-guest.h
@@ -225,6 +255,13 @@ pub fn load_igvm(
     memory_manager: Arc<Mutex<MemoryManager>>,
     cpu_manager: Arc<Mutex<CpuManager>>,
     cmdline: &str,
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
+    measured_boot: Option<MeasuredBootInfo>,
     #[cfg(feature = "sev_snp")] host_data: &Option<String>,
 ) -> Result<Box<IgvmLoadedInfo>, Error> {
     let hypervisor_type = cpu_manager.lock().unwrap().hypervisor_type();
@@ -275,6 +312,45 @@ pub fn load_igvm(
     let mut loader = Loader::new(memory);
 
     let mut parameter_areas: HashMap<u32, ParameterAreaState> = HashMap::new();
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
+    let measured_boot_hash_block = if hypervisor_type == HypervisorType::Kvm {
+        measured_boot
+            .as_ref()
+            .map(|measured_boot| {
+                measured_boot
+                    .build_hash_block()
+                    .map_err(Error::MeasuredBoot)
+            })
+            .transpose()?
+    } else {
+        None
+    };
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
+    let measured_boot_hash_page_base = SEV_HASH_BLOCK_ADDRESS / HV_PAGE_SIZE;
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
+    let measured_boot_hash_offset = (SEV_HASH_BLOCK_ADDRESS % HV_PAGE_SIZE) as usize;
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
+    let mut measured_boot_hash_block_inserted = measured_boot_hash_block.is_none();
 
     for header in igvm_file.directives() {
         debug_assert!(header.compatibility_mask().unwrap_or(mask) & mask == mask);
@@ -416,6 +492,34 @@ pub fn load_igvm(
                     loader
                         .import_pages(gpa / HV_PAGE_SIZE, 1, acceptance, new_cp.as_mut_bytes())
                         .map_err(Error::Loader)?;
+                    imported_page = true;
+                }
+                #[cfg(all(
+                    feature = "kvm",
+                    feature = "sev_snp",
+                    feature = "fw_cfg",
+                    target_arch = "x86_64"
+                ))]
+                if let Some(hash_block) = measured_boot_hash_block.as_ref().filter(|_| {
+                    !imported_page && gpa / HV_PAGE_SIZE == measured_boot_hash_page_base
+                }) {
+                    let mut page = if data.is_empty() {
+                        vec![0; HV_PAGE_SIZE as usize]
+                    } else {
+                        let mut page = data.clone();
+                        page.resize(HV_PAGE_SIZE as usize, 0);
+                        page
+                    };
+                    // If a data page from the bootloader contains this range,
+                    // we need to ensure that the measured boot table is injected
+                    // prior to importing the pages
+                    page[measured_boot_hash_offset
+                        ..measured_boot_hash_offset + SEV_HASH_BLOCK_SIZE]
+                        .copy_from_slice(&hash_block[..SEV_HASH_BLOCK_SIZE]);
+                    loader
+                        .import_pages(gpa / HV_PAGE_SIZE, 1, acceptance, &page)
+                        .map_err(Error::Loader)?;
+                    measured_boot_hash_block_inserted = true;
                     imported_page = true;
                 }
                 if !imported_page {
@@ -579,14 +683,37 @@ pub fn load_igvm(
                     .get_mut(parameter_area_index)
                     .expect("igvmfile should be valid");
                 match area {
-                    ParameterAreaState::Allocated { data, max_size } => loader
-                        .import_pages(
-                            gpa / HV_PAGE_SIZE,
-                            *max_size / HV_PAGE_SIZE,
-                            BootPageAcceptance::ExclusiveUnmeasured,
-                            data,
-                        )
-                        .map_err(Error::Loader)?,
+                    ParameterAreaState::Allocated { data, max_size } => {
+                        #[cfg(all(
+                            feature = "kvm",
+                            feature = "sev_snp",
+                            feature = "fw_cfg",
+                            target_arch = "x86_64"
+                        ))]
+                        if measured_boot_hash_block.is_some() {
+                            let region_end = *gpa + *max_size;
+                            let hash_end = SEV_HASH_BLOCK_ADDRESS + SEV_HASH_BLOCK_SIZE as u64;
+                            if *gpa <= SEV_HASH_BLOCK_ADDRESS && hash_end <= region_end {
+                                // In the case of parameter being inserted where the kernel hashes table lies,
+                                // we should reject the igvmfile since it would interfere with the launch digest
+                                return Err(Error::MeasuredBootHashOverlap {
+                                    region_start: *gpa,
+                                    region_end,
+                                    hash_start: SEV_HASH_BLOCK_ADDRESS,
+                                    hash_end,
+                                });
+                            }
+                        }
+
+                        loader
+                            .import_pages(
+                                gpa / HV_PAGE_SIZE,
+                                *max_size / HV_PAGE_SIZE,
+                                BootPageAcceptance::ExclusiveUnmeasured,
+                                data,
+                            )
+                            .map_err(Error::Loader)?;
+                    }
                     ParameterAreaState::Inserted => panic!("igvmfile is invalid, multiple insert"),
                 }
                 *area = ParameterAreaState::Inserted;
@@ -603,6 +730,34 @@ pub fn load_igvm(
                 todo!("Header not supported!!")
             }
         }
+    }
+
+    #[cfg(all(
+        feature = "kvm",
+        feature = "sev_snp",
+        feature = "fw_cfg",
+        target_arch = "x86_64"
+    ))]
+    if let Some(hash_block) = measured_boot_hash_block.as_ref()
+        && !measured_boot_hash_block_inserted
+    {
+        // Fallback to adding kernel hashes after importing if the page data wasn't found previously
+        let mut page = vec![0u8; HV_PAGE_SIZE as usize];
+        page[measured_boot_hash_offset..measured_boot_hash_offset + SEV_HASH_BLOCK_SIZE]
+            .copy_from_slice(&hash_block[..SEV_HASH_BLOCK_SIZE]);
+        loader
+            .import_pages(
+                measured_boot_hash_page_base,
+                1,
+                BootPageAcceptance::Exclusive,
+                &page,
+            )
+            .map_err(Error::Loader)?;
+        gpas.push(GpaPages {
+            gpa: measured_boot_hash_page_base * HV_PAGE_SIZE,
+            page_type: page_types.normal,
+            page_size: page_types.isolated_page_size_4kb,
+        });
     }
 
     #[cfg(feature = "sev_snp")]

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -87,6 +87,8 @@ pub enum Error {
     Igvm(#[source] std::io::Error),
     #[error("invalid igvm file")]
     InvalidIgvmFile(#[source] igvm::Error),
+    #[error("multiple SNP ID blocks in IGVM file")]
+    DuplicateSnpIdBlock,
     #[error("invalid guest memory map")]
     InvalidGuestMemmap(#[source] arch::Error),
     #[error("loader error")]
@@ -678,6 +680,9 @@ pub fn load_igvm(
                 author_key_signature,
                 author_public_key,
             } => {
+                if loaded_info.has_snp_id_block {
+                    return Err(Error::DuplicateSnpIdBlock);
+                }
                 loaded_info.snp_id_block.compatibility_mask = *compatibility_mask;
                 loaded_info.snp_id_block.author_key_enabled = *author_key_enabled;
                 loaded_info.snp_id_block.reserved = *reserved;
@@ -692,6 +697,7 @@ pub fn load_igvm(
                 loaded_info.snp_id_block.id_public_key = **id_public_key;
                 loaded_info.snp_id_block.author_key_signature = **author_key_signature;
                 loaded_info.snp_id_block.author_public_key = **author_public_key;
+                loaded_info.has_snp_id_block = true;
             }
             IgvmDirectiveHeader::X64VbsVpContext {
                 vtl: _,
@@ -929,7 +935,12 @@ pub fn load_igvm(
         let id_block_enabled = if hypervisor_type == HypervisorType::Mshv {
             1
         } else {
+            u8::from(loaded_info.has_snp_id_block)
+        };
+        let auth_key_enabled = if hypervisor_type == HypervisorType::Mshv {
             0
+        } else {
+            loaded_info.snp_id_block.author_key_enabled
         };
 
         now = Instant::now();
@@ -942,6 +953,7 @@ pub fn load_igvm(
                 loaded_info.snp_id_block,
                 host_data_contents,
                 id_block_enabled,
+                auth_key_enabled,
             )
             .map_err(Error::CompleteIsolatedImport)?;
 

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -8,6 +8,8 @@ use std::mem::size_of;
 use std::sync::{Arc, Mutex};
 
 use hypervisor::HypervisorType;
+#[cfg(feature = "sev_snp")]
+use igvm::IgvmInitializationHeader;
 use igvm::snp_defs::SevVmsa;
 use igvm::{IgvmDirectiveHeader, IgvmFile, IgvmPlatformHeader};
 #[cfg(feature = "sev_snp")]
@@ -227,6 +229,20 @@ fn import_parameter(
 
     parameter_area[offset..end_of_parameter].copy_from_slice(parameter);
     Ok(())
+}
+
+///
+/// Extract guest policy from the IGVM initialization headers.
+#[cfg(feature = "sev_snp")]
+pub fn extract_guest_policy(igvm_file: &IgvmFile) -> Option<igvm_defs::SnpPolicy> {
+    for header in igvm_file.initializations() {
+        if let IgvmInitializationHeader::GuestPolicy { policy, .. } = header
+            && *policy != 0
+        {
+            return Some(igvm_defs::SnpPolicy::from_bits(*policy));
+        }
+    }
+    None
 }
 
 ///

--- a/vmm/src/igvm/mod.rs
+++ b/vmm/src/igvm/mod.rs
@@ -45,6 +45,7 @@ pub struct IgvmLoadedInfo {
     pub gpas: Vec<u64>,
     pub vmsa_gpa: u64,
     pub snp_id_block: IGVM_VHS_SNP_ID_BLOCK,
+    pub has_snp_id_block: bool,
     pub vmsa: SevVmsa,
 }
 
@@ -54,6 +55,7 @@ impl Default for IgvmLoadedInfo {
             gpas: Vec::new(),
             vmsa_gpa: 0,
             snp_id_block: IGVM_VHS_SNP_ID_BLOCK::new_zeroed(),
+            has_snp_id_block: false,
             vmsa: SevVmsa::new_zeroed(),
         }
     }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -91,6 +91,13 @@ pub mod migration_transport;
 mod pci_segment;
 pub mod seccomp_filters;
 mod serial_manager;
+#[cfg(all(
+    feature = "kvm",
+    feature = "sev_snp",
+    feature = "fw_cfg",
+    target_arch = "x86_64"
+))]
+pub(crate) mod sev;
 mod sigwinch_listener;
 mod sync_utils;
 mod uffd;

--- a/vmm/src/sev.rs
+++ b/vmm/src/sev.rs
@@ -179,3 +179,213 @@ impl MeasuredBootInfo {
         Ok(hash_block)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    fn make_tempfile(data: &[u8]) -> File {
+        let mut f = tempfile::tempfile().unwrap();
+        f.write_all(data).unwrap();
+        f
+    }
+
+    fn make_fake_kernel(setup_sects: u8, kernel_payload: &[u8]) -> File {
+        let effective_sects = if setup_sects == 0 { 4 } else { setup_sects };
+        let setup_len = (usize::from(effective_sects) + 1) * 512;
+        let header_size = size_of::<boot_params>();
+        let file_len = std::cmp::max(setup_len, header_size) + kernel_payload.len();
+
+        let mut buf = vec![0u8; file_len];
+        let bp = boot_params::from_mut_slice(&mut buf[..header_size]).unwrap();
+        bp.hdr.setup_sects = setup_sects;
+        buf[setup_len..setup_len + kernel_payload.len()].copy_from_slice(kernel_payload);
+
+        make_tempfile(&buf)
+    }
+
+    #[test]
+    fn hash_block_deterministic() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(1, b"KERNEL_DATA"),
+            initramfs: None,
+            cmdline: CString::new("console=ttyS0").unwrap(),
+        };
+        let block1 = info.build_hash_block().unwrap();
+        let block2 = info.build_hash_block().unwrap();
+        assert_eq!(block1, block2);
+    }
+
+    #[test]
+    fn hash_block_cmdline_includes_nul() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(1, b"K"),
+            initramfs: None,
+            cmdline: CString::new("test").unwrap(),
+        };
+        let block = info.build_hash_block().unwrap();
+        let expected: [u8; 32] = Sha256::digest(b"test\0").into();
+        let cmdline_hash_offset = 2 * (size_of::<[u8; 16]>() + size_of::<u16>());
+        assert_eq!(
+            &block[cmdline_hash_offset..cmdline_hash_offset + 32],
+            &expected
+        );
+    }
+
+    #[test]
+    fn hash_block_no_initrd_hashes_empty() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(1, b"K"),
+            initramfs: None,
+            cmdline: CString::new("").unwrap(),
+        };
+        let block = info.build_hash_block().unwrap();
+        let expected: [u8; 32] = Sha256::digest([]).into();
+
+        let initrd_hash_offset =
+            2 * (size_of::<[u8; 16]>() + size_of::<u16>()) + size_of::<SevHashTableEntry>();
+        assert_eq!(
+            &block[initrd_hash_offset..initrd_hash_offset + 32],
+            &expected
+        );
+    }
+
+    #[test]
+    fn hash_block_with_initrd() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(1, b"K"),
+            initramfs: Some(make_tempfile(b"INITRD_CONTENTS")),
+            cmdline: CString::new("").unwrap(),
+        };
+        let block = info.build_hash_block().unwrap();
+        let expected: [u8; 32] = Sha256::digest(b"INITRD_CONTENTS").into();
+        let initrd_hash_offset =
+            2 * (size_of::<[u8; 16]>() + size_of::<u16>()) + size_of::<SevHashTableEntry>();
+        assert_eq!(
+            &block[initrd_hash_offset..initrd_hash_offset + 32],
+            &expected
+        );
+    }
+
+    #[test]
+    fn hash_block_setup_sects_zero_defaults_to_four() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(0, b"PAYLOAD"),
+            initramfs: None,
+            cmdline: CString::new("root=/dev/sda").unwrap(),
+        };
+        info.build_hash_block().unwrap();
+    }
+
+    #[test]
+    fn hash_block_guid_placement() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(1, b"K"),
+            initramfs: None,
+            cmdline: CString::new("x").unwrap(),
+        };
+        let block = info.build_hash_block().unwrap();
+        assert_eq!(&block[0..16], SEV_HASH_TABLE_GUID.to_bytes_le());
+        assert_eq!(&block[18..34], SEV_CMDLINE_HASH_GUID.to_bytes_le());
+        let initrd_guid_offset =
+            size_of::<[u8; 16]>() + size_of::<u16>() + size_of::<SevHashTableEntry>();
+        assert_eq!(
+            &block[initrd_guid_offset..initrd_guid_offset + 16],
+            SEV_INITRD_HASH_GUID.to_bytes_le()
+        );
+        let kernel_guid_offset = initrd_guid_offset + size_of::<SevHashTableEntry>();
+        assert_eq!(
+            &block[kernel_guid_offset..kernel_guid_offset + 16],
+            SEV_KERNEL_HASH_GUID.to_bytes_le()
+        );
+    }
+
+    #[test]
+    fn hash_block_struct_sizes() {
+        assert_eq!(size_of::<SevHashTableEntry>(), 16 + 2 + 32);
+        assert_eq!(
+            size_of::<SevHashTable>(),
+            16 + 2 + 3 * size_of::<SevHashTableEntry>()
+        );
+        assert_eq!(size_of::<PaddedSevHashTable>() % 16, 0);
+        assert!(size_of::<PaddedSevHashTable>() <= SEV_HASH_BLOCK_SIZE);
+    }
+
+    #[test]
+    fn hash_block_remainder_is_zeroed() {
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(1, b"K"),
+            initramfs: None,
+            cmdline: CString::new("").unwrap(),
+        };
+        let block = info.build_hash_block().unwrap();
+        let table_end = size_of::<PaddedSevHashTable>();
+        assert!(block[table_end..].iter().all(|&b| b == 0));
+    }
+
+    fn expected_kernel_digest(setup_sects: u8, kernel_payload: &[u8]) -> [u8; 32] {
+        let effective_sects = if setup_sects == 0 { 4 } else { setup_sects };
+        let setup_len = (usize::from(effective_sects) + 1) * 512;
+        let header_size = size_of::<boot_params>();
+        let file_len = std::cmp::max(setup_len, header_size) + kernel_payload.len();
+
+        let mut buf = vec![0u8; file_len];
+        let bp = boot_params::from_mut_slice(&mut buf[..header_size]).unwrap();
+        bp.hdr.setup_sects = setup_sects;
+        buf[setup_len..setup_len + kernel_payload.len()].copy_from_slice(kernel_payload);
+
+        Sha256::digest(&buf).into()
+    }
+
+    fn kernel_hash_offset() -> usize {
+        size_of::<[u8; 16]>()
+            + size_of::<u16>()
+            + 2 * size_of::<SevHashTableEntry>()
+            + size_of::<[u8; 16]>()
+            + size_of::<u16>()
+    }
+
+    #[test]
+    fn hash_block_kernel_digest_setup_sects_1() {
+        let payload = b"KERNEL_DATA";
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(1, payload),
+            initramfs: None,
+            cmdline: CString::new("").unwrap(),
+        };
+        let block = info.build_hash_block().unwrap();
+        let expected = expected_kernel_digest(1, payload);
+        let offset = kernel_hash_offset();
+        assert_eq!(&block[offset..offset + 32], &expected);
+    }
+
+    #[test]
+    fn hash_block_kernel_digest_setup_sects_0() {
+        let payload = b"KERNEL_DATA";
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(0, payload),
+            initramfs: None,
+            cmdline: CString::new("").unwrap(),
+        };
+        let block = info.build_hash_block().unwrap();
+        let expected = expected_kernel_digest(0, payload);
+        let offset = kernel_hash_offset();
+        assert_eq!(&block[offset..offset + 32], &expected);
+    }
+
+    #[test]
+    fn hash_block_kernel_digest_large_setup_sects() {
+        let payload = b"KERNEL_PAYLOAD_LARGE_SETUP";
+        let info = MeasuredBootInfo {
+            kernel: make_fake_kernel(8, payload),
+            initramfs: None,
+            cmdline: CString::new("").unwrap(),
+        };
+        let block = info.build_hash_block().unwrap();
+        let expected = expected_kernel_digest(8, payload);
+        let offset = kernel_hash_offset();
+        assert_eq!(&block[offset..offset + 32], &expected);
+    }
+}

--- a/vmm/src/sev.rs
+++ b/vmm/src/sev.rs
@@ -1,0 +1,181 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use core::mem::size_of;
+use std::ffi::CString;
+use std::fs::File;
+use std::io::{self, Cursor, Read, Seek, SeekFrom};
+use std::os::unix::fs::FileExt;
+
+use linux_loader::bootparam::boot_params;
+use sha2::{Digest, Sha256};
+use uuid::{Uuid, uuid};
+use vm_memory::ByteValued;
+use vmm_sys_util::errno;
+use zerocopy::{Immutable, IntoBytes};
+
+pub(crate) type Result<T> = std::result::Result<T, errno::Error>;
+
+// https://github.com/tianocore/edk2/blob/f98662c5e35b6ab60f46ee4350fa0e6eab0497cf/OvmfPkg/Include/Fdf/MemFd.fdf.inc#L89-L93
+pub const SEV_HASH_BLOCK_ADDRESS: u64 = 0x10c00;
+pub const SEV_HASH_BLOCK_SIZE: usize = 0x400;
+const SHA256_HASH_SIZE: usize = 32;
+
+// Measured hashes table definitions. These match the definitions found in
+// QEMU's implementation: https://gitlab.com/qemu-project/qemu/-/blob/master/target/i386/sev.c#L68
+#[repr(C, packed)]
+#[derive(IntoBytes, Immutable)]
+struct SevHashTableEntry {
+    pub guid: [u8; 16],
+    pub len: u16,
+    pub hash: [u8; SHA256_HASH_SIZE],
+}
+
+#[repr(C, packed)]
+#[derive(IntoBytes, Immutable)]
+struct SevHashTable {
+    pub guid: [u8; 16],
+    pub len: u16,
+    pub cmdline: SevHashTableEntry,
+    pub initrd: SevHashTableEntry,
+    pub kernel: SevHashTableEntry,
+}
+
+const SEV_HASH_TABLE_PADDING: usize =
+    size_of::<SevHashTable>().next_multiple_of(16) - size_of::<SevHashTable>();
+
+#[derive(IntoBytes, Immutable)]
+pub struct PaddedSevHashTable {
+    #[allow(dead_code)]
+    hash_table: SevHashTable,
+    #[allow(dead_code)]
+    padding: [u8; SEV_HASH_TABLE_PADDING],
+}
+
+// These GUIDs are defined in both EDK2 and QEMU:
+// https://github.com/tianocore/edk2/blob/master/OvmfPkg/AmdSev/BlobVerifierLibSevHashes/BlobVerifierSevHashes.c#L36-L43
+// https://gitlab.com/qemu-project/qemu/-/blob/master/target/i386/sev.c#L2344-2360
+const SEV_HASH_TABLE_GUID: Uuid = uuid!("9438d606-4f22-4cc9-b479-a793d411fd21");
+const SEV_KERNEL_HASH_GUID: Uuid = uuid!("4de79437-abd2-427f-b835-d5b172d2045b");
+const SEV_INITRD_HASH_GUID: Uuid = uuid!("44baf731-3a2f-4bd7-9af1-41e29169781d");
+const SEV_CMDLINE_HASH_GUID: Uuid = uuid!("97d02dd8-bd20-4c94-aa78-e7714d36ab2a");
+
+pub struct MeasuredBootInfo {
+    pub kernel: File,
+    // QEMU also makes initrd optional in the hash table
+    pub initramfs: Option<File>,
+    pub cmdline: CString,
+}
+
+impl MeasuredBootInfo {
+    fn measured_boot_io(err: &io::Error) -> errno::Error {
+        errno::Error::new(err.raw_os_error().unwrap_or(libc::EINVAL))
+    }
+
+    fn sha256_reader<R: Read>(mut reader: R) -> Result<[u8; 32]> {
+        let mut hasher = Sha256::new();
+        let mut chunk = [0u8; 8192];
+        loop {
+            let bytes_read = reader
+                .read(&mut chunk)
+                .map_err(|e| Self::measured_boot_io(&e))?;
+            if bytes_read == 0 {
+                break;
+            }
+            hasher.update(&chunk[..bytes_read]);
+        }
+
+        Ok(hasher.finalize().into())
+    }
+
+    pub fn build_hash_block(&self) -> Result<[u8; SEV_HASH_BLOCK_SIZE]> {
+        // Current tooling appends a NUL byte at the end of cmdlines:
+        // https://github.com/virtee/sev-snp-measure/blob/main/sevsnpmeasure/sev_hashes.py#L71-L74
+        let cmdline_digest: [u8; 32] = Sha256::digest(self.cmdline.as_bytes_with_nul()).into();
+
+        // If no initrd is provided, we will simply hash over an empty buffer, mimicking
+        // QEMU's behavior: https://gitlab.com/qemu-project/qemu/-/blob/master/target/i386/sev.c#L2387
+        let initrd_digest: [u8; 32] = if let Some(initramfs) = &self.initramfs {
+            let mut initramfs = initramfs
+                .try_clone()
+                .map_err(|e| Self::measured_boot_io(&e))?;
+            initramfs
+                .seek(SeekFrom::Start(0))
+                .map_err(|e| Self::measured_boot_io(&e))?;
+            Self::sha256_reader(initramfs)?
+        } else {
+            Self::sha256_reader(Cursor::new([]))?
+        };
+
+        // The kernel components are split up into a setup section and the actual kernel data,
+        // so split them up to avoid double counting, assuming this is a bzImage Linux kernel
+        let mut setup_header = vec![0u8; size_of::<boot_params>()];
+        self.kernel
+            .read_exact_at(&mut setup_header, 0)
+            .map_err(|e| Self::measured_boot_io(&e))?;
+
+        let kernel_start = {
+            // Matches QEMU's way of finding the kernel start/setup start
+            // https://gitlab.com/qemu-project/qemu/-/blob/master/hw/i386/x86-common.c#L903
+            let bp = boot_params::from_mut_slice(&mut setup_header).unwrap();
+            let setup_sects = if bp.hdr.setup_sects == 0 {
+                4
+            } else {
+                bp.hdr.setup_sects
+            };
+            (u64::from(setup_sects) + 1) * 512
+        };
+        let setup_len = kernel_start as usize;
+        let mut setup_data = vec![0u8; setup_len];
+        if setup_len <= setup_header.len() {
+            setup_data.copy_from_slice(&setup_header[..setup_len]);
+        } else {
+            setup_data[..setup_header.len()].copy_from_slice(&setup_header);
+            self.kernel
+                .read_exact_at(
+                    &mut setup_data[setup_header.len()..],
+                    setup_header.len() as u64,
+                )
+                .map_err(|e| Self::measured_boot_io(&e))?;
+        }
+
+        let mut kernel = self
+            .kernel
+            .try_clone()
+            .map_err(|e| Self::measured_boot_io(&e))?;
+        kernel
+            .seek(SeekFrom::Start(kernel_start))
+            .map_err(|e| Self::measured_boot_io(&e))?;
+        let kernel_digest = Self::sha256_reader(Cursor::new(setup_data).chain(kernel))?;
+
+        let table = PaddedSevHashTable {
+            hash_table: SevHashTable {
+                guid: SEV_HASH_TABLE_GUID.to_bytes_le(),
+                len: size_of::<SevHashTable>() as u16,
+                cmdline: SevHashTableEntry {
+                    guid: SEV_CMDLINE_HASH_GUID.to_bytes_le(),
+                    len: size_of::<SevHashTableEntry>() as u16,
+                    hash: cmdline_digest,
+                },
+                initrd: SevHashTableEntry {
+                    guid: SEV_INITRD_HASH_GUID.to_bytes_le(),
+                    len: size_of::<SevHashTableEntry>() as u16,
+                    hash: initrd_digest,
+                },
+                kernel: SevHashTableEntry {
+                    guid: SEV_KERNEL_HASH_GUID.to_bytes_le(),
+                    len: size_of::<SevHashTableEntry>() as u16,
+                    hash: kernel_digest,
+                },
+            },
+            padding: [0; SEV_HASH_TABLE_PADDING],
+        };
+
+        let mut hash_block = [0u8; SEV_HASH_BLOCK_SIZE];
+        // The remainder of the page is zeroed to ensure measurements are reliably calculated
+        hash_block[..size_of::<PaddedSevHashTable>()].copy_from_slice(table.as_bytes());
+        Ok(hash_block)
+    }
+}

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1139,6 +1139,7 @@ impl Vm {
         fw_cfg_config: &FwCfgConfig,
         device_manager: &Arc<Mutex<DeviceManager>>,
         config: &Arc<Mutex<VmConfig>>,
+        #[cfg(target_arch = "x86_64")] kvm_sev_snp_enabled: bool,
     ) -> Result<()> {
         let mut e820_option: Option<usize> = None;
         if fw_cfg_config.e820 {
@@ -1222,6 +1223,8 @@ impl Vm {
                 initramfs_option,
                 cmdline_option,
                 fw_cfg_item_list_option,
+                #[cfg(target_arch = "x86_64")]
+                kvm_sev_snp_enabled,
             )
             .map_err(Error::ErrorPopulatingFwCfg)?;
         Ok(())
@@ -2739,7 +2742,26 @@ impl Vm {
                     .map(|p| p.fw_cfg_config.clone())
                     .unwrap_or_default()
                     .ok_or(Error::VmMissingConfig)?;
-                Self::populate_fw_cfg(&fw_cfg_config, &self.device_manager, &self.config)?;
+                #[cfg(target_arch = "x86_64")]
+                let kvm_sev_snp_enabled = {
+                    #[cfg(feature = "sev_snp")]
+                    {
+                        self.config.lock().unwrap().is_sev_snp_enabled()
+                            && self.hypervisor.hypervisor_type() == hypervisor::HypervisorType::Kvm
+                    }
+                    #[cfg(not(feature = "sev_snp"))]
+                    {
+                        false
+                    }
+                };
+
+                Self::populate_fw_cfg(
+                    &fw_cfg_config,
+                    &self.device_manager,
+                    &self.config,
+                    #[cfg(target_arch = "x86_64")]
+                    kvm_sev_snp_enabled,
+                )?;
 
                 if fw_cfg_config.acpi_tables {
                     let tpm_enabled = self.config.lock().unwrap().tpm.is_some();

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1012,8 +1012,16 @@ impl Vm {
             .create_boot_vcpus(snapshot_from_id(snapshot, CPU_MANAGER_SNAPSHOT_ID))
             .map_err(Error::CpuManager)?;
 
-        // Initialize SEV-SNP - transitions guest into secure state
-        vm.sev_snp_init(Self::get_default_sev_snp_guest_policy())
+        // Extract guest policy from IGVM if available, otherwise use default.
+        #[cfg(feature = "igvm")]
+        let guest_policy = igvm_file
+            .as_ref()
+            .and_then(igvm_loader::extract_guest_policy)
+            .unwrap_or_else(Self::get_default_sev_snp_guest_policy);
+        #[cfg(not(feature = "igvm"))]
+        let guest_policy = Self::get_default_sev_snp_guest_policy();
+
+        vm.sev_snp_init(guest_policy)
             .map_err(Error::InitializeSevSnpVm)?;
 
         // Load payload for SEV-SNP (IGVM parser needs cpu_manager for cpuid)

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -105,6 +105,13 @@ use crate::migration::get_vm_snapshot;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::migration::url_to_file;
 use crate::migration::{SNAPSHOT_CONFIG_FILE, SNAPSHOT_STATE_FILE, url_to_path};
+#[cfg(all(
+    feature = "kvm",
+    feature = "sev_snp",
+    feature = "fw_cfg",
+    target_arch = "x86_64"
+))]
+use crate::sev::MeasuredBootInfo;
 #[cfg(feature = "fw_cfg")]
 use crate::vm_config::FwCfgConfig;
 use crate::vm_config::{
@@ -1545,6 +1552,13 @@ impl Vm {
         igvm_file: IgvmFile,
         memory_manager: Arc<Mutex<MemoryManager>>,
         cpu_manager: Arc<Mutex<cpu::CpuManager>>,
+        #[cfg(all(
+            feature = "kvm",
+            feature = "sev_snp",
+            feature = "fw_cfg",
+            target_arch = "x86_64"
+        ))]
+        measured_boot: Option<MeasuredBootInfo>,
         #[cfg(feature = "sev_snp")] host_data: &Option<String>,
     ) -> Result<EntryPoint> {
         // Only reserve bootloader/VMSA regions for KVM + SEV-SNP; other hypervisors
@@ -1561,6 +1575,13 @@ impl Vm {
             memory_manager,
             cpu_manager.clone(),
             "",
+            #[cfg(all(
+                feature = "kvm",
+                feature = "sev_snp",
+                feature = "fw_cfg",
+                target_arch = "x86_64"
+            ))]
+            measured_boot,
             #[cfg(feature = "sev_snp")]
             host_data,
         )
@@ -1655,10 +1676,61 @@ impl Vm {
             if payload.igvm.is_some() {
                 let igvm_file =
                     igvm_file.ok_or(Error::IgvmLoad(igvm_loader::Error::MissingIgvm))?;
+                #[cfg(all(
+                    feature = "kvm",
+                    feature = "sev_snp",
+                    feature = "fw_cfg",
+                    target_arch = "x86_64"
+                ))]
+                let measured_boot = if let (true, Some(kernel_path), Some(_cmdline)) = (
+                    payload
+                        .fw_cfg_config
+                        .as_ref()
+                        .is_some_and(|cfg| cfg.kernel && cfg.cmdline),
+                    payload.kernel.as_ref(),
+                    payload.cmdline.as_ref(),
+                ) {
+                    let kernel = File::open(kernel_path).map_err(Error::KernelFile)?;
+                    let initramfs = if payload
+                        .fw_cfg_config
+                        .as_ref()
+                        .is_some_and(|cfg| cfg.initramfs)
+                    {
+                        payload
+                            .initramfs
+                            .as_ref()
+                            .map(File::open)
+                            .transpose()
+                            .map_err(Error::InitramfsFile)?
+                    } else {
+                        None
+                    };
+
+                    // Must byte-match the cmdline that populate_fw_cfg sends to the guest,
+                    // otherwise the launch measurement will diverge.
+                    let cmdline = Self::generate_cmdline(payload)?
+                        .as_cstring()
+                        .map_err(Error::CmdLineCreate)?;
+
+                    Some(MeasuredBootInfo {
+                        kernel,
+                        initramfs,
+                        cmdline,
+                    })
+                } else {
+                    None
+                };
                 return Self::load_igvm(
                     igvm_file,
                     memory_manager,
                     cpu_manager,
+                    #[cfg(all(
+                        feature = "kvm",
+                        feature = "sev_snp",
+                        feature = "fw_cfg",
+                        target_arch = "x86_64"
+                    ))]
+                    measured_boot,
                     #[cfg(feature = "sev_snp")]
                     &payload.host_data,
                 );


### PR DESCRIPTION
This PR adds measured boot support for AMD SEV-SNP confidential VMs launched via Cloud Hypervisor with IGVM, bringing parity with QEMU's SEV-SNP launch flow.

The core goal is to ensure the guest's launch measurement accurately reflects the kernel, command line, and initrd provided by the VMM — and to pass a signed SNP ID block so the guest (or a remote attestor) can verify the launch against a known identity.

The kernel hashes patches are taken from #8084, and cleaned up. The ID Block patches largely follow the same principles in QEMU.

# Testing

## Step 1: Build Stage0 Firmware

Stage0 is built from the [Project Oak](https://github.com/project-oak/oak) `stage0_bin`.

## Step 2: Create a Signed SNP ID Block

### 2a. Compute the launch measurement

```bash
sev-snp-measure --vcpus 4 --vcpu-sig <sig> \
  --ovmf stage0_bin \
  --kernel vmlinuz \
  --append "console=ttyS0 root=/dev/vda1 rw" \
  --mode snp

53c4f97b9e994ac6a93176aca0b8e85017bae981276d636dff7129834ccfcfac4b3383e9ecdd90b38ebf471ebb4c6fb7
```

- `--vcpu-sig`: CPU signature from CPUID leaf 1 EAX
- `--ovmf`: the raw `stage0_bin`
- `--append`: must exactly match `--cmdline` passed to cloud-hypervisor later

### 2b. Generate keys (example):
```bash
openssl ... -out idkey.pem
openssl ... -out authorkey.pem
```

### 2c. Generate the ID block

```bash
MEASUREMENT_HEX="<paste hex from 2a>"
MEASUREMENT_B64=$(python3 -c "import base64; print(base64.b64encode(bytes.fromhex('${MEASUREMENT_HEX}')).decode())")

python3 sev-snp-measure/snp-create-id-block.py \
  --measurement "$MEASUREMENT_B64" \
  --idkey idkey.pem \
  --authorkey authorkey.pem \
  --igvm --policy <policy> \
  > snp-id-block.bin
```

- **sev-snp-measure requires changes in 
- https://github.com/rhakobyan/sev-snp-measure/tree/igvm-support**
- `--idkey` / `--authorkey`: ECDSA P-384 private key PEM files
- `--policy` must match the guest policy

---

## Step 3: Build the IGVM File

```bash
buildigvm sev-snp \
...
```
---

## Step 4: Launch Cloud-Hypervisor

### 4a. Build

```bash
cargo build --release --no-default-features --features "kvm,igvm,sev_snp,fw_cfg"
```

### 4b. Run

```bash
sudo ./target/release/cloud-hypervisor -vv \
  --platform sev_snp=on \
  --igvm stage0.igvm \
  --kernel vmlinuz \
  --cpus boot=4 \
  --memory size=2G,shared=on \
  --disk path=guest.qcow2,image_type=qcow2 \
  --cmdline "console=ttyS0 root=/dev/vda1 rw" \
  --serial tty \
  --console off
```

### 4c. Verify attestation (from inside the guest)

```bash
# Get attestation report from AMD PSP
snpguest report /tmp/report.bin /tmp/request.bin --random

snpguest display report /tmp/report.bin

Attestation Report (1184 bytes):
Version:                      5
Guest SVN:                    0

    Guest Policy (0x230000):
    ABI Major:     0
    ABI Minor:     0
    SMT Allowed:   1
    Migrate MA:    0
    Debug Allowed: 0
    Single Socket: 0

...
Measurement:                  
53 c4 f9 7b 9e 99 4a c6 a9 31 76 ac a0 b8 e8 50 
17 ba e9 81 27 6d 63 6d ff 71 29 83 4c cf cf ac 
4b 33 83 e9 ec dd 90 b3 8e bf 47 1e bb 4c 6f b7 
```

**Measurement matches 2a.**
