### PR TITLE
net: Prevent worker thread death on malformed guest descriptors

### DIFF
--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -272,33 +272,41 @@ impl RxVirtio {
                 };
                 if result < 0 {
                     let e = std::io::Error::last_os_error();
-                    exhausted_descs = false;
-                    queue.go_to_previous_position();
 
                     /* EAGAIN */
                     if e.kind() == std::io::ErrorKind::WouldBlock {
+                        exhausted_descs = false;
+                        queue.go_to_previous_position();
                         break;
                     }
 
-                    error!("net: rx: failed reading from tap: {e}");
-                    return Err(NetQueuePairError::ReadTap(e));
-                }
-
-                if (result as usize) < vnet_hdr_len() {
+                    if e.raw_os_error() == Some(libc::EINVAL) {
+                        error!("net: rx: dropping undersized buffer: {e}");
+                        desc_chain
+                            .memory()
+                            .write_obj(0u16, num_buffers_addr)
+                            .map_err(NetQueuePairError::GuestMemory)?;
+                        0
+                    } else {
+                        queue.go_to_previous_position();
+                        error!("net: rx: failed reading from tap: {e}");
+                        return Err(NetQueuePairError::ReadTap(e));
+                    }
+                } else if (result as usize) < vnet_hdr_len() {
                     return Err(NetQueuePairError::InvalidVirtioNetHeader);
+                } else {
+                    // Write num_buffers to guest memory. Always 1 because the
+                    // frame is never spread over more than one descriptor chain.
+                    desc_chain
+                        .memory()
+                        .write_obj(1u16, num_buffers_addr)
+                        .map_err(NetQueuePairError::GuestMemory)?;
+
+                    self.counter_bytes += Wrapping(result as u64 - vnet_hdr_len() as u64);
+                    self.counter_frames += Wrapping(1);
+
+                    result as u32
                 }
-
-                // Write num_buffers to guest memory. We simply write 1 as we
-                // never spread the frame over more than one descriptor chain.
-                desc_chain
-                    .memory()
-                    .write_obj(1u16, num_buffers_addr)
-                    .map_err(NetQueuePairError::GuestMemory)?;
-
-                self.counter_bytes += Wrapping(result as u64 - vnet_hdr_len() as u64);
-                self.counter_frames += Wrapping(1);
-
-                result as u32
             };
 
             // For the sake of simplicity (keeping the handling of RX_QUEUE_EVENT and

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -293,7 +293,15 @@ impl RxVirtio {
                         return Err(NetQueuePairError::ReadTap(e));
                     }
                 } else if (result as usize) < vnet_hdr_len() {
-                    return Err(NetQueuePairError::InvalidVirtioNetHeader);
+                    error!(
+                        "net: rx: buffer too short for virtio_net_hdr ({result} < {})",
+                        vnet_hdr_len()
+                    );
+                    desc_chain
+                        .memory()
+                        .write_obj(0u16, num_buffers_addr)
+                        .map_err(NetQueuePairError::GuestMemory)?;
+                    0
                 } else {
                     // Write num_buffers to guest memory. Always 1 because the
                     // frame is never spread over more than one descriptor chain.

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -118,18 +118,22 @@ impl TxVirtio {
                         retry_write = true;
                         break;
                     }
-                    error!("net: tx: failed writing to tap: {e}");
-                    return Err(NetQueuePairError::WriteTap(e));
-                }
 
-                if (result as usize) < vnet_hdr_len() {
+                    if e.raw_os_error() == Some(libc::EINVAL) {
+                        error!("net: tx: dropping malformed packet: {e}");
+                        0
+                    } else {
+                        error!("net: tx: failed writing to tap: {e}");
+                        return Err(NetQueuePairError::WriteTap(e));
+                    }
+                } else if (result as usize) < vnet_hdr_len() {
                     return Err(NetQueuePairError::InvalidVirtioNetHeader);
+                } else {
+                    self.counter_bytes += Wrapping(result as u64 - vnet_hdr_len() as u64);
+                    self.counter_frames += Wrapping(1);
+
+                    result as u64
                 }
