### PR TITLE
Ensure that the kernel cannot use freed iovecs

### DIFF
--- a/block/src/destructor_clear.rs
+++ b/block/src/destructor_clear.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 Demi Marie Obenour <demiobenour@gmail.com>
+
+use super::{IoUring, SubmissionQueue, Submitter};
+pub(super) struct DestructorClear<'a>(&'a mut Option<IoUring>);
+/// A struct that drops the contained [`IoUring`] instance
+/// on [`Drop`].  It crashes the program if the destructor
+/// for the [`IoUring`] panics.  It can be disarmed by
+/// setting the contained `&mut Option<IoUring>` to a
+/// reference to a `None`.
+impl<'a> Drop for DestructorClear<'a> {
+    fn drop(&mut self) {
+        struct ConvertPanicToAbort;
+        impl Drop for ConvertPanicToAbort {
+            fn drop(&mut self) {
+                if std::thread::panicking() {
+                    // double panic always aborts
+                    panic!("Cannot handle panic while closing io_uring instance")
+                }
+            }
+        }
+        if self.0.is_some() {
+            // Ensure that any panic in this destructor becomes a double panic.
+            let _convert_panic_into_abort = ConvertPanicToAbort;
+            // Cancel all outstanding requests to prevent
+            // use-after-scope of iovecs.
+            // TODO: this isn't safe in the presence
+            // of concurrent forks, but Cloud Hypervisor doesn't fork
+            // while this code is running.
+            *self.0 = None;
+        }
+    }
+}
+
+impl<'a> DestructorClear<'a> {
+    pub(super) fn new(io_uring: &'a mut Option<IoUring>) -> Self {
+        Self(io_uring)
+    }
+
+    pub(super) fn split_ring(&mut self) -> std::io::Result<(Submitter<'_>, SubmissionQueue<'_>)> {
+        let Some(io_uring) = self.0.as_mut() else {
+            return Err(std::io::Error::other("io_uring instance already deleted"));
+        };
+        let (submitter, sq, _) = io_uring.split();
+        Ok((submitter, sq))
+    }
+
+    pub(super) fn disarm(&mut self) {
+        *self.0 = None;
+    }
+}

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -226,6 +226,30 @@ pub fn request_type<B: Bitmap + 'static>(
     }
 }
 
