### PR TITLE
block: Various block image format fixes

### DIFF
--- a/block/src/formats/qcow/common.rs
+++ b/block/src/formats/qcow/common.rs
@@ -28,13 +28,17 @@ use super::internal::decoder::Decoder;
 pub fn pread_exact(fd: RawFd, buf: &mut [u8], offset: u64) -> io::Result<()> {
     let mut total = 0usize;
     while total < buf.len() {
+        let cur_offset = offset
+            .checked_add(total as u64)
+            .and_then(|o| i64::try_from(o).ok())
+            .ok_or_else(|| io::Error::other("pread_exact offset overflow"))?;
         // SAFETY: buf and fd are valid for the lifetime of the call.
         let ret = unsafe {
             libc::pread64(
                 fd,
                 buf[total..].as_mut_ptr().cast(),
                 buf.len() - total,
-                (offset + total as u64) as libc::off_t,
+                cur_offset,
             )
         };
         if ret < 0 {
@@ -79,13 +83,17 @@ pub fn decompress_cluster(
 pub fn pwrite_all(fd: RawFd, buf: &[u8], offset: u64) -> io::Result<()> {
     let mut total = 0usize;
     while total < buf.len() {
+        let cur_offset = offset
+            .checked_add(total as u64)
+            .and_then(|o| i64::try_from(o).ok())
+            .ok_or_else(|| io::Error::other("pwrite_all offset overflow"))?;
         // SAFETY: buf and fd are valid for the lifetime of the call.
         let ret = unsafe {
             libc::pwrite64(
                 fd,
                 buf[total..].as_ptr().cast(),
                 buf.len() - total,
-                (offset + total as u64) as libc::off_t,
+                cur_offset,
             )
         };
         if ret < 0 {

--- a/block/src/formats/qcow/internal/backing.rs
+++ b/block/src/formats/qcow/internal/backing.rs
@@ -140,12 +140,6 @@ impl Qcow2Backing {
     }
 }
 
-impl Drop for Qcow2Backing {
-    fn drop(&mut self) {
-        self.metadata.shutdown();
-    }
-}
-
 /// Construct a thread safe backing file reader.
 pub fn shared_backing_from(bf: BackingFile) -> BlockResult<Arc<dyn BackingRead>> {
     let (kind, virtual_size) = bf.into_kind();

--- a/block/src/formats/qcow/internal/header.rs
+++ b/block/src/formats/qcow/internal/header.rs
@@ -400,8 +400,9 @@ impl QcowHeader {
 
         // L2 blocks are always one cluster long. They contain cluster_size/sizeof(u64) addresses.
         let entries_per_cluster: u32 = cluster_size / size_of::<u64>() as u32;
-        let num_clusters: u32 = div_round_up_u64(size, u64::from(cluster_size)) as u32;
-        let num_l2_clusters: u32 = div_round_up_u32(num_clusters, entries_per_cluster);
+        let num_clusters: u64 = div_round_up_u64(size, u64::from(cluster_size));
+        let num_l2_clusters: u32 =
+            div_round_up_u64(num_clusters, u64::from(entries_per_cluster)) as u32;
         let l1_clusters: u32 = div_round_up_u32(num_l2_clusters, entries_per_cluster);
         let header_clusters = div_round_up_u32(size_of::<QcowHeader>() as u32, cluster_size);
         Ok(QcowHeader {
@@ -430,7 +431,10 @@ impl QcowHeader {
                 let max_refcount_clusters = max_refcount_clusters(
                     DEFAULT_REFCOUNT_ORDER,
                     cluster_size,
-                    num_clusters + l1_clusters + num_l2_clusters + header_clusters,
+                    num_clusters
+                        + u64::from(l1_clusters)
+                        + u64::from(num_l2_clusters)
+                        + u64::from(header_clusters),
                 ) as u32;
                 // The refcount table needs to store the offset of each refcount cluster.
                 div_round_up_u32(
@@ -591,12 +595,12 @@ impl QcowHeader {
 pub(super) fn max_refcount_clusters(
     refcount_order: u32,
     cluster_size: u32,
-    num_clusters: u32,
+    num_clusters: u64,
 ) -> u64 {
     // Use u64 as the product of the u32 inputs can overflow.
     let refcount_bits = 0x01u64 << u64::from(refcount_order);
     let cluster_bits = u64::from(cluster_size) * 8;
-    let for_data = div_round_up_u64(u64::from(num_clusters) * refcount_bits, cluster_bits);
+    let for_data = div_round_up_u64(num_clusters * refcount_bits, cluster_bits);
     let for_refcounts = div_round_up_u64(for_data * refcount_bits, cluster_bits);
     for_data + for_refcounts
 }

--- a/block/src/formats/qcow/internal/header.rs
+++ b/block/src/formats/qcow/internal/header.rs
@@ -226,6 +226,11 @@ impl QcowHeader {
 
             let ext_length = u32::read_be(f).map_err(Error::ReadingHeader)?;
 
+            const MAX_EXT_LENGTH: u32 = 1 << 20;
+            if ext_length > MAX_EXT_LENGTH {
+                return Err(Error::HeaderExtensionTooLarge(ext_length));
+            }
+
             match ext_type {
                 HEADER_EXT_BACKING_FORMAT => {
                     let mut format_bytes = vec![0u8; ext_length as usize];

--- a/block/src/formats/qcow/internal/metadata.rs
+++ b/block/src/formats/qcow/internal/metadata.rs
@@ -28,9 +28,10 @@ use super::decoder::Decoder;
 use super::qcow_raw_file::QcowRawFile;
 use super::refcount::RefCount;
 use super::util::{
-    div_round_up_u64, l1_entry_make, l2_entry_compressed_cluster_layout, l2_entry_is_compressed,
-    l2_entry_is_empty, l2_entry_is_zero, l2_entry_make_std, l2_entry_make_zero,
-    l2_entry_make_zero_plain, l2_entry_std_cluster_addr,
+    cluster_addr_is_valid, compressed_cluster_range_is_valid, div_round_up_u64, l1_entry_make,
+    l2_entry_compressed_cluster_layout, l2_entry_is_compressed, l2_entry_is_empty,
+    l2_entry_is_zero, l2_entry_make_std, l2_entry_make_zero, l2_entry_make_zero_plain,
+    l2_entry_std_cluster_addr,
 };
 use super::vec_cache::{CacheMap, Cacheable, VecCache};
 use super::{QcowHeader, refcount};
@@ -397,6 +398,15 @@ impl QcowState {
         if l2_entry_is_compressed(l2_entry) {
             let (host_offset, compressed_size) =
                 l2_entry_compressed_cluster_layout(l2_entry, self.header.cluster_bits);
+            if !compressed_cluster_range_is_valid(
+                host_offset,
+                compressed_size,
+                self.raw_file.cluster_size(),
+                self.refcounts.max_valid_cluster_offset(),
+            ) {
+                // Fall through to write lock path which sets the corrupt bit
+                return Ok(None);
+            }
             let cluster_offset = self.raw_file.cluster_offset(address) as usize;
             return Ok(Some(ClusterReadMapping::Compressed {
                 host_offset,
@@ -462,6 +472,15 @@ impl QcowState {
         } else if l2_entry_is_compressed(l2_entry) {
             let (host_offset, compressed_size) =
                 l2_entry_compressed_cluster_layout(l2_entry, self.header.cluster_bits);
+            if !compressed_cluster_range_is_valid(
+                host_offset,
+                compressed_size,
+                self.raw_file.cluster_size(),
+                self.refcounts.max_valid_cluster_offset(),
+            ) {
+                self.set_corrupt_bit_best_effort();
+                return Err(io::Error::from_raw_os_error(EIO));
+            }
             let cluster_offset = self.raw_file.cluster_offset(address) as usize;
             Ok(ClusterReadMapping::Compressed {
                 host_offset,
@@ -589,8 +608,11 @@ impl QcowState {
     }
 
     fn is_refcount_addressable_cluster_offset(&self, cluster_addr: u64) -> bool {
-        cluster_addr & (self.raw_file.cluster_size() - 1) == 0
-            && cluster_addr <= self.refcounts.max_valid_cluster_offset()
+        cluster_addr_is_valid(
+            cluster_addr,
+            self.raw_file.cluster_size(),
+            self.refcounts.max_valid_cluster_offset(),
+        )
     }
 
     fn reject_invalid_cluster_offset(&mut self, cluster_addr: u64) -> io::Result<()> {
@@ -1047,6 +1069,15 @@ impl QcowState {
     fn decompress_l2_cluster(&mut self, l2_entry: u64) -> io::Result<Vec<u8>> {
         let (compressed_addr, compressed_size) =
             l2_entry_compressed_cluster_layout(l2_entry, self.header.cluster_bits);
+        if !compressed_cluster_range_is_valid(
+            compressed_addr,
+            compressed_size,
+            self.raw_file.cluster_size(),
+            self.refcounts.max_valid_cluster_offset(),
+        ) {
+            self.set_corrupt_bit_best_effort();
+            return Err(io::Error::from_raw_os_error(EIO));
+        }
         self.raw_file
             .file_mut()
             .seek(io::SeekFrom::Start(compressed_addr))?;
@@ -1073,6 +1104,15 @@ impl QcowState {
         let (compressed_addr, compressed_size) =
             l2_entry_compressed_cluster_layout(l2_entry, self.header.cluster_bits);
         let cluster_size = self.raw_file.cluster_size();
+        if !compressed_cluster_range_is_valid(
+            compressed_addr,
+            compressed_size,
+            cluster_size,
+            self.refcounts.max_valid_cluster_offset(),
+        ) {
+            self.set_corrupt_bit_best_effort();
+            return Err(io::Error::from_raw_os_error(EIO));
+        }
 
         // Calculate the end of the compressed data region
         let compressed_clusters_end = self.raw_file.cluster_address(

--- a/block/src/formats/qcow/internal/metadata.rs
+++ b/block/src/formats/qcow/internal/metadata.rs
@@ -632,10 +632,16 @@ impl QcowState {
             self.reject_invalid_cluster_offset(l2_addr_disk)?;
             let l2_table =
                 VecCache::from_vec(self.raw_file.read_pointer_cluster(l2_addr_disk, None)?);
+            let cluster_size = self.raw_file.cluster_size();
+            let max_valid = self.refcounts.max_valid_cluster_offset();
             let l1_table = &self.l1_table;
             let raw_file = &mut self.raw_file;
             self.l2_cache.insert(l1_index, l2_table, |index, evicted| {
-                raw_file.write_pointer_table_direct(l1_table[index], evicted.iter())
+                let target = l1_table[index];
+                if !cluster_addr_is_valid(target, cluster_size, max_valid) {
+                    return Err(io::Error::from_raw_os_error(EIO));
+                }
+                raw_file.write_pointer_table_direct(target, evicted.iter())
             })?;
         }
         Ok(())
@@ -660,10 +666,16 @@ impl QcowState {
                 self.reject_invalid_cluster_offset(l2_addr_disk)?;
                 VecCache::from_vec(self.raw_file.read_pointer_cluster(l2_addr_disk, None)?)
             };
+            let cluster_size = self.raw_file.cluster_size();
+            let max_valid = self.refcounts.max_valid_cluster_offset();
             let l1_table = &self.l1_table;
             let raw_file = &mut self.raw_file;
             self.l2_cache.insert(l1_index, l2_table, |index, evicted| {
-                raw_file.write_pointer_table_direct(l1_table[index], evicted.iter())
+                let target = l1_table[index];
+                if !cluster_addr_is_valid(target, cluster_size, max_valid) {
+                    return Err(io::Error::from_raw_os_error(EIO));
+                }
+                raw_file.write_pointer_table_direct(target, evicted.iter())
             })?;
         }
         Ok(new_cluster)

--- a/block/src/formats/qcow/internal/metadata.rs
+++ b/block/src/formats/qcow/internal/metadata.rs
@@ -143,7 +143,15 @@ impl QcowMetadata {
             inner: RwLock::new(inner),
         }
     }
+}
 
+impl Drop for QcowMetadata {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+impl QcowMetadata {
     /// Maps a multicluster guest read range to a list of read mappings.
     ///
     /// This walks the range in cluster sized steps under a single lock

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -82,6 +82,8 @@ pub enum Error {
     GettingFileSize(#[source] io::Error),
     #[error("Failed to get refcount")]
     GettingRefcount(#[source] refcount::Error),
+    #[error("Header extension length too large: {0}")]
+    HeaderExtensionTooLarge(u32),
     #[error("Failed to parse filename")]
     InvalidBackingFileName(#[source] str::Utf8Error),
     #[error("Invalid cluster index")]

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -565,7 +565,7 @@ pub(crate) fn parse_qcow(
     let refcount_clusters = max_refcount_clusters(
         header.refcount_order,
         cluster_size as u32,
-        (num_clusters + l1_clusters + num_l2_clusters + header_clusters) as u32,
+        num_clusters + l1_clusters + num_l2_clusters + header_clusters,
     );
     // Check that the given header doesn't have a suspiciously sized refcount table.
     if u64::from(header.refcount_table_clusters) > 2 * refcount_clusters {
@@ -2524,15 +2524,18 @@ mod unit_tests {
         let mut header = QcowHeader::create_for_size_and_path(3, size, None).unwrap();
         let cluster_size = 1u32 << cluster_bits;
         let entries_per_cluster = cluster_size / std::mem::size_of::<u64>() as u32;
-        let num_clusters = div_round_up_u64(size, u64::from(cluster_size)) as u32;
-        let num_l2_clusters = div_round_up_u32(num_clusters, entries_per_cluster);
+        let num_clusters: u64 = div_round_up_u64(size, u64::from(cluster_size));
+        let num_l2_clusters = div_round_up_u64(num_clusters, u64::from(entries_per_cluster)) as u32;
         let l1_clusters = div_round_up_u32(num_l2_clusters, entries_per_cluster);
         let header_clusters =
             div_round_up_u32(std::mem::size_of::<QcowHeader>() as u32, cluster_size);
         let max_refcount_clusters = max_refcount_clusters(
             DEFAULT_REFCOUNT_ORDER,
             cluster_size,
-            num_clusters + l1_clusters + num_l2_clusters + header_clusters,
+            num_clusters
+                + u64::from(l1_clusters)
+                + u64::from(num_l2_clusters)
+                + u64::from(header_clusters),
         ) as u32;
 
         header.cluster_bits = cluster_bits;

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -47,7 +47,8 @@ use remain::sorted;
 use thiserror::Error;
 pub(crate) use util::MAX_NESTING_DEPTH;
 use util::{
-    L1_TABLE_OFFSET_MASK, L2_TABLE_OFFSET_MASK, div_round_up_u32, div_round_up_u64, l1_entry_make,
+    L1_TABLE_OFFSET_MASK, L2_TABLE_OFFSET_MASK, cluster_addr_is_valid,
+    compressed_cluster_range_is_valid, div_round_up_u32, div_round_up_u64, l1_entry_make,
     l2_entry_compressed_cluster_layout, l2_entry_is_compressed, l2_entry_is_empty,
     l2_entry_is_zero, l2_entry_make_std, l2_entry_make_zero, l2_entry_make_zero_plain,
     l2_entry_std_cluster_addr,
@@ -1414,6 +1415,17 @@ impl QcowFile {
     fn decompress_l2_cluster(&mut self, l2_entry: u64) -> std::io::Result<Vec<u8>> {
         let (compressed_cluster_addr, compressed_cluster_size) =
             l2_entry_compressed_cluster_layout(l2_entry, self.header.cluster_bits);
+        let cluster_size_u64 = self.raw_file.cluster_size();
+        let max_valid = self.refcounts.max_valid_cluster_offset();
+        if !compressed_cluster_range_is_valid(
+            compressed_cluster_addr,
+            compressed_cluster_size,
+            cluster_size_u64,
+            max_valid,
+        ) {
+            self.set_corrupt_bit_best_effort();
+            return Err(io::Error::from_raw_os_error(EIO));
+        }
         // Read compressed cluster from raw file
         self.raw_file
             .file_mut()
@@ -1486,7 +1498,9 @@ impl QcowFile {
             return Ok(Some(()));
         } else {
             let cluster_addr = l2_entry_std_cluster_addr(l2_entry);
-            if cluster_addr & (self.raw_file.cluster_size() - 1) != 0 {
+            let cluster_size = self.raw_file.cluster_size();
+            let max_valid = self.refcounts.max_valid_cluster_offset();
+            if !cluster_addr_is_valid(cluster_addr, cluster_size, max_valid) {
                 self.set_corrupt_bit_best_effort();
                 return Err(io::Error::from_raw_os_error(EIO));
             }
@@ -1561,7 +1575,9 @@ impl QcowFile {
             cluster_addr
         } else {
             let cluster_addr = l2_entry_std_cluster_addr(l2_entry);
-            if cluster_addr & (self.raw_file.cluster_size() - 1) != 0 {
+            let cluster_size = self.raw_file.cluster_size();
+            let max_valid = self.refcounts.max_valid_cluster_offset();
+            if !cluster_addr_is_valid(cluster_addr, cluster_size, max_valid) {
                 self.set_corrupt_bit_best_effort();
                 return Err(io::Error::from_raw_os_error(EIO));
             }
@@ -1732,12 +1748,23 @@ impl QcowFile {
     fn deallocate_compressed_cluster(&mut self, l2_entry: u64) -> std::io::Result<()> {
         let (compressed_cluster_addr, compressed_cluster_size) =
             l2_entry_compressed_cluster_layout(l2_entry, self.header.cluster_bits);
+        let cluster_size = self.raw_file.cluster_size();
+        let max_valid = self.refcounts.max_valid_cluster_offset();
+        if !compressed_cluster_range_is_valid(
+            compressed_cluster_addr,
+            compressed_cluster_size,
+            cluster_size,
+            max_valid,
+        ) {
+            self.set_corrupt_bit_best_effort();
+            return Err(io::Error::from_raw_os_error(EIO));
+        }
 
         // Calculate the end of the compressed data region
         let compressed_clusters_end = self.raw_file.cluster_address(
             compressed_cluster_addr             // Start of compressed data
             + compressed_cluster_size as u64    // Add size to get end address
-            + self.raw_file.cluster_size()
+            + cluster_size
                 - 1, // Catch possibly partially used last cluster
         );
 
@@ -1821,6 +1848,12 @@ impl QcowFile {
         }
 
         let cluster_addr = l2_entry_std_cluster_addr(l2_entry);
+        let cluster_size = self.raw_file.cluster_size();
+        let max_valid = self.refcounts.max_valid_cluster_offset();
+        if !cluster_addr_is_valid(cluster_addr, cluster_size, max_valid) {
+            self.set_corrupt_bit_best_effort();
+            return Err(io::Error::from_raw_os_error(EIO));
+        }
 
         // Decrement the refcount.
         let refcount = self

--- a/block/src/formats/qcow/internal/qcow_raw_file.rs
+++ b/block/src/formats/qcow/internal/qcow_raw_file.rs
@@ -106,7 +106,8 @@ where
     let bytes_per_entry = size_of::<T>();
     let mut buffer = BufWriter::with_capacity(table.len() * bytes_per_entry, file);
     for &val in table {
-        let converted = T::try_from(val).expect("refcount values are validated on increment");
+        let converted = T::try_from(val)
+            .map_err(|_| io::Error::other(format!("refcount value out of range: {val}")))?;
         T::write_be(&mut buffer, converted)?;
     }
     buffer.flush()

--- a/block/src/formats/qcow/internal/qcow_raw_file.rs
+++ b/block/src/formats/qcow/internal/qcow_raw_file.rs
@@ -277,13 +277,19 @@ impl QcowRawFile {
         // Determine where the new end of the file should be and set_len, which
         // translates to truncate(2).
         let file_end: u64 = self.file.seek(SeekFrom::End(0))?;
-        let new_cluster_address: u64 = (file_end + self.cluster_size - 1) & !self.cluster_mask;
+        let new_cluster_address: u64 = file_end
+            .checked_add(self.cluster_size - 1)
+            .ok_or_else(|| io::Error::other("file_end + cluster_size overflow"))?
+            & !self.cluster_mask;
 
         if new_cluster_address > max_valid_cluster_offset {
             return Ok(None);
         }
 
-        self.file.set_len(new_cluster_address + self.cluster_size)?;
+        let new_len = new_cluster_address
+            .checked_add(self.cluster_size)
+            .ok_or_else(|| io::Error::other("new cluster end overflow"))?;
+        self.file.set_len(new_len)?;
 
         Ok(Some(new_cluster_address))
     }

--- a/block/src/formats/qcow/internal/raw_file.rs
+++ b/block/src/formats/qcow/internal/raw_file.rs
@@ -100,7 +100,7 @@ impl RawFile {
 
     pub fn try_clone(&self) -> std::io::Result<RawFile> {
         Ok(RawFile {
-            file: self.file.try_clone().expect("RawFile cloning failed"),
+            file: self.file.try_clone()?,
             alignment: self.alignment,
             position: self.position,
             direct_io: self.direct_io,

--- a/block/src/formats/qcow/internal/raw_file.rs
+++ b/block/src/formats/qcow/internal/raw_file.rs
@@ -202,7 +202,7 @@ impl Read for RawFile {
                 to_copy = buf_len;
             }
 
-            buf.copy_from_slice(&tmp_buf[file_offset..(file_offset + buf_len)]);
+            buf[..to_copy].copy_from_slice(&tmp_buf[file_offset..(file_offset + to_copy)]);
             // SAFETY: tmp_ptr was allocated by alloc_zeroed with layout
             unsafe { dealloc(tmp_ptr, layout) };
 

--- a/block/src/formats/qcow/internal/raw_file.rs
+++ b/block/src/formats/qcow/internal/raw_file.rs
@@ -35,7 +35,9 @@ fn is_valid_alignment(fd: RawFd, alignment: usize) -> bool {
     let layout = Layout::from_size_align(alignment, alignment).unwrap();
     // SAFETY: layout has non-zero size
     let ptr = unsafe { alloc_zeroed(layout) };
-    assert!(!ptr.is_null());
+    if ptr.is_null() {
+        return false;
+    }
 
     // SAFETY: FFI call
     let ret = unsafe { ::libc::pread(fd, ptr.cast(), alignment, alignment.try_into().unwrap()) };

--- a/block/src/formats/qcow/internal/refcount.rs
+++ b/block/src/formats/qcow/internal/refcount.rs
@@ -75,8 +75,17 @@ impl RefCount {
             refcount_table_entries,
             None,
         )?);
-        let max_valid_cluster_index = (ref_table.len() as u64) * refcount_block_entries - 1;
-        let max_valid_cluster_offset = max_valid_cluster_index * cluster_size;
+        let max_valid_cluster_index = (ref_table.len() as u64)
+            .checked_mul(refcount_block_entries)
+            .and_then(|n| n.checked_sub(1))
+            .ok_or_else(|| {
+                io::Error::other("refcount table dimensions overflow max cluster index")
+            })?;
+        let max_valid_cluster_offset = max_valid_cluster_index
+            .checked_mul(cluster_size)
+            .ok_or_else(|| {
+                io::Error::other("refcount table dimensions overflow max cluster offset")
+            })?;
         let max_refcount = if refcount_bits >= 64 {
             u64::MAX
         } else {

--- a/block/src/formats/qcow/internal/refcount.rs
+++ b/block/src/formats/qcow/internal/refcount.rs
@@ -10,6 +10,7 @@ use libc::EINVAL;
 use thiserror::Error;
 
 use super::qcow_raw_file::QcowRawFile;
+use super::util::cluster_addr_is_valid;
 use super::vec_cache::{CacheMap, Cacheable, VecCache};
 
 #[derive(Debug, Error)]
@@ -143,9 +144,15 @@ impl RefCount {
             if let Some((addr, table)) = new_cluster.take() {
                 self.ref_table[table_index] = addr;
                 let ref_table = &self.ref_table;
+                let cluster_size = self.cluster_size;
+                let max_valid = self.max_valid_cluster_offset;
                 self.refblock_cache
                     .insert(table_index, table, |index, evicted| {
-                        raw_file.write_refcount_block(ref_table[index], evicted.get_values())
+                        let target = ref_table[index];
+                        if !cluster_addr_is_valid(target, cluster_size, max_valid) {
+                            return Err(io::Error::from_raw_os_error(EINVAL));
+                        }
+                        raw_file.write_refcount_block(target, evicted.get_values())
                     })
                     .map_err(Error::EvictingRefCounts)?;
             } else {
@@ -180,11 +187,10 @@ impl RefCount {
         // Write out all dirty L2 tables.
         for (table_index, block) in self.refblock_cache.iter_mut().filter(|(_k, v)| v.dirty()) {
             let addr = self.ref_table[*table_index];
-            if addr != 0 {
-                raw_file.write_refcount_block(addr, block.get_values())?;
-            } else {
+            if !cluster_addr_is_valid(addr, self.cluster_size, self.max_valid_cluster_offset) {
                 return Err(std::io::Error::from_raw_os_error(EINVAL));
             }
+            raw_file.write_refcount_block(addr, block.get_values())?;
             block.mark_clean();
         }
         Ok(())
@@ -224,9 +230,15 @@ impl RefCount {
                     .map_err(Error::ReadingRefCounts)?,
             );
             let ref_table = &self.ref_table;
+            let cluster_size = self.cluster_size;
+            let max_valid = self.max_valid_cluster_offset;
             self.refblock_cache
                 .insert(table_index, table, |index, evicted| {
-                    raw_file.write_refcount_block(ref_table[index], evicted.get_values())
+                    let target = ref_table[index];
+                    if !cluster_addr_is_valid(target, cluster_size, max_valid) {
+                        return Err(io::Error::from_raw_os_error(EINVAL));
+                    }
+                    raw_file.write_refcount_block(target, evicted.get_values())
                 })
                 .map_err(Error::EvictingRefCounts)?;
         }
@@ -254,11 +266,16 @@ impl RefCount {
                     .read_refcount_block(block_addr_disk)
                     .map_err(Error::ReadingRefCounts)?,
             );
-            // TODO(dgreid) - closure needs to return an error.
             let ref_table = &self.ref_table;
+            let cluster_size = self.cluster_size;
+            let max_valid = self.max_valid_cluster_offset;
             self.refblock_cache
                 .insert(table_index, table, |index, evicted| {
-                    raw_file.write_refcount_block(ref_table[index], evicted.get_values())
+                    let target = ref_table[index];
+                    if !cluster_addr_is_valid(target, cluster_size, max_valid) {
+                        return Err(io::Error::from_raw_os_error(EINVAL));
+                    }
+                    raw_file.write_refcount_block(target, evicted.get_values())
                 })
                 .map_err(Error::EvictingRefCounts)?;
         }

--- a/block/src/formats/qcow/internal/util.rs
+++ b/block/src/formats/qcow/internal/util.rs
@@ -54,6 +54,41 @@ pub(super) fn l2_entry_std_cluster_addr(l2_entry: u64) -> u64 {
     l2_entry & L2_TABLE_OFFSET_MASK
 }
 
+/// Returns true if `cluster_addr` is cluster aligned and within
+/// `[cluster_size, max_valid_cluster_offset]`.
+pub(super) fn cluster_addr_is_valid(
+    cluster_addr: u64,
+    cluster_size: u64,
+    max_valid_cluster_offset: u64,
+) -> bool {
+    cluster_addr >= cluster_size
+        && cluster_addr <= max_valid_cluster_offset
+        && cluster_addr.is_multiple_of(cluster_size)
+}
+
+/// Returns true if the compressed cluster address is within spec bounds.
+pub(super) fn compressed_cluster_addr_is_valid(addr: u64) -> bool {
+    addr < (1u64 << 56)
+}
+
+/// Returns true if the entire `[addr, addr+size)` range lies within
+/// `[cluster_size, max_valid_cluster_offset]` and the address is below 2^56.
+pub(super) fn compressed_cluster_range_is_valid(
+    addr: u64,
+    size: usize,
+    cluster_size: u64,
+    max_valid_cluster_offset: u64,
+) -> bool {
+    let Some(end) = addr.checked_add(size as u64) else {
+        return false;
+    };
+    compressed_cluster_addr_is_valid(addr)
+        && addr >= cluster_size
+        && max_valid_cluster_offset
+            .checked_add(cluster_size)
+            .is_some_and(|limit| end <= limit)
+}
+
 /// Make L2 entry for standard (non-compressed) cluster.
 pub(super) fn l2_entry_make_std(cluster_addr: u64) -> u64 {
     (cluster_addr & L2_TABLE_OFFSET_MASK) | CLUSTER_USED_FLAG

--- a/block/src/formats/qcow/internal/util.rs
+++ b/block/src/formats/qcow/internal/util.rs
@@ -38,6 +38,7 @@ pub(super) fn l2_entry_is_compressed(l2_entry: u64) -> bool {
 
 /// Get file offset and size of compressed cluster data.
 pub(super) fn l2_entry_compressed_cluster_layout(l2_entry: u64, cluster_bits: u32) -> (u64, usize) {
+    debug_assert!(cluster_bits >= 9);
     let compressed_size_shift = 62 - (cluster_bits - 8);
     let compressed_size_mask = (1 << (cluster_bits - 8)) - 1;
     let compressed_cluster_addr = l2_entry & ((1 << compressed_size_shift) - 1);

--- a/block/src/formats/qcow/mod.rs
+++ b/block/src/formats/qcow/mod.rs
@@ -97,12 +97,6 @@ impl QcowDisk {
     }
 }
 
-impl Drop for QcowDisk {
-    fn drop(&mut self) {
-        self.metadata.shutdown();
-    }
-}
-
 impl disk_file::DiskSize for QcowDisk {
     fn logical_size(&self) -> BlockResult<u64> {
         Ok(self.metadata.virtual_size())

--- a/block/src/formats/vhd/internal/fixed.rs
+++ b/block/src/formats/vhd/internal/fixed.rs
@@ -38,7 +38,10 @@ impl Read for FixedVhd {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         match self.file.read(buf) {
             Ok(r) => {
-                self.position = self.position.checked_add(r.try_into().unwrap()).unwrap();
+                self.position = self
+                    .position
+                    .checked_add(r as u64)
+                    .ok_or_else(|| std::io::Error::other("position overflow"))?;
                 Ok(r)
             }
             Err(e) => Err(e),
@@ -50,7 +53,10 @@ impl Write for FixedVhd {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         match self.file.write(buf) {
             Ok(r) => {
-                self.position = self.position.checked_add(r.try_into().unwrap()).unwrap();
+                self.position = self
+                    .position
+                    .checked_add(r as u64)
+                    .ok_or_else(|| std::io::Error::other("position overflow"))?;
                 Ok(r)
             }
             Err(e) => Err(e),

--- a/block/src/formats/vhd/internal/footer.rs
+++ b/block/src/formats/vhd/internal/footer.rs
@@ -35,13 +35,16 @@ impl VhdFooter {
     pub fn new(file: &mut File) -> std::io::Result<VhdFooter> {
         let blocksize = DiskTopology::probe(file)?.logical_block_size as usize;
 
+        let offset = blocksize.checked_sub(512).ok_or_else(|| {
+            std::io::Error::other(format!("logical block size below 512 bytes: {blocksize}"))
+        })?;
+
         // Place the cursor in the last block of the file
         file.seek(SeekFrom::End(0 - (blocksize as i64)))?;
         // Read in the last block
         let data = read_aligned_block_size(file)?;
 
         // We only care about the last sector
-        let offset = blocksize - 512;
         let sector = &data[offset..];
 
         Ok(VhdFooter {

--- a/block/src/formats/vhdx/internal/bat.rs
+++ b/block/src/formats/vhdx/internal/bat.rs
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fs::File;
-use std::io::{self, Seek, SeekFrom};
+use std::io::{self, Read, Seek, SeekFrom};
 use std::mem::size_of;
 
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 use remain::sorted;
 use thiserror::Error;
 
@@ -61,16 +61,15 @@ impl BatEntry {
         }
 
         let mut bat: Vec<BatEntry> = Vec::with_capacity(entry_count as usize);
-        let offset = bat_entry.file_offset;
-        for i in 0..entry_count {
-            f.seek(SeekFrom::Start(offset + i * size_of::<u64>() as u64))
-                .map_err(VhdxBatError::ReadBat)?;
-
-            let bat_entry = BatEntry(
-                f.read_u64::<LittleEndian>()
-                    .map_err(VhdxBatError::ReadBat)?,
-            );
-            bat.insert(i as usize, bat_entry);
+        let bytes = (entry_count as usize)
+            .checked_mul(size_of::<u64>())
+            .ok_or(VhdxBatError::InvalidEntryCount)?;
+        f.seek(SeekFrom::Start(bat_entry.file_offset))
+            .map_err(VhdxBatError::ReadBat)?;
+        let mut buf = vec![0u8; bytes];
+        f.read_exact(&mut buf).map_err(VhdxBatError::ReadBat)?;
+        for chunk in buf.chunks_exact(size_of::<u64>()) {
+            bat.push(BatEntry(LittleEndian::read_u64(chunk)));
         }
 
         Ok(bat)
@@ -82,25 +81,15 @@ impl BatEntry {
         data_blocks_count + (data_blocks_count - 1) / chunk_ratio
     }
 
-    // Routine for writing BAT entries to the disk
-    pub fn write_bat_entries(
-        f: &mut File,
-        bat_offset: u64,
-        bat_entries: &[BatEntry],
-    ) -> Result<()> {
-        for i in 0..bat_entries.len() as u64 {
-            f.seek(SeekFrom::Start(bat_offset + i * size_of::<u64>() as u64))
-                .map_err(VhdxBatError::WriteBat)?;
-            let bat_entry = match bat_entries.get(i as usize) {
-                Some(entry) => entry.0,
-                None => {
-                    return Err(VhdxBatError::InvalidBatEntry);
-                }
-            };
-
-            f.write_u64::<LittleEndian>(bat_entry)
-                .map_err(VhdxBatError::WriteBat)?;
-        }
+    pub fn write_bat_entry(f: &mut File, bat_offset: u64, index: u64, value: u64) -> Result<()> {
+        let off = index
+            .checked_mul(size_of::<u64>() as u64)
+            .and_then(|o| bat_offset.checked_add(o))
+            .ok_or(VhdxBatError::InvalidBatEntry)?;
+        f.seek(SeekFrom::Start(off))
+            .map_err(VhdxBatError::WriteBat)?;
+        f.write_u64::<LittleEndian>(value)
+            .map_err(VhdxBatError::WriteBat)?;
         Ok(())
     }
 }

--- a/block/src/formats/vhdx/internal/bat.rs
+++ b/block/src/formats/vhdx/internal/bat.rs
@@ -60,7 +60,7 @@ impl BatEntry {
             return Err(VhdxBatError::InvalidEntryCount);
         }
 
-        let mut bat: Vec<BatEntry> = Vec::with_capacity(bat_entry.length as usize);
+        let mut bat: Vec<BatEntry> = Vec::with_capacity(entry_count as usize);
         let offset = bat_entry.file_offset;
         for i in 0..entry_count {
             f.seek(SeekFrom::Start(offset + i * size_of::<u64>() as u64))

--- a/block/src/formats/vhdx/internal/header.rs
+++ b/block/src/formats/vhdx/internal/header.rs
@@ -81,6 +81,8 @@ pub enum VhdxHeaderError {
     SeekRegionTableEntries(#[source] io::Error),
     #[error("Failed to seek in region table header {0}")]
     SeekRegionTableHeader(#[source] io::Error),
+    #[error("Header sequence number overflowed")]
+    SequenceOverflow,
     #[error("We do not recognize this entry")]
     UnrecognizedRegionEntry,
     #[error("Failed to write header {0}")]
@@ -180,7 +182,10 @@ impl Header {
         let mut new_header = Header {
             signature: current_header.signature,
             checksum: 0,
-            sequence_number: current_header.sequence_number + 1,
+            sequence_number: current_header
+                .sequence_number
+                .checked_add(1)
+                .ok_or(VhdxHeaderError::SequenceOverflow)?,
             file_write_guid,
             data_write_guid,
             log_guid: current_header.log_guid,
@@ -196,7 +201,7 @@ impl Header {
 
         f.seek(SeekFrom::Start(start))
             .map_err(VhdxHeaderError::SeekHeader)?;
-        f.write(&buffer).map_err(VhdxHeaderError::WriteHeader)?;
+        f.write_all(&buffer).map_err(VhdxHeaderError::WriteHeader)?;
 
         Ok(new_header)
     }

--- a/block/src/formats/vhdx/internal/header.rs
+++ b/block/src/formats/vhdx/internal/header.rs
@@ -67,6 +67,8 @@ pub enum VhdxHeaderError {
     ReadRegionTableHeader(#[source] io::Error),
     #[error("Failed to read region entries")]
     RegionEntryCollectionFailed,
+    #[error("Region table entry length overflows file offset")]
+    RegionLengthOverflow,
     #[error("Overlapping regions found")]
     RegionOverlap,
     #[error("Reserved region has non-zero value")]
@@ -274,15 +276,19 @@ impl RegionInfo {
 
             offset += size_of::<RegionTableEntry>();
             let start = entry.file_offset;
-            let end = start + entry.length as u64;
+            let end = start
+                .checked_add(entry.length as u64)
+                .ok_or(VhdxHeaderError::RegionLengthOverflow)?;
 
-            for (region_ent_start, region_ent_end) in region_entries.iter() {
-                if !((start >= *region_ent_start) || (end <= *region_ent_end)) {
+            for (&region_ent_start, &region_ent_end) in region_entries.iter() {
+                if start < region_ent_end && region_ent_start < end {
                     return Err(VhdxHeaderError::RegionOverlap);
                 }
             }
 
-            region_entries.insert(entry.file_offset, entry.file_offset + entry.length as u64);
+            if region_entries.insert(start, end).is_some() {
+                return Err(VhdxHeaderError::RegionOverlap);
+            }
 
             if entry.guid == Uuid::parse_str(BAT_GUID).map_err(VhdxHeaderError::InvalidUuid)? {
                 if bat_entry.is_none() {

--- a/block/src/formats/vhdx/internal/header.rs
+++ b/block/src/formats/vhdx/internal/header.rs
@@ -253,7 +253,6 @@ impl RegionTableHeader {
 pub struct RegionInfo {
     pub bat_entry: RegionTableEntry,
     pub mdr_entry: RegionTableEntry,
-    pub region_entries: BTreeMap<u64, u64>,
 }
 
 impl RegionInfo {
@@ -319,7 +318,6 @@ impl RegionInfo {
         }
 
         if bat_entry.is_none() || mdr_entry.is_none() {
-            region_entries.clear();
             return Err(VhdxHeaderError::RegionEntryCollectionFailed);
         }
 
@@ -331,7 +329,6 @@ impl RegionInfo {
         Ok(RegionInfo {
             bat_entry,
             mdr_entry,
-            region_entries,
         })
     }
 }

--- a/block/src/formats/vhdx/internal/io.rs
+++ b/block/src/formats/vhdx/internal/io.rs
@@ -74,7 +74,10 @@ impl Sector {
         };
         sector.file_offset = bat_entry & bat::BAT_FILE_OFF_MASK;
         if sector.file_offset != 0 {
-            sector.file_offset += sector.block_offset;
+            sector.file_offset = sector
+                .file_offset
+                .checked_add(sector.block_offset)
+                .ok_or(VhdxIoError::InvalidBatEntryState)?;
         }
 
         Ok(sector)

--- a/block/src/formats/vhdx/internal/io.rs
+++ b/block/src/formats/vhdx/internal/io.rs
@@ -178,7 +178,8 @@ pub fn write(
                 let new_bat_entry =
                     file_offset | (bat::PAYLOAD_BLOCK_FULLY_PRESENT & bat::BAT_STATE_BIT_MASK);
                 bat[sector.bat_index as usize] = BatEntry(new_bat_entry);
-                BatEntry::write_bat_entries(f, bat_offset, bat).map_err(VhdxIoError::WriteBat)?;
+                BatEntry::write_bat_entry(f, bat_offset, sector.bat_index, new_bat_entry)
+                    .map_err(VhdxIoError::WriteBat)?;
 
                 if file_offset < metadata::BLOCK_SIZE_MIN as u64 {
                     break;

--- a/block/src/formats/vhdx/internal/io.rs
+++ b/block/src/formats/vhdx/internal/io.rs
@@ -11,8 +11,6 @@ use thiserror::Error;
 use super::bat::{self, BatEntry, VhdxBatError};
 use super::metadata::{self, DiskSpec};
 
-const SECTOR_SIZE: u64 = 512;
-
 #[sorted]
 #[derive(Error, Debug)]
 pub enum VhdxIoError {
@@ -116,11 +114,10 @@ pub fn read(
             bat::PAYLOAD_BLOCK_FULLY_PRESENT => {
                 f.seek(SeekFrom::Start(sector.file_offset))
                     .map_err(VhdxIoError::ReadSectorBlock)?;
-                f.read_exact(
-                    &mut buf
-                        [read_count..(read_count + (sector.free_sectors * SECTOR_SIZE) as usize)],
-                )
-                .map_err(VhdxIoError::ReadSectorBlock)?;
+                let start = read_count;
+                let end = read_count + sector.free_bytes as usize;
+                f.read_exact(&mut buf[start..end])
+                    .map_err(VhdxIoError::ReadSectorBlock)?;
             }
             bat::PAYLOAD_BLOCK_PARTIALLY_PRESENT => {
                 return Err(VhdxIoError::UnsupportedMode);
@@ -186,10 +183,10 @@ pub fn write(
 
                 f.seek(SeekFrom::Start(file_offset))
                     .map_err(VhdxIoError::ReadSectorBlock)?;
-                f.write_all(
-                    &buf[write_count..(write_count + (sector.free_sectors * SECTOR_SIZE) as usize)],
-                )
-                .map_err(VhdxIoError::ReadSectorBlock)?;
+                let start = write_count;
+                let end = write_count + sector.free_bytes as usize;
+                f.write_all(&buf[start..end])
+                    .map_err(VhdxIoError::ReadSectorBlock)?;
             }
             bat::PAYLOAD_BLOCK_FULLY_PRESENT => {
                 if sector.file_offset < metadata::BLOCK_SIZE_MIN as u64 {
@@ -198,10 +195,10 @@ pub fn write(
 
                 f.seek(SeekFrom::Start(sector.file_offset))
                     .map_err(VhdxIoError::ReadSectorBlock)?;
-                f.write_all(
-                    &buf[write_count..(write_count + (sector.free_sectors * SECTOR_SIZE) as usize)],
-                )
-                .map_err(VhdxIoError::ReadSectorBlock)?;
+                let start = write_count;
+                let end = write_count + sector.free_bytes as usize;
+                f.write_all(&buf[start..end])
+                    .map_err(VhdxIoError::ReadSectorBlock)?;
             }
             bat::PAYLOAD_BLOCK_PARTIALLY_PRESENT => {
                 return Err(VhdxIoError::UnsupportedMode);

--- a/block/src/formats/vhdx/internal/io.rs
+++ b/block/src/formats/vhdx/internal/io.rs
@@ -181,7 +181,7 @@ pub fn write(
                     break;
                 }
 
-                f.seek(SeekFrom::Start(file_offset))
+                f.seek(SeekFrom::Start(file_offset + sector.block_offset))
                     .map_err(VhdxIoError::ReadSectorBlock)?;
                 let start = write_count;
                 let end = write_count + sector.free_bytes as usize;

--- a/block/src/formats/vhdx/internal/metadata.rs
+++ b/block/src/formats/vhdx/internal/metadata.rs
@@ -123,6 +123,13 @@ impl DiskSpec {
             let metadata_entry =
                 MetadataTableEntry::new(&buffer[offset..offset + size_of::<MetadataTableEntry>()])?;
 
+            let entry_end = (metadata_entry.offset as u64)
+                .checked_add(metadata_entry.length as u64)
+                .ok_or(VhdxMetadataError::InvalidMetadataLength)?;
+            if entry_end > metadata_region.length as u64 {
+                return Err(VhdxMetadataError::InvalidMetadataLength);
+            }
+
             f.seek(SeekFrom::Start(
                 metadata_region.file_offset + metadata_entry.offset as u64,
             ))

--- a/block/src/formats/vhdx/internal/mod.rs
+++ b/block/src/formats/vhdx/internal/mod.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::btree_map::BTreeMap;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::os::fd::{AsRawFd, RawFd};
@@ -48,9 +47,7 @@ pub type Result<T> = std::result::Result<T, VhdxError>;
 pub struct Vhdx {
     file: File,
     vhdx_header: VhdxHeader,
-    region_entries: BTreeMap<u64, u64>,
     bat_entry: RegionTableEntry,
-    mdr_entry: RegionTableEntry,
     disk_spec: DiskSpec,
     bat_entries: Vec<BatEntry>,
     current_offset: u64,
@@ -81,9 +78,7 @@ impl Vhdx {
         Ok(Vhdx {
             file,
             vhdx_header,
-            region_entries: collected_entries.region_entries,
             bat_entry,
-            mdr_entry,
             disk_spec,
             bat_entries,
             current_offset: 0,
@@ -211,22 +206,6 @@ impl BlockBackend for Vhdx {
             .metadata()
             .map(|m| m.len())
             .map_err(crate::Error::GetFileMetadata)
-    }
-}
-
-impl Clone for Vhdx {
-    fn clone(&self) -> Self {
-        Vhdx {
-            file: self.file.try_clone().unwrap(),
-            vhdx_header: self.vhdx_header.clone(),
-            region_entries: self.region_entries.clone(),
-            bat_entry: self.bat_entry,
-            mdr_entry: self.mdr_entry,
-            disk_spec: self.disk_spec.clone(),
-            bat_entries: self.bat_entries.clone(),
-            current_offset: self.current_offset,
-            first_write: self.first_write,
-        }
     }
 }
 

--- a/block/src/formats/vhdx/internal/mod.rs
+++ b/block/src/formats/vhdx/internal/mod.rs
@@ -125,7 +125,7 @@ impl Read for Vhdx {
 
 impl Write for Vhdx {
     fn flush(&mut self) -> std::result::Result<(), std::io::Error> {
-        self.file.flush()
+        self.file.sync_all()
     }
 
     /// Wrapper function to satisfy Write trait implementation for VHDx disk.


### PR DESCRIPTION
These are AI-assisted fixes into possible bugs in the block image backends.
These implementations have been cross-referenced with the QEMU versions and the
specs where possible.

- **block: vhd: Reject logical block size below 512 in VhdFooter::new**
- **block: vhd: Don't panic on FixedVhd position overflow**
- **block: vhdx: Use logical_sector_size for read/write slice length**
- **block: vhdx: Seek to intra-block offset on newly-allocated write**
- **block: vhdx: Use sync_all in flush so guest fsync reaches disk**
- **block: vhdx: Use entry_count, not byte-length, for BAT capacity**
- **block: vhdx: Fix region overlap detection and reject duplicates**
- **block: vhdx: Use write_all and checked_add in update_header**
- **block: vhdx: Use checked_add when applying intra-block offset**
- **block: vhdx: Bound metadata entry offset+length to its region**
- **block: vhdx: Drop unused Clone impl and dead fields**
- **block: vhdx: Update one BAT entry per sparse allocation**
- **block: qcow: Don't overwrite caller buffer past short read**
- **block: qcow: Cap header extension allocation length**
- **block: qcow: Use checked arithmetic in RefCount::new bounds**
- **block: qcow: Avoid u32 truncation when computing max_refcount_clusters**
- **block: qcow: Validate offsets in pread_exact and pwrite_all**
- **block: qcow: Use checked arithmetic in add_cluster_end**
- **block: qcow: Don't panic on alloc failure in is_valid_alignment**
- **block: qcow: Surface out-of-range refcount values as io::Error**
- **block: qcow: Propagate try_clone errors instead of panicking**
- **block: qcow: Assert cluster_bits >= 9 in compressed-cluster math**
- **block: qcow: Validate L2 host offsets against cluster bounds**
- **block: qcow: Validate L1 entries before L2 cache load and eviction**
- **block: qcow: Validate refcount table entries before flushing refblocks**
- **block: qcow: Clear DIRTY bit only when the last metadata ref drops**
- **block: qcow: Drop Qcow2Backing's per-clone shutdown**
