### PR TITLE
feat(vmm): Introduce zero-copy userfaultfd backend for pmem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2621,6 +2621,7 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
+ "serde_repr",
  "serial_buffer",
  "sha2",
  "signal-hook",

--- a/cloud-hypervisor/src/bin/ch-uffd-handler.rs
+++ b/cloud-hypervisor/src/bin/ch-uffd-handler.rs
@@ -1,0 +1,450 @@
+// Copyright (C) 2026 Ant Group. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Example zero-copy UFFD handler for Cloud Hypervisor.
+//!
+//! Listens on a Unix socket, receives a UFFD file descriptor from
+//! cloud-hypervisor (via the handshake), polls it for page faults,
+//! and sends back `PageFaultResponse` messages with the blob fd
+//! so the VMM can `mmap(MAP_FIXED)` the data zero-copy.
+//!
+//! Usage:
+//!   ch-uffd-handler --socket /tmp/handler.sock --file /path/to/data
+//!
+//! The `--file` is the backing data file whose contents are mapped
+//! into guest memory on page faults.  For snapshot restore, this is
+//! the `memory-ranges` file from the snapshot directory.
+
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
+use std::os::unix::net::{UnixListener, UnixStream};
+
+use vmm::uffd_block::{BlobRange, FaultPolicy, HandshakeRequest, PageFaultResponse, VmaRegion};
+use vmm_sys_util::sock_ctrl_msg::ScmSocket;
+
+// ─── UFFD ioctls ────────────────────────────────────────────────────────────
+
+const UFFDIO: u64 = 0xAA;
+const _UFFDIO_COPY: u64 = 0x03;
+
+/// Wait for the uffd fd to become readable using poll().
+fn wait_for_uffd(uffd_fd: RawFd) -> io::Result<bool> {
+    let mut pfd = libc::pollfd {
+        fd: uffd_fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    loop {
+        // SAFETY: pfd is a valid pollfd struct on the stack.
+        let ret = unsafe { libc::poll(&mut pfd, 1, -1) };
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            return Err(err);
+        }
+        if pfd.revents & libc::POLLHUP != 0 {
+            return Ok(false); // uffd closed
+        }
+        return Ok(true); // readable
+    }
+}
+
+/// Read a userfaultfd event from the uffd file descriptor.
+/// Returns the fault address or None if no pagefault event.
+fn uffd_read_event(uffd_fd: RawFd) -> io::Result<Option<u64>> {
+    #[repr(C)]
+    struct UffdMsg {
+        event: u8,
+        _reserved1: u8,
+        _reserved2: u16,
+        _reserved3: u32,
+        arg: UffdMsgArg,
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    union UffdMsgArg {
+        pagefault: UffdMsgPagefault,
+        _pad: [u64; 3],
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    struct UffdMsgPagefault {
+        flags: u64,
+        address: u64,
+        _feat: UffdMsgFeat,
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    union UffdMsgFeat {
+        ptid: u32,
+        _pad: u64,
+    }
+
+    const UFFD_EVENT_PAGEFAULT: u8 = 0x12;
+    const UFFD_EVENT_UNMAP: u8 = 0x16;
+
+    let mut msg = std::mem::MaybeUninit::<UffdMsg>::zeroed();
+    // SAFETY: msg is a valid zeroed buffer of the correct size for a uffd_msg.
+    let n = unsafe {
+        libc::read(
+            uffd_fd,
+            msg.as_mut_ptr().cast(),
+            std::mem::size_of::<UffdMsg>(),
+        )
+    };
+
+    if n < 0 {
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::EAGAIN) {
+            return Ok(None);
+        }
+        return Err(err);
+    }
+
+    if n != std::mem::size_of::<UffdMsg>() as isize {
+        return Ok(None);
+    }
+
+    // SAFETY: We verified the read returned exactly size_of::<UffdMsg>() bytes.
+    let msg = unsafe { msg.assume_init() };
+
+    if msg.event == UFFD_EVENT_PAGEFAULT {
+        // SAFETY: We checked the event type is PAGEFAULT, so the pagefault union variant is valid.
+        let addr = unsafe { msg.arg.pagefault.address };
+        Ok(Some(addr))
+    } else if msg.event == UFFD_EVENT_UNMAP {
+        // UNMAP events are generated when mmap(MAP_FIXED) replaces a
+        // uffd-registered VMA.  Reading the event is sufficient to
+        // unblock the mmap caller and wake the faulting thread.
+        // SAFETY: UNMAP events also use the pagefault union variant.
+        let addr = unsafe { msg.arg.pagefault.address };
+        eprintln!("UNMAP event: addr=0x{addr:x}");
+        Ok(None)
+    } else {
+        eprintln!("Unexpected uffd event type: {}", msg.event);
+        Ok(None)
+    }
+}
+
+/// UFFDIO_COPY: copy data to resolve a page fault
+fn uffd_copy(uffd_fd: RawFd, dst: u64, src: *const u8, len: u64) -> io::Result<()> {
+    #[repr(C)]
+    struct UffdCopy {
+        dst: u64,
+        src: u64,
+        len: u64,
+        mode: u64,
+        copy: i64,
+    }
+
+    let mut copy = UffdCopy {
+        dst,
+        src: src as u64,
+        len,
+        mode: 0,
+        copy: 0,
+    };
+
+    // UFFDIO_COPY = _IOWR(0xAA, 0x03, struct uffdio_copy) = 0xC028AA03
+    let ioctl_num: u64 = (_UFFDIO_COPY)
+        | (UFFDIO << 8)
+        | (((std::mem::size_of::<UffdCopy>() as u64) & 0x3FFF) << 16)
+        | (3u64 << 30); // _IOWR direction bits
+    // SAFETY: uffd_fd is a valid userfaultfd, copy is a valid UffdCopy struct.
+    let ret = unsafe { libc::ioctl(uffd_fd, ioctl_num as libc::Ioctl, &mut copy as *mut _) };
+
+    if ret < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+// ─── Handler ────────────────────────────────────────────────────────────────
+
+struct Handler {
+    stream: UnixStream,
+    file: File,
+    data_size: u64,
+    regions: Vec<VmaRegion>,
+    policy: FaultPolicy,
+    uffd_fd: RawFd,
+}
+
+impl Handler {
+    fn run(listener: &UnixListener, file: File) -> io::Result<()> {
+        let data_size = file.metadata()?.len();
+        eprintln!(
+            "Data file size: {data_size} bytes ({:.2} MB)",
+            data_size as f64 / 1048576.0
+        );
+
+        eprintln!("Waiting for connection...");
+        let (stream, _) = listener.accept()?;
+        eprintln!("Client connected");
+
+        let mut handler = Handler {
+            stream,
+            file,
+            data_size,
+            regions: Vec::new(),
+            policy: FaultPolicy::Zerocopy, // updated by handshake
+            uffd_fd: -1,
+        };
+
+        handler.handshake()?;
+
+        handler.event_loop()
+    }
+
+    fn handshake(&mut self) -> io::Result<()> {
+        let mut buf = vec![0u8; 65536];
+        let (bytes_read, file) = self.stream.recv_with_fd(&mut buf)?;
+        let uffd_file = file.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "no uffd fd received in handshake",
+            )
+        })?;
+        buf.truncate(bytes_read);
+
+        let json_str =
+            std::str::from_utf8(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        let request: HandshakeRequest = serde_json::from_str(json_str)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        eprintln!(
+            "Handshake: {} regions, policy {:?}",
+            request.regions.len(),
+            request.policy
+        );
+        for (i, r) in request.regions.iter().enumerate() {
+            eprintln!(
+                "  Region[{i}]: base=0x{:x}, size=0x{:x} ({:.2} MB), offset=0x{:x}, page_size={}",
+                r.base_host_virt_addr,
+                r.size,
+                r.size as f64 / 1048576.0,
+                r.offset,
+                r.page_size
+            );
+        }
+
+        self.regions = request.regions;
+        self.policy = request.policy;
+        self.uffd_fd = uffd_file.into_raw_fd();
+        eprintln!("Received uffd fd: {}", self.uffd_fd);
+
+        Ok(())
+    }
+
+    fn event_loop(&mut self) -> io::Result<()> {
+        let mut fault_count: u64 = 0;
+
+        loop {
+            // Wait for uffd fd to become readable (blocks until a page fault occurs)
+            match wait_for_uffd(self.uffd_fd) {
+                Ok(true) => {}
+                Ok(false) => {
+                    eprintln!("UFFD closed (POLLHUP) after {fault_count} faults");
+                    return Ok(());
+                }
+                Err(e) => {
+                    eprintln!("poll() error after {fault_count} faults: {e}");
+                    return Err(e);
+                }
+            }
+
+            // Read all available events (uffd is non-blocking)
+            while let Some(fault_addr) = uffd_read_event(self.uffd_fd)? {
+                fault_count += 1;
+                if fault_count <= 5 || fault_count.is_multiple_of(1000) {
+                    eprintln!("Page fault #{fault_count}: addr=0x{fault_addr:x}");
+                }
+                self.handle_fault(fault_addr)?;
+            }
+        }
+    }
+
+    fn handle_fault(&mut self, fault_addr: u64) -> io::Result<()> {
+        // Find which region this fault belongs to
+        let region = self
+            .regions
+            .iter()
+            .find(|r| {
+                fault_addr >= r.base_host_virt_addr
+                    && fault_addr < r.base_host_virt_addr + r.size as u64
+            })
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("fault addr 0x{fault_addr:x} not in any region"),
+                )
+            })?;
+
+        let page_size = if region.page_size > 0 {
+            region.page_size
+        } else {
+            4096
+        };
+
+        // Align fault address down to page boundary
+        let aligned_addr = fault_addr & !(page_size as u64 - 1);
+        let offset_in_region = aligned_addr - region.base_host_virt_addr;
+        let file_offset = region.offset + offset_in_region;
+
+        // Clamp len to not exceed region or file boundary
+        let remaining_region = region.size as u64 - offset_in_region;
+        let remaining_file = self.data_size.saturating_sub(file_offset);
+        let len = page_size
+            .min(remaining_region as usize)
+            .min(remaining_file as usize);
+
+        if len == 0 {
+            // Zero-fill for pages beyond the file
+            let buf = vec![0u8; page_size];
+            uffd_copy(self.uffd_fd, aligned_addr, buf.as_ptr(), page_size as u64)?;
+            return Ok(());
+        }
+
+        match self.policy {
+            FaultPolicy::Zerocopy => {
+                // block_offset is relative to the first region's base
+                let block_offset = offset_in_region + region.offset;
+
+                let response = PageFaultResponse {
+                    ranges: vec![BlobRange {
+                        len,
+                        blob_offset: file_offset,
+                        block_offset,
+                    }],
+                };
+
+                let json = serde_json::to_string(&response)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+                self.stream
+                    .send_with_fd(json.as_bytes(), self.file.as_raw_fd())?;
+            }
+            FaultPolicy::Copy => {
+                // Read from file and UFFDIO_COPY
+                let mut buf = vec![0u8; len];
+                // SAFETY: file fd is valid, buf is a valid mutable buffer, file_offset is within bounds.
+                let n = unsafe {
+                    libc::pread(
+                        self.file.as_raw_fd(),
+                        buf.as_mut_ptr().cast(),
+                        len,
+                        file_offset as i64,
+                    )
+                };
+                if n < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                // Zero-fill remainder if short read
+                if (n as usize) < page_size {
+                    buf.resize(page_size, 0);
+                }
+                uffd_copy(self.uffd_fd, aligned_addr, buf.as_ptr(), page_size as u64)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+fn print_usage() {
+    eprintln!("Usage: ch-uffd-handler --socket <path> --file <path>");
+    eprintln!();
+    eprintln!("Options:");
+    eprintln!("  --socket <path>   Unix socket path to listen on");
+    eprintln!("  --file <path>     Backing data file (e.g. snapshot memory-ranges file)");
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    let mut socket_path = None;
+    let mut file_path = None;
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--socket" | "-s" => {
+                i += 1;
+                socket_path = args.get(i).cloned();
+            }
+            "--file" | "-f" => {
+                i += 1;
+                file_path = args.get(i).cloned();
+            }
+            "--help" | "-h" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            other => {
+                eprintln!("Unknown option: {other}");
+                print_usage();
+                std::process::exit(1);
+            }
+        }
+        i += 1;
+    }
+
+    let socket_path = match socket_path {
+        Some(p) => p,
+        None => {
+            eprintln!("Error: --socket is required");
+            print_usage();
+            std::process::exit(1);
+        }
+    };
+
+    let file_path = match file_path {
+        Some(p) => p,
+        None => {
+            eprintln!("Error: --file is required");
+            print_usage();
+            std::process::exit(1);
+        }
+    };
+
+    eprintln!("ch-uffd-handler starting");
+    eprintln!("  Socket: {socket_path}");
+    eprintln!("  File: {file_path}");
+
+    let file = match OpenOptions::new().read(true).write(true).open(&file_path) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Failed to open {file_path}: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    // Remove stale socket
+    let _ = std::fs::remove_file(&socket_path);
+
+    let listener = match UnixListener::bind(&socket_path) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("Failed to bind {socket_path}: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    eprintln!("Listening on {socket_path}...");
+
+    if let Err(e) = Handler::run(&listener, file) {
+        eprintln!("Handler error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/docs/device_model.md
+++ b/docs/device_model.md
@@ -142,6 +142,25 @@ allows bypassing the guest page cache and improve the guest memory footprint.
 This device is always built-in, and it is enabled based on the presence of the
 flag `--pmem`.
 
+#### UFFD Backend
+
+By default, the `file` parameter points to a regular file that backs the PMEM
+device. With `backend_type=uffd`, the `file` parameter instead specifies the
+path to a Unix socket connected to an external UFFD handler (such as nydusd):
+
+```bash
+cloud-hypervisor \
+    --pmem file=/tmp/handler.sock,size=8G,backend_type=uffd,discard_writes=on
+```
+
+In this mode, Cloud Hypervisor creates an anonymous memory region, registers it
+with `userfaultfd`, and connects to the external handler. Page faults are
+resolved zero-copy: the handler sends blob file descriptors back to Cloud
+Hypervisor, which `mmap(MAP_FIXED)`s them directly into the guest memory.
+
+The handler must implement the UFFD handshake protocol and respond to page
+faults with blob descriptors for the requested ranges.
+
 ### virtio-rng
 
 A VM does not generate entropy like a real machine would, which is an issue

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -124,6 +124,30 @@ Current constraints for `memory_restore_mode=ondemand`:
 - `prefault=on` is not supported
 - the snapshot memory ranges must be page-aligned
 
+### External UFFD Handler for Snapshot Restore
+
+When using `memory_restore_mode=ondemand`, an external UFFD handler can be
+specified to serve page faults on behalf of Cloud Hypervisor:
+
+```bash
+cloud-hypervisor \
+    --api-socket /tmp/cloud-hypervisor.sock \
+    --restore source_url=file:///home/foo/snapshot,memory_restore_mode=ondemand,external_sock=/tmp/handler.sock
+```
+
+With `external_sock`, Cloud Hypervisor performs a handshake with the external
+handler over the Unix socket and delegates page fault resolution (`UFFDIO_COPY`)
+to it. This allows the handler to serve snapshot memory pages from a remote
+source, avoiding the need for the `memory-ranges` file to be present locally.
+
+The handler must implement the UFFD protocol: accept a connection, receive the
+uffd file descriptor and VMA region list via the handshake, then respond to
+page faults by copying data into the faulting pages.
+
+When `external_sock` is not specified, Cloud Hypervisor reads pages from the
+local `memory-ranges` file and performs `UFFDIO_COPY` itself — no external
+handler thread is needed.
+
 ## Restore a VM with new Net FDs
 For a VM created with FDs explicitly passed to NetConfig, a set of valid FDs
 need to be provided along with the VM restore command in the following syntax:

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -80,6 +80,7 @@ rate_limiter = { path = "../rate_limiter" }
 seccompiler = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
+serde_repr = "0.1"
 serial_buffer = { path = "../serial_buffer" }
 sha2 = { workspace = true }
 signal-hook = { workspace = true }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2623,18 +2623,23 @@ pub struct RestoreConfig {
     pub net_fds: Option<Vec<RestoredNetConfig>>,
     #[serde(default)]
     pub resume: bool,
+    #[serde(default)]
+    pub external_sock: Option<PathBuf>,
 }
 
 impl RestoreConfig {
     pub const SYNTAX: &'static str = "Restore from a VM snapshot. \
         \nRestore parameters \"source_url=<source_url>,prefault=on|off,memory_restore_mode=copy|ondemand,\
-        net_fds=<list_of_net_ids_with_their_associated_fds>,resume=true|false\" \
+        external_sock=<path>,net_fds=<list_of_net_ids_with_their_associated_fds>,resume=true|false\" \
         \n`source_url` should be a valid URL (e.g file:///foo/bar or tcp://192.168.1.10/foo) \
         \n`prefault` controls eager prefaulting for the copy-based restore path (disabled by default) \
         \n`memory_restore_mode=copy` preserves the existing eager read-copy restore behavior, while `memory_restore_mode=ondemand` enables lazy demand paging and fails restore if userfaultfd support is unavailable \
         \n`net_fds` is a list of net ids with new file descriptors. \
         Only net devices backed by FDs directly are needed as input.\
-        \n `resume` controls whether the VM will be directly resumed after restore ";
+        \n`resume` controls whether the VM will be directly resumed after restore \
+        \n`external_sock` is the path to a Unix socket for an external UFFD handler \
+        that can provide zero-copy page fault resolution. \
+        Only used when memory_restore_mode=ondemand";
 
     pub fn parse(restore: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -2643,7 +2648,8 @@ impl RestoreConfig {
             .add("prefault")
             .add("memory_restore_mode")
             .add("net_fds")
-            .add("resume");
+            .add("resume")
+            .add("external_sock");
         parser.parse(restore).map_err(Error::ParseRestore)?;
 
         let source_url = parser
@@ -2676,6 +2682,7 @@ impl RestoreConfig {
             .map_err(Error::ParseRestore)?
             .unwrap_or(Toggle(false))
             .0;
+        let external_sock = parser.get("external_sock").map(PathBuf::from);
 
         Ok(RestoreConfig {
             source_url,
@@ -2683,6 +2690,7 @@ impl RestoreConfig {
             memory_restore_mode,
             net_fds,
             resume,
+            external_sock,
         })
     }
 
@@ -4749,6 +4757,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 memory_restore_mode: MemoryRestoreMode::Copy,
                 net_fds: None,
                 resume: false,
+                ..Default::default()
             }
         );
         assert_eq!(
@@ -4772,6 +4781,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                     }
                 ]),
                 resume: false,
+                ..Default::default()
             }
         );
         assert_eq!(
@@ -4782,6 +4792,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 memory_restore_mode: MemoryRestoreMode::OnDemand,
                 net_fds: None,
                 resume: false,
+                ..Default::default()
             }
         );
         assert_eq!(
@@ -4792,11 +4803,27 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 memory_restore_mode: MemoryRestoreMode::Copy,
                 net_fds: None,
                 resume: true,
+                ..Default::default()
             }
         );
         // Parsing should fail as source_url is a required field
         RestoreConfig::parse("prefault=off").unwrap_err();
         RestoreConfig::parse("source_url=/path/to/snapshot,memory_restore_mode=bogus").unwrap_err();