+#[cfg(feature = "io_uring")]
+fn submit_all(submitter: &Submitter<'_>, sq: &mut SubmissionQueue<'_>) -> std::io::Result<()> {
+    const MAX_ZERO_SUBMITS: u32 = 100;
+    let mut len = sq.len();
+    while len > 0 {
+        sq.sync();
+        let mut submissions_that_submitted_no_sqes = 0u32;
+        loop {
+            let submitted = submitter.submit()?;
+            if submitted != 0 {
+                len = len.saturating_sub(submitted);
+                break;
+            }
+            submissions_that_submitted_no_sqes += 1;
+            if submissions_that_submitted_no_sqes >= MAX_ZERO_SUBMITS {
+                return Err(std::io::Error::other(
+                    "100 consecutive calls to io_uring_enter didn't submit any SQEs",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn sector<B: Bitmap + 'static>(
     mem: &vm_memory::GuestMemoryMmap<B>,
     desc_addr: GuestAddress,

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -10,6 +10,8 @@
 
 mod aligned_operation;
 pub mod async_io;
+#[cfg(feature = "io_uring")]
+mod destructor_clear;
 pub mod disk_file;
 pub mod error;
 pub mod factory;
@@ -54,7 +56,9 @@ use std::{cmp, mem, result};
 
 pub use aligned_operation::AlignedOperation;
 #[cfg(feature = "io_uring")]
-use io_uring::{IoUring, Probe, opcode};
+use destructor_clear::DestructorClear;
+#[cfg(feature = "io_uring")]
+use io_uring::{IoUring, Probe, SubmissionQueue, Submitter, opcode};
 use libc::{
     FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE, FALLOC_FL_ZERO_RANGE, S_IFBLK, S_IFMT, ioctl,
 };

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -8,7 +8,7 @@
 
 use std::cmp::{max, min};
 use std::collections::VecDeque;
-use std::io;
+use std::io::{self, Error, ErrorKind};
 use std::os::unix::io::AsRawFd;
 use std::sync::Arc;
 
@@ -64,6 +64,12 @@ impl QcowAsync {
         let alignment = data_file.file().alignment();
         let io_alignment = max(alignment as u64, SECTOR_SIZE);
         let io_uring = IoUring::new(ring_depth)?;
+        if !io_uring.params().is_feature_submit_stable() {
+            return Err(Error::new(
+                ErrorKind::Unsupported,
+                "io_uring requires IORING_FEAT_SUBMIT_STABLE",
+            ));
+        }
         let eventfd = EventFd::new(libc::EFD_NONBLOCK)?;
         io_uring.submitter().register_eventfd(eventfd.as_raw_fd())?;
 

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -26,7 +26,7 @@ use crate::qcow_common::{
     AlignedBuf, aligned_pread, aligned_pwrite, decompress_cluster, gather_from_iovecs_into,
     pread_alloc, pread_exact, pwrite_all, scatter_to_iovecs, zero_fill_iovecs,
 };
-use crate::{BatchRequest, RequestType, SECTOR_SIZE};
+use crate::{BatchRequest, DestructorClear, RequestType, SECTOR_SIZE};
 
 /// Per queue QCOW2 I/O worker using io_uring.
 ///
@@ -48,7 +48,7 @@ pub struct QcowAsync {
     io_alignment: u64,
     cluster_size: u64,
     decoder: Arc<dyn Decoder>,
-    io_uring: IoUring,
+    io_uring: Option<IoUring>,
     eventfd: EventFd,
     completion_list: VecDeque<(u64, i32)>,
 }
@@ -82,7 +82,7 @@ impl QcowAsync {
             sparse,
             alignment,
             io_alignment,
-            io_uring,
+            io_uring: Some(io_uring),
             eventfd,
             completion_list: VecDeque::new(),
         })
@@ -121,6 +121,10 @@ impl AsyncIo for QcowAsync {
         user_data: u64,
     ) -> AsyncIoResult<()> {
         let total_len: usize = iovecs.iter().map(|v| v.iov_len).sum();
+        let mut destructor_clear = DestructorClear::new(&mut self.io_uring);
+        let (submitter, mut sq) = destructor_clear
+            .split_ring()
+            .map_err(AsyncIoError::ReadVectored)?;
 
         if let Some(host_offset) = Self::resolve_read(
             &self.metadata,
@@ -133,16 +137,17 @@ impl AsyncIo for QcowAsync {
             self.cluster_size,
             &*self.decoder,
         )? {
-            let fd = self.data_file.as_raw_fd();
-            let (submitter, mut sq, _) = self.io_uring.split();
-
             // SAFETY: fd is valid and iovecs point to valid guest memory.
             unsafe {
                 sq.push(
-                    &opcode::Readv::new(types::Fd(fd), iovecs.as_ptr(), iovecs.len() as u32)
-                        .offset(host_offset)
-                        .build()
-                        .user_data(user_data),
+                    &opcode::Readv::new(
+                        types::Fd(self.data_file.as_raw_fd()),
+                        iovecs.as_ptr(),
+                        iovecs.len() as u32,
+                    )
+                    .offset(host_offset)
+                    .build()
+                    .user_data(user_data),
                 )
                 .map_err(|_| {
                     AsyncIoError::ReadVectored(io::Error::other("Submission queue is full"))
@@ -156,6 +161,8 @@ impl AsyncIo for QcowAsync {
                 .push_back((user_data, total_len as i32));
             self.eventfd.write(1).unwrap();
         }
+        drop(sq);
+        destructor_clear.disarm();
         Ok(())
     }
 
@@ -199,6 +206,7 @@ impl AsyncIo for QcowAsync {
     fn next_completed_request(&mut self) -> Option<(u64, i32)> {
         // Drain io_uring completions first, then synthetic ones.
         self.io_uring
+            .as_mut()?
             .completion()
             .next()
             .map(|entry| (entry.user_data(), entry.result()))
@@ -282,7 +290,11 @@ impl AsyncIo for QcowAsync {
     }
 
     fn submit_batch_requests(&mut self, batch_request: &[BatchRequest]) -> AsyncIoResult<()> {
-        let (submitter, mut sq, _) = self.io_uring.split();
+        let mut destructor_clear = DestructorClear::new(&mut self.io_uring);
+        let (submitter, mut sq) = destructor_clear
+            .split_ring()
+            .map_err(AsyncIoError::SubmitBatchRequests)?;
+
         let mut needs_submit = false;
         let mut sync_completions: Vec<(u64, i32)> = Vec::new();
 
@@ -351,6 +363,8 @@ impl AsyncIo for QcowAsync {
                 .submit()
                 .map_err(AsyncIoError::SubmitBatchRequests)?;
         }
+        drop(sq);
+        destructor_clear.disarm();
 
         if !sync_completions.is_empty() {
             for c in sync_completions {

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -26,7 +26,7 @@ use crate::qcow_common::{
     AlignedBuf, aligned_pread, aligned_pwrite, decompress_cluster, gather_from_iovecs_into,
     pread_alloc, pread_exact, pwrite_all, scatter_to_iovecs, zero_fill_iovecs,
 };
-use crate::{BatchRequest, DestructorClear, RequestType, SECTOR_SIZE};
+use crate::{BatchRequest, DestructorClear, RequestType, SECTOR_SIZE, submit_all};
 
 /// Per queue QCOW2 I/O worker using io_uring.
 ///
@@ -153,9 +153,7 @@ impl AsyncIo for QcowAsync {
                     AsyncIoError::ReadVectored(io::Error::other("Submission queue is full"))
                 })?;
             };
-
-            sq.sync();
-            submitter.submit().map_err(AsyncIoError::ReadVectored)?;
+            submit_all(&submitter, &mut sq).map_err(AsyncIoError::ReadVectored)?;
         } else {
             self.completion_list
                 .push_back((user_data, total_len as i32));
@@ -358,10 +356,7 @@ impl AsyncIo for QcowAsync {
         }
 
         if needs_submit {
-            sq.sync();
-            submitter
-                .submit()
-                .map_err(AsyncIoError::SubmitBatchRequests)?;
+            submit_all(&submitter, &mut sq).map_err(AsyncIoError::SubmitBatchRequests)?;
         }
         drop(sq);
         destructor_clear.disarm();

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
-use std::io::Error;
+use std::io::{Error, ErrorKind};
 use std::os::unix::io::{AsRawFd, RawFd};
 
 use io_uring::{IoUring, opcode, types};
@@ -26,6 +26,15 @@ impl RawFileAsync {
     pub fn new(fd: RawFd, ring_depth: u32) -> BlockResult<Self> {
         let io_uring =
             IoUring::new(ring_depth).map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
+        if !io_uring.params().is_feature_submit_stable() {
+            return Err(BlockError::new(
+                BlockErrorKind::UnsupportedFeature,
+                Error::new(
+                    ErrorKind::Unsupported,
+                    "io_uring requires IORING_FEAT_SUBMIT_STABLE",
+                ),
+            ));
+        }
         let eventfd =
             EventFd::new(libc::EFD_NONBLOCK).map_err(|e| BlockError::new(BlockErrorKind::Io, e))?;
 

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -5,18 +5,18 @@
 use std::io::{Error, ErrorKind};
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use io_uring::{IoUring, opcode, types};
+use io_uring::{IoUring, SubmissionQueue, Submitter, opcode, types};
 use libc::{FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE, FALLOC_FL_ZERO_RANGE};
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
 use crate::sparse::{blkdiscard, blkzeroout};
-use crate::{BatchRequest, RequestType, SECTOR_SIZE, is_block_device};
+use crate::{BatchRequest, DestructorClear, RequestType, SECTOR_SIZE, is_block_device};
 
 pub struct RawFileAsync {
     fd: RawFd,
-    io_uring: IoUring,
+    io_uring: Option<IoUring>,
     eventfd: EventFd,
     alignment: u64,
     is_block_device: bool,
@@ -49,7 +49,7 @@ impl RawFileAsync {
 
         Ok(RawFileAsync {
             fd,
-            io_uring,
+            io_uring: Some(io_uring),
             eventfd,
             alignment: SECTOR_SIZE,
             is_block_device,
@@ -60,7 +60,7 @@ impl RawFileAsync {
     /// completed operation (e.g. a BLK* ioctl) is reaped through the normal
     /// io_uring completion path.
     fn submit_nop(&mut self, user_data: u64) -> Result<(), Error> {
-        let (submitter, mut sq, _) = self.io_uring.split();
+        let (submitter, mut sq, _) = self.split_ring()?;
         // SAFETY: Nop carries no buffer; only `user_data` is consumed by the
         // kernel.
         unsafe {
@@ -70,6 +70,14 @@ impl RawFileAsync {
         sq.sync();
         submitter.submit()?;
         Ok(())
+    }
+
+    fn split_ring(&mut self) -> std::io::Result<(Submitter<'_>, SubmissionQueue<'_>, i32)> {
+        let Some(ref mut io_uring) = self.io_uring else {
+            return Err(Error::other("io_uring instance already deleted"));
+        };
+        let (submitter, sq, _) = io_uring.split();
+        Ok((submitter, sq, self.fd))
     }
 }
 
@@ -88,13 +96,17 @@ impl AsyncIo for RawFileAsync {
         iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
-        let (submitter, mut sq, _) = self.io_uring.split();
+        let fd = self.fd;
+        let mut destructor_clear = DestructorClear::new(&mut self.io_uring);
+        let (submitter, mut sq) = destructor_clear
+            .split_ring()
+            .map_err(AsyncIoError::ReadVectored)?;
 
         // SAFETY: we know the file descriptor is valid and we
         // relied on vm-memory to provide the buffer address.
         unsafe {
             sq.push(
-                &opcode::Readv::new(types::Fd(self.fd), iovecs.as_ptr(), iovecs.len() as u32)
+                &opcode::Readv::new(types::Fd(fd), iovecs.as_ptr(), iovecs.len() as u32)
                     .offset(offset.try_into().unwrap())
                     .build()
                     .user_data(user_data),
@@ -107,8 +119,9 @@ impl AsyncIo for RawFileAsync {
         // Update the submission queue and submit new operations to the
         // io_uring instance.
         sq.sync();
+        drop(sq);
         submitter.submit().map_err(AsyncIoError::ReadVectored)?;
-
+        destructor_clear.disarm();
         Ok(())
     }
 
@@ -118,13 +131,17 @@ impl AsyncIo for RawFileAsync {
         iovecs: &[libc::iovec],
         user_data: u64,
     ) -> AsyncIoResult<()> {
-        let (submitter, mut sq, _) = self.io_uring.split();
+        let fd = self.fd;
+        let mut destructor_clear = DestructorClear::new(&mut self.io_uring);
+        let (submitter, mut sq) = destructor_clear
+            .split_ring()
+            .map_err(AsyncIoError::WriteVectored)?;
 
         // SAFETY: we know the file descriptor is valid and we
         // relied on vm-memory to provide the buffer address.
         unsafe {
             sq.push(
-                &opcode::Writev::new(types::Fd(self.fd), iovecs.as_ptr(), iovecs.len() as u32)
+                &opcode::Writev::new(types::Fd(fd), iovecs.as_ptr(), iovecs.len() as u32)
                     .offset(offset.try_into().unwrap())
                     .build()
                     .user_data(user_data),
@@ -139,19 +156,21 @@ impl AsyncIo for RawFileAsync {
         // Update the submission queue and submit new operations to the
         // io_uring instance.
         sq.sync();
+        drop(sq);
         submitter.submit().map_err(AsyncIoError::WriteVectored)?;
+        destructor_clear.disarm();
 
         Ok(())
     }
 
     fn fsync(&mut self, user_data: Option<u64>) -> AsyncIoResult<()> {
         if let Some(user_data) = user_data {
-            let (submitter, mut sq, _) = self.io_uring.split();
+            let (submitter, mut sq, fd) = self.split_ring().map_err(AsyncIoError::Fsync)?;
 
             // SAFETY: we know the file descriptor is valid.
             unsafe {
                 sq.push(
-                    &opcode::Fsync::new(types::Fd(self.fd))
+                    &opcode::Fsync::new(types::Fd(fd))
                         .build()
                         .user_data(user_data),
                 )
@@ -174,6 +193,7 @@ impl AsyncIo for RawFileAsync {
 
     fn next_completed_request(&mut self) -> Option<(u64, i32)> {
         self.io_uring
+            .as_mut()?
             .completion()
             .next()
             .map(|entry| (entry.user_data(), entry.result()))
@@ -188,7 +208,19 @@ impl AsyncIo for RawFileAsync {
             return Ok(());
         }
 
-        let (submitter, mut sq, _) = self.io_uring.split();
+        let fd = self.fd;
+        // If there is an error, the io_uring instance will be destroyed.
+        let mut destructor_clear = DestructorClear::new(&mut self.io_uring);
+        let (submitter, mut sq) = destructor_clear
+            .split_ring()
+            .map_err(AsyncIoError::SubmitBatchRequests)?;
+
+        if batch_request.len() > sq.capacity() - sq.len() {
+            return Err(AsyncIoError::SubmitBatchRequests(Error::new(
+                ErrorKind::WouldBlock,
+                "io_uring submission queue is full",
+            )));
+        }
         let mut submitted = false;
 
         // Refuse the whole batch if it can't fit in the SQ to avoid having to unroll a partially
@@ -207,7 +239,7 @@ impl AsyncIo for RawFileAsync {
                     unsafe {
                         sq.push(
                             &opcode::Readv::new(
-                                types::Fd(self.fd),
+                                types::Fd(fd),
                                 req.iovecs.as_ptr(),
                                 req.iovecs.len() as u32,
                             )
@@ -229,7 +261,7 @@ impl AsyncIo for RawFileAsync {
                     unsafe {
                         sq.push(
                             &opcode::Writev::new(
-                                types::Fd(self.fd),
+                                types::Fd(fd),
                                 req.iovecs.as_ptr(),
                                 req.iovecs.len() as u32,
                             )
@@ -256,11 +288,14 @@ impl AsyncIo for RawFileAsync {
             // Update the submission queue and submit new operations to the
             // io_uring instance.
             sq.sync();
+            drop(sq);
             submitter
                 .submit()
                 .map_err(AsyncIoError::SubmitBatchRequests)?;
+        } else {
+            drop(sq);
         }
-
+        destructor_clear.disarm();
         Ok(())
     }
 
@@ -277,14 +312,14 @@ impl AsyncIo for RawFileAsync {
             return self.submit_nop(user_data).map_err(AsyncIoError::PunchHole);
         }
 
-        let (submitter, mut sq, _) = self.io_uring.split();
+        let (submitter, mut sq, fd) = self.split_ring().map_err(AsyncIoError::PunchHole)?;
 
         let mode = FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE;
 
         // SAFETY: The file descriptor is known to be valid.
         unsafe {
             sq.push(
-                &opcode::Fallocate::new(types::Fd(self.fd), length)
+                &opcode::Fallocate::new(types::Fd(fd), length)
                     .offset(offset)
                     .mode(mode)
                     .build()
@@ -310,14 +345,14 @@ impl AsyncIo for RawFileAsync {
                 .map_err(AsyncIoError::WriteZeroes);
         }
 
-        let (submitter, mut sq, _) = self.io_uring.split();
+        let (submitter, mut sq, fd) = self.split_ring().map_err(AsyncIoError::WriteZeroes)?;
 
         let mode = FALLOC_FL_ZERO_RANGE | FALLOC_FL_KEEP_SIZE;
 
         // SAFETY: The file descriptor is known to be valid.
         unsafe {
             sq.push(
-                &opcode::Fallocate::new(types::Fd(self.fd), length)
+                &opcode::Fallocate::new(types::Fd(fd), length)
                     .offset(offset)
                     .mode(mode)
                     .build()

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -12,7 +12,7 @@ use vmm_sys_util::eventfd::EventFd;
 use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
 use crate::sparse::{blkdiscard, blkzeroout};
-use crate::{BatchRequest, DestructorClear, RequestType, SECTOR_SIZE, is_block_device};
+use crate::{BatchRequest, DestructorClear, RequestType, SECTOR_SIZE, is_block_device, submit_all};
 
 pub struct RawFileAsync {
     fd: RawFd,
@@ -118,9 +118,8 @@ impl AsyncIo for RawFileAsync {
 
         // Update the submission queue and submit new operations to the
         // io_uring instance.
-        sq.sync();
+        submit_all(&submitter, &mut sq).map_err(AsyncIoError::ReadVectored)?;
         drop(sq);
-        submitter.submit().map_err(AsyncIoError::ReadVectored)?;
         destructor_clear.disarm();
         Ok(())
     }
@@ -155,11 +154,9 @@ impl AsyncIo for RawFileAsync {
 
         // Update the submission queue and submit new operations to the
         // io_uring instance.
-        sq.sync();
+        submit_all(&submitter, &mut sq).map_err(AsyncIoError::WriteVectored)?;
         drop(sq);
-        submitter.submit().map_err(AsyncIoError::WriteVectored)?;
         destructor_clear.disarm();
-
         Ok(())
     }
 
@@ -181,8 +178,7 @@ impl AsyncIo for RawFileAsync {
 
             // Update the submission queue and submit new operations to the
             // io_uring instance.
-            sq.sync();
-            submitter.submit().map_err(AsyncIoError::Fsync)?;
+            submit_all(&submitter, &mut sq).map_err(AsyncIoError::Fsync)?;
         } else {
             // SAFETY: FFI call with a valid fd
             unsafe { libc::fsync(self.fd) };
@@ -285,16 +281,9 @@ impl AsyncIo for RawFileAsync {
 
         // Only submit if we actually queued something
         if submitted {
-            // Update the submission queue and submit new operations to the
-            // io_uring instance.
-            sq.sync();
-            drop(sq);
-            submitter
-                .submit()
-                .map_err(AsyncIoError::SubmitBatchRequests)?;
-        } else {
-            drop(sq);
+            submit_all(&submitter, &mut sq).map_err(AsyncIoError::SubmitBatchRequests)?;
         }
+        drop(sq);
         destructor_clear.disarm();
         Ok(())
     }
@@ -330,8 +319,9 @@ impl AsyncIo for RawFileAsync {
             })?;
         };
 
-        sq.sync();
-        submitter.submit().map_err(AsyncIoError::PunchHole)?;
+        // Update the submission queue and submit new operations to the
+        // io_uring instance.
+        submit_all(&submitter, &mut sq).map_err(AsyncIoError::PunchHole)?;
 
         Ok(())
     }
@@ -363,8 +353,7 @@ impl AsyncIo for RawFileAsync {
             })?;
         };
 
-        sq.sync();
-        submitter.submit().map_err(AsyncIoError::WriteZeroes)?;
+        submit_all(&submitter, &mut sq).map_err(AsyncIoError::WriteZeroes)?;
 
         Ok(())
     }


### PR DESCRIPTION
This ensures that Linux cannot use freed iovecs, even if there is an I/O error.