### PR TITLE
More TPM fixes for Windows

### DIFF
--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -5932,15 +5932,33 @@ mod common_parallel {
         let mut child = guest_cmd.spawn().unwrap();
         let r = std::panic::catch_unwind(|| {
             guest.wait_vm_boot().unwrap();
-            assert_eq!(
-                guest.ssh_command("ls /dev/tpm0").unwrap().trim(),
-                "/dev/tpm0"
-            );
-            guest.ssh_command("sudo tpm2_selftest -f").unwrap();
-            guest
-                .ssh_command("echo 'hello' > /tmp/checksum_test;  ")
-                .unwrap();
-            guest.ssh_command("cmp <(sudo tpm2_pcrevent  /tmp/checksum_test | grep sha256 | awk '{print $2}') <(sha256sum /tmp/checksum_test| awk '{print $1}')").unwrap();
+            let exercise_tpm = || {
+                assert_eq!(
+                    guest.ssh_command("ls /dev/tpm0").unwrap().trim(),
+                    "/dev/tpm0"
+                );
+                guest.ssh_command("sudo tpm2_selftest -f").unwrap();
+                guest
+                    .ssh_command(
+                        "sudo tpm2_getrandom 32 >/tmp/tpm_random \
+                         && test $(wc -c </tmp/tpm_random) -eq 32",
+                    )
+                    .unwrap();
+                guest
+                    .ssh_command("sudo tpm2_getcap properties-fixed | grep -q TPM2_PT_MANUFACTURER")
+                    .unwrap();
+                guest
+                    .ssh_command("sudo tpm2_pcrread sha256:0,1,2,3 >/tmp/tpm_pcrread")
+                    .unwrap();
+                guest
+                    .ssh_command("echo 'hello' > /tmp/checksum_test;  ")
+                    .unwrap();
+                guest.ssh_command("cmp <(sudo tpm2_pcrevent  /tmp/checksum_test | grep sha256 | awk '{print $2}') <(sha256sum /tmp/checksum_test| awk '{print $1}')").unwrap();
+            };
+
+            exercise_tpm();
+            guest.reboot_linux(0);
+            exercise_tpm();
         });
 
         let _ = swtpm_child.kill();

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -10017,6 +10017,16 @@ mod windows {
                 .unwrap_or(0)
         }
 
+        fn tpm_status(&self) -> String {
+            self.ssh_cmd(
+                "powershell -NoProfile -Command \"(Get-PnpDevice -Class SecurityDevices | \
+                 Where-Object { $_.FriendlyName -match 'Trusted Platform Module|TPM' } | \
+                 Select-Object -First 1 -ExpandProperty Status)\"",
+            )
+            .trim()
+            .to_string()
+        }
+
         fn reboot(&self) {
             let _ = self.ssh_cmd("shutdown /r /t 0");
         }
@@ -10256,6 +10266,61 @@ mod windows {
 
         let _ = child_dnsmasq.kill();
         let _ = child_dnsmasq.wait();
+
+        handle_child_output(r, &output);
+    }
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_windows_guest_tpm() {
+        let windows_guest = WindowsGuest::new();
+        let (mut swtpm_command, swtpm_socket_path) =
+            prepare_swtpm_daemon(&windows_guest.guest().tmp_dir);
+
+        let mut swtpm_child = swtpm_command.spawn().unwrap();
+        assert!(wait_until(Duration::from_secs(10), || {
+            std::path::Path::new(&swtpm_socket_path).exists()
+        }));
+
+        let mut child = GuestCommand::new(windows_guest.guest())
+            .args(["--cpus", "boot=2,kvm_hyperv=on"])
+            .args(["--memory", "size=4G"])
+            .args(["--kernel", edk2_path().to_str().unwrap()])
+            .args(["--serial", "tty"])
+            .args(["--console", "off"])
+            .args(["--tpm", &format!("socket={swtpm_socket_path}")])
+            .default_disks()
+            .default_net()
+            .capture_output()
+            .spawn()
+            .unwrap();
+
+        let fd = child.stdout.as_ref().unwrap().as_raw_fd();
+        let pipesize = unsafe { libc::fcntl(fd, libc::F_SETPIPE_SZ, PIPE_SIZE) };
+        let fd = child.stderr.as_ref().unwrap().as_raw_fd();
+        let pipesize1 = unsafe { libc::fcntl(fd, libc::F_SETPIPE_SZ, PIPE_SIZE) };
+
+        assert!(pipesize >= PIPE_SIZE && pipesize1 >= PIPE_SIZE);
+
+        let mut child_dnsmasq = windows_guest.run_dnsmasq();
+
+        let r = std::panic::catch_unwind(|| {
+            // Wait to make sure Windows boots up
+            windows_guest.wait_for_boot().unwrap();
+
+            assert_eq!(windows_guest.tpm_status(), "OK");
+            windows_guest.shutdown();
+        });
+
+        let _ = child.wait_timeout(std::time::Duration::from_secs(60));
+        let _ = child.kill();
+        let output = child.wait_with_output().unwrap();
+
+        let _ = child_dnsmasq.kill();
+        let _ = child_dnsmasq.wait();
+
+        let _ = swtpm_child.kill();
+        let _ = swtpm_child.wait_with_output().unwrap();
 
         handle_child_output(r, &output);
     }

--- a/devices/src/tpm.rs
+++ b/devices/src/tpm.rs
@@ -12,7 +12,7 @@ use anyhow::anyhow;
 use arch::aarch64::layout::{TPM_SIZE, TPM_START};
 #[cfg(target_arch = "x86_64")]
 use arch::x86_64::layout::{TPM_SIZE, TPM_START};
-use log::{debug, error, warn};
+use log::{debug, error};
 use thiserror::Error;
 use tpm::TPM_CRB_BUFFER_MAX;
 use tpm::emulator::{BackendCmd, Emulator};
@@ -512,7 +512,7 @@ impl BusDevice for Tpm {
                     }
                 }
                 CRB_LOC_CTRL => {
-                    warn!("CRB_LOC_CTRL locality to write = {locality:?} val = {v:?}");
+                    debug!("CRB_LOC_CTRL locality to write = {locality:?} val = {v:?}");
                     match v {
                         CRB_LOC_CTRL_RESET_ESTABLISHMENT_BIT => {}
                         CRB_LOC_CTRL_RELINQUISH => {

--- a/devices/src/tpm.rs
+++ b/devices/src/tpm.rs
@@ -219,6 +219,19 @@ fn locality_from_addr(addr: u32) -> u8 {
     (addr >> 12) as u8
 }
 
+fn update_reg(regs: &mut [u32; TPM_CRB_R_MAX], offset: u32, data: &[u8]) -> u32 {
+    let reg_offset = (offset & !0x3) as usize;
+    let byte_offset = (offset & 0x3) as usize;
+    let mut input = [0; 4];
+
+    input[..data.len()].copy_from_slice(data);
+    let value = u32::from_le_bytes(input);
+    let mask = (u32::MAX >> (32 - data.len() * 8)) << (byte_offset * 8);
+
+    regs[reg_offset] = (regs[reg_offset] & !mask) | ((value << (byte_offset * 8)) & mask);
+    regs[reg_offset]
+}
+
 pub struct Tpm {
     emulator: Emulator,
     regs: [u32; TPM_CRB_R_MAX],
@@ -257,7 +270,7 @@ impl Tpm {
     }
 
     fn request_completed(&mut self, success: bool) {
-        self.regs[CRB_CTRL_START as usize] = !CRB_START_INVOKE;
+        self.regs[CRB_CTRL_START as usize] &= !CRB_START_INVOKE;
         if !success {
             set_reg_field(
                 &mut self.regs,
@@ -353,7 +366,7 @@ impl BusDevice for Tpm {
         let read_len: usize = data.len();
 
         if offset >= CRB_DATA_BUFFER
-            && (offset + read_len as u32) < (CRB_DATA_BUFFER + self.data_buff.len() as u32)
+            && (offset + read_len as u32) <= (CRB_DATA_BUFFER + self.data_buff.len() as u32)
         {
             // Read from Data Buffer
             let start: usize = (offset as usize) - (CRB_DATA_BUFFER as usize);
@@ -361,17 +374,21 @@ impl BusDevice for Tpm {
             data[..].clone_from_slice(&self.data_buff[start..end]);
         } else {
             offset &= 0xff;
-            let mut val = self.regs[offset as usize];
+            let reg_offset = offset & !0x3;
+            let mut val = self.regs[reg_offset as usize];
 
             // Per the TCG PC Client Platform TPM Profile (PTP) spec, bit 0
             // of TPM_LOC_STATE_x is `tpmEstablished`. Reflect the live value
             // from the backend rather than the (zero-initialised) shadow.
-            if offset == CRB_LOC_STATE && self.emulator.get_established_bit() {
+            if reg_offset == CRB_LOC_STATE && self.emulator.get_established_bit() {
                 val |= 0x1;
             }
 
             if data.len() <= 4 {
-                data.clone_from_slice(val.to_ne_bytes()[0..read_len].as_ref());
+                let byte_offset = (offset & 0x3) as usize;
+                data.clone_from_slice(
+                    (val >> (byte_offset * 8)).to_ne_bytes()[0..read_len].as_ref(),
+                );
             } else {
                 error!(
                     "Invalid tpm read: offset {:#X}, data length {:?}",
@@ -403,7 +420,7 @@ impl BusDevice for Tpm {
         let write_len = data.len();
 
         if offset >= CRB_DATA_BUFFER
-            && (offset + write_len as u32) < (CRB_DATA_BUFFER + self.data_buff.len() as u32)
+            && (offset + write_len as u32) <= (CRB_DATA_BUFFER + self.data_buff.len() as u32)
         {
             let start: usize = (offset as usize) - (CRB_DATA_BUFFER as usize);
             if start == 0 {
@@ -426,25 +443,28 @@ impl BusDevice for Tpm {
                 return None;
             }
 
-            let mut input: [u8; 4] = [0; 4];
-            input.copy_from_slice(&data[0..4]);
-            let v = u32::from_le_bytes(input);
+            let write_offset = offset;
+            let reg_data_len = cmp::min(write_len, 4 - (offset as usize & 0x3));
+            let mut input = [0; 4];
+            input[..reg_data_len].copy_from_slice(&data[..reg_data_len]);
+            let v = u32::from_le_bytes(input) << ((offset & 0x3) * 8);
+            offset &= !0x3;
 
             match offset {
                 CRB_CTRL_CMD_SIZE_REG => {
-                    self.regs[CRB_CTRL_CMD_SIZE_REG as usize] = v;
+                    update_reg(&mut self.regs, write_offset, &data[..reg_data_len]);
                 }
                 CRB_CTRL_CMD_LADDR => {
-                    self.regs[CRB_CTRL_CMD_LADDR as usize] = v;
+                    update_reg(&mut self.regs, write_offset, &data[..reg_data_len]);
                 }
                 CRB_CTRL_CMD_HADDR => {
-                    self.regs[CRB_CTRL_CMD_HADDR as usize] = v;
+                    update_reg(&mut self.regs, write_offset, &data[..reg_data_len]);
                 }
                 CRB_CTRL_RSP_SIZE => {
-                    self.regs[CRB_CTRL_RSP_SIZE as usize] = v;
+                    update_reg(&mut self.regs, write_offset, &data[..reg_data_len]);
                 }
                 CRB_CTRL_RSP_ADDR => {
-                    self.regs[CRB_CTRL_RSP_ADDR as usize] = v;
+                    update_reg(&mut self.regs, write_offset, &data[..reg_data_len]);
                 }
                 CRB_CTRL_REQ => match v {
                     CRB_CTRL_REQ_CMD_READY => {
@@ -555,5 +575,15 @@ mod unit_tests {
             0xAC,
             concat!("Test: ", stringify!(set_get_reg_field))
         );
+    }
+
+    #[test]
+    fn test_update_reg_partial_write() {
+        let mut regs: [u32; TPM_CRB_R_MAX] = [0; TPM_CRB_R_MAX];
+
+        update_reg(&mut regs, CRB_CTRL_CMD_SIZE_REG, &[0x78, 0x56, 0x34, 0x12]);
+        update_reg(&mut regs, CRB_CTRL_CMD_SIZE_REG + 1, &[0xaa]);
+
+        assert_eq!(regs[CRB_CTRL_CMD_SIZE_REG as usize], 0x1234_aa78);
     }
 }

--- a/devices/src/tpm.rs
+++ b/devices/src/tpm.rs
@@ -232,6 +232,31 @@ fn update_reg(regs: &mut [u32; TPM_CRB_R_MAX], offset: u32, data: &[u8]) -> u32 
     regs[reg_offset]
 }
 
+fn read_reg_value(value: u32, offset: u32) -> u32 {
+    let byte_offset = (offset & 0x3) as usize;
+
+    value >> (byte_offset * 8)
+}
+
+fn complete_request(regs: &mut [u32; TPM_CRB_R_MAX], success: bool) {
+    regs[CRB_CTRL_START as usize] &= !CRB_START_INVOKE;
+    if !success {
+        set_reg_field(regs, CrbRegister::CtrlSts(CtrlStsFields::TpmSts), 1);
+    }
+}
+
+fn data_buffer_range(offset: u32, len: usize, buffer_len: usize) -> Option<std::ops::Range<usize>> {
+    let end_offset = offset.checked_add(len as u32)?;
+    let buffer_end = CRB_DATA_BUFFER.checked_add(buffer_len as u32)?;
+
+    if offset >= CRB_DATA_BUFFER && end_offset <= buffer_end {
+        let start = (offset - CRB_DATA_BUFFER) as usize;
+        Some(start..start + len)
+    } else {
+        None
+    }
+}
+
 pub struct Tpm {
     emulator: Emulator,
     regs: [u32; TPM_CRB_R_MAX],
@@ -270,14 +295,7 @@ impl Tpm {
     }
 
     fn request_completed(&mut self, success: bool) {
-        self.regs[CRB_CTRL_START as usize] &= !CRB_START_INVOKE;
-        if !success {
-            set_reg_field(
-                &mut self.regs,
-                CrbRegister::CtrlSts(CtrlStsFields::TpmSts),
-                1,
-            );
-        }
+        complete_request(&mut self.regs, success);
     }
 
     fn reset(&mut self) -> Result<()> {
@@ -365,13 +383,9 @@ impl BusDevice for Tpm {
         let mut offset: u32 = offset as u32;
         let read_len: usize = data.len();
 
-        if offset >= CRB_DATA_BUFFER
-            && (offset + read_len as u32) <= (CRB_DATA_BUFFER + self.data_buff.len() as u32)
-        {
+        if let Some(range) = data_buffer_range(offset, read_len, self.data_buff.len()) {
             // Read from Data Buffer
-            let start: usize = (offset as usize) - (CRB_DATA_BUFFER as usize);
-            let end: usize = start + read_len;
-            data[..].clone_from_slice(&self.data_buff[start..end]);
+            data[..].clone_from_slice(&self.data_buff[range]);
         } else {
             offset &= 0xff;
             let reg_offset = offset & !0x3;
@@ -383,12 +397,10 @@ impl BusDevice for Tpm {
             if reg_offset == CRB_LOC_STATE && self.emulator.get_established_bit() {
                 val |= 0x1;
             }
+            val = read_reg_value(val, offset);
 
             if data.len() <= 4 {
-                let byte_offset = (offset & 0x3) as usize;
-                data.clone_from_slice(
-                    (val >> (byte_offset * 8)).to_ne_bytes()[0..read_len].as_ref(),
-                );
+                data.clone_from_slice(val.to_ne_bytes()[0..read_len].as_ref());
             } else {
                 error!(
                     "Invalid tpm read: offset {:#X}, data length {:?}",
@@ -419,17 +431,14 @@ impl BusDevice for Tpm {
         let locality = locality_from_addr(offset) as u32;
         let write_len = data.len();
 
-        if offset >= CRB_DATA_BUFFER
-            && (offset + write_len as u32) <= (CRB_DATA_BUFFER + self.data_buff.len() as u32)
-        {
-            let start: usize = (offset as usize) - (CRB_DATA_BUFFER as usize);
+        if let Some(range) = data_buffer_range(offset, write_len, self.data_buff.len()) {
+            let start = range.start;
             if start == 0 {
                 // If filling data_buff at index 0, reset length to 0
                 self.data_buff_len = 0;
                 self.data_buff.fill(0);
             }
-            let end: usize = start + data.len();
-            self.data_buff[start..end].clone_from_slice(data);
+            self.data_buff[range].clone_from_slice(data);
             self.data_buff_len += data.len();
         } else {
             // Ctrl Commands that take more than 4 bytes as input are not yet supported

--- a/devices/src/tpm.rs
+++ b/devices/src/tpm.rs
@@ -238,6 +238,13 @@ fn read_reg_value(value: u32, offset: u32) -> u32 {
     value >> (byte_offset * 8)
 }
 
+#[cfg(test)]
+fn read_reg(regs: &[u32; TPM_CRB_R_MAX], offset: u32) -> u32 {
+    let reg_offset = (offset & !0x3) as usize;
+
+    read_reg_value(regs[reg_offset], offset)
+}
+
 fn complete_request(regs: &mut [u32; TPM_CRB_R_MAX], success: bool) {
     regs[CRB_CTRL_START as usize] &= !CRB_START_INVOKE;
     if !success {
@@ -594,5 +601,71 @@ mod unit_tests {
         update_reg(&mut regs, CRB_CTRL_CMD_SIZE_REG + 1, &[0xaa]);
 
         assert_eq!(regs[CRB_CTRL_CMD_SIZE_REG as usize], 0x1234_aa78);
+    }
+
+    #[test]
+    fn test_update_reg_preserves_untouched_byte_lanes() {
+        let mut regs: [u32; TPM_CRB_R_MAX] = [0; TPM_CRB_R_MAX];
+        regs[CRB_CTRL_CMD_LADDR as usize] = 0x1122_3344;
+
+        update_reg(&mut regs, CRB_CTRL_CMD_LADDR + 1, &[0xaa, 0xbb]);
+
+        assert_eq!(regs[CRB_CTRL_CMD_LADDR as usize], 0x11bb_aa44);
+    }
+
+    #[test]
+    fn test_read_reg_partial_read_uses_byte_offset() {
+        let mut regs: [u32; TPM_CRB_R_MAX] = [0; TPM_CRB_R_MAX];
+        regs[CRB_CTRL_CMD_SIZE_REG as usize] = 0x1234_5678;
+
+        assert_eq!(read_reg(&regs, CRB_CTRL_CMD_SIZE_REG + 1) as u8, 0x56);
+        assert_eq!(read_reg(&regs, CRB_CTRL_CMD_SIZE_REG + 2) as u16, 0x1234);
+        assert_eq!(read_reg_value(0x1, CRB_LOC_STATE + 1) as u8, 0);
+    }
+
+    #[test]
+    fn test_complete_request_preserves_reserved_bits() {
+        let mut regs: [u32; TPM_CRB_R_MAX] = [0; TPM_CRB_R_MAX];
+        regs[CRB_CTRL_START as usize] = 0xffff_fffe | CRB_START_INVOKE;
+
+        complete_request(&mut regs, true);
+
+        assert_eq!(regs[CRB_CTRL_START as usize], 0xffff_fffe);
+    }
+
+    #[test]
+    fn test_complete_request_sets_error_status_on_failure() {
+        let mut regs: [u32; TPM_CRB_R_MAX] = [0; TPM_CRB_R_MAX];
+        regs[CRB_CTRL_START as usize] = CRB_START_INVOKE;
+
+        complete_request(&mut regs, false);
+
+        assert_eq!(regs[CRB_CTRL_START as usize], 0);
+        assert_eq!(
+            get_reg_field(&regs, CrbRegister::CtrlSts(CtrlStsFields::TpmSts)),
+            1
+        );
+    }
+
+    #[test]
+    fn test_data_buffer_range_accepts_exact_end_access() {
+        let start = (TPM_CRB_BUFFER_MAX - 4)..TPM_CRB_BUFFER_MAX;
+
+        assert_eq!(
+            data_buffer_range(
+                CRB_DATA_BUFFER + TPM_CRB_BUFFER_MAX as u32 - 4,
+                4,
+                TPM_CRB_BUFFER_MAX
+            ),
+            Some(start)
+        );
+        assert_eq!(
+            data_buffer_range(
+                CRB_DATA_BUFFER + TPM_CRB_BUFFER_MAX as u32 - 3,
+                4,
+                TPM_CRB_BUFFER_MAX
+            ),
+            None
+        );
     }
 }

--- a/tpm/src/emulator.rs
+++ b/tpm/src/emulator.rs
@@ -562,3 +562,19 @@ impl Drop for Emulator {
         }
     }
 }
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn test_startup_response_accepts_success_and_initialized() {
+        assert!(startup_response_is_ok(TPM_SUCCESS));
+        assert!(startup_response_is_ok(TPM_RC_INITIALIZE));
+    }
+
+    #[test]
+    fn test_startup_response_rejects_other_errors() {
+        assert!(!startup_response_is_ok(0x101));
+    }
+}

--- a/tpm/src/emulator.rs
+++ b/tpm/src/emulator.rs
@@ -19,6 +19,13 @@ use crate::{
 };
 
 const TPM_REQ_HDR_SIZE: usize = 10;
+const TPM_RC_INITIALIZE: u32 = 0x100;
+const TPM2_STARTUP_CLEAR: [u8; 12] = [
+    0x80, 0x01, // TPM_ST_NO_SESSIONS
+    0x00, 0x00, 0x00, 0x0c, // commandSize
+    0x00, 0x00, 0x01, 0x44, // TPM_CC_Startup
+    0x00, 0x00, // TPM_SU_CLEAR
+];
 
 /* capability flags returned by PTM_GET_CAPABILITY */
 const PTM_CAP_INIT: u64 = 1;
@@ -145,7 +152,35 @@ impl Emulator {
         }
         self.control_socket.set_msgfd(fds[1]);
         debug!("data fd to be configured in swtpm = {:?}", fds[1]);
-        self.run_control_cmd(Commands::CmdSetDatafd, &mut res, 0, mem::size_of::<u32>())?;
+        if let Err(e) =
+            self.run_control_cmd(Commands::CmdSetDatafd, &mut res, 0, mem::size_of::<u32>())
+        {
+            // SAFETY: FFI calls and return values of the unsafe calls are checked
+            unsafe {
+                if libc::close(fds[0]) == -1 {
+                    error!(
+                        "Failed to close TPM data fd after CmdSetDatafd failure: {:?}",
+                        std::io::Error::last_os_error()
+                    );
+                }
+                if libc::close(fds[1]) == -1 {
+                    error!(
+                        "Failed to close TPM swtpm fd after CmdSetDatafd failure: {:?}",
+                        std::io::Error::last_os_error()
+                    );
+                }
+            }
+            return Err(e);
+        }
+        // SAFETY: FFI call and return value of the unsafe call is checked
+        unsafe {
+            if libc::close(fds[1]) == -1 {
+                error!(
+                    "Failed to close local TPM swtpm fd: {:?}",
+                    std::io::Error::last_os_error()
+                );
+            }
+        }
         debug!("data fd in cloud-hypervisor = {:?}", fds[0]);
         self.data_fd = fds[0];
 
@@ -470,6 +505,27 @@ impl Emulator {
             mem::size_of::<u32>(),
         )?;
 
+        self.tpm2_startup_clear()?;
+
+        Ok(())
+    }
+
+    fn tpm2_startup_clear(&mut self) -> Result<()> {
+        let mut buffer = TPM2_STARTUP_CLEAR;
+        let mut cmd = BackendCmd {
+            buffer: &mut buffer,
+            input_len: TPM2_STARTUP_CLEAR.len(),
+        };
+
+        self.deliver_request(&mut cmd)?;
+
+        let response_code = u32::from_be_bytes(buffer[6..10].try_into().unwrap());
+        if response_code != TPM_SUCCESS && response_code != TPM_RC_INITIALIZE {
+            return Err(Error::DeliverRequest(anyhow!(
+                "TPM2_Startup(CLEAR) returned error code: {response_code:#X}"
+            )));
+        }
+
         Ok(())
     }
 
@@ -483,5 +539,22 @@ impl Emulator {
 
     pub fn get_buffer_size(&mut self) -> usize {
         self.set_buffer_size(0).unwrap_or(TPM_CRB_BUFFER_MAX)
+    }
+}
+
+impl Drop for Emulator {
+    fn drop(&mut self) {
+        if self.data_fd >= 0 {
+            // SAFETY: FFI call and return value of the unsafe call is checked
+            unsafe {
+                if libc::close(self.data_fd) == -1 {
+                    error!(
+                        "Failed to close TPM data fd: {:?}",
+                        std::io::Error::last_os_error()
+                    );
+                }
+            }
+            self.data_fd = -1;
+        }
     }
 }

--- a/tpm/src/emulator.rs
+++ b/tpm/src/emulator.rs
@@ -27,6 +27,10 @@ const TPM2_STARTUP_CLEAR: [u8; 12] = [
     0x00, 0x00, // TPM_SU_CLEAR
 ];
 
+fn startup_response_is_ok(response_code: u32) -> bool {
+    response_code == TPM_SUCCESS || response_code == TPM_RC_INITIALIZE
+}
+
 /* capability flags returned by PTM_GET_CAPABILITY */
 const PTM_CAP_INIT: u64 = 1;
 const PTM_CAP_SHUTDOWN: u64 = 1 << 1;
@@ -520,7 +524,7 @@ impl Emulator {
         self.deliver_request(&mut cmd)?;
 
         let response_code = u32::from_be_bytes(buffer[6..10].try_into().unwrap());
-        if response_code != TPM_SUCCESS && response_code != TPM_RC_INITIALIZE {
+        if !startup_response_is_ok(response_code) {
             return Err(Error::DeliverRequest(anyhow!(
                 "TPM2_Startup(CLEAR) returned error code: {response_code:#X}"
             )));


### PR DESCRIPTION
It is reported that Windows Server 2025 doesn't work with CH's TPM emulation.

There are two issues:
  1. Windows issues byte-sized accesses, while CH only dealt with 4-byte accesses.
  2. CH TPM emulation doesn't handle guest reboot correctly.

This series fix those two issues and enhance unit and integration tests to cover more scenarios.