### PR TITLE
vm-allocator: gracefully free GSIs when no longer in use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2526,6 +2526,7 @@ version = "0.1.0"
 dependencies = [
  "arch",
  "libc",
+ "thiserror",
  "vm-memory",
 ]
 

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -339,7 +339,7 @@ pub trait Vm: Send + Sync + Any {
     ) -> Result<()>;
     /// Unregister an event from a certain address it has been previously registered to.
     fn unregister_ioevent(&self, fd: &EventFd, addr: &IoEventAddress) -> Result<()>;
-    // Construct a routing entry
+    /// Construct a routing entry
     fn make_routing_entry(&self, gsi: u32, config: &InterruptSourceConfig) -> IrqRoutingEntry;
     /// Sets the GSI routing table entries, overwriting any previously set
     fn set_gsi_routing(&self, entries: &[IrqRoutingEntry]) -> Result<()>;

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -11,6 +11,7 @@ kvm = ["arch/kvm"]
 
 [dependencies]
 libc = { workspace = true }
+thiserror = { workspace = true }
 vm-memory = { workspace = true }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]

--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -2,27 +2,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
-// Only for this commit
-#![expect(unused)]
+//! Interrupt-number allocation for interrupts.
+//!
+//! See [`GsiAllocator`].
 
 #[cfg(target_arch = "x86_64")]
 use std::collections::btree_map::BTreeMap;
+#[cfg(test)]
+use std::ops::Range;
 use std::result;
 
 use thiserror::Error;
 
-#[derive(Debug)]
-pub enum Error {
-    Overflow,
-}
+pub type Result<T> = result::Result<T, InterruptAllocError>;
 
-pub type Result<T> = result::Result<T, Error>;
-
-/// GsiApic
+/// Describes one APIC interrupt input range in the global system interrupt
+/// namespace.
 #[cfg(target_arch = "x86_64")]
 #[derive(Copy, Clone)]
 pub struct GsiApic {
+    /// The offset from 0.
     base: u32,
+    /// The number of interrupts in the range.
     irqs: u32,
 }
 
@@ -53,6 +54,39 @@ pub enum InterruptAllocError {
         u32, /* upper bound */
     ),
 }
+
+/// Maximum number of IRQ routes supported by KVM.
+///
+/// See <https://elixir.bootlin.com/linux/v7.0.1/source/include/linux/kvm_host.h#L2193>.
+const KVM_MAX_IRQ_ROUTES: u32 = {
+    #[cfg(feature = "kvm")]
+    {
+        4096
+    }
+    #[cfg(not(feature = "kvm"))]
+    {
+        0
+    }
+};
+
+/// Maximum number of IRQ routes supported by MSHV.
+///
+/// See <https://elixir.bootlin.com/linux/v7.0.1/source/drivers/hv/mshv_root.h#L170>.
+const MSHV_MAX_GUEST_IRQS: u32 = 4096;
+
+/// The effective max number of IRQs.
+///
+/// This affects the number of interrupts that can be allocated. This number
+/// alone doesn't mean that the backend necessarily accepts all the IRQs.
+#[allow(clippy::absurd_extreme_comparisons)]
+const MAX_GUEST_IRQS: u32 = {
+    // cmp::max is not const compatible
+    if KVM_MAX_IRQ_ROUTES > MSHV_MAX_GUEST_IRQS {
+        KVM_MAX_IRQ_ROUTES
+    } else {
+        MSHV_MAX_GUEST_IRQS
+    }
+};
 
 /// Simple bitmap-backed interrupt allocator.
 ///
