### PR TITLE
Use BLKDISCARD/BLKZEROOUT on block devices

### DIFF
--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -44,7 +44,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, IoSlice, IoSliceMut, Read, Seek, SeekFrom, Write};
 use std::os::linux::fs::MetadataExt;
 use std::os::unix::fs::FileTypeExt;
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 use std::str::FromStr;
 use std::{cmp, mem, result};
@@ -333,26 +333,25 @@ pub fn block_io_uring_is_supported() -> bool {
     }
 }
 
+/// Returns `true` iff `fd` refers to a block device.
+///
+/// Returns `false` if the `fstat()` probe itself fails. Callers that need to
+/// distinguish "not a block device" from "couldn't tell" should fall back to
+/// regular-file behaviour, which is what every current caller already does.
+pub(crate) fn is_block_device(fd: RawFd) -> bool {
+    // SAFETY: `libc::stat` is POD; zero-initialization is a valid bit pattern
+    // and `fstat` overwrites every field it cares about on success.
+    let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+    // SAFETY: FFI call with a valid fd and a valid out-pointer.
+    let ret = unsafe { libc::fstat(fd, &mut stat) };
+    ret == 0 && stat.st_mode & S_IFMT == S_IFBLK
+}
+
 /// Probe whether the file/device supports punch hole and zero range
 pub fn probe_sparse_support(file: &File) -> bool {
     let fd = file.as_raw_fd();
 
-    let is_block_device = {
-        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-        // SAFETY: FFI call with valid fd and buffer
-        let ret = unsafe { libc::fstat(fd, stat.as_mut_ptr()) };
-        if ret != 0 {
-            warn!(
-                "Failed to stat file descriptor for sparse probe: {}",
-                io::Error::last_os_error()
-            );
-            return false;
-        }
-        // SAFETY: stat result is valid at this point
-        unsafe { (*stat.as_ptr()).st_mode & S_IFMT == S_IFBLK }
-    };
-
-    if is_block_device {
+    if is_block_device(fd) {
         probe_block_device_sparse_support(fd)
     } else {
         probe_file_sparse_support(fd)
@@ -722,19 +721,6 @@ enum BlockSize {
 }
 
 impl DiskTopology {
-    fn is_block_device(f: &File) -> std::io::Result<bool> {
-        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-        // SAFETY: FFI call with a valid fd and buffer
-        let ret = unsafe { libc::fstat(f.as_raw_fd(), stat.as_mut_ptr()) };
-        if ret != 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-
-        // SAFETY: stat is valid at this point
-        let is_block = unsafe { (*stat.as_ptr()).st_mode & S_IFMT == S_IFBLK };
-        Ok(is_block)
-    }
-
     // libc::ioctl() takes different types on different architectures
     fn query_block_size(f: &File, block_size_type: BlockSize) -> std::io::Result<u64> {
         let mut block_size = 0;
@@ -810,7 +796,7 @@ impl DiskTopology {
     }
 
     pub fn probe(f: &File) -> std::io::Result<Self> {
-        if !Self::is_block_device(f)? {
+        if !is_block_device(f.as_raw_fd()) {
             // For regular files opened with O_DIRECT, the logical block size
             // must reflect the filesystem DIO alignment so the guest issues
             // correctly sized I/O.

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -33,6 +33,8 @@ mod raw_async_io_tests;
 pub mod raw_disk;
 pub(crate) mod raw_sync;
 mod request;
+mod sparse;
+pub use sparse::{BLKDISCARD, BLKZEROOUT};
 pub mod vhd;
 pub mod vhdx;
 pub mod vhdx_sync;

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -11,13 +11,15 @@ use vmm_sys_util::eventfd::EventFd;
 
 use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
-use crate::{BatchRequest, RequestType, SECTOR_SIZE};
+use crate::sparse::{blkdiscard, blkzeroout};
+use crate::{BatchRequest, RequestType, SECTOR_SIZE, is_block_device};
 
 pub struct RawFileAsync {
     fd: RawFd,
     io_uring: IoUring,
     eventfd: EventFd,
     alignment: u64,
+    is_block_device: bool,
 }
 
 impl RawFileAsync {
@@ -34,12 +36,31 @@ impl RawFileAsync {
             .register_eventfd(eventfd.as_raw_fd())
             .map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
 
+        let is_block_device = is_block_device(fd);
+
         Ok(RawFileAsync {
             fd,
             io_uring,
             eventfd,
             alignment: SECTOR_SIZE,
+            is_block_device,
         })
+    }
+
+    /// Queue an `IORING_OP_NOP` carrying `user_data` so a synchronously
+    /// completed operation (e.g. a BLK* ioctl) is reaped through the normal
+    /// io_uring completion path.
+    fn submit_nop(&mut self, user_data: u64) -> Result<(), Error> {
+        let (submitter, mut sq, _) = self.io_uring.split();
+        // SAFETY: Nop carries no buffer; only `user_data` is consumed by the
+        // kernel.
+        unsafe {
+            sq.push(&opcode::Nop::new().build().user_data(user_data))
+                .map_err(|e| Error::other(format!("Submission queue is full: {e:?}")))?;
+        };
+        sq.sync();
+        submitter.submit()?;
+        Ok(())
     }
 }
 
@@ -227,6 +248,18 @@ impl AsyncIo for RawFileAsync {
     }
 
     fn punch_hole(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {
+        // Some block devices don't support fallocate(). Use ioctl instead. The assumption is that
+        // this happens rarely and we don't need to introduce unnecessary complexity by submitting
+        // a fallocate request, reaping ENOTSUPP in the completion routine, and reissuing the
+        // request with an ioctl.
+        if self.is_block_device {
+            blkdiscard(self.fd, offset, length).map_err(AsyncIoError::PunchHole)?;
+            // Deliver the completion through the normal io_uring path by
+            // queuing a NOP carrying `user_data`. The registered eventfd will
+            // fire when it completes, just like any other request.
+            return self.submit_nop(user_data).map_err(AsyncIoError::PunchHole);
+        }
+
         let (submitter, mut sq, _) = self.io_uring.split();
 
         let mode = FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE;
@@ -252,6 +285,14 @@ impl AsyncIo for RawFileAsync {
     }
 
     fn write_zeroes(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {
+        // Same rationale as punch_hole().
+        if self.is_block_device {
+            blkzeroout(self.fd, offset, length).map_err(AsyncIoError::WriteZeroes)?;
+            return self
+                .submit_nop(user_data)
+                .map_err(AsyncIoError::WriteZeroes);
+        }
+
         let (submitter, mut sq, _) = self.io_uring.split();
 
         let mode = FALLOC_FL_ZERO_RANGE | FALLOC_FL_KEEP_SIZE;

--- a/block/src/raw_async_aio.rs
+++ b/block/src/raw_async_aio.rs
@@ -8,13 +8,13 @@
 use std::collections::VecDeque;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use libc::{FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE, FALLOC_FL_ZERO_RANGE};
 use vmm_sys_util::aio;
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::SECTOR_SIZE;
 use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
+use crate::sparse::{punch_hole, write_zeroes};
+use crate::{SECTOR_SIZE, is_block_device};
 
 pub struct RawFileAsyncAio {
     fd: RawFd,
@@ -22,6 +22,7 @@ pub struct RawFileAsyncAio {
     eventfd: EventFd,
     alignment: u64,
     completion_list: VecDeque<(u64, i32)>,
+    is_block_device: bool,
 }
 
 impl RawFileAsyncAio {
@@ -30,6 +31,7 @@ impl RawFileAsyncAio {
             EventFd::new(libc::EFD_NONBLOCK).map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
         let ctx =
             aio::IoContext::new(queue_depth).map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
+        let is_block_device = is_block_device(fd);
 
         Ok(RawFileAsyncAio {
             fd,
@@ -37,6 +39,7 @@ impl RawFileAsyncAio {
             eventfd,
             alignment: SECTOR_SIZE,
             completion_list: VecDeque::new(),
+            is_block_device,
         })
     }
 }
@@ -133,50 +136,22 @@ impl AsyncIo for RawFileAsyncAio {
     }
 
     fn punch_hole(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {
-        // Linux AIO has no IOCB command for fallocate, so perform the operation
-        // synchronously and signal completion via the completion list, matching
-        // the pattern used by the sync backend (RawFileSync).
-        let mode = FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE;
-
-        // SAFETY: FFI call with valid arguments
-        let result = unsafe {
-            libc::fallocate(
-                self.fd as libc::c_int,
-                mode,
-                offset as libc::off_t,
-                length as libc::off_t,
-            )
-        };
-        if result < 0 {
-            return Err(AsyncIoError::PunchHole(std::io::Error::last_os_error()));
-        }
-
-        self.completion_list.push_back((user_data, result));
+        // Linux AIO has no IOCB command for fallocate, so perform the
+        // operation synchronously and signal completion via the completion
+        // list, matching the pattern used by the sync backend (RawFileSync).
+        punch_hole(self.fd, self.is_block_device, offset, length)
+            .map_err(AsyncIoError::PunchHole)?;
+        self.completion_list.push_back((user_data, 0));
         self.eventfd.write(1).unwrap();
 
         Ok(())
     }
 
     fn write_zeroes(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {
-        // Linux AIO has no IOCB command for fallocate, so perform the operation
-        // synchronously and signal completion via the completion list, matching
-        // the pattern used by the sync backend (RawFileSync).
-        let mode = FALLOC_FL_ZERO_RANGE | FALLOC_FL_KEEP_SIZE;
-
-        // SAFETY: FFI call with valid arguments
-        let result = unsafe {
-            libc::fallocate(
-                self.fd as libc::c_int,
-                mode,
-                offset as libc::off_t,
-                length as libc::off_t,
-            )
-        };
-        if result < 0 {
-            return Err(AsyncIoError::WriteZeroes(std::io::Error::last_os_error()));
-        }
-
-        self.completion_list.push_back((user_data, result));
+        // Same as punch_hole().
+        write_zeroes(self.fd, self.is_block_device, offset, length)
+            .map_err(AsyncIoError::WriteZeroes)?;
+        self.completion_list.push_back((user_data, 0));
         self.eventfd.write(1).unwrap();
 
         Ok(())

--- a/block/src/raw_sync.rs
+++ b/block/src/raw_sync.rs
@@ -5,26 +5,29 @@
 use std::collections::VecDeque;
 use std::os::unix::io::RawFd;
 
-use libc::{FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE, FALLOC_FL_ZERO_RANGE};
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::SECTOR_SIZE;
 use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
+use crate::sparse::{punch_hole, write_zeroes};
+use crate::{SECTOR_SIZE, is_block_device};
 
 pub struct RawFileSync {
     fd: RawFd,
     eventfd: EventFd,
     completion_list: VecDeque<(u64, i32)>,
     alignment: u64,
+    is_block_device: bool,
 }
 
 impl RawFileSync {
     pub fn new(fd: RawFd) -> Self {
+        let is_block_device = is_block_device(fd);
         RawFileSync {
             fd,
             eventfd: EventFd::new(libc::EFD_NONBLOCK).expect("Failed creating EventFd for RawFile"),
             completion_list: VecDeque::new(),
             alignment: SECTOR_SIZE,
+            is_block_device,
         }
     }
 }
@@ -108,46 +111,18 @@ impl AsyncIo for RawFileSync {
     }
 
     fn punch_hole(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {
-        let mode = FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE;
-
-        // SAFETY: FFI call with valid arguments
-        let result = unsafe {
-            libc::fallocate(
-                self.fd as libc::c_int,
-                mode,
-                offset as libc::off_t,
-                length as libc::off_t,
-            )
-        };
-        if result < 0 {
-            return Err(AsyncIoError::PunchHole(std::io::Error::last_os_error()));
-        }
-
-        self.completion_list.push_back((user_data, result));
+        punch_hole(self.fd, self.is_block_device, offset, length)
+            .map_err(AsyncIoError::PunchHole)?;
+        self.completion_list.push_back((user_data, 0));
         self.eventfd.write(1).unwrap();
-
         Ok(())
     }
 
     fn write_zeroes(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {
-        let mode = FALLOC_FL_ZERO_RANGE | FALLOC_FL_KEEP_SIZE;
-
-        // SAFETY: FFI call with valid arguments
-        let result = unsafe {
-            libc::fallocate(
-                self.fd as libc::c_int,
-                mode,
-                offset as libc::off_t,
-                length as libc::off_t,
-            )
-        };
-        if result < 0 {
-            return Err(AsyncIoError::WriteZeroes(std::io::Error::last_os_error()));
-        }
-
-        self.completion_list.push_back((user_data, result));
+        write_zeroes(self.fd, self.is_block_device, offset, length)
+            .map_err(AsyncIoError::WriteZeroes)?;
+        self.completion_list.push_back((user_data, 0));
         self.eventfd.write(1).unwrap();
-
         Ok(())
     }
 }

--- a/block/src/sparse.rs
+++ b/block/src/sparse.rs
@@ -1,0 +1,104 @@
+// Copyright 2026 The Cloud Hypervisor Authors. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+// Helpers for issuing `BLKDISCARD` / `BLKZEROOUT` ioctls on block devices,
+// and the `punch_hole` / `write_zeroes` dispatchers used by the raw I/O
+// backends.
+//
+// The kernel ioctl numbers and argument layout are stable userspace ABI
+// (see `include/uapi/linux/fs.h`):
+//
+// ```c
+// #define BLKDISCARD  _IO(0x12, 119)   /* arg: const __u64 range[2] = { start, len } */
+// #define BLKZEROOUT  _IO(0x12, 127)   /* arg: const __u64 range[2] = { start, len } */
+// ```
+//
+// The kernel does `copy_from_user(range, arg, sizeof(range))`, i.e. it reads
+// 16 bytes through the single pointer it is given, so we must pass a single
+// `__u64[2]` array rather than two separate `*const u64` pointers.
+
+use std::io;
+use std::os::unix::io::RawFd;
+
+use libc::{FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE, FALLOC_FL_ZERO_RANGE};
+
+// `_IO(0x12, 119)` — issue a discard request to a block device.
+pub const BLKDISCARD: libc::c_ulong = 0x1277;
+// `_IO(0x12, 127)` — write zeroes to a range of a block device, with a
+// kernel-side fallback to writing zero pages when the hardware has no native
+// `WRITE_ZEROES`.
+pub const BLKZEROOUT: libc::c_ulong = 0x127f;
+
+// Issue a `BLK*` range ioctl with proper `[start, len]` argument.
+fn blk_range_ioctl(fd: RawFd, request: libc::c_ulong, offset: u64, length: u64) -> io::Result<()> {
+    let range: [u64; 2] = [offset, length];
+    // SAFETY: `fd` is a valid block-device fd owned by the caller; `&range`
+    // is a 16-byte array matching the kernel's expected `__u64[2]` layout
+    // and lives for the duration of the call.
+    let ret = unsafe { libc::ioctl(fd, request as _, &range) };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+// Discard (TRIM/UNMAP) the byte range `[offset, offset + length)` on the
+// block device referenced by `fd`.
+pub(crate) fn blkdiscard(fd: RawFd, offset: u64, length: u64) -> io::Result<()> {
+    blk_range_ioctl(fd, BLKDISCARD, offset, length)
+}
+
+// Zero the byte range `[offset, offset + length)` on the block device
+// referenced by `fd`. The kernel falls back to writing explicit zero pages
+// when the device has no hardware `WRITE_ZEROES`.
+pub(crate) fn blkzeroout(fd: RawFd, offset: u64, length: u64) -> io::Result<()> {
+    blk_range_ioctl(fd, BLKZEROOUT, offset, length)
+}
+
+// Punch a hole in `fd` over the byte range `[offset, offset + length)`.
+//
+// On block devices the kernel rejects `fallocate(PUNCH_HOLE)` (notably ZFS
+// zvols), so route through `BLKDISCARD` instead. On regular files use
+// `fallocate(FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE)`.
+pub(crate) fn punch_hole(fd: RawFd, is_blkdev: bool, offset: u64, length: u64) -> io::Result<()> {
+    if is_blkdev {
+        blkdiscard(fd, offset, length)
+    } else {
+        fallocate(
+            fd,
+            FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+            offset,
+            length,
+        )
+    }
+}
+
+// Zero the byte range `[offset, offset + length)` in `fd`.
+//
+// Uses `BLKZEROOUT` on block devices (see [`punch_hole`] for the rationale)
+// and `fallocate(FALLOC_FL_ZERO_RANGE | FALLOC_FL_KEEP_SIZE)` on regular
+// files.
+pub(crate) fn write_zeroes(fd: RawFd, is_blkdev: bool, offset: u64, length: u64) -> io::Result<()> {
+    if is_blkdev {
+        blkzeroout(fd, offset, length)
+    } else {
+        fallocate(
+            fd,
+            FALLOC_FL_ZERO_RANGE | FALLOC_FL_KEEP_SIZE,
+            offset,
+            length,
+        )
+    }
+}
+
+fn fallocate(fd: RawFd, mode: libc::c_int, offset: u64, length: u64) -> io::Result<()> {
+    // SAFETY: FFI call with a valid fd; fallocate touches no userspace memory.
+    let ret = unsafe { libc::fallocate(fd, mode, offset as libc::off_t, length as libc::off_t) };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -603,6 +603,191 @@ mod common_parallel {
         _test_virtio_block(&guest, true, true, false, false, ImageType::Raw);
     }
 
+    // RAII wrapper around a `losetup`'d loop device. The backing file lives
+    // in the guest's tmp_dir so it is cleaned up automatically when the
+    // guest is dropped.
+    struct LoopDev {
+        path: String,
+    }
+
+    impl LoopDev {
+        fn new(tmp: &std::path::Path, size_mb: u64) -> Self {
+            let backing = tmp.join("blkdev.img");
+            let backing_str = backing.to_str().unwrap();
+            assert!(
+                exec_host_command_status(&format!("truncate -s {size_mb}M {backing_str}"))
+                    .success(),
+                "truncate failed"
+            );
+            let out = exec_host_command_output(&format!("losetup -f --show -- {backing_str}"));
+            assert!(out.status.success(), "losetup failed: {out:?}");
+            let path = String::from_utf8(out.stdout).unwrap().trim().to_string();
+            Self { path }
+        }
+    }
+
+    impl Drop for LoopDev {
+        fn drop(&mut self) {
+            let _ = exec_host_command_status(&format!("losetup -d {}", self.path));
+        }
+    }
+
+    // Exercise the new BLKDISCARD / BLKZEROOUT ioctl paths in `block/` by
+    // attaching a real block device (a loop device) as a writable virtio-blk
+    // disk and issuing `blkdiscard` / `fstrim` from inside the guest.
+    //
+    // `is_block_device()` returns true for `/dev/loopN`, so cloud-hypervisor now
+    // routes punch_hole / write_zeroes through the BLK* ioctls regardless of
+    // whether `fallocate()` would have worked. This test therefore covers:
+    //   - is_block_device() detection at backend construction,
+    //   - blkdiscard() / blkzeroout() helpers in block::sparse,
+    //   - the io_uring `submit_nop()` completion plumbing (io_uring case),
+    //   - the BLKDISCARD / BLKZEROOUT additions to the VirtioBlock seccomp
+    //     whitelist (any of these would otherwise SIGSYS the device thread).
+    fn _test_virtio_block_blkdev(disable_io_uring: bool, disable_aio: bool) {
+        let focal = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(focal));
+        let loopdev = LoopDev::new(guest.tmp_dir.as_path(), 64);
+        let kernel_path = direct_kernel_boot_path();
+
+        let mut cloud_child = GuestCommand::new(&guest)
+            .args(["--cpus", "boot=2"])
+            .args(["--memory", "size=512M"])
+            .args(["--kernel", kernel_path.to_str().unwrap()])
+            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .args([
+                "--disk",
+                format!(
+                    "path={}",
+                    guest.disk_config.disk(DiskType::OperatingSystem).unwrap()
+                )
+                .as_str(),
+                format!(
+                    "path={}",
+                    guest.disk_config.disk(DiskType::CloudInit).unwrap()
+                )
+                .as_str(),
+                format!(
+                    "path={},image_type=raw,num_queues=2,\
+                     _disable_io_uring={},_disable_aio={}",
+                    loopdev.path, disable_io_uring, disable_aio,
+                )
+                .as_str(),
+            ])
+            .default_net()
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = std::panic::catch_unwind(|| {
+            guest.wait_vm_boot().unwrap();
+
+            // The loop device shows up as vdc.
+            assert_eq!(
+                guest
+                    .ssh_command("lsblk | grep -c vdc")
+                    .unwrap()
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap_or_default(),
+                1
+            );
+
+            // 1) BLKDISCARD path: fill the first 16 MiB with random data,
+            //    then discard the first 8 MiB. We only assert that the
+            //    ioctl path succeeds end-to-end; whether the discarded
+            //    range reads back as zeros is not guaranteed by the
+            //    BLKDISCARD contract (see BLKZEROOUT below for the
+            //    read-as-zero assertion).
+            guest
+                .ssh_command("sudo dd if=/dev/urandom of=/dev/vdc bs=1M count=16 conv=fsync")
+                .expect("initial write failed");
+            guest
+                .ssh_command("sudo blkdiscard -o 0 -l 8388608 /dev/vdc")
+                .expect("blkdiscard (BLKDISCARD ioctl path) failed");
+
+            // 2) BLKZEROOUT path: same idea, but via `blkdiscard -z` which
+            //    issues BLKZEROOUT instead of BLKDISCARD.
+            guest
+                .ssh_command("sudo dd if=/dev/urandom of=/dev/vdc bs=1M count=16 conv=fsync")
+                .expect("second write failed");
+            guest
+                .ssh_command("sudo blkdiscard -z -o 0 -l 8388608 /dev/vdc")
+                .expect("blkdiscard -z (BLKZEROOUT ioctl path) failed");
+            let nonzero = guest
+                .ssh_command(
+                    "sudo dd if=/dev/vdc bs=1M count=8 status=none | \
+                     tr -d '\\000' | wc -c",
+                )
+                .unwrap();
+            assert_eq!(
+                nonzero.trim(),
+                "0",
+                "BLKZEROOUT did not zero the requested range"
+            );
+
+            // 3) End-to-end fstrim through a real filesystem on the block
+            //    device. This is the closest CI-friendly approximation of
+            //    the original ZFS-zvol scenario in #8127.
+            guest
+                .ssh_command("sudo mkfs.ext4 -F /dev/vdc")
+                .expect("mkfs.ext4 failed");
+            guest
+                .ssh_command(
+                    "sudo mkdir -p /mnt/blkdev && \
+                     sudo mount -o discard /dev/vdc /mnt/blkdev",
+                )
+                .expect("mount -o discard failed");
+            guest
+                .ssh_command(
+                    "sudo dd if=/dev/urandom of=/mnt/blkdev/f bs=1M count=16 \
+                     conv=fsync && sudo rm /mnt/blkdev/f && sync",
+                )
+                .expect("populate-then-delete failed");
+            // `fstrim -v` prints e.g. "/mnt/blkdev: 12 MiB (12582912 bytes)
+            // trimmed on /dev/vdc". Extract the byte count and assert that
+            // it is non-zero: `fstrim` exits 0 even when nothing is trimmed
+            // (e.g. if virtio-blk DISCARD was not negotiated), which would
+            // silently mask exactly the regression this test exists to
+            // catch.
+            let fstrim_out = guest
+                .ssh_command("sudo fstrim -v /mnt/blkdev")
+                .expect("fstrim invocation failed");
+            let trimmed_bytes: u64 = fstrim_out
+                .split_once('(')
+                .and_then(|(_, rest)| rest.split_once(" bytes"))
+                .and_then(|(n, _)| n.trim().parse().ok())
+                .unwrap_or_else(|| panic!("could not parse fstrim output: {fstrim_out:?}"));
+            assert!(
+                trimmed_bytes > 0,
+                "fstrim trimmed 0 bytes -- virtio-blk DISCARD likely \
+                 not advertised or BLK* path not wired up: {fstrim_out:?}"
+            );
+            guest
+                .ssh_command("sudo umount /mnt/blkdev")
+                .expect("umount failed");
+        });
+
+        let _ = cloud_child.kill();
+        let output = cloud_child.wait_with_output().unwrap();
+        handle_child_output(r, &output);
+    }
+
+    #[test]
+    fn test_virtio_block_blkdev_io_uring() {
+        _test_virtio_block_blkdev(false, false);
+    }
+
+    #[test]
+    fn test_virtio_block_blkdev_aio() {
+        _test_virtio_block_blkdev(true, false);
+    }
+
+    #[test]
+    fn test_virtio_block_blkdev_sync() {
+        _test_virtio_block_blkdev(true, true);
+    }
+
     #[test]
     fn test_compute_file_checksum_empty() {
         let mut reader = io::Cursor::new(vec![]);

--- a/virtio-devices/src/seccomp_filters.rs
+++ b/virtio-devices/src/seccomp_filters.rs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use block::{BLKDISCARD, BLKZEROOUT};
 use libc::{FIONBIO, TIOCGWINSZ, TUNSETOFFLOAD};
 use seccompiler::SeccompCmpOp::Eq;
 use seccompiler::{
@@ -113,8 +114,7 @@ fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_fsync, vec![]),
         (libc::SYS_ftruncate, vec![]),
         (libc::SYS_getrandom, vec![]),
-        #[cfg(feature = "sev_snp")]
-        (libc::SYS_ioctl, create_mshv_sev_snp_ioctl_seccomp_rule()),
+        (libc::SYS_ioctl, create_virtio_block_ioctl_seccomp_rule()),
         (libc::SYS_io_destroy, vec![]),
         (libc::SYS_io_getevents, vec![]),
         (libc::SYS_io_submit, vec![]),
@@ -128,6 +128,15 @@ fn virtio_block_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
         (libc::SYS_sched_setaffinity, vec![]),
         (libc::SYS_set_robust_list, vec![]),
         (libc::SYS_timerfd_settime, vec![]),
+    ]
+}
+
+fn create_virtio_block_ioctl_seccomp_rule() -> Vec<SeccompRule> {
+    or![
+        and![Cond::new(1, ArgLen::Dword, Eq, BLKDISCARD as _).unwrap()],
+        and![Cond::new(1, ArgLen::Dword, Eq, BLKZEROOUT as _).unwrap()],
+        #[cfg(feature = "sev_snp")]
+        mshv_sev_snp_ioctl_seccomp_rule(),
     ]
 }
 


### PR DESCRIPTION
https://github.com/cloud-hypervisor/cloud-hypervisor/issues/8127 shows that the existing code doesn't work on ZFS volumes.

Using ioctl(BLK*) in `raw_async_aio.rs` and `raw_sync.rs` should be okay. It is not fundamentally different from calling `fallocate` performance wise.

The io_uring backend is tricker. Since there is no way to probe for `fallocate` support, if we want to retain io_uring as the preferred method, the code needs to reap `EOPNOTSUPP` in the completion path, and then reissue a synchronized ioctl.

I discussed with @weltling offline. It makes more sense to keep the code simple and optimize it later, given that `punch_hole` and `write_zeroes` are supposedly rare.

CC @philz please help test this PR.

For completeness, since 6.12, Linux supports BLKDISCARD in io_uring. ZEROOUT is not yet merged. For simplicity and compatibility sake, I opt to stick with synchronized ioctls.