### PR TITLE
tests: remove redundant hotplug sleep

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -8013,7 +8013,6 @@ mod snapshot_restore_common {
                     "remove-device",
                     Some(net_id),
                 ));
-                thread::sleep(std::time::Duration::new(10, 0));
                 let latest_events = [&MetaEvent {
                     event: "device-removed".to_string(),
                     device_id: Some(net_id.to_string()),


### PR DESCRIPTION
## Summary
Remove a fixed sleep from the snapshot/restore hotplug test path that already waits for the exact device removal event through the event monitor.

## Changes
- Drop the 10-second sleep before polling for `device-removed` in `test_snapshot_restore` hotplug coverage.

Refs #5127