### PR TITLE
ci: Move virtiofsd to docker container

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -14,11 +14,28 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  main:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
       - name: Code checkout
         uses: actions/checkout@v6
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -27,12 +44,52 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to ghcr
+        if: ${{ github.event_name == 'push' }}
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          file: ./resources/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'push' }}
+
+      - name: Export digest
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'push' }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker meta
         id: meta
@@ -44,22 +101,19 @@ jobs:
             type=raw,value=20260522-0
             type=sha
 
-      - name: Build and push
-        if: ${{ github.event_name == 'push' }}
-        uses: docker/build-push-action@v7
+      - name: Login to ghcr
+        uses: docker/login-action@v4
         with:
-          file: ./resources/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build only
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/build-push-action@v7
-        with:
-          file: ./resources/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -41,7 +41,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=raw,value=20260517-0
+            type=raw,value=20260522-0
             type=sha
 
       - name: Build and push

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -112,11 +112,7 @@ RUN export ARCH="$(uname -m)" \
             $RUST_TOOLCHAIN-x86_64-unknown-linux-musl; fi \
     && if [ "$TARGETARCH" = "amd64" ]; then rustup component add rustfmt; fi \
     && if [ "$TARGETARCH" = "amd64" ]; then rustup component add clippy; fi \
-    && cargo install cargo-nextest --locked --version 0.9.128 \
-    && rm -rf "$CARGO_HOME/registry" \
-    && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \
-    && rm -rf "$CARGO_HOME/git" \
-    && ln -s "$CARGO_GIT_REGISTRY_DIR" "$CARGO_HOME/git"
+    && cargo install cargo-nextest --locked --version 0.9.128
 
 # Set the rust environment
 # hadolint ignore=SC2016
@@ -149,6 +145,13 @@ RUN rm /usr/lib/python3.12/EXTERNALLY-MANAGED \
         && cp -rf ./python/spdk/ /usr/local/bin/spdk-nvme \
         && cp -rf ./python /usr/local/bin \
         && cd .. && rm -rf spdk
+
+# Replace the cargo registry and git dirs with symlinks to the host bind-mount
+# paths so that crate downloads are persisted across container invocations.
+RUN rm -rf "$CARGO_HOME/registry" \
+    && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \
+    && rm -rf "$CARGO_HOME/git" \
+    && ln -s "$CARGO_GIT_REGISTRY_DIR" "$CARGO_HOME/git"
 
 # install ethr tool for performance tests
 RUN if [ "$TARGETARCH" = "amd64" ]; then \

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -121,13 +121,13 @@ RUN echo 'source $CARGO_HOME/env' >> "$HOME"/.bashrc \
     && ln -s $CARGO_HOME/env "$HOME"/.cargo/env
 
 # Allow pip to install packages system wide
-# hadolint ignore=DL3003,SC2046
-RUN rm /usr/lib/python3.12/EXTERNALLY-MANAGED \
-        && git clone https://github.com/spdk/spdk \
+# hadolint ignore=DL3003,SC2046,DL3008
+RUN git clone https://github.com/spdk/spdk \
         && cd spdk \
-        && git checkout ef8bcce58f3f02b79c0619a297e4f17e81e62b24 \
+        && git checkout 046ae8c5439e5c45738d5222ee5c85b467e18358 \
         && git submodule update --init \
         && apt-get update \
+        && apt-get install --no-install-recommends -yq python3-jinja2 meson \
         && ./scripts/pkgdep.sh \
         && apt-get clean \
         && ./configure --with-vfio-user \

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -146,6 +146,15 @@ RUN rm /usr/lib/python3.12/EXTERNALLY-MANAGED \
         && cp -rf ./python /usr/local/bin \
         && cd .. && rm -rf spdk
 
