### PR TITLE
virtio-devices: net, block: Drop per handler NEEDS_RESET bookkeeping

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -50,7 +50,7 @@ use super::{
 };
 use crate::seccomp_filters::Thread;
 use crate::thread_helper::spawn_virtio_thread;
-use crate::{GuestMemoryMmap, VirtioInterrupt, device_needs_reset, mark_device_needs_reset};
+use crate::{GuestMemoryMmap, VirtioInterrupt, device_needs_reset};
 
 const SECTOR_SHIFT: u8 = 9;
 pub const SECTOR_SIZE: u64 = 0x01 << SECTOR_SHIFT;
@@ -207,20 +207,6 @@ impl BlockEpollHandler {
         Ok(())
     }
 
-    fn handle_queue_iterator_error(&mut self, err: &virtio_queue::Error) {
-        // The guest submitted a corrupted VirtQ request, and the error
-        // was logged during queue processing. Ignoring it would let the
-        // guest keep spamming the VMM with bad requests and trigger
-        // excessive error logging, so mark the device as NEEDS_RESET to
-        // stop request processing (see self.needs_reset() usage) until
-        // the guest resets and reactivates the device.
-        mark_device_needs_reset(
-            &self.device_status,
-            self.interrupt_cb.as_ref(),
-            format_args!("virtqueue error: {err:?}"),
-        );
-    }
-
     fn process_queue_submit(&mut self) -> Result<()> {
         if self.needs_reset() {
             return Ok(());
@@ -238,15 +224,13 @@ impl BlockEpollHandler {
                 break;
             }
             processed += 1;
-            let mut desc_chain = match queue.iter(self.mem.memory()) {
-                Ok(mut iter) => match iter.next() {
-                    Some(c) => c,
-                    None => break,
-                },
-                Err(err) => {
-                    self.handle_queue_iterator_error(&err);
-                    return Ok(());
-                }
+            let mut desc_chain = match queue
+                .iter(self.mem.memory())
+                .map_err(Error::QueueIterator)?
+                .next()
+            {
+                Some(c) => c,
+                None => break,
             };
             let mut request = Request::parse(&mut desc_chain, self.access_platform.as_deref())
                 .map_err(Error::RequestParsing)?;
@@ -408,9 +392,20 @@ impl BlockEpollHandler {
     }
 
     fn process_queue_submit_and_signal(&mut self) -> result::Result<(), EpollHelperError> {
-        // Per-request errors are logged but non-device fatal.
-        if let Err(e) = self.process_queue_submit() {
-            warn!("Failed to process queue (submit): {e:?}");
+        match self.process_queue_submit() {
+            Ok(()) => {}
+            Err(e @ Error::QueueIterator(_)) => {
+                // Iterator errors mean the guest virtqueue itself is corrupted.
+                // Surface the failure so the worker exits and spawn_virtio_thread
+                // marks the device as NEEDS_RESET.
+                return Err(EpollHelperError::HandleEvent(anyhow!(
+                    "Failed to process queue (submit): {e:?}"
+                )));
+            }
+            Err(e) => {
+                // Per-request errors are logged but non-device fatal.
+                warn!("Failed to process queue (submit): {e:?}");
+            }
         }
 
         self.try_signal_used_queue()

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -50,7 +50,7 @@ use super::{
 };
 use crate::seccomp_filters::Thread;
 use crate::thread_helper::spawn_virtio_thread;
-use crate::{GuestMemoryMmap, VirtioInterrupt, device_needs_reset};
+use crate::{GuestMemoryMmap, VirtioInterrupt};
 
 const SECTOR_SHIFT: u8 = 9;
 pub const SECTOR_SIZE: u64 = 0x01 << SECTOR_SHIFT;
@@ -165,7 +165,6 @@ struct BlockEpollHandler {
     host_cpus: Option<Vec<usize>>,
     acked_features: u64,
     disable_sector0_writes: bool,
-    device_status: Arc<AtomicU8>,
 }
 
 fn has_feature(features: u64, feature_flag: u64) -> bool {
@@ -173,10 +172,6 @@ fn has_feature(features: u64, feature_flag: u64) -> bool {
 }
 
 impl BlockEpollHandler {
-    fn needs_reset(&self) -> bool {
-        device_needs_reset(&self.device_status)
-    }
-
     fn check_request(
         features: u64,
         request: &Request,
@@ -208,9 +203,6 @@ impl BlockEpollHandler {
     }
 
     fn process_queue_submit(&mut self) -> Result<()> {
-        if self.needs_reset() {
-            return Ok(());
-        }
         let queue = &mut self.queue;
         let queue_size = queue.size();
         let mut batch_requests = Vec::new();
@@ -433,9 +425,6 @@ impl BlockEpollHandler {
     }
 
     fn process_queue_complete(&mut self) -> Result<()> {
-        if self.needs_reset() {
-            return Ok(());
-        }
         let mem = self.mem.memory();
         let mut read_bytes = Wrapping(0);
         let mut write_bytes = Wrapping(0);
@@ -1142,7 +1131,6 @@ impl VirtioDevice for Block {
                 host_cpus: self.queue_affinity.get(&queue_idx).cloned(),
                 acked_features: self.common.acked_features,
                 disable_sector0_writes: self.disable_sector0_writes,
-                device_status: self.device_status.clone(),
             };
 
             let paused = self.common.paused.clone();

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -391,12 +391,12 @@ impl BlockEpollHandler {
                 // Surface the failure so the worker exits and spawn_virtio_thread
                 // marks the device as NEEDS_RESET.
                 return Err(EpollHelperError::HandleEvent(anyhow!(
-                    "Failed to process queue (submit): {e:?}"
+                    "Failed to process queue (submit): {e}"
                 )));
             }
             Err(e) => {
                 // Per-request errors are logged but non-device fatal.
-                warn!("Failed to process queue (submit): {e:?}");
+                warn!("Failed to process queue (submit): {e}");
             }
         }
 

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -70,15 +70,10 @@ const DEVICE_FEATURES_OK: u32 = 0x08;
 const DEVICE_NEEDS_RESET: u32 = 0x40;
 const DEVICE_FAILED: u32 = 0x80;
 
-/// Returns true if `device_status` has the `DEVICE_NEEDS_RESET` bit set.
-pub(crate) fn device_needs_reset(device_status: &AtomicU8) -> bool {
-    (device_status.load(Ordering::Acquire) & DEVICE_NEEDS_RESET as u8) != 0
-}
-
 /// Marks a virtio device as `NEEDS_RESET` and notifies the guest via a config
 /// change interrupt. Used when a guest induced error (corrupted virtqueue,
-/// malformed descriptor chain or similar) is detected and the device wants
-/// to stop further queue processing without killing the worker thread.
+/// malformed descriptor chain or similar) is detected and the worker thread
+/// has stopped processing the device's queues.
 ///
 /// `context` is included verbatim in the warning log to identify the cause.
 pub(crate) fn mark_device_needs_reset(

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -42,7 +42,7 @@ use super::{
 };
 use crate::seccomp_filters::Thread;
 use crate::thread_helper::spawn_virtio_thread;
-use crate::{GuestMemoryMmap, VirtioInterrupt, device_needs_reset, mark_device_needs_reset};
+use crate::{GuestMemoryMmap, VirtioInterrupt};
 
 /// Control queue
 // Event available on the control queue.
@@ -174,7 +174,6 @@ struct NetEpollHandler {
     queue_index_base: u16,
     queue_pair: (Queue, Queue),
     queue_evt_pair: (EventFd, EventFd),
-    device_status: Arc<AtomicU8>,
 }
 
 impl NetEpollHandler {
@@ -188,9 +187,6 @@ impl NetEpollHandler {
     }
 
     fn handle_rx_event(&mut self) -> result::Result<(), DeviceError> {
-        if self.needs_reset() {
-            return Ok(());
-        }
         let queue_evt = &self.queue_evt_pair.0;
         if let Err(e) = queue_evt.read() {
             error!("Failed to get rx queue event: {e:?}");
@@ -219,34 +215,13 @@ impl NetEpollHandler {
         Ok(())
     }
 
-    fn handle_queue_iterator_error(&mut self, err: &virtio_queue::Error) {
-        // The guest submitted a corrupted VirtQ request, and the error
-        // was logged during queue processing. Ignoring it would let the
-        // guest keep spamming the VMM with bad requests and trigger
-        // excessive error logging, so mark the device as NEEDS_RESET to
-        // stop request processing (see self.needs_reset() usage) until
-        // the guest resets and reactivates the device.
-        mark_device_needs_reset(
-            &self.device_status,
-            self.interrupt_cb.as_ref(),
-            format_args!("virtqueue error: {err:?}"),
-        );
-    }
-
     fn process_tx(&mut self) -> result::Result<(), DeviceError> {
-        if self.needs_reset() {
-            return Ok(());
-        }
         let res = self
             .net
-            .process_tx(&self.mem.memory(), &mut self.queue_pair.1);
+            .process_tx(&self.mem.memory(), &mut self.queue_pair.1)
+            .map_err(DeviceError::NetQueuePair)?;
 
-        if let Err(net_util::NetQueuePairError::QueueIteratorFailed(err)) = res {
-            self.handle_queue_iterator_error(&err);
-            return Ok(());
-        }
-
-        if res.map_err(DeviceError::NetQueuePair)? {
+        if res {
             self.signal_used_queue(self.queue_index_base + 1)?;
             debug!("Signalling TX queue");
         } else {
@@ -270,19 +245,12 @@ impl NetEpollHandler {
     }
 
     fn handle_rx_tap_event(&mut self) -> result::Result<(), DeviceError> {
-        if self.needs_reset() {
-            return Ok(());
-        }
         let res = self
             .net
-            .process_rx(&self.mem.memory(), &mut self.queue_pair.0);
+            .process_rx(&self.mem.memory(), &mut self.queue_pair.0)
+            .map_err(DeviceError::NetQueuePair)?;
 
-        if let Err(net_util::NetQueuePairError::QueueIteratorFailed(err)) = res {
-            self.handle_queue_iterator_error(&err);
-            return Ok(());
-        }
-
-        if res.map_err(DeviceError::NetQueuePair)? {
+        if res {
             self.signal_used_queue(self.queue_index_base)?;
             debug!("Signalling RX queue");
         } else {
@@ -331,10 +299,6 @@ impl NetEpollHandler {
         helper.run(paused, paused_sync, self)?;
 
         Ok(())
-    }
-
-    fn needs_reset(&self) -> bool {
-        device_needs_reset(&self.device_status)
     }
 }
 
@@ -837,7 +801,6 @@ impl VirtioDevice for Net {
                 interrupt_cb: interrupt_cb.clone(),
                 kill_evt,
                 pause_evt,
-                device_status: self.device_status.clone(),
             };
 
             let paused = self.common.paused.clone();


### PR DESCRIPTION
Follow up to #8142.

That PR centralized `DEVICE_NEEDS_RESET` in `spawn_virtio_thread`, which now marks the device as `NEEDS_RESET` and raises the config interrupt whenever a worker thread exits with an error. The per handler `needs_reset()` gates and `handle_queue_iterator_error()` helpers in `net` and `block` predate that change and are now redundant. With the central path in place the worker can die on virtqueue corruption and let `spawn_virtio_thread` do the rest.

This series removes the per handler bookkeeping. No functional change for the guest. `NEEDS_RESET` is still set and the config change interrupt is still raised on virtqueue corruption. The only difference is where it happens. Instead of the handler swallowing the error and keeping the worker spinning while gated by `needs_reset()`, the worker thread exits and `spawn_virtio_thread` does the marking.

Once `NEEDS_RESET` is signaled, the device stays parked. The worker thread is gone, no further queue processing happens and no more interrupts are raised on its behalf. The device remains in that state until the guest acknowledges the condition and reinitializes it through the standard virtio reset and feature negotiation sequence, at which point the regular activate path spawns a fresh worker.