### PR TITLE
virtio-devices: Bump config_generation on device specific config reads

### DIFF
--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -126,7 +126,7 @@ pub fn get_vring_size(t: VringType, queue_size: u16) -> u64 {
 pub struct VirtioPciCommonConfig {
     pub device: Arc<Mutex<dyn VirtioDevice>>,
     pub driver_status: Arc<AtomicU8>,
-    pub config_generation: u8,
+    pub config_generation: Arc<AtomicU8>,
     pub device_feature_select: u32,
     pub driver_feature_select: u32,
     pub queue_select: u16,
@@ -139,7 +139,7 @@ impl VirtioPciCommonConfig {
         VirtioPciCommonConfig {
             device,
             driver_status: Arc::new(AtomicU8::new(state.driver_status)),
-            config_generation: state.config_generation,
+            config_generation: Arc::new(AtomicU8::new(state.config_generation)),
             device_feature_select: state.device_feature_select,
             driver_feature_select: state.driver_feature_select,
             queue_select: state.queue_select,
@@ -151,7 +151,7 @@ impl VirtioPciCommonConfig {
     fn state(&self) -> VirtioPciCommonConfigState {
         VirtioPciCommonConfigState {
             driver_status: self.driver_status.load(Ordering::Acquire),
-            config_generation: self.config_generation,
+            config_generation: self.config_generation.load(Ordering::Acquire),
             device_feature_select: self.device_feature_select,
             driver_feature_select: self.driver_feature_select,
             queue_select: self.queue_select,
@@ -216,7 +216,7 @@ impl VirtioPciCommonConfig {
         // The driver is only allowed to do aligned, properly sized access.
         match offset {
             0x14 => self.driver_status.load(Ordering::Acquire),
-            0x15 => self.config_generation,
+            0x15 => self.config_generation.load(Ordering::Acquire),
             _ => {
                 warn!("invalid virtio config byte read: 0x{offset:x}");
                 0
@@ -461,7 +461,7 @@ mod unit_tests {
         let mut regs = VirtioPciCommonConfig {
             device: dev.clone(),
             driver_status: Arc::new(AtomicU8::new(0xaa)),
-            config_generation: 0x55,
+            config_generation: Arc::new(AtomicU8::new(0x55)),
             device_feature_select: 0x0,
             driver_feature_select: 0x0,
             queue_select: 0xff,
@@ -513,7 +513,7 @@ mod unit_tests {
         let mut regs = VirtioPciCommonConfig {
             device: dev.clone(),
             driver_status: Arc::new(AtomicU8::new(0)),
-            config_generation: 0,
+            config_generation: Arc::new(AtomicU8::new(0)),
             device_feature_select: 0,
             driver_feature_select: 0,
             queue_select: 0,
@@ -541,7 +541,7 @@ mod unit_tests {
         let mut regs = VirtioPciCommonConfig {
             device: dev,
             driver_status: Arc::new(AtomicU8::new(0x55)),
-            config_generation: 0xab,
+            config_generation: Arc::new(AtomicU8::new(0xab)),
             device_feature_select: 1,
             driver_feature_select: 1,
             queue_select: 7,
@@ -552,7 +552,7 @@ mod unit_tests {
         regs.reset();
 
         assert_eq!(regs.driver_status.load(Ordering::Acquire), 0);
-        assert_eq!(regs.config_generation, 0xab); // unchanged across reset
+        assert_eq!(regs.config_generation.load(Ordering::Acquire), 0xab); // unchanged across reset
         assert_eq!(regs.device_feature_select, 0);
         assert_eq!(regs.driver_feature_select, 0);
         assert_eq!(regs.queue_select, 0);

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::sync::atomic::{AtomicU8, AtomicU16, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU16, Ordering};
 use std::sync::{Arc, Mutex};
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -127,6 +127,10 @@ pub struct VirtioPciCommonConfig {
     pub device: Arc<Mutex<dyn VirtioDevice>>,
     pub driver_status: Arc<AtomicU8>,
     pub config_generation: Arc<AtomicU8>,
+    /// Set when a Config interrupt fires. Cleared on the next read of
+    /// the device specific configuration region, which also bumps
+    /// config_generation.
+    pub config_changed: Arc<AtomicBool>,
     pub device_feature_select: u32,
     pub driver_feature_select: u32,
     pub queue_select: u16,
@@ -140,11 +144,22 @@ impl VirtioPciCommonConfig {
             device,
             driver_status: Arc::new(AtomicU8::new(state.driver_status)),
             config_generation: Arc::new(AtomicU8::new(state.config_generation)),
+            config_changed: Arc::new(AtomicBool::new(false)),
             device_feature_select: state.device_feature_select,
             driver_feature_select: state.driver_feature_select,
             queue_select: state.queue_select,
             msix_config: Arc::new(AtomicU16::new(state.msix_config)),
             msix_queues: Arc::new(Mutex::new(state.msix_queues)),
+        }
+    }
+
+    /// If a Config interrupt has fired since the last device specific
+    /// configuration read, increment config_generation and clear the
+    /// pending flag.
+    pub fn consume_config_change(&self) {
+        if self.config_changed.swap(false, Ordering::AcqRel) {
+            // Wrap at u8 max is intentional per the virtio spec.
+            self.config_generation.fetch_add(1, Ordering::Release);
         }
     }
 
@@ -165,6 +180,7 @@ impl VirtioPciCommonConfig {
     /// observe.
     pub fn reset(&mut self) {
         self.driver_status.store(0, Ordering::Release);
+        self.config_changed.store(false, Ordering::Release);
         self.device_feature_select = 0;
         self.driver_feature_select = 0;
         self.queue_select = 0;
@@ -462,6 +478,7 @@ mod unit_tests {
             device: dev.clone(),
             driver_status: Arc::new(AtomicU8::new(0xaa)),
             config_generation: Arc::new(AtomicU8::new(0x55)),
+            config_changed: Arc::new(AtomicBool::new(false)),
             device_feature_select: 0x0,
             driver_feature_select: 0x0,
             queue_select: 0xff,
@@ -514,6 +531,7 @@ mod unit_tests {
             device: dev.clone(),
             driver_status: Arc::new(AtomicU8::new(0)),
             config_generation: Arc::new(AtomicU8::new(0)),
+            config_changed: Arc::new(AtomicBool::new(false)),
             device_feature_select: 0,
             driver_feature_select: 0,
             queue_select: 0,
@@ -542,6 +560,7 @@ mod unit_tests {
             device: dev,
             driver_status: Arc::new(AtomicU8::new(0x55)),
             config_generation: Arc::new(AtomicU8::new(0xab)),
+            config_changed: Arc::new(AtomicBool::new(true)),
             device_feature_select: 1,
             driver_feature_select: 1,
             queue_select: 7,
@@ -553,6 +572,7 @@ mod unit_tests {
 
         assert_eq!(regs.driver_status.load(Ordering::Acquire), 0);
         assert_eq!(regs.config_generation.load(Ordering::Acquire), 0xab); // unchanged across reset
+        assert!(!regs.config_changed.load(Ordering::Acquire));
         assert_eq!(regs.device_feature_select, 0);
         assert_eq!(regs.driver_feature_select, 0);
         assert_eq!(regs.queue_select, 0);

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -588,4 +588,48 @@ mod unit_tests {
                 .all(|v| *v == VIRTQ_MSI_NO_VECTOR)
         );
     }
+
+    fn make_regs(config_generation: u8) -> VirtioPciCommonConfig {
+        let dev: Arc<Mutex<dyn VirtioDevice>> = Arc::new(Mutex::new(DummyDevice(0)));
+        VirtioPciCommonConfig {
+            device: dev,
+            driver_status: Arc::new(AtomicU8::new(0)),
+            config_generation: Arc::new(AtomicU8::new(config_generation)),
+            config_changed: Arc::new(AtomicBool::new(false)),
+            device_feature_select: 0,
+            driver_feature_select: 0,
+            queue_select: 0,
+            msix_config: Arc::new(AtomicU16::new(0)),
+            msix_queues: Arc::new(Mutex::new(vec![0; 1])),
+        }
+    }
+
+    #[test]
+    fn consume_config_change_bumps_when_flag_set() {
+        let regs = make_regs(0x10);
+        regs.config_changed.store(true, Ordering::Release);
+        regs.consume_config_change();
+        assert_eq!(regs.config_generation.load(Ordering::Acquire), 0x11);
+        assert!(!regs.config_changed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn consume_config_change_is_noop_when_flag_clear() {
+        let regs = make_regs(0x10);
+        regs.consume_config_change();
+        assert_eq!(regs.config_generation.load(Ordering::Acquire), 0x10);
+        assert!(!regs.config_changed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn consume_config_change_coalesces_multiple_sets() {
+        let regs = make_regs(0x10);
+        regs.config_changed.store(true, Ordering::Release);
+        regs.config_changed.store(true, Ordering::Release);
+        regs.config_changed.store(true, Ordering::Release);
+        regs.consume_config_change();
+        assert_eq!(regs.config_generation.load(Ordering::Acquire), 0x11);
+        regs.consume_config_change();
+        assert_eq!(regs.config_generation.load(Ordering::Acquire), 0x11);
+    }
 }

--- a/virtio-devices/src/transport/pci_common_config.rs
+++ b/virtio-devices/src/transport/pci_common_config.rs
@@ -632,4 +632,12 @@ mod unit_tests {
         regs.consume_config_change();
         assert_eq!(regs.config_generation.load(Ordering::Acquire), 0x11);
     }
+
+    #[test]
+    fn consume_config_change_wraps_at_u8_max() {
+        let regs = make_regs(0xff);
+        regs.config_changed.store(true, Ordering::Release);
+        regs.consume_config_change();
+        assert_eq!(regs.config_generation.load(Ordering::Acquire), 0x00);
+    }
 }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1417,4 +1417,19 @@ mod unit_tests {
         intr.config_vector.store(0xFFFE, Ordering::Release);
         intr.trigger(VirtioInterruptType::Config).unwrap();
     }
+
+    #[test]
+    fn trigger_config_sets_config_changed_flag() {
+        let intr = make_msix_interrupt(2);
+        assert!(!intr.config_changed.load(Ordering::Acquire));
+        intr.trigger(VirtioInterruptType::Config).unwrap();
+        assert!(intr.config_changed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn trigger_queue_does_not_set_config_changed_flag() {
+        let intr = make_msix_interrupt(2);
+        intr.trigger(VirtioInterruptType::Queue(0)).unwrap();
+        assert!(!intr.config_changed.load(Ordering::Acquire));
+    }
 }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -591,6 +591,7 @@ impl VirtioPciDevice {
         let virtio_interrupt = Arc::new(VirtioInterruptMsix::new(
             msix_config.clone(),
             common_config.msix_config.clone(),
+            common_config.config_changed.clone(),
             common_config.msix_queues.clone(),
             interrupt_source_group.clone(),
         ));
@@ -851,6 +852,7 @@ impl VirtioTransport for VirtioPciDevice {
 pub struct VirtioInterruptMsix {
     msix_config: Arc<Mutex<MsixConfig>>,
     config_vector: Arc<AtomicU16>,
+    config_changed: Arc<AtomicBool>,
     queues_vectors: Arc<Mutex<Vec<u16>>>,
     interrupt_source_group: MaybeMutInterruptSourceGroup,
     msix_table_size: usize,
@@ -860,6 +862,7 @@ impl VirtioInterruptMsix {
     pub fn new(
         msix_config: Arc<Mutex<MsixConfig>>,
         config_vector: Arc<AtomicU16>,
+        config_changed: Arc<AtomicBool>,
         queues_vectors: Arc<Mutex<Vec<u16>>>,
         interrupt_source_group: MaybeMutInterruptSourceGroup,
     ) -> Self {
@@ -867,6 +870,7 @@ impl VirtioInterruptMsix {
         VirtioInterruptMsix {
             msix_config,
             config_vector,
+            config_changed,
             queues_vectors,
             interrupt_source_group,
             msix_table_size,
@@ -876,6 +880,10 @@ impl VirtioInterruptMsix {
 
 impl VirtioInterrupt for VirtioInterruptMsix {
     fn trigger(&self, int_type: VirtioInterruptType) -> std::result::Result<(), std::io::Error> {
+        if matches!(int_type, VirtioInterruptType::Config) {
+            self.config_changed.store(true, Ordering::Release);
+        }
+
         let vector = match int_type {
             VirtioInterruptType::Config => self.config_vector.load(Ordering::Acquire),
             VirtioInterruptType::Queue(queue_index) => {
@@ -1159,6 +1167,7 @@ impl PciDevice for VirtioPciDevice {
             o if (DEVICE_CONFIG_BAR_OFFSET..DEVICE_CONFIG_BAR_OFFSET + DEVICE_CONFIG_SIZE)
                 .contains(&o) =>
             {
+                self.common_config.consume_config_change();
                 let device = self.device.lock().unwrap();
                 device.read_config(o - DEVICE_CONFIG_BAR_OFFSET, data);
             }
@@ -1362,11 +1371,13 @@ mod unit_tests {
             .unwrap(),
         ));
         let config_vector = Arc::new(AtomicU16::new(VIRTQ_MSI_NO_VECTOR));
+        let config_changed = Arc::new(AtomicBool::new(false));
         let queues_vectors = Arc::new(Mutex::new(vec![VIRTQ_MSI_NO_VECTOR; 1]));
 
         VirtioInterruptMsix::new(
             msix_config,
             config_vector,
+            config_changed,
             queues_vectors,
             MaybeMutInterruptSourceGroup::Immutable(isg),
         )


### PR DESCRIPTION
Per virtio 1.3

> The device MUST present a changed `config_generation` after the driver has read a device-specific configuration value which has changed since any part of the device-specific configuration was last read.
>
> Note: As `config_generation` is an 8-bit value, simply incrementing it on every configuration change could violate this requirement due to wrap. Better would be to set an internal flag when it has changed, and if that flag is set when the driver reads from the device-specific configuration, increment `config_generation` and clear the flag.

Today this register is wired up but never mutated. Devices that change their device specific configuration at runtime (balloon resize, mem resize, console resize, et cetera) trigger a config interrupt but the driver sees the same `config_generation` byte forever. Linux relies on this counter to retry torn reads and to notice that a Config event delivered new state, so the driver has no way to confirm the change is consistent and may operate on a stale or torn snapshot.

Make the virtio PCI transport actually maintain `config_generation` per the spec, so the driver can detect device specific configuration changes that happen across or in between its reads.