### PR TITLE
docs: update Ubuntu examples to Noble

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ it into a format that Cloud Hypervisor can use and a firmware to boot the image
 with.
 
 ```shell
-$ wget https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
-$ qemu-img convert -p -f qcow2 -O raw focal-server-cloudimg-amd64.img focal-server-cloudimg-amd64.raw
-$ wget https://github.com/cloud-hypervisor/rust-hypervisor-firmware/releases/download/0.4.2/hypervisor-fw
+$ wget https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img
+$ qemu-img convert -p -f qcow2 -O raw ubuntu-24.04-server-cloudimg-amd64.img ubuntu-24.04-server-cloudimg-amd64.raw
+$ wget https://github.com/cloud-hypervisor/edk2/releases/latest/download/CLOUDHV.fd
 ```
 
 The Ubuntu cloud images do not ship with a default password so it necessary to
@@ -153,8 +153,8 @@ interface will be enabled as per `network-config` details.
 $ sudo setcap cap_net_admin+ep ./cloud-hypervisor
 $ ./create-cloud-init.sh
 $ ./cloud-hypervisor \
-	--firmware ./hypervisor-fw \
-	--disk path=focal-server-cloudimg-amd64.raw path=/tmp/ubuntu-cloudinit.img \
+	--firmware ./CLOUDHV.fd \
+	--disk path=ubuntu-24.04-server-cloudimg-amd64.raw path=/tmp/ubuntu-cloudinit.img \
 	--cpus boot=4 \
 	--memory size=1024M \
 	--net "tap=,mac=,ip=,mask="
@@ -166,8 +166,8 @@ GRUB) is required then it necessary to switch to the serial console instead of
 
 ```shell
 $ ./cloud-hypervisor \
-	--kernel ./hypervisor-fw \
-	--disk path=focal-server-cloudimg-amd64.raw path=/tmp/ubuntu-cloudinit.img \
+	--kernel ./CLOUDHV.fd \
+	--disk path=ubuntu-24.04-server-cloudimg-amd64.raw path=/tmp/ubuntu-cloudinit.img \
 	--cpus boot=4 \
 	--memory size=1024M \
 	--net "tap=,mac=,ip=,mask=" \
@@ -183,9 +183,9 @@ to load a payload/bootitem(s):
 - Provide firmware
 - Provide kernel \[+ cmdline\]\ [+ initrd\]
 
-Please note that our Cloud Hypervisor firmware (`hypervisor-fw`) has a Xen PVH
-boot entry, therefore it can also be booted via the `--kernel` parameter, as 
-seen in some examples.
+Please note that firmware images with Cloud Hypervisor boot support, such as
+`hypervisor-fw` and `CLOUDHV.fd`, can also be booted via the `--kernel`
+parameter, as seen in some examples.
 
 ### Custom Kernel and Disk Image
 
@@ -218,10 +218,10 @@ For the disk image the same Ubuntu image as before can be used. This contains
 an `ext4` root filesystem.
 
 ```shell
