### PR TITLE
[RFC] vmm: cap default max_phys_bits at 43 bits

### DIFF
--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -980,7 +980,7 @@ mod unit_tests {
                 max_vcpus: 1,
                 topology: None,
                 kvm_hyperv: false,
-                max_phys_bits: 46,
+                max_phys_bits: 43,
                 affinity: None,
                 features: CpuFeatures::default(),
                 nested: true,

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -57,10 +57,13 @@ pub struct CpuTopology {
     pub packages: u16,
 }
 
-// When booting with PVH boot the maximum physical addressable size
-// is a 46 bit address space even when the host supports with 5-level
-// paging.
-pub const DEFAULT_MAX_PHYS_BITS: u8 = 46;
+// Default guest physical address width in bits.
+//
+// PVH boot uses 4-level paging, which supports up to a 48-bit physical
+// address space. However, a KASLR-enabled guest kernel only accepts
+// addresses up to ~11 TB (~43 bits). Combined with Cloud Hypervisor's
+// top-down memory allocation model, 43 bits is the effective maximum.
+pub const DEFAULT_MAX_PHYS_BITS: u8 = 43;
 
 pub fn default_cpuconfig_max_phys_bits() -> u8 {
     DEFAULT_MAX_PHYS_BITS


### PR DESCRIPTION
The previous comment claimed 46 bits was the PVH limit even with 5-level paging on the host, and DEFAULT_MAX_PHYS_BITS was set to 46. In practice, PVH boot with 4-level paging which supports a 48-bit physical address space, but a KASLR-enabled guest kernel only accepts addresses up to ~11 TB (~43 bits). Combined with Cloud Hypervisor's top-down memory allocation model, 43 bits is the effective ceiling.

Lower DEFAULT_MAX_PHYS_BITS to 43 and rewrite the comment to capture the real reasoning.

Fixes: https://github.com/cloud-hypervisor/cloud-hypervisor/issues/8191

Assisted-by: Claude:Opus-4.7