### PR TITLE
vmm, ch-remote: Make snapshot memory export optional

### DIFF
--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -20,7 +20,7 @@ use api_client::{
 use clap::ArgAction;
 use clap::{Arg, ArgMatches, Command};
 use log::error;
-use option_parser::{ByteSized, ByteSizedParseError};
+use option_parser::{ByteSized, ByteSizedParseError, OptionParser, OptionParserError, Toggle};
 use thiserror::Error;
 use vmm::config::RestoreConfig;
 use vmm::vm_config::{
@@ -65,6 +65,8 @@ enum Error {
     AddVsockConfig(#[source] vmm::config::Error),
     #[error("Error parsing restore syntax")]
     Restore(#[source] vmm::config::Error),
+    #[error("Error parsing snapshot syntax")]
+    SnapshotConfig(#[source] OptionParserError),
     #[error("Error reading from stdin")]
     ReadingStdin(#[source] std::io::Error),
     #[error("Error reading from file")]
@@ -490,7 +492,7 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                     .unwrap()
                     .get_one::<String>("snapshot_config")
                     .unwrap(),
-            );
+            )?;
             simple_api_command(socket, "PUT", "snapshot", Some(&snapshot_config))
                 .map_err(Error::HttpApiClient)
         }
@@ -713,7 +715,7 @@ fn dbus_api_do_command(matches: &ArgMatches, proxy: &DBusApi1ProxyBlocking<'_>) 
                     .unwrap()
                     .get_one::<String>("snapshot_config")
                     .unwrap(),
-            );
+            )?;
             proxy.api_vm_snapshot(&snapshot_config)
         }
         Some("restore") => {
@@ -909,12 +911,37 @@ fn add_vsock_config(config: &str) -> Result<String, Error> {
     Ok(vsock_config)
 }
 
-fn snapshot_config(url: &str) -> String {
+fn snapshot_config(config: &str) -> Result<String, Error> {
+    if !config.starts_with("destination_url=") && !config.starts_with("include_memory=") {
+        let snapshot_config = vmm::api::VmSnapshotConfig {
+            destination_url: String::from(config),
+            include_memory: true,
+        };
+
+        return Ok(serde_json::to_string(&snapshot_config).unwrap());
+    }
+
+    let mut parser = OptionParser::new();
+    parser.add("destination_url").add("include_memory");
+    parser.parse(config).map_err(Error::SnapshotConfig)?;
+
+    let destination_url = parser.get("destination_url").ok_or_else(|| {
+        Error::SnapshotConfig(OptionParserError::InvalidSyntax(
+            "destination_url is required".to_string(),
+        ))
+    })?;
+    let include_memory = parser
+        .convert::<Toggle>("include_memory")
+        .map_err(Error::SnapshotConfig)?
+        .unwrap_or(Toggle(true))
+        .0;
+
     let snapshot_config = vmm::api::VmSnapshotConfig {
-        destination_url: String::from(url),
+        destination_url,
+        include_memory,
     };
 
-    serde_json::to_string(&snapshot_config).unwrap()
+    Ok(serde_json::to_string(&snapshot_config).unwrap())
 }
 
 fn restore_config(config: &str) -> Result<(String, Vec<i32>), Error> {
@@ -1144,7 +1171,7 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
             .arg(
                 Arg::new("snapshot_config")
                     .index(1)
-                    .help("<destination_url>"),
+                    .help("<destination_url> or destination_url=<url>,include_memory=on|off"),
             ),
     ]
     .to_vec()
@@ -1318,5 +1345,29 @@ mod unit_tests {
         for command in commands {
             assert_args_sorted(|| command.get_arguments());
         }
+    }
+
+    #[test]
+    fn test_snapshot_config_parse() {
+        let config = snapshot_config("file:///tmp/snapshot").unwrap();
+        let config: vmm::api::VmSnapshotConfig = serde_json::from_str(&config).unwrap();
+        assert_eq!(config.destination_url, "file:///tmp/snapshot");
+        assert!(config.include_memory);
+
+        let config = snapshot_config("https://example.com/snapshot?token=abc").unwrap();
+        let config: vmm::api::VmSnapshotConfig = serde_json::from_str(&config).unwrap();
+        assert_eq!(
+            config.destination_url,
+            "https://example.com/snapshot?token=abc"
+        );
+        assert!(config.include_memory);
+
+        let config =
+            snapshot_config("destination_url=file:///tmp/snapshot,include_memory=off").unwrap();
+        let config: vmm::api::VmSnapshotConfig = serde_json::from_str(&config).unwrap();
+        assert_eq!(config.destination_url, "file:///tmp/snapshot");
+        assert!(!config.include_memory);
+
+        snapshot_config("include_memory=off").unwrap_err();
     }
 }

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -35,6 +35,13 @@ using the following command:
 ./ch-remote --api-socket=/tmp/cloud-hypervisor.sock snapshot file:///home/foo/snapshot
 ```
 
+By default, the snapshot includes guest RAM in the `memory-ranges` file. To
+snapshot only the VM state and configuration, without exporting guest RAM:
+
+```bash
+./ch-remote --api-socket=/tmp/cloud-hypervisor.sock snapshot destination_url=file:///home/foo/snapshot,include_memory=off
+```
+
 Given the directory was present on the system, the snapshot will succeed and
 it should contain the following files:
 
@@ -59,6 +66,11 @@ be needed.
 
 `state.json` contains the virtual machine state. It is used to restore each
 component in the state it was left before the snapshot occurred.
+
+When `include_memory=off` is used, only `config.json` and `state.json` are
+written. Such a snapshot does not contain guest RAM contents and cannot be
+restored through the default memory restore path without an external source for
+guest memory.
 
 ## Restore a Cloud Hypervisor VM
 

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -100,7 +100,7 @@ impl RequestHandler for StubApiRequestHandler {
         Ok(())
     }
 
-    fn vm_snapshot(&mut self, _: &str) -> Result<(), VmError> {
+    fn vm_snapshot(&mut self, _: &str, _: bool) -> Result<(), VmError> {
         Ok(())
     }
 

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -253,10 +253,26 @@ pub struct VmRemoveDeviceData {
     pub id: String,
 }
 
-#[derive(Clone, Deserialize, Serialize, Default, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct VmSnapshotConfig {
     /// The snapshot destination URL
     pub destination_url: String,
+    /// Whether to export the guest memory contents
+    #[serde(default = "default_include_memory")]
+    pub include_memory: bool,
+}
+
+fn default_include_memory() -> bool {
+    true
+}
+
+impl Default for VmSnapshotConfig {
+    fn default() -> Self {
+        Self {
+            destination_url: String::default(),
+            include_memory: default_include_memory(),
+        }
+    }
 }
 
 #[derive(Clone, Deserialize, Serialize, Default, Debug)]
@@ -513,7 +529,7 @@ pub trait RequestHandler {
 
     fn vm_resume(&mut self) -> Result<(), VmError>;
 
-    fn vm_snapshot(&mut self, destination_url: &str) -> Result<(), VmError>;
+    fn vm_snapshot(&mut self, destination_url: &str, include_memory: bool) -> Result<(), VmError>;
 
     fn vm_restore(&mut self, restore_cfg: RestoreConfig) -> Result<(), VmError>;
 
@@ -1634,7 +1650,7 @@ impl ApiAction for VmSnapshot {
             info!("API request event: VmSnapshot {config:?}");
 
             let response = vmm
-                .vm_snapshot(&config.destination_url)
+                .vm_snapshot(&config.destination_url, config.include_memory)
                 .map_err(ApiError::VmSnapshot)
                 .map(|_| ApiResponsePayload::Empty);
 
@@ -1757,6 +1773,15 @@ impl ApiAction for VmNmi {
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+
+    #[test]
+    fn test_vm_snapshot_config_deserialize_default_memory() {
+        let config: VmSnapshotConfig =
+            serde_json::from_str(r#"{"destination_url":"file:///tmp/snapshot"}"#).unwrap();
+
+        assert_eq!(config.destination_url, "file:///tmp/snapshot");
+        assert!(config.include_memory);
+    }
 
     #[test]
     fn test_vm_send_migration_data_parse() {

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1386,6 +1386,10 @@ components:
       properties:
         destination_url:
           type: string
+        include_memory:
+          default: true
+          description: Export guest memory contents to memory-ranges.
+          type: boolean
 
     VmCoredumpData:
       type: object

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -41,7 +41,7 @@ use vm_memory::bitmap::AtomicBitmap;
 use vm_migration::protocol::*;
 use vm_migration::{
     MemoryMigrationContext, Migratable, MigratableError, OngoingMigrationContext, Pausable,
-    Snapshot, Snapshottable, Transportable,
+    Snapshot, Snapshottable,
 };
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::unblock_signal;
@@ -1905,14 +1905,18 @@ impl RequestHandler for Vmm {
         }
     }
 
-    fn vm_snapshot(&mut self, destination_url: &str) -> result::Result<(), VmError> {
+    fn vm_snapshot(
+        &mut self,
+        destination_url: &str,
+        include_memory: bool,
+    ) -> result::Result<(), VmError> {
         if let Some(ref mut vm) = self.vm {
             // Drain console_info so that FDs are not reused
             let _ = self.console_info.take();
             vm.snapshot()
                 .map_err(VmError::Snapshot)
                 .and_then(|snapshot| {
-                    vm.send(&snapshot, destination_url)
+                    vm.send_snapshot(&snapshot, destination_url, include_memory)
                         .map_err(VmError::SnapshotSend)
                 })
         } else {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3392,11 +3392,12 @@ impl Snapshottable for Vm {
     }
 }
 
-impl Transportable for Vm {
-    fn send(
+impl Vm {
+    pub(crate) fn send_snapshot(
         &self,
         snapshot: &Snapshot,
         destination_url: &str,
+        include_memory: bool,
     ) -> std::result::Result<(), MigratableError> {
         let mut snapshot_config_path = url_to_path(destination_url)?;
         snapshot_config_path.push(SNAPSHOT_CONFIG_FILE);
@@ -3436,6 +3437,10 @@ impl Transportable for Vm {
             .write(&vm_state)
             .map_err(|e| MigratableError::MigrateSend(e.into()))?;
 
+        if !include_memory {
+            return Ok(());
+        }
+
         // Tell the memory manager to also send/write its own snapshot.
         if let Some(memory_manager_snapshot) = snapshot.snapshots.get(MEMORY_MANAGER_SNAPSHOT_ID) {
             self.memory_manager
@@ -3449,6 +3454,16 @@ impl Transportable for Vm {
         }
 
         Ok(())
+    }
+}
+
+impl Transportable for Vm {
+    fn send(
+        &self,
+        snapshot: &Snapshot,
+        destination_url: &str,
+    ) -> std::result::Result<(), MigratableError> {
+        self.send_snapshot(snapshot, destination_url, true)
     }
 }
 


### PR DESCRIPTION
## Summary

Add an optional `include_memory` field to `VmSnapshotConfig`.

When `include_memory` is omitted or set to `true`, snapshot behavior is
unchanged and Cloud Hypervisor writes:

- `config.json`
- `state.json`
- `memory-ranges`

When `include_memory=false`, Cloud Hypervisor writes only:

- `config.json`
- `state.json`

and skips exporting guest RAM to `memory-ranges`.

## Motivation

The snapshot API currently always exports guest memory as part of the
snapshot. This remains the right default for full snapshot/restore.

Some users may manage guest memory contents separately and only need the VM
state files from Cloud Hypervisor. For those workflows, forcing a full
`memory-ranges` export can add unnecessary snapshot latency and disk I/O.

## Compatibility

This is backward compatible.

Existing API clients that omit `include_memory` continue to get the current
full snapshot behavior.

State-only snapshots do not contain guest RAM contents and cannot be restored
through the default memory restore path unless guest memory is provided by
another mechanism.

## Implementation

- Add `include_memory` to `VmSnapshotConfig`, defaulting to `true`.
- Pass `include_memory` through the snapshot API path.
- Allow the VM snapshot send path to skip guest memory export.
- Extend `ch-remote snapshot` to accept:
  `destination_url=<url>,include_memory=on|off`
- Update OpenAPI, docs, and the HTTP API fuzz stub.