+        // external_sock with ondemand
+        assert_eq!(
+            RestoreConfig::parse(
+                "source_url=/path/to/snapshot,memory_restore_mode=ondemand,external_sock=/tmp/handler.sock"
+            )?,
+            RestoreConfig {
+                source_url: PathBuf::from("/path/to/snapshot"),
+                prefault: false,
+                memory_restore_mode: MemoryRestoreMode::OnDemand,
+                net_fds: None,
+                resume: false,
+                external_sock: Some(PathBuf::from("/tmp/handler.sock")),
+            }
+        );
+
         Ok(())
     }
 
@@ -4815,6 +4842,21 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             .unwrap()
             .memory_restore_mode,
             MemoryRestoreMode::OnDemand
+        );
+        // external_sock defaults to None
+        assert_eq!(
+            serde_json::from_str::<RestoreConfig>(r#"{"source_url":"/path/to/snapshot"}"#)
+                .unwrap()
+                .external_sock,
+            None
+        );
+        assert_eq!(
+            serde_json::from_str::<RestoreConfig>(
+                r#"{"source_url":"/path/to/snapshot","external_sock":"/tmp/handler.sock"}"#
+            )
+            .unwrap()
+            .external_sock,
+            Some(PathBuf::from("/tmp/handler.sock"))
         );
     }
 
