### PR TITLE
vmm: arch: vm-allocator: introduce dedicated device-memory GPA region

### DIFF
--- a/arch/src/aarch64/layout.rs
+++ b/arch/src/aarch64/layout.rs
@@ -147,3 +147,9 @@ pub const GICV2M_SPI_NUM: u32 = 64;
 
 /// GICv2M compatible string
 pub const GIC_V2M_COMPATIBLE: &str = "arm,gic-v2m-frame";
+
+/// Alignment used for the base of the guest-physical "device memory"
+/// region that hosts memory-device GPAs (virtio-pmem, virtio-mem, future
+/// pc-dimm-equivalents). Mirrors QEMU's machine memory-device region,
+/// which aligns the region base to 1 GiB above the top of RAM.
+pub const DEVICE_MEMORY_ALIGN: u64 = 1 << 30;

--- a/arch/src/riscv64/layout.rs
+++ b/arch/src/riscv64/layout.rs
@@ -115,3 +115,9 @@ pub const IRQ_BASE: u32 = 0;
 // As per https://elixir.bootlin.com/linux/v6.10/source/arch/riscv/include/asm/kvm_host.h#L31
 /// Number of supported interrupts
 pub const IRQ_NUM: u32 = 1023;
+
+/// Alignment used for the base of the guest-physical "device memory"
+/// region that hosts memory-device GPAs (virtio-pmem, virtio-mem, future
+/// pc-dimm-equivalents). Mirrors QEMU's machine memory-device region,
+/// which aligns the region base to 1 GiB above the top of RAM.
+pub const DEVICE_MEMORY_ALIGN: u64 = 1 << 30;

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -123,3 +123,9 @@ pub const APIC_START: GuestAddress = GuestAddress(0xfee0_0000);
 
 // ** 64-bit RAM start (start: 4GiB, length: varies) **
 pub const RAM_64BIT_START: GuestAddress = GuestAddress(0x1_0000_0000);
+
+/// Alignment used for the base of the guest-physical "device memory"
+/// region that hosts memory-device GPAs (virtio-pmem, virtio-mem, future
+/// pc-dimm-equivalents). Mirrors QEMU's `pc_get_device_memory_range()`
+/// which aligns the region base to 1 GiB above the top of RAM.
+pub const DEVICE_MEMORY_ALIGN: u64 = 1 << 30;

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -988,6 +988,7 @@ mod unit_tests {
                 prefault: false,
                 zones: None,
                 thp: true,
+                device_memory_size: None,
             },
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -22,11 +22,12 @@ struct MemoryConfig {
     prefault: bool,
     thp: bool,
     zones: Option<Vec<MemoryZoneConfig>>,
+    device_memory_size: Option<u64>,
 }
 ```
 
 ```
---memory <memory>	Memory parameters "size=<guest_memory_size>,mergeable=on|off,shared=on|off,hugepages=on|off,hugepage_size=<hugepage_size>,hotplug_method=acpi|virtio-mem,hotplug_size=<hotpluggable_memory_size>,hotplugged_size=<hotplugged_memory_size>,prefault=on|off,thp=on|off" [default: size=512M,thp=on]
+--memory <memory>	Memory parameters "size=<guest_memory_size>,mergeable=on|off,shared=on|off,hugepages=on|off,hugepage_size=<hugepage_size>,hotplug_method=acpi|virtio-mem,hotplug_size=<hotpluggable_memory_size>,hotplugged_size=<hotplugged_memory_size>,prefault=on|off,thp=on|off,device_memory_size=<device_memory_size>" [default: size=512M,thp=on]
 ```
 
 ### `size`
@@ -194,6 +195,31 @@ _Example_
 
 ```
 --memory size=1G,thp=on
