### PR TITLE
Topic/vhost user disconnect

### DIFF
--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -657,13 +657,28 @@ impl VhostUserCommon {
     }
 
     pub fn pause(&mut self) -> std::result::Result<(), MigratableError> {
-        if let Some(vu) = &self.vu {
-            vu.lock().unwrap().pause_vhost_user().map_err(|e| {
-                MigratableError::Pause(anyhow!("Error pausing vhost-user backend: {e:?}"))
-            })
-        } else {
-            Ok(())
+        if self.disconnected.load(Ordering::Relaxed) {
+            return Err(MigratableError::DeviceDisconnected(
+                self.socket_path.clone(),
+            ));
         }
+
+        if let Some(vu) = &self.vu
+            && let Err(e) = vu.lock().unwrap().pause_vhost_user()
+        {
+            if e.is_transport_lost() {
+                self.disconnected.store(true, Ordering::Relaxed);
+                return Err(MigratableError::DeviceDisconnected(
+                    self.socket_path.clone(),
+                ));
+            }
+
+            return Err(MigratableError::Pause(anyhow!(
+                "Error pausing vhost-user backend for socket {}: {e:?}",
+                self.socket_path
+            )));
+        }
+        Ok(())
     }
 
     pub fn resume(&mut self) -> std::result::Result<(), MigratableError> {

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -207,6 +207,8 @@ pub struct VhostUserEpollHandler<S: VhostUserFrontendReqHandler> {
     pub server: bool,
     pub backend_req_handler: Option<FrontendReqHandler<S>>,
     pub inflight: Option<Inflight>,
+    /// Flag set by the worker when the vhost-user backend is no longer reachable.
+    pub disconnected: Arc<AtomicBool>,
 }
 
 impl<S: VhostUserFrontendReqHandler> VhostUserEpollHandler<S> {
@@ -232,6 +234,18 @@ impl<S: VhostUserFrontendReqHandler> VhostUserEpollHandler<S> {
     }
 
     fn reconnect(&mut self, helper: &mut EpollHelper) -> std::result::Result<(), EpollHelperError> {
+        let result = self.reconnect_inner(helper);
+        if result.is_err() {
+            // If reconnect fails, mark disconnected to avoid repeated failed socket calls.
+            self.disconnected.store(true, Ordering::Relaxed);
+        }
+        result
+    }
+
+    fn reconnect_inner(
+        &mut self,
+        helper: &mut EpollHelper,
+    ) -> std::result::Result<(), EpollHelperError> {
         helper.del_event_custom(
             self.vu.lock().unwrap().socket_handle().as_raw_fd(),
             HUP_CONNECTION_EVENT,
@@ -301,7 +315,7 @@ impl<S: VhostUserFrontendReqHandler> EpollHelperHandler for VhostUserEpollHandle
         event: &epoll::Event,
     ) -> std::result::Result<(), EpollHelperError> {
         let ev_type = event.data as u16;
-        match ev_type {
+        let result = match ev_type {
             HUP_CONNECTION_EVENT => {
                 info!(
                     "vhost-user backend for socket {} disconnected, attempting reconnection",
@@ -312,25 +326,32 @@ impl<S: VhostUserFrontendReqHandler> EpollHelperHandler for VhostUserEpollHandle
                         "failed to reconnect vhost-user backend for socket {}: {e:?}",
                         self.socket_path
                     ))
-                })?;
+                })
             }
             BACKEND_REQ_EVENT => {
                 if let Some(backend_req_handler) = self.backend_req_handler.as_mut() {
-                    backend_req_handler.handle_request().map_err(|e| {
-                        EpollHelperError::HandleEvent(anyhow!(
-                            "Failed to handle request from vhost-user backend: {e:?}"
-                        ))
-                    })?;
+                    backend_req_handler
+                        .handle_request()
+                        .map(|_| ())
+                        .map_err(|e| {
+                            EpollHelperError::HandleEvent(anyhow!(
+                                "Failed to handle request from vhost-user backend: {e:?}"
+                            ))
+                        })
+                } else {
+                    Ok(())
                 }
             }
-            _ => {
-                return Err(EpollHelperError::HandleEvent(anyhow!(
-                    "Unknown event for vhost-user thread"
-                )));
-            }
-        }
+            _ => Err(EpollHelperError::HandleEvent(anyhow!(
+                "Unknown event for vhost-user thread"
+            ))),
+        };
 
-        Ok(())
+        // If the backend hits and error it is unusable from this point on.
+        if result.is_err() {
+            self.disconnected.store(true, Ordering::Relaxed);
+        }
+        result
     }
 }
 
