### PR TITLE
Preserve more underlying Errors to Assist Debugging 

### DIFF
--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -35,7 +35,9 @@ pub enum Error {
     #[error("The memory map table extends past the end of guest memory")]
     MemmapTablePastRamEnd,
     #[error("Error writing memory map table to guest memory")]
-    MemmapTableSetup,
+    MemmapTableSetup(#[source] vm_memory::GuestMemoryError),
+    #[error("Error generating memory map table")]
+    MemmapTableGeneration,
     #[error("The hvm_start_info structure extends past the end of guest memory")]
     StartInfoPastRamEnd,
     #[error("Error writing hvm_start_info to guest memory")]

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -39,7 +39,7 @@ pub enum Error {
     #[error("The hvm_start_info structure extends past the end of guest memory")]
     StartInfoPastRamEnd,
     #[error("Error writing hvm_start_info to guest memory")]
-    StartInfoSetup,
+    StartInfoSetup(#[source] vm_memory::GuestMemoryError),
     #[error("Failed to compute initramfs address")]
     InitramfsAddress,
     #[error("Error writing module entry to guest memory")]

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -1282,7 +1282,7 @@ fn configure_pvh(
     // Write the start_info struct to guest memory.
     guest_mem
         .write_obj(start_info, start_info_addr)
-        .map_err(|_| super::Error::StartInfoSetup)?;
+        .map_err(super::Error::StartInfoSetup)?;
 
     Ok(())
 }

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -1140,8 +1140,9 @@ pub fn generate_ram_ranges(guest_mem: &GuestMemoryMmap) -> super::Result<Vec<Ram
     // Generate the first usable physical memory range before the gap. The e820 map
     // should only report memory above 1MiB.
     let first_ram_range = {
-        let (first_region_start, first_region_end) =
-            ram_regions.first().ok_or(super::Error::MemmapTableSetup)?;
+        let (first_region_start, first_region_end) = ram_regions
+            .first()
+            .ok_or(super::Error::MemmapTableGeneration)?;
         let high_ram_start = layout::HIGH_RAM_START.raw_value();
         let mem_32bit_reserved_start = layout::MEM_32BIT_RESERVED_START.raw_value();
 
@@ -1154,7 +1155,7 @@ pub fn generate_ram_ranges(guest_mem: &GuestMemoryMmap) -> super::Result<Vec<Ram
                 high_ram_start: 0x{high_ram_start:08x}, mem_32bit_reserved_start: 0x{mem_32bit_reserved_start:08x}"
             );
 
-            return Err(super::Error::MemmapTableSetup);
+            return Err(super::Error::MemmapTableGeneration);
         }
 
         info!(
@@ -1265,7 +1266,7 @@ fn configure_pvh(
     for memmap_entry in memmap {
         guest_mem
             .write_obj(memmap_entry, memmap_start_addr)
-            .map_err(|_| super::Error::MemmapTableSetup)?;
+            .map_err(super::Error::MemmapTableSetup)?;
         memmap_start_addr =
             memmap_start_addr.unchecked_add(mem::size_of::<hvm_memmap_table_entry>() as u64);
     }

--- a/arch/src/x86_64/smbios.rs
+++ b/arch/src/x86_64/smbios.rs
@@ -28,10 +28,10 @@ pub enum Error {
     Clear,
     /// Failure to write SMBIOS entrypoint structure
     #[error("Failure to write SMBIOS entrypoint structure")]
-    WriteSmbiosEp,
+    WriteSmbiosEp(#[source] vm_memory::GuestMemoryError),
     /// Failure to write additional data to memory
     #[error("Failure to write additional data to memory")]
-    WriteData,
+    WriteData(#[source] vm_memory::GuestMemoryError),
     /// Failure to parse uuid, uuid format may be error
     #[error("Failure to parse uuid: {1}")]
     ParseUuid(#[source] uuid::Error, String),
@@ -207,7 +207,7 @@ fn write_and_incr<T: ByteValued>(
     val: T,
     mut curptr: GuestAddress,
 ) -> Result<GuestAddress> {
-    mem.write_obj(val, curptr).map_err(|_| Error::WriteData)?;
+    mem.write_obj(val, curptr).map_err(Error::WriteData)?;
     curptr = curptr
         .checked_add(mem::size_of::<T>() as u64)
         .ok_or(Error::NotEnoughMemory)?;
@@ -449,7 +449,7 @@ pub fn setup_smbios(mem: &GuestMemoryMmap, smbios: Option<&SmbiosConfig>) -> Res
         };
         smbios_ep.checksum = compute_checksum(&smbios_ep);
         mem.write_obj(smbios_ep, GuestAddress(SMBIOS_START))
-            .map_err(|_| Error::WriteSmbiosEp)?;
+            .map_err(Error::WriteSmbiosEp)?;
     }
 
     Ok(curptr.unchecked_offset_from(physptr) + std::mem::size_of::<Smbios30Entrypoint>() as u64)
@@ -704,6 +704,6 @@ mod unit_tests {
         .unwrap();
 
         let err = setup_smbios(&mem, None).unwrap_err();
-        assert!(matches!(err, Error::WriteData));
+        assert!(matches!(err, Error::WriteData(_)));
     }
 }

--- a/devices/src/ivshmem.rs
+++ b/devices/src/ivshmem.rs
@@ -45,11 +45,11 @@ pub enum IvshmemError {
     #[error("Failed to remove user memory region")]
     RemoveUserMemoryRegion,
     #[error("Failed to create user memory region.")]
-    CreateUserMemoryRegion,
+    CreateUserMemoryRegion(#[source] anyhow::Error),
     #[error("Failed to create userspace mapping.")]
-    CreateUserspaceMapping,
+    CreateUserspaceMapping(#[source] anyhow::Error),
     #[error("Failed to remove old userspace mapping.")]
-    RemoveUserspaceMapping,
+    RemoveUserspaceMapping(#[source] anyhow::Error),
 }
 
 #[derive(Copy, Clone)]

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -299,7 +299,7 @@ pub enum HypervisorCpuError {
     /// Failed to initialize PMU
     ///
     #[error("Failed to initialize PMU")]
-    InitializePmu,
+    InitializePmu(#[source] anyhow::Error),
     #[cfg(target_arch = "x86_64")]
     ///
     /// Error getting TSC frequency

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -28,6 +28,8 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
+#[cfg(target_arch = "x86_64")]
+use anyhow::Context;
 use anyhow::anyhow;
 #[cfg(feature = "sev_snp")]
 use kvm_bindings::kvm_create_guest_memfd;
@@ -2198,7 +2200,8 @@ impl cpu::Vcpu for KvmVcpu {
         let cpuid: Vec<kvm_bindings::kvm_cpuid_entry2> =
             cpuid.iter().map(|e| (*e).into()).collect();
         let kvm_cpuid = <CpuId>::from_entries(&cpuid)
-            .map_err(|_| cpu::HypervisorCpuError::SetCpuid(anyhow!("failed to create CpuId")))?;
+            .context("failed to create CpuId")
+            .map_err(cpu::HypervisorCpuError::SetCpuid)?;
 
         self.fd
             .set_cpuid2(&kvm_cpuid)
@@ -3338,10 +3341,10 @@ impl cpu::Vcpu for KvmVcpu {
         };
         self.fd
             .set_device_attr(&cpu_attr_irq)
-            .map_err(|_| cpu::HypervisorCpuError::InitializePmu)?;
+            .map_err(|e| cpu::HypervisorCpuError::InitializePmu(e.into()))?;
         self.fd
             .set_device_attr(&cpu_attr)
-            .map_err(|_| cpu::HypervisorCpuError::InitializePmu)
+            .map_err(|e| cpu::HypervisorCpuError::InitializePmu(e.into()))
     }
 
     #[cfg(target_arch = "x86_64")]

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -9,6 +9,8 @@ use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, RwLock};
 
+#[cfg(target_arch = "x86_64")]
+use anyhow::Context;
 use anyhow::anyhow;
 #[cfg(target_arch = "x86_64")]
 use arc_swap::ArcSwap;
@@ -1427,7 +1429,8 @@ impl cpu::Vcpu for MshvVcpu {
     fn set_cpuid2(&self, cpuid: &[CpuIdEntry]) -> cpu::Result<()> {
         let cpuid: Vec<mshv_bindings::hv_cpuid_entry> = cpuid.iter().map(|e| (*e).into()).collect();
         let mshv_cpuid = <CpuId>::from_entries(&cpuid)
-            .map_err(|_| cpu::HypervisorCpuError::SetCpuid(anyhow!("failed to create CpuId")))?;
+            .context("failed to create CpuId")
+            .map_err(cpu::HypervisorCpuError::SetCpuid)?;
 
         self.fd
             .register_intercept_result_cpuid(&mshv_cpuid)

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -90,30 +90,6 @@ pub enum VsockError {
 }
 type Result<T> = std::result::Result<T, VsockError>;
 
-#[derive(Debug)]
-pub enum VsockEpollHandlerError {
-    /// The vsock data/buffer virtio descriptor length is smaller than expected.
-    BufDescTooSmall,
-    /// The vsock data/buffer virtio descriptor is expected, but missing.
-    BufDescMissing,
-    /// Chained GuestMemory error.
-    GuestMemory,
-    /// Bounds check failed on guest memory pointer.
-    GuestMemoryBounds,
-    /// The vsock header descriptor length is too small.
-    HdrDescTooSmall(u32),
-    /// The vsock header `len` field holds an invalid value.
-    InvalidPktLen(u32),
-    /// A data fetch was attempted when no data was available.
-    NoData,
-    /// A data buffer was expected for the provided packet, but it is missing.
-    PktBufMissing,
-    /// Encountered an unexpected write-only virtio descriptor.
-    UnreadableDescriptor,
-    /// Encountered an unexpected read-only virtio descriptor.
-    UnwritableDescriptor,
-}
-
 /// A passive, event-driven object, that needs to be notified whenever an epoll-able event occurs.
 ///
 /// An event-polling control loop will use `get_polled_fd()` and `get_polled_evset()` to query

--- a/virtio-devices/src/vsock/mod.rs
+++ b/virtio-devices/src/vsock/mod.rs
@@ -16,6 +16,7 @@ mod unix;
 use std::os::unix::io::RawFd;
 
 use packet::VsockPacket;
+use thiserror::Error;
 
 pub use self::device::Vsock;
 pub use self::unix::{VsockUnixBackend, VsockUnixError};
@@ -63,29 +64,43 @@ mod defs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum VsockError {
     /// The vsock data/buffer virtio descriptor length is smaller than expected.
+    #[error("The vsock data/buffer virtio descriptor length is smaller than expected")]
     BufDescTooSmall,
     /// The vsock data/buffer virtio descriptor is expected, but missing.
+    #[error("The vsock data/buffer virtio descriptor is expected, but missing")]
     BufDescMissing,
     /// Chained GuestMemory error.
+    #[error("Guest memory error")]
     GuestMemory,
+    /// Chained GuestMemory access error.
+    #[error("Guest memory access error")]
+    GuestMemoryAccess(#[source] vm_memory::GuestMemoryError),
     /// Bounds check failed on guest memory pointer.
+    #[error("Bounds check failed on guest memory pointer")]
     GuestMemoryBounds,
     /// The vsock header descriptor length is too small.
+    #[error("The vsock header descriptor length is too small: {0}")]
     HdrDescTooSmall(u32),
     /// The vsock header descriptor is expected, but missing.
+    #[error("The vsock header descriptor is expected, but missing")]
     HdrDescMissing,
     /// The vsock header `len` field holds an invalid value.
+    #[error("The vsock header len field holds an invalid value: {0}")]
     InvalidPktLen(u32),
     /// A data fetch was attempted when no data was available.
+    #[error("A data fetch was attempted when no data was available")]
     NoData,
     /// A data buffer was expected for the provided packet, but it is missing.
+    #[error("A data buffer was expected for the provided packet, but it is missing")]
     PktBufMissing,
     /// Encountered an unexpected write-only virtio descriptor.
+    #[error("Encountered an unexpected write-only virtio descriptor")]
     UnreadableDescriptor,
     /// Encountered an unexpected read-only virtio descriptor.
+    #[error("Encountered an unexpected read-only virtio descriptor")]
     UnwritableDescriptor,
 }
 type Result<T> = std::result::Result<T, VsockError>;

--- a/virtio-devices/src/vsock/packet.rs
+++ b/virtio-devices/src/vsock/packet.rs
@@ -290,7 +290,7 @@ impl VsockPacket {
         desc_chain
             .memory()
             .read_slice(hdr.as_mut_slice(), guest_hdr_addr)
-            .map_err(|_| VsockError::GuestMemory)?;
+            .map_err(VsockError::GuestMemoryAccess)?;
 
         let mut pkt = Self {
             guest_hdr_addr,
@@ -361,7 +361,7 @@ impl VsockPacket {
                     desc_chain
                         .memory()
                         .read_slice(&mut owned[offset..offset + to_copy], desc.addr())
-                        .map_err(|_| VsockError::GuestMemory)?;
+                        .map_err(VsockError::GuestMemoryAccess)?;
                     offset += to_copy;
                 }
 
@@ -435,7 +435,7 @@ impl VsockPacket {
         desc_chain
             .memory()
             .read_slice(hdr.as_mut_slice(), guest_hdr_addr)
-            .map_err(|_| VsockError::GuestMemory)?;
+            .map_err(VsockError::GuestMemoryAccess)?;
 
         // Prior to Linux v6.3 there are two descriptors
         let (buf_size, buf_addr) = if head.has_next() {
@@ -506,7 +506,7 @@ impl VsockPacket {
 
         guest_mem
             .write(self.hdr(), self.guest_hdr_addr)
-            .map_err(|_| VsockError::GuestMemory)?;
+            .map_err(VsockError::GuestMemoryAccess)?;
 
         Ok(())
     }

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -26,7 +26,11 @@ pub enum UffdError {
     Create(#[source] std::io::Error),
 
     #[error("Cannot translate GPA {gpa:#x} to host address")]
-    GpaTranslation { gpa: u64 },
+    GpaTranslation {
+        gpa: u64,
+        #[source]
+        source: vm_memory::GuestMemoryError,
+    },
 
     #[error("Failed to register region at {addr:#x}+{len:#x}")]
     Register {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -5372,7 +5372,7 @@ impl IvshmemOps for IvshmemHandler {
             None,
             false,
         )
-        .map_err(|_| IvshmemError::CreateUserMemoryRegion)?;
+        .map_err(|e| IvshmemError::CreateUserMemoryRegion(e.into()))?;
         let mem_slot = {
             let mut manager = self.memory_manager.lock().unwrap();
             // SAFETY: guaranteed by MmapRegion invariants
@@ -5387,7 +5387,7 @@ impl IvshmemOps for IvshmemHandler {
                 )
             }
         }
-        .map_err(|_| IvshmemError::CreateUserspaceMapping)?;
+        .map_err(|e| IvshmemError::CreateUserspaceMapping(e.into()))?;
         let region = Arc::new(region);
         let mapping = UserspaceMapping {
             mapping: region.clone(),
@@ -5410,7 +5410,7 @@ impl IvshmemOps for IvshmemHandler {
                 mapping.mem_slot,
             )
         }
-        .map_err(|_| IvshmemError::RemoveUserspaceMapping)?;
+        .map_err(|e| IvshmemError::RemoveUserspaceMapping(e.into()))?;
         Ok(())
     }
 }

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -381,6 +381,10 @@ pub enum Error {
     #[error("Memory configuration is not valid")]
     InvalidMemoryParameters,
 
+    /// Memory backing path contains an interior NUL byte.
+    #[error("Memory backing path contains an interior NUL byte")]
+    InvalidMemoryPath(#[source] ffi::NulError),
+
     /// Forbidden operation. Impossible to resize guest memory if it is
     /// backed by user defined memory regions.
     #[error("Impossible to resize guest memory if it is backed by user defined memory regions")]
@@ -495,7 +499,7 @@ fn mmio_address_space_size(phys_bits: u8) -> u64 {
 //
 // See: https://github.com/torvalds/linux/blob/v6.3/fs/hugetlbfs/inode.c#L1169
 fn statfs_get_bsize(path: &str) -> Result<u64, Error> {
-    let path = std::ffi::CString::new(path).map_err(|_| Error::InvalidMemoryParameters)?;
+    let path = ffi::CString::new(path).map_err(Error::InvalidMemoryPath)?;
     let mut buf = std::mem::MaybeUninit::<libc::statfs>::uninit();
 
     // SAFETY: FFI call with a valid path and buffer

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -996,8 +996,10 @@ impl MemoryManager {
         for range in saved_regions.regions() {
             let host_addr = guest_memory
                 .get_host_address(GuestAddress(range.gpa))
-                .map_err(|_| UffdError::GpaTranslation { gpa: range.gpa })?
-                as u64;
+                .map_err(|e| UffdError::GpaTranslation {
+                    gpa: range.gpa,
+                    source: e,
+                })? as u64;
 
             let ioctls = uffd::register(uffd_fd.as_fd(), host_addr, range.length).map_err(|e| {
                 UffdError::Register {


### PR DESCRIPTION
The code base has many `.map_err(|_| SomeNewError)`-style lines. Not all of them are bad (some are even intentional), but some of them are dropping the underlying error when that error is actually helpful. Having the underlying error (thus, the full chain) improves the information for debugging in case something goes wrong.

Partially solves #7563.