### PR TITLE
Extend live migration protocol for postcopy and ondemand paging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,6 +1534,7 @@ dependencies = [
  "log",
  "serde_json",
  "thiserror",
+ "vm-memory",
  "vm-migration",
  "vmm",
  "vmm-sys-util",

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6872,16 +6872,39 @@ mod common_parallel {
         dest_event_path: &str,
         connections: NonZeroU32,
     ) -> bool {
+        start_live_migration_tcp_with_flags(
+            src_api_socket,
+            dest_api_socket,
+            dest_event_path,
+            connections,
+            false,
+        )
+    }
+
+    #[cfg(not(feature = "mshv"))]
+    fn start_live_migration_tcp_with_flags(
+        src_api_socket: &str,
+        dest_api_socket: &str,
+        dest_event_path: &str,
+        connections: NonZeroU32,
+        postcopy: bool,
+    ) -> bool {
         // Get an available TCP port
         let migration_port = get_available_port();
         let host_ip = "127.0.0.1";
+
+        let receive_arg = if postcopy {
+            format!("receiver_url=tcp:0.0.0.0:{migration_port},memory_mode=postcopy")
+        } else {
+            format!("receiver_url=tcp:0.0.0.0:{migration_port}")
+        };
 
         // Start the 'receive-migration' command on the destination
         let mut receive_migration = Command::new(clh_command("ch-remote"))
             .args([
                 &format!("--api-socket={dest_api_socket}"),
                 "receive-migration",
-                &format!("receiver_url=tcp:0.0.0.0:{migration_port}"),
+                &receive_arg,
             ])
             .stdin(Stdio::null())
             .stderr(Stdio::piped())
@@ -6901,12 +6924,17 @@ mod common_parallel {
 
         // Start the 'send-migration' command on the source
         let connections = connections.get();
+        let extra = if postcopy {
+            ",memory_mode=postcopy"
+        } else {
+            ""
+        };
         let mut send_migration = Command::new(clh_command("ch-remote"))
             .args([
                 &format!("--api-socket={src_api_socket}"),
                 "send-migration",
                 &format!(
-                    "destination_url=tcp:{host_ip}:{migration_port},connections={connections}"
+                    "destination_url=tcp:{host_ip}:{migration_port},connections={connections}{extra}"
                 ),
             ])
             .stdin(Stdio::null())
@@ -7158,6 +7186,102 @@ mod common_parallel {
         }
     }
 
+    // Postcopy live migration. Verifies the destination boots a guest
+    // that touches all of its memory, which forces every page to be
+    // demand-faulted across the network.
+    #[cfg(not(feature = "mshv"))]
+    fn _test_live_migration_tcp_postcopy() {
+        let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+        let kernel_path = direct_kernel_boot_path();
+        let console_text = String::from("On a branch floating down river a cricket, singing.");
+        let net_id = "netpc1";
+        let net_params = format!(
+            "id={},tap=,mac={},ip={},mask=255.255.255.128",
+            net_id, guest.network.guest_mac0, guest.network.host_ip0
+        );
+        let memory_param: &[&str] = &["--memory", "size=512M"];
+        let boot_vcpus = 2;
+
+        let src_vm_path = clh_command("cloud-hypervisor");
+        let src_api_socket = temp_api_path(&guest.tmp_dir);
+        let mut src_child = GuestCommand::new_with_binary_path(&guest, &src_vm_path)
+            .args(["--cpus", format!("boot={boot_vcpus}").as_str()])
+            .args(memory_param)
+            .args(["--kernel", kernel_path.to_str().unwrap()])
+            .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
+            .default_disks()
+            .args(["--net", net_params.as_str()])
+            .args(["--api-socket", &src_api_socket])
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let dest_event_path = temp_event_monitor_path(&guest.tmp_dir);
+        let mut dest_api_socket = temp_api_path(&guest.tmp_dir);
+        dest_api_socket.push_str(".dest");
+        let mut dest_child = GuestCommand::new(&guest)
+            .args(["--api-socket", &dest_api_socket])
+            .args([
+                "--event-monitor",
+                format!("path={dest_event_path}").as_str(),
+            ])
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = std::panic::catch_unwind(|| {
+            guest.wait_vm_boot().unwrap();
+            assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
+            assert!(guest.get_total_memory().unwrap_or_default() > 400_000);
+            guest.check_devices_common(None, Some(&console_text), None);
+
+            assert!(
+                start_live_migration_tcp_with_flags(
+                    &src_api_socket,
+                    &dest_api_socket,
+                    &dest_event_path,
+                    NonZeroU32::new(1).unwrap(),
+                    /* postcopy */ true,
+                ),
+                "Postcopy live migration command failed."
+            );
+        });
+        if r.is_err() {
+            print_and_panic(
+                src_child,
+                dest_child,
+                None,
+                "Error occurred during postcopy live-migration",
+            );
+        }
+
+        let src_exited_ok = wait_until(Duration::from_secs(60), || {
+            matches!(src_child.try_wait(), Ok(Some(_)))
+        }) && src_child.try_wait().unwrap().is_some_and(|s| s.success());
+        if !src_exited_ok {
+            print_and_panic(
+                src_child,
+                dest_child,
+                None,
+                "Source VM (postcopy) was not terminated successfully.",
+            );
+        }
+
+        let r = std::panic::catch_unwind(|| {
+            // Probing the destination forces page faults across most of
+            // guest memory. If the source serve loop drops bytes, these
+            // checks fail.
+            assert_eq!(guest.get_cpu_count().unwrap_or_default(), boot_vcpus);
+            assert!(guest.get_total_memory().unwrap_or_default() > 400_000);
+            guest.check_devices_common(None, Some(&console_text), None);
+        });
+
+        let _ = dest_child.kill();
+        let dest_output = dest_child.wait_with_output().unwrap();
+        handle_child_output(r, &dest_output);
+    }
+
     #[cfg(not(feature = "mshv"))]
     fn _test_live_migration_tcp_timeout(timeout_strategy: TimeoutStrategy) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
@@ -7381,6 +7505,12 @@ mod common_parallel {
     #[cfg(not(feature = "mshv"))]
     fn test_live_migration_tcp_parallel_connections() {
         _test_live_migration_tcp(NonZeroU32::new(8).unwrap());
+    }
+
+    #[test]
+    #[cfg(not(feature = "mshv"))]
+    fn test_live_migration_tcp_postcopy() {
+        _test_live_migration_tcp_postcopy();
     }
 
     #[test]

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -8264,13 +8264,19 @@ mod ivshmem {
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_offload() {
-        snapshot_restore_common::_test_snapshot_restore_offload(false);
+        snapshot_restore_common::_test_snapshot_restore_offload(false, false);
     }
 
     #[test]
     #[cfg(not(feature = "mshv"))]
     fn test_snapshot_restore_offload_virtio_mem() {
-        snapshot_restore_common::_test_snapshot_restore_offload(true);
+        snapshot_restore_common::_test_snapshot_restore_offload(true, false);
+    }
+
+    #[test]
+    #[cfg(not(feature = "mshv"))]
+    fn test_snapshot_restore_offload_ondemand() {
+        snapshot_restore_common::_test_snapshot_restore_offload(false, true);
     }
 
     #[test]
@@ -8971,7 +8977,7 @@ mod snapshot_restore_common {
     // Round-trip via the reference offload daemon over the existing
     // `vm.send-migration local=on` / `vm.receive-migration` endpoints,
     // proving parity with `vm.snapshot`/`vm.restore`.
-    pub(crate) fn _test_snapshot_restore_offload(virtio_mem: bool) {
+    pub(crate) fn _test_snapshot_restore_offload(virtio_mem: bool, ondemand: bool) {
         let disk_config = UbuntuDiskConfig::new(JAMMY_IMAGE_NAME.to_string());
         let guest = Guest::new(Box::new(disk_config));
         let kernel_path = direct_kernel_boot_path();
@@ -9121,16 +9127,19 @@ mod snapshot_restore_common {
                 None
             )));
 
-            // receive-migration blocks until done; run it in a thread
-            // so we can start the daemon as the sender in parallel.
+            // receive-migration blocks until done. Run it in a thread so
+            // we can start the daemon as the sender in parallel. On demand
+            // mode adds `memory_mode=postcopy`.
             let api_socket_restored_clone = api_socket_restored.clone();
             let restore_socket_clone = restore_socket.clone();
+            let ondemand_for_thread = ondemand;
             let restore_thread = std::thread::spawn(move || {
-                remote_command(
-                    &api_socket_restored_clone,
-                    "receive-migration",
-                    Some(format!("receiver_url=unix:{restore_socket_clone}").as_str()),
-                )
+                let arg = if ondemand_for_thread {
+                    format!("receiver_url=unix:{restore_socket_clone},memory_mode=postcopy")
+                } else {
+                    format!("receiver_url=unix:{restore_socket_clone}")
+                };
+                remote_command(&api_socket_restored_clone, "receive-migration", Some(&arg))
             });
 
             // Wait for CH to bind the socket before starting the daemon.
@@ -9139,26 +9148,35 @@ mod snapshot_restore_common {
             }));
 
             // Daemon in restore (sender) mode with --resume so the
-            // guest is live when we probe it.
+            // guest is live when we probe it. On demand mode adds --ondemand and
+            // keeps the daemon connected to serve PageFault requests.
+            let mut restore_args = vec![
+                "restore".to_string(),
+                "--socket".to_string(),
+                restore_socket.clone(),
+                "--input-dir".to_string(),
+                offload_dir.clone(),
+                "--resume".to_string(),
+            ];
+            if ondemand {
+                restore_args.push("--ondemand".to_string());
+            }
             let daemon = Command::new(clh_command("offload_daemon"))
-                .args([
-                    "restore",
-                    "--socket",
-                    &restore_socket,
-                    "--input-dir",
-                    &offload_dir,
-                    "--resume",
-                ])
+                .args(&restore_args)
                 .stderr(Stdio::piped())
                 .stdout(Stdio::piped())
                 .spawn()
                 .unwrap();
-            let daemon_output = daemon.wait_with_output().unwrap();
-            assert!(
-                daemon_output.status.success(),
-                "offload daemon (restore) failed: stderr={}",
-                String::from_utf8_lossy(&daemon_output.stderr)
-            );
+            if ondemand {
+                drop(daemon);
+            } else {
+                let daemon_output = daemon.wait_with_output().unwrap();
+                assert!(
+                    daemon_output.status.success(),
+                    "offload daemon (restore) failed: stderr={}",
+                    String::from_utf8_lossy(&daemon_output.stderr)
+                );
+            }
 
             assert!(
                 restore_thread.join().unwrap(),

--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -364,6 +364,9 @@ migration process. Via the API or `ch-remote`, you may specify:
   The number of parallel TCP connections to use for migration.
   Must be between `1` and `128`. Defaults to `1`.
   Multiple connections are not supported with local UNIX-socket migration.
+- `memory_mode <precopy|postcopy>`: \
+  Memory transfer mode. `postcopy` resumes the destination first and faults
+  guest pages in on demand over a dedicated connection. Defaults to `precopy`.
 
 ## Version Compatibility
 

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -213,6 +213,25 @@ migration today.
     --resume
 ```
 
+### On demand restore usage
+
+For speeding up a VM restore, the daemon's `--ondemand` mode hands CH
+empty memfds and serves page contents on demand via userfaultfd.
+
+This requires `memory_mode=postcopy` on the receive-migration call so CH
+registers userfaultfd on the memfds before resuming vCPUs and keeps
+the daemon's socket open for `PageFault` requests:
+
+```bash
+./ch-remote --api-socket /tmp/cloud-hypervisor.sock \
+    receive-migration receiver_url=unix:/tmp/restore.sock,memory_mode=postcopy &
+
+./offload_daemon restore \
+    --socket /tmp/restore.sock \
+    --input-dir /var/snapshots/vm1 \
+    --resume --ondemand
+```
+
 ### The daemon protocol
 
 The daemon implements the local live-migration wire protocol defined in

--- a/offload_daemon/Cargo.toml
+++ b/offload_daemon/Cargo.toml
@@ -12,6 +12,7 @@ libc = { workspace = true }
 log = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+vm-memory = { workspace = true, features = ["backend-mmap"] }
 vm-migration = { path = "../vm-migration" }
 vmm = { path = "../vmm" }
 vmm-sys-util = { workspace = true }

--- a/offload_daemon/src/main.rs
+++ b/offload_daemon/src/main.rs
@@ -13,21 +13,29 @@
 //! `state.json`.
 //!
 //! Restore (daemon sends): replays those files back to CH. `--resume` resumes
-//! the VM instead of leaving it paused.
+//! the VM, and `--ondemand` serves pages on demand over the postcopy fault
+//! connection instead of preloading them.
 
 use std::ffi::{CString, NulError};
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::fs::FileExt;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
-use std::result;
+use std::sync::Arc;
+use std::{result, thread};
 
 use clap::{Parser, Subcommand};
 use log::{debug, info};
 use thiserror::Error;
+use vm_memory::mmap::{MmapRegion, MmapRegionError};
+use vm_memory::{
+    Address, Bytes, FileOffset, GuestAddress, GuestMemoryError, GuestMemoryRegion, GuestRegionMmap,
+    MemoryRegionAddress,
+};
 use vm_migration::MigratableError;
-use vm_migration::protocol::{Command, Request, Response, Status};
+use vm_migration::protocol::{Command, ConnectionRole, MemoryRange, Request, Response, Status};
 use vmm::VmMigrationConfig;
 use vmm::migration::SNAPSHOT_STATE_FILE;
 use vmm::sparse::copy_region;
@@ -90,6 +98,20 @@ enum Error {
     MissingSlot(u32),
     #[error("Field {0:?} missing from memory_manager_data")]
     MissingField(&'static str),
+    #[error("Mapping memfd for the on demand slot")]
+    Mmap(#[source] MmapRegionError),
+    #[error("Guest region does not match the mapped size")]
+    GuestRegion,
+    #[error("Cloning memfd for mmap")]
+    CloneMemfd(#[source] io::Error),
+    #[error("Spawning the fault serve thread")]
+    SpawnServeThread(#[source] io::Error),
+    #[error("The fault serve thread panicked")]
+    ServeThreadPanic,
+    #[error("PageFault gpa={0:#x} len={1} is not within any slot")]
+    PageFaultUnmapped(u64, u64),
+    #[error("Writing a faulted page into guest memory")]
+    WriteGuestMemory(#[source] GuestMemoryError),
 }
 
 type Result<T> = result::Result<T, Error>;
@@ -128,6 +150,9 @@ enum Mode {
         /// paused (CompletePaused).
         #[arg(long)]
         resume: bool,
+        /// On demand paging.
+        #[arg(long)]
+        ondemand: bool,
     },
 }
 
@@ -141,7 +166,8 @@ fn main() -> Result<()> {
             socket,
             input_dir,
             resume,
-        } => run_restore(&socket, &input_dir, resume),
+            ondemand,
+        } => run_restore(&socket, &input_dir, resume, ondemand),
     }
 }
 
@@ -322,18 +348,22 @@ fn dump_fd_to_path(file: &File, src_offset: u64, size: u64, path: &Path) -> Resu
     Ok(())
 }
 
-/// (slot, size, file_offset) per memory slot, parsed via JSON to avoid
-/// depending on the private fields of `MemoryManagerSnapshotData`.
-///
-/// `file_offset` is non-zero when a zone spans multiple regions sharing one
-/// backing memfd.
+/// (slot, size, file_offset) per memory slot. `file_offset` is non-zero when a
+/// zone spans multiple regions sharing one backing memfd.
 fn slot_sizes(config: &VmMigrationConfig) -> Result<Vec<(u32, u64, u64)>> {
+    Ok(slot_info(config)?
+        .into_iter()
+        .map(|(slot, _gpa, size, file_offset)| (slot, size, file_offset))
+        .collect())
+}
+
+fn slot_info(config: &VmMigrationConfig) -> Result<Vec<(u32, u64, u64, u64)>> {
     parse_guest_ram_mappings(&serde_json::to_value(config.memory_manager_data())?)
 }
 
 /// Parse the `guest_ram_mappings` array out of the serialized
 /// `MemoryManagerSnapshotData`.
-fn parse_guest_ram_mappings(value: &serde_json::Value) -> Result<Vec<(u32, u64, u64)>> {
+fn parse_guest_ram_mappings(value: &serde_json::Value) -> Result<Vec<(u32, u64, u64, u64)>> {
     let mappings = value
         .get("guest_ram_mappings")
         .and_then(|v| v.as_array())
@@ -344,6 +374,10 @@ fn parse_guest_ram_mappings(value: &serde_json::Value) -> Result<Vec<(u32, u64, 
             .get("slot")
             .and_then(|v| v.as_u64())
             .ok_or(Error::MissingField("slot"))? as u32;
+        let gpa = m
+            .get("gpa")
+            .and_then(|v| v.as_u64())
+            .ok_or(Error::MissingField("gpa"))?;
         let size = m
             .get("size")
             .and_then(|v| v.as_u64())
@@ -353,35 +387,50 @@ fn parse_guest_ram_mappings(value: &serde_json::Value) -> Result<Vec<(u32, u64, 
             .and_then(|v| v.as_u64())
             .ok_or(Error::MissingField("file_offset"))?;
         // CH allocates one fresh memslot per GuestRegionMmap, so each
-        // (slot, size, file_offset) appears at most once here.
-        out.push((slot, size, file_offset));
+        // (slot, gpa, size, file_offset) appears at most once here.
+        out.push((slot, gpa, size, file_offset));
     }
     Ok(out)
 }
 
 // Restore mode (migration sender).
-fn run_restore(socket_path: &Path, input_dir: &Path, resume: bool) -> Result<()> {
+fn run_restore(socket_path: &Path, input_dir: &Path, resume: bool, ondemand: bool) -> Result<()> {
     let migration_config_bytes =
         fs::read(input_dir.join(MIGRATION_CONFIG_FILENAME)).map_err(Error::ReadFile)?;
     let migration_config: VmMigrationConfig = serde_json::from_slice(&migration_config_bytes)?;
     let state_bytes = fs::read(input_dir.join(SNAPSHOT_STATE_FILE)).map_err(Error::ReadFile)?;
-    let sizes = slot_sizes(&migration_config)?;
 
     let mut stream = UnixStream::connect(socket_path).map_err(Error::Connect)?;
-    info!("Offload daemon connected to {socket_path:?}");
+    info!("Offload daemon connected to {socket_path:?} (ondemand={ondemand})");
 
     send_request_expect_ok(&mut stream, Request::start(), "Start")?;
 
-    for (slot, size, file_offset) in &sizes {
-        let memfd = create_memfd_with_contents(
-            &input_dir.join(memory_slot_filename(*slot)),
-            *file_offset,
-            *size,
-            &format!("offload-slot-{slot}"),
-        )?;
-        send_memory_fd(&mut stream, *slot, &memfd)?;
+    let mut ondemand_slots: Vec<OnDemandSlot> = Vec::new();
+
+    for (slot, gpa, size, file_offset) in slot_info(&migration_config)? {
+        let disk_path = input_dir.join(memory_slot_filename(slot));
+        let memfd = if ondemand {
+            let memfd = create_empty_memfd(file_offset + size, &format!("offload-slot-{slot}"))?;
+            ondemand_slots.push(OnDemandSlot::new(
+                &memfd,
+                gpa,
+                size,
+                file_offset,
+                &disk_path,
+            )?);
+            memfd
+        } else {
+            create_memfd_with_contents(
+                &disk_path,
+                file_offset,
+                size,
+                &format!("offload-slot-{slot}"),
+            )?
+        };
+        send_memory_fd(&mut stream, slot, &memfd)?;
         debug!(
-            "restore: sent memory fd for slot {slot} ({size} bytes at fd offset {file_offset:#x})"
+            "restore: sent memory fd for slot {slot} ({size} bytes at fd offset \
+             {file_offset:#x}, ondemand={ondemand})"
         );
     }
 
@@ -391,6 +440,29 @@ fn run_restore(socket_path: &Path, input_dir: &Path, resume: bool) -> Result<()>
         &migration_config_bytes,
         "Config",
     )?;
+
+    // For on demand (postcopy) restore the fault connection must be serving before
+    // CH processes State, so connect it here and serve on its own thread.
+    let serve_handle = if ondemand {
+        let slots = Arc::new(ondemand_slots);
+        let mut fault_stream = UnixStream::connect(socket_path).map_err(Error::Connect)?;
+        ConnectionRole::Fault
+            .write_to(&mut fault_stream)
+            .map_err(Error::Protocol)?;
+        info!(
+            "offload daemon: connected dedicated fault connection, serving {} slot(s)",
+            slots.len()
+        );
+        let serve_slots = Arc::clone(&slots);
+        let handle = thread::Builder::new()
+            .name("offload-fault-serve".to_owned())
+            .spawn(move || serve_page_faults(&mut fault_stream, serve_slots.as_slice()))
+            .map_err(Error::SpawnServeThread)?;
+        Some(handle)
+    } else {
+        None
+    };
+
     send_payload_expect_ok(
         &mut stream,
         Request::state(state_bytes.len() as u64),
@@ -405,8 +477,101 @@ fn run_restore(socket_path: &Path, input_dir: &Path, resume: bool) -> Result<()>
     };
     send_request_expect_ok(&mut stream, final_req, "Complete")?;
 
+    if let Some(handle) = serve_handle {
+        info!("Offload daemon: waiting for fault serving to finish");
+        handle.join().map_err(|_| Error::ServeThreadPanic)??;
+    }
+
     info!("Restore replay finished");
     Ok(())
+}
+
+/// Per-slot state for serving PageFault requests in on demand mode.
+struct OnDemandSlot {
+    region: GuestRegionMmap,
+    disk: File,
+}
+
+impl OnDemandSlot {
+    fn new(memfd: &File, gpa: u64, size: u64, file_offset: u64, disk_path: &Path) -> Result<Self> {
+        // Map the same memfd CH maps, so our page writes are visible to it.
+        let fo = FileOffset::new(memfd.try_clone().map_err(Error::CloneMemfd)?, file_offset);
+        let mmap = MmapRegion::build(
+            Some(fo),
+            size as usize,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_SHARED,
+        )
+        .map_err(Error::Mmap)?;
+        let region = GuestRegionMmap::new(mmap, GuestAddress(gpa)).ok_or(Error::GuestRegion)?;
+        let disk = File::open(disk_path).map_err(Error::ReadFile)?;
+        Ok(Self { region, disk })
+    }
+
+    fn contains(&self, gpa: u64, len: u64) -> bool {
+        let base = self.region.start_addr().raw_value();
+        let end = base + self.region.len();
+        gpa >= base && gpa.saturating_add(len) <= end
+    }
+}
+
+fn serve_page_faults(stream: &mut UnixStream, slots: &[OnDemandSlot]) -> Result<()> {
+    let mut served: u64 = 0;
+    loop {
+        let req = match Request::read_from(stream) {
+            Ok(r) => r,
+            Err(e) => {
+                info!("Serve loop: socket closed after {served} PageFault(s) ({e:?})");
+                return Ok(());
+            }
+        };
+        match req.command() {
+            Command::PageFault => {
+                let range = MemoryRange::read_from(stream).map_err(Error::Protocol)?;
+                served += 1;
+                if served <= 5 || served.is_power_of_two() {
+                    info!(
+                        "PageFault #{served}: gpa={:#x} len={}",
+                        range.gpa, range.length
+                    );
+                }
+                let slot = slots
+                    .iter()
+                    .find(|s| s.contains(range.gpa, range.length))
+                    .ok_or(Error::PageFaultUnmapped(range.gpa, range.length))?;
+                let offset = range.gpa - slot.region.start_addr().raw_value();
+                // Reading a sparse hole returns zeros, so a single read+write
+                // path covers both data and unwritten pages.
+                let mut buf = vec![0u8; range.length as usize];
+                slot.disk
+                    .read_exact_at(&mut buf, offset)
+                    .map_err(Error::CopyMemory)?;
+                slot.region
+                    .write_slice(&buf, MemoryRegionAddress(offset))
+                    .map_err(Error::WriteGuestMemory)?;
+                Response::ok().write_to(stream).map_err(Error::Protocol)?;
+            }
+            Command::Abandon => {
+                info!("Serve loop: received Abandon, exiting");
+                Response::ok().write_to(stream).ok();
+                return Ok(());
+            }
+            c => return Err(Error::UnexpectedCommand(c, "a PageFault")),
+        }
+    }
+}
+
+fn create_empty_memfd(size: u64, name: &str) -> Result<File> {
+    let cname = CString::new(name).map_err(Error::MemfdName)?;
+    // SAFETY: memfd_create has no preconditions. We check the return value.
+    let raw = unsafe { libc::memfd_create(cname.as_ptr(), 0) };
+    if raw < 0 {
+        return Err(Error::MemfdCreate(io::Error::last_os_error()));
+    }
+    // SAFETY: `raw` is a fresh fd we now own.
+    let memfd = unsafe { File::from_raw_fd(raw) };
+    memfd.set_len(size).map_err(Error::MemfdSetLen)?;
+    Ok(memfd)
 }
 
 fn send_request_expect_ok(stream: &mut UnixStream, req: Request, name: &'static str) -> Result<()> {
@@ -443,19 +608,6 @@ fn send_memory_fd(stream: &mut UnixStream, slot: u32, memfd: &File) -> Result<()
     expect_ok_response(stream, "MemoryFd")
 }
 
-fn create_empty_memfd(size: u64, name: &str) -> Result<File> {
-    let cname = CString::new(name).map_err(Error::MemfdName)?;
-    // SAFETY: memfd_create has no preconditions. We check the return value.
-    let raw = unsafe { libc::memfd_create(cname.as_ptr(), 0) };
-    if raw < 0 {
-        return Err(Error::MemfdCreate(io::Error::last_os_error()));
-    }
-    // SAFETY: `raw` is a fresh fd we now own.
-    let memfd = unsafe { File::from_raw_fd(raw) };
-    memfd.set_len(size).map_err(Error::MemfdSetLen)?;
-    Ok(memfd)
-}
-
 fn create_memfd_with_contents(
     src_path: &Path,
     file_offset: u64,
@@ -486,13 +638,13 @@ mod tests {
     fn test_parse_guest_ram_mappings() {
         let value = json!({
             "guest_ram_mappings": [
-                { "slot": 0, "size": 4096u64, "file_offset": 0u64, "virtio_mem": true },
-                { "slot": 1, "size": 8192u64, "file_offset": 4096u64 },
+                { "slot": 0, "gpa": 0u64, "size": 4096u64, "file_offset": 0u64, "virtio_mem": true },
+                { "slot": 1, "gpa": 0x4000u64, "size": 8192u64, "file_offset": 4096u64 },
             ]
         });
         assert_eq!(
             parse_guest_ram_mappings(&value).unwrap(),
-            vec![(0, 4096, 0), (1, 8192, 4096)]
+            vec![(0, 0, 4096, 0), (1, 0x4000, 8192, 4096)]
         );
     }
 
@@ -507,7 +659,7 @@ mod tests {
 
     #[test]
     fn test_parse_guest_ram_mappings_missing_field() {
-        let value = json!({ "guest_ram_mappings": [{ "slot": 0, "size": 4096u64 }] });
+        let value = json!({ "guest_ram_mappings": [{ "slot": 0, "gpa": 0u64, "size": 4096u64 }] });
         assert!(matches!(
             parse_guest_ram_mappings(&value),
             Err(Error::MissingField("file_offset"))

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -47,6 +47,9 @@ pub enum UffdError {
     #[error("Region at {addr:#x}+{len:#x} missing COPY/WAKE support")]
     MissingIoctlSupport { addr: u64, len: u64 },
 
+    #[error("Failed to configure socket")]
+    SetSocket(#[source] io::Error),
+
     #[error("Failed to spawn handler thread")]
     SpawnThread(#[source] io::Error),
 

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -120,6 +120,7 @@ use crate::bitpos_iterator::BitposIteratorExt;
 ///     Configured --> StateReceived: State
 ///     StateReceived --> Completed: Complete
 ///     StateReceived --> Completed: CompletePaused
+///     Completed --> Completed: PageFault
 /// ```
 ///
 /// [live-migration protocol]: super::protocol
@@ -140,6 +141,52 @@ pub enum Command {
     /// Finalizes the migration without resuming the VM on the destination.
     /// Sent when the source VM was paused at migration time.
     CompletePaused = 8,
+    /// Request a page to be faulted in. The page content can be sent
+    /// through the response or simply written to the shared memory.
+    PageFault = 9,
+}
+
+/// Role announced as the first message on an additional migration connection.
+#[repr(u16)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+pub enum ConnectionRole {
+    /// Invalid role. Reserves the zero value so a default/zeroed message
+    /// carries no valid meaning on the wire.
+    #[default]
+    Invalid = 0,
+    /// Dedicated connection carrying precopy memory chunks.
+    PrecopyMemory = 1,
+    /// Dedicated connection carrying page faults.
+    Fault = 2,
+}
+
+impl ConnectionRole {
+    pub fn write_to(self, fd: &mut dyn Write) -> Result<(), MigratableError> {
+        fd.write_all(&(self as u16).to_le_bytes())
+            .map_err(MigratableError::MigrateSocket)
+    }
+
+    pub fn read_from(fd: &mut dyn Read) -> Result<ConnectionRole, MigratableError> {
+        let mut buf = [0u8; 2];
+        fd.read_exact(&mut buf)
+            .map_err(MigratableError::MigrateSocket)?;
+        ConnectionRole::try_from(u16::from_le_bytes(buf))
+    }
+}
+
+impl TryFrom<u16> for ConnectionRole {
+    type Error = MigratableError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(ConnectionRole::Invalid),
+            1 => Ok(ConnectionRole::PrecopyMemory),
+            2 => Ok(ConnectionRole::Fault),
+            _ => Err(MigratableError::MigrateReceive(anyhow!(
+                "unknown connection role: {value}"
+            ))),
+        }
+    }
 }
 
 /// Newest migration protocol version sent by this implementation.
@@ -215,6 +262,11 @@ impl Request {
         Self::new(Command::Abandon, 0)
     }
 
+    /// PageFault request always carries a single `MemoryRange`.
+    pub fn page_fault() -> Self {
+        Self::new(Command::PageFault, size_of::<MemoryRange>() as u64)
+    }
+
     pub fn command(&self) -> Command {
         self.command
     }
@@ -262,7 +314,7 @@ impl Request {
 }
 
 #[repr(u16)]
-#[derive(Copy, Clone, PartialEq, Eq, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub enum Status {
     #[default]
     Invalid,
@@ -337,10 +389,27 @@ impl Response {
 }
 
 #[repr(C)]
-#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemoryRange {
     pub gpa: u64,
     pub length: u64,
+}
+
+// SAFETY: MemoryRange is two u64 fields with no padding.
+unsafe impl ByteValued for MemoryRange {}
+
+impl MemoryRange {
+    pub fn read_from(fd: &mut dyn Read) -> Result<MemoryRange, MigratableError> {
+        let mut range = MemoryRange::default();
+        fd.read_exact(Self::as_mut_slice(&mut range))
+            .map_err(MigratableError::MigrateSocket)?;
+        Ok(range)
+    }
+
+    pub fn write_to(&self, fd: &mut dyn Write) -> Result<(), MigratableError> {
+        fd.write_all(Self::as_slice(self))
+            .map_err(MigratableError::MigrateSocket)
+    }
 }
 
 /// A set of guest-memory ranges to transfer as one migration payload.
