### PR TITLE
block: qcow: Reject backing file name outside first cluster

### DIFF
--- a/block/src/formats/qcow/internal/header.rs
+++ b/block/src/formats/qcow/internal/header.rs
@@ -331,6 +331,11 @@ impl QcowHeader {
         if header.backing_file_size > MAX_BACKING_FILE_SIZE {
             return Err(Error::BackingFileTooLong(header.backing_file_size as usize));
         }
+        if header.backing_file_offset == 0 && header.backing_file_size != 0 {
+            return Err(Error::BackingFileSizeWithoutOffset(
+                header.backing_file_size,
+            ));
+        }
         if header.backing_file_offset != 0 {
             let cluster_size = 1u64
                 .checked_shl(header.cluster_bits)

--- a/block/src/formats/qcow/internal/header.rs
+++ b/block/src/formats/qcow/internal/header.rs
@@ -336,6 +336,11 @@ impl QcowHeader {
                 header.backing_file_size,
             ));
         }
+        if header.backing_file_offset != 0 && header.backing_file_size == 0 {
+            return Err(Error::BackingFileOffsetWithoutSize(
+                header.backing_file_offset,
+            ));
+        }
         if header.backing_file_offset != 0 {
             let cluster_size = 1u64
                 .checked_shl(header.cluster_bits)

--- a/block/src/formats/qcow/internal/header.rs
+++ b/block/src/formats/qcow/internal/header.rs
@@ -335,6 +335,13 @@ impl QcowHeader {
             let cluster_size = 1u64
                 .checked_shl(header.cluster_bits)
                 .ok_or(Error::InvalidClusterSize)?;
+            if header.backing_file_offset < u64::from(header.header_size) {
+                return Err(Error::BackingFileOverlapsHeader(
+                    header.backing_file_offset,
+                    header.backing_file_size,
+                    header.header_size,
+                ));
+            }
             if header.backing_file_offset >= cluster_size
                 || header.backing_file_offset + u64::from(header.backing_file_size) > cluster_size
             {

--- a/block/src/formats/qcow/internal/header.rs
+++ b/block/src/formats/qcow/internal/header.rs
@@ -332,6 +332,18 @@ impl QcowHeader {
             return Err(Error::BackingFileTooLong(header.backing_file_size as usize));
         }
         if header.backing_file_offset != 0 {
+            let cluster_size = 1u64
+                .checked_shl(header.cluster_bits)
+                .ok_or(Error::InvalidClusterSize)?;
+            if header.backing_file_offset >= cluster_size
+                || header.backing_file_offset + u64::from(header.backing_file_size) > cluster_size
+            {
+                return Err(Error::BackingFileOutsideFirstCluster(
+                    header.backing_file_offset,
+                    header.backing_file_size,
+                    cluster_size,
+                ));
+            }
             f.seek(SeekFrom::Start(header.backing_file_offset))
                 .map_err(Error::ReadingHeader)?;
             let mut backing_file_name_bytes = vec![0u8; header.backing_file_size as usize];

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -74,6 +74,8 @@ pub enum Error {
     BackingFileOutsideFirstCluster(u64, u32, u64),
     #[error("Backing file name at offset {0:#x} length {1:#x} overlaps header of size {2:#x}")]
     BackingFileOverlapsHeader(u64, u32, u32),
+    #[error("Backing file size {0:#x} with zero offset")]
+    BackingFileSizeWithoutOffset(u32),
     #[error("Backing file support is disabled")]
     BackingFilesDisabled,
     #[error("Backing file name is too long: {0} bytes over")]

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -2727,6 +2727,16 @@ mod unit_tests {
         ));
     }
 
+    #[test]
+    fn backing_file_offset_past_cluster() {
+        let cluster_size = 1u64 << DEFAULT_CLUSTER_BITS;
+        let err = read_header_with_patched_backing(cluster_size + 4096, 16).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::BackingFileOutsideFirstCluster(_, _, _)
+        ));
+    }
+
     /// Helper to create a test file with header extensions
     fn create_header_with_extension(ext_type: u32, ext_data: &[u8]) -> (RawFile, QcowHeader) {
         let header = QcowHeader::create_for_size_and_path(3, 0x10_0000, None)

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -2737,6 +2737,16 @@ mod unit_tests {
         ));
     }
 
