### PR TITLE
main: Use UTC in wallclock time log

### DIFF
--- a/cloud-hypervisor/src/logger.rs
+++ b/cloud-hypervisor/src/logger.rs
@@ -23,6 +23,7 @@ pub enum Error {
 enum Token {
     Literal(String),
     BootTime,
+    /// Wallclock using RFC 3339 formatting.
     WallClock,
     Pid,
     Tid,
@@ -134,11 +135,9 @@ impl log::Log for Logger {
                 Token::Literal(s) => out.write_all(s.as_bytes()),
                 // 10: 6 decimal places + sep => whole seconds in range `0..=999` properly aligned
                 Token::BootTime => write!(&mut *out, "{duration_s:>10.6?}"),
-                Token::WallClock => write!(
-                    out,
-                    "{}",
-                    jiff::Zoned::now().strftime("%Y-%m-%dT%H:%M:%S%.6f")
-                ),
+                Token::WallClock => {
+                    write!(out, "{:.6}", jiff::Timestamp::now())
+                }
                 Token::Pid => write!(&mut *out, "{}", self.pid),
                 // SAFETY: gettid(2) always succeeds
                 Token::Tid => write!(&mut *out, "{}", unsafe { libc::gettid() }),
@@ -368,13 +367,14 @@ mod tests {
 
         let out = buf.contents();
         let out = out.trim();
-        assert_eq!(out.len(), 26, "got: {out}");
+        assert_eq!(out.len(), 27, "got: {out}");
         assert_eq!(&out[4..5], "-", "got: {out}");
         assert_eq!(&out[7..8], "-", "got: {out}");
         assert_eq!(&out[10..11], "T", "got: {out}");
         assert_eq!(&out[13..14], ":", "got: {out}");
         assert_eq!(&out[16..17], ":", "got: {out}");
         assert_eq!(&out[19..20], ".", "got: {out}");
+        assert!(out.ends_with('Z'), "got: {out}");
     }
 
     #[test]


### PR DESCRIPTION
Using `jiff::Timestamp::now()` instead of `jiff::Zoned::now()` skips the timezone logic required for `Zoned`. This makes the timestamp UTC, with the appropriate `Z` suffix.

Alternatively, we could use the default formatting without `strftime(...)`, but that includes three more digits of the fractional seconds, which I don't think are necessary.

```rust
println!("{}",jiff::Timestamp::now().strftime("%Y-%m-%dT%H:%M:%S%.6fZ"));
// 2026-05-12T09:29:29.622730Z
println!("{}",jiff::Timestamp::now());
// 2026-05-12T09:29:29.622739847Z
```