### PR TITLE
block: qcow: decouple pointer table writes from cursor state

### DIFF
--- a/block/src/formats/qcow/internal/metadata.rs
+++ b/block/src/formats/qcow/internal/metadata.rs
@@ -418,8 +418,7 @@ impl QcowState {
             }))
         } else {
             let cluster_addr = l2_entry_std_cluster_addr(l2_entry);
-            let cluster_size = self.raw_file.cluster_size();
-            if cluster_addr & (cluster_size - 1) != 0 {
+            if !self.is_refcount_addressable_cluster_offset(cluster_addr) {
                 // Fall through to write lock path which sets the corrupt bit
                 return Ok(None);
             }
@@ -476,11 +475,7 @@ impl QcowState {
             })
         } else {
             let cluster_addr = l2_entry_std_cluster_addr(l2_entry);
-            let cluster_size = self.raw_file.cluster_size();
-            if cluster_addr & (cluster_size - 1) != 0 {
-                self.set_corrupt_bit_best_effort();
-                return Err(io::Error::from_raw_os_error(EIO));
-            }
+            self.reject_invalid_cluster_offset(cluster_addr)?;
             let intra_offset = self.raw_file.cluster_offset(address);
             Ok(ClusterReadMapping::Allocated {
                 offset: cluster_addr + intra_offset,
@@ -567,12 +562,8 @@ impl QcowState {
             self.update_cluster_addr(l1_index, l2_index, cluster_addr, &mut set_refcounts)?;
             cluster_addr
         } else {
-            // Already allocated - validate alignment
             let cluster_addr = l2_entry_std_cluster_addr(l2_entry);
-            if cluster_addr & (self.raw_file.cluster_size() - 1) != 0 {
-                self.set_corrupt_bit_best_effort();
-                return Err(io::Error::from_raw_os_error(EIO));
-            }
+            self.reject_invalid_cluster_offset(cluster_addr)?;
             cluster_addr
         };
 
@@ -597,16 +588,26 @@ impl QcowState {
         (address / self.raw_file.cluster_size()) % self.l2_entries
     }
 
+    fn is_refcount_addressable_cluster_offset(&self, cluster_addr: u64) -> bool {
+        cluster_addr & (self.raw_file.cluster_size() - 1) == 0
+            && cluster_addr <= self.refcounts.max_valid_cluster_offset()
+    }
+
+    fn reject_invalid_cluster_offset(&mut self, cluster_addr: u64) -> io::Result<()> {
+        if self.is_refcount_addressable_cluster_offset(cluster_addr) {
+            Ok(())
+        } else {
+            self.set_corrupt_bit_best_effort();
+            Err(io::Error::from_raw_os_error(EIO))
+        }
+    }
+
     // -- Cache and allocation operations requiring exclusive access --
 
     /// Populates the L2 cache for read operations without allocation.
     fn cache_l2_cluster(&mut self, l1_index: usize, l2_addr_disk: u64) -> io::Result<()> {
         if !self.l2_cache.contains_key(l1_index) {
-            let cluster_size = self.raw_file.cluster_size();
-            if l2_addr_disk & (cluster_size - 1) != 0 {
-                self.set_corrupt_bit_best_effort();
-                return Err(io::Error::from_raw_os_error(EIO));
-            }
+            self.reject_invalid_cluster_offset(l2_addr_disk)?;
             let l2_table =
                 VecCache::from_vec(self.raw_file.read_pointer_cluster(l2_addr_disk, None)?);
             let l1_table = &self.l1_table;
@@ -634,11 +635,7 @@ impl QcowState {
                 self.l1_table[l1_index] = new_addr;
                 VecCache::new(self.l2_entries as usize)
             } else {
-                let cluster_size = self.raw_file.cluster_size();
-                if l2_addr_disk & (cluster_size - 1) != 0 {
-                    self.set_corrupt_bit_best_effort();
-                    return Err(io::Error::from_raw_os_error(EIO));
-                }
+                self.reject_invalid_cluster_offset(l2_addr_disk)?;
                 VecCache::from_vec(self.raw_file.read_pointer_cluster(l2_addr_disk, None)?)
             };
             let l1_table = &self.l1_table;
@@ -894,6 +891,7 @@ impl QcowState {
         }
 
         let cluster_addr = l2_entry_std_cluster_addr(l2_entry);
+        self.reject_invalid_cluster_offset(cluster_addr)?;
         let refcount = self
             .refcounts
             .get_cluster_refcount(&mut self.raw_file, cluster_addr)

--- a/block/src/formats/qcow/internal/qcow_raw_file.rs
+++ b/block/src/formats/qcow/internal/qcow_raw_file.rs
@@ -221,50 +221,40 @@ impl QcowRawFile {
         self.read_pointer_table(offset, count, mask)
     }
 
-    /// Internal helper for creating a buffered writer for pointer tables.
-    #[inline]
-    fn setup_pointer_table_writer<T>(
-        &mut self,
-        offset: u64,
-        entries: &impl Iterator<Item = T>,
-    ) -> io::Result<BufWriter<RawFile>> {
-        self.file.seek(SeekFrom::Start(offset))?;
-        let my_file = self.file.try_clone()?;
-        let capacity = entries.size_hint().0 * size_of::<u64>();
-        Ok(BufWriter::with_capacity(capacity, my_file))
-    }
-
     /// Writes a pointer table to `offset` in the file.
     /// Entries are computed on-the-fly by the callback.
+    ///
+    /// The callback may perform metadata I/O on this `QcowRawFile`, so all
+    /// entries are materialized before seeking to the final write offset.
     pub fn write_pointer_table<'a, T: Copy + 'a>(
         &mut self,
         offset: u64,
         entries: impl Iterator<Item = &'a T>,
         mut f: impl FnMut(&mut QcowRawFile, T) -> io::Result<u64>,
     ) -> io::Result<()> {
-        let mut buffer = self.setup_pointer_table_writer(offset, &entries)?;
-
+        let mut buffer = Vec::with_capacity(entries.size_hint().0 * size_of::<u64>());
         for addr in entries {
             let entry = f(self, *addr)?;
-            u64::write_be(&mut buffer, entry)?;
+            buffer.extend_from_slice(&entry.to_be_bytes());
         }
-        buffer.flush()?;
-        Ok(())
+        self.file.seek(SeekFrom::Start(offset))?;
+        self.file.write_all(&buffer)
     }
 
     /// Writes a pointer table directly without transforming values.
+    ///
+    /// Uses the same materialize-then-write path as `write_pointer_table`.
     pub fn write_pointer_table_direct<'a>(
         &mut self,
         offset: u64,
         entries: impl Iterator<Item = &'a u64>,
     ) -> io::Result<()> {
-        let mut buffer = self.setup_pointer_table_writer(offset, &entries)?;
-
+        let mut buffer = Vec::with_capacity(entries.size_hint().0 * size_of::<u64>());
         for &entry in entries {
-            u64::write_be(&mut buffer, entry)?;
+            buffer.extend_from_slice(&entry.to_be_bytes());
         }
-        buffer.flush()?;
-        Ok(())
+        self.file.seek(SeekFrom::Start(offset))?;
+        self.file.write_all(&buffer)
     }
 
     /// Read a refcount block from the file and returns a Vec containing the block.
@@ -365,5 +355,94 @@ impl AsRawFd for QcowRawFile {
 impl AsFd for QcowRawFile {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.file.as_fd()
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::io::{Read, Seek, SeekFrom};
+
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+
+    fn be_bytes(entries: &[u64]) -> Vec<u8> {
+        let mut v = Vec::with_capacity(std::mem::size_of_val(entries));
+        for e in entries {
+            v.extend_from_slice(&e.to_be_bytes());
+        }
+        v
+    }
+
+    fn find_all(haystack: &[u8], needle: &[u8]) -> Vec<usize> {
+        haystack
+            .windows(needle.len())
+            .enumerate()
+            .filter(|(_, w)| *w == needle)
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    const CLUSTER_SIZE: u64 = 0x10000; // 64 KiB
+    const TARGET_OFFSET: u64 = 0x1000; // where the table must be written
+    const FAR_OFFSET: u64 = 0x9000; // where the callback reads (refcount block)
+    const FILE_LEN: u64 = 0x40000; // 256 KiB filler so all offsets are valid
+
+    fn make_qcow_raw() -> (TempFile, QcowRawFile) {
+        let temp_file = TempFile::new().unwrap();
+        temp_file.as_file().set_len(FILE_LEN).unwrap();
+
+        let file = temp_file.as_file().try_clone().unwrap();
+        let raw = RawFile::new(file, false);
+        let qcow_raw = QcowRawFile::from(raw, CLUSTER_SIZE, 16).expect("QcowRawFile::from");
+        (temp_file, qcow_raw)
+    }
+
+    #[test]
+    fn write_pointer_table_lands_at_offset_despite_callback_seek() {
+        let (temp_file, mut qcow) = make_qcow_raw();
+        let entries: Vec<u64> = vec![0x1111_2222_3333_4444u64; 8]; // 64 bytes
+
+        qcow.write_pointer_table(TARGET_OFFSET, entries.iter(), |q, addr| {
+            let _ = q.read_refcount_block(FAR_OFFSET)?;
+            Ok(addr)
+        })
+        .expect("write_pointer_table");
+
+        let expected = be_bytes(&entries);
+        let mut verify = temp_file.as_file().try_clone().unwrap();
+        let mut whole = Vec::new();
+        verify.read_to_end(&mut whole).unwrap();
+        let found_at = find_all(&whole, &expected);
+
+        let mut at_target = vec![0u8; expected.len()];
+        verify.seek(SeekFrom::Start(TARGET_OFFSET)).unwrap();
+        verify.read_exact(&mut at_target).unwrap();
+
+        assert_eq!(
+            at_target, expected,
+            "pointer table did NOT land at TARGET_OFFSET {TARGET_OFFSET:#x}; \
+             found matching bytes at {found_at:x?}"
+        );
+    }
+
+    #[test]
+    fn write_pointer_table_direct_lands_at_offset() {
+        let (temp_file, mut qcow) = make_qcow_raw();
+        let entries: Vec<u64> = vec![0xAAAA_BBBB_CCCC_DDDDu64; 8];
+
+        qcow.write_pointer_table_direct(TARGET_OFFSET, entries.iter())
+            .expect("write_pointer_table_direct");
+
+        let expected = be_bytes(&entries);
+        let mut verify = temp_file.as_file().try_clone().unwrap();
+        let mut at_target = vec![0u8; expected.len()];
+        verify.seek(SeekFrom::Start(TARGET_OFFSET)).unwrap();
+        verify.read_exact(&mut at_target).unwrap();
+
+        assert_eq!(
+            at_target, expected,
+            "write_pointer_table_direct did not land at {TARGET_OFFSET:#x}"
+        );
     }
 }

--- a/block/src/formats/qcow/worker/sync.rs
+++ b/block/src/formats/qcow/worker/sync.rs
@@ -359,8 +359,10 @@ mod unit_tests {
 
     const TEST_L1_L2_ADDR_MASK: u64 = 0x00ff_ffff_ffff_fe00;
     const TEST_HEADER_L1_TABLE_OFFSET: u64 = 40;
+    const TEST_CLUSTER_USED_FLAG: u64 = 1 << 63;
     const TEST_COMPRESSED_FLAG: u64 = 1 << 62;
     const TEST_ZERO_FLAG: u64 = 1;
+    const TEST_OUT_OF_BOUNDS_CLUSTER: u64 = 0x0000_0001_4000_0000;
 
     fn read_be_u64_at(file: &mut File, offset: u64) -> u64 {
         let mut bytes = [0u8; 8];
@@ -390,9 +392,21 @@ mod unit_tests {
         file.sync_all().unwrap();
     }
 
+    fn set_first_l2_entry(file: &mut File, l2_entry: u64) {
+        let l2_entry_offset = first_l2_entry_offset(file);
+        write_be_u64_at(file, l2_entry_offset, l2_entry);
+        file.sync_all().unwrap();
+    }
+
     fn first_l2_entry(file: &mut File) -> u64 {
         let l2_entry_offset = first_l2_entry_offset(file);
         read_be_u64_at(file, l2_entry_offset)
+    }
+
+    fn qcow_header_is_corrupt(file: &File) -> bool {
+        let mut raw = RawFile::new(file.try_clone().unwrap(), false);
+        raw.seek(SeekFrom::Start(0)).unwrap();
+        QcowHeader::new(&mut raw).unwrap().is_corrupt()
     }
 
     fn create_disk_with_data(
@@ -493,6 +507,59 @@ mod unit_tests {
         let (user_data, result) = next_completion(async_io.as_mut());
         assert_eq!(user_data, 1);
         assert_eq!(result as usize, data.len());
+    }
+
+    #[test]
+    fn test_qcow_sync_rejects_out_of_bounds_allocated_l2_entry_on_read() {
+        let data = vec![0x5a; 4096];
+        let (temp_file, disk) = create_disk_with_data(100 * 1024 * 1024, &data, 0, true, false);
+        let mut file = temp_file.as_file().try_clone().unwrap();
+
+        set_first_l2_entry(
+            &mut file,
+            TEST_CLUSTER_USED_FLAG | TEST_OUT_OF_BOUNDS_CLUSTER,
+        );
+
+        let mut async_io = disk.create_async_io(1).unwrap();
+        let err = async_io
+            .read_to_vec(0, OwnedIoBuffer::from_vec(vec![0u8; 512]), 1)
+            .expect_err("out-of-bounds allocated L2 entry must fail");
+
+        match err {
+            AsyncIoError::ReadVectored(e) => assert_eq!(e.raw_os_error(), Some(libc::EIO)),
+            other => panic!("unexpected error: {other:?}"),
+        }
+        assert!(
+            qcow_header_is_corrupt(&file),
+            "out-of-bounds allocated L2 entry should set the corrupt bit"
+        );
+    }
+
+    #[test]
+    fn test_qcow_sync_rejects_out_of_bounds_allocated_l2_entry_on_write() {
+        let data = vec![0x5a; 4096];
+        let (temp_file, disk) = create_disk_with_data(100 * 1024 * 1024, &data, 0, true, false);
+        let mut file = temp_file.as_file().try_clone().unwrap();
+
+        set_first_l2_entry(
+            &mut file,
+            TEST_CLUSTER_USED_FLAG | TEST_OUT_OF_BOUNDS_CLUSTER,
+        );
+
+        let mut async_io = disk.create_async_io(1).unwrap();
+        let overwrite = vec![0x11u8; 512];
+        let err = async_io
+            .write_from_vec(0, OwnedIoBuffer::from_vec(overwrite), 1)
+            .expect_err("out-of-bounds allocated L2 entry must fail");
+
+        match err {
+            AsyncIoError::WriteVectored(e) => assert_eq!(e.raw_os_error(), Some(libc::EIO)),
+            other => panic!("unexpected error: {other:?}"),
+        }
+        assert!(
+            qcow_header_is_corrupt(&file),
+            "out-of-bounds allocated L2 entry should set the corrupt bit"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Materialize qcow pointer-table entries before seeking and writing the final table, so callback metadata I/O cannot influence the destination through kernel cursor state.
- Apply the same materialize-then-write shape to direct pointer-table writes.
- Centralize qcow cluster-offset validation for L1-referenced L2 tables and standard L2 entries, rejecting aligned-but-out-of-range offsets before metadata/data I/O.
- Add QcowDisk/QcowSync regression tests for out-of-range allocated L2 entries on read and write.

## Rationale

The pointer-table change removes a latent dependency on cloned-fd cursor state. It was motivated by corruption investigation, but the commit does not rely on proving that a cursor-moving callback is reachable in the current synchronous CH path. The mechanical behavior is now explicit: callback work finishes before the final seek and write.

The bounds check is defensive for corrupted metadata: cluster offsets can be aligned while still outside the range addressable by the image refcount table. Using one helper for the read, write, cache-population, and deallocation paths keeps the rejection behavior consistent and marks the image corrupt before using the bad offset.

Implementation and review were assisted by Codex:GPT-5; I reviewed and understand the resulting changes.

## Validation

- `git diff --check origin/main..HEAD`
- `uvx --from gitlint gitlint --commits origin/main..HEAD`
- `cargo fmt --check`
- `scripts/dev_cli.sh shell -- cargo check -p block --tests --examples`
- `scripts/dev_cli.sh shell -- cargo test -p block write_pointer_table -- --nocapture`
- `scripts/dev_cli.sh shell -- cargo test -p block test_qcow_sync_rejects_out_of_bounds_allocated_l2_entry -- --nocapture`
