### PR TITLE
misc: gitlint: allow links in Git trailers

### DIFF
--- a/scripts/gitlint/rules/BodyMaxLineLengthEx.py
+++ b/scripts/gitlint/rules/BodyMaxLineLengthEx.py
@@ -9,6 +9,7 @@ IGNORE_PREFIXES = [
     # Please sort alphabetically
     " ",
     "Acked-by: ",
+    "Closes: ",
     "Co-authored-by: ",
     "Co-developed-by: ",
     "Debugged-by: ",
@@ -18,6 +19,7 @@ IGNORE_PREFIXES = [
     "Fixes: ",
     "Helped-by: ",
     "Inspired-by: ",
+    "Link: ",
     "On-behalf-of: ",
     "Originally-by: ",
     "Reported-by: ",


### PR DESCRIPTION
The motivation for this was a kernel-style Link trailer in one of my commits, but there are a number of other commonly-used trailers that may use links, like Closes and Fixes, so I've opted to allow any trailer.  The pattern for this is broad enough to subsume the pattern for bracketed numeric prefixes previously allowed.