@@ -543,8 +612,10 @@ impl MemoryRangeTable {
 
 #[cfg(test)]
 mod unit_tests {
+    use std::io::Cursor;
+
     use crate::protocol::{
-        CURRENT_PROTOCOL_VERSION, Command, MemoryRange, MemoryRangeTable, Request,
+        CURRENT_PROTOCOL_VERSION, Command, ConnectionRole, MemoryRange, MemoryRangeTable, Request,
     };
 
     #[test]
@@ -571,6 +642,49 @@ mod unit_tests {
 
         const { assert!(CURRENT_PROTOCOL_VERSION < 255) };
         request.sender_protocol_version().unwrap_err();
+    }
+
+    #[test]
+    fn test_page_fault_request_roundtrip() {
+        let req = Request::page_fault();
+        assert_eq!(req.command(), Command::PageFault);
+        assert_eq!(req.length(), size_of::<MemoryRange>() as u64);
+
+        let range = MemoryRange {
+            gpa: 0x4000,
+            length: 0x1000,
+        };
+
+        let mut buf = Vec::new();
+        req.write_to(&mut buf).unwrap();
+        range.write_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let parsed_req = Request::read_from(&mut cursor).unwrap();
+        assert_eq!(parsed_req.command(), Command::PageFault);
+        assert_eq!(parsed_req.length(), size_of::<MemoryRange>() as u64);
+        let parsed_range = MemoryRange::read_from(&mut cursor).unwrap();
+        assert_eq!(parsed_range, range);
+    }
+
+    #[test]
+    fn test_conn_role_roundtrip() {
+        for role in [ConnectionRole::PrecopyMemory, ConnectionRole::Fault] {
+            let mut buf = Vec::new();
+            role.write_to(&mut buf).unwrap();
+            assert_eq!(buf.len(), size_of::<u16>());
+
+            let mut cursor = Cursor::new(buf);
+            assert_eq!(ConnectionRole::read_from(&mut cursor).unwrap(), role);
+        }
+    }
+
+    #[test]
+    fn test_conn_role_unknown_value_is_rejected() {
+        // An unknown on-the-wire role value must be rejected rather than
+        // producing an out-of-range enum discriminant.
+        let mut cursor = Cursor::new(99u16.to_le_bytes().to_vec());
+        ConnectionRole::read_from(&mut cursor).unwrap_err();
     }
 
     #[test]
@@ -650,10 +764,10 @@ mod unit_tests {
             assert_eq!(
                 chunks,
                 &[
-                    [expected_regions[0].clone()].to_vec(),
-                    [expected_regions[1].clone()].to_vec(),
-                    [expected_regions[2].clone()].to_vec(),
-                    [expected_regions[3].clone()].to_vec(),
+                    [expected_regions[0]].to_vec(),
+                    [expected_regions[1]].to_vec(),
+                    [expected_regions[2]].to_vec(),
+                    [expected_regions[3]].to_vec(),
                 ]
             );
         }

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -270,6 +270,31 @@ pub struct VmCoredumpData {
     pub destination_url: String,
 }
 
+/// Memory transfer mode for a migration.
+#[derive(Copy, Clone, Default, Deserialize, Serialize, Debug, PartialEq, Eq)]
+pub enum MigrationMode {
+    /// Transfer all guest memory before the destination resumes.
+    #[default]
+    Precopy,
+    /// Resume the destination first and fault guest pages in on demand.
+    /// This is an experimental mode. It uses a single connection even
+    /// when parallel connections are configured. Pages are served on
+    /// demand, but a background faulting mechanism also pulls in the
+    /// remaining pages to speed up completion.
+    Postcopy,
+}
+
+impl FromStr for MigrationMode {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "precopy" => Ok(MigrationMode::Precopy),
+            "postcopy" => Ok(MigrationMode::Postcopy),
+            _ => Err(format!("Invalid migration mode: {s}")),
+        }
+    }
+}
+
 #[derive(Clone, Deserialize, Serialize, Default, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct VmReceiveMigrationData {