-$ wget https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img # x86-64
-$ wget https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img # AArch64
-$ qemu-img convert -p -f qcow2 -O raw focal-server-cloudimg-amd64.img focal-server-cloudimg-amd64.raw # x86-64
-$ qemu-img convert -p -f qcow2 -O raw focal-server-cloudimg-arm64.img focal-server-cloudimg-arm64.raw # AArch64
+$ wget https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img # x86-64
+$ wget https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-arm64.img # AArch64
+$ qemu-img convert -p -f qcow2 -O raw ubuntu-24.04-server-cloudimg-amd64.img ubuntu-24.04-server-cloudimg-amd64.raw # x86-64
+$ qemu-img convert -p -f qcow2 -O raw ubuntu-24.04-server-cloudimg-arm64.img ubuntu-24.04-server-cloudimg-arm64.raw # AArch64
 ```
 
 #### Booting the guest VM
@@ -236,7 +236,7 @@ $ sudo setcap cap_net_admin+ep ./cloud-hypervisor
 $ ./create-cloud-init.sh
 $ ./cloud-hypervisor \
 	--kernel ./linux-cloud-hypervisor/arch/x86/boot/compressed/vmlinux.bin \
-	--disk path=focal-server-cloudimg-amd64.raw path=/tmp/ubuntu-cloudinit.img \
+	--disk path=ubuntu-24.04-server-cloudimg-amd64.raw path=/tmp/ubuntu-cloudinit.img \
 	--cmdline "console=hvc0 root=/dev/vda1 rw" \
 	--cpus boot=4 \
 	--memory size=1024M \
@@ -250,7 +250,7 @@ $ sudo setcap cap_net_admin+ep ./cloud-hypervisor
 $ ./create-cloud-init.sh
 $ ./cloud-hypervisor \
 	--kernel ./linux-cloud-hypervisor/arch/arm64/boot/Image \
-	--disk path=focal-server-cloudimg-arm64.raw path=/tmp/ubuntu-cloudinit.img \
+	--disk path=ubuntu-24.04-server-cloudimg-arm64.raw path=/tmp/ubuntu-cloudinit.img \
 	--cmdline "console=hvc0 root=/dev/vda1 rw" \
 	--cpus boot=4 \
 	--memory size=1024M \
@@ -266,7 +266,7 @@ $ ./cloud-hypervisor \
 	--kernel ./linux-cloud-hypervisor/arch/x86/boot/compressed/vmlinux.bin \
 	--console off \
 	--serial tty \
-	--disk path=focal-server-cloudimg-amd64.raw \
+	--disk path=ubuntu-24.04-server-cloudimg-amd64.raw \
 	--cmdline "console=ttyS0 root=/dev/vda1 rw" \
 	--cpus boot=4 \
 	--memory size=1024M \
@@ -280,7 +280,7 @@ $ ./cloud-hypervisor \
 	--kernel ./linux-cloud-hypervisor/arch/arm64/boot/Image \
 	--console off \
 	--serial tty \
-	--disk path=focal-server-cloudimg-arm64.raw \
+	--disk path=ubuntu-24.04-server-cloudimg-arm64.raw \
 	--cmdline "console=ttyAMA0 root=/dev/vda1 rw" \
 	--cpus boot=4 \
 	--memory size=1024M \
@@ -310,11 +310,10 @@ Currently the following items are **not** guaranteed across updates:
 
 Further details can be found in the [release documentation](docs/releases.md).
 
-As of 2023-01-03, the following cloud images are supported:
+As of 2026-05-06, the following cloud images are supported:
 
-- [Ubuntu Focal](https://cloud-images.ubuntu.com/focal/current/) (focal-server-cloudimg-{amd64,arm64}.img)
-- [Ubuntu Jammy](https://cloud-images.ubuntu.com/jammy/current/) (jammy-server-cloudimg-{amd64,arm64}.img)
-- [Ubuntu Noble](https://cloud-images.ubuntu.com/noble/current/) (noble-server-cloudimg-{amd64,arm64}.img)
+- [Ubuntu Jammy](https://cloud-images.ubuntu.com/releases/jammy/release/) (ubuntu-22.04-server-cloudimg-{amd64,arm64}.img)
+- [Ubuntu Noble](https://cloud-images.ubuntu.com/releases/noble/release/) (ubuntu-24.04-server-cloudimg-{amd64,arm64}.img)
 - [Fedora 36](https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/36/Cloud/) ([Fedora-Cloud-Base-36-1.5.x86_64.raw.xz](https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/36/Cloud/x86_64/images/) / [Fedora-Cloud-Base-36-1.5.aarch64.raw.xz](https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/36/Cloud/aarch64/images/))
 
 Direct kernel boot to userspace should work with a rootfs from most
@@ -387,8 +386,8 @@ are all equal and welcome means of contribution. See the
 
 ## Slack
 
-Get an [invite to our Slack channel](https://join.slack.com/t/cloud-hypervisor/shared_invite/enQtNjY3MTE3MDkwNDQ4LWQ1MTA1ZDVmODkwMWQ1MTRhYzk4ZGNlN2UwNTI3ZmFlODU0OTcwOWZjMTkwZDExYWE3YjFmNzgzY2FmNDAyMjI),
- [join us on Slack](https://cloud-hypervisor.slack.com/), and [participate in our community activities](https://cloud-hypervisor.slack.com/archives/C04R5DUQVBN).
+Join us on [Slack](https://cloud-hypervisor.slack.com/) and
+[participate in our community activities](https://cloud-hypervisor.slack.com/archives/C04R5DUQVBN).
 
 ## Mailing list
 


### PR DESCRIPTION
## Summary
Update the README examples from Ubuntu Focal daily images to Ubuntu Noble release images, and use the current `CLOUDHV.fd` release asset for firmware boot.

## Changes
- Replace Focal image download/conversion examples with Noble release images for x86-64 and AArch64.
- Point firmware boot examples at the latest Cloud Hypervisor EDK2 `CLOUDHV.fd` asset.
- Remove Focal from the supported Ubuntu cloud image list.

Closes #7067