### PR TITLE
tests: Cleanup macvtap interfaces

### DIFF
--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -3271,6 +3271,12 @@ pub(crate) fn _test_macvtap(
 
     let phy_net = "eth0";
 
+    // Clean up any stale macvtap interfaces from previous test runs
+    exec_host_command_status(&format!(
+        "sudo ip link del {guest_macvtap_name} 2>/dev/null"
+    ));
+    exec_host_command_status(&format!("sudo ip link del {host_macvtap_name} 2>/dev/null"));
+
     // Create a macvtap interface for the guest VM to use
     assert!(
         exec_host_command_status(&format!(


### PR DESCRIPTION
Clean up the macvtap interfaces that may have been left from a previous
failed run. Failure to clean those up guarantees that the subsequent
test runs will fail.

Signed-off-by: Rob Bradford <rbradford@meta.com>
