### PR TITLE
virtio-devices: Respect PCI CFG cap.length for BAR access

### DIFF
--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -221,6 +221,14 @@ impl VirtioPciCfgCap {
             ..Default::default()
         }
     }
+
+    /// Return the BAR offset and clamped access length for a PCI CFG cap
+    /// indirect BAR access.
+    fn bar_access_params(&self, data_len: usize) -> (u64, usize) {
+        let bar_offset = self.cap.offset.to_native() as u64;
+        let cap_length = self.cap.length.to_native() as usize;
+        (bar_offset, cmp::min(cap_length, data_len))
+    }
 }
 
 #[derive(Clone, Copy, Default)]
@@ -771,10 +779,10 @@ impl VirtioPciDevice {
                     .unwrap();
             }
         } else {
-            let bar_offset: u32 =
-                // SAFETY: we know self.cap_pci_cfg_info.cap.cap.offset is 32bits long.
-                unsafe { std::mem::transmute(self.cap_pci_cfg_info.cap.cap.offset) };
-            self.read_bar(0, bar_offset as u64, data);
+            let (bar_offset, access_len) = self.cap_pci_cfg_info.cap.bar_access_params(data_len);
+            if access_len > 0 {
+                self.read_bar(0, bar_offset, &mut data[..access_len]);
+            }
         }
     }
 
@@ -792,10 +800,12 @@ impl VirtioPciDevice {
             right[..data_len].copy_from_slice(data);
             None
         } else {
-            let bar_offset: u32 =
-                // SAFETY: we know self.cap_pci_cfg_info.cap.cap.offset is 32bits long.
-                unsafe { std::mem::transmute(self.cap_pci_cfg_info.cap.cap.offset) };
-            self.write_bar(0, bar_offset as u64, data)
+            let (bar_offset, access_len) = self.cap_pci_cfg_info.cap.bar_access_params(data_len);
+            if access_len > 0 {
+                self.write_bar(0, bar_offset, &data[..access_len])
+            } else {
+                None
+            }
         }
     }
 

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1501,4 +1501,18 @@ mod unit_tests {
         assert_eq!(bar_offset, 0x14);
         assert_eq!(access_len, 1);
     }
+
+    #[test]
+    fn bar_access_params_uses_data_len_when_smaller() {
+        let mut cap = VirtioPciCfgCap::new();
+        let slice = cap.as_mut_slice();
+
+        // cap.length = 4, but caller provides only 2 bytes
+        slice[6..10].copy_from_slice(&0x00u32.to_le_bytes());
+        slice[10..14].copy_from_slice(&4u32.to_le_bytes());
+
+        let (bar_offset, access_len) = cap.bar_access_params(2);
+        assert_eq!(bar_offset, 0);
+        assert_eq!(access_len, 2);
+    }
 }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1486,4 +1486,19 @@ mod unit_tests {
             (size_of::<VirtioPciCap64>() as u8) + VIRTIO_PCI_CAP_LEN_OFFSET
         );
     }
+
+    #[test]
+    fn bar_access_params_clamps_to_cap_length() {
+        let mut cap = VirtioPciCfgCap::new();
+        let slice = cap.as_mut_slice();
+
+        // Program cap.offset = 0x14, cap.length = 1 (byte access)
+        slice[6..10].copy_from_slice(&0x14u32.to_le_bytes());
+        slice[10..14].copy_from_slice(&1u32.to_le_bytes());
+
+        // PCI config reads always produce 4 bytes, but cap.length = 1
+        let (bar_offset, access_len) = cap.bar_access_params(4);
+        assert_eq!(bar_offset, 0x14);
+        assert_eq!(access_len, 1);
+    }
 }


### PR DESCRIPTION
The VIRTIO_PCI_CAP_PCI_CFG indirect access mechanism was ignoring the cap.length field written by the guest driver. PCI config register reads always produce a 4 byte buffer, so when a driver set cap.length to 1 for a byte wide access to device_status at common config offset 0x14, the VMM passed all 4 bytes to read_bar, dispatching to the dword handler which does not cover that offset.

Use cap.length to determine the actual BAR access width per virtio spec 4.1.4.9.1. Also replace the unsafe transmute with the safe Le32::to_native() conversion.