### PR TITLE
vmm: add explicit PCI BDF support for console device

### DIFF
--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -32,9 +32,10 @@ use vmm::vm_config::FwCfgConfig;
 #[cfg(feature = "ivshmem")]
 use vmm::vm_config::IvshmemConfig;
 use vmm::vm_config::{
-    BalloonConfig, DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, LandlockConfig,
-    NetConfig, NumaConfig, PciSegmentConfig, PlatformConfig, PmemConfig, RateLimiterGroupConfig,
-    RngConfig, TpmConfig, UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
+    BalloonConfig, ConsoleConfig, DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig,
+    LandlockConfig, NetConfig, NumaConfig, PciSegmentConfig, PlatformConfig, PmemConfig,
+    RateLimiterGroupConfig, RngConfig, SerialConfig, TpmConfig, UserDeviceConfig, VdpaConfig,
+    VmConfig, VsockConfig,
 };
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::block_signal;
@@ -165,7 +166,7 @@ fn get_cli_options_sorted(
             .group("vm-config"),
         Arg::new("console")
             .long("console")
-            .help("Control (virtio) console: \"off|null|pty|tty|file=<path>,iommu=on|off\"")
+            .help(ConsoleConfig::SYNTAX)
             .default_value("tty")
             .group("vm-config"),
         Arg::new("cpus")
@@ -405,7 +406,7 @@ fn get_cli_options_sorted(
             .default_value("true"),
         Arg::new("serial")
             .long("serial")
-            .help("Control serial port: off|null|pty|tty|file=<path>|socket=<path>")
+            .help(SerialConfig::SYNTAX)
             .default_value("null")
             .group("vm-config"),
         Arg::new("tpm")
@@ -920,8 +921,9 @@ mod unit_tests {
     #[cfg(target_arch = "x86_64")]
     use vmm::vm_config::DebugConsoleConfig;
     use vmm::vm_config::{
-        ConsoleConfig, ConsoleOutputMode, CoreScheduling, CpuFeatures, CpusConfig, HotplugMethod,
-        MemoryConfig, PayloadConfig, PciDeviceCommonConfig, RngConfig, VmConfig,
+        CommonConsoleConfig, ConsoleConfig, ConsoleOutputMode, CoreScheduling, CpuFeatures,
+        CpusConfig, HotplugMethod, MemoryConfig, PayloadConfig, PciDeviceCommonConfig, RngConfig,
+        SerialConfig, VmConfig,
     };
 
     use crate::test_util::assert_args_sorted;
@@ -1010,17 +1012,21 @@ mod unit_tests {
             fs: None,
             generic_vhost_user: None,
             pmem: None,
-            serial: ConsoleConfig {
-                file: None,
-                mode: ConsoleOutputMode::Null,
+            serial: SerialConfig {
+                common: CommonConsoleConfig {
+                    file: None,
+                    mode: ConsoleOutputMode::Null,
+                    socket: None,
+                },
                 iommu: false,
-                socket: None,
             },
             console: ConsoleConfig {
-                file: None,
-                mode: ConsoleOutputMode::Tty,
+                common: CommonConsoleConfig {
+                    file: None,
+                    mode: ConsoleOutputMode::Tty,
+                    socket: None,
+                },
                 iommu: false,
-                socket: None,
             },
             #[cfg(target_arch = "x86_64")]
             debug_console: DebugConsoleConfig::default(),

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -1025,7 +1025,7 @@ mod unit_tests {
                     mode: ConsoleOutputMode::Tty,
                     socket: None,
                 },
-                iommu: false,
+                pci_common: PciDeviceCommonConfig::default(),
             },
             #[cfg(target_arch = "x86_64")]
             debug_console: DebugConsoleConfig::default(),
@@ -1693,10 +1693,12 @@ mod unit_tests {
                     "--serial",
                     "null",
                     "--console",
-                    "tty",
+                    "tty,pci_segment=1,pci_device_id=7",
                 ],
                 r#"{
-                    "payload": {"kernel": "/path/to/kernel"}
+                    "payload": {"kernel": "/path/to/kernel"},
+                    "serial": {"mode": "Null"},
+                    "console": {"mode": "Tty", "iommu": false, "pci_segment": 1, "pci_device_id": 7}
                 }"#,
                 true,
             ),

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -1018,7 +1018,6 @@ mod unit_tests {
                     mode: ConsoleOutputMode::Null,
                     socket: None,
                 },
-                iommu: false,
             },
             console: ConsoleConfig {
                 common: CommonConsoleConfig {

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -5793,6 +5793,8 @@ mod common_parallel {
         handle_child_output(r, &output);
     }
 
+    // Checks that explicit PCI device IDs are honored for boot-time and hotplugged devices.
+    // It also verifies dynamic hotplug allocation reuses freed PCI device ID holes.
     #[test]
     fn test_pci_device_id() {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
@@ -5813,6 +5815,7 @@ mod common_parallel {
             .default_memory()
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .args(["--console", "tty,pci_device_id=7"])
             .default_net()
             .default_disks()
             .capture_output();
@@ -5823,6 +5826,17 @@ mod common_parallel {
 
         // Add a network device with non-static device id request
         let r = std::panic::catch_unwind(|| {
+            // Make sure an explicit BDF for virtio-console is set.
+            assert!(wait_until(Duration::from_secs(10), || {
+                ssh_command_ip_with_auth(
+                    "lspci | grep \"00:07.0\" | grep Virtio | grep console",
+                    &default_guest_auth(),
+                    &guest.network.guest_ip0,
+                    Some(Duration::from_secs(1)),
+                )
+                .is_ok()
+            }));
+
             let (cmd_success, cmd_stdout, _) = remote_command_w_output(
                 &api_socket,
                 "add-net",

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -177,7 +177,6 @@ impl RequestHandler for StubApiRequestHandler {
                         mode: ConsoleOutputMode::Tty,
                         socket: None,
                     },
-                    iommu: false,
                 },
                 console: ConsoleConfig {
                     common: CommonConsoleConfig {

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -184,7 +184,7 @@ impl RequestHandler for StubApiRequestHandler {
                         mode: ConsoleOutputMode::Tty,
                         socket: None,
                     },
-                    iommu: false,
+                    pci_common: PciDeviceCommonConfig::default(),
                 },
                 #[cfg(target_arch = "x86_64")]
                 debug_console: DebugConsoleConfig::default(),

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -171,17 +171,21 @@ impl RequestHandler for StubApiRequestHandler {
                 fs: None,
                 generic_vhost_user: None,
                 pmem: None,
-                serial: ConsoleConfig {
-                    file: None,
-                    mode: ConsoleOutputMode::Null,
+                serial: SerialConfig {
+                    common: CommonConsoleConfig {
+                        file: None,
+                        mode: ConsoleOutputMode::Tty,
+                        socket: None,
+                    },
                     iommu: false,
-                    socket: None,
                 },
                 console: ConsoleConfig {
-                    file: None,
-                    mode: ConsoleOutputMode::Tty,
+                    common: CommonConsoleConfig {
+                        file: None,
+                        mode: ConsoleOutputMode::Tty,
+                        socket: None,
+                    },
                     iommu: false,
-                    socket: None,
                 },
                 #[cfg(target_arch = "x86_64")]
                 debug_console: DebugConsoleConfig::default(),

--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -226,6 +226,17 @@ impl OptionParser {
         self
     }
 
+    /// Registers multiple flag-style options that do not take a value.
+    ///
+    /// Equivalent to calling [`add_valueless`](Self::add_valueless) for each
+    /// element in the slice.
+    pub fn add_all_valueless(&mut self, options: &[&str]) -> &mut Self {
+        for option in options {
+            self.add_valueless(option);
+        }
+        self
+    }
+
     /// Returns the raw string value of an option, or `None` if the option was
     /// not set or if its value is an empty string (e.g. `key=`).
     ///

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -638,7 +638,7 @@ components:
           items:
             $ref: "#/components/schemas/PmemConfig"
         serial:
-          $ref: "#/components/schemas/ConsoleConfig"
+          $ref: "#/components/schemas/SerialConfig"
         console:
           $ref: "#/components/schemas/ConsoleConfig"
         debug_console:
@@ -1197,6 +1197,26 @@ components:
         iommu:
           type: boolean
           default: false
+        id:
+          type: string
+        pci_segment:
+          type: integer
+          format: int16
+        pci_device_id:
+          type: integer
+          format: uint8
+
+    SerialConfig:
+      required:
+        - mode
+      type: object
+      properties:
+        file:
+          type: string
+        socket:
+          type: string
+        mode:
+          $ref: "#/components/schemas/ConsoleMode"
 
     DebugConsoleConfig:
       required:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -3004,8 +3004,6 @@ impl VmConfig {
             }
         }
 
-        self.rng.validate(self)?;
-
         if let Some(nets) = &self.net {
             for net in nets {
                 if net.vhost_user && !self.backed_by_shared_memory() {
@@ -3052,6 +3050,8 @@ impl VmConfig {
             }
         }
 
+        self.rng.validate(self)?;
+        Self::validate_identifier(&mut id_list, &self.rng.pci_common.id)?;
         self.iommu |= self.rng.pci_common.iommu;
 
         self.console.validate(self)?;

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2141,10 +2141,7 @@ impl ConsoleConfig {
     pub fn parse(console: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser
-            .add_valueless("off")
-            .add_valueless("pty")
-            .add_valueless("tty")
-            .add_valueless("null")
+            .add_all_valueless(&["off", "pty", "tty", "null"])
             .add("file")
             .add("iommu")
             .add("socket");

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2187,18 +2187,17 @@ impl ConsoleConfig {
         parser
             .add_all_valueless(CommonConsoleConfig::VALUELESS_OPTIONS)
             .add_all(CommonConsoleConfig::VALUE_OPTIONS)
-            .add("iommu");
+            .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU);
         parser.parse(console).map_err(Error::ParseConsole)?;
 
-        let iommu = parser
-            .convert::<Toggle>("iommu")
-            .map_err(Error::ParsePciDeviceCommonConfig)?
-            .unwrap_or(Toggle(false))
-            .0;
-
         let common = CommonConsoleConfig::parse(console, Error::ParseConsole)?;
+        let pci_common = PciDeviceCommonConfig::parse(console)?;
 
-        Ok(Self { common, iommu })
+        Ok(Self { common, pci_common })
+    }
+
+    pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
+        self.pci_common.validate(vm_config)
     }
 }
 
@@ -3054,7 +3053,10 @@ impl VmConfig {
         }
 
         self.iommu |= self.rng.pci_common.iommu;
-        self.iommu |= self.console.iommu;
+
+        self.console.validate(self)?;
+        Self::validate_identifier(&mut id_list, &self.console.pci_common.id)?;
+        self.iommu |= self.console.pci_common.iommu;
 
         if let Some(t) = &self.cpus.topology {
             if t.threads_per_core == 0
@@ -4411,7 +4413,10 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
     fn test_console_parsing() -> Result<()> {
         let console_config = |mode, file, socket, iommu| ConsoleConfig {
             common: CommonConsoleConfig { file, mode, socket },
-            iommu,
+            pci_common: PciDeviceCommonConfig {
+                iommu,
+                ..Default::default()
+            },
         };
 
         ConsoleConfig::parse("").unwrap_err();
@@ -5054,7 +5059,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                     mode: ConsoleOutputMode::Tty,
                     socket: None,
                 },
-                iommu: false,
+                pci_common: PciDeviceCommonConfig::default(),
             },
             #[cfg(target_arch = "x86_64")]
             debug_console: DebugConsoleConfig::default(),
@@ -5980,6 +5985,37 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         assert_eq!(
             invalid_config.validate(),
             Err(ValidationError::InvalidPciDeviceId(pci::NUM_DEVICE_IDS + 1))
+        );
+
+        // Invalid console BDF - Same ID as Root device
+        let mut invalid_config = valid_config.clone();
+        invalid_config.console.pci_common.pci_device_id = Some(pci::PCI_ROOT_DEVICE_ID);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::ReservedPciDeviceId(
+                pci::PCI_ROOT_DEVICE_ID
+            ))
+        );
+        // Invalid console BDF - Out of range
+        let mut invalid_config = valid_config.clone();
+        invalid_config.console.pci_common.pci_device_id = Some(pci::NUM_DEVICE_IDS + 1);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::InvalidPciDeviceId(pci::NUM_DEVICE_IDS + 1))
+        );
+        // Invalid console ID - Duplicate identifier
+        let mut invalid_config = valid_config.clone();
+        invalid_config.console.pci_common.id = Some("test0".to_string());
+        invalid_config.disks = Some(vec![DiskConfig {
+            pci_common: PciDeviceCommonConfig {
+                id: Some("test0".to_string()),
+                ..Default::default()
+            },
+            ..disk_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::IdentifierNotUnique("test0".to_string()))
         );
     }
     #[test]

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2207,18 +2207,11 @@ impl SerialConfig {
         let mut parser = OptionParser::new();
         parser
             .add_all_valueless(CommonConsoleConfig::VALUELESS_OPTIONS)
-            .add_all(CommonConsoleConfig::VALUE_OPTIONS)
-            .add("iommu");
+            .add_all(CommonConsoleConfig::VALUE_OPTIONS);
         parser.parse(serial).map_err(Error::ParseSerial)?;
 
-        let iommu = parser
-            .convert::<Toggle>("iommu")
-            .map_err(Error::ParsePciDeviceCommonConfig)?
-            .unwrap_or(Toggle(false))
-            .0;
-
         let common = CommonConsoleConfig::parse(serial, Error::ParseSerial)?;
-        Ok(Self { common, iommu })
+        Ok(Self { common })
     }
 }
 
@@ -5054,7 +5047,6 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                     mode: ConsoleOutputMode::Null,
                     socket: None,
                 },
-                iommu: false,
             },
             console: ConsoleConfig {
                 common: CommonConsoleConfig {

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -128,9 +128,12 @@ pub enum Error {
     /// Error parsing generic vhost-user parameters
     #[error("Error parsing --generic-vhost-user")]
     ParseGenericVhostUser(#[source] OptionParserError),
-    /// Failed parsing console
+    /// Failed parsing console parameters
     #[error("Error parsing --console")]
     ParseConsole(#[source] OptionParserError),
+    /// Failed parsing serial parameters
+    #[error("Error parsing --serial")]
+    ParseSerial(#[source] OptionParserError),
     #[cfg(target_arch = "x86_64")]
     /// Failed parsing debug-console
     #[error("Error parsing --debug-console")]
@@ -2137,17 +2140,18 @@ impl PmemConfig {
     }
 }
 
-impl ConsoleConfig {
-    pub fn parse(console: &str) -> Result<Self> {
+impl CommonConsoleConfig {
+    const VALUELESS_OPTIONS: &[&str] = &["off", "pty", "tty", "null"];
+    const VALUE_OPTIONS: &[&str] = &["file", "socket"];
+
+    fn parse(console: &str, map_err: impl Fn(OptionParserError) -> Error) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser
-            .add_all_valueless(&["off", "pty", "tty", "null"])
-            .add("file")
-            .add("iommu")
-            .add("socket");
-        parser.parse(console).map_err(Error::ParseConsole)?;
+            .add_all_valueless(Self::VALUELESS_OPTIONS)
+            .add_all(Self::VALUE_OPTIONS);
+        parser.parse_subset(console).map_err(map_err)?;
 
-        let mut file: Option<PathBuf> = default_consoleconfig_file();
+        let mut file: Option<PathBuf> = None;
         let mut socket: Option<PathBuf> = None;
         let mut mode: ConsoleOutputMode = ConsoleOutputMode::Off;
 
@@ -2172,18 +2176,49 @@ impl ConsoleConfig {
         } else {
             return Err(Error::ParseConsoleInvalidModeGiven);
         }
+
+        Ok(Self { mode, file, socket })
+    }
+}
+
+impl ConsoleConfig {
+    pub fn parse(console: &str) -> Result<Self> {
+        let mut parser = OptionParser::new();
+        parser
+            .add_all_valueless(CommonConsoleConfig::VALUELESS_OPTIONS)
+            .add_all(CommonConsoleConfig::VALUE_OPTIONS)
+            .add("iommu");
+        parser.parse(console).map_err(Error::ParseConsole)?;
+
         let iommu = parser
             .convert::<Toggle>("iommu")
-            .map_err(Error::ParseConsole)?
+            .map_err(Error::ParsePciDeviceCommonConfig)?
             .unwrap_or(Toggle(false))
             .0;
 
-        Ok(Self {
-            file,
-            mode,
-            iommu,
-            socket,
-        })
+        let common = CommonConsoleConfig::parse(console, Error::ParseConsole)?;
+
+        Ok(Self { common, iommu })
+    }
+}
+
+impl SerialConfig {
+    pub fn parse(serial: &str) -> Result<Self> {
+        let mut parser = OptionParser::new();
+        parser
+            .add_all_valueless(CommonConsoleConfig::VALUELESS_OPTIONS)
+            .add_all(CommonConsoleConfig::VALUE_OPTIONS)
+            .add("iommu");
+        parser.parse(serial).map_err(Error::ParseSerial)?;
+
+        let iommu = parser
+            .convert::<Toggle>("iommu")
+            .map_err(Error::ParsePciDeviceCommonConfig)?
+            .unwrap_or(Toggle(false))
+            .0;
+
+        let common = CommonConsoleConfig::parse(serial, Error::ParseSerial)?;
+        Ok(Self { common, iommu })
     }
 }
 
@@ -2202,7 +2237,7 @@ impl DebugConsoleConfig {
             .parse(debug_console_ops)
             .map_err(Error::ParseConsole)?;
 
-        let mut file: Option<PathBuf> = default_consoleconfig_file();
+        let mut file: Option<PathBuf> = None;
         let mut iobase: Option<u16> = None;
         let mut mode: ConsoleOutputMode = ConsoleOutputMode::Off;
 
@@ -2894,10 +2929,10 @@ impl VmConfig {
         // "console=hvc0 earlyprintk=ttyS0"
 
         let mut tty_consoles = Vec::new();
-        if self.console.mode == ConsoleOutputMode::Tty {
+        if self.console.common.mode == ConsoleOutputMode::Tty {
             tty_consoles.push("virtio-console");
         }
-        if self.serial.mode == ConsoleOutputMode::Tty {
+        if self.serial.common.mode == ConsoleOutputMode::Tty {
             tty_consoles.push("serial-console");
         }
         #[cfg(target_arch = "x86_64")]
@@ -2908,11 +2943,12 @@ impl VmConfig {
             warn!("Using TTY output for multiple consoles: {tty_consoles:?}");
         }
 
-        if self.console.mode == ConsoleOutputMode::File && self.console.file.is_none() {
+        if self.console.common.mode == ConsoleOutputMode::File && self.console.common.file.is_none()
+        {
             return Err(ValidationError::ConsoleFileMissing);
         }
 
-        if self.serial.mode == ConsoleOutputMode::File && self.serial.file.is_none() {
+        if self.serial.common.mode == ConsoleOutputMode::File && self.serial.common.file.is_none() {
             return Err(ValidationError::ConsoleFileMissing);
         }
 
@@ -3298,7 +3334,7 @@ impl VmConfig {
         }
 
         let console = ConsoleConfig::parse(vm_params.console)?;
-        let serial = ConsoleConfig::parse(vm_params.serial)?;
+        let serial = SerialConfig::parse(vm_params.serial)?;
         #[cfg(target_arch = "x86_64")]
         let debug_console = DebugConsoleConfig::parse(vm_params.debug_console)?;
 
@@ -4380,79 +4416,59 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
 
     #[test]
     fn test_console_parsing() -> Result<()> {
+        let console_config = |mode, file, socket, iommu| ConsoleConfig {
+            common: CommonConsoleConfig { file, mode, socket },
+            iommu,
+        };
+
         ConsoleConfig::parse("").unwrap_err();
         ConsoleConfig::parse("badmode").unwrap_err();
         assert_eq!(
             ConsoleConfig::parse("off")?,
-            ConsoleConfig {
-                mode: ConsoleOutputMode::Off,
-                iommu: false,
-                file: None,
-                socket: None,
-            }
+            console_config(ConsoleOutputMode::Off, None, None, false)
         );
         assert_eq!(
             ConsoleConfig::parse("pty")?,
-            ConsoleConfig {
-                mode: ConsoleOutputMode::Pty,
-                iommu: false,
-                file: None,
-                socket: None,
-            }
+            console_config(ConsoleOutputMode::Pty, None, None, false)
         );
         assert_eq!(
             ConsoleConfig::parse("tty")?,
-            ConsoleConfig {
-                mode: ConsoleOutputMode::Tty,
-                iommu: false,
-                file: None,
-                socket: None,
-            }
+            console_config(ConsoleOutputMode::Tty, None, None, false)
         );
         assert_eq!(
             ConsoleConfig::parse("null")?,
-            ConsoleConfig {
-                mode: ConsoleOutputMode::Null,
-                iommu: false,
-                file: None,
-                socket: None,
-            }
+            console_config(ConsoleOutputMode::Null, None, None, false)
         );
         assert_eq!(
             ConsoleConfig::parse("file=/tmp/console")?,
-            ConsoleConfig {
-                mode: ConsoleOutputMode::File,
-                iommu: false,
-                file: Some(PathBuf::from("/tmp/console")),
-                socket: None,
-            }
+            console_config(
+                ConsoleOutputMode::File,
+                Some(PathBuf::from("/tmp/console")),
+                None,
+                false
+            )
         );
         assert_eq!(
             ConsoleConfig::parse("null,iommu=on")?,
-            ConsoleConfig {
-                mode: ConsoleOutputMode::Null,
-                iommu: true,
-                file: None,
-                socket: None,
-            }
+            console_config(ConsoleOutputMode::Null, None, None, true)
         );
         assert_eq!(
             ConsoleConfig::parse("file=/tmp/console,iommu=on")?,
-            ConsoleConfig {
-                mode: ConsoleOutputMode::File,
-                iommu: true,
-                file: Some(PathBuf::from("/tmp/console")),
-                socket: None,
-            }
+            console_config(
+                ConsoleOutputMode::File,
+                Some(PathBuf::from("/tmp/console")),
+                None,
+                true
+            )
         );
         assert_eq!(
             ConsoleConfig::parse("socket=/tmp/serial.sock,iommu=on")?,
-            ConsoleConfig {
-                mode: ConsoleOutputMode::Socket,
-                iommu: true,
-                file: None,
-                socket: Some(PathBuf::from("/tmp/serial.sock")),
-            }
+            console_config(
+                ConsoleOutputMode::Socket,
+                None,
+                Some(PathBuf::from("/tmp/serial.sock")),
+                true
+            )
         );
         Ok(())
     }
@@ -4798,8 +4814,8 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             balloon: None,
             fs: None,
             pmem: None,
-            serial: default_serial(),
-            console: default_console(),
+            serial: SerialConfig::default(),
+            console: ConsoleConfig::default(),
             #[cfg(target_arch = "x86_64")]
             debug_console: DebugConsoleConfig::default(),
             devices: None,
@@ -5032,17 +5048,21 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             fs: None,
             generic_vhost_user: None,
             pmem: None,
-            serial: ConsoleConfig {
-                file: None,
-                mode: ConsoleOutputMode::Null,
+            serial: SerialConfig {
+                common: CommonConsoleConfig {
+                    file: None,
+                    mode: ConsoleOutputMode::Null,
+                    socket: None,
+                },
                 iommu: false,
-                socket: None,
             },
             console: ConsoleConfig {
-                file: None,
-                mode: ConsoleOutputMode::Tty,
+                common: CommonConsoleConfig {
+                    file: None,
+                    mode: ConsoleOutputMode::Tty,
+                    socket: None,
+                },
                 iommu: false,
-                socket: None,
             },
             #[cfg(target_arch = "x86_64")]
             debug_console: DebugConsoleConfig::default(),
@@ -5071,8 +5091,8 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         valid_config.validate().unwrap();
 
         let mut invalid_config = valid_config.clone();
-        invalid_config.serial.mode = ConsoleOutputMode::Tty;
-        invalid_config.console.mode = ConsoleOutputMode::Tty;
+        invalid_config.serial.common.mode = ConsoleOutputMode::Tty;
+        invalid_config.console.common.mode = ConsoleOutputMode::Tty;
         valid_config.validate().unwrap();
 
         let mut invalid_config = valid_config.clone();
@@ -5112,8 +5132,8 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         }
 
         let mut invalid_config = valid_config.clone();
-        invalid_config.serial.mode = ConsoleOutputMode::File;
-        invalid_config.serial.file = None;
+        invalid_config.serial.common.mode = ConsoleOutputMode::File;
+        invalid_config.serial.common.file = None;
         assert_eq!(
             invalid_config.validate(),
             Err(ValidationError::ConsoleFileMissing)

--- a/vmm/src/console_devices.rs
+++ b/vmm/src/console_devices.rs
@@ -181,9 +181,9 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
     let mut original_termios_opt = vmm.original_termios_opt.lock().unwrap();
 
     let console_info = ConsoleInfo {
-        console: match vmconfig.console.mode {
+        console: match vmconfig.console.common.mode {
             ConsoleOutputMode::File => {
-                let file = File::create(vmconfig.console.file.as_ref().unwrap())
+                let file = File::create(vmconfig.console.common.file.as_ref().unwrap())
                     .map_err(ConsoleDeviceError::CreateConsoleDevice)?;
                 ConsoleTransport::File(Arc::new(file))
             }
@@ -191,7 +191,7 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
                 let (main_fd, sub_fd, path) =
                     create_pty().map_err(ConsoleDeviceError::CreateConsoleDevice)?;
                 set_raw_mode(&sub_fd.as_raw_fd(), &mut original_termios_opt)?;
-                vmconfig.console.file = Some(path.clone());
+                vmconfig.console.common.file = Some(path.clone());
                 vmm.console_resize_pipe = Some(Arc::new(
                     listen_for_sigwinch_on_tty(
                         sub_fd,
@@ -230,9 +230,9 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
             ConsoleOutputMode::Null => ConsoleTransport::Null,
             ConsoleOutputMode::Off => ConsoleTransport::Off,
         },
-        serial: match vmconfig.serial.mode {
+        serial: match vmconfig.serial.common.mode {
             ConsoleOutputMode::File => {
-                let file = File::create(vmconfig.serial.file.as_ref().unwrap())
+                let file = File::create(vmconfig.serial.common.file.as_ref().unwrap())
                     .map_err(ConsoleDeviceError::CreateConsoleDevice)?;
                 ConsoleTransport::File(Arc::new(file))
             }
@@ -240,7 +240,7 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
                 let (main_fd, sub_fd, path) =
                     create_pty().map_err(ConsoleDeviceError::CreateConsoleDevice)?;
                 set_raw_mode(&sub_fd.as_raw_fd(), &mut original_termios_opt)?;
-                vmconfig.serial.file = Some(path.clone());
+                vmconfig.serial.common.file = Some(path.clone());
                 ConsoleTransport::Pty(Arc::new(main_fd))
             }
             ConsoleOutputMode::Tty => {
@@ -260,7 +260,7 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
                 ConsoleTransport::Tty(Arc::new(stdout))
             }
             ConsoleOutputMode::Socket => {
-                let listener = UnixListener::bind(vmconfig.serial.socket.as_ref().unwrap())
+                let listener = UnixListener::bind(vmconfig.serial.common.socket.as_ref().unwrap())
                     .map_err(ConsoleDeviceError::CreateConsoleDevice)?;
                 ConsoleTransport::Socket(Arc::new(listener))
             }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2440,11 +2440,13 @@ impl DeviceManager {
             .insert(id.clone(), device_node!(id, virtio_console_device));
 
         // Only provide a resizer (for SIGWINCH handling) if the console is attached to the TTY
-        Ok(if matches!(console_config.mode, ConsoleOutputMode::Tty) {
-            Some(console_resizer)
-        } else {
-            None
-        })
+        Ok(
+            if matches!(console_config.common.mode, ConsoleOutputMode::Tty) {
+                Some(console_resizer)
+            } else {
+                None
+            },
+        )
     }
 
     /// Adds all devices that behave like a console with respect to the VM
@@ -2482,9 +2484,12 @@ impl DeviceManager {
                 ConsoleTransport::Pty(_)
                 | ConsoleTransport::Tty(_)
                 | ConsoleTransport::Socket(_) => {
-                    let serial_manager =
-                        SerialManager::new(serial, console_info.serial, serial_config.socket)
-                            .map_err(DeviceManagerError::CreateSerialManager)?;
+                    let serial_manager = SerialManager::new(
+                        serial,
+                        console_info.serial,
+                        serial_config.common.socket,
+                    )
+                    .map_err(DeviceManagerError::CreateSerialManager)?;
                     if let Some(mut serial_manager) = serial_manager {
                         serial_manager
                             .start_thread(
@@ -5426,18 +5431,18 @@ impl Aml for DeviceManager {
         #[cfg(target_arch = "x86_64")]
         let serial_irq = 4;
         #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-        let serial_irq =
-            if self.config.lock().unwrap().serial.clone().mode == ConsoleOutputMode::Off {
-                // If serial is turned off, add a fake device with invalid irq.
-                31
-            } else {
-                self.get_device_info()
-                    .clone()
-                    .get(&(DeviceType::Serial, DeviceType::Serial.to_string()))
-                    .unwrap()
-                    .irq()
-            };
-        if self.config.lock().unwrap().serial.mode != ConsoleOutputMode::Off {
+        let serial_irq = if self.config.lock().unwrap().serial.common.mode == ConsoleOutputMode::Off
+        {
+            // If serial is turned off, add a fake device with invalid irq.
+            31
+        } else {
+            self.get_device_info()
+                .clone()
+                .get(&(DeviceType::Serial, DeviceType::Serial.to_string()))
+                .unwrap()
+                .irq()
+        };
+        if self.config.lock().unwrap().serial.common.mode != ConsoleOutputMode::Off {
             aml::Device::new(
                 "_SB_.COM1".into(),
                 vec![

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2368,7 +2368,7 @@ impl DeviceManager {
         transport: ConsoleTransport,
         resize_pipe: Option<Arc<File>>,
     ) -> DeviceManagerResult<Option<Arc<virtio_devices::ConsoleResizer>>> {
-        let console_config = self.config.lock().unwrap().console.clone();
+        let mut console_config = self.config.lock().unwrap().console.clone();
         let endpoint = match transport {
             ConsoleTransport::File(file) => Endpoint::File(file),
             ConsoleTransport::Pty(file) => {
@@ -2402,7 +2402,15 @@ impl DeviceManager {
             ConsoleTransport::Null => Endpoint::Null,
             ConsoleTransport::Off => return Ok(None),
         };
-        let id = String::from(CONSOLE_DEVICE_NAME);
+
+        let id = match console_config.pci_common.id.as_ref() {
+            Some(id) => id.clone(),
+            None => console_config
+                .pci_common
+                .id
+                .insert(CONSOLE_DEVICE_NAME.to_string())
+                .clone(),
+        };
 
         let (virtio_console_device, console_resizer) = virtio_devices::Console::new(
             id.clone(),
@@ -2410,7 +2418,7 @@ impl DeviceManager {
             self.console_resize_pipe
                 .as_ref()
                 .map(|p| p.try_clone().unwrap()),
-            self.force_access_platform | console_config.iommu,
+            self.force_access_platform | console_config.pci_common.iommu,
             self.seccomp_action.clone(),
             self.exit_evt
                 .try_clone()
@@ -2423,11 +2431,7 @@ impl DeviceManager {
         self.virtio_devices.push(MetaVirtioDevice {
             virtio_device: Arc::clone(&virtio_console_device)
                 as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-            pci_common: PciDeviceCommonConfig {
-                id: Some(id.clone()),
-                iommu: console_config.iommu,
-                ..Default::default()
-            },
+            pci_common: console_config.pci_common.clone(),
             dma_handler: None,
         });
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2653,8 +2653,9 @@ mod unit_tests {
     #[cfg(target_arch = "x86_64")]
     use crate::vm_config::DebugConsoleConfig;
     use crate::vm_config::{
-        ConsoleConfig, ConsoleOutputMode, CoreScheduling, CpuFeatures, CpusConfig, HotplugMethod,
-        MemoryConfig, PayloadConfig, PciDeviceCommonConfig, RngConfig,
+        CommonConsoleConfig, ConsoleConfig, ConsoleOutputMode, CoreScheduling, CpuFeatures,
+        CpusConfig, HotplugMethod, MemoryConfig, PayloadConfig, PciDeviceCommonConfig, RngConfig,
+        SerialConfig,
     };
 
     fn create_dummy_vmm() -> Vmm {
@@ -2722,18 +2723,22 @@ mod unit_tests {
             fs: None,
             generic_vhost_user: None,
             pmem: None,
-            serial: ConsoleConfig {
-                file: None,
-                mode: ConsoleOutputMode::Null,
+            serial: SerialConfig {
+                common: CommonConsoleConfig {
+                    file: None,
+                    mode: ConsoleOutputMode::Null,
+                    socket: None,
+                },
                 iommu: false,
-                socket: None,
             },
             console: ConsoleConfig {
-                file: None,
-                // Caution: Don't use `Tty` to not mess with users terminal
-                mode: ConsoleOutputMode::Off,
+                common: CommonConsoleConfig {
+                    file: None,
+                    // Caution: Don't use `Tty` to not mess with users terminal
+                    mode: ConsoleOutputMode::Off,
+                    socket: None,
+                },
                 iommu: false,
-                socket: None,
             },
             #[cfg(target_arch = "x86_64")]
             debug_console: DebugConsoleConfig::default(),

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2729,7 +2729,6 @@ mod unit_tests {
                     mode: ConsoleOutputMode::Null,
                     socket: None,
                 },
-                iommu: false,
             },
             console: ConsoleConfig {
                 common: CommonConsoleConfig {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2737,7 +2737,7 @@ mod unit_tests {
                     mode: ConsoleOutputMode::Off,
                     socket: None,
                 },
-                iommu: false,
+                pci_common: PciDeviceCommonConfig::default(),
             },
             #[cfg(target_arch = "x86_64")]
             debug_console: DebugConsoleConfig::default(),

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -582,13 +582,10 @@ impl ApplyLandlock for CommonConsoleConfig {
 pub struct SerialConfig {
     #[serde(flatten)]
     pub common: CommonConsoleConfig,
-    #[serde(default, skip_serializing_if = "<&bool as std::ops::Not>::not")]
-    pub iommu: bool,
 }
 
 impl SerialConfig {
-    pub const SYNTAX: &str =
-        "Control serial port: \"off|null|pty|tty|file=<path>|socket=<path>,iommu=on|off\"";
+    pub const SYNTAX: &str = "Control serial port: \"off|null|pty|tty|file=<path>|socket=<path>\"";
 }
 
 impl Default for SerialConfig {
@@ -599,7 +596,6 @@ impl Default for SerialConfig {
                 mode: ConsoleOutputMode::Null,
                 socket: None,
             },
-            iommu: false,
         }
     }
 }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -574,10 +574,6 @@ impl ApplyLandlock for CommonConsoleConfig {
 }
 
 /// Configuration for a legacy serial console device.
-///
-/// - On x86_64, this is a port I/O-mapped UART16550-compatible device
-/// - On aarch64, this is a MMIO-mapped PL011 device
-/// - On RISCV, this is a MMIO-mapped UART16550-compatible device
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct SerialConfig {
     #[serde(flatten)]
@@ -611,13 +607,12 @@ impl ApplyLandlock for SerialConfig {
 pub struct ConsoleConfig {
     #[serde(flatten)]
     pub common: CommonConsoleConfig,
-    #[serde(default, skip_serializing_if = "<&bool as std::ops::Not>::not")]
-    pub iommu: bool,
+    #[serde(default, flatten)]
+    pub pci_common: PciDeviceCommonConfig,
 }
 
 impl ConsoleConfig {
-    pub const SYNTAX: &str =
-        "Control (virtio) console: \"off|null|pty|tty|file=<path>,iommu=on|off\"";
+    pub const SYNTAX: &str = "Control (virtio) console: \"off|null|pty|tty|file=<path>,iommu=on|off,id=<device_id>,pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
 }
 
 impl Default for ConsoleConfig {
@@ -628,7 +623,7 @@ impl Default for ConsoleConfig {
                 mode: ConsoleOutputMode::Tty,
                 socket: None,
             },
-            iommu: false,
+            pci_common: PciDeviceCommonConfig::default(),
         }
     }
 }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -545,21 +545,19 @@ pub enum ConsoleOutputMode {
     Null,
 }
 
+/// Common configuration for plain console configs.
+///
+/// Independent of PCI or legacy devices.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct ConsoleConfig {
-    #[serde(default = "default_consoleconfig_file")]
+pub struct CommonConsoleConfig {
+    #[serde(default)]
     pub file: Option<PathBuf>,
     pub mode: ConsoleOutputMode,
     #[serde(default)]
-    pub iommu: bool,
     pub socket: Option<PathBuf>,
 }
 
-pub fn default_consoleconfig_file() -> Option<PathBuf> {
-    None
-}
-
-impl ApplyLandlock for ConsoleConfig {
+impl ApplyLandlock for CommonConsoleConfig {
     fn apply_landlock(&self, landlock: &mut Landlock) -> LandlockResult<()> {
         if self.mode == ConsoleOutputMode::Pty {
             landlock.add_rule_with_access(Path::new("/dev/pts"), "rw")?;
@@ -572,6 +570,76 @@ impl ApplyLandlock for ConsoleConfig {
             landlock.add_rule_with_access(socket, "rw")?;
         }
         Ok(())
+    }
+}
+
+/// Configuration for a legacy serial console device.
+///
+/// - On x86_64, this is a port I/O-mapped UART16550-compatible device
+/// - On aarch64, this is a MMIO-mapped PL011 device
+/// - On RISCV, this is a MMIO-mapped UART16550-compatible device
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct SerialConfig {
+    #[serde(flatten)]
+    pub common: CommonConsoleConfig,
+    #[serde(default, skip_serializing_if = "<&bool as std::ops::Not>::not")]
+    pub iommu: bool,
+}
+
+impl SerialConfig {
+    pub const SYNTAX: &str =
+        "Control serial port: \"off|null|pty|tty|file=<path>|socket=<path>,iommu=on|off\"";
+}
+
+impl Default for SerialConfig {
+    fn default() -> Self {
+        Self {
+            common: CommonConsoleConfig {
+                file: None,
+                mode: ConsoleOutputMode::Null,
+                socket: None,
+            },
+            iommu: false,
+        }
+    }
+}
+
+impl ApplyLandlock for SerialConfig {
+    fn apply_landlock(&self, landlock: &mut Landlock) -> LandlockResult<()> {
+        self.common.apply_landlock(landlock)
+    }
+}
+
+/// Configuration for a virtio-console device.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ConsoleConfig {
+    #[serde(flatten)]
+    pub common: CommonConsoleConfig,
+    #[serde(default, skip_serializing_if = "<&bool as std::ops::Not>::not")]
+    pub iommu: bool,
+}
+
+impl ConsoleConfig {
+    pub const SYNTAX: &str =
+        "Control (virtio) console: \"off|null|pty|tty|file=<path>,iommu=on|off\"";
+}
+
+impl Default for ConsoleConfig {
+    fn default() -> Self {
+        Self {
+            common: CommonConsoleConfig {
+                file: None,
+                mode: ConsoleOutputMode::Tty,
+                socket: None,
+            },
+            iommu: false,
+        }
+    }
+}
+
+impl ApplyLandlock for ConsoleConfig {
+    fn apply_landlock(&self, landlock: &mut Landlock) -> LandlockResult<()> {
+        self.common.apply_landlock(landlock)
     }
 }
 
@@ -929,24 +997,6 @@ impl ApplyLandlock for PayloadConfig {
     }
 }
 
-pub fn default_serial() -> ConsoleConfig {
-    ConsoleConfig {
-        file: None,
-        mode: ConsoleOutputMode::Null,
-        iommu: false,
-        socket: None,
-    }
-}
-
-pub fn default_console() -> ConsoleConfig {
-    ConsoleConfig {
-        file: None,
-        mode: ConsoleOutputMode::Tty,
-        iommu: false,
-        socket: None,
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct TpmConfig {
     pub socket: PathBuf,
@@ -988,9 +1038,9 @@ pub struct VmConfig {
     pub generic_vhost_user: Option<Vec<GenericVhostUserConfig>>,
     pub fs: Option<Vec<FsConfig>>,
     pub pmem: Option<Vec<PmemConfig>>,
-    #[serde(default = "default_serial")]
-    pub serial: ConsoleConfig,
-    #[serde(default = "default_console")]
+    #[serde(default)]
+    pub serial: SerialConfig,
+    #[serde(default)]
     pub console: ConsoleConfig,
     #[cfg(target_arch = "x86_64")]
     #[serde(default)]


### PR DESCRIPTION
Same as #8163 but for the virtio-console device. We missed this in #7965.

This series makes virtio-console PCI placement configurable by separating console and serial configuration, then wiring an explicit BDF through the VMM and CLI paths. 

- Add an `OptionParser::add_all_valueless()` helper for repeated valueless options.
- Split `ConsoleConfig` and `SerialConfig` so console-specific PCI fields can be represented cleanly.
- Remove the unused serial IOMMU flag after the config split.
- Add configurable PCI BDF support for virtio-console.
- Extend `test_pci_device_id()` to cover virtio-console BDF assignment.

