### PR TITLE
virtio/vsock - remove unneeded unsafety

### DIFF
--- a/virtio-devices/src/vsock/csm/connection.rs
+++ b/virtio-devices/src/vsock/csm/connection.rs
@@ -86,17 +86,25 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 
 use log::{debug, error, info, warn};
+use vm_memory::{ReadVolatile, WriteVolatile};
 
 use super::super::defs::uapi;
 use super::super::packet::VsockPacket;
 use super::super::{Result as VsockResult, VsockChannel, VsockEpollListener, VsockError};
-use super::txbuf::TxBuf;
+use super::txbuf::{TxBuf, TxBufSource};
 use super::{ConnState, Error, PendingRx, PendingRxSet, Result, defs};
+
+impl TxBufSource for VsockPacket {
+    fn copy_to_tx_buf(&self, offset: usize, dst: &mut [u8]) -> Result<()> {
+        self.copy_buf_to_slice(offset, dst)
+            .map_err(|_| Error::PktBufRead)
+    }
+}
 
 /// A self-managing connection object, that handles communication between a guest-side AF_VSOCK
 /// socket and a host-side `Read + Write + AsRawFd` stream.
 ///
-pub struct VsockConnection<S: Read + Write + AsRawFd> {
+pub struct VsockConnection<S: Read + ReadVolatile + Write + WriteVolatile + AsRawFd> {
     /// The current connection state.
     state: ConnState,
     /// The local CID. Most of the time this will be the constant `2` (the vsock host CID).
@@ -133,7 +141,7 @@ pub struct VsockConnection<S: Read + Write + AsRawFd> {
 
 impl<S> VsockChannel for VsockConnection<S>
 where
-    S: Read + Write + AsRawFd,
+    S: Read + ReadVolatile + Write + WriteVolatile + AsRawFd,
 {
     /// Fill in a vsock packet, to be delivered to our peer (the guest driver).
     ///
@@ -205,14 +213,14 @@ where
                 return Ok(());
             }
 
-            let buf = pkt.buf_mut().ok_or(VsockError::PktBufMissing)?;
+            let buf_capacity = pkt.buf_capacity().ok_or(VsockError::PktBufMissing)?;
 
             // The maximum amount of data we can read in is limited by both the RX buffer size and
             // the peer available buffer space.
-            let max_len = std::cmp::min(buf.len(), self.peer_avail_credit());
+            let max_len = std::cmp::min(buf_capacity, self.peer_avail_credit());
 
             // Read data from the stream straight to the RX buffer, for maximum throughput.
-            match self.stream.read(&mut buf[..max_len]) {
+            match pkt.read_volatile_from(&mut self.stream, max_len) {
                 Ok(read_cnt) => {
                     if read_cnt == 0 {
                         // A 0-length read means the host stream was closed down. In that case,
@@ -291,7 +299,7 @@ where
             ConnState::Established | ConnState::PeerClosed(_, false)
                 if pkt.op() == uapi::VSOCK_OP_RW =>
             {
-                if pkt.buf().is_none() {
+                if !pkt.has_buf() {
                     info!(
                         "vsock: dropping empty data packet from guest (lp={}, pp={}",
                         self.local_port, self.peer_port
@@ -299,9 +307,7 @@ where
                     return Ok(());
                 }
 
-                // Unwrapping here is safe, since we just checked `pkt.buf()` above.
-                let buf_slice = &pkt.buf().unwrap()[..(pkt.len() as usize)];
-                if let Err(err) = self.send_bytes(buf_slice) {
+                if let Err(err) = self.send_pkt_bytes(pkt) {
                     // If we can't write to the host stream, that's an unrecoverable error, so
                     // we'll terminate this connection.
                     warn!(
@@ -396,7 +402,7 @@ where
 
 impl<S> VsockEpollListener for VsockConnection<S>
 where
-    S: Read + Write + AsRawFd,
+    S: Read + ReadVolatile + Write + WriteVolatile + AsRawFd,
 {
     /// Get the file descriptor that this connection wants polled.
     ///
@@ -481,7 +487,7 @@ where
 
 impl<S> VsockConnection<S>
 where
-    S: Read + Write + AsRawFd,
+    S: Read + ReadVolatile + Write + WriteVolatile + AsRawFd,
 {
     /// Create a new guest-initiated connection object.
     ///
@@ -589,22 +595,24 @@ where
         self.stream.write(buf).map_err(Error::StreamWrite)
     }
 
-    /// Send some raw data (a byte-slice) to the host stream.
+    /// Send packet data to the host stream.
     ///
-    /// Raw data can either be sent straight to the host stream, or to our TX buffer, if the
+    /// Packet data can either be sent straight to the host stream, or to our TX buffer, if the
     /// former fails.
     ///
-    fn send_bytes(&mut self, buf: &[u8]) -> Result<()> {
+    fn send_pkt_bytes(&mut self, pkt: &VsockPacket) -> Result<()> {
+        let len = pkt.len() as usize;
+
         // If there is data in the TX buffer, that means we're already registered for EPOLLOUT
         // events on the underlying stream. Therefore, there's no point in attempting a write
         // at this point. `self.notify()` will get called when EPOLLOUT arrives, and it will
         // attempt to drain the TX buffer then.
         if !self.tx_buf.is_empty() {
-            return self.tx_buf.push(buf);
+            return self.buffer_pkt_bytes(pkt, 0, len);
         }
 
         // The TX buffer is empty, so we can try to write straight to the host stream.
-        let written = match self.stream.write(buf) {
+        let written = match pkt.write_volatile_to(&mut self.stream, 0, len) {
             Ok(cnt) => cnt,
             Err(e) => {
                 // Absorb any would-block errors, since we can always try again later.
@@ -620,13 +628,17 @@ where
         // Move the "forwarded bytes" counter ahead by how much we were able to send out.
         self.fwd_cnt += Wrapping(written as u32);
 
-        // If we couldn't write the whole slice, we'll need to push the remaining data to our
+        // If we couldn't write the whole packet, we'll need to push the remaining data to our
         // buffer.
-        if written < buf.len() {
-            self.tx_buf.push(&buf[written..])?;
+        if written < len {
+            self.buffer_pkt_bytes(pkt, written, len - written)?;
         }
 
         Ok(())
+    }
+
+    fn buffer_pkt_bytes(&mut self, pkt: &VsockPacket, offset: usize, len: usize) -> Result<()> {
+        self.tx_buf.push_from(pkt, offset, len)
     }
 
     /// Check if the credit information the peer has last received from us is outdated.
@@ -677,6 +689,8 @@ mod unit_tests {
 
     use libc::EFD_NONBLOCK;
     use virtio_queue::QueueOwnedT;
+    use vm_memory::bitmap::BitmapSlice;
+    use vm_memory::{VolatileMemoryError, VolatileSlice};
     use vmm_sys_util::eventfd::EventFd;
 
     use super::super::super::unit_tests::TestContext;
@@ -763,9 +777,32 @@ mod unit_tests {
         }
     }
 
+    impl ReadVolatile for TestStream {
+        fn read_volatile<B: BitmapSlice>(
+            &mut self,
+            data: &mut VolatileSlice<B>,
+        ) -> std::result::Result<usize, VolatileMemoryError> {
+            let mut buf = vec![0u8; data.len()];
+            let len = self.read(&mut buf).map_err(VolatileMemoryError::IOError)?;
+            data.copy_from(&buf[..len]);
+            Ok(len)
+        }
+    }
+
+    impl WriteVolatile for TestStream {
+        fn write_volatile<B: BitmapSlice>(
+            &mut self,
+            data: &VolatileSlice<B>,
+        ) -> std::result::Result<usize, VolatileMemoryError> {
+            let mut buf = vec![0u8; data.len()];
+            data.copy_to(&mut buf);
+            self.write(&buf).map_err(VolatileMemoryError::IOError)
+        }
+    }
+
     impl<S> VsockConnection<S>
     where
-        S: Read + Write + AsRawFd,
+        S: Read + ReadVolatile + Write + WriteVolatile + AsRawFd,
     {
         /// Get the fwd_cnt value from the connection.
         pub(crate) fn fwd_cnt(&self) -> Wrapping<u32> {
@@ -894,10 +931,16 @@ mod unit_tests {
         }
 
         fn init_data_pkt(&mut self, data: &[u8]) -> &VsockPacket {
-            assert!(data.len() <= self.pkt.buf().unwrap().len());
+            assert!(data.len() <= self.pkt.buf_capacity().unwrap());
             self.init_pkt(uapi::VSOCK_OP_RW, data.len() as u32);
-            self.pkt.buf_mut().unwrap()[..data.len()].copy_from_slice(data);
+            self.pkt.copy_buf_from_slice(0, data).unwrap();
             &self.pkt
+        }
+
+        fn pkt_data(&self) -> Vec<u8> {
+            let mut data = vec![0u8; self.pkt.len() as usize];
+            self.pkt.copy_buf_to_slice(0, &mut data).unwrap();
+            data
         }
     }
 
@@ -964,7 +1007,7 @@ mod unit_tests {
         ctx.recv();
         assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RW);
         assert_eq!(ctx.pkt.len() as usize, data.len());
-        assert_eq!(ctx.pkt.buf().unwrap()[..ctx.pkt.len() as usize], *data);
+        assert_eq!(ctx.pkt_data().as_slice(), data);
 
         // There's no more data in the stream, so `recv_pkt` should yield `VsockError::NoData`.
         match ctx.conn.recv_pkt(&mut ctx.pkt) {
@@ -1034,7 +1077,7 @@ mod unit_tests {
             ctx.notify_epollin();
             ctx.recv();
             assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RW);
-            assert_eq!(&ctx.pkt.buf().unwrap()[..ctx.pkt.len() as usize], data);
+            assert_eq!(ctx.pkt_data().as_slice(), data);
 
             ctx.init_data_pkt(data);
             ctx.send();
@@ -1234,7 +1277,7 @@ mod unit_tests {
         ctx.set_stream(stream);
 
         // Fill up the TX buffer.
-        let data = vec![0u8; ctx.pkt.buf().unwrap().len()];
+        let data = vec![0u8; ctx.pkt.buf_capacity().unwrap()];
         ctx.init_data_pkt(data.as_slice());
         for _i in 0..(csm_defs::CONN_TX_BUF_SIZE / data.len() as u32) {
             ctx.send();

--- a/virtio-devices/src/vsock/csm/mod.rs
+++ b/virtio-devices/src/vsock/csm/mod.rs
@@ -37,6 +37,9 @@ pub enum Error {
     /// An I/O error occurred, when attempting to write data to the host-side stream.
     #[error("Error writing to host side stream")]
     StreamWrite(#[source] std::io::Error),
+    /// An I/O error occurred, when reading packet data.
+    #[error("Error reading packet buffer")]
+    PktBufRead,
 }
 
 type Result<T> = std::result::Result<T, Error>;

--- a/virtio-devices/src/vsock/csm/txbuf.rs
+++ b/virtio-devices/src/vsock/csm/txbuf.rs
@@ -7,6 +7,19 @@ use std::num::Wrapping;
 
 use super::{Error, Result, defs};
 
+pub(super) trait TxBufSource {
+    fn copy_to_tx_buf(&self, offset: usize, dst: &mut [u8]) -> Result<()>;
+}
+
+impl TxBufSource for [u8] {
+    fn copy_to_tx_buf(&self, offset: usize, dst: &mut [u8]) -> Result<()> {
+        let end = offset.checked_add(dst.len()).ok_or(Error::PktBufRead)?;
+        let src = self.get(offset..end).ok_or(Error::PktBufRead)?;
+        dst.copy_from_slice(src);
+        Ok(())
+    }
+}
+
 /// A simple ring-buffer implementation, used by vsock connections to buffer TX (guest -> host)
 /// data.  Memory for this buffer is allocated lazily, since buffering will only be needed when
 /// the host can't read fast enough.
@@ -42,15 +55,22 @@ impl TxBuf {
         (self.head - self.tail).0 as usize
     }
 
-    /// Push a byte slice onto the ring-buffer.
+    /// Push data from a copy source into the ring-buffer.
     ///
-    /// Either the entire source slice will be pushed to the ring-buffer, or none of it, if
-    /// there isn't enough room, in which case `Err(Error::TxBufFull)` is returned.
+    /// Either the entire length will be pushed to the ring-buffer, or none of it, if there
+    /// isn't enough room, in which case `Err(Error::TxBufFull)` is returned.
     ///
-    pub fn push(&mut self, src: &[u8]) -> Result<()> {
-        // Error out if there's no room to push the entire slice.
-        if self.len() + src.len() > Self::SIZE {
+    pub(super) fn push_from<S>(&mut self, src: &S, offset: usize, len: usize) -> Result<()>
+    where
+        S: TxBufSource + ?Sized,
+    {
+        // Error out if there's no room to push the entire length.
+        if self.len() + len > Self::SIZE {
             return Err(Error::TxBufFull);
+        }
+
+        if len == 0 {
+            return Ok(());
         }
 
         let data = self
@@ -60,23 +80,24 @@ impl TxBuf {
         // Buffer head, as an offset into the data slice.
         let head_ofs = self.head.0 as usize % Self::SIZE;
 
-        // Pushing a slice to this buffer can take either one or two slice copies: - one copy,
-        // if the slice fits between `head_ofs` and `Self::SIZE`; or - two copies, if the
+        // Pushing to this buffer can take either one or two copies: - one copy, if the data
+        // fits between `head_ofs` and `Self::SIZE`; or - two copies, if the
         // ring-buffer head wraps around.
 
         // First copy length: we can only go from the head offset up to the total buffer size.
-        let len = std::cmp::min(Self::SIZE - head_ofs, src.len());
-        data[head_ofs..(head_ofs + len)].copy_from_slice(&src[..len]);
+        let first_len = std::cmp::min(Self::SIZE - head_ofs, len);
+        src.copy_to_tx_buf(offset, &mut data[head_ofs..(head_ofs + first_len)])?;
 
-        // If the slice didn't fit, the buffer head will wrap around, and pushing continues
+        // If the data didn't fit, the buffer head will wrap around, and pushing continues
         // from the start of the buffer (`&self.data[0]`).
-        if len < src.len() {
-            data[..(src.len() - len)].copy_from_slice(&src[len..]);
+        if first_len < len {
+            let offset = offset.checked_add(first_len).ok_or(Error::PktBufRead)?;
+            src.copy_to_tx_buf(offset, &mut data[..(len - first_len)])?;
         }
 
-        // Either way, we've just pushed exactly `src.len()` bytes, so that's the amount by
+        // Either way, we've just pushed exactly `len` bytes, so that's the amount by
         // which the (wrapping) buffer head needs to move forward.
-        self.head += Wrapping(src.len() as u32);
+        self.head += Wrapping(len as u32);
 
         Ok(())
     }
@@ -138,6 +159,17 @@ impl TxBuf {
     ///
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Push a byte slice onto the ring-buffer.
+    ///
+    /// A thin convenience wrapper around `push_from`, used only by the unit tests to push a
+    /// plain slice without having to spell out the offset and length. Production code pushes
+    /// directly from a packet buffer via `push_from`.
+    ///
+    #[cfg(test)]
+    pub fn push(&mut self, src: &[u8]) -> Result<()> {
+        self.push_from(src, 0, src.len())
     }
 }
 
@@ -219,6 +251,22 @@ mod unit_tests {
         txbuf.push(&[1, 2, 3, 4]).unwrap();
         assert_eq!(txbuf.flush_to(&mut sink).unwrap(), 4);
         assert_eq!(sink.data, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_push_from_wrap() {
+        let mut txbuf = TxBuf::new();
+        let mut sink = TestSink::new();
+        let tmp: Vec<u8> = vec![0; TxBuf::SIZE - 2];
+        txbuf.push(tmp.as_slice()).unwrap();
+        txbuf.flush_to(&mut sink).unwrap();
+        sink.clear();
+
+        let src = [1, 2, 3, 4];
+        txbuf.push_from(&src[..], 0, src.len()).unwrap();
+
+        assert_eq!(txbuf.flush_to(&mut sink).unwrap(), 4);
+        assert_eq!(sink.data, src);
     }
 
     #[test]

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -502,15 +502,26 @@ impl VsockPacket {
     /// Writes the local copy of the packet header to the guest memory.
     ///
     pub fn commit_hdr<M: GuestMemory>(&mut self, guest_mem: &M) -> Result<()> {
-        if self.len() as usize > defs::MAX_PKT_BUF_SIZE {
-            return Err(VsockError::InvalidPktLen(self.len()));
-        }
+        self.validate_len()?;
 
         guest_mem
             .write(self.hdr(), self.guest_hdr_addr)
             .map_err(|_| VsockError::GuestMemory)?;
 
         Ok(())
+    }
+
+    fn validate_len(&self) -> Result<()> {
+        let len = self.len() as usize;
+        if len > defs::MAX_PKT_BUF_SIZE {
+            return Err(VsockError::InvalidPktLen(self.len()));
+        }
+
+        match &self.buf {
+            Some(buf) if len > buf.len() => Err(VsockError::InvalidPktLen(self.len())),
+            None if len > 0 => Err(VsockError::PktBufMissing),
+            _ => Ok(()),
+        }
     }
 
     pub fn has_buf(&self) -> bool {
@@ -1096,5 +1107,44 @@ mod unit_tests {
             .read_slice(&mut after, GuestAddress(data_gpa))
             .unwrap();
         assert_eq!(&after, &payload);
+    }
+
+    #[test]
+    fn test_commit_hdr_allows_zero_length_packet() {
+        create_context!(test_ctx, handler_ctx);
+        let mut pkt = VsockPacket::from_rx_virtq_head(
+            &mut handler_ctx.handler.queues[0]
+                .iter(&test_ctx.mem)
+                .unwrap()
+                .next()
+                .unwrap(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(pkt.len(), 0);
+        pkt.commit_hdr(&test_ctx.mem).unwrap();
+    }
+
+    #[test]
+    fn test_commit_hdr_rejects_len_above_buf_capacity() {
+        create_context!(test_ctx, handler_ctx);
+        let mut pkt = VsockPacket::from_rx_virtq_head(
+            &mut handler_ctx.handler.queues[0]
+                .iter(&test_ctx.mem)
+                .unwrap()
+                .next()
+                .unwrap(),
+            None,
+        )
+        .unwrap();
+
+        let cap = pkt.buf_capacity().unwrap() as u32;
+        pkt.set_len(cap + 1);
+
+        match pkt.commit_hdr(&test_ctx.mem) {
+            Err(VsockError::InvalidPktLen(n)) => assert_eq!(n, cap + 1),
+            other => panic!("expected InvalidPktLen, got {other:?}"),
+        }
     }
 }

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -11,20 +11,23 @@
 //! the header, and the remaining descriptors (if any) hold the data. The data descriptors are
 //! only present for data packets (VSOCK_OP_RW).
 //!
-//! `VsockPacket` wraps these two buffers and provides direct access to the data stored
-//! in guest memory. This is done to avoid unnecessarily copying data from guest memory
-//! to temporary buffers, before passing it on to the vsock backend.
+//! `VsockPacket` copies the header locally. Contiguous packet data stays in guest memory as a
+//! checked range, so it can be moved with volatile I/O without exposing raw host pointers.
+//! Multi-descriptor TX packets use a local bounce buffer.
 
+use std::io::{self, ErrorKind, Read, Write};
 use std::ops::Deref;
 
 use byteorder::{ByteOrder, LittleEndian};
 use virtio_queue::DescriptorChain;
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemory};
+use vm_memory::{
+    Address, Bytes, GuestAddress, GuestMemory, ReadVolatile, VolatileMemoryError, WriteVolatile,
+};
 use vm_virtio::AccessPlatform;
 use vm_virtio::checked_descriptor::DescriptorChainExt;
 
 use super::{Result, VsockError, defs};
-use crate::get_host_address_range;
+use crate::{GuestMemoryMmap, get_host_address_range};
 
 // The vsock packet header is defined by the C struct:
 //
@@ -92,13 +95,147 @@ const HDROFF_BUF_ALLOC: usize = 36;
 const HDROFF_FWD_CNT: usize = 40;
 
 /// The packet data buffer, which may be either:
-/// - a borrowed slice of guest memory, if the packet data is stored in one contiguous buffer
+/// - a contiguous range of guest memory, if the packet data is stored in one contiguous buffer
 ///   described by a single virtq descriptor;
 /// - an owned, linear buffer, if the packet data is stored in multiple buffers described by
 ///   multiple virtq descriptors.
 enum PacketBuffer {
-    Borrowed { ptr: *mut u8, len: usize },
+    Guest {
+        mem: GuestMemoryMmap,
+        addr: GuestAddress,
+        len: usize,
+    },
     Owned(Box<[u8]>),
+}
+
+impl PacketBuffer {
+    fn guest(mem: GuestMemoryMmap, addr: GuestAddress, len: usize) -> Result<Self> {
+        // Validate the range before storing it.
+        mem.get_slice(addr, len)
+            .map_err(|_| VsockError::GuestMemory)?;
+
+        Ok(Self::Guest { mem, addr, len })
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Guest { len, .. } => *len,
+            Self::Owned(buf) => buf.len(),
+        }
+    }
+
+    fn check_range(&self, offset: usize, len: usize) -> Result<()> {
+        let end = offset.checked_add(len).ok_or(VsockError::GuestMemory)?;
+        if offset > self.len() || len > self.len() - offset {
+            return Err(VsockError::InvalidPktLen(
+                u32::try_from(end).unwrap_or(u32::MAX),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn guest_addr(addr: GuestAddress, offset: usize) -> Result<GuestAddress> {
+        addr.checked_add(u64::try_from(offset).map_err(|_| VsockError::GuestMemory)?)
+            .ok_or(VsockError::GuestMemory)
+    }
+
+    fn copy_to_slice(&self, offset: usize, dst: &mut [u8]) -> Result<()> {
+        self.check_range(offset, dst.len())?;
+        if dst.is_empty() {
+            return Ok(());
+        }
+
+        match self {
+            Self::Guest { mem, addr, .. } => {
+                let addr = Self::guest_addr(*addr, offset)?;
+                let slice = mem
+                    .get_slice(addr, dst.len())
+                    .map_err(|_| VsockError::GuestMemory)?;
+                if slice.copy_to(dst) != dst.len() {
+                    return Err(VsockError::GuestMemory);
+                }
+            }
+            Self::Owned(buf) => {
+                dst.copy_from_slice(&buf[offset..offset + dst.len()]);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn copy_from_slice(&mut self, offset: usize, src: &[u8]) -> Result<()> {
+        self.check_range(offset, src.len())?;
+        if src.is_empty() {
+            return Ok(());
+        }
+
+        match self {
+            Self::Guest { mem, addr, .. } => {
+                let addr = Self::guest_addr(*addr, offset)?;
+                let slice = mem
+                    .get_slice(addr, src.len())
+                    .map_err(|_| VsockError::GuestMemory)?;
+                slice.copy_from(src);
+            }
+            Self::Owned(buf) => {
+                buf[offset..offset + src.len()].copy_from_slice(src);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn read_volatile_from<R>(&mut self, reader: &mut R, len: usize) -> io::Result<usize>
+    where
+        R: Read + ReadVolatile,
+    {
+        self.check_range(0, len)
+            .map_err(|e| vsock_error_to_io(&e))?;
+
+        match self {
+            Self::Guest { mem, addr, .. } => {
+                let mut slice = mem.get_slice(*addr, len).map_err(|_| {
+                    io::Error::new(ErrorKind::InvalidInput, "invalid guest memory range")
+                })?;
+                reader
+                    .read_volatile(&mut slice)
+                    .map_err(volatile_error_to_io)
+            }
+            Self::Owned(buf) => reader.read(&mut buf[..len]),
+        }
+    }
+
+    fn write_volatile_to<W>(&self, writer: &mut W, offset: usize, len: usize) -> io::Result<usize>
+    where
+        W: Write + WriteVolatile,
+    {
+        self.check_range(offset, len)
+            .map_err(|e| vsock_error_to_io(&e))?;
+
+        match self {
+            Self::Guest { mem, addr, .. } => {
+                let addr = Self::guest_addr(*addr, offset).map_err(|e| vsock_error_to_io(&e))?;
+                let slice = mem.get_slice(addr, len).map_err(|_| {
+                    io::Error::new(ErrorKind::InvalidInput, "invalid guest memory range")
+                })?;
+                writer.write_volatile(&slice).map_err(volatile_error_to_io)
+            }
+            Self::Owned(buf) => writer.write(&buf[offset..offset + len]),
+        }
+    }
+}
+
+fn volatile_error_to_io(err: VolatileMemoryError) -> io::Error {
+    match err {
+        VolatileMemoryError::IOError(err) => err,
+        other => io::Error::other(other),
+    }
+}
+
+fn vsock_error_to_io(err: &VsockError) -> io::Error {
+    io::Error::new(ErrorKind::InvalidInput, format!("{err:?}"))
 }
 
 /// The vsock packet, implemented as a wrapper over a virtq descriptor chain:
@@ -125,8 +262,7 @@ impl VsockPacket {
         access_platform: Option<&dyn AccessPlatform>,
     ) -> Result<Self>
     where
-        M: Clone + Deref,
-        M::Target: GuestMemory,
+        M: Clone + Deref<Target = GuestMemoryMmap>,
     {
         let head = desc_chain
             .next_checked(access_platform)
@@ -173,29 +309,31 @@ impl VsockPacket {
             return Err(VsockError::InvalidPktLen(pkt.len()));
         }
 
-        // For small packets, the data may be stored in the same descriptor as the header.
+        let total_len = pkt.len() as usize;
+
         if !head.has_next() {
-            let buf_size: usize = head.len() as usize - VSOCK_PKT_HDR_SIZE;
-            if buf_size < pkt.len() as usize {
+            // For small packets, data may be stored in the same descriptor as
+            // the header.
+            let buf_size_in_head = head.len() as usize - VSOCK_PKT_HDR_SIZE;
+            // The descriptor must fit the length advertised by the header.
+            if buf_size_in_head < total_len {
                 return Err(VsockError::BufDescTooSmall);
             }
-            let buf_ptr = get_host_address_range(
-                desc_chain.memory(),
-                head.addr()
-                    .checked_add(VSOCK_PKT_HDR_SIZE as u64)
-                    .ok_or(VsockError::GuestMemory)?,
-                buf_size,
-            )
-            .ok_or(VsockError::GuestMemory)?;
-            pkt.buf = Some(PacketBuffer::Borrowed {
-                ptr: buf_ptr,
-                len: buf_size,
-            });
+
+            let buf_addr = head
+                .addr()
+                .checked_add(VSOCK_PKT_HDR_SIZE as u64)
+                .ok_or(VsockError::GuestMemory)?;
+            pkt.buf = Some(PacketBuffer::guest(
+                desc_chain.memory().clone(),
+                buf_addr,
+                total_len,
+            )?);
 
             return Ok(pkt);
         }
 
-        // We have separate header and data descriptors.
+        // The packet data starts in the descriptor after the header.
         let buf_desc = desc_chain
             .next_checked(access_platform)
             .map_err(|_| VsockError::GuestMemory)?
@@ -208,7 +346,6 @@ impl VsockPacket {
 
         if buf_desc.has_next() {
             // Multiple data descriptors -- copy into a linear buffer.
-            let total_len = pkt.len() as usize;
             let mut owned = vec![0u8; total_len];
             let mut offset = 0usize;
             let mut cur_desc = Some(buf_desc);
@@ -245,18 +382,16 @@ impl VsockPacket {
             }
             pkt.buf = Some(PacketBuffer::Owned(owned.into_boxed_slice()));
         } else {
-            // The data buffer should be large enough to fit the size of the data, as described by
-            // the header descriptor.
-            if buf_desc.len() < pkt.len() {
+            // A single data descriptor can be kept as a guest-memory range.
+            // It still has to fit the length advertised by the header.
+            if (buf_desc.len() as usize) < total_len {
                 return Err(VsockError::BufDescTooSmall);
             }
-            let buf_size = buf_desc.len() as usize;
-            let buf_ptr = get_host_address_range(desc_chain.memory(), buf_desc.addr(), buf_size)
-                .ok_or(VsockError::GuestMemory)?;
-            pkt.buf = Some(PacketBuffer::Borrowed {
-                ptr: buf_ptr,
-                len: buf_size,
-            });
+            pkt.buf = Some(PacketBuffer::guest(
+                desc_chain.memory().clone(),
+                buf_desc.addr(),
+                total_len,
+            )?);
         }
 
         Ok(pkt)
@@ -272,8 +407,7 @@ impl VsockPacket {
         access_platform: Option<&dyn AccessPlatform>,
     ) -> Result<Self>
     where
-        M: Clone + Deref,
-        M::Target: GuestMemory,
+        M: Clone + Deref<Target = GuestMemoryMmap>,
     {
         let head = desc_chain
             .next_checked(access_platform)
@@ -304,7 +438,7 @@ impl VsockPacket {
             .map_err(|_| VsockError::GuestMemory)?;
 
         // Prior to Linux v6.3 there are two descriptors
-        if head.has_next() {
+        let (buf_size, buf_addr) = if head.has_next() {
             let buf_desc = desc_chain
                 .next_checked(access_platform)
                 .map_err(|_| VsockError::GuestMemory)?
@@ -318,33 +452,39 @@ impl VsockPacket {
                 return Err(VsockError::BufDescTooSmall);
             }
 
-            Ok(Self {
-                guest_hdr_addr,
-                hdr,
-                buf: Some(PacketBuffer::Borrowed {
-                    ptr: get_host_address_range(desc_chain.memory(), buf_desc.addr(), buf_size)
-                        .ok_or(VsockError::GuestMemory)?,
-                    len: buf_size,
-                }),
-            })
+            if buf_size == 0 {
+                (0, None)
+            } else {
+                (buf_size, Some(buf_desc.addr()))
+            }
         } else {
             let buf_size: usize = head.len() as usize - VSOCK_PKT_HDR_SIZE;
-            Ok(Self {
-                guest_hdr_addr,
-                hdr,
-                buf: Some(PacketBuffer::Borrowed {
-                    ptr: get_host_address_range(
-                        desc_chain.memory(),
-                        head.addr()
-                            .checked_add(VSOCK_PKT_HDR_SIZE as u64)
-                            .ok_or(VsockError::GuestMemory)?,
-                        buf_size,
-                    )
-                    .ok_or(VsockError::GuestMemory)?,
-                    len: buf_size,
-                }),
-            })
-        }
+            if buf_size == 0 {
+                (0, None)
+            } else {
+                let addr = head
+                    .addr()
+                    .checked_add(VSOCK_PKT_HDR_SIZE as u64)
+                    .ok_or(VsockError::GuestMemory)?;
+                (buf_size, Some(addr))
+            }
+        };
+
+        let buf = if let Some(addr) = buf_addr {
+            Some(PacketBuffer::guest(
+                desc_chain.memory().clone(),
+                addr,
+                buf_size,
+            )?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            guest_hdr_addr,
+            hdr,
+            buf,
+        })
     }
 
     /// Provides in-place, byte-slice, access to the vsock packet header.
@@ -373,6 +513,23 @@ impl VsockPacket {
         Ok(())
     }
 
+    pub fn has_buf(&self) -> bool {
+        self.buf.is_some()
+    }
+
+    /// Return the data buffer capacity, which may be larger than `len()`.
+    pub fn buf_capacity(&self) -> Option<usize> {
+        self.buf.as_ref().map(PacketBuffer::len)
+    }
+
+    /// Copy data from the packet buffer into `dst`.
+    pub fn copy_buf_to_slice(&self, offset: usize, dst: &mut [u8]) -> Result<()> {
+        self.buf
+            .as_ref()
+            .ok_or(VsockError::PktBufMissing)?
+            .copy_to_slice(offset, dst)
+    }
+
     /// Provides in-place, byte-slice access to the vsock packet data buffer.
     ///
     /// Note: control packets (e.g. connection request or reset) have no data buffer associated.
@@ -383,10 +540,12 @@ impl VsockPacket {
     pub fn buf(&self) -> Option<&[u8]> {
         match self.buf.as_ref()? {
             PacketBuffer::Owned(owned) => Some(owned),
-            PacketBuffer::Borrowed { ptr, len } => {
+            PacketBuffer::Guest { mem, addr, len } => {
+                let ptr = get_host_address_range(mem, *addr, *len)?;
+
                 // SAFETY: bound checks have already been performed when creating the packet
                 // from the virtq descriptor.
-                Some(unsafe { std::slice::from_raw_parts((*ptr).cast(), *len) })
+                Some(unsafe { std::slice::from_raw_parts(ptr.cast(), *len) })
             }
         }
     }
@@ -401,12 +560,49 @@ impl VsockPacket {
     pub fn buf_mut(&mut self) -> Option<&mut [u8]> {
         match self.buf.as_mut()? {
             PacketBuffer::Owned(owned) => Some(owned),
-            PacketBuffer::Borrowed { ptr, len } => {
+            PacketBuffer::Guest { mem, addr, len } => {
+                let ptr = get_host_address_range(mem, *addr, *len)?;
+
                 // SAFETY: bound checks have already been performed when creating the packet
                 // from the virtq descriptor.
-                Some(unsafe { std::slice::from_raw_parts_mut(*ptr, *len) })
+                Some(unsafe { std::slice::from_raw_parts_mut(ptr, *len) })
             }
         }
+    }
+
+    #[cfg(test)]
+    pub fn copy_buf_from_slice(&mut self, offset: usize, src: &[u8]) -> Result<()> {
+        self.buf
+            .as_mut()
+            .ok_or(VsockError::PktBufMissing)?
+            .copy_from_slice(offset, src)
+    }
+
+    /// Read bytes directly into the packet buffer.
+    pub fn read_volatile_from<R>(&mut self, reader: &mut R, len: usize) -> io::Result<usize>
+    where
+        R: Read + ReadVolatile,
+    {
+        self.buf
+            .as_mut()
+            .ok_or_else(|| io::Error::new(ErrorKind::InvalidInput, "missing packet buffer"))?
+            .read_volatile_from(reader, len)
+    }
+
+    /// Write bytes directly from the packet buffer.
+    pub fn write_volatile_to<W>(
+        &self,
+        writer: &mut W,
+        offset: usize,
+        len: usize,
+    ) -> io::Result<usize>
+    where
+        W: Write + WriteVolatile,
+    {
+        self.buf
+            .as_ref()
+            .ok_or_else(|| io::Error::new(ErrorKind::InvalidInput, "missing packet buffer"))?
+            .write_volatile_to(writer, offset, len)
     }
 
     pub fn src_cid(&self) -> u64 {
@@ -578,10 +774,7 @@ mod unit_tests {
             )
             .unwrap();
             assert_eq!(pkt.hdr().len(), VSOCK_PKT_HDR_SIZE);
-            assert_eq!(
-                pkt.buf().unwrap().len(),
-                handler_ctx.guest_txvq.dtable[1].len.get() as usize
-            );
+            assert_eq!(pkt.buf_capacity().unwrap(), pkt.len() as usize);
         }
 
         // Test case: error on write-only hdr descriptor.
@@ -606,7 +799,7 @@ mod unit_tests {
         {
             create_context!(test_ctx, handler_ctx);
             set_pkt_len(0, &handler_ctx.guest_txvq.dtable[0], &test_ctx.mem);
-            let mut pkt = VsockPacket::from_tx_virtq_head(
+            let pkt = VsockPacket::from_tx_virtq_head(
                 &mut handler_ctx.handler.queues[1]
                     .iter(&test_ctx.mem)
                     .unwrap()
@@ -615,8 +808,8 @@ mod unit_tests {
                 None,
             )
             .unwrap();
-            assert!(pkt.buf().is_none());
-            assert!(pkt.buf_mut().is_none());
+            assert!(!pkt.has_buf());
+            assert!(pkt.buf_capacity().is_none());
         }
 
         // Test case: TX packet has more data than we can handle.
@@ -677,6 +870,14 @@ mod unit_tests {
         guest_txvq.avail.idx.set(1);
 
         set_pkt_len(8 * 1024, &guest_txvq.dtable[0], &test_ctx.mem);
+        test_ctx
+            .mem
+            .write_slice(&[0xaa_u8; 4 * 1024], GuestAddress(0x0061_1000))
+            .unwrap();
+        test_ctx
+            .mem
+            .write_slice(&[0xbb_u8; 4 * 1024], GuestAddress(0x0061_2000))
+            .unwrap();
 
         let pkt = VsockPacket::from_tx_virtq_head(
             &mut queue.iter(&test_ctx.mem).unwrap().next().unwrap(),
@@ -685,7 +886,21 @@ mod unit_tests {
         .unwrap();
 
         assert_eq!(pkt.len(), 8 * 1024);
-        assert_eq!(pkt.buf().unwrap().len(), 8 * 1024);
+        assert_eq!(pkt.buf_capacity().unwrap(), 8 * 1024);
+
+        test_ctx
+            .mem
+            .write_slice(&[0xff_u8; 4 * 1024], GuestAddress(0x0061_1000))
+            .unwrap();
+        test_ctx
+            .mem
+            .write_slice(&[0xff_u8; 4 * 1024], GuestAddress(0x0061_2000))
+            .unwrap();
+
+        let mut data = vec![0u8; 8 * 1024];
+        pkt.copy_buf_to_slice(0, &mut data).unwrap();
+        assert_eq!(&data[..4 * 1024], &[0xaa_u8; 4 * 1024]);
+        assert_eq!(&data[4 * 1024..], &[0xbb_u8; 4 * 1024]);
     }
 
     #[test]
@@ -704,7 +919,7 @@ mod unit_tests {
             .unwrap();
             assert_eq!(pkt.hdr().len(), VSOCK_PKT_HDR_SIZE);
             assert_eq!(
-                pkt.buf().unwrap().len(),
+                pkt.buf_capacity().unwrap(),
                 handler_ctx.guest_rxvq.dtable[1].len.get() as usize
             );
         }
@@ -842,17 +1057,84 @@ mod unit_tests {
         .unwrap();
 
         assert_eq!(
-            pkt.buf().unwrap().len(),
-            handler_ctx.guest_rxvq.dtable[1].len.get() as usize
-        );
-        assert_eq!(
-            pkt.buf_mut().unwrap().len(),
+            pkt.buf_capacity().unwrap(),
             handler_ctx.guest_rxvq.dtable[1].len.get() as usize
         );
 
-        for i in 0..pkt.buf().unwrap().len() {
-            pkt.buf_mut().unwrap()[i] = (i % 0x100) as u8;
-            assert_eq!(pkt.buf().unwrap()[i], (i % 0x100) as u8);
+        let mut payload = vec![0u8; pkt.buf_capacity().unwrap()];
+        for (i, byte) in payload.iter_mut().enumerate() {
+            *byte = (i % 0x100) as u8;
         }
+        pkt.copy_buf_from_slice(0, &payload).unwrap();
+
+        let mut actual = vec![0u8; payload.len()];
+        pkt.copy_buf_to_slice(0, &mut actual).unwrap();
+        assert_eq!(actual, payload);
+    }
+
+    #[test]
+    fn test_tx_packet_data_uses_guest_memory() {
+        create_context!(test_ctx, handler_ctx);
+        set_pkt_len(8, &handler_ctx.guest_txvq.dtable[0], &test_ctx.mem);
+
+        let data_gpa = handler_ctx.guest_txvq.dtable[1].addr.get();
+        let original = [0x11_u8, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+        test_ctx
+            .mem
+            .write_slice(&original, GuestAddress(data_gpa))
+            .unwrap();
+
+        let pkt = VsockPacket::from_tx_virtq_head(
+            &mut handler_ctx.handler.queues[1]
+                .iter(&test_ctx.mem)
+                .unwrap()
+                .next()
+                .unwrap(),
+            None,
+        )
+        .unwrap();
+
+        test_ctx
+            .mem
+            .write_slice(&[0xff_u8; 8], GuestAddress(data_gpa))
+            .unwrap();
+
+        let mut data = [0u8; 8];
+        pkt.copy_buf_to_slice(0, &mut data).unwrap();
+        assert_eq!(data, [0xff_u8; 8]);
+    }
+
+    #[test]
+    fn test_rx_packet_read_volatile_writes_to_guest() {
+        create_context!(test_ctx, handler_ctx);
+        let mut pkt = VsockPacket::from_rx_virtq_head(
+            &mut handler_ctx.handler.queues[0]
+                .iter(&test_ctx.mem)
+                .unwrap()
+                .next()
+                .unwrap(),
+            None,
+        )
+        .unwrap();
+
+        let data_gpa = handler_ctx.guest_rxvq.dtable[1].addr.get();
+        let mut before = [0u8; 6];
+        test_ctx
+            .mem
+            .read_slice(&mut before, GuestAddress(data_gpa))
+            .unwrap();
+        assert_eq!(&before, &[0u8; 6]);
+
+        let payload = [0xab_u8, 0xcd, 0xef, 0x01, 0x23, 0x45];
+        let mut reader = payload.as_slice();
+        let read = pkt.read_volatile_from(&mut reader, payload.len()).unwrap();
+        pkt.set_len(read as u32);
+
+        let mut after = [0u8; 6];
+        test_ctx
+            .mem
+            .read_slice(&mut after, GuestAddress(data_gpa))
+            .unwrap();
+        assert_eq!(&after, &payload);
     }
 }

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -27,7 +27,7 @@ use vm_virtio::AccessPlatform;
 use vm_virtio::checked_descriptor::DescriptorChainExt;
 
 use super::{Result, VsockError, defs};
-use crate::{GuestMemoryMmap, get_host_address_range};
+use crate::GuestMemoryMmap;
 
 // The vsock packet header is defined by the C struct:
 //
@@ -528,46 +528,6 @@ impl VsockPacket {
             .as_ref()
             .ok_or(VsockError::PktBufMissing)?
             .copy_to_slice(offset, dst)
-    }
-
-    /// Provides in-place, byte-slice access to the vsock packet data buffer.
-    ///
-    /// Note: control packets (e.g. connection request or reset) have no data buffer associated.
-    ///       For those packets, this method will return `None`.
-    /// Also note: calling `len()` on the returned slice will yield the buffer size, which may be
-    ///            (and often is) larger than the length of the packet data. The packet data length
-    ///            is stored in the packet header, and accessible via `VsockPacket::len()`.
-    pub fn buf(&self) -> Option<&[u8]> {
-        match self.buf.as_ref()? {
-            PacketBuffer::Owned(owned) => Some(owned),
-            PacketBuffer::Guest { mem, addr, len } => {
-                let ptr = get_host_address_range(mem, *addr, *len)?;
-
-                // SAFETY: bound checks have already been performed when creating the packet
-                // from the virtq descriptor.
-                Some(unsafe { std::slice::from_raw_parts(ptr.cast(), *len) })
-            }
-        }
-    }
-
-    /// Provides in-place, byte-slice, mutable access to the vsock packet data buffer.
-    ///
-    /// Note: control packets (e.g. connection request or reset) have no data buffer associated.
-    ///       For those packets, this method will return `None`.
-    /// Also note: calling `len()` on the returned slice will yield the buffer size, which may be
-    ///            (and often is) larger than the length of the packet data. The packet data length
-    ///            is stored in the packet header, and accessible via `VsockPacket::len()`.
-    pub fn buf_mut(&mut self) -> Option<&mut [u8]> {
-        match self.buf.as_mut()? {
-            PacketBuffer::Owned(owned) => Some(owned),
-            PacketBuffer::Guest { mem, addr, len } => {
-                let ptr = get_host_address_range(mem, *addr, *len)?;
-
-                // SAFETY: bound checks have already been performed when creating the packet
-                // from the virtq descriptor.
-                Some(unsafe { std::slice::from_raw_parts_mut(ptr, *len) })
-            }
-        }
     }
 
     #[cfg(test)]

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -555,12 +555,11 @@ mod unit_tests {
 
     fn set_pkt_len(len: u32, guest_desc: &GuestQDesc, mem: &GuestMemoryMmap) {
         let hdr_gpa = guest_desc.addr.get();
-        let hdr_ptr =
-            get_host_address_range(mem, GuestAddress(hdr_gpa), VSOCK_PKT_HDR_SIZE).unwrap();
-        // SAFETY: The length is valid.
-        let len_ptr = unsafe { hdr_ptr.add(HDROFF_LEN) };
-        // SAFETY: The length is valid.
-        LittleEndian::write_u32(unsafe { std::slice::from_raw_parts_mut(len_ptr, 4) }, len);
+        mem.write_slice(
+            &len.to_le_bytes(),
+            GuestAddress(hdr_gpa + HDROFF_LEN as u64),
+        )
+        .expect("test packet header len field should be in guest memory");
     }
 
     #[test]

--- a/virtio-devices/src/vsock/unix/muxer.rs
+++ b/virtio-devices/src/vsock/unix/muxer.rs
@@ -969,11 +969,17 @@ mod unit_tests {
             peer_port: u32,
             data: &[u8],
         ) -> &mut VsockPacket {
-            assert!(data.len() <= self.pkt.buf().unwrap().len());
+            assert!(data.len() <= self.pkt.buf_capacity().unwrap());
             self.init_pkt(local_port, peer_port, uapi::VSOCK_OP_RW)
                 .set_len(data.len() as u32);
-            self.pkt.buf_mut().unwrap()[..data.len()].copy_from_slice(data);
+            self.pkt.copy_buf_from_slice(0, data).unwrap();
             &mut self.pkt
+        }
+
+        fn pkt_data(&self) -> Vec<u8> {
+            let mut data = vec![0u8; self.pkt.len() as usize];
+            self.pkt.copy_buf_to_slice(0, &mut data).unwrap();
+            data
         }
 
         fn send(&mut self) {
@@ -1204,7 +1210,7 @@ mod unit_tests {
         assert!(ctx.muxer.has_pending_rx());
         ctx.recv();
         assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RW);
-        assert_eq!(ctx.pkt.buf().unwrap()[..data.len()], data);
+        assert_eq!(ctx.pkt_data().as_slice(), data);
         assert_eq!(ctx.pkt.src_port(), LOCAL_PORT);
         assert_eq!(ctx.pkt.dst_port(), PEER_PORT);
 
@@ -1236,7 +1242,7 @@ mod unit_tests {
         assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RW);
         assert_eq!(ctx.pkt.src_port(), local_port);
         assert_eq!(ctx.pkt.dst_port(), peer_port);
-        assert_eq!(ctx.pkt.buf().unwrap()[..data.len()], data);
+        assert_eq!(ctx.pkt_data().as_slice(), data);
     }
 
     #[test]


### PR DESCRIPTION
The main focus of this series is to remove the raw pointer carried by VsockPackets without a lifetime. In addition those raw pointers were unsafely turned in to slices. When back by mutable guest memory that is undefined behavior.