@@ -278,6 +303,9 @@ pub struct VmReceiveMigrationData {
     /// Directory containing the TLS server certificate (server-cert.pem), the TLS server key (server-key.pem), and the client TLS root CA certificate (ca-cert.pem).
     #[serde(default)]
     pub tls_dir: Option<PathBuf>,
+    /// Memory transfer mode.
+    #[serde(default)]
+    pub memory_mode: MigrationMode,
 }
 
 #[derive(Debug, Error)]
@@ -291,11 +319,11 @@ pub enum VmReceiveMigrationConfigError {
 
 impl VmReceiveMigrationData {
     pub const SYNTAX: &'static str = "VM receive migration parameters \
-        \"<receiver_url>\" or \"receiver_url=<url>[,tls_dir=<path>]\"";
+        \"<receiver_url>\" or \"receiver_url=<url>[,tls_dir=<path>][,memory_mode=precopy|postcopy]\"";
 
     pub fn parse(migration: &str) -> Result<Self, VmReceiveMigrationConfigError> {
         let mut parser = OptionParser::new();
-        parser.add("receiver_url").add("tls_dir");
+        parser.add("receiver_url").add("tls_dir").add("memory_mode");
         parser
             .parse(migration)
             .map_err(VmReceiveMigrationConfigError::ParseError)?;
@@ -309,10 +337,15 @@ impl VmReceiveMigrationData {
             .convert::<String>("tls_dir")
             .map_err(VmReceiveMigrationConfigError::ParseError)?
             .map(|path| PathBuf::from(&path));
+        let memory_mode = parser
+            .convert::<MigrationMode>("memory_mode")
+            .map_err(VmReceiveMigrationConfigError::ParseError)?
+            .unwrap_or_default();
 
         let data = Self {
             receiver_url,
             tls_dir,
+            memory_mode,
         };
 
         data.validate()?;
@@ -422,6 +455,9 @@ pub struct VmSendMigrationData {
     /// Path to the directory containing the TLS root CA certificate (ca-cert.pem), the TLS client certificate (client-cert.pem), and TLS client key (client-key.pem).
     #[serde(default)]
     pub tls_dir: Option<PathBuf>,
+    /// Memory transfer mode.
+    #[serde(default)]
+    pub memory_mode: MigrationMode,
 }
 
 impl VmSendMigrationData {
@@ -429,7 +465,7 @@ impl VmSendMigrationData {
         \"destination_url=<url>[,local=on|off,\
         downtime_ms=<milliseconds>,timeout_s=<seconds>,\
         timeout_strategy=cancel|ignore,connections=<amount>,\
-        tls_dir=<path>]\"";
+        tls_dir=<path>,memory_mode=precopy|postcopy]\"";
 
     // Same as QEMU.
     pub const DEFAULT_DOWNTIME: Duration = Duration::from_millis(300);
@@ -458,7 +494,8 @@ impl VmSendMigrationData {
             .add("timeout_s")
             .add("timeout_strategy")
             .add("connections")
-            .add("tls_dir");
+            .add("tls_dir")
+            .add("memory_mode");
         parser
             .parse(migration)
             .map_err(VmSendMigrationConfigError::ParseError)?;
@@ -514,6 +551,10 @@ impl VmSendMigrationData {
             .convert::<String>("tls_dir")
             .map_err(VmSendMigrationConfigError::ParseError)?
             .map(|path| PathBuf::from(&path));
+        let memory_mode = parser
+            .convert::<MigrationMode>("memory_mode")
+            .map_err(VmSendMigrationConfigError::ParseError)?
+            .unwrap_or_default();
 
         let data = Self {
             destination_url,
@@ -523,6 +564,7 @@ impl VmSendMigrationData {
             timeout_strategy,
             connections,
             tls_dir,
+            memory_mode,
         };
 
         data.validate()?;
@@ -591,6 +633,21 @@ impl VmSendMigrationData {
                     "invalid TLS configuration for send-migration: {e}"
                 ))
             })?;
+        }
+
+        if matches!(self.memory_mode, MigrationMode::Postcopy) {
+            if self.local {
+                return Err(VmSendMigrationConfigError::ValidationError(
+                    "memory_mode=postcopy and local options are mutually exclusive.".to_string(),
+                ));
+            }
+
+            if self.connections.get() > 1 {
+                return Err(VmSendMigrationConfigError::ValidationError(
+                    "memory_mode=postcopy currently requires a single connection (connections=1)."
+                        .to_string(),
+                ));
+            }
         }
 
         Ok(())
@@ -1921,6 +1978,7 @@ mod unit_tests {
             VmReceiveMigrationData {
                 receiver_url: "tcp:192.168.1.1:8080".to_string(),
                 tls_dir: None,
+                memory_mode: MigrationMode::Precopy,
             }
         );
 
@@ -1947,6 +2005,7 @@ mod unit_tests {
             VmReceiveMigrationData {
                 receiver_url: "tcp:192.168.1.1:8080".to_string(),
                 tls_dir: Some(tls_dir_path),
+                memory_mode: MigrationMode::Precopy,
             }
         );
 
@@ -1961,6 +2020,33 @@ mod unit_tests {
         VmReceiveMigrationData::parse("receiver_url=tcp:192.168.1.1").unwrap_err();
         VmReceiveMigrationData::parse("receiver_url=tcp:[2001:db8::1]").unwrap_err();
         VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,tls_dir=/tmp").unwrap_err();
+
+        // memory_mode defaults to precopy when not specified.
+        let data = VmReceiveMigrationData::parse("receiver_url=tcp:127.0.0.1:1234").unwrap();
+        assert_eq!(
+            data,
+            VmReceiveMigrationData {
+                receiver_url: "tcp:127.0.0.1:1234".to_string(),
+                tls_dir: None,
+                memory_mode: MigrationMode::Precopy,
+            }
+        );
+
+        // Explicit receiver_url with memory_mode=postcopy.
+        let data =
+            VmReceiveMigrationData::parse("receiver_url=unix:/tmp/sock,memory_mode=postcopy")
+                .unwrap();
+        assert_eq!(
+            data,
+            VmReceiveMigrationData {
+                receiver_url: "unix:/tmp/sock".to_string(),
+                tls_dir: None,
+                memory_mode: MigrationMode::Postcopy,
+            }
+        );
+
+        // Missing receiver_url in keyed form must fail.
+        VmReceiveMigrationData::parse("memory_mode=postcopy").unwrap_err();
     }
 
     #[test]
@@ -2062,6 +2148,7 @@ mod unit_tests {
                 timeout_strategy: Default::default(),
                 connections: VmSendMigrationData::default_connections(),
                 tls_dir: None,
+                memory_mode: MigrationMode::Precopy,
             }
         );
 
@@ -2082,7 +2169,24 @@ mod unit_tests {
                 timeout_strategy: TimeoutStrategy::Ignore,
                 connections: NonZeroU32::new(4).unwrap(),
                 tls_dir: Some(tls_dir_path),
+                memory_mode: MigrationMode::Precopy,
             }
         );
+
+        // Postcopy happy path (TCP only, single connection).
+        let data =
+            VmSendMigrationData::parse("destination_url=tcp:192.168.1.1:8080,memory_mode=postcopy")
+                .unwrap();
+        assert_eq!(data.memory_mode, MigrationMode::Postcopy);
+
+        // memory_mode=postcopy + local must be rejected.
+        VmSendMigrationData::parse("destination_url=unix:/tmp/sock,local=on,memory_mode=postcopy")
+            .unwrap_err();
+
+        // memory_mode=postcopy + multi-connection must be rejected.
+        VmSendMigrationData::parse(
+            "destination_url=tcp:192.168.1.1:8080,memory_mode=postcopy,connections=4",
+        )
+        .unwrap_err();
     }
 }

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1515,6 +1515,17 @@ components:
             Directory containing the TLS server certificate (server-cert.pem), the TLS
             server key (server-key.pem), and the client TLS root CA certificate (ca-cert.pem).
             TLS is only supported with tcp:<host>:<port> receiver URLs.
