### PR TITLE
vmm: Disable sector 0 writes for autodetected VHD images

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -193,9 +193,7 @@ impl BlockEpollHandler {
         }
 
         if request_type == RequestType::Out && disable_sector0_writes && request.sector() == 0 {
-            warn!(
-                "Attempting to write to sector 0 on a raw disk without specifying image_type=raw"
-            );
+            warn!("Attempting to write to sector 0 on a disk without specifying image_type");
             return Err(ExecuteError::ReadOnly);
         }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2700,8 +2700,12 @@ impl DeviceManager {
                     Configuration updated to persist type across reboots and migrations."
                 );
 
-                if detected_image_type == ImageType::Raw {
-                    warn!("Autodetected raw image type. Disabling sector 0 writes.");
+                if detected_image_type == ImageType::Raw
+                    || detected_image_type == ImageType::FixedVhd
+                {
+                    warn!(
+                        "Autodetected {detected_image_type} image type. Disabling sector 0 writes."
+                    );
                     disable_sector0_writes = true;
                 } else {
                     warn!(


### PR DESCRIPTION
When no image_type is specified, sector 0 writes are disabled as a safety measure for autodetected raw images. Extend this protection to autodetected fixed VHD images, which carry metadata in the last sector and are equally susceptible to accidental overwrites of the first sector when the format is not explicitly acknowledged.

Update the corresponding warning in the virtio block worker to be format agnostic.