### PR TITLE
Add confidential VM support to performance metrics: Part 2(Final)

### DIFF
--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -139,7 +139,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
     let (rx, bandwidth) = control.net_control.unwrap();
 
     let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-    let guest = performance_test_new_guest(Box::new(focal), control);
+    let mut guest = performance_test_new_guest(Box::new(focal), control);
 
     let num_queues = control.num_queues.unwrap();
     let queue_size = control.queue_size.unwrap();
@@ -147,9 +147,9 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
         "tap=,mac={},ip={},mask=255.255.255.128,num_queues={},queue_size={}",
         guest.network.guest_mac0, guest.network.host_ip0, num_queues, queue_size,
     );
-
+    guest.num_cpu = num_queues;
     let mut child = GuestCommand::new(&guest)
-        .args(["--cpus", &format!("boot={num_queues}")])
+        .default_cpus()
         .args(["--memory", "size=4G"])
         .default_kernel_cmdline()
         .default_disks()
@@ -179,7 +179,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
 
 pub fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
     let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-    let guest = performance_test_new_guest(Box::new(focal), control);
+    let mut guest = performance_test_new_guest(Box::new(focal), control);
 
     let num_queues = control.num_queues.unwrap();
     let queue_size = control.queue_size.unwrap();
@@ -187,9 +187,9 @@ pub fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
         "tap=,mac={},ip={},mask=255.255.255.128,num_queues={},queue_size={}",
         guest.network.guest_mac0, guest.network.host_ip0, num_queues, queue_size,
     );
-
+    guest.num_cpu = num_queues;
     let mut child = GuestCommand::new(&guest)
-        .args(["--cpus", &format!("boot={num_queues}")])
+        .default_cpus()
         .args(["--memory", "size=4G"])
         .default_kernel_cmdline()
         .default_disks()
@@ -330,10 +330,7 @@ pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
         let mut cmd = GuestCommand::new(&guest);
 
         let c = cmd
-            .args([
-                "--cpus",
-                &format!("boot={}", control.num_boot_vcpus.unwrap_or(1)),
-            ])
+            .default_cpus()
             .args(["--memory", "size=1G"])
             .default_kernel_cmdline()
             .args(["--console", "off"])
@@ -356,10 +353,7 @@ pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
         let guest = performance_test_new_guest(Box::new(focal), control);
         let mut cmd = GuestCommand::new(&guest);
         let c = cmd
-            .args([
-                "--cpus",
-                &format!("boot={}", control.num_boot_vcpus.unwrap_or(1)),
-            ])
+            .default_cpus()
             .args(["--memory", "size=1G,hugepages=on"])
             .args(["--kernel", direct_kernel_boot_path().to_str().unwrap()])
             .args(["--cmdline", "root=/dev/pmem0p1 console=ttyS0 quiet rw"])
@@ -394,7 +388,7 @@ pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
     let test_file = block_control.test_file;
 
     let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-    let guest = performance_test_new_guest(Box::new(focal), control);
+    let mut guest = performance_test_new_guest(Box::new(focal), control);
     let api_socket = guest
         .tmp_dir
         .as_path()
@@ -418,9 +412,9 @@ pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
     } else if test_file == BLK_IO_TEST_IMG {
         test_disk_arg.push_str(",image_type=raw");
     }
-
+    guest.num_cpu = num_queues;
     let mut child = GuestCommand::new(&guest)
