### PR TITLE
pci: vfio_user: replace file_offset().unwrap() with explicit error

### DIFF
--- a/pci/src/vfio_user.rs
+++ b/pci/src/vfio_user.rs
@@ -578,9 +578,12 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioUserDmaMappi
             )));
         }
 
-        // Unwrap is safe as we only do vfio with shared mem with a backing file.
-        let file_offset = region.file_offset().unwrap();
-        let offset = region_offset + file_offset.start();
+        let file_offset = region.file_offset().ok_or_else(|| {
+            std::io::Error::other(format!("region for gpa 0x{gpa:x} has no backing file"))
+        })?;
+        let offset = region_offset
+            .checked_add(file_offset.start())
+            .ok_or_else(|| std::io::Error::other("offset overflow in DMA map"))?;
 
         self.client
             .lock()


### PR DESCRIPTION
VfioUserDmaMapping::map panicked when find_region returned an anonymous mmap region. Change this so a user gets an error instead of a panic.

When the VMM hotplugs a region into a guest that also has a vfio-user device, all region's handlers are called. With the anonymous memory backing (no file=, shared=on, or hugepages), region.file_offset() returns None and the .unwrap() panics the VMM. Replace the unwrap with an explicit error and use checked_add for the offset combine.