### PR TITLE
tests: Make ovs setup idempotent

### DIFF
--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -337,6 +337,9 @@ pub(crate) fn setup_ovs_dpdk() {
     );
     assert!(exec_host_command_status("service openvswitch-switch restart").success());
 
+    // Clean up any stale bridge from a previous failed run
+    exec_host_command_status("ovs-vsctl --if-exists del-br ovsbr0");
+
     // Create OVS-DPDK bridge and ports
     assert!(
         exec_host_command_status(


### PR DESCRIPTION
Try and delete the bridge if it exists before setting up for the test.
This prevents cascading failures where if the test fails once any
subsequent run of the test will fail during the setup.

Signed-off-by: Rob Bradford <rbradford@meta.com>
