### PR TITLE
vmm: roll back mem64/IO allocator on failed move_bar

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -727,7 +727,9 @@ impl DeviceRelocation for AddressManager {
         match region_type {
             PciBarRegionType::IoRegion => {
                 let mut sys_allocator = self.allocator.lock().unwrap();
-                // Update system allocator
+                // Free old_base first so allocate(new_base) sees it as
+                // available; restore old_base on failure to keep the
+                // allocator in sync with the PIO bus.
                 sys_allocator.free_io_addresses(GuestAddress(old_base), len as GuestUsize);
                 if sys_allocator
                     .allocate_io_addresses(Some(GuestAddress(new_base)), len as GuestUsize, None)
@@ -767,6 +769,9 @@ impl DeviceRelocation for AddressManager {
                     if old_base >= pci_mmio_allocator.base().0
                         && old_base <= pci_mmio_allocator.end().0
                     {
+                        // Free old_base first so allocate(new_base) sees it
+                        // as available; restore old_base on failure to keep
+                        // the allocator in sync with the MMIO bus.
                         pci_mmio_allocator.free(GuestAddress(old_base), len as GuestUsize);
                         if pci_mmio_allocator
                             .allocate(Some(GuestAddress(new_base)), len as GuestUsize, Some(len))

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -729,9 +729,24 @@ impl DeviceRelocation for AddressManager {
                 let mut sys_allocator = self.allocator.lock().unwrap();
                 // Update system allocator
                 sys_allocator.free_io_addresses(GuestAddress(old_base), len as GuestUsize);
-                sys_allocator
+                if sys_allocator
                     .allocate_io_addresses(Some(GuestAddress(new_base)), len as GuestUsize, None)
-                    .ok_or_else(|| io::Error::other("failed allocating new IO range"))?;
+                    .is_none()
+                {
+                    if sys_allocator
+                        .allocate_io_addresses(
+                            Some(GuestAddress(old_base)),
+                            len as GuestUsize,
+                            None,
+                        )
+                        .is_none()
+                    {
+                        error!(
+                            "Failed to restore old IO range 0x{old_base:x} after rejected move_bar"
+                        );
+                    }
+                    return Err(io::Error::other("failed allocating new IO range"));
+                }
 
                 // Update PIO bus
                 self.io_bus
@@ -753,10 +768,24 @@ impl DeviceRelocation for AddressManager {
                         && old_base <= pci_mmio_allocator.end().0
                     {
                         pci_mmio_allocator.free(GuestAddress(old_base), len as GuestUsize);
-
-                        pci_mmio_allocator
+                        if pci_mmio_allocator
                             .allocate(Some(GuestAddress(new_base)), len as GuestUsize, Some(len))
-                            .ok_or_else(|| io::Error::other("failed allocating new MMIO range"))?;
+                            .is_none()
+                        {
+                            if pci_mmio_allocator
+                                .allocate(
+                                    Some(GuestAddress(old_base)),
+                                    len as GuestUsize,
+                                    Some(len),
+                                )
+                                .is_none()
+                            {
+                                error!(
+                                    "Failed to restore old MMIO range 0x{old_base:x} after rejected move_bar"
+                                );
+                            }
+                            return Err(io::Error::other("failed allocating new MMIO range"));
+                        }
 
                         break;
                     }


### PR DESCRIPTION
Fixes #8203.

When a guest writes a new BAR address that the host allocator cannot honor (e.g. the requested range overlaps another device's BAR), `move_bar()` previously freed `old_base`, attempted to allocate `new_base`, and early-returned the failure with `?` — leaving the allocator in a state where `old_base` is marked free even though the MMIO/PIO bus still maps the device there.

PR #7950 added `restore_bar_addr()` so the BAR config register and bus mapping stay consistent, but `move_bar()` itself was not touched, so the allocator's view of free addresses drifts away from the bus mapping on every failure path #7950 now silently absorbs.

The next allocation picks `old_base` off the free list (it is the highest free slot in the descending allocator), tries to insert the new device into the MMIO bus, and the insert fails with `Overlap` because the live device is still mapped there.

The fix: re-allocate `old_base` immediately when `allocate(new_base)` fails, before bubbling the error up. The PIO branch needs the same treatment for symmetry; the I/O bus has the same invariant.

The most reliable trigger we see is Windows 11 25H2's PnP resource rebalance (see #8202) — it routinely picks BAR targets that overlap other live virtio devices.

Signed-off-by: CMGS <ilskdw@gmail.com>