+        memory_mode:
+          $ref: "#/components/schemas/MigrationMode"
+
+    MigrationMode:
+      type: string
+      enum: ["Precopy", "Postcopy"]
+      default: "Precopy"
+      description: >
+        Memory transfer mode. Precopy transfers all guest memory before the
+        destination resumes. Postcopy resumes the destination first and faults
+        guest pages in on demand.
 
     TimeoutStrategy:
       type: string
@@ -1568,6 +1579,8 @@ components:
             Directory containing the TLS root CA certificate (ca-cert.pem), the TLS client
             certificate (client-cert.pem), and TLS client key (client-key.pem).
             TLS is only supported with tcp:<host>:<port> destination URLs.
+        memory_mode:
+          $ref: "#/components/schemas/MigrationMode"
 
     VmAddUserDevice:
       required:

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -13,7 +13,7 @@ use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::panic::AssertUnwindSafe;
 #[cfg(feature = "guest_debug")]
 use std::path::PathBuf;
-use std::sync::mpsc::{Receiver, RecvError, SendError, Sender};
+use std::sync::mpsc::{Receiver, RecvError, SendError, Sender, channel};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use std::{io, mem, result, thread};
@@ -49,7 +49,7 @@ use vmm_sys_util::signal::unblock_signal;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
 use crate::api::{
-    ApiRequest, ApiResponse, RequestHandler, TimeoutStrategy, VmInfoResponse,
+    ApiRequest, ApiResponse, MigrationMode, RequestHandler, TimeoutStrategy, VmInfoResponse,
     VmReceiveMigrationData, VmSendMigrationData, VmmPingResponse,
 };
 use crate::config::{MemoryRestoreMode, RestoreConfig, add_to_config};
@@ -685,13 +685,19 @@ pub struct Vmm {
     check_migration_evt: EventFd,
 }
 
+/// Time before aborting on the page fault connection.
+const FAULT_CONNECTION_ACCEPT_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Just a wrapper for the data that goes into
 /// [`ReceiveMigrationState::Configured`]
 struct ReceiveMigrationConfiguredData {
     memory_manager: Arc<Mutex<MemoryManager>>,
     guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
     connections: ReceiveAdditionalConnections,
+    shared_backing: bool,
+    fault_rx: Receiver<SocketStream>,
 }
+
 /// The receiver's state machine behind the migration protocol.
 enum ReceiveMigrationState {
     /// The connection is established and we haven't received any commands yet.
@@ -938,7 +944,7 @@ impl Vmm {
         listener: &ReceiveListener,
         state: ReceiveMigrationState,
         req: &Request,
-        _receive_data_migration: &VmReceiveMigrationData,
+        receive_data_migration: &VmReceiveMigrationData,
     ) -> std::result::Result<ReceiveMigrationState, MigratableError> {
         use ReceiveMigrationState::*;
 
@@ -948,23 +954,29 @@ impl Vmm {
             )))
         };
 
+        let mode = receive_data_migration.memory_mode;
         let mut configure_vm =
             |socket: &mut SocketStream,
              memory_files: HashMap<u32, File>|
              -> std::result::Result<ReceiveMigrationConfiguredData, MigratableError> {
-                let memory_manager = self.vm_receive_config(req, socket, memory_files)?;
+                let shared_backing = !memory_files.is_empty();
+                let memory_manager = self.vm_receive_config(req, socket, memory_files, mode)?;
                 let guest_memory = memory_manager.lock().unwrap().guest_memory();
                 // Create the additional-connection receiver even in the single-connection case.
                 // At this point the receiver does not know whether the sender will use extra TCP
                 // connections. If it does not, no worker connections are accepted and memory
                 // requests continue to arrive on the main connection.
-                let connections = listener
-                    .try_clone()
-                    .and_then(|l| ReceiveAdditionalConnections::new(l, guest_memory.clone()))?;
+                // The accept thread hands the page fault connection back via this channel.
+                let (fault_tx, fault_rx) = channel();
+                let connections = listener.try_clone().and_then(|l| {
+                    ReceiveAdditionalConnections::new(l, guest_memory.clone(), fault_tx)
+                })?;
                 Ok(ReceiveMigrationConfiguredData {
                     memory_manager,
                     guest_memory,
                     connections,
+                    shared_backing,
+                    fault_rx,
                 })
             };
 
@@ -1024,18 +1036,7 @@ impl Vmm {
                     Ok(Configured(config_data))
                 }
                 Command::State => {
-                    let state_receive_begin = Instant::now();
-                    config_data.connections.cleanup()?;
-                    let (recv_state_dur, restore_vm_dur) =
-                        self.vm_receive_state(req, socket, config_data.memory_manager)?;
-                    debug!(
-                        "Migration (incoming): recv_snapshot:{}ms restore:{}ms",
-                        recv_state_dur.as_millis(),
-                        restore_vm_dur.as_millis(),
-                    );
-                    Ok(StateReceived {
-                        state_receive_begin,
-                    })
+                    self.vm_receive_state_command(req, socket, config_data, receive_data_migration)
                 }
                 c => invalid_command(state_name, c),
             },
@@ -1076,11 +1077,65 @@ impl Vmm {
         }
     }
 
