### PR TITLE
arch, hypervisor: fix RISC-V AIA setup for KVM

### DIFF
--- a/arch/src/riscv64/fdt.rs
+++ b/arch/src/riscv64/fdt.rs
@@ -231,8 +231,8 @@ fn create_aia_node(fdt: &mut FdtWriter, aia_device: &Arc<Mutex<dyn Vaia>>) -> Fd
         fdt.property_u32("#interrupt-cells", 0u32)?;
         fdt.property_null("interrupt-controller")?;
         fdt.property_null("msi-controller")?;
-        // TODO complete num-ids
-        fdt.property_u32("riscv,num-ids", 2047u32)?;
+        let imsic_num_ids = aia_device.lock().unwrap().imsic_num_ids();
+        fdt.property_u32("riscv,num-ids", imsic_num_ids)?;
         fdt.property_u32("phandle", AIA_IMSIC_PHANDLE)?;
 
         let mut irq_cells = Vec::new();

--- a/arch/src/riscv64/uefi.rs
+++ b/arch/src/riscv64/uefi.rs
@@ -7,7 +7,7 @@ use std::os::fd::AsFd;
 use std::result;
 
 use thiserror::Error;
-use vm_memory::{GuestAddress, GuestMemory};
+use vm_memory::{Bytes, GuestAddress, GuestMemory};
 
 /// Errors thrown while loading UEFI binary
 #[derive(Debug, Error)]