@@ -110,7 +144,7 @@ impl InterruptAllocator {
     /// Allocates a vector by setting its bit in the bitmap.
     ///
     /// Returns an error if the allocator is exhausted.
-    fn alloc(&mut self) -> result::Result<u32, InterruptAllocError> {
+    fn alloc(&mut self) -> Result<u32> {
         // Find the next word with capacity for allocating a vector.
         let Some(idx) = self.words.iter().position(|&w| w != usize::MAX) else {
             return Err(InterruptAllocError::ExhaustedError(self.size));
@@ -134,7 +168,7 @@ impl InterruptAllocator {
     /// This vector is assumed to include the internal `offset`.
     ///
     /// Returns an error if the vector is already free.
-    fn free(&mut self, vector: u32) -> result::Result<(), InterruptAllocError> {
+    fn free(&mut self, vector: u32) -> Result<()> {
         // At first we make sure that the vector is not out of range.
         let begin = self.offset;
         let end = begin + self.size;
@@ -164,82 +198,96 @@ impl InterruptAllocator {
     fn size(&self) -> u32 {
         self.size
     }
+
+    #[cfg(test)]
+    fn range(&self) -> Range<u32> {
+        self.offset..(self.offset + self.size)
+    }
 }
 
-/// GsiAllocator
+/// Coordinates graceful resource allocation of IRQs and GSIs from the interrupt
+/// namespace.
+///
+/// Ensures that interrupt numbers either for IRQs or GSIs are not overlapping.
+///
+/// Check out the [module documentation](super::gsi) for more info.
 pub struct GsiAllocator {
     #[cfg(target_arch = "x86_64")]
-    apics: BTreeMap<u32, u32>,
-    next_irq: u32,
-    next_gsi: u32,
+    apics: BTreeMap<u32 /* base */, u32 /* number of interrupts */>,
+    irqs: InterruptAllocator,
+    gsis: InterruptAllocator,
 }
 
 impl GsiAllocator {
     #[cfg(target_arch = "x86_64")]
-    /// New GSI allocator
+    /// Creates a new GSI allocator with the proper interrupt number ranges
+    /// for IRQs and GSIs.
+    ///
+    /// Respects the provided [`GsiApic`]s
+    // On x86, the interrupt number space starts with IRQs and is followed by
+    // GSI.
     pub fn new(apics: &[GsiApic]) -> Self {
-        let mut allocator = GsiAllocator {
-            apics: BTreeMap::new(),
-            next_irq: 0xffff_ffff,
-            next_gsi: 0,
-        };
+        let next_irq = apics.iter().map(|apic| apic.base).min().unwrap_or(0);
 
-        for apic in apics {
-            if apic.base < allocator.next_irq {
-                allocator.next_irq = apic.base;
-            }
+        let next_gsi = apics
+            .iter()
+            .map(|apic| apic.base + apic.irqs)
+            .max()
+            .unwrap_or(0);
 
-            if apic.base + apic.irqs > allocator.next_gsi {
-                allocator.next_gsi = apic.base + apic.irqs;
-            }
+        let irqs = apics.iter().map(|apic| apic.irqs).sum();
 
-            allocator.apics.insert(apic.base, apic.irqs);
+        let allocator_apics = apics.iter().map(|apic| (apic.base, apic.irqs)).collect();
+
+        let gsis = MAX_GUEST_IRQS - next_gsi;
+
+        Self {
+            apics: allocator_apics,
+            irqs: InterruptAllocator::new(irqs, next_irq),
+            gsis: InterruptAllocator::new(gsis, next_gsi),
         }
-
-        allocator
     }
 
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-    /// New GSI allocator
+    /// New GSI allocator.
+    // On aarch 64 and riscv x86, the IRQs and GSIs use independent interrupt
+    // number namespaces.
     pub fn new() -> Self {
         GsiAllocator {
-            next_irq: arch::IRQ_BASE,
-            next_gsi: arch::IRQ_BASE,
+            irqs: InterruptAllocator::new(MAX_GUEST_IRQS - arch::IRQ_BASE, arch::IRQ_BASE),
+            gsis: InterruptAllocator::new(MAX_GUEST_IRQS - arch::IRQ_BASE, arch::IRQ_BASE),
         }
     }
 
     /// Allocate a GSI
     pub fn allocate_gsi(&mut self) -> Result<u32> {
-        let gsi = self.next_gsi;
-        self.next_gsi = self.next_gsi.checked_add(1).ok_or(Error::Overflow)?;
-        Ok(gsi)
+        self.gsis.alloc()
+    }
+
+    /// Frees a GSI
+    pub fn free_gsi(&mut self, vector: u32) -> Result<()> {
+        self.gsis.free(vector)
     }
 
     #[cfg(target_arch = "x86_64")]
     /// Allocate an IRQ
     pub fn allocate_irq(&mut self) -> Result<u32> {
-        let mut irq: u32 = 0;
+        let next_irq = self.irqs.alloc()?;
         for (base, irqs) in self.apics.iter() {
             // HACKHACK - This only works with 1 single IOAPIC...
-            if self.next_irq >= *base && self.next_irq < *base + *irqs {
-                irq = self.next_irq;
-                self.next_irq += 1;
+            if next_irq >= *base && next_irq < *base + *irqs {
+                return Ok(next_irq);
             }
         }
 
-        if irq == 0 {
-            return Err(Error::Overflow);
-        }
-
-        Ok(irq)
+        self.irqs.free(next_irq)?;
+        Err(InterruptAllocError::ExhaustedError(self.irqs.size()))
     }
 
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     /// Allocate an IRQ
     pub fn allocate_irq(&mut self) -> Result<u32> {
-        let irq = self.next_irq;
-        self.next_irq = self.next_irq.checked_add(1).ok_or(Error::Overflow)?;
-        Ok(irq)
+        self.irqs.alloc()
     }
 }
 
@@ -353,6 +401,108 @@ mod unit_tests {
                 let vector = i + allocator.offset;
                 allocator.free(vector).expect("should not be exhausted");
             }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    /// [`GsiAllocator`] tests for x86, where IRQs and GSIs are consecutive
+    /// in a single interrupt number namespace.
+    mod gsi_allocator {
+        use super::*;
+
+        fn single_apic_allocator() -> GsiAllocator {
+            // One IOAPIC: GSI 0..24 are pin-based IRQs, GSIs start after that.
+            GsiAllocator::new(&[GsiApic::new(5, 19)])
+        }
+
+        #[test]
+        fn test_allocator_uses_apic_irq_and_gsi_ranges() {
+            let mut allocator = single_apic_allocator();
+
+            assert_eq!(allocator.irqs.range(), 5..24);
+            assert_eq!(allocator.gsis.range(), 24..MAX_GUEST_IRQS);
+            assert_eq!(allocator.allocate_irq(), Ok(5));
+            assert_eq!(allocator.allocate_irq(), Ok(6));
+            assert_eq!(allocator.allocate_gsi(), Ok(24));
+            assert_eq!(allocator.allocate_gsi(), Ok(25));
+        }
+
+        #[test]
+        fn test_allocator_exhausts_irqs_at_apic_boundary() {
+            let mut allocator = single_apic_allocator();
+
+            for expected_irq in 5..24 {
+                assert_eq!(allocator.allocate_irq(), Ok(expected_irq));
+            }
+
+            assert_eq!(
+                allocator.allocate_irq(),
+                Err(InterruptAllocError::ExhaustedError(19))
+            );
+            assert_eq!(allocator.allocate_gsi(), Ok(24));
+        }
+
+        #[test]
+        fn test_allocator_can_free_and_reuse_gsis() {
+            let mut allocator = single_apic_allocator();
+
+            assert_eq!(
+                allocator.free_gsi(24),
+                Err(InterruptAllocError::AlreadyFree(24))
+            );
+
+            let gsi = allocator.allocate_gsi().unwrap();
+            assert_eq!(gsi, 24);
+
+            allocator.free_gsi(gsi).unwrap();
+            assert_eq!(allocator.allocate_gsi(), Ok(gsi));
+        }
+    }
+
+    /// [`GsiAllocator`] tests for aarch64 and RISC-V, where IRQs and GSIs
+    /// have independent interrupt number namespaces.
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    mod gsi_allocator {
+        use super::*;
+
+        fn single_apic_allocator() -> GsiAllocator {
+            GsiAllocator::new()
+        }
+
+        #[test]
+        fn test_allocator_uses_arch_irq_base() {
+            let mut allocator = single_apic_allocator();
+
+            assert_eq!(allocator.irqs.range(), ::arch::IRQ_BASE..MAX_GUEST_IRQS);
+            assert_eq!(allocator.gsis.range(), ::arch::IRQ_BASE..MAX_GUEST_IRQS);
+            assert_eq!(allocator.allocate_irq(), Ok(::arch::IRQ_BASE));
+            assert_eq!(allocator.allocate_irq(), Ok(::arch::IRQ_BASE + 1));
+            assert_eq!(allocator.allocate_gsi(), Ok(::arch::IRQ_BASE));
+            assert_eq!(allocator.allocate_gsi(), Ok(::arch::IRQ_BASE + 1));
+        }
+
+        #[test]
+        fn test_allocator_keeps_irq_and_gsi_namespaces_independent() {
+            let mut allocator = single_apic_allocator();
+
+            assert_eq!(allocator.allocate_irq(), Ok(::arch::IRQ_BASE));
+            assert_eq!(allocator.allocate_gsi(), Ok(::arch::IRQ_BASE));
+        }
+
+        #[test]
+        fn test_allocator_can_free_and_reuse_gsis() {
+            let mut allocator = single_apic_allocator();
+
+            assert_eq!(
+                allocator.free_gsi(::arch::IRQ_BASE),
+                Err(InterruptAllocError::AlreadyFree(::arch::IRQ_BASE))
+            );
+
+            let gsi = allocator.allocate_gsi().unwrap();
+            assert_eq!(gsi, ::arch::IRQ_BASE);
+
+            allocator.free_gsi(gsi).unwrap();
+            assert_eq!(allocator.allocate_gsi(), Ok(gsi));
         }
     }
 }

--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -2,9 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+// Only for this commit
+#![expect(unused)]
+
 #[cfg(target_arch = "x86_64")]
 use std::collections::btree_map::BTreeMap;
 use std::result;
+
+use thiserror::Error;
 
 #[derive(Debug)]
 pub enum Error {
@@ -26,6 +31,138 @@ impl GsiApic {
     /// New GSI APIC
     pub fn new(base: u32, irqs: u32) -> Self {
         GsiApic { base, irqs }
+    }
+}
+
+/// Errors that may happen while allocating or freeing an interrupt.
+#[derive(Error, Debug, PartialEq)]
+pub enum InterruptAllocError {
+    /// Interrupt allocator is exhausted, i.e. out of interrupt vectors.
+    #[error("Interrupt allocator is exhausted (capacity: {0})")]
+    ExhaustedError(u32 /* capacity/size */),
+
+    /// Tried to free an interrupt that wasn't allocated.
+    #[error("Interrupt was not allocated: {0}")]
+    AlreadyFree(u32 /* vector */),
+
+    /// Tried to free an interrupt that is not in range of the interrupt allocator.
+    #[error("Interrupt vector is out of range: {0} (range: [{1},{2}))")]
+    OutOfRange(
+        u32, /* vector */
+        u32, /* lower bound */
+        u32, /* upper bound */
+    ),
+}
+
+/// Simple bitmap-backed interrupt allocator.
+///
+/// The allocator can be configured with an offset. For example, to allocate
+/// interrupt vectors in the range `[512, 1024)`, use an offset of 512 and a
+/// size of 512.
+#[derive(Debug)]
+struct InterruptAllocator {
+    /// Backing store for bitmap.
+    words: Box<[usize]>,
+    /// The offset to start allocating interrupts from.
+    offset: u32,
+    /// Number of allocatable interrupt vectors starting at `offset`.
+    size: u32,
+}
+
+impl InterruptAllocator {
+    /// Creates a new allocator.
+    fn new(size: u32, offset: u32) -> Self {
+        assert_ne!(size, 0);
+        assert!(offset.checked_add(size).is_some());
+
+        let num_words = size.div_ceil(usize::BITS);
+        let num_words = usize::try_from(num_words).unwrap();
+        let mut words = vec![0; num_words].into_boxed_slice();
+        words[num_words - 1] = Self::last_word_mask(size);
+
+        Self {
+            words,
+            size,
+            offset,
+        }
+    }
+
+    /// Returns the mask of the last word, ensuring that no more than requested
+    /// interrupts can be allocated.
+    fn last_word_mask(size: u32) -> usize {
+        let rem = size % usize::BITS;
+
+        if rem == 0 { 0 } else { !((1 << rem) - 1) }
+    }
+
+    /// Returns word and bit indices for a given vector index.
+    fn word_and_bit(
+        vector: u32,
+    ) -> (
+        usize, /* index into `words` */
+        usize, /* index into `words[w]` */
+    ) {
+        let idx = usize::try_from(vector).unwrap();
+        let bits = usize::try_from(usize::BITS).unwrap();
+        (idx / bits, idx % bits)
+    }
+
+    /// Allocates a vector by setting its bit in the bitmap.
+    ///
+    /// Returns an error if the allocator is exhausted.
+    fn alloc(&mut self) -> result::Result<u32, InterruptAllocError> {
+        // Find the next word with capacity for allocating a vector.
+        let Some(idx) = self.words.iter().position(|&w| w != usize::MAX) else {
+            return Err(InterruptAllocError::ExhaustedError(self.size));
+        };
+        let word = &mut self.words[idx];
+
+        // Find lowest free bit.
+        let bit = (!*word).trailing_zeros() as usize;
+        // Set the bit.
+        *word |= 1 << bit;
+        // Calculate index, add offset and return.
+
+        let bits = usize::try_from(usize::BITS).unwrap();
+        let vector = idx * bits + bit;
+        let vector = u32::try_from(vector).unwrap();
+        Ok(vector + self.offset)
+    }
+
+    /// Frees a vector by clearing its bit in the bitmap.
+    ///
+    /// This vector is assumed to include the internal `offset`.
+    ///
+    /// Returns an error if the vector is already free.
+    fn free(&mut self, vector: u32) -> result::Result<(), InterruptAllocError> {
+        // At first we make sure that the vector is not out of range.
+        let begin = self.offset;
+        let end = begin + self.size;
+        if !(begin..end).contains(&vector) {
+            return Err(InterruptAllocError::OutOfRange(
+                vector,
+                self.offset,
+                self.offset + self.size,
+            ));
+        }
+
+        let idx = vector.abs_diff(self.offset);
+        let (w, b) = Self::word_and_bit(idx);
+        let mask = 1 << b;
+
+        // Let's first check whether the bit is set.
+        if self.words[w] & mask == 0 {
+            return Err(InterruptAllocError::AlreadyFree(vector));
+        }
+        // Clear the bit and we are done!
+        self.words[w] &= !mask;
+        Ok(())
+    }
+
+    /// Returns the capacity of vectors that can be allocated.
+    #[cfg(target_arch = "x86_64")]
+    fn size(&self) -> u32 {
+        self.size
     }
 }
 
@@ -110,5 +247,112 @@ impl GsiAllocator {
 impl Default for GsiAllocator {
     fn default() -> Self {
         GsiAllocator::new()
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    mod interrupt_allocator {
+        use super::*;
+
+        #[test]
+        // Checks that the allocator can only allocate as many vectors as configured.
+        fn test_allocator_respects_size() {
+            for size in [1, 8, 16, 32, 63, 64, 65, 128] {
+                let mut allocator = InterruptAllocator::new(size, 0);
+                for _ in 0..size {
+                    let _ = allocator.alloc().expect("should not be exhausted");
+                }
+                allocator.alloc().expect_err("should be exhausted");
+            }
+        }
+
+        #[test]
+        // Checks that the allocator starts allocating vectors at the given offset.
+        fn test_allocator_respects_offset() {
+            for offset in [0, 1, 2, 3, 8, 16, 32, 64, 77, 128] {
+                let mut allocator = InterruptAllocator::new(8, offset);
+                let vec = allocator.alloc().unwrap();
+                assert_eq!(offset, vec);
+                allocator.free(vec).unwrap();
+            }
+        }
+
+        #[test]
+        // Checks that the calculations in alloc and free are correct.
+        fn test_allocator_alloc_and_free_all_vectors() {
+            for size in [1, 3, 7, 8, 15, 16, 32, 63, 64, 65, 128, 4096] {
+                let mut allocator = InterruptAllocator::new(size, 0);
+                let mut num_vectors = 0;
+                while allocator.alloc().is_ok() {
+                    num_vectors += 1;
+                }
+                assert_eq!(size, num_vectors);
+                num_vectors -= 1;
+                loop {
+                    if let Err(e) = allocator.free(num_vectors) {
+                        println!("Could not free {num_vectors}: {e}");
+                        break;
+                    }
+                    if let Some(v) = num_vectors.checked_sub(1) {
+                        num_vectors = v;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+        #[test]
+        // Checks that freeing a vector that isn't allocated results in an error.
+        fn test_can_only_free_allocated_vectors() {
+            let mut allocator = InterruptAllocator::new(8, 0);
+            // Never-allocated vector.
+            assert_eq!(allocator.free(0), Err(InterruptAllocError::AlreadyFree(0)));
+            // Allocated then freed vector.
+            let vec = allocator.alloc().unwrap();
+            allocator.free(vec).unwrap();
+            assert_eq!(
+                allocator.free(vec),
+                Err(InterruptAllocError::AlreadyFree(vec))
+            );
+        }
+
+        #[test]
+        // Checks that freeing a vector that is not in range of the allocator results
+        // in an error.
+        fn test_can_only_free_vectors_in_range() {
+            let size = 8;
+            let offset = 16;
+            let mut allocator = InterruptAllocator::new(size, offset);
+            for _ in 0..size {
+                let _ = allocator.alloc().expect("should not be exhausted");
+            }
+            // Out of range above.
+            let vector_out_of_range = size + offset;
+            assert_eq!(
+                allocator.free(vector_out_of_range),
+                Err(InterruptAllocError::OutOfRange(
+                    vector_out_of_range,
+                    offset,
+                    offset + size
+                ))
+            );
+            // Out of range below.
+            assert_eq!(
+                allocator.free(offset - 1),
+                Err(InterruptAllocError::OutOfRange(
+                    offset - 1,
+                    offset,
+                    offset + size
+                ))
+            );
+            for i in 0..size {
+                let vector = i + allocator.offset;
+                allocator.free(vector).expect("should not be exhausted");
+            }
+        }
     }
 }

--- a/vm-allocator/src/lib.rs
+++ b/vm-allocator/src/lib.rs
@@ -17,9 +17,9 @@ pub mod page_size;
 mod system;
 
 pub use crate::address::AddressAllocator;
-pub use crate::gsi::GsiAllocator;
 #[cfg(target_arch = "x86_64")]
 pub use crate::gsi::GsiApic;
+pub use crate::gsi::{GsiAllocator, InterruptAllocError};
 pub use crate::system::SystemAllocator;
 mod memory_slot;
 pub use memory_slot::MemorySlotAllocator;

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -91,6 +91,11 @@ impl SystemAllocator {
         self.gsi_allocator.allocate_gsi()
     }
 
+    /// Frees the given GSI.
+    pub fn free_gsi(&mut self, vector: u32) -> Result<(), InterruptAllocError> {
+        self.gsi_allocator.free_gsi(vector)
+    }
+
     /// Reserves a section of `size` bytes of IO address space.
     pub fn allocate_io_addresses(
         &mut self,

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -10,9 +10,9 @@
 use vm_memory::{GuestAddress, GuestUsize};
 
 use crate::address::AddressAllocator;
-use crate::gsi::GsiAllocator;
 #[cfg(target_arch = "x86_64")]
 use crate::gsi::GsiApic;
+use crate::gsi::{GsiAllocator, InterruptAllocError};
 use crate::page_size::get_page_size;
 
 /// Manages allocating system resources such as address space and interrupt numbers.
@@ -31,17 +31,17 @@ use crate::page_size::get_page_size;
 ///           GuestAddress(0x10000000), 0x10000000,
 ///           #[cfg(target_arch = "x86_64")] &[GsiApic::new(5, 19)]).unwrap();
 ///   #[cfg(target_arch = "x86_64")]
-///   assert_eq!(allocator.allocate_irq(), Some(5));
+///   assert_eq!(allocator.allocate_irq(), Ok(5));
 ///   #[cfg(target_arch = "aarch64")]
-///   assert_eq!(allocator.allocate_irq(), Some(32));
+///   assert_eq!(allocator.allocate_irq(), Ok(32));
 ///   #[cfg(target_arch = "riscv64")]
-///   assert_eq!(allocator.allocate_irq(), Some(0));
+///   assert_eq!(allocator.allocate_irq(), Ok(0));
 ///   #[cfg(target_arch = "x86_64")]
-///   assert_eq!(allocator.allocate_irq(), Some(6));
+///   assert_eq!(allocator.allocate_irq(), Ok(6));
 ///   #[cfg(target_arch = "aarch64")]
-///   assert_eq!(allocator.allocate_irq(), Some(33));
+///   assert_eq!(allocator.allocate_irq(), Ok(33));
 ///   #[cfg(target_arch = "riscv64")]
-///   assert_eq!(allocator.allocate_irq(), Some(1));
+///   assert_eq!(allocator.allocate_irq(), Ok(1));
 ///   assert_eq!(allocator.allocate_platform_mmio_addresses(None, 0x1000, Some(0x1000)), Some(GuestAddress(0x1fff_f000)));
 ///
 /// ```
@@ -82,13 +82,13 @@ impl SystemAllocator {
     }
 
     /// Reserves the next available system irq number.
-    pub fn allocate_irq(&mut self) -> Option<u32> {
-        self.gsi_allocator.allocate_irq().ok()
+    pub fn allocate_irq(&mut self) -> Result<u32, InterruptAllocError> {
+        self.gsi_allocator.allocate_irq()
     }
 
     /// Reserves the next available GSI.
-    pub fn allocate_gsi(&mut self) -> Option<u32> {
-        self.gsi_allocator.allocate_gsi().ok()
+    pub fn allocate_gsi(&mut self) -> Result<u32, InterruptAllocError> {
+        self.gsi_allocator.allocate_gsi()
     }
 
     /// Reserves a section of `size` bytes of IO address space.

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -91,7 +91,7 @@ use virtio_devices::{
     AccessPlatformMapping, ActivateError, Block, Endpoint, IommuMapping, VdpaDmaMapping,
     VirtioMemMappingSource,
 };
-use vm_allocator::{AddressAllocator, SystemAllocator};
+use vm_allocator::{AddressAllocator, InterruptAllocError, SystemAllocator};
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, LegacyIrqGroupConfig, MsiIrqGroupConfig,
@@ -272,7 +272,7 @@ pub enum DeviceManagerError {
 
     /// Cannot allocate IRQ.
     #[error("Cannot allocate IRQ")]
-    AllocateIrq,
+    AllocateIrq(#[from] InterruptAllocError),
 
     /// Cannot configure the IRQ.
     #[error("Cannot configure the IRQ")]

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -19,32 +19,47 @@ use vmm_sys_util::eventfd::EventFd;
 /// Reuse std::io::Result to simplify interoperability among crates.
 type Result<T> = std::io::Result<T>;
 
+/// Per-interrupt routing state for an MSI/MSI-X vector.
+///
+/// A route lazily allocates one GSI when the interrupt is first unmasked, then
+/// reuses that same GSI for later routing updates until the route is dropped.
 struct InterruptRoute {
     gsi: Option<u32>,
     irq_fd: Option<EventFd>,
     registered: bool,
+    allocator: Arc<Mutex<SystemAllocator>>,
 }
 
 impl InterruptRoute {
-    fn new() -> Result<Self> {
+    fn new(allocator: Arc<Mutex<SystemAllocator>>) -> Result<Self> {
         // The irq_fd must be created eagerly because external components
         // (say, VFIO) need the fd at device initialization time via notifier().
-        Self::new_with_fd(Some(EventFd::new(libc::EFD_NONBLOCK)?))
+        Self::new_with_fd(Some(EventFd::new(libc::EFD_NONBLOCK)?), allocator)
     }
 
-    fn new_with_fd(irq_fd: Option<EventFd>) -> Result<Self> {
+    fn new_with_fd(
+        irq_fd: Option<EventFd>,
+        allocator: Arc<Mutex<SystemAllocator>>,
+    ) -> Result<Self> {
         Ok(InterruptRoute {
             gsi: None,
             irq_fd,
             registered: false,
+            allocator,
         })
     }
 
-    fn allocate_gsi(&mut self, allocator: &mut SystemAllocator) -> Result<u32> {
+    /// Allocates a GSI, if non was allocated yet.
+    ///
+    /// Repeated calls return a previously allocated GSI.
+    fn allocate_gsi(&mut self) -> Result<u32> {
         match self.gsi {
             Some(existing) => Ok(existing),
             None => {
-                let new_gsi = allocator
+                let new_gsi = self
+                    .allocator
+                    .lock()
+                    .unwrap()
                     .allocate_gsi()
                     .map_err(|e| io::Error::other(format!("Failed allocating new GSI: {e}")))?;
                 self.gsi = Some(new_gsi);
@@ -136,6 +151,20 @@ impl InterruptRoute {
     }
 }
 
+impl Drop for InterruptRoute {
+    fn drop(&mut self) {
+        if let Some(gsi) = self.gsi {
+            let mut allocator = self.allocator.lock().unwrap();
+            // This panics only if we have a programming error (two entities
+            // used the same interrupt and one was freed already). In these
+            // cases, VMM and the VM are likely to fail soon anyway.
+            allocator
+                .free_gsi(gsi)
+                .expect("previously allocated GSI should be in bounds and still allocated");
+        }
+    }
+}
+
 struct RoutingEntry {
     route: IrqRoutingEntry,
     masked: bool,
@@ -145,7 +174,6 @@ struct MsiInterruptGroup {
     vm: Arc<dyn hypervisor::Vm>,
     gsi_msi_routes: Arc<Mutex<HashMap<u32, RoutingEntry>>>,
     irq_routes: HashMap<InterruptIndex, Mutex<InterruptRoute>>,
-    allocator: Arc<Mutex<SystemAllocator>>,
 }
 
 impl MsiInterruptGroup {
@@ -153,13 +181,11 @@ impl MsiInterruptGroup {
         vm: Arc<dyn hypervisor::Vm>,
         gsi_msi_routes: Arc<Mutex<HashMap<u32, RoutingEntry>>>,
         irq_routes: HashMap<InterruptIndex, Mutex<InterruptRoute>>,
-        allocator: Arc<Mutex<SystemAllocator>>,
     ) -> Self {
         MsiInterruptGroup {
             vm,
             gsi_msi_routes,
             irq_routes,
-            allocator,
         }
     }
 
@@ -231,8 +257,7 @@ impl InterruptSourceGroup for MsiInterruptGroup {
                 }
             } else {
                 // Allocate a GSI when the interrupt vector is first unmasked
-                let mut allocator = self.allocator.lock().unwrap();
-                route.allocate_gsi(&mut allocator)?
+                route.allocate_gsi()?
             };
 
             let entry = RoutingEntry {
@@ -382,14 +407,13 @@ impl MsiInterruptManager {
         let mut irq_routes: HashMap<InterruptIndex, Mutex<InterruptRoute>> =
             HashMap::with_capacity(config.count as usize);
         for i in config.base..config.base + config.count {
-            irq_routes.insert(i, Mutex::new(InterruptRoute::new()?));
+            irq_routes.insert(i, Mutex::new(InterruptRoute::new(self.allocator.clone())?));
         }
 
         Ok(MsiInterruptGroup::new(
             self.vm.clone(),
             self.gsi_msi_routes.clone(),
             irq_routes,
-            self.allocator.clone(),
         ))
     }
 }
@@ -401,14 +425,13 @@ impl InterruptManager for MsiInterruptManager {
         let mut irq_routes: HashMap<InterruptIndex, Mutex<InterruptRoute>> =
             HashMap::with_capacity(config.count as usize);
         for i in config.base..config.base + config.count {
-            irq_routes.insert(i, Mutex::new(InterruptRoute::new()?));
+            irq_routes.insert(i, Mutex::new(InterruptRoute::new(self.allocator.clone())?));
         }
 
         Ok(Arc::new(MsiInterruptGroup::new(
             self.vm.clone(),
             self.gsi_msi_routes.clone(),
             irq_routes,
-            self.allocator.clone(),
         )))
     }
 
@@ -422,5 +445,83 @@ impl InterruptManager for MsiInterruptManager {
 
     fn destroy_group(&self, _group: Arc<dyn InterruptSourceGroup>) -> Result<()> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod interrupt_route {
+        #[cfg(target_arch = "x86_64")]
+        use vm_allocator::GsiApic;
+        use vm_memory::GuestAddress;
+
+        use super::*;
+
+        fn make_allocator() -> Arc<Mutex<SystemAllocator>> {
+            Arc::new(Mutex::new(
+                SystemAllocator::new(
+                    GuestAddress(0x1000_0000),
+                    0x1000_0000,
+                    GuestAddress(0x2000_0000),
+                    0x1000_0000,
+                    #[cfg(target_arch = "x86_64")]
+                    &[GsiApic::new(5, 19)],
+                )
+                .unwrap(),
+            ))
+        }
+
+        #[test]
+        fn test_allocate_gsi_on_same_route_is_idempotent() {
+            let allocator = make_allocator();
+            let mut route = InterruptRoute::new(allocator.clone()).unwrap();
+            let gsi1 = route.allocate_gsi().unwrap();
+            let gsi2 = route.allocate_gsi().unwrap();
+            assert_eq!(
+                gsi1, gsi2,
+                "repeated allocate_gsi on the same route must return the same GSI (as it uses the buffered value)"
+            );
+        }
+
+        #[test]
+        fn test_allocated_gsis_are_distinct_for_different_routes() {
+            let allocator = make_allocator();
+            let mut route1 = InterruptRoute::new(allocator.clone()).unwrap();
+            let mut route2 = InterruptRoute::new(allocator.clone()).unwrap();
+            let gsi1 = route1.allocate_gsi().unwrap();
+            let gsi2 = route2.allocate_gsi().unwrap();
+            assert_ne!(gsi1, gsi2, "two routes must receive distinct GSIs");
+        }
+
+        #[test]
+        // Test that a route can allocate a GSI, releases it on drop, and
+        // that a second route can then allocate the very same GSI.
+        fn test_drop_frees_gsi() {
+            let allocator = make_allocator();
+            let gsi = {
+                let mut route = InterruptRoute::new(allocator.clone()).unwrap();
+                route.allocate_gsi().unwrap()
+            }; // Drop reclaims the GSI.
+            let mut route2 = InterruptRoute::new(allocator.clone()).unwrap();
+            let gsi2 = route2.allocate_gsi().unwrap();
+            assert_eq!(gsi, gsi2, "dropped GSI should be reclaimed");
+        }
+
+        #[test]
+        fn test_drop_without_gsi_does_not_panic() {
+            // A route that never had a GSI allocated must drop cleanly.
+            drop(InterruptRoute::new(make_allocator()).unwrap());
+        }
+
+        #[test]
+        fn test_doesnt_run_out_of_gsis() {
+            // Would be exhausted at 4072 if GSIs are not freed
+            for _ in 0..5_000 {
+                let mut route = InterruptRoute::new(make_allocator()).unwrap();
+                route.allocate_gsi().expect("should allocate");
+            }
+        }
     }
 }

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -46,7 +46,7 @@ impl InterruptRoute {
             None => {
                 let new_gsi = allocator
                     .allocate_gsi()
-                    .ok_or_else(|| io::Error::other("Failed allocating new GSI"))?;
+                    .map_err(|e| io::Error::other(format!("Failed allocating new GSI: {e}")))?;
                 self.gsi = Some(new_gsi);
                 Ok(new_gsi)
             }

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -209,7 +209,7 @@ impl PciSegment {
                     .lock()
                     .unwrap()
                     .allocate_irq()
-                    .ok_or(DeviceManagerError::AllocateIrq)? as u8,
+                    .map_err(DeviceManagerError::AllocateIrq)? as u8,
             );
         }
 


### PR DESCRIPTION
# Problem

The old implementation used an ever monotonically increasing u32 counter
to allocate new GSIs. The counter increased every time a new GSI was
allocated, and freeing GSIs was not possible. Thus, Cloud Hypervisor
can run out of GSIs and panics. This currently happened at the 1024th
GSI [0]. Further, this caused the `KVM_SET_GSI_ROUTING` ioctl to carry
much more payload than needed.

# Design

This new implementation uses a bitmap for proper tracking of resources
and can gracefully free GSIs.



# Reproducer

```bash
#!/usr/bin/env bash

set +e

API_SOCKET=/tmp/chv1.sock
DISK_PATH=/tmp/tmp_raw_disk_chv
DISK_ID=tmpdisk
CYCLES=600

rm -rf "${DISK_PATH}"
truncate --size 1M "${DISK_PATH}"

for i in $(seq $CYCLES); do
    while true; do
        ch-remote --api-socket "${API_SOCKET}" info >/dev/null 2>&1
        if [ $? -eq 0 ]; then
            break
        fi
        echo "Waiting for CHV to spawn ..."
        sleep 0.1
    done

    echo "$i/$CYCLES"
    echo add-disk
    ch-remote --api-socket "${API_SOCKET}" add-disk path="${DISK_PATH}",id="${DISK_ID}"

    # The MMIO ACK to remove the device is not sync: we need to wait for the guest
    # to perform the operation. In that time window we can pause/resume.
    echo remove-device
    ch-remote --api-socket "${API_SOCKET}" remove-device "${DISK_ID}"

    sleep 0.05
done
```

ping @amphi 