### PR TITLE
Propagate SMBIOS fields for sysinfo and chassis

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -960,7 +960,7 @@ pub fn configure_system(
     rsdp_addr: Option<GuestAddress>,
     serial_number: Option<&str>,
     uuid: Option<&str>,
-    oem_strings: Option<&[&str]>,
+    oem_strings: Option<&[String]>,
     topology: Option<(u16, u16, u16, u16)>,
 ) -> super::Result<()> {
     // Write EBDA address to location where ACPICA expects to find it
@@ -968,8 +968,13 @@ pub fn configure_system(
         .write_obj((layout::EBDA_START.0 >> 4) as u16, layout::EBDA_POINTER)
         .map_err(Error::EbdaSetup)?;
 
-    let size = smbios::setup_smbios(guest_mem, serial_number, uuid, oem_strings)
-        .map_err(Error::SmbiosSetup)?;
+    let size = smbios::setup_smbios(
+        guest_mem,
+        serial_number,
+        uuid,
+        oem_strings.unwrap_or_default(),
+    )
+    .map_err(Error::SmbiosSetup)?;
 
     // Place the MP table after the SMIOS table aligned to 16 bytes
     let offset = GuestAddress(layout::SMBIOS_START).unchecked_add(size);

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -28,6 +28,7 @@ use linux_loader::loader::elf::start_info::{
     hvm_memmap_table_entry, hvm_modlist_entry, hvm_start_info,
 };
 use log::{debug, error, info};
+pub use smbios::SmbiosConfig;
 use thiserror::Error;
 use vm_memory::{
     Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
@@ -958,9 +959,7 @@ pub fn configure_system(
     _num_cpus: u32,
     setup_header: Option<setup_header>,
     rsdp_addr: Option<GuestAddress>,
-    serial_number: Option<&str>,
-    uuid: Option<&str>,
-    oem_strings: Option<&[String]>,
+    smbios: Option<&SmbiosConfig>,
     topology: Option<(u16, u16, u16, u16)>,
 ) -> super::Result<()> {
     // Write EBDA address to location where ACPICA expects to find it
@@ -968,13 +967,7 @@ pub fn configure_system(
         .write_obj((layout::EBDA_START.0 >> 4) as u16, layout::EBDA_POINTER)
         .map_err(Error::EbdaSetup)?;
 
-    let size = smbios::setup_smbios(
-        guest_mem,
-        serial_number,
-        uuid,
-        oem_strings.unwrap_or_default(),
-    )
-    .map_err(Error::SmbiosSetup)?;
+    let size = smbios::setup_smbios(guest_mem, smbios).map_err(Error::SmbiosSetup)?;
 
     // Place the MP table after the SMIOS table aligned to 16 bytes
     let offset = GuestAddress(layout::SMBIOS_START).unchecked_add(size);
@@ -1519,8 +1512,6 @@ mod unit_tests {
             Some(layout::RSDP_POINTER),
             None,
             None,
-            None,
-            None,
         );
         config_err.unwrap_err();
 
@@ -1539,8 +1530,6 @@ mod unit_tests {
             0,
             &None,
             no_vcpus,
-            None,
-            None,
             None,
             None,
             None,
@@ -1572,8 +1561,6 @@ mod unit_tests {
             None,
             None,
             None,
-            None,
-            None,
         )
         .unwrap();
 
@@ -1583,8 +1570,6 @@ mod unit_tests {
             0,
             &None,
             no_vcpus,
-            None,
-            None,
             None,
             None,
             None,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -28,7 +28,7 @@ use linux_loader::loader::elf::start_info::{
     hvm_memmap_table_entry, hvm_modlist_entry, hvm_start_info,
 };
 use log::{debug, error, info};
-pub use smbios::SmbiosConfig;
+pub use smbios::{SmbiosChassisConfig, SmbiosConfig, SmbiosSystem};
 use thiserror::Error;
 use vm_memory::{
     Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -50,6 +50,19 @@ const IS_VIRTUAL_MACHINE: u8 = 1 << 4;
 pub const DEFAULT_SYSTEM_MANUFACTURER: &str = "Cloud Hypervisor";
 pub const DEFAULT_SYSTEM_PRODUCT_NAME: &str = "cloud-hypervisor";
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SmbiosConfig {
+    pub serial_number: Option<String>,
+    pub uuid: Option<String>,
+    pub oem_strings: Box<[String]>,
+}
+
+impl SmbiosConfig {
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 fn compute_checksum<T: Copy>(v: &T) -> u8 {
     let v: *const T = v;
     // SAFETY: we are only reading the bytes within the size of the `T` reference `v`.
@@ -222,12 +235,10 @@ fn write_type1_system(
     Ok(())
 }
 
-pub fn setup_smbios(
-    mem: &GuestMemoryMmap,
-    serial_number: Option<&str>,
-    uuid: Option<&str>,
-    oem_strings: &[String],
-) -> Result<u64> {
+pub fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Result<u64> {
+    let serial_number = smbios.and_then(|cfg| cfg.serial_number.as_deref());
+    let uuid = smbios.and_then(|cfg| cfg.uuid.as_deref());
+    let oem_strings: &[String] = smbios.map_or(&[], |cfg| &cfg.oem_strings);
     let physptr = GuestAddress(SMBIOS_START)
         .checked_add(mem::size_of::<Smbios30Entrypoint>() as u64)
         .ok_or(Error::NotEnoughMemory)?;
@@ -333,7 +344,7 @@ mod unit_tests {
     fn entrypoint_checksum() {
         let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(SMBIOS_START), 4096)]).unwrap();
 
-        setup_smbios(&mem, None, None, &[]).unwrap();
+        setup_smbios(&mem, None).unwrap();
 
         let smbios_ep: Smbios30Entrypoint = mem.read_obj(GuestAddress(SMBIOS_START)).unwrap();
 

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -47,6 +47,8 @@ const OEM_STRINGS: u8 = 11;
 const END_OF_TABLE: u8 = 127;
 const PCI_SUPPORTED: u64 = 1 << 7;
 const IS_VIRTUAL_MACHINE: u8 = 1 << 4;
+pub const DEFAULT_SYSTEM_MANUFACTURER: &str = "Cloud Hypervisor";
+pub const DEFAULT_SYSTEM_PRODUCT_NAME: &str = "cloud-hypervisor";
 
 fn compute_checksum<T: Copy>(v: &T) -> u8 {
     let v: *const T = v;
@@ -59,8 +61,7 @@ fn compute_checksum<T: Copy>(v: &T) -> u8 {
     (!checksum).wrapping_add(1)
 }
 
-#[repr(C)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, Copy, Clone)]
 struct Smbios30Entrypoint {
     signature: [u8; 5usize],
@@ -75,8 +76,7 @@ struct Smbios30Entrypoint {
     physptr: u64,
 }
 
-#[repr(C)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, Copy, Clone)]
 struct SmbiosBiosInfo {
     r#type: u8,
@@ -92,8 +92,7 @@ struct SmbiosBiosInfo {
     characteristics_ext2: u8,
 }
 
-#[repr(C)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, Copy, Clone)]
 struct SmbiosSysInfo {
     r#type: u8,
@@ -109,8 +108,7 @@ struct SmbiosSysInfo {
     family: u8,
 }
 
-#[repr(C)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, Copy, Clone)]
 struct SmbiosOemStrings {
     r#type: u8,
@@ -119,8 +117,7 @@ struct SmbiosOemStrings {
     count: u8,
 }
 
-#[repr(C)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[derive(Default, Copy, Clone)]
 struct SmbiosEndOfTable {
     r#type: u8,
@@ -163,11 +160,73 @@ fn write_string(
     Ok(curptr)
 }
 
+fn write_opt_string(
+    mem: &GuestMemoryMmap,
+    s: Option<&str>,
+    cur: GuestAddress,
+) -> Result<GuestAddress> {
+    if let Some(v) = s {
+        write_string(mem, v, cur)
+    } else {
+        Ok(cur)
+    }
+}
+
+fn write_string_terminator(
+    mem: &GuestMemoryMmap,
+    cur: GuestAddress,
+    has_strings: bool,
+) -> Result<GuestAddress> {
+    // SMBIOS DSP0134 §6.1.3: if all string-reference fields are 0, follow the
+    // formatted section with two null bytes (empty string-set).
+    if has_strings {
+        write_and_incr(mem, 0u8, cur)
+    } else {
+        let cur = write_and_incr(mem, 0u8, cur)?;
+        write_and_incr(mem, 0u8, cur)
+    }
+}
+
+fn write_type1_system(
+    mem: &GuestMemoryMmap,
+    curptr: &mut GuestAddress,
+    handle: &mut u16,
+    serial_number: Option<&str>,
+    uuid: Option<&str>,
+) -> Result<()> {
+    *handle += 1;
+
+    let uuid_number = uuid
+        .map(Uuid::parse_str)
+        .transpose()
+        .map_err(|e| Error::ParseUuid(e, uuid.unwrap().to_string()))?
+        .unwrap_or(Uuid::nil());
+    let serial_idx = serial_number.map(|_| 3).unwrap_or_default();
+
+    let smbios_sysinfo = SmbiosSysInfo {
+        r#type: SYSTEM_INFORMATION,
+        length: mem::size_of::<SmbiosSysInfo>() as u8,
+        handle: *handle,
+        manufacturer: 1, // First string written in this section
+        product_name: 2, // Second string written in this section
+        serial_number: serial_idx,
+        uuid: uuid_number.to_bytes_le(),
+        ..Default::default()
+    };
+
+    *curptr = write_and_incr(mem, smbios_sysinfo, *curptr)?;
+    *curptr = write_string(mem, DEFAULT_SYSTEM_MANUFACTURER, *curptr)?;
+    *curptr = write_string(mem, DEFAULT_SYSTEM_PRODUCT_NAME, *curptr)?;
+    *curptr = write_opt_string(mem, serial_number, *curptr)?;
+    *curptr = write_and_incr(mem, 0u8, *curptr)?;
+    Ok(())
+}
+
 pub fn setup_smbios(
     mem: &GuestMemoryMmap,
     serial_number: Option<&str>,
     uuid: Option<&str>,
-    oem_strings: Option<&[&str]>,
+    oem_strings: &[String],
 ) -> Result<u64> {
     let physptr = GuestAddress(SMBIOS_START)
         .checked_add(mem::size_of::<Smbios30Entrypoint>() as u64)
@@ -193,34 +252,9 @@ pub fn setup_smbios(
         curptr = write_and_incr(mem, 0u8, curptr)?;
     }
 
-    {
-        handle += 1;
+    write_type1_system(mem, &mut curptr, &mut handle, serial_number, uuid)?;
 
-        let uuid_number = uuid
-            .map(Uuid::parse_str)
-            .transpose()
-            .map_err(|e| Error::ParseUuid(e, uuid.unwrap().to_string()))?
-            .unwrap_or(Uuid::nil());
-        let smbios_sysinfo = SmbiosSysInfo {
-            r#type: SYSTEM_INFORMATION,
-            length: mem::size_of::<SmbiosSysInfo>() as u8,
-            handle,
-            manufacturer: 1, // First string written in this section
-            product_name: 2, // Second string written in this section
-            serial_number: serial_number.map(|_| 3).unwrap_or_default(), // 3rd string
-            uuid: uuid_number.to_bytes_le(), // set uuid
-            ..Default::default()
-        };
-        curptr = write_and_incr(mem, smbios_sysinfo, curptr)?;
-        curptr = write_string(mem, "Cloud Hypervisor", curptr)?;
-        curptr = write_string(mem, "cloud-hypervisor", curptr)?;
-        if let Some(serial_number) = serial_number {
-            curptr = write_string(mem, serial_number, curptr)?;
-        }
-        curptr = write_and_incr(mem, 0u8, curptr)?;
-    }
-
-    if let Some(oem_strings) = oem_strings {
+    if !oem_strings.is_empty() {
         handle += 1;
 
         let smbios_oemstrings = SmbiosOemStrings {
@@ -236,7 +270,7 @@ pub fn setup_smbios(
             curptr = write_string(mem, s, curptr)?;
         }
 
-        curptr = write_and_incr(mem, 0u8, curptr)?;
+        curptr = write_string_terminator(mem, curptr, true)?;
     }
 
     {
@@ -299,7 +333,7 @@ mod unit_tests {
     fn entrypoint_checksum() {
         let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(SMBIOS_START), 4096)]).unwrap();
 
-        setup_smbios(&mem, None, None, None).unwrap();
+        setup_smbios(&mem, None, None, &[]).unwrap();
 
         let smbios_ep: Smbios30Entrypoint = mem.read_obj(GuestAddress(SMBIOS_START)).unwrap();
 

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -35,16 +35,24 @@ pub enum Error {
     /// Failure to parse uuid, uuid format may be error
     #[error("Failure to parse uuid: {1}")]
     ParseUuid(#[source] uuid::Error, String),
+    /// SMBIOS string index overflow (u8 limit reached).
+    #[error("SMBIOS string index overflow (u8 limit reached: {})", u8::MAX)]
+    TooManyStrings,
 }
 
 pub type Result<T> = result::Result<T, Error>;
 
-// Constants sourced from SMBIOS Spec 3.2.0.
+// Constants sourced from SMBIOS Spec 3.9.0.
 const SM3_MAGIC_IDENT: &[u8; 5usize] = b"_SM3_";
 const BIOS_INFORMATION: u8 = 0;
 const SYSTEM_INFORMATION: u8 = 1;
 const OEM_STRINGS: u8 = 11;
+const SYSTEM_ENCLOSURE: u8 = 3;
 const END_OF_TABLE: u8 = 127;
+const SYSTEM_WAKE_UP_TYPE_UNKNOWN: u8 = 0x02;
+const CHASSIS_TYPE_UNKNOWN: u8 = 0x02;
+const CHASSIS_STATE_UNKNOWN: u8 = 0x02;
+const CHASSIS_SECURITY_STATUS_NONE: u8 = 0x03;
 const PCI_SUPPORTED: u64 = 1 << 7;
 const IS_VIRTUAL_MACHINE: u8 = 1 << 4;
 pub const DEFAULT_SYSTEM_MANUFACTURER: &str = "Cloud Hypervisor";
@@ -52,9 +60,25 @@ pub const DEFAULT_SYSTEM_PRODUCT_NAME: &str = "cloud-hypervisor";
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SmbiosConfig {
+    pub system: Option<SmbiosSystem>,
+    pub chassis: Option<SmbiosChassisConfig>,
+    pub oem_strings: Box<[String]>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SmbiosSystem {
+    pub manufacturer: Option<String>,
+    pub product_name: Option<String>,
+    pub version: Option<String>,
     pub serial_number: Option<String>,
     pub uuid: Option<String>,
-    pub oem_strings: Box<[String]>,
+    pub sku_number: Option<String>,
+    pub family: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SmbiosChassisConfig {
+    pub asset_tag: Option<String>,
 }
 
 impl SmbiosConfig {
@@ -130,6 +154,33 @@ struct SmbiosOemStrings {
     count: u8,
 }
 
+/// SMBIOS Chassis Table (Type 3) as defined in DMTF SMBIOS 3.9.0:
+/// https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.9.0.pdf
+/// Note: trailing fields are omitted, so this structure is not complete.
+#[repr(C, packed)]
+#[derive(Default, Copy, Clone)]
+struct SmbiosChassis {
+    r#type: u8,
+    length: u8,
+    handle: u16,
+    manufacturer: u8,
+    chassis_type: u8,
+    version: u8,
+    serial_number: u8,
+    asset_tag: u8,
+    bootup_state: u8,
+    power_supply_state: u8,
+    thermal_state: u8,
+    security_status: u8,
+    oem_defined: u32,
+    height: u8,
+    number_of_power_cords: u8,
+    contained_element_count: u8,
+    contained_element_record_length: u8,
+    // followed by contained element records (optional, variable-length)
+    // followed by sku_number: u8, rack_type: u8, rack_height: u8
+}
+
 #[repr(C, packed)]
 #[derive(Default, Copy, Clone)]
 struct SmbiosEndOfTable {
@@ -146,6 +197,8 @@ unsafe impl ByteValued for SmbiosBiosInfo {}
 unsafe impl ByteValued for SmbiosSysInfo {}
 // SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for SmbiosOemStrings {}
+// SAFETY: data structure only contain a series of integers
+unsafe impl ByteValued for SmbiosChassis {}
 // SAFETY: data structure only contain a series of integers
 unsafe impl ByteValued for SmbiosEndOfTable {}
 
@@ -200,44 +253,125 @@ fn write_string_terminator(
     }
 }
 
+/// Allocate the next string index for an SMBIOS string-set.
+///
+/// Per SMBIOS DSP0134, index `0` means "no string", so valid indices run from
+/// `1` to `255`. Returns `0` when `present` is `false`. Otherwise returns the
+/// current value of `*next` and advances it by one. Fails with
+/// [`Error::TooManyStrings`] once all 255 indices have been used: `next`
+/// starts at `1`, so it can only be `0` here after wrapping past `255`.
+fn alloc_index(next: &mut u8, present: bool) -> Result<u8> {
+    if !present {
+        return Ok(0);
+    }
+
+    let idx = *next;
+    if idx == 0 {
+        return Err(Error::TooManyStrings);
+    }
+
+    *next = next.wrapping_add(1);
+    Ok(idx)
+}
+
 fn write_type1_system(
     mem: &GuestMemoryMmap,
     curptr: &mut GuestAddress,
     handle: &mut u16,
-    serial_number: Option<&str>,
-    uuid: Option<&str>,
+    system: Option<&SmbiosSystem>,
 ) -> Result<()> {
     *handle += 1;
+
+    let manufacturer = system
+        .and_then(|s| s.manufacturer.as_deref())
+        .unwrap_or(DEFAULT_SYSTEM_MANUFACTURER);
+    let product = system
+        .and_then(|s| s.product_name.as_deref())
+        .unwrap_or(DEFAULT_SYSTEM_PRODUCT_NAME);
+    let version = system.and_then(|s| s.version.as_deref());
+    let serial = system.and_then(|s| s.serial_number.as_deref());
+    let uuid = system.and_then(|s| s.uuid.as_deref());
+    let sku = system.and_then(|s| s.sku_number.as_deref());
+    let family = system.and_then(|s| s.family.as_deref());
 
     let uuid_number = uuid
         .map(Uuid::parse_str)
         .transpose()
         .map_err(|e| Error::ParseUuid(e, uuid.unwrap().to_string()))?
         .unwrap_or(Uuid::nil());
-    let serial_idx = serial_number.map(|_| 3).unwrap_or_default();
 
-    let smbios_sysinfo = SmbiosSysInfo {
+    let mut next = 1u8;
+    let manufacturer_idx = alloc_index(&mut next, true)?;
+    let product_idx = alloc_index(&mut next, true)?;
+    let version_idx = alloc_index(&mut next, version.is_some())?;
+    let serial_idx = alloc_index(&mut next, serial.is_some())?;
+    let sku_idx = alloc_index(&mut next, sku.is_some())?;
+    let family_idx = alloc_index(&mut next, family.is_some())?;
+
+    let sys = SmbiosSysInfo {
         r#type: SYSTEM_INFORMATION,
         length: mem::size_of::<SmbiosSysInfo>() as u8,
         handle: *handle,
-        manufacturer: 1, // First string written in this section
-        product_name: 2, // Second string written in this section
+        manufacturer: manufacturer_idx,
+        product_name: product_idx,
+        version: version_idx,
         serial_number: serial_idx,
         uuid: uuid_number.to_bytes_le(),
-        ..Default::default()
+        wake_up_type: SYSTEM_WAKE_UP_TYPE_UNKNOWN,
+        sku: sku_idx,
+        family: family_idx,
     };
 
-    *curptr = write_and_incr(mem, smbios_sysinfo, *curptr)?;
-    *curptr = write_string(mem, DEFAULT_SYSTEM_MANUFACTURER, *curptr)?;
-    *curptr = write_string(mem, DEFAULT_SYSTEM_PRODUCT_NAME, *curptr)?;
-    *curptr = write_opt_string(mem, serial_number, *curptr)?;
+    *curptr = write_and_incr(mem, sys, *curptr)?;
+    *curptr = write_string(mem, manufacturer, *curptr)?;
+    *curptr = write_string(mem, product, *curptr)?;
+    *curptr = write_opt_string(mem, version, *curptr)?;
+    *curptr = write_opt_string(mem, serial, *curptr)?;
+    *curptr = write_opt_string(mem, sku, *curptr)?;
+    *curptr = write_opt_string(mem, family, *curptr)?;
     *curptr = write_and_incr(mem, 0u8, *curptr)?;
     Ok(())
 }
 
+fn write_type3_chassis(
+    mem: &GuestMemoryMmap,
+    curptr: &mut GuestAddress,
+    handle: &mut u16,
+    chassis: &SmbiosChassisConfig,
+) -> Result<()> {
+    *handle += 1;
+
+    let asset_tag = chassis.asset_tag.as_deref();
+    let mut next = 1u8;
+    let asset_idx = alloc_index(&mut next, asset_tag.is_some())?;
+
+    let ch = SmbiosChassis {
+        r#type: SYSTEM_ENCLOSURE,
+        length: mem::size_of::<SmbiosChassis>() as u8,
+        handle: *handle,
+        manufacturer: 0,
+        chassis_type: CHASSIS_TYPE_UNKNOWN,
+        version: 0,
+        serial_number: 0,
+        asset_tag: asset_idx,
+        bootup_state: CHASSIS_STATE_UNKNOWN,
+        power_supply_state: CHASSIS_STATE_UNKNOWN,
+        thermal_state: CHASSIS_STATE_UNKNOWN,
+        security_status: CHASSIS_SECURITY_STATUS_NONE,
+        contained_element_count: 0,
+        contained_element_record_length: 0,
+        ..Default::default()
+    };
+
+    *curptr = write_and_incr(mem, ch, *curptr)?;
+    *curptr = write_opt_string(mem, asset_tag, *curptr)?;
+    *curptr = write_string_terminator(mem, *curptr, asset_tag.is_some())?;
+    Ok(())
+}
+
 pub fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Result<u64> {
-    let serial_number = smbios.and_then(|cfg| cfg.serial_number.as_deref());
-    let uuid = smbios.and_then(|cfg| cfg.uuid.as_deref());
+    let system = smbios.and_then(|cfg| cfg.system.as_ref());
+    let chassis = smbios.and_then(|cfg| cfg.chassis.as_ref());
     let oem_strings: &[String] = smbios.map_or(&[], |cfg| &cfg.oem_strings);
     let physptr = GuestAddress(SMBIOS_START)
         .checked_add(mem::size_of::<Smbios30Entrypoint>() as u64)
@@ -263,7 +397,11 @@ pub fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Res
         curptr = write_and_incr(mem, 0u8, curptr)?;
     }
 
-    write_type1_system(mem, &mut curptr, &mut handle, serial_number, uuid)?;
+    write_type1_system(mem, &mut curptr, &mut handle, system)?;
+
+    if let Some(chassis) = chassis {
+        write_type3_chassis(mem, &mut curptr, &mut handle, chassis)?;
+    }
 
     if !oem_strings.is_empty() {
         handle += 1;

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -459,8 +459,55 @@ pub fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Res
 mod unit_tests {
     use super::*;
 
+    /// Collects all strings after a SMBIOS structure, stopping at the double-NUL terminator and returns next addr.
+    fn read_string_set(mem: &GuestMemoryMmap, addr: GuestAddress) -> (Vec<String>, GuestAddress) {
+        let mut cur = addr;
+        let read_byte = |addr: GuestAddress| -> u8 { mem.read_obj(addr).unwrap() };
+
+        // SMBIOS string-set: NUL-terminated strings, terminated by an extra NUL.
+        // Empty string-set is exactly "\0\0".
+        if read_byte(cur) == 0 {
+            let next = cur.checked_add(1).unwrap();
+            assert_eq!(read_byte(next), 0);
+            return (Vec::new(), next.checked_add(1).unwrap());
+        }
+
+        let mut strings = Vec::new();
+        loop {
+            let mut bytes = Vec::new();
+            loop {
+                let b = read_byte(cur);
+                cur = cur.checked_add(1).unwrap();
+                if b == 0 {
+                    break;
+                }
+                bytes.push(b);
+            }
+            strings.push(String::from_utf8(bytes).unwrap());
+
+            // If the next byte is NUL, that's the extra terminator.
+            if read_byte(cur) == 0 {
+                cur = cur.checked_add(1).unwrap();
+                break;
+            }
+        }
+
+        (strings, cur)
+    }
+
     #[test]
-    fn struct_size() {
+    fn entrypoint_checksum() {
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(SMBIOS_START), 4096)]).unwrap();
+
+        setup_smbios(&mem, None).unwrap();
+
+        let smbios_ep: Smbios30Entrypoint = mem.read_obj(GuestAddress(SMBIOS_START)).unwrap();
+
+        assert_eq!(compute_checksum(&smbios_ep), 0);
+    }
+
+    #[test]
+    fn entrypoint_struct_size() {
         assert_eq!(
             mem::size_of::<Smbios30Entrypoint>(),
             0x18usize,
@@ -479,13 +526,184 @@ mod unit_tests {
     }
 
     #[test]
-    fn entrypoint_checksum() {
+    fn smbios_chassis_empty_string_set_has_double_null() {
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(SMBIOS_START), 4096)]).unwrap();
+        let smbios = SmbiosConfig {
+            chassis: Some(SmbiosChassisConfig::default()),
+            ..Default::default()
+        };
+
+        setup_smbios(&mem, Some(&smbios)).unwrap();
+
+        let smbios_ep: Smbios30Entrypoint = mem.read_obj(GuestAddress(SMBIOS_START)).unwrap();
+        let mut cur = GuestAddress(smbios_ep.physptr);
+
+        let bios: SmbiosBiosInfo = mem.read_obj(cur).unwrap();
+        cur = cur.checked_add(bios.length as u64).unwrap();
+        let (_, next) = read_string_set(&mem, cur);
+        cur = next;
+
+        let sys: SmbiosSysInfo = mem.read_obj(cur).unwrap();
+        cur = cur.checked_add(sys.length as u64).unwrap();
+        let (_, next) = read_string_set(&mem, cur);
+        cur = next;
+
+        let chassis: SmbiosChassis = mem.read_obj(cur).unwrap();
+        cur = cur.checked_add(chassis.length as u64).unwrap();
+        // SMBIOS DSP0134 §6.1.3: empty string-set ends with double NUL.
+        let b0: u8 = mem.read_obj(cur).unwrap();
+        let b1: u8 = mem.read_obj(cur.checked_add(1).unwrap()).unwrap();
+        assert_eq!(b0, 0);
+        assert_eq!(b1, 0);
+        cur = cur.checked_add(2).unwrap();
+
+        let end: SmbiosEndOfTable = mem.read_obj(cur).unwrap();
+        assert_eq!(end.r#type, END_OF_TABLE);
+    }
+
+    #[test]
+    fn smbios_chassis_oem_strings_layout() {
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(SMBIOS_START), 4096)]).unwrap();
+
+        let smbios = SmbiosConfig {
+            chassis: Some(SmbiosChassisConfig {
+                asset_tag: Some("rack1".to_string()),
+            }),
+            oem_strings: ["o1".to_string(), "o2".to_string()].into(),
+            ..Default::default()
+        };
+
+        setup_smbios(&mem, Some(&smbios)).unwrap();
+
+        let smbios_ep: Smbios30Entrypoint = mem.read_obj(GuestAddress(SMBIOS_START)).unwrap();
+        let mut cur = GuestAddress(smbios_ep.physptr);
+
+        let bios: SmbiosBiosInfo = mem.read_obj(cur).unwrap();
+        cur = cur.checked_add(bios.length as u64).unwrap();
+        let (_, next) = read_string_set(&mem, cur);
+        cur = next;
+
+        let sys: SmbiosSysInfo = mem.read_obj(cur).unwrap();
+        cur = cur.checked_add(sys.length as u64).unwrap();
+        let (_, next) = read_string_set(&mem, cur);
+        cur = next;
+
+        let chassis: SmbiosChassis = mem.read_obj(cur).unwrap();
+        assert_eq!(chassis.r#type, SYSTEM_ENCLOSURE);
+        assert_eq!(chassis.asset_tag, 1);
+        cur = cur.checked_add(chassis.length as u64).unwrap();
+        let (chassis_strings, next) = read_string_set(&mem, cur);
+        assert_eq!(chassis_strings, vec!["rack1"]);
+        cur = next;
+
+        let oem: SmbiosOemStrings = mem.read_obj(cur).unwrap();
+        assert_eq!(oem.r#type, OEM_STRINGS);
+        assert_eq!(oem.count, 2);
+        cur = cur.checked_add(oem.length as u64).unwrap();
+        let (oem_strings, next) = read_string_set(&mem, cur);
+        assert_eq!(oem_strings, vec!["o1", "o2"]);
+        cur = next;
+
+        let end: SmbiosEndOfTable = mem.read_obj(cur).unwrap();
+        assert_eq!(end.r#type, END_OF_TABLE);
+    }
+
+    #[test]
+    fn smbios_strings_terminators_default() {
         let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(SMBIOS_START), 4096)]).unwrap();
 
         setup_smbios(&mem, None).unwrap();
 
         let smbios_ep: Smbios30Entrypoint = mem.read_obj(GuestAddress(SMBIOS_START)).unwrap();
+        let mut cur = GuestAddress(smbios_ep.physptr);
 
-        assert_eq!(compute_checksum(&smbios_ep), 0);
+        let bios: SmbiosBiosInfo = mem.read_obj(cur).unwrap();
+        assert_eq!(bios.r#type, BIOS_INFORMATION);
+        cur = cur.checked_add(bios.length as u64).unwrap();
+        let (bios_strings, next) = read_string_set(&mem, cur);
+        assert_eq!(bios_strings, vec!["cloud-hypervisor", "0"]);
+        cur = next;
+
+        let sys: SmbiosSysInfo = mem.read_obj(cur).unwrap();
+        assert_eq!(sys.r#type, SYSTEM_INFORMATION);
+        assert_eq!(sys.manufacturer, 1);
+        assert_eq!(sys.product_name, 2);
+        assert_eq!(sys.version, 0);
+        assert_eq!(sys.serial_number, 0);
+        assert_eq!(sys.sku, 0);
+        assert_eq!(sys.family, 0);
+        cur = cur.checked_add(sys.length as u64).unwrap();
+        let (sys_strings, next) = read_string_set(&mem, cur);
+        assert_eq!(
+            sys_strings,
+            vec![DEFAULT_SYSTEM_MANUFACTURER, DEFAULT_SYSTEM_PRODUCT_NAME]
+        );
+        cur = next;
+
+        let end: SmbiosEndOfTable = mem.read_obj(cur).unwrap();
+        assert_eq!(end.r#type, END_OF_TABLE);
+    }
+
+    #[test]
+    fn smbios_strings_too_many() {
+        let mut next = 1u8;
+        for _ in 0..255 {
+            alloc_index(&mut next, true).unwrap();
+        }
+        let err = alloc_index(&mut next, true).unwrap_err();
+        assert!(matches!(err, Error::TooManyStrings));
+    }
+
+    #[test]
+    fn smbios_uuid_invalid_rejected() {
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(SMBIOS_START), 4096)]).unwrap();
+        let smbios = SmbiosConfig {
+            system: Some(SmbiosSystem {
+                uuid: Some("not-a-uuid".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let err = setup_smbios(&mem, Some(&smbios)).unwrap_err();
+        assert!(matches!(err, Error::ParseUuid(_, _)));
+    }
+
+    #[test]
+    fn smbios_uuid_written_le() {
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(SMBIOS_START), 4096)]).unwrap();
+        let uuid_str = "00112233-4455-6677-8899-aabbccddeeff";
+        let smbios = SmbiosConfig {
+            system: Some(SmbiosSystem {
+                uuid: Some(uuid_str.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        setup_smbios(&mem, Some(&smbios)).unwrap();
+
+        let smbios_ep: Smbios30Entrypoint = mem.read_obj(GuestAddress(SMBIOS_START)).unwrap();
+        let mut cur = GuestAddress(smbios_ep.physptr);
+
+        let bios: SmbiosBiosInfo = mem.read_obj(cur).unwrap();
+        cur = cur.checked_add(bios.length as u64).unwrap();
+        let (_, next) = read_string_set(&mem, cur);
+        cur = next;
+
+        let sys: SmbiosSysInfo = mem.read_obj(cur).unwrap();
+        assert_eq!(sys.uuid, Uuid::parse_str(uuid_str).unwrap().to_bytes_le());
+    }
+
+    #[test]
+    fn smbios_write_fails_with_too_small_memory() {
+        let mem = GuestMemoryMmap::from_ranges(&[(
+            GuestAddress(SMBIOS_START),
+            mem::size_of::<Smbios30Entrypoint>(),
+        )])
+        .unwrap();
+
+        let err = setup_smbios(&mem, None).unwrap_err();
+        assert!(matches!(err, Error::WriteData));
     }
 }

--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -2219,7 +2219,7 @@ pub(crate) fn _test_dmi_serial_number(guest: &Guest) {
     let mut child = GuestCommand::new(guest)
         .default_cpus()
         .default_memory()
-        .default_kernel_cmdline_with_platform(Some("serial_number=a=b;c=d"))
+        .default_kernel_cmdline_with_platform(Some("system_serial_number=a=b;c=d"))
         .default_disks()
         .default_net()
         .capture_output()
@@ -2248,7 +2248,9 @@ pub(crate) fn _test_dmi_uuid(guest: &Guest) {
     let mut child = GuestCommand::new(guest)
         .default_cpus()
         .default_memory()
-        .default_kernel_cmdline_with_platform(Some("uuid=1e8aa28a-435d-4027-87f4-40dceff1fa0a"))
+        .default_kernel_cmdline_with_platform(Some(
+            "system_uuid=1e8aa28a-435d-4027-87f4-40dceff1fa0a",
+        ))
         .default_disks()
         .default_net()
         .capture_output()

--- a/cloud-hypervisor/tests/common/tests_wrappers.rs
+++ b/cloud-hypervisor/tests/common/tests_wrappers.rs
@@ -2325,6 +2325,54 @@ pub(crate) fn _test_dmi_oem_strings(guest: &Guest) {
     handle_child_output(r, &output);
 }
 
+#[cfg(target_arch = "x86_64")]
+pub(crate) fn _test_dmi_system_and_chassis(guest: &Guest) {
+    let fields = [
+        ("system_manufacturer", "system-manufacturer", "Manufacturer"),
+        ("system_product_name", "system-product-name", "ProductName"),
+        ("system_version", "system-version", "Version"),
+        ("system_family", "system-family", "Family"),
+        ("system_sku_number", "system-sku-number", "SkuNumber"),
+        ("chassis_asset_tag", "chassis-asset-tag", "AssetTag"),
+    ];
+
+    let platform = fields
+        .iter()
+        .map(|(key, _, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let mut child = GuestCommand::new(guest)
+        .default_cpus()
+        .default_memory()
+        .default_kernel_cmdline_with_platform(Some(&platform))
+        .default_disks()
+        .default_net()
+        .capture_output()
+        .spawn()
+        .unwrap();
+
+    let r = std::panic::catch_unwind(|| {
+        guest.wait_vm_boot().unwrap();
+
+        for (_, dmidecode_field, expected) in fields {
+            assert_eq!(
+                guest
+                    .ssh_command(&format!("sudo dmidecode -s {dmidecode_field}"))
+                    .unwrap()
+                    .trim(),
+                expected,
+                "DMI field {dmidecode_field} mismatch"
+            );
+        }
+    });
+
+    kill_child(&mut child);
+    let output = child.wait_with_output().unwrap();
+
+    handle_child_output(r, &output);
+}
+
 pub(crate) fn _test_serial_off(guest: &Guest) {
     let mut child = GuestCommand::new(guest)
         .default_cpus()

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -2052,6 +2052,13 @@ mod common_parallel {
     }
 
     #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_dmi_system_and_chassis() {
+        let guest = basic_regular_guest!(JAMMY_IMAGE_NAME);
+        _test_dmi_system_and_chassis(&guest);
+    }
+
+    #[test]
     fn test_virtio_fs() {
         _test_virtio_fs(&prepare_virtiofsd, false, false, None);
     }

--- a/cloud-hypervisor/tests/integration_cvm.rs
+++ b/cloud-hypervisor/tests/integration_cvm.rs
@@ -220,6 +220,12 @@ mod common_cvm {
     }
 
     #[test]
+    fn test_dmi_system_and_chassis() {
+        let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
+        _test_dmi_system_and_chassis(&guest);
+    }
+
+    #[test]
     fn test_multiple_network_interfaces() {
         let guest = basic_cvm_guest!(JAMMY_IMAGE_NAME);
         _test_multiple_network_interfaces(&guest);

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -786,7 +786,11 @@ components:
         iommu_address_width_bits:
           type: integer
           format: uint8
+        system_serial_number:
+          type: string
         serial_number:
+          type: string
+        system_uuid:
           type: string
         uuid:
           type: string
@@ -794,6 +798,18 @@ components:
           type: array
           items:
             type: string
+        system_manufacturer:
+          type: string
+        system_product_name:
+          type: string
+        system_version:
+          type: string
+        system_family:
+          type: string
+        system_sku_number:
+          type: string
+        chassis_asset_tag:
+          type: string
         tdx:
           type: boolean
           default: false

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -790,10 +790,12 @@ components:
           type: string
         serial_number:
           type: string
+          deprecated: true
         system_uuid:
           type: string
         uuid:
           type: string
+          deprecated: true
         oem_strings:
           type: array
           items:

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -993,6 +993,9 @@ impl PlatformConfig {
         let legacy_serial_number = parser
             .convert::<String>("serial_number")
             .map_err(Error::ParsePlatform)?;
+        if legacy_serial_number.is_some() {
+            warn!("'serial_number' in --platform is deprecated; use 'system_serial_number'.");
+        }
         platform_config.system_serial_number = platform_config
             .system_serial_number
             .or(legacy_serial_number);
@@ -1000,6 +1003,9 @@ impl PlatformConfig {
         let legacy_uuid = parser
             .convert::<String>("uuid")
             .map_err(Error::ParsePlatform)?;
+        if legacy_uuid.is_some() {
+            warn!("'uuid' in --platform is deprecated; use 'system_uuid'.");
+        }
         platform_config.system_uuid = platform_config.system_uuid.or(legacy_uuid);
 
         Ok(platform_config)

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -838,9 +838,11 @@ impl PlatformConfig {
         static SYNTAX: LazyLock<String> = LazyLock::new(|| {
             let mut syntax = "Platform configuration parameters \
             \"num_pci_segments=<num_pci_segments>,iommu_segments=<list_of_segments>,\
-            iommu_address_width=<bits>,serial_number=<dmi_device_serial_number>,\
-            uuid=<dmi_device_uuid>,oem_strings=<list_of_strings>,iommufd=on|off,\
-            vfio_p2p_dma=on|off"
+            iommu_address_width=<bits>,iommufd=on|off,vfio_p2p_dma=on|off,system_manufacturer=<dmi_system_manufacturer>,\
+            system_product_name=<dmi_system_product_name>,system_version=<dmi_system_version>,\
+            system_serial_number=<dmi_system_serial_number>,system_uuid=<dmi_system_uuid>,\
+            system_sku_number=<dmi_system_sku_number>,system_family=<dmi_system_family>,\
+            oem_strings=<list_of_strings>,chassis_asset_tag=<dmi_chassis_asset_tag>"
                 .to_string();
 
             if cfg!(feature = "tdx") {
@@ -860,6 +862,46 @@ impl PlatformConfig {
     }
 
     pub fn parse(platform: &str) -> Result<Self> {
+        struct StringField {
+            key: &'static str,
+            apply: fn(&mut PlatformConfig, String),
+        }
+
+        const SMBIOS_STRING_FIELDS: &[StringField] = &[
+            StringField {
+                key: "system_manufacturer",
+                apply: |config, value| config.system_manufacturer = Some(value),
+            },
+            StringField {
+                key: "system_product_name",
+                apply: |config, value| config.system_product_name = Some(value),
+            },
+            StringField {
+                key: "system_version",
+                apply: |config, value| config.system_version = Some(value),
+            },
+            StringField {
+                key: "system_serial_number",
+                apply: |config, value| config.system_serial_number = Some(value),
+            },
+            StringField {
+                key: "system_uuid",
+                apply: |config, value| config.system_uuid = Some(value),
+            },
+            StringField {
+                key: "system_sku_number",
+                apply: |config, value| config.system_sku_number = Some(value),
+            },
+            StringField {
+                key: "system_family",
+                apply: |config, value| config.system_family = Some(value),
+            },
+            StringField {
+                key: "chassis_asset_tag",
+                apply: |config, value| config.chassis_asset_tag = Some(value),
+            },
+        ];
+
         let mut parser = OptionParser::new();
         parser
             .add("num_pci_segments")
@@ -870,6 +912,9 @@ impl PlatformConfig {
             .add("oem_strings")
             .add("iommufd")
             .add("vfio_p2p_dma");
+        for field in SMBIOS_STRING_FIELDS {
+            parser.add(field.key);
+        }
         #[cfg(feature = "tdx")]
         parser.add("tdx");
         #[cfg(feature = "sev_snp")]
@@ -888,10 +933,6 @@ impl PlatformConfig {
             .convert("iommu_address_width")
             .map_err(Error::ParsePlatform)?
             .unwrap_or(MAX_IOMMU_ADDRESS_WIDTH_BITS);
-        let serial_number = parser
-            .convert("serial_number")
-            .map_err(Error::ParsePlatform)?;
-        let uuid = parser.convert("uuid").map_err(Error::ParsePlatform)?;
         let oem_strings = parser
             .convert::<StringList>("oem_strings")
             .map_err(Error::ParsePlatform)?
@@ -918,20 +959,50 @@ impl PlatformConfig {
             .map_err(Error::ParsePlatform)?
             .unwrap_or(Toggle(false))
             .0;
-        Ok(PlatformConfig {
+
+        let mut platform_config = PlatformConfig {
             num_pci_segments,
             iommu_segments,
             iommu_address_width_bits,
-            serial_number,
-            uuid,
+            system_serial_number: None,
+            system_uuid: None,
             oem_strings,
+            system_manufacturer: None,
+            system_product_name: None,
+            system_version: None,
+            system_family: None,
+            system_sku_number: None,
+            chassis_asset_tag: None,
             iommufd,
-            vfio_p2p_dma,
             #[cfg(feature = "tdx")]
             tdx,
             #[cfg(feature = "sev_snp")]
             sev_snp,
-        })
+            vfio_p2p_dma,
+        };
+
+        for field in SMBIOS_STRING_FIELDS {
+            if let Some(value) = parser
+                .convert::<String>(field.key)
+                .map_err(Error::ParsePlatform)?
+            {
+                (field.apply)(&mut platform_config, value);
+            }
+        }
+
+        let legacy_serial_number = parser
+            .convert::<String>("serial_number")
+            .map_err(Error::ParsePlatform)?;
+        platform_config.system_serial_number = platform_config
+            .system_serial_number
+            .or(legacy_serial_number);
+
+        let legacy_uuid = parser
+            .convert::<String>("uuid")
+            .map_err(Error::ParsePlatform)?;
+        platform_config.system_uuid = platform_config.system_uuid.or(legacy_uuid);
+
+        Ok(platform_config)
     }
 
     pub fn validate(&self) -> ValidationResult<()> {
@@ -5018,11 +5089,17 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             num_pci_segments: MAX_NUM_PCI_SEGMENTS,
             iommu_segments: None,
             iommu_address_width_bits: MAX_IOMMU_ADDRESS_WIDTH_BITS,
-            serial_number: None,
-            uuid: None,
+            system_serial_number: None,
+            system_uuid: None,
             oem_strings: None,
             iommufd: false,
             vfio_p2p_dma: default_platformconfig_vfio_p2p_dma(),
+            system_manufacturer: None,
+            system_product_name: None,
+            system_version: None,
+            system_family: None,
+            system_sku_number: None,
+            chassis_asset_tag: None,
             #[cfg(feature = "tdx")]
             tdx: false,
             #[cfg(feature = "sev_snp")]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1879,10 +1879,6 @@ impl Vm {
             .as_ref()
             .and_then(|p| p.oem_strings.clone());
 
-        let oem_strings = oem_strings
-            .as_deref()
-            .map(|strings| strings.iter().map(|s| s.as_ref()).collect::<Vec<&str>>());
-
         let topology = self.cpu_manager.lock().unwrap().get_vcpu_topology();
 
         arch::configure_system(

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1855,29 +1855,13 @@ impl Vm {
 
         let boot_vcpus = self.cpu_manager.lock().unwrap().boot_vcpus();
 
-        let serial_number = self
+        let smbios = self
             .config
             .lock()
             .unwrap()
             .platform
             .as_ref()
-            .and_then(|p| p.serial_number.clone());
-
-        let uuid = self
-            .config
-            .lock()
-            .unwrap()
-            .platform
-            .as_ref()
-            .and_then(|p| p.uuid.clone());
-
-        let oem_strings = self
-            .config
-            .lock()
-            .unwrap()
-            .platform
-            .as_ref()
-            .and_then(|p| p.oem_strings.clone());
+            .and_then(|p| p.smbios_config());
 
         let topology = self.cpu_manager.lock().unwrap().get_vcpu_topology();
 
@@ -1889,9 +1873,7 @@ impl Vm {
             boot_vcpus,
             entry_addr.setup_header,
             rsdp_addr,
-            serial_number.as_deref(),
-            uuid.as_deref(),
-            oem_strings.as_deref(),
+            smbios.as_ref(),
             topology,
         )
         .map_err(Error::ConfigureSystem)?;

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -144,6 +144,21 @@ pub struct PlatformConfig {
     pub vfio_p2p_dma: bool,
 }
 
+#[cfg(target_arch = "x86_64")]
+impl PlatformConfig {
+    /// Returns `None` if no SMBIOS-relevant platform fields are set, otherwise
+    /// `Some` with a [`SmbiosConfig`] built from the populated fields.
+    pub fn smbios_config(&self) -> Option<arch::x86_64::SmbiosConfig> {
+        let smbios = arch::x86_64::SmbiosConfig {
+            serial_number: self.serial_number.clone(),
+            uuid: self.uuid.clone(),
+            oem_strings: self.oem_strings.clone().unwrap_or_default(),
+        };
+
+        (!smbios.is_empty()).then_some(smbios)
+    }
+}
+
 pub const DEFAULT_PCI_SEGMENT_APERTURE_WEIGHT: u32 = 1;
 
 fn default_pci_segment_aperture_weight() -> u32 {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -126,12 +126,24 @@ pub struct PlatformConfig {
     pub iommu_segments: Option<Box<[u16]>>,
     #[serde(default = "default_platformconfig_iommu_address_width_bits")]
     pub iommu_address_width_bits: u8,
-    #[serde(default)]
-    pub serial_number: Option<String>,
-    #[serde(default)]
-    pub uuid: Option<String>,
+    #[serde(default, alias = "serial_number")]
+    pub system_serial_number: Option<String>,
+    #[serde(default, alias = "uuid")]
+    pub system_uuid: Option<String>,
     #[serde(default)]
     pub oem_strings: Option<Box<[String]>>,
+    #[serde(default)]
+    pub system_manufacturer: Option<String>,
+    #[serde(default)]
+    pub system_product_name: Option<String>,
+    #[serde(default)]
+    pub system_version: Option<String>,
+    #[serde(default)]
+    pub system_family: Option<String>,
+    #[serde(default)]
+    pub system_sku_number: Option<String>,
+    #[serde(default)]
+    pub chassis_asset_tag: Option<String>,
     #[cfg(feature = "tdx")]
     #[serde(default)]
     pub tdx: bool,
@@ -149,9 +161,38 @@ impl PlatformConfig {
     /// Returns `None` if no SMBIOS-relevant platform fields are set, otherwise
     /// `Some` with a [`SmbiosConfig`] built from the populated fields.
     pub fn smbios_config(&self) -> Option<arch::x86_64::SmbiosConfig> {
+        let has_system = [
+            &self.system_serial_number,
+            &self.system_uuid,
+            &self.system_manufacturer,
+            &self.system_product_name,
+            &self.system_version,
+            &self.system_family,
+            &self.system_sku_number,
+        ]
+        .iter()
+        .any(|v| v.is_some());
+
+        let system = has_system.then_some(arch::x86_64::SmbiosSystem {
+            manufacturer: self.system_manufacturer.clone(),
+            product_name: self.system_product_name.clone(),
+            version: self.system_version.clone(),
+            serial_number: self.system_serial_number.clone(),
+            uuid: self.system_uuid.clone(),
+            sku_number: self.system_sku_number.clone(),
+            family: self.system_family.clone(),
+        });
+
+        let chassis =
+            self.chassis_asset_tag
+                .clone()
+                .map(|asset_tag| arch::x86_64::SmbiosChassisConfig {
+                    asset_tag: Some(asset_tag),
+                });
+
         let smbios = arch::x86_64::SmbiosConfig {
-            serial_number: self.serial_number.clone(),
-            uuid: self.uuid.clone(),
+            system,
+            chassis,
             oem_strings: self.oem_strings.clone().unwrap_or_default(),
         };
 


### PR DESCRIPTION
# Motivation

Some workloads consume SMBIOS/DMI data inside the guest for licensing, inventory, or host-identification purposes. Cloud Hypervisor currently exposes only a small subset of that data through `--platform`, and the existing `serial_number` / `uuid` keys are not scoped to a specific SMBIOS structure.

This PR extends the exposed fields and refactors the SMBIOS plumbing so future SMBIOS structures and fields can be added with explicit names.

# Description

Currently `--platform` exposes the SMBIOS serial number and UUID (Type 1, System Information) and OEM strings (Type 11). 
The Type 1 keys don't make their SMBIOS scope explicit, and Type 3 (System Enclosure) isn't exposed at all. This PR adds more Type 1 fields and a chassis asset tag, plumbed through `--platform` and the OpenAPI schema.

### Naming

New keys are prefixed with their SMBIOS structure name so they read unambiguously and leave room for future chassis or baseboard additions. The leaf names mirror `dmidecode -s <field>`.

- `system_manufacturer`
- `system_product_name`
- `system_version`
- `system_family`
- `system_serial_number`
- `system_uuid`
- `system_sku_number`
- `chassis_asset_tag`

### Backwards compatibility

We deprecate serial_number and uuid keys but keep backwards compatibility on `--platform` and map to their system_* counterparts. They emit a deprecation warning, and the OpenAPI schema marks them deprecated. No existing configuration breaks.

For Type 3 (Chassis), only the asset tag is wired in this PR. The remaining Type 3 fields can be added in a follow-up using the same pattern.


This change has been running in our fork for a few months https://github.com/cyberus-technology/cloud-hypervisor/pull/78.
