### PR TITLE
tests: poll for source VM exit after live-migration

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6257,9 +6257,10 @@ mod common_parallel {
             );
         }
 
-        // Check the source vm has been terminated successful (give it '3s' to settle)
-        thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
+        let src_exited_ok = wait_until(Duration::from_secs(30), || {
+            matches!(src_child.try_wait(), Ok(Some(_)))
+        }) && src_child.try_wait().unwrap().is_some_and(|s| s.success());
+        if !src_exited_ok {
             print_and_panic(
                 src_child,
                 dest_child,
@@ -6396,9 +6397,10 @@ mod common_parallel {
             );
         }
 
-        // Check the source vm has been terminated successful (give it '3s' to settle)
-        thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
+        let src_exited_ok = wait_until(Duration::from_secs(30), || {
+            matches!(src_child.try_wait(), Ok(Some(_)))
+        }) && src_child.try_wait().unwrap().is_some_and(|s| s.success());
+        if !src_exited_ok {
             print_and_panic(
                 src_child,
                 dest_child,
@@ -6622,9 +6624,10 @@ mod common_parallel {
             );
         }
 
-        // Check the source vm has been terminated successful (give it '3s' to settle)
-        thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
+        let src_exited_ok = wait_until(Duration::from_secs(30), || {
+            matches!(src_child.try_wait(), Ok(Some(_)))
+        }) && src_child.try_wait().unwrap().is_some_and(|s| s.success());
+        if !src_exited_ok {
             print_and_panic(
                 src_child,
                 dest_child,
@@ -7006,9 +7009,10 @@ mod common_parallel {
             );
         }
 
-        // Check the source vm has been terminated successfully (give it '3s' to settle)
-        thread::sleep(Duration::from_secs(3));
-        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
+        let src_exited_ok = wait_until(Duration::from_secs(30), || {
+            matches!(src_child.try_wait(), Ok(Some(_)))
+        }) && src_child.try_wait().unwrap().is_some_and(|s| s.success());
+        if !src_exited_ok {
             print_and_panic(
                 src_child,
                 dest_child,
@@ -7346,9 +7350,10 @@ mod ivshmem {
             );
         }
 
-        // Check the source vm has been terminated successful (give it '3s' to settle)
-        thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
+        let src_exited_ok = wait_until(Duration::from_secs(30), || {
+            matches!(src_child.try_wait(), Ok(Some(_)))
+        }) && src_child.try_wait().unwrap().is_some_and(|s| s.success());
+        if !src_exited_ok {
             print_and_panic(
                 src_child,
                 dest_child,
@@ -8858,9 +8863,10 @@ mod common_sequential {
             );
         }
 
-        // Check the source vm has been terminated successful (give it '3s' to settle)
-        thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
+        let src_exited_ok = wait_until(Duration::from_secs(30), || {
+            matches!(src_child.try_wait(), Ok(Some(_)))
+        }) && src_child.try_wait().unwrap().is_some_and(|s| s.success());
+        if !src_exited_ok {
             print_and_panic(
                 src_child,
                 dest_child,
@@ -9085,9 +9091,10 @@ mod common_sequential {
             );
         }
 
-        // Check the source vm has been terminated successful (give it '3s' to settle)
-        thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
+        let src_exited_ok = wait_until(Duration::from_secs(30), || {
+            matches!(src_child.try_wait(), Ok(Some(_)))
+        }) && src_child.try_wait().unwrap().is_some_and(|s| s.success());
+        if !src_exited_ok {
             print_and_panic(
                 src_child,
                 dest_child,
@@ -9219,9 +9226,10 @@ mod common_sequential {
             );
         }
 
-        // Check the source vm has been terminated successful (give it '3s' to settle)
-        thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
+        let src_exited_ok = wait_until(Duration::from_secs(30), || {
+            matches!(src_child.try_wait(), Ok(Some(_)))
+        }) && src_child.try_wait().unwrap().is_some_and(|s| s.success());
+        if !src_exited_ok {
             print_and_panic(
                 src_child,
                 dest_child,
@@ -9498,9 +9506,10 @@ mod common_sequential {
             );
         }
 
-        // Check the source vm has been terminated successful (give it '3s' to settle)
-        thread::sleep(std::time::Duration::new(3, 0));
-        if !src_child.try_wait().unwrap().is_some_and(|s| s.success()) {
+        let src_exited_ok = wait_until(Duration::from_secs(30), || {
+            matches!(src_child.try_wait(), Ok(Some(_)))
+        }) && src_child.try_wait().unwrap().is_some_and(|s| s.success());
+        if !src_exited_ok {
             print_and_panic(
                 src_child,
                 dest_child,


### PR DESCRIPTION
The post-migration check used a single fixed `thread::sleep(3s)` followed by `try_wait()` to verify the source VM had exited cleanly. That window is too tight when the source process is `~/workloads/cloud-hypervisor-static` (the `migratable_version` release binary used by `test_live_upgrade_*`). The released binary is older than the locally-built destination and its virtio-device teardown (resume-paused-thread -> kill -> join across the pmem/block/net/console/rng workers) regularly takes longer than 3s on contended hosts, causing the test to report:

  thread 'common_parallel::test_live_upgrade_basic' panicked:
  Test failed: source VM was not terminated successfully.

even though the source process eventually exited with status 0.

Replace the fixed sleep with a `wait_until(Duration::from_secs(30), ...)` poll that succeeds as soon as `try_wait()` reports a reaped child, and then keep the existing `success()` check on the exit status. This makes the assertion robust against the slower release-binary shutdown path while still failing fast on a genuine error.

The same pattern was duplicated across eight migration helpers plus the virtio-fs migration variant; convert all nine call sites for consistency.