### PR TITLE
block: Drop batch request support

### DIFF
--- a/block/src/async_io.rs
+++ b/block/src/async_io.rs
@@ -8,7 +8,7 @@ use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use thiserror::Error;
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::{BatchRequest, SECTOR_SIZE};
+use crate::SECTOR_SIZE;
 
 #[derive(Error, Debug)]
 pub enum DiskFileError {
@@ -100,12 +100,6 @@ pub trait AsyncIo: Send {
     fn punch_hole(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()>;
     fn write_zeroes(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()>;
     fn next_completed_request(&mut self) -> Option<(u64, i32)>;
-    fn batch_requests_enabled(&self) -> bool {
-        false
-    }
-    fn submit_batch_requests(&mut self, _batch_request: &[BatchRequest]) -> AsyncIoResult<()> {
-        Ok(())
-    }
     fn alignment(&self) -> u64 {
         SECTOR_SIZE
     }

--- a/block/src/fixed_vhd_async.rs
+++ b/block/src/fixed_vhd_async.rs
@@ -6,7 +6,6 @@ use std::os::unix::io::RawFd;
 
 use vmm_sys_util::eventfd::EventFd;
 
-use crate::BatchRequest;
 use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
 use crate::error::BlockResult;
 use crate::raw_async::RawFileAsync;
@@ -89,13 +88,5 @@ impl AsyncIo for FixedVhdAsync {
         Err(AsyncIoError::WriteZeroes(std::io::Error::other(
             "write_zeroes not supported for fixed VHD",
         )))
-    }
-
-    fn batch_requests_enabled(&self) -> bool {
-        true
-    }
-
-    fn submit_batch_requests(&mut self, batch_request: &[BatchRequest]) -> AsyncIoResult<()> {
-        self.raw_file_async.submit_batch_requests(batch_request)
     }
 }

--- a/block/src/fixed_vhd_disk.rs
+++ b/block/src/fixed_vhd_disk.rs
@@ -124,7 +124,6 @@ mod unit_tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
-    use crate::async_io::AsyncIo;
     use crate::disk_file::{AsyncDiskFile, DiskSize, PhysicalSize, Resizable};
 
     /// Minimal fixed VHD footer (disk type = 2, current_size = 0x11223344).
@@ -164,20 +163,19 @@ mod unit_tests {
         assert_eq!(disk.logical_size().unwrap(), 0x1122_3344);
     }
 
-    fn assert_async_io_from_dyn(disk: &dyn AsyncDiskFile, expect_batch: bool) {
-        let io: Box<dyn AsyncIo> = disk.create_async_io(128).unwrap();
-        assert_eq!(io.batch_requests_enabled(), expect_batch);
+    fn assert_async_io_from_dyn(disk: &dyn AsyncDiskFile) {
+        let _ = disk.create_async_io(128).unwrap();
     }
 
-    fn assert_async_io(disk: &FixedVhdDisk, expect_batch: bool) {
-        assert_async_io_from_dyn(disk, expect_batch);
+    fn assert_async_io(disk: &FixedVhdDisk) {
+        assert_async_io_from_dyn(disk);
     }
 
     #[test]
     fn sync_backend_disables_batch_requests() {
         let file = make_vhd_file();
         let disk = FixedVhdDisk::new(file, false).unwrap();
-        assert_async_io(&disk, false);
+        assert_async_io(&disk);
     }
 
     #[cfg(feature = "io_uring")]
@@ -185,7 +183,7 @@ mod unit_tests {
     fn io_uring_backend_enables_batch_requests() {
         let file = make_vhd_file();
         let disk = FixedVhdDisk::new(file, true).unwrap();
-        assert_async_io(&disk, true);
+        assert_async_io(&disk);
     }
 
     #[test]
@@ -193,7 +191,7 @@ mod unit_tests {
         let file = make_vhd_file();
         let disk = FixedVhdDisk::new(file, false).unwrap();
         let cloned = disk.try_clone().unwrap();
-        assert_async_io_from_dyn(cloned.as_ref(), false);
+        assert_async_io_from_dyn(cloned.as_ref());
     }
 
     #[cfg(feature = "io_uring")]
@@ -202,7 +200,7 @@ mod unit_tests {
         let file = make_vhd_file();
         let disk = FixedVhdDisk::new(file, true).unwrap();
         let cloned = disk.try_clone().unwrap();
-        assert_async_io_from_dyn(cloned.as_ref(), true);
+        assert_async_io_from_dyn(cloned.as_ref());
     }
 
     #[test]

--- a/block/src/lib.rs
+++ b/block/src/lib.rs
@@ -59,7 +59,7 @@ use libc::{
     FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE, FALLOC_FL_ZERO_RANGE, S_IFBLK, S_IFMT, ioctl,
 };
 use log::{debug, info, warn};
-pub use request::{BatchRequest, ExecuteAsync, MAX_DISCARD_WRITE_ZEROES_SEG, Request, RequestType};
+pub use request::{ExecuteAsync, MAX_DISCARD_WRITE_ZEROES_SEG, Request, RequestType};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use thiserror::Error;

--- a/block/src/qcow_async.rs
+++ b/block/src/qcow_async.rs
@@ -16,6 +16,7 @@ use io_uring::{IoUring, opcode, types};
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::write_zeroes::{PunchHole, WriteZeroesAt};
 
+use crate::SECTOR_SIZE;
 use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
 use crate::qcow::decoder::Decoder;
 use crate::qcow::metadata::{
@@ -26,7 +27,6 @@ use crate::qcow_common::{
     AlignedBuf, aligned_pread, aligned_pwrite, decompress_cluster, gather_from_iovecs_into,
     pread_alloc, pread_exact, pwrite_all, scatter_to_iovecs, zero_fill_iovecs,
 };
-use crate::{BatchRequest, RequestType, SECTOR_SIZE};
 
 /// Per queue QCOW2 I/O worker using io_uring.
 ///
@@ -243,93 +243,8 @@ impl AsyncIo for QcowAsync {
         self.punch_hole(offset, length, user_data)
     }
 
-    fn batch_requests_enabled(&self) -> bool {
-        true
-    }
-
     fn alignment(&self) -> u64 {
         self.io_alignment
-    }
-
-    fn submit_batch_requests(&mut self, batch_request: &[BatchRequest]) -> AsyncIoResult<()> {
-        let (submitter, mut sq, _) = self.io_uring.split();
-        let mut needs_submit = false;
-        let mut sync_completions: Vec<(u64, i32)> = Vec::new();
-
-        for req in batch_request {
-            match req.request_type {
-                RequestType::In => {
-                    let total_len: usize = req.iovecs.iter().map(|v| v.iov_len).sum();
-
-                    if let Some(host_offset) = Self::resolve_read(
-                        &self.metadata,
-                        &self.data_file,
-                        &self.backing_file,
-                        req.offset as u64,
-                        &req.iovecs,
-                        total_len,
-                        self.alignment,
-                        self.cluster_size,
-                        &*self.decoder,
-                    )? {
-                        let fd = self.data_file.as_raw_fd();
-                        // SAFETY: fd is valid and iovecs point to valid guest memory.
-                        unsafe {
-                            sq.push(
-                                &opcode::Readv::new(
-                                    types::Fd(fd),
-                                    req.iovecs.as_ptr(),
-                                    req.iovecs.len() as u32,
-                                )
-                                .offset(host_offset)
-                                .build()
-                                .user_data(req.user_data),
-                            )
-                            .map_err(|_| {
-                                AsyncIoError::ReadVectored(io::Error::other(
-                                    "Submission queue is full",
-                                ))
-                            })?;
-                        }
-                        needs_submit = true;
-                    } else {
-                        sync_completions.push((req.user_data, total_len as i32));
-                    }
-                }
-                RequestType::Out => {
-                    let total_len: usize = req.iovecs.iter().map(|v| v.iov_len).sum();
-                    Self::cow_write_sync(
-                        req.offset as u64,
-                        &req.iovecs,
-                        &self.metadata,
-                        &self.data_file,
-                        &self.backing_file,
-                        self.alignment,
-                        self.cluster_size,
-                    )?;
-                    sync_completions.push((req.user_data, total_len as i32));
-                }
-                _ => {
-                    unreachable!("Unexpected batch request type: {:?}", req.request_type)
-                }
-            }
-        }
-
-        if needs_submit {
-            sq.sync();
-            submitter
-                .submit()
-                .map_err(AsyncIoError::SubmitBatchRequests)?;
-        }
-
-        if !sync_completions.is_empty() {
-            for c in sync_completions {
-                self.completion_list.push_back(c);
-            }
-            self.eventfd.write(1).unwrap();
-        }
-
-        Ok(())
     }
 }
 
@@ -556,11 +471,11 @@ mod unit_tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
+    use crate::SECTOR_SIZE;
     use crate::disk_file::AsyncDiskFile;
     use crate::qcow::{QcowFile, RawFile};
     use crate::qcow_common::unit_tests::compress_allocated_clusters;
     use crate::qcow_disk::QcowDisk;
-    use crate::{BatchRequest, RequestType, SECTOR_SIZE};
 
     fn create_disk_with_data(
         file_size: u64,
@@ -727,108 +642,6 @@ mod unit_tests {
             buf[4096..].iter().all(|&b| b == 0xBB),
             "second half should come from cluster 1"
         );
-    }
-
-    #[test]
-    fn test_qcow_async_batch_mixed_requests() {
-        let file_size = 100 * 1024 * 1024;
-        let temp_file = TempFile::new().unwrap();
-        {
-            let raw_file = RawFile::new(temp_file.as_file().try_clone().unwrap(), false);
-            QcowFile::new(raw_file, 3, file_size, true).unwrap();
-        }
-        let disk = QcowDisk::new(
-            temp_file.as_file().try_clone().unwrap(),
-            false,
-            false,
-            true,
-            true,
-        )
-        .unwrap();
-
-        let mut async_io = disk.create_async_io(8).unwrap();
-
-        // Prepare write data for two regions.
-        let write_a = vec![0xAA; 4096];
-        let write_b = vec![0xBB; 4096];
-        let offset_a: u64 = 0;
-        let offset_b: u64 = 65536;
-
-        let iov_a = libc::iovec {
-            iov_base: write_a.as_ptr().cast::<libc::c_void>().cast_mut(),
-            iov_len: write_a.len(),
-        };
-        let iov_b = libc::iovec {
-            iov_base: write_b.as_ptr().cast::<libc::c_void>().cast_mut(),
-            iov_len: write_b.len(),
-        };
-
-        let batch = vec![
-            BatchRequest {
-                offset: offset_a as libc::off_t,
-                iovecs: smallvec::smallvec![iov_a],
-                user_data: 10,
-                request_type: RequestType::Out,
-            },
-            BatchRequest {
-                offset: offset_b as libc::off_t,
-                iovecs: smallvec::smallvec![iov_b],
-                user_data: 20,
-                request_type: RequestType::Out,
-            },
-        ];
-
-        async_io.submit_batch_requests(&batch).unwrap();
-
-        let mut completions = [
-            wait_for_completion(async_io.as_mut()),
-            wait_for_completion(async_io.as_mut()),
-        ];
-        completions.sort_by_key(|c| c.0);
-        assert_eq!(completions[0], (10, 4096));
-        assert_eq!(completions[1], (20, 4096));
-        drop(async_io);
-
-        // Batch read both regions back.
-        let mut read_a = vec![0u8; 4096];
-        let mut read_b = vec![0u8; 4096];
-        let riov_a = libc::iovec {
-            iov_base: read_a.as_mut_ptr().cast(),
-            iov_len: read_a.len(),
-        };
-        let riov_b = libc::iovec {
-            iov_base: read_b.as_mut_ptr().cast(),
-            iov_len: read_b.len(),
-        };
-
-        let mut async_io = disk.create_async_io(8).unwrap();
-        let read_batch = vec![
-            BatchRequest {
-                offset: offset_a as libc::off_t,
-                iovecs: smallvec::smallvec![riov_a],
-                user_data: 30,
-                request_type: RequestType::In,
-            },
-            BatchRequest {
-                offset: offset_b as libc::off_t,
-                iovecs: smallvec::smallvec![riov_b],
-                user_data: 40,
-                request_type: RequestType::In,
-            },
-        ];
-
-        async_io.submit_batch_requests(&read_batch).unwrap();
-
-        let mut completions = [
-            wait_for_completion(async_io.as_mut()),
-            wait_for_completion(async_io.as_mut()),
-        ];
-        completions.sort_by_key(|c| c.0);
-        assert_eq!(completions[0], (30, 4096));
-        assert_eq!(completions[1], (40, 4096));
-
-        assert_eq!(read_a, write_a, "batch read A should match written data");
-        assert_eq!(read_b, write_b, "batch read B should match written data");
     }
 
     #[test]

--- a/block/src/qcow_disk.rs
+++ b/block/src/qcow_disk.rs
@@ -192,7 +192,6 @@ mod unit_tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
-    use crate::async_io::AsyncIo;
     use crate::disk_file::{AsyncDiskFile, DiskSize, PhysicalSize};
     use crate::qcow::{QcowFile, RawFile};
 
@@ -214,20 +213,19 @@ mod unit_tests {
         assert_eq!(disk.logical_size().unwrap(), TEST_SIZE);
     }
 
-    fn assert_async_io_from_dyn(disk: &dyn AsyncDiskFile, expect_batch: bool) {
-        let io: Box<dyn AsyncIo> = disk.create_async_io(128).unwrap();
-        assert_eq!(io.batch_requests_enabled(), expect_batch);
+    fn assert_async_io_from_dyn(disk: &dyn AsyncDiskFile) {
+        let _ = disk.create_async_io(128).unwrap();
     }
 
-    fn assert_async_io(disk: &QcowDisk, expect_batch: bool) {
-        assert_async_io_from_dyn(disk, expect_batch);
+    fn assert_async_io(disk: &QcowDisk) {
+        assert_async_io_from_dyn(disk);
     }
 
     #[test]
     fn sync_backend_disables_batch_requests() {
         let file = make_qcow_file();
         let disk = QcowDisk::new(file, false, false, true, false).unwrap();
-        assert_async_io(&disk, false);
+        assert_async_io(&disk);
     }
 
     #[cfg(feature = "io_uring")]
@@ -235,7 +233,7 @@ mod unit_tests {
     fn io_uring_backend_enables_batch_requests() {
         let file = make_qcow_file();
         let disk = QcowDisk::new(file, false, false, true, true).unwrap();
-        assert_async_io(&disk, true);
+        assert_async_io(&disk);
     }
 
     #[test]
@@ -243,7 +241,7 @@ mod unit_tests {
         let file = make_qcow_file();
         let disk = QcowDisk::new(file, false, false, true, false).unwrap();
         let cloned = disk.try_clone().unwrap();
-        assert_async_io_from_dyn(cloned.as_ref(), false);
+        assert_async_io_from_dyn(cloned.as_ref());
     }
 
     #[cfg(feature = "io_uring")]
@@ -252,7 +250,7 @@ mod unit_tests {
         let file = make_qcow_file();
         let disk = QcowDisk::new(file, false, false, true, true).unwrap();
         let cloned = disk.try_clone().unwrap();
-        assert_async_io_from_dyn(cloned.as_ref(), true);
+        assert_async_io_from_dyn(cloned.as_ref());
     }
 
     #[test]

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -12,7 +12,7 @@ use vmm_sys_util::eventfd::EventFd;
 use crate::async_io::{AsyncIo, AsyncIoError, AsyncIoResult};
 use crate::error::{BlockError, BlockErrorKind, BlockResult};
 use crate::sparse::{blkdiscard, blkzeroout};
-use crate::{BatchRequest, RequestType, SECTOR_SIZE, is_block_device};
+use crate::{SECTOR_SIZE, is_block_device};
 
 pub struct RawFileAsync {
     fd: RawFd,
@@ -168,91 +168,6 @@ impl AsyncIo for RawFileAsync {
             .completion()
             .next()
             .map(|entry| (entry.user_data(), entry.result()))
-    }
-
-    fn batch_requests_enabled(&self) -> bool {
-        true
-    }
-
-    fn submit_batch_requests(&mut self, batch_request: &[BatchRequest]) -> AsyncIoResult<()> {
-        if !self.batch_requests_enabled() {
-            return Ok(());
-        }
-
-        let (submitter, mut sq, _) = self.io_uring.split();
-        let mut submitted = false;
-
-        // Refuse the whole batch if it can't fit in the SQ to avoid having to unroll a partially
-        // successful push.
-        if batch_request.len() > sq.capacity() - sq.len() {
-            return Err(AsyncIoError::SubmitBatchRequests(Error::other(
-                "io_uring submission queue is full",
-            )));
-        }
-
-        for req in batch_request {
-            match req.request_type {
-                RequestType::In => {
-                    // SAFETY: we know the file descriptor is valid and we
-                    // relied on vm-memory to provide the buffer address.
-                    unsafe {
-                        sq.push(
-                            &opcode::Readv::new(
-                                types::Fd(self.fd),
-                                req.iovecs.as_ptr(),
-                                req.iovecs.len() as u32,
-                            )
-                            .offset(req.offset as u64)
-                            .build()
-                            .user_data(req.user_data),
-                        )
-                        .map_err(|e| {
-                            AsyncIoError::ReadVectored(Error::other(format!(
-                                "Submission queue is full: {e:?}"
-                            )))
-                        })?;
-                    };
-                    submitted = true;
-                }
-                RequestType::Out => {
-                    // SAFETY: we know the file descriptor is valid and we
-                    // relied on vm-memory to provide the buffer address.
-                    unsafe {
-                        sq.push(
-                            &opcode::Writev::new(
-                                types::Fd(self.fd),
-                                req.iovecs.as_ptr(),
-                                req.iovecs.len() as u32,
-                            )
-                            .offset(req.offset as u64)
-                            .build()
-                            .user_data(req.user_data),
-                        )
-                        .map_err(|e| {
-                            AsyncIoError::WriteVectored(Error::other(format!(
-                                "Submission queue is full: {e:?}"
-                            )))
-                        })?;
-                    };
-                    submitted = true;
-                }
-                _ => {
-                    unreachable!("Unexpected batch request type: {:?}", req.request_type)
-                }
-            }
-        }
-
-        // Only submit if we actually queued something
-        if submitted {
-            // Update the submission queue and submit new operations to the
-            // io_uring instance.
-            sq.sync();
-            submitter
-                .submit()
-                .map_err(AsyncIoError::SubmitBatchRequests)?;
-        }
-
-        Ok(())
     }
 
     fn punch_hole(&mut self, offset: u64, length: u64, user_data: u64) -> AsyncIoResult<()> {

--- a/block/src/raw_disk.rs
+++ b/block/src/raw_disk.rs
@@ -150,7 +150,6 @@ mod unit_tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
-    use crate::async_io::AsyncIo;
     use crate::disk_file::{AsyncDiskFile, DiskSize, PhysicalSize, Resizable};
 
     const TEST_SIZE: u64 = 0x1122_3344;
@@ -168,33 +167,24 @@ mod unit_tests {
         assert_eq!(disk.logical_size().unwrap(), TEST_SIZE);
     }
 
-    fn assert_async_io_from_dyn(disk: &dyn AsyncDiskFile, expect_backend: RawBackend) {
-        let io: Box<dyn AsyncIo> = disk.create_async_io(128).unwrap();
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "io_uring")] {
-                let expected_batch_requests = expect_backend == RawBackend::IoUring;
-            } else {
-                let _ = expect_backend;
-                let expected_batch_requests = false;
-            }
-        }
-        assert_eq!(io.batch_requests_enabled(), expected_batch_requests);
+    fn assert_async_io_from_dyn(disk: &dyn AsyncDiskFile) {
+        let _ = disk.create_async_io(128).unwrap();
     }
 
     fn assert_sync_backend(disk: &RawDisk) {
         assert_eq!(disk.backend, RawBackend::Sync);
-        assert_async_io_from_dyn(disk, RawBackend::Sync);
+        assert_async_io_from_dyn(disk);
     }
 
     fn assert_aio_backend(disk: &RawDisk) {
         assert_eq!(disk.backend, RawBackend::Aio);
-        assert_async_io_from_dyn(disk, RawBackend::Aio);
+        assert_async_io_from_dyn(disk);
     }
 
     #[cfg(feature = "io_uring")]
     fn assert_io_uring_backend(disk: &RawDisk) {
         assert_eq!(disk.backend, RawBackend::IoUring);
-        assert_async_io_from_dyn(disk, RawBackend::IoUring);
+        assert_async_io_from_dyn(disk);
     }
 
     #[test]
@@ -219,23 +209,23 @@ mod unit_tests {
         assert_io_uring_backend(&disk);
     }
 
-    fn assert_try_clone(disk: &RawDisk, expect_backend: RawBackend) {
+    fn assert_try_clone(disk: &RawDisk) {
         let cloned = disk.try_clone().unwrap();
-        assert_async_io_from_dyn(cloned.as_ref(), expect_backend);
+        assert_async_io_from_dyn(cloned.as_ref());
     }
 
     #[test]
     fn try_clone_preserves_sync_backend() {
         let file = make_raw_file();
         let disk = RawDisk::new(file, RawBackend::Sync);
-        assert_try_clone(&disk, RawBackend::Sync);
+        assert_try_clone(&disk);
     }
 
     #[test]
     fn try_clone_preserves_aio_backend() {
         let file = make_raw_file();
         let disk = RawDisk::new(file, RawBackend::Aio);
-        assert_try_clone(&disk, RawBackend::Aio);
+        assert_try_clone(&disk);
     }
 
     #[cfg(feature = "io_uring")]
@@ -243,7 +233,7 @@ mod unit_tests {
     fn try_clone_preserves_io_uring_backend() {
         let file = make_raw_file();
         let disk = RawDisk::new(file, RawBackend::IoUring);
-        assert_try_clone(&disk, RawBackend::IoUring);
+        assert_try_clone(&disk);
     }
 
     #[test]

--- a/block/src/request.rs
+++ b/block/src/request.rs
@@ -56,18 +56,10 @@ pub enum RequestType {
 }
 
 pub const DEFAULT_DESCRIPTOR_VEC_SIZE: usize = 32;
-pub struct BatchRequest {
-    pub offset: libc::off_t,
-    pub iovecs: SmallVec<[libc::iovec; DEFAULT_DESCRIPTOR_VEC_SIZE]>,
-    pub user_data: u64,
-    pub request_type: RequestType,
-}
 
 pub struct ExecuteAsync {
     // `true` if the execution will complete asynchronously
     pub async_complete: bool,
-    // request need to be batched for submission if any
-    pub batch_request: Option<BatchRequest>,
 }
 
 #[derive(Debug)]
@@ -302,7 +294,6 @@ impl Request {
 
         let mut ret = ExecuteAsync {
             async_complete: true,
-            batch_request: None,
         };
         // Queue operations expected to be submitted.
         match request_type {
@@ -313,32 +304,14 @@ impl Request {
                         .bitmap()
                         .mark_dirty(0, *data_len as usize);
                 }
-                if disk_image.batch_requests_enabled() {
-                    ret.batch_request = Some(BatchRequest {
-                        offset,
-                        iovecs,
-                        user_data,
-                        request_type,
-                    });
-                } else {
-                    disk_image
-                        .read_vectored(offset, &iovecs, user_data)
-                        .map_err(ExecuteError::AsyncRead)?;
-                }
+                disk_image
+                    .read_vectored(offset, &iovecs, user_data)
+                    .map_err(ExecuteError::AsyncRead)?;
             }
             RequestType::Out => {
-                if disk_image.batch_requests_enabled() {
-                    ret.batch_request = Some(BatchRequest {
-                        offset,
-                        iovecs,
-                        user_data,
-                        request_type,
-                    });
-                } else {
-                    disk_image
-                        .write_vectored(offset, &iovecs, user_data)
-                        .map_err(ExecuteError::AsyncWrite)?;
-                }
+                disk_image
+                    .write_vectored(offset, &iovecs, user_data)
+                    .map_err(ExecuteError::AsyncWrite)?;
             }
             RequestType::Flush => {
                 disk_image

--- a/performance-metrics/src/main.rs
+++ b/performance-metrics/src/main.rs
@@ -381,7 +381,7 @@ mod adjuster {
     }
 }
 
-const TEST_LIST: [PerformanceTest; 100] = [
+const TEST_LIST: [PerformanceTest; 96] = [
     PerformanceTest {
         name: "boot_time_ms",
         func_ptr: performance_boot_time,
@@ -1521,30 +1521,6 @@ const TEST_LIST: [PerformanceTest; 100] = [
         unit_adjuster: adjuster::s_to_us,
     },
     PerformanceTest {
-        name: "micro_block_qcow_batch_read_128_us",
-        func_ptr: micro_bench_block::micro_bench_qcow_batch_read,
-        control: PerformanceTestControl {
-            test_timeout: 10,
-            test_iterations: 20,
-            warmup_iterations: 5,
-            num_ops: Some(128),
-            ..PerformanceTestControl::default()
-        },
-        unit_adjuster: adjuster::s_to_us,
-    },
-    PerformanceTest {
-        name: "micro_block_qcow_batch_read_256_us",
-        func_ptr: micro_bench_block::micro_bench_qcow_batch_read,
-        control: PerformanceTestControl {
-            test_timeout: 10,
-            test_iterations: 20,
-            warmup_iterations: 5,
-            num_ops: Some(256),
-            ..PerformanceTestControl::default()
-        },
-        unit_adjuster: adjuster::s_to_us,
-    },
-    PerformanceTest {
         name: "micro_block_qcow_async_random_read_128_us",
         func_ptr: micro_bench_block::micro_bench_qcow_async_random_read,
         control: PerformanceTestControl {
@@ -1679,30 +1655,6 @@ const TEST_LIST: [PerformanceTest; 100] = [
     PerformanceTest {
         name: "micro_block_qcow_async_l2_cache_miss_256_us",
         func_ptr: micro_bench_block::micro_bench_qcow_async_l2_cache_miss,
-        control: PerformanceTestControl {
-            test_timeout: 10,
-            test_iterations: 20,
-            warmup_iterations: 5,
-            num_ops: Some(256),
-            ..PerformanceTestControl::default()
-        },
-        unit_adjuster: adjuster::s_to_us,
-    },
-    PerformanceTest {
-        name: "micro_block_qcow_batch_write_128_us",
-        func_ptr: micro_bench_block::micro_bench_qcow_batch_write,
-        control: PerformanceTestControl {
-            test_timeout: 10,
-            test_iterations: 20,
-            warmup_iterations: 5,
-            num_ops: Some(128),
-            ..PerformanceTestControl::default()
-        },
-        unit_adjuster: adjuster::s_to_us,
-    },
-    PerformanceTest {
-        name: "micro_block_qcow_batch_write_256_us",
-        func_ptr: micro_bench_block::micro_bench_qcow_batch_write,
         control: PerformanceTestControl {
             test_timeout: 10,
             test_iterations: 20,

--- a/performance-metrics/src/micro_bench_block.rs
+++ b/performance-metrics/src/micro_bench_block.rs
@@ -11,7 +11,6 @@ use std::time::Instant;
 
 use block::disk_file::AsyncDiskFile;
 use block::raw_disk::{RawBackend, RawDisk};
-use block::{BatchRequest, RequestType};
 
 use crate::PerformanceTestControl;
 use crate::util::{
@@ -357,47 +356,6 @@ pub fn micro_bench_qcow_async_read(control: &PerformanceTestControl) -> f64 {
     start.elapsed().as_secs_f64()
 }
 
-/// Measure QCOW2 batch read submission via io_uring.
-///
-/// Builds a batch of `num_ops` read requests and submits them all at once
-/// through `submit_batch_requests`, which packs multiple SQEs into a single
-/// io_uring submission. Returns the total wall clock time in seconds.
-pub fn micro_bench_qcow_batch_read(control: &PerformanceTestControl) -> f64 {
-    let num_ops = control.num_ops.expect("num_ops required") as usize;
-    let (_tmp, disk) = util::qcow_async_tempfile(num_ops);
-    let mut async_io = disk
-        .create_async_io(num_ops as u32)
-        .expect("create_async_io failed");
-
-    let mut buf = vec![0u8; num_ops * QCOW_CLUSTER_SIZE as usize];
-
-    let batch: Vec<BatchRequest> = (0..num_ops)
-        .map(|i| {
-            let slice =
-                &mut buf[i * QCOW_CLUSTER_SIZE as usize..(i + 1) * QCOW_CLUSTER_SIZE as usize];
-            BatchRequest {
-                offset: (i as u64 * QCOW_CLUSTER_SIZE) as libc::off_t,
-                iovecs: vec![libc::iovec {
-                    iov_base: slice.as_mut_ptr().cast(),
-                    iov_len: QCOW_CLUSTER_SIZE as usize,
-                }]
-                .into(),
-                user_data: i as u64,
-                request_type: RequestType::In,
-            }
-        })
-        .collect();
-
-    let start = Instant::now();
-    async_io
-        .submit_batch_requests(&batch)
-        .expect("submit_batch_requests failed");
-
-    // Drain all io_uring completions before stopping the clock.
-    drain_async_completions(async_io.as_mut(), num_ops);
-    start.elapsed().as_secs_f64()
-}
-
 /// Read num_ops clusters from a prepopulated QCOW2 image in random order
 /// through the QcowAsync io_uring path.
 ///
@@ -545,49 +503,6 @@ pub fn micro_bench_qcow_async_l2_cache_miss(control: &PerformanceTestControl) ->
     let stride = L2_ENTRIES_PER_TABLE as u64 * QCOW_CLUSTER_SIZE;
     let start = Instant::now();
     submit_reads(async_io.as_mut(), num_ops, stride, &[iovec]);
-
-    drain_async_completions(async_io.as_mut(), num_ops);
-    start.elapsed().as_secs_f64()
-}
-
-/// Measure QCOW2 batch write submission via io_uring.
-///
-/// Builds a batch of num_ops write requests and submits them all at once
-/// through submit_batch_requests. Writes in QcowAsync are synchronous
-/// (COW path), so this measures whether batching reduces per-request
-/// overhead compared to individual write_vectored calls.
-///
-/// Returns the total wall clock time in seconds.
-pub fn micro_bench_qcow_batch_write(control: &PerformanceTestControl) -> f64 {
-    let num_ops = control.num_ops.expect("num_ops required") as usize;
-    let (_tmp, disk) = util::empty_qcow_async_tempfile(num_ops);
-    let mut async_io = disk
-        .create_async_io(num_ops as u32)
-        .expect("create_async_io failed");
-
-    let mut buf = vec![0xA5u8; num_ops * QCOW_CLUSTER_SIZE as usize];
-
-    let batch: Vec<BatchRequest> = (0..num_ops)
-        .map(|i| {
-            let slice =
-                &mut buf[i * QCOW_CLUSTER_SIZE as usize..(i + 1) * QCOW_CLUSTER_SIZE as usize];
-            BatchRequest {
-                offset: (i as u64 * QCOW_CLUSTER_SIZE) as libc::off_t,
-                iovecs: vec![libc::iovec {
-                    iov_base: slice.as_mut_ptr().cast(),
-                    iov_len: QCOW_CLUSTER_SIZE as usize,
-                }]
-                .into(),
-                user_data: i as u64,
-                request_type: RequestType::Out,
-            }
-        })
-        .collect();
-
-    let start = Instant::now();
-    async_io
-        .submit_batch_requests(&batch)
-        .expect("submit_batch_requests failed");
 
     drain_async_completions(async_io.as_mut(), num_ops);
     start.elapsed().as_secs_f64()

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -205,19 +205,13 @@ impl BlockEpollHandler {
     // A spec-compliant driver never reuses a virtqueue head_index while the
     // corresponding chain is still available (virtio 1.x §2.7.13.4).
     // Double check the guest driver is behaving.
-    fn is_head_in_flight(
-        inflight: &VecDeque<(u16, Request)>,
-        batch: &[(u16, Request)],
-        head: u16,
-    ) -> bool {
-        batch.iter().any(|(h, _)| *h == head) || inflight.iter().any(|(h, _)| *h == head)
+    fn is_head_in_flight(inflight: &VecDeque<(u16, Request)>, head: u16) -> bool {
+        inflight.iter().any(|(h, _)| *h == head)
     }
 
     fn process_queue_submit(&mut self) -> Result<()> {
         let queue = &mut self.queue;
         let queue_size = queue.size();
-        let mut batch_requests = Vec::new();
-        let mut batch_inflight_requests = Vec::new();
         let mut processed = 0;
 
         loop {
@@ -237,7 +231,7 @@ impl BlockEpollHandler {
             };
 
             let head = desc_chain.head_index();
-            if Self::is_head_in_flight(&self.inflight_requests, &batch_inflight_requests, head) {
+            if Self::is_head_in_flight(&self.inflight_requests, head) {
                 warn!("Guest reused virtio-blk head_index {head} while the chain was used");
                 return Err(Error::QueueDuplicatedHeadIndex);
             }
@@ -313,24 +307,10 @@ impl BlockEpollHandler {
 
             if let Ok(ExecuteAsync {
                 async_complete: true,
-                batch_request,
             }) = result
             {
-                if let Some(batch_request) = batch_request {
-                    match batch_request.request_type {
-                        RequestType::In | RequestType::Out => batch_requests.push(batch_request),
-                        _ => {
-                            unreachable!(
-                                "Unexpected batch request type: {:?}",
-                                request.request_type()
-                            )
-                        }
-                    }
-                    batch_inflight_requests.push((desc_chain.head_index(), request));
-                } else {
-                    self.inflight_requests
-                        .push_back((desc_chain.head_index(), request));
-                }
+                self.inflight_requests
+                    .push_back((desc_chain.head_index(), request));
             } else {
                 let status = match result {
                     Ok(_) => VIRTIO_BLK_S_OK,
@@ -360,28 +340,6 @@ impl BlockEpollHandler {
                 queue
                     .enable_notification(self.mem.memory().deref())
                     .map_err(Error::QueueEnableNotification)?;
-            }
-        }
-
-        match self.disk_image.submit_batch_requests(&batch_requests) {
-            Ok(()) => {
-                self.inflight_requests.extend(batch_inflight_requests);
-            }
-            Err(e) => {
-                // If batch submission fails, report VIRTIO_BLK_S_IOERR for all requests.
-                for (user_data, request) in batch_inflight_requests {
-                    warn!("Request failed with batch submission: {request:x?} {e:?}");
-                    let desc_index = user_data;
-                    let mem = self.mem.memory();
-                    mem.write_obj(VIRTIO_BLK_S_IOERR as u8, request.status_addr())
-                        .map_err(Error::RequestStatus)?;
-                    queue
-                        .add_used(mem.deref(), desc_index, 1)
-                        .map_err(Error::QueueAddUsed)?;
-                    queue
-                        .enable_notification(mem.deref())
-                        .map_err(Error::QueueEnableNotification)?;
-                }
             }
         }
 


### PR DESCRIPTION
It adds complexity, and none of the backends except possibly qcow2 require it for performance.