### PR TITLE
tests: avoid event wait log spam

### DIFF
--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -1059,9 +1059,11 @@ pub(crate) fn _test_virtio_fs(
                 event: "device-removed".to_string(),
                 device_id: Some("myfs0".to_string()),
             };
-            assert!(wait_until(Duration::from_secs(10), || {
-                check_sequential_events(&[&removed_event], &event_path)
-            }));
+            assert!(wait_for_sequential_events(
+                Duration::from_secs(10),
+                &[&removed_event],
+                &event_path
+            ));
         }
     });
 
@@ -1635,9 +1637,11 @@ pub(crate) fn _test_simple_launch(guest: &Guest) {
                 device_id: None,
             },
         ];
-        assert!(wait_until(Duration::from_secs(20), || {
-            check_latest_events_exact(&latest_events, &event_path)
-        }));
+        assert!(wait_for_latest_events_exact(
+            Duration::from_secs(20),
+            &latest_events,
+            &event_path
+        ));
     });
 
     kill_child(&mut child);
@@ -3173,9 +3177,11 @@ pub(crate) fn _test_pvpanic(guest: &Guest) {
             event: "panic".to_string(),
             device_id: None,
         }];
-        assert!(wait_until(Duration::from_secs(10), || {
-            check_latest_events_exact(&expected_sequential_events, &event_path)
-        }));
+        assert!(wait_for_latest_events_exact(
+            Duration::from_secs(10),
+            &expected_sequential_events,
+            &event_path
+        ));
     });
 
     kill_child(&mut child);

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -486,8 +486,8 @@ pub(crate) fn fw_path(_fw_type: FwType) -> String {
     fw_path.to_str().unwrap().to_string()
 }
 
-// Parse the event_monitor file based on the format that each event
-// is followed by a double newline
+/// Parse the event_monitor file based on the format that each event
+/// is followed by a double newline
 fn parse_event_file(event_file: &str) -> Vec<serde_json::Value> {
     let content = fs::read(event_file).unwrap();
     let mut ret = Vec::new();
@@ -502,9 +502,34 @@ fn parse_event_file(event_file: &str) -> Vec<serde_json::Value> {
     ret
 }
 
-// Return true if all events from the input 'expected_events' are matched sequentially
-// with events from the 'event_file'
+/// Return true if all events from the input 'expected_events' are matched sequentially
+/// with events from the 'event_file'
 pub(crate) fn check_sequential_events(expected_events: &[&MetaEvent], event_file: &str) -> bool {
+    check_sequential_events_with_options(expected_events, event_file, true)
+}
+
+/// Wait for a sequential event match and print diagnostics only after timeout.
+pub(crate) fn wait_for_sequential_events(
+    timeout: Duration,
+    expected_events: &[&MetaEvent],
+    event_file: &str,
+) -> bool {
+    if wait_until(timeout, || {
+        check_sequential_events_with_options(expected_events, event_file, false)
+    }) {
+        return true;
+    }
+
+    check_sequential_events(expected_events, event_file);
+    false
+}
+
+/// Check sequential events with optional mismatch diagnostics.
+fn check_sequential_events_with_options(
+    expected_events: &[&MetaEvent],
+    event_file: &str,
+    print_diagnostics: bool,
+) -> bool {
     if !Path::new(event_file).exists() {
         return false;
     }
@@ -522,7 +547,7 @@ pub(crate) fn check_sequential_events(expected_events: &[&MetaEvent], event_file
 
     let ret = idx == len;
 
-    if !ret {
+    if !ret && print_diagnostics {
         eprintln!(
             "\n\n==== Start 'check_sequential_events' failed ==== \
              \n\nexpected_events={expected_events:?}\nactual_events={json_events:?} \
@@ -563,9 +588,34 @@ pub(crate) fn check_sequential_events_exact(
     true
 }
 
-// Return true if events from the input 'latest_events' are matched exactly
-// with the most recent events from the 'event_file'
+/// Return true if events from the input 'latest_events' are matched exactly
+/// with the most recent events from the 'event_file'
 pub(crate) fn check_latest_events_exact(latest_events: &[&MetaEvent], event_file: &str) -> bool {
+    check_latest_events_exact_with_options(latest_events, event_file, true)
+}
+
+/// Wait for an exact latest-event match and print diagnostics only after timeout.
+pub(crate) fn wait_for_latest_events_exact(
+    timeout: Duration,
+    latest_events: &[&MetaEvent],
+    event_file: &str,
+) -> bool {
+    if wait_until(timeout, || {
+        check_latest_events_exact_with_options(latest_events, event_file, false)
+    }) {
+        return true;
+    }
+
+    check_latest_events_exact(latest_events, event_file);
+    false
+}
+
+/// Check latest events with optional mismatch diagnostics.
+fn check_latest_events_exact_with_options(
+    latest_events: &[&MetaEvent],
+    event_file: &str,
+    print_diagnostics: bool,
+) -> bool {
     if !Path::new(event_file).exists() {
         return false;
     }
@@ -577,11 +627,13 @@ pub(crate) fn check_latest_events_exact(latest_events: &[&MetaEvent], event_file
 
     for (idx, e) in json_events.iter().enumerate() {
         if !latest_events[idx].match_with_json_event(e) {
-            eprintln!(
-                "\n\n==== Start 'check_latest_events_exact' failed ==== \
-                 \n\nexpected_events={latest_events:?}\nactual_events={json_events:?} \
-                 \n\n==== End 'check_latest_events_exact' failed ====",
-            );
+            if print_diagnostics {
+                eprintln!(
+                    "\n\n==== Start 'check_latest_events_exact' failed ==== \
+                     \n\nexpected_events={latest_events:?}\nactual_events={json_events:?} \
+                     \n\n==== End 'check_latest_events_exact' failed ====",
+                );
+            }
 
             return false;
         }

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -5770,9 +5770,11 @@ mod common_parallel {
                 event: "panic".to_string(),
                 device_id: None,
             }];
-            assert!(wait_until(Duration::from_secs(3), || {
-                check_latest_events_exact(&expected_sequential_events, &event_path)
-            }));
+            assert!(wait_for_latest_events_exact(
+                Duration::from_secs(3),
+                &expected_sequential_events,
+                &event_path
+            ));
         });
 
         kill_child(&mut child);
@@ -7524,9 +7526,11 @@ mod ivshmem {
             device_id: None,
         }];
         // Wait for the restored event to show up in the monitor file.
-        assert!(wait_until(Duration::from_secs(30), || {
-            check_latest_events_exact(&latest_events, &event_path_restored)
-        }));
+        assert!(wait_for_latest_events_exact(
+            Duration::from_secs(30),
+            &latest_events,
+            &event_path_restored
+        ));
 
         // Remove the snapshot dir
         let _ = remove_dir_all(snapshot_dir.as_str());
@@ -7549,9 +7553,11 @@ mod ivshmem {
                     device_id: None,
                 },
             ];
-            assert!(wait_until(Duration::from_secs(30), || {
-                check_latest_events_exact(&latest_events, &event_path_restored)
-            }));
+            assert!(wait_for_latest_events_exact(
+                Duration::from_secs(30),
+                &latest_events,
+                &event_path_restored
+            ));
 
             // Check the number of vCPUs
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), 2);
@@ -7650,9 +7656,11 @@ mod snapshot_restore_common {
             },
         ];
 
