### PR TITLE
hypervisor: kvm: improve logging for triple fault

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -125,6 +125,7 @@ use kvm_bindings::{KVM_X86_SW_PROTECTED_VM, KVMIO};
 #[cfg(target_arch = "x86_64")]
 use kvm_bindings::{Xsave as xsave2, kvm_xsave2};
 pub use kvm_ioctls::{self, Cap, Kvm, VcpuExit};
+use log::error;
 use thiserror::Error;
 use vfio_ioctls::VfioDeviceFd;
 #[cfg(target_arch = "x86_64")]
@@ -2334,7 +2335,15 @@ impl cpu::Vcpu for KvmVcpu {
                 #[cfg(target_arch = "x86_64")]
                 VcpuExit::IoapicEoi(vector) => Ok(cpu::VmExit::IoapicEoi(vector)),
                 #[cfg(target_arch = "x86_64")]
-                VcpuExit::Shutdown | VcpuExit::Hlt => Ok(cpu::VmExit::Reset),
+                VcpuExit::Shutdown => {
+                    error!("Guest likely triple-faulted");
+                    Ok(cpu::VmExit::Reset)
+                }
+                // Practically unlikely, as KVM emulates the LAPIC and therefore HLT
+                VcpuExit::Hlt => {
+                    error!("Received a HLT exit but KVM should handle this in kernel space");
+                    Ok(cpu::VmExit::Reset)
+                }
 
                 #[cfg(target_arch = "aarch64")]
                 VcpuExit::SystemEvent(event_type, flags) => {


### PR DESCRIPTION
When a triple fault happens [0], we now get at least a log message. This helps to better understand the root cause of sudden reboots.

Broader context: We experience reboots caused by triple faults in edk2 (6 months old as well as recent). They happen so early in the boot that one doesn't really see them without looking at the VMM log. An automatic system reset plus reboot often hides these situations - now they are at least more visible in the log.

[0] https://elixir.bootlin.com/linux/v6.18.6/source/arch/x86/kvm/x86.c#L11123

On-behalf-of: SAP philipp.schuster@sap.com