### PR TITLE
build: make Windows tests blocking again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -741,8 +741,7 @@ jobs:
       - integration-arm64
       # VFIO worker is failing #8160
       # - integration-vfio
-      # See: #8211
-      # - integration-windows
+      - integration-windows
       - integration-x86-64-mq
       - integration-x86-64-pr
       - openapi


### PR DESCRIPTION
See #8211. The bug is with a change in memory allocation behaviour, not with Windows guests.