### PR TITLE
Add seccomp filters to the serial manager thread

### DIFF
--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -679,7 +679,6 @@ fn start_vmm(
             monitor,
             &seccomp_action,
             landlock_enable,
-            hypervisor.hypervisor_type(),
             exit_evt.try_clone().unwrap(),
         )
         .map_err(Error::EventMonitorThread)?;

--- a/vmm/src/api/dbus/mod.rs
+++ b/vmm/src/api/dbus/mod.rs
@@ -9,7 +9,6 @@ use std::thread;
 
 use futures::channel::oneshot;
 use futures::{FutureExt, executor};
-use hypervisor::HypervisorType;
 use log::{error, warn};
 use seccompiler::{SeccompAction, apply_filter};
 use vmm_sys_util::eventfd::EventFd;
@@ -326,7 +325,6 @@ pub fn start_dbus_thread(
     api_sender: Sender<ApiRequest>,
     seccomp_action: &SeccompAction,
     exit_evt: EventFd,
-    hypervisor_type: HypervisorType,
 ) -> VmmResult<(thread::JoinHandle<VmmResult<()>>, DBusApiShutdownChannels)> {
     let dbus_iface = DBusApi::new(api_notifier, api_sender);
     let (connection, iface_ref) = executor::block_on(async move {
@@ -356,7 +354,7 @@ pub fn start_dbus_thread(
     let (send_done, recv_done) = oneshot::channel::<()>();
 
     // Retrieve seccomp filter for API thread
-    let api_seccomp_filter = get_seccomp_filter(seccomp_action, Thread::DBusApi, hypervisor_type)
+    let api_seccomp_filter = get_seccomp_filter(seccomp_action, Thread::DBusApi, None)
         .map_err(VmmError::CreateSeccompFilter)?;
 
     let thread_join_handle = thread::Builder::new()

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -14,7 +14,6 @@ use std::sync::LazyLock;
 use std::sync::mpsc::Sender;
 use std::thread;
 
-use hypervisor::HypervisorType;
 use log::{error, info};
 use micro_http::{
     Body, HttpServer, MediaType, Method, Request, Response, ServerError, StatusCode, Version,
@@ -328,11 +327,10 @@ fn start_http_thread(
     api_sender: Sender<ApiRequest>,
     seccomp_action: &SeccompAction,
     exit_evt: EventFd,
-    hypervisor_type: HypervisorType,
     landlock_enable: bool,
 ) -> Result<HttpApiHandle> {
     // Retrieve seccomp filter for API thread
-    let api_seccomp_filter = get_seccomp_filter(seccomp_action, Thread::HttpApi, hypervisor_type)
+    let api_seccomp_filter = get_seccomp_filter(seccomp_action, Thread::HttpApi, None)
         .map_err(VmmError::CreateSeccompFilter)?;
 
     let api_shutdown_fd = EventFd::new(libc::EFD_NONBLOCK).map_err(VmmError::EventFdCreate)?;
@@ -410,7 +408,6 @@ pub fn start_http_path_thread(
     api_sender: Sender<ApiRequest>,
     seccomp_action: &SeccompAction,
     exit_evt: EventFd,
-    hypervisor_type: HypervisorType,
     landlock_enable: bool,
 ) -> Result<HttpApiHandle> {
     let socket_path = PathBuf::from(path);
@@ -425,7 +422,6 @@ pub fn start_http_path_thread(
         api_sender,
         seccomp_action,
         exit_evt,
-        hypervisor_type,
         landlock_enable,
     )
 }
@@ -436,7 +432,6 @@ pub fn start_http_fd_thread(
     api_sender: Sender<ApiRequest>,
     seccomp_action: &SeccompAction,
     exit_evt: EventFd,
-    hypervisor_type: HypervisorType,
     landlock_enable: bool,
 ) -> Result<HttpApiHandle> {
     // SAFETY: Valid FD
@@ -447,7 +442,6 @@ pub fn start_http_fd_thread(
         api_sender,
         seccomp_action,
         exit_evt,
-        hypervisor_type,
         landlock_enable,
     )
 }

--- a/vmm/src/console_devices.rs
+++ b/vmm/src/console_devices.rs
@@ -193,12 +193,8 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
                 set_raw_mode(&sub_fd.as_raw_fd(), &mut original_termios_opt)?;
                 vmconfig.console.common.file = Some(path.clone());
                 vmm.console_resize_pipe = Some(Arc::new(
-                    listen_for_sigwinch_on_tty(
-                        sub_fd,
-                        &vmm.seccomp_action,
-                        vmm.hypervisor.hypervisor_type(),
-                    )
-                    .map_err(ConsoleDeviceError::StartSigwinchListener)?,
+                    listen_for_sigwinch_on_tty(sub_fd, &vmm.seccomp_action)
+                        .map_err(ConsoleDeviceError::StartSigwinchListener)?,
                 ));
                 ConsoleTransport::Pty(Arc::new(main_fd))
             }
@@ -214,7 +210,6 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
                         listen_for_sigwinch_on_tty(
                             stdout.try_clone().unwrap(),
                             &vmm.seccomp_action,
-                            vmm.hypervisor.hypervisor_type(),
                         )
                         .map_err(ConsoleDeviceError::StartSigwinchListener)?,
                     ));

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1172,7 +1172,7 @@ impl CpuManager {
         let vcpu_seccomp_filter = get_seccomp_filter(
             &self.seccomp_action,
             Thread::Vcpu,
-            self.hypervisor.hypervisor_type(),
+            Some(self.hypervisor.hypervisor_type()),
         )
         .map_err(Error::CreateSeccompFilter)?;
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2534,6 +2534,7 @@ impl DeviceManager {
                                 self.exit_evt
                                     .try_clone()
                                     .map_err(DeviceManagerError::EventFd)?,
+                                &self.seccomp_action,
                             )
                             .map_err(DeviceManagerError::SpawnSerialManager)?;
                         Some(Arc::new(serial_manager))

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -391,11 +391,10 @@ pub fn start_event_monitor_thread(
     mut monitor: event_monitor::Monitor,
     seccomp_action: &SeccompAction,
     landlock_enable: bool,
-    hypervisor_type: hypervisor::HypervisorType,
     exit_event: EventFd,
 ) -> Result<thread::JoinHandle<Result<()>>> {
     // Retrieve seccomp filter
-    let seccomp_filter = get_seccomp_filter(seccomp_action, Thread::EventMonitor, hypervisor_type)
+    let seccomp_filter = get_seccomp_filter(seccomp_action, Thread::EventMonitor, None)
         .map_err(Error::CreateSeccompFilter)?;
 
     thread::Builder::new()
@@ -478,7 +477,7 @@ pub fn start_vmm_thread(
     let hypervisor_type = hypervisor.hypervisor_type();
 
     // Retrieve seccomp filter
-    let vmm_seccomp_filter = get_seccomp_filter(seccomp_action, Thread::Vmm, hypervisor_type)
+    let vmm_seccomp_filter = get_seccomp_filter(seccomp_action, Thread::Vmm, Some(hypervisor_type))
         .map_err(Error::CreateSeccompFilter)?;
 
     let vmm_seccomp_action = seccomp_action.clone();
@@ -527,7 +526,6 @@ pub fn start_vmm_thread(
                 api_sender.clone(),
                 seccomp_action,
                 exit_event.try_clone().map_err(Error::EventFdClone)?,
-                hypervisor_type,
             )?;
             Some(chs)
         }
@@ -541,7 +539,6 @@ pub fn start_vmm_thread(
             api_sender,
             seccomp_action,
             exit_event,
-            hypervisor_type,
             landlock_enable,
         )?)
     } else if let Some(http_fd) = http_fd {
@@ -551,7 +548,6 @@ pub fn start_vmm_thread(
             api_sender,
             seccomp_action,
             exit_event,
-            hypervisor_type,
             landlock_enable,
         )?)
     } else {
@@ -750,12 +746,9 @@ impl Vmm {
                 let exit_evt = self.exit_evt.try_clone().map_err(Error::EventFdClone)?;
                 let original_termios_opt = Arc::clone(&self.original_termios_opt);
 
-                let signal_handler_seccomp_filter = get_seccomp_filter(
-                    &self.seccomp_action,
-                    Thread::SignalHandler,
-                    self.hypervisor.hypervisor_type(),
-                )
-                .map_err(Error::CreateSeccompFilter)?;
+                let signal_handler_seccomp_filter =
+                    get_seccomp_filter(&self.seccomp_action, Thread::SignalHandler, None)
+                        .map_err(Error::CreateSeccompFilter)?;
                 self.threads.push(
                     thread::Builder::new()
                         .name("vmm_signal_handler".to_string())

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -39,6 +39,7 @@ pub enum Thread {
     Vcpu,
     Vmm,
     PtyForeground,
+    SerialManager,
 }
 
 /// Shorthand for chaining `SeccompCondition`s with the `and` operator  in a `SeccompRule`.
@@ -1031,6 +1032,33 @@ fn event_monitor_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendE
     ])
 }
 
+fn serial_manager_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError> {
+    Ok(vec![
+        (libc::SYS_accept4, vec![]),
+        (libc::SYS_clock_nanosleep, vec![]),
+        (libc::SYS_clock_gettime, vec![]),
+        (libc::SYS_close, vec![]),
+        (libc::SYS_epoll_ctl, vec![]),
+        (libc::SYS_epoll_pwait, vec![]),
+        #[cfg(target_arch = "x86_64")]
+        (libc::SYS_epoll_wait, vec![]),
+        (libc::SYS_exit, vec![]),
+        (libc::SYS_fcntl, vec![]),
+        (libc::SYS_futex, vec![]),
+        (libc::SYS_madvise, vec![]),
+        (libc::SYS_mmap, vec![]),
+        (libc::SYS_munmap, vec![]),
+        (libc::SYS_nanosleep, vec![]),
+        (libc::SYS_read, vec![]),
+        (libc::SYS_recvfrom, vec![]),
+        (libc::SYS_rt_sigprocmask, vec![]),
+        (libc::SYS_rt_sigreturn, vec![]),
+        (libc::SYS_shutdown, vec![]),
+        (libc::SYS_sigaltstack, vec![]),
+        (libc::SYS_write, vec![]),
+    ])
+}
+
 fn get_seccomp_rules(
     thread_type: Thread,
     hypervisor_type: Option<HypervisorType>,
@@ -1040,6 +1068,7 @@ fn get_seccomp_rules(
         #[cfg(feature = "dbus_api")]
         Thread::DBusApi => Ok(dbus_api_thread_rules()?),
         Thread::EventMonitor => Ok(event_monitor_thread_rules()?),
+        Thread::SerialManager => Ok(serial_manager_thread_rules()?),
         Thread::SignalHandler => Ok(signal_handler_thread_rules()?),
         Thread::Vcpu => Ok(vcpu_thread_rules(
             hypervisor_type.expect("hypervisor_type is required for Vcpu threads"),

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -1033,7 +1033,7 @@ fn event_monitor_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendE
 
 fn get_seccomp_rules(
     thread_type: Thread,
-    hypervisor_type: HypervisorType,
+    hypervisor_type: Option<HypervisorType>,
 ) -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError> {
     match thread_type {
         Thread::HttpApi => Ok(http_api_thread_rules()?),
@@ -1041,8 +1041,12 @@ fn get_seccomp_rules(
         Thread::DBusApi => Ok(dbus_api_thread_rules()?),
         Thread::EventMonitor => Ok(event_monitor_thread_rules()?),
         Thread::SignalHandler => Ok(signal_handler_thread_rules()?),
-        Thread::Vcpu => Ok(vcpu_thread_rules(hypervisor_type)?),
-        Thread::Vmm => Ok(vmm_thread_rules(hypervisor_type)?),
+        Thread::Vcpu => Ok(vcpu_thread_rules(
+            hypervisor_type.expect("hypervisor_type is required for Vcpu threads"),
+        )?),
+        Thread::Vmm => Ok(vmm_thread_rules(
+            hypervisor_type.expect("hypervisor_type is required for Vmm threads"),
+        )?),
         Thread::PtyForeground => Ok(pty_foreground_thread_rules()?),
     }
 }
@@ -1051,7 +1055,7 @@ fn get_seccomp_rules(
 pub fn get_seccomp_filter(
     seccomp_action: &SeccompAction,
     thread_type: Thread,
-    hypervisor_type: HypervisorType,
+    hypervisor_type: Option<HypervisorType>,
 ) -> Result<BpfProgram, Error> {
     match seccomp_action {
         SeccompAction::Allow => Ok(vec![]),

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -21,11 +21,13 @@ use devices::legacy::Pl011;
 use devices::legacy::Serial;
 use libc::EFD_NONBLOCK;
 use log::{error, info, warn};
+use seccompiler::{SeccompAction, apply_filter};
 use serial_buffer::SerialBuffer;
 use thiserror::Error;
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::console_devices::ConsoleTransport;
+use crate::seccomp_filters::{Thread, get_seccomp_filter};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -84,6 +86,14 @@ pub enum Error {
     /// Cannot duplicate file descriptor
     #[error("Error duplicating file descriptor")]
     DupFd(#[source] io::Error),
+
+    /// Cannot create seccomp filter.
+    #[error("Error creating seccomp filter")]
+    CreateSeccompFilter(seccompiler::Error),
+
+    /// Cannot apply seccomp filter.
+    #[error("Error applying seccomp filter")]
+    ApplySeccompFilter(seccompiler::Error),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -250,12 +260,19 @@ impl SerialManager {
         Ok(())
     }
 
-    pub fn start_thread(&mut self, exit_evt: EventFd) -> Result<()> {
+    pub fn start_thread(
+        &mut self,
+        exit_evt: EventFd,
+        seccomp_action: &SeccompAction,
+    ) -> Result<()> {
         // Don't allow this to be run if the handle exists
         if self.handle.is_some() {
             warn!("Tried to start multiple SerialManager threads, ignoring");
             return Ok(());
         }
+
+        let seccomp_filter = get_seccomp_filter(seccomp_action, Thread::SerialManager, None)
+            .map_err(Error::CreateSeccompFilter)?;
 
         let epoll_fd = self.epoll_fd.try_clone().map_err(Error::Epoll)?;
         let transport = self.transport.clone();
@@ -275,6 +292,11 @@ impl SerialManager {
             .name("serial-manager".to_string())
             .spawn(move || {
                 std::panic::catch_unwind(AssertUnwindSafe(move || {
+                    // Apply seccomp filter for serial manager thread.
+                    if !seccomp_filter.is_empty() {
+                        apply_filter(&seccomp_filter).map_err(Error::ApplySeccompFilter)?;
+                    }
+
                     let mut events =
                         [epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 

--- a/vmm/src/sigwinch_listener.rs
+++ b/vmm/src/sigwinch_listener.rs
@@ -12,7 +12,6 @@ use std::process::exit;
 use std::ptr::null_mut;
 
 use arch::_NSIG;
-use hypervisor::HypervisorType;
 use libc::{
     EINVAL, ENOSYS, ENOTTY, O_CLOEXEC, POLLERR, SIG_DFL, SIG_SETMASK, SIGCHLD, SIGWINCH,
     STDERR_FILENO, SYS_close_range, TIOCSCTTY, c_int, c_void, close, fork, getpgrp, ioctl, pipe2,
@@ -270,10 +269,8 @@ pub fn start_sigwinch_listener(seccomp_filter: BpfProgramRef, tty_sub: File) -> 
 pub fn listen_for_sigwinch_on_tty(
     pty_sub: File,
     seccomp_action: &SeccompAction,
-    hypervisor_type: HypervisorType,
 ) -> std::io::Result<File> {
-    let seccomp_filter =
-        get_seccomp_filter(seccomp_action, Thread::PtyForeground, hypervisor_type).unwrap();
+    let seccomp_filter = get_seccomp_filter(seccomp_action, Thread::PtyForeground, None).unwrap();
 
     let console_resize_pipe = start_sigwinch_listener(&seccomp_filter, pty_sub)?;
 


### PR DESCRIPTION
I was reading the code to cross-check the virtio-console and emulated serial implementation, then it occurred to me that the serial manager thread didn't have seccomp enabled.

I instructed an AI agent to generate the code, then I reviewed and modified the code a bit.