### PR TITLE
vmm: skip mem region creation for zero length zones

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -689,33 +689,35 @@ impl MemoryManager {
                     ram_region_available_size
                 };
 
-                info!(
-                    "create ram region for zone {}, region_start: {:#x}, region_size: {:#x}",
-                    zone.id,
-                    region_start.raw_value(),
-                    region_size
-                );
-                let region = MemoryManager::create_ram_region(
-                    &zone.file,
-                    file_offset,
-                    region_start,
-                    region_size as usize,
-                    prefault.unwrap_or(zone.prefault),
-                    zone.shared,
-                    zone.hugepages,
-                    zone.hugepage_size,
-                    zone.host_numa_node,
-                    None,
-                    thp,
-                )?;
+                if region_size > 0 {
+                    info!(
+                        "create ram region for zone {}, region_start: {:#x}, region_size: {:#x}",
+                        zone.id,
+                        region_start.raw_value(),
+                        region_size
+                    );
+                    let region = MemoryManager::create_ram_region(
+                        &zone.file,
+                        file_offset,
+                        region_start,
+                        region_size as usize,
+                        prefault.unwrap_or(zone.prefault),
+                        zone.shared,
+                        zone.hugepages,
+                        zone.hugepage_size,
+                        zone.host_numa_node,
+                        None,
+                        thp,
+                    )?;
 
-                // Add region to the list of regions associated with the
-                // current memory zone.
-                if let Some(memory_zone) = memory_zones.get_mut(&zone.id) {
-                    memory_zone.regions.push(region.clone());
+                    // Add region to the list of regions associated with the
+                    // current memory zone.
+                    if let Some(memory_zone) = memory_zones.get_mut(&zone.id) {
+                        memory_zone.regions.push(region.clone());
+                    }
+
+                    mem_regions.push(region);
                 }
-
-                mem_regions.push(region);
 
                 if pull_next_zone {
                     // Get the next zone and reset the offset.


### PR DESCRIPTION
The default zone can be omitted by specifying size zero with the intention of supplying user-defined zones instead. An example of this can be seen in the command line below:

```
./target/release/cloud-hypervisor \
--serial tty \
--console off \
--memory size=0,hotplug_method=virtio-mem \
--memory-zone id=boot,size=1G,shared=true \
--memory-zone id=hotplug,size=0,hotplug_size=1G,shared=false,mergeable=true \
--numa guest_numa_id=0,memory_zones=boot,cpus=0 \
--numa guest_numa_id=1,memory_zones=hotplug \
--cpus boot=1 \
--disk path=/path/to/disk \
--kernel /path/to/kernel \
--cmdline "..." \
--api-socket /tmp/ch.sock
```

But this leads to an mmap() call with a zero length argument which fails:

```
cloud-hypervisor:   0.023298s: <main>
ERROR:/path/to/src/cloud-hypervisor/cloud-hypervisor/src/lib.rs:23
-- Fatal error: VmBoot(VmBoot(MemoryManager(GuestMemoryRegion(Mmap(Os {
    code: 22, kind: InvalidInput, message: "Invalid argument" })))))
Error: Cloud Hypervisor exited with the following chain of errors:
0: Error booting VM
1: The VM could not boot
2: Memory manager error
3: Err or from region creation
4: Invalid argument (os error 22)
```

Prevent this by only creating memory regions when the associated size is greater than zero.