### PR TITLE
virtio-devices: vhost-user: Cancel reconnection if device unplugged

### DIFF
--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -198,6 +198,8 @@ fn virtio_vhost_fs_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_sendmsg, vec![]),
         (libc::SYS_sendto, vec![]),
         (libc::SYS_socket, vec![]),
+        (libc::SYS_timerfd_create, vec![]),
+        (libc::SYS_timerfd_settime, vec![]),
     ]
 }
 
@@ -212,6 +214,8 @@ fn virtio_generic_vhost_user_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_sendmsg, vec![]),
         (libc::SYS_sendto, vec![]),
         (libc::SYS_socket, vec![]),
+        (libc::SYS_timerfd_create, vec![]),
+        (libc::SYS_timerfd_settime, vec![]),
     ]
 }
 
@@ -232,6 +236,8 @@ fn virtio_vhost_net_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_sendmsg, vec![]),
         (libc::SYS_sendto, vec![]),
         (libc::SYS_socket, vec![]),
+        (libc::SYS_timerfd_create, vec![]),
+        (libc::SYS_timerfd_settime, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_unlink, vec![]),
         #[cfg(target_arch = "aarch64")]
@@ -247,6 +253,8 @@ fn virtio_vhost_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_recvmsg, vec![]),
         (libc::SYS_sendmsg, vec![]),
         (libc::SYS_socket, vec![]),