+    fn vm_receive_state_command(
+        &mut self,
+        req: &Request,
+        socket: &mut SocketStream,
+        mut config_data: ReceiveMigrationConfiguredData,
+        receive_data_migration: &VmReceiveMigrationData,
+    ) -> std::result::Result<ReceiveMigrationState, MigratableError> {
+        let state_receive_begin = Instant::now();
+
+        // Serve faults before restore so accesses during restore resolve on demand.
+        if matches!(receive_data_migration.memory_mode, MigrationMode::Postcopy) {
+            let shared_backing = config_data.shared_backing;
+            let fault_stream = config_data
+                .fault_rx
+                .recv_timeout(FAULT_CONNECTION_ACCEPT_TIMEOUT)
+                .map_err(|e| {
+                    config_data.connections.cleanup().ok();
+                    MigratableError::MigrateReceive(anyhow!(
+                        "Timed out waiting for postcopy fault connection: {e}"
+                    ))
+                })?;
+            let mm = config_data.memory_manager.clone();
+            let saved_regions = mm.lock().unwrap().memory_range_table(false)?;
+            mm.lock()
+                .unwrap()
+                .start_postcopy_serving(
+                    &saved_regions,
+                    shared_backing,
+                    fault_stream,
+                    &self.exit_evt,
+                )
+                .map_err(|e| {
+                    config_data.connections.cleanup().ok();
+                    MigratableError::MigrateReceive(anyhow!("start_postcopy_serving: {e:?}"))
+                })?;
+        }
+
+        // The fault connection is in hand, so stop the accept thread.
+        config_data.connections.cleanup()?;
+
+        let (recv_state_dur, restore_vm_dur) =
+            self.vm_receive_state(req, socket, config_data.memory_manager)?;
+        debug!(
+            "Migration (incoming): recv_snapshot:{}ms restore:{}ms",
+            recv_state_dur.as_millis(),
+            restore_vm_dur.as_millis(),
+        );
+
+        Ok(ReceiveMigrationState::StateReceived {
+            state_receive_begin,
+        })
+    }
+
     fn vm_receive_config<T>(
         &mut self,
         req: &Request,
         socket: &mut T,
         existing_memory_files: HashMap<u32, File>,
+        mode: MigrationMode,
     ) -> std::result::Result<Arc<Mutex<MemoryManager>>, MigratableError>
     where
         T: Read,
