### PR TITLE
Stablize VFIO worker and make windows integration job non-blocking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -741,7 +741,8 @@ jobs:
       - integration-arm64
       # VFIO worker is failing #8160
       # - integration-vfio
-      - integration-windows
+      # See: #8211
+      # - integration-windows
       - integration-x86-64-mq
       - integration-x86-64-pr
       - openapi

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,6 +7,6 @@ Files: docs/*.md *.md
 Copyright: 2024
 License: CC-BY-4.0
 
-Files: scripts/* test_data/* *.toml .git* fuzz/Cargo.lock fuzz/.gitignore resources/linux-config-* vmm/src/api/openapi/cloud-hypervisor.yaml CODEOWNERS Cargo.lock
+Files: scripts/* test_data/* *.toml .git* .editorconfig fuzz/Cargo.lock fuzz/.gitignore resources/linux-config-* vmm/src/api/openapi/cloud-hypervisor.yaml CODEOWNERS Cargo.lock
 Copyright: 2024
 License: Apache-2.0

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -10758,10 +10758,9 @@ mod vfio {
             // Add RAM to the VM
             let desired_ram = 6 << 30;
             resize_command(&api_socket, None, Some(desired_ram), None, None);
-            assert!(wait_until(Duration::from_secs(5), || {
+            assert!(wait_until(Duration::from_secs(15), || {
                 guest.get_total_memory().unwrap_or_default() > 5_760_000
             }));
-            assert!(guest.get_total_memory().unwrap_or_default() > 5_760_000);
 
             // Check the VFIO device works when RAM is increased to 6GiB.
             // After guest memory hotplug, the VMM must refresh VFIO/iommufd DMA

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -20,7 +20,7 @@ CLH_ROOT_DIR=$(cd "${CLH_SCRIPTS_DIR}/.." && pwd)
 CLH_BUILD_DIR="${CLH_ROOT_DIR}/build"
 CLH_CARGO_TARGET="${CLH_BUILD_DIR}/cargo_target"
 CLH_DOCKERFILE="${CLH_SCRIPTS_DIR}/../resources/Dockerfile"
-CLH_CTR_BUILD_DIR="/tmp/cloud-hypervisor/ctr-build"
+CLH_CTR_BUILD_DIR="/tmp/cloud-hypervisor-${USER}/ctr-build"
 CLH_INTEGRATION_WORKLOADS="${HOME}/workloads"
 
 # Container paths
@@ -649,10 +649,7 @@ cmd_tests() {
 build_container() {
     ensure_build_dir
 
-    BUILD_DIR=/tmp/cloud-hypervisor/container/
-
-    mkdir -p $BUILD_DIR
-    cp "$CLH_DOCKERFILE" $BUILD_DIR
+    cp "$CLH_DOCKERFILE" "$CLH_CTR_BUILD_DIR"
 
     [ "$(uname -m)" = "aarch64" ] && TARGETARCH="arm64"
     [ "$(uname -m)" = "x86_64" ] && TARGETARCH="amd64"
@@ -660,9 +657,9 @@ build_container() {
     $DOCKER_RUNTIME build \
         --target dev \
         -t "$CTR_IMAGE" \
-        -f $BUILD_DIR/Dockerfile \
+        -f "$CLH_CTR_BUILD_DIR/Dockerfile" \
         --build-arg TARGETARCH="$TARGETARCH" \
-        $BUILD_DIR
+        "$CLH_CTR_BUILD_DIR"
 }
 
 cmd_build-container() {


### PR DESCRIPTION
- scripts: namespace dev_cli tmp dir per user and drop dead BUILD_DIR
- tests: Stabilize VFIO NVIDIA memory hotplug check 
- build: Temporarily make windows integration job non-blocking
- build: Add .editorconfig to REUSE dep5