@@ -4903,6 +4945,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 },
             ]),
             resume: false,
+            ..Default::default()
         };
         valid_config.validate(&snapshot_vm_config).unwrap();
 
@@ -4968,6 +5011,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             memory_restore_mode: MemoryRestoreMode::Copy,
             net_fds: None,
             resume: false,
+            ..Default::default()
         };
         snapshot_vm_config.net = Some(vec![NetConfig {
             pci_common: PciDeviceCommonConfig {
@@ -4985,6 +5029,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             memory_restore_mode: MemoryRestoreMode::OnDemand,
             net_fds: None,
             resume: false,
+            ..Default::default()
         };
         assert_eq!(
             invalid_restore_mode.validate(&snapshot_vm_config),

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2104,7 +2104,8 @@ impl PmemConfig {
     pub const SYNTAX: &'static str = "Persistent memory parameters \
     \"file=<backing_file_path>,size=<persistent_memory_size>,iommu=on|off,\
     discard_writes=on|off,id=<device_id>,\
-    pci_segment=<segment_id>,pci_device_id=<pci_slot>\"";
+    pci_segment=<segment_id>,pci_device_id=<pci_slot>,\
+    backend_type=file|uffd\"";
 
     pub fn parse(pmem: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -2112,7 +2113,8 @@ impl PmemConfig {
             .add("size")
             .add("file")
             .add("discard_writes")
-            .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU);
+            .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU)
+            .add("backend_type");
         parser.parse(pmem).map_err(Error::ParsePersistentMemory)?;
 
         let pci_common = PciDeviceCommonConfig::parse(pmem)?;
@@ -2126,12 +2128,17 @@ impl PmemConfig {
             .map_err(Error::ParsePersistentMemory)?
             .unwrap_or(Toggle(false))
             .0;
+        let backend_type = parser
+            .convert::<MemBackendType>("backend_type")
+            .map_err(Error::ParsePersistentMemory)?
+            .unwrap_or_default();
 
         Ok(PmemConfig {
             pci_common,
             file,
             size,
             discard_writes,
+            backend_type,
         })
     }
 
@@ -4373,6 +4380,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             file: PathBuf::from("/tmp/pmem"),
             size: Some(128 << 20),
             discard_writes: false,
+            backend_type: MemBackendType::File,
         }
     }
 
@@ -4406,6 +4414,17 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 ..pmem_fixture()
             }
         );
+        // UFFD backend type
+        assert_eq!(
+            PmemConfig::parse("file=/tmp/handler.sock,size=128M,backend_type=uffd")?,
+            PmemConfig {
+                file: PathBuf::from("/tmp/handler.sock"),
+                backend_type: MemBackendType::Uffd,
+                ..pmem_fixture()
+            }
+        );
+        // Invalid backend type
+        PmemConfig::parse("file=/tmp/pmem,size=128M,backend_type=invalid").unwrap_err();
 
         Ok(())
     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -13,6 +13,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::{File, OpenOptions};
 use std::io::{self, IsTerminal, Seek, SeekFrom, stdout};
 use std::num::Wrapping;
+use std::os::fd::AsFd;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 #[cfg(not(target_arch = "riscv64"))]
@@ -69,8 +70,8 @@ use hypervisor::arch::aarch64::regs::AARCH64_PMU_IRQ;
 #[cfg(feature = "kvm")]
 use iommufd_ioctls::IommuFd;
 use libc::{
-    MAP_NORESERVE, MAP_PRIVATE, MAP_SHARED, O_TMPFILE, PROT_READ, PROT_WRITE, TCSANOW, tcsetattr,
-    termios,
+    EFD_NONBLOCK, MAP_NORESERVE, MAP_PRIVATE, MAP_SHARED, O_TMPFILE, PROT_READ, PROT_WRITE,
+    TCSANOW, tcsetattr, termios,
 };
 use log::{debug, error, info, warn};
 use pci::{
@@ -118,14 +119,16 @@ use crate::interrupt::{LegacyUserspaceInterruptManager, MsiInterruptManager};
 use crate::memory_manager::{Error as MemoryManagerError, MEMORY_MANAGER_ACPI_SIZE, MemoryManager};
 use crate::pci_segment::PciSegment;
 use crate::serial_manager::{Error as SerialManagerError, SerialManager};
+use crate::uffd_block::{FaultPolicy, UffdBlock, VmaRegion};
 #[cfg(feature = "ivshmem")]
 use crate::vm_config::IvshmemConfig;
 use crate::vm_config::{
     ConsoleOutputMode, DEFAULT_IOMMU_ADDRESS_WIDTH_BITS, DEFAULT_PCI_SEGMENT_APERTURE_WEIGHT,
-    DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, NetConfig, PciDeviceCommonConfig,
-    PmemConfig, UserDeviceConfig, VdpaConfig, VhostMode, VmConfig, VsockConfig,
+    DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, MemBackendType, NetConfig,
+    PciDeviceCommonConfig, PmemConfig, UserDeviceConfig, VdpaConfig, VhostMode, VmConfig,
+    VsockConfig,
 };
-use crate::{DEVICE_MANAGER_SNAPSHOT_ID, GuestRegionMmap, PciDeviceInfo, device_node};
+use crate::{DEVICE_MANAGER_SNAPSHOT_ID, GuestRegionMmap, PciDeviceInfo, device_node, uffd};
 
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 const MMIO_LEN: u64 = 0x1000;
@@ -515,6 +518,14 @@ pub enum DeviceManagerError {
     /// Trying to use a size that is not multiple of 2MiB
     #[error("Trying to use a size that is not multiple of 2MiB")]
     PmemSizeNotAligned,
+
+    /// UFFD backend requires size to be specified
+    #[error("UFFD pmem backend requires size to be specified")]
+    PmemUffdSizeMissing,
+
+    /// Failed to set up UFFD pmem backend
+    #[error("Failed to set up UFFD pmem backend: {0}")]
+    PmemUffdSetup(#[source] io::Error),
 
     /// Could not find the node in the device tree.
     #[error("Could not find the node in the device tree")]
@@ -987,6 +998,13 @@ impl AccessPlatform for SevSnpPageAccessProxy {
     }
 }
 
+/// Tracks the UFFD handler thread for a PMEM device with zerocopy backend.
+struct PmemUffdHandler {
+    stop_event: EventFd,
+    result_rx: std::sync::mpsc::Receiver<io::Result<()>>,
+    handle: std::thread::JoinHandle<()>,
+}
+
 pub struct DeviceManager {
     // Manage address space related to devices
     address_manager: Arc<AddressManager>,
@@ -1150,6 +1168,9 @@ pub struct DeviceManager {
     #[cfg(feature = "ivshmem")]
     // ivshmem device
     ivshmem_device: Option<Arc<Mutex<devices::IvshmemDevice>>>,
+
+    // UFFD handler threads for PMEM devices with zerocopy backend.
+    pmem_uffd_handlers: Vec<PmemUffdHandler>,
 }
 
 /// Create per-PCI-segment MMIO allocators over the range `[start, end]`.
@@ -1440,6 +1461,7 @@ impl DeviceManager {
             fw_cfg: None,
             #[cfg(feature = "ivshmem")]
             ivshmem_device: None,
+            pmem_uffd_handlers: Vec::new(),
             _acpi_cpu_hotplug_controller: acpi_cpu_hotplug_controller,
         };
 
@@ -3281,31 +3303,58 @@ impl DeviceManager {
             None
         };
 
-        let (custom_flags, set_len) = if pmem_cfg.file.is_dir() {
-            if pmem_cfg.size.is_none() {
-                return Err(DeviceManagerError::PmemWithDirectorySizeMissing);
+        let (file, size, backend_sock_path) = match pmem_cfg.backend_type {
+            MemBackendType::File => {
+                let (custom_flags, set_len) = if pmem_cfg.file.is_dir() {
+                    if pmem_cfg.size.is_none() {
+                        return Err(DeviceManagerError::PmemWithDirectorySizeMissing);
+                    }
+                    (O_TMPFILE, true)
+                } else {
+                    (0, false)
+                };
+
+                let mut file = OpenOptions::new()
+                    .read(true)
+                    .write(!pmem_cfg.discard_writes)
+                    .custom_flags(custom_flags)
+                    .open(&pmem_cfg.file)
+                    .map_err(DeviceManagerError::PmemFileOpen)?;
+
+                let size = if let Some(size) = pmem_cfg.size {
+                    if set_len {
+                        file.set_len(size)
+                            .map_err(DeviceManagerError::PmemFileSetLen)?;
+                    }
+                    size
+                } else {
+                    file.seek(SeekFrom::End(0))
+                        .map_err(DeviceManagerError::PmemFileSetLen)?
+                };
+
+                (file, size, None)
             }
-            (O_TMPFILE, true)
-        } else {
-            (0, false)
-        };
-
-        let mut file = OpenOptions::new()
-            .read(true)
-            .write(!pmem_cfg.discard_writes)
-            .custom_flags(custom_flags)
-            .open(&pmem_cfg.file)
-            .map_err(DeviceManagerError::PmemFileOpen)?;
-
-        let size = if let Some(size) = pmem_cfg.size {
-            if set_len {
+            MemBackendType::Uffd => {
+                let size = pmem_cfg
+                    .size
+                    .ok_or(DeviceManagerError::PmemUffdSizeMissing)?;
+                // Create an anonymous memfd as a placeholder backing for the
+                // guest mapping.  The actual data will be paged in via the
+                // external UFFD handler.
+                let memfd_name = std::ffi::CString::new("ch-pmem-uffd")
+                    .map_err(|e| DeviceManagerError::PmemUffdSetup(io::Error::other(e)))?;
+                // SAFETY: memfd_create with valid CString name.
+                let raw_fd = unsafe { libc::memfd_create(memfd_name.as_ptr(), libc::MFD_CLOEXEC) };
+                if raw_fd < 0 {
+                    return Err(DeviceManagerError::PmemUffdSetup(io::Error::last_os_error()));
+                }
+                // SAFETY: raw_fd is a valid fd returned by memfd_create.
+                let file = unsafe { File::from_raw_fd(raw_fd) };
                 file.set_len(size)
                     .map_err(DeviceManagerError::PmemFileSetLen)?;
+
+                (file, size, Some(pmem_cfg.file.clone()))
             }
-            size
-        } else {
-            file.seek(SeekFrom::End(0))
-                .map_err(DeviceManagerError::PmemFileSetLen)?
         };
 
         if size % 0x20_0000 != 0 {
@@ -3341,16 +3390,18 @@ impl DeviceManager {
         };
 
         let cloned_file = file.try_clone().map_err(DeviceManagerError::CloneFile)?;
+        let mmap_prot = PROT_READ | PROT_WRITE;
+        let mmap_flags = MAP_NORESERVE
+            | if pmem_cfg.discard_writes {
+                MAP_PRIVATE
+            } else {
+                MAP_SHARED
+            };
         let mmap_region = MmapRegion::build(
             Some(FileOffset::new(cloned_file, 0)),
             region_size as usize,
-            PROT_READ | PROT_WRITE,
-            MAP_NORESERVE
-                | if pmem_cfg.discard_writes {
-                    MAP_PRIVATE
-                } else {
-                    MAP_SHARED
-                },
+            mmap_prot,
+            mmap_flags,
         )
         .map_err(DeviceManagerError::NewMmapRegion)?;
         let host_addr = mmap_region.as_ptr();
@@ -3364,6 +3415,82 @@ impl DeviceManager {
                 .create_userspace_mapping(region_base, region_size, host_addr, false, false, false)
                 .map_err(DeviceManagerError::MemoryManager)
         }?;
+
+        // For UFFD backend, register the mapping with userfaultfd and start
+        // the handler thread that communicates with the external server.
+        if let Some(sock_path) = backend_sock_path {
+            let uffd_fd = uffd::create(0).map_err(DeviceManagerError::PmemUffdSetup)?;
+            uffd::register(uffd_fd.as_fd(), host_addr as u64, region_size)
+                .map_err(DeviceManagerError::PmemUffdSetup)?;
+
+            let vma_region = VmaRegion {
+                base_host_virt_addr: host_addr as u64,
+                size: region_size as usize,
+                offset: 0,
+                page_size: 512 * 4096,
+                page_size_kib: 0,
+                prot: mmap_prot,
+                flags: mmap_flags,
+            };
+
+            let sock_path_str = sock_path.to_string_lossy().to_string();
+            // Zerocopy policy: external server returns blob fds, CH mmaps
+            // them into the guest — requires a local handler thread.
+            let mut uffd_block = UffdBlock::new(&sock_path_str, FaultPolicy::Zerocopy)
+                .map_err(DeviceManagerError::PmemUffdSetup)?;
+            uffd_block
+                .handshake(uffd_fd, vec![vma_region])
+                .map_err(DeviceManagerError::PmemUffdSetup)?;
+
+            let stop_event = EventFd::new(EFD_NONBLOCK).map_err(DeviceManagerError::EventFd)?;
+            let thread_stop = stop_event
+                .try_clone()
+                .map_err(DeviceManagerError::EventFd)?;
+            let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
+            let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+            let thread_id = id.clone();
+
+            let handle = std::thread::Builder::new()
+                .name(format!("uffd-pmem-{id}"))
+                .spawn(move || {
+                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+                        let result = crate::uffd_block::uffd_handler_loop(
+                            &uffd_block,
+                            &thread_stop,
+                            &ready_tx,
+                        );
+                        if let Err(e) = &result {
+                            error!("UFFD pmem handler exited with error: {e}");
+                        }
+                        result_tx.send(result).ok();
+                    }))
+                    .map_err(|_| {
+                        error!("uffd-pmem-{thread_id} thread panicked");
+                    })
+                    .ok();
+                })
+                .map_err(DeviceManagerError::PmemUffdSetup)?;
+
+            // Wait for the handler to signal readiness (epoll setup done).
+            if ready_rx.recv().is_err() {
+                handle.join().ok();
+                return Err(DeviceManagerError::PmemUffdSetup(io::Error::other(
+                    "UFFD pmem handler failed to start",
+                )));
+            }
+
+            // Check for immediate runtime failure.
+            if let Ok(Err(e)) = result_rx.try_recv() {
+                handle.join().ok();
+                return Err(DeviceManagerError::PmemUffdSetup(e));
+            }
+
+            self.pmem_uffd_handlers.push(PmemUffdHandler {
+                stop_event,
+                result_rx,
+                handle,
+            });
+        }
 
         let mapping = UserspaceMapping {
             mem_slot,
@@ -5782,6 +5909,20 @@ impl BusDevice for DeviceManager {
 
 impl Drop for DeviceManager {
     fn drop(&mut self) {
+        // Stop PMEM UFFD handler threads before tearing down devices.
+        for handler in self.pmem_uffd_handlers.drain(..) {
+            handler.stop_event.write(1).ok();
+            handler.handle.join().ok();
+
+            match handler.result_rx.try_recv() {
+                Ok(Err(e)) => error!("UFFD pmem handler terminated with error: {e}"),
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    warn!("UFFD pmem handler terminated unexpectedly (possible panic)");
+                }
+                _ => {}
+            }
+        }
+
         // Explicitly clear the regions owned by this device to ensure
         // that they are dropped and unmapped before the container is cleared.
         // See eject_device() for the device hot-unplug equivalent.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1613,6 +1613,7 @@ impl Vmm {
         vm_config: Arc<Mutex<VmConfig>>,
         prefault: bool,
         memory_restore_mode: MemoryRestoreMode,
+        external_sock: Option<&std::path::Path>,
     ) -> std::result::Result<(), VmError> {
         let snapshot = recv_vm_state(source_url).map_err(VmError::Restore)?;
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
@@ -1661,6 +1662,7 @@ impl Vmm {
             Some(source_url),
             Some(prefault),
             Some(memory_restore_mode),
+            external_sock,
         )?;
         self.vm = Some(vm);
 
@@ -1883,6 +1885,7 @@ impl RequestHandler for Vmm {
                         None,
                         None,
                         None,
+                        None,
                     )?;
 
                     self.vm = Some(vm);
@@ -1974,6 +1977,7 @@ impl RequestHandler for Vmm {
             vm_config,
             restore_cfg.prefault,
             restore_cfg.memory_restore_mode,
+            restore_cfg.external_sock.as_deref(),
         )
         .and_then(|()| {
             if restore_cfg.resume {
@@ -2074,6 +2078,7 @@ impl RequestHandler for Vmm {
             self.console_info.clone(),
             self.console_resize_pipe.clone(),
             Arc::clone(&self.original_termios_opt),
+            None,
             None,
             None,
             None,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -101,6 +101,7 @@ pub(crate) mod sev;
 mod sigwinch_listener;
 mod sync_utils;
 mod uffd;
+pub mod uffd_block;
 mod userfaultfd;
 pub mod vm;
 pub mod vm_config;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -55,6 +55,7 @@ use crate::coredump::{
     CoredumpMemoryRegion, CoredumpMemoryRegions, DumpState, GuestDebuggableError,
 };
 use crate::migration::url_to_path;
+use crate::uffd_block::{FaultPolicy, UffdBlock, VmaRegion};
 use crate::vm_config::{HotplugMethod, MemoryConfig, MemoryZoneConfig};
 use crate::{GuestMemoryMmap, GuestRegionMmap, MEMORY_MANAGER_SNAPSHOT_ID, uffd};
 
@@ -270,6 +271,7 @@ pub struct MemoryManager {
     // slots that the mapping is created in.
     guest_ram_mappings: Vec<GuestRamMapping>,
     uffd_handler: Option<UffdHandler>,
+    uffd_block: Option<UffdBlock>,
 
     pub acpi_address: Option<GuestAddress>,
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
@@ -940,6 +942,7 @@ impl MemoryManager {
         file_path: &Path,
         saved_regions: &MemoryRangeTable,
         exit_evt: &EventFd,
+        external_sock: Option<&Path>,
     ) -> Result<(), Error> {
         if saved_regions.is_empty() {
             return Ok(());
@@ -963,8 +966,6 @@ impl MemoryManager {
         {
             return Err(UffdError::UnalignedRanges.into());
         }
-
-        let snapshot_file = File::open(file_path).map_err(Error::SnapshotOpen)?;
 
         let uffd_fd = uffd::create(required_uffd_features).map_err(UffdError::Create)?;
 
@@ -1016,6 +1017,46 @@ impl MemoryManager {
             handler_ranges.len(),
             file_offset
         );
+
+        if let Some(sock_path) = external_sock {
+            // External handler path: handshake with Copy policy, server handles
+            // UFFDIO_COPY directly via the uffd fd. No handler thread needed.
+            let vma_regions: Vec<VmaRegion> = handler_ranges
+                .iter()
+                .map(|r| VmaRegion {
+                    base_host_virt_addr: r.host_addr,
+                    size: r.length as usize,
+                    offset: r.file_offset,
+                    page_size: r.page_size as usize,
+                    page_size_kib: 0,
+                    prot: libc::PROT_READ | libc::PROT_WRITE,
+                    flags: libc::MAP_SHARED,
+                })
+                .collect();
+
+            let sock_path_str = sock_path.to_string_lossy().to_string();
+
+            // Copy policy: external server performs UFFDIO_COPY directly —
+            // no local handler thread needed.
+            let mut uffd_block =
+                UffdBlock::new(&sock_path_str, FaultPolicy::Copy).map_err(|e| {
+                    Error::Restore(vm_migration::MigratableError::Restore(anyhow!(
+                        "UffdBlock connect failed: {e}"
+                    )))
+                })?;
+
+            uffd_block.handshake(uffd_fd, vma_regions).map_err(|e| {
+                Error::Restore(vm_migration::MigratableError::Restore(anyhow!(
+                    "UffdBlock handshake failed: {e}"
+                )))
+            })?;
+
+            info!("UFFD restore: external handler handshake with {sock_path_str} succeeded");
+            self.uffd_block = Some(uffd_block);
+            return Ok(());
+        }
+
+        let snapshot_file = File::open(file_path).map_err(Error::SnapshotOpen)?;
 
         let stop_event = EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFdFail)?;
         let thread_stop_event = stop_event.try_clone().map_err(Error::EventFdFail)?;
@@ -1741,6 +1782,7 @@ impl MemoryManager {
             memory_zones,
             guest_ram_mappings: Vec::new(),
             uffd_handler: None,
+            uffd_block: None,
             acpi_address,
             log_dirty: dynamic, // Cannot log dirty pages on a TD
             arch_mem_regions,
@@ -1764,6 +1806,7 @@ impl MemoryManager {
         memory_restore_mode: MemoryRestoreMode,
         phys_bits: u8,
         exit_evt: &EventFd,
+        external_sock: Option<&Path>,
     ) -> Result<Arc<Mutex<MemoryManager>>, Error> {
         if let Some(source_url) = source_url {
             let mut memory_file_path = url_to_path(source_url).map_err(Error::Restore)?;
@@ -1788,6 +1831,7 @@ impl MemoryManager {
                     &memory_file_path,
                     &mem_snapshot.memory_ranges,
                     exit_evt,
+                    external_sock,
                 )?;
             } else {
                 mm.lock()

--- a/vmm/src/uffd_block.rs
+++ b/vmm/src/uffd_block.rs
@@ -1,0 +1,854 @@
+// Copyright (C) 2026 Ant Group. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! UFFD block backend for on-demand page fault handling via an external server.
+//!
+//! Supports zero-copy: the server responds with blob fds that are MAP_FIXED directly
+//! over the faulting region, avoiding any data copy into guest memory.
+//!
+//! For servers that do not support this protocol, the socket simply receives
+//! no messages and the event handler becomes a no-op with no overhead.
+
+use std::fs::File;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::fs::FileExt;
+use std::os::unix::net::UnixStream;
+use std::{fmt, io};
+
+use libc::MAP_FAILED;
+use log::{error, info, warn};
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use vmm_sys_util::eventfd::EventFd;
+use vmm_sys_util::sock_ctrl_msg::ScmSocket;
+
+use crate::uffd;
+
+/// Message type enum for UFFD protocol.
+#[derive(Debug, Clone, Copy, Default, Serialize_repr, Deserialize_repr, PartialEq, Eq)]
+#[repr(u8)]
+pub enum MessageType {
+    /// Handshake message.
+    #[default]
+    Handshake = 0,
+    /// Page fault notification.
+    PageFault = 1,
+}
+
+/// Fault handling policy for UFFD.
+#[derive(Debug, Clone, Copy, Default, Serialize_repr, Deserialize_repr, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FaultPolicy {
+    /// Zero-copy mode: send fd to client, let client do mmap.
+    #[default]
+    Zerocopy = 0,
+    /// Copy mode: use UFFDIO_COPY to copy data directly.
+    Copy = 1,
+}
+
+/// VMA region information for userfaultfd registration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VmaRegion {
+    /// Base host virtual address of this region.
+    pub base_host_virt_addr: u64,
+    /// Size of the region in bytes.
+    pub size: usize,
+    /// Offset in the backend.
+    pub offset: u64,
+    /// Page size for this region.
+    pub page_size: usize,
+    /// Page size in KiB (legacy, defaults to 0).
+    #[serde(default)]
+    pub page_size_kib: usize,
+    /// Memory protection flags (defaults to `PROT_READ`).
+    #[serde(default = "default_prot")]
+    pub prot: i32,
+    /// Mmap flags (defaults to `MAP_PRIVATE`).
+    /// Note: `MAP_FIXED` is added by the handler when doing mmap.
+    #[serde(default = "default_flags")]
+    pub flags: i32,
+}
+
+fn default_prot() -> i32 {
+    libc::PROT_READ
+}
+
+fn default_flags() -> i32 {
+    libc::MAP_PRIVATE
+}
+
+impl Default for VmaRegion {
+    fn default() -> Self {
+        Self {
+            base_host_virt_addr: 0,
+            size: 0,
+            offset: 0,
+            page_size: 4096,
+            page_size_kib: 0,
+            prot: default_prot(),
+            flags: default_flags(),
+        }
+    }
+}
+
+/// Handshake request to the UFFD server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandshakeRequest {
+    /// Message type (defaults to Handshake).
+    #[serde(default)]
+    pub r#type: MessageType,
+    /// VMA regions to register.
+    pub regions: Vec<VmaRegion>,
+    /// Fault handling policy (defaults to Zerocopy).
+    #[serde(default)]
+    pub policy: FaultPolicy,
+}
+
+/// Page fault response from the UFFD server.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PageFaultResponse {
+    pub ranges: Vec<BlobRange>,
+}
+
+/// A single range within a page fault response.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BlobRange {
+    pub len: usize,
+    pub blob_offset: u64,
+    pub block_offset: u64,
+}
+
+const RECV_BUF_SIZE: usize = 4096;
+const MAX_FDS: usize = 16;
+
+/// Inline UFFD block backend that connects to an external UFFD server via
+/// Unix socket for zero-copy on-demand page resolution and fault recovery.
+///
+/// Two-phase initialization:
+/// 1. `UffdBlock::new(sock_path, policy)` — connects to the server.
+/// 2. `block.handshake(uffd_fd, regions)` — performs protocol handshake.
+pub struct UffdBlock {
+    sock_path: String,
+    sock: UnixStream,
+    policy: FaultPolicy,
+    uffd_fd: Option<OwnedFd>,
+    regions: Vec<VmaRegion>,
+}
+
+impl fmt::Debug for UffdBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UffdBlock")
+            .field("sock_path", &self.sock_path)
+            .field("sock_fd", &self.sock.as_raw_fd())
+            .field("policy", &self.policy)
+            .field("uffd_fd", &self.uffd_fd.as_ref().map(|fd| fd.as_raw_fd()))
+            .field("regions", &self.regions)
+            .finish()
+    }
+}
+
+impl UffdBlock {
+    /// Create a new UffdBlock, connecting to the server at `sock_path`.
+    /// Call [`handshake`] to complete initialization.
+    pub fn new(sock_path: &str, policy: FaultPolicy) -> io::Result<Self> {
+        let sock = UnixStream::connect(sock_path)?;
+        Ok(Self {
+            sock_path: sock_path.to_string(),
+            sock,
+            policy,
+            uffd_fd: None,
+            regions: Vec::new(),
+        })
+    }
+
+    /// Perform a formal protocol handshake with the UFFD server.
+    pub fn handshake(&mut self, uffd_fd: OwnedFd, regions: Vec<VmaRegion>) -> io::Result<()> {
+        let request = HandshakeRequest {
+            r#type: MessageType::Handshake,
+            regions: regions.clone(),
+            policy: self.policy,
+        };
+        let json_data = serde_json::to_string(&request)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        self.sock
+            .send_with_fd(json_data.as_bytes(), uffd_fd.as_raw_fd())?;
+        self.sock.set_nonblocking(true)?;
+
+        self.uffd_fd = Some(uffd_fd);
+        self.regions = regions;
+        Ok(())
+    }
+
+    /// Handle a page fault response by mmapping blob fds in a zero-copy manner.
+    pub fn handle_response(&self) -> io::Result<bool> {
+        let mut data = [0u8; RECV_BUF_SIZE];
+        let mut fds = [0i32; MAX_FDS];
+
+        let iov = libc::iovec {
+            iov_base: data.as_mut_ptr().cast(),
+            iov_len: data.len(),
+        };
+        // SAFETY: iov points to a valid buffer, fds is a valid slice for receiving fds.
+        let (bytes_read, fd_count) = unsafe { self.sock.recv_with_fds(&mut [iov], &mut fds) }
+            .map_err(|e| io::Error::from_raw_os_error(e.errno()))?;
+
+        // Take ownership of received fds so they are closed on any early return.
+        // SAFETY: fds[0..fd_count] contain valid file descriptors received via sendfd.
+        let received_fds: Vec<File> = fds[..fd_count]
+            .iter()
+            .map(|&fd| unsafe { File::from_raw_fd(fd) })
+            .collect();
+
+        if bytes_read == 0 {
+            // connection closed
+            return Ok(false);
+        }
+
+        let json_str = std::str::from_utf8(&data[..bytes_read])
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let response: PageFaultResponse = serde_json::from_str(json_str)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        if received_fds.len() != response.ranges.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "fd count {} != ranges count {}",
+                    received_fds.len(),
+                    response.ranges.len()
+                ),
+            ));
+        }
+
+        for (range, file) in response.ranges.iter().zip(received_fds.iter()) {
+            let region = self.regions.iter().find(|r| {
+                range.block_offset >= r.offset && range.block_offset < r.offset + r.size as u64
+            });
+            let region = match region {
+                Some(r) => r,
+                None => {
+                    let block_offset = range.block_offset;
+                    warn!("UffdBlock: block_offset 0x{block_offset:x} not in any region");
+                    continue;
+                }
+            };
+
+            let target_addr = region.base_host_virt_addr + (range.block_offset - region.offset);
+            // SAFETY: We are calling mmap with a valid fd and checking the result.
+            let map_addr = unsafe {
+                libc::mmap(
+                    target_addr as *mut _,
+                    range.len,
+                    region.prot,
+                    region.flags | libc::MAP_FIXED,
+                    file.as_raw_fd(),
+                    range.blob_offset as i64,
+                )
+            };
+            if map_addr == MAP_FAILED {
+                let err = io::Error::last_os_error();
+                if err.raw_os_error() == Some(libc::ENOMEM) {
+                    warn!("UffdBlock: mmap ENOMEM at 0x{target_addr:x}, fallback to uffd copy");
+                    self.copy_fallback(file, target_addr, range.len, range.blob_offset)?;
+                } else {
+                    warn!("UffdBlock: mmap failed for 0x{target_addr:x}: {err}");
+                }
+                continue;
+            }
+
+            if let Err(e) = uffd::wake(self.uffd_fd(), target_addr, range.len as u64) {
+                warn!("UffdBlock: failed to wake page at 0x{target_addr:x}: {e}");
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Fallback when mmap hits vm.max_map_count: read from blob fd, then UFFDIO_COPY.
+    ///
+    /// NOTE: This uses an intermediate buffer + UFFDIO_COPY for Linux 5.10 compatibility.
+    /// UFFDIO_CONTINUE (zero-copy: pread directly into guest memory + continue) requires
+    /// Linux 5.13+. When all deployments upgrade to 5.13+, this can be optimized to:
+    ///   1. pread() directly into target_addr (guest memory)
+    ///   2. uffd_continue(target_addr, len) to resolve the fault
+    ///
+    /// Since this is a fallback path (triggered only when mmap hits vm.max_map_count),
+    /// the extra copy is acceptable for now.
+    fn copy_fallback(
+        &self,
+        file: &File,
+        target_addr: u64,
+        len: usize,
+        blob_offset: u64,
+    ) -> io::Result<()> {
+        let mut buf = vec![0u8; len];
+        file.read_at(&mut buf, blob_offset)?;
+
+        match uffd::copy(self.uffd_fd(), target_addr, buf.as_ptr(), len as u64) {
+            Ok(()) => Ok(()),
+            Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
+                if let Err(e) = uffd::wake(self.uffd_fd(), target_addr, len as u64) {
+                    warn!("UffdBlock: failed to wake page at 0x{target_addr:x}: {e}");
+                }
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Returns the raw file descriptor of the underlying Unix socket.
+    pub fn sock_fd(&self) -> RawFd {
+        self.sock.as_raw_fd()
+    }
+
+    fn uffd_fd(&self) -> BorrowedFd<'_> {
+        self.uffd_fd.as_ref().expect("handshake not called").as_fd()
+    }
+}
+
+/// Shared epoll loop for zero-copy UFFD handling.
+///
+/// Watches `stop_event` and the UffdBlock socket fd; dispatches incoming
+/// `PageFaultResponse` messages until stopped or the connection closes.
+/// Log messages use the current thread name as prefix.
+///
+/// Signals readiness via `ready_tx` after epoll setup succeeds.
+pub fn uffd_handler_loop(
+    uffd_block: &UffdBlock,
+    stop_event: &EventFd,
+    ready_tx: &std::sync::mpsc::SyncSender<()>,
+) -> io::Result<()> {
+    let label = std::thread::current()
+        .name()
+        .unwrap_or("uffd-handler")
+        .to_owned();
+    let sock_fd = uffd_block.sock_fd();
+
+    const EVENT_STOP: u64 = 0;
+    const EVENT_SOCK: u64 = 1;
+
+    let epoll_fd = epoll::create(true).map_err(io::Error::other)?;
+    // SAFETY: epoll_fd is valid and owned by this scope.
+    let _epoll_file = unsafe { File::from_raw_fd(epoll_fd) };
+
+    epoll::ctl(
+        epoll_fd,
+        epoll::ControlOptions::EPOLL_CTL_ADD,
+        stop_event.as_raw_fd(),
+        epoll::Event::new(epoll::Events::EPOLLIN, EVENT_STOP),
+    )
+    .map_err(io::Error::other)?;
+
+    epoll::ctl(
+        epoll_fd,
+        epoll::ControlOptions::EPOLL_CTL_ADD,
+        sock_fd,
+        epoll::Event::new(epoll::Events::EPOLLIN, EVENT_SOCK),
+    )
+    .map_err(io::Error::other)?;
+
+    ready_tx.send(()).ok();
+
+    let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); 2];
+    loop {
+        let num_events = match epoll::wait(epoll_fd, -1, &mut events) {
+            Ok(n) => n,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        };
+
+        for event in events.iter().take(num_events) {
+            if event.data == EVENT_STOP {
+                stop_event.read().ok();
+                info!("{label}: stop event received");
+                return Ok(());
+            }
+            if event.data == EVENT_SOCK {
+                loop {
+                    match uffd_block.handle_response() {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            info!("{label}: connection closed");
+                            return Ok(());
+                        }
+                        Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
+                        Err(e) => {
+                            error!("{label}: error: {e}");
+                            return Err(e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::net::UnixListener;
+
+    use vmm_sys_util::sock_ctrl_msg::ScmSocket;
+    use vmm_sys_util::tempdir::TempDir;
+
+    use super::*;
+
+    fn test_vma_regions() -> Vec<VmaRegion> {
+        vec![
+            VmaRegion {
+                base_host_virt_addr: 0x7f0000000000,
+                size: 0x100000,
+                offset: 0,
+                page_size: 4096,
+                page_size_kib: 4,
+                prot: libc::PROT_READ | libc::PROT_WRITE,
+                flags: libc::MAP_PRIVATE,
+            },
+            VmaRegion {
+                base_host_virt_addr: 0x7f0000100000,
+                size: 0x200000,
+                offset: 0x100000,
+                page_size: 4096,
+                page_size_kib: 4,
+                prot: libc::PROT_READ,
+                flags: libc::MAP_SHARED,
+            },
+        ]
+    }
+
+    // ─── MessageType / FaultPolicy serialization ──────────────────────────────
+
+    #[test]
+    fn test_message_type_serde_repr() {
+        assert_eq!(MessageType::Handshake as u8, 0);
+        assert_eq!(MessageType::PageFault as u8, 1);
+
+        let json = serde_json::to_string(&MessageType::PageFault).unwrap();
+        assert_eq!(json, "1");
+
+        let v: MessageType = serde_json::from_str("0").unwrap();
+        assert_eq!(v, MessageType::Handshake);
+        let v: MessageType = serde_json::from_str("1").unwrap();
+        assert_eq!(v, MessageType::PageFault);
+    }
+
+    #[test]
+    fn test_fault_policy_serde_repr() {
+        assert_eq!(FaultPolicy::Zerocopy as u8, 0);
+        assert_eq!(FaultPolicy::Copy as u8, 1);
+
+        let json = serde_json::to_string(&FaultPolicy::Copy).unwrap();
+        assert_eq!(json, "1");
+
+        let v: FaultPolicy = serde_json::from_str("0").unwrap();
+        assert_eq!(v, FaultPolicy::Zerocopy);
+        let v: FaultPolicy = serde_json::from_str("1").unwrap();
+        assert_eq!(v, FaultPolicy::Copy);
+    }
+
+    #[test]
+    fn test_fault_policy_default() {
+        assert_eq!(FaultPolicy::default(), FaultPolicy::Zerocopy);
+    }
+
+    #[test]
+    fn test_message_type_default() {
+        assert_eq!(MessageType::default(), MessageType::Handshake);
+    }
+
+    // ─── VmaRegion serialization ──────────────────────────────────────────────
+
+    #[test]
+    fn test_vma_region_defaults() {
+        let json = r#"{"base_host_virt_addr":100,"size":4096,"offset":0,"page_size":4096}"#;
+        let r: VmaRegion = serde_json::from_str(json).unwrap();
+        assert_eq!(r.base_host_virt_addr, 100);
+        assert_eq!(r.size, 4096);
+        assert_eq!(r.page_size_kib, 0);
+        assert_eq!(r.prot, libc::PROT_READ);
+        assert_eq!(r.flags, libc::MAP_PRIVATE);
+    }
+
+    #[test]
+    fn test_vma_region_default_trait() {
+        let r = VmaRegion::default();
+        assert_eq!(r.base_host_virt_addr, 0);
+        assert_eq!(r.size, 0);
+        assert_eq!(r.offset, 0);
+        assert_eq!(r.page_size, 4096);
+        assert_eq!(r.page_size_kib, 0);
+        assert_eq!(r.prot, libc::PROT_READ);
+        assert_eq!(r.flags, libc::MAP_PRIVATE);
+    }
+
+    #[test]
+    fn test_vma_region_explicit() {
+        let r = VmaRegion {
+            base_host_virt_addr: 0x1000,
+            size: 0x2000,
+            offset: 0x100,
+            page_size: 2097152,
+            page_size_kib: 2048,
+            prot: libc::PROT_READ | libc::PROT_WRITE,
+            flags: libc::MAP_SHARED,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        let r2: VmaRegion = serde_json::from_str(&json).unwrap();
+        assert_eq!(r2.base_host_virt_addr, 0x1000);
+        assert_eq!(r2.size, 0x2000);
+        assert_eq!(r2.offset, 0x100);
+        assert_eq!(r2.page_size, 2097152);
+        assert_eq!(r2.page_size_kib, 2048);
+        assert_eq!(r2.prot, libc::PROT_READ | libc::PROT_WRITE);
+        assert_eq!(r2.flags, libc::MAP_SHARED);
+    }
+
+    #[test]
+    fn test_vma_region_default_flags_is_map_private() {
+        assert_eq!(default_flags(), libc::MAP_PRIVATE);
+    }
+
+    #[test]
+    fn test_vma_region_default_prot_is_prot_read() {
+        assert_eq!(default_prot(), libc::PROT_READ);
+    }
+
+    // ─── HandshakeRequest serialization ───────────────────────────────────────
+
+    #[test]
+    fn test_handshake_request_serde() {
+        let req = HandshakeRequest {
+            r#type: MessageType::Handshake,
+            regions: test_vma_regions(),
+            policy: FaultPolicy::Zerocopy,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let req2: HandshakeRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req2.r#type, MessageType::Handshake);
+        assert_eq!(req2.policy, FaultPolicy::Zerocopy);
+        assert_eq!(req2.regions.len(), 2);
+        assert_eq!(req2.regions[0].base_host_virt_addr, 0x7f0000000000);
+        assert_eq!(req2.regions[1].size, 0x200000);
+    }
+
+    #[test]
+    fn test_handshake_request_defaults() {
+        let json = r#"{"regions":[]}"#;
+        let req: HandshakeRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.r#type, MessageType::Handshake);
+        assert_eq!(req.policy, FaultPolicy::Zerocopy);
+        assert!(req.regions.is_empty());
+    }
+
+    // ─── PageFaultResponse deserialization ────────────────────────────────────
+
+    #[test]
+    fn test_page_fault_response_deser() {
+        let json = r#"{"ranges":[{"len":4096,"blob_offset":0,"block_offset":0}]}"#;
+        let resp: PageFaultResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.ranges.len(), 1);
+        assert_eq!(resp.ranges[0].len, 4096);
+        assert_eq!(resp.ranges[0].blob_offset, 0);
+        assert_eq!(resp.ranges[0].block_offset, 0);
+    }
+
+    #[test]
+    fn test_page_fault_response_multiple_ranges() {
+        let json = r#"{"ranges":[
+            {"len":4096,"blob_offset":0,"block_offset":0},
+            {"len":8192,"blob_offset":4096,"block_offset":4096}
+        ]}"#;
+        let resp: PageFaultResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.ranges.len(), 2);
+        assert_eq!(resp.ranges[1].len, 8192);
+        assert_eq!(resp.ranges[1].blob_offset, 4096);
+        assert_eq!(resp.ranges[1].block_offset, 4096);
+    }
+
+    // ─── UffdBlock new + handshake ────────────────────────────────────────────
+
+    #[test]
+    fn test_uffd_block_new_connection_error() {
+        let result = UffdBlock::new("/tmp/nonexistent_uffd_test.sock", FaultPolicy::Zerocopy);
+        result.unwrap_err();
+    }
+
+    #[test]
+    fn test_uffd_block_new_and_handshake() {
+        let tmp_dir = TempDir::new().unwrap();
+        let sock_path = tmp_dir.as_path().join("test.sock");
+        let sock_path_str = sock_path.to_str().unwrap().to_string();
+
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let regions = test_vma_regions();
+
+        // Use an eventfd as a stand-in for the uffd fd — any valid fd works
+        // since it's just sent via SCM_RIGHTS during handshake.
+        // SAFETY: eventfd(0, 0) returns a valid fd on success; File::from_raw_fd takes ownership.
+        let uffd_fd = OwnedFd::from(unsafe { File::from_raw_fd(libc::eventfd(0, 0)) });
+        let uffd_raw = uffd_fd.as_raw_fd();
+
+        let mut block = UffdBlock::new(&sock_path_str, FaultPolicy::Zerocopy).unwrap();
+
+        let client_thread = std::thread::spawn(move || {
+            block.handshake(uffd_fd, regions.clone()).unwrap();
+            (block, regions)
+        });
+
+        // Server side: accept and verify handshake
+        let (stream, _) = listener.accept().unwrap();
+        let mut buf = vec![0u8; 4096];
+        let (bytes_read, file) = stream.recv_with_fd(&mut buf).unwrap();
+        buf.truncate(bytes_read);
+
+        let received: HandshakeRequest =
+            serde_json::from_slice(&buf).expect("Invalid JSON from handshake");
+        assert_eq!(received.r#type, MessageType::Handshake);
+        assert_eq!(received.regions.len(), 2);
+        assert_eq!(received.regions[0].base_host_virt_addr, 0x7f0000000000);
+        assert_eq!(received.regions[0].prot, libc::PROT_READ | libc::PROT_WRITE);
+        assert_eq!(received.regions[0].flags, libc::MAP_PRIVATE);
+        assert_eq!(received.regions[1].flags, libc::MAP_SHARED);
+        assert_eq!(received.policy, FaultPolicy::Zerocopy);
+
+        // Verify we received a file descriptor via SCM_RIGHTS
+        assert!(file.is_some());
+
+        let (block, regions) = client_thread.join().unwrap();
+        assert_eq!(block.sock_path, sock_path_str);
+        assert_eq!(block.uffd_fd.as_ref().unwrap().as_raw_fd(), uffd_raw);
+        assert_eq!(block.regions.len(), regions.len());
+        assert_eq!(block.policy, FaultPolicy::Zerocopy);
+    }
+
+    #[test]
+    fn test_uffd_block_handshake_copy_policy() {
+        let tmp_dir = TempDir::new().unwrap();
+        let sock_path = tmp_dir.as_path().join("test.sock");
+        let sock_path_str = sock_path.to_str().unwrap().to_string();
+
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let regions = test_vma_regions();
+        // SAFETY: eventfd(0, 0) returns a valid fd on success; File::from_raw_fd takes ownership.
+        let uffd_fd = OwnedFd::from(unsafe { File::from_raw_fd(libc::eventfd(0, 0)) });
+
+        let mut block = UffdBlock::new(&sock_path_str, FaultPolicy::Copy).unwrap();
+
+        let client_thread = std::thread::spawn(move || {
+            block.handshake(uffd_fd, regions).unwrap();
+            block
+        });
+
+        let (stream, _) = listener.accept().unwrap();
+        let mut buf = vec![0u8; 4096];
+        let (bytes_read, _) = stream.recv_with_fd(&mut buf).unwrap();
+        buf.truncate(bytes_read);
+
+        let received: HandshakeRequest = serde_json::from_slice(&buf).unwrap();
+        assert_eq!(received.policy, FaultPolicy::Copy);
+
+        let block = client_thread.join().unwrap();
+        assert_eq!(block.policy, FaultPolicy::Copy);
+    }
+
+    // ─── handle_response tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_handle_response_would_block() {
+        let tmp_dir = TempDir::new().unwrap();
+        let sock_path = tmp_dir.as_path().join("test.sock");
+        let sock_path_str = sock_path.to_str().unwrap().to_string();
+
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        // SAFETY: eventfd(0, 0) returns a valid fd on success; File::from_raw_fd takes ownership.
+        let uffd_fd = OwnedFd::from(unsafe { File::from_raw_fd(libc::eventfd(0, 0)) });
+
+        let mut block = UffdBlock::new(&sock_path_str, FaultPolicy::Zerocopy).unwrap();
+
+        let client_thread = std::thread::spawn(move || {
+            block.handshake(uffd_fd, test_vma_regions()).unwrap();
+            block
+        });
+
+        // Accept and drain handshake
+        let (stream, _) = listener.accept().unwrap();
+        let mut buf = vec![0u8; 4096];
+        let _ = stream.recv_with_fd(&mut buf).unwrap();
+
+        let block = client_thread.join().unwrap();
+
+        // No data sent, non-blocking socket → WouldBlock
+        let err = block.handle_response().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+    }
+
+    #[test]
+    fn test_handle_response_connection_closed() {
+        let tmp_dir = TempDir::new().unwrap();
+        let sock_path = tmp_dir.as_path().join("test.sock");
+        let sock_path_str = sock_path.to_str().unwrap().to_string();
+
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        // SAFETY: eventfd(0, 0) returns a valid fd on success; File::from_raw_fd takes ownership.
+        let uffd_fd = OwnedFd::from(unsafe { File::from_raw_fd(libc::eventfd(0, 0)) });
+
+        let mut block = UffdBlock::new(&sock_path_str, FaultPolicy::Zerocopy).unwrap();
+
+        let client_thread = std::thread::spawn(move || {
+            block.handshake(uffd_fd, test_vma_regions()).unwrap();
+            block
+        });
+
+        // Accept, drain handshake, then close server side
+        let (stream, _) = listener.accept().unwrap();
+        let mut buf = vec![0u8; 4096];
+        let _ = stream.recv_with_fd(&mut buf).unwrap();
+        drop(stream);
+
+        let block = client_thread.join().unwrap();
+
+        // Set blocking so recv returns 0 (connection closed) instead of WouldBlock
+        block.sock.set_nonblocking(false).unwrap();
+        assert!(!block.handle_response().unwrap());
+    }
+
+    #[test]
+    fn test_handle_response_fd_range_mismatch() {
+        let tmp_dir = TempDir::new().unwrap();
+        let sock_path = tmp_dir.as_path().join("test.sock");
+        let sock_path_str = sock_path.to_str().unwrap().to_string();
+
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        // SAFETY: eventfd(0, 0) returns a valid fd on success; File::from_raw_fd takes ownership.
+        let uffd_fd = OwnedFd::from(unsafe { File::from_raw_fd(libc::eventfd(0, 0)) });
+
+        let mut block = UffdBlock::new(&sock_path_str, FaultPolicy::Zerocopy).unwrap();
+
+        let client_thread = std::thread::spawn(move || {
+            block.handshake(uffd_fd, test_vma_regions()).unwrap();
+            block
+        });
+
+        // Accept and drain handshake
+        let (stream, _) = listener.accept().unwrap();
+        let mut buf = vec![0u8; 4096];
+        let _ = stream.recv_with_fd(&mut buf).unwrap();
+
+        // Send a response with 2 ranges but only 1 fd → mismatch
+        let response = r#"{"ranges":[{"len":4096,"blob_offset":0,"block_offset":0},{"len":4096,"blob_offset":4096,"block_offset":4096}]}"#;
+        let tmp_file = tempfile::NamedTempFile::new().unwrap();
+        stream
+            .send_with_fd(response.as_bytes(), tmp_file.as_raw_fd())
+            .unwrap();
+
+        let block = client_thread.join().unwrap();
+
+        // Set blocking temporarily to read the response
+        block.sock.set_nonblocking(false).unwrap();
+        let err = block.handle_response().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("fd count"));
+    }
+
+    #[test]
+    fn test_handle_response_invalid_json() {
+        let tmp_dir = TempDir::new().unwrap();
+        let sock_path = tmp_dir.as_path().join("test.sock");
+        let sock_path_str = sock_path.to_str().unwrap().to_string();
+
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        // SAFETY: eventfd(0, 0) returns a valid fd on success; File::from_raw_fd takes ownership.
+        let uffd_fd = OwnedFd::from(unsafe { File::from_raw_fd(libc::eventfd(0, 0)) });
+
+        let mut block = UffdBlock::new(&sock_path_str, FaultPolicy::Zerocopy).unwrap();
+
+        let client_thread = std::thread::spawn(move || {
+            block.handshake(uffd_fd, test_vma_regions()).unwrap();
+            block
+        });
+
+        let (stream, _) = listener.accept().unwrap();
+        let mut buf = vec![0u8; 4096];
+        let _ = stream.recv_with_fd(&mut buf).unwrap();
+
+        // Send invalid JSON — pass a valid fd since send_with_fd requires it
+        stream
+            .send_with_fd(&b"not json{}"[..], stream.as_raw_fd())
+            .unwrap();
+
+        let block = client_thread.join().unwrap();
+
+        block.sock.set_nonblocking(false).unwrap();
+        let err = block.handle_response().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    // ─── UffdBlock debug ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_uffd_block_debug() {
+        let tmp_dir = TempDir::new().unwrap();
+        let sock_path = tmp_dir.as_path().join("test.sock");
+        let sock_path_str = sock_path.to_str().unwrap().to_string();
+
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        // SAFETY: eventfd(0, 0) returns a valid fd on success; File::from_raw_fd takes ownership.
+        let uffd_fd = OwnedFd::from(unsafe { File::from_raw_fd(libc::eventfd(0, 0)) });
+
+        let mut block = UffdBlock::new(&sock_path_str, FaultPolicy::Copy).unwrap();
+        block.handshake(uffd_fd, test_vma_regions()).unwrap();
+
+        let debug_str = format!("{block:?}");
+        assert!(debug_str.contains("test.sock"));
+        assert!(debug_str.contains("Copy"));
+        assert!(debug_str.contains("sock_fd"));
+
+        // Drain the server side so the listener can be dropped
+        let (stream, _) = listener.accept().unwrap();
+        let mut buf = vec![0u8; 4096];
+        let _ = stream.recv_with_fd(&mut buf);
+    }
+
+    // ─── uffd_handler_loop stop ───────────────────────────────────────────────
+
+    #[test]
+    fn test_uffd_handler_loop_stop() {
+        let tmp_dir = TempDir::new().unwrap();
+        let sock_path = tmp_dir.as_path().join("test.sock");
+        let sock_path_str = sock_path.to_str().unwrap().to_string();
+
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        // SAFETY: eventfd(0, 0) returns a valid fd on success; File::from_raw_fd takes ownership.
+        let uffd_fd = OwnedFd::from(unsafe { File::from_raw_fd(libc::eventfd(0, 0)) });
+
+        let mut block = UffdBlock::new(&sock_path_str, FaultPolicy::Zerocopy).unwrap();
+
+        let client_thread = std::thread::spawn(move || {
+            block.handshake(uffd_fd, test_vma_regions()).unwrap();
+            block
+        });
+
+        // Accept and drain handshake so client thread finishes
+        let (stream, _) = listener.accept().unwrap();
+        let mut buf = vec![0u8; 4096];
+        let _ = stream.recv_with_fd(&mut buf).unwrap();
+
+        let block = client_thread.join().unwrap();
+        let stop_event = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+
+        // Write to stop_event to signal the loop to exit
+        stop_event.write(1).unwrap();
+
+        let (ready_tx, _ready_rx) = std::sync::mpsc::sync_channel(1);
+        let _sock_fd = block.sock_fd();
+        let handle = std::thread::Builder::new()
+            .name("test-uffd-handler".into())
+            .spawn(move || uffd_handler_loop(&block, &stop_event, &ready_tx))
+            .unwrap();
+
+        // The loop should exit promptly due to the stop event.
+        let result = handle.join().expect("handler loop should exit cleanly");
+        result.unwrap();
+    }
+}

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1338,6 +1338,7 @@ impl Vm {
         source_url: Option<&str>,
         prefault: Option<bool>,
         memory_restore_mode: Option<MemoryRestoreMode>,
+        external_sock: Option<&std::path::Path>,
     ) -> Result<Self> {
         trace_scoped!("Vm::new");
 
@@ -1395,6 +1396,7 @@ impl Vm {
                     memory_restore_mode.unwrap_or_default(),
                     phys_bits,
                     &exit_evt,
+                    external_sock,
                 )
                 .map_err(Error::MemoryManager)?
             } else {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -516,6 +516,24 @@ impl ApplyLandlock for GenericVhostUserConfig {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub enum MemBackendType {
+    #[default]
+    File,
+    Uffd,
+}
+
+impl std::str::FromStr for MemBackendType {
+    type Err = String;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "file" => Ok(Self::File),
+            "uffd" => Ok(Self::Uffd),
+            _ => Err(format!("invalid backend type: {s}")),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct PmemConfig {
     #[serde(flatten)]
@@ -525,12 +543,22 @@ pub struct PmemConfig {
     pub size: Option<u64>,
     #[serde(default)]
     pub discard_writes: bool,
+    #[serde(default)]
+    pub backend_type: MemBackendType,
 }
 
 impl ApplyLandlock for PmemConfig {
     fn apply_landlock(&self, landlock: &mut Landlock) -> LandlockResult<()> {
-        let access = if self.discard_writes { "r" } else { "rw" };
-        landlock.add_rule_with_access(&self.file, access)?;
+        match self.backend_type {
+            MemBackendType::File => {
+                let access = if self.discard_writes { "r" } else { "rw" };
+                landlock.add_rule_with_access(&self.file, access)?;
+            }
+            MemBackendType::Uffd => {
+                // For UFFD backend, file is a socket path
+                landlock.add_rule_with_access(&self.file, "rw")?;
+            }
+        }
         Ok(())
     }
 }
@@ -1182,5 +1210,32 @@ impl VmConfig {
         } else {
             self.cpus.max_vcpus
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mem_backend_type_default() {
+        assert_eq!(MemBackendType::default(), MemBackendType::File);
+    }
+
+    #[test]
+    fn test_mem_backend_type_from_str() {
+        assert_eq!(
+            "file".parse::<MemBackendType>().unwrap(),
+            MemBackendType::File
+        );
+        assert_eq!(
+            "uffd".parse::<MemBackendType>().unwrap(),
+            MemBackendType::Uffd
+        );
+        assert_eq!(
+            "UFFD".parse::<MemBackendType>().unwrap(),
+            MemBackendType::Uffd
+        );
+        "invalid".parse::<MemBackendType>().unwrap_err();
     }
 }


### PR DESCRIPTION
## Motivation

  Cloud Hypervisor's existing on-demand snapshot restore uses `userfaultfd` with an internal handler thread that reads
   pages from the local `memory-ranges` file. This works for local snapshots but cannot support scenarios where page
  data is served by an external process (e.g., a remote image service like nydusd).

  Similarly, PMEM devices are limited to file-backed memory. There is no mechanism for an external handler to supply
  page data on demand, which is required for zero-copy container image integration.

  This PR adds a UFFD backend protocol that allows an external handler to resolve page faults for guest RAM (both PMEM devices and snapshot restore are supported), enabling on-demand page loading from remote or lazily-prepared data sources.

  ## Changes

  ### New: `uffd_block` module (`vmm/src/uffd_block.rs`)

  A public module implementing the VMM side of the UFFD protocol shared between PMEM and snapshot restore:

  - **`UffdBlock`**: connects to an external handler over a Unix socket, performs a handshake (sends VMA regions +
  uffd fd via `SCM_RIGHTS`), then processes `PageFaultResponse` messages containing blob file descriptors
  - **Zero-copy path**: `mmap(MAP_FIXED)` blob fds directly over the faulting guest region; falls back to
  `UFFDIO_COPY` when `mmap` hits `vm.max_map_count`
  - **`uffd_handler_loop()`**: shared epoll event loop with stop-event and readiness synchronization, used by both
  PMEM and snapshot restore handler threads
  - Protocol types: `MessageType`, `FaultPolicy`, `VmaRegion`, `HandshakeRequest`, `PageFaultResponse`, `BlobRange`

  ### PMEM UFFD backend (`vmm/src/device_manager.rs`)

  - New `backend_type=uffd` option on `--pmem`: the `file` parameter becomes a Unix socket path to an external handler
  - Creates anonymous memory via `memfd`, registers it with `userfaultfd`, and spawns a handler thread running
  `uffd_handler_loop`
  - `PmemUffdHandler` struct manages the thread lifecycle (stop event, result channel, join handle), matching the
  pattern used by `MemoryManager::UffdHandler`

  ### External handler for snapshot restore (`vmm/src/memory_manager.rs`)

  - New `external_sock=<path>` option on `--restore` (used with `memory_restore_mode=ondemand`)
  - When specified, performs a `FaultPolicy::Copy` handshake with the external handler and delegates `UFFDIO_COPY` to
  it — no local handler thread is needed
  - Without `external_sock`, the existing behavior (local file + internal handler thread) is unchanged

  ### Example: `ch-uffd-handler` (`cloud-hypervisor/src/bin/ch-uffd-handler.rs`)

  A reference external UFFD handler binary that:
  - Listens on a Unix socket, receives the uffd fd via handshake
  - Monitors page faults and resolves them using either zerocopy (sends blob fd) or copy mode (`UFFDIO_COPY`)
  - Uses `vmm::uffd_block` protocol types and `vmm_sys_util::ScmSocket` for fd passing

  ### Documentation

  - `docs/device_model.md`: virtio-pmem UFFD backend usage and zerocopy explanation
  - `docs/snapshot_restore.md`: `external_sock` parameter and external handler workflow

  ## How to Test

Add pmem uffd device with nydusd 

  ```bash
  # Start nydusd UFFD handler (provides blob fds for zerocopy)
  nydusd uffd --config <config> --bootstrap <bootstrap> --sock /tmp/handler.sock &

  # Boot VM with PMEM backed by the UFFD handler
  cloud-hypervisor \
    --api-socket /tmp/ch.sock \
    --memory size=4G,shared=on \
    --pmem file=/tmp/handler.sock,size=$DEVSZ,backend_type=uffd,discard_writes=on \
    --kernel vmlinux --cmdline "root=/dev/vda console=ttyS0 rw" \
    --disk path=rootfs.ext4

  # Verify: guest should see /dev/pmem0 and be able to read from it
```

  Snapshot restore with external UFFD handler (copy-mode page fault resolution):

```
  # Pause and snapshot the VM
  ch-remote --api-socket /tmp/ch.sock pause
  ch-remote --api-socket /tmp/ch.sock snapshot file:///tmp/ch-snapshot

  # Kill the original VM, then start the handler against the memory file
  ch-uffd-handler --socket /tmp/mem-handler.sock --file /tmp/ch-snapshot/memory-ranges &

  # Restore with external_sock (handler will use Copy policy from handshake)
  cloud-hypervisor \
    --api-socket /tmp/ch-restore.sock \
    --restore
  source_url=file:///tmp/ch-snapshot,memory_restore_mode=ondemand,external_sock=/tmp/mem-handler.sock,resume=true

  # Verify: restored VM should be in Running state
```

## See Aslo

https://github.com/dragonflyoss/nydus/pull/1921
https://github.com/firecracker-microvm/firecracker/pull/5840