@@ -374,6 +395,8 @@ pub struct VhostUserCommon {
     pub server: bool,
     pub vring_bases: Option<Vec<u64>>,
     pub epoll_thread: Option<thread::JoinHandle<()>>,
+    /// Indicates that the backend is no longer reachable. Shared with EPollHandler.
+    pub disconnected: Arc<AtomicBool>,
 }
 
 impl VhostUserCommon {
@@ -432,6 +455,7 @@ impl VhostUserCommon {
             server: self.server,
             backend_req_handler,
             inflight,
+            disconnected: self.disconnected.clone(),
         })
     }
 

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -480,6 +480,14 @@ impl VhostUserCommon {
         kill_evt: EventFd,
         pause_evt: EventFd,
     ) -> std::result::Result<VhostUserEpollHandler<T>, ActivateError> {
+        if self.disconnected.load(Ordering::Relaxed) {
+            warn!(
+                "Not activating disconnected vhost-user device for socket {}",
+                self.socket_path
+            );
+            return Err(ActivateError::BadActivate);
+        }
+
         let mut inflight: Option<Inflight> =
             if self.acked_protocol_features & VhostUserProtocolFeatures::INFLIGHT_SHMFD.bits() != 0
             {

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::io::ErrorKind;
 use std::ops::Deref;
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -16,7 +17,7 @@ use vhost::Error as VhostError;
 use vhost::vhost_user::message::{
     VhostUserInflight, VhostUserProtocolFeatures, VhostUserVirtioFeatures,
 };
-use vhost::vhost_user::{FrontendReqHandler, VhostUserFrontendReqHandler};
+use vhost::vhost_user::{Error as VhostUserError, FrontendReqHandler, VhostUserFrontendReqHandler};
 use virtio_queue::{Error as QueueError, Queue};
 use vm_memory::guest_memory::Error as MmapError;
 use vm_memory::mmap::MmapRegionError;
@@ -73,6 +74,8 @@ pub enum Error {
     VhostUserOpen(#[source] VhostError),
     #[error("Connection to socket failed")]
     VhostUserConnect(#[source] VhostError),
+    #[error("Backend disconnected for socket {0}")]
+    BackendDisconnected(String),
     #[error("Get features failed")]
     VhostUserGetFeatures(#[source] VhostError),
     #[error("Get queue max number failed")]
@@ -175,6 +178,72 @@ pub enum Error {
     ConnectKilled,
 }
 type Result<T> = std::result::Result<T, Error>;
+
+fn io_error_is_connection_lost(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        ErrorKind::BrokenPipe
+            | ErrorKind::ConnectionAborted
+            | ErrorKind::ConnectionReset
+            | ErrorKind::NotConnected
+            | ErrorKind::UnexpectedEof
+    )
+}
+
+fn vhost_user_error_is_transport_lost(error: &VhostUserError) -> bool {
+    match error {
+        VhostUserError::Disconnected
+        | VhostUserError::PartialMessage
+        | VhostUserError::SocketBroken(_)
+        | VhostUserError::SocketConnect(_) => true,
+        VhostUserError::SocketError(e) => io_error_is_connection_lost(e),
+        _ => false,
+    }
+}
+
+fn vhost_error_is_transport_lost(error: &VhostError) -> bool {
+    match error {
+        VhostError::VhostUserProtocol(e) => vhost_user_error_is_transport_lost(e),
+        VhostError::IOError(e) => io_error_is_connection_lost(e),
+        _ => false,
+    }
+}
+
+impl Error {
+    fn is_transport_lost(&self) -> bool {
+        match self {
+            Error::VhostUserConnect(_) | Error::BackendDisconnected(_) => true,
+            Error::VhostUserCreateFrontend(e)
+            | Error::VhostUserOpen(e)
+            | Error::VhostUserGetFeatures(e)
+            | Error::VhostUserGetQueueMaxNum(e)
+            | Error::VhostUserGetProtocolFeatures(e)
+            | Error::VhostUserGetVringBase(e)
+            | Error::VhostUserSetOwner(e)
+            | Error::VhostUserResetOwner(e)
+            | Error::VhostUserSetFeatures(e)
+            | Error::VhostUserSetProtocolFeatures(e)
+            | Error::VhostUserSetMemTable(e)
+            | Error::VhostUserSetVringNum(e)
+            | Error::VhostUserSetVringAddr(e)
+            | Error::VhostUserSetVringBase(e)
+            | Error::VhostUserSetVringCall(e)
+            | Error::VhostUserSetVringKick(e)
+            | Error::VhostUserSetVringEnable(e)
+            | Error::VhostUserSetBackendRequestFd(e)
+            | Error::VhostUserAddMemReg(e)
+            | Error::VhostUserGetConfig(e)
+            | Error::VhostUserSetConfig(e)
+            | Error::VhostUserGetInflight(e)
+            | Error::VhostUserSetInflight(e)
+            | Error::VhostUserSetLogBase(e)
+            | Error::VhostUserSetDeviceStateFd(e)
+            | Error::VhostUserCheckDeviceState(e) => vhost_error_is_transport_lost(e),
+            Error::FrontendReqHandlerCreation(e) => vhost_user_error_is_transport_lost(e),
+            _ => false,
+        }
+    }
+}
 
 pub const DEFAULT_VIRTIO_FEATURES: u64 = (1 << VIRTIO_F_RING_INDIRECT_DESC)
     | (1 << VIRTIO_F_RING_EVENT_IDX)

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -10,7 +10,7 @@ use std::{io, thread};
 
 use anyhow::anyhow;
 use event_monitor::event;
-use log::{error, info};
+use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vhost::Error as VhostError;
@@ -538,13 +538,24 @@ impl VhostUserCommon {
             error!("Failed to resume paused device during reset: {e:?}");
         }
 
-        if let Some(vu) = &self.vu
+        // Skip reset_vhost_user if the backend is not connected.
+        if !self.disconnected.load(Ordering::Relaxed)
+            && let Some(vu) = &self.vu
             && let Err(e) = vu.lock().unwrap().reset_vhost_user()
         {
-            error!(
-                "Failed to reset vhost-user daemon for socket {}: {e:?}",
-                self.socket_path
-            );
+            if e.is_transport_lost() {
+                warn!(
+                    "Failed to reset vhost-user daemon for socket {}: {e:?}; \
+                     marking device as disconnected",
+                    self.socket_path
+                );
+                self.disconnected.store(true, Ordering::Relaxed);
+            } else {
+                warn!(
+                    "Failed to reset vhost-user daemon for socket {}: {e:?}",
+                    self.socket_path
+                );
+            }
         }
 
         if let Some(kill_evt) = self.virtio_common.kill_evt.take() {

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -528,22 +528,6 @@ impl VhostUserCommon {
         })
     }
 
-    pub fn restore_backend_connection(&mut self, acked_features: u64) -> Result<()> {
-        let mut vu = VhostUserHandle::connect_vhost_user(
-            self.server,
-            &self.socket_path,
-            self.vu_num_queues as u64,
-            false,
-            None,
-        )?;
-
-        vu.set_protocol_features_vhost_user(acked_features, self.acked_protocol_features)?;
-
-        self.vu = Some(Arc::new(Mutex::new(vu)));
-
-        Ok(())
-    }
-
     pub fn reset(&mut self, id: &str) {
         // Resume the virtio thread if it was paused. Reset must always
         // converge to fresh state, so backend resume / reset failures are

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -681,18 +681,45 @@ impl VhostUserCommon {
         Ok(())
     }
 
-    pub fn resume(&mut self) -> std::result::Result<(), MigratableError> {
-        if let Some(vu) = &self.vu {
-            vu.lock().unwrap().resume_vhost_user().map_err(|e| {
-                MigratableError::Resume(anyhow!("Error resuming vhost-user backend: {e:?}"))
-            })?;
+    fn resume_internal(&mut self) -> std::result::Result<(), MigratableError> {
+        // Skip the resume_vhost_user call if the backend is disconnected. Process the queue
+        // interrupts to kick any paused workers.
+        if self.disconnected.load(Ordering::Relaxed) {
+            return Err(MigratableError::DeviceDisconnected(
+                self.socket_path.clone(),
+            ));
         }
+
+        if let Some(vu) = &self.vu
+            && let Err(e) = vu.lock().unwrap().resume_vhost_user()
+        {
+            if e.is_transport_lost() {
+                self.disconnected.store(true, Ordering::Relaxed);
+                return Err(MigratableError::DeviceDisconnected(
+                    self.socket_path.clone(),
+                ));
+            }
+
+            return Err(MigratableError::Resume(anyhow!(
+                "Error resuming vhost-user backend for socket {}: {e:?}",
+                self.socket_path
+            )));
+        }
+
+        Ok(())
+    }
+
+    pub fn resume(&mut self) -> std::result::Result<(), MigratableError> {
+        let ret = self.resume_internal();
+
+        // Always run the interrupt loop so workers don't get stuck.
         for i in 0..self.vu_num_queues {
             self.virtio_common
                 .trigger_interrupt(crate::VirtioInterruptType::Queue(i as u16))
                 .ok();
         }
-        Ok(())
+
+        ret
     }
 
     pub fn state<C: Default>(

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -569,6 +569,15 @@ impl VhostUserCommon {
         self.virtio_common.interrupt_cb = None;
     }
 
+    fn memory_update_error(&self, source: Error) -> crate::Error {
+        if self.acked_protocol_features & VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS.bits() != 0
+        {
+            crate::Error::VhostUserAddMemoryRegion(source)
+        } else {
+            crate::Error::VhostUserUpdateMemory(source)
+        }
+    }
+
     pub fn shutdown(&mut self) {
         // Signal the epoll thread to exit, unpause it (it may be parked
         // if the VM was paused for migration), then wait for it to finish.
@@ -595,27 +604,54 @@ impl VhostUserCommon {
         self.vu = None;
     }
 
+    fn add_memory_region_internal(
+        &self,
+        guest_memory: &Option<GuestMemoryAtomic<GuestMemoryMmap>>,
+        region: &Arc<GuestRegionMmap>,
+    ) -> Result<()> {
+        if let Some(vu) = &self.vu {
+            if self.acked_protocol_features & VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS.bits()
+                != 0
+            {
+                return vu.lock().unwrap().add_memory_region(region);
+            } else if let Some(guest_memory) = guest_memory {
+                return vu
+                    .lock()
+                    .unwrap()
+                    .update_mem_table(guest_memory.memory().deref());
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn add_memory_region(
         &mut self,
         guest_memory: &Option<GuestMemoryAtomic<GuestMemoryMmap>>,
         region: &Arc<GuestRegionMmap>,
     ) -> std::result::Result<(), crate::Error> {
-        if let Some(vu) = &self.vu {
-            if self.acked_protocol_features & VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS.bits()
-                != 0
-            {
-                return vu
-                    .lock()
-                    .unwrap()
-                    .add_memory_region(region)
-                    .map_err(crate::Error::VhostUserAddMemoryRegion);
-            } else if let Some(guest_memory) = guest_memory {
-                return vu
-                    .lock()
-                    .unwrap()
-                    .update_mem_table(guest_memory.memory().deref())
-                    .map_err(crate::Error::VhostUserUpdateMemory);
+        if self.disconnected.load(Ordering::Relaxed) {
+            warn!(
+                "Skipping add memory region on disconnected dev with socket: {}",
+                self.socket_path
+            );
+        }
+
+        if let Err(e) = self.add_memory_region_internal(guest_memory, region) {
+            if e.is_transport_lost() {
+                warn!(
+                    "Failed updating memory on vhost-user backend for socket {}: {e:?}; \
+                     marking device as disconnected",
+                    self.socket_path
+                );
+                self.disconnected.store(true, Ordering::Relaxed);
+            } else {
+                warn!(
+                    "Failed updating memory on vhost-user backend for socket {}: {e:?}",
+                    self.socket_path
+                );
             }
+            return Err(self.memory_update_error(e));
         }
         Ok(())
     }

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -92,6 +92,9 @@ pub enum MigratableError {
 
     #[error("Failed to release a disk lock")]
     UnlockError(#[source] anyhow::Error),
+
+    #[error("Lifecycle operation skipped for disconnected component {0}")]
+    DeviceDisconnected(String),
 }
 
 /// A Pausable component can be paused and resumed.

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -5501,7 +5501,13 @@ impl Pausable for DeviceManager {
     fn pause(&mut self) -> result::Result<(), MigratableError> {
         for (_, device_node) in self.device_tree.lock().unwrap().iter() {
             if let Some(migratable) = &device_node.migratable {
-                migratable.lock().unwrap().pause()?;
+                match migratable.lock().unwrap().pause() {
+                    Ok(()) => {}
+                    Err(MigratableError::DeviceDisconnected(id)) => {
+                        warn!("Skipping pause for disconnected device {id}");
+                    }
+                    Err(e) => return Err(e),
+                }
             }
         }
         // On AArch64, the pause of device manager needs to trigger

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -5528,7 +5528,13 @@ impl Pausable for DeviceManager {
     fn resume(&mut self) -> result::Result<(), MigratableError> {
         for (_, device_node) in self.device_tree.lock().unwrap().iter() {
             if let Some(migratable) = &device_node.migratable {
-                migratable.lock().unwrap().resume()?;
+                match migratable.lock().unwrap().resume() {
+                    Ok(()) => {}
+                    Err(MigratableError::DeviceDisconnected(id)) => {
+                        warn!("Skipping resume for disconnected device {id}");
+                    }
+                    Err(e) => return Err(e),
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
This is a proposal to avoid immediately taking down the VMM when a vhost user backend exits.

This will make it easier for orchestrators to deal with shut down sequences. Particularly handling a vhost user backend crash. Currently the orchestrator will get an error if it tries to unplug the device after the backend exits. The orchestrator might also see a dead CH control socket if the VMM exits first.

After this change the VMM will stay running (flagging to the guest that the device is dead with needs reset) and allow for a clean shutdown of the VMM by the external orchestrator.

@rbradford I'll want to rebase this on your cancellation change, as they are complimentary.