### PR TITLE
vmm: emit 'vmm'/'api-ready' event when API socket is ready

### DIFF
--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -36,6 +36,7 @@ use crate::api::{
 use crate::landlock::Landlock;
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::{Error as VmmError, Result};
+use event_monitor::event;
 
 pub mod http_endpoint;
 
@@ -370,6 +371,7 @@ fn start_http_thread(
 
             std::panic::catch_unwind(AssertUnwindSafe(move || {
                 server.start_server().unwrap();
+                event!("vmm", "api-ready");
                 loop {
                     match server.requests() {
                         Ok(request_vec) => {


### PR DESCRIPTION
## Summary
- Add 'vmm'/'api-ready' event when HTTP API server is ready to accept connections
- Allows external processes to know when the API is available without polling
## Event sequence
"vmm"/"starting" -> "vmm"/"api-ready" -> (wait for API) -> "vm"/"booting" -> "vm"/"booted"
## Changes
- `vmm/src/api/http/mod.rs`: Emit event inside HTTP thread after `start_server()` is called, ensuring the server is truly ready to accept connections
## Use case
External orchestrators can monitor the event log to know exactly when the API server is ready, instead of polling with `os.Stat()` or retry loops.