### PR TITLE
virtio-devices: AI-assisted spec compliance changes

### DIFF
--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -357,11 +357,21 @@ impl BalloonEpollHandler {
             let mut descs_len = 0;
             while let Some(desc) = desc_chain.next() {
                 descs_len += desc.len();
-                let addr = desc
+                let addr = match desc
                     .addr()
                     .translate_gva(self.access_platform.as_deref(), desc.len() as usize)
-                    .map_err(|e| Error::GuestMemory(GuestMemoryError::IOError(e)))?;
-                Self::release_memory_range(desc_chain.memory(), addr, desc.len() as usize)?;
+                {
+                    Ok(a) => a,
+                    Err(e) => {
+                        warn!("Failed to translate reporting descriptor address: {e}");
+                        continue;
+                    }
+                };
+                if let Err(e) =
+                    Self::release_memory_range(desc_chain.memory(), addr, desc.len() as usize)
+                {
+                    warn!("Failed to release reported memory range: {e}");
+                }
             }
 
             self.queues[queue_index]

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -322,7 +322,7 @@ impl BalloonEpollHandler {
             }
 
             self.queues[queue_index]
-                .add_used(desc_chain.memory(), desc_chain.head_index(), desc.len())
+                .add_used(desc_chain.memory(), desc_chain.head_index(), 0)
                 .map_err(Error::QueueAddUsed)?;
             used_descs = true;
         }

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -81,8 +81,6 @@ pub enum Error {
     InvalidQueueIndex(usize),
     #[error("Failed to signal")]
     FailedSignal(#[source] io::Error),
-    #[error("Descriptor chain is too short")]
-    DescriptorChainTooShort,
     #[error("Failed adding used index")]
     QueueAddUsed(#[source] virtio_queue::Error),
 }
@@ -274,50 +272,54 @@ impl BalloonEpollHandler {
         while let Some(mut desc_chain) =
             self.queues[queue_index].pop_descriptor_chain(self.mem.memory())
         {
-            let desc = desc_chain.next().ok_or(Error::DescriptorChainTooShort)?;
-
             let data_chunk_size = size_of::<u32>();
 
-            // The head contains the request type which MUST be readable.
-            if desc.is_write_only() {
-                error!("The head contains the request type is not right");
-                return Err(Error::UnexpectedWriteOnlyDescriptor);
-            }
-            if !(desc.len() as usize).is_multiple_of(data_chunk_size) {
-                error!("the request size {} is not right", desc.len());
-                return Err(Error::InvalidRequest);
-            }
+            while let Some(desc) = desc_chain.next() {
+                if desc.is_write_only() {
+                    error!("Unexpected device-writable descriptor on inflate/deflate queue");
+                    return Err(Error::UnexpectedWriteOnlyDescriptor);
+                }
+                if !(desc.len() as usize).is_multiple_of(data_chunk_size) {
+                    error!("Descriptor length {} is not a multiple of {data_chunk_size}", desc.len());
+                    return Err(Error::InvalidRequest);
+                }
 
-            let mut offset = 0u64;
-            while offset < desc.len() as u64 {
-                let addr = desc
-                    .addr()
-                    .checked_add(offset)
-                    .unwrap()
-                    .translate_gva(self.access_platform.as_deref(), data_chunk_size)
-                    .map_err(|e| Error::GuestMemory(GuestMemoryError::IOError(e)))?;
-                let pfn: u32 = desc_chain
-                    .memory()
-                    .read_obj(addr)
-                    .map_err(Error::GuestMemory)?;
-                offset += data_chunk_size as u64;
+                let mut offset = 0u64;
+                while offset < desc.len() as u64 {
+                    let addr = desc
+                        .addr()
+                        .checked_add(offset)
+                        .unwrap()
+                        .translate_gva(self.access_platform.as_deref(), data_chunk_size)
+                        .map_err(|e| Error::GuestMemory(GuestMemoryError::IOError(e)))?;
+                    let pfn: u32 = desc_chain
+                        .memory()
+                        .read_obj(addr)
+                        .map_err(Error::GuestMemory)?;
+                    offset += data_chunk_size as u64;
 
-                match queue_index {
-                    0 => {
-                        Self::release_memory_range_4k(&mut self.pbp, desc_chain.memory(), pfn)?;
+                    match queue_index {
+                        0 => {
+                            Self::release_memory_range_4k(
+                                &mut self.pbp,
+                                desc_chain.memory(),
+                                pfn,
+                            )?;
+                        }
+                        1 => {
+                            let page_size = get_page_size() as usize;
+                            let rbase =
+                                align_page_size_down((pfn as u64) << VIRTIO_BALLOON_PFN_SHIFT);
+
+                            Self::advise_memory_range(
+                                desc_chain.memory(),
+                                vm_memory::GuestAddress(rbase),
+                                page_size,
+                                libc::MADV_WILLNEED,
+                            )?;
+                        }
+                        _ => return Err(Error::InvalidQueueIndex(queue_index)),
                     }
-                    1 => {
-                        let page_size = get_page_size() as usize;
-                        let rbase = align_page_size_down((pfn as u64) << VIRTIO_BALLOON_PFN_SHIFT);
-
-                        Self::advise_memory_range(
-                            desc_chain.memory(),
-                            vm_memory::GuestAddress(rbase),
-                            page_size,
-                            libc::MADV_WILLNEED,
-                        )?;
-                    }
-                    _ => return Err(Error::InvalidQueueIndex(queue_index)),
                 }
             }
 

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -77,18 +77,14 @@ pub enum Error {
     FallocateFail(#[source] std::io::Error),
     #[error("Madvise fail.")]
     MadviseFail(#[source] std::io::Error),
-    #[error("Failed to EventFd write.")]
-    EventFdWriteFail(#[source] std::io::Error),
     #[error("Invalid queue index: {0}")]
     InvalidQueueIndex(usize),
-    #[error("Fail tp signal")]
+    #[error("Failed to signal")]
     FailedSignal(#[source] io::Error),
     #[error("Descriptor chain is too short")]
     DescriptorChainTooShort,
     #[error("Failed adding used index")]
     QueueAddUsed(#[source] virtio_queue::Error),
-    #[error("Failed creating an iterator over the queue")]
-    QueueIterator(#[source] virtio_queue::Error),
 }
 
 // Got from include/uapi/linux/virtio_balloon.h
@@ -451,7 +447,7 @@ pub struct BalloonState {
     pub config: VirtioBalloonConfig,
 }
 
-// Virtio device for exposing entropy to the guest OS through virtio.
+// Virtio device for managing guest memory through a balloon.
 pub struct Balloon {
     common: VirtioCommon,
     id: String,

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -69,10 +69,6 @@ const VIRTIO_BALLOON_F_REPORTING: u64 = 5;
 pub enum Error {
     #[error("Guest gave us bad memory addresses.")]
     GuestMemory(#[source] GuestMemoryError),
-    #[error("Guest gave us a write only descriptor that protocol says to read from")]
-    UnexpectedWriteOnlyDescriptor,
-    #[error("Guest sent us invalid request")]
-    InvalidRequest,
     #[error("Fallocate fail.")]
     FallocateFail(#[source] std::io::Error),
     #[error("Madvise fail.")]
@@ -276,47 +272,64 @@ impl BalloonEpollHandler {
 
             while let Some(desc) = desc_chain.next() {
                 if desc.is_write_only() {
-                    error!("Unexpected device-writable descriptor on inflate/deflate queue");
-                    return Err(Error::UnexpectedWriteOnlyDescriptor);
+                    warn!("Skipping device-writable descriptor on inflate/deflate queue");
+                    continue;
                 }
                 if !(desc.len() as usize).is_multiple_of(data_chunk_size) {
-                    error!("Descriptor length {} is not a multiple of {data_chunk_size}", desc.len());
-                    return Err(Error::InvalidRequest);
+                    warn!(
+                        "Skipping descriptor with length {} not a multiple of {data_chunk_size}",
+                        desc.len()
+                    );
+                    continue;
                 }
 
                 let mut offset = 0u64;
                 while offset < desc.len() as u64 {
-                    let addr = desc
-                        .addr()
-                        .checked_add(offset)
-                        .unwrap()
+                    let Some(base) = desc.addr().checked_add(offset) else {
+                        warn!("Address overflow in balloon descriptor");
+                        break;
+                    };
+                    let addr = match base
                         .translate_gva(self.access_platform.as_deref(), data_chunk_size)
-                        .map_err(|e| Error::GuestMemory(GuestMemoryError::IOError(e)))?;
-                    let pfn: u32 = desc_chain
-                        .memory()
-                        .read_obj(addr)
-                        .map_err(Error::GuestMemory)?;
+                    {
+                        Ok(a) => a,
+                        Err(e) => {
+                            warn!("Failed to translate descriptor address: {e}");
+                            break;
+                        }
+                    };
+                    let pfn: u32 = match desc_chain.memory().read_obj(addr) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            warn!("Failed to read PFN from descriptor: {e}");
+                            break;
+                        }
+                    };
                     offset += data_chunk_size as u64;
 
                     match queue_index {
                         0 => {
-                            Self::release_memory_range_4k(
+                            if let Err(e) = Self::release_memory_range_4k(
                                 &mut self.pbp,
                                 desc_chain.memory(),
                                 pfn,
-                            )?;
+                            ) {
+                                warn!("Failed to release memory for PFN {pfn:#x}: {e}");
+                            }
                         }
                         1 => {
                             let page_size = get_page_size() as usize;
                             let rbase =
                                 align_page_size_down((pfn as u64) << VIRTIO_BALLOON_PFN_SHIFT);
 
-                            Self::advise_memory_range(
+                            if let Err(e) = Self::advise_memory_range(
                                 desc_chain.memory(),
                                 vm_memory::GuestAddress(rbase),
                                 page_size,
                                 libc::MADV_WILLNEED,
-                            )?;
+                            ) {
+                                warn!("Failed to advise memory for PFN {pfn:#x}: {e}");
+                            }
                         }
                         _ => return Err(Error::InvalidQueueIndex(queue_index)),
                     }

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -53,8 +53,6 @@ const VIRTIO_CONSOLE_F_SIZE: u64 = 0;
 enum Error {
     #[error("Failed to read from guest memory")]
     GuestMemoryRead(#[source] vm_memory::guest_memory::Error),
-    #[error("Failed to write to guest memory")]
-    GuestMemoryWrite(#[source] vm_memory::guest_memory::Error),
     #[error("Failed to write_all output")]
     OutputWriteAll(#[source] io::Error),
     #[error("Failed to flush output")]
@@ -217,22 +215,24 @@ impl ConsoleEpollHandler {
                     warn!("Skipping device-readable descriptor on receiveq");
                     continue;
                 }
-                let len = cmp::min(desc.len(), in_buffer.len() as u32);
-                let source_slice = in_buffer.drain(..len as usize).collect::<Vec<u8>>();
-
-                desc_chain
-                    .memory()
-                    .write_slice(
-                        &source_slice[..],
-                        desc.addr()
-                            .translate_gva(self.access_platform.as_deref(), desc.len() as usize)
-                            .map_err(|e| {
-                                Error::GuestMemoryWrite(vm_memory::GuestMemoryError::IOError(e))
-                            })?,
-                    )
-                    .map_err(Error::GuestMemoryWrite)?;
-
-                total_len += len;
+                let len = cmp::min(desc.len() as usize, in_buffer.len());
+                let addr = match desc
+                    .addr()
+                    .translate_gva(self.access_platform.as_deref(), desc.len() as usize)
+                {
+                    Ok(a) => a,
+                    Err(e) => {
+                        warn!("Failed to translate receiveq descriptor address: {e}");
+                        break;
+                    }
+                };
+                let source: Vec<u8> = in_buffer.range(..len).copied().collect();
+                if let Err(e) = desc_chain.memory().write_slice(&source, addr) {
+                    warn!("Failed to write to receiveq descriptor: {e}");
+                    break;
+                }
+                in_buffer.drain(..len);
+                total_len += len as u32;
             }
 
             recv_queue

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -12,7 +12,7 @@ use std::{cmp, io, result};
 use anyhow::anyhow;
 use event_monitor::event;
 use libc::{EFD_NONBLOCK, TIOCGWINSZ};
-use log::{error, info};
+use log::{error, info, warn};
 use seccompiler::SeccompAction;
 use serde::{Deserialize, Serialize};
 use serial_buffer::SerialBuffer;
@@ -212,6 +212,10 @@ impl ConsoleEpollHandler {
             while let Some(desc) = desc_chain.next() {
                 if in_buffer.is_empty() {
                     break;
+                }
+                if !desc.is_write_only() {
+                    warn!("Skipping device-readable descriptor on receiveq");
+                    continue;
                 }
                 let len = cmp::min(desc.len(), in_buffer.len() as u32);
                 let source_slice = in_buffer.drain(..len as usize).collect::<Vec<u8>>();

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -261,6 +261,10 @@ impl ConsoleEpollHandler {
 
         while let Some(mut desc_chain) = trans_queue.pop_descriptor_chain(self.mem.memory()) {
             while let Some(desc) = desc_chain.next() {
+                if desc.is_write_only() {
+                    warn!("Skipping device-writable descriptor on transmitq");
+                    continue;
+                }
                 if let Some(out) = &mut self.out {
                     let mut buf: Vec<u8> = Vec::new();
                     desc_chain

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -51,12 +51,6 @@ const VIRTIO_CONSOLE_F_SIZE: u64 = 0;
 
 #[derive(Error, Debug)]
 enum Error {
-    #[error("Failed to read from guest memory")]
-    GuestMemoryRead(#[source] vm_memory::guest_memory::Error),
-    #[error("Failed to write_all output")]
-    OutputWriteAll(#[source] io::Error),
-    #[error("Failed to flush output")]
-    OutputFlush(#[source] io::Error),
     #[error("Failed to add used index")]
     QueueAddUsed(#[source] virtio_queue::Error),
 }
@@ -266,21 +260,28 @@ impl ConsoleEpollHandler {
                     continue;
                 }
                 if let Some(out) = &mut self.out {
+                    let addr = match desc
+                        .addr()
+                        .translate_gva(self.access_platform.as_deref(), desc.len() as usize)
+                    {
+                        Ok(a) => a,
+                        Err(e) => {
+                            warn!("Failed to translate transmitq descriptor address: {e}");
+                            continue;
+                        }
+                    };
                     let mut buf: Vec<u8> = Vec::new();
-                    desc_chain
-                        .memory()
-                        .write_volatile_to(
-                            desc.addr()
-                                .translate_gva(self.access_platform.as_deref(), desc.len() as usize)
-                                .map_err(|e| {
-                                    Error::GuestMemoryRead(vm_memory::GuestMemoryError::IOError(e))
-                                })?,
-                            &mut buf,
-                            desc.len() as usize,
-                        )
-                        .map_err(Error::GuestMemoryRead)?;
-
-                    out.write_all(&buf).map_err(Error::OutputWriteAll)?;
+                    if let Err(e) =
+                        desc_chain
+                            .memory()
+                            .write_volatile_to(addr, &mut buf, desc.len() as usize)
+                    {
+                        warn!("Failed to read from transmitq descriptor: {e}");
+                        continue;
+                    }
+                    if let Err(e) = out.write_all(&buf) {
+                        warn!("Failed to write console output: {e}");
+                    }
                 }
             }
             trans_queue
@@ -289,8 +290,11 @@ impl ConsoleEpollHandler {
             used_descs = true;
         }
 
-        if used_descs && let Some(out) = &mut self.out {
-            out.flush().map_err(Error::OutputFlush)?;
+        if used_descs
+            && let Some(out) = &mut self.out
+            && let Err(e) = out.flush()
+        {
+            warn!("Failed to flush console output: {e}");
         }
 
         Ok(used_descs)

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -601,11 +601,9 @@ impl MemEpollHandler {
         let config = self.config.lock().unwrap();
         let size: u64 = nb_blocks as u64 * config.block_size;
 
-        let resp_type = if config.is_valid_range(addr, size) {
-            VIRTIO_MEM_RESP_ACK
-        } else {
-            VIRTIO_MEM_RESP_ERROR
-        };
+        if !config.is_valid_range(addr, size) {
+            return (VIRTIO_MEM_RESP_ERROR, 0);
+        }
 
         let offset = addr - config.addr;
         let first_block_index = (offset / config.block_size) as usize;
@@ -627,7 +625,7 @@ impl MemEpollHandler {
                 VIRTIO_MEM_STATE_MIXED
             };
 
-        (resp_type, resp_state)
+        (VIRTIO_MEM_RESP_ACK, resp_state)
     }
 
     fn signal(&self, int_type: VirtioInterruptType) -> result::Result<(), DeviceError> {

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -347,13 +347,8 @@ impl BlocksState {
         }
     }
 
-    fn is_range_state(&self, first_block_index: usize, nb_blocks: u16, plug: bool) -> bool {
-        for state in self
-            .bitmap
-            .iter()
-            .skip(first_block_index)
-            .take(nb_blocks as usize)
-        {
+    fn is_range_state(&self, first_block_index: usize, nb_blocks: usize, plug: bool) -> bool {
+        for state in self.bitmap.iter().skip(first_block_index).take(nb_blocks) {
             if *state != plug {
                 return false;
             }
@@ -361,12 +356,12 @@ impl BlocksState {
         true
     }
 
-    fn set_range(&mut self, first_block_index: usize, nb_blocks: u16, plug: bool) {
+    fn set_range(&mut self, first_block_index: usize, nb_blocks: usize, plug: bool) {
         for state in self
             .bitmap
             .iter_mut()
             .skip(first_block_index)
-            .take(nb_blocks as usize)
+            .take(nb_blocks)
         {
             *state = plug;
         }
@@ -509,12 +504,11 @@ impl MemEpollHandler {
         let offset = addr - config.addr;
 
         let first_block_index = (offset / config.block_size) as usize;
-        if !self
-            .blocks_state
-            .lock()
-            .unwrap()
-            .is_range_state(first_block_index, nb_blocks, !plug)
-        {
+        if !self.blocks_state.lock().unwrap().is_range_state(
+            first_block_index,
+            nb_blocks as usize,
+            !plug,
+        ) {
             return VIRTIO_MEM_RESP_ERROR;
         }
 
@@ -526,7 +520,7 @@ impl MemEpollHandler {
         self.blocks_state
             .lock()
             .unwrap()
-            .set_range(first_block_index, nb_blocks, plug);
+            .set_range(first_block_index, nb_blocks as usize, plug);
 
         let handlers = self.dma_mapping_handlers.lock().unwrap();
         if plug {
@@ -588,7 +582,7 @@ impl MemEpollHandler {
 
         self.blocks_state.lock().unwrap().set_range(
             0,
-            (config.region_size / config.block_size) as u16,
+            (config.region_size / config.block_size) as usize,
             false,
         );
 
@@ -607,23 +601,21 @@ impl MemEpollHandler {
 
         let offset = addr - config.addr;
         let first_block_index = (offset / config.block_size) as usize;
-        let resp_state =
-            if self
-                .blocks_state
-                .lock()
-                .unwrap()
-                .is_range_state(first_block_index, nb_blocks, true)
-            {
-                VIRTIO_MEM_STATE_PLUGGED
-            } else if self.blocks_state.lock().unwrap().is_range_state(
-                first_block_index,
-                nb_blocks,
-                false,
-            ) {
-                VIRTIO_MEM_STATE_UNPLUGGED
-            } else {
-                VIRTIO_MEM_STATE_MIXED
-            };
+        let resp_state = if self.blocks_state.lock().unwrap().is_range_state(
+            first_block_index,
+            nb_blocks as usize,
+            true,
+        ) {
+            VIRTIO_MEM_STATE_PLUGGED
+        } else if self.blocks_state.lock().unwrap().is_range_state(
+            first_block_index,
+            nb_blocks as usize,
+            false,
+        ) {
+            VIRTIO_MEM_STATE_UNPLUGGED
+        } else {
+            VIRTIO_MEM_STATE_MIXED
+        };
 
         (VIRTIO_MEM_RESP_ACK, resp_state)
     }

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -23,7 +23,7 @@ use std::{io, result};
 
 use anyhow::anyhow;
 use event_monitor::event;
-use log::{error, info};
+use log::{error, info, warn};
 use seccompiler::SeccompAction;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -654,7 +654,8 @@ impl MemEpollHandler {
                 VIRTIO_MEM_REQ_UNPLUG_ALL => (self.unplug_all(), 0u16),
                 VIRTIO_MEM_REQ_STATE => self.state_request(r.req.addr, r.req.nb_blocks),
                 _ => {
-                    return Err(Error::UnknownRequestType(r.req.req_type));
+                    warn!("Unknown request type: {}", r.req.req_type);
+                    (VIRTIO_MEM_RESP_ERROR, 0u16)
                 }
             };
             let len = r.send_response(desc_chain.memory(), resp_type, resp_state)?;

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -631,7 +631,17 @@ impl MemEpollHandler {
         let mut used_descs = false;
 
         while let Some(mut desc_chain) = self.queue.pop_descriptor_chain(self.mem.memory()) {
-            let r = Request::parse(&mut desc_chain)?;
+            let r = match Request::parse(&mut desc_chain) {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!("Failed to parse virtio-mem request: {e}");
+                    self.queue
+                        .add_used(desc_chain.memory(), desc_chain.head_index(), 0)
+                        .map_err(Error::QueueAddUsed)?;
+                    used_descs = true;
+                    continue;
+                }
+            };
             let (resp_type, resp_state) = match r.req.req_type {
                 VIRTIO_MEM_REQ_PLUG => (
                     self.state_change_request(r.req.addr, r.req.nb_blocks, true),

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeMap;
 use std::mem::size_of;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Barrier, Mutex, mpsc};
+use std::sync::{Arc, Barrier, Mutex};
 use std::{io, result};
 
 use anyhow::anyhow;
@@ -115,16 +115,8 @@ pub enum Error {
     BufferLengthTooSmall,
     #[error("Guest sent us invalid request")]
     InvalidRequest,
-    #[error("Failed to EventFd write")]
-    EventFdWriteFail(#[source] std::io::Error),
-    #[error("Failed to EventFd try_clone")]
-    EventFdTryCloneFail(#[source] std::io::Error),
-    #[error("Failed to MpscRecv")]
-    MpscRecvFail(#[source] mpsc::RecvError),
     #[error("Resize invalid argument")]
     ResizeError(#[source] anyhow::Error),
-    #[error("Fail to resize trigger")]
-    ResizeTriggerFail(#[source] DeviceError),
     #[error("Invalid configuration")]
     ValidateError(#[source] anyhow::Error),
     #[error("Failed discarding memory range")]
@@ -135,10 +127,6 @@ pub enum Error {
     DmaUnmap(#[source] std::io::Error),
     #[error("Invalid DMA mapping handler")]
     InvalidDmaMappingHandler,
-    #[error("Not activated by the guest")]
-    NotActivatedByGuest,
-    #[error("Unknown request type: {0}")]
-    UnknownRequestType(u16),
     #[error("Failed adding used index")]
     QueueAddUsed(#[source] virtio_queue::Error),
 }

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -15,7 +15,7 @@ use std::{io, result};
 
 use anyhow::anyhow;
 use event_monitor::event;
-use log::{error, info};
+use log::{error, info, warn};
 use seccompiler::SeccompAction;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -97,6 +97,7 @@ enum Error {
 #[derive(Debug, PartialEq, Eq)]
 enum RequestType {
     Flush,
+    Unknown(u32),
 }
 
 struct Request {
@@ -130,7 +131,7 @@ impl Request {
 
         let request_type = match request.type_ {
             VIRTIO_PMEM_REQ_TYPE_FLUSH => RequestType::Flush,
-            _ => return Err(Error::InvalidRequest),
+            t => RequestType::Unknown(t),
         };
 
         let status_desc = desc_chain.next().ok_or(Error::DescriptorChainTooShort)?;
@@ -170,11 +171,17 @@ impl PmemEpollHandler {
         let mut used_descs = false;
         while let Some(mut desc_chain) = self.queue.pop_descriptor_chain(self.mem.memory()) {
             let len = match Request::parse(&mut desc_chain, self.access_platform.as_deref()) {
-                Ok(ref req) if (req.type_ == RequestType::Flush) => {
-                    let status_code = match self.disk.sync_all() {
-                        Ok(()) => VIRTIO_PMEM_RESP_TYPE_OK,
-                        Err(e) => {
-                            error!("failed flushing disk image: {e}");
+                Ok(ref req) => {
+                    let status_code = match req.type_ {
+                        RequestType::Flush => match self.disk.sync_all() {
+                            Ok(()) => VIRTIO_PMEM_RESP_TYPE_OK,
+                            Err(e) => {
+                                error!("Failed flushing disk image: {e}");
+                                VIRTIO_PMEM_RESP_TYPE_EIO
+                            }
+                        },
+                        RequestType::Unknown(t) => {
+                            warn!("Unknown request type: {t}");
                             VIRTIO_PMEM_RESP_TYPE_EIO
                         }
                     };
@@ -184,21 +191,6 @@ impl PmemEpollHandler {
                         Ok(_) => size_of::<VirtioPmemResp>() as u32,
                         Err(e) => {
                             error!("bad guest memory address: {e}");
-                            0
-                        }
-                    }
-                }
-                Ok(ref req) => {
-                    // Currently, there is only one virtio-pmem request, FLUSH.
-                    error!("Invalid virtio request type {:?}", req.type_);
-                    // The virtio spec requires a status response even on error.
-                    let resp = VirtioPmemResp {
-                        ret: VIRTIO_PMEM_RESP_TYPE_EIO,
-                    };
-                    match desc_chain.memory().write_obj(resp, req.status_addr) {
-                        Ok(()) => size_of::<VirtioPmemResp>() as u32,
-                        Err(e) => {
-                            error!("Bad guest memory address: {e}");
                             0
                         }
                     }

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -64,14 +64,12 @@ impl RngEpollHandler {
             // report a used length of 0 to indicate failure.
             let mut total_len: usize = 0;
             while let Some(desc) = desc_chain.next() {
-                if !desc.is_write_only() || desc.len() == 0 {
-                    warn!(
-                        "Skipping descriptor with write_only={} len={}",
-                        desc.is_write_only(),
-                        desc.len()
-                    );
-                    total_len = 0;
-                    break;
+                if !desc.is_write_only() {
+                    warn!("Skipping device-readable descriptor");
+                    continue;
+                }
+                if desc.len() == 0 {
+                    continue;
                 }
                 let addr = match desc
                     .addr()

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -60,8 +60,6 @@ impl RngEpollHandler {
 
         let mut used_descs = false;
         while let Some(mut desc_chain) = queue.pop_descriptor_chain(self.mem.memory()) {
-            // virtio-rng has no status byte; on any error along the chain
-            // report a used length of 0 to indicate failure.
             let mut total_len: usize = 0;
             while let Some(desc) = desc_chain.next() {
                 if !desc.is_write_only() {
@@ -78,7 +76,6 @@ impl RngEpollHandler {
                     Ok(a) => a,
                     Err(e) => {
                         warn!("Failed to translate descriptor address: {e}");
-                        total_len = 0;
                         break;
                     }
                 };
@@ -90,7 +87,6 @@ impl RngEpollHandler {
                     Ok(written) => total_len += written,
                     Err(e) => {
                         warn!("Failed to read entropy into descriptor: {e}");
-                        total_len = 0;
                         break;
                     }
                 }


### PR DESCRIPTION
- **virtio-devices: rng: Skip device-readable descriptors instead of aborting chain**
- **virtio-devices: rng: Preserve already-written byte count on mid-chain errors**
- **virtio-devices: balloon: Fix typo, stale comment, and dead error variants**
- **virtio-devices: balloon: Report used length of 0 for inflate/deflate**
- **virtio-devices: balloon: Process all descriptors in inflate/deflate chains**
- **virtio-devices: balloon: Handle invalid inflate/deflate input without killing device**
- **virtio-devices: balloon: Handle reporting queue errors without killing device**
- **virtio-devices: mem: Respond to unknown request types instead of killing device**
- **virtio-devices: mem: Return early in state_request for invalid ranges**
- **virtio-devices: mem: Use usize for block counts in internal bitmap APIs**
- **virtio-devices: mem: Handle descriptor parse errors without killing device**
- **virtio-devices: mem: Remove dead error variants and unused import**
- **virtio-devices: console: Skip device-readable descriptors in input queue**
- **virtio-devices: console: Skip device-writable descriptors in output queue**
- **virtio-devices: console: Handle input queue errors without killing device**
- **virtio-devices: console: Handle output queue errors without killing device**
- **virtio-devices: pmem: Respond to unknown request types instead of dropping**
