### PR TITLE
virtio-devices: rng: Reject descriptor past end of guest RAM

### DIFF
--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -17,7 +17,7 @@ use seccompiler::SeccompAction;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use virtio_queue::{Queue, QueueT};
-use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryAtomic};
+use vm_memory::{Bytes, GuestAddressSpace, GuestMemory, GuestMemoryAtomic};
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vm_virtio::{AccessPlatform, Translatable};
 use vmm_sys_util::eventfd::EventFd;
@@ -79,6 +79,14 @@ impl RngEpollHandler {
                         break;
                     }
                 };
+                if !desc_chain.memory().check_range(addr, desc.len() as usize) {
+                    warn!(
+                        "Descriptor range out of guest memory: addr=0x{:x} len={}",
+                        addr.0,
+                        desc.len()
+                    );
+                    break;
+                }
                 match desc_chain.memory().read_volatile_from(
                     addr,
                     &mut self.random_file,

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -351,3 +351,72 @@ impl Snapshottable for Rng {
 
 impl Transportable for Rng {}
 impl Migratable for Rng {}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::sync::Arc;
+
+    use libc::EFD_NONBLOCK;
+    use virtio_bindings::virtio_ring::VRING_DESC_F_WRITE;
+    use vm_memory::{GuestAddress, GuestMemoryAtomic};
+    use vm_virtio::queue::testing::VirtQueue as GuestQ;
+    use vmm_sys_util::eventfd::EventFd;
+
+    use super::*;
+    use crate::GuestMemoryMmap;
+    use crate::device::{VirtioInterrupt, VirtioInterruptType};
+
+    struct NoopVirtioInterrupt;
+
+    impl VirtioInterrupt for NoopVirtioInterrupt {
+        fn trigger(
+            &self,
+            _int_type: VirtioInterruptType,
+        ) -> std::result::Result<(), std::io::Error> {
+            Ok(())
+        }
+
+        fn set_notifier(
+            &self,
+            _interrupt: u32,
+            _eventfd: Option<EventFd>,
+            _vm: &dyn hypervisor::Vm,
+        ) -> std::io::Result<()> {
+            unimplemented!()
+        }
+    }
+
+    fn build_handler(
+        mem_size: usize,
+        desc_addr: u64,
+        desc_len: u32,
+    ) -> (RngEpollHandler, GuestMemoryMmap) {
+        const QSIZE: u16 = 2;
+
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), mem_size)]).unwrap();
+        let guest_vq = GuestQ::new(GuestAddress(0x1_0000), &mem, QSIZE);
+        let queue = guest_vq.create_queue();
+
+        guest_vq.dtable[0].set(
+            desc_addr,
+            desc_len,
+            VRING_DESC_F_WRITE.try_into().unwrap(),
+            0,
+        );
+        guest_vq.avail.ring[0].set(0);
+        guest_vq.avail.idx.set(1);
+
+        let handler = RngEpollHandler {
+            mem: GuestMemoryAtomic::new(mem.clone()),
+            queue,
+            random_file: File::open("/dev/zero").unwrap(),
+            interrupt_cb: Arc::new(NoopVirtioInterrupt),
+            queue_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+            kill_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+            pause_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+            access_platform: None,
+        };
+
+        (handler, mem)
+    }
+}

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -430,4 +430,26 @@ mod unit_tests {
         let first: u8 = mem.read_obj(GuestAddress(0x4000)).unwrap();
         assert_eq!(first, 0);
     }
+
+    #[test]
+    fn process_queue_overflow_preserves_buffer() {
+        // 128 KiB of guest RAM, descriptor at 0x4000 claiming 1 GiB.
+        // The descriptor overshoots guest memory, so process_queue must
+        // skip it and leave the sentinel byte at 0x4000 untouched.
+        let (mut handler, mem) = build_handler(128 * 1024, 0x4000, 1 << 30);
+        mem.write_obj(SENTINEL, GuestAddress(0x4000))
+            .expect("write sentinel into guest memory");
+        assert!(
+            handler
+                .process_queue()
+                .expect("process_queue must not fail"),
+        );
+        let first: u8 = mem
+            .read_obj(GuestAddress(0x4000))
+            .expect("read back sentinel from guest memory");
+        assert_eq!(
+            first, SENTINEL,
+            "oversize descriptor must not overwrite buffer"
+        );
+    }
 }

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -358,7 +358,7 @@ mod unit_tests {
 
     use libc::EFD_NONBLOCK;
     use virtio_bindings::virtio_ring::VRING_DESC_F_WRITE;
-    use vm_memory::{GuestAddress, GuestMemoryAtomic};
+    use vm_memory::{Bytes, GuestAddress, GuestMemoryAtomic};
     use vm_virtio::queue::testing::VirtQueue as GuestQ;
     use vmm_sys_util::eventfd::EventFd;
 
@@ -418,5 +418,16 @@ mod unit_tests {
         };
 
         (handler, mem)
+    }
+
+    const SENTINEL: u8 = 0xa5;
+
+    #[test]
+    fn process_queue_in_bounds_overwrites_buffer() {
+        let (mut handler, mem) = build_handler(128 * 1024, 0x4000, 4096);
+        mem.write_obj(SENTINEL, GuestAddress(0x4000)).unwrap();
+        assert!(handler.process_queue().unwrap());
+        let first: u8 = mem.read_obj(GuestAddress(0x4000)).unwrap();
+        assert_eq!(first, 0);
     }
 }


### PR DESCRIPTION
`RngEpollHandler::process_queue` accepts a writable descriptor whose base sits in guest memory even when `len` runs past the end of guest physical memory. The device then issues a long write through the guest until vm-memory hits the first unmapped slice, by which point arbitrary guest pages, including kernel pages and the vring itself, may have been clobbered.

This series rejects such a descriptor before any byte is written and adds unit coverage for the new check.