-
-                self.counter_bytes += Wrapping(result as u64 - vnet_hdr_len() as u64);
-                self.counter_frames += Wrapping(1);
-
-                result as u64
             };
 
             // For the sake of simplicity (similar to the RX rate limiting), we always

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -127,7 +127,8 @@ impl TxVirtio {
                         return Err(NetQueuePairError::WriteTap(e));
                     }
                 } else if (result as usize) < vnet_hdr_len() {
-                    return Err(NetQueuePairError::InvalidVirtioNetHeader);
+                    error!("net: tx: short tap write ({result} < {})", vnet_hdr_len());
+                    0
                 } else {
                     self.counter_bytes += Wrapping(result as u64 - vnet_hdr_len() as u64);
                     self.counter_frames += Wrapping(1);

--- a/net_util/src/queue_pair.rs
+++ b/net_util/src/queue_pair.rs
@@ -13,7 +13,7 @@ use rate_limiter::{RateLimiter, TokenType};
 use thiserror::Error;
 use virtio_queue::{Queue, QueueOwnedT, QueueT};
 use vm_memory::bitmap::Bitmap;
-use vm_memory::{Bytes, GuestMemory};
+use vm_memory::{Bytes, GuestAddress, GuestMemory};
 use vm_virtio::{AccessPlatform, Translatable};
 
 use super::{Tap, register_listener, unregister_listener, vnet_hdr_len};
@@ -66,35 +66,50 @@ impl TxVirtio {
             let mut next_desc = desc_chain.next();
 
             let mut iovecs = self.iovecs.borrow();
-            while let Some(desc) = next_desc {
-                let desc_addr = desc
-                    .addr()
-                    .translate_gva(access_platform, desc.len() as usize)
-                    .map_err(|e| {
-                        NetQueuePairError::GuestMemory(vm_memory::GuestMemoryError::IOError(e))
-                    })?;
-                if !desc.is_write_only() && desc.len() > 0 {
-                    let buf = desc_chain
-                        .memory()
-                        .get_slice(desc_addr, desc.len() as usize)
-                        .map_err(NetQueuePairError::GuestMemory)?;
-                    assert!(buf.len() >= desc.len() as usize);
-                    let buf = buf.ptr_guard_mut();
-                    let iovec = libc::iovec {
-                        iov_base: buf.as_ptr().cast(),
-                        iov_len: desc.len() as libc::size_t,
-                    };
-                    iovecs.push(iovec);
-                } else {
-                    error!(
-                        "Invalid descriptor chain: address = 0x{:x} length = {} write_only = {}",
-                        desc_addr.0,
-                        desc.len(),
-                        desc.is_write_only()
-                    );
-                    return Err(NetQueuePairError::DescriptorChainInvalid);
+            // Parse the descriptor chain into an iovec array. On error, the
+            // offending head descriptor is still added to the used ring with
+            // len 0 below, so the guest does not see a descriptor leak.
+            let parse_result: Result<(), NetQueuePairError> = (|| {
+                while let Some(desc) = next_desc {
+                    let desc_addr = desc
+                        .addr()
+                        .translate_gva(access_platform, desc.len() as usize)
+                        .map_err(|e| {
+                            NetQueuePairError::GuestMemory(vm_memory::GuestMemoryError::IOError(e))
+                        })?;
+                    if !desc.is_write_only() && desc.len() > 0 {
+                        let buf = desc_chain
+                            .memory()
+                            .get_slice(desc_addr, desc.len() as usize)
+                            .map_err(NetQueuePairError::GuestMemory)?;
+                        assert!(buf.len() >= desc.len() as usize);
+                        let buf = buf.ptr_guard_mut();
+                        let iovec = libc::iovec {
+                            iov_base: buf.as_ptr().cast(),
+                            iov_len: desc.len() as libc::size_t,
+                        };
+                        iovecs.push(iovec);
+                    } else {
+                        error!(
+                            "Invalid descriptor chain: address = 0x{:x} length = {} write_only = {}",
+                            desc_addr.0,
+                            desc.len(),
+                            desc.is_write_only()
+                        );
+                        return Err(NetQueuePairError::DescriptorChainInvalid);
+                    }
+                    next_desc = desc_chain.next();
                 }
-                next_desc = desc_chain.next();
+                Ok(())
+            })();
+
+            if let Err(e) = parse_result {
+                // Surface the bad descriptor to the guest with len 0 so the
+                // used ring stays consistent before bailing.
+                queue
+                    .add_used(desc_chain.memory(), desc_chain.head_index(), 0)
+                    .map_err(NetQueuePairError::QueueAddUsed)?;
+                return Err(e);
             }
 
             let bytes_sent = if iovecs.is_empty() {
@@ -210,54 +225,72 @@ impl RxVirtio {
                 break;
             }
 
-            let desc = desc_chain
-                .next()
-                .ok_or(NetQueuePairError::DescriptorChainTooShort)?;
+            let mut iovecs = self.iovecs.borrow();
+            // Parse the descriptor chain into an iovec array. On error, the
+            // offending head descriptor is still added to the used ring with
+            // len 0 below, so the guest does not see a descriptor leak.
+            let parse_result: Result<GuestAddress, NetQueuePairError> = (|| {
+                let desc = desc_chain
+                    .next()
+                    .ok_or(NetQueuePairError::DescriptorChainTooShort)?;
 
-            let num_buffers_addr = desc_chain
-                .memory()
-                .checked_offset(
-                    desc.addr()
+                let num_buffers_addr = desc_chain
+                    .memory()
+                    .checked_offset(
+                        desc.addr()
+                            .translate_gva(access_platform, desc.len() as usize)
+                            .map_err(|e| {
+                                NetQueuePairError::GuestMemory(
+                                    vm_memory::GuestMemoryError::IOError(e),
+                                )
+                            })?,
+                        10,
+                    )
+                    .ok_or(NetQueuePairError::DescriptorInvalidHeader)?;
+                let mut next_desc = Some(desc);
+
+                while let Some(desc) = next_desc {
+                    let desc_addr = desc
+                        .addr()
                         .translate_gva(access_platform, desc.len() as usize)
                         .map_err(|e| {
                             NetQueuePairError::GuestMemory(vm_memory::GuestMemoryError::IOError(e))
-                        })?,
-                    10,
-                )
-                .ok_or(NetQueuePairError::DescriptorInvalidHeader)?;
-            let mut next_desc = Some(desc);
-
-            let mut iovecs = self.iovecs.borrow();
-            while let Some(desc) = next_desc {
-                let desc_addr = desc
-                    .addr()
-                    .translate_gva(access_platform, desc.len() as usize)
-                    .map_err(|e| {
-                        NetQueuePairError::GuestMemory(vm_memory::GuestMemoryError::IOError(e))
-                    })?;
-                if desc.is_write_only() && desc.len() > 0 {
-                    let buf = desc_chain
-                        .memory()
-                        .get_slice(desc_addr, desc.len() as usize)
-                        .map_err(NetQueuePairError::GuestMemory)?;
-                    assert!(buf.len() >= desc.len() as usize);
-                    let buf = buf.ptr_guard_mut();
-                    let iovec = libc::iovec {
-                        iov_base: buf.as_ptr().cast(),
-                        iov_len: desc.len() as libc::size_t,
-                    };
-                    iovecs.push(iovec);
-                } else {
-                    error!(
-                        "Invalid descriptor chain: address = 0x{:x} length = {} write_only = {}",
-                        desc_addr.0,
-                        desc.len(),
-                        desc.is_write_only()
-                    );
-                    return Err(NetQueuePairError::DescriptorChainInvalid);
+                        })?;
+                    if desc.is_write_only() && desc.len() > 0 {
+                        let buf = desc_chain
+                            .memory()
+                            .get_slice(desc_addr, desc.len() as usize)
+                            .map_err(NetQueuePairError::GuestMemory)?;
+                        assert!(buf.len() >= desc.len() as usize);
+                        let buf = buf.ptr_guard_mut();
+                        let iovec = libc::iovec {
+                            iov_base: buf.as_ptr().cast(),
+                            iov_len: desc.len() as libc::size_t,
+                        };
+                        iovecs.push(iovec);
+                    } else {
+                        error!(
+                            "Invalid descriptor chain: address = 0x{:x} length = {} write_only = {}",
+                            desc_addr.0,
+                            desc.len(),
+                            desc.is_write_only()
+                        );
+                        return Err(NetQueuePairError::DescriptorChainInvalid);
+                    }
+                    next_desc = desc_chain.next();
                 }
-                next_desc = desc_chain.next();
-            }
+                Ok(num_buffers_addr)
+            })();
+
+            let num_buffers_addr = match parse_result {
+                Ok(addr) => addr,
+                Err(e) => {
+                    queue
+                        .add_used(desc_chain.memory(), desc_chain.head_index(), 0)
+                        .map_err(NetQueuePairError::QueueAddUsed)?;
+                    return Err(e);
+                }
+            };
 
             let len = if iovecs.is_empty() {
                 0
@@ -305,10 +338,14 @@ impl RxVirtio {
                 } else {
                     // Write num_buffers to guest memory. Always 1 because the
                     // frame is never spread over more than one descriptor chain.
-                    desc_chain
-                        .memory()
-                        .write_obj(1u16, num_buffers_addr)
-                        .map_err(NetQueuePairError::GuestMemory)?;
+                    if let Err(e) = desc_chain.memory().write_obj(1u16, num_buffers_addr) {
+                        // Surface the bad descriptor to the guest with len 0 so
+                        // the used ring stays consistent before bailing.
+                        queue
+                            .add_used(desc_chain.memory(), desc_chain.head_index(), 0)
+                            .map_err(NetQueuePairError::QueueAddUsed)?;
+                        return Err(NetQueuePairError::GuestMemory(e));
+                    }
 
                     self.counter_bytes += Wrapping(result as u64 - vnet_hdr_len() as u64);
                     self.counter_frames += Wrapping(1);
@@ -425,8 +462,6 @@ pub enum NetQueuePairError {
     QueueAddUsed(#[source] virtio_queue::Error),
     #[error("Descriptor with invalid virtio-net header")]
     DescriptorInvalidHeader,
-    #[error("Invalid virtio-net header")]
-    InvalidVirtioNetHeader,
 }
 
 pub struct NetQueuePair {

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -620,7 +620,7 @@ impl VirtioDevice for Balloon {
             mem,
             interrupt_cb,
             mut queues,
-            ..
+            device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
         let (kill_evt, pause_evt) = self.common.dup_eventfds();
@@ -644,7 +644,7 @@ impl VirtioDevice for Balloon {
         let mut handler = BalloonEpollHandler {
             mem,
             queues: virtqueues,
-            interrupt_cb,
+            interrupt_cb: interrupt_cb.clone(),
             inflate_queue_evt,
             deflate_queue_evt,
             reporting_queue_evt,
@@ -664,6 +664,8 @@ impl VirtioDevice for Balloon {
             Thread::VirtioBalloon,
             &mut epoll_threads,
             &self.exit_evt,
+            device_status.clone(),
+            interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
         self.common.epoll_threads = Some(epoll_threads);

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -1159,6 +1159,8 @@ impl VirtioDevice for Block {
                 Thread::VirtioBlock,
                 &mut epoll_threads,
                 &self.exit_evt,
+                self.device_status.clone(),
+                interrupt_cb.clone(),
                 move || handler.run(&paused, paused_sync.as_ref().unwrap()),
             )?;
         }

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -50,7 +50,7 @@ use super::{
 };
 use crate::seccomp_filters::Thread;
 use crate::thread_helper::spawn_virtio_thread;
-use crate::{GuestMemoryMmap, VirtioInterrupt};
+use crate::{GuestMemoryMmap, VirtioInterrupt, device_needs_reset, mark_device_needs_reset};
 
 const SECTOR_SHIFT: u8 = 9;
 pub const SECTOR_SIZE: u64 = 0x01 << SECTOR_SHIFT;
@@ -174,7 +174,7 @@ fn has_feature(features: u64, feature_flag: u64) -> bool {
 
 impl BlockEpollHandler {
     fn needs_reset(&self) -> bool {
-        (self.device_status.load(Ordering::Acquire) & crate::DEVICE_NEEDS_RESET as u8) != 0
+        device_needs_reset(&self.device_status)
     }
 
     fn check_request(
@@ -209,25 +209,16 @@ impl BlockEpollHandler {
 
     fn handle_queue_iterator_error(&mut self, err: &virtio_queue::Error) {
         // The guest submitted a corrupted VirtQ request, and the error
-        // was logged during queue processing. We cannot just ignore the
-        // error, as the guest could continue spamming the VMM with bad
-        // requests, triggering excessive error logging. So we mark
-        // the device "NEEDS_RESET", effectively stopping all request
-        // processing (see self.needs_reset() usage) until the guest
-        // resets and reactivates the device.
-
-        warn!(
-            "Corrupted request detected (virtqueue error: {err:?}). \
-Setting device status to 'NEEDS_RESET' and stopping processing queues until reset."
+        // was logged during queue processing. Ignoring it would let the
+        // guest keep spamming the VMM with bad requests and trigger
+        // excessive error logging, so mark the device as NEEDS_RESET to
+        // stop request processing (see self.needs_reset() usage) until
+        // the guest resets and reactivates the device.
+        mark_device_needs_reset(
+            &self.device_status,
+            self.interrupt_cb.as_ref(),
+            format_args!("virtqueue error: {err:?}"),
         );
-
-        self.device_status
-            .fetch_or(crate::DEVICE_NEEDS_RESET as u8, Ordering::SeqCst);
-
-        // Let the guest know that the device status has changed.
-        if let Err(e) = self.interrupt_cb.trigger(VirtioInterruptType::Config) {
-            error!("Failed to signal config interrupt: {e:?}");
-        }
     }
 
     fn process_queue_submit(&mut self) -> Result<()> {

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -719,7 +719,7 @@ impl VirtioDevice for Console {
             mem,
             interrupt_cb,
             mut queues,
-            ..
+            device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
         self.resizer
@@ -741,7 +741,7 @@ impl VirtioDevice for Console {
             mem,
             input_queue,
             output_queue,
-            interrupt_cb,
+            interrupt_cb.clone(),
             self.in_buffer.clone(),
             Arc::clone(&self.resizer),
             self.endpoint.clone(),
@@ -764,6 +764,8 @@ impl VirtioDevice for Console {
             Thread::VirtioConsole,
             &mut epoll_threads,
             &self.exit_evt,
+            device_status.clone(),
+            interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
 

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -1282,7 +1282,7 @@ impl VirtioDevice for Iommu {
             mem,
             interrupt_cb,
             mut queues,
-            ..
+            device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
         let (kill_evt, pause_evt) = self.common.dup_eventfds();
@@ -1294,7 +1294,7 @@ impl VirtioDevice for Iommu {
             mem,
             request_queue,
             _event_queue,
-            interrupt_cb,
+            interrupt_cb: interrupt_cb.clone(),
             request_queue_evt,
             _event_queue_evt,
             kill_evt,
@@ -1314,6 +1314,8 @@ impl VirtioDevice for Iommu {
             Thread::VirtioIommu,
             &mut epoll_threads,
             &self.exit_evt,
+            device_status.clone(),
+            interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
 

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -11,6 +11,7 @@
 //! Implements virtio devices, queues, and transport mechanisms.
 
 use std::io;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -68,6 +69,33 @@ const DEVICE_DRIVER_OK: u32 = 0x04;
 const DEVICE_FEATURES_OK: u32 = 0x08;
 const DEVICE_NEEDS_RESET: u32 = 0x40;
 const DEVICE_FAILED: u32 = 0x80;
+
+/// Returns true if `device_status` has the `DEVICE_NEEDS_RESET` bit set.
+pub(crate) fn device_needs_reset(device_status: &AtomicU8) -> bool {
+    (device_status.load(Ordering::Acquire) & DEVICE_NEEDS_RESET as u8) != 0
+}
+
+/// Marks a virtio device as `NEEDS_RESET` and notifies the guest via a config
+/// change interrupt. Used when a guest induced error (corrupted virtqueue,
+/// malformed descriptor chain or similar) is detected and the device wants
+/// to stop further queue processing without killing the worker thread.
+///
+/// `context` is included verbatim in the warning log to identify the cause.
+pub(crate) fn mark_device_needs_reset(
+    device_status: &AtomicU8,
+    interrupt_cb: &dyn self::VirtioInterrupt,
+    context: std::fmt::Arguments<'_>,
+) {
+    log::warn!(
+        "Corrupted request detected ({context}). Setting device status to 'NEEDS_RESET' and stopping processing queues until reset."
+    );
+
+    device_status.fetch_or(DEVICE_NEEDS_RESET as u8, Ordering::SeqCst);
+
+    if let Err(e) = interrupt_cb.trigger(self::VirtioInterruptType::Config) {
+        log::error!("Failed to signal config interrupt: {e:?}");
+    }
+}
 
 const VIRTIO_F_RING_INDIRECT_DESC: u32 = 28;
 const VIRTIO_F_RING_EVENT_IDX: u32 = 29;

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -953,7 +953,7 @@ impl VirtioDevice for Mem {
             mem,
             interrupt_cb,
             mut queues,
-            ..
+            device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
         let (kill_evt, pause_evt) = self.common.dup_eventfds();
@@ -967,7 +967,7 @@ impl VirtioDevice for Mem {
             blocks_state: Arc::clone(&self.blocks_state),
             config: self.config.clone(),
             queue,
-            interrupt_cb,
+            interrupt_cb: interrupt_cb.clone(),
             queue_evt,
             kill_evt,
             pause_evt,
@@ -1000,6 +1000,8 @@ impl VirtioDevice for Mem {
             Thread::VirtioMem,
             &mut epoll_threads,
             &self.exit_evt,
+            device_status.clone(),
+            interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
         self.common.epoll_threads = Some(epoll_threads);

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -42,7 +42,7 @@ use super::{
 };
 use crate::seccomp_filters::Thread;
 use crate::thread_helper::spawn_virtio_thread;
-use crate::{GuestMemoryMmap, VirtioInterrupt};
+use crate::{GuestMemoryMmap, VirtioInterrupt, device_needs_reset, mark_device_needs_reset};
 
 /// Control queue
 // Event available on the control queue.
@@ -221,25 +221,16 @@ impl NetEpollHandler {
 
     fn handle_queue_iterator_error(&mut self, err: &virtio_queue::Error) {
         // The guest submitted a corrupted VirtQ request, and the error
-        // was logged during queue processing. We cannot just ignore the
-        // error, as the guest could continue spamming the VMM with bad
-        // requests, triggering excessive error logging. So we mark
-        // the device "NEEDS_RESET", effectively stopping all request
-        // processing (see self.needs_reset() usage) until the guest
-        // resets and reactivates the device.
-
-        warn!(
-            "Corrupted request detected (virtqueue error: {err:?}). \
-Setting device status to 'NEEDS_RESET' and stopping processing queues until reset."
+        // was logged during queue processing. Ignoring it would let the
+        // guest keep spamming the VMM with bad requests and trigger
+        // excessive error logging, so mark the device as NEEDS_RESET to
+        // stop request processing (see self.needs_reset() usage) until
+        // the guest resets and reactivates the device.
+        mark_device_needs_reset(
+            &self.device_status,
+            self.interrupt_cb.as_ref(),
+            format_args!("virtqueue error: {err:?}"),
         );
-
-        self.device_status
-            .fetch_or(crate::DEVICE_NEEDS_RESET as u8, Ordering::SeqCst);
-
-        // Let the guest know that the device status has changed.
-        if let Err(e) = self.interrupt_cb.trigger(VirtioInterruptType::Config) {
-            error!("Failed to signal config interrupt: {e:?}");
-        }
     }
 
     fn process_tx(&mut self) -> result::Result<(), DeviceError> {
@@ -343,7 +334,7 @@ Setting device status to 'NEEDS_RESET' and stopping processing queues until rese
     }
 
     fn needs_reset(&self) -> bool {
-        (self.device_status.load(Ordering::Acquire) & crate::DEVICE_NEEDS_RESET as u8) != 0
+        device_needs_reset(&self.device_status)
     }
 }
 

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -769,6 +769,8 @@ impl VirtioDevice for Net {
                 Thread::VirtioNetCtl,
                 &mut epoll_threads,
                 &self.exit_evt,
+                self.device_status.clone(),
+                interrupt_cb.clone(),
                 move || ctrl_handler.run_ctrl(&paused, paused_sync.as_ref().unwrap()),
             )?;
             self.ctrl_queue_epoll_thread = Some(epoll_threads.remove(0));
@@ -847,6 +849,8 @@ impl VirtioDevice for Net {
                 Thread::VirtioNet,
                 &mut epoll_threads,
                 &self.exit_evt,
+                self.device_status.clone(),
+                interrupt_cb.clone(),
                 move || handler.run(&paused, paused_sync.as_ref().unwrap()),
             )?;
         }

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -394,7 +394,7 @@ impl VirtioDevice for Pmem {
             mem,
             interrupt_cb,
             mut queues,
-            ..
+            device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
         let (kill_evt, pause_evt) = self.common.dup_eventfds();
@@ -410,7 +410,7 @@ impl VirtioDevice for Pmem {
                 mem,
                 queue,
                 disk,
-                interrupt_cb,
+                interrupt_cb: interrupt_cb.clone(),
                 queue_evt,
                 kill_evt,
                 pause_evt,
@@ -427,6 +427,8 @@ impl VirtioDevice for Pmem {
                 Thread::VirtioPmem,
                 &mut epoll_threads,
                 &self.exit_evt,
+                device_status.clone(),
+                interrupt_cb.clone(),
                 move || handler.run(&paused, paused_sync.as_ref().unwrap()),
             )?;
 

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -267,7 +267,7 @@ impl VirtioDevice for Rng {
             mem,
             interrupt_cb,
             mut queues,
-            ..
+            device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
         let (kill_evt, pause_evt) = self.common.dup_eventfds();
@@ -284,7 +284,7 @@ impl VirtioDevice for Rng {
                 mem,
                 queue,
                 random_file,
-                interrupt_cb,
+                interrupt_cb: interrupt_cb.clone(),
                 queue_evt,
                 kill_evt,
                 pause_evt,
@@ -300,6 +300,8 @@ impl VirtioDevice for Rng {
                 Thread::VirtioRng,
                 &mut epoll_threads,
                 &self.exit_evt,
+                device_status.clone(),
+                interrupt_cb.clone(),
                 move || handler.run(&paused, paused_sync.as_ref().unwrap()),
             )?;
 

--- a/virtio-devices/src/thread_helper.rs
+++ b/virtio-devices/src/thread_helper.rs
@@ -4,22 +4,27 @@
 //
 
 use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU8;
 use std::thread::{self, JoinHandle};
 
 use log::error;
 use seccompiler::{SeccompAction, apply_filter};
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::ActivateError;
 use crate::epoll_helper::EpollHelperError;
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
+use crate::{ActivateError, VirtioInterrupt, mark_device_needs_reset};
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn spawn_virtio_thread<F>(
     name: &str,
     seccomp_action: &SeccompAction,
     thread_type: Thread,
     epoll_threads: &mut Vec<JoinHandle<()>>,
     exit_evt: &EventFd,
+    device_status: Arc<AtomicU8>,
+    interrupt_cb: Arc<dyn VirtioInterrupt>,
     f: F,
 ) -> Result<(), ActivateError>
 where
@@ -49,12 +54,14 @@ where
                     error!("{thread_name} thread panicked");
                     thread_exit_evt.write(1).ok();
                 }
-                Ok(r) => {
-                    if let Err(e) = r {
-                        error!("Error running worker: {e:?}");
-                        thread_exit_evt.write(1).ok();
-                    }
+                Ok(Err(e)) => {
+                    mark_device_needs_reset(
+                        &device_status,
+                        interrupt_cb.as_ref(),
+                        format_args!("{thread_name}: worker exited with error: {e:?}"),
+                    );
                 }
+                Ok(Ok(())) => {}
             }
         })
         .map(|thread| epoll_threads.push(thread))

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -266,7 +266,7 @@ impl VirtioDevice for Blk {
             mem,
             interrupt_cb,
             queues,
-            ..
+            device_status,
         } = context;
         self.vu_common
             .virtio_common
@@ -282,7 +282,7 @@ impl VirtioDevice for Blk {
         let mut handler = self.vu_common.activate(
             mem,
             &queues,
-            interrupt_cb,
+            interrupt_cb.clone(),
             self.vu_common.virtio_common.acked_features,
             backend_req_handler,
             kill_evt,
@@ -300,6 +300,8 @@ impl VirtioDevice for Blk {
             Thread::VirtioVhostBlock,
             &mut epoll_threads,
             &self.exit_evt,
+            device_status.clone(),
+            interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
         self.vu_common.epoll_thread = Some(epoll_threads.remove(0));

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -245,7 +245,7 @@ impl VirtioDevice for Fs {
             mem,
             interrupt_cb,
             queues,
-            ..
+            device_status,
         } = context;
         self.vu_common
             .virtio_common
@@ -260,7 +260,7 @@ impl VirtioDevice for Fs {
         let mut handler = self.vu_common.activate(
             mem,
             &queues,
-            interrupt_cb,
+            interrupt_cb.clone(),
             self.vu_common.virtio_common.acked_features,
             backend_req_handler,
             kill_evt,
@@ -277,6 +277,8 @@ impl VirtioDevice for Fs {
             Thread::VirtioVhostFs,
             &mut epoll_threads,
             &self.exit_evt,
+            device_status.clone(),
+            interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
         self.vu_common.epoll_thread = Some(epoll_threads.remove(0));

--- a/virtio-devices/src/vhost_user/generic_vhost_user.rs
+++ b/virtio-devices/src/vhost_user/generic_vhost_user.rs
@@ -283,7 +283,7 @@ impl VirtioDevice for GenericVhostUser {
             mem,
             interrupt_cb,
             queues,
-            ..
+            device_status,
         } = context;
         self.vu_common
             .virtio_common
@@ -313,7 +313,7 @@ impl VirtioDevice for GenericVhostUser {
         let mut handler = self.vu_common.activate(
             mem,
             &queues,
-            interrupt_cb,
+            interrupt_cb.clone(),
             self.vu_common.virtio_common.acked_features,
             backend_req_handler,
             kill_evt,
@@ -330,6 +330,8 @@ impl VirtioDevice for GenericVhostUser {
             Thread::VirtioGenericVhostUser,
             &mut epoll_threads,
             &self.exit_evt,
+            device_status.clone(),
+            interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
         self.vu_common.epoll_thread = Some(epoll_threads.remove(0));

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -270,7 +270,7 @@ impl VirtioDevice for Net {
             mem,
             interrupt_cb,
             mut queues,
-            ..
+            device_status,
         } = context;
         self.vu_common
             .virtio_common
@@ -321,6 +321,8 @@ impl VirtioDevice for Net {
                 Thread::VirtioVhostNetCtl,
                 &mut epoll_threads,
                 &self.exit_evt,
+                device_status.clone(),
+                interrupt_cb.clone(),
                 move || ctrl_handler.run_ctrl(&paused, paused_sync.as_ref().unwrap()),
             )?;
             self.ctrl_queue_epoll_thread = Some(epoll_threads.remove(0));
@@ -340,7 +342,7 @@ impl VirtioDevice for Net {
         let mut handler = self.vu_common.activate(
             mem,
             &queues,
-            interrupt_cb,
+            interrupt_cb.clone(),
             backend_acked_features,
             backend_req_handler,
             kill_evt,
@@ -357,6 +359,8 @@ impl VirtioDevice for Net {
             Thread::VirtioVhostNet,
             &mut epoll_threads,
             &self.exit_evt,
+            device_status.clone(),
+            interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
         self.vu_common.epoll_thread = Some(epoll_threads.remove(0));

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -480,7 +480,7 @@ where
             mem,
             interrupt_cb,
             queues,
-            ..
+            device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
         let (kill_evt, pause_evt) = self.common.dup_eventfds();
@@ -498,7 +498,7 @@ where
             queue_evts,
             kill_evt,
             pause_evt,
-            interrupt_cb,
+            interrupt_cb: interrupt_cb.clone(),
             backend: self.backend.clone(),
             access_platform: self.common.access_platform(),
         };
@@ -513,6 +513,8 @@ where
             Thread::VirtioVsock,
             &mut epoll_threads,
             &self.exit_evt,
+            device_status.clone(),
+            interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
 

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -331,7 +331,7 @@ impl VirtioDevice for Watchdog {
             mem,
             interrupt_cb,
             mut queues,
-            ..
+            device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
         let (kill_evt, pause_evt) = self.common.dup_eventfds();
@@ -351,7 +351,7 @@ impl VirtioDevice for Watchdog {
         let mut handler = WatchdogEpollHandler {
             mem,
             queue,
-            interrupt_cb,
+            interrupt_cb: interrupt_cb.clone(),
             queue_evt,
             kill_evt,
             pause_evt,
@@ -370,6 +370,8 @@ impl VirtioDevice for Watchdog {
             Thread::VirtioWatchdog,
             &mut epoll_threads,
             &self.exit_evt,
+            device_status.clone(),
+            interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
 


### PR DESCRIPTION
A misbehaving guest can submit malformed descriptor chains or undersized buffers to the net device queues. The resulting errors propagated through the epoll handler, killing the worker thread and leaving the device WEDGED.

This series makes the net device resilient to guest misbehavior by handling errors gracefully at each layer. It covers the TAP rejection path where iteration succeeds but the packet is malformed and complements `563303b50` which covers the queue iterator failure path.

## TX path

- `writev` EINVAL (malformed `virtio_net_hdr`) drops the packet
- Short writes below `vnet_hdr_len` are logged and dropped

## RX path

- `readv` EINVAL (undersized buffer) returns len 0 to the used ring
- Short reads below `vnet_hdr_len` report truncated length to the guest

## Epoll handlers

- TX and RX handlers check `is_guest_error` and log instead of propagating
- Control queue handler catches processing failures

## Testing

- New `is_guest_error` classification with unit tests for all variants
- Error `Display` coverage and constructor sanity tests
- Unit tests cover only pure logic that does not require a TAP fd, guest memory or a virtio queue. The `process_desc_chain` paths call `libc::writev` and `libc::readv` directly on a kernel TAP fd and are not meaningfully unit testable without a full mock stack

## Notes

Analysis, patch decomposition and test design assisted by AI.

Assisted-by: GitHub Copilot:Claude-Opus-4.7