### PR TITLE
Virtio device guest-induced error fixes

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -235,10 +235,18 @@ Setting device status to 'NEEDS_RESET' and stopping processing queues until rese
             return Ok(());
         }
         let queue = &mut self.queue;
+        let queue_size = queue.size();
         let mut batch_requests = Vec::new();
         let mut batch_inflight_requests = Vec::new();
+        let mut processed = 0;
 
         loop {
+            // Cap a single drain at the virtqueue size. A compliant driver won't submit more that
+            // queue_size, but a buggy or malicious one can keep adding as the VMM is reading.
+            if processed >= queue_size {
+                break;
+            }
+            processed += 1;
             let mut desc_chain = match queue.iter(self.mem.memory()) {
                 Ok(mut iter) => match iter.next() {
                     Some(c) => c,

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -417,9 +417,10 @@ Setting device status to 'NEEDS_RESET' and stopping processing queues until rese
     }
 
     fn process_queue_submit_and_signal(&mut self) -> result::Result<(), EpollHelperError> {
-        self.process_queue_submit().map_err(|e| {
-            EpollHelperError::HandleEvent(anyhow!("Failed to process queue (submit): {e:?}"))
-        })?;
+        // Per-request errors are logged but non-device fatal.
+        if let Err(e) = self.process_queue_submit() {
+            warn!("Failed to process queue (submit): {e:?}");
+        }
 
         self.try_signal_used_queue()
     }
@@ -672,11 +673,9 @@ impl EpollHelperHandler for BlockEpollHandler {
                     EpollHelperError::HandleEvent(anyhow!("Failed to get queue event: {e:?}"))
                 })?;
 
-                self.process_queue_complete().map_err(|e| {
-                    EpollHelperError::HandleEvent(anyhow!(
-                        "Failed to process queue (complete): {e:?}"
-                    ))
-                })?;
+                if let Err(e) = self.process_queue_complete() {
+                    warn!("Failed to process queue (complete): {e:?}");
+                }
 
                 self.try_signal_used_queue()?;
 

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -157,19 +157,19 @@ impl TryInto<rate_limiter::RateLimiter> for RateLimiterConfig {
 /// Return the host virtual address corresponding to the given guest address range
 ///
 /// Convert an absolute address into an address space (GuestMemory)
-/// to a host pointer and verify that the provided size define a valid
+/// to a host pointer and verify that the provided size defines a valid
 /// range within a single memory region.
-/// Return None if it is out of bounds or if addr+size overlaps a single region.
+/// Return None if it is out of bounds, spans multiple regions, or has
+/// zero size at an unmapped GPA.
 pub fn get_host_address_range<M: GuestMemory + ?Sized>(
     mem: &M,
     addr: GuestAddress,
     size: usize,
 ) -> Option<*mut u8> {
-    if mem.check_range(addr, size) {
-        let slice = mem.get_slice(addr, size).unwrap();
-        assert!(slice.len() >= size);
-        Some(slice.ptr_guard_mut().as_ptr())
-    } else {
-        None
+    // Reject zero-length, no use of a pointer to an empty range.
+    if size == 0 {
+        return None;
     }
+    let slice = mem.get_slice(addr, size).ok()?;
+    Some(slice.ptr_guard_mut().as_ptr())
 }


### PR DESCRIPTION
Address a few paths the guest can panic the VMM or cause the worker to exit when a queue reset would suffice.