### PR TITLE
tests: Avoid IPv6 autoconf races in test_vdpa_net

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -5600,6 +5600,19 @@ mod common_parallel {
             guest
                 .ssh_command("sudo ip addr add 172.16.1.2/24 dev ens6")
                 .unwrap();
+            // Disable IPv6 on the interface before bringing it up to avoid
+            // IPv6 link-local autoconfiguration emitting NDP/RS packets which
+            // would invalidate the "zero packets" precondition checked below
+            // (some guest kernels emit these before our stats query races in).
+            // Use `sysctl -e` so the command is a no-op (rather than an error)
+            // on kernels built without IPv6, where these keys do not exist.
+            guest
+                .ssh_command(
+                    "sudo sysctl -e -w net.ipv6.conf.ens6.disable_ipv6=1 \
+                     net.ipv6.conf.ens6.accept_ra=0 \
+                     net.ipv6.conf.ens6.autoconf=0",
+                )
+                .unwrap();
             guest.ssh_command("sudo ip link set up dev ens6").unwrap();
 
             // Check there is no packet yet on both TX/RX of the network interface


### PR DESCRIPTION
The test_vdpa_net integration test brings the vDPA-backed interface (ens6) up and then asserts that both TX and RX packet counters are exactly zero before sending an explicit ping. On guest kernels that perform IPv6 link-local autoconfiguration quickly enough, however, Router Solicitation / Neighbor Discovery frames are emitted as soon as the link comes up. The vdpa_sim_net device loops those frames back to the interface, so by the time the test queries

    ip -j -p -s link show ens6 | grep -c '"packets": 0'

the TX and RX counters are already non-zero and the precondition assertion fails (observed reliably with the Microsoft internal guest kernel running on MSHV).

Disable IPv6 / accept_ra / autoconf on ens6 before bringing the link up. With IPv6 disabled no autoconf traffic is generated, the counters remain at zero until the explicit 'ping 172.16.1.10 -c 6' generates exactly the 6 packets the rest of the test expects on each direction, and the vDPA-specific portion of the test is unchanged.

Verified on an MSHV Azure VM (Linux 6.6.121.mshv2):

    test common_parallel::test_vdpa_net ... ok
    test result: ok. 1 passed; 0 failed; ...; finished in 26.13s