### PR TITLE
virtio-devices: Fix cap_len for VIRTIO_PCI_CAP_PCI_CFG

### DIFF
--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1451,4 +1451,11 @@ mod unit_tests {
         assert_eq!(cap.cap.cap_len, expected);
         assert_eq!(cap.cap.cap_len, 20);
     }
+
+    #[test]
+    fn pci_cfg_cap_cfg_type_is_pci() {
+        let cap = VirtioPciCfgCap::new();
+        assert_eq!(cap.cap.cfg_type, PciCapabilityType::Pci as u8);
+        assert_eq!(cap.cap.cfg_type, 5);
+    }
 }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -9,6 +9,7 @@
 use std::any::Any;
 use std::cmp;
 use std::io::Write;
+use std::mem::size_of;
 use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU16, AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
@@ -208,7 +209,15 @@ impl PciCapability for VirtioPciCfgCap {
 impl VirtioPciCfgCap {
     fn new() -> Self {
         VirtioPciCfgCap {
-            cap: VirtioPciCap::new(PciCapabilityType::Pci, 0, 0, 0),
+            cap: VirtioPciCap {
+                cap_len: (size_of::<VirtioPciCfgCap>() as u8) + VIRTIO_PCI_CAP_LEN_OFFSET,
+                cfg_type: PciCapabilityType::Pci as u8,
+                pci_bar: 0,
+                id: 0,
+                padding: [0; 2],
+                offset: Le32::from(0),
+                length: Le32::from(0),
+            },
             ..Default::default()
         }
     }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1458,4 +1458,19 @@ mod unit_tests {
         assert_eq!(cap.cap.cfg_type, PciCapabilityType::Pci as u8);
         assert_eq!(cap.cap.cfg_type, 5);
     }
+
+    #[test]
+    fn compound_caps_size_cap_len_from_own_type() {
+        let notify = VirtioPciNotifyCap::new(PciCapabilityType::Notify, 0, 0, 0, Le32::from(0));
+        assert_eq!(
+            notify.cap.cap_len,
+            (size_of::<VirtioPciNotifyCap>() as u8) + VIRTIO_PCI_CAP_LEN_OFFSET
+        );
+
+        let cap64 = VirtioPciCap64::new(PciCapabilityType::SharedMemory, 0, 0, 0, 0);
+        assert_eq!(
+            cap64.cap.cap_len,
+            (size_of::<VirtioPciCap64>() as u8) + VIRTIO_PCI_CAP_LEN_OFFSET
+        );
+    }
 }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1443,4 +1443,12 @@ mod unit_tests {
         intr.trigger(VirtioInterruptType::Queue(0)).unwrap();
         assert!(!intr.config_changed.load(Ordering::Acquire));
     }
+
+    #[test]
+    fn pci_cfg_cap_len_includes_data_window() {
+        let cap = VirtioPciCfgCap::new();
+        let expected = (size_of::<VirtioPciCfgCap>() as u8) + VIRTIO_PCI_CAP_LEN_OFFSET;
+        assert_eq!(cap.cap.cap_len, expected);
+        assert_eq!(cap.cap.cap_len, 20);
+    }
 }


### PR DESCRIPTION
The VIRTIO_PCI_CAP_PCI_CFG capability was emitted with cap_len 16 instead of 20. With this change cap_len reflects the full capability size, including the trailing pci_cfg_data window.

Per virtio 1.2 section 4.1.4.9, the PCI configuration access capability is a 16 byte virtio_pci_cap followed by a 4 byte pci_cfg_data window, so its declared cap_len must be 20.