### PR TITLE
virtio-devices: Signal NEEDS_RESET

### DIFF
--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -40,9 +40,9 @@ use vmm_sys_util::eventfd::EventFd;
 use super::pci_common_config::VirtioPciCommonConfigState;
 use crate::transport::{VIRTIO_PCI_COMMON_CONFIG_ID, VirtioPciCommonConfig, VirtioTransport};
 use crate::{
-    ActivateResult, DEVICE_ACKNOWLEDGE, DEVICE_DRIVER, DEVICE_DRIVER_OK, DEVICE_FAILED,
-    DEVICE_FEATURES_OK, DEVICE_INIT, GuestMemoryMmap, VirtioDevice, VirtioDeviceType,
-    VirtioInterrupt, VirtioInterruptType,
+    ActivateResult, ActivationContext, DEVICE_ACKNOWLEDGE, DEVICE_DRIVER, DEVICE_DRIVER_OK,
+    DEVICE_FAILED, DEVICE_FEATURES_OK, DEVICE_INIT, GuestMemoryMmap, VirtioDevice,
+    VirtioDeviceType, VirtioInterrupt, VirtioInterruptType, mark_device_needs_reset,
 };
 
 /// Vector value used to disable MSI for a queue.
@@ -331,22 +331,32 @@ pub struct VirtioPciDeviceActivator {
 
 impl VirtioPciDeviceActivator {
     pub fn activate(mut self) -> ActivateResult {
-        let mut locked_device = self.device.lock().unwrap();
-        locked_device.activate(crate::device::ActivationContext {
+        let result = self.device.lock().unwrap().activate(ActivationContext {
             mem: self.memory.take().unwrap(),
-            interrupt_cb: self.interrupt,
+            interrupt_cb: self.interrupt.clone(),
             queues: self.queues.take().unwrap(),
-            device_status: self.status,
-        })?;
-        self.device_activated.store(true, Ordering::SeqCst);
+            device_status: self.status.clone(),
+        });
 
+        if let Err(e) = &result {
+            mark_device_needs_reset(
+                &self.status,
+                self.interrupt.as_ref(),
+                format_args!("{}: virtio device activation failed: {e:?}", self.id),
+            );
+        } else {
+            self.device_activated.store(true, Ordering::SeqCst);
+        }
+
+        // Release the barrier regardless of outcome. A failing activate()
+        // would otherwise deadlock the vCPU that wrote DRIVER_OK.
         if let Some(barrier) = self.barrier.take() {
             info!("{}: Waiting for barrier", self.id);
             barrier.wait();
             info!("{}: Barrier released", self.id);
         }
 
-        Ok(())
+        result
     }
 }
 

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1365,6 +1365,7 @@ mod unit_tests {
     use vm_device::interrupt::InterruptSourceConfig;
 
     use super::*;
+    use crate::{ActivateError, DEVICE_NEEDS_RESET};
 
     struct TestInterruptSourceGroup {
         event_fd: EventFd,
@@ -1593,5 +1594,31 @@ mod unit_tests {
             status: status.clone(),
         };
         (activator, status, device_activated, interrupt, barrier)
+    }
+
+    #[test]
+    fn activate_failure_marks_needs_reset_and_releases_barrier() {
+        let (activator, status, device_activated, interrupt, barrier) =
+            make_activator(Err(ActivateError::BadActivate));
+
+        // Simulate the vCPU thread blocked on the activation
+        // barrier after writing DRIVER_OK.
+        let waiter = std::thread::spawn(move || barrier.wait());
+
+        let result = activator.activate();
+
+        assert!(matches!(result, Err(ActivateError::BadActivate)));
+        assert!(!device_activated.load(Ordering::SeqCst));
+        assert_ne!(
+            status.load(Ordering::SeqCst) & (DEVICE_NEEDS_RESET as u8),
+            0
+        );
+        let triggers = interrupt.triggers.lock().unwrap();
+        assert_eq!(triggers.len(), 1);
+        assert!(matches!(triggers[0], VirtioInterruptType::Config));
+
+        // The barrier waiter must complete, showing the activator
+        // did not deadlock the vCPU thread.
+        waiter.join().expect("barrier waiter deadlocked");
     }
 }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1525,4 +1525,73 @@ mod unit_tests {
         assert_eq!(bar_offset, 0);
         assert_eq!(access_len, 2);
     }
+
+    struct TestVirtioDevice {
+        result: Mutex<Option<ActivateResult>>,
+    }
+
+    impl VirtioDevice for TestVirtioDevice {
+        fn device_type(&self) -> u32 {
+            0
+        }
+        fn queue_max_sizes(&self) -> &[u16] {
+            &[]
+        }
+        fn activate(&mut self, _context: crate::device::ActivationContext) -> ActivateResult {
+            self.result.lock().unwrap().take().unwrap()
+        }
+    }
+
+    struct TestVirtioInterrupt {
+        triggers: Mutex<Vec<VirtioInterruptType>>,
+    }
+
+    impl VirtioInterrupt for TestVirtioInterrupt {
+        fn trigger(&self, int_type: VirtioInterruptType) -> std::io::Result<()> {
+            self.triggers.lock().unwrap().push(int_type);
+            Ok(())
+        }
+        fn set_notifier(
+            &self,
+            _int_type: u32,
+            _notifier: Option<EventFd>,
+            _vm: &dyn hypervisor::Vm,
+        ) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn make_activator(
+        result: ActivateResult,
+    ) -> (
+        VirtioPciDeviceActivator,
+        Arc<AtomicU8>,
+        Arc<AtomicBool>,
+        Arc<TestVirtioInterrupt>,
+        Arc<Barrier>,
+    ) {
+        let interrupt = Arc::new(TestVirtioInterrupt {
+            triggers: Mutex::new(Vec::new()),
+        });
+        let status = Arc::new(AtomicU8::new(DEVICE_DRIVER_OK as u8));
+        let device_activated = Arc::new(AtomicBool::new(false));
+        let device = Arc::new(Mutex::new(TestVirtioDevice {
+            result: Mutex::new(Some(result)),
+        }));
+        let memory = GuestMemoryAtomic::new(
+            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap(),
+        );
+        let barrier = Arc::new(Barrier::new(2));
+        let activator = VirtioPciDeviceActivator {
+            interrupt: interrupt.clone(),
+            memory: Some(memory),
+            device,
+            device_activated: device_activated.clone(),
+            queues: Some(Vec::new()),
+            barrier: Some(barrier.clone()),
+            id: "test-dev".to_string(),
+            status: status.clone(),
+        };
+        (activator, status, device_activated, interrupt, barrier)
+    }
 }

--- a/virtio-devices/src/transport/pci_device.rs
+++ b/virtio-devices/src/transport/pci_device.rs
@@ -1621,4 +1621,25 @@ mod unit_tests {
         // did not deadlock the vCPU thread.
         waiter.join().expect("barrier waiter deadlocked");
     }
+
+    #[test]
+    fn activate_success_sets_activated_and_does_not_signal_reset() {
+        let (activator, status, device_activated, interrupt, barrier) = make_activator(Ok(()));
+        let initial_status = status.load(Ordering::SeqCst);
+
+        let waiter = std::thread::spawn(move || barrier.wait());
+
+        let result = activator.activate();
+
+        result.unwrap();
+        assert!(device_activated.load(Ordering::SeqCst));
+        assert_eq!(
+            status.load(Ordering::SeqCst) & (DEVICE_NEEDS_RESET as u8),
+            0
+        );
+        assert_eq!(status.load(Ordering::SeqCst), initial_status);
+        assert!(interrupt.triggers.lock().unwrap().is_empty());
+
+        waiter.join().expect("barrier waiter deadlocked");
+    }
 }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -88,8 +88,7 @@ use vfio_ioctls::{VfioContainer, VfioDevice, VfioDeviceFd, VfioOps};
 use virtio_devices::transport::{VirtioPciDevice, VirtioPciDeviceActivator, VirtioTransport};
 use virtio_devices::vhost_user::VhostUserConfig;
 use virtio_devices::{
-    AccessPlatformMapping, ActivateError, Block, Endpoint, IommuMapping, VdpaDmaMapping,
-    VirtioMemMappingSource,
+    AccessPlatformMapping, Block, Endpoint, IommuMapping, VdpaDmaMapping, VirtioMemMappingSource,
 };
 use vm_allocator::{AddressAllocator, InterruptAllocError, SystemAllocator};
 use vm_device::dma_mapping::ExternalDmaMapping;