+        (libc::SYS_timerfd_create, vec![]),
+        (libc::SYS_timerfd_settime, vec![]),
     ]
 }
 

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -59,8 +59,13 @@ impl Blk {
     ) -> Result<Blk> {
         let num_queues = vu_cfg.num_queues;
 
-        let mut vu =
-            VhostUserHandle::connect_vhost_user(false, &vu_cfg.socket, num_queues as u64, false)?;
+        let mut vu = VhostUserHandle::connect_vhost_user(
+            false,
+            &vu_cfg.socket,
+            num_queues as u64,
+            false,
+            None,
+        )?;
 
         let (
             avail_features,

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -90,7 +90,8 @@ impl Fs {
         let num_queues = NUM_QUEUE_OFFSET + req_num_queues;
 
         // Connect to the vhost-user socket.
-        let mut vu = VhostUserHandle::connect_vhost_user(false, path, num_queues as u64, false)?;
+        let mut vu =
+            VhostUserHandle::connect_vhost_user(false, path, num_queues as u64, false, None)?;
 
         let (
             avail_features,

--- a/virtio-devices/src/vhost_user/generic_vhost_user.rs
+++ b/virtio-devices/src/vhost_user/generic_vhost_user.rs
@@ -78,7 +78,8 @@ impl GenericVhostUser {
         let num_queues = request_queue_sizes.len();
 
         // Connect to the vhost-user socket.
-        let mut vu = VhostUserHandle::connect_vhost_user(false, path, num_queues as u64, false)?;
+        let mut vu =
+            VhostUserHandle::connect_vhost_user(false, path, num_queues as u64, false, None)?;
 
         let (
             avail_features,

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -9,7 +9,7 @@ use std::{io, thread};
 
 use anyhow::anyhow;
 use event_monitor::event;
-use log::error;
+use log::{error, info};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vhost::Error as VhostError;
@@ -303,6 +303,10 @@ impl<S: VhostUserFrontendReqHandler> EpollHelperHandler for VhostUserEpollHandle
         let ev_type = event.data as u16;
         match ev_type {
             HUP_CONNECTION_EVENT => {
+                info!(
+                    "vhost-user backend for socket {} disconnected, attempting reconnection",
+                    self.socket_path
+                );
                 self.reconnect(helper).map_err(|e| {
                     EpollHelperError::HandleEvent(anyhow!(
                         "failed to reconnect vhost-user backend for socket {}: {e:?}",

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -72,7 +72,7 @@ pub enum Error {
     #[error("Failed to open vhost device")]
     VhostUserOpen(#[source] VhostError),
     #[error("Connection to socket failed")]
-    VhostUserConnect,
+    VhostUserConnect(#[source] VhostError),
     #[error("Get features failed")]
     VhostUserGetFeatures(#[source] VhostError),
     #[error("Get queue max number failed")]
@@ -159,6 +159,18 @@ pub enum Error {
     VringBasesCountMismatch(usize, usize),
     #[error("Backend state and vring bases must both be present or both be absent")]
     InconsistentBackendState,
+    #[error("Failed to create timerfd")]
+    TimerFdCreate(#[source] io::Error),
+    #[error("Failed to arm timerfd")]
+    TimerFdArm(#[source] io::Error),
+    #[error("Failed waiting on timerfd")]
+    TimerFdWait(#[source] io::Error),
+    #[error("Failed to create epoll instance")]
+    EpollCreate(#[source] io::Error),
+    #[error("Failed to add fd to epoll")]
+    EpollCtl(#[source] io::Error),
+    #[error("Failed waiting on epoll")]
+    EpollWait(#[source] io::Error),
 }
 type Result<T> = std::result::Result<T, Error>;
 

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -171,6 +171,8 @@ pub enum Error {
     EpollCtl(#[source] io::Error),
     #[error("Failed waiting on epoll")]
     EpollWait(#[source] io::Error),
+    #[error("Aborted vhost-user connect: kill event received")]
+    ConnectKilled,
 }
 type Result<T> = std::result::Result<T, Error>;
 
@@ -236,18 +238,25 @@ impl<S: VhostUserFrontendReqHandler> VhostUserEpollHandler<S> {
             epoll::Events::EPOLLHUP,
         )?;
 
-        let mut vhost_user = VhostUserHandle::connect_vhost_user(
+        let mut vhost_user = match VhostUserHandle::connect_vhost_user(
             self.server,
             &self.socket_path,
             self.queues.len() as u64,
             true,
-        )
-        .map_err(|e| {
-            EpollHelperError::IoError(std::io::Error::other(format!(
-                "failed connecting vhost-user backend for socket {}: {e:?}",
-                self.socket_path
-            )))
-        })?;
+            Some(&self.kill_evt),
+        ) {
+            Ok(vu) => vu,
+            // Kill event fired during the connect retry loop; abandon the
+            // reconnect attempt. The EpollHelper observes the same kill
+            // event and will tear down on its next iteration.
+            Err(Error::ConnectKilled) => return Ok(()),
+            Err(e) => {
+                return Err(EpollHelperError::IoError(std::io::Error::other(format!(
+                    "failed connecting vhost-user backend for socket {}: {e:?}",
+                    self.socket_path
+                ))));
+            }
+        };
 
         let queues = self
             .queues
@@ -428,6 +437,7 @@ impl VhostUserCommon {
             &self.socket_path,
             self.vu_num_queues as u64,
             false,
+            None,
         )?;
 
         vu.set_protocol_features_vhost_user(acked_features, self.acked_protocol_features)?;

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -69,8 +69,13 @@ impl Net {
     ) -> Result<Net> {
         let mut num_queues = vu_cfg.num_queues;
 
-        let mut vu =
-            VhostUserHandle::connect_vhost_user(server, &vu_cfg.socket, num_queues as u64, false)?;
+        let mut vu = VhostUserHandle::connect_vhost_user(
+            server,
+            &vu_cfg.socket,
+            num_queues as u64,
+            false,
+            None,
+        )?;
 
         let (
             avail_features,

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -8,7 +8,6 @@ use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 use log::{error, info};
@@ -26,7 +25,9 @@ use virtio_queue::{Queue, QueueT};
 use vm_memory::guest_memory::Error as MmapError;
 use vm_memory::{Address, FileOffset, GuestAddress, GuestMemory, GuestMemoryRegion};
 use vm_migration::protocol::MemoryRangeTable;
+use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 use vmm_sys_util::eventfd::EventFd;
+use vmm_sys_util::timerfd::TimerFd;
 
 use super::{Error, Result, VhostUserState};
 use crate::vhost_user::Inflight;
@@ -402,10 +403,28 @@ impl VhostUserHandle {
                 queue_indexes: Vec::new(),
             })
         } else {
-            let now = Instant::now();
+            const RETRY_INTERVAL: Duration = Duration::from_millis(100);
+            const CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
+            const TIMER_EVENT: u64 = 0;
 
-            // Retry connecting for a full minute
-            let err = loop {
+            let mut retry_timer = TimerFd::new().map_err(|e| Error::TimerFdCreate(e.into()))?;
+            retry_timer
+                .reset(RETRY_INTERVAL, Some(RETRY_INTERVAL))
+                .map_err(|e| Error::TimerFdArm(e.into()))?;
+
+            let epoll = Epoll::new().map_err(Error::EpollCreate)?;
+            epoll
+                .ctl(
+                    ControlOperation::Add,
+                    retry_timer.as_raw_fd(),
+                    EpollEvent::new(EventSet::IN, TIMER_EVENT),
+                )
+                .map_err(Error::EpollCtl)?;
+
+            let start = Instant::now();
+            let mut events = [EpollEvent::default(); 1];
+
+            loop {
                 let err = match Frontend::connect(socket_path, num_queues) {
                     Ok(m) => {
                         return Ok(VhostUserHandle {
@@ -421,17 +440,27 @@ impl VhostUserHandle {
                     }
                     Err(e) => e,
                 };
-                sleep(Duration::from_millis(100));
 
-                if now.elapsed().as_secs() >= 60 {
-                    break err;
+                if start.elapsed() >= CONNECT_TIMEOUT {
+                    error!(
+                        "Failed connecting the backend after trying for 1 minute for socket {socket_path}: {err:?}"
+                    );
+                    return Err(Error::VhostUserConnect(err));
                 }
-            };
 
-            error!(
-                "Failed connecting the backend after trying for 1 minute for socket {socket_path}: {err:?}"
-            );
-            Err(Error::VhostUserConnect)
+                loop {
+                    match epoll.wait(-1, &mut events) {
+                        Ok(_) => break,
+                        Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                        Err(e) => return Err(Error::EpollWait(e)),
+                    }
+                }
+
+                // Drain the timerfd so it stops signaling.
+                retry_timer
+                    .wait()
+                    .map_err(|e| Error::TimerFdWait(e.into()))?;
+            }
         }
     }
 

--- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
@@ -381,6 +381,7 @@ impl VhostUserHandle {
         socket_path: &str,
         num_queues: u64,
         unlink_socket: bool,
+        kill_evt: Option<&EventFd>,
     ) -> Result<Self> {
         if server {
             if unlink_socket {
@@ -405,7 +406,12 @@ impl VhostUserHandle {
         } else {
             const RETRY_INTERVAL: Duration = Duration::from_millis(100);
             const CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
-            const TIMER_EVENT: u64 = 0;
+
+            #[repr(u64)]
+            enum ConnectEvent {
+                Timer = 0,
+                Kill = 1,
+            }
 
             let mut retry_timer = TimerFd::new().map_err(|e| Error::TimerFdCreate(e.into()))?;
             retry_timer
@@ -417,9 +423,19 @@ impl VhostUserHandle {
                 .ctl(
                     ControlOperation::Add,
                     retry_timer.as_raw_fd(),
-                    EpollEvent::new(EventSet::IN, TIMER_EVENT),
+                    EpollEvent::new(EventSet::IN, ConnectEvent::Timer as u64),
                 )
                 .map_err(Error::EpollCtl)?;
+
+            if let Some(kill_evt) = kill_evt {
+                epoll
+                    .ctl(
+                        ControlOperation::Add,
+                        kill_evt.as_raw_fd(),
+                        EpollEvent::new(EventSet::IN, ConnectEvent::Kill as u64),
+                    )
+                    .map_err(Error::EpollCtl)?;
+            }
 
             let start = Instant::now();
             let mut events = [EpollEvent::default(); 1];
@@ -456,10 +472,21 @@ impl VhostUserHandle {
                     }
                 }
 
-                // Drain the timerfd so it stops signaling.
-                retry_timer
-                    .wait()
-                    .map_err(|e| Error::TimerFdWait(e.into()))?;
+                match events[0].data() {
+                    x if x == ConnectEvent::Kill as u64 => {
+                        info!(
+                            "Aborting vhost-user connect for socket {socket_path}: kill event received"
+                        );
+                        return Err(Error::ConnectKilled);
+                    }
+                    x if x == ConnectEvent::Timer as u64 => {
+                        // Drain the timerfd to clear the event.
+                        retry_timer
+                            .wait()
+                            .map_err(|e| Error::TimerFdWait(e.into()))?;
+                    }
+                    _ => unreachable!(),
+                }
             }
         }
     }


### PR DESCRIPTION
If the vhost-user device receives a kill_evt (most likely because a removal has
been requested) then cancel the reconnection.

- **virtio-devices: vhost-user: Use TimerFd connect_vhost_user**
- **virtio-devices: vhost-user: Abandon reconnection if kill event sent**
- **virtio-devices: vhost-user: Log when attempting reconnection**
