### PR TITLE
build: add .editorconfig to REUSE check and bump year to 2026

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,6 +7,6 @@ Files: docs/*.md *.md
 Copyright: 2024
 License: CC-BY-4.0
 
-Files: scripts/* test_data/* *.toml .git* fuzz/Cargo.lock fuzz/.gitignore resources/linux-config-* vmm/src/api/openapi/cloud-hypervisor.yaml CODEOWNERS Cargo.lock
-Copyright: 2024
+Files: scripts/* test_data/* *.toml .git* fuzz/Cargo.lock fuzz/.gitignore resources/linux-config-* vmm/src/api/openapi/cloud-hypervisor.yaml CODEOWNERS Cargo.lock .editorconfig
+Copyright: 2026
 License: Apache-2.0


### PR DESCRIPTION
The REUSE check fails with the newly added .editorconfig.