### PR TITLE
Fix deadlock regarding VcpuState handling (finally)

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1605,22 +1605,16 @@ impl CpuManager {
     /// Calls [`VcpuState::signal_thread`] and
     /// [`VcpuState::wait_until_signal_acknowledged`] for each vCPU.
     fn signal_vcpus(&mut self) -> Result<()> {
-        let vcpu_count = self.vcpu_states.lock().unwrap().len();
+        // Holding the lock for the whole operation is correct:
+        let vcpu_states = self.vcpu_states.lock().unwrap();
 
         // Splitting this into two loops reduced the time to pause many vCPUs
         // massively. Example: 254 vCPUs. >254ms -> ~4ms.
-        //
-        // Do not hold `vcpu_states` across the wait phase. A vCPU can handle
-        // the kick in userspace while servicing MMIO on the ACPI CPU hotplug
-        // device, and that path also takes `vcpu_states`. Holding the mutex
-        // here while waiting would deadlock pause against that MMIO access.
-        for cpu_id in 0..vcpu_count {
-            let vcpu_states = self.vcpu_states.lock().unwrap();
-            vcpu_states[cpu_id].signal_thread();
+        for state in vcpu_states.iter() {
+            state.signal_thread();
         }
-        for cpu_id in 0..vcpu_count {
-            let vcpu_states = self.vcpu_states.lock().unwrap();
-            vcpu_states[cpu_id].wait_until_signal_acknowledged()?;
+        for state in vcpu_states.iter() {
+            state.wait_until_signal_acknowledged()?;
         }
 
         Ok(())

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -19,7 +19,7 @@ use std::mem::size_of;
 use std::ops::Deref;
 use std::os::unix::thread::JoinHandleExt;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::sync::{Arc, Barrier, Mutex, RwLock};
+use std::sync::{Arc, Barrier, Mutex, RwLock, Weak};
 use std::{cmp, io, result, thread};
 
 use acpi_tables::sdt::Sdt;
@@ -1667,6 +1667,7 @@ impl CpuManager {
         }
 
         // Clear any stale data. Will be initialized on the next VM boot.
+        // AcpiCpuHotplugController only has a Weak reference.
         self.vcpu_states = Arc::new(Box::new([]));
 
         Ok(())
@@ -3204,7 +3205,7 @@ pub struct AcpiCpuHotplugController {
     /// The currently selected CPU by the guest.
     selected_cpu: u32,
     /// Shared vCPU state with [`CpuManager`].
-    vcpu_states: Arc<Box<[RwLock<VcpuState>]>>,
+    vcpu_states: Weak<Box<[RwLock<VcpuState>]>>,
     /// Maximum number of vCPUS of the VM.
     max_vcpus: u32,
 }
@@ -3223,7 +3224,7 @@ impl AcpiCpuHotplugController {
         Self {
             max_vcpus: cpu_manager.config.max_vcpus,
             selected_cpu: 0,
-            vcpu_states: cpu_manager.vcpu_states.clone(),
+            vcpu_states: Arc::downgrade(&cpu_manager.vcpu_states),
         }
     }
 
@@ -3248,6 +3249,11 @@ impl AcpiCpuHotplugController {
 
 impl BusDevice for AcpiCpuHotplugController {
     fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
+        let vcpu_states = self
+            .vcpu_states
+            .upgrade()
+            .expect("corresponding CpuManager should still be alive");
+
         // The Linux kernel, quite reasonably, doesn't zero the memory it gives us.
         data.fill(0);
 
@@ -3260,7 +3266,7 @@ impl BusDevice for AcpiCpuHotplugController {
             Self::CPU_STATUS_OFFSET => {
                 if self.selected_cpu < self.max_vcpus {
                     let vcpu_id = usize::try_from(self.selected_cpu).unwrap();
-                    let state = self.vcpu_states[vcpu_id].read().unwrap();
+                    let state = vcpu_states[vcpu_id].read().unwrap();
                     if state.active() {
                         data[0] |= 1 << Self::CPU_ENABLE_FLAG;
                     }
@@ -3281,6 +3287,11 @@ impl BusDevice for AcpiCpuHotplugController {
     }
 
     fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        let vcpu_states = self
+            .vcpu_states
+            .upgrade()
+            .expect("corresponding CpuManager should still be alive");
+
         match offset {
             Self::CPU_SELECTION_OFFSET => {
                 assert!(data.len() >= core::mem::size_of::<u32>());
@@ -3290,7 +3301,7 @@ impl BusDevice for AcpiCpuHotplugController {
             Self::CPU_STATUS_OFFSET => {
                 if self.selected_cpu < self.max_vcpus {
                     let vcpu_id = usize::try_from(self.selected_cpu).unwrap();
-                    let mut state = self.vcpu_states[vcpu_id].write().unwrap();
+                    let mut state = vcpu_states[vcpu_id].write().unwrap();
                     // The ACPI code writes back a 1 to acknowledge the insertion
                     if (data[0] & (1 << Self::CPU_INSERTING_FLAG) == 1 << Self::CPU_INSERTING_FLAG)
                         && state.hotplug_state.inserting.load(Ordering::Acquire)

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -773,10 +773,10 @@ impl TryFrom<i32> for CoreSchedulingLeader {
 struct VcpuHotplugState {
     /// Guest-visible ACPI status that is true until the guest acknowledged the
     /// hotplugging of a vCPU.
-    inserting: bool,
+    inserting: AtomicBool,
     /// Guest-visible ACPI status that is true until the guest acknowledged the
     /// removal of a vCPU.
-    removing: bool,
+    removing: AtomicBool,
 }
 
 /// Management structure for a vCPU (thread).
@@ -1186,15 +1186,12 @@ impl CpuManager {
         let vcpus_kick_signalled = self.vcpus_kick_signalled.clone();
 
         let mut vcpu_states = self.vcpu_states.lock().unwrap();
-
-        let vcpu_kill = vcpu_states[usize::try_from(vcpu_id).unwrap()].kill.clone();
-        let vcpu_run_interrupted = vcpu_states[usize::try_from(vcpu_id).unwrap()]
-            .vcpu_run_interrupted
-            .clone();
+        let vcpu_id_usize = usize::try_from(vcpu_id).unwrap();
+        let vcpu_state = &mut vcpu_states[vcpu_id_usize];
+        let vcpu_kill = vcpu_state.kill.clone();
+        let vcpu_run_interrupted = vcpu_state.vcpu_run_interrupted.clone();
         let panic_vcpu_run_interrupted = vcpu_run_interrupted.clone();
-        let vcpu_paused = vcpu_states[usize::try_from(vcpu_id).unwrap()]
-            .paused
-            .clone();
+        let vcpu_paused = vcpu_state.paused.clone();
 
         // Prepare the CPU set the current vCPU is expected to run onto.
         let cpuset = self.affinity.get(&vcpu_id).map(|host_cpus| {
@@ -1480,10 +1477,11 @@ impl CpuManager {
 
         // On hot plug calls into this function entry_point is None. It is for
         // those hotplug CPU additions that we need to set the inserting flag.
-        vcpu_states[usize::try_from(vcpu_id).unwrap()].handle = handle;
-        vcpu_states[usize::try_from(vcpu_id).unwrap()]
+        vcpu_state.handle = handle;
+        vcpu_state
             .hotplug_state
-            .inserting = inserting;
+            .inserting
+            .store(inserting, Ordering::Release);
 
         Ok(())
     }
@@ -1527,17 +1525,18 @@ impl CpuManager {
     }
 
     fn mark_vcpus_for_removal(&mut self, desired_vcpus: u32) {
-        let mut vcpu_states = self.vcpu_states.lock().unwrap();
+        let vcpu_states = self.vcpu_states.lock().unwrap();
         let present_vcpus = Self::active_vcpus(&vcpu_states);
 
         // Mark vCPUs for removal, actual removal happens on ejection
         for cpu_id in desired_vcpus..present_vcpus {
             vcpu_states[usize::try_from(cpu_id).unwrap()]
                 .hotplug_state
-                .removing = true;
+                .removing
+                .store(true, Ordering::Release);
             vcpu_states[usize::try_from(cpu_id).unwrap()]
                 .pending_removal
-                .store(true, Ordering::SeqCst);
+                .store(true, Ordering::Release);
         }
     }
 
@@ -3263,10 +3262,10 @@ impl BusDevice for AcpiCpuHotplugController {
                     if state.active() {
                         data[0] |= 1 << Self::CPU_ENABLE_FLAG;
                     }
-                    if state.hotplug_state.inserting {
+                    if state.hotplug_state.inserting.load(Ordering::Acquire) {
                         data[0] |= 1 << Self::CPU_INSERTING_FLAG;
                     }
-                    if state.hotplug_state.removing {
+                    if state.hotplug_state.removing.load(Ordering::Acquire) {
                         data[0] |= 1 << Self::CPU_REMOVING_FLAG;
                     }
                 } else {
@@ -3294,15 +3293,18 @@ impl BusDevice for AcpiCpuHotplugController {
                     let state = &mut vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
                     // The ACPI code writes back a 1 to acknowledge the insertion
                     if (data[0] & (1 << Self::CPU_INSERTING_FLAG) == 1 << Self::CPU_INSERTING_FLAG)
-                        && state.hotplug_state.inserting
+                        && state.hotplug_state.inserting.load(Ordering::Acquire)
                     {
-                        state.hotplug_state.inserting = false;
+                        state
+                            .hotplug_state
+                            .inserting
+                            .store(false, Ordering::Release);
                     }
                     // Ditto for removal
                     if (data[0] & (1 << Self::CPU_REMOVING_FLAG) == 1 << Self::CPU_REMOVING_FLAG)
-                        && state.hotplug_state.removing
+                        && state.hotplug_state.removing.load(Ordering::Acquire)
                     {
-                        state.hotplug_state.removing = false;
+                        state.hotplug_state.removing.store(false, Ordering::Release);
                     }
                     // Trigger removal of vCPU:
                     if data[0] & (1 << Self::CPU_EJECT_FLAG) == 1 << Self::CPU_EJECT_FLAG

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -16,9 +16,10 @@ use std::collections::BTreeMap;
 use std::io::Write;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use std::mem::size_of;
+use std::ops::Deref;
 use std::os::unix::thread::JoinHandleExt;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::sync::{Arc, Barrier, Mutex};
+use std::sync::{Arc, Barrier, Mutex, RwLock};
 use std::{cmp, io, result, thread};
 
 use acpi_tables::sdt::Sdt;
@@ -720,7 +721,7 @@ pub struct CpuManager {
     #[cfg(feature = "guest_debug")]
     vm_debug_evt: EventFd,
     // Shared with AcpiCpuHotplugController
-    vcpu_states: Arc<Mutex<Box<[VcpuState]>>>,
+    vcpu_states: Arc<Box<[RwLock<VcpuState>]>>,
     vcpus: Vec<Arc<Mutex<Vcpu>>>,
     seccomp_action: SeccompAction,
     vm_ops: Arc<dyn VmOps>,
@@ -899,8 +900,8 @@ impl CpuManager {
 
         let max_vcpus = usize::try_from(config.max_vcpus).unwrap();
         let mut vcpu_states = Vec::with_capacity(max_vcpus);
-        vcpu_states.resize_with(max_vcpus, VcpuState::default);
-        let vcpu_states = Arc::new(Mutex::new(vcpu_states.into_boxed_slice()));
+        vcpu_states.resize_with(max_vcpus, || RwLock::new(VcpuState::default()));
+        let vcpu_states = Arc::new(vcpu_states.into_boxed_slice());
         let hypervisor_type = hypervisor.hypervisor_type();
         #[cfg(target_arch = "x86_64")]
         let cpu_vendor = hypervisor.get_cpu_vendor();
@@ -1185,9 +1186,8 @@ impl CpuManager {
         let vcpus_pause_signalled = self.vcpus_pause_signalled.clone();
         let vcpus_kick_signalled = self.vcpus_kick_signalled.clone();
 
-        let mut vcpu_states = self.vcpu_states.lock().unwrap();
         let vcpu_id_usize = usize::try_from(vcpu_id).unwrap();
-        let vcpu_state = &mut vcpu_states[vcpu_id_usize];
+        let mut vcpu_state = self.vcpu_states[vcpu_id_usize].write().unwrap();
         let vcpu_kill = vcpu_state.kill.clone();
         let vcpu_run_interrupted = vcpu_state.vcpu_run_interrupted.clone();
         let panic_vcpu_run_interrupted = vcpu_run_interrupted.clone();
@@ -1525,23 +1525,22 @@ impl CpuManager {
     }
 
     fn mark_vcpus_for_removal(&mut self, desired_vcpus: u32) {
-        let vcpu_states = self.vcpu_states.lock().unwrap();
-        let present_vcpus = Self::active_vcpus(&vcpu_states);
+        let present_vcpus = Self::active_vcpus(self.vcpu_states.iter().map(|x| x.read().unwrap()));
 
         // Mark vCPUs for removal, actual removal happens on ejection
         for cpu_id in desired_vcpus..present_vcpus {
-            vcpu_states[usize::try_from(cpu_id).unwrap()]
+            let vcpu_id = usize::try_from(cpu_id).unwrap();
+            let vcpu_state = self.vcpu_states[vcpu_id].read().unwrap();
+            vcpu_state
                 .hotplug_state
                 .removing
                 .store(true, Ordering::Release);
-            vcpu_states[usize::try_from(cpu_id).unwrap()]
-                .pending_removal
-                .store(true, Ordering::Release);
+            vcpu_state.pending_removal.store(true, Ordering::Release);
         }
     }
 
     pub fn check_pending_removed_vcpu(&mut self) -> bool {
-        for state in self.vcpu_states.lock().unwrap().iter() {
+        for state in self.vcpu_states.iter().map(|state| state.read().unwrap()) {
             if state.active() && state.pending_removal.load(Ordering::SeqCst) {
                 return true;
             }
@@ -1631,15 +1630,17 @@ impl CpuManager {
     /// Calls [`VcpuState::signal_thread`] and
     /// [`VcpuState::wait_until_signal_acknowledged`] for each vCPU.
     fn signal_vcpus(&mut self) -> Result<()> {
-        // Holding the lock for the whole operation is correct:
-        let vcpu_states = self.vcpu_states.lock().unwrap();
-
         // Splitting this into two loops reduced the time to pause many vCPUs
         // massively. Example: 254 vCPUs. >254ms -> ~4ms.
-        for state in vcpu_states.iter() {
+        for state in self.vcpu_states.iter().map(|state| state.read().unwrap()) {
             state.signal_thread();
         }
-        for state in vcpu_states.iter() {
+
+        // Potential for deadlock: a vCPU thread may perform on the
+        // AcpiCpuHotplugController, which needs writable access to the
+        // vCPU state. We therefore need to not hold the lock here while we
+        // wait but grab it for every check (TODO next commit).
+        for state in self.vcpu_states.iter().map(|state| state.read().unwrap()) {
             state.wait_until_signal_acknowledged()?;
         }
 
@@ -1654,18 +1655,19 @@ impl CpuManager {
         self.vcpus_pause_signalled.store(false, Ordering::SeqCst);
 
         // Unpark all the VCPU threads.
-        for state in self.vcpu_states.lock().unwrap().iter() {
+        for state in self.vcpu_states.iter().map(|state| state.read().unwrap()) {
             state.unpark_thread();
         }
 
         self.signal_vcpus()?;
 
-        let mut vcpu_states = self.vcpu_states.lock().unwrap();
         // Wait for all the threads to finish. This removes the state from the vector.
-        for state in vcpu_states.iter_mut() {
+        for mut state in self.vcpu_states.iter().map(|state| state.write().unwrap()) {
             state.join_thread()?;
         }
-        *vcpu_states = Box::new([]);
+
+        // Clear any stale data. Will be initialized on the next VM boot.
+        self.vcpu_states = Arc::new(Box::new([]));
 
         Ok(())
     }
@@ -1698,15 +1700,17 @@ impl CpuManager {
 
     /// Locks the vCPU states and calls [`Self::active_vcpus`].
     fn present_vcpus(&self) -> u32 {
-        let lock = self.vcpu_states.lock().unwrap();
-        Self::active_vcpus(&lock)
+        let iter = self.vcpu_states.iter().map(|state| state.read().unwrap());
+        Self::active_vcpus(iter)
     }
 
     /// Counts the number of active vCPUs (running vCPU threads).
-    fn active_vcpus(vcpu_states: &[VcpuState]) -> u32 {
-        vcpu_states
-            .iter()
-            .fold(0, |acc, state| acc + state.active() as u32)
+    fn active_vcpus<I, T>(vcpu_states: I) -> u32
+    where
+        I: Iterator<Item = T>,
+        T: Deref<Target = VcpuState>,
+    {
+        vcpu_states.fold(0, |acc, state| acc + state.active() as u32)
     }
 
     #[cfg(target_arch = "aarch64")]
@@ -2664,7 +2668,7 @@ impl Pausable for CpuManager {
 
         // The vCPU thread will change its paused state before parking, wait here for each
         // activated vCPU change their state to ensure they have parked.
-        for state in self.vcpu_states.lock().unwrap().iter() {
+        for state in self.vcpu_states.iter().map(|state| state.read().unwrap()) {
             if state.active() {
                 // wait for vCPU to update state
                 while !state.paused.load(Ordering::SeqCst) {
@@ -2682,18 +2686,16 @@ impl Pausable for CpuManager {
         // their run vCPU loop.
         self.vcpus_pause_signalled.store(false, Ordering::SeqCst);
 
-        let vcpu_states = self.vcpu_states.lock().unwrap();
-
         // Unpark all the vCPU threads.
         // Step 1/2: signal each thread
         {
-            for state in vcpu_states.iter() {
+            for state in self.vcpu_states.iter().map(|state| state.read().unwrap()) {
                 state.unpark_thread();
             }
         }
         // Step 2/2: wait for state ACK
         {
-            for state in vcpu_states.iter() {
+            for state in self.vcpu_states.iter().map(|state| state.read().unwrap()) {
                 // wait for vCPU to update state
                 while state.paused.load(Ordering::SeqCst) {
                     // To avoid a priority inversion with the vCPU thread
@@ -3202,7 +3204,7 @@ pub struct AcpiCpuHotplugController {
     /// The currently selected CPU by the guest.
     selected_cpu: u32,
     /// Shared vCPU state with [`CpuManager`].
-    vcpu_states: Arc<Mutex<Box<[VcpuState]>>>,
+    vcpu_states: Arc<Box<[RwLock<VcpuState>]>>,
     /// Maximum number of vCPUS of the VM.
     max_vcpus: u32,
 }
@@ -3248,7 +3250,6 @@ impl BusDevice for AcpiCpuHotplugController {
     fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         // The Linux kernel, quite reasonably, doesn't zero the memory it gives us.
         data.fill(0);
-        let vcpu_states = self.vcpu_states.lock().unwrap();
 
         match offset {
             Self::CPU_SELECTION_OFFSET => {
@@ -3258,7 +3259,8 @@ impl BusDevice for AcpiCpuHotplugController {
             }
             Self::CPU_STATUS_OFFSET => {
                 if self.selected_cpu < self.max_vcpus {
-                    let state = &vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
+                    let vcpu_id = usize::try_from(self.selected_cpu).unwrap();
+                    let state = self.vcpu_states[vcpu_id].read().unwrap();
                     if state.active() {
                         data[0] |= 1 << Self::CPU_ENABLE_FLAG;
                     }
@@ -3287,10 +3289,8 @@ impl BusDevice for AcpiCpuHotplugController {
             }
             Self::CPU_STATUS_OFFSET => {
                 if self.selected_cpu < self.max_vcpus {
-                    // This structure is not shared with the vCPU thread, therefore, holding the
-                    // lock for the entire function doesn't cause any deadlock.
-                    let mut vcpu_states = self.vcpu_states.lock().unwrap();
-                    let state = &mut vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
+                    let vcpu_id = usize::try_from(self.selected_cpu).unwrap();
+                    let mut state = self.vcpu_states[vcpu_id].write().unwrap();
                     // The ACPI code writes back a 1 to acknowledge the insertion
                     if (data[0] & (1 << Self::CPU_INSERTING_FLAG) == 1 << Self::CPU_INSERTING_FLAG)
                         && state.hotplug_state.inserting.load(Ordering::Acquire)
@@ -3308,7 +3308,7 @@ impl BusDevice for AcpiCpuHotplugController {
                     }
                     // Trigger removal of vCPU:
                     if data[0] & (1 << Self::CPU_EJECT_FLAG) == 1 << Self::CPU_EJECT_FLAG
-                        && let Err(e) = Self::remove_vcpu(self.selected_cpu, state)
+                        && let Err(e) = Self::remove_vcpu(self.selected_cpu, &mut state)
                     {
                         error!("Error removing vCPU: {e:?}");
                     }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -59,12 +59,7 @@ use hypervisor::{CpuState, HypervisorCpuError, VmExit, VmOps};
 use libc::{c_void, siginfo_t};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use linux_loader::elf::Elf64_Nhdr;
-#[cfg(any(
-    target_arch = "aarch64",
-    all(target_arch = "x86_64", feature = "guest_debug")
-))]
-use log::debug;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use seccompiler::{SeccompAction, apply_filter};
 use thiserror::Error;
 use tracer::trace_scoped;
@@ -837,26 +832,51 @@ impl VcpuState {
     /// the signal every 10ms. Times out after 1000ms.
     ///
     /// This is the counterpart of [`Self::signal_thread`].
-    fn wait_until_signal_acknowledged(&self) -> Result<()> {
-        if let Some(_handle) = self.handle.as_ref() {
-            let mut count = 0;
-            loop {
-                if self.vcpu_run_interrupted.load(Ordering::SeqCst) {
+    ///
+    /// This code may race with [`AcpiCpuHotplugController::remove_vcpu`] when
+    /// a vCPU thread is doing MMIO and needs mutable access to the vCPU state.
+    /// The careful locking architecture makes sure that these situations are
+    /// handled gracefully.
+    ///
+    /// # Arguments
+    ///
+    /// - `get_vcpu_state`: Function that returns the vCPU state. This may be
+    ///   a freshly locked accessory or a direct reference.
+    fn wait_until_signal_acknowledged<F, T>(get_vcpu_state: F) -> Result<()>
+    where
+        F: Fn() -> T,
+        T: Deref<Target = VcpuState>,
+    {
+        let mut count = 0;
+        loop {
+            // `get_vcpu_state()` may acquire a lock, depending on the caller.
+            // Scope the lock to this block so it is dropped before this loop
+            // sleeps. Otherwise, AcpiCpuHotplugController::remove_vcpu() could
+            // be blocked from taking the vCPU write lock if the vCPU performs
+            // MMIO before acknowledging the signal.
+            {
+                let vcpu_state = get_vcpu_state();
+                if vcpu_state.vcpu_run_interrupted.load(Ordering::SeqCst) {
                     return Ok(());
                 }
-                // This is more effective than thread::yield_now() at
-                // avoiding a priority inversion with the vCPU thread
-                thread::sleep(std::time::Duration::from_millis(1));
-                count += 1;
-                if count >= 1000 {
-                    return Err(Error::SignalAcknowledgeTimeout);
-                } else if count % 10 == 0 {
-                    warn!("vCPU thread did not respond in {count}ms to signal - retrying");
-                    self.signal_thread();
+                if !vcpu_state.active() {
+                    debug!("vCPU was removed while we waited for it to acknowledge its signal");
+                    return Ok(());
                 }
             }
+
+            // This is more effective than thread::yield_now() at
+            // avoiding a priority inversion with the vCPU thread
+            thread::sleep(std::time::Duration::from_millis(1));
+            count += 1;
+            if count >= 1000 {
+                return Err(Error::SignalAcknowledgeTimeout);
+            } else if count % 10 == 0 {
+                warn!("vCPU thread did not respond in {count}ms to signal - retrying");
+                let lock = get_vcpu_state();
+                lock.signal_thread();
+            }
         }
-        Ok(())
     }
 
     fn join_thread(&mut self) -> Result<()> {
@@ -1640,8 +1660,8 @@ impl CpuManager {
         // AcpiCpuHotplugController, which needs writable access to the
         // vCPU state. We therefore need to not hold the lock here while we
         // wait but grab it for every check (TODO next commit).
-        for state in self.vcpu_states.iter().map(|state| state.read().unwrap()) {
-            state.wait_until_signal_acknowledged()?;
+        for state in self.vcpu_states.iter() {
+            VcpuState::wait_until_signal_acknowledged(|| state.read().unwrap())?;
         }
 
         Ok(())
@@ -3235,7 +3255,7 @@ impl AcpiCpuHotplugController {
         info!("Removing vCPU: cpu_id = {cpu_id}");
         state.kill.store(true, Ordering::SeqCst);
         state.signal_thread();
-        state.wait_until_signal_acknowledged()?;
+        VcpuState::wait_until_signal_acknowledged(|| &*state)?;
         state.join_thread()?;
         state.handle = None;
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -19,7 +19,7 @@ use std::mem::size_of;
 use std::ops::Deref;
 use std::os::unix::thread::JoinHandleExt;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::sync::{Arc, Barrier, Mutex, RwLock, Weak};
+use std::sync::{Arc, Barrier, Mutex, RwLock, RwLockWriteGuard, Weak};
 use std::{cmp, io, result, thread};
 
 use acpi_tables::sdt::Sdt;
@@ -3256,19 +3256,50 @@ impl AcpiCpuHotplugController {
     /// Removes a vCPU from the guest.
     ///
     /// The corresponding vCPU thread will be gracefully stopped and joined.
-    fn remove_vcpu(cpu_id: u32, state: &mut VcpuState) -> Result<()> {
+    fn remove_vcpu(
+        vcpu_states: &[RwLock<VcpuState>],
+        cpu_id: u32,
+        state: RwLockWriteGuard<VcpuState>,
+    ) -> Result<()> {
         info!("Removing vCPU: cpu_id = {cpu_id}");
-        state.kill.store(true, Ordering::SeqCst);
-        state.signal_thread();
-        VcpuState::wait_until_signal_acknowledged(|| &*state)?;
-        state.join_thread()?;
-        state.handle = None;
+        let cpu_id_usize = usize::try_from(cpu_id).unwrap();
 
-        // Once the thread has exited, clear the "kill" so that it can reused
-        state.kill.store(false, Ordering::SeqCst);
+        // Lock phase 1/3: Signal thread
+        {
+            state.kill.store(true, Ordering::SeqCst);
+            state.signal_thread();
+            drop(state);
+        }
+        // Lock phase 2/3: Wait for signal to acknowledge
+        //
+        // An unusual behaving guest could perform MMIO to the
+        // AcpiCpuHotplugController. A normal guest would never do this on a
+        // vCPU that is about to be removed, but we need to protect the VMM
+        // from deadlocks caused by malicious or weird performing guests.
+        let wait_signal_ack_res = {
+            VcpuState::wait_until_signal_acknowledged(|| {
+                vcpu_states[cpu_id_usize].write().unwrap()
+            })
+                .inspect_err(|e| {
+                    warn!("vCPU {cpu_id_usize} did not acknowledge its signal - the vCPU thread may remain in dangling state: {e}");
+                })
+        };
+        // Lock phase 3/3: Gracefully kill the vCPU thread
+        {
+            let mut state = vcpu_states[cpu_id_usize].write().unwrap();
+            let join_res = wait_signal_ack_res.and_then(|()| state.join_thread());
+            if join_res.is_err() {
+                error!("vCPU {cpu_id_usize} thread already joined");
+            }
 
-        // Important that this happens last: CpuManager uses this as synchronization point
-        state.pending_removal.store(false, Ordering::SeqCst);
+            state.handle = None;
+
+            // Once the thread has exited, clear the "kill" so that it can reused
+            state.kill.store(false, Ordering::SeqCst);
+
+            // Important that this happens last: CpuManager uses this as synchronization point
+            state.pending_removal.store(false, Ordering::SeqCst);
+        }
 
         Ok(())
     }
@@ -3328,7 +3359,7 @@ impl BusDevice for AcpiCpuHotplugController {
             Self::CPU_STATUS_OFFSET => {
                 if self.selected_cpu < self.max_vcpus {
                     let vcpu_id = usize::try_from(self.selected_cpu).unwrap();
-                    let mut state = vcpu_states[vcpu_id].write().unwrap();
+                    let state = vcpu_states[vcpu_id].write().unwrap();
                     // The ACPI code writes back a 1 to acknowledge the insertion
                     if (data[0] & (1 << Self::CPU_INSERTING_FLAG) == 1 << Self::CPU_INSERTING_FLAG)
                         && state.hotplug_state.inserting.load(Ordering::Acquire)
@@ -3346,7 +3377,7 @@ impl BusDevice for AcpiCpuHotplugController {
                     }
                     // Trigger removal of vCPU:
                     if data[0] & (1 << Self::CPU_EJECT_FLAG) == 1 << Self::CPU_EJECT_FLAG
-                        && let Err(e) = Self::remove_vcpu(self.selected_cpu, &mut state)
+                        && let Err(e) = Self::remove_vcpu(&vcpu_states, self.selected_cpu, state)
                     {
                         error!("Error removing vCPU: {e:?}");
                     }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -768,13 +768,34 @@ impl TryFrom<i32> for CoreSchedulingLeader {
     }
 }
 
+/// Hotplug-related state of a [`Vcpu`] and companion of [`VcpuState`].
+#[derive(Default)]
+struct VcpuHotplugState {
+    /// Guest-visible ACPI status that is true until the guest acknowledged the
+    /// hotplugging of a vCPU.
+    inserting: bool,
+    /// Guest-visible ACPI status that is true until the guest acknowledged the
+    /// removal of a vCPU.
+    removing: bool,
+}
+
 /// Management structure for a vCPU (thread).
 #[derive(Default)]
 struct VcpuState {
-    inserting: bool,
-    removing: bool,
+    /// Tracks that this active vCPU is in the host-side hot-remove flow until
+    /// ejection completes.
+    ///
+    /// Used to prevent further VM resizes until the vCPU thread has actually
+    /// been removed.
     pending_removal: Arc<AtomicBool>,
-    /// Handle to the vCPU thread.
+    /// Handle to the underlying thread.
+    ///
+    /// The underlying handle is `Some` when a vCPU is actively visible to a
+    /// guest, i.e., a vCPU thread exits. This is initially the case for all
+    /// boot vCPUs. For hotplugged vCPUs, this dynamically switches between
+    /// `Some` and `None`, including if a boot vCPU is removed:
+    /// - `None` -> `Some`: in [`CpuManager::start_vcpu`]
+    /// - `Some` -> `None`: in [`AcpiCpuHotplugController::remove_vcpu`]
     handle: Option<thread::JoinHandle<()>>,
     /// Instructs the thread to exit the run-vCPU loop.
     kill: Arc<AtomicBool>,
@@ -782,6 +803,8 @@ struct VcpuState {
     vcpu_run_interrupted: Arc<AtomicBool>,
     /// Used to ACK state changes from the run vCPU loop to the CPU Manager.
     paused: Arc<AtomicBool>,
+    /// vCPU-related state to hotplugging.
+    hotplug_state: VcpuHotplugState,
 }
 
 impl VcpuState {
@@ -1458,7 +1481,9 @@ impl CpuManager {
         // On hot plug calls into this function entry_point is None. It is for
         // those hotplug CPU additions that we need to set the inserting flag.
         vcpu_states[usize::try_from(vcpu_id).unwrap()].handle = handle;
-        vcpu_states[usize::try_from(vcpu_id).unwrap()].inserting = inserting;
+        vcpu_states[usize::try_from(vcpu_id).unwrap()]
+            .hotplug_state
+            .inserting = inserting;
 
         Ok(())
     }
@@ -1507,7 +1532,9 @@ impl CpuManager {
 
         // Mark vCPUs for removal, actual removal happens on ejection
         for cpu_id in desired_vcpus..present_vcpus {
-            vcpu_states[usize::try_from(cpu_id).unwrap()].removing = true;
+            vcpu_states[usize::try_from(cpu_id).unwrap()]
+                .hotplug_state
+                .removing = true;
             vcpu_states[usize::try_from(cpu_id).unwrap()]
                 .pending_removal
                 .store(true, Ordering::SeqCst);
@@ -3234,10 +3261,10 @@ impl BusDevice for AcpiCpuHotplugController {
                     if state.active() {
                         data[0] |= 1 << Self::CPU_ENABLE_FLAG;
                     }
-                    if state.inserting {
+                    if state.hotplug_state.inserting {
                         data[0] |= 1 << Self::CPU_INSERTING_FLAG;
                     }
-                    if state.removing {
+                    if state.hotplug_state.removing {
                         data[0] |= 1 << Self::CPU_REMOVING_FLAG;
                     }
                 } else {
@@ -3265,15 +3292,15 @@ impl BusDevice for AcpiCpuHotplugController {
                     let state = &mut vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
                     // The ACPI code writes back a 1 to acknowledge the insertion
                     if (data[0] & (1 << Self::CPU_INSERTING_FLAG) == 1 << Self::CPU_INSERTING_FLAG)
-                        && state.inserting
+                        && state.hotplug_state.inserting
                     {
-                        state.inserting = false;
+                        state.hotplug_state.inserting = false;
                     }
                     // Ditto for removal
                     if (data[0] & (1 << Self::CPU_REMOVING_FLAG) == 1 << Self::CPU_REMOVING_FLAG)
-                        && state.removing
+                        && state.hotplug_state.removing
                     {
-                        state.removing = false;
+                        state.hotplug_state.removing = false;
                     }
                     // Trigger removal of vCPU:
                     if data[0] & (1 << Self::CPU_EJECT_FLAG) == 1 << Self::CPU_EJECT_FLAG

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -720,7 +720,7 @@ pub struct CpuManager {
     #[cfg(feature = "guest_debug")]
     vm_debug_evt: EventFd,
     // Shared with AcpiCpuHotplugController
-    vcpu_states: Arc<Mutex<Vec<VcpuState>>>,
+    vcpu_states: Arc<Mutex<Box<[VcpuState]>>>,
     vcpus: Vec<Arc<Mutex<Vcpu>>>,
     seccomp_action: SeccompAction,
     vm_ops: Arc<dyn VmOps>,
@@ -900,7 +900,7 @@ impl CpuManager {
         let max_vcpus = usize::try_from(config.max_vcpus).unwrap();
         let mut vcpu_states = Vec::with_capacity(max_vcpus);
         vcpu_states.resize_with(max_vcpus, VcpuState::default);
-        let vcpu_states = Arc::new(Mutex::new(vcpu_states));
+        let vcpu_states = Arc::new(Mutex::new(vcpu_states.into_boxed_slice()));
         let hypervisor_type = hypervisor.hypervisor_type();
         #[cfg(target_arch = "x86_64")]
         let cpu_vendor = hypervisor.get_cpu_vendor();
@@ -1661,10 +1661,12 @@ impl CpuManager {
 
         self.signal_vcpus()?;
 
+        let mut vcpu_states = self.vcpu_states.lock().unwrap();
         // Wait for all the threads to finish. This removes the state from the vector.
-        for mut state in self.vcpu_states.lock().unwrap().drain(..) {
+        for state in vcpu_states.iter_mut() {
             state.join_thread()?;
         }
+        *vcpu_states = Box::new([]);
 
         Ok(())
     }
@@ -3201,7 +3203,7 @@ pub struct AcpiCpuHotplugController {
     /// The currently selected CPU by the guest.
     selected_cpu: u32,
     /// Shared vCPU state with [`CpuManager`].
-    vcpu_states: Arc<Mutex<Vec<VcpuState>>>,
+    vcpu_states: Arc<Mutex<Box<[VcpuState]>>>,
     /// Maximum number of vCPUS of the VM.
     max_vcpus: u32,
 }

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1559,6 +1559,11 @@ impl CpuManager {
         }
     }
 
+    /// Returns whether any hot-removed vCPU slot is still being torn down.
+    ///
+    /// A slot only becomes reusable once `pending_removal` is cleared again.
+    /// `active()` alone is not sufficient, as the thread handle may already be
+    /// gone before `kill` and the teardown state are fully reset
     pub fn check_pending_removed_vcpu(&mut self) -> bool {
         for state in self.vcpu_states.iter().map(|state| state.read().unwrap()) {
             if state.active() && state.pending_removal.load(Ordering::SeqCst) {
@@ -3261,6 +3266,8 @@ impl AcpiCpuHotplugController {
 
         // Once the thread has exited, clear the "kill" so that it can reused
         state.kill.store(false, Ordering::SeqCst);
+
+        // Important that this happens last: CpuManager uses this as synchronization point
         state.pending_removal.store(false, Ordering::SeqCst);
 
         Ok(())


### PR DESCRIPTION
In #7990 I layed important groundwork to fix a unlikely but still realistic deadlock that existed for many years - unfortunately I introduced a new (less likely) race condition, which still exists in v52. In #8092 I thought I fixed it but I just made the time window shorter where it can happen. **SORRY!** This time, I investigated the hell out of this and especially my colleagues @amphi and @olivereanderson were really helpful and supportive.

I think the new design cleans up many things and finally once and for all (famous last words) solves the ugly deadlock when CpuManager and a vCPU (via the AcpiCpuHotplugController) want to access the same vCPU state simultaneously.

# Deadlock Explained

- `VcpuState` is shared between `CpuManager` and `AcpiCpuHotplugController`
- `CpuManager::pause()` calls `CpuManager::signal_vcpus()` which calls `VcpuState::wait_until_signal_acknowledged()` 
- While the latter invocation, the `VcpuState` is locked and a Vcpu thread could never enter a MMIO-path into `AcpiCpuHotplugController` as it can't grab the lock 
- Simply using a `RwLock` with `.read()` on both sides is not enough, as some MMIO-calls to `AcpiCpuHotplugController` can trigger `AcpiCpuHotplugController::remove_vcpu`, which needs exclusive mutable access to the `VcpuState`
- Therefore the solution is now:
  - fine-grained lock per `VcpuState` instead of the whole range (this also models the way things are mutated actually)
  - `VcpuState::wait_until_signal_acknowledged()` regrabs the lock on each iteration and releases it before a `sleep()`

I hope this finally resolves the problem once and for all. I'm pretty confident about this design.

# Steps to Undraft
- [x] get internal feedback from my colleagues first