### PR TITLE
performance-metrics: avoid double ref in test selection

### DIFF
--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -1868,8 +1868,8 @@ fn main() {
     };
 
     // Determine which tests will actually run.
-    let tests_to_run: Vec<&&PerformanceTest> = test_list
-        .iter()
+    let tests_to_run: Vec<&PerformanceTest> = test_list
+        .into_iter()
         .filter(|t| test_filter.is_empty() || test_filter.iter().any(|&s| t.name.contains(s)))
         .filter(|t| !test_exclude.iter().any(|&s| t.name.contains(s)))
         .collect();


### PR DESCRIPTION
Use into_iter() for test_list when building tests_to_run.

This keeps the collected type as Vec<&PerformanceTest>.