+    #[test]
+    fn backing_file_end_past_cluster() {
+        let cluster_size = 1u64 << DEFAULT_CLUSTER_BITS;
+        let err = read_header_with_patched_backing(cluster_size - 4, 16).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::BackingFileOutsideFirstCluster(_, _, _)
+        ));
+    }
+
     /// Helper to create a test file with header extensions
     fn create_header_with_extension(ext_type: u32, ext_data: &[u8]) -> (RawFile, QcowHeader) {
         let header = QcowHeader::create_for_size_and_path(3, 0x10_0000, None)

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -66,6 +66,8 @@ use crate::error::{BlockError, BlockErrorKind, BlockResult};
 pub enum Error {
     #[error("Backing file I/O error: {0}")]
     BackingFileIo(String /* path */, #[source] io::Error),
+    #[error("Backing file offset {0:#x} with zero size")]
+    BackingFileOffsetWithoutSize(u64),
     #[error("Backing file open error: {0}")]
     BackingFileOpen(String /* path */, #[source] Box<Error>),
     #[error(

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -72,6 +72,8 @@ pub enum Error {
         "Backing file name at offset {0:#x} length {1:#x} lies outside first cluster of {2:#x}"
     )]
     BackingFileOutsideFirstCluster(u64, u32, u64),
+    #[error("Backing file name at offset {0:#x} length {1:#x} overlaps header of size {2:#x}")]
+    BackingFileOverlapsHeader(u64, u32, u32),
     #[error("Backing file support is disabled")]
     BackingFilesDisabled,
     #[error("Backing file name is too long: {0} bytes over")]

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -2748,6 +2748,12 @@ mod unit_tests {
     }
 
     #[test]
+    fn backing_file_offset_inside_header() {
+        let err = read_header_with_patched_backing(64, 16).unwrap_err();
+        assert!(matches!(err, Error::BackingFileOverlapsHeader(_, _, _)));
+    }
+
+    #[test]
     fn backing_file_fits_at_cluster_end() {
         let cluster_size = 1u64 << DEFAULT_CLUSTER_BITS;
         let header =

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -2760,6 +2760,12 @@ mod unit_tests {
     }
 
     #[test]
+    fn backing_file_offset_without_size() {
+        let err = read_header_with_patched_backing(1024, 0).unwrap_err();
+        assert!(matches!(err, Error::BackingFileOffsetWithoutSize(1024)));
+    }
+
+    #[test]
     fn backing_file_fits_at_cluster_end() {
         let cluster_size = 1u64 << DEFAULT_CLUSTER_BITS;
         let header =

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -2434,6 +2434,7 @@ mod unit_tests {
     use vmm_sys_util::tempfile::TempFile;
     use vmm_sys_util::write_zeroes::WriteZeroes;
 
+    use super::header::DEFAULT_CLUSTER_BITS;
     use super::util::{COMPRESSED_FLAG, ZERO_FLAG};
     use super::*;
     use crate::formats::qcow::common::unit_tests::compress_allocated_clusters;
@@ -2693,6 +2694,37 @@ mod unit_tests {
             read_header.backing_file.as_ref().map(|bf| &bf.path),
             header.backing_file.as_ref().map(|bf| &bf.path)
         );
+    }
+
+    /// Write a header to a fresh file with backing_file_offset and
+    /// backing_file_size patched. Panics on setup failures, returns
+    /// the parse result of the patched header.
+    fn read_header_with_patched_backing(offset: u64, size: u32) -> Result<QcowHeader> {
+        let mut header = QcowHeader::create_for_size_and_path(3, 0x10_0000, None)
+            .expect("Failed to create header.");
+        header.backing_file_offset = offset;
+        header.backing_file_size = size;
+        let mut disk_file: RawFile = RawFile::new(
+            TempFile::new()
+                .expect("Failed to create temp file.")
+                .into_file(),
+            false,
+        );
+        header
+            .write_to(&mut disk_file)
+            .expect("Failed to write header.");
+        disk_file.rewind().expect("Failed to rewind disk file.");
+        QcowHeader::new(&mut disk_file)
+    }
+
+    #[test]
+    fn backing_file_offset_at_cluster_boundary() {
+        let cluster_size = 1u64 << DEFAULT_CLUSTER_BITS;
+        let err = read_header_with_patched_backing(cluster_size, 1).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::BackingFileOutsideFirstCluster(_, _, _)
+        ));
     }
 
     /// Helper to create a test file with header extensions

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -2747,6 +2747,15 @@ mod unit_tests {
         ));
     }
 
+    #[test]
+    fn backing_file_fits_at_cluster_end() {
+        let cluster_size = 1u64 << DEFAULT_CLUSTER_BITS;
+        let header =
+            read_header_with_patched_backing(cluster_size - 16, 16).expect("Header should parse.");
+        assert_eq!(header.backing_file_offset, cluster_size - 16);
+        assert_eq!(header.backing_file_size, 16);
+    }
+
     /// Helper to create a test file with header extensions
     fn create_header_with_extension(ext_type: u32, ext_data: &[u8]) -> (RawFile, QcowHeader) {
         let header = QcowHeader::create_for_size_and_path(3, 0x10_0000, None)

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -2754,6 +2754,12 @@ mod unit_tests {
     }
 
     #[test]
+    fn backing_file_size_without_offset() {
+        let err = read_header_with_patched_backing(0, 16).unwrap_err();
+        assert!(matches!(err, Error::BackingFileSizeWithoutOffset(16)));
+    }
+
+    #[test]
     fn backing_file_fits_at_cluster_end() {
         let cluster_size = 1u64 << DEFAULT_CLUSTER_BITS;
         let header =

--- a/block/src/formats/qcow/internal/mod.rs
+++ b/block/src/formats/qcow/internal/mod.rs
@@ -68,6 +68,10 @@ pub enum Error {
     BackingFileIo(String /* path */, #[source] io::Error),
     #[error("Backing file open error: {0}")]
     BackingFileOpen(String /* path */, #[source] Box<Error>),
+    #[error(
+        "Backing file name at offset {0:#x} length {1:#x} lies outside first cluster of {2:#x}"
+    )]
+    BackingFileOutsideFirstCluster(u64, u32, u64),
     #[error("Backing file support is disabled")]
     BackingFilesDisabled,
     #[error("Backing file name is too long: {0} bytes over")]


### PR DESCRIPTION
The qcow2 spec states that when a backing file is present, its name must reside between the end of the header extension area and the end of the first cluster, and that no other data may live in that space:

> If the image has a backing file then the backing file name should be stored in the remaining space between the end of the header extension area and the end of the first cluster. It is not allowed to store other data here

Today `QcowHeader::new()` only rejects `backing_file_size` values above `MAX_BACKING_FILE_SIZE` (1023). A header whose `backing_file_offset` points past the first cluster, or whose offset plus size crosses the cluster boundary, is accepted and parsing proceeds with a name that overlaps L1 or refcount tables or other image regions.

Fixed by adding a bound check in `QcowHeader::new()` that rejects any header where `backing_file_offset + backing_file_size` exceeds the cluster size implied by `cluster_bits`.

Fixes: #8261