### PR TITLE
pci: vfio: Implement migration v2 for snapshot and restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1667,7 @@ name = "pci"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "byteorder",
  "hypervisor",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ serde_with = { version = "3.19.0", default-features = false }
 
 # other crates
 anyhow = "1.0.102"
+base64 = "0.22.1"
 bitflags = "2.11.1"
 byteorder = "1.5.0"
 cfg-if = "1.0.4"

--- a/docs/snapshot_restore.md
+++ b/docs/snapshot_restore.md
@@ -139,9 +139,13 @@ In the example above, the net device with id `net1` will be backed by FDs '23'
 and '24', and the net device with id `net2` will be backed by FDs '25' and '26'
 from the restored VM.
 
-## Limitations
+## VFIO devices
 
-VFIO devices is out of scope.
+Snapshot and restore are supported for VFIO devices that implement the kernel
+VFIO migration v2 protocol (e.g. Mellanox NICs bound to the `mlx5_vfio_pci`
+driver).
+
+See [`vfio.md`](vfio.md) for details on requirements and behavior.
 
 ## Offload Snapshot and Restore
 

--- a/docs/vfio.md
+++ b/docs/vfio.md
@@ -194,3 +194,47 @@ mmio address space is available for use by devices on PCI segment 1.
 --pci-segment pci_segment=0,mmio32_aperture_weight=2
 --pci-segment pci_segment=1,mmio32_aperture_weight=1
 ```
+
+## Snapshot and Restore of VFIO Devices
+
+Cloud Hypervisor supports snapshotting and restoring VFIO devices that advertise
+the kernel VFIO migration v2 protocol. Live migration of VFIO devices, where the
+guest keeps running while its state transfers, is a separate effort not covered
+by this section.
+
+### Requirements
+
+- **Kernel.** Linux 5.18 or newer for the migration v2 ioctls. 6.0 or newer is
+  recommended for the broadest set of state transitions.
+- **Driver.** The device must be bound to a VFIO variant driver that implements
+  migration v2, for example `mlx5_vfio_pci` on Mellanox NICs. The generic
+  `vfio_pci` driver does not implement migration and is treated as non
+  migratable.
+
+### Behavior
+
+At device creation time, Cloud Hypervisor probes the VFIO device for migration
+support via `VFIO_DEVICE_FEATURE_MIGRATION`. A device that advertises migration
+v2 with at least STOP_COPY is driven through the full state machine on snapshot
+and restore.
+
+Pausing the guest transitions the device to STOP. Snapshot then walks STOP_COPY,
+captures the opaque device state, and returns the device to STOP. On restore, the
+saved device blob is written through RESUMING in a single transition and the
+kernel handles the intermediate STOP arc internally. After the blob loads, Cloud
+Hypervisor pushes the saved PCI_COMMAND to the device and rearms MSI or MSI-X
+eventfds, because the kernel's view of those is not restored by in memory state
+replay alone. The device is left in RESUMING and `resume()` drives it to RUNNING
+when the guest is resumed. This matches QEMU's `vfio_pci_load_config()` behavior.
+
+Migration support is logged at device init.
+
+```
+INFO  vfio: VFIO device 0000:01:00.0 supports migration v2 (flags=0x7, ...)
+```
+
+### Limitations
+
+The current snapshot format stores the blob as base64 inside the snapshot
+JSON. Very large blobs may benefit from a binary transport path in the
+future.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -114,6 +114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitfield-struct"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +986,7 @@ name = "pci"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "byteorder",
  "hypervisor",
  "libc",

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -12,6 +12,7 @@ mshv = ["hypervisor/mshv", "vfio-ioctls/mshv"]
 
 [dependencies]
 anyhow = { workspace = true }
+base64 = { workspace = true }
 byteorder = { workspace = true }
 hypervisor = { path = "../hypervisor" }
 libc = { workspace = true }

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -15,7 +15,7 @@ use anyhow::anyhow;
 use byteorder::{ByteOrder, LittleEndian};
 use hypervisor::HypervisorVmError;
 use libc::{_SC_PAGESIZE, sysconf};
-use log::{error, info};
+use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vfio_bindings::bindings::vfio::*;
@@ -437,6 +437,10 @@ pub(crate) trait Vfio: Send + Sync {
     fn unmask_irq(&self, _irq_index: u32) -> Result<(), VfioError> {
         unimplemented!()
     }
+
+    fn migration_flags(&self) -> Result<Option<u64>, VfioError> {
+        Ok(None)
+    }
 }
 
 struct VfioDeviceWrapper {
@@ -479,6 +483,12 @@ impl Vfio for VfioDeviceWrapper {
             .unmask_irq(irq_index)
             .map_err(VfioError::KernelVfio)
     }
+
+    fn migration_flags(&self) -> Result<Option<u64>, VfioError> {
+        self.device
+            .query_migration_support()
+            .map_err(VfioError::KernelVfio)
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -503,6 +513,8 @@ pub(crate) struct VfioCommon {
     pub(crate) patches: HashMap<usize, ConfigPatch>,
     x_nv_gpudirect_clique: Option<u8>,
     x_exclude_mmap_bars: Vec<u8>,
+    #[allow(dead_code)]
+    pub(crate) migration_flags: Option<u64>,
 }
 
 #[derive(Default)]
@@ -542,6 +554,27 @@ impl VfioCommon {
             pci_configuration_state,
         );
 
+        let migration_flags = match vfio_wrapper.migration_flags() {
+            Ok(Some(flags)) => {
+                info!(
+                    "VFIO device {bdf} supports migration v2 (flags=0x{flags:x}, \
+                     STOP_COPY={}, P2P={}, PRE_COPY={})",
+                    flags & VFIO_MIGRATION_STOP_COPY as u64 != 0,
+                    flags & VFIO_MIGRATION_P2P as u64 != 0,
+                    flags & VFIO_MIGRATION_PRE_COPY as u64 != 0,
+                );
+                Some(flags)
+            }
+            Ok(None) => {
+                debug!("VFIO device {bdf} does not support migration v2");
+                None
+            }
+            Err(e) => {
+                debug!("VFIO device {bdf} migration probe failed, treating as non-migratable: {e}");
+                None
+            }
+        };
+
         let mut vfio_common = VfioCommon {
             mmio_regions: Vec::new(),
             configuration,
@@ -556,6 +589,7 @@ impl VfioCommon {
             patches: HashMap::new(),
             x_nv_gpudirect_clique: config.x_nv_gpudirect_clique,
             x_exclude_mmap_bars: config.x_exclude_mmap_bars,
+            migration_flags,
         };
 
         let state: Option<VfioCommonState> = snapshot

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -2456,3 +2456,274 @@ impl<M: GuestAddressSpace + Sync + Send> ExternalDmaMapping for VfioDmaMapping<M
             })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    // Trait default behavior and state enum round trip.
+
+    #[test]
+    fn vfio_migration_state_round_trips() {
+        for state in [
+            VfioMigrationState::Error,
+            VfioMigrationState::Stop,
+            VfioMigrationState::Running,
+            VfioMigrationState::StopCopy,
+            VfioMigrationState::Resuming,
+            VfioMigrationState::RunningP2P,
+            VfioMigrationState::PreCopy,
+            VfioMigrationState::PreCopyP2P,
+        ] {
+            let raw = u32::from(state);
+            assert_eq!(VfioMigrationState::try_from(raw).unwrap(), state);
+        }
+    }
+
+    #[test]
+    fn vfio_migration_state_invalid_errors() {
+        match VfioMigrationState::try_from(999_u32) {
+            Err(VfioError::InvalidMigrationState(999)) => {}
+            other => panic!("expected InvalidMigrationState(999), got {other:?}"),
+        }
+    }
+
+    struct DefaultVfio;
+    impl Vfio for DefaultVfio {}
+
+    #[test]
+    fn default_migration_flags_returns_none() {
+        assert!(matches!(DefaultVfio.migration_flags(), Ok(None)));
+    }
+
+    #[test]
+    fn default_set_migration_state_errors() {
+        assert!(matches!(
+            DefaultVfio.set_migration_state(VfioMigrationState::Stop),
+            Err(VfioError::NoMigrationSupport)
+        ));
+    }
+
+    // Save and load state machine flows, driven through a mock Vfio wrapper
+    // that records state transitions and stores the migration data in memory.
+
+    #[derive(Default)]
+    struct MockVfioState {
+        transitions: Vec<VfioMigrationState>,
+        save_blob: Vec<u8>,
+        loaded: Vec<u8>,
+        fail_at: Option<VfioMigrationState>,
+        fail_read: bool,
+    }
+
+    struct MockVfio {
+        state: Mutex<MockVfioState>,
+    }
+
+    impl MockVfio {
+        fn for_save(blob: Vec<u8>) -> Arc<Self> {
+            Arc::new(Self {
+                state: Mutex::new(MockVfioState {
+                    save_blob: blob,
+                    ..Default::default()
+                }),
+            })
+        }
+
+        fn for_load() -> Arc<Self> {
+            Arc::new(Self {
+                state: Mutex::new(MockVfioState::default()),
+            })
+        }
+
+        fn failing_at(target: VfioMigrationState) -> Arc<Self> {
+            Arc::new(Self {
+                state: Mutex::new(MockVfioState {
+                    fail_at: Some(target),
+                    ..Default::default()
+                }),
+            })
+        }
+
+        fn failing_read() -> Arc<Self> {
+            Arc::new(Self {
+                state: Mutex::new(MockVfioState {
+                    fail_read: true,
+                    ..Default::default()
+                }),
+            })
+        }
+
+        fn transitions(&self) -> Vec<VfioMigrationState> {
+            self.state.lock().unwrap().transitions.clone()
+        }
+
+        fn loaded(&self) -> Vec<u8> {
+            self.state.lock().unwrap().loaded.clone()
+        }
+    }
+
+    impl Vfio for MockVfio {
+        fn set_migration_state(&self, state: VfioMigrationState) -> Result<(), VfioError> {
+            let mut s = self.state.lock().unwrap();
+            s.transitions.push(state);
+            if s.fail_at == Some(state) {
+                return Err(VfioError::NoMigrationSupport);
+            }
+            Ok(())
+        }
+
+        fn read_migration_data(&self) -> Result<Vec<u8>, VfioError> {
+            let s = self.state.lock().unwrap();
+            if s.fail_read {
+                return Err(VfioError::NoMigrationSupport);
+            }
+            Ok(s.save_blob.clone())
+        }
+
+        fn write_migration_data(&self, data: &[u8]) -> Result<(), VfioError> {
+            self.state.lock().unwrap().loaded.extend_from_slice(data);
+            Ok(())
+        }
+
+        fn region_write(&self, _index: u32, _offset: u64, _data: &[u8]) {}
+    }
+
+    struct MockMsiInterruptManager;
+    impl InterruptManager for MockMsiInterruptManager {
+        type GroupConfig = MsiIrqGroupConfig;
+        fn create_group(&self, _: MsiIrqGroupConfig) -> io::Result<Arc<dyn InterruptSourceGroup>> {
+            unimplemented!("not exercised by the migration-helper tests")
+        }
+        fn destroy_group(&self, _: Arc<dyn InterruptSourceGroup>) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn test_vfio_common(vfio_wrapper: Arc<dyn Vfio>, migration_flags: Option<u64>) -> VfioCommon {
+        let configuration = PciConfiguration::new(
+            0,
+            0,
+            0,
+            PciClassCode::Other,
+            &PciVfioSubclass::VfioSubclass,
+            None,
+            PciHeaderType::Device,
+            0,
+            0,
+            None,
+            None,
+        );
+        VfioCommon {
+            configuration,
+            mmio_regions: Vec::new(),
+            interrupt: Interrupt {
+                intx: None,
+                msi: None,
+                msix: None,
+            },
+            msi_interrupt_manager: Arc::new(MockMsiInterruptManager),
+            legacy_interrupt_group: None,
+            vfio_wrapper,
+            patches: HashMap::new(),
+            x_nv_gpudirect_clique: None,
+            x_exclude_mmap_bars: Vec::new(),
+            migration_flags,
+        }
+    }
+
+    #[test]
+    fn save_migration_data_success_path() {
+        let blob = b"hello migration".to_vec();
+        let mock = MockVfio::for_save(blob.clone());
+        let common = test_vfio_common(mock.clone(), Some(1));
+        let got = common.save_migration_data().unwrap();
+        assert_eq!(got, blob);
+        assert_eq!(
+            mock.transitions(),
+            vec![VfioMigrationState::StopCopy, VfioMigrationState::Stop]
+        );
+    }
+
+    #[test]
+    fn save_migration_data_stop_copy_failure_does_not_attempt_stop() {
+        let mock = MockVfio::failing_at(VfioMigrationState::StopCopy);
+        let common = test_vfio_common(mock.clone(), Some(1));
+        let err = common.save_migration_data().unwrap_err();
+        assert!(matches!(err, MigratableError::Snapshot(_)));
+        // Entering STOP_COPY failed, so no STOP is attempted afterwards.
+        assert_eq!(mock.transitions(), vec![VfioMigrationState::StopCopy]);
+    }
+
+    #[test]
+    fn save_migration_data_read_failure_returns_to_stop() {
+        let mock = MockVfio::failing_read();
+        let common = test_vfio_common(mock.clone(), Some(1));
+        let err = common.save_migration_data().unwrap_err();
+        assert!(matches!(err, MigratableError::Snapshot(_)));
+        // STOP_COPY was entered, so the device is returned to STOP.
+        assert_eq!(
+            mock.transitions(),
+            vec![VfioMigrationState::StopCopy, VfioMigrationState::Stop]
+        );
+    }
+
+    #[test]
+    fn load_migration_data_success_path() {
+        let blob = b"restore me".to_vec();
+        let mock = MockVfio::for_load();
+        let common = test_vfio_common(mock.clone(), Some(1));
+        common.load_migration_data(&blob).unwrap();
+        assert_eq!(mock.loaded(), blob);
+        // Device is left in RESUMING so resume() can drive it to RUNNING.
+        assert_eq!(mock.transitions(), vec![VfioMigrationState::Resuming]);
+    }
+
+    #[test]
+    fn load_migration_data_recovers_on_failure() {
+        let mock = MockVfio::failing_at(VfioMigrationState::Resuming);
+        let common = test_vfio_common(mock.clone(), Some(1));
+        let err = common.load_migration_data(b"ignored").unwrap_err();
+        assert!(matches!(err, MigratableError::Restore(_)));
+        assert_eq!(
+            mock.transitions(),
+            vec![VfioMigrationState::Resuming, VfioMigrationState::Stop]
+        );
+    }
+
+    // A snapshot with migration state restored onto a device without migration
+    // support must fail rather than silently drop the device state.
+    #[test]
+    fn set_state_rejects_migration_data_without_support() {
+        let mock = MockVfio::for_load();
+        let mut common = test_vfio_common(mock, None);
+        let state = VfioCommonState {
+            intx_state: None,
+            msi_state: None,
+            msix_state: None,
+        };
+        let mig = VfioMigrationData {
+            blob: String::new(),
+        };
+        let err = common.set_state(&state, None, None, Some(mig)).unwrap_err();
+        assert!(matches!(err, VfioPciError::RestoreMigration(_)));
+    }
+
+    // A guest write to a non BAR, non MSI config register must mirror into
+    // the PciConfiguration shadow so a later snapshot() picks up the live
+    // value.
+    #[test]
+    fn write_config_register_mirrors_non_bar_into_shadow() {
+        let mock = MockVfio::for_load();
+        let mut common = test_vfio_common(mock, Some(1));
+
+        // PCI_COMMAND is reg index 1. Write the 16 bit command word only.
+        let cmd: u16 = 0x0406;
+        common.write_config_register(COMMAND_REG, 0, &cmd.to_le_bytes());
+
+        let got = common.configuration.read_reg(COMMAND_REG) & 0xFFFF;
+        assert_eq!(got as u16, cmd);
+    }
+}

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -89,6 +89,8 @@ pub enum VfioPciError {
     RetrievePciConfigurationState(#[source] anyhow::Error),
     #[error("Failed to retrieve VfioCommonState")]
     RetrieveVfioCommonState(#[source] anyhow::Error),
+    #[error("Failed to restore VFIO migration state")]
+    RestoreMigration(#[source] anyhow::Error),
 }
 
 #[derive(Copy, Clone)]
@@ -510,6 +512,10 @@ pub(crate) trait Vfio: Send + Sync {
     fn read_migration_data(&self) -> Result<Vec<u8>, VfioError> {
         Err(VfioError::NoMigrationSupport)
     }
+
+    fn write_migration_data(&self, _data: &[u8]) -> Result<(), VfioError> {
+        Err(VfioError::NoMigrationSupport)
+    }
 }
 
 struct VfioDeviceWrapper {
@@ -568,6 +574,12 @@ impl Vfio for VfioDeviceWrapper {
     fn read_migration_data(&self) -> Result<Vec<u8>, VfioError> {
         self.device
             .read_migration_data_to_end()
+            .map_err(VfioError::KernelVfio)
+    }
+
+    fn write_migration_data(&self, data: &[u8]) -> Result<(), VfioError> {
+        self.device
+            .write_migration_data(data)
             .map_err(VfioError::KernelVfio)
     }
 }
@@ -698,7 +710,13 @@ impl VfioCommon {
         })?;
 
         if let Some(state) = state.as_ref() {
-            vfio_common.set_state(state, msi_state, msix_state)?;
+            let mig: Option<VfioMigrationData> =
+                vm_migration::state_from_id(snapshot, VFIO_MIGRATION_ID).map_err(|e| {
+                    VfioPciError::RestoreMigration(anyhow!(
+                        "Failed to get VfioMigrationData from Snapshot: {e}"
+                    ))
+                })?;
+            vfio_common.set_state(state, msi_state, msix_state, mig)?;
         } else {
             vfio_common.parse_capabilities(bdf);
             vfio_common.initialize_legacy_interrupt()?;
@@ -910,14 +928,19 @@ impl VfioCommon {
                 .set_region_type(region_type)
                 .set_prefetchable(prefetchable);
 
-            if bar_id == VFIO_PCI_ROM_REGION_INDEX {
-                self.configuration
-                    .add_pci_rom_bar(&bar, flags & 0x1)
-                    .map_err(|e| PciDeviceError::IoRegistrationFailed(bar_addr.raw_value(), e))?;
-            } else {
-                self.configuration
-                    .add_pci_bar(&bar)
-                    .map_err(|e| PciDeviceError::IoRegistrationFailed(bar_addr.raw_value(), e))?;
+            // Skip on restore as BARs come from the saved PciConfiguration state.
+            if resources.is_none() {
+                if bar_id == VFIO_PCI_ROM_REGION_INDEX {
+                    self.configuration
+                        .add_pci_rom_bar(&bar, flags & 0x1)
+                        .map_err(|e| {
+                            PciDeviceError::IoRegistrationFailed(bar_addr.raw_value(), e)
+                        })?;
+                } else {
+                    self.configuration.add_pci_bar(&bar).map_err(|e| {
+                        PciDeviceError::IoRegistrationFailed(bar_addr.raw_value(), e)
+                    })?;
+                }
             }
 
             bars.push(bar);
@@ -1552,7 +1575,16 @@ impl VfioCommon {
         state: &VfioCommonState,
         msi_state: Option<MsiConfigState>,
         msix_state: Option<MsixConfigState>,
+        migration_data: Option<VfioMigrationData>,
     ) -> Result<(), VfioPciError> {
+        // A snapshot carrying VFIO migration state cannot be restored onto a
+        // device without migration support.
+        if migration_data.is_some() && self.migration_flags.is_none() {
+            return Err(VfioPciError::RestoreMigration(anyhow!(
+                "snapshot carries VFIO migration state but the device does not support migration"
+            )));
+        }
+
         if let (Some(intx), Some(interrupt_source_group)) =
             (&state.intx_state, self.legacy_interrupt_group.clone())
         {
@@ -1572,6 +1604,39 @@ impl VfioCommon {
 
         if let Some(msix) = &state.msix_state {
             self.initialize_msix(msix.cap, msix.cap_offset, msix.bdf.into(), msix_state);
+        }
+
+        // Replay the opaque device state captured at snapshot. The kernel walks
+        // the intermediate STOP arc internally, so RESUMING is a single write.
+        if let Some(mig) = migration_data {
+            let blob = BASE64_STANDARD.decode(mig.blob.as_bytes()).map_err(|e| {
+                VfioPciError::RestoreMigration(anyhow!(
+                    "Failed to base64-decode migration blob: {e}"
+                ))
+            })?;
+            self.load_migration_data(&blob)
+                .map_err(|e| VfioPciError::RestoreMigration(anyhow!("{e}")))?;
+        }
+
+        // Push PCI_COMMAND to the device. State replay updates the shadow config
+        // space but not the device, so memory decode and bus mastering would
+        // otherwise stay disabled after restore.
+        let cmd = (self.configuration.read_reg(COMMAND_REG) & 0xFFFF) as u16;
+        self.vfio_wrapper.write_config(
+            (COMMAND_REG * PCI_CONFIG_REGISTER_SIZE) as u32,
+            &cmd.to_le_bytes(),
+        );
+
+        // Rearm the kernel interrupt eventfds. State replay restores only the
+        // MSI or MSI-X state in memory, not the VFIO_DEVICE_SET_IRQS wiring.
+        if let Some(msi) = &self.interrupt.msi
+            && msi.cfg.enabled()
+        {
+            self.enable_msi()?;
+        } else if let Some(msix) = &self.interrupt.msix
+            && msix.bar.enabled()
+        {
+            self.enable_msix()?;
         }
 
         Ok(())
@@ -1606,6 +1671,24 @@ impl VfioCommon {
         })?;
         stop?;
         Ok(data)
+    }
+
+    pub(crate) fn load_migration_data(&self, data: &[u8]) -> Result<(), MigratableError> {
+        // Leave the device in RESUMING and resume() drives it back to RUNNING.
+        let result = (|| -> Result<(), MigratableError> {
+            self.transition_migration_state(VfioMigrationState::Resuming)
+                .map_err(MigratableError::Restore)?;
+
+            self.vfio_wrapper.write_migration_data(data).map_err(|e| {
+                MigratableError::Restore(anyhow!("VFIO migration data write failed: {e}"))
+            })?;
+            Ok(())
+        })();
+
+        if result.is_err() {
+            let _ = self.transition_migration_state(VfioMigrationState::Stop);
+        }
+        result
     }
 }
 

--- a/pci/src/vfio.rs
+++ b/pci/src/vfio.rs
@@ -12,13 +12,24 @@ use std::sync::{Arc, Barrier, Mutex};
 use std::{cmp, io, result};
 
 use anyhow::anyhow;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use byteorder::{ByteOrder, LittleEndian};
 use hypervisor::HypervisorVmError;
 use libc::{_SC_PAGESIZE, sysconf};
 use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use vfio_bindings::bindings::vfio::*;
+use vfio_bindings::bindings::vfio::{
+    vfio_device_mig_state_VFIO_DEVICE_STATE_ERROR as VFIO_DEV_STATE_ERROR,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_PRE_COPY as VFIO_DEV_STATE_PRE_COPY,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_PRE_COPY_P2P as VFIO_DEV_STATE_PRE_COPY_P2P,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_RESUMING as VFIO_DEV_STATE_RESUMING,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_RUNNING as VFIO_DEV_STATE_RUNNING,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_RUNNING_P2P as VFIO_DEV_STATE_RUNNING_P2P,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_STOP as VFIO_DEV_STATE_STOP,
+    vfio_device_mig_state_VFIO_DEVICE_STATE_STOP_COPY as VFIO_DEV_STATE_STOP_COPY, *,
+};
 use vfio_ioctls::{VfioDevice, VfioIrq, VfioOps, VfioRegionInfoCap, VfioRegionSparseMmapArea};
 use vm_allocator::page_size::{
     align_page_size_down, align_page_size_up, get_page_size, is_4k_aligned, is_4k_multiple,
@@ -46,6 +57,7 @@ use crate::{
 };
 
 pub(crate) const VFIO_COMMON_ID: &str = "vfio_common";
+pub(crate) const VFIO_MIGRATION_ID: &str = "vfio_migration";
 
 #[derive(Debug, Error)]
 pub enum VfioPciError {
@@ -364,6 +376,55 @@ pub enum VfioError {
     KernelVfio(#[source] vfio_ioctls::VfioError),
     #[error("VFIO user error")]
     VfioUser(#[source] vfio_user::Error),
+    #[error("VFIO device does not support migration")]
+    NoMigrationSupport,
+    #[error("VFIO device reported unknown migration state {0}")]
+    InvalidMigrationState(u32),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VfioMigrationState {
+    Error,
+    Stop,
+    Running,
+    StopCopy,
+    Resuming,
+    RunningP2P,
+    PreCopy,
+    PreCopyP2P,
+}
+
+impl From<VfioMigrationState> for u32 {
+    fn from(state: VfioMigrationState) -> u32 {
+        match state {
+            VfioMigrationState::Error => VFIO_DEV_STATE_ERROR,
+            VfioMigrationState::Stop => VFIO_DEV_STATE_STOP,
+            VfioMigrationState::Running => VFIO_DEV_STATE_RUNNING,
+            VfioMigrationState::StopCopy => VFIO_DEV_STATE_STOP_COPY,
+            VfioMigrationState::Resuming => VFIO_DEV_STATE_RESUMING,
+            VfioMigrationState::RunningP2P => VFIO_DEV_STATE_RUNNING_P2P,
+            VfioMigrationState::PreCopy => VFIO_DEV_STATE_PRE_COPY,
+            VfioMigrationState::PreCopyP2P => VFIO_DEV_STATE_PRE_COPY_P2P,
+        }
+    }
+}
+
+impl TryFrom<u32> for VfioMigrationState {
+    type Error = VfioError;
+
+    fn try_from(value: u32) -> Result<Self, VfioError> {
+        match value {
+            VFIO_DEV_STATE_ERROR => Ok(Self::Error),
+            VFIO_DEV_STATE_STOP => Ok(Self::Stop),
+            VFIO_DEV_STATE_RUNNING => Ok(Self::Running),
+            VFIO_DEV_STATE_STOP_COPY => Ok(Self::StopCopy),
+            VFIO_DEV_STATE_RESUMING => Ok(Self::Resuming),
+            VFIO_DEV_STATE_RUNNING_P2P => Ok(Self::RunningP2P),
+            VFIO_DEV_STATE_PRE_COPY => Ok(Self::PreCopy),
+            VFIO_DEV_STATE_PRE_COPY_P2P => Ok(Self::PreCopyP2P),
+            other => Err(VfioError::InvalidMigrationState(other)),
+        }
+    }
 }
 
 pub(crate) trait Vfio: Send + Sync {
@@ -441,6 +502,14 @@ pub(crate) trait Vfio: Send + Sync {
     fn migration_flags(&self) -> Result<Option<u64>, VfioError> {
         Ok(None)
     }
+
+    fn set_migration_state(&self, _state: VfioMigrationState) -> Result<(), VfioError> {
+        Err(VfioError::NoMigrationSupport)
+    }
+
+    fn read_migration_data(&self) -> Result<Vec<u8>, VfioError> {
+        Err(VfioError::NoMigrationSupport)
+    }
 }
 
 struct VfioDeviceWrapper {
@@ -489,6 +558,18 @@ impl Vfio for VfioDeviceWrapper {
             .query_migration_support()
             .map_err(VfioError::KernelVfio)
     }
+
+    fn set_migration_state(&self, state: VfioMigrationState) -> Result<(), VfioError> {
+        self.device
+            .set_migration_state(state.into())
+            .map_err(VfioError::KernelVfio)
+    }
+
+    fn read_migration_data(&self) -> Result<Vec<u8>, VfioError> {
+        self.device
+            .read_migration_data_to_end()
+            .map_err(VfioError::KernelVfio)
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -496,6 +577,11 @@ struct VfioCommonState {
     intx_state: Option<IntxState>,
     msi_state: Option<MsiState>,
     msix_state: Option<MsixState>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct VfioMigrationData {
+    blob: String,
 }
 
 pub(crate) struct ConfigPatch {
@@ -513,7 +599,6 @@ pub(crate) struct VfioCommon {
     pub(crate) patches: HashMap<usize, ConfigPatch>,
     x_nv_gpudirect_clique: Option<u8>,
     x_exclude_mmap_bars: Vec<u8>,
-    #[allow(dead_code)]
     pub(crate) migration_flags: Option<u64>,
 }
 
@@ -1359,6 +1444,27 @@ impl VfioCommon {
         // to the device region to update the MSI Enable bit.
         self.vfio_wrapper.write_config((reg + offset) as u32, data);
 
+        // The non BAR write path goes directly to the VFIO device and not the shadow,
+        // so the PciConfiguration shadow can get stale. Mirror the write into the
+        // shadow here since snapshot() serializes it. Without this the shadow keeps its
+        // device init values and a snapshot encodes PCI_COMMAND as zero.
+        //
+        // Use the raw write_* helpers rather than the PciConfiguration method
+        // self.configuration.write_config_register(), which would otherwise drain
+        // pending_bar_reprogram, owned by the BAR block below, and rerun MSI-X
+        // set_msg_ctl, already done by update_msix_capabilities above.
+        let byte_offset = reg_idx * PCI_CONFIG_REGISTER_SIZE + offset as usize;
+        match data.len() {
+            1 => self.configuration.write_byte(byte_offset, data[0]),
+            2 => self
+                .configuration
+                .write_word(byte_offset, u16::from(data[0]) | (u16::from(data[1]) << 8)),
+            4 => self
+                .configuration
+                .write_reg(reg_idx, LittleEndian::read_u32(data)),
+            _ => {}
+        }
+
         // Return pending BAR repgrogramming if MSE bit is set
         let mut ret_param = self.configuration.pending_bar_reprogram();
         if !ret_param.is_empty() {
@@ -1470,6 +1576,37 @@ impl VfioCommon {
 
         Ok(())
     }
+
+    pub(crate) fn transition_migration_state(
+        &self,
+        target: VfioMigrationState,
+    ) -> anyhow::Result<()> {
+        debug!("VFIO migration transition -> {target:?}");
+        self.vfio_wrapper
+            .set_migration_state(target)
+            .map_err(|e| anyhow!("VFIO set_migration_state({target:?}) failed: {e}"))
+    }
+
+    pub(crate) fn save_migration_data(&self) -> Result<Vec<u8>, MigratableError> {
+        self.transition_migration_state(VfioMigrationState::StopCopy)
+            .map_err(MigratableError::Snapshot)?;
+
+        let data = self.vfio_wrapper.read_migration_data();
+
+        // We entered STOP_COPY successfully, so the STOP_COPY to STOP arc is
+        // valid whether or not the read succeeded. Return the device to STOP
+        // either way, since a failed transition into STOP_COPY would have
+        // returned above and a STOP from ERROR cannot help.
+        let stop = self
+            .transition_migration_state(VfioMigrationState::Stop)
+            .map_err(MigratableError::Snapshot);
+
+        let data = data.map_err(|e| {
+            MigratableError::Snapshot(anyhow!("VFIO migration data read failed: {e}"))
+        })?;
+        stop?;
+        Ok(data)
+    }
 }
 
 impl Pausable for VfioCommon {}
@@ -1493,6 +1630,17 @@ impl Snapshottable for VfioCommon {
         // Snapshot MSI-X
         if let Some(msix) = &mut self.interrupt.msix {
             vfio_common_snapshot.add_snapshot(msix.bar.id(), msix.bar.snapshot()?);
+        }
+
+        if self.migration_flags.is_some() {
+            let data = self.save_migration_data()?;
+            let mig = VfioMigrationData {
+                blob: BASE64_STANDARD.encode(&data),
+            };
+            vfio_common_snapshot.add_snapshot(
+                VFIO_MIGRATION_ID.to_string(),
+                Snapshot::new_from_state(&mig)?,
+            );
         }
 
         Ok(vfio_common_snapshot)
@@ -2101,7 +2249,25 @@ iova 0x{:x}, size 0x{:x}: {}, ",
     }
 }
 
-impl Pausable for VfioPciDevice {}
+impl Pausable for VfioPciDevice {
+    fn pause(&mut self) -> result::Result<(), MigratableError> {
+        if self.common.migration_flags.is_some() {
+            self.common
+                .transition_migration_state(VfioMigrationState::Stop)
+                .map_err(MigratableError::Pause)?;
+        }
+        Ok(())
+    }
+
+    fn resume(&mut self) -> result::Result<(), MigratableError> {
+        if self.common.migration_flags.is_some() {
+            self.common
+                .transition_migration_state(VfioMigrationState::Running)
+                .map_err(MigratableError::Resume)?;
+        }
+        Ok(())
+    }
+}
 
 impl Snapshottable for VfioPciDevice {
     fn id(&self) -> String {

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -86,6 +86,7 @@ const VFIO_DEVICE_RESET: u64 = 0x3b6f;
 const VFIO_IOMMU_MAP_DMA: u64 = 0x3b71;
 const VFIO_IOMMU_UNMAP_DMA: u64 = 0x3b72;
 const VFIO_DEVICE_IOEVENTFD: u64 = 0x3b74;
+const VFIO_DEVICE_FEATURE: u64 = 0x3b75;
 
 // See include/uapi/linux/kvm.h in the kernel code.
 #[cfg(feature = "kvm")]
@@ -381,6 +382,7 @@ fn create_vmm_ioctl_seccomp_rule_common(
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_IOMMU_MAP_DMA)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_IOMMU_UNMAP_DMA)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VFIO_DEVICE_IOEVENTFD)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, VFIO_DEVICE_FEATURE)?],
         and![Cond::new(1, ArgLen::Dword, Eq, VHOST_GET_FEATURES())?],
         and![Cond::new(1, ArgLen::Dword, Eq, VHOST_SET_FEATURES())?],
         and![Cond::new(1, ArgLen::Dword, Eq, VHOST_SET_OWNER())?],


### PR DESCRIPTION
## Summary

 Adds VFIO v2 migration protocol support for same host snapshot and restore of migratable VFIO devices, for example ConnectX VFs bound to `mlx5_vfio_pci`. Non migratable devices retain their existing snapshot behavior. Live migration with VFIO Devices, DMA dirty page tracking, and precopy iteration are follow up work and are not in this PR.
 
 ### VFIO Migration v2 State Transitions

  | Phase | Action | Device State Transition |
  |---|---|---|
  | Save | `pause()` | RUNNING → STOP |
  | Save | `snapshot()` requests data | STOP → STOP_COPY |
  | Save | `snapshot()` drains `data_fd` (device blob) | no transition |
  | Save | `snapshot()` finalizes | STOP_COPY → STOP |
  | Restore | `load_migration_data()` requests `data_fd` | RUNNING → RESUMING (*) |
  | Restore | `load_migration_data()` writes device blob | no transition |
  | Restore | post load fixups (PCI_COMMAND, rearm MSI or MSI-X) | no transition |
  | Resume | `resume()` after save (optional) | STOP → RUNNING |
  | Resume | `resume()` after restore (mandatory) | RESUMING → RUNNING (*) |

(*) Each arrow (→) is one `VFIO_DEVICE_FEATURE_SET_MIG_DEVICE_STATE` ioctl.
Non adjacent transitions such as `RUNNING → RESUMING, RESUMING → RUNNING` has to pass through `STOP` as per the protocol, and the host kernel walks that intermediate `STOP` state internally via the variant driver (`mlx5_vfio_pci`), therefore in this implementation Cloud-Hypervisor avoids enforcing `STOP` in the restore, resume phases. Referred QEMU's VFIO Migration ioctl sequence.

## Test
* Unit Tests
```
cargo test -p pci --lib vfio::tests
   Compiling log v0.4.30
   Compiling either v1.16.0
   Compiling serde_json v1.0.150
   Compiling vm-allocator v0.1.0 (/home/saravanand/cloud-hypervisor/vm-allocator)
   Compiling vfio-ioctls v0.6.1
   Compiling itertools v0.14.0
   Compiling hypervisor v0.1.0 (/home/saravanand/cloud-hypervisor/hypervisor)
   Compiling vfio_user v0.1.3
   Compiling vm-device v0.1.0 (/home/saravanand/cloud-hypervisor/vm-device)
   Compiling vm-migration v0.1.0 (/home/saravanand/cloud-hypervisor/vm-migration)
   Compiling pci v0.1.0 (/home/saravanand/cloud-hypervisor/pci)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.79s
     Running unittests src/lib.rs (target/debug/deps/pci-2f3a4b128c172bab)

running 9 tests
test vfio::tests::default_query_migration_support_returns_none ... ok
test vfio::tests::default_set_migration_state_errors ... ok
test vfio::tests::load_migration_data_recovers_on_failure ... ok
test vfio::tests::vfio_migration_state_invalid_errors ... ok
test vfio::tests::load_migration_data_happy_path ... ok
test vfio::tests::save_migration_data_happy_path ... ok
test vfio::tests::vfio_migration_state_round_trips ... ok
test vfio::tests::save_migration_data_recovers_on_failure ... ok
test vfio::tests::write_config_register_mirrors_non_bar_into_shadow ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s

```
* Snapshot and Restore validated on a Mellanox ConnectX 7 VF (`mlx5_vfio_pci`, firmware 28.43.1014)

https://github.com/user-attachments/assets/e8739af2-ab37-4657-9435-519e762027d9