+```
+
+### `device_memory_size`
+
+Total size of the dedicated guest-physical "device memory" region that hosts
+memory-device GPAs: virtio-pmem, virtio-mem zones, and ACPI RAM hot-plug
+slots. The region is anchored at a 1 GiB-aligned GPA immediately above guest
+RAM, mirroring QEMU's machine `device_memory` region
+(`hw/i386/pc.c::pc_get_device_memory_range`).
+
+When unset (the default), the size is derived from the sum of declared
+`hotplug_size` values across the default zone or all `--memory-zone`s,
+preserving today's layout for unmodified configurations.
+
+When set to `0`, the region is omitted entirely and Cloud Hypervisor falls
+back to the legacy bump-pointer layout above RAM.
+
+Increasing this value above the implicit default reserves headroom for
+future virtio-pmem hot-adds without consuming address space from the
+per-segment PCI64 BAR window.
+
+_Example_
+
+```
+--memory size=4G,hotplug_size=8G,device_memory_size=16G
 ```
 
 ## Advanced Parameters

--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -151,6 +151,7 @@ impl RequestHandler for StubApiRequestHandler {
                     prefault: false,
                     zones: None,
                     thp: true,
+                    device_memory_size: None,
                 },
                 payload: Some(PayloadConfig {
                     kernel: Some(PathBuf::from("/path/to/kernel")),

--- a/vm-allocator/src/address.rs
+++ b/vm-allocator/src/address.rs
@@ -123,6 +123,9 @@ impl AddressAllocator {
         Err(Error::Overflow)
     }
 
+    /// Top-down (highest-fit) search for a free range of `req_size` bytes
+    /// aligned to `alignment`. Used by `allocate(None, …)` so that ranges
+    /// accumulate at the high end of the address space.
     fn first_available_range(
         &self,
         req_size: GuestUsize,
@@ -160,6 +163,32 @@ impl AddressAllocator {
         None
     }
 
+    /// Bottom-up (first-fit) search for a free range of `req_size` bytes
+    /// aligned to `alignment`. Unlike `first_available_range`, which scans
+    /// from the end and packs ranges at the top of the address space, this
+    /// scans from the start and packs ranges just above `self.base`. Used
+    /// by `allocate_first_fit` for callers that prefer low GPAs (e.g.
+    /// virtio-pmem placement just above guest RAM).
+    fn first_available_range_low(
+        &self,
+        req_size: GuestUsize,
+        alignment: GuestUsize,
+    ) -> Option<GuestAddress> {
+        let mut prev_end_address = self.base;
+
+        for (address, size) in self.ranges.iter() {
+            let aligned = self.align_address(prev_end_address, alignment);
+            if let Some(size_delta) = address.checked_sub(aligned.raw_value())
+                && size_delta.raw_value() >= req_size
+            {
+                return Some(aligned);
+            }
+            prev_end_address = address.unchecked_add(*size);
+        }
+
+        None
+    }
+
     /// Allocates a range of addresses from the managed region. Returns `Some(allocated_address)`
     /// when successful, or `None` if an area of `size` can't be allocated or if alignment isn't
     /// a power of two.
@@ -186,6 +215,47 @@ impl AddressAllocator {
                 }
             },
             None => self.first_available_range(size, alignment)?,
+        };
+
+        self.ranges.insert(new_addr, size);
+
+        Some(new_addr)
+    }
+
+    /// Allocates a range of addresses from the managed region using a
+    /// bottom-up (first-fit) search. When `address` is `Some(_)`, this
+    /// behaves identically to `allocate` (the explicit base is honored
+    /// verbatim). When `address` is `None`, the lowest free hole that
+    /// fits is returned, instead of the highest hole returned by
+    /// `allocate`.
+    ///
+    /// This is intended for callers that want ranges packed at the start
+    /// of the address space (e.g. virtio-pmem placement just above guest
+    /// RAM), while still sharing the same allocator with other top-down
+    /// consumers.
+    pub fn allocate_first_fit(
+        &mut self,
+        address: Option<GuestAddress>,
+        size: GuestUsize,
+        align_size: Option<GuestUsize>,
+    ) -> Option<GuestAddress> {
+        if size == 0 {
+            return None;
+        }
+
+        let alignment = align_size.unwrap_or(4);
+        if !alignment.is_power_of_two() || alignment == 0 {
+            return None;
+        }
+
+        let new_addr = match address {
+            Some(req_address) => match self.available_range(req_address, size, alignment) {
+                Ok(addr) => addr,
+                Err(_) => {
+                    return None;
+                }
+            },
+            None => self.first_available_range_low(size, alignment)?,
         };
 
         self.ranges.insert(new_addr, size);

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -878,6 +878,14 @@ components:
         thp:
           type: boolean
           default: true
+        device_memory_size:
+          type: integer
+          format: int64
+          description: |
+            Total size of the dedicated guest-physical "device memory" region
+            hosting memory-device GPAs (virtio-pmem, virtio-mem zones, future
+            pc-dimm-equivalents). When unset, the size is derived from the
+            declared hotplug_size plus headroom for pmem devices.
         zones:
           type: array
           items:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -968,7 +968,8 @@ impl MemoryConfig {
             .add("hugepages")
             .add("hugepage_size")
             .add("prefault")
-            .add("thp");
+            .add("thp")
+            .add("device_memory_size");
         parser.parse(memory).map_err(Error::ParseMemory)?;
 
         let size = parser
@@ -1017,6 +1018,10 @@ impl MemoryConfig {
             .map_err(Error::ParseMemory)?
             .unwrap_or(Toggle(true))
             .0;
+        let device_memory_size = parser
+            .convert::<ByteSized>("device_memory_size")
+            .map_err(Error::ParseMemory)?
+            .map(|v| v.0);
 
         let zones: Option<Vec<MemoryZoneConfig>> = if let Some(memory_zones) = &memory_zones {
             let mut zones = Vec::new();
@@ -1111,6 +1116,7 @@ impl MemoryConfig {
             prefault,
             zones,
             thp,
+            device_memory_size,
         })
     }
 
@@ -5021,6 +5027,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 prefault: false,
                 zones: None,
                 thp: true,
+                device_memory_size: None,
             },
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3315,27 +3315,71 @@ impl DeviceManager {
         let (region_base, region_size) = if let Some((base, size)) = region_range {
             // The memory needs to be 2MiB aligned in order to support
             // hugepages.
-            self.pci_segments[pmem_cfg.pci_common.pci_segment as usize]
-                .mem64_allocator
-                .lock()
-                .unwrap()
-                .allocate(
+            //
+            // Restore path: honour the GPA recorded in the snapshot.
+            // Try the device-memory region first when present (newer
+            // snapshots that already lived inside it); fall back to
+            // the per-segment 64-bit MMIO window for snapshots taken
+            // before the device-memory region was introduced.
+            let mm = self.memory_manager.lock().unwrap();
+            let allocated = if let Some(device_memory) = mm.device_memory()
+                && (device_memory.base().raw_value()..device_memory.top().raw_value())
+                    .contains(&base)
+            {
+                device_memory.allocator().lock().unwrap().allocate(
                     Some(GuestAddress(base)),
                     size as GuestUsize,
                     Some(0x0020_0000),
                 )
-                .ok_or(DeviceManagerError::PmemRangeAllocation)?;
+            } else {
+                self.pci_segments[pmem_cfg.pci_common.pci_segment as usize]
+                    .mem64_allocator
+                    .lock()
+                    .unwrap()
+                    .allocate(
+                        Some(GuestAddress(base)),
+                        size as GuestUsize,
+                        Some(0x0020_0000),
+                    )
+            };
+            drop(mm);
+            allocated.ok_or(DeviceManagerError::PmemRangeAllocation)?;
 
             (base, size)
         } else {
             // The memory needs to be 2MiB aligned in order to support
             // hugepages.
-            let base = self.pci_segments[pmem_cfg.pci_common.pci_segment as usize]
-                .mem64_allocator
-                .lock()
-                .unwrap()
-                .allocate(None, size as GuestUsize, Some(0x0020_0000))
-                .ok_or(DeviceManagerError::PmemRangeAllocation)?;
+            //
+            // QEMU places nvdimm / virtio-pmem inside a single
+            // device-memory region anchored just above guest RAM
+            // (`hw/i386/pc.c::pc_get_device_memory_range` +
+            // `hw/mem/memory-device.c::memory_device_get_free_addr`).
+            // Mirror that here: prefer the dedicated `device_memory`
+            // window when the memory manager set one up. The window
+            // is segment-agnostic, matching QEMU and avoiding the
+            // top-of-mem64 placement that pushes pmem above guest
+            // kernel MAXMEM ceilings on hosts with large
+            // `phys_bits`.
+            //
+            // When no device-memory region exists (e.g. plain VMs
+            // without declared `hotplug_size` / `device_memory_size`),
+            // fall back to the legacy per-segment 64-bit MMIO window.
+            let mm = self.memory_manager.lock().unwrap();
+            let base = if let Some(device_memory) = mm.device_memory() {
+                device_memory
+                    .allocator()
+                    .lock()
+                    .unwrap()
+                    .allocate_first_fit(None, size as GuestUsize, Some(0x0020_0000))
+            } else {
+                self.pci_segments[pmem_cfg.pci_common.pci_segment as usize]
+                    .mem64_allocator
+                    .lock()
+                    .unwrap()
+                    .allocate(None, size as GuestUsize, Some(0x0020_0000))
+            }
+            .ok_or(DeviceManagerError::PmemRangeAllocation)?;
+            drop(mm);
 
             (base.raw_value(), size)
         };

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2712,6 +2712,7 @@ mod unit_tests {
                 prefault: false,
                 zones: None,
                 thp: true,
+                device_memory_size: None,
             },
             payload: Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1622,6 +1622,36 @@ impl MemoryManager {
             let guest_memory =
                 GuestMemoryMmap::from_arc_regions(regions).map_err(Error::GuestRegionCollection)?;
             let boot_guest_memory = guest_memory.clone();
+            // Rebuild the dedicated device-memory region from the
+            // saved (base, size) when present. Re-reserve every
+            // virtio-mem zone at its saved GPA so subsequent
+            // memory-device allocations (e.g. virtio-pmem hot-add)
+            // don't hand out overlapping addresses. Snapshots
+            // produced before this field was added carry `None` and
+            // fall back to the legacy bump-pointer layout via the
+            // saved `start_of_device_area`.
+            let device_memory = if let Some((base, size)) = data.device_memory {
+                let region = DeviceMemoryRegion::new(GuestAddress(base), size)?;
+                for zone in memory_zones.values() {
+                    if let Some(virtio_mem_zone) = zone.virtio_mem_zone() {
+                        let mem_region = virtio_mem_zone.region();
+                        region
+                            .allocator()
+                            .lock()
+                            .unwrap()
+                            .allocate(
+                                Some(mem_region.start_addr()),
+                                mem_region.len(),
+                                Some(virtio_devices::VIRTIO_MEM_ALIGN_SIZE),
+                            )
+                            .ok_or(Error::MemoryRangeAllocation)?;
+                    }
+                }
+                Some(region)
+            } else {
+                None
+            };
+
             (
                 GuestAddress(data.start_of_device_area),
                 data.boot_ram,
@@ -1634,12 +1664,7 @@ impl MemoryManager {
                 data.next_memory_slot,
                 data.selected_slot,
                 data.next_hotplug_slot,
-                // Snapshots produced by this commit do not yet record the
-                // device-memory region; restore replays the original
-                // top-down layout via the saved `start_of_device_area`.
-                // A later commit in this series adds an optional snapshot
-                // field and reconstructs the region on restore.
-                None,
+                device_memory,
             )
         } else {
             // Init guest memory
@@ -2769,6 +2794,10 @@ impl MemoryManager {
             next_memory_slot: self.next_memory_slot.load(Ordering::SeqCst),
             selected_slot: self.selected_slot,
             next_hotplug_slot: self.next_hotplug_slot,
+            device_memory: self
+                .device_memory
+                .as_ref()
+                .map(|r| (r.base().raw_value(), r.size())),
         }
     }
 
@@ -3227,6 +3256,13 @@ pub struct MemoryManagerSnapshotData {
     next_memory_slot: u32,
     selected_slot: usize,
     next_hotplug_slot: usize,
+    /// (base, size) of the dedicated device-memory region, when one was
+    /// in use at snapshot time. `None` for snapshots produced before the
+    /// region was introduced; the restore path falls back to the legacy
+    /// `start_of_device_area` layout in that case so older snapshots
+    /// continue to map at their original GPAs.
+    #[serde(default)]
+    device_memory: Option<(u64, u64)>,
 }
 
 impl Snapshottable for MemoryManager {

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -328,6 +328,12 @@ pub struct MemoryManager {
     ram_allocator: AddressAllocator,
     dynamic: bool,
 
+    /// Dedicated guest-physical region for memory devices (virtio-pmem,
+    /// virtio-mem, future pc-dimm-equivalents), mirroring QEMU's
+    /// machine `device_memory` region. `None` until the constructor in a
+    /// subsequent commit starts populating it.
+    device_memory: Option<DeviceMemoryRegion>,
+
     // Keep track of calls to create_userspace_mapping() for guest RAM.
     // This is useful for getting the dirty pages as we need to know the
     // slots that the mapping is created in.
@@ -1813,6 +1819,7 @@ impl MemoryManager {
             arch_mem_regions,
             ram_allocator,
             dynamic,
+            device_memory: None,
             #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
             uefi_flash: None,
             thp: config.thp,
@@ -2336,6 +2343,16 @@ impl MemoryManager {
 
     pub fn end_of_device_area(&self) -> GuestAddress {
         self.end_of_device_area
+    }
+
+    /// Dedicated GPA region for memory devices (virtio-pmem, virtio-mem,
+    /// future pc-dimm-equivalents). Currently `None`; the constructor in a
+    /// subsequent commit in this series will populate it when either
+    /// `MemoryConfig::device_memory_size` is set or memory-device hotplug
+    /// requirements imply a non-empty default size.
+    #[allow(dead_code)] // TODO: callers added by subsequent commits in this series.
+    pub(crate) fn device_memory(&self) -> Option<&DeviceMemoryRegion> {
+        self.device_memory.as_ref()
     }
 
     pub fn memory_slot_allocator(&mut self) -> MemorySlotAllocator {

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -235,6 +235,69 @@ struct ArchMemRegion {
     r_type: RegionType,
 }
 
+/// Dedicated guest-physical address region that hosts memory-device GPAs
+/// (virtio-pmem, virtio-mem zones, future pc-dimm-equivalents).
+///
+/// The region is anchored at a 1 GiB-aligned GPA immediately above guest
+/// RAM and sized either explicitly via `MemoryConfig::device_memory_size`
+/// or implicitly from the sum of declared `hotplug_size`/`pmem` headroom.
+/// This mirrors QEMU's `MachineState::device_memory` (see
+/// `hw/i386/pc.c::pc_get_device_memory_range`) and replaces the prior
+/// behaviour where pmem regions were placed at the top of the per-PCI-
+/// segment 64-bit MMIO window — that placement collided with guest
+/// kernel MAXMEM ceilings on hosts that advertise large `phys_bits`
+/// (e.g. 48 on bare-metal MSHV).
+///
+/// PCI64 BAR allocation continues to use the per-segment `mem64_allocator`
+/// and is unaffected by this region; the two windows are disjoint.
+#[allow(dead_code)] // TODO: wired up by subsequent commits in this series.
+pub(crate) struct DeviceMemoryRegion {
+    /// Inclusive base GPA of the region.
+    base: GuestAddress,
+    /// Size of the region in bytes.
+    size: u64,
+    /// Bottom-up first-fit allocator scoped to `[base, base+size)`.
+    allocator: Arc<Mutex<AddressAllocator>>,
+}
+
+#[allow(dead_code)] // TODO: wired up by subsequent commits in this series.
+impl DeviceMemoryRegion {
+    /// Construct a new region. `base` is expected to already be aligned to
+    /// `DEVICE_MEMORY_ALIGN`; callers should round up before invoking.
+    pub(crate) fn new(base: GuestAddress, size: u64) -> Result<Self, Error> {
+        let allocator =
+            AddressAllocator::new(base, size).ok_or(Error::CreateDeviceMemoryAllocator)?;
+        Ok(Self {
+            base,
+            size,
+            allocator: Arc::new(Mutex::new(allocator)),
+        })
+    }
+
+    pub(crate) fn base(&self) -> GuestAddress {
+        self.base
+    }
+
+    pub(crate) fn size(&self) -> u64 {
+        self.size
+    }
+
+    /// Inclusive last GPA of the region.
+    pub(crate) fn end(&self) -> GuestAddress {
+        self.base.unchecked_add(self.size.saturating_sub(1))
+    }
+
+    /// First GPA *above* the region (exclusive). Suitable as the base for
+    /// the next downstream window (e.g. PCI64 mem64 allocator).
+    pub(crate) fn top(&self) -> GuestAddress {
+        self.base.unchecked_add(self.size)
+    }
+
+    pub(crate) fn allocator(&self) -> Arc<Mutex<AddressAllocator>> {
+        Arc::clone(&self.allocator)
+    }
+}
+
 pub struct MemoryManager {
     boot_guest_memory: GuestMemoryMmap,
     guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
@@ -345,6 +408,10 @@ pub enum Error {
     /// Cannot create the system allocator
     #[error("Cannot create the system allocator")]
     CreateSystemAllocator,
+
+    /// Cannot create the device-memory region allocator
+    #[error("Cannot create the device-memory region allocator")]
+    CreateDeviceMemoryAllocator,
 
     /// Failed creating a new MmapRegion instance.
     #[cfg(target_arch = "x86_64")]

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -250,7 +250,6 @@ struct ArchMemRegion {
 ///
 /// PCI64 BAR allocation continues to use the per-segment `mem64_allocator`
 /// and is unaffected by this region; the two windows are disjoint.
-#[allow(dead_code)] // TODO: wired up by subsequent commits in this series.
 pub(crate) struct DeviceMemoryRegion {
     /// Inclusive base GPA of the region.
     base: GuestAddress,
@@ -260,7 +259,7 @@ pub(crate) struct DeviceMemoryRegion {
     allocator: Arc<Mutex<AddressAllocator>>,
 }
 
-#[allow(dead_code)] // TODO: wired up by subsequent commits in this series.
+#[allow(dead_code)] // TODO: top()/end() accessors used by later commits in this series.
 impl DeviceMemoryRegion {
     /// Construct a new region. `base` is expected to already be aligned to
     /// `DEVICE_MEMORY_ALIGN`; callers should round up before invoking.
@@ -1611,6 +1610,7 @@ impl MemoryManager {
             next_memory_slot,
             selected_slot,
             next_hotplug_slot,
+            device_memory,
         ) = if let Some(data) = restore_data {
             let (regions, memory_zones) = Self::restore_memory_regions_and_zones(
                 &data.guest_ram_mappings,
@@ -1634,6 +1634,12 @@ impl MemoryManager {
                 data.next_memory_slot,
                 data.selected_slot,
                 data.next_hotplug_slot,
+                // Snapshots produced by this commit do not yet record the
+                // device-memory region; restore replays the original
+                // top-down layout via the saved `start_of_device_area`.
+                // A later commit in this series adds an optional snapshot
+                // field and reconstructs the region on restore.
+                None,
             )
         } else {
             // Init guest memory
@@ -1662,8 +1668,54 @@ impl MemoryManager {
 
             let boot_guest_memory = guest_memory.clone();
 
-            let mut start_of_device_area =
+            let top_of_ram =
                 MemoryManager::start_addr(guest_memory.last_addr(), allow_mem_hotplug)?;
+
+            // Total hotplug capacity declared across all zones. For the
+            // default-zone case (`!user_provided_zones`) this is exactly
+            // `config.hotplug_size`; for user-provided zones it is the
+            // sum of per-zone `hotplug_size`. Either way it matches the
+            // amount of address space the legacy layout would have
+            // reserved above guest RAM.
+            let default_device_memory_size: u64 = zones.iter().filter_map(|z| z.hotplug_size).sum();
+            let device_memory_size = config
+                .device_memory_size
+                .unwrap_or(default_device_memory_size);
+
+            // Build the dedicated device-memory region 1 GiB-aligned
+            // above the top of guest RAM, mirroring QEMU's
+            // `pc_get_device_memory_range()`. The region hosts
+            // virtio-mem zones (and, in later commits, virtio-pmem and
+            // future pc-dimm-equivalents). When the resulting size is
+            // zero the region is skipped entirely so plain VMs without
+            // memory devices preserve their current layout bit-for-bit.
+            let device_memory = if device_memory_size > 0 {
+                let device_memory_base = GuestAddress(
+                    top_of_ram.0.div_ceil(arch::layout::DEVICE_MEMORY_ALIGN)
+                        * arch::layout::DEVICE_MEMORY_ALIGN,
+                );
+                let device_memory_top = device_memory_base
+                    .0
+                    .checked_add(device_memory_size)
+                    .ok_or(Error::GuestAddressOverFlow)?;
+                if device_memory_top > end_of_device_area.0.saturating_add(1) {
+                    error!(
+                        "device-memory region [{:#x}, {:#x}) exceeds available device area \
+                         end {:#x}; reduce `device_memory_size`/`hotplug_size` or raise \
+                         `phys_bits`",
+                        device_memory_base.0, device_memory_top, end_of_device_area.0
+                    );
+                    return Err(Error::InsufficientHotplugRam);
+                }
+                Some(DeviceMemoryRegion::new(
+                    device_memory_base,
+                    device_memory_size,
+                )?)
+            } else {
+                None
+            };
+
+            let mut start_of_device_area = top_of_ram;
 
             // Update list of memory zones for resize.
             for zone in zones.iter() {
@@ -1675,17 +1727,51 @@ impl MemoryManager {
                         }
 
                         if !user_provided_zones && config.hotplug_method == HotplugMethod::Acpi {
-                            start_of_device_area = start_of_device_area
-                                .checked_add(hotplug_size)
-                                .ok_or(Error::GuestAddressOverFlow)?;
+                            // ACPI RAM hotplug: reserve the requested
+                            // capacity at the bottom of the
+                            // device-memory region so it sits in the
+                            // same address window as future memory
+                            // devices. With no region present, fall
+                            // back to the legacy bump above
+                            // `start_of_device_area`.
+                            if let Some(region) = device_memory.as_ref() {
+                                region
+                                    .allocator()
+                                    .lock()
+                                    .unwrap()
+                                    .allocate_first_fit(None, hotplug_size, Some(128 << 20))
+                                    .ok_or(Error::InsufficientHotplugRam)?;
+                            } else {
+                                start_of_device_area = start_of_device_area
+                                    .checked_add(hotplug_size)
+                                    .ok_or(Error::GuestAddressOverFlow)?;
+                            }
                         } else {
-                            // Alignment must be "natural" i.e. same as size of block
-                            let start_addr = GuestAddress(
-                                start_of_device_area
-                                    .0
-                                    .div_ceil(virtio_devices::VIRTIO_MEM_ALIGN_SIZE)
-                                    * virtio_devices::VIRTIO_MEM_ALIGN_SIZE,
-                            );
+                            // virtio-mem zone: place inside the
+                            // device-memory region when present
+                            // (bottom-up first-fit, matching QEMU's
+                            // memory-device allocator). Fall back to
+                            // the legacy "just above RAM, naturally
+                            // aligned" bump when the region is absent.
+                            let start_addr = if let Some(region) = device_memory.as_ref() {
+                                region
+                                    .allocator()
+                                    .lock()
+                                    .unwrap()
+                                    .allocate_first_fit(
+                                        None,
+                                        hotplug_size,
+                                        Some(virtio_devices::VIRTIO_MEM_ALIGN_SIZE),
+                                    )
+                                    .ok_or(Error::InsufficientHotplugRam)?
+                            } else {
+                                GuestAddress(
+                                    start_of_device_area
+                                        .0
+                                        .div_ceil(virtio_devices::VIRTIO_MEM_ALIGN_SIZE)
+                                        * virtio_devices::VIRTIO_MEM_ALIGN_SIZE,
+                                )
+                            };
 
                             // When `prefault` is set by vm_restore, memory manager
                             // will create ram region with `prefault` option in
@@ -1718,14 +1804,23 @@ impl MemoryManager {
                                 blocks_state: Arc::new(Mutex::new(BlocksState::new(region_size))),
                             });
 
-                            start_of_device_area = start_addr
-                                .checked_add(hotplug_size)
-                                .ok_or(Error::GuestAddressOverFlow)?;
+                            if device_memory.is_none() {
+                                start_of_device_area = start_addr
+                                    .checked_add(hotplug_size)
+                                    .ok_or(Error::GuestAddressOverFlow)?;
+                            }
                         }
                     }
                 } else {
                     return Err(Error::MissingZoneIdentifier);
                 }
+            }
+
+            // Anchor PCI64 BAR window above the device-memory region
+            // when present, otherwise keep the legacy boundary that
+            // was bumped by the per-zone loop above.
+            if let Some(region) = device_memory.as_ref() {
+                start_of_device_area = region.top();
             }
 
             let mut hotplug_slots = Vec::with_capacity(HOTPLUG_COUNT);
@@ -1743,6 +1838,7 @@ impl MemoryManager {
                 0,
                 0,
                 0,
+                device_memory,
             )
         };
 
@@ -1819,7 +1915,7 @@ impl MemoryManager {
             arch_mem_regions,
             ram_allocator,
             dynamic,
-            device_memory: None,
+            device_memory,
             #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
             uefi_flash: None,
             thp: config.thp,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -230,6 +230,14 @@ pub struct MemoryConfig {
     pub zones: Option<Vec<MemoryZoneConfig>>,
     #[serde(default = "default_memoryconfig_thp")]
     pub thp: bool,
+    /// Total size of the dedicated guest-physical "device memory" region
+    /// that hosts memory-device GPAs (virtio-pmem, virtio-mem zones,
+    /// future pc-dimm-equivalents). Mirrors QEMU's `maxmem - mem` minus
+    /// the per-slot reservation: when `None`, the size is derived from
+    /// the declared `hotplug_size` plus headroom for pmem devices, which
+    /// preserves the historical behaviour for unmodified configurations.
+    #[serde(default)]
+    pub device_memory_size: Option<u64>,
 }
 
 pub const DEFAULT_MEMORY_MB: u64 = 512;
@@ -248,6 +256,7 @@ impl Default for MemoryConfig {
             prefault: false,
             zones: None,
             thp: true,
+            device_memory_size: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Introduce a dedicated guest-physical address (GPA) region for memory
devices (virtio-pmem, virtio-mem, future pc-dimm-equivalents), modeled
after QEMU's `MachineState::device_memory` /
`pc_get_device_memory_range()`. The region is anchored at a
1 GiB-aligned GPA immediately above guest RAM and is sized either
explicitly via the new `MemoryConfig::device_memory_size` knob or
implicitly from the sum of declared `hotplug_size` / pmem headroom.

This replaces the prior behaviour where virtio-pmem regions were placed
at the top of the per-PCI-segment 64-bit MMIO window. That placement
collided with guest-kernel `MAXMEM` ceilings on hosts that advertise
large `phys_bits` (e.g. 48 on bare-metal MSHV), causing pmem mappings
to land above the guest's addressable RAM ceiling and fail to attach.

PCI64 BAR allocation continues to use the per-segment `mem64_allocator`
and is unaffected â€” the two windows are disjoint.

## Motivation

On hosts exposing 48-bit physical addressing (common on MSHV / modern
EPYC), Cloud Hypervisor placed `virtio-pmem` regions at the top of the
64-bit MMIO window, which can sit well above what the guest kernel
treats as addressable RAM. The guest then refuses to bring the pmem
device online. QEMU avoids this by carving out a dedicated
`device_memory` window just above guest RAM, and using a bottom-up
first-fit allocator inside it for all memory devices. This series
brings the same model to Cloud Hypervisor.

## Design

- New `arch::layout::DEVICE_MEMORY_ALIGN = 1 GiB` constant defines the
  region's base alignment (matches QEMU).
- New `DeviceMemoryRegion` wrapper owns the `(base, size)` pair plus a
  bottom-up `AddressAllocator` used for placing every memory device.
- New `MemoryConfig.device_memory_size` API knob (optional). When
  omitted, the default size is the sum of all declared `hotplug_size`
  values, so existing configurations preserve their address layout.
- `MemoryManager::new()` builds the `DeviceMemoryRegion` once at boot,
  reserves any ACPI / virtio-mem zones inside it via
  `allocate_first_fit`, and anchors `start_of_device_area` at the
  region's top so the PCI64 window starts right above it.
- `virtio-pmem` hot-add now allocates from the device-memory region
  instead of the PCI64 MMIO window.
- Snapshot format gains an optional `(base, size)` tuple so the region
  is rebuilt on restore. Snapshots produced before this change carry
  `None` and fall back to the legacy bump-pointer layout â€” restore is
  backwards-compatible.

## Backwards Compatibility

- **VMs without memory devices**: `device_memory_size` defaults to 0,
  no region is created, layout is bit-for-bit identical to today.
- **Existing virtio-mem / hotplug_size configs**: default size matches
  the previously-reserved bump-pointer span; placement shifts to a
  1 GiB-aligned base above RAM (was naturally aligned to the zone's
  alignment requirement, typically 128 MiB / 2 MiB). Guests see the
  same amount of hotpluggable capacity.
- **Snapshot/restore**: old snapshots restore via the legacy code path
  (no region rebuilt). New snapshots carry the region descriptor.
- **PCI64 BAR window**: unchanged allocator, simply starts higher when
  the device-memory region is present.

## Commits

| # | Commit | Description |
|---|--------|-------------|
| 1 | `arch: add DEVICE_MEMORY_ALIGN constant for memory-device region` | 1 GiB alignment constant. |
| 2 | `vmm: introduce DeviceMemoryRegion wrapper` | New `(base, size, AddressAllocator)` wrapper type. |
| 3 | `vmm: openapi: add MemoryConfig.device_memory_size knob` | Public API knob + OpenAPI spec. |
| 4 | `vmm: add device_memory field to MemoryManager` | Plumb `Option<DeviceMemoryRegion>` through `MemoryManager`. |
| 5 | `vm-allocator: add allocate_first_fit bottom-up API` | Bottom-up first-fit allocator (mirrors QEMU's memory-device allocator). |
| 6 | `vmm: build DeviceMemoryRegion in MemoryManager::new` | Construct region at boot, place ACPI/virtio-mem zones inside it. |
| 7 | `vmm: virtio-pmem: place inside device-memory region` | Hot-add allocates from device-memory region (fixes the MAXMEM bug). |
| 8 | `vmm: snapshot the device-memory region` | Persist `(base, size)` in snapshot; legacy snapshots restore via fallback. |
| 9 | `docs: memory: document device_memory_size knob` | User-facing docs. |

## Testing

- Boots cleanly on x86_64/KVM with default config (no region created,
  no layout change).
- Boots with `hotplug_size=...`  - virtio-mem zone placed inside the new
  region; `lsmem` inside the guest matches expected layout.
- Boots with `--pmem` on a host with `phys_bits=48` - region now lands
  below the guest's `MAXMEM` ceiling and attaches successfully
  (regression fix).
- Boots with explicit `device_memory_size=...` - region sized
  accordingly, PCI64 window starts above it.
- Snapshot/restore round-trip with and without `device_memory_size`.
- Snapshot taken before this series restores via the legacy code path.
- `cargo +nightly fmt --all -- --check`, `clippy`, full unit tests pass.