### PR TITLE
vmm: openapi: Fix integer schema formats

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1144,7 +1144,8 @@ components:
         queue_size:
           type: array
           items:
-            type: uint16
+            type: integer
+            format: uint16
         pci_segment:
           type: integer
           format: int16
@@ -1152,7 +1153,8 @@ components:
           type: integer
           format: uint8
         virtio_id:
-          type: uint32
+          type: integer
+          format: uint32
 
     PmemConfig:
       required:


### PR DESCRIPTION
Running oapi-codegen against the current schema is failing on the wrong formatting of the types for the queue_size and virtio_id fields. This PR resolves the issue.