@@ -628,10 +627,6 @@ pub enum DeviceManagerError {
     /// vfio-user socket path already in use by another user device.
     #[error("vfio-user socket path already in use: {0:?}")]
     UserDeviceSocketInUse(std::path::PathBuf),
-
-    /// Error activating virtio device
-    #[error("Error activating virtio device")]
-    VirtioActivate(#[source] ActivateError),
 
     /// Failed retrieving device state from snapshot
     #[error("Failed retrieving device state from snapshot")]
@@ -4699,9 +4694,9 @@ impl DeviceManager {
 
     pub fn activate_virtio_devices(&self) -> DeviceManagerResult<()> {
         for activator in self.pending_activations.lock().unwrap().drain(..) {
-            activator
-                .activate()
-                .map_err(DeviceManagerError::VirtioActivate)?;
+            // Failures are logged and signalled to the guest via
+            // NEEDS_RESET by the activator, hence keep going.
+            let _ = activator.activate();
         }
         Ok(())
     }


### PR DESCRIPTION
When a virtio device fails to activate after the guest writes DRIVER_OK, the VMM bubbles the error up and never releases the activation barrier. The vCPU stays blocked and the guest deadlocks.

The fix is to signal `DEVICE_NEEDS_RESET`, deliver a config change interrupt, and release the activation barrier so the guest can recover.