### PR TITLE
vm-virtio: Add centralized descriptor range validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ name = "vm-virtio"
 version = "0.1.0"
 dependencies = [
  "log",
+ "virtio-bindings",
  "virtio-queue",
  "vm-memory",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,6 +2692,7 @@ dependencies = [
 name = "vm-virtio"
 version = "0.1.0"
 dependencies = [
+ "log",
  "virtio-queue",
  "vm-memory",
 ]

--- a/block/src/io/request.rs
+++ b/block/src/io/request.rs
@@ -27,7 +27,8 @@ use vm_memory::{
     Address as _, Bytes as _, GuestAddress, GuestMemory as _, GuestMemoryError,
     GuestMemoryLoadGuard,
 };
-use vm_virtio::{AccessPlatform, Translatable as _};
+use vm_virtio::AccessPlatform;
+use vm_virtio::checked_descriptor::DescriptorChainExt;
 
 use crate::async_io::{
     AsyncIo, AsyncIoCompletion, AsyncIoOperation, GuestMemoryTarget, OwnedIoBuffer,
@@ -84,10 +85,11 @@ impl Request {
         access_platform: Option<&dyn AccessPlatform>,
     ) -> Result<Request, Error> {
         let hdr_desc = desc_chain
-            .next()
-            .ok_or(Error::DescriptorChainTooShort)
-            .inspect_err(|_| {
+            .next_checked(access_platform)
+            .map_err(|addr| Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(addr)))?
+            .ok_or_else(|| {
                 error!("Missing head descriptor");
+                Error::DescriptorChainTooShort
             })?;
 
         // The head contains the request type which MUST be readable.
@@ -95,10 +97,7 @@ impl Request {
             return Err(Error::UnexpectedWriteOnlyDescriptor);
         }
 
-        let hdr_desc_addr = hdr_desc
-            .addr()
-            .translate_gva(access_platform, hdr_desc.len() as usize)
-            .map_err(|e| Error::GuestMemory(GuestMemoryError::IOError(e)))?;
+        let hdr_desc_addr = hdr_desc.addr();
 
         let mut req = Request {
             request_type: request_type(desc_chain.memory(), hdr_desc_addr)?,
@@ -111,10 +110,11 @@ impl Request {
 
         let status_desc;
         let mut desc = desc_chain
-            .next()
-            .ok_or(Error::DescriptorChainTooShort)
-            .inspect_err(|_| {
+            .next_checked(access_platform)
+            .map_err(|addr| Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(addr)))?
+            .ok_or_else(|| {
                 error!("Only head descriptor present: request = {req:?}");
+                Error::DescriptorChainTooShort
             })?;
 
         if desc.has_next() {
@@ -136,17 +136,15 @@ impl Request {
                     return Err(Error::UnexpectedReadOnlyDescriptor);
                 }
 
-                req.data_descriptors.push((
-                    desc.addr()
-                        .translate_gva(access_platform, desc.len() as usize)
-                        .map_err(|e| Error::GuestMemory(GuestMemoryError::IOError(e)))?,
-                    desc.len(),
-                ));
+                req.data_descriptors.push((desc.addr(), desc.len()));
                 desc = desc_chain
-                    .next()
-                    .ok_or(Error::DescriptorChainTooShort)
-                    .inspect_err(|_| {
+                    .next_checked(access_platform)
+                    .map_err(|addr| {
+                        Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(addr))
+                    })?
+                    .ok_or_else(|| {
                         error!("DescriptorChain corrupted: request = {req:?}");
+                        Error::DescriptorChainTooShort
                     })?;
             }
             status_desc = desc;
@@ -164,14 +162,11 @@ impl Request {
             return Err(Error::UnexpectedReadOnlyDescriptor);
         }
 
-        if status_desc.len() < 1 {
+        if status_desc.is_empty() {
             return Err(Error::DescriptorLengthTooSmall);
         }
 
-        req.status_addr = status_desc
-            .addr()
-            .translate_gva(access_platform, status_desc.len() as usize)
-            .map_err(|e| Error::GuestMemory(GuestMemoryError::IOError(e)))?;
+        req.status_addr = status_desc.addr();
 
         Ok(req)
     }

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -34,7 +34,8 @@ use vm_memory::{
     GuestMemoryError, GuestMemoryRegion,
 };
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
-use vm_virtio::{AccessPlatform, Translatable};
+use vm_virtio::AccessPlatform;
+use vm_virtio::checked_descriptor::DescriptorChainExt;
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::seccomp_filters::Thread;
@@ -276,7 +277,14 @@ impl BalloonEpollHandler {
         {
             let data_chunk_size = size_of::<u32>();
 
-            while let Some(desc) = desc_chain.next() {
+            let results: Vec<_> = desc_chain
+                .checked_iter(self.access_platform.as_deref())
+                .collect();
+            for result in results {
+                let desc = match result {
+                    Ok(d) => d,
+                    Err(_) => break,
+                };
                 if desc.is_write_only() {
                     warn!("Skipping device-writable descriptor on inflate/deflate queue");
                     continue;
@@ -298,18 +306,9 @@ impl BalloonEpollHandler {
 
                 let mut offset = 0u64;
                 while offset < desc.len() as u64 {
-                    let Some(base) = desc.addr().checked_add(offset) else {
+                    let Some(addr) = desc.addr().checked_add(offset) else {
                         warn!("Address overflow in balloon descriptor");
                         break;
-                    };
-                    let addr = match base
-                        .translate_gva(self.access_platform.as_deref(), data_chunk_size)
-                    {
-                        Ok(a) => a,
-                        Err(e) => {
-                            warn!("Failed to translate descriptor address: {e}");
-                            break;
-                        }
                     };
                     let pfn: u32 = match desc_chain.memory().read_obj(addr) {
                         Ok(v) => v,
@@ -368,21 +367,20 @@ impl BalloonEpollHandler {
             self.queues[queue_index].pop_descriptor_chain(self.mem.memory())
         {
             let mut descs_len = 0;
-            while let Some(desc) = desc_chain.next() {
-                descs_len += desc.len();
-                let addr = match desc
-                    .addr()
-                    .translate_gva(self.access_platform.as_deref(), desc.len() as usize)
-                {
-                    Ok(a) => a,
-                    Err(e) => {
-                        warn!("Failed to translate reporting descriptor address: {e}");
-                        continue;
-                    }
+            let results: Vec<_> = desc_chain
+                .checked_iter(self.access_platform.as_deref())
+                .collect();
+            for result in results {
+                let desc = match result {
+                    Ok(d) => d,
+                    Err(_) => break,
                 };
-                if let Err(e) =
-                    Self::release_memory_range(desc_chain.memory(), addr, desc.len() as usize)
-                {
+                descs_len += desc.len();
+                if let Err(e) = Self::release_memory_range(
+                    desc_chain.memory(),
+                    desc.addr(),
+                    desc.len() as usize,
+                ) {
                     warn!("Failed to release reported memory range: {e}");
                 }
             }

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -20,7 +20,8 @@ use thiserror::Error;
 use virtio_queue::{Queue, QueueT};
 use vm_memory::{ByteValued, Bytes, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
-use vm_virtio::{AccessPlatform, Translatable};
+use vm_virtio::AccessPlatform;
+use vm_virtio::checked_descriptor::DescriptorChainExt;
 use vmm_sys_util::eventfd::EventFd;
 
 use super::{
@@ -201,7 +202,15 @@ impl ConsoleEpollHandler {
 
         while let Some(mut desc_chain) = recv_queue.pop_descriptor_chain(self.mem.memory()) {
             let mut total_len = 0;
-            while let Some(desc) = desc_chain.next() {
+
+            // Validate all descriptors upfront so we never partially fill
+            // buffers for a chain that turns out to be invalid.
+            let descs: Vec<_> = desc_chain
+                .checked_iter(self.access_platform.as_deref())
+                .collect::<Result<_, _>>()
+                .unwrap_or_default();
+
+            for desc in &descs {
                 if in_buffer.is_empty() {
                     break;
                 }
@@ -210,18 +219,8 @@ impl ConsoleEpollHandler {
                     continue;
                 }
                 let len = cmp::min(desc.len() as usize, in_buffer.len());
-                let addr = match desc
-                    .addr()
-                    .translate_gva(self.access_platform.as_deref(), desc.len() as usize)
-                {
-                    Ok(a) => a,
-                    Err(e) => {
-                        warn!("Failed to translate receiveq descriptor address: {e}");
-                        break;
-                    }
-                };
                 let source: Vec<u8> = in_buffer.range(..len).copied().collect();
-                if let Err(e) = desc_chain.memory().write_slice(&source, addr) {
+                if let Err(e) = desc_chain.memory().write_slice(&source, desc.addr()) {
                     warn!("Failed to write to receiveq descriptor: {e}");
                     break;
                 }
@@ -254,28 +253,25 @@ impl ConsoleEpollHandler {
         let mut used_descs = false;
 
         while let Some(mut desc_chain) = trans_queue.pop_descriptor_chain(self.mem.memory()) {
-            while let Some(desc) = desc_chain.next() {
+            let results: Vec<_> = desc_chain
+                .checked_iter(self.access_platform.as_deref())
+                .collect();
+            for result in results {
+                let desc = match result {
+                    Ok(d) => d,
+                    Err(_) => break,
+                };
                 if desc.is_write_only() {
                     warn!("Skipping device-writable descriptor on transmitq");
                     continue;
                 }
                 if let Some(out) = &mut self.out {
-                    let addr = match desc
-                        .addr()
-                        .translate_gva(self.access_platform.as_deref(), desc.len() as usize)
-                    {
-                        Ok(a) => a,
-                        Err(e) => {
-                            warn!("Failed to translate transmitq descriptor address: {e}");
-                            continue;
-                        }
-                    };
                     let mut buf: Vec<u8> = Vec::new();
-                    if let Err(e) =
-                        desc_chain
-                            .memory()
-                            .write_volatile_to(addr, &mut buf, desc.len() as usize)
-                    {
+                    if let Err(e) = desc_chain.memory().write_volatile_to(
+                        desc.addr(),
+                        &mut buf,
+                        desc.len() as usize,
+                    ) {
                         warn!("Failed to read from transmitq descriptor: {e}");
                         continue;
                     }

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use virtio_queue::{DescriptorChain, Queue, QueueT};
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_memory::{
-    Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
+    Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
     GuestMemoryError, GuestMemoryLoadGuard,
 };
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
@@ -369,6 +369,15 @@ impl Request {
 
         if (desc.len() as usize) < size_of::<VirtioIommuReqHead>() {
             return Err(Error::InvalidRequest);
+        }
+
+        if !desc_chain
+            .memory()
+            .check_range(desc.addr(), desc.len() as usize)
+        {
+            return Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
+                desc.addr(),
+            )));
         }
 
         let req_head: VirtioIommuReqHead = desc_chain
@@ -783,6 +792,15 @@ impl Request {
             .ok_or(Error::BufferLengthTooSmall)?;
         if (status_desc.len() as usize) < reply_len {
             return Err(Error::BufferLengthTooSmall);
+        }
+
+        if !desc_chain
+            .memory()
+            .check_range(status_desc.addr(), status_desc.len() as usize)
+        {
+            return Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
+                status_desc.addr(),
+            )));
         }
 
         let tail = VirtioIommuReqTail {

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -30,7 +30,7 @@ use thiserror::Error;
 use virtio_queue::{DescriptorChain, Queue, QueueT};
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_memory::{
-    Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
+    Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
     GuestMemoryError, GuestMemoryLoadGuard, GuestMemoryRegion,
 };
 use vm_migration::protocol::MemoryRangeTable;
@@ -284,6 +284,14 @@ impl Request {
         if (desc.len() as usize) < size_of::<VirtioMemReq>() {
             return Err(Error::InvalidRequest);
         }
+        if !desc_chain
+            .memory()
+            .check_range(desc.addr(), desc.len() as usize)
+        {
+            return Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
+                desc.addr(),
+            )));
+        }
         let req: VirtioMemReq = desc_chain
             .memory()
             .read_obj(desc.addr())
@@ -298,6 +306,15 @@ impl Request {
 
         if (status_desc.len() as usize) < size_of::<VirtioMemResp>() {
             return Err(Error::BufferLengthTooSmall);
+        }
+
+        if !desc_chain
+            .memory()
+            .check_range(status_desc.addr(), status_desc.len() as usize)
+        {
+            return Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
+                status_desc.addr(),
+            )));
         }
 
         Ok(Request {

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -26,7 +26,8 @@ use vm_memory::{
     GuestMemoryError, GuestMemoryLoadGuard,
 };
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
-use vm_virtio::{AccessPlatform, Translatable};
+use vm_virtio::AccessPlatform;
+use vm_virtio::checked_descriptor::DescriptorChainExt;
 use vmm_sys_util::eventfd::EventFd;
 
 use super::{
@@ -110,7 +111,10 @@ impl Request {
         desc_chain: &mut DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap>>,
         access_platform: Option<&dyn AccessPlatform>,
     ) -> result::Result<Request, Error> {
-        let desc = desc_chain.next().ok_or(Error::DescriptorChainTooShort)?;
+        let desc = desc_chain
+            .next_checked(access_platform)
+            .map_err(|addr| Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(addr)))?
+            .ok_or(Error::DescriptorChainTooShort)?;
         // The descriptor contains the request type which MUST be readable.
         if desc.is_write_only() {
             return Err(Error::UnexpectedWriteOnlyDescriptor);
@@ -122,11 +126,7 @@ impl Request {
 
         let request: VirtioPmemReq = desc_chain
             .memory()
-            .read_obj(
-                desc.addr()
-                    .translate_gva(access_platform, desc.len() as usize)
-                    .map_err(|e| Error::GuestMemory(GuestMemoryError::IOError(e)))?,
-            )
+            .read_obj(desc.addr())
             .map_err(Error::GuestMemory)?;
 
         let request_type = match request.type_ {
@@ -134,7 +134,10 @@ impl Request {
             t => RequestType::Unknown(t),
         };
 
-        let status_desc = desc_chain.next().ok_or(Error::DescriptorChainTooShort)?;
+        let status_desc = desc_chain
+            .next_checked(access_platform)
+            .map_err(|addr| Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(addr)))?
+            .ok_or(Error::DescriptorChainTooShort)?;
 
         // The status MUST always be writable
         if !status_desc.is_write_only() {
@@ -147,10 +150,7 @@ impl Request {
 
         Ok(Request {
             type_: request_type,
-            status_addr: status_desc
-                .addr()
-                .translate_gva(access_platform, status_desc.len() as usize)
-                .map_err(|e| Error::GuestMemory(GuestMemoryError::IOError(e)))?,
+            status_addr: status_desc.addr(),
         })
     }
 }

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -19,7 +19,8 @@ use thiserror::Error;
 use virtio_queue::{Queue, QueueT};
 use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
-use vm_virtio::{AccessPlatform, Translatable};
+use vm_virtio::AccessPlatform;
+use vm_virtio::checked_descriptor::DescriptorChainExt;
 use vmm_sys_util::eventfd::EventFd;
 
 use super::{
@@ -61,26 +62,25 @@ impl RngEpollHandler {
         let mut used_descs = false;
         while let Some(mut desc_chain) = queue.pop_descriptor_chain(self.mem.memory()) {
             let mut total_len: usize = 0;
-            while let Some(desc) = desc_chain.next() {
+
+            // Validate the entire descriptor chain upfront so we never
+            // partially fill buffers for a chain that turns out to be
+            // invalid.
+            let descs: Vec<_> = desc_chain
+                .checked_iter(self.access_platform.as_deref())
+                .collect::<Result<_, _>>()
+                .unwrap_or_default();
+
+            for desc in &descs {
                 if !desc.is_write_only() {
                     warn!("Skipping device-readable descriptor");
                     continue;
                 }
-                if desc.len() == 0 {
+                if desc.is_empty() {
                     continue;
                 }
-                let addr = match desc
-                    .addr()
-                    .translate_gva(self.access_platform.as_deref(), desc.len() as usize)
-                {
-                    Ok(a) => a,
-                    Err(e) => {
-                        warn!("Failed to translate descriptor address: {e}");
-                        break;
-                    }
-                };
                 match desc_chain.memory().read_volatile_from(
-                    addr,
+                    desc.addr(),
                     &mut self.random_file,
                     desc.len() as usize,
                 ) {

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -137,7 +137,7 @@ where
             ) {
                 Ok(mut pkt) => {
                     if self.backend.write().unwrap().recv_pkt(&mut pkt).is_ok() {
-                        match pkt.commit_hdr(&*self.mem.memory()) {
+                        match pkt.commit_hdr(desc_chain.memory()) {
                             Ok(()) => pkt.hdr().len() as u32 + pkt.len(),
                             Err(err) => {
                                 warn!(

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -20,7 +20,8 @@ use std::ops::Deref;
 use byteorder::{ByteOrder, LittleEndian};
 use virtio_queue::DescriptorChain;
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemory};
-use vm_virtio::{AccessPlatform, Translatable};
+use vm_virtio::AccessPlatform;
+use vm_virtio::checked_descriptor::DescriptorChainExt;
 
 use super::{Result, VsockError, defs};
 use crate::get_host_address_range;
@@ -127,7 +128,10 @@ impl VsockPacket {
         M: Clone + Deref,
         M::Target: GuestMemory,
     {
-        let head = desc_chain.next().ok_or(VsockError::HdrDescMissing)?;
+        let head = desc_chain
+            .next_checked(access_platform)
+            .map_err(|_| VsockError::GuestMemory)?
+            .ok_or(VsockError::HdrDescMissing)?;
 
         // All buffers in the TX queue must be readable.
         //
@@ -140,10 +144,7 @@ impl VsockPacket {
             return Err(VsockError::HdrDescTooSmall(head.len()));
         }
 
-        let guest_hdr_addr = head
-            .addr()
-            .translate_gva(access_platform, VSOCK_PKT_HDR_SIZE)
-            .map_err(|_| VsockError::GuestMemory)?;
+        let guest_hdr_addr = head.addr();
 
         // To avoid TOCTOU issues when reading/writing the VSock packet header in guest memory,
         // we need to copy the content of the header in the VMM's memory.
@@ -182,9 +183,7 @@ impl VsockPacket {
                 desc_chain.memory(),
                 head.addr()
                     .checked_add(VSOCK_PKT_HDR_SIZE as u64)
-                    .ok_or(VsockError::GuestMemory)?
-                    .translate_gva(access_platform, buf_size)
-                    .map_err(|_| VsockError::GuestMemory)?,
+                    .ok_or(VsockError::GuestMemory)?,
                 buf_size,
             )
             .ok_or(VsockError::GuestMemory)?;
@@ -197,7 +196,10 @@ impl VsockPacket {
         }
 
         // We have separate header and data descriptors.
-        let buf_desc = desc_chain.next().ok_or(VsockError::BufDescMissing)?;
+        let buf_desc = desc_chain
+            .next_checked(access_platform)
+            .map_err(|_| VsockError::GuestMemory)?
+            .ok_or(VsockError::BufDescMissing)?;
 
         // TX data should be read-only.
         if buf_desc.is_write_only() {
@@ -219,19 +221,20 @@ impl VsockPacket {
                 let desc_len = desc.len() as usize;
                 if desc_len > 0 && offset < total_len {
                     let to_copy = std::cmp::min(desc_len, total_len - offset);
-                    let desc_addr = desc
-                        .addr()
-                        .translate_gva(access_platform, desc_len)
-                        .map_err(|_| VsockError::GuestMemory)?;
                     desc_chain
                         .memory()
-                        .read_slice(&mut owned[offset..offset + to_copy], desc_addr)
+                        .read_slice(&mut owned[offset..offset + to_copy], desc.addr())
                         .map_err(|_| VsockError::GuestMemory)?;
                     offset += to_copy;
                 }
 
                 cur_desc = if desc.has_next() {
-                    Some(desc_chain.next().ok_or(VsockError::BufDescMissing)?)
+                    Some(
+                        desc_chain
+                            .next_checked(access_platform)
+                            .map_err(|_| VsockError::GuestMemory)?
+                            .ok_or(VsockError::BufDescMissing)?,
+                    )
                 } else {
                     None
                 };
@@ -248,15 +251,8 @@ impl VsockPacket {
                 return Err(VsockError::BufDescTooSmall);
             }
             let buf_size = buf_desc.len() as usize;
-            let buf_ptr = get_host_address_range(
-                desc_chain.memory(),
-                buf_desc
-                    .addr()
-                    .translate_gva(access_platform, buf_size)
-                    .map_err(|_| VsockError::GuestMemory)?,
-                buf_size,
-            )
-            .ok_or(VsockError::GuestMemory)?;
+            let buf_ptr = get_host_address_range(desc_chain.memory(), buf_desc.addr(), buf_size)
+                .ok_or(VsockError::GuestMemory)?;
             pkt.buf = Some(PacketBuffer::Borrowed {
                 ptr: buf_ptr,
                 len: buf_size,
@@ -279,7 +275,10 @@ impl VsockPacket {
         M: Clone + Deref,
         M::Target: GuestMemory,
     {
-        let head = desc_chain.next().ok_or(VsockError::HdrDescMissing)?;
+        let head = desc_chain
+            .next_checked(access_platform)
+            .map_err(|_| VsockError::GuestMemory)?
+            .ok_or(VsockError::HdrDescMissing)?;
 
         // All RX buffers must be writable.
         //
@@ -292,10 +291,7 @@ impl VsockPacket {
             return Err(VsockError::HdrDescTooSmall(head.len()));
         }
 
-        let guest_hdr_addr = head
-            .addr()
-            .translate_gva(access_platform, VSOCK_PKT_HDR_SIZE)
-            .map_err(|_| VsockError::GuestMemory)?;
+        let guest_hdr_addr = head.addr();
 
         // To avoid TOCTOU issues when reading/writing the VSock packet header in guest memory,
         // we need to copy the content of the header in the VMM's memory.
@@ -309,7 +305,10 @@ impl VsockPacket {
 
         // Prior to Linux v6.3 there are two descriptors
         if head.has_next() {
-            let buf_desc = desc_chain.next().ok_or(VsockError::BufDescMissing)?;
+            let buf_desc = desc_chain
+                .next_checked(access_platform)
+                .map_err(|_| VsockError::GuestMemory)?
+                .ok_or(VsockError::BufDescMissing)?;
             let buf_size = buf_desc.len() as usize;
 
             // TODO: We still assume that there are at most two descriptors. We should probably
@@ -323,15 +322,8 @@ impl VsockPacket {
                 guest_hdr_addr,
                 hdr,
                 buf: Some(PacketBuffer::Borrowed {
-                    ptr: get_host_address_range(
-                        desc_chain.memory(),
-                        buf_desc
-                            .addr()
-                            .translate_gva(access_platform, buf_size)
-                            .map_err(|_| VsockError::GuestMemory)?,
-                        buf_size,
-                    )
-                    .ok_or(VsockError::GuestMemory)?,
+                    ptr: get_host_address_range(desc_chain.memory(), buf_desc.addr(), buf_size)
+                        .ok_or(VsockError::GuestMemory)?,
                     len: buf_size,
                 }),
             })
@@ -345,9 +337,7 @@ impl VsockPacket {
                         desc_chain.memory(),
                         head.addr()
                             .checked_add(VSOCK_PKT_HDR_SIZE as u64)
-                            .ok_or(VsockError::GuestMemory)?
-                            .translate_gva(access_platform, buf_size)
-                            .map_err(|_| VsockError::GuestMemory)?,
+                            .ok_or(VsockError::GuestMemory)?,
                         buf_size,
                     )
                     .ok_or(VsockError::GuestMemory)?,

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -22,6 +22,7 @@ use thiserror::Error;
 use virtio_queue::{Queue, QueueT};
 use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
+use vm_virtio::checked_descriptor::DescriptorChainExt;
 use vmm_sys_util::eventfd::EventFd;
 
 use super::{
@@ -81,9 +82,13 @@ impl WatchdogEpollHandler {
         let queue = &mut self.queue;
         let mut used_descs = false;
         while let Some(mut desc_chain) = queue.pop_descriptor_chain(self.mem.memory()) {
-            let desc = desc_chain.next().ok_or(Error::DescriptorChainTooShort)?;
+            let mut descs = desc_chain.checked_iter(None);
+            let desc = descs
+                .next()
+                .ok_or(Error::DescriptorChainTooShort)?
+                .map_err(|_| Error::InvalidDescriptor)?;
 
-            if !(desc.is_write_only() && desc.len() > 0) {
+            if !desc.is_write_only() || desc.is_empty() {
                 return Err(Error::InvalidDescriptor);
             }
 

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.1.0"
 default = []
 
 [dependencies]
+log = { workspace = true }
 virtio-queue = { workspace = true }
 vm-memory = { workspace = true, features = [
   "backend-atomic",

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -19,3 +19,6 @@ vm-memory = { workspace = true, features = [
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+virtio-bindings = { workspace = true }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -238,4 +238,17 @@ mod unit_tests {
         let result = it.next().expect("iterator must yield an item");
         result.unwrap_err();
     }
+
+    #[test]
+    fn passes_through_zero_length_descriptor() {
+        let (_mem, mem_atomic, mut queue) = setup_vq(128 * 1024, 0x4000, 0, 0);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let mut it = chain.checked_iter(None);
+        let desc = it
+            .next()
+            .unwrap()
+            .expect("zero length descriptor must pass through");
+        assert_eq!(desc.len(), 0);
+    }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -430,4 +430,32 @@ mod unit_tests {
         assert_eq!(desc.addr().0, gpa);
         assert_eq!(desc.len(), LEN);
     }
+
+    /// AccessPlatform stub that always fails translation.
+    #[derive(Debug)]
+    struct FailingTranslator;
+
+    impl AccessPlatform for FailingTranslator {
+        fn translate_gva(&self, _base: u64, _size: u64) -> std::io::Result<u64> {
+            Err(std::io::Error::other("translation failed"))
+        }
+        fn translate_gpa(&self, _base: u64, _size: u64) -> std::io::Result<u64> {
+            Err(std::io::Error::other("translation failed"))
+        }
+    }
+
+    #[test]
+    fn rejects_descriptor_when_translation_fails() {
+        const MEM_SIZE: usize = 128 * 1024;
+        let gva = 0x4000u64;
+        let (_mem, mem_atomic, mut queue) = setup_vq(MEM_SIZE, gva, 256, 0);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let ap = FailingTranslator;
+        let mut it = chain.checked_iter(Some(&ap));
+        let result = it.next().expect("must yield an item");
+        // The error reports the original descriptor address, not a
+        // translated one.
+        assert_eq!(result.unwrap_err(), GuestAddress(gva));
+    }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -313,4 +313,16 @@ mod unit_tests {
         assert_eq!(desc.addr().0, 0x4000);
         assert_eq!(desc.len(), 256);
     }
+
+    #[test]
+    fn next_checked_returns_none_when_exhausted() {
+        let (_mem, mem_atomic, mut queue) = setup_vq(128 * 1024, 0x4000, 256, 0);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        // Consume the single descriptor.
+        let _ = chain.next_checked(None).unwrap().unwrap();
+        // The chain is now exhausted; expect Ok(None).
+        let res = chain.next_checked(None);
+        assert!(matches!(res, Ok(None)));
+    }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -392,4 +392,42 @@ mod unit_tests {
         let result = it.next().expect("must yield an item");
         assert_eq!(result.unwrap_err(), GuestAddress(addr));
     }
+
+    /// AccessPlatform stub that applies a fixed offset between GVA and GPA.
+    #[derive(Debug)]
+    struct OffsetTranslator {
+        gva_base: u64,
+        gpa_base: u64,
+    }
+
+    impl AccessPlatform for OffsetTranslator {
+        fn translate_gva(&self, base: u64, _size: u64) -> std::io::Result<u64> {
+            Ok(base - self.gva_base + self.gpa_base)
+        }
+        fn translate_gpa(&self, base: u64, _size: u64) -> std::io::Result<u64> {
+            Ok(base - self.gpa_base + self.gva_base)
+        }
+    }
+
+    #[test]
+    fn translates_descriptor_via_access_platform() {
+        const MEM_SIZE: usize = 128 * 1024;
+        const LEN: u32 = 256;
+        let gva = 0x1_0000_0000u64;
+        let gpa = 0x4000u64;
+        let (_mem, mem_atomic, mut queue) = setup_vq(MEM_SIZE, gva, LEN, 0);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let ap = OffsetTranslator {
+            gva_base: gva,
+            gpa_base: gpa,
+        };
+        let mut it = chain.checked_iter(Some(&ap));
+        let desc = it
+            .next()
+            .unwrap()
+            .expect("translated descriptor must be Ok");
+        assert_eq!(desc.addr().0, gpa);
+        assert_eq!(desc.len(), LEN);
+    }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -176,3 +176,56 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod unit_tests {
+    use virtio_bindings::virtio_ring::VRING_DESC_F_WRITE;
+    use virtio_queue::{Queue, QueueT};
+    use vm_memory::bitmap::AtomicBitmap;
+    use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+
+    use super::*;
+    use crate::queue::testing::VirtQueue as GuestQ;
+
+    type TestMmap = GuestMemoryMmap<AtomicBitmap>;
+
+    /// Set up a single descriptor in a virtqueue backed by `mem_size` bytes
+    /// of guest RAM. Returns the guest memory, an atomic wrapper around it,
+    /// and the ready queue.
+    fn setup_vq(
+        mem_size: usize,
+        desc_addr: u64,
+        desc_len: u32,
+        desc_flags: u16,
+    ) -> (TestMmap, GuestMemoryAtomic<TestMmap>, Queue) {
+        const QSIZE: u16 = 2;
+
+        let mem = TestMmap::from_ranges(&[(GuestAddress(0), mem_size)]).unwrap();
+        let guest_vq = GuestQ::new(GuestAddress(0x1_0000), &mem, QSIZE);
+        let queue = guest_vq.create_queue();
+
+        guest_vq.dtable[0].set(desc_addr, desc_len, desc_flags, 0);
+        guest_vq.avail.ring[0].set(0);
+        guest_vq.avail.idx.set(1);
+
+        let mem_atomic = GuestMemoryAtomic::new(mem.clone());
+        (mem, mem_atomic, queue)
+    }
+
+    #[test]
+    fn yields_valid_single_descriptor() {
+        let (_mem, mem_atomic, mut queue) =
+            setup_vq(128 * 1024, 0x4000, 256, VRING_DESC_F_WRITE as u16);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let mut it = chain.checked_iter(None);
+        let desc = it
+            .next()
+            .unwrap()
+            .expect("valid descriptor must be yielded");
+        assert_eq!(desc.addr().0, 0x4000);
+        assert_eq!(desc.len(), 256);
+        assert!(desc.is_write_only());
+        assert!(it.next().is_none());
+    }
+}

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -336,4 +336,14 @@ mod unit_tests {
             .expect_err("validation must reject the descriptor");
         assert_eq!(err.0, 0x4000);
     }
+
+    #[test]
+    fn err_reports_rejected_address() {
+        let (_mem, mem_atomic, mut queue) = setup_vq(128 * 1024, 0x4000, 1 << 30, 0);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let mut it = chain.checked_iter(None);
+        let result = it.next().expect("must yield an item");
+        assert_eq!(result.unwrap_err(), GuestAddress(0x4000));
+    }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -325,4 +325,15 @@ mod unit_tests {
         let res = chain.next_checked(None);
         assert!(matches!(res, Ok(None)));
     }
+
+    #[test]
+    fn next_checked_returns_err_on_invalid_descriptor() {
+        let (_mem, mem_atomic, mut queue) = setup_vq(128 * 1024, 0x4000, 1 << 30, 0);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let err = chain
+            .next_checked(None)
+            .expect_err("validation must reject the descriptor");
+        assert_eq!(err.0, 0x4000);
+    }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -458,4 +458,16 @@ mod unit_tests {
         // translated one.
         assert_eq!(result.unwrap_err(), GuestAddress(gva));
     }
+
+    #[test]
+    fn exhausted_chain_returns_none() {
+        // After the iterator yields the only descriptor in the chain, the
+        // subsequent None must reflect exhaustion, not a validation failure.
+        let (_mem, mem_atomic, mut queue) = setup_vq(128 * 1024, 0x4000, 256, 0);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let mut it = chain.checked_iter(None);
+        it.next().unwrap().unwrap();
+        assert!(it.next().is_none());
+    }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -300,4 +300,17 @@ mod unit_tests {
         second.unwrap_err();
         assert!(it.next().is_none());
     }
+
+    #[test]
+    fn next_checked_returns_valid_descriptor() {
+        let (_mem, mem_atomic, mut queue) = setup_vq(128 * 1024, 0x4000, 256, 0);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let desc = chain
+            .next_checked(None)
+            .expect("validation must succeed")
+            .expect("descriptor must be present");
+        assert_eq!(desc.addr().0, 0x4000);
+        assert_eq!(desc.len(), 256);
+    }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -346,4 +346,20 @@ mod unit_tests {
         let result = it.next().expect("must yield an item");
         assert_eq!(result.unwrap_err(), GuestAddress(0x4000));
     }
+
+    #[test]
+    fn accepts_descriptor_at_memory_end() {
+        // 128 KiB of guest RAM ends at 0x20000. A descriptor whose buffer
+        // ends exactly at that boundary must be accepted.
+        const MEM_SIZE: usize = 128 * 1024;
+        const LEN: u32 = 256;
+        let addr = (MEM_SIZE as u64) - LEN as u64;
+        let (_mem, mem_atomic, mut queue) = setup_vq(MEM_SIZE, addr, LEN, 0);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let mut it = chain.checked_iter(None);
+        let desc = it.next().unwrap().expect("boundary descriptor must be Ok");
+        assert_eq!(desc.addr().0, addr);
+        assert_eq!(desc.len(), LEN);
+    }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -228,4 +228,14 @@ mod unit_tests {
         assert!(desc.is_write_only());
         assert!(it.next().is_none());
     }
+
+    #[test]
+    fn rejects_out_of_range_descriptor() {
+        let (_mem, mem_atomic, mut queue) = setup_vq(128 * 1024, 0x4000, 1 << 30, 0);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let mut it = chain.checked_iter(None);
+        let result = it.next().expect("iterator must yield an item");
+        result.unwrap_err();
+    }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -362,4 +362,19 @@ mod unit_tests {
         assert_eq!(desc.addr().0, addr);
         assert_eq!(desc.len(), LEN);
     }
+
+    #[test]
+    fn rejects_descriptor_one_past_memory_end() {
+        // A descriptor whose buffer extends one byte past the end of guest
+        // RAM must be rejected.
+        const MEM_SIZE: usize = 128 * 1024;
+        const LEN: u32 = 256;
+        let addr = (MEM_SIZE as u64) - LEN as u64 + 1;
+        let (_mem, mem_atomic, mut queue) = setup_vq(MEM_SIZE, addr, LEN, 0);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let mut it = chain.checked_iter(None);
+        let result = it.next().expect("must yield an item");
+        assert_eq!(result.unwrap_err(), GuestAddress(addr));
+    }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -179,7 +179,7 @@ where
 
 #[cfg(test)]
 mod unit_tests {
-    use virtio_bindings::virtio_ring::VRING_DESC_F_WRITE;
+    use virtio_bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
     use virtio_queue::{Queue, QueueT};
     use vm_memory::bitmap::AtomicBitmap;
     use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
@@ -205,6 +205,40 @@ mod unit_tests {
         let queue = guest_vq.create_queue();
 
         guest_vq.dtable[0].set(desc_addr, desc_len, desc_flags, 0);
+        guest_vq.avail.ring[0].set(0);
+        guest_vq.avail.idx.set(1);
+
+        let mem_atomic = GuestMemoryAtomic::new(mem.clone());
+        (mem, mem_atomic, queue)
+    }
+
+    /// Set up a chain of descriptors linked via VRING_DESC_F_NEXT in a
+    /// virtqueue backed by `mem_size` bytes of guest RAM. Each entry is
+    /// `(addr, len, flags)`; the helper adds the NEXT flag on every
+    /// descriptor except the last.
+    fn setup_vq_chain(
+        mem_size: usize,
+        descs: &[(u64, u32, u16)],
+    ) -> (TestMmap, GuestMemoryAtomic<TestMmap>, Queue) {
+        let qsize = descs.len() as u16;
+        assert!(qsize >= 1);
+
+        let mem = TestMmap::from_ranges(&[(GuestAddress(0), mem_size)]).unwrap();
+        let guest_vq = GuestQ::new(GuestAddress(0x1_0000), &mem, qsize);
+        let queue = guest_vq.create_queue();
+
+        let last = descs.len() - 1;
+        for (i, &(addr, len, flags)) in descs.iter().enumerate() {
+            let (flags, next) = if i < last {
+                (
+                    flags | u16::try_from(VRING_DESC_F_NEXT).unwrap(),
+                    (i + 1) as u16,
+                )
+            } else {
+                (flags, 0)
+            };
+            guest_vq.dtable[i].set(addr, len, flags, next);
+        }
         guest_vq.avail.ring[0].set(0);
         guest_vq.avail.idx.set(1);
 
@@ -250,5 +284,20 @@ mod unit_tests {
             .unwrap()
             .expect("zero length descriptor must pass through");
         assert_eq!(desc.len(), 0);
+    }
+
+    #[test]
+    fn yields_valid_prefix_then_err_on_invalid() {
+        let (_mem, mem_atomic, mut queue) =
+            setup_vq_chain(128 * 1024, &[(0x4000, 256, 0), (0x8000, 1 << 30, 0)]);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let mut it = chain.checked_iter(None);
+        let first = it.next().unwrap().expect("first descriptor must be Ok");
+        assert_eq!(first.addr().0, 0x4000);
+        assert_eq!(first.len(), 256);
+        let second = it.next().expect("second must yield an item");
+        second.unwrap_err();
+        assert!(it.next().is_none());
     }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -377,4 +377,19 @@ mod unit_tests {
         let result = it.next().expect("must yield an item");
         assert_eq!(result.unwrap_err(), GuestAddress(addr));
     }
+
+    #[test]
+    fn rejects_descriptor_with_address_overflow() {
+        // A descriptor whose addr plus len would wrap around the u64 address
+        // space must be rejected without panicking.
+        const MEM_SIZE: usize = 128 * 1024;
+        let addr = u64::MAX - 100;
+        let len: u32 = 1024;
+        let (_mem, mem_atomic, mut queue) = setup_vq(MEM_SIZE, addr, len, 0);
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let mut it = chain.checked_iter(None);
+        let result = it.next().expect("must yield an item");
+        assert_eq!(result.unwrap_err(), GuestAddress(addr));
+    }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -470,4 +470,34 @@ mod unit_tests {
         it.next().unwrap().unwrap();
         assert!(it.next().is_none());
     }
+
+    #[test]
+    fn accessors_reflect_underlying_descriptor() {
+        // Two descriptor chain: a non-empty writable head followed by a
+        // zero length tail. Verify the CheckedDescriptor accessors agree
+        // with the descriptor flags and length on each entry.
+        let (_mem, mem_atomic, mut queue) = setup_vq_chain(
+            128 * 1024,
+            &[(0x4000, 256, VRING_DESC_F_WRITE as u16), (0x5000, 0, 0)],
+        );
+        let mem_guard = mem_atomic.memory();
+        let mut chain = queue.pop_descriptor_chain(mem_guard).unwrap();
+        let mut it = chain.checked_iter(None);
+
+        let head = it.next().unwrap().expect("head must be Ok");
+        assert_eq!(head.addr().0, 0x4000);
+        assert_eq!(head.len(), 256);
+        assert!(!head.is_empty());
+        assert!(head.is_write_only());
+        assert!(head.has_next());
+
+        let tail = it.next().unwrap().expect("tail must be Ok");
+        assert_eq!(tail.addr().0, 0x5000);
+        assert_eq!(tail.len(), 0);
+        assert!(tail.is_empty());
+        assert!(!tail.is_write_only());
+        assert!(!tail.has_next());
+
+        assert!(it.next().is_none());
+    }
 }

--- a/vm-virtio/src/checked_descriptor.rs
+++ b/vm-virtio/src/checked_descriptor.rs
@@ -1,0 +1,178 @@
+// Copyright © 2026 Cloud Hypervisor Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Centralized descriptor buffer validation for virtio devices.
+//!
+//! This module provides [`CheckedDescriptorIter`], an iterator adapter over
+//! [`DescriptorChain`] that validates each descriptor's buffer range against
+//! guest memory before yielding it. Any descriptor whose translated
+//! `(addr, len)` range is not fully backed by guest RAM is rejected, so the
+//! device never performs I/O against memory the guest does not actually own.
+
+use std::ops::Deref;
+
+use log::warn;
+use virtio_queue::DescriptorChain;
+use virtio_queue::desc::split::Descriptor;
+use vm_memory::{GuestAddress, GuestMemory};
+
+use crate::{AccessPlatform, Translatable};
+
+/// A descriptor whose buffer range has been validated against guest memory.
+#[derive(Debug)]
+pub struct CheckedDescriptor {
+    inner: Descriptor,
+    /// The translated guest physical address.
+    addr: GuestAddress,
+}
+
+impl CheckedDescriptor {
+    pub fn addr(&self) -> GuestAddress {
+        self.addr
+    }
+
+    pub fn len(&self) -> u32 {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.len() == 0
+    }
+
+    pub fn is_write_only(&self) -> bool {
+        self.inner.is_write_only()
+    }
+
+    pub fn has_next(&self) -> bool {
+        self.inner.has_next()
+    }
+}
+
+/// Iterator adapter that validates each descriptor's buffer against guest
+/// memory before yielding it.
+///
+/// Each call to [`Iterator::next`] returns `Some(Ok(desc))` for a valid
+/// descriptor, `Some(Err(addr))` when validation rejects a descriptor
+/// (with the offending guest address), or `None` when the chain is
+/// exhausted.
+pub struct CheckedDescriptorIter<'a, M> {
+    chain: &'a mut DescriptorChain<M>,
+    access_platform: Option<&'a dyn AccessPlatform>,
+    done: bool,
+}
+
+impl<'a, M> CheckedDescriptorIter<'a, M>
+where
+    M: Deref,
+    M::Target: GuestMemory,
+{
+    pub fn new(
+        chain: &'a mut DescriptorChain<M>,
+        access_platform: Option<&'a dyn AccessPlatform>,
+    ) -> Self {
+        Self {
+            chain,
+            access_platform,
+            done: false,
+        }
+    }
+}
+
+impl<M> Iterator for CheckedDescriptorIter<'_, M>
+where
+    M: Deref,
+    M::Target: GuestMemory,
+{
+    type Item = Result<CheckedDescriptor, GuestAddress>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        let desc = self.chain.next()?;
+
+        // A zero length descriptor describes no buffer, so skip
+        // translation and range checks and let the device layer
+        // decide. See CVE-2023-5158 for why hosts must tolerate them.
+        if desc.len() == 0 {
+            return Some(Ok(CheckedDescriptor {
+                addr: desc.addr(),
+                inner: desc,
+            }));
+        }
+
+        let desc_addr = desc.addr();
+        let desc_len = desc.len() as usize;
+
+        let result = desc_addr
+            .translate_gva(self.access_platform, desc_len)
+            .map_err(|_| {
+                warn!(
+                    "Descriptor address translation failed: addr=0x{:x} len={}",
+                    desc_addr.0, desc_len
+                );
+                desc_addr
+            })
+            .and_then(|addr| {
+                if self.chain.memory().check_range(addr, desc_len) {
+                    Ok(CheckedDescriptor { inner: desc, addr })
+                } else {
+                    warn!(
+                        "Descriptor buffer extends past guest memory: addr=0x{:x} len={}",
+                        addr.0, desc_len
+                    );
+                    Err(addr)
+                }
+            });
+
+        if result.is_err() {
+            self.done = true;
+        }
+        Some(result)
+    }
+}
+
+/// Extension trait on [`DescriptorChain`] providing validated iteration.
+pub trait DescriptorChainExt<M> {
+    fn checked_iter<'a>(
+        &'a mut self,
+        access_platform: Option<&'a dyn AccessPlatform>,
+    ) -> CheckedDescriptorIter<'a, M>;
+
+    /// Fetch the next descriptor from the chain, validating its buffer range
+    /// against guest memory.
+    ///
+    /// Returns `Ok(None)` when the chain is exhausted, and
+    /// `Err(failing_addr)` when validation rejected a descriptor. Callers can
+    /// map the failing address into a domain specific error.
+    fn next_checked(
+        &mut self,
+        access_platform: Option<&dyn AccessPlatform>,
+    ) -> Result<Option<CheckedDescriptor>, GuestAddress>;
+}
+
+impl<M> DescriptorChainExt<M> for DescriptorChain<M>
+where
+    M: Deref,
+    M::Target: GuestMemory,
+{
+    fn checked_iter<'a>(
+        &'a mut self,
+        access_platform: Option<&'a dyn AccessPlatform>,
+    ) -> CheckedDescriptorIter<'a, M> {
+        CheckedDescriptorIter::new(self, access_platform)
+    }
+
+    fn next_checked(
+        &mut self,
+        access_platform: Option<&dyn AccessPlatform>,
+    ) -> Result<Option<CheckedDescriptor>, GuestAddress> {
+        match self.checked_iter(access_platform).next() {
+            Some(Ok(desc)) => Ok(Some(desc)),
+            Some(Err(addr)) => Err(addr),
+            None => Ok(None),
+        }
+    }
+}

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -15,6 +15,7 @@ use std::fmt::{self, Debug};
 use virtio_queue::{Queue, QueueT};
 use vm_memory::GuestAddress;
 
+pub mod checked_descriptor;
 pub mod queue;
 pub use queue::*;
 


### PR DESCRIPTION
Introduce a centralized helper in `vm-virtio` that validates virtio descriptor ranges and, when applicable, translates them through an `AccessPlatform`. Migrate the existing virtio devices to use it instead of open coding the same checks (or, in several cases, not checking at all).

## Motivation

Every virtio backend has to verify that descriptor buffers actually fit inside guest memory before reading or writing them, and that the address arithmetic does not overflow. Today this is repeated (with small variations) in each device and, in a few places, missing entirely. Centralizing the check removes the duplication, makes the overflow and bounds rules consistent, and gives a single place to plug in `AccessPlatform` translation.

## Changes

- `vm-virtio`: new `checked_descriptor` module with unit tests covering happy path, exhaustion, out of range, zero length, boundary, one past end, address overflow, `AccessPlatform` translation success and failure, error reporting via `failed_addr`, and accessor round trip.
- Devices were migrated, no behavior change for well behaved guests. Malformed chains are now consistently rejected with a logged error:
  - `block`
  - `virtio-devices`: `console`, `rng`, `balloon`, `watchdog`, `pmem`, `mem`, `iommu`, `vsock`

Supersedes #8197