### PR TITLE
block: preserve async queue push errors

### DIFF
--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -69,7 +69,9 @@ impl AsyncIo for RawFileAsync {
                     .build()
                     .user_data(user_data),
             )
-            .map_err(|_| AsyncIoError::ReadVectored(Error::other("Submission queue is full")))?;
+            .map_err(|e| {
+                AsyncIoError::ReadVectored(Error::other(format!("Submission queue is full: {e:?}")))
+            })?;
         };
 
         // Update the submission queue and submit new operations to the
@@ -97,7 +99,11 @@ impl AsyncIo for RawFileAsync {
                     .build()
                     .user_data(user_data),
             )
-            .map_err(|_| AsyncIoError::WriteVectored(Error::other("Submission queue is full")))?;
+            .map_err(|e| {
+                AsyncIoError::WriteVectored(Error::other(format!(
+                    "Submission queue is full: {e:?}"
+                )))
+            })?;
         };
 
         // Update the submission queue and submit new operations to the
@@ -119,7 +125,9 @@ impl AsyncIo for RawFileAsync {
                         .build()
                         .user_data(user_data),
                 )
-                .map_err(|_| AsyncIoError::Fsync(Error::other("Submission queue is full")))?;
+                .map_err(|e| {
+                    AsyncIoError::Fsync(Error::other(format!("Submission queue is full: {e:?}")))
+                })?;
             };
 
             // Update the submission queue and submit new operations to the
@@ -169,8 +177,10 @@ impl AsyncIo for RawFileAsync {
                             .build()
                             .user_data(req.user_data),
                         )
-                        .map_err(|_| {
-                            AsyncIoError::ReadVectored(Error::other("Submission queue is full"))
+                        .map_err(|e| {
+                            AsyncIoError::ReadVectored(Error::other(format!(
+                                "Submission queue is full: {e:?}"
+                            )))
                         })?;
                     };
                     submitted = true;
@@ -189,8 +199,10 @@ impl AsyncIo for RawFileAsync {
                             .build()
                             .user_data(req.user_data),
                         )
-                        .map_err(|_| {
-                            AsyncIoError::WriteVectored(Error::other("Submission queue is full"))
+                        .map_err(|e| {
+                            AsyncIoError::WriteVectored(Error::other(format!(
+                                "Submission queue is full: {e:?}"
+                            )))
                         })?;
                     };
                     submitted = true;


### PR DESCRIPTION
## Summary
Preserve the underlying io_uring submission queue push error in raw async I/O paths instead of dropping it behind a generic full-queue message.

## Changes
- Include the push error details for read/write/fsync queueing failures.
- Match the existing punch-hole/write-zeroes handling style in the same file.

Refs #7563