### PR TITLE
virtio-devices: Refactor virtio worker thread handling

### DIFF
--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -39,7 +39,6 @@ use vm_virtio::checked_descriptor::DescriptorChainExt;
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::{
     ActivateResult, EPOLL_HELPER_EVENT_LAST, EpollHelper, EpollHelperError, EpollHelperHandler,
     GuestMemoryMmap, VIRTIO_F_ACCESS_PLATFORM, VIRTIO_F_VERSION_1, VirtioCommon, VirtioDevice,
@@ -688,19 +687,16 @@ impl VirtioDevice for Balloon {
 
         let paused = self.common.paused.clone();
         let paused_sync = self.common.paused_sync.clone();
-        let mut epoll_threads = Vec::new();
 
-        spawn_virtio_thread(
+        self.common.spawn_worker(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioBalloon,
-            &mut epoll_threads,
             &self.exit_evt,
             device_status.clone(),
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-        self.common.epoll_threads = Some(epoll_threads);
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -644,7 +644,7 @@ impl VirtioDevice for Balloon {
             device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
-        let (kill_evt, pause_evt) = self.common.dup_eventfds();
+        let (kill_evt, pause_evt) = self.common.dup_eventfds()?;
 
         let mut virtqueues = Vec::new();
         let (_, queue, queue_evt) = queues.remove(0);

--- a/virtio-devices/src/balloon.rs
+++ b/virtio-devices/src/balloon.rs
@@ -583,16 +583,6 @@ impl Balloon {
     }
 }
 
-impl Drop for Balloon {
-    fn drop(&mut self) {
-        if let Some(kill_evt) = self.common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-        self.common.wait_for_epoll_threads();
-    }
-}
-
 impl VirtioDevice for Balloon {
     fn device_type(&self) -> u32 {
         self.common.device_type

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -51,7 +51,6 @@ use super::{
     VirtioInterruptType,
 };
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::{GuestMemoryMmap, VirtioInterrupt};
 
 const SECTOR_SHIFT: u8 = 9;
@@ -405,7 +404,7 @@ impl BlockEpollHandler {
             Ok(()) => {}
             Err(e @ (Error::QueueIterator(_) | Error::QueueDuplicatedHeadIndex)) => {
                 // Virtqueue is corrupted or guest driver is misbehaving; exit
-                // the worker so spawn_virtio_thread marks the device NEEDS_RESET.
+                // the worker so spawn_worker marks the device NEEDS_RESET.
                 return Err(EpollHelperError::HandleEvent(anyhow!(
                     "Failed to process queue (submit): {e}"
                 )));
@@ -1108,7 +1107,6 @@ impl VirtioDevice for Block {
         let writeback = self.is_writeback_enabled(self.config.writeback == 1);
         self.set_writeback_mode(writeback);
 
-        let mut epoll_threads = Vec::new();
         let event_idx = self.common.feature_acked(VIRTIO_RING_F_EVENT_IDX.into());
 
         for i in 0..queues.len() {
@@ -1157,11 +1155,10 @@ impl VirtioDevice for Block {
             let paused = self.common.paused.clone();
             let paused_sync = self.common.paused_sync.clone();
 
-            spawn_virtio_thread(
+            self.common.spawn_worker(
                 &format!("{}_q{}", self.id.clone(), i),
                 &self.seccomp_action,
                 Thread::VirtioBlock,
-                &mut epoll_threads,
                 &self.exit_evt,
                 self.device_status.clone(),
                 interrupt_cb.clone(),
@@ -1169,7 +1166,6 @@ impl VirtioDevice for Block {
             )?;
         }
 
-        self.common.epoll_threads = Some(epoll_threads);
         event!("virtio-device", "activated", "id", &self.id);
 
         Ok(())

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -1104,7 +1104,7 @@ impl VirtioDevice for Block {
             queue.set_event_idx(event_idx);
 
             let queue_size = queue.size();
-            let (kill_evt, pause_evt) = self.common.dup_eventfds();
+            let (kill_evt, pause_evt) = self.common.dup_eventfds()?;
             let queue_idx = i as u16;
 
             let mut handler = BlockEpollHandler {

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -1035,16 +1035,6 @@ impl Block {
     }
 }
 
-impl Drop for Block {
-    fn drop(&mut self) {
-        if let Some(kill_evt) = self.common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-        self.common.wait_for_epoll_threads();
-    }
-}
-
 impl VirtioDevice for Block {
     fn device_type(&self) -> u32 {
         self.common.device_type

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -729,7 +729,7 @@ impl VirtioDevice for Console {
             error!("Failed to signal console driver: {e:?}");
         }
 
-        let (kill_evt, pause_evt) = self.common.dup_eventfds();
+        let (kill_evt, pause_evt) = self.common.dup_eventfds()?;
 
         let (_, input_queue, input_queue_evt) = queues.remove(0);
         let (_, output_queue, output_queue_evt) = queues.remove(0);

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -690,16 +690,6 @@ impl Console {
     }
 }
 
-impl Drop for Console {
-    fn drop(&mut self) {
-        if let Some(kill_evt) = self.common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-        self.common.wait_for_epoll_threads();
-    }
-}
-
 impl VirtioDevice for Console {
     fn device_type(&self) -> u32 {
         self.common.device_type

--- a/virtio-devices/src/console.rs
+++ b/virtio-devices/src/console.rs
@@ -30,7 +30,6 @@ use super::{
     VirtioDeviceType, VirtioInterruptType,
 };
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::{GuestMemoryMmap, VirtioInterrupt};
 
 const QUEUE_SIZE: u16 = 256;
@@ -764,20 +763,16 @@ impl VirtioDevice for Console {
 
         let paused = self.common.paused.clone();
         let paused_sync = self.common.paused_sync.clone();
-        let mut epoll_threads = Vec::new();
 
-        spawn_virtio_thread(
+        self.common.spawn_worker(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioConsole,
-            &mut epoll_threads,
             &self.exit_evt,
             device_status.clone(),
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-
-        self.common.epoll_threads = Some(epoll_threads);
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -427,16 +427,21 @@ impl VirtioCommon {
         self.workers = None;
     }
 
-    pub fn dup_eventfds(&self) -> (EventFd, EventFd) {
-        (
-            self.workers
-                .as_ref()
-                .unwrap()
-                .kill_evt()
-                .try_clone()
-                .unwrap(),
-            self.pause_evt.as_ref().unwrap().try_clone().unwrap(),
-        )
+    pub fn dup_eventfds(&self) -> Result<(EventFd, EventFd), ActivateError> {
+        let kill_evt = self
+            .workers
+            .as_ref()
+            .ok_or(ActivateError::BadActivate)?
+            .kill_evt()
+            .try_clone()
+            .map_err(ActivateError::CloneEventFd)?;
+        let pause_evt = self
+            .pause_evt
+            .as_ref()
+            .ok_or(ActivateError::BadActivate)?
+            .try_clone()
+            .map_err(ActivateError::CloneEventFd)?;
+        Ok((kill_evt, pause_evt))
     }
 
     pub fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -225,17 +225,70 @@ pub trait DmaRemapping {
     ) -> std::result::Result<u64, std::io::Error>;
 }
 
+/// Owns a device's worker threads plus the kill event that stops them.
+///
+/// Dropping signals every worker to exit, unparks any that are parked, and joins them.
+pub struct WorkerThreads {
+    /// shared kill event, a single write wakes all of them.
+    kill_evt: EventFd,
+    // true if the device is paused.
+    paused: Arc<AtomicBool>,
+    // The running worker thread's handles.
+    threads: Vec<thread::JoinHandle<()>>,
+}
+
+impl WorkerThreads {
+    fn new(kill_evt: EventFd, paused: Arc<AtomicBool>) -> Self {
+        WorkerThreads {
+            kill_evt,
+            paused,
+            threads: Vec::new(),
+        }
+    }
+
+    /// Borrow access to the kill eventfd
+    fn kill_evt(&self) -> &EventFd {
+        &self.kill_evt
+    }
+
+    /// Signal the workers to exit without joining; they are joined later when
+    /// this is dropped.
+    pub(crate) fn signal_exit(&self) -> std::io::Result<()> {
+        self.kill_evt.write(1)
+    }
+
+    /// Unpark every worker so threads parked while paused resume their loop.
+    fn unpark(&self) {
+        for t in &self.threads {
+            t.thread().unpark();
+        }
+    }
+}
+
+impl Drop for WorkerThreads {
+    fn drop(&mut self) {
+        // Signal the workers to exit, wake any parked so they observe it, then join.
+        let _ = self.kill_evt.write(1);
+        self.paused.store(false, Ordering::SeqCst);
+        self.unpark();
+        for t in self.threads.drain(..) {
+            if let Err(e) = t.join() {
+                error!("Error joining thread: {e:?}");
+            }
+        }
+    }
+}
+
 /// Structure to handle device state common to all devices
 #[derive(Default)]
 pub struct VirtioCommon {
     pub avail_features: u64,
     pub acked_features: u64,
-    pub kill_evt: Option<EventFd>,
     pub interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
     pub pause_evt: Option<EventFd>,
     pub paused: Arc<AtomicBool>,
     pub paused_sync: Option<Arc<Barrier>>,
-    pub epoll_threads: Option<Vec<thread::JoinHandle<()>>>,
+    pub workers: Option<WorkerThreads>,
     pub queue_sizes: Vec<u16>,
     pub queue_evts: Vec<EventFd>,
     pub device_type: u32,
@@ -289,7 +342,9 @@ impl VirtioCommon {
             error!("failed creating kill EventFd: {e}");
             ActivateError::BadActivate
         })?;
-        self.kill_evt = Some(kill_evt);
+        // Create the worker collection up front so it owns the kill event;
+        // handlers clone it via dup_eventfds() before any worker is spawned.
+        self.workers = Some(WorkerThreads::new(kill_evt, self.paused.clone()));
 
         let pause_evt = EventFd::new(EFD_NONBLOCK).map_err(|e| {
             error!("failed creating pause EventFd: {e}");
@@ -306,35 +361,21 @@ impl VirtioCommon {
 
     pub fn reset(&mut self) {
         self.queue_evts.clear();
+        self.pause_evt = None;
 
-        // Resume the virtio thread if it was paused. Reset must always
-        // converge to fresh state, so a resume failure is logged but doesn't
-        // skip the rest of the teardown.
-        if self.pause_evt.take().is_some()
-            && let Err(e) = self.resume()
-        {
-            error!("Failed to resume paused device during reset: {e:?}");
-        }
+        // Clear paused explicitly; the workers' Drop does so too, but only
+        // when they exist, and reset may run before activate().
+        self.paused.store(false, Ordering::SeqCst);
 
-        if let Some(kill_evt) = self.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-
-        if let Some(mut threads) = self.epoll_threads.take() {
-            for t in threads.drain(..) {
-                if let Err(e) = t.join() {
-                    error!("Error joining thread: {e:?}");
-                }
-            }
-        }
+        // Dropping the workers signals kill_evt, unparks any thread parked
+        // for migration, and joins them.
+        self.workers = None;
 
         // Drop the interrupt callback clone
         self.interrupt_cb = None;
     }
 
-    /// Spawn a worker, push its handle into `self.epoll_threads`, and on
-    /// spawn failure run `self.reset()` to join prior workers.
+    /// Spawn a worker; on failure, reset the device to join prior workers.
     #[expect(clippy::too_many_arguments)]
     pub fn spawn_worker<F>(
         &mut self,
@@ -349,18 +390,23 @@ impl VirtioCommon {
     where
         F: FnOnce() -> Result<(), EpollHelperError> + Send + 'static,
     {
-        let mut threads = self.epoll_threads.take().unwrap_or_default();
-        let res = spawn_virtio_thread(
-            name,
-            seccomp_action,
-            thread_type,
-            &mut threads,
-            exit_evt,
-            device_status,
-            interrupt_cb,
-            f,
-        );
-        self.epoll_threads = Some(threads);
+        // Scope the borrow of `workers` so it ends before the reset() below.
+        let res = {
+            let Some(workers) = self.workers.as_mut() else {
+                error!("spawn_worker called before activate()");
+                return Err(ActivateError::BadActivate);
+            };
+            spawn_virtio_thread(
+                name,
+                seccomp_action,
+                thread_type,
+                &mut workers.threads,
+                exit_evt,
+                device_status,
+                interrupt_cb,
+                f,
+            )
+        };
         if let Err(e) = res {
             self.reset();
             return Err(e);
@@ -376,20 +422,19 @@ impl VirtioCommon {
         }
     }
 
-    // Wait for the worker thread to finish and return
+    // Dropping the workers signals, unparks, and joins them. Idempotent.
     pub fn wait_for_epoll_threads(&mut self) {
-        if let Some(mut threads) = self.epoll_threads.take() {
-            for t in threads.drain(..) {
-                if let Err(e) = t.join() {
-                    error!("Error joining thread: {e:?}");
-                }
-            }
-        }
+        self.workers = None;
     }
 
     pub fn dup_eventfds(&self) -> (EventFd, EventFd) {
         (
-            self.kill_evt.as_ref().unwrap().try_clone().unwrap(),
+            self.workers
+                .as_ref()
+                .unwrap()
+                .kill_evt()
+                .try_clone()
+                .unwrap(),
             self.pause_evt.as_ref().unwrap().try_clone().unwrap(),
         )
     }
@@ -446,10 +491,8 @@ impl Pausable for VirtioCommon {
             VirtioDeviceType::from(self.device_type)
         );
         self.paused.store(false, Ordering::SeqCst);
-        if let Some(epoll_threads) = &self.epoll_threads {
-            for t in epoll_threads.iter() {
-                t.thread().unpark();
-            }
+        if let Some(workers) = &self.workers {
+            workers.unpark();
         }
 
         // Signal each activated queue eventfd so workers process restored queues
@@ -495,19 +538,23 @@ mod unit_tests {
         }
     }
 
-    fn make_common_with_kill_evt() -> (VirtioCommon, EventFd) {
+    /// VirtioCommon with its worker collection created (as activate() does)
+    /// and a kill_evt clone for the spawned worker to watch.
+    fn make_common_with_workers() -> (VirtioCommon, EventFd) {
         let kill_evt = EventFd::new(EFD_NONBLOCK).unwrap();
         let kill_evt_clone = kill_evt.try_clone().unwrap();
+        let common = VirtioCommon::default();
+        let workers = WorkerThreads::new(kill_evt, common.paused.clone());
         let common = VirtioCommon {
-            kill_evt: Some(kill_evt),
-            ..Default::default()
+            workers: Some(workers),
+            ..common
         };
         (common, kill_evt_clone)
     }
 
     #[test]
-    fn spawn_worker_appends_to_epoll_threads() {
-        let (mut common, kill_evt_clone) = make_common_with_kill_evt();
+    fn spawn_worker_appends_to_workers() {
+        let (mut common, kill_evt_clone) = make_common_with_workers();
         let started = Arc::new(AtomicUsize::new(0));
         let started_clone = started.clone();
 
@@ -530,15 +577,60 @@ mod unit_tests {
             )
             .unwrap();
 
-        let threads = common.epoll_threads.as_ref().expect("epoll_threads set");
-        assert_eq!(threads.len(), 1);
+        let workers = common.workers.as_ref().expect("workers set");
+        assert_eq!(workers.threads.len(), 1);
 
-        // reset() joins the worker; this confirms the spawn_worker
-        // -> reset() chain (used on spawn failure) actually drains
-        // a real, running worker rather than dropping it detached.
+        // reset() drops the WorkerThreads and joins the worker, exercising
+        // the spawn-failure cleanup path on a real running thread.
         common.reset();
-        assert!(common.epoll_threads.is_none());
-        assert!(common.kill_evt.is_none());
+        assert!(common.workers.is_none());
         assert_eq!(started.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn dropping_common_joins_workers() {
+        let (mut common, kill_evt_clone) = make_common_with_workers();
+        let started = Arc::new(AtomicUsize::new(0));
+        let started_clone = started.clone();
+
+        let exit_evt = EventFd::new(EFD_NONBLOCK).unwrap();
+        let status = Arc::new(AtomicU8::new(0));
+
+        common
+            .spawn_worker(
+                "test",
+                &SeccompAction::Allow,
+                Thread::VirtioBlock,
+                &exit_evt,
+                status,
+                Arc::new(NoopInterrupt),
+                move || {
+                    started_clone.fetch_add(1, Ordering::SeqCst);
+                    let _ = kill_evt_clone.read();
+                    Ok(())
+                },
+            )
+            .unwrap();
+
+        // Dropping `common` alone must join the worker via WorkerThreads' Drop.
+        drop(common);
+        assert_eq!(started.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn reset_clears_paused_without_workers() {
+        // reset() before any worker was spawned must still clear paused, or
+        // the next activation's workers would park immediately and never run.
+        let mut common = VirtioCommon {
+            pause_evt: Some(EventFd::new(EFD_NONBLOCK).unwrap()),
+            ..Default::default()
+        };
+        common.paused.store(true, Ordering::SeqCst);
+        assert!(common.workers.is_none());
+
+        common.reset();
+
+        assert!(!common.paused.load(Ordering::SeqCst));
+        assert!(common.pause_evt.is_none());
     }
 }

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -16,6 +16,7 @@ use std::thread;
 use anyhow::anyhow;
 use libc::EFD_NONBLOCK;
 use log::{error, info, warn};
+use seccompiler::SeccompAction;
 use virtio_bindings::virtio_config::VIRTIO_F_ACCESS_PLATFORM;
 use virtio_queue::Queue;
 use vm_device::UserspaceMapping;
@@ -24,6 +25,9 @@ use vm_migration::{MigratableError, Pausable};
 use vm_virtio::{AccessPlatform, VirtioDeviceType};
 use vmm_sys_util::eventfd::EventFd;
 
+use crate::epoll_helper::EpollHelperError;
+use crate::seccomp_filters::Thread;
+use crate::thread_helper::spawn_virtio_thread;
 use crate::{
     ActivateError, ActivateResult, Error, GuestMemoryMmap, GuestRegionMmap, MmapRegion,
     VIRTIO_F_RING_INDIRECT_DESC,
@@ -329,6 +333,41 @@ impl VirtioCommon {
         self.interrupt_cb = None;
     }
 
+    /// Spawn a worker, push its handle into `self.epoll_threads`, and on
+    /// spawn failure run `self.reset()` to join prior workers.
+    #[expect(clippy::too_many_arguments)]
+    pub fn spawn_worker<F>(
+        &mut self,
+        name: &str,
+        seccomp_action: &SeccompAction,
+        thread_type: Thread,
+        exit_evt: &EventFd,
+        device_status: Arc<AtomicU8>,
+        interrupt_cb: Arc<dyn VirtioInterrupt>,
+        f: F,
+    ) -> Result<(), ActivateError>
+    where
+        F: FnOnce() -> Result<(), EpollHelperError> + Send + 'static,
+    {
+        let mut threads = self.epoll_threads.take().unwrap_or_default();
+        let res = spawn_virtio_thread(
+            name,
+            seccomp_action,
+            thread_type,
+            &mut threads,
+            exit_evt,
+            device_status,
+            interrupt_cb,
+            f,
+        );
+        self.epoll_threads = Some(threads);
+        if let Err(e) = res {
+            self.reset();
+            return Err(e);
+        }
+        Ok(())
+    }
+
     pub fn trigger_interrupt(&self, int_type: VirtioInterruptType) -> std::io::Result<()> {
         if let Some(interrupt_cb) = &self.interrupt_cb {
             interrupt_cb.trigger(int_type)
@@ -430,5 +469,76 @@ impl Pausable for VirtioCommon {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use vmm_sys_util::eventfd::EFD_NONBLOCK;
+
+    use super::*;
+
+    struct NoopInterrupt;
+    impl VirtioInterrupt for NoopInterrupt {
+        fn trigger(&self, _: VirtioInterruptType) -> std::io::Result<()> {
+            Ok(())
+        }
+        fn set_notifier(
+            &self,
+            _: u32,
+            _: Option<EventFd>,
+            _: &dyn hypervisor::Vm,
+        ) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn make_common_with_kill_evt() -> (VirtioCommon, EventFd) {
+        let kill_evt = EventFd::new(EFD_NONBLOCK).unwrap();
+        let kill_evt_clone = kill_evt.try_clone().unwrap();
+        let common = VirtioCommon {
+            kill_evt: Some(kill_evt),
+            ..Default::default()
+        };
+        (common, kill_evt_clone)
+    }
+
+    #[test]
+    fn spawn_worker_appends_to_epoll_threads() {
+        let (mut common, kill_evt_clone) = make_common_with_kill_evt();
+        let started = Arc::new(AtomicUsize::new(0));
+        let started_clone = started.clone();
+
+        let exit_evt = EventFd::new(EFD_NONBLOCK).unwrap();
+        let status = Arc::new(AtomicU8::new(0));
+
+        common
+            .spawn_worker(
+                "test",
+                &SeccompAction::Allow,
+                Thread::VirtioBlock,
+                &exit_evt,
+                status,
+                Arc::new(NoopInterrupt),
+                move || {
+                    started_clone.fetch_add(1, Ordering::SeqCst);
+                    let _ = kill_evt_clone.read();
+                    Ok(())
+                },
+            )
+            .unwrap();
+
+        let threads = common.epoll_threads.as_ref().expect("epoll_threads set");
+        assert_eq!(threads.len(), 1);
+
+        // reset() joins the worker; this confirms the spawn_worker
+        // -> reset() chain (used on spawn failure) actually drains
+        // a real, running worker rather than dropping it detached.
+        common.reset();
+        assert!(common.epoll_threads.is_none());
+        assert!(common.kill_evt.is_none());
+        assert_eq!(started.load(Ordering::SeqCst), 1);
     }
 }

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -1252,16 +1252,6 @@ impl Iommu {
     }
 }
 
-impl Drop for Iommu {
-    fn drop(&mut self) {
-        if let Some(kill_evt) = self.common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-        self.common.wait_for_epoll_threads();
-    }
-}
-
 impl VirtioDevice for Iommu {
     fn device_type(&self) -> u32 {
         self.common.device_type

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -1301,7 +1301,7 @@ impl VirtioDevice for Iommu {
             device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
-        let (kill_evt, pause_evt) = self.common.dup_eventfds();
+        let (kill_evt, pause_evt) = self.common.dup_eventfds()?;
 
         let (_, request_queue, request_queue_evt) = queues.remove(0);
         let (_, _event_queue, _event_queue_evt) = queues.remove(0);

--- a/virtio-devices/src/iommu.rs
+++ b/virtio-devices/src/iommu.rs
@@ -30,7 +30,6 @@ use super::{
     Error as DeviceError, VIRTIO_F_VERSION_1, VirtioCommon, VirtioDevice, VirtioDeviceType,
 };
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::{DmaRemapping, GuestMemoryMmap, VirtioInterrupt, VirtioInterruptType};
 
 /// Queues sizes
@@ -1334,19 +1333,15 @@ impl VirtioDevice for Iommu {
 
         let paused = self.common.paused.clone();
         let paused_sync = self.common.paused_sync.clone();
-        let mut epoll_threads = Vec::new();
-        spawn_virtio_thread(
+        self.common.spawn_worker(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioIommu,
-            &mut epoll_threads,
             &self.exit_evt,
             device_status.clone(),
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-
-        self.common.epoll_threads = Some(epoll_threads);
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -108,8 +108,8 @@ const VIRTIO_F_NOTIFICATION_DATA: u32 = 38;
 pub enum ActivateError {
     #[error("Failed to activate virtio device")]
     BadActivate,
-    #[error("Failed to clone exit event fd")]
-    CloneExitEventFd(#[source] std::io::Error),
+    #[error("Failed to clone EventFd")]
+    CloneEventFd(#[source] std::io::Error),
     #[error("Failed to spawn thread")]
     ThreadSpawn(#[source] std::io::Error),
     #[error("Failed to setup vhost-user-fs daemon")]

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -951,7 +951,7 @@ impl VirtioDevice for Mem {
             device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
-        let (kill_evt, pause_evt) = self.common.dup_eventfds();
+        let (kill_evt, pause_evt) = self.common.dup_eventfds()?;
 
         let (_, queue, queue_evt) = queues.remove(0);
 

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -922,16 +922,6 @@ impl Mem {
     }
 }
 
-impl Drop for Mem {
-    fn drop(&mut self) {
-        if let Some(kill_evt) = self.common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-        self.common.wait_for_epoll_threads();
-    }
-}
-
 impl VirtioDevice for Mem {
     fn device_type(&self) -> u32 {
         self.common.device_type

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -43,7 +43,6 @@ use super::{
     VirtioDeviceType,
 };
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::{GuestMemoryMmap, GuestRegionMmap, VirtioInterrupt, VirtioInterruptType};
 
 const QUEUE_SIZE: u16 = 128;
@@ -998,19 +997,16 @@ impl VirtioDevice for Mem {
 
         let paused = self.common.paused.clone();
         let paused_sync = self.common.paused_sync.clone();
-        let mut epoll_threads = Vec::new();
 
-        spawn_virtio_thread(
+        self.common.spawn_worker(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioMem,
-            &mut epoll_threads,
             &self.exit_evt,
             device_status.clone(),
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-        self.common.epoll_threads = Some(epoll_threads);
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -691,7 +691,7 @@ impl VirtioDevice for Net {
 
             ctrl_queue.set_event_idx(event_idx);
 
-            let (kill_evt, pause_evt) = self.common.dup_eventfds();
+            let (kill_evt, pause_evt) = self.common.dup_eventfds()?;
             let mut ctrl_handler = NetCtrlEpollHandler {
                 mem: mem.clone(),
                 kill_evt,
@@ -732,7 +732,7 @@ impl VirtioDevice for Net {
 
             let queue_evt_pair = (queue_evt_0, queue_evt_1);
 
-            let (kill_evt, pause_evt) = self.common.dup_eventfds();
+            let (kill_evt, pause_evt) = self.common.dup_eventfds()?;
 
             let rx_rate_limiter: Option<rate_limiter::RateLimiter> = self
                 .rate_limiter_config

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -41,7 +41,6 @@ use super::{
     VirtioDeviceType, VirtioInterruptType,
 };
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::{GuestMemoryMmap, VirtioInterrupt};
 
 /// Control queue
@@ -697,8 +696,6 @@ impl VirtioDevice for Net {
         let qp_threads = (num_queues - ctrl_threads) / 2;
         self.common.paused_sync = Some(Arc::new(Barrier::new(1 + qp_threads + ctrl_threads)));
 
-        let mut epoll_threads = Vec::new();
-
         if has_ctrl_queue {
             let ctrl_queue_index = num_queues - 1;
             let (_, mut ctrl_queue, ctrl_queue_evt) = queues.remove(ctrl_queue_index);
@@ -721,11 +718,10 @@ impl VirtioDevice for Net {
             let paused = self.common.paused.clone();
             let paused_sync = self.common.paused_sync.clone();
 
-            spawn_virtio_thread(
+            self.common.spawn_worker(
                 &format!("{}_ctrl", self.id),
                 &self.seccomp_action,
                 Thread::VirtioNetCtl,
-                &mut epoll_threads,
                 &self.exit_evt,
                 self.device_status.clone(),
                 interrupt_cb.clone(),
@@ -798,19 +794,16 @@ impl VirtioDevice for Net {
             let paused = self.common.paused.clone();
             let paused_sync = self.common.paused_sync.clone();
 
-            spawn_virtio_thread(
+            self.common.spawn_worker(
                 &format!("{}_qp{}", self.id.clone(), i),
                 &self.seccomp_action,
                 Thread::VirtioNet,
-                &mut epoll_threads,
                 &self.exit_evt,
                 self.device_status.clone(),
                 interrupt_cb.clone(),
                 move || handler.run(&paused, paused_sync.as_ref().unwrap()),
             )?;
         }
-
-        self.common.epoll_threads = Some(epoll_threads);
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -10,9 +10,9 @@ use std::net::IpAddr;
 use std::num::Wrapping;
 use std::ops::Deref;
 use std::os::unix::io::{AsRawFd, RawFd};
+use std::result;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Barrier};
-use std::{result, thread};
 
 use anyhow::anyhow;
 use event_monitor::event;
@@ -400,7 +400,6 @@ pub struct Net {
     id: String,
     taps: Vec<Tap>,
     config: VirtioNetConfig,
-    ctrl_queue_epoll_thread: Option<thread::JoinHandle<()>>,
     counters: NetCounters,
     seccomp_action: SeccompAction,
     rate_limiter_config: Option<RateLimiterConfig>,
@@ -520,7 +519,6 @@ impl Net {
             id,
             taps,
             config,
-            ctrl_queue_epoll_thread: None,
             counters: NetCounters::default(),
             seccomp_action,
             rate_limiter_config,
@@ -655,11 +653,6 @@ impl Drop for Net {
         }
         // Needed to ensure all references to tap FDs are dropped (#4868)
         self.common.wait_for_epoll_threads();
-        if let Some(thread) = self.ctrl_queue_epoll_thread.take()
-            && let Err(e) = thread.join()
-        {
-            error!("Error joining thread: {e:?}");
-        }
     }
 }
 
@@ -704,6 +697,8 @@ impl VirtioDevice for Net {
         let qp_threads = (num_queues - ctrl_threads) / 2;
         self.common.paused_sync = Some(Arc::new(Barrier::new(1 + qp_threads + ctrl_threads)));
 
+        let mut epoll_threads = Vec::new();
+
         if has_ctrl_queue {
             let ctrl_queue_index = num_queues - 1;
             let (_, mut ctrl_queue, ctrl_queue_evt) = queues.remove(ctrl_queue_index);
@@ -726,7 +721,6 @@ impl VirtioDevice for Net {
             let paused = self.common.paused.clone();
             let paused_sync = self.common.paused_sync.clone();
 
-            let mut epoll_threads = Vec::new();
             spawn_virtio_thread(
                 &format!("{}_ctrl", self.id),
                 &self.seccomp_action,
@@ -737,10 +731,8 @@ impl VirtioDevice for Net {
                 interrupt_cb.clone(),
                 move || ctrl_handler.run_ctrl(&paused, paused_sync.as_ref().unwrap()),
             )?;
-            self.ctrl_queue_epoll_thread = Some(epoll_threads.remove(0));
         }
 
-        let mut epoll_threads = Vec::new();
         let mut taps = self.taps.clone();
         for i in 0..queues.len() / 2 {
             let rx = RxVirtio::new();
@@ -867,12 +859,7 @@ impl Pausable for Net {
     }
 
     fn resume(&mut self) -> result::Result<(), MigratableError> {
-        self.common.resume()?;
-
-        if let Some(ctrl_queue_epoll_thread) = &self.ctrl_queue_epoll_thread {
-            ctrl_queue_epoll_thread.thread().unpark();
-        }
-        Ok(())
+        self.common.resume()
     }
 }
 

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -644,17 +644,6 @@ impl Net {
     }
 }
 
-impl Drop for Net {
-    fn drop(&mut self) {
-        if let Some(kill_evt) = self.common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-        // Needed to ensure all references to tap FDs are dropped (#4868)
-        self.common.wait_for_epoll_threads();
-    }
-}
-
 impl VirtioDevice for Net {
     fn device_type(&self) -> u32 {
         self.common.device_type

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -378,7 +378,7 @@ impl VirtioDevice for Pmem {
             device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
-        let (kill_evt, pause_evt) = self.common.dup_eventfds();
+        let (kill_evt, pause_evt) = self.common.dup_eventfds()?;
         if let Some(disk) = self.disk.as_ref() {
             let disk = disk.try_clone().map_err(|e| {
                 error!("failed cloning pmem disk: {e}");

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -349,16 +349,6 @@ impl Pmem {
     }
 }
 
-impl Drop for Pmem {
-    fn drop(&mut self) {
-        if let Some(kill_evt) = self.common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-        self.common.wait_for_epoll_threads();
-    }
-}
-
 impl VirtioDevice for Pmem {
     fn device_type(&self) -> u32 {
         self.common.device_type

--- a/virtio-devices/src/pmem.rs
+++ b/virtio-devices/src/pmem.rs
@@ -36,7 +36,6 @@ use super::{
     VirtioCommon, VirtioDevice, VirtioDeviceType,
 };
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::{GuestMemoryMmap, VirtioInterrupt, VirtioInterruptType};
 
 const QUEUE_SIZE: u16 = 256;
@@ -411,20 +410,16 @@ impl VirtioDevice for Pmem {
 
             let paused = self.common.paused.clone();
             let paused_sync = self.common.paused_sync.clone();
-            let mut epoll_threads = Vec::new();
 
-            spawn_virtio_thread(
+            self.common.spawn_worker(
                 &self.id,
                 &self.seccomp_action,
                 Thread::VirtioPmem,
-                &mut epoll_threads,
                 &self.exit_evt,
                 device_status.clone(),
                 interrupt_cb.clone(),
                 move || handler.run(&paused, paused_sync.as_ref().unwrap()),
             )?;
-
-            self.common.epoll_threads = Some(epoll_threads);
 
             event!("virtio-device", "activated", "id", &self.id);
             return Ok(());

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -29,7 +29,6 @@ use super::{
     VirtioCommon, VirtioDevice, VirtioDeviceType,
 };
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::{GuestMemoryMmap, VirtioInterrupt, VirtioInterruptType};
 
 const QUEUE_SIZE: u16 = 256;
@@ -287,19 +286,15 @@ impl VirtioDevice for Rng {
 
             let paused = self.common.paused.clone();
             let paused_sync = self.common.paused_sync.clone();
-            let mut epoll_threads = Vec::new();
-            spawn_virtio_thread(
+            self.common.spawn_worker(
                 &self.id,
                 &self.seccomp_action,
                 Thread::VirtioRng,
-                &mut epoll_threads,
                 &self.exit_evt,
                 device_status.clone(),
                 interrupt_cb.clone(),
                 move || handler.run(&paused, paused_sync.as_ref().unwrap()),
             )?;
-
-            self.common.epoll_threads = Some(epoll_threads);
 
             event!("virtio-device", "activated", "id", &self.id);
             return Ok(());

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -228,16 +228,6 @@ impl Rng {
     }
 }
 
-impl Drop for Rng {
-    fn drop(&mut self) {
-        if let Some(kill_evt) = self.common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-        self.common.wait_for_epoll_threads();
-    }
-}
-
 impl VirtioDevice for Rng {
     fn device_type(&self) -> u32 {
         self.common.device_type

--- a/virtio-devices/src/rng.rs
+++ b/virtio-devices/src/rng.rs
@@ -253,7 +253,7 @@ impl VirtioDevice for Rng {
             device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
-        let (kill_evt, pause_evt) = self.common.dup_eventfds();
+        let (kill_evt, pause_evt) = self.common.dup_eventfds()?;
 
         if let Some(file) = self.random_file.as_ref() {
             let random_file = file.try_clone().map_err(|e| {

--- a/virtio-devices/src/rtc.rs
+++ b/virtio-devices/src/rtc.rs
@@ -624,7 +624,7 @@ impl VirtioDevice for Rtc {
             device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
-        let (kill_evt, pause_evt) = self.common.dup_eventfds();
+        let (kill_evt, pause_evt) = self.common.dup_eventfds()?;
 
         let (_, queue, queue_evt) = queues.remove(0);
 

--- a/virtio-devices/src/rtc.rs
+++ b/virtio-devices/src/rtc.rs
@@ -599,16 +599,6 @@ impl Rtc {
     }
 }
 
-impl Drop for Rtc {
-    fn drop(&mut self) {
-        if let Some(kill_evt) = self.common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-        self.common.wait_for_epoll_threads();
-    }
-}
-
 impl VirtioDevice for Rtc {
     fn device_type(&self) -> u32 {
         self.common.device_type

--- a/virtio-devices/src/rtc.rs
+++ b/virtio-devices/src/rtc.rs
@@ -28,7 +28,6 @@ use super::{
 };
 use crate::device::ActivationContext;
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::{GuestMemoryMmap, VirtioInterrupt, VirtioInterruptType};
 
 const QUEUE_SIZE: u16 = 256;
@@ -651,19 +650,15 @@ impl VirtioDevice for Rtc {
 
         let paused = self.common.paused.clone();
         let paused_sync = self.common.paused_sync.clone();
-        let mut epoll_threads = Vec::new();
-        spawn_virtio_thread(
+        self.common.spawn_worker(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioRtc,
-            &mut epoll_threads,
             &self.exit_evt,
             device_status.clone(),
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-
-        self.common.epoll_threads = Some(epoll_threads);
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())

--- a/virtio-devices/src/thread_helper.rs
+++ b/virtio-devices/src/thread_helper.rs
@@ -34,9 +34,7 @@ where
     let seccomp_filter = get_seccomp_filter(seccomp_action, thread_type)
         .map_err(ActivateError::CreateSeccompFilter)?;
 
-    let thread_exit_evt = exit_evt
-        .try_clone()
-        .map_err(ActivateError::CloneExitEventFd)?;
+    let thread_exit_evt = exit_evt.try_clone().map_err(ActivateError::CloneEventFd)?;
     let thread_name = name.to_string();
 
     thread::Builder::new()

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -26,7 +26,6 @@ use super::super::{ActivateResult, VirtioCommon, VirtioDevice, VirtioDeviceType}
 use super::vu_common_ctrl::{VhostUserConfig, VhostUserHandle};
 use super::{DEFAULT_VIRTIO_FEATURES, Error, Result};
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::vhost_user::{VhostUserCommon, VhostUserState};
 use crate::{GuestMemoryMmap, GuestRegionMmap, VIRTIO_F_ACCESS_PLATFORM};
 
@@ -297,19 +296,15 @@ impl VirtioDevice for Blk {
         let paused = self.vu_common.virtio_common.paused.clone();
         let paused_sync = self.vu_common.virtio_common.paused_sync.clone();
 
-        let mut epoll_threads = Vec::new();
-
-        spawn_virtio_thread(
+        self.vu_common.spawn_worker(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioVhostBlock,
-            &mut epoll_threads,
             &self.exit_evt,
             device_status.clone(),
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-        self.vu_common.virtio_common.epoll_threads = Some(epoll_threads);
 
         Ok(())
     }

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -281,7 +281,7 @@ impl VirtioDevice for Blk {
 
         // Run a dedicated thread for handling potential reconnections with
         // the backend.
-        let (kill_evt, pause_evt) = self.vu_common.virtio_common.dup_eventfds();
+        let (kill_evt, pause_evt) = self.vu_common.virtio_common.dup_eventfds()?;
 
         let mut handler = self.vu_common.activate(
             mem,

--- a/virtio-devices/src/vhost_user/blk.rs
+++ b/virtio-devices/src/vhost_user/blk.rs
@@ -309,7 +309,7 @@ impl VirtioDevice for Blk {
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-        self.vu_common.epoll_thread = Some(epoll_threads.remove(0));
+        self.vu_common.virtio_common.epoll_threads = Some(epoll_threads);
 
         Ok(())
     }
@@ -338,11 +338,6 @@ impl Pausable for Blk {
 
     fn resume(&mut self) -> result::Result<(), MigratableError> {
         self.vu_common.virtio_common.resume()?;
-
-        if let Some(epoll_thread) = &self.vu_common.epoll_thread {
-            epoll_thread.thread().unpark();
-        }
-
         self.vu_common.resume()
     }
 }

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -21,7 +21,6 @@ use vmm_sys_util::eventfd::EventFd;
 use super::vu_common_ctrl::VhostUserHandle;
 use super::{DEFAULT_VIRTIO_FEATURES, Error, Result};
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::vhost_user::{VhostUserCommon, VhostUserState};
 use crate::{
     ActivateResult, GuestMemoryMmap, GuestRegionMmap, MmapRegion, VIRTIO_F_ACCESS_PLATFORM,
@@ -271,18 +270,15 @@ impl VirtioDevice for Fs {
         let paused = self.vu_common.virtio_common.paused.clone();
         let paused_sync = self.vu_common.virtio_common.paused_sync.clone();
 
-        let mut epoll_threads = Vec::new();
-        spawn_virtio_thread(
+        self.vu_common.spawn_worker(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioVhostFs,
-            &mut epoll_threads,
             &self.exit_evt,
             device_status.clone(),
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-        self.vu_common.virtio_common.epoll_threads = Some(epoll_threads);
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -282,7 +282,7 @@ impl VirtioDevice for Fs {
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-        self.vu_common.epoll_thread = Some(epoll_threads.remove(0));
+        self.vu_common.virtio_common.epoll_threads = Some(epoll_threads);
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())
@@ -342,11 +342,6 @@ impl Pausable for Fs {
 
     fn resume(&mut self) -> result::Result<(), MigratableError> {
         self.vu_common.virtio_common.resume()?;
-
-        if let Some(epoll_thread) = &self.vu_common.epoll_thread {
-            epoll_thread.thread().unpark();
-        }
-
         self.vu_common.resume()
     }
 }

--- a/virtio-devices/src/vhost_user/fs.rs
+++ b/virtio-devices/src/vhost_user/fs.rs
@@ -255,7 +255,7 @@ impl VirtioDevice for Fs {
         let backend_req_handler: Option<FrontendReqHandler<BackendReqHandler>> = None;
         // Run a dedicated thread for handling potential reconnections with
         // the backend.
-        let (kill_evt, pause_evt) = self.vu_common.virtio_common.dup_eventfds();
+        let (kill_evt, pause_evt) = self.vu_common.virtio_common.dup_eventfds()?;
 
         let mut handler = self.vu_common.activate(
             mem,

--- a/virtio-devices/src/vhost_user/generic_vhost_user.rs
+++ b/virtio-devices/src/vhost_user/generic_vhost_user.rs
@@ -22,7 +22,6 @@ use vmm_sys_util::eventfd::EventFd;
 use super::vu_common_ctrl::VhostUserHandle;
 use super::{Error, Result};
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::vhost_user::{VhostUserCommon, VhostUserState};
 use crate::{
     ActivateResult, GuestMemoryMmap, GuestRegionMmap, MmapRegion, VIRTIO_F_ACCESS_PLATFORM,
@@ -333,18 +332,15 @@ impl VirtioDevice for GenericVhostUser {
         let paused = self.vu_common.virtio_common.paused.clone();
         let paused_sync = self.vu_common.virtio_common.paused_sync.clone();
 
-        let mut epoll_threads = Vec::new();
-        spawn_virtio_thread(
+        self.vu_common.spawn_worker(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioGenericVhostUser,
-            &mut epoll_threads,
             &self.exit_evt,
             device_status.clone(),
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-        self.vu_common.virtio_common.epoll_threads = Some(epoll_threads);
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())

--- a/virtio-devices/src/vhost_user/generic_vhost_user.rs
+++ b/virtio-devices/src/vhost_user/generic_vhost_user.rs
@@ -344,7 +344,7 @@ impl VirtioDevice for GenericVhostUser {
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-        self.vu_common.epoll_thread = Some(epoll_threads.remove(0));
+        self.vu_common.virtio_common.epoll_threads = Some(epoll_threads);
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())
@@ -404,11 +404,6 @@ impl Pausable for GenericVhostUser {
 
     fn resume(&mut self) -> result::Result<(), MigratableError> {
         self.vu_common.virtio_common.resume()?;
-
-        if let Some(epoll_thread) = &self.vu_common.epoll_thread {
-            epoll_thread.thread().unpark();
-        }
-
         self.vu_common.resume()
     }
 }

--- a/virtio-devices/src/vhost_user/generic_vhost_user.rs
+++ b/virtio-devices/src/vhost_user/generic_vhost_user.rs
@@ -317,7 +317,7 @@ impl VirtioDevice for GenericVhostUser {
 
         // Run a dedicated thread for handling potential reconnections with
         // the backend.
-        let (kill_evt, pause_evt) = self.vu_common.virtio_common.dup_eventfds();
+        let (kill_evt, pause_evt) = self.vu_common.virtio_common.dup_eventfds()?;
 
         let mut handler = self.vu_common.activate(
             mem,

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -613,19 +613,8 @@ impl VhostUserCommon {
     }
 
     pub fn shutdown(&mut self) {
-        // Signal workers to exit, unpause them (they may be parked
-        // if the VM was paused for migration), then wait for them
-        // to finish so they drop their Arc<VhostUserHandle> and the
-        // socket fully closes for the destination to reconnect.
-        if let Some(kill_evt) = self.virtio_common.kill_evt.take() {
-            let _ = kill_evt.write(1);
-        }
-        self.virtio_common.paused.store(false, Ordering::SeqCst);
-        if let Some(threads) = self.virtio_common.epoll_threads.as_ref() {
-            for t in threads {
-                t.thread().unpark();
-            }
-        }
+        // Join the workers so they drop their Arc<VhostUserHandle> and the
+        // socket closes, letting the migration destination reconnect.
         self.virtio_common.wait_for_epoll_threads();
 
         // Remove socket path if needed
@@ -862,8 +851,8 @@ impl VhostUserCommon {
 
         // Make sure the device thread is killed in order to prevent from
         // reconnections to the socket.
-        if let Some(kill_evt) = self.virtio_common.kill_evt.take() {
-            kill_evt.write(1).map_err(|e| {
+        if let Some(workers) = self.virtio_common.workers.as_ref() {
+            workers.signal_exit().map_err(|e| {
                 MigratableError::CompleteMigration(anyhow!(
                     "Error killing vhost-user thread: {e:?}"
                 ))

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -1,12 +1,12 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::io;
 use std::io::ErrorKind;
 use std::ops::Deref;
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
-use std::{io, thread};
 
 use anyhow::anyhow;
 use event_monitor::event;
@@ -463,7 +463,6 @@ pub struct VhostUserCommon {
     pub migration_started: bool,
     pub server: bool,
     pub vring_bases: Option<Vec<u64>>,
-    pub epoll_thread: Option<thread::JoinHandle<()>>,
     /// Indicates that the backend is no longer reachable. Shared with EPollHandler.
     pub disconnected: Arc<AtomicBool>,
 }
@@ -566,15 +565,9 @@ impl VhostUserCommon {
             }
         }
 
-        if let Some(kill_evt) = self.virtio_common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
+        self.virtio_common.reset();
 
         event!("virtio-device", "reset", "id", id);
-
-        // Drop the interrupt callback clone
-        self.virtio_common.interrupt_cb = None;
     }
 
     fn memory_update_error(&self, source: Error) -> crate::Error {
@@ -587,21 +580,20 @@ impl VhostUserCommon {
     }
 
     pub fn shutdown(&mut self) {
-        // Signal the epoll thread to exit, unpause it (it may be parked
-        // if the VM was paused for migration), then wait for it to finish.
-        // This ensures the thread drops its Arc<VhostUserHandle>, fully
-        // closing the vhost-user socket so the backend can accept a new
-        // connection from the destination.
+        // Signal workers to exit, unpause them (they may be parked
+        // if the VM was paused for migration), then wait for them
+        // to finish so they drop their Arc<VhostUserHandle> and the
+        // socket fully closes for the destination to reconnect.
         if let Some(kill_evt) = self.virtio_common.kill_evt.take() {
             let _ = kill_evt.write(1);
         }
         self.virtio_common.paused.store(false, Ordering::SeqCst);
-        if let Some(t) = self.epoll_thread.as_ref() {
-            t.thread().unpark();
+        if let Some(threads) = self.virtio_common.epoll_threads.as_ref() {
+            for t in threads {
+                t.thread().unpark();
+            }
         }
-        if let Some(t) = self.epoll_thread.take() {
-            let _ = t.join();
-        }
+        self.virtio_common.wait_for_epoll_threads();
 
         // Remove socket path if needed
         if self.server {

--- a/virtio-devices/src/vhost_user/mod.rs
+++ b/virtio-devices/src/vhost_user/mod.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, Barrier, Mutex};
 use anyhow::anyhow;
 use event_monitor::event;
 use log::{error, info, warn};
+use seccompiler::SeccompAction;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vhost::Error as VhostError;
@@ -27,6 +28,7 @@ use vm_migration::{MigratableError, Pausable, Snapshot};
 use vmm_sys_util::eventfd::EventFd;
 use vu_common_ctrl::VhostUserHandle;
 
+use crate::seccomp_filters::Thread;
 use crate::{
     ActivateError, EPOLL_HELPER_EVENT_LAST, EpollHelper, EpollHelperError, EpollHelperHandler,
     GuestMemoryMmap, GuestRegionMmap, VIRTIO_F_IN_ORDER, VIRTIO_F_NOTIFICATION_DATA,
@@ -533,6 +535,37 @@ impl VhostUserCommon {
             inflight,
             disconnected: self.disconnected.clone(),
         })
+    }
+
+    /// Like `VirtioCommon::spawn_worker`, but on failure also runs
+    /// `self.reset(id)` to tear down the vhost-user backend.
+    #[expect(clippy::too_many_arguments)]
+    pub fn spawn_worker<F>(
+        &mut self,
+        id: &str,
+        seccomp_action: &SeccompAction,
+        thread_type: Thread,
+        exit_evt: &EventFd,
+        device_status: Arc<std::sync::atomic::AtomicU8>,
+        interrupt_cb: Arc<dyn VirtioInterrupt>,
+        f: F,
+    ) -> std::result::Result<(), ActivateError>
+    where
+        F: FnOnce() -> std::result::Result<(), EpollHelperError> + Send + 'static,
+    {
+        if let Err(e) = self.virtio_common.spawn_worker(
+            id,
+            seccomp_action,
+            thread_type,
+            exit_evt,
+            device_status,
+            interrupt_cb,
+            f,
+        ) {
+            self.reset(id);
+            return Err(e);
+        }
+        Ok(())
     }
 
     pub fn reset(&mut self, id: &str) {

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -1,9 +1,9 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::result;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier, Mutex};
-use std::{result, thread};
 
 use log::{error, info};
 use net_util::{CtrlQueue, MacAddr, VirtioNetConfig, build_net_config_space};
@@ -44,7 +44,6 @@ pub struct Net {
     id: String,
     config: VirtioNetConfig,
     guest_memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
-    ctrl_queue_epoll_thread: Option<thread::JoinHandle<()>>,
     seccomp_action: SeccompAction,
     exit_evt: EventFd,
     access_platform_enabled: bool,
@@ -221,7 +220,6 @@ impl Net {
             },
             config,
             guest_memory: None,
-            ctrl_queue_epoll_thread: None,
             seccomp_action,
             exit_evt,
             access_platform_enabled,
@@ -236,12 +234,6 @@ impl Net {
 impl Drop for Net {
     fn drop(&mut self) {
         self.vu_common.shutdown();
-
-        if let Some(thread) = self.ctrl_queue_epoll_thread.take()
-            && let Err(e) = thread.join()
-        {
-            error!("Error joining thread: {e:?}");
-        }
     }
 }
 
@@ -319,18 +311,18 @@ impl VirtioDevice for Net {
             self.vu_common.virtio_common.paused_sync = Some(Arc::new(Barrier::new(3)));
             let paused_sync = self.vu_common.virtio_common.paused_sync.clone();
 
-            let mut epoll_threads = Vec::new();
+            let mut ctrl_threads = Vec::new();
             spawn_virtio_thread(
                 &format!("{}_ctrl", self.id),
                 &self.seccomp_action,
                 Thread::VirtioVhostNetCtl,
-                &mut epoll_threads,
+                &mut ctrl_threads,
                 &self.exit_evt,
                 device_status.clone(),
                 interrupt_cb.clone(),
                 move || ctrl_handler.run_ctrl(&paused, paused_sync.as_ref().unwrap()),
             )?;
-            self.ctrl_queue_epoll_thread = Some(epoll_threads.remove(0));
+            self.vu_common.virtio_common.epoll_threads = Some(ctrl_threads);
         }
 
         let backend_req_handler: Option<FrontendReqHandler<BackendReqHandler>> = None;
@@ -357,18 +349,21 @@ impl VirtioDevice for Net {
         let paused = self.vu_common.virtio_common.paused.clone();
         let paused_sync = self.vu_common.virtio_common.paused_sync.clone();
 
-        let mut epoll_threads = Vec::new();
+        let threads = self
+            .vu_common
+            .virtio_common
+            .epoll_threads
+            .get_or_insert_with(Vec::new);
         spawn_virtio_thread(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioVhostNet,
-            &mut epoll_threads,
+            threads,
             &self.exit_evt,
             device_status.clone(),
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-        self.vu_common.epoll_thread = Some(epoll_threads.remove(0));
 
         Ok(())
     }
@@ -397,15 +392,6 @@ impl Pausable for Net {
 
     fn resume(&mut self) -> result::Result<(), MigratableError> {
         self.vu_common.virtio_common.resume()?;
-
-        if let Some(epoll_thread) = &self.vu_common.epoll_thread {
-            epoll_thread.thread().unpark();
-        }
-
-        if let Some(ctrl_queue_epoll_thread) = &self.ctrl_queue_epoll_thread {
-            ctrl_queue_epoll_thread.thread().unpark();
-        }
-
         self.vu_common.resume()
     }
 }

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -24,7 +24,6 @@ use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottabl
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::vhost_user::vu_common_ctrl::{VhostUserConfig, VhostUserHandle};
 use crate::vhost_user::{DEFAULT_VIRTIO_FEATURES, Error, Result, VhostUserCommon, VhostUserState};
 use crate::{
@@ -311,18 +310,15 @@ impl VirtioDevice for Net {
             self.vu_common.virtio_common.paused_sync = Some(Arc::new(Barrier::new(3)));
             let paused_sync = self.vu_common.virtio_common.paused_sync.clone();
 
-            let mut ctrl_threads = Vec::new();
-            spawn_virtio_thread(
+            self.vu_common.virtio_common.spawn_worker(
                 &format!("{}_ctrl", self.id),
                 &self.seccomp_action,
                 Thread::VirtioVhostNetCtl,
-                &mut ctrl_threads,
                 &self.exit_evt,
                 device_status.clone(),
                 interrupt_cb.clone(),
                 move || ctrl_handler.run_ctrl(&paused, paused_sync.as_ref().unwrap()),
             )?;
-            self.vu_common.virtio_common.epoll_threads = Some(ctrl_threads);
         }
 
         let backend_req_handler: Option<FrontendReqHandler<BackendReqHandler>> = None;
@@ -349,16 +345,10 @@ impl VirtioDevice for Net {
         let paused = self.vu_common.virtio_common.paused.clone();
         let paused_sync = self.vu_common.virtio_common.paused_sync.clone();
 
-        let threads = self
-            .vu_common
-            .virtio_common
-            .epoll_threads
-            .get_or_insert_with(Vec::new);
-        spawn_virtio_thread(
+        self.vu_common.spawn_worker(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioVhostNet,
-            threads,
             &self.exit_evt,
             device_status.clone(),
             interrupt_cb.clone(),

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -289,7 +289,7 @@ impl VirtioDevice for Net {
 
             ctrl_queue.set_event_idx(event_idx);
 
-            let (kill_evt, pause_evt) = self.vu_common.virtio_common.dup_eventfds();
+            let (kill_evt, pause_evt) = self.vu_common.virtio_common.dup_eventfds()?;
 
             let mut ctrl_handler = NetCtrlEpollHandler {
                 mem: mem.clone(),
@@ -330,7 +330,7 @@ impl VirtioDevice for Net {
 
         // Run a dedicated thread for handling potential reconnections with
         // the backend.
-        let (kill_evt, pause_evt) = self.vu_common.virtio_common.dup_eventfds();
+        let (kill_evt, pause_evt) = self.vu_common.virtio_common.dup_eventfds()?;
 
         let mut handler = self.vu_common.activate(
             mem,

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -48,7 +48,6 @@ use vmm_sys_util::eventfd::EventFd;
 ///
 use super::{VsockBackend, VsockPacket};
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::{
     ActivateResult, EPOLL_HELPER_EVENT_LAST, EpollHelper, EpollHelperError, EpollHelperHandler,
     Error as DeviceError, GuestMemoryMmap, VIRTIO_F_ACCESS_PLATFORM, VIRTIO_F_IN_ORDER,
@@ -505,20 +504,16 @@ where
 
         let paused = self.common.paused.clone();
         let paused_sync = self.common.paused_sync.clone();
-        let mut epoll_threads = Vec::new();
 
-        spawn_virtio_thread(
+        self.common.spawn_worker(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioVsock,
-            &mut epoll_threads,
             &self.exit_evt,
             device_status.clone(),
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-
-        self.common.epoll_threads = Some(epoll_threads);
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -469,7 +469,7 @@ where
             device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
-        let (kill_evt, pause_evt) = self.common.dup_eventfds();
+        let (kill_evt, pause_evt) = self.common.dup_eventfds()?;
 
         let mut virtqueues = Vec::new();
         let mut queue_evts = Vec::new();

--- a/virtio-devices/src/vsock/device.rs
+++ b/virtio-devices/src/vsock/device.rs
@@ -426,19 +426,6 @@ where
     }
 }
 
-impl<B> Drop for Vsock<B>
-where
-    B: VsockBackend,
-{
-    fn drop(&mut self) {
-        if let Some(kill_evt) = self.common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-        self.common.wait_for_epoll_threads();
-    }
-}
-
 impl<B> VirtioDevice for Vsock<B>
 where
     B: VsockBackend + Sync + 'static,

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -328,7 +328,7 @@ impl VirtioDevice for Watchdog {
             device_status,
         } = context;
         self.common.activate(&queues, interrupt_cb.clone())?;
-        let (kill_evt, pause_evt) = self.common.dup_eventfds();
+        let (kill_evt, pause_evt) = self.common.dup_eventfds()?;
 
         let reset_evt = self.reset_evt.try_clone().map_err(|e| {
             error!("Failed to clone reset_evt eventfd: {e}");

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -31,7 +31,6 @@ use super::{
     VirtioDeviceType,
 };
 use crate::seccomp_filters::Thread;
-use crate::thread_helper::spawn_virtio_thread;
 use crate::{GuestMemoryMmap, VirtioInterrupt, VirtioInterruptType};
 
 const QUEUE_SIZE: u16 = 8;
@@ -367,20 +366,16 @@ impl VirtioDevice for Watchdog {
 
         let paused = self.common.paused.clone();
         let paused_sync = self.common.paused_sync.clone();
-        let mut epoll_threads = Vec::new();
 
-        spawn_virtio_thread(
+        self.common.spawn_worker(
             &self.id,
             &self.seccomp_action,
             Thread::VirtioWatchdog,
-            &mut epoll_threads,
             &self.exit_evt,
             device_status.clone(),
             interrupt_cb.clone(),
             move || handler.run(&paused, paused_sync.as_ref().unwrap()),
         )?;
-
-        self.common.epoll_threads = Some(epoll_threads);
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())

--- a/virtio-devices/src/watchdog.rs
+++ b/virtio-devices/src/watchdog.rs
@@ -270,16 +270,6 @@ impl Watchdog {
     }
 }
 
-impl Drop for Watchdog {
-    fn drop(&mut self) {
-        if let Some(kill_evt) = self.common.kill_evt.take() {
-            // Ignore the result because there is nothing we can do about it.
-            let _ = kill_evt.write(1);
-        }
-        self.common.wait_for_epoll_threads();
-    }
-}
-
 fn timerfd_create() -> Result<RawFd, io::Error> {
     // SAFETY: FFI call, trivially safe
     let res = unsafe { libc::timerfd_create(libc::CLOCK_MONOTONIC, 0) };


### PR DESCRIPTION
Refactor the virtio worker thread handling by consolidating on a helper method
that spawns and "manages" the thread that are created. Replacing a repeated
pattern acrosss all the devices. Whilst doing that also handle resetting the
device on spawn failure.

- **virtio-devices: Simplify epoll thread handling**
- **virtio-devices: Add VirtioCommon::spawn_worker helper**
- **virtio-devices: Use VirtioCommon::spawn_worker()**
- **virtio-devices: vhost_user: Add VhostUserCommon::spawn_worker helper**
- **virtio-devices: vhost_user: Use VhostUserCommon::spawn_worker**
