### PR TITLE
scripts: Download assets before entering container

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -583,7 +583,6 @@ cmd_tests() {
             "${common_env_args[@]}" \
             --env PARALLEL_INTEGRATION_TESTS_NUM="${PARALLEL_INTEGRATION_TESTS_NUM:-}" \
             --env LLVM_PROFILE_FILE="$LLVM_PROFILE_FILE" \
-            --env MIGRATABLE_VERSION="$MIGRATABLE_VERSION" \
             "$CTR_IMAGE" \
             dbus-run-session ./scripts/run_integration_tests_"$(uname -m)".sh "$@" || fix_dir_perms $? || exit $?
     fi

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -287,6 +287,9 @@ cmd_help() {
     echo "        Run the development container into an interactive, privileged BASH shell."
     echo "        --volumes             Hash separated volumes to be exported. Example --volumes /mnt:/mnt#/myvol:/myvol"
     echo ""
+    echo "    fetch-workloads [--test TEST] [--verify-only]"
+    echo "        Download workload assets needed for integration tests."
+    echo ""
     echo "    help"
     echo "        Display this help message."
     echo ""
@@ -477,6 +480,12 @@ cmd_tests() {
     ensure_latest_ctr
 
     process_volumes_args
+
+    # Fetch workload assets on the host before launching the container.
+    say "Fetching workloads..."
+    python3 "$CLH_SCRIPTS_DIR/fetch_workloads.py" \
+        --workloads-dir "$CLH_INTEGRATION_WORKLOADS" || die "Failed to fetch workloads"
+
     target="$(uname -m)-unknown-linux-${libc}"
 
     rustflags="$RUSTFLAGS"
@@ -660,6 +669,12 @@ build_container() {
         -f "$CLH_CTR_BUILD_DIR/Dockerfile" \
         --build-arg TARGETARCH="$TARGETARCH" \
         "$CLH_CTR_BUILD_DIR"
+}
+
+cmd_fetch-workloads() {
+    ensure_build_dir
+    python3 "$CLH_SCRIPTS_DIR/fetch_workloads.py" \
+        --workloads-dir "$CLH_INTEGRATION_WORKLOADS" "$@"
 }
 
 cmd_build-container() {

--- a/scripts/fetch_workloads.py
+++ b/scripts/fetch_workloads.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+#
+# Copyright © 2025 Meta Platforms, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Download workload assets for Cloud Hypervisor integration tests.
+
+Reads scripts/test_assets.yaml, downloads missing files, and verifies
+SHA-1 checksums.  Uses only the Python 3 standard library.
+
+Usage:
+    fetch_workloads.py [--arch ARCH] [--test TEST] [--workloads-dir DIR]
+                       [--verify-only] [--asset-file FILE] [-j JOBS]
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import os
+import platform
+import re
+import sys
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+_print_lock = threading.Lock()
+
+
+def parse_yaml(path: Path) -> list[dict]:
+    """Minimal parser for the flat asset list in test_assets.yaml.
+
+    Handles only the subset of YAML used by this project: a top-level
+    ``assets:`` key containing a list of mappings with scalar and
+    flow-sequence values.  Does not handle nested structures, multi-line
+    strings, or anchors.
+    """
+    assets: list[dict] = []
+    current: dict | None = None
+
+    with open(path) as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if stripped == "assets:":
+                continue
+            if stripped.startswith("- "):
+                if current is not None:
+                    assets.append(current)
+                current = {}
+                stripped = stripped[2:].strip()
+                if not stripped:
+                    continue
+
+            if current is None:
+                continue
+
+            m = re.match(r"([a-zA-Z_]\w*):\s*(.*)", stripped)
+            if not m:
+                continue
+            key, value = m.group(1), m.group(2)
+
+            # Flow-sequence: [a, b, c]
+            seq = re.match(r"\[([^\]]*)\]", value)
+            if seq:
+                items = [s.strip() for s in seq.group(1).split(",") if s.strip()]
+                current[key] = items
+            else:
+                current[key] = value if value else None
+
+    if current is not None:
+        assets.append(current)
+
+    return assets
+
+
+def sha1_file(path: Path) -> str:
+    h = hashlib.sha1()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(1 << 20)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _fmt_size(n: int) -> str:
+    size = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if size < 1024:
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TiB"
+
+
+def _log(msg: str, **kwargs) -> None:
+    with _print_lock:
+        print(msg, **kwargs)
+
+
+def _log_err(msg: str) -> None:
+    with _print_lock:
+        print(msg, file=sys.stderr)
+
+
+def download(url: str, dest: Path, auth_token: str | None = None,
+             retries: int = 3, delay: float = 5.0,
+             show_progress: bool = True) -> bool:
+    """Download *url* to *dest* with retries.  Returns True on success."""
+    tmp = dest.parent / (dest.name + ".part")
+    headers = {}
+    host = urllib.parse.urlparse(url).hostname or ""
+    if auth_token and (host == "github.com" or host.endswith(".github.com")):
+        headers["Authorization"] = f"token {auth_token}"
+
+    for attempt in range(1, retries + 1):
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            _log(f"  Downloading {url} (attempt {attempt}/{retries})")
+            t0 = time.monotonic()
+            with urllib.request.urlopen(req, timeout=300) as resp, \
+                 open(tmp, "wb") as out:
+                total = resp.headers.get("Content-Length")
+                total = int(total) if total else None
+                downloaded = 0
+                while True:
+                    chunk = resp.read(1 << 20)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+                    downloaded += len(chunk)
+                    if show_progress:
+                        with _print_lock:
+                            if total:
+                                pct = downloaded * 100 // total
+                                print(f"\r  {_fmt_size(downloaded)} / "
+                                      f"{_fmt_size(total)}  ({pct}%)",
+                                      end="", flush=True)
+                            else:
+                                print(f"\r  {_fmt_size(downloaded)}",
+                                      end="", flush=True)
+                elapsed = time.monotonic() - t0
+                if show_progress:
+                    with _print_lock:
+                        print()
+                _log(f"  {_fmt_size(downloaded)} in {elapsed:.1f}s")
+        except (urllib.error.URLError, OSError, TimeoutError) as e:
+            _log_err(f"  Attempt {attempt} failed: {e}")
+            tmp.unlink(missing_ok=True)
+            if attempt < retries:
+                time.sleep(delay)
+            continue
+
+        tmp.rename(dest)
+        return True
+
+    return False
+
+
+def process_asset(asset: dict, workloads: Path, auth_token: str | None,
+                  verify_only: bool, show_progress: bool) -> bool:
+    """Process a single asset.  Returns True on success."""
+    filename = asset["filename"]
+    if ".." in Path(filename).parts:
+        _log(f"SKIPPED  {filename}: path traversal in filename")
+        return False
+    url = asset.get("url")
+    expected_sha1 = asset.get("sha1")
+    dest = workloads / filename
+
+    if dest.exists():
+        if expected_sha1:
+            actual = sha1_file(dest)
+            if actual != expected_sha1:
+                _log(f"MISMATCH {filename}: expected {expected_sha1}, got {actual}")
+                if verify_only:
+                    return False
+                dest.unlink()
+            else:
+                _log(f"OK       {filename}")
+                return True
+        else:
+            _log(f"OK       {filename} (no checksum)")
+            return True
+
+    if verify_only:
+        _log(f"MISSING  {filename}")
+        return False
+
+    if not url:
+        _log(f"MISSING  {filename} (no URL to download from)")
+        return False
+
+    if not download(url, dest, auth_token, show_progress=show_progress):
+        _log(f"FAILED   {filename}")
+        return False
+
+    if expected_sha1:
+        actual = sha1_file(dest)
+        if actual != expected_sha1:
+            _log(f"CORRUPT  {filename}: expected {expected_sha1}, got {actual}")
+            dest.unlink()
+            return False
+
+    if (asset.get("executable") or "").lower() == "true":
+        dest.chmod(0o755)
+
+    _log(f"FETCHED  {filename}")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arch", default=platform.machine(),
+                        help="Target architecture (default: host arch)")
+    parser.add_argument("--test", dest="test_filter", default=None,
+                        help="Only fetch assets for this test group")
+    parser.add_argument("--workloads-dir", default=None,
+                        help="Directory to store assets (default: ~/workloads)")
+    parser.add_argument("--verify-only", action="store_true",
+                        help="Check existing files without downloading")
+    parser.add_argument("--asset-file", default=None,
+                        help="Path to test_assets.yaml (default: alongside this script)")
+    parser.add_argument("-j", "--jobs", type=int, default=os.cpu_count() or 1,
+                        help="Parallel downloads (default: number of CPUs, use 1 to disable)")
+    args = parser.parse_args()
+
+    script_dir = Path(__file__).resolve().parent
+    asset_file = Path(args.asset_file) if args.asset_file else script_dir / "test_assets.yaml"
+
+    if not asset_file.exists():
+        print(f"Error: asset file not found: {asset_file}", file=sys.stderr)
+        return 1
+
+    if args.workloads_dir:
+        workloads = Path(args.workloads_dir)
+    else:
+        workloads = Path.home() / "workloads"
+
+    workloads.mkdir(parents=True, exist_ok=True)
+
+    assets = parse_yaml(asset_file)
+    auth_token = os.environ.get("AUTH_DOWNLOAD_TOKEN")
+
+    filtered = []
+    for asset in assets:
+        arch_list = asset.get("arch") or []
+        if arch_list and args.arch not in arch_list:
+            continue
+        if args.test_filter:
+            test_list = asset.get("test") or []
+            if test_list and args.test_filter not in test_list:
+                continue
+        filtered.append(asset)
+
+    if not filtered:
+        print(f"No assets match arch={args.arch}"
+              + (f" test={args.test_filter}" if args.test_filter else ""))
+        return 0
+
+    jobs = max(1, args.jobs)
+    show_progress = jobs == 1
+
+    errors = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
+        futures = {
+            pool.submit(process_asset, asset, workloads, auth_token,
+                        args.verify_only, show_progress): asset
+            for asset in filtered
+        }
+        for f in concurrent.futures.as_completed(futures):
+            try:
+                if not f.result():
+                    errors += 1
+            except Exception as e:
+                asset = futures[f]
+                _log_err(f"EXCEPTION {asset.get('filename', '?')}: {e}")
+                errors += 1
+
+    if errors:
+        print(f"\n{errors} error(s)")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -10,24 +10,25 @@ source "$(dirname "$0")"/common-aarch64.sh
 WORKLOADS_LOCK="$WORKLOADS_DIR/integration_test.lock"
 
 update_workloads() {
-    cp scripts/sha1sums-aarch64-common "$WORKLOADS_DIR"
-
     JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.raw"
-    JAMMY_OS_RAW_IMAGE_DOWNLOAD_URL="https://ch-images.azureedge.net/$JAMMY_OS_RAW_IMAGE_NAME"
     JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
-    if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
-        pushd "$WORKLOADS_DIR" || exit
-        time wget --quiet $JAMMY_OS_RAW_IMAGE_DOWNLOAD_URL || exit 1
-        popd || exit
-    fi
 
     JAMMY_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.qcow2"
-    JAMMY_OS_QCOW2_IMAGE_UNCOMPRESSED_DOWNLOAD_URL="https://ch-images.azureedge.net/$JAMMY_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME"
     JAMMY_OS_QCOW2_UNCOMPRESSED_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW2_IMAGE_UNCOMPRESSED_NAME"
-    if [ ! -f "$JAMMY_OS_QCOW2_UNCOMPRESSED_IMAGE" ]; then
-        pushd "$WORKLOADS_DIR" || exit
-        time wget --quiet $JAMMY_OS_QCOW2_IMAGE_UNCOMPRESSED_DOWNLOAD_URL || exit 1
-        popd || exit
+
+    for required in "$JAMMY_OS_RAW_IMAGE" "$JAMMY_OS_QCOW2_UNCOMPRESSED_IMAGE" \
+        "$WORKLOADS_DIR/CLOUDHV_EFI.fd" \
+        "$WORKLOADS_DIR/cloud-hypervisor-static-aarch64" \
+        "$WORKLOADS_DIR/alpine-minirootfs-aarch64.tar.gz" \
+        "$WORKLOADS_DIR/Image-arm64"; do
+        if [ ! -f "$required" ]; then
+            echo "Missing: $required — run: python3 scripts/fetch_workloads.py --test integration"
+            exit 1
+        fi
+    done
+
+    if [ ! -f "$WORKLOADS_DIR/virtiofsd" ]; then
+        cp /usr/local/bin/virtiofsd "$WORKLOADS_DIR/virtiofsd"
     fi
 
     JAMMY_OS_QCOW2_ZLIB_FILE_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0-zlib.qcow2"
@@ -76,13 +77,7 @@ update_workloads() {
         popd || exit
     fi
 
-    ALPINE_MINIROOTFS_URL="http://dl-cdn.alpinelinux.org/alpine/v3.11/releases/aarch64/alpine-minirootfs-3.11.3-aarch64.tar.gz"
     ALPINE_MINIROOTFS_TARBALL="$WORKLOADS_DIR/alpine-minirootfs-aarch64.tar.gz"
-    if [ ! -f "$ALPINE_MINIROOTFS_TARBALL" ]; then
-        pushd "$WORKLOADS_DIR" || exit
-        time wget --quiet $ALPINE_MINIROOTFS_URL -O "$ALPINE_MINIROOTFS_TARBALL" || exit 1
-        popd || exit
-    fi
 
     ALPINE_INITRAMFS_IMAGE="$WORKLOADS_DIR/alpine_initramfs.img"
     if [ ! -f "$ALPINE_INITRAMFS_IMAGE" ]; then
@@ -100,54 +95,6 @@ update_workloads() {
         find . -print0 |
             cpio --null --create --verbose --owner root:root --format=newc >"$ALPINE_INITRAMFS_IMAGE"
         popd || exit
-    fi
-
-    # Download aarch64 ovmf
-    if [ ! -f "$WORKLOADS_DIR/CLOUDHV_EFI.fd" ]; then
-        download_aarch64_ovmf
-    fi
-
-    pushd "$WORKLOADS_DIR" || exit
-
-    # Skip checksum verification for custom-provided workloads
-    if [ -n "$CH_CUSTOM_OVMF" ]; then
-        if ! grep -v "CLOUDHV_EFI.fd" sha1sums-aarch64-common | sha1sum --check; then
-            echo "sha1sum validation of images failed, remove invalid images to fix the issue."
-            exit 1
-        fi
-    else
-        if ! sha1sum sha1sums-aarch64-common --check; then
-            echo "sha1sum validation of images failed, remove invalid images to fix the issue."
-            exit 1
-        fi
-    fi
-    popd || exit
-
-    # Download Cloud Hypervisor binary from its last stable release
-    CH_RELEASE_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${migratable_version}/cloud-hypervisor-static-aarch64"
-    CH_RELEASE_NAME="cloud-hypervisor-static-aarch64"
-    pushd "$WORKLOADS_DIR" || exit
-    # Repeat a few times to workaround a random wget failure
-    WGET_RETRY_MAX=10
-    wget_retry=0
-
-    until [ "$wget_retry" -ge "$WGET_RETRY_MAX" ]; do
-        time wget $CH_RELEASE_URL -O "$CH_RELEASE_NAME" && break
-        wget_retry=$((wget_retry + 1))
-    done
-
-    if [ $wget_retry -ge "$WGET_RETRY_MAX" ]; then
-        exit 1
-    else
-        chmod +x $CH_RELEASE_NAME
-    fi
-    popd || exit
-
-    # Prepare linux image (build from source or download pre-built)
-    prepare_linux
-
-    if [ ! -f "$WORKLOADS_DIR/virtiofsd" ]; then
-        cp /usr/local/bin/virtiofsd "$WORKLOADS_DIR/virtiofsd"
     fi
 
     BLK_IMAGE="$WORKLOADS_DIR/blk.img"
@@ -174,21 +121,10 @@ update_workloads() {
 
 process_common_args "$@"
 
-migratable_version=v39.0
 test_features=""
 
 if [ "$hypervisor" = "mshv" ]; then
     test_features="--features mshv"
-fi
-
-# if migratable version is set to override the default
-if [ -n "${MIGRATABLE_VERSION}" ]; then
-    # validate the version if matched with vxx.0
-    if ! [[ "${MIGRATABLE_VERSION}" =~ ^v[0-9]{2,}\.[0-9]$ ]]; then
-        echo "MIGRATABLE_VERSION should be in format vxx.0, e.g. v47.0"
-        exit 1
-    fi
-    migratable_version=${MIGRATABLE_VERSION}
 fi
 
 # lock the workloads folder to avoid parallel updating by different containers

--- a/scripts/run_integration_tests_cvm.sh
+++ b/scripts/run_integration_tests_cvm.sh
@@ -15,15 +15,20 @@ process_common_args "$@"
 test_features="--features mshv,igvm,sev_snp"
 build_features="mshv,igvm,sev_snp"
 
-download_x86_guest_images
-cp scripts/sha1sums-x86_64-common "$WORKLOADS_DIR"
-
-pushd "$WORKLOADS_DIR" || exit
-if ! sha1sum sha1sums-x86_64-common --check; then
-    echo "sha1sum validation of images failed, remove invalid images to fix the issue."
+JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
+JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"
+if [ ! -f "$JAMMY_OS_IMAGE" ]; then
+    echo "Missing: $JAMMY_OS_IMAGE — run: python3 scripts/fetch_workloads.py --test cvm"
     exit 1
 fi
-popd || exit
+
+JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
+JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
+if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
+    pushd "$WORKLOADS_DIR" || exit
+    time qemu-img convert -p -f qcow2 -O raw $JAMMY_OS_IMAGE_NAME $JAMMY_OS_RAW_IMAGE_NAME || exit 1
+    popd || exit
+fi
 
 cargo build --features $build_features --all --release --target "$BUILD_TARGET"
 

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -18,15 +18,11 @@ if [ "$hypervisor" = "mshv" ]; then
     test_features="--features mshv"
 fi
 
-cp scripts/sha1sums-x86_64* "$WORKLOADS_DIR"
-
 JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
-JAMMY_OS_IMAGE_URL="https://ch-images.azureedge.net/$JAMMY_OS_IMAGE_NAME"
 JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"
 if [ ! -f "$JAMMY_OS_IMAGE" ]; then
-    pushd "$WORKLOADS_DIR" || exit
-    time wget --quiet $JAMMY_OS_IMAGE_URL || exit 1
-    popd || exit
+    echo "Missing: $JAMMY_OS_IMAGE — run: python3 scripts/fetch_workloads.py --test rate-limiter"
+    exit 1
 fi
 
 JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
@@ -37,15 +33,11 @@ if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
     popd || exit
 fi
 
-pushd "$WORKLOADS_DIR" || exit
-if ! grep jammy sha1sums-x86_64-common | sha1sum --check; then
-    echo "sha1sum validation of images failed, remove invalid images to fix the issue."
+VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux-x86_64"
+if [ ! -f "$VMLINUX_IMAGE" ]; then
+    echo "Missing: $VMLINUX_IMAGE — run: python3 scripts/fetch_workloads.py --test rate-limiter"
     exit 1
 fi
-popd || exit
-
-# Prepare linux image (build from source or download pre-built)
-prepare_linux
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "x86_64-unknown-linux-musl" ]]; then

--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -17,7 +17,9 @@ process_common_args "$@"
 WORKLOADS_DIR="$HOME/workloads"
 
 if [ ! -f "$WORKLOADS_DIR/hypervisor-fw" ]; then
-    download_hypervisor_fw
+    echo "Missing workload asset: $WORKLOADS_DIR/hypervisor-fw"
+    echo "Run: python3 scripts/fetch_workloads.py --test vfio"
+    exit 1
 fi
 
 CFLAGS=""

--- a/scripts/run_integration_tests_windows_aarch64.sh
+++ b/scripts/run_integration_tests_windows_aarch64.sh
@@ -18,10 +18,11 @@ fi
 WIN_IMAGE_BASENAME="windows-11-iot-enterprise-aarch64.raw"
 WIN_IMAGE_FILE="$WORKLOADS_DIR/$WIN_IMAGE_BASENAME"
 
-# Download aarch64 OVMF
 OVMF_FW="$WORKLOADS_DIR/CLOUDHV_EFI.fd"
 if [ ! -f "$OVMF_FW" ]; then
-    download_aarch64_ovmf
+    echo "Missing workload asset: $OVMF_FW"
+    echo "Run: python3 scripts/fetch_workloads.py --test windows"
+    exit 1
 fi
 
 # Check if the images are present

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -18,9 +18,10 @@ WIN_IMAGE_FILE="/root/workloads/windows-server-2025-amd64-1.raw"
 WORKLOADS_DIR="/root/workloads"
 OVMF_FW="$WORKLOADS_DIR/CLOUDHV.fd"
 
-# Download amd64 ovmf
 if [ ! -f "$OVMF_FW" ]; then
-    download_amd64_ovmf
+    echo "Missing workload asset: $OVMF_FW"
+    echo "Run: python3 scripts/fetch_workloads.py --test windows"
+    exit 1
 fi
 
 CFLAGS=""

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -12,7 +12,6 @@ mkdir -p "$WORKLOADS_DIR/junit"
 
 process_common_args "$@"
 
-migratable_version=v39.0
 # For now these values are default for kvm
 test_features=""
 
@@ -21,26 +20,27 @@ if [ "$hypervisor" = "mshv" ]; then
 fi
 
 # if migratable version is set to override the default
-if [ -n "${MIGRATABLE_VERSION}" ]; then
-    # validate the version if matched with vxx.0
-    if ! [[ "${MIGRATABLE_VERSION}" =~ ^v[0-9]{2,}\.[0-9]$ ]]; then
-        echo "MIGRATABLE_VERSION should be in format vxx.0, e.g. v47.0"
+FW="$WORKLOADS_DIR/hypervisor-fw"
+JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
+JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"
+JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
+JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
+
+for required in "$FW" "$WORKLOADS_DIR/CLOUDHV.fd" "$JAMMY_OS_IMAGE" \
+    "$WORKLOADS_DIR/vmlinux-x86_64" "$WORKLOADS_DIR/bzImage-x86_64" \
+    "$WORKLOADS_DIR/alpine-minirootfs-x86_64.tar.gz" \
+    "$WORKLOADS_DIR/cloud-hypervisor-static"; do
+    if [ ! -f "$required" ]; then
+        echo "Missing: $required — run: python3 scripts/fetch_workloads.py --test integration"
         exit 1
     fi
-    migratable_version=${MIGRATABLE_VERSION}
+done
+
+if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
+    pushd "$WORKLOADS_DIR" || exit
+    time qemu-img convert -p -f qcow2 -O raw $JAMMY_OS_IMAGE_NAME $JAMMY_OS_RAW_IMAGE_NAME || exit 1
+    popd || exit
 fi
-
-cp scripts/sha1sums-x86_64* "$WORKLOADS_DIR"
-
-if [ ! -f "$WORKLOADS_DIR/hypervisor-fw" ]; then
-    download_hypervisor_fw
-fi
-
-if [ ! -f "$WORKLOADS_DIR/CLOUDHV.fd" ]; then
-    download_amd64_ovmf
-fi
-
-download_x86_guest_images
 
 JAMMY_OS_QCOW_ZLIB_FILE_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0-zlib.qcow2"
 JAMMY_OS_QCOW_ZLIB_FILE_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_QCOW_ZLIB_FILE_IMAGE_NAME"
@@ -90,12 +90,10 @@ if [ ! -f "$JAMMY_OS_QCOW_BACKING_RAW_FILE_IMAGE" ]; then
     popd || exit
 fi
 
-ALPINE_MINIROOTFS_URL="http://dl-cdn.alpinelinux.org/alpine/v3.11/releases/x86_64/alpine-minirootfs-3.11.3-x86_64.tar.gz"
 ALPINE_MINIROOTFS_TARBALL="$WORKLOADS_DIR/alpine-minirootfs-x86_64.tar.gz"
 if [ ! -f "$ALPINE_MINIROOTFS_TARBALL" ]; then
-    pushd "$WORKLOADS_DIR" || exit
-    time wget --quiet $ALPINE_MINIROOTFS_URL -O "$ALPINE_MINIROOTFS_TARBALL" || exit 1
-    popd || exit
+    echo "Missing: $ALPINE_MINIROOTFS_TARBALL — run: python3 scripts/fetch_workloads.py --test integration"
+    exit 1
 fi
 
 ALPINE_INITRAMFS_IMAGE="$WORKLOADS_DIR/alpine_initramfs.img"
@@ -116,39 +114,9 @@ if [ ! -f "$ALPINE_INITRAMFS_IMAGE" ]; then
     popd || exit
 fi
 
-pushd "$WORKLOADS_DIR" || exit
-# Skip checksum verification for custom-provided workloads
-sha1_exclude=""
-[ -n "$CH_CUSTOM_FIRMWARE" ] && sha1_exclude="${sha1_exclude}|hypervisor-fw"
-[ -n "$CH_CUSTOM_OVMF" ] && sha1_exclude="${sha1_exclude}|CLOUDHV\\.fd"
-sha1_exclude="${sha1_exclude#|}"
-if [ -n "$sha1_exclude" ]; then
-    if ! cat sha1sums-x86_64 sha1sums-x86_64-common | grep -Ev "$sha1_exclude" | sha1sum --check; then
-        echo "sha1sum validation of images failed, remove invalid images to fix the issue."
-        exit 1
-    fi
-else
-    if ! sha1sum sha1sums-x86_64 sha1sums-x86_64-common --check; then
-        echo "sha1sum validation of images failed, remove invalid images to fix the issue."
-        exit 1
-    fi
-fi
-popd || exit
+python3 scripts/fetch_workloads.py --test integration --verify-only || exit 1
 
-# Download Cloud Hypervisor binary from its last stable release for live-upgrade tests
-CH_RELEASE_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${migratable_version}/cloud-hypervisor-static"
-CH_RELEASE_NAME="cloud-hypervisor-static"
-pushd "$WORKLOADS_DIR" || exit
-time wget --quiet $CH_RELEASE_URL -O "$CH_RELEASE_NAME" || exit 1
-chmod +x $CH_RELEASE_NAME
-popd || exit
-
-# Build custom kernel based on virtio-pmem and virtio-fs upstream patches
 VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux-x86_64"
-if [ ! -f "$VMLINUX_IMAGE" ]; then
-    # Prepare linux image (build from source or download pre-built)
-    prepare_linux
-fi
 
 VIRTIOFSD="$WORKLOADS_DIR/virtiofsd"
 if [ ! -f "$VIRTIOFSD" ]; then

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -20,26 +20,18 @@ if [ "$VM_TYPE" = "confidential" ]; then
     vm_type_arg="--vm-type confidential"
 fi
 
-cp scripts/sha1sums-"${TEST_ARCH}"-common "$WORKLOADS_DIR"
-
 if [ "${TEST_ARCH}" == "aarch64" ]; then
     JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.qcow2"
-else
-    JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
-fi
-
-JAMMY_OS_IMAGE_URL="https://ch-images.azureedge.net/$JAMMY_OS_IMAGE_NAME"
-JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"
-if [ ! -f "$JAMMY_OS_IMAGE" ]; then
-    pushd "$WORKLOADS_DIR" || exit
-    time wget --quiet $JAMMY_OS_IMAGE_URL || exit 1
-    popd || exit
-fi
-
-if [ "${TEST_ARCH}" == "aarch64" ]; then
     JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-arm64-custom-20220329-0.raw"
 else
+    JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.qcow2"
     JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-custom-20241017-0.raw"
+fi
+
+JAMMY_OS_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_IMAGE_NAME"
+if [ ! -f "$JAMMY_OS_IMAGE" ]; then
+    echo "Missing: $JAMMY_OS_IMAGE — run: python3 scripts/fetch_workloads.py --test metrics"
+    exit 1
 fi
 
 JAMMY_OS_RAW_IMAGE="$WORKLOADS_DIR/$JAMMY_OS_RAW_IMAGE_NAME"
@@ -49,16 +41,15 @@ if [ ! -f "$JAMMY_OS_RAW_IMAGE" ]; then
     popd || exit
 fi
 
-pushd "$WORKLOADS_DIR" || exit
-if ! grep jammy sha1sums-"${TEST_ARCH}"-common | sha1sum --check; then
-    echo "sha1sum validation of images failed, remove invalid images to fix the issue."
+if [ "${TEST_ARCH}" == "aarch64" ]; then
+    KERNEL_IMAGE="$WORKLOADS_DIR/Image-arm64"
+else
+    KERNEL_IMAGE="$WORKLOADS_DIR/vmlinux-x86_64"
+fi
+if [ ! -f "$KERNEL_IMAGE" ]; then
+    echo "Missing: $KERNEL_IMAGE — run: python3 scripts/fetch_workloads.py --test metrics"
     exit 1
 fi
-
-popd || exit
-
-# Prepare linux image (build from source or download pre-built)
-prepare_linux
 
 CFLAGS=""
 if [[ "${BUILD_TARGET}" == "${TEST_ARCH}-unknown-linux-musl" ]]; then

--- a/scripts/test_assets.yaml
+++ b/scripts/test_assets.yaml
@@ -60,28 +60,33 @@ assets:
   # Kernels
   - filename: vmlinux-x86_64
     url: https://github.com/cloud-hypervisor/linux/releases/download/ch-release-v6.16.9-20260508/vmlinux-x86_64
+    sha1: 322b3850a8247077def70845559c6752b7d5f49b
     arch: [x86_64]
     test: [integration, rate-limiter, metrics]
 
   - filename: bzImage-x86_64
     url: https://github.com/cloud-hypervisor/linux/releases/download/ch-release-v6.16.9-20260508/bzImage-x86_64
+    sha1: 18107cf13f1566b5ddae6cbd88e3cb22a28d6a6c
     arch: [x86_64]
     test: [integration]
 
   - filename: Image-arm64
     url: https://github.com/cloud-hypervisor/linux/releases/download/ch-release-v6.16.9-20260508/Image-arm64
+    sha1: 324becf5f9d57266999e25e93d3d7bbe97d35b4e
     arch: [aarch64]
     test: [integration, metrics]
 
   # Previous release binaries for live-upgrade tests
   - filename: cloud-hypervisor-static
     url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v39.0/cloud-hypervisor-static
+    sha1: 8516a22620021f2b39abff1836f2f2a8a025cbf9
     executable: true
     arch: [x86_64]
     test: [integration]
 
   - filename: cloud-hypervisor-static-aarch64
     url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v39.0/cloud-hypervisor-static-aarch64
+    sha1: 588d0a12f38d87560b4a4cf95a43478064481aa2
     executable: true
     arch: [aarch64]
     test: [integration]

--- a/scripts/test_assets.yaml
+++ b/scripts/test_assets.yaml
@@ -1,0 +1,87 @@
+# Copyright © 2025 Meta Platforms, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Workload assets required by integration tests.
+# Use scripts/fetch_workloads.py to download them before running tests.
+
+assets:
+  # Firmware
+  - filename: hypervisor-fw
+    url: https://github.com/cloud-hypervisor/rust-hypervisor-firmware/releases/download/0.5.0/hypervisor-fw
+    sha1: 540ac358429305d7aa94e15363665d1c9d845982
+    arch: [x86_64]
+    test: [integration, vfio]
+
+  - filename: CLOUDHV.fd
+    url: https://github.com/cloud-hypervisor/edk2/releases/download/ch-1e1b96f126/CLOUDHV.fd
+    sha1: fb2e6834cc482c80a45766f6dcf12474f4fcb74e
+    arch: [x86_64]
+    test: [integration, windows]
+
+  - filename: CLOUDHV_EFI.fd
+    url: https://github.com/cloud-hypervisor/edk2/releases/download/ch-1e1b96f126/CLOUDHV_EFI.fd
+    sha1: ce3656987f9e4238ef8afbd65fca219460c1f767
+    arch: [aarch64]
+    test: [integration, windows]
+
+  # Guest images
+  - filename: jammy-server-cloudimg-amd64-custom-20241017-0.qcow2
+    url: https://ch-images.azureedge.net/jammy-server-cloudimg-amd64-custom-20241017-0.qcow2
+    sha1: 5f10738920efb74f0bf854cadcd1b1fd544e49c8
+    arch: [x86_64]
+    test: [integration, cvm, rate-limiter, metrics]
+
+  - filename: jammy-server-cloudimg-arm64-custom-20220329-0.raw
+    url: https://ch-images.azureedge.net/jammy-server-cloudimg-arm64-custom-20220329-0.raw
+    sha1: 1f2b71be43b8f748f01306c4454e5c921343faa4
+    arch: [aarch64]
+    test: [integration]
+
+  - filename: jammy-server-cloudimg-arm64-custom-20220329-0.qcow2
+    url: https://ch-images.azureedge.net/jammy-server-cloudimg-arm64-custom-20220329-0.qcow2
+    sha1: 7118f4d4cad18c8357bc2ad9824a50f9a82a860a
+    arch: [aarch64]
+    test: [integration]
+
+  # Alpine minirootfs
+  - filename: alpine-minirootfs-x86_64.tar.gz
+    url: http://dl-cdn.alpinelinux.org/alpine/v3.11/releases/x86_64/alpine-minirootfs-3.11.3-x86_64.tar.gz
+    sha1: d4a44acc6014d5f83dea1c625c43d677a95fa75f
+    arch: [x86_64]
+    test: [integration]
+
+  - filename: alpine-minirootfs-aarch64.tar.gz
+    url: http://dl-cdn.alpinelinux.org/alpine/v3.11/releases/aarch64/alpine-minirootfs-3.11.3-aarch64.tar.gz
+    sha1: e4addb6e212a298144f9eb0eb6e36019d013f0e7
+    arch: [aarch64]
+    test: [integration]
+
+  # Kernels
+  - filename: vmlinux-x86_64
+    url: https://github.com/cloud-hypervisor/linux/releases/download/ch-release-v6.16.9-20260508/vmlinux-x86_64
+    arch: [x86_64]
+    test: [integration, rate-limiter, metrics]
+
+  - filename: bzImage-x86_64
+    url: https://github.com/cloud-hypervisor/linux/releases/download/ch-release-v6.16.9-20260508/bzImage-x86_64
+    arch: [x86_64]
+    test: [integration]
+
+  - filename: Image-arm64
+    url: https://github.com/cloud-hypervisor/linux/releases/download/ch-release-v6.16.9-20260508/Image-arm64
+    arch: [aarch64]
+    test: [integration, metrics]
+
+  # Previous release binaries for live-upgrade tests
+  - filename: cloud-hypervisor-static
+    url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v39.0/cloud-hypervisor-static
+    executable: true
+    arch: [x86_64]
+    test: [integration]
+
+  - filename: cloud-hypervisor-static-aarch64
+    url: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v39.0/cloud-hypervisor-static-aarch64
+    executable: true
+    arch: [aarch64]
+    test: [integration]


### PR DESCRIPTION
Reduce the requirement to have internet access in the container. Achieve this
by downloading the assets a priori. To streamline the build time take advantage
of that by downloading and verfying the checksums in parallel. Internet access is
still required for cargo build for now.

- **scripts: Add a tool for downloading test assets**
- **scripts: Add asset files for all test downloads**
- **scripts: Make dev_cli.sh download assets before entering container**
- **scripts: Remove downloads from integration test scripts**
- **scripts: Add SHA-1 checksums for kernel and static binary assets**
