### PR TITLE
vmm: Revert "vmm: create memfd for private mappings"

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1932,8 +1932,8 @@ impl MemoryManager {
             mmap_flags |= libc::MAP_SHARED;
             Some(Self::create_anonymous_file(size, hugepages, hugepage_size)?)
         } else {
-            mmap_flags |= libc::MAP_PRIVATE;
-            Some(Self::create_anonymous_file(size, hugepages, hugepage_size)?)
+            mmap_flags |= libc::MAP_PRIVATE | libc::MAP_ANONYMOUS;
+            None
         };
 
         let region = MmapRegion::build(fo, size, libc::PROT_READ | libc::PROT_WRITE, mmap_flags)


### PR DESCRIPTION
This reverts commit ced3762a67b69d66cda5b929500e5bcf266c4217.

This change lead to a serious memory regression when not using hugepages
or shared=on.

`MAP_PRIVATE` creates an anonymous memory allocation for every page
written when the backing store is a file. This CoW behaviour is useful
but leads to double allocations when the backing store is an empty file
created by `memfd_create()`. When the page is written to, the CoW
semantics require a real page to be created in the memory for the memfd
(previously before the page was touched they would all point to the zero
page). This real page is filled with zeroes because in theory this page
would be accessible via read/write syscalls on the FD even though in our
implementation it is only ever `mmap()`ed.

The intention of the commit was to enable `fallocate()` to be used to
punch holes but that would only affect the inaccessible backing page and
the page in the CoW anonymous memory would be unaffected. Leading it
likely not to have the desired effect.

Fixes: #8211

Signed-off-by: Rob Bradford <rbradford@meta.com>
