### PR TITLE
vmm: openapi: Fix typo in iommu_address_width field name

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -781,7 +781,7 @@ components:
           items:
             type: integer
             format: int16
-        iommu_address_width:
+        iommu_address_width_bits:
           type: integer
           format: uint8
         serial_number:


### PR DESCRIPTION
This PR resolves a bug where iommu_address_width would be ignored when passed using the JSON API

Fixes #8243 [https://github.com/cloud-hypervisor/cloud-hypervisor/issues/8243]

cc @alyssais