### PR TITLE
arch: Correctly set guest physical address space size for AMD

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -1413,27 +1413,15 @@ pub fn initramfs_load_addr(
     Ok(aligned_addr)
 }
 
-pub fn get_host_cpu_phys_bits(hypervisor: &dyn hypervisor::Hypervisor) -> u8 {
+pub fn get_host_cpu_phys_bits(_hypervisor: &dyn hypervisor::Hypervisor) -> u8 {
     // SAFETY: call cpuid with valid leaves
     #[allow(unused_unsafe)]
     unsafe {
         let leaf = x86_64::__cpuid(0x8000_0000);
 
-        // Detect and handle AMD SME (Secure Memory Encryption) properly.
-        // Some physical address bits may become reserved when the feature is enabled.
-        // See AMD64 Architecture Programmer's Manual Volume 2, Section 7.10.1
-        let reduced = if leaf.eax >= 0x8000_001f
-            && matches!(hypervisor.get_cpu_vendor(), CpuVendor::AMD)
-            && x86_64::__cpuid(0x8000_001f).eax & 0x1 != 0
-        {
-            (x86_64::__cpuid(0x8000_001f).ebx >> 6) & 0x3f
-        } else {
-            0
-        };
-
         if leaf.eax >= 0x8000_0008 {
             let leaf = x86_64::__cpuid(0x8000_0008);
-            ((leaf.eax & 0xff) - reduced) as u8
+            (leaf.eax & 0xff) as u8
         } else {
             36
         }

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -808,9 +808,11 @@ fn required_common_cpuid_updates(
                 entry.ecx = leaf.ecx;
                 entry.edx = leaf.edx;
             }
-            // Set CPU physical bits
+            // Set CPU physical bits and guest physical bits
             0x8000_0008 => {
-                entry.eax = (entry.eax & 0xffff_ff00) | (config.phys_bits as u32 & 0xff);
+                entry.eax = (entry.eax & 0xff00_ff00)
+                    | (config.phys_bits as u32 & 0xff)
+                    | ((config.phys_bits as u32 & 0xff) << 16);
             }
             0x4000_0001 => {
                 // Enable KVM_FEATURE_MSI_EXT_DEST_ID. This allows the guest to target


### PR DESCRIPTION
We've seen a guest boot hang when running VMs with Oak stage0 firmware on EC2 c6a.metal instances.

The root cause seems to be that cloud-hypervisor sets CPUID 0x80000008 PhysAddrSize (bits 7:0) to 43 (after SME c-bit reduction) but leaves GuestPhysAddrSize (bits 23:16) at the host default value of 48. Stage0 reads GuestPhysAddrSize to determine the guest address space and places PCI BARs near the top of 48-bit space. 
```
  stage0 DEBUG:   BAR0: memory, 64-bit pref, size 524288
  stage0 DEBUG:     assigning [0x0000ff8000000000-0x0000ff8000080000)
```

Cloud-hypervisor's MMIO bus only covers 43 bits (mem64 area ends at 0x7ffffeeffff), so those devices are unreachable.
```
Failed moving device BAR: failed allocating new MMIO range: 0x7ffff800000->0xff8000000000(0x80000), keeping old BAR
```

The fix sets both CPUID fields to the same value.

With the second commit we get rid of the reduction to the physical address space size, which doesn't seem to be needed, and just cuts the address space to 43 bits.