--- a/hypervisor/src/arch/riscv64/aia.rs
+++ b/hypervisor/src/arch/riscv64/aia.rs
@@ -46,6 +46,9 @@ pub trait Vaia: Send + Sync {
     /// Returns an array with IMSIC device properties
     fn imsic_properties(&self) -> [u32; 4];
 
+    /// Returns the number of IMSIC interrupt identities exposed to the guest
+    fn imsic_num_ids(&self) -> u32;
+
     /// Returns the number of vCPUs this AIA handles
     fn vcpu_count(&self) -> u32;
 

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -831,6 +831,25 @@ impl vm::Vm for KvmVm {
             .create_vcpu(id as u64)
             .map_err(|e| vm::HypervisorVmError::CreateVcpu(e.into()))?;
 
+        #[cfg(target_arch = "riscv64")]
+        {
+            // KVM defaults sstateen0 to zero for new RISC-V vCPUs. When AIA is
+            // exposed, Linux accesses supervisor AIA CSRs during IMSIC init;
+            // leave all state enabled so those CSR accesses do not trap as
+            // illegal instructions in the guest.
+            let sstateen0 = u64::MAX;
+            let sstateen0_id = kvm_bindings::KVM_REG_RISCV as u64
+                | u64::from(kvm_bindings::KVM_REG_SIZE_U64)
+                | u64::from(kvm_bindings::KVM_REG_RISCV_CSR)
+                | u64::from(kvm_bindings::KVM_REG_RISCV_CSR_SMSTATEEN);
+            fd.set_one_reg(sstateen0_id, &sstateen0.to_le_bytes())
+                .map_err(|e| {
+                    vm::HypervisorVmError::CreateVcpu(anyhow!(
+                        "Failed to enable RISC-V sstateen0 for vCPU {id}: {e}"
+                    ))
+                })?;
+        }
+
         #[cfg(target_arch = "x86_64")]
         // Safety: `xsave_size` will not change after vcpu creation because:
         // 1. `xsave_size` depends on cpuid

--- a/hypervisor/src/kvm/riscv64/aia.rs
+++ b/hypervisor/src/kvm/riscv64/aia.rs
@@ -24,6 +24,9 @@ pub struct KvmAiaImsics {
 
     /// Number of CPUs handled by the device
     vcpu_count: u32,
+
+    /// Number of IMSIC interrupt identities configured by KVM
+    imsic_num_ids: u32,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize)]
@@ -37,19 +40,16 @@ impl KvmAiaImsics {
 
     /// Setup the device-specific attributes
     fn init_device_attributes(&mut self, nr_irqs: u32) -> Result<()> {
-        // AIA part attributes
-        // Getting the working mode of RISC-V AIA, defaults to EMUL, passible
-        // variants are EMUL, HW_ACCL, AUTO
-        let mut aia_mode = kvm_bindings::KVM_DEV_RISCV_AIA_MODE_EMUL;
+        // Read the working mode selected by KVM. Possible modes are EMUL,
+        // HW_ACCL and AUTO.
+        let mut aia_mode_readback: u32 = 0;
         Self::get_device_attribute(
             &self.device,
             kvm_bindings::KVM_DEV_RISCV_AIA_GRP_CONFIG,
             u64::from(kvm_bindings::KVM_DEV_RISCV_AIA_CONFIG_MODE),
-            &raw mut aia_mode as u64,
+            &raw mut aia_mode_readback as u64,
             0,
         )?;
-
-        // Report AIA MODE
 
         // Setting up the number of wired interrupt sources
         Self::set_device_attribute(
@@ -71,6 +71,7 @@ impl KvmAiaImsics {
         )?;
 
         // Report NR_IDS
+        self.imsic_num_ids = aia_nr_ids;
 
         // Setting up hart_bits
         let max_hart_index = self.vcpu_count as u64 - 1;
@@ -191,6 +192,7 @@ impl KvmAiaImsics {
             vcpu_count: config.vcpu_count,
             aplic_addr: config.aplic_addr,
             imsic_addr: config.imsic_addr,
+            imsic_num_ids: 0,
         };
 
         aia_device.init_device_attributes(config.nr_irqs)?;
@@ -224,6 +226,10 @@ impl Vaia for KvmAiaImsics {
             0,
             kvm_bindings::KVM_DEV_RISCV_IMSIC_SIZE * self.vcpu_count,
         ]
+    }
+
+    fn imsic_num_ids(&self) -> u32 {
+        self.imsic_num_ids
     }
 
     fn vcpu_count(&self) -> u32 {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -12,9 +12,7 @@ use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, RecvError, SendError, Sender};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
-#[cfg(not(target_arch = "riscv64"))]
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use std::{io, result, thread};
 
 use anyhow::{Context, anyhow};

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -24,7 +24,7 @@ use anyhow::anyhow;
 use arch::RegionType;
 #[cfg(target_arch = "x86_64")]
 use devices::ioapic;
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use hypervisor::HypervisorVmError;
 use libc::_SC_NPROCESSORS_ONLN;
 use log::{debug, error, info, warn};
@@ -445,7 +445,7 @@ pub enum Error {
     #[error("Failed to allocate MMIO address")]
     AllocateMmioAddress,
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     /// Failed to create UEFI flash
     #[error("Failed to create UEFI flash")]
     CreateUefiFlash(#[source] HypervisorVmError),

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -710,7 +710,7 @@ fn vmm_thread_rules(
         (libc::SYS_readv, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_readlink, vec![]),
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
         (libc::SYS_readlinkat, vec![]),
         (libc::SYS_recvfrom, vec![]),
         (libc::SYS_recvmsg, vec![]),
@@ -753,7 +753,7 @@ fn vmm_thread_rules(
         ),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_unlink, vec![]),
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
         (libc::SYS_unlinkat, vec![]),
         (libc::SYS_userfaultfd, vec![]),
         (libc::SYS_wait4, vec![]),
@@ -918,7 +918,7 @@ fn vcpu_thread_rules(
         (libc::SYS_read, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_readlink, vec![]),
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
         (libc::SYS_readlinkat, vec![]),
         (libc::SYS_recvfrom, vec![]),
         (libc::SYS_recvmsg, vec![]),
@@ -935,7 +935,7 @@ fn vcpu_thread_rules(
         (libc::SYS_tkill, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_unlink, vec![]),
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
         (libc::SYS_unlinkat, vec![]),
         (libc::SYS_write, vec![]),
         (libc::SYS_writev, vec![]),


### PR DESCRIPTION
Fix RISC-V KVM AIA setup for guests using IMSIC interrupt virtualization.

The series enables sstateen0 for RISC-V KVM vCPUs, reports the IMSIC interrupt ID count from KVM in the generated FDT, and allows unlinkat in riscv64 seccomp filters.

Validation: an equivalent patch set was deployed on openRuyi Creek riscv64 and started a Kata + Cloud Hypervisor BusyBox container. It reported riscv64, pinged the bridge gateway and 1.1.1.1, and completed in 31 seconds.

AI assistance is disclosed in the commit trailers.