### PR TITLE
vmm: return all-ones for unregistered MMIO and PIO reads

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -467,7 +467,8 @@ impl VmOps for VmOpsHandler {
 
     fn mmio_read(&self, gpa: u64, data: &mut [u8]) -> result::Result<(), HypervisorVmError> {
         if let Err(vm_device::BusError::MissingAddressRange) = self.mmio_bus.read(gpa, data) {
-            info!("Guest MMIO read to unregistered address 0x{gpa:x}");
+            info!("Guest MMIO read from unregistered address 0x{gpa:x}");
+            data.fill(0xff); // 0xff is sentinel value for invalid reads
         }
         Ok(())
     }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -491,7 +491,8 @@ impl VmOps for VmOpsHandler {
     #[cfg(target_arch = "x86_64")]
     fn pio_read(&self, port: u64, data: &mut [u8]) -> result::Result<(), HypervisorVmError> {
         if let Err(vm_device::BusError::MissingAddressRange) = self.io_bus.read(port, data) {
-            info!("Guest PIO read to unregistered address 0x{port:x}");
+            info!("Guest PIO read from unregistered address 0x{port:x}");
+            data.fill(0xff); // 0xff is sentinel value for invalid reads
         }
         Ok(())
     }


### PR DESCRIPTION
When reading from an unregistered MMIO or PIO address, `mmio_read()` and `pio_read()` weren't initialising the buffer, so guests were reading stale bytes from the previous MMIO/PIO transaction rather than all 0xff bytes like master abort on real hardware.

Fill the buffer with 0xff on invalid reads in each case.

Fixes #7415