@@ -1096,6 +1151,24 @@ impl Vmm {
             serde_json::from_slice(&data).map_err(|e| {
                 MigratableError::MigrateReceive(anyhow!("Error deserialising config: {e}"))
             })?;
+
+        // Eager prefault populates memory before UFFD is registered, so those
+        // pages never fault and are never served. Reject postcopy+prefault
+        // rather than serve stale data.
+        if matches!(mode, MigrationMode::Postcopy) {
+            let memory = &vm_migration_config.vm_config.lock().unwrap().memory;
+            let prefault_enabled = memory.prefault
+                || memory
+                    .zones
+                    .as_ref()
+                    .is_some_and(|zones| zones.iter().any(|zone| zone.prefault));
+            if prefault_enabled {
+                return Err(MigratableError::MigrateReceive(anyhow!(
+                    "postcopy migration is incompatible with memory prefault; \
+                     the source VM must not be configured with prefault=on"
+                )));
+            }
+        }
 
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         self.vm_check_cpuid_compatibility(
@@ -1551,7 +1624,7 @@ impl Vmm {
                 // No memory was transferred
                 MemoryMigrationContext::empty_finalized(),
             )
-            .expect("migration context should transition to VmPaused for local migration");
+            .expect("migration context should transition to VmPaused for local/postcopy migration");
         } else {
             let mut mem_send = transport::SendAdditionalConnections::new(
                 &send_data_migration.destination_url,
@@ -2822,12 +2895,17 @@ impl RequestHandler for Vmm {
             response.write_to(&mut socket)?;
         }
 
-        if let ReceiveMigrationState::Aborted = state {
-            event!("vm", "migration-receive-failed");
-            self.vm = VmOwnership::None;
-            self.vm_config = None;
-        } else {
-            event!("vm", "migration-receive-finished");
+        match state {
+            ReceiveMigrationState::Aborted => {
+                event!("vm", "migration-receive-failed");
+                self.vm = VmOwnership::None;
+                self.vm_config = None;
+            }
+            ReceiveMigrationState::Completed => {
+                // Serving and resume already happened in the protocol loop.
+                event!("vm", "migration-receive-finished");
+            }
+            _ => unreachable!("loop only exits in Completed or Aborted"),
         }
 
         Ok(())

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -37,8 +37,8 @@ use serde::{Deserialize, Serialize};
 use signal_hook::iterator::{Handle, Signals};
 use thiserror::Error;
 use tracer::trace_scoped;
-use vm_memory::GuestMemoryAtomic;
 use vm_memory::bitmap::AtomicBitmap;
+use vm_memory::{Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic};
 use vm_migration::protocol::*;
 use vm_migration::{
     MemoryMigrationContext, Migratable, MigratableError, OngoingMigrationContext, Pausable,
@@ -1613,7 +1613,9 @@ impl Vmm {
         // Let every Migratable object know about the migration being started.
         vm.start_migration()?;
 
-        if send_data_migration.local {
+        if send_data_migration.local
+            || matches!(send_data_migration.memory_mode, MigrationMode::Postcopy)
+        {
             // Now pause VM (skip if already paused, e.g. migrating a paused VM)
             let downtime_begin = Instant::now();
             if vm.get_state() != VmState::Paused {
@@ -1656,12 +1658,34 @@ impl Vmm {
         vm.release_disk_locks()
             .map_err(|e| MigratableError::UnlockError(anyhow!("{e}")))?;
 
+        // For postcopy, serve faults before sending State so the destination
+        // can fault pages in during restore.
+        let postcopy_handle = if matches!(send_data_migration.memory_mode, MigrationMode::Postcopy)
+        {
+            let fault_stream = transport::open_fault_connection(
+                &send_data_migration.destination_url,
+                send_data_migration.tls_dir.as_deref(),
+            )?;
+            let guest_memory = vm.guest_memory();
+            let handle = thread::Builder::new()
+                .name("migrate-send-postcopy".to_owned())
+                .spawn(move || Self::serve_postcopy(fault_stream, guest_memory))
+                .map_err(|e| {
+                    MigratableError::MigrateSend(anyhow!("spawning postcopy serve thread: {e}"))
+                })?;
+            Some(handle)
+        } else {
+            None
+        };
+
         let (vm_snapshot, snapshot_duration) = measure_ok(|| {
             // Capture snapshot. This may have side effects, e.g. vhost-user backend inflight drain
             let snapshot = vm.snapshot()?;
 
             // One final memory iteration to handle side effects from snapshot.
-            if !send_data_migration.local {
+            if !send_data_migration.local
+                && !matches!(send_data_migration.memory_mode, MigrationMode::Postcopy)
+            {
                 let memory_ranges = vm.dirty_log()?;
                 transport::send_memory_ranges(&vm.guest_memory(), &memory_ranges, &mut socket)?;
             }
@@ -1701,12 +1725,90 @@ impl Vmm {
         debug!("Downtime breakdown: {}", ctx.downtime_ctx);
 
         // Stop logging dirty pages
-        if !send_data_migration.local {
+        if !send_data_migration.local
+            && !matches!(send_data_migration.memory_mode, MigrationMode::Postcopy)
+        {
             vm.stop_dirty_log()?;
+        }
+
+        // Wait for the serve thread to drain every page
+        if let Some(handle) = postcopy_handle {
+            handle.join().map_err(|e| {
+                MigratableError::MigrateSend(anyhow!("postcopy serve thread panicked: {e:?}"))
+            })??;
+            // Signal that postcopy has drained every page to the destination.
+            event!("vm", "postcopy-migration-completed");
         }
 
         // Let every Migratable object know about the migration being complete
         vm.complete_migration()
+    }
+
+    /// Serve `Command::PageFault` requests from local guest memory on the fault
+    /// connection until the destination closes it. Runs on its own thread.
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "runs on a dedicated thread and must own its arguments"
+    )]
+    fn serve_postcopy(
+        mut socket: SocketStream,
+        guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
+    ) -> result::Result<(), MigratableError> {
+        let mut buf: Vec<u8> = Vec::new();
+        info!("Postcopy: source entering PageFault serve loop");
+
+        loop {
+            let req = match Request::read_from(&mut socket) {
+                Ok(r) => r,
+                Err(MigratableError::MigrateSocket(e))
+                    if matches!(
+                        e.kind(),
+                        io::ErrorKind::UnexpectedEof | io::ErrorKind::BrokenPipe
+                    ) =>
+                {
+                    info!("Postcopy: destination closed the fault connection — drain complete");
+                    return Ok(());
+                }
+                Err(e) => return Err(e),
+            };
+
+            match req.command() {
+                Command::PageFault => {
+                    let range = MemoryRange::read_from(&mut socket)?;
+                    let len = range.length as usize;
+                    const MAX_PAGE: usize = 1 << 30; // 1 GiB
+                    if len == 0 || len > MAX_PAGE {
+                        return Err(MigratableError::MigrateSend(anyhow!(
+                            "Postcopy: invalid page length {len}"
+                        )));
+                    }
+                    buf.resize(len, 0);
+                    let mem = guest_memory.memory();
+                    mem.read_slice(&mut buf[..len], GuestAddress(range.gpa))
+                        .map_err(|e| {
+                            MigratableError::MigrateSend(anyhow!(
+                                "Postcopy: reading guest memory gpa={:#x} len={}: {e}",
+                                range.gpa,
+                                range.length
+                            ))
+                        })?;
+                    Response::new(Status::Ok, range.length).write_to(&mut socket)?;
+                    socket
+                        .write_all(&buf[..len])
+                        .map_err(MigratableError::MigrateSocket)?;
+                }
+                Command::Abandon => {
+                    Response::ok().write_to(&mut socket)?;
+                    info!("Postcopy: received Abandon, exiting serve loop");
+                    return Ok(());
+                }
+                c => {
+                    return Err(MigratableError::MigrateSend(anyhow!(
+                        "Postcopy: unexpected command in serve loop: {c:?}",
+                    )));
+                }
+            }
+        }
     }
 
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -31,7 +31,7 @@ use libc::{EFD_NONBLOCK, SIGINT, SIGTERM, TCSANOW, tcsetattr, termios};
 use log::{debug, error, info, trace, warn};
 use memory_manager::MemoryManagerSnapshotData;
 use pci::PciBdf;
-use seccompiler::{SeccompAction, apply_filter};
+use seccompiler::{BpfProgram, SeccompAction, apply_filter};
 use serde::ser::{SerializeStruct, Serializer};
 use serde::{Deserialize, Serialize};
 use signal_hook::iterator::{Handle, Signals};
@@ -1531,6 +1531,7 @@ impl Vmm {
         hypervisor: &dyn hypervisor::Hypervisor,
         send_data_migration: &VmSendMigrationData,
         initial_vm_state: VmState,
+        seccomp_action: &SeccompAction,
     ) -> result::Result<(), MigratableError> {
         // State machine that is updated with more context as we progress.
         let mut ctx = OngoingMigrationContext::new();
@@ -1667,9 +1668,19 @@ impl Vmm {
                 send_data_migration.tls_dir.as_deref(),
             )?;
             let guest_memory = vm.guest_memory();
+            // Build the seccomp filter on the parent thread so any failure aborts
+            // the migration before the serve thread is spawned.
+            let seccomp_filter = get_seccomp_filter(
+                seccomp_action,
+                Thread::MigrateSendPostcopy,
+                None,
+            )
+            .map_err(|e| {
+                MigratableError::MigrateSend(anyhow!("creating postcopy serve seccomp filter: {e}"))
+            })?;
             let handle = thread::Builder::new()
                 .name("migrate-send-postcopy".to_owned())
-                .spawn(move || Self::serve_postcopy(fault_stream, guest_memory))
+                .spawn(move || Self::serve_postcopy(seccomp_filter, fault_stream, guest_memory))
                 .map_err(|e| {
                     MigratableError::MigrateSend(anyhow!("spawning postcopy serve thread: {e}"))
                 })?;
@@ -1751,9 +1762,19 @@ impl Vmm {
         reason = "runs on a dedicated thread and must own its arguments"
     )]
     fn serve_postcopy(
+        seccomp_filter: BpfProgram,
         mut socket: SocketStream,
         guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
     ) -> result::Result<(), MigratableError> {
+        // Apply the dedicated seccomp filter for this thread. It is empty when
+        // seccomp is disabled (SeccompAction::Allow), in which case there is
+        // nothing to apply.
+        if !seccomp_filter.is_empty() {
+            apply_filter(&seccomp_filter).map_err(|e| {
+                MigratableError::MigrateSend(anyhow!("applying postcopy serve seccomp filter: {e}"))
+            })?;
+        }
+
         let mut buf: Vec<u8> = Vec::new();
         info!("Postcopy: source entering PageFault serve loop");
 
@@ -3099,6 +3120,7 @@ impl RequestHandler for Vmm {
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             self.hypervisor.clone(),
             initial_vm_state,
+            self.seccomp_action.clone(),
         ) {
             Ok(handle) => {
                 self.vm = VmOwnership::Migration {

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -11,7 +11,6 @@ use std::io::{self, Seek, SeekFrom};
 use std::num::NonZeroUsize;
 use std::ops::{BitAnd, Not, Sub};
 use std::os::fd::{AsFd, OwnedFd};
-use std::os::unix::fs::FileExt;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -57,41 +56,14 @@ use crate::coredump::{
 };
 use crate::migration::url_to_path;
 use crate::sparse::{next_data_extent, write_region_sparse};
+use crate::uffd::{self, FaultResolution, FileUffdMemorySource, UffdMemorySource, UffdRange};
 use crate::vm_config::{HotplugMethod, MemoryConfig, MemoryZoneConfig};
-use crate::{GuestMemoryMmap, GuestRegionMmap, MEMORY_MANAGER_SNAPSHOT_ID, uffd};
+use crate::{GuestMemoryMmap, GuestRegionMmap, MEMORY_MANAGER_SNAPSHOT_ID};
 
 struct UffdHandler {
     stop_event: EventFd,
     result_rx: Receiver<Result<(), io::Error>>,
     handle: thread::JoinHandle<()>,
-}
-
-struct UffdRange {
-    host_addr: u64,
-    length: u64,
-    file_offset: u64,
-    page_size: u64,
-}
-
-impl UffdRange {
-    fn num_pages(&self) -> u64 {
-        self.length.div_ceil(self.page_size)
-    }
-
-    fn page_addr(&self, page_idx: u64) -> u64 {
-        self.host_addr + page_idx * self.page_size
-    }
-
-    fn file_pos(&self, page_idx: u64) -> u64 {
-        self.file_offset + page_idx * self.page_size
-    }
-
-    /// Returns the page index containing `addr` if it falls within this range.
-    fn page_index_of(&self, addr: u64) -> Option<u64> {
-        let page_addr = addr & !(self.page_size - 1);
-        (page_addr >= self.host_addr && page_addr < self.host_addr + self.length)
-            .then(|| (page_addr - self.host_addr) / self.page_size)
-    }
 }
 
 pub const MEMORY_MANAGER_ACPI_SIZE: usize = 0x18;
@@ -944,6 +916,19 @@ impl MemoryManager {
             return Ok(());
         }
 
+        let snapshot_file = File::open(file_path).map_err(Error::SnapshotOpen)?;
+        let source: Box<dyn UffdMemorySource> = Box::new(FileUffdMemorySource::new(snapshot_file));
+        self.register_uffd_handler(saved_regions, exit_evt, source)
+    }
+
+    /// Register every range against userfaultfd, then spawn the
+    /// handler thread that resolves faults through the memory source.
+    fn register_uffd_handler(
+        &mut self,
+        saved_regions: &MemoryRangeTable,
+        exit_evt: &EventFd,
+        source: Box<dyn UffdMemorySource>,
+    ) -> Result<(), Error> {
         let guest_memory = self.guest_memory.memory();
         let required_uffd_features = self.required_uffd_features();
 
@@ -962,8 +947,6 @@ impl MemoryManager {
         {
             return Err(UffdError::UnalignedRanges.into());
         }
-
-        let snapshot_file = File::open(file_path).map_err(Error::SnapshotOpen)?;
 
         let uffd_fd = uffd::create(required_uffd_features).map_err(UffdError::Create)?;
 
@@ -1005,7 +988,7 @@ impl MemoryManager {
             handler_ranges.push(UffdRange {
                 host_addr,
                 length: range.length,
-                file_offset,
+                source_offset: file_offset,
                 page_size: range_page_size,
             });
 
@@ -1027,17 +1010,11 @@ impl MemoryManager {
             .name("uffd-handler".to_string())
             .spawn(move || {
                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-                    let max_page_size = handler_ranges
-                        .iter()
-                        .map(|r| r.page_size)
-                        .max()
-                        .unwrap_or(base_page_size);
                     let result = Self::uffd_handler_loop(
                         uffd_fd,
                         thread_stop_event,
-                        snapshot_file,
+                        source,
                         &handler_ranges,
-                        max_page_size,
                         &ready_tx,
                     );
 
@@ -1102,25 +1079,17 @@ impl MemoryManager {
         }
     }
 
-    /// Poll the UFFD fd and serve page faults from the snapshot file, while
-    /// opportunistically prefaulting the remaining pages in between faults.
-    ///
-    /// Runs until the fd is closed (EPOLLHUP), `stop_event` fires, or an
-    /// unrecoverable error occurs. Each fault triggers a read from the
-    /// snapshot file followed by a `UFFDIO_COPY` to resolve the fault and
-    /// wake the faulting thread. When no fault is pending, one prefault
-    /// page is copied per loop iteration.
+    /// Serve UFFD faults via `source`, prefaulting one page per idle
+    /// iteration.
     #[expect(clippy::needless_pass_by_value)]
     fn uffd_handler_loop(
         uffd_fd: OwnedFd,
         stop_event: EventFd,
-        snapshot_file: File,
+        mut source: Box<dyn UffdMemorySource>,
         ranges: &[UffdRange],
-        page_size: u64,
         ready_tx: &SyncSender<()>,
     ) -> Result<(), io::Error> {
         let uffd_raw_fd = uffd_fd.as_raw_fd();
-        let mut page_buf = vec![0u8; page_size as usize];
 
         let total_pages: u64 = ranges.iter().map(UffdRange::num_pages).sum();
         let mut pages_served: u64 = 0;
@@ -1245,39 +1214,19 @@ impl MemoryManager {
                     let Some(page_idx) = range.page_index_of(fault_addr) else {
                         continue;
                     };
-                    let page_addr = range.page_addr(page_idx);
-                    let file_pos = range.file_pos(page_idx);
-
-                    snapshot_file
-                        .read_exact_at(&mut page_buf[..range.page_size as usize], file_pos)?;
 
                     loop {
-                        match uffd::copy(
-                            uffd_fd.as_fd(),
-                            page_addr,
-                            page_buf.as_ptr(),
-                            range.page_size,
-                        ) {
-                            Ok(()) => {
+                        match source.resolve(uffd_fd.as_fd(), range, page_idx)? {
+                            FaultResolution::Served => {
                                 pages_served += 1;
                                 served_bitmap[range_idx].set_bit(page_idx as usize);
                                 break;
                             }
-                            Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
-                                if let Err(e) =
-                                    uffd::wake(uffd_fd.as_fd(), page_addr, range.page_size)
-                                {
-                                    warn!("UFFDIO_WAKE failed at {page_addr:#x}: {e}");
-                                }
-                                served_bitmap[range_idx].set_bit(page_idx as usize);
-                                break;
-                            }
-                            Err(e) if e.raw_os_error() == Some(libc::EAGAIN) => {
-                                // The kernel can report a transient EAGAIN while the fault
-                                // is being resolved; yield and retry instead of aborting restore.
+                            FaultResolution::Retry => {
+                                // The kernel reported a transient state while the fault
+                                // is being resolved; yield and retry instead of aborting.
                                 thread::yield_now();
                             }
-                            Err(e) => return Err(e),
                         }
                     }
                     served = true;
@@ -1328,46 +1277,23 @@ impl MemoryManager {
             };
 
             let range = &ranges[range_idx];
-            let file_pos = range.file_pos(page_idx);
-            let page_addr = range.page_addr(page_idx);
-            let len = range.page_size as usize;
 
-            let advance = match snapshot_file.read_exact_at(&mut page_buf[..len], file_pos) {
-                Ok(()) => match uffd::copy(
-                    uffd_fd.as_fd(),
-                    page_addr,
-                    page_buf.as_ptr(),
-                    range.page_size,
-                ) {
-                    Ok(()) => {
-                        pages_prefaulted += 1;
-                        true
-                    }
-                    Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
-                        // Should be unreachable: in single-thread mode with
-                        // MISSING-only registration, the only installer is us,
-                        // and the bitmap check above already filtered served
-                        // pages. Treat as a bug signal but keep going.
-                        warn!(
-                            "UFFD prefault: unexpected EEXIST at {page_addr:#x} \
-                             (bitmap/handler bug?)"
-                        );
-                        true
-                    }
-                    Err(e) if e.raw_os_error() == Some(libc::EAGAIN) => {
-                        // Unlike the on-demand handler (which must retry to
-                        // wake the faulting thread), prefault can safely skip:
-                        // any future guest access will simply page-fault and
-                        // be served by the on-demand path.
-                        true
-                    }
-                    Err(e) => {
-                        warn!("UFFD prefault: UFFDIO_COPY error at {page_addr:#x}: {e}");
-                        false
-                    }
-                },
+            let advance = match source.resolve(uffd_fd.as_fd(), range, page_idx) {
+                Ok(FaultResolution::Served) => {
+                    pages_prefaulted += 1;
+                    served_bitmap[range_idx].set_bit(page_idx as usize);
+                    true
+                }
+                Ok(FaultResolution::Retry) => {
+                    // Unlike the on demand handler (which must retry to wake
+                    // the faulting thread), prefault can safely skip: any
+                    // future guest access will simply page-fault and be
+                    // served by the on demand path.
+                    true
+                }
                 Err(e) => {
-                    warn!("UFFD prefault: read error at {file_pos:#x}: {e}");
+                    let page_addr = range.page_addr(page_idx);
+                    warn!("UFFD prefault: source error at {page_addr:#x}: {e}");
                     false
                 }
             };

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -54,9 +54,13 @@ use crate::config::MemoryRestoreMode;
 use crate::coredump::{
     CoredumpMemoryRegion, CoredumpMemoryRegions, DumpState, GuestDebuggableError,
 };
+use crate::migration::transport::SocketStream;
 use crate::migration::url_to_path;
 use crate::sparse::{next_data_extent, write_region_sparse};
-use crate::uffd::{self, FaultResolution, FileUffdMemorySource, UffdMemorySource, UffdRange};
+use crate::uffd::{
+    self, FaultResolution, FileUffdMemorySource, SocketUffdMemorySource, UffdMemorySource,
+    UffdRange,
+};
 use crate::vm_config::{HotplugMethod, MemoryConfig, MemoryZoneConfig};
 use crate::{GuestMemoryMmap, GuestRegionMmap, MEMORY_MANAGER_SNAPSHOT_ID};
 
@@ -64,6 +68,7 @@ struct UffdHandler {
     stop_event: EventFd,
     result_rx: Receiver<Result<(), io::Error>>,
     handle: thread::JoinHandle<()>,
+    fault_socket_fd: Option<OwnedFd>,
 }
 
 pub const MEMORY_MANAGER_ACPI_SIZE: usize = 0x18;
@@ -912,23 +917,59 @@ impl MemoryManager {
         saved_regions: &MemoryRangeTable,
         exit_evt: &EventFd,
     ) -> Result<(), Error> {
-        if saved_regions.is_empty() {
+        let mut file_offset: u64 = 0;
+        let Some((uffd_fd, ranges)) = self.prepare_uffd(saved_regions, |r| {
+            let o = file_offset;
+            file_offset += r.length;
+            o
+        })?
+        else {
             return Ok(());
-        }
-
+        };
         let snapshot_file = File::open(file_path).map_err(Error::SnapshotOpen)?;
         let source: Box<dyn UffdMemorySource> = Box::new(FileUffdMemorySource::new(snapshot_file));
-        self.register_uffd_handler(saved_regions, exit_evt, source)
+        self.spawn_uffd_handler(uffd_fd, None, ranges, source, exit_evt)?;
+        info!("UFFD restore: demand-paged restore enabled");
+        Ok(())
     }
 
-    /// Register every range against userfaultfd, then spawn the
-    /// handler thread that resolves faults through the memory source.
-    fn register_uffd_handler(
+    /// Register UFFD and spawn the handler that serves faults over `socket`.
+    /// No-op when there are no regions.
+    pub(crate) fn start_postcopy_serving(
         &mut self,
         saved_regions: &MemoryRangeTable,
+        shared_backing: bool,
+        socket: SocketStream,
         exit_evt: &EventFd,
-        source: Box<dyn UffdMemorySource>,
     ) -> Result<(), Error> {
+        // PageFault uses the GPA as the page identifier on the wire.
+        let Some((uffd_fd, ranges)) = self.prepare_uffd(saved_regions, |r| r.gpa)? else {
+            return Ok(());
+        };
+        // Make every fault a small request/response round-trip.
+        socket.set_nodelay(true).map_err(UffdError::SetSocket)?;
+        let socket_fd = socket
+            .as_fd()
+            .try_clone_to_owned()
+            .map_err(UffdError::SetSocket)?;
+        let source: Box<dyn UffdMemorySource> =
+            Box::new(SocketUffdMemorySource::new(socket, shared_backing));
+        self.spawn_uffd_handler(uffd_fd, Some(socket_fd), ranges, source, exit_evt)
+    }
+
+    /// Create a UFFD fd and register every range.
+    fn prepare_uffd<F>(
+        &mut self,
+        saved_regions: &MemoryRangeTable,
+        mut source_offset_for: F,
+    ) -> Result<Option<(OwnedFd, Vec<UffdRange>)>, Error>
+    where
+        F: FnMut(&MemoryRange) -> u64,
+    {
+        if saved_regions.is_empty() {
+            return Ok(None);
+        }
+
         let guest_memory = self.guest_memory.memory();
         let required_uffd_features = self.required_uffd_features();
 
@@ -936,7 +977,7 @@ impl MemoryManager {
         let base_page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u64;
 
         info!(
-            "UFFD restore: attempting demand-paged restore for {} region(s)",
+            "UFFD: registering {} region(s) for demand paging",
             saved_regions.regions().len()
         );
 
@@ -951,7 +992,6 @@ impl MemoryManager {
         let uffd_fd = uffd::create(required_uffd_features).map_err(UffdError::Create)?;
 
         let mut handler_ranges: Vec<UffdRange> = Vec::new();
-        let mut file_offset: u64 = 0;
 
         for range in saved_regions.regions() {
             let host_addr = guest_memory
@@ -988,22 +1028,32 @@ impl MemoryManager {
             handler_ranges.push(UffdRange {
                 host_addr,
                 length: range.length,
-                source_offset: file_offset,
+                source_offset: source_offset_for(range),
                 page_size: range_page_size,
             });
-
-            file_offset += range.length;
         }
 
+        Ok(Some((uffd_fd, handler_ranges)))
+    }
+
+    /// Spawn the UFFD handler thread that resolves faults through `source`.
+    fn spawn_uffd_handler(
+        &mut self,
+        uffd_fd: OwnedFd,
+        fault_socket_fd: Option<OwnedFd>,
+        handler_ranges: Vec<UffdRange>,
+        source: Box<dyn UffdMemorySource>,
+        exit_evt: &EventFd,
+    ) -> Result<(), Error> {
         info!(
-            "UFFD restore: registered {} region(s), {} total bytes, spawning handler",
-            handler_ranges.len(),
-            file_offset
+            "UFFD: spawning handler for {} region(s)",
+            handler_ranges.len()
         );
 
         let stop_event = EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFdFail)?;
         let thread_stop_event = stop_event.try_clone().map_err(Error::EventFdFail)?;
         let thread_exit_evt = exit_evt.try_clone().map_err(Error::EventFdFail)?;
+        let panic_exit_evt = exit_evt.try_clone().map_err(Error::EventFdFail)?;
         let (ready_tx, ready_rx) = mpsc::sync_channel(1);
         let (result_tx, result_rx) = mpsc::sync_channel(1);
         let handle = thread::Builder::new()
@@ -1020,13 +1070,14 @@ impl MemoryManager {
 
                     if let Err(e) = &result {
                         error!("UFFD handler exited with error: {e}");
+                        thread_exit_evt.write(1).ok();
                     }
 
                     result_tx.send(result).ok();
                 }))
                 .map_err(|_| {
                     error!("uffd-handler thread panicked");
-                    thread_exit_evt.write(1).ok();
+                    panic_exit_evt.write(1).ok();
                 })
                 .ok();
             })
@@ -1046,16 +1097,15 @@ impl MemoryManager {
             stop_event,
             result_rx,
             handle,
+            fault_socket_fd,
         });
-
-        info!("UFFD restore: demand-paged restore enabled");
 
         Ok(())
     }
 
     fn required_uffd_features(&self) -> u64 {
         let mut features = 0u64;
-        if self.memory_zones.values().any(|z| z.shared && !z.hugepages) {
+        if self.memory_zones.values().any(|z| z.shared || !z.hugepages) {
             features |= crate::userfaultfd::UFFD_FEATURE_MISSING_SHMEM;
         }
         if self.memory_zones.values().any(|z| z.hugepages) {
@@ -1067,6 +1117,10 @@ impl MemoryManager {
     fn stop_uffd_handler(&mut self) {
         if let Some(uffd_handler) = self.uffd_handler.take() {
             uffd_handler.stop_event.write(1).ok();
+            if let Some(fd) = &uffd_handler.fault_socket_fd {
+                // SAFETY: fd is a valid owned fd for the duration of this call.
+                unsafe { libc::shutdown(fd.as_raw_fd(), libc::SHUT_RDWR) };
+            }
             uffd_handler.handle.join().ok();
 
             match uffd_handler.result_rx.try_recv() {

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -6,16 +6,15 @@
 use std::io::{self, ErrorKind, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::num::{NonZeroU32, ParseIntError};
-use std::os::fd::{AsFd, BorrowedFd};
-use std::os::unix::io::AsRawFd;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::result::Result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender, SyncSender, TrySendError, channel, sync_channel};
 use std::sync::{Arc, Mutex};
-use std::thread;
 use std::time::Duration;
+use std::{mem, thread};
 
 use anyhow::{Context, anyhow};
 use log::{debug, error, info, warn};
@@ -26,7 +25,7 @@ use vm_memory::{
     Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, ReadVolatile, VolatileMemoryError,
     VolatileSlice, WriteVolatile,
 };
-use vm_migration::protocol::{Command, MemoryRangeTable, Request, Response};
+use vm_migration::protocol::{Command, ConnectionRole, MemoryRangeTable, Request, Response};
 use vm_migration::tls::{TlsServerConfig, TlsStream};
 use vm_migration::{MigratableError, Snapshot};
 use vmm_sys_util::eventfd::EventFd;
@@ -159,6 +158,40 @@ impl Write for SocketStream {
     }
 }
 
+impl SocketStream {
+    pub(crate) fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        match self {
+            SocketStream::Unix(s) => s.set_read_timeout(dur),
+            SocketStream::Tcp(s) => s.set_read_timeout(dur),
+            SocketStream::Tls(s) => {
+                let fd = s.as_fd().as_raw_fd();
+                // SAFETY: fd is borrowed from the TLS stream and forgotten
+                // immediately. The TLS stream retains ownership.
+                let tcp = unsafe { TcpStream::from_raw_fd(fd) };
+                let r = tcp.set_read_timeout(dur);
+                mem::forget(tcp);
+                r
+            }
+        }
+    }
+
+    pub(crate) fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
+        match self {
+            SocketStream::Unix(_) => Ok(()),
+            SocketStream::Tcp(s) => s.set_nodelay(nodelay),
+            SocketStream::Tls(s) => {
+                let fd = s.as_fd().as_raw_fd();
+                // SAFETY: fd is borrowed from the TLS stream and forgotten
+                // immediately. The TLS stream retains ownership.
+                let tcp = unsafe { TcpStream::from_raw_fd(fd) };
+                let r = tcp.set_nodelay(nodelay);
+                mem::forget(tcp);
+                r
+            }
+        }
+    }
+}
+
 impl AsFd for SocketStream {
     fn as_fd(&self) -> BorrowedFd<'_> {
         match self {
@@ -263,6 +296,7 @@ impl ReceiveAdditionalConnections {
     pub(crate) fn new(
         listener: ReceiveListener,
         guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
+        fault_tx: Sender<SocketStream>,
     ) -> Result<Self, MigratableError> {
         let event_fd = EventFd::new(0)
             .context("Error creating terminate fd")
@@ -275,7 +309,9 @@ impl ReceiveAdditionalConnections {
 
         let accept_thread = thread::Builder::new()
             .name("migrate-receive-accept-connections".to_owned())
-            .spawn(move || Self::accept_connections(listener, &terminate_fd, &guest_memory))
+            .spawn(move || {
+                Self::accept_connections(listener, &terminate_fd, &guest_memory, &fault_tx)
+            })
             .context("Error creating connection accept thread")
             .map_err(MigratableError::MigrateReceive)?;
 
@@ -289,6 +325,7 @@ impl ReceiveAdditionalConnections {
         mut listener: ReceiveListener,
         terminate_fd: &EventFd,
         guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
+        fault_tx: &Sender<SocketStream>,
     ) -> Result<(), MigratableError> {
         let mut threads: Vec<thread::JoinHandle<Result<(), MigratableError>>> = Vec::new();
         let mut first_err = loop {
@@ -304,6 +341,39 @@ impl ReceiveAdditionalConnections {
                 break Err(MigratableError::MigrateReceive(anyhow!(
                     "Received more than {MAX_MIGRATION_CONNECTIONS} additional migration connections."
                 )));
+            }
+
+            // Read the role header with a timeout so a stalled peer can't block
+            // acceptance of other connections.
+            socket
+                .set_read_timeout(Some(Duration::from_secs(10)))
+                .map_err(MigratableError::MigrateSocket)?;
+            let role = match ConnectionRole::read_from(&mut socket) {
+                Ok(role) => role,
+                Err(e) => {
+                    warn!("Dropping connection: failed to read connection role: {e}");
+                    continue;
+                }
+            };
+            socket
+                .set_read_timeout(None)
+                .map_err(MigratableError::MigrateSocket)?;
+
+            match role {
+                ConnectionRole::Invalid => {
+                    warn!("Dropping connection: invalid connection role");
+                    continue;
+                }
+                ConnectionRole::Fault => {
+                    // Hand the fault connection to the main thread. No memory worker for it.
+                    if let Err(e) = fault_tx.send(socket) {
+                        break Err(MigratableError::MigrateReceive(anyhow!(
+                            "Failed to hand off fault connection: {e}"
+                        )));
+                    }
+                    continue;
+                }
+                ConnectionRole::PrecopyMemory => {}
             }
 
             let guest_memory = guest_memory.clone();
@@ -539,6 +609,7 @@ impl SendAdditionalConnections {
         // this case we create one additional thread for each connection.
         for n in 0..configured_connections {
             let mut socket = send_migration_socket(destination, tls_dir)?;
+            ConnectionRole::PrecopyMemory.write_to(&mut socket)?;
             let guest_memory = guest_memory.clone();
             let message_rx = message_rx.clone();
             let worker_error = worker_error.clone();

--- a/vmm/src/migration/transport.rs
+++ b/vmm/src/migration/transport.rs
@@ -958,6 +958,22 @@ pub(crate) fn send_migration_socket(
     }
 }
 
+/// Open a dedicated fault connection with the destination VM and announce
+/// the [`ConnectionRole::Fault`] role. Used by the source to serve `PageFault`
+/// requests asynchronously.
+pub(crate) fn open_fault_connection(
+    destination_url: &str,
+    tls_dir: Option<&Path>,
+) -> Result<SocketStream, MigratableError> {
+    let mut socket = send_migration_socket(destination_url, tls_dir)?;
+    ConnectionRole::Fault.write_to(&mut socket)?;
+    // Enable fault request/response round-trips.
+    socket
+        .set_nodelay(true)
+        .map_err(MigratableError::MigrateSocket)?;
+    Ok(socket)
+}
+
 /// Bind a migration listener for the receiver side.
 pub(crate) fn receive_migration_listener(
     receiver_url: &str,

--- a/vmm/src/migration/worker.rs
+++ b/vmm/src/migration/worker.rs
@@ -21,6 +21,7 @@ use std::thread::JoinHandle;
 
 use event_monitor::event;
 use log::warn;
+use seccompiler::SeccompAction;
 use vm_migration::MigratableError;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -75,6 +76,7 @@ pub struct MigrationWorker {
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
     hypervisor: Arc<dyn hypervisor::Hypervisor>,
     initial_vm_state: VmState,
+    seccomp_action: SeccompAction,
 }
 
 impl MigrationWorker {
@@ -90,6 +92,7 @@ impl MigrationWorker {
             self.hypervisor.as_ref(),
             &self.config,
             self.initial_vm_state,
+            &self.seccomp_action,
         )
         .inspect(|_| event!("vm", "migration-finished"))
         .inspect_err(|_| event!("vm", "migration-failed"));
@@ -116,6 +119,7 @@ impl MigrationWorker {
             dyn hypervisor::Hypervisor,
         >,
         initial_vm_state: VmState,
+        seccomp_action: SeccompAction,
     ) -> Result<MigrationWorkerHandle, MigrationWorkerSpawnError> {
         let (vm_sender, vm_receiver) = std::sync::mpsc::sync_channel(0);
         let worker = MigrationWorker {
@@ -125,6 +129,7 @@ impl MigrationWorker {
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             hypervisor,
             initial_vm_state,
+            seccomp_action,
         };
 
         let inner_handle = match thread::Builder::new()

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -42,6 +42,7 @@ pub enum Thread {
     Vmm,
     PtyForeground,
     SerialManager,
+    MigrateSendPostcopy,
 }
 
 /// Shorthand for chaining `SeccompCondition`s with the `and` operator  in a `SeccompRule`.
@@ -1084,6 +1085,35 @@ fn serial_manager_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, Backend
     ])
 }
 
+// The filter containing the white listed syscall rules required by the
+// migration postcopy thread.
+fn migrate_send_postcopy_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError> {
+    Ok(vec![
+        (libc::SYS_brk, vec![]),
+        (libc::SYS_clock_gettime, vec![]),
+        (libc::SYS_close, vec![]),
+        (libc::SYS_exit, vec![]),
+        (libc::SYS_futex, vec![]),
+        (libc::SYS_getrandom, vec![]),
+        (libc::SYS_gettid, vec![]),
+        (libc::SYS_madvise, vec![]),
+        (libc::SYS_mmap, vec![]),
+        (libc::SYS_mprotect, vec![]),
+        (libc::SYS_munmap, vec![]),
+        (libc::SYS_read, vec![]),
+        (libc::SYS_recvfrom, vec![]),
+        (libc::SYS_recvmsg, vec![]),
+        (libc::SYS_rt_sigprocmask, vec![]),
+        (libc::SYS_rt_sigreturn, vec![]),
+        (libc::SYS_sched_yield, vec![]),
+        (libc::SYS_sendmsg, vec![]),
+        (libc::SYS_sendto, vec![]),
+        (libc::SYS_sigaltstack, vec![]),
+        (libc::SYS_write, vec![]),
+        (libc::SYS_writev, vec![]),
+    ])
+}
+
 fn get_seccomp_rules(
     thread_type: Thread,
     hypervisor_type: Option<HypervisorType>,
@@ -1102,6 +1132,7 @@ fn get_seccomp_rules(
             hypervisor_type.expect("hypervisor_type is required for Vmm threads"),
         )?),
         Thread::PtyForeground => Ok(pty_foreground_thread_rules()?),
+        Thread::MigrateSendPostcopy => Ok(migrate_send_postcopy_thread_rules()?),
     }
 }
 

--- a/vmm/src/uffd.rs
+++ b/vmm/src/uffd.rs
@@ -13,10 +13,11 @@
 //! original memory mapping, so it remains compatible with VFIO device
 //! passthrough and shared-memory-backed guest RAM.
 
-use std::fs::OpenOptions;
-use std::io::Error;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Error};
 use std::mem;
 use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::fs::FileExt;
 
 use crate::userfaultfd;
 
@@ -177,6 +178,100 @@ pub(crate) fn copy(fd: BorrowedFd<'_>, dst: u64, src: *const u8, len: u64) -> Re
 struct UffdioRange {
     start: u64,
     len: u64,
+}
+
+/// A guest memory range registered with userfaultfd, plus where its bytes
+/// live in the snapshot file.
+pub(crate) struct UffdRange {
+    pub host_addr: u64,
+    pub length: u64,
+    pub source_offset: u64,
+    pub page_size: u64,
+}
+
+impl UffdRange {
+    pub fn num_pages(&self) -> u64 {
+        self.length.div_ceil(self.page_size)
+    }
+
+    pub fn page_addr(&self, page_idx: u64) -> u64 {
+        self.host_addr + page_idx * self.page_size
+    }
+
+    pub fn page_source_offset(&self, page_idx: u64) -> u64 {
+        self.source_offset + page_idx * self.page_size
+    }
+
+    pub fn page_index_of(&self, addr: u64) -> Option<u64> {
+        let page_addr = addr & !(self.page_size - 1);
+        (page_addr >= self.host_addr && page_addr < self.host_addr + self.length)
+            .then(|| (page_addr - self.host_addr) / self.page_size)
+    }
+}
+
+/// Result of a page fault being resolved.
+pub(crate) enum FaultResolution {
+    /// Page installed.
+    Served,
+    /// Indicates the page couldn't be installed and it's worth retrying.
+    Retry,
+}
+
+/// Provider of guest-memory page contents for a UFFD handler.
+pub(crate) trait UffdMemorySource: Send {
+    fn resolve(
+        &mut self,
+        uffd_fd: BorrowedFd<'_>,
+        range: &UffdRange,
+        page_idx: u64,
+    ) -> Result<FaultResolution, io::Error>;
+}
+
+/// Source that reads pages from a local snapshot file.
+pub(crate) struct FileUffdMemorySource {
+    file: File,
+    buf: Vec<u8>,
+}
+
+impl FileUffdMemorySource {
+    pub fn new(file: File) -> Self {
+        Self {
+            file,
+            buf: Vec::new(),
+        }
+    }
+}
+
+impl UffdMemorySource for FileUffdMemorySource {
+    fn resolve(
+        &mut self,
+        uffd_fd: BorrowedFd<'_>,
+        range: &UffdRange,
+        page_idx: u64,
+    ) -> Result<FaultResolution, io::Error> {
+        let page_size = range.page_size as usize;
+        let page_addr = range.page_addr(page_idx);
+        let file_pos = range.page_source_offset(page_idx);
+
+        if self.buf.len() < page_size {
+            self.buf.resize(page_size, 0);
+        }
+        self.file
+            .read_exact_at(&mut self.buf[..page_size], file_pos)?;
+
+        match copy(uffd_fd, page_addr, self.buf.as_ptr(), range.page_size) {
+            Ok(()) => Ok(FaultResolution::Served),
+            Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
+                // Installed concurrently. Wake any blocked threads.
+                if let Err(e) = wake(uffd_fd, page_addr, range.page_size) {
+                    log::warn!("UFFDIO_WAKE failed at {page_addr:#x}: {e}");
+                }
+                Ok(FaultResolution::Served)
+            }
+            Err(e) if e.raw_os_error() == Some(libc::EAGAIN) => Ok(FaultResolution::Retry),
+            Err(e) => Err(e),
+        }
+    }
 }
 
 /// Wake threads waiting on a fault in the given range without copying data.

--- a/vmm/src/uffd.rs
+++ b/vmm/src/uffd.rs
@@ -278,15 +278,12 @@ impl UffdMemorySource for FileUffdMemorySource {
 }
 
 /// Memory source that provides pages content over a socket.
-// Wired into the receive-migration path in the next commit.
-#[allow(dead_code)]
 pub(crate) struct SocketUffdMemorySource {
     stream: SocketStream,
     shared_backing: bool,
     buf: Vec<u8>,
 }
 
-#[allow(dead_code)]
 impl SocketUffdMemorySource {
     pub fn new(stream: SocketStream, shared_backing: bool) -> Self {
         Self {

--- a/vmm/src/uffd.rs
+++ b/vmm/src/uffd.rs
@@ -14,11 +14,14 @@
 //! passthrough and shared-memory-backed guest RAM.
 
 use std::fs::{File, OpenOptions};
-use std::io::{self, Error};
-use std::mem;
-use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+use std::io::{self, Error, Read};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::fs::FileExt;
+use std::{fmt, mem};
 
+use vm_migration::protocol::{MemoryRange, Request, Response, Status};
+
+use crate::migration::transport::SocketStream;
 use crate::userfaultfd;
 
 #[repr(C)]
@@ -181,7 +184,7 @@ struct UffdioRange {
 }
 
 /// A guest memory range registered with userfaultfd, plus where its bytes
-/// live in the snapshot file.
+/// live for the data source.
 pub(crate) struct UffdRange {
     pub host_addr: u64,
     pub length: u64,
@@ -272,6 +275,106 @@ impl UffdMemorySource for FileUffdMemorySource {
             Err(e) => Err(e),
         }
     }
+}
+
+/// Memory source that provides pages content over a socket.
+// Wired into the receive-migration path in the next commit.
+#[allow(dead_code)]
+pub(crate) struct SocketUffdMemorySource {
+    stream: SocketStream,
+    shared_backing: bool,
+    buf: Vec<u8>,
+}
+
+#[allow(dead_code)]
+impl SocketUffdMemorySource {
+    pub fn new(stream: SocketStream, shared_backing: bool) -> Self {
+        Self {
+            stream,
+            shared_backing,
+            buf: Vec::new(),
+        }
+    }
+
+    /// Returns the length of the inline page payload the peer is about to send
+    /// (0 when the page was written directly into shared memory).
+    fn request_page(&mut self, gpa: u64, len: u64) -> Result<u64, io::Error> {
+        Request::page_fault()
+            .write_to(&mut self.stream)
+            .map_err(io_other)?;
+        MemoryRange { gpa, length: len }
+            .write_to(&mut self.stream)
+            .map_err(io_other)?;
+
+        let resp = Response::read_from(&mut self.stream).map_err(io_other)?;
+        match resp.status() {
+            Status::Ok => Ok(resp.length()),
+            s => Err(io::Error::other(format!(
+                "peer returned {s:?} for PageFault at gpa={gpa:#x} len={len}",
+            ))),
+        }
+    }
+}
+
+impl UffdMemorySource for SocketUffdMemorySource {
+    fn resolve(
+        &mut self,
+        uffd_fd: BorrowedFd<'_>,
+        range: &UffdRange,
+        page_idx: u64,
+    ) -> Result<FaultResolution, io::Error> {
+        let page_size = range.page_size;
+        let page_addr = range.page_addr(page_idx);
+        let page_gpa = range.page_source_offset(page_idx);
+
+        let resp_len = self.request_page(page_gpa, page_size)?;
+
+        if self.shared_backing {
+            if resp_len != 0 {
+                return Err(io::Error::other(format!(
+                    "shared-backing PageFault response carried {resp_len} unexpected bytes",
+                )));
+            }
+            match wake(uffd_fd, page_addr, page_size) {
+                Ok(()) => Ok(FaultResolution::Served),
+                Err(e) if e.raw_os_error() == Some(libc::EAGAIN) => Ok(FaultResolution::Retry),
+                Err(e) => Err(e),
+            }
+        } else {
+            if resp_len != page_size {
+                return Err(io::Error::other(format!(
+                    "inline PageFault response length {resp_len} != page size {page_size}",
+                )));
+            }
+            let len = page_size as usize;
+            if self.buf.len() < len {
+                self.buf.resize(len, 0);
+            }
+            self.stream.read_exact(&mut self.buf[..len])?;
+            match copy(uffd_fd, page_addr, self.buf.as_ptr(), page_size) {
+                Ok(()) => Ok(FaultResolution::Served),
+                Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
+                    if let Err(e) = wake(uffd_fd, page_addr, page_size) {
+                        log::warn!("UFFDIO_WAKE failed at {page_addr:#x}: {e}");
+                    }
+                    Ok(FaultResolution::Served)
+                }
+                Err(e) if e.raw_os_error() == Some(libc::EAGAIN) => Ok(FaultResolution::Retry),
+                Err(e) => Err(e),
+            }
+        }
+    }
+}
+
+impl Drop for SocketUffdMemorySource {
+    fn drop(&mut self) {
+        // SAFETY: the fd is valid for the duration of this borrow.
+        unsafe { libc::shutdown(self.stream.as_fd().as_raw_fd(), libc::SHUT_RDWR) };
+    }
+}
+
+fn io_other<E: fmt::Display>(e: E) -> io::Error {
+    io::Error::other(e.to_string())
 }
 
 /// Wake threads waiting on a fault in the given range without copying data.


### PR DESCRIPTION
Following up the introduction of the offload daemon through #8403, the
current PR extends the live migration protocol to allow page faults to be
handled from the source (source VM or offload daemon).

In the context of remote live migration, that gives the ability to perform
what's called postcopy, while in the offload daemon case, we call it ondemand
paging. In both cases, the VMM relies on the userfaultfd mechanism.

This new feature brings the offload daemon on parity with the internal
snapshot/restore implementation.