-        .args(["--cpus", &format!("boot={num_queues}")])
+        .default_cpus()
         .args(["--memory", "size=4G"])
         .default_kernel_cmdline()
         .args([
@@ -547,10 +541,7 @@ pub fn performance_restore_latency(control: &PerformanceTestControl) -> f64 {
 
         let mut child = GuestCommand::new(&guest)
             .args(["--api-socket", &api_socket_source])
-            .args([
-                "--cpus",
-                &format!("boot={}", control.num_boot_vcpus.unwrap_or(1)),
-            ])
+            .default_cpus()
             .args(["--memory", "size=256M"])
             .default_kernel_cmdline()
             .args(["--console", "off"])

--- a/performance-metrics/src/performance_tests.rs
+++ b/performance-metrics/src/performance_tests.rs
@@ -120,9 +120,13 @@ pub fn cleanup_tests() {
 // private network. The default constructor "Guest::new()" does not work
 // well, as we can easily create more than 256 VMs from repeating various
 // performance tests dozens times in a single run.
-fn performance_test_new_guest(disk_config: Box<dyn DiskConfig>, vm_type: GuestVmType) -> Guest {
+fn performance_test_new_guest(
+    disk_config: Box<dyn DiskConfig>,
+    control: &PerformanceTestControl,
+) -> Guest {
     let mut guest = Guest::new_from_ip_range(disk_config, "172.19", 0);
-    if vm_type == GuestVmType::Confidential {
+    guest.num_cpu = control.num_boot_vcpus.unwrap_or(1) as u32;
+    if control.vm_type == GuestVmType::Confidential {
         guest.vm_type = GuestVmType::Confidential;
         guest.boot_timeout = DEFAULT_CVM_TCP_LISTENER_TIMEOUT;
         guest.nested = false;
@@ -135,7 +139,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
     let (rx, bandwidth) = control.net_control.unwrap();
 
     let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-    let guest = performance_test_new_guest(Box::new(focal), control.vm_type);
+    let guest = performance_test_new_guest(Box::new(focal), control);
 
     let num_queues = control.num_queues.unwrap();
     let queue_size = control.queue_size.unwrap();
@@ -175,7 +179,7 @@ pub fn performance_net_throughput(control: &PerformanceTestControl) -> f64 {
 
 pub fn performance_net_latency(control: &PerformanceTestControl) -> f64 {
     let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-    let guest = performance_test_new_guest(Box::new(focal), control.vm_type);
+    let guest = performance_test_new_guest(Box::new(focal), control);
 
     let num_queues = control.num_queues.unwrap();
     let queue_size = control.queue_size.unwrap();
@@ -322,7 +326,7 @@ fn measure_boot_time(cmd: &mut GuestCommand, test_timeout: u32) -> Result<f64, E
 pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-        let guest = performance_test_new_guest(Box::new(focal), control.vm_type);
+        let guest = performance_test_new_guest(Box::new(focal), control);
         let mut cmd = GuestCommand::new(&guest);
 
         let c = cmd
@@ -349,7 +353,7 @@ pub fn performance_boot_time(control: &PerformanceTestControl) -> f64 {
 pub fn performance_boot_time_pmem(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-        let guest = performance_test_new_guest(Box::new(focal), control.vm_type);
+        let guest = performance_test_new_guest(Box::new(focal), control);
         let mut cmd = GuestCommand::new(&guest);
         let c = cmd
             .args([
@@ -390,7 +394,7 @@ pub fn performance_block_io(control: &PerformanceTestControl) -> f64 {
     let test_file = block_control.test_file;
 
     let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-    let guest = performance_test_new_guest(Box::new(focal), control.vm_type);
+    let guest = performance_test_new_guest(Box::new(focal), control);
     let api_socket = guest
         .tmp_dir
         .as_path()
@@ -531,7 +535,7 @@ fn measure_restore_time(
 pub fn performance_restore_latency(control: &PerformanceTestControl) -> f64 {
     let r = std::panic::catch_unwind(|| {
         let focal = UbuntuDiskConfig::new(FOCAL_IMAGE_NAME.to_string());
-        let guest = performance_test_new_guest(Box::new(focal), control.vm_type);
+        let guest = performance_test_new_guest(Box::new(focal), control);
         let api_socket_source = String::from(
             guest
                 .tmp_dir

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -234,6 +234,14 @@ copy_igvm_files() {
     fi
 }
 
+# Prepare the IGVM files needed for the confidential VM integration
+# tests. Copies the IGVM files from the source path to the workloads
+# directory.
+prepare_igvm_files() {
+    mkdir -p "$DEST_IGVM_FILES_PATH"
+    copy_igvm_files "$SRC_IGVM_FILES_PATH" "$DEST_IGVM_FILES_PATH"
+}
+
 cmd_help() {
     echo ""
     echo "Cloud Hypervisor $(basename "$0")"
@@ -266,6 +274,7 @@ cmd_help() {
     echo "        --coverage                   Generate code coverage information"
     echo "        --volumes                    Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
     echo "        --hypervisor                 Underlying hypervisor. Options kvm, mshv"
+    echo "        --vm-type                    Type of VM to run. Options regular, confidential"
     echo "        --all                        Run all tests."
     echo ""
     echo "    build-container [--type]"
@@ -434,6 +443,12 @@ cmd_tests() {
             unit=true
             integration=true
         } ;;
+        "--vm-type")
+            shift
+            [[ "$1" =~ ^(regular|confidential)$ ]] ||
+                die "Invalid VM type: $1. Valid options are \"regular\" and \"confidential\"."
+            vm_type="$1"
+            ;;
         "--") {
             shift
             break
@@ -549,6 +564,7 @@ cmd_tests() {
         --env CH_CUSTOM_BZIMAGE="$CH_CUSTOM_BZIMAGE"
         --env CH_CUSTOM_FIRMWARE="$CH_CUSTOM_FIRMWARE"
         --env CH_CUSTOM_OVMF="$CH_CUSTOM_OVMF"
+        --env VM_TYPE="$vm_type"
     )
 
     if [ "$integration" = true ]; then
@@ -564,8 +580,7 @@ cmd_tests() {
     fi
 
     if [ "$integration_cvm" = true ]; then
-        mkdir -p "$DEST_IGVM_FILES_PATH"
-        copy_igvm_files "$SRC_IGVM_FILES_PATH" "$DEST_IGVM_FILES_PATH"
+        prepare_igvm_files
         say "Running CVM integration tests for $target..."
         run_container "$DOCKER_RUNTIME" run \
             "${common_args[@]}" \
@@ -604,11 +619,17 @@ cmd_tests() {
     fi
 
     if [ "$metrics" = true ]; then
+        local igvm_volume_args=()
+        if [ "$vm_type" = "confidential" ]; then
+            prepare_igvm_files
+            igvm_volume_args=(--volume "$DEST_IGVM_FILES_PATH:$CTR_IGVM_FILES_PATH")
+        fi
         say "Generating performance metrics for $target..."
         run_container "$DOCKER_RUNTIME" run \
             "${common_args[@]}" \
             "${common_env_args[@]}" \
             --env RUST_BACKTRACE="${RUST_BACKTRACE}" \
+            "${igvm_volume_args[@]}" \
             "$CTR_IMAGE" \
             ./scripts/run_metrics.sh "$@" || fix_dir_perms $? || exit $?
     fi

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -28,6 +28,13 @@ build_fio() {
 
 process_common_args "$@"
 
+build_features="mshv"
+vm_type_arg=""
+if [ "$VM_TYPE" = "confidential" ]; then
+    build_features="mshv,igvm,sev_snp"
+    vm_type_arg="--vm-type confidential"
+fi
+
 cp scripts/sha1sums-"${TEST_ARCH}"-common "$WORKLOADS_DIR"
 
 if [ "${TEST_ARCH}" == "aarch64" ]; then
@@ -96,7 +103,7 @@ if [[ "${BUILD_TARGET}" == "${TEST_ARCH}-unknown-linux-musl" ]]; then
     CFLAGS="-I /usr/include/${TEST_ARCH}-linux-musl/ -idirafter /usr/include/"
 fi
 
-cargo build --features mshv --all --release --target "$BUILD_TARGET"
+cargo build --features "$build_features" --all --release --target "$BUILD_TARGET"
 
 # setup hugepages
 HUGEPAGESIZE=$(grep Hugepagesize /proc/meminfo | awk '{print $2}')
@@ -122,7 +129,7 @@ else
     echo "RUST_BACKTRACE is set to: $RUST_BACKTRACE_VALUE"
 fi
 # shellcheck disable=SC2048,SC2086
-time target/"$BUILD_TARGET"/release/performance-metrics ${test_binary_args[*]}
+time target/"$BUILD_TARGET"/release/performance-metrics $vm_type_arg ${test_binary_args[*]}
 RES=$?
 
 exit $RES


### PR DESCRIPTION
## Summary

This series adds support for running performance metrics with confidential VMs (SEV-SNP). A new `--vm-type` argument is introduced in the test infrastructure to control whether tests run with regular or confidential guests.

## Changes

- **scripts/dev_cli.sh**: Add `--vm-type` argument to the `tests` command, passing `VM_TYPE` to the container. Extract `prepare_igvm_files()` helper and conditionally mount IGVM volume for confidential metrics runs.
- **scripts/run_metrics.sh**: Use `VM_TYPE` environment variable to enable `igvm,sev_snp` features for confidential builds and pass `--vm-type confidential` to the performance-metrics binary.
- **performance-metrics/src/performance_tests.rs**: Refactor `performance_test_new_guest` to accept the full `PerformanceTestControl`, setting `guest.num_cpu` from the control struct. Replace explicit `--cpus boot=N` with `.default_cpus()` across all tests to ensure `nested=off` is correctly set for confidential VMs where nested virtualization is not supported.