-        assert!(wait_until(Duration::from_secs(30), || {
-            check_latest_events_exact(&latest_events, event_path)
-        }));
+        assert!(wait_for_latest_events_exact(
+            Duration::from_secs(30),
+            &latest_events,
+            event_path
+        ));
 
         // Take a snapshot from the VM
         assert!(remote_command(
@@ -7672,9 +7680,11 @@ mod snapshot_restore_common {
             },
         ];
 
-        assert!(wait_until(Duration::from_secs(30), || {
-            check_latest_events_exact(&latest_events, event_path)
-        }));
+        assert!(wait_for_latest_events_exact(
+            Duration::from_secs(30),
+            &latest_events,
+            event_path
+        ));
     }
 
     pub(crate) fn _test_snapshot_restore(use_hotplug: bool, use_resume_option: bool) {
@@ -7787,9 +7797,11 @@ mod snapshot_restore_common {
                     event: "device-removed".to_string(),
                     device_id: Some(net_id.to_string()),
                 }];
-                assert!(wait_until(Duration::from_secs(30), || {
-                    check_latest_events_exact(&latest_events, &event_path)
-                }));
+                assert!(wait_for_latest_events_exact(
+                    Duration::from_secs(30),
+                    &latest_events,
+                    &event_path
+                ));
 
                 // Plug the virtio-net device again
                 assert!(remote_command(
@@ -7861,9 +7873,11 @@ mod snapshot_restore_common {
                 device_id: None,
             },
         ];
-        assert!(wait_until(Duration::from_secs(30), || {
-            check_sequential_events(&expected_events, &event_path_restored)
-        }));
+        assert!(wait_for_sequential_events(
+            Duration::from_secs(30),
+            &expected_events,
+            &event_path_restored
+        ));
         if use_resume_option {
             let latest_events = [
                 &MetaEvent {
@@ -7879,17 +7893,21 @@ mod snapshot_restore_common {
                     device_id: None,
                 },
             ];
-            assert!(wait_until(Duration::from_secs(30), || {
-                check_latest_events_exact(&latest_events, &event_path_restored)
-            }));
+            assert!(wait_for_latest_events_exact(
+                Duration::from_secs(30),
+                &latest_events,
+                &event_path_restored
+            ));
         } else {
             let latest_events = [&MetaEvent {
                 event: "restored".to_string(),
                 device_id: None,
             }];
-            assert!(wait_until(Duration::from_secs(30), || {
-                check_latest_events_exact(&latest_events, &event_path_restored)
-            }));
+            assert!(wait_for_latest_events_exact(
+                Duration::from_secs(30),
+                &latest_events,
+                &event_path_restored
+            ));
         }
 
         // Wait until the restored VM API is ready before issuing follow-up requests.
@@ -7925,9 +7943,11 @@ mod snapshot_restore_common {
                         device_id: None,
                     },
                 ];
-                assert!(wait_until(Duration::from_secs(30), || {
-                    check_latest_events_exact(&latest_events, &event_path_restored)
-                }));
+                assert!(wait_for_latest_events_exact(
+                    Duration::from_secs(30),
+                    &latest_events,
+                    &event_path_restored
+                ));
             }
 
             // Perform same checks to validate VM has been properly restored
