### PR TITLE
ci: Remove lychee as a required CI step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -743,7 +743,6 @@ jobs:
       - integration-windows
       - integration-x86-64-mq
       - integration-x86-64-pr
-      - lychee
       - openapi
       - package-consistency
       - preflight


### PR DESCRIPTION
Remove the dependency on lychee from all-green.

Signed-off-by: Rob Bradford <rbradford@meta.com>
