### PR TITLE
vmm: create memfd for private mappings

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1932,8 +1932,8 @@ impl MemoryManager {
             mmap_flags |= libc::MAP_SHARED;
             Some(Self::create_anonymous_file(size, hugepages, hugepage_size)?)
         } else {
-            mmap_flags |= libc::MAP_PRIVATE | libc::MAP_ANONYMOUS;
-            None
+            mmap_flags |= libc::MAP_PRIVATE;
+            Some(Self::create_anonymous_file(size, hugepages, hugepage_size)?)
         };
 
         let region = MmapRegion::build(fo, size, libc::PROT_READ | libc::PROT_WRITE, mmap_flags)


### PR DESCRIPTION
User-defined zones may be mapped private. Create a memfd for private zones so that fallocate operations are available on all regions, not just shared ones. This prepares for zone management via hole punching.

The MAP_ANONYMOUS flag is now omitted since the memory becomes file-backed.