### PR TITLE
fix: vmm: clear restore snapshot after device creation

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6730,6 +6730,29 @@ mod common_parallel {
             .output()
             .expect("Expect creating disk image to succeed");
         let pmem_path = String::from("/dev/pmem0");
+        let mut hotplug_blk_file_path = dirs::home_dir().unwrap();
+        hotplug_blk_file_path.push("workloads");
+        hotplug_blk_file_path.push("blk.img");
+        let hotplug_disk_id = "test0";
+        let hotplug_disk_params = format!(
+            "path={},id={hotplug_disk_id},readonly=true",
+            hotplug_blk_file_path.to_str().unwrap()
+        );
+        let hotplug_disk_exists = || {
+            guest
+                .ssh_command("lsblk | grep vdc | grep -c 16M")
+                .is_ok_and(|s| s.trim().parse::<u32>().unwrap_or_default() == 1)
+        };
+        let hotplug_disk_absent = || {
+            guest
+                .ssh_command("lsblk | grep -c vdc.*16M || true")
+                .is_ok_and(|s| s.trim().parse::<u32>().unwrap_or(1) == 0)
+        };
+        let check_hotplug_disk_readable = || {
+            guest
+                .ssh_command("sudo dd if=/dev/vdc of=/dev/null bs=1M iflag=direct count=16")
+                .unwrap();
+        };
 
         // Start the source VM
         let src_vm_path = clh_command("cloud-hypervisor");
@@ -6791,6 +6814,14 @@ mod common_parallel {
                     Some(net_params.as_str()),
                 ));
                 guest.wait_for_ssh(Duration::from_secs(10)).unwrap();
+
+                assert!(remote_command(
+                    &src_api_socket,
+                    "add-disk",
+                    Some(hotplug_disk_params.as_str()),
+                ));
+                assert!(wait_until(Duration::from_secs(10), hotplug_disk_exists));
+                check_hotplug_disk_readable();
             }
             // Start TCP live migration
             assert!(
@@ -6827,6 +6858,27 @@ mod common_parallel {
             assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
             assert!(guest.get_total_memory().unwrap_or_default() > 1_400_000);
             guest.check_devices_common(None, Some(&console_text), Some(&pmem_path));
+
+            // Test hot(re)plugging works after a migration
+            {
+                assert!(hotplug_disk_exists());
+                check_hotplug_disk_readable();
+
+                assert!(remote_command(
+                    &dest_api_socket,
+                    "remove-device",
+                    Some(hotplug_disk_id),
+                ));
+                assert!(wait_until(Duration::from_secs(10), hotplug_disk_absent));
+
+                assert!(remote_command(
+                    &dest_api_socket,
+                    "add-disk",
+                    Some(hotplug_disk_params.as_str()),
+                ));
+                assert!(wait_until(Duration::from_secs(10), hotplug_disk_exists));
+                check_hotplug_disk_readable();
+            }
         });
 
         // Clean up the destination VM and ensure it terminates properly

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1567,6 +1567,11 @@ impl DeviceManager {
         Ok(())
     }
 
+    /// Drop restore-only state once all devices have consumed it.
+    pub(crate) fn clear_restore_snapshot(&mut self) {
+        self.snapshot = None;
+    }
+
     #[cfg(feature = "fw_cfg")]
     pub fn create_fw_cfg_device(&mut self) -> Result<(), DeviceManagerError> {
         let fw_cfg = Arc::new(Mutex::new(devices::legacy::FwCfg::new(

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -665,6 +665,9 @@ impl Vm {
             igvm_file,
         )?;
 
+        // Remove any snapshot artifacts after the hypervisor-specific init.
+        device_manager.lock().unwrap().clear_restore_snapshot();
+
         // Load kernel and initramfs files
         #[cfg(feature = "tdx")]
         let kernel = config


### PR DESCRIPTION
## TL:DR

If the scenario described below, which is not unlikely, happens then VMs can be in an invalid state after a live migration, preventing hotplugging of some devices. This happened in production unfortunately. Luckily, the fix is quick and we can write a nice test for it.

## Writeup

A restore snapshot is only construction input. The restore path should
use it while rebuilding the VM from saved state, then discard it before
later VM lifecycle operations run.

Keeping it around is observable after a restored VM changes its device
set. For example, a VM can be restored from a snapshot, live-migrated,
and then hot-remove a device on the destination. The restored device
tree no longer contains that device, but DeviceManager still carries the
original device snapshot.

That stale snapshot can affect later hotplug. Every added device
eventually reaches a constructor that calls
state_from_id(self.snapshot.as_ref(), id) or an equivalent snapshot
lookup. If the stale snapshot still contains an entry with the newly
added device name, the new device is created with old saved state even
though the matching device was already removed from the live device
tree.

Clear the DeviceManager snapshot after hypervisor-specific
initialization has rebuilt the interrupt controller and devices. From
that point onward, device operations should behave as normal runtime
operations, not as restore operations.

Co-developed-by: Thomas Prescher <thomas.prescher@cyberus-technology.de>
Co-developed-by: Leander Kohler <leander.kohler@cyberus-technology.de>

On-behalf-of: SAP philipp.schuster@sap.com
Signed-off-by: Philipp Schuster <philipp.schuster@cyberus-technology.de>