### PR TITLE
vmm: make PCI BDF configurable for balloon and ivshmem

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -6075,6 +6075,7 @@ mod common_parallel {
             .args(["--kernel", kernel_path.to_str().unwrap()])
             .args(["--cmdline", DIRECT_KERNEL_BOOT_CMDLINE])
             .args(["--console", "tty,pci_device_id=7"])
+            .args(["--balloon", "size=0,pci_device_id=8"])
             .default_net()
             .default_disks()
             .capture_output();
@@ -6089,6 +6090,17 @@ mod common_parallel {
             assert!(wait_until(Duration::from_secs(10), || {
                 ssh_command_ip_with_auth(
                     "lspci | grep \"00:07.0\" | grep Virtio | grep console",
+                    &default_guest_auth(),
+                    &guest.network.guest_ip0,
+                    Some(Duration::from_secs(1)),
+                )
+                .is_ok()
+            }));
+
+            // Make sure an explicit BDF for virtio-balloon is set.
+            assert!(wait_until(Duration::from_secs(10), || {
+                ssh_command_ip_with_auth(
+                    "lspci -n | grep \"00:08.0\"",
                     &default_guest_auth(),
                     &guest.network.guest_ip0,
                     Some(Duration::from_secs(1)),

--- a/docs/ivshmem.md
+++ b/docs/ivshmem.md
@@ -19,7 +19,7 @@ This argument takes a file as a `path` value and a file size as a `size` value.
 The `size` value must be 2^n.
 
 ```
---ivshmem <ivshmem>  device backend file "path=</path/to/a/file>,size=<file_size>"
+--ivshmem <ivshmem>  device backend file "path=</path/to/a/file>,size=<file_size>,id=<device_id>,pci_segment=<segment_id>,pci_device_id=<pci_slot>"
 ```
 
 ## Example

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1127,6 +1127,17 @@ components:
         - size
       type: object
       properties:
+        id:
+          type: string
+        pci_segment:
+          type: integer
+          format: int16
+        pci_device_id:
+          type: integer
+          format: uint8
+        iommu:
+          type: boolean
+          default: false
         size:
           type: integer
           format: int64

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1896,13 +1896,15 @@ impl RtcConfig {
 
 impl BalloonConfig {
     pub const SYNTAX: &'static str = "Balloon parameters \"size=<balloon_size>,deflate_on_oom=on|off,\
-        free_page_reporting=on|off\"";
+        free_page_reporting=on|off,iommu=on|off,id=<device_id>,pci_segment=<segment_id>,\
+        pci_device_id=<pci_slot>\"";
 
     pub fn parse(balloon: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser.add("size");
         parser.add("deflate_on_oom");
         parser.add("free_page_reporting");
+        parser.add_all(PciDeviceCommonConfig::OPTIONS_IOMMU);
         parser.parse(balloon).map_err(Error::ParseBalloon)?;
 
         let size = parser
@@ -1922,11 +1924,18 @@ impl BalloonConfig {
             .unwrap_or(Toggle(false))
             .0;
 
+        let pci_common = PciDeviceCommonConfig::parse(balloon)?;
+
         Ok(BalloonConfig {
+            pci_common,
             size,
             deflate_on_oom,
             free_page_reporting,
         })
+    }
+
+    pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
+        self.pci_common.validate(vm_config)
     }
 }
 
@@ -3258,6 +3267,10 @@ impl VmConfig {
         }
 
         if let Some(balloon) = &self.balloon {
+            balloon.validate(self)?;
+            Self::validate_identifier(&mut id_list, &balloon.pci_common.id)?;
+            self.iommu |= balloon.pci_common.iommu;
+
             let ram_size = self.memory.total_size();
             if balloon.size >= ram_size {
                 return Err(ValidationError::BalloonLargerThanRam(
@@ -4370,6 +4383,40 @@ mod unit_tests {
                 ..Default::default()
             }
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_balloon() -> Result<()> {
+        assert_eq!(
+            BalloonConfig::parse(
+                "size=128M,deflate_on_oom=on,free_page_reporting=on,pci_segment=1,pci_device_id=7"
+            )?,
+            BalloonConfig {
+                pci_common: PciDeviceCommonConfig {
+                    pci_segment: 1,
+                    pci_device_id: Some(7),
+                    ..Default::default()
+                },
+                size: 128 << 20,
+                deflate_on_oom: true,
+                free_page_reporting: true,
+            }
+        );
+
+        assert_eq!(
+            BalloonConfig::parse("size=0,iommu=on")?,
+            BalloonConfig {
+                pci_common: PciDeviceCommonConfig {
+                    iommu: true,
+                    ..Default::default()
+                },
+                size: 0,
+                deflate_on_oom: false,
+                free_page_reporting: false,
+            }
+        );
+
         Ok(())
     }
 
@@ -6122,6 +6169,47 @@ id=\"{id}\",pci_segment={pci_segment},queue_sizes={queue_sizes}"
         assert_eq!(
             invalid_config.validate(),
             Err(ValidationError::InvalidPciDeviceId(pci::NUM_DEVICE_IDS + 1))
+        );
+
+        // Invalid balloon BDF - Same ID as Root device
+        let mut invalid_config = valid_config.clone();
+        invalid_config.balloon = Some(BalloonConfig {
+            pci_common: PciDeviceCommonConfig {
+                pci_device_id: Some(pci::PCI_ROOT_DEVICE_ID),
+                ..Default::default()
+            },
+            size: 0,
+            deflate_on_oom: false,
+            free_page_reporting: false,
+        });
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::ReservedPciDeviceId(
+                pci::PCI_ROOT_DEVICE_ID
+            ))
+        );
+
+        // Invalid balloon ID - Duplicate identifier
+        let mut invalid_config = valid_config.clone();
+        invalid_config.balloon = Some(BalloonConfig {
+            pci_common: PciDeviceCommonConfig {
+                id: Some("test0".to_string()),
+                ..Default::default()
+            },
+            size: 0,
+            deflate_on_oom: false,
+            free_page_reporting: false,
+        });
+        invalid_config.disks = Some(vec![DiskConfig {
+            pci_common: PciDeviceCommonConfig {
+                id: Some("test0".to_string()),
+                ..Default::default()
+            },
+            ..disk_fixture()
+        }]);
+        assert_eq!(
+            invalid_config.validate(),
+            Err(ValidationError::IdentifierNotUnique("test0".to_string()))
         );
 
         // Invalid console BDF - Same ID as Root device

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -2911,12 +2911,14 @@ impl LandlockConfig {
 #[cfg(feature = "ivshmem")]
 impl IvshmemConfig {
     pub const SYNTAX: &'static str = "Ivshmem device. Specify the backend file path and size \
-    for the shared memory: \"path=</path/to/a/file>, size=<file_size>\" \
+    for the shared memory: \"path=</path/to/a/file>,size=<file_size>,id=<device_id>,\
+    pci_segment=<segment_id>,pci_device_id=<pci_slot>\" \
     \nThe <file_size> must be a power of 2 (e.g., 2M, 4M, etc.), as it represents the size \
     of the memory region mapped to the guest. Default size is 128M.";
     pub fn parse(ivshmem: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser.add("path").add("size");
+        parser.add_all(PciDeviceCommonConfig::OPTIONS);
         parser.parse(ivshmem).map_err(Error::ParseIvshmem)?;
         let path = parser
             .get("path")
@@ -2927,13 +2929,20 @@ impl IvshmemConfig {
             .map_err(Error::ParseIvshmem)?
             .unwrap_or(ByteSized((DEFAULT_IVSHMEM_SIZE << 20) as u64))
             .0;
+        let pci_common = PciDeviceCommonConfig::parse(ivshmem)?;
         Ok(IvshmemConfig {
+            pci_common,
             path,
             size: size as usize,
         })
     }
 
-    pub fn validate(&self) -> ValidationResult<()> {
+    pub fn validate(&self, vm_config: &VmConfig) -> ValidationResult<()> {
+        if self.pci_common.iommu {
+            return Err(ValidationError::IommuNotSupported);
+        }
+        self.pci_common.validate(vm_config)?;
+
         let size = self.size as u64;
         let path = &self.path;
         // size must = 2^n
@@ -3376,7 +3385,8 @@ impl VmConfig {
         }
         #[cfg(feature = "ivshmem")]
         if let Some(ivshmem_config) = &self.ivshmem {
-            ivshmem_config.validate()?;
+            ivshmem_config.validate(self)?;
+            Self::validate_identifier(&mut id_list, &ivshmem_config.pci_common.id)?;
         }
 
         Ok(id_list)
@@ -4414,6 +4424,25 @@ mod unit_tests {
                 size: 0,
                 deflate_on_oom: false,
                 free_page_reporting: false,
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "ivshmem")]
+    fn test_parse_ivshmem() -> Result<()> {
+        assert_eq!(
+            IvshmemConfig::parse("path=/tmp/ivshmem.data,size=2M,pci_segment=1,pci_device_id=7")?,
+            IvshmemConfig {
+                pci_common: PciDeviceCommonConfig {
+                    pci_segment: 1,
+                    pci_device_id: Some(7),
+                    ..Default::default()
+                },
+                path: PathBuf::from("/tmp/ivshmem.data"),
+                size: 2 << 20,
             }
         );
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1565,8 +1565,11 @@ impl DeviceManager {
         }
 
         #[cfg(feature = "ivshmem")]
-        if let Some(ivshmem) = self.config.clone().lock().unwrap().ivshmem.as_ref() {
-            self.ivshmem_device = self.add_ivshmem_device(ivshmem, snapshot)?;
+        {
+            let mut ivshmem = self.config.lock().unwrap().ivshmem.clone();
+            if let Some(ivshmem) = &mut ivshmem {
+                self.ivshmem_device = self.add_ivshmem_device(ivshmem, snapshot)?;
+            }
         }
 
         Ok(())
@@ -4486,15 +4489,24 @@ impl DeviceManager {
     #[cfg(feature = "ivshmem")]
     fn add_ivshmem_device(
         &mut self,
-        ivshmem_cfg: &IvshmemConfig,
+        ivshmem_cfg: &mut IvshmemConfig,
         snapshot: Option<&Snapshot>,
     ) -> DeviceManagerResult<Option<Arc<Mutex<devices::IvshmemDevice>>>> {
-        let id = String::from(IVSHMEM_DEVICE_NAME);
-        let pci_segment_id = 0x0_u16;
+        let id = match ivshmem_cfg.pci_common.id.as_ref() {
+            Some(id) => id.clone(),
+            None => ivshmem_cfg
+                .pci_common
+                .id
+                .insert(IVSHMEM_DEVICE_NAME.to_string())
+                .clone(),
+        };
         info!("Creating ivshmem device {id}");
 
-        let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&id, pci_segment_id, None)?;
+        let (pci_segment_id, pci_device_bdf, resources) = self.pci_resources(
+            &id,
+            ivshmem_cfg.pci_common.pci_segment,
+            ivshmem_cfg.pci_common.pci_device_id,
+        )?;
         let snapshot = snapshot_from_id(snapshot, id.as_str());
 
         let ivshmem_ops = Arc::new(Mutex::new(IvshmemHandler {
@@ -4561,6 +4573,14 @@ impl DeviceManager {
                         .reserve_device_id(device_id)?;
                 }
             }
+        }
+
+        #[cfg(feature = "ivshmem")]
+        if let Some(ivshmem_cfg) = &config.ivshmem
+            && let Some(device_id) = ivshmem_cfg.pci_common.pci_device_id
+        {
+            self.pci_segments[ivshmem_cfg.pci_common.pci_segment as usize]
+                .reserve_device_id(device_id)?;
         }
 
         Ok(())

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3669,8 +3669,16 @@ impl DeviceManager {
         &mut self,
         snapshot: Option<&Snapshot>,
     ) -> DeviceManagerResult<()> {
-        if let Some(balloon_config) = &self.config.lock().unwrap().balloon {
-            let id = String::from(BALLOON_DEVICE_NAME);
+        let mut balloon_config = self.config.lock().unwrap().balloon.clone();
+        if let Some(balloon_config) = &mut balloon_config {
+            let id = match balloon_config.pci_common.id.as_ref() {
+                Some(id) => id.clone(),
+                None => balloon_config
+                    .pci_common
+                    .id
+                    .insert(BALLOON_DEVICE_NAME.to_string())
+                    .clone(),
+            };
             info!("Creating virtio-balloon device: id = {id}");
 
             let virtio_balloon_device = Arc::new(Mutex::new(
@@ -3679,7 +3687,7 @@ impl DeviceManager {
                     balloon_config.size,
                     balloon_config.deflate_on_oom,
                     balloon_config.free_page_reporting,
-                    self.force_access_platform,
+                    self.force_access_platform | balloon_config.pci_common.iommu,
                     self.seccomp_action.clone(),
                     self.exit_evt
                         .try_clone()
@@ -3695,10 +3703,7 @@ impl DeviceManager {
             self.virtio_devices.push(MetaVirtioDevice {
                 virtio_device: Arc::clone(&virtio_balloon_device)
                     as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
-                pci_common: PciDeviceCommonConfig {
-                    id: Some(id.clone()),
-                    ..Default::default()
-                },
+                pci_common: balloon_config.pci_common.clone(),
                 dma_handler: None,
             });
 

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -826,6 +826,8 @@ pub const DEFAULT_IVSHMEM_SIZE: usize = 128;
 #[cfg(feature = "ivshmem")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct IvshmemConfig {
+    #[serde(flatten)]
+    pub pci_common: PciDeviceCommonConfig,
     pub path: PathBuf,
     pub size: usize,
 }
@@ -834,6 +836,7 @@ pub struct IvshmemConfig {
 impl Default for IvshmemConfig {
     fn default() -> Self {
         Self {
+            pci_common: PciDeviceCommonConfig::default(),
             path: PathBuf::new(),
             size: DEFAULT_IVSHMEM_SIZE << 20,
         }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -528,6 +528,8 @@ impl ApplyLandlock for RngConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct BalloonConfig {
+    #[serde(flatten)]
+    pub pci_common: PciDeviceCommonConfig,
     pub size: u64,
     /// Option to deflate the balloon in case the guest is out of memory.
     #[serde(default)]


### PR DESCRIPTION
Make the device ID of the PCI BDF configurable for balloon and ivshmem - I think now we've covered all configurable PCI devices in CH.

See #8175.

With that, I think that we've finished the PCI BDF chapter for now. Ping @scholzp 