### PR TITLE
virtio-devices: Check MSI-X vector bounds before table access

### DIFF
--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1398,4 +1398,12 @@ mod unit_tests {
         intr.queues_vectors.lock().unwrap()[0] = 0xFFFE;
         assert!(intr.notifier(VirtioInterruptType::Queue(0)).is_none());
     }
+
+    #[test]
+    fn trigger_with_valid_vector_fires() {
+        let intr = make_msix_interrupt(2);
+        intr.queues_vectors.lock().unwrap()[0] = 0;
+        intr.msix_config.lock().unwrap().set_msg_ctl(1u16 << 15);
+        intr.trigger(VirtioInterruptType::Queue(0)).unwrap();
+    }
 }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1323,3 +1323,66 @@ impl Snapshottable for VirtioPciDevice {
 }
 impl Transportable for VirtioPciDevice {}
 impl Migratable for VirtioPciDevice {}
+
+#[cfg(test)]
+mod unit_tests {
+    use vm_device::interrupt::InterruptSourceConfig;
+
+    use super::*;
+
+    struct TestInterruptSourceGroup {
+        event_fd: EventFd,
+    }
+
+    impl InterruptSourceGroup for TestInterruptSourceGroup {
+        fn trigger(&self, _index: InterruptIndex) -> std::result::Result<(), std::io::Error> {
+            self.event_fd.write(1)
+        }
+        fn notifier(&self, _index: InterruptIndex) -> Option<EventFd> {
+            Some(self.event_fd.try_clone().unwrap())
+        }
+        fn update(
+            &self,
+            _index: InterruptIndex,
+            _config: InterruptSourceConfig,
+            _masked: bool,
+            _set_gsi: bool,
+        ) -> std::result::Result<(), std::io::Error> {
+            Ok(())
+        }
+        fn set_gsi(&self) -> std::result::Result<(), std::io::Error> {
+            Ok(())
+        }
+    }
+
+    fn make_msix_interrupt(num_vectors: u16) -> VirtioInterruptMsix {
+        let isg = Arc::new(TestInterruptSourceGroup {
+            event_fd: EventFd::new(0).unwrap(),
+        });
+        let msix_config = Arc::new(Mutex::new(
+            MsixConfig::new(
+                num_vectors,
+                MaybeMutInterruptSourceGroup::Immutable(isg.clone()),
+                0,
+                None,
+            )
+            .unwrap(),
+        ));
+        let config_vector = Arc::new(AtomicU16::new(VIRTQ_MSI_NO_VECTOR));
+        let queues_vectors = Arc::new(Mutex::new(vec![VIRTQ_MSI_NO_VECTOR; 1]));
+
+        VirtioInterruptMsix::new(
+            msix_config,
+            config_vector,
+            queues_vectors,
+            MaybeMutInterruptSourceGroup::Immutable(isg),
+        )
+    }
+
+    #[test]
+    fn trigger_with_oob_vector_does_not_panic() {
+        let intr = make_msix_interrupt(2);
+        intr.queues_vectors.lock().unwrap()[0] = 0xFFFE;
+        intr.trigger(VirtioInterruptType::Queue(0)).unwrap();
+    }
+}

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1391,4 +1391,11 @@ mod unit_tests {
         let intr = make_msix_interrupt(2);
         intr.trigger(VirtioInterruptType::Queue(0)).unwrap();
     }
+
+    #[test]
+    fn notifier_with_oob_vector_returns_none() {
+        let intr = make_msix_interrupt(2);
+        intr.queues_vectors.lock().unwrap()[0] = 0xFFFE;
+        assert!(intr.notifier(VirtioInterruptType::Queue(0)).is_none());
+    }
 }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1385,4 +1385,10 @@ mod unit_tests {
         intr.queues_vectors.lock().unwrap()[0] = 0xFFFE;
         intr.trigger(VirtioInterruptType::Queue(0)).unwrap();
     }
+
+    #[test]
+    fn trigger_with_no_vector_returns_ok() {
+        let intr = make_msix_interrupt(2);
+        intr.trigger(VirtioInterruptType::Queue(0)).unwrap();
+    }
 }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Barrier, Mutex};
 
 use anyhow::anyhow;
 use libc::EFD_NONBLOCK;
-use log::{error, info};
+use log::{error, info, warn};
 use pci::{
     BarReprogrammingParams, MaybeMutInterruptSourceGroup, MsixCap, MsixConfig, PciBarConfiguration,
     PciBarRegionType, PciCapability, PciCapabilityId, PciClassCode, PciConfiguration, PciDevice,
@@ -860,6 +860,7 @@ pub struct VirtioInterruptMsix {
     config_vector: Arc<AtomicU16>,
     queues_vectors: Arc<Mutex<Vec<u16>>>,
     interrupt_source_group: MaybeMutInterruptSourceGroup,
+    msix_table_size: usize,
 }
 
 impl VirtioInterruptMsix {
@@ -869,11 +870,13 @@ impl VirtioInterruptMsix {
         queues_vectors: Arc<Mutex<Vec<u16>>>,
         interrupt_source_group: MaybeMutInterruptSourceGroup,
     ) -> Self {
+        let msix_table_size = msix_config.lock().unwrap().table_entries.len();
         VirtioInterruptMsix {
             msix_config,
             config_vector,
             queues_vectors,
             interrupt_source_group,
+            msix_table_size,
         }
     }
 }
@@ -888,6 +891,11 @@ impl VirtioInterrupt for VirtioInterruptMsix {
         };
 
         if vector == VIRTQ_MSI_NO_VECTOR {
+            return Ok(());
+        }
+
+        if vector as usize >= self.msix_table_size {
+            warn!("MSI-X vector {vector} out of range, ignoring interrupt");
             return Ok(());
         }
 
@@ -914,6 +922,15 @@ impl VirtioInterrupt for VirtioInterruptMsix {
                 self.queues_vectors.lock().unwrap()[queue_index as usize]
             }
         };
+
+        if vector == VIRTQ_MSI_NO_VECTOR {
+            return None;
+        }
+
+        if vector as usize >= self.msix_table_size {
+            warn!("MSI-X vector {vector} out of range, notifier unavailable");
+            return None;
+        }
 
         self.interrupt_source_group
             .notifier(vector as InterruptIndex)

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1406,4 +1406,11 @@ mod unit_tests {
         intr.msix_config.lock().unwrap().set_msg_ctl(1u16 << 15);
         intr.trigger(VirtioInterruptType::Queue(0)).unwrap();
     }
+
+    #[test]
+    fn config_vector_oob_does_not_panic() {
+        let intr = make_msix_interrupt(2);
+        intr.config_vector.store(0xFFFE, Ordering::Release);
+        intr.trigger(VirtioInterruptType::Config).unwrap();
+    }
 }


### PR DESCRIPTION
A malicious or buggy guest can write an out-of-bounds value to queue_msix_vector or msix_config. When the device later triggers an interrupt, it indexes into table_entries with the unchecked vector, causing a panic.

Validate the vector against the MSI-X table size in both trigger() and notifier() paths, logging a warning and returning early when the vector exceeds the table bounds.

Added also initial unit tests module and tests covering the behavior.