+# Build virtiofsd at a pinned commit
+# hadolint ignore=DL3003
+RUN git clone https://gitlab.com/virtio-fs/virtiofsd.git /tmp/virtiofsd \
+        && cd /tmp/virtiofsd \
+        && git checkout 0f5865629dc995a3e9d5a73b4eb45bb91740bccb \
+        && cargo build --release \
+        && cp target/release/virtiofsd /usr/local/bin/virtiofsd \
+        && cd / && rm -rf /tmp/virtiofsd
+
 # Replace the cargo registry and git dirs with symlinks to the host bind-mount
 # paths so that crate downloads are persisted across container invocations.
 RUN rm -rf "$CARGO_HOME/registry" \

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -9,7 +9,7 @@ CLI_NAME="Cloud Hypervisor"
 CTR_IMAGE_TAG="ghcr.io/cloud-hypervisor/cloud-hypervisor"
 
 # Needs to match explicit version in docker-image.yaml workflow
-CTR_IMAGE_VERSION="20260517-0"
+CTR_IMAGE_VERSION="20260522-0"
 : "${CTR_IMAGE:=${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}}"
 
 DOCKER_RUNTIME="docker"

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -9,22 +9,6 @@ source "$(dirname "$0")"/common-aarch64.sh
 
 WORKLOADS_LOCK="$WORKLOADS_DIR/integration_test.lock"
 
-build_virtiofsd() {
-    VIRTIOFSD_DIR="$WORKLOADS_DIR/virtiofsd_build"
-    VIRTIOFSD_REPO="https://gitlab.com/virtio-fs/virtiofsd.git"
-
-    checkout_repo "$VIRTIOFSD_DIR" "$VIRTIOFSD_REPO" main "0f5865629dc995a3e9d5a73b4eb45bb91740bccb"
-
-    if [ ! -f "$VIRTIOFSD_DIR/.built" ]; then
-        pushd "$VIRTIOFSD_DIR" || exit
-        rm -rf target/
-        time RUSTFLAGS="" TARGET_CC="" cargo build --release
-        cp target/release/virtiofsd "$WORKLOADS_DIR/" || exit 1
-        touch .built
-        popd || exit
-    fi
-}
-
 update_workloads() {
     cp scripts/sha1sums-aarch64-common "$WORKLOADS_DIR"
 
@@ -162,8 +146,9 @@ update_workloads() {
     # Prepare linux image (build from source or download pre-built)
     prepare_linux
 
-    # Build virtiofsd
-    build_virtiofsd
+    if [ ! -f "$WORKLOADS_DIR/virtiofsd" ]; then
+        cp /usr/local/bin/virtiofsd "$WORKLOADS_DIR/virtiofsd"
+    fi
 
     BLK_IMAGE="$WORKLOADS_DIR/blk.img"
     MNT_DIR="mount_image"

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -151,17 +151,8 @@ if [ ! -f "$VMLINUX_IMAGE" ]; then
 fi
 
 VIRTIOFSD="$WORKLOADS_DIR/virtiofsd"
-VIRTIOFSD_DIR="virtiofsd_build"
 if [ ! -f "$VIRTIOFSD" ]; then
-    pushd "$WORKLOADS_DIR" || exit
-    git clone "https://gitlab.com/virtio-fs/virtiofsd.git" $VIRTIOFSD_DIR
-    pushd $VIRTIOFSD_DIR || exit
-    git checkout 0f5865629dc995a3e9d5a73b4eb45bb91740bccb
-    time cargo build --release
-    cp target/release/virtiofsd "$VIRTIOFSD" || exit 1
-    popd || exit
-    rm -rf $VIRTIOFSD_DIR
-    popd || exit
+    cp /usr/local/bin/virtiofsd "$VIRTIOFSD"
 fi
 
 BLK_IMAGE="$WORKLOADS_DIR/blk.img"


### PR DESCRIPTION
Rather than downloading and building during the CI run. This works
towards removing the need to have network access inside the running
container.

Signed-off-by: Rob Bradford <rbradford@meta.com>
