### PR TITLE
pci: msix: Replace panic with graceful error on invalid table write

### DIFF
--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -321,7 +321,13 @@ impl MsixConfig {
     }
 
     pub fn write_table(&mut self, offset: u64, data: &[u8]) {
-        assert!(data.len() == 4 || data.len() == 8);
+        if data.len() != 4 && data.len() != 8 {
+            error!(
+                "invalid MSI-X table write size: {} (allowed: 4 or 8)",
+                data.len()
+            );
+            return;
+        }
 
         let index: usize = (offset / MSIX_TABLE_ENTRIES_MODULO) as usize;
         let modulo_offset = offset % MSIX_TABLE_ENTRIES_MODULO;


### PR DESCRIPTION
A malicious or buggy guest can issue an MSI-X table write with an unexpected size (not 4 or 8 bytes), triggering an assert!() that crashes the VMM process. Replace the assertion with an error log and early return to maintain VMM stability under adversarial guest behavior.