@@ -8049,9 +8069,11 @@ mod snapshot_restore_common {
             device_id: None,
         }];
 
-        assert!(wait_until(Duration::from_secs(30), || {
-            check_latest_events_exact(&latest_events, &event_path_restored)
-        }));
+        assert!(wait_for_latest_events_exact(
+            Duration::from_secs(30),
+            &latest_events,
+            &event_path_restored
+        ));
 
         let r = std::panic::catch_unwind(|| {
             assert!(wait_until(Duration::from_secs(30), || remote_command(
@@ -8071,9 +8093,11 @@ mod snapshot_restore_common {
                     device_id: None,
                 },
             ];
-            assert!(wait_until(Duration::from_secs(30), || {
-                check_latest_events_exact(&latest_events, &event_path_restored)
-            }));
+            assert!(wait_for_latest_events_exact(
+                Duration::from_secs(30),
+                &latest_events,
+                &event_path_restored
+            ));
 
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), 4);
             assert!(guest.get_total_memory().unwrap_or_default() > min_total_memory_kib);
@@ -8178,9 +8202,11 @@ mod snapshot_restore_common {
             event: "restored".to_string(),
             device_id: None,
         }];
-        assert!(wait_until(Duration::from_secs(30), || {
-            check_latest_events_exact(&latest_events, &event_path_restored)
-        }));
+        assert!(wait_for_latest_events_exact(
+            Duration::from_secs(30),
+            &latest_events,
+            &event_path_restored
+        ));
 
         let _ = remove_dir_all(snapshot_dir.as_str());
 
@@ -8201,9 +8227,11 @@ mod snapshot_restore_common {
                     device_id: None,
                 },
             ];
-            assert!(wait_until(Duration::from_secs(30), || {
-                check_latest_events_exact(&latest_events, &event_path_restored)
-            }));
+            assert!(wait_for_latest_events_exact(
+                Duration::from_secs(30),
+                &latest_events,
+                &event_path_restored
+            ));
 
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), 2);
             guest.check_devices_common(Some(&socket), Some(&console_text), None);
@@ -8438,16 +8466,20 @@ mod common_sequential {
             },
         ];
         // Wait for the restore event sequence to be recorded.
-        assert!(wait_until(Duration::from_secs(30), || {
-            check_sequential_events(&expected_events, &event_path_restored)
-        }));
+        assert!(wait_for_sequential_events(
+            Duration::from_secs(30),
+            &expected_events,
+            &event_path_restored
+        ));
         let latest_events = [&MetaEvent {
             event: "restored".to_string(),
             device_id: None,
         }];
-        assert!(wait_until(Duration::from_secs(30), || {
-            check_latest_events_exact(&latest_events, &event_path_restored)
-        }));
+        assert!(wait_for_latest_events_exact(
+            Duration::from_secs(30),
+            &latest_events,
+            &event_path_restored
+        ));
 
         // Remove the snapshot dir
         let _ = remove_dir_all(snapshot_dir.as_str());
@@ -8471,9 +8503,11 @@ mod common_sequential {
                     device_id: None,
                 },
             ];
-            assert!(wait_until(Duration::from_secs(30), || {
-                check_latest_events_exact(&latest_events, &event_path_restored)
-            }));
+            assert!(wait_for_latest_events_exact(
+                Duration::from_secs(30),
+                &latest_events,
+                &event_path_restored
+            ));
 
             // Perform same checks to validate VM has been properly restored
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), n_cpu);


### PR DESCRIPTION
Event expectation helpers print detailed diagnostics when the observed event stream does not match the expected one. That is useful for direct assertions, but it becomes extremely noisy [0] when the helper is used as the predicate for wait_until(), because every polling attempt emits the full mismatch dump.

Add quiet wait wrappers for event polling and emit the existing detailed diagnostics only once after the timeout expires.

[0] https://github.com/cloud-hypervisor/cloud-hypervisor/actions/runs/25745401604/job/75619840718?pr=8021
