### PR TITLE
block: fix `cargo test -p block`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
+ "cfg-if",
  "crc-any",
  "flate2",
  "io-uring",

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -33,5 +33,8 @@ vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { workspace = true }
 zstd = "0.13"
 
+[dev-dependencies]
+cfg-if = { workspace = true }
+
 [lints]
 workspace = true

--- a/block/src/raw_disk.rs
+++ b/block/src/raw_disk.rs
@@ -170,10 +170,15 @@ mod unit_tests {
 
     fn assert_async_io_from_dyn(disk: &dyn AsyncDiskFile, expect_backend: RawBackend) {
         let io: Box<dyn AsyncIo> = disk.create_async_io(128).unwrap();
-        assert_eq!(
-            io.batch_requests_enabled(),
-            expect_backend == RawBackend::IoUring
-        );
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "io_uring")] {
+                let expected_batch_requests = expect_backend == RawBackend::IoUring;
+            } else {
+                let _ = expect_backend;
+                let expected_batch_requests = false;
+            }
+        }
+        assert_eq!(io.batch_requests_enabled(), expected_batch_requests);
     }
 
     fn assert_sync_backend(disk: &RawDisk) {


### PR DESCRIPTION
`RawBackend::IoUring` is only available when `io_uring` feature is defined.