### PR TITLE
virtio-devices: Require at least one ready queue for activation

### DIFF
--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -828,7 +828,9 @@ impl VirtioPciDevice {
     }
 
     fn needs_activation(&self) -> bool {
-        !self.device_activated.load(Ordering::SeqCst) && self.is_driver_ready()
+        !self.device_activated.load(Ordering::SeqCst)
+            && self.is_driver_ready()
+            && self.queues.iter().any(|q| q.ready())
     }
 
     pub fn dma_handler(&self) -> Option<&dyn ExternalDmaMapping> {


### PR DESCRIPTION
When a guest resets a device by writing status=0 and reinitializes without enabling queues before writing DRIVER_OK, the activation path would collect zero ready queues and treat that as a fatal error, killing the entire VMM process.

The PCI transport now checks that at least one queue is ready before reporting that the device needs activation. This prevents a spurious activation attempt that would fatally fail when no queues are enabled.