### PR TITLE
virtio-devices: ack requests from backends

### DIFF
--- a/virtio-devices/src/vhost_user/generic_vhost_user.rs
+++ b/virtio-devices/src/vhost_user/generic_vhost_user.rs
@@ -297,12 +297,21 @@ impl VirtioDevice for GenericVhostUser {
 
         let backend_req_handler = has_backend_req
             .then(|| {
-                FrontendReqHandler::new(Arc::new(BackendReqHandler {
+                let mut handler = FrontendReqHandler::new(Arc::new(BackendReqHandler {
                     interrupt_cb: interrupt_cb.clone(),
                 }))
                 .map_err(|e| {
                     crate::ActivateError::VhostUserSetup(Error::FrontendReqHandlerCreation(e))
-                })
+                })?;
+
+                if self.vu_common.acked_protocol_features
+                    & VhostUserProtocolFeatures::REPLY_ACK.bits()
+                    != 0
+                {
+                    handler.set_reply_ack_flag(true);
+                }
+
+                Ok(handler)
             })
             // Return inner Err early, keep Option of `Ok` value
             .transpose()?;


### PR DESCRIPTION
Quoting the spec:

> If VHOST_USER_PROTOCOL_F_REPLY_ACK is negotiated, and the back-end sets the VHOST_USER_NEED_REPLY flag, the front-end must respond with zero when operation is successfully completed, or non-zero otherwise.

cloud-hypervisor would previously not send a response to a VHOST_USER_BACKEND_CONFIG_CHANGE_MSG message, even if VHOST_USER_PROTOCOL_F_REPLY_ACK had been negotiated and VHOST_USER_NEED_REPLY was set, in violation of the spec.

Link: https://qemu-project.gitlab.io/qemu/interop/vhost-user.html#back-end-message-types
Fixes: 8d6213338 ("virtio-devices: generic-vhost-user: Config change notification")