### PR TITLE
Accept pre-opened VFIO cdev and iommufd FDs

### DIFF
--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -371,14 +371,14 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                 .map_err(Error::HttpApiClient)
         }
         Some("add-device") => {
-            let device_config = add_device_config(
+            let (device_config, fds) = add_device_config(
                 matches
                     .subcommand_matches("add-device")
                     .unwrap()
                     .get_one::<String>("device_config")
                     .unwrap(),
             )?;
-            simple_api_command(socket, "PUT", "add-device", Some(&device_config))
+            simple_api_command_with_fds(socket, "PUT", "add-device", Some(&device_config), &fds)
                 .map_err(Error::HttpApiClient)
         }
         Some("remove-device") => {
@@ -609,7 +609,7 @@ fn dbus_api_do_command(matches: &ArgMatches, proxy: &DBusApi1ProxyBlocking<'_>) 
             proxy.api_vm_resize_zone(&resize_zone)
         }
         Some("add-device") => {
-            let device_config = add_device_config(
+            let (device_config, _fds) = add_device_config(
                 matches
                     .subcommand_matches("add-device")
                     .unwrap()
@@ -835,11 +835,21 @@ fn resize_zone_config(id: &str, size: &str) -> Result<String, Error> {
     Ok(serde_json::to_string(&resize_zone).unwrap())
 }
 
-fn add_device_config(config: &str) -> Result<String, Error> {
-    let device_config = DeviceConfig::parse(config).map_err(Error::AddDeviceConfig)?;
+fn add_device_config(config: &str) -> Result<(String, Vec<i32>), Error> {
+    let mut device_config = DeviceConfig::parse(config).map_err(Error::AddDeviceConfig)?;
+
+    // DeviceConfig is modified on purpose here by taking the file
+    // descriptor out. Keeping it and sending it over to the server side
+    // process would not make any sense since the file descriptor may be
+    // represented with different values.
+    let fds = device_config
+        .fd
+        .take()
+        .map(|fd| vec![fd])
+        .unwrap_or_default();
     let device_config = serde_json::to_string(&device_config).unwrap();
 
-    Ok(device_config)
+    Ok((device_config, fds))
 }
 
 fn add_user_device_config(config: &str) -> Result<String, Error> {

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -11128,6 +11128,8 @@ mod windows {
 
 #[cfg(target_arch = "x86_64")]
 mod vfio {
+    use std::io;
+
     use crate::*;
 
     const NVIDIA_VFIO_DEVICE: &str = "/sys/bus/pci/devices/0002:00:01.0";
@@ -11391,6 +11393,92 @@ mod vfio {
     #[test]
     fn test_iommufd_nvidia_card_reboot() {
         test_nvidia_card_reboot_common(true);
+    }
+
+    // Pass the NVIDIA card to the guest via an externally-opened
+    // /dev/vfio/devices/<n> FD instead of a sysfs path, and verify it
+    // survives a guest reboot. Mirrors `_test_tap_from_fd` for VFIO.
+    #[test]
+    fn test_iommufd_nvidia_card_reboot_from_fd() {
+        let disk_config = UbuntuDiskConfig::new(JAMMY_VFIO_IMAGE_NAME.to_string());
+        let guest = Guest::new(Box::new(disk_config));
+        let api_socket = temp_api_path(&guest.tmp_dir);
+
+        // Discover the cdev for the NVIDIA card. The directory has a
+        // single entry whose name (e.g. "vfio0") is also the basename
+        // of the corresponding /dev/vfio/devices/<n> node.
+        let vfio_dev_dir = format!("{NVIDIA_VFIO_DEVICE}/vfio-dev");
+        let cdev_name = fs::read_dir(&vfio_dev_dir)
+            .unwrap_or_else(|e| panic!("read_dir({vfio_dev_dir}) failed: {e}"))
+            .next()
+            .expect("no vfio-dev entry")
+            .unwrap()
+            .file_name();
+        let cdev_path = PathBuf::from("/dev/vfio/devices").join(&cdev_name);
+
+        let cdev_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&cdev_path)
+            .unwrap_or_else(|e| panic!("open({cdev_path:?}) failed: {e}"));
+        let iommufd_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/iommu")
+            .unwrap_or_else(|e| panic!("open(/dev/iommu) failed: {e}"));
+        // OpenOptions sets FD_CLOEXEC by default; clear it for both fds
+        // so they're inherited by the VMM child via spawn().
+        for f in [&cdev_file, &iommufd_file] {
+            // SAFETY: FFI call to fcntl on a valid fd we own.
+            let ret = unsafe { libc::fcntl(f.as_raw_fd(), libc::F_SETFD, 0) };
+            assert!(
+                ret >= 0,
+                "fcntl(F_SETFD, 0) failed: {}",
+                io::Error::last_os_error()
+            );
+        }
+
+        let platform = format!(
+            "{},iommufd_fd={}",
+            platform_cfg(true),
+            iommufd_file.as_raw_fd()
+        );
+
+        let mut child = GuestCommand::new(&guest)
+            .args(["--cpus", "boot=4"])
+            .args(["--memory", "size=1G"])
+            .args(["--platform", &platform])
+            .args(["--kernel", fw_path(FwType::RustHypervisorFirmware).as_str()])
+            .args([
+                "--device",
+                format!("fd={},iommu=on", cdev_file.as_raw_fd()).as_str(),
+            ])
+            .args(["--api-socket", &api_socket])
+            .default_disks()
+            .default_net()
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let r = std::panic::catch_unwind(|| {
+            guest.wait_vm_boot().unwrap();
+
+            // VFIO device works after boot from an externally-opened FD.
+            assert!(guest.check_nvidia_gpu());
+
+            guest.reboot_linux(0);
+
+            // Both FDs survive a VM reboot
+            assert!(guest.check_nvidia_gpu());
+        });
+
+        drop(cdev_file);
+        drop(iommufd_file);
+
+        let _ = child.kill();
+        let output = child.wait_with_output().unwrap();
+
+        handle_child_output(r, &output);
     }
 
     fn test_nvidia_card_iommu_address_width_common(iommufd: bool) {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "acpi_tables"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad581b2b0fa02638f3df6ff3f852ebc30dc7cfe531e9745d1ca4c0f283a6dbe"
+checksum = "ce821f856a3eb1d033287f2dcfcdf94276d7895dd5bdd8ca45ae17e7d33d4dd9"
 dependencies = [
  "zerocopy",
 ]
@@ -53,7 +53,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,7 +64,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -112,6 +112,28 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "bitfield-struct"
@@ -263,6 +285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,7 +482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -509,6 +546,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +603,17 @@ checksum = "6c02bfe7bd65f42bcda751456869dfa1eb2bd1c36e309b9ec27f4888d41cf258"
 dependencies = [
  "gdbstub",
  "num-traits",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -688,9 +742,9 @@ checksum = "fd7de3a04f6fd55f171a6682852f7aa360bb848a85e0c610513349e006b3c139"
 
 [[package]]
 name = "iommufd-ioctls"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eabd3414d9c4e716c9a198fbfac484625f088c075605372daf037edfe336e18"
+checksum = "8050f03ef0c6979597140b6d20da076931fb7a06389b8b0eb971b8f65b271748"
 dependencies = [
  "iommufd-bindings",
  "thiserror",
@@ -741,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3c06ff73c7ce03e780887ec2389d62d2a2a9ddf471ab05c2ff69207cd3f3b4"
+checksum = "11cf0ca75d59e9d298647c59cf6c5286fa048120caa77972a7a504a0824d234f"
 dependencies = [
  "serde",
  "vmm-sys-util",
@@ -752,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333f77a20344a448f3f70664918135fddeb804e938f28a99d685bd92926e0b19"
+checksum = "06ac372c120eb893b086d1a12027669cf2b478d1f71204021ffa7adf57948d63"
 dependencies = [
  "bitflags 2.13.0",
  "kvm-bindings",
@@ -1086,6 +1140,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,6 +1357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "vfio-ioctls"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b1d98dff7f0d219278e406323e7eda4d426447bd203c7828189baf0d8c07b7"
+checksum = "f2b1110f3ab5703a0f788d569b1b4a2436e8cc434f384b3ef5d77283f8ee03d8"
 dependencies = [
  "byteorder",
  "iommufd-bindings",
@@ -1524,6 +1641,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "itertools",
+ "log",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror",
@@ -1602,6 +1721,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1730,12 +1855,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1859,6 +2057,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -45,7 +45,7 @@ use crate::api::VmCoredump;
 use crate::api::http::http_endpoint::fds_helper::{attach_fds_to_cfg, attach_fds_to_cfgs};
 use crate::api::http::{EndpointHandler, HttpError, error_response};
 use crate::api::{
-    AddDisk, ApiAction, ApiError, ApiRequest, NetConfig, VmAddDevice, VmAddFs,
+    AddDisk, ApiAction, ApiError, ApiRequest, DeviceConfig, NetConfig, VmAddDevice, VmAddFs,
     VmAddGenericVhostUser, VmAddNet, VmAddPmem, VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot,
     VmConfig, VmCounters, VmDelete, VmNmi, VmPause, VmPowerButton, VmReboot, VmReceiveMigration,
     VmRemoveDevice, VmResize, VmResizeDisk, VmResizeZone, VmRestore, VmResume, VmSendMigration,
@@ -115,10 +115,11 @@ mod fds_helper {
 
     mod config_with_fds_impls {
         use std::os::fd::RawFd;
+        use std::slice::from_ref;
 
         use super::{ConfigWithFDs, ConfigWithVariableFDs};
         use crate::config::RestoredNetConfig;
-        use crate::vm_config::NetConfig;
+        use crate::vm_config::{DeviceConfig, NetConfig};
 
         impl ConfigWithFDs for NetConfig {
             fn id(&self) -> Option<&str> {
@@ -131,6 +132,24 @@ mod fds_helper {
 
             fn set_fds(&mut self, fds: Option<Vec<RawFd>>) {
                 self.fds = fds;
+            }
+        }
+
+        impl ConfigWithFDs for DeviceConfig {
+            fn id(&self) -> Option<&str> {
+                self.pci_common.id.as_deref()
+            }
+
+            fn fds_from_http_body(&self) -> Option<&[RawFd]> {
+                // A DeviceConfig carries at most one FD.
+                self.fd.as_ref().map(from_ref)
+            }
+
+            fn set_fds(&mut self, fds: Option<Vec<RawFd>>) {
+                // The VmAddDevice PutHandler enforces `fds.len() <= 1`
+                // before calling into this trait, so `pop()` yields the
+                // single FD when present.
+                self.fd = fds.and_then(|mut v| v.pop());
             }
         }
 
@@ -295,6 +314,19 @@ impl EndpointHandler for VmCreate {
                             }
                         }
 
+                        if let Some(ref mut devices) = vm_config.devices {
+                            // For the VmCreate call, we do not accept FDs from the socket currently.
+                            // This call sets all FDs to null while doing the same logging as
+                            // similar code paths.
+                            for cfg in devices.iter_mut() {
+                                if let Err(e) =
+                                    attach_fds_to_cfg(vec![], cfg).map_err(error_response)
+                                {
+                                    return e;
+                                }
+                            }
+                        }
+
                         match crate::api::VmCreate
                             .send(api_notifier, api_sender, vm_config)
                             .map_err(HttpError::ApiError)
@@ -417,7 +449,6 @@ vm_action_put_handler!(VmResume);
 vm_action_put_handler!(VmPowerButton);
 vm_action_put_handler!(VmNmi);
 
-vm_action_put_handler_body!(VmAddDevice);
 vm_action_put_handler_body!(AddDisk);
 vm_action_put_handler_body!(VmAddFs);
 vm_action_put_handler_body!(VmAddGenericVhostUser);
@@ -434,6 +465,34 @@ vm_action_put_handler_body!(VmSendMigration);
 
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 vm_action_put_handler_body!(VmCoredump);
+
+// Special handling for VFIO devices backed by an externally-opened cdev FD.
+// See module description for more info.
+impl PutHandler for VmAddDevice {
+    fn handle_request(
+        &'static self,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+        body: &Option<Body>,
+        files: Vec<File>,
+    ) -> Result<Option<Body>, HttpError> {
+        if let Some(body) = body {
+            // A DeviceConfig is backed by at most one FD.
+            if files.len() > 1 {
+                return Err(HttpError::BadRequest);
+            }
+            let mut device_cfg: DeviceConfig = serde_json::from_slice(body.raw())?;
+            attach_fds_to_cfg(files, &mut device_cfg)?;
+
+            self.send(api_notifier, api_sender, device_cfg)
+                .map_err(HttpError::ApiError)
+        } else {
+            Err(HttpError::BadRequest)
+        }
+    }
+}
+
+impl GetHandler for VmAddDevice {}
 
 // Special handling for virtio-net devices backed by network FDs.
 // See module description for more info.

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1285,12 +1285,15 @@ components:
           type: integer
 
     DeviceConfig:
-      required:
-        - path
       type: object
       properties:
         path:
           type: string
+          description: |
+            Sysfs path of the VFIO device. Exactly one of `path` or an
+            externally-opened cdev FD must be supplied; an FD is passed
+            out of band via SCM_RIGHTS on the UNIX domain socket, never
+            in this body.
         iommu:
           type: boolean
           default: false

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -349,9 +349,13 @@ pub enum ValidationError {
     /// A DeviceConfig specified both `path` and `fd`.
     #[error("VFIO device config must specify at most one of `path=` or `fd=`")]
     VfioDeviceBothPathAndFd,
-    /// FD-based VFIO requires the `iommufd` platform option to be enabled.
-    #[error("VFIO device `fd=` requires platform `iommufd=on`")]
-    VfioFdRequiresIommufd,
+    /// FD-based VFIO requires an externally-supplied iommufd FD so the
+    /// cdev's bind state can survive across an in-process VM reboot.
+    #[error("VFIO device `fd=` requires platform `iommufd_fd=<fd>`")]
+    VfioFdRequiresIommufdFd,
+    /// `iommufd_fd` was provided without also enabling the iommufd backend.
+    #[error("Platform `iommufd_fd=<fd>` requires `iommufd=on`")]
+    IommufdFdRequiresIommufd,
     /// Provided MTU is lower than what the VIRTIO specification expects
     #[error("Provided MTU {0} is lower than 1280 (expected by VIRTIO specification)")]
     InvalidMtu(u16),
@@ -853,7 +857,8 @@ impl PlatformConfig {
         static SYNTAX: LazyLock<String> = LazyLock::new(|| {
             let mut syntax = "Platform configuration parameters \
             \"num_pci_segments=<num_pci_segments>,iommu_segments=<list_of_segments>,\
-            iommu_address_width=<bits>,iommufd=on|off,vfio_p2p_dma=on|off,system_manufacturer=<dmi_system_manufacturer>,\
+            iommu_address_width=<bits>,iommufd=on|off,iommufd_fd=<fd>,vfio_p2p_dma=on|off,\
+            system_manufacturer=<dmi_system_manufacturer>,\
             system_product_name=<dmi_system_product_name>,system_version=<dmi_system_version>,\
             system_serial_number=<dmi_system_serial_number>,system_uuid=<dmi_system_uuid>,\
             system_sku_number=<dmi_system_sku_number>,system_family=<dmi_system_family>,\
@@ -926,6 +931,7 @@ impl PlatformConfig {
             .add("uuid")
             .add("oem_strings")
             .add("iommufd")
+            .add("iommufd_fd")
             .add("vfio_p2p_dma");
         for field in SMBIOS_STRING_FIELDS {
             parser.add(field.key);
@@ -952,11 +958,14 @@ impl PlatformConfig {
             .convert::<StringList>("oem_strings")
             .map_err(Error::ParsePlatform)?
             .map(|v| v.0.into_boxed_slice());
+        let iommufd_fd = parser
+            .convert::<i32>("iommufd_fd")
+            .map_err(Error::ParsePlatform)?;
+        // `iommufd_fd=<n>` implies `iommufd=on` unless the user explicitly set the value.
         let iommufd = parser
             .convert::<Toggle>("iommufd")
             .map_err(Error::ParsePlatform)?
-            .unwrap_or(Toggle(false))
-            .0;
+            .map_or(iommufd_fd.is_some(), |Toggle(v)| v);
         let vfio_p2p_dma = parser
             .convert::<Toggle>("vfio_p2p_dma")
             .map_err(Error::ParsePlatform)?
@@ -989,6 +998,7 @@ impl PlatformConfig {
             system_sku_number: None,
             chassis_asset_tag: None,
             iommufd,
+            iommufd_fd,
             #[cfg(feature = "tdx")]
             tdx,
             #[cfg(feature = "sev_snp")]
@@ -1045,6 +1055,10 @@ impl PlatformConfig {
             return Err(ValidationError::InvalidIommuAddressWidthBits(
                 self.iommu_address_width_bits,
             ));
+        }
+
+        if self.iommufd_fd.is_some() && !self.iommufd {
+            return Err(ValidationError::IommufdFdRequiresIommufd);
         }
 
         Ok(())
@@ -2461,9 +2475,12 @@ impl DeviceConfig {
             (None, None) => return Err(ValidationError::VfioDeviceNeitherPathNorFd),
             (Some(_), Some(_)) => return Err(ValidationError::VfioDeviceBothPathAndFd),
             (None, Some(_)) => {
-                let iommufd_on = vm_config.platform.as_ref().is_some_and(|p| p.iommufd);
-                if !iommufd_on {
-                    return Err(ValidationError::VfioFdRequiresIommufd);
+                let iommufd_fd_set = vm_config
+                    .platform
+                    .as_ref()
+                    .is_some_and(|p| p.iommufd_fd.is_some());
+                if !iommufd_fd_set {
+                    return Err(ValidationError::VfioFdRequiresIommufdFd);
                 }
             }
             (Some(_), None) => {}
@@ -4873,6 +4890,26 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
     }
 
     #[test]
+    fn test_platform_iommufd_fd_parsing() -> Result<()> {
+        // `iommufd_fd=N` alone implies `iommufd=on`.
+        let p = PlatformConfig::parse("iommufd_fd=42")?;
+        assert!(p.iommufd);
+        assert_eq!(p.iommufd_fd, Some(42));
+
+        // Explicit `iommufd=on,iommufd_fd=N` is the same.
+        let p = PlatformConfig::parse("iommufd=on,iommufd_fd=42")?;
+        assert!(p.iommufd);
+        assert_eq!(p.iommufd_fd, Some(42));
+
+        // No flags → both default to off.
+        let p = PlatformConfig::parse("")?;
+        assert!(!p.iommufd);
+        assert_eq!(p.iommufd_fd, None);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_vsock_parsing() -> Result<()> {
         // socket and cid is required
         VsockConfig::parse("").unwrap_err();
@@ -5276,6 +5313,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             system_uuid: None,
             oem_strings: None,
             iommufd: false,
+            iommufd_fd: None,
             vfio_p2p_dma: default_platformconfig_vfio_p2p_dma(),
             system_manufacturer: None,
             system_product_name: None,
@@ -6145,10 +6183,12 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         ]);
         invalid_config.validate().unwrap_err();
 
-        // An fd-backed DeviceConfig is only valid with iommufd enabled.
+        // An fd-backed DeviceConfig is only valid with
+        // externally-supplied fd is provided for iommufd too
         let mut fd_valid_config = valid_config.clone();
         fd_valid_config.platform = Some(PlatformConfig {
             iommufd: true,
+            iommufd_fd: Some(8),
             ..platform_fixture()
         });
         fd_valid_config.devices = Some(vec![DeviceConfig {
@@ -6158,11 +6198,27 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         }]);
         fd_valid_config.validate().unwrap();
 
-        let mut fd_without_iommufd = fd_valid_config.clone();
-        fd_without_iommufd.platform = None;
+        let mut fd_without_iommufd_fd = fd_valid_config.clone();
+        fd_without_iommufd_fd.platform = Some(PlatformConfig {
+            iommufd: true,
+            iommufd_fd: None,
+            ..platform_fixture()
+        });
         assert!(matches!(
-            fd_without_iommufd.validate(),
-            Err(ValidationError::VfioFdRequiresIommufd),
+            fd_without_iommufd_fd.validate(),
+            Err(ValidationError::VfioFdRequiresIommufdFd),
+        ));
+
+        // iommufd_fd without iommufd=on is rejected at PlatformConfig::validate.
+        let mut iommufd_fd_without_iommufd = valid_config.clone();
+        iommufd_fd_without_iommufd.platform = Some(PlatformConfig {
+            iommufd: false,
+            iommufd_fd: Some(8),
+            ..platform_fixture()
+        });
+        assert!(matches!(
+            iommufd_fd_without_iommufd.validate(),
+            Err(ValidationError::IommufdFdRequiresIommufd),
         ));
 
         // Exactly one of path and fd must be set.

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2442,7 +2442,7 @@ impl DeviceConfig {
             .unwrap_or_default();
         Ok(DeviceConfig {
             pci_common,
-            path,
+            path: Some(path),
             x_nv_gpudirect_clique,
             x_exclude_mmap_bars,
         })
@@ -3312,9 +3312,11 @@ impl VmConfig {
         if let Some(devices) = &self.devices {
             let mut device_paths = BTreeSet::new();
             for device in devices {
-                if !device_paths.insert(device.path.to_string_lossy()) {
+                if let Some(path) = device.path.as_deref()
+                    && !device_paths.insert(path.to_string_lossy())
+                {
                     return Err(ValidationError::DuplicateDevicePath(
-                        device.path.to_string_lossy().to_string(),
+                        path.to_string_lossy().to_string(),
                     ));
                 }
 
@@ -4719,7 +4721,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
     fn device_fixture() -> DeviceConfig {
         DeviceConfig {
             pci_common: PciDeviceCommonConfig::default(),
-            path: PathBuf::from("/path/to/device"),
+            path: Some(PathBuf::from("/path/to/device")),
             x_nv_gpudirect_clique: None,
             x_exclude_mmap_bars: Vec::new(),
         }
@@ -6073,11 +6075,11 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         let mut still_valid_config = valid_config.clone();
         still_valid_config.devices = Some(vec![
             DeviceConfig {
-                path: "/device1".into(),
+                path: Some("/device1".into()),
                 ..device_fixture()
             },
             DeviceConfig {
-                path: "/device2".into(),
+                path: Some("/device2".into()),
                 ..device_fixture()
             },
         ]);
@@ -6086,11 +6088,11 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         let mut invalid_config = valid_config.clone();
         invalid_config.devices = Some(vec![
             DeviceConfig {
-                path: "/device1".into(),
+                path: Some("/device1".into()),
                 ..device_fixture()
             },
             DeviceConfig {
-                path: "/device1".into(),
+                path: Some("/device1".into()),
                 ..device_fixture()
             },
         ]);

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2413,7 +2413,7 @@ impl DebugConsoleConfig {
 
 impl DeviceConfig {
     pub const SYNTAX: &'static str = "Direct device assignment parameters \
-    \"path=<device_path>,iommu=on|off,id=<device_id>,\
+    \"path=<device_path>,fd=<vfio_cdev_fd>,iommu=on|off,id=<device_id>,\
     pci_segment=<segment_id>,pci_device_id=<pci_slot>,\
     x_nv_gpudirect_clique=<clique_id>,\
     x_exclude_mmap_bars=[<bar>...]\"";
@@ -2422,6 +2422,7 @@ impl DeviceConfig {
         let mut parser = OptionParser::new();
         parser
             .add("path")
+            .add("fd")
             .add_all(PciDeviceCommonConfig::OPTIONS_IOMMU)
             .add("x_nv_gpudirect_clique")
             .add("x_exclude_mmap_bars");
@@ -2432,6 +2433,7 @@ impl DeviceConfig {
             .get("path")
             .map(PathBuf::from)
             .ok_or(Error::ParseDevicePathMissing)?;
+        let fd = parser.convert::<i32>("fd").map_err(Error::ParseDevice)?;
         let x_nv_gpudirect_clique = parser
             .convert::<u8>("x_nv_gpudirect_clique")
             .map_err(Error::ParseDevice)?;
@@ -2443,6 +2445,7 @@ impl DeviceConfig {
         Ok(DeviceConfig {
             pci_common,
             path: Some(path),
+            fd,
             x_nv_gpudirect_clique,
             x_exclude_mmap_bars,
         })
@@ -4722,6 +4725,7 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         DeviceConfig {
             pci_common: PciDeviceCommonConfig::default(),
             path: Some(PathBuf::from("/path/to/device")),
+            fd: None,
             x_nv_gpudirect_clique: None,
             x_exclude_mmap_bars: Vec::new(),
         }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -148,9 +148,6 @@ pub enum Error {
     /// Failed parsing device parameters
     #[error("Error parsing --device")]
     ParseDevice(#[source] OptionParserError),
-    /// Missing path from device,
-    #[error("Error parsing --device: path missing")]
-    ParseDevicePathMissing,
     /// Failed parsing vsock parameters
     #[error("Error parsing --vsock")]
     ParseVsock(#[source] OptionParserError),
@@ -346,6 +343,15 @@ pub enum ValidationError {
     /// Duplicated device path (device added twice)
     #[error("Duplicated device path: {0}")]
     DuplicateDevicePath(String),
+    /// A DeviceConfig specified neither `path` nor `fd`.
+    #[error("VFIO device config must specify `path=` or `fd=`")]
+    VfioDeviceNeitherPathNorFd,
+    /// A DeviceConfig specified both `path` and `fd`.
+    #[error("VFIO device config must specify at most one of `path=` or `fd=`")]
+    VfioDeviceBothPathAndFd,
+    /// FD-based VFIO requires the `iommufd` platform option to be enabled.
+    #[error("VFIO device `fd=` requires platform `iommufd=on`")]
+    VfioFdRequiresIommufd,
     /// Provided MTU is lower than what the VIRTIO specification expects
     #[error("Provided MTU {0} is lower than 1280 (expected by VIRTIO specification)")]
     InvalidMtu(u16),
@@ -2429,10 +2435,7 @@ impl DeviceConfig {
         parser.parse(device).map_err(Error::ParseDevice)?;
 
         let pci_common = PciDeviceCommonConfig::parse(device)?;
-        let path = parser
-            .get("path")
-            .map(PathBuf::from)
-            .ok_or(Error::ParseDevicePathMissing)?;
+        let path = parser.get("path").map(PathBuf::from);
         let fd = parser.convert::<i32>("fd").map_err(Error::ParseDevice)?;
         let x_nv_gpudirect_clique = parser
             .convert::<u8>("x_nv_gpudirect_clique")
@@ -2444,7 +2447,7 @@ impl DeviceConfig {
             .unwrap_or_default();
         Ok(DeviceConfig {
             pci_common,
-            path: Some(path),
+            path,
             fd,
             x_nv_gpudirect_clique,
             x_exclude_mmap_bars,
@@ -2453,6 +2456,18 @@ impl DeviceConfig {
 
     pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
         self.pci_common.validate(vm_config)?;
+
+        match (&self.path, self.fd) {
+            (None, None) => return Err(ValidationError::VfioDeviceNeitherPathNorFd),
+            (Some(_), Some(_)) => return Err(ValidationError::VfioDeviceBothPathAndFd),
+            (None, Some(_)) => {
+                let iommufd_on = vm_config.platform.as_ref().is_some_and(|p| p.iommufd);
+                if !iommufd_on {
+                    return Err(ValidationError::VfioFdRequiresIommufd);
+                }
+            }
+            (Some(_), None) => {}
+        }
 
         if self.x_nv_gpudirect_clique.is_some() {
             let vfio_p2p_dma = vm_config.platform.as_ref().is_none_or(|p| p.vfio_p2p_dma);
@@ -4733,8 +4748,15 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
 
     #[test]
     fn test_device_parsing() -> Result<()> {
-        // Device must have a path provided
-        DeviceConfig::parse("").unwrap_err();
+        // The parser itself is purely syntactic; the "path or fd is
+        // required" rule is enforced by VmConfig::validate instead.
+        assert_eq!(
+            DeviceConfig::parse("")?,
+            DeviceConfig {
+                path: None,
+                ..device_fixture()
+            }
+        );
         assert_eq!(
             DeviceConfig::parse("path=/path/to/device")?,
             device_fixture()
@@ -4786,6 +4808,27 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
                 ..device_fixture()
             }
         );
+
+        // `fd=` is accepted alongside or in place of `path=`; exclusivity
+        // is enforced by DeviceConfig::validate, not by the parser.
+        assert_eq!(
+            DeviceConfig::parse("fd=7")?,
+            DeviceConfig {
+                path: None,
+                fd: Some(7),
+                ..device_fixture()
+            }
+        );
+        assert_eq!(
+            DeviceConfig::parse("path=/path/to/device,fd=7")?,
+            DeviceConfig {
+                fd: Some(7),
+                ..device_fixture()
+            }
+        );
+        // Non-integer fd fails at parse time.
+        DeviceConfig::parse("fd=notanint").unwrap_err();
+
         Ok(())
     }
 
@@ -6101,6 +6144,49 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
             },
         ]);
         invalid_config.validate().unwrap_err();
+
+        // An fd-backed DeviceConfig is only valid with iommufd enabled.
+        let mut fd_valid_config = valid_config.clone();
+        fd_valid_config.platform = Some(PlatformConfig {
+            iommufd: true,
+            ..platform_fixture()
+        });
+        fd_valid_config.devices = Some(vec![DeviceConfig {
+            path: None,
+            fd: Some(7),
+            ..device_fixture()
+        }]);
+        fd_valid_config.validate().unwrap();
+
+        let mut fd_without_iommufd = fd_valid_config.clone();
+        fd_without_iommufd.platform = None;
+        assert!(matches!(
+            fd_without_iommufd.validate(),
+            Err(ValidationError::VfioFdRequiresIommufd),
+        ));
+
+        // Exactly one of path and fd must be set.
+        let mut both_path_and_fd = fd_valid_config.clone();
+        both_path_and_fd.devices = Some(vec![DeviceConfig {
+            path: Some("/device1".into()),
+            fd: Some(7),
+            ..device_fixture()
+        }]);
+        assert!(matches!(
+            both_path_and_fd.validate(),
+            Err(ValidationError::VfioDeviceBothPathAndFd),
+        ));
+
+        let mut neither_path_nor_fd = fd_valid_config.clone();
+        neither_path_nor_fd.devices = Some(vec![DeviceConfig {
+            path: None,
+            fd: None,
+            ..device_fixture()
+        }]);
+        assert!(matches!(
+            neither_path_nor_fd.validate(),
+            Err(ValidationError::VfioDeviceNeitherPathNorFd),
+        ));
         #[cfg(feature = "sev_snp")]
         {
             // Payload with empty host data

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3892,7 +3892,7 @@ impl DeviceManager {
             .try_clone()
             .map_err(DeviceManagerError::VfioCreate)?;
 
-        let iommufd = self
+        let iommufd_on = self
             .config
             .lock()
             .unwrap()
@@ -3900,11 +3900,40 @@ impl DeviceManager {
             .as_ref()
             .is_some_and(|p| p.iommufd);
 
-        if iommufd {
+        if iommufd_on {
             #[cfg(feature = "kvm")]
             {
-                info!("Using vfio cdev mode with iommufd.");
-                let iommufd = IommuFd::new().map_err(DeviceManagerError::IommufdCreate)?;
+                let iommufd_fd = self
+                    .config
+                    .lock()
+                    .unwrap()
+                    .platform
+                    .as_ref()
+                    .and_then(|p| p.iommufd_fd);
+                let iommufd = match iommufd_fd {
+                    Some(fd) => {
+                        info!("Using vfio cdev mode with externally-supplied iommufd fd: {fd}.");
+                        // Dup so the IommuFd owns its own File; the
+                        // caller-supplied fd is kept alive across reboot
+                        // via VmConfig::preserved_fds.
+                        // SAFETY: FFI call to dup. Trivially safe.
+                        let dup_fd = unsafe { libc::dup(fd) };
+                        if dup_fd < 0 {
+                            return Err(DeviceManagerError::VfioDupFd(io::Error::last_os_error()));
+                        }
+                        // SAFETY: dup_fd is valid and can be owned by this File
+                        let file = unsafe { File::from_raw_fd(dup_fd) };
+                        // SAFETY: fd is a valid open iommufd
+                        unsafe {
+                            self.config.lock().unwrap().add_preserved_fds(vec![fd]);
+                        }
+                        IommuFd::new_from_fd(file)
+                    }
+                    None => {
+                        info!("Using vfio cdev mode with iommufd.");
+                        IommuFd::new().map_err(DeviceManagerError::IommufdCreate)?
+                    }
+                };
                 let vfio_iommufd = VfioIommufd::new(Arc::new(iommufd), None, Some(Arc::new(dup)))
                     .map_err(DeviceManagerError::VfioCreate)?;
                 Ok(Arc::new(vfio_iommufd))
@@ -3933,15 +3962,26 @@ impl DeviceManager {
         fd: i32,
         vfio_ops: Arc<dyn VfioOps>,
     ) -> DeviceManagerResult<(VfioDevice, PathBuf)> {
-        assert!(
-            self.config
-                .lock()
-                .unwrap()
-                .platform
+        let already_bound = {
+            let config = self.config.lock().unwrap();
+            assert!(
+                config.platform.as_ref().is_some_and(|p| p.iommufd),
+                "DeviceConfig::validate enforces iommufd when fd is set",
+            );
+            assert!(
+                config
+                    .platform
+                    .as_ref()
+                    .is_some_and(|p| p.iommufd_fd.is_some()),
+                "DeviceConfig::validate enforces iommufd_fd when device fd is set",
+            );
+            // If a cdev fd was preserved on a prior boot, it is already bound
+            // to an iommufd instance
+            config
+                .preserved_fds
                 .as_ref()
-                .is_some_and(|p| p.iommufd),
-            "DeviceConfig::validate enforces iommufd when fd is set",
-        );
+                .is_some_and(|s| s.contains(&fd))
+        };
 
         // SAFETY: FFI call to dup. Trivially safe.
         let dup_fd = unsafe { libc::dup(fd) };
@@ -3950,8 +3990,11 @@ impl DeviceManager {
         }
         // SAFETY: dup_fd is a freshly-opened fd owned by this File.
         let file = unsafe { File::from_raw_fd(dup_fd) };
-        let vfio_device =
-            VfioDevice::new_from_fd(file, vfio_ops).map_err(DeviceManagerError::VfioCreate)?;
+        let vfio_device = if already_bound {
+            VfioDevice::new_from_bound_fd(file, vfio_ops).map_err(DeviceManagerError::VfioCreate)?
+        } else {
+            VfioDevice::new_from_fd(file, vfio_ops).map_err(DeviceManagerError::VfioCreate)?
+        };
 
         // SAFETY: fd is a valid open vfio cdev FD; the VfioDevice only
         // holds a dup, so VmConfig can safely take ownership of the

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -10,6 +10,8 @@
 //
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+#[cfg(feature = "kvm")]
+use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io::{self, IsTerminal, Seek, SeekFrom, stdout};
 use std::num::Wrapping;
@@ -375,6 +377,10 @@ pub enum DeviceManagerError {
     /// Cannot create a VFIO device
     #[error("Cannot create a VFIO device")]
     VfioCreate(#[source] vfio_ioctls::VfioError),
+
+    /// Failed to duplicate an externally-provided vfio cdev FD
+    #[error("Failed to duplicate VFIO device FD")]
+    VfioDupFd(#[source] io::Error),
 
     /// Cannot create a VFIO PCI device
     #[error("Cannot create a VFIO PCI device")]
@@ -3913,6 +3919,54 @@ impl DeviceManager {
         }
     }
 
+    // Build a VfioDevice from an externally-opened vfio cdev FD:
+    // The caller's FD is dup'd so the dup can be owned (and closed
+    // on drop) by the VfioDevice, while the original FD is kept alive
+    // for the lifetime of the VM via VmConfig::preserved_fds. This
+    // lets the cdev FD survive a VM reboot.
+    //
+    // Returns the built VfioDevice together with a diagnostic path
+    // resolved from /proc/self/fd/<n>.
+    #[cfg(feature = "kvm")]
+    fn create_vfio_device_from_fd(
+        &self,
+        fd: i32,
+        vfio_ops: Arc<dyn VfioOps>,
+    ) -> DeviceManagerResult<(VfioDevice, PathBuf)> {
+        assert!(
+            self.config
+                .lock()
+                .unwrap()
+                .platform
+                .as_ref()
+                .is_some_and(|p| p.iommufd),
+            "DeviceConfig::validate enforces iommufd when fd is set",
+        );
+
+        // SAFETY: FFI call to dup. Trivially safe.
+        let dup_fd = unsafe { libc::dup(fd) };
+        if dup_fd < 0 {
+            return Err(DeviceManagerError::VfioDupFd(io::Error::last_os_error()));
+        }
+        // SAFETY: dup_fd is a freshly-opened fd owned by this File.
+        let file = unsafe { File::from_raw_fd(dup_fd) };
+        let vfio_device =
+            VfioDevice::new_from_fd(file, vfio_ops).map_err(DeviceManagerError::VfioCreate)?;
+
+        // SAFETY: fd is a valid open vfio cdev FD; the VfioDevice only
+        // holds a dup, so VmConfig can safely take ownership of the
+        // original.
+        unsafe {
+            self.config.lock().unwrap().add_preserved_fds(vec![fd]);
+        }
+
+        // Diagnostic-only: resolve the FD back to the path it was opened
+        // from, falling back to /proc/self/fd/<n>.
+        let fd_link = PathBuf::from(format!("/proc/self/fd/{fd}"));
+        let device_path = fs::read_link(&fd_link).unwrap_or(fd_link);
+        Ok((vfio_device, device_path))
+    }
+
     fn add_vfio_device(
         &mut self,
         device_cfg: &mut DeviceConfig,
@@ -3976,13 +4030,25 @@ impl DeviceManager {
             vfio_ops
         };
 
-        // The CLI parser and OpenAPI spec enforce that `path` is set
-        let device_path = device_cfg
-            .path
-            .as_deref()
-            .expect("DeviceConfig::parse enforces a path");
-        let vfio_device = VfioDevice::new(device_path, Arc::clone(&vfio_ops) as Arc<dyn VfioOps>)
-            .map_err(DeviceManagerError::VfioCreate)?;
+        let (vfio_device, device_path) = match (&device_cfg.path, device_cfg.fd) {
+            (Some(path), None) => {
+                let vfio_device = VfioDevice::new(path, Arc::clone(&vfio_ops) as Arc<dyn VfioOps>)
+                    .map_err(DeviceManagerError::VfioCreate)?;
+                (vfio_device, path.clone())
+            }
+            (None, Some(fd)) => {
+                #[cfg(feature = "kvm")]
+                {
+                    self.create_vfio_device_from_fd(fd, Arc::clone(&vfio_ops) as Arc<dyn VfioOps>)?
+                }
+                #[cfg(not(feature = "kvm"))]
+                {
+                    let _ = fd;
+                    return Err(DeviceManagerError::IommufdNotSupported);
+                }
+            }
+            _ => unreachable!("DeviceConfig::validate enforces exactly one of path/fd"),
+        };
 
         if needs_dma_mapping {
             // Register DMA mapping in IOMMU.
@@ -4067,7 +4133,7 @@ impl DeviceManager {
                 .iter()
                 .map(|bar| *bar as u8)
                 .collect(),
-            device_path.to_path_buf(),
+            device_path,
         )
         .map_err(DeviceManagerError::VfioPciCreate)?;
 
@@ -4942,6 +5008,27 @@ impl DeviceManager {
                 | VirtioDeviceType::Fs
                 | VirtioDeviceType::Vsock => {}
                 _ => return Err(DeviceManagerError::RemovalNotAllowed(device_type)),
+            }
+        } else if matches!(pci_device_handle, PciDeviceHandle::Vfio(_)) {
+            // Cleanup externally-provided VFIO cdev FDs: remove the preserved
+            // original from VmConfig and close it.
+            let mut config = self.config.lock().unwrap();
+            if let Some(devices) = config.devices.as_deref_mut()
+                && let Some(device_cfg) = devices
+                    .iter_mut()
+                    .find(|d| d.pci_common.id.as_deref() == Some(id))
+                && let Some(fd) = device_cfg.fd.take()
+            {
+                debug!("Closing preserved FD from VFIO device: id={id}, fd={fd}");
+                let fd_removed = config.preserved_fds.as_mut().unwrap().remove(&fd);
+                assert!(
+                    fd_removed,
+                    "FD {fd} for device id={id} was not in preserved_fds"
+                );
+                // SAFETY: We are closing the only remaining instance of this FD.
+                unsafe {
+                    libc::close(fd);
+                }
             }
         }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3976,9 +3976,13 @@ impl DeviceManager {
             vfio_ops
         };
 
-        let vfio_device =
-            VfioDevice::new(&device_cfg.path, Arc::clone(&vfio_ops) as Arc<dyn VfioOps>)
-                .map_err(DeviceManagerError::VfioCreate)?;
+        // The CLI parser and OpenAPI spec enforce that `path` is set
+        let device_path = device_cfg
+            .path
+            .as_deref()
+            .expect("DeviceConfig::parse enforces a path");
+        let vfio_device = VfioDevice::new(device_path, Arc::clone(&vfio_ops) as Arc<dyn VfioOps>)
+            .map_err(DeviceManagerError::VfioCreate)?;
 
         if needs_dma_mapping {
             // Register DMA mapping in IOMMU.
@@ -4063,7 +4067,7 @@ impl DeviceManager {
                 .iter()
                 .map(|bar| *bar as u8)
                 .collect(),
-            device_cfg.path.clone(),
+            device_path.to_path_buf(),
         )
         .map_err(DeviceManagerError::VfioPciCreate)?;
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -123,6 +123,7 @@ mod kvm {
 
 mod iommufd {
     // See include/uapi/linux/iommufd.h in the kernel code.
+    pub const IOMMU_DESTROY: u64 = 0x3b80;
     pub const IOMMU_IOAS_ALLOC: u64 = 0x3b81;
     pub const IOMMU_IOAS_MAP: u64 = 0x3b85;
     pub const IOMMU_IOAS_UNMAP: u64 = 0x3b86;
@@ -284,6 +285,7 @@ fn create_vmm_ioctl_seccomp_rule_common_kvm() -> Result<Vec<SeccompRule>, Backen
 fn create_vmm_ioctl_seccomp_rule_iommufd() -> Result<Vec<SeccompRule>, BackendError> {
     use iommufd::*;
     Ok(or![
+        and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_DESTROY)?],
         and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_ALLOC)?],
         and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_MAP)?],
         and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_UNMAP)?],
@@ -838,6 +840,7 @@ fn create_vcpu_ioctl_seccomp_rule_hypervisor(
 fn create_vcpu_ioctl_seccomp_rule_iommufd() -> Result<Vec<SeccompRule>, BackendError> {
     use iommufd::*;
     Ok(or![
+        and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_DESTROY)?],
         and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_MAP)?],
         and![Cond::new(1, ArgLen::Dword, Eq, IOMMU_IOAS_UNMAP)?],
         and![Cond::new(

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -159,6 +159,9 @@ pub struct PlatformConfig {
     pub sev_snp: bool,
     #[serde(default)]
     pub iommufd: bool,
+    // FDs are not serialized and any deserialized value is invalid; see NetConfig::fds.
+    #[serde(default, deserialize_with = "deserialize_platformconfig_iommufd_fd")]
+    pub iommufd_fd: Option<i32>,
     #[serde(default = "default_platformconfig_vfio_p2p_dma")]
     pub vfio_p2p_dma: bool,
 }
@@ -204,6 +207,21 @@ impl PlatformConfig {
         };
 
         (!smbios.is_empty()).then_some(smbios)
+    }
+}
+
+fn deserialize_platformconfig_iommufd_fd<'de, D>(d: D) -> Result<Option<i32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let invalid_fd: Option<i32> = Option::deserialize(d)?;
+    if invalid_fd.is_some() {
+        debug!(
+            "FD in 'PlatformConfig::iommufd_fd' won't be deserialized as it is most likely invalid now. Deserializing it as -1."
+        );
+        Ok(Some(-1))
+    } else {
+        Ok(None)
     }
 }
 

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -786,10 +786,11 @@ where
 
 impl ApplyLandlock for DeviceConfig {
     fn apply_landlock(&self, landlock: &mut Landlock) -> LandlockResult<()> {
-        let path = self
-            .path
-            .as_deref()
-            .expect("DeviceConfig::parse and OpenAPI spec enforce a path");
+        // When the device is supplied via an externally-opened FD, there is no
+        // path to grant access to: the file is already open. Skip the rule.
+        let Some(path) = self.path.as_deref() else {
+            return Ok(());
+        };
         let device_path = fs::read_link(path).map_err(LandlockError::OpenPath)?;
         let iommu_group = device_path.file_name();
         let iommu_group_str = iommu_group

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -760,10 +760,28 @@ pub struct DeviceConfig {
     pub pci_common: PciDeviceCommonConfig,
     #[serde(default)]
     pub path: Option<PathBuf>,
+    // FDs are not serialized and any deserialized value is invalid; see NetConfig::fds.
+    #[serde(default, deserialize_with = "deserialize_deviceconfig_fd")]
+    pub fd: Option<i32>,
     #[serde(default)]
     pub x_nv_gpudirect_clique: Option<u8>,
     #[serde(default)]
     pub x_exclude_mmap_bars: Vec<u64>,
+}
+
+fn deserialize_deviceconfig_fd<'de, D>(d: D) -> Result<Option<i32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let invalid_fd: Option<i32> = Option::deserialize(d)?;
+    if invalid_fd.is_some() {
+        debug!(
+            "FD in 'DeviceConfig' won't be deserialized as it is most likely invalid now. Deserializing it as -1."
+        );
+        Ok(Some(-1))
+    } else {
+        Ok(None)
+    }
 }
 
 impl ApplyLandlock for DeviceConfig {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -758,7 +758,8 @@ impl ApplyLandlock for DebugConsoleConfig {
 pub struct DeviceConfig {
     #[serde(flatten)]
     pub pci_common: PciDeviceCommonConfig,
-    pub path: PathBuf,
+    #[serde(default)]
+    pub path: Option<PathBuf>,
     #[serde(default)]
     pub x_nv_gpudirect_clique: Option<u8>,
     #[serde(default)]
@@ -767,7 +768,11 @@ pub struct DeviceConfig {
 
 impl ApplyLandlock for DeviceConfig {
     fn apply_landlock(&self, landlock: &mut Landlock) -> LandlockResult<()> {
-        let device_path = fs::read_link(self.path.as_path()).map_err(LandlockError::OpenPath)?;
+        let path = self
+            .path
+            .as_deref()
+            .expect("DeviceConfig::parse and OpenAPI spec enforce a path");
+        let device_path = fs::read_link(path).map_err(LandlockError::OpenPath)?;
         let iommu_group = device_path.file_name();
         let iommu_group_str = iommu_group
             .ok_or(LandlockError::InvalidPath)?


### PR DESCRIPTION
Enable cloud-hypervisor to consume pre-opened VFIO cdev and iommufd file descriptors supplied by the caller, rather than always opening them itself from sysfs and /dev/iommu. This lets a privileged orchestrator open and configure the device nodes once and hand the FDs to an unprivileged VMM, both at boot (CLI) and at runtime (HTTP API). It is also a prerequisite for live migration for VMs using VFIO devices, where the destination VM cannot be tied to the exact sysfs device node on the source host.

