### PR TITLE
build: Temporarily make VFIO job non-blocking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -739,7 +739,8 @@ jobs:
       - gitlint
       - hadolint
       - integration-arm64
-      - integration-vfio
+      # VFIO worker is failing #8160
+      # - integration-vfio
       - integration-windows
       - integration-x86-64-mq
       - integration-x86-64-pr


### PR DESCRIPTION
Don't block the CI passing if the VFIO integration tests fail.

Signed-off-by: Rob Bradford <rbradford@meta.com>
